### PR TITLE
fix(fs): resolve preview module probes from the index instead of re-listing

### DIFF
--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -677,6 +677,11 @@ export class VeryfrontFSAdapter implements FSAdapter {
   private shouldRecoverBranchMiss(path: string, error: unknown): boolean {
     if (this.contentContext?.sourceType !== "branch") return false;
     if (!isNotFoundLikeError(error)) return false;
+    // The listing this render already fetched says the path is absent. A
+    // snapshot refresh would fetch that same listing again, so a page that
+    // probes N candidate spellings would pay N listing requests to be told
+    // the same thing. Pokes clear the index, so a real edit still recovers.
+    if (this.statOps.isIndexAuthoritative()) return false;
 
     const recoveryKey = this.getBranchMissRecoveryKey(path);
     return !this.hasRecentBranchMissRecoveryFailure(recoveryKey);
@@ -968,7 +973,13 @@ export class VeryfrontFSAdapter implements FSAdapter {
         await this.cache.deleteAsync(cacheKey);
         return undefined;
       }
+      // The stat index and directory tree are built from the listing this
+      // poke just replaced. Left standing they keep answering with the
+      // pre-edit file set -- a file created by the edit reads as absent, and
+      // one deleted by it reads as present.
       this.readOps.clearFileListIndex();
+      this.statOps.clearIndex();
+      this.dirOps.clearTree();
       this.markSourceSnapshotChanged(files);
       // Retain after the version bump so the poked listing -- not the one it
       // replaced -- is what later reads see when the cache keeps nothing.

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -677,10 +677,16 @@ export class VeryfrontFSAdapter implements FSAdapter {
   private shouldRecoverBranchMiss(path: string, error: unknown): boolean {
     if (this.contentContext?.sourceType !== "branch") return false;
     if (!isNotFoundLikeError(error)) return false;
-    // The listing this render already fetched says the path is absent. A
-    // snapshot refresh would fetch that same listing again, so a page that
-    // probes N candidate spellings would pay N listing requests to be told
-    // the same thing. Pokes clear the index, so a real edit still recovers.
+    // The index was built from a listing already fetched for this snapshot, and
+    // it says the path is absent. Recovering here re-derives that answer per
+    // probe, so a page trying N candidate spellings pays N recoveries to be
+    // told the same thing N times — which is the fan-out this fixes.
+    //
+    // Two things bound the staleness this trades for. A poke clears the index
+    // (see the invalidation path below), so an edit that reaches us re-enables
+    // recovery immediately. And `isIndexAuthoritative` is time-boxed by
+    // INDEX_AUTHORITY_LIMIT_MS, so an edit whose poke we MISS costs at most
+    // that window before recovery turns back on by itself.
     if (this.statOps.isIndexAuthoritative()) return false;
 
     const recoveryKey = this.getBranchMissRecoveryKey(path);

--- a/src/platform/adapters/fs/veryfront/adapter.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.ts
@@ -1091,6 +1091,12 @@ export class VeryfrontFSAdapter implements FSAdapter {
         this.sourceSnapshotFiles = files;
         this.sourceSnapshotIdentity = refreshIdentity;
         this.sourceSnapshotCheckedAt = Date.now();
+        // The API just confirmed this listing is current, so the index built
+        // from it may answer "absent" on its own again. Skipping this leaves
+        // the index expired after the first probe past
+        // INDEX_AUTHORITY_LIMIT_MS, and every later probe repeats this refresh
+        // to be told the same thing -- the per-probe fan-out, five minutes in.
+        this.statOps.renewIndexAuthority();
       }
 
       this.branchMissRecoveryFailures.clear();

--- a/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
@@ -810,4 +810,41 @@ describe("file list fan-out (issue inbox#32)", () => {
     );
     assertEquals(searched > 0, true, "the API fallback must not be disabled unconditionally");
   });
+  it("still recovers a branch miss when the index is not authoritative", async () => {
+    // The fan-out gate disables snapshot recovery while the index can answer.
+    // Raised in review: nothing pinned that recovery still works when it
+    // cannot — i.e. that the gate narrows the path rather than closing it.
+    const files: StubFile[] = [{ path: "app/page.tsx", content: "export default () => null;" }];
+    const { adapter, counts } = createDraftAdapter(files, true, true);
+
+    const before = counts.listFiles;
+    assertEquals(await adapter.resolveFile("app/added-later"), null);
+    assertEquals(
+      counts.listFiles > before,
+      true,
+      "a recoverable snapshot must still refresh when the index cannot answer",
+    );
+  });
+
+  it("lets index authority expire so a missed poke cannot wedge recovery shut", async () => {
+    // INDEX_AUTHORITY_LIMIT_MS is the only thing bounding a MISSED poke: a poke
+    // that never arrives would otherwise leave the gate closed forever against
+    // a listing that predates the edit.
+    const files: StubFile[] = [{ path: "app/page.tsx", content: "export default () => null;" }];
+    const { adapter } = createDraftAdapter(files, true, true);
+    await adapter.resolveFile("app/page");
+
+    const statOps = (adapter as unknown as {
+      statOps: { isIndexAuthoritative(): boolean; indexBuiltAt: number };
+    }).statOps;
+    assertEquals(statOps.isIndexAuthoritative(), true, "fresh index answers authoritatively");
+
+    // Age the index past the window rather than sleeping through it.
+    statOps.indexBuiltAt = Date.now() - (5 * 60 * 1000 + 1);
+    assertEquals(
+      statOps.isIndexAuthoritative(),
+      false,
+      "authority must lapse so recovery turns back on without a poke",
+    );
+  });
 });

--- a/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
@@ -14,6 +14,13 @@ interface ClientCallCounts {
   listAllFiles: number;
   getFileContent: number;
   listFiles: number;
+  /**
+   * Every request that hits `GET /projects/{slug}/files` -- the full listing
+   * (`listAllFiles`) and each pattern probe (`listFiles`) alike. This is the
+   * number the production trace counts, so it is the number a render budget
+   * has to be expressed in.
+   */
+  listingRequests: number;
 }
 
 /**
@@ -28,6 +35,7 @@ function stubClient(
     listAllFiles: 0,
     getFileContent: 0,
     listFiles: 0,
+    listingRequests: 0,
   };
 
   const client = adapter.getClient() as unknown as {
@@ -39,6 +47,7 @@ function stubClient(
 
   client.listAllFiles = () => {
     counts.listAllFiles++;
+    counts.listingRequests++;
     return Promise.resolve(files.map((file) => ({ ...file })));
   };
   client.getFileContent = (path: string) => {
@@ -53,15 +62,34 @@ function stubClient(
     if (!file) return Promise.reject(new Error(`404 Not Found: ${path}`));
     return Promise.resolve(new TextEncoder().encode(file.content));
   };
-  client.listFiles = () => {
+  client.listFiles = (options?: { pattern?: string }) => {
     counts.listFiles++;
-    return Promise.resolve({ files: [] });
+    counts.listingRequests++;
+    const pattern = options?.pattern;
+    if (!pattern) return Promise.resolve({ files: files.map((file) => ({ ...file })) });
+    const matcher = new RegExp(
+      `^${
+        pattern.split("*").map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join(".*")
+      }$`,
+    );
+    return Promise.resolve({
+      files: files.filter((file) => matcher.test(file.path)).map((file) => ({ ...file })),
+    });
   };
 
   return counts;
 }
 
-function createDraftAdapter(files: StubFile[], cacheEnabled = true): {
+/**
+ * @param recoverableSnapshot Give the client a project id so the adapter's
+ * branch-miss snapshot recovery can actually run. Production previews always
+ * have one, so leaving it off hides every listing refetch that recovery costs.
+ */
+function createDraftAdapter(
+  files: StubFile[],
+  cacheEnabled = true,
+  recoverableSnapshot = false,
+): {
   adapter: VeryfrontFSAdapter;
   counts: ClientCallCounts;
 } {
@@ -74,6 +102,11 @@ function createDraftAdapter(files: StubFile[], cacheEnabled = true): {
     },
   });
   const counts = stubClient(adapter, files);
+
+  if (recoverableSnapshot) {
+    (adapter.getClient() as unknown as { getProjectId: () => string }).getProjectId = () =>
+      "project-123";
+  }
 
   adapter.setContentContext({
     sourceType: "branch",
@@ -667,5 +700,114 @@ describe("file list fan-out (issue inbox#32)", () => {
       "export default 'v2';",
       "a queued replacement must keep the generation from when it was requested",
     );
+  });
+
+  it("answers a preview root render's module probes from the single listing fetch", async () => {
+    // A default project's module graph, exactly as the listing returns it.
+    const modulePaths = [
+      "app/layout",
+      "pages/index",
+      "components/Welcome",
+      "components/app",
+      "components/Header",
+      "components/Footer",
+      "styles/globals",
+    ];
+    const files: StubFile[] = modulePaths.map((modulePath) => ({
+      path: `${modulePath}.tsx`,
+      content: `export const source = "${modulePath}";`,
+    }));
+    const { adapter, counts } = createDraftAdapter(files, true, true);
+
+    // `mdx.load_module_esm` -> `mdx.fetch_module` asks for every import
+    // specifier once per candidate extension. None of these spellings exist,
+    // and the listing this render already fetched says so.
+    const probedExtensions = [".js", ".jsx", ".ts", ".md", ".mdx"];
+    for (const modulePath of modulePaths) {
+      for (const extension of probedExtensions) {
+        assertEquals(
+          await adapter.exists(`${modulePath}${extension}`),
+          false,
+          `${modulePath}${extension} is not in the listing`,
+        );
+      }
+    }
+
+    // Freshness is unchanged: the listing still answers the real modules.
+    for (const file of files) {
+      assertEquals(await adapter.readTextFile(file.path), file.content);
+    }
+
+    assertEquals(
+      counts.listingRequests,
+      1,
+      "a preview root render must cost exactly one file-listing request",
+    );
+  });
+
+  it("stops trusting the listing for absent paths once a poke lands", async () => {
+    const files: StubFile[] = [
+      { path: "pages/index.tsx", content: "export default function Home() {}" },
+    ];
+    const { adapter, counts } = createDraftAdapter(files, true, true);
+
+    assertEquals(
+      await adapter.exists("components/Welcome.tsx"),
+      false,
+      "the file does not exist yet, and the listing is authoritative about that",
+    );
+    assertEquals(counts.listingRequests, 1, "the absent path must not cost a probe");
+
+    // The user creates the file; the WebSocket poke replaces the snapshot.
+    files.push({ path: "components/Welcome.tsx", content: "export const Welcome = 1;" });
+    const context = adapter.getContentContext();
+    if (!context) throw new Error("content context required");
+    const internals = adapter as unknown as {
+      replaceSourceSnapshot: (
+        cacheKey: string,
+        snapshotFiles: Array<{ path: string; content?: string }>,
+      ) => Promise<void>;
+    };
+    await internals.replaceSourceSnapshot(
+      buildFileListCacheKey(context),
+      files.map((file) => ({ ...file })),
+    );
+
+    assertEquals(
+      await adapter.exists("components/Welcome.tsx"),
+      true,
+      "a poked snapshot must retire the previous listing's authority, not serve its absence",
+    );
+    assertEquals(
+      await adapter.readTextFile("components/Welcome.tsx"),
+      "export const Welcome = 1;",
+      "the new file must be readable immediately after the poke",
+    );
+  });
+
+  it("still falls back to the API when no listing is available at all", async () => {
+    const { adapter } = createDraftAdapter([], true, true);
+
+    // No listing can be fetched, so nothing is authoritative: a miss must fall
+    // through to the API rather than being reported absent on no evidence.
+    const client = adapter.getClient() as unknown as {
+      listAllFiles: () => Promise<Array<{ path: string }>>;
+      searchFiles: (pattern: string) => Promise<Array<{ path: string }>>;
+    };
+    client.listAllFiles = () => Promise.reject(new Error("listing unavailable"));
+    let searched = 0;
+    client.searchFiles = (pattern: string) => {
+      searched++;
+      return Promise.resolve(
+        pattern === "components/Late.*" ? [{ path: "components/Late.tsx" }] : [],
+      );
+    };
+
+    assertEquals(
+      await adapter.resolveFile("components/Late"),
+      "components/Late.tsx",
+      "without any listing the API search must still run",
+    );
+    assertEquals(searched > 0, true, "the API fallback must not be disabled unconditionally");
   });
 });

--- a/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
@@ -847,4 +847,99 @@ describe("file list fan-out (issue inbox#32)", () => {
       "authority must lapse so recovery turns back on without a poke",
     );
   });
+
+  it("renews index authority when an expired refresh finds the snapshot unchanged", async () => {
+    // The expiry above is a safety valve, not a budget: crossing it must cost
+    // ONE re-check, not one per probe. A preview open longer than the window
+    // whose refresh keeps confirming "nothing changed" must not slide back
+    // into the per-probe fan-out this whole change exists to remove.
+    const files: StubFile[] = [{ path: "app/page.tsx", content: "export default () => null;" }];
+    const { adapter, counts } = createDraftAdapter(files, true, true);
+
+    // A preview that has been open a while: the listing is warm and a snapshot
+    // has been recorded, so later refreshes have a baseline to compare against
+    // and can come back unchanged.
+    assertEquals(await adapter.exists("app/page.tsx"), true);
+    await adapter.refreshSourceSnapshot("test-warmup");
+    assertEquals(await adapter.exists("app/page.tsx"), true);
+
+    const statOps = (adapter as unknown as {
+      statOps: { isIndexAuthoritative(): boolean; indexBuiltAt: number };
+    }).statOps;
+    assertEquals(statOps.isIndexAuthoritative(), true, "the warm index answers authoritatively");
+
+    // Five idle minutes pass. Age the index rather than sleeping through it.
+    statOps.indexBuiltAt = Date.now() - (5 * 60 * 1000 + 1);
+
+    // The first probe past the window re-checks the API, as designed.
+    const beforeFirstMiss = counts.listingRequests;
+    assertEquals(await adapter.exists("components/Missing-one.tsx"), false);
+    assertEquals(
+      counts.listingRequests > beforeFirstMiss,
+      true,
+      "the first probe past the window must re-check the listing against the API",
+    );
+
+    // That re-check confirmed the listing, so the index built from it describes
+    // the current snapshot again. Every later probe must be answered from it.
+    const afterFirstMiss = counts.listingRequests;
+    assertEquals(await adapter.exists("components/Missing-two.tsx"), false);
+    assertEquals(
+      counts.listingRequests,
+      afterFirstMiss,
+      "an unchanged refresh must renew index authority, not leave each later probe to re-check",
+    );
+  });
+
+  it("still sees an edit whose poke was missed once the renewed window lapses", async () => {
+    // The other half of the renewal: it must not turn "unchanged once" into
+    // "never re-check again". Each renewal buys exactly one more window, and
+    // an edit that arrives without a poke must be picked up when that lapses.
+    const files: StubFile[] = [{ path: "app/page.tsx", content: "export default () => null;" }];
+    const { adapter } = createDraftAdapter(files, true, true);
+
+    assertEquals(await adapter.exists("app/page.tsx"), true);
+    await adapter.refreshSourceSnapshot("test-warmup");
+    assertEquals(await adapter.exists("app/page.tsx"), true);
+
+    const statOps = (adapter as unknown as {
+      statOps: { isIndexAuthoritative(): boolean; indexBuiltAt: number };
+    }).statOps;
+    const expire = () => {
+      statOps.indexBuiltAt = Date.now() - (5 * 60 * 1000 + 1);
+    };
+
+    // Window one lapses against an unchanged listing, so authority is renewed.
+    // Probe a path unrelated to the edit below: a path that misses while the
+    // window is open is memoised as a recent recovery failure, which would
+    // suppress the recovery this test is here to observe.
+    expire();
+    assertEquals(await adapter.exists("components/Unrelated.tsx"), false);
+    assertEquals(
+      statOps.isIndexAuthoritative(),
+      true,
+      "the confirming refresh renews the window",
+    );
+
+    // The user now creates the file and the poke never reaches us.
+    files.push({ path: "components/Welcome.tsx", content: "export const Welcome = 1;" });
+    assertEquals(
+      await adapter.exists("components/Welcome.tsx"),
+      false,
+      "inside the renewed window the index still answers from the confirmed listing",
+    );
+
+    // Window two lapses. The renewal bought a window, not immunity.
+    expire();
+    assertEquals(
+      await adapter.exists("components/Welcome.tsx"),
+      true,
+      "a missed poke must still surface once the renewed window expires",
+    );
+    assertEquals(
+      await adapter.readTextFile("components/Welcome.tsx"),
+      "export const Welcome = 1;",
+      "the recovered snapshot must serve the missed file's content",
+    );
+  });
 });

--- a/src/platform/adapters/fs/veryfront/stat-operations.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.ts
@@ -272,6 +272,28 @@ export class StatOperations extends VeryfrontOperationsBase {
   }
 
   /**
+   * Restart the authority window for the index already in memory, after the
+   * API has confirmed the listing it was built from is still current.
+   *
+   * `INDEX_AUTHORITY_LIMIT_MS` bounds a poke that never arrived, so crossing
+   * it has to cost one re-check -- not one per probe. A refresh that comes
+   * back unchanged is exactly that re-check: it just compared this snapshot
+   * against the API and found nothing new, which is stronger evidence than
+   * the build that opened the window. Without renewing here the index stays
+   * expired, and every distinct module probe pays its own refresh forever --
+   * the fan-out this gate removes, returning after five minutes.
+   *
+   * This cannot become "never re-check again": only a completed refresh calls
+   * it, so each renewal costs one verified listing fetch and the next window
+   * expires on the same timer. An edit is still seen the moment its poke
+   * lands, because `clearIndex` drops the index outright.
+   */
+  renewIndexAuthority(): void {
+    if (!this.fileIndex || !this.directoryIndex) return;
+    this.indexBuiltAt = Date.now();
+  }
+
+  /**
    * Whether the built index is the complete file listing for the snapshot
    * being rendered, and may therefore answer "this path does not exist"
    * without asking the API.

--- a/src/platform/adapters/fs/veryfront/stat-operations.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.ts
@@ -25,14 +25,6 @@ const NOT_FOUND_SENTINEL = "__NOT_FOUND__";
 const API_SEARCH_CIRCUIT_BREAKER_THRESHOLD = 5;
 const API_SEARCH_CIRCUIT_BREAKER_COOLDOWN_MS = 30_000;
 
-/**
- * How long a built index may keep answering "absent" on its own authority.
- * Every invalidation path clears the index, so this only bounds the damage of
- * a poke that never arrived -- the same safety net FileListIndex applies to
- * the read path.
- */
-const INDEX_AUTHORITY_LIMIT_MS = 5 * 60 * 1000;
-
 function isFileNotFoundError(error: unknown): boolean {
   if (error instanceof VeryfrontError && error.slug === "file-not-found") {
     return true;
@@ -46,7 +38,6 @@ export class StatOperations extends VeryfrontOperationsBase {
   private fileIndex: Map<string, ProjectFile> | null = null;
   private directoryIndex: Set<string> | null = null;
   private buildingIndex: Promise<void> | null = null;
-  private indexBuiltAt = 0;
 
   private indexBuildLockResolver: (() => void) | null = null;
   private indexBuildLockPromise: Promise<void> | null = null;
@@ -108,13 +99,8 @@ export class StatOperations extends VeryfrontOperationsBase {
     }
 
     // File not in index - try API pattern search as fallback for project files
-    // Skip for framework paths (node_modules, _veryfront, etc.) and whenever
-    // the index is the authoritative listing for this snapshot: it has already
-    // answered, and asking again costs one file-listing request per probe.
-    if (
-      !this.isIndexAuthoritative() && !isFrameworkSourcePath(normalizedPath) &&
-      this.apiSearchCircuitBreaker.canSearch()
-    ) {
+    // Skip for framework paths (node_modules, _veryfront, etc.)
+    if (!isFrameworkSourcePath(normalizedPath) && this.apiSearchCircuitBreaker.canSearch()) {
       const hasKnownExt = EXTENSION_PRIORITY.some((ext) => normalizedPath.endsWith(ext));
       if (hasKnownExt) {
         logger.debug("stat file not in index, trying API search", {
@@ -250,7 +236,6 @@ export class StatOperations extends VeryfrontOperationsBase {
     this.fileIndex = fileIdx;
     this.directoryIndex = dirIdx;
     this.pathMapping = pathMap;
-    this.indexBuiltAt = Date.now();
 
     const indexMs = Math.round(performance.now() - indexStart);
     const totalMs = Math.round(performance.now() - buildStart);
@@ -268,33 +253,6 @@ export class StatOperations extends VeryfrontOperationsBase {
     this.fileIndex = null;
     this.directoryIndex = null;
     this.pathMapping.clear();
-    this.indexBuiltAt = 0;
-  }
-
-  /**
-   * Whether the built index is the complete file listing for the snapshot
-   * being rendered, and may therefore answer "this path does not exist"
-   * without asking the API.
-   *
-   * The index is built from `loadAllProjectFiles`, the same listing that
-   * serves every positive answer this render gives. A path missing from it is
-   * missing from the snapshot, so re-asking the API for that exact path can
-   * only re-derive the answer the index already holds -- which is what turned
-   * one preview render into dozens of file-listing requests.
-   *
-   * This authority covers exact-path lookups only. `resolveFile`'s pattern
-   * search still runs on a miss: it is the documented safety net for a listing
-   * that came back incomplete, and it searches spellings the index was never
-   * asked about.
-   *
-   * The authority lasts exactly as long as the index: every invalidation path
-   * (`clearMemoryCaches`, snapshot replacement, token or branch change,
-   * `dispose`) calls `clearIndex`, so an edit can never be answered from a
-   * pre-edit listing.
-   */
-  isIndexAuthoritative(): boolean {
-    if (!this.fileIndex || !this.directoryIndex) return false;
-    return Date.now() - this.indexBuiltAt < INDEX_AUTHORITY_LIMIT_MS;
   }
 
   getOriginalApiPath(normalizedPath: string): string {

--- a/src/platform/adapters/fs/veryfront/stat-operations.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.ts
@@ -25,6 +25,14 @@ const NOT_FOUND_SENTINEL = "__NOT_FOUND__";
 const API_SEARCH_CIRCUIT_BREAKER_THRESHOLD = 5;
 const API_SEARCH_CIRCUIT_BREAKER_COOLDOWN_MS = 30_000;
 
+/**
+ * How long a built index may keep answering "absent" on its own authority.
+ * Every invalidation path clears the index, so this only bounds the damage of
+ * a poke that never arrived -- the same safety net FileListIndex applies to
+ * the read path.
+ */
+const INDEX_AUTHORITY_LIMIT_MS = 5 * 60 * 1000;
+
 function isFileNotFoundError(error: unknown): boolean {
   if (error instanceof VeryfrontError && error.slug === "file-not-found") {
     return true;
@@ -38,6 +46,7 @@ export class StatOperations extends VeryfrontOperationsBase {
   private fileIndex: Map<string, ProjectFile> | null = null;
   private directoryIndex: Set<string> | null = null;
   private buildingIndex: Promise<void> | null = null;
+  private indexBuiltAt = 0;
 
   private indexBuildLockResolver: (() => void) | null = null;
   private indexBuildLockPromise: Promise<void> | null = null;
@@ -99,8 +108,13 @@ export class StatOperations extends VeryfrontOperationsBase {
     }
 
     // File not in index - try API pattern search as fallback for project files
-    // Skip for framework paths (node_modules, _veryfront, etc.)
-    if (!isFrameworkSourcePath(normalizedPath) && this.apiSearchCircuitBreaker.canSearch()) {
+    // Skip for framework paths (node_modules, _veryfront, etc.) and whenever
+    // the index is the authoritative listing for this snapshot: it has already
+    // answered, and asking again costs one file-listing request per probe.
+    if (
+      !this.isIndexAuthoritative() && !isFrameworkSourcePath(normalizedPath) &&
+      this.apiSearchCircuitBreaker.canSearch()
+    ) {
       const hasKnownExt = EXTENSION_PRIORITY.some((ext) => normalizedPath.endsWith(ext));
       if (hasKnownExt) {
         logger.debug("stat file not in index, trying API search", {
@@ -236,6 +250,7 @@ export class StatOperations extends VeryfrontOperationsBase {
     this.fileIndex = fileIdx;
     this.directoryIndex = dirIdx;
     this.pathMapping = pathMap;
+    this.indexBuiltAt = Date.now();
 
     const indexMs = Math.round(performance.now() - indexStart);
     const totalMs = Math.round(performance.now() - buildStart);
@@ -253,6 +268,33 @@ export class StatOperations extends VeryfrontOperationsBase {
     this.fileIndex = null;
     this.directoryIndex = null;
     this.pathMapping.clear();
+    this.indexBuiltAt = 0;
+  }
+
+  /**
+   * Whether the built index is the complete file listing for the snapshot
+   * being rendered, and may therefore answer "this path does not exist"
+   * without asking the API.
+   *
+   * The index is built from `loadAllProjectFiles`, the same listing that
+   * serves every positive answer this render gives. A path missing from it is
+   * missing from the snapshot, so re-asking the API for that exact path can
+   * only re-derive the answer the index already holds -- which is what turned
+   * one preview render into dozens of file-listing requests.
+   *
+   * This authority covers exact-path lookups only. `resolveFile`'s pattern
+   * search still runs on a miss: it is the documented safety net for a listing
+   * that came back incomplete, and it searches spellings the index was never
+   * asked about.
+   *
+   * The authority lasts exactly as long as the index: every invalidation path
+   * (`clearMemoryCaches`, snapshot replacement, token or branch change,
+   * `dispose`) calls `clearIndex`, so an edit can never be answered from a
+   * pre-edit listing.
+   */
+  isIndexAuthoritative(): boolean {
+    if (!this.fileIndex || !this.directoryIndex) return false;
+    return Date.now() - this.indexBuiltAt < INDEX_AUTHORITY_LIMIT_MS;
   }
 
   getOriginalApiPath(normalizedPath: string): string {


### PR DESCRIPTION
Addresses symptom 2 of veryfront-issue-inbox#32.

## The `awaiting-release` label was wrong

PR #3810 shipped in v0.1.1242 and is live as v0.1.1244 — and produced **zero change** in the fan-out it was written to remove. Same project, same route, identical span shape before and after: 253 spans and 81 veryfront-api fetches per preview root render. Post-release renders were 4260ms and 5808ms.

#3810 cached `adapter.getFileList`/`hasCachedFileList`. Nothing on the render path calls those, which is why it looked fixed and production was unchanged.

## What actually happens

The listing is fetched once and then **re-derived path-by-path**: every extensionless probe and every candidate spelling pays its own round trip. The index built from that first listing already holds the answer.

Two changes:

- **`stat-operations.ts`** — resolve from the index it already built instead of re-probing. This carries most of the reduction.
- **`adapter.ts`** — `shouldRecoverBranchMiss` no longer recovers while the index can answer. Recovering per probe re-derives the same "absent" answer N times for a page trying N spellings.

## Scope

**Symptom 2 only.** Symptoms 1 (freeze after ~20 chars) and 3 (stale SSR) are untouched and the issue should stay open for them. Saying so explicitly rather than letting a partial fix read as a close.

## The staleness trade, and what bounds it

Gating recovery trades some freshness for the fan-out, so both escape hatches are now stated and tested:

- a **poke that arrives** clears the stat index and directory tree (added here — previously they kept answering from the pre-edit file set, so a file created by an edit read as absent and one deleted read as present);
- a **poke that never arrives** expires: `isIndexAuthoritative` is time-boxed by `INDEX_AUTHORITY_LIMIT_MS`, so recovery turns back on by itself.

Both directions are pinned by tests — recovery still fires when the index cannot answer, and authority lapses when aged past the window.

## Review findings, addressed

The gate's original justification claimed "a snapshot refresh would fetch that same listing again". That is not what recovery does, and the comment now says what is actually true.

Review also suggested the `stat-operations` hunk alone carried the result and the gate could be dropped. **Measured — it cannot:** removing the gate fails the headline test, `answers a preview root render's module probes from the single listing fetch`. Kept, with its bounds now covered rather than assumed.

## Verification

Red against `origin/main`: 3 failed steps. Green: 19 steps.
`src/platform/adapters/fs`: 53 passed (917 steps), 0 failed.

## Not claimed

The production numbers have not been re-measured. The issue asks for that, and it is the only thing that will confirm the render-path fan-out actually collapses — the last attempt looked right in tests and changed nothing in production.
