### PR TITLE
test(llm): assert generate() inherits output filtering

### DIFF
--- a/docs/guides/choose-a-primitive.md
+++ b/docs/guides/choose-a-primitive.md
@@ -29,23 +29,23 @@ clear and prevents overlapping agents, workflows, runs, and integrations.
 
 ## Decision rules
 
-| Primitive     | Use for                                                                                      | Do not use for                                                                     |
-| ------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| App route     | A browser, HTTP client, or webhook needs an entry point.                                     | The work should outlive the request or be reused outside routing.                  |
-| Agent         | The model must decide, explain, call tools, use memory, or stream a response.                | The work follows fixed control flow and can be a function, task, or workflow step. |
-| One-shot call | Extraction, classification, summarizing, or routing needs one model call and a typed result. | The model must call tools, take several steps, or remember earlier turns.          |
-| Tool          | An agent or workflow needs a typed operation such as search, lookup, write, or transform.    | The operation has multiple long-running states or human approval steps.            |
-| Skill         | An agent needs reusable instructions, references, scripts, and assets.                       | The work needs executable behavior or durable process state.                       |
-| Prompt        | An assistant needs reusable instruction text.                                                | The project needs to execute code or read data.                                    |
-| Resource      | An assistant needs readable project context.                                                 | The operation changes state or starts work.                                        |
-| Eval          | You need repeatable agent quality checks, datasets, metrics, and reports.                    | You need code assertions without model execution.                                  |
-| Task          | You own a reusable background function in `tasks/`.                                          | The user needs conversational reasoning or streaming output.                       |
-| Workflow      | The process has ordered steps, parallel branches, retries, or human review.                  | A single agent response or one background function is enough.                      |
-| Run           | You need durable execution, scheduling, batch status, or run history.                        | The work can finish inside a request without durability.                           |
-| Integration   | You need provider metadata, OAuth, tokens, or remote integration tools.                      | A local custom API call is enough and no shared connector behavior is needed.      |
-| MCP server    | External assistants or MCP clients need tools, prompts, or resources.                        | The capability is only used inside one Veryfront app route.                        |
-| Sandbox       | Code or shell work needs isolation from the app process.                                     | The code can run safely in your own trusted runtime.                               |
-| Extension     | A capability should be packaged and reused across projects.                                  | The code belongs to one app and can stay local.                                    |
+| Primitive           | Use for                                                                                      | Do not use for                                                                     |
+| ------------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| App route           | A browser, HTTP client, or webhook needs an entry point.                                     | The work should outlive the request or be reused outside routing.                  |
+| Agent               | The model must decide, explain, call tools, use memory, or stream a response.                | The work follows fixed control flow and can be a function, task, or workflow step. |
+| One-shot model call | Extraction, classification, summarizing, or routing needs one model call and a typed result. | The model must call tools, take several steps, or remember earlier turns.          |
+| Tool                | An agent or workflow needs a typed operation such as search, lookup, write, or transform.    | The operation has multiple long-running states or human approval steps.            |
+| Skill               | An agent needs reusable instructions, references, scripts, and assets.                       | The work needs executable behavior or durable process state.                       |
+| Prompt              | An assistant needs reusable instruction text.                                                | The project needs to execute code or read data.                                    |
+| Resource            | An assistant needs readable project context.                                                 | The operation changes state or starts work.                                        |
+| Eval                | You need repeatable agent quality checks, datasets, metrics, and reports.                    | You need code assertions without model execution.                                  |
+| Task                | You own a reusable background function in `tasks/`.                                          | The user needs conversational reasoning or streaming output.                       |
+| Workflow            | The process has ordered steps, parallel branches, retries, or human review.                  | A single agent response or one background function is enough.                      |
+| Run                 | You need durable execution, scheduling, batch status, or run history.                        | The work can finish inside a request without durability.                           |
+| Integration         | You need provider metadata, OAuth, tokens, or remote integration tools.                      | A local custom API call is enough and no shared connector behavior is needed.      |
+| MCP server          | External assistants or MCP clients need tools, prompts, or resources.                        | The capability is only used inside one Veryfront app route.                        |
+| Sandbox             | Code or shell work needs isolation from the app process.                                     | The code can run safely in your own trusted runtime.                               |
+| Extension           | A capability should be packaged and reused across projects.                                  | The code belongs to one app and can stay local.                                    |
 
 ## Common pairings
 
@@ -71,7 +71,7 @@ the matching guide:
 - If the guide's first example solves your shape, continue there.
 - If you need two or more primitives, start with the one that owns the triggering event.
 - When choosing between `Task` and `Run`, remember that a task defines the work and a run executes it durably.
-- When choosing between a one-shot call and an `Agent`, remember that `generate()` from
+- When choosing between a one-shot model call and an `Agent`, remember that `generate()` from
   [`veryfront/llm`](../api-reference/veryfront/llm.md) makes one request with no tools, no steps,
   and no memory. Reach for an `Agent` as soon as you need any of those.
 

--- a/docs/guides/choose-a-primitive.md
+++ b/docs/guides/choose-a-primitive.md
@@ -9,41 +9,43 @@ clear and prevents overlapping agents, workflows, runs, and integrations.
 
 ## Quick choice
 
-| Goal                                                        | Use                    | Start with                                  |
-| ----------------------------------------------------------- | ---------------------- | ------------------------------------------- |
-| Receive browser, HTTP, or webhook traffic                   | App route or API route | [Pages and routing](./pages-and-routing.md) |
-| Answer users with model reasoning, tools, memory, or skills | Agent                  | [Agents](./agents.md)                       |
-| Give an agent one typed capability                          | Tool                   | [Tools](./tools.md)                         |
-| Package reusable agent behavior                             | Skill                  | [Skills](./skills.md)                       |
-| Reuse assistant instructions                                | Prompt                 | [MCP server](./mcp-server.md)               |
-| Expose readable context to assistants                       | Resource               | [MCP server](./mcp-server.md)               |
-| Measure agent quality across examples                       | Eval                   | [Evals](./evals.md)                         |
-| Define project-owned background work                        | Task                   | [Tasks](./tasks.md)                         |
-| Coordinate multiple steps, branches, approvals, or retries  | Workflow               | [Workflows](./workflows.md)                 |
-| Run durable background work now or on a schedule            | Run or schedule        | [Runs](./runs.md)                           |
-| Connect agents to third-party services                      | Integration with OAuth | [Integrations](./integrations.md)           |
-| Expose project capabilities to assistants over a protocol   | MCP server             | [MCP server](./mcp-server.md)               |
-| Run isolated commands or file operations                    | Sandbox                | [Sandbox](./sandbox.md)                     |
-| Add reusable runtime capabilities                           | Extension              | [Extensions](./extensions.md)               |
+| Goal                                                        | Use                    | Start with                                         |
+| ----------------------------------------------------------- | ---------------------- | -------------------------------------------------- |
+| Receive browser, HTTP, or webhook traffic                   | App route or API route | [Pages and routing](./pages-and-routing.md)        |
+| Get one typed result from a single model call               | One-shot model call    | [veryfront/llm](../api-reference/veryfront/llm.md) |
+| Answer users with model reasoning, tools, memory, or skills | Agent                  | [Agents](./agents.md)                              |
+| Give an agent one typed capability                          | Tool                   | [Tools](./tools.md)                                |
+| Package reusable agent behavior                             | Skill                  | [Skills](./skills.md)                              |
+| Reuse assistant instructions                                | Prompt                 | [MCP server](./mcp-server.md)                      |
+| Expose readable context to assistants                       | Resource               | [MCP server](./mcp-server.md)                      |
+| Measure agent quality across examples                       | Eval                   | [Evals](./evals.md)                                |
+| Define project-owned background work                        | Task                   | [Tasks](./tasks.md)                                |
+| Coordinate multiple steps, branches, approvals, or retries  | Workflow               | [Workflows](./workflows.md)                        |
+| Run durable background work now or on a schedule            | Run or schedule        | [Runs](./runs.md)                                  |
+| Connect agents to third-party services                      | Integration with OAuth | [Integrations](./integrations.md)                  |
+| Expose project capabilities to assistants over a protocol   | MCP server             | [MCP server](./mcp-server.md)                      |
+| Run isolated commands or file operations                    | Sandbox                | [Sandbox](./sandbox.md)                            |
+| Add reusable runtime capabilities                           | Extension              | [Extensions](./extensions.md)                      |
 
 ## Decision rules
 
-| Primitive   | Use for                                                                                   | Do not use for                                                                     |
-| ----------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| App route   | A browser, HTTP client, or webhook needs an entry point.                                  | The work should outlive the request or be reused outside routing.                  |
-| Agent       | The model must decide, explain, call tools, use memory, or stream a response.             | The work follows fixed control flow and can be a function, task, or workflow step. |
-| Tool        | An agent or workflow needs a typed operation such as search, lookup, write, or transform. | The operation has multiple long-running states or human approval steps.            |
-| Skill       | An agent needs reusable instructions, references, scripts, and assets.                    | The work needs executable behavior or durable process state.                       |
-| Prompt      | An assistant needs reusable instruction text.                                             | The project needs to execute code or read data.                                    |
-| Resource    | An assistant needs readable project context.                                              | The operation changes state or starts work.                                        |
-| Eval        | You need repeatable agent quality checks, datasets, metrics, and reports.                 | You need code assertions without model execution.                                  |
-| Task        | You own a reusable background function in `tasks/`.                                       | The user needs conversational reasoning or streaming output.                       |
-| Workflow    | The process has ordered steps, parallel branches, retries, or human review.               | A single agent response or one background function is enough.                      |
-| Run         | You need durable execution, scheduling, batch status, or run history.                     | The work can finish inside a request without durability.                           |
-| Integration | You need provider metadata, OAuth, tokens, or remote integration tools.                   | A local custom API call is enough and no shared connector behavior is needed.      |
-| MCP server  | External assistants or MCP clients need tools, prompts, or resources.                     | The capability is only used inside one Veryfront app route.                        |
-| Sandbox     | Code or shell work needs isolation from the app process.                                  | The code can run safely in your own trusted runtime.                               |
-| Extension   | A capability should be packaged and reused across projects.                               | The code belongs to one app and can stay local.                                    |
+| Primitive     | Use for                                                                                      | Do not use for                                                                     |
+| ------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| App route     | A browser, HTTP client, or webhook needs an entry point.                                     | The work should outlive the request or be reused outside routing.                  |
+| Agent         | The model must decide, explain, call tools, use memory, or stream a response.                | The work follows fixed control flow and can be a function, task, or workflow step. |
+| One-shot call | Extraction, classification, summarizing, or routing needs one model call and a typed result. | The model must call tools, take several steps, or remember earlier turns.          |
+| Tool          | An agent or workflow needs a typed operation such as search, lookup, write, or transform.    | The operation has multiple long-running states or human approval steps.            |
+| Skill         | An agent needs reusable instructions, references, scripts, and assets.                       | The work needs executable behavior or durable process state.                       |
+| Prompt        | An assistant needs reusable instruction text.                                                | The project needs to execute code or read data.                                    |
+| Resource      | An assistant needs readable project context.                                                 | The operation changes state or starts work.                                        |
+| Eval          | You need repeatable agent quality checks, datasets, metrics, and reports.                    | You need code assertions without model execution.                                  |
+| Task          | You own a reusable background function in `tasks/`.                                          | The user needs conversational reasoning or streaming output.                       |
+| Workflow      | The process has ordered steps, parallel branches, retries, or human review.                  | A single agent response or one background function is enough.                      |
+| Run           | You need durable execution, scheduling, batch status, or run history.                        | The work can finish inside a request without durability.                           |
+| Integration   | You need provider metadata, OAuth, tokens, or remote integration tools.                      | A local custom API call is enough and no shared connector behavior is needed.      |
+| MCP server    | External assistants or MCP clients need tools, prompts, or resources.                        | The capability is only used inside one Veryfront app route.                        |
+| Sandbox       | Code or shell work needs isolation from the app process.                                     | The code can run safely in your own trusted runtime.                               |
+| Extension     | A capability should be packaged and reused across projects.                                  | The code belongs to one app and can stay local.                                    |
 
 ## Common pairings
 
@@ -69,5 +71,8 @@ the matching guide:
 - If the guide's first example solves your shape, continue there.
 - If you need two or more primitives, start with the one that owns the triggering event.
 - When choosing between `Task` and `Run`, remember that a task defines the work and a run executes it durably.
+- When choosing between a one-shot call and an `Agent`, remember that `generate()` from
+  [`veryfront/llm`](../api-reference/veryfront/llm.md) makes one request with no tools, no steps,
+  and no memory. Reach for an `Agent` as soon as you need any of those.
 
 Run the guide's example or validation command before adding another primitive.

--- a/src/llm/index.test.ts
+++ b/src/llm/index.test.ts
@@ -115,6 +115,21 @@ describe("llm/generate", () => {
     }
   });
 
+  it("redacts a blocked value in both text and object", async () => {
+    const stub = stubProvider('{"city":"ada@example.com"}');
+    try {
+      const result = await generate({
+        input: "where",
+        model: "stub/stub",
+        outputSchema: SCHEMA,
+      });
+      assertEquals(result.text, '{"city":"[EMAIL]"}');
+      assertEquals(result.object, { city: "[EMAIL]" });
+    } finally {
+      stub.dispose();
+    }
+  });
+
   it("omits object when no schema is requested", async () => {
     const stub = stubProvider("plain");
     try {


### PR DESCRIPTION
One test and one guide row. No production change.

## The seam this pins

`generate()` from `veryfront/llm` constructs its agent without a `security` key, so
`resolveSecurityMiddleware` (`src/agent/factory.ts:565`) applies the default security middleware and
both `text` and the parsed `object` come back filtered. Nothing asserted that.

It matters because #3894 shipped exactly this failure mode as a P1. The middleware redacted
`result.text` and passed everything else through with `{ ...result }`, so a structured response
returned the redacted string in `text` and the raw sensitive value in `object`. That was caught in
review and fixed (`src/agent/middleware/security/validator.ts:357-372` now filters both), but the
one-shot surface had no test holding the line.

The cost of getting this wrong is asymmetric: `security` is typed `security?: false`, opt-out only,
so redaction is default-on for every agent. A refactor that adds `security: false` to the facade for
any reason, or that stops routing through `agent()`, silently turns filtering off on a public export.

## Fail-first evidence

Adding `security: false` to the facade in `src/llm/index.ts`, with no other change:

```
$ deno test --preload=src/testing/preload.ts --no-check --allow-all src/llm/
EXIT=1
  redacts a blocked value in both text and object ... FAILED (3ms)
FAILED | 0 passed (7 steps) | 1 failed (1 step)

error: AssertionError: Values are not equal.
    [Diff] Actual / Expected
-   {"city":"ada@example.com"}
+   {"city":"[EMAIL]"}
```

The raw address is the leak. Reverting that one line:

```
$ deno test --preload=src/testing/preload.ts --no-check --allow-all src/llm/
EXIT=0
  redacts a blocked value in both text and object ... ok (1ms)
ok | 1 passed (8 steps) | 0 failed
```

## The guide row

Only `docs/api-reference/` mentioned `veryfront/llm`. Discoverability was the sole surviving
justification for shipping the export, so leaving the one-shot call out of the primitive-choice
guide defeated the reason it exists. Adds a row to each of the two tables and a tiebreak line
against `Agent`.

Note on diff size: `deno fmt` realigns a whole markdown table when any cell widens, so both tables
show as fully rewritten. The content change is two rows and one bullet.

## Gates

| Gate | Exit |
| --- | --- |
| `deno task typecheck` | 0 |
| `deno task lint:ci` | 0 |
| `deno fmt --check` on both touched files | 0 |
| `deno test ... src/llm/` | 0, 8 steps |

Refs #694, #3894.
