### PR TITLE
ci(coverage): report unit coverage to Codecov

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -230,12 +230,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: coverage shard ${{ matrix.shard }}/8
-    # Job-level permissions replace the workflow default entirely, so `contents:
-    # read` is restated here for checkout. `id-token: write` lets the Codecov
-    # upload authenticate via OIDC instead of a stored CODECOV_TOKEN secret.
-    permissions:
-      contents: read
-      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -259,33 +253,6 @@ jobs:
           name: coverage-shard-${{ matrix.shard }}
           path: coverage-shard-${{ matrix.shard }}/lcov.info
           retention-days: 1
-      # `deno coverage --lcov` emits absolute `SF:` paths (e.g.
-      # /home/runner/work/veryfront-code/veryfront-code/src/...). Codecov matches
-      # coverage records against repo-relative paths, so strip the workspace
-      # prefix into a separate file. The original lcov.info is left untouched so
-      # the artifact and the `coverage gate` job keep their existing behaviour.
-      - name: Normalize lcov paths for Codecov
-        if: ${{ success() }}
-        run: |
-          sed "s|^SF:${GITHUB_WORKSPACE}/|SF:|" \
-            "coverage-shard-${{ matrix.shard }}/lcov.info" \
-            > "coverage-shard-${{ matrix.shard }}/lcov.codecov.info"
-      # Authenticated with OIDC (`id-token: write` above) rather than a stored
-      # CODECOV_TOKEN, so there is no upload secret to manage or rotate. A token
-      # is otherwise mandatory here: `main` is a protected branch, and Codecov
-      # only permits tokenless uploads for fork PRs.
-      #
-      # Advisory only: `fail_ci_if_error` stays false so a Codecov outage can
-      # never break CI. The blocking threshold remains `deno task coverage:gate`.
-      - name: Upload coverage to Codecov
-        if: ${{ success() }}
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          use_oidc: true
-          files: coverage-shard-${{ matrix.shard }}/lcov.codecov.info
-          disable_search: true
-          name: unit-shard-${{ matrix.shard }}
-          fail_ci_if_error: false
       - name: Add coverage shard summary
         run: echo "### Coverage shard ${{ matrix.shard }}/8 completed in ${{ steps.coverage.outputs.duration }}" >> "$GITHUB_STEP_SUMMARY"
 
@@ -338,6 +305,58 @@ jobs:
           echo "duration=$(($(date +%s) - START))s" >> "$GITHUB_OUTPUT"
       - name: Add coverage summary
         run: echo "### Coverage shard merge completed in ${{ steps.coverage.outputs.duration }}" >> "$GITHUB_STEP_SUMMARY"
+
+  # Uploading is a separate job from `coverage-shards` on purpose. The shard job
+  # runs the unit suite with `--allow-all`, so any code on the branch executes
+  # there. Granting that job `id-token: write` would let branch code mint a
+  # repository OIDC token. This job runs no repository code: it downloads the
+  # shard artifacts, rewrites paths with sed, and calls the upload action.
+  codecov-upload:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    name: codecov upload
+    needs: [coverage-shards]
+    if: ${{ needs.coverage-shards.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Download unit coverage lcov files
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: coverage-profiles
+          pattern: coverage-shard-*
+      # `deno coverage --lcov` emits absolute `SF:` paths (e.g.
+      # /home/runner/work/veryfront-code/veryfront-code/src/...). Codecov matches
+      # coverage records against repo-relative paths, so strip the workspace
+      # prefix. This edits the downloaded copies only. The stored artifact and
+      # the `coverage gate` job read their own copies and are unaffected.
+      - name: Normalize lcov paths for Codecov
+        run: |
+          for file in coverage-profiles/coverage-shard-*/lcov.info; do
+            sed -i "s|^SF:${GITHUB_WORKSPACE}/|SF:|" "$file"
+          done
+      # Authenticated with OIDC rather than a stored CODECOV_TOKEN, so there is
+      # no upload secret to manage or rotate. A token is otherwise mandatory
+      # here: `main` is a protected branch, and Codecov only permits tokenless
+      # uploads for fork PRs.
+      #
+      # Advisory only: `fail_ci_if_error` stays false so a Codecov outage can
+      # never fail this job, and this job is not a required status check. The
+      # blocking threshold remains `deno task coverage:gate`.
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          use_oidc: true
+          # Comma separated, the form the action documents. All 8 files go up
+          # in one call, so Codecov records one upload per commit.
+          files: coverage-profiles/coverage-shard-1/lcov.info,coverage-profiles/coverage-shard-2/lcov.info,coverage-profiles/coverage-shard-3/lcov.info,coverage-profiles/coverage-shard-4/lcov.info,coverage-profiles/coverage-shard-5/lcov.info,coverage-profiles/coverage-shard-6/lcov.info,coverage-profiles/coverage-shard-7/lcov.info,coverage-profiles/coverage-shard-8/lcov.info
+          disable_search: true
+          name: unit
+          fail_ci_if_error: false
 
   tests-e2e-rsc-browser:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -230,6 +230,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: coverage shard ${{ matrix.shard }}/8
+    # Job-level permissions replace the workflow default entirely, so `contents:
+    # read` is restated here for checkout. `id-token: write` lets the Codecov
+    # upload authenticate via OIDC instead of a stored CODECOV_TOKEN secret.
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -253,6 +259,33 @@ jobs:
           name: coverage-shard-${{ matrix.shard }}
           path: coverage-shard-${{ matrix.shard }}/lcov.info
           retention-days: 1
+      # `deno coverage --lcov` emits absolute `SF:` paths (e.g.
+      # /home/runner/work/veryfront-code/veryfront-code/src/...). Codecov matches
+      # coverage records against repo-relative paths, so strip the workspace
+      # prefix into a separate file. The original lcov.info is left untouched so
+      # the artifact and the `coverage gate` job keep their existing behaviour.
+      - name: Normalize lcov paths for Codecov
+        if: ${{ success() }}
+        run: |
+          sed "s|^SF:${GITHUB_WORKSPACE}/|SF:|" \
+            "coverage-shard-${{ matrix.shard }}/lcov.info" \
+            > "coverage-shard-${{ matrix.shard }}/lcov.codecov.info"
+      # Authenticated with OIDC (`id-token: write` above) rather than a stored
+      # CODECOV_TOKEN, so there is no upload secret to manage or rotate. A token
+      # is otherwise mandatory here: `main` is a protected branch, and Codecov
+      # only permits tokenless uploads for fork PRs.
+      #
+      # Advisory only: `fail_ci_if_error` stays false so a Codecov outage can
+      # never break CI. The blocking threshold remains `deno task coverage:gate`.
+      - name: Upload coverage to Codecov
+        if: ${{ success() }}
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          use_oidc: true
+          files: coverage-shard-${{ matrix.shard }}/lcov.codecov.info
+          disable_search: true
+          name: unit-shard-${{ matrix.shard }}
+          fail_ci_if_error: false
       - name: Add coverage shard summary
         run: echo "### Coverage shard ${{ matrix.shard }}/8 completed in ${{ steps.coverage.outputs.duration }}" >> "$GITHUB_STEP_SUMMARY"
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Veryfront Code
 
+[![CI/CD](https://github.com/veryfront/veryfront-code/actions/workflows/cicd.yml/badge.svg?branch=main)](https://github.com/veryfront/veryfront-code/actions/workflows/cicd.yml)
 [![npm version](https://badge.fury.io/js/veryfront.svg)](https://www.npmjs.com/package/veryfront)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/veryfront)](https://socket.dev/npm/package/veryfront)
 [![codecov](https://codecov.io/gh/veryfront/veryfront-code/branch/main/graph/badge.svg)](https://codecov.io/gh/veryfront/veryfront-code)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/veryfront.svg)](https://www.npmjs.com/package/veryfront)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/veryfront)](https://socket.dev/npm/package/veryfront)
+[![codecov](https://codecov.io/gh/veryfront/veryfront-code/branch/main/graph/badge.svg)](https://codecov.io/gh/veryfront/veryfront-code)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)
 
 **Put your agents to work.**

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,8 @@
 # Codecov configuration
 # Docs: https://docs.codecov.com/docs/codecov-yaml
 #
-# Coverage is uploaded from the `coverage shard N/8` jobs in
-# .github/workflows/cicd.yml: one upload per shard, merged by Codecov.
+# Coverage is uploaded by the `codecov upload` job in
+# .github/workflows/cicd.yml, which sends all 8 shard lcov files in one call.
 #
 # Codecov is ADVISORY here. The blocking threshold is still enforced in CI by
 # `deno task coverage:gate` (scripts/lint/check-coverage.ts, 80% line coverage).
@@ -12,10 +12,10 @@
 codecov:
   require_ci_to_pass: true
   notify:
-    # Wait for all 8 unit coverage shards before reporting, otherwise the first
-    # shard to land would be treated as the full picture and report ~1/8th of
-    # actual coverage.
-    after_n_builds: 8
+    # The `codecov upload` job sends all 8 shard lcov files in one call, so
+    # there is exactly one upload per commit and reporting must not wait for
+    # more. Raise this if uploads are ever split back out per shard.
+    after_n_builds: 1
     wait_for_ci: true
 
 coverage:
@@ -40,7 +40,8 @@ comment:
   layout: "condensed_header, diff, condensed_files, condensed_footer"
   behavior: default
   require_changes: false
-  after_n_builds: 8
+  # One upload per commit; see codecov.notify.after_n_builds above.
+  after_n_builds: 1
 
 # Belt and braces for paths `buildCoverageCommandArgs` (scripts/test/coverage-ci.ts)
 # already keeps out of the lcov, so an upload stays consistent if the coverage

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,58 @@
+# Codecov configuration
+# Docs: https://docs.codecov.com/docs/codecov-yaml
+#
+# Coverage is uploaded from the `coverage shard N/8` jobs in
+# .github/workflows/cicd.yml — one upload per shard, merged by Codecov.
+#
+# Codecov is ADVISORY here. The blocking threshold is still enforced in CI by
+# `deno task coverage:gate` (scripts/lint/check-coverage.ts, 80% line coverage).
+# Both status checks below are `informational: true`, so they report but never
+# block a merge. Remove `informational` to make them required checks.
+
+codecov:
+  require_ci_to_pass: true
+  notify:
+    # Wait for all 8 unit coverage shards before reporting, otherwise the first
+    # shard to land would be treated as the full picture and report ~1/8th of
+    # actual coverage.
+    after_n_builds: 8
+    wait_for_ci: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...90"
+
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        # Coverage of lines changed by the PR itself.
+        target: 80%
+        threshold: 0%
+        informational: true
+
+comment:
+  layout: "condensed_header, diff, condensed_files, condensed_footer"
+  behavior: default
+  require_changes: false
+  after_n_builds: 8
+
+# Mirrors the filters in `buildCoverageCommandArgs` (scripts/test/coverage-ci.ts):
+# only src/ is measured, with test files excluded. Listed again here so uploads
+# stay consistent if the coverage command ever changes.
+ignore:
+  - "tests/**"
+  - "scripts/**"
+  - "extensions/**"
+  - "templates/**"
+  - "docs/**"
+  - "npm/**"
+  - "src/**/*_test.ts"
+  - "src/**/*_test.tsx"
+  - "src/**/*.test.ts"
+  - "src/**/*.test.tsx"

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@
 # Docs: https://docs.codecov.com/docs/codecov-yaml
 #
 # Coverage is uploaded from the `coverage shard N/8` jobs in
-# .github/workflows/cicd.yml — one upload per shard, merged by Codecov.
+# .github/workflows/cicd.yml: one upload per shard, merged by Codecov.
 #
 # Codecov is ADVISORY here. The blocking threshold is still enforced in CI by
 # `deno task coverage:gate` (scripts/lint/check-coverage.ts, 80% line coverage).
@@ -42,13 +42,18 @@ comment:
   require_changes: false
   after_n_builds: 8
 
-# Mirrors the filters in `buildCoverageCommandArgs` (scripts/test/coverage-ci.ts):
-# only src/ is measured, with test files excluded. Listed again here so uploads
-# stay consistent if the coverage command ever changes.
+# Belt and braces for paths `buildCoverageCommandArgs` (scripts/test/coverage-ci.ts)
+# already keeps out of the lcov, so an upload stays consistent if the coverage
+# command ever changes.
+#
+# Do not add `extensions/**` here. `deno coverage --include` matches on path
+# substring, so `--include=src/` also selects `extensions/*/src/**`. Those files
+# are in the lcov and the `coverage gate` job counts them (447 records, 23,654
+# lines, 35% covered as of this change). Ignoring them here would make Codecov
+# report a materially higher number than the gate for the same commit.
 ignore:
   - "tests/**"
   - "scripts/**"
-  - "extensions/**"
   - "templates/**"
   - "docs/**"
   - "npm/**"


### PR DESCRIPTION
Uploads the existing unit coverage shards to Codecov so pull requests get **patch coverage**, whether the lines a PR changes are tested, which the current line-total gate cannot express.

## Changes

- **`.github/workflows/cicd.yml`**: a new `codecov-upload` job. `coverage-shards` is untouched apart from losing nothing it had before this PR.
- **`codecov.yml`**: new. Validated against Codecov's `/validate` endpoint (`Valid!`).
- **`README.md`**: coverage badge, plus the CI/CD badge from #4014 which merged into this branch.

## The upload runs in its own job

`coverage-shards` runs the unit suite with `--allow-all`, so any code on the branch executes there. Giving that job `id-token: write` would let branch code read `ACTIONS_ID_TOKEN_REQUEST_URL` and mint a repository OIDC token. This repo's npm trusted publishing is bound to `environment: production` (`.github/SECURITY-HARDENING.md`) and the shard job has no environment, so npm publish was never reachable that way, but the grant was still wider than it needed to be, and it would have been the first `pull_request`-triggered job in this workflow to hold it.

So `codecov-upload` is a separate job. It `needs: [coverage-shards]`, downloads the shard artifacts, rewrites the `SF:` paths, and calls the pinned upload action. It executes no repository code, and `id-token: write` lives only there.

**Path normalization is required, not incidental.** `deno coverage --lcov` emits absolute `SF:` paths, which on CI look like `/home/runner/work/veryfront-code/veryfront-code/src/...`. Codecov matches records against repo-relative paths, so without this every file would fail to match. Verified against the real toolchain:

```
before: SF:/private/tmp/.../lcovprobe/src/add.ts
after:  SF:src/add.ts
```

Normalizing after download means `sed -i` on the downloaded copies. The stored artifact and the `coverage gate` job read their own copies, so both are byte-for-byte unchanged, and there is no second lcov file to keep in sync.

Five records per merged report sit outside `$GITHUB_WORKSPACE` (build output under `/home/runner/.cache/veryfront/...`) and keep their absolute path. They carry 9 lines in total and Codecov will drop them as unmatched.

**One upload per commit.** All 8 shard files go up in a single action call, so `codecov.notify.after_n_builds` and `comment.after_n_builds` are 1. If uploads are ever split back out per shard, raise both to the shard count, otherwise Codecov reports on the first shard to land and shows roughly one eighth of actual coverage.

**Codecov cannot fail this repo's CI.** Three independent reasons, and all three have to be understood together before anyone reads a Codecov status as a gate:

- `fail_ci_if_error: false`, so a failed upload leaves the step green.
- Both statuses are `informational: true`, so Codecov always reports success.
- Neither `codecov/project` nor `codecov/patch` is in branch protection, and neither is the new `codecov upload` job. The nine required contexts are `ci (format)`, `ci (lint)`, `ci (typecheck)`, `tests (unit)`, `tests (integration)`, `coverage gate`, `tests (rsc browser e2e)`, `tests (binary e2e)`, `Analyze`.

The blocking threshold stays `deno task coverage:gate` at 80%.

**OIDC instead of a stored token.** `main` is a protected branch and Codecov only permits tokenless uploads for fork PRs, so an upload credential is mandatory. `use_oidc: true` plus `id-token: write` avoids a `CODECOV_TOKEN` secret entirely, so there is nothing to rotate.

**Fork PRs are unaffected either way.** `coverage-shards` is already gated on `head.repo.full_name == github.repository`, and `codecov-upload` carries the same guard, so on a fork PR neither job runs. No secret is exposed and no token is needed. The same gate already skips `coverage gate` and `tests (unit)` on fork PRs, so fork PRs cannot satisfy branch protection today. That is pre-existing and out of scope here.

## Why `extensions/**` is not in `ignore`

`deno coverage --include` matches on path substring, so `--include=src/` in `buildCoverageCommandArgs` also selects `extensions/*/src/**`. Measured on the merged lcov from CI run 32624944948: 76 records, 23,654 lines, 35.39% covered, all of it counted by the `coverage gate` job.

An `ignore: extensions/**` entry compiles to `(?s:extensions/.*)\Z` (confirmed by Codecov's own `/validate` output), which matches those files. With it, Codecov would report roughly 85.6% where the required gate reports 83% for the same commit. Two different coverage numbers on one PR is worse than no Codecov number, so the entry is gone and the file comment says why.

## Known limitations

- **Fork PRs get no coverage.** See above. Relaxing that is a separate cost and policy decision.
- **First run is the real test.** Path normalization was verified locally; the `/home/runner/work/...` prefix can only be confirmed once this runs on CI.
- The Codecov org still needs OAuth access granted for `veryfront` to view dashboards. It does not block uploads.
