### PR TITLE
test(react): drain stubbed animation frames in the remaining UI harnesses

### DIFF
--- a/src/react/components/ui/adapter/drawer.conformance.test.tsx
+++ b/src/react/components/ui/adapter/drawer.conformance.test.tsx
@@ -47,9 +47,25 @@ function installDom(dom: JSDOM): () => void {
   g.window = w;
   g.getComputedStyle = (w.getComputedStyle as (e: Element) => CSSStyleDeclaration).bind(w);
   g.ResizeObserver = ResizeObserverStub;
-  g.requestAnimationFrame = (cb: (t: number) => void) => setTimeout(() => cb(0), 0);
-  g.cancelAnimationFrame = (id: number) => clearTimeout(id);
+  // The stub is a real timer, so a frame still queued when the test ends is a
+  // pending timer and trips the leak sanitizer. React can schedule a frame right
+  // up to unmount, so track outstanding frames and drain them on teardown.
+  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
+  g.requestAnimationFrame = (cb: (t: number) => void) => {
+    const id = setTimeout(() => {
+      pendingFrames.delete(id);
+      cb(0);
+    }, 0);
+    pendingFrames.add(id);
+    return id as unknown as number;
+  };
+  g.cancelAnimationFrame = (id: number) => {
+    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
+    clearTimeout(id);
+  };
   return () => {
+    for (const frame of pendingFrames) clearTimeout(frame);
+    pendingFrames.clear();
     for (const k of keys) g[k] = prev[k];
     dom.window.close();
   };

--- a/src/react/components/ui/alert-dialog.test.tsx
+++ b/src/react/components/ui/alert-dialog.test.tsx
@@ -86,10 +86,26 @@ function installDom(dom: JSDOM): () => void {
     onchange: null,
     dispatchEvent: () => false,
   });
-  g.requestAnimationFrame = (cb: (t: number) => void) => setTimeout(() => cb(0), 0);
-  g.cancelAnimationFrame = (id: number) => clearTimeout(id);
+  // The stub is a real timer, so a frame still queued when the test ends is a
+  // pending timer and trips the leak sanitizer. React can schedule a frame right
+  // up to unmount, so track outstanding frames and drain them on teardown.
+  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
+  g.requestAnimationFrame = (cb: (t: number) => void) => {
+    const id = setTimeout(() => {
+      pendingFrames.delete(id);
+      cb(0);
+    }, 0);
+    pendingFrames.add(id);
+    return id as unknown as number;
+  };
+  g.cancelAnimationFrame = (id: number) => {
+    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
+    clearTimeout(id);
+  };
 
   return () => {
+    for (const frame of pendingFrames) clearTimeout(frame);
+    pendingFrames.clear();
     for (const k of keys) g[k] = prev[k];
     dom.window.close();
   };

--- a/src/react/components/ui/breadcrumb.test.tsx
+++ b/src/react/components/ui/breadcrumb.test.tsx
@@ -72,10 +72,26 @@ function installDom(dom: JSDOM): () => void {
     onchange: null,
     dispatchEvent: () => false,
   });
-  g.requestAnimationFrame = (cb: (t: number) => void) => setTimeout(() => cb(0), 0);
-  g.cancelAnimationFrame = (id: number) => clearTimeout(id);
+  // The stub is a real timer, so a frame still queued when the test ends is a
+  // pending timer and trips the leak sanitizer. React can schedule a frame right
+  // up to unmount, so track outstanding frames and drain them on teardown.
+  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
+  g.requestAnimationFrame = (cb: (t: number) => void) => {
+    const id = setTimeout(() => {
+      pendingFrames.delete(id);
+      cb(0);
+    }, 0);
+    pendingFrames.add(id);
+    return id as unknown as number;
+  };
+  g.cancelAnimationFrame = (id: number) => {
+    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
+    clearTimeout(id);
+  };
 
   return () => {
+    for (const frame of pendingFrames) clearTimeout(frame);
+    pendingFrames.clear();
     for (const k of keys) g[k] = prev[k];
     dom.window.close();
   };

--- a/src/react/components/ui/calendar.test.tsx
+++ b/src/react/components/ui/calendar.test.tsx
@@ -69,10 +69,26 @@ function installDom(dom: JSDOM): () => void {
     onchange: null,
     dispatchEvent: () => false,
   });
-  g.requestAnimationFrame = (cb: (t: number) => void) => setTimeout(() => cb(0), 0);
-  g.cancelAnimationFrame = (id: number) => clearTimeout(id);
+  // The stub is a real timer, so a frame still queued when the test ends is a
+  // pending timer and trips the leak sanitizer. React can schedule a frame right
+  // up to unmount, so track outstanding frames and drain them on teardown.
+  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
+  g.requestAnimationFrame = (cb: (t: number) => void) => {
+    const id = setTimeout(() => {
+      pendingFrames.delete(id);
+      cb(0);
+    }, 0);
+    pendingFrames.add(id);
+    return id as unknown as number;
+  };
+  g.cancelAnimationFrame = (id: number) => {
+    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
+    clearTimeout(id);
+  };
 
   return () => {
+    for (const frame of pendingFrames) clearTimeout(frame);
+    pendingFrames.clear();
     for (const k of keys) g[k] = prev[k];
     dom.window.close();
   };

--- a/src/react/components/ui/conformance.test.tsx
+++ b/src/react/components/ui/conformance.test.tsx
@@ -110,10 +110,26 @@ function installDom(dom: JSDOM): () => void {
     onchange: null,
     dispatchEvent: () => false,
   });
-  g.requestAnimationFrame = (cb: (t: number) => void) => setTimeout(() => cb(0), 0);
-  g.cancelAnimationFrame = (id: number) => clearTimeout(id);
+  // The stub is a real timer, so a frame still queued when the test ends is a
+  // pending timer and trips the leak sanitizer. React can schedule a frame right
+  // up to unmount, so track outstanding frames and drain them on teardown.
+  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
+  g.requestAnimationFrame = (cb: (t: number) => void) => {
+    const id = setTimeout(() => {
+      pendingFrames.delete(id);
+      cb(0);
+    }, 0);
+    pendingFrames.add(id);
+    return id as unknown as number;
+  };
+  g.cancelAnimationFrame = (id: number) => {
+    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
+    clearTimeout(id);
+  };
 
   return () => {
+    for (const frame of pendingFrames) clearTimeout(frame);
+    pendingFrames.clear();
     for (const k of keys) g[k] = prev[k];
     dom.window.close();
   };

--- a/src/react/components/ui/date-picker.test.tsx
+++ b/src/react/components/ui/date-picker.test.tsx
@@ -69,10 +69,26 @@ function installDom(dom: JSDOM): () => void {
     onchange: null,
     dispatchEvent: () => false,
   });
-  g.requestAnimationFrame = (cb: (t: number) => void) => setTimeout(() => cb(0), 0);
-  g.cancelAnimationFrame = (id: number) => clearTimeout(id);
+  // The stub is a real timer, so a frame still queued when the test ends is a
+  // pending timer and trips the leak sanitizer. React can schedule a frame right
+  // up to unmount, so track outstanding frames and drain them on teardown.
+  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
+  g.requestAnimationFrame = (cb: (t: number) => void) => {
+    const id = setTimeout(() => {
+      pendingFrames.delete(id);
+      cb(0);
+    }, 0);
+    pendingFrames.add(id);
+    return id as unknown as number;
+  };
+  g.cancelAnimationFrame = (id: number) => {
+    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
+    clearTimeout(id);
+  };
 
   return () => {
+    for (const frame of pendingFrames) clearTimeout(frame);
+    pendingFrames.clear();
     for (const k of keys) g[k] = prev[k];
     dom.window.close();
   };

--- a/src/react/components/ui/field.test.tsx
+++ b/src/react/components/ui/field.test.tsx
@@ -63,10 +63,26 @@ function installDom(dom: JSDOM): () => void {
     onchange: null,
     dispatchEvent: () => false,
   });
-  g.requestAnimationFrame = (cb: (t: number) => void) => setTimeout(() => cb(0), 0);
-  g.cancelAnimationFrame = (id: number) => clearTimeout(id);
+  // The stub is a real timer, so a frame still queued when the test ends is a
+  // pending timer and trips the leak sanitizer. React can schedule a frame right
+  // up to unmount, so track outstanding frames and drain them on teardown.
+  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
+  g.requestAnimationFrame = (cb: (t: number) => void) => {
+    const id = setTimeout(() => {
+      pendingFrames.delete(id);
+      cb(0);
+    }, 0);
+    pendingFrames.add(id);
+    return id as unknown as number;
+  };
+  g.cancelAnimationFrame = (id: number) => {
+    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
+    clearTimeout(id);
+  };
 
   return () => {
+    for (const frame of pendingFrames) clearTimeout(frame);
+    pendingFrames.clear();
     for (const k of keys) g[k] = prev[k];
     dom.window.close();
   };

--- a/src/react/components/ui/input-otp.test.tsx
+++ b/src/react/components/ui/input-otp.test.tsx
@@ -67,10 +67,26 @@ function installDom(dom: JSDOM): () => void {
     onchange: null,
     dispatchEvent: () => false,
   });
-  g.requestAnimationFrame = (cb: (t: number) => void) => setTimeout(() => cb(0), 0);
-  g.cancelAnimationFrame = (id: number) => clearTimeout(id);
+  // The stub is a real timer, so a frame still queued when the test ends is a
+  // pending timer and trips the leak sanitizer. React can schedule a frame right
+  // up to unmount, so track outstanding frames and drain them on teardown.
+  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
+  g.requestAnimationFrame = (cb: (t: number) => void) => {
+    const id = setTimeout(() => {
+      pendingFrames.delete(id);
+      cb(0);
+    }, 0);
+    pendingFrames.add(id);
+    return id as unknown as number;
+  };
+  g.cancelAnimationFrame = (id: number) => {
+    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
+    clearTimeout(id);
+  };
 
   return () => {
+    for (const frame of pendingFrames) clearTimeout(frame);
+    pendingFrames.clear();
     for (const k of keys) g[k] = prev[k];
     dom.window.close();
   };

--- a/src/react/components/ui/meter.test.tsx
+++ b/src/react/components/ui/meter.test.tsx
@@ -63,10 +63,26 @@ function installDom(dom: JSDOM): () => void {
     onchange: null,
     dispatchEvent: () => false,
   });
-  g.requestAnimationFrame = (cb: (t: number) => void) => setTimeout(() => cb(0), 0);
-  g.cancelAnimationFrame = (id: number) => clearTimeout(id);
+  // The stub is a real timer, so a frame still queued when the test ends is a
+  // pending timer and trips the leak sanitizer. React can schedule a frame right
+  // up to unmount, so track outstanding frames and drain them on teardown.
+  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
+  g.requestAnimationFrame = (cb: (t: number) => void) => {
+    const id = setTimeout(() => {
+      pendingFrames.delete(id);
+      cb(0);
+    }, 0);
+    pendingFrames.add(id);
+    return id as unknown as number;
+  };
+  g.cancelAnimationFrame = (id: number) => {
+    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
+    clearTimeout(id);
+  };
 
   return () => {
+    for (const frame of pendingFrames) clearTimeout(frame);
+    pendingFrames.clear();
     for (const k of keys) g[k] = prev[k];
     dom.window.close();
   };

--- a/src/react/components/ui/pagination.test.tsx
+++ b/src/react/components/ui/pagination.test.tsx
@@ -70,10 +70,26 @@ function installDom(dom: JSDOM): () => void {
     onchange: null,
     dispatchEvent: () => false,
   });
-  g.requestAnimationFrame = (cb: (t: number) => void) => setTimeout(() => cb(0), 0);
-  g.cancelAnimationFrame = (id: number) => clearTimeout(id);
+  // The stub is a real timer, so a frame still queued when the test ends is a
+  // pending timer and trips the leak sanitizer. React can schedule a frame right
+  // up to unmount, so track outstanding frames and drain them on teardown.
+  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
+  g.requestAnimationFrame = (cb: (t: number) => void) => {
+    const id = setTimeout(() => {
+      pendingFrames.delete(id);
+      cb(0);
+    }, 0);
+    pendingFrames.add(id);
+    return id as unknown as number;
+  };
+  g.cancelAnimationFrame = (id: number) => {
+    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
+    clearTimeout(id);
+  };
 
   return () => {
+    for (const frame of pendingFrames) clearTimeout(frame);
+    pendingFrames.clear();
     for (const k of keys) g[k] = prev[k];
     dom.window.close();
   };

--- a/src/react/components/ui/scroll-area.test.tsx
+++ b/src/react/components/ui/scroll-area.test.tsx
@@ -64,10 +64,26 @@ function installDom(dom: JSDOM): () => void {
     onchange: null,
     dispatchEvent: () => false,
   });
-  g.requestAnimationFrame = (cb: (t: number) => void) => setTimeout(() => cb(0), 0);
-  g.cancelAnimationFrame = (id: number) => clearTimeout(id);
+  // The stub is a real timer, so a frame still queued when the test ends is a
+  // pending timer and trips the leak sanitizer. React can schedule a frame right
+  // up to unmount, so track outstanding frames and drain them on teardown.
+  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
+  g.requestAnimationFrame = (cb: (t: number) => void) => {
+    const id = setTimeout(() => {
+      pendingFrames.delete(id);
+      cb(0);
+    }, 0);
+    pendingFrames.add(id);
+    return id as unknown as number;
+  };
+  g.cancelAnimationFrame = (id: number) => {
+    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
+    clearTimeout(id);
+  };
 
   return () => {
+    for (const frame of pendingFrames) clearTimeout(frame);
+    pendingFrames.clear();
     for (const k of keys) g[k] = prev[k];
     dom.window.close();
   };


### PR DESCRIPTION
## Description

Eleven UI test files stub `requestAnimationFrame` with a real timer and never drain it:

```ts
g.requestAnimationFrame = (cb) => setTimeout(() => cb(0), 0);
g.cancelAnimationFrame = (id) => clearTimeout(id);
```

`cancelAnimationFrame` only helps a caller holding the id. A frame still queued at teardown is a pending timer, which the Deno op sanitizer reports as *"a timer was started in this test, but never completed"*. React can schedule a frame right up to unmount, so whether it has run by teardown is a matter of load.

Because the sanitizer reports at **suite** level, the resulting failure names a suite rather than a step and lands on whatever branch happens to be pushing — the misattribution pattern already recorded in #594 and #612.

## Fix

Track outstanding frames and clear them in the teardown that already restores globals and closes the DOM. The stub and its teardown were byte-identical across every file, so the change is identical in each — a mechanical, exact-match patch rather than eleven judgement calls.

## Scope and honesty

**None of these was observed failing.** This closes a latent hole; it is not a live defect. I am not claiming it fixes a specific flake.

`navigation-menu.test.tsx` is excluded — it is fixed on the pre-push-gate branch, and patching it here would only create a conflict.

**Deliberately not bundled:** each of these files hand-rolls the same JSDOM globals harness. Extracting one shared helper would remove the next copy of this bug before it is written, and is the better long-term answer. But that is a refactor across twelve files with subtly different surroundings, and it deserves its own review rather than riding along with a mechanical fix. Worth doing next.

## Evidence

`src/react/` under `--parallel --trace-leaks`, three consecutive runs:

```
ok | 241 passed (1839 steps) | 0 failed
ok | 241 passed (1839 steps) | 0 failed
ok | 241 passed (1839 steps) | 0 failed
```

No production code changed.

## Related Issue(s)

Tracked internally.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] Identical, exact-match change in every file
- [x] No production code changed
- [x] Remaining refactor named rather than silently skipped
