### PR TITLE
feat(deploy): probe a protected environment with an exchanged access token

### DIFF
--- a/cli/commands/deploy/command-help.ts
+++ b/cli/commands/deploy/command-help.ts
@@ -51,6 +51,6 @@ export const deployHelp: CommandHelp = {
     "With --project, promotes only: the working directory is never pushed, so the selected project directory's push receipt must already name that project",
     "Creates a new release from the resolved branch",
     "Verifies the target environment points to the created deployment before succeeding",
-    "Warns when only the environment's access gate answered the readiness probe, so the app itself was never observed serving",
+    "Probes a protected environment with a short-lived environment access token exchanged for the API key, and warns when only the access gate answered, so the app itself was never observed serving",
   ],
 };

--- a/cli/commands/deploy/command-help.ts
+++ b/cli/commands/deploy/command-help.ts
@@ -51,6 +51,6 @@ export const deployHelp: CommandHelp = {
     "With --project, promotes only: the working directory is never pushed, so the selected project directory's push receipt must already name that project",
     "Creates a new release from the resolved branch",
     "Verifies the target environment points to the created deployment before succeeding",
-    "Probes a protected environment with a short-lived environment access token exchanged for the API key, and warns when only the access gate answered, so the app itself was never observed serving",
+    "Probes a protected environment with a short-lived environment access token obtained by exchanging the API key, and warns when only the access gate answered, so the app itself was never observed serving",
   ],
 };

--- a/cli/commands/deploy/command.integration.test.ts
+++ b/cli/commands/deploy/command.integration.test.ts
@@ -1096,6 +1096,9 @@ it("uses canonical production read-back in human and JSON modes", async () => {
         `POST /api/projects/${PROJECT_ID}/deployments`,
         `GET /api/projects/${PROJECT_ID}/deployments/${DEPLOYMENT_ID}`,
         `GET /api/projects/${PROJECT_ID}/environments`,
+        // The environment is protected and the credential is an API key, so
+        // deploy asks for a token bound to this environment before probing.
+        "POST /api/auth/environment-token",
         "GET /dashboard",
         "GET /dashboard",
       ]);

--- a/cli/shared/deployment/control-plane.test.ts
+++ b/cli/shared/deployment/control-plane.test.ts
@@ -56,10 +56,16 @@ describe("createHttpDeployControlPlane", () => {
     );
 
     assertEquals(
-      await controlPlane.createEnvironmentAccessToken(),
+      await controlPlane.createEnvironmentAccessToken({
+        projectId: "11111111-1111-4111-8111-111111111111",
+        environmentName: "production",
+      }),
       "eyJhbGciOiJSUzI1NiJ9.eyJ1c2VySWQiOiJ1XzEifQ.sig",
     );
-    assertEquals(calls, [{ path: "/auth/environment-token", body: undefined }]);
+    assertEquals(calls, [{
+      path: "/auth/environment-token",
+      body: { project_id: "11111111-1111-4111-8111-111111111111", environment_name: "production" },
+    }]);
   });
 
   it("treats only not-found release asset manifests as polling absence", async () => {

--- a/cli/shared/deployment/control-plane.test.ts
+++ b/cli/shared/deployment/control-plane.test.ts
@@ -64,7 +64,10 @@ describe("createHttpDeployControlPlane", () => {
     );
     assertEquals(calls, [{
       path: "/auth/environment-token",
-      body: { project_id: "11111111-1111-4111-8111-111111111111", environment_name: "production" },
+      body: {
+        project_reference: "11111111-1111-4111-8111-111111111111",
+        environment_name: "production",
+      },
     }]);
   });
 

--- a/cli/shared/deployment/control-plane.test.ts
+++ b/cli/shared/deployment/control-plane.test.ts
@@ -39,6 +39,29 @@ async function collectReleaseFiles(files: AsyncIterable<DeployReleaseFile>) {
 }
 
 describe("createHttpDeployControlPlane", () => {
+  it("exchanges the API key for an environment access token", async () => {
+    const calls: Array<{ path: string; body: unknown }> = [];
+    const controlPlane = createHttpDeployControlPlane(
+      config,
+      mockClientReturning({
+        post: (path, body) => {
+          calls.push({ path, body });
+          return Promise.resolve({
+            access_token: "eyJhbGciOiJSUzI1NiJ9.eyJ1c2VySWQiOiJ1XzEifQ.sig",
+            token_type: "Bearer",
+            expires_in: 300,
+          });
+        },
+      }),
+    );
+
+    assertEquals(
+      await controlPlane.createEnvironmentAccessToken(),
+      "eyJhbGciOiJSUzI1NiJ9.eyJ1c2VySWQiOiJ1XzEifQ.sig",
+    );
+    assertEquals(calls, [{ path: "/auth/environment-token", body: undefined }]);
+  });
+
   it("treats only not-found release asset manifests as polling absence", async () => {
     const notFound = { status: 404 };
     const forbidden = { status: 403 };

--- a/cli/shared/deployment/control-plane.ts
+++ b/cli/shared/deployment/control-plane.ts
@@ -345,7 +345,7 @@ export function createHttpDeployControlPlane(
 
     async createEnvironmentAccessToken(target) {
       const response = await client.post<WireEnvironmentAccessToken>("/auth/environment-token", {
-        project_id: target.projectId,
+        project_reference: target.projectId,
         environment_name: target.environmentName,
       });
       const token = response?.access_token;

--- a/cli/shared/deployment/control-plane.ts
+++ b/cli/shared/deployment/control-plane.ts
@@ -82,10 +82,16 @@ export interface DeployControlPlane {
   ): Promise<DeployDeployment>;
   getDeployment(reference: string, deploymentId: string): Promise<DeployDeployment>;
   /**
-   * Exchanges the stored API key for a short-lived user token that a protected
-   * environment's gate accepts. The API refuses that token as a session.
+   * Exchanges the stored API key for a short-lived token bound to one protected
+   * environment. The API authorizes the key for that target and refuses the
+   * token as a session.
    */
-  createEnvironmentAccessToken(): Promise<string>;
+  createEnvironmentAccessToken(target: EnvironmentAccessTarget): Promise<string>;
+}
+
+export interface EnvironmentAccessTarget {
+  projectId: string;
+  environmentName: string;
 }
 
 interface WireEnvironmentAccessToken {
@@ -337,8 +343,11 @@ export function createHttpDeployControlPlane(
       );
     },
 
-    async createEnvironmentAccessToken() {
-      const response = await client.post<WireEnvironmentAccessToken>("/auth/environment-token");
+    async createEnvironmentAccessToken(target) {
+      const response = await client.post<WireEnvironmentAccessToken>("/auth/environment-token", {
+        project_id: target.projectId,
+        environment_name: target.environmentName,
+      });
       const token = response?.access_token;
       if (typeof token !== "string" || token.length === 0) {
         throw new Error("The API did not return an environment access token");

--- a/cli/shared/deployment/control-plane.ts
+++ b/cli/shared/deployment/control-plane.ts
@@ -81,6 +81,15 @@ export interface DeployControlPlane {
     input: { releaseId: string; environmentId: string },
   ): Promise<DeployDeployment>;
   getDeployment(reference: string, deploymentId: string): Promise<DeployDeployment>;
+  /**
+   * Exchanges the stored API key for a short-lived user token that a protected
+   * environment's gate accepts. The API refuses that token as a session.
+   */
+  createEnvironmentAccessToken(): Promise<string>;
+}
+
+interface WireEnvironmentAccessToken {
+  access_token: string;
 }
 
 interface WireEnvironmentDeployment {
@@ -326,6 +335,15 @@ export function createHttpDeployControlPlane(
       return normalizeDeployment(
         await client.get<WireDeployment>(`/projects/${reference}/deployments/${deploymentId}`),
       );
+    },
+
+    async createEnvironmentAccessToken() {
+      const response = await client.post<WireEnvironmentAccessToken>("/auth/environment-token");
+      const token = response?.access_token;
+      if (typeof token !== "string" || token.length === 0) {
+        throw new Error("The API did not return an environment access token");
+      }
+      return token;
     },
   };
 }

--- a/cli/shared/deployment/deploy-project.test.ts
+++ b/cli/shared/deployment/deploy-project.test.ts
@@ -83,6 +83,8 @@ function helperControlPlane(overrides: Partial<DeployControlPlane>): DeployContr
     getReleaseAssetManifest: () => Promise.resolve(null),
     createDeployment: () => Promise.reject(new Error("unexpected createDeployment call")),
     getDeployment: () => Promise.reject(new Error("unexpected getDeployment call")),
+    createEnvironmentAccessToken: () =>
+      Promise.reject(new Error("unexpected createEnvironmentAccessToken call")),
     ...overrides,
   };
 }
@@ -116,6 +118,11 @@ async function executeApply(
       }, observer),
   );
 }
+
+// JWT-shaped, as the API mints it; the probe refuses anything else.
+const EXCHANGED_SESSION_TOKEN =
+  "eyJhbGciOiJSUzI1NiJ9.eyJ1c2VySWQiOiJ1XzEiLCJ0b2tlblVzZSI6ImVudmlyb25tZW50X2FjY2VzcyJ9.sig";
+const API_KEY_TOKEN = "vf_d157f0000000000000000000000000000000000";
 
 describe("DeployProject", () => {
   it("prefers the request projectSlug over configured project references", async () => {
@@ -623,6 +630,110 @@ describe("DeployProject", () => {
     });
   });
 
+  it("verifies a protected environment with an environment access token exchanged for the API key", async () => {
+    await withDeployEnv(async () => {
+      const { projectDir } = await createPushedProject();
+      const controlPlane = new InMemoryDeployControlPlane();
+      controlPlane.environmentProtected = true;
+      controlPlane.environmentAccessToken = EXCHANGED_SESSION_TOKEN;
+      const events: DeployEvent[] = [];
+      const cookies: Array<string | null> = [];
+      try {
+        const outcome = await withFetchStub(
+          (input, init) => {
+            const request = input instanceof Request ? input : new Request(input, init);
+            const cookie = request.headers.get("cookie");
+            cookies.push(cookie);
+            // The gate admits the minted token and the app answers behind it.
+            if (cookie === `authToken=${EXCHANGED_SESSION_TOKEN}`) return new Response("ready");
+            return new Response(null, {
+              status: 302,
+              headers: { location: "https://veryfront.com/sign-in" },
+            });
+          },
+          () =>
+            createDeployment(controlPlane).execute({
+              projectDir,
+              environment: "production",
+              mode: "apply",
+              source: { kind: "already-pushed" },
+            }, {
+              onEvent(event) {
+                events.push(event);
+              },
+            }),
+        );
+
+        assertEquals(outcome.kind, "deployed");
+        assertEquals(controlPlane.environmentAccessTokenRequests.length, 1);
+        assertEquals(cookies, [`authToken=${EXCHANGED_SESSION_TOKEN}`]);
+        assertEquals(
+          events.some((event) =>
+            event.kind === "warning" && event.code === "environment-url-unverified"
+          ),
+          false,
+        );
+        assertEquals(
+          outcome.kind === "deployed" ? outcome.result.urlVerification : undefined,
+          "served",
+        );
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    }, { VERYFRONT_API_TOKEN: API_KEY_TOKEN });
+  });
+
+  it("degrades to the gated outcome when the environment access token exchange fails", async () => {
+    await withDeployEnv(async () => {
+      const { projectDir } = await createPushedProject();
+      const controlPlane = new InMemoryDeployControlPlane();
+      controlPlane.environmentProtected = true;
+      controlPlane.environmentAccessToken = null;
+      const events: DeployEvent[] = [];
+      const cookies: Array<string | null> = [];
+      try {
+        const outcome = await withFetchStub(
+          (input, init) => {
+            const request = input instanceof Request ? input : new Request(input, init);
+            cookies.push(request.headers.get("cookie"));
+            return new Response(null, {
+              status: 302,
+              headers: { location: "https://veryfront.com/sign-in" },
+            });
+          },
+          () =>
+            createDeployment(controlPlane).execute({
+              projectDir,
+              environment: "production",
+              mode: "apply",
+              source: { kind: "already-pushed" },
+            }, {
+              onEvent(event) {
+                events.push(event);
+              },
+            }),
+        );
+
+        assertEquals(outcome.kind, "deployed");
+        // The raw API key must never reach the gate, exchange or no exchange.
+        assertEquals(cookies, [null]);
+        const warning = events.find((event) =>
+          event.kind === "warning" && event.code === "environment-url-unverified"
+        );
+        assertStringIncludes(
+          warning?.kind === "warning" ? warning.message : "",
+          "could not exchange the API key for an environment access token (API request failed: 404 Not Found)",
+        );
+        assertEquals(
+          outcome.kind === "deployed" ? outcome.result.urlVerification : undefined,
+          "gated",
+        );
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+  });
+
   it("records the environment URL as served when the probe sees the app answer", async () => {
     await withDeployEnv(async () => {
       const { projectDir } = await createPushedProject();
@@ -837,6 +948,46 @@ describe("environment URL readiness", () => {
     );
 
     assertEquals(cookie, `authToken=${sessionToken}`);
+  });
+
+  it("sends an exchanged session token instead of the API key it was exchanged for", async () => {
+    let cookie: string | null = null;
+
+    await withMockFetch(
+      (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        cookie = request.headers.get("cookie");
+        return Promise.resolve(new Response("ready"));
+      },
+      () =>
+        waitForEnvironmentReady({
+          ...hostedTarget,
+          protected: true,
+          apiToken: apiKeyToken,
+          sessionToken,
+        }),
+    );
+
+    assertEquals(cookie, `authToken=${sessionToken}`);
+  });
+
+  it("reports a refused exchanged token as gated instead of failing the committed deploy", async () => {
+    const readiness = await withMockFetch(
+      () => Promise.resolve(new Response("forbidden", { status: 403 })),
+      () =>
+        waitForEnvironmentReady({
+          ...hostedTarget,
+          protected: true,
+          apiToken: apiKeyToken,
+          sessionToken,
+        }, { pollIntervalMs: 1, timeoutMs: 1_000 }),
+    );
+
+    assertEquals(readiness, {
+      kind: "gated",
+      url: "https://my-project.production.veryfront.com/",
+      status: 403,
+    });
   });
 
   it("does not send an API key to the protected environment gate", async () => {

--- a/cli/shared/deployment/deploy-project.test.ts
+++ b/cli/shared/deployment/deploy-project.test.ts
@@ -665,7 +665,10 @@ describe("DeployProject", () => {
         );
 
         assertEquals(outcome.kind, "deployed");
-        assertEquals(controlPlane.environmentAccessTokenRequests.length, 1);
+        // The exchange names the target, so the API can bind the token to it.
+        assertEquals(controlPlane.environmentAccessTokenRequests, [
+          { projectId: PROJECT_ID, environmentName: "production" },
+        ]);
         assertEquals(cookies, [`authToken=${EXCHANGED_SESSION_TOKEN}`]);
         assertEquals(
           events.some((event) =>
@@ -720,10 +723,14 @@ describe("DeployProject", () => {
         const warning = events.find((event) =>
           event.kind === "warning" && event.code === "environment-url-unverified"
         );
+        const message = warning?.kind === "warning" ? warning.message : "";
         assertStringIncludes(
-          warning?.kind === "warning" ? warning.message : "",
-          "could not exchange the API key for an environment access token (API request failed: 404 Not Found)",
+          message,
+          "the Cloud API does not offer the environment access token exchange (HTTP 404)",
         );
+        // Server-provided detail never reaches the operator-facing warning.
+        assertEquals(message.includes("internal-host"), false);
+        assertEquals(message.includes("server detail"), false);
         assertEquals(
           outcome.kind === "deployed" ? outcome.result.urlVerification : undefined,
           "gated",
@@ -732,6 +739,50 @@ describe("DeployProject", () => {
         await Deno.remove(projectDir, { recursive: true });
       }
     });
+  });
+
+  it("names a refused exchange by its class, not by the server's words", async () => {
+    await withDeployEnv(async () => {
+      const { projectDir } = await createPushedProject();
+      const controlPlane = new InMemoryDeployControlPlane();
+      controlPlane.environmentProtected = true;
+      controlPlane.environmentAccessToken = null;
+      controlPlane.environmentAccessTokenFailureStatus = 403;
+      const events: DeployEvent[] = [];
+      try {
+        const outcome = await withFetchStub(
+          () =>
+            new Response(null, {
+              status: 302,
+              headers: { location: "https://veryfront.com/sign-in" },
+            }),
+          () =>
+            createDeployment(controlPlane).execute({
+              projectDir,
+              environment: "production",
+              mode: "apply",
+              source: { kind: "already-pushed" },
+            }, {
+              onEvent(event) {
+                events.push(event);
+              },
+            }),
+        );
+
+        assertEquals(outcome.kind, "deployed");
+        const warning = events.find((event) =>
+          event.kind === "warning" && event.code === "environment-url-unverified"
+        );
+        const message = warning?.kind === "warning" ? warning.message : "";
+        assertStringIncludes(
+          message,
+          "the Cloud API refused to issue an environment access token for this API key (HTTP 403)",
+        );
+        assertEquals(message.includes("internal-host"), false);
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    }, { VERYFRONT_API_TOKEN: API_KEY_TOKEN });
   });
 
   it("records the environment URL as served when the probe sees the app answer", async () => {
@@ -964,7 +1015,7 @@ describe("environment URL readiness", () => {
           ...hostedTarget,
           protected: true,
           apiToken: apiKeyToken,
-          sessionToken,
+          environmentAccessToken: sessionToken,
         }),
     );
 
@@ -979,7 +1030,7 @@ describe("environment URL readiness", () => {
           ...hostedTarget,
           protected: true,
           apiToken: apiKeyToken,
-          sessionToken,
+          environmentAccessToken: sessionToken,
         }, { pollIntervalMs: 1, timeoutMs: 1_000 }),
     );
 

--- a/cli/shared/deployment/deploy-project.ts
+++ b/cli/shared/deployment/deploy-project.ts
@@ -933,6 +933,8 @@ interface EnvironmentReadinessTarget {
   route?: string | null;
   protected: boolean;
   apiToken: string;
+  /** A user token exchanged for `apiToken`, sent to the gate in its place. */
+  sessionToken?: string;
 }
 
 interface EnvironmentReadinessProbe {
@@ -1005,7 +1007,11 @@ function buildEnvironmentReadinessProbes(
   // environment — the most this step can establish, and the deployment it
   // would otherwise fail is already committed and verified. Same allowance the
   // protected custom-domain probe below already makes.
-  const canAuthenticate = isSessionCredential(target.apiToken);
+  const canAuthenticate = isSessionCredential(target.sessionToken ?? target.apiToken);
+  // A gate that refuses an exchanged token says something about the key
+  // owner's access, not about the app. The deployment is already committed, so
+  // that reads as gated rather than failing the deploy.
+  const tolerateChallenge = !canAuthenticate || target.sessionToken !== undefined;
 
   const targetUrl = buildEnvironmentProbeUrl(target.url, route);
   if (target.protected && !isMatchingVeryfrontHostedUrl(new URL(targetUrl), target)) {
@@ -1027,15 +1033,42 @@ function buildEnvironmentReadinessProbes(
           route,
         ),
         authenticate: canAuthenticate,
-        acceptAuthenticationChallenge: !canAuthenticate,
+        acceptAuthenticationChallenge: tolerateChallenge,
       },
     ];
   }
   return [{
     url: target.protected ? secureEnvironmentProbeUrl(targetUrl) : targetUrl,
     authenticate: target.protected && canAuthenticate,
-    acceptAuthenticationChallenge: target.protected && !canAuthenticate,
+    acceptAuthenticationChallenge: target.protected && tolerateChallenge,
   }];
+}
+
+/** What the deploy could obtain to probe past a protected environment's gate. */
+type EnvironmentAccess =
+  | { kind: "session" }
+  | { kind: "exchanged"; token: string }
+  | { kind: "unavailable"; reason: string };
+
+/**
+ * An API key cannot pass the gate, but the API can exchange it for a user token
+ * that does. Failing to obtain one must not fail a committed deploy: the probe
+ * then establishes what it always could, that the gate answers.
+ */
+async function resolveEnvironmentAccess(
+  controlPlane: DeployControlPlane,
+  apiToken: string,
+): Promise<EnvironmentAccess> {
+  if (isSessionCredential(apiToken)) return { kind: "session" };
+  try {
+    const token = await controlPlane.createEnvironmentAccessToken();
+    if (!isSessionCredential(token)) {
+      return { kind: "unavailable", reason: "the API returned a token the gate cannot read" };
+    }
+    return { kind: "exchanged", token };
+  } catch (error) {
+    return { kind: "unavailable", reason: error instanceof Error ? error.message : String(error) };
+  }
 }
 
 function isVeryfrontSignInUrl(url: URL): boolean {
@@ -1117,7 +1150,7 @@ export async function waitForEnvironmentReady(
   for (const probe of probes) {
     const headers = new Headers({ "Cache-Control": "no-cache" });
     if (probe.authenticate) {
-      headers.set("Cookie", `authToken=${target.apiToken}`);
+      headers.set("Cookie", `authToken=${target.sessionToken ?? target.apiToken}`);
     }
     let lastResponse = "no response";
 
@@ -1221,9 +1254,19 @@ function getProbeCredentialRemedy(source: ResolvedConfig["apiTokenSource"]): str
 function getEnvironmentUrlWarning(
   readiness: EnvironmentReadiness,
   apiTokenSource: ResolvedConfig["apiTokenSource"],
+  access: EnvironmentAccess,
 ): string | null {
   if (readiness.kind !== "gated") return null;
-  return `Deployment committed, but ${readiness.url} was never observed serving this app: the access gate answered HTTP ${readiness.status} and this CLI has no session credential to probe past it. ${
+  const prefix = `Deployment committed, but ${readiness.url} was never observed serving this app:`;
+  if (access.kind === "exchanged") {
+    return `${prefix} the access gate refused the environment access token with HTTP ${readiness.status}. Check that the API key owner is a member of this project, or open the URL signed in, to confirm the app responds.`;
+  }
+  if (access.kind === "unavailable") {
+    return `${prefix} the access gate answered HTTP ${readiness.status} and this CLI could not exchange the API key for an environment access token (${access.reason}). ${
+      getProbeCredentialRemedy(apiTokenSource)
+    }`;
+  }
+  return `${prefix} the access gate answered HTTP ${readiness.status} and this CLI has no session credential to probe past it. ${
     getProbeCredentialRemedy(apiTokenSource)
   }`;
 }
@@ -1519,24 +1562,30 @@ export function createDeployProject(options: {
         buildEnvironmentUrl(verification.projectSlug, environment),
         readinessRoute,
       );
+      let access: EnvironmentAccess = { kind: "session" };
       const readiness = await step(
         observer,
         "wait-environment-url",
-        async () =>
-          waitForEnvironmentReady({
+        async () => {
+          if (environment.protected) {
+            access = await resolveEnvironmentAccess(controlPlane, config.apiToken);
+          }
+          return waitForEnvironmentReady({
             projectSlug: verification.projectSlug,
             environmentName: environment.name,
             url: environmentUrl,
             route: readinessRoute,
             protected: environment.protected,
             apiToken: config.apiToken,
+            ...(access.kind === "exchanged" ? { sessionToken: access.token } : {}),
           }, {
             pollIntervalMs: polling.environmentPollIntervalMs,
             timeoutMs: polling.environmentTimeoutMs,
-          }),
+          });
+        },
       );
 
-      const urlWarning = getEnvironmentUrlWarning(readiness, config.apiTokenSource);
+      const urlWarning = getEnvironmentUrlWarning(readiness, config.apiTokenSource, access);
       if (urlWarning) {
         await emit(observer, {
           kind: "warning",

--- a/cli/shared/deployment/deploy-project.ts
+++ b/cli/shared/deployment/deploy-project.ts
@@ -68,6 +68,7 @@ import {
   type DeployEnvironment,
   type DeploymentRoutingConvergence,
   type DeployRelease,
+  type EnvironmentAccessTarget,
 } from "./control-plane.ts";
 import type { DeployResult } from "./result.ts";
 
@@ -933,8 +934,11 @@ interface EnvironmentReadinessTarget {
   route?: string | null;
   protected: boolean;
   apiToken: string;
-  /** A user token exchanged for `apiToken`, sent to the gate in its place. */
-  sessionToken?: string;
+  /**
+   * A token bound to this environment, obtained by exchanging `apiToken`, and
+   * sent to the gate in its place. Not a session: the API refuses it as one.
+   */
+  environmentAccessToken?: string;
 }
 
 interface EnvironmentReadinessProbe {
@@ -1007,11 +1011,11 @@ function buildEnvironmentReadinessProbes(
   // environment — the most this step can establish, and the deployment it
   // would otherwise fail is already committed and verified. Same allowance the
   // protected custom-domain probe below already makes.
-  const canAuthenticate = isSessionCredential(target.sessionToken ?? target.apiToken);
+  const canAuthenticate = isSessionCredential(target.environmentAccessToken ?? target.apiToken);
   // A gate that refuses an exchanged token says something about the key
   // owner's access, not about the app. The deployment is already committed, so
   // that reads as gated rather than failing the deploy.
-  const tolerateChallenge = !canAuthenticate || target.sessionToken !== undefined;
+  const tolerateChallenge = !canAuthenticate || target.environmentAccessToken !== undefined;
 
   const targetUrl = buildEnvironmentProbeUrl(target.url, route);
   if (target.protected && !isMatchingVeryfrontHostedUrl(new URL(targetUrl), target)) {
@@ -1044,30 +1048,69 @@ function buildEnvironmentReadinessProbes(
   }];
 }
 
+/**
+ * Why no environment access token could be obtained. A bounded class, never the
+ * server's words: the warning that names it is operator-facing output.
+ */
+type EnvironmentAccessFailure =
+  | "unsupported"
+  | "refused"
+  | "rate_limited"
+  | "unreachable"
+  | "unusable";
+
 /** What the deploy could obtain to probe past a protected environment's gate. */
 type EnvironmentAccess =
   | { kind: "session" }
   | { kind: "exchanged"; token: string }
-  | { kind: "unavailable"; reason: string };
+  | { kind: "unavailable"; failure: EnvironmentAccessFailure; status?: number };
+
+function classifyEnvironmentAccessFailure(error: unknown): EnvironmentAccess {
+  const status = getErrorStatus(error);
+  if (status === 404 || status === 405 || status === 501) {
+    return { kind: "unavailable", failure: "unsupported", status };
+  }
+  if (status === 401 || status === 403) return { kind: "unavailable", failure: "refused", status };
+  if (status === 429) return { kind: "unavailable", failure: "rate_limited", status };
+  return { kind: "unavailable", failure: "unreachable", ...(status ? { status } : {}) };
+}
 
 /**
- * An API key cannot pass the gate, but the API can exchange it for a user token
- * that does. Failing to obtain one must not fail a committed deploy: the probe
- * then establishes what it always could, that the gate answers.
+ * An API key cannot pass the gate, but the API can exchange it for a token
+ * bound to this environment that does. Failing to obtain one must not fail a
+ * committed deploy: the probe then establishes what it always could, that the
+ * gate answers.
  */
 async function resolveEnvironmentAccess(
   controlPlane: DeployControlPlane,
   apiToken: string,
+  target: EnvironmentAccessTarget,
 ): Promise<EnvironmentAccess> {
   if (isSessionCredential(apiToken)) return { kind: "session" };
   try {
-    const token = await controlPlane.createEnvironmentAccessToken();
-    if (!isSessionCredential(token)) {
-      return { kind: "unavailable", reason: "the API returned a token the gate cannot read" };
-    }
+    const token = await controlPlane.createEnvironmentAccessToken(target);
+    if (!isSessionCredential(token)) return { kind: "unavailable", failure: "unusable" };
     return { kind: "exchanged", token };
   } catch (error) {
-    return { kind: "unavailable", reason: error instanceof Error ? error.message : String(error) };
+    return classifyEnvironmentAccessFailure(error);
+  }
+}
+
+function describeEnvironmentAccessFailure(
+  access: Extract<EnvironmentAccess, { kind: "unavailable" }>,
+): string {
+  const status = access.status === undefined ? "" : ` (HTTP ${access.status})`;
+  switch (access.failure) {
+    case "unsupported":
+      return `the Cloud API does not offer the environment access token exchange${status}`;
+    case "refused":
+      return `the Cloud API refused to issue an environment access token for this API key${status}`;
+    case "rate_limited":
+      return `the Cloud API rate limited the environment access token exchange${status}`;
+    case "unusable":
+      return "the Cloud API returned a token the gate cannot read";
+    case "unreachable":
+      return `the environment access token exchange did not complete${status}`;
   }
 }
 
@@ -1150,7 +1193,7 @@ export async function waitForEnvironmentReady(
   for (const probe of probes) {
     const headers = new Headers({ "Cache-Control": "no-cache" });
     if (probe.authenticate) {
-      headers.set("Cookie", `authToken=${target.sessionToken ?? target.apiToken}`);
+      headers.set("Cookie", `authToken=${target.environmentAccessToken ?? target.apiToken}`);
     }
     let lastResponse = "no response";
 
@@ -1262,9 +1305,12 @@ function getEnvironmentUrlWarning(
     return `${prefix} the access gate refused the environment access token with HTTP ${readiness.status}. Check that the API key owner is a member of this project, or open the URL signed in, to confirm the app responds.`;
   }
   if (access.kind === "unavailable") {
-    return `${prefix} the access gate answered HTTP ${readiness.status} and this CLI could not exchange the API key for an environment access token (${access.reason}). ${
-      getProbeCredentialRemedy(apiTokenSource)
-    }`;
+    const remedy = access.failure === "refused"
+      ? "Use an API key for this project whose owner can read it, or open the URL signed in, to confirm the app responds."
+      : getProbeCredentialRemedy(apiTokenSource);
+    return `${prefix} the access gate answered HTTP ${readiness.status} and ${
+      describeEnvironmentAccessFailure(access)
+    }. ${remedy}`;
   }
   return `${prefix} the access gate answered HTTP ${readiness.status} and this CLI has no session credential to probe past it. ${
     getProbeCredentialRemedy(apiTokenSource)
@@ -1568,7 +1614,10 @@ export function createDeployProject(options: {
         "wait-environment-url",
         async () => {
           if (environment.protected) {
-            access = await resolveEnvironmentAccess(controlPlane, config.apiToken);
+            access = await resolveEnvironmentAccess(controlPlane, config.apiToken, {
+              projectId: project!.id,
+              environmentName: environment.name,
+            });
           }
           return waitForEnvironmentReady({
             projectSlug: verification.projectSlug,
@@ -1577,7 +1626,7 @@ export function createDeployProject(options: {
             route: readinessRoute,
             protected: environment.protected,
             apiToken: config.apiToken,
-            ...(access.kind === "exchanged" ? { sessionToken: access.token } : {}),
+            ...(access.kind === "exchanged" ? { environmentAccessToken: access.token } : {}),
           }, {
             pollIntervalMs: polling.environmentPollIntervalMs,
             timeoutMs: polling.environmentTimeoutMs,

--- a/cli/test-utils/deploy-test-support.ts
+++ b/cli/test-utils/deploy-test-support.ts
@@ -208,6 +208,9 @@ export class InMemoryDeployControlPlane implements DeployControlPlane {
   environmentDomains: string[] = ["https://my-project.production.veryfront.com"];
   /** Whether the default environment sits behind the platform access gate. */
   environmentProtected = false;
+  /** What the API hands back for the stored API key; null means the exchange fails. */
+  environmentAccessToken: string | null = null;
+  readonly environmentAccessTokenRequests: number[] = [];
   releaseVersion: string | null = "2026.07.30-1";
   releaseProjectId = PROJECT_ID;
   releaseFiles: DeployReleaseFile[] = [
@@ -298,6 +301,14 @@ export class InMemoryDeployControlPlane implements DeployControlPlane {
     this.deployment = deployment;
     this.createdDeployments.push(deployment);
     return deployment;
+  }
+
+  async createEnvironmentAccessToken(): Promise<string> {
+    this.environmentAccessTokenRequests.push(Date.now());
+    if (this.environmentAccessToken === null) {
+      throw new Error("API request failed: 404 Not Found");
+    }
+    return this.environmentAccessToken;
   }
 
   async getDeployment(_reference: string, deploymentId: string): Promise<DeployDeployment> {

--- a/cli/test-utils/deploy-test-support.ts
+++ b/cli/test-utils/deploy-test-support.ts
@@ -210,7 +210,10 @@ export class InMemoryDeployControlPlane implements DeployControlPlane {
   environmentProtected = false;
   /** What the API hands back for the stored API key; null means the exchange fails. */
   environmentAccessToken: string | null = null;
-  readonly environmentAccessTokenRequests: number[] = [];
+  /** HTTP status the failed exchange reports, as the CLI API client attaches it. */
+  environmentAccessTokenFailureStatus = 404;
+  readonly environmentAccessTokenRequests: Array<{ projectId: string; environmentName: string }> =
+    [];
   releaseVersion: string | null = "2026.07.30-1";
   releaseProjectId = PROJECT_ID;
   releaseFiles: DeployReleaseFile[] = [
@@ -303,10 +306,19 @@ export class InMemoryDeployControlPlane implements DeployControlPlane {
     return deployment;
   }
 
-  async createEnvironmentAccessToken(): Promise<string> {
-    this.environmentAccessTokenRequests.push(Date.now());
+  async createEnvironmentAccessToken(
+    target: { projectId: string; environmentName: string },
+  ): Promise<string> {
+    this.environmentAccessTokenRequests.push({ ...target });
     if (this.environmentAccessToken === null) {
-      throw new Error("API request failed: 404 Not Found");
+      // Shaped like the CLI API client's error: a status, and a message that
+      // carries whatever the server said, which must never reach a warning.
+      throw Object.assign(
+        new Error(
+          `API request failed: ${this.environmentAccessTokenFailureStatus} server detail: internal-host-10.0.0.7`,
+        ),
+        { status: this.environmentAccessTokenFailureStatus },
+      );
     }
     return this.environmentAccessToken;
   }

--- a/docs/architecture/29-environment-access-gate.md
+++ b/docs/architecture/29-environment-access-gate.md
@@ -1,0 +1,97 @@
+# Environment access gate
+
+A protected Veryfront Cloud environment is fronted by the proxy, which admits a
+request only when it carries a credential the gate can verify. This page
+documents the gate's decision, the environment access token that lets an
+API-key client through it, and which component owns each part.
+
+## Responsibility
+
+- The proxy decides whether a request reaches a protected environment. It
+  owns the decision in
+  [src/proxy/proxy-access-control.ts](../../src/proxy/proxy-access-control.ts),
+  called from [src/proxy/handler.ts](../../src/proxy/handler.ts) once the
+  project and environment are resolved.
+- The Cloud API owns credential issuance. A browser session is a user JWT in
+  the `authToken` cookie. An environment access token is a purpose-bound JWT
+  the API mints from an API key for one environment
+  (`POST /auth/environment-token`).
+- The CLI deploy flow obtains an environment access token only to probe the
+  environment it just deployed, in
+  [cli/shared/deployment/deploy-project.ts](../../cli/shared/deployment/deploy-project.ts)
+  through the control-plane seam in
+  [cli/shared/deployment/control-plane.ts](../../cli/shared/deployment/control-plane.ts).
+
+## Flow
+
+```mermaid
+sequenceDiagram
+  participant CLI as veryfront deploy
+  participant API as Cloud API
+  participant Proxy as Proxy gate
+  CLI->>API: POST /auth/environment-token (API key, project_reference, environment_name)
+  API->>API: principal: owner for an all-project key, token for a project-scoped key
+  API->>API: require effective read scope, check project access, resolve environment
+  API-->>CLI: token bound to project and environment (5 min)
+  CLI->>Proxy: GET route, Cookie: authToken=token
+  Proxy->>Proxy: verify against API JWKS, read principal and bindings
+  Proxy->>Proxy: match projectId and environmentId, check membership
+  Proxy-->>CLI: app response, or 403 when the binding does not match
+```
+
+The gate reads a verified payload into a principal with `toProxyPrincipal`:
+
+| Token                    | Accepted when                                                                                                               |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| User session             | Carries `userId` and no `tokenUse`; the user is a project member.                                                           |
+| Environment access token | Carries `aud: environment-gate`, `tokenUse: environment_access`, `projectId`, and `environmentId`.                          |
+| Anything in between      | Refused. A token that names the use without the audience, or either without both bindings, is not one this gate issued for. |
+
+For an environment access token the gate compares `projectId` and
+`environmentId` to the environment it resolved for the request, fails closed
+when the proxy cannot identify the environment, and still checks membership on
+the owner. A signature the API's JWKS does not verify, or a missing credential,
+redirects to sign-in.
+
+## Boundaries
+
+- The proxy never exchanges or mints. It only verifies and compares.
+- The API never sends an environment access token anywhere; it returns it to
+  the caller that presented the key. The API refuses that token as a session on
+  every one of its own authentication paths, including magic-link
+  verification, so an API key cannot be traded up to a user session.
+- The token carries no email and no API scopes. The key's effective scopes are
+  checked at the exchange, where read access is required; a key scoped to one
+  project is refused for any other before access is checked.
+- The deploy probe sends either a session credential or an exchanged
+  environment access token, never the raw API key. A failed or refused
+  exchange degrades the probe to the `gated` outcome and names a bounded
+  failure class, not the server's words.
+
+## Deployment dependency
+
+The Cloud API must be deployed before a CLI release that performs the exchange:
+an older API answers the exchange with `404`, which the CLI reports as
+`unsupported` and degrades to `gated`. The gate change is backward compatible
+with existing session cookies, so the proxy can ship in either order relative
+to the CLI.
+
+## Change checks
+
+- `deno task test:file src/proxy/proxy-access-control.test.ts` for the gate
+  decision and token bindings.
+- `deno task test:file cli/shared/deployment/deploy-project.test.ts` and
+  `cli/shared/deployment/control-plane.test.ts` for the probe and the exchange
+  seam.
+- When the token's claims change, update the API minter, `toProxyPrincipal`,
+  and this page together.
+
+## Related guides
+
+- [Cloud environment access](../guides/cloud-environment-access.md)
+- [Deployment behavior](../guides/deploying.md)
+
+## Related reference
+
+- [Control-plane channels](./11-control-plane-channels.md) for the other signed
+  path through the proxy, which is not reachable with an API key.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -44,6 +44,7 @@ one runtime concern. Architecture pages do not duplicate the user guides in
 | [22-chat-collection-composition-contract.md](./22-chat-collection-composition-contract.md)   | Chat collection composition and conformance    |
 | [24-context-compaction-current-state.md](./24-context-compaction-current-state.md)           | Current Code and API compaction review         |
 | [27-agent-message-stream-dataflow.md](./27-agent-message-stream-dataflow.md)                 | Agent prompt, stream, tool, and replay flow    |
+| [29-environment-access-gate.md](./29-environment-access-gate.md)                             | Protected environment gate and access tokens   |
 
 ## Runtime boundaries
 

--- a/docs/getting-started/deploy-project.md
+++ b/docs/getting-started/deploy-project.md
@@ -55,9 +55,11 @@ deployed site.
 
 Veryfront Cloud environments are protected by default. An unauthenticated
 request is redirected to sign-in, and `VERYFRONT_API_TOKEN` does not open a
-protected environment. To make the environment public, open **Environments** in
-Veryfront Studio, select the environment, enable **Public Environment**, and
-confirm **Make Public**.
+protected environment on its own. Deploy exchanges it for a short-lived
+environment access token, probes the environment with that, and reports
+`urlVerification: "served"` in `--json` output once the app answers. To make the
+environment public, open **Environments** in Veryfront Studio, select the
+environment, enable **Public Environment**, and confirm **Make Public**.
 
 See [Cloud environment access](../guides/cloud-environment-access.md) for
 authenticated requests and status codes. See

--- a/docs/guides/cloud-environment-access.md
+++ b/docs/guides/cloud-environment-access.md
@@ -36,9 +36,21 @@ A non-browser client can still authenticate by sending the `authToken` cookie
 with a project member's session token. Store that token as a secret and account
 for its expiration.
 
-`VERYFRONT_API_TOKEN` does not open a protected environment. It authenticates
-the CLI against the Cloud API, not requests to the deployed app. A signed-in
-user who is not a member of the project gets a `403`.
+`VERYFRONT_API_TOKEN` does not open a protected environment on its own. It
+authenticates the CLI against the Cloud API, not requests to the deployed app.
+Exchange it for an environment access token instead: a user token for the key
+owner that the gate accepts for five minutes and that the Cloud API refuses as a
+session. `veryfront deploy` performs this exchange to probe the environment it
+deployed. A CI smoke test can do the same:
+
+```bash
+TOKEN=$(curl -sS -X POST https://api.veryfront.com/auth/environment-token \
+  -H "Authorization: Bearer $VERYFRONT_API_TOKEN" | jq -r .access_token)
+curl -sSf -o /dev/null --cookie "authToken=$TOKEN" <environment-url>/<route>
+```
+
+A signed-in user who is not a member of the project gets a `403`, and so does
+an environment access token exchanged for that user's API key.
 
 ## Make an environment public
 

--- a/docs/guides/cloud-environment-access.md
+++ b/docs/guides/cloud-environment-access.md
@@ -48,7 +48,7 @@ set -euo pipefail
 TOKEN=$(curl -fsS -X POST https://api.veryfront.com/auth/environment-token \
   -H "Authorization: Bearer $VERYFRONT_API_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"project_id":"<PROJECT_ID>","environment_name":"production"}' |
+  -d '{"project_reference":"<PROJECT_ID>","environment_name":"production"}' |
   jq -er '.access_token | strings | select(length > 0)')
 STATUS=$(curl -sS -o /dev/null -w '%{http_code}' --cookie "authToken=$TOKEN" \
   <environment-url>/<route>)

--- a/docs/guides/cloud-environment-access.md
+++ b/docs/guides/cloud-environment-access.md
@@ -85,4 +85,6 @@ curl -s -o /dev/null -w '%{http_code} %{redirect_url}\n' \
 Validate the status that route normally returns. Do not require a `200` from
 the environment root when the project has no static page at `/`.
 
-See [Deployment behavior](./deploying.md) for readiness and URL semantics.
+See [Deployment behavior](./deploying.md) for readiness and URL semantics, and
+[Environment access gate](../architecture/29-environment-access-gate.md) for how
+the gate decides.

--- a/docs/guides/cloud-environment-access.md
+++ b/docs/guides/cloud-environment-access.md
@@ -44,13 +44,17 @@ session. `veryfront deploy` performs this exchange to probe the environment it
 deployed. A CI smoke test can do the same:
 
 ```bash
-TOKEN=$(curl -sS -X POST https://api.veryfront.com/auth/environment-token \
-  -H "Authorization: Bearer $VERYFRONT_API_TOKEN" | jq -r .access_token)
-curl -sSf -o /dev/null --cookie "authToken=$TOKEN" <environment-url>/<route>
+TOKEN=$(curl -fsS -X POST https://api.veryfront.com/auth/environment-token \
+  -H "Authorization: Bearer $VERYFRONT_API_TOKEN" |
+  jq -er '.access_token | strings | select(length > 0)')
+curl -sS -o /dev/null -w '%{http_code}\n' --cookie "authToken=$TOKEN" \
+  <environment-url>/<route>
 ```
 
-A signed-in user who is not a member of the project gets a `403`, and so does
-an environment access token exchanged for that user's API key.
+Require the status the route normally returns. A `302` means the gate refused
+the token, not that the app answered, so do not follow redirects. A signed-in
+user who is not a member of the project gets a `403`, and so does an
+environment access token obtained by exchanging that user's API key.
 
 ## Make an environment public
 

--- a/docs/guides/cloud-environment-access.md
+++ b/docs/guides/cloud-environment-access.md
@@ -57,7 +57,9 @@ STATUS=$(curl -sS -o /dev/null -w '%{http_code}' --cookie "authToken=$TOKEN" \
 
 Compare against the status the route normally returns. The probe does not
 follow redirects: a `302` means the gate refused the token, not that the app
-answered, and the comparison turns it into a failed job. The token is bound to
+answered, and the comparison turns it into a failed job. The token lives five
+minutes and an expired token is refused the same way, so mint it immediately
+before the probe rather than once for a long suite. The token is bound to
 the project and environment named in the exchange. A key scoped to another
 project, or a key whose owner is not a member of the project gets a `403` at
 the exchange.

--- a/docs/guides/cloud-environment-access.md
+++ b/docs/guides/cloud-environment-access.md
@@ -44,17 +44,23 @@ session. `veryfront deploy` performs this exchange to probe the environment it
 deployed. A CI smoke test can do the same:
 
 ```bash
+set -euo pipefail
 TOKEN=$(curl -fsS -X POST https://api.veryfront.com/auth/environment-token \
-  -H "Authorization: Bearer $VERYFRONT_API_TOKEN" |
+  -H "Authorization: Bearer $VERYFRONT_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"project_id":"<PROJECT_ID>","environment_name":"production"}' |
   jq -er '.access_token | strings | select(length > 0)')
-curl -sS -o /dev/null -w '%{http_code}\n' --cookie "authToken=$TOKEN" \
-  <environment-url>/<route>
+STATUS=$(curl -sS -o /dev/null -w '%{http_code}' --cookie "authToken=$TOKEN" \
+  <environment-url>/<route>)
+[ "$STATUS" = "200" ] || { echo "expected 200, got $STATUS" >&2; exit 1; }
 ```
 
-Require the status the route normally returns. A `302` means the gate refused
-the token, not that the app answered, so do not follow redirects. A signed-in
-user who is not a member of the project gets a `403`, and so does an
-environment access token obtained by exchanging that user's API key.
+Compare against the status the route normally returns. The probe does not
+follow redirects: a `302` means the gate refused the token, not that the app
+answered, and the comparison turns it into a failed job. The token is bound to
+the project and environment named in the exchange. A key scoped to another
+project, or a key whose owner is not a member of the project gets a `403` at
+the exchange.
 
 ## Make an environment public
 

--- a/docs/guides/cloud-environment-access.md
+++ b/docs/guides/cloud-environment-access.md
@@ -38,9 +38,9 @@ for its expiration.
 
 `VERYFRONT_API_TOKEN` does not open a protected environment on its own. It
 authenticates the CLI against the Cloud API, not requests to the deployed app.
-Exchange it for an environment access token instead: a user token for the key
-owner that the gate accepts for five minutes and that the Cloud API refuses as a
-session. `veryfront deploy` performs this exchange to probe the environment it
+Exchange it for an environment access token for the key owner instead. The gate
+accepts it for five minutes, and the Cloud API refuses it as a session.
+`veryfront deploy` performs this exchange to probe the environment it
 deployed. A CI smoke test can do the same:
 
 ```bash

--- a/docs/guides/deploy-from-ci.md
+++ b/docs/guides/deploy-from-ci.md
@@ -272,7 +272,9 @@ configured environment.
 ## Verify it worked
 
 1. Confirm the staging CI job reports successful Push and Deploy steps.
-2. Confirm the final deployment evidence names the merged commit.
+2. Confirm the final deployment evidence names the merged commit and reports
+   `urlVerification: "served"`, which means Deploy observed the protected
+   environment answer behind its access gate.
 3. Open the staging environment with `veryfront open --env staging`.
 4. Check the changed route or API behavior.
 5. Record the Admin or Owner staging approval before production promotion.

--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -164,8 +164,8 @@ development and preview. Validate the status or behavior that the selected
 route normally returns.
 
 For a protected environment, Deploy already probes the URL with an environment
-access token exchanged for your API key and prints a warning when only the
-access gate answered. Repeat the check in a browser signed in as a project
+access token obtained by exchanging your API key and prints a warning when only
+the access gate answered. Repeat the check in a browser signed in as a project
 member, or exchange the token yourself as described in
 [Cloud environment access](./cloud-environment-access.md). For a public agent
 route:

--- a/docs/guides/deploying.md
+++ b/docs/guides/deploying.md
@@ -163,8 +163,12 @@ Use the environment URL that Deploy printed and repeat the check from
 development and preview. Validate the status or behavior that the selected
 route normally returns.
 
-For a protected environment, verify in a browser signed in as a project member.
-For a public agent route:
+For a protected environment, Deploy already probes the URL with an environment
+access token exchanged for your API key and prints a warning when only the
+access gate answered. Repeat the check in a browser signed in as a project
+member, or exchange the token yourself as described in
+[Cloud environment access](./cloud-environment-access.md). For a public agent
+route:
 
 ```bash
 curl -sSf -N -X POST <environment-url>/api/ag-ui \

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -619,6 +619,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     const protectionError = await checkProtectedProxyAccess({
       url,
       matchingEnv,
+      projectId: lookupResult.id,
       userToken,
       users: lookupResult.users,
       apiBaseUrl: config.apiBaseUrl,
@@ -744,6 +745,7 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
         const protectionError = await checkProtectedProxyAccess({
           url,
           matchingEnv: accessEnv,
+          projectId: routingResult.id,
           userToken,
           users: accessResult.users,
           apiBaseUrl: config.apiBaseUrl,

--- a/src/proxy/proxy-access-control.test.ts
+++ b/src/proxy/proxy-access-control.test.ts
@@ -5,6 +5,7 @@ import {
   checkProtectedProxyAccess,
   extractUserIdFromToken,
   isProjectMember,
+  toProxyPrincipal,
 } from "./proxy-access-control.ts";
 import { register, reset } from "../extensions/contracts.ts";
 import type { AuthProvider } from "../extensions/auth/index.ts";
@@ -162,7 +163,7 @@ describe("proxy/proxy-access-control", () => {
         users: undefined,
         apiBaseUrl: "https://api.example.com",
         isSignedInternalControlPlaneRequest: false,
-        extractUserIdFromToken: extractUserId,
+        extractPrincipal: extractUserId,
       }),
       null,
     );
@@ -174,7 +175,7 @@ describe("proxy/proxy-access-control", () => {
         users: undefined,
         apiBaseUrl: "https://api.example.com",
         isSignedInternalControlPlaneRequest: true,
-        extractUserIdFromToken: extractUserId,
+        extractPrincipal: extractUserId,
       }),
       null,
     );
@@ -194,7 +195,7 @@ describe("proxy/proxy-access-control", () => {
         users: [{ id: "user-1" }],
         apiBaseUrl: "https://api.example.com",
         isSignedInternalControlPlaneRequest: false,
-        extractUserIdFromToken: () => Promise.resolve("user-1"),
+        extractPrincipal: () => Promise.resolve({ userId: "user-1" }),
       }),
       {
         status: 302,
@@ -211,7 +212,7 @@ describe("proxy/proxy-access-control", () => {
         users: [{ id: "user-1" }],
         apiBaseUrl: "https://api.example.com",
         isSignedInternalControlPlaneRequest: false,
-        extractUserIdFromToken: () => Promise.resolve(undefined),
+        extractPrincipal: () => Promise.resolve(undefined),
       }),
       {
         status: 302,
@@ -228,7 +229,7 @@ describe("proxy/proxy-access-control", () => {
         users: [{ id: "user-1" }],
         apiBaseUrl: "https://api.example.com",
         isSignedInternalControlPlaneRequest: false,
-        extractUserIdFromToken: () => Promise.resolve("user-2"),
+        extractPrincipal: () => Promise.resolve({ userId: "user-2" }),
       }),
       { status: 403, message: "Access denied" },
     );
@@ -241,9 +242,101 @@ describe("proxy/proxy-access-control", () => {
         users: [{ id: "user-1" }],
         apiBaseUrl: "https://api.example.com",
         isSignedInternalControlPlaneRequest: false,
-        extractUserIdFromToken: () => Promise.resolve("user-1"),
+        extractPrincipal: () => Promise.resolve({ userId: "user-1" }),
       }),
       null,
+    );
+  });
+});
+
+describe("environment access tokens at the gate", () => {
+  const req = new Request("https://app.preview.veryfront.com/dashboard");
+  const url = new URL(req.url);
+  const matchingEnv = { id: "env-1", name: "preview", protected: true };
+  const bound = {
+    userId: "user-1",
+    environmentAccess: { projectId: "project-1", environmentId: "env-1" },
+  };
+
+  it("maps a verified payload to a principal, requiring audience and use for a bound token", () => {
+    assertEquals(toProxyPrincipal({ userId: "user-1" }), { userId: "user-1" });
+    assertEquals(
+      toProxyPrincipal({
+        userId: "user-1",
+        aud: "environment-gate",
+        tokenUse: "environment_access",
+        projectId: "project-1",
+        environmentId: "env-1",
+      }),
+      bound,
+    );
+    // A token that names the use but not the audience, or the other way round,
+    // or that is bound to nothing, is not a credential this gate issued for.
+    assertEquals(
+      toProxyPrincipal({
+        userId: "user-1",
+        tokenUse: "environment_access",
+        projectId: "project-1",
+      }),
+      undefined,
+    );
+    assertEquals(
+      toProxyPrincipal({ userId: "user-1", aud: "environment-gate", projectId: "project-1" }),
+      undefined,
+    );
+    assertEquals(
+      toProxyPrincipal({
+        userId: "user-1",
+        aud: "environment-gate",
+        tokenUse: "environment_access",
+      }),
+      undefined,
+    );
+    assertEquals(
+      toProxyPrincipal({ aud: "environment-gate", tokenUse: "environment_access" }),
+      undefined,
+    );
+  });
+
+  it("admits a bound token only for the project and environment it names", async () => {
+    const base = {
+      url,
+      matchingEnv,
+      projectId: "project-1",
+      userToken: "environment-token",
+      users: [{ id: "user-1" }],
+      apiBaseUrl: "https://api.example.com",
+      isSignedInternalControlPlaneRequest: false,
+    };
+
+    assertEquals(
+      await checkProtectedProxyAccess({ ...base, extractPrincipal: () => Promise.resolve(bound) }),
+      null,
+    );
+    assertEquals(
+      await checkProtectedProxyAccess({
+        ...base,
+        projectId: "project-2",
+        extractPrincipal: () => Promise.resolve(bound),
+      }),
+      { status: 403, message: "Access denied" },
+    );
+    assertEquals(
+      await checkProtectedProxyAccess({
+        ...base,
+        matchingEnv: { id: "env-2", name: "preview", protected: true },
+        extractPrincipal: () => Promise.resolve(bound),
+      }),
+      { status: 403, message: "Access denied" },
+    );
+    // Membership is still the owner's: a bound token for a non-member is refused.
+    assertEquals(
+      await checkProtectedProxyAccess({
+        ...base,
+        users: [{ id: "user-2" }],
+        extractPrincipal: () => Promise.resolve(bound),
+      }),
+      { status: 403, message: "Access denied" },
     );
   });
 });

--- a/src/proxy/proxy-access-control.test.ts
+++ b/src/proxy/proxy-access-control.test.ts
@@ -339,4 +339,30 @@ describe("environment access tokens at the gate", () => {
       { status: 403, message: "Access denied" },
     );
   });
+  it("requires both bindings on the token and a known environment at the gate", async () => {
+    // A token naming only the project is not a credential this gate issued.
+    assertEquals(
+      toProxyPrincipal({
+        userId: "user-1",
+        aud: "environment-gate",
+        tokenUse: "environment_access",
+        projectId: "project-1",
+      }),
+      undefined,
+    );
+    // An environment the proxy cannot identify fails closed.
+    assertEquals(
+      await checkProtectedProxyAccess({
+        url,
+        matchingEnv: { name: "preview", protected: true },
+        projectId: "project-1",
+        userToken: "environment-token",
+        users: [{ id: "user-1" }],
+        apiBaseUrl: "https://api.example.com",
+        isSignedInternalControlPlaneRequest: false,
+        extractPrincipal: () => Promise.resolve(bound),
+      }),
+      { status: 403, message: "Access denied" },
+    );
+  });
 });

--- a/src/proxy/proxy-access-control.ts
+++ b/src/proxy/proxy-access-control.ts
@@ -12,8 +12,53 @@ export interface ProxyAccessControlLogger {
 }
 
 export interface ProtectedProxyEnvironment {
+  id?: string;
   name: string;
   protected?: boolean;
+}
+
+/** Who a verified token speaks for at the gate, and what it is bound to. */
+export interface ProxyPrincipal {
+  userId: string;
+  /** Present for an environment access token: the one target it may open. */
+  environmentAccess?: { projectId: string; environmentId?: string };
+}
+
+const ENVIRONMENT_ACCESS_TOKEN_USE = "environment_access";
+const ENVIRONMENT_GATE_AUDIENCE = "environment-gate";
+
+function hasGateAudience(payload: unknown): boolean {
+  if (typeof payload !== "object" || payload === null) return false;
+  if (!Object.hasOwn(payload, "aud")) return false;
+  const aud = (payload as Record<string, unknown>).aud;
+  if (typeof aud === "string") return aud === ENVIRONMENT_GATE_AUDIENCE;
+  return Array.isArray(aud) && aud.includes(ENVIRONMENT_GATE_AUDIENCE);
+}
+
+/**
+ * Reads the principal off a verified payload.
+ *
+ * A plain user token speaks for its user. An environment access token has to
+ * say so twice, by audience and by use, and name the project it is bound to;
+ * anything that claims only part of that is not a credential this gate issued
+ * for and is refused outright.
+ */
+export function toProxyPrincipal(payload: unknown): ProxyPrincipal | undefined {
+  const userId = readOwnString(payload, "userId", 512);
+  if (!userId) return undefined;
+
+  const tokenUse = readOwnString(payload, "tokenUse", 64);
+  const gateAudience = hasGateAudience(payload);
+  if (tokenUse === undefined && !gateAudience) return { userId };
+  if (tokenUse !== ENVIRONMENT_ACCESS_TOKEN_USE || !gateAudience) return undefined;
+
+  const projectId = readOwnString(payload, "projectId", 512);
+  if (!projectId) return undefined;
+  const environmentId = readOwnString(payload, "environmentId", 512);
+  return {
+    userId,
+    environmentAccess: { projectId, ...(environmentId ? { environmentId } : {}) },
+  };
 }
 
 export interface ProtectedProxyProjectUser {
@@ -106,6 +151,14 @@ export async function extractUserIdFromToken(
   apiBaseUrl: string,
   log?: ProxyAccessControlLogger,
 ): Promise<string | undefined> {
+  return (await extractProxyPrincipal(token, apiBaseUrl, log))?.userId;
+}
+
+export async function extractProxyPrincipal(
+  token: string,
+  apiBaseUrl: string,
+  log?: ProxyAccessControlLogger,
+): Promise<ProxyPrincipal | undefined> {
   const auth = getAuthProvider();
 
   let header: unknown;
@@ -132,7 +185,7 @@ export async function extractUserIdFromToken(
       const payload = await auth.verifyWithJwks(token, jwksUrl, {
         algorithms: ["RS256"],
       });
-      return readOwnString(payload, "userId", 512);
+      return toProxyPrincipal(payload);
     } catch (error) {
       log?.debug("RS256 JWT verification failed", {
         error: safeErrorMessage(error),
@@ -158,7 +211,7 @@ export async function extractUserIdFromToken(
     // passed to the extension factory; the explicit env check above is kept
     // so callers can warn once before attempting verification.
     const payload = await auth.verify(token, { algorithms: ["HS256"] });
-    return readOwnString(payload, "userId", 512);
+    return toProxyPrincipal(payload);
   } catch (error) {
     log?.debug("JWT verification failed", {
       error: safeErrorMessage(error),
@@ -229,17 +282,19 @@ export function isProjectMember(
 export async function checkProtectedProxyAccess(input: {
   url: URL;
   matchingEnv: ProtectedProxyEnvironment | undefined;
+  /** The project the matching environment belongs to, for bound tokens. */
+  projectId?: string;
   userToken: string | undefined;
   users: ProtectedProxyProjectUser[] | undefined;
   apiBaseUrl: string;
   logger?: ProxyAccessControlLogger;
   logContext?: Record<string, unknown>;
   isSignedInternalControlPlaneRequest: boolean;
-  extractUserIdFromToken?: (
+  extractPrincipal?: (
     token: string,
     apiBaseUrl: string,
     log?: ProxyAccessControlLogger,
-  ) => Promise<string | undefined>;
+  ) => Promise<ProxyPrincipal | undefined>;
 }): Promise<ProxyAccessError | null> {
   const {
     apiBaseUrl,
@@ -275,13 +330,13 @@ export async function checkProtectedProxyAccess(input: {
     return { status: 302, message: "Authentication required", redirectUrl };
   }
 
-  const resolveUserId = input.extractUserIdFromToken ?? extractUserIdFromToken;
-  const userId = await resolveUserId(
+  const resolvePrincipal = input.extractPrincipal ?? extractProxyPrincipal;
+  const principal = await resolvePrincipal(
     userToken,
     apiBaseUrl,
     logger,
   );
-  if (!userId) {
+  if (!principal) {
     const redirectUrl = buildProxyAuthRedirectUrl(url);
     logger?.info("Could not extract userId from token", {
       ...logContext,
@@ -289,6 +344,22 @@ export async function checkProtectedProxyAccess(input: {
       redirectUrl,
     });
     return { status: 302, message: "Authentication required", redirectUrl };
+  }
+  const { userId, environmentAccess } = principal;
+  if (environmentAccess) {
+    // A bound token opens the one environment it names, nothing else.
+    const boundElsewhere = input.projectId === undefined ||
+      environmentAccess.projectId !== input.projectId ||
+      (environmentAccess.environmentId !== undefined &&
+        environmentAccess.environmentId !== matchingEnv.id);
+    if (boundElsewhere) {
+      logger?.info("Environment access token is bound to another target", {
+        ...logContext,
+        environmentName: matchingEnv.name,
+        userId,
+      });
+      return { status: 403, message: "Access denied" };
+    }
   }
   if (!isProjectMember(users, userId)) {
     logger?.info("User is not a member of the project", {

--- a/src/proxy/proxy-access-control.ts
+++ b/src/proxy/proxy-access-control.ts
@@ -21,7 +21,7 @@ export interface ProtectedProxyEnvironment {
 export interface ProxyPrincipal {
   userId: string;
   /** Present for an environment access token: the one target it may open. */
-  environmentAccess?: { projectId: string; environmentId?: string };
+  environmentAccess?: { projectId: string; environmentId: string };
 }
 
 const ENVIRONMENT_ACCESS_TOKEN_USE = "environment_access";
@@ -39,9 +39,9 @@ function hasGateAudience(payload: unknown): boolean {
  * Reads the principal off a verified payload.
  *
  * A plain user token speaks for its user. An environment access token has to
- * say so twice, by audience and by use, and name the project it is bound to;
- * anything that claims only part of that is not a credential this gate issued
- * for and is refused outright.
+ * say so twice, by audience and by use, and name both the project and the
+ * environment it is bound to; anything that claims only part of that is not a
+ * credential this gate issued for and is refused outright.
  */
 export function toProxyPrincipal(payload: unknown): ProxyPrincipal | undefined {
   const userId = readOwnString(payload, "userId", 512);
@@ -53,12 +53,9 @@ export function toProxyPrincipal(payload: unknown): ProxyPrincipal | undefined {
   if (tokenUse !== ENVIRONMENT_ACCESS_TOKEN_USE || !gateAudience) return undefined;
 
   const projectId = readOwnString(payload, "projectId", 512);
-  if (!projectId) return undefined;
   const environmentId = readOwnString(payload, "environmentId", 512);
-  return {
-    userId,
-    environmentAccess: { projectId, ...(environmentId ? { environmentId } : {}) },
-  };
+  if (!projectId || !environmentId) return undefined;
+  return { userId, environmentAccess: { projectId, environmentId } };
 }
 
 export interface ProtectedProxyProjectUser {
@@ -347,11 +344,12 @@ export async function checkProtectedProxyAccess(input: {
   }
   const { userId, environmentAccess } = principal;
   if (environmentAccess) {
-    // A bound token opens the one environment it names, nothing else.
+    // A bound token opens the one environment it names, nothing else. An
+    // environment the proxy cannot identify fails closed.
     const boundElsewhere = input.projectId === undefined ||
       environmentAccess.projectId !== input.projectId ||
-      (environmentAccess.environmentId !== undefined &&
-        environmentAccess.environmentId !== matchingEnv.id);
+      matchingEnv.id === undefined ||
+      environmentAccess.environmentId !== matchingEnv.id;
     if (boundElsewhere) {
       logger?.info("Environment access token is bound to another target", {
         ...logContext,

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -312,6 +312,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "protected by default",
       "`authToken` cookie",
       "VERYFRONT_API_TOKEN",
+      "/auth/environment-token",
       "Public Environment",
       "<environment-url>/<route>",
     ],


### PR DESCRIPTION
## Description

`veryfront deploy` can now verify a protected environment from an API-key-authenticated CLI, which is the CI case, and the proxy gate enforces that the credential it is shown was issued for that environment.

### Why

The access gate admits only a JWT verified against the API's JWKS. veryfront/veryfront-code#3527 stopped deploy from failing on that but left it reporting `urlVerification: "gated"`: the probe proved the gate answers, never that the app serves. The Cloud API now exchanges an API key for a five-minute token bound to one environment (`POST /auth/environment-token`, veryfront/veryfront-api#4472).

### What

**Proxy gate** (`src/proxy/proxy-access-control.ts`)
- `toProxyPrincipal` reads a verified payload into a principal. A plain user token is its user. An environment access token must carry both `aud: "environment-gate"` and `tokenUse: "environment_access"` and name a `projectId`; anything claiming only part of that is refused.
- `checkProtectedProxyAccess` takes the environment's `projectId` (both handler call sites pass it) and answers `403` when a bound token names another project or environment. Membership is still checked on the owner. A key scoped to project A therefore never opens project B.

**CLI** (`cli/shared/deployment/`)
- `DeployControlPlane.createEnvironmentAccessToken({ projectId, environmentName })` posts the target; the API authorizes the key for it and mints a bound token.
- The readiness probe exchanges when the environment is protected and the stored credential is not already a session token, and sends the result as `environmentAccessToken` (named for its role; the API refuses it as a session). The raw key is still never sent to the gate.
- Exchange failures are classified, never quoted: `unsupported` (404/405/501), `refused` (401/403), `rate_limited` (429), `unreachable`, `unusable`. The `environment-url-unverified` warning names the class and HTTP status; server-provided text never reaches it. A refused minted token degrades to `gated` rather than failing the committed deploy.

**Docs**: the cloud environment access guide documents the exchange with a fail-closed CI smoke test (status compared, non-zero exit on mismatch, redirects not followed); deploy getting-started, deploying, and deploy-from-CI guides updated; deploy help updated.

### Not in this change

No new subcommand, no signed preview URLs, no visibility toggle. `veryfront open` stays token-free by design. Debug-level output of the raw exchange error is not added: the deploy observer has no debug channel today, and adding one is out of scope.

## Related Issue(s)

Fixes veryfront/veryfront-issue-inbox#717

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Verification

- `src/proxy/proxy-access-control.test.ts`: principal mapping (audience and use both required, project binding required); a bound token admitted only for its project and environment, refused for another project, another environment, or a non-member.
- `cli/shared/deployment/control-plane.test.ts`: the exchange posts `project_reference` and `environment_name`.
- `cli/shared/deployment/deploy-project.test.ts`: the target reaches the exchange; the minted token is the only cookie sent and the run records `served`; an unsupported exchange and a refused exchange each degrade to `gated` with a bounded message that does not contain the server's text; a refused minted token reports `gated`; the existing "never sends the API key to the gate" test stays green.
- Full `src/proxy/` and `cli/` trees, cwd-sensitive CLI tests serially, `deno check`, `deno lint`, `deno fmt --check`, `docs:validate`, guide contract and content tests, API reference current (Deno 2.7.7). Pre-push hook on push.
