### PR TITLE
fix(test): keep semantic audit sound across Object.assign mutations

### DIFF
--- a/scripts/test/test-semantic-audit.test.ts
+++ b/scripts/test/test-semantic-audit.test.ts
@@ -2391,6 +2391,30 @@ const spreadReturned = Object.assign(
 );
 spreadReturned.safe();
 
+const mixedSource = { known: Deno.remove, ...source };
+const mixedReturned = Object.assign(
+  { safe: () => undefined },
+  mixedSource,
+);
+mixedReturned.safe();
+
+const mixedWrapper = { ...mixedSource };
+const wrappedReturned = Object.assign(
+  { safe: () => undefined },
+  mixedWrapper,
+);
+wrappedReturned.safe();
+
+const reorderedTarget = { 0: () => undefined };
+Object.preventExtensions(reorderedTarget);
+try {
+  Object.assign(reorderedTarget, {
+    blocked: () => undefined,
+    ...source,
+  });
+} catch {}
+reorderedTarget[0]();
+
 function assignDefaultedSource(defaultedSource = {}) {
   const defaultedTarget = { safe: () => undefined };
   Object.assign(defaultedTarget, defaultedSource);
@@ -2420,7 +2444,7 @@ conditionalTarget.write("conditional.txt");
         "src/runtime-object-assign-unknown-source.test.ts",
       ).map((marker) => marker.effect),
       Array.from(
-        { length: 4 },
+        { length: 7 },
         () => [
           "browser",
           "filesystem-read",
@@ -3493,6 +3517,289 @@ Object.defineProperty(target, "run", { value: () => undefined });
 target.run("cleared.txt");
 `,
       "src/runtime-object-assign-literal-copy-writable.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(effects, []);
+  });
+
+  it("does not create Object.assign properties on non-extensible targets", () => {
+    const effects = collectSemanticMarkers(
+      `
+const target = {};
+Object.preventExtensions(target);
+try {
+  Object.assign(target, { run: Deno.remove });
+} catch {}
+target.run?.("not-created.txt");
+`,
+      "src/runtime-object-assign-non-extensible-target.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(effects, []);
+  });
+
+  it("stops Object.assign after a definitely blocked property", () => {
+    const effects = collectSemanticMarkers(
+      `
+const target = { retained: Deno.remove };
+Object.preventExtensions(target);
+try {
+  Object.assign(target, {
+    blocked: () => undefined,
+    retained: () => undefined,
+  });
+} catch {}
+target.retained("still-retained.txt");
+`,
+      "src/runtime-object-assign-blocked-order.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(effects, ["filesystem-write"]);
+  });
+
+  it("keeps successful Object.assign prefix writes inside try blocks", () => {
+    const effects = collectSemanticMarkers(
+      `
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+try {
+  Object.assign(target, {
+    safe: () => undefined,
+    effectful: Deno.remove,
+  });
+} catch {}
+target.safe("cleared.txt");
+`,
+      "src/runtime-object-assign-try-prefix.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(effects, []);
+  });
+
+  it("does not clear Object.assign writes when a try entry may be skipped", () => {
+    const laterCall = collectSemanticMarkers(
+      `
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+try {
+  maybeThrow();
+  Object.assign(target, {
+    safe: () => undefined,
+    effectful: Deno.remove,
+  });
+} catch {}
+target.safe("retained-after-earlier-call.txt");
+`,
+      "src/runtime-object-assign-later-try-call.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(laterCall, ["filesystem-write"]);
+
+    const conditionalCall = collectSemanticMarkers(
+      `
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+try {
+  if (maybe) {
+    Object.assign(target, {
+      safe: () => undefined,
+      effectful: Deno.remove,
+    });
+  }
+} catch {}
+target.safe("retained-after-conditional-call.txt");
+`,
+      "src/runtime-object-assign-conditional-try-call.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(conditionalCall, ["filesystem-write"]);
+
+    const argumentCall = collectSemanticMarkers(
+      `
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+try {
+  Object.assign(target, makeSource(), {
+    safe: () => undefined,
+    effectful: Deno.remove,
+  });
+} catch {}
+target.safe("retained-after-argument-call.txt");
+`,
+      "src/runtime-object-assign-throwing-argument.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(argumentCall, [
+      "browser",
+      "filesystem-read",
+      "filesystem-watch",
+      "filesystem-write",
+      "network",
+      "process",
+      "server",
+      "shared-cwd",
+    ]);
+
+    const argumentGetter = collectSemanticMarkers(
+      `
+const source = {};
+Object.defineProperty(source, "value", {
+  get() { throw new Error("before call"); },
+});
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+try {
+  Object.assign(target, source.value, {
+    safe: () => undefined,
+    effectful: Deno.remove,
+  });
+} catch {}
+target.safe("retained-after-argument-getter.txt");
+`,
+      "src/runtime-object-assign-throwing-argument-getter.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(argumentGetter, [
+      "browser",
+      "filesystem-read",
+      "filesystem-watch",
+      "filesystem-write",
+      "network",
+      "process",
+      "server",
+      "shared-cwd",
+    ]);
+
+    const outerConditionalTry = collectSemanticMarkers(
+      `
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+if (maybe) {
+  try {
+    Object.assign(target, {
+      safe: () => undefined,
+      effectful: Deno.remove,
+    });
+  } catch {}
+}
+target.safe("retained-after-outer-conditional-try.txt");
+`,
+      "src/runtime-object-assign-conditional-try.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(outerConditionalTry, ["filesystem-write"]);
+  });
+
+  it("tracks Object.assign getter throws within try prefixes", () => {
+    const getterBeforeWrite = collectSemanticMarkers(
+      `
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+try {
+  Object.assign(target, {
+    get safe() { throw new Error("before write"); },
+    effectful: Deno.remove,
+  });
+} catch {}
+target.safe("retained-after-getter.txt");
+`,
+      "src/runtime-object-assign-throwing-getter.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(getterBeforeWrite, ["filesystem-write"]);
+
+    const getterAfterWrite = collectSemanticMarkers(
+      `
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+try {
+  Object.assign(target, {
+    safe: () => undefined,
+    get effectful() { throw new Error("after write"); },
+  });
+} catch {}
+target.safe("cleared-before-getter.txt");
+`,
+      "src/runtime-object-assign-later-throwing-getter.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(getterAfterWrite, []);
+  });
+
+  it("does not invoke Object.assign getters after a blocked write", () => {
+    const markers = collectSemanticMarkers(
+      `
+const later = {};
+Object.defineProperty(later, "observed", {
+  enumerable: true,
+  get: Deno.cwd,
+});
+
+const target = {};
+Object.preventExtensions(target);
+try {
+  Object.assign(target, { blocked: () => undefined }, later);
+} catch {}
+`,
+      "src/runtime-object-assign-blocked-getter-order.test.ts",
+    ).map((marker) => [marker.effect, marker.symbol]);
+    assertEquals(markers, [["shared-cwd", "Deno.cwd"]]);
+  });
+
+  it("does not invoke Object.assign setters after a blocked write", () => {
+    const effects = collectSemanticMarkers(
+      `
+const target = {};
+Object.defineProperty(target, "observed", { set: Deno.remove });
+Object.preventExtensions(target);
+try {
+  Object.assign(target, {
+    blocked: () => undefined,
+    observed: "not-written.txt",
+  });
+} catch {}
+`,
+      "src/runtime-object-assign-blocked-setter-order.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(effects, []);
+  });
+
+  it("uses JavaScript property order for Object.assign accessors", () => {
+    const effects = collectSemanticMarkers(
+      `
+const target = {};
+Object.defineProperty(target, "0", { set: Deno.remove });
+Object.preventExtensions(target);
+try {
+  Object.assign(target, {
+    1: "blocked.txt",
+    0: "setter-runs-first.txt",
+  });
+} catch {}
+`,
+      "src/runtime-object-assign-property-order.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(effects, ["filesystem-write"]);
+  });
+
+  it("masks inherited data when Object.assign creates an own property", () => {
+    const effects = collectSemanticMarkers(
+      `
+const target = Object.create({ run: Deno.remove });
+Object.assign(target, { run: () => undefined });
+Object.seal(target);
+Object.defineProperty(target, "run", { value: () => undefined });
+target.run("cleared.txt");
+
+const returned = Object.assign(
+  Object.create({ run: Deno.remove }),
+  { run: () => undefined },
+);
+returned.run("returned.txt");
+
+const getterReturned = Object.assign(
+  Object.create({ run: Deno.remove }),
+  { get run() { return () => undefined; } },
+);
+getterReturned.run("getter-returned.txt");
+
+const getterSource = { get run() { return () => undefined; } };
+const getterSourceReturned = Object.assign(
+  Object.create({ run: Deno.remove }),
+  getterSource,
+);
+getterSourceReturned.run("getter-source-returned.txt");
+`,
+      "src/runtime-object-assign-inherited-data-shadow.test.ts",
     ).map((marker) => marker.effect);
     assertEquals(effects, []);
   });

--- a/scripts/test/test-semantic-audit.test.ts
+++ b/scripts/test/test-semantic-audit.test.ts
@@ -3687,6 +3687,104 @@ target.safe("retained-after-nullable-argument-receiver.txt");
       "shared-cwd",
     ]);
 
+    const temporalDeadZoneSource = collectSemanticMarkers(
+      `
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+try {
+  Object.assign(target, {
+    safe: () => undefined,
+  }, source);
+} catch {}
+const source = {};
+target.safe("retained-before-source-initialization.txt");
+`,
+      "src/runtime-object-assign-tdz-argument.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(temporalDeadZoneSource, ["filesystem-write"]);
+
+    for (
+      const [kind, declaration, expected] of [
+        ["let", "let source = {};", ["filesystem-write"]],
+        [
+          "class",
+          "class source {}",
+          [
+            "browser",
+            "filesystem-read",
+            "filesystem-watch",
+            "filesystem-write",
+            "network",
+            "process",
+            "server",
+            "shared-cwd",
+          ],
+        ],
+      ] as const
+    ) {
+      const laterLexicalSource = collectSemanticMarkers(
+        `
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+try {
+  Object.assign(target, { safe: () => undefined }, source);
+} catch {}
+${declaration}
+target.safe("retained-before-${kind}-initialization.txt");
+`,
+        `src/runtime-object-assign-${kind}-tdz-argument.test.ts`,
+      ).map((marker) => marker.effect);
+      assertEquals(laterLexicalSource, [...expected]);
+    }
+
+    const laterInnerShadow = collectSemanticMarkers(
+      `
+const source = {};
+{
+  const target = { safe: Deno.remove };
+  Object.preventExtensions(target);
+  try {
+    Object.assign(target, { safe: () => undefined }, source);
+  } catch {}
+  const source = {};
+  target.safe("retained-before-inner-source-initialization.txt");
+}
+`,
+      "src/runtime-object-assign-inner-tdz-argument.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(laterInnerShadow, ["filesystem-write"]);
+
+    const initializedSource = collectSemanticMarkers(
+      `
+const source = {};
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+try {
+  Object.assign(target, { safe: () => undefined }, source);
+} catch {}
+target.safe("cleared-after-source-initialization.txt");
+`,
+      "src/runtime-object-assign-initialized-source.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(initializedSource, []);
+
+    const capturedSource = collectSemanticMarkers(
+      `
+const source = {};
+function run() {
+  const target = { safe: Deno.remove };
+  Object.preventExtensions(target);
+  try {
+    Object.assign(target, { safe: () => undefined }, source);
+  } catch {}
+  target.safe("retained-for-captured-source.txt");
+}
+run();
+`,
+      "src/runtime-object-assign-captured-source.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(capturedSource, ["filesystem-write"]);
+
     const outerConditionalTry = collectSemanticMarkers(
       `
 const target = { safe: Deno.remove };

--- a/scripts/test/test-semantic-audit.test.ts
+++ b/scripts/test/test-semantic-audit.test.ts
@@ -3662,6 +3662,31 @@ target.safe("retained-after-argument-getter.txt");
       "shared-cwd",
     ]);
 
+    const nullableArgumentReceiver = collectSemanticMarkers(
+      `
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+const holder = maybe ? { source: {} } : null;
+try {
+  Object.assign(target, {
+    safe: () => undefined,
+  }, holder!.source);
+} catch {}
+target.safe("retained-after-nullable-argument-receiver.txt");
+`,
+      "src/runtime-object-assign-nullable-argument-receiver.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(nullableArgumentReceiver, [
+      "browser",
+      "filesystem-read",
+      "filesystem-watch",
+      "filesystem-write",
+      "network",
+      "process",
+      "server",
+      "shared-cwd",
+    ]);
+
     const outerConditionalTry = collectSemanticMarkers(
       `
 const target = { safe: Deno.remove };

--- a/scripts/test/test-semantic-audit.test.ts
+++ b/scripts/test/test-semantic-audit.test.ts
@@ -3703,6 +3703,259 @@ target.safe("retained-before-source-initialization.txt");
     ).map((marker) => marker.effect);
     assertEquals(temporalDeadZoneSource, ["filesystem-write"]);
 
+    const temporalDeadZoneCallee = collectSemanticMarkers(
+      `
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+try {
+  assign(target, { safe: () => undefined });
+} catch {}
+const assign = Object.assign;
+target.safe("retained-before-callee-initialization.txt");
+`,
+      "src/runtime-object-assign-tdz-callee.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(temporalDeadZoneCallee, ["filesystem-write"]);
+
+    const temporalDeadZoneCalleeReceiver = collectSemanticMarkers(
+      `
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+try {
+  holder.assign(target, { safe: () => undefined });
+} catch {}
+const holder = { assign: Object.assign };
+target.safe("retained-before-callee-receiver-initialization.txt");
+`,
+      "src/runtime-object-assign-tdz-callee-receiver.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(temporalDeadZoneCalleeReceiver, ["filesystem-write"]);
+
+    const capturedCallee = collectSemanticMarkers(
+      `
+run();
+const assign = Object.assign;
+function run() {
+  const target = { safe: Deno.remove };
+  Object.preventExtensions(target);
+  try {
+    assign(target, { safe: () => undefined });
+  } catch {}
+  target.safe("retained-for-captured-callee.txt");
+}
+`,
+      "src/runtime-object-assign-captured-callee.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(capturedCallee, ["filesystem-write"]);
+
+    const getterBackedCallee = collectSemanticMarkers(
+      `
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+const holder = Object.defineProperty({}, "assign", {
+  get: () => {
+    throw new Error("callee getter failed");
+  },
+});
+try {
+  holder.assign(target, { safe: () => undefined });
+} catch {}
+target.safe("retained-after-callee-getter.txt");
+`,
+      "src/runtime-object-assign-getter-callee.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(getterBackedCallee, ["filesystem-write"]);
+
+    const initializedCallee = collectSemanticMarkers(
+      `
+const assign = Object.assign;
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+try {
+  assign(target, { safe: () => undefined });
+} catch {}
+target.safe("cleared-after-callee-initialization.txt");
+`,
+      "src/runtime-object-assign-initialized-callee.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(initializedCallee, []);
+
+    const initializedCalleeReceiver = collectSemanticMarkers(
+      `
+const holder = { assign: Object.assign };
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+try {
+  holder.assign(target, { safe: () => undefined });
+} catch {}
+target.safe("cleared-after-callee-receiver-initialization.txt");
+`,
+      "src/runtime-object-assign-initialized-callee-receiver.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(initializedCalleeReceiver, []);
+
+    const alternativeCallee = collectSemanticMarkers(
+      `
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+const assign = Math.random() > 0.5 ? Object.assign : Object.freeze;
+try {
+  assign(target, { safe: () => undefined });
+} catch {}
+target.safe("retained-for-alternative-callee.txt");
+`,
+      "src/runtime-object-assign-alternative-callee.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(alternativeCallee, ["filesystem-write"]);
+
+    const partialMemberCallee = collectSemanticMarkers(
+      `
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+const holder = Math.random() > 0.5
+  ? { assign: Object.assign }
+  : { assign: undefined };
+try {
+  holder.assign(target, { safe: () => undefined });
+} catch {}
+target.safe("retained-for-partial-member-callee.txt");
+`,
+      "src/runtime-object-assign-partial-member-callee.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(partialMemberCallee, ["filesystem-write"]);
+
+    const opaqueTrailingSpreadCallee = collectSemanticMarkers(
+      `
+function run(maybeHolder) {
+  const target = { safe: Deno.remove };
+  Object.preventExtensions(target);
+  const holder = { assign: Object.assign, ...maybeHolder };
+  try {
+    holder.assign(target, { safe: () => undefined });
+  } catch {}
+  target.safe("retained-for-opaque-trailing-spread-callee.txt");
+}
+run({});
+`,
+      "src/runtime-object-assign-opaque-trailing-spread-callee.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(opaqueTrailingSpreadCallee, ["filesystem-write"]);
+
+    const exactTrailingPropertyCallee = collectSemanticMarkers(
+      `
+function run(maybeHolder) {
+  const target = { safe: Deno.remove };
+  Object.preventExtensions(target);
+  const holder = { ...maybeHolder, assign: Object.assign };
+  try {
+    holder.assign(target, { safe: () => undefined });
+  } catch {}
+  target.safe("cleared-for-exact-trailing-property-callee.txt");
+}
+run({});
+`,
+      "src/runtime-object-assign-exact-trailing-property-callee.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(exactTrailingPropertyCallee, []);
+
+    const emptyTrailingSpreadCallee = collectSemanticMarkers(
+      `
+const source = {};
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+const holder = { assign: Object.assign, ...source };
+try {
+  holder.assign(target, { safe: () => undefined });
+} catch {}
+target.safe("cleared-for-empty-trailing-spread-callee.txt");
+`,
+      "src/runtime-object-assign-empty-trailing-spread-callee.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(emptyTrailingSpreadCallee, []);
+
+    const undefinedTrailingSpreadCallee = collectSemanticMarkers(
+      `
+const source = { assign: undefined };
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+const holder = { assign: Object.assign, ...source };
+try {
+  holder.assign(target, { safe: () => undefined });
+} catch {}
+target.safe("retained-for-undefined-trailing-spread-callee.txt");
+`,
+      "src/runtime-object-assign-undefined-trailing-spread-callee.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(undefinedTrailingSpreadCallee, ["filesystem-write"]);
+
+    const maybeUndefinedTrailingSpreadCallee = collectSemanticMarkers(
+      `
+const source = Math.random() > 0.5
+  ? { assign: Object.assign }
+  : { assign: undefined };
+const target = { safe: Deno.remove };
+Object.preventExtensions(target);
+const holder = { assign: Object.assign, ...source };
+try {
+  holder.assign(target, { safe: () => undefined });
+} catch {}
+target.safe("retained-for-maybe-undefined-trailing-spread-callee.txt");
+`,
+      "src/runtime-object-assign-maybe-undefined-trailing-spread-callee.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(maybeUndefinedTrailingSpreadCallee, ["filesystem-write"]);
+
+    const computedCallableOverrideCallee = collectSemanticMarkers(
+      `
+function run(key) {
+  const target = { safe: Deno.remove };
+  Object.preventExtensions(target);
+  const holder = { assign: Object.assign, [key]: () => undefined };
+  try {
+    holder.assign(target, { safe: () => undefined });
+  } catch {}
+  target.safe("retained-for-computed-callable-override-callee.txt");
+}
+run("assign");
+`,
+      "src/runtime-object-assign-computed-callable-override-callee.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(computedCallableOverrideCallee, ["filesystem-write"]);
+
+    const computedPrimitiveOverrideCallee = collectSemanticMarkers(
+      `
+function run(key) {
+  const target = { safe: Deno.remove };
+  Object.preventExtensions(target);
+  const holder = { assign: Object.assign, [key]: "not callable" };
+  try {
+    holder.assign(target, { safe: () => undefined });
+  } catch {}
+  target.safe("retained-for-computed-primitive-override-callee.txt");
+}
+run("assign");
+`,
+      "src/runtime-object-assign-computed-primitive-override-callee.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(computedPrimitiveOverrideCallee, ["filesystem-write"]);
+
+    const exactPropertyAfterComputedCallee = collectSemanticMarkers(
+      `
+function run(key) {
+  const target = { safe: Deno.remove };
+  Object.preventExtensions(target);
+  const holder = { [key]: "not callable", assign: Object.assign };
+  try {
+    holder.assign(target, { safe: () => undefined });
+  } catch {}
+  target.safe("cleared-for-exact-property-after-computed-callee.txt");
+}
+run("other");
+`,
+      "src/runtime-object-assign-exact-property-after-computed-callee.test.ts",
+    ).map((marker) => marker.effect);
+    assertEquals(exactPropertyAfterComputedCallee, []);
+
     for (
       const [kind, declaration, expected] of [
         ["let", "let source = {};", ["filesystem-write"]],

--- a/scripts/test/test-semantic-audit.ts
+++ b/scripts/test/test-semantic-audit.ts
@@ -636,6 +636,7 @@ type NamespacePropertyOperation =
     readonly minimumArrayIndex?: number;
     readonly fallbackOnly?: boolean;
     readonly replacesFallback?: boolean;
+    readonly fallbackSource?: RuntimeBinding;
     readonly enumerable?: boolean;
     readonly configurable?: boolean;
     readonly writable?: boolean;
@@ -687,6 +688,7 @@ type RuntimeBinding =
     readonly exactArrayLength?: number;
     readonly extensible?: boolean;
     readonly integrityLevel?: RuntimeIntegrityLevel;
+    readonly hasUnknownOwnProperties?: boolean;
     readonly properties: ReadonlyMap<string, RuntimeBinding>;
     readonly propertyOperations?: readonly NamespacePropertyOperation[];
   }
@@ -820,6 +822,7 @@ export function collectSemanticMarkers(
   const program = ast.program as unknown as Node;
   const bindings = collectImportBindings(program, file);
   const markers: SemanticMarker[] = [];
+  const definitelyReachedTryEntryPrefixClearingCalls = new Set<Node>();
 
   const visit = (
     node: Node,
@@ -831,6 +834,12 @@ export function collectSemanticMarkers(
     const nextScopes = SCOPE_NODES.has(node.type)
       ? [...scopes, createScope(node, bindings, scopes)]
       : scopes;
+    const tryEntryCall = allowAssignmentClearing
+      ? runtimeTryEntryPrefixClearingCall(node, bindings, nextScopes)
+      : undefined;
+    if (tryEntryCall) {
+      definitelyReachedTryEntryPrefixClearingCalls.add(tryEntryCall);
+    }
     if (node.type === "VariableDeclarator") {
       const scope = nextScopes.at(-1);
       if (scope && declarationBelongsToScope(node, scope)) {
@@ -910,6 +919,7 @@ export function collectSemanticMarkers(
       bindings,
       nextScopes,
       allowAssignmentClearing,
+      definitelyReachedTryEntryPrefixClearingCalls.has(node),
     );
   };
   visit(program, []);
@@ -2513,6 +2523,31 @@ function namespacePropertyNames(
   return propertyNames;
 }
 
+function runtimeObjectAssignPropertyNames(
+  binding: RuntimeBinding,
+): readonly string[] {
+  const candidates = flattenRuntimeBindings(binding);
+  const operations = candidates.length === 1 &&
+      candidates[0].kind === "namespace-object"
+    ? candidates[0].propertyOperations ?? []
+    : [];
+  const names = operations.flatMap((operation) =>
+    operation.kind === "define" ? [operation.name] : []
+  );
+  return [...new Set(names)].sort(compareRuntimeOwnPropertyNames);
+}
+
+function compareRuntimeOwnPropertyNames(left: string, right: string): number {
+  const leftIndex = runtimeArrayIndex(left);
+  const rightIndex = runtimeArrayIndex(right);
+  if (leftIndex !== undefined && rightIndex !== undefined) {
+    return leftIndex - rightIndex;
+  }
+  if (leftIndex !== undefined) return -1;
+  if (rightIndex !== undefined) return 1;
+  return 0;
+}
+
 function conservativeModuleEffects(
   source: string,
 ): readonly SemanticEffect[] {
@@ -2827,11 +2862,10 @@ function mutationCallMarker(
   }
   const canonicalName = `${binding.receiver}.${binding.method}`;
   if (canonicalName === "Object.create") return undefined;
-  let setterMarkers: readonly SemanticMarker[] = [];
-  let getterMarkers: readonly SemanticMarker[] = [];
+  let accessorMarkers: readonly SemanticMarker[] = [];
   if (canonicalName === "Reflect.set") {
     const property = literalPropertyName(args[1]);
-    setterMarkers = memberSetterRuntimeEffectMarkers(
+    accessorMarkers = memberSetterRuntimeEffectMarkers(
       property === undefined
         ? runtimeUnknownPropertyExpression(args[0])
         : runtimePropertyExpression(args[0], property),
@@ -2841,8 +2875,7 @@ function mutationCallMarker(
       args[2],
     );
   } else if (canonicalName === "Object.assign") {
-    setterMarkers = objectAssignSetterMarkers(args, line, imports, scopes);
-    getterMarkers = objectAssignGetterMarkers(args, line, imports, scopes);
+    accessorMarkers = objectAssignAccessorMarkers(args, line, imports, scopes);
   }
   const mutatesSingleProperty = GLOBAL_SINGLE_PROPERTY_MUTATORS.has(
     canonicalName,
@@ -2874,46 +2907,48 @@ function mutationCallMarker(
       symbol: `${calleeName}(${target.symbol}.${property ?? "*"})`,
     };
   }
-  const accessorMarkers = [...getterMarkers, ...setterMarkers];
   return accessorMarkers.length > 0
     ? [...accessorMarkers, ...(mutationMarker ? [mutationMarker] : [])]
     : mutationMarker;
 }
 
-function objectAssignGetterMarkers(
-  args: readonly unknown[],
-  line: number,
-  imports: ImportBindings,
-  scopes: readonly Scope[],
-): readonly SemanticMarker[] {
-  return args.slice(1).flatMap((source) => {
-    const sourceBinding = runtimeBindingForExpression(source, imports, scopes);
-    return getterRuntimeEffectMarkers(
-      runtimeUnknownPropertyGetterEffectBinding(sourceBinding, true),
-      `Object.assign(${
-        invocationSymbol(
-          unwrapExpression(source) ?? {
-            type: "Identifier",
-            name: "source",
-          },
-        )
-      } getter)`,
-      line,
-    );
-  });
-}
-
-function objectAssignSetterMarkers(
+function objectAssignAccessorMarkers(
   args: readonly unknown[],
   line: number,
   imports: ImportBindings,
   scopes: readonly Scope[],
 ): readonly SemanticMarker[] {
   const markers: SemanticMarker[] = [];
-  for (const sourceExpression of args.slice(1)) {
-    const source = unwrapExpression(sourceExpression);
-    if (!source || source.type !== "ObjectExpression") {
+  let targetBinding = runtimeBindingForExpression(args[0], imports, scopes);
+  objectAssignSources:
+  for (const source of args.slice(1)) {
+    const sourceBinding = runtimeBindingForExpression(source, imports, scopes);
+    const sourceSymbol = invocationSymbol(
+      unwrapExpression(source) ?? {
+        type: "Identifier",
+        name: "source",
+      },
+    );
+    const sourceNode = unwrapExpression(source);
+    const sourceProperties = sourceNode?.type === "ObjectExpression" &&
+        Array.isArray(sourceNode.properties)
+      ? sourceNode.properties
+      : undefined;
+    const entries = sourceProperties
+      ? localMutationResultAssignedEntries("Object.assign", [args[0], source])
+      : undefined;
+    const hasExactOrder = sourceProperties !== undefined &&
+      sourceProperties.every((property) =>
+        isNode(property) && staticObjectPropertyName(property) !== undefined
+      ) && entries !== undefined &&
+      entries.every((entry) => entry.property !== undefined);
+    if (!hasExactOrder || !entries) {
       markers.push(
+        ...getterRuntimeEffectMarkers(
+          runtimeUnknownPropertyGetterEffectBinding(sourceBinding, true),
+          `Object.assign(${sourceSymbol} getter)`,
+          line,
+        ),
         ...memberSetterRuntimeEffectMarkers(
           runtimeUnknownPropertyExpression(args[0]),
           line,
@@ -2924,27 +2959,45 @@ function objectAssignSetterMarkers(
       );
       continue;
     }
-    for (
-      const property of Array.isArray(source.properties)
-        ? source.properties
-        : []
-    ) {
-      const propertyName = isNode(property)
-        ? staticObjectPropertyName(property)
-        : undefined;
+
+    for (const entry of entries) {
+      const property = entry.property;
+      if (property === undefined) continue;
       markers.push(
-        ...memberSetterRuntimeEffectMarkers(
-          propertyName === undefined
-            ? runtimeUnknownPropertyExpression(args[0])
-            : runtimePropertyExpression(args[0], propertyName),
+        ...getterRuntimeEffectMarkers(
+          sourceBinding
+            ? runtimePropertyGetterEffectBinding(
+              sourceBinding,
+              property,
+              true,
+            )
+            : undefined,
+          `Object.assign(${sourceSymbol} getter)`,
           line,
-          imports,
-          scopes,
-          property.type === "ObjectProperty"
-            ? property.value
-            : unknownRuntimeValueExpression(),
         ),
       );
+      const targetMember = runtimePropertyExpression(args[0], property);
+      const setterBinding = targetBinding
+        ? runtimePropertySetterBinding(targetBinding, property)
+        : undefined;
+      const targetChain = memberChain(targetMember);
+      markers.push(
+        ...callableRuntimeBindingMarkers(
+          setterBinding,
+          `${targetChain?.join(".") ?? invocationSymbol(targetMember)} setter`,
+          line,
+          [entry.expression],
+        ),
+      );
+      if (!targetBinding) continue;
+      const applied = applyRuntimeObjectAssignEntry(
+        targetBinding,
+        entry,
+        imports,
+        scopes,
+      );
+      if (applied.write.outcome === "blocked") break objectAssignSources;
+      targetBinding = applied.result;
     }
   }
   return markers;
@@ -4002,11 +4055,18 @@ function visitRuntimeBindingSummary(
   imports: ImportBindings,
   scopes: readonly Scope[],
   allowClearing: boolean,
+  definitelyReachedTryEntryPrefixClearingCalls = new Set<Node>(),
 ): void {
   if (isErasedTypeScriptNode(node)) return;
   const nextScopes = SCOPE_NODES.has(node.type)
     ? [...scopes, createScope(node, imports, scopes)]
     : scopes;
+  const tryEntryCall = allowClearing
+    ? runtimeTryEntryPrefixClearingCall(node, imports, nextScopes)
+    : undefined;
+  if (tryEntryCall) {
+    definitelyReachedTryEntryPrefixClearingCalls.add(tryEntryCall);
+  }
   if (node.type === "VariableDeclarator") {
     const scope = nextScopes.at(-1);
     if (scope && declarationBelongsToScope(node, scope)) {
@@ -4041,6 +4101,7 @@ function visitRuntimeBindingSummary(
             imports,
             nextScopes,
             childAllowsClearing,
+            definitelyReachedTryEntryPrefixClearingCalls,
           );
         }
       }
@@ -4050,10 +4111,17 @@ function visitRuntimeBindingSummary(
         imports,
         nextScopes,
         childAllowsClearing,
+        definitelyReachedTryEntryPrefixClearingCalls,
       );
     }
   }
-  bindRuntimeCallMutation(node, imports, nextScopes, allowClearing);
+  bindRuntimeCallMutation(
+    node,
+    imports,
+    nextScopes,
+    allowClearing,
+    definitelyReachedTryEntryPrefixClearingCalls.has(node),
+  );
 }
 
 function collectHoistedVarDeclaredNames(
@@ -4278,6 +4346,10 @@ function mergeRuntimeNamespaceBindings(
       : undefined,
     integrityLevel: existing.integrityLevel === incoming.integrityLevel
       ? existing.integrityLevel
+      : undefined,
+    hasUnknownOwnProperties: existing.hasUnknownOwnProperties === true ||
+        incoming.hasUnknownOwnProperties === true
+      ? true
       : undefined,
     properties,
   };
@@ -4583,6 +4655,7 @@ function bindRuntimeCallMutation(
   imports: ImportBindings,
   scopes: readonly Scope[],
   allowClearing: boolean,
+  allowPrefixClearing = false,
 ): void {
   if (!isCallLikeExpression(node) || !isNode(node.callee)) return;
   const callee = unwrapExpression(node.callee);
@@ -4740,10 +4813,37 @@ function bindRuntimeCallMutation(
         invocation.args.length >= 4
       ? invocation.args[3]
       : target;
+    let prefixAllowsClearing = canonicalName === "Object.assign" &&
+      allowPrefixClearing;
     for (const entry of assigned) {
+      if (
+        canonicalName === "Object.assign" &&
+        entry.copyReadDefinitelyCompletes !== true
+      ) {
+        prefixAllowsClearing = false;
+      }
+      const objectAssignWrite = canonicalName === "Object.assign" &&
+          entry.property !== undefined
+        ? runtimeObjectAssignPropertyWrite(
+          runtimeBindingForExpression(mutationTarget, imports, scopes),
+          entry.property,
+        )
+        : undefined;
+      if (
+        objectAssignWrite?.outcome === "blocked"
+      ) {
+        break;
+      }
+      if (objectAssignWrite?.outcome === "setter") {
+        prefixAllowsClearing = false;
+        continue;
+      }
       const attributes = descriptorMutations.find((descriptor) =>
         descriptor.property === entry.property
       )?.attributes;
+      const effectiveAttributes = objectAssignWrite?.outcome === "assigned"
+        ? objectAssignWrite.attributes
+        : attributes;
       const binding = localMutationAssignedEntryBinding(
         entry,
         imports,
@@ -4759,12 +4859,21 @@ function bindRuntimeCallMutation(
           scopes,
           {
             allowClearing: entry.definiteOverwrite === true &&
-              mutationAllowsClearing,
-            enumerable: attributes ? attributes.enumerable : entry.enumerable,
-            configurable: attributes
-              ? attributes.configurable
+              (mutationAllowsClearing ||
+                prefixAllowsClearing &&
+                  objectAssignWrite?.outcome === "assigned") &&
+              (objectAssignWrite === undefined ||
+                objectAssignWrite.outcome === "assigned"),
+            definitelyAssigned: objectAssignWrite?.outcome === "assigned",
+            enumerable: effectiveAttributes
+              ? effectiveAttributes.enumerable
+              : entry.enumerable,
+            configurable: effectiveAttributes
+              ? effectiveAttributes.configurable
               : entry.configurable,
-            writable: attributes ? attributes.writable : entry.writable,
+            writable: effectiveAttributes
+              ? effectiveAttributes.writable
+              : entry.writable,
           },
         );
       } else {
@@ -4775,6 +4884,9 @@ function bindRuntimeCallMutation(
           imports,
           scopes,
         );
+      }
+      if (objectAssignWrite?.outcome !== "assigned") {
+        prefixAllowsClearing = false;
       }
     }
     for (const accessor of descriptorMutations) {
@@ -5025,6 +5137,11 @@ function mutationCallResultRuntimeBinding(
       ? emptyRuntimeNamespaceBinding()
       : targetBinding ?? emptyRuntimeNamespaceBinding();
     if (canonicalName === "Object.create") {
+      const prototypeBinding = runtimeBindingForExpression(
+        invocation.args[0],
+        imports,
+        scopes,
+      );
       result = appendRuntimeMutationResultProperty(
         result,
         undefined,
@@ -5037,6 +5154,7 @@ function mutationCallResultRuntimeBinding(
           preservesPrevious: false,
           fallbackOnly: true,
           replacesFallback: true,
+          fallbackSource: prototypeBinding,
         },
       );
     }
@@ -5088,19 +5206,19 @@ function mutationCallResultRuntimeBinding(
           },
         );
       } else if (canonicalName === "Object.assign") {
+        objectAssignSources:
         for (const source of invocation.args.slice(1)) {
           const sourceBinding = runtimeBindingForExpression(
             source,
             imports,
             scopes,
           );
-          const getterEnumerabilities = sourceBinding
-            ? runtimeBindingHasPartialAlternative(sourceBinding)
-              ? []
-              : runtimeUnknownGetterEnumerabilities(sourceBinding)
-            : [];
-          if (sourceBinding && getterEnumerabilities.length > 0) {
-            for (const property of namespacePropertyNames(sourceBinding)) {
+          if (
+            sourceBinding && runtimeBindingHasExactOwnPropertySet(sourceBinding)
+          ) {
+            for (
+              const property of runtimeObjectAssignPropertyNames(sourceBinding)
+            ) {
               const sourceResolution = runtimePropertyResolution(
                 sourceBinding,
                 property,
@@ -5108,22 +5226,29 @@ function mutationCallResultRuntimeBinding(
                 true,
               );
               if (sourceResolution.enumerable === false) continue;
-              const preservesSetter = runtimePropertySetterBinding(
+              const write = runtimeObjectAssignPropertyWrite(
                 result,
                 property,
-              ) !== undefined;
+              );
+              if (write.outcome === "blocked") break objectAssignSources;
+              if (write.outcome === "setter") continue;
               const definitelyCopies = sourceResolution.enumerable === true &&
                 !sourceResolution.defaultMayRun;
+              const definitelyAssigns = definitelyCopies &&
+                write.outcome === "assigned";
+              const attributes = write.outcome === "assigned"
+                ? write.attributes
+                : undefined;
               result = appendRuntimeMutationResultProperty(
                 result,
                 property,
                 runtimeEnumerablePropertyBinding(sourceBinding, property),
                 {
-                  preservesPrevious: preservesSetter || !definitelyCopies,
-                  allowClearing: !preservesSetter && definitelyCopies,
-                  configurable: definitelyCopies ? true : undefined,
-                  enumerable: definitelyCopies ? true : undefined,
-                  writable: definitelyCopies ? true : undefined,
+                  preservesPrevious: !definitelyAssigns,
+                  allowClearing: definitelyAssigns,
+                  configurable: attributes?.configurable,
+                  enumerable: attributes?.enumerable,
+                  writable: attributes?.writable,
                 },
               );
             }
@@ -5135,28 +5260,16 @@ function mutationCallResultRuntimeBinding(
               [invocation.args[0], source],
             )
           ) {
-            const preservesSetter = entry.property !== undefined &&
-              runtimePropertySetterBinding(result, entry.property) !==
-                undefined;
-            const createsOwnDataProperty = entry.property !== undefined &&
-              entry.definiteOverwrite === true &&
-              !preservesSetter &&
-              runtimeOwnPropertyDefinitelyAbsent(result, entry.property);
-            result = appendRuntimeMutationResultProperty(
+            const applied = applyRuntimeObjectAssignEntry(
               result,
-              entry.property,
-              localMutationAssignedEntryBinding(entry, imports, scopes),
-              {
-                preservesPrevious: preservesSetter,
-                allowClearing: entry.definiteOverwrite === true &&
-                  !preservesSetter,
-                configurable: createsOwnDataProperty
-                  ? true
-                  : entry.configurable,
-                writable: createsOwnDataProperty ? true : entry.writable,
-                enumerable: createsOwnDataProperty ? true : entry.enumerable,
-              },
+              entry,
+              imports,
+              scopes,
             );
+            if (applied.write.outcome === "blocked") {
+              break objectAssignSources;
+            }
+            result = applied.result;
           }
         }
       } else {
@@ -5362,6 +5475,7 @@ interface RuntimeMutationResultPropertyOptions {
   readonly writable?: boolean;
   readonly fallbackOnly?: boolean;
   readonly replacesFallback?: boolean;
+  readonly fallbackSource?: RuntimeBinding;
 }
 
 function appendRuntimeMutationResultProperty(
@@ -5386,6 +5500,7 @@ function appendRuntimeMutationResultProperty(
         crossesFunctionBoundary: false,
         fallbackOnly: options.fallbackOnly,
         replacesFallback: options.replacesFallback,
+        fallbackSource: options.fallbackSource,
       }
       : {
         kind: "define",
@@ -5420,6 +5535,7 @@ interface LocalMutationAssignedEntry {
   readonly expression: unknown;
   readonly unknownSource?: unknown;
   readonly copySource?: unknown;
+  readonly copyReadDefinitelyCompletes?: boolean;
   readonly definiteOverwrite?: boolean;
   readonly enumerable?: boolean;
   readonly configurable?: boolean;
@@ -5432,43 +5548,7 @@ function localMutationAssignedEntries(
   args: readonly unknown[],
 ): readonly LocalMutationAssignedEntry[] {
   if (canonicalName === "Object.assign") {
-    return args.slice(1).flatMap((sourceExpression) => {
-      const source = unwrapExpression(sourceExpression);
-      if (source?.type !== "ObjectExpression") {
-        return [{
-          expression: runtimeUnknownPropertyExpression(sourceExpression),
-          unknownSource: sourceExpression,
-          copyEnumerableOnly: true,
-        }];
-      }
-      return (Array.isArray(source.properties) ? source.properties : []).map(
-        (property) => {
-          const propertyName = isNode(property)
-            ? staticObjectPropertyName(property)
-            : undefined;
-          if (propertyName !== undefined) {
-            return {
-              property: propertyName,
-              expression: runtimePropertyExpression(
-                sourceExpression,
-                propertyName,
-              ),
-              copySource: sourceExpression,
-              definiteOverwrite: true,
-            };
-          }
-          const unknownSource = isNode(property) &&
-              property.type === "SpreadElement" && isNode(property.argument)
-            ? property.argument
-            : sourceExpression;
-          return {
-            expression: runtimeUnknownPropertyExpression(unknownSource),
-            unknownSource,
-            copyEnumerableOnly: true,
-          };
-        },
-      );
-    });
+    return args.slice(1).flatMap(objectAssignSourceEntries);
   }
   if (canonicalName === "Object.defineProperties") {
     return [{
@@ -5508,6 +5588,75 @@ function localMutationAssignedEntries(
   return [];
 }
 
+function objectAssignSourceEntries(
+  sourceExpression: unknown,
+): readonly LocalMutationAssignedEntry[] {
+  const source = unwrapExpression(sourceExpression);
+  if (source?.type !== "ObjectExpression") {
+    return [{
+      expression: runtimeUnknownPropertyExpression(sourceExpression),
+      unknownSource: sourceExpression,
+      copyEnumerableOnly: true,
+    }];
+  }
+  const entries = (Array.isArray(source.properties) ? source.properties : [])
+    .map((property): LocalMutationAssignedEntry => {
+      const propertyName = isNode(property)
+        ? staticObjectPropertyName(property)
+        : undefined;
+      if (propertyName !== undefined) {
+        return {
+          property: propertyName,
+          expression: runtimePropertyExpression(
+            sourceExpression,
+            propertyName,
+          ),
+          copySource: sourceExpression,
+          copyReadDefinitelyCompletes: isObjectPropertyReadNonThrowing(
+            property,
+          ),
+          definiteOverwrite: true,
+        };
+      }
+      const unknownSource = isNode(property) &&
+          property.type === "SpreadElement" && isNode(property.argument)
+        ? property.argument
+        : sourceExpression;
+      return {
+        expression: runtimeUnknownPropertyExpression(unknownSource),
+        unknownSource,
+        copyEnumerableOnly: true,
+      };
+    });
+  if (entries.some((entry) => entry.property === undefined)) {
+    return [{
+      expression: runtimeUnknownPropertyExpression(sourceExpression),
+      unknownSource: sourceExpression,
+      copyEnumerableOnly: true,
+    }];
+  }
+  const exactEntries: Array<
+    LocalMutationAssignedEntry & { readonly property: string }
+  > = [];
+  for (const entry of entries) {
+    if (entry.property === undefined) continue;
+    exactEntries.push({ ...entry, property: entry.property });
+  }
+  const unique = new Map<
+    string,
+    LocalMutationAssignedEntry & { readonly property: string }
+  >();
+  for (const entry of exactEntries) unique.set(entry.property, entry);
+  return [...unique.values()].sort((left, right) =>
+    compareRuntimeOwnPropertyNames(left.property, right.property)
+  );
+}
+
+function isObjectPropertyReadNonThrowing(property: Node): boolean {
+  if (property.type === "ObjectProperty") return property.kind !== "get";
+  return property.type === "ObjectMethod" && property.kind !== "get";
+}
+
 function localMutationAssignedEntryBinding(
   entry: LocalMutationAssignedEntry,
   imports: ImportBindings,
@@ -5538,7 +5687,11 @@ function localMutationAssignedEntryBinding(
     const copied = sourceBinding
       ? runtimeUnknownPropertyResolution(sourceBinding, true).binding
       : undefined;
-    if (copied) return copied;
+    if (copied) {
+      return runtimeBindingHasUnknownOwnProperties(sourceBinding)
+        ? unionRuntimeBindings([copied, conservativeSemanticEffectBinding()])
+        : copied;
+    }
     const source = unwrapExpression(entry.unknownSource);
     const sourceName = source?.type === "Identifier" &&
         typeof source.name === "string"
@@ -5551,7 +5704,7 @@ function localMutationAssignedEntryBinding(
       sourceBinding !== undefined &&
       flattenRuntimeBindings(sourceBinding).every((candidate) =>
         candidate.kind === "namespace-object"
-      );
+      ) && !runtimeBindingHasUnknownOwnProperties(sourceBinding);
     return sourceIsFullyModeled
       ? undefined
       : conservativeSemanticEffectBinding();
@@ -5872,6 +6025,117 @@ function runtimeDescriptorDefinitionAllowsClearing(
     if (writable && existing.writable !== true) return false;
   }
   return true;
+}
+
+type RuntimeObjectAssignPropertyWrite =
+  | { readonly outcome: "blocked" | "setter" | "uncertain" }
+  | {
+    readonly outcome: "assigned";
+    readonly attributes: RuntimeDescriptorAttributes;
+  };
+
+function runtimeObjectAssignPropertyWrite(
+  target: RuntimeBinding | undefined,
+  property: string,
+): RuntimeObjectAssignPropertyWrite {
+  if (!target) return { outcome: "uncertain" };
+  const resolution = runtimePropertyResolution(target, property, true);
+  const candidates = flattenRuntimeBindings(resolution.binding);
+  const hasSetter = candidates.some((candidate) =>
+    candidate.kind === "property-setter"
+  );
+  const definitelyUsesSetter = !resolution.defaultMayRun && hasSetter &&
+    candidates.every((candidate) =>
+      candidate.kind === "property-getter-effect" ||
+      candidate.kind === "property-getter-value" ||
+      candidate.kind === "property-setter"
+    );
+  if (definitelyUsesSetter) return { outcome: "setter" };
+
+  const ownPropertyDefinitelyAbsent = runtimeOwnPropertyDefinitelyAbsent(
+    target,
+    property,
+  );
+  if (ownPropertyDefinitelyAbsent) {
+    if (hasSetter) return { outcome: "uncertain" };
+    if (
+      runtimeBindingExtensibility(target) === false ||
+      !resolution.defaultMayRun && resolution.writable !== true
+    ) {
+      return { outcome: "blocked" };
+    }
+    const inheritedWriteDefinitelySucceeds = !resolution.defaultMayRun &&
+      resolution.writable === true;
+    const propertyDefinitelyAbsentThroughout = resolution.defaultMayRun &&
+      resolution.binding === undefined &&
+      (resolution.aliasTargets?.length ?? 0) === 0;
+    if (
+      runtimeBindingExtensibility(target) === true &&
+      (inheritedWriteDefinitelySucceeds || propertyDefinitelyAbsentThroughout)
+    ) {
+      return {
+        outcome: "assigned",
+        attributes: {
+          configurable: true,
+          enumerable: true,
+          writable: true,
+        },
+      };
+    }
+    return { outcome: "uncertain" };
+  }
+
+  if (!resolution.defaultMayRun && !hasSetter) {
+    if (resolution.writable === false) return { outcome: "blocked" };
+    if (resolution.writable === true) {
+      return {
+        outcome: "assigned",
+        attributes: {
+          configurable: resolution.configurable,
+          enumerable: resolution.enumerable,
+          writable: true,
+        },
+      };
+    }
+  }
+  return { outcome: "uncertain" };
+}
+
+function applyRuntimeObjectAssignEntry(
+  target: RuntimeBinding,
+  entry: LocalMutationAssignedEntry,
+  imports: ImportBindings,
+  scopes: readonly Scope[],
+): {
+  readonly result: RuntimeBinding;
+  readonly write: RuntimeObjectAssignPropertyWrite;
+} {
+  const write = entry.property === undefined
+    ? { outcome: "uncertain" as const }
+    : runtimeObjectAssignPropertyWrite(target, entry.property);
+  if (write.outcome === "blocked" || write.outcome === "setter") {
+    return { result: target, write };
+  }
+  const definitelyAssigns = entry.definiteOverwrite === true &&
+    write.outcome === "assigned";
+  const attributes = write.outcome === "assigned"
+    ? write.attributes
+    : undefined;
+  return {
+    result: appendRuntimeMutationResultProperty(
+      target,
+      entry.property,
+      localMutationAssignedEntryBinding(entry, imports, scopes),
+      {
+        preservesPrevious: !definitelyAssigns,
+        allowClearing: definitelyAssigns,
+        configurable: attributes?.configurable ?? entry.configurable,
+        writable: attributes?.writable ?? entry.writable,
+        enumerable: attributes?.enumerable ?? entry.enumerable,
+      },
+    ),
+    write,
+  };
 }
 
 function runtimeBindingExtensibility(
@@ -6441,6 +6705,25 @@ function runtimeFunctionReturnExpressions(value: Node): {
   return { expressions, known: true };
 }
 
+function runtimeFunctionUnconditionalReturnExpression(
+  value: Node,
+): unknown | undefined {
+  if (
+    value.type === "ArrowFunctionExpression" && isNode(value.body) &&
+    value.body.type !== "BlockStatement"
+  ) {
+    return value.body;
+  }
+  if (!isNode(value.body) || value.body.type !== "BlockStatement") {
+    return undefined;
+  }
+  const statements = Array.isArray(value.body.body) ? value.body.body : [];
+  const statement = statements.length === 1 && isNode(statements[0])
+    ? statements[0]
+    : undefined;
+  return statement?.type === "ReturnStatement" ? statement.argument : undefined;
+}
+
 function isFunctionLikeNode(node: Node): boolean {
   return node.type === "ArrowFunctionExpression" ||
     node.type === "FunctionDeclaration" ||
@@ -6523,12 +6806,14 @@ function bindRuntimeNamedPropertyMutation(
 interface RuntimeMemberMutationOptions {
   readonly allowClearing?: boolean;
   readonly clearAccessors?: boolean;
+  readonly definitelyAssigned?: boolean;
   readonly configurable?: boolean;
   readonly enumerable?: boolean;
   readonly writable?: boolean;
   readonly fallbackOnly?: boolean;
   readonly minimumArrayIndex?: number;
   readonly replacesFallback?: boolean;
+  readonly fallbackSource?: RuntimeBinding;
 }
 
 function bindRuntimeNamedPropertyMutationBinding(
@@ -6713,12 +6998,14 @@ function bindRuntimeMemberAssignmentTarget(
     (options.clearAccessors ||
       runtimePropertySetterBindingAtPath(existing, propertyPath) ===
         undefined);
-  const defaultMayRun = expressionMayBeUndefined(
-    assignedExpression,
-    binding,
-    imports,
-    scopes,
-  );
+  const defaultMayRun = options.definitelyAssigned === true
+    ? false
+    : expressionMayBeUndefined(
+      assignedExpression,
+      binding,
+      imports,
+      scopes,
+    );
   const aliasTargets = runtimeNamespaceAliasTargetsForExpression(
     assignedExpression,
     imports,
@@ -6738,6 +7025,7 @@ function bindRuntimeMemberAssignmentTarget(
       options.enumerable,
       options.configurable,
       options.writable,
+      options.fallbackSource,
     )
     : assignRuntimeProperty(
       existing,
@@ -7166,6 +7454,7 @@ function assignUnknownRuntimeProperty(
   enumerable?: boolean,
   configurable?: boolean,
   writable?: boolean,
+  fallbackSource?: RuntimeBinding,
 ): RuntimeBinding {
   const [property, ...rest] = objectPath;
   if (property) {
@@ -7182,6 +7471,7 @@ function assignUnknownRuntimeProperty(
       enumerable,
       configurable,
       writable,
+      fallbackSource,
     );
     return assignRuntimeProperty(existing, [property], nested, false, false);
   }
@@ -7194,6 +7484,7 @@ function assignUnknownRuntimeProperty(
     minimumArrayIndex,
     fallbackOnly,
     replacesFallback,
+    fallbackSource,
     enumerable,
     configurable,
     writable,
@@ -7225,6 +7516,7 @@ function appendRuntimePropertyOperation(
       previous.minimumArrayIndex === operation.minimumArrayIndex &&
       previous.fallbackOnly === operation.fallbackOnly &&
       previous.replacesFallback === operation.replacesFallback &&
+      previous.fallbackSource === operation.fallbackSource &&
       previous.enumerable === operation.enumerable &&
       previous.configurable === operation.configurable &&
       previous.writable === operation.writable
@@ -7235,6 +7527,7 @@ function appendRuntimePropertyOperation(
         exactArrayLength: updatedRuntimeArrayLength(existing, operation),
         extensible: existing.extensible,
         integrityLevel: existing.integrityLevel,
+        hasUnknownOwnProperties: existing.hasUnknownOwnProperties,
         properties: existing.properties,
         propertyOperations: [
           ...existing.propertyOperations.slice(0, -1),
@@ -7256,6 +7549,7 @@ function appendRuntimePropertyOperation(
             minimumArrayIndex: operation.minimumArrayIndex,
             fallbackOnly: operation.fallbackOnly,
             replacesFallback: operation.replacesFallback,
+            fallbackSource: operation.fallbackSource,
             enumerable: operation.enumerable,
             configurable: operation.configurable,
             writable: operation.writable,
@@ -7269,6 +7563,7 @@ function appendRuntimePropertyOperation(
       exactArrayLength: updatedRuntimeArrayLength(existing, operation),
       extensible: existing.extensible,
       integrityLevel: existing.integrityLevel,
+      hasUnknownOwnProperties: existing.hasUnknownOwnProperties,
       properties: existing.properties,
       propertyOperations: [...existing.propertyOperations, operation],
     };
@@ -7284,6 +7579,9 @@ function appendRuntimePropertyOperation(
       : undefined,
     integrityLevel: existing?.kind === "namespace-object"
       ? existing.integrityLevel
+      : undefined,
+    hasUnknownOwnProperties: existing?.kind === "namespace-object"
+      ? existing.hasUnknownOwnProperties
       : undefined,
     properties: new Map(),
     propertyOperations: existing
@@ -7547,6 +7845,133 @@ function unwrapExportDeclaration(statement: Node): Node {
     return statement.declaration;
   }
   return statement;
+}
+
+function runtimeTryEntryPrefixClearingCall(
+  node: Node,
+  imports: ImportBindings,
+  scopes: readonly Scope[],
+): Node | undefined {
+  if (node.type !== "TryStatement" || !isNode(node.block)) return undefined;
+  const statements = Array.isArray(node.block.body) ? node.block.body : [];
+  const statement = statements.length > 0 && isNode(statements[0])
+    ? statements[0]
+    : undefined;
+  const call = statement?.type === "ExpressionStatement" &&
+      isNode(statement.expression) && isCallLikeExpression(statement.expression)
+    ? statement.expression
+    : undefined;
+  if (!call || call.optional === true || !isNode(call.callee)) return undefined;
+  const blockScopes = SCOPE_NODES.has(node.block.type)
+    ? [...scopes, createScope(node.block, imports, scopes)]
+    : scopes;
+  const args = Array.isArray(call.arguments) ? call.arguments : [];
+  if (
+    !args.every((argument) =>
+      runtimeTryEntryArgumentEvaluationIsNonThrowing(
+        argument,
+        imports,
+        blockScopes,
+      )
+    )
+  ) {
+    return undefined;
+  }
+  const isObjectAssign = mutationMethodInvocations(
+    call.callee,
+    args,
+    imports,
+    blockScopes,
+  ).some((invocation) =>
+    invocation.binding.receiver === "Object" &&
+    invocation.binding.method === "assign"
+  );
+  return isObjectAssign ? call : undefined;
+}
+
+function runtimeTryEntryArgumentEvaluationIsNonThrowing(
+  value: unknown,
+  imports: ImportBindings,
+  scopes: readonly Scope[],
+): boolean {
+  if (!isNode(value)) return false;
+  if (
+    value.type.endsWith("Literal") || value.type === "Identifier" ||
+    value.type === "ThisExpression" || value.type === "MetaProperty" ||
+    value.type === "ArrowFunctionExpression" ||
+    value.type === "FunctionExpression"
+  ) {
+    return true;
+  }
+  if (
+    value.type === "TSAsExpression" || value.type === "TSTypeAssertion" ||
+    value.type === "TSSatisfiesExpression" ||
+    value.type === "TSInstantiationExpression" ||
+    value.type === "TSNonNullExpression" ||
+    value.type === "ParenthesizedExpression"
+  ) {
+    return runtimeTryEntryArgumentEvaluationIsNonThrowing(
+      value.expression,
+      imports,
+      scopes,
+    );
+  }
+  if (value.type === "MemberExpression") {
+    const property = memberProperty(value);
+    const objectBinding = runtimeBindingForExpression(
+      value.object,
+      imports,
+      scopes,
+    );
+    const propertyBinding = objectBinding && property
+      ? runtimePropertyResolution(objectBinding, property, true).binding
+      : undefined;
+    return value.computed !== true && property !== undefined &&
+      objectBinding !== undefined &&
+      !flattenRuntimeBindings(propertyBinding).some((binding) =>
+        binding.kind === "property-getter-effect" ||
+        binding.kind === "property-getter-value"
+      ) &&
+      runtimeTryEntryArgumentEvaluationIsNonThrowing(
+        value.object,
+        imports,
+        scopes,
+      );
+  }
+  if (value.type === "ObjectExpression") {
+    return (Array.isArray(value.properties) ? value.properties : []).every(
+      (property) => {
+        if (!isNode(property) || property.type === "SpreadElement") {
+          return false;
+        }
+        if (
+          property.type !== "ObjectProperty" &&
+          property.type !== "ObjectMethod"
+        ) {
+          return false;
+        }
+        if (property.computed === true) return false;
+        return property.type === "ObjectMethod" ||
+          runtimeTryEntryArgumentEvaluationIsNonThrowing(
+            property.value,
+            imports,
+            scopes,
+          );
+      },
+    );
+  }
+  if (value.type === "ArrayExpression") {
+    return (Array.isArray(value.elements) ? value.elements : []).every(
+      (element) =>
+        element === null ||
+        runtimeTryEntryArgumentEvaluationIsNonThrowing(
+          element,
+          imports,
+          scopes,
+        ),
+    );
+  }
+  return false;
 }
 
 function isConditionalBranch(parent: Node, key: string): boolean {
@@ -8088,6 +8513,7 @@ function objectLiteralRuntimeBinding(
   if (value.type !== "ObjectExpression") return undefined;
   const properties = new Map<string, RuntimeBinding>();
   const propertyOperations: NamespacePropertyOperation[] = [];
+  let hasUnknownOwnProperties = false;
   for (
     const property of Array.isArray(value.properties) ? value.properties : []
   ) {
@@ -8104,6 +8530,8 @@ function objectLiteralRuntimeBinding(
           binding: spread,
           conservativePartial: true,
         });
+      } else {
+        hasUnknownOwnProperties = true;
       }
       continue;
     }
@@ -8206,6 +8634,7 @@ function objectLiteralRuntimeBinding(
     kind: "namespace-object",
     shape: "object",
     extensible: true,
+    hasUnknownOwnProperties: hasUnknownOwnProperties || undefined,
     properties,
     propertyOperations,
   };
@@ -8217,6 +8646,9 @@ function runtimeGetterResolution(
   scopes: readonly Scope[],
 ): RuntimePropertyResolution {
   const returned = runtimeFunctionReturnExpressions(getter);
+  const unconditionalReturn = runtimeFunctionUnconditionalReturnExpression(
+    getter,
+  );
   const bindings = returned.expressions.flatMap((expression) => {
     const binding = runtimeBindingForExpression(expression, imports, scopes);
     return binding ? [binding] : [];
@@ -8228,8 +8660,13 @@ function runtimeGetterResolution(
         runtimeNamespaceAliasTargetsForExpression(expression, imports, scopes)
       ),
     ),
-    // Block-bodied getters may complete without reaching a return statement.
-    defaultMayRun: true,
+    defaultMayRun: unconditionalReturn === undefined ||
+      expressionMayBeUndefined(
+        unconditionalReturn,
+        runtimeBindingForExpression(unconditionalReturn, imports, scopes),
+        imports,
+        scopes,
+      ),
   };
 }
 
@@ -8921,25 +9358,6 @@ function runtimeEnumerablePropertyBinding(
   );
 }
 
-function runtimeUnknownGetterEnumerabilities(
-  binding: RuntimeBinding,
-): readonly (boolean | undefined)[] {
-  return flattenRuntimeBindings(binding).flatMap((candidate) =>
-    candidate.kind === "namespace-object"
-      ? [...namespaceUnknownPropertyNames(candidate)].flatMap((property) =>
-        flattenRuntimeBindings(
-          runtimePropertyResolution(candidate, property, true).binding,
-        ).flatMap((propertyBinding) =>
-          propertyBinding.kind === "property-getter-effect" ||
-            propertyBinding.kind === "property-getter-value"
-            ? [propertyBinding.enumerable]
-            : []
-        )
-      )
-      : []
-  );
-}
-
 function runtimePropertyResolution(
   binding: RuntimeBinding,
   property: string,
@@ -9129,11 +9547,17 @@ function runtimePropertyResolution(
       }
       for (const operation of fallbackOperations) {
         if (!resolution.defaultMayRun) break;
-        resolution = applyRuntimeUnknownPropertyOperation(
-          resolution,
-          operation,
-          property,
-        );
+        resolution = operation.fallbackSource
+          ? applyRuntimeFallbackSourceOperation(
+            resolution,
+            operation.fallbackSource,
+            property,
+          )
+          : applyRuntimeUnknownPropertyOperation(
+            resolution,
+            operation,
+            property,
+          );
       }
       const mutation = frame.binding.shape === "array" &&
           resolution.defaultMayRun
@@ -9217,6 +9641,41 @@ function runtimePropertyResolution(
     ));
   }
   return resolutions.at(-1) ?? { defaultMayRun: true };
+}
+
+function applyRuntimeFallbackSourceOperation(
+  resolution: RuntimePropertyResolution,
+  fallbackSource: RuntimeBinding,
+  property: string,
+): RuntimePropertyResolution {
+  const fallback = runtimePropertyResolution(
+    fallbackSource,
+    property,
+    true,
+  );
+  const hasOwnCandidate = resolution.binding !== undefined ||
+    (resolution.aliasTargets?.length ?? 0) > 0;
+  const inheritedAttribute = (
+    attribute: "configurable" | "enumerable" | "writable",
+  ): boolean | undefined =>
+    !hasOwnCandidate || resolution[attribute] === fallback[attribute]
+      ? fallback[attribute]
+      : undefined;
+  return {
+    binding: unionRuntimeBindingsPreservingPartial(
+      [resolution.binding, fallback.binding].flatMap((candidate) =>
+        candidate ?? []
+      ),
+    ),
+    aliasTargets: uniqueRuntimeAliasTargets([
+      ...(resolution.aliasTargets ?? []),
+      ...(fallback.aliasTargets ?? []),
+    ]),
+    defaultMayRun: resolution.defaultMayRun && fallback.defaultMayRun,
+    configurable: inheritedAttribute("configurable"),
+    enumerable: inheritedAttribute("enumerable"),
+    writable: inheritedAttribute("writable"),
+  };
 }
 
 function applyRuntimeUnknownPropertyOperation(
@@ -9401,6 +9860,46 @@ function runtimeBindingHasPartialAlternative(
   return binding?.kind === "partial" ||
     (binding?.kind === "one-of" &&
       binding.bindings.some(runtimeBindingHasPartialAlternative));
+}
+
+function runtimeBindingHasUnknownOwnProperties(
+  binding: RuntimeBinding | undefined,
+): boolean {
+  const pending = binding ? [binding] : [];
+  const visited = new Set<RuntimeBinding>();
+  while (pending.length > 0) {
+    const candidate = pending.pop();
+    if (!candidate || visited.has(candidate)) continue;
+    visited.add(candidate);
+    if (candidate.kind === "partial") {
+      pending.push(candidate.binding);
+      continue;
+    }
+    if (candidate.kind === "one-of") {
+      pending.push(...candidate.bindings);
+      continue;
+    }
+    if (candidate.kind !== "namespace-object") continue;
+    if (candidate.hasUnknownOwnProperties === true) return true;
+    for (const operation of candidate.propertyOperations ?? []) {
+      if (operation.kind === "spread") pending.push(operation.binding);
+    }
+  }
+  return false;
+}
+
+function runtimeBindingHasExactOwnPropertySet(
+  binding: RuntimeBinding,
+): boolean {
+  if (runtimeBindingHasPartialAlternative(binding)) return false;
+  const candidates = flattenRuntimeBindings(binding);
+  const operations = candidates.length === 1 &&
+      candidates[0].kind === "namespace-object" &&
+      candidates[0].hasUnknownOwnProperties !== true
+    ? candidates[0].propertyOperations ?? []
+    : [];
+  return operations.length > 0 &&
+    operations.every((operation) => operation.kind === "define");
 }
 
 function runtimePropertyHasCrossFunctionMutation(

--- a/scripts/test/test-semantic-audit.ts
+++ b/scripts/test/test-semantic-audit.ts
@@ -7896,12 +7896,23 @@ function runtimeTryEntryArgumentEvaluationIsNonThrowing(
 ): boolean {
   if (!isNode(value)) return false;
   if (
-    value.type.endsWith("Literal") || value.type === "Identifier" ||
+    value.type.endsWith("Literal") ||
     value.type === "ThisExpression" || value.type === "MetaProperty" ||
     value.type === "ArrowFunctionExpression" ||
     value.type === "FunctionExpression"
   ) {
     return true;
+  }
+  if (value.type === "Identifier") {
+    const resolved = resolveLocalBinding(value.name as string, scopes);
+    const binding = resolved.declared
+      ? resolved.binding
+      : runtimeBindingForExpression(value, imports, scopes);
+    // A partial binding can hide a nullish alternative. TypeScript's `!`
+    // changes no runtime evaluation, so it cannot make a member read safe.
+    return binding !== undefined &&
+      (!resolved.declared || resolved.definitelyNonUndefined === true) &&
+      !runtimeBindingHasPartialAlternative(binding);
   }
   if (
     value.type === "TSAsExpression" || value.type === "TSTypeAssertion" ||

--- a/scripts/test/test-semantic-audit.ts
+++ b/scripts/test/test-semantic-audit.ts
@@ -648,9 +648,23 @@ interface RuntimePropertyResolution {
   readonly binding?: RuntimeBinding;
   readonly aliasTargets?: readonly RuntimeAliasTarget[];
   readonly defaultMayRun: boolean;
+  readonly propertyMayBeAbsent?: boolean;
+  readonly presentValueMayBeUndefined?: boolean;
   readonly enumerable?: boolean;
   readonly configurable?: boolean;
   readonly writable?: boolean;
+}
+
+function runtimePropertyMayBeAbsent(
+  resolution: RuntimePropertyResolution,
+): boolean {
+  return resolution.propertyMayBeAbsent ?? resolution.defaultMayRun;
+}
+
+function runtimePresentValueMayBeUndefined(
+  resolution: RuntimePropertyResolution,
+): boolean {
+  return resolution.presentValueMayBeUndefined ?? resolution.defaultMayRun;
 }
 
 interface RuntimePatternEntry {
@@ -7941,6 +7955,11 @@ function runtimeTryEntryPrefixClearingCall(
     : scopes;
   const args = Array.isArray(call.arguments) ? call.arguments : [];
   if (
+    !runtimeTryEntryArgumentEvaluationIsNonThrowing(
+      call.callee,
+      imports,
+      blockScopes,
+    ) ||
     !args.every((argument) =>
       runtimeTryEntryArgumentEvaluationIsNonThrowing(
         argument,
@@ -7951,15 +7970,18 @@ function runtimeTryEntryPrefixClearingCall(
   ) {
     return undefined;
   }
-  const isObjectAssign = mutationMethodInvocations(
+  const calleeBinding = runtimeBindingForExpression(
     call.callee,
-    args,
     imports,
     blockScopes,
-  ).some((invocation) =>
-    invocation.binding.receiver === "Object" &&
-    invocation.binding.method === "assign"
   );
+  const calleeBindings = flattenRuntimeBindings(calleeBinding);
+  const isObjectAssign = !runtimeBindingHasPartialAlternative(calleeBinding) &&
+    calleeBindings.length > 0 &&
+    calleeBindings.every((binding) =>
+      binding.kind === "mutation-method" && binding.receiver === "Object" &&
+      binding.method === "assign"
+    );
   return isObjectAssign ? call : undefined;
 }
 
@@ -8011,11 +8033,13 @@ function runtimeTryEntryArgumentEvaluationIsNonThrowing(
       imports,
       scopes,
     );
-    const propertyBinding = objectBinding && property
-      ? runtimePropertyResolution(objectBinding, property, true).binding
+    const propertyResolution = objectBinding && property
+      ? runtimePropertyResolution(objectBinding, property, true)
       : undefined;
+    const propertyBinding = propertyResolution?.binding;
     return value.computed !== true && property !== undefined &&
       objectBinding !== undefined &&
+      propertyResolution?.defaultMayRun === false &&
       !flattenRuntimeBindings(propertyBinding).some((binding) =>
         binding.kind === "property-getter-effect" ||
         binding.kind === "property-getter-value"
@@ -8620,6 +8644,13 @@ function objectLiteralRuntimeBinding(
         });
       } else {
         hasUnknownOwnProperties = true;
+        propertyOperations.push({
+          kind: "define-unknown",
+          defaultMayRun: true,
+          configurable: true,
+          enumerable: true,
+          writable: true,
+        });
       }
       continue;
     }
@@ -9486,6 +9517,8 @@ function runtimePropertyResolution(
           ? { kind: "partial", binding: resolution.binding }
           : undefined,
         defaultMayRun: true,
+        propertyMayBeAbsent: true,
+        presentValueMayBeUndefined: true,
       });
       continue;
     }
@@ -9493,6 +9526,10 @@ function runtimePropertyResolution(
       const candidates = frame.count === 0
         ? []
         : resolutions.splice(-frame.count, frame.count);
+      const propertyMayBeAbsent = candidates.length === 0 ||
+        candidates.some(runtimePropertyMayBeAbsent);
+      const presentValueMayBeUndefined = candidates.length === 0 ||
+        candidates.some(runtimePresentValueMayBeUndefined);
       resolutions.push({
         binding: unionRuntimeBindingsPreservingPartial(
           candidates.flatMap((resolution) => resolution.binding ?? []),
@@ -9500,9 +9537,9 @@ function runtimePropertyResolution(
         aliasTargets: uniqueRuntimeAliasTargets(
           candidates.flatMap((resolution) => resolution.aliasTargets ?? []),
         ),
-        defaultMayRun: candidates.some((resolution) =>
-          resolution.defaultMayRun
-        ),
+        defaultMayRun: propertyMayBeAbsent || presentValueMayBeUndefined,
+        propertyMayBeAbsent,
+        presentValueMayBeUndefined,
         enumerable: candidates.every((resolution) =>
             resolution.enumerable === candidates[0]?.enumerable
           )
@@ -9526,7 +9563,11 @@ function runtimePropertyResolution(
         ? []
         : resolutions.splice(-frame.spreadCount, frame.spreadCount);
       let spreadIndex = 0;
-      let resolution: RuntimePropertyResolution = { defaultMayRun: true };
+      let resolution: RuntimePropertyResolution = {
+        defaultMayRun: true,
+        propertyMayBeAbsent: true,
+        presentValueMayBeUndefined: false,
+      };
       const fallbackOperations: Extract<
         NamespacePropertyOperation,
         { readonly kind: "define-unknown" }
@@ -9539,6 +9580,8 @@ function runtimePropertyResolution(
             ) {
               resolution = {
                 defaultMayRun: true,
+                propertyMayBeAbsent: true,
+                presentValueMayBeUndefined: false,
                 enumerable: false,
                 configurable: operation.configurable,
                 writable: operation.writable,
@@ -9551,8 +9594,14 @@ function runtimePropertyResolution(
                 currentRuntimeAliasBinding(operation.aliasTargets),
               ].flatMap((candidate) => candidate ?? []),
             );
-            resolution = operation.preservesPrevious
-              ? {
+            if (operation.preservesPrevious) {
+              const propertyMayBeAbsent = runtimePropertyMayBeAbsent(
+                resolution,
+              );
+              const presentValueMayBeUndefined =
+                runtimePresentValueMayBeUndefined(resolution) ||
+                operation.defaultMayRun;
+              resolution = {
                 binding: unionRuntimeBindingsPreservingPartial(
                   [resolution.binding, operationBinding].flatMap(
                     (candidate) => candidate ?? [],
@@ -9562,8 +9611,10 @@ function runtimePropertyResolution(
                   ...(resolution.aliasTargets ?? []),
                   ...(operation.aliasTargets ?? []),
                 ]),
-                defaultMayRun: resolution.defaultMayRun ||
-                  operation.defaultMayRun,
+                defaultMayRun: propertyMayBeAbsent ||
+                  presentValueMayBeUndefined,
+                propertyMayBeAbsent,
+                presentValueMayBeUndefined,
                 enumerable: resolution.enumerable === operation.enumerable
                   ? resolution.enumerable
                   : undefined,
@@ -9573,15 +9624,19 @@ function runtimePropertyResolution(
                 writable: resolution.writable === operation.writable
                   ? resolution.writable
                   : undefined,
-              }
-              : {
+              };
+            } else {
+              resolution = {
                 binding: operationBinding,
                 aliasTargets: operation.aliasTargets,
                 defaultMayRun: operation.defaultMayRun,
+                propertyMayBeAbsent: false,
+                presentValueMayBeUndefined: operation.defaultMayRun,
                 enumerable: operation.enumerable,
                 configurable: operation.configurable,
                 writable: operation.writable,
               };
+            }
           }
           continue;
         }
@@ -9613,24 +9668,33 @@ function runtimePropertyResolution(
             conservativeSemanticEffectBinding(),
           ].flatMap((candidate) => candidate ?? []))
           : spreadResolution.binding;
+        const spreadPropertyMayBeAbsent = runtimePropertyMayBeAbsent(
+          spreadResolution,
+        );
+        const propertyMayBeAbsent = spreadPropertyMayBeAbsent &&
+          runtimePropertyMayBeAbsent(resolution);
+        const presentValueMayBeUndefined =
+          runtimePresentValueMayBeUndefined(spreadResolution) ||
+          (spreadPropertyMayBeAbsent &&
+            runtimePresentValueMayBeUndefined(resolution));
         resolution = {
           binding: unionRuntimeBindingsPreservingPartial(
             [
               spreadBinding,
-              spreadResolution.defaultMayRun ? resolution.binding : undefined,
+              spreadPropertyMayBeAbsent ? resolution.binding : undefined,
             ].flatMap((candidate) => candidate ?? []),
           ),
           aliasTargets: uniqueRuntimeAliasTargets([
             ...(spreadResolution.aliasTargets ?? []),
-            ...(spreadResolution.defaultMayRun
-              ? resolution.aliasTargets ?? []
-              : []),
+            ...(spreadPropertyMayBeAbsent ? resolution.aliasTargets ?? [] : []),
           ]),
-          defaultMayRun: spreadResolution.defaultMayRun &&
-            resolution.defaultMayRun,
-          enumerable: spreadResolution.defaultMayRun ? undefined : true,
-          configurable: spreadResolution.defaultMayRun ? undefined : true,
-          writable: spreadResolution.defaultMayRun ? undefined : true,
+          defaultMayRun: propertyMayBeAbsent ||
+            presentValueMayBeUndefined,
+          propertyMayBeAbsent,
+          presentValueMayBeUndefined,
+          enumerable: spreadPropertyMayBeAbsent ? undefined : true,
+          configurable: spreadPropertyMayBeAbsent ? undefined : true,
+          writable: spreadPropertyMayBeAbsent ? undefined : true,
         };
       }
       for (const operation of fallbackOperations) {
@@ -9749,6 +9813,12 @@ function applyRuntimeFallbackSourceOperation(
     !hasOwnCandidate || resolution[attribute] === fallback[attribute]
       ? fallback[attribute]
       : undefined;
+  const propertyMayBeAbsent = runtimePropertyMayBeAbsent(resolution) &&
+    runtimePropertyMayBeAbsent(fallback);
+  const presentValueMayBeUndefined =
+    runtimePresentValueMayBeUndefined(resolution) ||
+    (runtimePropertyMayBeAbsent(resolution) &&
+      runtimePresentValueMayBeUndefined(fallback));
   return {
     binding: unionRuntimeBindingsPreservingPartial(
       [resolution.binding, fallback.binding].flatMap((candidate) =>
@@ -9759,7 +9829,9 @@ function applyRuntimeFallbackSourceOperation(
       ...(resolution.aliasTargets ?? []),
       ...(fallback.aliasTargets ?? []),
     ]),
-    defaultMayRun: resolution.defaultMayRun && fallback.defaultMayRun,
+    defaultMayRun: propertyMayBeAbsent || presentValueMayBeUndefined,
+    propertyMayBeAbsent,
+    presentValueMayBeUndefined,
     configurable: inheritedAttribute("configurable"),
     enumerable: inheritedAttribute("enumerable"),
     writable: inheritedAttribute("writable"),
@@ -9781,19 +9853,32 @@ function applyRuntimeUnknownPropertyOperation(
   ) {
     return resolution;
   }
-  return {
-    binding: unionRuntimeBindingsPreservingPartial(
-      [
-        resolution.binding,
-        operation.binding,
-        currentRuntimeAliasBinding(operation.aliasTargets),
-      ].flatMap((candidate) => candidate ?? []),
+  const propertyMayBeAbsent = runtimePropertyMayBeAbsent(resolution);
+  const presentValueMayBeUndefined =
+    runtimePresentValueMayBeUndefined(resolution) || operation.defaultMayRun;
+  const operationBinding = unionRuntimeBindingsPreservingPartial(
+    [
+      operation.binding,
+      currentRuntimeAliasBinding(operation.aliasTargets),
+    ].flatMap((candidate) => candidate ?? []),
+  );
+  const combinedBinding = unionRuntimeBindingsPreservingPartial(
+    [resolution.binding, operationBinding].flatMap((candidate) =>
+      candidate ?? []
     ),
+  );
+  return {
+    binding: operationBinding === undefined && combinedBinding !== undefined &&
+        !runtimeBindingHasPartialAlternative(combinedBinding)
+      ? { kind: "partial", binding: combinedBinding }
+      : combinedBinding,
     aliasTargets: uniqueRuntimeAliasTargets([
       ...(resolution.aliasTargets ?? []),
       ...(operation.aliasTargets ?? []),
     ]),
-    defaultMayRun: resolution.defaultMayRun || operation.defaultMayRun,
+    defaultMayRun: propertyMayBeAbsent || presentValueMayBeUndefined,
+    propertyMayBeAbsent,
+    presentValueMayBeUndefined,
     enumerable: resolution.enumerable === operation.enumerable
       ? resolution.enumerable
       : undefined,
@@ -9844,10 +9929,16 @@ function directRuntimePropertyResolution(
         ? mutationMethodBinding("Array", property)
         : undefined);
   }
+  const propertyMayBeAbsent = propertyBinding === undefined;
+  const presentValueMayBeUndefined = propertyBinding === undefined &&
+    binding.kind === "namespace-object" &&
+    binding.hasUnknownOwnProperties === true;
   return finalizeRuntimePropertyResolution(
     {
       binding: propertyBinding,
-      defaultMayRun: propertyBinding === undefined,
+      defaultMayRun: propertyMayBeAbsent || presentValueMayBeUndefined,
+      propertyMayBeAbsent,
+      presentValueMayBeUndefined,
       enumerable: binding.kind === "namespace-object" && propertyBinding
         ? true
         : undefined,
@@ -9874,10 +9965,14 @@ function finalizeRuntimePropertyResolution(
       candidate.kind === "property-getter-effect" ||
       candidate.kind === "property-setter"
     );
+  const presentValueMayBeUndefined =
+    runtimePresentValueMayBeUndefined(resolution) || accessorOnly;
   return {
     ...resolution,
     binding: resolvedBinding,
-    defaultMayRun: resolution.defaultMayRun || accessorOnly,
+    defaultMayRun: runtimePropertyMayBeAbsent(resolution) ||
+      presentValueMayBeUndefined,
+    presentValueMayBeUndefined,
   };
 }
 

--- a/scripts/test/test-semantic-audit.ts
+++ b/scripts/test/test-semantic-audit.ts
@@ -735,6 +735,7 @@ const RUNTIME_GETTER_EFFECT_PRESENCE = new WeakMap<RuntimeBinding, boolean>();
 
 interface Scope {
   readonly names: Set<string>;
+  readonly definitelyInitializedNames: Set<string>;
   readonly definitelyNonUndefinedNames: Set<string>;
   readonly functionBoundary: boolean;
   readonly playwrightFixtures: Set<string>;
@@ -881,6 +882,13 @@ export function collectSemanticMarkers(
         key === "loc" || COMMENT_KEYS.has(key) ||
         TYPE_ONLY_CHILD_KEYS.has(key)
       ) continue;
+      if (key === "body" && isFunctionScopeNode(node)) {
+        markRuntimeFunctionParametersInitialized(
+          node,
+          nextScopes,
+          allowAssignmentClearing,
+        );
+      }
       const value = node[key];
       if (Array.isArray(value)) {
         for (const item of value) {
@@ -914,6 +922,11 @@ export function collectSemanticMarkers(
         );
       }
     }
+    markRuntimeDeclarationInitialized(
+      node,
+      nextScopes,
+      allowAssignmentClearing,
+    );
     bindRuntimeCallMutation(
       node,
       bindings,
@@ -3521,20 +3534,26 @@ function createScope(
   outerScopes: readonly Scope[],
 ): Scope {
   const names = new Set<string>();
+  const definitelyInitializedNames = new Set<string>();
   const definitelyNonUndefinedNames = new Set<string>();
   const playwrightFixtures = new Set<string>();
   collectLocalDeclaredNames(
     node,
     names,
+    definitelyInitializedNames,
     definitelyNonUndefinedNames,
     playwrightFixtures,
   );
-  if (hasOwnThisRuntimeBinding(node)) names.add(THIS_RUNTIME_ROOT);
+  if (hasOwnThisRuntimeBinding(node)) {
+    names.add(THIS_RUNTIME_ROOT);
+    definitelyInitializedNames.add(THIS_RUNTIME_ROOT);
+  }
   if (isVarHoistScope(node)) collectHoistedVarDeclaredNames(node, names);
   const className = classRuntimeName(node);
   const classReceiver = classRuntimeReceiverForScope(node, outerScopes);
   const scope: Scope = {
     names,
+    definitelyInitializedNames,
     definitelyNonUndefinedNames,
     functionBoundary: isFunctionScopeNode(node),
     playwrightFixtures,
@@ -3587,6 +3606,7 @@ function createScope(
 function collectLocalDeclaredNames(
   node: Node,
   names: Set<string>,
+  definitelyInitializedNames: Set<string>,
   definitelyNonUndefinedNames: Set<string>,
   playwrightFixtures: Set<string>,
 ): void {
@@ -3602,6 +3622,9 @@ function collectLocalDeclaredNames(
         const name = statement.id.name as string;
         names.add(name);
         definitelyNonUndefinedNames.add(name);
+        if (statement.type === "FunctionDeclaration") {
+          definitelyInitializedNames.add(name);
+        }
       }
       if (
         statement.type === "TSModuleDeclaration" &&
@@ -3640,6 +3663,7 @@ function collectLocalDeclaredNames(
     if (node.type === "FunctionExpression" && isNode(node.id)) {
       const name = node.id.name as string;
       names.add(name);
+      definitelyInitializedNames.add(name);
       definitelyNonUndefinedNames.add(name);
     }
     for (const param of Array.isArray(node.params) ? node.params : []) {
@@ -3654,6 +3678,7 @@ function collectLocalDeclaredNames(
   ) {
     const name = node.id.name as string;
     names.add(name);
+    definitelyInitializedNames.add(name);
     definitelyNonUndefinedNames.add(name);
     return;
   }
@@ -3674,7 +3699,10 @@ function collectLocalDeclaredNames(
     }
     return;
   }
-  if (node.type === "CatchClause") collectPatternNames(node.param, names);
+  if (node.type === "CatchClause") {
+    collectPatternNames(node.param, names);
+    collectPatternNames(node.param, definitelyInitializedNames);
+  }
 }
 
 function collectLocalRuntimeBindings(
@@ -3763,6 +3791,7 @@ function runtimeReceiverScope(
 ): Scope {
   return {
     names: new Set([THIS_RUNTIME_ROOT]),
+    definitelyInitializedNames: new Set([THIS_RUNTIME_ROOT]),
     definitelyNonUndefinedNames: new Set([THIS_RUNTIME_ROOT]),
     functionBoundary: false,
     playwrightFixtures: new Set(),
@@ -4090,6 +4119,13 @@ function visitRuntimeBindingSummary(
     ) {
       continue;
     }
+    if (key === "body" && isFunctionScopeNode(node)) {
+      markRuntimeFunctionParametersInitialized(
+        node,
+        nextScopes,
+        allowClearing,
+      );
+    }
     const value = node[key];
     const childAllowsClearing = allowClearing &&
       !isConditionalBranch(node, key);
@@ -4115,6 +4151,7 @@ function visitRuntimeBindingSummary(
       );
     }
   }
+  markRuntimeDeclarationInitialized(node, nextScopes, allowClearing);
   bindRuntimeCallMutation(
     node,
     imports,
@@ -4221,6 +4258,43 @@ function declarationBelongsToScope(
     if (scope.names.has(name)) return true;
   }
   return names.size === 0;
+}
+
+function markRuntimeFunctionParametersInitialized(
+  node: Node,
+  scopes: readonly Scope[],
+  definitelyReached: boolean,
+): void {
+  if (!definitelyReached || !isFunctionScopeNode(node)) return;
+  const scope = scopes.at(-1);
+  if (!scope?.functionBoundary) return;
+  for (const parameter of Array.isArray(node.params) ? node.params : []) {
+    collectPatternNames(parameter, scope.definitelyInitializedNames);
+  }
+}
+
+function markRuntimeDeclarationInitialized(
+  node: Node,
+  scopes: readonly Scope[],
+  definitelyReached: boolean,
+): void {
+  if (!definitelyReached) return;
+  if (node.type === "VariableDeclarator" && isNode(node.id)) {
+    const scope = scopes.at(-1);
+    if (!scope || !declarationBelongsToScope(node, scope)) return;
+    collectPatternNames(node.id, scope.definitelyInitializedNames);
+    return;
+  }
+  if (
+    node.type === "ClassDeclaration" && isNode(node.id) &&
+    node.id.type === "Identifier"
+  ) {
+    const outerScope = scopes.at(-2);
+    const name = node.id.name as string;
+    if (outerScope?.names.has(name)) {
+      outerScope.definitelyInitializedNames.add(name);
+    }
+  }
 }
 
 function lexicalScopeStatements(node: Node): readonly Node[] | undefined {
@@ -7911,7 +7985,10 @@ function runtimeTryEntryArgumentEvaluationIsNonThrowing(
     // A partial binding can hide a nullish alternative. TypeScript's `!`
     // changes no runtime evaluation, so it cannot make a member read safe.
     return binding !== undefined &&
-      (!resolved.declared || resolved.definitelyNonUndefined === true) &&
+      (!resolved.declared ||
+        (resolved.definitelyInitialized === true &&
+          resolved.definitelyNonUndefined === true &&
+          resolved.crossesFunctionBoundary !== true)) &&
       !runtimeBindingHasPartialAlternative(binding);
   }
   if (
@@ -10350,17 +10427,24 @@ function resolveLocalBinding(
   scopes: readonly Scope[],
 ): {
   readonly declared: boolean;
+  readonly definitelyInitialized?: boolean;
   readonly definitelyNonUndefined?: boolean;
+  readonly crossesFunctionBoundary?: boolean;
   readonly binding?: RuntimeBinding;
 } {
+  let crossesFunctionBoundary = false;
   for (let index = scopes.length - 1; index >= 0; index--) {
     const scope = scopes[index];
-    if (!scope.names.has(name)) continue;
-    return {
-      declared: true,
-      definitelyNonUndefined: scope.definitelyNonUndefinedNames.has(name),
-      binding: scope.runtimeBindings.get(name),
-    };
+    if (scope.names.has(name)) {
+      return {
+        declared: true,
+        definitelyInitialized: scope.definitelyInitializedNames.has(name),
+        definitelyNonUndefined: scope.definitelyNonUndefinedNames.has(name),
+        crossesFunctionBoundary,
+        binding: scope.runtimeBindings.get(name),
+      };
+    }
+    if (scope.functionBoundary) crossesFunctionBoundary = true;
   }
   return { declared: false };
 }


### PR DESCRIPTION
## Why

The final adversarial review after #4019 merged found two gaps in the new semantic audit model:

- nested unknown object spreads could lose unknown provenance and under-report effects;
- caught Object.assign calls could not distinguish a completed early write from a later blocked write, retaining stale provenance.

A direct probe against merge commit f9add2b3 reproduced both. This follow-up keeps #4019 closed and isolates the missed hardening.

## Design

- Model Object.assign source keys in JavaScript own-key order and stop after definitely blocked writes.
- Classify target writes as assigned, setter, blocked, or uncertain.
- Preserve unknown-own-property metadata transitively through object spreads and partial bindings.
- Model inherited data shadowing and copied getter/data property attributes.
- Permit clearing a completed Object.assign prefix inside try only when the call is definitely reached and argument evaluation is statically non-throwing; conditional, later, getter-backed, and unknown cases remain fail-closed.

## Verification

- Full format: 5,167 files
- Full lint: 5,090 files
- Full typecheck and generated-artifact checks
- Semantic audit + automated review gate: 5 passed / 156 steps
- Anti-slop ratchet: 239 findings / 90 files, unchanged
- Exact code review: CLEAR, 93% confidence
- Exact architecture review: CLEAR, 93% confidence
- Pre-push suite: 4,173 passed; one unrelated source-span timing assertion exceeded 1,500 ms once (1,683 ms). The unchanged source-span suite passed twice immediately afterward (243 steps each; bounded scan 278 ms and 281 ms).

Related: #4019

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `Object.assign` and object spread operations, including mixed or unknown sources and inherited properties.
  * More accurately models blocked writes, getters, setters, property ordering, and partial updates when errors occur.
  * Improved tracking of property values across complex object and namespace merges.
* **Tests**
  * Expanded semantic analysis coverage for non-extensible targets, accessor behavior, property shadowing, and partial completion scenarios.
  * Updated expected analysis results to reflect the improved behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->