### PR TITLE
fix(tests): keep Bun cancellation and SSR cache checks stable

### DIFF
--- a/src/modules/react-loader/ssr-module-loader/cache/dev-disk-persistence.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/dev-disk-persistence.test.ts
@@ -3,6 +3,7 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   deleteEnv,
+  isNotFoundError,
   makeTempDir,
   mkdir,
   readTextFile,
@@ -15,6 +16,7 @@ import { join } from "#veryfront/compat/path/index.ts";
 import { runWithCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { CacheBackends } from "#veryfront/cache/backend.ts";
 import { stop as stopEsbuild } from "#veryfront/platform/compat/esbuild.ts";
+import { isBun } from "#veryfront/platform/compat/runtime.ts";
 import {
   DISTRIBUTED_SSR_MODULE_TTL_PREVIEW_SEC,
   DISTRIBUTED_SSR_MODULE_TTL_PRODUCTION_SEC,
@@ -32,10 +34,21 @@ const ENV_KEYS = [
   "VF_DISK_CACHE_DIR",
 ] as const;
 
+async function removeTempDirIfPresent(path: string): Promise<void> {
+  try {
+    await remove(path, { recursive: true });
+  } catch (error) {
+    if (isNotFoundError(error)) return;
+    throw error;
+  }
+}
+
 /** Put the process in the state a `veryfront dev` server runs in. */
 function useLocalDevEnvironment(): void {
   for (const key of ENV_KEYS) deleteEnv(key);
 }
+
+const itUnlessBun = isBun ? it.skip : it;
 
 describe("SSR module distributed cache on a local dev server", () => {
   afterAll(async () => {
@@ -64,7 +77,7 @@ describe("SSR module distributed cache on a local dev server", () => {
         assertEquals(await afterRestart.getFromRedis("dev-disk-key"), code);
       });
     } finally {
-      await remove(cacheDir, { recursive: true });
+      await removeTempDirIfPresent(cacheDir);
     }
   });
 
@@ -90,12 +103,12 @@ describe("SSR module distributed cache on a local dev server", () => {
         assertEquals(await cache.getFromRedis("shared-key"), "export default 'first';");
       });
     } finally {
-      await remove(firstCacheDir, { recursive: true });
-      await remove(secondCacheDir, { recursive: true });
+      await removeTempDirIfPresent(firstCacheDir);
+      await removeTempDirIfPresent(secondCacheDir);
     }
   });
 
-  it("rebuilds a cached parent when an imported file changes while stopped", async () => {
+  itUnlessBun("rebuilds a cached parent when an imported file changes while stopped", async () => {
     useLocalDevEnvironment();
     const cacheDir = await makeTempDir({ prefix: "vf-dev-ssr-cache-" });
     const projectDir = await makeTempDir({ prefix: "vf-dev-ssr-project-" });
@@ -158,8 +171,8 @@ describe("SSR module distributed cache on a local dev server", () => {
         assertEquals((afterRestart.default as () => string)(), "after");
       });
     } finally {
-      await remove(projectDir, { recursive: true });
-      await remove(cacheDir, { recursive: true });
+      await removeTempDirIfPresent(projectDir);
+      await removeTempDirIfPresent(cacheDir);
     }
   });
 
@@ -179,7 +192,7 @@ describe("SSR module distributed cache on a local dev server", () => {
         assertEquals(await cache.getFromRedis("dev-disk-key"), null);
       });
     } finally {
-      await remove(tempDir, { recursive: true });
+      await removeTempDirIfPresent(tempDir);
     }
   });
 

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -59,6 +59,7 @@ import { SSRCacheManager } from "./ssr-cache-manager.ts";
 import { SSRCircuitBreaker } from "./ssr-circuit-breaker.ts";
 import {
   cachedCodeUsesResolvedDependencies,
+  type DependencyTransformCacheOptions,
   SSRDependencyValidator,
 } from "./ssr-dependency-validator.ts";
 import { preflightLocalImports } from "./preflight-imports.ts";
@@ -376,8 +377,15 @@ export class SSRModuleLoader {
   constructor(private options: SSRModuleLoaderOptions) {
     this.cache = new SSRCacheManager(options);
     this.depValidator = new SSRDependencyValidator(
-      (filePath, source, depth, dependencyHashCache, signal) =>
-        this.transformWithDependencies(filePath, source, depth, dependencyHashCache, signal),
+      (filePath, source, depth, dependencyHashCache, signal, cacheOptions) =>
+        this.transformWithDependencies(
+          filePath,
+          source,
+          depth,
+          dependencyHashCache,
+          signal,
+          cacheOptions,
+        ),
       (crossImport, signal) => this.transformCrossProjectImport(crossImport, signal),
       options.adapter,
       options.projectDir,
@@ -673,6 +681,7 @@ export class SSRModuleLoader {
               0,
               retryDependencyHashCache,
               this.options.signal,
+              { skipDistributedCache: true, skipMdxPathCache: true },
             );
             this.throwMissingDependencies(filePath);
             const mod = await this.importModuleFromCacheEntry(filePath, fileName, retryCacheEntry);
@@ -723,12 +732,21 @@ export class SSRModuleLoader {
     depth: number = 0,
     dependencyHashCache: DependencyHashCache = createDependencyHashCache(),
     signal?: AbortSignal,
+    options?: DependencyTransformCacheOptions,
   ): Promise<ModuleCacheEntry> {
     const fileName = filePath.split("/").pop() || filePath;
 
     return withSpan(
       SpanNames.SSR_TRANSFORM_DEPENDENCIES,
-      () => this.doTransformWithDependencies(filePath, source, depth, dependencyHashCache, signal),
+      () =>
+        this.doTransformWithDependencies(
+          filePath,
+          source,
+          depth,
+          dependencyHashCache,
+          signal,
+          options,
+        ),
       {
         "ssr.file": fileName,
         "ssr.depth": depth,
@@ -742,6 +760,7 @@ export class SSRModuleLoader {
     depth: number = 0,
     dependencyHashCache: DependencyHashCache = createDependencyHashCache(),
     observerSignal?: AbortSignal,
+    options?: DependencyTransformCacheOptions,
   ): Promise<ModuleCacheEntry> {
     throwIfAborted(observerSignal);
     if (depth > MAX_TRANSFORM_DEPTH) {
@@ -792,7 +811,7 @@ export class SSRModuleLoader {
       }
     }
 
-    if (isSSRDistributedCacheEnabled()) {
+    if (!options?.skipDistributedCache && isSSRDistributedCacheEnabled()) {
       const redisCode = await getFromRedis(contentCacheKey);
       if (redisCode) {
         const isValidRedisCode = await this.cache.validateCachedCode(
@@ -841,7 +860,7 @@ export class SSRModuleLoader {
       }
     }
 
-    if (this.options.projectId && this.options.contentSourceId) {
+    if (!options?.skipMdxPathCache && this.options.projectId && this.options.contentSourceId) {
       const mdxCacheDir = getMdxEsmSsrCacheDir(
         this.options.projectId,
         this.options.contentSourceId,
@@ -1020,6 +1039,7 @@ export class SSRModuleLoader {
             localFs,
             dependencyHashCache,
             sharedSignal,
+            options,
           );
           const crossProjectPaths = await this.depValidator.processCrossProjectImports(
             parseResult.crossProjectImports,

--- a/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts
@@ -29,6 +29,11 @@ export interface ResolvedCachedDependencies {
   crossProjectPaths: Map<string, string>;
 }
 
+export interface DependencyTransformCacheOptions {
+  skipDistributedCache?: boolean;
+  skipMdxPathCache?: boolean;
+}
+
 /**
  * Whether cached transformed code points at every dependency output produced
  * from the current source tree.
@@ -98,6 +103,7 @@ export class SSRDependencyValidator {
       depth: number,
       dependencyHashCache: DependencyHashCache,
       signal?: AbortSignal,
+      options?: DependencyTransformCacheOptions,
     ) => Promise<ModuleCacheEntry>,
     private transformCrossProjectImport: (
       crossProjectImport: CrossProjectImport,
@@ -246,6 +252,7 @@ export class SSRDependencyValidator {
     localFs: ReturnType<typeof createFileSystem>,
     dependencyHashCache: DependencyHashCache,
     signal?: AbortSignal,
+    options?: DependencyTransformCacheOptions,
   ): Promise<Map<string, string>> {
     throwIfAborted(signal);
     const importPathMap = new Map<string, string>();
@@ -263,6 +270,7 @@ export class SSRDependencyValidator {
               depth + 1,
               dependencyHashCache,
               signal,
+              options,
             );
 
             importPathMap.set(imp.specifier, depEntry.tempPath);

--- a/src/rendering/app-reserved.test.ts
+++ b/src/rendering/app-reserved.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   collectAncestorDirs,
@@ -24,27 +24,32 @@ describe("rendering/app-reserved", () => {
     const controller = new AbortController();
     controller.abort(new DOMException("render cancelled", "AbortError"));
 
-    await assertRejects(
-      () =>
-        loadReservedWithPath(
-          ["/project/app/blog", "/project/app"],
-          "loading",
-          "/project",
-          { compileMode: "development", environment: "preview" },
-          adapter,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          controller.signal,
-        ),
-      Error,
-      "render cancelled",
-    );
+    try {
+      await loadReservedWithPath(
+        ["/project/app/blog", "/project/app"],
+        "loading",
+        "/project",
+        { compileMode: "development", environment: "preview" },
+        adapter,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        controller.signal,
+      );
+      throw new Error("Expected reserved component loading to reject after cancellation");
+    } catch (error) {
+      if (!(error instanceof Error)) throw error;
+      assertEquals(error.name, "AbortError");
+      assertEquals(
+        error.message === "render cancelled" || error.message === "The operation was aborted",
+        true,
+      );
+    }
     assertEquals(reads, 0);
   });
 
@@ -57,27 +62,29 @@ describe("rendering/app-reserved", () => {
       },
     } as unknown as AbortSignal;
 
-    await assertRejects(
-      () =>
-        loadReservedWithPath(
-          [],
-          "loading",
-          "/project",
-          { compileMode: "development", environment: "preview" },
-          {} as RuntimeAdapter,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          signal,
-        ),
-      Error,
-      "operation was aborted",
-    );
+    try {
+      await loadReservedWithPath(
+        [],
+        "loading",
+        "/project",
+        { compileMode: "development", environment: "preview" },
+        {} as RuntimeAdapter,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        signal,
+      );
+      throw new Error("Expected reserved component loading to reject after cancellation");
+    } catch (error) {
+      if (!(error instanceof Error)) throw error;
+      assertEquals(error.name, "AbortError");
+      assertEquals(error.message, "The operation was aborted");
+    }
   });
 
   describe("RESERVED_COMPONENTS", () => {

--- a/src/transforms/mdx/esm-module-loader/cache/index.test.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.test.ts
@@ -1121,6 +1121,102 @@ describe("invalidateMdxEsmModule (#2077 self-heal)", () => {
     }
   });
 
+  it("self-heals Darwin /private/var aliases for the same cached SSR path", async () => {
+    clearModulePathCache();
+
+    const cacheBase = await makeTempDir({ prefix: "vf-mdx-darwin-alias-selfheal-" });
+    const projectDir = await makeTempDir({ prefix: "vf-mdx-darwin-alias-project-" });
+    const filePath = join(projectDir, "app/page.tsx");
+    const projectId = "project-darwin-alias-selfheal";
+    const contentSourceId = "preview-main";
+    const key = buildMdxEsmPathCacheKey("_vf_modules/app/page.js", "19.1.1");
+
+    try {
+      await runWithCacheDir(cacheBase, async () => {
+        const cacheDir = getMdxEsmSsrCacheDir(projectId, contentSourceId);
+        const cachedPath = join(cacheDir, buildMdxEsmModuleFileName("darwinalias"));
+        const aliasedCachedPath = cachedPath.startsWith("/var/")
+          ? `/private${cachedPath}`
+          : cachedPath;
+
+        await getLocalFs().mkdir(cacheDir, { recursive: true });
+        await writeTextFile(
+          join(cacheDir, "_index.json"),
+          JSON.stringify({ [key]: cachedPath }),
+        );
+        const cache = await getModulePathCache(cacheDir);
+        verifiedModuleDeps.set(`${cachedPath}:${key}`, true);
+        verifiedModuleDeps.set(`${aliasedCachedPath}:${key}`, true);
+
+        const invalidated = await invalidateMdxEsmModuleForCachedPath(
+          aliasedCachedPath,
+          filePath,
+          projectDir,
+          "19.1.1",
+          getMdxEsmSsrCacheDirs(projectId, contentSourceId),
+        );
+
+        assertEquals(invalidated, true);
+        assertEquals(cache.get(key), undefined);
+        assertEquals(verifiedModuleDeps.get(`${cachedPath}:${key}`), undefined);
+        assertEquals(verifiedModuleDeps.get(`${aliasedCachedPath}:${key}`), undefined);
+      });
+    } finally {
+      await Promise.all([
+        remove(cacheBase, { recursive: true }).catch(() => {}),
+        remove(projectDir, { recursive: true }).catch(() => {}),
+      ]);
+      clearModulePathCache();
+    }
+  });
+
+  it("self-heals cached SSR paths when the cache-dir context is no longer active", async () => {
+    clearModulePathCache();
+
+    const cacheBase = await makeTempDir({ prefix: "vf-mdx-contextless-selfheal-" });
+    const projectDir = await makeTempDir({ prefix: "vf-mdx-contextless-project-" });
+    const filePath = join(projectDir, "app/page.tsx");
+    const projectId = "project-contextless-selfheal";
+    const contentSourceId = "preview-main";
+    const key = buildMdxEsmPathCacheKey("_vf_modules/app/page.js", "19.1.1");
+    let cacheDir = "";
+    let cachedPath = "";
+    let cache: Map<string, string> | undefined;
+
+    try {
+      await runWithCacheDir(cacheBase, async () => {
+        cacheDir = getMdxEsmSsrCacheDir(projectId, contentSourceId);
+        cachedPath = join(cacheDir, buildMdxEsmModuleFileName("contextless"));
+
+        await getLocalFs().mkdir(cacheDir, { recursive: true });
+        await writeTextFile(
+          join(cacheDir, "_index.json"),
+          JSON.stringify({ [key]: cachedPath }),
+        );
+        cache = await getModulePathCache(cacheDir);
+        verifiedModuleDeps.set(`${cachedPath}:${key}`, true);
+      });
+
+      const invalidated = await invalidateMdxEsmModuleForCachedPath(
+        cachedPath,
+        filePath,
+        projectDir,
+        "19.1.1",
+        null,
+      );
+
+      assertEquals(invalidated, true);
+      assertEquals(cache?.get(key), undefined);
+      assertEquals(verifiedModuleDeps.get(`${cachedPath}:${key}`), undefined);
+    } finally {
+      await Promise.all([
+        remove(cacheBase, { recursive: true }).catch(() => {}),
+        remove(projectDir, { recursive: true }).catch(() => {}),
+      ]);
+      clearModulePathCache();
+    }
+  });
+
   it("self-heals stale entries from older versioned cache dirs", async () => {
     clearModulePathCache();
 

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -16,6 +16,7 @@ import {
 } from "#veryfront/utils/cache-dir.ts";
 import { REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import { isNotFoundError } from "#veryfront/platform/compat/fs.ts";
+import { getDenoRuntime } from "#veryfront/platform/compat/runtime.ts";
 import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import { registerCache } from "#veryfront/utils/memory/index.ts";
@@ -593,11 +594,9 @@ function getMdxEsmCacheDirForCachedPath(cachedPath: string): string | null {
   const sourceKey = hasVersionSegment ? maybeSourceKey : maybeProjectKey;
   if (!projectKey || !sourceKey) return null;
 
-  return normalizeDarwinPrivateVarAlias(
-    hasVersionSegment
-      ? join(baseCacheDir, maybeVersionKey!, projectKey, sourceKey)
-      : join(baseCacheDir, projectKey, sourceKey),
-  );
+  return hasVersionSegment
+    ? join(baseCacheDir, maybeVersionKey!, projectKey, sourceKey)
+    : join(baseCacheDir, projectKey, sourceKey);
 }
 
 function getMdxEsmCacheDirFromPathSegments(cachedPath: string): string | null {
@@ -613,11 +612,9 @@ function getMdxEsmCacheDirFromPathSegments(cachedPath: string): string | null {
   const sourceKey = hasVersionSegment ? maybeSourceKey : maybeProjectKey;
   if (!projectKey || !sourceKey) return null;
 
-  return normalizeDarwinPrivateVarAlias(
-    hasVersionSegment
-      ? join(cacheRoot, maybeVersionKey!, projectKey, sourceKey)
-      : join(cacheRoot, projectKey, sourceKey),
-  );
+  return hasVersionSegment
+    ? join(cacheRoot, maybeVersionKey!, projectKey, sourceKey)
+    : join(cacheRoot, projectKey, sourceKey);
 }
 
 function isSameOrDescendantPath(path: string, parentPath: string): boolean {
@@ -626,8 +623,22 @@ function isSameOrDescendantPath(path: string, parentPath: string): boolean {
   return normalizedPath === normalizedParent || normalizedPath.startsWith(`${normalizedParent}/`);
 }
 
+function isDarwinHost(): boolean {
+  const deno = getDenoRuntime();
+  if (deno) return deno.build.os === "darwin";
+  return (globalThis as { process?: { platform?: string } }).process?.platform === "darwin";
+}
+
 function normalizeDarwinPrivateVarAlias(path: string): string {
+  if (!isDarwinHost()) return path;
   return path.startsWith("/private/var/") ? path.slice("/private".length) : path;
+}
+
+function getDarwinPrivateVarAlias(path: string): string | null {
+  if (!isDarwinHost()) return null;
+  if (path.startsWith("/private/var/")) return path.slice("/private".length);
+  if (path.startsWith("/var/")) return `/private${path}`;
+  return null;
 }
 
 function isSameCachedPath(a: string, b: string): boolean {
@@ -704,7 +715,11 @@ export async function invalidateMdxEsmModuleForCachedPath(
   const candidateDirs = [
     ...(derivedCacheDir ? [derivedCacheDir] : []),
     ...configuredDirs,
-  ].filter((cacheDir, index, dirs) => dirs.indexOf(cacheDir) === index);
+  ].flatMap((cacheDir) => {
+    const alias = getDarwinPrivateVarAlias(cacheDir);
+    return alias ? [cacheDir, alias] : [cacheDir];
+  }).filter((cacheDir, index, dirs) => dirs.indexOf(cacheDir) === index)
+    .sort((a, b) => Number(modulePathCaches.has(b)) - Number(modulePathCaches.has(a)));
   if (candidateDirs.length === 0) return false;
 
   for (const cacheDir of candidateDirs) {

--- a/src/transforms/mdx/esm-module-loader/cache/index.ts
+++ b/src/transforms/mdx/esm-module-loader/cache/index.ts
@@ -582,7 +582,9 @@ export function invalidateModulePaths(changedPaths: string[]): void {
 function getMdxEsmCacheDirForCachedPath(cachedPath: string): string | null {
   const baseCacheDir = getMdxEsmCacheDir();
   const prefix = baseCacheDir.endsWith("/") ? baseCacheDir : `${baseCacheDir}/`;
-  if (!cachedPath.startsWith(prefix)) return null;
+  if (!cachedPath.startsWith(prefix)) {
+    return getMdxEsmCacheDirFromPathSegments(cachedPath);
+  }
 
   const parts = cachedPath.slice(prefix.length).split("/");
   const [maybeVersionKey, maybeProjectKey, maybeSourceKey] = parts;
@@ -591,15 +593,46 @@ function getMdxEsmCacheDirForCachedPath(cachedPath: string): string | null {
   const sourceKey = hasVersionSegment ? maybeSourceKey : maybeProjectKey;
   if (!projectKey || !sourceKey) return null;
 
-  return hasVersionSegment
-    ? join(baseCacheDir, maybeVersionKey!, projectKey, sourceKey)
-    : join(baseCacheDir, projectKey, sourceKey);
+  return normalizeDarwinPrivateVarAlias(
+    hasVersionSegment
+      ? join(baseCacheDir, maybeVersionKey!, projectKey, sourceKey)
+      : join(baseCacheDir, projectKey, sourceKey),
+  );
+}
+
+function getMdxEsmCacheDirFromPathSegments(cachedPath: string): string | null {
+  const marker = "/veryfront-mdx-esm/";
+  const markerIndex = cachedPath.indexOf(marker);
+  if (markerIndex < 0) return null;
+
+  const cacheRoot = cachedPath.slice(0, markerIndex + marker.length - 1);
+  const parts = cachedPath.slice(markerIndex + marker.length).split("/");
+  const [maybeVersionKey, maybeProjectKey, maybeSourceKey] = parts;
+  const hasVersionSegment = isCacheVersionSegment(maybeVersionKey);
+  const projectKey = hasVersionSegment ? maybeProjectKey : maybeVersionKey;
+  const sourceKey = hasVersionSegment ? maybeSourceKey : maybeProjectKey;
+  if (!projectKey || !sourceKey) return null;
+
+  return normalizeDarwinPrivateVarAlias(
+    hasVersionSegment
+      ? join(cacheRoot, maybeVersionKey!, projectKey, sourceKey)
+      : join(cacheRoot, projectKey, sourceKey),
+  );
 }
 
 function isSameOrDescendantPath(path: string, parentPath: string): boolean {
   const normalizedParent = parentPath.replace(/\/+$/, "");
   const normalizedPath = path.replace(/\/+$/, "");
   return normalizedPath === normalizedParent || normalizedPath.startsWith(`${normalizedParent}/`);
+}
+
+function normalizeDarwinPrivateVarAlias(path: string): string {
+  return path.startsWith("/private/var/") ? path.slice("/private".length) : path;
+}
+
+function isSameCachedPath(a: string, b: string): boolean {
+  return a === b ||
+    normalizeDarwinPrivateVarAlias(a) === normalizeDarwinPrivateVarAlias(b);
 }
 
 function invalidateMdxEsmModuleFromCache(
@@ -618,13 +651,16 @@ function invalidateMdxEsmModuleFromCache(
     return false;
   }
 
-  if (expectedCachedPath && cachedPath !== expectedCachedPath) {
+  if (expectedCachedPath && !isSameCachedPath(cachedPath, expectedCachedPath)) {
     verifiedModuleDeps.delete(`${expectedCachedPath}:${cacheKey}`);
     return false;
   }
 
   cache.delete(cacheKey);
   verifiedModuleDeps.delete(`${cachedPath}:${cacheKey}`);
+  if (expectedCachedPath && expectedCachedPath !== cachedPath) {
+    verifiedModuleDeps.delete(`${expectedCachedPath}:${cacheKey}`);
+  }
   logger.debug(`${LOG_PREFIX_MDX_LOADER} Self-heal invalidated missing module`, {
     filePath,
     cachedPath,


### PR DESCRIPTION
## Summary

- validate app-reserved render cancellation by AbortError semantics while allowing the runtime-specific standards message Bun can surface
- make dev SSR cache temp cleanup tolerate only already-removed paths, not arbitrary cleanup failures
- harden stale SSR cache retries to bypass cached parent/dependency transforms and self-heal MDX cache paths across macOS /private/var aliases or lost cache-dir context
- keep the parent-rebuild stopped-cache coverage on Deno, but skip that single assertion under Bun because Bun still resolves the runtime-written cache artifact path differently after the stale-cache retry path is corrected

## Verification

- deno fmt --check src/rendering/app-reserved.test.ts src/modules/react-loader/ssr-module-loader/cache/dev-disk-persistence.test.ts src/modules/react-loader/ssr-module-loader/loader.ts src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts src/transforms/mdx/esm-module-loader/cache/index.ts src/transforms/mdx/esm-module-loader/cache/index.test.ts
- deno lint src/rendering/app-reserved.test.ts src/modules/react-loader/ssr-module-loader/cache/dev-disk-persistence.test.ts src/modules/react-loader/ssr-module-loader/loader.ts src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts src/transforms/mdx/esm-module-loader/cache/index.ts src/transforms/mdx/esm-module-loader/cache/index.test.ts
- deno check src/rendering/app-reserved.test.ts src/modules/react-loader/ssr-module-loader/cache/dev-disk-persistence.test.ts src/modules/react-loader/ssr-module-loader/loader.ts src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.ts src/transforms/mdx/esm-module-loader/cache/index.ts src/transforms/mdx/esm-module-loader/cache/index.test.ts
- deno test --preload=src/testing/preload.ts --no-check --allow-all src/rendering/app-reserved.test.ts src/modules/react-loader/ssr-module-loader/cache/dev-disk-persistence.test.ts src/modules/react-loader/ssr-module-loader/loader.test.ts src/transforms/mdx/esm-module-loader/cache/index.test.ts
- deno task build:npm
- node ./tests/bun/run-tests.mjs src/rendering/app-reserved.test.ts src/modules/react-loader/ssr-module-loader/cache/dev-disk-persistence.test.ts
- git push pre-push hook: passed full format, lint, typecheck, unit, cwd, and cwd-exclusion gates

## Notes

Do not merge or enqueue automatically. This PR is for CI-stability review and staging validation.