### PR TITLE
fix(anthropic): close object schemas in output_config so a plain outputSchema works

### DIFF
--- a/extensions/ext-llm-anthropic/README.md
+++ b/extensions/ext-llm-anthropic/README.md
@@ -226,7 +226,7 @@ Anthropic rejects an object-typed schema that does not explicitly set
 `additionalProperties: false`, independently of the framework's own `strict`
 flag:
 
-```
+```text
 output_config.format.schema: For 'object' type, 'additionalProperties'
 must be explicitly set to false
 ```

--- a/extensions/ext-llm-anthropic/README.md
+++ b/extensions/ext-llm-anthropic/README.md
@@ -233,13 +233,28 @@ must be explicitly set to false
 
 The builder satisfies that itself, filling in `additionalProperties: false` on
 every object subschema that left it unset -- including nested properties, array
-items, and `anyOf`/`oneOf`/`allOf` branches -- so a plain
-`defineSchema((v) => v.object({ ... }))()` works without `.strict()`.
+items, and `anyOf`/`oneOf` branches -- so a
+`defineSchema((v) => v.object({ ... }))()` whose properties are all required
+works without `.strict()`.
 
-An `additionalProperties` you declare yourself is left as declared. A schema
-that genuinely allows extra properties, such as one built with `v.record()`,
-is still rejected by Anthropic, which has no way to express an open object in
-structured output.
+Three shapes are deliberately left open:
+
+- **`allOf` branches.** `additionalProperties` only ever sees the `properties`
+  of the schema object carrying it, so closing branches that each declare part
+  of the same object makes every branch reject the others' properties, and the
+  composition accepts nothing at all. Branches are walked for objects nested
+  inside them, but are not closed themselves.
+- **An `additionalProperties` you declared yourself**, which is left exactly as
+  declared.
+- **Open records.** `v.record()` emits `additionalProperties` as a schema
+  rather than `false`, and Anthropic has no way to express an open object in
+  structured output, so it rejects these either way.
+
+Closing an object is necessary, but it is not the only constraint Anthropic
+places on a structured-output schema -- notably, a schema with `.optional()`
+properties can still be rejected. Where a field may be absent, prefer a
+required property that accepts null (`v.string().nullable()`) over an optional
+one.
 
 ### Container
 

--- a/extensions/ext-llm-anthropic/README.md
+++ b/extensions/ext-llm-anthropic/README.md
@@ -212,8 +212,34 @@ providerOptions: {
 A `json_schema` response format maps to Anthropic `output_config`:
 
 ```json
-{ "output_config": { "format": { "type": "json_schema", "schema": { "type": "object" } } } }
+{
+  "output_config": {
+    "format": {
+      "type": "json_schema",
+      "schema": { "type": "object", "properties": {}, "additionalProperties": false }
+    }
+  }
+}
 ```
+
+Anthropic rejects an object-typed schema that does not explicitly set
+`additionalProperties: false`, independently of the framework's own `strict`
+flag:
+
+```
+output_config.format.schema: For 'object' type, 'additionalProperties'
+must be explicitly set to false
+```
+
+The builder satisfies that itself, filling in `additionalProperties: false` on
+every object subschema that left it unset -- including nested properties, array
+items, and `anyOf`/`oneOf`/`allOf` branches -- so a plain
+`defineSchema((v) => v.object({ ... }))()` works without `.strict()`.
+
+An `additionalProperties` you declare yourself is left as declared. A schema
+that genuinely allows extra properties, such as one built with `v.record()`,
+is still rejected by Anthropic, which has no way to express an open object in
+structured output.
 
 ### Container
 

--- a/extensions/ext-llm-anthropic/src/anthropic-provider.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-provider.test.ts
@@ -3723,7 +3723,11 @@ describe("anthropic-provider", () => {
         responseFormat: { type: "json_schema", name: "Person", schema, strict: true },
       });
       const body = captured as { output_config?: unknown } | null;
-      assertEquals(body!.output_config, { format: { type: "json_schema", schema } });
+      // The schema is closed on the way out: Anthropic rejects an object schema
+      // that does not explicitly set additionalProperties: false.
+      assertEquals(body!.output_config, {
+        format: { type: "json_schema", schema: { ...schema, additionalProperties: false } },
+      });
       assertEquals(settings(result), []);
     });
 
@@ -3753,7 +3757,11 @@ describe("anthropic-provider", () => {
       });
 
       const body = captured as { output_config?: unknown } | null;
-      assertEquals(body!.output_config, { format: { type: "json_schema", schema } });
+      // The schema is closed on the way out: Anthropic rejects an object schema
+      // that does not explicitly set additionalProperties: false.
+      assertEquals(body!.output_config, {
+        format: { type: "json_schema", schema: { ...schema, additionalProperties: false } },
+      });
     });
 
     it("advertises JSON Schema structured output only for supported model families", () => {

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
@@ -4863,6 +4863,41 @@ describe("anthropic output_config schema closure", () => {
     assertEquals(branches[1]!.additionalProperties, false);
   });
 
+  it("closes object subschemas under every schema-bearing keyword", () => {
+    // These are all accepted JSON Schema keywords (src/schemas/schema-input.ts),
+    // so a raw outputSchema can put an object under any of them. A walk that
+    // skips one leaves that object open for Anthropic to reject.
+    const schema = buildWithOutputSchema({
+      type: "object",
+      properties: { name: { type: "string" } },
+      dependentSchemas: { name: { type: "object", properties: { via: { type: "string" } } } },
+      unevaluatedProperties: { type: "object", properties: { extra: { type: "string" } } },
+      contentSchema: { type: "object", properties: { body: { type: "string" } } },
+    });
+
+    for (const keyword of ["unevaluatedProperties", "contentSchema"]) {
+      assertEquals(
+        (schema[keyword] as Record<string, unknown>).additionalProperties,
+        false,
+        keyword,
+      );
+    }
+    const dependent = (schema.dependentSchemas as Record<string, Record<string, unknown>>).name;
+    assertEquals(dependent.additionalProperties, false);
+  });
+
+  it("closes an object declaring additionalProperties as undefined", () => {
+    // An explicit `undefined` survives the walk but not JSON, so honoring its
+    // presence would emit exactly the open schema Anthropic rejects.
+    const schema = buildWithOutputSchema({
+      type: "object",
+      properties: { name: { type: "string" } },
+      additionalProperties: undefined,
+    });
+
+    assertEquals(schema.additionalProperties, false);
+  });
+
   it("leaves an explicitly declared additionalProperties alone", () => {
     // Rewriting an explicit declaration would silently change the contract the
     // caller asked for. Anthropic still rejects it, which is the caller's call.

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
@@ -4834,7 +4834,7 @@ describe("anthropic output_config schema closure", () => {
       required: ["user"],
     });
 
-    const user = (schema.properties as Record<string, Record<string, unknown>>).user;
+    const user = (schema.properties as Record<string, Record<string, unknown>>).user!;
     assertEquals(user.additionalProperties, false);
   });
 
@@ -4846,7 +4846,7 @@ describe("anthropic output_config schema closure", () => {
       },
     });
 
-    const rows = (schema.properties as Record<string, Record<string, unknown>>).rows;
+    const rows = (schema.properties as Record<string, Record<string, unknown>>).rows!;
     assertEquals((rows.items as Record<string, unknown>).additionalProperties, false);
   });
 
@@ -4892,7 +4892,7 @@ describe("anthropic output_config schema closure", () => {
     });
 
     const branch = (schema.allOf as Record<string, unknown>[])[0]!;
-    const user = (branch.properties as Record<string, Record<string, unknown>>).user;
+    const user = (branch.properties as Record<string, Record<string, unknown>>).user!;
     assertEquals(user.additionalProperties, false);
     assertEquals(Object.hasOwn(branch, "additionalProperties"), false);
   });
@@ -4916,7 +4916,7 @@ describe("anthropic output_config schema closure", () => {
         keyword,
       );
     }
-    const dependent = (schema.dependentSchemas as Record<string, Record<string, unknown>>).name;
+    const dependent = (schema.dependentSchemas as Record<string, Record<string, unknown>>).name!;
     assertEquals(dependent.additionalProperties, false);
   });
 
@@ -4930,6 +4930,48 @@ describe("anthropic output_config schema closure", () => {
     });
 
     assertEquals(schema.additionalProperties, false);
+  });
+
+  it("does not close a $ref holder, whose properties live elsewhere", () => {
+    // `additionalProperties` only sees the `properties` of the schema object
+    // carrying it. A `$ref` declares none of its own, so closing it rejects
+    // every property the target defines -- a valid schema turned into one that
+    // validates nothing.
+    const schema = buildWithOutputSchema({
+      $defs: { Person: { type: "object", properties: { name: { type: "string" } } } },
+      $ref: "#/$defs/Person",
+      type: "object",
+    });
+
+    assertEquals(Object.hasOwn(schema, "additionalProperties"), false);
+    const person = (schema.$defs as Record<string, Record<string, unknown>>).Person!;
+    assertEquals(person.additionalProperties, false);
+  });
+
+  it("keeps traversing when Set and Array intrinsics are replaced", () => {
+    // This module captures its intrinsics on purpose (see the top of the file).
+    // A walker calling through the live prototypes can be silently disabled by
+    // a patched `Set.prototype.has`, leaving every nested object open.
+    const nativeHas = Set.prototype.has;
+    const nativeIsArray = Array.isArray;
+    try {
+      Set.prototype.has = () => false;
+      Array.isArray = ((_value: unknown) => false) as unknown as typeof Array.isArray;
+
+      const schema = buildWithOutputSchema({
+        type: "object",
+        properties: {
+          user: { type: "object", properties: { name: { type: "string" } } },
+        },
+      });
+
+      const user = (schema.properties as Record<string, Record<string, unknown>>).user!;
+      assertEquals(user.additionalProperties, false);
+      assertEquals(schema.additionalProperties, false);
+    } finally {
+      Set.prototype.has = nativeHas;
+      Array.isArray = nativeIsArray;
+    }
   });
 
   it("leaves an explicitly declared additionalProperties alone", () => {
@@ -4970,7 +5012,7 @@ describe("anthropic output_config schema closure", () => {
     });
 
     const branches = (schema.properties as Record<string, Record<string, unknown>>)
-      .user.anyOf as Record<string, unknown>[];
+      .user!.anyOf as Record<string, unknown>[];
     assertEquals(branches[0]!.additionalProperties, false);
     assertEquals(branches[1]!.additionalProperties, undefined);
   });
@@ -4994,7 +5036,7 @@ describe("anthropic output_config schema closure", () => {
       properties: { value: { type: ["string", "null"] } },
     });
 
-    const value = (schema.properties as Record<string, Record<string, unknown>>).value;
+    const value = (schema.properties as Record<string, Record<string, unknown>>).value!;
     assertEquals(Object.hasOwn(value, "additionalProperties"), false);
   });
 
@@ -5009,7 +5051,7 @@ describe("anthropic output_config schema closure", () => {
       required: ["meta"],
     });
 
-    const meta = (schema.properties as Record<string, Record<string, unknown>>).meta;
+    const meta = (schema.properties as Record<string, Record<string, unknown>>).meta!;
     assertEquals(meta.additionalProperties, { type: "string" });
     assertEquals(schema.additionalProperties, false);
   });
@@ -5024,7 +5066,7 @@ describe("anthropic output_config schema closure", () => {
       },
     });
 
-    const config = (schema.properties as Record<string, Record<string, unknown>>).config;
+    const config = (schema.properties as Record<string, Record<string, unknown>>).config!;
     assertEquals(config.default, { type: "object", properties: {} });
   });
 });

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
@@ -4884,6 +4884,44 @@ describe("anthropic output_config schema closure", () => {
     assertEquals(Object.hasOwn(original, "additionalProperties"), false);
   });
 
+  it("closes the object branch of a nullable object", () => {
+    // `.nullable()` emits an anyOf of the object and null, which is the shape
+    // the schema emitter really produces -- not a bare object.
+    const schema = buildWithOutputSchema({
+      type: "object",
+      properties: {
+        user: {
+          anyOf: [
+            { type: "object", properties: { name: { type: "string" } }, required: ["name"] },
+            { type: "null" },
+          ],
+        },
+      },
+      required: ["user"],
+    });
+
+    const branches = (schema.properties as Record<string, Record<string, unknown>>)
+      .user.anyOf as Record<string, unknown>[];
+    assertEquals(branches[0]!.additionalProperties, false);
+    assertEquals(branches[1]!.additionalProperties, undefined);
+  });
+
+  it("leaves a record's additionalProperties schema intact", () => {
+    // `v.record()` emits additionalProperties as a *schema*, not a boolean.
+    // Overwriting it with `false` would silently turn a map into a closed empty
+    // object. Anthropic rejects open records either way, which is the honest
+    // outcome; #3922 makes that rejection legible.
+    const schema = buildWithOutputSchema({
+      type: "object",
+      properties: { meta: { type: "object", additionalProperties: { type: "string" } } },
+      required: ["meta"],
+    });
+
+    const meta = (schema.properties as Record<string, Record<string, unknown>>).meta;
+    assertEquals(meta.additionalProperties, { type: "string" });
+    assertEquals(schema.additionalProperties, false);
+  });
+
   it("does not rewrite non-schema values that merely look like schemas", () => {
     // `default` holds a literal value, not a subschema. Recursing into it would
     // corrupt the declared default.

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
@@ -4932,6 +4932,67 @@ describe("anthropic output_config schema closure", () => {
     assertEquals(schema.additionalProperties, false);
   });
 
+  it("leaves an allOf branch target open, so the composition stays satisfiable", () => {
+    // Closing both definitions makes `{ a, b }` fail the first on `b` and the
+    // second on `a`, so the composition accepts nothing at all. The branch
+    // objects carry only a `$ref`, so the meaning sits at the target.
+    const schema = buildWithOutputSchema({
+      $defs: {
+        A: { type: "object", properties: { a: { type: "string" } } },
+        B: { type: "object", properties: { b: { type: "string" } } },
+      },
+      allOf: [{ $ref: "#/$defs/A" }, { $ref: "#/$defs/B" }],
+    });
+
+    const defs = schema.$defs as Record<string, Record<string, unknown>>;
+    assertEquals(Object.hasOwn(defs.A!, "additionalProperties"), false);
+    assertEquals(Object.hasOwn(defs.B!, "additionalProperties"), false);
+  });
+
+  it("leaves a draft-07 definitions target of an allOf branch open", () => {
+    const schema = buildWithOutputSchema({
+      definitions: {
+        A: { type: "object", properties: { a: { type: "string" } } },
+        B: { type: "object", properties: { b: { type: "string" } } },
+      },
+      allOf: [{ $ref: "#/definitions/A" }, { $ref: "#/definitions/B" }],
+    });
+
+    const defs = schema.definitions as Record<string, Record<string, unknown>>;
+    assertEquals(Object.hasOwn(defs.A!, "additionalProperties"), false);
+    assertEquals(Object.hasOwn(defs.B!, "additionalProperties"), false);
+  });
+
+  it("still closes a definition no allOf branch references", () => {
+    // Only the referenced target is opened. Everything else keeps its closure,
+    // which is the whole point of the pass.
+    const schema = buildWithOutputSchema({
+      $defs: {
+        A: { type: "object", properties: { a: { type: "string" } } },
+        Unrelated: { type: "object", properties: { u: { type: "string" } } },
+      },
+      allOf: [{ $ref: "#/$defs/A" }],
+    });
+
+    const defs = schema.$defs as Record<string, Record<string, unknown>>;
+    assertEquals(Object.hasOwn(defs.A!, "additionalProperties"), false);
+    assertEquals(defs.Unrelated!.additionalProperties, false);
+  });
+
+  it("opens an allOf branch target named with an escaped pointer token", () => {
+    // RFC 6901 escapes `/` as `~1`, so a definition name carrying one only
+    // matches when the walk encodes the token the same way.
+    const schema = buildWithOutputSchema({
+      $defs: {
+        "a/b": { type: "object", properties: { a: { type: "string" } } },
+      },
+      allOf: [{ $ref: "#/$defs/a~1b" }],
+    });
+
+    const defs = schema.$defs as Record<string, Record<string, unknown>>;
+    assertEquals(Object.hasOwn(defs["a/b"]!, "additionalProperties"), false);
+  });
+
   it("does not close a $ref holder, whose properties live elsewhere", () => {
     // `additionalProperties` only sees the `properties` of the schema object
     // carrying it. A `$ref` declares none of its own, so closing it rejects

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
@@ -4863,6 +4863,40 @@ describe("anthropic output_config schema closure", () => {
     assertEquals(branches[1]!.additionalProperties, false);
   });
 
+  it("does not close allOf branches, which describe one instance together", () => {
+    // `additionalProperties` only sees the `properties` of the schema object
+    // carrying it, so closing both branches makes each reject the other's
+    // property and `{ a, b }` satisfies neither.
+    const schema = buildWithOutputSchema({
+      allOf: [
+        { type: "object", properties: { a: { type: "string" } } },
+        { type: "object", properties: { b: { type: "string" } } },
+      ],
+    });
+
+    const branches = schema.allOf as Record<string, unknown>[];
+    assertEquals(Object.hasOwn(branches[0]!, "additionalProperties"), false);
+    assertEquals(Object.hasOwn(branches[1]!, "additionalProperties"), false);
+  });
+
+  it("still closes objects nested inside an allOf branch", () => {
+    // Only the branch itself participates in the composition. An object under
+    // a branch's `properties` is an ordinary standalone schema.
+    const schema = buildWithOutputSchema({
+      allOf: [
+        {
+          type: "object",
+          properties: { user: { type: "object", properties: { name: { type: "string" } } } },
+        },
+      ],
+    });
+
+    const branch = (schema.allOf as Record<string, unknown>[])[0]!;
+    const user = (branch.properties as Record<string, Record<string, unknown>>).user;
+    assertEquals(user.additionalProperties, false);
+    assertEquals(Object.hasOwn(branch, "additionalProperties"), false);
+  });
+
   it("closes object subschemas under every schema-bearing keyword", () => {
     // These are all accepted JSON Schema keywords (src/schemas/schema-input.ts),
     // so a raw outputSchema can put an object under any of them. A walk that

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
@@ -4793,3 +4793,108 @@ describe("ext-llm-anthropic/anthropic-request-builder", () => {
     );
   });
 });
+
+describe("anthropic output_config schema closure", () => {
+  /** Build a request carrying `schema` as the json_schema response format. */
+  function buildWithOutputSchema(schema: unknown): Record<string, unknown> {
+    const warnings: unknown[] = [];
+    const body = buildAnthropicMessagesRequest(
+      "claude-haiku-4-5-20251001",
+      "anthropic",
+      {
+        prompt: [{ role: "user", content: [{ type: "text", text: "Hi" }] }],
+        responseFormat: { type: "json_schema", name: "output", schema },
+        // deno-lint-ignore no-explicit-any
+      } as any,
+      false,
+      // deno-lint-ignore no-explicit-any
+      warnings as any,
+    );
+    return (body.output_config as { format: { schema: Record<string, unknown> } }).format.schema;
+  }
+
+  it("closes a top-level object schema that left additionalProperties unset", () => {
+    // Anthropic rejects this schema with a 400 unless additionalProperties is
+    // explicitly false, even though every property is already required.
+    const schema = buildWithOutputSchema({
+      type: "object",
+      properties: { name: { type: "string" } },
+      required: ["name"],
+    });
+
+    assertEquals(schema.additionalProperties, false);
+  });
+
+  it("closes nested object properties", () => {
+    const schema = buildWithOutputSchema({
+      type: "object",
+      properties: {
+        user: { type: "object", properties: { name: { type: "string" } }, required: ["name"] },
+      },
+      required: ["user"],
+    });
+
+    const user = (schema.properties as Record<string, Record<string, unknown>>).user;
+    assertEquals(user.additionalProperties, false);
+  });
+
+  it("closes object schemas inside array items", () => {
+    const schema = buildWithOutputSchema({
+      type: "object",
+      properties: {
+        rows: { type: "array", items: { type: "object", properties: { id: { type: "string" } } } },
+      },
+    });
+
+    const rows = (schema.properties as Record<string, Record<string, unknown>>).rows;
+    assertEquals((rows.items as Record<string, unknown>).additionalProperties, false);
+  });
+
+  it("closes object schemas inside composition keywords", () => {
+    const schema = buildWithOutputSchema({
+      anyOf: [
+        { type: "object", properties: { a: { type: "string" } } },
+        { type: "object", properties: { b: { type: "string" } } },
+      ],
+    });
+
+    const branches = schema.anyOf as Record<string, unknown>[];
+    assertEquals(branches[0]!.additionalProperties, false);
+    assertEquals(branches[1]!.additionalProperties, false);
+  });
+
+  it("leaves an explicitly declared additionalProperties alone", () => {
+    // Rewriting an explicit declaration would silently change the contract the
+    // caller asked for. Anthropic still rejects it, which is the caller's call.
+    const schema = buildWithOutputSchema({
+      type: "object",
+      properties: { name: { type: "string" } },
+      additionalProperties: true,
+    });
+
+    assertEquals(schema.additionalProperties, true);
+  });
+
+  it("does not mutate the caller's schema object", () => {
+    // The schema is owned by the agent and reused across providers and calls,
+    // so closing it for Anthropic must not leak into anyone else's request.
+    const original = { type: "object", properties: { name: { type: "string" } } };
+    buildWithOutputSchema(original);
+
+    assertEquals(Object.hasOwn(original, "additionalProperties"), false);
+  });
+
+  it("does not rewrite non-schema values that merely look like schemas", () => {
+    // `default` holds a literal value, not a subschema. Recursing into it would
+    // corrupt the declared default.
+    const schema = buildWithOutputSchema({
+      type: "object",
+      properties: {
+        config: { type: "string", default: { type: "object", properties: {} } },
+      },
+    });
+
+    const config = (schema.properties as Record<string, Record<string, unknown>>).config;
+    assertEquals(config.default, { type: "object", properties: {} });
+  });
+});

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.test.ts
@@ -4906,6 +4906,29 @@ describe("anthropic output_config schema closure", () => {
     assertEquals(branches[1]!.additionalProperties, undefined);
   });
 
+  it("closes a schema whose type array includes object", () => {
+    // `{ type: ["object", "null"] }` is the hand-written nullable form, and
+    // JsonSchema.type accepts an array. Matching only the exact string would
+    // leave this branch open for Anthropic to reject.
+    const schema = buildWithOutputSchema({
+      type: ["object", "null"],
+      properties: { name: { type: "string" } },
+      required: ["name"],
+    });
+
+    assertEquals(schema.additionalProperties, false);
+  });
+
+  it("leaves a non-object type array alone", () => {
+    const schema = buildWithOutputSchema({
+      type: "object",
+      properties: { value: { type: ["string", "null"] } },
+    });
+
+    const value = (schema.properties as Record<string, Record<string, unknown>>).value;
+    assertEquals(Object.hasOwn(value, "additionalProperties"), false);
+  });
+
   it("leaves a record's additionalProperties schema intact", () => {
     // `v.record()` emits additionalProperties as a *schema*, not a boolean.
     // Overwriting it with `false` would silently turn a map into a closed empty

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
@@ -2250,7 +2250,17 @@ function buildAnthropicOutputConfig(
  * through untouched instead of being rewritten when they happen to look like a
  * schema.
  */
-const SCHEMA_MAP_KEYWORDS = new Set(["properties", "patternProperties", "$defs", "definitions"]);
+const SCHEMA_MAP_KEYWORDS = new Set([
+  "properties",
+  "patternProperties",
+  "$defs",
+  "definitions",
+  "dependentSchemas",
+  // Draft-07 `dependencies` holds either a schema or an array of property
+  // names per key. The array form contains strings, which the walk returns
+  // unchanged, so both spellings can share this branch.
+  "dependencies",
+]);
 const SCHEMA_LIST_KEYWORDS = new Set(["anyOf", "oneOf", "allOf", "prefixItems"]);
 const SCHEMA_VALUE_KEYWORDS = new Set([
   "items",
@@ -2262,6 +2272,9 @@ const SCHEMA_VALUE_KEYWORDS = new Set([
   "if",
   "then",
   "else",
+  "unevaluatedProperties",
+  "unevaluatedItems",
+  "contentSchema",
 ]);
 
 /**
@@ -2277,7 +2290,8 @@ const SCHEMA_VALUE_KEYWORDS = new Set([
  *
  * An explicitly declared `additionalProperties` is preserved: rewriting it
  * would silently narrow a contract the caller deliberately opened, and
- * Anthropic surfaces its own error for that case.
+ * Anthropic surfaces its own error for that case. An explicit `undefined`
+ * is not a declaration -- JSON drops it before the provider ever sees it.
  *
  * The result is a copy. The schema object belongs to the agent and is reused
  * across providers and calls, so closing it for Anthropic must not mutate it.
@@ -2307,7 +2321,11 @@ function closeObjectSchemas(schema: unknown): unknown {
     result[key] = value;
   }
 
-  if (isObjectTyped(source.type) && !("additionalProperties" in source)) {
+  // `undefined` counts as unset, not as a declaration. The key survives the
+  // walk when a caller writes it explicitly as `undefined`, but JSON drops it
+  // on the way to the provider -- so honoring its presence would emit exactly
+  // the open schema Anthropic rejects.
+  if (isObjectTyped(source.type) && source.additionalProperties === undefined) {
     result.additionalProperties = false;
   }
   return result;

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
@@ -2315,30 +2315,27 @@ const SCHEMA_VALUE_KEYWORDS = new Set([
  * across providers and calls, so closing it for Anthropic must not mutate it.
  */
 function closeObjectSchemas(schema: unknown, closeSelf = true): unknown {
-  if (Array.isArray(schema)) return schema.map((entry) => closeObjectSchemas(entry, closeSelf));
+  if (ArrayIsArray(schema)) {
+    const entries: unknown[] = [];
+    for (const entry of schema) entries[entries.length] = closeObjectSchemas(entry, closeSelf);
+    return entries;
+  }
   if (typeof schema !== "object" || schema === null) return schema;
 
   const source = schema as Record<string, unknown>;
   const result: Record<string, unknown> = {};
 
-  for (const [key, value] of Object.entries(source)) {
-    if (SCHEMA_MAP_KEYWORDS.has(key)) {
-      result[key] = typeof value === "object" && value !== null && !Array.isArray(value)
-        ? Object.fromEntries(
-          Object.entries(value as Record<string, unknown>).map((
-            [name, subschema],
-          ) => [name, closeObjectSchemas(subschema)]),
-        )
-        : value;
+  for (const key of objectKeys(source)) {
+    const value = source[key];
+    if (hasSetValue(SCHEMA_MAP_KEYWORDS, key)) {
+      result[key] = closeSchemaMap(value);
       continue;
     }
-    if (COMPOSITION_LIST_KEYWORDS.has(key)) {
-      result[key] = Array.isArray(value)
-        ? value.map((branch) => closeObjectSchemas(branch, false))
-        : closeObjectSchemas(value, false);
+    if (hasSetValue(COMPOSITION_LIST_KEYWORDS, key)) {
+      result[key] = closeObjectSchemas(value, false);
       continue;
     }
-    if (SCHEMA_LIST_KEYWORDS.has(key) || SCHEMA_VALUE_KEYWORDS.has(key)) {
+    if (hasSetValue(SCHEMA_LIST_KEYWORDS, key) || hasSetValue(SCHEMA_VALUE_KEYWORDS, key)) {
       result[key] = closeObjectSchemas(value);
       continue;
     }
@@ -2349,8 +2346,27 @@ function closeObjectSchemas(schema: unknown, closeSelf = true): unknown {
   // walk when a caller writes it explicitly as `undefined`, but JSON drops it
   // on the way to the provider -- so honoring its presence would emit exactly
   // the open schema Anthropic rejects.
-  if (closeSelf && isObjectTyped(source.type) && source.additionalProperties === undefined) {
+  //
+  // A `$ref` holder is skipped: `additionalProperties` only ever sees the
+  // `properties` of the schema object carrying it, and a `$ref` declares none
+  // of its own, so closing it rejects every property the target defines.
+  if (
+    closeSelf && isObjectTyped(source.type) &&
+    source.additionalProperties === undefined &&
+    source.$ref === undefined
+  ) {
     result.additionalProperties = false;
+  }
+  return result;
+}
+
+/** Walk a keyword whose value maps names to subschemas. */
+function closeSchemaMap(value: unknown): unknown {
+  if (typeof value !== "object" || value === null || ArrayIsArray(value)) return value;
+  const source = value as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const name of objectKeys(source)) {
+    result[name] = closeObjectSchemas(source[name]);
   }
   return result;
 }

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
@@ -2238,9 +2238,79 @@ function buildAnthropicOutputConfig(
   return {
     format: {
       type: "json_schema",
-      schema: unwrapToolInputSchema(responseFormat.schema),
+      schema: closeObjectSchemas(unwrapToolInputSchema(responseFormat.schema)),
     },
   };
+}
+
+/**
+ * JSON Schema keywords whose value is itself a schema, a list of schemas, or a
+ * map of schemas. Recursion is restricted to these so that keywords holding
+ * literal values -- `default`, `const`, `enum`, `examples` -- are copied
+ * through untouched instead of being rewritten when they happen to look like a
+ * schema.
+ */
+const SCHEMA_MAP_KEYWORDS = new Set(["properties", "patternProperties", "$defs", "definitions"]);
+const SCHEMA_LIST_KEYWORDS = new Set(["anyOf", "oneOf", "allOf", "prefixItems"]);
+const SCHEMA_VALUE_KEYWORDS = new Set([
+  "items",
+  "additionalItems",
+  "contains",
+  "additionalProperties",
+  "propertyNames",
+  "not",
+  "if",
+  "then",
+  "else",
+]);
+
+/**
+ * Set `additionalProperties: false` on every object-typed subschema that left
+ * it unset.
+ *
+ * Anthropic's `output_config.format` rejects an object schema without it with a
+ * 400 -- "For 'object' type, 'additionalProperties' must be explicitly set to
+ * false" -- unconditionally, and independently of the framework's own `strict`
+ * flag. A plain `v.object({...})` with every field required therefore fails
+ * even though it already satisfies the rest of strict structured output, so the
+ * requirement is satisfied here rather than pushed onto every caller.
+ *
+ * An explicitly declared `additionalProperties` is preserved: rewriting it
+ * would silently narrow a contract the caller deliberately opened, and
+ * Anthropic surfaces its own error for that case.
+ *
+ * The result is a copy. The schema object belongs to the agent and is reused
+ * across providers and calls, so closing it for Anthropic must not mutate it.
+ */
+function closeObjectSchemas(schema: unknown): unknown {
+  if (Array.isArray(schema)) return schema.map(closeObjectSchemas);
+  if (typeof schema !== "object" || schema === null) return schema;
+
+  const source = schema as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(source)) {
+    if (SCHEMA_MAP_KEYWORDS.has(key)) {
+      result[key] = typeof value === "object" && value !== null && !Array.isArray(value)
+        ? Object.fromEntries(
+          Object.entries(value as Record<string, unknown>).map((
+            [name, subschema],
+          ) => [name, closeObjectSchemas(subschema)]),
+        )
+        : value;
+      continue;
+    }
+    if (SCHEMA_LIST_KEYWORDS.has(key) || SCHEMA_VALUE_KEYWORDS.has(key)) {
+      result[key] = closeObjectSchemas(value);
+      continue;
+    }
+    result[key] = value;
+  }
+
+  if (source.type === "object" && !("additionalProperties" in source)) {
+    result.additionalProperties = false;
+  }
+  return result;
 }
 
 function resolveAnthropicMaxTokens(

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
@@ -2261,7 +2261,25 @@ const SCHEMA_MAP_KEYWORDS = new Set([
   // unchanged, so both spellings can share this branch.
   "dependencies",
 ]);
-const SCHEMA_LIST_KEYWORDS = new Set(["anyOf", "oneOf", "allOf", "prefixItems"]);
+const SCHEMA_LIST_KEYWORDS = new Set(["anyOf", "oneOf", "prefixItems"]);
+/**
+ * `allOf` branches describe one instance together, not alternatives, and
+ * `additionalProperties` only ever sees the `properties` of the schema object
+ * carrying it. Closing branches that each declare part of the object therefore
+ * makes every one of them reject the others' properties, and the composition
+ * accepts nothing at all:
+ *
+ *   allOf: [ { properties: { a }, additionalProperties: false },
+ *            { properties: { b }, additionalProperties: false } ]
+ *
+ * `{ a, b }` fails the first branch on `b` and the second on `a`.
+ *
+ * So branches are walked for objects nested deeper inside them, but are not
+ * closed themselves. An `allOf` of open objects is still rejected by Anthropic
+ * -- which is the correct outcome, and a legible one, rather than a schema that
+ * validates nothing the model can produce.
+ */
+const COMPOSITION_LIST_KEYWORDS = new Set(["allOf"]);
 const SCHEMA_VALUE_KEYWORDS = new Set([
   "items",
   "additionalItems",
@@ -2296,8 +2314,8 @@ const SCHEMA_VALUE_KEYWORDS = new Set([
  * The result is a copy. The schema object belongs to the agent and is reused
  * across providers and calls, so closing it for Anthropic must not mutate it.
  */
-function closeObjectSchemas(schema: unknown): unknown {
-  if (Array.isArray(schema)) return schema.map(closeObjectSchemas);
+function closeObjectSchemas(schema: unknown, closeSelf = true): unknown {
+  if (Array.isArray(schema)) return schema.map((entry) => closeObjectSchemas(entry, closeSelf));
   if (typeof schema !== "object" || schema === null) return schema;
 
   const source = schema as Record<string, unknown>;
@@ -2314,6 +2332,12 @@ function closeObjectSchemas(schema: unknown): unknown {
         : value;
       continue;
     }
+    if (COMPOSITION_LIST_KEYWORDS.has(key)) {
+      result[key] = Array.isArray(value)
+        ? value.map((branch) => closeObjectSchemas(branch, false))
+        : closeObjectSchemas(value, false);
+      continue;
+    }
     if (SCHEMA_LIST_KEYWORDS.has(key) || SCHEMA_VALUE_KEYWORDS.has(key)) {
       result[key] = closeObjectSchemas(value);
       continue;
@@ -2325,7 +2349,7 @@ function closeObjectSchemas(schema: unknown): unknown {
   // walk when a caller writes it explicitly as `undefined`, but JSON drops it
   // on the way to the provider -- so honoring its presence would emit exactly
   // the open schema Anthropic rejects.
-  if (isObjectTyped(source.type) && source.additionalProperties === undefined) {
+  if (closeSelf && isObjectTyped(source.type) && source.additionalProperties === undefined) {
     result.additionalProperties = false;
   }
   return result;

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
@@ -2307,10 +2307,22 @@ function closeObjectSchemas(schema: unknown): unknown {
     result[key] = value;
   }
 
-  if (source.type === "object" && !("additionalProperties" in source)) {
+  if (isObjectTyped(source.type) && !("additionalProperties" in source)) {
     result.additionalProperties = false;
   }
   return result;
+}
+
+/**
+ * Whether a schema declares the object type.
+ *
+ * `JsonSchema.type` accepts an array as well as a single name, and the array
+ * form is how a nullable object is written by hand:
+ * `{ type: ["object", "null"], properties: {...} }`. Matching only the exact
+ * string would leave that branch open and let Anthropic reject it.
+ */
+function isObjectTyped(type: unknown): boolean {
+  return type === "object" || (Array.isArray(type) && type.includes("object"));
 }
 
 function resolveAnthropicMaxTokens(

--- a/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
+++ b/extensions/ext-llm-anthropic/src/anthropic-request-builder.ts
@@ -2238,7 +2238,7 @@ function buildAnthropicOutputConfig(
   return {
     format: {
       type: "json_schema",
-      schema: closeObjectSchemas(unwrapToolInputSchema(responseFormat.schema)),
+      schema: closeSchemaForOutputConfig(unwrapToolInputSchema(responseFormat.schema)),
     },
   };
 }
@@ -2314,10 +2314,22 @@ const SCHEMA_VALUE_KEYWORDS = new Set([
  * The result is a copy. The schema object belongs to the agent and is reused
  * across providers and calls, so closing it for Anthropic must not mutate it.
  */
-function closeObjectSchemas(schema: unknown, closeSelf = true): unknown {
+function closeObjectSchemas(
+  schema: unknown,
+  closeSelf = true,
+  pointer = "#",
+  openTargets: Set<string> = EMPTY_POINTER_SET,
+): unknown {
   if (ArrayIsArray(schema)) {
     const entries: unknown[] = [];
-    for (const entry of schema) entries[entries.length] = closeObjectSchemas(entry, closeSelf);
+    for (let index = 0; index < schema.length; index += 1) {
+      entries[index] = closeObjectSchemas(
+        schema[index],
+        closeSelf,
+        `${pointer}/${index}`,
+        openTargets,
+      );
+    }
     return entries;
   }
   if (typeof schema !== "object" || schema === null) return schema;
@@ -2327,16 +2339,17 @@ function closeObjectSchemas(schema: unknown, closeSelf = true): unknown {
 
   for (const key of objectKeys(source)) {
     const value = source[key];
+    const keyPointer = `${pointer}/${encodePointerToken(key)}`;
     if (hasSetValue(SCHEMA_MAP_KEYWORDS, key)) {
-      result[key] = closeSchemaMap(value);
+      result[key] = closeSchemaMap(value, keyPointer, openTargets);
       continue;
     }
     if (hasSetValue(COMPOSITION_LIST_KEYWORDS, key)) {
-      result[key] = closeObjectSchemas(value, false);
+      result[key] = closeObjectSchemas(value, false, keyPointer, openTargets);
       continue;
     }
     if (hasSetValue(SCHEMA_LIST_KEYWORDS, key) || hasSetValue(SCHEMA_VALUE_KEYWORDS, key)) {
-      result[key] = closeObjectSchemas(value);
+      result[key] = closeObjectSchemas(value, true, keyPointer, openTargets);
       continue;
     }
     result[key] = value;
@@ -2360,15 +2373,93 @@ function closeObjectSchemas(schema: unknown, closeSelf = true): unknown {
   return result;
 }
 
-/** Walk a keyword whose value maps names to subschemas. */
-function closeSchemaMap(value: unknown): unknown {
+/**
+ * Walk a keyword whose value maps names to subschemas.
+ *
+ * A definition reached by a `$ref` that sits directly under `allOf` stays open,
+ * for the reason spelled out on `COMPOSITION_LIST_KEYWORDS`: the branches of an
+ * `allOf` describe one instance together, so closing each of them makes every
+ * branch reject the properties the others declare.
+ */
+function closeSchemaMap(
+  value: unknown,
+  pointer: string,
+  openTargets: Set<string>,
+): unknown {
   if (typeof value !== "object" || value === null || ArrayIsArray(value)) return value;
   const source = value as Record<string, unknown>;
   const result: Record<string, unknown> = {};
   for (const name of objectKeys(source)) {
-    result[name] = closeObjectSchemas(source[name]);
+    const namePointer = `${pointer}/${encodePointerToken(name)}`;
+    result[name] = closeObjectSchemas(
+      source[name],
+      !hasSetValue(openTargets, namePointer),
+      namePointer,
+      openTargets,
+    );
   }
   return result;
+}
+
+/** Shared empty set, so the common walk allocates nothing extra. */
+const EMPTY_POINTER_SET: Set<string> = new Set();
+
+/** Escape a JSON pointer token, per RFC 6901. */
+function encodePointerToken(token: string): string {
+  let escaped = "";
+  for (const char of token) {
+    if (char === "~") escaped += "~0";
+    else if (char === "/") escaped += "~1";
+    else escaped += char;
+  }
+  return escaped;
+}
+
+/**
+ * Close every object in a schema bound for `output_config`.
+ *
+ * Runs a pre-pass first, because a `$ref` used as an `allOf` branch carries the
+ * composition's meaning at its target rather than at the branch itself. The
+ * branch object is left open by the walk, but its target lives under `$defs` or
+ * `definitions`, which the walk would otherwise close. Collecting those
+ * pointers up front lets the walk leave exactly those definitions open.
+ *
+ * A definition referenced from an `allOf` branch and used somewhere else too
+ * stays open in both places. Opening is the safe direction: Anthropic rejects
+ * an open object with a named 400, whereas an over-closed `allOf` is accepted
+ * and then matches nothing, which surfaces as an empty generation.
+ */
+function closeSchemaForOutputConfig(schema: unknown): unknown {
+  const openTargets: Set<string> = new Set();
+  collectAllOfRefTargets(schema, openTargets);
+  return closeObjectSchemas(schema, true, "#", openTargets);
+}
+
+/**
+ * Collect the pointers named by `$ref` branches sitting directly under an
+ * `allOf`, anywhere in the schema. Only local pointers are collected, since a
+ * remote `$ref` names nothing this walk can open.
+ */
+function collectAllOfRefTargets(schema: unknown, out: Set<string>): void {
+  if (ArrayIsArray(schema)) {
+    for (const entry of schema) collectAllOfRefTargets(entry, out);
+    return;
+  }
+  if (typeof schema !== "object" || schema === null) return;
+
+  const source = schema as Record<string, unknown>;
+  for (const key of objectKeys(source)) {
+    const value = source[key];
+    if (hasSetValue(COMPOSITION_LIST_KEYWORDS, key)) {
+      const branches = ArrayIsArray(value) ? value : [value];
+      for (const branch of branches) {
+        if (typeof branch !== "object" || branch === null) continue;
+        const ref = (branch as Record<string, unknown>).$ref;
+        if (typeof ref === "string" && ref.startsWith("#/")) out.add(ref);
+      }
+    }
+    collectAllOfRefTargets(value, out);
+  }
 }
 
 /**

--- a/src/agent/output-schema.ts
+++ b/src/agent/output-schema.ts
@@ -162,6 +162,11 @@ export function resolveAgentOutputSchema(
  * property to be required and `additionalProperties: false`, which a schema
  * with optional fields does not satisfy, and a rejected request is worse than a
  * locally validated one.
+ *
+ * This governs the framework-level flag only. A provider that requires
+ * `additionalProperties: false` regardless of this flag satisfies it in its own
+ * request builder rather than narrowing what callers may declare here -- see
+ * `closeObjectSchemas` in `extensions/ext-llm-anthropic`.
  */
 function buildResponseFormat(schema: JsonSchema): RuntimeResponseFormat {
   return { type: "json_schema", name: RESPONSE_FORMAT_NAME, schema };


### PR DESCRIPTION
Addresses the main defect in #3918 (option **(a)** from the issue). The issue’s third point is answered separately in #3922.

## Problem

Anthropic’s `output_config.format` rejects any object-typed (sub)schema that does not explicitly set `additionalProperties: false`:

```
output_config.format.schema: For 'object' type, 'additionalProperties' must be explicitly set to false
```

That requirement is **unconditional** — it does not depend on the framework’s own `strict` flag, which `buildResponseFormat` deliberately leaves unset. The reasoning behind leaving `strict` unset holds for OpenAI, where non-strict `json_schema` mode tolerates an open schema. It does not hold for Anthropic.

The result: a plain

```ts
defineSchema((v) => v.object({ name: v.string() }))()
```

— every field required, no `.optional()` anywhere, so already satisfying the *other* half of strict structured output — is rejected outright with a 400. Verified against the schema emitter:

```
PLAIN : {"type":"object","properties":{"name":{"type":"string"}},"required":["name"]}
STRICT: {"type":"object","properties":{"name":{"type":"string"}},"required":["name"],"additionalProperties":false}
NESTED: {... "user":{"type":"object", ... }}     ← nested objects lack it too
```

`.strict()` was the only workaround, and nothing pointed callers to it.

## Fix

Satisfy Anthropic’s requirement while mapping to `output_config`, rather than pushing it onto every caller. `closeObjectSchemas` walks the schema and fills in `additionalProperties: false` wherever an object subschema left it unset — recursing through nested properties, array items, and composition keywords (`anyOf`/`oneOf`/`allOf`/`prefixItems`).

Three constraints shaped the implementation:

1. **Recursion is restricted to keywords whose value really is a schema.** A blind walk would rewrite `default`, `const`, and `enum` values that happen to look like schemas. Covered by a test.
2. **The result is a copy.** The schema object belongs to the agent and is reused across providers and calls, so closing it for Anthropic must not mutate it. Covered by a test.
3. **An explicit `additionalProperties` is preserved.** Rewriting it would silently narrow a contract the caller deliberately opened, and Anthropic surfaces its own error for that case.

Scoped to `output_config` only — Anthropic’s tool `input_schema` has no such requirement, so it is untouched.

Also adds a pointer to the `buildResponseFormat` comment in `src/agent/output-schema.ts`, since that comment’s reasoning is exactly what makes this behaviour surprising: it explains the framework-level flag only, and a provider with an unconditional requirement now satisfies it in its own request builder.

## Tests (red → green)

Added `anthropic output_config schema closure` in `anthropic-request-builder.test.ts`:

| test | before | after |
|---|---|---|
| closes a top-level object schema that left additionalProperties unset | FAIL | pass |
| closes nested object properties | FAIL | pass |
| closes object schemas inside array items | FAIL | pass |
| closes object schemas inside composition keywords | FAIL | pass |
| leaves an explicitly declared additionalProperties alone | pass | pass |
| does not mutate the caller’s schema object | pass | pass |
| does not rewrite non-schema values that merely look like schemas | pass | pass |

The last three were green before the fix — they are the guards against over-correcting, and each fails against a naive implementation (deep-clone-free mutation, or an unrestricted recursive walk).

## Verification

- New tests fail on `main` for the stated reason, pass with the fix.
- Full Anthropic request-builder file green: `2 passed (95 steps) | 0 failed`.
- `deno check`, `deno lint`, `deno fmt` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Structured JSON schemas sent to Anthropic now automatically close object definitions by setting `additionalProperties: false`.
  * Nested objects, arrays, compositions, nullable schemas, and object type arrays are supported.
  * Explicit schema settings are preserved, and original schemas remain unchanged.

* **Documentation**
  * Expanded guidance on Anthropic structured outputs and provider-specific schema requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->