### PR TITLE
fix(chat): match the schema rejection on the plain-message path too

### DIFF
--- a/src/chat/provider-errors.test.ts
+++ b/src/chat/provider-errors.test.ts
@@ -305,7 +305,7 @@ describe("chat/provider-errors", () => {
     const EXPECTED = {
       code: "OUTPUT_SCHEMA_NOT_CLOSED",
       message:
-        "The model rejected the output schema because an object in it allows additional properties. " +
+        "The provider rejected the output schema because an object in it allows additional properties. " +
         "Set additionalProperties: false on that object -- add .strict() if the outputSchema was " +
         "built with defineSchema(), or set the property directly on a raw JSON Schema.",
     };
@@ -359,6 +359,31 @@ describe("chat/provider-errors", () => {
       // can quote request content, so they never reach the caller verbatim.
       const parsed = parseProviderError(providerError(OPEN_OBJECT_REJECTION));
       assertEquals(parsed.message.includes("output_config.format.schema"), false);
+    });
+
+    it("matches when the rejection arrives as a bare error message", () => {
+      // The body is only preserved for a structured 400. An unparsed shape, a
+      // truncated read, or a provider whose envelope carries no
+      // `invalid_request_error` type reaches here as a plain Error instead.
+      assertEquals(
+        parseProviderError(
+          new Error(
+            "Invalid schema for response_format 'Person': In context=(), 'additionalProperties' is required to be supplied and to be false.",
+          ),
+        ),
+        EXPECTED,
+      );
+    });
+
+    it("does not claim a bare tool schema error is about the output schema", () => {
+      assertEquals(
+        parseProviderError(
+          new Error(
+            "Invalid schema for function 'lookup': In context=(), 'additionalProperties' is required to be supplied and to be false.",
+          ),
+        ),
+        { code: "EXTERNAL_SERVICE_ERROR", message: "LLM provider service error" },
+      );
     });
 
     it("leaves an unrelated invalid_request_error on the generic path", () => {

--- a/src/chat/provider-errors.test.ts
+++ b/src/chat/provider-errors.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#std/assert";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { parseProviderError } from "./provider-errors.ts";
+import { buildProviderError } from "#veryfront/provider/runtime-loader/provider-http.ts";
 
 describe("chat/provider-errors", () => {
   it("parses gateway problem JSON strings and direct provider problem objects", () => {
@@ -384,6 +385,53 @@ describe("chat/provider-errors", () => {
         ),
         { code: "EXTERNAL_SERVICE_ERROR", message: "LLM provider service error" },
       );
+    });
+
+    describe("through the real buildProviderError", () => {
+      function jsonResponse(status: number, body: unknown): Response {
+        return new Response(JSON.stringify(body), {
+          status,
+          headers: { "content-type": "application/json" },
+        });
+      }
+
+      it("classifies an Anthropic rejection end to end", async () => {
+        // The hand-built responseBody in the tests above bypasses the real
+        // preservation criteria. This one goes through them.
+        const error = await buildProviderError(
+          "anthropic",
+          jsonResponse(400, OPEN_OBJECT_REJECTION),
+        );
+
+        assertEquals(error.message, "Provider request failed with status 400");
+        assertEquals(parseProviderError(error), EXPECTED);
+      });
+
+      it("does not reach a provider whose 400 envelope is not preserved", async () => {
+        // Documents a boundary rather than asserting desired behaviour.
+        // `buildProviderError` preserves a body only for a structured
+        // `invalid_request_error`, and replaces every message with the generic
+        // status text -- so Google's `{error:{code,status,message}}` envelope
+        // arrives with neither a body nor its own wording, and no classifier
+        // downstream can see the rejection. Tracked in #3932.
+        const error = await buildProviderError(
+          "google",
+          jsonResponse(400, {
+            error: {
+              code: 400,
+              status: "INVALID_ARGUMENT",
+              message:
+                "Invalid schema for response_format: 'additionalProperties' is required to be supplied and to be false.",
+            },
+          }),
+        );
+
+        assertEquals(error.message, "Provider request failed with status 400");
+        assertEquals(parseProviderError(error), {
+          code: "EXTERNAL_SERVICE_ERROR",
+          message: "LLM provider service error",
+        });
+      });
     });
 
     it("leaves an unrelated invalid_request_error on the generic path", () => {

--- a/src/chat/provider-errors.ts
+++ b/src/chat/provider-errors.ts
@@ -29,7 +29,7 @@ const MODEL_UNSUPPORTED_ASSISTANT_PREFILL_ERROR = {
 const OUTPUT_SCHEMA_NOT_CLOSED_ERROR = {
   code: "OUTPUT_SCHEMA_NOT_CLOSED",
   message:
-    "The model rejected the output schema because an object in it allows additional properties. " +
+    "The provider rejected the output schema because an object in it allows additional properties. " +
     "Set additionalProperties: false on that object -- add .strict() if the outputSchema was " +
     "built with defineSchema(), or set the property directly on a raw JSON Schema.",
 } as const;
@@ -426,6 +426,13 @@ function parseProviderErrorInner(
     const normalizedMessage = message.toLowerCase();
     if (isAssistantPrefillUnsupportedMessage(message)) {
       return MODEL_UNSUPPORTED_ASSISTANT_PREFILL_ERROR;
+    }
+    // Also matched here, not only on the structured-body path: the same
+    // rejection reaches this function as a bare `Error` whenever the body was
+    // never preserved -- an unparsed shape, a truncated read, or a provider
+    // whose envelope carries no `invalid_request_error` type at all.
+    if (isOpenObjectSchemaRejection(message)) {
+      return OUTPUT_SCHEMA_NOT_CLOSED_ERROR;
     }
     if (isProviderBillingMessage(normalizedMessage)) {
       return AI_PROVIDER_BILLING_ERROR;


### PR DESCRIPTION
Follow-up to #3922 (merged), completing the mapping added there. Raised in review on that PR after it had already merged.

> **Correction:** an earlier version of this description claimed this change makes the mapping reachable for Google's error envelope. That was wrong, and review caught it. `buildProviderError` replaces every message with generic status text, so the message path cannot rescue a case whose body was never preserved. The real scope is below, and the Google gap is now tracked in #3932.

## Problem

The mapping was wired only into `parseKnownProviderBody`'s `invalid_request_error` branch — the structured-body path. That misses every route where the rejection arrives as a bare `Error` carrying provider text rather than a preserved body: errors raised outside `buildProviderError`, or re-wrapped by a caller. The existing plain-message heuristics (rate limit, overloaded, credit limit, context length) all live on that path for exactly this reason; this one did not.

## Fix

Match it on the message heuristic path as well, with the same structured-output discriminator, so a bare *tool*-schema rejection still stays generic.

Also corrects the curated wording: these are request validation failures the provider raises **before** the model runs, so "The provider rejected the output schema…" rather than "The model rejected…".

## What this does not fix

Verified through the real `buildProviderError`:

```
ANTHROPIC msg : Provider request failed with status 400
ANTHROPIC body: true
ANTHROPIC parsed: {"code":"OUTPUT_SCHEMA_NOT_CLOSED", ...}      ← classified

GOOGLE    msg : Provider request failed with status 400
GOOGLE    body: false
GOOGLE    parsed: {"code":"EXTERNAL_SERVICE_ERROR", ...}        ← not classified
```

A provider whose 400 envelope has no `type: "invalid_request_error"` gets neither its body preserved nor its wording kept, so nothing downstream can classify it — and that is true of **every** curated mapping, not just this one. Widening what gets retained from a provider response touches a security-sensitive boundary, so it is filed as #3932 rather than folded in here.

## Tests (red → green)

| test | before | after |
|---|---|---|
| matches when the rejection arrives as a bare error message | FAIL | pass |
| does not claim a bare tool schema error is about the output schema | pass | pass |
| classifies an Anthropic rejection end to end (real `buildProviderError`) | FAIL | pass |
| does not reach a provider whose 400 envelope is not preserved | pass | pass |

The last two go through the real preservation criteria rather than a hand-built `responseBody`, which is what let the overclaim above go unnoticed. The fourth pins current behaviour and points at #3932, so the boundary is documented rather than implied.

## Verification

- `src/chat` + `src/agent` suites green: `1265 passed (2290 steps) | 0 failed`.
- `deno check`, `deno lint`, `deno fmt` clean; full pre-push suite green.
