### PR TITLE
docs(workflows): verify a run through a route the guide actually creates

### DIFF
--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -357,7 +357,7 @@ workflows.register(contentPipeline);
 export async function POST(request: Request) {
   const input = await request.json();
   const handle = await workflows.start("content-pipeline", input);
-  await handle.result();
+  await handle.settled();
 
   const run = await workflows.getRun(handle.runId);
   return Response.json({ status: run?.status, nodeStates: run?.nodeStates });

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -328,23 +328,63 @@ export default workflow({
 
 ## Verify it worked
 
-Start the workflow from the start route, then poll the run state until it
-reaches a terminal status:
+`createWorkflowClient()` stores runs in memory, private to the client that
+started them. A second client, in another route file or the same file on a
+later request, does not see them. Verify the run from the request that started
+it, and add a persistent backend before reading run state from anywhere else.
 
-```bash
-RUN=$(curl -s http://localhost:3000/api/start-content-workflow \
-  -H "Content-Type: application/json" \
-  -d '{"topic":"AI agents"}' | jq -r .runId)
+Add a route that starts the workflow, waits for it, and reads the finished run
+back through the same client:
 
-while true; do
-  STATE=$(curl -s "http://localhost:3000/api/workflows/runs/$RUN")
-  STATUS=$(echo "$STATE" | jq -r '.status')
-  echo "status=$STATUS"
-  case "$STATUS" in
-    completed|failed|cancelled) break ;;
-  esac
-  sleep 2
-done
+```ts
+// app/api/verify-content-workflow/route.ts
+import { getAgent, getAllAgentIds } from "veryfront/agent";
+import { toolRegistry } from "veryfront/tool";
+import { createWorkflowClient } from "veryfront/workflow";
+import contentPipeline from "../../../workflows/content-pipeline.ts";
+
+const workflows = createWorkflowClient({
+  executor: {
+    stepExecutor: {
+      agentRegistry: { get: getAgent, list: getAllAgentIds },
+      toolRegistry,
+    },
+  },
+});
+
+workflows.register(contentPipeline);
+
+export async function POST(request: Request) {
+  const input = await request.json();
+  const handle = await workflows.start("content-pipeline", input);
+  await handle.result();
+
+  const run = await workflows.getRun(handle.runId);
+  return Response.json({ status: run?.status, nodeStates: run?.nodeStates });
+}
 ```
 
-A working run reaches `status: "completed"` and exposes a `nodeStates` map with one `completed` entry per step. If `status` ends in `failed`, inspect the matching node entry in `nodeStates` for the underlying error.
+Call it:
+
+```bash
+curl -s http://localhost:3000/api/verify-content-workflow \
+  -H "Content-Type: application/json" \
+  -d '{"topic":"AI agents"}' \
+  | jq '{status, nodes: (.nodeStates | to_entries | map({(.key): .value.status}))}'
+```
+
+A working run reaches `status: "completed"` and exposes a `nodeStates` map with one `completed` entry per step:
+
+```json
+{
+  "status": "completed",
+  "nodes": [{ "research": "completed" }, { "write": "completed" }, { "review": "completed" }]
+}
+```
+
+If `status` ends in `failed`, inspect the matching node entry in `nodeStates` for the underlying error.
+
+To read run state from a different request (a status endpoint, a dashboard, or
+the `useWorkflow` hook), give every client the same persistent backend, such as
+`RedisBackend`, instead of the default in-memory one. Run state written by one
+in-memory client is not readable from any other.

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -42,6 +42,46 @@ describe("guide content contracts", () => {
     );
   });
 
+  it("only tells workflow readers to call routes the same guide creates", async () => {
+    // A guide that curls an endpoint it never builds is unrunnable end to end,
+    // and the reader cannot tell the missing route from their own mistake. The
+    // framework serves no /api/workflows/** handler, so every localhost path
+    // this guide calls has to come from a route file the guide itself shows.
+    const guide = await Deno.readTextFile(
+      new URL("docs/guides/workflows.md", repoRoot),
+    );
+
+    const toSegments = (path: string) =>
+      path.split("/").filter(Boolean).map((segment) =>
+        segment.startsWith("$") || segment.startsWith("[") ? "*" : segment
+      );
+
+    const created = [...guide.matchAll(/(?:app\/api\/[^\s"'`]*?)\/route\.ts/g)]
+      .map((match) => toSegments((match[0] ?? "").replace(/^app/, "").replace(/\/route\.ts$/, "")));
+
+    const called = [...guide.matchAll(/http:\/\/localhost:\d+(\/api\/[^\s"'`)]*)/g)]
+      .map((match) => match[1] ?? "");
+
+    assert(called.length > 0, "expected the guide to show at least one API call");
+
+    for (const path of called) {
+      const wanted = toSegments(path);
+      const served = created.some((route) =>
+        route.length === wanted.length &&
+        route.every((segment, index) =>
+          segment === "*" || wanted[index] === "*" || segment === wanted[index]
+        )
+      );
+      assert(
+        served,
+        `docs/guides/workflows.md calls ${path} but never shows the route that serves it. ` +
+          `Routes the guide creates: ${
+            created.map((route) => "/" + route.join("/")).join(", ") || "(none)"
+          }`,
+      );
+    }
+  });
+
   it("presents open source, self-hosted, and managed paths as first-class options", async () => {
     const overview = await Deno.readTextFile(
       new URL("docs/getting-started/index.md", repoRoot),

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -63,6 +63,11 @@ describe("guide content contracts", () => {
       .map((match) => match[1] ?? "");
 
     assert(called.length > 0, "expected the guide to show at least one API call");
+    assertStringIncludes(
+      guide,
+      "await handle.settled();",
+      "the verification route must still return failed and cancelled run state for inspection",
+    );
 
     for (const path of called) {
       const wanted = toSegments(path);


### PR DESCRIPTION
## What

The workflows guide's **"Verify it worked"** section told readers to poll:

```bash
STATE=$(curl -s "http://localhost:3000/api/workflows/runs/$RUN")
```

The guide never shows that route, and the framework serves no `/api/workflows/**` handler (the only built-in workflow endpoint is `/_dev/api/workflows`, the dev dashboard). A reader who followed the page top to bottom got:

```
$ curl -s -w '%{http_code}' localhost:3000/api/workflows/runs/run_3b71be7d-5c5
Not Found
404
```

The page's own verification step could not be run. Observed on `0.1.1246-rc.13479`.

## Why the obvious fix isn't enough

Adding the missing route does not make the documented flow work. `createWorkflowClient()` defaults to a per-instance `MemoryBackend`, so a run started by one client is invisible to any other — including one in a different route file. Extracting a single shared client module does not help either.

The runtime itself is fine. Starting a run and reading it back inside one request reaches exactly what the guide promises:

```json
{ "status": "completed", "nodeStates": [{ "start": "completed" }] }
```

So the defect is reachability, not execution.

## Fix

Verify from the request that started the run, which is what the default client can actually support — and state the in-memory constraint outright rather than leaving readers to infer it. For the cross-request case the `useWorkflow` hook needs, point at a shared persistent backend.

## Regression test

`tests/docs/guide-content.test.ts` pins the invariant behind the defect: every localhost API path the guide tells a reader to call must correspond to a route file the same guide shows them how to create.

Against the old text it fails with:

```
docs/guides/workflows.md calls /api/workflows/runs/$RUN but never shows the
route that serves it. Routes the guide creates: /api/start-content-workflow
```

## Verification

- Confirmed the test fails on the old text before changing it.
- `deno test --no-check -A tests/docs/` → 57 passed, 0 failed.
- `scripts/docs/validate-public-docs.ts` clean across 126 files.
- Copied the new route verbatim from the fixed guide into a scratch project and ran the guide's exact curl: `status: "completed"` with a `completed` node.
- Full pre-push suite green.

## Not addressed here

The workflow React hooks (`useWorkflow`, `useWorkflowStart`, `useApproval`, `useWorkflowList`) all default to `apiBase = "/api/workflows"` and depend on server routes that ship no handler factory and are documented nowhere. That is a framework gap rather than a doc fix, and wants its own issue.

Found while dogfooding the documented developer journey.