### PR TITLE
test(agent): pin the schema rejection across the child run boundary

### DIFF
--- a/src/agent/hosted/child-lifecycle.test.ts
+++ b/src/agent/hosted/child-lifecycle.test.ts
@@ -742,6 +742,9 @@ describe("agent/hosted-child-lifecycle", () => {
       },
     });
 
+    // Asserted before the leak check below, so that check cannot pass on an
+    // empty snapshot list.
+    assertEquals(snapshots.length, 1, "the child settles exactly one failure snapshot");
     assertEquals(
       (snapshots[0]?.error ?? "").includes("output_config.format.schema"),
       false,

--- a/src/agent/hosted/child-lifecycle.test.ts
+++ b/src/agent/hosted/child-lifecycle.test.ts
@@ -1,7 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import type { ChildRunExecutionResult } from "../child-run/execution-snapshot.ts";
+import { buildProviderError } from "#veryfront/provider/runtime-loader/provider-http.ts";
+import type {
+  ChildRunExecutionResult,
+  ChildRunExecutionSnapshot,
+} from "../child-run/execution-snapshot.ts";
 import {
   HOSTED_CHILD_FINALIZATION_FAILED_CODE,
   type HostedChildLifecycleAdapter,
@@ -9,7 +13,9 @@ import {
   runHostedChildLifecycle,
   shouldSkipHostedChildTerminalPersistence,
 } from "./child-lifecycle.ts";
+import { handleHostedChildForkFailure } from "./child-fork-stream-execution.ts";
 import { HostedChildTerminalStateError } from "./child-status.ts";
+import { getHostedStreamErrorText } from "./stream-terminal-error.ts";
 
 describe("agent/hosted-child-lifecycle", () => {
   it("identifies externally persisted terminal states", () => {
@@ -697,5 +703,69 @@ describe("agent/hosted-child-lifecycle", () => {
       terminalErrorMessage:
         "Hosted child run run-1 became completed before local execution finished",
     });
+  });
+
+  it("keeps a child run's schema rejection classified across the run boundary", async () => {
+    // The child run boundary is the route the plain-message matcher in
+    // `resolveKnownProviderTerminalError` exists for, so walk it end to end
+    // with the real helpers on both sides instead of a hand-built error.
+    const providerError = await buildProviderError(
+      "anthropic",
+      new Response(
+        JSON.stringify({
+          type: "error",
+          error: {
+            type: "invalid_request_error",
+            message:
+              "output_config.format.schema: For 'object' type, 'additionalProperties' must be explicitly set to false",
+          },
+        }),
+        { status: 400, headers: { "content-type": "application/json" } },
+      ),
+    );
+
+    // Child side. The stream error becomes text (what the runtime's `onError`
+    // does), and `handleHostedChildForkFailure` copies that text into the
+    // failure snapshot. Nothing structured survives the hop, so the message is
+    // all the parent gets.
+    const snapshots: ChildRunExecutionSnapshot[] = [];
+    const childResult = await handleHostedChildForkFailure({
+      error: new Error(getHostedStreamErrorText(providerError)),
+      description: "Summarize the repo",
+      kind: "invoke_agent",
+      finalText: "",
+      toolCalls: [],
+      toolResults: [],
+      startTime: Date.now(),
+      onSettled: (snapshot) => {
+        snapshots.push(snapshot);
+      },
+    });
+
+    assertEquals(
+      (snapshots[0]?.error ?? "").includes("output_config.format.schema"),
+      false,
+      "the parent gets our curated wording, not the provider's raw rejection",
+    );
+
+    // Parent side. The lifecycle rebuilds the snapshot string as a bare
+    // `HostedChildExecutionFailure` and re-classifies it.
+    const result = await runHostedChildExecutionLifecycle({
+      adapter: {},
+      executionFailedCode: "INVOKE_AGENT_FAILED",
+      execute: () => Promise.resolve(childResult),
+      getExecutionSnapshot: () => snapshots[0] ?? null,
+    });
+
+    assertEquals(result.status, "failed");
+    // The round trip survives only because the curated message still names
+    // both things the matcher keys on. Rewording it, dropping the message from
+    // the snapshot, or rebuilding the failure without it all land here as
+    // INVOKE_AGENT_FAILED, which is what this assertion catches.
+    assertEquals(
+      result.terminalState.terminalErrorCode,
+      "OUTPUT_SCHEMA_NOT_CLOSED",
+      "a child run's schema rejection stays classified after crossing the boundary",
+    );
   });
 });

--- a/src/agent/streaming/stream-outcome.test.ts
+++ b/src/agent/streaming/stream-outcome.test.ts
@@ -8,8 +8,6 @@ import {
   resolveKnownProviderTerminalError,
   resolveStreamOutcome,
 } from "./stream-outcome.ts";
-import { getHostedStreamErrorText } from "../hosted/stream-terminal-error.ts";
-import { buildProviderError } from "#veryfront/provider/runtime-loader/provider-http.ts";
 import type { StreamLifecyclePhase, StreamSnapshot } from "./lifecycle/types.ts";
 
 describe("agent/stream-outcome", () => {
@@ -78,49 +76,6 @@ describe("agent/stream-outcome", () => {
       const resolved = resolveKnownProviderTerminalError(error);
       assertEquals(resolved?.code, "PROJECT_SCHEMA_ERROR");
       assertEquals(typeof resolved?.message, "string");
-    });
-
-    it("keeps a child run's schema rejection classified across the run boundary", async () => {
-      // The route the plain-message matcher exists for, walked end to end with
-      // the real functions rather than a hand-built error.
-      //
-      // A child run's failure crosses back to its parent as a bare string:
-      // child-fork-stream-execution.ts reads `error.message` into the failure
-      // snapshot, and child-lifecycle.ts rebuilds it as
-      // `new HostedChildExecutionFailure(snapshot.error)` before handing it
-      // here. Nothing structured survives that hop, so the message is all the
-      // parent has left to classify.
-      const providerError = await buildProviderError(
-        "anthropic",
-        new Response(
-          JSON.stringify({
-            type: "error",
-            error: {
-              type: "invalid_request_error",
-              message:
-                "output_config.format.schema: For 'object' type, 'additionalProperties' must be explicitly set to false",
-            },
-          }),
-          { status: 400, headers: { "content-type": "application/json" } },
-        ),
-      );
-
-      // Child side: the text the child reports for that failure.
-      const childErrorText = getHostedStreamErrorText(providerError);
-      // The curated wording, not the provider's, so no request content leaves
-      // the child even though the text is about to become a plain message.
-      assertEquals(childErrorText.includes("output_config.format.schema"), false);
-
-      // Parent side: the same text, rebuilt as a bare Error.
-      const resolved = resolveKnownProviderTerminalError(new Error(childErrorText));
-      assertEquals(resolved?.code, "OUTPUT_SCHEMA_NOT_CLOSED");
-
-      // The round trip works because the curated message still names the two
-      // things the matcher keys on. Rewording it without keeping both silently
-      // drops the child back to a generic execution failure, which is what
-      // this assertion is here to catch.
-      assertEquals(childErrorText.toLowerCase().includes("additionalproperties"), true);
-      assertEquals(childErrorText.toLowerCase().includes("output schema"), true);
     });
   });
 });

--- a/src/agent/streaming/stream-outcome.test.ts
+++ b/src/agent/streaming/stream-outcome.test.ts
@@ -8,6 +8,8 @@ import {
   resolveKnownProviderTerminalError,
   resolveStreamOutcome,
 } from "./stream-outcome.ts";
+import { getHostedStreamErrorText } from "../hosted/stream-terminal-error.ts";
+import { buildProviderError } from "#veryfront/provider/runtime-loader/provider-http.ts";
 import type { StreamLifecyclePhase, StreamSnapshot } from "./lifecycle/types.ts";
 
 describe("agent/stream-outcome", () => {
@@ -76,6 +78,49 @@ describe("agent/stream-outcome", () => {
       const resolved = resolveKnownProviderTerminalError(error);
       assertEquals(resolved?.code, "PROJECT_SCHEMA_ERROR");
       assertEquals(typeof resolved?.message, "string");
+    });
+
+    it("keeps a child run's schema rejection classified across the run boundary", async () => {
+      // The route the plain-message matcher exists for, walked end to end with
+      // the real functions rather than a hand-built error.
+      //
+      // A child run's failure crosses back to its parent as a bare string:
+      // child-fork-stream-execution.ts reads `error.message` into the failure
+      // snapshot, and child-lifecycle.ts rebuilds it as
+      // `new HostedChildExecutionFailure(snapshot.error)` before handing it
+      // here. Nothing structured survives that hop, so the message is all the
+      // parent has left to classify.
+      const providerError = await buildProviderError(
+        "anthropic",
+        new Response(
+          JSON.stringify({
+            type: "error",
+            error: {
+              type: "invalid_request_error",
+              message:
+                "output_config.format.schema: For 'object' type, 'additionalProperties' must be explicitly set to false",
+            },
+          }),
+          { status: 400, headers: { "content-type": "application/json" } },
+        ),
+      );
+
+      // Child side: the text the child reports for that failure.
+      const childErrorText = getHostedStreamErrorText(providerError);
+      // The curated wording, not the provider's, so no request content leaves
+      // the child even though the text is about to become a plain message.
+      assertEquals(childErrorText.includes("output_config.format.schema"), false);
+
+      // Parent side: the same text, rebuilt as a bare Error.
+      const resolved = resolveKnownProviderTerminalError(new Error(childErrorText));
+      assertEquals(resolved?.code, "OUTPUT_SCHEMA_NOT_CLOSED");
+
+      // The round trip works because the curated message still names the two
+      // things the matcher keys on. Rewording it without keeping both silently
+      // drops the child back to a generic execution failure, which is what
+      // this assertion is here to catch.
+      assertEquals(childErrorText.toLowerCase().includes("additionalproperties"), true);
+      assertEquals(childErrorText.toLowerCase().includes("output schema"), true);
     });
   });
 });


### PR DESCRIPTION
Follow-up to #3931, which merged at 13:07:05Z (`574988c712`) while its review was still in flight. The change it made is correct and reachable, but nothing in that PR named or tested the route that makes it work, so the behaviour was unpinned.

## What was missing

#3931 matches the schema rejection on the plain-message path. The Codex thread on that PR was right that the direct HTTP path cannot reach it: `buildProviderError` (`src/provider/runtime-loader/provider-http.ts:169`) always overwrites `.message`, and `buildAnthropicSseError` (`extensions/ext-llm-anthropic/src/anthropic-stream.ts:331`) is templated too. No raw provider text arrives that way.

The route that does work is the child run boundary, where everything structured is gone by construction and a bare string is all the parent has left:

1. `src/agent/hosted/chat-execution-runtime.ts:775` turns the child's stream error into text via `getHostedStreamErrorText` (`stream-terminal-error.ts:109`), yielding the curated message.
2. `src/agent/hosted/child-fork-stream-execution.ts:298` reads `error.message` into the failure snapshot.
3. `src/agent/hosted/child-lifecycle.ts:411` rebuilds it as `new HostedChildExecutionFailure(snapshot.error ?? "Unknown error", ...)`.
4. `src/agent/hosted/child-lifecycle.ts:360` re-classifies it with `resolveKnownProviderTerminalError`.

## Why this test matters beyond coverage

The round trip works only because our own curated message happens to contain `additionalProperties` and `output schema`. #3931 itself reworded that message. A future reword silently drops every child run back to a generic execution failure, with no test failing to say so.

## What the test does

The test drives steps 2 through 4 with the real helpers, not stand-ins. It builds the provider rejection with `buildProviderError`, turns it into child-side text with `getHostedStreamErrorText`, hands that to `handleHostedChildForkFailure`, captures the failure snapshot that emits, feeds the snapshot to `runHostedChildExecutionLifecycle`, and asserts the terminal error code the lifecycle produces is `OUTPUT_SCHEMA_NOT_CLOSED`. Breaking any link in that chain surfaces here as `INVOKE_AGENT_FAILED`.

It lives in `src/agent/hosted/child-lifecycle.test.ts`, where the boundary is, so `stream-outcome.test.ts` stays a unit test of the classifier.

## Verification

Red at #3931's merge parent `8d0ce3c2f0`, with only this test file applied:

```
deno test --preload=src/testing/preload.ts --no-check --allow-all src/agent/hosted/child-lifecycle.test.ts
  keeps a child run's schema rejection classified across the run boundary ... FAILED
  AssertionError: Values are not equal: a child run's schema rejection stays classified after crossing the boundary
  -   INVOKE_AGENT_FAILED
  +   OUTPUT_SCHEMA_NOT_CLOSED
FAILED | 0 passed (23 steps) | 1 failed (1 step)     EXIT=1
```

Red under mutation on current `main`, one boundary broken at a time:

| Mutation | Result |
|---|---|
| `child-fork-stream-execution.ts:298` stops forwarding the message (`const errorText = "Unknown error";`) | FAILED, `INVOKE_AGENT_FAILED`, exit 1 |
| Only the snapshot drops it (`buildChildRunFailureSnapshot(common, "Unknown error", ...)` at `child-fork-stream-execution.ts:312`) | FAILED, `INVOKE_AGENT_FAILED`, exit 1 |
| `child-lifecycle.ts:411` rebuilds without it (`new HostedChildExecutionFailure("Unknown error", ...)`) | FAILED, `INVOKE_AGENT_FAILED`, exit 1 |
| The curated `OUTPUT_SCHEMA_NOT_CLOSED` message reworded to drop `additionalProperties` | FAILED, `INVOKE_AGENT_FAILED`, exit 1 |

The second row isolates the snapshot from the result object, which the first row does not: both read the same `errorText`. The test also asserts the child settled exactly one snapshot before reading it, so the leak check cannot pass on an empty list.

Green unmutated on current `main`: `ok | 1 passed (24 steps) | 0 failed  EXIT=0`

Gates on this branch: `deno task typecheck` 0, `deno task lint:ci` 0, `deno fmt --check` 0, `deno test src/agent/hosted/ src/agent/streaming/ src/chat/provider-errors.test.ts` 0 (463 passed / 519 steps).

One test file changed, test only. No production code changes.
