### PR TITLE
docs(readme): add CI/CD status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Veryfront Code
 
+[![CI/CD](https://github.com/veryfront/veryfront-code/actions/workflows/cicd.yml/badge.svg?branch=main)](https://github.com/veryfront/veryfront-code/actions/workflows/cicd.yml)
 [![npm version](https://badge.fury.io/js/veryfront.svg)](https://www.npmjs.com/package/veryfront)
 [![Socket Badge](https://socket.dev/api/badge/npm/package/veryfront)](https://socket.dev/npm/package/veryfront)
 [![codecov](https://codecov.io/gh/veryfront/veryfront-code/branch/main/graph/badge.svg)](https://codecov.io/gh/veryfront/veryfront-code)


### PR DESCRIPTION
Adds a CI/CD status badge to the README badge row.

```markdown
[![CI/CD](https://github.com/veryfront/veryfront-code/actions/workflows/cicd.yml/badge.svg?branch=main)](https://github.com/veryfront/veryfront-code/actions/workflows/cicd.yml)
```

## Two corrections to the originally proposed badge

**1. Filename.** The proposed URL used `cicd.yaml`; the workflow is `cicd.yml`. Verified:

```
cicd.yaml/badge.svg → 404
cicd.yml/badge.svg  → 200   <title>CI/CD - passing</title>
```

**2. Branch scope.** Added `?branch=main`. Without it the badge shows the most recent run on *any* branch, so a failing feature branch would display the project as failing on the landing page.

**Format:** written as Markdown rather than the raw `<a><img>` HTML to match the four badges already in that row.

## Base

Stacked on `ci/codecov-integration` (#4013) because both PRs edit the same badge block. GitHub will retarget this to `main` automatically once #4013 merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a CI/CD status badge to the README.
  * The badge links to the project’s automated workflow status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->