### PR TITLE
fix(rendering): compile client and module output for the render mode

### DIFF
--- a/src/modules/react-loader/ssr-module-loader/loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.test.ts
@@ -51,6 +51,7 @@ import {
   buildMdxEsmModuleRecoveryCacheKey,
   buildMdxEsmPathCacheKey,
 } from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
+import { MDX_MODULE_DEV_COMPILE_VARIANT } from "#veryfront/transforms/mdx/esm-module-loader/module-fetcher/cache-keys.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { FileSystem } from "#veryfront/platform/compat/fs.ts";
 import type { ModuleCacheEntry } from "./types.ts";
@@ -266,10 +267,12 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
     const originA = __ssrModuleLoaderInternals.getMdxEsmCacheVariant({
       dependencyPinningCacheKey: CANONICAL_PIN_KEY,
       moduleServerOrigin: "https://a.example",
+      dev: false,
     });
     const originB = __ssrModuleLoaderInternals.getMdxEsmCacheVariant({
       dependencyPinningCacheKey: CANONICAL_PIN_KEY,
       moduleServerOrigin: "https://b.example",
+      dev: false,
     });
 
     assert(originA?.startsWith(`${CANONICAL_PIN_KEY}:origin:`));
@@ -279,17 +282,27 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       __ssrModuleLoaderInternals.getMdxEsmCacheVariant({
         dependencyPinningCacheKey: "off",
         moduleServerOrigin: "https://a.example",
+        dev: false,
       }),
       undefined,
     );
     const externalA = __ssrModuleLoaderInternals.getMdxEsmCacheVariant({
       serverExternalPackages: ["knex", "@prisma/client"],
+      dev: false,
     });
     const externalB = __ssrModuleLoaderInternals.getMdxEsmCacheVariant({
       serverExternalPackages: ["@prisma/client", "knex"],
+      dev: false,
     });
     assertEquals(externalB, externalA);
     assert(externalA?.startsWith("on:server-externals-"));
+    assertEquals(
+      __ssrModuleLoaderInternals.getMdxEsmCacheVariant({
+        serverExternalPackages: ["knex", "@prisma/client"],
+        dev: true,
+      }),
+      `${externalA}:${MDX_MODULE_DEV_COMPILE_VARIANT}`,
+    );
   });
 
   it("invalidates stale cache entries with missing local dependencies and retransforms", async () => {
@@ -667,6 +680,8 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
 
       const mdxPathCacheKey = buildMdxEsmPathCacheKey(
         "_vf_modules/components/VerifiedMdxStaleCache.js",
+        undefined,
+        MDX_MODULE_DEV_COMPILE_VARIANT,
       );
       const mdxPathCache = await getModulePathCache(mdxCacheDir);
       mdxPathCache.set(mdxPathCacheKey, staleTempPath);
@@ -751,6 +766,8 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
 
       const mdxPathCacheKey = buildMdxEsmPathCacheKey(
         "_vf_modules/components/ColdMdxStaleCache.js",
+        undefined,
+        MDX_MODULE_DEV_COMPILE_VARIANT,
       );
       await writeTextFile(
         join(mdxCacheDir, "_index.json"),
@@ -842,6 +859,8 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
 
       const mdxPathCacheKey = buildMdxEsmPathCacheKey(
         "_vf_modules/components/BranchMdxStaleCache.js",
+        undefined,
+        MDX_MODULE_DEV_COMPILE_VARIANT,
       );
       await writeTextFile(
         join(mdxCacheDir, "_index.json"),
@@ -1835,6 +1854,55 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
         "production must not run injectNodePositions on tsx",
       );
     } finally {
+      await remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("compiles _vf_modules imports for production without an inline sourcemap", async () => {
+    clearSSRModuleCache();
+
+    const projectDir = await makeTempDir({ prefix: "vf-ssr-vfmod-gate-" });
+    const componentsDir = join(projectDir, "components");
+    const filePath = join(componentsDir, "Widget.tsx");
+    const projectId = "prod-gate-vf-modules";
+    const mdxCacheDir = getMdxEsmSsrCacheDir(projectId, PRODUCTION_GATE_CONTENT_SOURCE_ID);
+    const source = [
+      `import { used } from "/_vf_modules/util.js";`,
+      `export default function Widget() { return used(); }`,
+    ].join("\n");
+
+    try {
+      await mkdir(componentsDir, { recursive: true });
+      await writeTextFile(filePath, source);
+      await writeTextFile(
+        join(projectDir, "util.ts"),
+        ["function unusedHelper() { return 2; }", "export const used = () => 1;"].join("\n"),
+      );
+
+      const loader = new SSRModuleLoader({
+        projectDir,
+        projectId,
+        contentSourceId: PRODUCTION_GATE_CONTENT_SOURCE_ID,
+        adapter: denoAdapter,
+        dev: false,
+      });
+      await loader.loadRawModule(filePath, source);
+
+      const pathCache = await getModulePathCache(mdxCacheDir);
+      const artifactPath = pathCache.get(buildMdxEsmPathCacheKey("_vf_modules/util.js"));
+      assert(artifactPath !== undefined, "expected the _vf_modules artifact to be cached");
+
+      const artifact = await Deno.readTextFile(artifactPath);
+      assertEquals(
+        artifact.includes("sourceMappingURL=data:"),
+        false,
+        "production must not ship an inline sourcemap for _vf_modules imports",
+      );
+      assertEquals(artifact.includes("unusedHelper"), false, "production must tree-shake");
+    } finally {
+      await waitForDiskCleanup();
+      clearModulePathCache();
+      await remove(mdxCacheDir, { recursive: true }).catch(() => {});
       await remove(projectDir, { recursive: true });
     }
   });

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -216,13 +216,14 @@ function wasRetainedInProgressTransformLeader(
 function getMdxEsmCacheVariant(
   options: Pick<
     SSRModuleLoaderOptions,
-    "dependencyPinningCacheKey" | "moduleServerOrigin" | "serverExternalPackages"
+    "dependencyPinningCacheKey" | "moduleServerOrigin" | "serverExternalPackages" | "dev"
   >,
 ): string | undefined {
   return getMdxModuleCacheVariant(
     options.dependencyPinningCacheKey,
     options.moduleServerOrigin,
     options.serverExternalPackages,
+    options.dev,
   );
 }
 
@@ -1068,6 +1069,7 @@ export class SSRModuleLoader {
             contentSourceId: this.options.contentSourceId!,
             adapter: this.options.adapter,
             projectDir: this.options.projectDir,
+            dev: this.options.dev,
             reactVersion: this.options.reactVersion,
             moduleServerOrigin: this.options.moduleServerOrigin,
             dependencyPinningCacheKey: this.options.dependencyPinningCacheKey,

--- a/src/modules/react-loader/ssr-module-loader/vf-module-resolver.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/vf-module-resolver.test.ts
@@ -1,7 +1,18 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
-import { findVfModuleImports } from "./vf-module-resolver.ts";
+import { assert, assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
+import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
+import { stop as stopEsbuild } from "veryfront/extensions/bundler";
+import {
+  makeTempDir,
+  readTextFile,
+  remove,
+  writeTextFile,
+} from "#veryfront/testing/deno-compat.ts";
+import { join } from "#veryfront/compat/path";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { runWithCacheDir } from "#veryfront/utils/cache-dir.ts";
+import { clearModulePathCache } from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
+import { findVfModuleImports, resolveVfModuleImports } from "./vf-module-resolver.ts";
 
 describe("modules/react-loader/ssr-module-loader/vf-module-resolver", () => {
   describe("findVfModuleImports", () => {
@@ -45,5 +56,73 @@ describe("modules/react-loader/ssr-module-loader/vf-module-resolver", () => {
       const code = `import x from "./local.js";`;
       assertEquals(await findVfModuleImports(code), []);
     });
+  });
+});
+
+/**
+ * `/_vf_modules/*` imports are fetched and compiled for every SSR module, so
+ * the render mode has to reach the module fetcher. A production render that
+ * compiled these modules in development mode shipped unminified, un-tree-shaken
+ * code with an inline sourcemap of the project source, and because the compile
+ * mode was absent from the module cache identity the two modes could also be
+ * served each other's artifacts.
+ */
+describe("modules/react-loader/ssr-module-loader/vf-module-resolver compile mode", () => {
+  afterAll(async () => {
+    await stopEsbuild();
+  });
+
+  const MODULE_SOURCE = [
+    "function unusedHelper() { return 2; }",
+    "export const used = () => 1;",
+  ].join("\n");
+
+  async function resolveModuleArtifact(dev: boolean, projectDir: string): Promise<string> {
+    const code = [
+      `import { used } from "/_vf_modules/util.js";`,
+      `export default used;`,
+    ].join("\n");
+
+    const resolved = await resolveVfModuleImports(code, {
+      filePath: join(projectDir, "page.tsx"),
+      projectId: "compile-mode-project",
+      contentSourceId: "release-compile-mode",
+      adapter: { fs: {} } as unknown as RuntimeAdapter,
+      projectDir,
+      dev,
+    });
+
+    const cachedPath = /file:\/\/([^"']+)/.exec(resolved)?.[1];
+    assert(cachedPath !== undefined, "Expected the _vf_modules import to resolve to a cache file");
+    return cachedPath;
+  }
+
+  it("compiles _vf_modules imports for production without an inline sourcemap", async () => {
+    const cacheDir = await makeTempDir({ prefix: "vf-compile-mode-cache-" });
+    const projectDir = await makeTempDir({ prefix: "vf-compile-mode-project-" });
+    await writeTextFile(join(projectDir, "util.ts"), MODULE_SOURCE);
+
+    try {
+      await runWithCacheDir(cacheDir, async () => {
+        // The development render runs first so a production render that ignored
+        // the compile mode would be served this artifact from the module caches.
+        const devPath = await resolveModuleArtifact(true, projectDir);
+        const devCode = await readTextFile(devPath);
+        assertEquals(devCode.includes("sourceMappingURL=data:"), true);
+        assertEquals(devCode.includes("unusedHelper"), true);
+
+        const productionPath = await resolveModuleArtifact(false, projectDir);
+        assertNotEquals(productionPath, devPath);
+
+        const productionCode = await readTextFile(productionPath);
+        assertEquals(productionCode.includes("sourceMappingURL=data:"), false);
+        assertEquals(productionCode.includes("unusedHelper"), false);
+        assertEquals(productionCode.includes("__name"), false);
+      });
+    } finally {
+      clearModulePathCache();
+      await remove(cacheDir, { recursive: true }).catch(() => {});
+      await remove(projectDir, { recursive: true }).catch(() => {});
+    }
   });
 });

--- a/src/modules/react-loader/ssr-module-loader/vf-module-resolver.ts
+++ b/src/modules/react-loader/ssr-module-loader/vf-module-resolver.ts
@@ -27,6 +27,12 @@ interface ResolveVfModuleImportsOptions {
   contentSourceId: string;
   adapter: RuntimeAdapter;
   projectDir: string;
+  /**
+   * Compile mode of the render that resolves these imports. Production renders
+   * must pass false: development output is unminified, not tree-shaken and
+   * carries an inline sourcemap that discloses the project source.
+   */
+  dev: boolean;
   reactVersion?: string;
   moduleServerOrigin?: string;
   dependencyPinningCacheKey?: string;
@@ -85,6 +91,7 @@ export async function resolveVfModuleImports(
     options.projectId,
     {
       contentSourceId: options.contentSourceId,
+      dev: options.dev,
       reactVersion: options.reactVersion,
       moduleServerOrigin: options.moduleServerOrigin,
       dependencyPinningCacheKey: options.dependencyPinningCacheKey,

--- a/src/rendering/component-handling.test.ts
+++ b/src/rendering/component-handling.test.ts
@@ -1,10 +1,13 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { assert, assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { FakeTime } from "#std/testing/time";
+import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
+import type { EntityInfo } from "#veryfront/types";
 import { DEFAULT_REACT_VERSION } from "#veryfront/transforms/import-rewriter/url-builder.ts";
-import { bundleComponentForClient } from "./component-handling.ts";
+import { bundleComponentForClient, handleComponentPage } from "./component-handling.ts";
 
 const PIN_KEY_A = "on:z7bg3qnfgtcb";
 const PIN_KEY_B = "on:3w5e11264sgsf";
@@ -388,5 +391,107 @@ describe("rendering/component-handling", () => {
       "replacement-code",
     );
     assertEquals(transformCalls, 2);
+  });
+});
+
+describe("rendering/component-handling client hydration compile mode", () => {
+  afterAll(async () => {
+    await stopEsbuild();
+  });
+
+  const HYDRATION_SOURCE = [
+    "function unusedHelper() { return 2; }",
+    "export default function Page() { return null; }",
+  ].join("\n");
+
+  function pageEntity(path: string): EntityInfo {
+    return {
+      entity: {
+        id: path,
+        path,
+        slug: "compile-mode",
+        type: "page",
+        content: HYDRATION_SOURCE,
+        frontmatter: {},
+        kind: "tsx",
+      },
+    };
+  }
+
+  async function renderClientModule(mode: "development" | "production"): Promise<string> {
+    const path = `/compile-mode-project/app/${mode}.tsx`;
+    const adapter = createMockAdapter();
+    adapter.fs.files.set(path, HYDRATION_SOURCE);
+
+    const result = await handleComponentPage(
+      pageEntity(path),
+      "compile-mode",
+      "/compile-mode-project",
+      undefined,
+      adapter as unknown as RuntimeAdapter,
+      {
+        projectId: "compile-mode-project",
+        contentSourceId: "release-compile-mode",
+        mode,
+      },
+    );
+
+    const clientModuleCode = result.pageBundle.clientModuleCode;
+    assert(clientModuleCode !== undefined, "Expected a client hydration bundle");
+    return clientModuleCode;
+  }
+
+  it("emits a production hydration bundle without an inline sourcemap", async () => {
+    const code = await renderClientModule("production");
+
+    assertEquals(code.includes("sourceMappingURL=data:"), false);
+    assertEquals(code.includes("unusedHelper"), false);
+    assertEquals(code.includes("__name"), false);
+  });
+
+  it("keeps the development hydration bundle debuggable", async () => {
+    const code = await renderClientModule("development");
+
+    assertEquals(code.includes("sourceMappingURL=data:"), true);
+    assertEquals(code.includes("unusedHelper"), true);
+    assertEquals(code.includes("__name"), true);
+  });
+
+  it("keeps the hydration cache entries of the two compile modes apart", async () => {
+    const transformed: boolean[] = [];
+    const deps = {
+      transformToESM: (
+        _source: string,
+        _filePath: string,
+        _projectDir: string,
+        _adapter: RuntimeAdapter,
+        options: { dev: boolean },
+      ) => {
+        transformed.push(options.dev);
+        return Promise.resolve(options.dev ? "dev-bundle" : "production-bundle");
+      },
+    };
+    const bundle = (dev: boolean) =>
+      bundleComponentForClient(
+        "export default function Page() { return null; }",
+        "/compile-mode-project/app/cache-identity.tsx",
+        "/compile-mode-project",
+        {} as RuntimeAdapter,
+        "https://modules.example.test",
+        "project-compile-mode-identity",
+        "19.1.0",
+        deps,
+        undefined,
+        "off",
+        undefined,
+        undefined,
+        undefined,
+        dev,
+      );
+
+    assertEquals(await bundle(false), "production-bundle");
+    assertEquals(await bundle(true), "dev-bundle");
+    assertEquals(await bundle(false), "production-bundle");
+    assertEquals(transformed, [false, true]);
   });
 });

--- a/src/rendering/component-handling.ts
+++ b/src/rendering/component-handling.ts
@@ -66,6 +66,7 @@ registerLRUCache("component-hydration-cache", componentHydrationCache);
 
 async function buildComponentHydrationCacheHash(
   source: string,
+  dev: boolean,
   moduleServerUrl?: string,
   reactVersion?: string,
   serverExternalPackages?: readonly string[],
@@ -80,11 +81,15 @@ async function buildComponentHydrationCacheHash(
   const serverExternalPackagesIdentity = buildServerExternalPackagesIdentity(
     serverExternalPackages,
   );
-  const cacheIdentity = JSON.stringify(
-    serverExternalPackagesIdentity
-      ? [...legacyCacheIdentity, serverExternalPackagesIdentity]
-      : legacyCacheIdentity,
-  );
+  const packageScopedIdentity = serverExternalPackagesIdentity
+    ? [...legacyCacheIdentity, serverExternalPackagesIdentity]
+    : legacyCacheIdentity;
+  // The compile mode decides minification, tree shaking and whether an inline
+  // sourcemap is emitted, so two modes must never share one hydration entry.
+  const cacheIdentity = JSON.stringify([
+    ...packageScopedIdentity,
+    dev ? "compile-dev" : "compile-production",
+  ]);
   return (await computeHash(cacheIdentity)).slice(0, 16);
 }
 
@@ -134,6 +139,7 @@ export async function handleComponentPage(
     const fileContent = await adapter.fs.readFile(pageInfo.entity.path);
     const dependencyPinningCacheKey = options?.dependencyPinningCacheKey ??
       await getDependencyPinningCacheKey(projectDir);
+    const dev = options?.mode === "development";
 
     const clientModuleCode = options?.cachedClientModule ??
       (await bundleComponentForClient(
@@ -150,10 +156,10 @@ export async function handleComponentPage(
         options?.dependencyPinningDependencies,
         options?.dependencyPinningSource,
         options?.serverExternalPackages,
+        dev,
       ));
 
     const { loadComponentFromSource } = await import("#veryfront/modules/react-loader/index.ts");
-    const dev = options?.mode === "development";
     const PageComponent = await loadComponentFromSource(
       fileContent,
       pageInfo.entity.path,
@@ -226,10 +232,17 @@ export async function bundleComponentForClient(
   dependencyPinningDependencies?: Readonly<Record<string, string>>,
   dependencyPinningSource?: DependencyPinningSourceInput,
   serverExternalPackages?: readonly string[],
+  /**
+   * Compile the hydration bundle in development mode. Production renders must
+   * leave this false: dev output is unminified, not tree-shaken and carries an
+   * inline sourcemap that discloses the project source.
+   */
+  dev = false,
 ): Promise<string> {
   try {
     const cacheHash = await buildComponentHydrationCacheHash(
       source,
+      dev,
       moduleServerUrl,
       reactVersion,
       serverExternalPackages,
@@ -253,7 +266,7 @@ export async function bundleComponentForClient(
         const { transformToESM } = injectedDeps ?? await getBundleComponentForClientDeps();
         const transformed = await transformToESM(source, filePath, projectDir, adapter, {
           projectId: projectId ?? projectDir,
-          dev: true,
+          dev,
           jsxImportSource: "react",
           moduleServerUrl,
           moduleServerOrigin,

--- a/src/rendering/orchestrator/module-loader/index.ts
+++ b/src/rendering/orchestrator/module-loader/index.ts
@@ -364,6 +364,7 @@ async function transformModuleWithDepsUnmemoized(
     dependencyPinningCacheKey: config.dependencyPinningCacheKey,
     moduleServerOrigin: config.moduleServerOrigin,
     serverExternalPackages: config.serverExternalPackages,
+    dev: config.mode === "development",
   });
   if (cachedPath) {
     const cycleManifestState = await inspectCycleManifestCache(
@@ -593,6 +594,7 @@ async function transformModuleWithDepsUnmemoized(
     moduleServerOrigin: config.moduleServerOrigin,
     dependencyPinningCacheKey: config.dependencyPinningCacheKey,
     serverExternalPackages: config.serverExternalPackages,
+    dev: config.mode === "development",
     unresolvedSpecifiers: [...moduleUnresolvedSpecifiers],
     cycleArtifactPath: useCycleArtifact ? cycleManifest.reserveArtifactPath(filePath) : undefined,
     deferCachePublication: (publication) => {
@@ -941,6 +943,7 @@ export async function loadModule(
           config.dependencyPinningCacheKey,
           config.moduleServerOrigin,
           config.serverExternalPackages,
+          config.mode === "development",
         ),
       );
 

--- a/src/rendering/orchestrator/module-loader/module-cache-lookup.ts
+++ b/src/rendering/orchestrator/module-loader/module-cache-lookup.ts
@@ -22,11 +22,13 @@ export function buildModuleTransformCacheVariant(
   dependencyPinningCacheKey?: string,
   moduleServerOrigin?: string,
   serverExternalPackages?: readonly string[],
+  dev?: boolean,
 ): string | undefined {
   return getMdxModuleCacheVariant(
     dependencyPinningCacheKey,
     moduleServerOrigin,
     serverExternalPackages,
+    dev,
   );
 }
 
@@ -53,6 +55,7 @@ export function getModuleCacheKey(
     dependencyPinningCacheKey,
     moduleServerOrigin,
     serverExternalPackages,
+    mode === "development",
   );
   return JSON.stringify(cacheVariant ? [...fields, cacheVariant, filePath] : [...fields, filePath]);
 }
@@ -70,6 +73,8 @@ export interface ResolveCachedModulePathInput {
   dependencyPinningCacheKey?: string;
   moduleServerOrigin?: string;
   serverExternalPackages?: readonly string[];
+  /** Compile mode of the artifacts this lookup may reuse. */
+  dev?: boolean;
   moduleCache: Map<string, string>;
   readTextFile?: (path: string) => Promise<string>;
   fileSystem?: FileSystemReader;
@@ -132,6 +137,7 @@ async function resolveMdxEsmCachedPath(
       input.dependencyPinningCacheKey,
       input.moduleServerOrigin,
       input.serverExternalPackages,
+      input.dev,
     ),
   );
 

--- a/src/rendering/orchestrator/module-loader/module-persistence.ts
+++ b/src/rendering/orchestrator/module-loader/module-persistence.ts
@@ -78,6 +78,8 @@ export interface PersistTransformedModuleInput {
   dependencyPinningCacheKey?: string;
   moduleServerOrigin?: string;
   serverExternalPackages?: readonly string[];
+  /** Compile mode of `transformedCode`, kept in the artifact cache identity. */
+  dev?: boolean;
   /** Tenant-authored imports left unresolved in this module subtree. */
   unresolvedSpecifiers?: readonly string[];
   /** Exact graph-content-addressed path for a cycle-dependent artifact. */
@@ -96,6 +98,11 @@ type ModuleOutputInput = Pick<
   | "serverExternalPackages"
 >;
 
+/**
+ * Artifact filenames carry a hash of the transformed code, so the two compile
+ * modes cannot collide on disk and the directory layout leaves the compile mode
+ * out. The cache keys that point at these artifacts do carry it.
+ */
 function getOutputRelativePath(input: ModuleOutputInput): string {
   const relativePath = input.filePath.startsWith(input.projectDir)
     ? input.filePath.slice(input.projectDir.length).replace(/^\/+/, "")
@@ -592,6 +599,7 @@ export async function persistTransformedModule(
             input.dependencyPinningCacheKey,
             input.moduleServerOrigin,
             input.serverExternalPackages,
+            input.dev,
           ),
         );
         const cache = await getModulePathCache(input.tmpDir);

--- a/src/transforms/mdx/esm-module-loader/cache-format.ts
+++ b/src/transforms/mdx/esm-module-loader/cache-format.ts
@@ -112,6 +112,12 @@ function buildMdxEsmCacheSchemaSample() {
       "_vf_modules/pages/index.js",
       "deadbeef",
     ),
+    // Development artifacts carry a compile-mode variant segment; production
+    // artifacts stay on the unsegmented key. Naming the split here rolls the
+    // namespace, so entries written before the compile mode was part of the
+    // cache identity (all of them development-compiled) cannot be served to a
+    // production render.
+    devCompileVariant: "on:compile-dev",
     pathKey: formatMdxEsmPathCacheKey(
       CACHE_NAMESPACE_SENTINEL,
       REACT_DEFAULT_VERSION,

--- a/src/transforms/mdx/esm-module-loader/loader-helpers.ts
+++ b/src/transforms/mdx/esm-module-loader/loader-helpers.ts
@@ -196,6 +196,11 @@ export async function processVfModuleImports(
     {
       contentSourceId: context.contentSourceId,
       isLocalProject: context.isLocalProject,
+      // The compiled-MDX entry path carries no render mode yet, so it keeps the
+      // development compile mode it has always used. The flag is part of the
+      // module cache identity, so these artifacts stay isolated from the
+      // production-compiled ones the SSR module loader fetches.
+      dev: true,
       reactVersion: context.reactVersion,
       serverExternalPackages: context.serverExternalPackages,
       moduleServerOrigin: context.moduleServerOrigin,

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/cache-keys.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/cache-keys.test.ts
@@ -1,7 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { getTransformCacheKey, getVersionedPathCacheKey } from "./cache-keys.ts";
+import {
+  getMdxModuleCacheVariant,
+  getTransformCacheKey,
+  getVersionedPathCacheKey,
+} from "./cache-keys.ts";
 import { MDX_ESM_CACHE_NAMESPACE } from "../cache-format.ts";
 
 describe("transforms/mdx/esm-module-loader/module-fetcher/cache-keys", () => {
@@ -255,5 +259,82 @@ describe("transforms/mdx/esm-module-loader/module-fetcher/cache-keys", () => {
       assertEquals(combined === knex, false);
       assertEquals(reordered, combined);
     });
+  });
+});
+
+/**
+ * The compile mode decides minification, tree shaking and inline sourcemaps, so
+ * it is part of every module cache identity. The transform key feeds the
+ * distributed transform cache, whose entries are shared across requests and
+ * across instances, so a key without the compile mode would let one instance
+ * serve development-compiled modules to a hosted production render.
+ */
+describe("transforms/mdx/esm-module-loader/module-fetcher/cache-keys compile mode", () => {
+  const TRANSFORM_BASE = [
+    "proj",
+    "preview-main",
+    "19.1.1",
+    "lib/utils.ts",
+    "abc123",
+    "off",
+    undefined,
+    undefined,
+  ] as const;
+
+  it("gives the two compile modes different distributed transform cache keys", () => {
+    const production = getTransformCacheKey(...TRANSFORM_BASE, false);
+    const dev = getTransformCacheKey(...TRANSFORM_BASE, true);
+
+    assertEquals(production === dev, false);
+    assertEquals(dev.includes(":on:compile-dev:"), true);
+    assertEquals(production.includes("compile-dev"), false);
+  });
+
+  it("treats an unset compile mode as production", () => {
+    assertEquals(
+      getTransformCacheKey(...TRANSFORM_BASE),
+      getTransformCacheKey(...TRANSFORM_BASE, false),
+    );
+    assertEquals(
+      getVersionedPathCacheKey("lib/utils.ts", "19.1.1"),
+      getVersionedPathCacheKey("lib/utils.ts", "19.1.1", undefined, undefined, undefined, false),
+    );
+  });
+
+  it("gives the two compile modes different path cache keys", () => {
+    const production = getVersionedPathCacheKey(
+      "lib/utils.ts",
+      "19.1.1",
+      "off",
+      undefined,
+      undefined,
+      false,
+    );
+    const dev = getVersionedPathCacheKey(
+      "lib/utils.ts",
+      "19.1.1",
+      "off",
+      undefined,
+      undefined,
+      true,
+    );
+
+    assertEquals(production === dev, false);
+    assertEquals(dev.includes("on:compile-dev"), true);
+  });
+
+  it("keeps the compile mode apart from the pin and server-external segments", () => {
+    const variant = getMdxModuleCacheVariant(
+      "on:snapshot",
+      "https://a.example",
+      ["knex"],
+      true,
+    );
+
+    assertEquals(variant?.endsWith(":on:compile-dev"), true);
+    assertEquals(
+      getMdxModuleCacheVariant("on:snapshot", "https://a.example", ["knex"], false),
+      variant?.slice(0, -":on:compile-dev".length),
+    );
   });
 });

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/cache-keys.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/cache-keys.ts
@@ -9,21 +9,39 @@ import { buildDependencyPinningCacheVariant } from "#veryfront/cache/keys/depend
 import { buildServerExternalPackagesIdentity } from "#veryfront/config/server-external-packages.ts";
 import { hashString } from "#veryfront/cache/hash.ts";
 
+/** Variant segment that isolates development-compiled module artifacts. */
+export const MDX_MODULE_DEV_COMPILE_VARIANT = "on:compile-dev";
+
+/**
+ * Build the cache-variant segment shared by every MDX module cache key.
+ *
+ * `dev` decides minification, tree shaking and inline sourcemaps, so a
+ * development artifact must never be reachable from a production key. Only the
+ * development compile mode adds a segment: production keeps the production
+ * artifact on the unsegmented key, and the cache namespace is rolled alongside
+ * this change so the legacy development-compiled entries written under that key
+ * cannot be read back.
+ */
 export function getMdxModuleCacheVariant(
   dependencyPinningCacheKey?: string,
   moduleServerOrigin?: string,
   serverExternalPackages?: readonly string[],
+  dev?: boolean,
 ): string | undefined {
+  // MDX cache variants use the `on:` prefix to opt into the variant segment.
+  const segments: string[] = [];
   const pinVariant = buildDependencyPinningCacheVariant(
     dependencyPinningCacheKey,
     moduleServerOrigin,
   );
-  const externalIdentity = buildServerExternalPackagesIdentity(serverExternalPackages);
-  if (!externalIdentity) return pinVariant;
+  if (pinVariant) segments.push(pinVariant);
 
-  // MDX cache variants use the `on:` prefix to opt into the variant segment.
-  const externalVariant = `on:server-externals-${hashString(externalIdentity)}`;
-  return pinVariant ? `${pinVariant}:${externalVariant}` : externalVariant;
+  const externalIdentity = buildServerExternalPackagesIdentity(serverExternalPackages);
+  if (externalIdentity) segments.push(`on:server-externals-${hashString(externalIdentity)}`);
+
+  if (dev) segments.push(MDX_MODULE_DEV_COMPILE_VARIANT);
+
+  return segments.length > 0 ? segments.join(":") : undefined;
 }
 
 /**
@@ -32,6 +50,9 @@ export function getMdxModuleCacheVariant(
  * Always uses SSR mode suffix since this module loader is for server-side MDX rendering.
  * CRITICAL: The :ssr suffix is required to avoid cache collisions with browser-mode transforms
  * that use relative paths (../lib/utils.js) instead of absolute paths (/_vf_modules/lib/utils.js).
+ * CRITICAL: `dev` must stay part of this key. It feeds the distributed transform
+ * cache, so a shared entry that dropped the compile mode would serve
+ * development-compiled modules to hosted production renders across instances.
  */
 export function getTransformCacheKey(
   projectId: string,
@@ -42,6 +63,7 @@ export function getTransformCacheKey(
   dependencyPinningCacheKey?: string,
   moduleServerOrigin?: string,
   serverExternalPackages?: readonly string[],
+  dev?: boolean,
 ): string {
   return buildMdxEsmTransformCacheKey(
     projectId,
@@ -53,6 +75,7 @@ export function getTransformCacheKey(
       dependencyPinningCacheKey,
       moduleServerOrigin,
       serverExternalPackages,
+      dev,
     ),
   );
 }
@@ -63,6 +86,7 @@ export function getVersionedPathCacheKey(
   dependencyPinningCacheKey?: string,
   moduleServerOrigin?: string,
   serverExternalPackages?: readonly string[],
+  dev?: boolean,
 ): string {
   return buildMdxEsmPathCacheKey(
     normalizedPath,
@@ -71,6 +95,7 @@ export function getVersionedPathCacheKey(
       dependencyPinningCacheKey,
       moduleServerOrigin,
       serverExternalPackages,
+      dev,
     ),
   );
 }

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/http-fallback.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/http-fallback.ts
@@ -28,6 +28,8 @@ export interface ResolveUnresolvedModuleViaHttpFallbackInput {
   dependencyPinningCacheKey?: string;
   moduleServerOrigin?: string;
   serverExternalPackages?: readonly string[];
+  /** Compile mode of the render fetching this module, part of the cache identity. */
+  dev?: boolean;
   fetchViaHttp?: FetchModuleViaHttpFn;
   cacheLocalModule?: CacheLocalModuleFn;
 }
@@ -67,6 +69,7 @@ export async function resolveUnresolvedModuleViaHttpFallback(
       input.dependencyPinningCacheKey,
       input.moduleServerOrigin,
       input.serverExternalPackages,
+      input.dev,
     );
   }
 

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
@@ -274,6 +274,7 @@ async function doFetchAndCacheModule(
   const log = getLog(context);
   const { esmCacheDir, adapter, projectDir, projectId, contentSourceId } = context;
   const effectiveReactVersion = context.reactVersion ?? REACT_DEFAULT_VERSION;
+  const dev = context.dev === true;
   const dependencyPinningCacheKey = context.dependencyPinningCacheKey ?? "off";
   const moduleServerOrigin = dependencyPinningCacheKey.startsWith("on:")
     ? context.moduleServerOrigin
@@ -286,6 +287,7 @@ async function doFetchAndCacheModule(
     dependencyPinningCacheKey,
     moduleServerOrigin,
     context.serverExternalPackages,
+    dev,
   );
   const cachedPath = await readValidCachedModulePath({
     normalizedPath,
@@ -319,6 +321,7 @@ async function doFetchAndCacheModule(
         dependencyPinningCacheKey,
         moduleServerOrigin,
         serverExternalPackages: context.serverExternalPackages,
+        dev,
         parentModulePath,
       });
     }
@@ -344,6 +347,7 @@ async function doFetchAndCacheModule(
         dependencyPinningCacheKey,
         moduleServerOrigin,
         context.serverExternalPackages,
+        dev,
       )
       : null;
 
@@ -386,6 +390,7 @@ async function doFetchAndCacheModule(
         dependencyPinningSource: context.dependencyPinningSource,
         adapter,
         log,
+        dev,
       });
 
       // Mark for distributed cache write AFTER nested imports are resolved.
@@ -415,6 +420,7 @@ async function doFetchAndCacheModule(
       dependencyPinningCacheKey,
       moduleServerOrigin,
       serverExternalPackages: context.serverExternalPackages,
+      dev,
       distributedCacheWrite:
         needsDistributedCacheWrite && distResult?.distributedCache && transformCacheKey &&
           contentSourceId
@@ -447,6 +453,8 @@ export function createModuleFetcherContext(
     contentSourceId?: string;
     isLocalProject?: boolean;
     projectSlug?: string;
+    /** Compile fetched modules in development mode. Defaults to false. */
+    dev?: boolean;
     reactVersion?: string;
     moduleServerOrigin?: string;
     dependencyPinningCacheKey?: string;

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/module-cache.ts
@@ -62,6 +62,7 @@ export async function cacheModule(
   dependencyPinningCacheKey = "off",
   moduleServerOrigin?: string,
   serverExternalPackages?: readonly string[],
+  dev = false,
 ): Promise<string | null> {
   moduleCode = ensureFilenameDefaultExport(normalizedPath, moduleCode);
 
@@ -83,6 +84,7 @@ export async function cacheModule(
       dependencyPinningCacheKey,
       moduleServerOrigin,
       serverExternalPackages,
+      dev,
     ),
   );
 

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/persistence.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/persistence.ts
@@ -25,6 +25,8 @@ export interface PersistResolvedModuleInput {
   dependencyPinningCacheKey?: string;
   moduleServerOrigin?: string;
   serverExternalPackages?: readonly string[];
+  /** Compile mode of `moduleCode`, kept in the local path-cache identity. */
+  dev?: boolean;
   distributedCacheWrite?: {
     distributedCache: DistributedCache;
     transformCacheKey: string;
@@ -72,6 +74,7 @@ export async function persistResolvedModule(
     input.dependencyPinningCacheKey,
     input.moduleServerOrigin,
     input.serverExternalPackages,
+    input.dev,
   );
   input.log.debug(`${LOG_PREFIX_MDX_LOADER} [fetchAndCacheModule] cacheModule DONE`, {
     projectSlug: input.projectSlug,

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.test.ts
@@ -27,6 +27,7 @@ describe("module-fetcher/source-transform", () => {
       serverExternalPackages: ["knex"],
       moduleServerOrigin: "https://preview.example",
       dependencyPinningCacheKey: "on:pins",
+      dev: false,
       adapter,
       log: noopLog,
       transformToEsm: (source, actualFilePath, projectDir, receivedAdapter, options) => {
@@ -41,7 +42,7 @@ describe("module-fetcher/source-transform", () => {
         assertEquals(receivedAdapter, adapter);
         assertEquals(options, {
           projectId: "project-1",
-          dev: true,
+          dev: false,
           ssr: true,
           reactVersion: "19.1.1",
           serverExternalPackages: ["knex"],
@@ -68,5 +69,32 @@ describe("module-fetcher/source-transform", () => {
 
     assertEquals(calls, ["transform", "loadImportMap", "cacheHttpImportsToLocal"]);
     assertEquals(result, `import React from "file:///cache/react.mjs";\nexport default React;`);
+  });
+
+  it("compiles in the requested mode", async () => {
+    const observed: Array<boolean | undefined> = [];
+    const transform = (dev: boolean) =>
+      transformResolvedModuleSource({
+        sourceCode: `export default 1;`,
+        actualFilePath: "/project/lib/util.ts",
+        projectDir: "/project",
+        projectId: "project-1",
+        normalizedPath: "_vf_modules/lib/util.js",
+        projectSlug: "docs",
+        dev,
+        adapter: {} as RuntimeAdapter,
+        log: noopLog,
+        transformToEsm: (_source, _actualFilePath, _projectDir, _adapter, options) => {
+          observed.push(options.dev);
+          return Promise.resolve(`export default 1;`);
+        },
+        loadImportMap: () => Promise.resolve({ imports: {} }),
+        cacheHttpImportsToLocal: (code) => Promise.resolve({ code }),
+      });
+
+    await transform(false);
+    await transform(true);
+
+    assertEquals(observed, [false, true]);
   });
 });

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.ts
@@ -26,6 +26,12 @@ export interface TransformResolvedModuleSourceInput {
   projectId: string;
   normalizedPath: string;
   projectSlug: string;
+  /**
+   * Compile the module in development mode. Production renders must leave this
+   * false: development output is unminified, not tree-shaken and carries an
+   * inline sourcemap that discloses the project source.
+   */
+  dev: boolean;
   reactVersion?: string;
   serverExternalPackages?: readonly string[];
   moduleServerOrigin?: string;
@@ -64,7 +70,7 @@ export async function transformResolvedModuleSource(
       input.adapter,
       {
         projectId: input.projectId,
-        dev: true,
+        dev: input.dev,
         ssr: true,
         reactVersion: input.reactVersion,
         serverExternalPackages: input.serverExternalPackages,

--- a/src/transforms/mdx/esm-module-loader/types.ts
+++ b/src/transforms/mdx/esm-module-loader/types.ts
@@ -84,6 +84,12 @@ export interface ModuleFetcherContext {
   inFlightModules?: Map<string, Promise<string | null>>;
   /** Unique normalized modules admitted to this request-scoped graph. */
   moduleGraph?: Set<string>;
+  /**
+   * Compile fetched modules in development mode. Defaults to false so a caller
+   * that cannot name a render mode gets production output, and it is part of
+   * every module cache identity because it changes the emitted code.
+   */
+  dev?: boolean;
   /** React version for transforms (from project config) */
   reactVersion?: string;
   /** Bare npm package roots that the runtime resolves without bundling. */


### PR DESCRIPTION
## Summary

This is a production behaviour change. Two transform call sites still hardcoded `dev: true` after #3841, so the hosted production render path shipped development-compiled output on every request. Per `src/transforms/pipeline/stages/compile.ts`, `dev: true` means `minify: false`, `treeShaking: false` and an inline sourcemap, so production paid a payload-size cost and disclosed the project source. Both sites are fixed here, and each one's cache identity is updated in the same commit.

Refs veryfront/veryfront-issue-inbox#555

## Site A: the client hydration bundle

`bundleComponentForClient` (`src/rendering/component-handling.ts`) hardcoded `dev: true` and had no mode parameter. `src/rendering/page-renderer.ts` reaches it on every TSX page render that does not supply a cached client module.

- `bundleComponentForClient` takes the compile mode, defaulting to production.
- `handleComponentPage` derives it from the render mode with the same `options?.mode === "development"` line the SSR half of the file already used.

**Cache identity, updated alongside the flag.** `buildComponentHydrationCacheHash` did not include the compile mode. Fixing the flag alone would let a development bundle be served to a production render, or the reverse, because both modes resolve to one hydration cache entry. The hash now carries the compile mode.

## Site B: the MDX ESM module fetcher

`transformResolvedModuleSource` (`src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.ts`) hardcoded `dev: true`, and `createModuleFetcherContext` had no way to express the render mode. The chain is `ssr-module-loader/loader.ts` to `vf-module-resolver.ts` to `createModuleFetcherContext` to `fetchAndCacheModule`, and it fires for every `/_vf_modules/*` import of every SSR module.

- The module fetcher context takes a compile mode, defaulting to production.
- `resolveVfModuleImports` requires one, so a caller cannot silently omit it.
- The SSR module loader passes `this.options.dev`.

**Cache identity, mandatory in the same commit.** `getTransformCacheKey` had no compile-mode segment, and it feeds the distributed transform cache, whose entries are shared across requests and across instances with a TTL. Fixing the transform without the key would have been worse than the original bug: one instance could serve a development-compiled module to a hosted production render, and the reverse.

The compile mode is now part of `getMdxModuleCacheVariant`, the single segment builder behind the distributed transform key (`getTransformCacheKey` to `buildMdxEsmTransformCacheKey`), the module path-cache key (`getVersionedPathCacheKey` and `cacheModule`), and the SSR loader and render orchestrator lookups. All of these share one key space, so every writer and reader of it had to agree; a partial fix would have left the same cross-mode reuse through the path cache, which short-circuits before any transform runs.

Development artifacts take an `on:compile-dev` segment and production keeps the unsegmented key. The MDX-ESM cache namespace is rolled in the same change (the compile-mode split is named in the namespace schema sample), so the legacy entries written under the unsegmented key, all of them development-compiled, cannot be read back by a production render.

Artifact filenames already hash the transformed code, so the two modes cannot collide on disk and the artifact directory layout is unchanged.

## Scope

The compiled-MDX entry path (`esm-module-loader/loader-helpers.ts`) carries no render mode yet, so it keeps the development compile mode it has always used. That is now explicit rather than implied by a hardcoded literal, and the compile mode in the cache identity keeps its artifacts isolated from the production-compiled ones. Threading a render mode into `MDXRenderer.loadModuleESM` is a separate change.

No `RenderContext.mode` value ("development" | "production") is forwarded into a `"preview" | "production"` field. Only the compile-mode boolean is threaded.

## Tests

- `src/rendering/component-handling.test.ts`: a production-mode `handleComponentPage` render emits a hydration bundle with no inline sourcemap, minified and tree-shaken; a development-mode render still emits the debuggable bundle. Both assert on the emitted code. A third case pins that the two modes take separate hydration cache entries.
- `src/modules/react-loader/ssr-module-loader/vf-module-resolver.test.ts`: a development resolve runs first, then a production resolve of the same module for the same project and content source. The production render gets a different artifact with no inline sourcemap and no dead code, which fails if either the flag or the cache identity is missing.
- `src/modules/react-loader/ssr-module-loader/loader.test.ts`: an end-to-end `SSRModuleLoader` production load of a module with a `/_vf_modules/` import, asserting the cached artifact.
- `src/transforms/mdx/esm-module-loader/module-fetcher/cache-keys.test.ts`: the compile mode changes the distributed transform key and the path-cache key, an unset mode reads as production, and the compile segment stays separate from the pin and server-external segments.
- `src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.test.ts`: the requested compile mode reaches the transform.

Each new behaviour test was confirmed to fail against the unfixed code.

## Verification

```
deno test --preload=src/testing/preload.ts --no-check --allow-all src/rendering/    111 passed, 0 failed
deno test ... src/transforms/                                                       159 passed, 0 failed
deno test ... src/modules/react-loader/                                              26 passed, 0 failed
full src unit suite                                                                3639 passed, 0 failed
tests/ integration suite                                                            302 passed, 0 failed
deno fmt --check src/ cli/ react/ templates/                                        clean
deno lint on touched files, deno task typecheck                                     clean
deno task lint:sanitizer-baseline, lint:test-typecheck, lint:module-boundaries       clean
```
