### PR TITLE
fix(workflow): stop a loop node deleting its siblings' node states

### DIFF
--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -962,6 +962,93 @@ describe("DAGExecutor", () => {
     });
   });
 
+  describe("loop node sibling isolation", () => {
+    it("does not re-execute a step declared before the loop", async () => {
+      const executed: string[] = [];
+      const trackingExecutor = new MockStepExecutor(new Map(), (node) => {
+        executed.push(node.id);
+        return { success: true, output: node.id, executionTime: 1 };
+      });
+      const exec = new DAGExecutor({ stepExecutor: trackingExecutor });
+
+      const nodes: WorkflowNode[] = [
+        { id: "before", dependsOn: [], config: { type: "step" } as any },
+        {
+          id: "the-loop",
+          dependsOn: ["before"],
+          config: {
+            type: "loop",
+            maxIterations: 2,
+            while: (_context: WorkflowContext, loop: LoopExecutionContext) => loop.iteration < 2,
+            steps: [{ id: "inner", config: { type: "step" } as any }],
+          } as any,
+        },
+        { id: "after", dependsOn: ["the-loop"], config: { type: "step" } as any },
+      ];
+
+      const result = await exec.execute(nodes, createTestRun());
+
+      assertEquals(result.completed, true);
+      // A loop iteration patches the parent's node states against its own child
+      // graph only. Diffing that against the parent map would report every
+      // completed sibling as deleted, which re-schedules them.
+      assertEquals(executed.filter((id) => id === "before").length, 1);
+      assertEquals(executed, ["before", "inner", "inner", "after"]);
+    });
+
+    it("keeps a preceding sibling's node state after the loop completes", async () => {
+      const nodes: WorkflowNode[] = [
+        { id: "before", dependsOn: [], config: { type: "step" } as any },
+        {
+          id: "the-loop",
+          dependsOn: ["before"],
+          config: {
+            type: "loop",
+            maxIterations: 1,
+            while: (_context: WorkflowContext, loop: LoopExecutionContext) => loop.iteration < 1,
+            steps: [{ id: "inner", config: { type: "step" } as any }],
+          } as any,
+        },
+      ];
+
+      const result = await executor.execute(nodes, createTestRun());
+
+      assertEquals(result.completed, true);
+      assertExists(result.nodeStates["before"]);
+      assertEquals(result.nodeStates["before"]!.status, "completed");
+      assertExists(result.nodeStates["inner"]);
+    });
+
+    it("keeps a preceding sibling's node state when the loop suspends on a wait", async () => {
+      const nodes: WorkflowNode[] = [
+        { id: "before", dependsOn: [], config: { type: "step" } as any },
+        {
+          id: "the-loop",
+          dependsOn: ["before"],
+          config: {
+            type: "loop",
+            maxIterations: 2,
+            while: () => true,
+            steps: [
+              { id: "inner", dependsOn: [], config: { type: "step" } as any },
+              {
+                id: "inner-wait",
+                dependsOn: ["inner"],
+                config: { type: "wait", waitType: "approval", message: "approve?" } as any,
+              },
+            ],
+          } as any,
+        },
+      ];
+
+      const result = await executor.execute(nodes, createTestRun());
+
+      assertEquals(result.waiting, true);
+      assertExists(result.nodeStates["before"]);
+      assertEquals(result.nodeStates["before"]!.status, "completed");
+    });
+  });
+
   describe("loop resume (H9)", () => {
     it("should not re-run completed steps of an in-flight loop iteration on resume", async () => {
       let incrRuns = 0;

--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -1047,6 +1047,32 @@ describe("DAGExecutor", () => {
       assertExists(result.nodeStates["before"]);
       assertEquals(result.nodeStates["before"]!.status, "completed");
     });
+
+    it("removes child node states from previous dynamic loop iterations", async () => {
+      const nodes: WorkflowNode[] = [
+        {
+          id: "the-loop",
+          config: {
+            type: "loop",
+            maxIterations: 2,
+            while: (_context: WorkflowContext, loop: LoopExecutionContext) => loop.iteration < 2,
+            steps: (_context: WorkflowContext, loop: LoopExecutionContext) => [
+              {
+                id: loop.iteration === 0 ? "old-child" : "current-child",
+                config: { type: "step" } as any,
+              },
+            ],
+          } as any,
+        },
+      ];
+
+      const result = await executor.execute(nodes, createTestRun());
+
+      assertEquals(result.completed, true);
+      assertEquals(result.nodeStates["old-child"], undefined);
+      assertExists(result.nodeStates["current-child"]);
+      assertEquals(result.nodeStates["current-child"]!.status, "completed");
+    });
   });
 
   describe("loop resume (H9)", () => {

--- a/src/workflow/executor/dag/loop-node-strategy.ts
+++ b/src/workflow/executor/dag/loop-node-strategy.ts
@@ -109,7 +109,11 @@ export async function executeLoopNodeStrategy(
     runtime.abortSignal?.throwIfAborted();
 
     if (result.waiting) {
-      applyRecordPatch(nodeStates, createRecordPatch(nodeStates, result.nodeStates));
+      // Diff the iteration against its own starting state, never against the
+      // parent's map. `result.nodeStates` holds this iteration's children only,
+      // so diffing the parent against it reports every completed sibling as
+      // deleted -- which removes their state and gets them re-scheduled.
+      applyRecordPatch(nodeStates, createRecordPatch(iterationNodeStates, result.nodeStates));
 
       const state: NodeState = {
         nodeId: node.id,
@@ -145,7 +149,7 @@ export async function executeLoopNodeStrategy(
 
     previousResults.push(result.context);
     applyContextPatch(context, result.contextPatch);
-    applyRecordPatch(nodeStates, createRecordPatch(nodeStates, result.nodeStates));
+    applyRecordPatch(nodeStates, createRecordPatch(iterationNodeStates, result.nodeStates));
 
     if (config.delay && iteration < config.maxIterations - 1) {
       const delayMs = typeof config.delay === "number" ? config.delay : parseDuration(config.delay);

--- a/src/workflow/executor/dag/loop-node-strategy.ts
+++ b/src/workflow/executor/dag/loop-node-strategy.ts
@@ -62,6 +62,10 @@ export async function executeLoopNodeStrategy(
     resumeIteration = existingLoopState.iteration;
   }
 
+  let exposedIterationNodeStates: Record<string, NodeState> = resumeIterationNodeStates
+    ? { ...resumeIterationNodeStates }
+    : {};
+
   while (iteration < config.maxIterations) {
     runtime.abortSignal?.throwIfAborted();
     const loopContext: LoopExecutionContext = {
@@ -113,7 +117,10 @@ export async function executeLoopNodeStrategy(
       // parent's map. `result.nodeStates` holds this iteration's children only,
       // so diffing the parent against it reports every completed sibling as
       // deleted -- which removes their state and gets them re-scheduled.
-      applyRecordPatch(nodeStates, createRecordPatch(iterationNodeStates, result.nodeStates));
+      applyRecordPatch(
+        nodeStates,
+        createRecordPatch(exposedIterationNodeStates, result.nodeStates),
+      );
 
       const state: NodeState = {
         nodeId: node.id,
@@ -149,7 +156,8 @@ export async function executeLoopNodeStrategy(
 
     previousResults.push(result.context);
     applyContextPatch(context, result.contextPatch);
-    applyRecordPatch(nodeStates, createRecordPatch(iterationNodeStates, result.nodeStates));
+    applyRecordPatch(nodeStates, createRecordPatch(exposedIterationNodeStates, result.nodeStates));
+    exposedIterationNodeStates = { ...result.nodeStates };
 
     if (config.delay && iteration < config.maxIterations - 1) {
       const delayMs = typeof config.delay === "number" ? config.delay : parseDuration(config.delay);


### PR DESCRIPTION
## Description

A `loop` node deletes the persisted node state of every sibling that completed before it. Those nodes return to `pending`, the DAG executor re-schedules them, and they **execute a second time**. Nothing throws and the run reports `completed`.

For a workflow whose pre-loop steps have side effects, this is a repeated real-world action.

### Root cause

`loop-node-strategy.ts` patched the parent's node states with:

```ts
applyRecordPatch(nodeStates, createRecordPatch(nodeStates, result.nodeStates));
```

- `nodeStates` (the "before" side) is the **parent's** map, holding every completed sibling.
- `result.nodeStates` (the "after" side) is the **loop iteration's child graph only**, seeded from `{}`.

`createRecordPatch` emits every key present in "before" and absent from "after" as a deletion, so the parent's siblings are collateral. The deletion then propagates outward through `dag/index.ts`, which diffs the node's snapshot against its batch baseline and applies the same removal to the live run map.

`map-node-strategy.ts` performs the identical diff and is unaffected only because it seeds its child graph from the parent's `nodeStates`, making "after" a superset. A loop genuinely needs fresh per-iteration child state, so the fix belongs on the diff rather than the seed.

### Fix

Diff each iteration against its own starting state (`iterationNodeStates`). Applied to both the completed-iteration path and the waiting path.

### Why the final state map looked healthy

The re-executed node repopulates its own entry, so `nodeStates` ends up complete. Only execution counts reveal the defect — which is why one of the three added tests (`keeps a preceding sibling's node state after the loop completes`) passes even without the fix. It is retained as a companion assertion; the two meaningful regression tests are the execution-count test and the waiting-path test.

### Evidence

Before:

```
does not re-execute a step declared before the loop ......... FAILED
  Actual: 2   Expected: 1
keeps sibling state when the loop suspends on a wait ........ FAILED
  Expected actual: "undefined" to not be null or undefined

execution order: before -> inner -> inner -> before -> after
```

After — `src/workflow/executor/dag/`, `dag-executor`, `workflow-executor`, `checkpoint-manager`:

```
ok | 4 passed (116 steps) | 0 failed
```

Full suite passes at push (`3952 passed`). The existing `loop resume (H9)` coverage still passes, which exercises the waiting path this change touches.

## Related Issue(s)

Tracked internally. No linked public issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have added tests that prove my fix is effective
- [x] Existing tests pass locally
- [ ] Documentation changes (not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loop execution so previously completed sibling steps are not re-run.
  * Preserved the state of completed sibling steps after loop completion.
  * Preserved sibling step state when a loop pauses at a wait step.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->