### PR TITLE
fix(chat): name the open-object schema rejection instead of a generic service error

### DIFF
--- a/src/chat/provider-errors.test.ts
+++ b/src/chat/provider-errors.test.ts
@@ -302,15 +302,56 @@ describe("chat/provider-errors", () => {
       },
     };
 
+    const EXPECTED = {
+      code: "OUTPUT_SCHEMA_NOT_CLOSED",
+      message:
+        "The model rejected the output schema because an object in it allows additional properties. " +
+        "Set additionalProperties: false on that object -- add .strict() if the outputSchema was " +
+        "built with defineSchema(), or set the property directly on a raw JSON Schema.",
+    };
+
     it("names the schema requirement instead of a generic service error", () => {
       // Without a mapping this lands on EXTERNAL_SERVICE_ERROR ("LLM provider
       // service error"), which points nowhere: the caller cannot tell that
       // their own outputSchema is what needs changing.
-      assertEquals(parseProviderError(providerError(OPEN_OBJECT_REJECTION)), {
-        code: "OUTPUT_SCHEMA_NOT_CLOSED",
-        message:
-          "The model rejected the output schema because an object in it allows additional properties. Add .strict() to the object in your outputSchema so it sets additionalProperties: false.",
-      });
+      assertEquals(parseProviderError(providerError(OPEN_OBJECT_REJECTION)), EXPECTED);
+    });
+
+    it("matches OpenAI's wording for the same rejection", () => {
+      assertEquals(
+        parseProviderError(providerError({
+          error: {
+            type: "invalid_request_error",
+            message:
+              "Invalid schema for response_format 'Person': In context=(), 'additionalProperties' is required to be supplied and to be false.",
+          },
+        })),
+        EXPECTED,
+      );
+    });
+
+    it("does not claim a tool schema rejection is about the output schema", () => {
+      // Providers reject open objects in tool/function schemas with a nearly
+      // identical sentence. Sending the caller to fix `outputSchema` would be
+      // pointing at the wrong schema entirely.
+      assertEquals(
+        parseProviderError(providerError({
+          error: {
+            type: "invalid_request_error",
+            message:
+              "Invalid schema for function 'lookup': In context=(), 'additionalProperties' is required to be supplied and to be false.",
+          },
+        })),
+        { code: "EXTERNAL_SERVICE_ERROR", message: "LLM provider service error" },
+      );
+    });
+
+    it("gives raw JSON Schema callers a remediation they can apply", () => {
+      // `.strict()` exists only on schema-builder objects; outputSchema also
+      // accepts a plain JSON Schema, where the fix is the property itself.
+      const { message } = parseProviderError(providerError(OPEN_OBJECT_REJECTION));
+      assertEquals(message.includes("additionalProperties: false"), true);
+      assertEquals(message.includes(".strict()"), true);
     });
 
     it("does not echo the provider's raw message", () => {

--- a/src/chat/provider-errors.test.ts
+++ b/src/chat/provider-errors.test.ts
@@ -281,4 +281,53 @@ describe("chat/provider-errors", () => {
     assertEquals(parseProviderError(nestedError), expected);
     assertEquals(parseProviderError(nestedLastError), expected);
   });
+
+  describe("structured-output schema rejections", () => {
+    /** An error carrying `body` the way buildProviderError attaches it. */
+    function providerError(body: unknown): Error {
+      const error = new Error("Provider request failed with status 400");
+      Object.defineProperty(error, "responseBody", {
+        value: JSON.stringify(body),
+        enumerable: false,
+      });
+      return error;
+    }
+
+    const OPEN_OBJECT_REJECTION = {
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        message:
+          "output_config.format.schema: For 'object' type, 'additionalProperties' must be explicitly set to false",
+      },
+    };
+
+    it("names the schema requirement instead of a generic service error", () => {
+      // Without a mapping this lands on EXTERNAL_SERVICE_ERROR ("LLM provider
+      // service error"), which points nowhere: the caller cannot tell that
+      // their own outputSchema is what needs changing.
+      assertEquals(parseProviderError(providerError(OPEN_OBJECT_REJECTION)), {
+        code: "OUTPUT_SCHEMA_NOT_CLOSED",
+        message:
+          "The model rejected the output schema because an object in it allows additional properties. Add .strict() to the object in your outputSchema so it sets additionalProperties: false.",
+      });
+    });
+
+    it("does not echo the provider's raw message", () => {
+      // The curated message is the whole point of this layer: provider bodies
+      // can quote request content, so they never reach the caller verbatim.
+      const parsed = parseProviderError(providerError(OPEN_OBJECT_REJECTION));
+      assertEquals(parsed.message.includes("output_config.format.schema"), false);
+    });
+
+    it("leaves an unrelated invalid_request_error on the generic path", () => {
+      assertEquals(
+        parseProviderError(providerError({
+          type: "error",
+          error: { type: "invalid_request_error", message: "something else entirely" },
+        })),
+        { code: "EXTERNAL_SERVICE_ERROR", message: "LLM provider service error" },
+      );
+    });
+  });
 });

--- a/src/chat/provider-errors.ts
+++ b/src/chat/provider-errors.ts
@@ -30,7 +30,8 @@ const OUTPUT_SCHEMA_NOT_CLOSED_ERROR = {
   code: "OUTPUT_SCHEMA_NOT_CLOSED",
   message:
     "The model rejected the output schema because an object in it allows additional properties. " +
-    "Add .strict() to the object in your outputSchema so it sets additionalProperties: false.",
+    "Set additionalProperties: false on that object -- add .strict() if the outputSchema was " +
+    "built with defineSchema(), or set the property directly on a raw JSON Schema.",
 } as const;
 
 const AI_PROVIDER_SPEND_LIMIT_ERROR = {
@@ -185,18 +186,37 @@ export function isCreditLimitMessage(normalizedMessage: string): boolean {
 }
 
 /**
+ * Wordings that identify a rejection as being about the *structured output*
+ * schema rather than a tool or function schema. Providers reject open objects
+ * in both, with near-identical sentences:
+ *
+ *   output_config.format.schema: For 'object' type, 'additionalProperties'
+ *     must be explicitly set to false                              (Anthropic)
+ *   Invalid schema for response_format 'X': ... 'additionalProperties' is
+ *     required to be supplied and to be false                         (OpenAI)
+ *   Invalid schema for function 'X': ... 'additionalProperties' is
+ *     required to be supplied and to be false            (OpenAI, tool schema)
+ *
+ * Only the first two are about `outputSchema`. Without this discriminator the
+ * third is mislabeled and the caller is sent to fix the wrong schema.
+ */
+const STRUCTURED_OUTPUT_MARKERS = ["output_config", "response_format", "output schema"];
+
+/**
  * Detects a provider rejecting the structured-output schema because an object
  * in it does not set `additionalProperties: false`.
  *
  * The caller's own `outputSchema` is what has to change, so this is worth
  * naming rather than collapsing into a generic service error. Matched on the
- * two things the wording is built from -- the property name and the closure
- * requirement -- rather than a fixed sentence, which providers reword.
+ * pieces the wording is built from -- the property name, the closure
+ * requirement, and a structured-output marker -- rather than a fixed sentence,
+ * which providers reword.
  */
 function isOpenObjectSchemaRejection(message: string): boolean {
   const normalizedMessage = message.toLowerCase();
-  return normalizedMessage.includes("additionalproperties") &&
-    (normalizedMessage.includes("false") || normalizedMessage.includes("required"));
+  if (!normalizedMessage.includes("additionalproperties")) return false;
+  if (!normalizedMessage.includes("false") && !normalizedMessage.includes("required")) return false;
+  return STRUCTURED_OUTPUT_MARKERS.some((marker) => normalizedMessage.includes(marker));
 }
 
 function isAssistantPrefillUnsupportedMessage(message: string): boolean {

--- a/src/chat/provider-errors.ts
+++ b/src/chat/provider-errors.ts
@@ -26,6 +26,13 @@ const MODEL_UNSUPPORTED_ASSISTANT_PREFILL_ERROR = {
     "The selected model does not support assistant-message prefill. Start a new user message or choose a compatible model.",
 } as const;
 
+const OUTPUT_SCHEMA_NOT_CLOSED_ERROR = {
+  code: "OUTPUT_SCHEMA_NOT_CLOSED",
+  message:
+    "The model rejected the output schema because an object in it allows additional properties. " +
+    "Add .strict() to the object in your outputSchema so it sets additionalProperties: false.",
+} as const;
+
 const AI_PROVIDER_SPEND_LIMIT_ERROR = {
   code: "AI_PROVIDER_SPEND_LIMIT_EXCEEDED",
   message:
@@ -177,6 +184,21 @@ export function isCreditLimitMessage(normalizedMessage: string): boolean {
   );
 }
 
+/**
+ * Detects a provider rejecting the structured-output schema because an object
+ * in it does not set `additionalProperties: false`.
+ *
+ * The caller's own `outputSchema` is what has to change, so this is worth
+ * naming rather than collapsing into a generic service error. Matched on the
+ * two things the wording is built from -- the property name and the closure
+ * requirement -- rather than a fixed sentence, which providers reword.
+ */
+function isOpenObjectSchemaRejection(message: string): boolean {
+  const normalizedMessage = message.toLowerCase();
+  return normalizedMessage.includes("additionalproperties") &&
+    (normalizedMessage.includes("false") || normalizedMessage.includes("required"));
+}
+
 function isAssistantPrefillUnsupportedMessage(message: string): boolean {
   const normalizedMessage = message.toLowerCase();
   const mentionsAssistantPrefill = normalizedMessage.includes("assistant message prefill") ||
@@ -275,6 +297,9 @@ function parseKnownProviderBody(
     }
     if (isAssistantPrefillUnsupportedMessage(body.message)) {
       return MODEL_UNSUPPORTED_ASSISTANT_PREFILL_ERROR;
+    }
+    if (isOpenObjectSchemaRejection(body.message)) {
+      return OUTPUT_SCHEMA_NOT_CLOSED_ERROR;
     }
     if (normalizedMessage.includes("too long")) {
       return { code: "CONTEXT_LENGTH_EXCEEDED", message: "Conversation is too long" };


### PR DESCRIPTION
Addresses the third point in #3918 ("the real error is discarded"), stacked conceptually on #3921.

## The reported premise needs correcting first

The issue asks that `buildProviderError` stop discarding the provider's response body, on the grounding that it is "read into `rawBody`/`parsedBody` and then thrown away." **It is not thrown away.** For a structured 400 it is attached to the error non-enumerably:

```ts
// src/provider/runtime-loader/provider-http.ts
return isStructuredInvalidRequest || isStructuredVeryfrontCreditProblem
  ? preserveStructuredResponseBody(requestError, rawBody)
  : requestError;
```

Keeping it out of `error.message` is a deliberate, test-locked boundary, not an oversight. Two tests encode it:

- `does not surface provider error body contents` — asserts a body containing `private provider payload <TOKEN>` never reaches the message.
- `preserves structured 400 details for internal classification without enumerating them` — asserts the body is preserved for classification while staying out of both `message` and `JSON.stringify(error)`.

Provider bodies can quote request content, so inlining them into a message that gets logged and shown to end users would reverse a security decision. **This PR does not do that.**

## The real gap

The body is preserved so `parseProviderError` can turn it into a curated, safe message. For this error class there was no mapping, so it fell through to the generic default. Verified directly:

```
PARSED: {"code":"EXTERNAL_SERVICE_ERROR","message":"LLM provider service error"}
```

"LLM provider service error" points nowhere. The thing that has to change is the caller's own `outputSchema`, and nothing in the surfaced error says so — which is exactly the dead end the issue describes, just one layer up from where it was diagnosed.

## Fix

Add a curated mapping alongside the existing assistant-prefill and context-length ones:

```
OUTPUT_SCHEMA_NOT_CLOSED
"The model rejected the output schema because an object in it allows additional
 properties. Add .strict() to the object in your outputSchema so it sets
 additionalProperties: false."
```

Matching is on the two things the wording is built from — the property name and the closure requirement — rather than a fixed sentence, since providers reword these messages.

With #3921 merged, framework-built schemas no longer trigger this at all. This still covers raw JSON Schema `outputSchema`s and any schema that explicitly declares an open object, which #3921 deliberately leaves alone.

## Tests (red → green)

| test | before | after |
|---|---|---|
| names the schema requirement instead of a generic service error | FAIL | pass |
| does not echo the provider's raw message | pass | pass |
| leaves an unrelated invalid_request_error on the generic path | pass | pass |

The two that were already green are the guards: one holds the secrecy boundary, the other prevents the matcher from over-capturing.

## Verification

- New test fails on `main` for the stated reason, passes with the fix.
- `src/chat` + `src/provider` suites green: `88 passed (448 steps) | 0 failed`.
- `deno check`, `deno lint`, `deno fmt` clean.