### PR TITLE
fix(transforms): strip browser server hooks before compile

### DIFF
--- a/docs/guides/data-fetching.md
+++ b/docs/guides/data-fetching.md
@@ -45,6 +45,27 @@ entirely, including their top-level side effects. Put client initialization in a
 separate client-referenced module or a bare side-effect import that is not only
 used by a server data hook.
 
+Declare server data hooks in the page module. Do not re-export a hook from
+another file:
+
+```tsx
+// Do not use this form.
+export { getServerData } from "../server/loaders.ts";
+```
+
+A re-export has no local body for Veryfront to empty, so the browser build
+fails instead of shipping the loader and its transitive server graph. Import the
+server helper and call it from a local hook:
+
+```tsx
+import type { DataContext } from "veryfront";
+import { loadDashboard } from "../server/loaders.ts";
+
+export async function getServerData(ctx: DataContext) {
+  return { props: await loadDashboard(ctx) };
+}
+```
+
 The `props` you return are passed to the page component. To read the same props
 data from a layout or nested component without prop-drilling, use
 `usePageContext().data` (see

--- a/extensions/ext-parser-babel/src/index.test.ts
+++ b/extensions/ext-parser-babel/src/index.test.ts
@@ -90,6 +90,18 @@ describe("ext-parser-babel", () => {
       assert(ast);
     });
 
+    it("parses decorators before and after export accepted by the bundler", async () => {
+      for (
+        const code of [
+          "@logged export class Store {}",
+          "export @logged class Store {}",
+        ]
+      ) {
+        const ast = await parser.parse({ code, filePath: "file.ts" });
+        assert(ast);
+      }
+    });
+
     it("reports function directives without exposing Babel AST details", async () => {
       assertEquals(
         await parser.hasFunctionDirective?.({

--- a/extensions/ext-parser-babel/src/index.test.ts
+++ b/extensions/ext-parser-babel/src/index.test.ts
@@ -102,6 +102,14 @@ describe("ext-parser-babel", () => {
       }
     });
 
+    it("parses legacy TypeScript parameter decorators", async () => {
+      const ast = await parser.parse({
+        code: "class Store { load(@inject dep: Dependency) { return dep; } }",
+        filePath: "file.ts",
+      });
+      assert(ast);
+    });
+
     it("reports function directives without exposing Babel AST details", async () => {
       assertEquals(
         await parser.hasFunctionDirective?.({

--- a/extensions/ext-parser-babel/src/parser-only.test.ts
+++ b/extensions/ext-parser-babel/src/parser-only.test.ts
@@ -52,6 +52,15 @@ describe("BabelParseOnlyParser", () => {
     assertEquals(asserted.type, "File");
   });
 
+  it("parses legacy TypeScript parameter decorators", async () => {
+    const ast = await parser.parse({
+      code: "class Store { load(@inject dep: Dependency) { return dep; } }",
+      filePath: "store.ts",
+    });
+
+    assertEquals(ast.type, "File");
+  });
+
   it("preserves Babel syntax-error identity and location metadata", async () => {
     let thrown: unknown;
     try {

--- a/extensions/ext-parser-babel/src/parser-only.test.ts
+++ b/extensions/ext-parser-babel/src/parser-only.test.ts
@@ -61,6 +61,15 @@ describe("BabelParseOnlyParser", () => {
     assertEquals(ast.type, "File");
   });
 
+  it("parses legacy TypeScript decorator type arguments", async () => {
+    const ast = await parser.parse({
+      code: "@logged<string> export class Store {}",
+      filePath: "store.ts",
+    });
+
+    assertEquals(ast.type, "File");
+  });
+
   it("preserves Babel syntax-error identity and location metadata", async () => {
     let thrown: unknown;
     try {

--- a/extensions/ext-parser-babel/src/parser-only.ts
+++ b/extensions/ext-parser-babel/src/parser-only.ts
@@ -41,7 +41,7 @@ function pickPlugins(filePath?: string): parser.ParserPlugin[] {
     "classProperties",
     "classPrivateProperties",
     "classPrivateMethods",
-    "decorators-legacy",
+    "decorators",
     "decoratorAutoAccessors",
     "deprecatedImportAssert",
     "dynamicImport",

--- a/extensions/ext-parser-babel/src/parser-only.ts
+++ b/extensions/ext-parser-babel/src/parser-only.ts
@@ -57,6 +57,20 @@ function pickPlugins(filePath?: string): parser.ParserPlugin[] {
   return plugins;
 }
 
+function pickLegacyDecoratorPlugins(filePath?: string): parser.ParserPlugin[] {
+  return pickPlugins(filePath).map((plugin) =>
+    plugin === "decorators" ? "decorators-legacy" : plugin
+  );
+}
+
+function shouldRetryWithLegacyDecorators(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const code = Object.getOwnPropertyDescriptor(error, "code")?.value;
+  const reasonCode = Object.getOwnPropertyDescriptor(error, "reasonCode")?.value;
+  return code === "BABEL_PARSER_SYNTAX_ERROR" &&
+    reasonCode === "UnsupportedParameterDecorator";
+}
+
 /**
  * Babel-backed parser with the same parse behavior as {@link BabelCodeParser},
  * without loading traversal, generation, or extension runtime dependencies.
@@ -64,12 +78,22 @@ function pickPlugins(filePath?: string): parser.ParserPlugin[] {
 export class BabelParseOnlyParser implements BabelParseOnlyParserContract {
   parse(options: ParseOptions): Promise<ASTNode> {
     const filePath = options.filePath?.toLowerCase() ?? "";
-    const ast = parser.parse(options.code, {
+    const parseOptions: parser.ParserOptions = {
       sourceType: "unambiguous",
       allowReturnOutsideFunction: options.allowReturnOutsideFunction === true ||
         /\.(?:cjs|js)$/.test(filePath),
       plugins: pickPlugins(parseablePath(options.filePath)),
-    });
+    };
+    let ast: parser.ParseResult<parser.File>;
+    try {
+      ast = parser.parse(options.code, parseOptions);
+    } catch (error) {
+      if (!shouldRetryWithLegacyDecorators(error)) throw error;
+      ast = parser.parse(options.code, {
+        ...parseOptions,
+        plugins: pickLegacyDecoratorPlugins(parseablePath(options.filePath)),
+      });
+    }
     const node: { type: string } = ast;
     return Promise.resolve(node as ASTNode);
   }

--- a/extensions/ext-parser-babel/src/parser-only.ts
+++ b/extensions/ext-parser-babel/src/parser-only.ts
@@ -63,12 +63,10 @@ function pickLegacyDecoratorPlugins(filePath?: string): parser.ParserPlugin[] {
   );
 }
 
-function shouldRetryWithLegacyDecorators(error: unknown): boolean {
+function isBabelSyntaxError(error: unknown): boolean {
   if (typeof error !== "object" || error === null) return false;
   const code = Object.getOwnPropertyDescriptor(error, "code")?.value;
-  const reasonCode = Object.getOwnPropertyDescriptor(error, "reasonCode")?.value;
-  return code === "BABEL_PARSER_SYNTAX_ERROR" &&
-    reasonCode === "UnsupportedParameterDecorator";
+  return code === "BABEL_PARSER_SYNTAX_ERROR";
 }
 
 /**
@@ -88,11 +86,17 @@ export class BabelParseOnlyParser implements BabelParseOnlyParserContract {
       try {
         return parser.parse(options.code, parseOptions);
       } catch (error) {
-        if (!shouldRetryWithLegacyDecorators(error)) throw error;
-        return parser.parse(options.code, {
-          ...parseOptions,
-          plugins: pickLegacyDecoratorPlugins(parseablePath(options.filePath)),
-        });
+        if (!isBabelSyntaxError(error)) throw error;
+        try {
+          return parser.parse(options.code, {
+            ...parseOptions,
+            plugins: pickLegacyDecoratorPlugins(parseablePath(options.filePath)),
+          });
+        } catch {
+          // Preserve the primary parser's diagnostic when neither supported
+          // decorator dialect accepts the source.
+          throw error;
+        }
       }
     })();
     const node: { type: string } = ast;

--- a/extensions/ext-parser-babel/src/parser-only.ts
+++ b/extensions/ext-parser-babel/src/parser-only.ts
@@ -84,16 +84,17 @@ export class BabelParseOnlyParser implements BabelParseOnlyParserContract {
         /\.(?:cjs|js)$/.test(filePath),
       plugins: pickPlugins(parseablePath(options.filePath)),
     };
-    let ast: parser.ParseResult<parser.File>;
-    try {
-      ast = parser.parse(options.code, parseOptions);
-    } catch (error) {
-      if (!shouldRetryWithLegacyDecorators(error)) throw error;
-      ast = parser.parse(options.code, {
-        ...parseOptions,
-        plugins: pickLegacyDecoratorPlugins(parseablePath(options.filePath)),
-      });
-    }
+    const ast = (() => {
+      try {
+        return parser.parse(options.code, parseOptions);
+      } catch (error) {
+        if (!shouldRetryWithLegacyDecorators(error)) throw error;
+        return parser.parse(options.code, {
+          ...parseOptions,
+          plugins: pickLegacyDecoratorPlugins(parseablePath(options.filePath)),
+        });
+      }
+    })();
     const node: { type: string } = ast;
     return Promise.resolve(node as ASTNode);
   }

--- a/src/transforms/esm/transform-utils.ts
+++ b/src/transforms/esm/transform-utils.ts
@@ -47,6 +47,15 @@ export function getLoaderFromPath(filePath: string): Loader {
   return EXTENSION_LOADERS[ext] ?? "tsx";
 }
 
+/**
+ * Markdown and MDX source is compiled before the generic ESM stages run, so a
+ * diagnostic in those stages points at generated JSX rather than authored
+ * content. Source syntax errors are classified upstream by the content parser.
+ */
+export function isGeneratedContentOutput(filePath: string | undefined): boolean {
+  return filePath?.endsWith(".mdx") === true || filePath?.endsWith(".md") === true;
+}
+
 export function needsTransform(filePath: string): boolean {
   return /\.(tsx?|jsx?|mdx?|md)$/.test(filePath);
 }

--- a/src/transforms/pipeline/index.ts
+++ b/src/transforms/pipeline/index.ts
@@ -68,9 +68,9 @@ const SSR_PIPELINE: TransformPlugin[] = [
 
 const BROWSER_PIPELINE: TransformPlugin[] = [
   parsePlugin,
+  browserServerExportsStripPlugin, // Drop server-only hooks + their now-unused imports
   compilePlugin,
   cssStripPlugin, // Strip CSS imports before they hit import resolution
-  browserServerExportsStripPlugin, // Drop server-only hooks + their now-unused imports
   browserNodeBuiltinImportsPlugin, // node:* named imports -> namespace + destructure
   resolveImportsPlugin, // Unified import resolution
   finalizePlugin,

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
@@ -11,6 +11,7 @@ import {
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { register, tryResolve, unregister } from "#veryfront/extensions/contracts.ts";
 import type { CodeParser } from "#veryfront/extensions/parser/index.ts";
+import { getErrorCollector, resetErrorCollector } from "#veryfront/observability";
 import {
   browserServerExportsStripPlugin,
   moduleReferenceWalkers,
@@ -1325,28 +1326,56 @@ describe("browser-server-exports-strip", () => {
     });
 
     it("classifies authored browser parse errors as tenant compilation failures", async () => {
+      resetErrorCollector();
       const source = [
         `export async function getServerData() { return { props: {} }; }`,
         `export default function Page( { return null; }`,
       ].join("\n");
 
-      const error = await assertRejects(
-        () =>
-          runPipeline(
-            source,
-            "/project/pages/broken.tsx",
-            "/project",
-            { projectId: "authored-strip-parse-error", dev: false, ssr: false },
-          ),
-        VeryfrontError,
-      );
+      try {
+        const error = await assertRejects(
+          () =>
+            runPipeline(
+              source,
+              "/project/pages/broken.tsx",
+              "/project",
+              { projectId: "authored-strip-parse-error", dev: false, ssr: false },
+            ),
+          VeryfrontError,
+        );
 
-      assertInstanceOf(error, VeryfrontError);
-      assertEquals(error.slug, "compilation-error");
-      assertEquals(
-        (error.context as { tenantBuildFailure?: unknown } | undefined)?.tenantBuildFailure,
-        true,
-      );
+        assertInstanceOf(error, VeryfrontError);
+        assertEquals(error.slug, "compilation-error");
+        assertEquals(
+          (error.context as { tenantBuildFailure?: unknown } | undefined)?.tenantBuildFailure,
+          true,
+        );
+
+        const compileErrors = getErrorCollector().getAll({ type: "compile" });
+        assertEquals(compileErrors.length, 1);
+        assertEquals(compileErrors[0]?.file, "/project/pages/broken.tsx");
+        assertStringIncludes(compileErrors[0]?.message ?? "", "Unexpected keyword");
+      } finally {
+        resetErrorCollector();
+      }
+    });
+
+    it("strips modules with legacy parameter decorators before compiling browser modules", async () => {
+      const source = [
+        `function inject(_target: unknown, _key: string, _index: number) {}`,
+        `const SECRET = "SERVER_ONLY_PARAMETER_DECORATOR_SECRET";`,
+        `export async function getServerData() { return { props: { secret: SECRET } }; }`,
+        `class PageModel { load(@inject dep: unknown) { return dep; } }`,
+        `export default function Page() { return PageModel; }`,
+      ].join("\n");
+
+      const result = await browserServerExportsStripPlugin.transform({
+        ...ctx(source, "browser"),
+        filePath: "/project/pages/parameter-decorator.tsx",
+      } as TransformContext);
+
+      assertNotIncludes(result, "SERVER_ONLY_PARAMETER_DECORATOR_SECRET");
+      assertStringIncludes(result, "PageModel");
     });
 
     it("does not claim tenant ownership of generated Markdown or MDX parse diagnostics", async () => {

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
@@ -1,18 +1,24 @@
 import "#veryfront/schemas/_test-setup.ts";
 import "../../plugins/__tests__/code-parser-setup.ts";
+import "../../mdx/compiler/__tests__/content-processor-setup.ts";
 import { stop as stopEsbuild } from "#veryfront/platform/compat/esbuild.ts";
-import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
-import { tryResolve } from "#veryfront/extensions/contracts.ts";
+import { register, tryResolve, unregister } from "#veryfront/extensions/contracts.ts";
 import type { CodeParser } from "#veryfront/extensions/parser/index.ts";
 import {
   browserServerExportsStripPlugin,
   moduleReferenceWalkers,
   stripServerOnlyExports,
 } from "./browser-server-exports-strip.ts";
-import { COMPILE_SOURCE_MAP_DIRECTIVE_METADATA, compilePlugin } from "./compile.ts";
 import { runPipeline } from "../index.ts";
 import { type TransformContext, TransformStage } from "../types.ts";
+import { VeryfrontError } from "#veryfront/errors";
 
 function assertNotIncludes(haystack: string, needle: string): void {
   assertEquals(haystack.includes(needle), false, `expected not to find ${needle} in:\n${haystack}`);
@@ -29,6 +35,38 @@ describe("browser-server-exports-strip", () => {
   });
 
   describe("emptying server-only hooks", () => {
+    it("runs before custom pre-compile browser plugins see server-only code", async () => {
+      const source = [
+        `const SERVER_SECRET = "secret-from-server-hook";`,
+        `export async function getServerData() {`,
+        `  return { props: { secret: SERVER_SECRET } };`,
+        `}`,
+        `export default function Page() { return null; }`,
+      ].join("\n");
+
+      let customPluginSawSecret = false;
+      const result = await runPipeline(
+        source,
+        "/project/pages/test.tsx",
+        "/project",
+        { projectId: "strip-before-custom-plugin", dev: false, ssr: false },
+        {
+          plugins: [{
+            name: "pre-compile-observer",
+            stage: TransformStage.PARSE + 0.75,
+            transform: (ctx) => {
+              customPluginSawSecret = ctx.code.includes("SERVER_SECRET");
+              return ctx.code;
+            },
+          }],
+        },
+      );
+
+      assertEquals(customPluginSawSecret, false);
+      assertNotIncludes(result.code, "SERVER_SECRET");
+      assertNotIncludes(result.code, "secret-from-server-hook");
+    });
+
     it("empties an exported async function declaration body", async () => {
       const code = [
         `import { hashOf } from "../lib/uses-crypto.js";`,
@@ -216,6 +254,109 @@ describe("browser-server-exports-strip", () => {
 
       assertNotIncludes(result, `hashOf("hello")`);
       assertStringIncludes(result, "hashed");
+    });
+
+    it("does not keep a hook-only import because its name matches an intrinsic JSX tag", async () => {
+      const code = [
+        `import { table } from "../server/table.ts";`,
+        `export async function getServerData() {`,
+        `  return { props: { table: table() } };`,
+        `}`,
+        `export default function Page() {`,
+        `  return <table><tbody /></table>;`,
+        `}`,
+      ].join("\n");
+
+      const result = await stripServerOnlyExports(code, "page.tsx");
+
+      assertNotIncludes(result, "../server/table.ts");
+      assertEquals(occurrences(result, "table"), 2);
+      assertStringIncludes(result, "<table>");
+    });
+
+    it("keeps a JSX member object that browser code still reads", async () => {
+      const code = [
+        `import { motion } from "../client/motion.ts";`,
+        `const helper = motion;`,
+        `export async function getServerData() {`,
+        `  return { props: { helper } };`,
+        `}`,
+        `export default function Page() {`,
+        `  return <motion.div />;`,
+        `}`,
+      ].join("\n");
+
+      const result = await stripServerOnlyExports(code, "page.tsx");
+
+      assertStringIncludes(result, "../client/motion.ts");
+      assertStringIncludes(result, "motion.div");
+    });
+
+    it("keeps leading JSX import-source comments when the first statement is removed", async () => {
+      const code = [
+        `/** @jsxImportSource preact */`,
+        `import { loadSecret } from "../server/load-secret.ts";`,
+        `export async function getServerData() {`,
+        `  return { props: { secret: loadSecret() } };`,
+        `}`,
+        `export default function Page() { return <main />; }`,
+      ].join("\n");
+
+      const result = await stripServerOnlyExports(code, "page.tsx");
+
+      assertStringIncludes(result, "@jsxImportSource preact");
+      assertNotIncludes(result, "../server/load-secret.ts");
+    });
+
+    it("does not delete an unrelated top-level binding named like a class expression", async () => {
+      const code = [
+        `import { initClient } from "../client/init.ts";`,
+        `const Inner = initClient();`,
+        `const Factory = class Inner {`,
+        `  static make() { return Inner; }`,
+        `};`,
+        `export async function getServerData() {`,
+        `  return { props: { Factory } };`,
+        `}`,
+        `export default function Page() { return null; }`,
+      ].join("\n");
+
+      const result = await stripServerOnlyExports(code, "page.tsx");
+
+      assertStringIncludes(result, "../client/init.ts");
+      assertStringIncludes(result, "const Inner = initClient()");
+      assertNotIncludes(result, "class Inner");
+    });
+
+    it("matches escaped server-only export names before deciding to skip parsing", async () => {
+      const escapedHookName = "get\\u0053erverData";
+      const code = [
+        `import { getEnv } from "veryfront";`,
+        `const SECRET = getEnv("ORDERS_SECRET");`,
+        `function loadIt() { return { props: { SECRET } }; }`,
+        `export { loadIt as ${escapedHookName} };`,
+        `export default function Page() { return null; }`,
+      ].join("\n");
+
+      const result = await stripServerOnlyExports(code, "page.tsx");
+
+      assertNotIncludes(result, "ORDERS_SECRET");
+      assertNotIncludes(result, "getEnv");
+      assertStringIncludes(result, "getServerData");
+    });
+
+    it("fails closed when a server hook is an import-equals alias", async () => {
+      const code = [
+        `import Loader = require("../server/loader.ts");`,
+        `export { Loader as getServerData };`,
+        `export default function Page() { return null; }`,
+      ].join("\n");
+
+      await assertRejects(
+        () => stripServerOnlyExports(code, "page.ts"),
+        Error,
+        "import Loader = require",
+      );
     });
 
     // Emitting a module this pass could not analyse would put the loader and
@@ -529,7 +670,7 @@ describe("browser-server-exports-strip", () => {
 
       const result = await stripServerOnlyExports(code);
 
-      // The barrel is gone completely — not even a side-effect import survives.
+      // The barrel is gone completely. Not even a side-effect import survives.
       assertNotIncludes(result, `"veryfront"`);
       assertNotIncludes(result, `'veryfront'`);
       assertEquals(occurrences(result, "getEnv"), 0);
@@ -564,8 +705,8 @@ describe("browser-server-exports-strip", () => {
       assertEquals(occurrences(result, "thing"), 0);
     });
 
-    // Secret-leak fix: a module-scope value computed for a server-only hook —
-    // `const API_KEY = getEnv("SECRET_KEY")` read only inside getServerData —
+    // Secret-leak fix: a module-scope value computed for a server-only hook,
+    // `const API_KEY = getEnv("SECRET_KEY")` read only inside getServerData,
     // must not survive into the browser output. Emptying the hook leaves it
     // dead; the pass now drops it, which in turn drops the framework import.
     it("drops a module-scope server value used only by a stripped hook", async () => {
@@ -585,7 +726,7 @@ describe("browser-server-exports-strip", () => {
     });
 
     // Contrast pin: the same value is KEPT when the browser component also reads
-    // it — pruning is scoped to declarations nothing else references.
+    // it. Pruning is scoped to declarations nothing else references.
     it("keeps a module-scope value the client component also reads", async () => {
       const code = [
         `import { getEnv } from "veryfront";`,
@@ -603,7 +744,7 @@ describe("browser-server-exports-strip", () => {
     // Over-pruning guard: pruning is scoped to the stripped hook's closure, so
     // unrelated module-scope initialization with side effects (client analytics,
     // custom-element registration, instrumentation) sitting next to a server-only
-    // hook must survive — only the hook's own closure is removed.
+    // hook must survive. Only the hook's own closure is removed.
     it("keeps unrelated top-level side-effect declarations while dropping the hook's closure", async () => {
       const code = [
         `const clientInit = bootClientAnalytics();`,
@@ -659,7 +800,7 @@ describe("browser-server-exports-strip", () => {
       assertEquals(occurrences(result, "getEnv"), 0);
     });
 
-    // The hook can be an arrow assigned to `const` — its closure must be
+    // The hook can be an arrow assigned to `const`. Its closure must be
     // captured the same way as a `function` declaration before it is emptied.
     it("prunes the closure of a const-arrow hook form", async () => {
       const code = [
@@ -904,7 +1045,7 @@ describe("browser-server-exports-strip", () => {
       assertStringIncludes(result, "a, b");
     });
 
-    it("keeps side effects for ordinary imports with mixed hook-only bindings", async () => {
+    it("deletes a mixed import whose surviving specifier nothing reads", async () => {
       const code = [
         `import { initClient, loadSecret } from "./client-setup.ts";`,
         `export async function getServerData() { return { props: { token: loadSecret() } }; }`,
@@ -913,7 +1054,7 @@ describe("browser-server-exports-strip", () => {
 
       const result = await stripServerOnlyExports(code);
 
-      assertStringIncludes(result, `import "./client-setup.ts"`);
+      assertNotIncludes(result, "./client-setup.ts");
       assertEquals(occurrences(result, "initClient"), 0);
       assertEquals(occurrences(result, "loadSecret"), 0);
     });
@@ -1137,6 +1278,155 @@ describe("browser-server-exports-strip", () => {
       return { code, target, filePath: "pages/test.tsx", metadata: new Map() } as TransformContext;
     }
 
+    function pageWithUnownedUnusedImport(): string {
+      return [
+        `import { initClientMetrics } from "./client-metrics.ts";`,
+        `export async function getServerData() { return { props: {} }; }`,
+        `export default function Page() { return null; }`,
+      ].join("\n");
+    }
+
+    function assertNoClientMetricsImport(code: string): void {
+      assertNotIncludes(code, "client-metrics.ts");
+      assertEquals(occurrences(code, "initClientMetrics"), 0);
+    }
+
+    function assertBareClientMetricsImport(code: string): void {
+      assertEquals(/import\s*["'][^"']*client-metrics[^"']*["'];/.test(code), true);
+      assertNotIncludes(code, "import { initClientMetrics }");
+      assertEquals(occurrences(code, "initClientMetrics"), 0);
+    }
+
+    function assertOneBareProjectImport(code: string): void {
+      const sideEffectImports = code.match(/import\s*["'][^"']+["'];/g) ?? [];
+      assertEquals(sideEffectImports.length, 1, code);
+      assertStringIncludes(sideEffectImports[0] ?? "", "/_veryfront/fs/");
+      assertEquals(occurrences(code, "initClientMetrics"), 0);
+    }
+
+    it("accepts decorators after export before compiling browser modules", async () => {
+      const source = [
+        `function logged(value: unknown) { return value; }`,
+        `const SECRET = "SERVER_ONLY_DECORATOR_SECRET";`,
+        `export async function getServerData() { return { props: { secret: SECRET } }; }`,
+        `export @logged class PageModel {}`,
+        `export default function Page() { return null; }`,
+      ].join("\n");
+
+      const result = await runPipeline(
+        source,
+        "/project/pages/decorated.tsx",
+        "/project",
+        { projectId: "decorator-after-export-strip", dev: false, ssr: false },
+      );
+
+      assertNotIncludes(result.code, "SERVER_ONLY_DECORATOR_SECRET");
+      assertStringIncludes(result.code, "PageModel");
+    });
+
+    it("classifies authored browser parse errors as tenant compilation failures", async () => {
+      const source = [
+        `export async function getServerData() { return { props: {} }; }`,
+        `export default function Page( { return null; }`,
+      ].join("\n");
+
+      const error = await assertRejects(
+        () =>
+          runPipeline(
+            source,
+            "/project/pages/broken.tsx",
+            "/project",
+            { projectId: "authored-strip-parse-error", dev: false, ssr: false },
+          ),
+        VeryfrontError,
+      );
+
+      assertInstanceOf(error, VeryfrontError);
+      assertEquals(error.slug, "compilation-error");
+      assertEquals(
+        (error.context as { tenantBuildFailure?: unknown } | undefined)?.tenantBuildFailure,
+        true,
+      );
+    });
+
+    it("does not claim tenant ownership of generated Markdown or MDX parse diagnostics", async () => {
+      const source = [
+        `export async function getServerData() { return { props: {} }; }`,
+        `export default function Page( { return null; }`,
+      ].join("\n");
+
+      for (const extension of ["md", "mdx"]) {
+        const error = await assertRejects(
+          async () =>
+            await browserServerExportsStripPlugin.transform({
+              ...ctx(source, "browser"),
+              filePath: `/project/pages/generated.${extension}`,
+            } as TransformContext),
+          VeryfrontError,
+        );
+
+        assertInstanceOf(error, VeryfrontError);
+        assertEquals(error.slug, "compilation-error");
+        assertEquals(
+          (error.context as { tenantBuildFailure?: unknown } | undefined)?.tenantBuildFailure,
+          false,
+        );
+      }
+    });
+
+    it("keeps missing parser failures framework owned", async () => {
+      const previous = tryResolve<CodeParser>("CodeParser");
+      unregister("CodeParser");
+
+      try {
+        const error = await assertRejects(
+          async () =>
+            await browserServerExportsStripPlugin.transform(
+              ctx(`export async function getServerData() { return { props: {} }; }`, "browser"),
+            ),
+          Error,
+        );
+
+        assertEquals(error instanceof VeryfrontError, false);
+        assertStringIncludes((error as Error).message, "no CodeParser extension is registered");
+      } finally {
+        if (previous !== undefined) register("CodeParser", previous);
+      }
+    });
+
+    it("keeps parser-internal failures framework owned", async () => {
+      const parser = tryResolve<CodeParser>("CodeParser");
+      if (!parser) throw new Error("no CodeParser extension is registered");
+
+      const failingParser: CodeParser = {
+        parse: (options) => {
+          if (options.code.includes("__vfStub")) return parser.parse(options);
+          return Promise.reject(new Error("parser exploded internally"));
+        },
+        traverse: (ast, visitor) => parser.traverse(ast, visitor),
+        generate: (ast, options) => parser.generate(ast, options),
+        injectJsxNodePositions: (source, options) => parser.injectJsxNodePositions(source, options),
+        hasFunctionDirective: parser.hasFunctionDirective?.bind(parser),
+        findStaticCommonJsImports: parser.findStaticCommonJsImports?.bind(parser),
+      };
+      register("CodeParser", failingParser);
+
+      try {
+        const error = await assertRejects(
+          async () =>
+            await browserServerExportsStripPlugin.transform(
+              ctx(`export async function getServerData() { return { props: {} }; }`, "browser"),
+            ),
+          Error,
+        );
+
+        assertEquals(error instanceof VeryfrontError, false);
+        assertStringIncludes((error as Error).message, "parser exploded internally");
+      } finally {
+        register("CodeParser", parser);
+      }
+    });
+
     it("drops the server-only import chain from the client artifact", async () => {
       const code = [
         `import { hashOf } from "@/lib/uses-crypto";`,
@@ -1154,7 +1444,52 @@ describe("browser-server-exports-strip", () => {
       assertStringIncludes(result, "TestD as default");
     });
 
-    it("does not retain a pre-strip inline source map", async () => {
+    it("lets compile erase unrelated unused TS and TSX named imports", async () => {
+      for (const extension of ["ts", "tsx"]) {
+        const result = await runPipeline(
+          pageWithUnownedUnusedImport(),
+          `/project/pages/test.${extension}`,
+          "/project",
+          { projectId: `unused-import-${extension}`, dev: false, ssr: false },
+        );
+
+        assertNoClientMetricsImport(result.code);
+      }
+    });
+
+    it("retains only a side-effect import for unrelated unused JS and JSX imports", async () => {
+      for (const extension of ["js", "jsx"]) {
+        const result = await runPipeline(
+          pageWithUnownedUnusedImport(),
+          `/project/pages/test.${extension}`,
+          "/project",
+          { projectId: `unused-import-${extension}`, dev: false, ssr: false },
+        );
+
+        assertBareClientMetricsImport(result.code);
+      }
+    });
+
+    it("retains only a side-effect import for unrelated unused generated MDX imports", async () => {
+      const source = [
+        `import { initClientMetrics } from "./client-metrics.ts";`,
+        ``,
+        `export async function getServerData() { return { props: {} }; }`,
+        ``,
+        `# Dashboard`,
+      ].join("\n");
+
+      const result = await runPipeline(
+        source,
+        "/project/pages/test.mdx",
+        "/project",
+        { projectId: "unused-import-mdx", dev: false, ssr: false },
+      );
+
+      assertOneBareProjectImport(result.code);
+    });
+
+    it("builds the dev compile map from stripped browser input", async () => {
       const source = [
         `import { getEnv } from "veryfront";`,
         `const KEY = getEnv("SERVER_VALUE");`,
@@ -1162,15 +1497,18 @@ describe("browser-server-exports-strip", () => {
         `export async function getServerData() { return { props: { key: KEY } }; }`,
         `export default function Page() { return CLIENT_MARKER; }`,
       ].join("\n");
-      const compileContext = {
-        ...ctx(source, "browser"),
-        dev: true,
-        jsxImportSource: "react",
-      };
-      const compiled = await compilePlugin.transform(compileContext);
-      const directive = compileContext.metadata.get(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA);
-      assertEquals(typeof directive, "string");
-      const match = String(directive).match(
+
+      const result = await runPipeline(
+        source,
+        "/project/pages/test.tsx",
+        "/project",
+        { projectId: "source-map-after-strip", dev: true, ssr: false },
+      );
+
+      assertNotIncludes(result.code, "SERVER_VALUE");
+      assertStringIncludes(result.code, "sourceMappingURL=data:application/json;base64,");
+      assertStringIncludes(result.code, "sourceMappingURL=data:text/plain;base64,AAAA");
+      const match = result.code.match(
         /\/\/[#@]\s*sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/]+={0,2})/,
       );
       assertEquals(match === null, false);
@@ -1179,55 +1517,28 @@ describe("browser-server-exports-strip", () => {
       };
       assertEquals(
         sourceMap.sourcesContent?.some((content) => content.includes("SERVER_VALUE")),
-        true,
+        false,
       );
-
-      const result = await browserServerExportsStripPlugin.transform({
-        ...compileContext,
-        code: compiled,
-      });
-
-      assertNotIncludes(result, "SERVER_VALUE");
-      assertNotIncludes(result, "sourceMappingURL=data:application/json;base64,");
-      assertStringIncludes(result, "sourceMappingURL=data:text/plain;base64,AAAA");
     });
 
-    it("removes a pre-strip inline map before an appended MDX export", async () => {
+    it("removes a pre-existing source map directive after stripping", async () => {
       const source = [
         `import { getEnv } from "veryfront";`,
         `const KEY = getEnv("SERVER_VALUE");`,
         `const CLIENT_MARKER = "//# sourceMappingURL=data:text/plain;base64,AAAA";`,
-        `const MDXLayout = () => CLIENT_MARKER;`,
         `export async function getServerData() { return { props: { key: KEY } }; }`,
+        `export default function Page() { return CLIENT_MARKER; }`,
+        `//# sourceMappingURL=data:application/json;base64,AAAA`,
       ].join("\n");
-      const compileContext = {
-        ...ctx(source, "browser"),
-        filePath: "pages/test.mdx",
-        dev: true,
-        jsxImportSource: "react",
-      };
-      const compiled = await compilePlugin.transform(compileContext);
-      assertEquals(
-        String(compileContext.metadata.get(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA)).includes(
-          "sourceMappingURL=data:application/json;base64,",
-        ),
-        true,
-      );
-      assertNotIncludes(compiled, "sourceMappingURL=data:application/json;base64,");
-      assertStringIncludes(compiled, "export { MDXLayout };");
 
-      const result = await browserServerExportsStripPlugin.transform({
-        ...compileContext,
-        code: compiled,
-      });
+      const result = await browserServerExportsStripPlugin.transform(ctx(source, "browser"));
 
       assertNotIncludes(result, "SERVER_VALUE");
       assertNotIncludes(result, "sourceMappingURL=data:application/json;base64,");
       assertStringIncludes(result, "sourceMappingURL=data:text/plain;base64,AAAA");
-      assertStringIncludes(result, "export { MDXLayout };");
     });
 
-    it("removes the compile map after an intermediate plugin appends code", async () => {
+    it("keeps the stripped compile map after an intermediate plugin appends code", async () => {
       const source = [
         `const KEY = "SERVER_ONLY_HOOK_SOURCE";`,
         `export async function getServerData() { return { props: { key: KEY } }; }`,
@@ -1249,11 +1560,22 @@ describe("browser-server-exports-strip", () => {
       );
 
       assertNotIncludes(result.code, "SERVER_ONLY_HOOK_SOURCE");
-      assertNotIncludes(result.code, "sourceMappingURL=data:application/json;base64,");
+      assertStringIncludes(result.code, "sourceMappingURL=data:application/json;base64,");
       assertStringIncludes(result.code, "export const APPENDED = true;");
+      const match = result.code.match(
+        /\/\/[#@]\s*sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/]+={0,2})/,
+      );
+      assertEquals(match === null, false);
+      const sourceMap = JSON.parse(atob(match?.[1] ?? "")) as {
+        sourcesContent?: string[];
+      };
+      assertEquals(
+        sourceMap.sourcesContent?.some((content) => content.includes("SERVER_ONLY_HOOK_SOURCE")),
+        false,
+      );
     });
 
-    it("does not confuse a copied map string with the compile map comment", async () => {
+    it("allows a later plugin to copy the stripped compile map string", async () => {
       const source = [
         `const KEY = "SERVER_ONLY_HOOK_SOURCE";`,
         `export async function getServerData() { return { props: { key: KEY } }; }`,
@@ -1283,8 +1605,8 @@ describe("browser-server-exports-strip", () => {
       );
 
       assertNotIncludes(result.code, "SERVER_ONLY_HOOK_SOURCE");
-      assertNotIncludes(result.code, "sourceMappingURL=data:application/json;base64,");
-      assertNotIncludes(result.code, "COPIED_COMPILE_MAP");
+      assertStringIncludes(result.code, "sourceMappingURL=data:application/json;base64,");
+      assertStringIncludes(result.code, "COPIED_COMPILE_MAP");
       assertStringIncludes(result.code, "export const APPENDED = true;");
     });
 
@@ -1504,9 +1826,10 @@ export const v = live();`,
         const result = await stripServerOnlyExports(code, "/project/app/page.tsx");
 
         // The binding goes; the module specifier is demoted to a side-effect
-        // import by dropUnusedImportBindings, which is pre-existing behaviour
+        // import by dropUnusedImportBindings, which is pre-existing behavior
         // and not what this case is about.
         assertNotIncludes(result, "{ audit }");
+        assertStringIncludes(result, `import "./audit.ts"`);
         assertNotIncludes(result, 'getEnv("SECRET")');
       });
 
@@ -1784,10 +2107,7 @@ export function hook() {
         const result = await stripServerOnlyExports(code, "page.tsx");
 
         assertNotIncludes(result, "{ secretOnly, Low }");
-        // A mixed project import keeps its pre-existing side-effect contract.
-        // The TypeScript fix removes the false live binding; it does not prove
-        // that evaluating the imported module is safe to delete.
-        assertStringIncludes(result, `import "../lib/server-only.ts"`);
+        assertNotIncludes(result, "../lib/server-only.ts");
         assertStringIncludes(result, "Level.Low");
       });
 
@@ -1867,7 +2187,7 @@ export function hook() {
         const result = await stripServerOnlyExports(code, "page.tsx");
 
         assertNotIncludes(result, "{ secretOnly, Alias }");
-        assertStringIncludes(result, `import "../lib/server-only.ts"`);
+        assertNotIncludes(result, "../lib/server-only.ts");
         assertStringIncludes(result, "import Alias = ClientNS");
       });
 
@@ -1901,7 +2221,7 @@ export function hook() {
         const result = await stripServerOnlyExports(code, "page.tsx");
 
         assertNotIncludes(result, "{ secretOnly, Alias }");
-        assertStringIncludes(result, `import "../lib/server-only.ts"`);
+        assertNotIncludes(result, "../lib/server-only.ts");
         assertStringIncludes(result, "enum Alias");
       });
 

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
@@ -1378,6 +1378,26 @@ describe("browser-server-exports-strip", () => {
       assertStringIncludes(result, "PageModel");
     });
 
+    it("strips modules with legacy decorator type arguments before compiling browser modules", async () => {
+      const source = [
+        `function logged<T>(value: T) { return value; }`,
+        `const SECRET = "SERVER_ONLY_GENERIC_DECORATOR_SECRET";`,
+        `export async function getServerData() { return { props: { secret: SECRET } }; }`,
+        `@logged<string> export class PageModel {}`,
+        `export default function Page() { return PageModel; }`,
+      ].join("\n");
+
+      const result = await runPipeline(
+        source,
+        "/project/pages/generic-decorator.tsx",
+        "/project",
+        { projectId: "generic-decorator-strip", dev: false, ssr: false },
+      );
+
+      assertNotIncludes(result.code, "SERVER_ONLY_GENERIC_DECORATOR_SECRET");
+      assertStringIncludes(result.code, "PageModel");
+    });
+
     it("does not claim tenant ownership of generated Markdown or MDX parse diagnostics", async () => {
       const source = [
         `export async function getServerData() { return { props: {} }; }`,

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.ts
@@ -50,27 +50,43 @@
  * getEnv(...)` used only by `getServerData` does not reach the browser), and
  * removes the hook-only imports that leaves unused. What it does NOT do: reason
  * about a value that is *also* read by browser code, or one reached only through
- * an existing bare side-effect import — those are kept. It is not a general
+ * an existing bare side-effect import. Those are kept. It is not a general
  * guarantee that every secret stays on the server, but a value used solely by a
  * server-only hook no longer leaks.
  */
 
 import { tryResolve } from "#veryfront/extensions/contracts.ts";
 import type { ASTNode, CodeParser } from "#veryfront/extensions/parser/index.ts";
+import { COMPILATION_ERROR } from "#veryfront/errors";
+import { getLoaderFromPath, isGeneratedContentOutput } from "../../esm/transform-utils.ts";
+import { isTypeScript } from "../context.ts";
 import type { TransformContext, TransformPlugin } from "../types.ts";
 import { TransformStage } from "../types.ts";
-import {
-  COMPILE_SOURCE_MAP_DIRECTIVE_METADATA,
-  COMPILE_SOURCE_MAP_INPUT_METADATA,
-} from "./compile.ts";
 
 /** Exports that only ever execute on the server. */
-const SERVER_ONLY_EXPORTS = ["getServerData", "getStaticData", "getStaticPaths"];
+export const SERVER_ONLY_EXPORTS = ["getServerData", "getStaticData", "getStaticPaths"];
 
-// The compile stage runs before this pass and embeds its input in a development
-// sourcemap. Once a hook is stripped, any prior map is stale and may contain or
-// point at a verbatim copy of the server-only source. Match only an actual
-// trailing directive so source-map-like text inside authored strings survives.
+export interface StripServerOnlyExportsOptions {
+  /**
+   * Leave imports this pass did not make unused exactly as authored. This is
+   * only safe before a later compiler pass can erase unused named imports.
+   */
+  preserveUnownedUnusedImports?: boolean;
+  /**
+   * Convert authored source syntax diagnostics into the same tenant-owned
+   * compilation error shape as the compiler stage.
+   */
+  classifySourceParseErrors?: boolean;
+}
+
+const ObjectPrototypeHasOwnProperty = Object.prototype.hasOwnProperty;
+const ReflectApply = Reflect.apply;
+const ReflectGetOwnPropertyDescriptor = Reflect.getOwnPropertyDescriptor;
+
+// This pass runs before compile, so no compile map exists yet. Checked-in build
+// output can still carry a stale map directive, and once a hook is stripped that
+// map may point at verbatim server-only source. Match only an actual trailing
+// directive so source-map-like text inside authored strings survives.
 const SOURCE_MAP_SUFFIX =
   /(^|\r?\n)[\t ]*\/\/[#@][\t ]*sourceMappingURL=[^"'`\s]+[\t ]*(?:\r?\n)?$/;
 
@@ -78,9 +94,52 @@ function dropSourceMapSuffix(code: string): string {
   return code.replace(SOURCE_MAP_SUFFIX, "$1");
 }
 
-function appendSourceMapDirective(code: string, directive: string): string {
-  const separator = code.length > 0 && !code.endsWith("\n") ? "\n" : "";
-  return `${code}${separator}${directive}\n`;
+function readOwnDataProperty(value: unknown, key: PropertyKey): unknown {
+  if (
+    value === null ||
+    (typeof value !== "object" && typeof value !== "function")
+  ) {
+    return undefined;
+  }
+  try {
+    const descriptor = ReflectGetOwnPropertyDescriptor(value, key);
+    if (
+      descriptor !== undefined &&
+      ReflectApply(ObjectPrototypeHasOwnProperty, descriptor, ["value"]) === true
+    ) {
+      return descriptor.value;
+    }
+  } catch {
+    // A hostile proxy cannot provide trusted source-diagnostic evidence.
+  }
+  return undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isParserSourceDiagnostic(error: unknown): boolean {
+  const loc = readOwnDataProperty(error, "loc");
+  if (loc !== null && typeof loc === "object") return true;
+  if (readOwnDataProperty(error, "code") === "BABEL_PARSE_ERROR") return true;
+  return typeof readOwnDataProperty(error, "pos") === "number";
+}
+
+function createSourceParseCompilationError(
+  filePath: string | undefined,
+  cause: unknown,
+): Error {
+  const loader = getLoaderFromPath(filePath ?? "module.tsx");
+  const detail = `ESM transform failed for ${filePath ?? "this module"} ` +
+    `(loader: ${loader}): ${errorMessage(cause)}`;
+  return COMPILATION_ERROR.create({
+    detail,
+    cause,
+    context: {
+      tenantBuildFailure: !isGeneratedContentOutput(filePath) && isParserSourceDiagnostic(cause),
+    },
+  });
 }
 
 /** Source the stub nodes are lifted from, so no node shape is hand-built. */
@@ -110,13 +169,108 @@ function children(node: Node): Node[] {
   return found;
 }
 
+function isEcmaScriptIdentifier(name: string): boolean {
+  return /^[$_\p{ID_Start}][$_\u200c\u200d\p{ID_Continue}]*$/u.test(name);
+}
+
+function isIntrinsicJsxName(name: string): boolean {
+  if (/^[a-z]/.test(name)) return true;
+  return !isEcmaScriptIdentifier(name);
+}
+
+function jsxElementNameReadsBinding(node: Node): boolean {
+  if (node.type !== "JSXIdentifier") return true;
+  const name = nodeName(node);
+  return name !== null && !isIntrinsicJsxName(name);
+}
+
+function isReferenceChildKey(parent: Node, key: string): boolean {
+  if (parent.type === "ImportDeclaration" || parent.type === "ImportSpecifier") return false;
+  if (parent.type === "ImportDefaultSpecifier" || parent.type === "ImportNamespaceSpecifier") {
+    return false;
+  }
+  if (parent.type === "ImportAttribute") return false;
+  if (parent.type === "ExportAllDeclaration") return false;
+  if (parent.type === "ExportDefaultSpecifier" || parent.type === "ExportNamespaceSpecifier") {
+    return false;
+  }
+  if (parent.type === "ExportSpecifier") return key === "local";
+  if (
+    parent.type === "ExportNamedDeclaration" && isNode(parent.source) && key === "specifiers"
+  ) {
+    return false;
+  }
+  if (
+    (parent.type === "JSXOpeningElement" || parent.type === "JSXClosingElement") &&
+    key === "name" && isNode(parent.name) && !jsxElementNameReadsBinding(parent.name)
+  ) {
+    return false;
+  }
+  if (parent.type === "JSXAttribute" && key === "name") return false;
+  if (parent.type === "JSXNamespacedName") return false;
+  if (parent.type === "JSXMemberExpression" && key === "property") return false;
+  if (
+    (parent.type === "MemberExpression" || parent.type === "OptionalMemberExpression") &&
+    key === "property" && parent.computed !== true
+  ) {
+    return false;
+  }
+  if (
+    (parent.type === "ObjectProperty" || parent.type === "ObjectMethod" ||
+      parent.type === "ClassMethod" || parent.type === "ClassProperty" ||
+      parent.type === "ClassAccessorProperty" || parent.type === "ClassPrivateProperty" ||
+      parent.type === "ClassPrivateMethod") &&
+    key === "key" && parent.computed !== true
+  ) {
+    return false;
+  }
+  if (parent.type === "PrivateName" && key === "id") return false;
+  if (
+    (parent.type === "TSEnumDeclaration" || parent.type === "TSEnumMember") && key === "id"
+  ) {
+    return false;
+  }
+  if (parent.type === "TSQualifiedName" && key === "right") return false;
+  if (
+    (parent.type === "BreakStatement" || parent.type === "ContinueStatement" ||
+      parent.type === "LabeledStatement") && key === "label"
+  ) {
+    return false;
+  }
+  if (parent.type === "MetaProperty") return false;
+  if (parent.type === "Directive" || parent.type === "DirectiveLiteral") return false;
+  return true;
+}
+
+function referenceChildren(node: Node): Node[] {
+  const found: Node[] = [];
+
+  for (const [key, value] of Object.entries(node)) {
+    if (
+      key === "loc" || key === "leadingComments" || key === "trailingComments" ||
+      key === "comments" || key === "tokens"
+    ) {
+      continue;
+    }
+    if (!isReferenceChildKey(node, key)) continue;
+
+    if (Array.isArray(value)) {
+      for (const entry of value) if (isNode(entry)) found.push(entry);
+      continue;
+    }
+    if (isNode(value)) found.push(value);
+  }
+
+  return found;
+}
+
 /**
  * Walk every node in the tree. Returning `false` from `visit` skips the
  * subtree, which is how import statements stay out of the reference count.
  */
 function walk(node: Node, visit: (node: Node) => boolean | void): void {
   if (visit(node) === false) return;
-  for (const child of children(node)) walk(child, visit);
+  for (const child of referenceChildren(node)) walk(child, visit);
 }
 
 /**
@@ -199,6 +353,16 @@ function nodeName(value: unknown): string | null {
   if (!isNode(value)) return null;
   const name = value.name;
   return typeof name === "string" ? name : null;
+}
+
+function exportName(value: unknown): string | null {
+  return isNode(value) ? (stringLiteralText(value) ?? nodeName(value)) : null;
+}
+
+function mayNameServerOnlyExport(code: string): boolean {
+  if (!/\bexport\b/.test(code)) return false;
+  if (SERVER_ONLY_EXPORTS.some((name) => code.includes(name))) return true;
+  return code.includes("\\");
 }
 
 function bodyOf(ast: ASTNode): Node[] {
@@ -333,13 +497,14 @@ function exportedHookBindings(body: Node[]): { locals: Set<string>; unhandled: s
     for (const specifier of Array.isArray(statement.specifiers) ? statement.specifiers : []) {
       if (!isNode(specifier)) continue;
       if (specifier.exportKind === "type") continue;
-      if (!isHook(nodeName(specifier.exported))) continue;
+      const exported = exportName(specifier.exported);
+      if (!isHook(exported)) continue;
 
       // `export { x as getServerData } from "./loader"` never binds `x` here,
       // so there is no body to empty and the module it points at is still
       // pulled into the graph.
       if (isNode(statement.source)) {
-        unhandled.push(`export { … as ${nodeName(specifier.exported)} } from …`);
+        unhandled.push(`export { … as ${exported} } from …`);
         continue;
       }
 
@@ -371,6 +536,14 @@ function exportedHookBindings(body: Node[]): { locals: Set<string>; unhandled: s
       if (patternBoundNames(id).some(isHook)) {
         unhandled.push("export const { … } = …");
       }
+    }
+  }
+
+  for (const statement of body) {
+    if (statement.type !== "TSImportEqualsDeclaration") continue;
+    const name = nodeName(statement.id);
+    if (name && (locals.has(name) || (statement.isExport === true && isHook(name)))) {
+      unhandled.push(`import ${name} = require(…)`);
     }
   }
 
@@ -536,6 +709,16 @@ function moduleScopeDeclarations(body: Node[]): ModuleScopeDecl[] {
       continue;
     }
 
+    if (
+      statement.type === "TSImportEqualsDeclaration" && statement.isExport !== true &&
+      !isErasedTypeNode(statement)
+    ) {
+      const id = statement.id;
+      const name = nodeName(id);
+      if (name && isNode(id)) decls.push({ statement, names: [name], bindingIds: [id] });
+      continue;
+    }
+
     if (statement.type === "VariableDeclaration") {
       const variableDecls: ModuleScopeDecl[] = [];
 
@@ -654,7 +837,7 @@ function freeReferencedIdentifiers(root: Node): Set<string> {
   };
 
   const visitChildren = (node: Node, scopes: LexicalScope[]): void => {
-    for (const child of children(node)) visit(child, scopes);
+    for (const child of referenceChildren(node)) visit(child, scopes);
   };
 
   const visitDecorators = (node: Node, scopes: LexicalScope[]): void => {
@@ -906,9 +1089,11 @@ function freeReferencedIdentifiers(root: Node): Set<string> {
     if (node.type === "ClassDeclaration" || node.type === "ClassExpression") {
       if (node.type === "ClassDeclaration") bindPatternNames(scopes[0] ?? rootScope, node.id);
       visitDecorators(node, scopes);
-      const body = node.body;
-      if (isNode(body)) visitChildren(body, scopes);
       if (isNode(node.superClass)) visit(node.superClass, scopes);
+      const classScope: LexicalScope = { kind: "block", names: new Set() };
+      bindPatternNames(classScope, node.id);
+      const body = node.body;
+      if (isNode(body)) visitChildren(body, [classScope, ...scopes]);
       return;
     }
 
@@ -966,7 +1151,7 @@ function freeReferencedIdentifiers(root: Node): Set<string> {
 
 /**
  * Identifiers referenced inside the server-only hooks that are about to be
- * emptied — the seed of the hook's dependency closure. Must be collected before
+ * emptied. It is the seed of the hook's dependency closure. Must be collected before
  * the hook bodies are replaced with stubs. `targets` is the set of local hook
  * names (as passed to `emptyServerOnlyHooks`).
  */
@@ -1293,17 +1478,49 @@ function compilerNameRegistrations(body: Node[]): CompilerNameRegistration[] {
   return registrations;
 }
 
+const JSX_PRAGMA_RUNTIME = /@jsxRuntime\s+(\S+)/;
+const JSX_PRAGMA_FACTORY = /@jsx\s+(\S+)/;
+const JSX_PRAGMA_FRAGMENT = /@jsxFrag\s+(\S+)/;
+const DEFAULT_CLASSIC_FACTORY_ROOT = "React";
+
+function pragmaRootBinding(expression: string | undefined): string | null {
+  const root = expression?.split(/[.([]/)[0]?.trim();
+  return root && isEcmaScriptIdentifier(root) ? root : null;
+}
+
+function jsxPragmaBindings(ast: ASTNode): Set<string> {
+  const pinned = new Set<string>();
+  const comments = (ast as { comments?: unknown }).comments;
+  if (!Array.isArray(comments)) return pinned;
+
+  const texts: string[] = [];
+  for (const comment of comments) {
+    const text = isNode(comment) ? comment.value : undefined;
+    if (typeof text === "string" && text.includes("@jsx")) texts.push(text);
+  }
+  if (!texts.some((text) => JSX_PRAGMA_RUNTIME.exec(text)?.[1] === "classic")) return pinned;
+
+  for (const text of texts) {
+    for (const pattern of [JSX_PRAGMA_FACTORY, JSX_PRAGMA_FRAGMENT]) {
+      const root = pragmaRootBinding(pattern.exec(text)?.[1]);
+      if (root) pinned.add(root);
+    }
+  }
+  pinned.add(DEFAULT_CLASSIC_FACTORY_ROOT);
+  return pinned;
+}
+
 /**
  * Drop the top-level declarations the emptied server-only hooks closed over.
  *
  * Scope is the *dependency closure of the stripped hooks*, not "everything
  * unreferenced". A declaration is removed only when (a) it is reached from the
- * hook's own reference graph — seeded from `hookClosure` and grown through the
- * initialisers of declarations already removed — and (b) nothing surviving in
+ * hook's own reference graph, seeded from `hookClosure` and grown through the
+ * initialisers of declarations already removed, and (b) nothing surviving in
  * the module still references it. So `const API_KEY = getEnv(...)` read only by
  * `getServerData` goes (letting `dropUnusedImportBindings` drop the import
- * next), while an unrelated `const _ = bootClientAnalytics()` — never part of
- * the hook graph — is left intact along with its side effect. Iterates to a
+ * next), while an unrelated `const _ = bootClientAnalytics()`, never part of
+ * the hook graph, is left intact along with its side effect. Iterates to a
  * fixpoint: removing one binding can leave a helper it was the last user of
  * newly dead *within the closure*.
  */
@@ -1311,6 +1528,7 @@ function dropUnusedModuleScopeBindings(
   body: Node[],
   hookClosure: Set<string>,
   filePath: string | undefined,
+  pinned: Set<string>,
 ): Node[] {
   let current = body;
 
@@ -1336,7 +1554,7 @@ function dropUnusedModuleScopeBindings(
     const removedDecls: ModuleScopeDecl[] = [];
     for (const decl of decls) {
       const inClosure = decl.names.every((name) => hookClosure.has(name));
-      const unused = decl.names.every((name) => !referenced.has(name));
+      const unused = decl.names.every((name) => !referenced.has(name) && !pinned.has(name));
       if (!inClosure || !unused) continue;
 
       removedDecls.push(decl);
@@ -1417,7 +1635,12 @@ function importedBindings(statement: Node): string[] {
  * artifact, which is exactly what this stage strips. Other unused imports keep
  * the legacy conservative side-effect rewrite.
  */
-function dropUnusedImportBindings(body: Node[], hookClosure: Set<string>): Node[] {
+function dropUnusedImportBindings(
+  body: Node[],
+  hookClosure: Set<string>,
+  pinned: Set<string>,
+  options: StripServerOnlyExportsOptions,
+): Node[] {
   // Import liveness must be scope-aware. A local enum member, namespace,
   // parameter property, or ordinary nested binding can share a spelling with
   // an import without reading that imported binding.
@@ -1430,26 +1653,69 @@ function dropUnusedImportBindings(body: Node[], hookClosure: Set<string>): Node[
     const bindings = importedBindings(statement);
     // Already a side-effect import: nothing to drop.
     if (bindings.length === 0) return true;
-    if (bindings.some((binding) => referenced.has(binding))) return true;
+    if (bindings.some((binding) => referenced.has(binding) || pinned.has(binding))) return true;
 
     const source = isNode(statement.source) ? statement.source.value : undefined;
     const isKnownDroppableSource = typeof source === "string" &&
       (source.startsWith("node:") || source === "veryfront" || source.startsWith("veryfront/"));
-    // Two different reasons to delete rather than reduce, and one to reduce.
     // A node: or veryfront source is unsafe or pointless as a browser
-    // side-effect import whatever used it. A project-relative source is deleted
-    // only when the stripped hook owned every binding, because that module is
-    // reached solely through server-only code and a bare side-effect import
-    // would keep its whole transitive graph in the browser artifact. An import
-    // the hook never touched was already unused before this pass ran, so it
-    // keeps the legacy reduction and its side effects with it.
-    if (isKnownDroppableSource || bindings.every((binding) => hookClosure.has(binding))) {
+    // side-effect import whatever used it. Any other source is deleted when the
+    // stripped hook owned at least one binding and no surviving code reads any
+    // binding it declares. Keeping the rest of that statement would keep the
+    // imported module's transitive graph in the browser artifact, especially
+    // under JS/JSX loaders where compile cannot erase unused named imports.
+    if (isKnownDroppableSource || bindings.some((binding) => hookClosure.has(binding))) {
       return false;
     }
 
+    if (options.preserveUnownedUnusedImports === true) {
+      // The browser strip runs before compile. For TS and TSX, esbuild can
+      // erase genuinely unused named imports after this stage. Rewriting them
+      // to bare side-effect imports here would make erasable imports
+      // non-erasable.
+      return true;
+    }
+
+    // Direct helper callers and non-TypeScript browser inputs keep the legacy
+    // conservative behavior: leave the module evaluation but remove the
+    // binding. JS, JSX, and generated MDX compile output do not get unused
+    // import erasure from esbuild transform mode.
     statement.specifiers = [];
     return true;
   });
+}
+
+function retainLeadingComments(before: Node[], after: Node[]): Node[] {
+  const kept = new Set<Node>(after);
+  let orphaned: unknown[] = [];
+  let lastKept: Node | undefined;
+
+  for (const statement of before) {
+    if (!kept.has(statement)) {
+      const comments = statement.leadingComments;
+      if (Array.isArray(comments)) orphaned = [...orphaned, ...comments];
+      continue;
+    }
+
+    lastKept = statement;
+    if (orphaned.length === 0) continue;
+    const existing = Array.isArray(statement.leadingComments) ? statement.leadingComments : [];
+    statement.leadingComments = [
+      ...orphaned,
+      ...existing.filter((comment) => !orphaned.includes(comment)),
+    ];
+    orphaned = [];
+  }
+
+  if (orphaned.length > 0 && lastKept !== undefined) {
+    const existing = Array.isArray(lastKept.trailingComments) ? lastKept.trailingComments : [];
+    lastKept.trailingComments = [
+      ...existing.filter((comment) => !orphaned.includes(comment)),
+      ...orphaned,
+    ];
+  }
+
+  return after;
 }
 
 function setBody(ast: ASTNode, body: Node[]): void {
@@ -1482,14 +1748,16 @@ class ServerExportStripError extends Error {
  * Throws when the module names a server-only export and this pass cannot act on
  * it: no parser registered, the module does not parse, or the hook is exported
  * in a form with no local declaration to empty. Failing the build is the only
- * safe outcome — the alternative is shipping the loader to the browser.
+ * safe outcome. The alternative is shipping the loader to the browser.
  */
 export async function stripServerOnlyExports(
   code: string,
   filePath?: string,
+  options: StripServerOnlyExportsOptions = {},
 ): Promise<string> {
-  // Cheap pre-check: no mention of a hook means no parse.
-  if (!SERVER_ONLY_EXPORTS.some((name) => code.includes(name))) return code;
+  // Cheap pre-check: no plausible exported hook shape means no parse. Escaped
+  // export names require parsing because the runtime sees the normalized name.
+  if (!mayNameServerOnlyExport(code)) return code;
 
   const parser = tryResolve<CodeParser>("CodeParser");
   if (!parser) {
@@ -1504,14 +1772,18 @@ export async function stripServerOnlyExports(
     const parsedStubs = await parseStubs(parser);
     if (!parsedStubs) throw new Error("the stub source did not parse");
     stubs = parsedStubs;
+  } catch (error) {
+    throw new ServerExportStripError(filePath, errorMessage(error));
+  }
 
+  try {
     ast = await parser.parse({ code, filePath: filePath ?? "module.tsx" });
     body = bodyOf(ast);
   } catch (error) {
-    throw new ServerExportStripError(
-      filePath,
-      error instanceof Error ? error.message : String(error),
-    );
+    if (options.classifySourceParseErrors === true && isParserSourceDiagnostic(error)) {
+      throw createSourceParseCompilationError(filePath, error);
+    }
+    throw new ServerExportStripError(filePath, errorMessage(error));
   }
 
   const { locals, unhandled } = exportedHookBindings(body);
@@ -1529,8 +1801,20 @@ export async function stripServerOnlyExports(
   // Drop the module-scope state the emptied hooks were the last user of, then
   // the imports that leaves unused. Order matters: pruning `const API_KEY =
   // getEnv(...)` is what makes the `veryfront` import droppable.
-  const pruned = dropUnusedModuleScopeBindings(body, hookClosure, filePath);
-  setBody(ast, dropUnusedImportBindings(pruned, hookClosure));
+  //
+  // Ordering dependency: this pass runs before compile. Browser TS and TSX
+  // inputs can leave unowned unused named imports authored so compile can erase
+  // them. Moving this pass back after compile must restore a later
+  // unused-import erasure step or revisit that policy.
+  const pinned = jsxPragmaBindings(ast);
+  const pruned = retainLeadingComments(
+    body,
+    dropUnusedModuleScopeBindings(body, hookClosure, filePath, pinned),
+  );
+  setBody(
+    ast,
+    retainLeadingComments(pruned, dropUnusedImportBindings(pruned, hookClosure, pinned, options)),
+  );
 
   const generated = await parser.generate(ast);
   return dropSourceMapSuffix(generated.code);
@@ -1538,18 +1822,15 @@ export async function stripServerOnlyExports(
 
 export const browserServerExportsStripPlugin: TransformPlugin = {
   name: "browser-server-exports-strip",
-  // After esbuild compile and CSS strip, before any import resolution, so the
-  // dropped bindings are never rewritten or pre-fetched.
-  stage: TransformStage.COMPILE + 0.6,
+  // After parse and before compile, so stripped hook bodies never reach
+  // esbuild keepNames or the compile sourcemap. The array order in
+  // BROWSER_PIPELINE must agree with this stage number because custom plugins
+  // cause the pipeline to be sorted by stage.
+  stage: TransformStage.PARSE + 0.5,
   condition: (ctx: TransformContext) => ctx.target === "browser",
-  transform: async (ctx: TransformContext) => {
-    const directive = ctx.metadata.get(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA);
-    const compileInput = ctx.metadata.get(COMPILE_SOURCE_MAP_INPUT_METADATA);
-    ctx.metadata.delete(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA);
-    ctx.metadata.delete(COMPILE_SOURCE_MAP_INPUT_METADATA);
-    const result = await stripServerOnlyExports(ctx.code, ctx.filePath);
-    return result === ctx.code && compileInput === ctx.code && typeof directive === "string"
-      ? appendSourceMapDirective(result, directive)
-      : result;
-  },
+  transform: (ctx: TransformContext) =>
+    stripServerOnlyExports(ctx.code, ctx.filePath, {
+      classifySourceParseErrors: true,
+      preserveUnownedUnusedImports: isTypeScript(ctx),
+    }),
 };

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.ts
@@ -58,6 +58,7 @@
 import { tryResolve } from "#veryfront/extensions/contracts.ts";
 import type { ASTNode, CodeParser } from "#veryfront/extensions/parser/index.ts";
 import { COMPILATION_ERROR } from "#veryfront/errors";
+import { getErrorCollector } from "#veryfront/observability";
 import { getLoaderFromPath, isGeneratedContentOutput } from "../../esm/transform-utils.ts";
 import { isTypeScript } from "../context.ts";
 import type { TransformContext, TransformPlugin } from "../types.ts";
@@ -1781,6 +1782,7 @@ export async function stripServerOnlyExports(
     body = bodyOf(ast);
   } catch (error) {
     if (options.classifySourceParseErrors === true && isParserSourceDiagnostic(error)) {
+      getErrorCollector().addCompileError(errorMessage(error), filePath);
       throw createSourceParseCompilationError(filePath, error);
     }
     throw new ServerExportStripError(filePath, errorMessage(error));

--- a/src/transforms/pipeline/stages/compile.ts
+++ b/src/transforms/pipeline/stages/compile.ts
@@ -3,7 +3,11 @@ import { rendererLogger } from "#veryfront/utils";
 import { COMPILATION_ERROR } from "#veryfront/errors";
 import { getErrorCollector } from "#veryfront/observability";
 import { upgradeImportAssertions } from "../../esm/import-attributes.ts";
-import { ESBUILD_SUPPORTED_FEATURES, getLoaderFromPath } from "../../esm/transform-utils.ts";
+import {
+  ESBUILD_SUPPORTED_FEATURES,
+  getLoaderFromPath,
+  isGeneratedContentOutput,
+} from "../../esm/transform-utils.ts";
 import { type TransformContext, type TransformPlugin, TransformStage } from "../types.ts";
 
 const logger = rendererLogger.component("esm-transform");
@@ -15,17 +19,6 @@ const ReflectApply = Reflect.apply;
 const ReflectGetOwnPropertyDescriptor = Reflect.getOwnPropertyDescriptor;
 const SOURCE_MAP_SUFFIX =
   /(^|\r?\n)[\t ]*\/\/[#@][\t ]*sourceMappingURL=[^"'`\s]+[\t ]*(?:\r?\n)?$/;
-export const COMPILE_SOURCE_MAP_DIRECTIVE_METADATA = "compileSourceMapDirective";
-export const COMPILE_SOURCE_MAP_INPUT_METADATA = "compileSourceMapInput";
-
-function trailingSourceMapDirective(code: string): string | undefined {
-  const match = SOURCE_MAP_SUFFIX.exec(code);
-  return match?.[0].slice((match[1] ?? "").length).trimEnd();
-}
-
-function dropTrailingSourceMapDirective(code: string): string {
-  return code.replace(SOURCE_MAP_SUFFIX, "$1");
-}
 
 function appendBeforeSourceMap(code: string, addition: string): string {
   const match = SOURCE_MAP_SUFFIX.exec(code);
@@ -56,23 +49,6 @@ function readOwnDataProperty(value: unknown, key: PropertyKey): unknown {
 
 function isEsbuildSourceDiagnostic(error: unknown): boolean {
   return readOwnDataProperty(error, ESBUILD_SOURCE_DIAGNOSTIC) === true;
-}
-
-/**
- * `.mdx` and `.md` reach this stage as *generated* JSX: PARSE has already run
- * the MDX compiler over the tenant's source, so `ctx.code` here is framework
- * output. A diagnostic with a location points into that generated code, not
- * into anything the project wrote, so it must not claim tenant ownership — a
- * remark/rehype/recma plugin emitting broken JSX is a framework fault that has
- * to page someone.
- *
- * Nothing is lost by refusing to infer ownership for these two extensions:
- * genuine MDX and Markdown *source* errors are classified upstream at PARSE as
- * `mdx-compile-error` / `markdown-compile-error`, both of which the shared
- * tenant classifier already recognizes.
- */
-function isGeneratedContentOutput(filePath: string): boolean {
-  return filePath.endsWith(".mdx") || filePath.endsWith(".md");
 }
 
 export const compilePlugin: TransformPlugin = {
@@ -108,25 +84,8 @@ export const compilePlugin: TransformPlugin = {
         /\bconst\s+MDXLayout\b/.test(code) &&
         !/export\s+\{[^}]*MDXLayout/.test(code)
       ) {
-        // Keep esbuild's directive last. Browser server-hook stripping removes
-        // a stale compile map after rewriting, and a framework export appended
-        // after the directive would otherwise hide that suffix.
+        // Keep esbuild's directive last.
         code = appendBeforeSourceMap(code, "\nexport { MDXLayout };\n");
-      }
-
-      const sourceMapDirective = trailingSourceMapDirective(code);
-      if (ctx.target === "browser" && sourceMapDirective) {
-        // Keep the compiler map out of intermediate browser plugins. The
-        // server-export strip stage restores it only when the map-free compile
-        // output is unchanged and no hook is rewritten. This makes the real
-        // comment unambiguous even if a plugin copies its text into a string,
-        // appends code, or removes the hook itself.
-        ctx.metadata.set(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA, sourceMapDirective);
-        code = dropTrailingSourceMapDirective(code);
-        ctx.metadata.set(COMPILE_SOURCE_MAP_INPUT_METADATA, code);
-      } else {
-        ctx.metadata.delete(COMPILE_SOURCE_MAP_DIRECTIVE_METADATA);
-        ctx.metadata.delete(COMPILE_SOURCE_MAP_INPUT_METADATA);
       }
 
       return code;


### PR DESCRIPTION
## Why

Browser server hooks were stripped after compile. That let server-only bodies reach custom pre-compile plugins and development source maps, and forced the strip stage to repair compiler metadata after the fact.

PR #3855 identified the ordering problem, but its branch grew to thousands of lines and mixed the fix with broad predicate corpora. This is the bounded extraction.

## What changed

- Run `browser-server-exports-strip` after parse and before compile.
- Remove the compile-stage source-map metadata handoff. Development maps now originate from already-stripped input.
- Align Babel parsing with compiler-supported decorator placement before and after `export`.
- Preserve tenant `compilation-error` classification for authored syntax diagnostics while keeping generated MD/MDX and parser-internal failures framework owned.
- Parse authored TS, TSX, JS, JSX, and generated MDX safely at the earlier seam.
- Preserve JSX pragma bindings, runtime TypeScript references, escaped export names, comments, and named class-expression scope.
- Fail closed for hook re-exports and import-equals aliases that have no local hook body to empty.
- Preserve direct helper behavior for the code-splitter while letting the pipeline defer unrelated unused TS and TSX imports to esbuild. JS, JSX, and generated MDX retain the prior bare side-effect import behavior.
- Document the local-hook requirement and migration path.

## Proof

The regression test observes the real browser pipeline. Before the ordering change, a custom plugin at `PARSE + 0.75` sees `SERVER_SECRET`; after the change it does not, and the final artifact contains neither the binding nor its value.

Final-artifact tests also cover:

- compiler-supported decorator placement before and after export
- authored, generated-content, missing-parser, and parser-internal error ownership
- stripped development source-map contents
- TS and TSX unused-import erasure
- JS, JSX, and MDX side-effect import retention in production and development
- JSX intrinsic and member names
- named class-expression scope
- escaped hook export names
- import-equals fail-closed behavior
- direct code-splitter helper compatibility

The independently extracted #3955 commit composes with this branch without conflict. Its 16-step leak corpus and this branch's focused suites pass together.

## Validation

- focused parser, strip, compile, pipeline, and code-splitter suites: 212 steps passed
- focused `deno fmt --check`, `deno lint`, `deno check`, and `git diff --check`
- full repository pre-push gate passed: format, lint, typecheck, all unit tests, and cwd isolation suites
- independent review approved the amended decorator and error-classification boundaries

Supersedes #3855.
Refs veryfront/veryfront-issue-inbox#605.