### PR TITLE
fix(provider): close the GOOGLE_GEMINI_BASE_URL gaps found after #3876

### DIFF
--- a/extensions/ext-llm-google/README.md
+++ b/extensions/ext-llm-google/README.md
@@ -18,10 +18,11 @@ export default defineConfig({
 
 ## Environment Variables
 
-| Variable                       | Required | Description                                                                    |
-| ------------------------------ | -------- | ------------------------------------------------------------------------------ |
-| `GOOGLE_API_KEY`               | Yes      | Your Google AI API key (from [AI Studio](https://aistudio.google.com/apikey)). |
-| `GOOGLE_GENERATIVE_AI_API_KEY` | No       | Alternative name for the API key (checked as fallback).                        |
+| Variable                       | Required | Description                                                                                                                                     |
+| ------------------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GOOGLE_API_KEY`               | Yes      | Your Google AI API key (from [AI Studio](https://aistudio.google.com/apikey)).                                                                  |
+| `GOOGLE_GEMINI_BASE_URL`       | No       | Custom Gemini endpoint (proxy or regional). Include the API version segment, e.g. `https://example.com/v1beta`. Applies to chat and embeddings. |
+| `GOOGLE_GENERATIVE_AI_API_KEY` | No       | Alternative name for the API key (checked as fallback).                                                                                         |
 
 ## Usage
 

--- a/src/embedding/embedding.test.ts
+++ b/src/embedding/embedding.test.ts
@@ -13,6 +13,7 @@ describe("embedding", () => {
     globalThis.fetch = originalFetch;
     deleteEnv("GOOGLE_API_KEY");
     deleteEnv("GOOGLE_GENERATIVE_AI_API_KEY");
+    deleteEnv("GOOGLE_GEMINI_BASE_URL");
     clearEmbeddingProviders();
   });
 
@@ -98,5 +99,31 @@ describe("embedding", () => {
     assertEquals(guardedCalls, 1);
     assertEquals(replacedGlobalCalls, 0);
     assertEquals(requestedApiKey, "google-test-key");
+  });
+
+  it("sends Google embedding requests to GOOGLE_GEMINI_BASE_URL", async () => {
+    // The chat path is covered in model-registry.test.ts. Embeddings resolve
+    // through a separate registration in embedding/resolve.ts, which had the
+    // same hardcoded endpoint, so it needs its own assertion.
+    ensureBuiltinLLMProviders();
+    setEnv("GOOGLE_API_KEY", "google-test-key");
+    setEnv("GOOGLE_GEMINI_BASE_URL", "https://example.com/gemini/v1beta");
+    let requestedUrl = "";
+
+    globalThis.fetch = (async (input: URL | Request | string, init?: RequestInit) => {
+      requestedUrl = new Request(input, init).url;
+      return Response.json({
+        embedding: { values: [0.5] },
+        usageMetadata: { promptTokenCount: 1 },
+      });
+    }) as typeof fetch;
+
+    const embedder = embedding({ model: "google/gemini-embedding-001" });
+    assertEquals(await embedder.embed("hello"), [0.5]);
+    assertEquals(
+      requestedUrl.startsWith("https://example.com/gemini/v1beta/"),
+      true,
+      requestedUrl,
+    );
   });
 });

--- a/tests/bun/run-tests.mjs
+++ b/tests/bun/run-tests.mjs
@@ -179,6 +179,7 @@ for (
     "ANTHROPIC_BASE_URL",
     "GOOGLE_API_KEY",
     "GOOGLE_GENERATIVE_AI_API_KEY",
+    "GOOGLE_GEMINI_BASE_URL",
   ]
 ) {
   delete env[key];

--- a/tests/node/run-tests.mjs
+++ b/tests/node/run-tests.mjs
@@ -111,6 +111,7 @@ for (
     "ANTHROPIC_BASE_URL",
     "GOOGLE_API_KEY",
     "GOOGLE_GENERATIVE_AI_API_KEY",
+    "GOOGLE_GEMINI_BASE_URL",
   ]
 ) {
   delete env[key];


### PR DESCRIPTION
Three review findings landed on #3876 after it had already merged. All three verified against `main` before fixing.

## 1. Undiscoverable from the extension README (Codex, P1)

`extensions/ext-llm-google/README.md` has an environment-variable table listing only `GOOGLE_API_KEY`. A Google user reads that first, so the new endpoint was invisible there. Adds the row, noting the API version segment and that it applies to chat *and* embeddings.

The other half of that finding — the direct-provider docs — is #3875, which now documents `GOOGLE_GEMINI_BASE_URL` in the providers guide.

## 2. Not scrubbed in the test runners (Codex, P2)

`tests/node/run-tests.mjs` and `tests/bun/run-tests.mjs` both delete every provider key and base URL before a run, so tests get a deterministic environment. The new variable was on neither list.

A developer with `GOOGLE_GEMINI_BASE_URL` exported in their shell would have Google tests target that endpoint instead of the default — failing for a reason unrelated to whatever they were testing. Added to both lists.

## 3. Embedding path untested (CodeRabbit, Major)

Embeddings resolve through a separate registration in `src/embedding/resolve.ts`, which carried the same hardcoded endpoint as the chat path. #3876 fixed both but only tested chat.

Adds a mocked-fetch test asserting `google/gemini-embedding-001` requests reach the configured base URL, plus `GOOGLE_GEMINI_BASE_URL` in that suite's `afterEach` cleanup.

**Verified the test is not vacuous:** reverting the `resolve.ts` fix makes it fail.

## Noticed, deliberately not fixed here

Neither runner scrubs `MISTRAL_API_KEY` or `MISTRAL_BASE_URL`, so the same class of interference exists for Mistral. It predates this work and isn't what this change touches — worth a separate cleanup.

## Verification

78 tests pass across `src/embedding`, `src/provider`, `src/config`. `fmt:check`, `lint`, and `docs:public:check` green.
