### PR TITLE
refactor(rendering): thread RenderModes through the MDX layout chain

### DIFF
--- a/src/rendering/layouts/index.ts
+++ b/src/rendering/layouts/index.ts
@@ -19,8 +19,11 @@ export { compileMDXLayouts } from "./utils/compiler.ts";
 export { computeDepsHash } from "./utils/hash-calculator.ts";
 export {
   applyMDXLayout,
+  type ApplyMDXLayoutOptions,
   applyTSXLayout,
   loadMDXLayout,
+  type LoadMDXLayoutOptions,
   loadTSXComponent,
+  type MDXLayoutModuleOptions,
 } from "./utils/component-loader.ts";
 export { applyLayoutsESM, applyLayoutsFunctionBody } from "./utils/applicator.ts";

--- a/src/rendering/layouts/utils/applicator.ts
+++ b/src/rendering/layouts/utils/applicator.ts
@@ -74,15 +74,16 @@ export function applyLayoutsESM(
             element = await withSpan(
               SpanNames.LAYOUT_APPLY_MDX,
               () =>
-                applyMDXLayout(
+                applyMDXLayout({
                   element,
-                  item.bundle!,
+                  bundle: item.bundle!,
                   projectDir,
                   mergedComponents,
                   adapter,
                   projectId,
                   projectSlug,
                   contentSourceId,
+                  modes,
                   preloadedImportMap,
                   reactVersion,
                   dependencyPinningCacheKey,
@@ -91,8 +92,7 @@ export function applyLayoutsESM(
                   moduleServerOrigin,
                   config,
                   isLocalProject,
-                  modes.compileMode,
-                ),
+                }),
               spanAttrs,
             );
             continue;
@@ -142,15 +142,16 @@ export function applyLayoutsESM(
       element = await withSpan(
         SpanNames.LAYOUT_APPLY_MDX,
         () =>
-          applyMDXLayout(
+          applyMDXLayout({
             element,
-            layoutBundle,
+            bundle: layoutBundle,
             projectDir,
             mergedComponents,
             adapter,
             projectId,
             projectSlug,
             contentSourceId,
+            modes,
             preloadedImportMap,
             reactVersion,
             dependencyPinningCacheKey,
@@ -159,8 +160,7 @@ export function applyLayoutsESM(
             moduleServerOrigin,
             config,
             isLocalProject,
-            modes.compileMode,
-          ),
+          }),
         { "layout.kind": "mdx", "layout.type": "named" },
       );
       logger.debug("Named layoutBundle applied successfully");

--- a/src/rendering/layouts/utils/component-loader.test.ts
+++ b/src/rendering/layouts/utils/component-loader.test.ts
@@ -7,12 +7,14 @@ import {
   createLayoutComponentCache,
   loadMDXLayout,
   loadTSXComponent,
+  preloadMDXLayoutModule,
   shouldUnwrapAppRouterDocumentLayout,
   unwrapAppRouterDocumentLayout,
 } from "./component-loader.ts";
 import { type MDXLoadModuleOptions, mdxRenderer } from "#veryfront/transforms/mdx/index.ts";
 import type { MdxBundle } from "#veryfront/types";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { RenderModes } from "#veryfront/rendering/context/render-context.ts";
 import { hashString } from "#veryfront/cache/hash.ts";
 import { validateVeryfrontConfig } from "#veryfront/config";
 import {
@@ -23,6 +25,18 @@ import {
 const PRODUCTION_MODES = {
   compileMode: "production",
   environment: "production",
+} as const;
+
+/** Hosted preview: production compile, preview instrumentation. */
+const PREVIEW_MODES = {
+  compileMode: "production",
+  environment: "preview",
+} as const;
+
+/** Local development: development compile, preview instrumentation. */
+const DEVELOPMENT_MODES = {
+  compileMode: "development",
+  environment: "preview",
 } as const;
 
 function cacheKeyForDependencies(
@@ -557,18 +571,21 @@ describe("rendering/layouts/utils/component-loader", () => {
     };
 
     try {
-      await loadMDXLayout(
-        { compiledCode: "export default function Layout() { return null; }" } as MdxBundle,
-        "/project",
-        { fs: {} } as unknown as RuntimeAdapter,
-        "project-18",
-        "project-slug",
-        "preview-main",
-        { imports: {} },
-        "18.3.1",
-        SNAPSHOT_A_PIN_KEY,
-        SNAPSHOT_A_DEPENDENCIES,
-      );
+      await loadMDXLayout({
+        bundle: {
+          compiledCode: "export default function Layout() { return null; }",
+        } as MdxBundle,
+        projectDir: "/project",
+        adapter: { fs: {} } as unknown as RuntimeAdapter,
+        projectId: "project-18",
+        projectSlug: "project-slug",
+        contentSourceId: "preview-main",
+        modes: PRODUCTION_MODES,
+        preloadedImportMap: { imports: {} },
+        reactVersion: "18.3.1",
+        dependencyPinningCacheKey: SNAPSHOT_A_PIN_KEY,
+        dependencyPinningDependencies: SNAPSHOT_A_DEPENDENCIES,
+      });
 
       assertEquals(moduleReactVersion, "18.3.1");
       assertEquals(modulePinKey, SNAPSHOT_A_PIN_KEY);
@@ -578,44 +595,105 @@ describe("rendering/layouts/utils/component-loader", () => {
     }
   });
 
-  it("threads the render mode into MDX layout module loading", async () => {
+  it("unpacks the compile half of the render modes into MDX layout module loading", async () => {
     const originalLoadModuleESM = mdxRenderer.loadModuleESM;
     const mutableRenderer = mdxRenderer as unknown as {
       loadModuleESM: typeof mdxRenderer.loadModuleESM;
     };
-    const observedModes: unknown[] = [];
+    const observed: Array<MDXLoadModuleOptions | undefined> = [];
     mutableRenderer.loadModuleESM = (_compiledProgramCode, options) => {
-      observedModes.push((options as MDXLoadModuleOptions | undefined)?.mode);
+      observed.push(options as MDXLoadModuleOptions | undefined);
       return Promise.resolve({ default: () => null });
     };
 
-    const loadWithMode = (mode?: "development" | "production") =>
-      loadMDXLayout(
-        { compiledCode: "export default function Layout() { return null; }" } as MdxBundle,
-        "/project",
-        { fs: {} } as unknown as RuntimeAdapter,
-        "mode-project",
-        "project-slug",
-        "release-1",
-        { imports: {} },
-        "19.1.1",
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        mode,
-      );
+    const loadWithModes = (modes: RenderModes) =>
+      loadMDXLayout({
+        bundle: {
+          compiledCode: "export default function Layout() { return null; }",
+        } as MdxBundle,
+        projectDir: "/project",
+        adapter: { fs: {} } as unknown as RuntimeAdapter,
+        projectId: "mode-project",
+        projectSlug: "project-slug",
+        contentSourceId: "release-1",
+        modes,
+        preloadedImportMap: { imports: {} },
+        reactVersion: "19.1.1",
+      });
 
     try {
       // A layout's own `/_vf_modules/*` imports must compile for the same mode
-      // as the page that wraps them, and for production when none is named.
-      await loadWithMode("production");
-      await loadWithMode("development");
-      await loadWithMode(undefined);
+      // as the page that wraps them. The loader speaks the compile vocabulary
+      // only, so the hosted preview pair is the case that fails if the request
+      // vocabulary is unpacked in its place.
+      await loadWithModes(DEVELOPMENT_MODES);
+      await loadWithModes(PREVIEW_MODES);
+      await loadWithModes(PRODUCTION_MODES);
 
-      assertEquals(observedModes, ["production", "development", undefined]);
+      assertEquals(observed.map((options) => options?.mode), [
+        "development",
+        "production",
+        "production",
+      ]);
+      assertEquals(observed.map((options) => options?.projectSlug), [
+        "project-slug",
+        "project-slug",
+        "project-slug",
+      ]);
+      assertEquals(observed.map((options) => options?.reactVersion), [
+        "19.1.1",
+        "19.1.1",
+        "19.1.1",
+      ]);
+    } finally {
+      mutableRenderer.loadModuleESM = originalLoadModuleESM;
+    }
+  });
+
+  it("unpacks the compile half of the render modes when preloading an MDX layout", async () => {
+    const originalLoadModuleESM = mdxRenderer.loadModuleESM;
+    const mutableRenderer = mdxRenderer as unknown as {
+      loadModuleESM: typeof mdxRenderer.loadModuleESM;
+    };
+    const observed: Array<MDXLoadModuleOptions | undefined> = [];
+    mutableRenderer.loadModuleESM = (_compiledProgramCode, options) => {
+      observed.push(options as MDXLoadModuleOptions | undefined);
+      return Promise.resolve({ default: () => null });
+    };
+
+    const preloadWithModes = (modes: RenderModes) =>
+      preloadMDXLayoutModule({
+        bundle: {
+          compiledCode: "export default function Layout() { return null; }",
+        } as MdxBundle,
+        projectDir: "/project",
+        adapter: { fs: {} } as unknown as RuntimeAdapter,
+        projectId: "preload-mode-project",
+        projectSlug: "preload-project-slug",
+        contentSourceId: "release-1",
+        modes,
+        reactVersion: "19.1.1",
+        isLocalProject: true,
+      });
+
+    try {
+      // Preloading warms the same module cache the apply phase reads back, so
+      // it must resolve the identical compile mode for the identical pair.
+      await preloadWithModes(DEVELOPMENT_MODES);
+      await preloadWithModes(PREVIEW_MODES);
+      await preloadWithModes(PRODUCTION_MODES);
+
+      assertEquals(observed.map((options) => options?.mode), [
+        "development",
+        "production",
+        "production",
+      ]);
+      assertEquals(observed.map((options) => options?.isLocalProject), [true, true, true]);
+      assertEquals(observed.map((options) => options?.projectSlug), [
+        "preload-project-slug",
+        "preload-project-slug",
+        "preload-project-slug",
+      ]);
     } finally {
       mutableRenderer.loadModuleESM = originalLoadModuleESM;
     }
@@ -650,21 +728,21 @@ describe("rendering/layouts/utils/component-loader", () => {
     });
 
     try {
-      await loadMDXLayout(
-        { compiledCode: "export default function Layout() { return null; }" } as MdxBundle,
-        "/context-project",
+      await loadMDXLayout({
+        bundle: {
+          compiledCode: "export default function Layout() { return null; }",
+        } as MdxBundle,
+        projectDir: "/context-project",
         adapter,
-        "context-project-id",
-        "project-slug",
-        "release-1",
-        undefined,
-        "19.1.0",
-        SNAPSHOT_A_PIN_KEY,
-        SNAPSHOT_A_DEPENDENCIES,
-        undefined,
-        undefined,
+        projectId: "context-project-id",
+        projectSlug: "project-slug",
+        contentSourceId: "release-1",
+        modes: PRODUCTION_MODES,
+        reactVersion: "19.1.0",
+        dependencyPinningCacheKey: SNAPSHOT_A_PIN_KEY,
+        dependencyPinningDependencies: SNAPSHOT_A_DEPENDENCIES,
         config,
-      );
+      });
 
       // The production call site must register the preloaded map under the
       // exact release/config variant, not the ambient projectId-only variant.

--- a/src/rendering/layouts/utils/component-loader.ts
+++ b/src/rendering/layouts/utils/component-loader.ts
@@ -361,25 +361,66 @@ export async function loadTSXComponent(
   return loaded;
 }
 
+/**
+ * Inputs shared by every MDX layout module load.
+ *
+ * These are named rather than positional because the chain is long enough that
+ * a value in the wrong slot still type-checks. `modes` in particular carries
+ * two vocabularies that are both mode-shaped and disagree on a hosted preview
+ * render, so it travels as the pair and is unpacked at the one seam that
+ * consumes it.
+ */
+export interface MDXLayoutModuleOptions {
+  bundle: MdxBundle;
+  projectDir: string;
+  adapter: RuntimeAdapter;
+  projectId: string;
+  projectSlug: string;
+  contentSourceId: string;
+  /**
+   * Compile and request vocabularies for this render. `compileMode` selects the
+   * compile mode of the layout's own `/_vf_modules/*` imports. `environment`
+   * has no consumer below this seam today and is carried so that no caller has
+   * to choose between the two, which is the choice that type-checks when made
+   * wrongly.
+   */
+  modes: RenderModes;
+  reactVersion?: string;
+  dependencyPinningCacheKey?: string;
+  dependencyPinningDependencies?: Readonly<Record<string, string>>;
+  dependencyPinningSource?: DependencyPinningSourceInput;
+  moduleServerOrigin?: string;
+  config?: VeryfrontConfig;
+  isLocalProject?: boolean;
+}
+
+/** Inputs for {@link loadMDXLayout}. */
+export interface LoadMDXLayoutOptions extends MDXLayoutModuleOptions {
+  preloadedImportMap?: ImportMapConfig;
+}
+
 /** Load an MDX layout module from a bundle. */
 export function loadMDXLayout(
-  bundle: MdxBundle,
-  projectDir: string,
-  adapter: RuntimeAdapter,
-  projectId: string,
-  projectSlug: string,
-  contentSourceId: string,
-  preloadedImportMap?: ImportMapConfig,
-  reactVersion?: string,
-  dependencyPinningCacheKey?: string,
-  dependencyPinningDependencies?: Readonly<Record<string, string>>,
-  dependencyPinningSource?: DependencyPinningSourceInput,
-  moduleServerOrigin?: string,
-  config?: VeryfrontConfig,
-  isLocalProject?: boolean,
-  /** Render mode for the layout's own `/_vf_modules/*` imports. */
-  mode?: "development" | "production",
+  options: LoadMDXLayoutOptions,
 ): Promise<BundledReact.ComponentType<{ components?: MDXComponents }> | undefined> {
+  const {
+    bundle,
+    projectDir,
+    adapter,
+    projectId,
+    projectSlug,
+    contentSourceId,
+    modes,
+    preloadedImportMap,
+    reactVersion,
+    dependencyPinningCacheKey,
+    dependencyPinningDependencies,
+    dependencyPinningSource,
+    moduleServerOrigin,
+    config,
+    isLocalProject,
+  } = options;
+
   return withSpan(
     SpanNames.LAYOUT_LOAD_MDX,
     async () => {
@@ -409,7 +450,7 @@ export function loadMDXLayout(
         projectDir,
         projectSlug,
         contentSourceId,
-        mode,
+        mode: modes.compileMode,
         reactVersion,
         dependencyPinningCacheKey,
         dependencyPinningDependencies,
@@ -434,40 +475,16 @@ export function loadMDXLayout(
   );
 }
 
-/** Preload an MDX layout module into cache for faster subsequent loads. */
+/**
+ * Preload an MDX layout module into cache for faster subsequent loads.
+ *
+ * The preload resolves the import map itself, so it takes no
+ * `preloadedImportMap`.
+ */
 export async function preloadMDXLayoutModule(
-  bundle: MdxBundle,
-  projectDir: string,
-  adapter: RuntimeAdapter,
-  projectId: string,
-  projectSlug: string,
-  contentSourceId: string,
-  reactVersion?: string,
-  dependencyPinningCacheKey?: string,
-  dependencyPinningDependencies?: Readonly<Record<string, string>>,
-  dependencyPinningSource?: DependencyPinningSourceInput,
-  moduleServerOrigin?: string,
-  config?: VeryfrontConfig,
-  isLocalProject?: boolean,
-  mode?: "development" | "production",
+  options: MDXLayoutModuleOptions,
 ): Promise<void> {
-  await loadMDXLayout(
-    bundle,
-    projectDir,
-    adapter,
-    projectId,
-    projectSlug,
-    contentSourceId,
-    undefined,
-    reactVersion,
-    dependencyPinningCacheKey,
-    dependencyPinningDependencies,
-    dependencyPinningSource,
-    moduleServerOrigin,
-    config,
-    isLocalProject,
-    mode,
-  );
+  await loadMDXLayout(options);
 }
 
 export async function applyTSXLayout(
@@ -544,43 +561,18 @@ export async function applyTSXLayout(
   }
 }
 
+/** Inputs for {@link applyMDXLayout}. */
+export interface ApplyMDXLayoutOptions extends LoadMDXLayoutOptions {
+  element: BundledReact.ReactElement;
+  mergedComponents: MDXComponents;
+}
+
 export async function applyMDXLayout(
-  element: BundledReact.ReactElement,
-  bundle: MdxBundle,
-  projectDir: string,
-  mergedComponents: MDXComponents,
-  adapter: RuntimeAdapter,
-  projectId: string,
-  projectSlug: string,
-  contentSourceId: string,
-  preloadedImportMap?: ImportMapConfig,
-  reactVersion?: string,
-  dependencyPinningCacheKey?: string,
-  dependencyPinningDependencies?: Readonly<Record<string, string>>,
-  dependencyPinningSource?: DependencyPinningSourceInput,
-  moduleServerOrigin?: string,
-  config?: VeryfrontConfig,
-  isLocalProject?: boolean,
-  mode?: "development" | "production",
+  options: ApplyMDXLayoutOptions,
 ): Promise<BundledReact.ReactElement> {
+  const { element, mergedComponents, reactVersion } = options;
   const React = await getProjectReact(reactVersion);
-  const LayoutFn = await loadMDXLayout(
-    bundle,
-    projectDir,
-    adapter,
-    projectId,
-    projectSlug,
-    contentSourceId,
-    preloadedImportMap,
-    reactVersion,
-    dependencyPinningCacheKey,
-    dependencyPinningDependencies,
-    dependencyPinningSource,
-    moduleServerOrigin,
-    config,
-    isLocalProject,
-    mode,
-  );
+  const LayoutFn = await loadMDXLayout(options);
 
   if (!LayoutFn) {
     applyMdxLayoutLog.debug("No layout function found");

--- a/src/rendering/orchestrator/layout.ts
+++ b/src/rendering/orchestrator/layout.ts
@@ -273,7 +273,7 @@ export class LayoutOrchestrator {
                   projectId: this.config.projectId,
                   projectSlug: this.config.projectSlug,
                   contentSourceId: this.config.contentSourceId,
-                  modes: this.renderModes,
+                  modes: { ...this.renderModes, environment },
                   reactVersion,
                   dependencyPinningCacheKey,
                   dependencyPinningDependencies,

--- a/src/rendering/orchestrator/layout.ts
+++ b/src/rendering/orchestrator/layout.ts
@@ -266,22 +266,22 @@ export class LayoutOrchestrator {
           preloadPromises.push(
             (async (): Promise<LayoutPreloadResult> => {
               try {
-                await preloadMDXLayoutModule(
-                  layout.bundle!,
-                  this.config.projectDir,
-                  this.config.adapter,
-                  this.config.projectId,
-                  this.config.projectSlug,
-                  this.config.contentSourceId,
+                await preloadMDXLayoutModule({
+                  bundle: layout.bundle!,
+                  projectDir: this.config.projectDir,
+                  adapter: this.config.adapter,
+                  projectId: this.config.projectId,
+                  projectSlug: this.config.projectSlug,
+                  contentSourceId: this.config.contentSourceId,
+                  modes: this.renderModes,
                   reactVersion,
                   dependencyPinningCacheKey,
                   dependencyPinningDependencies,
                   dependencyPinningSource,
                   moduleServerOrigin,
-                  this.config.config,
-                  this.config.isLocalProject === true,
-                  this.config.mode,
-                );
+                  config: this.config.config,
+                  isLocalProject: this.config.isLocalProject === true,
+                });
                 return { type: "mdx" as const, path: layout.path, success: true };
               } catch (error) {
                 throwIfAborted(signal);


### PR DESCRIPTION
Follow-up recommended by the verifier on #3848.

## The problem

The layout path spoke two mode vocabularies at once.

- **Compile**: `"development" | "production"`, selects minify, tree shaking, sourcemaps.
- **Request**: `"preview" | "production"`, selects Studio Navigator node position injection.

#3847 introduced `RenderModes` (`src/rendering/context/render-context.ts`) carrying both as `{ compileMode, environment }`, and `applyLayoutsESM`, `applyLayoutsFunctionBody` and `PageRenderer` already take it. The MDX half of the chain still took a trailing optional `mode?: "development" | "production"`, so the compile half had to be picked out at the call site, on positional chains 14 to 17 arguments long where the request half type-checks in the same slot.

That is not hypothetical. `applicator.ts:94` and `:162` needed exactly that fix during #3848 after #3847 renamed the parameter, and it surfaced only as a merge-group typecheck failure, not on either PR alone.

## The change

`applyMDXLayout`, `loadMDXLayout` and `preloadMDXLayoutModule` take a required `modes: RenderModes`. The trailing optional `mode` is gone, so the whole layout path speaks one type.

`modes` is **required**, not optional-with-a-production-default. An optional render mode is the failure class of veryfront/veryfront-issue-inbox#555, which `scripts/lint/audit-render-mode-defaults.ts` (wired into `lint:ci`) now guards against.

## Options object: what I chose and why

I converted these three signatures to an options object.

The alternative I weighed was a required positional `modes` inserted after `contentSourceId`, matching `applyTSXLayout`, `loadTSXComponent` and `applyLayoutsESM`. That touches the identical files and the identical call sites, with a smaller edit at each, and it does make the `modes` argument itself unmistakable: `RenderModes` is structurally incompatible with every neighbouring parameter type.

But it only narrows the hazard. It leaves ten adjacent `string | undefined` parameters (`reactVersion`, `dependencyPinningCacheKey`, `moduleServerOrigin`, `contentSourceId`, `projectId`, `projectSlug`, ...) that stay mutually assignable, and the call sites keep passing runs of bare `undefined`. Naming the parameters removes the wrong-slot class outright at this boundary rather than for one argument, which is what the #3848 review asked for.

Supporting reasons:

- The repository already answers this exact problem the same way one layer down: `MDXLoadModuleOptions` in `src/transforms/mdx/index.ts` is an options object introduced for the same reason, and `loadComponentFromSource` takes one too.
- No public API changes. These three functions are reachable only through the internal `rendering/layouts` barrel; `veryfront/rendering` re-exports `applyLayoutsESM` and `applyLayoutsFunctionBody`, and neither signature changes.
- The blast radius is 3 definitions, 3 production call sites and 3 test call sites, all in this diff.

Scope is deliberately limited to the three MDX functions this change already had to touch. `applyTSXLayout`, `loadTSXComponent`, `applyLayoutsESM` and `applyLayoutsFunctionBody` keep their positional signatures. The resulting local asymmetry inside `component-loader.ts` is the accepted cost of not doing a sweeping refactor of functions this change has no other reason to touch.

## Behaviour

Unchanged. This is a type-level consolidation. The single value the loader consumes is still `modes.compileMode`, at the one seam that calls `mdxRenderer.loadModuleESM`. `environment` has no consumer below that seam today; it is carried so that no caller has to choose between two mode-shaped values, which is the choice that type-checks when made wrongly.

## Tests

The #3848 guards keep passing unchanged, across all three `RenderModes` pairs including hosted preview (`{ compileMode: "production", environment: "preview" }`):

- `src/rendering/layouts/utils/applicator.test.ts`, "threads the compile mode into every MDX layout load"
- `src/rendering/orchestrator/layout.test.ts`, "threads the compile mode through MDX layout preloading"

Extended to the newly threaded boundary, driving the two functions directly rather than only through the applicator:

- `component-loader.test.ts`, "unpacks the compile half of the render modes into MDX layout module loading" (replaces the old positional-`mode` test, now over the three pairs)
- `component-loader.test.ts`, "unpacks the compile half of the render modes when preloading an MDX layout" (new; `preloadMDXLayoutModule` had no direct coverage of the mode it forwards)

### Mutation testing

Each of the three sites this change touches was mutated, and each mutation fails tests:

| Mutation | Result |
| --- | --- |
| `loadMDXLayout`: `mode: modes.compileMode` to `modes.environment` | all 4 guards fail |
| `applicator.ts`: swapped pair at both MDX call sites | applicator guard fails |
| `orchestrator/layout.ts`: swapped pair at the preload site | orchestrator guard fails |

## Verification

- `deno test src/rendering/` : 112 passed, 0 failed
- `tests/integration/server/production/` and `production-server.test.ts` : 9 passed, 0 failed
- `tests/integration/renderer/` : 21 passed, 1 failed. The failure is a pre-existing flaky TCP/`op_read` leak in `layout-handling.test.ts` that only appears in a full-directory run. On an unmodified `origin/main` scratch tree the same command gives **20 passed, 2 failed** with the same leak, and the file passes in isolation on both trees.
- `deno fmt`, `deno lint`, `deno check`, `deno task lint:ci` : clean
- Merge-group pre-flight: `origin/main` merged into a scratch tree, `deno task typecheck` exit 0

Refs veryfront/veryfront-issue-inbox#112
Refs veryfront/veryfront-issue-inbox#555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MDX layout loading and preloading across development and production rendering modes.
  * Preserved project, dependency, configuration, and local-development settings during layout processing.

* **Refactor**
  * Updated MDX layout APIs to use clearer named options, improving consistency and reliability.
  * Added reusable type definitions for MDX layout configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->