### PR TITLE
perf(dev): overlap SSR transforms with dependency walks

### DIFF
--- a/src/modules/react-loader/ssr-module-loader/loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.test.ts
@@ -1300,16 +1300,15 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
     assertEquals(result, { transformed: "compiled", dependencies: "resolved" });
   });
 
-  it("preserves dependency error precedence while draining a failed transform", async () => {
-    const transformError = new Error("transform failed");
+  it("returns a dependency error without draining a stalled transform", async () => {
     const dependencyError = new Error("dependency failed");
-    let rejectTransform!: (error: Error) => void;
+    let finishTransform!: () => void;
     let resultSettled = false;
 
     const result = __ssrModuleLoaderInternals.runTransformAndDependencies(
       () =>
-        new Promise<never>((_resolve, reject) => {
-          rejectTransform = reject;
+        new Promise<void>((resolve) => {
+          finishTransform = resolve;
         }),
       () => Promise.reject(dependencyError),
     );
@@ -1323,11 +1322,15 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       "dependency failed",
     );
 
-    await Promise.resolve();
-    assertEquals(resultSettled, false);
-    rejectTransform(transformError);
-    const error = await rejected;
-    assertStrictEquals(error, dependencyError);
+    try {
+      await Promise.resolve();
+      await Promise.resolve();
+      assertEquals(resultSettled, true);
+      const error = await rejected;
+      assertStrictEquals(error, dependencyError);
+    } finally {
+      finishTransform();
+    }
   });
 
   it("bounds a caller wait without evicting the shared transform", async () => {

--- a/src/modules/react-loader/ssr-module-loader/loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.test.ts
@@ -1303,6 +1303,8 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
   it("returns a dependency error without draining a stalled transform", async () => {
     const dependencyError = new Error("dependency failed");
     let finishTransform!: () => void;
+    let failedTransformSettlement: Promise<void> | undefined;
+    let observedDependencyError: unknown;
     let resultSettled = false;
 
     const result = __ssrModuleLoaderInternals.runTransformAndDependencies(
@@ -1311,6 +1313,10 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
           finishTransform = resolve;
         }),
       () => Promise.reject(dependencyError),
+      (error, transformSettlement) => {
+        observedDependencyError = error;
+        failedTransformSettlement = transformSettlement;
+      },
     );
     void result.then(
       () => resultSettled = true,
@@ -1328,7 +1334,49 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       assertEquals(resultSettled, true);
       const error = await rejected;
       assertStrictEquals(error, dependencyError);
+      assertStrictEquals(observedDependencyError, dependencyError);
+      assert(failedTransformSettlement);
     } finally {
+      finishTransform();
+    }
+    await failedTransformSettlement;
+  });
+
+  it("retains a failed leader until its abandoned transform releases capacity", async () => {
+    const key = "test:retained-failed-transform";
+    const dependencyError = new Error("dependency failed");
+    const leader = new Promise<ModuleCacheEntry>(() => {});
+    let finishTransform!: () => void;
+    const transformSettlement = new Promise<void>((resolve) => {
+      finishTransform = resolve;
+    });
+    globalInProgress.set(key, leader);
+
+    const retained = __ssrModuleLoaderInternals.retainInProgressTransformUntilSettled(
+      key,
+      leader,
+      transformSettlement,
+      dependencyError,
+    );
+
+    try {
+      assert(retained);
+      assertStrictEquals(globalInProgress.get(key), retained);
+      let retainedSettled = false;
+      void retained.catch(() => retainedSettled = true);
+      await Promise.resolve();
+      assertEquals(retainedSettled, false);
+
+      finishTransform();
+      const error = await assertRejects(
+        () => retained,
+        Error,
+        "dependency failed",
+      );
+      assertStrictEquals(error, dependencyError);
+      assertEquals(globalInProgress.has(key), false);
+    } finally {
+      globalInProgress.delete(key);
       finishTransform();
     }
   });

--- a/src/modules/react-loader/ssr-module-loader/loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.test.ts
@@ -1267,6 +1267,83 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
     }
   });
 
+  it("returns a dependency error to followers already waiting on its leader", async () => {
+    clearSSRModuleCache();
+
+    const projectDir = await makeTempDir({ prefix: "vf-ssr-loader-retained-follower-" });
+    const componentsDir = join(projectDir, "components");
+    const filePath = join(componentsDir, "RetainedFollower.tsx");
+    const projectId = "project-retained-follower";
+    const contentSourceId = "local-main";
+    const source = "export default function RetainedFollower() { return null; }";
+    const dependencyError = new Error("dependency failed");
+    let finishTransform!: () => void;
+    let rejectLeader!: (error: Error) => void;
+    let retained: Promise<ModuleCacheEntry> | null = null;
+    let follower: Promise<React.ComponentType<Record<string, unknown>>> | undefined;
+    let contentCacheKey = "";
+
+    try {
+      await mkdir(componentsDir, { recursive: true });
+      await writeTextFile(filePath, source);
+
+      const contentHash = hashAsLoader(source, filePath, projectDir);
+      const leader = new Promise<ModuleCacheEntry>((_, reject) => {
+        rejectLeader = reject;
+      });
+      leader.catch(() => {});
+      const transformSettlement = new Promise<void>((resolve) => {
+        finishTransform = resolve;
+      });
+
+      const loader = new SSRModuleLoader({
+        projectDir,
+        projectId,
+        contentSourceId,
+        adapter: denoAdapter,
+        dev: true,
+      });
+      contentCacheKey = (loader as unknown as {
+        cache: { getCacheKey(value: string): string };
+      }).cache.getCacheKey(`${filePath}:${contentHash}`);
+      globalInProgress.set(contentCacheKey, leader);
+      __ssrModuleLoaderInternals.registerInProgressTransformObservers(contentCacheKey, leader);
+
+      follower = loader.loadModule(filePath, source);
+      let attempts = 0;
+      while (
+        __ssrModuleLoaderInternals.inProgressTransformObserverCount(leader) === 0 &&
+        attempts++ < 100
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      assertEquals(__ssrModuleLoaderInternals.inProgressTransformObserverCount(leader), 1);
+
+      retained = __ssrModuleLoaderInternals.retainInProgressTransformUntilSettled(
+        contentCacheKey,
+        leader,
+        transformSettlement,
+        dependencyError,
+      );
+      assert(retained);
+      rejectLeader(dependencyError);
+
+      let followerError: unknown;
+      void follower.catch((error) => followerError = error);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      assertStrictEquals(followerError, dependencyError);
+      assertStrictEquals(globalInProgress.get(contentCacheKey), retained);
+    } finally {
+      rejectLeader?.(dependencyError);
+      finishTransform?.();
+      await retained?.catch(() => {});
+      await follower?.catch(() => {});
+      if (contentCacheKey) globalInProgress.delete(contentCacheKey);
+      clearSSRModuleCache();
+      await remove(projectDir, { recursive: true });
+    }
+  });
+
   it("allows one rejected shared transform retry per caller", () => {
     assertEquals(
       __ssrModuleLoaderInternals.shouldRetryRejectedInProgressTransform(1),

--- a/src/modules/react-loader/ssr-module-loader/loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.test.ts
@@ -1344,6 +1344,72 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
     }
   });
 
+  it("returns a dependency error to followers after retained work already settled", async () => {
+    clearSSRModuleCache();
+
+    const projectDir = await makeTempDir({ prefix: "vf-ssr-loader-settled-follower-" });
+    const componentsDir = join(projectDir, "components");
+    const filePath = join(componentsDir, "SettledFollower.tsx");
+    const projectId = "project-settled-follower";
+    const contentSourceId = "local-main";
+    const source = "export default function SettledFollower() { return null; }";
+    const dependencyError = new Error("dependency failed");
+    let rejectLeader!: (error: Error) => void;
+    let follower: Promise<React.ComponentType<Record<string, unknown>>> | undefined;
+    let contentCacheKey = "";
+
+    try {
+      await mkdir(componentsDir, { recursive: true });
+      await writeTextFile(filePath, source);
+
+      const contentHash = hashAsLoader(source, filePath, projectDir);
+      const leader = new Promise<ModuleCacheEntry>((_, reject) => {
+        rejectLeader = reject;
+      });
+      leader.catch(() => {});
+
+      const loader = new SSRModuleLoader({
+        projectDir,
+        projectId,
+        contentSourceId,
+        adapter: denoAdapter,
+        dev: true,
+      });
+      contentCacheKey = (loader as unknown as {
+        cache: { getCacheKey(value: string): string };
+      }).cache.getCacheKey(`${filePath}:${contentHash}`);
+      globalInProgress.set(contentCacheKey, leader);
+      __ssrModuleLoaderInternals.registerInProgressTransformObservers(contentCacheKey, leader);
+
+      follower = loader.loadModule(filePath, source);
+      let attempts = 0;
+      while (
+        __ssrModuleLoaderInternals.inProgressTransformObserverCount(leader) === 0 &&
+        attempts++ < 100
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      assertEquals(__ssrModuleLoaderInternals.inProgressTransformObserverCount(leader), 1);
+
+      __ssrModuleLoaderInternals.retainInProgressTransformUntilSettled(
+        contentCacheKey,
+        leader,
+        Promise.resolve(),
+        dependencyError,
+      );
+      rejectLeader(dependencyError);
+
+      const error = await assertRejects(() => follower!, Error, "dependency failed");
+      assertStrictEquals(error, dependencyError);
+    } finally {
+      rejectLeader?.(dependencyError);
+      await follower?.catch(() => {});
+      if (contentCacheKey) globalInProgress.delete(contentCacheKey);
+      clearSSRModuleCache();
+      await remove(projectDir, { recursive: true });
+    }
+  });
+
   it("allows one rejected shared transform retry per caller", () => {
     assertEquals(
       __ssrModuleLoaderInternals.shouldRetryRejectedInProgressTransform(1),

--- a/src/modules/react-loader/ssr-module-loader/loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.test.ts
@@ -1278,6 +1278,58 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
     );
   });
 
+  it("starts a module transform before recursive dependencies settle", async () => {
+    const events: string[] = [];
+    let finishTransform!: (value: string) => void;
+
+    const result = await __ssrModuleLoaderInternals.runTransformAndDependencies(
+      async () => {
+        events.push("transform:start");
+        return await new Promise<string>((resolve) => {
+          finishTransform = resolve;
+        });
+      },
+      async () => {
+        events.push("dependencies:start");
+        assertEquals(events, ["transform:start", "dependencies:start"]);
+        finishTransform("compiled");
+        return await Promise.resolve("resolved");
+      },
+    );
+
+    assertEquals(result, { transformed: "compiled", dependencies: "resolved" });
+  });
+
+  it("preserves dependency error precedence while draining a failed transform", async () => {
+    const transformError = new Error("transform failed");
+    const dependencyError = new Error("dependency failed");
+    let rejectTransform!: (error: Error) => void;
+    let resultSettled = false;
+
+    const result = __ssrModuleLoaderInternals.runTransformAndDependencies(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectTransform = reject;
+        }),
+      () => Promise.reject(dependencyError),
+    );
+    void result.then(
+      () => resultSettled = true,
+      () => resultSettled = true,
+    );
+    const rejected = assertRejects(
+      () => result,
+      Error,
+      "dependency failed",
+    );
+
+    await Promise.resolve();
+    assertEquals(resultSettled, false);
+    rejectTransform(transformError);
+    const error = await rejected;
+    assertStrictEquals(error, dependencyError);
+  });
+
   it("bounds a caller wait without evicting the shared transform", async () => {
     using time = new FakeTime();
     const key = "test:shared-transform-wait";

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -191,12 +191,58 @@ function getMdxEsmCacheVariant(
   );
 }
 
+type SettledOperation<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: unknown };
+
+function startSettledOperation<T>(operation: () => Promise<T>): Promise<SettledOperation<T>> {
+  try {
+    return operation().then(
+      (value) => ({ ok: true, value }),
+      (error: unknown) => ({ ok: false, error }),
+    );
+  } catch (error) {
+    return Promise.resolve({ ok: false, error });
+  }
+}
+
+/**
+ * Start compilation before walking dependencies, then join both results.
+ *
+ * The compiler rejection is handled immediately so dependency resolution can
+ * retain its historical error precedence without risking an unhandled promise.
+ */
+async function runTransformAndDependencies<T, D>(
+  transform: () => Promise<T>,
+  dependencies: () => Promise<D>,
+): Promise<{ transformed: T; dependencies: D }> {
+  const transformResult = startSettledOperation(transform);
+
+  let resolvedDependencies: D;
+  try {
+    resolvedDependencies = await dependencies();
+  } catch (dependencyError) {
+    // Drain the compiler before rejecting the leader. This releases its
+    // capacity slot before another request can start a replacement transform.
+    await transformResult;
+    throw dependencyError;
+  }
+
+  const settledTransform = await transformResult;
+  if (!settledTransform.ok) throw settledTransform.error;
+  return {
+    transformed: settledTransform.value,
+    dependencies: resolvedDependencies,
+  };
+}
+
 /** Internal test seam for the singleflight timeout lifecycle. */
 export const __ssrModuleLoaderInternals = {
   deleteInProgressTransformIfCurrent,
   getMdxEsmCacheVariant,
   publishTransformCacheIfCurrent,
   registerInProgressTransformObservers,
+  runTransformAndDependencies,
   scheduleStaleInProgressTransformEviction,
   shouldRetryRejectedInProgressTransform,
   waitForInProgressTransform,
@@ -904,45 +950,40 @@ export class SSRModuleLoader {
           }
         }
 
-        // Process recursive imports FIRST, without holding a project slot.
-        // Each recursive child acquires its own slot for its own transform only.
-        // This prevents hierarchical deadlock where parent holds a slot while
-        // children also need slots (10 batch x 2 depth = 21 slots, but limit is 17).
+        const projectId = this.options.projectId;
+        const transformOpts: TransformOptions = {
+          projectId,
+          dev: this.options.dev,
+          ssr: true,
+          apiBaseUrl: this.options.apiBaseUrl,
+          moduleServerOrigin: this.options.moduleServerOrigin,
+          reactVersion: this.options.reactVersion,
+          serverExternalPackages: this.options.serverExternalPackages,
+          dependencyHashCache,
+          dependencyPinningCacheKey: this.options.dependencyPinningCacheKey,
+          dependencyPinningDependencies: this.options.dependencyPinningDependencies,
+          dependencyPinningSource: this.options.dependencyPinningSource,
+        };
         const localFs = createFileSystem();
 
-        const localImportPaths = await this.depValidator.processLocalImports(
-          parseResult.imports,
-          filePath,
-          depth,
-          localFs,
-          dependencyHashCache,
-          sharedSignal,
-        );
-
-        const crossProjectPaths = await this.depValidator.processCrossProjectImports(
-          parseResult.crossProjectImports,
-          filePath,
-          sharedSignal,
-        );
-
-        // Hold project slots only around the actual transform and file write.
-        const entry = await this.withTransformCapacity(filePath, "build", async () => {
-          const projectId = this.options.projectId;
-          const transformOpts: TransformOptions = {
-            projectId,
-            dev: this.options.dev,
-            ssr: true,
-            apiBaseUrl: this.options.apiBaseUrl,
-            moduleServerOrigin: this.options.moduleServerOrigin,
-            reactVersion: this.options.reactVersion,
-            serverExternalPackages: this.options.serverExternalPackages,
+        const resolveDependencies = async () => {
+          const localImportPaths = await this.depValidator.processLocalImports(
+            parseResult.imports,
+            filePath,
+            depth,
+            localFs,
             dependencyHashCache,
-            dependencyPinningCacheKey: this.options.dependencyPinningCacheKey,
-            dependencyPinningDependencies: this.options.dependencyPinningDependencies,
-            dependencyPinningSource: this.options.dependencyPinningSource,
-          };
-
-          let transformed = await withSpan(
+            sharedSignal,
+          );
+          const crossProjectPaths = await this.depValidator.processCrossProjectImports(
+            parseResult.crossProjectImports,
+            filePath,
+            sharedSignal,
+          );
+          return { localImportPaths, crossProjectPaths };
+        };
+        const compile = async (): Promise<string> => {
+          const transformed = await withSpan(
             SpanNames.SSR_TRANSFORM_SINGLE,
             () =>
               transformToESM(
@@ -955,6 +996,15 @@ export class SSRModuleLoader {
             { "ssr.file": filePath.split("/").pop() || filePath },
           );
           throwIfAborted(sharedSignal);
+          return transformed;
+        };
+        const finishTransform = async (
+          compiled: string,
+          dependencies: Awaited<ReturnType<typeof resolveDependencies>>,
+        ): Promise<ModuleCacheEntry> => {
+          throwIfAborted(sharedSignal);
+          const { localImportPaths, crossProjectPaths } = dependencies;
+          let transformed = compiled;
 
           for (const [specifier, tempPath] of crossProjectPaths.entries()) {
             transformed = await rewriteCrossProjectImport(transformed, specifier, tempPath);
@@ -1059,7 +1109,33 @@ export class SSRModuleLoader {
           // A revoked leader must not update shared caches, but its immutable
           // output is still valid for requests that joined this singleflight.
           return entry;
-        }, sharedSignal);
+        };
+
+        let entry: ModuleCacheEntry;
+        if (this.options.dev) {
+          // Dev cold starts overlap compilation with dependency traversal. The
+          // first capacity slot ends with compilation, before the helper waits
+          // for children, and post-processing reacquires a slot separately.
+          const prepared = await runTransformAndDependencies(
+            () => this.withTransformCapacity(filePath, "build", compile, sharedSignal),
+            resolveDependencies,
+          );
+          entry = await this.withTransformCapacity(
+            filePath,
+            "build",
+            () => finishTransform(prepared.transformed, prepared.dependencies),
+            sharedSignal,
+          );
+        } else {
+          // Preserve production ordering and its single capacity window.
+          const dependencies = await resolveDependencies();
+          entry = await this.withTransformCapacity(
+            filePath,
+            "build",
+            async () => await finishTransform(await compile(), dependencies),
+            sharedSignal,
+          );
+        }
 
         markInProgressTransformSettled(transformPromise);
         resolveTransform(entry);

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -71,6 +71,7 @@ import {
   type DependencyHashCache,
 } from "#veryfront/cache/dependency-graph.ts";
 import { getMdxModuleCacheVariant } from "#veryfront/transforms/mdx/esm-module-loader/module-fetcher/cache-keys.ts";
+import { composeAbortSignals } from "#veryfront/extensions/abort-signal.ts";
 
 const logger = rendererLogger.component("ssr-module-loader");
 const CACHE_FILE_MISSING_PREFIX = "Cache file missing:";
@@ -178,6 +179,26 @@ function publishTransformCacheIfCurrent(input: {
   return true;
 }
 
+/** Keep a failed singleflight reserved until its abandoned transform settles. */
+function retainInProgressTransformUntilSettled(
+  key: string,
+  leader: Promise<ModuleCacheEntry>,
+  transformSettlement: Promise<void>,
+  error: unknown,
+): Promise<ModuleCacheEntry> | null {
+  if (globalInProgress.get(key) !== leader) return null;
+  const retainedError = error instanceof Error ? error : new Error(String(error));
+  const retained = transformSettlement.then<ModuleCacheEntry>(() => {
+    throw retainedError;
+  });
+  globalInProgress.set(key, retained);
+  void retained.then(
+    () => deleteInProgressTransformIfCurrent(key, retained),
+    () => deleteInProgressTransformIfCurrent(key, retained),
+  );
+  return retained;
+}
+
 function getMdxEsmCacheVariant(
   options: Pick<
     SSRModuleLoaderOptions,
@@ -216,6 +237,7 @@ function startSettledOperation<T>(operation: () => Promise<T>): Promise<SettledO
 async function runTransformAndDependencies<T, D>(
   transform: () => Promise<T>,
   dependencies: () => Promise<D>,
+  onDependencyFailure?: (error: unknown, transformSettlement: Promise<void>) => void,
 ): Promise<{ transformed: T; dependencies: D }> {
   const transformResult = startSettledOperation(transform);
 
@@ -223,6 +245,10 @@ async function runTransformAndDependencies<T, D>(
   try {
     resolvedDependencies = await dependencies();
   } catch (dependencyError) {
+    onDependencyFailure?.(
+      dependencyError,
+      transformResult.then(() => undefined),
+    );
     throw dependencyError;
   }
 
@@ -240,6 +266,7 @@ export const __ssrModuleLoaderInternals = {
   getMdxEsmCacheVariant,
   publishTransformCacheIfCurrent,
   registerInProgressTransformObservers,
+  retainInProgressTransformUntilSettled,
   runTransformAndDependencies,
   scheduleStaleInProgressTransformEviction,
   shouldRetryRejectedInProgressTransform,
@@ -980,7 +1007,7 @@ export class SSRModuleLoader {
           );
           return { localImportPaths, crossProjectPaths };
         };
-        const compile = async (): Promise<string> => {
+        const compile = async (signal: AbortSignal): Promise<string> => {
           const transformed = await withSpan(
             SpanNames.SSR_TRANSFORM_SINGLE,
             () =>
@@ -993,7 +1020,7 @@ export class SSRModuleLoader {
               ),
             { "ssr.file": filePath.split("/").pop() || filePath },
           );
-          throwIfAborted(sharedSignal);
+          throwIfAborted(signal);
           return transformed;
         };
         const finishTransform = async (
@@ -1114,9 +1141,29 @@ export class SSRModuleLoader {
           // Dev cold starts overlap compilation with dependency traversal. The
           // first capacity slot ends with compilation, before the helper waits
           // for children, and post-processing reacquires a slot separately.
+          const compileController = new AbortController();
+          const compileSignal = composeAbortSignals([
+            sharedSignal,
+            compileController.signal,
+          ]);
           const prepared = await runTransformAndDependencies(
-            () => this.withTransformCapacity(filePath, "build", compile, sharedSignal),
+            () =>
+              this.withTransformCapacity(
+                filePath,
+                "build",
+                () => compile(compileSignal),
+                compileSignal,
+              ),
             resolveDependencies,
+            (dependencyError, transformSettlement) => {
+              retainInProgressTransformUntilSettled(
+                inProgressKey,
+                transformPromise,
+                transformSettlement,
+                dependencyError,
+              );
+              compileController.abort(dependencyError);
+            },
           );
           entry = await this.withTransformCapacity(
             filePath,
@@ -1130,7 +1177,7 @@ export class SSRModuleLoader {
           entry = await this.withTransformCapacity(
             filePath,
             "build",
-            async () => await finishTransform(await compile(), dependencies),
+            async () => await finishTransform(await compile(sharedSignal), dependencies),
             sharedSignal,
           );
         }

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -209,9 +209,9 @@ function startSettledOperation<T>(operation: () => Promise<T>): Promise<SettledO
 /**
  * Start compilation before walking dependencies, then join both results.
  *
- * The compiler settlement is handled immediately, so dependency resolution
- * can retain its historical error precedence without draining a compiler that
- * cannot be aborted.
+ * Compiler settlement handlers are attached immediately, so dependency
+ * resolution can retain its historical error precedence without draining a
+ * compiler that cannot be aborted.
  */
 async function runTransformAndDependencies<T, D>(
   transform: () => Promise<T>,

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -209,8 +209,9 @@ function startSettledOperation<T>(operation: () => Promise<T>): Promise<SettledO
 /**
  * Start compilation before walking dependencies, then join both results.
  *
- * The compiler rejection is handled immediately so dependency resolution can
- * retain its historical error precedence without risking an unhandled promise.
+ * The compiler settlement is handled immediately, so dependency resolution
+ * can retain its historical error precedence without draining a compiler that
+ * cannot be aborted.
  */
 async function runTransformAndDependencies<T, D>(
   transform: () => Promise<T>,
@@ -222,9 +223,6 @@ async function runTransformAndDependencies<T, D>(
   try {
     resolvedDependencies = await dependencies();
   } catch (dependencyError) {
-    // Drain the compiler before rejecting the leader. This releases its
-    // capacity slot before another request can start a replacement transform.
-    await transformResult;
     throw dependencyError;
   }
 

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -108,10 +108,7 @@ const inProgressTransformObservers = new WeakMap<
   Promise<ModuleCacheEntry>,
   InProgressTransformObserverState
 >();
-const retainedInProgressTransformLeaders = new WeakMap<
-  Promise<ModuleCacheEntry>,
-  Promise<ModuleCacheEntry>
->();
+const retainedInProgressTransformLeaders = new WeakSet<Promise<ModuleCacheEntry>>();
 
 function signalAbortReason(signal: AbortSignal): unknown {
   return signal.reason ?? new DOMException("The operation was aborted", "AbortError");
@@ -201,7 +198,7 @@ function retainInProgressTransformUntilSettled(
   const retained = transformSettlement.then<ModuleCacheEntry>(() => {
     throw retainedError;
   });
-  retainedInProgressTransformLeaders.set(retained, leader);
+  retainedInProgressTransformLeaders.add(leader);
   globalInProgress.set(key, retained);
   void retained.then(
     () => deleteInProgressTransformIfCurrent(key, retained),
@@ -210,12 +207,10 @@ function retainInProgressTransformUntilSettled(
   return retained;
 }
 
-function hasRetainedReservationForLeader(
-  key: string,
+function wasRetainedInProgressTransformLeader(
   leader: Promise<ModuleCacheEntry>,
 ): boolean {
-  const retained = globalInProgress.get(key);
-  return retained !== undefined && retainedInProgressTransformLeaders.get(retained) === leader;
+  return retainedInProgressTransformLeaders.has(leader);
 }
 
 function getMdxEsmCacheVariant(
@@ -911,7 +906,7 @@ export class SSRModuleLoader {
         }
         // Callers already joined to this failed leader receive its dependency
         // error now. The replacement only reserves capacity for new callers.
-        if (hasRetainedReservationForLeader(inProgressKey, existingTransform)) {
+        if (wasRetainedInProgressTransformLeader(existingTransform)) {
           throw error;
         }
 

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -108,6 +108,10 @@ const inProgressTransformObservers = new WeakMap<
   Promise<ModuleCacheEntry>,
   InProgressTransformObserverState
 >();
+const retainedInProgressTransformLeaders = new WeakMap<
+  Promise<ModuleCacheEntry>,
+  Promise<ModuleCacheEntry>
+>();
 
 function signalAbortReason(signal: AbortSignal): unknown {
   return signal.reason ?? new DOMException("The operation was aborted", "AbortError");
@@ -134,6 +138,12 @@ function registerInProgressTransformObservers(
 function markInProgressTransformSettled(transformPromise: Promise<ModuleCacheEntry>): void {
   const state = inProgressTransformObservers.get(transformPromise);
   if (state) state.settled = true;
+}
+
+function inProgressTransformObserverCount(
+  transformPromise: Promise<ModuleCacheEntry>,
+): number {
+  return inProgressTransformObservers.get(transformPromise)?.observerCount ?? 0;
 }
 
 function shouldRetryRejectedInProgressTransform(rejectedLeaderCount: number): boolean {
@@ -191,12 +201,21 @@ function retainInProgressTransformUntilSettled(
   const retained = transformSettlement.then<ModuleCacheEntry>(() => {
     throw retainedError;
   });
+  retainedInProgressTransformLeaders.set(retained, leader);
   globalInProgress.set(key, retained);
   void retained.then(
     () => deleteInProgressTransformIfCurrent(key, retained),
     () => deleteInProgressTransformIfCurrent(key, retained),
   );
   return retained;
+}
+
+function hasRetainedReservationForLeader(
+  key: string,
+  leader: Promise<ModuleCacheEntry>,
+): boolean {
+  const retained = globalInProgress.get(key);
+  return retained !== undefined && retainedInProgressTransformLeaders.get(retained) === leader;
 }
 
 function getMdxEsmCacheVariant(
@@ -264,6 +283,7 @@ async function runTransformAndDependencies<T, D>(
 export const __ssrModuleLoaderInternals = {
   deleteInProgressTransformIfCurrent,
   getMdxEsmCacheVariant,
+  inProgressTransformObserverCount,
   publishTransformCacheIfCurrent,
   registerInProgressTransformObservers,
   retainInProgressTransformUntilSettled,
@@ -887,6 +907,11 @@ export class SSRModuleLoader {
           // Detach this caller without deleting the shared leader. The leader
           // owns a separate last-resort eviction timer, so healthy slow work is
           // not multiplied into competing retries.
+          throw error;
+        }
+        // Callers already joined to this failed leader receive its dependency
+        // error now. The replacement only reserves capacity for new callers.
+        if (hasRetainedReservationForLeader(inProgressKey, existingTransform)) {
           throw error;
         }
 


### PR DESCRIPTION
## Summary

- Start each dev SSR module compile while recursively resolving its local dependencies.
- Release transform capacity after compilation, then reacquire it for rewrite, validation, write, and publication after dependencies settle.
- Preserve production dependency-first ordering and its existing single capacity window.
- Return dependency failures immediately to the leader and followers already awaiting it. Cancel a compile that is still queued, and keep its singleflight key reserved for new callers until any already-running compile releases capacity.

## RED-GREEN TDD

RED:

- A deterministic scheduling test failed because dependency traversal started before the parent compile.
- A deterministic failure test showed that dependency rejection waited for a stalled compile to settle.
- Cleanup-handoff coverage failed because dependency rejection did not expose the abandoned compile settlement.
- A failed-leader regression showed that singleflight state could disappear while its compile still held transform capacity.
- A real `loadModule` follower consumed its normal failed-leader retry and waited on the cleanup reservation instead of returning the dependency error.

GREEN:

- The parent compile now starts before recursive dependency work.
- Dependency errors remain authoritative and return without draining a stalled compile.
- A local abort signal removes an abandoned compile from the capacity queue when it has not started.
- A settlement-backed singleflight promise reserves the in-progress key for new callers until an already-running compile releases its capacity slot.
- The reservation records its originating leader, so callers already awaiting that leader return its original dependency error immediately. Ordinary stale failed leaders remain retryable.

## Performance evidence

A synthetic 16-module deep local import tree was run against exact base `010a396f9ea4b65fd09fbd7113eb5b3f3124994d` and this exact patch. Every sample used a new project and empty module cache. The first sample includes esbuild service startup; the remaining five keep the service warm while keeping every module transform cold.

Base then patch:

- Base: 53.101, 38.403, 29.403, 25.832, 25.093, 24.339 ms
- Patch: 47.141, 21.269, 19.446, 18.761, 17.858, 17.127 ms
- Warm median: 25.832 to 18.761 ms, 27.4% lower

Patch then base:

- Patch: 50.164, 20.563, 20.026, 18.300, 19.542, 18.702 ms
- Base: 57.097, 28.407, 33.113, 27.003, 25.251, 25.168 ms
- Warm median: 27.003 to 19.542 ms, 27.6% lower

The first-process sample improved by 11.2% and 12.1% in the two run orders. This is controlled synthetic evidence for the removed sequential critical path, not a claim that every real route improves by the same percentage.

## Verification

- `deno test --preload=src/testing/preload.ts --no-check --allow-all --parallel src/modules/react-loader`: passed
- Focused SSR module loader file: 31 steps passed
- `deno check src/modules/react-loader/ssr-module-loader/loader.ts`: passed
- `deno task lint:ci`: passed
- `git diff --check`: passed

Closes veryfront/veryfront-issue-inbox#113