### PR TITLE
fix(ssr-module-loader): keep background cache writes reachable so tests can drain them

### DIFF
--- a/src/modules/react-loader/ssr-module-loader/cache/background-writes.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/background-writes.test.ts
@@ -1,0 +1,60 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { drainBackgroundWrites, trackBackgroundWrite } from "./redis.ts";
+
+describe("SSR module cache background writes", () => {
+  it("waits for a tracked write to settle", async () => {
+    const write = Promise.withResolvers<void>();
+    trackBackgroundWrite(write.promise);
+
+    let drained = false;
+    const draining = drainBackgroundWrites().then(() => {
+      drained = true;
+    });
+
+    // Give the drain every chance to resolve early if it is not really waiting.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assertEquals(drained, false);
+
+    write.resolve();
+    await draining;
+    assertEquals(drained, true);
+  });
+
+  it("settles even when the tracked write rejects", async () => {
+    // A write whose directory disappeared mid-flight rejects. Draining must
+    // still complete, and the rejection must not surface as an unhandled one.
+    const write = Promise.withResolvers<void>();
+    trackBackgroundWrite(write.promise);
+    write.reject(new Error("cache directory removed"));
+
+    await drainBackgroundWrites();
+  });
+
+  it("returns immediately when nothing is in flight", async () => {
+    await drainBackgroundWrites();
+  });
+
+  it("waits for a write registered while draining", async () => {
+    const first = Promise.withResolvers<void>();
+    const second = Promise.withResolvers<void>();
+    trackBackgroundWrite(first.promise);
+
+    let drained = false;
+    const draining = drainBackgroundWrites().then(() => {
+      drained = true;
+    });
+
+    // A settling write can publish another one; the drain is only done when
+    // nothing at all is left in flight.
+    trackBackgroundWrite(second.promise);
+    first.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assertEquals(drained, false);
+
+    second.resolve();
+    await draining;
+    assertEquals(drained, true);
+  });
+});

--- a/src/modules/react-loader/ssr-module-loader/cache/dev-disk-persistence.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/dev-disk-persistence.test.ts
@@ -169,6 +169,12 @@ describe("SSR module distributed cache on a local dev server", () => {
 
         const afterRestart = await createLoader().loadRawModule(parentPath, parentSource);
         assertEquals((afterRestart.default as () => string)(), "after");
+
+        // A transform publishes to the distributed cache without blocking the
+        // render, so a write can still be in flight here. The `finally` below
+        // deletes the directory it is writing into; without this the write
+        // fails into a cleanup path that outlives the test.
+        await persistent.drainBackgroundWrites();
       });
     } finally {
       await removeTempDirIfPresent(projectDir);

--- a/src/modules/react-loader/ssr-module-loader/cache/index.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/index.ts
@@ -22,8 +22,10 @@ export {
 export type { ClearSSRModuleCacheForProjectOptions } from "./memory.ts";
 
 export {
+  drainBackgroundWrites,
   getFromRedis,
   initializeSSRDistributedCache,
   isSSRDistributedCacheEnabled,
   setInRedis,
+  trackBackgroundWrite,
 } from "./redis.ts";

--- a/src/modules/react-loader/ssr-module-loader/cache/redis.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/redis.ts
@@ -24,6 +24,41 @@ const getDistributedCodeCache = createDistributedCodeCacheAccessor(
   getCacheBaseDir,
 );
 
+/**
+ * Background cache writes started by the render path.
+ *
+ * A transform publishes to the distributed cache without blocking the render on
+ * it, which leaves the write running with nobody holding its promise. Tracking
+ * those promises keeps the fire-and-forget deliberate rather than unobservable:
+ * a caller that is about to tear down the cache directory -- a test, or a
+ * shutdown path -- can wait for the disk to settle instead of racing it.
+ *
+ * Racing it is not harmless. The write fails mid-flight when its directory
+ * disappears, and the failure lands in a cleanup path that is still running
+ * after its owner has gone.
+ */
+const backgroundWrites = new Set<Promise<unknown>>();
+
+/** Register a write started without an owner awaiting it. */
+export function trackBackgroundWrite(write: Promise<unknown>): void {
+  backgroundWrites.add(write);
+  void write.catch(() => {}).finally(() => {
+    backgroundWrites.delete(write);
+  });
+}
+
+/**
+ * Wait for every tracked background write to settle.
+ *
+ * Loops because a settling write can register another one; the set is empty
+ * only when nothing is left in flight.
+ */
+export async function drainBackgroundWrites(): Promise<void> {
+  while (backgroundWrites.size > 0) {
+    await Promise.allSettled([...backgroundWrites]);
+  }
+}
+
 let distributedCacheEnabled = false;
 
 /** Initialize distributed caching for SSR modules */

--- a/src/modules/react-loader/ssr-module-loader/loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.ts
@@ -41,6 +41,7 @@ import {
   isSSRDistributedCacheEnabled,
   releaseTransformSlot,
   setInRedis,
+  trackBackgroundWrite,
   tryAcquireTransformSlot,
 } from "./cache/index.ts";
 import type { ModuleCacheEntry, SSRModuleLoaderOptions } from "./types.ts";
@@ -1156,14 +1157,20 @@ export class SSRModuleLoader {
             ...(isSSRDistributedCacheEnabled()
               ? {
                 publishDistributed: () => {
-                  void setInRedis(contentCacheKey, transformed, {
-                    isProduction: this.cache.isProductionContentSource(),
-                  }).catch((error) => {
-                    logger.debug("Distributed cache set failed", {
-                      key: contentCacheKey,
-                      error,
-                    });
-                  });
+                  // Deliberately not awaited: a render must not block on a cache
+                  // write. Tracked so the write is still reachable -- otherwise
+                  // it outlives its cache directory and fails into a cleanup
+                  // path nobody is waiting on.
+                  trackBackgroundWrite(
+                    setInRedis(contentCacheKey, transformed, {
+                      isProduction: this.cache.isProductionContentSource(),
+                    }).catch((error) => {
+                      logger.debug("Distributed cache set failed", {
+                        key: contentCacheKey,
+                        error,
+                      });
+                    }),
+                  );
                 },
               }
               : {}),


### PR DESCRIPTION
Fixes the intermittent `coverage shard 4/8` failure that has been red on unrelated PRs (seen on #3919).

## Symptom

```
SSR module distributed cache on a local dev server
error: Leaks detected:
  - An async operation to remove a file or directory was started in this test,
    but never completed.
    at DiskCacheBackend.set (src/cache/backends/disk.ts:648)
```

Every individual step in that suite reports `ok`; the failure is attributed to the suite, and it does not reproduce locally in isolation (3/3 clean runs).

## Cause

The stack points at `disk.ts`, but nothing there is missing an `await` — every `unlink` in that file is awaited. The orphan starts a level up, in the loader:

```ts
// src/modules/react-loader/ssr-module-loader/loader.ts:1159
void setInRedis(contentCacheKey, transformed, { ... })
```

Nobody holds that promise. So `dev-disk-persistence.test.ts` runs `loadRawModule`, reaches its `finally`, and deletes the cache directory **while the write is still in flight**. The writes `rename` then fails, which routes it into the temp-file cleanup `unlink` — an operation still running after the test that started it has finished. That is precisely the reported stack:

```
at disk.ts:659            ← unlink, in the catch (write failed)
at DiskCacheBackend.withMutation
at DiskCacheBackend.set
```

On an unloaded machine the write wins the race and the suite passes. On a loaded CI runner it does not. That is the whole flake.

## Fix

Not blocking a render on a cache write is correct, so that stays. The problem is not that the write is unawaited — it is that it is **unreachable**, so no teardown can wait for it. `trackBackgroundWrite` registers the promise and `drainBackgroundWrites` waits for the set to drain, letting a caller that is about to delete the directory settle the disk instead of racing it.

The loader test drains before its `finally` removes the directory.

This is not test-only scaffolding: an unowned write that fails after its directory is gone is a hazard on any teardown path, not just this one.

## Tests

`cache/background-writes.test.ts` covers the drain:

- waits for a tracked write to settle
- settles even when the tracked write rejects (the directory-removed case) without an unhandled rejection
- returns immediately when nothing is in flight
- waits for a write registered *while* a drain is already in progress (why the drain loops rather than awaiting one snapshot)

## Verification

- `src/modules/react-loader` suites green under `--trace-leaks`: `27 passed (248 steps) | 0 failed`.
- `deno check`, `deno lint` (49 files), `deno fmt` clean.
- Full pre-push suite green.

The race itself cannot be asserted directly — it is timing-dependent by nature, which is why it only appears under CI load — so the tests pin the drain contract that removes it instead.