### PR TITLE
Prepare v0.1.1246-rc for staging verification

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "veryfront",
-  "version": "0.1.1245",
+  "version": "0.1.1246-rc",
   "license": "Apache-2.0",
   "nodeModulesDir": "auto",
   "minimumDependencyAge": {

--- a/src/utils/version-constant.ts
+++ b/src/utils/version-constant.ts
@@ -1,4 +1,4 @@
 // Keep in sync with deno.json version.
 // scripts/release.ts updates this constant during releases.
 /** Shared version value. */
-export const VERSION = "0.1.1245";
+export const VERSION = "0.1.1246-rc";


### PR DESCRIPTION
Creates an RC patch version for staging verification without publishing a stable release.\n\nChanges:\n- Sets deno.json version to 0.1.1246-rc.\n- Keeps src/utils/version-constant.ts aligned with deno.json so CI release preparation can append the run number.\n\nVerification:\n- deno test --config=scripts/test.deno.json --no-check --allow-read --allow-write scripts/ci/prepare-rc-build.test.ts\n- deno fmt --check deno.json src/utils/version-constant.ts scripts/ci/prepare-rc-build.ts scripts/ci/prepare-rc-build.test.ts\n- deno check --config=deno.json src/utils/version-constant.ts scripts/ci/prepare-rc-build.ts\n- git diff --check\n- full pre-push checks passed during branch push