### PR TITLE
feat(cli): mint protected environment access tokens

### DIFF
--- a/cli/commands/env/command-help.ts
+++ b/cli/commands/env/command-help.ts
@@ -1,0 +1,36 @@
+import type { CommandHelp } from "../../help/types.ts";
+
+export const envHelp: CommandHelp = {
+  name: "env",
+  category: "deploy",
+  description: "Mint a short-lived token for a protected environment",
+  usage: "veryfront env token --env <name> [options]",
+  options: [
+    {
+      flag: "-e, --env, --environment <name>",
+      description: "Environment the token can access",
+    },
+    {
+      flag: "-p, --project <ref>",
+      description: "Project slug or ID (default: the configured project)",
+    },
+    {
+      flag: "-d, --dir <path>",
+      description: "Project directory (default: current directory)",
+    },
+    {
+      flag: "-j, --json",
+      description: "Output a machine-readable JSON envelope",
+    },
+  ],
+  examples: [
+    "veryfront env token --env production",
+    "veryfront env token --env staging --project my-app",
+    "veryfront env token --env production --json",
+  ],
+  notes: [
+    "Requires VERYFRONT_API_TOKEN or an authenticated Veryfront login",
+    "The token is bound to one project and environment and expires after the API-provided lifetime",
+    "Human output contains only the credential. Capture it with command substitution instead of pasting it into another command",
+  ],
+};

--- a/cli/commands/env/command.test.ts
+++ b/cli/commands/env/command.test.ts
@@ -1,0 +1,80 @@
+import "#veryfront/schemas/_test-setup.ts";
+
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ResolvedConfig } from "#cli/shared/config";
+import type { ParsedArgs } from "#cli/shared/types";
+import { mintEnvironmentAccessToken, parseEnvironmentTokenArgs } from "./command.ts";
+
+const config: ResolvedConfig = {
+  apiUrl: "https://control.example.test/api",
+  apiToken: "test-api-key",
+  projectSlug: "configured-project",
+};
+
+describe("veryfront env token", () => {
+  it("requires an environment name", () => {
+    const result = parseEnvironmentTokenArgs({ _: ["env", "token"] } as ParsedArgs);
+
+    assertEquals(result.success, false);
+  });
+
+  it("resolves the selected project before exchanging for its environment", async () => {
+    const calls: unknown[] = [];
+
+    const credential = await mintEnvironmentAccessToken(
+      { environment: "staging", projectReference: "selected-project" },
+      {
+        resolveConfig: () => Promise.resolve(config),
+        createControlPlane: (resolvedConfig) => {
+          calls.push({
+            kind: "config",
+            projectSlug: resolvedConfig.projectSlug,
+            projectId: resolvedConfig.projectId,
+          });
+          return {
+            getProject(reference) {
+              calls.push({ kind: "project", reference });
+              return Promise.resolve({ id: "project-id", slug: "selected-project" });
+            },
+            createEnvironmentAccessToken(target) {
+              calls.push({ kind: "token", target });
+              return Promise.resolve({ accessToken: "bound-token", expiresIn: 300 });
+            },
+          };
+        },
+      },
+    );
+
+    assertEquals(credential, { accessToken: "bound-token", expiresIn: 300 });
+    assertEquals(calls, [
+      { kind: "config", projectSlug: "selected-project", projectId: undefined },
+      { kind: "project", reference: "selected-project" },
+      {
+        kind: "token",
+        target: { projectId: "project-id", environmentName: "staging" },
+      },
+    ]);
+  });
+
+  it("uses the configured project when --project is omitted", async () => {
+    const projectReferences: string[] = [];
+
+    await mintEnvironmentAccessToken(
+      { environment: "production" },
+      {
+        resolveConfig: () => Promise.resolve(config),
+        createControlPlane: () => ({
+          getProject(reference) {
+            projectReferences.push(reference);
+            return Promise.resolve({ id: "configured-id", slug: reference });
+          },
+          createEnvironmentAccessToken: () =>
+            Promise.resolve({ accessToken: "bound-token", expiresIn: 300 }),
+        }),
+      },
+    );
+
+    assertEquals(projectReferences, ["configured-project"]);
+  });
+});

--- a/cli/commands/env/command.test.ts
+++ b/cli/commands/env/command.test.ts
@@ -57,13 +57,17 @@ describe("veryfront env token", () => {
     ]);
   });
 
-  it("uses the configured project when --project is omitted", async () => {
+  it("prefers the linked project id when --project is omitted", async () => {
     const projectReferences: string[] = [];
 
     await mintEnvironmentAccessToken(
       { environment: "production" },
       {
-        resolveConfig: () => Promise.resolve(config),
+        resolveConfig: () =>
+          Promise.resolve({
+            ...config,
+            projectId: "linked-project-id",
+          }),
         createControlPlane: () => ({
           getProject(reference) {
             projectReferences.push(reference);
@@ -75,6 +79,6 @@ describe("veryfront env token", () => {
       },
     );
 
-    assertEquals(projectReferences, ["configured-project"]);
+    assertEquals(projectReferences, ["linked-project-id"]);
   });
 });

--- a/cli/commands/env/command.ts
+++ b/cli/commands/env/command.ts
@@ -1,0 +1,59 @@
+import { defineSchema, lazySchema } from "veryfront/schemas";
+import type { InferSchema } from "veryfront/extensions/schema";
+import { CommonArgs, createArgParser } from "#cli/shared/args";
+import { resolveConfigWithAuth, type ResolvedConfig } from "#cli/shared/config";
+import {
+  createHttpDeployControlPlane,
+  type DeployControlPlane,
+  type EnvironmentAccessToken,
+} from "../../shared/deployment/control-plane.ts";
+
+const getEnvironmentTokenArgsSchema = defineSchema((v) =>
+  v.object({
+    environment: v.string().min(1),
+    projectReference: v.string().min(1).optional(),
+    projectDir: v.string().optional(),
+  })
+);
+
+const EnvironmentTokenArgsSchema = lazySchema(getEnvironmentTokenArgsSchema);
+
+export type EnvironmentTokenOptions = InferSchema<
+  ReturnType<typeof getEnvironmentTokenArgsSchema>
+>;
+
+export const parseEnvironmentTokenArgs = createArgParser(EnvironmentTokenArgsSchema, {
+  environment: CommonArgs.env,
+  projectReference: CommonArgs.projectSlug,
+  projectDir: CommonArgs.projectDir,
+}, { rejectUnknown: true });
+
+type EnvironmentTokenControlPlane = Pick<
+  DeployControlPlane,
+  "getProject" | "createEnvironmentAccessToken"
+>;
+
+export interface EnvironmentTokenDependencies {
+  resolveConfig?: (projectDir?: string) => Promise<ResolvedConfig>;
+  createControlPlane?: (config: ResolvedConfig) => EnvironmentTokenControlPlane;
+}
+
+export async function mintEnvironmentAccessToken(
+  options: EnvironmentTokenOptions,
+  dependencies: EnvironmentTokenDependencies = {},
+): Promise<EnvironmentAccessToken> {
+  const resolveConfig = dependencies.resolveConfig ?? resolveConfigWithAuth;
+  const createControlPlane = dependencies.createControlPlane ?? createHttpDeployControlPlane;
+  const config = await resolveConfig(options.projectDir);
+  const projectReference = options.projectReference ?? config.projectSlug;
+  const targetConfig = options.projectReference
+    ? { ...config, projectId: undefined, projectSlug: projectReference }
+    : config;
+  const controlPlane = createControlPlane(targetConfig);
+  const project = await controlPlane.getProject(projectReference);
+
+  return controlPlane.createEnvironmentAccessToken({
+    projectId: project.id,
+    environmentName: options.environment,
+  });
+}

--- a/cli/commands/env/command.ts
+++ b/cli/commands/env/command.ts
@@ -2,6 +2,7 @@ import { defineSchema, lazySchema } from "veryfront/schemas";
 import type { InferSchema } from "veryfront/extensions/schema";
 import { CommonArgs, createArgParser } from "#cli/shared/args";
 import { resolveConfigWithAuth, type ResolvedConfig } from "#cli/shared/config";
+import { projectApiReference } from "#cli/shared/project-resolution";
 import {
   createHttpDeployControlPlane,
   type DeployControlPlane,
@@ -45,7 +46,7 @@ export async function mintEnvironmentAccessToken(
   const resolveConfig = dependencies.resolveConfig ?? resolveConfigWithAuth;
   const createControlPlane = dependencies.createControlPlane ?? createHttpDeployControlPlane;
   const config = await resolveConfig(options.projectDir);
-  const projectReference = options.projectReference ?? config.projectSlug;
+  const projectReference = options.projectReference ?? projectApiReference(config);
   const targetConfig = options.projectReference
     ? { ...config, projectId: undefined, projectSlug: projectReference }
     : config;

--- a/cli/commands/env/handler.test.ts
+++ b/cli/commands/env/handler.test.ts
@@ -1,0 +1,102 @@
+import "#veryfront/schemas/_test-setup.ts";
+
+import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ParsedArgs } from "#cli/shared/types";
+import { setJsonMode } from "../../shared/json-output.ts";
+import type { EnvironmentTokenDependencies } from "./command.ts";
+import { handleEnvCommand } from "./handler.ts";
+
+const dependencies: EnvironmentTokenDependencies = {
+  resolveConfig: () =>
+    Promise.resolve({
+      apiUrl: "https://control.example.test/api",
+      apiToken: "test-api-key",
+      projectSlug: "my-project",
+    }),
+  createControlPlane: () => ({
+    getProject: () => Promise.resolve({ id: "project-id", slug: "my-project" }),
+    createEnvironmentAccessToken: () =>
+      Promise.resolve({ accessToken: "bound-token", expiresIn: 300 }),
+  }),
+};
+
+async function captureConsole(fn: () => Promise<void>): Promise<{
+  stdout: string[];
+  stderr: string[];
+}> {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  const originalWarn = console.warn;
+  console.log = (...args: unknown[]) => stdout.push(args.map(String).join(" "));
+  console.error = (...args: unknown[]) => stderr.push(args.map(String).join(" "));
+  console.warn = (...args: unknown[]) => stderr.push(args.map(String).join(" "));
+  try {
+    await fn();
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+    console.warn = originalWarn;
+  }
+  return { stdout, stderr };
+}
+
+describe("handleEnvCommand", () => {
+  it("prints only the token in human mode, including with --verbose", async () => {
+    setJsonMode(false);
+
+    const output = await captureConsole(() =>
+      handleEnvCommand(
+        { _: ["env", "token"], env: "production", verbose: true } as ParsedArgs,
+        dependencies,
+      )
+    );
+
+    assertEquals(output, { stdout: ["bound-token"], stderr: [] });
+  });
+
+  it("prints the standard JSON envelope with the API expiry", async () => {
+    setJsonMode(true);
+    try {
+      const output = await captureConsole(() =>
+        handleEnvCommand(
+          { _: ["env", "token"], env: "production", json: true } as ParsedArgs,
+          dependencies,
+        )
+      );
+
+      assertEquals(output.stderr, []);
+      assertEquals(output.stdout.length, 1);
+      assertEquals(JSON.parse(output.stdout[0]), {
+        success: true,
+        command: "env",
+        data: {
+          access_token: "bound-token",
+          expires_in: 300,
+        },
+      });
+    } finally {
+      setJsonMode(false);
+    }
+  });
+
+  it("rejects an unknown subcommand as a usage error", async () => {
+    const error = await assertRejects(() =>
+      handleEnvCommand({ _: ["env", "tokens"] } as ParsedArgs, dependencies)
+    );
+
+    assertStringIncludes(String(error), "Unknown env subcommand: tokens");
+    assertEquals((error as { exitCode?: number }).exitCode, 2);
+  });
+
+  it("requires the token subcommand", async () => {
+    const error = await assertRejects(() =>
+      handleEnvCommand({ _: ["env"] } as ParsedArgs, dependencies)
+    );
+
+    assertStringIncludes(String(error), "Environment subcommand is required");
+    assertEquals((error as { exitCode?: number }).exitCode, 2);
+  });
+});

--- a/cli/commands/env/handler.test.ts
+++ b/cli/commands/env/handler.test.ts
@@ -1,6 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
 
-import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { ParsedArgs } from "#cli/shared/types";
 import { setJsonMode } from "../../shared/json-output.ts";
@@ -69,7 +74,9 @@ describe("handleEnvCommand", () => {
 
       assertEquals(output.stderr, []);
       assertEquals(output.stdout.length, 1);
-      assertEquals(JSON.parse(output.stdout[0]), {
+      const [jsonOutput] = output.stdout;
+      assertExists(jsonOutput);
+      assertEquals(JSON.parse(jsonOutput), {
         success: true,
         command: "env",
         data: {

--- a/cli/commands/env/handler.ts
+++ b/cli/commands/env/handler.ts
@@ -1,0 +1,39 @@
+import type { ParsedArgs } from "#cli/shared/types";
+import { parseArgsOrThrow } from "#cli/shared/args";
+import { INVALID_ARGUMENT } from "veryfront/errors";
+import { createSuccessEnvelope, isJsonMode, outputJson } from "../../shared/json-output.ts";
+import {
+  type EnvironmentTokenDependencies,
+  mintEnvironmentAccessToken,
+  parseEnvironmentTokenArgs,
+} from "./command.ts";
+
+export async function handleEnvCommand(
+  args: ParsedArgs,
+  dependencies: EnvironmentTokenDependencies = {},
+): Promise<void> {
+  const subcommand = args._[1];
+  if (typeof subcommand !== "string" || subcommand.length === 0) {
+    throw INVALID_ARGUMENT.create({
+      detail: "Environment subcommand is required. Usage: veryfront env token --env <name>",
+    });
+  }
+  if (subcommand !== "token") {
+    throw INVALID_ARGUMENT.create({
+      detail: `Unknown env subcommand: ${
+        String(subcommand)
+      }. Usage: veryfront env token --env <name>`,
+    });
+  }
+
+  const options = parseArgsOrThrow(parseEnvironmentTokenArgs, "env token", args);
+  const credential = await mintEnvironmentAccessToken(options, dependencies);
+  if (isJsonMode()) {
+    await outputJson(createSuccessEnvelope("env", {
+      access_token: credential.accessToken,
+      expires_in: credential.expiresIn,
+    }));
+    return;
+  }
+  console.log(credential.accessToken);
+}

--- a/cli/help/command-definitions.test.ts
+++ b/cli/help/command-definitions.test.ts
@@ -26,6 +26,7 @@ describe("command-definitions", () => {
       assertExists(COMMANDS.uploads);
       assertExists(COMMANDS.files);
       assertExists(COMMANDS.knowledge);
+      assertExists(COMMANDS.env);
     });
 
     it("each command has required properties", () => {

--- a/cli/help/command-definitions.ts
+++ b/cli/help/command-definitions.ts
@@ -28,6 +28,7 @@ import { filesHelp } from "../commands/files/command-help.ts";
 import { knowledgeHelp } from "../commands/knowledge/command-help.ts";
 import { mergeHelp } from "../commands/merge/command-help.ts";
 import { deployHelp } from "../commands/deploy/command-help.ts";
+import { envHelp } from "../commands/env/command-help.ts";
 import { upHelp } from "../commands/up/command-help.ts";
 import { scheduleHelp } from "../commands/schedule/command-help.ts";
 import { schedulesHelp } from "../commands/schedules/command-help.ts";
@@ -79,6 +80,7 @@ export const COMMANDS: CommandRegistry = {
   knowledge: knowledgeHelp,
   merge: mergeHelp,
   deploy: deployHelp,
+  env: envHelp,
   up: upHelp,
   schedule: scheduleHelp,
   schedules: schedulesHelp,

--- a/cli/router.test.ts
+++ b/cli/router.test.ts
@@ -498,6 +498,26 @@ describe("cli/router helpers", () => {
       }
     });
 
+    it("routes env to its subcommand handler", async () => {
+      stubExit();
+      stubConsole();
+      setJsonMode(true);
+      try {
+        const code = await runAndCaptureExit({ _: ["env"], json: true } as ParsedArgs);
+        assertEquals(code, 2);
+        assertEquals(consoleOutput.length, 1);
+        const parsed = JSON.parse(consoleOutput[0]!);
+        assertEquals(parsed.command, "env");
+        assertEquals(parsed.error.registrySlug, "invalid-argument");
+        assertEquals(
+          parsed.error.message,
+          "Environment subcommand is required. Usage: veryfront env token --env <name>",
+        );
+      } finally {
+        restoreAll();
+      }
+    });
+
     const DUPLICATED_BINARY_MESSAGE =
       '  You already included "veryfront". Remove the extra "veryfront" argument and run the command again.';
 

--- a/cli/router.ts
+++ b/cli/router.ts
@@ -54,6 +54,7 @@ const commands: Record<string, CommandLoader> = {
   "knowledge": async () => (await import("./commands/knowledge/index.ts")).handleKnowledgeCommand,
   "merge": async () => (await import("./commands/merge/handler.ts")).handleMergeCommand,
   "deploy": async () => (await import("./commands/deploy/handler.ts")).handleDeployCommand,
+  "env": async () => (await import("./commands/env/handler.ts")).handleEnvCommand,
   "up": async () => (await import("./commands/up/index.ts")).handleUpCommand,
   "schedule": async () => (await import("./commands/schedule/handler.ts")).handleScheduleCommand,
   "schedules": async () => (await import("./commands/schedules/handler.ts")).handleSchedulesCommand,

--- a/cli/shared/deployment/control-plane.test.ts
+++ b/cli/shared/deployment/control-plane.test.ts
@@ -39,7 +39,7 @@ async function collectReleaseFiles(files: AsyncIterable<DeployReleaseFile>) {
 }
 
 describe("createHttpDeployControlPlane", () => {
-  it("exchanges the API key for an environment access token", async () => {
+  it("preserves the environment access token expiry returned by the API", async () => {
     const calls: Array<{ path: string; body: unknown }> = [];
     const controlPlane = createHttpDeployControlPlane(
       config,
@@ -60,7 +60,10 @@ describe("createHttpDeployControlPlane", () => {
         projectId: "11111111-1111-4111-8111-111111111111",
         environmentName: "production",
       }),
-      "eyJhbGciOiJSUzI1NiJ9.eyJ1c2VySWQiOiJ1XzEifQ.sig",
+      {
+        accessToken: "eyJhbGciOiJSUzI1NiJ9.eyJ1c2VySWQiOiJ1XzEifQ.sig",
+        expiresIn: 300,
+      },
     );
     assertEquals(calls, [{
       path: "/auth/environment-token",
@@ -69,6 +72,31 @@ describe("createHttpDeployControlPlane", () => {
         environment_name: "production",
       },
     }]);
+  });
+
+  it("rejects an environment access token without a positive integer expiry", async () => {
+    for (const expiresIn of [undefined, 0, 1.5]) {
+      const controlPlane = createHttpDeployControlPlane(
+        config,
+        mockClientReturning({
+          post: () =>
+            Promise.resolve({
+              access_token: "eyJhbGciOiJSUzI1NiJ9.eyJ1c2VySWQiOiJ1XzEifQ.sig",
+              expires_in: expiresIn,
+            }),
+        }),
+      );
+
+      await assertRejects(
+        () =>
+          controlPlane.createEnvironmentAccessToken({
+            projectId: "11111111-1111-4111-8111-111111111111",
+            environmentName: "production",
+          }),
+        Error,
+        "positive integer expiry",
+      );
+    }
   });
 
   it("treats only not-found release asset manifests as polling absence", async () => {

--- a/cli/shared/deployment/control-plane.ts
+++ b/cli/shared/deployment/control-plane.ts
@@ -86,7 +86,9 @@ export interface DeployControlPlane {
    * environment. The API authorizes the key for that target and refuses the
    * token as a session.
    */
-  createEnvironmentAccessToken(target: EnvironmentAccessTarget): Promise<string>;
+  createEnvironmentAccessToken(
+    target: EnvironmentAccessTarget,
+  ): Promise<EnvironmentAccessToken>;
 }
 
 export interface EnvironmentAccessTarget {
@@ -94,8 +96,14 @@ export interface EnvironmentAccessTarget {
   environmentName: string;
 }
 
+export interface EnvironmentAccessToken {
+  accessToken: string;
+  expiresIn: number;
+}
+
 interface WireEnvironmentAccessToken {
   access_token: string;
+  expires_in: number;
 }
 
 interface WireEnvironmentDeployment {
@@ -352,7 +360,11 @@ export function createHttpDeployControlPlane(
       if (typeof token !== "string" || token.length === 0) {
         throw new Error("The API did not return an environment access token");
       }
-      return token;
+      const expiresIn = response?.expires_in;
+      if (typeof expiresIn !== "number" || !Number.isInteger(expiresIn) || expiresIn <= 0) {
+        throw new Error("The API did not return a positive integer expiry");
+      }
+      return { accessToken: token, expiresIn };
     },
   };
 }

--- a/cli/shared/deployment/deploy-project.ts
+++ b/cli/shared/deployment/deploy-project.ts
@@ -1088,9 +1088,11 @@ async function resolveEnvironmentAccess(
 ): Promise<EnvironmentAccess> {
   if (isSessionCredential(apiToken)) return { kind: "session" };
   try {
-    const token = await controlPlane.createEnvironmentAccessToken(target);
-    if (!isSessionCredential(token)) return { kind: "unavailable", failure: "unusable" };
-    return { kind: "exchanged", token };
+    const credential = await controlPlane.createEnvironmentAccessToken(target);
+    if (!isSessionCredential(credential.accessToken)) {
+      return { kind: "unavailable", failure: "unusable" };
+    }
+    return { kind: "exchanged", token: credential.accessToken };
   } catch (error) {
     return classifyEnvironmentAccessFailure(error);
   }

--- a/cli/test-utils/deploy-test-support.ts
+++ b/cli/test-utils/deploy-test-support.ts
@@ -23,6 +23,7 @@ import type {
   DeployProjectRecord,
   DeployRelease,
   DeployReleaseFile,
+  EnvironmentAccessToken,
 } from "../shared/deployment/control-plane.ts";
 
 export const CONTROL_PLANE = "https://control.example.test/api";
@@ -308,7 +309,7 @@ export class InMemoryDeployControlPlane implements DeployControlPlane {
 
   async createEnvironmentAccessToken(
     target: { projectId: string; environmentName: string },
-  ): Promise<string> {
+  ): Promise<EnvironmentAccessToken> {
     this.environmentAccessTokenRequests.push({ ...target });
     if (this.environmentAccessToken === null) {
       // Shaped like the CLI API client's error: a status, and a message that
@@ -320,7 +321,7 @@ export class InMemoryDeployControlPlane implements DeployControlPlane {
         { status: this.environmentAccessTokenFailureStatus },
       );
     }
-    return this.environmentAccessToken;
+    return { accessToken: this.environmentAccessToken, expiresIn: 300 };
   }
 
   async getDeployment(_reference: string, deploymentId: string): Promise<DeployDeployment> {

--- a/docs/api-reference/veryfront/cli.md
+++ b/docs/api-reference/veryfront/cli.md
@@ -38,6 +38,7 @@ The CLI groups commands by category. Each command supports `--help` for its full
 | Command            | Description                                           |
 | ------------------ | ----------------------------------------------------- |
 | `veryfront deploy` | Promote a branch to an environment                    |
+| `veryfront env`    | Mint a short-lived token for a protected environment  |
 | `veryfront lock`   | Manage remote import lockfile for reproducible builds |
 | `veryfront merge`  | Merge a branch into main (or another branch)          |
 | `veryfront pull`   | Download project files from Veryfront remote          |

--- a/docs/guides/cloud-environment-access.md
+++ b/docs/guides/cloud-environment-access.md
@@ -41,18 +41,16 @@ authenticates the CLI against the Cloud API, not requests to the deployed app.
 Exchange it for an environment access token for the key owner instead. The gate
 accepts it for five minutes, and the Cloud API refuses it as a session.
 `veryfront deploy` performs this exchange to probe the environment it
-deployed. A CI smoke test can do the same:
+deployed. Use `veryfront env token` to mint the same bound credential for a
+manual check or a later CI smoke test:
 
 ```bash
 set -euo pipefail
-TOKEN=$(curl -fsS -X POST https://api.veryfront.com/auth/environment-token \
-  -H "Authorization: Bearer $VERYFRONT_API_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{"project_reference":"<PROJECT_ID>","environment_name":"production"}' |
-  jq -er '.access_token | strings | select(length > 0)')
-STATUS=$(curl -sS -o /dev/null -w '%{http_code}' --cookie "authToken=$TOKEN" \
-  <environment-url>/<route>)
+TOKEN="$(veryfront env token --env production --project <PROJECT_ID>)"
+STATUS="$(curl -sS -o /dev/null -w '%{http_code}' \
+  --cookie "authToken=$TOKEN" <environment-url>/<route>)"
 [ "$STATUS" = "200" ] || { echo "expected 200, got $STATUS" >&2; exit 1; }
+unset TOKEN
 ```
 
 Compare against the status the route normally returns. The probe does not
@@ -62,7 +60,10 @@ minutes and an expired token is refused the same way, so mint it immediately
 before the probe rather than once for a long suite. The token is bound to
 the project and environment named in the exchange. A key scoped to another
 project, or a key whose owner is not a member of the project gets a `403` at
-the exchange.
+the exchange. Human output contains only the token so command substitution can
+capture it without placing the credential in shell history. With `--json`, read
+the token from `.data.access_token` and its API-provided lifetime from
+`.data.expires_in`.
 
 ## Make an environment public
 

--- a/tests/docs/guide-contracts.test.ts
+++ b/tests/docs/guide-contracts.test.ts
@@ -312,7 +312,7 @@ const GUIDE_CONTRACTS: Record<string, GuideContract> = {
       "protected by default",
       "`authToken` cookie",
       "VERYFRONT_API_TOKEN",
-      "/auth/environment-token",
+      "veryfront env token",
       "Public Environment",
       "<environment-url>/<route>",
     ],


### PR DESCRIPTION
## Description

Add `veryfront env token --env <name> [--project <ref>] [--json]` as the supported manual path for minting a short-lived, target-bound environment credential.

- reuse the existing environment-token exchange and validate the API-provided expiry
- resolve the default project exactly like deploy, preferring a canonical local project link
- keep human stdout token-only; use the standard CLI envelope in JSON mode
- share the structured credential response with deploy instead of duplicating its lifetime
- register router/help/docs surfaces and replace the guide's raw endpoint recipe

The command does not widen access: the API remains responsible for refusing mismatched projects/environments, and deploy continues to send only the exchanged credential to the protected gate.

## Related Issue(s)

Closes veryfront/veryfront-issue-inbox#718

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [x] Test update

## Verification

- Deno 2.7.7 full unit gate: 3,985 tests / 30,922 steps, zero failures
- focused command/router/control-plane/deploy/guide suite: 279 steps, zero failures
- `deno task docs:validate`: 52 tests / 108 steps plus 1,399 links, zero failures
- `deno task typecheck`: passed
- focused format and lint checks: passed
- independent final reviews: zero remaining Spec, Standards, or Security findings

Known local-only baseline: `docs:api-reference:check` reports the same 43 generated API-reference files as stale on clean `main` under macOS. Linux CI is the authoritative generator check; those unrelated generated diffs are intentionally excluded.

Not tested locally: live Cloud token mint followed by a protected-environment request; that requires the API exchange deployment.

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `veryfront env token` command to create short-lived access tokens for protected environments.
  * Supports project, directory, JSON output, and configured project options.
  * Provides human-readable token output or structured JSON with expiration details.
  * Added validation for required environment names and command usage.

* **Documentation**
  * Added CLI reference and updated cloud-environment access guidance to use the new command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->