### PR TITLE
fix(proxy): register a SchemaValidator so routing invalidation stops 401ing

### DIFF
--- a/cli/commands/serve/_routing-invalidation-bootstrap-fixture.ts
+++ b/cli/commands/serve/_routing-invalidation-bootstrap-fixture.ts
@@ -1,0 +1,120 @@
+/**
+ * Clean-process fixture for the dedicated proxy binary's routing-invalidation
+ * ingress.
+ *
+ * The unit suites register a SchemaValidator through
+ * `deno test --preload=src/testing/preload.ts`, which no proxy process ever
+ * does. This fixture therefore runs as its own `deno run` process, with no
+ * preload and no `#veryfront/schemas/_test-setup.ts` import, so it observes the
+ * contract registry exactly as a proxy pod does: whatever the proxy bootstrap
+ * registers, and nothing else.
+ *
+ * It reproduces the production sequence — bootstrap the standalone proxy
+ * runtime, then serve a signed deployment invalidation — and prints
+ * `__RESULT__<json>` on stdout so the owning test can assert the status.
+ *
+ * @module commands/serve/_routing-invalidation-bootstrap-fixture
+ */
+
+import {
+  handleProxyRoutingInvalidationRequest,
+  PROXY_ROUTING_INVALIDATION_PATH,
+  PROXY_ROUTING_INVALIDATION_PLATFORM,
+  PROXY_ROUTING_INVALIDATION_SUBJECT,
+} from "#veryfront/proxy/routing-invalidation.ts";
+import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+import { tryResolve } from "veryfront/extensions/contracts";
+import { runStandaloneProxyRuntime } from "./proxy-runtime.ts";
+
+/** Marker prefix for the single machine-readable stdout line. */
+const ROUTING_INVALIDATION_FIXTURE_RESULT_PREFIX = "__RESULT__";
+
+const encoder = new TextEncoder();
+
+const BODY = JSON.stringify({
+  version: 1,
+  projectId: "proj-1",
+  projectSlug: "demo-project",
+  deploymentId: "deployment-1",
+  environmentId: "environment-1",
+  environmentName: "production",
+  releaseId: "release-1",
+});
+
+function encodePem(label: string, der: ArrayBuffer): string {
+  const base64 = btoa(String.fromCharCode(...new Uint8Array(der)));
+  const lines = base64.match(/.{1,64}/g) ?? [base64];
+  return `-----BEGIN ${label}-----\n${lines.join("\n")}\n-----END ${label}-----`;
+}
+
+async function signBody(
+  body: string,
+): Promise<{ jws: string; publicKeyPem: string }> {
+  const keyPair = await crypto.subtle.generateKey(
+    "Ed25519",
+    true,
+    ["sign", "verify"],
+  ) as CryptoKeyPair;
+  const publicKeyPem = encodePem(
+    "PUBLIC KEY",
+    await crypto.subtle.exportKey("spki", keyPair.publicKey),
+  );
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(body));
+  const now = Math.floor(Date.now() / 1000);
+  const encodedHeader = base64urlEncode(JSON.stringify({ alg: "EdDSA", typ: "JWT" }));
+  const encodedPayload = base64urlEncode(JSON.stringify({
+    iss: "veryfront-api",
+    aud: "demo-project",
+    sub: PROXY_ROUTING_INVALIDATION_SUBJECT,
+    project_id: "proj-1",
+    platform: PROXY_ROUTING_INVALIDATION_PLATFORM,
+    body_sha256: base64urlEncodeBytes(new Uint8Array(digest)),
+    iat: now,
+    exp: now + 60,
+  }));
+  const signature = await crypto.subtle.sign(
+    "Ed25519",
+    keyPair.privateKey,
+    encoder.encode(`${encodedHeader}.${encodedPayload}`),
+  );
+  return {
+    publicKeyPem,
+    jws: `${encodedHeader}.${encodedPayload}.${base64urlEncodeBytes(new Uint8Array(signature))}`,
+  };
+}
+
+await runStandaloneProxyRuntime({}, {
+  activateExtensions: () => Promise.resolve(null),
+  registerTeardown: () => Promise.resolve(() => Promise.resolve()),
+  // The real entrypoint imports `veryfront/proxy/main`, which binds a socket.
+  // Only the bootstrap that precedes it is under test here.
+  loadProxy: () => Promise.resolve(),
+  keepAlive: () => Promise.resolve(),
+});
+
+const schemaValidatorRegistered = tryResolve("SchemaValidator") !== undefined;
+const { jws, publicKeyPem } = await signBody(BODY);
+const response = await handleProxyRoutingInvalidationRequest(
+  new Request(`http://proxy.test${PROXY_ROUTING_INVALIDATION_PATH}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-veryfront-dispatch-jws": jws },
+    body: BODY,
+  }),
+  {
+    publicKeyPem,
+    createEventId: () => "event-1",
+    publisher: {
+      publish: () => Promise.resolve({ acknowledged: 2, converged: true, recipients: 2 }),
+    },
+  },
+);
+
+console.log(
+  `${ROUTING_INVALIDATION_FIXTURE_RESULT_PREFIX}${
+    JSON.stringify({
+      schemaValidatorRegistered,
+      status: response.status,
+      body: await response.json(),
+    })
+  }`,
+);

--- a/cli/commands/serve/proxy-runtime-schema-contracts.test.ts
+++ b/cli/commands/serve/proxy-runtime-schema-contracts.test.ts
@@ -1,0 +1,75 @@
+// Deliberately does NOT import `#veryfront/schemas/_test-setup.ts`. That import
+// (and the identical `deno test --preload=src/testing/preload.ts`) is what hid
+// this bug: it registers a SchemaValidator that no proxy process ever
+// registers, so every in-process suite verified dispatch signatures against a
+// registry the proxy does not have. The clean-process case below is therefore
+// a child `deno run` that inherits neither.
+
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { register, tryResolve, unregister } from "veryfront/extensions/contracts";
+import { runStandaloneProxyRuntime } from "./proxy-runtime.ts";
+
+// Kept in sync by hand with the fixture's own constant. The fixture is never
+// imported here: its module body *is* the scenario, so importing it would run
+// the proxy bootstrap inside the test process and defeat the whole point.
+const FIXTURE_RESULT_PREFIX = "__RESULT__";
+
+const FIXTURE_URL = new URL(
+  "./_routing-invalidation-bootstrap-fixture.ts",
+  import.meta.url,
+);
+const REPOSITORY_ROOT_URL = new URL("../../../", import.meta.url);
+
+function readFixtureResult(stdout: string): Record<string, unknown> {
+  const line = stdout.split("\n").find((entry) => entry.startsWith(FIXTURE_RESULT_PREFIX));
+  if (line === undefined) {
+    throw new Error(`Fixture produced no result line:\n${stdout}`);
+  }
+  return JSON.parse(line.slice(FIXTURE_RESULT_PREFIX.length)) as Record<string, unknown>;
+}
+
+describe("standalone proxy runtime schema contracts", () => {
+  it("registers a SchemaValidator before the proxy runtime is imported", async () => {
+    // Dispatch-signature verification parses its claims through a
+    // SchemaValidator-backed schema. Without one the proxy cannot verify any
+    // control-plane signature, so the contract must be satisfied by the time
+    // the proxy runtime — and its request router — exists.
+    const previous = tryResolve<unknown>("SchemaValidator");
+    unregister("SchemaValidator");
+    let registeredAtProxyLoad: unknown;
+    try {
+      await runStandaloneProxyRuntime({}, {
+        activateExtensions: () => Promise.resolve(null),
+        registerTeardown: () => Promise.resolve(() => Promise.resolve()),
+        loadProxy: () => {
+          registeredAtProxyLoad = tryResolve<unknown>("SchemaValidator");
+          return Promise.resolve();
+        },
+        keepAlive: () => Promise.resolve(),
+      });
+    } finally {
+      if (previous !== undefined) register("SchemaValidator", previous);
+    }
+
+    assertEquals(registeredAtProxyLoad !== undefined, true);
+  });
+
+  it("accepts a signed deployment routing invalidation in a clean proxy process", async () => {
+    const command = new Deno.Command(Deno.execPath(), {
+      args: ["run", "--no-check", "--allow-all", FIXTURE_URL.href],
+      cwd: REPOSITORY_ROOT_URL,
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const output = await command.output();
+    const stdout = new TextDecoder().decode(output.stdout);
+    const stderr = new TextDecoder().decode(output.stderr);
+    assertEquals(output.success, true, stderr);
+
+    const result = readFixtureResult(stdout);
+    assertEquals(result.status, 200, JSON.stringify(result));
+    assertEquals(result.body, { acknowledged: 2, converged: true, recipients: 2 });
+    assertEquals(result.schemaValidatorRegistered, true);
+  });
+});

--- a/cli/commands/serve/proxy-runtime-schema-contracts.test.ts
+++ b/cli/commands/serve/proxy-runtime-schema-contracts.test.ts
@@ -16,7 +16,7 @@ import { runStandaloneProxyRuntime } from "./proxy-runtime.ts";
 const FIXTURE_RESULT_PREFIX = "__RESULT__";
 
 const FIXTURE_URL = new URL(
-  "./_routing-invalidation-bootstrap-fixture.ts",
+  "../../../tests/proxy/routing-invalidation-bootstrap-fixture.ts",
   import.meta.url,
 );
 const REPOSITORY_ROOT_URL = new URL("../../../", import.meta.url);

--- a/cli/commands/serve/proxy-runtime.ts
+++ b/cli/commands/serve/proxy-runtime.ts
@@ -1,6 +1,7 @@
 import { getEnv, setEnv } from "veryfront/platform/env";
 import { cliLogger } from "veryfront/utils/logger";
 import denoConfig from "../../../deno.json" with { type: "json" };
+import { ensureCliSchemaValidator } from "../../shared/default-contracts.ts";
 import { isJsonMode } from "../../shared/json-output.ts";
 import { bold, brand, dim } from "../../ui/colors.ts";
 import {
@@ -50,6 +51,15 @@ export async function runStandaloneProxyRuntime(
   const bindAddress = getEnv("HOST") || "0.0.0.0";
   showProxyHeader();
   cliLogger.info(`Starting proxy server on ${bindAddress}:${port}`);
+
+  // The proxy verifies control-plane dispatch signatures (deployment routing
+  // invalidation among them), and claim parsing goes through a
+  // SchemaValidator-backed schema. Nothing else on this path registers one:
+  // `activateStandaloneProxyExtensions` only composes the infrastructure
+  // providers selected by CACHE_TYPE/REDIS_URL. Without this the proxy answers
+  // every signed request 401 before any signature is checked, so it must run
+  // before the runtime that serves those requests is imported.
+  await ensureCliSchemaValidator();
 
   const activateExtensions = dependencies.activateExtensions ??
     activateStandaloneProxyExtensions;

--- a/cli/proxy-main.ts
+++ b/cli/proxy-main.ts
@@ -6,11 +6,15 @@ import { runStandaloneProxyRuntime } from "./commands/serve/proxy-runtime.ts";
 // Keep the proxy's runtime-selected providers in the compile graph. Using
 // `deno compile --include` for these modules embeds the workspace file tree;
 // static references embed only each provider and its real dependencies.
+// ext-schema-zod is loaded through the same dynamic first-party import as the
+// rest, so without its static anchor `ensureCliSchemaValidator` resolves in
+// source checkouts and fails inside the compiled binary.
 import "../extensions/ext-auth-jwt/src/index.ts";
 import "../extensions/ext-cache-redis/src/index.ts";
 import "../extensions/ext-observability-opentelemetry/src/index.ts";
 import "../extensions/ext-observability-sentry/src/index.ts";
 import "../extensions/ext-redis/src/index.ts";
+import "../extensions/ext-schema-zod/src/index.ts";
 
 setLoggerPreset("cli");
 

--- a/docs/api-reference/veryfront/extensions.md
+++ b/docs/api-reference/veryfront/extensions.md
@@ -623,15 +623,15 @@ import {
 | ------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | `hasProjectIdentityControlCharacters` | Whether a string contains a Unicode Cc control code point. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/utils/project-identity.ts#L38)      |
 | `isCanonicalOpaqueProjectIdentifier`  | Whether a value is a bounded, exact opaque identifier.     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/utils/project-identity.ts#L54)      |
-| `parseProxyRoutingInvalidationEvent`  |                                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/proxy/routing-invalidation.ts#L234) |
+| `parseProxyRoutingInvalidationEvent`  |                                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/proxy/routing-invalidation.ts#L328) |
 
 #### Types
 
 | Name                                    | Description | Source                                                                                                |
 | --------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------- |
-| `ProxyRoutingInvalidationEvent`         |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/proxy/routing-invalidation.ts#L31) |
-| `ProxyRoutingInvalidationPublisher`     |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/proxy/routing-invalidation.ts#L41) |
-| `ProxyRoutingInvalidationPublishResult` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/proxy/routing-invalidation.ts#L35) |
+| `ProxyRoutingInvalidationEvent`         |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/proxy/routing-invalidation.ts#L36) |
+| `ProxyRoutingInvalidationPublisher`     |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/proxy/routing-invalidation.ts#L46) |
+| `ProxyRoutingInvalidationPublishResult` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/proxy/routing-invalidation.ts#L40) |
 
 ### `veryfront/extensions/eval`
 

--- a/docs/api-reference/veryfront/extensions.md
+++ b/docs/api-reference/veryfront/extensions.md
@@ -623,15 +623,15 @@ import {
 | ------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | `hasProjectIdentityControlCharacters` | Whether a string contains a Unicode Cc control code point. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/utils/project-identity.ts#L38)      |
 | `isCanonicalOpaqueProjectIdentifier`  | Whether a value is a bounded, exact opaque identifier.     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/utils/project-identity.ts#L54)      |
-| `parseProxyRoutingInvalidationEvent`  |                                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/proxy/routing-invalidation.ts#L175) |
+| `parseProxyRoutingInvalidationEvent`  |                                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/proxy/routing-invalidation.ts#L234) |
 
 #### Types
 
 | Name                                    | Description | Source                                                                                                |
 | --------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------- |
-| `ProxyRoutingInvalidationEvent`         |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/proxy/routing-invalidation.ts#L30) |
-| `ProxyRoutingInvalidationPublisher`     |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/proxy/routing-invalidation.ts#L40) |
-| `ProxyRoutingInvalidationPublishResult` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/proxy/routing-invalidation.ts#L34) |
+| `ProxyRoutingInvalidationEvent`         |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/proxy/routing-invalidation.ts#L31) |
+| `ProxyRoutingInvalidationPublisher`     |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/proxy/routing-invalidation.ts#L41) |
+| `ProxyRoutingInvalidationPublishResult` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/proxy/routing-invalidation.ts#L35) |
 
 ### `veryfront/extensions/eval`
 

--- a/scripts/build/compile-binary.test.ts
+++ b/scripts/build/compile-binary.test.ts
@@ -226,6 +226,10 @@ it("proxy binary embeds only the runtime-resolved proxy entrypoint", async () =>
       "ext-redis",
       "ext-observability-opentelemetry",
       "ext-observability-sentry",
+      // Anchors the SchemaValidator the proxy needs to verify control-plane
+      // dispatch signatures. It is reached only through a dynamic first-party
+      // import, which `deno compile` cannot trace.
+      "ext-schema-zod",
     ]
   ) {
     const extensionImportIndex = entrypoint.indexOf(

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -738,6 +738,7 @@ async function router(req: Request): Promise<Response> {
       response = await handleWebSocketUpgrade(req, url);
     } else if (url.pathname === PROXY_ROUTING_INVALIDATION_PATH) {
       response = await handleProxyRoutingInvalidationRequest(req, {
+        logger: proxyLogger,
         publisher: routingInvalidationBus,
       });
     } else if (url.pathname === "/_proxy/stats") {

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -91,6 +91,7 @@ import {
   ProxyRequestDrainTracker,
 } from "./request-drain.ts";
 import {
+  createProxyRoutingInvalidationRejectionThrottle,
   handleProxyRoutingInvalidationRequest,
   PROXY_ROUTING_INVALIDATION_PATH,
 } from "./routing-invalidation.ts";
@@ -252,6 +253,12 @@ if (isProduction() && !routingInvalidationBus) {
     "Proxy routing invalidation bus requires REDIS_URL and a valid VERYFRONT_PROXY_ROUTING_INVALIDATION_SECRET in production",
   );
 }
+
+// The invalidation endpoint answers on the same public listener as ordinary
+// traffic and has no source-IP guard, so anyone can drive its rejection path.
+// Coalescing keeps a flood from becoming an equal flood of proxy log writes;
+// the first rejection of each class still warns immediately.
+const routingInvalidationRejectionThrottle = createProxyRoutingInvalidationRejectionThrottle();
 
 // Validate configuration on startup
 const missingCredentials = proxyHandler.validateConfig();
@@ -740,6 +747,7 @@ async function router(req: Request): Promise<Response> {
       response = await handleProxyRoutingInvalidationRequest(req, {
         logger: proxyLogger,
         publisher: routingInvalidationBus,
+        rejectionThrottle: routingInvalidationRejectionThrottle,
       });
     } else if (url.pathname === "/_proxy/stats") {
       response = Object.keys(proxyHandler.localProjects).length === 0

--- a/src/proxy/routing-invalidation.test.ts
+++ b/src/proxy/routing-invalidation.test.ts
@@ -1,9 +1,9 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { register, tryResolve, unregister } from "#veryfront/extensions/contracts.ts";
 import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
 import {
+  createProxyRoutingInvalidationRejectionThrottle,
   handleProxyRoutingInvalidationRequest,
   PROXY_ROUTING_INVALIDATION_PATH,
   type ProxyRoutingInvalidationEvent,
@@ -269,12 +269,60 @@ describe("proxy routing invalidation ingress", () => {
     const [warning] = warnings;
     assertEquals(typeof warning?.extra?.reason, "string");
     assertStringIncludes(String(warning?.extra?.reason), "signature verification failed");
-    assertEquals(warning?.extra?.projectId, "proj-1");
-    assertEquals(warning?.extra?.projectSlug, "demo-project");
     // The rejected credential must never reach the log.
     const serialized = JSON.stringify(warnings);
     assertEquals(serialized.includes(tampered), false);
     assertEquals(serialized.includes(tampered.split(".")[2] ?? ""), false);
+  });
+
+  it("keeps caller-supplied identifiers out of a rejected invalidation warning", async () => {
+    // Nothing in the body is trustworthy on this path: verification has already
+    // failed, so every identifier is attacker-chosen. Logging them lets an
+    // unauthenticated caller pin a forged rejection on someone else's project
+    // and turns each request into ~4.5KB of caller-controlled log volume, which
+    // AGENTS.md ("Secret and internal-detail safety") forbids. The reason is
+    // minted by our own verification code, so it stays.
+    const body = createBody();
+    const { jws, publicKeyPem } = await createDispatchSignature(body);
+    const tampered = jws.slice(0, -4) + (jws.endsWith("AAAA") ? "BBBB" : "AAAA");
+    const warnings: Array<{ message: string; extra?: Record<string, unknown> }> = [];
+    const response = await handleProxyRoutingInvalidationRequest(
+      new Request(`http://proxy.test${PROXY_ROUTING_INVALIDATION_PATH}`, {
+        method: "POST",
+        headers: { "x-veryfront-dispatch-jws": tampered },
+        body,
+      }),
+      {
+        publicKeyPem,
+        logger: {
+          warn: (message, extra) => warnings.push({ message, extra }),
+        },
+        publisher: {
+          publish: () => Promise.resolve({ acknowledged: 1, converged: true, recipients: 1 }),
+        },
+      },
+    );
+
+    assertEquals(response.status, 401);
+    assertEquals(warnings.length, 1);
+    assertStringIncludes(String(warnings[0]?.extra?.reason), "signature verification failed");
+    const serialized = JSON.stringify(warnings);
+    for (
+      const identifier of [
+        "proj-1",
+        "demo-project",
+        "deployment-1",
+        "environment-1",
+        "production",
+        "release-1",
+      ]
+    ) {
+      assertEquals(
+        serialized.includes(identifier),
+        false,
+        `rejection warning leaked the caller-supplied identifier ${identifier}`,
+      );
+    }
   });
 
   it("logs the missing-signature rejection without inventing a verification reason", async () => {
@@ -299,6 +347,49 @@ describe("proxy routing invalidation ingress", () => {
     assertEquals(response.status, 401);
     assertEquals(warnings.length, 1);
     assertStringIncludes(String(warnings[0]?.extra?.reason), "missing");
+  });
+
+  it("coalesces repeated rejections of one class into a counted warning", async () => {
+    // Unauthenticated callers reach this path, so one log write per request is
+    // an amplification lever. The first rejection must still warn immediately —
+    // suppressing it would rebuild the silence that hid this bug for a month.
+    const body = createBody();
+    const warnings: Array<{ message: string; extra?: Record<string, unknown> }> = [];
+    let clockMs = 0;
+    const rejectionThrottle = createProxyRoutingInvalidationRejectionThrottle({
+      nowMs: () => clockMs,
+      windowMs: 60_000,
+    });
+    const reject = (): Promise<Response> =>
+      handleProxyRoutingInvalidationRequest(
+        new Request(`http://proxy.test${PROXY_ROUTING_INVALIDATION_PATH}`, {
+          method: "POST",
+          body,
+        }),
+        {
+          publicKeyPem: "configured",
+          logger: {
+            warn: (message, extra) => warnings.push({ message, extra }),
+          },
+          publisher: {
+            publish: () => Promise.resolve({ acknowledged: 1, converged: true, recipients: 1 }),
+          },
+          rejectionThrottle,
+        },
+      );
+
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      assertEquals((await reject()).status, 401);
+      clockMs += 1_000;
+    }
+    assertEquals(warnings.length, 1);
+    assertEquals(warnings[0]?.extra?.coalescedSincePreviousWarning, undefined);
+
+    clockMs += 60_000;
+    assertEquals((await reject()).status, 401);
+    assertEquals(warnings.length, 2);
+    assertEquals(warnings[1]?.extra?.coalescedSincePreviousWarning, 4);
+    assertStringIncludes(String(warnings[1]?.extra?.reason), "missing");
   });
 
   // Deliberately no in-process "missing SchemaValidator" test. One was written

--- a/src/proxy/routing-invalidation.test.ts
+++ b/src/proxy/routing-invalidation.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { register, tryResolve, unregister } from "#veryfront/extensions/contracts.ts";
 import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
 import {
   handleProxyRoutingInvalidationRequest,
@@ -237,5 +238,102 @@ describe("proxy routing invalidation ingress", () => {
     assertEquals(response.status, 413);
     assertEquals(cancelled, true);
     assertEquals(pulls < 10, true);
+  });
+  it("logs why a routing invalidation signature was rejected", async () => {
+    // A silent 401 is why this path stayed inert in production for a month:
+    // the proxy answered every invalidation with 401 and logged nothing, so
+    // neither the sender nor the pod logs named a cause.
+    const body = createBody();
+    const { jws, publicKeyPem } = await createDispatchSignature(body);
+    const tampered = jws.slice(0, -4) + (jws.endsWith("AAAA") ? "BBBB" : "AAAA");
+    const warnings: Array<{ message: string; extra?: Record<string, unknown> }> = [];
+    const response = await handleProxyRoutingInvalidationRequest(
+      new Request(`http://proxy.test${PROXY_ROUTING_INVALIDATION_PATH}`, {
+        method: "POST",
+        headers: { "x-veryfront-dispatch-jws": tampered },
+        body,
+      }),
+      {
+        publicKeyPem,
+        logger: {
+          warn: (message, extra) => warnings.push({ message, extra }),
+        },
+        publisher: {
+          publish: () => Promise.resolve({ acknowledged: 1, converged: true, recipients: 1 }),
+        },
+      },
+    );
+
+    assertEquals(response.status, 401);
+    assertEquals(warnings.length, 1);
+    const [warning] = warnings;
+    assertEquals(typeof warning?.extra?.reason, "string");
+    assertStringIncludes(String(warning?.extra?.reason), "signature verification failed");
+    assertEquals(warning?.extra?.projectId, "proj-1");
+    assertEquals(warning?.extra?.projectSlug, "demo-project");
+    // The rejected credential must never reach the log.
+    const serialized = JSON.stringify(warnings);
+    assertEquals(serialized.includes(tampered), false);
+    assertEquals(serialized.includes(tampered.split(".")[2] ?? ""), false);
+  });
+
+  it("logs the missing-signature rejection without inventing a verification reason", async () => {
+    const body = createBody();
+    const warnings: Array<{ message: string; extra?: Record<string, unknown> }> = [];
+    const response = await handleProxyRoutingInvalidationRequest(
+      new Request(`http://proxy.test${PROXY_ROUTING_INVALIDATION_PATH}`, {
+        method: "POST",
+        body,
+      }),
+      {
+        publicKeyPem: "configured",
+        logger: {
+          warn: (message, extra) => warnings.push({ message, extra }),
+        },
+        publisher: {
+          publish: () => Promise.resolve({ acknowledged: 1, converged: true, recipients: 1 }),
+        },
+      },
+    );
+
+    assertEquals(response.status, 401);
+    assertEquals(warnings.length, 1);
+    assertStringIncludes(String(warnings[0]?.extra?.reason), "missing");
+  });
+
+  it("reports a missing SchemaValidator as the reason a signature could not be checked", async () => {
+    // The production failure mode: the dedicated proxy binary never registered
+    // a SchemaValidator, so claim parsing threw before any signature check and
+    // the bare `catch` turned it into an unexplained 401.
+    const body = createBody();
+    const { jws } = await createDispatchSignature(body);
+    const warnings: Array<{ message: string; extra?: Record<string, unknown> }> = [];
+    const previous = tryResolve<unknown>("SchemaValidator");
+    unregister("SchemaValidator");
+    let response: Response;
+    try {
+      response = await handleProxyRoutingInvalidationRequest(
+        new Request(`http://proxy.test${PROXY_ROUTING_INVALIDATION_PATH}`, {
+          method: "POST",
+          headers: { "x-veryfront-dispatch-jws": jws },
+          body,
+        }),
+        {
+          publicKeyPem: "configured",
+          logger: {
+            warn: (message, extra) => warnings.push({ message, extra }),
+          },
+          publisher: {
+            publish: () => Promise.resolve({ acknowledged: 1, converged: true, recipients: 1 }),
+          },
+        },
+      );
+    } finally {
+      if (previous !== undefined) register("SchemaValidator", previous);
+    }
+
+    assertEquals(response.status, 401);
+    assertEquals(warnings.length, 1);
+    assertEquals(typeof warnings[0]?.extra?.reason, "string");
   });
 });

--- a/src/proxy/routing-invalidation.test.ts
+++ b/src/proxy/routing-invalidation.test.ts
@@ -301,39 +301,12 @@ describe("proxy routing invalidation ingress", () => {
     assertStringIncludes(String(warnings[0]?.extra?.reason), "missing");
   });
 
-  it("reports a missing SchemaValidator as the reason a signature could not be checked", async () => {
-    // The production failure mode: the dedicated proxy binary never registered
-    // a SchemaValidator, so claim parsing threw before any signature check and
-    // the bare `catch` turned it into an unexplained 401.
-    const body = createBody();
-    const { jws } = await createDispatchSignature(body);
-    const warnings: Array<{ message: string; extra?: Record<string, unknown> }> = [];
-    const previous = tryResolve<unknown>("SchemaValidator");
-    unregister("SchemaValidator");
-    let response: Response;
-    try {
-      response = await handleProxyRoutingInvalidationRequest(
-        new Request(`http://proxy.test${PROXY_ROUTING_INVALIDATION_PATH}`, {
-          method: "POST",
-          headers: { "x-veryfront-dispatch-jws": jws },
-          body,
-        }),
-        {
-          publicKeyPem: "configured",
-          logger: {
-            warn: (message, extra) => warnings.push({ message, extra }),
-          },
-          publisher: {
-            publish: () => Promise.resolve({ acknowledged: 1, converged: true, recipients: 1 }),
-          },
-        },
-      );
-    } finally {
-      if (previous !== undefined) register("SchemaValidator", previous);
-    }
-
-    assertEquals(response.status, 401);
-    assertEquals(warnings.length, 1);
-    assertEquals(typeof warnings[0]?.extra?.reason, "string");
-  });
+  // Deliberately no in-process "missing SchemaValidator" test. One was written
+  // and removed: `lazySchema` memoises a materialized schema permanently, so an
+  // in-process `unregister("SchemaValidator")` is a no-op once any earlier test
+  // in this file has parsed a JWS — and an invalid `publicKeyPem` makes WebCrypto
+  // throw "Invalid key data" first regardless. It asserted only that some reason
+  // string existed, which every rejection path satisfies, so it would have passed
+  // with the fix deleted. The production failure mode needs a clean process and is
+  // covered by cli/commands/serve/proxy-runtime-schema-contracts.test.ts.
 });

--- a/src/proxy/routing-invalidation.ts
+++ b/src/proxy/routing-invalidation.ts
@@ -16,6 +16,7 @@ const MAX_SIGNATURE_AGE_SECONDS = 60;
 const MAX_REQUEST_BODY_BYTES = 16 * 1024;
 const DEFAULT_REQUEST_BODY_TIMEOUT_MS = 5_000;
 const MAX_REQUEST_BODY_TIMEOUT_MS = 60_000;
+const MAX_LOGGED_REJECTION_REASON_CODE_UNITS = 200;
 
 export interface ProxyRoutingInvalidationRequest {
   readonly version: 1;
@@ -43,11 +44,69 @@ export interface ProxyRoutingInvalidationPublisher {
   ): Promise<ProxyRoutingInvalidationPublishResult>;
 }
 
+/**
+ * Warning sink for rejected invalidations.
+ *
+ * Structurally compatible with `proxyLogger`, which is what `src/proxy/main.ts`
+ * passes in.
+ */
+export interface ProxyRoutingInvalidationLogger {
+  warn(message: string, extra?: Record<string, unknown>): void;
+}
+
 interface ProxyRoutingInvalidationHandlerOptions {
   bodyReadTimeoutMs?: number;
   createEventId?: () => string;
+  logger?: ProxyRoutingInvalidationLogger;
   publicKeyPem?: string;
   publisher: ProxyRoutingInvalidationPublisher | null;
+}
+
+/**
+ * Describe why a dispatch signature was refused, without ever echoing the
+ * credential.
+ *
+ * Every message this can surface is minted by our own verification code
+ * ("Control-plane audience mismatch", "Control-plane signature expired",
+ * `Missing extension for contract "SchemaValidator"`, …) and names the check
+ * that failed rather than the material that failed it. The bound keeps a
+ * third-party error message from turning a proxy log line into an unbounded
+ * write.
+ */
+function describeSignatureRejection(error: unknown): string {
+  const message = error instanceof Error && typeof error.message === "string"
+    ? error.message
+    : "Unrecognized routing invalidation signature failure";
+  return message.length > MAX_LOGGED_REJECTION_REASON_CODE_UNITS
+    ? `${message.slice(0, MAX_LOGGED_REJECTION_REASON_CODE_UNITS)}…`
+    : message;
+}
+
+/**
+ * Report a refused invalidation.
+ *
+ * A 401 here means a deployment is still being routed to the previous release,
+ * so it has to be diagnosable from proxy logs alone: the response body is
+ * deliberately generic, and the sender only ever sees that generic body.
+ */
+function warnRejectedInvalidation(
+  logger: ProxyRoutingInvalidationLogger | undefined,
+  input: ProxyRoutingInvalidationRequest,
+  reason: string,
+): void {
+  if (!logger) return;
+  try {
+    logger.warn("Rejected proxy routing invalidation", {
+      reason,
+      projectId: input.projectId,
+      projectSlug: input.projectSlug,
+      deploymentId: input.deploymentId,
+      environmentId: input.environmentId,
+      releaseId: input.releaseId,
+    });
+  } catch {
+    // A logging sink must never upgrade a rejection into a 500.
+  }
 }
 
 function jsonResponse(status: number, body: Record<string, unknown>): Response {
@@ -267,7 +326,14 @@ export async function handleProxyRoutingInvalidationRequest(
   if (!input) return jsonResponse(400, { error: "Invalid routing invalidation request" });
 
   const jws = req.headers.get(DISPATCH_JWS_HEADER);
-  if (!jws) return jsonResponse(401, { error: "Invalid routing invalidation signature" });
+  if (!jws) {
+    warnRejectedInvalidation(
+      options.logger,
+      input,
+      `Request is missing the ${DISPATCH_JWS_HEADER} dispatch signature`,
+    );
+    return jsonResponse(401, { error: "Invalid routing invalidation signature" });
+  }
 
   try {
     await verifyDispatchJws(jws, body, {
@@ -278,7 +344,8 @@ export async function handleProxyRoutingInvalidationRequest(
       maxAgeSeconds: MAX_SIGNATURE_AGE_SECONDS,
       publicKeyPem,
     });
-  } catch {
+  } catch (error) {
+    warnRejectedInvalidation(options.logger, input, describeSignatureRejection(error));
     return jsonResponse(401, { error: "Invalid routing invalidation signature" });
   }
 

--- a/src/proxy/routing-invalidation.ts
+++ b/src/proxy/routing-invalidation.ts
@@ -17,6 +17,11 @@ const MAX_REQUEST_BODY_BYTES = 16 * 1024;
 const DEFAULT_REQUEST_BODY_TIMEOUT_MS = 5_000;
 const MAX_REQUEST_BODY_TIMEOUT_MS = 60_000;
 const MAX_LOGGED_REJECTION_REASON_CODE_UNITS = 200;
+const MAX_REJECTION_CLASS_CODE_UNITS = 64;
+const MAX_TRACKED_REJECTION_CLASSES = 32;
+const OVERFLOW_REJECTION_CLASS = "OverflowRejection";
+const REJECTION_WARNING_WINDOW_MS = 60_000;
+const MISSING_SIGNATURE_REJECTION_CLASS = "MissingDispatchSignature";
 
 export interface ProxyRoutingInvalidationRequest {
   readonly version: 1;
@@ -54,12 +59,92 @@ export interface ProxyRoutingInvalidationLogger {
   warn(message: string, extra?: Record<string, unknown>): void;
 }
 
+/**
+ * Coalescer for rejection warnings.
+ *
+ * This endpoint sits on the public listener with no source-IP guard, so an
+ * unauthenticated caller can drive one log write per request. Without this,
+ * every rejection is a separate line in the log pipeline.
+ */
+export interface ProxyRoutingInvalidationRejectionThrottle {
+  /**
+   * Open a warning window for `rejectionClass`, or coalesce into the window
+   * that is already open.
+   *
+   * Returns the number of warnings coalesced away since the previous emission,
+   * or `null` when this rejection should stay silent.
+   */
+  admit(rejectionClass: string): number | null;
+}
+
 interface ProxyRoutingInvalidationHandlerOptions {
   bodyReadTimeoutMs?: number;
   createEventId?: () => string;
   logger?: ProxyRoutingInvalidationLogger;
   publicKeyPem?: string;
   publisher: ProxyRoutingInvalidationPublisher | null;
+  /**
+   * Omit to warn on every rejection. `src/proxy/main.ts` passes one so a flood
+   * against the public listener cannot flood the log pipeline with it.
+   */
+  rejectionThrottle?: ProxyRoutingInvalidationRejectionThrottle;
+}
+
+/**
+ * Build a rejection throttle that emits at most one warning per class per
+ * window and counts the rest.
+ *
+ * The first rejection of a class always warns, so a new failure mode is never
+ * hidden — this endpoint stayed inert for a month precisely because rejections
+ * were silent, and suppressing the first occurrence would rebuild that trap.
+ * Repeats inside the window are counted and reported on the next emission.
+ *
+ * Classes are bounded and never caller-chosen (see `classifySignatureRejection`),
+ * but the tracking map is capped anyway: an unforeseen error type carrying a
+ * dynamic `name` must not turn this into a memory leak.
+ */
+export function createProxyRoutingInvalidationRejectionThrottle(
+  options: { nowMs?: () => number; windowMs?: number } = {},
+): ProxyRoutingInvalidationRejectionThrottle {
+  const nowMs = options.nowMs ?? (() => Date.now());
+  const windowMs = options.windowMs ?? REJECTION_WARNING_WINDOW_MS;
+  const openWindows = new Map<string, { openedAtMs: number; coalesced: number }>();
+  return {
+    admit(rejectionClass: string): number | null {
+      const key = openWindows.has(rejectionClass) ||
+          openWindows.size < MAX_TRACKED_REJECTION_CLASSES
+        ? rejectionClass
+        : OVERFLOW_REJECTION_CLASS;
+      const now = nowMs();
+      const open = openWindows.get(key);
+      if (open) {
+        const elapsedMs = now - open.openedAtMs;
+        // A clock that stepped backwards expires the window rather than
+        // silencing the class until the clock catches up.
+        if (elapsedMs >= 0 && elapsedMs < windowMs) {
+          open.coalesced += 1;
+          return null;
+        }
+      }
+      openWindows.set(key, { openedAtMs: now, coalesced: 0 });
+      return open?.coalesced ?? 0;
+    },
+  };
+}
+
+/**
+ * Bucket a rejection by the failing check rather than by its message.
+ *
+ * The message can carry caller-shaped fragments — a claim-schema rejection can
+ * name the properties the caller sent — so keying windows on it would let a
+ * caller mint unlimited classes and defeat the coalescing. Which error type our
+ * verification throws is ours alone.
+ */
+function classifySignatureRejection(error: unknown): string {
+  const name = error instanceof Error && typeof error.name === "string" ? error.name : "";
+  return name.length > 0 && name.length <= MAX_REJECTION_CLASS_CODE_UNITS
+    ? name
+    : "UnrecognizedRejection";
 }
 
 /**
@@ -88,21 +173,30 @@ function describeSignatureRejection(error: unknown): string {
  * A 401 here means a deployment is still being routed to the previous release,
  * so it has to be diagnosable from proxy logs alone: the response body is
  * deliberately generic, and the sender only ever sees that generic body.
+ *
+ * The warning carries the failing check and nothing else. The body reached this
+ * point unauthenticated, so its `projectId`, `projectSlug`, `deploymentId`,
+ * `environmentId` and `releaseId` are attacker-chosen: logging them would let
+ * any caller on the public listener attribute a forged rejection to someone
+ * else's project, and would write kilobytes of caller-controlled text per
+ * request into the log pipeline. Identifiers may only be logged past a
+ * successful `verifyDispatchJws`, never here. Diagnosis does not need them: the
+ * question a stuck rollout raises is *why* dispatch was refused, and the sender
+ * already holds the authenticated identifiers for the attempt it made.
  */
 function warnRejectedInvalidation(
   logger: ProxyRoutingInvalidationLogger | undefined,
-  input: ProxyRoutingInvalidationRequest,
+  throttle: ProxyRoutingInvalidationRejectionThrottle | undefined,
+  rejectionClass: string,
   reason: string,
 ): void {
   if (!logger) return;
+  const coalesced = throttle ? throttle.admit(rejectionClass) : 0;
+  if (coalesced === null) return;
   try {
     logger.warn("Rejected proxy routing invalidation", {
       reason,
-      projectId: input.projectId,
-      projectSlug: input.projectSlug,
-      deploymentId: input.deploymentId,
-      environmentId: input.environmentId,
-      releaseId: input.releaseId,
+      ...(coalesced > 0 ? { coalescedSincePreviousWarning: coalesced } : {}),
     });
   } catch {
     // A logging sink must never upgrade a rejection into a 500.
@@ -329,7 +423,8 @@ export async function handleProxyRoutingInvalidationRequest(
   if (!jws) {
     warnRejectedInvalidation(
       options.logger,
-      input,
+      options.rejectionThrottle,
+      MISSING_SIGNATURE_REJECTION_CLASS,
       `Request is missing the ${DISPATCH_JWS_HEADER} dispatch signature`,
     );
     return jsonResponse(401, { error: "Invalid routing invalidation signature" });
@@ -345,7 +440,12 @@ export async function handleProxyRoutingInvalidationRequest(
       publicKeyPem,
     });
   } catch (error) {
-    warnRejectedInvalidation(options.logger, input, describeSignatureRejection(error));
+    warnRejectedInvalidation(
+      options.logger,
+      options.rejectionThrottle,
+      classifySignatureRejection(error),
+      describeSignatureRejection(error),
+    );
     return jsonResponse(401, { error: "Invalid routing invalidation signature" });
   }
 

--- a/tests/proxy/routing-invalidation-bootstrap-fixture.ts
+++ b/tests/proxy/routing-invalidation-bootstrap-fixture.ts
@@ -22,9 +22,9 @@ import {
   PROXY_ROUTING_INVALIDATION_PLATFORM,
   PROXY_ROUTING_INVALIDATION_SUBJECT,
 } from "#veryfront/proxy/routing-invalidation.ts";
-import { base64urlEncode, base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
+import { base64urlEncode, base64urlEncodeBytes } from "veryfront/utils";
 import { tryResolve } from "veryfront/extensions/contracts";
-import { runStandaloneProxyRuntime } from "./proxy-runtime.ts";
+import { runStandaloneProxyRuntime } from "../../cli/commands/serve/proxy-runtime.ts";
 
 /** Marker prefix for the single machine-readable stdout line. */
 const ROUTING_INVALIDATION_FIXTURE_RESULT_PREFIX = "__RESULT__";


### PR DESCRIPTION
Fixes veryfront-issue-inbox#39.

## The mechanism was merged a month ago and has been inert in production ever since

Every routing-invalidation dispatch has returned **HTTP 401**. Deployment activation has silently not been invalidating shared proxy routing caches.

**Root cause.** `verifySignedRequestJws` (`src/channels/control-plane.ts`) runs `compactJwsHeaderSchema.parse(...)` and `claimsSchema.parse(...)` *before* `crypto.subtle.verify("Ed25519", ...)`. Schema materialization resolves `SchemaValidator` from the contract registry, which throws when none is registered. The dedicated proxy binary never registered one — and a bare `catch {}` in `src/proxy/routing-invalidation.ts` turned that throw into an unexplained 401.

`cli/router.ts` already called `ensureCliSchemaValidator()`, so **only the dedicated binary was broken** — which is exactly what production runs. That is why it survived a month: the proxy logged nothing at all on 401.

## The fix

1. `ensureCliSchemaValidator()` at proxy bootstrap. Verified this covers every launch path: `src/proxy/main.ts` is imported only via `runStandaloneProxyRuntime`, reached from `cli/proxy-main.ts` (the dedicated binary) and `veryfront serve --mode=proxy`. There is no third entrypoint.
2. Replace the bare `catch {}` with a warn carrying the rejection reason — signature verification failed vs audience mismatch vs expired — never the signature itself.

## Mutation proof

Reverting **only** the `ensureCliSchemaValidator()` call, keeping both tests:

```
registers a SchemaValidator before the proxy runtime is imported        FAILED
accepts a signed deployment routing invalidation in a clean proxy process FAILED
  Actual {"schemaValidatorRegistered":false,"status":401,
          "body":{"error":"Invalid routing invalidation signature"}}
```

That payload is the production symptom verbatim.

## Security boundary — not weakened

Zero lines of `src/channels/control-plane.ts` changed. Every check is byte-identical: Ed25519 verify, `iss`, `aud`, `expectedProjectId`, `expectedSubject`, the scoped `platform` claim, and exp/iat skew. The only functional additions are two log calls immediately before the same pre-existing `return jsonResponse(401, ...)` — no branch relaxed, no early return removed, no new accept path. The logger call is wrapped so a throwing sink cannot upgrade a rejection into a 500 or an accept. All six pre-existing rejection tests pass unchanged.

The bug is that verification never ran, not that it was too strict.

## Two review findings, fixed

**cli-boundary violation.** The clean-process fixture imported `#veryfront/**` from `cli/`. `lint:cli-boundary` is not part of `ci (lint)`, so this would have landed green and left `deno task verify` broken for whoever ran it next. base64url is public via `veryfront/utils`; the fixture moved to `tests/proxy/`.

**A test that could not fail.** "reports a missing SchemaValidator…" never exercised a missing SchemaValidator — `lazySchema` memoises permanently so the in-process `unregister` is a no-op, and an invalid `publicKeyPem` throws "Invalid key data" first. Its assertion passed with the fix deleted. Removed, with a comment recording why an in-process version cannot work.

## Known, not addressed here

- The failure class is "works from source, dead in the compiled binary". `compile-binary.test.ts` now asserts `ext-schema-zod` is statically reachable from the proxy entrypoint, but no lane exercises the built binary's invalidation endpoint end to end.
- `ensureCliSchemaValidator()` is unguarded at boot, so an extension-resolution failure now aborts proxy startup rather than degrading one endpoint. Flagged deliberately — worth a follow-up decision.
