### PR TITLE
fix(rendering): support pre-runtime release hydration

### DIFF
--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -52,14 +52,20 @@ the runtime from the currently serving Veryfront process.
 This pairing is a compatibility boundary. Keep the hydration runtime for as
 long as its immutable release can be deployed or served. Retire the release and
 its browser artifacts together; never delete only the hydration runtime or
-redirect its hashed URL to newer bytes. A release that is missing its single
-versioned runtime fails rendering instead of falling back to a potentially
-incompatible runtime.
+redirect its hashed URL to newer bytes.
+
+Releases created before versioned runtimes use their own
+`/_veryfront/hydration-runtime.js` asset. Veryfront revalidates that legacy
+asset from the release itself and never substitutes the currently serving
+runtime. For releases created before the runtime artifact contract, Veryfront
+uses the serving runtime only when the release has no hydration runtime at all.
+All contract-era releases must provide a baked runtime, otherwise rendering
+fails instead of falling back to potentially incompatible bytes.
 
 Veryfront's required browser regression job exercises the current server
-against an aged release artifact set. The build contract test also verifies
-that every promoted artifact set contains exactly one discoverable versioned
-hydration runtime, so an incompatible pairing blocks promotion in CI.
+against aged release artifact sets. The build contract test verifies that new
+production builds contain exactly one discoverable versioned hydration runtime,
+while runtime compatibility tests cover legacy-only releases.
 
 This policy follows [incident #264](https://github.com/veryfront/veryfront-issue-inbox/issues/264)
 and the immediate compatibility fix in

--- a/src/html/hydration-script-builder/prod-path.ts
+++ b/src/html/hydration-script-builder/prod-path.ts
@@ -5,3 +5,7 @@ export const PROD_HYDRATION_MODULE_VERSIONED_PATH_PATTERN =
 export function isVersionedProdHydrationModulePath(pathname: string): boolean {
   return PROD_HYDRATION_MODULE_VERSIONED_PATH_PATTERN.test(pathname);
 }
+
+export function isProdHydrationModulePath(pathname: string): boolean {
+  return pathname === PROD_HYDRATION_MODULE_PATH || isVersionedProdHydrationModulePath(pathname);
+}

--- a/src/html/hydration-script-builder/prod-runtime-selection.test.ts
+++ b/src/html/hydration-script-builder/prod-runtime-selection.test.ts
@@ -2,7 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertNotStrictEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { DirEntry, FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
-import { getProdHydrationModulePath } from "./prod-scripts.ts";
+import { getProdHydrationModulePath, PROD_HYDRATION_MODULE_PATH } from "./prod-scripts.ts";
 import {
   hasImmutableReleaseHydrationRuntime,
   resolveProdHydrationModulePath,
@@ -133,13 +133,82 @@ describe("resolveProdHydrationModulePath", () => {
     );
   });
 
-  it("fails closed when a release has no baked content-addressed runtime", async () => {
+  it("uses the legacy runtime baked into a pre-versioned release", async () => {
+    assertEquals(
+      await resolveProdHydrationModulePath({
+        fs: releaseFileSystem(["hydration-runtime.js", "router.js"]),
+        projectDir: "/project",
+        releaseId: "release-pre-versioned",
+      }),
+      PROD_HYDRATION_MODULE_PATH,
+    );
+  });
+
+  it("uses the serving runtime for a pre-contract release with no baked runtime", async () => {
+    assertEquals(
+      await resolveProdHydrationModulePath({
+        fs: releaseFileSystem(["router.js"]),
+        projectDir: "/project",
+        releaseId: "release-pre-contract",
+        releaseBuilderVersion: "0.1.1220",
+      }),
+      getProdHydrationModulePath(),
+    );
+  });
+
+  it("uses the serving runtime for a pre-contract release with no runtime directory", async () => {
+    const missingDirectory = Object.assign(new Error("missing runtime directory"), {
+      code: "ENOENT",
+    });
+
+    assertEquals(
+      await resolveProdHydrationModulePath({
+        fs: rejectingFileSystem(missingDirectory),
+        projectDir: "/project",
+        releaseId: "release-pre-contract-no-directory",
+        releaseBuilderVersion: "0.1.1220",
+      }),
+      getProdHydrationModulePath(),
+    );
+  });
+
+  it("fails closed when a contract-era release has no baked hydration runtime", async () => {
     const error = await assertRejects(
       () =>
         resolveProdHydrationModulePath({
-          fs: releaseFileSystem(["hydration-runtime.js", "router.js"]),
+          fs: releaseFileSystem(["router.js"]),
           projectDir: "/project",
           releaseId: "release-incomplete",
+          releaseBuilderVersion: "0.1.1244",
+        }),
+      Error,
+    );
+
+    assertEquals((error as { slug?: unknown }).slug, "render-error");
+  });
+
+  it("fails closed when a runtime-less release has unknown builder metadata", async () => {
+    const error = await assertRejects(
+      () =>
+        resolveProdHydrationModulePath({
+          fs: releaseFileSystem(["router.js"]),
+          projectDir: "/project",
+          releaseId: "release-unknown",
+        }),
+      Error,
+    );
+
+    assertEquals((error as { slug?: unknown }).slug, "render-error");
+  });
+
+  it("fails closed when a runtime-less release has malformed builder metadata", async () => {
+    const error = await assertRejects(
+      () =>
+        resolveProdHydrationModulePath({
+          fs: releaseFileSystem(["router.js"]),
+          projectDir: "/project",
+          releaseId: "release-malformed",
+          releaseBuilderVersion: "v0.1.1220",
         }),
       Error,
     );

--- a/src/html/hydration-script-builder/prod-runtime-selection.ts
+++ b/src/html/hydration-script-builder/prod-runtime-selection.ts
@@ -1,7 +1,16 @@
 import { join, resolve } from "#veryfront/compat/path/index.ts";
 import { RENDER_ERROR } from "#veryfront/errors";
+import { isNotFoundError } from "#veryfront/platform/compat/fs.ts";
+import { getReadyManifestForRenderAsync } from "#veryfront/release-assets/manifest-cache.ts";
+import { serverLogger } from "#veryfront/utils";
 import { getProdHydrationModulePath } from "./prod-scripts.ts";
-import { isVersionedProdHydrationModulePath } from "./prod-path.ts";
+import { isVersionedProdHydrationModulePath, PROD_HYDRATION_MODULE_PATH } from "./prod-path.ts";
+
+const FIRST_BUILDER_VERSION_REQUIRING_BAKED_RUNTIME = [0, 1, 1244] as const;
+const BUILDER_VERSION_PATTERN = /^(\d+)\.(\d+)\.(\d+)$/;
+const MAX_REPORTED_SERVING_RUNTIME_FALLBACKS = 500;
+const reportedServingRuntimeFallbacks = new Set<string>();
+const logger = serverLogger.component("hydration-runtime-selection");
 
 export interface ProdHydrationModuleSelectionOptions {
   fs: {
@@ -10,6 +19,8 @@ export interface ProdHydrationModuleSelectionOptions {
   projectDir: string;
   buildOutDir?: string;
   releaseId?: string;
+  /** Builder version from the release asset manifest when already resolved by the caller. */
+  releaseBuilderVersion?: string;
 }
 
 /** Whether the release ID names an immutable artifact set rather than local source serving. */
@@ -19,13 +30,44 @@ export function hasImmutableReleaseHydrationRuntime(
   return releaseId !== undefined && releaseId.length > 0 && releaseId !== "standalone-dev";
 }
 
+function isPreRuntimeArtifactContract(builderVersion: string | undefined): boolean {
+  const match = builderVersion?.match(BUILDER_VERSION_PATTERN);
+  if (!match) return false;
+
+  const parsed = match.slice(1).map(Number);
+  for (let index = 0; index < FIRST_BUILDER_VERSION_REQUIRING_BAKED_RUNTIME.length; index++) {
+    const value = parsed[index];
+    const floor = FIRST_BUILDER_VERSION_REQUIRING_BAKED_RUNTIME[index];
+    if (value === undefined || floor === undefined) return false;
+    if (value !== floor) return value < floor;
+  }
+  return false;
+}
+
+function reportServingRuntimeFallback(releaseId: string, builderVersion: string): void {
+  const key = `${releaseId}:${builderVersion}`;
+  if (reportedServingRuntimeFallbacks.has(key)) return;
+
+  if (reportedServingRuntimeFallbacks.size >= MAX_REPORTED_SERVING_RUNTIME_FALLBACKS) {
+    const oldestKey = reportedServingRuntimeFallbacks.values().next().value;
+    if (oldestKey) reportedServingRuntimeFallbacks.delete(oldestKey);
+  }
+  reportedServingRuntimeFallbacks.add(key);
+  logger.warn("Using the serving hydration runtime for a pre-contract release", {
+    releaseId,
+    builderVersion,
+    reason: "release-missing-hydration-runtime",
+  });
+}
+
 /**
  * Select the hydration runtime owned by the rendered artifact set.
  *
  * Non-release renders use the serving runtime. Release renders discover the
- * single content-addressed runtime baked into that immutable release. Missing
- * or ambiguous release artifacts fail closed instead of mixing the serving
- * runtime with release-pinned browser modules.
+ * content-addressed runtime baked into that immutable release. Pre-versioned
+ * releases use their baked legacy runtime. Releases built before the runtime
+ * artifact contract use the serving runtime only when no baked runtime exists.
+ * Missing or ambiguous contract-era artifacts fail closed.
  */
 export async function resolveProdHydrationModulePath(
   options: ProdHydrationModuleSelectionOptions,
@@ -37,6 +79,7 @@ export async function resolveProdHydrationModulePath(
   const configuredOutDir = options.buildOutDir || "dist";
   const runtimeDirectory = join(resolve(options.projectDir, configuredOutDir), "_veryfront");
   let selectedPath: string | null = null;
+  let hasLegacyRuntime = false;
   let hasMultipleRuntimes = false;
 
   try {
@@ -44,6 +87,10 @@ export async function resolveProdHydrationModulePath(
       if (!entry.isFile) continue;
 
       const candidate = `/_veryfront/${entry.name}`;
+      if (candidate === PROD_HYDRATION_MODULE_PATH) {
+        hasLegacyRuntime = true;
+        continue;
+      }
       if (!isVersionedProdHydrationModulePath(candidate)) continue;
       if (selectedPath !== null) {
         hasMultipleRuntimes = true;
@@ -51,10 +98,12 @@ export async function resolveProdHydrationModulePath(
       }
       selectedPath = candidate;
     }
-  } catch {
-    throw RENDER_ERROR.create({
-      detail: "Release hydration runtime could not be inspected",
-    });
+  } catch (error) {
+    if (!isNotFoundError(error)) {
+      throw RENDER_ERROR.create({
+        detail: "Release hydration runtime could not be inspected",
+      });
+    }
   }
 
   if (hasMultipleRuntimes) {
@@ -63,11 +112,17 @@ export async function resolveProdHydrationModulePath(
     });
   }
 
-  if (selectedPath === null) {
-    throw RENDER_ERROR.create({
-      detail: "Release is missing its versioned hydration runtime",
-    });
+  if (selectedPath !== null) return selectedPath;
+  if (hasLegacyRuntime) return PROD_HYDRATION_MODULE_PATH;
+
+  const builderVersion = options.releaseBuilderVersion ??
+    (await getReadyManifestForRenderAsync(options.releaseId))?.builderVersion;
+  if (builderVersion && isPreRuntimeArtifactContract(builderVersion)) {
+    reportServingRuntimeFallback(options.releaseId, builderVersion);
+    return getProdHydrationModulePath();
   }
 
-  return selectedPath;
+  throw RENDER_ERROR.create({
+    detail: "Release is missing its hydration runtime",
+  });
 }

--- a/src/html/hydration-script-builder/prod-scripts.test.ts
+++ b/src/html/hydration-script-builder/prod-scripts.test.ts
@@ -108,6 +108,13 @@ describe("hydration-script-builder/prod-scripts", () => {
       assertEquals(result.includes(getProdHydrationModulePath()), false);
     });
 
+    it("should use an explicitly selected legacy release runtime path", () => {
+      const result = getProdScriptsForPath(PROD_HYDRATION_MODULE_PATH, "nonce-abc");
+
+      assertEquals(result.includes(`src="${PROD_HYDRATION_MODULE_PATH}"`), true);
+      assertEquals(result.includes(getProdHydrationModulePath()), false);
+    });
+
     it("should reject an invalid selected runtime path", () => {
       const error = assertThrows(
         () => getProdScriptsForPath('"><script>alert(1)</script>'),

--- a/src/html/hydration-script-builder/prod-scripts.ts
+++ b/src/html/hydration-script-builder/prod-scripts.ts
@@ -2,7 +2,7 @@ import { fnv1aHash } from "#veryfront/utils/hash-utils.ts";
 import { RENDER_ERROR } from "#veryfront/errors";
 import { buildNonceAttribute } from "../html-escape.ts";
 import { HYDRATION_RUNTIME_BUNDLE } from "./hydration-runtime.generated.ts";
-import { isVersionedProdHydrationModulePath } from "./prod-path.ts";
+import { isProdHydrationModulePath } from "./prod-path.ts";
 
 export {
   isVersionedProdHydrationModulePath,
@@ -44,7 +44,7 @@ export function getProdScriptsForPath(
   hydrationModulePath: string,
   nonce?: string,
 ): string {
-  if (!isVersionedProdHydrationModulePath(hydrationModulePath)) {
+  if (!isProdHydrationModulePath(hydrationModulePath)) {
     throw RENDER_ERROR.create({ detail: "Invalid production hydration runtime path" });
   }
   const nonceAttr = buildNonceAttribute(nonce);

--- a/src/rendering/orchestrator/html.ts
+++ b/src/rendering/orchestrator/html.ts
@@ -861,6 +861,7 @@ export class HTMLGenerator {
             projectDir: this.config.projectDir,
             buildOutDir: this.config.config?.build?.outDir,
             releaseId,
+            releaseBuilderVersion: context.options?.releaseAssetManifest?.builderVersion,
           }),
       )
       : undefined;

--- a/src/server/handlers/request/prod-hydration-module.handler.test.ts
+++ b/src/server/handlers/request/prod-hydration-module.handler.test.ts
@@ -119,6 +119,19 @@ describe("server/handlers/request/prod-hydration-module.handler", () => {
     assertEquals(result.response?.headers.get("expires"), "0");
   });
 
+  it("defers an immutable release's legacy runtime to its static artifact", async () => {
+    const registry = new RouteRegistry()
+      .register(new ProdHydrationModuleHandler())
+      .register(makeStaticHandler("export const releaseRuntime = true;"));
+    const response = await registry.execute(
+      new Request(`http://localhost${PROD_HYDRATION_MODULE_PATH}`),
+      makeCtx({ releaseId: "release-pre-versioned" }),
+    );
+
+    assertExists(response);
+    assertEquals(await response.text(), "export const releaseRuntime = true;");
+  });
+
   it("returns not modified with immutable caching when the versioned ETag matches", async () => {
     const handler = new ProdHydrationModuleHandler();
     const runtimePath = getProdHydrationModulePath();

--- a/src/server/handlers/request/prod-hydration-module.handler.ts
+++ b/src/server/handlers/request/prod-hydration-module.handler.ts
@@ -7,6 +7,7 @@ import {
   PROD_HYDRATION_MODULE_PATH,
   PROD_HYDRATION_MODULE_VERSIONED_PATH_PATTERN,
 } from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
+import { hasImmutableReleaseHydrationRuntime } from "#veryfront/html/hydration-script-builder/prod-runtime-selection.ts";
 import { computeStrongEtag, hasMatchingEtag } from "../utils/etag.ts";
 import { HTTP_OK, PRIORITY_HIGH_DEV } from "#veryfront/utils/constants/index.ts";
 
@@ -42,6 +43,16 @@ export class ProdHydrationModuleHandler extends BaseHandler {
 
     const pathname = new URL(req.url).pathname;
     const isVersioned = isVersionedProdHydrationModulePath(pathname);
+
+    // Legacy releases have no content-addressed runtime. Their HTML selects the
+    // release-baked legacy file, so StaticHandler must serve that file rather
+    // than this process's generated runtime.
+    if (
+      pathname === PROD_HYDRATION_MODULE_PATH &&
+      hasImmutableReleaseHydrationRuntime(ctx.releaseId)
+    ) {
+      return this.continue();
+    }
 
     // Serve only the current content address dynamically. Non-current hashes
     // may name valid release-baked assets, so StaticHandler owns their lookup

--- a/src/server/services/static/static-file.service.test.ts
+++ b/src/server/services/static/static-file.service.test.ts
@@ -211,6 +211,29 @@ describe("server/services/static/static-file.service", () => {
       }
     });
 
+    it("revalidates a legacy hydration runtime from an immutable release", async () => {
+      __injectDepsForTests({
+        manifestCache: new Map(),
+        manifestLoading: new Map(),
+      });
+
+      const files = new Map<string, Uint8Array>([
+        [
+          "/project/dist/_veryfront/hydration-runtime.js",
+          new TextEncoder().encode("export const releaseRuntime = true;"),
+        ],
+      ]);
+      const service = new StaticFileService(createMockFsRepo(files));
+
+      const result = await service.resolveFile(
+        "/_veryfront/hydration-runtime.js",
+        makeOptions(),
+      );
+
+      assertExists(result);
+      assertEquals(result.cacheStrategy, "no-cache");
+    });
+
     it("returns medium for regular public file", async () => {
       __injectDepsForTests({
         manifestCache: new Map(),

--- a/src/server/services/static/static-file.service.ts
+++ b/src/server/services/static/static-file.service.ts
@@ -30,6 +30,7 @@ import {
   CONTENT_TYPES,
   getContentType as getContentTypeFromExt,
 } from "../../handlers/utils/content-types.ts";
+import { PROD_HYDRATION_MODULE_PATH } from "#veryfront/html/hydration-script-builder/prod-path.ts";
 
 const logger = serverLogger.component("static-file-service");
 
@@ -307,6 +308,7 @@ export class StaticFileService {
     options: StaticFileOptions,
   ): CacheStrategy {
     if (options.isPreviewMode && !options.isLocalProject) return "no-cache";
+    if (requestPath === PROD_HYDRATION_MODULE_PATH) return "no-cache";
 
     const isVeryfrontAsset = requestPath.includes("/_veryfront/") ||
       requestPath.includes("/_vf/assets/");

--- a/tests/e2e/regressions/2026-07-27-legacy-router-hydration.test.ts
+++ b/tests/e2e/regressions/2026-07-27-legacy-router-hydration.test.ts
@@ -38,6 +38,14 @@ import {
 } from "#veryfront/html/hydration-script-builder/prod-scripts.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { deleteEnv, getEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import {
+  clearReleaseAssetManifestCache,
+  getReadyManifestForRenderAsync,
+  isReleaseAssetManifestEnabled,
+  registerManifestFetcherForRelease,
+} from "#veryfront/release-assets/manifest-cache.ts";
+import { RELEASE_ASSET_MANIFEST_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
 import { PageRenderer } from "#veryfront/rendering/page-renderer.ts";
 
 const HTML = `<!doctype html>
@@ -304,6 +312,117 @@ describe(
         if (server) {
           await server.shutdown();
           await server.finished;
+        }
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("loads the serving runtime for a pre-contract release without build assets", async () => {
+      const releaseId = "release-pre-runtime-contract";
+      const projectDir = await Deno.makeTempDir({ prefix: "vf-pre-runtime-release-browser-" });
+      const previousManifestFlag = getEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG);
+      let unregisterManifest = () => {};
+      let server: ReturnType<typeof Deno.serve> | undefined;
+      let browser: Awaited<ReturnType<typeof launchChromium>> = null;
+
+      try {
+        setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+        clearReleaseAssetManifestCache();
+        unregisterManifest = registerManifestFetcherForRelease(
+          releaseId,
+          () =>
+            Promise.resolve({
+              state: "ready",
+              manifest_version: 1,
+              manifest: {
+                schemaVersion: 2,
+                projectId: "aged-release-project",
+                releaseId,
+                releaseVersion: 1,
+                manifestVersion: 1,
+                builderVersion: "0.1.1220",
+                sourceContentHash: "a".repeat(64),
+                createdAt: "2026-08-18T00:00:00.000Z",
+                assetBasePath: "/_vf/assets",
+                modules: {},
+                css: [],
+                routes: {},
+                dependencyMode: "source",
+                dependencies: {},
+              },
+            }),
+        );
+        assertEquals(isReleaseAssetManifestEnabled(), true);
+        assertEquals(
+          (await getReadyManifestForRenderAsync(releaseId))?.builderVersion,
+          "0.1.1220",
+        );
+        const pagePath = `${projectDir}/page.js`;
+        await Deno.writeTextFile(pagePath, `export default "<main>Pre-contract release</main>";`);
+
+        const adapter = { fs: createFileSystem() } as unknown as RuntimeAdapter;
+        const renderer = new PageRenderer({
+          projectDir,
+          mode: "production",
+          config: {},
+          adapter,
+          componentRegistry: {} as never,
+          compileMDX: () => Promise.reject(new Error("not used for script pages")),
+        });
+        const renderResult = await renderer.preparePageBundles(
+          { entity: { path: pagePath, frontmatter: {} } } as never,
+          "pre-contract-release",
+          undefined,
+          { releaseId },
+        );
+        const html = renderResult.scriptResult?.html;
+        if (!html) throw new Error("Expected the script page renderer to return HTML");
+
+        const servingRuntimePath = getProdHydrationModulePath();
+        assertStringIncludes(html, servingRuntimePath);
+
+        server = Deno.serve({
+          hostname: "127.0.0.1",
+          port: 0,
+          onListen() {},
+        }, (request) => {
+          const pathname = new URL(request.url).pathname;
+          if (pathname === "/") {
+            return new Response(html, {
+              headers: { "content-type": "text/html; charset=utf-8" },
+            });
+          }
+          if (pathname === servingRuntimePath) return javascript(AGED_RELEASE_HYDRATION_MODULE);
+          if (pathname.endsWith(".js")) return javascript("export default {};");
+          return new Response(null, { status: 204 });
+        });
+        browser = await launchChromium();
+        if (!browser) return;
+
+        const page = await browser.newPage();
+        const diagnostics = captureBrowserDiagnostics(page);
+        const { port } = server.addr as Deno.NetAddr;
+        const response = await page.goto(`http://127.0.0.1:${port}/`);
+
+        assertEquals(response?.status(), 200);
+        await waitForHydration(page, diagnostics);
+        assertEquals(
+          await page.evaluate(() => document.documentElement.dataset.hydrationArtifact),
+          "aged-release",
+        );
+        assertEquals(getBrowserDiagnosticMessages(diagnostics), []);
+      } finally {
+        await closeChromium(browser);
+        if (server) {
+          await server.shutdown();
+          await server.finished;
+        }
+        unregisterManifest();
+        clearReleaseAssetManifestCache();
+        if (previousManifestFlag === undefined) {
+          deleteEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG);
+        } else {
+          setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, previousManifestFlag);
         }
         await Deno.remove(projectDir, { recursive: true });
       }


### PR DESCRIPTION
## Summary

Restore compatibility for immutable releases created before hydration runtime artifacts existed.

- prefer a release-baked hashed runtime
- serve a release-baked legacy runtime through static handling
- use the serving runtime only for manifest-verified pre-contract releases with no runtime artifact
- fail closed for unknown, malformed, and contract-era missing artifacts
- emit a bounded structured warning whenever the compatibility fallback is used

## Root cause

The v0.1.1243 renderer required a release-baked hydration runtime. Existing customer releases can contain neither a hashed nor legacy runtime, so SSR failed before rendering HTML.

## Validation

- Red: a legacy-only release fixture failed against the previous selector with Release is missing its versioned hydration runtime.
- Green: focused selector, script, handler, and static-service suite, 83 steps passed.
- Green: browser regression covers a runtime-less pre-contract release, 3 steps passed.
- Formatting, touched-file lint, and diff check passed.

## Validation gaps

The local repository-wide typecheck is blocked before checking sources because templates/manifest.generated.ts is already stale on main. The original test runner also requires a non-committed Deno 2.9 compatibility shim for the existing native-brand-check bootstrap issue.