### PR TITLE
docs(providers): document custom endpoints, platform token, and secret managers

### DIFF
--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -29,6 +29,13 @@ Run `veryfront login`, then Push the project once to create its local project
 link. `veryfront dev` and `veryfront eval` load the stored login and linked
 project automatically.
 
+To authenticate without an interactive browser (CI, a container, a remote
+shell), set `VERYFRONT_API_TOKEN` instead. The environment variable takes
+precedence over a stored login, so it also works as a temporary override on a
+machine that is already signed in. `veryfront whoami` reports which credential
+is active. This is a separate credential from a model provider key: it selects
+the AI Gateway, it does not authenticate you to a vendor.
+
 Model selection follows these rules:
 
 | Agent model                            | With Cloud context                                  | With a matching direct provider key                      |
@@ -104,7 +111,30 @@ ANTHROPIC_API_KEY="op://Private/Anthropic API/credential"
 op run --env-file=.env.local -- veryfront dev
 ```
 
-Veryfront never overwrites a variable that is already set, so the resolved value wins over anything in a `.env` file. Wrap once in a package script or a `.envrc` rather than per command. The same pattern works with `doppler run`, `infisical run`, and `vault`.
+Veryfront never overwrites a variable that is already set, so the resolved value wins over the `op://` reference sitting in the file.
+
+Wrap once rather than per command:
+
+```json
+{
+  "scripts": {
+    "dev": "op run --env-file=.env.local -- veryfront dev",
+    "eval": "op run --env-file=.env.local -- veryfront eval"
+  }
+}
+```
+
+A `.envrc` with [direnv](https://direnv.net) covers every command in the directory, including ones started by an editor. The same pattern works with other managers:
+
+```bash
+doppler run -- veryfront dev
+infisical run -- veryfront dev
+envconsul -secret secret/veryfront -- veryfront dev   # HashiCorp Vault
+```
+
+Veryfront does not resolve `op://` or similar references itself. An unresolved reference is treated as a literal value and reaches the provider as an invalid key, so run the wrapper rather than the bare command.
+
+The same applies to `VERYFRONT_API_TOKEN` if you keep the platform credential in a manager too.
 
 If you would rather not manage a provider key at all, use the [Veryfront Cloud AI Gateway](#veryfront-cloud-ai-gateway) instead.
 
@@ -233,6 +263,18 @@ OPENAI_BASE_URL=https://openrouter.ai/api/v1
 ```
 
 Both `apiKey` and `baseURL` are resolved per-request, so each project in a multi-tenant setup can have its own configuration.
+
+Anthropic and Mistral take the same treatment, for a self-hosted deployment or
+a gateway in front of the vendor:
+
+| Provider  | Base URL variable        | Default                                            |
+| --------- | ------------------------ | -------------------------------------------------- |
+| OpenAI    | `OPENAI_BASE_URL`        | `https://api.openai.com/v1`                        |
+| Anthropic | `ANTHROPIC_BASE_URL`     | `https://api.anthropic.com/v1`                     |
+| Mistral   | `MISTRAL_BASE_URL`       | `https://api.mistral.ai/v1`                        |
+| Google    | `GOOGLE_GEMINI_BASE_URL` | `https://generativelanguage.googleapis.com/v1beta` |
+
+Include the API version segment in the value, matching the defaults above.
 
 For local chat development, use Ollama or LM Studio. Both keep model loading and
 hardware management outside the Veryfront app process.


### PR DESCRIPTION
Docs only. Rebased onto main after #3874 and #3876, so this is a single-file change.

Also addresses the P1 documentation finding on #3876, which asked for `GOOGLE_GEMINI_BASE_URL` to appear in the direct-provider docs.

## Three gaps, all in `docs/guides/providers.md`

**1. Custom endpoints for Anthropic and Mistral were undocumented.** Both reach the runtime today — `src/provider/model-registry.ts` passes them to `createModel` and to `createOriginBoundOutboundFetch` — but only `OPENAI_BASE_URL` appeared in the guide. Google's endpoint is not configurable at all, which was also unstated.

| Provider | Base URL variable | Default |
| --- | --- | --- |
| OpenAI | `OPENAI_BASE_URL` | `https://api.openai.com/v1` |
| Anthropic | `ANTHROPIC_BASE_URL` | `https://api.anthropic.com/v1` |
| Mistral | `MISTRAL_BASE_URL` | `https://api.mistral.ai/v1` |
| Google | `GOOGLE_GEMINI_BASE_URL` | `https://generativelanguage.googleapis.com/v1beta` |

Added next to the existing OpenAI-compatible section, with a note that a base URL carries the API version segment — matching `provider-endpoints.ts` and the existing `OPENAI_BASE_URL` examples. This covers self-hosted deployments and gateways; LM Studio and Ollama already have full setup sections further down.

**2. `VERYFRONT_API_TOKEN` had no mention outside the CI and cloud-access guides.** Nothing said how to reach the AI Gateway without an interactive browser, or that the variable takes precedence over a stored login. Documented in the AI Gateway section, since that is the inference path the token selects, along with the fact that it is a *separate* credential from a model provider key — configuring one does not configure the other.

**3. The secret-manager section gains the wrap-once form**, a corrected Vault reference (`envconsul`, since `vault exec` is not a real command), and a warning that an unresolved `op://` reference is treated as a literal and reaches the provider as an invalid key.

```bash
op run --env-file=.env.local -- veryfront dev
```

## Why not a separate authentication guide

I drafted one and dropped it. Of ~126 lines, only 16 were about the platform token; the rest — provider keys, secret managers, base URLs, local servers — are topics `providers.md` already owns through "Direct providers", "OpenAI-compatible services", "Ollama", and "LM Studio". A second page duplicated `OPENAI_BASE_URL`, the local-server SSRF opt-in, and the LM Studio port example, and left two places to keep in sync. The platform-token content attaches naturally to the AI Gateway section instead.

## Verification

`fmt:check`, `docs:public:check`, and `docs:validate` pass. No source changes.
