### PR TITLE
fix(workflow): forward an agent step's validated object into workflow context

### DIFF
--- a/src/workflow/executor/step-executor.test.ts
+++ b/src/workflow/executor/step-executor.test.ts
@@ -385,6 +385,24 @@ describe("StepExecutor agent structured output", () => {
     });
   });
 
+  it("keeps a structured output whose schema transformed it to undefined", async () => {
+    // The runtime sets `object` iff an outputSchema is configured, so presence
+    // -- not definedness -- is what separates a structured response from a
+    // schemaless one. A schema using the supported `transform()` operation can
+    // legitimately yield `undefined`, and that is not the same as no schema.
+    const node = makeAgentStepNode({
+      text: "null",
+      object: undefined,
+      status: "completed",
+      usage: { totalTokens: 2 },
+    });
+
+    const result = await new StepExecutor({}).execute(node, makeContext());
+
+    assertEquals(Object.hasOwn(result.output as object, "object"), true);
+    assertEquals((result.output as { object?: unknown }).object, undefined);
+  });
+
   it("omits the object key entirely for an agent with no outputSchema", async () => {
     const node = makeAgentStepNode({
       text: "plain text",

--- a/src/workflow/executor/step-executor.test.ts
+++ b/src/workflow/executor/step-executor.test.ts
@@ -385,22 +385,32 @@ describe("StepExecutor agent structured output", () => {
     });
   });
 
-  it("keeps a structured output whose schema transformed it to undefined", async () => {
-    // The runtime sets `object` iff an outputSchema is configured, so presence
-    // -- not definedness -- is what separates a structured response from a
-    // schemaless one. A schema using the supported `transform()` operation can
-    // legitimately yield `undefined`, and that is not the same as no schema.
+  it("survives a durable round-trip unchanged", async () => {
+    // The durable path persists workflow context with JSON.stringify, which
+    // drops undefined-valued keys. If the stored output carried any, the same
+    // run would present one shape in memory and another after a pause/resume.
     const node = makeAgentStepNode({
-      text: "null",
+      text: "hi",
+      toolCalls: undefined,
       object: undefined,
       status: "completed",
-      usage: { totalTokens: 2 },
+      usage: undefined,
     });
 
     const result = await new StepExecutor({}).execute(node, makeContext());
 
-    assertEquals(Object.hasOwn(result.output as object, "object"), true);
-    assertEquals((result.output as { object?: unknown }).object, undefined);
+    assertEquals(result.output, JSON.parse(JSON.stringify(result.output)));
+  });
+
+  it("omits response fields the agent did not produce", async () => {
+    // Not just `object`: `toolCalls` and `usage` were stored as present-but-
+    // undefined keys, so `"usage" in ctx.step` answered differently before and
+    // after a resume.
+    const node = makeAgentStepNode({ text: "hi", status: "completed" });
+
+    const result = await new StepExecutor({}).execute(node, makeContext());
+
+    assertEquals(Object.keys(result.output as object), ["text", "status"]);
   });
 
   it("omits the object key entirely for an agent with no outputSchema", async () => {
@@ -412,8 +422,9 @@ describe("StepExecutor agent structured output", () => {
 
     const result = await new StepExecutor({}).execute(node, makeContext());
 
-    // Absent, not present-and-undefined: a schemaless agent's output shape is
-    // unchanged, so `"object" in context.extract` stays a usable signal.
+    // Absent, not present-and-undefined, so a schemaless agent's output gains
+    // no key and the fields it did produce are untouched.
     assertEquals(Object.hasOwn(result.output as object, "object"), false);
+    assertEquals((result.output as { usage?: unknown }).usage, { totalTokens: 3 });
   });
 });

--- a/src/workflow/executor/step-executor.test.ts
+++ b/src/workflow/executor/step-executor.test.ts
@@ -335,3 +335,67 @@ describe("StepExecutor run scoping", () => {
     assertEquals(errors, [["s2", "run-xyz"]]);
   });
 });
+
+describe("StepExecutor agent structured output", () => {
+  /** An agent whose `generate()` returns `response`, as the real runtime does. */
+  function makeAgentStepNode(response: Record<string, unknown>): WorkflowNode {
+    return step("extract", {
+      agent: {
+        id: "extractor",
+        generate: () => Promise.resolve(response),
+        // deno-lint-ignore no-explicit-any
+      } as any,
+    });
+  }
+
+  it("forwards the validated object from an agent declaring an outputSchema", async () => {
+    const node = makeAgentStepNode({
+      text: '{"name":"Max"}',
+      object: { name: "Max" },
+      status: "completed",
+      usage: { totalTokens: 7 },
+    });
+
+    const result = await new StepExecutor({}).execute(node, makeContext());
+
+    assertEquals(result.success, true);
+    // A later step reads `context.extract.object`; dropping it here makes the
+    // agent's structured output unreachable from inside a workflow.
+    assertEquals((result.output as { object?: unknown }).object, { name: "Max" });
+  });
+
+  it("still forwards the other response fields alongside the object", async () => {
+    const toolCalls = [{ id: "c1", name: "lookup", args: {} }];
+    const node = makeAgentStepNode({
+      text: '{"name":"Max"}',
+      object: { name: "Max" },
+      toolCalls,
+      status: "completed",
+      usage: { totalTokens: 7 },
+    });
+
+    const result = await new StepExecutor({}).execute(node, makeContext());
+
+    assertEquals(result.output, {
+      text: '{"name":"Max"}',
+      toolCalls,
+      status: "completed",
+      usage: { totalTokens: 7 },
+      object: { name: "Max" },
+    });
+  });
+
+  it("omits the object key entirely for an agent with no outputSchema", async () => {
+    const node = makeAgentStepNode({
+      text: "plain text",
+      status: "completed",
+      usage: { totalTokens: 3 },
+    });
+
+    const result = await new StepExecutor({}).execute(node, makeContext());
+
+    // Absent, not present-and-undefined: a schemaless agent's output shape is
+    // unchanged, so `"object" in context.extract` stays a usable signal.
+    assertEquals(Object.hasOwn(result.output as object, "object"), false);
+  });
+});

--- a/src/workflow/executor/step-executor.ts
+++ b/src/workflow/executor/step-executor.ts
@@ -370,9 +370,13 @@ export class StepExecutor {
       // `generate()` has already parsed and validated this against the agent's
       // `outputSchema`. Dropping it here is silent: a later step reading
       // `context.<nodeId>.object` gets `undefined` with no error, which makes
-      // `outputSchema` unusable from inside a workflow. Spread conditionally so
-      // a schemaless agent's output shape gains no `object` key.
-      ...(response.object !== undefined ? { object: response.object } : {}),
+      // `outputSchema` unusable from inside a workflow.
+      //
+      // Keyed on presence, not on value, to mirror how the runtime sets it:
+      // `...(outputSchema ? { object: await outputSchema.parseOutput(text) } : {})`.
+      // A schema whose `transform()` yields `undefined` is a real structured
+      // output and must survive; only a schemaless agent has no key at all.
+      ...("object" in response ? { object: response.object } : {}),
     };
   }
 

--- a/src/workflow/executor/step-executor.ts
+++ b/src/workflow/executor/step-executor.ts
@@ -367,6 +367,12 @@ export class StepExecutor {
       toolCalls: response.toolCalls,
       status: response.status,
       usage: response.usage,
+      // `generate()` has already parsed and validated this against the agent's
+      // `outputSchema`. Dropping it here is silent: a later step reading
+      // `context.<nodeId>.object` gets `undefined` with no error, which makes
+      // `outputSchema` unusable from inside a workflow. Spread conditionally so
+      // a schemaless agent's output shape gains no `object` key.
+      ...(response.object !== undefined ? { object: response.object } : {}),
     };
   }
 

--- a/src/workflow/executor/step-executor.ts
+++ b/src/workflow/executor/step-executor.ts
@@ -154,6 +154,30 @@ export interface StepResult {
   executionTime: number;
 }
 
+/**
+ * Build a step's stored output, keeping only the fields that actually have a
+ * value.
+ *
+ * A step's output is written into workflow context, and the durable path
+ * persists that context with `JSON.stringify`, which drops every
+ * `undefined`-valued key. A response field that is absent -- `toolCalls` and
+ * `usage` on a schemaless agent, `object` on one whose schema parsed to
+ * `undefined` -- would therefore exist as a key in memory and be gone after a
+ * pause/resume, so the same run would present two different context shapes
+ * depending on whether it ever suspended.
+ *
+ * Emitting only defined fields collapses that to one shape: what a step reads
+ * in memory is exactly what survives a durable round-trip. Reading an absent
+ * field still yields `undefined`, so this is invisible to `ctx.step.usage`; it
+ * only makes `"usage" in ctx.step` and `Object.keys(ctx.step)` mean the same
+ * thing on both paths.
+ */
+function buildAgentStepOutput(fields: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(fields).filter(([, value]) => value !== undefined),
+  );
+}
+
 export class StepExecutor {
   private config: StepExecutorConfig;
   private nonCooperativeErrors = new WeakSet<Error>();
@@ -362,22 +386,17 @@ export class StepExecutor {
     });
     abortSignal?.throwIfAborted();
 
-    return {
+    // `object` is the validated structured output from the agent's
+    // `outputSchema`, already parsed by `generate()`. Omitting it here was
+    // silent: a later step reading `context.<nodeId>.object` got `undefined`
+    // with no error, making `outputSchema` unusable from inside a workflow.
+    return buildAgentStepOutput({
       text: response.text,
       toolCalls: response.toolCalls,
       status: response.status,
       usage: response.usage,
-      // `generate()` has already parsed and validated this against the agent's
-      // `outputSchema`. Dropping it here is silent: a later step reading
-      // `context.<nodeId>.object` gets `undefined` with no error, which makes
-      // `outputSchema` unusable from inside a workflow.
-      //
-      // Keyed on presence, not on value, to mirror how the runtime sets it:
-      // `...(outputSchema ? { object: await outputSchema.parseOutput(text) } : {})`.
-      // A schema whose `transform()` yields `undefined` is a real structured
-      // output and must survive; only a schemaless agent has no key at all.
-      ...("object" in response ? { object: response.object } : {}),
-    };
+      object: response.object,
+    });
   }
 
   private async executeTool(


### PR DESCRIPTION
Fixes #3917, and the pre-existing shape bug underneath it.

## Problem

`StepExecutor.executeAgent` whitelists which response fields become a step's stored output, and `object` was not on the list:

```ts
return { text, toolCalls, status, usage };   // object dropped
```

`generate()` has already parsed and validated `response.object` against the agent's `outputSchema` before `executeAgent` returns it, so the value exists and is simply discarded. `outputSchema` therefore works for a direct `agent.generate()` call but silently stops working the moment the same agent is wired into a `workflow()` via `agentStep`.

The failure is quiet in a way that makes it expensive to debug:

- `context.<nodeId>.object` is `undefined` with nothing thrown.
- Casting the context entry to `AgentResponse<T>` (its real runtime type) types `.object` as `T`, so the type system actively conceals the gap.
- It surfaces later and elsewhere, typically as a `TypeError` from destructuring `undefined`.

## The pre-existing bug underneath

Review raised that forwarding `object` as a *present-but-undefined* key only holds in memory: the durable path persists workflow context with `JSON.stringify` (`src/workflow/backends/redis/index.ts:341`), which drops undefined-valued keys.

That is true, and it was **already true on main** for two other keys:

```
KEYS      : ["text","toolCalls","status","usage"]
UNDEFINED : ["toolCalls","usage"]
ROUNDTRIP : ["text","status"]
```

So the same run presented one context shape in memory and a different one after a pause/resume — and which one a step saw depended on a suspension it has no way to observe.

## Fix

Fix the shape rather than one key of it. The step output now carries **only fields that actually have a value**, so what a step reads in memory is exactly what survives a durable round-trip:

```ts
return buildAgentStepOutput({ text, toolCalls, status, usage, object: response.object });
```

Reading an absent field still yields `undefined`, so `ctx.step.usage` is unaffected. It only makes `"usage" in ctx.step` and `Object.keys(ctx.step)` answer the same on both paths.

A schema parsing to `undefined` consistently produces no `object` key anywhere, rather than one that silently vanishes on resume — not drawing a distinction is better than drawing one the durable path cannot preserve.

No public API change.

## Tests (red → green)

`StepExecutor agent structured output` in `src/workflow/executor/step-executor.test.ts`:

| test | on main | with fix |
|---|---|---|
| forwards the validated object from an agent declaring an outputSchema | FAIL | pass |
| still forwards the other response fields alongside the object | FAIL | pass |
| survives a durable round-trip unchanged | FAIL | pass |
| omits response fields the agent did not produce | FAIL | pass |
| omits the object key entirely for an agent with no outputSchema | pass | pass |

`survives a durable round-trip unchanged` asserts the invariant directly — the output equals its own JSON round-trip. The last test is the guard against over-correcting.

## Verification

- Four new/updated tests fail against main's shape for the stated reason, pass with the fix.
- Full workflow suite green: `77 passed (774 steps) | 0 failed`.
- `deno check`, `deno lint`, `deno fmt` clean; full pre-push suite green.

## Note on CI

The `coverage shard 4/8` failure seen on this PR is an unrelated pre-existing flake — a leaked background disk-cache write in the SSR module loader, in a suite this branch does not touch. Diagnosed and fixed separately in #3923.
