### PR TITLE
fix(workflow): reconcile a resumed loop iteration against the run's node states

### DIFF
--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -1051,6 +1051,70 @@ describe("DAGExecutor", () => {
       assertEquals(result.nodeStates["before"]!.status, "completed");
     });
 
+    it("runs a step declared after a wait in the same iteration once the wait resolves", async () => {
+      // The loop keeps its own per-iteration snapshot in `<id>_loop_state`,
+      // taken when it suspended. The approval that resumes the run patches the
+      // authoritative top-level nodeStates, not that snapshot -- so without
+      // reconciling the two, the loop replays its iteration with the wait
+      // still "running", nothing becomes ready, and the child graph reports
+      // completed with the dependent step never scheduled.
+      const order: string[] = [];
+      const trackingExecutor = new MockStepExecutor(new Map(), (node) => {
+        order.push(node.id);
+        return { success: true, output: node.id, executionTime: 1 };
+      });
+      const exec = new DAGExecutor({ stepExecutor: trackingExecutor });
+      const nodes: WorkflowNode[] = [
+        {
+          id: "the-loop",
+          dependsOn: [],
+          config: {
+            type: "loop",
+            maxIterations: 1,
+            while: (_context: WorkflowContext, loop: LoopExecutionContext) => loop.iteration < 1,
+            steps: [
+              {
+                id: "inner-wait",
+                dependsOn: [],
+                config: { type: "wait", waitType: "approval", message: "approve?" } as any,
+              },
+              { id: "after-wait", dependsOn: ["inner-wait"], config: { type: "step" } as any },
+            ],
+          } as any,
+        },
+      ];
+
+      const first = await exec.execute(nodes, createTestRun());
+      assertEquals(first.waiting, true);
+      assertEquals(order, []);
+
+      // What ApprovalManager.processDecision persists before calling resume:
+      // the decision lands on the top-level node state, never on the loop's
+      // private snapshot.
+      const second = await exec.execute(
+        nodes,
+        createTestRun({
+          status: "waiting",
+          nodeStates: {
+            ...first.nodeStates,
+            "inner-wait": {
+              nodeId: "inner-wait",
+              status: "completed",
+              output: { approved: true },
+              attempt: 1,
+              startedAt: new Date(),
+              completedAt: new Date(),
+            },
+          },
+          context: first.context,
+        }),
+      );
+
+      assertEquals(second.completed, true);
+      assertEquals(order, ["after-wait"]);
+      assertEquals(second.nodeStates["after-wait"]!.status, "completed");
+    });
+
     it("removes child node states from previous dynamic loop iterations", async () => {
       const nodes: WorkflowNode[] = [
         {

--- a/src/workflow/executor/dag/loop-node-strategy.ts
+++ b/src/workflow/executor/dag/loop-node-strategy.ts
@@ -90,9 +90,11 @@ export async function executeLoopNodeStrategy(
     runtime.abortSignal?.throwIfAborted();
 
     // On resume, rehydrate the in-flight iteration's child node states so its
-    // already-completed steps are skipped instead of re-executed (H9).
+    // already-completed steps are skipped instead of re-executed (H9),
+    // reconciled against the run's own map so the node that was just resolved
+    // is not replayed as still pending.
     const iterationNodeStates = resumeIteration === iteration && resumeIterationNodeStates
-      ? { ...resumeIterationNodeStates }
+      ? reconcileIterationNodeStates(resumeIterationNodeStates, nodeStates)
       : {};
     // Only rehydrate once; subsequent iterations start fresh.
     resumeIterationNodeStates = undefined;
@@ -216,4 +218,31 @@ export async function executeLoopNodeStrategy(
     }),
     waiting: false,
   };
+}
+
+/**
+ * Overlay the run's authoritative node states onto a resumed iteration's
+ * snapshot.
+ *
+ * The snapshot is frozen at the moment the loop suspended. Whatever resolves
+ * the wait afterwards -- an approval decision, a signal -- patches the run's
+ * own `nodeStates` and then resumes; it has no idea the loop is holding a
+ * private copy. Replaying the iteration from that copy leaves the wait node
+ * `running`, so `getReadyNodes` excludes it, the step depending on it never
+ * becomes ready, and the child graph reports completion having scheduled
+ * nothing -- losing the step silently while the iteration looks successful.
+ *
+ * The run's map wins for every node it also knows about. Nodes it has never
+ * heard of stay as the snapshot left them, so this cannot pull a sibling from
+ * outside the loop into the iteration's graph.
+ */
+function reconcileIterationNodeStates(
+  snapshot: Record<string, NodeState>,
+  runNodeStates: Record<string, NodeState>,
+): Record<string, NodeState> {
+  const reconciled: Record<string, NodeState> = { ...snapshot };
+  for (const [nodeId, state] of Object.entries(runNodeStates)) {
+    if (nodeId in reconciled) reconciled[nodeId] = state;
+  }
+  return reconciled;
 }


### PR DESCRIPTION
Fixes #3927.

## Problem

A step declared after a `waitForApproval` **inside the same loop iteration** never runs once that wait is approved. No error — the loop reports the iteration completed, one step short, permanently.

The reporter's root-cause analysis is correct and I confirmed each link.

A loop keeps a private snapshot of its in-flight iteration in `context.<id>_loop_state`, frozen at the moment it suspended. Whatever resolves the wait afterwards patches the run's **own** `nodeStates` and calls resume — it has no idea the loop is holding a separate copy:

```ts
const iterationNodeStates = resumeIteration === iteration && resumeIterationNodeStates
  ? { ...resumeIterationNodeStates }   // wait node still "running", frozen at suspend time
  : {};
```

From there it fails quietly, and it takes three independent things lining up:

1. `getReadyNodes` treats only absent / `pending` / `failed` nodes as ready, so the wait node — still `running` in the stale copy — is excluded.
2. The "a suspended composite is resumable" fallback that rescues the *outer* loop node cannot fire for the child graph: it is gated on `run.status === "waiting"`, and the synthetic run the loop builds for its iteration hardcodes `status: "running"`.
3. Nothing marks the wait done, so the step depending on it never becomes ready either — and an empty ready set reads as a finished graph.

So `executeChildGraph` returns `completed: true` having scheduled nothing, and the loop is told its iteration succeeded.

## Fix

Reconcile the snapshot against the run's map before replaying the iteration. The run wins for every node it also knows about, so the node that was just resolved is seen as resolved. Nodes the run has never heard of stay as the snapshot left them, which keeps a sibling from outside the loop out of the iteration's graph.

## Why the control experiment holds

The same `[wait, step]` shape outside a loop works, and the equivalent `branch` case already has a passing test — both because their node states live directly in the run's map, with no loop-private copy in between. That isolates the loop's resume bookkeeping as the differentiator, exactly as the report says.

## Tests (red → green)

Added `runs a step declared after a wait in the same iteration once the wait resolves` in `src/workflow/executor/dag/index.test.ts`. It drives the real sequence: run to suspension, apply the node-state patch `ApprovalManager.processDecision` persists, resume with `status: "waiting"`, then assert the dependent step ran exactly once.

Fails on `main` (`order` is empty, the step never runs); passes with the fix.

The existing `loop node sibling isolation` tests still pass, including `removes child node states from previous dynamic loop iterations` — the guard that this reconciliation does not resurrect states a dynamic iteration deliberately dropped.

## Verification

- New test fails on `main` for the stated reason, passes with the fix.
- Full workflow suite green: `77 passed (775 steps) | 0 failed`.
- `deno check`, `deno lint`, `deno fmt` clean.