### PR TITLE
ci: stop orphaned apt-get from starving Chromium install retries

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -266,9 +266,9 @@ jobs:
         timeout-minutes: 20
         run: |
           readonly install_attempts=2
-          readonly install_timeout_minutes=8
+          readonly install_timeout_minutes=7
           readonly install_kill_grace_seconds=15
-          readonly apt_lock_attempts=24
+          readonly apt_lock_attempts=12
           readonly apt_lock_sleep_seconds=5
           readonly retry_backoff_seconds=20
           readonly apt_lock_files="/var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock /var/lib/apt/lists/lock"
@@ -378,9 +378,9 @@ jobs:
         timeout-minutes: 20
         run: |
           readonly install_attempts=2
-          readonly install_timeout_minutes=8
+          readonly install_timeout_minutes=7
           readonly install_kill_grace_seconds=15
-          readonly apt_lock_attempts=24
+          readonly apt_lock_attempts=12
           readonly apt_lock_sleep_seconds=5
           readonly retry_backoff_seconds=20
           readonly apt_lock_files="/var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock /var/lib/apt/lists/lock"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -263,18 +263,25 @@ jobs:
             echo "::warning::No Ubuntu archive apt source detected; leaving apt sources untouched"
           fi
       - name: Install Chromium
-        timeout-minutes: 15
+        timeout-minutes: 20
         run: |
           readonly install_attempts=2
-          readonly install_timeout_minutes=5
+          readonly install_timeout_minutes=8
           readonly install_kill_grace_seconds=15
-          readonly apt_lock_attempts=12
+          readonly apt_lock_attempts=24
           readonly apt_lock_sleep_seconds=5
           readonly retry_backoff_seconds=20
+          readonly apt_lock_files="/var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock /var/lib/apt/lists/lock"
+
+          # Playwright shells out to apt-get itself, so a lock held by the
+          # runner image's own apt activity used to surface inside the install
+          # as an instant "Could not get lock" failure. A global lock timeout
+          # makes every apt invocation wait for the holder instead.
+          echo 'DPkg::Lock::Timeout "300";' | sudo tee /etc/apt/apt.conf.d/99vf-lock-timeout >/dev/null
 
           wait_for_apt_locks() {
             for _ in $(seq 1 "${apt_lock_attempts}"); do
-              if ! sudo fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock >/dev/null 2>&1; then
+              if ! sudo fuser ${apt_lock_files} >/dev/null 2>&1; then
                 return 0
               fi
               sleep "${apt_lock_sleep_seconds}"
@@ -282,10 +289,22 @@ jobs:
             return 1
           }
 
+          # `timeout` signals only the wrapper process, so a timed-out attempt
+          # orphans the sudo apt-get underneath it. That orphan keeps holding
+          # the dpkg locks and starved every later attempt on this VM. Reap
+          # the lock holders and repair any half-configured packages before
+          # trying again.
+          reap_apt_lock_holders() {
+            sudo fuser -k -TERM ${apt_lock_files} >/dev/null 2>&1 || true
+            sleep 5
+            sudo fuser -k -KILL ${apt_lock_files} >/dev/null 2>&1 || true
+            sudo dpkg --configure -a >/dev/null 2>&1 || true
+          }
+
           for attempt in $(seq 1 "${install_attempts}"); do
             if ! wait_for_apt_locks; then
-              echo "::error::Timed out waiting for apt/dpkg locks"
-              exit 1
+              echo "::warning::apt/dpkg locks still held; reaping the holders"
+              reap_apt_lock_holders
             fi
             timeout --signal=TERM --kill-after="${install_kill_grace_seconds}s" "${install_timeout_minutes}m" \
               deno run -A npm:playwright install --with-deps chromium && exit 0
@@ -295,6 +314,7 @@ jobs:
               exit "$status"
             fi
 
+            reap_apt_lock_holders
             sleep "${retry_backoff_seconds}"
           done
       - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
@@ -355,18 +375,25 @@ jobs:
             echo "::warning::No Ubuntu archive apt source detected; leaving apt sources untouched"
           fi
       - name: Install Chromium
-        timeout-minutes: 15
+        timeout-minutes: 20
         run: |
           readonly install_attempts=2
-          readonly install_timeout_minutes=5
+          readonly install_timeout_minutes=8
           readonly install_kill_grace_seconds=15
-          readonly apt_lock_attempts=12
+          readonly apt_lock_attempts=24
           readonly apt_lock_sleep_seconds=5
           readonly retry_backoff_seconds=20
+          readonly apt_lock_files="/var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock /var/lib/apt/lists/lock"
+
+          # Playwright shells out to apt-get itself, so a lock held by the
+          # runner image's own apt activity used to surface inside the install
+          # as an instant "Could not get lock" failure. A global lock timeout
+          # makes every apt invocation wait for the holder instead.
+          echo 'DPkg::Lock::Timeout "300";' | sudo tee /etc/apt/apt.conf.d/99vf-lock-timeout >/dev/null
 
           wait_for_apt_locks() {
             for _ in $(seq 1 "${apt_lock_attempts}"); do
-              if ! sudo fuser /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock >/dev/null 2>&1; then
+              if ! sudo fuser ${apt_lock_files} >/dev/null 2>&1; then
                 return 0
               fi
               sleep "${apt_lock_sleep_seconds}"
@@ -374,10 +401,22 @@ jobs:
             return 1
           }
 
+          # `timeout` signals only the wrapper process, so a timed-out attempt
+          # orphans the sudo apt-get underneath it. That orphan keeps holding
+          # the dpkg locks and starved every later attempt on this VM. Reap
+          # the lock holders and repair any half-configured packages before
+          # trying again.
+          reap_apt_lock_holders() {
+            sudo fuser -k -TERM ${apt_lock_files} >/dev/null 2>&1 || true
+            sleep 5
+            sudo fuser -k -KILL ${apt_lock_files} >/dev/null 2>&1 || true
+            sudo dpkg --configure -a >/dev/null 2>&1 || true
+          }
+
           for attempt in $(seq 1 "${install_attempts}"); do
             if ! wait_for_apt_locks; then
-              echo "::error::Timed out waiting for apt/dpkg locks"
-              exit 1
+              echo "::warning::apt/dpkg locks still held; reaping the holders"
+              reap_apt_lock_holders
             fi
             timeout --signal=TERM --kill-after="${install_kill_grace_seconds}s" "${install_timeout_minutes}m" \
               deno run -A npm:playwright install --with-deps chromium && exit 0
@@ -387,6 +426,7 @@ jobs:
               exit "$status"
             fi
 
+            reap_apt_lock_holders
             sleep "${retry_backoff_seconds}"
           done
       - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0

--- a/scripts/ci/setup-deno-workflow.test.ts
+++ b/scripts/ci/setup-deno-workflow.test.ts
@@ -18,7 +18,7 @@ const CACHE_SAVE_ACTION =
 const MAX_SETUP_MINUTES = 5;
 const MAX_CACHE_SETUP_MINUTES = 10;
 const CACHE_PRODUCER_JOB = "tests";
-const CHROMIUM_STEP_MINUTES = 15;
+const CHROMIUM_STEP_MINUTES = 20;
 const CHROMIUM_OVERHEAD_MARGIN_SECONDS = 120;
 /**
  * How long an upstream outage on the two REQUIRED Deno downloads must be


### PR DESCRIPTION
## Problem

The `tests (binary e2e)` and `tests (rsc browser e2e)` jobs failed three times today on **Install Chromium**, in two related shapes:

1. Playwright's internal `apt-get` hit a lock held by the runner image's own apt activity and failed instantly with `Could not get lock /var/lib/apt/lists/lock. It is held by process NNNN (apt-get)` — the existing `wait_for_apt_locks` guard only covers the moment before the install starts, not the apt calls inside it. (Seen on #3846's and #3843's runs.)
2. On a slow-mirror day (azure.archive.ubuntu.com was degraded today, ~60s per package retry), the 5-minute `timeout` killed the playwright wrapper but **not the `sudo apt-get` under it**. The orphan kept holding the dpkg locks, so the retry died with `Timed out waiting for apt/dpkg locks` — twice in a row on the same run, including a `--failed` rerun (https://github.com/veryfront/veryfront-code/actions/runs/32169657173, attempts 1 and 2).

## Fix (applied identically to both jobs)

- A global `DPkg::Lock::Timeout "300"` in `apt.conf.d`, so every apt invocation — including the ones playwright spawns — waits for a lock holder instead of failing instantly. This is the only way to protect apt calls we don't invoke ourselves.
- A `reap_apt_lock_holders` step between attempts: `fuser -k` (TERM then KILL) on the lock files plus `dpkg --configure -a`, so an orphaned apt-get from a timed-out attempt cannot starve the retry. The pre-install lock wait now reaps instead of giving up.
- Headroom for degraded mirrors: 7-minute install attempts inside a 20-minute step budget (previously 5 in 15), and `/var/lib/apt/lists/lock` joins the guarded set since that is the lock failure mode 1 actually reported.

## Verification

- `yaml.safe_load` parses the workflow.
- Both step occurrences updated identically (diff is textually the same block twice).
- The failure archaeology above is from today's job logs; the fix addresses both observed messages directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability of automated browser testing by allowing more time for Chromium setup.
  * Added automatic recovery for package-manager locks and interrupted package configuration, reducing failures caused by stalled environment setup.
  * Enhanced retry handling so setup issues can be resolved automatically before a job fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
