### PR TITLE
fix(dev): resolve --port 0 to a real port before the server starts

### DIFF
--- a/cli/commands/dev/command.ts
+++ b/cli/commands/dev/command.ts
@@ -112,7 +112,8 @@ export async function startDevServerOnFreePort<T>(
   start: (port: number) => Promise<T>,
 ): Promise<{ server: T; port: number }> {
   const port = await findAvailablePort(requestedPort);
-  if (port !== requestedPort) {
+  // Port 0 asked for any free port, so landing elsewhere took nothing away.
+  if (requestedPort !== 0 && port !== requestedPort) {
     console.log();
     console.log(`  ${warning("!")} Port ${requestedPort} is in use, using ${port} instead`);
   }

--- a/cli/commands/dev/dev.test.ts
+++ b/cli/commands/dev/dev.test.ts
@@ -409,3 +409,26 @@ describe("cli/commands/dev", () => {
     });
   });
 });
+
+describe("cli/commands/dev: --port 0", () => {
+  it("hands the server a concrete port and reports that same port", async () => {
+    const startedOn: number[] = [];
+    const logged: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => logged.push(args.map(String).join(" "));
+
+    try {
+      const started = await startDevServerOnFreePort(0, (port) => {
+        startedOn.push(port);
+        return Promise.resolve(null);
+      });
+
+      assert(started.port > 0, `expected a real port, got ${started.port}`);
+      assertEquals(startedOn, [started.port]);
+      // The user asked for "any port", so nothing was taken from them.
+      assertEquals(logged.some((line) => line.includes("is in use")), false);
+    } finally {
+      console.log = originalLog;
+    }
+  });
+});

--- a/cli/commands/dev/port-fallback.test.ts
+++ b/cli/commands/dev/port-fallback.test.ts
@@ -330,3 +330,17 @@ describe("cli/commands/dev/port-fallback", () => {
     });
   });
 });
+
+describe("cli/commands/dev/port-fallback: port 0", () => {
+  it("resolves --port 0 to a concrete ephemeral port before the server starts", async () => {
+    // Everything downstream of the dev server - the MCP port, VERYFRONT_DEV_PORT,
+    // the module server URL, the printed http://localhost:<port> - is derived
+    // from the number the server was handed. Handing it 0 would let the OS pick
+    // a port nothing else is told about.
+    const port = await findAvailablePort(0);
+
+    assert(port > 0, `expected a real port, got ${port}`);
+    assert(port <= MAX_TCP_PORT, `expected a TCP port, got ${port}`);
+    assertEquals(await isPortAvailable(port), true);
+  });
+});

--- a/cli/commands/dev/port-fallback.ts
+++ b/cli/commands/dev/port-fallback.ts
@@ -140,7 +140,43 @@ export async function isPortAvailable(port: number): Promise<boolean> {
 }
 
 /**
+ * Asks the OS for an unused ephemeral port and releases it again.
+ *
+ * Same runtime split as `isPortAvailable`, for the same reason: the npm build's
+ * `Deno.listen` is a shim that does not work under a real Deno.
+ */
+async function allocateEphemeralPort(): Promise<number> {
+  const deno = getDenoRuntime();
+  if (deno) {
+    const listener = deno.listen({ hostname: LOCALHOST.IPV4, port: 0 });
+    const { port } = listener.addr as { port: number };
+    listener.close();
+    return port;
+  }
+
+  const net = await import("node:net");
+  return await new Promise<number>((resolve, reject) => {
+    const server = net.createServer();
+    server.unref?.();
+    server.once("error", reject);
+    server.listen({ port: 0, host: LOCALHOST.IPV4, exclusive: true }, () => {
+      const address = server.address();
+      const port = address && typeof address === "object" ? address.port : 0;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+/**
  * Returns `requestedPort`, or the first free port after it.
+ *
+ * Port 0 means "any free port", but it cannot be passed through: everything
+ * downstream - the MCP port, `VERYFRONT_DEV_PORT`, the module server URL, the
+ * printed `http://localhost:<port>` - is derived from the number the dev server
+ * is handed, so handing it 0 lets the OS pick a port nothing else is told
+ * about. It is resolved to a concrete ephemeral port here instead, and checked
+ * with `probe` like any other candidate because the OS pool is per address
+ * family while the dev server needs the port free on all of them.
  *
  * The scan stops at `MAX_TCP_PORT`: a runtime rejects port 65536 as an invalid
  * port rather than as an address in use, so scanning past the end of the range
@@ -157,6 +193,18 @@ export async function findAvailablePort(
   probe: (port: number) => Promise<boolean> = isPortAvailable,
 ): Promise<number> {
   const attempts = Math.max(1, maxAttempts);
+
+  if (requestedPort === 0) {
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      const port = await allocateEphemeralPort();
+      if (await probe(port)) return port;
+    }
+    throw PORT_IN_USE.create({
+      detail: `Could not find a free port after ${attempts} attempts`,
+      context: { requestedPort, attempts },
+    });
+  }
+
   let lastPort = requestedPort;
 
   for (let attempt = 0; attempt < attempts; attempt++) {


### PR DESCRIPTION
## Summary
- `veryfront dev --port 0` (the standard "any free port" request, useful for test harnesses and parallel dev servers) passed the 0 straight through. The app listened on an ephemeral port, but the banner printed `http://localhost:0`, the MCP server tried port 2 (`port + 2`) and warned, and `VERYFRONT_DEV_PORT` / the SSR port / the module server URL were all derived from 0.
- `findAvailablePort` now resolves 0 to a concrete ephemeral port (bound and released, then probed on every address family like any other candidate) before the dev server starts, so everything downstream sees the port the server really binds. The "Port 0 is in use, using N instead" line is skipped for a 0 request since nothing was taken from the user.

Found by the `vf-dx-dogfood` edge-case pass against published `veryfront@0.1.1251`.

## Test plan
- [x] RED: `findAvailablePort(0)` returned 0 and `startDevServerOnFreePort(0, …)` handed the server 0 on main
- [x] GREEN after the fix; `cli/commands/dev/` (11 files, 111 steps incl. the integration tests and the bare-`Deno.` guard) pass
- [x] Pass 2: `deno run -A cli/main.ts dev --port 0` → `http://localhost:63542`, app 200 on 63542, MCP listening on 63544
- [x] `deno lint`, `deno fmt --check`, `deno check`, `lint:anti-slop`, `lint:sanitizer-baseline`, `lint:test-typecheck`, `docs:api-reference:check` clean
