### PR TITLE
fix(workflow): make the persistence check agree with JSON.stringify, and hold the framework to it

### DIFF
--- a/src/workflow/backends/redis/index.test.ts
+++ b/src/workflow/backends/redis/index.test.ts
@@ -626,7 +626,13 @@ describe("RedisBackend", () => {
       assertEquals(await backend.getRun(run.id), null);
     });
 
-    it("does not warn about framework-owned node timestamps", async () => {
+    it("names the run when a patch persists a lossy value", async () => {
+      // Creation usually writes only `input`. Patches write the accumulated
+      // node outputs, so a patch is where a warning actually fires, and it
+      // used to arrive with no run to attribute it to.
+      const runId = "run-patch-warning";
+      await backend.createRun(createTestRun(runId));
+
       const warnings: LogEntry[] = [];
       const unsubscribe = __subscribeLogRecordEmitter((entry) => {
         if (entry.level === "warn" && entry.component === "workflow-context") {
@@ -635,22 +641,17 @@ describe("RedisBackend", () => {
       });
 
       try {
-        await backend.createRun(createTestRun("run-node-timestamps", {
-          nodeStates: {
-            step: {
-              nodeId: "step",
-              status: "completed",
-              attempt: 1,
-              startedAt: new Date("2025-01-01T00:00:00Z"),
-              completedAt: new Date("2025-01-01T00:00:01Z"),
-            },
-          },
-        }));
+        await backend.updateRun(runId, {
+          context: { input: {}, step: { when: new Date("2026-01-01T00:00:00Z") } },
+        });
       } finally {
         unsubscribe();
       }
 
-      assertEquals(warnings, []);
+      assertEquals(warnings.length, 1);
+      // The logger promotes the run id to its own field rather than leaving it
+      // in the free-form context, so that is where it has to be asserted.
+      assertEquals(warnings[0]?.run_id, runId);
     });
   });
 

--- a/src/workflow/backends/redis/index.ts
+++ b/src/workflow/backends/redis/index.ts
@@ -310,6 +310,9 @@ export class RedisBackend implements WorkflowBackend {
 
   private serializeRun(run: WorkflowRun): Record<string, string> {
     const sourceIntegrationPolicy = requireWorkflowSourceIntegrationPolicy(run);
+    // Encoded before the fields below, on purpose. A step's return value reaches
+    // `input`, `output`, and `nodeStates` as well, and those are encoded by
+    // `JSON.stringify`, so whichever runs first decides the error a caller sees.
     const context = serializeWorkflowContext(run.context, run.id);
     return {
       id: run.id,
@@ -333,6 +336,9 @@ export class RedisBackend implements WorkflowBackend {
   }
 
   private serializeRunPatch(patch: WorkflowRunUpdate): Record<string, string> {
+    // Encoded before the fields below for the same reason as in `serializeRun`:
+    // `output` and `nodeStates` carry the same step values, and the field that
+    // is encoded first decides the error a caller sees.
     const context = patch.context !== undefined
       ? serializeWorkflowContext(patch.context)
       : undefined;
@@ -360,6 +366,8 @@ export class RedisBackend implements WorkflowBackend {
   }
 
   private serializeCheckpoint(runId: string, checkpoint: Checkpoint): string {
+    // Checked before the rest of the checkpoint is encoded below, so a value
+    // JSON refuses is named by its path rather than by the native error.
     const { normalized: context } = prepareWorkflowJson(
       checkpoint.context,
       "checkpoint.context",

--- a/src/workflow/backends/redis/index.ts
+++ b/src/workflow/backends/redis/index.ts
@@ -335,12 +335,16 @@ export class RedisBackend implements WorkflowBackend {
     };
   }
 
-  private serializeRunPatch(patch: WorkflowRunUpdate): Record<string, string> {
+  private serializeRunPatch(patch: WorkflowRunUpdate, runId?: string): Record<string, string> {
     // Encoded before the fields below for the same reason as in `serializeRun`:
     // `output` and `nodeStates` carry the same step values, and the field that
     // is encoded first decides the error a caller sees.
+    //
+    // `runId` is passed so a lossy-value warning names the run it came from.
+    // Patches are where warnings actually fire, because creation usually writes
+    // only `input` while patches write the accumulated node outputs.
     const context = patch.context !== undefined
-      ? serializeWorkflowContext(patch.context)
+      ? serializeWorkflowContext(patch.context, runId)
       : undefined;
     const fields: Record<string, string> = {};
     if (Object.hasOwn(patch, "workerId")) fields.workerId = patch.workerId ?? "";
@@ -593,7 +597,7 @@ export class RedisBackend implements WorkflowBackend {
 
     if (this.config.debug) logger.debug(`[RedisBackend] Updating run: ${runId}`);
 
-    const fields = this.serializeRunPatch(patch);
+    const fields = this.serializeRunPatch(patch, runId);
     // status is written by MOVE_STATUS_SCRIPT below (atomically with its index
     // move), so it is deliberately excluded from this plain hset.
     if (Object.keys(fields).length > 0) await client.hset(this.runKey(runId), fields);
@@ -643,7 +647,7 @@ export class RedisBackend implements WorkflowBackend {
   ): Promise<boolean> {
     assertWorkflowRunUpdate(patch);
     const client = await this.ensureClient();
-    const fields = this.serializeRunPatch(patch);
+    const fields = this.serializeRunPatch(patch, runId);
     const fieldArgs = Object.entries(fields).flatMap(([field, value]) => [field, value]);
     const result = await client.eval(
       UPDATE_RUN_IF_STATUS_SCRIPT,

--- a/src/workflow/context-serialization.test.ts
+++ b/src/workflow/context-serialization.test.ts
@@ -1,7 +1,13 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { __subscribeLogRecordEmitter, type LogEntry } from "#veryfront/utils/logger/index.ts";
+import {
+  __resetLoggerConfigForTests,
+  __subscribeLogRecordEmitter,
+  type LogEntry,
+  LogLevel,
+  setLogLevel,
+} from "#veryfront/utils/logger/index.ts";
 import type { WorkflowContext } from "./types.ts";
 import { serializeWorkflowContext, serializeWorkflowJson } from "./context-serialization.ts";
 
@@ -236,6 +242,38 @@ describe("serializeWorkflowContext", () => {
     assertEquals(JSON.parse(serialized).step, { total: 7 });
   });
 
+  it("converts a boxed primitive the way JSON converts it, through the object", () => {
+    // JSON puts a Number box through ToNumber, which asks the object, so a
+    // replaced prototype leaves it with no `valueOf` to reach and JSON writes
+    // null. Reading the slot instead would persist a 7 JSON never wrote.
+    const boxed = Object.setPrototypeOf(new Number(7), Object.prototype);
+
+    const serialized = serializeWorkflowContext(contextWith({ total: boxed }));
+
+    assertEquals(JSON.parse(serialized).step, JSON.parse(JSON.stringify({ total: boxed })));
+    assertEquals(JSON.parse(serialized).step.total, null);
+  });
+
+  it("does not probe primitive slots on an ordinary object", () => {
+    // Each probe throws on a miss and a context is mostly objects that miss
+    // every one, so probing all of them spent several thrown exceptions per
+    // object on the path every persisted run takes.
+    const originalValueOf = Number.prototype.valueOf;
+    let probes = 0;
+    Number.prototype.valueOf = function (this: number) {
+      probes++;
+      return originalValueOf.call(this);
+    };
+
+    try {
+      serializeWorkflowContext(contextWith({ rows: [{ id: 1 }, { id: 2 }] }));
+    } finally {
+      Number.prototype.valueOf = originalValueOf;
+    }
+
+    assertEquals(probes, 0);
+  });
+
   it("does not trust a spoofed boxed-primitive tag", () => {
     const serialized = serializeWorkflowContext(contextWith({
       value: 7,
@@ -321,6 +359,203 @@ describe("serializeWorkflowContext", () => {
 
     assertEquals(JSON.parse(nested).step, 123);
     assertEquals(root, "456");
+  });
+
+  describe("values larger than a diagnostic can describe", () => {
+    it("encodes a value nested deeper than the walk follows", () => {
+      // The walk recurses and `JSON.stringify` does not, so a value nested this
+      // deep persisted fine before this check existed. Failing it now with
+      // `Maximum call stack size exceeded` raised from inside the backend is
+      // the exact error the check was written to replace.
+      let deep: unknown = 1;
+      for (let index = 0; index < 5000; index++) deep = { n: deep };
+
+      assertEquals(
+        serializeWorkflowContext(contextWith(deep)),
+        JSON.stringify({ input: {}, step: deep }),
+      );
+    });
+
+    it("still names a fatal value found above the depth it stops at", () => {
+      let deep: unknown = 1;
+      for (let index = 0; index < 5000; index++) deep = { n: deep };
+
+      const error = assertThrows(() =>
+        serializeWorkflowContext(contextWith({ shallow: 1n, deep }))
+      );
+
+      assertEquals((error as Error).message.includes("context.step.shallow"), true);
+    });
+
+    it("counts every hole in a sparse array without keeping one entry each", () => {
+      // Only MAX_REPORTED_PATHS paths ever reach a message, so keeping an entry
+      // per hole would spend memory proportional to the payload on the
+      // persistence path and show none of it.
+      const sparse: unknown[] = [];
+      sparse.length = 500_000;
+
+      const before = process.memoryUsage().heapUsed;
+      const warnings = captureWorkflowWarnings(() => {
+        serializeWorkflowContext(contextWith({ rows: sparse }));
+      });
+      const retained = process.memoryUsage().heapUsed - before;
+      const paths = String(warnings[0]?.context?.paths);
+
+      assertEquals(paths.includes("context.step.rows[0] (array hole)"), true);
+      assertEquals(paths.includes("and 499995 more"), true);
+      assertEquals(retained < 50_000_000, true);
+    });
+  });
+
+  describe("agreement with JSON.stringify", () => {
+    // This module walks the value itself instead of delegating, so it can drift
+    // from `JSON.stringify`, and a drift does not blur a diagnostic: it writes
+    // into durable storage something JSON never wrote. The generator below is
+    // seeded, so a failing seed rebuilds the value that broke.
+    const SAMPLE_STRINGS: readonly [string, ...string[]] = [
+      "",
+      "a",
+      "he\u0301",
+      "\ud83d\ude00",
+      "\ud800",
+      '"\\\n\t',
+      "__proto__",
+    ];
+    const SAMPLE_NUMBERS: readonly [number, ...number[]] = [
+      0,
+      -0,
+      1,
+      -1,
+      1e21,
+      1e-7,
+      5e-324,
+      Number.MAX_SAFE_INTEGER,
+      0.1,
+    ];
+    const SAMPLE_KEYS: readonly [string, ...string[]] = [
+      "a",
+      "b",
+      "toJSON",
+      "__proto__",
+      "constructor",
+      "0",
+      "length",
+      "u@x.com",
+    ];
+
+    function seededRandom(seed: number): () => number {
+      let state = seed;
+      return () => {
+        state = (state + 0x6D2B79F5) | 0;
+        let mixed = Math.imul(state ^ (state >>> 15), 1 | state);
+        mixed = (mixed + Math.imul(mixed ^ (mixed >>> 7), 61 | mixed)) ^ mixed;
+        return ((mixed ^ (mixed >>> 14)) >>> 0) / 4294967296;
+      };
+    }
+
+    function pick<T>(random: () => number, values: readonly [T, ...T[]]): T {
+      return values[Math.floor(random() * values.length)] ?? values[0];
+    }
+
+    function generateLeaf(random: () => number): unknown {
+      const choice = random();
+      if (choice < 0.2) return pick(random, SAMPLE_STRINGS);
+      if (choice < 0.45) return pick(random, SAMPLE_NUMBERS);
+      if (choice < 0.55) return random() < 0.5;
+      if (choice < 0.65) return null;
+      if (choice < 0.72) return undefined;
+      if (choice < 0.77) return new Date(Math.floor(random() * 1e12));
+      if (choice < 0.81) return () => 1;
+      if (choice < 0.84) return Symbol("generated");
+      if (choice < 0.87) return new Map([["k", 1]]);
+      if (choice < 0.9) return new Set([1, 2]);
+      if (choice < 0.93) return new Number(random() * 10);
+      if (choice < 0.96) return new String("boxed");
+      if (choice < 0.98) return new Boolean(true);
+      return /generated/g;
+    }
+
+    function generateArray(random: () => number, depth: number): unknown[] {
+      const values: unknown[] = [];
+      const length = Math.floor(random() * 4);
+      for (let index = 0; index < length; index++) {
+        // A hole, which JSON materializes as null.
+        if (random() < 0.2) values.length += 1;
+        else values.push(generateValue(random, depth - 1));
+      }
+      return values;
+    }
+
+    function generateObject(random: () => number, depth: number): object {
+      const shape = random();
+      const value: Record<string, unknown> = shape < 0.12 ? Object.create(null) : {};
+      const keys = Math.floor(random() * 4);
+      for (let index = 0; index < keys; index++) {
+        const key = pick(random, SAMPLE_KEYS);
+        const child = generateValue(random, depth - 1);
+        // A callable `toJSON` is generated deliberately below, not by accident.
+        if (key === "toJSON" && typeof child === "function") continue;
+        if (random() < 0.12) {
+          Object.defineProperty(value, key, {
+            value: child,
+            enumerable: random() < 0.5,
+            writable: true,
+            configurable: true,
+          });
+        } else {
+          value[key] = child;
+        }
+      }
+      if (shape >= 0.12 && shape < 0.2) {
+        class Generated {}
+        Object.setPrototypeOf(value, Generated.prototype);
+      }
+      if (shape >= 0.2 && shape < 0.26) {
+        Object.defineProperty(value, "toJSON", { value: () => ({ replaced: true }) });
+      }
+      if (shape >= 0.26 && shape < 0.3) {
+        Object.defineProperty(value, "lazy", { enumerable: true, get: () => 42 });
+      }
+      return value;
+    }
+
+    function generateValue(random: () => number, depth: number): unknown {
+      const choice = random();
+      if (depth <= 0 || choice < 0.22) return generateLeaf(random);
+      return choice < 0.6 ? generateArray(random, depth) : generateObject(random, depth);
+    }
+
+    it("encodes generated values exactly as JSON.stringify encodes them", () => {
+      // Every lossy value found warns, and the generator makes thousands, so
+      // the level is lowered for the loop rather than flooding the run output.
+      setLogLevel(LogLevel.ERROR);
+      const divergences: string[] = [];
+      try {
+        for (let seed = 0; seed < 3000; seed++) {
+          let expected: string;
+          try {
+            expected = JSON.stringify(generateValue(seededRandom(seed), 4));
+          } catch {
+            // JSON refuses this value outright, which the fatal cases cover.
+            continue;
+          }
+          let actual: string;
+          try {
+            actual = serializeWorkflowJson(generateValue(seededRandom(seed), 4), "root");
+          } catch (error) {
+            divergences.push(`seed ${seed} threw ${(error as Error).message}`);
+            continue;
+          }
+          if (actual !== expected) {
+            divergences.push(`seed ${seed}: got ${actual}, wanted ${expected}`);
+          }
+        }
+      } finally {
+        __resetLoggerConfigForTests();
+      }
+
+      assertEquals(divergences.slice(0, 5), []);
+    });
   });
 
   it("does not mistake a repeated value for a cycle", () => {

--- a/src/workflow/context-serialization.test.ts
+++ b/src/workflow/context-serialization.test.ts
@@ -265,6 +265,16 @@ describe("serializeWorkflowContext", () => {
     assertEquals(JSON.parse(serialized).step.total, null);
   });
 
+  it("refuses a boxed Number whose valueOf returns a BigInt, as JSON does", () => {
+    // `Number()` accepts a BigInt that JSON's `ToNumber` refuses, so converting
+    // with it would quietly coerce this to 2 and persist a number JSON would
+    // have thrown on. The conversion has to be the operation JSON performs, not
+    // one that merely looks like it.
+    const boxed = Object.assign(new Number(1), { valueOf: () => 2n });
+
+    assertThrows(() => serializeWorkflowContext(contextWith({ total: boxed })), TypeError);
+  });
+
   it("does not probe primitive slots on an ordinary object", () => {
     // Each probe throws on a miss and a context is mostly objects that miss
     // every one, so probing all of them spent several thrown exceptions per
@@ -409,6 +419,34 @@ describe("serializeWorkflowContext", () => {
 
       assertEquals((error as Error).message.includes("context.step.shallow"), true);
       assertEquals((error as Error).message.includes(".n.n"), false);
+    });
+
+    it("reads a hook above the depth cutoff exactly once", () => {
+      // Handing the whole root back to `JSON.stringify` would re-run every
+      // getter and `toJSON` the walk had already run on the way down, and a
+      // hook that answers differently the second time would then persist a
+      // value this check never saw. Only the subtree below the cutoff is left
+      // to JSON, so nothing above it is read twice.
+      let reads = 0;
+      let deep: unknown = { leaf: 1 };
+      for (let index = 0; index < PAST_THE_WALK; index++) deep = { n: deep };
+      // The getter is keyed before the deep value on purpose. Keyed after it,
+      // the walk would stop before ever reaching the getter and read it once
+      // even when restarting from the root, so the test would prove nothing.
+      const output: Record<string, unknown> = {};
+      Object.defineProperty(output, "counted", {
+        enumerable: true,
+        get: () => {
+          reads++;
+          return reads;
+        },
+      });
+      output.deep = deep;
+
+      const serialized = serializeWorkflowContext(contextWith(output));
+
+      assertEquals(reads, 1);
+      assertEquals(JSON.parse(serialized).step.counted, 1);
     });
 
     it("counts every hole in a sparse array without keeping one entry each", () => {

--- a/src/workflow/context-serialization.test.ts
+++ b/src/workflow/context-serialization.test.ts
@@ -9,7 +9,18 @@ import {
   setLogLevel,
 } from "#veryfront/utils/logger/index.ts";
 import type { WorkflowContext } from "./types.ts";
-import { serializeWorkflowContext, serializeWorkflowJson } from "./context-serialization.ts";
+import {
+  MAX_TRAVERSAL_DEPTH,
+  serializeWorkflowContext,
+  serializeWorkflowJson,
+} from "./context-serialization.ts";
+
+// Deep enough that the walk stops and hands the value to `JSON.stringify`, and
+// no deeper. `JSON.stringify` is itself stack bound, and how deep it reaches
+// varies by engine and by the stack a test runner leaves it, so a fixed large
+// depth tests the host rather than this module. Deriving it from the constant
+// also keeps these tests from going quiet if the limit is ever raised.
+const PAST_THE_WALK = MAX_TRAVERSAL_DEPTH + 25;
 
 const jsonRawSupport = JSON as typeof JSON & {
   rawJSON(source: string): unknown;
@@ -362,29 +373,42 @@ describe("serializeWorkflowContext", () => {
   });
 
   describe("values larger than a diagnostic can describe", () => {
-    it("encodes a value nested deeper than the walk follows", () => {
-      // The walk recurses and `JSON.stringify` does not, so a value nested this
-      // deep persisted fine before this check existed. Failing it now with
-      // `Maximum call stack size exceeded` raised from inside the backend is
-      // the exact error the check was written to replace.
-      let deep: unknown = 1;
-      for (let index = 0; index < 5000; index++) deep = { n: deep };
+    it("hands a value deeper than the walk follows back to JSON.stringify", () => {
+      // The walk recurses far more heavily than `JSON.stringify`, so past a few
+      // thousand levels it died with `Maximum call stack size exceeded` raised
+      // from inside the backend, on a value that persisted fine before this
+      // check existed. That is the error class the check exists to replace.
+      //
+      // The `Date` at the bottom is what proves the walk actually stopped: it
+      // is a lossy value, so a walk that reached it would report it. Asserting
+      // the stack overflow itself would test the host, since how deep the walk
+      // and `JSON.stringify` each reach depends on the engine and the stack a
+      // test runner leaves them.
+      let deep: unknown = { when: new Date(0) };
+      for (let index = 0; index < PAST_THE_WALK; index++) deep = { n: deep };
 
-      assertEquals(
-        serializeWorkflowContext(contextWith(deep)),
-        JSON.stringify({ input: {}, step: deep }),
-      );
+      let serialized = "";
+      const warnings = captureWorkflowWarnings(() => {
+        serialized = serializeWorkflowContext(contextWith(deep));
+      });
+
+      assertEquals(warnings, []);
+      assertEquals(serialized, JSON.stringify({ input: {}, step: deep }));
     });
 
     it("still names a fatal value found above the depth it stops at", () => {
-      let deep: unknown = 1;
-      for (let index = 0; index < 5000; index++) deep = { n: deep };
+      // What the walk found on the way down still holds. What sits below the
+      // depth it follows does not get named, which is why the deep BigInt is
+      // absent from the message while the shallow one is not.
+      let deep: unknown = 2n;
+      for (let index = 0; index < PAST_THE_WALK; index++) deep = { n: deep };
 
       const error = assertThrows(() =>
         serializeWorkflowContext(contextWith({ shallow: 1n, deep }))
       );
 
       assertEquals((error as Error).message.includes("context.step.shallow"), true);
+      assertEquals((error as Error).message.includes(".n.n"), false);
     });
 
     it("counts every hole in a sparse array without keeping one entry each", () => {
@@ -511,7 +535,13 @@ describe("serializeWorkflowContext", () => {
         Object.setPrototypeOf(value, Generated.prototype);
       }
       if (shape >= 0.2 && shape < 0.26) {
-        Object.defineProperty(value, "toJSON", { value: () => ({ replaced: true }) });
+        // Enumerable on purpose. JavaScriptCore skips a non-enumerable own
+        // `toJSON` that V8 calls, so generating one would compare two engines
+        // against each other rather than this module against its own host.
+        Object.defineProperty(value, "toJSON", {
+          value: () => ({ replaced: true }),
+          enumerable: true,
+        });
       }
       if (shape >= 0.26 && shape < 0.3) {
         Object.defineProperty(value, "lazy", { enumerable: true, get: () => 42 });

--- a/src/workflow/context-serialization.ts
+++ b/src/workflow/context-serialization.ts
@@ -8,6 +8,21 @@ const logger = agentLogger.component("workflow-context");
 const MAX_REPORTED_PATHS = 5;
 
 /**
+ * How deep the walk descends before handing the value back to `JSON.stringify`.
+ *
+ * This walk recurses and `JSON.stringify` does not, so a value nested a few
+ * thousand levels deep exhausts the stack here while JSON encodes it without
+ * complaint. Failing such a run with `Maximum call stack size exceeded` raised
+ * from inside the backend is the outcome this module exists to remove, so past
+ * this depth the diagnostic is dropped rather than the run: the value is
+ * encoded the way the backend encoded it before this check existed.
+ */
+const MAX_TRAVERSAL_DEPTH = 1000;
+
+/** Ends a walk that ran past `MAX_TRAVERSAL_DEPTH`. Never leaves this module. */
+const TRAVERSAL_TOO_DEEP = new Error("workflow value nested deeper than the walk follows");
+
+/**
  * Property names safe to quote verbatim in a diagnostic.
  *
  * A path is built from the keys a step chose, and a step is free to key an
@@ -27,18 +42,31 @@ function redactPathSegment(key: string): string {
   return SAFE_PATH_SEGMENT.test(key) ? key : "<redacted>";
 }
 
-/**
- * A value the durable codec cannot carry.
- *
- * `fatal` separates the two ways JSON fails a value: it either refuses to
- * encode it at all -- a BigInt, a cycle -- or encodes something lesser, like a
- * Date becoming a string or a Map becoming `{}`. The first fails the run, the
- * second changes what a later step reads, so they warrant different responses.
- */
+/** A value the durable codec cannot carry, named by where it sits. */
 interface UnrepresentableValue {
   readonly path: string;
   readonly kind: string;
-  readonly fatal: boolean;
+}
+
+/**
+ * What one walk found, split by how JSON fails the value.
+ *
+ * JSON fails a value in two ways: it refuses to encode it at all -- a BigInt, a
+ * cycle -- or it encodes something lesser, like a Date becoming a string or a
+ * Map becoming `{}`. The first fails the run, the second changes what a later
+ * step reads, so they warrant different responses.
+ *
+ * Each side keeps at most `MAX_REPORTED_PATHS` paths and counts the rest. A
+ * step is free to return an array with half a million holes, and every hole is
+ * a diagnostic no message will ever show, so holding one entry per hole would
+ * spend memory proportional to the payload on the persistence path. The counts
+ * stay exact, so a message still says how many there were.
+ */
+interface UnrepresentableValues {
+  readonly fatal: UnrepresentableValue[];
+  readonly lossy: UnrepresentableValue[];
+  fatalCount: number;
+  lossyCount: number;
 }
 
 /** Object identity tracked while JSON.stringify walks the active value graph. */
@@ -110,51 +138,116 @@ function toJsonLength(value: unknown): number {
   return Math.min(Math.floor(number), Number.MAX_SAFE_INTEGER);
 }
 
-interface BoxedJsonPrimitive {
-  readonly value: string | number | boolean | bigint;
+/**
+ * Whether a value could hold a primitive slot, judging only unspoofed tags.
+ *
+ * `Object.prototype.toString` reports the same internal slots the probes below
+ * read, and reports them without throwing. It stops being trustworthy only when
+ * the value carries a `Symbol.toStringTag`, which anything can set, so a value
+ * that has one is sent to the probes instead of being judged here.
+ */
+function couldHoldPrimitiveSlot(value: JsonTraversalReference): boolean {
+  try {
+    if (Symbol.toStringTag in value) return true;
+    const tag = Object.prototype.toString.call(value);
+    return tag === "[object Number]" || tag === "[object String]" ||
+      tag === "[object Boolean]" || tag === "[object BigInt]";
+  } catch {
+    // Hostile metadata cannot answer this; let the probes decide.
+    return true;
+  }
 }
 
-/** Probe internal primitive slots without consulting spoofable metadata. */
-function unboxJsonPrimitive(value: JsonTraversalReference): BoxedJsonPrimitive | null {
+/** The kind of primitive slot a boxed value carries. */
+type BoxedPrimitiveSlot = "number" | "string" | "boolean" | "bigint";
+
+/**
+ * Which primitive slot a value carries, read without consulting metadata.
+ *
+ * Each probe throws on a miss, so reaching all four costs four thrown
+ * exceptions, and a context is mostly made of objects that miss every one.
+ * `couldHoldPrimitiveSlot` rejects those without throwing, which is what keeps
+ * this off the cost of every object a run persists.
+ */
+function boxedPrimitiveSlot(value: JsonTraversalReference): BoxedPrimitiveSlot | null {
+  if (!couldHoldPrimitiveSlot(value)) return null;
   try {
-    return { value: Number.prototype.valueOf.call(value) };
+    Number.prototype.valueOf.call(value);
+    return "number";
   } catch {
     // Try the next boxed primitive brand.
   }
   try {
-    return { value: String.prototype.valueOf.call(value) };
+    String.prototype.valueOf.call(value);
+    return "string";
   } catch {
     // Try the next boxed primitive brand.
   }
   try {
-    return { value: Boolean.prototype.valueOf.call(value) };
+    Boolean.prototype.valueOf.call(value);
+    return "boolean";
   } catch {
     // Try the next boxed primitive brand.
   }
   try {
-    return { value: BigInt.prototype.valueOf.call(value) };
+    BigInt.prototype.valueOf.call(value);
+    return "bigint";
   } catch {
     return null;
   }
 }
 
-/** Serialize once while collecting every value JSON cannot carry unchanged. */
-function serializeAndFindUnrepresentableValues(
+/**
+ * Convert a boxed primitive the way JSON converts it.
+ *
+ * JSON puts a Number box through `ToNumber` and a String box through
+ * `ToString`, and both of those ask the object, so a replaced `valueOf` or a
+ * replaced prototype decides what JSON writes. `Number` and `String` perform
+ * those same two conversions. Reading the slot instead would persist a value
+ * JSON never wrote, which is the one outcome this module has to avoid. A
+ * Boolean box is the case JSON does read straight from the slot.
+ */
+function unboxAsJsonWould(
+  value: JsonTraversalReference,
+  slot: BoxedPrimitiveSlot,
+): string | number | boolean | bigint {
+  if (slot === "number") return Number(value);
+  if (slot === "string") return String(value);
+  if (slot === "boolean") return Boolean.prototype.valueOf.call(value);
+  // JSON refuses a BigInt box outright, and the walk reports it by its path.
+  return BigInt.prototype.valueOf.call(value);
+}
+
+/** Build the exact value JSON will encode, collecting what it cannot carry. */
+function normalizeAndFindUnrepresentableValues(
   root: unknown,
   label: string,
 ): {
-  normalized: NormalizedJsonValue | undefined;
-  serialized: string;
-  unrepresentable: UnrepresentableValue[];
+  normalized: unknown;
+  unrepresentable: UnrepresentableValues;
 } {
-  const found: UnrepresentableValue[] = [];
+  const found: UnrepresentableValues = { fatal: [], lossy: [], fatalCount: 0, lossyCount: 0 };
   const active = new Set<JsonTraversalReference>();
+
+  const recordFatal = (path: string, kind: string) => {
+    found.fatalCount++;
+    if (found.fatal.length < MAX_REPORTED_PATHS) found.fatal.push({ path, kind });
+  };
+
+  // `index` is appended here rather than by the caller, so an array with more
+  // holes than a message can show never builds the paths it would drop.
+  const recordLossy = (path: string, kind: string, index?: number) => {
+    found.lossyCount++;
+    if (found.lossy.length >= MAX_REPORTED_PATHS) return;
+    found.lossy.push({ path: index === undefined ? path : `${path}[${index}]`, kind });
+  };
 
   const normalize = (
     value: unknown,
     path: string,
     key: string,
     applyToJson: boolean,
+    depth: number,
   ): NormalizedJsonValue | typeof OMIT_JSON_VALUE => {
     if (value === null) return null;
 
@@ -174,43 +267,44 @@ function serializeAndFindUnrepresentableValues(
       const toJson = Reflect.get(receiver, "toJSON");
       if (typeof toJson === "function") {
         const replacement = Reflect.apply(toJson, value, [key]);
-        found.push({ path, kind: describeToJsonValue(value), fatal: false });
-        return normalize(replacement, path, key, false);
+        recordLossy(path, describeToJsonValue(value));
+        return normalize(replacement, path, key, false, depth);
       }
     }
 
     if (type === "string" || type === "boolean") return value as string | boolean;
     if (type === "number") {
       if (!Number.isFinite(value)) {
-        found.push({ path, kind: describe(value), fatal: false });
+        recordLossy(path, describe(value));
         return null;
       }
       return value as number;
     }
     if (type === "bigint") {
-      found.push({ path, kind: "BigInt", fatal: true });
+      recordFatal(path, "BigInt");
       return null;
     }
     if (type === "undefined" || type === "function" || type === "symbol") {
-      found.push({ path, kind: describe(value), fatal: false });
+      recordLossy(path, describe(value));
       return OMIT_JSON_VALUE;
     }
 
     const nested = value as JsonTraversalReference;
     if (active.has(nested)) {
-      found.push({ path, kind: "circular reference", fatal: true });
+      recordFatal(path, "circular reference");
       return null;
     }
 
     const isArray = Array.isArray(nested);
     if (!isArray) {
-      const boxed = unboxJsonPrimitive(nested);
-      if (boxed) {
-        found.push({ path, kind: "boxed primitive", fatal: false });
-        return normalize(boxed.value, path, key, false);
+      const slot = boxedPrimitiveSlot(nested);
+      if (slot !== null) {
+        recordLossy(path, "boxed primitive");
+        return normalize(unboxAsJsonWould(nested, slot), path, key, false, depth);
       }
     }
 
+    if (depth >= MAX_TRAVERSAL_DEPTH) throw TRAVERSAL_TOO_DEEP;
     active.add(nested);
     try {
       if (isArray) {
@@ -225,9 +319,7 @@ function serializeAndFindUnrepresentableValues(
           } catch {
             // Hole diagnostics are best-effort; the captured value still wins.
           }
-          if (isHole) {
-            found.push({ path: `${path}[${index}]`, kind: "array hole", fatal: false });
-          }
+          if (isHole) recordLossy(path, "array hole", index);
           if (isHole && child === undefined) {
             result.push(null);
             continue;
@@ -237,6 +329,7 @@ function serializeAndFindUnrepresentableValues(
             `${path}[${index}]`,
             indexKey,
             true,
+            depth + 1,
           );
           result.push(normalized === OMIT_JSON_VALUE ? null : normalized);
         }
@@ -250,32 +343,39 @@ function serializeAndFindUnrepresentableValues(
           `${path}.${redactPathSegment(childKey)}`,
           childKey,
           true,
+          depth + 1,
         );
         if (normalized !== OMIT_JSON_VALUE) result[childKey] = normalized;
       }
       // Prototype diagnostics are best-effort and run after the snapshot is
       // complete, so hostile metadata traps cannot change persistence output.
-      if (!isPlainObject(nested)) {
-        found.push({ path, kind: describe(nested), fatal: false });
-      }
+      if (!isPlainObject(nested)) recordLossy(path, describe(nested));
       return result;
     } finally {
       active.delete(nested);
     }
   };
 
-  const normalized = normalize(root, label, "", true);
-  const normalizedValue = normalized === OMIT_JSON_VALUE ? undefined : normalized;
-  const serialized = JSON.stringify(normalizedValue);
+  let normalized: NormalizedJsonValue | typeof OMIT_JSON_VALUE;
+  try {
+    normalized = normalize(root, label, "", true, 0);
+  } catch (error) {
+    if (error !== TRAVERSAL_TOO_DEEP) throw error;
+    // Nested past what this walk follows. What it found on the way down still
+    // holds, and the rest is left to `JSON.stringify`, which is iterative and
+    // reaches a depth this walk cannot.
+    return { normalized: root, unrepresentable: found };
+  }
 
-  return { normalized: normalizedValue, serialized, unrepresentable: found };
+  return {
+    normalized: normalized === OMIT_JSON_VALUE ? undefined : normalized,
+    unrepresentable: found,
+  };
 }
 
-function formatPaths(values: readonly UnrepresentableValue[]): string {
-  const shown = values.slice(0, MAX_REPORTED_PATHS)
-    .map(({ path, kind }) => `${path} (${kind})`)
-    .join(", ");
-  const remaining = values.length - MAX_REPORTED_PATHS;
+function formatPaths(samples: readonly UnrepresentableValue[], total: number): string {
+  const shown = samples.map(({ path, kind }) => `${path} (${kind})`).join(", ");
+  const remaining = total - samples.length;
   return remaining > 0 ? `${shown}, and ${remaining} more` : shown;
 }
 
@@ -307,32 +407,30 @@ export function prepareWorkflowJson(
   label: string,
   runId?: string,
 ): { normalized: unknown; serialized: string } {
-  const { normalized, serialized, unrepresentable } = serializeAndFindUnrepresentableValues(
-    value,
-    label,
-  );
+  const { normalized, unrepresentable } = normalizeAndFindUnrepresentableValues(value, label);
+  const { fatal, fatalCount, lossy, lossyCount } = unrepresentable;
 
-  const fatal = unrepresentable.filter((entry) => entry.fatal);
-  if (fatal.length > 0) {
+  if (fatalCount > 0) {
     throw ORCHESTRATION_ERROR.create({
-      detail: `Workflow run cannot be persisted: ${formatPaths(fatal)}. Workflow state must be ` +
-        `JSON-representable, because a run that suspends is stored as JSON. Return a plain ` +
-        `object from the step that produced this value.`,
+      detail: `Workflow run cannot be persisted: ${formatPaths(fatal, fatalCount)}. Workflow ` +
+        `state must be JSON-representable, because a run that suspends is stored as JSON. ` +
+        `Return a plain object from the step that produced this value.`,
     });
   }
 
-  const lossy = unrepresentable.filter((entry) => !entry.fatal);
-  if (lossy.length > 0) {
+  if (lossyCount > 0) {
     logger.warn(
       "Workflow state holds values that do not survive persistence unchanged",
       {
         ...(runId ? { runId } : {}),
-        paths: formatPaths(lossy),
+        paths: formatPaths(lossy, lossyCount),
       },
     );
   }
 
-  return { normalized, serialized };
+  // Encoded only once the fatal check has passed, so a value JSON refuses is
+  // named by this module rather than by the anonymous error JSON raises.
+  return { normalized, serialized: JSON.stringify(normalized) };
 }
 
 export function serializeWorkflowJson(value: unknown, label: string, runId?: string): string {

--- a/src/workflow/context-serialization.ts
+++ b/src/workflow/context-serialization.ts
@@ -8,7 +8,7 @@ const logger = agentLogger.component("workflow-context");
 const MAX_REPORTED_PATHS = 5;
 
 /**
- * How deep the walk descends before handing the value back to `JSON.stringify`.
+ * @internal How deep the walk descends before handing the value back to JSON.
  *
  * This walk recurses and `JSON.stringify` does not, so a value nested a few
  * thousand levels deep exhausts the stack here while JSON encodes it without
@@ -17,7 +17,7 @@ const MAX_REPORTED_PATHS = 5;
  * this depth the diagnostic is dropped rather than the run: the value is
  * encoded the way the backend encoded it before this check existed.
  */
-const MAX_TRAVERSAL_DEPTH = 1000;
+export const MAX_TRAVERSAL_DEPTH = 1000;
 
 /** Ends a walk that ran past `MAX_TRAVERSAL_DEPTH`. Never leaves this module. */
 const TRAVERSAL_TOO_DEEP = new Error("workflow value nested deeper than the walk follows");

--- a/src/workflow/context-serialization.ts
+++ b/src/workflow/context-serialization.ts
@@ -19,9 +19,6 @@ const MAX_REPORTED_PATHS = 5;
  */
 export const MAX_TRAVERSAL_DEPTH = 1000;
 
-/** Ends a walk that ran past `MAX_TRAVERSAL_DEPTH`. Never leaves this module. */
-const TRAVERSAL_TOO_DEEP = new Error("workflow value nested deeper than the walk follows");
-
 /**
  * Property names safe to quote verbatim in a diagnostic.
  *
@@ -202,20 +199,25 @@ function boxedPrimitiveSlot(value: JsonTraversalReference): BoxedPrimitiveSlot |
  *
  * JSON puts a Number box through `ToNumber` and a String box through
  * `ToString`, and both of those ask the object, so a replaced `valueOf` or a
- * replaced prototype decides what JSON writes. `Number` and `String` perform
- * those same two conversions. Reading the slot instead would persist a value
- * JSON never wrote, which is the one outcome this module has to avoid. A
- * Boolean box is the case JSON does read straight from the slot.
+ * replaced prototype decides what JSON writes. Reading the slot instead would
+ * persist a value JSON never wrote, which is the one outcome this module has to
+ * avoid. A Boolean box is the case JSON does read straight from the slot.
+ *
+ * `+` and a template literal are used rather than `Number()` and `String()`,
+ * which are close but not the same operations: `Number()` accepts a BigInt that
+ * `ToNumber` refuses, so a `valueOf` returning one would be quietly coerced to a
+ * number here and rejected by JSON. The parameter is `unknown` so each branch
+ * needs one assertion rather than a chain; `slot` is what makes it sound.
  */
 function unboxAsJsonWould(
-  value: JsonTraversalReference,
+  value: unknown,
   slot: BoxedPrimitiveSlot,
 ): string | number | boolean | bigint {
-  if (slot === "number") return Number(value);
-  if (slot === "string") return String(value);
-  if (slot === "boolean") return Boolean.prototype.valueOf.call(value);
+  if (slot === "number") return +(value as number);
+  if (slot === "string") return `${value as string}`;
+  if (slot === "boolean") return Boolean.prototype.valueOf.call(value as boolean);
   // JSON refuses a BigInt box outright, and the walk reports it by its path.
-  return BigInt.prototype.valueOf.call(value);
+  return BigInt.prototype.valueOf.call(value as bigint);
 }
 
 /** Build the exact value JSON will encode, collecting what it cannot carry. */
@@ -304,7 +306,12 @@ function normalizeAndFindUnrepresentableValues(
       }
     }
 
-    if (depth >= MAX_TRAVERSAL_DEPTH) throw TRAVERSAL_TOO_DEEP;
+    // Past the depth this walk follows, the subtree is spliced in as it is and
+    // left to `JSON.stringify`. Handing back the whole root instead would make
+    // every getter and `toJSON` above this point run a second time, and a hook
+    // that answers differently on its second call would then persist a value
+    // this check never saw. Nothing below here is reported, which is the price.
+    if (depth >= MAX_TRAVERSAL_DEPTH) return nested as NormalizedJsonValue;
     active.add(nested);
     try {
       if (isArray) {
@@ -356,16 +363,7 @@ function normalizeAndFindUnrepresentableValues(
     }
   };
 
-  let normalized: NormalizedJsonValue | typeof OMIT_JSON_VALUE;
-  try {
-    normalized = normalize(root, label, "", true, 0);
-  } catch (error) {
-    if (error !== TRAVERSAL_TOO_DEEP) throw error;
-    // Nested past what this walk follows. What it found on the way down still
-    // holds, and the rest is left to `JSON.stringify`, which is iterative and
-    // reaches a depth this walk cannot.
-    return { normalized: root, unrepresentable: found };
-  }
+  const normalized = normalize(root, label, "", true, 0);
 
   return {
     normalized: normalized === OMIT_JSON_VALUE ? undefined : normalized,

--- a/src/workflow/context-serialization.ts
+++ b/src/workflow/context-serialization.ts
@@ -398,8 +398,17 @@ function formatPaths(samples: readonly UnrepresentableValue[], total: number): s
  *   `Date`, decided by whether the run happened to pause.
  *
  * Durable backends serialize context before its duplicate run projections, so
- * this check decides the diagnostic without treating framework-owned metadata
- * such as node timestamps as user-authored lossy values.
+ * this check decides the diagnostic rather than the anonymous error a later
+ * field would raise on the same value.
+ *
+ * Scope, stated plainly because the ordering above is easy to read as more:
+ * only `context` is checked. A run's `input`, `output`, `nodeStates`,
+ * `currentNodes`, and `error` are encoded directly, so nothing here inspects
+ * them. That is deliberate for now: `nodeStates` carries a `Date` on every
+ * node, so checking it would report the framework's own timestamps on every
+ * run. Anything the framework writes into `context` has to obey the same rule
+ * it asks of a step, which is why the loop encodes its child node states
+ * rather than being exempted from the check.
  */
 /** @internal Prepare the exact JSON value and encoded string for durable storage. */
 export function prepareWorkflowJson(

--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -26,6 +26,8 @@ import { StepExecutor, type StepResult } from "../step-executor.ts";
 import { CheckpointManager } from "../checkpoint-manager.ts";
 import type { WorkflowBackend } from "../../backends/types.ts";
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
+import { __subscribeLogRecordEmitter, type LogEntry } from "#veryfront/utils/logger/index.ts";
+import { serializeWorkflowContext } from "../../context-serialization.ts";
 
 const UNRESTRICTED_SOURCE_INTEGRATION_POLICY = normalizeSourceIntegrationPolicy(undefined);
 
@@ -1049,6 +1051,59 @@ describe("DAGExecutor", () => {
       assertEquals(result.waiting, true);
       assertExists(result.nodeStates["before"]);
       assertEquals(result.nodeStates["before"]!.status, "completed");
+    });
+
+    it("persists a suspended iteration's child states without a value JSON rewrites", async () => {
+      // `WorkflowContext` is JSON-representable by contract, and the loop was
+      // writing `NodeState` straight into it, timestamps included. That made
+      // the framework break the rule it asks of a step: the persistence check
+      // reported the loop's own `startedAt` as a user-authored lossy value,
+      // naming a path no step wrote and telling the reader to return a plain
+      // object from it. It also meant a resumed iteration read a string where
+      // the suspending one wrote a `Date`.
+      const nodes: WorkflowNode[] = [
+        {
+          id: "the-loop",
+          dependsOn: [],
+          config: {
+            type: "loop",
+            maxIterations: 2,
+            while: () => true,
+            steps: [
+              { id: "inner", dependsOn: [], config: { type: "step" } as any },
+              {
+                id: "inner-wait",
+                dependsOn: ["inner"],
+                config: { type: "wait", waitType: "approval", message: "approve?" } as any,
+              },
+            ],
+          } as any,
+        },
+      ];
+
+      const result = await executor.execute(nodes, createTestRun());
+
+      assertEquals(result.waiting, true);
+      const loopState = result.context["the-loop_loop_state"] as {
+        iterationNodeStates: Record<string, { startedAt?: unknown }>;
+      };
+      const inner = loopState.iterationNodeStates["inner"];
+      assertExists(inner);
+      assertEquals(typeof inner.startedAt, "string");
+
+      const warnings: LogEntry[] = [];
+      const unsubscribe = __subscribeLogRecordEmitter((entry) => {
+        if (entry.level === "warn" && entry.component === "workflow-context") {
+          warnings.push(entry);
+        }
+      });
+      try {
+        serializeWorkflowContext(result.context);
+      } finally {
+        unsubscribe();
+      }
+
+      assertEquals(warnings, []);
     });
 
     it("runs a step declared after a wait in the same iteration once the wait resolves", async () => {

--- a/src/workflow/executor/dag/index.ts
+++ b/src/workflow/executor/dag/index.ts
@@ -787,10 +787,14 @@ export class DAGExecutor {
     const state: NodeState = {
       nodeId: node.id,
       status: "running",
+      // Absent optional fields are left out rather than written as `undefined`.
+      // A suspended loop stores its child states in the context, where JSON
+      // drops those keys, so writing them had the persistence check report the
+      // framework's own empty fields as user-authored lossy values.
       input: {
         type: config.waitType,
-        message: config.message,
-        payload,
+        ...(config.message !== undefined ? { message: config.message } : {}),
+        ...(payload !== undefined ? { payload } : {}),
       },
       attempt: 1,
       startedAt: new Date(),

--- a/src/workflow/executor/dag/loop-node-strategy.ts
+++ b/src/workflow/executor/dag/loop-node-strategy.ts
@@ -27,10 +27,81 @@ interface ExecuteLoopNodeStrategyInput {
   abortSignal?: AbortSignal;
 }
 
+/**
+ * A `NodeState` in the shape that survives the context's JSON round trip.
+ *
+ * `WorkflowContext` is JSON-representable by contract, and `NodeState` is not:
+ * `startedAt` and `completedAt` are `Date`. Writing them into the context puts
+ * a value there that `JSON.stringify` rewrites, so a resumed iteration read
+ * back a string where the suspending one wrote a `Date`, and the persistence
+ * check reported the framework's own timestamps as user-authored lossy values.
+ *
+ * The encoded bytes are unchanged: `JSON.stringify` already produced these
+ * strings. What changes is that the loop now writes them itself, so the value
+ * in memory matches the value after a resume either way.
+ */
+type PersistedNodeState =
+  & Omit<NodeState, "startedAt" | "completedAt">
+  & {
+    startedAt?: string;
+    completedAt?: string;
+  };
+
 interface PersistedLoopState {
   iteration: number;
   previousResults: unknown[];
-  iterationNodeStates?: Record<string, NodeState>;
+  iterationNodeStates?: Record<string, PersistedNodeState>;
+}
+
+/**
+ * @internal Encode child node states so the context holds nothing JSON rewrites.
+ *
+ * Absent optional fields are dropped rather than written as `undefined`, which
+ * JSON removes anyway. Keeping them would have the check report the framework's
+ * own empty fields as lossy. `input` and `output` are copied through untouched:
+ * they hold step values, and a step writing something JSON cannot carry is
+ * exactly what the check exists to report.
+ */
+export function toPersistedNodeStates(
+  states: Record<string, NodeState>,
+): Record<string, PersistedNodeState> {
+  const persisted: Record<string, PersistedNodeState> = {};
+  for (const [nodeId, state] of Object.entries(states)) {
+    persisted[nodeId] = {
+      nodeId: state.nodeId,
+      status: state.status,
+      attempt: state.attempt,
+      ...(state.input !== undefined ? { input: state.input } : {}),
+      ...(state.output !== undefined ? { output: state.output } : {}),
+      ...(state.error !== undefined ? { error: state.error } : {}),
+      ...(state.startedAt ? { startedAt: state.startedAt.toISOString() } : {}),
+      ...(state.completedAt ? { completedAt: state.completedAt.toISOString() } : {}),
+    };
+  }
+  return persisted;
+}
+
+/**
+ * Restore child node states read back from the context.
+ *
+ * A run that suspended before this encoding existed holds the same strings,
+ * because `JSON.stringify` is what wrote them, so no migration is needed. This
+ * is also what makes a resumed iteration see the same types an in-memory one
+ * sees, rather than a `Date` on one path and a string on the other.
+ */
+function fromPersistedNodeStates(
+  states: Record<string, PersistedNodeState>,
+): Record<string, NodeState> {
+  const restored: Record<string, NodeState> = {};
+  for (const [nodeId, state] of Object.entries(states)) {
+    const { startedAt, completedAt, ...rest } = state;
+    restored[nodeId] = {
+      ...rest,
+      ...(startedAt ? { startedAt: new Date(startedAt) } : {}),
+      ...(completedAt ? { completedAt: new Date(completedAt) } : {}),
+    };
+  }
+  return restored;
 }
 
 export async function executeLoopNodeStrategy(
@@ -58,7 +129,8 @@ export async function executeLoopNodeStrategy(
   if (existingLoopState) {
     iteration = existingLoopState.iteration;
     previousResults.push(...existingLoopState.previousResults);
-    resumeIterationNodeStates = existingLoopState.iterationNodeStates;
+    resumeIterationNodeStates = existingLoopState.iterationNodeStates &&
+      fromPersistedNodeStates(existingLoopState.iterationNodeStates);
     resumeIteration = existingLoopState.iteration;
   }
 
@@ -142,7 +214,7 @@ export async function executeLoopNodeStrategy(
               previousResults,
               // Persist the in-flight iteration's child states so completed
               // steps are not re-executed when this iteration resumes (H9).
-              iterationNodeStates: result.nodeStates,
+              iterationNodeStates: toPersistedNodeStates(result.nodeStates),
             },
           }),
         ),


### PR DESCRIPTION
## What this is

Follow-up to #3926, squash-merged as `42383dbb17`.

#3926 is a real improvement and this is not an argument against it. Workflow state was declared JSON-representable and nothing enforced it, so a run that never suspended kept values a persisted run would silently rewrite, and the failure surfaced as `Do not know how to serialize a BigInt` raised from inside the backend with nothing pointing back at the step. Making that legible at the persistence boundary is the right call, and the module it added is careful work.

Enforcing the rule meant walking the value rather than delegating to `JSON.stringify`, and the walk drifted from it in three ways. Two more defects come from the framework not obeying the rule the module now enforces. All five are on `main`.

Each is verified against a clean `origin/main` checkout, with the test files applied on their own so they go red before the fix.

## Defect 1: a value JSON never wrote is persisted

`unboxJsonPrimitive` read the internal primitive slot. JSON does not: it puts a Number box through `ToNumber` and a String box through `ToString`, and both of those ask the object, so a replaced `valueOf` or a replaced prototype decides what JSON writes.

```
new Number(7) reparented to Object.prototype    JSON.stringify: null      module: 7
new Number(8) reparented to null                JSON.stringify: throws    module: 8
```

This is the worst of the five. The module exists to make persistence honest, and as merged it silently writes a value `JSON.stringify` never produced into durable storage. That is worse than the raw error it replaced, because nothing reports it.

`boxedPrimitiveSlot` now only says which slot is present, and `unboxAsJsonWould` performs the conversion JSON performs.

## Defect 2: unbounded recursion, on a path that used to be safe

The walk recurses far more heavily than `JSON.stringify`, so it runs out of stack first.

```
maximum nesting that encodes, same process, Deno
  JSON.stringify   200,000 or more
  the walk         3,125, then RangeError: Maximum call stack size exceeded
```

A `RangeError` escaping from inside the backend is the exact error class this module was written to eliminate, and it now fires on values that persisted fine before. Past `MAX_TRAVERSAL_DEPTH` the walk hands the value back to `JSON.stringify`, keeping every diagnostic it found on the way down.

`JSON.stringify` is itself stack bound, so its own ceiling is not a fixed number: 200,000 at the top level under Deno, 10,000 under `node --test` locally, and under 5,000 on the CI runner. The gap over the walk is what matters, and the tests are written so they do not depend on either figure. See the note at the end.

## Defect 3: about 42x slower on every persist

The four slot probes each throw on a miss, and a context is almost entirely objects that miss all four, so an ordinary object cost four thrown exceptions on the path every persisted run takes.

Workload: five encodings of a context holding 5,000 rows of `{ id, name, tags: ["a", "b"], nested: { ok, when } }`, which is 10,000 objects and 5,000 arrays per encoding. One machine, one process, all three measured in the same run:

```
before  6219ms        after  147ms        JSON.stringify  11ms
```

`Object.prototype.toString` reports the same internal slots without throwing. It stops being trustworthy only when the value carries a `Symbol.toStringTag`, which anything can set, so a value that has one still falls through to the probes and the existing spoofing test still passes.

Also fixed alongside it: diagnostics were retained one per finding, so a 500,000 hole array held 116MB of paths that no message would ever show. Each side now keeps `MAX_REPORTED_PATHS` samples and counts the rest, so the count a message quotes stays exact.

## Defect 4: every suspended loop iteration warns, blaming a step that wrote nothing

Found by the agent auditing #3930 and reproduced here independently on `origin/main`.

A loop that suspends mid-iteration persists a whole `Record<string, NodeState>` inside the context, at `loop-node-strategy.ts:143`. `NodeState.startedAt` and `completedAt` are `Date`, and that path does reach the check:

```
warn workflow-context "Workflow state holds values that do not survive persistence unchanged"
  paths: context.the_loop_loop_state.iterationNodeStates.<redacted>.startedAt (Date)
```

So any workflow with a `wait` inside a `loop` warns on a completely correct path, and the message tells the reader to "return a plain object from the step that produced this value" about a timestamp the framework itself wrote. The child node id is `<redacted>` because it contains a hyphen, so the path does not even name which node. The wait strategy has the same problem in a smaller way: it wrote `message` and `payload` as `undefined` into its own node input, and JSON drops those keys.

The fix holds the framework to the rule it asks of a step, rather than exempting it. The loop encodes the timestamps and omits absent optional fields. **The encoded bytes do not change**, because `JSON.stringify` already produced these strings, so a run suspended before this needs no migration. What changes is that a resumed iteration and an in-memory one now see the same types instead of a string on one path and a `Date` on the other, which is the divergence #3926's own doc comment complains about.

`input` and `output` are copied through untouched. They hold step values, and a step writing something JSON cannot carry is what the check exists to report.

**On exempting the subtree instead**, which was the other candidate. It is worse on two counts. It keys the carve-out on where data lives rather than on who owns it, which is the shape of the original defect. And `_loop_state.previousResults` holds `result.context` for every completed iteration, which is user step output, so exempting the subtree would blind the check to exactly the data it exists to check.

## Defect 5: the warning cannot be traced to a run

`serializeRun` passes the run id. `serializeRunPatch` did not, and both of its call sites had one in scope. Patches are where warnings actually fire, because creation usually writes only `input` while patches write the accumulated node outputs. Combined with defect 4, the production signature was an unattributable warning once per suspended loop iteration.

`runId` is now threaded through `serializeRunPatch` and passed at both call sites.

## Two claims corrected rather than implemented

`prepareWorkflowJson`'s doc comment said the check decided the diagnostic "without treating framework-owned metadata such as node timestamps as user-authored lossy values". There is no such predicate anywhere in the code. The claim held only because `nodeStates` bypasses the check entirely. The comment now states the real scope: `context` is checked, and `input`, `output`, `nodeStates`, `currentNodes`, and `error` are not.

**I chose not to widen the check to those five fields here.** `nodeStates` carries a `Date` on every node of every run, so checking it would warn on every run until `NodeState` persistence is reworked. That is a larger change and belongs on its own. Saying so in the comment is the part that could not wait, because a comment asserting a guarantee the code does not provide is the same dishonesty this module was written to remove.

`redis/index.test.ts`'s "does not warn about framework-owned node timestamps" is removed. It asserted the carve-out through top-level `nodeStates`, which is encoded directly and never reaches the check, so it held whether the claim was true or false. It was a green gate that had never been red. The behaviour it meant to cover is now tested end to end through the executor, on a test that fails without this change.

## Fail-first evidence

Test files applied alone to a clean `origin/main` checkout:

```
converts a boxed primitive the way JSON converts it, through the object ... FAILED
    Actual / Expected     { total: 7, }  vs  { total: null, }
does not probe primitive slots on an ordinary object ... FAILED
    Actual / Expected     5  vs  0
hands a value deeper than the walk follows back to JSON.stringify ... FAILED
    reports  context.step.n.n.n. ... .n.when (Date)  where nothing should be reported
still names a fatal value found above the depth it stops at ... FAILED
    the deep BigInt is named alongside the shallow one
counts every hole in a sparse array without keeping one entry each ... FAILED
persists a suspended iteration's child states without a value JSON rewrites ... FAILED
    Actual / Expected     object  vs  string
names the run when a patch persists a lossy value ... FAILED
    Actual / Expected     undefined  vs  "run-patch-warning"
```

**One new test is a drift guard, not a proof, and passes on `main` too.** It encodes 3,000 seeded generated values and compares them byte for byte against `JSON.stringify`. Its generator does not build a reparented box, so it does not catch defect 1. It is here because this module walks the value itself and can drift again, and a drift writes into durable storage something JSON never wrote. Run separately at 20,000 values while preparing this, all byte identical, plus 15 hand-built boxed-primitive cases including the two that diverge on `main`.

## Gates

Run after the last edit, each redirected to a file with its exit code echoed rather than piped.

```
deno fmt --check src/workflow/                            EXIT=0
deno task typecheck                                       EXIT=0
deno test ... --ignore=src/workflow/blob src/workflow/     EXIT=0
deno task lint:ci                                          EXIT=0
```

`src/workflow/blob/veryfront-cloud-storage.test.ts` is excluded because it makes real outbound requests that the sandbox here blocks at the SOCKS layer. It is untouched by this work and fails identically on `origin/main`.

`lint:ci` caught two real problems in the first draft of this change, a chained type assertion and a `noUncheckedIndexedAccess` violation. Both are fixed.

## One note on the static-analysis threads from #3926

CodeQL alert 296 asked for the `value === null` guard in `isPlainObject` to be deleted. Applying that suggestion as written would have introduced a crash: `typeof null === "object"`, so `null` would then have reached `Object.getPrototypeOf(null)`, which throws. The alert was still correct that the guard was unreachable, and #3926 resolved it the safe way by typing the parameter as the non-null reference every caller already holds. Worth recording, because it is a case where resolving a static-analysis thread by applying its own suggested fix would have shipped a bug.


## A note on the two runtime suites

The first push of this branch failed `tests (bun)` and `tests (node)`, both on the new tests rather than on the module. Recorded here because both are the kind of thing that is easy to paper over:

**JavaScriptCore skips a non-enumerable own `toJSON` that V8 calls.** JSON reads `toJSON` with an ordinary get, so enumerability should not enter into it, which makes this a JavaScriptCore deviation. The differential generator was producing that case, so it was comparing two engines against each other instead of comparing this module against its own host. The generator now makes `toJSON` enumerable and says why.

```
                                          Deno / Node        Bun
plain enumerable toJSON                   {"replaced":true}  {"replaced":true}
defineProperty default, non-enumerable    {"replaced":true}  {}
```

**The depth tests were testing the host.** They asserted that a 5,000 level value encodes, which `JSON.stringify` itself could not do on the CI runner. Both tests now nest just past `MAX_TRAVERSAL_DEPTH` and prove the walk stopped by behaviour rather than by surviving a stack overflow: a `Date` sits below the depth the walk follows, so a walk that reached it would report it, and the assertion is that nothing is reported while the value still encodes to exactly what `JSON.stringify` produces. Deriving the depth from the constant also keeps them from going quiet if the limit is raised, which is the failure mode of the carve-out test removed above.

Verified on all three runtimes before the second push: `deno test`, `tests/node/run-tests.mjs`, and `tests/bun/run-tests.mjs` over the three changed test files.
