### PR TITLE
fix(workflow): fail closed when a child graph stalls

### DIFF
--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -1176,6 +1176,55 @@ describe("DAGExecutor", () => {
       assertEquals(second.nodeStates["after-wait"]!.status, "completed");
     });
 
+    it("fails a resumed iteration whose stale wait leaves its child graph stuck", async () => {
+      const order: string[] = [];
+      const trackingExecutor = new MockStepExecutor(new Map(), (node) => {
+        order.push(node.id);
+        return { success: true, output: node.id, executionTime: 1 };
+      });
+      const exec = new DAGExecutor({ stepExecutor: trackingExecutor });
+      const nodes: WorkflowNode[] = [
+        {
+          id: "the-loop",
+          dependsOn: [],
+          config: {
+            type: "loop",
+            maxIterations: 1,
+            while: (_context: WorkflowContext, loop: LoopExecutionContext) => loop.iteration < 1,
+            steps: [
+              {
+                id: "inner-wait",
+                dependsOn: [],
+                config: { type: "wait", waitType: "approval", message: "approve?" } as any,
+              },
+              { id: "after-wait", dependsOn: ["inner-wait"], config: { type: "step" } as any },
+            ],
+          } as any,
+        },
+      ];
+
+      const first = await exec.execute(nodes, createTestRun());
+      assertEquals(first.waiting, true);
+
+      const nodeStates = { ...first.nodeStates };
+      delete nodeStates["inner-wait"];
+      const second = await exec.execute(
+        nodes,
+        createTestRun({
+          status: "waiting",
+          nodeStates,
+          context: first.context,
+        }),
+      );
+
+      assertEquals(second.completed, false, "an unfinished child graph cannot report success");
+      assertEquals(order, [], "a dependent of the unresolved wait must not execute");
+      assertStringIncludes(second.error ?? "", 'Workflow run "test-run" stalled');
+      assertStringIncludes(second.error ?? "", 'child graph "the-loop_iter_0"');
+      assertStringIncludes(second.error ?? "", '"inner-wait" (running)');
+      assertStringIncludes(second.error ?? "", '"after-wait" (pending)');
+    });
+
     it("removes child node states from previous dynamic loop iterations", async () => {
       const nodes: WorkflowNode[] = [
         {
@@ -1945,6 +1994,47 @@ describe("DAGExecutor", () => {
 
       assertEquals(executed, []);
       assertEquals(result.nodeStates["approve"]!.status, "running");
+    });
+
+    it("bounds the node details reported for a stuck graph", async () => {
+      const blockedNodes: WorkflowNode[] = Array.from({ length: 11 }, (_, index) => ({
+        id: `blocked-${index}`,
+        dependsOn: ["approve"],
+        config: { type: "step" } as any,
+      }));
+      const nodes: WorkflowNode[] = [
+        {
+          id: "approve",
+          dependsOn: [],
+          config: { type: "wait", waitType: "approval", message: "m" } as any,
+        },
+        ...blockedNodes,
+      ];
+      const exec = new DAGExecutor({ stepExecutor: new MockStepExecutor() });
+      const result = await exec.execute(
+        nodes,
+        createTestRun({
+          status: "running",
+          nodeStates: {
+            approve: {
+              nodeId: "approve",
+              status: "running",
+              attempt: 1,
+              startedAt: new Date(),
+            },
+          },
+        }),
+      );
+
+      assertEquals(result.completed, false);
+      assertStringIncludes(result.error ?? "", '"approve" (running)');
+      assertStringIncludes(result.error ?? "", '"blocked-8" (pending)');
+      assertEquals(
+        (result.error ?? "").includes('"blocked-9" (pending)'),
+        false,
+        "the diagnostic must stop after ten node details",
+      );
+      assertStringIncludes(result.error ?? "", "and 2 more");
     });
 
     it("leaves a composite parked on a nested wait alone", async () => {

--- a/src/workflow/executor/dag/index.ts
+++ b/src/workflow/executor/dag/index.ts
@@ -58,6 +58,17 @@ import {
 } from "./context-patch.ts";
 
 const RESUMABLE_COMPOSITE_TYPES = new Set(["branch", "parallel", "map", "loop", "subWorkflow"]);
+const MAX_STALLED_GRAPH_NODE_DETAILS = 10;
+
+function getUnfinishedNodeDetails(
+  nodes: WorkflowNode[],
+  nodeStates: Record<string, NodeState>,
+): Array<{ nodeId: string; status: NodeState["status"] }> {
+  return nodes.flatMap((node) => {
+    const status = nodeStates[node.id]?.status ?? "pending";
+    return status === "completed" || status === "skipped" ? [] : [{ nodeId: node.id, status }];
+  });
+}
 
 export class DAGExecutor {
   private config: DAGExecutorInternalConfig;
@@ -431,6 +442,26 @@ export class DAGExecutor {
         queued.add(nodeId);
         ready.push(nodeId);
       }
+    }
+
+    const unfinished = getUnfinishedNodeDetails(nodes, nodeStates);
+    if (unfinished.length > 0) {
+      const graph = run.id === scope.rootRunId
+        ? "the root graph"
+        : `child graph ${JSON.stringify(run.id)}`;
+      const details = unfinished.slice(0, MAX_STALLED_GRAPH_NODE_DETAILS)
+        .map(({ nodeId, status }) => `${JSON.stringify(nodeId)} (${status})`)
+        .join(", ");
+      const omitted = unfinished.length - MAX_STALLED_GRAPH_NODE_DETAILS;
+      return {
+        completed: false,
+        waiting: false,
+        context,
+        nodeStates,
+        contextPatch,
+        error: `Workflow run ${JSON.stringify(scope.rootRunId)} stalled in ${graph}; ` +
+          `unfinished nodes: ${details}${omitted > 0 ? `, and ${omitted} more` : ""}`,
+      };
     }
 
     return {


### PR DESCRIPTION
## Summary

- Treat an empty ready queue as success only when every declared node is completed or skipped.
- Return a failed DAG result when running or dependency-blocked nodes remain.
- Name the durable run, synthetic child graph, unfinished node IDs, and their statuses in the diagnostic.
- Bound the diagnostic to ten node details so a large workflow cannot create an unbounded error record.

## Root cause

`executeUnwrapped` ended with `completed: true` whenever the ready queue drained. It never checked whether the graph was terminal. A stale loop iteration snapshot could therefore retain a wait as `running`, keep its dependent blocked, schedule nothing, and report the iteration as successful.

The new invariant is evaluated only after scheduling is exhausted. Normal completion is unchanged, waiting still returns from the existing waiting branch, and failed nodes still return from the existing failure branch.

## Red-green TDD

The issue reproduction was added first. Against unchanged source it produced:

```text
fails a resumed iteration whose stale wait leaves its child graph stuck ... FAILED
Actual completed: true
Expected completed: false
FAILED | 0 passed (111 steps) | 1 failed (2 steps)
```

After the fix, the same test proves:

- no dependent step executes,
- `completed` is false,
- the diagnostic names run `test-run`, child graph `the-loop_iter_0`, `inner-wait` as running, and `after-wait` as pending.

A second test proves large stuck graphs report ten node details and an omitted count.

## Verification

- `deno task test:file src/workflow/executor/dag/index.test.ts`: 1 passed, 114 steps
- `deno task test:file src/workflow/executor`: 12 passed, 202 steps
- `deno task test:file src/workflow`: 82 passed, 912 steps
- Node runtime test: 88 tests passed
- Bun runtime test: 1 file passed
- `deno fmt --check`: passed
- `deno lint`: passed
- `deno check src/index.ts`: passed
- `deno task build:npm`: passed
- `deno task generate:manifests:check`: passed
- `deno task docs:api-reference:check`: passed
- `git diff --check`: passed

Fixes veryfront/veryfront-issue-inbox#701