### PR TITLE
test(transforms): assert linear closing-tag lookahead instead of wall clock

### DIFF
--- a/src/transforms/mdx/esm-module-loader/utils/source-spans.test.ts
+++ b/src/transforms/mdx/esm-module-loader/utils/source-spans.test.ts
@@ -35,6 +35,29 @@ function countStartsWithCalls(callback: () => void): number {
   return calls;
 }
 
+function countIndexOfCalls(callback: () => void): number {
+  const original = String.prototype.indexOf;
+  let calls = 0;
+  Object.defineProperty(String.prototype, "indexOf", {
+    configurable: true,
+    writable: true,
+    value(this: string, searchString: string, position?: number) {
+      calls++;
+      return original.call(this, searchString, position);
+    },
+  });
+  try {
+    callback();
+  } finally {
+    Object.defineProperty(String.prototype, "indexOf", {
+      configurable: true,
+      writable: true,
+      value: original,
+    });
+  }
+  return calls;
+}
+
 describe("transforms/mdx/esm-module-loader/utils/source-spans", () => {
   it("keeps static imports inside regexes hidden after local type export lists", () => {
     const matchRelative = (specifier: string) => specifier.startsWith("./") ? specifier : null;
@@ -1725,19 +1748,27 @@ import real from "./real.js";`,
       );
     });
 
-    it("keeps distinct TypeScript assertion lookahead within a bounded runtime", () => {
+    // Every assertion here sits in one statement with a distinct tag name, so the
+    // closing-tag lookahead must index that statement once and answer all 8,000
+    // names from the cache. Losing the cache makes the scan quadratic. Counting
+    // the `indexOf` calls that build the index states that invariant directly:
+    // the cached scan makes one call per assertion, an uncached one makes a call
+    // per assertion per source character.
+    it("keeps distinct TypeScript assertion lookahead linear", () => {
       const source = "type Value = unknown;\nconst values = [" +
         Array.from({ length: 8_000 }, (_, index) => `<T${index}>value`).join(",") +
         "];";
-      const startedAt = performance.now();
+      let paths: string[] = [];
 
-      assertEquals(specifiers(source), []);
+      const indexOfCalls = countIndexOfCalls(() => {
+        paths = specifiers(source);
+      });
 
-      const durationMs = performance.now() - startedAt;
+      assertEquals(paths, []);
       assert(
-        durationMs < 200,
-        `Expected a ${Math.round(source.length / 1024)} KB distinct TypeScript assertion scan ` +
-          `to finish within 200 ms, got ${durationMs.toFixed(1)} ms`,
+        indexOfCalls < source.length,
+        `Expected a linear distinct TypeScript assertion scan, got ${indexOfCalls} indexOf ` +
+          `calls for ${source.length} source characters`,
       );
     });
 


### PR DESCRIPTION
## Problem

`src/transforms/mdx/esm-module-loader/utils/source-spans.test.ts` bounded the "distinct TypeScript assertion lookahead" case at 200 ms of wall clock for a 101 KB source. On a shared CI runner it measured 221.4 ms and failed a required check on an unrelated PR, costing a merge-queue cycle. The margin was roughly 10 percent, which is noise on a contended runner.

The test exists to catch catastrophic blowup in the closing-tag lookahead, not to measure milliseconds, so a wall-clock bound was the wrong proxy for the invariant.

## Fix

Assert the property directly instead of the duration.

The source is one statement holding 8,000 distinct tag names. The invariant is that `hasRawJsxClosingTagBeforeStatementEnd` indexes that statement once and answers every name from `RawJsxLookaheadCache`. Losing the cache makes the scan quadratic. The test now counts the `String.prototype.indexOf` calls that build the index and asserts they stay below the source length, following the existing `countStartsWithCalls` linearity pattern already in this file.

No wall clock is read, so the assertion is load independent.

## Evidence

Measured on the current tree:

| Scan | `indexOf` calls | Source characters | Elapsed |
| --- | --- | --- | --- |
| Cached (current behavior) | 8,000 | 102,929 | 4.6 ms |
| Cache dropped (simulated regression) | 32,004,000 | 102,929 | 350.6 ms |

The new bound of 102,929 sits 12.9x above real behavior and 311x below the regression.

Mutation check: patching `hasRawJsxClosingTagBeforeStatementEnd` to ignore the cache fails the new assertion with `got 32004000 indexOf calls for 102929 source characters`. That regression measured 371 ms in the suite, so it would have passed the 750 ms bounds used by the sibling cases. The new assertion is strictly stronger than the 200 ms bound it replaces, not a relaxation.

Stability: 10 consecutive runs of the suite, all green, per-case time 8 ms to 9 ms and suite wall clock 0.55 s to 0.58 s. Repeated under 12 competing CPU busy loops: 5 more runs, all green, per-case time 10 ms to 13 ms. A call count cannot drift with runner load.

## Verification

- `deno test --preload=src/testing/preload.ts --no-check --allow-all src/transforms/mdx/esm-module-loader/utils/source-spans.test.ts`: 243 steps pass, 15 consecutive runs.
- `deno fmt`, `deno lint`, `deno check` on the touched file: clean.
- `deno task lint:ci`: exit 0.
- Merge-group pre-flight: `deno task typecheck` in a scratch copy of the merged tree: exit 0.

## Scope note

The task also named the `applies the per-project transform cap in production and bypasses it in dev` case in `src/modules/react-loader/ssr-module-loader/loader.test.ts` as a wall-clock flake. That case was already converted to `FakeTime` on main by #3847, asserts the selected deadline value rather than an elapsed delta, and runs in 63 ms to 110 ms. No change was needed and none was made.

Context: veryfront/veryfront-issue-inbox#112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved performance coverage for source scanning.
  * Replaced timing-based validation with a more reliable check that confirms efficient lookahead behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->