### PR TITLE
fix(transforms): fail closed on duplicate compiler name helpers

### DIFF
--- a/src/transforms/pipeline/stages/browser-server-exports-leak-corpus.test.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-leak-corpus.test.ts
@@ -1,0 +1,231 @@
+import "#veryfront/schemas/_test-setup.ts";
+import "../../plugins/__tests__/code-parser-setup.ts";
+import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { stripServerOnlyExports } from "./browser-server-exports-strip.ts";
+
+function assertNotIncludes(haystack: string, needle: string): void {
+  assertEquals(haystack.includes(needle), false, `expected not to find ${needle} in:\n${haystack}`);
+}
+
+/** The esbuild keepNames shape from veryfront-code#3846's leak-probe corpus. */
+function keepNamesModule(clientLine: string): string {
+  return [
+    `import { getEnv } from "veryfront";`,
+    `import { db } from "../lib/server/db.ts";`,
+    `var __defProp = Object.defineProperty;`,
+    `var __name = (target, value) => __defProp(target, "name", { value, configurable: true });`,
+    `const API_KEY = getEnv("ORDERS_SECRET");`,
+    `async function loadUser(id) { return db.query(id, API_KEY); }`,
+    `__name(loadUser, "loadUser");`,
+    `export async function getServerData(ctx) {`,
+    `  return { props: { user: await loadUser(ctx.id) } };`,
+    `}`,
+    clientLine,
+    `export default function Page() { return null; }`,
+  ].join("\n");
+}
+
+async function assertServerChainRemoved(clientLine: string): Promise<void> {
+  const output = await stripServerOnlyExports(keepNamesModule(clientLine), "pages/orders.tsx");
+  assertNotIncludes(output, "../lib/server/db.ts");
+  assertNotIncludes(output, "ORDERS_SECRET");
+}
+
+describe("browser server-exports leak corpus", () => {
+  describe("veryfront-code#3846 keepNames-shaped server-chain probes", () => {
+    const stripRows: Array<[string, string]> = [
+      ['typeof v === "object"', `const isPlain = (v) => typeof v === "object";`],
+      ["v?.constructor === Object", `const isPlain = (v) => v?.constructor === Object;`],
+      ["e.constructor.name", `const label = (e) => e.constructor.name;`],
+      ["v.__proto__", `const proto = (v) => v.__proto__;`],
+      ["v instanceof Function", `const isFn = (v) => v instanceof Function;`],
+      ["typeof eval", `const hasEval = typeof eval;`],
+      ["__name reassigned", `__name = (target, value) => target;`],
+      // The #3846 body names `Obj2`; the historical 991e3096b fixture used
+      // a module-scope `Object` alias. Keep the body row here so the corpus
+      // matches the disposition note rather than broadening it.
+      ["const Obj2 = globalThis.Object", `const Obj2 = globalThis.Object;`],
+      ["globalThis.Object = Object", `globalThis.Object = Object;`],
+    ];
+
+    for (const [label, clientLine] of stripRows) {
+      it(`removes the server chain for ${label}`, async () => {
+        await assertServerChainRemoved(clientLine);
+      });
+    }
+
+    it("rejects a duplicate compiler name helper instead of retaining the server chain", async () => {
+      const error = await assertRejects(() =>
+        stripServerOnlyExports(
+          keepNamesModule(`var __name = (target, value) => target;`),
+          "pages/orders.tsx",
+        )
+      );
+
+      assertStringIncludes(
+        (error as Error).message,
+        "compiler name helper `__name` is declared more than once",
+      );
+      assertStringIncludes((error as Error).message, "pages/orders.tsx");
+    });
+
+    it("rejects a duplicated defineProperty alias instead of deleting a browser registration", async () => {
+      const code = [
+        `import { getEnv } from "veryfront";`,
+        `import { db } from "../lib/server/db.ts";`,
+        `var d = Object.defineProperty;`,
+        `var n = (target, value) => d(target, "name", { value, configurable: true });`,
+        `function registerClient(target) { globalThis.registered = target; return target; }`,
+        `var d = registerClient;`,
+        `const API_KEY = getEnv("ORDERS_SECRET");`,
+        `async function loadUser(id) { return db.query(id, API_KEY); }`,
+        `n(loadUser, "loadUser");`,
+        `export async function getServerData(ctx) {`,
+        `  return { props: { user: await loadUser(ctx.id) } };`,
+        `}`,
+        `export default function Page() { return null; }`,
+      ].join("\n");
+
+      const error = await assertRejects(() => stripServerOnlyExports(code, "pages/orders.tsx"));
+
+      assertStringIncludes(
+        (error as Error).message,
+        "compiler name helper `n` uses defineProperty alias `d` declared more than once",
+      );
+    });
+
+    it("rejects an ambiguous helper whose target becomes hook-only while pruning", async () => {
+      const code = [
+        `import { getEnv } from "veryfront";`,
+        `import { db } from "../lib/server/db.ts";`,
+        `var __defProp = Object.defineProperty;`,
+        `var __name = (target, value) => __defProp(target, "name", { value, configurable: true });`,
+        `function registerClient(target) { globalThis.registered = target; return target; }`,
+        `const API_KEY = getEnv("ORDERS_SECRET");`,
+        `function inner(id) { return db.query(id, API_KEY); }`,
+        `function outer(id) { return inner(id); }`,
+        `__name(inner, "inner");`,
+        `var __name = registerClient;`,
+        `export async function getServerData(ctx) {`,
+        `  return { props: { u: await outer(ctx.id) } };`,
+        `}`,
+        `export default function Page() { return null; }`,
+      ].join("\n");
+
+      const error = await assertRejects(() => stripServerOnlyExports(code, "pages/orders.tsx"));
+
+      assertStringIncludes(
+        (error as Error).message,
+        "compiler name helper `__name` is declared more than once",
+      );
+      assertStringIncludes((error as Error).message, "pages/orders.tsx");
+    });
+
+    it("rejects an ambiguous helper even when a valid helper also registers the hook-only target", async () => {
+      const code = [
+        `import { getEnv } from "veryfront";`,
+        `import { db } from "../lib/server/db.ts";`,
+        `var d = Object.defineProperty;`,
+        `var n = (target, value) => d(target, "name", { value, configurable: true });`,
+        `var m = (target, value) => d(target, "name", { value, configurable: true });`,
+        `function registerClient(target) { globalThis.registered = target; return target; }`,
+        `var n = registerClient;`,
+        `const API_KEY = getEnv("ORDERS_SECRET");`,
+        `async function loadUser(id) { return db.query(id, API_KEY); }`,
+        `n(loadUser, "loadUser");`,
+        `m(loadUser, "loadUser");`,
+        `export async function getServerData(ctx) {`,
+        `  return { props: { user: await loadUser(ctx.id) } };`,
+        `}`,
+        `export default function Page() { return null; }`,
+      ].join("\n");
+
+      const error = await assertRejects(() => stripServerOnlyExports(code, "pages/orders.tsx"));
+
+      assertStringIncludes(
+        (error as Error).message,
+        "compiler name helper `n` is declared more than once",
+      );
+      assertStringIncludes((error as Error).message, "pages/orders.tsx");
+    });
+
+    it("does not reject a duplicate helper when its registered target is still browser-read", async () => {
+      const code = [
+        `import { getEnv } from "veryfront";`,
+        `var __defProp = Object.defineProperty;`,
+        `var __name = (target, value) => __defProp(target, "name", { value, configurable: true });`,
+        `function format(v) { return String(v); }`,
+        `__name(format, "format");`,
+        `var __name = (target, value) => target;`,
+        `export async function getServerData() { return { props: { k: getEnv("K"), f: format(1) } }; }`,
+        `export default function Page() { return format(2); }`,
+      ].join("\n");
+
+      const result = await stripServerOnlyExports(code, "pages/orders.tsx");
+
+      assertStringIncludes(result, "function format(v)");
+      assertNotIncludes(result, `getEnv("K")`);
+    });
+
+    it("does not reject mixed helper registrations when the target is still browser-read", async () => {
+      const code = [
+        `import { getEnv } from "veryfront";`,
+        `var d = Object.defineProperty;`,
+        `var n = (target, value) => d(target, "name", { value, configurable: true });`,
+        `var m = (target, value) => d(target, "name", { value, configurable: true });`,
+        `function registerClient(target) { globalThis.registered = target; return target; }`,
+        `var n = registerClient;`,
+        `function format(v) { return String(v); }`,
+        `n(format, "format");`,
+        `m(format, "format");`,
+        `export async function getServerData() { return { props: { k: getEnv("K"), f: format(1) } }; }`,
+        `export default function Page() { return format(2); }`,
+      ].join("\n");
+
+      const result = await stripServerOnlyExports(code, "pages/orders.tsx");
+
+      assertStringIncludes(result, `n(format, "format")`);
+      assertStringIncludes(result, `m(format, "format")`);
+      assertStringIncludes(result, "function format(v)");
+      assertNotIncludes(result, `getEnv("K")`);
+    });
+
+    it("keeps an ambiguous defineProperty-alias registration for a browser-read target", async () => {
+      const code = [
+        `import { getEnv } from "veryfront";`,
+        `var d = Object.defineProperty;`,
+        `var n = (target, value) => d(target, "name", { value, configurable: true });`,
+        `function registerClient(target) { globalThis.registered = target; return target; }`,
+        `var d = registerClient;`,
+        `function format(v) { return String(v); }`,
+        `n(format, "format");`,
+        `export async function getServerData() { return { props: { k: getEnv("K") } }; }`,
+        `export default function Page() { return format(2); }`,
+      ].join("\n");
+
+      const result = await stripServerOnlyExports(code, "pages/orders.tsx");
+
+      assertStringIncludes(result, `n(format, "format")`);
+      assertStringIncludes(result, "function format(v)");
+      assertNotIncludes(result, `getEnv("K")`);
+    });
+
+    it("does not reject an unrelated duplicated callable helper", async () => {
+      const code = [
+        `import { getEnv } from "veryfront";`,
+        `var register = (target, value) => target;`,
+        `function format(v) { return String(v); }`,
+        `register(format, "format");`,
+        `var register = (target, value) => target;`,
+        `export async function getServerData() { return { props: { k: getEnv("K") } }; }`,
+        `export default function Page() { return format(2); }`,
+      ].join("\n");
+
+      const result = await stripServerOnlyExports(code, "pages/orders.tsx");
+
+      assertStringIncludes(result, "function format(v)");
+      assertNotIncludes(result, `getEnv("K")`);
+    });
+  });
+});

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.ts
@@ -1091,48 +1091,177 @@ function isNameDescriptor(node: Node | undefined, valueParam: string): boolean {
  * `Object.defineProperty(target, "name", …)` semantics rather than by its
  * minified binding name.
  */
-function compilerNameHelperBindings(body: Node[]): Set<string> {
-  const initializers = new Map<string, Node>();
+function moduleBindingInitializers(body: Node[]): Map<string, Node[]> {
+  const initializers = new Map<string, Node[]>();
   for (const statement of body) {
     if (statement.type !== "VariableDeclaration") continue;
     for (const declarator of Array.isArray(statement.declarations) ? statement.declarations : []) {
       if (!isNode(declarator) || !isNode(declarator.init)) continue;
       const name = nodeName(declarator.id);
-      if (name) initializers.set(name, declarator.init);
+      if (!name) continue;
+      const existing = initializers.get(name);
+      if (existing) existing.push(declarator.init);
+      else initializers.set(name, [declarator.init]);
     }
   }
+  return initializers;
+}
 
-  const definePropertyBindings = new Set<string>();
-  for (const [name, init] of initializers) {
-    if (isObjectDefineProperty(init)) definePropertyBindings.add(name);
+function definePropertyHelperBindings(initializers: Map<string, Node[]>): Set<string> {
+  const bindings = new Set<string>();
+  for (const [name, inits] of initializers) {
+    if (inits.length === 1 && inits.some(isObjectDefineProperty)) bindings.add(name);
+  }
+  return bindings;
+}
+
+function duplicateDefinePropertyHelperBindings(initializers: Map<string, Node[]>): Set<string> {
+  const bindings = new Set<string>();
+  for (const [name, inits] of initializers) {
+    if (inits.length > 1 && inits.some(isObjectDefineProperty)) bindings.add(name);
+  }
+  return bindings;
+}
+
+interface CompilerNameHelperShape {
+  definePropertyBinding: string | null;
+}
+
+function compilerNameHelperShape(init: Node): CompilerNameHelperShape | null {
+  if (init.type !== "ArrowFunctionExpression" && init.type !== "FunctionExpression") return null;
+  const params = Array.isArray(init.params) ? init.params.filter(isNode) : [];
+  if (params.length !== 2) return null;
+  const targetParam = nodeName(params[0]);
+  const valueParam = nodeName(params[1]);
+  if (!targetParam || !valueParam) return null;
+
+  const call = returnedCall(init);
+  if (!call) return null;
+  const callee = isNode(call.callee) ? call.callee : undefined;
+  let definePropertyBinding: string | null;
+  if (isObjectDefineProperty(callee)) {
+    definePropertyBinding = null;
+  } else {
+    if (callee?.type !== "Identifier") return null;
+    const binding = nodeName(callee);
+    if (!binding) return null;
+    definePropertyBinding = binding;
   }
 
+  const args = Array.isArray(call.arguments) ? call.arguments.filter(isNode) : [];
+  if (
+    args.length !== 3 || nodeName(args[0]) !== targetParam ||
+    stringLiteralText(args[1]) !== "name" || !isNameDescriptor(args[2], valueParam)
+  ) {
+    return null;
+  }
+  return { definePropertyBinding };
+}
+
+function isCompilerNameHelperInitializer(
+  init: Node,
+  definePropertyBindings: Set<string>,
+): boolean {
+  const shape = compilerNameHelperShape(init);
+  return shape !== null &&
+    (shape.definePropertyBinding === null ||
+      definePropertyBindings.has(shape.definePropertyBinding));
+}
+
+function compilerNameHelperBindings(body: Node[]): Set<string> {
+  const initializers = moduleBindingInitializers(body);
+  const definePropertyBindings = definePropertyHelperBindings(initializers);
+
   const helpers = new Set<string>();
-  for (const [name, init] of initializers) {
-    if (init.type !== "ArrowFunctionExpression" && init.type !== "FunctionExpression") continue;
-    const params = Array.isArray(init.params) ? init.params.filter(isNode) : [];
-    if (params.length !== 2) continue;
-    const targetParam = nodeName(params[0]);
-    const valueParam = nodeName(params[1]);
-    if (!targetParam || !valueParam) continue;
-
-    const call = returnedCall(init);
-    if (!call) continue;
-    const callee = isNode(call.callee) ? call.callee : undefined;
-    const callsDefineProperty = isObjectDefineProperty(callee) ||
-      (callee?.type === "Identifier" && definePropertyBindings.has(nodeName(callee) ?? ""));
-    if (!callsDefineProperty) continue;
-
-    const args = Array.isArray(call.arguments) ? call.arguments.filter(isNode) : [];
-    if (
-      args.length === 3 && nodeName(args[0]) === targetParam &&
-      stringLiteralText(args[1]) === "name" && isNameDescriptor(args[2], valueParam)
-    ) {
+  for (const [name, inits] of initializers) {
+    if (inits.some((init) => isCompilerNameHelperInitializer(init, definePropertyBindings))) {
       helpers.add(name);
     }
   }
 
   return helpers;
+}
+
+function duplicateCompilerNameHelperBindings(body: Node[]): Set<string> {
+  const initializers = moduleBindingInitializers(body);
+  const definePropertyBindings = definePropertyHelperBindings(initializers);
+  const duplicates = new Set<string>();
+  for (const [name, inits] of initializers) {
+    if (
+      inits.length > 1 &&
+      inits.some((init) => isCompilerNameHelperInitializer(init, definePropertyBindings))
+    ) {
+      duplicates.add(name);
+    }
+  }
+  return duplicates;
+}
+
+function compilerNameHelpersWithDuplicateDefinePropertyAliases(body: Node[]): Map<string, string> {
+  const initializers = moduleBindingInitializers(body);
+  const duplicateAliases = duplicateDefinePropertyHelperBindings(initializers);
+  const helpers = new Map<string, string>();
+  for (const [name, inits] of initializers) {
+    for (const init of inits) {
+      const alias = compilerNameHelperShape(init)?.definePropertyBinding;
+      if (alias && duplicateAliases.has(alias)) helpers.set(name, alias);
+    }
+  }
+  return helpers;
+}
+
+function failOnAmbiguousCompilerNameHelperDuplicates(
+  body: Node[],
+  hookClosure: Set<string>,
+  filePath: string | undefined,
+): void {
+  const duplicates = duplicateCompilerNameHelperBindings(body);
+  const duplicateAliases = compilerNameHelpersWithDuplicateDefinePropertyAliases(body);
+  if (duplicates.size === 0 && duplicateAliases.size === 0) return;
+
+  const candidates: Array<{
+    target: Node;
+    targetName: string;
+    reason: string;
+  }> = [];
+  for (const statement of body) {
+    if (statement.type !== "ExpressionStatement" || !isNode(statement.expression)) continue;
+    const expression = statement.expression;
+    if (expression.type !== "CallExpression" || !isNode(expression.callee)) continue;
+    const calleeName = nodeName(expression.callee);
+    if (!calleeName) continue;
+    const duplicateAlias = duplicateAliases.get(calleeName);
+    if (!duplicates.has(calleeName) && duplicateAlias === undefined) continue;
+
+    const args = Array.isArray(expression.arguments) ? expression.arguments.filter(isNode) : [];
+    const target = args[0];
+    const targetName = nodeName(target);
+    if (!target || args.length !== 2 || !targetName || stringLiteralText(args[1]) === null) {
+      continue;
+    }
+    const reason = duplicateAlias === undefined
+      ? `compiler name helper \`${calleeName}\` is declared more than once`
+      : `compiler name helper \`${calleeName}\` uses defineProperty alias \`${duplicateAlias}\` declared more than once`;
+    candidates.push({ target, targetName, reason });
+  }
+  if (candidates.length === 0) return;
+
+  const excluded = new WeakSet<Node>();
+  for (const decl of moduleScopeDeclarations(body)) {
+    for (const id of decl.bindingIds) excluded.add(id);
+  }
+  for (const registration of compilerNameRegistrations(body)) excluded.add(registration.target);
+  for (const candidate of candidates) excluded.add(candidate.target);
+  const referenced = referencedIdentifiers(body, excluded);
+
+  for (const candidate of candidates) {
+    if (hookClosure.has(candidate.targetName) && !referenced.has(candidate.targetName)) {
+      throw new ServerExportStripError(
+        filePath,
+        candidate.reason,
+      );
+    }
+  }
 }
 
 interface CompilerNameRegistration {
@@ -1178,12 +1307,17 @@ function compilerNameRegistrations(body: Node[]): CompilerNameRegistration[] {
  * fixpoint: removing one binding can leave a helper it was the last user of
  * newly dead *within the closure*.
  */
-function dropUnusedModuleScopeBindings(body: Node[], hookClosure: Set<string>): Node[] {
+function dropUnusedModuleScopeBindings(
+  body: Node[],
+  hookClosure: Set<string>,
+  filePath: string | undefined,
+): Node[] {
   let current = body;
 
   for (;;) {
     const decls = moduleScopeDeclarations(current);
     if (decls.length === 0) return current;
+    failOnAmbiguousCompilerNameHelperDuplicates(current, hookClosure, filePath);
 
     const excluded = new WeakSet<Node>();
     for (const decl of decls) for (const id of decl.bindingIds) excluded.add(id);
@@ -1395,7 +1529,7 @@ export async function stripServerOnlyExports(
   // Drop the module-scope state the emptied hooks were the last user of, then
   // the imports that leaves unused. Order matters: pruning `const API_KEY =
   // getEnv(...)` is what makes the `veryfront` import droppable.
-  const pruned = dropUnusedModuleScopeBindings(body, hookClosure);
+  const pruned = dropUnusedModuleScopeBindings(body, hookClosure, filePath);
   setBody(ast, dropUnusedImportBindings(pruned, hookClosure));
 
   const generated = await parser.generate(ast);


### PR DESCRIPTION
## Summary

Preserve the 10-case server-hook leak corpus from #3846 as a focused merge gate. The corpus accepts only two safe outcomes: the server chain is removed, or the build intentionally rejects an ambiguous compiler-helper shape.

The RED runs found three unsafe cases: a duplicated generated `__name` helper silently retained the server import and `ORDERS_SECRET`; a redeclared `Object.defineProperty` alias could make an ordinary browser registration look like compiler metadata and be deleted; and an ambiguous target discovered only during transitive pruning could be deleted before validation saw it. The fix fails closed when any ambiguity is the sole browser read of a directly or indirectly hook-owned target.

## Scope

- Adds the 10-case keepNames-shaped corpus in a separate test file.
- Adds narrow fail-closed guards for duplicate helpers and duplicate defineProperty aliases.
- Revalidates ambiguity at every pruning iteration before metadata removal.
- Keeps unrelated duplicated helpers and browser-read registration targets working.
- Does not import #3846's deferred-execution classifier or broad transform rewrite.

## Verification

- Focused leak corpus: 16 passed, 0 failed.
- Existing server-export-strip suite: 132 passed, 0 failed.
- Formatting, lint, typecheck, and diff checks pass.
- The full repository pre-push gate passed.
- Independent code review approved the amended commit and its composition with #3956.

Refs veryfront/veryfront-issue-inbox#605
Supersedes the leak-corpus artifact in #3846.