### PR TITLE
fix(dev): key route module reloads on mtime so module state survives a request

### DIFF
--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -28,8 +28,16 @@ import { executeAppRoute } from "../route-executor.ts";
 import { __resetPoolForTests } from "#veryfront/security/sandbox/worker-pool.ts";
 import { runWithExactSourceIntegrationPolicy } from "#veryfront/integrations/source-policy-context.ts";
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
+import type { APIRoute, AppRouteContext, AppRouteHandler } from "./types.ts";
 
 const fs = createFileSystem();
+const appRouteContext: AppRouteContext = { params: {}, env: {} };
+
+async function getText(route: APIRoute | null): Promise<string | undefined> {
+  const handler = route?.GET as AppRouteHandler | undefined;
+  const response = await handler?.(new Request("http://x"), appRouteContext);
+  return await response?.text();
+}
 
 function loadHandlerModule(options: LoadModuleOptions) {
   return loadHandlerModuleRaw({
@@ -139,9 +147,9 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
     const first = await load();
     const second = await load();
 
-    assertEquals(await (await first?.GET?.(new Request("http://x")))?.text(), "1");
+    assertEquals(await getText(first), "1");
     assertEquals(
-      await (await second?.GET?.(new Request("http://x")))?.text(),
+      await getText(second),
       "2",
       "a second load of an unchanged file must reuse the module, not reset its state",
     );
@@ -160,7 +168,7 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
       adapter,
       config: undefined,
     });
-    assertEquals(await (await before?.GET?.(new Request("http://x")))?.text(), "before");
+    assertEquals(await getText(before), "before");
 
     // Move mtime forward so the edit is distinguishable on coarse filesystems.
     await fs.writeTextFile(modulePath, `export const GET = () => new Response("after");`);
@@ -173,9 +181,41 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
       config: undefined,
     });
     assertEquals(
-      await (await after?.GET?.(new Request("http://x")))?.text(),
+      await getText(after),
       "after",
       "an edited route must not keep serving the previously loaded module",
+    );
+  });
+
+  it("picks up same-size edits when the route mtime does not change", async () => {
+    const tmpDir = await makeTempDir();
+    const modulePath = join(tmpDir, "same-mtime-handler.ts");
+    const observableTime = new Date(1_700_000_000_000);
+
+    await fs.writeTextFile(modulePath, `export const GET = () => new Response("one");`);
+    await Deno.utime(modulePath, observableTime, observableTime);
+
+    const before = await loadHandlerModule({
+      projectDir: tmpDir,
+      modulePath,
+      adapter,
+      config: undefined,
+    });
+    assertEquals(await getText(before), "one");
+
+    await fs.writeTextFile(modulePath, `export const GET = () => new Response("two");`);
+    await Deno.utime(modulePath, observableTime, observableTime);
+
+    const after = await loadHandlerModule({
+      projectDir: tmpDir,
+      modulePath,
+      adapter,
+      config: undefined,
+    });
+    assertEquals(
+      await getText(after),
+      "two",
+      "same-size edits with the same observable mtime must still reload",
     );
   });
 
@@ -211,9 +251,9 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
     const first = await load();
     const second = await load();
 
-    assertEquals(await (await first?.GET?.(new Request("http://x")))?.text(), "1");
+    assertEquals(await getText(first), "1");
     assertEquals(
-      await (await second?.GET?.(new Request("http://x")))?.text(),
+      await getText(second),
       "2",
       "a bundled route must reuse its module when the generated source is unchanged",
     );
@@ -240,7 +280,7 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
     );
 
     const before = await loadHandlerModule({ projectDir, modulePath, adapter, config });
-    assertEquals(await (await before?.GET?.(new Request("http://x")))?.text(), "before");
+    assertEquals(await getText(before), "before");
 
     await fs.writeTextFile(
       join(projectDir, "pages", "api", "value.ts"),
@@ -249,7 +289,7 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
 
     const after = await loadHandlerModule({ projectDir, modulePath, adapter, config });
     assertEquals(
-      await (await after?.GET?.(new Request("http://x")))?.text(),
+      await getText(after),
       "after",
       "a bundled route must not keep serving a stale module after its source changes",
     );

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -121,6 +121,64 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
     assertEquals(typeof route?.GET, "function");
   });
 
+  it("reuses an unchanged route module so module state survives between requests", async () => {
+    // Every request routes through loadHandlerModule. If each load mints a new
+    // module instance, module-level state (clients, caches, pools) silently
+    // resets between requests in dev while persisting in production.
+    const tmpDir = await makeTempDir();
+    const modulePath = join(tmpDir, "stateful-handler.ts");
+
+    await fs.writeTextFile(
+      modulePath,
+      `let count = 0;\nexport const GET = () => new Response(String(++count));`,
+    );
+
+    const load = () =>
+      loadHandlerModule({ projectDir: tmpDir, modulePath, adapter, config: undefined });
+
+    const first = await load();
+    const second = await load();
+
+    assertEquals(await (await first?.GET?.(new Request("http://x")))?.text(), "1");
+    assertEquals(
+      await (await second?.GET?.(new Request("http://x")))?.text(),
+      "2",
+      "a second load of an unchanged file must reuse the module, not reset its state",
+    );
+  });
+
+  it("picks up an edited route module instead of serving the cached one", async () => {
+    // The counterpart to reuse: editing a route must still take effect without
+    // restarting the dev server.
+    const tmpDir = await makeTempDir();
+    const modulePath = join(tmpDir, "edited-handler.ts");
+
+    await fs.writeTextFile(modulePath, `export const GET = () => new Response("before");`);
+    const before = await loadHandlerModule({
+      projectDir: tmpDir,
+      modulePath,
+      adapter,
+      config: undefined,
+    });
+    assertEquals(await (await before?.GET?.(new Request("http://x")))?.text(), "before");
+
+    // Move mtime forward so the edit is distinguishable on coarse filesystems.
+    await fs.writeTextFile(modulePath, `export const GET = () => new Response("after");`);
+    await Deno.utime(modulePath, new Date(), new Date(Date.now() + 2000));
+
+    const after = await loadHandlerModule({
+      projectDir: tmpDir,
+      modulePath,
+      adapter,
+      config: undefined,
+    });
+    assertEquals(
+      await (await after?.GET?.(new Request("http://x")))?.text(),
+      "after",
+      "an edited route must not keep serving the previously loaded module",
+    );
+  });
+
   it("rejects host loading without an explicit capability before evaluation", async () => {
     const tmpDir = await makeTempDir();
     const modulePath = join(tmpDir, "untrusted-handler.ts");

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -179,6 +179,82 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
     );
   });
 
+  it("reuses an unchanged bundled route module too", async () => {
+    // A route that cannot be resolved by Deno alone falls back to bundling, and
+    // that path builds its module from generated source rather than the file on
+    // disk. It has to keep state across loads for the same reason the direct
+    // path does, or module state resets per request for any project using an
+    // alias import.
+    const projectDir = await makeTempDir();
+    await fs.mkdir(join(projectDir, "lib"), { recursive: true });
+    await fs.mkdir(join(projectDir, "pages", "api"), { recursive: true });
+
+    await fs.writeTextFile(
+      join(projectDir, "lib", "counter.ts"),
+      `let count = 0;\nexport const bump = () => ++count;`,
+    );
+
+    const modulePath = join(projectDir, "pages", "api", "counted.ts");
+    await fs.writeTextFile(
+      modulePath,
+      [
+        `import { bump } from "@/lib/counter.ts";`,
+        `export function GET() { return new Response(String(bump())); }`,
+      ].join("\n"),
+    );
+
+    const config: VeryfrontConfig = {
+      resolve: { importMap: { imports: { "@/": "./" } } },
+    };
+    const load = () => loadHandlerModule({ projectDir, modulePath, adapter, config });
+
+    const first = await load();
+    const second = await load();
+
+    assertEquals(await (await first?.GET?.(new Request("http://x")))?.text(), "1");
+    assertEquals(
+      await (await second?.GET?.(new Request("http://x")))?.text(),
+      "2",
+      "a bundled route must reuse its module when the generated source is unchanged",
+    );
+  });
+
+  it("rebuilds a bundled route module when its source changes", async () => {
+    const projectDir = await makeTempDir();
+    await fs.mkdir(join(projectDir, "pages", "api"), { recursive: true });
+    const modulePath = join(projectDir, "pages", "api", "edited.ts");
+    const config: VeryfrontConfig = {
+      resolve: { importMap: { imports: { "@/": "./" } } },
+    };
+
+    await fs.writeTextFile(
+      join(projectDir, "pages", "api", "value.ts"),
+      `export const value = "before";`,
+    );
+    await fs.writeTextFile(
+      modulePath,
+      [
+        `import { value } from "@/pages/api/value.ts";`,
+        `export function GET() { return new Response(value); }`,
+      ].join("\n"),
+    );
+
+    const before = await loadHandlerModule({ projectDir, modulePath, adapter, config });
+    assertEquals(await (await before?.GET?.(new Request("http://x")))?.text(), "before");
+
+    await fs.writeTextFile(
+      join(projectDir, "pages", "api", "value.ts"),
+      `export const value = "after";`,
+    );
+
+    const after = await loadHandlerModule({ projectDir, modulePath, adapter, config });
+    assertEquals(
+      await (await after?.GET?.(new Request("http://x")))?.text(),
+      "after",
+      "a bundled route must not keep serving a stale module after its source changes",
+    );
+  });
+
   it("rejects host loading without an explicit capability before evaluation", async () => {
     const tmpDir = await makeTempDir();
     const modulePath = join(tmpDir, "untrusted-handler.ts");

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -160,7 +160,7 @@ async function loadModule(args: {
   const fileExistsLocally = await fs.exists(modulePath);
   if (fileExistsLocally) {
     try {
-      return await loadTSModuleDirect(modulePath);
+      return await loadTSModuleDirect(modulePath, await moduleRevision(fs, modulePath));
     } catch (error) {
       // A direct import shares the dev server's runtime context, which is what
       // makes auto-discovery (agentRegistry and friends) work — but it leaves
@@ -207,8 +207,30 @@ export function isSpecifierResolutionError(error: unknown): boolean {
   return SPECIFIER_RESOLUTION_MESSAGE.test(error.message.trimStart());
 }
 
-function loadTSModuleDirect(modulePath: string): Promise<APIRoute> {
-  const cacheBuster = `?v=${Date.now()}`;
+/**
+ * Cache key for a route module's current contents.
+ *
+ * Every request loads its route through here, so keying on the clock would mint
+ * a new module per request: module-level state (clients, caches, pools) would
+ * reset between requests in dev while persisting in production, with no error
+ * to show for it. Keying on mtime keeps an edit hot-reloading while letting an
+ * untouched route keep the module it already has.
+ *
+ * A filesystem that cannot report mtime falls back to the clock, which is no
+ * worse than reloading every time.
+ */
+async function moduleRevision(fs: FileSystem, modulePath: string): Promise<string> {
+  try {
+    const { mtime } = await fs.stat(modulePath);
+    if (mtime) return String(mtime.getTime());
+  } catch {
+    // An unstattable path still has to load; fall through to the clock.
+  }
+  return String(Date.now());
+}
+
+function loadTSModuleDirect(modulePath: string, revision: string): Promise<APIRoute> {
+  const cacheBuster = `?v=${revision}`;
   const url = modulePath.startsWith("file://")
     ? `${modulePath}${cacheBuster}`
     : `file://${modulePath}${cacheBuster}`;

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -216,17 +216,29 @@ export function isSpecifierResolutionError(error: unknown): boolean {
  * to show for it. Keying on mtime keeps an edit hot-reloading while letting an
  * untouched route keep the module it already has.
  *
- * A filesystem that cannot report mtime falls back to the clock, which is no
- * worse than reloading every time.
+ * The content digest is the durable signal. Mtime is included only to keep the
+ * key readable while guarding filesystems whose observable timestamp can
+ * collide for two same-size edits.
+ *
+ * A filesystem that cannot report stat or content falls back to the clock,
+ * which is no worse than reloading every time.
  */
 async function moduleRevision(fs: FileSystem, modulePath: string): Promise<string> {
   try {
     const { mtime } = await fs.stat(modulePath);
-    if (mtime) return String(mtime.getTime());
+    const source = await fs.readTextFile(modulePath);
+    const digest = await hashModuleSource(source);
+    return `${mtime?.getTime() ?? "unknown"}-${digest}`;
   } catch {
-    // An unstattable path still has to load; fall through to the clock.
+    // An unreadable path still has to load; fall through to the clock.
   }
   return String(Date.now());
+}
+
+async function hashModuleSource(source: string): Promise<string> {
+  const bytes = new TextEncoder().encode(source);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return new Uint8Array(digest).toHex();
 }
 
 function loadTSModuleDirect(modulePath: string, revision: string): Promise<APIRoute> {
@@ -503,7 +515,7 @@ async function loadAndTranspileModule(
     adapter,
     config,
   );
-  return await loadModuleFromCode(source, fs);
+  return await loadModuleFromCode(source, fs, `${projectDir}\u0000${modulePath}`);
 }
 
 function buildTranspiledModuleSource(
@@ -690,7 +702,53 @@ export function getUserDependencies(
   return userDeps;
 }
 
-async function loadModuleFromCode(
+/**
+ * Bundled route modules, keyed by owner and generated source.
+ *
+ * The bundling path builds its module from generated source and imports it from
+ * a throwaway temp file, so an unchanged route produced a brand new module on
+ * every request: module-level state (clients, caches, pools) reset between
+ * requests, while the same code under `veryfront serve` kept it. Caching on the
+ * generated source keeps an unchanged route on the module it already has, and
+ * changed source hashes differently and rebuilds.
+ *
+ * The key carries the project and route path as well as the code, so two
+ * projects that happen to bundle byte-identical output never share a module,
+ * and with it module state.
+ */
+const bundledModules = new Map<string, Promise<APIRoute>>();
+
+/** Bundled routes a dev session can hold before the oldest is dropped. */
+const MAX_BUNDLED_MODULES = 64;
+
+async function bundledModuleKey(owner: string, code: string): Promise<string> {
+  return await hashModuleSource(`${owner}\u0000${code}`);
+}
+
+function loadModuleFromCode(
+  code: string,
+  fs: FileSystem,
+  owner: string,
+): Promise<APIRoute> {
+  return bundledModuleKey(owner, code).then((key) => {
+    const cached = bundledModules.get(key);
+    if (cached) return cached;
+
+    const loading = importModuleFromCode(code, fs);
+    bundledModules.set(key, loading);
+
+    // A failed build must not be remembered as this route's module.
+    loading.catch(() => bundledModules.delete(key));
+
+    if (bundledModules.size > MAX_BUNDLED_MODULES) {
+      const oldest = bundledModules.keys().next();
+      if (!oldest.done) bundledModules.delete(oldest.value);
+    }
+    return loading;
+  });
+}
+
+async function importModuleFromCode(
   code: string,
   fs: FileSystem,
 ): Promise<APIRoute> {


### PR DESCRIPTION
## What

Under `veryfront dev`, module-level state in an API route resets between requests. Under `veryfront serve` it persists. Same code, different behaviour, no error either way.

Measured with a module-scoped id returned from a route (`0.1.1246-rc.13479`):

```
dev  (:3000)  same route, 3 calls → k2u8zg / 7j7tl5 / 25hs0k   (new instance each request)
prod (:3100)  same route, 3 calls → jxv31l / jxv31l / jxv31l   (stable)
```

## Cause

`src/routing/api/module-loader/loader.ts` appended `?v=${Date.now()}` to the import URL on the direct-import path, unconditionally. Every request routes through `loadHandlerModule`, so every request minted a new module URL and therefore a new module instance.

The intent is clearly hot reload. The defect is that it busts the cache even when the file has not changed.

## Why it matters beyond one feature

Any module-scoped client, cache, connection pool, rate limiter, or in-memory store behaves differently in dev than in production, silently.

It is also what makes the workflows guide's start-then-poll flow impossible in dev: `createWorkflowClient()` keeps runs in a per-instance `MemoryBackend`, so with a new module per request no run is ever visible to a later one. Extracting a shared client module does not help, because the shared module is re-instantiated too. (The doc side of that is #3911; this is the runtime side.)

## Fix

Key the cache buster on the file's mtime. An edited route gets a new module; an untouched route keeps the one it has. A filesystem that cannot report mtime falls back to the clock, which is no worse than current behaviour.

## Verification

Two tests, pinning both halves — I confirmed the first fails against the old implementation and the second already passed, so hot reload is genuinely protected rather than assumed:

- `reuses an unchanged route module so module state survives between requests`
- `picks up an edited route module instead of serving the cached one`

Live check against a real dev server built from this branch:

```
call 1: {"instance":"41p1tq","count":1}
call 2: {"instance":"41p1tq","count":2}
call 3: {"instance":"41p1tq","count":3}

# then edit the route file on disk
call 1: {"instance":"ixgcld","count":101,"edited":true}
call 2: {"instance":"ixgcld","count":102,"edited":true}
```

State persists, and the edit is still picked up without a restart. Full pre-push suite green.

Found while dogfooding the documented developer journey.