### PR TITLE
fix(workflow): preserve queued recovery reservations

### DIFF
--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -2116,6 +2116,76 @@ describe("DAGExecutor", () => {
       assertEquals(result.nodeStates["side-effect"]!.status, "completed");
     });
 
+    it("does not spend a recovery reserved behind a wait before it starts", async () => {
+      const executed: string[] = [];
+      const persistedReservations: NodeState[] = [];
+      const exec = new DAGExecutor({
+        maxConcurrency: 1,
+        stepExecutor: new MockStepExecutor(new Map(), (node) => {
+          executed.push(node.id);
+          return { success: true, output: node.id, executionTime: 1 };
+        }),
+        onRecoveryScheduled: ({ nodeId, nodeStates }) => {
+          persistedReservations.push(structuredClone(nodeStates[nodeId]!));
+        },
+      });
+      const nodes: WorkflowNode[] = [
+        {
+          id: "gate",
+          dependsOn: [],
+          config: { type: "wait", waitType: "approval", message: "m" } as any,
+        },
+        { id: "side-effect", dependsOn: [], config: { type: "step" } as any },
+      ];
+
+      const first = await exec.execute(
+        nodes,
+        createTestRun({
+          status: "running",
+          nodeStates: {
+            "side-effect": {
+              nodeId: "side-effect",
+              status: "running",
+              attempt: 1,
+              startedAt: new Date(),
+            },
+          },
+        }),
+      );
+
+      assertEquals(first.waiting, true);
+      assertEquals(first.waitingNode, "gate");
+      assertEquals(executed, []);
+      assertEquals(persistedReservations[0]?.attempt, 2);
+      assertEquals(
+        persistedReservations[0]?.startedAt,
+        undefined,
+        "a reserved recovery must remain distinguishable from one that started",
+      );
+
+      const resumed = await exec.execute(
+        nodes,
+        createTestRun({
+          status: "waiting",
+          context: first.context,
+          nodeStates: {
+            ...first.nodeStates,
+            gate: {
+              ...first.nodeStates.gate!,
+              status: "completed",
+              completedAt: new Date(),
+            },
+          },
+        }),
+      );
+
+      assertEquals(resumed.error, undefined);
+      assertEquals(resumed.completed, true);
+      assertEquals(executed, ["side-effect"]);
+      assertEquals(resumed.nodeStates["side-effect"]!.status, "completed");
+      assertEquals(resumed.nodeStates["side-effect"]!.attempt, 2);
+    });
+
     it("never reports completion while an interrupted step is out of budget", async () => {
       // The same shape once the budget is gone. Failing loudly is the only
       // honest answer; reporting success would drop the step on the floor.

--- a/src/workflow/executor/dag/index.ts
+++ b/src/workflow/executor/dag/index.ts
@@ -186,28 +186,35 @@ export class DAGExecutor {
         //
         // An interrupted attempt never finished, so it does not consume the
         // node's retry budget outright -- a default node still gets recovered
-        // once. What it does consume is one recovery: the count below is
-        // written back before scheduling, and nothing overwrites it if the
-        // worker dies again, so the next resume sees a higher number.
+        // once. Reserve that recovery durably before queueing it. Clearing
+        // startedAt distinguishes a reservation from a recovery that entered a
+        // batch; the batch-start boundary restores and persists startedAt before
+        // any side effect can run.
         const maxAttempts = node.config.retry?.maxAttempts ?? 1;
         const attempts = state.attempt ?? 0;
-        if (attempts > maxAttempts) {
+        const recoveryReserved = state.startedAt === undefined;
+        const largestValidAttempt = maxAttempts + (recoveryReserved ? 1 : 0);
+        if (attempts > largestValidAttempt) {
           exhausted.push({ nodeId, attempts, maxAttempts });
           continue;
         }
-        nodeStates[nodeId] = { ...state, attempt: attempts + 1 };
-        if (isDurableRun) {
-          const recovered = await this.config.onRecoveryScheduled?.({
-            runId: scope.rootRunId,
-            nodeId,
-            nodeStates: structuredClone(nodeStates),
-            ownership: scope.ownership,
-          });
-          if (recovered === false) {
-            throw ORCHESTRATION_ERROR.create({
-              detail:
-                `Cannot recover workflow node "${nodeId}" because execution ownership changed`,
+        if (!recoveryReserved) {
+          const reservation: NodeState = { ...state, attempt: attempts + 1 };
+          delete reservation.startedAt;
+          nodeStates[nodeId] = reservation;
+          if (isDurableRun) {
+            const recovered = await this.config.onRecoveryScheduled?.({
+              runId: scope.rootRunId,
+              nodeId,
+              nodeStates: structuredClone(nodeStates),
+              ownership: scope.ownership,
             });
+            if (recovered === false) {
+              throw ORCHESTRATION_ERROR.create({
+                detail:
+                  `Cannot recover workflow node "${nodeId}" because execution ownership changed`,
+              });
+            }
           }
         }
         ready.push(nodeId);

--- a/src/workflow/executor/workflow-executor.test.ts
+++ b/src/workflow/executor/workflow-executor.test.ts
@@ -462,6 +462,10 @@ describe("workflow/executor/workflow-executor", () => {
     assertEquals(persistedWhileRunning.workerId, "run-execution:old-owner");
     assertEquals(persistedWhileRunning.nodeStates["side-effect"]?.attempt, 2);
     assertEquals(persistedWhileRunning.nodeStates["side-effect"]?.status, "running");
+    assertExists(
+      persistedWhileRunning.nodeStates["side-effect"]?.startedAt,
+      "a started recovery must be durably distinguishable from a queued reservation",
+    );
 
     release.resolve();
     await execution;


### PR DESCRIPTION
## Summary

- distinguish a durably reserved recovery from one that actually entered an execution batch
- reuse a queued reservation across wait and approval-resume passes without spending another attempt
- keep the batch-start node-state write authoritative before any recovered side effect runs
- preserve retry exhaustion after a started recovery crashes again

## Red and green

The new `maxConcurrency: 1` regression starts with a parked wait ahead of an interrupted step. Before the fix, recovery persisted `attempt=2` with the old `startedAt`, and the approval-resume pass failed with retry budget exhausted before the step ran.

The reservation now persists `attempt=2` with no `startedAt`. The approval-resume pass reuses that reservation, batch start durably restores `startedAt`, and the side effect executes exactly once. Existing out-of-budget and no-silent-completion tests remain green.

## Verification

- `deno task test:file src/workflow/executor` (12 groups, 201 steps)
- focused DAG regression (113 steps)
- Node targeted executor tests (115 pass)
- Bun targeted executor tests (115 pass)
- `deno task fmt:check`
- `deno task lint`
- `deno task typecheck`
- `deno task docs:api-reference:check`

Refs veryfront/veryfront-issue-inbox#719