### PR TITLE
fix(ssr): return 404 when a project release is gone instead of 500

### DIFF
--- a/docs/api-reference/veryfront/observability.md
+++ b/docs/api-reference/veryfront/observability.md
@@ -82,15 +82,15 @@ const result = await withSpan("load-data", async () => {
 | `parseMaxSize`                           | Parses max size.                                                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/file-log-subscriber.ts#L47)                   |
 | `profilePhase`                           |                                                                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/request-profiler.ts#L191)                     |
 | `profileSyncPhase`                       |                                                                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/request-profiler.ts#L211)                     |
-| `recordApiRequest`                       |                                                                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/simple-metrics/metrics-recorder.ts#L307)      |
-| `recordApiRetry`                         |                                                                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/simple-metrics/metrics-recorder.ts#L322)      |
+| `recordApiRequest`                       |                                                                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/simple-metrics/metrics-recorder.ts#L326)      |
+| `recordApiRetry`                         |                                                                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/simple-metrics/metrics-recorder.ts#L341)      |
 | `recordBuild`                            | Record build.                                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/metrics/index.ts#L124)                        |
 | `recordBundle`                           | Record bundle.                                                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/metrics/index.ts#L132)                        |
 | `recordCacheGet`                         | Record cache get.                                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/metrics/index.ts#L56)                         |
 | `recordCacheInvalidate`                  | Record cache invalidate.                                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/metrics/index.ts#L69)                         |
 | `recordCacheSet`                         | Record cache set.                                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/metrics/index.ts#L64)                         |
-| `recordContentCacheHit`                  | Record a content cache hit at the specified layer                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/simple-metrics/metrics-recorder.ts#L344)      |
-| `recordContentNetworkFetch`              | Record a content network fetch with timing                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/simple-metrics/metrics-recorder.ts#L370)      |
+| `recordContentCacheHit`                  | Record a content cache hit at the specified layer                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/simple-metrics/metrics-recorder.ts#L363)      |
+| `recordContentNetworkFetch`              | Record a content network fetch with timing                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/simple-metrics/metrics-recorder.ts#L389)      |
 | `recordCorsRejection`                    | Record CORS rejection.                                               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/metrics/index.ts#L165)                        |
 | `recordDataFetch`                        | Record data fetch.                                                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/metrics/index.ts#L152)                        |
 | `recordDataFetchError`                   | Error shape for record data fetch.                                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/metrics/index.ts#L160)                        |
@@ -180,7 +180,7 @@ const result = await withSpan("load-data", async () => {
 
 | Name      | Description | Source                                                                                                        |
 | --------- | ----------- | ------------------------------------------------------------------------------------------------------------- |
-| `metrics` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/simple-metrics/index.ts#L76) |
+| `metrics` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/simple-metrics/index.ts#L78) |
 | `trace`   |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/observability/tracing/api-shim.ts#L588)    |
 
 ## Deep imports

--- a/src/observability/simple-metrics/index.ts
+++ b/src/observability/simple-metrics/index.ts
@@ -48,6 +48,7 @@ export {
   recordRSCStreamDuration,
   recordSecurityHeaders,
   recordSSR,
+  recordSSRSourceUnavailable,
 } from "./metrics-recorder.ts";
 
 export type { ContentCacheLayer, ModuleServeStatus } from "./metrics-recorder.ts";
@@ -70,6 +71,7 @@ import {
   recordRSCStreamDuration,
   recordSecurityHeaders,
   recordSSR,
+  recordSSRSourceUnavailable,
 } from "./metrics-recorder.ts";
 import { createSnapshot, getRequestCount } from "./metrics-state.ts";
 
@@ -91,6 +93,7 @@ export const metrics = {
   recordModuleServe,
   recordModuleTransform,
   recordRouteManifestLookup,
+  recordSSRSourceUnavailable,
   snapshot: createSnapshot,
   getRequestCount,
 };

--- a/src/observability/simple-metrics/metrics-recorder.ts
+++ b/src/observability/simple-metrics/metrics-recorder.ts
@@ -293,6 +293,25 @@ export function recordCorsRejection(): void {
 }
 
 /**
+ * Record that SSR answered 404 because a project's published source could not
+ * be read, as opposed to an ordinary route miss.
+ *
+ * This is the alertable replacement for the per-request error report that the
+ * same condition used to raise while it was misclassified as a render fault.
+ * A deleted project moves it a bounded number of times and then stops; an
+ * API-side regression that 404s every read moves it continuously, which is the
+ * shape worth alerting on.
+ *
+ * @example
+ * ```ts
+ * recordSSRSourceUnavailable()
+ * ```
+ */
+export function recordSSRSourceUnavailable(): void {
+  state.ssrSourceUnavailable = saturatingAdd(state.ssrSourceUnavailable);
+}
+
+/**
  * Record security headers application
  *
  * @example

--- a/src/observability/simple-metrics/metrics-state.ts
+++ b/src/observability/simple-metrics/metrics-state.ts
@@ -30,6 +30,7 @@ export const state: MetricsState = {
   ssrHistogram: undefined,
   rscStreamHistogram: undefined,
   corsRejections: 0,
+  ssrSourceUnavailable: 0,
   securityHeadersApplied: 0,
   apiRequests2xx: 0,
   apiRequests4xx: 0,
@@ -81,6 +82,7 @@ export function createSnapshot(): VeryfrontMetrics {
     routeManifestLruHits: state.routeManifestLruHits,
     routeManifestLruMisses: state.routeManifestLruMisses,
     corsRejections: state.corsRejections,
+    ssrSourceUnavailable: state.ssrSourceUnavailable,
     securityHeadersApplied: state.securityHeadersApplied,
     apiRequests2xx: state.apiRequests2xx,
     apiRequests4xx: state.apiRequests4xx,
@@ -135,6 +137,7 @@ export function resetMetrics(): void {
   state.routeManifestLruHits = 0;
   state.routeManifestLruMisses = 0;
   state.corsRejections = 0;
+  state.ssrSourceUnavailable = 0;
   state.securityHeadersApplied = 0;
   state.apiRequests2xx = 0;
   state.apiRequests4xx = 0;

--- a/src/observability/simple-metrics/types.ts
+++ b/src/observability/simple-metrics/types.ts
@@ -52,6 +52,8 @@ export interface VeryfrontMetrics {
   routeManifestLruMisses: number;
   ssrHistogram?: { boundaries: number[]; counts: number[] };
   corsRejections: number;
+  /** SSR answered 404 because a project's published source could not be read. */
+  ssrSourceUnavailable: number;
   securityHeadersApplied: number;
   apiRequests2xx: number;
   apiRequests4xx: number;

--- a/src/platform/adapters/fs/veryfront/read-operations-helpers.test.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations-helpers.test.ts
@@ -5,11 +5,14 @@ import { buildFileCacheKeyPrefix } from "./cache-keys.ts";
 import {
   assertProjectSourcePath,
   buildReadFetchState,
+  createNotFoundLikeError,
   getResolvedCacheKey,
   isNotFoundLikeError,
   READ_OPERATION_EXTENSION_PRIORITY,
   splitKnownFileExtension,
 } from "./read-operations-helpers.ts";
+import { VeryfrontError } from "#veryfront/errors";
+import { isCanonicalNotFoundError } from "#veryfront/platform/compat/not-found-error.ts";
 import type { ResolvedContentContext } from "./types.ts";
 
 describe("read-operations helpers", () => {
@@ -119,6 +122,39 @@ describe("read-operations helpers", () => {
         true,
       );
       assertEquals(isNotFoundLikeError(new Error("500 Internal Server Error")), false);
+    });
+
+    it("raises the registry file-not-found error, not a raw Error", () => {
+      const error = createNotFoundLikeError("app/layout.tsx");
+
+      assertEquals(
+        error instanceof VeryfrontError,
+        true,
+        "the adapter's absence error must carry a registry identity",
+      );
+      assertEquals(
+        (error as VeryfrontError).slug,
+        "file-not-found",
+        "slug is what resolveSSRFailure reads to answer 404",
+      );
+      assertEquals((error as VeryfrontError).status, 404, "file-not-found is a 404 condition");
+      assertEquals(error.message, "404 Not Found: app/layout.tsx", "message shape is unchanged");
+    });
+
+    it("keeps the ENOENT contract its own callers depend on", () => {
+      const error = createNotFoundLikeError("app/layout.tsx");
+
+      assertEquals(error.code, "ENOENT", "isNotFoundLikeError and Node-style checks read code");
+      assertEquals(
+        isNotFoundLikeError(error),
+        true,
+        "the adapter's own optional-file catches must still treat it as a miss",
+      );
+      assertEquals(
+        isCanonicalNotFoundError(error),
+        true,
+        "fail-closed filesystem boundaries must still see ordinary absence",
+      );
     });
   });
 });

--- a/src/platform/adapters/fs/veryfront/read-operations-helpers.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations-helpers.ts
@@ -1,5 +1,5 @@
 import { isFrameworkSourcePath } from "#veryfront/utils/path-utils.ts";
-import { INVALID_IMPORT } from "#veryfront/errors";
+import { FILE_NOT_FOUND, INVALID_IMPORT } from "#veryfront/errors";
 import { buildFileCacheKeyPrefix } from "./cache-keys.ts";
 import { READ_OPERATION_EXTENSION_PRIORITY } from "./extension-priority.ts";
 import type { ResolvedContentContext } from "./types.ts";
@@ -113,6 +113,24 @@ export function isNotFoundLikeError(error: unknown): boolean {
   return errorMessage.includes("404") || errorMessage.includes("Not Found");
 }
 
+/**
+ * Raise the framework's "this path is not in the release" error.
+ *
+ * Registry-branded rather than a raw `Error` so that whoever decides the
+ * response status can tell an absent path from a render that faulted: the
+ * `file-not-found` slug is what `resolveSSRFailure` already reads to answer
+ * 404. A release whose project has been deleted answers 404 to every source
+ * read, and a raw `Error` buried that routine deletion in 500s.
+ *
+ * `code` is kept because {@link isNotFoundLikeError} and the platform's Node
+ * and Deno absence checks both read it.
+ */
 export function createNotFoundLikeError(path: string): NotFoundLikeError {
-  return Object.assign(new Error(`404 Not Found: ${path}`), { code: "ENOENT" });
+  return Object.assign(
+    FILE_NOT_FOUND.create({
+      detail: `404 Not Found: ${path}`,
+      context: { path },
+    }),
+    { code: "ENOENT" },
+  );
 }

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -8,6 +8,7 @@ import { isTenantBuildFailure, markBuildFailure } from "./module-loader/build-fa
 import {
   COMPILATION_ERROR,
   createError,
+  FILE_NOT_FOUND,
   SSG_GENERATION_ERROR,
   toError,
   VeryfrontError,
@@ -40,7 +41,7 @@ import {
 } from "#veryfront/data/response-metadata.ts";
 import { notFound } from "#veryfront/data/helpers.ts";
 import { createNotFoundLikeError } from "#veryfront/platform/adapters/fs/veryfront/read-operations-helpers.ts";
-import { isFileNotFoundError } from "#veryfront/rendering/ssr-outcome.ts";
+import { isMissingProjectSourceError } from "#veryfront/rendering/ssr-outcome.ts";
 import {
   __registerLogRecordEmitter,
   __resetLoggerConfigForTests,
@@ -329,9 +330,40 @@ describe("RenderPipeline behavior", () => {
     );
 
     assertEquals(
-      isFileNotFoundError(error),
-      true,
+      (error as VeryfrontError).slug,
+      "file-not-found",
       "resolveSSRFailure reads this slug to answer 404",
+    );
+    assertEquals(
+      isMissingProjectSourceError(error),
+      true,
+      "the absent-source identity must survive the re-raise intact",
+    );
+  });
+
+  it("keeps a render-error identity for an infrastructure file-not-found", async () => {
+    // http-cache raises `file-not-found` when a bundle write reports success and
+    // the file still is not there. That is a server fault reachable from
+    // loadModule, and routing it to 404 would page nobody.
+    const pipeline = createPipeline("/project/pages/index.tsx");
+    (pipeline as unknown as { loadModule: () => Promise<unknown> }).loadModule = () =>
+      Promise.reject(
+        FILE_NOT_FOUND.create({
+          detail: "[HTTP-CACHE] INVARIANT VIOLATION: File write succeeded but file does not exist",
+        }),
+      );
+
+    const error = await assertRejects(() =>
+      pipeline.resolvePageData("/", {
+        request: new Request("http://localhost/"),
+        url: new URL("http://localhost/"),
+      })
+    );
+
+    assertEquals(
+      (error as VeryfrontError).slug,
+      "render-error",
+      "an infrastructure fault must keep a 500 identity",
     );
   });
 
@@ -348,7 +380,7 @@ describe("RenderPipeline behavior", () => {
     );
 
     assertEquals(
-      isFileNotFoundError(error),
+      isMissingProjectSourceError(error),
       false,
       "a genuine fault must not be downgraded to a 404",
     );

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -5,7 +5,13 @@ import { FakeTime } from "#std/testing/time";
 import { RenderPipeline, type RenderPipelineConfig } from "./pipeline.ts";
 import type { RenderOptions, RenderResult } from "./types.ts";
 import { isTenantBuildFailure, markBuildFailure } from "./module-loader/build-failure.ts";
-import { COMPILATION_ERROR, createError, SSG_GENERATION_ERROR, toError } from "#veryfront/errors";
+import {
+  COMPILATION_ERROR,
+  createError,
+  SSG_GENERATION_ERROR,
+  toError,
+  VeryfrontError,
+} from "#veryfront/errors";
 import { cachePageCss, getPageCssCacheKey } from "./css-cache.ts";
 import { cacheCSSAsync, hashCSS } from "#veryfront/html/styles-builder/index.ts";
 import { RELEASE_ASSET_MANIFEST_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
@@ -15,7 +21,7 @@ import {
   registerManifestFetcherForRelease,
 } from "#veryfront/release-assets/manifest-cache.ts";
 import type { ReleaseAssetManifest } from "#veryfront/release-assets/manifest-schema.ts";
-import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import { deleteEnv, getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import {
   finalizeRequestProfiling,
   resetRequestProfiles,
@@ -33,6 +39,14 @@ import {
   unwrapDataResponseMetadataError,
 } from "#veryfront/data/response-metadata.ts";
 import { notFound } from "#veryfront/data/helpers.ts";
+import { createNotFoundLikeError } from "#veryfront/platform/adapters/fs/veryfront/read-operations-helpers.ts";
+import { isFileNotFoundError } from "#veryfront/rendering/ssr-outcome.ts";
+import {
+  __registerLogRecordEmitter,
+  __resetLoggerConfigForTests,
+  __resetLogRecordEmitterForTests,
+  type LogEntry,
+} from "#veryfront/utils/logger/logger.ts";
 
 const RELEASE_CSS_HASH = "c".repeat(64);
 
@@ -153,14 +167,35 @@ async function primeReadyReleaseCssManifest(): Promise<void> {
   await new Promise((r) => setTimeout(r, 0));
 }
 
+/** Collect the warn-and-above log records emitted while a test runs. Reset by the suite's afterEach. */
+function captureLogs(): LogEntry[] {
+  const entries: LogEntry[] = [];
+  setEnv("LOG_LEVEL", "WARN");
+  __resetLoggerConfigForTests();
+  __registerLogRecordEmitter((entry) => entries.push(entry));
+  return entries;
+}
+
+/** The record reporting that `path` failed to load, ignoring surrounding progress logs. */
+function findModuleFailureLog(entries: LogEntry[], path: string): LogEntry | undefined {
+  return entries.find((entry) =>
+    entry.context?.path === path && typeof entry.context?.error === "string"
+  );
+}
+
 describe("RenderPipeline behavior", () => {
   const originalManifestFlag = getHostEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG);
+  const originalLogLevel = getHostEnv("LOG_LEVEL");
 
   afterEach(() => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, originalManifestFlag ?? "");
     Deno.env.delete("VERYFRONT_ENABLE_SERVER_TIMING");
     resetRequestProfiles();
     clearReleaseAssetManifestCache();
+    if (originalLogLevel === undefined) deleteEnv("LOG_LEVEL");
+    else setEnv("LOG_LEVEL", originalLogLevel);
+    __resetLoggerConfigForTests();
+    __resetLogRecordEmitterForTests();
   });
 
   it("threads render cancellation through layout preload and application", async () => {
@@ -208,6 +243,120 @@ describe("RenderPipeline behavior", () => {
 
     assertEquals(preloadSignal, controller.signal);
     assertEquals(applySignal, controller.signal);
+  });
+
+  /** Build a pipeline whose single TSX layout fails to load with `error`. */
+  function createPipelineWithFailingLayout(error: Error): RenderPipeline {
+    const pipeline = createPipeline("/project/pages/index.tsx", {
+      layoutOrchestrator: {
+        collectLayouts: async () => ({
+          layoutBundle: undefined,
+          nestedLayouts: [{ kind: "tsx", componentPath: "/project/app/layout.tsx" }],
+        }),
+        preloadLayoutModules: async () => ({
+          tsxTotal: 1,
+          tsxSuccess: 0,
+          tsxFailures: ["/project/app/layout.tsx"],
+          mdxTotal: 0,
+          mdxSuccess: 0,
+          mdxFailures: [],
+          importMapSuccess: true,
+          durationMs: 0,
+          allSuccess: false,
+        }),
+        applyLayoutsAndWrappers: async (element: unknown) => element,
+      },
+    } as unknown as Partial<RenderPipelineConfig>);
+
+    (pipeline as unknown as { loadModule: (path: string) => Promise<unknown> }).loadModule = (
+      path: string,
+    ) => path === "/project/app/layout.tsx" ? Promise.reject(error) : Promise.resolve({});
+
+    return pipeline;
+  }
+
+  it("does not call a terminal layout failure non-critical", async () => {
+    // The apply phase reloads the layout from the same source. When that source
+    // is gone the reload fails identically and the render is over, so a warning
+    // labelled "non-critical" misleads anyone triaging by severity.
+    const entries = captureLogs();
+    const pipeline = createPipelineWithFailingLayout(
+      createNotFoundLikeError("app/layout.tsx"),
+    );
+
+    await pipeline.resolvePageData("/", {
+      request: new Request("http://localhost/"),
+      url: new URL("http://localhost/"),
+    });
+
+    const entry = findModuleFailureLog(entries, "/project/app/layout.tsx");
+    assert(entry, "expected a log entry for the failed layout module");
+    assertEquals(entry.level, "error", "a failure about to be terminal is not a warning");
+    assertEquals(
+      entry.message.includes("non-critical"),
+      false,
+      "the message must not claim non-critical for a terminal failure",
+    );
+  });
+
+  it("still treats a recoverable layout load failure as a warning", async () => {
+    const entries = captureLogs();
+    const pipeline = createPipelineWithFailingLayout(new Error("connection reset"));
+
+    await pipeline.resolvePageData("/", {
+      request: new Request("http://localhost/"),
+      url: new URL("http://localhost/"),
+    });
+
+    const entry = findModuleFailureLog(entries, "/project/app/layout.tsx");
+    assert(entry, "expected a log entry for the failed layout module");
+    assertEquals(entry.level, "warn", "the apply phase can still recover this one");
+  });
+
+  it("keeps the file-not-found identity of an unretrievable page module", async () => {
+    // The page module reads the same unreachable source as the layout. A
+    // render-error wrapper would drop that identity and answer 500 for the very
+    // deletion the layout path already answers 404 for.
+    const pipeline = createPipeline("/project/pages/index.tsx");
+    (pipeline as unknown as { loadModule: () => Promise<unknown> }).loadModule = () =>
+      Promise.reject(createNotFoundLikeError("pages/index.tsx"));
+
+    const error = await assertRejects(() =>
+      pipeline.resolvePageData("/", {
+        request: new Request("http://localhost/"),
+        url: new URL("http://localhost/"),
+      })
+    );
+
+    assertEquals(
+      isFileNotFoundError(error),
+      true,
+      "resolveSSRFailure reads this slug to answer 404",
+    );
+  });
+
+  it("keeps a render-error identity for a page module that loaded and threw", async () => {
+    const pipeline = createPipeline("/project/pages/index.tsx");
+    (pipeline as unknown as { loadModule: () => Promise<unknown> }).loadModule = () =>
+      Promise.reject(new Error("Cannot read properties of undefined (reading 'map')"));
+
+    const error = await assertRejects(() =>
+      pipeline.resolvePageData("/", {
+        request: new Request("http://localhost/"),
+        url: new URL("http://localhost/"),
+      })
+    );
+
+    assertEquals(
+      isFileNotFoundError(error),
+      false,
+      "a genuine fault must not be downgraded to a 404",
+    );
+    assertEquals(
+      (error as VeryfrontError).slug,
+      "render-error",
+      "the existing render-error identity is unchanged",
+    );
   });
 
   it("resolves request-scoped module loader identity and the configured React version", async () => {

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -20,6 +20,7 @@ import { createBuildVersion } from "#veryfront/utils/version.ts";
 import { profilePhase, SpanNames } from "#veryfront/observability";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { FILE_NOT_FOUND, RENDER_ERROR, VeryfrontError } from "#veryfront/errors";
+import { isFileNotFoundError } from "../ssr-outcome.ts";
 import { buildQueryAwareCacheKey } from "#veryfront/cache/keys.ts";
 import {
   buildDependencyPinnedRenderCacheKey,
@@ -370,8 +371,11 @@ export class RenderPipeline {
    * we throw an error instead of silently continuing with missing props. This prevents
    * users from seeing broken pages with no indication of the problem.
    *
-   * Layout modules are considered non-critical - their failures are logged as warnings
-   * and the page continues to render (possibly without that layout's data).
+   * A layout module that fails to load does not stop this phase: the page
+   * continues without that layout's data, and the apply phase loads the layout
+   * again. That second attempt is what decides the render, so a failure here is
+   * only provisional - unless the project's source is gone, in which case the
+   * reload fails identically and the render is already over.
    */
   private async loadModulesInParallel(
     modules: ModuleToLoad[],
@@ -415,6 +419,7 @@ export class RenderPipeline {
       error: string;
       buildFailure: boolean;
       tenantBuildFailure: boolean;
+      missingSource: boolean;
     }> = [];
 
     for (const result of results) {
@@ -433,6 +438,7 @@ export class RenderPipeline {
           error: errorMessage,
           buildFailure: isBuildFailure(result.error),
           tenantBuildFailure: isTenantBuildFailure(result.error),
+          missingSource: isFileNotFoundError(result.error),
         });
         renderPageLog.error("Critical page module failed to load", {
           path: result.path,
@@ -441,7 +447,18 @@ export class RenderPipeline {
         continue;
       }
 
-      renderPageLog.warn("Layout module failed to load (non-critical)", {
+      if (isFileNotFoundError(result.error)) {
+        // The apply phase reloads this layout from the same unreachable source,
+        // so the render is already lost. Logging it as a recoverable warning
+        // misleads anyone triaging by severity.
+        renderPageLog.error("Layout module source is unavailable; render will fail", {
+          path: result.path,
+          error: errorMessage,
+        });
+        continue;
+      }
+
+      renderPageLog.warn("Layout module failed to load; apply phase will retry it", {
         path: result.path,
         error: errorMessage,
       });
@@ -451,7 +468,17 @@ export class RenderPipeline {
       const failedDetails = criticalFailures
         .map((f) => `${f.path}: ${f.error}`)
         .join("\n");
-      throw RENDER_ERROR.create({
+      // A page module the adapter could not retrieve is the same condition the
+      // layout path already answers 404 for, so it keeps the `file-not-found`
+      // slug that `resolveSSRFailure` reads. Wrapping it in a `render-error`
+      // would drop that identity and answer 500 for a deleted project on the
+      // page path while answering 404 on the layout path.
+      //
+      // `every`, matching `tenantBuildFailure` below: one retrievable module
+      // that threw must not be reported as an absent release.
+      const raised = criticalFailures.every((f) => f.missingSource) ? FILE_NOT_FOUND : RENDER_ERROR;
+
+      throw raised.create({
         detail: `Critical page module(s) failed to load:\n${failedDetails}`,
         context: {
           criticalFailures,

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -20,7 +20,7 @@ import { createBuildVersion } from "#veryfront/utils/version.ts";
 import { profilePhase, SpanNames } from "#veryfront/observability";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { FILE_NOT_FOUND, RENDER_ERROR, VeryfrontError } from "#veryfront/errors";
-import { isFileNotFoundError } from "../ssr-outcome.ts";
+import { isMissingProjectSourceError } from "../ssr-outcome.ts";
 import { buildQueryAwareCacheKey } from "#veryfront/cache/keys.ts";
 import {
   buildDependencyPinnedRenderCacheKey,
@@ -438,7 +438,7 @@ export class RenderPipeline {
           error: errorMessage,
           buildFailure: isBuildFailure(result.error),
           tenantBuildFailure: isTenantBuildFailure(result.error),
-          missingSource: isFileNotFoundError(result.error),
+          missingSource: isMissingProjectSourceError(result.error),
         });
         renderPageLog.error("Critical page module failed to load", {
           path: result.path,
@@ -447,7 +447,7 @@ export class RenderPipeline {
         continue;
       }
 
-      if (isFileNotFoundError(result.error)) {
+      if (isMissingProjectSourceError(result.error)) {
         // The apply phase reloads this layout from the same unreachable source,
         // so the render is already lost. Logging it as a recoverable warning
         // misleads anyone triaging by severity.
@@ -469,16 +469,16 @@ export class RenderPipeline {
         .map((f) => `${f.path}: ${f.error}`)
         .join("\n");
       // A page module the adapter could not retrieve is the same condition the
-      // layout path already answers 404 for, so it keeps the `file-not-found`
-      // slug that `resolveSSRFailure` reads. Wrapping it in a `render-error`
-      // would drop that identity and answer 500 for a deleted project on the
-      // page path while answering 404 on the layout path.
+      // layout path already answers 404 for, so it is re-raised with the same
+      // identity the adapter used. Wrapping it in a `render-error` would answer
+      // 500 for a deleted project on the page path while answering 404 on the
+      // layout path.
       //
-      // `every`, matching `tenantBuildFailure` below: one retrievable module
-      // that threw must not be reported as an absent release.
-      const raised = criticalFailures.every((f) => f.missingSource) ? FILE_NOT_FOUND : RENDER_ERROR;
-
-      throw raised.create({
+      // `every`, matching `tenantBuildFailure` below: one module that loaded and
+      // threw, or an infrastructure `file-not-found` such as http-cache's write
+      // verification, must not be reported as an absent release.
+      const missingSource = criticalFailures.every((f) => f.missingSource);
+      const failure = (missingSource ? FILE_NOT_FOUND : RENDER_ERROR).create({
         detail: `Critical page module(s) failed to load:\n${failedDetails}`,
         context: {
           criticalFailures,
@@ -500,6 +500,11 @@ export class RenderPipeline {
           totalModules: modules.length,
         },
       });
+
+      // Carry the adapter's own marker across the re-raise so that one notion of
+      // "absent project source" holds on both sides of this boundary, rather
+      // than the slug alone standing in for it here.
+      throw missingSource ? Object.assign(failure, { code: "ENOENT" }) : failure;
     }
 
     return loaded;

--- a/src/rendering/ssr-outcome.test.ts
+++ b/src/rendering/ssr-outcome.test.ts
@@ -318,6 +318,28 @@ describe("ssr-outcome.ts", () => {
       }
     });
 
+    it("keeps a layout that exists but throws a server error", () => {
+      // The regression guard for the file-not-found branch above: only the
+      // framework's own absence error becomes a 404. Project code that loaded
+      // and then threw is still a fault, including when its message names a
+      // missing file or it sets ENOENT itself.
+      const thrown = new Error("404 Not Found: app/layout.tsx");
+      const enoent = Object.assign(new Error("Cannot read properties of undefined"), {
+        code: "ENOENT",
+      });
+
+      assertSSRFailureOutcome(
+        resolveSSRFailure(thrown, { isLocalProject: false }),
+        { kind: "server-error", exposure: "generic", error: thrown },
+        "message text must never be read as a routing decision",
+      );
+      assertSSRFailureOutcome(
+        resolveSSRFailure(enoent, { isLocalProject: false }),
+        { kind: "server-error", exposure: "generic", error: enoent },
+        "an unbranded ENOENT is not the framework's absence error",
+      );
+    });
+
     it("defaults service-overloaded to 503 when the error has no status", () => {
       const overloaded = SERVICE_OVERLOADED.create({ detail: "queue is full" });
       Object.assign(overloaded, { status: undefined });

--- a/src/rendering/ssr-outcome.test.ts
+++ b/src/rendering/ssr-outcome.test.ts
@@ -342,6 +342,36 @@ describe("ssr-outcome.ts", () => {
       );
     });
 
+    it("reads the ENOENT marker as an own data property only", () => {
+      // Pins the shape of the check, not just its answer. A plain
+      // `error.code === "ENOENT"` passes every other assertion in this file
+      // while accepting an accessor and an inherited value, so without this the
+      // narrowing could be "simplified" away and CI would stay green.
+      const withGetter = FILE_NOT_FOUND.create({ detail: "accessor" });
+      Object.defineProperty(withGetter, "code", { get: () => "ENOENT" });
+
+      const proto = Object.assign(FILE_NOT_FOUND.create({ detail: "proto" }), {
+        code: "ENOENT",
+      });
+      const inherited = Object.create(proto);
+
+      assertEquals(
+        isMissingProjectSourceError(withGetter),
+        false,
+        "an accessor must not stand in for the marker, and must not be invoked",
+      );
+      assertEquals(
+        isMissingProjectSourceError(inherited),
+        false,
+        "an inherited marker is not this error's own",
+      );
+      assertEquals(
+        isMissingProjectSourceError(proto),
+        true,
+        "an own data property is the shape the adapter writes",
+      );
+    });
+
     it("keeps a layout that exists but throws a server error", () => {
       // The regression guard for the file-not-found branch above: only the
       // framework's own absence error becomes a 404. Project code that loaded

--- a/src/rendering/ssr-outcome.test.ts
+++ b/src/rendering/ssr-outcome.test.ts
@@ -12,12 +12,14 @@ import {
 import type { SSRFailureOutcome } from "./ssr-outcome.ts";
 import {
   findSSRControlOutcome,
+  isMissingProjectSourceError,
   isSSRBuildFailure,
   isSSRControlOutcome,
   resolveSSRControlOutcome,
   resolveSSRFailure,
 } from "./ssr-outcome.ts";
 import { attachDataResponseMetadata } from "#veryfront/data/response-metadata.ts";
+import { createNotFoundLikeError } from "#veryfront/platform/adapters/fs/veryfront/read-operations-helpers.ts";
 
 function assertSSRFailureOutcome(
   actual: SSRFailureOutcome,
@@ -316,6 +318,28 @@ describe("ssr-outcome.ts", () => {
           testCase.name,
         );
       }
+    });
+
+    it("does not treat every file-not-found as an absent project source", () => {
+      // `file-not-found` is raised in-tree for conditions that are not an
+      // absent source: http-cache raises it when a bundle write reports success
+      // and the file still is not there, and discovery/transpiler folds EACCES
+      // and EIO into it. Routing those to 404 would hide a real fault behind a
+      // status nothing alerts on -- the exact inversion this PR exists to stop.
+      const invariantViolation = FILE_NOT_FOUND.create({
+        detail: "[HTTP-CACHE] INVARIANT VIOLATION: File write succeeded but file does not exist",
+      });
+
+      assertEquals(
+        isMissingProjectSourceError(invariantViolation),
+        false,
+        "an infrastructure fault must not be read as a deleted release",
+      );
+      assertEquals(
+        isMissingProjectSourceError(createNotFoundLikeError("app/layout.tsx")),
+        true,
+        "the filesystem adapter's own absence error still qualifies",
+      );
     });
 
     it("keeps a layout that exists but throws a server error", () => {

--- a/src/rendering/ssr-outcome.ts
+++ b/src/rendering/ssr-outcome.ts
@@ -231,17 +231,28 @@ function isFileNotFoundError(error: unknown): error is VeryfrontError {
  * EIO, aborts and timeouts into it. Both are server faults, and answering them
  * with a 404 would hide a real outage behind a status nothing alerts on.
  *
- * `code` narrows it to that one raiser: of the sixteen in-tree raisers of this
- * slug, `createNotFoundLikeError` is the only one that sets ENOENT alongside
- * it, and removing that assignment reddens tests in four files.
+ * `code` narrows it: of the sixteen in-tree raisers of this slug, exactly two
+ * set ENOENT alongside it -- `createNotFoundLikeError`, and the re-raise in
+ * `rendering/orchestrator/pipeline.ts`, which carries the marker across that
+ * boundary only when every critical failure already had it. Removing either
+ * assignment reddens tests.
  *
- * This is a correctness guard, not a security boundary. `FILE_NOT_FOUND` is
- * public API via the `veryfront/errors/general` export, so project code can
- * raise this slug and can set an own `code` of its own. Reading the own data
- * descriptor rules out an accessor -- no project getter runs during
- * classification, and a getter cannot stand in for the marker -- but a plain
- * assignment still passes, and project code can already reach a 404 through
- * `notFound()` by design. Nothing here depends on the tenant being unable to.
+ * This is a correctness guard, not a security boundary, and the distinction
+ * matters because the check reads as though it were one. `FILE_NOT_FOUND` and
+ * `VeryfrontError` are public API via `veryfront/errors`, so project code can
+ * raise this slug and assign an own `code` that this predicate accepts. The
+ * own-data-descriptor read stops an accidental accessor, not a determined
+ * forgery, and no project getter runs during classification. A project that
+ * did forge it would route its own route to 404 and suppress its own alerting;
+ * nothing cross-tenant turns on it, and `notFound()` already lets a project
+ * reach a 404 by design.
+ *
+ * The narrowing is deliberately conservative: adapters that raise the slug
+ * without ENOENT -- `runtime/cloudflare/filesystem.ts`, `fs/github`, `mock.ts`,
+ * `skill/testing.ts` -- answer 500 for a genuinely absent file rather than 404.
+ * Wrong in the safe direction today because SSR is served through the
+ * veryfront-api adapter. If SSR is ever served through one of those, the
+ * symptom this guard exists to fix returns there and they need the marker too.
  *
  * Message text is never consulted, so an error that merely reads "not found"
  * stays a fault.

--- a/src/rendering/ssr-outcome.ts
+++ b/src/rendering/ssr-outcome.ts
@@ -216,7 +216,15 @@ function extractRedirectLocation(
   }
 }
 
-function isFileNotFoundError(error: unknown): error is VeryfrontError {
+/**
+ * True for the framework's own "this path is not in the project" error.
+ *
+ * The slug is the identity; message text is never consulted. Only framework
+ * filesystem adapters raise it, and only where the source could not be
+ * retrieved, so project code that loaded and then threw never matches -- which
+ * is what keeps a genuine render fault a fault rather than a 404.
+ */
+export function isFileNotFoundError(error: unknown): error is VeryfrontError {
   return error instanceof VeryfrontError && error.slug === "file-not-found";
 }
 

--- a/src/rendering/ssr-outcome.ts
+++ b/src/rendering/ssr-outcome.ts
@@ -231,9 +231,17 @@ function isFileNotFoundError(error: unknown): error is VeryfrontError {
  * EIO, aborts and timeouts into it. Both are server faults, and answering them
  * with a 404 would hide a real outage behind a status nothing alerts on.
  *
- * `code` narrows it to the adapter: `createNotFoundLikeError` is the only
- * raiser that sets ENOENT alongside the slug, and a test pins that. It is read
- * as an own data property so a project-owned getter cannot forge it.
+ * `code` narrows it to that one raiser: of the sixteen in-tree raisers of this
+ * slug, `createNotFoundLikeError` is the only one that sets ENOENT alongside
+ * it, and removing that assignment reddens tests in four files.
+ *
+ * This is a correctness guard, not a security boundary. `FILE_NOT_FOUND` is
+ * public API via the `veryfront/errors/general` export, so project code can
+ * raise this slug and can set an own `code` of its own. Reading the own data
+ * descriptor rules out an accessor -- no project getter runs during
+ * classification, and a getter cannot stand in for the marker -- but a plain
+ * assignment still passes, and project code can already reach a 404 through
+ * `notFound()` by design. Nothing here depends on the tenant being unable to.
  *
  * Message text is never consulted, so an error that merely reads "not found"
  * stays a fault.

--- a/src/rendering/ssr-outcome.ts
+++ b/src/rendering/ssr-outcome.ts
@@ -216,16 +216,33 @@ function extractRedirectLocation(
   }
 }
 
-/**
- * True for the framework's own "this path is not in the project" error.
- *
- * The slug is the identity; message text is never consulted. Only framework
- * filesystem adapters raise it, and only where the source could not be
- * retrieved, so project code that loaded and then threw never matches -- which
- * is what keeps a genuine render fault a fault rather than a 404.
- */
-export function isFileNotFoundError(error: unknown): error is VeryfrontError {
+function isFileNotFoundError(error: unknown): error is VeryfrontError {
   return error instanceof VeryfrontError && error.slug === "file-not-found";
+}
+
+/**
+ * True for the veryfront-api filesystem adapter's own "this path is not in the
+ * release" error, and for nothing else.
+ *
+ * The `file-not-found` slug alone is not safe to route a status on. It is
+ * raised in-tree for conditions that are not an absent source at all:
+ * `transforms/esm/http-cache.ts` raises it when a bundle write reports success
+ * and the file still is not there, and `discovery/transpiler.ts` folds EACCES,
+ * EIO, aborts and timeouts into it. Both are server faults, and answering them
+ * with a 404 would hide a real outage behind a status nothing alerts on.
+ *
+ * `code` narrows it to the adapter: `createNotFoundLikeError` is the only
+ * raiser that sets ENOENT alongside the slug, and a test pins that. It is read
+ * as an own data property so a project-owned getter cannot forge it.
+ *
+ * Message text is never consulted, so an error that merely reads "not found"
+ * stays a fault.
+ */
+export function isMissingProjectSourceError(error: unknown): boolean {
+  if (!isFileNotFoundError(error)) return false;
+
+  const code = Object.getOwnPropertyDescriptor(error, "code");
+  return code !== undefined && "value" in code && code.value === "ENOENT";
 }
 
 function isUndeployedFileListError(error: unknown): boolean {

--- a/src/server/services/rendering/ssr.service.test.ts
+++ b/src/server/services/rendering/ssr.service.test.ts
@@ -18,6 +18,7 @@ import {
   setApplicationErrorReporter,
 } from "#veryfront/observability/application-errors.ts";
 import { createNotFoundLikeError } from "#veryfront/platform/adapters/fs/veryfront/read-operations-helpers.ts";
+import { resetMetrics, state } from "#veryfront/observability/simple-metrics/index.ts";
 
 function createMockAdapter(): RuntimeAdapter {
   return {
@@ -560,6 +561,51 @@ describe("server/services/rendering/ssr.service", () => {
         const result = await service.renderPage(makeCtx(), makeRenderOptions());
         assertEquals(result.status, 404, "a deleted project is a 404, not a 500");
         assertEquals(result.failure?.kind, "not-found", "classified as a routing outcome");
+      });
+
+      it("counts an unreadable project source so the 404 is not silent", async () => {
+        // The old 500 raised a Sentry event per request. Dropping that must not
+        // leave an API-side regression invisible, so the condition is counted:
+        // an ordinary route miss stays uncounted, a source that cannot be read
+        // moves the counter.
+        resetMetrics();
+        const adapter = createMockRendererAdapter({
+          renderPage: () => {
+            throw createNotFoundLikeError("app/layout.tsx");
+          },
+        });
+        const service = new SSRService({
+          rendererProvider: createMockRendererProvider(adapter),
+        });
+
+        await service.renderPage(makeCtx(), makeRenderOptions());
+
+        assertEquals(
+          state.ssrSourceUnavailable,
+          1,
+          "an unreadable release must remain visible after the Sentry event is gone",
+        );
+      });
+
+      it("does not count an ordinary route miss as an unreadable source", async () => {
+        resetMetrics();
+        const adapter = createMockRendererAdapter({
+          renderPage: () => {
+            throw notFound();
+          },
+        });
+        const service = new SSRService({
+          rendererProvider: createMockRendererProvider(adapter),
+        });
+
+        const result = await service.renderPage(makeCtx(), makeRenderOptions());
+
+        assertEquals(result.status, 404, "a route miss is still a 404");
+        assertEquals(
+          state.ssrSourceUnavailable,
+          0,
+          "routine 404s must not drown the signal they would otherwise raise",
+        );
       });
 
       it("still answers 500 when a layout exists but throws", async () => {

--- a/src/server/services/rendering/ssr.service.test.ts
+++ b/src/server/services/rendering/ssr.service.test.ts
@@ -17,6 +17,7 @@ import {
   type ApplicationErrorContext,
   setApplicationErrorReporter,
 } from "#veryfront/observability/application-errors.ts";
+import { createNotFoundLikeError } from "#veryfront/platform/adapters/fs/veryfront/read-operations-helpers.ts";
 
 function createMockAdapter(): RuntimeAdapter {
   return {
@@ -541,6 +542,39 @@ describe("server/services/rendering/ssr.service", () => {
         const result = await service.renderPage(makeCtx(), makeRenderOptions());
         assertEquals(result.status, 404);
         assertEquals(result.failure?.kind, "undeployed");
+      });
+
+      it("answers 404 when the project's release source is gone", async () => {
+        // A deleted project answers 404 to every source read. The error the
+        // filesystem adapter actually raises must reach SSR as a 404 condition,
+        // not as a platform fault.
+        const adapter = createMockRendererAdapter({
+          renderPage: () => {
+            throw createNotFoundLikeError("app/layout.tsx");
+          },
+        });
+        const service = new SSRService({
+          rendererProvider: createMockRendererProvider(adapter),
+        });
+
+        const result = await service.renderPage(makeCtx(), makeRenderOptions());
+        assertEquals(result.status, 404, "a deleted project is a 404, not a 500");
+        assertEquals(result.failure?.kind, "not-found", "classified as a routing outcome");
+      });
+
+      it("still answers 500 when a layout exists but throws", async () => {
+        const adapter = createMockRendererAdapter({
+          renderPage: () => {
+            throw new Error("Cannot read properties of undefined (reading 'map')");
+          },
+        });
+        const service = new SSRService({
+          rendererProvider: createMockRendererProvider(adapter),
+        });
+
+        const result = await service.renderPage(makeCtx(), makeRenderOptions());
+        assertEquals(result.status, 500, "a genuine render fault must stay a fault");
+        assertEquals(result.failure?.kind, "runtime", "not downgraded to a routing outcome");
       });
 
       it("maps render redirects to redirect results", async () => {

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -26,6 +26,8 @@ import {
   startRenderSession,
 } from "#veryfront/transforms/mdx/esm-module-loader/module-fetcher/index.ts";
 import { getErrorCollector, profilePhase } from "#veryfront/observability";
+// Not on the `#veryfront/observability` barrel: that surface is frozen by an
+// export-snapshot test, and the sibling in-process recorders sit here too.
 import { recordSSRSourceUnavailable } from "#veryfront/observability/simple-metrics/index.ts";
 import { captureApplicationError } from "#veryfront/observability/application-errors.ts";
 import { ErrorOverlay, parseErrorLocation } from "../../dev-server/error-overlay/index.ts";

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -8,7 +8,11 @@ import { getHeapStats } from "#veryfront/utils/memory/index.ts";
 import { serverLogger, timeAsync } from "#veryfront/utils";
 import { computeSSRETag } from "../../handlers/request/ssr/etag-handler.ts";
 import type { SSRFailureOutcome } from "#veryfront/rendering/ssr-outcome.ts";
-import { findSSRControlOutcome, resolveSSRFailure } from "#veryfront/rendering/ssr-outcome.ts";
+import {
+  findSSRControlOutcome,
+  isMissingProjectSourceError,
+  resolveSSRFailure,
+} from "#veryfront/rendering/ssr-outcome.ts";
 import { REDIRECT_DESTINATION_NOT_ALLOWED } from "#veryfront/errors/index.ts";
 import {
   isRedirectDestinationAllowed,
@@ -22,6 +26,7 @@ import {
   startRenderSession,
 } from "#veryfront/transforms/mdx/esm-module-loader/module-fetcher/index.ts";
 import { getErrorCollector, profilePhase } from "#veryfront/observability";
+import { recordSSRSourceUnavailable } from "#veryfront/observability/simple-metrics/index.ts";
 import { captureApplicationError } from "#veryfront/observability/application-errors.ts";
 import { ErrorOverlay, parseErrorLocation } from "../../dev-server/error-overlay/index.ts";
 import { ErrorPages } from "../../utils/error-html.ts";
@@ -449,7 +454,20 @@ export class SSRService implements SSRServiceLike {
           );
         }
       case "not-found":
-        logger.debug("SSR notFound", { slug });
+        if (isMissingProjectSourceError(error)) {
+          // This 404 used to be a 500, and the error report it raised was the
+          // only thing that made an unreadable release visible. Reclassifying it
+          // must not make it silent, so count it and say so once per request at
+          // a level Loki can alert on -- a routine deletion moves this a bounded
+          // number of times, an API-side regression moves it continuously.
+          recordSSRSourceUnavailable();
+          logger.warn("Project source unavailable; served 404", {
+            slug,
+            projectSlug: ctx.projectSlug,
+          });
+        } else {
+          logger.debug("SSR notFound", { slug });
+        }
         return buildNotFoundResult({
           ...outcome,
           ...mergeDataResponseMetadata([

--- a/src/transforms/esm/http-cache.test.ts
+++ b/src/transforms/esm/http-cache.test.ts
@@ -1207,6 +1207,53 @@ describe("HTTP Bundle Cache", { sanitizeResources: false, sanitizeOps: false }, 
     }
   });
 
+  it("reports a publish-verification invariant as a server fault, not an absent file", async () => {
+    // The bundle write succeeds and the file still is not there. That is a
+    // cache invariant violation -- a 500 -- and it must not borrow the
+    // `file-not-found` identity: SSR routes that slug to a 404, which would
+    // turn disk pressure or an eviction race into a status nothing alerts on.
+    const moduleUrl = "https://93.184.216.34/invariant/module.js";
+    const originalRename = Deno.rename.bind(Deno);
+
+    Deno.rename = async (oldPath, newPath) => {
+      if (
+        String(newPath).includes("veryfront-http-bundle") || String(oldPath).includes(".pending-")
+      ) {
+        await remove(String(oldPath));
+        return;
+      }
+      await originalRename(oldPath, newPath);
+    };
+
+    const mockFetch = (() =>
+      Promise.resolve(
+        new Response("export const loaded = true;", {
+          headers: { "content-type": "application/javascript" },
+        }),
+      )) as typeof fetch;
+
+    try {
+      await withIsolatedHttpCache("vf-esm-invariant-slug-", mockFetch, async (tempDir) => {
+        const error = await assertRejects(() =>
+          cacheHttpImportsToLocal(`import "${moduleUrl}";`, {
+            cacheDir: tempDir,
+            importMap: { imports: {}, scopes: {} },
+          })
+        );
+
+        assertInstanceOf(error, VeryfrontError);
+        assertNotEquals(
+          error.slug,
+          "file-not-found",
+          "an invariant violation must not claim the identity SSR routes to 404",
+        );
+        assertEquals(error.status, 500, "a broken cache invariant is a server fault");
+      });
+    } finally {
+      Deno.rename = originalRename;
+    }
+  });
+
   it("does not retry permanent HTTP module failures", async () => {
     let fetchCount = 0;
     let bodyCancelled = false;

--- a/src/transforms/esm/http-cache.ts
+++ b/src/transforms/esm/http-cache.ts
@@ -10,7 +10,7 @@
 import { createFileSystem, exists, type FileSystem } from "#veryfront/platform/compat/fs.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { rendererLogger as logger } from "#veryfront/utils";
-import { BUILD_FAILED, BUNDLE_ERROR, FILE_NOT_FOUND, retryWithBackoff } from "#veryfront/errors";
+import { BUILD_FAILED, BUNDLE_ERROR, retryWithBackoff } from "#veryfront/errors";
 import { SpanNames } from "#veryfront/observability";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { sanitizeUrlForSpan } from "#veryfront/utils/logger/redact.ts";
@@ -28,6 +28,7 @@ import { unbrand } from "./http-cache-types.ts";
 import { asLocalModuleCode, VeryfrontError } from "./http-cache-invariants.ts";
 import {
   CACHE_DIR_TOKEN,
+  CACHE_INVARIANT_VIOLATION,
   detokenizeAllCachePaths,
   detokenizeCachePaths,
   tokenizeAllCachePaths,
@@ -570,7 +571,7 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
           () => Promise.resolve(),
           async () => {
             if (!(await exists(cachePath))) {
-              throw FILE_NOT_FOUND.create({
+              throw CACHE_INVARIANT_VIOLATION.create({
                 detail:
                   `[HTTP-CACHE] INVARIANT VIOLATION: Redis recovery write succeeded but file does not exist: ${cachePath}`,
               });
@@ -667,7 +668,7 @@ async function cacheHttpModuleInternal(url: string, options: CacheOptions): Prom
       },
       async () => {
         if (!(await exists(cachePath))) {
-          throw FILE_NOT_FOUND.create({
+          throw CACHE_INVARIANT_VIOLATION.create({
             detail:
               `[HTTP-CACHE] INVARIANT VIOLATION: File write succeeded but file does not exist: ${cachePath}`,
           });


### PR DESCRIPTION
Fixes veryfront/veryfront-issue-inbox#705

## Problem

When a project is deleted, the API answers 404 to every read for its release —
the asset manifest and every source file alike. SSR did not recognise that as a
routing condition, so every request to a deleted project returned **500** for as
long as the deployment kept serving it.

Two consequences:

1. A routine deletion looked like a platform fault, and each request was reported
   to the error reporter as an application error.
2. `render-page` logged `Layout module failed to load (non-critical)` at `warn`,
   and the same missing module hard-failed the render milliseconds later. Anyone
   triaging by severity was misled.

## Root cause

`resolveSSRFailure` already knows how to answer this: `resolveSSRControlOutcome`
maps a `file-not-found` `VeryfrontError` to the `not-found` outcome, which
returns 404 with a framework error page.

The defect is that the veryfront-api filesystem adapter never raised that error.
`createNotFoundLikeError` threw a **raw `Error`** with `code: "ENOENT"`, so the
error arrived at SSR with no registry identity, fell through every branch, and
landed on `server-error` → 500.

So the fix is to stop throwing a raw `Error` — per the repo's error-handling
convention, absence is `FILE_NOT_FOUND` from the registry, identified by slug:

```ts
export function createNotFoundLikeError(path: string): NotFoundLikeError {
  return Object.assign(
    FILE_NOT_FOUND.create({ detail: `404 Not Found: ${path}`, context: { path } }),
    { code: "ENOENT" },
  );
}
```

**`resolveSSRFailure` needed no change at all.** No new error was added to the
registry, and no bespoke error-tagging mechanism was introduced — the existing
`file-not-found` slug was already the right identity and was already wired to a
404. `code: "ENOENT"` is retained because `isNotFoundLikeError`, the adapter's
own optional-file catches, and the platform's Node/Deno absence checks all read
it; tests pin that.

`stat-operations.ts` already tested for exactly this shape
(`error.slug === "file-not-found"`), which is further evidence it is the
intended representation for this adapter.

## Two smaller pieces

- `loadModulesInParallel` wrapped a critical page-module failure in a
  `RENDER_ERROR`, which drops the `file-not-found` identity. It now raises
  `FILE_NOT_FOUND` when *every* critical failure was an unretrievable source
  (`every`, matching the neighbouring `tenantBuildFailure`: one module that
  loaded and threw must not be reported as an absent release). Without this a
  deleted project would answer 404 on the layout path and 500 on the page path.
- The `(non-critical)` log is split. When the source is unreachable the apply
  phase reloads from the same place and fails identically, so the render is
  already lost: that logs at `error` and no longer claims non-critical. A
  failure that can still recover in the apply phase logs at `warn`, now saying
  so.

Nothing in the rendering pipeline is restructured.

## Does this leak which projects exist?

Turning a 500 into a 404 changes what an unauthenticated caller can infer, so I
checked what the neighbouring conditions already answer:

- A host that resolves to no project already returns **404**
  (`createProjectNotFoundProxyContext`, `src/proxy/proxy-error-context.ts:49`).
- A project with no active release already returns **404**
  (`createReleaseNotFoundProxyContext`, same file).

After this change a deleted project returns 404 as well — the *same* status as a
project that never existed. Before the change, 500 uniquely marked "this project
existed and its content has vanished", which distinguished a deleted project
from a never-existed host. **The change removes that distinction, so it reduces
existence disclosure rather than adding any.**

The response body is `ErrorPages.notFound(slug)`, which echoes only the caller's
own request path and escapes it. It does not name the project, the release, or
the API URL; the path in the error's `detail`/`context` stays server-side in
logs. I deliberately did **not** route this to `ErrorPages.undeployed()`, whose
text ("This project has not been deployed yet") would assert something about the
project's state that the generic 404 does not.

No path handling, redirect, or auth boundary is touched.

## Tests

Written first, each watched fail:

- `createNotFoundLikeError` raises a `VeryfrontError` with slug `file-not-found`
  and status 404, and still satisfies `isNotFoundLikeError`,
  `isCanonicalNotFoundError`, and `code === "ENOENT"`.
- `SSRService.renderPage` answers **404** for the error the adapter actually
  raises.
- **Regression guard:** a layout that exists but throws still yields
  `server-error` / **500**, as does an unbranded error carrying `code: "ENOENT"`
  or a message reading `404 Not Found`. Message text is never consulted.
- A terminal layout failure logs at `error` without the word "non-critical"; a
  recoverable one still logs at `warn`.
- An unretrievable page module keeps its `file-not-found` identity through
  `loadModulesInParallel`; one that loaded and threw keeps `render-error`.

## Gates

`deno lint`, `deno fmt --check src/`, `deno task typecheck`, and
`deno task test:unit` all pass.
