### PR TITLE
fix(init): exit non-zero when the target directory already exists

### DIFF
--- a/cli/commands/init/init-command.test.ts
+++ b/cli/commands/init/init-command.test.ts
@@ -5,7 +5,7 @@ import "#veryfront/schemas/_test-setup.ts";
  * Tests the init command types and options validation.
  */
 
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { exists, makeTempDir, remove } from "#veryfront/testing/deno-compat.ts";
 import { cwd } from "veryfront/platform";
@@ -178,5 +178,40 @@ describe("InitCommand Types", () => {
     it("should default runtime to undefined when not specified", () => {
       assertEquals(options.runtime, undefined);
     });
+  });
+});
+
+describe("initCommand target directory", () => {
+  it("rejects an existing target directory so the CLI exits non-zero", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-init-existing-" });
+    const name = "taken";
+    const keepsake = join(parentDir, name, "README.md");
+
+    try {
+      await Deno.mkdir(join(parentDir, name));
+      await Deno.writeTextFile(keepsake, "keep me\n");
+
+      // `veryfront init x && cd x && npm run dev` must stop at the refusal. A
+      // printed message with a zero exit lets the chain run on in the wrong
+      // directory, so the refusal has to surface as an error, not a return.
+      await assertRejects(
+        () =>
+          initCommand({
+            name,
+            parentDir,
+            template: "minimal",
+            skipInstall: true,
+            skipEnvPrompt: true,
+            quiet: true,
+          }),
+        Error,
+        `Directory "${name}" already exists`,
+      );
+
+      assertEquals(await Deno.readTextFile(keepsake), "keep me\n");
+      assertEquals(await exists(join(parentDir, name, "app")), false);
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
   });
 });

--- a/cli/commands/init/init-command.ts
+++ b/cli/commands/init/init-command.ts
@@ -4,7 +4,7 @@
  *******************************/
 
 import { cliLogger as logger, isVerbose } from "#cli/utils";
-import { brand, dim, red } from "#cli/ui";
+import { brand, dim } from "#cli/ui";
 import { createTransientSpinner } from "../../ui/progress.ts";
 import { join } from "veryfront/platform/path";
 import { createError, toError } from "veryfront/errors";
@@ -141,17 +141,19 @@ export async function initCommand(
     }
   }
 
-  // Check if directory already exists before entering the wizard
+  // Refuse an existing directory before entering the wizard. This has to be an
+  // error rather than a printed message: `veryfront init x && cd x` must stop
+  // here, not carry on into a directory that was never scaffolded.
   if (name && !options.force) {
     const fs = createFileSystem();
-    const targetDir = join(parentDir, name);
-    if (await fs.exists(targetDir)) {
-      console.error(
-        red(
-          `Directory "${name}" already exists. Choose a different name or use --force to overwrite.`,
-        ),
+    if (await fs.exists(join(parentDir, name))) {
+      throw toError(
+        createError({
+          type: "config",
+          message:
+            `Directory "${name}" already exists. Choose a different name or use --force to overwrite.`,
+        }),
       );
-      return;
     }
   }
 


### PR DESCRIPTION
## Summary
- `veryfront init <name>` refused an existing directory by printing a message and returning, so the process exited 0. `veryfront init app && cd app && npm run dev` in a script or CI then carried on into a directory that was never scaffolded.
- The pre-wizard refusal in `cli/commands/init/init-command.ts` now throws the same config error the post-wizard check already throws; the CLI maps it to a non-zero exit.

Found by the `vf-dx-dogfood` edge-case pass against published `veryfront@0.1.1251`.

## Test plan
- [x] RED: new `initCommand` test "rejects an existing target directory so the CLI exits non-zero" failed on main (`assertRejects` saw a resolved promise)
- [x] GREEN after the fix; `cli/commands/init/` + `cli/shared/project-creation.test.ts` (13 files, 172 steps) pass
- [x] Pass 2 from a sandbox outside the repo: `deno run -A cli/main.ts init existing --template minimal` → exit 1, existing `README.md` untouched
- [x] `deno lint`, `deno fmt --check`, `lint:anti-slop`, `lint:sanitizer-baseline`, `lint:test-typecheck`, `docs:api-reference:check` clean

Follow-up (not in this PR): an existing *empty* directory is still refused; create-vite/create-next-app accept one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The initialization command now clearly reports an error when the target directory already exists.
  * Existing files are protected from accidental changes when initialization is refused.
  * Forced initialization continues to support overwriting existing directories when explicitly requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->