### PR TITLE
fix(cli): generate api routes under app/api, not app/

### DIFF
--- a/cli/commands/generate/generate.integration.test.ts
+++ b/cli/commands/generate/generate.integration.test.ts
@@ -42,7 +42,7 @@ describe("CLI generate command", () => {
 
       assert(await exists(join(context.projectDir, "app", "docs", "intro", "page.tsx")));
       assert(await exists(join(context.projectDir, "app", "main", "layout.tsx")));
-      assert(await exists(join(context.projectDir, "app", "users", "[id]", "route.ts")));
+      assert(await exists(join(context.projectDir, "app", "api", "users", "[id]", "route.ts")));
     });
   });
 
@@ -55,7 +55,7 @@ describe("CLI generate command", () => {
       await generateCommand(context.projectDir, "layout", "nested");
 
       assert(await exists(join(context.projectDir, "app", "docs", "intro", "page.tsx")));
-      assert(await exists(join(context.projectDir, "app", "users", "[id]", "route.ts")));
+      assert(await exists(join(context.projectDir, "app", "api", "users", "[id]", "route.ts")));
       assert(await exists(join(context.projectDir, "app", "nested", "layout.tsx")));
     });
   });

--- a/cli/scaffold/engine.test.ts
+++ b/cli/scaffold/engine.test.ts
@@ -33,6 +33,10 @@ describe("scaffold engine", () => {
       "/project/app/api/users/[id]/route.ts",
     );
     assertEquals(
+      planScaffold({ projectDir, type: "api", name: "api" }).files[0]?.path,
+      "/project/app/api/route.ts",
+    );
+    assertEquals(
       planScaffold({ projectDir, type: "layout", name: "admin" }).files[0]?.path,
       "/project/app/admin/layout.tsx",
     );
@@ -49,6 +53,10 @@ describe("scaffold engine", () => {
     assertEquals(
       planScaffold({ projectDir, router, type: "api", name: "users/[id]" }).files[0]?.path,
       "/project/pages/api/users/[id].ts",
+    );
+    assertEquals(
+      planScaffold({ projectDir, router, type: "api", name: "api" }).files[0]?.path,
+      "/project/pages/api/index.ts",
     );
     assertEquals(
       planScaffold({ projectDir, router, type: "layout", name: "main" }).files[0]?.path,

--- a/cli/scaffold/engine.test.ts
+++ b/cli/scaffold/engine.test.ts
@@ -25,7 +25,12 @@ describe("scaffold engine", () => {
     );
     assertEquals(
       planScaffold({ projectDir, type: "api", name: "users/[id]" }).files[0]?.path,
-      "/project/app/users/[id]/route.ts",
+      "/project/app/api/users/[id]/route.ts",
+    );
+    // An explicit "api/" prefix must not be doubled up.
+    assertEquals(
+      planScaffold({ projectDir, type: "api", name: "api/users/[id]" }).files[0]?.path,
+      "/project/app/api/users/[id]/route.ts",
     );
     assertEquals(
       planScaffold({ projectDir, type: "layout", name: "admin" }).files[0]?.path,

--- a/cli/scaffold/engine.ts
+++ b/cli/scaffold/engine.ts
@@ -195,7 +195,7 @@ function resolveInput(input: ScaffoldInput): ResolvedScaffoldInput {
 }
 
 function stripApiPrefix(slug: string): string {
-  return slug.replace(/^api\//, "");
+  return slug === "api" ? "" : slug.replace(/^api\//, "");
 }
 
 function joinPagesFile(base: string, slug: string, extension: ".mdx" | ".ts"): string {

--- a/cli/scaffold/engine.ts
+++ b/cli/scaffold/engine.ts
@@ -72,10 +72,13 @@ const SCAFFOLD_DEFINITIONS: Record<ScaffoldType, ScaffoldDefinition> = {
     },
   },
   api: {
+    // Both routers serve API handlers from an "api" segment, so the segment is
+    // owned by the scaffold rather than the caller. Accept a slug that already
+    // spells it so `generate api api/users/[id]` does not nest a second one.
     getPath: ({ projectDir, router, slug }) =>
       router === "app-router"
-        ? join(projectDir, "app", slug, "route.ts")
-        : joinPagesFile(join(projectDir, "pages", "api"), slug, ".ts"),
+        ? join(projectDir, "app", "api", stripApiPrefix(slug), "route.ts")
+        : joinPagesFile(join(projectDir, "pages", "api"), stripApiPrefix(slug), ".ts"),
     getContent: ({ router, methods }) => generateApiTemplate(methods, router),
   },
   layout: {
@@ -189,6 +192,10 @@ function resolveInput(input: ScaffoldInput): ResolvedScaffoldInput {
     slug,
     componentName: toComponentName(slug),
   };
+}
+
+function stripApiPrefix(slug: string): string {
+  return slug.replace(/^api\//, "");
 }
 
 function joinPagesFile(base: string, slug: string, extension: ".mdx" | ".ts"): string {


### PR DESCRIPTION
## What

`veryfront generate api users/[id]` created `app/users/[id]/route.ts`, which serves `GET /users/{id}`.

The [API routes guide](https://veryfront.com/docs/code/guides/api-routes) documents app-router API routes at `app/api/**/route.ts` mapping to `/api/**`, and `users/[id]` is the CLI's own `--help` example. So the documented command produced a route at an undocumented URL.

Observed on `0.1.1246-rc.13479`:

```
$ veryfront generate api "users/[id]"
  ● Created .../app/users/[id]/route.ts

$ curl -o /dev/null -w '%{http_code}' localhost:3000/users/1        # 200
$ curl -o /dev/null -w '%{http_code}' localhost:3000/api/users/1    # 404
```

## Why it happened

In `cli/scaffold/engine.ts`, the pages-router branch of the `api` scaffold already inserted the `"api"` segment; only the app-router branch omitted it.

The gap survived because three assertions pinned the wrong path (`engine.test.ts` and `generate.integration.test.ts` x2) — they encoded the behaviour rather than the routing contract.

## Fix

Own the `api` segment in both branches, and strip a caller-supplied `api/` prefix so `generate api api/users/[id]` does not nest a second one.

## Verification

- Updated the three assertions to the routing contract and confirmed they fail against the old implementation before fixing.
- `deno test -A cli/scaffold/ cli/commands/generate/` passes.
- Ran the fixed CLI against a scratch project: `generate api users/[id]` → `app/api/users/[id]/route.ts`, and `generate api api/orders/[id]` → `app/api/orders/[id]/route.ts` (no doubled segment).
- Full pre-push suite green.

Found while dogfooding the documented developer journey.