### PR TITLE
docs(llm): show structured output on the veryfront/llm page

### DIFF
--- a/docs/api-reference/veryfront/llm.md
+++ b/docs/api-reference/veryfront/llm.md
@@ -27,11 +27,19 @@ import { generate } from "veryfront/llm";
 import { defineSchema } from "veryfront/schemas";
 
 const { object } = await generate({
-  input: "Berlin is 12 degrees today.",
-  outputSchema: defineSchema((v) => v.object({ city: v.string(), tempC: v.number() }))(),
+  input: "The checkout button does nothing on mobile Safari.",
+  system: "Classify the support ticket.",
+  outputSchema: defineSchema((v) =>
+    v.object({
+      category: v.enum(["bug", "billing", "feature"] as const),
+      reasoning: v.string(),
+      confidence: v.number().min(0).max(100),
+    })
+  )(),
 });
 
-object.city; // string
+object.category; // "bug" | "billing" | "feature"
+object.confidence; // number, 0-100
 ```
 
 ### Choosing a model
@@ -52,10 +60,10 @@ const { text } = await generate({
 
 | Name       | Description                                                   | Source                                                                               |
 | ---------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `generate` | Run a single model call without registering a reusable agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/llm/index.ts#L71) |
+| `generate` | Run a single model call without registering a reusable agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/llm/index.ts#L77) |
 
 ### Types
 
 | Name            | Description                     | Source                                                                               |
 | --------------- | ------------------------------- | ------------------------------------------------------------------------------------ |
-| `GenerateInput` | Request accepted by `generate`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/llm/index.ts#L50) |
+| `GenerateInput` | Request accepted by `generate`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/llm/index.ts#L56) |

--- a/docs/api-reference/veryfront/llm.md
+++ b/docs/api-reference/veryfront/llm.md
@@ -12,10 +12,38 @@ import { generate } from "veryfront/llm";
 
 ## Examples
 
+### Text
+
 ```ts
 import { generate } from "veryfront/llm";
 
 const { text } = await generate({ input: "Name three colours." });
+```
+
+### Structured output
+
+```ts
+import { generate } from "veryfront/llm";
+import { defineSchema } from "veryfront/schemas";
+
+const { object } = await generate({
+  input: "Berlin is 12 degrees today.",
+  outputSchema: defineSchema((v) => v.object({ city: v.string(), tempC: v.number() }))(),
+});
+
+object.city; // string
+```
+
+### Choosing a model
+
+```ts
+import { generate } from "veryfront/llm";
+
+const { text } = await generate({
+  input: "Summarise this in one line.",
+  system: "You are terse.",
+  model: "anthropic/claude-haiku-4-5-20251001",
+});
 ```
 
 ## Exports
@@ -24,10 +52,10 @@ const { text } = await generate({ input: "Name three colours." });
 
 | Name       | Description                                                   | Source                                                                               |
 | ---------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `generate` | Run a single model call without registering a reusable agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/llm/index.ts#L45) |
+| `generate` | Run a single model call without registering a reusable agent. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/llm/index.ts#L71) |
 
 ### Types
 
 | Name            | Description                     | Source                                                                               |
 | --------------- | ------------------------------- | ------------------------------------------------------------------------------------ |
-| `GenerateInput` | Request accepted by `generate`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/llm/index.ts#L24) |
+| `GenerateInput` | Request accepted by `generate`. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/llm/index.ts#L50) |

--- a/docs/api-reference/veryfront/llm.md
+++ b/docs/api-reference/veryfront/llm.md
@@ -24,18 +24,18 @@ const { text } = await generate({ input: "Name three colours." });
 
 ```ts
 import { generate } from "veryfront/llm";
-import { defineSchema } from "veryfront/schemas";
+import { defineSchema, lazySchema } from "veryfront/schemas";
 
 const { object } = await generate({
   input: "The checkout button does nothing on mobile Safari.",
   system: "Classify the support ticket.",
-  outputSchema: defineSchema((v) =>
+  outputSchema: lazySchema(defineSchema((v) =>
     v.object({
       category: v.enum(["bug", "billing", "feature"] as const),
       reasoning: v.string(),
       confidence: v.number().min(0).max(100),
     })
-  )(),
+  )),
 });
 
 object.category; // "bug" | "billing" | "feature"

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -3,11 +3,37 @@
  *
  * @module llm
  *
- * @example
+ * @example Text
  * ```ts
  * import { generate } from "veryfront/llm";
  *
  * const { text } = await generate({ input: "Name three colours." });
+ * ```
+ *
+ * @example Structured output
+ * ```ts
+ * import { generate } from "veryfront/llm";
+ * import { defineSchema } from "veryfront/schemas";
+ *
+ * const { object } = await generate({
+ *   input: "Berlin is 12 degrees today.",
+ *   outputSchema: defineSchema((v) =>
+ *     v.object({ city: v.string(), tempC: v.number() })
+ *   )(),
+ * });
+ *
+ * object.city; // string
+ * ```
+ *
+ * @example Choosing a model
+ * ```ts
+ * import { generate } from "veryfront/llm";
+ *
+ * const { text } = await generate({
+ *   input: "Summarise this in one line.",
+ *   system: "You are terse.",
+ *   model: "anthropic/claude-haiku-4-5-20251001",
+ * });
  * ```
  */
 

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -13,18 +13,18 @@
  * @example Structured output
  * ```ts
  * import { generate } from "veryfront/llm";
- * import { defineSchema } from "veryfront/schemas";
+ * import { defineSchema, lazySchema } from "veryfront/schemas";
  *
  * const { object } = await generate({
  *   input: "The checkout button does nothing on mobile Safari.",
  *   system: "Classify the support ticket.",
- *   outputSchema: defineSchema((v) =>
+ *   outputSchema: lazySchema(defineSchema((v) =>
  *     v.object({
  *       category: v.enum(["bug", "billing", "feature"] as const),
  *       reasoning: v.string(),
  *       confidence: v.number().min(0).max(100),
  *     })
- *   )(),
+ *   )),
  * });
  *
  * object.category; // "bug" | "billing" | "feature"

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -16,13 +16,19 @@
  * import { defineSchema } from "veryfront/schemas";
  *
  * const { object } = await generate({
- *   input: "Berlin is 12 degrees today.",
+ *   input: "The checkout button does nothing on mobile Safari.",
+ *   system: "Classify the support ticket.",
  *   outputSchema: defineSchema((v) =>
- *     v.object({ city: v.string(), tempC: v.number() })
+ *     v.object({
+ *       category: v.enum(["bug", "billing", "feature"] as const),
+ *       reasoning: v.string(),
+ *       confidence: v.number().min(0).max(100),
+ *     })
  *   )(),
  * });
  *
- * object.city; // string
+ * object.category; // "bug" | "billing" | "feature"
+ * object.confidence; // number, 0-100
  * ```
  *
  * @example Choosing a model


### PR DESCRIPTION
The generated `veryfront/llm` API reference carried only a bare exports table — `generate` and
`GenerateInput` with one-line descriptions and no fields. `outputSchema` did not appear anywhere on
the page, so a developer landing there had no way to learn that structured output exists.

The generator renders whatever the module docblock provides, and named `@example` blocks become
their own headings (`veryfront/agent` carries eight). This adds two:

- **Structured output** — `defineSchema`, `outputSchema`, and a typed `object.city`
- **Choosing a model** — `system` and an explicit `model`

alongside the existing text example.

## Verification

The structured-output sample was type-checked rather than eyeballed: `object.city` resolves to
`string`, `object.tempC` to `number`, and a field outside the schema is a compile error — a
`@ts-expect-error` on it is satisfied, which proves inference resolves to a real shape rather than
`any`.

`deno task lint:ci` — EXIT=0 (test-typecheck baseline holds 0 new, anti-slop baseline ok).
`deno task docs` regenerated and committed.

Two files: the module docblock and its generated page. No renumbering churn, since no export was
added.

## Note

This page is not yet reachable at
`veryfront.com/docs/code/api-reference/veryfront/llm`. Publishing also needs veryfront-docs#397,
which carries the synced pages and the `docs.json` nav entry. The same gap currently hides the
"Structured output" section of the agents guide — that section is on `main` here, but
`outputSchema` appears zero times on the live guide page.