### PR TITLE
test: fix three sources of pre-push gate flakiness

### DIFF
--- a/src/errors/error-handlers.test.ts
+++ b/src/errors/error-handlers.test.ts
@@ -318,13 +318,11 @@ describe("error-handlers", () => {
 
     it("uses the captured Error constructor for timeout reasons", async () => {
       const NativeError = Error;
-      let replacementConstructions = 0;
-      class ReplacementError extends NativeError {
-        constructor(message?: string) {
-          super(message);
-          replacementConstructions++;
-        }
-      }
+      class ReplacementError extends NativeError {}
+      // Swapping a global built-in stays in effect across the awaits below, and
+      // the suite runs other tests in this isolate meanwhile. Assert only on the
+      // value this call produced -- counting constructions process-wide would
+      // also count every unrelated Error built inside the same window.
       globalThis.Error = ReplacementError as ErrorConstructor;
 
       try {
@@ -338,7 +336,7 @@ describe("error-handlers", () => {
           )
         );
 
-        assertEquals(replacementConstructions, 0);
+        assertEquals(thrown instanceof ReplacementError, false);
         assertInstanceOf(thrown, NativeError);
         assertEquals(thrown.name, "AbortError");
       } finally {

--- a/src/react/components/ui/navigation-menu.test.tsx
+++ b/src/react/components/ui/navigation-menu.test.tsx
@@ -80,10 +80,27 @@ function installDom(dom: JSDOM): () => void {
     onchange: null,
     dispatchEvent: () => false,
   });
-  g.requestAnimationFrame = (cb: (t: number) => void) => setTimeout(() => cb(0), 0);
-  g.cancelAnimationFrame = (id: number) => clearTimeout(id);
+  // rAF is stubbed with a real timer, so a frame still queued when the test ends
+  // is a leaked timer and trips the sanitizer. Track them and drain on teardown:
+  // React can schedule a frame right up to unmount, and under a loaded parallel
+  // suite that frame may not have run yet.
+  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
+  g.requestAnimationFrame = (cb: (t: number) => void) => {
+    const id = setTimeout(() => {
+      pendingFrames.delete(id);
+      cb(0);
+    }, 0);
+    pendingFrames.add(id);
+    return id as unknown as number;
+  };
+  g.cancelAnimationFrame = (id: number) => {
+    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
+    clearTimeout(id);
+  };
 
   return () => {
+    for (const frame of pendingFrames) clearTimeout(frame);
+    pendingFrames.clear();
     for (const k of keys) g[k] = prev[k];
     dom.window.close();
   };

--- a/src/react/components/ui/navigation-menu.test.tsx
+++ b/src/react/components/ui/navigation-menu.test.tsx
@@ -13,6 +13,7 @@
  */
 import * as React from "react";
 import { flushSync } from "react-dom";
+import { waitFor } from "#veryfront/testing/deno-compat.ts";
 import { createRoot } from "react-dom/client";
 import { JSDOM } from "npm:jsdom@28.0.0";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
@@ -162,6 +163,9 @@ function triggers(host: HTMLElement): HTMLElement[] {
   return Array.from(host.querySelectorAll<HTMLElement>("nav ul li button"));
 }
 
+/** Comfortably longer than the component's 100ms close delay. */
+const CLOSE_SETTLE_MS = 300;
+
 describe("NavigationMenu behaviour", () => {
   it("renders a nav landmark with its list, items and collapsed triggers", () => {
     const { host, unmount } = render(<Fixture />);
@@ -298,17 +302,23 @@ describe("NavigationMenu behaviour", () => {
         "leaving the trigger does not close the panel immediately",
       );
       await pointerEnter(panel);
-      await new Promise((resolve) => setTimeout(resolve, 150));
+      // Proving a negative, so this has to be a real wait: comfortably longer
+      // than the component's close delay, and asserting the panel survived it.
+      await new Promise((resolve) => setTimeout(resolve, CLOSE_SETTLE_MS));
       assert(
         host.querySelector('[data-slot="navigation-menu-content"]'),
         "entering the panel cancels the pending close",
       );
 
       await pointerLeave(panel);
-      await new Promise((resolve) => setTimeout(resolve, 150));
-      assert(
-        host.querySelector('[data-slot="navigation-menu-content"]') == null,
-        "the panel closes after the pointer leaves the coordinated region",
+      // Poll rather than sleeping past the close delay. A fixed sleep races the
+      // component's timer under a loaded parallel suite: too short and the
+      // assertion fails, and either way the test can finish with that timer
+      // still pending, which trips the leak sanitizer. Waiting for the observable
+      // outcome guarantees the timer has fired before teardown.
+      await waitFor(
+        () => host.querySelector('[data-slot="navigation-menu-content"]') == null,
+        { interval: 10, message: "panel did not close after the pointer left the region" },
       );
     } finally {
       unmount();


### PR DESCRIPTION
## Description

The pre-push gate (`deno task test:unit`, `--parallel`, 3,952 tests) failed on roughly **one run in three**, always on something unrelated to the change being pushed. That trains people to retry a red gate, which is worse than not having one.

Three fixes here. They were found in order, and the first two turned out **not** to be the cause — recorded honestly because the third is the interesting one.

### 1. A test racing a component timer

`navigation-menu.test.tsx` slept a fixed **150 ms** waiting on a **100 ms** close delay. Under contention that timer runs late: the assertion fails, or the test finishes with the timer pending and trips the leak sanitiser.

Now polls for the observable outcome. Verified by standing in for a starved timer — raising the component's close delay to 200 ms makes the old test fail and the new one pass:

```
OLD (fixed 150ms sleep), 200ms delay:  FAILED | 0 passed (8 steps) | 1 failed
NEW (polls for outcome), 200ms delay:  ok     | 1 passed (9 steps) | 0 failed
```

### 2. A stubbed `requestAnimationFrame` that nothing drains

```js
g.requestAnimationFrame = (cb) => setTimeout(() => cb(0), 0);
```

A frame still queued at teardown is a pending timer — exactly the sanitiser's message. React can schedule one right up to unmount. Now tracked and cleared in the teardown that already restores globals and closes the DOM.

**The same stub appears in eleven other UI test files with the same gap.** Only the one that demonstrably failed is fixed here; the rest are worth a follow-up sweep.

### 3. The actual cause — a test asserting on other tests' `Error` constructions

Found by looping the full suite under `--trace-leaks` until it reproduced. It was never a leak:

```
error-handlers ... uses the captured Error constructor for timeout reasons
AssertionError: Values are not equal.
-   1
+   0
```

The test swaps `globalThis.Error` for a counting subclass and asserts the counter is zero. **The swap stays in effect across the awaits that follow**, and the suite runs other tests in the same isolate meanwhile — the surrounding output shows a sibling retry test constructing `Error: fail 1` inside exactly that window. The counter reads 1 and the assertion fails for reasons unrelated to the code under test.

Now asserts on the value the call actually produced: if `retryWithBackoff` used the current global rather than its captured constructor, the rejection would be a `ReplacementError`. That is the real contract, and it is local to the call.

## Measured effect

Full `deno task test:unit` runs, same machine, same conditions:

| Stage | Runs | Failures |
| --- | --- | --- |
| Baseline | 3 | 1 |
| After fixes 1 + 2 | 3 | 1 |
| Traced run that caught the cause | 1 | 1 |
| **After fix 3** | **6** | **0** |

Fixes 1 and 2 are correct on their own merits but moved nothing. Fix 3 did.

**This is evidence, not proof.** At the prior failure rate (~3 in 7) six consecutive passes would happen about 3% of the time by chance, so the rate has very likely dropped — but 0/6 cannot establish that the tail is empty, and the two failures I captured had two *different* causes. Expect more in the tail, and note the `requestAnimationFrame` stub gap still exists in eleven other UI test files.

No production code changed.

## Related Issue(s)

Tracked internally. No linked public issue.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] Reproduced each failure before fixing it
- [x] No production code changed
- [x] Remaining risk stated rather than implied closed
