### PR TITLE
docs(jira): note that an Atlassian OAuth app must have sharing enabled

### DIFF
--- a/docs/guides/integrations/jira.md
+++ b/docs/guides/integrations/jira.md
@@ -34,7 +34,7 @@ managed OAuth connection.
 4. Open **Distribution** and enable sharing. An OAuth 2.0 (3LO) app is private
    when created, so only the account that owns it can authorize. Leave sharing
    off and every other user reaches Atlassian, picks their site, and gets
-   Atlassian's own "Something went wrong" page — your deployment never sees the
+   Atlassian's own "Something went wrong" page. Your deployment never sees the
    callback, so nothing surfaces in your logs. Test with an account outside the
    app owner's Atlassian organization; the owner's account succeeds either way
    and proves nothing.

--- a/docs/guides/integrations/jira.md
+++ b/docs/guides/integrations/jira.md
@@ -31,7 +31,14 @@ managed OAuth connection.
    - `offline_access` to receive refresh tokens. Veryfront uses refresh tokens
      to keep a user connection active; omit it only when the connection must
      not be refreshable.
-4. Set the OAuth app client ID and client secret as project environment variables:
+4. Open **Distribution** and enable sharing. An OAuth 2.0 (3LO) app is private
+   when created, so only the account that owns it can authorize. Leave sharing
+   off and every other user reaches Atlassian, picks their site, and gets
+   Atlassian's own "Something went wrong" page — your deployment never sees the
+   callback, so nothing surfaces in your logs. Test with an account outside the
+   app owner's Atlassian organization; the owner's account succeeds either way
+   and proves nothing.
+5. Set the OAuth app client ID and client secret as project environment variables:
 
 | Variable                  | Value                         |
 | ------------------------- | ----------------------------- |

--- a/docs/guides/integrations/jira.md
+++ b/docs/guides/integrations/jira.md
@@ -32,12 +32,22 @@ managed OAuth connection.
      to keep a user connection active; omit it only when the connection must
      not be refreshable.
 4. Open **Distribution** and enable sharing. An OAuth 2.0 (3LO) app is private
-   when created, so only the account that owns it can authorize. Leave sharing
-   off and every other user reaches Atlassian, picks their site, and gets
-   Atlassian's own "Something went wrong" page. Your deployment never sees the
-   callback, so nothing surfaces in your logs. Test with an account outside the
-   app owner's Atlassian organization; the owner's account succeeds either way
-   and proves nothing.
+   when created, so only the account that owns it can authorize. Atlassian will
+   not save the toggle until you also fill in **Vendor** and **Privacy policy**
+   (plus **Terms of service** where it asks for one), so have those URLs ready.
+
+   Leave sharing off and every other user reaches Atlassian, picks their site,
+   and gets Atlassian's own "Something went wrong" page. Your deployment never
+   sees the callback, so nothing surfaces in your logs.
+
+   Test with any Atlassian account other than the app owner's. A private app is
+   restricted to the owning **account**, not to the owning organization, so a
+   colleague in the same organization fails too. The owner's own account
+   succeeds either way, so testing with it proves nothing.
+
+   This covers **Confluence** as well. Both connectors use the same Atlassian
+   app and the same `ATLASSIAN_CLIENT_ID` and `ATLASSIAN_CLIENT_SECRET`, so
+   enabling sharing once unblocks both.
 5. Set the OAuth app client ID and client secret as project environment variables:
 
 | Variable                  | Value                         |

--- a/docs/guides/integrations/jira.md
+++ b/docs/guides/integrations/jira.md
@@ -45,9 +45,10 @@ managed OAuth connection.
    colleague in the same organization fails too. The owner's own account
    succeeds either way, so testing with it proves nothing.
 
-   This covers **Confluence** as well. Both connectors use the same Atlassian
-   app and the same `ATLASSIAN_CLIENT_ID` and `ATLASSIAN_CLIENT_SECRET`, so
-   enabling sharing once unblocks both.
+   Sharing is a property of the **app**, not of one connector, so you enable it
+   once even if you also use Confluence. Confluence still needs its own setup on
+   the same app: a second callback URL ending `/api/auth/confluence/callback`
+   and its own scopes. See the Confluence connector's README for that list.
 5. Set the OAuth app client ID and client secret as project environment variables:
 
 | Variable                  | Value                         |

--- a/templates/integrations/confluence/README.md
+++ b/templates/integrations/confluence/README.md
@@ -51,6 +51,23 @@ confluence/
      - `read:page:confluence`
      - `write:page:confluence`
      - `offline_access` (for refresh tokens)
+5. Open **Distribution** and enable sharing. An OAuth 2.0 (3LO) app is private
+   when created, so only the account that owns it can authorize. Atlassian will
+   not save the toggle until **Vendor** and **Privacy policy** are filled in
+   (plus **Terms of service** where it asks for one).
+
+   Leave sharing off and every other user reaches Atlassian, picks their site,
+   and gets Atlassian's own "Something went wrong" page. The flow never reaches
+   your callback, so nothing appears in the deployment's logs.
+
+   Test with any Atlassian account other than the app owner's. A private app is
+   restricted to the owning **account**, not the owning organization, so a
+   colleague in the same organization fails too. The owner's own account
+   succeeds either way, so testing with it proves nothing.
+
+   Sharing is a property of the app. If the same app also serves the Jira
+   connector, enabling it once covers both — but each connector still needs its
+   own callback URL and scopes.
 
 ### 2. Configure Environment Variables
 

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -649,9 +649,12 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "read:jira-user",
       "ATLASSIAN_CLIENT_ID",
       "JIRA_CLOUD_ID",
-      // A 3LO app is private until sharing is enabled, and the failure is invisible in our
-      // logs because the flow dies on Atlassian's page. Pinned so a later edit cannot drop it.
+      // A 3LO app is private until sharing is enabled, and the failure is invisible in the
+      // deployment's logs because the flow dies on Atlassian's page. These three pin the step
+      // and the two corrections that were needed, so none can silently regress.
       "Distribution",
+      "Privacy policy",
+      "owning **account**",
     ],
   },
   "guides/integrations/salesforce.md": {

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -649,6 +649,9 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "read:jira-user",
       "ATLASSIAN_CLIENT_ID",
       "JIRA_CLOUD_ID",
+      // A 3LO app is private until sharing is enabled, and the failure is invisible in our
+      // logs because the flow dies on Atlassian's page. Pinned so a later edit cannot drop it.
+      "Distribution",
     ],
   },
   "guides/integrations/salesforce.md": {


### PR DESCRIPTION
The self-hosted Jira setup guide covers the callback URL and the four scopes but
never mentions **Distribution**, which is the step that decides whether anyone
other than the app owner can connect.

Per [Atlassian's OAuth 2.0 (3LO) docs](https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/):

> When you create an OAuth 2.0 (3LO) app it's private by default. This means that
> only you can install and use it. If you want to distribute your app to other
> users, you must enable sharing.

Leaving it off fails in a way that is easy to misdiagnose. The user reaches
Atlassian, picks their site, and gets Atlassian's own "Something went wrong"
page. The flow never reaches the deployment's callback, so there is nothing in
its logs to look at. And the app owner's own account connects either way, so
testing with it proves nothing — which is the trap the added step calls out
explicitly.

Docs only; no code or connector changes.