### PR TITLE
test: classify public platform namespace effects

### DIFF
--- a/cli/commands/config/handler.test.ts
+++ b/cli/commands/config/handler.test.ts
@@ -131,13 +131,15 @@ describe("Config Command", () => {
   });
 
   describe("detectConfigSource", () => {
-    it("detects config file in current project", async () => {
-      const { cwd } = await import("veryfront/platform");
-      const source = await detectConfigSource(cwd());
-      // Project may or may not have a config file — just verify it returns string or null
-      assertEquals(
-        source === null || typeof source === "string",
-        true,
+    it("detects config file in project", async () => {
+      await withTempConfigProject(
+        { "veryfront.config.ts": "export default {};\n" },
+        async (projectDir) => {
+          assertEquals(
+            await detectConfigSource(projectDir),
+            "veryfront.config.ts",
+          );
+        },
       );
     });
 

--- a/scripts/test/test-semantic-audit.test.ts
+++ b/scripts/test/test-semantic-audit.test.ts
@@ -488,9 +488,11 @@ cwd();
     assertEquals(
       collectSemanticMarkers(
         `
-import { chdir, cwd, deleteEnv, exit, getEnv, runCommand, setEnv } from "veryfront/platform";
+import { chdir, cwd, deleteEnv, env, exit, getArgs, getEnv, runCommand, setEnv } from "veryfront/platform";
 cwd();
 chdir("fixtures");
+env();
+getArgs();
 getEnv("TEST_KEY");
 setEnv("TEST_KEY", "value");
 deleteEnv("TEST_KEY");
@@ -502,6 +504,8 @@ exit(0);
       [
         ["shared-cwd", "cwd"],
         ["shared-cwd", "chdir"],
+        ["process", "env"],
+        ["process", "getArgs"],
         ["process", "getEnv"],
         ["process", "setEnv"],
         ["process", "deleteEnv"],
@@ -518,6 +522,11 @@ exit(0);
 import * as platform from "veryfront/platform";
 platform.cwd();
 platform.chdir("fixtures");
+platform.getArgs();
+platform.env();
+const { env: platformEnv, getArgs: platformGetArgs } = platform;
+platformGetArgs();
+platformEnv();
 platform.getEnv("TEST_KEY");
 platform.setEnv("TEST_KEY", "value");
 platform.deleteEnv("TEST_KEY");
@@ -529,6 +538,10 @@ platform.exit(0);
       [
         ["shared-cwd", "platform.cwd"],
         ["shared-cwd", "platform.chdir"],
+        ["process", "platform.getArgs"],
+        ["process", "platform.env"],
+        ["process", "platformGetArgs"],
+        ["process", "platformEnv"],
         ["process", "platform.getEnv"],
         ["process", "platform.setEnv"],
         ["process", "platform.deleteEnv"],

--- a/scripts/test/test-semantic-audit.test.ts
+++ b/scripts/test/test-semantic-audit.test.ts
@@ -511,6 +511,33 @@ exit(0);
     );
   });
 
+  it("classifies process wrappers on the public platform namespace", () => {
+    assertEquals(
+      collectSemanticMarkers(
+        `
+import * as platform from "veryfront/platform";
+platform.cwd();
+platform.chdir("fixtures");
+platform.getEnv("TEST_KEY");
+platform.setEnv("TEST_KEY", "value");
+platform.deleteEnv("TEST_KEY");
+await platform.runCommand({ command: "deno", args: ["--version"] });
+platform.exit(0);
+`,
+        "src/public-platform-process-namespace.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [
+        ["shared-cwd", "platform.cwd"],
+        ["shared-cwd", "platform.chdir"],
+        ["process", "platform.getEnv"],
+        ["process", "platform.setEnv"],
+        ["process", "platform.deleteEnv"],
+        ["process", "platform.runCommand"],
+        ["process", "platform.exit"],
+      ],
+    );
+  });
+
   it("classifies repo-relative compat filesystem and process imports from importer path", () => {
     assertEquals(
       collectSemanticMarkers(

--- a/scripts/test/test-semantic-audit.ts
+++ b/scripts/test/test-semantic-audit.ts
@@ -323,6 +323,8 @@ const PROCESS_STATE_METHODS = new Set([
   "setEnv",
 ]);
 
+const PUBLIC_PLATFORM_PROCESS_METHODS = new Set(["env", "getArgs"]);
+
 const PROCESS_ARGUMENT_PROPERTIES = new Set(["args", "argv"]);
 
 const TESTING_RUNTIME_WRITE_METHODS = new Set([
@@ -2544,7 +2546,10 @@ function collectImportBindings(program: Node, file: string): ImportBindings {
       if (isProcessEffectSpecifier(source)) {
         if (SHARED_CWD_METHODS.has(importedName)) {
           bindings.sharedCwd.add(local);
-        } else if (isProcessEffectMethod(importedName)) {
+        } else if (
+          isProcessEffectMethod(importedName) ||
+          isPublicPlatformProcessMethod(source, importedName)
+        ) {
           bindings.process.add(local);
         }
       }
@@ -3738,6 +3743,9 @@ function moduleRuntimeBindingForProperty(
   if (isFilesystemSpecifier(source) && FILESYSTEM_OPEN_METHODS.has(property)) {
     return { kind: "filesystem-open", source };
   }
+  if (isPublicPlatformProcessMethod(source, property)) {
+    return { kind: "effect", effect: "process" };
+  }
   if (isProcessEffectSpecifier(source) && property === "env") {
     return { kind: "effect-object", effect: "process" };
   }
@@ -4263,6 +4271,14 @@ function isProcessEffectMethod(method: string): boolean {
     PROCESS_STATE_METHODS.has(method);
 }
 
+function isPublicPlatformProcessMethod(
+  source: string,
+  method: string,
+): boolean {
+  return isPublicPlatformSpecifier(source) &&
+    PUBLIC_PLATFORM_PROCESS_METHODS.has(method);
+}
+
 function isServerSpecifier(source: string): boolean {
   return source === "node:http" || source === "node:https" ||
     source === "node:net" || source === "node:tls" ||
@@ -4315,6 +4331,9 @@ function effectForModuleMethod(
     return "shared-cwd";
   }
   if (isProcessEffectSpecifier(source) && isProcessEffectMethod(method)) {
+    return "process";
+  }
+  if (isPublicPlatformProcessMethod(source, method)) {
     return "process";
   }
   if (isProcessEffectSpecifier(source) && method === "argv") return "process";

--- a/scripts/test/test-semantic-audit.ts
+++ b/scripts/test/test-semantic-audit.ts
@@ -2541,22 +2541,12 @@ function collectImportBindings(program: Node, file: string): ImportBindings {
           bindings.filesystemWrite.add(local);
         }
       }
-      if (isProcessSpecifier(source)) {
+      if (isProcessEffectSpecifier(source)) {
         if (SHARED_CWD_METHODS.has(importedName)) {
           bindings.sharedCwd.add(local);
         } else if (isProcessEffectMethod(importedName)) {
           bindings.process.add(local);
         }
-      } else if (
-        isPublicPlatformSpecifier(source) &&
-        SHARED_CWD_METHODS.has(importedName)
-      ) {
-        bindings.sharedCwd.add(local);
-      } else if (
-        isPublicPlatformSpecifier(source) &&
-        isProcessEffectMethod(importedName)
-      ) {
-        bindings.process.add(local);
       }
       if (isTestingRuntimeSpecifier(source)) {
         const effect = effectForModuleMethod(source, importedName);
@@ -2617,7 +2607,9 @@ function addRuntimeNamespaceImport(
     bindings.runtimeNamespaces.set(local, source);
   }
   if (isFilesystemSpecifier(source)) bindings.filesystemNamespaces.add(local);
-  if (isProcessSpecifier(source)) bindings.processNamespaces.add(local);
+  if (isProcessEffectSpecifier(source)) {
+    bindings.processNamespaces.add(local);
+  }
   if (isServerSpecifier(source)) bindings.serverNamespaces.add(local);
   if (isPlaywrightSpecifier(source)) bindings.playwrightNamespaces.add(local);
 }
@@ -3746,10 +3738,10 @@ function moduleRuntimeBindingForProperty(
   if (isFilesystemSpecifier(source) && FILESYSTEM_OPEN_METHODS.has(property)) {
     return { kind: "filesystem-open", source };
   }
-  if (isProcessSpecifier(source) && property === "env") {
+  if (isProcessEffectSpecifier(source) && property === "env") {
     return { kind: "effect-object", effect: "process" };
   }
-  if (isProcessSpecifier(source) && property === "argv") {
+  if (isProcessEffectSpecifier(source) && property === "argv") {
     return { kind: "effect-object", effect: "process" };
   }
   const effect = effectForModuleMethod(source, property);
@@ -4251,6 +4243,10 @@ function isPublicPlatformSpecifier(source: string): boolean {
   return source === "veryfront/platform" || source === "#veryfront/platform";
 }
 
+function isProcessEffectSpecifier(source: string): boolean {
+  return isProcessSpecifier(source) || isPublicPlatformSpecifier(source);
+}
+
 function isTestingRuntimeSpecifier(source: string): boolean {
   return source === "#veryfront/testing" ||
     source === "#veryfront/testing/deno-compat" ||
@@ -4284,7 +4280,7 @@ function isCreateRequireSpecifier(source: string): boolean {
 }
 
 function isRuntimeEffectModule(source: string): boolean {
-  return isFilesystemSpecifier(source) || isProcessSpecifier(source) ||
+  return isFilesystemSpecifier(source) || isProcessEffectSpecifier(source) ||
     isServerSpecifier(source) || isDnsSpecifier(source) ||
     isPlaywrightSpecifier(source) ||
     isTestingRuntimeSpecifier(source);
@@ -4315,13 +4311,13 @@ function effectForModuleMethod(
     if (READ_METHODS.has(method)) return "filesystem-read";
     if (WRITE_METHODS.has(method)) return "filesystem-write";
   }
-  if (isProcessSpecifier(source) && SHARED_CWD_METHODS.has(method)) {
+  if (isProcessEffectSpecifier(source) && SHARED_CWD_METHODS.has(method)) {
     return "shared-cwd";
   }
-  if (isProcessSpecifier(source) && isProcessEffectMethod(method)) {
+  if (isProcessEffectSpecifier(source) && isProcessEffectMethod(method)) {
     return "process";
   }
-  if (isProcessSpecifier(source) && method === "argv") return "process";
+  if (isProcessEffectSpecifier(source) && method === "argv") return "process";
   if (isServerSpecifier(source) && SERVER_METHODS.has(method)) return "server";
   if (isServerSpecifier(source) && NETWORK_METHODS.has(method)) {
     return "network";


### PR DESCRIPTION
## Summary

- classify process and shared-cwd effects consistently for named and namespace imports from `veryfront/platform`
- replace a cwd-dependent config unit assertion with a deterministic temp-project assertion
- preserve the shrink-only semantic migration inventory

## Verification

- `deno task test:file cli/commands/config/handler.test.ts` — 19 steps passed
- semantic audit suite — 80 steps passed
- migration audit — 2,142 executables; 762 effect-bearing files disposed
- lint and typecheck passed
- exhaustive pre-push gate passed on the identical tree — 4,175 parallel unit tests plus cwd suites

Related: #4021