### PR TITLE
docs(otel): correct loop child span naming in the workflow tracing README

### DIFF
--- a/extensions/ext-observability-opentelemetry/README.md
+++ b/extensions/ext-observability-opentelemetry/README.md
@@ -96,12 +96,17 @@ name their spans differently, and the difference decides which problem you get:
 Two consequences worth planning for:
 
 - **Span volume.** A map over 10,000 items yields at least 10,000 node spans in a single
-  trace, before any agent spans nested beneath them. The framework applies no cap; use the
-  batch span processor's queue settings (`OTEL_BSP_MAX_QUEUE_SIZE`,
-  `OTEL_BSP_MAX_EXPORT_BATCH_SIZE`) or collector-side tail sampling to bound it.
+  trace, before any agent spans nested beneath them. The framework applies no cap on `items`,
+  so the caller is the only bound on how large a map can get. `OTEL_BSP_MAX_QUEUE_SIZE` and
+  `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` govern the SDK's export buffer, not span generation: once
+  the queue fills, further spans are dropped rather than exported. Collector-side tail
+  sampling decides whether to keep or drop an entire trace, not how many spans it contains.
+  Neither control substitutes for keeping map size bounded at the call site.
 - **Name cardinality.** Backends that aggregate by span name, for example Tempo's metrics
   generator, see one series per map item. Loop iterations add no name cardinality. Drop or
-  rewrite `workflow.node` names at the collector if map fan-out matters for your backend.
+  rewrite the `workflow.node <id>` span name at the collector if map fan-out matters for your
+  backend; `workflow.node.id` is a separate attribute and rewriting the span name leaves it
+  untouched unless you rewrite it too.
 
 `workflow.run` is always a trace root. Started from an instrumented HTTP handler, webhook,
 or approval callback it does **not** join that request's trace: a run is durable work that

--- a/extensions/ext-observability-opentelemetry/README.md
+++ b/extensions/ext-observability-opentelemetry/README.md
@@ -80,22 +80,31 @@ With this extension registered, the workflow executor emits a `workflow.run` spa
 execution and a `workflow.node <id>` span per node, and agent spans nest beneath the node
 that produced them.
 
-Node spans are named after the node id so a trace reads at a glance. Generated child nodes
-carry generated ids — `<map>_0`, `<map>_1`, … for map items and `<loop>_iter_0`,
-`<loop>_iter_1`, … for loop iterations — so a `map` over a large collection, or a long
-`loop`, produces both one span per child and one distinct span _name_ per child. Two consequences worth
-planning for:
+Node spans are named after the node id so a trace reads at a glance. Map and loop children
+name their spans differently, and the difference decides which problem you get:
+
+- **Map children carry generated ids.** A `map` over N items builds children `<map>_0`,
+  `<map>_1`, and so on, so it emits one span per item _and_ one distinct span name per item.
+  The same generated id also lands in `workflow.node.id`.
+- **Loop children keep their authored ids.** A `loop` re-runs the same authored steps once
+  per iteration, so every iteration emits a span carrying that step's own id as both its
+  name and its `workflow.node.id`. Span names stay bounded no matter how long the loop runs,
+  and nothing on the span says which iteration produced it: only the span id and the start
+  timestamp separate iteration 0 from iteration 5. The `<loop>_iter_N` ids that appear in run
+  state are child-graph run ids, not span names, and no span is ever named after one.
+
+Two consequences worth planning for:
 
 - **Span volume.** A map over 10,000 items yields at least 10,000 node spans in a single
   trace, before any agent spans nested beneath them. The framework applies no cap; use the
   batch span processor's queue settings (`OTEL_BSP_MAX_QUEUE_SIZE`,
   `OTEL_BSP_MAX_EXPORT_BATCH_SIZE`) or collector-side tail sampling to bound it.
-- **Name cardinality.** Backends that aggregate by span name — for example Tempo's metrics
-  generator — will see one series per item. Drop or rewrite `workflow.node` names at the
-  collector if that matters for your backend.
+- **Name cardinality.** Backends that aggregate by span name, for example Tempo's metrics
+  generator, see one series per map item. Loop iterations add no name cardinality. Drop or
+  rewrite `workflow.node` names at the collector if map fan-out matters for your backend.
 
 `workflow.run` is always a trace root. Started from an instrumented HTTP handler, webhook,
-or approval callback it does **not** join that request's trace — a run is durable work that
+or approval callback it does **not** join that request's trace: a run is durable work that
 outlives whatever started it. Parked on an approval it can resume days later, so nesting it
 under the request would leave an open span inside a finished trace, and OpenTelemetry's
 default parent-based sampler would let a sampled-out request silently drop the entire run.
@@ -115,7 +124,7 @@ filtering on that attribute reassembles the whole run as it always did.
 
 The link is built from a W3C `traceparent` persisted on the run record when each execution
 claims it. A run executed with tracing disabled simply stores nothing and the next
-execution links to nothing — the chain degrades to `workflow.run_id` correlation.
+execution links to nothing, so the chain degrades to `workflow.run_id` correlation.
 
 Node spans carry `workflow.node.status`, and a failed node or run sets the span status to
 ERROR, so the usual errored-spans filters in Jaeger, Tempo and Datadog work. A cancelled run


### PR DESCRIPTION
The workflow tracing section of the OpenTelemetry extension README claims loop
iterations produce `<loop>_iter_0`, `<loop>_iter_1`, ... span names and therefore
add span-name cardinality. They do not. `${node.id}_iter_${iteration}` in
`src/workflow/executor/dag/loop-node-strategy.ts:175` is the child-graph run
state id, never a span name. `src/workflow/executor/dag/index.ts:481` holds the
only `withSpan` call in the DAG executor and names every node span
`workflow.node ${nodeId}`, where `nodeId` is the authored step id.

Measured on `origin/main` (9d6cdefb86) with a real `BasicTracerProvider` plus
`InMemorySpanExporter`, a 3-iteration loop over one step `body` exports three
spans all named `workflow.node body`, all with `workflow.node.id="body"` and
`workflow.node.attempts=1`. Nothing on the span says which iteration it came
from. So loop naming has the opposite problem from map naming: bounded names,
zero iteration identity.

Changes:

- Split the naming paragraph so map children (generated ids, unbounded names) and
  loop children (authored ids, bounded names, no iteration identity) are stated
  separately.
- Scope the name-cardinality warning to map fan-out and say loop iterations add
  none.
- Remove the six em dash characters in this file, which AGENTS.md forbids in
  public copy.

No behavior change. The retry-sibling paragraph is unchanged and was re-verified
against the same measurement: an exhausted composite retry exports sibling spans
identical in name, status and attributes with `workflow.node.attempts=1` on each.

Related: veryfront/veryfront-issue-inbox#720.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how map and loop child spans are named and identified.
  * Explained that map items use generated identifiers and distinct span names, while loop iterations retain authored step names.
  * Distinguished span names from the `workflow.node.id` attribute for cardinality guidance.
  * Clarified that export buffering and tail sampling can drop spans or traces but do not limit map generation.
  * Noted that loop iteration identifiers in run state are child-graph run IDs, not span names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->