### PR TITLE
fix(renderer): publish cycle artifacts atomically

### DIFF
--- a/src/rendering/orchestrator/module-loader/cycle-manifest.test.ts
+++ b/src/rendering/orchestrator/module-loader/cycle-manifest.test.ts
@@ -8,7 +8,7 @@ import {
   assertThrows,
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { basename, join } from "#veryfront/compat/path/index.ts";
+import { basename, dirname, join } from "#veryfront/compat/path/index.ts";
 import {
   getCycleManifestCacheDir,
 } from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
@@ -186,6 +186,65 @@ describe("module-loader/cycle-manifest", () => {
       assertInstanceOf(error, VeryfrontError);
       assertEquals(error.slug, "cache-error");
       assertEquals(published, false);
+    } finally {
+      await removeFixture(tmpDir);
+    }
+  });
+
+  it("rejects a graph root whose persisted bytes lost their sealed evidence", async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "vf-cycle-manifest-missing-evidence-" });
+    const localAdapter = await getLocalAdapter();
+    const transaction = new CycleManifestTransaction(tmpDir, "missing-evidence");
+    const rootSource = "/project/root.ts";
+    const rootArtifact = transaction.registerEdge(rootSource, rootSource, false);
+
+    try {
+      await Deno.mkdir(dirname(rootArtifact), { recursive: true });
+      await transaction.sealRootArtifactCode(
+        "export const root = true;",
+        rootSource,
+        false,
+        localAdapter,
+      );
+      await Deno.writeTextFile(rootArtifact, "export const root = true;");
+      transaction.recordArtifact(rootSource, rootArtifact, false, true);
+
+      await assertRejects(
+        () => transaction.commit(localAdapter),
+        VeryfrontError,
+        "Cycle manifest root evidence is missing",
+      );
+    } finally {
+      await removeFixture(tmpDir);
+    }
+  });
+
+  it("rejects graph root bytes changed after sealing", async () => {
+    const tmpDir = await Deno.makeTempDir({ prefix: "vf-cycle-manifest-changed-root-" });
+    const localAdapter = await getLocalAdapter();
+    const transaction = new CycleManifestTransaction(tmpDir, "changed-root");
+    const rootSource = "/project/root.ts";
+    const rootArtifact = transaction.registerEdge(rootSource, rootSource, false);
+
+    try {
+      await Deno.mkdir(dirname(rootArtifact), { recursive: true });
+      const sealed = await transaction.sealRootArtifactCode(
+        "export const root = true;",
+        rootSource,
+        false,
+        localAdapter,
+      );
+      await Deno.writeTextFile(
+        rootArtifact,
+        sealed.replace("root = true", "root = false"),
+      );
+      transaction.recordArtifact(rootSource, rootArtifact, false, true);
+
+      await assertRejects(
+        () => transaction.commit(localAdapter),
+        VeryfrontError,
+        "Cycle manifest changed after its root was sealed",
+      );
     } finally {
       await removeFixture(tmpDir);
     }

--- a/src/rendering/orchestrator/module-loader/index.test.ts
+++ b/src/rendering/orchestrator/module-loader/index.test.ts
@@ -730,39 +730,33 @@ describe("module-loader/transformModuleWithDeps", () => {
       },
       async ({ projectDir, tmpDir, config }) => {
         const pagePath = join(projectDir, "app/page.ts");
-        const [firstPath, secondPath] = await Promise.all([
-          transformModuleWithDeps(
-            pagePath,
-            tmpDir,
-            config.adapter,
-            { ...config, moduleCache: new Map() },
-          ),
-          transformModuleWithDeps(
-            pagePath,
-            tmpDir,
-            config.adapter,
-            { ...config, moduleCache: new Map() },
-          ),
-        ]);
-        assertStrictEquals(firstPath, secondPath);
+        const moduleCache = new Map<string, string>();
+        const paths = await Promise.all(
+          Array.from({ length: 8 }, () =>
+            transformModuleWithDeps(
+              pagePath,
+              tmpDir,
+              config.adapter,
+              { ...config, moduleCache },
+            )),
+        );
+        const firstPath = paths[0]!;
+        for (const path of paths) assertStrictEquals(path, firstPath);
 
-        const [firstNamespace, secondNamespace] = await Promise.all([
-          import(toFileUrl(firstPath).href),
-          import(toFileUrl(secondPath).href),
-        ]);
-        const [firstCycleNamespace, secondCycleNamespace] = await Promise.all([
-          firstNamespace.later(),
-          secondNamespace.later(),
-        ]);
+        const namespaces = await Promise.all(
+          paths.map((path) => import(toFileUrl(path).href)),
+        );
+        const cycleNamespaces = await Promise.all(
+          namespaces.map((namespace) => namespace.later()),
+        );
 
-        assertStrictEquals(firstNamespace, secondNamespace);
-        assertStrictEquals(firstCycleNamespace, firstNamespace);
-        assertStrictEquals(secondCycleNamespace, secondNamespace);
-        for (const namespace of [firstNamespace, secondNamespace]) {
+        for (let index = 0; index < namespaces.length; index++) {
+          const namespace = namespaces[index]!;
+          assertStrictEquals(namespace, namespaces[0]);
+          assertStrictEquals(cycleNamespaces[index], namespace);
           const wrapperUrl = namespace.wrapperUrl as string;
           const wrapperPath = fromFileUrl(wrapperUrl);
           assertStringIncludes(wrapperUrl, "/veryfront-cycle-manifests/");
-          assertEquals(namespace.wrapperUrl, wrapperUrl);
           assertEquals(namespace.bracketUrl, wrapperUrl);
           assertEquals(namespace.aliasUrl, wrapperUrl);
           assertEquals(namespace.filename, wrapperPath);

--- a/src/rendering/orchestrator/module-loader/module-persistence.test.ts
+++ b/src/rendering/orchestrator/module-loader/module-persistence.test.ts
@@ -1,11 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assert, assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertNotEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { basename, dirname, join } from "#veryfront/compat/path/index.ts";
 import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
 import {
   makeTempDir,
   mkdir,
+  readDir,
   readTextFile,
   remove,
   writeTextFile,
@@ -37,6 +38,15 @@ function deferred<T = void>(): {
     reject = rej;
   });
   return { promise, resolve, reject };
+}
+
+/** Names of the staging files a cycle publish left behind in its directory. */
+async function stagedArtifactLeftovers(artifactPath: string): Promise<string[]> {
+  const leftovers: string[] = [];
+  for await (const entry of readDir(dirname(artifactPath))) {
+    if (entry.name.startsWith(`${basename(artifactPath)}.pending-`)) leftovers.push(entry.name);
+  }
+  return leftovers;
 }
 
 describe("module-loader/module-persistence", () => {
@@ -183,6 +193,53 @@ describe("module-loader/module-persistence", () => {
       assertEquals(renames.length, 1, "identical later writers must reuse the durable artifact");
       assertEquals(renames[0]?.[1], cycleArtifactPath);
       assertEquals(await readTextFile(cycleArtifactPath), "export const page = 1;");
+      assertEquals(
+        await stagedArtifactLeftovers(cycleArtifactPath),
+        [],
+        "a finished publish must leave no staged file behind",
+      );
+    } finally {
+      await remove(projectDir, { recursive: true }).catch(() => undefined);
+      await remove(tmpDir, { recursive: true }).catch(() => undefined);
+    }
+  });
+
+  it("fails closed and clears staging when a cycle artifact path holds other bytes", async () => {
+    const projectDir = await makeTempDir({ prefix: "vf-module-persist-project-" });
+    const tmpDir = await makeTempDir({ prefix: "vf-module-persist-out-" });
+    const localAdapter = await getLocalAdapter();
+    const cycleArtifactPath = join(tmpDir, "cycle/artifact.js");
+
+    try {
+      await mkdir(dirname(cycleArtifactPath), { recursive: true });
+      await writeTextFile(cycleArtifactPath, "export const page = 0;");
+
+      await assertRejects(
+        () =>
+          persistTransformedModule({
+            filePath: join(projectDir, "app/page.ts"),
+            projectDir,
+            tmpDir,
+            transformedCode: "export const page = 1;",
+            localAdapter,
+            moduleCache: new Map(),
+            cacheKey: "cycle-conflict",
+            cycleArtifactPath,
+          }),
+        Error,
+        "Cycle artifact path contains conflicting content",
+      );
+
+      assertEquals(
+        await readTextFile(cycleArtifactPath),
+        "export const page = 0;",
+        "a conflicting publish must not replace the bytes already at the path",
+      );
+      assertEquals(
+        await stagedArtifactLeftovers(cycleArtifactPath),
+        [],
+        "a rejected publish must leave no staged file behind",
+      );
     } finally {
       await remove(projectDir, { recursive: true }).catch(() => undefined);
       await remove(tmpDir, { recursive: true }).catch(() => undefined);

--- a/src/rendering/orchestrator/module-loader/module-persistence.test.ts
+++ b/src/rendering/orchestrator/module-loader/module-persistence.test.ts
@@ -139,6 +139,56 @@ describe("module-loader/module-persistence", () => {
     }
   });
 
+  it("publishes concurrent cycle artifacts only from complete staged files", async () => {
+    const projectDir = await makeTempDir({ prefix: "vf-module-persist-project-" });
+    const tmpDir = await makeTempDir({ prefix: "vf-module-persist-out-" });
+    const localAdapter = await getLocalAdapter();
+    const cycleArtifactPath = join(tmpDir, "cycle/artifact.js");
+    const writes: string[] = [];
+    const renames: Array<[string, string]> = [];
+    const fs = Object.create(localAdapter.fs) as typeof localAdapter.fs;
+    fs.writeFile = async (path, content) => {
+      writes.push(path);
+      await localAdapter.fs.writeFile(path, content);
+    };
+    fs.rename = async (from, to) => {
+      renames.push([from, to]);
+      await localAdapter.fs.rename!(from, to);
+    };
+    const adapter = Object.create(localAdapter) as typeof localAdapter;
+    Object.defineProperty(adapter, "fs", { value: fs });
+
+    try {
+      const paths = await Promise.all(
+        Array.from({ length: 8 }, (_, index) =>
+          persistTransformedModule({
+            filePath: join(projectDir, "app/page.ts"),
+            projectDir,
+            tmpDir,
+            transformedCode: "export const page = 1;",
+            localAdapter: adapter,
+            moduleCache: new Map(),
+            cacheKey: `cycle-${index}`,
+            cycleArtifactPath,
+          })),
+      );
+
+      assertEquals(paths, Array(8).fill(cycleArtifactPath));
+      assert(
+        writes.every((path) =>
+          path !== cycleArtifactPath && path.startsWith(`${cycleArtifactPath}.pending-`)
+        ),
+        "cycle writers must stage complete bytes away from the published path",
+      );
+      assertEquals(renames.length, 1, "identical later writers must reuse the durable artifact");
+      assertEquals(renames[0]?.[1], cycleArtifactPath);
+      assertEquals(await readTextFile(cycleArtifactPath), "export const page = 1;");
+    } finally {
+      await remove(projectDir, { recursive: true }).catch(() => undefined);
+      await remove(tmpDir, { recursive: true }).catch(() => undefined);
+    }
+  });
+
   it("registers the artifact under the compile mode it was transformed with", async () => {
     const projectDir = await makeTempDir({ prefix: "vf-module-persist-project-" });
     const tmpDir = await makeTempDir({ prefix: "vf-module-persist-out-" });

--- a/src/rendering/orchestrator/module-loader/module-persistence.ts
+++ b/src/rendering/orchestrator/module-loader/module-persistence.ts
@@ -5,6 +5,7 @@
  */
 
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { CACHE_ERROR } from "#veryfront/errors";
 import { join } from "#veryfront/compat/path/index.ts";
 import { rendererLogger } from "#veryfront/utils";
 import { isCacheWriteRaceError } from "#veryfront/utils/cache-file-ops.ts";
@@ -32,6 +33,7 @@ const createdDirs = new Set<string>();
 type ModulePathCacheSave = (cacheDir: string) => Promise<void>;
 
 const pendingModulePathCacheSaves = new Set<Promise<void>>();
+const cycleArtifactPublications = new Map<string, Promise<void>>();
 let modulePathCacheSave: ModulePathCacheSave = saveModulePathCache;
 
 /** Prune oldest entries when cache exceeds limit. */
@@ -97,6 +99,69 @@ async function ensureDir(
 
   createdDirs.add(dir);
   pruneCreatedDirs();
+}
+
+async function readExistingCycleArtifact(
+  adapter: RuntimeAdapter,
+  artifactPath: string,
+): Promise<string | undefined> {
+  try {
+    return await adapter.fs.readFile(artifactPath);
+  } catch (error) {
+    if (isNotFoundError(error)) return undefined;
+    throw error;
+  }
+}
+
+async function publishCycleArtifact(
+  adapter: RuntimeAdapter,
+  artifactPath: string,
+  code: string,
+): Promise<void> {
+  const stagedPath = `${artifactPath}.pending-${crypto.randomUUID()}`;
+  try {
+    await adapter.fs.writeFile(stagedPath, code);
+    const previous = cycleArtifactPublications.get(artifactPath) ?? Promise.resolve();
+    const publication = previous.catch(() => undefined).then(async () => {
+      const existing = await readExistingCycleArtifact(adapter, artifactPath);
+      if (existing !== undefined) {
+        if (existing !== code) {
+          throw CACHE_ERROR.create({
+            detail: "Cycle artifact path contains conflicting content",
+          });
+        }
+        return;
+      }
+      if (!adapter.fs.rename) {
+        throw CACHE_ERROR.create({
+          detail: "Cycle artifact filesystem cannot publish an atomic replacement",
+        });
+      }
+      try {
+        await adapter.fs.rename(stagedPath, artifactPath);
+      } catch (error) {
+        // A different process can win after the read above. Reuse only the
+        // complete artifact with the exact immutable bytes this path denotes.
+        const raced = await readExistingCycleArtifact(adapter, artifactPath);
+        if (raced === code) return;
+        throw error;
+      }
+    }).finally(() => {
+      if (cycleArtifactPublications.get(artifactPath) === publication) {
+        cycleArtifactPublications.delete(artifactPath);
+      }
+    });
+    cycleArtifactPublications.set(artifactPath, publication);
+    await publication;
+  } finally {
+    try {
+      await adapter.fs.remove(stagedPath);
+    } catch (error) {
+      if (!isNotFoundError(error)) {
+        logger.debug("Failed to remove a staged cycle artifact", { error });
+      }
+    }
+  }
 }
 
 export interface PersistTransformedModuleInput {
@@ -574,8 +639,13 @@ export async function persistTransformedModule(
     // Fall through to the write, which retries the mkdir on failure.
   });
 
+  const writeArtifact = () =>
+    input.cycleArtifactPath
+      ? publishCycleArtifact(input.localAdapter, tempFilePath, input.transformedCode)
+      : input.localAdapter.fs.writeFile(tempFilePath, input.transformedCode);
+
   try {
-    await input.localAdapter.fs.writeFile(tempFilePath, input.transformedCode);
+    await writeArtifact();
   } catch (error) {
     // The cache directory can vanish between mkdir and write — a manual
     // `rm -rf .cache`, a cache sweep, or a mkdir that never actually landed.
@@ -591,7 +661,7 @@ export async function persistTransformedModule(
 
     try {
       await ensureDir(input.localAdapter, tempDir, true);
-      await input.localAdapter.fs.writeFile(tempFilePath, input.transformedCode);
+      await writeArtifact();
       logger.debug("Recreated module cache directory after failed write", { tempDir });
     } catch (retryError) {
       logger.error("Failed to write module:", {


### PR DESCRIPTION
## Summary

- Stage graph-content-addressed cycle artifacts under unique sibling paths.
- Serialize publication by final artifact path and atomically rename only complete bytes into visibility.
- Reuse an already-published artifact only when its bytes exactly match; fail closed on conflicting content.
- Leave ordinary non-cycle module persistence unchanged.
- Expand the original race to eight top-level callers sharing the same production-shaped module cache.

## Reachability analysis

A shared `moduleCache` does not prevent the race. It maps cache keys to completed path strings only. It has no in-flight entry. Two concurrent `loadModule` calls can both miss, enter separate top-level cycle-manifest transactions, and write one graph-content-addressed root path.

The existing per-source in-flight sharing is scoped to one `CycleManifestTransaction`, so it cannot coordinate those independent top-level graphs.

Request-wide transform coalescing is not the right fix. It would couple independent cancellation signals and could merge source generations. The shared mutable boundary is artifact publication. Content-addressed graph paths make complete-byte atomic publication the smaller and safer invariant.

## Failure mechanism

`persistTransformedModule` wrote transformed code directly to the final cycle artifact path. A sibling transaction could read that path while the write was incomplete. Its commit then raised either:

- `Cycle manifest root evidence is missing`, or
- `Cycle manifest changed after its root was sealed`.

Each writer now writes a complete unique staging file. Publication for a final path is serialized. The first writer renames its staged file atomically; later identical writers reuse it. The manifest commit can observe an old complete file or the new complete file, never partial bytes.

## Red-green TDD

Red before the implementation:

```text
publishes concurrent cycle artifacts only from complete staged files ... FAILED
AssertionError: cycle writers must stage complete bytes away from the published path
```

That deterministic test runs eight concurrent writers and records every write and rename. The unchanged source wrote all eight directly to the final path and performed no rename.

The original race now also runs eight simultaneous top-level transforms with one shared `moduleCache`. All callers still receive the same path, module namespace, cycle namespace, and `import.meta` identity.

The two corruption guards remain independently reachable and tested:

- removing sealed root evidence still raises `Cycle manifest root evidence is missing`;
- changing root bytes after sealing still raises `Cycle manifest changed after its root was sealed`.

## Verification

- Race stress: 200 consecutive eight-way runs, zero failures
- `module-persistence.test.ts`: 20 steps passed
- `cycle-manifest.test.ts`: 10 steps passed
- `index.test.ts`: 69 steps passed
- `src/rendering/orchestrator/module-loader`: 13 passed / 165 steps
- `src/rendering/orchestrator`: 33 passed / 503 steps
- Node emitted-package test: 20 tests passed
- Bun emitted-package test: 1 file passed
- `deno task build:npm`: passed
- `deno fmt --check`: passed
- `deno lint`: passed
- `deno check src/index.ts`: passed
- `deno task generate:manifests:check`: passed
- `git diff --check`: passed

Fixes veryfront/veryfront-issue-inbox#613