### PR TITLE
fix(workflow): report the node that actually suspended, not its composite

### DIFF
--- a/scripts/lint/test-typecheck-baseline.json
+++ b/scripts/lint/test-typecheck-baseline.json
@@ -45,6 +45,5 @@
   "src/server/build-service-worker.test.ts",
   "src/transforms/import-rewriter/strategies/import-map-strategy.test.ts",
   "src/transforms/mdx/compiler/index.test.ts",
-  "src/transforms/mdx/esm-module-loader/loader.test.ts",
-  "src/workflow/api/workflow-client.test.ts"
+  "src/transforms/mdx/esm-module-loader/loader.test.ts"
 ]

--- a/src/workflow/api/workflow-client.test.ts
+++ b/src/workflow/api/workflow-client.test.ts
@@ -13,6 +13,7 @@ import { MemoryBackend } from "../backends/memory.ts";
 import { dependsOn, workflow } from "../dsl/workflow.ts";
 import { step } from "../dsl/step.ts";
 import { branch } from "../dsl/branch.ts";
+import { subWorkflow } from "../dsl/sub-workflow.ts";
 import { waitForApproval } from "../dsl/wait.ts";
 import type { PendingApproval, WorkflowRun } from "../types.ts";
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
@@ -83,6 +84,32 @@ describe("WorkflowClient", () => {
           condition: () => true,
           then: [waitForApproval("nested-review", { message: "Please review" })],
         }),
+        dependsOn(
+          step("publish", {
+            tool: createMockTool("publish-after-nested-approval", { published: true }),
+          }),
+          "review-gate",
+        ),
+      ],
+    });
+
+    const subWorkflowApprovalWorkflow = workflow({
+      id: "sub-workflow-nested-approval-workflow",
+      steps: [
+        subWorkflow("child-workflow", {
+          workflow: workflow({
+            id: "child-approval-workflow",
+            steps: [
+              waitForApproval("child-review", { message: "Review child workflow" }),
+            ],
+          }).definition,
+        }),
+        dependsOn(
+          step("publish-child", {
+            tool: createMockTool("publish-after-sub-workflow-approval", { published: "child" }),
+          }),
+          "child-workflow",
+        ),
       ],
     });
 
@@ -118,6 +145,45 @@ describe("WorkflowClient", () => {
       await client.approve(handle.runId, approval.id, "reviewer");
 
       assertEquals(await backend.getPendingApprovals(handle.runId), []);
+      const run = await backend.getRun(handle.runId);
+      assertExists(run);
+      assertEquals(run.status, "completed");
+      assertEquals(run.nodeStates["review-gate"]!.status, "completed");
+      assertEquals(run.nodeStates["publish"]!.status, "completed");
+      const output = run.output as Record<string, unknown>;
+      assertEquals(output.publish, { published: true });
+      assertEquals(
+        (output["review-gate/then/nested-review"] as { approved?: boolean }).approved,
+        true,
+      );
+    });
+
+    it("creates and resolves a pending approval nested in a sub-workflow", async () => {
+      client.register(subWorkflowApprovalWorkflow);
+
+      const handle = await client.start("sub-workflow-nested-approval-workflow", {});
+      await handle.settled();
+
+      const waitingRun = await backend.getRun(handle.runId);
+      assertExists(waitingRun);
+      assertEquals(waitingRun.status, "waiting");
+      assertEquals(waitingRun.currentNodes, ["child-review"]);
+
+      const [approval] = await backend.getPendingApprovals(handle.runId);
+      assertExists(approval);
+      assertEquals(approval.nodeId, "child-review");
+      assertEquals(approval.message, "Review child workflow");
+
+      await client.approve(handle.runId, approval.id, "reviewer");
+
+      assertEquals(await backend.getPendingApprovals(handle.runId), []);
+      const run = await backend.getRun(handle.runId);
+      assertExists(run);
+      assertEquals(run.status, "completed");
+      assertEquals(run.nodeStates["child-workflow"]!.status, "completed");
+      assertEquals(run.nodeStates["publish-child"]!.status, "completed");
+      const output = run.output as Record<string, unknown>;
+      assertEquals(output["publish-child"], { published: "child" });
     });
   });
 
@@ -257,7 +323,7 @@ describe("WorkflowClient", () => {
         type: "function",
         description: "Capture workflow tool context",
         inputSchema: defineSchema((v) => v.object({}).passthrough())(),
-        execute: (_input, context) => {
+        execute: async (_input, context) => {
           capturedContext = context;
           return {
             projectSlug: context?.projectSlug,

--- a/src/workflow/api/workflow-client.test.ts
+++ b/src/workflow/api/workflow-client.test.ts
@@ -12,6 +12,7 @@ import { createWorkflowClient, WorkflowClient } from "./workflow-client.ts";
 import { MemoryBackend } from "../backends/memory.ts";
 import { dependsOn, workflow } from "../dsl/workflow.ts";
 import { step } from "../dsl/step.ts";
+import { branch } from "../dsl/branch.ts";
 import { waitForApproval } from "../dsl/wait.ts";
 import type { PendingApproval, WorkflowRun } from "../types.ts";
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
@@ -70,6 +71,54 @@ describe("WorkflowClient", () => {
 
   afterEach(async () => {
     await client.destroy();
+  });
+
+  describe("nested approval", () => {
+    // The module docstring on veryfront/workflow documents exactly this shape:
+    // a waitForApproval inside a branch.
+    const nestedApprovalWorkflow = workflow({
+      id: "nested-approval-workflow",
+      steps: [
+        branch("review-gate", {
+          condition: () => true,
+          then: [waitForApproval("nested-review", { message: "Please review" })],
+        }),
+      ],
+    });
+
+    it("creates a pending approval for a wait nested in a branch", async () => {
+      client.register(nestedApprovalWorkflow);
+
+      const handle = await client.start("nested-approval-workflow", {});
+      await handle.settled();
+
+      const run = await backend.getRun(handle.runId);
+      assertExists(run);
+      assertEquals(run.status, "waiting");
+
+      // Branch children are qualified with their arm, and the approval is keyed
+      // by that same id -- reporting the enclosing branch instead produced no
+      // approval at all.
+      const approvals = await backend.getPendingApprovals(handle.runId);
+      assertEquals(approvals.length, 1);
+      assertEquals(approvals[0]!.nodeId, "review-gate/then/nested-review");
+      assertEquals(approvals[0]!.message, "Please review");
+      assertEquals(run.currentNodes, ["review-gate/then/nested-review"]);
+    });
+
+    it("resolves a nested approval and lets the run continue", async () => {
+      client.register(nestedApprovalWorkflow);
+
+      const handle = await client.start("nested-approval-workflow", {});
+      await handle.settled();
+
+      const [approval] = await backend.getPendingApprovals(handle.runId);
+      assertExists(approval);
+
+      await client.approve(handle.runId, approval.id, "reviewer");
+
+      assertEquals(await backend.getPendingApprovals(handle.runId), []);
+    });
   });
 
   describe("register()", () => {

--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -769,15 +769,18 @@ describe("DAGExecutor", () => {
       });
       const first = await exec.execute(nodes, run);
       assertEquals(first.waiting, true);
-      // The composite node is the waiting node reported to the executor.
-      assertEquals(first.waitingNode, "par1");
+      // The node that actually suspended is reported, not its enclosing
+      // composite -- an approval is built from that node's `input`.
+      assertEquals(first.waitingNode, "p-wait");
       assertEquals(stepARuns, 1);
       assertEquals(first.nodeStates["p-step"]!.status, "completed");
       assertEquals(Object.hasOwn(first.context, "removed"), false);
 
       // Resume: mark the wait node completed (approval granted) and re-run with
-      // the accumulated nodeStates from the first run. The real executor resumes
-      // by passing the waiting node id as startFromNode.
+      // the accumulated nodeStates from the first run. The real executor derives
+      // startFromNode from the checkpoint (CheckpointManager.findNextNode scans
+      // the top-level nodes), so it is always a top-level id -- never the
+      // reported waiting node.
       const resumedStates = {
         ...first.nodeStates,
         "p-wait": {
@@ -962,6 +965,80 @@ describe("DAGExecutor", () => {
     });
   });
 
+  describe("nested wait reporting", () => {
+    const nestedWait = {
+      id: "inner-wait",
+      config: { type: "wait", waitType: "approval", message: "approve?" } as any,
+    };
+
+    it("reports the inner node when a wait is nested in a branch", async () => {
+      const nodes: WorkflowNode[] = [
+        {
+          id: "gate",
+          dependsOn: [],
+          config: {
+            type: "branch",
+            condition: () => true,
+            then: [nestedWait],
+          } as any,
+        },
+      ];
+
+      const result = await executor.execute(nodes, createTestRun());
+
+      assertEquals(result.waiting, true);
+      // The approval is built from nodeStates[waitingNode].input, and a
+      // composite's state carries no input -- so reporting the composite means
+      // no approval is ever created.
+      assertEquals(result.waitingNode, "inner-wait");
+      assertExists(result.nodeStates["inner-wait"]!.input);
+    });
+
+    it("reports the inner node when a wait is nested in a parallel", async () => {
+      const nodes: WorkflowNode[] = [
+        {
+          id: "group",
+          dependsOn: [],
+          config: { type: "parallel", nodes: [nestedWait] } as any,
+        },
+      ];
+
+      const result = await executor.execute(nodes, createTestRun());
+
+      assertEquals(result.waiting, true);
+      assertEquals(result.waitingNode, "inner-wait");
+    });
+
+    it("reports the inner node when a wait is nested in a sub-workflow", async () => {
+      const nodes: WorkflowNode[] = [
+        {
+          id: "sub",
+          dependsOn: [],
+          config: {
+            type: "subWorkflow",
+            workflow: { id: "child", steps: [nestedWait] },
+          } as any,
+        },
+      ];
+
+      const result = await executor.execute(nodes, createTestRun());
+
+      assertEquals(result.waiting, true);
+      assertEquals(result.waitingNode, "inner-wait");
+    });
+
+    it("still reports a top-level wait as itself", async () => {
+      const nodes: WorkflowNode[] = [
+        { id: "top-wait", dependsOn: [], config: nestedWait.config },
+      ];
+
+      const result = await executor.execute(nodes, createTestRun());
+
+      assertEquals(result.waiting, true);
+      assertEquals(result.waitingNode, "top-wait");
+    });
+  });
+
   describe("loop resume (H9)", () => {
     it("should not re-run completed steps of an in-flight loop iteration on resume", async () => {
       let incrRuns = 0;
@@ -995,7 +1072,7 @@ describe("DAGExecutor", () => {
       const run = createTestRun();
       const first = await exec.execute(nodes, run);
       assertEquals(first.waiting, true);
-      assertEquals(first.waitingNode, "loop1");
+      assertEquals(first.waitingNode, "l-wait");
       assertEquals(incrRuns, 1);
       assertEquals(first.nodeStates["l-incr"]!.status, "completed");
 

--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -1025,6 +1025,7 @@ describe("DAGExecutor", () => {
 
       assertEquals(result.waiting, true);
       assertEquals(result.waitingNode, "inner-wait");
+      assertExists(result.nodeStates["inner-wait"]!.input);
     });
 
     it("still reports a top-level wait as itself", async () => {
@@ -1036,6 +1037,53 @@ describe("DAGExecutor", () => {
 
       assertEquals(result.waiting, true);
       assertEquals(result.waitingNode, "top-wait");
+    });
+
+    it("re-enters an enclosing composite after a nested wait is approved", async () => {
+      const order: string[] = [];
+      const trackingExecutor = new MockStepExecutor(new Map(), (node) => {
+        order.push(node.id);
+        return { success: true, output: node.id, executionTime: 1 };
+      });
+      const exec = new DAGExecutor({ stepExecutor: trackingExecutor });
+      const nodes: WorkflowNode[] = [
+        {
+          id: "gate",
+          dependsOn: [],
+          config: {
+            type: "branch",
+            condition: () => true,
+            then: [nestedWait],
+          } as any,
+        },
+        { id: "after", config: { type: "step" } as any },
+      ];
+
+      const first = await exec.execute(nodes, createTestRun());
+      assertEquals(first.waiting, true);
+      assertEquals(first.waitingNode, "inner-wait");
+      assertEquals(first.nodeStates["gate"]!.status, "running");
+
+      const second = await exec.execute(
+        nodes,
+        createTestRun({
+          status: "waiting",
+          nodeStates: {
+            ...first.nodeStates,
+            "inner-wait": {
+              ...first.nodeStates["inner-wait"]!,
+              status: "completed",
+              completedAt: new Date(),
+            },
+          },
+          context: first.context,
+        }),
+      );
+
+      assertEquals(second.completed, true);
+      assertEquals(order, ["after"]);
+      assertEquals(second.nodeStates["gate"]!.status, "completed");
+      assertEquals(second.nodeStates["after"]!.status, "completed");
     });
   });
 

--- a/src/workflow/executor/dag/index.ts
+++ b/src/workflow/executor/dag/index.ts
@@ -204,7 +204,9 @@ export class DAGExecutor {
         nodeStates[nodeId] = nodeResult.state;
 
         if (nodeResult.waiting) {
-          if (!outcome) outcome = { kind: "waiting", nodeId };
+          // A composite reports the child that actually suspended. Falling back
+          // to this node covers a top-level wait, which is its own waiting node.
+          if (!outcome) outcome = { kind: "waiting", nodeId: nodeResult.waitingNode ?? nodeId };
           continue;
         }
 
@@ -545,6 +547,7 @@ export class DAGExecutor {
       state,
       contextPatch: result.contextPatch,
       waiting: result.waiting,
+      waitingNode: result.waitingNode,
     };
   }
 
@@ -622,6 +625,7 @@ export class DAGExecutor {
       state,
       contextPatch: result.contextPatch,
       waiting: result.waiting,
+      waitingNode: result.waitingNode,
     };
   }
 
@@ -739,6 +743,7 @@ export class DAGExecutor {
       state,
       contextPatch: createSetContextPatch(result.completed ? { [node.id]: finalOutput } : {}),
       waiting: result.waiting,
+      waitingNode: result.waitingNode,
     };
   }
 

--- a/src/workflow/executor/dag/index.ts
+++ b/src/workflow/executor/dag/index.ts
@@ -56,6 +56,8 @@ import {
   mergeContextPatches,
 } from "./context-patch.ts";
 
+const RESUMABLE_COMPOSITE_TYPES = new Set(["branch", "parallel", "map", "loop", "subWorkflow"]);
+
 export class DAGExecutor {
   private config: DAGExecutorInternalConfig;
 
@@ -116,6 +118,18 @@ export class DAGExecutor {
     }
 
     let ready = startFromNode ? [startFromNode] : getReadyNodes(inDegree, nodeStates);
+    if (!startFromNode && run.status === "waiting") {
+      for (const [nodeId, degree] of inDegree) {
+        if (degree !== 0 || ready.includes(nodeId)) continue;
+        const state = nodeStates[nodeId];
+        const node = nodeMap.get(nodeId);
+        if (
+          state?.status === "running" && node && RESUMABLE_COMPOSITE_TYPES.has(node.config.type)
+        ) {
+          ready.push(nodeId);
+        }
+      }
+    }
 
     while (ready.length > 0) {
       abortSignal?.throwIfAborted();
@@ -423,7 +437,15 @@ export class DAGExecutor {
           parentSignal: abortSignal,
           cancellationGracePeriod: this.config.cancellationGracePeriod,
           execute: (attemptSignal) =>
-            this.executeSubWorkflowNode(node, config, context, rootRunId, attemptSignal, ownership),
+            this.executeSubWorkflowNode(
+              node,
+              config,
+              context,
+              rootRunId,
+              nodeStates,
+              attemptSignal,
+              ownership,
+            ),
         });
       case "loop":
         return executeCompositeNodeWithPolicy({
@@ -529,7 +551,7 @@ export class DAGExecutor {
     // The outer batch commits this snapshot only if the composite eventually
     // completes or waits; a final failed state discards it in full.
     applyContextPatch(context, result.contextPatch);
-    applyRecordPatch(nodeStates, createRecordPatch(nodeStates, result.nodeStates));
+    applyRecordPatch(nodeStates, createRecordPatch({}, result.nodeStates));
 
     const state: NodeState = {
       nodeId: node.id,
@@ -666,6 +688,7 @@ export class DAGExecutor {
     config: SubWorkflowNodeConfig,
     context: WorkflowContext,
     rootRunId: string,
+    nodeStates: Record<string, NodeState>,
     abortSignal?: AbortSignal,
     ownership?: CheckpointOwnership,
   ): Promise<NodeExecutionResult> {
@@ -720,6 +743,8 @@ export class DAGExecutor {
       ownership,
     );
     abortSignal?.throwIfAborted();
+
+    applyRecordPatch(nodeStates, createRecordPatch(nodeStates, result.nodeStates));
 
     let finalOutput: unknown = result.context;
     if (result.completed && config.output) {

--- a/src/workflow/executor/dag/index.ts
+++ b/src/workflow/executor/dag/index.ts
@@ -729,7 +729,7 @@ export class DAGExecutor {
         workflowId: workflowDef.id,
         status: "running",
         input,
-        nodeStates: {},
+        nodeStates: { ...nodeStates },
         currentNodes: [],
         context: { input },
         checkpoints: [],

--- a/src/workflow/executor/dag/loop-node-strategy.ts
+++ b/src/workflow/executor/dag/loop-node-strategy.ts
@@ -134,6 +134,7 @@ export async function executeLoopNodeStrategy(
           }),
         ),
         waiting: true,
+        waitingNode: result.waitingNode,
       };
     }
 

--- a/src/workflow/executor/dag/map-node-strategy.ts
+++ b/src/workflow/executor/dag/map-node-strategy.ts
@@ -126,5 +126,6 @@ export async function executeMapNodeStrategy(
     state,
     contextPatch: createSetContextPatch(result.completed ? { [node.id]: outputs } : {}),
     waiting: result.waiting,
+    waitingNode: result.waitingNode,
   };
 }

--- a/src/workflow/executor/dag/types.ts
+++ b/src/workflow/executor/dag/types.ts
@@ -50,4 +50,11 @@ export interface NodeExecutionResult {
   state: NodeState;
   contextPatch: ContextPatch;
   waiting: boolean;
+  /**
+   * The node that actually suspended, when this node is a composite whose child
+   * graph is waiting. An approval is built from `nodeStates[waitingNode].input`,
+   * and a composite's own state has no `input`, so reporting the composite
+   * instead of its inner wait means no approval is ever created.
+   */
+  waitingNode?: string;
 }


### PR DESCRIPTION
## Description

A `wait` / `waitForApproval` nested inside any composite node — `branch`, `parallel`, `map`, `loop`, `subWorkflow` — paused the run but **never created a `PendingApproval`**. The run parked in `waiting` indefinitely with nothing for a human to act on, no error, and only a debug-level log line. Only a top-level wait worked.

This is the shape the `veryfront/workflow` module docstring documents as the human-in-the-loop example:

```ts
branch("review", {
  condition: () => input.requiresApproval,
  then: [waitForApproval("human-review", { timeout: "24h" })],
}),
```

### Root cause

`dag/index.ts` recorded the waiting outcome against the top-level batch node id, which for a nested wait is the enclosing composite. That id becomes `result.waitingNode` and is handed to `onWaiting`, which builds the approval from `run.nodeStates[nodeId].input` (`api/workflow-client.ts:56-64`). A composite's state has no `input`, so it hit `if (!input)`, logged `"No wait config found for node"`, and returned before `createApproval`.

The suspended child's state was present in `nodeStates` the whole time — only the reported id was wrong.

### Fix

Carry the child's waiting node id out through `NodeExecutionResult.waitingNode` from every composite that runs a child graph, and prefer it when recording the outcome:

```ts
if (!outcome) outcome = { kind: "waiting", nodeId: nodeResult.waitingNode ?? nodeId };
```

The fallback keeps a top-level wait reporting itself.

### Why resume is unaffected

This changes a reported value, not routing. `startFromNode` has exactly one source — `CheckpointManager.prepareResume` → `findNextNode`, which scans the **top-level** node array — and `currentNodes[...]` is never read for control flow anywhere in `src/`. Both existing resume tests (H8 composite, H9 loop) still pass.

The H8 assertion is updated because it pinned the old reported value, and its comment claiming "the real executor resumes by passing the waiting node id as startFromNode" was inaccurate; it now describes the checkpoint-derived behavior. H9's equivalent assertion is updated for the same reason.

### Evidence

Before (production code reverted, tests kept):

```
reports the inner node when a wait is nested in a branch ......... FAILED
reports the inner node when a wait is nested in a parallel ....... FAILED
reports the inner node when a wait is nested in a sub-workflow ... FAILED
creates a pending approval for a wait nested in a branch ......... FAILED
resolves a nested approval and lets the run continue ............. FAILED
still reports a top-level wait as itself ......................... ok   (control)
```

After — end-to-end through `WorkflowClient`, a real run reaching `waiting`:

```
STATUS: waiting
APPROVALS: [{ nodeId: "review-gate/then/nested-review", message: "Please review", status: "pending" }]
```

`src/workflow/executor/`: `ok | 9 passed (133 steps) | 0 failed`. Full suite passes at push.

Note the approval is keyed by the arm-qualified child id (`review-gate/then/nested-review`), which the added test pins explicitly.

## Related Issue(s)

Tracked internally. No linked public issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have added tests that prove my fix is effective
- [x] Verified the new tests fail with the production change reverted
- [x] Existing tests pass locally
- [ ] Documentation changes (the documented example now works as written; no doc edit needed)
