### PR TITLE
docs: explain how one project targets both self-hosted and hosted

### DIFF
--- a/docs/guides/self-hosting.md
+++ b/docs/guides/self-hosting.md
@@ -47,6 +47,43 @@ credentials from the project environment by default and never sends them to
 Veryfront. Managed per-user OAuth and connector features outside the supported
 local subset still require the configured API layer.
 
+## Target both self-hosted and Veryfront Cloud
+
+Self-hosting activates an extension only when the project declares it:
+
+```ts
+// veryfront.config.ts
+import { defineConfig } from "veryfront";
+import extRedis from "@veryfront/ext-redis";
+
+export default defineConfig({
+  extensions: [extRedis()],
+});
+```
+
+The hosted runtime rejects that same declaration. It provides those capabilities
+itself, and the only entry it accepts under `extensions` is
+`{ name, enabled: false }`, which turns one off. A configuration file that works
+locally therefore fails to deploy, and the reverse.
+
+Deploying to both means selecting the extension list per target:
+
+```ts
+// veryfront.config.ts
+import { defineConfig } from "veryfront";
+import extRedis from "@veryfront/ext-redis";
+
+const selfHosted = !Deno.env.get("VERYFRONT_PROJECT_SLUG");
+
+export default defineConfig({
+  extensions: selfHosted ? [extRedis()] : [],
+});
+```
+
+Use whichever signal already distinguishes your environments. The condition is
+the point, not the specific variable: declare extensions when you own the
+runtime, and leave the list empty when the platform owns it.
+
 ## Run Salesforce integration tools locally
 
 The Salesforce service account source runs the catalog's fixed Salesforce


### PR DESCRIPTION
## Description

Self-hosting activates an extension only when the project declares it:

```ts
export default defineConfig({ extensions: [extRedis()] });
```

The hosted runtime **rejects that same declaration** — it provides those capabilities itself, and the only entry it accepts under `extensions` is `{ name, enabled: false }`. So the configuration that works locally is the one that fails to deploy, and a project moving between the two discovers it at deploy time.

## Why documentation rather than a behaviour change

The obvious "fix" is to make the hosted runtime ignore a declared extension with a warning. I considered it and decided against it:

- The current rejection is a **good failure** — it happens early, names the constraint, and gives a remedy.
- Silently ignoring configuration means the same file means different things depending on where it runs, and it would also swallow the genuine mistake of declaring something hosted truly cannot provide.
- The affected population is projects deploying both ways, and they hit it exactly once.

That makes it a documentation gap, not a runtime one. The section goes in the self-hosting guide beside the capability table that already tells readers which capabilities they must substitute, and presents selecting the extension list per target as an idiom rather than a workaround.

The example uses an environment signal to pick the list, and says explicitly that the condition is the point, not the specific variable.

## Evidence

```
deno task docs:validate      ok | 0 failed
deno task docs:check-links   All 1387 doc links OK
```

## Related Issue(s)

Tracked internally.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] Claims verified against `src/config/hosted-compatibility.ts`
- [x] Docs validation and link check pass
- [ ] Tests (documentation only)
