### PR TITLE
fix(api): load route modules on Node without the Uint8Array hex proposal

### DIFF
--- a/scripts/test/npm-install-smoke.sh
+++ b/scripts/test/npm-install-smoke.sh
@@ -15,6 +15,8 @@
 #      package's build output to reach the starter templates
 #   7. the packed ai-agent starter starts under Node and renders over HTTP
 #      without unresolved generated runtime helpers
+#   8. an API route in that starter loads and responds on a Node that lacks the
+#      Uint8Array base64/hex proposal (issue #3968)
 #
 # Requires: `deno task build:npm` output in ./npm, node + npm + curl on PATH.
 set -euo pipefail
@@ -253,6 +255,97 @@ if grep -Eq \
   "$DEV_LOG"; then
   cat "$DEV_LOG" >&2
   fail "packed ai-agent starter logged an SSR module-resolution failure"
+fi
+
+stop_dev_server
+
+echo "== 8. API route loads on a Node without the Uint8Array base64/hex proposal"
+# Regression guard for issue #3968: the API module loader hashed route source
+# with `new Uint8Array(digest).toHex()`. That method is native and unflagged in
+# Deno, so the Deno-native suite never saw it, and it is absent from every Node
+# release before 25 -- so `veryfront dev` returned 500 for *every* API route on
+# the supported Node floor while this smoke test stayed green, because step 7
+# only ever requests `/`.
+#
+# The methods are stripped explicitly rather than relying on the runner's Node
+# version. Node 25 ships them unflagged, so a version-dependent check would go
+# quietly vacuous the moment CI moves off Node 24.
+mkdir -p "$WORKDIR/app/api/health"
+cat > "$WORKDIR/app/api/health/route.ts" <<'ROUTE'
+export async function GET() {
+  return Response.json({ ok: true });
+}
+ROUTE
+
+cat > "$WORKDIR/strip-uint8array-proposal.mjs" <<'PRELOAD'
+// Simulate the oldest supported Node: remove the Uint8Array base64/hex
+// proposal that Deno provides natively.
+for (const method of ["toHex", "toBase64", "setFromHex", "setFromBase64"]) {
+  delete Uint8Array.prototype[method];
+}
+for (const method of ["fromHex", "fromBase64"]) {
+  delete Uint8Array[method];
+}
+PRELOAD
+
+# Negative control: prove the preload actually removes the methods. Without
+# this, a preload that silently stopped working would leave the whole step
+# passing for the wrong reason on a Node that still has them.
+node --import "$WORKDIR/strip-uint8array-proposal.mjs" -e '
+if (typeof Uint8Array.prototype.toHex === "function") process.exit(1);
+if (typeof Uint8Array.prototype.toBase64 === "function") process.exit(1);
+' || fail "strip preload did not remove the Uint8Array proposal methods"
+
+API_PORT="${VF_NPM_API_SMOKE_PORT:-43121}"
+API_LOG="$WORKDIR/veryfront-dev-api.log"
+API_RESPONSE="$WORKDIR/veryfront-api-response.json"
+
+CI=1 \
+NO_COLOR=1 \
+NODE_ENV=development \
+LOG_FORMAT=text \
+VERYFRONT_NO_UPDATE_CHECK=1 \
+VF_DISABLE_LRU_INTERVAL=1 \
+SSR_TRANSFORM_PER_PROJECT_LIMIT=0 \
+REVALIDATION_PER_PROJECT_LIMIT=0 \
+node --import "$WORKDIR/strip-uint8array-proposal.mjs" \
+  node_modules/veryfront/bin/veryfront.js dev --port "$API_PORT" --no-hmr \
+  </dev/null >"$API_LOG" 2>&1 &
+DEV_PID=$!
+
+API_READY=""
+for _attempt in $(seq 1 120); do
+  kill -0 "$DEV_PID" 2>/dev/null || break
+  if grep -q "Ready in" "$API_LOG"; then
+    API_READY="yes"
+    break
+  fi
+  sleep 0.25
+done
+
+if [ "$API_READY" != "yes" ]; then
+  cat "$API_LOG" >&2
+  fail "dev server did not become ready without the Uint8Array proposal"
+fi
+
+API_STATUS="$(curl --silent --show-error --max-time 30 \
+  --output "$API_RESPONSE" --write-out '%{http_code}' \
+  "http://127.0.0.1:$API_PORT/api/health" || true)"
+
+if [ "$API_STATUS" != "200" ]; then
+  echo "--- response body ---" >&2
+  head -c 2000 "$API_RESPONSE" >&2
+  echo >&2
+  cat "$API_LOG" >&2
+  fail "API route returned ${API_STATUS:-none}, expected 200 (issue #3968)"
+fi
+
+grep -q '"ok":true' "$API_RESPONSE" ||
+  fail "API route did not return its JSON body: $(head -c 500 "$API_RESPONSE")"
+
+if grep -q "is not a function" "$API_LOG"; then
+  cat "$API_LOG" >&2
+  fail "dev server logged a missing-method failure while serving the API route"
 fi
 
 stop_dev_server

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -8,6 +8,7 @@ import { loadSecurityConfig } from "./security-config.ts";
 import type { APIRoute, LoadHostModuleOptions, LoadModuleOptions } from "./types.ts";
 import { createError, toError } from "#veryfront/errors";
 import { getEsbuildLoader } from "#veryfront/utils/path-utils.ts";
+import { computeHash, computeHashBytes } from "#veryfront/utils/hash-utils.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import type { FileSystem } from "#veryfront/platform/compat/fs.ts";
 import * as pathHelper from "#veryfront/compat/path";
@@ -121,10 +122,9 @@ export function prepareHandlerModule(options: LoadModuleOptions): Promise<Prepar
             `Prepared API route exceeds the ${MAX_WORKER_MODULE_SOURCE_BYTES}-byte worker limit`,
           );
         }
-        const digest = await crypto.subtle.digest("SHA-256", bytes);
         return Object.freeze({
           source,
-          sha256: new Uint8Array(digest).toHex(),
+          sha256: await computeHashBytes(bytes),
         });
       } catch (error: unknown) {
         const errorMsg = error instanceof Error ? error.message : String(error);
@@ -236,9 +236,7 @@ async function moduleRevision(fs: FileSystem, modulePath: string): Promise<strin
 }
 
 async function hashModuleSource(source: string): Promise<string> {
-  const bytes = new TextEncoder().encode(source);
-  const digest = await crypto.subtle.digest("SHA-256", bytes);
-  return new Uint8Array(digest).toHex();
+  return await computeHash(source);
 }
 
 function loadTSModuleDirect(modulePath: string, revision: string): Promise<APIRoute> {


### PR DESCRIPTION
Fixes #3968.

## The bug

`src/routing/api/module-loader/loader.ts` hashed route module source with
`new Uint8Array(digest).toHex()`. That is the Uint8Array base64/hex proposal — native and
unflagged in Deno, and **absent from every Node release before 25**, where it sits behind V8's
`--js-base-64` and cannot be enabled through `NODE_OPTIONS`.

On the supported Node floor, `veryfront dev` therefore returned `500` for **every API route in
every app**, not just workflow routes:

```
Failed to load API handler: (intermediate value).toHex is not a function
```

## Reproduction

Minimal app — a `package.json` and one `app/api/hello/route.ts` returning `Response.json({ ok: true })`
— against published `veryfront@0.1.1248`:

| Runtime | `Uint8Array.prototype.toHex` | `GET /api/hello` |
| --- | --- | --- |
| Node 22.22.3 | absent | `500` — `toHex is not a function` |
| Node 24.15.0 | absent | `500` |
| Node 25.9.0 | present | `200 {"ok":true}` |
| Node 25.9.0 + strip preload | removed | `500` — identical failure |

Same app, same package, one variable.

## The fix

Reuse the hand-rolled hex encoder already present in `src/utils/hash-utils.ts`, which is how the
rest of the codebase hashes. Net −5/+3 lines in `loader.ts`.

## Why this shipped

`tests (npm install smoke)` already does a clean-room install of the built npm packages and runs a
real dev server **on Node 24 — which lacks the method**. It stayed green because step 7 only ever
requests `/`. Page rendering never touches the API module loader, so a total API outage was
invisible to the one job positioned to catch it.

Step 8 closes that: it drops an API route into the packed starter and requires `200 {"ok":true}`.

**It strips the proposal methods explicitly instead of trusting the runner's Node version.** Node 25
ships them unflagged, so a version-dependent check would go quietly vacuous the moment CI moves off
Node 24 — the same way step 7 was vacuous for this bug. The step asserts the strip actually worked
before relying on it, so a preload that silently stopped working can't leave the step passing for
the wrong reason.

## Verification against the real build

`deno task build:npm` then `bash scripts/test/npm-install-smoke.sh` on Node 24:

| | steps 1–7 | step 8 | exit |
| --- | --- | --- | --- |
| with the fix | pass | **pass** | 0 |
| without the fix (`.toHex()` restored in the built artifact) | pass | **FAIL** — `API route returned 500, expected 200 (issue #3968)` | 1 |

Step 7 passes in both rows. That is the coverage gap, demonstrated rather than asserted.

Also run: `deno task fmt:check`, `deno task lint`, `deno task typecheck`, and
`deno task test src/routing/api/module-loader/ src/routing/api/handler.test.ts src/routing/api/route-executor.test.ts`
(11 passed, 264 steps, 0 failed).

## Deliberately not in this PR

Two more production call sites use the same proposal and are **not** fixed here:

- `src/security/sandbox/worker-generation.ts:74` — `digest.toHex()`
- `src/security/sandbox/worker-script.ts:159-160` — captures both `toBase64` and `toHex` off
  `NativeUint8Array.prototype` at module load

Step 8 does **not** exercise those paths — I confirmed that from the run, rather than assuming the
class is closed. They are the same latent break on the same Node floor and deserve their own change
with their own reproduction; folding them in here on a guess would ship untested edits to the
sandbox. Worth a follow-up issue.

The `.toHex()` calls in test fixtures (`handler.test.ts`, `route-executor.test.ts`,
`worker-script.test.ts`) are left alone — they only run under Deno.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API module loading while preserving existing behavior.
  * Enhanced compatibility when certain Uint8Array encoding methods are unavailable.

* **Tests**
  * Added smoke-test coverage for API routes in the packaged starter.
  * Verified successful server startup, JSON responses, and HTTP 200 health checks in the simulated environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->