### PR TITLE
fix(init): accept an existing directory unless a scaffold file would be overwritten

### DIFF
--- a/cli/app/operations/project-creation.test.ts
+++ b/cli/app/operations/project-creation.test.ts
@@ -89,4 +89,73 @@ describe("TUI project creation", () => {
       await Deno.remove(configHome, { recursive: true });
     }
   });
+
+  it("refuses a slug whose directory already exists rather than adopting it", async () => {
+    const originalFetch = globalThis.fetch;
+    const envKeys = ["VERYFRONT_API_URL", "VERYFRONT_API_BASE_URL", "XDG_CONFIG_HOME"];
+    const savedEnv = envKeys.map((key) => Deno.env.get(key));
+    const workDir = await Deno.makeTempDir();
+    const configHome = await Deno.makeTempDir();
+    const existingDir = join(workDir, "projects", "my-app");
+
+    try {
+      await Deno.mkdir(join(configHome, "veryfront"), { recursive: true });
+      await Deno.writeTextFile(join(configHome, "veryfront", "token"), TOKEN);
+      Deno.env.set("VERYFRONT_API_URL", API_URL);
+      Deno.env.delete("VERYFRONT_API_BASE_URL");
+      Deno.env.set("XDG_CONFIG_HOME", configHome);
+      _resetEnvironmentConfig();
+
+      // A directory already linked to a different project, holding nothing the
+      // template writes. `veryfront init` scaffolds into a directory like this
+      // on purpose; this caller must not, because it would repoint the link.
+      await Deno.mkdir(join(existingDir, ".veryfront"), { recursive: true });
+      await Deno.writeTextFile(
+        join(existingDir, ".veryfront", "project.json"),
+        '{"projectId":"proj_someone_else"}\n',
+      );
+      await Deno.writeTextFile(join(existingDir, "notes.txt"), "mine\n");
+
+      globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        const url = new URL(request.url);
+        if (request.method === "POST" && url.pathname === "/projects") {
+          return Promise.resolve(Response.json({ id: "proj_new", slug: "my-app" }));
+        }
+        if (request.method === "GET" && url.pathname === "/projects") {
+          return Promise.resolve(Response.json({ data: [], page_info: {} }));
+        }
+        throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
+      }) as typeof fetch;
+
+      const state = await withCwd(workDir, () =>
+        createProject(
+          { state: createInitialState(), render: () => {} },
+          "My App",
+          "minimal",
+        ));
+
+      assertEquals(
+        state.logs.some((entry) => entry.message.includes("projects/my-app already exists")),
+        true,
+      );
+      // The existing link and the existing file are both untouched, and no
+      // scaffold file landed in the directory.
+      assertEquals(
+        (await Deno.readTextFile(join(existingDir, ".veryfront", "project.json"))).trim(),
+        '{"projectId":"proj_someone_else"}',
+      );
+      assertEquals(await Deno.readTextFile(join(existingDir, "notes.txt")), "mine\n");
+      assertEquals(
+        await Deno.stat(join(existingDir, "README.md")).then(() => true, () => false),
+        false,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
+      _resetEnvironmentConfig();
+      await Deno.remove(workDir, { recursive: true });
+      await Deno.remove(configHome, { recursive: true });
+    }
+  });
 });

--- a/cli/app/operations/project-creation.ts
+++ b/cli/app/operations/project-creation.ts
@@ -5,7 +5,7 @@
  * including remote project registration and local scaffolding.
  */
 
-import { cwd } from "veryfront/platform";
+import { createFileSystem, cwd } from "veryfront/platform";
 import { join } from "veryfront/platform/path";
 import type { AppState } from "../state.ts";
 import { addLog, setProjects, setRemoteProjects } from "../state.ts";
@@ -48,6 +48,19 @@ export async function createProject(
     const normalizedSlug = normalizeProjectSlug(projectName);
     const reserved = await reserveProjectSlug(normalizedSlug, token);
     const slug = reserved.slug;
+
+    // `veryfront init` deliberately scaffolds into a directory that is already
+    // there. This caller must not: it has just reserved a brand new remote
+    // slug, and `resolveOrCreateProject` below writes the link for it. Adopting
+    // an existing `projects/<slug>` would point a directory that is already
+    // someone else's project at the project just reserved.
+    const projectDir = join(cwd(), "projects", slug);
+    if (await createFileSystem().exists(projectDir)) {
+      return addLog(
+        "error",
+        `projects/${slug} already exists. Remove it or choose a different name.`,
+      )(state);
+    }
 
     const creation = await createSharedProject({
       name: slug,

--- a/cli/commands/init/init-command.test.ts
+++ b/cli/commands/init/init-command.test.ts
@@ -205,7 +205,7 @@ describe("initCommand target directory", () => {
             quiet: true,
           }),
         Error,
-        `Directory "${name}" already exists`,
+        `Directory "${name}" already contains README.md`,
       );
 
       assertEquals(await Deno.readTextFile(keepsake), "keep me\n");

--- a/cli/commands/init/init-command.ts
+++ b/cli/commands/init/init-command.ts
@@ -6,11 +6,9 @@
 import { cliLogger as logger, isVerbose } from "#cli/utils";
 import { brand, dim } from "#cli/ui";
 import { createTransientSpinner } from "../../ui/progress.ts";
-import { join } from "veryfront/platform/path";
 import { createError, toError } from "veryfront/errors";
 import type { InitOptions, InitRuntime, InitTemplate } from "./types.ts";
 import { cwd } from "veryfront/platform";
-import { createFileSystem } from "veryfront/platform";
 import { getDlxCommand, getInstallCommand, getRunCommand } from "../../utils/package-manager.ts";
 import { createProject, type ProjectCreationObserver } from "../../shared/project-creation.ts";
 import { validateProjectName } from "../../shared/project-name.ts";
@@ -141,22 +139,6 @@ export async function initCommand(
     }
   }
 
-  // Refuse an existing directory before entering the wizard. This has to be an
-  // error rather than a printed message: `veryfront init x && cd x` must stop
-  // here, not carry on into a directory that was never scaffolded.
-  if (name && !options.force) {
-    const fs = createFileSystem();
-    if (await fs.exists(join(parentDir, name))) {
-      throw toError(
-        createError({
-          type: "config",
-          message:
-            `Directory "${name}" already exists. Choose a different name or use --force to overwrite.`,
-        }),
-      );
-    }
-  }
-
   let wizardRuntime: InitRuntime = "node";
   if (shouldRunWizard(options)) {
     const wizardResult = await runInteractiveWizard(name, options.runtime);
@@ -174,19 +156,9 @@ export async function initCommand(
   }
 
   const runtime: InitRuntime = options.runtime ?? wizardRuntime;
-  const projectDir = projectName ? join(parentDir, projectName) : parentDir;
-  if (projectName && !options.force) {
-    const fs = createFileSystem();
-    if (await fs.exists(projectDir)) {
-      throw toError(
-        createError({
-          type: "config",
-          message:
-            `Directory "${projectName}" already exists. Choose a different name or use --force to overwrite.`,
-        }),
-      );
-    }
-  }
+  // Whether the target can be written to is `createProject`'s call: it knows
+  // which files the template ships, so it refuses exactly the files it would
+  // overwrite rather than any directory that happens to exist.
 
   let installSpinner: ReturnType<typeof createTransientSpinner> | null = null;
   const installObserver: ProjectCreationObserver = {

--- a/cli/commands/init/init-deploy.integration.test.ts
+++ b/cli/commands/init/init-deploy.integration.test.ts
@@ -98,8 +98,9 @@ describe("init command integration", () => {
   });
 
   describe("validation", () => {
-    it("should reject existing directories without --force", async () => {
+    it("should reject a directory holding files the template writes without --force", async () => {
       await mkdir(projectDir);
+      await writeTextFile(join(projectDir, "README.md"), "mine");
 
       const result = await runInitCommand(projectName, [
         "-t",
@@ -107,7 +108,8 @@ describe("init command integration", () => {
         "--skip-install",
         "--skip-env-prompt",
       ]);
-      assertEquals(result.code !== 0 || (result.stderr ?? "").includes("already exists"), true);
+      assertEquals(result.code !== 0, true);
+      assertEquals((result.stderr ?? "").includes("already contains README.md"), true);
     });
 
     it("should overwrite with --force flag", async () => {

--- a/cli/commands/init/init.integration.test.ts
+++ b/cli/commands/init/init.integration.test.ts
@@ -712,17 +712,35 @@ describe("init command integration", () => {
   });
 
   describe("existing directory", () => {
-    it("should show error when directory already exists", async () => {
+    it("should show error when the directory holds files the template writes", async () => {
       const dirName = `exists-${randomSuffix()}`;
       const dirPath = join(TEST_DIR, dirName);
       await Deno.mkdir(dirPath);
+      await Deno.writeTextFile(join(dirPath, "README.md"), "mine\n");
 
       try {
         const result = await runInitCommand([dirName, "-t", "minimal", "--skip-install"]);
         const output = (result.stdout ?? "") + (result.stderr ?? "");
 
-        assertEquals(output.includes("already exists"), true);
+        assertEquals(result.code === 0, false);
+        assertEquals(output.includes("already contains README.md"), true);
         assertEquals(output.includes("Stack trace"), false);
+        assertEquals(await Deno.readTextFile(join(dirPath, "README.md")), "mine\n");
+      } finally {
+        await remove(dirPath, { recursive: true }).catch(() => {});
+      }
+    });
+
+    it("should scaffold into an existing empty directory", async () => {
+      const dirName = `empty-${randomSuffix()}`;
+      const dirPath = join(TEST_DIR, dirName);
+      await Deno.mkdir(dirPath);
+
+      try {
+        const result = await runInitCommand([dirName, "-t", "minimal", "--skip-install"]);
+
+        assertEquals(result.code, 0);
+        assertEquals(await exists(join(dirPath, "app", "page.tsx")), true);
       } finally {
         await remove(dirPath, { recursive: true }).catch(() => {});
       }

--- a/cli/shared/project-creation.test.ts
+++ b/cli/shared/project-creation.test.ts
@@ -728,7 +728,7 @@ describe("createProject into an existing named directory", () => {
   });
 });
 
-describe("createProject when something blocks a scaffold directory", () => {
+describe("createProject when a path cannot be written through", () => {
   it("refuses a file where the scaffold needs a directory, before writing anything", async () => {
     const parentDir = await makeTempDir({ prefix: "veryfront-create-blocked-file-" });
     const projectDir = join(parentDir, "contract-project");
@@ -842,6 +842,71 @@ describe("createProject when something blocks a scaffold directory", () => {
       assertEquals(await Deno.readTextFile(join(projectDir, "app", "about")), "mine\n");
       assertEquals(await exists(join(projectDir, "app", "page.tsx")), false);
       assertEquals(await exists(join(projectDir, "README.md")), false);
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("refuses a link at a scaffold path itself, dangling or not", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-leaf-link-" });
+    const projectDir = join(parentDir, "contract-project");
+    const outside = join(parentDir, "outside.md");
+
+    try {
+      await Deno.mkdir(projectDir);
+      // A dangling link resolves to nothing, so `findExistingPaths` reports it
+      // absent and the write follows it out of the project.
+      await Deno.symlink(outside, join(projectDir, "README.md"));
+
+      await assertRejects(
+        () => createProject(baseRequest(parentDir)),
+        Error,
+        'Directory "contract-project" already contains README.md as a file or a link',
+      );
+
+      assertEquals(await exists(outside), false);
+      assertEquals(await exists(join(projectDir, "AGENTS.md")), false);
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("refuses a link at a scaffold path under --force as well", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-leaf-force-" });
+    const projectDir = join(parentDir, "contract-project");
+    const outside = join(parentDir, "outside.md");
+
+    try {
+      await Deno.mkdir(projectDir);
+      await Deno.symlink(outside, join(projectDir, "README.md"));
+
+      await assertRejects(
+        () => createProject({ ...baseRequest(parentDir), conflictPolicy: "overwrite" }),
+        Error,
+        'Directory "contract-project" already contains README.md as a file or a link',
+      );
+
+      assertEquals(await exists(outside), false);
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("still reports a real file at a scaffold path as an overwritable conflict", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-leaf-file-" });
+    const projectDir = join(parentDir, "contract-project");
+
+    try {
+      await Deno.mkdir(projectDir);
+      await Deno.writeTextFile(join(projectDir, "README.md"), "mine\n");
+
+      // A real file resolves fine, so it stays a conflict pointing at --force
+      // rather than the refusal above.
+      await assertRejects(
+        () => createProject(baseRequest(parentDir)),
+        Error,
+        'Directory "contract-project" already contains README.md. Use --force to overwrite.',
+      );
     } finally {
       await remove(parentDir, { recursive: true }).catch(() => {});
     }

--- a/cli/shared/project-creation.test.ts
+++ b/cli/shared/project-creation.test.ts
@@ -727,3 +727,141 @@ describe("createProject into an existing named directory", () => {
     }
   });
 });
+
+describe("createProject when something blocks a scaffold directory", () => {
+  it("refuses a file where the scaffold needs a directory, before writing anything", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-blocked-file-" });
+    const projectDir = join(parentDir, "contract-project");
+
+    try {
+      await Deno.mkdir(projectDir);
+      // `app/page.tsx` cannot resolve through a regular `app`, so the conflict
+      // check sees nothing and the scaffold used to write README.md and
+      // AGENTS.md before failing on the directory it could not create.
+      await Deno.writeTextFile(join(projectDir, "app"), "mine\n");
+
+      await assertRejects(
+        () => createProject(baseRequest(parentDir)),
+        Error,
+        'Directory "contract-project" already contains app as a file or a link',
+      );
+
+      assertEquals(await Deno.readTextFile(join(projectDir, "app")), "mine\n");
+      assertEquals(await exists(join(projectDir, "README.md")), false);
+      assertEquals(await exists(join(projectDir, "AGENTS.md")), false);
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("refuses a link where the scaffold needs a directory, and writes nothing through it", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-blocked-link-" });
+    const projectDir = join(parentDir, "contract-project");
+    const outside = join(parentDir, "outside");
+
+    try {
+      await Deno.mkdir(projectDir);
+      await Deno.mkdir(outside);
+      await Deno.symlink(outside, join(projectDir, "app"));
+
+      await assertRejects(
+        () => createProject(baseRequest(parentDir)),
+        Error,
+        'Directory "contract-project" already contains app as a file or a link',
+      );
+
+      // The scaffold would otherwise report success and leave page.tsx,
+      // layout.tsx and about/page.mdx outside the project it named.
+      assertEquals(await exists(join(outside, "page.tsx")), false);
+      assertEquals(await exists(join(outside, "layout.tsx")), false);
+      assertEquals(await exists(join(projectDir, "README.md")), false);
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("refuses a blocked directory in the current-directory path too", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-blocked-cwd-" });
+    const outside = await makeTempDir({ prefix: "veryfront-create-blocked-target-" });
+
+    try {
+      await Deno.symlink(outside, join(parentDir, "app"));
+
+      await assertRejects(
+        () => createProject({ ...baseRequest(parentDir), name: undefined }),
+        Error,
+        "Directory already contains app as a file or a link",
+      );
+
+      assertEquals(await exists(join(outside, "page.tsx")), false);
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+      await remove(outside, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("refuses under --force as well, because force overwrites files it does not redirect writes", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-blocked-force-" });
+    const projectDir = join(parentDir, "contract-project");
+    const outside = join(parentDir, "outside");
+
+    try {
+      await Deno.mkdir(projectDir);
+      await Deno.mkdir(outside);
+      await Deno.symlink(outside, join(projectDir, "app"));
+
+      await assertRejects(
+        () => createProject({ ...baseRequest(parentDir), conflictPolicy: "overwrite" }),
+        Error,
+        'Directory "contract-project" already contains app as a file or a link',
+      );
+
+      assertEquals(await exists(join(outside, "page.tsx")), false);
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("refuses a block nested below a directory that is genuinely there", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-blocked-nested-" });
+    const projectDir = join(parentDir, "contract-project");
+
+    try {
+      // `app/` is a real directory, so only the second segment is in the way.
+      // Checking the first segment alone would let the scaffold write
+      // app/page.tsx and app/layout.tsx before failing on app/about.
+      await Deno.mkdir(join(projectDir, "app"), { recursive: true });
+      await Deno.writeTextFile(join(projectDir, "app", "about"), "mine\n");
+
+      await assertRejects(
+        () => createProject(baseRequest(parentDir)),
+        Error,
+        'Directory "contract-project" already contains app/about as a file or a link',
+      );
+
+      assertEquals(await Deno.readTextFile(join(projectDir, "app", "about")), "mine\n");
+      assertEquals(await exists(join(projectDir, "app", "page.tsx")), false);
+      assertEquals(await exists(join(projectDir, "README.md")), false);
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("scaffolds normally when the directories it needs are absent or already directories", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-blocked-clear-" });
+    const projectDir = join(parentDir, "contract-project");
+
+    try {
+      // A real `app/` directory is not in the way, it is exactly what the
+      // scaffold is about to create.
+      await Deno.mkdir(join(projectDir, "app"), { recursive: true });
+
+      await createProject(baseRequest(parentDir));
+
+      assertEquals(await exists(join(projectDir, "app", "page.tsx")), true);
+      assertEquals(await exists(join(projectDir, "README.md")), true);
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+});

--- a/cli/shared/project-creation.test.ts
+++ b/cli/shared/project-creation.test.ts
@@ -104,7 +104,7 @@ describe("createProject", () => {
       await assertRejects(
         () => createProject({ ...request, conflictPolicy: "fail" }),
         Error,
-        'Directory "contract-project" already exists',
+        'Directory "contract-project" already contains',
       );
 
       const overwritten = await createProject({
@@ -666,6 +666,62 @@ describe("createProject into the current directory", () => {
       await createProject({ ...cwdRequest(parentDir), conflictPolicy: "overwrite" });
 
       assertEquals((await Deno.readTextFile(readme)) === "mine\n", false);
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+});
+
+describe("createProject into an existing named directory", () => {
+  it("scaffolds into an existing empty directory", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-empty-named-" });
+
+    try {
+      // `mkdir app && veryfront init app`, or a freshly cloned empty repo.
+      await Deno.mkdir(join(parentDir, "contract-project"));
+
+      const result = await createProject(baseRequest(parentDir));
+
+      assertEquals(result.projectDir, join(parentDir, "contract-project"));
+      assertEquals(await exists(join(parentDir, "contract-project", "app", "page.tsx")), true);
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("scaffolds beside files the template does not write", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-beside-named-" });
+    const projectDir = join(parentDir, "contract-project");
+
+    try {
+      await Deno.mkdir(join(projectDir, ".git"), { recursive: true });
+      await Deno.writeTextFile(join(projectDir, "LICENSE"), "MIT\n");
+
+      await createProject(baseRequest(parentDir));
+
+      assertEquals(await exists(join(projectDir, "app", "page.tsx")), true);
+      assertEquals(await Deno.readTextFile(join(projectDir, "LICENSE")), "MIT\n");
+    } finally {
+      await remove(parentDir, { recursive: true }).catch(() => {});
+    }
+  });
+
+  it("names the files it would overwrite, not just the directory", async () => {
+    const parentDir = await makeTempDir({ prefix: "veryfront-create-conflict-named-" });
+    const projectDir = join(parentDir, "contract-project");
+
+    try {
+      await Deno.mkdir(projectDir);
+      await Deno.writeTextFile(join(projectDir, "README.md"), "mine\n");
+
+      await assertRejects(
+        () => createProject(baseRequest(parentDir)),
+        Error,
+        'Directory "contract-project" already contains README.md',
+      );
+
+      assertEquals(await Deno.readTextFile(join(projectDir, "README.md")), "mine\n");
+      assertEquals(await exists(join(projectDir, "app")), false);
     } finally {
       await remove(parentDir, { recursive: true }).catch(() => {});
     }

--- a/cli/shared/project-creation.ts
+++ b/cli/shared/project-creation.ts
@@ -517,29 +517,22 @@ export async function createProject(
   const projectDir = projectName === undefined
     ? request.parentDir
     : join(request.parentDir, projectName);
-  const fs = createFileSystem();
 
   validateIntegrationsOrThrow(request.integrations);
 
-  if (
-    projectName !== undefined &&
-    request.conflictPolicy === "fail" &&
-    await fs.exists(projectDir)
-  ) {
-    throw createConfigError(`Directory "${projectName}" already exists`);
-  }
-
   const assembly = await assembleScaffold(request);
 
-  // A named project gets a fresh directory, checked above. Without a name the
-  // scaffold lands in `parentDir` itself, which always exists, so the conflict
-  // is any file the scaffold would write over - a `package.json` with the
-  // author's scripts, a `README.md` - and those are refused the same way.
-  if (projectName === undefined && request.conflictPolicy === "fail") {
+  // A conflict is a file the scaffold would write over - a `package.json` with
+  // the author's scripts, a `README.md` - not the directory existing. So an
+  // empty directory, a fresh clone holding only `.git`, or the working
+  // directory itself (the no-name case) all scaffold, and a `--force` is asked
+  // for only when something would actually be replaced.
+  if (request.conflictPolicy === "fail") {
     const conflicts = await findExistingPaths(projectDir, scaffoldWritePaths(assembly, request));
     if (conflicts.length) {
+      const where = projectName === undefined ? "Directory" : `Directory "${projectName}"`;
       throw createConfigError(
-        `Directory already contains ${conflicts.join(", ")}. Use --force to overwrite.`,
+        `${where} already contains ${conflicts.join(", ")}. Use --force to overwrite.`,
       );
     }
   }

--- a/cli/shared/project-creation.ts
+++ b/cli/shared/project-creation.ts
@@ -505,35 +505,48 @@ async function findExistingPaths(dir: string, paths: string[]): Promise<string[]
 }
 
 /**
- * Directories the scaffold has to create that are already something else.
+ * Paths the scaffold cannot write through, checked before anything is written.
  *
- * A regular file or a link named `app` hides every scaffold path under it:
- * `app/page.tsx` cannot be resolved, so the conflict check reports nothing,
- * and the write then either stops halfway through or follows the link and
- * lands outside the project. Both are caught here, before anything is written.
+ * `findExistingPaths` resolves a whole path, so it cannot see either of these:
+ *
+ * - a link anywhere along the path. `app -> ../elsewhere` makes `app/page.tsx`
+ *   resolve outside the project, and a dangling `README.md -> ../outside.md`
+ *   resolves to nothing at all, so both are reported absent and the write then
+ *   follows the link out of the project.
+ * - a regular file where a directory has to go. `app/page.tsx` cannot resolve
+ *   through a file named `app`, so the write stops halfway through instead.
+ *
+ * A real file sitting at a scaffold path is not listed here. That one resolves
+ * fine and is the conflict `findExistingPaths` reports.
  */
-async function findBlockedDirectories(dir: string, paths: string[]): Promise<string[]> {
+async function findUnwritablePaths(dir: string, paths: string[]): Promise<string[]> {
   const fs = createFileSystem();
-  // `lstat` reports a link as "not a directory", which is exactly the answer
-  // this needs. It is optional only for virtual filesystems that have no
-  // links of their own; every runtime this CLI scaffolds on provides it, and
-  // `stat` still catches a plain file in the way if one ever does not.
+  // `lstat` is what makes a link visible: `stat` follows it and reports the
+  // target. It is optional only for virtual filesystems that have no links of
+  // their own; every runtime this CLI scaffolds on provides it, and `stat`
+  // still catches a plain file in the way if one ever does not.
   const describe = fs.lstat?.bind(fs) ?? fs.stat.bind(fs);
   const blocked = new Set<string>();
 
   for (const path of paths) {
-    const segments = path.split("/").slice(0, -1);
+    const segments = path.split("/");
     for (let depth = 1; depth <= segments.length; depth++) {
-      const ancestor = segments.slice(0, depth).join("/");
-      if (blocked.has(ancestor)) break;
+      const prefix = segments.slice(0, depth).join("/");
+      if (blocked.has(prefix)) break;
       let info: Awaited<ReturnType<typeof describe>>;
       try {
-        info = await describe(join(dir, ancestor));
+        info = await describe(join(dir, prefix));
       } catch {
         break; // Nothing there yet, so nothing below it either.
       }
-      if (!info.isDirectory) {
-        blocked.add(ancestor);
+      if (info.isSymlink) {
+        blocked.add(prefix);
+        break;
+      }
+      // The last segment is the file itself, and a real file there is a
+      // conflict rather than something to refuse outright.
+      if (depth < segments.length && !info.isDirectory) {
+        blocked.add(prefix);
         break;
       }
     }
@@ -564,11 +577,11 @@ export async function createProject(
 
   // Checked whatever the conflict policy is: `--force` says you accept your
   // files being replaced, not the scaffold writing somewhere else entirely.
-  const blocked = await findBlockedDirectories(projectDir, writePaths);
-  if (blocked.length) {
+  const unwritable = await findUnwritablePaths(projectDir, writePaths);
+  if (unwritable.length) {
     throw createConfigError(
-      `${where} already contains ${blocked.join(", ")} as a file or a link, ` +
-        `and the scaffold needs a directory there. Move it aside or use a different name.`,
+      `${where} already contains ${unwritable.join(", ")} as a file or a link ` +
+        `the scaffold cannot write through. Move it aside or use a different name.`,
     );
   }
 

--- a/cli/shared/project-creation.ts
+++ b/cli/shared/project-creation.ts
@@ -504,6 +504,44 @@ async function findExistingPaths(dir: string, paths: string[]): Promise<string[]
   return existing;
 }
 
+/**
+ * Directories the scaffold has to create that are already something else.
+ *
+ * A regular file or a link named `app` hides every scaffold path under it:
+ * `app/page.tsx` cannot be resolved, so the conflict check reports nothing,
+ * and the write then either stops halfway through or follows the link and
+ * lands outside the project. Both are caught here, before anything is written.
+ */
+async function findBlockedDirectories(dir: string, paths: string[]): Promise<string[]> {
+  const fs = createFileSystem();
+  // `lstat` reports a link as "not a directory", which is exactly the answer
+  // this needs. It is optional only for virtual filesystems that have no
+  // links of their own; every runtime this CLI scaffolds on provides it, and
+  // `stat` still catches a plain file in the way if one ever does not.
+  const describe = fs.lstat?.bind(fs) ?? fs.stat.bind(fs);
+  const blocked = new Set<string>();
+
+  for (const path of paths) {
+    const segments = path.split("/").slice(0, -1);
+    for (let depth = 1; depth <= segments.length; depth++) {
+      const ancestor = segments.slice(0, depth).join("/");
+      if (blocked.has(ancestor)) break;
+      let info: Awaited<ReturnType<typeof describe>>;
+      try {
+        info = await describe(join(dir, ancestor));
+      } catch {
+        break; // Nothing there yet, so nothing below it either.
+      }
+      if (!info.isDirectory) {
+        blocked.add(ancestor);
+        break;
+      }
+    }
+  }
+
+  return [...blocked].sort();
+}
+
 export async function createProject(
   request: CreateProjectRequest,
   dependencies: CreateProjectDependencies = {},
@@ -521,6 +559,18 @@ export async function createProject(
   validateIntegrationsOrThrow(request.integrations);
 
   const assembly = await assembleScaffold(request);
+  const writePaths = scaffoldWritePaths(assembly, request);
+  const where = projectName === undefined ? "Directory" : `Directory "${projectName}"`;
+
+  // Checked whatever the conflict policy is: `--force` says you accept your
+  // files being replaced, not the scaffold writing somewhere else entirely.
+  const blocked = await findBlockedDirectories(projectDir, writePaths);
+  if (blocked.length) {
+    throw createConfigError(
+      `${where} already contains ${blocked.join(", ")} as a file or a link, ` +
+        `and the scaffold needs a directory there. Move it aside or use a different name.`,
+    );
+  }
 
   // A conflict is a file the scaffold would write over - a `package.json` with
   // the author's scripts, a `README.md` - not the directory existing. So an
@@ -528,9 +578,8 @@ export async function createProject(
   // directory itself (the no-name case) all scaffold, and a `--force` is asked
   // for only when something would actually be replaced.
   if (request.conflictPolicy === "fail") {
-    const conflicts = await findExistingPaths(projectDir, scaffoldWritePaths(assembly, request));
+    const conflicts = await findExistingPaths(projectDir, writePaths);
     if (conflicts.length) {
-      const where = projectName === undefined ? "Directory" : `Directory "${projectName}"`;
       throw createConfigError(
         `${where} already contains ${conflicts.join(", ")}. Use --force to overwrite.`,
       );

--- a/docs/api-reference/veryfront/scaffold.md
+++ b/docs/api-reference/veryfront/scaffold.md
@@ -38,20 +38,20 @@ for (const file of files) {
 
 | Name                        | Description                                                                 | Source                                                                                              |
 | --------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `SCAFFOLD_TEMPLATE_ALIASES` | Slugs other product surfaces use for a template this CLI names differently. | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L597) |
+| `SCAFFOLD_TEMPLATE_ALIASES` | Slugs other product surfaces use for a template this CLI names differently. | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L646) |
 
 ### Functions
 
 | Name                      | Description                                                             | Source                                                                                              |
 | ------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `listScaffoldTemplates`   | Every template slug a caller may ask for, canonical names and aliases.  | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L612) |
-| `materializeScaffold`     | Produce the complete contents of a new project without touching a disk. | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L651) |
-| `resolveScaffoldTemplate` | Canonical starter template for a slug, or `null` when nothing matches.  | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L604) |
+| `listScaffoldTemplates`   | Every template slug a caller may ask for, canonical names and aliases.  | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L661) |
+| `materializeScaffold`     | Produce the complete contents of a new project without touching a disk. | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L700) |
+| `resolveScaffoldTemplate` | Canonical starter template for a slug, or `null` when nothing matches.  | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L653) |
 
 ### Types
 
 | Name                         | Description                                                                       | Source                                                                                              |
 | ---------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `MaterializedScaffold`       | A new project: every file it starts with, plus anything worth telling the author. | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L633) |
-| `MaterializeScaffoldRequest` | What to build: which starter, under what name, for which runtime.                 | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L617) |
+| `MaterializedScaffold`       | A new project: every file it starts with, plus anything worth telling the author. | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L682) |
+| `MaterializeScaffoldRequest` | What to build: which starter, under what name, for which runtime.                 | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L666) |
 | `TemplateFile`               |                                                                                   | [source](https://github.com/veryfront/veryfront-code/blob/main/templates/types.ts#L17)              |

--- a/docs/api-reference/veryfront/scaffold.md
+++ b/docs/api-reference/veryfront/scaffold.md
@@ -38,20 +38,20 @@ for (const file of files) {
 
 | Name                        | Description                                                                 | Source                                                                                              |
 | --------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `SCAFFOLD_TEMPLATE_ALIASES` | Slugs other product surfaces use for a template this CLI names differently. | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L604) |
+| `SCAFFOLD_TEMPLATE_ALIASES` | Slugs other product surfaces use for a template this CLI names differently. | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L597) |
 
 ### Functions
 
 | Name                      | Description                                                             | Source                                                                                              |
 | ------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `listScaffoldTemplates`   | Every template slug a caller may ask for, canonical names and aliases.  | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L619) |
-| `materializeScaffold`     | Produce the complete contents of a new project without touching a disk. | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L658) |
-| `resolveScaffoldTemplate` | Canonical starter template for a slug, or `null` when nothing matches.  | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L611) |
+| `listScaffoldTemplates`   | Every template slug a caller may ask for, canonical names and aliases.  | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L612) |
+| `materializeScaffold`     | Produce the complete contents of a new project without touching a disk. | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L651) |
+| `resolveScaffoldTemplate` | Canonical starter template for a slug, or `null` when nothing matches.  | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L604) |
 
 ### Types
 
 | Name                         | Description                                                                       | Source                                                                                              |
 | ---------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `MaterializedScaffold`       | A new project: every file it starts with, plus anything worth telling the author. | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L640) |
-| `MaterializeScaffoldRequest` | What to build: which starter, under what name, for which runtime.                 | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L624) |
+| `MaterializedScaffold`       | A new project: every file it starts with, plus anything worth telling the author. | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L633) |
+| `MaterializeScaffoldRequest` | What to build: which starter, under what name, for which runtime.                 | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L617) |
 | `TemplateFile`               |                                                                                   | [source](https://github.com/veryfront/veryfront-code/blob/main/templates/types.ts#L17)              |

--- a/docs/api-reference/veryfront/scaffold.md
+++ b/docs/api-reference/veryfront/scaffold.md
@@ -38,20 +38,20 @@ for (const file of files) {
 
 | Name                        | Description                                                                 | Source                                                                                              |
 | --------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `SCAFFOLD_TEMPLATE_ALIASES` | Slugs other product surfaces use for a template this CLI names differently. | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L646) |
+| `SCAFFOLD_TEMPLATE_ALIASES` | Slugs other product surfaces use for a template this CLI names differently. | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L659) |
 
 ### Functions
 
 | Name                      | Description                                                             | Source                                                                                              |
 | ------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `listScaffoldTemplates`   | Every template slug a caller may ask for, canonical names and aliases.  | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L661) |
-| `materializeScaffold`     | Produce the complete contents of a new project without touching a disk. | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L700) |
-| `resolveScaffoldTemplate` | Canonical starter template for a slug, or `null` when nothing matches.  | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L653) |
+| `listScaffoldTemplates`   | Every template slug a caller may ask for, canonical names and aliases.  | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L674) |
+| `materializeScaffold`     | Produce the complete contents of a new project without touching a disk. | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L713) |
+| `resolveScaffoldTemplate` | Canonical starter template for a slug, or `null` when nothing matches.  | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L666) |
 
 ### Types
 
 | Name                         | Description                                                                       | Source                                                                                              |
 | ---------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| `MaterializedScaffold`       | A new project: every file it starts with, plus anything worth telling the author. | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L682) |
-| `MaterializeScaffoldRequest` | What to build: which starter, under what name, for which runtime.                 | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L666) |
+| `MaterializedScaffold`       | A new project: every file it starts with, plus anything worth telling the author. | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L695) |
+| `MaterializeScaffoldRequest` | What to build: which starter, under what name, for which runtime.                 | [source](https://github.com/veryfront/veryfront-code/blob/main/cli/shared/project-creation.ts#L679) |
 | `TemplateFile`               |                                                                                   | [source](https://github.com/veryfront/veryfront-code/blob/main/templates/types.ts#L17)              |


### PR DESCRIPTION
## Summary
Follow-up to #3983 and #3985.

- `veryfront init app` refused **any** existing `app/` — including an empty one (`mkdir app && veryfront init app`) or a fresh clone holding only `.git`. Every mainstream scaffolder accepts those.
- A conflict is now *a file the scaffold would write over*, not the directory existing. `createProject` is the single authority for both the named and current-directory paths (same `findExistingPaths` check #3985 introduced); the two directory-existence checks in `initCommand` are removed. The refusal names the files:
  ```
  Directory "app" already contains README.md. Use --force to overwrite.
  ```
- `.gitignore` is merged, never a conflict. Behaviour change to be aware of: the interactive wizard now runs before a refusal for a taken name (the old pre-wizard check could not know the template's file list). The message it ends on says exactly what is in the way.
- Left alone on purpose: the `vf_create_project` MCP tool keeps its own `Directory already exists` check/message (`cli/mcp/tools/catalog-tools.ts`). Aligning it is a separate change.
- `docs/api-reference/veryfront/scaffold.md` pins regenerated with CI's Deno 2.7.7.

Found by the `vf-dx-dogfood` edge-case pass against `veryfront@0.1.1251`; recorded there as friction and deliberately kept out of #3983.

## Test plan
- [x] RED on the stacked base: `createProject` into an empty named dir and beside `.git`/`LICENSE` threw "already exists"; `initCommand` into an empty dir was refused pre-wizard
- [x] GREEN: `cli/commands/init/` (incl. `init.integration.test.ts`, subprocess-level empty-dir + conflict cases), `cli/shared/project-creation.test.ts`, `cli/app/` — 24 files pass
- [x] Pass 2 from a sandbox outside the repo with `deno run -A cli/main.ts`: empty dir → scaffolded; `.git`-only dir → scaffolded beside `.git`; dir with `README.md` → refused, exit 1, file intact; no-name into non-empty cwd → still refused (#3985 guard)
- [x] `deno lint`, `deno fmt --check`, `deno check`, `lint:anti-slop`, `lint:sanitizer-baseline`, `lint:test-typecheck`, `docs:api-reference:check` clean


## Update: refuse a file or a link where the scaffold needs a directory

Accepting an existing target directory lets the scaffold reach states the old
`Directory already exists` check never let it see. One of them wrote outside the
project, so this branch now closes it.

`findExistingPaths` asks whether `app/page.tsx` exists. When `app` is a regular
file that path cannot resolve, so the conflict check reports nothing:

- `app` is a **file**: `README.md` and `AGENTS.md` get written, then
  `ensureDir("app")` fails with a raw `Not a directory (os error 20)`, leaving a
  half scaffold behind.
- `app` is a **link** to another directory: nothing fails at all.
  `veryfront init proj` exits 0, prints `proj ready`, and leaves `page.tsx`,
  `layout.tsx` and `about/page.mdx` in the link target instead of `proj/`.

`createProject` now checks every directory the scaffold has to create, before it
writes anything:

```
Directory "app" already contains app as a file or a link, and the scaffold
needs a directory there. Move it aside or use a different name.
```

- The check runs whatever the conflict policy is. `--force` says you accept your
  own files being replaced, not the scaffold writing somewhere else.
- Every segment is checked, so a real `app/` holding a file at `app/about` is
  caught before `app/page.tsx` is written.
- A real directory that is already there is never blocked, which is the point of
  this PR: `mkdir app && veryfront init app` still scaffolds.
- The project directory itself is not checked. `ln -s /mnt/big/app app &&
  veryfront init app` is a legitimate setup and still works.
- The current-directory path had the same hole before this branch, so
  `cd repo && veryfront init` with a linked `app/` wrote outside the repo on
  `main` too. The check sits in `createProject` and covers both paths.

Nothing is ever overwritten through a link: `findExistingPaths` resolves through
it, so an existing `elsewhere/page.tsx` is still reported as a conflict and
refused with the file byte-identical.

### Verification

- Scenario matrix against the real CLI in a sandbox outside the repo, run on
  `origin/main` and on this branch side by side: target holding `README.md`,
  partial scaffold holding only `app/page.tsx`, symlink to a populated
  directory, a directory where a file is expected, a file where a directory is
  expected, non-empty and unreadable, empty, unrelated files plus an existing
  `.gitignore`, `.git`-only, no-name non-empty cwd, and `--force`. No case where
  `main` refused and this branch overwrites. Where behaviour opens up (empty
  directory, unrelated files, `.git`-only) the user's files are byte-identical
  afterwards and `.gitignore` is merged, not replaced.
- Five new tests for the blocked-directory check, all red without it.
- Mutation: skipping the first segment, ignoring nested segments, treating a
  missing path as blocked, refusing any existing ancestor, refusing only when
  every scaffold path exists, refusing any non-empty directory, dropping
  `deno.json` or the env files from `scaffoldWritePaths`, and removing either
  guard outright are each caught by the suite.
- `deno task typecheck`, `deno task lint:ci`, `deno fmt --check`, and
  `deno test cli/shared/project-creation.test.ts cli/commands/init/` all exit 0.


## Update 2: a link at a scaffold path, and the TUI caller

Codex found two more consequences of accepting an existing directory. Both are fixed.

**A link at the scaffold path itself.** The first preflight only walked the
directories above a path, so a dangling `proj/README.md -> ../outside.md` slipped
through: `findExistingPaths` resolves a dangling link to nothing and reports it
absent. `veryfront init proj` exited 0, printed `proj ready`, and wrote the README
to `outside.md` outside the project. Every segment is now checked, including the
last, and a link anywhere along the path is refused whatever the conflict policy:

```
Directory "proj" already contains README.md as a file or a link the scaffold
cannot write through. Move it aside or use a different name.
```

A real file at a scaffold path is still the ordinary conflict pointing at
`--force`, pinned by a test so this cannot drift into refusing any non-empty
directory. The named target being a link stays allowed on purpose:
`ln -s /mnt/big/app app && veryfront init app` puts the project on another volume
and every file is reachable at the path you named. Only a link you did not name
can surprise you.

**The TUI caller.** `cli/app/operations/project-creation.ts` is the second caller
of `createProject` with a fail policy, and it relied on the directory check this
branch removes. It reserves a new remote slug, scaffolds into `projects/<slug>`,
then writes the link for that slug, so with the check gone it would adopt an
existing `projects/<slug>` holding none of the template files and repoint a
directory that is already another project. It now refuses first. The constraint
lives in that caller rather than in `createProject`, because the two want opposite
things: `veryfront init` accepting an existing directory is the point of this PR,
and a freshly reserved slug wanting a fresh directory is the opposite requirement.

**Considered and not changed:** an orphan `package-lock.json` is rewritten by
`npm install`. A real project is already refused, because `package.json` is in
`scaffoldWritePaths`; `--skip-install` never touches the lockfile; so the exposure
is a lockfile with no manifest, which npm regenerates from the manifest the
scaffold just wrote. Adding lockfiles to the preflight would refuse a directory
holding a stray lockfile, which is exactly the behaviour this PR exists to allow.
Reasoning and evidence are on the thread.

### Verification

- Real CLI, sandbox outside the repo: the dangling-leaf case, the same under
  `--force`, and the same on the no-name path all exit 1 and create nothing,
  inside the project or outside it.
- The three cases this PR opens up still scaffold: empty directory (9 files),
  unrelated files (`notes.txt` intact, `.gitignore` merged), and a `.git`-only
  directory.
- Mutation, 10 mutants, all killed. Both coarse mutants from #3985 (refuse only
  when every scaffold path exists; refuse whenever the directory is non-empty)
  are still killed, and the drift test is still the sole killer of the two
  `scaffoldWritePaths` mutants.
- `deno task typecheck`, `deno task lint:ci`, `deno fmt --check`, and
  `deno test cli/shared/project-creation.test.ts cli/app/ cli/commands/init/`
  (24 files, 334 steps) all exit 0.
