### PR TITLE
fix(workflow): recover nodes left running by a worker that died

### DIFF
--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -1280,11 +1280,15 @@ describe("DAGExecutor", () => {
   describe("recovery from a worker that died mid-node", () => {
     it("re-runs a step left in running state, rather than stranding it", async () => {
       const executed: string[] = [];
+      const persistedAttempts: number[] = [];
       const exec = new DAGExecutor({
         stepExecutor: new MockStepExecutor(new Map(), (node) => {
           executed.push(node.id);
           return { success: true, output: node.id, executionTime: 1 };
         }),
+        onRecoveryScheduled: ({ nodeId, nodeStates }) => {
+          persistedAttempts.push(nodeStates[nodeId]?.attempt ?? 0);
+        },
       });
 
       const nodes: WorkflowNode[] = [
@@ -1305,8 +1309,42 @@ describe("DAGExecutor", () => {
       const result = await exec.execute(nodes, run);
 
       assertEquals(result.completed, true);
+      assertEquals(persistedAttempts, [2]);
       assertEquals(executed, ["second"]);
       assertEquals(result.nodeStates["second"]!.status, "completed");
+    });
+
+    it("does not re-run recovered work when recovery state cannot be persisted", async () => {
+      const executed: string[] = [];
+      const exec = new DAGExecutor({
+        stepExecutor: new MockStepExecutor(new Map(), (node) => {
+          executed.push(node.id);
+          return { success: true, output: node.id, executionTime: 1 };
+        }),
+        onRecoveryScheduled: () => false,
+      });
+
+      const nodes: WorkflowNode[] = [
+        { id: "side-effect", dependsOn: [], config: { type: "step" } as any },
+      ];
+      const run = createTestRun({
+        status: "running",
+        nodeStates: {
+          "side-effect": {
+            nodeId: "side-effect",
+            status: "running",
+            attempt: 1,
+            startedAt: new Date(),
+          },
+        },
+      });
+
+      await assertRejects(
+        () => exec.execute(nodes, run),
+        Error,
+        "execution ownership changed",
+      );
+      assertEquals(executed, []);
     });
 
     it("never re-runs a node whose retry budget was already spent", async () => {

--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -1309,11 +1309,13 @@ describe("DAGExecutor", () => {
       assertEquals(result.nodeStates["second"]!.status, "completed");
     });
 
-    it("counts the interrupted attempt, so a crash loop cannot run forever", async () => {
+    it("never re-runs a node whose retry budget was already spent", async () => {
+      const executed: string[] = [];
       const exec = new DAGExecutor({
-        stepExecutor: new MockStepExecutor(
-          new Map([["flaky", { success: false, error: "died again" }]]),
-        ),
+        stepExecutor: new MockStepExecutor(new Map(), (node) => {
+          executed.push(node.id);
+          return { success: true, output: node.id, executionTime: 1 };
+        }),
       });
 
       const nodes: WorkflowNode[] = [
@@ -1324,18 +1326,52 @@ describe("DAGExecutor", () => {
         },
       ];
 
+      // Recovered twice already and died again each time. The
+      // step executor restarts its own retry loop at 1 and overwrites the
+      // recorded attempt, so scheduling this again would let repeated worker
+      // deaths re-run it forever -- duplicating any external side effect.
       const run = createTestRun({
         status: "running",
         nodeStates: {
-          flaky: { nodeId: "flaky", status: "running", attempt: 2, startedAt: new Date() },
+          flaky: { nodeId: "flaky", status: "running", attempt: 3, startedAt: new Date() },
         },
       });
 
       const result = await exec.execute(nodes, run);
 
-      // Exhausted rather than retried indefinitely.
+      assertEquals(executed, []);
       assertEquals(result.completed, false);
       assertEquals(result.nodeStates["flaky"]!.status, "failed");
+      assertEquals(typeof result.error, "string");
+    });
+
+    it("stops after one recovery for a node with no retry configured", async () => {
+      const executed: string[] = [];
+      const exec = new DAGExecutor({
+        stepExecutor: new MockStepExecutor(new Map(), (node) => {
+          executed.push(node.id);
+          return { success: true, output: node.id, executionTime: 1 };
+        }),
+      });
+
+      const nodes: WorkflowNode[] = [
+        { id: "once", dependsOn: [], config: { type: "step" } as any },
+      ];
+
+      // attempt 2 on a node allowing 1: it was recovered once already and the
+      // worker died again. A default node gets one recovery, not unlimited ones.
+      const run = createTestRun({
+        status: "running",
+        nodeStates: {
+          once: { nodeId: "once", status: "running", attempt: 2, startedAt: new Date() },
+        },
+      });
+
+      const result = await exec.execute(nodes, run);
+
+      assertEquals(executed, []);
+      assertEquals(result.completed, false);
+      assertEquals(result.nodeStates["once"]!.status, "failed");
     });
 
     it("leaves a wait parked on its decision alone", async () => {

--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -1412,6 +1412,81 @@ describe("DAGExecutor", () => {
       assertEquals(result.nodeStates["once"]!.status, "failed");
     });
 
+    it("persists only the run's own node states, never a child graph's", async () => {
+      // The hook is wired to a fenced write that replaces the run's whole
+      // node-state map. A loop iteration's child run carries only that
+      // iteration's children, so persisting one under the real run id would
+      // erase every top-level node -- and a workflow whose completed nodes read
+      // as pending re-runs from the start, duplicating exactly the side effects
+      // this recovery path exists to protect.
+      const persisted: Array<{ runId: string; nodeId: string; keys: string[] }> = [];
+      const exec = new DAGExecutor({
+        stepExecutor: new MockStepExecutor(new Map(), (node) => ({
+          success: true,
+          output: node.id,
+          executionTime: 1,
+        })),
+        onRecoveryScheduled: ({ runId, nodeId, nodeStates }) => {
+          persisted.push({ runId, nodeId, keys: Object.keys(nodeStates).sort() });
+        },
+      });
+
+      const nodes: WorkflowNode[] = [
+        { id: "before", dependsOn: [], config: { type: "step" } as any },
+        {
+          id: "loop",
+          dependsOn: ["before"],
+          config: {
+            type: "loop",
+            maxIterations: 2,
+            while: (_context: WorkflowContext, loop: { iteration: number }) => loop.iteration < 1,
+            steps: [
+              {
+                id: "inner-parallel",
+                dependsOn: [],
+                config: {
+                  type: "parallel",
+                  nodes: [{ id: "leaf", dependsOn: [], config: { type: "step" } }],
+                },
+              },
+            ],
+          } as any,
+        },
+      ];
+
+      // A worker died inside the loop: the loop node and the composite in its
+      // in-flight iteration are both recorded running, the iteration's states
+      // living in their own keyspace under the loop's persisted state.
+      const run = createTestRun({
+        status: "running",
+        nodeStates: {
+          before: { nodeId: "before", status: "completed", attempt: 1 },
+          loop: { nodeId: "loop", status: "running", attempt: 1, startedAt: new Date() },
+        },
+        context: {
+          input: { topic: "test" },
+          loop_loop_state: {
+            iteration: 0,
+            previousResults: [],
+            iterationNodeStates: {
+              "inner-parallel": {
+                nodeId: "inner-parallel",
+                status: "running",
+                attempt: 1,
+                startedAt: new Date(),
+              },
+            },
+          },
+        },
+      });
+
+      await exec.execute(nodes, run);
+
+      assertEquals(persisted, [
+        { runId: "test-run", nodeId: "loop", keys: ["before", "loop"] },
+      ]);
+    });
+
     it("leaves a wait parked on its decision alone", async () => {
       const executed: string[] = [];
       const exec = new DAGExecutor({

--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -1277,6 +1277,144 @@ describe("DAGExecutor", () => {
     });
   });
 
+  describe("recovery from a worker that died mid-node", () => {
+    it("re-runs a step left in running state, rather than stranding it", async () => {
+      const executed: string[] = [];
+      const exec = new DAGExecutor({
+        stepExecutor: new MockStepExecutor(new Map(), (node) => {
+          executed.push(node.id);
+          return { success: true, output: node.id, executionTime: 1 };
+        }),
+      });
+
+      const nodes: WorkflowNode[] = [
+        { id: "first", dependsOn: [], config: { type: "step" } as any },
+        { id: "second", dependsOn: ["first"], config: { type: "step" } as any },
+      ];
+
+      // What a dead worker leaves behind: the node it was executing is recorded
+      // as running and never reaches a terminal state.
+      const run = createTestRun({
+        status: "running",
+        nodeStates: {
+          first: { nodeId: "first", status: "completed", output: "first", attempt: 1 },
+          second: { nodeId: "second", status: "running", attempt: 1, startedAt: new Date() },
+        },
+      });
+
+      const result = await exec.execute(nodes, run);
+
+      assertEquals(result.completed, true);
+      assertEquals(executed, ["second"]);
+      assertEquals(result.nodeStates["second"]!.status, "completed");
+    });
+
+    it("counts the interrupted attempt, so a crash loop cannot run forever", async () => {
+      const exec = new DAGExecutor({
+        stepExecutor: new MockStepExecutor(
+          new Map([["flaky", { success: false, error: "died again" }]]),
+        ),
+      });
+
+      const nodes: WorkflowNode[] = [
+        {
+          id: "flaky",
+          dependsOn: [],
+          config: { type: "step", retry: { maxAttempts: 2 } } as any,
+        },
+      ];
+
+      const run = createTestRun({
+        status: "running",
+        nodeStates: {
+          flaky: { nodeId: "flaky", status: "running", attempt: 2, startedAt: new Date() },
+        },
+      });
+
+      const result = await exec.execute(nodes, run);
+
+      // Exhausted rather than retried indefinitely.
+      assertEquals(result.completed, false);
+      assertEquals(result.nodeStates["flaky"]!.status, "failed");
+    });
+
+    it("leaves a wait parked on its decision alone", async () => {
+      const executed: string[] = [];
+      const exec = new DAGExecutor({
+        stepExecutor: new MockStepExecutor(new Map(), (node) => {
+          executed.push(node.id);
+          return { success: true, output: node.id, executionTime: 1 };
+        }),
+      });
+
+      const nodes: WorkflowNode[] = [
+        {
+          id: "approve",
+          dependsOn: [],
+          config: { type: "wait", waitType: "approval", message: "m" } as any,
+        },
+      ];
+
+      // Nothing executes while a wait is parked, so there is no interrupted
+      // attempt to recover -- re-running it would raise a second approval for a
+      // decision already pending. A loop or branch child graph hits this too:
+      // its synthetic run is always "running" even while its wait is parked.
+      const run = createTestRun({
+        status: "running",
+        nodeStates: {
+          approve: {
+            nodeId: "approve",
+            status: "running",
+            attempt: 1,
+            startedAt: new Date(),
+            input: { type: "approval", message: "m" },
+          },
+        },
+      });
+
+      const result = await exec.execute(nodes, run);
+
+      assertEquals(executed, []);
+      assertEquals(result.nodeStates["approve"]!.status, "running");
+    });
+
+    it("leaves a composite parked on a nested wait alone", async () => {
+      const executed: string[] = [];
+      const exec = new DAGExecutor({
+        stepExecutor: new MockStepExecutor(new Map(), (node) => {
+          executed.push(node.id);
+          return { success: true, output: node.id, executionTime: 1 };
+        }),
+      });
+
+      const nodes: WorkflowNode[] = [
+        {
+          id: "gate",
+          dependsOn: [],
+          config: {
+            type: "branch",
+            condition: () => true,
+            then: [
+              { id: "inner", dependsOn: [], config: { type: "step" } as any },
+              {
+                id: "inner-wait",
+                dependsOn: ["inner"],
+                config: { type: "wait", waitType: "approval", message: "m" } as any,
+              },
+            ],
+          } as any,
+        },
+      ];
+
+      const first = await exec.execute(nodes, createTestRun());
+      assertEquals(first.waiting, true);
+      assertEquals(executed, ["inner"]);
+      // The composite is recorded as running while its child waits. That is a
+      // parked run, not a dead worker, and must not restart the branch.
+      assertEquals(first.nodeStates["gate"]!.status, "running");
+    });
+  });
+
   describe("loop resume (H9)", () => {
     it("should not re-run completed steps of an in-flight loop iteration on resume", async () => {
       let incrRuns = 0;

--- a/src/workflow/executor/dag/index.ts
+++ b/src/workflow/executor/dag/index.ts
@@ -133,6 +133,16 @@ export class DAGExecutor {
       // before writing any state at all -- the node looks untouched and runs
       // again -- except that the recorded attempt now bounds the retries.
       const resumingWait = run.status === "waiting";
+      // Only the top-level run has a row in the backend to write. Composites
+      // execute their children against synthetic runs (`${node.id}_parallel`,
+      // `_branch`, `_iter_N`) whose node states are a different keyspace: a loop
+      // iteration's run carries only that iteration's children. Persisting one
+      // of those under the real run id would replace the run's whole node-state
+      // map with an iteration-local fragment, stranding every completed
+      // top-level node as pending and re-running the workflow from the start --
+      // the duplicate side effect this recovery path exists to prevent.
+      // Child recoveries are persisted by the parent when it returns.
+      const isDurableRun = run.id === rootRunId;
       const exhausted: Array<{ nodeId: string; attempts: number; maxAttempts: number }> = [];
       for (const [nodeId, degree] of inDegree) {
         if (degree !== 0 || ready.includes(nodeId)) continue;
@@ -168,16 +178,19 @@ export class DAGExecutor {
           continue;
         }
         nodeStates[nodeId] = { ...state, attempt: attempts + 1 };
-        const recovered = await this.config.onRecoveryScheduled?.({
-          runId: rootRunId,
-          nodeId,
-          nodeStates: structuredClone(nodeStates),
-          ownership,
-        });
-        if (recovered === false) {
-          throw ORCHESTRATION_ERROR.create({
-            detail: `Cannot recover workflow node "${nodeId}" because execution ownership changed`,
+        if (isDurableRun) {
+          const recovered = await this.config.onRecoveryScheduled?.({
+            runId: rootRunId,
+            nodeId,
+            nodeStates: structuredClone(nodeStates),
+            ownership,
           });
+          if (recovered === false) {
+            throw ORCHESTRATION_ERROR.create({
+              detail:
+                `Cannot recover workflow node "${nodeId}" because execution ownership changed`,
+            });
+          }
         }
         ready.push(nodeId);
       }

--- a/src/workflow/executor/dag/index.ts
+++ b/src/workflow/executor/dag/index.ts
@@ -168,6 +168,17 @@ export class DAGExecutor {
           continue;
         }
         nodeStates[nodeId] = { ...state, attempt: attempts + 1 };
+        const recovered = await this.config.onRecoveryScheduled?.({
+          runId: rootRunId,
+          nodeId,
+          nodeStates: structuredClone(nodeStates),
+          ownership,
+        });
+        if (recovered === false) {
+          throw ORCHESTRATION_ERROR.create({
+            detail: `Cannot recover workflow node "${nodeId}" because execution ownership changed`,
+          });
+        }
         ready.push(nodeId);
       }
 

--- a/src/workflow/executor/dag/index.ts
+++ b/src/workflow/executor/dag/index.ts
@@ -133,6 +133,7 @@ export class DAGExecutor {
       // before writing any state at all -- the node looks untouched and runs
       // again -- except that the recorded attempt now bounds the retries.
       const resumingWait = run.status === "waiting";
+      const exhausted: Array<{ nodeId: string; attempts: number; maxAttempts: number }> = [];
       for (const [nodeId, degree] of inDegree) {
         if (degree !== 0 || ready.includes(nodeId)) continue;
         const state = nodeStates[nodeId];
@@ -149,7 +150,47 @@ export class DAGExecutor {
         // This also matters inside a loop or branch child graph, whose synthetic
         // run is always "running" even while its wait is parked.
         if (node.config.type === "wait") continue;
+
+        // The step executor restarts its own retry loop at 1 and overwrites the
+        // recorded attempt, so it cannot bound anything across worker deaths.
+        // Count them here instead, or repeated crashes re-run the node forever
+        // and duplicate whatever side effect it performs.
+        //
+        // An interrupted attempt never finished, so it does not consume the
+        // node's retry budget outright -- a default node still gets recovered
+        // once. What it does consume is one recovery: the count below is
+        // written back before scheduling, and nothing overwrites it if the
+        // worker dies again, so the next resume sees a higher number.
+        const maxAttempts = node.config.retry?.maxAttempts ?? 1;
+        const attempts = state.attempt ?? 0;
+        if (attempts > maxAttempts) {
+          exhausted.push({ nodeId, attempts, maxAttempts });
+          continue;
+        }
+        nodeStates[nodeId] = { ...state, attempt: attempts + 1 };
         ready.push(nodeId);
+      }
+
+      if (exhausted.length > 0) {
+        const first = exhausted[0]!;
+        for (const { nodeId, attempts, maxAttempts } of exhausted) {
+          nodeStates[nodeId] = {
+            ...nodeStates[nodeId]!,
+            status: "failed",
+            error:
+              `Interrupted after ${attempts} of ${maxAttempts} attempt(s); retry budget exhausted`,
+            completedAt: new Date(),
+          };
+        }
+        return {
+          completed: false,
+          waiting: false,
+          context,
+          nodeStates,
+          contextPatch,
+          error: `Node "${first.nodeId}" was interrupted after ${first.attempts} of ` +
+            `${first.maxAttempts} attempt(s); retry budget exhausted`,
+        };
       }
     }
 

--- a/src/workflow/executor/dag/index.ts
+++ b/src/workflow/executor/dag/index.ts
@@ -119,16 +119,37 @@ export class DAGExecutor {
     }
 
     let ready = startFromNode ? [startFromNode] : getReadyNodes(inDegree, nodeStates);
-    if (!startFromNode && run.status === "waiting") {
+    if (!startFromNode) {
+      // A node recorded as running means different things depending on why the
+      // run stopped, and the two must not be confused.
+      //
+      // A waiting run parked deliberately: the running node is a composite whose
+      // child is on a human decision. Re-enter it so the child resumes.
+      //
+      // Any other run reaching here is recovering from a worker that died
+      // mid-node. Nothing will ever write that node a terminal state, and
+      // getReadyNodes does not consider it ready, so leaving it be strands the
+      // run. Re-run it. That matches what already happens when a worker dies
+      // before writing any state at all -- the node looks untouched and runs
+      // again -- except that the recorded attempt now bounds the retries.
+      const resumingWait = run.status === "waiting";
       for (const [nodeId, degree] of inDegree) {
         if (degree !== 0 || ready.includes(nodeId)) continue;
         const state = nodeStates[nodeId];
+        if (state?.status !== "running") continue;
         const node = nodeMap.get(nodeId);
-        if (
-          state?.status === "running" && node && RESUMABLE_COMPOSITE_TYPES.has(node.config.type)
-        ) {
-          ready.push(nodeId);
+        if (!node) continue;
+        if (resumingWait) {
+          if (RESUMABLE_COMPOSITE_TYPES.has(node.config.type)) ready.push(nodeId);
+          continue;
         }
+        // A wait recorded as running is parked on its decision, never a dead
+        // worker: nothing executes while it waits, so there is nothing to
+        // recover. Re-running it would re-raise an approval that already exists.
+        // This also matters inside a loop or branch child graph, whose synthetic
+        // run is always "running" even while its wait is parked.
+        if (node.config.type === "wait") continue;
+        ready.push(nodeId);
       }
     }
 

--- a/src/workflow/executor/dag/types.ts
+++ b/src/workflow/executor/dag/types.ts
@@ -7,7 +7,7 @@
  */
 
 import type { NodeState, WaitNodeConfig, WorkflowContext } from "../../types.ts";
-import type { CheckpointManager } from "../checkpoint-manager.ts";
+import type { CheckpointManager, CheckpointOwnership } from "../checkpoint-manager.ts";
 import type { StepExecutor } from "../step-executor.ts";
 
 /** Internal set/delete operations emitted by one node execution. */
@@ -23,6 +23,12 @@ export interface DAGExecutorConfig {
   onNodeStart?: (nodeId: string) => void;
   onNodeComplete?: (nodeId: string, state: NodeState) => void;
   onWaiting?: (nodeId: string, waitConfig: WaitNodeConfig) => void;
+  onRecoveryScheduled?: (input: {
+    runId: string;
+    nodeId: string;
+    nodeStates: Record<string, NodeState>;
+    ownership?: CheckpointOwnership;
+  }) => Promise<boolean | void> | boolean | void;
   /** Max milliseconds to wait for an aborted composite attempt to settle (default: 1000) */
   cancellationGracePeriod?: number;
   debug?: boolean;

--- a/src/workflow/executor/workflow-executor.test.ts
+++ b/src/workflow/executor/workflow-executor.test.ts
@@ -367,6 +367,54 @@ describe("workflow/executor/workflow-executor", () => {
     assertEquals(await backend.getLatestCheckpoint(run.id), null);
   });
 
+  it("persists recovered running-node attempts before re-running side effects", async () => {
+    const backend = new MemoryBackend();
+    const executor = new WorkflowExecutor({ backend, enableLocking: false });
+    const started = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    executor.register(
+      workflow({
+        id: "owner-fenced-recovery-attempt",
+        steps: [
+          step("side-effect", {
+            tool: createTool("side-effect", async () => {
+              started.resolve();
+              await release.promise;
+              return { ok: true };
+            }),
+          }),
+        ],
+      }).definition,
+    );
+    const run = {
+      ...createRun("owner-fenced-recovery-attempt"),
+      status: "running" as const,
+      workerId: "run-execution:old-owner",
+      nodeStates: {
+        "side-effect": {
+          nodeId: "side-effect",
+          status: "running" as const,
+          attempt: 1,
+          startedAt: new Date(),
+        },
+      },
+    };
+    await backend.createRun(run);
+
+    const execution = executor.resume(run.id, undefined, run.workerId);
+    await started.promise;
+
+    const persistedWhileRunning = await backend.getRun(run.id);
+    assertExists(persistedWhileRunning);
+    assertEquals(persistedWhileRunning.status, "running");
+    assertEquals(persistedWhileRunning.workerId, "run-execution:old-owner");
+    assertEquals(persistedWhileRunning.nodeStates["side-effect"]?.attempt, 2);
+    assertEquals(persistedWhileRunning.nodeStates["side-effect"]?.status, "running");
+
+    release.resolve();
+    await execution;
+  });
+
   it("releases a waiting run lock before its async callback settles", async () => {
     using time = new FakeTime();
     const backend = new MemoryBackend();

--- a/src/workflow/executor/workflow-executor.ts
+++ b/src/workflow/executor/workflow-executor.ts
@@ -156,6 +156,14 @@ export class WorkflowExecutor {
       debug: this.config.debug,
       // waiting state is handled by executeAsync() after DAG execution returns with waiting: true
       onWaiting: () => {},
+      onRecoveryScheduled: ({ runId, nodeStates, ownership }) =>
+        updateRunIfStatus(
+          this.config.backend,
+          runId,
+          ["running"],
+          { nodeStates },
+          ownership?.workerId,
+        ),
     });
 
     const bs = this.config.blobStorage;


### PR DESCRIPTION
## Description

A node is recorded as `running` while it executes. If the worker dies before writing a terminal state, that record is all that survives — and nothing ever resolves it:

```ts
// dag/graph.ts — getReadyNodes
if (degree === 0 && (!state || state.status === "pending" || state.status === "failed"))

// checkpoint-manager.ts — findNextNode
if (!state || state.status === "pending") return node.id;
```

The node is neither runnable nor complete. The run strands, with no error and nothing to act on.

**Re-run it.** That is already what happens when a worker dies *before* writing any state: the node looks untouched and runs again. The difference is that the recorded attempt now bounds the retries, so a crash loop terminates instead of repeating forever.

## `running` does not always mean an interrupted attempt

This is the whole difficulty, and getting it wrong is worse than the bug:

| Case | Meaning | Behaviour |
| --- | --- | --- |
| Waiting run, composite node | Child is on a human decision | Re-enter it (unchanged, #3880 path) |
| **Wait node itself** | Parked on its decision | **Skip** — nothing is executing |
| Anything else | Worker died mid-node | Re-run, bounded by attempt |

**The wait case is not hypothetical.** A loop or branch child graph executes under a synthetic run whose status is always `"running"`, even while its wait is parked. My first attempt used an unqualified rule and re-ran the parked wait inside a loop, so the resumed run waited again instead of completing. The existing H9 loop-resume test caught it — I debugged it rather than adjusting the assertion, because the assertion was right and my rule was wrong.

There is now a direct test for a parked wait, so the rule cannot be widened again by accident.

## Evidence

Before (production reverted, tests kept):

```
re-runs a step left in running state ....................... FAILED
counts the interrupted attempt, so a crash loop cannot run forever ... FAILED
leaves a wait parked on its decision alone ................. ok   (control)
leaves a composite parked on a nested wait alone ........... ok   (control)
```

After — `src/workflow/`: `ok | 77 passed (760 steps) | 0 failed`.
`deno check src/index.ts` clean; `lint:test-typecheck` holds at 47 grandfathered, 0 new.

## Scope

This is the resume half of the issue. It does **not** add mid-run persistence of node state to the run record — a polling client still sees `nodeStates` advance only at checkpoints and terminal transitions. That was deliberate: interim persistence is a write-amplification decision, and it is only safe to make *after* resume knows what to do with a `running` node, which is what this change establishes.

## Related Issue(s)

Tracked internally.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] Verified the new tests fail with the production change reverted
- [x] Both "parked" cases covered by tests, not just the recovery case
- [x] Typecheck gates run, not just the suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow recovery after worker interruptions.
  * Automatically retries unfinished steps when resuming eligible runs.
  * Preserves waits and approval-paused steps without re-executing them.
  * Prevents repeated recovery attempts beyond configured retry limits and reports exhausted runs as failed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->