### PR TITLE
test(react): give the JSDOM harness one home

### DIFF
--- a/src/react/components/ui/adapter/drawer.conformance.test.tsx
+++ b/src/react/components/ui/adapter/drawer.conformance.test.tsx
@@ -13,12 +13,12 @@ import { createRoot } from "react-dom/client";
 import { JSDOM } from "npm:jsdom@28.0.0";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 import { Drawer, DrawerClose, DrawerContent, DrawerTitle, DrawerTrigger } from "../drawer.tsx";
 import { UIAdapterProvider } from "./context.tsx";
 import { Slot } from "../slot.tsx";
 import type { DrawerParts } from "./contract.ts";
 
-import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 function installDom(dom: JSDOM): () => void {
   return installComponentDom(dom);
 }

--- a/src/react/components/ui/adapter/drawer.conformance.test.tsx
+++ b/src/react/components/ui/adapter/drawer.conformance.test.tsx
@@ -18,57 +18,9 @@ import { UIAdapterProvider } from "./context.tsx";
 import { Slot } from "../slot.tsx";
 import type { DrawerParts } from "./contract.ts";
 
-class ResizeObserverStub {
-  observe(): void {}
-  unobserve(): void {}
-  disconnect(): void {}
-}
-
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 function installDom(dom: JSDOM): () => void {
-  const w = dom.window as unknown as Record<string, unknown>;
-  const g = globalThis as unknown as Record<string, unknown>;
-  const keys = [
-    "document",
-    "window",
-    "navigator",
-    "HTMLElement",
-    "Node",
-    "Element",
-    "MouseEvent",
-    "getComputedStyle",
-    "ResizeObserver",
-    "requestAnimationFrame",
-    "cancelAnimationFrame",
-  ];
-  const prev: Record<string, unknown> = {};
-  for (const k of keys) prev[k] = g[k];
-  for (const k of keys) g[k] = w[k];
-  g.document = w.document;
-  g.window = w;
-  g.getComputedStyle = (w.getComputedStyle as (e: Element) => CSSStyleDeclaration).bind(w);
-  g.ResizeObserver = ResizeObserverStub;
-  // The stub is a real timer, so a frame still queued when the test ends is a
-  // pending timer and trips the leak sanitizer. React can schedule a frame right
-  // up to unmount, so track outstanding frames and drain them on teardown.
-  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
-  g.requestAnimationFrame = (cb: (t: number) => void) => {
-    const id = setTimeout(() => {
-      pendingFrames.delete(id);
-      cb(0);
-    }, 0);
-    pendingFrames.add(id);
-    return id as unknown as number;
-  };
-  g.cancelAnimationFrame = (id: number) => {
-    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
-    clearTimeout(id);
-  };
-  return () => {
-    for (const frame of pendingFrames) clearTimeout(frame);
-    pendingFrames.clear();
-    for (const k of keys) g[k] = prev[k];
-    dom.window.close();
-  };
+  return installComponentDom(dom);
 }
 
 function render(el: React.ReactElement): { doc: Document; unmount: () => void } {

--- a/src/react/components/ui/alert-dialog.test.tsx
+++ b/src/react/components/ui/alert-dialog.test.tsx
@@ -18,6 +18,7 @@ import { JSDOM } from "npm:jsdom@28.0.0";
 import { unmountReactRoot } from "#veryfront/react/react-root.test-helpers.ts";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 
 import {
   AlertDialog,
@@ -31,7 +32,6 @@ import {
 } from "./alert-dialog.tsx";
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "./dialog.tsx";
 
-import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 // ---------------------------------------------------------------------------
 // jsdom harness - installs a fresh DOM per render and stubs the browser APIs
 // jsdom lacks (ResizeObserver, rAF, matchMedia) so effect-driven components mount.
@@ -39,7 +39,7 @@ import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 function installDom(dom: JSDOM): () => void {
   return installComponentDom(dom, {
     matchMedia: true,
-    windowGlobals: ["KeyboardEvent", "FocusEvent"],
+    windowGlobals: ["KeyboardEvent", "FocusEvent", "HTMLButtonElement"],
   });
 }
 

--- a/src/react/components/ui/alert-dialog.test.tsx
+++ b/src/react/components/ui/alert-dialog.test.tsx
@@ -31,84 +31,16 @@ import {
 } from "./alert-dialog.tsx";
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "./dialog.tsx";
 
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 // ---------------------------------------------------------------------------
 // jsdom harness - installs a fresh DOM per render and stubs the browser APIs
 // jsdom lacks (ResizeObserver, rAF, matchMedia) so effect-driven components mount.
 // ---------------------------------------------------------------------------
-class ResizeObserverStub {
-  observe(): void {}
-  unobserve(): void {}
-  disconnect(): void {}
-}
-
 function installDom(dom: JSDOM): () => void {
-  const w = dom.window as unknown as Record<string, unknown>;
-  const g = globalThis as unknown as Record<string, unknown>;
-  const keys = [
-    "document",
-    "window",
-    "navigator",
-    "HTMLElement",
-    "HTMLButtonElement",
-    "Node",
-    "Element",
-    "FocusEvent",
-    "KeyboardEvent",
-    "MouseEvent",
-    "getComputedStyle",
-    "ResizeObserver",
-    "matchMedia",
-    "requestAnimationFrame",
-    "cancelAnimationFrame",
-  ];
-  const prev: Record<string, unknown> = {};
-  for (const k of keys) prev[k] = g[k];
-
-  g.document = w.document;
-  g.window = w;
-  g.navigator = w.navigator;
-  g.HTMLElement = w.HTMLElement;
-  g.HTMLButtonElement = w.HTMLButtonElement;
-  g.Node = w.Node;
-  g.Element = w.Element;
-  g.FocusEvent = w.FocusEvent;
-  g.KeyboardEvent = w.KeyboardEvent;
-  g.MouseEvent = w.MouseEvent;
-  g.getComputedStyle = (w.getComputedStyle as (e: Element) => CSSStyleDeclaration).bind(w);
-  g.ResizeObserver = ResizeObserverStub;
-  g.matchMedia = () => ({
-    matches: false,
-    media: "",
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    addListener: () => {},
-    removeListener: () => {},
-    onchange: null,
-    dispatchEvent: () => false,
+  return installComponentDom(dom, {
+    matchMedia: true,
+    windowGlobals: ["KeyboardEvent", "FocusEvent"],
   });
-  // The stub is a real timer, so a frame still queued when the test ends is a
-  // pending timer and trips the leak sanitizer. React can schedule a frame right
-  // up to unmount, so track outstanding frames and drain them on teardown.
-  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
-  g.requestAnimationFrame = (cb: (t: number) => void) => {
-    const id = setTimeout(() => {
-      pendingFrames.delete(id);
-      cb(0);
-    }, 0);
-    pendingFrames.add(id);
-    return id as unknown as number;
-  };
-  g.cancelAnimationFrame = (id: number) => {
-    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
-    clearTimeout(id);
-  };
-
-  return () => {
-    for (const frame of pendingFrames) clearTimeout(frame);
-    pendingFrames.clear();
-    for (const k of keys) g[k] = prev[k];
-    dom.window.close();
-  };
 }
 
 async function waitFor(

--- a/src/react/components/ui/breadcrumb.test.tsx
+++ b/src/react/components/ui/breadcrumb.test.tsx
@@ -13,6 +13,7 @@ import { JSDOM } from "npm:jsdom@28.0.0";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 import {
   Breadcrumb,
   BreadcrumbEllipsis,
@@ -27,74 +28,8 @@ import {
 // jsdom harness - installs a fresh DOM per render and stubs the browser APIs
 // jsdom lacks (ResizeObserver, rAF, matchMedia) so effect-driven components mount.
 // ---------------------------------------------------------------------------
-class ResizeObserverStub {
-  observe(): void {}
-  unobserve(): void {}
-  disconnect(): void {}
-}
-
 function installDom(dom: JSDOM): () => void {
-  const w = dom.window as unknown as Record<string, unknown>;
-  const g = globalThis as unknown as Record<string, unknown>;
-  const keys = [
-    "document",
-    "window",
-    "navigator",
-    "HTMLElement",
-    "Node",
-    "Element",
-    "MouseEvent",
-    "getComputedStyle",
-    "ResizeObserver",
-    "matchMedia",
-    "requestAnimationFrame",
-    "cancelAnimationFrame",
-  ];
-  const prev: Record<string, unknown> = {};
-  for (const k of keys) prev[k] = g[k];
-
-  g.document = w.document;
-  g.window = w;
-  g.navigator = w.navigator;
-  g.HTMLElement = w.HTMLElement;
-  g.Node = w.Node;
-  g.Element = w.Element;
-  g.MouseEvent = w.MouseEvent;
-  g.getComputedStyle = (w.getComputedStyle as (e: Element) => CSSStyleDeclaration).bind(w);
-  g.ResizeObserver = ResizeObserverStub;
-  g.matchMedia = () => ({
-    matches: false,
-    media: "",
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    addListener: () => {},
-    removeListener: () => {},
-    onchange: null,
-    dispatchEvent: () => false,
-  });
-  // The stub is a real timer, so a frame still queued when the test ends is a
-  // pending timer and trips the leak sanitizer. React can schedule a frame right
-  // up to unmount, so track outstanding frames and drain them on teardown.
-  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
-  g.requestAnimationFrame = (cb: (t: number) => void) => {
-    const id = setTimeout(() => {
-      pendingFrames.delete(id);
-      cb(0);
-    }, 0);
-    pendingFrames.add(id);
-    return id as unknown as number;
-  };
-  g.cancelAnimationFrame = (id: number) => {
-    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
-    clearTimeout(id);
-  };
-
-  return () => {
-    for (const frame of pendingFrames) clearTimeout(frame);
-    pendingFrames.clear();
-    for (const k of keys) g[k] = prev[k];
-    dom.window.close();
-  };
+  return installComponentDom(dom, { matchMedia: true });
 }
 
 /** Render `element` into a fresh DOM; returns the host node and a teardown. */

--- a/src/react/components/ui/calendar.test.tsx
+++ b/src/react/components/ui/calendar.test.tsx
@@ -18,80 +18,13 @@ import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { Calendar } from "./calendar.tsx";
 
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 // ---------------------------------------------------------------------------
 // jsdom harness - installs a fresh DOM per render and stubs the browser APIs
 // jsdom lacks (ResizeObserver, rAF, matchMedia) so effect-driven components mount.
 // ---------------------------------------------------------------------------
-class ResizeObserverStub {
-  observe(): void {}
-  unobserve(): void {}
-  disconnect(): void {}
-}
-
 function installDom(dom: JSDOM): () => void {
-  const w = dom.window as unknown as Record<string, unknown>;
-  const g = globalThis as unknown as Record<string, unknown>;
-  const keys = [
-    "document",
-    "window",
-    "navigator",
-    "HTMLElement",
-    "Node",
-    "Element",
-    "KeyboardEvent",
-    "MouseEvent",
-    "getComputedStyle",
-    "ResizeObserver",
-    "matchMedia",
-    "requestAnimationFrame",
-    "cancelAnimationFrame",
-  ];
-  const prev: Record<string, unknown> = {};
-  for (const k of keys) prev[k] = g[k];
-
-  g.document = w.document;
-  g.window = w;
-  g.navigator = w.navigator;
-  g.HTMLElement = w.HTMLElement;
-  g.Node = w.Node;
-  g.Element = w.Element;
-  g.KeyboardEvent = w.KeyboardEvent;
-  g.MouseEvent = w.MouseEvent;
-  g.getComputedStyle = (w.getComputedStyle as (e: Element) => CSSStyleDeclaration).bind(w);
-  g.ResizeObserver = ResizeObserverStub;
-  g.matchMedia = () => ({
-    matches: false,
-    media: "",
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    addListener: () => {},
-    removeListener: () => {},
-    onchange: null,
-    dispatchEvent: () => false,
-  });
-  // The stub is a real timer, so a frame still queued when the test ends is a
-  // pending timer and trips the leak sanitizer. React can schedule a frame right
-  // up to unmount, so track outstanding frames and drain them on teardown.
-  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
-  g.requestAnimationFrame = (cb: (t: number) => void) => {
-    const id = setTimeout(() => {
-      pendingFrames.delete(id);
-      cb(0);
-    }, 0);
-    pendingFrames.add(id);
-    return id as unknown as number;
-  };
-  g.cancelAnimationFrame = (id: number) => {
-    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
-    clearTimeout(id);
-  };
-
-  return () => {
-    for (const frame of pendingFrames) clearTimeout(frame);
-    pendingFrames.clear();
-    for (const k of keys) g[k] = prev[k];
-    dom.window.close();
-  };
+  return installComponentDom(dom, { matchMedia: true, windowGlobals: ["KeyboardEvent"] });
 }
 
 /** Render `element` into a fresh DOM; returns the host node, a click helper and a teardown. */

--- a/src/react/components/ui/calendar.test.tsx
+++ b/src/react/components/ui/calendar.test.tsx
@@ -16,9 +16,9 @@ import { createRoot } from "react-dom/client";
 import { JSDOM } from "npm:jsdom@28.0.0";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 import { Calendar } from "./calendar.tsx";
 
-import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 // ---------------------------------------------------------------------------
 // jsdom harness - installs a fresh DOM per render and stubs the browser APIs
 // jsdom lacks (ResizeObserver, rAF, matchMedia) so effect-driven components mount.

--- a/src/react/components/ui/conformance.test.tsx
+++ b/src/react/components/ui/conformance.test.tsx
@@ -24,6 +24,7 @@ import { createRoot } from "react-dom/client";
 import { JSDOM } from "npm:jsdom@28.0.0";
 import { assert } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 
 import { Button, LoadingButton } from "./button.tsx";
 import { IconButton } from "./icon-button.tsx";
@@ -61,7 +62,6 @@ import { Slider } from "./slider.tsx";
 import { Toggle } from "./toggle.tsx";
 import { ToggleGroup, ToggleGroupItem } from "./toggle-group.tsx";
 
-import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 // ---------------------------------------------------------------------------
 // jsdom harness - installs a fresh DOM per render and stubs the browser APIs
 // jsdom lacks (ResizeObserver, rAF, matchMedia) so effect-driven components mount.

--- a/src/react/components/ui/conformance.test.tsx
+++ b/src/react/components/ui/conformance.test.tsx
@@ -61,78 +61,13 @@ import { Slider } from "./slider.tsx";
 import { Toggle } from "./toggle.tsx";
 import { ToggleGroup, ToggleGroupItem } from "./toggle-group.tsx";
 
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 // ---------------------------------------------------------------------------
 // jsdom harness - installs a fresh DOM per render and stubs the browser APIs
 // jsdom lacks (ResizeObserver, rAF, matchMedia) so effect-driven components mount.
 // ---------------------------------------------------------------------------
-class ResizeObserverStub {
-  observe(): void {}
-  unobserve(): void {}
-  disconnect(): void {}
-}
-
 function installDom(dom: JSDOM): () => void {
-  const w = dom.window as unknown as Record<string, unknown>;
-  const g = globalThis as unknown as Record<string, unknown>;
-  const keys = [
-    "document",
-    "window",
-    "navigator",
-    "HTMLElement",
-    "Node",
-    "Element",
-    "MouseEvent",
-    "getComputedStyle",
-    "ResizeObserver",
-    "matchMedia",
-    "requestAnimationFrame",
-    "cancelAnimationFrame",
-  ];
-  const prev: Record<string, unknown> = {};
-  for (const k of keys) prev[k] = g[k];
-
-  g.document = w.document;
-  g.window = w;
-  g.navigator = w.navigator;
-  g.HTMLElement = w.HTMLElement;
-  g.Node = w.Node;
-  g.Element = w.Element;
-  g.MouseEvent = w.MouseEvent;
-  g.getComputedStyle = (w.getComputedStyle as (e: Element) => CSSStyleDeclaration).bind(w);
-  g.ResizeObserver = ResizeObserverStub;
-  g.matchMedia = () => ({
-    matches: false,
-    media: "",
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    addListener: () => {},
-    removeListener: () => {},
-    onchange: null,
-    dispatchEvent: () => false,
-  });
-  // The stub is a real timer, so a frame still queued when the test ends is a
-  // pending timer and trips the leak sanitizer. React can schedule a frame right
-  // up to unmount, so track outstanding frames and drain them on teardown.
-  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
-  g.requestAnimationFrame = (cb: (t: number) => void) => {
-    const id = setTimeout(() => {
-      pendingFrames.delete(id);
-      cb(0);
-    }, 0);
-    pendingFrames.add(id);
-    return id as unknown as number;
-  };
-  g.cancelAnimationFrame = (id: number) => {
-    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
-    clearTimeout(id);
-  };
-
-  return () => {
-    for (const frame of pendingFrames) clearTimeout(frame);
-    pendingFrames.clear();
-    for (const k of keys) g[k] = prev[k];
-    dom.window.close();
-  };
+  return installComponentDom(dom, { matchMedia: true });
 }
 
 /** Render `element` into a fresh DOM; returns the host node and a teardown. */

--- a/src/react/components/ui/date-picker.test.tsx
+++ b/src/react/components/ui/date-picker.test.tsx
@@ -18,9 +18,9 @@ import { createRoot } from "react-dom/client";
 import { JSDOM } from "npm:jsdom@28.0.0";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 import { DatePicker, DatePickerContent, DatePickerTrigger } from "./date-picker.tsx";
 
-import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 // ---------------------------------------------------------------------------
 // jsdom harness - installs a fresh DOM per render and stubs the browser APIs
 // jsdom lacks (ResizeObserver, rAF, matchMedia) that Popover's Floating needs.

--- a/src/react/components/ui/date-picker.test.tsx
+++ b/src/react/components/ui/date-picker.test.tsx
@@ -20,78 +20,13 @@ import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { DatePicker, DatePickerContent, DatePickerTrigger } from "./date-picker.tsx";
 
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 // ---------------------------------------------------------------------------
 // jsdom harness - installs a fresh DOM per render and stubs the browser APIs
 // jsdom lacks (ResizeObserver, rAF, matchMedia) that Popover's Floating needs.
 // ---------------------------------------------------------------------------
-class ResizeObserverStub {
-  observe(): void {}
-  unobserve(): void {}
-  disconnect(): void {}
-}
-
 function installDom(dom: JSDOM): () => void {
-  const w = dom.window as unknown as Record<string, unknown>;
-  const g = globalThis as unknown as Record<string, unknown>;
-  const keys = [
-    "document",
-    "window",
-    "navigator",
-    "HTMLElement",
-    "Node",
-    "Element",
-    "MouseEvent",
-    "getComputedStyle",
-    "ResizeObserver",
-    "matchMedia",
-    "requestAnimationFrame",
-    "cancelAnimationFrame",
-  ];
-  const prev: Record<string, unknown> = {};
-  for (const k of keys) prev[k] = g[k];
-
-  g.document = w.document;
-  g.window = w;
-  g.navigator = w.navigator;
-  g.HTMLElement = w.HTMLElement;
-  g.Node = w.Node;
-  g.Element = w.Element;
-  g.MouseEvent = w.MouseEvent;
-  g.getComputedStyle = (w.getComputedStyle as (e: Element) => CSSStyleDeclaration).bind(w);
-  g.ResizeObserver = ResizeObserverStub;
-  g.matchMedia = () => ({
-    matches: false,
-    media: "",
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    addListener: () => {},
-    removeListener: () => {},
-    onchange: null,
-    dispatchEvent: () => false,
-  });
-  // The stub is a real timer, so a frame still queued when the test ends is a
-  // pending timer and trips the leak sanitizer. React can schedule a frame right
-  // up to unmount, so track outstanding frames and drain them on teardown.
-  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
-  g.requestAnimationFrame = (cb: (t: number) => void) => {
-    const id = setTimeout(() => {
-      pendingFrames.delete(id);
-      cb(0);
-    }, 0);
-    pendingFrames.add(id);
-    return id as unknown as number;
-  };
-  g.cancelAnimationFrame = (id: number) => {
-    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
-    clearTimeout(id);
-  };
-
-  return () => {
-    for (const frame of pendingFrames) clearTimeout(frame);
-    pendingFrames.clear();
-    for (const k of keys) g[k] = prev[k];
-    dom.window.close();
-  };
+  return installComponentDom(dom, { matchMedia: true });
 }
 
 /** Render `element` into a fresh DOM; returns the host node, a click helper, and teardown. */

--- a/src/react/components/ui/field.test.tsx
+++ b/src/react/components/ui/field.test.tsx
@@ -11,10 +11,10 @@ import { createRoot } from "react-dom/client";
 import { JSDOM } from "npm:jsdom@28.0.0";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 
 import { Field, FieldControl, FieldDescription, FieldError, FieldLabel } from "./field.tsx";
 
-import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 // ---------------------------------------------------------------------------
 // jsdom harness (from conformance.test.tsx) - fresh DOM per render, with the
 // browser-API stubs effect-driven components expect.

--- a/src/react/components/ui/field.test.tsx
+++ b/src/react/components/ui/field.test.tsx
@@ -14,78 +14,13 @@ import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 
 import { Field, FieldControl, FieldDescription, FieldError, FieldLabel } from "./field.tsx";
 
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 // ---------------------------------------------------------------------------
 // jsdom harness (from conformance.test.tsx) - fresh DOM per render, with the
 // browser-API stubs effect-driven components expect.
 // ---------------------------------------------------------------------------
-class ResizeObserverStub {
-  observe(): void {}
-  unobserve(): void {}
-  disconnect(): void {}
-}
-
 function installDom(dom: JSDOM): () => void {
-  const w = dom.window as unknown as Record<string, unknown>;
-  const g = globalThis as unknown as Record<string, unknown>;
-  const keys = [
-    "document",
-    "window",
-    "navigator",
-    "HTMLElement",
-    "Node",
-    "Element",
-    "MouseEvent",
-    "getComputedStyle",
-    "ResizeObserver",
-    "matchMedia",
-    "requestAnimationFrame",
-    "cancelAnimationFrame",
-  ];
-  const prev: Record<string, unknown> = {};
-  for (const k of keys) prev[k] = g[k];
-
-  g.document = w.document;
-  g.window = w;
-  g.navigator = w.navigator;
-  g.HTMLElement = w.HTMLElement;
-  g.Node = w.Node;
-  g.Element = w.Element;
-  g.MouseEvent = w.MouseEvent;
-  g.getComputedStyle = (w.getComputedStyle as (e: Element) => CSSStyleDeclaration).bind(w);
-  g.ResizeObserver = ResizeObserverStub;
-  g.matchMedia = () => ({
-    matches: false,
-    media: "",
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    addListener: () => {},
-    removeListener: () => {},
-    onchange: null,
-    dispatchEvent: () => false,
-  });
-  // The stub is a real timer, so a frame still queued when the test ends is a
-  // pending timer and trips the leak sanitizer. React can schedule a frame right
-  // up to unmount, so track outstanding frames and drain them on teardown.
-  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
-  g.requestAnimationFrame = (cb: (t: number) => void) => {
-    const id = setTimeout(() => {
-      pendingFrames.delete(id);
-      cb(0);
-    }, 0);
-    pendingFrames.add(id);
-    return id as unknown as number;
-  };
-  g.cancelAnimationFrame = (id: number) => {
-    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
-    clearTimeout(id);
-  };
-
-  return () => {
-    for (const frame of pendingFrames) clearTimeout(frame);
-    pendingFrames.clear();
-    for (const k of keys) g[k] = prev[k];
-    dom.window.close();
-  };
+  return installComponentDom(dom, { matchMedia: true });
 }
 
 function render(element: React.ReactElement): {

--- a/src/react/components/ui/input-otp.test.tsx
+++ b/src/react/components/ui/input-otp.test.tsx
@@ -18,78 +18,13 @@ import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { InputOTP } from "./input-otp.tsx";
 
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 // ---------------------------------------------------------------------------
 // jsdom harness - installs a fresh DOM per render and stubs the browser APIs
 // jsdom lacks (ResizeObserver, rAF, matchMedia) so effect-driven components mount.
 // ---------------------------------------------------------------------------
-class ResizeObserverStub {
-  observe(): void {}
-  unobserve(): void {}
-  disconnect(): void {}
-}
-
 function installDom(dom: JSDOM): () => void {
-  const w = dom.window as unknown as Record<string, unknown>;
-  const g = globalThis as unknown as Record<string, unknown>;
-  const keys = [
-    "document",
-    "window",
-    "navigator",
-    "HTMLElement",
-    "Node",
-    "Element",
-    "MouseEvent",
-    "getComputedStyle",
-    "ResizeObserver",
-    "matchMedia",
-    "requestAnimationFrame",
-    "cancelAnimationFrame",
-  ];
-  const prev: Record<string, unknown> = {};
-  for (const k of keys) prev[k] = g[k];
-
-  g.document = w.document;
-  g.window = w;
-  g.navigator = w.navigator;
-  g.HTMLElement = w.HTMLElement;
-  g.Node = w.Node;
-  g.Element = w.Element;
-  g.MouseEvent = w.MouseEvent;
-  g.getComputedStyle = (w.getComputedStyle as (e: Element) => CSSStyleDeclaration).bind(w);
-  g.ResizeObserver = ResizeObserverStub;
-  g.matchMedia = () => ({
-    matches: false,
-    media: "",
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    addListener: () => {},
-    removeListener: () => {},
-    onchange: null,
-    dispatchEvent: () => false,
-  });
-  // The stub is a real timer, so a frame still queued when the test ends is a
-  // pending timer and trips the leak sanitizer. React can schedule a frame right
-  // up to unmount, so track outstanding frames and drain them on teardown.
-  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
-  g.requestAnimationFrame = (cb: (t: number) => void) => {
-    const id = setTimeout(() => {
-      pendingFrames.delete(id);
-      cb(0);
-    }, 0);
-    pendingFrames.add(id);
-    return id as unknown as number;
-  };
-  g.cancelAnimationFrame = (id: number) => {
-    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
-    clearTimeout(id);
-  };
-
-  return () => {
-    for (const frame of pendingFrames) clearTimeout(frame);
-    pendingFrames.clear();
-    for (const k of keys) g[k] = prev[k];
-    dom.window.close();
-  };
+  return installComponentDom(dom, { matchMedia: true });
 }
 
 /** Render `element` into a fresh DOM; returns the host node and a teardown. */

--- a/src/react/components/ui/input-otp.test.tsx
+++ b/src/react/components/ui/input-otp.test.tsx
@@ -16,9 +16,9 @@ import { createRoot } from "react-dom/client";
 import { JSDOM } from "npm:jsdom@28.0.0";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 import { InputOTP } from "./input-otp.tsx";
 
-import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 // ---------------------------------------------------------------------------
 // jsdom harness - installs a fresh DOM per render and stubs the browser APIs
 // jsdom lacks (ResizeObserver, rAF, matchMedia) so effect-driven components mount.

--- a/src/react/components/ui/meter.test.tsx
+++ b/src/react/components/ui/meter.test.tsx
@@ -14,78 +14,13 @@ import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { Meter } from "./meter.tsx";
 
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 // ---------------------------------------------------------------------------
 // jsdom harness - installs a fresh DOM per render and stubs the browser APIs
 // jsdom lacks (ResizeObserver, rAF, matchMedia) so effect-driven components mount.
 // ---------------------------------------------------------------------------
-class ResizeObserverStub {
-  observe(): void {}
-  unobserve(): void {}
-  disconnect(): void {}
-}
-
 function installDom(dom: JSDOM): () => void {
-  const w = dom.window as unknown as Record<string, unknown>;
-  const g = globalThis as unknown as Record<string, unknown>;
-  const keys = [
-    "document",
-    "window",
-    "navigator",
-    "HTMLElement",
-    "Node",
-    "Element",
-    "MouseEvent",
-    "getComputedStyle",
-    "ResizeObserver",
-    "matchMedia",
-    "requestAnimationFrame",
-    "cancelAnimationFrame",
-  ];
-  const prev: Record<string, unknown> = {};
-  for (const k of keys) prev[k] = g[k];
-
-  g.document = w.document;
-  g.window = w;
-  g.navigator = w.navigator;
-  g.HTMLElement = w.HTMLElement;
-  g.Node = w.Node;
-  g.Element = w.Element;
-  g.MouseEvent = w.MouseEvent;
-  g.getComputedStyle = (w.getComputedStyle as (e: Element) => CSSStyleDeclaration).bind(w);
-  g.ResizeObserver = ResizeObserverStub;
-  g.matchMedia = () => ({
-    matches: false,
-    media: "",
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    addListener: () => {},
-    removeListener: () => {},
-    onchange: null,
-    dispatchEvent: () => false,
-  });
-  // The stub is a real timer, so a frame still queued when the test ends is a
-  // pending timer and trips the leak sanitizer. React can schedule a frame right
-  // up to unmount, so track outstanding frames and drain them on teardown.
-  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
-  g.requestAnimationFrame = (cb: (t: number) => void) => {
-    const id = setTimeout(() => {
-      pendingFrames.delete(id);
-      cb(0);
-    }, 0);
-    pendingFrames.add(id);
-    return id as unknown as number;
-  };
-  g.cancelAnimationFrame = (id: number) => {
-    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
-    clearTimeout(id);
-  };
-
-  return () => {
-    for (const frame of pendingFrames) clearTimeout(frame);
-    pendingFrames.clear();
-    for (const k of keys) g[k] = prev[k];
-    dom.window.close();
-  };
+  return installComponentDom(dom, { matchMedia: true });
 }
 
 /** Render `element` into a fresh DOM; returns the host node and a teardown. */

--- a/src/react/components/ui/meter.test.tsx
+++ b/src/react/components/ui/meter.test.tsx
@@ -12,9 +12,9 @@ import { createRoot } from "react-dom/client";
 import { JSDOM } from "npm:jsdom@28.0.0";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 import { Meter } from "./meter.tsx";
 
-import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 // ---------------------------------------------------------------------------
 // jsdom harness - installs a fresh DOM per render and stubs the browser APIs
 // jsdom lacks (ResizeObserver, rAF, matchMedia) so effect-driven components mount.

--- a/src/react/components/ui/navigation-menu.test.tsx
+++ b/src/react/components/ui/navigation-menu.test.tsx
@@ -18,6 +18,7 @@ import { createRoot } from "react-dom/client";
 import { JSDOM } from "npm:jsdom@28.0.0";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 import {
   NavigationMenu,
   NavigationMenuContent,
@@ -31,79 +32,11 @@ import {
 // jsdom harness - installs a fresh DOM per render and stubs the browser APIs
 // jsdom lacks (ResizeObserver, rAF, matchMedia) so effect-driven components mount.
 // ---------------------------------------------------------------------------
-class ResizeObserverStub {
-  observe(): void {}
-  unobserve(): void {}
-  disconnect(): void {}
-}
-
 function installDom(dom: JSDOM): () => void {
-  const w = dom.window as unknown as Record<string, unknown>;
-  const g = globalThis as unknown as Record<string, unknown>;
-  const keys = [
-    "document",
-    "window",
-    "navigator",
-    "HTMLElement",
-    "Node",
-    "Element",
-    "MouseEvent",
-    "KeyboardEvent",
-    "FocusEvent",
-    "getComputedStyle",
-    "ResizeObserver",
-    "matchMedia",
-    "requestAnimationFrame",
-    "cancelAnimationFrame",
-  ];
-  const prev: Record<string, unknown> = {};
-  for (const k of keys) prev[k] = g[k];
-
-  g.document = w.document;
-  g.window = w;
-  g.navigator = w.navigator;
-  g.HTMLElement = w.HTMLElement;
-  g.Node = w.Node;
-  g.Element = w.Element;
-  g.MouseEvent = w.MouseEvent;
-  g.KeyboardEvent = w.KeyboardEvent;
-  g.FocusEvent = w.FocusEvent;
-  g.getComputedStyle = (w.getComputedStyle as (e: Element) => CSSStyleDeclaration).bind(w);
-  g.ResizeObserver = ResizeObserverStub;
-  g.matchMedia = () => ({
-    matches: false,
-    media: "",
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    addListener: () => {},
-    removeListener: () => {},
-    onchange: null,
-    dispatchEvent: () => false,
+  return installComponentDom(dom, {
+    matchMedia: true,
+    windowGlobals: ["KeyboardEvent", "FocusEvent"],
   });
-  // rAF is stubbed with a real timer, so a frame still queued when the test ends
-  // is a leaked timer and trips the sanitizer. Track them and drain on teardown:
-  // React can schedule a frame right up to unmount, and under a loaded parallel
-  // suite that frame may not have run yet.
-  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
-  g.requestAnimationFrame = (cb: (t: number) => void) => {
-    const id = setTimeout(() => {
-      pendingFrames.delete(id);
-      cb(0);
-    }, 0);
-    pendingFrames.add(id);
-    return id as unknown as number;
-  };
-  g.cancelAnimationFrame = (id: number) => {
-    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
-    clearTimeout(id);
-  };
-
-  return () => {
-    for (const frame of pendingFrames) clearTimeout(frame);
-    pendingFrames.clear();
-    for (const k of keys) g[k] = prev[k];
-    dom.window.close();
-  };
 }
 
 /** Render `element` into a fresh DOM; returns the host node, a click helper and a teardown. */

--- a/src/react/components/ui/pagination.test.tsx
+++ b/src/react/components/ui/pagination.test.tsx
@@ -11,6 +11,7 @@ import { createRoot } from "react-dom/client";
 import { JSDOM } from "npm:jsdom@28.0.0";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 import {
   Pagination,
   PaginationContent,
@@ -25,74 +26,8 @@ import {
 // jsdom harness (copied from conformance.test.tsx) - fresh DOM per render with
 // the browser-API stubs (ResizeObserver/matchMedia/rAF) effect-driven mounts need.
 // ---------------------------------------------------------------------------
-class ResizeObserverStub {
-  observe(): void {}
-  unobserve(): void {}
-  disconnect(): void {}
-}
-
 function installDom(dom: JSDOM): () => void {
-  const w = dom.window as unknown as Record<string, unknown>;
-  const g = globalThis as unknown as Record<string, unknown>;
-  const keys = [
-    "document",
-    "window",
-    "navigator",
-    "HTMLElement",
-    "Node",
-    "Element",
-    "MouseEvent",
-    "getComputedStyle",
-    "ResizeObserver",
-    "matchMedia",
-    "requestAnimationFrame",
-    "cancelAnimationFrame",
-  ];
-  const prev: Record<string, unknown> = {};
-  for (const k of keys) prev[k] = g[k];
-
-  g.document = w.document;
-  g.window = w;
-  g.navigator = w.navigator;
-  g.HTMLElement = w.HTMLElement;
-  g.Node = w.Node;
-  g.Element = w.Element;
-  g.MouseEvent = w.MouseEvent;
-  g.getComputedStyle = (w.getComputedStyle as (e: Element) => CSSStyleDeclaration).bind(w);
-  g.ResizeObserver = ResizeObserverStub;
-  g.matchMedia = () => ({
-    matches: false,
-    media: "",
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    addListener: () => {},
-    removeListener: () => {},
-    onchange: null,
-    dispatchEvent: () => false,
-  });
-  // The stub is a real timer, so a frame still queued when the test ends is a
-  // pending timer and trips the leak sanitizer. React can schedule a frame right
-  // up to unmount, so track outstanding frames and drain them on teardown.
-  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
-  g.requestAnimationFrame = (cb: (t: number) => void) => {
-    const id = setTimeout(() => {
-      pendingFrames.delete(id);
-      cb(0);
-    }, 0);
-    pendingFrames.add(id);
-    return id as unknown as number;
-  };
-  g.cancelAnimationFrame = (id: number) => {
-    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
-    clearTimeout(id);
-  };
-
-  return () => {
-    for (const frame of pendingFrames) clearTimeout(frame);
-    pendingFrames.clear();
-    for (const k of keys) g[k] = prev[k];
-    dom.window.close();
-  };
+  return installComponentDom(dom, { matchMedia: true });
 }
 
 function render(element: React.ReactElement): {

--- a/src/react/components/ui/scroll-area.test.tsx
+++ b/src/react/components/ui/scroll-area.test.tsx
@@ -15,78 +15,13 @@ import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { ScrollArea } from "./scroll-area.tsx";
 
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 // ---------------------------------------------------------------------------
 // jsdom harness - installs a fresh DOM per render and stubs the browser APIs
 // jsdom lacks (ResizeObserver, rAF, matchMedia) so effect-driven components mount.
 // ---------------------------------------------------------------------------
-class ResizeObserverStub {
-  observe(): void {}
-  unobserve(): void {}
-  disconnect(): void {}
-}
-
 function installDom(dom: JSDOM): () => void {
-  const w = dom.window as unknown as Record<string, unknown>;
-  const g = globalThis as unknown as Record<string, unknown>;
-  const keys = [
-    "document",
-    "window",
-    "navigator",
-    "HTMLElement",
-    "Node",
-    "Element",
-    "MouseEvent",
-    "getComputedStyle",
-    "ResizeObserver",
-    "matchMedia",
-    "requestAnimationFrame",
-    "cancelAnimationFrame",
-  ];
-  const prev: Record<string, unknown> = {};
-  for (const k of keys) prev[k] = g[k];
-
-  g.document = w.document;
-  g.window = w;
-  g.navigator = w.navigator;
-  g.HTMLElement = w.HTMLElement;
-  g.Node = w.Node;
-  g.Element = w.Element;
-  g.MouseEvent = w.MouseEvent;
-  g.getComputedStyle = (w.getComputedStyle as (e: Element) => CSSStyleDeclaration).bind(w);
-  g.ResizeObserver = ResizeObserverStub;
-  g.matchMedia = () => ({
-    matches: false,
-    media: "",
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    addListener: () => {},
-    removeListener: () => {},
-    onchange: null,
-    dispatchEvent: () => false,
-  });
-  // The stub is a real timer, so a frame still queued when the test ends is a
-  // pending timer and trips the leak sanitizer. React can schedule a frame right
-  // up to unmount, so track outstanding frames and drain them on teardown.
-  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
-  g.requestAnimationFrame = (cb: (t: number) => void) => {
-    const id = setTimeout(() => {
-      pendingFrames.delete(id);
-      cb(0);
-    }, 0);
-    pendingFrames.add(id);
-    return id as unknown as number;
-  };
-  g.cancelAnimationFrame = (id: number) => {
-    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
-    clearTimeout(id);
-  };
-
-  return () => {
-    for (const frame of pendingFrames) clearTimeout(frame);
-    pendingFrames.clear();
-    for (const k of keys) g[k] = prev[k];
-    dom.window.close();
-  };
+  return installComponentDom(dom, { matchMedia: true });
 }
 
 /** Render `element` into a fresh DOM; returns the host node and a teardown. */

--- a/src/react/components/ui/scroll-area.test.tsx
+++ b/src/react/components/ui/scroll-area.test.tsx
@@ -13,9 +13,9 @@ import { createRoot } from "react-dom/client";
 import { JSDOM } from "npm:jsdom@28.0.0";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 import { ScrollArea } from "./scroll-area.tsx";
 
-import { installComponentDom } from "#veryfront/testing/dom-globals.ts";
 // ---------------------------------------------------------------------------
 // jsdom harness - installs a fresh DOM per render and stubs the browser APIs
 // jsdom lacks (ResizeObserver, rAF, matchMedia) so effect-driven components mount.

--- a/src/testing/dom-globals.ts
+++ b/src/testing/dom-globals.ts
@@ -1,0 +1,121 @@
+/**
+ * Install JSDOM globals for a component test, and take them back down again.
+ *
+ * Every UI test that renders React needs the same handful of browser globals
+ * installed on `globalThis`, and needs them restored afterwards. Twelve test
+ * files each grew their own copy of that code, which is how the same defect
+ * appeared in all of them: `requestAnimationFrame` is stubbed with a real timer,
+ * and nothing drained the frames still queued at teardown. A pending timer is
+ * what the op sanitizer reports as a leak, and because it reports at suite
+ * level, the failure names a suite with no step and lands on whatever branch is
+ * being pushed.
+ *
+ * This module owns the mechanics -- snapshot, install, drain, restore -- so
+ * there is one place to fix. It deliberately does not decide *which* globals a
+ * test installs: callers opt into the ones they need, so migrating a file
+ * changes no behaviour.
+ *
+ * @module testing/dom-globals
+ */
+
+/** Minimal ResizeObserver that satisfies components which construct one. */
+export class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+/** A `matchMedia` that always reports no match, with the full event surface. */
+export function createMatchMediaStub(): () => MediaQueryList {
+  return () =>
+    ({
+      matches: false,
+      media: "",
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      onchange: null,
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList;
+}
+
+/** Options for {@linkcode installComponentDom}. */
+export interface ComponentDomOptions {
+  /** Install a `matchMedia` stub. Omit it for tests whose component branches on its absence. */
+  matchMedia?: boolean;
+  /** Extra constructors to copy off the JSDOM window, such as `KeyboardEvent`. */
+  windowGlobals?: readonly string[];
+}
+
+/** The globals every component test installs. */
+const BASE_GLOBALS = [
+  "document",
+  "window",
+  "navigator",
+  "HTMLElement",
+  "Node",
+  "Element",
+  "MouseEvent",
+  "getComputedStyle",
+  "ResizeObserver",
+] as const;
+
+/**
+ * Install browser globals from `dom`, and return a teardown.
+ *
+ * The teardown drains animation frames before restoring globals: React can
+ * schedule a frame right up to unmount, and a frame still queued when the test
+ * ends is a leaked timer.
+ */
+export function installComponentDom(
+  dom: { window: unknown },
+  options: ComponentDomOptions = {},
+): () => void {
+  const w = dom.window as Record<string, unknown>;
+  const g = globalThis as unknown as Record<string, unknown>;
+
+  const keys = [
+    ...BASE_GLOBALS,
+    ...(options.matchMedia ? ["matchMedia"] : []),
+    ...(options.windowGlobals ?? []),
+    "requestAnimationFrame",
+    "cancelAnimationFrame",
+  ];
+
+  const previous: Record<string, unknown> = {};
+  for (const key of keys) previous[key] = g[key];
+
+  g.document = w.document;
+  g.window = w;
+  g.navigator = w.navigator;
+  g.HTMLElement = w.HTMLElement;
+  g.Node = w.Node;
+  g.Element = w.Element;
+  g.MouseEvent = w.MouseEvent;
+  g.getComputedStyle = (w.getComputedStyle as (e: Element) => CSSStyleDeclaration).bind(w);
+  g.ResizeObserver = ResizeObserverStub;
+  if (options.matchMedia) g.matchMedia = createMatchMediaStub();
+  for (const name of options.windowGlobals ?? []) g[name] = w[name];
+
+  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
+  g.requestAnimationFrame = (callback: (time: number) => void) => {
+    const id = setTimeout(() => {
+      pendingFrames.delete(id);
+      callback(0);
+    }, 0);
+    pendingFrames.add(id);
+    return id as unknown as number;
+  };
+  g.cancelAnimationFrame = (id: number) => {
+    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
+    clearTimeout(id);
+  };
+
+  return () => {
+    for (const frame of pendingFrames) clearTimeout(frame);
+    pendingFrames.clear();
+    for (const key of keys) g[key] = previous[key];
+    (dom.window as { close: () => void }).close();
+  };
+}

--- a/src/testing/dom-globals.ts
+++ b/src/testing/dom-globals.ts
@@ -25,19 +25,30 @@ export class ResizeObserverStub {
   disconnect(): void {}
 }
 
+/** The subset of `MediaQueryList` components actually touch. */
+export interface MediaQueryListStub {
+  matches: boolean;
+  media: string;
+  addEventListener: () => void;
+  removeEventListener: () => void;
+  addListener: () => void;
+  removeListener: () => void;
+  onchange: null;
+  dispatchEvent: () => boolean;
+}
+
 /** A `matchMedia` that always reports no match, with the full event surface. */
-export function createMatchMediaStub(): () => MediaQueryList {
-  return () =>
-    ({
-      matches: false,
-      media: "",
-      addEventListener: () => {},
-      removeEventListener: () => {},
-      addListener: () => {},
-      removeListener: () => {},
-      onchange: null,
-      dispatchEvent: () => false,
-    }) as unknown as MediaQueryList;
+export function createMatchMediaStub(): () => MediaQueryListStub {
+  return () => ({
+    matches: false,
+    media: "",
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    onchange: null,
+    dispatchEvent: () => false,
+  });
 }
 
 /** Options for {@linkcode installComponentDom}. */
@@ -73,7 +84,10 @@ export function installComponentDom(
   options: ComponentDomOptions = {},
 ): () => void {
   const w = dom.window as Record<string, unknown>;
-  const g = globalThis as unknown as Record<string, unknown>;
+  const readGlobal = (key: string): unknown => Reflect.get(globalThis, key);
+  const writeGlobal = (key: string, value: unknown): void => {
+    Reflect.set(globalThis, key, value);
+  };
 
   const keys = [
     ...BASE_GLOBALS,
@@ -84,38 +98,41 @@ export function installComponentDom(
   ];
 
   const previous: Record<string, unknown> = {};
-  for (const key of keys) previous[key] = g[key];
+  for (const key of keys) previous[key] = readGlobal(key);
 
-  g.document = w.document;
-  g.window = w;
-  g.navigator = w.navigator;
-  g.HTMLElement = w.HTMLElement;
-  g.Node = w.Node;
-  g.Element = w.Element;
-  g.MouseEvent = w.MouseEvent;
-  g.getComputedStyle = (w.getComputedStyle as (e: Element) => CSSStyleDeclaration).bind(w);
-  g.ResizeObserver = ResizeObserverStub;
-  if (options.matchMedia) g.matchMedia = createMatchMediaStub();
-  for (const name of options.windowGlobals ?? []) g[name] = w[name];
+  writeGlobal("document", w.document);
+  writeGlobal("window", w);
+  writeGlobal("navigator", w.navigator);
+  writeGlobal("HTMLElement", w.HTMLElement);
+  writeGlobal("Node", w.Node);
+  writeGlobal("Element", w.Element);
+  writeGlobal("MouseEvent", w.MouseEvent);
+  writeGlobal(
+    "getComputedStyle",
+    (w.getComputedStyle as (e: Element) => CSSStyleDeclaration).bind(w),
+  );
+  writeGlobal("ResizeObserver", ResizeObserverStub);
+  if (options.matchMedia) writeGlobal("matchMedia", createMatchMediaStub());
+  for (const name of options.windowGlobals ?? []) writeGlobal(name, w[name]);
 
-  const pendingFrames = new Set<ReturnType<typeof setTimeout>>();
-  g.requestAnimationFrame = (callback: (time: number) => void) => {
+  const pendingFrames = new Set<number>();
+  writeGlobal("requestAnimationFrame", (callback: (time: number) => void): number => {
     const id = setTimeout(() => {
       pendingFrames.delete(id);
       callback(0);
     }, 0);
     pendingFrames.add(id);
-    return id as unknown as number;
-  };
-  g.cancelAnimationFrame = (id: number) => {
-    pendingFrames.delete(id as unknown as ReturnType<typeof setTimeout>);
+    return id;
+  });
+  writeGlobal("cancelAnimationFrame", (id: number): void => {
+    pendingFrames.delete(id);
     clearTimeout(id);
-  };
+  });
 
   return () => {
     for (const frame of pendingFrames) clearTimeout(frame);
     pendingFrames.clear();
-    for (const key of keys) g[key] = previous[key];
+    for (const key of keys) writeGlobal(key, previous[key]);
     (dom.window as { close: () => void }).close();
   };
 }


### PR DESCRIPTION
## Description

Twelve UI test files each carried their own copy of the same harness — snapshot globals, install them off a JSDOM window, stub `ResizeObserver` and `matchMedia`, stub `requestAnimationFrame`, restore on teardown. Identical code, twelve times.

That duplication is *how* one defect ended up in all twelve. The rAF stub is a real timer, and nothing drained the frames still queued at teardown, so a frame React scheduled just before unmount became a pending timer — reported by the op sanitizer as a leak, at **suite** level, with no step and no stack, on whatever branch happened to be pushing.

Fixing twelve copies (#3890) closed the instances. This closes the source.

```
12 files changed, 28 insertions(+), 798 deletions(-)
files still stubbing requestAnimationFrame by hand: 0
```

## Design

The helper owns the **mechanics** — snapshot, install, drain, restore — and deliberately does *not* decide which globals a test installs. Callers opt in:

```ts
installComponentDom(dom)                                  // drawer: no matchMedia
installComponentDom(dom, { matchMedia: true })            // most files
installComponentDom(dom, { matchMedia: true, windowGlobals: ["KeyboardEvent", "FocusEvent"] })
```

That matters because the twelve were not uniform: eight shared a key set, `drawer.conformance` deliberately omits `matchMedia`, and three add keyboard/focus constructors. Installing a superset would have changed behaviour for components that branch on a global's absence. Every file keeps exactly the globals it had.

## Why the export is called `installComponentDom`

Fourteen *other* test files already define a local `function installDomGlobals` with a different signature. I named the export that first, added the import broadly, and the suite ran **241 passed / 0 failed** while those files had an import shadowing their own declaration — invisible because the test tasks run `--no-check`.

Reverted and renamed. Worth recording: a green test run does not tell you a test file typechecks in this repo. `deno task lint:test-typecheck` is the gate that does.

## Evidence

```
lint:test-typecheck   Test typecheck baseline holds: 47 grandfathered files, 0 new.
deno check src/index.ts   clean
src/react/ (--parallel --trace-leaks), 3 runs:
  ok | 241 passed (1839 steps) | 0 failed
  ok | 241 passed (1839 steps) | 0 failed
  ok | 241 passed (1839 steps) | 0 failed
```

No production code changed.

## Related Issue(s)

Tracked internally.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] Every file keeps the exact globals it installed before
- [x] Typecheck gates run, not just the test suite
- [x] No production code changed
