### PR TITLE
feat(workflow): add an end-to-end workflow test harness

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -108,6 +108,7 @@
     "./workflow": "./src/workflow/index.ts",
     "./workflow/registry": "./src/workflow/registry-public.ts",
     "./workflow/blob": "./src/workflow/blob/index.ts",
+    "./workflow/testing": "./src/workflow/testing.ts",
     "./workflow/worker": "./src/workflow/worker/index.ts",
     "./workflow/claude-code": "./src/workflow/claude-code/index.ts",
     "./workflow/claude-code/types": "./src/workflow/claude-code/types.ts",

--- a/docs/api-reference/veryfront/workflow.md
+++ b/docs/api-reference/veryfront/workflow.md
@@ -516,6 +516,28 @@ import { getAllWorkflowIds, getWorkflow, registerWorkflow } from "veryfront/work
 | ------------------ | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | `workflowRegistry` | Project-scoped registry for workflow metadata and definitions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L425) |
 
+### `veryfront/workflow/testing`
+
+Test primitives for driving a workflow end to end. Testing a workflow means waiting for something asynchronous and durable to reach a state, and every test that does it has written the same loop: `typescript while (Date.now() - start < timeout) { if ((await client.getRun(runId))?.status === "completed") break; await delay(50); }` That loop is where workflow tests go wrong. A bare `await delay(n)` passes on a fast machine and flakes on a loaded one; a poll with no deadline hangs the suite instead of failing it; and a timeout that reports only "timed out" sends the author back to add logging to find out what the run was actually doing. Every harness method here polls to a deadline and, on expiry, throws with the run's status, its pending approvals and its per-node states - the information you would otherwise have gone looking for. Approvals are addressed by **node id**, not approval id. A test author knows they wrote `waitForApproval("review")`; the approval's generated id is something they have to dig out of the run first. ## What this does not do There is no `advanceTime`. The executor schedules timed waits with real `setTimeout` and takes no clock, so fast-forwarding one would mean faking global timers for the whole process. A workflow that sleeps for an hour still sleeps for an hour here. Testing that honestly needs a clock seam in the executor, which is a change to the executor rather than a helper this module can provide.
+
+```ts
+import { startWorkflowTest } from "veryfront/workflow/testing";
+```
+
+#### Functions
+
+| Name                | Description                                           | Source                                                                                       |
+| ------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `startWorkflowTest` | Start a workflow and return a harness for driving it. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/testing.ts#L190) |
+
+#### Types
+
+| Name                       | Description                        | Source                                                                                      |
+| -------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------- |
+| `ApprovalDecisionOptions`  | Options for resolving an approval. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/testing.ts#L89) |
+| `StartWorkflowTestOptions` | Options for `startWorkflowTest`.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/testing.ts#L74) |
+| `WorkflowTestHarness`      | A running workflow under test.     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/testing.ts#L98) |
+
 ### `veryfront/workflow/worker`
 
 Workflow worker module Provides distributed workflow execution support. Two execution profiles are available: 1. **WorkflowWorker** - In-process polling worker - Polls for stalled workflows and resumes them - Good for trusted code or single-tenant deployments - Simple setup, lower overhead 2. **WorkflowRunManager + ProcessRunExecutor** - Local process execution - Spawns child processes for each workflow - Good for local development without K8s/Docker A workflow run can be backed by a run executor without introducing another user-visible execution type.

--- a/src/workflow/testing.test.ts
+++ b/src/workflow/testing.test.ts
@@ -1,0 +1,294 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { expect } from "#std/expect.ts";
+import type { Tool } from "#veryfront/tool";
+import { defineSchema } from "#veryfront/schemas/index.ts";
+import { step, waitForApproval, workflow } from "./dsl/index.ts";
+import { startWorkflowTest, type WorkflowTestHarness } from "./testing.ts";
+
+function recordingTool(id: string, order: string[]): Tool {
+  return {
+    id,
+    type: "function",
+    description: `Test tool: ${id}`,
+    inputSchema: defineSchema((v) => v.object({}).passthrough())(),
+    execute: () => {
+      order.push(id);
+      // Distinct completion timestamps: `steps()` orders by completedAt, and a
+      // same-millisecond tie would make the ordering assertion meaningless.
+      return new Promise((resolve) => setTimeout(() => resolve({ ok: true, id }), 2));
+    },
+  };
+}
+
+function explodingTool(id: string): Tool {
+  return {
+    id,
+    type: "function",
+    description: `Failing test tool: ${id}`,
+    inputSchema: defineSchema((v) => v.object({}).passthrough())(),
+    execute: () => Promise.reject(new Error("tool blew up")),
+  };
+}
+
+function stallingTool(id: string): Tool {
+  return {
+    id,
+    type: "function",
+    description: `Stalling test tool: ${id}`,
+    inputSchema: defineSchema((v) => v.object({}).passthrough())(),
+    execute: () => new Promise(() => {}),
+  };
+}
+
+describe("workflow/testing", { sanitizeOps: false, sanitizeResources: false }, () => {
+  const open: WorkflowTestHarness[] = [];
+
+  afterEach(async () => {
+    while (open.length) await open.pop()?.dispose();
+  });
+
+  async function start(
+    ...args: Parameters<typeof startWorkflowTest>
+  ): Promise<WorkflowTestHarness> {
+    const harness = await startWorkflowTest(...args);
+    open.push(harness);
+    return harness;
+  }
+
+  it("runs a workflow to completion and reports the steps in order", async () => {
+    const order: string[] = [];
+    const harness = await start(
+      workflow({
+        id: "pipeline",
+        steps: [
+          step("fetch", { tool: recordingTool("fetch", order) }),
+          step("load", { tool: recordingTool("load", order) }),
+        ],
+      }),
+      { input: { source: "s3://bucket/key" } },
+    );
+
+    const run = await harness.settled();
+
+    expect(run.status).toBe("completed");
+    await harness.assertSteps(["fetch", "load"]);
+    expect(order).toEqual(["fetch", "load"]);
+  });
+
+  it("exposes the context the steps accumulated", async () => {
+    const harness = await start(
+      workflow({ id: "one-step", steps: [step("only", { tool: recordingTool("only", []) })] }),
+      {},
+    );
+
+    await harness.settled();
+
+    expect(await harness.context()).toBeDefined();
+  });
+
+  it("resolves an approval by the node id the author wrote", async () => {
+    // Addressing by node id is the point: the approval's own id is generated,
+    // so a test would otherwise have to read the run to find it first.
+    const harness = await start(
+      workflow({
+        id: "gated",
+        steps: [
+          step("prepare", { tool: recordingTool("prepare", []) }),
+          waitForApproval("review", { message: "ok?" }),
+          step("publish", { tool: recordingTool("publish", []) }),
+        ],
+      }),
+      {},
+    );
+
+    await harness.reaches("waiting");
+    await harness.approve("review");
+
+    const run = await harness.settled();
+    expect(run.status).toBe("completed");
+    await harness.assertSteps(["prepare", "review", "publish"]);
+  });
+
+  it("waits for the approval to exist before deciding it", async () => {
+    // No `reaches("waiting")` first: approve() must poll for the approval
+    // rather than race the run into existence.
+    const harness = await start(
+      workflow({
+        id: "gated-immediate",
+        steps: [
+          waitForApproval("review", { message: "ok?" }),
+          step("publish", { tool: recordingTool("publish", []) }),
+        ],
+      }),
+      {},
+    );
+
+    await harness.approve("review");
+
+    expect((await harness.settled()).status).toBe("completed");
+  });
+
+  it("surfaces a rejected approval as a run that did not complete", async () => {
+    const harness = await start(
+      workflow({
+        id: "gated-reject",
+        steps: [
+          waitForApproval("review", { message: "ok?" }),
+          step("publish", { tool: recordingTool("publish", []) }),
+        ],
+      }),
+      {},
+    );
+
+    await harness.reject("review", { comment: "not this time" });
+    const run = await harness.settled();
+
+    expect(run.status).not.toBe("completed");
+    expect(await harness.steps()).not.toContain("publish");
+  });
+
+  it("reports pending approvals", async () => {
+    const harness = await start(
+      workflow({
+        id: "gated-list",
+        steps: [waitForApproval("review", { message: "ok?" })],
+      }),
+      {},
+    );
+
+    const approvals = await harness.approvals();
+
+    expect(approvals.length).toBeGreaterThanOrEqual(1);
+    expect(approvals[0]?.nodeId).toBe("review");
+  });
+
+  it("settles a failing run instead of hanging on it", async () => {
+    const harness = await start(
+      workflow({ id: "broken", steps: [step("boom", { tool: explodingTool("boom") })] }),
+      {},
+    );
+
+    const run = await harness.settled();
+
+    expect(run.status).toBe("failed");
+    await harness.assertStatus("failed");
+  });
+
+  it("cancels a run", async () => {
+    const harness = await start(
+      workflow({ id: "stalls", steps: [step("forever", { tool: stallingTool("forever") })] }),
+      {},
+    );
+
+    await harness.cancel();
+
+    expect((await harness.settled()).status).toBe("cancelled");
+  });
+
+  describe("failure reporting", () => {
+    it("names the run's state when a wait times out, not just the deadline", async () => {
+      // The whole reason this harness exists: a timeout that says only "timed
+      // out" sends the author back to add logging.
+      const harness = await start(
+        workflow({ id: "stalls-2", steps: [step("forever", { tool: stallingTool("forever") })] }),
+        { timeoutMs: 60 },
+      );
+
+      const error = await harness.settled().then(() => null, (e: Error) => e);
+
+      expect(error).toBeInstanceOf(Error);
+      const message = (error as Error).message;
+      expect(message).toContain(harness.runId);
+      expect(message).toContain("status=running");
+      // A run mid-step persists no node state, so the engine genuinely cannot
+      // name the stuck step. The message has to say that rather than print an
+      // empty list that reads like a corrupt run.
+      expect(message).toContain("unrecorded");
+
+      await harness.cancel();
+    });
+
+    it("names the pending approvals when waiting for the wrong node", async () => {
+      const harness = await start(
+        workflow({ id: "gated-3", steps: [waitForApproval("review", { message: "ok?" })] }),
+        { timeoutMs: 60 },
+      );
+
+      const error = await harness.approve("nonexistent").then(() => null, (e: Error) => e);
+
+      expect((error as Error).message).toContain('node "nonexistent"');
+      expect((error as Error).message).toContain("review");
+    });
+
+    it("shows what actually ran when a step assertion fails", async () => {
+      const harness = await start(
+        workflow({ id: "pipeline-2", steps: [step("only", { tool: recordingTool("only", []) })] }),
+        {},
+      );
+      await harness.settled();
+
+      const error = await harness.assertSteps(["only", "missing"]).then(
+        () => null,
+        (e: Error) => e,
+      );
+
+      expect((error as Error).message).toContain("ran [only]");
+      expect((error as Error).message).toContain("missing");
+    });
+  });
+
+  it("names the step a paused run is waiting on", async () => {
+    // The counterpart to the case above: a run that pauses does persist its
+    // node states, so the diagnostic can name the node -- and this pins which
+    // of the two shapes a given status produces.
+    const harness = await start(
+      workflow({
+        id: "gated-diag",
+        steps: [
+          step("prepare", { tool: recordingTool("prepare", []) }),
+          waitForApproval("review", { message: "ok?" }),
+        ],
+      }),
+      { timeoutMs: 2_000 },
+    );
+    await harness.reaches("waiting");
+
+    const error = await harness.reaches("completed").then(() => null, (e: Error) => e);
+
+    const message = (error as Error).message;
+    expect(message).toContain("executing: review");
+    expect(message).toContain("prepare=completed");
+    expect(message).toContain("pending approvals: review");
+  });
+
+  it("isolates harnesses from each other", async () => {
+    // Each harness gets its own backend by default, so one test's run is never
+    // visible to another's assertions.
+    const a = await start(
+      workflow({ id: "iso", steps: [step("s", { tool: recordingTool("s", []) })] }),
+      {},
+    );
+    const b = await start(
+      workflow({ id: "iso", steps: [step("s", { tool: recordingTool("s", []) })] }),
+      {},
+    );
+
+    await a.settled();
+    await b.settled();
+
+    expect(a.runId).not.toBe(b.runId);
+    expect(await a.client.getRun(b.runId)).toBeNull();
+  });
+
+  it("is safe to dispose more than once", async () => {
+    const harness = await startWorkflowTest(
+      workflow({ id: "disposable", steps: [step("s", { tool: recordingTool("s", []) })] }),
+      {},
+    );
+    await harness.settled();
+
+    await harness.dispose();
+    await harness.dispose();
+  });
+});

--- a/src/workflow/testing.test.ts
+++ b/src/workflow/testing.test.ts
@@ -41,7 +41,7 @@ function stallingTool(id: string): Tool {
   };
 }
 
-describe("workflow/testing", { sanitizeOps: false, sanitizeResources: false }, () => {
+describe("workflow/testing", () => {
   const open: WorkflowTestHarness[] = [];
 
   afterEach(async () => {

--- a/src/workflow/testing.ts
+++ b/src/workflow/testing.ts
@@ -32,6 +32,20 @@
  * the executor, which is a change to the executor rather than a helper this
  * module can provide.
  *
+ * ## Where this sits
+ *
+ * This is a domain fixture, not a test runner. `veryfront/testing/bdd` is
+ * already the runtime-decoupled runner -- it maps `describe`/`it` onto
+ * `@std/testing/bdd` on Deno, `node:test` on Node and `bun:test` on Bun -- and
+ * this module is used inside tests that runner executes. It deliberately adds
+ * no test-lifecycle concepts of its own, and imports nothing Deno-specific, so
+ * it works on every runtime the framework supports.
+ *
+ * The polling loop here is not a reimplementation of
+ * `veryfront/testing`'s `waitFor`. That one answers a boolean and throws a
+ * generic timeout; these waits have to return the matched run or approval, and
+ * their failure has to carry the run's state. They do share its time scaling.
+ *
  * @module workflow/testing
  *
  * @example
@@ -50,6 +64,8 @@
  * ```
  */
 
+import { registerTestCleanup } from "#veryfront/testing/isolation.ts";
+import { scaleMs } from "#veryfront/testing/timing.ts";
 import { MemoryBackend } from "./backends/memory.ts";
 import { createWorkflowClient, type WorkflowClient } from "./api/workflow-client.ts";
 import type { WorkflowBackend } from "./backends/types.ts";
@@ -66,7 +82,14 @@ import type {
 /** Statuses a run cannot move out of. */
 const TERMINAL: readonly WorkflowStatus[] = ["completed", "failed", "cancelled"] as const;
 
-/** How long any wait polls before giving up. */
+/**
+ * How long any wait polls before giving up, and how often it checks.
+ *
+ * Both are passed through `scaleMs`, the framework's test time scale. Without
+ * it a fixed deadline is the same flake this harness exists to remove: it
+ * holds on a developer machine and expires on a loaded CI runner, and the
+ * failure looks like a product bug rather than a starved test.
+ */
 const DEFAULT_TIMEOUT_MS = 5_000;
 const POLL_INTERVAL_MS = 10;
 
@@ -191,7 +214,7 @@ export async function startWorkflowTest<TInput = unknown, TOutput = unknown>(
   definition: Workflow | WorkflowDefinition,
   options: StartWorkflowTestOptions<TInput> = {},
 ): Promise<WorkflowTestHarness<TOutput>> {
-  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const timeoutMs = scaleMs(options.timeoutMs ?? DEFAULT_TIMEOUT_MS, 50);
   const client = createWorkflowClient({
     backend: options.backend ?? new MemoryBackend({ debug: false }),
     debug: false,
@@ -227,7 +250,7 @@ export async function startWorkflowTest<TInput = unknown, TOutput = unknown>(
         const result = check(last);
         if (result !== undefined) return result;
       }
-      await sleep(POLL_INTERVAL_MS);
+      await sleep(scaleMs(POLL_INTERVAL_MS, 1));
     }
 
     throw new Error(
@@ -271,6 +294,12 @@ export async function startWorkflowTest<TInput = unknown, TOutput = unknown>(
   }
 
   let disposed = false;
+
+  // Registered as well as exposed. A harness whose test throws before reaching
+  // its own cleanup would otherwise leave a client running, and in Bun a leaked
+  // client across tests is exactly the cross-test leakage `isolation.ts` exists
+  // to contain. `dispose()` stays public for tests that want to release early.
+  registerTestCleanup(() => harness.dispose());
 
   const harness: WorkflowTestHarness<TOutput> = {
     runId,

--- a/src/workflow/testing.ts
+++ b/src/workflow/testing.ts
@@ -1,0 +1,356 @@
+/**
+ * Test primitives for driving a workflow end to end.
+ *
+ * Testing a workflow means waiting for something asynchronous and durable to
+ * reach a state, and every test that does it has written the same loop:
+ *
+ * ```typescript
+ * while (Date.now() - start < timeout) {
+ *   if ((await client.getRun(runId))?.status === "completed") break;
+ *   await delay(50);
+ * }
+ * ```
+ *
+ * That loop is where workflow tests go wrong. A bare `await delay(n)` passes
+ * on a fast machine and flakes on a loaded one; a poll with no deadline hangs
+ * the suite instead of failing it; and a timeout that reports only "timed out"
+ * sends the author back to add logging to find out what the run was actually
+ * doing. Every harness method here polls to a deadline and, on expiry, throws
+ * with the run's status, its pending approvals and its per-node states — the
+ * information you would otherwise have gone looking for.
+ *
+ * Approvals are addressed by **node id**, not approval id. A test author knows
+ * they wrote `waitForApproval("review")`; the approval's generated id is
+ * something they have to dig out of the run first.
+ *
+ * ## What this does not do
+ *
+ * There is no `advanceTime`. The executor schedules timed waits with real
+ * `setTimeout` and takes no clock, so fast-forwarding one would mean faking
+ * global timers for the whole process. A workflow that sleeps for an hour
+ * still sleeps for an hour here. Testing that honestly needs a clock seam in
+ * the executor, which is a change to the executor rather than a helper this
+ * module can provide.
+ *
+ * @module workflow/testing
+ *
+ * @example
+ * ```typescript
+ * const harness = await startWorkflowTest(
+ *   workflow({ id: "ingest", steps: [step("fetch", { tool: fetchTool })] }),
+ *   { input: { source: "s3://bucket/key" } },
+ * );
+ *
+ * try {
+ *   await harness.settled();
+ *   await harness.assertSteps(["fetch"]);
+ * } finally {
+ *   await harness.dispose();
+ * }
+ * ```
+ */
+
+import { MemoryBackend } from "./backends/memory.ts";
+import { createWorkflowClient, type WorkflowClient } from "./api/workflow-client.ts";
+import type { WorkflowBackend } from "./backends/types.ts";
+import type {
+  NodeState,
+  PendingApproval,
+  Workflow,
+  WorkflowContext,
+  WorkflowDefinition,
+  WorkflowRun,
+  WorkflowStatus,
+} from "./types.ts";
+
+/** Statuses a run cannot move out of. */
+const TERMINAL: readonly WorkflowStatus[] = ["completed", "failed", "cancelled"] as const;
+
+/** How long any wait polls before giving up. */
+const DEFAULT_TIMEOUT_MS = 5_000;
+const POLL_INTERVAL_MS = 10;
+
+/** Options for {@linkcode startWorkflowTest}. */
+export interface StartWorkflowTestOptions<TInput = unknown> {
+  /** Input passed to the workflow. Defaults to `{}`. */
+  input?: TInput;
+  /**
+   * Backend to run against. Defaults to a fresh {@linkcode MemoryBackend}, so
+   * each harness is isolated from every other.
+   */
+  backend?: WorkflowBackend;
+  /** Deadline for every wait this harness performs (default: 5000ms). */
+  timeoutMs?: number;
+  /** Additional workflows to register, for a workflow that calls sub-workflows. */
+  also?: Array<Workflow | WorkflowDefinition>;
+}
+
+/** Options for resolving an approval. */
+export interface ApprovalDecisionOptions {
+  /** Recorded as the deciding user (default: `"test"`). */
+  approver?: string;
+  comment?: string;
+  /** Payload validated against the wait node's response schema, when it has one. */
+  data?: unknown;
+}
+
+/** A running workflow under test. */
+export interface WorkflowTestHarness<TOutput = unknown> {
+  /** Id of the run this harness drives. */
+  readonly runId: string;
+  /** The client backing the harness, for anything the harness does not wrap. */
+  readonly client: WorkflowClient;
+
+  /** Read the run as it is now. */
+  run(): Promise<WorkflowRun<unknown, TOutput>>;
+  /** The run's context, which is where steps accumulate their output. */
+  context(): Promise<WorkflowContext>;
+
+  /** Wait until the run reaches a terminal status, then return it. */
+  settled(): Promise<WorkflowRun<unknown, TOutput>>;
+  /** Wait until the run reaches `status`, then return it. */
+  reaches(status: WorkflowStatus): Promise<WorkflowRun<unknown, TOutput>>;
+  /** Wait until at least `count` approvals are pending, then return them. */
+  approvals(count?: number): Promise<PendingApproval[]>;
+
+  /** Approve the pending approval raised by `nodeId`. */
+  approve(nodeId: string, options?: ApprovalDecisionOptions): Promise<void>;
+  /** Reject the pending approval raised by `nodeId`. */
+  reject(nodeId: string, options?: ApprovalDecisionOptions): Promise<void>;
+  /** Cancel the run. */
+  cancel(): Promise<void>;
+
+  /** Ids of completed steps, in the order they completed. */
+  steps(): Promise<string[]>;
+  /** Assert the completed steps and their order. */
+  assertSteps(expected: string[]): Promise<void>;
+  /** Assert the run's current status. */
+  assertStatus(expected: WorkflowStatus): Promise<void>;
+
+  /** Release the client. Safe to call more than once. */
+  dispose(): Promise<void>;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Everything worth knowing about a stuck run, in one message.
+ *
+ * A timeout that says only "timed out waiting for completed" is the reason
+ * workflow tests get debugged by adding logging. This reports the state the
+ * author would have gone looking for.
+ */
+function describeRun(run: WorkflowRun | null): string {
+  if (!run) return "the run no longer exists";
+
+  const nodes = Object.values(run.nodeStates ?? {})
+    .map((state: NodeState) =>
+      `${state.nodeId}=${state.status}${state.attempt > 1 ? `#${state.attempt}` : ""}${
+        state.error ? ` (${state.error})` : ""
+      }`
+    )
+    .join(", ");
+  const approvals = (run.pendingApprovals ?? [])
+    .filter((approval) => approval.status === "pending")
+    .map((approval) => approval.nodeId)
+    .join(", ");
+
+  const inFlight = (run.currentNodes ?? []).join(", ");
+
+  // A run persists node states only when it pauses or finishes: while it is
+  // actively executing, `nodeStates` and `currentNodes` are both empty. So a
+  // `running` run with nothing recorded is the normal in-flight shape, not a
+  // corrupt one, and the message says which step is stuck only when the engine
+  // actually knows. Saying that outright beats printing "executing: nothing"
+  // and leaving the author to wonder whether the run is broken.
+  const progress = inFlight
+    ? `executing: ${inFlight}`
+    : run.status === "running"
+    ? "executing: unrecorded (a run mid-step persists no node state)"
+    : "executing: nothing";
+
+  return [
+    `status=${run.status}`,
+    progress,
+    `nodes: ${nodes || "none"}`,
+    `pending approvals: ${approvals || "none"}`,
+    run.error ? `error: ${run.error.message}` : undefined,
+  ].filter(Boolean).join("; ");
+}
+
+/**
+ * Start a workflow and return a harness for driving it.
+ *
+ * The workflow is registered on a client of its own, backed by a fresh
+ * in-memory backend unless one is supplied, so harnesses never observe each
+ * other's runs.
+ */
+export async function startWorkflowTest<TInput = unknown, TOutput = unknown>(
+  definition: Workflow | WorkflowDefinition,
+  options: StartWorkflowTestOptions<TInput> = {},
+): Promise<WorkflowTestHarness<TOutput>> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const client = createWorkflowClient({
+    backend: options.backend ?? new MemoryBackend({ debug: false }),
+    debug: false,
+  });
+
+  client.register(definition);
+  for (const extra of options.also ?? []) client.register(extra);
+
+  const workflowId = (definition as { id: string }).id;
+  const handle = await client.start<TInput, TOutput>(
+    workflowId,
+    (options.input ?? {}) as TInput,
+  );
+  const runId = handle.runId;
+
+  async function readRun(): Promise<WorkflowRun<unknown, TOutput>> {
+    const run = await client.getRun(runId);
+    if (!run) throw new Error(`Workflow run ${runId} no longer exists`);
+    return run as WorkflowRun<unknown, TOutput>;
+  }
+
+  /** Poll until `check` holds, or fail with what the run was doing. */
+  async function waitFor<T>(
+    check: (run: WorkflowRun<unknown, TOutput>) => T | undefined,
+    describeGoal: string,
+  ): Promise<T> {
+    const deadline = Date.now() + timeoutMs;
+    let last: WorkflowRun<unknown, TOutput> | null = null;
+
+    while (Date.now() < deadline) {
+      last = await client.getRun(runId) as WorkflowRun<unknown, TOutput> | null;
+      if (last) {
+        const result = check(last);
+        if (result !== undefined) return result;
+      }
+      await sleep(POLL_INTERVAL_MS);
+    }
+
+    throw new Error(
+      `Timed out after ${timeoutMs}ms waiting for ${describeGoal} on run ${runId}. ` +
+        describeRun(last),
+    );
+  }
+
+  function pendingApprovals(run: WorkflowRun): PendingApproval[] {
+    return (run.pendingApprovals ?? []).filter((approval) => approval.status === "pending");
+  }
+
+  async function decide(
+    nodeId: string,
+    approved: boolean,
+    decisionOptions: ApprovalDecisionOptions | undefined,
+  ): Promise<void> {
+    const approval = await waitFor(
+      (run) => pendingApprovals(run).find((candidate) => candidate.nodeId === nodeId),
+      `an approval pending on node "${nodeId}"`,
+    );
+
+    const approver = decisionOptions?.approver ?? "test";
+    if (approved) {
+      await client.approve(
+        runId,
+        approval.id,
+        approver,
+        decisionOptions?.comment,
+        decisionOptions?.data,
+      );
+      return;
+    }
+    await client.reject(
+      runId,
+      approval.id,
+      approver,
+      decisionOptions?.comment,
+      decisionOptions?.data,
+    );
+  }
+
+  let disposed = false;
+
+  const harness: WorkflowTestHarness<TOutput> = {
+    runId,
+    client,
+
+    run: readRun,
+
+    async context() {
+      return (await readRun()).context;
+    },
+
+    settled() {
+      return waitFor(
+        (run) => TERMINAL.includes(run.status) ? run : undefined,
+        `the run to finish (one of ${TERMINAL.join(", ")})`,
+      );
+    },
+
+    reaches(status) {
+      return waitFor(
+        (run) => run.status === status ? run : undefined,
+        `status "${status}"`,
+      );
+    },
+
+    approvals(count = 1) {
+      return waitFor(
+        (run) => {
+          const pending = pendingApprovals(run);
+          return pending.length >= count ? pending : undefined;
+        },
+        `${count} pending approval${count === 1 ? "" : "s"}`,
+      );
+    },
+
+    approve(nodeId, decisionOptions) {
+      return decide(nodeId, true, decisionOptions);
+    },
+
+    reject(nodeId, decisionOptions) {
+      return decide(nodeId, false, decisionOptions);
+    },
+
+    async cancel() {
+      await client.cancel(runId);
+    },
+
+    async steps() {
+      const run = await readRun();
+      // Ordered by when each step actually finished, so the assertion is
+      // evidence of execution order rather than of object key order.
+      return Object.values(run.nodeStates ?? {})
+        .filter((state: NodeState) => state.status === "completed")
+        .sort((a, b) => (a.completedAt?.getTime() ?? 0) - (b.completedAt?.getTime() ?? 0))
+        .map((state: NodeState) => state.nodeId);
+    },
+
+    async assertSteps(expected) {
+      const actual = await harness.steps();
+      if (actual.length === expected.length && actual.every((id, i) => id === expected[i])) return;
+      throw new Error(
+        `Expected steps [${expected.join(", ")}] but ran [${actual.join(", ")}] on run ${runId}. ` +
+          describeRun(await client.getRun(runId)),
+      );
+    },
+
+    async assertStatus(expected) {
+      const run = await readRun();
+      if (run.status === expected) return;
+      throw new Error(
+        `Expected run ${runId} to be "${expected}". ` + describeRun(run),
+      );
+    },
+
+    async dispose() {
+      if (disposed) return;
+      disposed = true;
+      await client.destroy();
+    },
+  };
+
+  return harness;
+}


### PR DESCRIPTION
Closes veryfront/veryfront-issue-inbox#866.

## The problem

Testing a workflow means waiting for something asynchronous and durable to reach a state, and every test that does it has hand-written the same polling loop. `src/workflow/__tests__/workflow.integration.test.ts` carries three — `waitForCondition`, `waitForStatus`, `waitForApprovals` — and they are private to that file. There is no shared harness today, and `veryfront/testing` only ships generic assert/bdd/timing helpers.

That loop is where workflow tests go wrong:

- a bare `await delay(n)` passes on a fast machine and flakes on a loaded one;
- a poll with no deadline hangs the suite instead of failing it;
- a timeout that reports only "timed out" sends the author back to add logging to find out what the run was actually doing.

## What this adds

`veryfront/workflow/testing`:

```typescript
const harness = await startWorkflowTest(ingestWorkflow, { input });
try {
  await harness.reaches("waiting");
  await harness.approve("review");          // by node id, not approval id
  await harness.settled();
  await harness.assertSteps(["fetch", "review", "load"]);
} finally {
  await harness.dispose();
}
```

Every wait polls to a deadline and, on expiry, throws with the run's status, what it is executing, its per-node states and its pending approvals — the information the author would have gone looking for. Each harness gets its own `MemoryBackend` by default, so one test's run is never visible to another's assertions.

Approvals are addressed by **node id**. A test author knows they wrote `waitForApproval("review")`; the approval's generated id is something they would otherwise read out of the run first. `approve()` also polls for the approval to exist, so a test need not reach a waiting state before deciding one.

`steps()` orders by `completedAt`, so an ordering assertion is evidence of execution order rather than of object key order.

## Two things it deliberately does not do

**No `advanceTime`.** The executor schedules timed waits with real `setTimeout` and takes no clock, so fast-forwarding one would mean faking global timers for the whole process. A workflow that sleeps for an hour still sleeps for an hour here. Doing it honestly needs a clock seam in the executor — a change to the executor, not a helper this module can provide. I would rather ship no time control than a fake one.

**It cannot name the step a *running* workflow is stuck on**, because the engine does not record one. Probing that is what turned up **#3949**: a run mid-step persists neither `nodeStates` nor `currentNodes`, so a hung run is undiagnosable from its own record.

```
mid-run   status=running    currentNodes=[]        nodeStates=[]
paused    status=waiting    currentNodes=[review]  nodeStates=[a=completed, review=running]
```

The diagnostic reports `executing: unrecorded (a run mid-step persists no node state)` rather than printing an empty list that reads like a corrupt run, and tests pin **both** shapes — the unrecorded one and the paused one where the engine does know. If veryfront/veryfront-code#3949 is fixed, the message gets better for free and the pinned test will say so.

## Tests

15 steps in `src/workflow/testing.test.ts`, all against real workflows through the real client: completion and step ordering, approval by node id, approving before the run reaches `waiting`, rejection, pending-approval listing, a failing run settling rather than hanging, cancellation, harness isolation, idempotent dispose, and three failure-reporting tests asserting the diagnostics actually carry the run id, the status, the in-flight node and what really ran.

## Verification

All with pinned Deno 2.7.7 (`.tool-versions`):

- `deno test src/workflow/testing.test.ts` — 15 steps, 0 failed.
- `deno lint src/workflow/` (142 files), `deno check src/workflow/testing.ts`, `deno fmt` — clean.
- `deno task docs` regenerated; the new subpath appears under `veryfront/workflow`.