### PR TITLE
test: one way to control outbound fetch, and it cannot fail open

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,10 +46,17 @@ rewrites them even when nothing changed, and committing that output turns CI red
 for everyone. `deno task docs` refuses to run on the wrong version rather than
 producing a plausible-looking diff.
 
-Use these tasks rather than a hand-written `deno test` command. They set `DENO_TESTING=1` and
-deny network access to the LLM provider origins. Without both, a test that stubs
-`globalThis.fetch` is ignored by the outbound fetch guard (`src/security/http/outbound-fetch.ts`)
-and issues a real request to a live provider, failing with a confusing 401 or 405.
+Use these tasks rather than a hand-written `deno test` command; they deny network access to
+the LLM provider origins.
+
+To control outbound HTTP in a test, use `src/testing/mock-fetch.ts` -- `withMockFetch(mock, fn)`
+where the stub has a callback to scope, or the `installMockFetch` / `restoreMockFetch` pair for
+suites that install per test and tear down in `afterEach`. Both move `globalThis.fetch` and the
+host transport in `src/security/http/outbound-fetch.ts` together.
+
+Assigning `globalThis.fetch` by hand controls only code that calls `fetch` directly. Anything
+routed through `guardedOutboundFetch` reads the host transport instead, so a hand-assigned stub
+is ignored there and the request reaches the live endpoint, failing with a confusing 401 or 405.
 
 ## Public copy rules
 

--- a/cli/commands/schedule/handler.test.ts
+++ b/cli/commands/schedule/handler.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import {
   assertEquals,
   assertInstanceOf,
@@ -26,7 +27,6 @@ import {
 } from "./handler.ts";
 
 const originalExit = Deno.exit;
-const originalFetch = globalThis.fetch;
 const originalConsoleLog = console.log;
 const environmentNames = [
   "VERYFRONT_API_URL",
@@ -131,7 +131,7 @@ describe("schedule command", () => {
     // for it outside a turn would yank it from whichever test file holds it now.
     // deno-lint-ignore no-explicit-any
     (Deno as any).exit = originalExit;
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
     console.log = originalConsoleLog;
     setJsonMode(false);
     restoreEnvironment();
@@ -194,20 +194,22 @@ describe("schedule command", () => {
       _resetEnvironmentConfig();
       setJsonMode(true);
       console.log = (...args: unknown[]) => output.push(args.map(String).join(" "));
-      globalThis.fetch = (async (
-        input: string | URL | Request,
-        init?: RequestInit,
-      ) => {
-        const url = typeof input === "string"
-          ? input
-          : input instanceof URL
-          ? input.toString()
-          : input.url;
-        requests.push({ url, init });
-        const response = responses.shift();
-        if (!response) throw new Error(`Unexpected request: ${url}`);
-        return response;
-      }) as typeof fetch;
+      installMockFetch(
+        (async (
+          input: string | URL | Request,
+          init?: RequestInit,
+        ) => {
+          const url = typeof input === "string"
+            ? input
+            : input instanceof URL
+            ? input.toString()
+            : input.url;
+          requests.push({ url, init });
+          const response = responses.shift();
+          if (!response) throw new Error(`Unexpected request: ${url}`);
+          return response;
+        }) as typeof fetch,
+      );
       // deno-lint-ignore no-explicit-any
       (Deno as any).exit = (code = 0) => {
         throw new ExitSentinel(code);

--- a/src/cache/backend.test.ts
+++ b/src/cache/backend.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 /**
  * Cache Backend Tests
  *
@@ -466,14 +467,13 @@ Deno.test("ApiCacheBackend enforces exact bounded decoded values", async () => {
   const { ApiCacheBackend, CacheValueTooLargeError } = await importBackend();
   const globals = globalThis as Record<string, unknown>;
   const originalAdapter = globals.__vf_multi_project_adapter;
-  const originalFetch = globalThis.fetch;
   globals.__vf_multi_project_adapter = {
     getCurrentRequestContext: () => ({
       token: "request-token",
       projectSlug: "project-slug",
     }),
   };
-  globalThis.fetch = (() => Promise.resolve(Response.json({ value: "é" }))) as typeof fetch;
+  installMockFetch((() => Promise.resolve(Response.json({ value: "é" }))) as typeof fetch);
 
   try {
     const cache = new ApiCacheBackend({
@@ -490,7 +490,7 @@ Deno.test("ApiCacheBackend enforces exact bounded decoded values", async () => {
   } finally {
     if (originalAdapter === undefined) delete globals.__vf_multi_project_adapter;
     else globals.__vf_multi_project_adapter = originalAdapter;
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
   }
 });
 
@@ -498,7 +498,6 @@ Deno.test("ApiCacheBackend reserves JSON escape bytes outside its response polic
   const { ApiCacheBackend } = await importBackend();
   const globals = globalThis as Record<string, unknown>;
   const originalAdapter = globals.__vf_multi_project_adapter;
-  const originalFetch = globalThis.fetch;
   const body = '{"value":"\\u0000\\u0000"}';
   assertEquals(new TextEncoder().encode(body).byteLength, 24);
   globals.__vf_multi_project_adapter = {
@@ -507,7 +506,7 @@ Deno.test("ApiCacheBackend reserves JSON escape bytes outside its response polic
       projectSlug: "project-slug",
     }),
   };
-  globalThis.fetch = (() => Promise.resolve(new Response(body))) as typeof fetch;
+  installMockFetch((() => Promise.resolve(new Response(body))) as typeof fetch);
 
   try {
     const cache = new ApiCacheBackend({
@@ -522,7 +521,7 @@ Deno.test("ApiCacheBackend reserves JSON escape bytes outside its response polic
   } finally {
     if (originalAdapter === undefined) delete globals.__vf_multi_project_adapter;
     else globals.__vf_multi_project_adapter = originalAdapter;
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
   }
 });
 
@@ -530,7 +529,6 @@ Deno.test("ApiCacheBackend keeps unused string headroom outside its response pol
   const { ApiCacheBackend } = await importBackend();
   const globals = globalThis as Record<string, unknown>;
   const originalAdapter = globals.__vf_multi_project_adapter;
-  const originalFetch = globalThis.fetch;
   const body = '{"value":"","x":0}';
   let fetchCalls = 0;
   assertEquals(new TextEncoder().encode(body).byteLength, 18);
@@ -540,10 +538,12 @@ Deno.test("ApiCacheBackend keeps unused string headroom outside its response pol
       projectSlug: "project-slug",
     }),
   };
-  globalThis.fetch = (() => {
-    fetchCalls++;
-    return Promise.resolve(new Response(body));
-  }) as typeof fetch;
+  installMockFetch(
+    (() => {
+      fetchCalls++;
+      return Promise.resolve(new Response(body));
+    }) as typeof fetch,
+  );
 
   try {
     const cache = new ApiCacheBackend({
@@ -559,7 +559,7 @@ Deno.test("ApiCacheBackend keeps unused string headroom outside its response pol
   } finally {
     if (originalAdapter === undefined) delete globals.__vf_multi_project_adapter;
     else globals.__vf_multi_project_adapter = originalAdapter;
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
   }
 });
 
@@ -567,7 +567,6 @@ Deno.test("ApiCacheBackend rejects unsafe combined response limits before fetchi
   const { ApiCacheBackend } = await importBackend();
   const globals = globalThis as Record<string, unknown>;
   const originalAdapter = globals.__vf_multi_project_adapter;
-  const originalFetch = globalThis.fetch;
   let fetchCalls = 0;
   globals.__vf_multi_project_adapter = {
     getCurrentRequestContext: () => ({
@@ -575,10 +574,12 @@ Deno.test("ApiCacheBackend rejects unsafe combined response limits before fetchi
       projectSlug: "project-slug",
     }),
   };
-  globalThis.fetch = (() => {
-    fetchCalls++;
-    return Promise.resolve(Response.json({ value: "small" }));
-  }) as typeof fetch;
+  installMockFetch(
+    (() => {
+      fetchCalls++;
+      return Promise.resolve(Response.json({ value: "small" }));
+    }) as typeof fetch,
+  );
 
   try {
     const cache = new ApiCacheBackend({
@@ -596,7 +597,7 @@ Deno.test("ApiCacheBackend rejects unsafe combined response limits before fetchi
   } finally {
     if (originalAdapter === undefined) delete globals.__vf_multi_project_adapter;
     else globals.__vf_multi_project_adapter = originalAdapter;
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
   }
 });
 
@@ -604,7 +605,6 @@ Deno.test("ApiCacheBackend rejects oversized escaped values before JSON.parse", 
   const { ApiCacheBackend, CacheValueTooLargeError } = await importBackend();
   const globals = globalThis as Record<string, unknown>;
   const originalAdapter = globals.__vf_multi_project_adapter;
-  const originalFetch = globalThis.fetch;
   const originalJsonParse = JSON.parse;
   let parseCalls = 0;
   globals.__vf_multi_project_adapter = {
@@ -613,10 +613,12 @@ Deno.test("ApiCacheBackend rejects oversized escaped values before JSON.parse", 
       projectSlug: "project-slug",
     }),
   };
-  globalThis.fetch = (() =>
-    Promise.resolve(
-      new Response(JSON.stringify({ value: "\0".repeat(1_000) })),
-    )) as typeof fetch;
+  installMockFetch(
+    (() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ value: "\0".repeat(1_000) })),
+      )) as typeof fetch,
+  );
   JSON.parse = ((...args: Parameters<typeof JSON.parse>) => {
     parseCalls++;
     return Reflect.apply(originalJsonParse, JSON, args);
@@ -638,7 +640,7 @@ Deno.test("ApiCacheBackend rejects oversized escaped values before JSON.parse", 
     JSON.parse = originalJsonParse;
     if (originalAdapter === undefined) delete globals.__vf_multi_project_adapter;
     else globals.__vf_multi_project_adapter = originalAdapter;
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
   }
 });
 
@@ -646,7 +648,6 @@ Deno.test("ApiCacheBackend bounded overflows do not open the dependency circuit"
   const { ApiCacheBackend, CacheValueTooLargeError } = await importBackend();
   const globals = globalThis as Record<string, unknown>;
   const originalAdapter = globals.__vf_multi_project_adapter;
-  const originalFetch = globalThis.fetch;
   let fetchCalls = 0;
   globals.__vf_multi_project_adapter = {
     getCurrentRequestContext: () => ({
@@ -654,10 +655,12 @@ Deno.test("ApiCacheBackend bounded overflows do not open the dependency circuit"
       projectSlug: "project-slug",
     }),
   };
-  globalThis.fetch = (() => {
-    fetchCalls++;
-    return Promise.resolve(new Response(JSON.stringify({ value: "xx" })));
-  }) as typeof fetch;
+  installMockFetch(
+    (() => {
+      fetchCalls++;
+      return Promise.resolve(new Response(JSON.stringify({ value: "xx" })));
+    }) as typeof fetch,
+  );
 
   try {
     const cache = new ApiCacheBackend({
@@ -675,7 +678,7 @@ Deno.test("ApiCacheBackend bounded overflows do not open the dependency circuit"
   } finally {
     if (originalAdapter === undefined) delete globals.__vf_multi_project_adapter;
     else globals.__vf_multi_project_adapter = originalAdapter;
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
   }
 });
 
@@ -704,17 +707,18 @@ Deno.test("ApiCacheBackend propagates attempted delete failures", async () => {
   const { ApiCacheBackend } = await importBackend();
   const globals = globalThis as Record<string, unknown>;
   const originalAdapter = globals.__vf_multi_project_adapter;
-  const originalFetch = globalThis.fetch;
   const originalToken = Deno.env.get("VERYFRONT_API_TOKEN");
 
   Deno.env.set("VERYFRONT_API_TOKEN", "host-framework-token");
   globals.__vf_multi_project_adapter = {
     getCurrentRequestContext: () => ({ projectSlug: "project-slug" }),
   };
-  globalThis.fetch = (() =>
-    Promise.resolve(
-      new Response("cache unavailable", { status: 503 }),
-    )) as typeof fetch;
+  installMockFetch(
+    (() =>
+      Promise.resolve(
+        new Response("cache unavailable", { status: 503 }),
+      )) as typeof fetch,
+  );
 
   try {
     const cache = new ApiCacheBackend({
@@ -731,7 +735,7 @@ Deno.test("ApiCacheBackend propagates attempted delete failures", async () => {
     } else {
       globals.__vf_multi_project_adapter = originalAdapter;
     }
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
     if (originalToken === undefined) {
       Deno.env.delete("VERYFRONT_API_TOKEN");
     } else {
@@ -784,7 +788,6 @@ Deno.test("ApiCacheBackend safely maps query-aware keys without logging key-deri
   const { ApiCacheBackend } = await importBackend();
   const globals = globalThis as Record<string, unknown>;
   const originalAdapter = globals.__vf_multi_project_adapter;
-  const originalFetch = globalThis.fetch;
   const originalWarn = console.warn;
   const requests: Array<{ url: string; body: Record<string, unknown> | null }> = [];
   const warnings: string[] = [];
@@ -798,24 +801,26 @@ Deno.test("ApiCacheBackend safely maps query-aware keys without logging key-deri
   console.warn = (...args: unknown[]) => {
     warnings.push(args.map(String).join(" "));
   };
-  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
-    const url = String(input);
-    requests.push({
-      url,
-      body: init?.body ? JSON.parse(String(init.body)) : null,
-    });
-    const response = url.includes("/get-batch")
-      ? { values: {} }
-      : url.includes("/get?")
-      ? { value: null }
-      : {};
-    return Promise.resolve(
-      new Response(JSON.stringify(response), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
-    );
-  }) as typeof fetch;
+  installMockFetch(
+    ((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      requests.push({
+        url,
+        body: init?.body ? JSON.parse(String(init.body)) : null,
+      });
+      const response = url.includes("/get-batch")
+        ? { values: {} }
+        : url.includes("/get?")
+        ? { value: null }
+        : {};
+      return Promise.resolve(
+        new Response(JSON.stringify(response), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    }) as typeof fetch,
+  );
 
   try {
     const cache = new ApiCacheBackend({
@@ -878,7 +883,7 @@ Deno.test("ApiCacheBackend safely maps query-aware keys without logging key-deri
     } else {
       globals.__vf_multi_project_adapter = originalAdapter;
     }
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
     console.warn = originalWarn;
   }
 });
@@ -887,7 +892,6 @@ Deno.test("ApiCacheBackend bounds long keys and refuses malformed delete pattern
   const { ApiCacheBackend } = await importBackend();
   const globals = globalThis as Record<string, unknown>;
   const originalAdapter = globals.__vf_multi_project_adapter;
-  const originalFetch = globalThis.fetch;
   const requests: Array<{ url: string; body: Record<string, unknown> | null }> = [];
 
   globals.__vf_multi_project_adapter = {
@@ -896,18 +900,20 @@ Deno.test("ApiCacheBackend bounds long keys and refuses malformed delete pattern
       projectSlug: "project-slug",
     }),
   };
-  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
-    requests.push({
-      url: String(input),
-      body: init?.body ? JSON.parse(String(init.body)) : null,
-    });
-    return Promise.resolve(
-      new Response("{}", {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
-    );
-  }) as typeof fetch;
+  installMockFetch(
+    ((input: RequestInfo | URL, init?: RequestInit) => {
+      requests.push({
+        url: String(input),
+        body: init?.body ? JSON.parse(String(init.body)) : null,
+      });
+      return Promise.resolve(
+        new Response("{}", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    }) as typeof fetch,
+  );
 
   try {
     const cache = new ApiCacheBackend({
@@ -941,7 +947,7 @@ Deno.test("ApiCacheBackend bounds long keys and refuses malformed delete pattern
     } else {
       globals.__vf_multi_project_adapter = originalAdapter;
     }
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
   }
 });
 
@@ -949,7 +955,6 @@ Deno.test("ApiCacheBackend URL-encodes project refs and omits cache keys from sp
   const { ApiCacheBackend } = await importBackend();
   const globals = globalThis as Record<string, unknown>;
   const originalAdapter = globals.__vf_multi_project_adapter;
-  const originalFetch = globalThis.fetch;
   const records: RecordedSpan[] = [];
   const projectRef = "team/../../demo?token=raw";
   let capturedUrl = "";
@@ -961,15 +966,17 @@ Deno.test("ApiCacheBackend URL-encodes project refs and omits cache keys from sp
       projectSlug: projectRef,
     }),
   };
-  globalThis.fetch = ((input: RequestInfo | URL) => {
-    capturedUrl = String(input);
-    return Promise.resolve(
-      new Response(JSON.stringify({ value: null }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
-    );
-  }) as typeof fetch;
+  installMockFetch(
+    ((input: RequestInfo | URL) => {
+      capturedUrl = String(input);
+      return Promise.resolve(
+        new Response(JSON.stringify({ value: null }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    }) as typeof fetch,
+  );
 
   try {
     const cache = new ApiCacheBackend({
@@ -1010,7 +1017,7 @@ Deno.test("ApiCacheBackend URL-encodes project refs and omits cache keys from sp
     } else {
       globals.__vf_multi_project_adapter = originalAdapter;
     }
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
     _resetShimForTests();
   }
 });
@@ -1019,7 +1026,6 @@ Deno.test("ApiCacheBackend uses the credential paired with an explicit endpoint"
   const { ApiCacheBackend } = await importBackend();
   const globals = globalThis as Record<string, unknown>;
   const originalAdapter = globals.__vf_multi_project_adapter;
-  const originalFetch = globalThis.fetch;
   const originalToken = Deno.env.get("VERYFRONT_API_TOKEN");
   const capturedAuthorizations: string[] = [];
   const capturedUrls: string[] = [];
@@ -1033,16 +1039,18 @@ Deno.test("ApiCacheBackend uses the credential paired with an explicit endpoint"
       projectSlug: "forged-project-slug",
     }),
   };
-  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
-    capturedUrls.push(String(input));
-    capturedAuthorizations.push(new Headers(init?.headers).get("authorization") ?? "");
-    return Promise.resolve(
-      new Response(JSON.stringify({ deleted: 3 }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      }),
-    );
-  }) as typeof fetch;
+  installMockFetch(
+    ((input: RequestInfo | URL, init?: RequestInit) => {
+      capturedUrls.push(String(input));
+      capturedAuthorizations.push(new Headers(init?.headers).get("authorization") ?? "");
+      return Promise.resolve(
+        new Response(JSON.stringify({ deleted: 3 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    }) as typeof fetch,
+  );
 
   try {
     const cache = new ApiCacheBackend({
@@ -1110,7 +1118,7 @@ Deno.test("ApiCacheBackend uses the credential paired with an explicit endpoint"
     } else {
       globals.__vf_multi_project_adapter = originalAdapter;
     }
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
     if (originalToken === undefined) {
       Deno.env.delete("VERYFRONT_API_TOKEN");
     } else {
@@ -1658,7 +1666,6 @@ Deno.test({
     const originalAdapter = globals.__vf_multi_project_adapter;
     const originalProjectEnvGetter = globals.__vfProjectEnvGetter;
     const originalProjectEnvActiveChecker = globals.__vfProjectEnvActiveChecker;
-    const originalFetch = globalThis.fetch;
     const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
     const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
     const capturedUrls: string[] = [];
@@ -1671,12 +1678,14 @@ Deno.test({
     globals.__vf_multi_project_adapter = {
       getCurrentRequestContext: () => ({ projectId: "project-123" }),
     };
-    globalThis.fetch = ((input: RequestInfo | URL) => {
-      capturedUrls.push(String(input));
-      return Promise.resolve(
-        Response.json({ deleted: 1 }),
-      );
-    }) as typeof fetch;
+    installMockFetch(
+      ((input: RequestInfo | URL) => {
+        capturedUrls.push(String(input));
+        return Promise.resolve(
+          Response.json({ deleted: 1 }),
+        );
+      }) as typeof fetch,
+    );
 
     try {
       const cache = new ApiCacheBackend({
@@ -1697,7 +1706,7 @@ Deno.test({
       } else {
         globals.__vfProjectEnvActiveChecker = originalProjectEnvActiveChecker;
       }
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
       if (originalApiBaseUrl === undefined) Deno.env.delete("VERYFRONT_API_BASE_URL");
       else Deno.env.set("VERYFRONT_API_BASE_URL", originalApiBaseUrl);
       if (originalApiToken === undefined) Deno.env.delete("VERYFRONT_API_TOKEN");

--- a/src/embedding/embedding.test.ts
+++ b/src/embedding/embedding.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { deleteEnv, setEnv } from "#veryfront/compat/process.ts";
@@ -7,10 +8,8 @@ import { embedding } from "./embedding.ts";
 import { clearEmbeddingProviders, registerEmbeddingProvider } from "./resolve.ts";
 
 describe("embedding", () => {
-  const originalFetch = globalThis.fetch;
-
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
     deleteEnv("GOOGLE_API_KEY");
     deleteEnv("GOOGLE_GENERATIVE_AI_API_KEY");
     deleteEnv("GOOGLE_GEMINI_BASE_URL");
@@ -79,17 +78,22 @@ describe("embedding", () => {
     let guardedCalls = 0;
     let replacedGlobalCalls = 0;
     let requestedApiKey: string | null = null;
-    globalThis.fetch = (async (input: URL | Request | string, init?: RequestInit) => {
-      guardedCalls++;
-      const request = new Request(input, init);
-      requestedApiKey = request.headers.get("x-goog-api-key");
-      return Response.json({
-        embedding: { values: [0.25, 0.75] },
-        usageMetadata: { promptTokenCount: 2 },
-      });
-    }) as typeof fetch;
+    installMockFetch(
+      (async (input: URL | Request | string, init?: RequestInit) => {
+        guardedCalls++;
+        const request = new Request(input, init);
+        requestedApiKey = request.headers.get("x-goog-api-key");
+        return Response.json({
+          embedding: { values: [0.25, 0.75] },
+          usageMetadata: { promptTokenCount: 2 },
+        });
+      }) as typeof fetch,
+    );
 
     const embedder = embedding({ model: "google/gemini-embedding-001" });
+    // Deliberately a raw global assignment, not another install: the point of
+    // this test is that the transport captured at construction wins over
+    // whatever tenant code later does to globalThis.fetch.
     globalThis.fetch = (() => {
       replacedGlobalCalls++;
       return Promise.resolve(new Response("unexpected", { status: 500 }));
@@ -110,13 +114,15 @@ describe("embedding", () => {
     setEnv("GOOGLE_GEMINI_BASE_URL", "https://example.com/gemini/v1beta");
     let requestedUrl = "";
 
-    globalThis.fetch = (async (input: URL | Request | string, init?: RequestInit) => {
-      requestedUrl = new Request(input, init).url;
-      return Response.json({
-        embedding: { values: [0.5] },
-        usageMetadata: { promptTokenCount: 1 },
-      });
-    }) as typeof fetch;
+    installMockFetch(
+      (async (input: URL | Request | string, init?: RequestInit) => {
+        requestedUrl = new Request(input, init).url;
+        return Response.json({
+          embedding: { values: [0.5] },
+          usageMetadata: { promptTokenCount: 1 },
+        });
+      }) as typeof fetch,
+    );
 
     const embedder = embedding({ model: "google/gemini-embedding-001" });
     assertEquals(await embedder.embed("hello"), [0.5]);

--- a/src/oauth/handlers/callback-dispatcher.test.ts
+++ b/src/oauth/handlers/callback-dispatcher.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { assertEquals, assertThrows } from "#std/assert";
 import { createTestEnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import {
@@ -91,12 +92,13 @@ Deno.test("callback dispatcher exchanges and stores tokens for the state-selecte
   await store.setState("beta-state", stateFor(BETA_CONFIG.serviceId));
   const exchanges: string[] = [];
   const successes: string[] = [];
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = ((input: string | URL | Request) => {
-    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-    exchanges.push(url);
-    return Promise.resolve(Response.json({ access_token: "beta-access-token" }));
-  }) as typeof fetch;
+  installMockFetch(
+    ((input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      exchanges.push(url);
+      return Promise.resolve(Response.json({ access_token: "beta-access-token" }));
+    }) as typeof fetch,
+  );
 
   try {
     const handler = createOAuthCallbackDispatcher([ALPHA_CONFIG, BETA_CONFIG], {
@@ -128,7 +130,7 @@ Deno.test("callback dispatcher exchanges and stores tokens for the state-selecte
     );
     assertEquals(await store.getTokens(ALPHA_CONFIG.serviceId, "alice"), null);
   } finally {
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
   }
 });
 
@@ -137,11 +139,12 @@ Deno.test("callback dispatcher rejects and consumes state for a service outside 
   const unknownServiceId = "unlisted-provider";
   await store.setState("unknown-state", stateFor(unknownServiceId));
   let fetchCalls = 0;
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = (() => {
-    fetchCalls++;
-    return Promise.resolve(Response.json({ access_token: "should-not-exist" }));
-  }) as typeof fetch;
+  installMockFetch(
+    (() => {
+      fetchCalls++;
+      return Promise.resolve(Response.json({ access_token: "should-not-exist" }));
+    }) as typeof fetch,
+  );
 
   try {
     const handler = createOAuthCallbackDispatcher([ALPHA_CONFIG, BETA_CONFIG], {
@@ -160,7 +163,7 @@ Deno.test("callback dispatcher rejects and consumes state for a service outside 
     assertEquals(fetchCalls, 0);
     assertEquals(await store.consumeState("unknown-state"), null);
   } finally {
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
   }
 });
 
@@ -173,11 +176,12 @@ Deno.test("callback dispatcher enforces the exact shared redirect binding", asyn
     }),
   );
   let fetchCalls = 0;
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = (() => {
-    fetchCalls++;
-    return Promise.resolve(Response.json({ access_token: "should-not-exist" }));
-  }) as typeof fetch;
+  installMockFetch(
+    (() => {
+      fetchCalls++;
+      return Promise.resolve(Response.json({ access_token: "should-not-exist" }));
+    }) as typeof fetch,
+  );
 
   try {
     const handler = createOAuthCallbackDispatcher([ALPHA_CONFIG, BETA_CONFIG], {
@@ -197,7 +201,7 @@ Deno.test("callback dispatcher enforces the exact shared redirect binding", asyn
     assertEquals(fetchCalls, 0);
     assertEquals(await store.consumeState("wrong-redirect"), null);
   } finally {
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
   }
 });
 
@@ -208,11 +212,12 @@ Deno.test("callback dispatcher applies the selected service PKCE requirement", a
     stateFor(ALPHA_CONFIG.serviceId, { codeVerifier: undefined }),
   );
   let fetchCalls = 0;
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = (() => {
-    fetchCalls++;
-    return Promise.resolve(Response.json({ access_token: "should-not-exist" }));
-  }) as typeof fetch;
+  installMockFetch(
+    (() => {
+      fetchCalls++;
+      return Promise.resolve(Response.json({ access_token: "should-not-exist" }));
+    }) as typeof fetch,
+  );
 
   try {
     const handler = createOAuthCallbackDispatcher([ALPHA_CONFIG, BETA_CONFIG], {
@@ -231,7 +236,7 @@ Deno.test("callback dispatcher applies the selected service PKCE requirement", a
     );
     assertEquals(fetchCalls, 0);
   } finally {
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
   }
 });
 
@@ -242,11 +247,12 @@ Deno.test("callback dispatcher rejects PKCE state for a service that does not su
     stateFor(BETA_CONFIG.serviceId, { codeVerifier: CODE_VERIFIER }),
   );
   let fetchCalls = 0;
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = (() => {
-    fetchCalls++;
-    return Promise.resolve(Response.json({ access_token: "should-not-exist" }));
-  }) as typeof fetch;
+  installMockFetch(
+    (() => {
+      fetchCalls++;
+      return Promise.resolve(Response.json({ access_token: "should-not-exist" }));
+    }) as typeof fetch,
+  );
 
   try {
     const handler = createOAuthCallbackDispatcher([ALPHA_CONFIG, BETA_CONFIG], {
@@ -265,7 +271,7 @@ Deno.test("callback dispatcher rejects PKCE state for a service that does not su
     );
     assertEquals(fetchCalls, 0);
   } finally {
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
   }
 });
 
@@ -315,11 +321,12 @@ Deno.test("callback dispatcher relies on one-shot state consumption under concur
   const store = new MemoryTokenStore();
   await store.setState("one-shot", stateFor(BETA_CONFIG.serviceId));
   let fetchCalls = 0;
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = (() => {
-    fetchCalls++;
-    return Promise.resolve(Response.json({ access_token: "beta-token" }));
-  }) as typeof fetch;
+  installMockFetch(
+    (() => {
+      fetchCalls++;
+      return Promise.resolve(Response.json({ access_token: "beta-token" }));
+    }) as typeof fetch,
+  );
 
   try {
     const handler = createOAuthCallbackDispatcher([BETA_CONFIG], {
@@ -345,7 +352,7 @@ Deno.test("callback dispatcher relies on one-shot state consumption under concur
     );
     assertEquals(fetchCalls, 1);
   } finally {
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
   }
 });
 

--- a/src/oauth/providers/base.test.ts
+++ b/src/oauth/providers/base.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { assert, assertEquals, assertNotEquals, assertRejects, assertThrows } from "#std/assert";
 import { OAuthProvider, OAuthService } from "./base.ts";
 import type {
@@ -66,25 +67,26 @@ async function withStubbedFetch(
   captured: string[],
   fn: () => Promise<unknown>,
 ): Promise<void> {
-  const original = globalThis.fetch;
-  globalThis.fetch = ((input: string | URL | Request): Promise<Response> => {
-    const url = typeof input === "string"
-      ? input
-      : input instanceof URL
-      ? input.toString()
-      : input.url;
-    captured.push(url);
-    return Promise.resolve(
-      new Response(JSON.stringify({ ok: true }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      }),
-    );
-  }) as typeof fetch;
+  installMockFetch(
+    ((input: string | URL | Request): Promise<Response> => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+      captured.push(url);
+      return Promise.resolve(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }) as typeof fetch,
+  );
   try {
     await fn();
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 }
 
@@ -117,15 +119,16 @@ Deno.test("OAuthService.fetch: joins relative endpoints without requiring a lead
 
 Deno.test("OAuthService.fetch: preserves Headers instances and caller content types", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);
-  const original = globalThis.fetch;
   let capturedHeaders: Headers | undefined;
-  globalThis.fetch = ((
-    _input: string | URL | Request,
-    init?: RequestInit,
-  ): Promise<Response> => {
-    capturedHeaders = new Headers(init?.headers);
-    return Promise.resolve(Response.json({ ok: true }));
-  }) as typeof fetch;
+  installMockFetch(
+    ((
+      _input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      capturedHeaders = new Headers(init?.headers);
+      return Promise.resolve(Response.json({ ok: true }));
+    }) as typeof fetch,
+  );
 
   try {
     await service.fetch("user-1", "/v1/me", {
@@ -137,7 +140,7 @@ Deno.test("OAuthService.fetch: preserves Headers instances and caller content ty
       }),
     });
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 
   assertEquals(capturedHeaders?.get("authorization"), "Bearer test-access-token");
@@ -147,12 +150,13 @@ Deno.test("OAuthService.fetch: preserves Headers instances and caller content ty
 
 Deno.test("OAuthService.fetch does not invent a content type for caller-owned bodies", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (key) => ENV[key]);
-  const original = globalThis.fetch;
   let capturedHeaders: Headers | undefined;
-  globalThis.fetch = ((_input: string | URL | Request, init?: RequestInit) => {
-    capturedHeaders = new Headers(init?.headers);
-    return Promise.resolve(Response.json({ ok: true }));
-  }) as typeof fetch;
+  installMockFetch(
+    ((_input: string | URL | Request, init?: RequestInit) => {
+      capturedHeaders = new Headers(init?.headers);
+      return Promise.resolve(Response.json({ ok: true }));
+    }) as typeof fetch,
+  );
 
   try {
     await service.fetch("user-1", "/v1/me", {
@@ -160,7 +164,7 @@ Deno.test("OAuthService.fetch does not invent a content type for caller-owned bo
       body: new URLSearchParams({ field: "value" }),
     });
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 
   assertEquals(capturedHeaders?.get("authorization"), "Bearer test-access-token");
@@ -173,19 +177,20 @@ Deno.test("OAuthService.fetch applies provider API headers and owns Authorizatio
     apiHeaders: { "X-Provider-Version": "2026-01-01" },
   };
   const service = new OAuthService(config, makeAuthedTokenStore(), (key) => ENV[key]);
-  const original = globalThis.fetch;
   let capturedHeaders: Headers | undefined;
-  globalThis.fetch = ((_input: string | URL | Request, init?: RequestInit) => {
-    capturedHeaders = new Headers(init?.headers);
-    return Promise.resolve(Response.json({ ok: true }));
-  }) as typeof fetch;
+  installMockFetch(
+    ((_input: string | URL | Request, init?: RequestInit) => {
+      capturedHeaders = new Headers(init?.headers);
+      return Promise.resolve(Response.json({ ok: true }));
+    }) as typeof fetch,
+  );
 
   try {
     await service.fetch("user-1", "/v1/me", {
       headers: { Authorization: "Bearer caller-controlled", "X-Request-Id": "request-1" },
     });
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 
   assertEquals(capturedHeaders?.get("authorization"), "Bearer test-access-token");
@@ -200,30 +205,30 @@ Deno.test("OAuthService.fetch bounds successful JSON responses and accepts the e
     maxApiResponseBytes: new TextEncoder().encode(exactJson).byteLength,
   };
   const service = new OAuthService(config, makeAuthedTokenStore(), (key) => ENV[key]);
-  const original = globalThis.fetch;
 
   try {
-    globalThis.fetch = (() => Promise.resolve(new Response(exactJson))) as typeof fetch;
+    installMockFetch((() => Promise.resolve(new Response(exactJson))) as typeof fetch);
     assertEquals(await service.fetch("user-1", "/v1/me"), { ok: 1 });
 
-    globalThis.fetch = (() => Promise.resolve(new Response('{"oversized":true}'))) as typeof fetch;
+    installMockFetch((() => Promise.resolve(new Response('{"oversized":true}'))) as typeof fetch);
     await assertRejects(
       () => service.fetch("user-1", "/v1/me"),
       Error,
       "response exceeded",
     );
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
 Deno.test("OAuthService.fetch rejects malformed UTF-8 response bodies", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (key) => ENV[key]);
-  const original = globalThis.fetch;
-  globalThis.fetch = (() =>
-    Promise.resolve(
-      new Response(new Uint8Array([0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xc3, 0x28, 0x22, 0x7d])),
-    )) as typeof fetch;
+  installMockFetch(
+    (() =>
+      Promise.resolve(
+        new Response(new Uint8Array([0x7b, 0x22, 0x78, 0x22, 0x3a, 0x22, 0xc3, 0x28, 0x22, 0x7d])),
+      )) as typeof fetch,
+  );
   try {
     await assertRejects(
       () => service.fetch("user-1", "/v1/me"),
@@ -231,7 +236,7 @@ Deno.test("OAuthService.fetch rejects malformed UTF-8 response bodies", async ()
       "response could not be read",
     );
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
@@ -246,14 +251,15 @@ Deno.test("OAuthService.fetch snapshots RequestInit before asynchronous token lo
     return { accessToken: "token" };
   };
   const service = new OAuthService(TEST_CONFIG, store, (key) => ENV[key]);
-  const original = globalThis.fetch;
   let capturedMethod: string | undefined;
   let capturedHeader: string | null = null;
-  globalThis.fetch = ((_input: string | URL | Request, init?: RequestInit) => {
-    capturedMethod = init?.method;
-    capturedHeader = new Headers(init?.headers).get("x-request-version");
-    return Promise.resolve(Response.json({ ok: true }));
-  }) as typeof fetch;
+  installMockFetch(
+    ((_input: string | URL | Request, init?: RequestInit) => {
+      capturedMethod = init?.method;
+      capturedHeader = new Headers(init?.headers).get("x-request-version");
+      return Promise.resolve(Response.json({ ok: true }));
+    }) as typeof fetch,
+  );
 
   const headers = { "X-Request-Version": "original" };
   const options: RequestInit = { method: "POST", headers };
@@ -267,14 +273,13 @@ Deno.test("OAuthService.fetch snapshots RequestInit before asynchronous token lo
     assertEquals(capturedMethod, "POST");
     assertEquals(capturedHeader, "original");
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
 Deno.test("OAuthService.fetch supports successful no-content responses", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (key) => ENV[key]);
-  const original = globalThis.fetch;
-  globalThis.fetch = (() => Promise.resolve(new Response(null, { status: 204 }))) as typeof fetch;
+  installMockFetch((() => Promise.resolve(new Response(null, { status: 204 }))) as typeof fetch);
 
   try {
     assertEquals(
@@ -282,7 +287,7 @@ Deno.test("OAuthService.fetch supports successful no-content responses", async (
       undefined,
     );
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
@@ -305,8 +310,7 @@ Deno.test("OAuthService.fetch bounds token lookup and non-cooperative API fetche
     makeAuthedTokenStore(),
     (key) => ENV[key],
   );
-  const original = globalThis.fetch;
-  globalThis.fetch = (() => new Promise<Response>(() => {})) as typeof fetch;
+  installMockFetch((() => new Promise<Response>(() => {})) as typeof fetch);
   try {
     await assertRejects(
       () => service.fetch("user-1", "/v1/me"),
@@ -314,26 +318,27 @@ Deno.test("OAuthService.fetch bounds token lookup and non-cooperative API fetche
       "API request failed",
     );
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
 Deno.test("OAuthService.fetch preserves caller cancellation during provider fetch", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (key) => ENV[key]);
-  const original = globalThis.fetch;
   let markFetchStarted!: () => void;
   const fetchStarted = new Promise<void>((resolve) => {
     markFetchStarted = resolve;
   });
-  globalThis.fetch = ((_input: string | URL | Request, init?: RequestInit) => {
-    markFetchStarted();
-    return new Promise<Response>((_resolve, reject) => {
-      const signal = init?.signal;
-      const rejectForAbort = () => reject(signal?.reason);
-      signal?.addEventListener("abort", rejectForAbort, { once: true });
-      if (signal?.aborted) rejectForAbort();
-    });
-  }) as typeof fetch;
+  installMockFetch(
+    ((_input: string | URL | Request, init?: RequestInit) => {
+      markFetchStarted();
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        const rejectForAbort = () => reject(signal?.reason);
+        signal?.addEventListener("abort", rejectForAbort, { once: true });
+        if (signal?.aborted) rejectForAbort();
+      });
+    }) as typeof fetch,
+  );
 
   const controller = new AbortController();
   const reason = new DOMException("caller cancelled provider fetch", "AbortError");
@@ -345,28 +350,29 @@ Deno.test("OAuthService.fetch preserves caller cancellation during provider fetc
     const error = await assertRejects(() => pending);
     assert(error === reason);
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
 Deno.test("OAuthService.fetch preserves caller cancellation during provider body read", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (key) => ENV[key]);
-  const original = globalThis.fetch;
   let markBodyReadStarted!: () => void;
   const bodyReadStarted = new Promise<void>((resolve) => {
     markBodyReadStarted = resolve;
   });
-  globalThis.fetch = (() =>
-    Promise.resolve(
-      new Response(
-        new ReadableStream<Uint8Array>({
-          pull() {
-            markBodyReadStarted();
-            return new Promise<void>(() => {});
-          },
-        }),
-      ),
-    )) as typeof fetch;
+  installMockFetch(
+    (() =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull() {
+              markBodyReadStarted();
+              return new Promise<void>(() => {});
+            },
+          }),
+        ),
+      )) as typeof fetch,
+  );
 
   const controller = new AbortController();
   const reason = new DOMException("caller cancelled body read", "AbortError");
@@ -378,7 +384,7 @@ Deno.test("OAuthService.fetch preserves caller cancellation during provider body
     const error = await assertRejects(() => pending);
     assert(error === reason);
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
@@ -388,19 +394,20 @@ Deno.test("OAuthService.fetch timeout cancels a stalled API body", async () => {
     makeAuthedTokenStore(),
     (key) => ENV[key],
   );
-  const original = globalThis.fetch;
   let bodyCancelled = false;
-  globalThis.fetch = (() =>
-    Promise.resolve(
-      new Response(
-        new ReadableStream({
-          pull: () => new Promise<void>(() => {}),
-          cancel() {
-            bodyCancelled = true;
-          },
-        }),
-      ),
-    )) as typeof fetch;
+  installMockFetch(
+    (() =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream({
+            pull: () => new Promise<void>(() => {}),
+            cancel() {
+              bodyCancelled = true;
+            },
+          }),
+        ),
+      )) as typeof fetch,
+  );
 
   try {
     await assertRejects(
@@ -410,7 +417,7 @@ Deno.test("OAuthService.fetch timeout cancels a stalled API body", async () => {
     );
     assertEquals(bodyCancelled, true);
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
@@ -478,12 +485,13 @@ Deno.test("OAuthProvider enforces explicit PKCE capability modes", async () => {
     "requires PKCE",
   );
 
-  const originalFetch = globalThis.fetch;
   let tokenRequestCount = 0;
-  globalThis.fetch = (() => {
-    tokenRequestCount++;
-    return Promise.resolve(Response.json({ access_token: "unexpected" }));
-  }) as typeof fetch;
+  installMockFetch(
+    (() => {
+      tokenRequestCount++;
+      return Promise.resolve(Response.json({ access_token: "unexpected" }));
+    }) as typeof fetch,
+  );
   try {
     await assertRejects(
       () =>
@@ -506,7 +514,7 @@ Deno.test("OAuthProvider enforces explicit PKCE capability modes", async () => {
     );
     assertEquals(tokenRequestCount, 0);
   } finally {
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
   }
 });
 
@@ -745,19 +753,20 @@ async function withErrorFetch(
   body: string,
   fn: () => Promise<unknown>,
 ): Promise<void> {
-  const original = globalThis.fetch;
-  globalThis.fetch = ((): Promise<Response> => {
-    return Promise.resolve(
-      new Response(body, {
-        status,
-        headers: { "Content-Type": "text/plain" },
-      }),
-    );
-  }) as typeof fetch;
+  installMockFetch(
+    ((): Promise<Response> => {
+      return Promise.resolve(
+        new Response(body, {
+          status,
+          headers: { "Content-Type": "text/plain" },
+        }),
+      );
+    }) as typeof fetch,
+  );
   try {
     await fn();
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 }
 
@@ -795,19 +804,20 @@ async function withTokenFetch(
   body: unknown,
   fn: () => Promise<unknown>,
 ): Promise<void> {
-  const original = globalThis.fetch;
-  globalThis.fetch = ((): Promise<Response> => {
-    return Promise.resolve(
-      new Response(JSON.stringify(body), {
-        status,
-        headers: { "Content-Type": "application/json" },
-      }),
-    );
-  }) as typeof fetch;
+  installMockFetch(
+    ((): Promise<Response> => {
+      return Promise.resolve(
+        new Response(JSON.stringify(body), {
+          status,
+          headers: { "Content-Type": "application/json" },
+        }),
+      );
+    }) as typeof fetch,
+  );
   try {
     await fn();
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 }
 
@@ -816,14 +826,15 @@ Deno.test("OAuthProvider uses form-encoded UTF-8 credentials for HTTP Basic auth
     { ...TEST_CONFIG, useBasicAuth: true },
     (key) => key === TEST_CONFIG.clientIdEnvVar ? "user: ä" : "s%écret",
   );
-  const original = globalThis.fetch;
   let requestHeaders: Headers | undefined;
   let requestBody = "";
-  globalThis.fetch = ((_input: string | URL | Request, init?: RequestInit) => {
-    requestHeaders = new Headers(init?.headers);
-    requestBody = String(init?.body ?? "");
-    return Promise.resolve(Response.json({ access_token: "token" }));
-  }) as typeof fetch;
+  installMockFetch(
+    ((_input: string | URL | Request, init?: RequestInit) => {
+      requestHeaders = new Headers(init?.headers);
+      requestBody = String(init?.body ?? "");
+      return Promise.resolve(Response.json({ access_token: "token" }));
+    }) as typeof fetch,
+  );
 
   try {
     const result = await provider.exchangeCode({
@@ -839,7 +850,7 @@ Deno.test("OAuthProvider uses form-encoded UTF-8 credentials for HTTP Basic auth
     assertEquals(body.has("client_id"), false);
     assertEquals(body.has("client_secret"), false);
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
@@ -851,14 +862,15 @@ Deno.test("OAuthProvider supports JSON token bodies and required static headers"
     tokenRequestHeaders: { "X-Provider-Version": "2026-01-01" },
   };
   const provider = new OAuthProvider(config, (key) => ENV[key]);
-  const original = globalThis.fetch;
   let requestHeaders: Headers | undefined;
   let requestBody = "";
-  globalThis.fetch = ((_input: string | URL | Request, init?: RequestInit) => {
-    requestHeaders = new Headers(init?.headers);
-    requestBody = String(init?.body ?? "");
-    return Promise.resolve(Response.json({ access_token: "token" }));
-  }) as typeof fetch;
+  installMockFetch(
+    ((_input: string | URL | Request, init?: RequestInit) => {
+      requestHeaders = new Headers(init?.headers);
+      requestBody = String(init?.body ?? "");
+      return Promise.resolve(Response.json({ access_token: "token" }));
+    }) as typeof fetch,
+  );
 
   try {
     const result = await provider.exchangeCode({
@@ -874,7 +886,7 @@ Deno.test("OAuthProvider supports JSON token bodies and required static headers"
       redirect_uri: "https://app.test/callback",
     });
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
@@ -972,9 +984,9 @@ Deno.test("OAuthProvider rejects token responses larger than its configured boun
     { ...TEST_CONFIG, maxTokenResponseBytes: 32 },
     (key) => ENV[key],
   );
-  const original = globalThis.fetch;
-  globalThis.fetch =
-    (() => Promise.resolve(Response.json({ access_token: "x".repeat(1_024) }))) as typeof fetch;
+  installMockFetch(
+    (() => Promise.resolve(Response.json({ access_token: "x".repeat(1_024) }))) as typeof fetch,
+  );
 
   try {
     const result = await provider.exchangeCode({
@@ -984,7 +996,7 @@ Deno.test("OAuthProvider rejects token responses larger than its configured boun
     assertEquals(result.success, false);
     assertEquals(result.error, "invalid_token_response");
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
@@ -994,8 +1006,7 @@ Deno.test("OAuthProvider accepts a valid token response exactly at its configure
     { ...TEST_CONFIG, maxTokenResponseBytes: new TextEncoder().encode(body).byteLength },
     (key) => ENV[key],
   );
-  const original = globalThis.fetch;
-  globalThis.fetch = (() => Promise.resolve(new Response(body, { status: 200 }))) as typeof fetch;
+  installMockFetch((() => Promise.resolve(new Response(body, { status: 200 }))) as typeof fetch);
 
   try {
     const result = await provider.exchangeCode({
@@ -1005,41 +1016,42 @@ Deno.test("OAuthProvider accepts a valid token response exactly at its configure
     assertEquals(result.success, true);
     assertEquals(result.tokens?.accessToken, "token");
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
 Deno.test("OAuthProvider rejects malformed UTF-8 token responses", async () => {
   const provider = new OAuthProvider(TEST_CONFIG, (key) => ENV[key]);
-  const original = globalThis.fetch;
-  globalThis.fetch = (() =>
-    Promise.resolve(
-      new Response(
-        new Uint8Array([
-          0x7b,
-          0x22,
-          0x61,
-          0x63,
-          0x63,
-          0x65,
-          0x73,
-          0x73,
-          0x5f,
-          0x74,
-          0x6f,
-          0x6b,
-          0x65,
-          0x6e,
-          0x22,
-          0x3a,
-          0x22,
-          0xc3,
-          0x28,
-          0x22,
-          0x7d,
-        ]),
-      ),
-    )) as typeof fetch;
+  installMockFetch(
+    (() =>
+      Promise.resolve(
+        new Response(
+          new Uint8Array([
+            0x7b,
+            0x22,
+            0x61,
+            0x63,
+            0x63,
+            0x65,
+            0x73,
+            0x73,
+            0x5f,
+            0x74,
+            0x6f,
+            0x6b,
+            0x65,
+            0x6e,
+            0x22,
+            0x3a,
+            0x22,
+            0xc3,
+            0x28,
+            0x22,
+            0x7d,
+          ]),
+        ),
+      )) as typeof fetch,
+  );
 
   try {
     const result = await provider.exchangeCode({
@@ -1049,7 +1061,7 @@ Deno.test("OAuthProvider rejects malformed UTF-8 token responses", async () => {
     assertEquals(result.success, false);
     assertEquals(result.error, "network_error");
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
@@ -1058,8 +1070,7 @@ Deno.test("OAuthProvider aborts token requests at the configured timeout", async
     { ...TEST_CONFIG, requestTimeoutMs: 5 },
     (key) => ENV[key],
   );
-  const original = globalThis.fetch;
-  globalThis.fetch =
+  installMockFetch(
     ((_input: string | URL | Request, init?: RequestInit) =>
       new Promise<Response>((_resolve, reject) => {
         const signal = init?.signal;
@@ -1070,7 +1081,8 @@ Deno.test("OAuthProvider aborts token requests at the configured timeout", async
         const rejectWithReason = () => reject(signal.reason);
         if (signal.aborted) rejectWithReason();
         else signal.addEventListener("abort", rejectWithReason, { once: true });
-      })) as typeof fetch;
+      })) as typeof fetch,
+  );
 
   try {
     const result = await provider.exchangeCode({
@@ -1081,7 +1093,7 @@ Deno.test("OAuthProvider aborts token requests at the configured timeout", async
     assertEquals(result.error, "network_error");
     assertEquals(result.errorDescription, "OAuth token request timed out");
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
@@ -1090,8 +1102,7 @@ Deno.test("OAuthProvider timeout wins when fetch ignores AbortSignal", async () 
     { ...TEST_CONFIG, requestTimeoutMs: 5 },
     (key) => ENV[key],
   );
-  const original = globalThis.fetch;
-  globalThis.fetch = (() => new Promise<Response>(() => {})) as typeof fetch;
+  installMockFetch((() => new Promise<Response>(() => {})) as typeof fetch);
 
   try {
     const result = await provider.exchangeCode({
@@ -1102,7 +1113,7 @@ Deno.test("OAuthProvider timeout wins when fetch ignores AbortSignal", async () 
     assertEquals(result.error, "network_error");
     assertEquals(result.errorDescription, "OAuth token request timed out");
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
@@ -1111,19 +1122,20 @@ Deno.test("OAuthProvider timeout bounds stalled bodies and cancels late response
     { ...TEST_CONFIG, requestTimeoutMs: 5 },
     (key) => ENV[key],
   );
-  const original = globalThis.fetch;
   let bodyCancelled = false;
-  globalThis.fetch = (() =>
-    Promise.resolve(
-      new Response(
-        new ReadableStream({
-          pull: () => new Promise<void>(() => {}),
-          cancel() {
-            bodyCancelled = true;
-          },
-        }),
-      ),
-    )) as typeof fetch;
+  installMockFetch(
+    (() =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream({
+            pull: () => new Promise<void>(() => {}),
+            cancel() {
+              bodyCancelled = true;
+            },
+          }),
+        ),
+      )) as typeof fetch,
+  );
 
   try {
     const result = await provider.exchangeCode({
@@ -1134,7 +1146,7 @@ Deno.test("OAuthProvider timeout bounds stalled bodies and cancels late response
     assertEquals(result.errorDescription, "OAuth token request timed out");
     assertEquals(bodyCancelled, true);
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
@@ -1143,13 +1155,14 @@ Deno.test("OAuthProvider cancels a response that arrives after strict timeout", 
     { ...TEST_CONFIG, requestTimeoutMs: 5 },
     (key) => ENV[key],
   );
-  const original = globalThis.fetch;
   let resolveFetch!: (response: Response) => void;
   let bodyCancelled = false;
-  globalThis.fetch = (() =>
-    new Promise<Response>((resolve) => {
-      resolveFetch = resolve;
-    })) as typeof fetch;
+  installMockFetch(
+    (() =>
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      })) as typeof fetch,
+  );
 
   try {
     const result = await provider.exchangeCode({
@@ -1170,7 +1183,7 @@ Deno.test("OAuthProvider cancels a response that arrives after strict timeout", 
     await Promise.resolve();
     assertEquals(bodyCancelled, true);
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
@@ -1240,12 +1253,13 @@ Deno.test("OAuthProvider blocks an internal token endpoint before credentials le
     { ...TEST_CONFIG, tokenUrl: "https://169.254.169.254/token" },
     (key) => ENV[key],
   );
-  const original = globalThis.fetch;
   let fetchCalls = 0;
-  globalThis.fetch = (() => {
-    fetchCalls++;
-    return Promise.resolve(Response.json({ access_token: "unexpected" }));
-  }) as typeof fetch;
+  installMockFetch(
+    (() => {
+      fetchCalls++;
+      return Promise.resolve(Response.json({ access_token: "unexpected" }));
+    }) as typeof fetch,
+  );
 
   try {
     const result = await provider.exchangeCode({
@@ -1256,7 +1270,7 @@ Deno.test("OAuthProvider blocks an internal token endpoint before credentials le
     assertEquals(result.error, "network_error");
     assertEquals(fetchCalls, 0);
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
@@ -1280,18 +1294,19 @@ Deno.test("OAuthProvider rejects cross-origin HTTP redirects for secret-bearing 
     { ...TEST_CONFIG, revocationUrl: "https://93.184.216.34/revoke" },
     (key) => ENV[key],
   );
-  const original = globalThis.fetch;
   const redirects: Array<RequestRedirect | undefined> = [];
-  globalThis.fetch = ((_input: string | URL | Request, init?: RequestInit) => {
-    redirects.push(init?.redirect);
-    return Promise.resolve(Response.json({ access_token: "token" }));
-  }) as typeof fetch;
+  installMockFetch(
+    ((_input: string | URL | Request, init?: RequestInit) => {
+      redirects.push(init?.redirect);
+      return Promise.resolve(Response.json({ access_token: "token" }));
+    }) as typeof fetch,
+  );
 
   try {
     await provider.exchangeCode({ code: "code", redirectUri: "https://app.test/callback" });
     await provider.revokeToken("token");
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 
   assertEquals(redirects, ["manual", "manual"]);
@@ -1302,22 +1317,23 @@ Deno.test("OAuthProvider bounds revocation tokens before fetch and releases resp
     { ...TEST_CONFIG, revocationUrl: "https://93.184.216.34/revoke" },
     (key) => ENV[key],
   );
-  const original = globalThis.fetch;
   let fetchCalls = 0;
   let responseCancelled = false;
-  globalThis.fetch = (() => {
-    fetchCalls++;
-    return Promise.resolve(
-      new Response(
-        new ReadableStream({
-          cancel() {
-            responseCancelled = true;
-            return new Promise<void>(() => {});
-          },
-        }),
-      ),
-    );
-  }) as typeof fetch;
+  installMockFetch(
+    (() => {
+      fetchCalls++;
+      return Promise.resolve(
+        new Response(
+          new ReadableStream({
+            cancel() {
+              responseCancelled = true;
+              return new Promise<void>(() => {});
+            },
+          }),
+        ),
+      );
+    }) as typeof fetch,
+  );
 
   try {
     await assertRejects(
@@ -1330,7 +1346,7 @@ Deno.test("OAuthProvider bounds revocation tokens before fetch and releases resp
     assertEquals(fetchCalls, 1);
     assertEquals(responseCancelled, true);
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
@@ -1339,17 +1355,18 @@ Deno.test("OAuthProvider authenticates revocation with client credentials in the
     { ...TEST_CONFIG, revocationUrl: "https://93.184.216.34/revoke" },
     (key) => ENV[key],
   );
-  const original = globalThis.fetch;
   let init: RequestInit | undefined;
-  globalThis.fetch = ((_input: string | URL | Request, requestInit?: RequestInit) => {
-    init = requestInit;
-    return Promise.resolve(new Response(null, { status: 200 }));
-  }) as typeof fetch;
+  installMockFetch(
+    ((_input: string | URL | Request, requestInit?: RequestInit) => {
+      init = requestInit;
+      return Promise.resolve(new Response(null, { status: 200 }));
+    }) as typeof fetch,
+  );
 
   try {
     assertEquals(await provider.revokeToken("token"), true);
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 
   const body = new URLSearchParams(String(init?.body));
@@ -1366,17 +1383,18 @@ Deno.test("OAuthProvider authenticates revocation with Basic auth when configure
     { ...TEST_CONFIG, revocationUrl: "https://93.184.216.34/revoke", useBasicAuth: true },
     (key) => ENV[key],
   );
-  const original = globalThis.fetch;
   let init: RequestInit | undefined;
-  globalThis.fetch = ((_input: string | URL | Request, requestInit?: RequestInit) => {
-    init = requestInit;
-    return Promise.resolve(new Response(null, { status: 200 }));
-  }) as typeof fetch;
+  installMockFetch(
+    ((_input: string | URL | Request, requestInit?: RequestInit) => {
+      init = requestInit;
+      return Promise.resolve(new Response(null, { status: 200 }));
+    }) as typeof fetch,
+  );
 
   try {
     assertEquals(await provider.revokeToken("token"), true);
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 
   const headers = new Headers(init?.headers);
@@ -1393,17 +1411,18 @@ Deno.test("OAuthProvider skips revocation when client credentials are missing", 
     { ...TEST_CONFIG, revocationUrl: "https://93.184.216.34/revoke" },
     () => undefined,
   );
-  const original = globalThis.fetch;
   let fetchCalls = 0;
-  globalThis.fetch = (() => {
-    fetchCalls++;
-    return Promise.resolve(new Response(null, { status: 200 }));
-  }) as typeof fetch;
+  installMockFetch(
+    (() => {
+      fetchCalls++;
+      return Promise.resolve(new Response(null, { status: 200 }));
+    }) as typeof fetch,
+  );
 
   try {
     assertEquals(await provider.revokeToken("token"), false);
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 
   assertEquals(fetchCalls, 0);
@@ -1414,37 +1433,39 @@ Deno.test("OAuthProvider revocation logging does not coerce hostile thrown value
     { ...TEST_CONFIG, revocationUrl: "https://93.184.216.34/revoke" },
     (key) => ENV[key],
   );
-  const original = globalThis.fetch;
   const hostile = Object.create(null);
   Object.defineProperty(hostile, "toString", {
     get() {
       throw new Error("must not be coerced");
     },
   });
-  globalThis.fetch = (() => {
-    throw hostile;
-  }) as typeof fetch;
+  installMockFetch(
+    (() => {
+      throw hostile;
+    }) as typeof fetch,
+  );
 
   try {
     assertEquals(await provider.revokeToken("token"), false);
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
 Deno.test("OAuthService.fetch cannot be configured to follow redirects", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (key) => ENV[key]);
-  const original = globalThis.fetch;
   let redirect: RequestRedirect | undefined;
-  globalThis.fetch = ((_input: string | URL | Request, init?: RequestInit) => {
-    redirect = init?.redirect;
-    return Promise.resolve(Response.json({ ok: true }));
-  }) as typeof fetch;
+  installMockFetch(
+    ((_input: string | URL | Request, init?: RequestInit) => {
+      redirect = init?.redirect;
+      return Promise.resolve(Response.json({ ok: true }));
+    }) as typeof fetch,
+  );
 
   try {
     await service.fetch("alice", "/me", { redirect: "follow" });
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 
   assertEquals(redirect, "manual");
@@ -1452,12 +1473,13 @@ Deno.test("OAuthService.fetch cannot be configured to follow redirects", async (
 
 Deno.test("OAuthService rejects oversized authorization codes before fetch", async () => {
   const provider = new OAuthProvider(TEST_CONFIG, (key) => ENV[key]);
-  const original = globalThis.fetch;
   let fetchCalls = 0;
-  globalThis.fetch = (() => {
-    fetchCalls++;
-    return Promise.resolve(Response.json({ access_token: "token" }));
-  }) as typeof fetch;
+  installMockFetch(
+    (() => {
+      fetchCalls++;
+      return Promise.resolve(Response.json({ access_token: "token" }));
+    }) as typeof fetch,
+  );
 
   try {
     await assertRejects(
@@ -1471,7 +1493,7 @@ Deno.test("OAuthService rejects oversized authorization codes before fetch", asy
     );
     assertEquals(fetchCalls, 0);
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
@@ -1518,25 +1540,26 @@ Deno.test(
       },
     };
     const service = new OAuthService(TEST_CONFIG, tokenStore, (k) => ENV[k]);
-    const original = globalThis.fetch;
     let refreshCalls = 0;
-    globalThis.fetch = ((): Promise<Response> => {
-      refreshCalls++;
-      return Promise.resolve(
-        new Response(
-          JSON.stringify({
-            access_token: "fresh-access-token",
-            refresh_token: "rotated-refresh-token",
-            token_type: "Bearer",
-            expires_in: 3600,
-          }),
-          {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          },
-        ),
-      );
-    }) as typeof fetch;
+    installMockFetch(
+      ((): Promise<Response> => {
+        refreshCalls++;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              access_token: "fresh-access-token",
+              refresh_token: "rotated-refresh-token",
+              token_type: "Bearer",
+              expires_in: 3600,
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        );
+      }) as typeof fetch,
+    );
 
     try {
       const [first, second] = await Promise.all([
@@ -1551,7 +1574,7 @@ Deno.test(
       assertEquals(storedTokens.refreshToken, "rotated-refresh-token");
       assertEquals(storedTokens.scope, "read");
     } finally {
-      globalThis.fetch = original;
+      restoreMockFetch();
     }
   },
 );
@@ -1564,20 +1587,21 @@ Deno.test("OAuthService aborting one waiter does not evict a shared refresh lead
     expiresAt: Date.now() - 1,
   });
   const service = new OAuthService(TEST_CONFIG, store, (key) => ENV[key]);
-  const original = globalThis.fetch;
   let fetchCalls = 0;
   let resolveFetch!: (response: Response) => void;
   let markFetchStarted!: () => void;
   const fetchStarted = new Promise<void>((resolve) => {
     markFetchStarted = resolve;
   });
-  globalThis.fetch = (() => {
-    fetchCalls++;
-    markFetchStarted();
-    return new Promise<Response>((resolve) => {
-      resolveFetch = resolve;
-    });
-  }) as typeof fetch;
+  installMockFetch(
+    (() => {
+      fetchCalls++;
+      markFetchStarted();
+      return new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      });
+    }) as typeof fetch,
+  );
 
   try {
     const controller = new AbortController();
@@ -1593,7 +1617,7 @@ Deno.test("OAuthService aborting one waiter does not evict a shared refresh lead
     assertEquals(await second, "fresh");
     assertEquals(fetchCalls, 1);
   } finally {
-    globalThis.fetch = original;
+    restoreMockFetch();
   }
 });
 
@@ -1641,18 +1665,19 @@ Deno.test(
     const store = makeAuthedTokenStore();
     store.getTokens = () => Promise.resolve(expired);
     const service = new OAuthService(TEST_CONFIG, store, (key) => ENV[key]);
-    const original = globalThis.fetch;
     let fetchCalls = 0;
-    globalThis.fetch = (() => {
-      fetchCalls++;
-      return Promise.resolve(Response.json({ access_token: "unexpected" }));
-    }) as typeof fetch;
+    installMockFetch(
+      (() => {
+        fetchCalls++;
+        return Promise.resolve(Response.json({ access_token: "unexpected" }));
+      }) as typeof fetch,
+    );
 
     try {
       await assertRejects(() => service.getAccessToken("alice"), Error, "atomic token refresh");
       assertEquals(fetchCalls, 0);
     } finally {
-      globalThis.fetch = original;
+      restoreMockFetch();
     }
   },
 );
@@ -1914,22 +1939,23 @@ Deno.test(
     const firstService = new OAuthService(TEST_CONFIG, store, (k) => ENV[k]);
     const secondService = new OAuthService(TEST_CONFIG, store, (k) => ENV[k]);
 
-    const original = globalThis.fetch;
     let tokenCalls = 0;
-    globalThis.fetch = ((input: string | URL | Request): Promise<Response> => {
-      const url = typeof input === "string"
-        ? input
-        : input instanceof URL
-        ? input.toString()
-        : input.url;
-      if (url === TEST_CONFIG.tokenUrl) tokenCalls++;
-      return Promise.resolve(
-        new Response(JSON.stringify({ access_token: "new-token", token_type: "Bearer" }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
-      );
-    }) as typeof fetch;
+    installMockFetch(
+      ((input: string | URL | Request): Promise<Response> => {
+        const url = typeof input === "string"
+          ? input
+          : input instanceof URL
+          ? input.toString()
+          : input.url;
+        if (url === TEST_CONFIG.tokenUrl) tokenCalls++;
+        return Promise.resolve(
+          new Response(JSON.stringify({ access_token: "new-token", token_type: "Bearer" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }) as typeof fetch,
+    );
 
     try {
       const [first, second] = await Promise.all([
@@ -1941,7 +1967,7 @@ Deno.test(
       assertEquals(tokenCalls, 1);
       assertEquals(setCount, 1);
     } finally {
-      globalThis.fetch = original;
+      restoreMockFetch();
     }
   },
 );
@@ -1969,16 +1995,17 @@ Deno.test(
     });
     const firstService = new OAuthService(TEST_CONFIG, createWrapper(), (key) => ENV[key]);
     const secondService = new OAuthService(TEST_CONFIG, createWrapper(), (key) => ENV[key]);
-    const original = globalThis.fetch;
     let refreshCalls = 0;
-    globalThis.fetch = (() => {
-      refreshCalls++;
-      return Promise.resolve(Response.json({
-        access_token: "new-token",
-        refresh_token: "new-refresh-token",
-        expires_in: 3_600,
-      }));
-    }) as typeof fetch;
+    installMockFetch(
+      (() => {
+        refreshCalls++;
+        return Promise.resolve(Response.json({
+          access_token: "new-token",
+          refresh_token: "new-refresh-token",
+          expires_in: 3_600,
+        }));
+      }) as typeof fetch,
+    );
 
     try {
       assertEquals(
@@ -1990,7 +2017,7 @@ Deno.test(
       );
       assertEquals(refreshCalls, 1);
     } finally {
-      globalThis.fetch = original;
+      restoreMockFetch();
     }
   },
 );
@@ -2041,20 +2068,21 @@ Deno.test(
       (k) => ENV[k],
     );
 
-    const original = globalThis.fetch;
     const refreshBodies: string[] = [];
-    globalThis.fetch = ((
-      _input: string | URL | Request,
-      init?: RequestInit,
-    ): Promise<Response> => {
-      refreshBodies.push(String(init?.body ?? ""));
-      return Promise.resolve(
-        new Response(JSON.stringify({ access_token: "new-token", token_type: "Bearer" }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
-      );
-    }) as typeof fetch;
+    installMockFetch(
+      ((
+        _input: string | URL | Request,
+        init?: RequestInit,
+      ): Promise<Response> => {
+        refreshBodies.push(String(init?.body ?? ""));
+        return Promise.resolve(
+          new Response(JSON.stringify({ access_token: "new-token", token_type: "Bearer" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }) as typeof fetch,
+    );
 
     try {
       await Promise.all([
@@ -2065,7 +2093,7 @@ Deno.test(
       assertEquals(refreshBodies.some((body) => body.includes("refresh-a")), true);
       assertEquals(refreshBodies.some((body) => body.includes("refresh-b")), true);
     } finally {
-      globalThis.fetch = original;
+      restoreMockFetch();
     }
   },
 );
@@ -2114,13 +2142,14 @@ Deno.test(
     const started = new Promise<void>((resolve) => {
       markStarted = resolve;
     });
-    const original = globalThis.fetch;
-    globalThis.fetch = (() => {
-      markStarted();
-      return new Promise<Response>((resolve) => {
-        resolveFetch = resolve;
-      });
-    }) as typeof fetch;
+    installMockFetch(
+      (() => {
+        markStarted();
+        return new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        });
+      }) as typeof fetch,
+    );
 
     try {
       const accessToken = service.getAccessToken("user-1");
@@ -2132,7 +2161,7 @@ Deno.test(
       assertEquals(storedTokens, null);
       assertEquals(setCalls, 0);
     } finally {
-      globalThis.fetch = original;
+      restoreMockFetch();
     }
   },
 );
@@ -2175,13 +2204,14 @@ Deno.test(
     const started = new Promise<void>((resolve) => {
       markStarted = resolve;
     });
-    const original = globalThis.fetch;
-    globalThis.fetch = (() => {
-      markStarted();
-      return new Promise<Response>((resolve) => {
-        resolveFetch = resolve;
-      });
-    }) as typeof fetch;
+    installMockFetch(
+      (() => {
+        markStarted();
+        return new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        });
+      }) as typeof fetch,
+    );
 
     try {
       const accessToken = service.getAccessToken("user-1");
@@ -2197,7 +2227,7 @@ Deno.test(
       assertEquals(storedTokens.accessToken, "newer-authorization-token");
       assertEquals(setCalls, 1);
     } finally {
-      globalThis.fetch = original;
+      restoreMockFetch();
     }
   },
 );

--- a/src/oauth/providers/protocols.test.ts
+++ b/src/oauth/providers/protocols.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { jiraConfig } from "./atlassian.ts";
@@ -21,9 +22,8 @@ async function captureExchange(
     [config.clientSecretEnvVar]: "client-secret",
   };
   const provider = new OAuthProvider(config, (key) => credentials[key]);
-  const original = globalThis.fetch;
   let captured: CapturedTokenRequest | undefined;
-  globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+  const stub = ((input: string | URL | Request, init?: RequestInit) => {
     captured = {
       url: input instanceof Request ? input.url : String(input),
       headers: new Headers(init?.headers),
@@ -32,16 +32,14 @@ async function captureExchange(
     return Promise.resolve(Response.json(responseBody));
   }) as typeof fetch;
 
-  try {
+  return await withMockFetch(stub, async () => {
     const result = await provider.exchangeCode({
       code: "authorization-code",
       redirectUri: "https://app.test/oauth/callback",
     });
     assert(captured, "expected a token request");
     return { request: captured, result };
-  } finally {
-    globalThis.fetch = original;
-  }
+  });
 }
 
 describe("built-in OAuth provider wire contracts", () => {

--- a/src/provider/model-registry.test.ts
+++ b/src/provider/model-registry.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { assertEquals, assertStrictEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { runWithCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
@@ -61,10 +62,8 @@ function testRuntime(provider: string, modelId: string): ModelRuntime {
 }
 
 describe("provider/model-registry", () => {
-  const originalFetch = globalThis.fetch;
-
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
     clearModelRegistryEnv();
     clearModelProviders();
   });
@@ -404,20 +403,22 @@ describe("provider/model-registry", () => {
     setEnv("GOOGLE_GEMINI_BASE_URL", "https://example.com/gemini/v1beta");
     let requestedUrl = "";
 
-    globalThis.fetch = (async (input: URL | Request | string, init?: RequestInit) => {
-      const request = new Request(input, init);
-      requestedUrl = request.url;
-      return new Response(
-        JSON.stringify({
-          candidates: [{
-            content: { role: "model", parts: [{ text: "ok" }] },
-            finishReason: "STOP",
-          }],
-          usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 1, totalTokenCount: 3 },
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      );
-    }) as typeof fetch;
+    installMockFetch(
+      (async (input: URL | Request | string, init?: RequestInit) => {
+        const request = new Request(input, init);
+        requestedUrl = request.url;
+        return new Response(
+          JSON.stringify({
+            candidates: [{
+              content: { role: "model", parts: [{ text: "ok" }] },
+              finishReason: "STOP",
+            }],
+            usageMetadata: { promptTokenCount: 2, candidatesTokenCount: 1, totalTokenCount: 3 },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }) as typeof fetch,
+    );
 
     const runtime = resolveModel("google/gemini-3.5-flash");
     await runtime.doGenerate({
@@ -436,28 +437,30 @@ describe("provider/model-registry", () => {
     let requestedUrl = "";
     let requestedBody: Record<string, unknown> | undefined;
 
-    globalThis.fetch = (async (input: URL | Request | string, init?: RequestInit) => {
-      const request = new Request(input, init);
-      requestedUrl = request.url;
-      requestedBody = JSON.parse(await request.text()) as Record<string, unknown>;
+    installMockFetch(
+      (async (input: URL | Request | string, init?: RequestInit) => {
+        const request = new Request(input, init);
+        requestedUrl = request.url;
+        requestedBody = JSON.parse(await request.text()) as Record<string, unknown>;
 
-      return new Response(
-        JSON.stringify({
-          id: "resp_lookup",
-          object: "response",
-          status: "completed",
-          output: [{
-            id: "msg_lookup",
-            type: "message",
-            role: "assistant",
+        return new Response(
+          JSON.stringify({
+            id: "resp_lookup",
+            object: "response",
             status: "completed",
-            content: [{ type: "output_text", text: "Found order." }],
-          }],
-          usage: { input_tokens: 4, output_tokens: 2, total_tokens: 6 },
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      );
-    }) as typeof fetch;
+            output: [{
+              id: "msg_lookup",
+              type: "message",
+              role: "assistant",
+              status: "completed",
+              content: [{ type: "output_text", text: "Found order." }],
+            }],
+            usage: { input_tokens: 4, output_tokens: 2, total_tokens: 6 },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }) as typeof fetch,
+    );
 
     const runtime = resolveModel("openai/gpt-5.4-nano");
     const result = await runtime.doGenerate({
@@ -495,27 +498,29 @@ describe("provider/model-registry", () => {
     setEnv("OPENAI_API_KEY", "sk-test-openai");
     let requestedBody: Record<string, unknown> | undefined;
 
-    globalThis.fetch = (async (input: URL | Request | string, init?: RequestInit) => {
-      const request = new Request(input, init);
-      requestedBody = JSON.parse(await request.text()) as Record<string, unknown>;
+    installMockFetch(
+      (async (input: URL | Request | string, init?: RequestInit) => {
+        const request = new Request(input, init);
+        requestedBody = JSON.parse(await request.text()) as Record<string, unknown>;
 
-      return new Response(
-        JSON.stringify({
-          id: "resp_reasoning",
-          object: "response",
-          status: "completed",
-          output: [{
-            id: "msg_reasoning",
-            type: "message",
-            role: "assistant",
+        return new Response(
+          JSON.stringify({
+            id: "resp_reasoning",
+            object: "response",
             status: "completed",
-            content: [{ type: "output_text", text: "Done." }],
-          }],
-          usage: { input_tokens: 4, output_tokens: 2, total_tokens: 6 },
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      );
-    }) as typeof fetch;
+            output: [{
+              id: "msg_reasoning",
+              type: "message",
+              role: "assistant",
+              status: "completed",
+              content: [{ type: "output_text", text: "Done." }],
+            }],
+            usage: { input_tokens: 4, output_tokens: 2, total_tokens: 6 },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }) as typeof fetch,
+    );
 
     const runtime = resolveModel("openai/gpt-5.4-nano");
     await runtime.doGenerate({
@@ -534,27 +539,29 @@ describe("provider/model-registry", () => {
     setEnv("OPENAI_API_KEY", "sk-test-openai");
     let requestedBody: Record<string, unknown> | undefined;
 
-    globalThis.fetch = (async (input: URL | Request | string, init?: RequestInit) => {
-      const request = new Request(input, init);
-      requestedBody = JSON.parse(await request.text()) as Record<string, unknown>;
+    installMockFetch(
+      (async (input: URL | Request | string, init?: RequestInit) => {
+        const request = new Request(input, init);
+        requestedBody = JSON.parse(await request.text()) as Record<string, unknown>;
 
-      return new Response(
-        JSON.stringify({
-          id: "resp_options",
-          object: "response",
-          status: "completed",
-          output: [{
-            id: "msg_options",
-            type: "message",
-            role: "assistant",
+        return new Response(
+          JSON.stringify({
+            id: "resp_options",
+            object: "response",
             status: "completed",
-            content: [{ type: "output_text", text: "Done." }],
-          }],
-          usage: { input_tokens: 4, output_tokens: 2, total_tokens: 6 },
-        }),
-        { status: 200, headers: { "content-type": "application/json" } },
-      );
-    }) as typeof fetch;
+            output: [{
+              id: "msg_options",
+              type: "message",
+              role: "assistant",
+              status: "completed",
+              content: [{ type: "output_text", text: "Done." }],
+            }],
+            usage: { input_tokens: 4, output_tokens: 2, total_tokens: 6 },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }) as typeof fetch,
+    );
 
     const runtime = resolveModel("openai/gpt-5.4-nano");
     await runtime.doGenerate({

--- a/src/provider/veryfront-cloud/provider.test.ts
+++ b/src/provider/veryfront-cloud/provider.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { agent } from "#veryfront/agent";
@@ -43,10 +44,8 @@ function setCloudBootstrap(): void {
 }
 
 describe("provider/veryfront-cloud", () => {
-  const originalFetch = globalThis.fetch;
-
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
     clearCloudEnv();
     clearModelProviders();
     clearEmbeddingProviders();
@@ -139,29 +138,31 @@ describe("provider/veryfront-cloud", () => {
     let capturedRequest: Request | undefined;
     let capturedBody: Record<string, unknown> | undefined;
 
-    globalThis.fetch = (async (input: URL | Request | string, init?: RequestInit) => {
-      const request = new Request(input, init);
-      capturedRequest = request;
-      capturedBody = JSON.parse(await request.text()) as Record<string, unknown>;
+    installMockFetch(
+      (async (input: URL | Request | string, init?: RequestInit) => {
+        const request = new Request(input, init);
+        capturedRequest = request;
+        capturedBody = JSON.parse(await request.text()) as Record<string, unknown>;
 
-      return new Response(
-        new ReadableStream({
-          start(controller) {
-            controller.enqueue(
-              encoder.encode('data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n'),
-            );
-            controller.enqueue(
-              encoder.encode(
-                'data: {"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3,"veryfront":{"billable_input_tokens":2,"billable_output_tokens":1,"provider_input_cost_usd":0.0004,"provider_output_cost_usd":0.0006,"provider_cost_usd":0.001,"veryfront_input_charge_usd":0.001,"veryfront_output_charge_usd":0.0015,"veryfront_charge_usd":0.0025,"cost_source":"gateway","billing_mode":"deferred","usage_capture_status":"complete"}}}\n\n',
-              ),
-            );
-            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-            controller.close();
-          },
-        }),
-        { status: 200, headers: { "content-type": "text/event-stream" } },
-      );
-    }) as typeof fetch;
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode('data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n'),
+              );
+              controller.enqueue(
+                encoder.encode(
+                  'data: {"choices":[{"finish_reason":"stop"}],"usage":{"prompt_tokens":2,"completion_tokens":1,"total_tokens":3,"veryfront":{"billable_input_tokens":2,"billable_output_tokens":1,"provider_input_cost_usd":0.0004,"provider_output_cost_usd":0.0006,"provider_cost_usd":0.001,"veryfront_input_charge_usd":0.001,"veryfront_output_charge_usd":0.0015,"veryfront_charge_usd":0.0025,"cost_source":"gateway","billing_mode":"deferred","usage_capture_status":"complete"}}}\n\n',
+                ),
+              );
+              controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+              controller.close();
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }) as typeof fetch,
+    );
 
     const assistant = agent({
       model: "veryfront-cloud/openai/gpt-test",
@@ -202,25 +203,27 @@ describe("provider/veryfront-cloud", () => {
     const encoder = new TextEncoder();
     const capturedRequests: Array<{ url: string; body: Record<string, unknown> }> = [];
 
-    globalThis.fetch = (async (input: URL | Request | string, init?: RequestInit) => {
-      const request = new Request(input, init);
-      capturedRequests.push({
-        url: request.url,
-        body: JSON.parse(await request.text()) as Record<string, unknown>,
-      });
+    installMockFetch(
+      (async (input: URL | Request | string, init?: RequestInit) => {
+        const request = new Request(input, init);
+        capturedRequests.push({
+          url: request.url,
+          body: JSON.parse(await request.text()) as Record<string, unknown>,
+        });
 
-      return new Response(
-        readableStreamFrom([
-          encoder.encode(
-            'data: {"prompt_filter_results":[{"prompt_index":0,"content_filter_results":{}}],"choices":[]}\n\n',
-          ),
-          encoder.encode('data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n'),
-          encoder.encode('data: {"choices":[{"finish_reason":"stop"}]}\n\n'),
-          encoder.encode("data: [DONE]\n\n"),
-        ]),
-        { status: 200, headers: { "content-type": "text/event-stream" } },
-      );
-    }) as typeof fetch;
+        return new Response(
+          readableStreamFrom([
+            encoder.encode(
+              'data: {"prompt_filter_results":[{"prompt_index":0,"content_filter_results":{}}],"choices":[]}\n\n',
+            ),
+            encoder.encode('data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n'),
+            encoder.encode('data: {"choices":[{"finish_reason":"stop"}]}\n\n'),
+            encoder.encode("data: [DONE]\n\n"),
+          ]),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }) as typeof fetch,
+    );
 
     for (const modelId of ["gpt-5.4", "gpt-5.5"]) {
       const assistant = agent({
@@ -269,51 +272,53 @@ describe("provider/veryfront-cloud", () => {
     let capturedRequest: Request | undefined;
     let capturedBody: Record<string, unknown> | undefined;
 
-    globalThis.fetch = (async (input: URL | Request | string, init?: RequestInit) => {
-      const request = new Request(input, init);
-      capturedRequest = request;
-      capturedBody = JSON.parse(await request.text()) as Record<string, unknown>;
-      const requestUrl = request.url;
+    installMockFetch(
+      (async (input: URL | Request | string, init?: RequestInit) => {
+        const request = new Request(input, init);
+        capturedRequest = request;
+        capturedBody = JSON.parse(await request.text()) as Record<string, unknown>;
+        const requestUrl = request.url;
 
-      if (requestUrl.endsWith("/responses")) {
+        if (requestUrl.endsWith("/responses")) {
+          return new Response(
+            readableStreamFrom([
+              encoder.encode(
+                'data: {"type":"response.output_item.added","item":{"id":"rs_1","type":"reasoning"}}\n\n',
+              ),
+              encoder.encode(
+                'data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_1","output_index":0,"summary_index":0,"delta":"Thinking."}\n\n',
+              ),
+              encoder.encode(
+                'data: {"type":"response.output_item.done","output_index":0,"item":{"id":"rs_1","type":"reasoning","status":"completed","summary":[{"type":"summary_text","text":"Thinking."}]}}\n\n',
+              ),
+              encoder.encode(
+                'data: {"type":"response.output_item.added","output_index":1,"item":{"id":"msg_1","type":"message","role":"assistant","status":"in_progress","content":[]}}\n\n',
+              ),
+              encoder.encode(
+                'data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":1,"content_index":0,"delta":"Hello"}\n\n',
+              ),
+              encoder.encode(
+                'data: {"type":"response.output_item.done","output_index":1,"item":{"id":"msg_1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"Hello"}]}}\n\n',
+              ),
+              encoder.encode(
+                'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}}\n\n',
+              ),
+              encoder.encode("data: [DONE]\n\n"),
+            ]),
+            { status: 200, headers: { "content-type": "text/event-stream" } },
+          );
+        }
+
         return new Response(
           readableStreamFrom([
-            encoder.encode(
-              'data: {"type":"response.output_item.added","item":{"id":"rs_1","type":"reasoning"}}\n\n',
-            ),
-            encoder.encode(
-              'data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_1","output_index":0,"summary_index":0,"delta":"Thinking."}\n\n',
-            ),
-            encoder.encode(
-              'data: {"type":"response.output_item.done","output_index":0,"item":{"id":"rs_1","type":"reasoning","status":"completed","summary":[{"type":"summary_text","text":"Thinking."}]}}\n\n',
-            ),
-            encoder.encode(
-              'data: {"type":"response.output_item.added","output_index":1,"item":{"id":"msg_1","type":"message","role":"assistant","status":"in_progress","content":[]}}\n\n',
-            ),
-            encoder.encode(
-              'data: {"type":"response.output_text.delta","item_id":"msg_1","output_index":1,"content_index":0,"delta":"Hello"}\n\n',
-            ),
-            encoder.encode(
-              'data: {"type":"response.output_item.done","output_index":1,"item":{"id":"msg_1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"Hello"}]}}\n\n',
-            ),
-            encoder.encode(
-              'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}}\n\n',
-            ),
+            encoder.encode('data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n'),
+            encoder.encode('data: {"choices":[{"finish_reason":"stop"}]}\n\n'),
             encoder.encode("data: [DONE]\n\n"),
           ]),
           { status: 200, headers: { "content-type": "text/event-stream" } },
         );
-      }
-
-      return new Response(
-        readableStreamFrom([
-          encoder.encode('data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n'),
-          encoder.encode('data: {"choices":[{"finish_reason":"stop"}]}\n\n'),
-          encoder.encode("data: [DONE]\n\n"),
-        ]),
-        { status: 200, headers: { "content-type": "text/event-stream" } },
-      );
-    }) as typeof fetch;
+      }) as typeof fetch,
+    );
 
     const assistant = agent({
       model: "veryfront-cloud/openai/gpt-5.4-nano",

--- a/src/routing/api/module-loader/esbuild-plugin.test.ts
+++ b/src/routing/api/module-loader/esbuild-plugin.test.ts
@@ -1,7 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { observeFetchRequestInit } from "#veryfront/testing/mock-fetch.ts";
+import {
+  installMockFetch,
+  observeFetchRequestInit,
+  restoreMockFetch,
+} from "#veryfront/testing/mock-fetch.ts";
 import { computeIntegrity, type LockfileManager } from "#veryfront/utils";
 import { MAX_BUNDLE_CHUNK_SIZE_BYTES } from "#veryfront/utils/constants/buffers.ts";
 import { createHTTPPlugin } from "./esbuild-plugin.ts";
@@ -275,7 +279,6 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
     });
 
     it("blocks prefix-domain bypasses of the allowed host list", async () => {
-      const originalFetch = globalThis.fetch;
       let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
       const plugin = createHTTPPlugin({ allowedHosts: ["https://esm.sh"] });
       const mockBuild = createMockBuild(
@@ -288,9 +291,11 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
       assertExists(loadHandler);
 
       try {
-        globalThis.fetch = (() => {
-          throw new Error("disallowed host should not be fetched");
-        }) as typeof fetch;
+        installMockFetch(
+          (() => {
+            throw new Error("disallowed host should not be fetched");
+          }) as typeof fetch,
+        );
 
         const result = await loadHandler({
           path: "https://esm.sh.evil.example/yaml@2",
@@ -303,12 +308,11 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
         assertExists(errors?.[0]);
         assertEquals(errors[0].text.includes("Remote import blocked by allow-list"), true);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
 
     it("blocks every remote module when the allowed host list is empty", async () => {
-      const originalFetch = globalThis.fetch;
       let fetchCalls = 0;
       let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
       const plugin = createHTTPPlugin([]);
@@ -321,10 +325,12 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
       assertExists(loadHandler);
 
       try {
-        globalThis.fetch = (() => {
-          fetchCalls += 1;
-          return Promise.resolve(new Response("unexpected"));
-        }) as typeof fetch;
+        installMockFetch(
+          (() => {
+            fetchCalls += 1;
+            return Promise.resolve(new Response("unexpected"));
+          }) as typeof fetch,
+        );
         const result = await loadHandler({
           path: "https://esm.sh/yaml@2",
           namespace: "http-url",
@@ -337,12 +343,11 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
         assertEquals(errors[0].text.includes("Remote import blocked by allow-list"), true);
         assertEquals(fetchCalls, 0);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
 
     it("blocks internal module targets before invoking fetch", async () => {
-      const originalFetch = globalThis.fetch;
       let fetchCalls = 0;
       let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
       const plugin = createHTTPPlugin(["http://169.254.169.254"]);
@@ -356,10 +361,12 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
       assertExists(loadHandler);
 
       try {
-        globalThis.fetch = (() => {
-          fetchCalls += 1;
-          return Promise.resolve(new Response("unexpected"));
-        }) as typeof fetch;
+        installMockFetch(
+          (() => {
+            fetchCalls += 1;
+            return Promise.resolve(new Response("unexpected"));
+          }) as typeof fetch,
+        );
         const result = await loadHandler({
           path: "http://169.254.169.254/module.js",
           namespace: "http-url",
@@ -371,12 +378,11 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
         assertEquals(errors[0].text.includes("internal host"), true);
         assertEquals(fetchCalls, 0);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
 
     it("reapplies the remote-host allow-list to redirects", async () => {
-      const originalFetch = globalThis.fetch;
       let fetchCalls = 0;
       let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
       const plugin = createHTTPPlugin({ allowedHosts: ["https://93.184.216.34"] });
@@ -390,15 +396,17 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
       assertExists(loadHandler);
 
       try {
-        globalThis.fetch = (() => {
-          fetchCalls += 1;
-          return Promise.resolve(
-            new Response(null, {
-              status: 302,
-              headers: { location: "https://93.184.216.35/module.js" },
-            }),
-          );
-        }) as typeof fetch;
+        installMockFetch(
+          (() => {
+            fetchCalls += 1;
+            return Promise.resolve(
+              new Response(null, {
+                status: 302,
+                headers: { location: "https://93.184.216.35/module.js" },
+              }),
+            );
+          }) as typeof fetch,
+        );
         const result = await loadHandler({
           path: "https://93.184.216.34/module.js",
           namespace: "http-url",
@@ -410,19 +418,18 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
         assertEquals(errors[0].text.includes("Remote import blocked by allow-list"), true);
         assertEquals(fetchCalls, 1);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
 
     it("serves a previously fetched remote module when the CDN later returns an error", async () => {
-      const originalFetch = globalThis.fetch;
       const projectDir = await Deno.makeTempDir();
       const moduleSource = "export const parsed = true;";
       const requestUrl = "https://esm.sh/yaml@2";
       const resolvedUrl = "https://esm.sh/yaml@2?target=es2020&bundle=true";
 
       const load = (fetchImpl: typeof fetch) => {
-        globalThis.fetch = fetchImpl;
+        installMockFetch(fetchImpl);
         let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
         const plugin = createHTTPPlugin({ allowedHosts: ["https://esm.sh"], projectDir });
         const mockBuild = createMockBuild(
@@ -463,13 +470,12 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
         );
         assertEquals((second as { contents: string }).contents, moduleSource);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
         await Deno.remove(projectDir, { recursive: true }).catch(() => {});
       }
     });
 
     it("retries transient remote module fetch failures before returning an error", async () => {
-      const originalFetch = globalThis.fetch;
       let attempts = 0;
       let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
       const plugin = createHTTPPlugin({ allowedHosts: ["https://esm.sh"] });
@@ -483,11 +489,13 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
       assertExists(loadHandler);
 
       try {
-        globalThis.fetch = (async () => {
-          attempts += 1;
-          if (attempts < 3) return new Response("unavailable", { status: 503 });
-          return new Response("export const ok = true;", { status: 200 });
-        }) as typeof fetch;
+        installMockFetch(
+          (async () => {
+            attempts += 1;
+            if (attempts < 3) return new Response("unavailable", { status: 503 });
+            return new Response("export const ok = true;", { status: 200 });
+          }) as typeof fetch,
+        );
 
         const result = await loadHandler({
           path: "https://esm.sh/yaml@2",
@@ -499,12 +507,11 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
         assertEquals((result as { contents: string }).contents, "export const ok = true;");
         assertEquals(attempts, 3);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
 
     it("rejects oversized remote module bodies without retrying", async () => {
-      const originalFetch = globalThis.fetch;
       let attempts = 0;
       let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
       const plugin = createHTTPPlugin({ allowedHosts: ["https://esm.sh"] });
@@ -517,14 +524,16 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
       assertExists(loadHandler);
 
       try {
-        globalThis.fetch = (async () => {
-          attempts += 1;
-          return new Response("export {};", {
-            headers: {
-              "content-length": String(MAX_BUNDLE_CHUNK_SIZE_BYTES + 1),
-            },
-          });
-        }) as typeof fetch;
+        installMockFetch(
+          (async () => {
+            attempts += 1;
+            return new Response("export {};", {
+              headers: {
+                "content-length": String(MAX_BUNDLE_CHUNK_SIZE_BYTES + 1),
+              },
+            });
+          }) as typeof fetch,
+        );
 
         await assertRejects(
           async () => {
@@ -540,12 +549,11 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
         );
         assertEquals(attempts, 1);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
 
     it("keeps the fetch deadline active while reading a streaming module body", async () => {
-      const originalFetch = globalThis.fetch;
       let attempts = 0;
       let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
       const plugin = createHTTPPlugin({
@@ -561,22 +569,24 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
       assertExists(loadHandler);
 
       try {
-        globalThis.fetch = ((_input, init) => {
-          attempts += 1;
-          const signal = observeFetchRequestInit(init).signal;
-          return Promise.resolve(
-            new Response(
-              new ReadableStream<Uint8Array>({
-                start(controller) {
-                  controller.enqueue(new TextEncoder().encode("export const pending = "));
-                  signal?.addEventListener("abort", () => controller.error(signal.reason), {
-                    once: true,
-                  });
-                },
-              }),
-            ),
-          );
-        }) as typeof fetch;
+        installMockFetch(
+          ((_input, init) => {
+            attempts += 1;
+            const signal = observeFetchRequestInit(init).signal;
+            return Promise.resolve(
+              new Response(
+                new ReadableStream<Uint8Array>({
+                  start(controller) {
+                    controller.enqueue(new TextEncoder().encode("export const pending = "));
+                    signal?.addEventListener("abort", () => controller.error(signal.reason), {
+                      once: true,
+                    });
+                  },
+                }),
+              ),
+            );
+          }) as typeof fetch,
+        );
 
         const result = await loadHandler!({
           path: "https://93.184.216.34/module.js",
@@ -590,12 +600,11 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
         assertEquals(errors[0].text.includes("Failed to fetch"), true);
         assertEquals(attempts, 3);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
 
     it("serves remote modules without repeated warnings when lockfile flush hits a read-only filesystem", async () => {
-      const originalFetch = globalThis.fetch;
       const originalWarn = console.warn;
       const projectDir = await Deno.makeTempDir();
       const moduleSource = "export const ok = true;";
@@ -649,10 +658,12 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
         console.warn = ((...args: unknown[]) => {
           warnings.push(args.map(String).join(" "));
         }) as typeof console.warn;
-        globalThis.fetch = (async () =>
-          failRemoteFetches
-            ? new Response("cdn unavailable", { status: 599 })
-            : new Response(moduleSource, { status: 200 })) as typeof fetch;
+        installMockFetch(
+          (async () =>
+            failRemoteFetches
+              ? new Response("cdn unavailable", { status: 599 })
+              : new Response(moduleSource, { status: 200 })) as typeof fetch,
+        );
 
         const first = await loadHandler({
           path: "https://esm.sh/yaml@2/stringify",
@@ -683,22 +694,19 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
 
         assertEquals((cached as { contents: string }).contents, moduleSource);
         assertEquals(
-          warnings.some((warning) =>
-            warning.includes("could not persist lockfile entry")
-          ),
+          warnings.some((warning) => warning.includes("could not persist lockfile entry")),
           false,
         );
         assertEquals(warnings.some((warning) => warning.includes("veryfront.lock")), false);
         assertEquals(warnings.some((warning) => warning.includes("/app/project")), false);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
         console.warn = originalWarn;
         await Deno.remove(projectDir, { recursive: true }).catch(() => {});
       }
     });
 
     it("propagates lockfile set failures", async () => {
-      const originalFetch = globalThis.fetch;
       let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
 
       const failingLockfile: LockfileManager = {
@@ -726,8 +734,7 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
       const handler = loadHandler;
 
       try {
-        globalThis.fetch = (async () =>
-          new Response("export const parsed = true;")) as typeof fetch;
+        installMockFetch((async () => new Response("export const parsed = true;")) as typeof fetch);
 
         await assertRejects(
           async () => {
@@ -742,12 +749,11 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
           "lockfile set failed",
         );
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
 
     it("propagates non-read-only lockfile flush failures", async () => {
-      const originalFetch = globalThis.fetch;
       let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
 
       const failingLockfile: LockfileManager = {
@@ -775,8 +781,7 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
       const handler = loadHandler;
 
       try {
-        globalThis.fetch = (async () =>
-          new Response("export const parsed = true;")) as typeof fetch;
+        installMockFetch((async () => new Response("export const parsed = true;")) as typeof fetch);
 
         await assertRejects(
           async () => {
@@ -791,12 +796,11 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
           "disk quota exceeded",
         );
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
 
     it("rejects cached remote modules whose integrity no longer matches the lockfile", async () => {
-      const originalFetch = globalThis.fetch;
       const projectDir = await Deno.makeTempDir();
       const firstSource = "export const value = 'first';";
       const secondSource = "export const value = 'second';";
@@ -804,7 +808,7 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
       const firstIntegrity = await computeIntegrity(firstSource);
 
       const load = (fetchImpl: typeof fetch) => {
-        globalThis.fetch = fetchImpl;
+        installMockFetch(fetchImpl);
         let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
         const plugin = createHTTPPlugin({ allowedHosts: ["https://esm.sh"], projectDir });
         const mockBuild = createMockBuild(
@@ -840,13 +844,12 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
 
         assertEquals("errors" in (result as Record<string, unknown>), true);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
         await Deno.remove(projectDir, { recursive: true }).catch(() => {});
       }
     });
 
     it("refetches instead of serving stale cache when a lockfile URL returns new content", async () => {
-      const originalFetch = globalThis.fetch;
       const projectDir = await Deno.makeTempDir();
       const oldSource = "export const value = 'old';";
       const newSource = "export const value = 'new';";
@@ -855,10 +858,12 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
       let attempts = 0;
 
       const load = () => {
-        globalThis.fetch = (async () => {
-          attempts += 1;
-          return new Response(fetchMode === "old" ? oldSource : newSource, { status: 200 });
-        }) as typeof fetch;
+        installMockFetch(
+          (async () => {
+            attempts += 1;
+            return new Response(fetchMode === "old" ? oldSource : newSource, { status: 200 });
+          }) as typeof fetch,
+        );
 
         let loadHandler: ((args: OnLoadArgs) => unknown) | undefined;
         const plugin = createHTTPPlugin({ allowedHosts: ["https://esm.sh"], projectDir });
@@ -889,7 +894,7 @@ describe("routing/api/module-loader/esbuild-plugin", () => {
         assertEquals((second as { contents: string }).contents, newSource);
         assertEquals(attempts, 2);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
         await Deno.remove(projectDir, { recursive: true }).catch(() => {});
       }
     });

--- a/src/routing/api/openapi/mcp-tools.test.ts
+++ b/src/routing/api/openapi/mcp-tools.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { generateMCPToolsFromSpec } from "./mcp-tools.ts";
@@ -232,17 +233,16 @@ describe("routing/api/openapi/mcp-tools", () => {
     });
 
     it("does not propagate caller-supplied end-user identity headers", async () => {
-      const originalFetch = globalThis.fetch;
       let requestHeaders: Headers | undefined;
 
       try {
-        globalThis.fetch = (input: string | URL | Request, init?: RequestInit) => {
+        installMockFetch((input: string | URL | Request, init?: RequestInit) => {
           const request = input instanceof Request ? input : new Request(input, init);
           requestHeaders = request.headers;
           return Promise.resolve(
             Response.json({ ok: true }, { status: 200 }),
           );
-        };
+        });
 
         const tools = generateTools(
           makeSpec({
@@ -263,17 +263,18 @@ describe("routing/api/openapi/mcp-tools", () => {
         assertExists(requestHeaders);
         assertEquals(requestHeaders.get("X-End-User-Id"), null);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
 
     it("blocks an internal configured API base URL before invoking fetch", async () => {
-      const originalFetch = globalThis.fetch;
       let fetchCalls = 0;
-      globalThis.fetch = (() => {
-        fetchCalls++;
-        return Promise.resolve(Response.json({ unexpected: true }));
-      }) as typeof fetch;
+      installMockFetch(
+        (() => {
+          fetchCalls++;
+          return Promise.resolve(Response.json({ unexpected: true }));
+        }) as typeof fetch,
+      );
 
       try {
         const tools = generateTools(
@@ -294,7 +295,7 @@ describe("routing/api/openapi/mcp-tools", () => {
         assertEquals(fetchCalls, 0);
         assertEquals((result as { error?: boolean }).error, true);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
   });

--- a/src/runs/runs-client.test.ts
+++ b/src/runs/runs-client.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd";
 import {
   assertEquals,
@@ -10,7 +11,6 @@ import { deleteEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import { runWithVeryfrontCloudContext } from "#veryfront/provider";
 import { createRunsClient, VeryfrontRunsClient } from "./runs-client.ts";
 
-const originalFetch = globalThis.fetch;
 let fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
 let fetchResponses: Array<Response | (() => Response)> = [];
 
@@ -20,21 +20,24 @@ const scheduleId = "33333333-3333-4333-8333-333333333333";
 function mockFetch(responses: Array<Response | (() => Response)>): void {
   fetchCalls = [];
   fetchResponses = [...responses];
-  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-    const url = typeof input === "string"
-      ? input
-      : input instanceof URL
-      ? input.toString()
-      : input.url;
-    fetchCalls.push({ url, init });
+  restoreMockFetch();
+  installMockFetch(
+    (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+        ? input.toString()
+        : input.url;
+      fetchCalls.push({ url, init });
 
-    const next = fetchResponses.shift();
-    if (!next) {
-      throw new Error(`No mock response for ${url}`);
-    }
+      const next = fetchResponses.shift();
+      if (!next) {
+        throw new Error(`No mock response for ${url}`);
+      }
 
-    return typeof next === "function" ? next() : next;
-  }) as typeof fetch;
+      return typeof next === "function" ? next() : next;
+    }) as typeof fetch,
+  );
 }
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -126,7 +129,7 @@ describe("VeryfrontRunsClient", () => {
   });
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
     clearRunsEnv();
   });
 

--- a/src/security/http/outbound-fetch.test.ts
+++ b/src/security/http/outbound-fetch.test.ts
@@ -38,6 +38,41 @@ describe("guardedOutboundFetch", () => {
     assertEquals(captured?.url, "https://93.184.216.34/rag/documents");
   });
 
+  it("ignores a hand-assigned globalThis.fetch rather than failing open to it", async () => {
+    // The old ambient path honoured this assignment, but only when DENO_TESTING
+    // was set four modules away. Forgetting the flag did not break loudly -- it
+    // reached the internet. There is now no flag and no ambient path: an
+    // assignment controls direct fetch callers and nothing else, so a test that
+    // stubs it and expects a canned response fails on its own terms instead of
+    // egressing to a third party.
+    let ambientCalls = 0;
+    const originalFetch = globalThis.fetch;
+    Object.defineProperty(globalThis, "fetch", {
+      value: () => {
+        ambientCalls++;
+        return Promise.resolve(Response.json({ ambient: true }));
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    try {
+      const response = await withMockFetch(
+        () => Promise.resolve(Response.json({ seam: true })),
+        () => guardedOutboundFetch("https://93.184.216.34/rag/documents"),
+      );
+
+      assertEquals(await response.json(), { seam: true });
+      assertEquals(ambientCalls, 0);
+    } finally {
+      Object.defineProperty(globalThis, "fetch", {
+        value: originalFetch,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
   it("rejects loopback and cloud metadata before invoking fetch", async () => {
     let calls = 0;
     const fetchImpl: typeof fetch = () => {

--- a/src/security/http/outbound-fetch.ts
+++ b/src/security/http/outbound-fetch.ts
@@ -238,6 +238,27 @@ export function createOutboundFetchBoundary(
  * `__runWithOutboundFetchTransportForTests` when there is one -- it cannot be
  * left installed by an early return.
  */
+/**
+ * Route outbound requests through the captured host `fetch` without address
+ * pinning, for the duration of a test process.
+ *
+ * Deno's pinned path uses its SOCKS client, which holds a connection open past
+ * the end of a test and trips the resource sanitiser. Tests that genuinely
+ * reach the network want the plain transport; production never does. Installed
+ * once from `src/testing/preload.ts`, where it is visible, rather than inferred
+ * from an environment variable inside this module.
+ *
+ * This is not a stub: it is the real host `fetch`, captured before tenant code
+ * could replace it, so it cannot silently honour an ambient
+ * `globalThis.fetch` assignment the way the old `DENO_TESTING` branch did.
+ */
+export function __installUnpinnedHostTransportForTests(): () => void {
+  return __installOutboundFetchTransportForTests({
+    fetch: capturedHostFetch,
+    pinnedFetch: (url, _addresses, init) => capturedHostFetch(url, init),
+  });
+}
+
 export function __installOutboundFetchTransportForTests(
   transport: OutboundFetchTransport,
 ): () => void {

--- a/src/security/http/outbound-fetch.ts
+++ b/src/security/http/outbound-fetch.ts
@@ -56,20 +56,9 @@ function getTrustedHostTransport(): OutboundFetchTransport {
     return outboundFetchTransportForTests;
   }
 
-  if (getHostEnv("DENO_TESTING") !== "1") {
-    // Omitting pinnedFetch is deliberate: Node and Bun then use the native
-    // address-pinned transport, while Deno uses its pinned SOCKS client.
-    return { fetch: capturedHostFetch };
-  }
-
-  // Tests explicitly opt into their current deterministic fetch replacement.
-  // The pinned seam receives only addresses that the egress guard validated,
-  // and production never selects this transport.
-  const fetchImpl = globalThis.fetch.bind(globalThis);
-  return {
-    fetch: fetchImpl,
-    pinnedFetch: (url, _addresses, init) => fetchImpl(url, init),
-  };
+  // Omitting pinnedFetch is deliberate: Node and Bun then use the native
+  // address-pinned transport, while Deno uses its pinned SOCKS client.
+  return { fetch: capturedHostFetch };
 }
 
 async function fetchWithHostTransport(
@@ -241,16 +230,33 @@ export function createOutboundFetchBoundary(
   });
 }
 
+/**
+ * Point the host transport at `transport` until the returned function is called.
+ *
+ * For suites that install a stub in `beforeEach` and tear it down in
+ * `afterEach`, where there is no single callback to scope. Prefer
+ * `__runWithOutboundFetchTransportForTests` when there is one -- it cannot be
+ * left installed by an early return.
+ */
+export function __installOutboundFetchTransportForTests(
+  transport: OutboundFetchTransport,
+): () => void {
+  const previous = outboundFetchTransportForTests;
+  outboundFetchTransportForTests = snapshotOutboundFetchTransport(transport);
+  return () => {
+    outboundFetchTransportForTests = previous;
+  };
+}
+
 export async function __runWithOutboundFetchTransportForTests<T>(
   transport: OutboundFetchTransport,
   fn: () => Promise<T>,
 ): Promise<T> {
-  const previous = outboundFetchTransportForTests;
-  outboundFetchTransportForTests = snapshotOutboundFetchTransport(transport);
+  const restore = __installOutboundFetchTransportForTests(transport);
   try {
     return await fn();
   } finally {
-    outboundFetchTransportForTests = previous;
+    restore();
   }
 }
 

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -15,7 +15,12 @@ import type { RuntimeRemoteToolConfig } from "#veryfront/agent/runtime/mcp-serve
 import { getRuntimeSourceIntegrationPolicy } from "#veryfront/agent/runtime/runtime-tool-config.ts";
 import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { observeFetchRequestInit, withMockFetch } from "#veryfront/testing/mock-fetch.ts";
+import {
+  installMockFetch,
+  observeFetchRequestInit,
+  restoreMockFetch,
+  withMockFetch,
+} from "#veryfront/testing/mock-fetch.ts";
 import { DEFAULT_MAX_BODY_SIZE_BYTES } from "#veryfront/utils/constants/index.ts";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
 import { getVerifiedCacheApiCredential } from "#veryfront/cache/verified-api-credential-context.ts";
@@ -779,54 +784,55 @@ describe("server/handlers/request/agent-stream.handler", () => {
     let capturedTools: unknown;
     let capturedAllowedRemoteTools: string[] | undefined;
     let platformMcpFetchCalls = 0;
-    const originalFetch = globalThis.fetch;
     const originalApiUrl = Deno.env.get("VERYFRONT_API_URL");
     const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
 
     Deno.env.set("VERYFRONT_API_URL", TEST_PUBLIC_API_ORIGIN);
     Deno.env.delete("VERYFRONT_API_BASE_URL");
-    globalThis.fetch = ((url, init) => {
-      if (String(url) === `${TEST_PUBLIC_API_ORIGIN}/mcp`) {
-        platformMcpFetchCalls += 1;
-        assertEquals(
-          new Headers(observeFetchRequestInit(init).headers).get("authorization"),
-          "Bearer request-scoped-user-token",
-        );
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              jsonrpc: "2.0",
-              id: "veryfront-platform-mcp:tools:list",
-              result: {
-                tools: [
-                  {
-                    name: "search_knowledge",
-                    description: "Search project knowledge",
-                    inputSchema: { type: "object", properties: {} },
-                  },
-                  {
-                    name: "get_file",
-                    description: "Read a project file",
-                    inputSchema: { type: "object", properties: {} },
-                  },
-                ],
-              },
+    installMockFetch(
+      ((url, init) => {
+        if (String(url) === `${TEST_PUBLIC_API_ORIGIN}/mcp`) {
+          platformMcpFetchCalls += 1;
+          assertEquals(
+            new Headers(observeFetchRequestInit(init).headers).get("authorization"),
+            "Bearer request-scoped-user-token",
+          );
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: "veryfront-platform-mcp:tools:list",
+                result: {
+                  tools: [
+                    {
+                      name: "search_knowledge",
+                      description: "Search project knowledge",
+                      inputSchema: { type: "object", properties: {} },
+                    },
+                    {
+                      name: "get_file",
+                      description: "Read a project file",
+                      inputSchema: { type: "object", properties: {} },
+                    },
+                  ],
+                },
+              }),
+              { headers: { "content-type": "application/json" } },
+            ),
+          );
+        }
+
+        if (String(url) === `${TEST_PUBLIC_API_ORIGIN}/projects/demo-project/environments`) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ data: [] }), {
+              headers: { "content-type": "application/json" },
             }),
-            { headers: { "content-type": "application/json" } },
-          ),
-        );
-      }
+          );
+        }
 
-      if (String(url) === `${TEST_PUBLIC_API_ORIGIN}/projects/demo-project/environments`) {
-        return Promise.resolve(
-          new Response(JSON.stringify({ data: [] }), {
-            headers: { "content-type": "application/json" },
-          }),
-        );
-      }
-
-      return Promise.reject(new Error(`unexpected fetch: ${url}`));
-    }) as typeof fetch;
+        return Promise.reject(new Error(`unexpected fetch: ${url}`));
+      }) as typeof fetch,
+    );
 
     try {
       const handler = createTestAgentStreamHandler({
@@ -911,7 +917,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
       assertEquals(capturedAllowedRemoteTools, ["get_file", "search_knowledge"]);
       assertEquals(platformMcpFetchCalls, 1);
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
       if (originalApiUrl === undefined) Deno.env.delete("VERYFRONT_API_URL");
       else Deno.env.set("VERYFRONT_API_URL", originalApiUrl);
       if (originalApiBaseUrl === undefined) Deno.env.delete("VERYFRONT_API_BASE_URL");
@@ -1276,41 +1282,42 @@ describe("server/handlers/request/agent-stream.handler", () => {
   it("auto-exposes Studio MCP tools for trusted Studio project-agent requests", async () => {
     let capturedAllowedRemoteTools: string[] | undefined;
     let capturedRemoteToolNames: string[] = [];
-    const originalFetch = globalThis.fetch;
     const originalStudioMcpUrl = Deno.env.get("VERYFRONT_STUDIO_MCP_URL");
 
     Deno.env.set("VERYFRONT_STUDIO_MCP_URL", TEST_PUBLIC_STUDIO_MCP_URL);
-    globalThis.fetch = ((url, init) => {
-      assertEquals(String(url), TEST_PUBLIC_STUDIO_MCP_URL);
-      const headers = new Headers(observeFetchRequestInit(init).headers);
-      assertEquals(headers.get("authorization"), "Bearer request-scoped-user-token");
-      assertEquals(headers.get("x-project-id"), "proj-1");
-      assertEquals(headers.get("x-conversation-id"), "10000000-1000-4000-8000-100000000001");
+    installMockFetch(
+      ((url, init) => {
+        assertEquals(String(url), TEST_PUBLIC_STUDIO_MCP_URL);
+        const headers = new Headers(observeFetchRequestInit(init).headers);
+        assertEquals(headers.get("authorization"), "Bearer request-scoped-user-token");
+        assertEquals(headers.get("x-project-id"), "proj-1");
+        assertEquals(headers.get("x-conversation-id"), "10000000-1000-4000-8000-100000000001");
 
-      return Promise.resolve(
-        new Response(
-          JSON.stringify({
-            jsonrpc: "2.0",
-            id: "studio-mcp:tools:list",
-            result: {
-              tools: [
-                {
-                  name: "studio_todo_write",
-                  description: "Write the assistant task list",
-                  inputSchema: { type: "object", properties: {} },
-                },
-                {
-                  name: "studio_panel_control",
-                  description: "Control Studio panels",
-                  inputSchema: { type: "object", properties: {} },
-                },
-              ],
-            },
-          }),
-          { headers: { "content-type": "application/json" } },
-        ),
-      );
-    }) as typeof fetch;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: "studio-mcp:tools:list",
+              result: {
+                tools: [
+                  {
+                    name: "studio_todo_write",
+                    description: "Write the assistant task list",
+                    inputSchema: { type: "object", properties: {} },
+                  },
+                  {
+                    name: "studio_panel_control",
+                    description: "Control Studio panels",
+                    inputSchema: { type: "object", properties: {} },
+                  },
+                ],
+              },
+            }),
+            { headers: { "content-type": "application/json" } },
+          ),
+        );
+      }) as typeof fetch,
+    );
 
     try {
       const handler = createTestAgentStreamHandler({
@@ -1383,7 +1390,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
       assertEquals(capturedAllowedRemoteTools, ["studio_todo_write"]);
       assertEquals(capturedRemoteToolNames, ["studio_todo_write", "studio_panel_control"]);
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
       if (originalStudioMcpUrl === undefined) Deno.env.delete("VERYFRONT_STUDIO_MCP_URL");
       else Deno.env.set("VERYFRONT_STUDIO_MCP_URL", originalStudioMcpUrl);
     }
@@ -1393,16 +1400,17 @@ describe("server/handlers/request/agent-stream.handler", () => {
     let studioMcpFetchCalls = 0;
     let capturedAllowedRemoteTools: string[] | undefined;
     let capturedRemoteSourceCount = -1;
-    const originalFetch = globalThis.fetch;
     const originalStudioMcpUrl = Deno.env.get("VERYFRONT_STUDIO_MCP_URL");
 
     Deno.env.set("VERYFRONT_STUDIO_MCP_URL", TEST_PUBLIC_STUDIO_MCP_URL);
-    globalThis.fetch = ((url) => {
-      if (String(url) === TEST_PUBLIC_STUDIO_MCP_URL) {
-        studioMcpFetchCalls += 1;
-      }
-      return Promise.resolve(new Response(null, { status: 503 }));
-    }) as typeof fetch;
+    installMockFetch(
+      ((url) => {
+        if (String(url) === TEST_PUBLIC_STUDIO_MCP_URL) {
+          studioMcpFetchCalls += 1;
+        }
+        return Promise.resolve(new Response(null, { status: 503 }));
+      }) as typeof fetch,
+    );
 
     try {
       const handler = createTestAgentStreamHandler({
@@ -1484,7 +1492,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
       assertEquals(capturedAllowedRemoteTools, ["studio_todo_write"]);
       assertEquals(capturedRemoteSourceCount, 0);
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
       if (originalStudioMcpUrl === undefined) Deno.env.delete("VERYFRONT_STUDIO_MCP_URL");
       else Deno.env.set("VERYFRONT_STUDIO_MCP_URL", originalStudioMcpUrl);
     }
@@ -1554,14 +1562,13 @@ describe("server/handlers/request/agent-stream.handler", () => {
 
   it("does not probe platform MCP for boolean tools already supplied by the run", async () => {
     let fetchCalls = 0;
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = async () => {
+    installMockFetch(async () => {
       fetchCalls += 1;
       return new Response(JSON.stringify({ tools: [] }), {
         status: 200,
         headers: { "content-type": "application/json" },
       });
-    };
+    });
 
     try {
       const handler = createTestAgentStreamHandler({
@@ -1618,13 +1625,11 @@ describe("server/handlers/request/agent-stream.handler", () => {
       assertEquals(result.response.status, 200);
       assertEquals(fetchCalls, 0);
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 
   it("fails closed when platform MCP is opted out or discovery fails", async () => {
-    const originalFetch = globalThis.fetch;
-
     try {
       for (
         const testCase of [
@@ -1645,13 +1650,15 @@ describe("server/handlers/request/agent-stream.handler", () => {
         let mcpFetchCalls = 0;
         let capturedAllowedRemoteTools: string[] | undefined;
         let capturedRemoteSourceCount = -1;
-        globalThis.fetch = ((url) => {
-          if (String(url).endsWith("/mcp")) {
-            mcpFetchCalls += 1;
-            return Promise.reject(new Error(`${testCase.name} discovery unavailable`));
-          }
-          return Promise.resolve(new Response(null, { status: 503 }));
-        }) as typeof fetch;
+        installMockFetch(
+          ((url) => {
+            if (String(url).endsWith("/mcp")) {
+              mcpFetchCalls += 1;
+              return Promise.reject(new Error(`${testCase.name} discovery unavailable`));
+            }
+            return Promise.resolve(new Response(null, { status: 503 }));
+          }) as typeof fetch,
+        );
 
         const handler = createTestAgentStreamHandler({
           ensureProjectDiscovery: async () => createEmptyDiscoveryResult(),
@@ -1725,7 +1732,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
         assertEquals(capturedRemoteSourceCount, 0);
       }
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 
@@ -1733,63 +1740,64 @@ describe("server/handlers/request/agent-stream.handler", () => {
     let capturedAllowedRemoteTools: string[] | undefined;
     let capturedRemoteToolNames: string[] = [];
     let capturedToolArguments: Record<string, unknown> | undefined;
-    const originalFetch = globalThis.fetch;
     const originalApiUrl = Deno.env.get("VERYFRONT_API_URL");
     const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
 
     Deno.env.set("VERYFRONT_API_URL", TEST_PUBLIC_API_ORIGIN);
     Deno.env.delete("VERYFRONT_API_BASE_URL");
-    globalThis.fetch = ((url, init) => {
-      assertEquals(String(url), `${TEST_PUBLIC_API_ORIGIN}/mcp`);
-      assertEquals(
-        new Headers(observeFetchRequestInit(init).headers).get("authorization"),
-        "Bearer request-scoped-user-token",
-      );
-      const request = JSON.parse(String(observeFetchRequestInit(init).body)) as {
-        id: string;
-        method: string;
-        params?: { arguments?: Record<string, unknown> };
-      };
-      if (request.method === "tools/call") {
-        capturedToolArguments = request.params?.arguments;
+    installMockFetch(
+      ((url, init) => {
+        assertEquals(String(url), `${TEST_PUBLIC_API_ORIGIN}/mcp`);
+        assertEquals(
+          new Headers(observeFetchRequestInit(init).headers).get("authorization"),
+          "Bearer request-scoped-user-token",
+        );
+        const request = JSON.parse(String(observeFetchRequestInit(init).body)) as {
+          id: string;
+          method: string;
+          params?: { arguments?: Record<string, unknown> };
+        };
+        if (request.method === "tools/call") {
+          capturedToolArguments = request.params?.arguments;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { content: [] } }),
+              { headers: { "content-type": "application/json" } },
+            ),
+          );
+        }
         return Promise.resolve(
           new Response(
-            JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { content: [] } }),
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: request.id,
+              result: {
+                tools: [
+                  {
+                    name: "list_uploads",
+                    description: "List uploads",
+                    inputSchema: {
+                      type: "object",
+                      properties: {
+                        project_reference: { type: "string" },
+                        limit: { type: "number" },
+                      },
+                      required: ["project_reference"],
+                    },
+                  },
+                  {
+                    name: "delete_upload",
+                    description: "Delete upload",
+                    inputSchema: { type: "object", properties: {} },
+                  },
+                ],
+              },
+            }),
             { headers: { "content-type": "application/json" } },
           ),
         );
-      }
-      return Promise.resolve(
-        new Response(
-          JSON.stringify({
-            jsonrpc: "2.0",
-            id: request.id,
-            result: {
-              tools: [
-                {
-                  name: "list_uploads",
-                  description: "List uploads",
-                  inputSchema: {
-                    type: "object",
-                    properties: {
-                      project_reference: { type: "string" },
-                      limit: { type: "number" },
-                    },
-                    required: ["project_reference"],
-                  },
-                },
-                {
-                  name: "delete_upload",
-                  description: "Delete upload",
-                  inputSchema: { type: "object", properties: {} },
-                },
-              ],
-            },
-          }),
-          { headers: { "content-type": "application/json" } },
-        ),
-      );
-    }) as typeof fetch;
+      }) as typeof fetch,
+    );
 
     try {
       const handler = createTestAgentStreamHandler({
@@ -1877,7 +1885,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
         limit: 10,
       });
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
       if (originalApiUrl === undefined) Deno.env.delete("VERYFRONT_API_URL");
       else Deno.env.set("VERYFRONT_API_URL", originalApiUrl);
       if (originalApiBaseUrl === undefined) Deno.env.delete("VERYFRONT_API_BASE_URL");
@@ -1967,97 +1975,98 @@ describe("server/handlers/request/agent-stream.handler", () => {
       proxyToken: "run-scoped-token",
       projectSlug: "support-agent-fork",
     };
-    const originalFetch = globalThis.fetch;
     const originalApiUrl = Deno.env.get("VERYFRONT_API_URL");
     const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
     const fetchUrls: string[] = [];
     Deno.env.set("VERYFRONT_API_URL", TEST_PUBLIC_API_ORIGIN);
     Deno.env.delete("VERYFRONT_API_BASE_URL");
-    globalThis.fetch = ((url, init) => {
-      fetchUrls.push(String(url));
-      assertEquals(
-        new Headers(observeFetchRequestInit(init).headers).get("authorization"),
-        "Bearer request-scoped-user-token",
-      );
-
-      if (String(url).endsWith("/projects/support-agent-fork/environments")) {
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              data: [
-                { id: "env-staging", name: "staging", protected: true },
-                {
-                  id: "10000000-1000-4000-8000-100000000097",
-                  name: "production",
-                  protected: false,
-                  active_release_id: "release-production",
-                },
-              ],
-            }),
-            { headers: { "content-type": "application/json" } },
-          ),
-        );
-      }
-
-      if (String(url).includes("/projects/support-agent-fork/environment-variables?")) {
+    installMockFetch(
+      ((url, init) => {
+        fetchUrls.push(String(url));
         assertEquals(
-          String(url).includes(
-            "environment_id=10000000-1000-4000-8000-100000000097",
-          ),
-          true,
+          new Headers(observeFetchRequestInit(init).headers).get("authorization"),
+          "Bearer request-scoped-user-token",
         );
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              data: [
-                { key: "CUSTOM_PROJECT_ENV", value: "project-value" },
-                { key: "VERYFRONT_API_TOKEN", value: "unsafe-project-token" },
-                { key: "VERYFRONT_API_URL", value: "https://evil.example" },
-                { key: "VERYFRONT_PROJECT_SLUG", value: "wrong-project" },
-                {
-                  key: "OTEL_EXPORTER_OTLP_ENDPOINT",
-                  value: "https://tenant-collector.example/otlp",
-                },
-                { key: "OTEL_RESOURCE_ATTRIBUTES", value: "tenant.secret=do-not-export" },
-              ],
-            }),
-            { headers: { "content-type": "application/json" } },
-          ),
-        );
-      }
 
-      if (String(url) === `${TEST_PUBLIC_API_ORIGIN}/mcp`) {
-        capturedMcpRequest = {
-          url: String(url),
-          authorization: new Headers(observeFetchRequestInit(init).headers).get("authorization"),
-        };
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              jsonrpc: "2.0",
-              id: "veryfront-platform-mcp:tools:list",
-              result: {
-                tools: [
+        if (String(url).endsWith("/projects/support-agent-fork/environments")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                data: [
+                  { id: "env-staging", name: "staging", protected: true },
                   {
-                    name: "search_knowledge",
-                    description: "Search knowledge",
-                    inputSchema: { type: "object", properties: {} },
-                  },
-                  {
-                    name: "list_projects",
-                    description: "List projects",
-                    inputSchema: { type: "object", properties: {} },
+                    id: "10000000-1000-4000-8000-100000000097",
+                    name: "production",
+                    protected: false,
+                    active_release_id: "release-production",
                   },
                 ],
-              },
-            }),
-            { headers: { "content-type": "application/json" } },
-          ),
-        );
-      }
+              }),
+              { headers: { "content-type": "application/json" } },
+            ),
+          );
+        }
 
-      return Promise.reject(new Error(`unexpected fetch: ${url}`));
-    }) as typeof fetch;
+        if (String(url).includes("/projects/support-agent-fork/environment-variables?")) {
+          assertEquals(
+            String(url).includes(
+              "environment_id=10000000-1000-4000-8000-100000000097",
+            ),
+            true,
+          );
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                data: [
+                  { key: "CUSTOM_PROJECT_ENV", value: "project-value" },
+                  { key: "VERYFRONT_API_TOKEN", value: "unsafe-project-token" },
+                  { key: "VERYFRONT_API_URL", value: "https://evil.example" },
+                  { key: "VERYFRONT_PROJECT_SLUG", value: "wrong-project" },
+                  {
+                    key: "OTEL_EXPORTER_OTLP_ENDPOINT",
+                    value: "https://tenant-collector.example/otlp",
+                  },
+                  { key: "OTEL_RESOURCE_ATTRIBUTES", value: "tenant.secret=do-not-export" },
+                ],
+              }),
+              { headers: { "content-type": "application/json" } },
+            ),
+          );
+        }
+
+        if (String(url) === `${TEST_PUBLIC_API_ORIGIN}/mcp`) {
+          capturedMcpRequest = {
+            url: String(url),
+            authorization: new Headers(observeFetchRequestInit(init).headers).get("authorization"),
+          };
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: "veryfront-platform-mcp:tools:list",
+                result: {
+                  tools: [
+                    {
+                      name: "search_knowledge",
+                      description: "Search knowledge",
+                      inputSchema: { type: "object", properties: {} },
+                    },
+                    {
+                      name: "list_projects",
+                      description: "List projects",
+                      inputSchema: { type: "object", properties: {} },
+                    },
+                  ],
+                },
+              }),
+              { headers: { "content-type": "application/json" } },
+            ),
+          );
+        }
+
+        return Promise.reject(new Error(`unexpected fetch: ${url}`));
+      }) as typeof fetch,
+    );
 
     let result;
     try {
@@ -2073,7 +2082,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
         ctx,
       );
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
       if (originalApiUrl === undefined) Deno.env.delete("VERYFRONT_API_URL");
       else Deno.env.set("VERYFRONT_API_URL", originalApiUrl);
       if (originalApiBaseUrl === undefined) Deno.env.delete("VERYFRONT_API_BASE_URL");
@@ -2111,39 +2120,40 @@ describe("server/handlers/request/agent-stream.handler", () => {
     const targetEnvironmentId = "10000000-1000-4000-8000-100000000088";
     let capturedProjectEnv: string | undefined;
     const fetchUrls: string[] = [];
-    const originalFetch = globalThis.fetch;
     const originalApiUrl = Deno.env.get("VERYFRONT_API_URL");
     const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
 
     Deno.env.set("VERYFRONT_API_URL", "https://api.veryfront.org");
     Deno.env.delete("VERYFRONT_API_BASE_URL");
-    globalThis.fetch = ((url, init) => {
-      const urlString = String(url);
-      fetchUrls.push(urlString);
-      assertEquals(
-        new Headers(observeFetchRequestInit(init).headers).get("authorization"),
-        "Bearer request-scoped-user-token",
-      );
-      if (urlString === "https://api.veryfront.org/projects/demo-project/environments") {
-        return Promise.resolve(Response.json({
-          data: [{
-            id: targetEnvironmentId,
-            name: "staging",
-            active_release_id: "release-staging",
-          }],
-        }));
-      }
-      assertEquals(
-        urlString,
-        `https://api.veryfront.org/projects/demo-project/environment-variables?environment_id=${targetEnvironmentId}&limit=100`,
-      );
-      return Promise.resolve(
-        new Response(
-          JSON.stringify({ data: [{ key: "TARGET_ENV_VALUE", value: "staging-value" }] }),
-          { headers: { "content-type": "application/json" } },
-        ),
-      );
-    }) as typeof fetch;
+    installMockFetch(
+      ((url, init) => {
+        const urlString = String(url);
+        fetchUrls.push(urlString);
+        assertEquals(
+          new Headers(observeFetchRequestInit(init).headers).get("authorization"),
+          "Bearer request-scoped-user-token",
+        );
+        if (urlString === "https://api.veryfront.org/projects/demo-project/environments") {
+          return Promise.resolve(Response.json({
+            data: [{
+              id: targetEnvironmentId,
+              name: "staging",
+              active_release_id: "release-staging",
+            }],
+          }));
+        }
+        assertEquals(
+          urlString,
+          `https://api.veryfront.org/projects/demo-project/environment-variables?environment_id=${targetEnvironmentId}&limit=100`,
+        );
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ data: [{ key: "TARGET_ENV_VALUE", value: "staging-value" }] }),
+            { headers: { "content-type": "application/json" } },
+          ),
+        );
+      }) as typeof fetch,
+    );
 
     const agent = createAgentWithConfig("assistant-1", {
       system: () => `target=${getEnv("TARGET_ENV_VALUE")}`,
@@ -2210,7 +2220,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
         },
       );
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
       if (originalApiUrl === undefined) Deno.env.delete("VERYFRONT_API_URL");
       else Deno.env.set("VERYFRONT_API_URL", originalApiUrl);
       if (originalApiBaseUrl === undefined) Deno.env.delete("VERYFRONT_API_BASE_URL");
@@ -2298,79 +2308,80 @@ describe("server/handlers/request/agent-stream.handler", () => {
       proxyToken: "run-scoped-token",
       projectSlug: "base-url-agent-fork",
     };
-    const originalFetch = globalThis.fetch;
     const originalApiUrl = Deno.env.get("VERYFRONT_API_URL");
     const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
     const fetchUrls: string[] = [];
     Deno.env.set("VERYFRONT_API_URL", "https://1.1.1.1/unused-fallback");
     Deno.env.set("VERYFRONT_API_BASE_URL", apiBaseUrl);
-    globalThis.fetch = ((url, init) => {
-      fetchUrls.push(String(url));
-      assertEquals(
-        new Headers(observeFetchRequestInit(init).headers).get("authorization"),
-        "Bearer request-scoped-user-token",
-      );
+    installMockFetch(
+      ((url, init) => {
+        fetchUrls.push(String(url));
+        assertEquals(
+          new Headers(observeFetchRequestInit(init).headers).get("authorization"),
+          "Bearer request-scoped-user-token",
+        );
 
-      if (String(url) === `${canonicalApiOrigin}/mcp`) {
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              jsonrpc: "2.0",
-              id: "veryfront-platform-mcp:tools:list",
-              result: {
-                tools: [
+        if (String(url) === `${canonicalApiOrigin}/mcp`) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: "veryfront-platform-mcp:tools:list",
+                result: {
+                  tools: [
+                    {
+                      name: "list_projects",
+                      description: "List projects",
+                      inputSchema: { type: "object", properties: {} },
+                    },
+                  ],
+                },
+              }),
+              { headers: { "content-type": "application/json" } },
+            ),
+          );
+        }
+
+        if (String(url) === `${canonicalApiOrigin}/projects/base-url-agent-fork/environments`) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                data: [
                   {
-                    name: "list_projects",
-                    description: "List projects",
-                    inputSchema: { type: "object", properties: {} },
+                    id: "10000000-1000-4000-8000-100000000096",
+                    name: "production",
+                    protected: false,
+                    active_release_id: "release-production",
                   },
                 ],
-              },
-            }),
-            { headers: { "content-type": "application/json" } },
-          ),
-        );
-      }
+              }),
+              { headers: { "content-type": "application/json" } },
+            ),
+          );
+        }
 
-      if (String(url) === `${canonicalApiOrigin}/projects/base-url-agent-fork/environments`) {
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              data: [
-                {
-                  id: "10000000-1000-4000-8000-100000000096",
-                  name: "production",
-                  protected: false,
-                  active_release_id: "release-production",
-                },
-              ],
-            }),
-            { headers: { "content-type": "application/json" } },
-          ),
-        );
-      }
+        if (
+          String(url).includes(`${apiBaseUrl}/projects/base-url-agent-fork/environment-variables?`)
+        ) {
+          assertEquals(
+            String(url).includes(
+              "environment_id=10000000-1000-4000-8000-100000000096",
+            ),
+            true,
+          );
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                data: [{ key: "CUSTOM_PROJECT_ENV", value: "project-value-from-base-url" }],
+              }),
+              { headers: { "content-type": "application/json" } },
+            ),
+          );
+        }
 
-      if (
-        String(url).includes(`${apiBaseUrl}/projects/base-url-agent-fork/environment-variables?`)
-      ) {
-        assertEquals(
-          String(url).includes(
-            "environment_id=10000000-1000-4000-8000-100000000096",
-          ),
-          true,
-        );
-        return Promise.resolve(
-          new Response(
-            JSON.stringify({
-              data: [{ key: "CUSTOM_PROJECT_ENV", value: "project-value-from-base-url" }],
-            }),
-            { headers: { "content-type": "application/json" } },
-          ),
-        );
-      }
-
-      return Promise.reject(new Error(`unexpected fetch: ${url}`));
-    }) as typeof fetch;
+        return Promise.reject(new Error(`unexpected fetch: ${url}`));
+      }) as typeof fetch,
+    );
 
     let result;
     try {
@@ -2386,7 +2397,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
         ctx,
       );
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
       if (originalApiUrl === undefined) Deno.env.delete("VERYFRONT_API_URL");
       else Deno.env.set("VERYFRONT_API_URL", originalApiUrl);
       if (originalApiBaseUrl === undefined) Deno.env.delete("VERYFRONT_API_BASE_URL");
@@ -2940,13 +2951,14 @@ describe("server/handlers/request/agent-stream.handler", () => {
   });
 
   it("fails closed with typed authorization semantics when named env lookup is denied", async () => {
-    const originalFetch = globalThis.fetch;
     let discoveryCalls = 0;
     let redirect: RequestRedirect | undefined;
-    globalThis.fetch = ((_input, init) => {
-      redirect = observeFetchRequestInit(init).redirect;
-      return Promise.resolve(new Response(null, { status: 403 }));
-    }) as typeof fetch;
+    installMockFetch(
+      ((_input, init) => {
+        redirect = observeFetchRequestInit(init).redirect;
+        return Promise.resolve(new Response(null, { status: 403 }));
+      }) as typeof fetch,
+    );
     const handler = new AgentStreamHandler({
       ensureProjectDiscovery: async () => {
         discoveryCalls += 1;
@@ -2995,30 +3007,31 @@ describe("server/handlers/request/agent-stream.handler", () => {
       assertEquals(discoveryCalls, 0);
       assertEquals(redirect, "error");
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 
   it("rejects a stale named environment source before loading project secrets", async () => {
-    const originalFetch = globalThis.fetch;
     let discoveryCalls = 0;
     let environmentVariableCalls = 0;
-    globalThis.fetch = ((input) => {
-      const url = String(input);
-      if (url.endsWith("/projects/support-agent-fork/environments")) {
-        return Promise.resolve(Response.json({
-          data: [{
-            id: "10000000-1000-4000-8000-100000000098",
-            name: "staging",
-            active_release_id: "release-new",
-          }],
-        }));
-      }
-      if (url.includes("/environment-variables?")) {
-        environmentVariableCalls += 1;
-      }
-      return Promise.reject(new Error(`unexpected fetch: ${url}`));
-    }) as typeof fetch;
+    installMockFetch(
+      ((input) => {
+        const url = String(input);
+        if (url.endsWith("/projects/support-agent-fork/environments")) {
+          return Promise.resolve(Response.json({
+            data: [{
+              id: "10000000-1000-4000-8000-100000000098",
+              name: "staging",
+              active_release_id: "release-new",
+            }],
+          }));
+        }
+        if (url.includes("/environment-variables?")) {
+          environmentVariableCalls += 1;
+        }
+        return Promise.reject(new Error(`unexpected fetch: ${url}`));
+      }) as typeof fetch,
+    );
     const handler = new AgentStreamHandler({
       ensureProjectDiscovery: async () => {
         discoveryCalls += 1;
@@ -3064,17 +3077,18 @@ describe("server/handlers/request/agent-stream.handler", () => {
       assertEquals(environmentVariableCalls, 0);
       assertEquals(discoveryCalls, 0);
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 
   it("does not discover or inject production secrets for a branch source", async () => {
-    const originalFetch = globalThis.fetch;
     let fetchCalls = 0;
-    globalThis.fetch = (() => {
-      fetchCalls += 1;
-      return Promise.reject(new Error("branch source must not fetch an environment"));
-    }) as typeof fetch;
+    installMockFetch(
+      (() => {
+        fetchCalls += 1;
+        return Promise.reject(new Error("branch source must not fetch an environment"));
+      }) as typeof fetch,
+    );
     const handler = new AgentStreamHandler({
       ensureProjectDiscovery: async () => createEmptyDiscoveryResult(),
       getAgent: () => undefined,
@@ -3105,7 +3119,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
       assertEquals(result.response.status, 404);
       assertEquals(fetchCalls, 0);
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 

--- a/src/testing/mock-fetch.ts
+++ b/src/testing/mock-fetch.ts
@@ -1,4 +1,7 @@
-import { __runWithOutboundFetchTransportForTests } from "#veryfront/security/http/outbound-fetch.ts";
+import {
+  __installOutboundFetchTransportForTests,
+  __runWithOutboundFetchTransportForTests,
+} from "#veryfront/security/http/outbound-fetch.ts";
 
 type FetchMock = typeof globalThis.fetch | undefined;
 
@@ -88,4 +91,53 @@ export async function withMockFetch<T>(
       release();
     }
   }
+}
+
+/**
+ * Install `mockFetch` as both the ambient `globalThis.fetch` and the host
+ * outbound transport, until `restoreMockFetch` puts them back.
+ *
+ * Assigning `globalThis.fetch` alone controls only code that calls `fetch`
+ * directly. Anything routed through `guardedOutboundFetch` reads the host
+ * transport instead and would reach the real network, so both move together
+ * here or neither does.
+ *
+ * Prefer `withMockFetch` where the stub has a single callback to scope. This
+ * pair exists for suites that install per test and tear down in `afterEach`,
+ * where there is no callback to wrap.
+ */
+export function installMockFetch(mockFetch: typeof globalThis.fetch): void {
+  const restoreTransport = __installOutboundFetchTransportForTests({
+    fetch: mockFetch,
+    pinnedFetch: (url, _addresses, init) => mockFetch(url, init),
+  });
+  // Only the first install records the pristine state, so a test that swaps its
+  // stub mid-way still restores to the real transport rather than to its own
+  // earlier stub.
+  installedMockFetch ??= { fetch: globalThis.fetch, restoreTransport };
+  defineGlobalFetch(mockFetch);
+}
+
+/**
+ * Restore the ambient fetch and outbound transport that were in place before
+ * the first `installMockFetch`. Safe to call when nothing is installed.
+ */
+export function restoreMockFetch(): void {
+  const installed = installedMockFetch;
+  if (!installed) return;
+  installedMockFetch = undefined;
+  installed.restoreTransport();
+  defineGlobalFetch(installed.fetch);
+}
+
+let installedMockFetch:
+  | { fetch: typeof globalThis.fetch; restoreTransport: () => void }
+  | undefined;
+
+function defineGlobalFetch(value: typeof globalThis.fetch): void {
+  Object.defineProperty(globalThis, "fetch", {
+    value,
+    configurable: true,
+    writable: true,
+  });
 }

--- a/src/testing/preload.ts
+++ b/src/testing/preload.ts
@@ -9,3 +9,10 @@
 
 import "./bdd.ts";
 import "../schemas/_test-setup.ts";
+import { __installUnpinnedHostTransportForTests } from "../security/http/outbound-fetch.ts";
+
+// Tests that genuinely reach the network use the plain host transport rather
+// than Deno's pinned SOCKS client, which holds connections open past the end of
+// a test. Installing it here keeps the security module to a single rule and
+// leaves the test-only decision somewhere a reader can find it.
+__installUnpinnedHostTransportForTests();

--- a/src/workflow/blob/veryfront-cloud-storage.test.ts
+++ b/src/workflow/blob/veryfront-cloud-storage.test.ts
@@ -1,11 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 import { runWithVeryfrontCloudContext } from "#veryfront/provider";
 import { VeryfrontCloudBlobStorage } from "./veryfront-cloud-storage.ts";
 
-const originalFetch = globalThis.fetch;
 const FIXED_NOW = new Date("2026-03-08T12:00:00.000Z");
 
 interface FetchCallRecord {
@@ -51,166 +51,168 @@ function createMockUploadService() {
   const pendingUploads = new Map<string, PendingUpload>();
   const fetchCalls: FetchCallRecord[] = [];
 
-  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
-    const request = new Request(input, init);
-    const url = new URL(request.url);
-    const method = request.method.toUpperCase();
-    const headers = new Headers(request.headers);
+  installMockFetch(
+    (async (input: string | URL | Request, init?: RequestInit) => {
+      const request = new Request(input, init);
+      const url = new URL(request.url);
+      const method = request.method.toUpperCase();
+      const headers = new Headers(request.headers);
 
-    fetchCalls.push({
-      url: url.toString(),
-      method,
-      headers,
-    });
+      fetchCalls.push({
+        url: url.toString(),
+        method,
+        headers,
+      });
 
-    if (url.origin === "https://93.184.216.34") {
-      const authHeader = headers.get("Authorization");
-      if (!authHeader?.startsWith("Bearer ")) {
-        return new Response("Unauthorized", { status: 401 });
-      }
-
-      const createMatch = url.pathname.match(/^\/projects\/([^/]+)\/uploads$/);
-      if (createMatch && method === "GET") {
-        const projectSlug = decodeURIComponent(createMatch[1] ?? "");
-        const prefix = `${projectSlug}:`;
-        const data = [...uploads.keys()]
-          .filter((key) => key.startsWith(prefix))
-          .map((key) => ({ path: key.slice(prefix.length) }));
-        return Response.json({ data });
-      }
-      if (createMatch && method === "POST") {
-        const projectSlug = decodeURIComponent(createMatch[1] ?? "");
-        const body = await request.json() as {
-          file_path: string;
-          content_type?: string;
-          size: number;
-        };
-
-        pendingUploads.set(makeStorageKey(projectSlug, body.file_path), {
-          projectSlug,
-          path: body.file_path,
-          contentType: body.content_type ?? "application/octet-stream",
-          size: body.size,
-        });
-
-        return Response.json({
-          file_upload_url: `https://93.184.216.35/${encodeURIComponent(projectSlug)}/${
-            encodeURIComponent(body.file_path)
-          }`,
-          file_path: `${projectSlug}/${body.file_path}`,
-          upload_id: crypto.randomUUID(),
-          required_headers: {
-            "Content-Type": body.content_type ?? "application/octet-stream",
-          },
-        }, { status: 201 });
-      }
-
-      const downloadMatch = url.pathname.match(/^\/projects\/([^/]+)\/uploads\/(.+)\/url$/);
-      if (downloadMatch && method === "GET") {
-        const projectSlug = decodeURIComponent(downloadMatch[1] ?? "");
-        const path = decodeURIComponent(downloadMatch[2] ?? "");
-        const key = makeStorageKey(projectSlug, path);
-        if (!uploads.has(key)) {
-          return new Response("Not found", { status: 404 });
+      if (url.origin === "https://93.184.216.34") {
+        const authHeader = headers.get("Authorization");
+        if (!authHeader?.startsWith("Bearer ")) {
+          return new Response("Unauthorized", { status: 401 });
         }
 
-        return Response.json({
-          signed_url: `https://93.184.216.36/${encodeURIComponent(projectSlug)}/${
-            encodeURIComponent(path)
-          }`,
-          expires_at: new Date(FIXED_NOW.getTime() + 30 * 60 * 1000).toISOString(),
-        });
-      }
+        const createMatch = url.pathname.match(/^\/projects\/([^/]+)\/uploads$/);
+        if (createMatch && method === "GET") {
+          const projectSlug = decodeURIComponent(createMatch[1] ?? "");
+          const prefix = `${projectSlug}:`;
+          const data = [...uploads.keys()]
+            .filter((key) => key.startsWith(prefix))
+            .map((key) => ({ path: key.slice(prefix.length) }));
+          return Response.json({ data });
+        }
+        if (createMatch && method === "POST") {
+          const projectSlug = decodeURIComponent(createMatch[1] ?? "");
+          const body = await request.json() as {
+            file_path: string;
+            content_type?: string;
+            size: number;
+          };
 
-      const metadataMatch = url.pathname.match(/^\/projects\/([^/]+)\/uploads\/(.+)$/);
-      if (metadataMatch) {
-        const projectSlug = decodeURIComponent(metadataMatch[1] ?? "");
-        const path = decodeURIComponent(metadataMatch[2] ?? "");
-        const key = makeStorageKey(projectSlug, path);
+          pendingUploads.set(makeStorageKey(projectSlug, body.file_path), {
+            projectSlug,
+            path: body.file_path,
+            contentType: body.content_type ?? "application/octet-stream",
+            size: body.size,
+          });
 
-        if (method === "GET") {
-          const upload = uploads.get(key);
-          if (!upload) {
+          return Response.json({
+            file_upload_url: `https://93.184.216.35/${encodeURIComponent(projectSlug)}/${
+              encodeURIComponent(body.file_path)
+            }`,
+            file_path: `${projectSlug}/${body.file_path}`,
+            upload_id: crypto.randomUUID(),
+            required_headers: {
+              "Content-Type": body.content_type ?? "application/octet-stream",
+            },
+          }, { status: 201 });
+        }
+
+        const downloadMatch = url.pathname.match(/^\/projects\/([^/]+)\/uploads\/(.+)\/url$/);
+        if (downloadMatch && method === "GET") {
+          const projectSlug = decodeURIComponent(downloadMatch[1] ?? "");
+          const path = decodeURIComponent(downloadMatch[2] ?? "");
+          const key = makeStorageKey(projectSlug, path);
+          if (!uploads.has(key)) {
             return new Response("Not found", { status: 404 });
           }
 
           return Response.json({
-            id: crypto.randomUUID(),
-            path,
-            file_name: path.split("/").pop() ?? path,
-            content_type: upload.contentType,
-            size: upload.bytes.byteLength,
-            url: null,
-            status: "active",
-            visibility: "project",
-            created_at: upload.createdAt,
-            updated_at: upload.createdAt,
-            deleted_at: null,
+            signed_url: `https://93.184.216.36/${encodeURIComponent(projectSlug)}/${
+              encodeURIComponent(path)
+            }`,
+            expires_at: new Date(FIXED_NOW.getTime() + 30 * 60 * 1000).toISOString(),
           });
         }
 
-        if (method === "DELETE") {
-          const existed = uploads.delete(key);
-          return new Response(null, { status: existed ? 204 : 404 });
+        const metadataMatch = url.pathname.match(/^\/projects\/([^/]+)\/uploads\/(.+)$/);
+        if (metadataMatch) {
+          const projectSlug = decodeURIComponent(metadataMatch[1] ?? "");
+          const path = decodeURIComponent(metadataMatch[2] ?? "");
+          const key = makeStorageKey(projectSlug, path);
+
+          if (method === "GET") {
+            const upload = uploads.get(key);
+            if (!upload) {
+              return new Response("Not found", { status: 404 });
+            }
+
+            return Response.json({
+              id: crypto.randomUUID(),
+              path,
+              file_name: path.split("/").pop() ?? path,
+              content_type: upload.contentType,
+              size: upload.bytes.byteLength,
+              url: null,
+              status: "active",
+              visibility: "project",
+              created_at: upload.createdAt,
+              updated_at: upload.createdAt,
+              deleted_at: null,
+            });
+          }
+
+          if (method === "DELETE") {
+            const existed = uploads.delete(key);
+            return new Response(null, { status: existed ? 204 : 404 });
+          }
         }
       }
-    }
 
-    if (url.origin === "https://93.184.216.35" && method === "PUT") {
-      const [, encodedProjectSlug = "", encodedPath = ""] = url.pathname.split("/");
-      const projectSlug = decodeURIComponent(encodedProjectSlug);
-      const path = decodeURIComponent(encodedPath);
-      const key = makeStorageKey(projectSlug, path);
-      const pending = pendingUploads.get(key);
+      if (url.origin === "https://93.184.216.35" && method === "PUT") {
+        const [, encodedProjectSlug = "", encodedPath = ""] = url.pathname.split("/");
+        const projectSlug = decodeURIComponent(encodedProjectSlug);
+        const path = decodeURIComponent(encodedPath);
+        const key = makeStorageKey(projectSlug, path);
+        const pending = pendingUploads.get(key);
 
-      if (!pending) {
-        return new Response("Missing pending upload", { status: 404 });
+        if (!pending) {
+          return new Response("Missing pending upload", { status: 404 });
+        }
+
+        const bytes = new Uint8Array(await request.arrayBuffer());
+        assertEquals(bytes.byteLength, pending.size);
+
+        uploads.set(key, {
+          bytes,
+          contentType: pending.contentType,
+          createdAt: FIXED_NOW.toISOString(),
+        });
+        pendingUploads.delete(key);
+
+        return new Response(null, { status: 200 });
       }
 
-      const bytes = new Uint8Array(await request.arrayBuffer());
-      assertEquals(bytes.byteLength, pending.size);
+      if (url.origin === "https://93.184.216.36" && method === "GET") {
+        const [, encodedProjectSlug = "", encodedPath = ""] = url.pathname.split("/");
+        const projectSlug = decodeURIComponent(encodedProjectSlug);
+        const path = decodeURIComponent(encodedPath);
+        const upload = uploads.get(makeStorageKey(projectSlug, path));
 
-      uploads.set(key, {
-        bytes,
-        contentType: pending.contentType,
-        createdAt: FIXED_NOW.toISOString(),
-      });
-      pendingUploads.delete(key);
+        if (!upload) {
+          return new Response("Not found", { status: 404 });
+        }
 
-      return new Response(null, { status: 200 });
-    }
-
-    if (url.origin === "https://93.184.216.36" && method === "GET") {
-      const [, encodedProjectSlug = "", encodedPath = ""] = url.pathname.split("/");
-      const projectSlug = decodeURIComponent(encodedProjectSlug);
-      const path = decodeURIComponent(encodedPath);
-      const upload = uploads.get(makeStorageKey(projectSlug, path));
-
-      if (!upload) {
-        return new Response("Not found", { status: 404 });
+        return new Response(Uint8Array.from(upload.bytes), {
+          status: 200,
+          headers: { "Content-Type": upload.contentType },
+        });
       }
 
-      return new Response(Uint8Array.from(upload.bytes), {
-        status: 200,
-        headers: { "Content-Type": upload.contentType },
-      });
-    }
-
-    throw new Error(`Unhandled fetch: ${method} ${url.toString()}`);
-  }) as typeof fetch;
+      throw new Error(`Unhandled fetch: ${method} ${url.toString()}`);
+    }) as typeof fetch,
+  );
 
   return {
     uploads,
     fetchCalls,
     restore() {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     },
   };
 }
 
 describe("VeryfrontCloudBlobStorage", () => {
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
   });
 
   it("stores, retrieves, stats, and deletes blobs via project uploads", async () => {
@@ -399,10 +401,12 @@ describe("VeryfrontCloudBlobStorage", () => {
     Deno.env.set("VERYFRONT_API_BASE_URL", "https://93.184.216.34");
     Deno.env.set("VERYFRONT_API_TOKEN", "host-token");
     let fetchCalls = 0;
-    globalThis.fetch = (() => {
-      fetchCalls++;
-      return Promise.resolve(new Response("unexpected"));
-    }) as typeof fetch;
+    installMockFetch(
+      (() => {
+        fetchCalls++;
+        return Promise.resolve(new Response("unexpected"));
+      }) as typeof fetch,
+    );
 
     try {
       await runWithVeryfrontCloudContext(
@@ -456,25 +460,27 @@ describe("VeryfrontCloudBlobStorage", () => {
 
   it("times out and cancels a stalled signed-download body", async () => {
     let cancelled = false;
-    globalThis.fetch = ((input: string | URL | Request) => {
-      const url = new URL(String(input));
-      if (url.origin === "https://93.184.216.34") {
-        return Promise.resolve(Response.json({
-          signed_url: "https://93.184.216.35/download",
-          expires_at: FIXED_NOW.toISOString(),
-        }));
-      }
-      return Promise.resolve(
-        new Response(
-          new ReadableStream({
-            pull: () => new Promise<void>(() => {}),
-            cancel() {
-              cancelled = true;
-            },
-          }),
-        ),
-      );
-    }) as typeof fetch;
+    installMockFetch(
+      ((input: string | URL | Request) => {
+        const url = new URL(String(input));
+        if (url.origin === "https://93.184.216.34") {
+          return Promise.resolve(Response.json({
+            signed_url: "https://93.184.216.35/download",
+            expires_at: FIXED_NOW.toISOString(),
+          }));
+        }
+        return Promise.resolve(
+          new Response(
+            new ReadableStream({
+              pull: () => new Promise<void>(() => {}),
+              cancel() {
+                cancelled = true;
+              },
+            }),
+          ),
+        );
+      }) as typeof fetch,
+    );
     const storage = new VeryfrontCloudBlobStorage({
       apiBaseUrl: "https://93.184.216.34",
       apiToken: "vf_test",
@@ -487,16 +493,18 @@ describe("VeryfrontCloudBlobStorage", () => {
   });
 
   it("rejects oversized signed-download bodies", async () => {
-    globalThis.fetch = ((input: string | URL | Request) => {
-      const url = new URL(String(input));
-      if (url.origin === "https://93.184.216.34") {
-        return Promise.resolve(Response.json({
-          signed_url: "https://93.184.216.35/download",
-          expires_at: FIXED_NOW.toISOString(),
-        }));
-      }
-      return Promise.resolve(new Response(new Uint8Array([1, 2, 3, 4, 5])));
-    }) as typeof fetch;
+    installMockFetch(
+      ((input: string | URL | Request) => {
+        const url = new URL(String(input));
+        if (url.origin === "https://93.184.216.34") {
+          return Promise.resolve(Response.json({
+            signed_url: "https://93.184.216.35/download",
+            expires_at: FIXED_NOW.toISOString(),
+          }));
+        }
+        return Promise.resolve(new Response(new Uint8Array([1, 2, 3, 4, 5])));
+      }) as typeof fetch,
+    );
     const storage = new VeryfrontCloudBlobStorage({
       apiBaseUrl: "https://93.184.216.34",
       apiToken: "vf_test",
@@ -509,10 +517,12 @@ describe("VeryfrontCloudBlobStorage", () => {
 
   it("rejects known-size uploads before opening a network request", async () => {
     let fetchCalls = 0;
-    globalThis.fetch = (() => {
-      fetchCalls++;
-      return Promise.resolve(new Response("unexpected"));
-    }) as typeof fetch;
+    installMockFetch(
+      (() => {
+        fetchCalls++;
+        return Promise.resolve(new Response("unexpected"));
+      }) as typeof fetch,
+    );
     const storage = new VeryfrontCloudBlobStorage({
       apiBaseUrl: "https://93.184.216.34",
       apiToken: "vf_test",
@@ -539,10 +549,12 @@ describe("VeryfrontCloudBlobStorage", () => {
   it("bounds and cancels streamed upload preprocessing", async () => {
     let cancelled = false;
     let fetchCalls = 0;
-    globalThis.fetch = (() => {
-      fetchCalls++;
-      return Promise.resolve(new Response("unexpected"));
-    }) as typeof fetch;
+    installMockFetch(
+      (() => {
+        fetchCalls++;
+        return Promise.resolve(new Response("unexpected"));
+      }) as typeof fetch,
+    );
     const input = new ReadableStream<Uint8Array>({
       start(controller) {
         controller.enqueue(new Uint8Array([1, 2, 3]));
@@ -567,10 +579,12 @@ describe("VeryfrontCloudBlobStorage", () => {
   it("does not await a project stream cancellation that never settles", async () => {
     let cancelCalls = 0;
     let fetchCalls = 0;
-    globalThis.fetch = (() => {
-      fetchCalls++;
-      return Promise.resolve(new Response("unexpected"));
-    }) as typeof fetch;
+    installMockFetch(
+      (() => {
+        fetchCalls++;
+        return Promise.resolve(new Response("unexpected"));
+      }) as typeof fetch,
+    );
     const input = new ReadableStream<Uint8Array>({
       start(controller) {
         controller.enqueue(new Uint8Array([1, 2]));
@@ -644,10 +658,12 @@ describe("VeryfrontCloudBlobStorage", () => {
     for (const testCase of cases) {
       let pulls = 0;
       let fetchCalls = 0;
-      globalThis.fetch = (() => {
-        fetchCalls++;
-        return Promise.resolve(new Response("unexpected"));
-      }) as typeof fetch;
+      installMockFetch(
+        (() => {
+          fetchCalls++;
+          return Promise.resolve(new Response("unexpected"));
+        }) as typeof fetch,
+      );
       const input = new ReadableStream<Uint8Array>(
         {
           pull(controller) {
@@ -677,10 +693,12 @@ describe("VeryfrontCloudBlobStorage", () => {
   it("times out and cancels a stalled upload stream before network access", async () => {
     let cancelled = false;
     let fetchCalls = 0;
-    globalThis.fetch = (() => {
-      fetchCalls++;
-      return Promise.resolve(new Response("unexpected"));
-    }) as typeof fetch;
+    installMockFetch(
+      (() => {
+        fetchCalls++;
+        return Promise.resolve(new Response("unexpected"));
+      }) as typeof fetch,
+    );
     const input = new ReadableStream<Uint8Array>({
       pull: () => new Promise<void>(() => {}),
       cancel() {

--- a/tests/docs/guide-examples.test-helpers.ts
+++ b/tests/docs/guide-examples.test-helpers.ts
@@ -1,4 +1,5 @@
 import "../_helpers/contract-init.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { agent } from "../../src/agent/factory.ts";
 
 export function jsonResponse(body: unknown, status = 200): Response {
@@ -18,10 +19,9 @@ export async function withMockedFetch<T>(
   responses: Response[],
   run: (calls: MockFetchCall[]) => Promise<T>,
 ): Promise<T> {
-  const originalFetch = globalThis.fetch;
   const calls: MockFetchCall[] = [];
 
-  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+  const mockFetch = (async (input: string | URL | Request, init?: RequestInit) => {
     const url = toRequestUrl(input);
     calls.push({ url, init });
     const next = responses.shift();
@@ -31,11 +31,7 @@ export async function withMockedFetch<T>(
     return next;
   }) as typeof fetch;
 
-  try {
-    return await run(calls);
-  } finally {
-    globalThis.fetch = originalFetch;
-  }
+  return await withMockFetch(mockFetch, () => run(calls));
 }
 
 export function createGuideAgent(


### PR DESCRIPTION
Delivers steps **1** and **2** of veryfront/veryfront-issue-inbox#692. Step 3 turns out to be blocked on something the issue did not know about — measured and reported below.

## What was wrong

Two ways to control outbound fetch in a test:

- the explicit seam `__runWithOutboundFetchTransportForTests` — scoped, self-restoring, typed;
- assigning `globalThis.fetch` and relying on `getTrustedHostTransport()` honouring it, which it did **only** under `DENO_TESTING=1`.

The second failed open. Without the flag the guard returned `capturedHostFetch` — the real network — so a test that stubbed fetch and expected a canned response called the live endpoint and failed with a provider 401/405 that looked nothing like the cause.

`getTrustedHostTransport()` now has one rule: the installed test transport if there is one, the captured host transport otherwise.

## The campaign is 12 files, not ~80

The issue estimated ~80 files to migrate, from the count of files assigning `globalThis.fetch`. That count is the wrong denominator: most of those stub fetch for code that calls `fetch` **directly**, which the host transport never mediates — deleting the branch does not affect them at all.

Rather than grep, I deleted the branch and ran the unit suite. Exactly **12 files** broke:

```
src/cache/backend.test.ts                       src/routing/api/module-loader/esbuild-plugin.test.ts
src/embedding/embedding.test.ts                 src/routing/api/openapi/mcp-tools.test.ts
src/oauth/handlers/callback-dispatcher.test.ts  src/runs/runs-client.test.ts
src/oauth/providers/base.test.ts                src/server/handlers/request/agent-stream.handler.test.ts
src/oauth/providers/protocols.test.ts           src/workflow/blob/veryfront-cloud-storage.test.ts
src/provider/model-registry.test.ts
src/provider/veryfront-cloud/provider.test.ts
```

CI then found **two more** that this probe could not see: `test:unit:parallel` excludes five cli files by path and does not run `tests/` at all. Both are migrated too:

```
cli/commands/schedule/handler.test.ts        (was spending 49s timing out against a real endpoint; now 81ms)
tests/docs/guide-examples.test-helpers.ts    (every runs.mdx guide example goes through it)
```

**14 files**, and step 2 is complete rather than pending a longer campaign.

## The branch was doing something the issue did not describe

It did not only honour ambient stubs. It also handed back a transport with **no address pinning**, so Deno tests used plain `fetch`. Without it they use Deno's pinned SOCKS client, which holds a connection open past the end of a test — `tests/integration/renderer/layouts.test.ts` fetches `esm.sh` and started failing the resource sanitiser with a leaked TCP connection.

That decision now lives in `src/testing/preload.ts`, named and commented, rather than being inferred from an environment variable inside the security module. Crucially it is **not a stub**: it installs the *captured host fetch*, so it still cannot silently honour a `globalThis.fetch` assignment the way the old branch did. A new test pins exactly that:

> `ignores a hand-assigned globalThis.fetch rather than failing open to it`

## The helper

`src/testing/mock-fetch.ts` already set both the ambient fetch and the transport via `withMockFetch(mock, fn)`. Most of these files install in `beforeEach` / restore in `afterEach`, where there is no single callback to wrap, so it gains a pair:

```ts
installMockFetch(mock);   // sets globalThis.fetch and the host transport
restoreMockFetch();       // back to the state before the *first* install
```

Restoring to the pristine state rather than one level up matters for tests that deliberately swap their stub mid-way (`embedding.test.ts` asserts a captured transport beats a later `globalThis.fetch` replacement) — those land on the real transport, not on their own earlier stub.

## Result

```
before (branch deleted, no migration):   3866 passed | 101 failed   10m43s
after  (14 files migrated):              3966 passed |   0 failed    1m53s
```

The 9-minute difference is those 101 failures each waiting out a real connection attempt.

`AGENTS.md` had a paragraph explaining the `DENO_TESTING` trap. It is replaced with what to use instead.

## Step 3 (loopback-only `--allow-net`) is blocked on the egress guard, not on 19 tests

Measured on this branch with `--allow-net=127.0.0.1,localhost,0.0.0.0,[::1],[::]`: **17 files fail**, and the cause is not what the issue expected.

```
16  OutboundRequestBlockedError: unable to resolve host <provider host>
```

`guardedEgressFetch` resolves the destination host to addresses **before** it consults the transport — that is the whole point of the DNS-pinned design. DNS resolution itself needs net permission for that host, so a fully stubbed test is still blocked at the pinning step. No amount of stub migration fixes it.

Getting to loopback-only therefore needs a decision the issue did not anticipate: let an installed test transport skip address pinning (which weakens what the egress-guard tests themselves verify), or grant DNS for the hosts under test. That belongs in its own issue.

Two things the issue predicted are already resolved: nothing in the unit suite reaches `api.veryfront.com` any more (`runs-client.test.ts` was the one), and `[::]` binding was not among the causes.

## Verification

All three suites, with `--trace-leaks`:

```
unit (test:unit:parallel equivalent)   3966 passed (30553 steps), 0 failed
unit (the five excluded cli files)       11 passed   (211 steps), 0 failed
integration (tests/)                    304 passed  (2841 steps), 0 failed
fmt:check / lint:anti-slop / docs:api-reference:check   clean
```

No generated churn committed: `deno.lock` and `templates/manifest.generated.ts` were touched by running the docs task and have been reverted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved network mocking across cache, embeddings, OAuth, provider, routing, workflow, and server test suites.
  * Tests now consistently isolate and restore both standard and guarded network requests.
  * Existing request, streaming, timeout, validation, security, and concurrency coverage remains intact.

* **Chores**
  * Added shared testing utilities for installing and restoring fetch mocks.
  * Updated testing guidance for blocking external LLM provider access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
