### PR TITLE
fix(transforms): prune destructured server values from the client artifact

### DIFF
--- a/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
@@ -8,6 +8,7 @@ import type { CodeParser } from "#veryfront/extensions/parser/index.ts";
 import {
   browserServerExportsStripPlugin,
   moduleReferenceWalkers,
+  patternBindings,
   stripServerOnlyExports,
 } from "./browser-server-exports-strip.ts";
 import { COMPILE_SOURCE_MAP_DIRECTIVE_METADATA, compilePlugin } from "./compile.ts";
@@ -26,6 +27,68 @@ function occurrences(haystack: string, name: string): number {
 describe("browser-server-exports-strip", () => {
   afterAll(async () => {
     await stopEsbuild();
+  });
+
+  // The binding/value-position split inside a destructuring pattern is the safety
+  // property of `patternBindings`: a binding position joins the `excluded` set in
+  // `dropUnusedModuleScopeBindings`, so anything wrongly classified as a binding
+  // becomes invisible to `referencedIdentifiers` and can be pruned while still live.
+  //
+  // These assert the split directly because it is NOT observable end to end today —
+  // a naive walk that also collected default and computed-key identifiers produced
+  // byte-identical stage output on every module shape probed. That makes an
+  // end-to-end test useless as a guard here, and this the only place the invariant
+  // can actually be pinned.
+  describe("patternBindings", () => {
+    const bindingNamesOf = async (source: string): Promise<string[] | null> => {
+      const parser = tryResolve<CodeParser>("CodeParser");
+      if (!parser) throw new Error("CodeParser extension is not registered");
+      const ast = await parser.parse({ code: source, filePath: "pattern.ts" }) as unknown as {
+        program: { body: Array<Record<string, unknown>> };
+      };
+      const statement = ast.program.body[0];
+      const declarations = statement.declarations as Array<Record<string, unknown>>;
+      const bindings = patternBindings(declarations[0].id);
+      return bindings === null
+        ? null
+        : bindings.map((node) => (node as unknown as { name: string }).name);
+    };
+
+    it("collects a plain identifier", async () => {
+      assertEquals(await bindingNamesOf("const a = x;"), ["a"]);
+    });
+
+    it("collects object-pattern bindings through their values, not their keys", async () => {
+      assertEquals(await bindingNamesOf("const { k: a } = x;"), ["a"]);
+    });
+
+    it("excludes a destructuring default expression — it is a read", async () => {
+      assertEquals(await bindingNamesOf("const { a = fallback } = x;"), ["a"]);
+    });
+
+    it("excludes a computed key expression — it is a read", async () => {
+      assertEquals(await bindingNamesOf("const { [keyName]: a } = x;"), ["a"]);
+    });
+
+    it("excludes a nested default expression", async () => {
+      assertEquals(await bindingNamesOf("const { o: { a = fallback } } = x;"), ["a"]);
+    });
+
+    it("excludes an array-pattern default expression", async () => {
+      assertEquals(await bindingNamesOf("const [a = fallback] = x;"), ["a"]);
+    });
+
+    it("collects nested, rest and hole shapes", async () => {
+      assertEquals(await bindingNamesOf("const { o: { i } } = x;"), ["i"]);
+      assertEquals(await bindingNamesOf("const { a, ...rest } = x;"), ["a", "rest"]);
+      assertEquals(await bindingNamesOf("const [a, , b] = x;"), ["a", "b"]);
+      assertEquals(await bindingNamesOf("const [...rest] = x;"), ["rest"]);
+    });
+
+    it("returns null for a shape it does not model, so the caller keeps the statement", () => {
+      assertEquals(patternBindings(undefined), null);
+      assertEquals(patternBindings({ type: "TSParameterProperty" }), null);
+    });
   });
 
   describe("emptying server-only hooks", () => {
@@ -758,12 +821,12 @@ describe("browser-server-exports-strip", () => {
       assertEquals(occurrences(result, "TOKEN"), 0); // hook-only tail → dropped
     });
 
-    // Known limitation (pinned): a *destructured* server value is NOT pruned —
-    // `moduleScopeDeclarations` handles only simple identifiers, to avoid
-    // mishandling default-value references inside patterns. Conservative (never
-    // over-prunes) but it means a destructured server value still ships. If this
-    // ever needs closing, extend the declaration collector to safe patterns.
-    it("conservatively keeps a destructured server value (documented limitation)", async () => {
+    // A destructured server value is pruned like a simple one. `moduleScopeDeclarations`
+    // collects binding positions out of object/array patterns; value positions inside a
+    // pattern (defaults, computed keys) stay visible to `referencedIdentifiers`, so the
+    // pass keeps its conservative "never over-prune" property. See the over-prune guards
+    // immediately below — those are what make this safe.
+    it("drops a hook-only destructured server value and its import", async () => {
       const code = [
         `import { getEnv } from "veryfront";`,
         `const { a } = getEnv("X");`,
@@ -773,8 +836,100 @@ describe("browser-server-exports-strip", () => {
 
       const result = await stripServerOnlyExports(code);
 
-      // Pinned as-is: the destructured binding and its import survive.
+      assertEquals(occurrences(result, "getEnv"), 0);
+      assertEquals(occurrences(result, "veryfront"), 0);
+    });
+
+    it("drops a hook-only nested destructured server value", async () => {
+      const code = [
+        `import { getEnv } from "veryfront";`,
+        `const { outer: { inner } } = getEnv("X");`,
+        `export async function getServerData() { return { props: { inner } }; }`,
+        `export default function Page() { return null; }`,
+      ].join("\n");
+
+      const result = await stripServerOnlyExports(code);
+
+      assertEquals(occurrences(result, "getEnv"), 0);
+    });
+
+    it("drops a hook-only array-destructured server value, holes included", async () => {
+      const code = [
+        `import { getEnv } from "veryfront";`,
+        `const [first, , third] = getEnv("X");`,
+        `export async function getServerData() { return { props: { first, third } }; }`,
+        `export default function Page() { return null; }`,
+      ].join("\n");
+
+      const result = await stripServerOnlyExports(code);
+
+      assertEquals(occurrences(result, "getEnv"), 0);
+    });
+
+    it("drops a hook-only rest-destructured server value", async () => {
+      const code = [
+        `import { getEnv } from "veryfront";`,
+        `const { a, ...rest } = getEnv("X");`,
+        `export async function getServerData() { return { props: { a, rest } }; }`,
+        `export default function Page() { return null; }`,
+      ].join("\n");
+
+      const result = await stripServerOnlyExports(code);
+
+      assertEquals(occurrences(result, "getEnv"), 0);
+    });
+
+    // --- over-prune guards -------------------------------------------------
+    // These are the reason the collector originally bailed out on patterns. A default
+    // value or a computed key inside a pattern is a *read*, not a binding. If the
+    // collector swallowed those identifiers as bindings they would be hidden from
+    // `referencedIdentifiers` and the pass would delete live client code — a worse
+    // failure than the leak it is closing.
+
+    it("keeps a client binding referenced by a destructuring default in a stripped hook", async () => {
+      const code = [
+        `import { getEnv } from "veryfront";`,
+        `import { fallback } from "../lib/client.js";`,
+        `const { a = fallback } = getEnv("X");`,
+        `export async function getServerData() { return { props: { a } }; }`,
+        `export default function Page() { return fallback; }`,
+      ].join("\n");
+
+      const result = await stripServerOnlyExports(code);
+
+      assertStringIncludes(result, "fallback");
+      assertStringIncludes(result, "../lib/client.js");
+    });
+
+    it("keeps a client binding used as a computed key in a stripped hook's pattern", async () => {
+      const code = [
+        `import { getEnv } from "veryfront";`,
+        `import { keyName } from "../lib/client.js";`,
+        `const { [keyName]: a } = getEnv("X");`,
+        `export async function getServerData() { return { props: { a } }; }`,
+        `export default function Page() { return keyName; }`,
+      ].join("\n");
+
+      const result = await stripServerOnlyExports(code);
+
+      assertStringIncludes(result, "keyName");
+      assertStringIncludes(result, "../lib/client.js");
+    });
+
+    it("keeps a destructured binding the client still reads", async () => {
+      const code = [
+        `import { getEnv } from "veryfront";`,
+        `const { a, b } = getEnv("X");`,
+        `export async function getServerData() { return { props: { b } }; }`,
+        `export default function Page() { return a; }`,
+      ].join("\n");
+
+      const result = await stripServerOnlyExports(code);
+
+      // One binding of the pattern is live on the client, so the whole
+      // declaration — and its import — must survive.
       assertStringIncludes(result, "getEnv");
+      assertStringIncludes(result, "a");
     });
 
     it("keeps an import that the client still references", async () => {

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
@@ -47,8 +47,11 @@ describe("browser-server-exports-strip", () => {
         program: { body: Array<Record<string, unknown>> };
       };
       const statement = ast.program.body[0];
+      if (!statement) throw new Error(`no statement parsed from: ${source}`);
       const declarations = statement.declarations as Array<Record<string, unknown>>;
-      const bindings = patternBindings(declarations[0].id);
+      const declarator = declarations[0];
+      if (!declarator) throw new Error(`no declarator parsed from: ${source}`);
+      const bindings = patternBindings(declarator.id);
       return bindings === null
         ? null
         : bindings.map((node) => (node as unknown as { name: string }).name);
@@ -879,12 +882,23 @@ describe("browser-server-exports-strip", () => {
       assertEquals(occurrences(result, "getEnv"), 0);
     });
 
-    // --- over-prune guards -------------------------------------------------
-    // These are the reason the collector originally bailed out on patterns. A default
-    // value or a computed key inside a pattern is a *read*, not a binding. If the
-    // collector swallowed those identifiers as bindings they would be hidden from
-    // `referencedIdentifiers` and the pass would delete live client code — a worse
-    // failure than the leak it is closing.
+    // --- over-prune behaviour -----------------------------------------------
+    // A default value or a computed key inside a pattern is a *read*, not a binding.
+    // If the collector swallowed those identifiers as bindings they would be hidden
+    // from `referencedIdentifiers` and the pass could delete live client code — a
+    // worse failure than the leak it is closing.
+    //
+    // These pin the resulting BEHAVIOUR. They are deliberately NOT the guard for that
+    // property, and should not be read as one: a collector that wrongly treats
+    // defaults and computed keys as bindings passes all three. Two independent
+    // attempts to build a discriminating end-to-end case failed — a differential run
+    // over both collectors produced byte-identical stage output on every shape tried,
+    // including `const { a = fallback } = getEnv("X")` with no client read of
+    // `fallback`, where the declaration is dropped either way because `a` is
+    // unreferenced once the hook body is emptied, taking `fallback` with it.
+    //
+    // The property is pinned in the `patternBindings` block above, at the seam where
+    // it is actually decidable.
 
     it("keeps a client binding referenced by a destructuring default in a stripped hook", async () => {
       const code = [

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.ts
@@ -492,6 +492,81 @@ interface ModuleScopeDecl {
  * Destructuring declarations are skipped — a pattern can carry default-value
  * references, and a partial removal is not worth the risk.
  */
+/**
+ * Binding identifiers introduced by a declarator `id`, or `null` when the
+ * pattern contains a shape this collector does not model.
+ *
+ * Only *binding positions* are returned. Value positions inside a pattern are
+ * deliberately left out so `referencedIdentifiers` still counts them as reads:
+ *
+ * - `AssignmentPattern.right` — `const { a = fallback } = ...` reads `fallback`
+ * - a computed `ObjectProperty.key` — `const { [keyName]: a } = ...` reads `keyName`
+ *
+ * Swallowing those as bindings would add them to the `excluded` set in
+ * `dropUnusedModuleScopeBindings`, hiding a live client read and letting the
+ * pass delete code the browser still needs. Over-pruning is a worse failure
+ * than leaving a server value in place, so an unrecognised shape returns `null`
+ * and the caller keeps the whole statement.
+ *
+ * Exported for direct testing: the binding/value-position split is the safety
+ * property of this walk, and it is not observable through the stage's
+ * end-to-end behaviour today (a naive walk that also collected default and
+ * computed-key identifiers produces byte-identical output on every shape
+ * probed). Testing it here is what keeps the invariant from silently rotting.
+ */
+export function patternBindings(value: unknown): Node[] | null {
+  if (!isNode(value)) return null;
+
+  switch (value.type) {
+    case "Identifier":
+      return [value];
+
+    case "ObjectPattern": {
+      const bindings: Node[] = [];
+      const properties = Array.isArray(value.properties) ? value.properties : [];
+      for (const property of properties) {
+        if (!isNode(property)) return null;
+        // A rest element binds; an ordinary property binds through its *value*,
+        // never its key. A computed key is a read and is left to the reference
+        // walker.
+        const target = property.type === "RestElement"
+          ? property.argument
+          : property.type === "ObjectProperty"
+          ? property.value
+          : undefined;
+        if (target === undefined) return null;
+        const nested = patternBindings(target);
+        if (!nested) return null;
+        bindings.push(...nested);
+      }
+      return bindings;
+    }
+
+    case "ArrayPattern": {
+      const bindings: Node[] = [];
+      const elements = Array.isArray(value.elements) ? value.elements : [];
+      for (const element of elements) {
+        // `[a, , b]` — a hole binds nothing.
+        if (element === null || element === undefined) continue;
+        const nested = patternBindings(element);
+        if (!nested) return null;
+        bindings.push(...nested);
+      }
+      return bindings;
+    }
+
+    // `left` is the binding; `right` is the default expression, i.e. a read.
+    case "AssignmentPattern":
+      return patternBindings(value.left);
+
+    case "RestElement":
+      return patternBindings(value.argument);
+
+    default:
+      return null;
+  }
+}
+
 function moduleScopeDeclarations(body: Node[]): ModuleScopeDecl[] {
   const decls: ModuleScopeDecl[] = [];
 
@@ -510,14 +585,30 @@ function moduleScopeDeclarations(body: Node[]): ModuleScopeDecl[] {
         const declarator of Array.isArray(statement.declarations) ? statement.declarations : []
       ) {
         if (!isNode(declarator)) continue;
-        const id = declarator.id;
-        if (isNode(id) && id.type === "Identifier") {
-          const name = nodeName(id);
-          if (name) variableDecls.push({ statement, declarator, names: [name], bindingIds: [id] });
-        } else {
+        const bindingIds = patternBindings(declarator.id);
+        if (!bindingIds) {
           variableDecls.length = 0;
           break;
         }
+
+        const names: string[] = [];
+        for (const bindingId of bindingIds) {
+          const name = nodeName(bindingId);
+          // A binding whose name cannot be resolved would be invisible to the
+          // liveness check, so keep the whole statement rather than prune
+          // around it.
+          if (!name) {
+            names.length = 0;
+            break;
+          }
+          names.push(name);
+        }
+        if (names.length !== bindingIds.length) {
+          variableDecls.length = 0;
+          break;
+        }
+
+        variableDecls.push({ statement, declarator, names, bindingIds });
       }
 
       decls.push(...variableDecls);


### PR DESCRIPTION
## Description

A hook-only **destructured** server value shipped to the browser. `moduleScopeDeclarations` collected binding names only from plain-identifier declarators; any `VariableDeclaration` containing a destructuring pattern hit the bail-out branch and was discarded from the collector entirely, so it could never be pruned:

```ts
import { getEnv } from "veryfront";
const { a } = getEnv("X");                                  // ← survived, with its import
export async function getServerData() { return { props: { a } }; }
export default function Page() { return null; }
```

The simple-identifier form (`const a = getEnv("X")`) was already pruned correctly, so the leak was purely a function of how the value was bound. It was pinned in the suite as a documented limitation; this replaces that pin with the behaviour.

### The fix

`patternBindings()` walks object/array patterns and returns identifiers in **binding positions**. Value positions are deliberately excluded, because they are reads:

| shape | binding | read |
|---|---|---|
| `{ a }`, `{ k: a }` | `a` | — |
| `{ [expr]: a }` | `a` | **`expr`** |
| `{ a = def }` | `a` | **`def`** |
| `{ ...rest }`, `[...rest]` | `rest` | — |
| `[a, , b]` | `a`, `b` | — (hole binds nothing) |
| `{ a: { b } }` | `b` | — |

Adding a value-position identifier to the `excluded` set in `dropUnusedModuleScopeBindings` would hide a live client read and let the pass delete code the browser still needs. **Over-pruning is a worse failure than the leak this closes**, so an unmodelled shape returns `null` and the caller keeps the whole statement — preserving the existing fail-safe.

**The consumer needed no change.** `ModuleScopeDecl` already carried plural `names` / `bindingIds`, and the liveness check already used `names.some(...)` / `names.every(...)`. Only the collector never populated them.

## Related Issue(s)

Refs veryfront/veryfront-issue-inbox#607

Scope note: this is deliberately *only* the destructured-value leak. It does not touch the deferred-execution classifier, the intrinsic-tampering analysis, or the strip/compile ordering — those live in #3846 and #3855 and are tracked on veryfront/veryfront-issue-inbox#605.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have added tests that prove my fix is effective
- [x] `deno fmt --check`, `deno lint`, `deno check` clean
- [ ] Documentation changes (n/a — no public API change)

## Why `patternBindings` is exported

Because the binding/value split **is not observable through this stage end to end today**, and I would rather say so than imply coverage that does not exist.

I mutated the fix to the naive version — collecting default and computed-key identifiers as bindings — and it produced **byte-identical stage output** on every module shape I probed (8 targeted differential shapes, plus a 12-case end-to-end probe). The end-to-end over-prune guards in this PR passed against the naive variant too. As written, they do not discriminate it.

So the invariant is pinned at the seam where it lives. Both naive variants now fail:

| variant | `patternBindings` tests |
|---|---|
| `AssignmentPattern.right` treated as a binding | **FAILED** (4 steps) |
| computed `ObjectProperty.key` treated as a binding | **FAILED** (2 steps) |
| this PR | **ok** — 140 steps |

The end-to-end guards are still worth keeping — they pin real behaviour — but the seam tests are what actually protect the property if `hookClosure` construction changes later.

## Verification

```
deno test src/transforms/               160 passed (2629 steps)  0 failed
deno test src/transforms/pipeline/stages/  22 passed  (332 steps)  0 failed
deno fmt --check src/transforms/pipeline/stages/   clean
deno lint          src/transforms/pipeline/stages/  clean
deno check         src/transforms/index.ts          clean
```

Independent probe against the real stage (not the test helper), asserting the secret and the server import are absent from the emitted artifact — 12/12, including the three over-prune guards. Notably `{ a, b }` with `b` live on the client correctly **keeps** the server value: under-pruning, never over-pruning.

## Size

`+258 / -12` across two files.
