### PR TITLE
Expose durable mirror disable reasons in persistence failures

### DIFF
--- a/src/agent/hosted/durable-run-event-sink.test.ts
+++ b/src/agent/hosted/durable-run-event-sink.test.ts
@@ -429,6 +429,38 @@ describe("agent/hosted/durable-run-event-sink", () => {
     assertEquals(order, ["append:first", "flush", "append:second", "flush"]);
   });
 
+  it("reports the concrete disable reason when a required mirror is already disabled", async () => {
+    for (
+      const disableReason of [
+        "auth_rejected",
+        "payload_too_large",
+      ] as const
+    ) {
+      const target = mirror();
+      const error = await assertRejects(
+        async () =>
+          await createDurableRunEventSink({
+            mirror: {
+              ...target.result,
+              getSnapshot: () => snapshot({ disabled: true, disableReason }),
+            },
+          })({
+            type: "AGENT_RUN_MODEL_CALL_CONTEXT",
+            messages: [],
+          }),
+        DurableRunEventPersistenceError,
+        disableReason,
+      );
+
+      assertInstanceOf(error, DurableRunEventPersistenceError);
+      assertEquals(
+        String(error.detail).includes(disableReason),
+        true,
+        "structured VeryfrontError detail should expose the durable mirror disable reason",
+      );
+    }
+  });
+
   it("does not mask later persistence failures with a rejected tail", async () => {
     const firstAppendStarted = Promise.withResolvers<void>();
     const releaseFirstAppend = Promise.withResolvers<void>();

--- a/src/agent/hosted/durable-run-event-sink.ts
+++ b/src/agent/hosted/durable-run-event-sink.ts
@@ -19,7 +19,10 @@ export { DurableRunEventPersistenceError } from "../conversation/private-run-eve
 
 function assertEnabled(snapshot: ConversationRunMirrorSnapshot): void {
   if (snapshot.disabled) {
-    throw new DurableRunEventPersistenceError("Required durable run event mirror is disabled");
+    const suffix = snapshot.disableReason === undefined ? "" : `: ${snapshot.disableReason}`;
+    throw new DurableRunEventPersistenceError(
+      `Required durable run event mirror is disabled${suffix}`,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

- preserve the existing durable persistence error type and failure behavior
- include the mirror snapshot disable reason in required-mirror failures
- make causes such as `auth_rejected` and `payload_too_large` visible to Sentry and operators
- avoid attaching broader mirror state or payload data

## Sentry

- https://veryfront.sentry.io/issues/VERYFRONT-AGENT-4
- https://veryfront.sentry.io/issues/VERYFRONT-AGENT-7

## Verification

- focused durable sink test: 15 steps passed
- pre-push format, lint, and typecheck passed
- pre-push unit suite: 3,965 tests / 30,510 steps passed, 0 failed
- cwd isolation suites passed

## Risk

This is observability hardening only. It does not resolve the initiating mirror-disable condition; staging canary validation remains blocked by a separate agent authorization configuration.