### PR TITLE
fix(ci): accept CodeRabbit current review-range wording

### DIFF
--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -4,13 +4,14 @@ const AUTOMATED_REVIEW_LOGINS = new Set([
 ]);
 const CODERABBIT_LOGIN = "coderabbitai[bot]";
 const CODERABBIT_RECENT_REVIEW_MARKER = "<!-- recent_review_start -->";
-const CODERABBIT_RECENT_REVIEW_END_MARKER = "<!-- recent_review_end -->";
+const CODERABBIT_RECENT_REVIEW_MARKER_PATTERN =
+  /<!-- recent_review_start -->|<!-- recent_review_end -->/g;
 const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
   "No actionable comments were generated in the recent review.";
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r?\n)Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r?\n|$)/;
 const CODERABBIT_REVIEW_RANGE_STATEMENT_PATTERN =
-  /(?:^|\r?\n)\s*(?:[-*+]\s+)?(Reviewing\s+(?:files(?:\s+that\s+changed\s+from\s+the\s+base\s+of\s+the\s+PR)?|changed files(?:\s+from\s+the\s+base\s+of\s+the\s+PR)?)\s+(?:and\s+)?between\s+[0-9a-f]{40}\s+and(?:[ \t]*\r?\n)?[ \t]*[0-9a-f]{40}[^\r\n]*)/gi;
+  /(?:^|\r?\n)[ \t]*(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+))*(Reviewing\s+(?:files(?:\s+that\s+changed\s+from\s+the\s+base\s+of\s+the\s+PR)?|changed files(?:\s+from\s+the\s+base\s+of\s+the\s+PR)?)\s+(?:and\s+)?between\s+[0-9a-f]{40}\s+and(?:[ \t]*\r?\n)?[ \t]*[0-9a-f]{40}[^\r\n]*)/gi;
 const FULL_COMMIT_TOKEN_PATTERN = /(^|[^0-9a-f])([0-9a-f]{40})(?![0-9a-f])/gi;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
   /Requested commit:\s*([0-9a-f]{40})/gi;
@@ -215,22 +216,32 @@ async function classifyAutomatedReviewEvent(
     selectedRecentReview,
     headSha,
   );
-  if (rangeEvidence === "current-invalid") {
+  const effectiveRangeReview =
+    rangeEvidence === "none" && selectedRecentReview?.fallbackContent
+      ? {
+        content: selectedRecentReview.fallbackContent,
+        terminated: false,
+      }
+      : selectedRecentReview;
+  const effectiveRangeEvidence = effectiveRangeReview === selectedRecentReview
+    ? rangeEvidence
+    : classifyCodeRabbitRangeEvidence(effectiveRangeReview, headSha);
+  if (effectiveRangeEvidence === "current-invalid") {
     return {
       kind: "failure",
       url: typeof comment.html_url === "string" ? comment.html_url : undefined,
     };
   }
-  if (rangeEvidence !== "current-valid") {
+  if (effectiveRangeEvidence !== "current-valid") {
     return { kind: "not-head" };
   }
-  if (!selectedRecentReview?.terminated) {
+  if (!effectiveRangeReview?.terminated) {
     return {
       kind: "failure",
       url: typeof comment.html_url === "string" ? comment.html_url : undefined,
     };
   }
-  return selectedRecentReview?.content.includes(
+  return effectiveRangeReview?.content.includes(
       CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER,
     )
     ? {
@@ -252,45 +263,55 @@ async function classifyAutomatedReviewEvent(
 
 function codeRabbitSelectedRecentReview(body) {
   if (typeof body !== "string") return undefined;
-  const start = body.lastIndexOf(CODERABBIT_RECENT_REVIEW_MARKER);
-  if (start < 0) return undefined;
-  const contentStart = start + CODERABBIT_RECENT_REVIEW_MARKER.length;
-  const end = body.indexOf(CODERABBIT_RECENT_REVIEW_END_MARKER, contentStart);
-  if (end < 0) {
-    const previousStart = body.lastIndexOf(
-      CODERABBIT_RECENT_REVIEW_MARKER,
-      start - 1,
-    );
-    const previousContentStart = previousStart +
-      CODERABBIT_RECENT_REVIEW_MARKER.length;
-    const previousEnd = previousStart < 0 ? -1 : body.indexOf(
-      CODERABBIT_RECENT_REVIEW_END_MARKER,
-      previousContentStart,
-    );
-    return {
-      content: body.slice(
-        previousEnd < 0 ? contentStart : previousContentStart,
-      ),
-      terminated: false,
+  const groups = [];
+  let openGroup;
+  let previousCompleteContent;
+  for (
+    const marker of body.matchAll(CODERABBIT_RECENT_REVIEW_MARKER_PATTERN)
+  ) {
+    if (marker[0] === CODERABBIT_RECENT_REVIEW_MARKER) {
+      if (openGroup) {
+        openGroup.invalid = true;
+      } else {
+        openGroup = {
+          contentStart: marker.index + CODERABBIT_RECENT_REVIEW_MARKER.length,
+          invalid: false,
+        };
+      }
+      continue;
+    }
+    if (!openGroup) continue;
+    const content = body.slice(openGroup.contentStart, marker.index);
+    const group = {
+      content,
+      terminated: !openGroup.invalid,
     };
+    groups.push(group);
+    if (group.terminated) previousCompleteContent = content;
+    openGroup = undefined;
   }
-  return {
-    content: body.slice(contentStart, end),
-    terminated: true,
-  };
+  if (openGroup) {
+    groups.push({
+      content: body.slice(openGroup.contentStart),
+      fallbackContent: previousCompleteContent,
+      terminated: false,
+    });
+  }
+  return groups.at(-1);
 }
 
 function classifyCodeRabbitRangeEvidence(selectedRecentReview, headSha) {
-  if (!selectedRecentReview) return "not-head";
+  if (!selectedRecentReview) return "none";
   const evidenceBlocks = codeRabbitRangeEvidenceStatements(
     selectedRecentReview.content,
   ).map((block) => parseCodeRabbitRangeEvidence(block, headSha)).filter((
     evidence,
   ) => evidence !== undefined);
+  if (evidenceBlocks.length === 0) return "none";
   const currentEvidence = evidenceBlocks.filter((evidence) =>
     evidence.tipIsHead || evidence.extraHasHead
   );
-  if (currentEvidence.length === 0) return "not-head";
+  if (currentEvidence.length === 0) return "stale";
   if (
     currentEvidence.length === 1 && evidenceBlocks.length === 1 &&
     currentEvidence[0].isExactProduction && !currentEvidence[0].extraHasHead
@@ -303,7 +324,7 @@ function classifyCodeRabbitRangeEvidence(selectedRecentReview, headSha) {
 function codeRabbitRangeEvidenceStatements(content) {
   return [...content.matchAll(CODERABBIT_REVIEW_RANGE_STATEMENT_PATTERN)].map((
     match,
-  ) => match[0].trim());
+  ) => match[0].replace(/^\r?\n/, ""));
 }
 
 function parseCodeRabbitRangeEvidence(block, headSha) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -10,7 +10,7 @@ const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r\n|[\r\n])Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r\n|[\r\n]|$)/;
 const CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN =
-  /(?:^|\r\n|[\r\n])([ \t]*(?:(?:>[ \t]*)|(?:\|[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*(?:Reviewing[ \t]+(?:files(?:[ \t]+that[ \t]+changed[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?|changed[ \t]+files(?:[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?)[ \t]+(?:and[ \t]+)?between))([^\r\n]*)/gi;
+  /(?:^|\r\n|[\r\n])([ \t]*(?:(?:>[ \t]*)|(?:\|[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*(?:`+)?(?:Reviewing[ \t]+(?:files(?:[ \t]+that[ \t]+changed[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?|changed[ \t]+files(?:[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?)[ \t]+(?:and[ \t]+)?between))([^\r\n]*)/gi;
 const CODERABBIT_REVIEW_RANGE_CONTINUATION_PREFIX_PATTERN =
   /^[ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*/;
 const CODERABBIT_REVIEW_RANGE_SEPARATOR_PATTERN =
@@ -921,9 +921,13 @@ function isMarkdownNonInterruptingHtmlLine(line) {
   // GitHub Flavored Markdown HTML block types 1–6 interrupt paragraphs;
   // type 7 does not.
   return /^ {0,3}<(?:[A-Za-z!?/])/.test(line) &&
-    !MARKDOWN_PARAGRAPH_INTERRUPTING_HTML_TAG_PATTERN.test(line) &&
-    !MARKDOWN_PARAGRAPH_INTERRUPTING_RAW_HTML_PATTERN.test(line) &&
-    !MARKDOWN_PARAGRAPH_INTERRUPTING_HTML_SYNTAX_PATTERN.test(line);
+    !isMarkdownParagraphInterruptingHtmlLine(line);
+}
+
+function isMarkdownParagraphInterruptingHtmlLine(line) {
+  return MARKDOWN_PARAGRAPH_INTERRUPTING_HTML_TAG_PATTERN.test(line) ||
+    MARKDOWN_PARAGRAPH_INTERRUPTING_RAW_HTML_PATTERN.test(line) ||
+    MARKDOWN_PARAGRAPH_INTERRUPTING_HTML_SYNTAX_PATTERN.test(line);
 }
 
 function markdownParagraphAfterLine(
@@ -1225,6 +1229,7 @@ function markdownInlineStructureRanges(content, excludedRanges = []) {
 function markdownTableInlineStructure(content, lines, excludedRanges) {
   const ranges = [];
   const cellRanges = [];
+  const listContinuationIndents = markdownListContinuationIndents(lines);
   let excludedRangeIndex = 0;
   const lineIsExcluded = (line) => {
     while (excludedRanges[excludedRangeIndex]?.[1] <= line.start) {
@@ -1243,8 +1248,16 @@ function markdownTableInlineStructure(content, lines, excludedRanges) {
       delimiterLine.content,
     );
     if (
-      isMarkdownIndentedCodeLine(headerLine.content) ||
-      isMarkdownIndentedCodeLine(delimiterLine.content) ||
+      isMarkdownIndentedCodeLine(
+        headerLine.content,
+        headerContext,
+        listContinuationIndents[lineIndex - 1],
+      ) ||
+      isMarkdownIndentedCodeLine(
+        delimiterLine.content,
+        delimiterContext,
+        listContinuationIndents[lineIndex],
+      ) ||
       isMarkdownInlineCodeBarrier(headerContext.content) ||
       !markdownTableContextsMatch(headerContext, delimiterContext)
     ) continue;
@@ -1276,7 +1289,11 @@ function markdownTableInlineStructure(content, lines, excludedRanges) {
       }
       const bodyContext = markdownParagraphLineContext(bodyLine.content);
       if (
-        isMarkdownIndentedCodeLine(bodyLine.content) ||
+        isMarkdownIndentedCodeLine(
+          bodyLine.content,
+          bodyContext,
+          listContinuationIndents[bodyLineIndex],
+        ) ||
         !markdownTableContextsMatch(headerContext, bodyContext) ||
         isMarkdownInlineCodeBarrier(bodyContext.content)
       ) break;
@@ -1294,6 +1311,44 @@ function markdownTableInlineStructure(content, lines, excludedRanges) {
     cellRanges,
     splitRanges: mergeMarkdownRanges(ranges, []),
   };
+}
+
+function markdownListContinuationIndents(lines) {
+  const continuationIndents = [];
+  let openListContexts = [];
+  let openParagraph;
+  for (const line of lines) {
+    const paragraphLine = markdownParagraphLineContext(line.content);
+    const continuesParagraph = markdownLineContinuesParagraph(
+      paragraphLine,
+      openParagraph,
+    );
+    const listContextsForLine = markdownListContextsForLine(
+      paragraphLine,
+      openListContexts,
+      continuesParagraph,
+    );
+    const continuationIndent = listContextsForLine.at(-1)?.continuationIndent ??
+      0;
+    const indentedCodeLine = isMarkdownIndentedCodeLine(
+      line.content,
+      paragraphLine,
+      continuationIndent,
+    ) && !continuesParagraph;
+    continuationIndents.push(continuationIndent);
+    openListContexts = markdownListContextsAfterLine(
+      paragraphLine,
+      listContextsForLine,
+      continuesParagraph,
+    );
+    openParagraph = markdownParagraphAfterLine(
+      paragraphLine,
+      openParagraph,
+      continuesParagraph,
+      indentedCodeLine,
+    );
+  }
+  return continuationIndents;
 }
 
 function markdownTableContextsMatch(header, row) {
@@ -1494,6 +1549,7 @@ function markdownReferenceContinuationLine(lines, lineIndex, firstLine) {
   if (line === undefined || line.content.trim().length === 0) return undefined;
   const continuation = markdownParagraphLineContext(line.content);
   if (
+    isMarkdownParagraphInterruptingHtmlLine(continuation.content) ||
     continuation.structuralPrefix !== firstLine.structuralPrefix ||
     continuation.listContinuationIndent !== undefined ||
     (firstLine.listContinuationIndent !== undefined &&
@@ -2310,7 +2366,7 @@ function parseCodeRabbitRangeStatement(content, match, continuationEnd) {
     statementStart.slice(
       0,
       statementStart.toLowerCase().lastIndexOf("reviewing"),
-    ),
+    ).replace(/`+$/, ""),
   );
   const sameLineSeparator = firstLineTail.match(
     CODERABBIT_REVIEW_RANGE_SEPARATOR_PATTERN,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -25,7 +25,7 @@ const MARKDOWN_FENCE_LINE_PATTERN =
 const MARKDOWN_HTML_COMMENT_BLOCK_START_PATTERN =
   /^( {0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+))*)<!--/;
 const MARKDOWN_LIST_PREFIX_PATTERN = /([-*+]|\d{1,9}[.)])([ \t]+)/g;
-const MARKDOWN_PARAGRAPH_LIST_PREFIX_PATTERN = /^(?:[-*+]|\d{1,9}[.)])[ \t]+/;
+const MARKDOWN_LIST_MARKER_PATTERN = /^(?:[-*+]|\d{1,9}[.)])/;
 const MARKDOWN_RAW_HTML_BLOCK_START_PATTERN =
   /^<(script|pre|style|textarea)(?:[ \t]|>|$)/i;
 const MARKDOWN_PARAGRAPH_INTERRUPTING_HTML_TAG_PATTERN =
@@ -862,9 +862,10 @@ function markdownParagraphLineContext(line) {
   const structuralPrefix = codeRabbitMarkdownPrefixSignature(containerPrefix);
   const indentation = markdownContainerIndentColumns(containerPrefix);
   const remainingLine = line.slice(containerPrefix.length);
-  const listPrefix = remainingLine.match(
-    MARKDOWN_PARAGRAPH_LIST_PREFIX_PATTERN,
-  )?.[0];
+  const listPrefix = markdownListItemPrefix(
+    remainingLine,
+    markdownColumns(containerPrefix),
+  );
   return {
     blockquoteDepth:
       [...containerPrefix].filter((character) => character === ">").length,
@@ -947,6 +948,27 @@ function markdownListMarkerInterruptsParagraph(listPrefix) {
   return Number(marker.slice(0, -1)) === 1;
 }
 
+function markdownListItemPrefix(line, initialColumn = 0) {
+  const marker = line.match(MARKDOWN_LIST_MARKER_PATTERN)?.[0];
+  if (marker === undefined) return undefined;
+  let whitespaceEnd = marker.length;
+  while (line[whitespaceEnd] === " " || line[whitespaceEnd] === "\t") {
+    whitespaceEnd += 1;
+  }
+  if (whitespaceEnd === marker.length) return undefined;
+
+  const markerEndColumn = markdownColumns(marker, initialColumn);
+  const paddingColumns = markdownColumns(
+    line.slice(marker.length, whitespaceEnd),
+    markerEndColumn,
+  ) - markerEndColumn;
+  const contentFollowsPadding = whitespaceEnd < line.length;
+  const prefixEnd = contentFollowsPadding && paddingColumns <= 4
+    ? whitespaceEnd
+    : marker.length + 1;
+  return line.slice(0, prefixEnd);
+}
+
 function isMarkdownNonInterruptingHtmlLine(line) {
   // GitHub Flavored Markdown HTML block types 1–6 interrupt paragraphs;
   // type 7 does not.
@@ -985,9 +1007,10 @@ function markdownHtmlBlockStart(line, indentedCodeLine) {
   )?.[0] ?? "";
   if (!hasValidMarkdownBlockquoteSpacing(containerPrefix)) return undefined;
   const remainingLine = line.slice(containerPrefix.length);
-  const listPrefix = remainingLine.match(
-    MARKDOWN_PARAGRAPH_LIST_PREFIX_PATTERN,
-  )?.[0] ?? "";
+  const listPrefix = markdownListItemPrefix(
+    remainingLine,
+    markdownColumns(containerPrefix),
+  ) ?? "";
   const blockContent = remainingLine.slice(listPrefix.length);
   const tag = blockContent.match(
     MARKDOWN_RAW_HTML_BLOCK_START_PATTERN,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -214,7 +214,7 @@ async function classifyAutomatedReviewEvent(
     CODERABBIT_REVIEW_RANGE_CANDIDATE_PATTERN.test(line)
   );
   const rangeCandidateHasCurrentTip = rangeCandidates?.some((line) =>
-    lastFullCommitToken(line)?.toLowerCase() === headSha.toLowerCase()
+    rangeCandidateReferencesTip(line, headSha)
   );
   const reviewedTips = rangeCandidates?.map((line) =>
     line.match(CODERABBIT_REVIEW_RANGE_PATTERN)?.[2]
@@ -265,12 +265,14 @@ function codeRabbitRecentReview(body) {
   return end < 0 ? undefined : body.slice(contentStart, end);
 }
 
-function lastFullCommitToken(value) {
-  let lastToken;
-  for (const match of value.matchAll(FULL_COMMIT_TOKEN_PATTERN)) {
-    lastToken = match[1];
-  }
-  return lastToken;
+function rangeCandidateReferencesTip(value, headSha) {
+  const tokens = [...value.matchAll(FULL_COMMIT_TOKEN_PATTERN)].map((match) =>
+    match[1]?.toLowerCase()
+  );
+  const normalizedHeadSha = headSha.toLowerCase();
+  if (tokens.length === 1) return tokens[0] === normalizedHeadSha;
+  if (tokens[1] === normalizedHeadSha) return true;
+  return tokens.slice(2).includes(normalizedHeadSha);
 }
 
 /** Publish the current automated-review decision on the exact PR head SHA. */

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -2193,16 +2193,18 @@ function appendMarkdownInlineHtmlRanges(content, start, end, ranges) {
 function createMarkdownInlineTerminatorFinder(content, end) {
   const nextIndexByTerminator = new Map();
   return (terminator, start) => {
-    let nextIndex = nextIndexByTerminator.get(terminator);
-    if (nextIndex === -1) return undefined;
-    if (nextIndex === undefined || nextIndex < start) {
-      nextIndex = content.indexOf(terminator, start);
-      if (nextIndex < 0 || nextIndex >= end) {
-        nextIndexByTerminator.set(terminator, -1);
-        return undefined;
-      }
-      nextIndexByTerminator.set(terminator, nextIndex);
+    const cached = nextIndexByTerminator.get(terminator);
+    if (cached?.searchStart <= start) {
+      if (cached.index < 0 || cached.index >= end) return undefined;
+      if (cached.index >= start) return cached.index;
     }
+
+    const nextIndex = content.indexOf(terminator, start);
+    nextIndexByTerminator.set(terminator, {
+      index: nextIndex,
+      searchStart: start,
+    });
+    if (nextIndex < 0 || nextIndex >= end) return undefined;
     return nextIndex;
   };
 }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -22,6 +22,8 @@ const CODERABBIT_REVIEW_RANGE_WRAPPED_SEPARATOR_PATTERN =
 const FULL_COMMIT_TOKEN_PATTERN = /(^|[^0-9a-f])([0-9a-f]{40})(?![0-9a-f])/gi;
 const MARKDOWN_FENCE_LINE_PATTERN =
   /^( {0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*)(`{3,}|~{3,})/;
+const MARKDOWN_HTML_COMMENT_BLOCK_START_PATTERN =
+  /^( {0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*)<!--/;
 const MARKDOWN_LIST_PREFIX_PATTERN =
   /([-*+]|\d+[.)])([ \t]+)(?:\[[ xX]\][ \t]+)?/g;
 const MARKDOWN_FENCE_CONTAINER_CONTINUATION_PATTERN = /^[ \t]*(?:>[ \t]*)*/;
@@ -421,7 +423,7 @@ function scanMarkdownStructure(content) {
     return range?.[0] <= index && index < range[1];
   };
   let openFence;
-  let openHtmlCommentStart;
+  let openHtmlComment;
   let lineStart = 0;
   for (const lineMatch of content.matchAll(/[^\r\n]*(?:\r\n|[\r\n]|$)/g)) {
     const line = lineMatch[0];
@@ -429,15 +431,26 @@ function scanMarkdownStructure(content) {
     const lineEnd = lineStart + line.length;
     const lineWithoutEnding = line.replace(/(?:\r\n|[\r\n])$/, "");
 
-    if (openHtmlCommentStart !== undefined) {
+    if (
+      openHtmlComment?.container !== undefined &&
+      !continuesMarkdownFenceContainer(
+        lineWithoutEnding,
+        openHtmlComment.container,
+      )
+    ) {
+      ranges.push([openHtmlComment.start, lineStart]);
+      openHtmlComment = undefined;
+    }
+
+    if (openHtmlComment !== undefined) {
       const relativeCloseStart = lineWithoutEnding.indexOf("-->");
       if (relativeCloseStart < 0) {
         lineStart = lineEnd;
         continue;
       }
       const closeStart = lineStart + relativeCloseStart;
-      ranges.push([openHtmlCommentStart, closeStart + 3]);
-      openHtmlCommentStart = scanMarkdownHtmlComments(
+      ranges.push([openHtmlComment.start, closeStart + 3]);
+      openHtmlComment = scanMarkdownHtmlComments(
         content,
         lineWithoutEnding,
         lineStart,
@@ -489,7 +502,7 @@ function scanMarkdownStructure(content) {
       }
     }
 
-    openHtmlCommentStart = scanMarkdownHtmlComments(
+    openHtmlComment = scanMarkdownHtmlComments(
       content,
       lineWithoutEnding,
       lineStart,
@@ -500,8 +513,8 @@ function scanMarkdownStructure(content) {
     );
     lineStart = lineEnd;
   }
-  if (openHtmlCommentStart !== undefined) {
-    ranges.push([openHtmlCommentStart, content.length]);
+  if (openHtmlComment !== undefined) {
+    ranges.push([openHtmlComment.start, content.length]);
   } else if (openFence !== undefined) {
     ranges.push([openFence.start, content.length]);
   }
@@ -576,11 +589,28 @@ function scanMarkdownHtmlComments(
       continue;
     }
     const relativeCloseStart = line.indexOf("-->", relativeCommentStart + 4);
-    if (relativeCloseStart < 0) return commentStart;
+    if (relativeCloseStart < 0) {
+      return {
+        start: commentStart,
+        container: markdownHtmlCommentBlockContainer(
+          line,
+          relativeCommentStart,
+        ),
+      };
+    }
     ranges.push([commentStart, lineStart + relativeCloseStart + 3]);
     searchStart = relativeCloseStart + 3;
   }
   return undefined;
+}
+
+function markdownHtmlCommentBlockContainer(line, commentStart) {
+  const match = line.match(MARKDOWN_HTML_COMMENT_BLOCK_START_PATTERN);
+  if (
+    !match || match[1].length !== commentStart ||
+    !hasValidMarkdownBlockquoteSpacing(match[1])
+  ) return undefined;
+  return markdownFenceContainer(match[1]);
 }
 
 function markdownInlineCodeRanges(content) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -10,9 +10,9 @@ const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r?\n)Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r?\n|$)/;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
-  /Requested commit:\s*([0-9a-f]{40})/i;
+  /Requested commit:\s*([0-9a-f]{40})/gi;
 const CODERABBIT_SKIPPED_COMMIT_PATTERN =
-  /Review skipped for current commit\s*([0-9a-f]{40})/i;
+  /Review skipped for current commit\s*([0-9a-f]{40})/gi;
 const CODEX_LOGIN = "chatgpt-codex-connector[bot]";
 const CODEX_BOT_ID = 199175422;
 const CODEX_NO_FINDING_PREFIX = "Codex Review: Didn't find any major issues.";
@@ -198,12 +198,11 @@ async function classifyAutomatedReviewEvent(
     return { kind: "not-head" };
   }
   const recentReview = codeRabbitRecentReview(body);
-  const skippedTip = body.match(CODERABBIT_SKIPPED_COMMIT_PATTERN)?.[1];
-  const requestedTip = body.match(CODERABBIT_REQUESTED_COMMIT_PATTERN)?.[1];
-  if (
-    skippedTip?.toLowerCase() === headSha.toLowerCase() ||
-    requestedTip?.toLowerCase() === headSha.toLowerCase()
-  ) {
+  const currentHeadMarker = [
+    ...body.matchAll(CODERABBIT_SKIPPED_COMMIT_PATTERN),
+    ...body.matchAll(CODERABBIT_REQUESTED_COMMIT_PATTERN),
+  ].some((match) => match[1]?.toLowerCase() === headSha.toLowerCase());
+  if (currentHeadMarker) {
     return {
       kind: "failure",
       url: typeof comment.html_url === "string" ? comment.html_url : undefined,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -562,6 +562,16 @@ function hasValidMarkdownBlockquoteSpacing(prefix) {
   return true;
 }
 
+function isMarkdownIndentedCodeLine(line) {
+  const prefix = line.match(
+    MARKDOWN_FENCE_CONTAINER_CONTINUATION_PATTERN,
+  )?.[0] ?? "";
+  const firstBlockquote = prefix.indexOf(">");
+  if (firstBlockquote < 0) return markdownColumns(prefix) >= 4;
+  if (markdownColumns(prefix.slice(0, firstBlockquote)) >= 4) return true;
+  return !hasValidMarkdownBlockquoteSpacing(prefix);
+}
+
 function scanMarkdownHtmlComments(
   content,
   line,
@@ -575,17 +585,18 @@ function scanMarkdownHtmlComments(
     const relativeCommentStart = line.indexOf("<!--", searchStart);
     if (relativeCommentStart < 0) return undefined;
     const commentStart = lineStart + relativeCommentStart;
+    if (
+      isInsidePossibleInlineCode(commentStart) ||
+      isEscapedMarkdownToken(content, commentStart) ||
+      isMarkdownIndentedCodeLine(line)
+    ) {
+      searchStart = relativeCommentStart + 4;
+      continue;
+    }
     const reviewMarker = codeRabbitReviewMarkerAt(line, relativeCommentStart);
     if (reviewMarker) {
       reviewMarkers.push({ value: reviewMarker, index: commentStart });
       searchStart = relativeCommentStart + reviewMarker.length;
-      continue;
-    }
-    if (
-      isInsidePossibleInlineCode(commentStart) ||
-      isEscapedMarkdownToken(content, commentStart)
-    ) {
-      searchStart = relativeCommentStart + 4;
       continue;
     }
     const relativeCloseStart = line.indexOf("-->", relativeCommentStart + 4);

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -10,7 +10,7 @@ const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r\n|[\r\n])Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r\n|[\r\n]|$)/;
 const CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN =
-  /(?:^|\r\n|[\r\n])([ \t]*(?:(?:>[ \t]*)|(?:\|[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*(?:`+)?(?:Reviewing[ \t]+(?:files(?:[ \t]+that[ \t]+changed[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?|changed[ \t]+files(?:[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?)[ \t]+(?:and[ \t]+)?between))([^\r\n]*)/gi;
+  /(?:^|\r\n|[\r\n])([ \t]*(?:(?:>[ \t]*)|(?:\|[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*[\\`]*(?:Reviewing[ \t]+(?:files(?:[ \t]+that[ \t]+changed[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?|changed[ \t]+files(?:[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?)[ \t]+(?:and[ \t]+)?between))([^\r\n]*)/gi;
 const CODERABBIT_REVIEW_RANGE_CONTINUATION_PREFIX_PATTERN =
   /^[ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*/;
 const CODERABBIT_REVIEW_RANGE_SEPARATOR_PATTERN =
@@ -2353,7 +2353,8 @@ function isEscapedMarkdownToken(content, tokenStart) {
 }
 
 function codeRabbitStatementIndex(match) {
-  return match.index + match[0].indexOf(match[1]);
+  return match.index + match[0].indexOf(match[1]) +
+    match[1].toLowerCase().lastIndexOf("reviewing");
 }
 
 function parseCodeRabbitRangeStatement(content, match, continuationEnd) {
@@ -2368,7 +2369,7 @@ function parseCodeRabbitRangeStatement(content, match, continuationEnd) {
     statementStart.slice(
       0,
       statementStart.toLowerCase().lastIndexOf("reviewing"),
-    ).replace(/`+$/, ""),
+    ).replace(/[\\`]+$/, ""),
   );
   const sameLineSeparator = firstLineTail.match(
     CODERABBIT_REVIEW_RANGE_SEPARATOR_PATTERN,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -30,6 +30,12 @@ const MARKDOWN_PARAGRAPH_LIST_PREFIX_PATTERN =
   /^(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?/;
 const MARKDOWN_RAW_HTML_BLOCK_START_PATTERN =
   /^<(script|pre|style|textarea)(?:[ \t]|>|$)/i;
+const MARKDOWN_PARAGRAPH_INTERRUPTING_HTML_TAG_PATTERN =
+  /^ {0,3}<\/?(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h[1-6]|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|search|section|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)(?:[ \t]|\/?>|$)/i;
+const MARKDOWN_PARAGRAPH_INTERRUPTING_RAW_HTML_PATTERN =
+  /^ {0,3}<(?:script|pre|style|textarea)(?:[ \t]|>|$)/i;
+const MARKDOWN_PARAGRAPH_INTERRUPTING_HTML_SYNTAX_PATTERN =
+  /^ {0,3}(?:<!--|<\?|<![A-Z]|<!\[CDATA\[)/;
 const MARKDOWN_FENCE_CONTAINER_CONTINUATION_PATTERN = /^[ \t]*(?:>[ \t]*)*/;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
   /Requested commit:\s*([0-9a-f]{40})/gi;
@@ -715,7 +721,16 @@ function markdownLineContinuesParagraph(line, paragraph) {
     !lazyBlockquoteContinuation && !lazyListContinuation
   ) return false;
   return line.indentation - paragraph.continuationIndent >= 4 ||
+    isMarkdownNonInterruptingHtmlLine(line.content) ||
     !isMarkdownInlineCodeBarrier(line.content);
+}
+
+function isMarkdownNonInterruptingHtmlLine(line) {
+  // CommonMark HTML block types 1–6 interrupt paragraphs; type 7 does not.
+  return /^ {0,3}<(?:[A-Za-z!?/])/.test(line) &&
+    !MARKDOWN_PARAGRAPH_INTERRUPTING_HTML_TAG_PATTERN.test(line) &&
+    !MARKDOWN_PARAGRAPH_INTERRUPTING_RAW_HTML_PATTERN.test(line) &&
+    !MARKDOWN_PARAGRAPH_INTERRUPTING_HTML_SYNTAX_PATTERN.test(line);
 }
 
 function markdownParagraphAfterLine(

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -11,7 +11,7 @@ const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r?\n)Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r?\n|$)/;
 const CODERABBIT_REVIEW_RANGE_STATEMENT_PATTERN =
-  /(?:^|\r?\n)([ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*(?:Reviewing\s+(?:files(?:\s+that\s+changed\s+from\s+the\s+base\s+of\s+the\s+PR)?|changed files(?:\s+from\s+the\s+base\s+of\s+the\s+PR)?)\s+(?:and\s+)?between[ \t]+([^ \t\r\n]+)(?:[ \t]+|[ \t]*\r?\n[ \t]*)and(?:[ \t]*\r?\n)?[ \t]*([0-9a-f]{40})[^\r\n]*))/gi;
+  /(?:^|\r?\n)([ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*(?:Reviewing\s+(?:files(?:\s+that\s+changed\s+from\s+the\s+base\s+of\s+the\s+PR)?|changed files(?:\s+from\s+the\s+base\s+of\s+the\s+PR)?)\s+(?:and\s+)?between((?:[ \t]+[^\r\n]*?)?)(?:[ \t]+|[ \t]*\r?\n[ \t]*)and(?:[ \t]*\r?\n)?[ \t]*([0-9a-f]{40})[^\r\n]*))/gi;
 const FULL_COMMIT_TOKEN_PATTERN = /(^|[^0-9a-f])([0-9a-f]{40})(?![0-9a-f])/gi;
 const MARKDOWN_FENCE_LINE_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})/;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
@@ -341,7 +341,7 @@ function codeRabbitRangeEvidenceStatements(content) {
       statementIndex < fenceRanges[fenceIndex][1];
     if (insideFence) continue;
     statements.push({
-      baseToken: match[2].toLowerCase(),
+      baseToken: match[2].trim().toLowerCase(),
       statement: match[1],
       tipToken: match[3].toLowerCase(),
     });

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -8,6 +8,8 @@ const CODERABBIT_RECENT_REVIEW_END_MARKER = "<!-- recent_review_end -->";
 const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
   "No actionable comments were generated in the recent review.";
 const CODERABBIT_REVIEW_RANGE_CANDIDATE_PATTERN = /^\s*reviewing\s+files\b/i;
+const CODERABBIT_REVIEW_RANGE_EVIDENCE_PATTERN =
+  /(?:^|\r?\n)\s*(?:[-*+]\s+)?Reviewing\s+(?:files|changed files)\b[^\r\n]*\bbetween\s+[0-9a-f]{40}\s+and(?:[ \t]*\r?\n)?[ \t]*([0-9a-f]{40})(?![0-9a-f])/gi;
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r?\n)Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r?\n|$)/;
 const FULL_COMMIT_TOKEN_PATTERN = /(?:^|[^0-9a-f])([0-9a-f]{40})(?![0-9a-f])/gi;
@@ -216,6 +218,11 @@ async function classifyAutomatedReviewEvent(
   const rangeCandidateHasCurrentTip = rangeCandidates?.some((line) =>
     rangeCandidateReferencesTip(line, headSha)
   );
+  const rangeEvidenceHasCurrentTip = [
+    ...(selectedRecentReview?.content.matchAll(
+      CODERABBIT_REVIEW_RANGE_EVIDENCE_PATTERN,
+    ) ?? []),
+  ].some((match) => match[1]?.toLowerCase() === headSha.toLowerCase());
   const reviewedTips = rangeCandidates?.map((line) =>
     line.match(CODERABBIT_REVIEW_RANGE_PATTERN)?.[2]
   );
@@ -224,7 +231,8 @@ async function classifyAutomatedReviewEvent(
   );
   if (
     selectedRecentReview && !selectedRecentReview.terminated &&
-    (hasCurrentRange || rangeCandidateHasCurrentTip)
+    (hasCurrentRange || rangeCandidateHasCurrentTip ||
+      rangeEvidenceHasCurrentTip)
   ) {
     return {
       kind: "failure",
@@ -232,7 +240,8 @@ async function classifyAutomatedReviewEvent(
     };
   }
   if (rangeCandidates?.length !== 1) {
-    return hasCurrentRange || rangeCandidateHasCurrentTip
+    return hasCurrentRange || rangeCandidateHasCurrentTip ||
+        rangeEvidenceHasCurrentTip
       ? {
         kind: "failure",
         url: typeof comment.html_url === "string"
@@ -243,7 +252,7 @@ async function classifyAutomatedReviewEvent(
   }
   const reviewedTip = reviewedTips?.[0];
   if (reviewedTip?.toLowerCase() !== headSha.toLowerCase()) {
-    return rangeCandidateHasCurrentTip
+    return rangeCandidateHasCurrentTip || rangeEvidenceHasCurrentTip
       ? { kind: "failure" }
       : { kind: "not-head" };
   }
@@ -273,9 +282,27 @@ function codeRabbitSelectedRecentReview(body) {
   if (start < 0) return undefined;
   const contentStart = start + CODERABBIT_RECENT_REVIEW_MARKER.length;
   const end = body.indexOf(CODERABBIT_RECENT_REVIEW_END_MARKER, contentStart);
+  if (end < 0) {
+    const previousStart = body.lastIndexOf(
+      CODERABBIT_RECENT_REVIEW_MARKER,
+      start - 1,
+    );
+    const previousContentStart = previousStart +
+      CODERABBIT_RECENT_REVIEW_MARKER.length;
+    const previousEnd = previousStart < 0 ? -1 : body.indexOf(
+      CODERABBIT_RECENT_REVIEW_END_MARKER,
+      previousContentStart,
+    );
+    return {
+      content: body.slice(
+        previousEnd < 0 ? contentStart : previousContentStart,
+      ),
+      terminated: false,
+    };
+  }
   return {
-    content: end < 0 ? body.slice(contentStart) : body.slice(contentStart, end),
-    terminated: end >= 0,
+    content: body.slice(contentStart, end),
+    terminated: true,
   };
 }
 

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -4,8 +4,7 @@ const AUTOMATED_REVIEW_LOGINS = new Set([
 ]);
 const CODERABBIT_LOGIN = "coderabbitai[bot]";
 const CODERABBIT_RECENT_REVIEW_MARKER = "<!-- recent_review_start -->";
-const CODERABBIT_RECENT_REVIEW_MARKER_PATTERN =
-  /<!-- recent_review_start -->|<!-- recent_review_end -->/g;
+const CODERABBIT_RECENT_REVIEW_END_MARKER = "<!-- recent_review_end -->";
 const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
   "No actionable comments were generated in the recent review.";
 const CODERABBIT_REVIEW_RANGE_PATTERN =
@@ -22,7 +21,7 @@ const CODERABBIT_REVIEW_RANGE_WRAPPED_SEPARATOR_PATTERN =
   /^[ \t]*and[ \t]+([0-9a-f]{40})(?![0-9a-f])/i;
 const FULL_COMMIT_TOKEN_PATTERN = /(^|[^0-9a-f])([0-9a-f]{40})(?![0-9a-f])/gi;
 const MARKDOWN_FENCE_LINE_PATTERN =
-  /^([ \t]{0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*)(`{3,}|~{3,})/;
+  /^( {0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*)(`{3,}|~{3,})/;
 const MARKDOWN_LIST_PREFIX_PATTERN =
   /([-*+]|\d+[.)])([ \t]+)(?:\[[ xX]\][ \t]+)?/g;
 const MARKDOWN_FENCE_CONTAINER_CONTINUATION_PATTERN = /^[ \t]*(?:>[ \t]*)*/;
@@ -279,10 +278,8 @@ function codeRabbitSelectedRecentReview(body) {
   const groups = [];
   let openGroup;
   let previousFallbackContent;
-  for (
-    const marker of body.matchAll(CODERABBIT_RECENT_REVIEW_MARKER_PATTERN)
-  ) {
-    if (marker[0] === CODERABBIT_RECENT_REVIEW_MARKER) {
+  for (const marker of markdownReviewMarkers(body)) {
+    if (marker.value === CODERABBIT_RECENT_REVIEW_MARKER) {
       if (openGroup) {
         openGroup.invalid = true;
       } else {
@@ -369,7 +366,16 @@ function codeRabbitRangeEvidenceStatements(content) {
 }
 
 function markdownExcludedRanges(content) {
+  return scanMarkdownStructure(content).excludedRanges;
+}
+
+function markdownReviewMarkers(content) {
+  return scanMarkdownStructure(content).reviewMarkers;
+}
+
+function scanMarkdownStructure(content) {
   const ranges = [];
+  const reviewMarkers = [];
   let openFence;
   let openHtmlCommentStart;
   let lineStart = 0;
@@ -393,6 +399,7 @@ function markdownExcludedRanges(content) {
         lineStart,
         relativeCloseStart + 3,
         ranges,
+        reviewMarkers,
       );
       lineStart = lineEnd;
       continue;
@@ -443,6 +450,7 @@ function markdownExcludedRanges(content) {
       lineStart,
       0,
       ranges,
+      reviewMarkers,
     );
     lineStart = lineEnd;
   }
@@ -451,7 +459,7 @@ function markdownExcludedRanges(content) {
   } else if (openFence !== undefined) {
     ranges.push([openFence.start, content.length]);
   }
-  return ranges;
+  return { excludedRanges: ranges, reviewMarkers };
 }
 
 function scanMarkdownHtmlComments(
@@ -460,6 +468,7 @@ function scanMarkdownHtmlComments(
   lineStart,
   searchStart,
   ranges,
+  reviewMarkers,
 ) {
   while (searchStart < line.length) {
     const relativeCommentStart = line.indexOf("<!--", searchStart);
@@ -469,10 +478,36 @@ function scanMarkdownHtmlComments(
       searchStart = relativeCommentStart + 4;
       continue;
     }
+    const reviewMarker = codeRabbitReviewMarkerAt(line, relativeCommentStart);
+    if (reviewMarker) {
+      reviewMarkers.push({ value: reviewMarker, index: commentStart });
+      searchStart = relativeCommentStart + reviewMarker.length;
+      continue;
+    }
     const relativeCloseStart = line.indexOf("-->", relativeCommentStart + 4);
     if (relativeCloseStart < 0) return commentStart;
     ranges.push([commentStart, lineStart + relativeCloseStart + 3]);
     searchStart = relativeCloseStart + 3;
+  }
+  return undefined;
+}
+
+function codeRabbitReviewMarkerAt(line, markerStart) {
+  if (markerStart > 3) return undefined;
+  const prefix = line.slice(0, markerStart);
+  if (prefix.trim().length > 0 || markdownColumns(prefix) > 3) {
+    return undefined;
+  }
+  for (
+    const marker of [
+      CODERABBIT_RECENT_REVIEW_MARKER,
+      CODERABBIT_RECENT_REVIEW_END_MARKER,
+    ]
+  ) {
+    if (
+      line.startsWith(marker, markerStart) &&
+      line.slice(markerStart + marker.length).trim().length === 0
+    ) return marker;
   }
   return undefined;
 }
@@ -615,8 +650,23 @@ function markdownFenceContainer(prefix) {
     ),
     continuationIndent: listPrefixes.length === 0
       ? 0
-      : prefix.length - (prefix.lastIndexOf(">") + 1),
+      : markdownContainerIndentColumns(prefix),
   };
+}
+
+function markdownContainerIndentColumns(prefix) {
+  const structuralEnd = prefix.lastIndexOf(">") + 1;
+  const structuralColumns = markdownColumns(prefix.slice(0, structuralEnd));
+  return markdownColumns(prefix.slice(structuralEnd), structuralColumns) -
+    structuralColumns;
+}
+
+function markdownColumns(value, initialColumn = 0) {
+  let column = initialColumn;
+  for (const character of value) {
+    column += character === "\t" ? 4 - (column % 4) : 1;
+  }
+  return column;
 }
 
 function markdownClosingFenceMarker(line, fence) {
@@ -627,7 +677,7 @@ function markdownClosingFenceMarker(line, fence) {
     codeRabbitMarkdownPrefixSignature(linePrefix) !==
       fence.container.structuralPrefix
   ) return undefined;
-  const indentation = linePrefix.match(/[ \t]*$/)?.[0].length ?? 0;
+  const indentation = markdownContainerIndentColumns(linePrefix);
   if (
     indentation < fence.container.continuationIndent ||
     indentation > fence.container.continuationIndent + 3
@@ -653,7 +703,7 @@ function continuesMarkdownFenceContainer(line, container) {
       container.structuralPrefix
   ) return false;
   if (linePrefix.length === line.length) return true;
-  return (linePrefix.match(/[ \t]*$/)?.[0].length ?? 0) >=
+  return markdownContainerIndentColumns(linePrefix) >=
     container.continuationIndent;
 }
 

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -372,36 +372,53 @@ function parseCodeRabbitRangeStatement(content, match) {
     };
   }
 
-  const nextLine = codeRabbitNextLine(content, match.index + match[0].length);
-  if (!nextLine) return undefined;
-  const trailingAnd = firstLineTail.match(/(^|[ \t])and[ \t]*$/i);
-  if (trailingAnd) {
+  const baseLines = [firstLineTail];
+  const statementParts = [statementStart + firstLineTail];
+  let lineEnd = match.index + match[0].length;
+  while (true) {
+    const nextLine = codeRabbitNextLine(content, lineEnd);
+    if (!nextLine || nextLine.content.trim().length === 0) return undefined;
+    statementParts.push(nextLine.separator, nextLine.content);
+
+    const previousLine = baseLines.at(-1);
+    const trailingAnd = previousLine?.match(/(^|[ \t])and[ \t]*$/i);
     const wrappedTip = nextLine.content.match(
       CODERABBIT_REVIEW_RANGE_WRAPPED_TIP_PATTERN,
     );
-    if (wrappedTip) {
+    if (trailingAnd && wrappedTip) {
       return {
-        baseSegment: firstLineTail.slice(0, trailingAnd.index).trim()
-          .toLowerCase(),
-        statement: statementStart + firstLineTail + nextLine.separator +
-          nextLine.content,
+        baseSegment: codeRabbitBaseSegment(
+          baseLines.slice(0, -1),
+          previousLine.slice(0, trailingAnd.index),
+        ),
+        statement: statementParts.join(""),
         tipToken: wrappedTip[1].toLowerCase(),
         trailingStatement: nextLine.content.slice(wrappedTip[0].length),
       };
     }
-  }
 
-  const wrappedSeparator = nextLine.content.match(
-    CODERABBIT_REVIEW_RANGE_WRAPPED_SEPARATOR_PATTERN,
-  );
-  if (!wrappedSeparator) return undefined;
-  return {
-    baseSegment: firstLineTail.trim().toLowerCase(),
-    statement: statementStart + firstLineTail + nextLine.separator +
-      nextLine.content,
-    tipToken: wrappedSeparator[1].toLowerCase(),
-    trailingStatement: nextLine.content.slice(wrappedSeparator[0].length),
-  };
+    const wrappedSeparator = nextLine.content.match(
+      CODERABBIT_REVIEW_RANGE_WRAPPED_SEPARATOR_PATTERN,
+    );
+    if (wrappedSeparator) {
+      return {
+        baseSegment: codeRabbitBaseSegment(
+          baseLines,
+          nextLine.content.slice(0, wrappedSeparator.index),
+        ),
+        statement: statementParts.join(""),
+        tipToken: wrappedSeparator[1].toLowerCase(),
+        trailingStatement: nextLine.content.slice(wrappedSeparator[0].length),
+      };
+    }
+
+    baseLines.push(nextLine.content);
+    lineEnd = nextLine.lineEnd;
+  }
+}
+
+function codeRabbitBaseSegment(lines, finalLine) {
+  return [...lines, finalLine].join("\n").trim().toLowerCase();
 }
 
 function codeRabbitNextLine(content, lineEnd) {
@@ -417,6 +434,7 @@ function codeRabbitNextLine(content, lineEnd) {
     content: nextLineEnd < 0
       ? content.slice(contentStart)
       : content.slice(contentStart, contentStart + nextLineEnd),
+    lineEnd: nextLineEnd < 0 ? content.length : contentStart + nextLineEnd,
     separator,
   };
 }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -10,15 +10,15 @@ const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r\n|[\r\n])Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r\n|[\r\n]|$)/;
 const CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN =
-  /(?<![A-Za-z0-9])(?=(Reviewing[ \t]+(?:files(?:[ \t]+that[ \t]+changed[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?|changed[ \t]+files(?:[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?)[ \t]+(?:and[ \t]+)?between))/gi;
+  /(?<![A-Za-z0-9])(?=(Reviewing\b))/gi;
+const CODERABBIT_REVIEW_RANGE_BASE_INTRO_PATTERN =
+  /^(?:files(?: that changed from the base of the pr)?|changed files(?: from the base of the pr)?)(?: and)? between(?: |$)/;
 const CODERABBIT_REVIEW_RANGE_CONTINUATION_PREFIX_PATTERN =
   /^[ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*/;
 const CODERABBIT_REVIEW_RANGE_SEPARATOR_PATTERN =
   /(^|[ \t])and[ \t]+([0-9a-f]{40})(?![0-9a-f])/i;
 const CODERABBIT_REVIEW_RANGE_WRAPPED_TIP_PATTERN =
   /^[ \t]*([0-9a-f]{40})(?![0-9a-f])/i;
-const CODERABBIT_REVIEW_RANGE_WRAPPED_SEPARATOR_PATTERN =
-  /^[ \t]*and[ \t]+([0-9a-f]{40})(?![0-9a-f])/i;
 const FULL_COMMIT_TOKEN_PATTERN = /(^|[^0-9a-f])([0-9a-f]{40})(?![0-9a-f])/gi;
 const MARKDOWN_FENCE_LINE_PATTERN =
   /^( {0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+))*)(`{3,}|~{3,})/;
@@ -354,6 +354,8 @@ function classifyCodeRabbitRangeEvidence(selectedRecentReview, headSha) {
 function codeRabbitRangeEvidenceStatements(content) {
   const markdownStructure = scanMarkdownStructure(content);
   const excludedRanges = markdownStructure.excludedRanges;
+  const paragraphContinuationLineStarts =
+    markdownStructure.paragraphContinuationLineStarts;
   const matches = mergeCodeRabbitRangeMatches(
     [...content.matchAll(CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN)],
     markdownTableRangeEvidenceMatches(
@@ -388,6 +390,7 @@ function codeRabbitRangeEvidenceStatements(content) {
       match,
       continuationEnd,
       nextStatementIndex,
+      paragraphContinuationLineStarts,
     );
     if (statement) {
       statement.insideTableCell = match.tableCell !== undefined;
@@ -542,6 +545,7 @@ function visibleMarkdownMatches(content, patterns, excludedRanges) {
 function scanMarkdownStructure(content) {
   const ranges = [];
   const reviewMarkers = [];
+  const paragraphContinuationLineStarts = new Set();
   const {
     inlineCodeRanges,
     inlineHtmlRanges,
@@ -582,6 +586,7 @@ function scanMarkdownStructure(content) {
       paragraphLine,
       openParagraph,
     );
+    if (continuesParagraph) paragraphContinuationLineStarts.add(lineStart);
     const listContextsForLine = markdownListContextsForLine(
       paragraphLine,
       openListContexts,
@@ -792,6 +797,7 @@ function scanMarkdownStructure(content) {
       ),
     ),
     reviewMarkers,
+    paragraphContinuationLineStarts,
     tableCellRanges: refinedInlineRanges.tableCellRanges,
   };
 }
@@ -2414,6 +2420,7 @@ function parseCodeRabbitRangeStatement(
   match,
   continuationEnd,
   nextStatementIndex,
+  paragraphContinuationLineStarts,
 ) {
   const statementPhrase = match[1];
   const statementEnd = match.index + statementPhrase.length;
@@ -2437,9 +2444,13 @@ function parseCodeRabbitRangeStatement(
     CODERABBIT_REVIEW_RANGE_SEPARATOR_PATTERN,
   );
   if (sameLineSeparator) {
+    const baseSegment = codeRabbitBaseSegment(
+      [],
+      firstLineTail.slice(0, sameLineSeparator.index),
+    );
+    if (baseSegment === undefined) return undefined;
     return {
-      baseSegment: firstLineTail.slice(0, sameLineSeparator.index).trim()
-        .toLowerCase(),
+      baseSegment,
       statement: statementStart + firstLineTail,
       tipToken: sameLineSeparator[2].toLowerCase(),
       trailingStatement: firstLineTail.slice(
@@ -2471,7 +2482,10 @@ function parseCodeRabbitRangeStatement(
     if (
       continuationContent.trim().length === 0 ||
       continuationContent.trimStart().startsWith("<!--") ||
-      codeRabbitRangeContainerSignature(continuationPrefix) !== statementPrefix
+      (codeRabbitRangeContainerSignature(continuationPrefix) !==
+          statementPrefix &&
+        (match.tableCell !== undefined ||
+          !paragraphContinuationLineStarts.has(nextLine.lineStart)))
     ) return undefined;
     statementParts.push(nextLine.separator, nextLine.content);
 
@@ -2481,30 +2495,34 @@ function parseCodeRabbitRangeStatement(
       CODERABBIT_REVIEW_RANGE_WRAPPED_TIP_PATTERN,
     );
     if (trailingAnd && wrappedTip) {
+      const baseSegment = codeRabbitBaseSegment(
+        baseLines.slice(0, -1),
+        previousLine.slice(0, trailingAnd.index),
+      );
+      if (baseSegment === undefined) return undefined;
       return {
-        baseSegment: codeRabbitBaseSegment(
-          baseLines.slice(0, -1),
-          previousLine.slice(0, trailingAnd.index),
-        ),
+        baseSegment,
         statement: statementParts.join(""),
         tipToken: wrappedTip[1].toLowerCase(),
         trailingStatement: continuationContent.slice(wrappedTip[0].length),
       };
     }
 
-    const wrappedSeparator = continuationContent.match(
-      CODERABBIT_REVIEW_RANGE_WRAPPED_SEPARATOR_PATTERN,
+    const continuationSeparator = continuationContent.match(
+      CODERABBIT_REVIEW_RANGE_SEPARATOR_PATTERN,
     );
-    if (wrappedSeparator) {
+    if (continuationSeparator) {
+      const baseSegment = codeRabbitBaseSegment(
+        baseLines,
+        continuationContent.slice(0, continuationSeparator.index),
+      );
+      if (baseSegment === undefined) return undefined;
       return {
-        baseSegment: codeRabbitBaseSegment(
-          baseLines,
-          continuationContent.slice(0, wrappedSeparator.index),
-        ),
+        baseSegment,
         statement: statementParts.join(""),
-        tipToken: wrappedSeparator[1].toLowerCase(),
+        tipToken: continuationSeparator[2].toLowerCase(),
         trailingStatement: continuationContent.slice(
-          wrappedSeparator[0].length,
+          continuationSeparator.index + continuationSeparator[0].length,
         ),
       };
     }
@@ -2519,6 +2537,7 @@ function codeRabbitNextTableCell(content, cell, continuationEnd) {
   const cellEnd = Math.min(cell.end, continuationEnd);
   return {
     content: content.slice(cell.start, cellEnd),
+    lineStart: cell.start,
     lineEnd: cellEnd,
     nextTableCell: cell.nextTableCell,
     separator: "\n",
@@ -2539,7 +2558,13 @@ function codeRabbitRangeContainerSignature(prefix) {
 }
 
 function codeRabbitBaseSegment(lines, finalLine) {
-  return [...lines, finalLine].join("\n").trim().toLowerCase();
+  const normalized = [...lines, finalLine].join("\n").trim().toLowerCase()
+    .replace(/[ \t]*(?:\r\n|[\r\n])[ \t]*/g, " ")
+    .replace(/[ \t]+/g, " ");
+  const intro = normalized.match(
+    CODERABBIT_REVIEW_RANGE_BASE_INTRO_PATTERN,
+  )?.[0];
+  return intro === undefined ? undefined : normalized.slice(intro.length);
 }
 
 function codeRabbitNextLine(content, lineEnd, continuationEnd) {
@@ -2565,6 +2590,7 @@ function codeRabbitNextLine(content, lineEnd, continuationEnd) {
       contentStart,
       nextLineEnd < 0 ? content.length : nextLineEnd,
     ),
+    lineStart: contentStart,
     lineEnd: nextLineEnd < 0 ? content.length : nextLineEnd,
     separator,
   };

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -35,7 +35,7 @@ const MARKDOWN_PARAGRAPH_INTERRUPTING_HTML_TAG_PATTERN =
 const MARKDOWN_PARAGRAPH_INTERRUPTING_RAW_HTML_PATTERN =
   /^ {0,3}<(?:script|pre|style|textarea)(?:[ \t]|>|$)/i;
 const MARKDOWN_PARAGRAPH_INTERRUPTING_HTML_SYNTAX_PATTERN =
-  /^ {0,3}(?:<!--|<\?|<![A-Z]|<!\[CDATA\[)/;
+  /^ {0,3}(?:<!--|<\?|<![A-Za-z]|<!\[CDATA\[)/;
 const MARKDOWN_FENCE_CONTAINER_CONTINUATION_PATTERN = /^[ \t]*(?:>[ \t]*)*/;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
   /Requested commit:\s*([0-9a-f]{40})/gi;

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -334,28 +334,28 @@ function classifyCodeRabbitRangeEvidence(selectedRecentReview, headSha) {
 }
 
 function codeRabbitRangeEvidenceStatements(content) {
-  const fenceRanges = markdownFenceRanges(content);
+  const excludedRanges = markdownExcludedRanges(content);
   const matches = [
     ...content.matchAll(CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN),
   ];
   const statementIndexes = matches.map(codeRabbitStatementIndex);
   const statements = [];
-  let fenceIndex = 0;
+  let excludedRangeIndex = 0;
   for (const [matchIndex, match] of matches.entries()) {
     const statementIndex = statementIndexes[matchIndex];
     while (
-      fenceIndex < fenceRanges.length &&
-      fenceRanges[fenceIndex][1] <= statementIndex
+      excludedRangeIndex < excludedRanges.length &&
+      excludedRanges[excludedRangeIndex][1] <= statementIndex
     ) {
-      fenceIndex += 1;
+      excludedRangeIndex += 1;
     }
-    const insideFence = fenceIndex < fenceRanges.length &&
-      fenceRanges[fenceIndex][0] <= statementIndex &&
-      statementIndex < fenceRanges[fenceIndex][1];
-    if (insideFence) continue;
+    const insideExcludedRange = excludedRangeIndex < excludedRanges.length &&
+      excludedRanges[excludedRangeIndex][0] <= statementIndex &&
+      statementIndex < excludedRanges[excludedRangeIndex][1];
+    if (insideExcludedRange) continue;
     const continuationEnd = Math.min(
       statementIndexes[matchIndex + 1] ?? content.length,
-      fenceRanges[fenceIndex]?.[0] ?? content.length,
+      excludedRanges[excludedRangeIndex]?.[0] ?? content.length,
     );
     const statement = parseCodeRabbitRangeStatement(
       content,
@@ -365,6 +365,75 @@ function codeRabbitRangeEvidenceStatements(content) {
     if (statement) statements.push(statement);
   }
   return statements;
+}
+
+function markdownExcludedRanges(content) {
+  const fenceRanges = markdownFenceRanges(content);
+  return mergeMarkdownRanges(
+    fenceRanges,
+    markdownHtmlCommentRanges(content, fenceRanges),
+  );
+}
+
+function markdownHtmlCommentRanges(content, fenceRanges) {
+  const ranges = [];
+  let fenceIndex = 0;
+  let searchStart = 0;
+  while (searchStart < content.length) {
+    const commentStart = content.indexOf("<!--", searchStart);
+    if (commentStart < 0) break;
+    while (
+      fenceIndex < fenceRanges.length &&
+      fenceRanges[fenceIndex][1] <= commentStart
+    ) {
+      fenceIndex += 1;
+    }
+    if (
+      fenceIndex < fenceRanges.length &&
+      fenceRanges[fenceIndex][0] <= commentStart
+    ) {
+      searchStart = fenceRanges[fenceIndex][1];
+      continue;
+    }
+    if (isEscapedMarkdownToken(content, commentStart)) {
+      searchStart = commentStart + 4;
+      continue;
+    }
+    const closeStart = content.indexOf("-->", commentStart + 4);
+    const commentEnd = closeStart < 0 ? content.length : closeStart + 3;
+    ranges.push([commentStart, commentEnd]);
+    searchStart = commentEnd;
+  }
+  return ranges;
+}
+
+function isEscapedMarkdownToken(content, tokenStart) {
+  let slashStart = tokenStart;
+  while (slashStart > 0 && content[slashStart - 1] === "\\") {
+    slashStart -= 1;
+  }
+  return (tokenStart - slashStart) % 2 === 1;
+}
+
+function mergeMarkdownRanges(leftRanges, rightRanges) {
+  const ranges = [];
+  let leftIndex = 0;
+  let rightIndex = 0;
+  while (leftIndex < leftRanges.length || rightIndex < rightRanges.length) {
+    const takeLeft = rightIndex >= rightRanges.length ||
+      (leftIndex < leftRanges.length &&
+        leftRanges[leftIndex][0] <= rightRanges[rightIndex][0]);
+    const nextRange = takeLeft
+      ? leftRanges[leftIndex++]
+      : rightRanges[rightIndex++];
+    const previousRange = ranges.at(-1);
+    if (previousRange && nextRange[0] <= previousRange[1]) {
+      previousRange[1] = Math.max(previousRange[1], nextRange[1]);
+    } else {
+      ranges.push([...nextRange]);
+    }
+  }
+  return ranges;
 }
 
 function codeRabbitStatementIndex(match) {
@@ -511,6 +580,12 @@ function markdownFenceRanges(content) {
         lineWithoutEnding.slice(markerEnd),
       );
       if (openFence === undefined) {
+        const hasValidInfoString = marker[0] === "~" ||
+          !lineWithoutEnding.slice(markerEnd).includes("`");
+        if (!hasValidInfoString) {
+          lineStart = lineEnd;
+          continue;
+        }
         openFence = {
           char: marker[0],
           length: marker.length,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -411,6 +411,7 @@ function codeRabbitRangeEvidenceStatements(content) {
   const markdownStructure = scanMarkdownStructure(content);
   const excludedRanges = markdownStructure.excludedRanges;
   const continuationBarrierRanges = markdownStructure.continuationBarrierRanges;
+  const inlineCodeRanges = markdownStructure.inlineCodeRanges;
   const inlineLinkRanges = markdownStructure.inlineLinkRanges;
   const paragraphContinuationLineStarts =
     markdownStructure.paragraphContinuationLineStarts;
@@ -475,7 +476,12 @@ function codeRabbitRangeEvidenceStatements(content) {
     const insideExcludedRange = excludedRangeIndex < excludedRanges.length &&
       excludedRanges[excludedRangeIndex][0] <= statementIndex &&
       statementIndex < excludedRanges[excludedRangeIndex][1];
-    if (insideExcludedRange) continue;
+    const containingInlineCodeRange = insideExcludedRange
+      ? markdownRangeContainingIndex(inlineCodeRanges, statementIndex)
+      : undefined;
+    if (insideExcludedRange && containingInlineCodeRange === undefined) {
+      continue;
+    }
     while (
       continuationBarrierRangeIndex < continuationBarrierRanges.length &&
       continuationBarrierRanges[continuationBarrierRangeIndex][1] <=
@@ -485,6 +491,20 @@ function codeRabbitRangeEvidenceStatements(content) {
     }
     const nextStatementIndex = statementIndexes[matchIndex + 1] ??
       content.length;
+    if (
+      containingInlineCodeRange !== undefined &&
+      match.statementPhraseEnd <= containingInlineCodeRange[1] &&
+      parseCodeRabbitRangeStatement(
+          content,
+          match,
+          Math.min(nextStatementIndex, containingInlineCodeRange[1]),
+          nextStatementIndex,
+          paragraphContinuationLineStarts,
+          inlineLinkRanges,
+        ) !== undefined
+    ) {
+      continue;
+    }
     const continuationEnd = Math.min(
       nextStatementIndex,
       continuationBarrierRanges[continuationBarrierRangeIndex]?.[0] ??
@@ -909,10 +929,7 @@ function scanMarkdownStructure(content) {
       continuationBlockRanges,
       paragraphInterruptingHtmlRanges,
     ),
-    mergeMarkdownRanges(
-      refinedInlineRanges.inlineCodeRanges,
-      refinedInlineRanges.referenceDefinitionRanges,
-    ),
+    refinedInlineRanges.referenceDefinitionRanges,
   );
   return {
     continuationBarrierRanges,
@@ -923,6 +940,7 @@ function scanMarkdownStructure(content) {
         refinedInlineRanges.inlineHtmlRanges,
       ),
     ),
+    inlineCodeRanges: refinedInlineRanges.inlineCodeRanges,
     inlineLinkRanges: refinedInlineRanges.inlineLinkRanges,
     reviewMarkers,
     paragraphContinuationLineStarts,
@@ -2759,6 +2777,11 @@ function firstMarkdownRangeEndingAfter(ranges, index) {
     else upper = middle;
   }
   return lower;
+}
+
+function markdownRangeContainingIndex(ranges, index) {
+  const range = ranges[firstMarkdownRangeEndingAfter(ranges, index)];
+  return range !== undefined && range[0] <= index ? range : undefined;
 }
 
 function markdownRangesIntersect(ranges, start, end) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -25,6 +25,7 @@ const MARKDOWN_FENCE_LINE_PATTERN =
   /^([ \t]{0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*)(`{3,}|~{3,})/;
 const MARKDOWN_LIST_PREFIX_PATTERN =
   /([-*+]|\d+[.)])([ \t]+)(?:\[[ xX]\][ \t]+)?/g;
+const MARKDOWN_FENCE_CONTAINER_CONTINUATION_PATTERN = /^[ \t]*(?:>[ \t]*)*/;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
   /Requested commit:\s*([0-9a-f]{40})/gi;
 const CODERABBIT_SKIPPED_COMMIT_PATTERN =
@@ -624,7 +625,7 @@ function continuesMarkdownFenceContainer(line, container) {
     container.continuationIndent === 0
   ) return true;
   const linePrefix = line.match(
-    CODERABBIT_REVIEW_RANGE_CONTINUATION_PREFIX_PATTERN,
+    MARKDOWN_FENCE_CONTAINER_CONTINUATION_PATTERN,
   )?.[0] ?? "";
   if (
     codeRabbitMarkdownPrefixSignature(linePrefix) !==

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -539,6 +539,7 @@ function scanMarkdownStructure(content) {
   let openFence;
   let openHtmlBlock;
   let openHtmlComment;
+  let openListContexts = [];
   let openParagraph;
   let lineStart = 0;
   for (const lineMatch of content.matchAll(/[^\r\n]*(?:\r\n|[\r\n]|$)/g)) {
@@ -551,8 +552,21 @@ function scanMarkdownStructure(content) {
       paragraphLine,
       openParagraph,
     );
-    const indentedCodeLine = isMarkdownIndentedCodeLine(lineWithoutEnding) &&
-      !continuesParagraph;
+    const listContextsForLine = markdownListContextsForLine(
+      paragraphLine,
+      openListContexts,
+      continuesParagraph,
+    );
+    const indentedCodeLine = isMarkdownIndentedCodeLine(
+      lineWithoutEnding,
+      paragraphLine,
+      listContextsForLine.at(-1)?.continuationIndent ?? 0,
+    ) && !continuesParagraph;
+    openListContexts = markdownListContextsAfterLine(
+      paragraphLine,
+      listContextsForLine,
+      continuesParagraph,
+    );
     const paragraphAfterLine = markdownParagraphAfterLine(
       paragraphLine,
       openParagraph,
@@ -790,11 +804,22 @@ function hasValidMarkdownBlockquoteSpacing(prefix) {
   return true;
 }
 
-function isMarkdownIndentedCodeLine(line) {
+function isMarkdownIndentedCodeLine(
+  line,
+  paragraphLine,
+  listContinuationIndent,
+) {
   const prefix = line.match(
     MARKDOWN_FENCE_CONTAINER_CONTINUATION_PATTERN,
   )?.[0] ?? "";
   const firstBlockquote = prefix.indexOf(">");
+  if (listContinuationIndent > 0) {
+    if (
+      firstBlockquote >= 0 &&
+      markdownColumns(prefix.slice(0, firstBlockquote)) >= 4
+    ) return true;
+    return paragraphLine.indentation - listContinuationIndent >= 4;
+  }
   if (firstBlockquote < 0) return markdownColumns(prefix) >= 4;
   if (markdownColumns(prefix.slice(0, firstBlockquote)) >= 4) return true;
   return !hasValidMarkdownBlockquoteSpacing(prefix);
@@ -826,6 +851,40 @@ function markdownParagraphLineContext(line) {
       : markdownContainerIndentColumns(containerPrefix + listPrefix),
     structuralPrefix,
   };
+}
+
+function markdownListContextsForLine(
+  line,
+  openListContexts,
+  continuesParagraph,
+) {
+  const blankContainerLine = line.listContinuationIndent === undefined &&
+    line.content.trim().length === 0;
+  if (continuesParagraph || blankContainerLine) return openListContexts;
+  while (openListContexts.length > 0) {
+    const context = openListContexts.at(-1);
+    if (
+      context.structuralPrefix === line.structuralPrefix &&
+      context.continuationIndent <= line.indentation
+    ) break;
+    openListContexts.pop();
+  }
+  return openListContexts;
+}
+
+function markdownListContextsAfterLine(
+  line,
+  listContextsForLine,
+  continuesParagraph,
+) {
+  if (continuesParagraph || line.listContinuationIndent === undefined) {
+    return listContextsForLine;
+  }
+  listContextsForLine.push({
+    continuationIndent: line.listContinuationIndent,
+    structuralPrefix: line.structuralPrefix,
+  });
+  return listContextsForLine;
 }
 
 function markdownLineContinuesParagraph(line, paragraph) {
@@ -1047,6 +1106,7 @@ function markdownInlineStructureRanges(content, excludedRanges = []) {
   const tableSplitRangeCursor = { index: 0 };
 
   let segmentStart = 0;
+  let openListContexts = [];
   let openParagraph;
   let excludedRangeIndex = 0;
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
@@ -1059,8 +1119,21 @@ function markdownInlineStructureRanges(content, excludedRanges = []) {
       paragraphLine,
       openParagraph,
     );
-    const indentedCodeLine = isMarkdownIndentedCodeLine(lineWithoutEnding) &&
-      !continuesParagraph;
+    const listContextsForLine = markdownListContextsForLine(
+      paragraphLine,
+      openListContexts,
+      continuesParagraph,
+    );
+    const indentedCodeLine = isMarkdownIndentedCodeLine(
+      lineWithoutEnding,
+      paragraphLine,
+      listContextsForLine.at(-1)?.continuationIndent ?? 0,
+    ) && !continuesParagraph;
+    openListContexts = markdownListContextsAfterLine(
+      paragraphLine,
+      listContextsForLine,
+      continuesParagraph,
+    );
     while (excludedRanges[excludedRangeIndex]?.[1] <= lineStart) {
       excludedRangeIndex += 1;
     }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -10,8 +10,14 @@ const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
   "No actionable comments were generated in the recent review.";
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r?\n)Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r?\n|$)/;
-const CODERABBIT_REVIEW_RANGE_STATEMENT_PATTERN =
-  /(?:^|\r?\n)([ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*(?:Reviewing\s+(?:files(?:\s+that\s+changed\s+from\s+the\s+base\s+of\s+the\s+PR)?|changed files(?:\s+from\s+the\s+base\s+of\s+the\s+PR)?)\s+(?:and\s+)?between((?:[ \t]+[^\r\n]*?)?)(?:[ \t]+|[ \t]*\r?\n[ \t]*)and(?:[ \t]*\r?\n)?[ \t]*([0-9a-f]{40})[^\r\n]*))/gi;
+const CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN =
+  /(?:^|\r?\n)([ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*(?:Reviewing[ \t]+(?:files(?:[ \t]+that[ \t]+changed[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?|changed[ \t]+files(?:[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?)[ \t]+(?:and[ \t]+)?between))([^\r\n]*)/gi;
+const CODERABBIT_REVIEW_RANGE_SEPARATOR_PATTERN =
+  /(^|[ \t])and[ \t]+([0-9a-f]{40})(?![0-9a-f])/i;
+const CODERABBIT_REVIEW_RANGE_WRAPPED_TIP_PATTERN =
+  /^[ \t]*([0-9a-f]{40})(?![0-9a-f])/i;
+const CODERABBIT_REVIEW_RANGE_WRAPPED_SEPARATOR_PATTERN =
+  /^[ \t]*and[ \t]+([0-9a-f]{40})(?![0-9a-f])/i;
 const FULL_COMMIT_TOKEN_PATTERN = /(^|[^0-9a-f])([0-9a-f]{40})(?![0-9a-f])/gi;
 const MARKDOWN_FENCE_LINE_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})/;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
@@ -327,7 +333,9 @@ function codeRabbitRangeEvidenceStatements(content) {
   const statements = [];
   let fenceIndex = 0;
   for (
-    const match of content.matchAll(CODERABBIT_REVIEW_RANGE_STATEMENT_PATTERN)
+    const match of content.matchAll(
+      CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN,
+    )
   ) {
     const statementIndex = match.index + match[0].indexOf(match[1]);
     while (
@@ -340,13 +348,77 @@ function codeRabbitRangeEvidenceStatements(content) {
       fenceRanges[fenceIndex][0] <= statementIndex &&
       statementIndex < fenceRanges[fenceIndex][1];
     if (insideFence) continue;
-    statements.push({
-      baseToken: match[2].trim().toLowerCase(),
-      statement: match[1],
-      tipToken: match[3].toLowerCase(),
-    });
+    const statement = parseCodeRabbitRangeStatement(content, match);
+    if (statement) statements.push(statement);
   }
   return statements;
+}
+
+function parseCodeRabbitRangeStatement(content, match) {
+  const statementStart = match[1];
+  const firstLineTail = match[2];
+  const sameLineSeparator = firstLineTail.match(
+    CODERABBIT_REVIEW_RANGE_SEPARATOR_PATTERN,
+  );
+  if (sameLineSeparator) {
+    return {
+      baseSegment: firstLineTail.slice(0, sameLineSeparator.index).trim()
+        .toLowerCase(),
+      statement: statementStart + firstLineTail,
+      tipToken: sameLineSeparator[2].toLowerCase(),
+      trailingStatement: firstLineTail.slice(
+        sameLineSeparator.index + sameLineSeparator[0].length,
+      ),
+    };
+  }
+
+  const nextLine = codeRabbitNextLine(content, match.index + match[0].length);
+  if (!nextLine) return undefined;
+  const trailingAnd = firstLineTail.match(/(^|[ \t])and[ \t]*$/i);
+  if (trailingAnd) {
+    const wrappedTip = nextLine.content.match(
+      CODERABBIT_REVIEW_RANGE_WRAPPED_TIP_PATTERN,
+    );
+    if (wrappedTip) {
+      return {
+        baseSegment: firstLineTail.slice(0, trailingAnd.index).trim()
+          .toLowerCase(),
+        statement: statementStart + firstLineTail + nextLine.separator +
+          nextLine.content,
+        tipToken: wrappedTip[1].toLowerCase(),
+        trailingStatement: nextLine.content.slice(wrappedTip[0].length),
+      };
+    }
+  }
+
+  const wrappedSeparator = nextLine.content.match(
+    CODERABBIT_REVIEW_RANGE_WRAPPED_SEPARATOR_PATTERN,
+  );
+  if (!wrappedSeparator) return undefined;
+  return {
+    baseSegment: firstLineTail.trim().toLowerCase(),
+    statement: statementStart + firstLineTail + nextLine.separator +
+      nextLine.content,
+    tipToken: wrappedSeparator[1].toLowerCase(),
+    trailingStatement: nextLine.content.slice(wrappedSeparator[0].length),
+  };
+}
+
+function codeRabbitNextLine(content, lineEnd) {
+  const separator = content.startsWith("\r\n", lineEnd)
+    ? "\r\n"
+    : content.startsWith("\n", lineEnd)
+    ? "\n"
+    : undefined;
+  if (!separator) return undefined;
+  const contentStart = lineEnd + separator.length;
+  const nextLineEnd = content.slice(contentStart).search(/[\r\n]/);
+  return {
+    content: nextLineEnd < 0
+      ? content.slice(contentStart)
+      : content.slice(contentStart, contentStart + nextLineEnd),
+    separator,
+  };
 }
 
 function markdownFenceRanges(content) {
@@ -387,22 +459,17 @@ function markdownFenceRanges(content) {
 
 function parseCodeRabbitRangeEvidence(evidence, headSha) {
   const normalizedHeadSha = headSha.toLowerCase();
-  const tipIndex = evidence.statement.toLowerCase().indexOf(
-    evidence.tipToken,
-  );
-  const trailingStatement = tipIndex < 0
-    ? ""
-    : evidence.statement.slice(tipIndex + evidence.tipToken.length);
   const extraTokens = [
-    ...trailingStatement.matchAll(FULL_COMMIT_TOKEN_PATTERN),
+    ...evidence.trailingStatement.matchAll(FULL_COMMIT_TOKEN_PATTERN),
   ].map((match) => match[2].toLowerCase());
   const exactMatch = evidence.statement.match(CODERABBIT_REVIEW_RANGE_PATTERN);
   return {
     tipIsHead: evidence.tipToken === normalizedHeadSha,
     extraHasHead: extraTokens.includes(normalizedHeadSha),
-    isExactProduction: exactMatch?.[1]?.toLowerCase() === evidence.baseToken &&
+    isExactProduction:
+      exactMatch?.[1]?.toLowerCase() === evidence.baseSegment &&
       exactMatch?.[2]?.toLowerCase() === evidence.tipToken &&
-      FULL_COMMIT_PATTERN.test(evidence.baseToken) &&
+      FULL_COMMIT_PATTERN.test(evidence.baseSegment) &&
       extraTokens.length === 0,
   };
 }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -11,7 +11,7 @@ const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r?\n)Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r?\n|$)/;
 const CODERABBIT_REVIEW_RANGE_STATEMENT_PATTERN =
-  /(?:^|\r?\n)[ \t]*(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+))*(Reviewing\s+(?:files(?:\s+that\s+changed\s+from\s+the\s+base\s+of\s+the\s+PR)?|changed files(?:\s+from\s+the\s+base\s+of\s+the\s+PR)?)\s+(?:and\s+)?between\s+[0-9a-f]{40}\s+and(?:[ \t]*\r?\n)?[ \t]*[0-9a-f]{40}[^\r\n]*)/gi;
+  /(?:^|\r?\n)([ \t]*(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+))*(?:Reviewing\s+(?:files(?:\s+that\s+changed\s+from\s+the\s+base\s+of\s+the\s+PR)?|changed files(?:\s+from\s+the\s+base\s+of\s+the\s+PR)?)\s+(?:and\s+)?between[ \t]+([^ \t\r\n]+)[ \t]+and(?:[ \t]*\r?\n)?[ \t]*([0-9a-f]{40})[^\r\n]*))/gi;
 const FULL_COMMIT_TOKEN_PATTERN = /(^|[^0-9a-f])([0-9a-f]{40})(?![0-9a-f])/gi;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
   /Requested commit:\s*([0-9a-f]{40})/gi;
@@ -324,24 +324,32 @@ function classifyCodeRabbitRangeEvidence(selectedRecentReview, headSha) {
 function codeRabbitRangeEvidenceStatements(content) {
   return [...content.matchAll(CODERABBIT_REVIEW_RANGE_STATEMENT_PATTERN)].map((
     match,
-  ) => match[0].replace(/^\r?\n/, ""));
+  ) => ({
+    baseToken: match[2].toLowerCase(),
+    statement: match[1],
+    tipToken: match[3].toLowerCase(),
+  }));
 }
 
-function parseCodeRabbitRangeEvidence(block, headSha) {
-  const betweenIndex = block.search(/\bbetween\b/i);
-  if (betweenIndex < 0) return undefined;
-  const tokens = [
-    ...block.slice(betweenIndex).matchAll(FULL_COMMIT_TOKEN_PATTERN),
-  ].map((match) => match[2].toLowerCase());
-  if (tokens.length < 2) return undefined;
+function parseCodeRabbitRangeEvidence(evidence, headSha) {
   const normalizedHeadSha = headSha.toLowerCase();
-  const exactMatch = block.match(CODERABBIT_REVIEW_RANGE_PATTERN);
+  const tipIndex = evidence.statement.toLowerCase().indexOf(
+    evidence.tipToken,
+  );
+  const trailingStatement = tipIndex < 0
+    ? ""
+    : evidence.statement.slice(tipIndex + evidence.tipToken.length);
+  const extraTokens = [
+    ...trailingStatement.matchAll(FULL_COMMIT_TOKEN_PATTERN),
+  ].map((match) => match[2].toLowerCase());
+  const exactMatch = evidence.statement.match(CODERABBIT_REVIEW_RANGE_PATTERN);
   return {
-    tipIsHead: tokens[1] === normalizedHeadSha,
-    extraHasHead: tokens.slice(2).includes(normalizedHeadSha),
-    isExactProduction: exactMatch?.[1]?.toLowerCase() === tokens[0] &&
-      exactMatch?.[2]?.toLowerCase() === tokens[1] &&
-      tokens.length === 2,
+    tipIsHead: evidence.tipToken === normalizedHeadSha,
+    extraHasHead: extraTokens.includes(normalizedHeadSha),
+    isExactProduction: exactMatch?.[1]?.toLowerCase() === evidence.baseToken &&
+      exactMatch?.[2]?.toLowerCase() === evidence.tipToken &&
+      FULL_COMMIT_PATTERN.test(evidence.baseToken) &&
+      extraTokens.length === 0,
   };
 }
 

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -372,6 +372,12 @@ function codeRabbitStatementIndex(match) {
 function parseCodeRabbitRangeStatement(content, match, continuationEnd) {
   const statementStart = match[1];
   const firstLineTail = match[2];
+  const statementPrefix = codeRabbitMarkdownPrefixSignature(
+    statementStart.slice(
+      0,
+      statementStart.toLowerCase().lastIndexOf("reviewing"),
+    ),
+  );
   const sameLineSeparator = firstLineTail.match(
     CODERABBIT_REVIEW_RANGE_SEPARATOR_PATTERN,
   );
@@ -393,11 +399,17 @@ function parseCodeRabbitRangeStatement(content, match, continuationEnd) {
   while (true) {
     const nextLine = codeRabbitNextLine(content, lineEnd, continuationEnd);
     if (!nextLine) return undefined;
-    const continuationContent = nextLine.content.replace(
+    const continuationPrefix = nextLine.content.match(
       CODERABBIT_REVIEW_RANGE_CONTINUATION_PREFIX_PATTERN,
-      "",
+    )?.[0] ?? "";
+    const continuationContent = nextLine.content.slice(
+      continuationPrefix.length,
     );
-    if (continuationContent.trim().length === 0) return undefined;
+    if (
+      continuationContent.trim().length === 0 ||
+      continuationContent.trimStart().startsWith("<!--") ||
+      codeRabbitMarkdownPrefixSignature(continuationPrefix) !== statementPrefix
+    ) return undefined;
     statementParts.push(nextLine.separator, nextLine.content);
 
     const previousLine = baseLines.at(-1);
@@ -437,6 +449,10 @@ function parseCodeRabbitRangeStatement(content, match, continuationEnd) {
     baseLines.push(continuationContent);
     lineEnd = nextLine.lineEnd;
   }
+}
+
+function codeRabbitMarkdownPrefixSignature(prefix) {
+  return prefix.trim().toLowerCase().replace(/[ \t]+/g, " ");
 }
 
 function codeRabbitBaseSegment(lines, finalLine) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -522,18 +522,21 @@ function scanMarkdownStructure(content) {
     referenceDefinitionRanges,
     tableCellRanges,
   } = markdownInlineStructureRanges(content);
-  const inlineExcludedRanges = mergeMarkdownRanges(
-    mergeMarkdownRanges(inlineCodeRanges, inlineLinkRanges),
-    referenceDefinitionRanges,
+  const inlineSyntaxRanges = mergeMarkdownRanges(
+    mergeMarkdownRanges(
+      mergeMarkdownRanges(inlineCodeRanges, inlineLinkRanges),
+      referenceDefinitionRanges,
+    ),
+    inlineHtmlRanges,
   );
-  let inlineCodeRangeIndex = 0;
-  const isInsideInlineCode = (index) => {
+  let inlineSyntaxRangeIndex = 0;
+  const isInsideInlineSyntax = (index) => {
     while (
-      inlineExcludedRanges[inlineCodeRangeIndex]?.[1] <= index
+      inlineSyntaxRanges[inlineSyntaxRangeIndex]?.[1] <= index
     ) {
-      inlineCodeRangeIndex += 1;
+      inlineSyntaxRangeIndex += 1;
     }
-    const range = inlineExcludedRanges[inlineCodeRangeIndex];
+    const range = inlineSyntaxRanges[inlineSyntaxRangeIndex];
     return range?.[0] <= index && index < range[1];
   };
   let openFence;
@@ -638,7 +641,7 @@ function scanMarkdownStructure(content) {
         relativeCloseStart + 3,
         ranges,
         reviewMarkers,
-        isInsideInlineCode,
+        isInsideInlineSyntax,
         indentedCodeLine,
       );
       openParagraph = inlineComment && openHtmlComment?.container === undefined
@@ -721,7 +724,7 @@ function scanMarkdownStructure(content) {
       0,
       ranges,
       reviewMarkers,
-      isInsideInlineCode,
+      isInsideInlineSyntax,
       indentedCodeLine,
     );
     openParagraph = openHtmlComment?.container === undefined
@@ -1012,7 +1015,7 @@ function scanMarkdownHtmlComments(
   searchStart,
   ranges,
   reviewMarkers,
-  isInsideInlineCode,
+  isInsideInlineSyntax,
   indentedCodeLine,
 ) {
   while (searchStart < line.length) {
@@ -1020,7 +1023,7 @@ function scanMarkdownHtmlComments(
     if (relativeCommentStart < 0) return undefined;
     const commentStart = lineStart + relativeCommentStart;
     if (
-      isInsideInlineCode(commentStart) ||
+      isInsideInlineSyntax(commentStart) ||
       isEscapedMarkdownToken(content, commentStart) ||
       indentedCodeLine
     ) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -26,6 +26,8 @@ const MARKDOWN_HTML_COMMENT_BLOCK_START_PATTERN =
   /^( {0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*)<!--/;
 const MARKDOWN_LIST_PREFIX_PATTERN =
   /([-*+]|\d+[.)])([ \t]+)(?:\[[ xX]\][ \t]+)?/g;
+const MARKDOWN_PARAGRAPH_LIST_PREFIX_PATTERN =
+  /^(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?/;
 const MARKDOWN_FENCE_CONTAINER_CONTINUATION_PATTERN = /^[ \t]*(?:>[ \t]*)*/;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
   /Requested commit:\s*([0-9a-f]{40})/gi;
@@ -216,11 +218,19 @@ async function classifyAutomatedReviewEvent(
   if (login.toLowerCase() !== CODERABBIT_LOGIN) {
     return { kind: "not-head" };
   }
-  const selectedRecentReview = codeRabbitSelectedRecentReview(body);
-  const currentHeadMarker = [
-    ...body.matchAll(CODERABBIT_SKIPPED_COMMIT_PATTERN),
-    ...body.matchAll(CODERABBIT_REQUESTED_COMMIT_PATTERN),
-  ].some((match) => match[1]?.toLowerCase() === headSha.toLowerCase());
+  const markdownStructure = scanMarkdownStructure(body);
+  const selectedRecentReview = codeRabbitSelectedRecentReview(
+    body,
+    markdownStructure.reviewMarkers,
+  );
+  const currentHeadMarker = visibleMarkdownMatches(
+    body,
+    [
+      CODERABBIT_SKIPPED_COMMIT_PATTERN,
+      CODERABBIT_REQUESTED_COMMIT_PATTERN,
+    ],
+    markdownStructure.excludedRanges,
+  ).some((match) => match[1]?.toLowerCase() === headSha.toLowerCase());
   if (currentHeadMarker) {
     return {
       kind: "failure",
@@ -277,12 +287,12 @@ async function classifyAutomatedReviewEvent(
     };
 }
 
-function codeRabbitSelectedRecentReview(body) {
+function codeRabbitSelectedRecentReview(body, reviewMarkers) {
   if (typeof body !== "string") return undefined;
   const groups = [];
   let openGroup;
   let previousFallbackContent;
-  for (const marker of markdownReviewMarkers(body)) {
+  for (const marker of reviewMarkers) {
     if (marker.value === CODERABBIT_RECENT_REVIEW_MARKER) {
       if (openGroup) {
         openGroup.invalid = true;
@@ -397,14 +407,28 @@ function hasExactVisibleMarkdownLine(content, expectedLine) {
   return false;
 }
 
-function markdownReviewMarkers(content) {
-  return scanMarkdownStructure(content).reviewMarkers;
+function visibleMarkdownMatches(content, patterns, excludedRanges) {
+  const matches = patterns.flatMap((pattern) => [...content.matchAll(pattern)])
+    .sort((left, right) => left.index - right.index);
+  let excludedRangeIndex = 0;
+  return matches.filter((match) => {
+    while (
+      excludedRangeIndex < excludedRanges.length &&
+      excludedRanges[excludedRangeIndex][1] <= match.index
+    ) {
+      excludedRangeIndex += 1;
+    }
+    const range = excludedRanges[excludedRangeIndex];
+    return !(range?.[0] <= match.index && match.index < range[1]);
+  });
 }
 
 function scanMarkdownStructure(content) {
   const ranges = [];
   const reviewMarkers = [];
-  const inlineCodeRanges = markdownInlineCodeRanges(content);
+  const { inlineCodeRanges, inlineHtmlRanges } = markdownInlineStructureRanges(
+    content,
+  );
   let inlineCodeRangeIndex = 0;
   const isInsideInlineCode = (index) => {
     while (
@@ -417,17 +441,31 @@ function scanMarkdownStructure(content) {
   };
   let openFence;
   let openHtmlComment;
+  let openParagraph;
   let lineStart = 0;
   for (const lineMatch of content.matchAll(/[^\r\n]*(?:\r\n|[\r\n]|$)/g)) {
     const line = lineMatch[0];
     if (line.length === 0 && lineStart >= content.length) break;
     const lineEnd = lineStart + line.length;
     const lineWithoutEnding = line.replace(/(?:\r\n|[\r\n])$/, "");
+    const paragraphLine = markdownParagraphLineContext(lineWithoutEnding);
+    const continuesParagraph = markdownLineContinuesParagraph(
+      paragraphLine,
+      openParagraph,
+    );
+    const indentedCodeLine = isMarkdownIndentedCodeLine(lineWithoutEnding) &&
+      !continuesParagraph;
+    const paragraphAfterLine = markdownParagraphAfterLine(
+      paragraphLine,
+      openParagraph,
+      continuesParagraph,
+      indentedCodeLine,
+    );
 
     if (
       openHtmlComment !== undefined &&
       openHtmlComment.container === undefined &&
-      isMarkdownInlineCodeBarrier(lineWithoutEnding)
+      !continuesParagraph
     ) {
       openHtmlComment = undefined;
     }
@@ -444,8 +482,10 @@ function scanMarkdownStructure(content) {
     }
 
     if (openHtmlComment !== undefined) {
+      const inlineComment = openHtmlComment.container === undefined;
       const relativeCloseStart = lineWithoutEnding.indexOf("-->");
       if (relativeCloseStart < 0) {
+        openParagraph = inlineComment ? paragraphAfterLine : undefined;
         lineStart = lineEnd;
         continue;
       }
@@ -459,7 +499,11 @@ function scanMarkdownStructure(content) {
         ranges,
         reviewMarkers,
         isInsideInlineCode,
+        indentedCodeLine,
       );
+      openParagraph = inlineComment && openHtmlComment?.container === undefined
+        ? paragraphAfterLine
+        : undefined;
       lineStart = lineEnd;
       continue;
     }
@@ -481,6 +525,7 @@ function scanMarkdownStructure(content) {
         ranges.push([openFence.start, lineEnd]);
         openFence = undefined;
       }
+      openParagraph = undefined;
       lineStart = lineEnd;
       continue;
     }
@@ -498,6 +543,7 @@ function scanMarkdownStructure(content) {
           start: lineStart,
           container: markdownFenceContainer(fenceMatch[1]),
         };
+        openParagraph = undefined;
         lineStart = lineEnd;
         continue;
       }
@@ -511,7 +557,11 @@ function scanMarkdownStructure(content) {
       ranges,
       reviewMarkers,
       isInsideInlineCode,
+      indentedCodeLine,
     );
+    openParagraph = openHtmlComment?.container === undefined
+      ? paragraphAfterLine
+      : undefined;
     lineStart = lineEnd;
   }
   if (openHtmlComment?.container !== undefined) {
@@ -520,7 +570,10 @@ function scanMarkdownStructure(content) {
     ranges.push([openFence.start, content.length]);
   }
   return {
-    excludedRanges: mergeMarkdownRanges(ranges, inlineCodeRanges),
+    excludedRanges: mergeMarkdownRanges(
+      ranges,
+      mergeMarkdownRanges(inlineCodeRanges, inlineHtmlRanges),
+    ),
     reviewMarkers,
   };
 }
@@ -573,6 +626,54 @@ function isMarkdownIndentedCodeLine(line) {
   return !hasValidMarkdownBlockquoteSpacing(prefix);
 }
 
+function markdownParagraphLineContext(line) {
+  const containerPrefix = line.match(
+    MARKDOWN_FENCE_CONTAINER_CONTINUATION_PATTERN,
+  )?.[0] ?? "";
+  const structuralPrefix = codeRabbitMarkdownPrefixSignature(containerPrefix);
+  const indentation = markdownContainerIndentColumns(containerPrefix);
+  const remainingLine = line.slice(containerPrefix.length);
+  const listPrefix = remainingLine.match(
+    MARKDOWN_PARAGRAPH_LIST_PREFIX_PATTERN,
+  )?.[0];
+  return {
+    content: listPrefix === undefined
+      ? remainingLine
+      : remainingLine.slice(listPrefix.length),
+    indentation,
+    listContinuationIndent: listPrefix === undefined
+      ? undefined
+      : markdownContainerIndentColumns(containerPrefix + listPrefix),
+    structuralPrefix,
+  };
+}
+
+function markdownLineContinuesParagraph(line, paragraph) {
+  if (
+    paragraph === undefined || line.listContinuationIndent !== undefined ||
+    line.structuralPrefix !== paragraph.structuralPrefix ||
+    line.indentation < paragraph.continuationIndent
+  ) return false;
+  return line.indentation - paragraph.continuationIndent >= 4 ||
+    !isMarkdownInlineCodeBarrier(line.content);
+}
+
+function markdownParagraphAfterLine(
+  line,
+  openParagraph,
+  continuesParagraph,
+  indentedCodeLine,
+) {
+  if (continuesParagraph) return openParagraph;
+  if (indentedCodeLine || isMarkdownInlineCodeBarrier(line.content)) {
+    return undefined;
+  }
+  return {
+    continuationIndent: line.listContinuationIndent ?? 0,
+    structuralPrefix: line.structuralPrefix,
+  };
+}
+
 function scanMarkdownHtmlComments(
   content,
   line,
@@ -581,6 +682,7 @@ function scanMarkdownHtmlComments(
   ranges,
   reviewMarkers,
   isInsideInlineCode,
+  indentedCodeLine,
 ) {
   while (searchStart < line.length) {
     const relativeCommentStart = line.indexOf("<!--", searchStart);
@@ -589,7 +691,7 @@ function scanMarkdownHtmlComments(
     if (
       isInsideInlineCode(commentStart) ||
       isEscapedMarkdownToken(content, commentStart) ||
-      isMarkdownIndentedCodeLine(line)
+      indentedCodeLine
     ) {
       searchStart = relativeCommentStart + 4;
       continue;
@@ -598,6 +700,15 @@ function scanMarkdownHtmlComments(
     if (reviewMarker) {
       reviewMarkers.push({ value: reviewMarker, index: commentStart });
       searchStart = relativeCommentStart + reviewMarker.length;
+      continue;
+    }
+    const shortCommentEnd = markdownShortHtmlCommentEnd(
+      line,
+      relativeCommentStart,
+    );
+    if (shortCommentEnd !== undefined) {
+      ranges.push([commentStart, lineStart + shortCommentEnd]);
+      searchStart = shortCommentEnd;
       continue;
     }
     const relativeCloseStart = line.indexOf("-->", relativeCommentStart + 4);
@@ -625,23 +736,56 @@ function markdownHtmlCommentBlockContainer(line, commentStart) {
   return markdownFenceContainer(match[1]);
 }
 
-function markdownInlineCodeRanges(content) {
-  const ranges = [];
+function markdownInlineStructureRanges(content) {
+  const inlineCodeRanges = [];
+  const inlineHtmlRanges = [];
   let segmentStart = 0;
+  let openParagraph;
   let lineStart = 0;
   for (const lineMatch of content.matchAll(/[^\r\n]*(?:\r\n|[\r\n]|$)/g)) {
     const line = lineMatch[0];
     if (line.length === 0 && lineStart >= content.length) break;
     const lineEnd = lineStart + line.length;
     const lineWithoutEnding = line.replace(/(?:\r\n|[\r\n])$/, "");
-    if (isMarkdownInlineCodeBarrier(lineWithoutEnding)) {
-      appendMarkdownInlineCodeRanges(content, segmentStart, lineStart, ranges);
+    const paragraphLine = markdownParagraphLineContext(lineWithoutEnding);
+    const continuesParagraph = markdownLineContinuesParagraph(
+      paragraphLine,
+      openParagraph,
+    );
+    const indentedCodeLine = isMarkdownIndentedCodeLine(lineWithoutEnding) &&
+      !continuesParagraph;
+    if (isMarkdownInlineCodeBarrier(lineWithoutEnding) || indentedCodeLine) {
+      appendMarkdownInlineCodeRanges(
+        content,
+        segmentStart,
+        lineStart,
+        inlineCodeRanges,
+        inlineHtmlRanges,
+      );
+      appendMarkdownInlineHtmlRanges(
+        content,
+        lineStart,
+        lineEnd,
+        inlineHtmlRanges,
+      );
       segmentStart = lineEnd;
     }
+    openParagraph = markdownParagraphAfterLine(
+      paragraphLine,
+      openParagraph,
+      continuesParagraph,
+      indentedCodeLine,
+    );
     lineStart = lineEnd;
   }
-  appendMarkdownInlineCodeRanges(content, segmentStart, content.length, ranges);
-  return ranges;
+  appendMarkdownInlineCodeRanges(
+    content,
+    segmentStart,
+    content.length,
+    inlineCodeRanges,
+    inlineHtmlRanges,
+  );
+  return { inlineCodeRanges, inlineHtmlRanges };
 }
 
 function isMarkdownInlineCodeBarrier(line) {
@@ -661,7 +805,13 @@ function isMarkdownInlineCodeBarrier(line) {
     hasValidMarkdownBlockquoteSpacing(fenceMatch[1]);
 }
 
-function appendMarkdownInlineCodeRanges(content, start, end, ranges) {
+function appendMarkdownInlineCodeRanges(
+  content,
+  start,
+  end,
+  inlineCodeRanges,
+  inlineHtmlRanges,
+) {
   const delimiterRuns = [];
   for (let index = start; index < end;) {
     if (content[index] !== "`") {
@@ -690,18 +840,159 @@ function appendMarkdownInlineCodeRanges(content, start, end, ranges) {
     nextIndexByLength.set(run.length, index);
   }
 
-  for (let index = 0; index < delimiterRuns.length;) {
-    const closingIndex = nextRunWithLength[index];
-    if (closingIndex === undefined) {
-      index += 1;
+  let delimiterIndex = 0;
+  let cursor = start;
+  while (cursor < end) {
+    while (delimiterRuns[delimiterIndex]?.end <= cursor) {
+      delimiterIndex += 1;
+    }
+    const delimiter = delimiterRuns[delimiterIndex];
+    const htmlStart = content.indexOf("<", cursor);
+    if (
+      htmlStart >= 0 && htmlStart < end &&
+      (delimiter === undefined || htmlStart < delimiter.start)
+    ) {
+      if (isEscapedMarkdownToken(content, htmlStart)) {
+        cursor = htmlStart + 1;
+        continue;
+      }
+      const htmlEnd = markdownInlineHtmlEnd(content, htmlStart, end);
+      cursor = htmlEnd ?? htmlStart + 1;
+      if (htmlEnd !== undefined) {
+        if (!content.startsWith("<!--", htmlStart)) {
+          inlineHtmlRanges.push([htmlStart, htmlEnd]);
+        }
+        while (delimiterRuns[delimiterIndex]?.start < htmlEnd) {
+          delimiterIndex += 1;
+        }
+      }
       continue;
     }
-    ranges.push([
-      delimiterRuns[index].start,
+    if (delimiter === undefined) break;
+
+    const closingIndex = nextRunWithLength[delimiterIndex];
+    if (closingIndex === undefined) {
+      cursor = delimiter.end;
+      delimiterIndex += 1;
+      continue;
+    }
+    inlineCodeRanges.push([
+      delimiter.start,
       delimiterRuns[closingIndex].end,
     ]);
-    index = closingIndex + 1;
+    cursor = delimiterRuns[closingIndex].end;
+    delimiterIndex = closingIndex + 1;
   }
+}
+
+function appendMarkdownInlineHtmlRanges(content, start, end, ranges) {
+  let cursor = start;
+  while (cursor < end) {
+    const htmlStart = content.indexOf("<", cursor);
+    if (htmlStart < 0 || htmlStart >= end) return;
+    if (isEscapedMarkdownToken(content, htmlStart)) {
+      cursor = htmlStart + 1;
+      continue;
+    }
+    const htmlEnd = markdownInlineHtmlEnd(content, htmlStart, end);
+    if (htmlEnd === undefined) {
+      cursor = htmlStart + 1;
+      continue;
+    }
+    if (!content.startsWith("<!--", htmlStart)) {
+      ranges.push([htmlStart, htmlEnd]);
+    }
+    cursor = htmlEnd;
+  }
+}
+
+function markdownInlineHtmlEnd(content, start, end) {
+  if (content.startsWith("<!--", start)) {
+    const shortCommentEnd = markdownShortHtmlCommentEnd(content, start);
+    if (shortCommentEnd !== undefined && shortCommentEnd <= end) {
+      return shortCommentEnd;
+    }
+    const closeStart = content.indexOf("-->", start + 4);
+    return closeStart >= 0 && closeStart < end ? closeStart + 3 : undefined;
+  }
+  if (content.startsWith("<?", start)) {
+    const closeStart = content.indexOf("?>", start + 2);
+    return closeStart >= 0 && closeStart < end ? closeStart + 2 : undefined;
+  }
+  if (content.startsWith("<![CDATA[", start)) {
+    const closeStart = content.indexOf("]]>", start + 9);
+    return closeStart >= 0 && closeStart < end ? closeStart + 3 : undefined;
+  }
+  if (content.startsWith("<!", start) && isAsciiLetter(content[start + 2])) {
+    const closeStart = content.indexOf(">", start + 3);
+    return closeStart >= 0 && closeStart < end ? closeStart + 1 : undefined;
+  }
+  return markdownInlineHtmlTagEnd(content, start, end);
+}
+
+function markdownShortHtmlCommentEnd(content, start) {
+  if (content.startsWith("<!-->", start)) return start + 5;
+  if (content.startsWith("<!--->", start)) return start + 6;
+  return undefined;
+}
+
+function markdownInlineHtmlTagEnd(content, start, end) {
+  let index = start + 1;
+  const closingTag = content[index] === "/";
+  if (closingTag) index += 1;
+  if (!isAsciiLetter(content[index])) return undefined;
+  index += 1;
+  while (index < end && /[A-Za-z0-9-]/.test(content[index])) index += 1;
+
+  if (closingTag) {
+    while (index < end && isMarkdownWhitespace(content[index])) index += 1;
+    return content[index] === ">" ? index + 1 : undefined;
+  }
+
+  while (index < end) {
+    const whitespaceStart = index;
+    while (index < end && isMarkdownWhitespace(content[index])) index += 1;
+    if (content[index] === ">") return index + 1;
+    if (content[index] === "/" && content[index + 1] === ">") {
+      return index + 2;
+    }
+    if (
+      index === whitespaceStart ||
+      !/[A-Za-z_:]/.test(content[index])
+    ) return undefined;
+
+    index += 1;
+    while (index < end && /[A-Za-z0-9_.:-]/.test(content[index])) index += 1;
+    while (index < end && isMarkdownWhitespace(content[index])) index += 1;
+    if (content[index] !== "=") continue;
+
+    index += 1;
+    while (index < end && isMarkdownWhitespace(content[index])) index += 1;
+    const quote = content[index];
+    if (quote === '"' || quote === "'") {
+      const quoteEnd = content.indexOf(quote, index + 1);
+      if (quoteEnd < 0 || quoteEnd >= end) return undefined;
+      index = quoteEnd + 1;
+      continue;
+    }
+    const valueStart = index;
+    while (
+      index < end &&
+      !isMarkdownWhitespace(content[index]) &&
+      !/["'=<>`]/.test(content[index])
+    ) index += 1;
+    if (index === valueStart) return undefined;
+  }
+  return undefined;
+}
+
+function isAsciiLetter(value) {
+  return typeof value === "string" && /[A-Za-z]/.test(value);
+}
+
+function isMarkdownWhitespace(value) {
+  return value === " " || value === "\t" || value === "\n" ||
+    value === "\r" || value === "\f";
 }
 
 function codeRabbitReviewMarkerAt(line, markerStart) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -908,14 +908,28 @@ function markdownInlineStructureRanges(content, excludedRanges = []) {
   const inlineCodeRanges = [];
   const inlineHtmlRanges = [];
   const excludedRangeCursor = { index: 0 };
-  let segmentStart = 0;
-  let openParagraph;
-  let lineStart = 0;
+  const lines = [];
+  let nextLineStart = 0;
   for (const lineMatch of content.matchAll(/[^\r\n]*(?:\r\n|[\r\n]|$)/g)) {
     const line = lineMatch[0];
-    if (line.length === 0 && lineStart >= content.length) break;
-    const lineEnd = lineStart + line.length;
-    const lineWithoutEnding = line.replace(/(?:\r\n|[\r\n])$/, "");
+    if (line.length === 0 && nextLineStart >= content.length) break;
+    const end = nextLineStart + line.length;
+    lines.push({
+      content: line.replace(/(?:\r\n|[\r\n])$/, ""),
+      end,
+      start: nextLineStart,
+    });
+    nextLineStart = end;
+  }
+
+  let segmentStart = 0;
+  let openParagraph;
+  let excludedRangeIndex = 0;
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex];
+    const lineStart = line.start;
+    const lineEnd = line.end;
+    const lineWithoutEnding = line.content;
     const paragraphLine = markdownParagraphLineContext(lineWithoutEnding);
     const continuesParagraph = markdownLineContinuesParagraph(
       paragraphLine,
@@ -923,6 +937,34 @@ function markdownInlineStructureRanges(content, excludedRanges = []) {
     );
     const indentedCodeLine = isMarkdownIndentedCodeLine(lineWithoutEnding) &&
       !continuesParagraph;
+    while (excludedRanges[excludedRangeIndex]?.[1] <= lineStart) {
+      excludedRangeIndex += 1;
+    }
+    const excludedRange = excludedRanges[excludedRangeIndex];
+    const lineIsExcluded = excludedRange?.[0] <= lineStart &&
+      lineStart < excludedRange[1];
+    const referenceDefinitionLineCount = !continuesParagraph &&
+        !indentedCodeLine && !lineIsExcluded
+      ? markdownReferenceDefinitionLineCount(lines, lineIndex)
+      : 0;
+    if (referenceDefinitionLineCount > 0) {
+      appendMarkdownInlineCodeRanges(
+        content,
+        segmentStart,
+        lineStart,
+        inlineCodeRanges,
+        inlineHtmlRanges,
+        excludedRanges,
+        excludedRangeCursor,
+      );
+      const finalDefinitionLine = lines[
+        lineIndex + referenceDefinitionLineCount - 1
+      ];
+      segmentStart = finalDefinitionLine.end;
+      lineIndex += referenceDefinitionLineCount - 1;
+      openParagraph = undefined;
+      continue;
+    }
     const paragraphAfterLine = markdownParagraphAfterLine(
       paragraphLine,
       openParagraph,
@@ -954,7 +996,6 @@ function markdownInlineStructureRanges(content, excludedRanges = []) {
       }
     }
     openParagraph = paragraphAfterLine;
-    lineStart = lineEnd;
   }
   appendMarkdownInlineCodeRanges(
     content,
@@ -983,6 +1024,218 @@ function isMarkdownInlineCodeBarrier(line) {
   const fenceMatch = line.match(MARKDOWN_FENCE_LINE_PATTERN);
   return fenceMatch !== null &&
     hasValidMarkdownBlockquoteSpacing(fenceMatch[1]);
+}
+
+function markdownReferenceDefinitionLineCount(lines, lineIndex) {
+  const firstLine = markdownParagraphLineContext(lines[lineIndex].content);
+  let candidate = firstLine.content;
+  let finalCandidateLine = lineIndex;
+  while (candidate.length <= 2_048) {
+    const parsed = markdownReferenceCandidate(candidate);
+    const continuation = markdownReferenceContinuationLine(
+      lines,
+      finalCandidateLine + 1,
+      firstLine,
+    );
+    if (
+      parsed !== undefined &&
+      (!parsed.acceptsTitleContinuation || continuation === undefined ||
+        !markdownReferenceTitleStarts(continuation))
+    ) return parsed.lineCount;
+    if (continuation === undefined) return parsed?.lineCount ?? 0;
+    candidate += `\n${continuation}`;
+    finalCandidateLine += 1;
+  }
+
+  for (
+    let index = finalCandidateLine + 1;
+    index < lines.length;
+    index += 1
+  ) {
+    const continuation = markdownReferenceContinuationLine(
+      lines,
+      index,
+      firstLine,
+    );
+    if (continuation === undefined) break;
+    candidate += `\n${continuation}`;
+  }
+  return markdownReferenceCandidate(candidate)?.lineCount ?? 0;
+}
+
+function markdownReferenceCandidate(candidate) {
+  const labelEnd = markdownReferenceLabelEnd(candidate);
+  if (labelEnd === undefined) return undefined;
+
+  const beforeDestination = markdownReferenceWhitespaceEnd(candidate, labelEnd);
+  const destinationEnd = markdownReferenceDestinationEnd(
+    candidate,
+    beforeDestination.end,
+  );
+  if (destinationEnd === undefined) return undefined;
+
+  const destinationLineEnd = markdownReferenceLineEnd(
+    candidate,
+    destinationEnd,
+  );
+  const afterDestination = markdownReferenceWhitespaceEnd(
+    candidate,
+    destinationEnd,
+  );
+  if (afterDestination.end === candidate.length) {
+    return {
+      acceptsTitleContinuation: true,
+      lineCount: markdownReferenceLineCount(candidate, destinationLineEnd),
+    };
+  }
+
+  const titleStarts = candidate[afterDestination.end] === '"' ||
+    candidate[afterDestination.end] === "'" ||
+    candidate[afterDestination.end] === "(";
+  if (titleStarts && afterDestination.end > destinationEnd) {
+    const titleEnd = markdownReferenceTitleEnd(
+      candidate,
+      afterDestination.end,
+    );
+    if (titleEnd !== undefined) {
+      const titleLineEnd = markdownReferenceLineEnd(candidate, titleEnd);
+      if (/^[ \t]*$/.test(candidate.slice(titleEnd, titleLineEnd))) {
+        return {
+          acceptsTitleContinuation: false,
+          lineCount: markdownReferenceLineCount(candidate, titleLineEnd),
+        };
+      }
+    }
+  }
+
+  if (afterDestination.crossedLine) {
+    return {
+      acceptsTitleContinuation: false,
+      lineCount: markdownReferenceLineCount(candidate, destinationLineEnd),
+    };
+  }
+  return undefined;
+}
+
+function markdownReferenceTitleStarts(line) {
+  const firstCharacter = line.trimStart()[0];
+  return firstCharacter === '"' || firstCharacter === "'" ||
+    firstCharacter === "(";
+}
+
+function markdownReferenceContinuationLine(lines, lineIndex, firstLine) {
+  const line = lines[lineIndex];
+  if (line === undefined || line.content.trim().length === 0) return undefined;
+  const continuation = markdownParagraphLineContext(line.content);
+  if (
+    continuation.structuralPrefix !== firstLine.structuralPrefix ||
+    continuation.listContinuationIndent !== undefined ||
+    (firstLine.listContinuationIndent !== undefined &&
+      continuation.indentation < firstLine.listContinuationIndent)
+  ) return undefined;
+  return continuation.content;
+}
+
+function markdownReferenceLabelEnd(candidate) {
+  if (candidate[0] !== "[") return undefined;
+
+  let index = 1;
+  let labelLength = 0;
+  let hasNonWhitespace = false;
+  while (index < candidate.length && labelLength <= 999) {
+    const character = candidate[index];
+    if (character === "]") {
+      return labelLength <= 999 && hasNonWhitespace &&
+          candidate[index + 1] === ":"
+        ? index + 2
+        : undefined;
+    }
+    if (character === "[") return undefined;
+    if (character === "\\" && index + 1 < candidate.length) index += 1;
+    if (!/[ \t\n]/.test(candidate[index])) hasNonWhitespace = true;
+    labelLength += 1;
+    index += 1;
+  }
+  return undefined;
+}
+
+function markdownReferenceWhitespaceEnd(candidate, start) {
+  let index = start;
+  while (candidate[index] === " " || candidate[index] === "\t") index += 1;
+  if (candidate[index] !== "\n") {
+    return { crossedLine: false, end: index };
+  }
+  index += 1;
+  while (candidate[index] === " " || candidate[index] === "\t") index += 1;
+  return { crossedLine: true, end: index };
+}
+
+function markdownReferenceDestinationEnd(candidate, start) {
+  if (candidate[start] === "<") {
+    for (let index = start + 1; index < candidate.length; index += 1) {
+      if (candidate[index] === "\\" && index + 1 < candidate.length) {
+        index += 1;
+        continue;
+      }
+      if (candidate[index] === "\n" || candidate[index] === "<") {
+        return undefined;
+      }
+      if (candidate[index] === ">") return index + 1;
+    }
+    return undefined;
+  }
+  if (candidate[start] === undefined || candidate[start] === "<") {
+    return undefined;
+  }
+
+  let parentheses = 0;
+  let index = start;
+  while (index < candidate.length && !/[ \t\n]/.test(candidate[index])) {
+    const character = candidate[index];
+    const characterCode = character.charCodeAt(0);
+    if (characterCode <= 0x1f || characterCode === 0x7f) return undefined;
+    if (character === "\\" && index + 1 < candidate.length) {
+      index += 2;
+      continue;
+    }
+    if (character === "(") parentheses += 1;
+    else if (character === ")") {
+      if (parentheses === 0) return undefined;
+      parentheses -= 1;
+    }
+    index += 1;
+  }
+  return index > start && parentheses === 0 ? index : undefined;
+}
+
+function markdownReferenceTitleEnd(line, start) {
+  const opening = line[start];
+  const closing = opening === "(" ? ")" : opening;
+  if (opening !== '"' && opening !== "'" && opening !== "(") return undefined;
+  for (let index = start + 1; index < line.length; index += 1) {
+    if (line[index] === "\\" && index + 1 < line.length) {
+      index += 1;
+      continue;
+    }
+    if (line[index] === closing) {
+      return index + 1;
+    }
+    if (opening === "(" && line[index] === "(") return undefined;
+  }
+  return undefined;
+}
+
+function markdownReferenceLineEnd(candidate, start) {
+  const lineEnd = candidate.indexOf("\n", start);
+  return lineEnd < 0 ? candidate.length : lineEnd;
+}
+
+function markdownReferenceLineCount(candidate, end) {
+  let lineCount = 1;
+  for (let index = 0; index < end; index += 1) {
+    if (candidate[index] === "\n") lineCount += 1;
+  }
+  return lineCount;
 }
 
 function appendMarkdownInlineCodeRanges(
@@ -1047,13 +1300,10 @@ function appendMarkdownInlineCodeRangesInSegment(
       index += 1;
       continue;
     }
-    if (isEscapedMarkdownToken(content, index)) {
-      index += 1;
-      continue;
-    }
     let runEnd = index + 1;
     while (content[runEnd] === "`") runEnd += 1;
     delimiterRuns.push({
+      escaped: isEscapedMarkdownToken(content, index),
       start: index,
       end: runEnd,
       length: runEnd - index,
@@ -1065,17 +1315,35 @@ function appendMarkdownInlineCodeRangesInSegment(
   const nextIndexByLength = new Map();
   for (let index = delimiterRuns.length - 1; index >= 0; index -= 1) {
     const run = delimiterRuns[index];
-    nextRunWithLength[index] = nextIndexByLength.get(run.length);
+    const openingLength = run.escaped ? run.length - 1 : run.length;
+    if (openingLength > 0) {
+      nextRunWithLength[index] = nextIndexByLength.get(openingLength);
+    }
     nextIndexByLength.set(run.length, index);
   }
 
+  const findHtmlTerminator = createMarkdownInlineTerminatorFinder(content, end);
   let delimiterIndex = 0;
   let cursor = start;
   while (cursor < end) {
     while (delimiterRuns[delimiterIndex]?.end <= cursor) {
       delimiterIndex += 1;
     }
-    const delimiter = delimiterRuns[delimiterIndex];
+    while (
+      delimiterRuns[delimiterIndex]?.escaped &&
+      delimiterRuns[delimiterIndex].length === 1
+    ) {
+      cursor = delimiterRuns[delimiterIndex].end;
+      delimiterIndex += 1;
+    }
+    const delimiterRun = delimiterRuns[delimiterIndex];
+    const delimiter = delimiterRun?.escaped
+      ? {
+        start: delimiterRun.start + 1,
+        end: delimiterRun.end,
+        length: delimiterRun.length - 1,
+      }
+      : delimiterRun;
     const htmlStart = content.indexOf("<", cursor);
     if (
       htmlStart >= 0 && htmlStart < end &&
@@ -1085,7 +1353,12 @@ function appendMarkdownInlineCodeRangesInSegment(
         cursor = htmlStart + 1;
         continue;
       }
-      const htmlEnd = markdownInlineHtmlEnd(content, htmlStart, end);
+      const htmlEnd = markdownInlineHtmlEnd(
+        content,
+        htmlStart,
+        end,
+        findHtmlTerminator,
+      );
       cursor = htmlEnd ?? htmlStart + 1;
       if (htmlEnd !== undefined) {
         if (!content.startsWith("<!--", htmlStart)) {
@@ -1115,6 +1388,7 @@ function appendMarkdownInlineCodeRangesInSegment(
 }
 
 function appendMarkdownInlineHtmlRanges(content, start, end, ranges) {
+  const findHtmlTerminator = createMarkdownInlineTerminatorFinder(content, end);
   let cursor = start;
   while (cursor < end) {
     const htmlStart = content.indexOf("<", cursor);
@@ -1123,7 +1397,12 @@ function appendMarkdownInlineHtmlRanges(content, start, end, ranges) {
       cursor = htmlStart + 1;
       continue;
     }
-    const htmlEnd = markdownInlineHtmlEnd(content, htmlStart, end);
+    const htmlEnd = markdownInlineHtmlEnd(
+      content,
+      htmlStart,
+      end,
+      findHtmlTerminator,
+    );
     if (htmlEnd === undefined) {
       cursor = htmlStart + 1;
       continue;
@@ -1135,28 +1414,71 @@ function appendMarkdownInlineHtmlRanges(content, start, end, ranges) {
   }
 }
 
-function markdownInlineHtmlEnd(content, start, end) {
+function createMarkdownInlineTerminatorFinder(content, end) {
+  const nextIndexByTerminator = new Map();
+  return (terminator, start) => {
+    let nextIndex = nextIndexByTerminator.get(terminator);
+    if (nextIndex === -1) return undefined;
+    if (nextIndex === undefined || nextIndex < start) {
+      nextIndex = content.indexOf(terminator, start);
+      if (nextIndex < 0 || nextIndex >= end) {
+        nextIndexByTerminator.set(terminator, -1);
+        return undefined;
+      }
+      nextIndexByTerminator.set(terminator, nextIndex);
+    }
+    return nextIndex;
+  };
+}
+
+function markdownInlineHtmlEnd(content, start, end, findTerminator) {
   if (content.startsWith("<!--", start)) {
     const shortCommentEnd = markdownShortHtmlCommentEnd(content, start);
     if (shortCommentEnd !== undefined && shortCommentEnd <= end) {
       return shortCommentEnd;
     }
-    const closeStart = content.indexOf("-->", start + 4);
-    return closeStart >= 0 && closeStart < end ? closeStart + 3 : undefined;
+    const closeStart = findTerminator("-->", start + 4);
+    return closeStart === undefined ? undefined : closeStart + 3;
   }
   if (content.startsWith("<?", start)) {
-    const closeStart = content.indexOf("?>", start + 2);
-    return closeStart >= 0 && closeStart < end ? closeStart + 2 : undefined;
+    const closeStart = findTerminator("?>", start + 2);
+    return closeStart === undefined ? undefined : closeStart + 2;
   }
   if (content.startsWith("<![CDATA[", start)) {
-    const closeStart = content.indexOf("]]>", start + 9);
-    return closeStart >= 0 && closeStart < end ? closeStart + 3 : undefined;
+    const closeStart = findTerminator("]]>", start + 9);
+    return closeStart === undefined ? undefined : closeStart + 3;
   }
   if (content.startsWith("<!", start) && isAsciiLetter(content[start + 2])) {
-    const closeStart = content.indexOf(">", start + 3);
-    return closeStart >= 0 && closeStart < end ? closeStart + 1 : undefined;
+    const closeStart = findTerminator(">", start + 3);
+    return closeStart === undefined ? undefined : closeStart + 1;
   }
-  return markdownInlineHtmlTagEnd(content, start, end);
+  return markdownAngleAutolinkEnd(content, start, end) ??
+    markdownInlineHtmlTagEnd(content, start, end, findTerminator);
+}
+
+function markdownAngleAutolinkEnd(content, start, end) {
+  let index = start + 1;
+  while (index < end) {
+    const character = content[index];
+    if (character === ">") {
+      const destination = content.slice(start + 1, index);
+      const uri = /^[A-Za-z][A-Za-z0-9.+-]{1,31}:[^\s<>]*$/.test(
+        destination,
+      );
+      const email =
+        /^[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$/
+          .test(
+            destination,
+          );
+      return uri || email ? index + 1 : undefined;
+    }
+    const characterCode = character.charCodeAt(0);
+    if (
+      character === "<" || characterCode <= 0x20 || characterCode === 0x7f
+    ) return undefined;
+    index += 1;
+  }
+  return undefined;
 }
 
 function markdownShortHtmlCommentEnd(content, start) {
@@ -1165,7 +1487,7 @@ function markdownShortHtmlCommentEnd(content, start) {
   return undefined;
 }
 
-function markdownInlineHtmlTagEnd(content, start, end) {
+function markdownInlineHtmlTagEnd(content, start, end, findTerminator) {
   let index = start + 1;
   const closingTag = content[index] === "/";
   if (closingTag) index += 1;
@@ -1199,8 +1521,8 @@ function markdownInlineHtmlTagEnd(content, start, end) {
     while (index < end && isMarkdownWhitespace(content[index])) index += 1;
     const quote = content[index];
     if (quote === '"' || quote === "'") {
-      const quoteEnd = content.indexOf(quote, index + 1);
-      if (quoteEnd < 0 || quoteEnd >= end) return undefined;
+      const quoteEnd = findTerminator(quote, index + 1);
+      if (quoteEnd === undefined) return undefined;
       index = quoteEnd + 1;
       continue;
     }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -10,7 +10,7 @@ const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r\n|[\r\n])Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r\n|[\r\n]|$)/;
 const CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN = new RegExp(
-  `(?=(${markdownAsciiWordPattern("Reviewing")}))`,
+  `(?=(${markdownAsciiCharacterPattern("R")}))`,
   "gi",
 );
 const CODERABBIT_REVIEW_RANGE_BASE_INTRO_PATTERN =
@@ -39,8 +39,9 @@ const MARKDOWN_PARAGRAPH_INTERRUPTING_HTML_SYNTAX_PATTERN =
 const MARKDOWN_FENCE_CONTAINER_CONTINUATION_PATTERN = /^[ \t]*(?:>[ \t]*)*/;
 const MARKDOWN_CHARACTER_REFERENCE_PATTERN =
   /&#(?:[xX][0-9A-Fa-f]{1,6}|[0-9]{1,7});|&[A-Za-z][A-Za-z0-9]{1,31};/g;
-const MARKDOWN_CHARACTER_REFERENCE_AT_END_PATTERN =
-  /(?:&#(?:[xX][0-9A-Fa-f]{1,6}|[0-9]{1,7});|&[A-Za-z][A-Za-z0-9]{1,31};)$/;
+const MARKDOWN_CHARACTER_REFERENCE_AT_START_PATTERN =
+  /^(?:&#(?:[xX][0-9A-Fa-f]{1,6}|[0-9]{1,7});|&[A-Za-z][A-Za-z0-9]{1,31};)/;
+const MARKDOWN_CHARACTER_REFERENCE_MAX_LENGTH = 34;
 const MARKDOWN_NAMED_CHARACTER_REFERENCE_NORMALIZATIONS = new Map([
   ["&Tab;", " "],
   ["&NewLine;", " "],
@@ -409,6 +410,8 @@ function classifyCodeRabbitRangeEvidence(selectedRecentReview, headSha) {
 function codeRabbitRangeEvidenceStatements(content) {
   const markdownStructure = scanMarkdownStructure(content);
   const excludedRanges = markdownStructure.excludedRanges;
+  const continuationBarrierRanges = markdownStructure.continuationBarrierRanges;
+  const inlineLinkRanges = markdownStructure.inlineLinkRanges;
   const paragraphContinuationLineStarts =
     markdownStructure.paragraphContinuationLineStarts;
   const matches = mergeCodeRabbitRangeMatches(
@@ -419,10 +422,49 @@ function codeRabbitRangeEvidenceStatements(content) {
     ),
   );
   assignCodeRabbitMatchLineBounds(content, matches);
-  const statementIndexes = matches.map(codeRabbitStatementIndex);
+  const normalizationContexts = new Map();
+  const reviewingMatches = matches.filter((match) => {
+    const rangeStart = match.tableLocal
+      ? match.tableCell.start
+      : match.lineStart;
+    const rangeEnd = match.tableLocal ? match.tableCell.end : match.lineEnd;
+    const contextKey = `${rangeStart}:${rangeEnd}`;
+    let normalizationContext = normalizationContexts.get(contextKey);
+    if (normalizationContext === undefined) {
+      normalizationContext = markdownInlineNormalizationContext(
+        content,
+        rangeStart,
+        rangeEnd,
+      );
+      normalizationContexts.set(contextKey, normalizationContext);
+    }
+    const phraseEnd = markdownVisibleAsciiWordEnd(
+      content,
+      match.index,
+      rangeEnd,
+      "Reviewing",
+      normalizationContext,
+    );
+    if (
+      phraseEnd === undefined ||
+      markdownRangesIntersect(
+        continuationBarrierRanges,
+        match.index,
+        phraseEnd,
+      ) ||
+      codeRabbitPreviousVisibleCharacterIsWord(
+        match.index,
+        normalizationContext,
+      )
+    ) return false;
+    match.statementPhraseEnd = phraseEnd;
+    return true;
+  });
+  const statementIndexes = reviewingMatches.map(codeRabbitStatementIndex);
   const statements = [];
   let excludedRangeIndex = 0;
-  for (const [matchIndex, match] of matches.entries()) {
+  let continuationBarrierRangeIndex = 0;
+  for (const [matchIndex, match] of reviewingMatches.entries()) {
     const statementIndex = statementIndexes[matchIndex];
     while (
       excludedRangeIndex < excludedRanges.length &&
@@ -434,11 +476,19 @@ function codeRabbitRangeEvidenceStatements(content) {
       excludedRanges[excludedRangeIndex][0] <= statementIndex &&
       statementIndex < excludedRanges[excludedRangeIndex][1];
     if (insideExcludedRange) continue;
+    while (
+      continuationBarrierRangeIndex < continuationBarrierRanges.length &&
+      continuationBarrierRanges[continuationBarrierRangeIndex][1] <=
+        statementIndex
+    ) {
+      continuationBarrierRangeIndex += 1;
+    }
     const nextStatementIndex = statementIndexes[matchIndex + 1] ??
       content.length;
     const continuationEnd = Math.min(
       nextStatementIndex,
-      excludedRanges[excludedRangeIndex]?.[0] ?? content.length,
+      continuationBarrierRanges[continuationBarrierRangeIndex]?.[0] ??
+        content.length,
     );
     const statement = parseCodeRabbitRangeStatement(
       content,
@@ -446,6 +496,7 @@ function codeRabbitRangeEvidenceStatements(content) {
       continuationEnd,
       nextStatementIndex,
       paragraphContinuationLineStarts,
+      inlineLinkRanges,
     );
     if (statement) {
       statement.insideTableCell = match.tableCell !== undefined;
@@ -599,6 +650,7 @@ function visibleMarkdownMatches(content, patterns, excludedRanges) {
 
 function scanMarkdownStructure(content) {
   const ranges = [];
+  const paragraphInterruptingHtmlRanges = [];
   const reviewMarkers = [];
   const paragraphContinuationLineStarts = new Set();
   const {
@@ -637,6 +689,9 @@ function scanMarkdownStructure(content) {
     const lineEnd = lineStart + line.length;
     const lineWithoutEnding = line.replace(/(?:\r\n|[\r\n])$/, "");
     const paragraphLine = markdownParagraphLineContext(lineWithoutEnding);
+    if (isMarkdownParagraphInterruptingHtmlLine(paragraphLine.content)) {
+      paragraphInterruptingHtmlRanges.push([lineStart, lineEnd]);
+    }
     const continuesParagraph = markdownLineContinuesParagraph(
       paragraphLine,
       openParagraph,
@@ -827,6 +882,12 @@ function scanMarkdownStructure(content) {
     ranges.push([openFence.start, content.length]);
   }
   const blockRanges = mergeMarkdownRanges(ranges, []);
+  const continuationBlockRanges = mergeMarkdownRanges(
+    ranges.filter((range) =>
+      !markdownRangeStartsAsInlineHtmlComment(content, range)
+    ),
+    [],
+  );
   const refinedInlineRanges = blockRanges.length === 0
     ? {
       inlineCodeRanges,
@@ -843,7 +904,18 @@ function scanMarkdownStructure(content) {
     ),
     refinedInlineRanges.referenceDefinitionRanges,
   );
+  const continuationBarrierRanges = mergeMarkdownRanges(
+    mergeMarkdownRanges(
+      continuationBlockRanges,
+      paragraphInterruptingHtmlRanges,
+    ),
+    mergeMarkdownRanges(
+      refinedInlineRanges.inlineCodeRanges,
+      refinedInlineRanges.referenceDefinitionRanges,
+    ),
+  );
   return {
+    continuationBarrierRanges,
     excludedRanges: mergeMarkdownRanges(
       blockRanges,
       mergeMarkdownRanges(
@@ -851,10 +923,35 @@ function scanMarkdownStructure(content) {
         refinedInlineRanges.inlineHtmlRanges,
       ),
     ),
+    inlineLinkRanges: refinedInlineRanges.inlineLinkRanges,
     reviewMarkers,
     paragraphContinuationLineStarts,
     tableCellRanges: refinedInlineRanges.tableCellRanges,
   };
+}
+
+function markdownRangeStartsAsInlineHtmlComment(content, range) {
+  const start = range[0];
+  if (!content.startsWith("<!--", start)) return false;
+  if (/[\r\n]/.test(content.slice(start, range[1]))) return false;
+  let lineStart = start;
+  while (
+    lineStart > 0 && content[lineStart - 1] !== "\n" &&
+    content[lineStart - 1] !== "\r"
+  ) {
+    lineStart -= 1;
+  }
+  let lineEnd = start;
+  while (
+    lineEnd < content.length && content[lineEnd] !== "\n" &&
+    content[lineEnd] !== "\r"
+  ) {
+    lineEnd += 1;
+  }
+  return markdownHtmlCommentBlockContainer(
+    content.slice(lineStart, lineEnd),
+    start - lineStart,
+  ) === undefined;
 }
 
 function mergeMarkdownRanges(left, right) {
@@ -2466,22 +2563,20 @@ function isEscapedMarkdownToken(content, tokenStart) {
   return (tokenStart - slashStart) % 2 === 1;
 }
 
-function markdownAsciiWordPattern(word) {
-  return Array.from(word, (character) => {
-    const codes = new Set([
-      character.toLowerCase().charCodeAt(0),
-      character.toUpperCase().charCodeAt(0),
-    ]);
-    const references = [...codes].flatMap((code) => {
-      const decimal = String(code);
-      const hexadecimal = code.toString(16);
-      return [
-        `&#0{0,${7 - decimal.length}}${decimal};`,
-        `&#[xX]0{0,${6 - hexadecimal.length}}${hexadecimal};`,
-      ];
-    });
-    return `(?:${character}|${references.join("|")})`;
-  }).join("");
+function markdownAsciiCharacterPattern(character) {
+  const codes = new Set([
+    character.toLowerCase().charCodeAt(0),
+    character.toUpperCase().charCodeAt(0),
+  ]);
+  const references = [...codes].flatMap((code) => {
+    const decimal = String(code);
+    const hexadecimal = code.toString(16);
+    return [
+      `&#0{0,${7 - decimal.length}}${decimal};`,
+      `&#[xX]0{0,${6 - hexadecimal.length}}${hexadecimal};`,
+    ];
+  });
+  return `(?:${character}|${references.join("|")})`;
 }
 
 function decodeMarkdownCharacterReferences(value) {
@@ -2507,15 +2602,240 @@ function decodeMarkdownCharacterReferences(value) {
   });
 }
 
-function codeRabbitPreviousVisibleCharacterIsWord(content, index) {
-  if (index === 0) return false;
-  const prefix = content.slice(Math.max(0, index - 40), index);
-  const reference = prefix.match(
-    MARKDOWN_CHARACTER_REFERENCE_AT_END_PATTERN,
-  )?.[0];
-  const previous = reference === undefined
-    ? content[index - 1]
-    : decodeMarkdownCharacterReferences(reference).at(-1);
+function markdownCharacterReferenceAt(content, index, end) {
+  return content.slice(
+    index,
+    Math.min(end, index + MARKDOWN_CHARACTER_REFERENCE_MAX_LENGTH),
+  ).match(MARKDOWN_CHARACTER_REFERENCE_AT_START_PATTERN)?.[0];
+}
+
+function markdownInlineDecorationEnd(
+  content,
+  index,
+  end,
+  normalizationContext,
+) {
+  if (isEscapedMarkdownToken(content, index)) return undefined;
+  if (content[index] === "<") {
+    return markdownInlineHtmlEnd(
+      content,
+      index,
+      end,
+      normalizationContext.findHtmlTerminator,
+    );
+  }
+  if (content[index] === "]" && content[index + 1] === "(") {
+    return normalizationContext.findInlineLinkTailEnd(index + 2);
+  }
+  if (!"*_~[]`".includes(content[index])) return undefined;
+  let runEnd = index + 1;
+  while (runEnd < end && content[runEnd] === content[index]) runEnd += 1;
+  return runEnd;
+}
+
+function markdownInlineNormalizationContext(content, start, end) {
+  let inlineLinkTailEndFinder;
+  let previousVisibleCharacters;
+  const context = {
+    findHtmlTerminator: createMarkdownInlineTerminatorFinder(content, end),
+    findInlineLinkTailEnd: (tailStart) => {
+      inlineLinkTailEndFinder ??= createMarkdownInlineLinkTailEndFinder(
+        content,
+        start,
+        end,
+      );
+      return inlineLinkTailEndFinder(tailStart);
+    },
+    previousVisibleCharacter: (index) => {
+      previousVisibleCharacters ??= markdownVisiblePreviousCharacters(
+        content,
+        start,
+        end,
+        context,
+      );
+      return previousVisibleCharacters[index - start];
+    },
+  };
+  return context;
+}
+
+function markdownVisiblePreviousCharacters(content, start, end, context) {
+  const previousCharacters = new Array(end - start + 1);
+  let previousCharacter;
+  for (let cursor = start; cursor < end;) {
+    const offset = cursor - start;
+    previousCharacters[offset] = previousCharacter;
+    const reference = markdownCharacterReferenceAt(content, cursor, end);
+    if (reference !== undefined) {
+      for (let index = 1; index < reference.length; index += 1) {
+        previousCharacters[offset + index] = previousCharacter;
+      }
+      const decoded = decodeMarkdownCharacterReferences(reference);
+      if (decoded.length > 0) previousCharacter = decoded.at(-1);
+      cursor += reference.length;
+      continue;
+    }
+    const decorationEnd = markdownInlineDecorationEnd(
+      content,
+      cursor,
+      end,
+      context,
+    );
+    if (decorationEnd !== undefined) {
+      for (let index = cursor + 1; index < decorationEnd; index += 1) {
+        previousCharacters[index - start] = previousCharacter;
+      }
+      cursor = decorationEnd;
+      continue;
+    }
+    previousCharacter = content[cursor];
+    cursor += 1;
+  }
+  previousCharacters[end - start] = previousCharacter;
+  return previousCharacters;
+}
+
+function markdownVisibleAsciiWordEnd(
+  content,
+  start,
+  end,
+  word,
+  normalizationContext,
+) {
+  let cursor = start;
+  for (const expectedCharacter of word.toLowerCase()) {
+    let matched = false;
+    while (cursor < end) {
+      const reference = markdownCharacterReferenceAt(content, cursor, end);
+      if (
+        reference !== undefined &&
+        decodeMarkdownCharacterReferences(reference).toLowerCase() ===
+          expectedCharacter
+      ) {
+        cursor += reference.length;
+        matched = true;
+        break;
+      }
+      if (content[cursor].toLowerCase() === expectedCharacter) {
+        cursor += 1;
+        matched = true;
+        break;
+      }
+      const decorationEnd = markdownInlineDecorationEnd(
+        content,
+        cursor,
+        end,
+        normalizationContext,
+      );
+      if (decorationEnd === undefined) return undefined;
+      cursor = decorationEnd;
+    }
+    if (!matched) return undefined;
+  }
+  return cursor;
+}
+
+function normalizeMarkdownInlineRangeText(value) {
+  const normalizationContext = markdownInlineNormalizationContext(
+    value,
+    0,
+    value.length,
+  );
+  return normalizeMarkdownInlineContentRange(
+    value,
+    0,
+    value.length,
+    normalizationContext,
+    [],
+  );
+}
+
+function firstMarkdownRangeEndingAfter(ranges, index) {
+  let lower = 0;
+  let upper = ranges.length;
+  while (lower < upper) {
+    const middle = Math.floor((lower + upper) / 2);
+    if (ranges[middle][1] <= index) lower = middle + 1;
+    else upper = middle;
+  }
+  return lower;
+}
+
+function markdownRangesIntersect(ranges, start, end) {
+  const range = ranges[firstMarkdownRangeEndingAfter(ranges, start)];
+  return range !== undefined && range[0] < end;
+}
+
+function normalizeMarkdownInlineContentRange(
+  content,
+  start,
+  end,
+  normalizationContext,
+  hiddenRanges,
+) {
+  let normalized = "";
+  let hiddenRangeIndex = firstMarkdownRangeEndingAfter(hiddenRanges, start);
+  for (let cursor = start; cursor < end;) {
+    while (hiddenRanges[hiddenRangeIndex]?.[1] <= cursor) {
+      hiddenRangeIndex += 1;
+    }
+    const hiddenRange = hiddenRanges[hiddenRangeIndex];
+    if (
+      hiddenRange !== undefined && hiddenRange[0] <= cursor &&
+      cursor < hiddenRange[1]
+    ) {
+      cursor = hiddenRange[1];
+      hiddenRangeIndex += 1;
+      continue;
+    }
+    const reference = markdownCharacterReferenceAt(content, cursor, end);
+    if (reference !== undefined) {
+      normalized += decodeMarkdownCharacterReferences(reference);
+      cursor += reference.length;
+      continue;
+    }
+    const decorationEnd = markdownInlineDecorationEnd(
+      content,
+      cursor,
+      end,
+      normalizationContext,
+    );
+    if (decorationEnd !== undefined) {
+      cursor = decorationEnd;
+      continue;
+    }
+    normalized += content[cursor];
+    cursor += 1;
+  }
+  return normalized;
+}
+
+function normalizeMarkdownRangeLineContent(
+  content,
+  start,
+  end,
+  normalizationContext,
+  hiddenRanges,
+) {
+  const normalized = normalizeMarkdownInlineContentRange(
+    content,
+    start,
+    end,
+    normalizationContext,
+    hiddenRanges,
+  );
+  let trailingBackslashes = 0;
+  while (
+    trailingBackslashes < normalized.length &&
+    normalized[normalized.length - trailingBackslashes - 1] === "\\"
+  ) {
+    trailingBackslashes += 1;
+  }
+  return trailingBackslashes % 2 === 1 ? normalized.slice(0, -1) : normalized;
+}
+
+function codeRabbitPreviousVisibleCharacterIsWord(index, normalizationContext) {
+  const previous = normalizationContext.previousVisibleCharacter(index);
   return previous !== undefined && /[A-Za-z0-9]/.test(previous);
 }
 
@@ -2529,28 +2849,48 @@ function parseCodeRabbitRangeStatement(
   continuationEnd,
   nextStatementIndex,
   paragraphContinuationLineStarts,
+  inlineLinkRanges,
 ) {
-  const rawStatementPhrase = match[1];
+  const rawStatementPhrase = content.slice(
+    match.index,
+    match.statementPhraseEnd,
+  );
   if (
-    codeRabbitPreviousVisibleCharacterIsWord(content, match.index) ||
-    decodeMarkdownCharacterReferences(rawStatementPhrase).toLowerCase() !==
+    normalizeMarkdownInlineRangeText(rawStatementPhrase).toLowerCase() !==
       "reviewing"
   ) return undefined;
-  const statementEnd = match.index + rawStatementPhrase.length;
+  const statementEnd = match.statementPhraseEnd;
   const statementDecoration = match.index === match.lineStart ? "" : " ";
   const statementStart = statementDecoration + rawStatementPhrase;
   const firstLineEnd = Math.min(
     match.tableLocal ? match.tableCell.end : match.lineEnd,
     nextStatementIndex,
+    continuationEnd,
+  );
+  const normalizationContext = markdownInlineNormalizationContext(
+    content,
+    match.tableLocal ? match.tableCell.start : match.lineStart,
+    continuationEnd,
   );
   let rawFirstLineTail = content.slice(statementEnd, firstLineEnd);
+  let firstLineTail = normalizeMarkdownRangeLineContent(
+    content,
+    statementEnd,
+    firstLineEnd,
+    normalizationContext,
+    inlineLinkRanges,
+  );
   if (match.tableLocal && nextStatementIndex > match.tableCell.end) {
-    rawFirstLineTail += content.slice(
+    const rowTailEnd = Math.min(match.tableCell.rowEnd, nextStatementIndex);
+    rawFirstLineTail += content.slice(match.tableCell.end, rowTailEnd);
+    firstLineTail += normalizeMarkdownRangeLineContent(
+      content,
       match.tableCell.end,
-      Math.min(match.tableCell.rowEnd, nextStatementIndex),
+      rowTailEnd,
+      normalizationContext,
+      inlineLinkRanges,
     );
   }
-  const firstLineTail = decodeMarkdownCharacterReferences(rawFirstLineTail);
   const statementPrefix = codeRabbitRangeContainerSignature(
     match.tableCell === undefined ? match.linePrefix : "",
   );
@@ -2593,18 +2933,35 @@ function parseCodeRabbitRangeStatement(
     const rawContinuationContent = nextLine.content.slice(
       continuationPrefix.length,
     );
-    const continuationContent = decodeMarkdownCharacterReferences(
-      rawContinuationContent,
+    const continuationContentStart = nextLine.lineStart +
+      continuationPrefix.length;
+    const continuationContent = normalizeMarkdownRangeLineContent(
+      content,
+      continuationContentStart,
+      nextLine.lineEnd,
+      normalizationContext,
+      inlineLinkRanges,
     );
+    const hiddenLinkContinuation = continuationContent.trim().length === 0 &&
+      markdownRangesIntersect(
+        inlineLinkRanges,
+        continuationContentStart,
+        nextLine.lineEnd,
+      );
     if (
-      rawContinuationContent.trim().length === 0 ||
-      rawContinuationContent.trimStart().startsWith("<!--") ||
-      (codeRabbitRangeContainerSignature(continuationPrefix) !==
-          statementPrefix &&
-        (match.tableCell !== undefined ||
-          !paragraphContinuationLineStarts.has(nextLine.lineStart)))
+      !hiddenLinkContinuation &&
+      (rawContinuationContent.trim().length === 0 ||
+        rawContinuationContent.trimStart().startsWith("<!--") ||
+        (codeRabbitRangeContainerSignature(continuationPrefix) !==
+            statementPrefix &&
+          (match.tableCell !== undefined ||
+            !paragraphContinuationLineStarts.has(nextLine.lineStart))))
     ) return undefined;
     statementParts.push(nextLine.separator, nextLine.content);
+    if (hiddenLinkContinuation) {
+      lineEnd = nextLine.lineEnd;
+      continue;
+    }
 
     const previousLine = baseLines.at(-1);
     const trailingAnd = previousLine?.match(/(^|[ \t])and[ \t]*$/i);
@@ -2702,13 +3059,14 @@ function codeRabbitNextLine(content, lineEnd, continuationEnd) {
     : lineFeed < 0
     ? carriageReturn
     : Math.min(carriageReturn, lineFeed);
+  const boundedLineEnd = Math.min(
+    nextLineEnd < 0 ? content.length : nextLineEnd,
+    continuationEnd,
+  );
   return {
-    content: content.slice(
-      contentStart,
-      nextLineEnd < 0 ? content.length : nextLineEnd,
-    ),
+    content: content.slice(contentStart, boundedLineEnd),
     lineStart: contentStart,
-    lineEnd: nextLineEnd < 0 ? content.length : nextLineEnd,
+    lineEnd: boundedLineEnd,
     separator,
   };
 }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -432,17 +432,20 @@ function visibleMarkdownMatches(content, patterns, excludedRanges) {
 function scanMarkdownStructure(content) {
   const ranges = [];
   const reviewMarkers = [];
-  const { inlineCodeRanges, inlineHtmlRanges } = markdownInlineStructureRanges(
-    content,
+  const { inlineCodeRanges, inlineHtmlRanges, inlineLinkRanges } =
+    markdownInlineStructureRanges(content);
+  const inlineExcludedRanges = mergeMarkdownRanges(
+    inlineCodeRanges,
+    inlineLinkRanges,
   );
   let inlineCodeRangeIndex = 0;
   const isInsideInlineCode = (index) => {
     while (
-      inlineCodeRanges[inlineCodeRangeIndex]?.[1] <= index
+      inlineExcludedRanges[inlineCodeRangeIndex]?.[1] <= index
     ) {
       inlineCodeRangeIndex += 1;
     }
-    const range = inlineCodeRanges[inlineCodeRangeIndex];
+    const range = inlineExcludedRanges[inlineCodeRangeIndex];
     return range?.[0] <= index && index < range[1];
   };
   let openFence;
@@ -626,13 +629,17 @@ function scanMarkdownStructure(content) {
   }
   const blockRanges = mergeMarkdownRanges(ranges, []);
   const refinedInlineRanges = blockRanges.length === 0
-    ? { inlineCodeRanges, inlineHtmlRanges }
+    ? { inlineCodeRanges, inlineHtmlRanges, inlineLinkRanges }
     : markdownInlineStructureRanges(content, blockRanges);
+  const refinedInlineExcludedRanges = mergeMarkdownRanges(
+    refinedInlineRanges.inlineCodeRanges,
+    refinedInlineRanges.inlineLinkRanges,
+  );
   return {
     excludedRanges: mergeMarkdownRanges(
       blockRanges,
       mergeMarkdownRanges(
-        refinedInlineRanges.inlineCodeRanges,
+        refinedInlineExcludedRanges,
         refinedInlineRanges.inlineHtmlRanges,
       ),
     ),
@@ -907,6 +914,7 @@ function markdownHtmlCommentBlockContainer(line, commentStart) {
 function markdownInlineStructureRanges(content, excludedRanges = []) {
   const inlineCodeRanges = [];
   const inlineHtmlRanges = [];
+  const inlineLinkRanges = [];
   const excludedRangeCursor = { index: 0 };
   const lines = [];
   let nextLineStart = 0;
@@ -954,6 +962,7 @@ function markdownInlineStructureRanges(content, excludedRanges = []) {
         lineStart,
         inlineCodeRanges,
         inlineHtmlRanges,
+        inlineLinkRanges,
         excludedRanges,
         excludedRangeCursor,
       );
@@ -980,6 +989,7 @@ function markdownInlineStructureRanges(content, excludedRanges = []) {
         lineStart,
         inlineCodeRanges,
         inlineHtmlRanges,
+        inlineLinkRanges,
         excludedRanges,
         excludedRangeCursor,
       );
@@ -1003,10 +1013,11 @@ function markdownInlineStructureRanges(content, excludedRanges = []) {
     content.length,
     inlineCodeRanges,
     inlineHtmlRanges,
+    inlineLinkRanges,
     excludedRanges,
     excludedRangeCursor,
   );
-  return { inlineCodeRanges, inlineHtmlRanges };
+  return { inlineCodeRanges, inlineHtmlRanges, inlineLinkRanges };
 }
 
 function isMarkdownInlineCodeBarrier(line) {
@@ -1244,6 +1255,7 @@ function appendMarkdownInlineCodeRanges(
   end,
   inlineCodeRanges,
   inlineHtmlRanges,
+  inlineLinkRanges,
   excludedRanges,
   excludedRangeCursor,
 ) {
@@ -1262,6 +1274,7 @@ function appendMarkdownInlineCodeRanges(
         Math.min(excludedStart, end),
         inlineCodeRanges,
         inlineHtmlRanges,
+        inlineLinkRanges,
       );
     }
     segmentStart = Math.max(segmentStart, excludedEnd);
@@ -1283,6 +1296,7 @@ function appendMarkdownInlineCodeRanges(
       end,
       inlineCodeRanges,
       inlineHtmlRanges,
+      inlineLinkRanges,
     );
   }
 }
@@ -1293,6 +1307,7 @@ function appendMarkdownInlineCodeRangesInSegment(
   end,
   inlineCodeRanges,
   inlineHtmlRanges,
+  inlineLinkRanges,
 ) {
   const delimiterRuns = [];
   for (let index = start; index < end;) {
@@ -1323,9 +1338,34 @@ function appendMarkdownInlineCodeRangesInSegment(
   }
 
   const findHtmlTerminator = createMarkdownInlineTerminatorFinder(content, end);
+  let inlineLinkTailEndFinder;
+  const findInlineLinkTailEnd = (tailStart) => {
+    inlineLinkTailEndFinder ??= createMarkdownInlineLinkTailEndFinder(
+      content,
+      start,
+      end,
+    );
+    return inlineLinkTailEndFinder(tailStart);
+  };
+  const segmentInlineLinkRanges = markdownInlineLinkRanges(
+    content,
+    start,
+    end,
+    delimiterRuns,
+    nextRunWithLength,
+    findHtmlTerminator,
+    findInlineLinkTailEnd,
+  );
+  inlineLinkRanges.push(...segmentInlineLinkRanges);
+  let inlineLinkRangeIndex = 0;
   let delimiterIndex = 0;
   let cursor = start;
   while (cursor < end) {
+    while (
+      segmentInlineLinkRanges[inlineLinkRangeIndex]?.[1] <= cursor
+    ) {
+      inlineLinkRangeIndex += 1;
+    }
     while (delimiterRuns[delimiterIndex]?.end <= cursor) {
       delimiterIndex += 1;
     }
@@ -1345,6 +1385,19 @@ function appendMarkdownInlineCodeRangesInSegment(
       }
       : delimiterRun;
     const htmlStart = content.indexOf("<", cursor);
+    const inlineLinkRange = segmentInlineLinkRanges[inlineLinkRangeIndex];
+    if (
+      inlineLinkRange !== undefined &&
+      (delimiter === undefined || inlineLinkRange[0] <= delimiter.start) &&
+      (htmlStart < 0 || htmlStart >= end || inlineLinkRange[0] < htmlStart)
+    ) {
+      cursor = inlineLinkRange[1];
+      inlineLinkRangeIndex += 1;
+      while (delimiterRuns[delimiterIndex]?.start < cursor) {
+        delimiterIndex += 1;
+      }
+      continue;
+    }
     if (
       htmlStart >= 0 && htmlStart < end &&
       (delimiter === undefined || htmlStart < delimiter.start)
@@ -1385,6 +1438,269 @@ function appendMarkdownInlineCodeRangesInSegment(
     cursor = delimiterRuns[closingIndex].end;
     delimiterIndex = closingIndex + 1;
   }
+}
+
+function markdownInlineLinkRanges(
+  content,
+  start,
+  end,
+  delimiterRuns,
+  nextRunWithLength,
+  findHtmlTerminator,
+  findInlineLinkTailEnd,
+) {
+  const ranges = [];
+  const labelOpeners = [];
+  let delimiterIndex = 0;
+  for (let cursor = start; cursor < end;) {
+    while (delimiterRuns[delimiterIndex]?.end <= cursor) {
+      delimiterIndex += 1;
+    }
+    const delimiterRun = delimiterRuns[delimiterIndex];
+    const delimiter = delimiterRun?.escaped
+      ? {
+        start: delimiterRun.start + 1,
+        end: delimiterRun.end,
+        length: delimiterRun.length - 1,
+      }
+      : delimiterRun;
+    if (delimiter?.length > 0 && delimiter.start === cursor) {
+      const closingIndex = nextRunWithLength[delimiterIndex];
+      if (closingIndex !== undefined) {
+        cursor = delimiterRuns[closingIndex].end;
+        delimiterIndex = closingIndex + 1;
+      } else {
+        cursor = delimiter.end;
+        delimiterIndex += 1;
+      }
+      continue;
+    }
+
+    const character = content[cursor];
+    if (character === "\\" && cursor + 1 < end) {
+      cursor += 2;
+      continue;
+    }
+    if (character === "<") {
+      const htmlEnd = markdownInlineHtmlEnd(
+        content,
+        cursor,
+        end,
+        findHtmlTerminator,
+      );
+      if (htmlEnd !== undefined) {
+        cursor = htmlEnd;
+        continue;
+      }
+    }
+    if (character === "[") {
+      labelOpeners.push({
+        image: cursor > start && content[cursor - 1] === "!" &&
+          !isEscapedMarkdownToken(content, cursor - 1),
+        start: cursor,
+      });
+      cursor += 1;
+      continue;
+    }
+    if (character !== "]" || labelOpeners.length === 0) {
+      cursor += 1;
+      continue;
+    }
+
+    const labelOpener = labelOpeners.pop();
+    const tailStart = cursor + 2;
+    if (
+      content[cursor + 1] !== "(" ||
+      cursor - labelOpener.start > 1_000
+    ) {
+      cursor += 1;
+      continue;
+    }
+    const tailEnd = findInlineLinkTailEnd(tailStart);
+    if (tailEnd === undefined) {
+      cursor += 1;
+      continue;
+    }
+
+    ranges.push([tailStart, tailEnd]);
+    if (!labelOpener.image) labelOpeners.length = 0;
+    cursor = tailEnd;
+  }
+  return ranges;
+}
+
+function createMarkdownInlineLinkTailEndFinder(content, start, end) {
+  const length = end - start;
+  const escaped = new Uint8Array(length);
+  let precedingBackslashes = 0;
+  for (let offset = 0; offset < length; offset += 1) {
+    escaped[offset] = precedingBackslashes % 2;
+    if (content[start + offset] === "\\") precedingBackslashes += 1;
+    else precedingBackslashes = 0;
+  }
+
+  const nextUnescapedByCharacter = new Map();
+  for (const character of ["<", ">", '"', "'", "(", ")", "\r", "\n"]) {
+    const nextIndexes = new Int32Array(length + 1);
+    nextIndexes.fill(-1);
+    let nextIndex = -1;
+    for (let offset = length - 1; offset >= 0; offset -= 1) {
+      if (
+        content[start + offset] === character &&
+        (character === "\r" || character === "\n" || escaped[offset] === 0)
+      ) nextIndex = start + offset;
+      nextIndexes[offset] = nextIndex;
+    }
+    nextUnescapedByCharacter.set(character, nextIndexes);
+  }
+  const nextUnescaped = (character, index) => {
+    if (index < start || index >= end) return undefined;
+    const nextIndex = nextUnescapedByCharacter.get(character)[index - start];
+    return nextIndex < 0 ? undefined : nextIndex;
+  };
+
+  const spaceTabEnd = new Int32Array(length + 1);
+  spaceTabEnd[length] = end;
+  for (let offset = length - 1; offset >= 0; offset -= 1) {
+    const index = start + offset;
+    spaceTabEnd[offset] = content[index] === " " || content[index] === "\t"
+      ? spaceTabEnd[offset + 1]
+      : index;
+  }
+  const lineEndingEnd = (index) => {
+    if (content[index] === "\n") return index + 1;
+    if (content[index] !== "\r") return undefined;
+    return content[index + 1] === "\n" ? index + 2 : index + 1;
+  };
+  const whitespaceEnd = (index) => {
+    const spacesEnd = spaceTabEnd[index - start];
+    const lineEnd = lineEndingEnd(spacesEnd);
+    const finalEnd = lineEnd === undefined
+      ? spacesEnd
+      : spaceTabEnd[lineEnd - start];
+    return { end: finalEnd, hasWhitespace: finalEnd > index };
+  };
+
+  const nextBlankLine = new Int32Array(length + 1);
+  nextBlankLine.fill(-1);
+  let nextBlankLineIndex = -1;
+  for (let offset = length - 1; offset >= 0; offset -= 1) {
+    const index = start + offset;
+    const firstLineEnd = lineEndingEnd(index);
+    if (firstLineEnd !== undefined) {
+      const secondLineStart = spaceTabEnd[firstLineEnd - start];
+      if (lineEndingEnd(secondLineStart) !== undefined) {
+        nextBlankLineIndex = index;
+      }
+    }
+    nextBlankLine[offset] = nextBlankLineIndex;
+  }
+
+  const bareDestinationEnd = new Int32Array(length + 1);
+  bareDestinationEnd.fill(-1);
+  for (let tokenStart = start; tokenStart < end;) {
+    const firstCode = content.charCodeAt(tokenStart);
+    if (firstCode <= 0x20 || firstCode === 0x7f) {
+      tokenStart += 1;
+      continue;
+    }
+    let tokenEnd = tokenStart + 1;
+    while (tokenEnd < end) {
+      const characterCode = content.charCodeAt(tokenEnd);
+      if (characterCode <= 0x20 || characterCode === 0x7f) break;
+      tokenEnd += 1;
+    }
+
+    const tokenLength = tokenEnd - tokenStart;
+    const balances = new Int32Array(tokenLength + 1);
+    for (let offset = 0; offset < tokenLength; offset += 1) {
+      const index = tokenStart + offset;
+      let change = 0;
+      if (escaped[index - start] === 0) {
+        if (content[index] === "(") change = 1;
+        else if (content[index] === ")") change = -1;
+      }
+      balances[offset + 1] = balances[offset] + change;
+    }
+
+    const nextSmallerBoundary = new Int32Array(tokenLength + 1);
+    nextSmallerBoundary.fill(-1);
+    const boundaryStack = [];
+    for (let offset = tokenLength; offset >= 0; offset -= 1) {
+      while (
+        boundaryStack.length > 0 &&
+        balances[boundaryStack.at(-1)] >= balances[offset]
+      ) boundaryStack.pop();
+      if (boundaryStack.length > 0) {
+        nextSmallerBoundary[offset] = boundaryStack.at(-1);
+      }
+      boundaryStack.push(offset);
+    }
+    for (let offset = 0; offset < tokenLength; offset += 1) {
+      const smallerBoundary = nextSmallerBoundary[offset];
+      if (smallerBoundary >= 0) {
+        bareDestinationEnd[tokenStart + offset - start] = tokenStart +
+          smallerBoundary - 1;
+      } else if (balances[tokenLength] === balances[offset]) {
+        bareDestinationEnd[tokenStart + offset - start] = tokenEnd;
+      }
+    }
+    tokenStart = tokenEnd;
+  }
+
+  const destinationEnd = (index) => {
+    if (index < start || index >= end) return undefined;
+    if (content[index] !== "<") {
+      const destination = bareDestinationEnd[index - start];
+      return destination < 0 ? undefined : destination;
+    }
+    const closing = nextUnescaped(">", index + 1);
+    if (closing === undefined) return undefined;
+    const nestedOpening = nextUnescaped("<", index + 1);
+    const carriageReturn = nextUnescaped("\r", index + 1);
+    const lineFeed = nextUnescaped("\n", index + 1);
+    const forbidden = Math.min(
+      nestedOpening ?? Infinity,
+      carriageReturn ?? Infinity,
+      lineFeed ?? Infinity,
+    );
+    return forbidden < closing ? undefined : closing + 1;
+  };
+
+  const titleEnd = (index) => {
+    const opening = content[index];
+    const closingCharacter = opening === "(" ? ")" : opening;
+    if (opening !== '"' && opening !== "'" && opening !== "(") {
+      return undefined;
+    }
+    const closing = nextUnescaped(closingCharacter, index + 1);
+    if (closing === undefined) return undefined;
+    const nestedOpening = opening === "("
+      ? nextUnescaped("(", index + 1)
+      : undefined;
+    if (nestedOpening !== undefined && nestedOpening < closing) {
+      return undefined;
+    }
+    const blankLine = nextBlankLine[index - start];
+    return blankLine >= 0 && blankLine < closing ? undefined : closing + 1;
+  };
+
+  return (tailStart) => {
+    const beforeDestination = whitespaceEnd(tailStart);
+    const parsedDestinationEnd = destinationEnd(beforeDestination.end);
+    if (parsedDestinationEnd === undefined) return undefined;
+
+    const afterDestination = whitespaceEnd(parsedDestinationEnd);
+    if (content[afterDestination.end] === ")") {
+      return afterDestination.end + 1;
+    }
+    if (!afterDestination.hasWhitespace) return undefined;
+
+    const parsedTitleEnd = titleEnd(afterDestination.end);
+    if (parsedTitleEnd === undefined) return undefined;
+    const afterTitle = whitespaceEnd(parsedTitleEnd);
+    return content[afterTitle.end] === ")" ? afterTitle.end + 1 : undefined;
+  };
 }
 
 function appendMarkdownInlineHtmlRanges(content, start, end, ranges) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -405,21 +405,14 @@ function scanMarkdownStructure(content) {
   const ranges = [];
   const reviewMarkers = [];
   const inlineCodeRanges = markdownInlineCodeRanges(content);
-  const possibleInlineCodeRanges = [];
-  appendMarkdownInlineCodeRanges(
-    content,
-    0,
-    content.length,
-    possibleInlineCodeRanges,
-  );
-  let possibleInlineCodeRangeIndex = 0;
-  const isInsidePossibleInlineCode = (index) => {
+  let inlineCodeRangeIndex = 0;
+  const isInsideInlineCode = (index) => {
     while (
-      possibleInlineCodeRanges[possibleInlineCodeRangeIndex]?.[1] <= index
+      inlineCodeRanges[inlineCodeRangeIndex]?.[1] <= index
     ) {
-      possibleInlineCodeRangeIndex += 1;
+      inlineCodeRangeIndex += 1;
     }
-    const range = possibleInlineCodeRanges[possibleInlineCodeRangeIndex];
+    const range = inlineCodeRanges[inlineCodeRangeIndex];
     return range?.[0] <= index && index < range[1];
   };
   let openFence;
@@ -430,6 +423,14 @@ function scanMarkdownStructure(content) {
     if (line.length === 0 && lineStart >= content.length) break;
     const lineEnd = lineStart + line.length;
     const lineWithoutEnding = line.replace(/(?:\r\n|[\r\n])$/, "");
+
+    if (
+      openHtmlComment !== undefined &&
+      openHtmlComment.container === undefined &&
+      isMarkdownInlineCodeBarrier(lineWithoutEnding)
+    ) {
+      openHtmlComment = undefined;
+    }
 
     if (
       openHtmlComment?.container !== undefined &&
@@ -457,7 +458,7 @@ function scanMarkdownStructure(content) {
         relativeCloseStart + 3,
         ranges,
         reviewMarkers,
-        isInsidePossibleInlineCode,
+        isInsideInlineCode,
       );
       lineStart = lineEnd;
       continue;
@@ -509,11 +510,11 @@ function scanMarkdownStructure(content) {
       0,
       ranges,
       reviewMarkers,
-      isInsidePossibleInlineCode,
+      isInsideInlineCode,
     );
     lineStart = lineEnd;
   }
-  if (openHtmlComment !== undefined) {
+  if (openHtmlComment?.container !== undefined) {
     ranges.push([openHtmlComment.start, content.length]);
   } else if (openFence !== undefined) {
     ranges.push([openFence.start, content.length]);
@@ -579,14 +580,14 @@ function scanMarkdownHtmlComments(
   searchStart,
   ranges,
   reviewMarkers,
-  isInsidePossibleInlineCode,
+  isInsideInlineCode,
 ) {
   while (searchStart < line.length) {
     const relativeCommentStart = line.indexOf("<!--", searchStart);
     if (relativeCommentStart < 0) return undefined;
     const commentStart = lineStart + relativeCommentStart;
     if (
-      isInsidePossibleInlineCode(commentStart) ||
+      isInsideInlineCode(commentStart) ||
       isEscapedMarkdownToken(content, commentStart) ||
       isMarkdownIndentedCodeLine(line)
     ) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -7,12 +7,11 @@ const CODERABBIT_RECENT_REVIEW_MARKER = "<!-- recent_review_start -->";
 const CODERABBIT_RECENT_REVIEW_END_MARKER = "<!-- recent_review_end -->";
 const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
   "No actionable comments were generated in the recent review.";
-const CODERABBIT_REVIEW_RANGE_CANDIDATE_PATTERN = /^\s*reviewing\s+files\b/i;
-const CODERABBIT_REVIEW_RANGE_EVIDENCE_PATTERN =
-  /(?:^|\r?\n)\s*(?:[-*+]\s+)?Reviewing\s+(?:files|changed files)\b[^\r\n]*\bbetween\s+[0-9a-f]{40}\s+and(?:[ \t]*\r?\n)?[ \t]*([0-9a-f]{40})(?![0-9a-f])/gi;
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r?\n)Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r?\n|$)/;
-const FULL_COMMIT_TOKEN_PATTERN = /(?:^|[^0-9a-f])([0-9a-f]{40})(?![0-9a-f])/gi;
+const CODERABBIT_REVIEW_RANGE_STATEMENT_PATTERN =
+  /(?:^|\r?\n)\s*(?:[-*+]\s+)?(Reviewing\s+(?:files(?:\s+that\s+changed\s+from\s+the\s+base\s+of\s+the\s+PR)?|changed files(?:\s+from\s+the\s+base\s+of\s+the\s+PR)?)\s+(?:and\s+)?between\s+[0-9a-f]{40}\s+and(?:[ \t]*\r?\n)?[ \t]*[0-9a-f]{40}[^\r\n]*)/gi;
+const FULL_COMMIT_TOKEN_PATTERN = /(^|[^0-9a-f])([0-9a-f]{40})(?![0-9a-f])/gi;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
   /Requested commit:\s*([0-9a-f]{40})/gi;
 const CODERABBIT_SKIPPED_COMMIT_PATTERN =
@@ -212,49 +211,24 @@ async function classifyAutomatedReviewEvent(
       url: typeof comment.html_url === "string" ? comment.html_url : undefined,
     };
   }
-  const rangeCandidates = selectedRecentReview?.content.split(/\r?\n/).filter((
-    line,
-  ) => CODERABBIT_REVIEW_RANGE_CANDIDATE_PATTERN.test(line));
-  const rangeCandidateHasCurrentTip = rangeCandidates?.some((line) =>
-    rangeCandidateReferencesTip(line, headSha)
+  const rangeEvidence = classifyCodeRabbitRangeEvidence(
+    selectedRecentReview,
+    headSha,
   );
-  const rangeEvidenceHasCurrentTip = [
-    ...(selectedRecentReview?.content.matchAll(
-      CODERABBIT_REVIEW_RANGE_EVIDENCE_PATTERN,
-    ) ?? []),
-  ].some((match) => match[1]?.toLowerCase() === headSha.toLowerCase());
-  const reviewedTips = rangeCandidates?.map((line) =>
-    line.match(CODERABBIT_REVIEW_RANGE_PATTERN)?.[2]
-  );
-  const hasCurrentRange = reviewedTips?.some((tip) =>
-    tip?.toLowerCase() === headSha.toLowerCase()
-  );
-  if (
-    selectedRecentReview && !selectedRecentReview.terminated &&
-    (hasCurrentRange || rangeCandidateHasCurrentTip ||
-      rangeEvidenceHasCurrentTip)
-  ) {
+  if (rangeEvidence === "current-invalid") {
     return {
       kind: "failure",
       url: typeof comment.html_url === "string" ? comment.html_url : undefined,
     };
   }
-  if (rangeCandidates?.length !== 1) {
-    return hasCurrentRange || rangeCandidateHasCurrentTip ||
-        rangeEvidenceHasCurrentTip
-      ? {
-        kind: "failure",
-        url: typeof comment.html_url === "string"
-          ? comment.html_url
-          : undefined,
-      }
-      : { kind: "not-head" };
+  if (rangeEvidence !== "current-valid") {
+    return { kind: "not-head" };
   }
-  const reviewedTip = reviewedTips?.[0];
-  if (reviewedTip?.toLowerCase() !== headSha.toLowerCase()) {
-    return rangeCandidateHasCurrentTip || rangeEvidenceHasCurrentTip
-      ? { kind: "failure" }
-      : { kind: "not-head" };
+  if (!selectedRecentReview?.terminated) {
+    return {
+      kind: "failure",
+      url: typeof comment.html_url === "string" ? comment.html_url : undefined,
+    };
   }
   return selectedRecentReview?.content.includes(
       CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER,
@@ -306,14 +280,48 @@ function codeRabbitSelectedRecentReview(body) {
   };
 }
 
-function rangeCandidateReferencesTip(value, headSha) {
-  const tokens = [...value.matchAll(FULL_COMMIT_TOKEN_PATTERN)].map((match) =>
-    match[1]?.toLowerCase()
+function classifyCodeRabbitRangeEvidence(selectedRecentReview, headSha) {
+  if (!selectedRecentReview) return "not-head";
+  const evidenceBlocks = codeRabbitRangeEvidenceStatements(
+    selectedRecentReview.content,
+  ).map((block) => parseCodeRabbitRangeEvidence(block, headSha)).filter((
+    evidence,
+  ) => evidence !== undefined);
+  const currentEvidence = evidenceBlocks.filter((evidence) =>
+    evidence.tipIsHead || evidence.extraHasHead
   );
+  if (currentEvidence.length === 0) return "not-head";
+  if (
+    currentEvidence.length === 1 && evidenceBlocks.length === 1 &&
+    currentEvidence[0].isExactProduction && !currentEvidence[0].extraHasHead
+  ) {
+    return "current-valid";
+  }
+  return "current-invalid";
+}
+
+function codeRabbitRangeEvidenceStatements(content) {
+  return [...content.matchAll(CODERABBIT_REVIEW_RANGE_STATEMENT_PATTERN)].map((
+    match,
+  ) => match[0].trim());
+}
+
+function parseCodeRabbitRangeEvidence(block, headSha) {
+  const betweenIndex = block.search(/\bbetween\b/i);
+  if (betweenIndex < 0) return undefined;
+  const tokens = [
+    ...block.slice(betweenIndex).matchAll(FULL_COMMIT_TOKEN_PATTERN),
+  ].map((match) => match[2].toLowerCase());
+  if (tokens.length < 2) return undefined;
   const normalizedHeadSha = headSha.toLowerCase();
-  if (tokens.length === 1) return tokens[0] === normalizedHeadSha;
-  if (tokens[1] === normalizedHeadSha) return true;
-  return tokens.slice(2).includes(normalizedHeadSha);
+  const exactMatch = block.match(CODERABBIT_REVIEW_RANGE_PATTERN);
+  return {
+    tipIsHead: tokens[1] === normalizedHeadSha,
+    extraHasHead: tokens.slice(2).includes(normalizedHeadSha),
+    isExactProduction: exactMatch?.[1]?.toLowerCase() === tokens[0] &&
+      exactMatch?.[2]?.toLowerCase() === tokens[1] &&
+      tokens.length === 2,
+  };
 }
 
 /** Publish the current automated-review decision on the exact PR head SHA. */

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -28,6 +28,8 @@ const MARKDOWN_LIST_PREFIX_PATTERN =
   /([-*+]|\d+[.)])([ \t]+)(?:\[[ xX]\][ \t]+)?/g;
 const MARKDOWN_PARAGRAPH_LIST_PREFIX_PATTERN =
   /^(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?/;
+const MARKDOWN_RAW_HTML_BLOCK_START_PATTERN =
+  /^<(script|pre|style|textarea)(?:[ \t]|>|$)/i;
 const MARKDOWN_FENCE_CONTAINER_CONTINUATION_PATTERN = /^[ \t]*(?:>[ \t]*)*/;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
   /Requested commit:\s*([0-9a-f]{40})/gi;
@@ -441,6 +443,7 @@ function scanMarkdownStructure(content) {
   };
   let openFence;
   let openHtmlComment;
+  let openRawHtmlBlock;
   let openParagraph;
   let lineStart = 0;
   for (const lineMatch of content.matchAll(/[^\r\n]*(?:\r\n|[\r\n]|$)/g)) {
@@ -461,6 +464,27 @@ function scanMarkdownStructure(content) {
       continuesParagraph,
       indentedCodeLine,
     );
+
+    if (
+      openRawHtmlBlock !== undefined &&
+      !continuesMarkdownFenceContainer(
+        lineWithoutEnding,
+        openRawHtmlBlock.container,
+      )
+    ) {
+      ranges.push([openRawHtmlBlock.start, lineStart]);
+      openRawHtmlBlock = undefined;
+    }
+
+    if (openRawHtmlBlock !== undefined) {
+      if (markdownRawHtmlBlockCloses(lineWithoutEnding, openRawHtmlBlock.tag)) {
+        ranges.push([openRawHtmlBlock.start, lineEnd]);
+        openRawHtmlBlock = undefined;
+      }
+      openParagraph = undefined;
+      lineStart = lineEnd;
+      continue;
+    }
 
     if (
       openHtmlComment !== undefined &&
@@ -549,6 +573,24 @@ function scanMarkdownStructure(content) {
       }
     }
 
+    const rawHtmlBlock = markdownRawHtmlBlockStart(
+      lineWithoutEnding,
+      indentedCodeLine,
+    );
+    if (rawHtmlBlock !== undefined) {
+      if (markdownRawHtmlBlockCloses(lineWithoutEnding, rawHtmlBlock.tag)) {
+        ranges.push([lineStart, lineEnd]);
+      } else {
+        openRawHtmlBlock = {
+          ...rawHtmlBlock,
+          start: lineStart,
+        };
+      }
+      openParagraph = undefined;
+      lineStart = lineEnd;
+      continue;
+    }
+
     openHtmlComment = scanMarkdownHtmlComments(
       content,
       lineWithoutEnding,
@@ -564,15 +606,24 @@ function scanMarkdownStructure(content) {
       : undefined;
     lineStart = lineEnd;
   }
-  if (openHtmlComment?.container !== undefined) {
+  if (openRawHtmlBlock !== undefined) {
+    ranges.push([openRawHtmlBlock.start, content.length]);
+  } else if (openHtmlComment?.container !== undefined) {
     ranges.push([openHtmlComment.start, content.length]);
   } else if (openFence !== undefined) {
     ranges.push([openFence.start, content.length]);
   }
+  const blockRanges = mergeMarkdownRanges(ranges, []);
+  const refinedInlineRanges = blockRanges.length === 0
+    ? { inlineCodeRanges, inlineHtmlRanges }
+    : markdownInlineStructureRanges(content, blockRanges);
   return {
     excludedRanges: mergeMarkdownRanges(
-      ranges,
-      mergeMarkdownRanges(inlineCodeRanges, inlineHtmlRanges),
+      blockRanges,
+      mergeMarkdownRanges(
+        refinedInlineRanges.inlineCodeRanges,
+        refinedInlineRanges.inlineHtmlRanges,
+      ),
     ),
     reviewMarkers,
   };
@@ -637,6 +688,8 @@ function markdownParagraphLineContext(line) {
     MARKDOWN_PARAGRAPH_LIST_PREFIX_PATTERN,
   )?.[0];
   return {
+    blockquoteDepth:
+      [...containerPrefix].filter((character) => character === ">").length,
     content: listPrefix === undefined
       ? remainingLine
       : remainingLine.slice(listPrefix.length),
@@ -649,10 +702,17 @@ function markdownParagraphLineContext(line) {
 }
 
 function markdownLineContinuesParagraph(line, paragraph) {
+  if (paragraph === undefined || line.listContinuationIndent !== undefined) {
+    return false;
+  }
+  const sameContainer = line.structuralPrefix === paragraph.structuralPrefix;
+  const lazyBlockquoteContinuation = paragraph.blockquoteDepth > 0 &&
+    line.blockquoteDepth < paragraph.blockquoteDepth;
+  const lazyListContinuation = paragraph.isListItem;
+  if (!sameContainer && !lazyBlockquoteContinuation) return false;
   if (
-    paragraph === undefined || line.listContinuationIndent !== undefined ||
-    line.structuralPrefix !== paragraph.structuralPrefix ||
-    line.indentation < paragraph.continuationIndent
+    line.indentation < paragraph.continuationIndent &&
+    !lazyBlockquoteContinuation && !lazyListContinuation
   ) return false;
   return line.indentation - paragraph.continuationIndent >= 4 ||
     !isMarkdownInlineCodeBarrier(line.content);
@@ -669,9 +729,35 @@ function markdownParagraphAfterLine(
     return undefined;
   }
   return {
+    blockquoteDepth: line.blockquoteDepth,
     continuationIndent: line.listContinuationIndent ?? 0,
+    isListItem: line.listContinuationIndent !== undefined,
     structuralPrefix: line.structuralPrefix,
   };
+}
+
+function markdownRawHtmlBlockStart(line, indentedCodeLine) {
+  if (indentedCodeLine) return undefined;
+  const containerPrefix = line.match(
+    MARKDOWN_FENCE_CONTAINER_CONTINUATION_PATTERN,
+  )?.[0] ?? "";
+  if (!hasValidMarkdownBlockquoteSpacing(containerPrefix)) return undefined;
+  const remainingLine = line.slice(containerPrefix.length);
+  const listPrefix = remainingLine.match(
+    MARKDOWN_PARAGRAPH_LIST_PREFIX_PATTERN,
+  )?.[0] ?? "";
+  const tag = remainingLine.slice(listPrefix.length).match(
+    MARKDOWN_RAW_HTML_BLOCK_START_PATTERN,
+  )?.[1];
+  if (tag === undefined) return undefined;
+  return {
+    container: markdownFenceContainer(containerPrefix + listPrefix),
+    tag: tag.toLowerCase(),
+  };
+}
+
+function markdownRawHtmlBlockCloses(line, tag) {
+  return line.toLowerCase().includes(`</${tag}>`);
 }
 
 function scanMarkdownHtmlComments(
@@ -736,9 +822,10 @@ function markdownHtmlCommentBlockContainer(line, commentStart) {
   return markdownFenceContainer(match[1]);
 }
 
-function markdownInlineStructureRanges(content) {
+function markdownInlineStructureRanges(content, excludedRanges = []) {
   const inlineCodeRanges = [];
   const inlineHtmlRanges = [];
+  const excludedRangeCursor = { index: 0 };
   let segmentStart = 0;
   let openParagraph;
   let lineStart = 0;
@@ -754,28 +841,37 @@ function markdownInlineStructureRanges(content) {
     );
     const indentedCodeLine = isMarkdownIndentedCodeLine(lineWithoutEnding) &&
       !continuesParagraph;
-    if (isMarkdownInlineCodeBarrier(lineWithoutEnding) || indentedCodeLine) {
+    const paragraphAfterLine = markdownParagraphAfterLine(
+      paragraphLine,
+      openParagraph,
+      continuesParagraph,
+      indentedCodeLine,
+    );
+    const splitsInlineCode = indentedCodeLine ||
+      (isMarkdownInlineCodeBarrier(lineWithoutEnding) && !continuesParagraph);
+    if (splitsInlineCode) {
       appendMarkdownInlineCodeRanges(
         content,
         segmentStart,
         lineStart,
         inlineCodeRanges,
         inlineHtmlRanges,
+        excludedRanges,
+        excludedRangeCursor,
       );
-      appendMarkdownInlineHtmlRanges(
-        content,
-        lineStart,
-        lineEnd,
-        inlineHtmlRanges,
-      );
-      segmentStart = lineEnd;
+      if (paragraphAfterLine !== undefined && !indentedCodeLine) {
+        segmentStart = lineStart;
+      } else {
+        appendMarkdownInlineHtmlRanges(
+          content,
+          lineStart,
+          lineEnd,
+          inlineHtmlRanges,
+        );
+        segmentStart = lineEnd;
+      }
     }
-    openParagraph = markdownParagraphAfterLine(
-      paragraphLine,
-      openParagraph,
-      continuesParagraph,
-      indentedCodeLine,
-    );
+    openParagraph = paragraphAfterLine;
     lineStart = lineEnd;
   }
   appendMarkdownInlineCodeRanges(
@@ -784,6 +880,8 @@ function markdownInlineStructureRanges(content) {
     content.length,
     inlineCodeRanges,
     inlineHtmlRanges,
+    excludedRanges,
+    excludedRangeCursor,
   );
   return { inlineCodeRanges, inlineHtmlRanges };
 }
@@ -806,6 +904,55 @@ function isMarkdownInlineCodeBarrier(line) {
 }
 
 function appendMarkdownInlineCodeRanges(
+  content,
+  start,
+  end,
+  inlineCodeRanges,
+  inlineHtmlRanges,
+  excludedRanges,
+  excludedRangeCursor,
+) {
+  let segmentStart = start;
+  let excludedIndex = excludedRangeCursor.index;
+  while (excludedRanges[excludedIndex]?.[1] <= segmentStart) {
+    excludedIndex += 1;
+  }
+  while (excludedIndex < excludedRanges.length) {
+    const [excludedStart, excludedEnd] = excludedRanges[excludedIndex];
+    if (excludedStart >= end) break;
+    if (segmentStart < excludedStart) {
+      appendMarkdownInlineCodeRangesInSegment(
+        content,
+        segmentStart,
+        Math.min(excludedStart, end),
+        inlineCodeRanges,
+        inlineHtmlRanges,
+      );
+    }
+    segmentStart = Math.max(segmentStart, excludedEnd);
+    if (excludedEnd > end) {
+      excludedRangeCursor.index = excludedIndex;
+      return;
+    }
+    excludedIndex += 1;
+    if (segmentStart >= end) {
+      excludedRangeCursor.index = excludedIndex;
+      return;
+    }
+  }
+  excludedRangeCursor.index = excludedIndex;
+  if (segmentStart < end) {
+    appendMarkdownInlineCodeRangesInSegment(
+      content,
+      segmentStart,
+      end,
+      inlineCodeRanges,
+      inlineHtmlRanges,
+    );
+  }
+}
+
+function appendMarkdownInlineCodeRangesInSegment(
   content,
   start,
   end,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -369,43 +369,115 @@ function codeRabbitRangeEvidenceStatements(content) {
 }
 
 function markdownExcludedRanges(content) {
-  const fenceRanges = markdownFenceRanges(content);
-  return mergeMarkdownRanges(
-    fenceRanges,
-    markdownHtmlCommentRanges(content, fenceRanges),
-  );
-}
-
-function markdownHtmlCommentRanges(content, fenceRanges) {
   const ranges = [];
-  let fenceIndex = 0;
-  let searchStart = 0;
-  while (searchStart < content.length) {
-    const commentStart = content.indexOf("<!--", searchStart);
-    if (commentStart < 0) break;
-    while (
-      fenceIndex < fenceRanges.length &&
-      fenceRanges[fenceIndex][1] <= commentStart
-    ) {
-      fenceIndex += 1;
+  let openFence;
+  let openHtmlCommentStart;
+  let lineStart = 0;
+  for (const lineMatch of content.matchAll(/[^\r\n]*(?:\r?\n|$)/g)) {
+    const line = lineMatch[0];
+    if (line.length === 0 && lineStart >= content.length) break;
+    const lineEnd = lineStart + line.length;
+    const lineWithoutEnding = line.replace(/\r?\n$/, "");
+
+    if (openHtmlCommentStart !== undefined) {
+      const relativeCloseStart = lineWithoutEnding.indexOf("-->");
+      if (relativeCloseStart < 0) {
+        lineStart = lineEnd;
+        continue;
+      }
+      const closeStart = lineStart + relativeCloseStart;
+      ranges.push([openHtmlCommentStart, closeStart + 3]);
+      openHtmlCommentStart = scanMarkdownHtmlComments(
+        content,
+        lineWithoutEnding,
+        lineStart,
+        relativeCloseStart + 3,
+        ranges,
+      );
+      lineStart = lineEnd;
+      continue;
     }
+
     if (
-      fenceIndex < fenceRanges.length &&
-      fenceRanges[fenceIndex][0] <= commentStart
+      openFence !== undefined &&
+      !continuesMarkdownFenceContainer(lineWithoutEnding, openFence.container)
     ) {
-      searchStart = fenceRanges[fenceIndex][1];
+      ranges.push([openFence.start, lineStart]);
+      openFence = undefined;
+    }
+
+    const fenceMatch = line.match(MARKDOWN_FENCE_LINE_PATTERN);
+    if (openFence !== undefined) {
+      if (fenceMatch) {
+        const marker = fenceMatch[2];
+        const markerEnd = lineWithoutEnding.indexOf(marker) + marker.length;
+        if (
+          marker[0] === openFence.char && marker.length >= openFence.length &&
+          /^[ \t]*$/.test(lineWithoutEnding.slice(markerEnd))
+        ) {
+          ranges.push([openFence.start, lineEnd]);
+          openFence = undefined;
+        }
+      }
+      lineStart = lineEnd;
       continue;
     }
-    if (isEscapedMarkdownToken(content, commentStart)) {
-      searchStart = commentStart + 4;
-      continue;
+
+    if (fenceMatch) {
+      const marker = fenceMatch[2];
+      const markerEnd = lineWithoutEnding.indexOf(marker) + marker.length;
+      const hasValidInfoString = marker[0] === "~" ||
+        !lineWithoutEnding.slice(markerEnd).includes("`");
+      if (hasValidInfoString) {
+        openFence = {
+          char: marker[0],
+          length: marker.length,
+          start: lineStart,
+          container: markdownFenceContainer(fenceMatch[1]),
+        };
+        lineStart = lineEnd;
+        continue;
+      }
     }
-    const closeStart = content.indexOf("-->", commentStart + 4);
-    const commentEnd = closeStart < 0 ? content.length : closeStart + 3;
-    ranges.push([commentStart, commentEnd]);
-    searchStart = commentEnd;
+
+    openHtmlCommentStart = scanMarkdownHtmlComments(
+      content,
+      lineWithoutEnding,
+      lineStart,
+      0,
+      ranges,
+    );
+    lineStart = lineEnd;
+  }
+  if (openHtmlCommentStart !== undefined) {
+    ranges.push([openHtmlCommentStart, content.length]);
+  } else if (openFence !== undefined) {
+    ranges.push([openFence.start, content.length]);
   }
   return ranges;
+}
+
+function scanMarkdownHtmlComments(
+  content,
+  line,
+  lineStart,
+  searchStart,
+  ranges,
+) {
+  while (searchStart < line.length) {
+    const relativeCommentStart = line.indexOf("<!--", searchStart);
+    if (relativeCommentStart < 0) return undefined;
+    const commentStart = lineStart + relativeCommentStart;
+    if (isEscapedMarkdownToken(content, commentStart)) {
+      searchStart = relativeCommentStart + 4;
+      continue;
+    }
+    const relativeCloseStart = line.indexOf("-->", relativeCommentStart + 4);
+    if (relativeCloseStart < 0) return commentStart;
+    ranges.push([commentStart, lineStart + relativeCloseStart + 3]);
+    searchStart = relativeCloseStart + 3;
+  }
+  return undefined;
 }
 
 function isEscapedMarkdownToken(content, tokenStart) {
@@ -414,27 +486,6 @@ function isEscapedMarkdownToken(content, tokenStart) {
     slashStart -= 1;
   }
   return (tokenStart - slashStart) % 2 === 1;
-}
-
-function mergeMarkdownRanges(leftRanges, rightRanges) {
-  const ranges = [];
-  let leftIndex = 0;
-  let rightIndex = 0;
-  while (leftIndex < leftRanges.length || rightIndex < rightRanges.length) {
-    const takeLeft = rightIndex >= rightRanges.length ||
-      (leftIndex < leftRanges.length &&
-        leftRanges[leftIndex][0] <= rightRanges[rightIndex][0]);
-    const nextRange = takeLeft
-      ? leftRanges[leftIndex++]
-      : rightRanges[rightIndex++];
-    const previousRange = ranges.at(-1);
-    if (previousRange && nextRange[0] <= previousRange[1]) {
-      previousRange[1] = Math.max(previousRange[1], nextRange[1]);
-    } else {
-      ranges.push([...nextRange]);
-    }
-  }
-  return ranges;
 }
 
 function codeRabbitStatementIndex(match) {
@@ -555,56 +606,6 @@ function codeRabbitNextLine(content, lineEnd, continuationEnd) {
     lineEnd: nextLineEnd < 0 ? content.length : nextLineEnd,
     separator,
   };
-}
-
-function markdownFenceRanges(content) {
-  const ranges = [];
-  let openFence;
-  let lineStart = 0;
-  for (const lineMatch of content.matchAll(/[^\r\n]*(?:\r?\n|$)/g)) {
-    const line = lineMatch[0];
-    if (line.length === 0 && lineStart >= content.length) break;
-    const lineEnd = lineStart + line.length;
-    const lineWithoutEnding = line.replace(/\r?\n$/, "");
-    if (
-      openFence !== undefined &&
-      !continuesMarkdownFenceContainer(lineWithoutEnding, openFence.container)
-    ) {
-      ranges.push([openFence.start, lineStart]);
-      openFence = undefined;
-    }
-    const fenceMatch = line.match(MARKDOWN_FENCE_LINE_PATTERN);
-    if (fenceMatch) {
-      const marker = fenceMatch[2];
-      const markerEnd = lineWithoutEnding.indexOf(marker) + marker.length;
-      const hasOnlyClosingFenceWhitespace = /^[ \t]*$/.test(
-        lineWithoutEnding.slice(markerEnd),
-      );
-      if (openFence === undefined) {
-        const hasValidInfoString = marker[0] === "~" ||
-          !lineWithoutEnding.slice(markerEnd).includes("`");
-        if (!hasValidInfoString) {
-          lineStart = lineEnd;
-          continue;
-        }
-        openFence = {
-          char: marker[0],
-          length: marker.length,
-          start: lineStart,
-          container: markdownFenceContainer(fenceMatch[1]),
-        };
-      } else if (
-        marker[0] === openFence.char && marker.length >= openFence.length &&
-        hasOnlyClosingFenceWhitespace
-      ) {
-        ranges.push([openFence.start, lineEnd]);
-        openFence = undefined;
-      }
-    }
-    lineStart = lineEnd;
-  }
-  if (openFence !== undefined) ranges.push([openFence.start, content.length]);
-  return ranges;
 }
 
 function markdownFenceContainer(prefix) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -8,7 +8,7 @@ const CODERABBIT_RECENT_REVIEW_END_MARKER = "<!-- recent_review_end -->";
 const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
   "No actionable comments were generated in the recent review.";
 const CODERABBIT_REVIEW_RANGE_PATTERN =
-  /Reviewing files between\s+([0-9a-f]{40})\s+and\s+([0-9a-f]{40})(?:\.|\s|$)/i;
+  /Reviewing files(?:\s+that changed from the base of the PR and)?\s+between\s+([0-9a-f]{40})\s+and\s+([0-9a-f]{40})(?:\.|\s|$)/i;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
   /Requested commit:\s*([0-9a-f]{40})/i;
 const CODERABBIT_SKIPPED_COMMIT_PATTERN =

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -21,7 +21,8 @@ const CODERABBIT_REVIEW_RANGE_WRAPPED_TIP_PATTERN =
 const CODERABBIT_REVIEW_RANGE_WRAPPED_SEPARATOR_PATTERN =
   /^[ \t]*and[ \t]+([0-9a-f]{40})(?![0-9a-f])/i;
 const FULL_COMMIT_TOKEN_PATTERN = /(^|[^0-9a-f])([0-9a-f]{40})(?![0-9a-f])/gi;
-const MARKDOWN_FENCE_LINE_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})/;
+const MARKDOWN_FENCE_LINE_PATTERN =
+  /^[ \t]{0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*(`{3,}|~{3,})/;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
   /Requested commit:\s*([0-9a-f]{40})/gi;
 const CODERABBIT_SKIPPED_COMMIT_PATTERN =
@@ -332,14 +333,14 @@ function classifyCodeRabbitRangeEvidence(selectedRecentReview, headSha) {
 
 function codeRabbitRangeEvidenceStatements(content) {
   const fenceRanges = markdownFenceRanges(content);
+  const matches = [
+    ...content.matchAll(CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN),
+  ];
+  const statementIndexes = matches.map(codeRabbitStatementIndex);
   const statements = [];
   let fenceIndex = 0;
-  for (
-    const match of content.matchAll(
-      CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN,
-    )
-  ) {
-    const statementIndex = match.index + match[0].indexOf(match[1]);
+  for (const [matchIndex, match] of matches.entries()) {
+    const statementIndex = statementIndexes[matchIndex];
     while (
       fenceIndex < fenceRanges.length &&
       fenceRanges[fenceIndex][1] <= statementIndex
@@ -350,13 +351,25 @@ function codeRabbitRangeEvidenceStatements(content) {
       fenceRanges[fenceIndex][0] <= statementIndex &&
       statementIndex < fenceRanges[fenceIndex][1];
     if (insideFence) continue;
-    const statement = parseCodeRabbitRangeStatement(content, match);
+    const continuationEnd = Math.min(
+      statementIndexes[matchIndex + 1] ?? content.length,
+      fenceRanges[fenceIndex]?.[0] ?? content.length,
+    );
+    const statement = parseCodeRabbitRangeStatement(
+      content,
+      match,
+      continuationEnd,
+    );
     if (statement) statements.push(statement);
   }
   return statements;
 }
 
-function parseCodeRabbitRangeStatement(content, match) {
+function codeRabbitStatementIndex(match) {
+  return match.index + match[0].indexOf(match[1]);
+}
+
+function parseCodeRabbitRangeStatement(content, match, continuationEnd) {
   const statementStart = match[1];
   const firstLineTail = match[2];
   const sameLineSeparator = firstLineTail.match(
@@ -378,7 +391,7 @@ function parseCodeRabbitRangeStatement(content, match) {
   const statementParts = [statementStart + firstLineTail];
   let lineEnd = match.index + match[0].length;
   while (true) {
-    const nextLine = codeRabbitNextLine(content, lineEnd);
+    const nextLine = codeRabbitNextLine(content, lineEnd, continuationEnd);
     if (!nextLine) return undefined;
     const continuationContent = nextLine.content.replace(
       CODERABBIT_REVIEW_RANGE_CONTINUATION_PREFIX_PATTERN,
@@ -430,7 +443,7 @@ function codeRabbitBaseSegment(lines, finalLine) {
   return [...lines, finalLine].join("\n").trim().toLowerCase();
 }
 
-function codeRabbitNextLine(content, lineEnd) {
+function codeRabbitNextLine(content, lineEnd, continuationEnd) {
   const separator = content.startsWith("\r\n", lineEnd)
     ? "\r\n"
     : content.startsWith("\n", lineEnd)
@@ -438,12 +451,20 @@ function codeRabbitNextLine(content, lineEnd) {
     : undefined;
   if (!separator) return undefined;
   const contentStart = lineEnd + separator.length;
-  const nextLineEnd = content.slice(contentStart).search(/[\r\n]/);
+  if (contentStart >= continuationEnd) return undefined;
+  const carriageReturn = content.indexOf("\r", contentStart);
+  const lineFeed = content.indexOf("\n", contentStart);
+  const nextLineEnd = carriageReturn < 0
+    ? lineFeed
+    : lineFeed < 0
+    ? carriageReturn
+    : Math.min(carriageReturn, lineFeed);
   return {
-    content: nextLineEnd < 0
-      ? content.slice(contentStart)
-      : content.slice(contentStart, contentStart + nextLineEnd),
-    lineEnd: nextLineEnd < 0 ? content.length : contentStart + nextLineEnd,
+    content: content.slice(
+      contentStart,
+      nextLineEnd < 0 ? content.length : nextLineEnd,
+    ),
+    lineEnd: nextLineEnd < 0 ? content.length : nextLineEnd,
     separator,
   };
 }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -88,6 +88,13 @@ export async function findAutomatedReview(
       return { kind: "failure" };
     }
   }
+  events.sort((left, right) => {
+    if (left.time === undefined) {
+      return right.time === undefined ? right.order - left.order : 1;
+    }
+    if (right.time === undefined) return -1;
+    return right.time - left.time || right.order - left.order;
+  });
   const timedEvents = Map.groupBy(
     events.filter((event) => event.time !== undefined),
     (event) => event.time,
@@ -98,18 +105,13 @@ export async function findAutomatedReview(
     )).filter(
       (outcome) => outcome.kind !== "not-head",
     );
+    if (exactHeadOutcomes.length === 0) continue;
     if (
       exactHeadOutcomes.length > 1 &&
       exactHeadOutcomes.some((outcome) => outcome.kind !== "success")
     ) return { kind: "failure" };
+    break;
   }
-  events.sort((left, right) => {
-    if (left.time === undefined) {
-      return right.time === undefined ? right.order - left.order : 1;
-    }
-    if (right.time === undefined) return -1;
-    return right.time - left.time || right.order - left.order;
-  });
 
   for (const event of events) {
     const outcome = await outcomeFor(event);

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -253,7 +253,8 @@ async function classifyAutomatedReviewEvent(
       url: typeof comment.html_url === "string" ? comment.html_url : undefined,
     };
   }
-  return effectiveRangeReview?.content.includes(
+  return hasExactVisibleMarkdownLine(
+      effectiveRangeReview.content,
       CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER,
     )
     ? {
@@ -367,6 +368,30 @@ function codeRabbitRangeEvidenceStatements(content) {
 
 function markdownExcludedRanges(content) {
   return scanMarkdownStructure(content).excludedRanges;
+}
+
+function hasExactVisibleMarkdownLine(content, expectedLine) {
+  const excludedRanges = markdownExcludedRanges(content);
+  let excludedRangeIndex = 0;
+  let lineStart = 0;
+  for (const lineMatch of content.matchAll(/[^\r\n]*(?:\r\n|[\r\n]|$)/g)) {
+    const line = lineMatch[0];
+    if (line.length === 0 && lineStart >= content.length) break;
+    const lineEnd = lineStart + line.length;
+    const lineWithoutEnding = line.replace(/(?:\r\n|[\r\n])$/, "");
+    while (
+      excludedRangeIndex < excludedRanges.length &&
+      excludedRanges[excludedRangeIndex][1] <= lineStart
+    ) {
+      excludedRangeIndex += 1;
+    }
+    const excludedRange = excludedRanges[excludedRangeIndex];
+    const isExcluded = excludedRange?.[0] <= lineStart &&
+      lineStart < excludedRange[1];
+    if (!isExcluded && lineWithoutEnding === expectedLine) return true;
+    lineStart = lineEnd;
+  }
+  return false;
 }
 
 function markdownReviewMarkers(content) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -21,13 +21,11 @@ const CODERABBIT_REVIEW_RANGE_WRAPPED_SEPARATOR_PATTERN =
   /^[ \t]*and[ \t]+([0-9a-f]{40})(?![0-9a-f])/i;
 const FULL_COMMIT_TOKEN_PATTERN = /(^|[^0-9a-f])([0-9a-f]{40})(?![0-9a-f])/gi;
 const MARKDOWN_FENCE_LINE_PATTERN =
-  /^( {0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*)(`{3,}|~{3,})/;
+  /^( {0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+))*)(`{3,}|~{3,})/;
 const MARKDOWN_HTML_COMMENT_BLOCK_START_PATTERN =
-  /^( {0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*)<!--/;
-const MARKDOWN_LIST_PREFIX_PATTERN =
-  /([-*+]|\d{1,9}[.)])([ \t]+)(?:\[[ xX]\][ \t]+)?/g;
-const MARKDOWN_PARAGRAPH_LIST_PREFIX_PATTERN =
-  /^(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?/;
+  /^( {0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+))*)<!--/;
+const MARKDOWN_LIST_PREFIX_PATTERN = /([-*+]|\d{1,9}[.)])([ \t]+)/g;
+const MARKDOWN_PARAGRAPH_LIST_PREFIX_PATTERN = /^(?:[-*+]|\d{1,9}[.)])[ \t]+/;
 const MARKDOWN_RAW_HTML_BLOCK_START_PATTERN =
   /^<(script|pre|style|textarea)(?:[ \t]|>|$)/i;
 const MARKDOWN_PARAGRAPH_INTERRUPTING_HTML_TAG_PATTERN =

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -376,6 +376,24 @@ function markdownReviewMarkers(content) {
 function scanMarkdownStructure(content) {
   const ranges = [];
   const reviewMarkers = [];
+  const inlineCodeRanges = markdownInlineCodeRanges(content);
+  const possibleInlineCodeRanges = [];
+  appendMarkdownInlineCodeRanges(
+    content,
+    0,
+    content.length,
+    possibleInlineCodeRanges,
+  );
+  let possibleInlineCodeRangeIndex = 0;
+  const isInsidePossibleInlineCode = (index) => {
+    while (
+      possibleInlineCodeRanges[possibleInlineCodeRangeIndex]?.[1] <= index
+    ) {
+      possibleInlineCodeRangeIndex += 1;
+    }
+    const range = possibleInlineCodeRanges[possibleInlineCodeRangeIndex];
+    return range?.[0] <= index && index < range[1];
+  };
   let openFence;
   let openHtmlCommentStart;
   let lineStart = 0;
@@ -400,6 +418,7 @@ function scanMarkdownStructure(content) {
         relativeCloseStart + 3,
         ranges,
         reviewMarkers,
+        isInsidePossibleInlineCode,
       );
       lineStart = lineEnd;
       continue;
@@ -427,7 +446,7 @@ function scanMarkdownStructure(content) {
     }
 
     const fenceMatch = line.match(MARKDOWN_FENCE_LINE_PATTERN);
-    if (fenceMatch) {
+    if (fenceMatch && hasValidMarkdownBlockquoteSpacing(fenceMatch[1])) {
       const marker = fenceMatch[2];
       const markerEnd = lineWithoutEnding.indexOf(marker) + marker.length;
       const hasValidInfoString = marker[0] === "~" ||
@@ -451,6 +470,7 @@ function scanMarkdownStructure(content) {
       0,
       ranges,
       reviewMarkers,
+      isInsidePossibleInlineCode,
     );
     lineStart = lineEnd;
   }
@@ -459,7 +479,48 @@ function scanMarkdownStructure(content) {
   } else if (openFence !== undefined) {
     ranges.push([openFence.start, content.length]);
   }
-  return { excludedRanges: ranges, reviewMarkers };
+  return {
+    excludedRanges: mergeMarkdownRanges(ranges, inlineCodeRanges),
+    reviewMarkers,
+  };
+}
+
+function mergeMarkdownRanges(left, right) {
+  const merged = [];
+  let leftIndex = 0;
+  let rightIndex = 0;
+  while (leftIndex < left.length || rightIndex < right.length) {
+    const next = rightIndex >= right.length ||
+        (leftIndex < left.length &&
+          left[leftIndex][0] <= right[rightIndex][0])
+      ? left[leftIndex++]
+      : right[rightIndex++];
+    const previous = merged.at(-1);
+    if (previous && next[0] <= previous[1]) {
+      previous[1] = Math.max(previous[1], next[1]);
+    } else {
+      merged.push([...next]);
+    }
+  }
+  return merged;
+}
+
+function hasValidMarkdownBlockquoteSpacing(prefix) {
+  let column = 0;
+  for (let index = 0; index < prefix.length;) {
+    const character = prefix[index];
+    column += character === "\t" ? 4 - (column % 4) : 1;
+    index += 1;
+    if (character !== ">") continue;
+
+    const contentColumn = column;
+    while (prefix[index] === " " || prefix[index] === "\t") {
+      column += prefix[index] === "\t" ? 4 - (column % 4) : 1;
+      index += 1;
+    }
+    if (column - contentColumn > 4) return false;
+  }
+  return true;
 }
 
 function scanMarkdownHtmlComments(
@@ -469,19 +530,23 @@ function scanMarkdownHtmlComments(
   searchStart,
   ranges,
   reviewMarkers,
+  isInsidePossibleInlineCode,
 ) {
   while (searchStart < line.length) {
     const relativeCommentStart = line.indexOf("<!--", searchStart);
     if (relativeCommentStart < 0) return undefined;
     const commentStart = lineStart + relativeCommentStart;
-    if (isEscapedMarkdownToken(content, commentStart)) {
-      searchStart = relativeCommentStart + 4;
-      continue;
-    }
     const reviewMarker = codeRabbitReviewMarkerAt(line, relativeCommentStart);
     if (reviewMarker) {
       reviewMarkers.push({ value: reviewMarker, index: commentStart });
       searchStart = relativeCommentStart + reviewMarker.length;
+      continue;
+    }
+    if (
+      isInsidePossibleInlineCode(commentStart) ||
+      isEscapedMarkdownToken(content, commentStart)
+    ) {
+      searchStart = relativeCommentStart + 4;
       continue;
     }
     const relativeCloseStart = line.indexOf("-->", relativeCommentStart + 4);
@@ -490,6 +555,81 @@ function scanMarkdownHtmlComments(
     searchStart = relativeCloseStart + 3;
   }
   return undefined;
+}
+
+function markdownInlineCodeRanges(content) {
+  const ranges = [];
+  let segmentStart = 0;
+  let lineStart = 0;
+  for (const lineMatch of content.matchAll(/[^\r\n]*(?:\r\n|[\r\n]|$)/g)) {
+    const line = lineMatch[0];
+    if (line.length === 0 && lineStart >= content.length) break;
+    const lineEnd = lineStart + line.length;
+    const lineWithoutEnding = line.replace(/(?:\r\n|[\r\n])$/, "");
+    if (isMarkdownInlineCodeBarrier(lineWithoutEnding)) {
+      appendMarkdownInlineCodeRanges(content, segmentStart, lineStart, ranges);
+      segmentStart = lineEnd;
+    }
+    lineStart = lineEnd;
+  }
+  appendMarkdownInlineCodeRanges(content, segmentStart, content.length, ranges);
+  return ranges;
+}
+
+function isMarkdownInlineCodeBarrier(line) {
+  if (
+    line.trim().length === 0 ||
+    /^ {0,3}<(?:[A-Za-z!?/])/.test(line) ||
+    /^ {0,3}(?:>|#{1,6}(?:[ \t]|$)|(?:[-+*]|\d+[.)])(?:[ \t]|$))/.test(
+      line,
+    ) ||
+    /^ {0,3}=+[ \t]*$/.test(line) ||
+    /^ {0,3}(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/.test(
+      line,
+    )
+  ) return true;
+  const fenceMatch = line.match(MARKDOWN_FENCE_LINE_PATTERN);
+  return fenceMatch !== null &&
+    hasValidMarkdownBlockquoteSpacing(fenceMatch[1]);
+}
+
+function appendMarkdownInlineCodeRanges(content, start, end, ranges) {
+  const delimiterRuns = [];
+  for (let index = start; index < end;) {
+    if (content[index] !== "`") {
+      index += 1;
+      continue;
+    }
+    if (isEscapedMarkdownToken(content, index)) {
+      index += 1;
+      continue;
+    }
+    let end = index + 1;
+    while (content[end] === "`") end += 1;
+    delimiterRuns.push({ start: index, end, length: end - index });
+    index = end;
+  }
+
+  const nextRunWithLength = new Array(delimiterRuns.length);
+  const nextIndexByLength = new Map();
+  for (let index = delimiterRuns.length - 1; index >= 0; index -= 1) {
+    const run = delimiterRuns[index];
+    nextRunWithLength[index] = nextIndexByLength.get(run.length);
+    nextIndexByLength.set(run.length, index);
+  }
+
+  for (let index = 0; index < delimiterRuns.length;) {
+    const closingIndex = nextRunWithLength[index];
+    if (closingIndex === undefined) {
+      index += 1;
+      continue;
+    }
+    ranges.push([
+      delimiterRuns[index].start,
+      delimiterRuns[closingIndex].end,
+    ]);
+    index = closingIndex + 1;
+  }
 }
 
 function codeRabbitReviewMarkerAt(line, markerStart) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -9,9 +9,9 @@ const CODERABBIT_RECENT_REVIEW_MARKER_PATTERN =
 const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
   "No actionable comments were generated in the recent review.";
 const CODERABBIT_REVIEW_RANGE_PATTERN =
-  /(?:^|\r?\n)Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r?\n|$)/;
+  /(?:^|\r\n|[\r\n])Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r\n|[\r\n]|$)/;
 const CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN =
-  /(?:^|\r?\n)([ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*(?:Reviewing[ \t]+(?:files(?:[ \t]+that[ \t]+changed[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?|changed[ \t]+files(?:[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?)[ \t]+(?:and[ \t]+)?between))([^\r\n]*)/gi;
+  /(?:^|\r\n|[\r\n])([ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*(?:Reviewing[ \t]+(?:files(?:[ \t]+that[ \t]+changed[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?|changed[ \t]+files(?:[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?)[ \t]+(?:and[ \t]+)?between))([^\r\n]*)/gi;
 const CODERABBIT_REVIEW_RANGE_CONTINUATION_PREFIX_PATTERN =
   /^[ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*/;
 const CODERABBIT_REVIEW_RANGE_SEPARATOR_PATTERN =
@@ -584,6 +584,8 @@ function codeRabbitNextLine(content, lineEnd, continuationEnd) {
     ? "\r\n"
     : content.startsWith("\n", lineEnd)
     ? "\n"
+    : content.startsWith("\r", lineEnd)
+    ? "\r"
     : undefined;
   if (!separator) return undefined;
   const contentStart = lineEnd + separator.length;

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -604,10 +604,14 @@ function appendMarkdownInlineCodeRanges(content, start, end, ranges) {
       index += 1;
       continue;
     }
-    let end = index + 1;
-    while (content[end] === "`") end += 1;
-    delimiterRuns.push({ start: index, end, length: end - index });
-    index = end;
+    let runEnd = index + 1;
+    while (content[runEnd] === "`") runEnd += 1;
+    delimiterRuns.push({
+      start: index,
+      end: runEnd,
+      length: runEnd - index,
+    });
+    index = runEnd;
   }
 
   const nextRunWithLength = new Array(delimiterRuns.length);

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -7,6 +7,7 @@ const CODERABBIT_RECENT_REVIEW_MARKER = "<!-- recent_review_start -->";
 const CODERABBIT_RECENT_REVIEW_END_MARKER = "<!-- recent_review_end -->";
 const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
   "No actionable comments were generated in the recent review.";
+const CODERABBIT_REVIEW_RANGE_CANDIDATE_PATTERN = /^\s*reviewing\s+files\b/i;
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r?\n)Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r?\n|$)/;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
@@ -208,9 +209,26 @@ async function classifyAutomatedReviewEvent(
       url: typeof comment.html_url === "string" ? comment.html_url : undefined,
     };
   }
-  const reviewedTip = recentReview?.match(
-    CODERABBIT_REVIEW_RANGE_PATTERN,
-  )?.[2];
+  const rangeCandidates = recentReview?.split(/\r?\n/).filter((line) =>
+    CODERABBIT_REVIEW_RANGE_CANDIDATE_PATTERN.test(line)
+  );
+  const reviewedTips = rangeCandidates?.map((line) =>
+    line.match(CODERABBIT_REVIEW_RANGE_PATTERN)?.[2]
+  );
+  const hasCurrentRange = reviewedTips?.some((tip) =>
+    tip?.toLowerCase() === headSha.toLowerCase()
+  );
+  if (rangeCandidates?.length !== 1) {
+    return hasCurrentRange
+      ? {
+        kind: "failure",
+        url: typeof comment.html_url === "string"
+          ? comment.html_url
+          : undefined,
+      }
+      : { kind: "not-head" };
+  }
+  const reviewedTip = reviewedTips?.[0];
   if (reviewedTip?.toLowerCase() !== headSha.toLowerCase()) {
     return { kind: "not-head" };
   }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -199,7 +199,7 @@ async function classifyAutomatedReviewEvent(
   if (login.toLowerCase() !== CODERABBIT_LOGIN) {
     return { kind: "not-head" };
   }
-  const recentReview = codeRabbitRecentReview(body);
+  const selectedRecentReview = codeRabbitSelectedRecentReview(body);
   const currentHeadMarker = [
     ...body.matchAll(CODERABBIT_SKIPPED_COMMIT_PATTERN),
     ...body.matchAll(CODERABBIT_REQUESTED_COMMIT_PATTERN),
@@ -210,9 +210,9 @@ async function classifyAutomatedReviewEvent(
       url: typeof comment.html_url === "string" ? comment.html_url : undefined,
     };
   }
-  const rangeCandidates = recentReview?.split(/\r?\n/).filter((line) =>
-    CODERABBIT_REVIEW_RANGE_CANDIDATE_PATTERN.test(line)
-  );
+  const rangeCandidates = selectedRecentReview?.content.split(/\r?\n/).filter((
+    line,
+  ) => CODERABBIT_REVIEW_RANGE_CANDIDATE_PATTERN.test(line));
   const rangeCandidateHasCurrentTip = rangeCandidates?.some((line) =>
     rangeCandidateReferencesTip(line, headSha)
   );
@@ -222,6 +222,15 @@ async function classifyAutomatedReviewEvent(
   const hasCurrentRange = reviewedTips?.some((tip) =>
     tip?.toLowerCase() === headSha.toLowerCase()
   );
+  if (
+    selectedRecentReview && !selectedRecentReview.terminated &&
+    (hasCurrentRange || rangeCandidateHasCurrentTip)
+  ) {
+    return {
+      kind: "failure",
+      url: typeof comment.html_url === "string" ? comment.html_url : undefined,
+    };
+  }
   if (rangeCandidates?.length !== 1) {
     return hasCurrentRange || rangeCandidateHasCurrentTip
       ? {
@@ -238,7 +247,9 @@ async function classifyAutomatedReviewEvent(
       ? { kind: "failure" }
       : { kind: "not-head" };
   }
-  return recentReview?.includes(CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER)
+  return selectedRecentReview?.content.includes(
+      CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER,
+    )
     ? {
       kind: "success",
       review: {
@@ -256,13 +267,16 @@ async function classifyAutomatedReviewEvent(
     };
 }
 
-function codeRabbitRecentReview(body) {
+function codeRabbitSelectedRecentReview(body) {
   if (typeof body !== "string") return undefined;
   const start = body.lastIndexOf(CODERABBIT_RECENT_REVIEW_MARKER);
   if (start < 0) return undefined;
   const contentStart = start + CODERABBIT_RECENT_REVIEW_MARKER.length;
   const end = body.indexOf(CODERABBIT_RECENT_REVIEW_END_MARKER, contentStart);
-  return end < 0 ? undefined : body.slice(contentStart, end);
+  return {
+    content: end < 0 ? body.slice(contentStart) : body.slice(contentStart, end),
+    terminated: end >= 0,
+  };
 }
 
 function rangeCandidateReferencesTip(value, headSha) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -12,6 +12,8 @@ const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r?\n)Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r?\n|$)/;
 const CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN =
   /(?:^|\r?\n)([ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*(?:Reviewing[ \t]+(?:files(?:[ \t]+that[ \t]+changed[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?|changed[ \t]+files(?:[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?)[ \t]+(?:and[ \t]+)?between))([^\r\n]*)/gi;
+const CODERABBIT_REVIEW_RANGE_CONTINUATION_PREFIX_PATTERN =
+  /^[ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*/;
 const CODERABBIT_REVIEW_RANGE_SEPARATOR_PATTERN =
   /(^|[ \t])and[ \t]+([0-9a-f]{40})(?![0-9a-f])/i;
 const CODERABBIT_REVIEW_RANGE_WRAPPED_TIP_PATTERN =
@@ -377,12 +379,17 @@ function parseCodeRabbitRangeStatement(content, match) {
   let lineEnd = match.index + match[0].length;
   while (true) {
     const nextLine = codeRabbitNextLine(content, lineEnd);
-    if (!nextLine || nextLine.content.trim().length === 0) return undefined;
+    if (!nextLine) return undefined;
+    const continuationContent = nextLine.content.replace(
+      CODERABBIT_REVIEW_RANGE_CONTINUATION_PREFIX_PATTERN,
+      "",
+    );
+    if (continuationContent.trim().length === 0) return undefined;
     statementParts.push(nextLine.separator, nextLine.content);
 
     const previousLine = baseLines.at(-1);
     const trailingAnd = previousLine?.match(/(^|[ \t])and[ \t]*$/i);
-    const wrappedTip = nextLine.content.match(
+    const wrappedTip = continuationContent.match(
       CODERABBIT_REVIEW_RANGE_WRAPPED_TIP_PATTERN,
     );
     if (trailingAnd && wrappedTip) {
@@ -393,26 +400,28 @@ function parseCodeRabbitRangeStatement(content, match) {
         ),
         statement: statementParts.join(""),
         tipToken: wrappedTip[1].toLowerCase(),
-        trailingStatement: nextLine.content.slice(wrappedTip[0].length),
+        trailingStatement: continuationContent.slice(wrappedTip[0].length),
       };
     }
 
-    const wrappedSeparator = nextLine.content.match(
+    const wrappedSeparator = continuationContent.match(
       CODERABBIT_REVIEW_RANGE_WRAPPED_SEPARATOR_PATTERN,
     );
     if (wrappedSeparator) {
       return {
         baseSegment: codeRabbitBaseSegment(
           baseLines,
-          nextLine.content.slice(0, wrappedSeparator.index),
+          continuationContent.slice(0, wrappedSeparator.index),
         ),
         statement: statementParts.join(""),
         tipToken: wrappedSeparator[1].toLowerCase(),
-        trailingStatement: nextLine.content.slice(wrappedSeparator[0].length),
+        trailingStatement: continuationContent.slice(
+          wrappedSeparator[0].length,
+        ),
       };
     }
 
-    baseLines.push(nextLine.content);
+    baseLines.push(continuationContent);
     lineEnd = nextLine.lineEnd;
   }
 }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -448,8 +448,8 @@ function scanMarkdownStructure(content) {
     return range?.[0] <= index && index < range[1];
   };
   let openFence;
+  let openHtmlBlock;
   let openHtmlComment;
-  let openRawHtmlBlock;
   let openParagraph;
   let lineStart = 0;
   for (const lineMatch of content.matchAll(/[^\r\n]*(?:\r\n|[\r\n]|$)/g)) {
@@ -471,25 +471,27 @@ function scanMarkdownStructure(content) {
       indentedCodeLine,
     );
 
-    if (
-      openRawHtmlBlock !== undefined &&
-      !continuesMarkdownFenceContainer(
-        lineWithoutEnding,
-        openRawHtmlBlock.container,
-      )
-    ) {
-      ranges.push([openRawHtmlBlock.start, lineStart]);
-      openRawHtmlBlock = undefined;
-    }
-
-    if (openRawHtmlBlock !== undefined) {
-      if (markdownRawHtmlBlockCloses(lineWithoutEnding, openRawHtmlBlock.tag)) {
-        ranges.push([openRawHtmlBlock.start, lineEnd]);
-        openRawHtmlBlock = undefined;
+    if (openHtmlBlock !== undefined) {
+      if (markdownHtmlBlockCloses(lineWithoutEnding, openHtmlBlock)) {
+        ranges.push([openHtmlBlock.start, lineEnd]);
+        openHtmlBlock = undefined;
+        openParagraph = undefined;
+        lineStart = lineEnd;
+        continue;
       }
-      openParagraph = undefined;
-      lineStart = lineEnd;
-      continue;
+      if (
+        !continuesMarkdownFenceContainer(
+          lineWithoutEnding,
+          openHtmlBlock.container,
+        )
+      ) {
+        ranges.push([openHtmlBlock.start, lineStart]);
+        openHtmlBlock = undefined;
+      } else {
+        openParagraph = undefined;
+        lineStart = lineEnd;
+        continue;
+      }
     }
 
     if (
@@ -579,16 +581,16 @@ function scanMarkdownStructure(content) {
       }
     }
 
-    const rawHtmlBlock = markdownRawHtmlBlockStart(
+    const htmlBlock = markdownHtmlBlockStart(
       lineWithoutEnding,
       indentedCodeLine,
     );
-    if (rawHtmlBlock !== undefined) {
-      if (markdownRawHtmlBlockCloses(lineWithoutEnding, rawHtmlBlock.tag)) {
+    if (htmlBlock !== undefined) {
+      if (markdownHtmlBlockCloses(lineWithoutEnding, htmlBlock)) {
         ranges.push([lineStart, lineEnd]);
       } else {
-        openRawHtmlBlock = {
-          ...rawHtmlBlock,
+        openHtmlBlock = {
+          ...htmlBlock,
           start: lineStart,
         };
       }
@@ -612,8 +614,8 @@ function scanMarkdownStructure(content) {
       : undefined;
     lineStart = lineEnd;
   }
-  if (openRawHtmlBlock !== undefined) {
-    ranges.push([openRawHtmlBlock.start, content.length]);
+  if (openHtmlBlock !== undefined) {
+    ranges.push([openHtmlBlock.start, content.length]);
   } else if (openHtmlComment?.container !== undefined) {
     ranges.push([openHtmlComment.start, content.length]);
   } else if (openFence !== undefined) {
@@ -751,7 +753,7 @@ function markdownParagraphAfterLine(
   };
 }
 
-function markdownRawHtmlBlockStart(line, indentedCodeLine) {
+function markdownHtmlBlockStart(line, indentedCodeLine) {
   if (indentedCodeLine) return undefined;
   const containerPrefix = line.match(
     MARKDOWN_FENCE_CONTAINER_CONTINUATION_PATTERN,
@@ -761,18 +763,51 @@ function markdownRawHtmlBlockStart(line, indentedCodeLine) {
   const listPrefix = remainingLine.match(
     MARKDOWN_PARAGRAPH_LIST_PREFIX_PATTERN,
   )?.[0] ?? "";
-  const tag = remainingLine.slice(listPrefix.length).match(
+  const blockContent = remainingLine.slice(listPrefix.length);
+  const tag = blockContent.match(
     MARKDOWN_RAW_HTML_BLOCK_START_PATTERN,
   )?.[1];
-  if (tag === undefined) return undefined;
+  if (tag !== undefined) {
+    return {
+      caseInsensitive: true,
+      container: markdownFenceContainer(containerPrefix + listPrefix),
+      terminator: `</${tag.toLowerCase()}>`,
+    };
+  }
+  let terminator;
+  if (blockContent.startsWith("<?")) terminator = "?>";
+  else if (blockContent.startsWith("<![CDATA[")) terminator = "]]>";
+  else if (/^<![A-Za-z]/.test(blockContent)) terminator = ">";
+  if (terminator === undefined) return undefined;
   return {
+    caseInsensitive: false,
     container: markdownFenceContainer(containerPrefix + listPrefix),
-    tag: tag.toLowerCase(),
+    terminator,
   };
 }
 
-function markdownRawHtmlBlockCloses(line, tag) {
-  return line.toLowerCase().includes(`</${tag}>`);
+function markdownHtmlBlockCloses(line, block) {
+  const content = markdownContainerContent(line, block.container);
+  if (content === undefined) return false;
+  return (block.caseInsensitive ? content.toLowerCase() : content).includes(
+    block.terminator,
+  );
+}
+
+function markdownContainerContent(line, container) {
+  let index = 0;
+  while (line[index] === " " || line[index] === "\t") index += 1;
+  for (let depth = 0; depth < container.blockquoteDepth; depth += 1) {
+    if (line[index] !== ">") return undefined;
+    index += 1;
+    while (line[index] === " " || line[index] === "\t") index += 1;
+  }
+  const prefix = line.slice(0, index);
+  if (
+    !hasValidMarkdownBlockquoteSpacing(prefix) ||
+    markdownContainerIndentColumns(prefix) < container.continuationIndent
+  ) return undefined;
+  return line.slice(index);
 }
 
 function scanMarkdownHtmlComments(
@@ -1310,6 +1345,8 @@ function codeRabbitNextLine(content, lineEnd, continuationEnd) {
 function markdownFenceContainer(prefix) {
   const listPrefixes = [...prefix.matchAll(MARKDOWN_LIST_PREFIX_PATTERN)];
   return {
+    blockquoteDepth:
+      [...prefix].filter((character) => character === ">").length,
     structuralPrefix: codeRabbitMarkdownPrefixSignature(
       prefix.replace(MARKDOWN_LIST_PREFIX_PATTERN, ""),
     ),

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -93,7 +93,6 @@ export async function findAutomatedReview(
     (event) => event.time,
   );
   for (const tiedEvents of timedEvents.values()) {
-    if (new Set(tiedEvents.map((event) => event.kind)).size < 2) continue;
     const exactHeadOutcomes = (await Promise.all(
       tiedEvents.map(outcomeFor),
     )).filter(

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -10,7 +10,7 @@ const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r\n|[\r\n])Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r\n|[\r\n]|$)/;
 const CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN =
-  /(?:^|\r\n|[\r\n])([ \t]*(?:(?:>[ \t]*)|(?:\|[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*[\\`]*(?:Reviewing[ \t]+(?:files(?:[ \t]+that[ \t]+changed[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?|changed[ \t]+files(?:[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?)[ \t]+(?:and[ \t]+)?between))([^\r\n]*)/gi;
+  /(?:^|\r\n|[\r\n])([ \t]*(?:(?:>[ \t]*)|(?:\|[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*[\\`*_~!\[]*(?:Reviewing[ \t]+(?:files(?:[ \t]+that[ \t]+changed[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?|changed[ \t]+files(?:[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?)[ \t]+(?:and[ \t]+)?between))([^\r\n]*)/gi;
 const CODERABBIT_REVIEW_RANGE_CONTINUATION_PREFIX_PATTERN =
   /^[ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*/;
 const CODERABBIT_REVIEW_RANGE_SEPARATOR_PATTERN =
@@ -2369,7 +2369,7 @@ function parseCodeRabbitRangeStatement(content, match, continuationEnd) {
     statementStart.slice(
       0,
       statementStart.toLowerCase().lastIndexOf("reviewing"),
-    ).replace(/[\\`]+$/, ""),
+    ).replace(/[\\`*_~!\[]+$/, ""),
   );
   const sameLineSeparator = firstLineTail.match(
     CODERABBIT_REVIEW_RANGE_SEPARATOR_PATTERN,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -10,7 +10,7 @@ const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r\n|[\r\n])Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r\n|[\r\n]|$)/;
 const CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN =
-  /(?:^|\r\n|[\r\n])([ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*(?:Reviewing[ \t]+(?:files(?:[ \t]+that[ \t]+changed[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?|changed[ \t]+files(?:[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?)[ \t]+(?:and[ \t]+)?between))([^\r\n]*)/gi;
+  /(?:^|\r\n|[\r\n])([ \t]*(?:(?:>[ \t]*)|(?:\|[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*(?:Reviewing[ \t]+(?:files(?:[ \t]+that[ \t]+changed[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?|changed[ \t]+files(?:[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?)[ \t]+(?:and[ \t]+)?between))([^\r\n]*)/gi;
 const CODERABBIT_REVIEW_RANGE_CONTINUATION_PREFIX_PATTERN =
   /^[ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*/;
 const CODERABBIT_REVIEW_RANGE_SEPARATOR_PATTERN =
@@ -352,10 +352,15 @@ function classifyCodeRabbitRangeEvidence(selectedRecentReview, headSha) {
 }
 
 function codeRabbitRangeEvidenceStatements(content) {
-  const excludedRanges = markdownExcludedRanges(content);
-  const matches = [
-    ...content.matchAll(CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN),
-  ];
+  const markdownStructure = scanMarkdownStructure(content);
+  const excludedRanges = markdownStructure.excludedRanges;
+  const matches = mergeCodeRabbitRangeMatches(
+    [...content.matchAll(CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN)],
+    markdownTableRangeEvidenceMatches(
+      content,
+      markdownStructure.tableCellRanges,
+    ),
+  );
   const statementIndexes = matches.map(codeRabbitStatementIndex);
   const statements = [];
   let excludedRangeIndex = 0;
@@ -380,18 +385,88 @@ function codeRabbitRangeEvidenceStatements(content) {
       match,
       continuationEnd,
     );
-    if (statement) statements.push(statement);
+    if (statement) {
+      statement.insideTableCell = match.tableCell !== undefined;
+      statements.push(statement);
+    } else if (match.tableCell !== undefined) {
+      statements.push({
+        baseSegment: "",
+        insideTableCell: true,
+        statement: match[1] + match[2],
+        tableCell: match.tableCell,
+        tableContent: content,
+        tableEvidenceEnd: continuationEnd,
+        tableEvidenceStart: statementIndex,
+        tipToken: "",
+        trailingStatement: "",
+      });
+    }
   }
   return statements;
 }
 
-function markdownExcludedRanges(content) {
-  return scanMarkdownStructure(content).excludedRanges;
+function mergeCodeRabbitRangeMatches(globalMatches, tableMatches) {
+  const matches = [];
+  let globalIndex = 0;
+  let tableIndex = 0;
+  while (
+    globalIndex < globalMatches.length || tableIndex < tableMatches.length
+  ) {
+    const globalMatch = globalMatches[globalIndex];
+    const tableMatch = tableMatches[tableIndex];
+    if (globalMatch === undefined) {
+      matches.push(tableMatch);
+      tableIndex += 1;
+      continue;
+    }
+    if (tableMatch === undefined) {
+      matches.push(globalMatch);
+      globalIndex += 1;
+      continue;
+    }
+    const globalStatementIndex = codeRabbitStatementIndex(globalMatch);
+    const tableStatementIndex = codeRabbitStatementIndex(tableMatch);
+    if (globalStatementIndex === tableStatementIndex) {
+      globalMatch.tableCell = tableMatch.tableCell;
+      matches.push(globalMatch);
+      globalIndex += 1;
+      tableIndex += 1;
+    } else if (globalStatementIndex < tableStatementIndex) {
+      matches.push(globalMatch);
+      globalIndex += 1;
+    } else {
+      matches.push(tableMatch);
+      tableIndex += 1;
+    }
+  }
+  return matches;
+}
+
+function markdownTableRangeEvidenceMatches(content, tableCellRanges) {
+  const matches = [];
+  for (const tableCell of tableCellRanges) {
+    const { end: cellEnd, start: cellStart } = tableCell;
+    const cell = content.slice(cellStart, cellEnd);
+    for (
+      const match of cell.matchAll(
+        CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN,
+      )
+    ) {
+      match.index += cellStart;
+      match.tableCell = tableCell;
+      match.tableLocal = true;
+      matches.push(match);
+    }
+  }
+  return matches;
 }
 
 function hasExactVisibleMarkdownLine(content, expectedLine) {
-  const excludedRanges = markdownExcludedRanges(content);
+  const markdownStructure = scanMarkdownStructure(content);
+  const excludedRanges = markdownStructure.excludedRanges;
+  const tableCellRanges = markdownStructure.tableCellRanges;
   let excludedRangeIndex = 0;
+  let tableCellRangeIndex = 0;
   let lineStart = 0;
   for (const lineMatch of content.matchAll(/[^\r\n]*(?:\r\n|[\r\n]|$)/g)) {
     const line = lineMatch[0];
@@ -407,7 +482,15 @@ function hasExactVisibleMarkdownLine(content, expectedLine) {
     const excludedRange = excludedRanges[excludedRangeIndex];
     const isExcluded = excludedRange?.[0] <= lineStart &&
       lineStart < excludedRange[1];
-    if (!isExcluded && lineWithoutEnding === expectedLine) return true;
+    while (tableCellRanges[tableCellRangeIndex]?.end <= lineStart) {
+      tableCellRangeIndex += 1;
+    }
+    const tableCellRange = tableCellRanges[tableCellRangeIndex];
+    const isInsideTableCell = tableCellRange?.start <= lineStart &&
+      lineStart < tableCellRange.end;
+    if (
+      !isExcluded && !isInsideTableCell && lineWithoutEnding === expectedLine
+    ) return true;
     lineStart = lineEnd;
   }
   return false;
@@ -432,11 +515,16 @@ function visibleMarkdownMatches(content, patterns, excludedRanges) {
 function scanMarkdownStructure(content) {
   const ranges = [];
   const reviewMarkers = [];
-  const { inlineCodeRanges, inlineHtmlRanges, inlineLinkRanges } =
-    markdownInlineStructureRanges(content);
-  const inlineExcludedRanges = mergeMarkdownRanges(
+  const {
     inlineCodeRanges,
+    inlineHtmlRanges,
     inlineLinkRanges,
+    referenceDefinitionRanges,
+    tableCellRanges,
+  } = markdownInlineStructureRanges(content);
+  const inlineExcludedRanges = mergeMarkdownRanges(
+    mergeMarkdownRanges(inlineCodeRanges, inlineLinkRanges),
+    referenceDefinitionRanges,
   );
   let inlineCodeRangeIndex = 0;
   const isInsideInlineCode = (index) => {
@@ -629,11 +717,20 @@ function scanMarkdownStructure(content) {
   }
   const blockRanges = mergeMarkdownRanges(ranges, []);
   const refinedInlineRanges = blockRanges.length === 0
-    ? { inlineCodeRanges, inlineHtmlRanges, inlineLinkRanges }
+    ? {
+      inlineCodeRanges,
+      inlineHtmlRanges,
+      inlineLinkRanges,
+      referenceDefinitionRanges,
+      tableCellRanges,
+    }
     : markdownInlineStructureRanges(content, blockRanges);
   const refinedInlineExcludedRanges = mergeMarkdownRanges(
-    refinedInlineRanges.inlineCodeRanges,
-    refinedInlineRanges.inlineLinkRanges,
+    mergeMarkdownRanges(
+      refinedInlineRanges.inlineCodeRanges,
+      refinedInlineRanges.inlineLinkRanges,
+    ),
+    refinedInlineRanges.referenceDefinitionRanges,
   );
   return {
     excludedRanges: mergeMarkdownRanges(
@@ -644,6 +741,7 @@ function scanMarkdownStructure(content) {
       ),
     ),
     reviewMarkers,
+    tableCellRanges: refinedInlineRanges.tableCellRanges,
   };
 }
 
@@ -711,6 +809,7 @@ function markdownParagraphLineContext(line) {
     content: listPrefix === undefined
       ? remainingLine
       : remainingLine.slice(listPrefix.length),
+    contentOffset: containerPrefix.length + (listPrefix?.length ?? 0),
     indentation,
     listInterruptsParagraph: listPrefix === undefined
       ? false
@@ -915,20 +1014,30 @@ function markdownInlineStructureRanges(content, excludedRanges = []) {
   const inlineCodeRanges = [];
   const inlineHtmlRanges = [];
   const inlineLinkRanges = [];
+  const referenceDefinitionRanges = [];
   const excludedRangeCursor = { index: 0 };
   const lines = [];
   let nextLineStart = 0;
   for (const lineMatch of content.matchAll(/[^\r\n]*(?:\r\n|[\r\n]|$)/g)) {
     const line = lineMatch[0];
     if (line.length === 0 && nextLineStart >= content.length) break;
+    const contentWithoutEnding = line.replace(/(?:\r\n|[\r\n])$/, "");
     const end = nextLineStart + line.length;
     lines.push({
-      content: line.replace(/(?:\r\n|[\r\n])$/, ""),
+      content: contentWithoutEnding,
+      contentEnd: nextLineStart + contentWithoutEnding.length,
       end,
       start: nextLineStart,
     });
     nextLineStart = end;
   }
+  const tableStructure = markdownTableInlineStructure(
+    content,
+    lines,
+    excludedRanges,
+  );
+  const tableSplitRanges = tableStructure.splitRanges;
+  const tableSplitRangeCursor = { index: 0 };
 
   let segmentStart = 0;
   let openParagraph;
@@ -965,10 +1074,13 @@ function markdownInlineStructureRanges(content, excludedRanges = []) {
         inlineLinkRanges,
         excludedRanges,
         excludedRangeCursor,
+        tableSplitRanges,
+        tableSplitRangeCursor,
       );
       const finalDefinitionLine = lines[
         lineIndex + referenceDefinitionLineCount - 1
       ];
+      referenceDefinitionRanges.push([lineStart, finalDefinitionLine.end]);
       segmentStart = finalDefinitionLine.end;
       lineIndex += referenceDefinitionLineCount - 1;
       openParagraph = undefined;
@@ -992,6 +1104,8 @@ function markdownInlineStructureRanges(content, excludedRanges = []) {
         inlineLinkRanges,
         excludedRanges,
         excludedRangeCursor,
+        tableSplitRanges,
+        tableSplitRangeCursor,
       );
       if (paragraphAfterLine !== undefined && !indentedCodeLine) {
         segmentStart = lineStart;
@@ -1016,8 +1130,169 @@ function markdownInlineStructureRanges(content, excludedRanges = []) {
     inlineLinkRanges,
     excludedRanges,
     excludedRangeCursor,
+    tableSplitRanges,
+    tableSplitRangeCursor,
   );
-  return { inlineCodeRanges, inlineHtmlRanges, inlineLinkRanges };
+  return {
+    inlineCodeRanges,
+    inlineHtmlRanges,
+    inlineLinkRanges,
+    referenceDefinitionRanges,
+    tableCellRanges: tableStructure.cellRanges,
+  };
+}
+
+function markdownTableInlineStructure(content, lines, excludedRanges) {
+  const ranges = [];
+  const cellRanges = [];
+  let excludedRangeIndex = 0;
+  const lineIsExcluded = (line) => {
+    while (excludedRanges[excludedRangeIndex]?.[1] <= line.start) {
+      excludedRangeIndex += 1;
+    }
+    const range = excludedRanges[excludedRangeIndex];
+    return range?.[0] <= line.start && line.start < range[1];
+  };
+
+  for (let lineIndex = 1; lineIndex < lines.length; lineIndex += 1) {
+    const headerLine = lines[lineIndex - 1];
+    const delimiterLine = lines[lineIndex];
+    if (lineIsExcluded(headerLine) || lineIsExcluded(delimiterLine)) continue;
+    const headerContext = markdownParagraphLineContext(headerLine.content);
+    const delimiterContext = markdownParagraphLineContext(
+      delimiterLine.content,
+    );
+    if (
+      isMarkdownIndentedCodeLine(headerLine.content) ||
+      isMarkdownIndentedCodeLine(delimiterLine.content) ||
+      isMarkdownInlineCodeBarrier(headerContext.content) ||
+      !markdownTableContextsMatch(headerContext, delimiterContext)
+    ) continue;
+    const headerRow = markdownTableRow(content, headerLine, headerContext);
+    const delimiterRow = markdownTableRow(
+      content,
+      delimiterLine,
+      delimiterContext,
+    );
+    if (
+      delimiterRow.cellCount === 0 ||
+      headerRow.cellCount !== delimiterRow.cellCount ||
+      delimiterRow.pipeIndexes.length === 0 ||
+      !delimiterRow.cells.every((cell) => /^:?-+:?$/.test(cell.content.trim()))
+    ) continue;
+
+    appendMarkdownTableRowSplits(ranges, headerLine, headerRow.pipeIndexes);
+    let previousRowCells = appendAndLinkMarkdownTableCells(
+      cellRanges,
+      headerRow.cells,
+      [],
+    );
+    ranges.push([delimiterLine.start, delimiterLine.end]);
+    let bodyLineIndex = lineIndex + 1;
+    for (; bodyLineIndex < lines.length; bodyLineIndex += 1) {
+      const bodyLine = lines[bodyLineIndex];
+      if (lineIsExcluded(bodyLine) || bodyLine.content.trim().length === 0) {
+        break;
+      }
+      const bodyContext = markdownParagraphLineContext(bodyLine.content);
+      if (
+        isMarkdownIndentedCodeLine(bodyLine.content) ||
+        !markdownTableContextsMatch(headerContext, bodyContext) ||
+        isMarkdownInlineCodeBarrier(bodyContext.content)
+      ) break;
+      const bodyRow = markdownTableRow(content, bodyLine, bodyContext);
+      appendMarkdownTableRowSplits(ranges, bodyLine, bodyRow.pipeIndexes);
+      previousRowCells = appendAndLinkMarkdownTableCells(
+        cellRanges,
+        bodyRow.cells,
+        previousRowCells,
+      );
+    }
+    lineIndex = bodyLineIndex - 1;
+  }
+  return {
+    cellRanges,
+    splitRanges: mergeMarkdownRanges(ranges, []),
+  };
+}
+
+function markdownTableContextsMatch(header, row) {
+  if (
+    header.structuralPrefix !== row.structuralPrefix ||
+    header.blockquoteDepth !== row.blockquoteDepth ||
+    row.listContinuationIndent !== undefined
+  ) return false;
+  const continuationIndent = header.listContinuationIndent ??
+    header.indentation;
+  return row.indentation >= continuationIndent &&
+    row.indentation <= continuationIndent + 3;
+}
+
+function markdownTableRow(content, line, context) {
+  const start = line.start + context.contentOffset;
+  const pipeIndexes = [];
+  for (let index = start; index < line.contentEnd; index += 1) {
+    if (
+      content[index] === "|" && !isEscapedMarkdownToken(content, index)
+    ) pipeIndexes.push(index);
+  }
+  const cellRanges = [];
+  let cellStart = start;
+  for (const pipeIndex of pipeIndexes) {
+    cellRanges.push([cellStart, pipeIndex]);
+    cellStart = pipeIndex + 1;
+  }
+  cellRanges.push([cellStart, line.contentEnd]);
+  if (
+    pipeIndexes.length > 0 &&
+    content.slice(...cellRanges[0]).trim().length === 0
+  ) cellRanges.shift();
+  const finalPipe = pipeIndexes.at(-1);
+  if (
+    finalPipe !== undefined &&
+    content.slice(finalPipe + 1, line.contentEnd).trim().length === 0
+  ) cellRanges.pop();
+  const cells = cellRanges.map(([start, end]) => ({
+    content: content.slice(start, end),
+    end,
+    rowEnd: line.contentEnd,
+    start,
+  }));
+  return {
+    cellCount: cells.length,
+    cells,
+    pipeIndexes,
+  };
+}
+
+function appendMarkdownTableRowSplits(ranges, line, pipeIndexes) {
+  ranges.push([line.start, line.start]);
+  for (const pipeIndex of pipeIndexes) {
+    ranges.push([pipeIndex, pipeIndex + 1]);
+  }
+  ranges.push([line.contentEnd, line.end]);
+}
+
+function appendAndLinkMarkdownTableCells(
+  allCells,
+  rowCells,
+  previousRowCells,
+) {
+  const firstCell = rowCells[0];
+  if (firstCell !== undefined) {
+    for (const previousCell of previousRowCells) {
+      previousCell.nextRowFirstCell = firstCell;
+    }
+    const previousFinalCell = previousRowCells.at(-1);
+    if (previousFinalCell !== undefined) {
+      previousFinalCell.nextTableCell = firstCell;
+    }
+  }
+  for (const [columnIndex, cell] of rowCells.entries()) {
+    cell.nextTableCell = rowCells[columnIndex + 1];
+    allCells.push(cell);
+  }
+  return rowCells;
 }
 
 function isMarkdownInlineCodeBarrier(line) {
@@ -1258,6 +1533,8 @@ function appendMarkdownInlineCodeRanges(
   inlineLinkRanges,
   excludedRanges,
   excludedRangeCursor,
+  splitRanges,
+  splitRangeCursor,
 ) {
   let segmentStart = start;
   let excludedIndex = excludedRangeCursor.index;
@@ -1268,13 +1545,15 @@ function appendMarkdownInlineCodeRanges(
     const [excludedStart, excludedEnd] = excludedRanges[excludedIndex];
     if (excludedStart >= end) break;
     if (segmentStart < excludedStart) {
-      appendMarkdownInlineCodeRangesInSegment(
+      appendMarkdownInlineCodeRangesAcrossSplits(
         content,
         segmentStart,
         Math.min(excludedStart, end),
         inlineCodeRanges,
         inlineHtmlRanges,
         inlineLinkRanges,
+        splitRanges,
+        splitRangeCursor,
       );
     }
     segmentStart = Math.max(segmentStart, excludedEnd);
@@ -1289,6 +1568,51 @@ function appendMarkdownInlineCodeRanges(
     }
   }
   excludedRangeCursor.index = excludedIndex;
+  if (segmentStart < end) {
+    appendMarkdownInlineCodeRangesAcrossSplits(
+      content,
+      segmentStart,
+      end,
+      inlineCodeRanges,
+      inlineHtmlRanges,
+      inlineLinkRanges,
+      splitRanges,
+      splitRangeCursor,
+    );
+  }
+}
+
+function appendMarkdownInlineCodeRangesAcrossSplits(
+  content,
+  start,
+  end,
+  inlineCodeRanges,
+  inlineHtmlRanges,
+  inlineLinkRanges,
+  splitRanges,
+  splitRangeCursor,
+) {
+  let segmentStart = start;
+  let splitIndex = splitRangeCursor.index;
+  while (splitRanges[splitIndex]?.[1] <= segmentStart) splitIndex += 1;
+  while (splitIndex < splitRanges.length) {
+    const [splitStart, splitEnd] = splitRanges[splitIndex];
+    if (splitStart >= end) break;
+    if (segmentStart < splitStart) {
+      appendMarkdownInlineCodeRangesInSegment(
+        content,
+        segmentStart,
+        splitStart,
+        inlineCodeRanges,
+        inlineHtmlRanges,
+        inlineLinkRanges,
+      );
+    }
+    segmentStart = Math.max(segmentStart, splitEnd);
+    splitIndex += 1;
+    if (segmentStart >= end) break;
+  }
+  splitRangeCursor.index = splitIndex;
   if (segmentStart < end) {
     appendMarkdownInlineCodeRangesInSegment(
       content,
@@ -1896,7 +2220,12 @@ function codeRabbitStatementIndex(match) {
 
 function parseCodeRabbitRangeStatement(content, match, continuationEnd) {
   const statementStart = match[1];
-  const firstLineTail = match[2];
+  const firstLineTail = match.tableLocal
+    ? match[2] + content.slice(
+      match.tableCell.end,
+      Math.min(match.tableCell.rowEnd, continuationEnd),
+    )
+    : match[2];
   const statementPrefix = codeRabbitMarkdownPrefixSignature(
     statementStart.slice(
       0,
@@ -1921,9 +2250,17 @@ function parseCodeRabbitRangeStatement(content, match, continuationEnd) {
   const baseLines = [firstLineTail];
   const statementParts = [statementStart + firstLineTail];
   let lineEnd = match.index + match[0].length;
+  let tableContinuationCell = match.tableCell?.nextRowFirstCell;
   while (true) {
-    const nextLine = codeRabbitNextLine(content, lineEnd, continuationEnd);
+    const nextLine = match.tableCell !== undefined
+      ? codeRabbitNextTableCell(
+        content,
+        tableContinuationCell,
+        continuationEnd,
+      )
+      : codeRabbitNextLine(content, lineEnd, continuationEnd);
     if (!nextLine) return undefined;
+    tableContinuationCell = nextLine.nextTableCell;
     const continuationPrefix = nextLine.content.match(
       CODERABBIT_REVIEW_RANGE_CONTINUATION_PREFIX_PATTERN,
     )?.[0] ?? "";
@@ -1974,6 +2311,17 @@ function parseCodeRabbitRangeStatement(content, match, continuationEnd) {
     baseLines.push(continuationContent);
     lineEnd = nextLine.lineEnd;
   }
+}
+
+function codeRabbitNextTableCell(content, cell, continuationEnd) {
+  if (cell === undefined || cell.start >= continuationEnd) return undefined;
+  const cellEnd = Math.min(cell.end, continuationEnd);
+  return {
+    content: content.slice(cell.start, cellEnd),
+    lineEnd: cellEnd,
+    nextTableCell: cell.nextTableCell,
+    separator: "\n",
+  };
 }
 
 function codeRabbitMarkdownPrefixSignature(prefix) {
@@ -2085,15 +2433,54 @@ function parseCodeRabbitRangeEvidence(evidence, headSha) {
     ...evidence.trailingStatement.matchAll(FULL_COMMIT_TOKEN_PATTERN),
   ].map((match) => match[2].toLowerCase());
   const exactMatch = evidence.statement.match(CODERABBIT_REVIEW_RANGE_PATTERN);
+  const tableExtraHasHead = tableEvidenceHasCommit(
+    evidence,
+    normalizedHeadSha,
+  );
   return {
     tipIsHead: evidence.tipToken === normalizedHeadSha,
-    extraHasHead: extraTokens.includes(normalizedHeadSha),
-    isExactProduction:
+    extraHasHead: tableExtraHasHead || extraTokens.includes(normalizedHeadSha),
+    isExactProduction: !evidence.insideTableCell &&
       exactMatch?.[1]?.toLowerCase() === evidence.baseSegment &&
       exactMatch?.[2]?.toLowerCase() === evidence.tipToken &&
       FULL_COMMIT_PATTERN.test(evidence.baseSegment) &&
       extraTokens.length === 0,
   };
+}
+
+function tableEvidenceHasCommit(evidence, commit) {
+  if (evidence.tableCell === undefined) return false;
+  if (
+    markdownRangeHasCommit(
+      evidence.tableContent,
+      evidence.tableEvidenceStart,
+      Math.min(evidence.tableCell.rowEnd, evidence.tableEvidenceEnd),
+      commit,
+    )
+  ) return true;
+
+  let cell = evidence.tableCell.nextRowFirstCell;
+  while (cell !== undefined && cell.start < evidence.tableEvidenceEnd) {
+    if (
+      markdownRangeHasCommit(
+        evidence.tableContent,
+        cell.start,
+        Math.min(cell.end, evidence.tableEvidenceEnd),
+        commit,
+      )
+    ) return true;
+    cell = cell.nextTableCell;
+  }
+  return false;
+}
+
+function markdownRangeHasCommit(content, start, end, commit) {
+  for (
+    const match of content.slice(start, end).matchAll(FULL_COMMIT_TOKEN_PATTERN)
+  ) {
+    if (match[2].toLowerCase() === commit) return true;
+  }
+  return false;
 }
 
 /** Publish the current automated-review decision on the exact PR head SHA. */

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -8,7 +8,7 @@ const CODERABBIT_RECENT_REVIEW_END_MARKER = "<!-- recent_review_end -->";
 const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
   "No actionable comments were generated in the recent review.";
 const CODERABBIT_REVIEW_RANGE_PATTERN =
-  /Reviewing files(?:\s+that changed from the base of the PR and)?\s+between\s+([0-9a-f]{40})\s+and\s+([0-9a-f]{40})(?:\.|\s|$)/i;
+  /(?:^|\r?\n)Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r?\n|$)/;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
   /Requested commit:\s*([0-9a-f]{40})/i;
 const CODERABBIT_SKIPPED_COMMIT_PATTERN =

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -22,7 +22,9 @@ const CODERABBIT_REVIEW_RANGE_WRAPPED_SEPARATOR_PATTERN =
   /^[ \t]*and[ \t]+([0-9a-f]{40})(?![0-9a-f])/i;
 const FULL_COMMIT_TOKEN_PATTERN = /(^|[^0-9a-f])([0-9a-f]{40})(?![0-9a-f])/gi;
 const MARKDOWN_FENCE_LINE_PATTERN =
-  /^[ \t]{0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*(`{3,}|~{3,})/;
+  /^([ \t]{0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*)(`{3,}|~{3,})/;
+const MARKDOWN_LIST_PREFIX_PATTERN =
+  /([-*+]|\d+[.)])([ \t]+)(?:\[[ xX]\][ \t]+)?/g;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
   /Requested commit:\s*([0-9a-f]{40})/gi;
 const CODERABBIT_SKIPPED_COMMIT_PATTERN =
@@ -493,10 +495,17 @@ function markdownFenceRanges(content) {
     const line = lineMatch[0];
     if (line.length === 0 && lineStart >= content.length) break;
     const lineEnd = lineStart + line.length;
+    const lineWithoutEnding = line.replace(/\r?\n$/, "");
+    if (
+      openFence !== undefined &&
+      !continuesMarkdownFenceContainer(lineWithoutEnding, openFence.container)
+    ) {
+      ranges.push([openFence.start, lineStart]);
+      openFence = undefined;
+    }
     const fenceMatch = line.match(MARKDOWN_FENCE_LINE_PATTERN);
     if (fenceMatch) {
-      const marker = fenceMatch[1];
-      const lineWithoutEnding = line.replace(/\r?\n$/, "");
+      const marker = fenceMatch[2];
       const markerEnd = lineWithoutEnding.indexOf(marker) + marker.length;
       const hasOnlyClosingFenceWhitespace = /^[ \t]*$/.test(
         lineWithoutEnding.slice(markerEnd),
@@ -506,6 +515,7 @@ function markdownFenceRanges(content) {
           char: marker[0],
           length: marker.length,
           start: lineStart,
+          container: markdownFenceContainer(fenceMatch[1]),
         };
       } else if (
         marker[0] === openFence.char && marker.length >= openFence.length &&
@@ -519,6 +529,34 @@ function markdownFenceRanges(content) {
   }
   if (openFence !== undefined) ranges.push([openFence.start, content.length]);
   return ranges;
+}
+
+function markdownFenceContainer(prefix) {
+  const listPrefixes = [...prefix.matchAll(MARKDOWN_LIST_PREFIX_PATTERN)];
+  return {
+    structuralPrefix: codeRabbitMarkdownPrefixSignature(
+      prefix.replace(MARKDOWN_LIST_PREFIX_PATTERN, ""),
+    ),
+    continuationIndent: listPrefixes.length === 0
+      ? 0
+      : prefix.length - (prefix.lastIndexOf(">") + 1),
+  };
+}
+
+function continuesMarkdownFenceContainer(line, container) {
+  if (
+    container.structuralPrefix.length === 0 &&
+    container.continuationIndent === 0
+  ) return true;
+  const linePrefix = line.match(
+    CODERABBIT_REVIEW_RANGE_CONTINUATION_PREFIX_PATTERN,
+  )?.[0] ?? "";
+  if (
+    codeRabbitMarkdownPrefixSignature(linePrefix) !==
+      container.structuralPrefix
+  ) return false;
+  return (linePrefix.match(/[ \t]*$/)?.[0].length ?? 0) >=
+    container.continuationIndent;
 }
 
 function parseCodeRabbitRangeEvidence(evidence, headSha) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -9,8 +9,10 @@ const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
   "No actionable comments were generated in the recent review.";
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r\n|[\r\n])Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r\n|[\r\n]|$)/;
-const CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN =
-  /(?<![A-Za-z0-9])(?=(Reviewing\b))/gi;
+const CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN = new RegExp(
+  `(?=(${markdownAsciiWordPattern("Reviewing")}))`,
+  "gi",
+);
 const CODERABBIT_REVIEW_RANGE_BASE_INTRO_PATTERN =
   /^(?:files(?: that changed from the base of the pr)?|changed files(?: from the base of the pr)?)(?: and)? between(?: |$)/;
 const CODERABBIT_REVIEW_RANGE_CONTINUATION_PREFIX_PATTERN =
@@ -35,6 +37,59 @@ const MARKDOWN_PARAGRAPH_INTERRUPTING_RAW_HTML_PATTERN =
 const MARKDOWN_PARAGRAPH_INTERRUPTING_HTML_SYNTAX_PATTERN =
   /^ {0,3}(?:<!--|<\?|<![A-Za-z]|<!\[CDATA\[)/;
 const MARKDOWN_FENCE_CONTAINER_CONTINUATION_PATTERN = /^[ \t]*(?:>[ \t]*)*/;
+const MARKDOWN_CHARACTER_REFERENCE_PATTERN =
+  /&#(?:[xX][0-9A-Fa-f]{1,6}|[0-9]{1,7});|&[A-Za-z][A-Za-z0-9]{1,31};/g;
+const MARKDOWN_CHARACTER_REFERENCE_AT_END_PATTERN =
+  /(?:&#(?:[xX][0-9A-Fa-f]{1,6}|[0-9]{1,7});|&[A-Za-z][A-Za-z0-9]{1,31};)$/;
+const MARKDOWN_NAMED_CHARACTER_REFERENCE_NORMALIZATIONS = new Map([
+  ["&Tab;", " "],
+  ["&NewLine;", " "],
+  ["&nbsp;", " "],
+  ["&NonBreakingSpace;", " "],
+  ["&ensp;", " "],
+  ["&emsp;", " "],
+  ["&emsp13;", " "],
+  ["&emsp14;", " "],
+  ["&numsp;", " "],
+  ["&puncsp;", " "],
+  ["&thinsp;", " "],
+  ["&ThinSpace;", " "],
+  ["&hairsp;", " "],
+  ["&VeryThinSpace;", " "],
+  ["&MediumSpace;", " "],
+  ["&ThickSpace;", " "],
+  ["&NegativeMediumSpace;", ""],
+  ["&NegativeThickSpace;", ""],
+  ["&NegativeThinSpace;", ""],
+  ["&NegativeVeryThinSpace;", ""],
+  ["&ZeroWidthSpace;", ""],
+  ["&NoBreak;", ""],
+  ["&ApplyFunction;", ""],
+  ["&InvisibleTimes;", ""],
+  ["&InvisibleComma;", ""],
+  ["&af;", ""],
+  ["&it;", ""],
+  ["&ic;", ""],
+  ["&zwj;", ""],
+  ["&zwnj;", ""],
+  ["&shy;", ""],
+  ["&lrm;", ""],
+  ["&rlm;", ""],
+  ["&period;", "."],
+]);
+const MARKDOWN_INVISIBLE_CHARACTER_REFERENCE_CODE_POINTS = new Set([
+  0x00ad,
+  0x200b,
+  0x200c,
+  0x200d,
+  0x200e,
+  0x200f,
+  0x2060,
+  0x2061,
+  0x2062,
+  0x2063,
+  0xfeff,
+]);
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
   /Requested commit:[ \t]*([0-9a-f]{40})/gi;
 const CODERABBIT_SKIPPED_COMMIT_PATTERN =
@@ -2411,6 +2466,59 @@ function isEscapedMarkdownToken(content, tokenStart) {
   return (tokenStart - slashStart) % 2 === 1;
 }
 
+function markdownAsciiWordPattern(word) {
+  return Array.from(word, (character) => {
+    const codes = new Set([
+      character.toLowerCase().charCodeAt(0),
+      character.toUpperCase().charCodeAt(0),
+    ]);
+    const references = [...codes].flatMap((code) => {
+      const decimal = String(code);
+      const hexadecimal = code.toString(16);
+      return [
+        `&#0{0,${7 - decimal.length}}${decimal};`,
+        `&#[xX]0{0,${6 - hexadecimal.length}}${hexadecimal};`,
+      ];
+    });
+    return `(?:${character}|${references.join("|")})`;
+  }).join("");
+}
+
+function decodeMarkdownCharacterReferences(value) {
+  return value.replace(MARKDOWN_CHARACTER_REFERENCE_PATTERN, (reference) => {
+    const named = MARKDOWN_NAMED_CHARACTER_REFERENCE_NORMALIZATIONS.get(
+      reference,
+    );
+    if (named !== undefined) return named;
+    if (!reference.startsWith("&#")) return reference;
+    const hexadecimal = reference[2] === "x" || reference[2] === "X";
+    const digits = reference.slice(hexadecimal ? 3 : 2, -1);
+    const codePoint = Number.parseInt(digits, hexadecimal ? 16 : 10);
+    if (
+      codePoint > 0x10ffff ||
+      (codePoint >= 0xd800 && codePoint <= 0xdfff)
+    ) return reference;
+    if (MARKDOWN_INVISIBLE_CHARACTER_REFERENCE_CODE_POINTS.has(codePoint)) {
+      return "";
+    }
+    const decoded = String.fromCodePoint(codePoint);
+    if (/\s/u.test(decoded)) return " ";
+    return codePoint >= 32 && codePoint <= 126 ? decoded : reference;
+  });
+}
+
+function codeRabbitPreviousVisibleCharacterIsWord(content, index) {
+  if (index === 0) return false;
+  const prefix = content.slice(Math.max(0, index - 40), index);
+  const reference = prefix.match(
+    MARKDOWN_CHARACTER_REFERENCE_AT_END_PATTERN,
+  )?.[0];
+  const previous = reference === undefined
+    ? content[index - 1]
+    : decodeMarkdownCharacterReferences(reference).at(-1);
+  return previous !== undefined && /[A-Za-z0-9]/.test(previous);
+}
+
 function codeRabbitStatementIndex(match) {
   return match.index;
 }
@@ -2422,21 +2530,27 @@ function parseCodeRabbitRangeStatement(
   nextStatementIndex,
   paragraphContinuationLineStarts,
 ) {
-  const statementPhrase = match[1];
-  const statementEnd = match.index + statementPhrase.length;
+  const rawStatementPhrase = match[1];
+  if (
+    codeRabbitPreviousVisibleCharacterIsWord(content, match.index) ||
+    decodeMarkdownCharacterReferences(rawStatementPhrase).toLowerCase() !==
+      "reviewing"
+  ) return undefined;
+  const statementEnd = match.index + rawStatementPhrase.length;
   const statementDecoration = match.index === match.lineStart ? "" : " ";
-  const statementStart = statementDecoration + statementPhrase;
+  const statementStart = statementDecoration + rawStatementPhrase;
   const firstLineEnd = Math.min(
     match.tableLocal ? match.tableCell.end : match.lineEnd,
     nextStatementIndex,
   );
-  let firstLineTail = content.slice(statementEnd, firstLineEnd);
+  let rawFirstLineTail = content.slice(statementEnd, firstLineEnd);
   if (match.tableLocal && nextStatementIndex > match.tableCell.end) {
-    firstLineTail += content.slice(
+    rawFirstLineTail += content.slice(
       match.tableCell.end,
       Math.min(match.tableCell.rowEnd, nextStatementIndex),
     );
   }
+  const firstLineTail = decodeMarkdownCharacterReferences(rawFirstLineTail);
   const statementPrefix = codeRabbitRangeContainerSignature(
     match.tableCell === undefined ? match.linePrefix : "",
   );
@@ -2451,7 +2565,7 @@ function parseCodeRabbitRangeStatement(
     if (baseSegment === undefined) return undefined;
     return {
       baseSegment,
-      statement: statementStart + firstLineTail,
+      statement: statementStart + rawFirstLineTail,
       tipToken: sameLineSeparator[2].toLowerCase(),
       trailingStatement: firstLineTail.slice(
         sameLineSeparator.index + sameLineSeparator[0].length,
@@ -2460,7 +2574,7 @@ function parseCodeRabbitRangeStatement(
   }
 
   const baseLines = [firstLineTail];
-  const statementParts = [statementStart + firstLineTail];
+  const statementParts = [statementStart + rawFirstLineTail];
   let lineEnd = match.tableLocal ? match.tableCell.end : match.lineEnd;
   let tableContinuationCell = match.tableCell?.nextRowFirstCell;
   while (true) {
@@ -2476,12 +2590,15 @@ function parseCodeRabbitRangeStatement(
     const continuationPrefix = nextLine.content.match(
       CODERABBIT_REVIEW_RANGE_CONTINUATION_PREFIX_PATTERN,
     )?.[0] ?? "";
-    const continuationContent = nextLine.content.slice(
+    const rawContinuationContent = nextLine.content.slice(
       continuationPrefix.length,
     );
+    const continuationContent = decodeMarkdownCharacterReferences(
+      rawContinuationContent,
+    );
     if (
-      continuationContent.trim().length === 0 ||
-      continuationContent.trimStart().startsWith("<!--") ||
+      rawContinuationContent.trim().length === 0 ||
+      rawContinuationContent.trimStart().startsWith("<!--") ||
       (codeRabbitRangeContainerSignature(continuationPrefix) !==
           statementPrefix &&
         (match.tableCell !== undefined ||

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -415,6 +415,9 @@ function codeRabbitRangeEvidenceStatements(content) {
   const inlineLinkRanges = markdownStructure.inlineLinkRanges;
   const paragraphContinuationLineStarts =
     markdownStructure.paragraphContinuationLineStarts;
+  const inlineDecorationTokenIndexes = markdownInlineDecorationTokenIndexes(
+    content,
+  );
   const matches = mergeCodeRabbitRangeMatches(
     [...content.matchAll(CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN)],
     markdownTableRangeEvidenceMatches(
@@ -424,11 +427,8 @@ function codeRabbitRangeEvidenceStatements(content) {
   );
   assignCodeRabbitMatchLineBounds(content, matches);
   const normalizationContexts = new Map();
-  const reviewingMatches = matches.filter((match) => {
-    const rangeStart = match.tableLocal
-      ? match.tableCell.start
-      : match.lineStart;
-    const rangeEnd = match.tableLocal ? match.tableCell.end : match.lineEnd;
+  const nextRawStatementAfterLine = new Map();
+  const normalizationContextFor = (rangeStart, rangeEnd) => {
     const contextKey = `${rangeStart}:${rangeEnd}`;
     let normalizationContext = normalizationContexts.get(contextKey);
     if (normalizationContext === undefined) {
@@ -439,13 +439,73 @@ function codeRabbitRangeEvidenceStatements(content) {
       );
       normalizationContexts.set(contextKey, normalizationContext);
     }
-    const phraseEnd = markdownVisibleAsciiWordEnd(
+    return normalizationContext;
+  };
+  const reviewingMatches = matches.filter((match, matchIndex) => {
+    const rangeStart = match.tableLocal
+      ? match.tableCell.start
+      : match.lineStart;
+    const rangeEnd = match.tableLocal ? match.tableCell.end : match.lineEnd;
+    const lineNormalizationContext = normalizationContextFor(
+      rangeStart,
+      rangeEnd,
+    );
+    let phraseNormalizationContext = lineNormalizationContext;
+    let phraseNormalizationEnd = rangeEnd;
+    let phraseEnd = markdownVisibleAsciiWordEnd(
       content,
       match.index,
       rangeEnd,
       "Reviewing",
-      normalizationContext,
+      phraseNormalizationContext,
     );
+    if (
+      phraseEnd === undefined && !match.tableLocal &&
+      markdownIndexesIntersectRange(
+        inlineDecorationTokenIndexes,
+        match.index,
+        rangeEnd,
+      )
+    ) {
+      let nextRawStatementIndex = nextRawStatementAfterLine.get(rangeEnd);
+      if (nextRawStatementIndex === undefined) {
+        let nextMatchIndex = matchIndex + 1;
+        while (
+          matches[nextMatchIndex] !== undefined &&
+          codeRabbitStatementIndex(matches[nextMatchIndex]) < rangeEnd
+        ) {
+          nextMatchIndex += 1;
+        }
+        nextRawStatementIndex = matches[nextMatchIndex] === undefined
+          ? content.length
+          : codeRabbitStatementIndex(matches[nextMatchIndex]);
+        nextRawStatementAfterLine.set(rangeEnd, nextRawStatementIndex);
+      }
+      const nextBarrier = continuationBarrierRanges[
+        firstMarkdownRangeEndingAfter(
+          continuationBarrierRanges,
+          match.index,
+        )
+      ];
+      const extendedEnd = Math.min(
+        nextRawStatementIndex,
+        nextBarrier?.[0] ?? content.length,
+      );
+      if (extendedEnd > rangeEnd) {
+        phraseNormalizationContext = normalizationContextFor(
+          match.lineStart,
+          extendedEnd,
+        );
+        phraseNormalizationEnd = extendedEnd;
+        phraseEnd = markdownVisibleAsciiWordEnd(
+          content,
+          match.index,
+          extendedEnd,
+          "Reviewing",
+          phraseNormalizationContext,
+        );
+      }
+    }
     if (
       phraseEnd === undefined ||
       markdownRangesIntersect(
@@ -455,9 +515,11 @@ function codeRabbitRangeEvidenceStatements(content) {
       ) ||
       codeRabbitPreviousVisibleCharacterIsWord(
         match.index,
-        normalizationContext,
+        lineNormalizationContext,
       )
     ) return false;
+    match.normalizationContext = phraseNormalizationContext;
+    match.normalizationContextEnd = phraseNormalizationEnd;
     match.statementPhraseEnd = phraseEnd;
     return true;
   });
@@ -1997,6 +2059,7 @@ function appendMarkdownInlineCodeRangesInSegment(
   inlineCodeRanges,
   inlineHtmlRanges,
   inlineLinkRanges,
+  inlineDelimiterEnds,
 ) {
   const delimiterRuns = [];
   for (let index = start; index < end;) {
@@ -2044,6 +2107,7 @@ function appendMarkdownInlineCodeRangesInSegment(
     nextRunWithLength,
     findHtmlTerminator,
     findInlineLinkTailEnd,
+    inlineDelimiterEnds,
   );
   inlineLinkRanges.push(...segmentInlineLinkRanges);
   let inlineLinkRangeIndex = 0;
@@ -2124,6 +2188,11 @@ function appendMarkdownInlineCodeRangesInSegment(
       delimiter.start,
       delimiterRuns[closingIndex].end,
     ]);
+    inlineDelimiterEnds?.set(delimiter.start, delimiter.end);
+    inlineDelimiterEnds?.set(
+      delimiterRuns[closingIndex].start,
+      delimiterRuns[closingIndex].end,
+    );
     cursor = delimiterRuns[closingIndex].end;
     delimiterIndex = closingIndex + 1;
   }
@@ -2137,6 +2206,7 @@ function markdownInlineLinkRanges(
   nextRunWithLength,
   findHtmlTerminator,
   findInlineLinkTailEnd,
+  inlineDelimiterEnds,
 ) {
   const ranges = [];
   const labelOpeners = [];
@@ -2212,6 +2282,8 @@ function markdownInlineLinkRanges(
     }
 
     ranges.push([tailStart, tailEnd]);
+    inlineDelimiterEnds?.set(labelOpener.start, labelOpener.start + 1);
+    inlineDelimiterEnds?.set(cursor, tailEnd);
     if (!labelOpener.image) labelOpeners.length = 0;
     cursor = tailEnd;
   }
@@ -2633,8 +2705,10 @@ function markdownInlineDecorationEnd(
   end,
   normalizationContext,
 ) {
+  const character = content[index];
+  if (character !== "<" && !"*_~[]`".includes(character)) return undefined;
   if (isEscapedMarkdownToken(content, index)) return undefined;
-  if (content[index] === "<") {
+  if (character === "<") {
     return markdownInlineHtmlEnd(
       content,
       index,
@@ -2642,16 +2716,11 @@ function markdownInlineDecorationEnd(
       normalizationContext.findHtmlTerminator,
     );
   }
-  if (content[index] === "]" && content[index + 1] === "(") {
-    return normalizationContext.findInlineLinkTailEnd(index + 2);
-  }
-  if (!"*_~[]`".includes(content[index])) return undefined;
-  let runEnd = index + 1;
-  while (runEnd < end && content[runEnd] === content[index]) runEnd += 1;
-  return runEnd;
+  return normalizationContext.findDelimiterEnd(index);
 }
 
 function markdownInlineNormalizationContext(content, start, end) {
+  let delimiterEnds;
   let inlineLinkTailEndFinder;
   let previousVisibleCharacters;
   const context = {
@@ -2664,6 +2733,14 @@ function markdownInlineNormalizationContext(content, start, end) {
       );
       return inlineLinkTailEndFinder(tailStart);
     },
+    findDelimiterEnd: (index) => {
+      delimiterEnds ??= markdownInlineDelimiterEnds(
+        content,
+        start,
+        end,
+      );
+      return delimiterEnds.get(index);
+    },
     previousVisibleCharacter: (index) => {
       previousVisibleCharacters ??= markdownVisiblePreviousCharacters(
         content,
@@ -2675,6 +2752,160 @@ function markdownInlineNormalizationContext(content, start, end) {
     },
   };
   return context;
+}
+
+function markdownInlineDelimiterEnds(content, start, end) {
+  const delimiterEnds = new Map();
+  const inlineCodeRanges = [];
+  const inlineHtmlRanges = [];
+  const inlineLinkTailRanges = [];
+  appendMarkdownInlineCodeRangesInSegment(
+    content,
+    start,
+    end,
+    inlineCodeRanges,
+    inlineHtmlRanges,
+    inlineLinkTailRanges,
+    delimiterEnds,
+  );
+
+  const hiddenRanges = mergeMarkdownRanges(
+    mergeMarkdownRanges(inlineCodeRanges, inlineHtmlRanges),
+    inlineLinkTailRanges,
+  );
+  const emphasisRuns = markdownInlineEmphasisRuns(
+    content,
+    start,
+    end,
+    hiddenRanges,
+  );
+  const openerStacks = new Map();
+  for (const run of emphasisRuns) {
+    const key = run.character;
+    const openers = openerStacks.get(key) ?? [];
+    let closerConsumed = 0;
+    if (run.canClose) {
+      while (closerConsumed < run.length) {
+        const closerRemaining = run.length - closerConsumed;
+        let openerIndex = openers.length - 1;
+        while (
+          openerIndex >= 0 &&
+          !markdownInlineEmphasisRunsMayPair(
+            openers[openerIndex],
+            run,
+            closerRemaining,
+          )
+        ) {
+          openerIndex -= 1;
+        }
+        if (openerIndex < 0) break;
+        const opener = openers[openerIndex];
+        const delimiterLength = run.character === "~"
+          ? closerRemaining
+          : opener.remaining >= 2 && closerRemaining >= 2
+          ? 2
+          : 1;
+        const openerDelimiterStart = opener.start + opener.remaining -
+          delimiterLength;
+        delimiterEnds.set(
+          openerDelimiterStart,
+          openerDelimiterStart + delimiterLength,
+        );
+        delimiterEnds.set(
+          run.start + closerConsumed,
+          run.start + closerConsumed + delimiterLength,
+        );
+        opener.remaining -= delimiterLength;
+        closerConsumed += delimiterLength;
+        if (opener.remaining === 0) openers.splice(openerIndex, 1);
+      }
+    }
+    if (run.canOpen && closerConsumed < run.length) {
+      openers.push({
+        ...run,
+        remaining: run.length - closerConsumed,
+        start: run.start + closerConsumed,
+      });
+    }
+    openerStacks.set(key, openers);
+  }
+  return delimiterEnds;
+}
+
+function markdownInlineEmphasisRuns(content, start, end, hiddenRanges) {
+  const runs = [];
+  let hiddenRangeIndex = 0;
+  for (let cursor = start; cursor < end;) {
+    while (hiddenRanges[hiddenRangeIndex]?.[1] <= cursor) {
+      hiddenRangeIndex += 1;
+    }
+    const hiddenRange = hiddenRanges[hiddenRangeIndex];
+    if (hiddenRange?.[0] <= cursor && cursor < hiddenRange[1]) {
+      cursor = hiddenRange[1];
+      continue;
+    }
+    if (content[cursor] === "\\" && cursor + 1 < end) {
+      cursor += 2;
+      continue;
+    }
+    const character = content[cursor];
+    if (character !== "*" && character !== "_" && character !== "~") {
+      cursor += 1;
+      continue;
+    }
+    let runEnd = cursor + 1;
+    while (runEnd < end && content[runEnd] === character) runEnd += 1;
+    const length = runEnd - cursor;
+    if (character !== "~" || length <= 2) {
+      const previous = cursor > start ? content[cursor - 1] : undefined;
+      const next = runEnd < end ? content[runEnd] : undefined;
+      const previousWhitespace = markdownCharacterIsWhitespace(previous);
+      const nextWhitespace = markdownCharacterIsWhitespace(next);
+      const previousPunctuation = markdownCharacterIsPunctuation(previous);
+      const nextPunctuation = markdownCharacterIsPunctuation(next);
+      const leftFlanking = !nextWhitespace &&
+        (!nextPunctuation || previousWhitespace || previousPunctuation);
+      const rightFlanking = !previousWhitespace &&
+        (!previousPunctuation || nextWhitespace || nextPunctuation);
+      runs.push({
+        canClose: character === "_"
+          ? rightFlanking && (!leftFlanking || nextPunctuation)
+          : rightFlanking,
+        canOpen: character === "_"
+          ? leftFlanking && (!rightFlanking || previousPunctuation)
+          : leftFlanking,
+        character,
+        end: runEnd,
+        length,
+        start: cursor,
+      });
+    }
+    cursor = runEnd;
+  }
+  return runs;
+}
+
+function markdownInlineEmphasisRunsMayPair(
+  opener,
+  closer,
+  closerRemaining,
+) {
+  if (opener.end >= closer.start) return false;
+  if (
+    opener.character === "~" && opener.remaining !== closerRemaining
+  ) return false;
+  if (!(opener.canClose || closer.canOpen)) return true;
+  const lengthSum = opener.remaining + closerRemaining;
+  return lengthSum % 3 !== 0 ||
+    (opener.remaining % 3 === 0 && closerRemaining % 3 === 0);
+}
+
+function markdownCharacterIsWhitespace(character) {
+  return character === undefined || /\s/u.test(character);
+}
+
+function markdownCharacterIsPunctuation(character) {
+  return character !== undefined && /[\p{P}\p{S}]/u.test(character);
 }
 
 function markdownVisiblePreviousCharacters(content, start, end, context) {
@@ -2751,21 +2982,6 @@ function markdownVisibleAsciiWordEnd(
     if (!matched) return undefined;
   }
   return cursor;
-}
-
-function normalizeMarkdownInlineRangeText(value) {
-  const normalizationContext = markdownInlineNormalizationContext(
-    value,
-    0,
-    value.length,
-  );
-  return normalizeMarkdownInlineContentRange(
-    value,
-    0,
-    value.length,
-    normalizationContext,
-    [],
-  );
 }
 
 function firstMarkdownRangeEndingAfter(ranges, index) {
@@ -2878,11 +3094,14 @@ function parseCodeRabbitRangeStatement(
     match.index,
     match.statementPhraseEnd,
   );
-  if (
-    normalizeMarkdownInlineRangeText(rawStatementPhrase).toLowerCase() !==
-      "reviewing"
-  ) return undefined;
   const statementEnd = match.statementPhraseEnd;
+  if (
+    !markdownRangeMayContainCommitToken(
+      content,
+      statementEnd,
+      continuationEnd,
+    )
+  ) return undefined;
   const statementDecoration = match.index === match.lineStart ? "" : " ";
   const statementStart = statementDecoration + rawStatementPhrase;
   const firstLineEnd = Math.min(
@@ -2890,17 +3109,35 @@ function parseCodeRabbitRangeStatement(
     nextStatementIndex,
     continuationEnd,
   );
-  const normalizationContext = markdownInlineNormalizationContext(
-    content,
-    match.tableLocal ? match.tableCell.start : match.lineStart,
-    continuationEnd,
-  );
+  let continuationNormalizationContext;
+  const extendedNormalizationContext = () => {
+    if (match.normalizationContextEnd >= continuationEnd) {
+      return match.normalizationContext;
+    }
+    continuationNormalizationContext ??= markdownInlineNormalizationContext(
+      content,
+      match.tableLocal ? match.tableCell.start : match.lineStart,
+      continuationEnd,
+    );
+    return continuationNormalizationContext;
+  };
+  const firstLineContextEnd = match.normalizationContextEnd;
+  const firstLineNormalizationContext = match.tableLocal &&
+        nextStatementIndex > match.tableCell.end ||
+      continuationEnd > firstLineContextEnd &&
+        markdownRangeHasInlineDecorationToken(
+          content,
+          statementEnd,
+          firstLineEnd,
+        )
+    ? extendedNormalizationContext()
+    : match.normalizationContext;
   let rawFirstLineTail = content.slice(statementEnd, firstLineEnd);
   let firstLineTail = normalizeMarkdownRangeLineContent(
     content,
     statementEnd,
     firstLineEnd,
-    normalizationContext,
+    firstLineNormalizationContext,
     inlineLinkRanges,
   );
   if (match.tableLocal && nextStatementIndex > match.tableCell.end) {
@@ -2910,7 +3147,7 @@ function parseCodeRabbitRangeStatement(
       content,
       match.tableCell.end,
       rowTailEnd,
-      normalizationContext,
+      firstLineNormalizationContext,
       inlineLinkRanges,
     );
   }
@@ -2962,7 +3199,7 @@ function parseCodeRabbitRangeStatement(
       content,
       continuationContentStart,
       nextLine.lineEnd,
-      normalizationContext,
+      extendedNormalizationContext(),
       inlineLinkRanges,
     );
     const hiddenLinkContinuation = continuationContent.trim().length === 0 &&
@@ -3052,6 +3289,47 @@ function codeRabbitRangeContainerSignature(prefix) {
       "",
     ),
   );
+}
+
+function markdownRangeHasInlineDecorationToken(content, start, end) {
+  for (let index = start; index < end; index += 1) {
+    if ("<*_~[]`".includes(content[index])) return true;
+  }
+  return false;
+}
+
+function markdownInlineDecorationTokenIndexes(content) {
+  const indexes = [];
+  for (let index = 0; index < content.length; index += 1) {
+    if ("<*_~[]`".includes(content[index])) indexes.push(index);
+  }
+  return indexes;
+}
+
+function markdownIndexesIntersectRange(indexes, start, end) {
+  let lower = 0;
+  let upper = indexes.length;
+  while (lower < upper) {
+    const middle = lower + Math.floor((upper - lower) / 2);
+    if (indexes[middle] < start) lower = middle + 1;
+    else upper = middle;
+  }
+  return indexes[lower] < end;
+}
+
+function markdownRangeMayContainCommitToken(content, start, end) {
+  let hexadecimalRunLength = 0;
+  for (let index = start; index < end; index += 1) {
+    const character = content[index];
+    if (/[0-9a-f]/i.test(character)) {
+      hexadecimalRunLength += 1;
+      if (hexadecimalRunLength === 40) return true;
+      continue;
+    }
+    hexadecimalRunLength = 0;
+    if ("&<\\*_~[]`".includes(character)) return true;
+  }
+  return false;
 }
 
 function codeRabbitBaseSegment(lines, finalLine) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -373,11 +373,11 @@ function markdownExcludedRanges(content) {
   let openFence;
   let openHtmlCommentStart;
   let lineStart = 0;
-  for (const lineMatch of content.matchAll(/[^\r\n]*(?:\r?\n|$)/g)) {
+  for (const lineMatch of content.matchAll(/[^\r\n]*(?:\r\n|[\r\n]|$)/g)) {
     const line = lineMatch[0];
     if (line.length === 0 && lineStart >= content.length) break;
     const lineEnd = lineStart + line.length;
-    const lineWithoutEnding = line.replace(/\r?\n$/, "");
+    const lineWithoutEnding = line.replace(/(?:\r\n|[\r\n])$/, "");
 
     if (openHtmlCommentStart !== undefined) {
       const relativeCloseStart = lineWithoutEnding.indexOf("-->");
@@ -406,23 +406,20 @@ function markdownExcludedRanges(content) {
       openFence = undefined;
     }
 
-    const fenceMatch = line.match(MARKDOWN_FENCE_LINE_PATTERN);
     if (openFence !== undefined) {
-      if (fenceMatch) {
-        const marker = fenceMatch[2];
-        const markerEnd = lineWithoutEnding.indexOf(marker) + marker.length;
-        if (
-          marker[0] === openFence.char && marker.length >= openFence.length &&
-          /^[ \t]*$/.test(lineWithoutEnding.slice(markerEnd))
-        ) {
-          ranges.push([openFence.start, lineEnd]);
-          openFence = undefined;
-        }
+      const closingMarker = markdownClosingFenceMarker(
+        lineWithoutEnding,
+        openFence,
+      );
+      if (closingMarker) {
+        ranges.push([openFence.start, lineEnd]);
+        openFence = undefined;
       }
       lineStart = lineEnd;
       continue;
     }
 
+    const fenceMatch = line.match(MARKDOWN_FENCE_LINE_PATTERN);
     if (fenceMatch) {
       const marker = fenceMatch[2];
       const markerEnd = lineWithoutEnding.indexOf(marker) + marker.length;
@@ -620,6 +617,27 @@ function markdownFenceContainer(prefix) {
   };
 }
 
+function markdownClosingFenceMarker(line, fence) {
+  const linePrefix = line.match(
+    MARKDOWN_FENCE_CONTAINER_CONTINUATION_PATTERN,
+  )?.[0] ?? "";
+  if (
+    codeRabbitMarkdownPrefixSignature(linePrefix) !==
+      fence.container.structuralPrefix
+  ) return undefined;
+  const indentation = linePrefix.match(/[ \t]*$/)?.[0].length ?? 0;
+  if (
+    indentation < fence.container.continuationIndent ||
+    indentation > fence.container.continuationIndent + 3
+  ) return undefined;
+  const marker = line.slice(linePrefix.length).match(
+    /^(`{3,}|~{3,})[ \t]*$/,
+  )?.[1];
+  return marker?.[0] === fence.char && marker.length >= fence.length
+    ? marker
+    : undefined;
+}
+
 function continuesMarkdownFenceContainer(line, container) {
   if (
     container.structuralPrefix.length === 0 &&
@@ -632,6 +650,7 @@ function continuesMarkdownFenceContainer(line, container) {
     codeRabbitMarkdownPrefixSignature(linePrefix) !==
       container.structuralPrefix
   ) return false;
+  if (linePrefix.length === line.length) return true;
   return (linePrefix.match(/[ \t]*$/)?.[0].length ?? 0) >=
     container.continuationIndent;
 }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -10,7 +10,7 @@ const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r\n|[\r\n])Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r\n|[\r\n]|$)/;
 const CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN =
-  /(?:^|\r\n|[\r\n])([ \t]*(?:(?:>[ \t]*)|(?:\|[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*[\\`*_~!\[]*(?:Reviewing[ \t]+(?:files(?:[ \t]+that[ \t]+changed[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?|changed[ \t]+files(?:[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?)[ \t]+(?:and[ \t]+)?between))([^\r\n]*)/gi;
+  /(?<![A-Za-z0-9])(?=(Reviewing[ \t]+(?:files(?:[ \t]+that[ \t]+changed[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?|changed[ \t]+files(?:[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?)[ \t]+(?:and[ \t]+)?between))/gi;
 const CODERABBIT_REVIEW_RANGE_CONTINUATION_PREFIX_PATTERN =
   /^[ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*/;
 const CODERABBIT_REVIEW_RANGE_SEPARATOR_PATTERN =
@@ -361,6 +361,7 @@ function codeRabbitRangeEvidenceStatements(content) {
       markdownStructure.tableCellRanges,
     ),
   );
+  assignCodeRabbitMatchLineBounds(content, matches);
   const statementIndexes = matches.map(codeRabbitStatementIndex);
   const statements = [];
   let excludedRangeIndex = 0;
@@ -376,14 +377,17 @@ function codeRabbitRangeEvidenceStatements(content) {
       excludedRanges[excludedRangeIndex][0] <= statementIndex &&
       statementIndex < excludedRanges[excludedRangeIndex][1];
     if (insideExcludedRange) continue;
+    const nextStatementIndex = statementIndexes[matchIndex + 1] ??
+      content.length;
     const continuationEnd = Math.min(
-      statementIndexes[matchIndex + 1] ?? content.length,
+      nextStatementIndex,
       excludedRanges[excludedRangeIndex]?.[0] ?? content.length,
     );
     const statement = parseCodeRabbitRangeStatement(
       content,
       match,
       continuationEnd,
+      nextStatementIndex,
     );
     if (statement) {
       statement.insideTableCell = match.tableCell !== undefined;
@@ -440,6 +444,29 @@ function mergeCodeRabbitRangeMatches(globalMatches, tableMatches) {
     }
   }
   return matches;
+}
+
+function assignCodeRabbitMatchLineBounds(content, matches) {
+  if (matches.length === 0) return;
+  let matchIndex = 0;
+  let lineStart = 0;
+  for (const lineMatch of content.matchAll(/[^\r\n]*(?:\r\n|[\r\n]|$)/g)) {
+    const line = lineMatch[0];
+    if (line.length === 0 && lineStart >= content.length) break;
+    const lineContentEnd = lineStart +
+      line.replace(/(?:\r\n|[\r\n])$/, "").length;
+    const linePrefix = line.match(
+      CODERABBIT_REVIEW_RANGE_CONTINUATION_PREFIX_PATTERN,
+    )?.[0] ?? "";
+    while (matches[matchIndex]?.index < lineContentEnd) {
+      matches[matchIndex].lineStart = lineStart;
+      matches[matchIndex].lineEnd = lineContentEnd;
+      matches[matchIndex].linePrefix = linePrefix;
+      matchIndex += 1;
+    }
+    if (matchIndex >= matches.length) return;
+    lineStart += line.length;
+  }
 }
 
 function markdownTableRangeEvidenceMatches(content, tableCellRanges) {
@@ -2356,23 +2383,32 @@ function isEscapedMarkdownToken(content, tokenStart) {
 }
 
 function codeRabbitStatementIndex(match) {
-  return match.index + match[0].indexOf(match[1]) +
-    match[1].toLowerCase().lastIndexOf("reviewing");
+  return match.index;
 }
 
-function parseCodeRabbitRangeStatement(content, match, continuationEnd) {
-  const statementStart = match[1];
-  const firstLineTail = match.tableLocal
-    ? match[2] + content.slice(
+function parseCodeRabbitRangeStatement(
+  content,
+  match,
+  continuationEnd,
+  nextStatementIndex,
+) {
+  const statementPhrase = match[1];
+  const statementEnd = match.index + statementPhrase.length;
+  const statementDecoration = match.index === match.lineStart ? "" : " ";
+  const statementStart = statementDecoration + statementPhrase;
+  const firstLineEnd = Math.min(
+    match.tableLocal ? match.tableCell.end : match.lineEnd,
+    nextStatementIndex,
+  );
+  let firstLineTail = content.slice(statementEnd, firstLineEnd);
+  if (match.tableLocal && nextStatementIndex > match.tableCell.end) {
+    firstLineTail += content.slice(
       match.tableCell.end,
-      Math.min(match.tableCell.rowEnd, continuationEnd),
-    )
-    : match[2];
-  const statementPrefix = codeRabbitMarkdownPrefixSignature(
-    statementStart.slice(
-      0,
-      statementStart.toLowerCase().lastIndexOf("reviewing"),
-    ).replace(/[\\`*_~!\[]+$/, ""),
+      Math.min(match.tableCell.rowEnd, nextStatementIndex),
+    );
+  }
+  const statementPrefix = codeRabbitRangeContainerSignature(
+    match.tableCell === undefined ? match.linePrefix : "",
   );
   const sameLineSeparator = firstLineTail.match(
     CODERABBIT_REVIEW_RANGE_SEPARATOR_PATTERN,
@@ -2391,7 +2427,7 @@ function parseCodeRabbitRangeStatement(content, match, continuationEnd) {
 
   const baseLines = [firstLineTail];
   const statementParts = [statementStart + firstLineTail];
-  let lineEnd = match.index + match[0].length;
+  let lineEnd = match.tableLocal ? match.tableCell.end : match.lineEnd;
   let tableContinuationCell = match.tableCell?.nextRowFirstCell;
   while (true) {
     const nextLine = match.tableCell !== undefined
@@ -2412,7 +2448,7 @@ function parseCodeRabbitRangeStatement(content, match, continuationEnd) {
     if (
       continuationContent.trim().length === 0 ||
       continuationContent.trimStart().startsWith("<!--") ||
-      codeRabbitMarkdownPrefixSignature(continuationPrefix) !== statementPrefix
+      codeRabbitRangeContainerSignature(continuationPrefix) !== statementPrefix
     ) return undefined;
     statementParts.push(nextLine.separator, nextLine.content);
 
@@ -2468,6 +2504,15 @@ function codeRabbitNextTableCell(content, cell, continuationEnd) {
 
 function codeRabbitMarkdownPrefixSignature(prefix) {
   return prefix.trim().toLowerCase().replace(/[ \t]+/g, " ");
+}
+
+function codeRabbitRangeContainerSignature(prefix) {
+  return codeRabbitMarkdownPrefixSignature(
+    prefix.replace(MARKDOWN_LIST_PREFIX_PATTERN, "").replace(
+      /\[[ xX]\][ \t]+/g,
+      "",
+    ),
+  );
 }
 
 function codeRabbitBaseSegment(lines, finalLine) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -10,9 +10,9 @@ const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r\n|[\r\n])Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r\n|[\r\n]|$)/;
 const CODERABBIT_REVIEW_RANGE_STATEMENT_START_PATTERN =
-  /(?:^|\r\n|[\r\n])([ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*(?:Reviewing[ \t]+(?:files(?:[ \t]+that[ \t]+changed[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?|changed[ \t]+files(?:[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?)[ \t]+(?:and[ \t]+)?between))([^\r\n]*)/gi;
+  /(?:^|\r\n|[\r\n])([ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*(?:Reviewing[ \t]+(?:files(?:[ \t]+that[ \t]+changed[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?|changed[ \t]+files(?:[ \t]+from[ \t]+the[ \t]+base[ \t]+of[ \t]+the[ \t]+PR)?)[ \t]+(?:and[ \t]+)?between))([^\r\n]*)/gi;
 const CODERABBIT_REVIEW_RANGE_CONTINUATION_PREFIX_PATTERN =
-  /^[ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*/;
+  /^[ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*/;
 const CODERABBIT_REVIEW_RANGE_SEPARATOR_PATTERN =
   /(^|[ \t])and[ \t]+([0-9a-f]{40})(?![0-9a-f])/i;
 const CODERABBIT_REVIEW_RANGE_WRAPPED_TIP_PATTERN =
@@ -21,26 +21,26 @@ const CODERABBIT_REVIEW_RANGE_WRAPPED_SEPARATOR_PATTERN =
   /^[ \t]*and[ \t]+([0-9a-f]{40})(?![0-9a-f])/i;
 const FULL_COMMIT_TOKEN_PATTERN = /(^|[^0-9a-f])([0-9a-f]{40})(?![0-9a-f])/gi;
 const MARKDOWN_FENCE_LINE_PATTERN =
-  /^( {0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*)(`{3,}|~{3,})/;
+  /^( {0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*)(`{3,}|~{3,})/;
 const MARKDOWN_HTML_COMMENT_BLOCK_START_PATTERN =
-  /^( {0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*)<!--/;
+  /^( {0,3}(?:(?:>[ \t]*)|(?:(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*)<!--/;
 const MARKDOWN_LIST_PREFIX_PATTERN =
-  /([-*+]|\d+[.)])([ \t]+)(?:\[[ xX]\][ \t]+)?/g;
+  /([-*+]|\d{1,9}[.)])([ \t]+)(?:\[[ xX]\][ \t]+)?/g;
 const MARKDOWN_PARAGRAPH_LIST_PREFIX_PATTERN =
-  /^(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?/;
+  /^(?:[-*+]|\d{1,9}[.)])[ \t]+(?:\[[ xX]\][ \t]+)?/;
 const MARKDOWN_RAW_HTML_BLOCK_START_PATTERN =
   /^<(script|pre|style|textarea)(?:[ \t]|>|$)/i;
 const MARKDOWN_PARAGRAPH_INTERRUPTING_HTML_TAG_PATTERN =
-  /^ {0,3}<\/?(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h[1-6]|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|search|section|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)(?:[ \t]|\/?>|$)/i;
+  /^ {0,3}<\/?(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h[1-6]|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|search|section|source|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)(?:[ \t]|\/?>|$)/i;
 const MARKDOWN_PARAGRAPH_INTERRUPTING_RAW_HTML_PATTERN =
   /^ {0,3}<(?:script|pre|style|textarea)(?:[ \t]|>|$)/i;
 const MARKDOWN_PARAGRAPH_INTERRUPTING_HTML_SYNTAX_PATTERN =
   /^ {0,3}(?:<!--|<\?|<![A-Za-z]|<!\[CDATA\[)/;
 const MARKDOWN_FENCE_CONTAINER_CONTINUATION_PATTERN = /^[ \t]*(?:>[ \t]*)*/;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
-  /Requested commit:\s*([0-9a-f]{40})/gi;
+  /Requested commit:[ \t]*([0-9a-f]{40})/gi;
 const CODERABBIT_SKIPPED_COMMIT_PATTERN =
-  /Review skipped for current commit\s*([0-9a-f]{40})/gi;
+  /Review skipped for current commit[ \t]*([0-9a-f]{40})/gi;
 const CODEX_LOGIN = "chatgpt-codex-connector[bot]";
 const CODEX_BOT_ID = 199175422;
 const CODEX_NO_FINDING_PREFIX = "Codex Review: Didn't find any major issues.";
@@ -522,7 +522,12 @@ function scanMarkdownStructure(content) {
         continue;
       }
       const closeStart = lineStart + relativeCloseStart;
-      ranges.push([openHtmlComment.start, closeStart + 3]);
+      if (
+        !inlineComment ||
+        markdownInlineHtmlCommentHasValidEnd(content, closeStart)
+      ) {
+        ranges.push([openHtmlComment.start, closeStart + 3]);
+      }
       openHtmlComment = scanMarkdownHtmlComments(
         content,
         lineWithoutEnding,
@@ -702,6 +707,9 @@ function markdownParagraphLineContext(line) {
       ? remainingLine
       : remainingLine.slice(listPrefix.length),
     indentation,
+    listInterruptsParagraph: listPrefix === undefined
+      ? false
+      : markdownListMarkerInterruptsParagraph(listPrefix),
     listContinuationIndent: listPrefix === undefined
       ? undefined
       : markdownContainerIndentColumns(containerPrefix + listPrefix),
@@ -710,8 +718,13 @@ function markdownParagraphLineContext(line) {
 }
 
 function markdownLineContinuesParagraph(line, paragraph) {
-  if (paragraph === undefined || line.listContinuationIndent !== undefined) {
-    return false;
+  if (paragraph === undefined) return false;
+  if (line.listContinuationIndent !== undefined) {
+    if (line.listInterruptsParagraph) return false;
+    if (
+      paragraph.isListItem &&
+      line.indentation < paragraph.continuationIndent
+    ) return false;
   }
   const sameContainer = line.structuralPrefix === paragraph.structuralPrefix;
   const lazyBlockquoteContinuation = paragraph.blockquoteDepth > 0 &&
@@ -722,13 +735,21 @@ function markdownLineContinuesParagraph(line, paragraph) {
     line.indentation < paragraph.continuationIndent &&
     !lazyBlockquoteContinuation && !lazyListContinuation
   ) return false;
+  if (line.listContinuationIndent !== undefined) return true;
   return line.indentation - paragraph.continuationIndent >= 4 ||
     isMarkdownNonInterruptingHtmlLine(line.content) ||
     !isMarkdownInlineCodeBarrier(line.content);
 }
 
+function markdownListMarkerInterruptsParagraph(listPrefix) {
+  const marker = listPrefix.match(/^([-*+]|\d{1,9}[.)])/)?.[1];
+  if (marker === undefined || /^[-*+]$/.test(marker)) return true;
+  return Number(marker.slice(0, -1)) === 1;
+}
+
 function isMarkdownNonInterruptingHtmlLine(line) {
-  // CommonMark HTML block types 1–6 interrupt paragraphs; type 7 does not.
+  // GitHub Flavored Markdown HTML block types 1–6 interrupt paragraphs;
+  // type 7 does not.
   return /^ {0,3}<(?:[A-Za-z!?/])/.test(line) &&
     !MARKDOWN_PARAGRAPH_INTERRUPTING_HTML_TAG_PATTERN.test(line) &&
     !MARKDOWN_PARAGRAPH_INTERRUPTING_RAW_HTML_PATTERN.test(line) &&
@@ -847,20 +868,33 @@ function scanMarkdownHtmlComments(
       searchStart = shortCommentEnd;
       continue;
     }
+    const container = markdownHtmlCommentBlockContainer(
+      line,
+      relativeCommentStart,
+    );
     const relativeCloseStart = line.indexOf("-->", relativeCommentStart + 4);
     if (relativeCloseStart < 0) {
       return {
         start: commentStart,
-        container: markdownHtmlCommentBlockContainer(
-          line,
-          relativeCommentStart,
-        ),
+        container,
       };
     }
-    ranges.push([commentStart, lineStart + relativeCloseStart + 3]);
+    if (
+      container !== undefined ||
+      markdownInlineHtmlCommentHasValidEnd(
+        content,
+        lineStart + relativeCloseStart,
+      )
+    ) {
+      ranges.push([commentStart, lineStart + relativeCloseStart + 3]);
+    }
     searchStart = relativeCloseStart + 3;
   }
   return undefined;
+}
+
+function markdownInlineHtmlCommentHasValidEnd(content, closeStart) {
+  return content[closeStart - 1] !== "-";
 }
 
 function markdownHtmlCommentBlockContainer(line, commentStart) {
@@ -940,10 +974,10 @@ function isMarkdownInlineCodeBarrier(line) {
   if (
     line.trim().length === 0 ||
     /^ {0,3}<(?:[A-Za-z!?/])/.test(line) ||
-    /^ {0,3}(?:>|#{1,6}(?:[ \t]|$)|(?:[-+*]|\d+[.)])(?:[ \t]|$))/.test(
+    /^ {0,3}(?:>|#{1,6}(?:[ \t]|$)|(?:[-+*]|\d{1,9}[.)])(?:[ \t]|$))/.test(
       line,
     ) ||
-    /^ {0,3}=+[ \t]*$/.test(line) ||
+    /^ {0,3}(?:=+|-+)[ \t]*$/.test(line) ||
     /^ {0,3}(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/.test(
       line,
     )

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -656,6 +656,13 @@ function scanMarkdownStructure(content) {
       continue;
     }
 
+    if (indentedCodeLine) {
+      ranges.push([lineStart, lineEnd]);
+      openParagraph = undefined;
+      lineStart = lineEnd;
+      continue;
+    }
+
     const fenceMatch = line.match(MARKDOWN_FENCE_LINE_PATTERN);
     if (fenceMatch && hasValidMarkdownBlockquoteSpacing(fenceMatch[1])) {
       const marker = fenceMatch[2];

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -11,8 +11,9 @@ const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r?\n)Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r?\n|$)/;
 const CODERABBIT_REVIEW_RANGE_STATEMENT_PATTERN =
-  /(?:^|\r?\n)([ \t]*(?:(?:>[ \t]*)|(?:(?:[-*+]|\d+[.)])[ \t]+))*(?:Reviewing\s+(?:files(?:\s+that\s+changed\s+from\s+the\s+base\s+of\s+the\s+PR)?|changed files(?:\s+from\s+the\s+base\s+of\s+the\s+PR)?)\s+(?:and\s+)?between[ \t]+([^ \t\r\n]+)[ \t]+and(?:[ \t]*\r?\n)?[ \t]*([0-9a-f]{40})[^\r\n]*))/gi;
+  /(?:^|\r?\n)([ \t]*(?:(?:>[ \t]*)|(?:#{1,6}[ \t]+)|(?:(?:[-*+]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?))*(?:Reviewing\s+(?:files(?:\s+that\s+changed\s+from\s+the\s+base\s+of\s+the\s+PR)?|changed files(?:\s+from\s+the\s+base\s+of\s+the\s+PR)?)\s+(?:and\s+)?between[ \t]+([^ \t\r\n]+)(?:[ \t]+|[ \t]*\r?\n[ \t]*)and(?:[ \t]*\r?\n)?[ \t]*([0-9a-f]{40})[^\r\n]*))/gi;
 const FULL_COMMIT_TOKEN_PATTERN = /(^|[^0-9a-f])([0-9a-f]{40})(?![0-9a-f])/gi;
+const MARKDOWN_FENCE_LINE_PATTERN = /^[ \t]{0,3}(`{3,}|~{3,})/;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
   /Requested commit:\s*([0-9a-f]{40})/gi;
 const CODERABBIT_SKIPPED_COMMIT_PATTERN =
@@ -265,7 +266,7 @@ function codeRabbitSelectedRecentReview(body) {
   if (typeof body !== "string") return undefined;
   const groups = [];
   let openGroup;
-  let previousCompleteContent;
+  let previousFallbackContent;
   for (
     const marker of body.matchAll(CODERABBIT_RECENT_REVIEW_MARKER_PATTERN)
   ) {
@@ -287,13 +288,13 @@ function codeRabbitSelectedRecentReview(body) {
       terminated: !openGroup.invalid,
     };
     groups.push(group);
-    if (group.terminated) previousCompleteContent = content;
+    previousFallbackContent = content;
     openGroup = undefined;
   }
   if (openGroup) {
     groups.push({
       content: body.slice(openGroup.contentStart),
-      fallbackContent: previousCompleteContent,
+      fallbackContent: previousFallbackContent,
       terminated: false,
     });
   }
@@ -322,13 +323,66 @@ function classifyCodeRabbitRangeEvidence(selectedRecentReview, headSha) {
 }
 
 function codeRabbitRangeEvidenceStatements(content) {
-  return [...content.matchAll(CODERABBIT_REVIEW_RANGE_STATEMENT_PATTERN)].map((
-    match,
-  ) => ({
-    baseToken: match[2].toLowerCase(),
-    statement: match[1],
-    tipToken: match[3].toLowerCase(),
-  }));
+  const fenceRanges = markdownFenceRanges(content);
+  const statements = [];
+  let fenceIndex = 0;
+  for (
+    const match of content.matchAll(CODERABBIT_REVIEW_RANGE_STATEMENT_PATTERN)
+  ) {
+    const statementIndex = match.index + match[0].indexOf(match[1]);
+    while (
+      fenceIndex < fenceRanges.length &&
+      fenceRanges[fenceIndex][1] <= statementIndex
+    ) {
+      fenceIndex += 1;
+    }
+    const insideFence = fenceIndex < fenceRanges.length &&
+      fenceRanges[fenceIndex][0] <= statementIndex &&
+      statementIndex < fenceRanges[fenceIndex][1];
+    if (insideFence) continue;
+    statements.push({
+      baseToken: match[2].toLowerCase(),
+      statement: match[1],
+      tipToken: match[3].toLowerCase(),
+    });
+  }
+  return statements;
+}
+
+function markdownFenceRanges(content) {
+  const ranges = [];
+  let openFence;
+  let lineStart = 0;
+  for (const lineMatch of content.matchAll(/[^\r\n]*(?:\r?\n|$)/g)) {
+    const line = lineMatch[0];
+    if (line.length === 0 && lineStart >= content.length) break;
+    const lineEnd = lineStart + line.length;
+    const fenceMatch = line.match(MARKDOWN_FENCE_LINE_PATTERN);
+    if (fenceMatch) {
+      const marker = fenceMatch[1];
+      const lineWithoutEnding = line.replace(/\r?\n$/, "");
+      const markerEnd = lineWithoutEnding.indexOf(marker) + marker.length;
+      const hasOnlyClosingFenceWhitespace = /^[ \t]*$/.test(
+        lineWithoutEnding.slice(markerEnd),
+      );
+      if (openFence === undefined) {
+        openFence = {
+          char: marker[0],
+          length: marker.length,
+          start: lineStart,
+        };
+      } else if (
+        marker[0] === openFence.char && marker.length >= openFence.length &&
+        hasOnlyClosingFenceWhitespace
+      ) {
+        ranges.push([openFence.start, lineEnd]);
+        openFence = undefined;
+      }
+    }
+    lineStart = lineEnd;
+  }
+  if (openFence !== undefined) ranges.push([openFence.start, content.length]);
+  return ranges;
 }
 
 function parseCodeRabbitRangeEvidence(evidence, headSha) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -10,6 +10,7 @@ const CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER =
 const CODERABBIT_REVIEW_RANGE_CANDIDATE_PATTERN = /^\s*reviewing\s+files\b/i;
 const CODERABBIT_REVIEW_RANGE_PATTERN =
   /(?:^|\r?\n)Reviewing files that changed from the base of the PR and between ([0-9a-f]{40}) and ([0-9a-f]{40})\.(?=\r?\n|$)/;
+const FULL_COMMIT_TOKEN_PATTERN = /(?:^|[^0-9a-f])([0-9a-f]{40})(?![0-9a-f])/gi;
 const CODERABBIT_REQUESTED_COMMIT_PATTERN =
   /Requested commit:\s*([0-9a-f]{40})/gi;
 const CODERABBIT_SKIPPED_COMMIT_PATTERN =
@@ -212,6 +213,9 @@ async function classifyAutomatedReviewEvent(
   const rangeCandidates = recentReview?.split(/\r?\n/).filter((line) =>
     CODERABBIT_REVIEW_RANGE_CANDIDATE_PATTERN.test(line)
   );
+  const rangeCandidateHasCurrentTip = rangeCandidates?.some((line) =>
+    lastFullCommitToken(line)?.toLowerCase() === headSha.toLowerCase()
+  );
   const reviewedTips = rangeCandidates?.map((line) =>
     line.match(CODERABBIT_REVIEW_RANGE_PATTERN)?.[2]
   );
@@ -219,7 +223,7 @@ async function classifyAutomatedReviewEvent(
     tip?.toLowerCase() === headSha.toLowerCase()
   );
   if (rangeCandidates?.length !== 1) {
-    return hasCurrentRange
+    return hasCurrentRange || rangeCandidateHasCurrentTip
       ? {
         kind: "failure",
         url: typeof comment.html_url === "string"
@@ -230,7 +234,9 @@ async function classifyAutomatedReviewEvent(
   }
   const reviewedTip = reviewedTips?.[0];
   if (reviewedTip?.toLowerCase() !== headSha.toLowerCase()) {
-    return { kind: "not-head" };
+    return rangeCandidateHasCurrentTip
+      ? { kind: "failure" }
+      : { kind: "not-head" };
   }
   return recentReview?.includes(CODERABBIT_NO_ACTIONABLE_REVIEW_MARKER)
     ? {
@@ -257,6 +263,14 @@ function codeRabbitRecentReview(body) {
   const contentStart = start + CODERABBIT_RECENT_REVIEW_MARKER.length;
   const end = body.indexOf(CODERABBIT_RECENT_REVIEW_END_MARKER, contentStart);
   return end < 0 ? undefined : body.slice(contentStart, end);
+}
+
+function lastFullCommitToken(value) {
+  let lastToken;
+  for (const match of value.matchAll(FULL_COMMIT_TOKEN_PATTERN)) {
+    lastToken = match[1];
+  }
+  return lastToken;
 }
 
 /** Publish the current automated-review decision on the exact PR head SHA. */

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -36,6 +36,8 @@ const MARKDOWN_PARAGRAPH_INTERRUPTING_RAW_HTML_PATTERN =
   /^ {0,3}<(?:script|pre|style|textarea)(?:[ \t]|>|$)/i;
 const MARKDOWN_PARAGRAPH_INTERRUPTING_HTML_SYNTAX_PATTERN =
   /^ {0,3}(?:<!--|<\?|<![A-Za-z]|<!\[CDATA\[)/;
+const MARKDOWN_RENDERED_BREAK_HTML_TAG_AT_START_PATTERN =
+  /^(?:<\/br|<(?:br|hr))(?:[ \t\r\n\f]|\/?>)/i;
 const MARKDOWN_FENCE_CONTAINER_CONTINUATION_PATTERN = /^[ \t]*(?:>[ \t]*)*/;
 const MARKDOWN_CHARACTER_REFERENCE_PATTERN =
   /&#(?:[xX][0-9A-Fa-f]{1,6}|[0-9]{1,7});|&[A-Za-z][A-Za-z0-9]{1,31};/g;
@@ -2060,6 +2062,7 @@ function appendMarkdownInlineCodeRangesInSegment(
   inlineHtmlRanges,
   inlineLinkRanges,
   inlineDelimiterEnds,
+  inlineCommentRanges,
 ) {
   const delimiterRuns = [];
   for (let index = start; index < end;) {
@@ -2167,7 +2170,9 @@ function appendMarkdownInlineCodeRangesInSegment(
       );
       cursor = htmlEnd ?? htmlStart + 1;
       if (htmlEnd !== undefined) {
-        if (!content.startsWith("<!--", htmlStart)) {
+        if (content.startsWith("<!--", htmlStart)) {
+          inlineCommentRanges?.push([htmlStart, htmlEnd]);
+        } else {
           inlineHtmlRanges.push([htmlStart, htmlEnd]);
         }
         while (delimiterRuns[delimiterIndex]?.start < htmlEnd) {
@@ -2702,29 +2707,39 @@ function markdownCharacterReferenceAt(content, index, end) {
 function markdownInlineDecorationEnd(
   content,
   index,
-  end,
   normalizationContext,
 ) {
   const character = content[index];
   if (character !== "<" && !"*_~[]`".includes(character)) return undefined;
   if (isEscapedMarkdownToken(content, index)) return undefined;
   if (character === "<") {
-    return markdownInlineHtmlEnd(
-      content,
-      index,
-      end,
-      normalizationContext.findHtmlTerminator,
-    );
+    return normalizationContext.findInlineHtmlEnd(index);
   }
   return normalizationContext.findDelimiterEnd(index);
 }
 
+function markdownInlineDecorationReplacement(content, start, end) {
+  return content[start] === "<" &&
+      MARKDOWN_RENDERED_BREAK_HTML_TAG_AT_START_PATTERN.test(
+        content.slice(start, Math.min(end, start + 6)),
+      )
+    ? " "
+    : "";
+}
+
 function markdownInlineNormalizationContext(content, start, end) {
-  let delimiterEnds;
+  let normalizationTokens;
   let inlineLinkTailEndFinder;
   let previousVisibleCharacters;
+  const tokens = () => {
+    normalizationTokens ??= markdownInlineNormalizationTokens(
+      content,
+      start,
+      end,
+    );
+    return normalizationTokens;
+  };
   const context = {
-    findHtmlTerminator: createMarkdownInlineTerminatorFinder(content, end),
     findInlineLinkTailEnd: (tailStart) => {
       inlineLinkTailEndFinder ??= createMarkdownInlineLinkTailEndFinder(
         content,
@@ -2733,14 +2748,8 @@ function markdownInlineNormalizationContext(content, start, end) {
       );
       return inlineLinkTailEndFinder(tailStart);
     },
-    findDelimiterEnd: (index) => {
-      delimiterEnds ??= markdownInlineDelimiterEnds(
-        content,
-        start,
-        end,
-      );
-      return delimiterEnds.get(index);
-    },
+    findDelimiterEnd: (index) => tokens().delimiterEnds.get(index),
+    findInlineHtmlEnd: (index) => tokens().inlineHtmlEnds.get(index),
     previousVisibleCharacter: (index) => {
       previousVisibleCharacters ??= markdownVisiblePreviousCharacters(
         content,
@@ -2754,9 +2763,10 @@ function markdownInlineNormalizationContext(content, start, end) {
   return context;
 }
 
-function markdownInlineDelimiterEnds(content, start, end) {
+function markdownInlineNormalizationTokens(content, start, end) {
   const delimiterEnds = new Map();
   const inlineCodeRanges = [];
+  const inlineCommentRanges = [];
   const inlineHtmlRanges = [];
   const inlineLinkTailRanges = [];
   appendMarkdownInlineCodeRangesInSegment(
@@ -2767,6 +2777,7 @@ function markdownInlineDelimiterEnds(content, start, end) {
     inlineHtmlRanges,
     inlineLinkTailRanges,
     delimiterEnds,
+    inlineCommentRanges,
   );
 
   const hiddenRanges = mergeMarkdownRanges(
@@ -2829,7 +2840,14 @@ function markdownInlineDelimiterEnds(content, start, end) {
     }
     openerStacks.set(key, openers);
   }
-  return delimiterEnds;
+  return {
+    delimiterEnds,
+    inlineHtmlEnds: new Map(
+      [...inlineCommentRanges, ...inlineHtmlRanges].sort((left, right) =>
+        left[0] - right[0]
+      ),
+    ),
+  };
 }
 
 function markdownInlineEmphasisRuns(content, start, end, hiddenRanges) {
@@ -2927,13 +2945,18 @@ function markdownVisiblePreviousCharacters(content, start, end, context) {
     const decorationEnd = markdownInlineDecorationEnd(
       content,
       cursor,
-      end,
       context,
     );
     if (decorationEnd !== undefined) {
       for (let index = cursor + 1; index < decorationEnd; index += 1) {
         previousCharacters[index - start] = previousCharacter;
       }
+      const replacement = markdownInlineDecorationReplacement(
+        content,
+        cursor,
+        decorationEnd,
+      );
+      if (replacement.length > 0) previousCharacter = replacement.at(-1);
       cursor = decorationEnd;
       continue;
     }
@@ -2973,10 +2996,13 @@ function markdownVisibleAsciiWordEnd(
       const decorationEnd = markdownInlineDecorationEnd(
         content,
         cursor,
-        end,
         normalizationContext,
       );
       if (decorationEnd === undefined) return undefined;
+      if (
+        markdownInlineDecorationReplacement(content, cursor, decorationEnd)
+          .length > 0
+      ) return undefined;
       cursor = decorationEnd;
     }
     if (!matched) return undefined;
@@ -3036,10 +3062,14 @@ function normalizeMarkdownInlineContentRange(
     const decorationEnd = markdownInlineDecorationEnd(
       content,
       cursor,
-      end,
       normalizationContext,
     );
     if (decorationEnd !== undefined) {
+      normalized += markdownInlineDecorationReplacement(
+        content,
+        cursor,
+        decorationEnd,
+      );
       cursor = decorationEnd;
       continue;
     }

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -34,6 +34,14 @@ function review(
   };
 }
 
+function codeRabbitReviewRange(
+  baseSha = STALE_SHA,
+  headSha = HEAD_SHA,
+): string {
+  return "Reviewing files that changed from the base of the PR and between " +
+    `${baseSha} and ${headSha}.`;
+}
+
 function codeRabbitSummary(
   overrides: Record<string, unknown> = {},
 ): Record<string, unknown> {
@@ -42,7 +50,7 @@ function codeRabbitSummary(
     body: [
       "<!-- recent_review_start -->",
       "No actionable comments were generated in the recent review.",
-      `Reviewing files between ${STALE_SHA} and ${HEAD_SHA}.`,
+      codeRabbitReviewRange(),
       "<!-- recent_review_end -->",
     ].join("\n"),
     html_url:
@@ -146,13 +154,12 @@ describe("automated review gate", () => {
     );
   });
 
-  it("accepts CodeRabbit's current base-change review wording", async () => {
+  it("requires CodeRabbit's exact current base-change review sentence", async () => {
     const currentSummary = codeRabbitSummary({
       body: [
         "<!-- recent_review_start -->",
         "No actionable comments were generated in the recent review.",
-        "Reviewing files that changed from the base of the PR and between " +
-        `${STALE_SHA} and ${HEAD_SHA}.`,
+        codeRabbitReviewRange(),
         "<!-- recent_review_end -->",
       ].join("\n"),
     });
@@ -171,6 +178,30 @@ describe("automated review gate", () => {
       ),
       undefined,
     );
+
+    for (
+      const invalidRange of [
+        `Reviewing files between ${STALE_SHA} and ${HEAD_SHA}.`,
+        codeRabbitReviewRange() + " but this is not the final review.",
+        codeRabbitReviewRange().replace("Reviewing", "reviewing"),
+      ]
+    ) {
+      const invalidSummary = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          invalidRange,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+      });
+      assertEquals(
+        await findAutomatedReview(
+          { reviews: [], comments: [invalidSummary] },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
   });
 
   it("accepts an authenticated Codex no-finding comment for the current head", async () => {
@@ -302,7 +333,7 @@ describe("automated review gate", () => {
             body: [
               "<!-- recent_review_start -->",
               "No actionable comments were generated in the recent review.",
-              `Reviewing files between ${HEAD_SHA} and ${STALE_SHA}.`,
+              codeRabbitReviewRange(HEAD_SHA, STALE_SHA),
               "<!-- recent_review_end -->",
             ].join("\n"),
           }),
@@ -380,7 +411,7 @@ describe("automated review gate", () => {
       body: [
         "<!-- recent_review_start -->",
         "No actionable comments were generated in the recent review.",
-        `Reviewing files between ${STALE_SHA} and ${HEAD_SHA}.`,
+        codeRabbitReviewRange(),
         "<!-- recent_review_end -->",
         `Review skipped for current commit ${HEAD_SHA}.`,
       ].join("\n"),
@@ -480,7 +511,7 @@ describe("automated review gate", () => {
       body: [
         "<!-- recent_review_start -->",
         "No actionable comments were generated in the recent review.",
-        `Reviewing files between ${HEAD_SHA} and ${STALE_SHA}.`,
+        codeRabbitReviewRange(HEAD_SHA, STALE_SHA),
         "<!-- recent_review_end -->",
       ].join("\n"),
       created_at: "2026-08-22T12:04:00Z",
@@ -502,7 +533,7 @@ describe("automated review gate", () => {
       body: [
         "<!-- recent_review_start -->",
         "No actionable comments were generated in the recent review.",
-        `Reviewing files between ${HEAD_SHA} and ${STALE_SHA}.`,
+        codeRabbitReviewRange(HEAD_SHA, STALE_SHA),
         "<!-- recent_review_end -->",
         `Review skipped for current commit ${HEAD_SHA}.`,
       ].join("\n"),
@@ -561,7 +592,7 @@ describe("automated review gate", () => {
           body: [
             "<!-- recent_review_start -->",
             "No actionable comments were generated in the recent review.",
-            `Reviewing files between ${STALE_SHA} and ${HEAD_SHA}.`,
+            codeRabbitReviewRange(),
             "<!-- recent_review_end -->",
             `Review skipped for current commit ${HEAD_SHA}.`,
           ].join("\n"),
@@ -571,7 +602,7 @@ describe("automated review gate", () => {
         codeRabbitSummary({
           body: [
             "<!-- recent_review_start -->",
-            `Reviewing files between ${STALE_SHA} and ${HEAD_SHA}.`,
+            codeRabbitReviewRange(),
             "<!-- recent_review_end -->",
           ].join("\n"),
           created_at: timestamp,

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1562,6 +1562,28 @@ describe("automated review gate", () => {
       undefined,
     );
 
+    const newerVisibleRangeAfterTaskCheckboxText = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "- [ ] ~~~text",
+        `      ${MALFORMED_CURRENT_RANGE}`,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerVisibleRangeAfterTaskCheckboxText],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+
     for (
       const visibleRangeAfterCommentLookalike of [
         ["\\<!--", MALFORMED_CURRENT_RANGE, "-->"],

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -496,6 +496,11 @@ describe("automated review gate", () => {
     for (
       const malformedCurrentRange of [
         `Reviewing files between ${STALE_SHA} and ${HEAD_SHA}.`,
+        `Reviewing files that changed from the base of the PR and between ${
+          STALE_SHA.slice(0, 12)
+        } and ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and between " +
+        `not-a-sha and ${HEAD_SHA}.`,
         codeRabbitReviewRange() + " but this is not the final review.",
         codeRabbitReviewRange() + ` Later requested ${STALE_SHA}.`,
         codeRabbitReviewRange().replace("Reviewing", "reviewing"),
@@ -530,8 +535,12 @@ describe("automated review gate", () => {
       body: [
         "<!-- recent_review_start -->",
         "No actionable comments were generated in the recent review.",
-        codeRabbitReviewRange(HEAD_SHA, STALE_SHA) +
-        ` but this is not the final review. Later requested ${STALE_SHA}.`,
+        [
+          codeRabbitReviewRange(HEAD_SHA, STALE_SHA) +
+          ` but this is not the final review. Later requested ${STALE_SHA}.`,
+          "Reviewing files that changed from the base of the PR and between " +
+          `not-a-sha and ${STALE_SHA}.`,
+        ].join("\n"),
         "<!-- recent_review_end -->",
       ].join("\n"),
       created_at: "2026-08-22T12:03:00Z",

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -769,6 +769,10 @@ describe("automated review gate", () => {
 
   it("classifies malformed and wrapped current-head ranges fail closed", async () => {
     const olderSuccess = olderCodeRabbitSuccess();
+    const encodedHeadSha = Array.from(
+      HEAD_SHA,
+      (character) => `&#${character.charCodeAt(0)};`,
+    ).join("");
     const rangeWords = [
       "Reviewing",
       "files",
@@ -797,6 +801,28 @@ describe("automated review gate", () => {
 
     for (
       const malformedCurrentRange of [
+        "Reviewing files that changed from the base of the PR and " +
+        `betw&#101;en not-a-sha and ${HEAD_SHA}.`,
+        "&#82;eviewing files that changed from the base of the PR and " +
+        `between not-a-sha and ${HEAD_SHA}.`,
+        "&#0000082;eviewing files that changed from the base of the PR and " +
+        `between not-a-sha and ${HEAD_SHA}.`,
+        "&#x000052;eviewing files that changed from the base of the PR and " +
+        `between not-a-sha and ${HEAD_SHA}.`,
+        "Review&#105;ng files that changed from the base of the PR and " +
+        `between not-a-sha and ${HEAD_SHA}.`,
+        "Reviewing&#32;files that changed from the base of the PR and " +
+        `between not-a-sha and ${HEAD_SHA}.`,
+        "Reviewing&nbsp;files that changed from the base of the PR and " +
+        `between not-a-sha and ${HEAD_SHA}.`,
+        "Reviewing&#160;files that changed from the base of the PR and " +
+        `between not-a-sha and ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and " +
+        `betw&ZeroWidthSpace;een not-a-sha and ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and " +
+        `betw&#8203;een not-a-sha and ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and " +
+        `between not-a-sha a&#x6e;d ${encodedHeadSha}.`,
         ...softWrappedIntroRanges,
         "> Reviewing files that changed from the base\n" +
         `> of the PR and between not-a-sha and ${HEAD_SHA}.`,
@@ -900,6 +926,37 @@ describe("automated review gate", () => {
       ))?.url,
       olderSuccess.html_url,
     );
+
+    for (
+      const nonRangeEncodedReviewingText of [
+        `x&#82;eviewing files between not-a-sha and ${HEAD_SHA}.`,
+        `&#00000082;eviewing files between not-a-sha and ${HEAD_SHA}.`,
+        "`&#82;eviewing files that changed from the base of the PR and " +
+        `between not-a-sha and ${HEAD_SHA}.\``,
+      ]
+    ) {
+      const newerNonRangeEncodedReviewingText = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          nonRangeEncodedReviewingText,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:02:00Z",
+        updated_at: "2026-08-22T12:02:00Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerNonRangeEncodedReviewingText],
+          },
+          HEAD_SHA,
+        ))?.url,
+        olderSuccess.html_url,
+        nonRangeEncodedReviewingText,
+      );
+    }
 
     const newerBareCarriageReturnCurrentRange = codeRabbitSummary({
       body: [

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1486,31 +1486,34 @@ describe("automated review gate", () => {
     );
 
     for (
-      const partiallyInlineCodeRange of [
-        `Rev\`iew\`ing files that changed from the base of the PR and between not-a-sha and ${HEAD_SHA}.`,
+      const partiallyCodeStyledRange of [
+        `Re\`view\`ing files that changed from the base of the PR and between not-a-sha and ${HEAD_SHA}.`,
+        `\`Re\`viewing files that changed from the base of the PR and between not-a-sha and ${HEAD_SHA}.`,
+        `\`Review\`ing files that changed from the base of the PR and between not-a-sha and ${HEAD_SHA}.`,
+        `\`Reviewing\` files that changed from the base of the PR and between not-a-sha and ${HEAD_SHA}.`,
         "Reviewing files that changed from the base of the PR and between " +
         `not-a-sha \`and ${HEAD_SHA}.\``,
       ]
     ) {
-      const newerPartiallyInlineCodeCurrentRange = codeRabbitSummary({
+      const newerPartiallyCodeStyledCurrentRange = codeRabbitSummary({
         body: [
           "<!-- recent_review_start -->",
           "No actionable comments were generated in the recent review.",
-          partiallyInlineCodeRange,
+          partiallyCodeStyledRange,
           "<!-- recent_review_end -->",
         ].join("\n"),
         created_at: "2026-08-22T12:03:42Z",
         updated_at: "2026-08-22T12:03:42Z",
       });
       assertEquals(
-        (await findAutomatedReview(
+        await findAutomatedReview(
           {
             reviews: [],
-            comments: [olderSuccess, newerPartiallyInlineCodeCurrentRange],
+            comments: [olderSuccess, newerPartiallyCodeStyledCurrentRange],
           },
           HEAD_SHA,
-        ))?.url,
-        olderSuccess.html_url,
+        ),
+        undefined,
       );
     }
 
@@ -2434,7 +2437,7 @@ describe("automated review gate", () => {
       olderSuccess.html_url,
     );
 
-    const currentHeadOnlyInsideCodeAfterMultilineLink = codeRabbitSummary({
+    const codeStyledCurrentHeadAfterMultilineLink = codeRabbitSummary({
       body: [
         "<!-- recent_review_start -->",
         "No actionable comments were generated in the recent review.",
@@ -2447,14 +2450,14 @@ describe("automated review gate", () => {
       updated_at: "2026-08-22T12:03:43Z",
     });
     assertEquals(
-      (await findAutomatedReview(
+      await findAutomatedReview(
         {
           reviews: [],
-          comments: [olderSuccess, currentHeadOnlyInsideCodeAfterMultilineLink],
+          comments: [olderSuccess, codeStyledCurrentHeadAfterMultilineLink],
         },
         HEAD_SHA,
-      ))?.url,
-      olderSuccess.html_url,
+      ),
+      undefined,
     );
 
     for (

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1034,6 +1034,30 @@ describe("automated review gate", () => {
       "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
     );
 
+    const newerVisibleRangeAfterCommentedFence = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "<!--",
+        "```text",
+        "-->",
+        malformedCurrentRange,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerVisibleRangeAfterCommentedFence],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+
     for (
       const visibleRangeAfterCommentLookalike of [
         ["\\<!--", malformedCurrentRange, "-->"],

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1292,6 +1292,115 @@ describe("automated review gate", () => {
     }
   });
 
+  it("preserves rendered HTML breaks while normalizing review ranges", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+    const newerSummary = (range: string) =>
+      codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          range,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:05:00Z",
+        updated_at: "2026-08-22T12:05:00Z",
+      });
+
+    for (
+      const renderedBreak of [
+        "<br>",
+        "<BR>",
+        "<br/>",
+        "<br />",
+        '<br class="markdown-break">',
+        "</br>",
+        "<hr>",
+      ]
+    ) {
+      const brokenCurrentRange = MALFORMED_CURRENT_RANGE.replace(
+        "base of",
+        `base${renderedBreak}of`,
+      );
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerSummary(brokenCurrentRange)],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+        renderedBreak,
+      );
+    }
+
+    assertEquals(
+      (
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [
+              olderSuccess,
+              newerSummary(
+                MALFORMED_CURRENT_RANGE.replace(
+                  "Reviewing",
+                  "Review<br>ing",
+                ),
+              ),
+            ],
+          },
+          HEAD_SHA,
+        )
+      )?.url,
+      olderSuccess.html_url,
+    );
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [
+            olderSuccess,
+            newerSummary(
+              MALFORMED_CURRENT_RANGE.replace(
+                "Reviewing",
+                "<strong>Reviewing</strong>",
+              ),
+            ),
+          ],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+
+    for (
+      const zeroWidthHtml of [
+        "</hr>",
+        "<wbr>",
+        "\\<br>",
+        "`<br>`",
+      ]
+    ) {
+      const visibleMalformedRange = MALFORMED_CURRENT_RANGE.replace(
+        "base of",
+        `base${zeroWidthHtml}of`,
+      );
+      assertEquals(
+        (
+          await findAutomatedReview(
+            {
+              reviews: [],
+              comments: [olderSuccess, newerSummary(visibleMalformedRange)],
+            },
+            HEAD_SHA,
+          )
+        )?.url,
+        olderSuccess.html_url,
+        zeroWidthHtml,
+      );
+    }
+  });
+
   it("rejects unterminated and Markdown-prefixed current-head ranges", async () => {
     const olderSuccess = olderCodeRabbitSuccess();
     const escapedVisibleMalformedBodies = ["\\", "\\\\", "\\\\\\"].map(

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2210,19 +2210,43 @@ describe("automated review gate", () => {
 
   it("accepts matching tied successes and rejects conflicting outcomes", async () => {
     const timestamp = "2026-08-22T12:00:00Z";
+    const successfulSummary = codeRabbitSummary({
+      created_at: timestamp,
+      updated_at: timestamp,
+    });
+    const failedSummary = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        codeRabbitReviewRange(),
+        "<!-- recent_review_end -->",
+        `Review skipped for current commit ${HEAD_SHA}.`,
+      ].join("\n"),
+      created_at: timestamp,
+      updated_at: timestamp,
+    });
     assertEquals(
       (await findAutomatedReview(
         {
           reviews: [review({ submitted_at: timestamp })],
-          comments: [codeRabbitSummary({
-            created_at: timestamp,
-            updated_at: timestamp,
-          })],
+          comments: [successfulSummary],
         },
         HEAD_SHA,
       ))?.reviewer,
       "coderabbitai[bot]",
     );
+
+    for (
+      const comments of [
+        [failedSummary, successfulSummary],
+        [successfulSummary, failedSummary],
+      ]
+    ) {
+      assertEquals(
+        await findAutomatedReview({ reviews: [], comments }, HEAD_SHA),
+        undefined,
+      );
+    }
 
     assertEquals(
       await findAutomatedReview(

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1029,6 +1029,19 @@ describe("automated review gate", () => {
           "<!-- recent_review_end -->",
         ].join("\n"),
     );
+    const decoratedVisibleMalformedBodies = [
+      ["**", "**"],
+      ["_", "_"],
+      ["~~", "~~"],
+      ["[", "](https://example.com)"],
+    ].map(([prefix, suffix]) =>
+      [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        prefix + MALFORMED_CURRENT_RANGE + suffix,
+        "<!-- recent_review_end -->",
+      ].join("\n")
+    );
 
     for (
       const unterminatedCurrentRange of [
@@ -1061,6 +1074,7 @@ describe("automated review gate", () => {
     for (
       const newerMalformedBody of [
         ...escapedVisibleMalformedBodies,
+        ...decoratedVisibleMalformedBodies,
         [
           "<!-- recent_review_start -->",
           "No actionable comments were generated in the recent review.",

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -554,6 +554,94 @@ describe("automated review gate", () => {
       );
     }
 
+    for (const prefix of ["> ", "1. ", "- [x] ", "> 1. - [ ] "]) {
+      for (
+        const compatibleCurrentRange of [
+          `${prefix}Reviewing files that changed from the base of the PR and between ` +
+          `${STALE_SHA} and\n${prefix}${HEAD_SHA}.`,
+          `${prefix}Reviewing files that changed from the base of the PR and between ` +
+          `${STALE_SHA}\n${prefix}and ${HEAD_SHA}.`,
+        ]
+      ) {
+        const newerCompatibleCurrentRange = codeRabbitSummary({
+          body: [
+            "<!-- recent_review_start -->",
+            "No actionable comments were generated in the recent review.",
+            compatibleCurrentRange,
+            "<!-- recent_review_end -->",
+          ].join("\n"),
+          created_at: "2026-08-22T12:02:00Z",
+          updated_at: "2026-08-22T12:02:00Z",
+        });
+        assertEquals(
+          await findAutomatedReview(
+            {
+              reviews: [],
+              comments: [olderSuccess, newerCompatibleCurrentRange],
+            },
+            HEAD_SHA,
+          ),
+          undefined,
+        );
+      }
+
+      const newerCompatibleStaleRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          `${prefix}Reviewing files that changed from the base of the PR and between ` +
+          `${HEAD_SHA} and\n${prefix}${STALE_SHA}.`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:02:00Z",
+        updated_at: "2026-08-22T12:02:00Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerCompatibleStaleRange],
+          },
+          HEAD_SHA,
+        ))?.source,
+        "summary",
+      );
+    }
+
+    for (
+      const separatedCurrentRange of [
+        "> Reviewing files that changed from the base of the PR and between " +
+        `${STALE_SHA} and\n${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and between " +
+        `${STALE_SHA} and\n> ${HEAD_SHA}.`,
+        "1. Reviewing files that changed from the base of the PR and between " +
+        `${STALE_SHA}\n> and ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and between " +
+        `not-a-sha\n<!-- evidence boundary -->\nand ${HEAD_SHA}.`,
+      ]
+    ) {
+      const newerSeparatedCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          separatedCurrentRange,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:02:00Z",
+        updated_at: "2026-08-22T12:02:00Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerSeparatedCurrentRange],
+          },
+          HEAD_SHA,
+        ))?.source,
+        "summary",
+      );
+    }
+
     const newerMalformedStaleRange = codeRabbitSummary({
       body: [
         "<!-- recent_review_start -->",

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1020,6 +1020,15 @@ describe("automated review gate", () => {
 
   it("rejects unterminated and Markdown-prefixed current-head ranges", async () => {
     const olderSuccess = olderCodeRabbitSuccess();
+    const escapedVisibleMalformedBodies = ["\\", "\\\\", "\\\\\\"].map(
+      (slashes) =>
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          slashes + "`" + MALFORMED_CURRENT_RANGE,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+    );
 
     for (
       const unterminatedCurrentRange of [
@@ -1051,6 +1060,7 @@ describe("automated review gate", () => {
 
     for (
       const newerMalformedBody of [
+        ...escapedVisibleMalformedBodies,
         [
           "<!-- recent_review_start -->",
           "No actionable comments were generated in the recent review.",
@@ -1166,7 +1176,6 @@ describe("automated review gate", () => {
         undefined,
       );
     }
-
     const newerExactCurrentWithMalformedBaseDuplicates = codeRabbitSummary({
       body: [
         "<!-- recent_review_start -->",
@@ -1253,6 +1262,30 @@ describe("automated review gate", () => {
         HEAD_SHA,
       ))?.url,
       "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
+    );
+
+    const newerEscapedInlineCodeCurrentRangeExample = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "\\\\" + "`" + MALFORMED_CURRENT_RANGE + "`",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:42Z",
+      updated_at: "2026-08-22T12:03:42Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [
+            olderSuccess,
+            newerEscapedInlineCodeCurrentRangeExample,
+          ],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
     );
 
     for (

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -184,6 +184,8 @@ describe("automated review gate", () => {
         `Reviewing files between ${STALE_SHA} and ${HEAD_SHA}.`,
         codeRabbitReviewRange() + " but this is not the final review.",
         codeRabbitReviewRange().replace("Reviewing", "reviewing"),
+        codeRabbitReviewRange().replace("files that", "files  that"),
+        codeRabbitReviewRange().replace(HEAD_SHA, HEAD_SHA.toUpperCase()),
       ]
     ) {
       const invalidSummary = codeRabbitSummary({
@@ -430,6 +432,47 @@ describe("automated review gate", () => {
       ),
       undefined,
     );
+  });
+
+  it("rejects any current-head skip or request marker in a summary", async () => {
+    for (
+      const markers of [
+        [
+          `Review skipped for current commit ${STALE_SHA}.`,
+          `Review skipped for current commit ${HEAD_SHA}.`,
+        ],
+        [
+          `Review skipped for current commit ${HEAD_SHA}.`,
+          `Review skipped for current commit ${STALE_SHA}.`,
+        ],
+        [
+          `Requested commit: ${STALE_SHA}.`,
+          `Requested commit: ${HEAD_SHA}.`,
+        ],
+        [
+          `Requested commit: ${HEAD_SHA}.`,
+          `Requested commit: ${STALE_SHA}.`,
+        ],
+      ]
+    ) {
+      const summary = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          codeRabbitReviewRange(),
+          "<!-- recent_review_end -->",
+          ...markers,
+        ].join("\n"),
+      });
+
+      assertEquals(
+        await findAutomatedReview(
+          { reviews: [], comments: [summary] },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
   });
 
   it("fails closed when exact-head event chronology is indeterminate", async () => {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -806,6 +806,46 @@ describe("automated review gate", () => {
       "summary",
     );
 
+    for (
+      const fencedContinuation of [
+        [
+          "Reviewing files that changed from the base of the PR and between " +
+          "not-a-sha",
+          "```text",
+          `and ${HEAD_SHA}.`,
+          "```",
+        ],
+        [
+          "> Reviewing files that changed from the base of the PR and between " +
+          "not-a-sha",
+          "> ```text",
+          `> and ${HEAD_SHA}.`,
+          "> ```",
+        ],
+      ]
+    ) {
+      const newerRangeEndingInFencedExample = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...fencedContinuation,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:42Z",
+        updated_at: "2026-08-22T12:03:42Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerRangeEndingInFencedExample],
+          },
+          HEAD_SHA,
+        ))?.source,
+        "summary",
+      );
+    }
+
     const newerManyFencedCurrentRangeExamples = codeRabbitSummary({
       body: [
         "<!-- recent_review_start -->",
@@ -1140,6 +1180,45 @@ describe("automated review gate", () => {
         HEAD_SHA,
       ))?.url,
       "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-5",
+    );
+  });
+
+  it("scans dense malformed range candidates in linear time", async () => {
+    const olderSuccess = codeRabbitSummary({
+      created_at: "2026-08-22T12:01:00Z",
+      updated_at: "2026-08-22T12:01:00Z",
+    });
+    const denseMalformedRanges = Array.from(
+      { length: 5_000 },
+      (_, index) =>
+        "Reviewing files that changed from the base of the PR and between " +
+        `malformed-base-${index}`,
+    );
+    const newerDenseMalformedRanges = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        ...denseMalformedRanges,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:02:00Z",
+      updated_at: "2026-08-22T12:02:00Z",
+    });
+
+    const startedAt = performance.now();
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerDenseMalformedRanges],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+    assert(
+      performance.now() - startedAt < 1_000,
+      "dense malformed range parsing must stay linear",
     );
   });
 

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -501,6 +501,8 @@ describe("automated review gate", () => {
         } and ${HEAD_SHA}.`,
         "Reviewing files that changed from the base of the PR and between " +
         `not-a-sha and ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and between " +
+        `not-a-sha\nand ${HEAD_SHA}.`,
         codeRabbitReviewRange() + " but this is not the final review.",
         codeRabbitReviewRange() + ` Later requested ${STALE_SHA}.`,
         codeRabbitReviewRange().replace("Reviewing", "reviewing"),
@@ -540,6 +542,8 @@ describe("automated review gate", () => {
           ` but this is not the final review. Later requested ${STALE_SHA}.`,
           "Reviewing files that changed from the base of the PR and between " +
           `not-a-sha and ${STALE_SHA}.`,
+          "Reviewing files that changed from the base of the PR and between " +
+          `not-a-sha\nand ${STALE_SHA}.`,
         ].join("\n"),
         "<!-- recent_review_end -->",
       ].join("\n"),
@@ -587,6 +591,30 @@ describe("automated review gate", () => {
 
     for (
       const newerMalformedBody of [
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          `- [ ] ${codeRabbitReviewRange()}`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          `## ${codeRabbitReviewRange()}`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          `${"- [ ] ".repeat(1_000)}${codeRabbitReviewRange()}`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          `${"###### ".repeat(1_000)}${codeRabbitReviewRange()}`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
         [
           "<!-- recent_review_start -->",
           "No actionable comments were generated in the recent review.",
@@ -679,6 +707,129 @@ describe("automated review gate", () => {
       );
     }
 
+    const newerFencedCurrentRangeExample = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "```",
+        codeRabbitReviewRange(),
+        "```",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:42Z",
+      updated_at: "2026-08-22T12:03:42Z",
+    });
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [newerFencedCurrentRangeExample],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerFencedCurrentRangeExample],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+
+    const newerManyFencedCurrentRangeExamples = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        ...Array.from({ length: 250 }, () =>
+          [
+            "```",
+            codeRabbitReviewRange(),
+            "```",
+          ].join("\n")),
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:43Z",
+      updated_at: "2026-08-22T12:03:43Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerManyFencedCurrentRangeExamples],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+
+    const newerMismatchedFenceDelimiterCurrentRangeExample = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "```",
+        "~~~",
+        codeRabbitReviewRange(),
+        "```",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:44Z",
+      updated_at: "2026-08-22T12:03:44Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [
+            olderSuccess,
+            newerMismatchedFenceDelimiterCurrentRangeExample,
+          ],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+
+    const newerNonClosingFenceLineCurrentRangeExample = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "```",
+        "```not-a-close",
+        codeRabbitReviewRange(),
+        "```",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:44Z",
+      updated_at: "2026-08-22T12:03:44Z",
+    });
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [newerNonClosingFenceLineCurrentRangeExample],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [
+            olderSuccess,
+            newerNonClosingFenceLineCurrentRangeExample,
+          ],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+
     const newerUnterminatedStaleRange = codeRabbitSummary({
       body: [
         "<!-- recent_review_start -->",
@@ -760,6 +911,31 @@ describe("automated review gate", () => {
         undefined,
       );
     }
+
+    const newerInvalidCurrentThenEmptyTail = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        codeRabbitReviewRange(),
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        codeRabbitReviewRange(HEAD_SHA, STALE_SHA),
+        "<!-- recent_review_end -->",
+        "<!-- recent_review_start -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:57Z",
+      updated_at: "2026-08-22T12:03:57Z",
+    });
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerInvalidCurrentThenEmptyTail],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
 
     const newerOutOfScopeCurrentRange = codeRabbitSummary({
       body: [

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -602,6 +602,20 @@ describe("automated review gate", () => {
         [
           "<!-- recent_review_start -->",
           "No actionable comments were generated in the recent review.",
+          "Reviewing files that changed from the base of the PR and between " +
+          `${STALE_SHA} and ${STALE_SHA}. Later requested ${HEAD_SHA}.`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          "Reviewing changed files from the base of the PR and between " +
+          `${STALE_SHA} and ${STALE_SHA}. Later requested ${HEAD_SHA}.`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
           codeRabbitReviewRange(),
           "<!-- recent_review_end -->",
           "<!-- recent_review_start -->",
@@ -688,6 +702,74 @@ describe("automated review gate", () => {
         HEAD_SHA,
       ))?.source,
       "summary",
+    );
+
+    const newerStaleRangeThenDiagnostic = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        codeRabbitReviewRange(HEAD_SHA, STALE_SHA),
+        `Diagnostic commit: ${HEAD_SHA}.`,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:04:30Z",
+      updated_at: "2026-08-22T12:04:30Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerStaleRangeThenDiagnostic],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+
+    const newerUnrelatedBetweenText = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        `Reviewing files between jobs for ${STALE_SHA}; diagnostic ${HEAD_SHA}.`,
+        codeRabbitReviewRange(HEAD_SHA, STALE_SHA),
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:04:45Z",
+      updated_at: "2026-08-22T12:04:45Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerUnrelatedBetweenText],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+
+    const newerExactCurrentWithDiagnostic = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        codeRabbitReviewRange(),
+        `Diagnostic commit: ${HEAD_SHA}.`,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:05:00Z",
+      updated_at: "2026-08-22T12:05:00Z",
+      html_url:
+        "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-5",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerExactCurrentWithDiagnostic],
+        },
+        HEAD_SHA,
+      ))?.url,
+      "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-5",
     );
   });
 

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1065,6 +1065,33 @@ describe("automated review gate", () => {
       "summary",
     );
 
+    const newerWhitespaceOnlyRangeStart = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "Reviewing files that changed from the base of the PR and between" +
+        " ".repeat(2_000),
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:04:50Z",
+      updated_at: "2026-08-22T12:04:50Z",
+    });
+    const whitespaceOnlyStartedAt = performance.now();
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerWhitespaceOnlyRangeStart],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+    assert(
+      performance.now() - whitespaceOnlyStartedAt < 1_000,
+      "whitespace-only malformed range parsing must stay linear",
+    );
+
     const newerExactCurrentWithDiagnostic = codeRabbitSummary({
       body: [
         "<!-- recent_review_start -->",

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -152,6 +152,25 @@ describe("automated review gate", () => {
         ?.source,
       "summary",
     );
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [
+            codeRabbitSummary({
+              body: [
+                "<!-- recent_review_start -->",
+                "No actionable comments were generated in the recent review.",
+                codeRabbitReviewRange(),
+                "<!-- recent_review_end -->",
+              ].join("\r"),
+            }),
+          ],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
   });
 
   it("requires CodeRabbit's exact current base-change review sentence", async () => {
@@ -505,6 +524,10 @@ describe("automated review gate", () => {
         `not a sha and ${HEAD_SHA}.`,
         "Reviewing files that changed from the base of the PR and between " +
         `not-a-sha\nand ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and between " +
+        `not-a-sha\rand ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and between " +
+        `not-a-sha and\r${HEAD_SHA}.`,
         "Reviewing files that changed from the base of the PR and between\n" +
         `${STALE_SHA}\nand ${HEAD_SHA}.`,
         "Reviewing files that changed from the base of the PR and between\n" +
@@ -553,6 +576,49 @@ describe("automated review gate", () => {
         undefined,
       );
     }
+
+    const newerBareCarriageReturnCurrentRange = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "Reviewing files that changed from the base of the PR and between " +
+        `not-a-sha and ${HEAD_SHA}.`,
+        "<!-- recent_review_end -->",
+      ].join("\r"),
+      created_at: "2026-08-22T12:02:00Z",
+      updated_at: "2026-08-22T12:02:00Z",
+    });
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerBareCarriageReturnCurrentRange],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+
+    const newerBareCarriageReturnStaleRange = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        codeRabbitReviewRange(HEAD_SHA, STALE_SHA),
+        "<!-- recent_review_end -->",
+      ].join("\r"),
+      created_at: "2026-08-22T12:02:00Z",
+      updated_at: "2026-08-22T12:02:00Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerBareCarriageReturnStaleRange],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
 
     for (const prefix of ["> ", "1. ", "- [x] ", "> 1. - [ ] "]) {
       for (
@@ -1596,6 +1662,32 @@ describe("automated review gate", () => {
     assert(
       performance.now() - startedAt < 1_000,
       "dense malformed range parsing must stay linear",
+    );
+
+    const newerDenseBareCarriageReturnRanges = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        ...denseMalformedRanges,
+        "<!-- recent_review_end -->",
+      ].join("\r"),
+      created_at: "2026-08-22T12:02:00Z",
+      updated_at: "2026-08-22T12:02:00Z",
+    });
+    const denseBareCarriageReturnStartedAt = performance.now();
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerDenseBareCarriageReturnRanges],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+    assert(
+      performance.now() - denseBareCarriageReturnStartedAt < 1_000,
+      "dense bare carriage-return range parsing must stay linear",
     );
 
     const newerBareCarriageReturnLine = codeRabbitSummary({

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -14,6 +14,9 @@ import {
 
 const HEAD_SHA = "a".repeat(40);
 const STALE_SHA = "b".repeat(40);
+const MALFORMED_CURRENT_RANGE =
+  "Reviewing files that changed from the base of the PR and between " +
+  `not-a-sha and ${HEAD_SHA}.`;
 const CODEX_BOT_ID = 199175422;
 const WORKFLOW_PATH = new URL(
   "../../.github/workflows/automated-review-gate.yml",
@@ -59,6 +62,40 @@ function codeRabbitSummary(
     updated_at: "2026-08-22T12:00:00Z",
     ...overrides,
   };
+}
+
+function codeRabbitRecentReviewSummary(
+  reviewContent: string[],
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return codeRabbitSummary({
+    body: [
+      "<!-- recent_review_start -->",
+      ...reviewContent,
+      "<!-- recent_review_end -->",
+    ].join("\n"),
+    ...overrides,
+  });
+}
+
+function olderCodeRabbitSuccess(): Record<string, unknown> {
+  return codeRabbitSummary({
+    created_at: "2026-08-22T12:01:00Z",
+    updated_at: "2026-08-22T12:01:00Z",
+  });
+}
+
+function findCodeRabbitComments(...comments: Record<string, unknown>[]) {
+  return findAutomatedReview({ reviews: [], comments }, HEAD_SHA);
+}
+
+async function assertCodeRabbitSummaryRejected(
+  ...reviewContent: string[]
+): Promise<void> {
+  assertEquals(
+    await findCodeRabbitComments(codeRabbitRecentReviewSummary(reviewContent)),
+    undefined,
+  );
 }
 
 function codexNoFindingComment(
@@ -221,6 +258,49 @@ describe("automated review gate", () => {
           HEAD_SHA,
         ),
         undefined,
+      );
+    }
+  });
+
+  it("rejects an HTML-commented CodeRabbit no-actionable verdict", async () => {
+    await assertCodeRabbitSummaryRejected(
+      "<!--",
+      "No actionable comments were generated in the recent review.",
+      "-->",
+      codeRabbitReviewRange(),
+    );
+  });
+
+  it("rejects a fenced CodeRabbit no-actionable verdict", async () => {
+    await assertCodeRabbitSummaryRejected(
+      "```text",
+      "No actionable comments were generated in the recent review.",
+      "```",
+      codeRabbitReviewRange(),
+    );
+  });
+
+  it("rejects an inline-code CodeRabbit no-actionable verdict", async () => {
+    await assertCodeRabbitSummaryRejected(
+      "`inline code starts",
+      "No actionable comments were generated in the recent review.",
+      "inline code closes`",
+      codeRabbitReviewRange(),
+    );
+  });
+
+  it("requires CodeRabbit's exact no-actionable verdict line", async () => {
+    for (
+      const alteredVerdict of [
+        " No actionable comments were generated in the recent review.",
+        "No actionable comments were generated in the recent review. ",
+        "> No actionable comments were generated in the recent review.",
+        "No actionable comments were generated in the recent review. Example.",
+      ]
+    ) {
+      await assertCodeRabbitSummaryRejected(
+        alteredVerdict,
+        codeRabbitReviewRange(),
       );
     }
   });
@@ -506,11 +586,8 @@ describe("automated review gate", () => {
     );
   });
 
-  it("lets a malformed current-head range override an older valid review", async () => {
-    const olderSuccess = codeRabbitSummary({
-      created_at: "2026-08-22T12:01:00Z",
-      updated_at: "2026-08-22T12:01:00Z",
-    });
+  it("classifies malformed and wrapped current-head ranges fail closed", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
 
     for (
       const malformedCurrentRange of [
@@ -752,6 +829,10 @@ describe("automated review gate", () => {
       ))?.source,
       "summary",
     );
+  });
+
+  it("rejects unterminated and Markdown-prefixed current-head ranges", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
 
     for (
       const unterminatedCurrentRange of [
@@ -926,6 +1007,10 @@ describe("automated review gate", () => {
       ),
       undefined,
     );
+  });
+
+  it("scopes range evidence outside inline code and fenced blocks", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
 
     const newerFencedCurrentRangeExample = codeRabbitSummary({
       body: [
@@ -983,9 +1068,6 @@ describe("automated review gate", () => {
       "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
     );
 
-    const malformedCurrentRange =
-      "Reviewing files that changed from the base of the PR and between " +
-      `not-a-sha and ${HEAD_SHA}.`;
     for (
       const paragraphBoundary of [
         "> quoted block",
@@ -1003,7 +1085,7 @@ describe("automated review gate", () => {
           "No actionable comments were generated in the recent review.",
           "`inline code starts",
           paragraphBoundary,
-          malformedCurrentRange,
+          MALFORMED_CURRENT_RANGE,
           "inline code closes`",
           "<!-- recent_review_end -->",
         ].join("\n"),
@@ -1024,11 +1106,11 @@ describe("automated review gate", () => {
 
     for (
       const escapedContainerFence of [
-        ["> ```text", malformedCurrentRange, "```"],
-        [">     ```text", `> ${malformedCurrentRange}`, "> ```"],
-        ["- ```text", malformedCurrentRange, "```"],
-        ["   - ```text", `  ${malformedCurrentRange}`, "  ```"],
-        ["> - ```text", `>  ${malformedCurrentRange}`, ">  ```"],
+        ["> ```text", MALFORMED_CURRENT_RANGE, "```"],
+        [">     ```text", `> ${MALFORMED_CURRENT_RANGE}`, "> ```"],
+        ["- ```text", MALFORMED_CURRENT_RANGE, "```"],
+        ["   - ```text", `  ${MALFORMED_CURRENT_RANGE}`, "  ```"],
+        ["> - ```text", `>  ${MALFORMED_CURRENT_RANGE}`, ">  ```"],
       ]
     ) {
       const newerCurrentRangeOutsideFenceContainer = codeRabbitSummary({
@@ -1055,12 +1137,12 @@ describe("automated review gate", () => {
 
     for (
       const containedFence of [
-        ["> ```text", `> ${malformedCurrentRange}`, "> ```"],
-        [">    ```text", `> ${malformedCurrentRange}`, "> ```"],
-        ["- ```text", `  ${malformedCurrentRange}`, "  ```"],
-        ["   - ```text", `     ${malformedCurrentRange}`, "     ```"],
-        ["- [ ] ```text", `      ${malformedCurrentRange}`, "      ```"],
-        ["> - ```text", `>   ${malformedCurrentRange}`, ">   ```"],
+        ["> ```text", `> ${MALFORMED_CURRENT_RANGE}`, "> ```"],
+        [">    ```text", `> ${MALFORMED_CURRENT_RANGE}`, "> ```"],
+        ["- ```text", `  ${MALFORMED_CURRENT_RANGE}`, "  ```"],
+        ["   - ```text", `     ${MALFORMED_CURRENT_RANGE}`, "     ```"],
+        ["- [ ] ```text", `      ${MALFORMED_CURRENT_RANGE}`, "      ```"],
+        ["> - ```text", `>   ${MALFORMED_CURRENT_RANGE}`, ">   ```"],
       ]
     ) {
       const newerCurrentRangeInsideFenceContainer = codeRabbitSummary({
@@ -1090,37 +1172,37 @@ describe("automated review gate", () => {
         [
           "- ```md",
           "  # example",
-          `  ${malformedCurrentRange}`,
+          `  ${MALFORMED_CURRENT_RANGE}`,
           "  ```",
         ],
         [
           "> ```md",
           "> - example",
-          `> ${malformedCurrentRange}`,
+          `> ${MALFORMED_CURRENT_RANGE}`,
           "> ```",
         ],
         [
           "> - ```md",
           ">   # example",
-          `>   ${malformedCurrentRange}`,
+          `>   ${MALFORMED_CURRENT_RANGE}`,
           ">   ```",
         ],
         [
           "- ```md",
           "  - ```",
-          `  ${malformedCurrentRange}`,
+          `  ${MALFORMED_CURRENT_RANGE}`,
           "  ```",
         ],
         [
           "- ```md",
           "",
-          `  ${malformedCurrentRange}`,
+          `  ${MALFORMED_CURRENT_RANGE}`,
           "  ```",
         ],
         [
           "> - ```md",
           ">",
-          `>   ${malformedCurrentRange}`,
+          `>   ${MALFORMED_CURRENT_RANGE}`,
           ">   ```",
         ],
       ]
@@ -1149,12 +1231,12 @@ describe("automated review gate", () => {
 
     for (
       const closedContainerFence of [
-        ["- ```text", "  example", "  ```", malformedCurrentRange],
+        ["- ```text", "  example", "  ```", MALFORMED_CURRENT_RANGE],
         [
           "> - ```text",
           ">   example",
           ">   ```",
-          malformedCurrentRange,
+          MALFORMED_CURRENT_RANGE,
         ],
       ]
     ) {
@@ -1182,8 +1264,8 @@ describe("automated review gate", () => {
 
     for (
       const tabSensitiveFence of [
-        ["- ```text", "\t```", malformedCurrentRange],
-        ["\t```text", malformedCurrentRange],
+        ["- ```text", "\t```", MALFORMED_CURRENT_RANGE],
+        ["\t```text", MALFORMED_CURRENT_RANGE],
       ]
     ) {
       const newerVisibleCurrentRangeAroundTabFence = codeRabbitSummary({
@@ -1236,7 +1318,7 @@ describe("automated review gate", () => {
         body: [
           "<!-- recent_review_start -->",
           "No actionable comments were generated in the recent review.",
-          malformedCurrentRange,
+          MALFORMED_CURRENT_RANGE,
           "<!-- recent_review_end -->",
           ...nonStructuralMarkerExample,
         ].join("\n"),
@@ -1260,7 +1342,7 @@ describe("automated review gate", () => {
         "<!-- recent_review_start -->",
         "No actionable comments were generated in the recent review.",
         "   ```text",
-        malformedCurrentRange,
+        MALFORMED_CURRENT_RANGE,
         "   ```",
         "<!-- recent_review_end -->",
       ].join("\n"),
@@ -1277,6 +1359,10 @@ describe("automated review gate", () => {
       ))?.source,
       "summary",
     );
+  });
+
+  it("scopes HTML comments and validates fence openers", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
 
     const newerHtmlCommentedCurrentRange = codeRabbitSummary({
       body: [
@@ -1317,7 +1403,7 @@ describe("automated review gate", () => {
         "<!--",
         "```text",
         "-->",
-        malformedCurrentRange,
+        MALFORMED_CURRENT_RANGE,
         "<!-- recent_review_end -->",
       ].join("\n"),
       created_at: "2026-08-22T12:03:41Z",
@@ -1336,18 +1422,18 @@ describe("automated review gate", () => {
 
     for (
       const visibleRangeAfterCommentLookalike of [
-        ["\\<!--", malformedCurrentRange, "-->"],
-        ["`<!--`", malformedCurrentRange, "-->"],
-        ["``<!--``", malformedCurrentRange, "-->"],
-        ["inline code ```<!--```", malformedCurrentRange, "-->"],
+        ["\\<!--", MALFORMED_CURRENT_RANGE, "-->"],
+        ["`<!--`", MALFORMED_CURRENT_RANGE, "-->"],
+        ["``<!--``", MALFORMED_CURRENT_RANGE, "-->"],
+        ["inline code ```<!--```", MALFORMED_CURRENT_RANGE, "-->"],
         [
           "`multiline inline code starts",
           "text <!--",
           "multiline inline code closes`",
-          malformedCurrentRange,
+          MALFORMED_CURRENT_RANGE,
           "-->",
         ],
-        ["```", "<!--", "```", malformedCurrentRange, "-->"],
+        ["```", "<!--", "```", MALFORMED_CURRENT_RANGE, "-->"],
       ]
     ) {
       const newerVisibleCurrentRange = codeRabbitSummary({
@@ -1378,7 +1464,7 @@ describe("automated review gate", () => {
           "<!-- recent_review_start -->",
           "No actionable comments were generated in the recent review.",
           activeCommentAfterLiteralBacktick,
-          malformedCurrentRange,
+          MALFORMED_CURRENT_RANGE,
           "-->",
           "<!-- recent_review_end -->",
         ].join("\n"),
@@ -1402,7 +1488,7 @@ describe("automated review gate", () => {
         "<!-- recent_review_start -->",
         "No actionable comments were generated in the recent review.",
         "```js`oops",
-        malformedCurrentRange,
+        MALFORMED_CURRENT_RANGE,
         "```",
         "<!-- recent_review_end -->",
       ].join("\n"),
@@ -1425,7 +1511,7 @@ describe("automated review gate", () => {
         "<!-- recent_review_start -->",
         "No actionable comments were generated in the recent review.",
         "~~~js`allowed",
-        malformedCurrentRange,
+        MALFORMED_CURRENT_RANGE,
         "~~~",
         "<!-- recent_review_end -->",
       ].join("\n"),
@@ -1442,6 +1528,10 @@ describe("automated review gate", () => {
       ))?.source,
       "summary",
     );
+  });
+
+  it("keeps fence continuation examples excluded", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
 
     for (
       const fencedContinuation of [
@@ -1572,6 +1662,10 @@ describe("automated review gate", () => {
       ))?.source,
       "summary",
     );
+  });
+
+  it("handles unterminated and nested recent-review groups", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
 
     const newerUnterminatedStaleRange = codeRabbitSummary({
       body: [
@@ -1679,6 +1773,10 @@ describe("automated review gate", () => {
       ),
       undefined,
     );
+  });
+
+  it("ignores out-of-scope and diagnostic commit text", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
 
     const newerOutOfScopeCurrentRange = codeRabbitSummary({
       body: [
@@ -1767,6 +1865,10 @@ describe("automated review gate", () => {
       ))?.source,
       "summary",
     );
+  });
+
+  it("keeps whitespace-only malformed range parsing linear", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
 
     const newerWhitespaceOnlyRangeStart = codeRabbitSummary({
       body: [
@@ -1794,6 +1896,10 @@ describe("automated review gate", () => {
       performance.now() - whitespaceOnlyStartedAt < 1_000,
       "whitespace-only malformed range parsing must stay linear",
     );
+  });
+
+  it("accepts an exact range with unrelated diagnostic text", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
 
     const newerExactCurrentWithDiagnostic = codeRabbitSummary({
       body: [

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -587,6 +587,36 @@ describe("automated review gate", () => {
         [
           "<!-- recent_review_start -->",
           "No actionable comments were generated in the recent review.",
+          `    ${codeRabbitReviewRange()}`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          `> ${codeRabbitReviewRange()}`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          `1. ${codeRabbitReviewRange()}`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          `> 1. ${codeRabbitReviewRange()}`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          `${"> ".repeat(2_000)}${codeRabbitReviewRange()}`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
           "Reviewing changed files from the base of the PR and between " +
           `${STALE_SHA} and ${HEAD_SHA}.`,
           "<!-- recent_review_end -->",
@@ -659,6 +689,68 @@ describe("automated review gate", () => {
       ))?.source,
       "summary",
     );
+
+    const newerCompleteCurrentThenUnterminatedStale = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        codeRabbitReviewRange(),
+        "<!-- recent_review_end -->",
+        "<!-- recent_review_start -->",
+        codeRabbitReviewRange(HEAD_SHA, STALE_SHA),
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:50Z",
+      updated_at: "2026-08-22T12:03:50Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerCompleteCurrentThenUnterminatedStale],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+
+    for (
+      const newerNestedMarkerBody of [
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          codeRabbitReviewRange(),
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          codeRabbitReviewRange(HEAD_SHA, STALE_SHA),
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          codeRabbitReviewRange(HEAD_SHA, STALE_SHA),
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          codeRabbitReviewRange(),
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+      ]
+    ) {
+      const newerNestedMarkers = codeRabbitSummary({
+        body: newerNestedMarkerBody,
+        created_at: "2026-08-22T12:03:55Z",
+        updated_at: "2026-08-22T12:03:55Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerNestedMarkers],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
 
     const newerOutOfScopeCurrentRange = codeRabbitSummary({
       body: [

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -958,6 +958,50 @@ describe("automated review gate", () => {
       );
     }
 
+    for (
+      const fenceWithMarkdownLookingCode of [
+        [
+          "- ```md",
+          "  # example",
+          `  ${malformedCurrentRange}`,
+          "  ```",
+        ],
+        [
+          "> ```md",
+          "> - example",
+          `> ${malformedCurrentRange}`,
+          "> ```",
+        ],
+        [
+          "> - ```md",
+          ">   # example",
+          `>   ${malformedCurrentRange}`,
+          ">   ```",
+        ],
+      ]
+    ) {
+      const newerMarkdownLookingCodeInsideFence = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...fenceWithMarkdownLookingCode,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerMarkdownLookingCodeInsideFence],
+          },
+          HEAD_SHA,
+        ))?.source,
+        "summary",
+      );
+    }
+
     const newerHtmlCommentedCurrentRange = codeRabbitSummary({
       body: [
         "<!-- recent_review_start -->",

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1516,28 +1516,97 @@ describe("automated review gate", () => {
 
   it("excludes indented code from range evidence", async () => {
     const olderSuccess = olderCodeRabbitSuccess();
-    const newerIndentedMalformedCurrentRange = codeRabbitSummary({
-      body: [
-        "<!-- recent_review_start -->",
-        "No actionable comments were generated in the recent review.",
-        "",
-        `    ${MALFORMED_CURRENT_RANGE}`,
-        "<!-- recent_review_end -->",
-      ].join("\n"),
-      created_at: "2026-08-22T12:03:43Z",
-      updated_at: "2026-08-22T12:03:43Z",
-    });
-
-    assertEquals(
-      (await findAutomatedReview(
+    for (
+      const { beforeRange, visibleIndent, hiddenIndent } of [
+        { beforeRange: [""], hiddenIndent: "    " },
         {
-          reviews: [],
-          comments: [olderSuccess, newerIndentedMalformedCurrentRange],
+          beforeRange: ["- list item", ""],
+          hiddenIndent: " ".repeat(6),
+          visibleIndent: " ".repeat(5),
         },
-        HEAD_SHA,
-      ))?.url,
-      olderSuccess.html_url,
-    );
+        {
+          beforeRange: ["", "9. list item", ""],
+          hiddenIndent: " ".repeat(7),
+          visibleIndent: " ".repeat(6),
+        },
+        {
+          beforeRange: ["", "123. list item", ""],
+          hiddenIndent: " ".repeat(9),
+          visibleIndent: " ".repeat(8),
+        },
+        {
+          beforeRange: ["", "123456789. list item", ""],
+          hiddenIndent: " ".repeat(15),
+          visibleIndent: " ".repeat(14),
+        },
+        {
+          beforeRange: ["- outer", "  - inner", ""],
+          hiddenIndent: " ".repeat(8),
+          visibleIndent: " ".repeat(7),
+        },
+        {
+          beforeRange: ["> - list item", ">"],
+          hiddenIndent: `>${" ".repeat(7)}`,
+          visibleIndent: `>${" ".repeat(6)}`,
+        },
+        {
+          beforeRange: ["- list item", "", "outside paragraph", ""],
+          hiddenIndent: "    ",
+        },
+        {
+          beforeRange: ["ordinary paragraph", "123. not a list", ""],
+          hiddenIndent: "    ",
+        },
+      ]
+    ) {
+      if (visibleIndent !== undefined) {
+        const newerVisibleListContinuation = codeRabbitSummary({
+          body: [
+            "<!-- recent_review_start -->",
+            "No actionable comments were generated in the recent review.",
+            ...beforeRange,
+            `${visibleIndent}${MALFORMED_CURRENT_RANGE}`,
+            "<!-- recent_review_end -->",
+          ].join("\n"),
+          created_at: "2026-08-22T12:03:44Z",
+          updated_at: "2026-08-22T12:03:44Z",
+        });
+        assertEquals(
+          await findAutomatedReview(
+            {
+              reviews: [],
+              comments: [olderSuccess, newerVisibleListContinuation],
+            },
+            HEAD_SHA,
+          ),
+          undefined,
+          JSON.stringify({ beforeRange, visibleIndent }),
+        );
+      }
+
+      const newerIndentedCode = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...beforeRange,
+          `${hiddenIndent}${MALFORMED_CURRENT_RANGE}`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:45Z",
+        updated_at: "2026-08-22T12:03:45Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerIndentedCode],
+          },
+          HEAD_SHA,
+        ))?.url,
+        olderSuccess.html_url,
+        JSON.stringify({ beforeRange, hiddenIndent }),
+      );
+    }
   });
 
   it("scopes HTML comments and validates fence openers", async () => {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1442,6 +1442,32 @@ describe("automated review gate", () => {
       "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
     );
 
+    const newerTabbedBlockquotedCommentedCurrentRange = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        ">\t<!--",
+        `> ${codeRabbitReviewRange()}`,
+        "> -->",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [
+            olderSuccess,
+            newerTabbedBlockquotedCommentedCurrentRange,
+          ],
+        },
+        HEAD_SHA,
+      ))?.url,
+      "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
+    );
+
     const newerVisibleRangeAfterCommentedFence = codeRabbitSummary({
       body: [
         "<!-- recent_review_start -->",
@@ -1469,6 +1495,11 @@ describe("automated review gate", () => {
     for (
       const visibleRangeAfterCommentLookalike of [
         ["\\<!--", MALFORMED_CURRENT_RANGE, "-->"],
+        ["    <!--", MALFORMED_CURRENT_RANGE, "-->"],
+        ["    example <!--", MALFORMED_CURRENT_RANGE, "-->"],
+        ["\t<!--", MALFORMED_CURRENT_RANGE, "-->"],
+        [">     <!--", `> ${MALFORMED_CURRENT_RANGE}`, "> -->"],
+        [">     example <!--", `> ${MALFORMED_CURRENT_RANGE}`, "> -->"],
         ["`<!--`", MALFORMED_CURRENT_RANGE, "-->"],
         ["``<!--``", MALFORMED_CURRENT_RANGE, "-->"],
         ["inline code ```<!--```", MALFORMED_CURRENT_RANGE, "-->"],

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1607,6 +1607,129 @@ describe("automated review gate", () => {
     );
   });
 
+  it("does not let incomplete inline comments cross Markdown blocks", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+
+    for (
+      const visibleRangeAfterIncompleteInlineComment of [
+        ["ordinary text <!--", MALFORMED_CURRENT_RANGE],
+        ["ordinary text <!--", "", MALFORMED_CURRENT_RANGE, "-->"],
+        ["ordinary text <!--", "# next block", MALFORMED_CURRENT_RANGE, "-->"],
+      ]
+    ) {
+      const newerVisibleCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...visibleRangeAfterIncompleteInlineComment,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerVisibleCurrentRange],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
+
+    const newerHiddenCurrentRange = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "ordinary text <!--",
+        codeRabbitReviewRange(),
+        "-->",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      html_url:
+        "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-valid-inline-comment",
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerHiddenCurrentRange],
+        },
+        HEAD_SHA,
+      ))?.url,
+      "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
+    );
+  });
+
+  it("keeps raw-block backticks from masking later comments", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+    for (
+      const [index, earlierComment] of [
+        "<!-- ` -->",
+        "ordinary text <!-- ` -->",
+      ].entries()
+    ) {
+      const newerHiddenCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          earlierComment,
+          "<!--",
+          codeRabbitReviewRange(),
+          "-->",
+          "`",
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        html_url:
+          `https://github.com/veryfront/veryfront-code/pull/1#issuecomment-raw-backtick-${index}`,
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerHiddenCurrentRange],
+          },
+          HEAD_SHA,
+        ))?.url,
+        "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
+      );
+    }
+  });
+
+  it("keeps structural review markers outside unmatched inline code", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+    const newerMalformedCurrentRange = codeRabbitSummary({
+      body: [
+        "`possible inline code",
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        MALFORMED_CURRENT_RANGE,
+        "<!-- recent_review_end -->",
+        "possible inline code closes`",
+      ].join("\n"),
+      html_url:
+        "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-structural-marker",
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerMalformedCurrentRange],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+  });
+
   it("keeps fence continuation examples excluded", async () => {
     const olderSuccess = olderCodeRabbitSuccess();
 

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1396,6 +1396,52 @@ describe("automated review gate", () => {
       "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
     );
 
+    const newerVisibleRangeAfterBlockquotedComment = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "> <!--",
+        MALFORMED_CURRENT_RANGE,
+        "-->",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerVisibleRangeAfterBlockquotedComment],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+
+    const newerBlockquotedCommentedCurrentRange = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "> <!--",
+        `> ${codeRabbitReviewRange()}`,
+        "> -->",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerBlockquotedCommentedCurrentRange],
+        },
+        HEAD_SHA,
+      ))?.url,
+      "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
+    );
+
     const newerVisibleRangeAfterCommentedFence = codeRabbitSummary({
       body: [
         "<!-- recent_review_start -->",

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -697,6 +697,35 @@ describe("automated review gate", () => {
   it("keeps markers inside invalid reference definitions visible", async () => {
     const olderSuccess = olderCodeRabbitSuccess();
     for (
+      const marker of [
+        `Requested commit: ${HEAD_SHA}`,
+        `Review skipped for current commit ${HEAD_SHA}.`,
+      ]
+    ) {
+      const markerBeforeReviewEnd = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          "",
+          `[${marker}]:`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:05:00Z",
+        html_url:
+          "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-invalid-reference-before-end",
+        updated_at: "2026-08-22T12:05:00Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          { reviews: [], comments: [olderSuccess, markerBeforeReviewEnd] },
+          HEAD_SHA,
+        ),
+        undefined,
+        marker,
+      );
+    }
+
+    for (
       const visibleDefinitionLookalike of [
         ["", `[Requested commit: ${HEAD_SHA}]:`],
         [
@@ -743,6 +772,12 @@ describe("automated review gate", () => {
 
     for (
       const malformedCurrentRange of [
+        "`Reviewing files that changed from the base of the PR and between " +
+        `not-a-sha and ${HEAD_SHA}.`,
+        "`Reviewing files that changed from the base of the PR and between " +
+        `not-a-sha\nand ${HEAD_SHA}.`,
+        "`Reviewing files that changed from the base of the PR and between " +
+        `${STALE_SHA}\nand ${HEAD_SHA}.`,
         `Reviewing files between ${STALE_SHA} and ${HEAD_SHA}.`,
         `Reviewing files that changed from the base of the PR and between ${
           STALE_SHA.slice(0, 12)
@@ -2724,6 +2759,14 @@ describe("automated review gate", () => {
           "  | --- |",
           `  | ${MALFORMED_CURRENT_RANGE} |`,
           "  | ` |",
+        ],
+        [
+          "-   item",
+          "",
+          "    | header ` |",
+          "    | --- |",
+          `    | ${MALFORMED_CURRENT_RANGE} |`,
+          "    | ` |",
         ],
         [
           "- | header ` |",

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -801,6 +801,30 @@ describe("automated review gate", () => {
 
     for (
       const malformedCurrentRange of [
+        "Review<strong>ing</strong> files that changed from the base of the " +
+        `PR and betw<em>ee</em>n not-a-sha and ${HEAD_SHA}.`,
+        "Review<strong>ing</strong> files that changed from the base\n" +
+        `of the PR and between not-a-sha and ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base\\\n" +
+        `of the PR and between not-a-sha and ${HEAD_SHA}.`,
+        "Rev<!-- hidden -->iewing files that changed from the base\n" +
+        `of the PR and between not-a-sha and ${HEAD_SHA}.`,
+        "> Review<strong>ing</strong> files that changed from the base\n" +
+        `> of the PR and between not-a-sha and ${HEAD_SHA}.`,
+        "> Review<strong>ing</strong> files that changed from the base\n" +
+        `of the PR and between not-a-sha and ${HEAD_SHA}.`,
+        "| review |\n| --- |\n" +
+        "| Review<strong>ing</strong> files that changed from the base |\n" +
+        `| of the PR and betw<em>ee</em>n not-a-sha and ${HEAD_SHA}. |`,
+        "Rev**iew**ing files that changed from the base of the PR and " +
+        `betw[ee](https://example.com)n not-a-sha and ${HEAD_SHA}.`,
+        "Rev**iew**ing files that changed from the base of the PR and " +
+        "betw[ee](https://example.com)n not-a-sha\n" +
+        `and ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and between " +
+        `not-a-sha [and](https://example.com \"\nhidden title\n\") ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and between " +
+        `not-a-sha [x](https://example.com \"\nhidden title\n\") and ${HEAD_SHA}.`,
         "Reviewing files that changed from the base of the PR and " +
         `betw&#101;en not-a-sha and ${HEAD_SHA}.`,
         "&#82;eviewing files that changed from the base of the PR and " +
@@ -930,6 +954,8 @@ describe("automated review gate", () => {
     for (
       const nonRangeEncodedReviewingText of [
         `x&#82;eviewing files between not-a-sha and ${HEAD_SHA}.`,
+        `x<strong>Reviewing</strong> files between not-a-sha and ${HEAD_SHA}.`,
+        `&#120;<strong>Reviewing</strong> files between not-a-sha and ${HEAD_SHA}.`,
         `&#00000082;eviewing files between not-a-sha and ${HEAD_SHA}.`,
         "`&#82;eviewing files that changed from the base of the PR and " +
         `between not-a-sha and ${HEAD_SHA}.\``,
@@ -1458,6 +1484,35 @@ describe("automated review gate", () => {
       ))?.url,
       "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
     );
+
+    for (
+      const partiallyInlineCodeRange of [
+        `Rev\`iew\`ing files that changed from the base of the PR and between not-a-sha and ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and between " +
+        `not-a-sha \`and ${HEAD_SHA}.\``,
+      ]
+    ) {
+      const newerPartiallyInlineCodeCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          partiallyInlineCodeRange,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:42Z",
+        updated_at: "2026-08-22T12:03:42Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerPartiallyInlineCodeCurrentRange],
+          },
+          HEAD_SHA,
+        ))?.url,
+        olderSuccess.html_url,
+      );
+    }
 
     const newerEscapedInlineCodeCurrentRangeExample = codeRabbitSummary({
       body: [
@@ -2331,6 +2386,77 @@ describe("automated review gate", () => {
       "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
     );
 
+    const currentHeadOnlyInsideMultilineComment = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "Reviewing files that changed from the base of the PR and between " +
+        `${STALE_SHA} <!--`,
+        `and ${HEAD_SHA}.`,
+        "-->",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, currentHeadOnlyInsideMultilineComment],
+        },
+        HEAD_SHA,
+      ))?.url,
+      olderSuccess.html_url,
+    );
+
+    const currentHeadOnlyInsideMultilineLinkTitle = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "Reviewing files that changed from the base of the PR and between " +
+        `${STALE_SHA} [x](https://example.com \"`,
+        `and ${HEAD_SHA}.`,
+        `\")`,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:42Z",
+      updated_at: "2026-08-22T12:03:42Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, currentHeadOnlyInsideMultilineLinkTitle],
+        },
+        HEAD_SHA,
+      ))?.url,
+      olderSuccess.html_url,
+    );
+
+    const currentHeadOnlyInsideCodeAfterMultilineLink = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        'Reviewing[](https://example.com "',
+        "title",
+        `\") files that changed from the base of the PR and between ${STALE_SHA} \`and ${HEAD_SHA}.\``,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:43Z",
+      updated_at: "2026-08-22T12:03:43Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, currentHeadOnlyInsideCodeAfterMultilineLink],
+        },
+        HEAD_SHA,
+      ))?.url,
+      olderSuccess.html_url,
+    );
+
     for (
       const hiddenInlineComment of [
         [
@@ -2496,6 +2622,30 @@ describe("automated review gate", () => {
         "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
       );
     }
+
+    const decoratedRangeBeforeTypeSixHtmlBlock = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "Review<strong>ing</strong> files that changed from the base",
+        "<div>",
+        `of the PR and between not-a-sha and ${HEAD_SHA}.`,
+        "</div>",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, decoratedRangeBeforeTypeSixHtmlBlock],
+        },
+        HEAD_SHA,
+      ))?.url,
+      olderSuccess.html_url,
+    );
 
     const currentSummaryWithHiddenMarkers = codeRabbitSummary({
       body: [

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -505,6 +505,13 @@ describe("automated review gate", () => {
         `not a sha and ${HEAD_SHA}.`,
         "Reviewing files that changed from the base of the PR and between " +
         `not-a-sha\nand ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and between\n" +
+        `${STALE_SHA}\nand ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and between\n" +
+        `${STALE_SHA}\nand\n${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and between\n" +
+        `${STALE_SHA}\nmalformed continuation\nanother continuation\nand\n` +
+        `${HEAD_SHA}.`,
         "Reviewing files that changed from the base of the PR and between " +
         `and ${HEAD_SHA}.`,
         "Reviewing files that changed from the base of the PR and between " +
@@ -554,6 +561,13 @@ describe("automated review gate", () => {
           `not a sha and ${STALE_SHA}.`,
           "Reviewing files that changed from the base of the PR and between " +
           `not-a-sha\nand ${STALE_SHA}.`,
+          "Reviewing files that changed from the base of the PR and between\n" +
+          `${HEAD_SHA}\nand ${STALE_SHA}.`,
+          "Reviewing files that changed from the base of the PR and between\n" +
+          `${HEAD_SHA}\nand\n${STALE_SHA}.`,
+          "Reviewing files that changed from the base of the PR and between\n" +
+          `${HEAD_SHA}\nmalformed continuation\nanother continuation\nand\n` +
+          `${STALE_SHA}.`,
           "Reviewing files that changed from the base of the PR and between " +
           `and ${STALE_SHA}.`,
         ].join("\n"),

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -548,6 +548,54 @@ describe("automated review gate", () => {
       "summary",
     );
 
+    for (
+      const unterminatedCurrentRange of [
+        codeRabbitReviewRange(),
+        `Reviewing files between ${STALE_SHA} and ${HEAD_SHA}.`,
+      ]
+    ) {
+      const newerUnterminatedCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          unterminatedCurrentRange,
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:30Z",
+        updated_at: "2026-08-22T12:03:30Z",
+      });
+
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerUnterminatedCurrentRange],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
+
+    const newerUnterminatedStaleRange = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        codeRabbitReviewRange(HEAD_SHA, STALE_SHA),
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:45Z",
+      updated_at: "2026-08-22T12:03:45Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerUnterminatedStaleRange],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+
     const newerOutOfScopeCurrentRange = codeRabbitSummary({
       body: [
         `Reviewing files between ${STALE_SHA} and ${HEAD_SHA}.`,

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -769,9 +769,47 @@ describe("automated review gate", () => {
 
   it("classifies malformed and wrapped current-head ranges fail closed", async () => {
     const olderSuccess = olderCodeRabbitSuccess();
+    const rangeWords = [
+      "Reviewing",
+      "files",
+      "that",
+      "changed",
+      "from",
+      "the",
+      "base",
+      "of",
+      "the",
+      "PR",
+      "and",
+      "between",
+      "not-a-sha",
+      "and",
+      `${HEAD_SHA}.`,
+    ];
+    const softWrappedIntroRanges = Array.from(
+      { length: 11 },
+      (_, index) =>
+        [
+          rangeWords.slice(0, index + 1).join(" "),
+          rangeWords.slice(index + 1).join(" "),
+        ].join("\n"),
+    );
 
     for (
       const malformedCurrentRange of [
+        ...softWrappedIntroRanges,
+        "> Reviewing files that changed from the base\n" +
+        `> of the PR and between not-a-sha and ${HEAD_SHA}.`,
+        "> Reviewing files that changed from the base\n" +
+        `of the PR and between not-a-sha and ${HEAD_SHA}.`,
+        "> > Reviewing files that changed from the base\n" +
+        `> of the PR and between not-a-sha and ${HEAD_SHA}.`,
+        "> > Reviewing files that changed from the base\n" +
+        `of the PR and between not-a-sha and ${HEAD_SHA}.`,
+        "> Reviewing files that changed from the base of the PR and between " +
+        `${STALE_SHA} and\n${HEAD_SHA}.`,
+        "- Reviewing files that changed from the base\n" +
+        `  of the PR and between not-a-sha and ${HEAD_SHA}.`,
         "`Reviewing files that changed from the base of the PR and between " +
         `not-a-sha and ${HEAD_SHA}.`,
         "`Reviewing files that changed from the base of the PR and between " +
@@ -838,8 +876,30 @@ describe("automated review gate", () => {
           HEAD_SHA,
         ),
         undefined,
+        `Expected the current-head range to fail closed: ${malformedCurrentRange}`,
       );
     }
+
+    const newerUnrelatedReviewingText = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        `Reviewing bananas and ${HEAD_SHA}.`,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:02:00Z",
+      updated_at: "2026-08-22T12:02:00Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerUnrelatedReviewingText],
+        },
+        HEAD_SHA,
+      ))?.url,
+      olderSuccess.html_url,
+    );
 
     const newerBareCarriageReturnCurrentRange = codeRabbitSummary({
       body: [
@@ -979,8 +1039,6 @@ describe("automated review gate", () => {
 
     for (
       const separatedCurrentRange of [
-        "> Reviewing files that changed from the base of the PR and between " +
-        `${STALE_SHA} and\n${HEAD_SHA}.`,
         "Reviewing files that changed from the base of the PR and between " +
         `${STALE_SHA} and\n> ${HEAD_SHA}.`,
         "1. Reviewing files that changed from the base of the PR and between " +
@@ -989,6 +1047,12 @@ describe("automated review gate", () => {
         `not-a-sha\n<!-- evidence boundary -->\nand ${HEAD_SHA}.`,
         "- Reviewing files that changed from the base of the PR and between " +
         `not-a-sha and\n\n      ${HEAD_SHA}.`,
+        "> Reviewing files that changed from the base\n\n" +
+        `of the PR and between not-a-sha and ${HEAD_SHA}.`,
+        "> Reviewing files that changed from the base\n- " +
+        `of the PR and between not-a-sha and ${HEAD_SHA}.`,
+        "> Reviewing files that changed from the base\n---\n" +
+        `of the PR and between not-a-sha and ${HEAD_SHA}.`,
       ]
     ) {
       const newerSeparatedCurrentRange = codeRabbitSummary({

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -894,6 +894,70 @@ describe("automated review gate", () => {
       "summary",
     );
 
+    const malformedCurrentRange =
+      "Reviewing files that changed from the base of the PR and between " +
+      `not-a-sha and ${HEAD_SHA}.`;
+    for (
+      const escapedContainerFence of [
+        ["> ```text", malformedCurrentRange, "```"],
+        ["- ```text", malformedCurrentRange, "```"],
+        ["   - ```text", `  ${malformedCurrentRange}`, "  ```"],
+        ["> - ```text", `>  ${malformedCurrentRange}`, ">  ```"],
+      ]
+    ) {
+      const newerCurrentRangeOutsideFenceContainer = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...escapedContainerFence,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerCurrentRangeOutsideFenceContainer],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
+
+    for (
+      const containedFence of [
+        ["> ```text", `> ${malformedCurrentRange}`, "> ```"],
+        ["- ```text", `  ${malformedCurrentRange}`, "  ```"],
+        ["   - ```text", `     ${malformedCurrentRange}`, "     ```"],
+        ["- [ ] ```text", `      ${malformedCurrentRange}`, "      ```"],
+        ["> - ```text", `>   ${malformedCurrentRange}`, ">   ```"],
+      ]
+    ) {
+      const newerCurrentRangeInsideFenceContainer = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...containedFence,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerCurrentRangeInsideFenceContainer],
+          },
+          HEAD_SHA,
+        ))?.source,
+        "summary",
+      );
+    }
+
     for (
       const fencedContinuation of [
         [

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1999,6 +1999,75 @@ describe("automated review gate", () => {
     }
   });
 
+  it("excludes multiline delimited HTML block bodies from review evidence", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+
+    for (
+      const hiddenHtmlBlock of [
+        ["<!DECL", MALFORMED_CURRENT_RANGE, ">"],
+        ["<!decl", MALFORMED_CURRENT_RANGE, ">"],
+        ["<!Decl", MALFORMED_CURRENT_RANGE, ">"],
+        ["- <!DECL", `  ${MALFORMED_CURRENT_RANGE}`, "  >"],
+        ["> <!DECL", `> ${MALFORMED_CURRENT_RANGE}`, "> >"],
+        ["<?process", MALFORMED_CURRENT_RANGE, "?>"],
+        ["> <?process", `> ${MALFORMED_CURRENT_RANGE}`, "> ?>"],
+        ["<![CDATA[", MALFORMED_CURRENT_RANGE, "]]>"],
+        ["- <![CDATA[", `  ${MALFORMED_CURRENT_RANGE}`, "  ]]>"],
+      ]
+    ) {
+      const newerHiddenCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...hiddenHtmlBlock,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerHiddenCurrentRange],
+          },
+          HEAD_SHA,
+        ))?.url,
+        "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
+        hiddenHtmlBlock.join("\n"),
+      );
+    }
+
+    for (
+      const visibleRangeOutsideContainer of [
+        ["- <!DECL", MALFORMED_CURRENT_RANGE, "  >"],
+        ["> <![CDATA[", MALFORMED_CURRENT_RANGE, "> ]]>"],
+      ]
+    ) {
+      const newerVisibleCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...visibleRangeOutsideContainer,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerVisibleCurrentRange],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+        visibleRangeOutsideContainer.join("\n"),
+      );
+    }
+  });
+
   it("preserves lazy blockquote paragraphs for inline HTML comments", async () => {
     const olderSuccess = olderCodeRabbitSuccess();
 

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1206,6 +1206,92 @@ describe("automated review gate", () => {
     );
   });
 
+  it("keeps unmatched inline Markdown punctuation visible", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+    const newerSummary = (range: string) =>
+      codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          range,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:05:00Z",
+        updated_at: "2026-08-22T12:05:00Z",
+      });
+
+    for (
+      const literalPunctuationRange of [
+        MALFORMED_CURRENT_RANGE.replace("Reviewing", "Review*ing"),
+        MALFORMED_CURRENT_RANGE.replace("Reviewing", "Review_ing"),
+        MALFORMED_CURRENT_RANGE.replace("Reviewing", "Review~ing"),
+        MALFORMED_CURRENT_RANGE.replace("Reviewing", "Review~~~ing~~~"),
+        MALFORMED_CURRENT_RANGE.replace("Reviewing", "Review***ing**"),
+        MALFORMED_CURRENT_RANGE.replace("Reviewing", "Review**ing***"),
+        MALFORMED_CURRENT_RANGE.replace("Reviewing", "Review[ing"),
+        MALFORMED_CURRENT_RANGE.replace("Reviewing", "Review]ing"),
+        MALFORMED_CURRENT_RANGE.replace("Reviewing", "Review`ing"),
+        MALFORMED_CURRENT_RANGE.replace("Reviewing", "Review_ing_"),
+        MALFORMED_CURRENT_RANGE.replace("base", "ba*se"),
+        MALFORMED_CURRENT_RANGE.replace("between", "betwe*en"),
+        MALFORMED_CURRENT_RANGE.replace(
+          " and " + HEAD_SHA,
+          " a*nd " + HEAD_SHA,
+        ),
+        MALFORMED_CURRENT_RANGE.replace(
+          HEAD_SHA,
+          HEAD_SHA.slice(0, 20) + "*" + HEAD_SHA.slice(20),
+        ),
+        "Review*ing files that changed from the base of the PR and between " +
+        `not-a-sha\nand ${HEAD_SHA}.`,
+      ]
+    ) {
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerSummary(literalPunctuationRange)],
+          },
+          HEAD_SHA,
+        ))?.url,
+        olderSuccess.html_url,
+      );
+    }
+
+    for (
+      const decoratedCurrentRange of [
+        MALFORMED_CURRENT_RANGE.replace("Reviewing", "**Reviewing**"),
+        MALFORMED_CURRENT_RANGE.replace("Reviewing", "Review*ing*"),
+        MALFORMED_CURRENT_RANGE.replace("Reviewing", "_Reviewing_"),
+        MALFORMED_CURRENT_RANGE.replace("Reviewing", "Review~ing~"),
+        MALFORMED_CURRENT_RANGE.replace("Reviewing", "Review~~ing~~"),
+        MALFORMED_CURRENT_RANGE.replace("Reviewing", "Review***ing***"),
+        "Review*ing files that changed from the base of the PR and between " +
+        `not-a-sha\nand ${HEAD_SHA}.*`,
+        MALFORMED_CURRENT_RANGE.replace(
+          "Reviewing",
+          "[Reviewing](https://example.com)",
+        ),
+        MALFORMED_CURRENT_RANGE.replace(
+          "Reviewing",
+          "Review[ing](https://example.com)",
+        ),
+        MALFORMED_CURRENT_RANGE.replace("Reviewing", "`Reviewing`"),
+      ]
+    ) {
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerSummary(decoratedCurrentRange)],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
+  });
+
   it("rejects unterminated and Markdown-prefixed current-head ranges", async () => {
     const olderSuccess = olderCodeRabbitSuccess();
     const escapedVisibleMalformedBodies = ["\\", "\\\\", "\\\\\\"].map(
@@ -4133,6 +4219,64 @@ describe("automated review gate", () => {
     assert(
       performance.now() - startedAt < 1_000,
       "dense malformed range parsing must stay linear",
+    );
+
+    const newerDenseLiteralDelimiterRanges = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        Array.from(
+          { length: 2_000 },
+          () => MALFORMED_CURRENT_RANGE.replace("Reviewing", "Review_ing"),
+        ).join(" "),
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:02:00Z",
+      updated_at: "2026-08-22T12:02:00Z",
+    });
+    const literalDelimiterStartedAt = performance.now();
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerDenseLiteralDelimiterRanges],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+    assert(
+      performance.now() - literalDelimiterStartedAt < 1_000,
+      "dense unmatched inline delimiters must stay linear",
+    );
+
+    const newerDenseDecoratedRanges = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        Array.from(
+          { length: 1_000 },
+          () => MALFORMED_CURRENT_RANGE.replace("Reviewing", "Review*ing*"),
+        ).join(" "),
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:02:00Z",
+      updated_at: "2026-08-22T12:02:00Z",
+    });
+    const decoratedStartedAt = performance.now();
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerDenseDecoratedRanges],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+    assert(
+      performance.now() - decoratedStartedAt < 1_000,
+      "dense matched inline delimiters must stay linear",
     );
 
     const newerDenseSameLineCurrentRanges = codeRabbitSummary({

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -487,6 +487,67 @@ describe("automated review gate", () => {
     );
   });
 
+  it("lets a malformed current-head range override an older valid review", async () => {
+    const olderSuccess = codeRabbitSummary({
+      created_at: "2026-08-22T12:01:00Z",
+      updated_at: "2026-08-22T12:01:00Z",
+    });
+
+    for (
+      const malformedCurrentRange of [
+        `Reviewing files between ${STALE_SHA} and ${HEAD_SHA}.`,
+        codeRabbitReviewRange() + " but this is not the final review.",
+        codeRabbitReviewRange().replace("Reviewing", "reviewing"),
+        codeRabbitReviewRange().replace("files that", "files  that"),
+        codeRabbitReviewRange().replace(HEAD_SHA, HEAD_SHA.toUpperCase()),
+      ]
+    ) {
+      const newerMalformedCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          malformedCurrentRange,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:02:00Z",
+        updated_at: "2026-08-22T12:02:00Z",
+      });
+
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerMalformedCurrentRange],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
+
+    const newerMalformedStaleRange = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        codeRabbitReviewRange(HEAD_SHA, STALE_SHA) +
+        " but this is not the final review.",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:00Z",
+      updated_at: "2026-08-22T12:03:00Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerMalformedStaleRange],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+  });
+
   it("rejects any current-head skip or request marker in a summary", async () => {
     for (
       const markers of [

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -958,6 +958,112 @@ describe("automated review gate", () => {
       );
     }
 
+    const newerHtmlCommentedCurrentRange = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "<!--",
+        codeRabbitReviewRange(),
+        "-->",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      html_url:
+        "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-hidden",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      await findAutomatedReview(
+        { reviews: [], comments: [newerHtmlCommentedCurrentRange] },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerHtmlCommentedCurrentRange],
+        },
+        HEAD_SHA,
+      ))?.url,
+      "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
+    );
+
+    for (
+      const visibleRangeAfterCommentLookalike of [
+        ["\\<!--", malformedCurrentRange, "-->"],
+        ["```", "<!--", "```", malformedCurrentRange, "-->"],
+      ]
+    ) {
+      const newerVisibleCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...visibleRangeAfterCommentLookalike,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerVisibleCurrentRange],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
+
+    const newerInvalidBacktickFence = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "```js`oops",
+        malformedCurrentRange,
+        "```",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerInvalidBacktickFence],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+
+    const newerValidTildeFenceWithBacktickInfo = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "~~~js`allowed",
+        malformedCurrentRange,
+        "~~~",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerValidTildeFenceWithBacktickInfo],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+
     for (
       const fencedContinuation of [
         [

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1119,6 +1119,104 @@ describe("automated review gate", () => {
       );
     }
 
+    for (
+      const tabSensitiveFence of [
+        ["- ```text", "\t```", malformedCurrentRange],
+        ["\t```text", malformedCurrentRange],
+      ]
+    ) {
+      const newerVisibleCurrentRangeAroundTabFence = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...tabSensitiveFence,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerVisibleCurrentRangeAroundTabFence],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
+
+    for (
+      const nonStructuralMarkerExample of [
+        [
+          "```md",
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          codeRabbitReviewRange(HEAD_SHA, STALE_SHA),
+          "<!-- recent_review_end -->",
+          "```",
+        ],
+        [
+          "`<!-- recent_review_start -->`",
+          "No actionable comments were generated in the recent review.",
+          codeRabbitReviewRange(HEAD_SHA, STALE_SHA),
+          "`<!-- recent_review_end -->`",
+        ],
+        [
+          "    <!-- recent_review_start -->",
+          "    No actionable comments were generated in the recent review.",
+          `    ${codeRabbitReviewRange(HEAD_SHA, STALE_SHA)}`,
+          "    <!-- recent_review_end -->",
+        ],
+      ]
+    ) {
+      const newerLiveCurrentRangeBeforeMarkerExample = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          malformedCurrentRange,
+          "<!-- recent_review_end -->",
+          ...nonStructuralMarkerExample,
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerLiveCurrentRangeBeforeMarkerExample],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
+
+    const newerCurrentRangeInsideThreeSpaceFence = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "   ```text",
+        malformedCurrentRange,
+        "   ```",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerCurrentRangeInsideThreeSpaceFence],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+
     const newerHtmlCommentedCurrentRange = codeRabbitSummary({
       body: [
         "<!-- recent_review_start -->",

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2447,6 +2447,132 @@ describe("automated review gate", () => {
     );
   });
 
+  it("keeps non-code backticks from masking visible evidence", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+
+    for (
+      const nonCodeBacktick of [
+        ["`inline code starts", "\\` closes inline code"],
+        ["ordinary <https://example.com/`>"],
+        ["ordinary <foo`bar@example.com>"],
+        ["", "[reference]: https://example.com/`"],
+        ["", "[reference]:", "  https://example.com/`"],
+        ["", "[reference]: https://example.com/", '  "title `"'],
+        ["", "[", "reference", "]: https://example.com/`"],
+        [
+          "",
+          '[reference]: https://example.com/ "title',
+          'continued `"',
+        ],
+      ]
+    ) {
+      const newerVisibleCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...nonCodeBacktick,
+          MALFORMED_CURRENT_RANGE,
+          "`",
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerVisibleCurrentRange],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
+  });
+
+  it("keeps reference-definition lookalikes inside inline code", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+
+    for (
+      const lookalike of [
+        "[reference]:",
+        "[reference]:   ",
+      ]
+    ) {
+      const newerHiddenCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          "`inline code starts",
+          lookalike,
+          MALFORMED_CURRENT_RANGE,
+          "inline code closes`",
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerHiddenCurrentRange],
+          },
+          HEAD_SHA,
+        ))?.url,
+        olderSuccess.html_url,
+      );
+    }
+
+    const newerParagraphLookalike = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "[reference]: https://example.com/`",
+        MALFORMED_CURRENT_RANGE,
+        "`",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerParagraphLookalike],
+        },
+        HEAD_SHA,
+      ))?.url,
+      olderSuccess.html_url,
+    );
+
+    const newerUnseparatedTitleLookalike = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "",
+        "[reference]: <https://example.com>(title `)",
+        MALFORMED_CURRENT_RANGE,
+        "`",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerUnseparatedTitleLookalike],
+        },
+        HEAD_SHA,
+      ))?.url,
+      olderSuccess.html_url,
+    );
+  });
+
   it("keeps structural review markers outside unmatched inline code", async () => {
     const olderSuccess = olderCodeRabbitSuccess();
     const newerMalformedCurrentRange = codeRabbitSummary({
@@ -2988,6 +3114,67 @@ describe("automated review gate", () => {
     assert(
       performance.now() - denseInlineStartedAt < 1_000,
       "dense inline-code scanning must stay linear",
+    );
+
+    const newerDenseUnmatchedProcessingInstructions = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        `ordinary ${"<?".repeat(32_000)}`,
+        MALFORMED_CURRENT_RANGE,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:02:02Z",
+      updated_at: "2026-08-22T12:02:02Z",
+    });
+    const denseProcessingInstructionsStartedAt = performance.now();
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [
+            olderSuccess,
+            newerDenseUnmatchedProcessingInstructions,
+          ],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+    assert(
+      performance.now() - denseProcessingInstructionsStartedAt < 1_000,
+      "dense unmatched processing-instruction scanning must stay linear",
+    );
+
+    const newerDenseReferenceDefinitions = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "",
+        ...Array.from(
+          { length: 4_000 },
+          (_, index) => `[reference-${index}]: /target-${index}`,
+        ),
+        MALFORMED_CURRENT_RANGE,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:02:02Z",
+      updated_at: "2026-08-22T12:02:02Z",
+    });
+    const denseReferenceDefinitionsStartedAt = performance.now();
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerDenseReferenceDefinitions],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+    assert(
+      performance.now() - denseReferenceDefinitionsStartedAt < 1_000,
+      "dense reference-definition scanning must stay linear",
     );
 
     const newerDenseRawHtmlBlocks = codeRabbitSummary({

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -509,6 +509,12 @@ describe("automated review gate", () => {
         `${STALE_SHA}\nand ${HEAD_SHA}.`,
         "Reviewing files that changed from the base of the PR and between\n" +
         `${STALE_SHA}\nand\n${HEAD_SHA}.`,
+        "> Reviewing files that changed from the base of the PR and between " +
+        `${STALE_SHA} and\n> ${HEAD_SHA}.`,
+        "> Reviewing files that changed from the base of the PR and between " +
+        `${STALE_SHA}\n> and ${HEAD_SHA}.`,
+        "> Reviewing files that changed from the base of the PR and between\n" +
+        `> ${STALE_SHA}\n> and\n> ${HEAD_SHA}.`,
         "Reviewing files that changed from the base of the PR and between\n" +
         `${STALE_SHA}\nmalformed continuation\nanother continuation\nand\n` +
         `${HEAD_SHA}.`,
@@ -565,6 +571,12 @@ describe("automated review gate", () => {
           `${HEAD_SHA}\nand ${STALE_SHA}.`,
           "Reviewing files that changed from the base of the PR and between\n" +
           `${HEAD_SHA}\nand\n${STALE_SHA}.`,
+          "> Reviewing files that changed from the base of the PR and between " +
+          `${HEAD_SHA} and\n> ${STALE_SHA}.`,
+          "> Reviewing files that changed from the base of the PR and between " +
+          `${HEAD_SHA}\n> and ${STALE_SHA}.`,
+          "> Reviewing files that changed from the base of the PR and between\n" +
+          `> ${HEAD_SHA}\n> and\n> ${STALE_SHA}.`,
           "Reviewing files that changed from the base of the PR and between\n" +
           `${HEAD_SHA}\nmalformed continuation\nanother continuation\nand\n` +
           `${STALE_SHA}.`,

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -146,6 +146,33 @@ describe("automated review gate", () => {
     );
   });
 
+  it("accepts CodeRabbit's current base-change review wording", async () => {
+    const currentSummary = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "Reviewing files that changed from the base of the PR and between " +
+        `${STALE_SHA} and ${HEAD_SHA}.`,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+    });
+
+    assertEquals(
+      (await findAutomatedReview(
+        { reviews: [], comments: [currentSummary] },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+    assertEquals(
+      await findAutomatedReview(
+        { reviews: [], comments: [currentSummary] },
+        STALE_SHA,
+      ),
+      undefined,
+    );
+  });
+
   it("accepts an authenticated Codex no-finding comment for the current head", async () => {
     assertEquals(
       await findAutomatedReview(

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -884,6 +884,45 @@ describe("automated review gate", () => {
       "summary",
     );
 
+    for (
+      const wrappedListCurrentRange of [
+        "- Reviewing files that changed from the base of the PR and between not-a-sha and\n" +
+        `  ${HEAD_SHA}.`,
+        "1. Reviewing files that changed from the base of the PR and between not-a-sha and\n" +
+        `   ${HEAD_SHA}.`,
+        "- [ ] Reviewing files that changed from the base of the PR and between not-a-sha and\n" +
+        `      ${HEAD_SHA}.`,
+        "> - Reviewing files that changed from the base of the PR and between not-a-sha and\n" +
+        `>   ${HEAD_SHA}.`,
+        "- 1. Reviewing files that changed from the base of the PR and between not-a-sha and\n" +
+        `     ${HEAD_SHA}.`,
+        "- Reviewing files that changed from the base of the PR and between not-a-sha and\n" +
+        `- ${HEAD_SHA}.`,
+      ]
+    ) {
+      const newerWrappedListCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          wrappedListCurrentRange,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:02:00Z",
+        updated_at: "2026-08-22T12:02:00Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerWrappedListCurrentRange],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+        wrappedListCurrentRange,
+      );
+    }
+
     for (const prefix of ["> ", "1. ", "- [x] ", "> 1. - [ ] "]) {
       for (
         const compatibleCurrentRange of [
@@ -948,6 +987,8 @@ describe("automated review gate", () => {
         `${STALE_SHA}\n> and ${HEAD_SHA}.`,
         "Reviewing files that changed from the base of the PR and between " +
         `not-a-sha\n<!-- evidence boundary -->\nand ${HEAD_SHA}.`,
+        "- Reviewing files that changed from the base of the PR and between " +
+        `not-a-sha and\n\n      ${HEAD_SHA}.`,
       ]
     ) {
       const newerSeparatedCurrentRange = codeRabbitSummary({
@@ -1034,6 +1075,12 @@ describe("automated review gate", () => {
       ["_", "_"],
       ["~~", "~~"],
       ["[", "](https://example.com)"],
+      ["<strong>", "</strong>"],
+      ['<span title="x > y">', "</span>"],
+      ["ordinary <!--hidden-->", ""],
+      ["ordinary <?pi?>", ""],
+      ["ordinary <!DECL>", ""],
+      ["ordinary <![CDATA[x]]>", ""],
     ].map(([prefix, suffix]) =>
       [
         "<!-- recent_review_start -->",
@@ -1075,6 +1122,18 @@ describe("automated review gate", () => {
       const newerMalformedBody of [
         ...escapedVisibleMalformedBodies,
         ...decoratedVisibleMalformedBodies,
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          `<strong>${codeRabbitReviewRange()}</strong>`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          `<span title="${MALFORMED_CURRENT_RANGE}">${MALFORMED_CURRENT_RANGE}</span>`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
         [
           "<!-- recent_review_start -->",
           "No actionable comments were generated in the recent review.",
@@ -1188,6 +1247,7 @@ describe("automated review gate", () => {
           HEAD_SHA,
         ),
         undefined,
+        newerMalformedBody,
       );
     }
     const newerExactCurrentWithMalformedBaseDuplicates = codeRabbitSummary({
@@ -1844,11 +1904,62 @@ describe("automated review gate", () => {
       undefined,
     );
 
+    const newerRangeInsideInlineHtmlAttribute = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        `<span title="${MALFORMED_CURRENT_RANGE}">ordinary text</span>`,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerRangeInsideInlineHtmlAttribute],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+
+    const newerRangeInsideCommentAfterEscapedTag = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        '\\<span title="<!--">',
+        MALFORMED_CURRENT_RANGE,
+        "-->",
+        "</span>",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerRangeInsideCommentAfterEscapedTag],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+
     for (
       const visibleRangeAfterCommentLookalike of [
         ["\\<!--", MALFORMED_CURRENT_RANGE, "-->"],
         [
           '<span title="<!--">',
+          MALFORMED_CURRENT_RANGE,
+          "-->",
+          "</span>",
+        ],
+        [
+          '\\<span title="\\<!--">',
           MALFORMED_CURRENT_RANGE,
           "-->",
           "</span>",
@@ -3690,6 +3801,35 @@ describe("automated review gate", () => {
     assert(
       performance.now() - startedAt < 1_000,
       "dense malformed range parsing must stay linear",
+    );
+
+    const newerDenseSameLineCurrentRanges = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        Array.from(
+          { length: 3_000 },
+          () => MALFORMED_CURRENT_RANGE,
+        ).join(" "),
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:02:00Z",
+      updated_at: "2026-08-22T12:02:00Z",
+    });
+    const denseSameLineStartedAt = performance.now();
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerDenseSameLineCurrentRanges],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+    assert(
+      performance.now() - denseSameLineStartedAt < 1_000,
+      "dense same-line range parsing must stay linear",
     );
 
     const newerDenseBareCarriageReturnRanges = codeRabbitSummary({

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2248,6 +2248,25 @@ describe("automated review gate", () => {
       );
     }
 
+    const newerSuccessfulSummary = codeRabbitSummary({
+      created_at: "2026-08-22T12:01:00Z",
+      updated_at: "2026-08-22T12:01:00Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [
+            failedSummary,
+            successfulSummary,
+            newerSuccessfulSummary,
+          ],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+
     assertEquals(
       await findAutomatedReview(
         {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -621,6 +621,14 @@ describe("automated review gate", () => {
           `Review skipped for current commit ${STALE_SHA}.`,
           [`<![CDATA[Requested commit: ${HEAD_SHA}.]]>`],
         ],
+        [
+          `Review skipped for current commit ${STALE_SHA}.`,
+          ["Requested commit:", "", `    ${HEAD_SHA}.`],
+        ],
+        [
+          `Requested commit: ${STALE_SHA}.`,
+          ["Review skipped for current commit", "", `    ${HEAD_SHA}.`],
+        ],
       ] as const
     ) {
       const newerSuccessfulSummary = codeRabbitSummary({
@@ -1133,6 +1141,7 @@ describe("automated review gate", () => {
       const paragraphBoundary of [
         "> quoted block",
         "- list item",
+        "--",
         "---",
         "===",
         "# heading",
@@ -1733,6 +1742,13 @@ describe("automated review gate", () => {
           "-->",
         ],
         ["ordinary text <!--", "<!xml>", MALFORMED_CURRENT_RANGE, "-->"],
+        ["ordinary text <!--", MALFORMED_CURRENT_RANGE, "--->"],
+        [
+          "ordinary text <!--",
+          '<source src="movie.mp4">',
+          MALFORMED_CURRENT_RANGE,
+          "-->",
+        ],
         [
           "ordinary text <!--",
           "<!DoCtYpE html>",
@@ -1794,6 +1810,49 @@ describe("automated review gate", () => {
       ))?.url,
       "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
     );
+
+    for (
+      const hiddenInlineComment of [
+        [
+          "ordinary text <!--",
+          "2. lazy continuation",
+          MALFORMED_CURRENT_RANGE,
+          "-->",
+        ],
+        [
+          "ordinary text <!-- invalid -- text",
+          MALFORMED_CURRENT_RANGE,
+          "-->",
+        ],
+        [
+          "ordinary text <!--",
+          "<plaintext>",
+          MALFORMED_CURRENT_RANGE,
+          "-->",
+        ],
+      ]
+    ) {
+      const newerHiddenCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...hiddenInlineComment,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerHiddenCurrentRange],
+          },
+          HEAD_SHA,
+        ))?.url,
+        "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
+      );
+    }
   });
 
   it("does not extend short inline HTML comments across later evidence", async () => {
@@ -2159,6 +2218,24 @@ describe("automated review gate", () => {
           codeRabbitReviewRange(),
           "> -->",
         ],
+        [
+          "- ordinary <!--",
+          "  2. lazy continuation",
+          codeRabbitReviewRange(),
+          "-->",
+        ],
+        [
+          "- ordinary <!--",
+          "  2) lazy continuation",
+          codeRabbitReviewRange(),
+          "-->",
+        ],
+        [
+          "- ordinary <!--",
+          "0000000001. lazy continuation",
+          codeRabbitReviewRange(),
+          "-->",
+        ],
       ]
     ) {
       const newerHiddenExactRange = codeRabbitSummary({
@@ -2195,6 +2272,9 @@ describe("automated review gate", () => {
         "",
         "# next block",
         "- next item",
+        "2. next item",
+        "2) next item",
+        "000000001. next item",
         "<div>",
         "<script></script>",
       ]

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1847,6 +1847,12 @@ describe("automated review gate", () => {
     for (
       const visibleRangeAfterCommentLookalike of [
         ["\\<!--", MALFORMED_CURRENT_RANGE, "-->"],
+        [
+          '<span title="<!--">',
+          MALFORMED_CURRENT_RANGE,
+          "-->",
+          "</span>",
+        ],
         ["", "    <!--", MALFORMED_CURRENT_RANGE, "-->"],
         ["", "    example <!--", MALFORMED_CURRENT_RANGE, "-->"],
         ["", "\t<!--", MALFORMED_CURRENT_RANGE, "-->"],

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2455,6 +2455,13 @@ describe("automated review gate", () => {
         ["`inline code starts", "\\` closes inline code"],
         ["ordinary <https://example.com/`>"],
         ["ordinary <foo`bar@example.com>"],
+        ["ordinary [link](https://example.com/`)"],
+        ["ordinary ![image](https://example.com/`)"],
+        ["ordinary [link](https://example.com/ 'title `')"],
+        ["ordinary [link](`)"],
+        ["ordinary ![image](`)"],
+        ["ordinary [link](`a)"],
+        ["`[link](https://example.com/`)"],
         ["", "[reference]: https://example.com/`"],
         ["", "[reference]:", "  https://example.com/`"],
         ["", "[reference]: https://example.com/", '  "title `"'],
@@ -2487,6 +2494,91 @@ describe("automated review gate", () => {
           HEAD_SHA,
         ),
         undefined,
+      );
+    }
+  });
+
+  it("keeps link destinations and titles out of review evidence", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+    const newerRangeInsideLinkTitle = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        '[link](https://example.com/ "title',
+        codeRabbitReviewRange(),
+        'continued")',
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerRangeInsideLinkTitle],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+
+    const newerRangeInsideInvalidLinkTitle = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        '[link](https://example.com/ "title',
+        "",
+        MALFORMED_CURRENT_RANGE,
+        'continued")',
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerRangeInsideInvalidLinkTitle],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+  });
+
+  it("keeps invalid link tails inside inline code", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+    for (
+      const invalidLinkTail of [
+        'ordinary [link](https://example.com/ "title `)',
+        "ordinary [link](https://example.com/`",
+        "ordinary \\[link](https://example.com/`)",
+        "ordinary ![image](https://example.com/`",
+      ]
+    ) {
+      const newerHiddenCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          invalidLinkTail,
+          MALFORMED_CURRENT_RANGE,
+          "`",
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerHiddenCurrentRange],
+          },
+          HEAD_SHA,
+        ))?.source,
+        "summary",
       );
     }
   });
@@ -3175,6 +3267,63 @@ describe("automated review gate", () => {
     assert(
       performance.now() - denseReferenceDefinitionsStartedAt < 1_000,
       "dense reference-definition scanning must stay linear",
+    );
+
+    const newerDenseUnclosedInlineLinks = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        `[link](`.repeat(8_000),
+        MALFORMED_CURRENT_RANGE,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:02:02Z",
+      updated_at: "2026-08-22T12:02:02Z",
+    });
+    const denseUnclosedInlineLinksStartedAt = performance.now();
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerDenseUnclosedInlineLinks],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+    assert(
+      performance.now() - denseUnclosedInlineLinksStartedAt < 1_000,
+      "dense unclosed inline-link scanning must stay linear",
+    );
+
+    const newerDenseValidInlineLinks = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        Array.from(
+          { length: 4_000 },
+          (_, index) => `[link-${index}](https://example.com/${index}\`)`,
+        ).join(" "),
+        MALFORMED_CURRENT_RANGE,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:02:02Z",
+      updated_at: "2026-08-22T12:02:02Z",
+    });
+    const denseValidInlineLinksStartedAt = performance.now();
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerDenseValidInlineLinks],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+    assert(
+      performance.now() - denseValidInlineLinksStartedAt < 1_000,
+      "dense valid inline-link scanning must stay linear",
     );
 
     const newerDenseRawHtmlBlocks = codeRabbitSummary({

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -960,12 +960,72 @@ describe("automated review gate", () => {
       "summary",
     );
 
+    const newerInlineCodeCurrentRangeExample = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "`multiline inline code starts",
+        codeRabbitReviewRange(),
+        "multiline inline code closes`",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:42Z",
+      updated_at: "2026-08-22T12:03:42Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerInlineCodeCurrentRangeExample],
+        },
+        HEAD_SHA,
+      ))?.url,
+      "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
+    );
+
     const malformedCurrentRange =
       "Reviewing files that changed from the base of the PR and between " +
       `not-a-sha and ${HEAD_SHA}.`;
     for (
+      const paragraphBoundary of [
+        "> quoted block",
+        "- list item",
+        "---",
+        "===",
+        "# heading",
+        "<?processing instruction?>",
+        "<!DECLARATION>",
+      ]
+    ) {
+      const newerVisibleRangeAfterParagraphBoundary = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          "`inline code starts",
+          paragraphBoundary,
+          malformedCurrentRange,
+          "inline code closes`",
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:42Z",
+        updated_at: "2026-08-22T12:03:42Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerVisibleRangeAfterParagraphBoundary],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
+
+    for (
       const escapedContainerFence of [
         ["> ```text", malformedCurrentRange, "```"],
+        [">     ```text", `> ${malformedCurrentRange}`, "> ```"],
         ["- ```text", malformedCurrentRange, "```"],
         ["   - ```text", `  ${malformedCurrentRange}`, "  ```"],
         ["> - ```text", `>  ${malformedCurrentRange}`, ">  ```"],
@@ -996,6 +1056,7 @@ describe("automated review gate", () => {
     for (
       const containedFence of [
         ["> ```text", `> ${malformedCurrentRange}`, "> ```"],
+        [">    ```text", `> ${malformedCurrentRange}`, "> ```"],
         ["- ```text", `  ${malformedCurrentRange}`, "  ```"],
         ["   - ```text", `     ${malformedCurrentRange}`, "     ```"],
         ["- [ ] ```text", `      ${malformedCurrentRange}`, "      ```"],
@@ -1276,6 +1337,16 @@ describe("automated review gate", () => {
     for (
       const visibleRangeAfterCommentLookalike of [
         ["\\<!--", malformedCurrentRange, "-->"],
+        ["`<!--`", malformedCurrentRange, "-->"],
+        ["``<!--``", malformedCurrentRange, "-->"],
+        ["inline code ```<!--```", malformedCurrentRange, "-->"],
+        [
+          "`multiline inline code starts",
+          "text <!--",
+          "multiline inline code closes`",
+          malformedCurrentRange,
+          "-->",
+        ],
         ["```", "<!--", "```", malformedCurrentRange, "-->"],
       ]
     ) {
@@ -1298,6 +1369,31 @@ describe("automated review gate", () => {
           HEAD_SHA,
         ),
         undefined,
+      );
+    }
+
+    for (const activeCommentAfterLiteralBacktick of ["`<!--", "\\`<!--`"]) {
+      const newerHiddenCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          activeCommentAfterLiteralBacktick,
+          malformedCurrentRange,
+          "-->",
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerHiddenCurrentRange],
+          },
+          HEAD_SHA,
+        ))?.url,
+        "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
       );
     }
 
@@ -1812,6 +1908,35 @@ describe("automated review gate", () => {
     assert(
       performance.now() - bareCarriageReturnStartedAt < 1_000,
       "bare carriage-return line scanning must stay linear",
+    );
+
+    const newerDenseInlineCommentLookalikes = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        ...Array.from(
+          { length: 5_000 },
+          (_, index) => `inline-${index} \`<!--\``,
+        ),
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:02:02Z",
+      updated_at: "2026-08-22T12:02:02Z",
+    });
+    const denseInlineStartedAt = performance.now();
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerDenseInlineCommentLookalikes],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+    assert(
+      performance.now() - denseInlineStartedAt < 1_000,
+      "dense inline-code scanning must stay linear",
     );
   });
 

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2704,6 +2704,64 @@ describe("automated review gate", () => {
     }
   });
 
+  it("uses CommonMark list-marker padding when classifying indented evidence", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+    for (
+      const visibleListEvidence of [
+        ["-     item", "", `    ${MALFORMED_CURRENT_RANGE}`],
+        ["1.     item", "", `     ${MALFORMED_CURRENT_RANGE}`],
+        ["-     [ ] item", "", `    ${MALFORMED_CURRENT_RANGE}`],
+        ["", "9.    item", "", `      ${MALFORMED_CURRENT_RANGE}`],
+        ["", "123.     item", "", `     ${MALFORMED_CURRENT_RANGE}`],
+      ]
+    ) {
+      const newerVisibleCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...visibleListEvidence,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerVisibleCurrentRange],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+        visibleListEvidence.join("\n"),
+      );
+    }
+
+    const newerIndentedCodeCurrentRange = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "- item",
+        "",
+        `      ${MALFORMED_CURRENT_RANGE}`,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:42Z",
+      updated_at: "2026-08-22T12:03:42Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerIndentedCodeCurrentRange],
+        },
+        HEAD_SHA,
+      ))?.url,
+      olderSuccess.html_url,
+    );
+  });
+
   it("pairs multiline inline code across blockquote paragraph lines", async () => {
     const olderSuccess = olderCodeRabbitSuccess();
 

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -576,6 +576,56 @@ describe("automated review gate", () => {
       );
     }
 
+    for (
+      const newerMalformedBody of [
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          `- ${codeRabbitReviewRange()}`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          "Reviewing changed files from the base of the PR and between " +
+          `${STALE_SHA} and ${HEAD_SHA}.`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          "Reviewing files that changed from the base of the PR and between " +
+          `${STALE_SHA} and`,
+          `${HEAD_SHA}.`,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          codeRabbitReviewRange(),
+          "<!-- recent_review_end -->",
+          "<!-- recent_review_start -->",
+        ].join("\n"),
+      ]
+    ) {
+      const newerMalformedCurrentRange = codeRabbitSummary({
+        body: newerMalformedBody,
+        created_at: "2026-08-22T12:03:40Z",
+        updated_at: "2026-08-22T12:03:40Z",
+      });
+
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerMalformedCurrentRange],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
+
     const newerUnterminatedStaleRange = codeRabbitSummary({
       body: [
         "<!-- recent_review_start -->",
@@ -612,6 +662,28 @@ describe("automated review gate", () => {
         {
           reviews: [],
           comments: [olderSuccess, newerOutOfScopeCurrentRange],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+
+    const newerUnrelatedCurrentText = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        `Diagnostic commit: ${HEAD_SHA}.`,
+        codeRabbitReviewRange(HEAD_SHA, STALE_SHA),
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:04:15Z",
+      updated_at: "2026-08-22T12:04:15Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerUnrelatedCurrentText],
         },
         HEAD_SHA,
       ))?.source,

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1514,6 +1514,32 @@ describe("automated review gate", () => {
     );
   });
 
+  it("excludes indented code from range evidence", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+    const newerIndentedMalformedCurrentRange = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "",
+        `    ${MALFORMED_CURRENT_RANGE}`,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:43Z",
+      updated_at: "2026-08-22T12:03:43Z",
+    });
+
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerIndentedMalformedCurrentRange],
+        },
+        HEAD_SHA,
+      ))?.url,
+      olderSuccess.html_url,
+    );
+  });
+
   it("scopes HTML comments and validates fence openers", async () => {
     const olderSuccess = olderCodeRabbitSuccess();
 

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -502,7 +502,15 @@ describe("automated review gate", () => {
         "Reviewing files that changed from the base of the PR and between " +
         `not-a-sha and ${HEAD_SHA}.`,
         "Reviewing files that changed from the base of the PR and between " +
+        `not a sha and ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and between " +
         `not-a-sha\nand ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and between " +
+        `and ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and between " +
+        `\nand ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and between " +
+        `${"not and ".repeat(1_000)}base and ${HEAD_SHA}.`,
         codeRabbitReviewRange() + " but this is not the final review.",
         codeRabbitReviewRange() + ` Later requested ${STALE_SHA}.`,
         codeRabbitReviewRange().replace("Reviewing", "reviewing"),
@@ -543,7 +551,11 @@ describe("automated review gate", () => {
           "Reviewing files that changed from the base of the PR and between " +
           `not-a-sha and ${STALE_SHA}.`,
           "Reviewing files that changed from the base of the PR and between " +
+          `not a sha and ${STALE_SHA}.`,
+          "Reviewing files that changed from the base of the PR and between " +
           `not-a-sha\nand ${STALE_SHA}.`,
+          "Reviewing files that changed from the base of the PR and between " +
+          `and ${STALE_SHA}.`,
         ].join("\n"),
         "<!-- recent_review_end -->",
       ].join("\n"),
@@ -706,6 +718,34 @@ describe("automated review gate", () => {
         undefined,
       );
     }
+
+    const newerExactCurrentWithMalformedBaseDuplicates = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        codeRabbitReviewRange(),
+        "Reviewing files that changed from the base of the PR and between " +
+        `and ${HEAD_SHA}.`,
+        "Reviewing files that changed from the base of the PR and between " +
+        `not a sha and ${HEAD_SHA}.`,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [
+            olderSuccess,
+            newerExactCurrentWithMalformedBaseDuplicates,
+          ],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
 
     const newerFencedCurrentRangeExample = codeRabbitSummary({
       body: [

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -289,6 +289,23 @@ describe("automated review gate", () => {
     );
   });
 
+  it("rejects a structurally nested CodeRabbit no-actionable verdict", async () => {
+    await assertCodeRabbitSummaryRejected(
+      "",
+      "[",
+      "No actionable comments were generated in the recent review.",
+      "]: /target",
+      codeRabbitReviewRange(),
+    );
+    await assertCodeRabbitSummaryRejected(
+      "| verdict |",
+      "| --- |",
+      "No actionable comments were generated in the recent review.",
+      "",
+      codeRabbitReviewRange(),
+    );
+  });
+
   it("requires CodeRabbit's exact no-actionable verdict line", async () => {
     for (
       const alteredVerdict of [
@@ -629,6 +646,28 @@ describe("automated review gate", () => {
           `Requested commit: ${STALE_SHA}.`,
           ["Review skipped for current commit", "", `    ${HEAD_SHA}.`],
         ],
+        [
+          `Review skipped for current commit ${STALE_SHA}.`,
+          ["", `[Requested commit: ${HEAD_SHA}]: https://example.com`],
+        ],
+        [
+          `Requested commit: ${STALE_SHA}.`,
+          [
+            "",
+            `[Review skipped for current commit ${HEAD_SHA}.]: /target`,
+          ],
+        ],
+        [
+          `Review skipped for current commit ${STALE_SHA}.`,
+          ["", `[marker]: /target \"Requested commit: ${HEAD_SHA}.\"`],
+        ],
+        [
+          `Requested commit: ${STALE_SHA}.`,
+          [
+            "",
+            `[marker]: /target \"Review skipped for current commit ${HEAD_SHA}.\"`,
+          ],
+        ],
       ] as const
     ) {
       const newerSuccessfulSummary = codeRabbitSummary({
@@ -651,6 +690,50 @@ describe("automated review gate", () => {
           HEAD_SHA,
         ))?.url,
         "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-visible-review",
+      );
+    }
+  });
+
+  it("keeps markers inside invalid reference definitions visible", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+    for (
+      const visibleDefinitionLookalike of [
+        ["", `[Requested commit: ${HEAD_SHA}]:`],
+        [
+          "paragraph",
+          `[Requested commit: ${HEAD_SHA}]: https://example.com`,
+        ],
+        [
+          "",
+          '[marker]: /target "title',
+          "",
+          `Requested commit: ${HEAD_SHA}.\"`,
+        ],
+        [
+          "",
+          "| marker |",
+          "| --- |",
+          `[Requested commit: ${HEAD_SHA}]: /target`,
+        ],
+      ]
+    ) {
+      const newerVisibleCurrentMarker = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          codeRabbitReviewRange(),
+          "<!-- recent_review_end -->",
+          ...visibleDefinitionLookalike,
+        ].join("\n"),
+        created_at: "2026-08-22T12:05:00Z",
+        updated_at: "2026-08-22T12:05:00Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          { reviews: [], comments: [olderSuccess, newerVisibleCurrentMarker] },
+          HEAD_SHA,
+        ),
+        undefined,
       );
     }
   });
@@ -2498,6 +2581,232 @@ describe("automated review gate", () => {
     }
   });
 
+  it("bounds inline code to GFM table cells", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+    for (
+      const visibleTableEvidence of [
+        [
+          "| first | second |",
+          "| --- | --- |",
+          `| Reviewing files that changed from the base of the PR and between not-a-sha | and ${HEAD_SHA}. |`,
+        ],
+        [
+          "| first | second |",
+          "| --- | --- |",
+          `| Reviewing files that changed from the base of the PR and between ${STALE_SHA} | and ${HEAD_SHA}. |`,
+        ],
+        [
+          "| header ` | other |",
+          "| --- | --- |",
+          `| ${MALFORMED_CURRENT_RANGE} | \` |`,
+        ],
+        [
+          "| first | second | third |",
+          "| --- | --- | --- |",
+          `| \` | ${MALFORMED_CURRENT_RANGE} | \` |`,
+        ],
+        [
+          "| header ` |",
+          "| --- |",
+          MALFORMED_CURRENT_RANGE,
+          "`",
+        ],
+        [
+          "prefix `",
+          "| header |",
+          "| --- |",
+          `| ${MALFORMED_CURRENT_RANGE} |`,
+          "`",
+        ],
+        [
+          "> | header ` |",
+          "> | --- |",
+          `> | ${MALFORMED_CURRENT_RANGE} |`,
+          "> | ` |",
+        ],
+        [
+          "- | header ` |",
+          "  | --- |",
+          `  | ${MALFORMED_CURRENT_RANGE} |`,
+          "  | ` |",
+        ],
+        [
+          "- | header ` |",
+          "  | --- |",
+          `| ${MALFORMED_CURRENT_RANGE} |`,
+          "| ` |",
+        ],
+        [
+          "- | header ` |",
+          "  | --- |",
+          MALFORMED_CURRENT_RANGE,
+          "`",
+        ],
+        [
+          "> | header ` |",
+          "> | --- |",
+          `| ${MALFORMED_CURRENT_RANGE} |`,
+          "| ` |",
+        ],
+        [
+          "> | header ` |",
+          "> | --- |",
+          MALFORMED_CURRENT_RANGE,
+          "`",
+        ],
+        [
+          "- | header ` |",
+          "  | --- |",
+          "",
+          `| ${MALFORMED_CURRENT_RANGE} |`,
+          "| ` |",
+        ],
+      ]
+    ) {
+      const newerVisibleCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...visibleTableEvidence,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          { reviews: [], comments: [olderSuccess, newerVisibleCurrentRange] },
+          HEAD_SHA,
+        ),
+        undefined,
+        JSON.stringify(visibleTableEvidence),
+      );
+    }
+
+    const newerHiddenRangeWithEscapedPipe = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "| header |",
+        "| --- |",
+        `| \`code \\| ${MALFORMED_CURRENT_RANGE} closes\` |`,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerHiddenRangeWithEscapedPipe],
+        },
+        HEAD_SHA,
+      ))?.url,
+      olderSuccess.html_url,
+    );
+
+    for (
+      const visibleTableRows of [
+        [
+          `| Reviewing files that changed from the base of the PR and between not-a-sha | x |`,
+          `| and ${HEAD_SHA}. | y |`,
+        ],
+        [
+          `| Reviewing files that changed from the base of the PR and between not-a-sha | x |`,
+          "| and | y |",
+          `| ${HEAD_SHA}. | z |`,
+        ],
+        [
+          `| Reviewing files that changed from the base of the PR and between not-a-sha | x |`,
+          `| y | and ${HEAD_SHA}. |`,
+        ],
+      ]
+    ) {
+      const newerMalformedRangeAcrossTableRows = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          "| first | second |",
+          "| --- | --- |",
+          ...visibleTableRows,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerMalformedRangeAcrossTableRows],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+        JSON.stringify(visibleTableRows),
+      );
+    }
+
+    const newerExactRangeInsideTable = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "| evidence |",
+        "| --- |",
+        `|${codeRabbitReviewRange()}|`,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerExactRangeInsideTable],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+
+    for (
+      const invalidTableLookalike of [
+        [
+          "| header ` | other |",
+          "| --- |",
+          MALFORMED_CURRENT_RANGE,
+          "| ` |",
+        ],
+        [
+          "| header ` |",
+          "| === |",
+          MALFORMED_CURRENT_RANGE,
+          "| ` |",
+        ],
+      ]
+    ) {
+      const newerHiddenCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...invalidTableLookalike,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          { reviews: [], comments: [olderSuccess, newerHiddenCurrentRange] },
+          HEAD_SHA,
+        ))?.url,
+        olderSuccess.html_url,
+      );
+    }
+  });
+
   it("keeps link destinations and titles out of review evidence", async () => {
     const olderSuccess = olderCodeRabbitSuccess();
     const newerRangeInsideLinkTitle = codeRabbitSummary({
@@ -3267,6 +3576,62 @@ describe("automated review gate", () => {
     assert(
       performance.now() - denseReferenceDefinitionsStartedAt < 1_000,
       "dense reference-definition scanning must stay linear",
+    );
+
+    const newerDenseTables = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        ...Array.from(
+          { length: 500 },
+          (_, index) =>
+            `| header-${index} \` | value |\n| --- | --- |\n| body | \` |\n`,
+        ),
+        MALFORMED_CURRENT_RANGE,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:02:02Z",
+      updated_at: "2026-08-22T12:02:02Z",
+    });
+    const denseTablesStartedAt = performance.now();
+    assertEquals(
+      await findAutomatedReview(
+        { reviews: [], comments: [olderSuccess, newerDenseTables] },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+    assert(
+      performance.now() - denseTablesStartedAt < 1_000,
+      "dense GFM table scanning must stay linear",
+    );
+
+    const wideTableCells = Array.from({ length: 4_000 }, () => "cell");
+    const newerWideTable = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        `| ${wideTableCells.join(" | ")} |`,
+        `| ${wideTableCells.map(() => "-").join(" | ")} |`,
+        `| ${wideTableCells.join(" | ")} |`,
+        "",
+        MALFORMED_CURRENT_RANGE,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:02:02Z",
+      updated_at: "2026-08-22T12:02:02Z",
+    });
+    const wideTableStartedAt = performance.now();
+    assertEquals(
+      await findAutomatedReview(
+        { reviews: [], comments: [olderSuccess, newerWideTable] },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+    assert(
+      performance.now() - wideTableStartedAt < 1_000,
+      "wide GFM table scanning must stay linear",
     );
 
     const newerDenseUnclosedInlineLinks = codeRabbitSummary({

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -586,6 +586,67 @@ describe("automated review gate", () => {
     );
   });
 
+  it("ignores skip and request markers inside non-rendered Markdown", async () => {
+    for (
+      const [staleMarker, hiddenCurrentMarker] of [
+        [
+          `Review skipped for current commit ${STALE_SHA}.`,
+          [
+            "```text",
+            `Review skipped for current commit ${HEAD_SHA}.`,
+            "```",
+          ],
+        ],
+        [
+          `Requested commit: ${STALE_SHA}.`,
+          ["<!--", `Requested commit: ${HEAD_SHA}.`, "-->"],
+        ],
+        [
+          `Review skipped for current commit ${STALE_SHA}.`,
+          [`\`Requested commit: ${HEAD_SHA}.\``],
+        ],
+        [
+          `Requested commit: ${STALE_SHA}.`,
+          [`<span title="Review skipped for current commit ${HEAD_SHA}.">`],
+        ],
+        [
+          `Review skipped for current commit ${STALE_SHA}.`,
+          [`<? Requested commit: ${HEAD_SHA}. ?>`],
+        ],
+        [
+          `Requested commit: ${STALE_SHA}.`,
+          [`<!DECL Review skipped for current commit ${HEAD_SHA}.>`],
+        ],
+        [
+          `Review skipped for current commit ${STALE_SHA}.`,
+          [`<![CDATA[Requested commit: ${HEAD_SHA}.]]>`],
+        ],
+      ] as const
+    ) {
+      const newerSuccessfulSummary = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          codeRabbitReviewRange(),
+          "<!-- recent_review_end -->",
+          staleMarker,
+          ...hiddenCurrentMarker,
+        ].join("\n"),
+        created_at: "2026-08-22T12:05:00Z",
+        html_url:
+          "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-visible-review",
+        updated_at: "2026-08-22T12:05:00Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          { reviews: [], comments: [newerSuccessfulSummary] },
+          HEAD_SHA,
+        ))?.url,
+        "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-visible-review",
+      );
+    }
+  });
+
   it("classifies malformed and wrapped current-head ranges fail closed", async () => {
     const olderSuccess = olderCodeRabbitSuccess();
 
@@ -1495,9 +1556,9 @@ describe("automated review gate", () => {
     for (
       const visibleRangeAfterCommentLookalike of [
         ["\\<!--", MALFORMED_CURRENT_RANGE, "-->"],
-        ["    <!--", MALFORMED_CURRENT_RANGE, "-->"],
-        ["    example <!--", MALFORMED_CURRENT_RANGE, "-->"],
-        ["\t<!--", MALFORMED_CURRENT_RANGE, "-->"],
+        ["", "    <!--", MALFORMED_CURRENT_RANGE, "-->"],
+        ["", "    example <!--", MALFORMED_CURRENT_RANGE, "-->"],
+        ["", "\t<!--", MALFORMED_CURRENT_RANGE, "-->"],
         [">     <!--", `> ${MALFORMED_CURRENT_RANGE}`, "> -->"],
         [">     example <!--", `> ${MALFORMED_CURRENT_RANGE}`, "> -->"],
         ["`<!--`", MALFORMED_CURRENT_RANGE, "-->"],
@@ -1607,6 +1668,56 @@ describe("automated review gate", () => {
     );
   });
 
+  it("preserves paragraph context before classifying indented code", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+
+    for (
+      const paragraphContinuation of [
+        ["    <!--", MALFORMED_CURRENT_RANGE, "-->"],
+        ["    example <!--", MALFORMED_CURRENT_RANGE, "-->"],
+        ["\t<!--", MALFORMED_CURRENT_RANGE, "-->"],
+        [
+          "> paragraph text",
+          ">     <!--",
+          `> ${MALFORMED_CURRENT_RANGE}`,
+          "> -->",
+        ],
+        [
+          "> ordinary text <!--",
+          `> ${MALFORMED_CURRENT_RANGE}`,
+          "> -->",
+        ],
+        [
+          "- paragraph text",
+          "      <!--",
+          `  ${MALFORMED_CURRENT_RANGE}`,
+          "  -->",
+        ],
+      ]
+    ) {
+      const newerHiddenCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...paragraphContinuation,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerHiddenCurrentRange],
+          },
+          HEAD_SHA,
+        ))?.url,
+        "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
+      );
+    }
+  });
+
   it("does not let incomplete inline comments cross Markdown blocks", async () => {
     const olderSuccess = olderCodeRabbitSuccess();
 
@@ -1665,6 +1776,35 @@ describe("automated review gate", () => {
     );
   });
 
+  it("does not extend short inline HTML comments across later evidence", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+
+    for (const shortComment of ["<!-->", "<!--->"]) {
+      const newerVisibleCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          `ordinary ${shortComment}`,
+          MALFORMED_CURRENT_RANGE,
+          "-->",
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerVisibleCurrentRange],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
+  });
+
   it("keeps raw-block backticks from masking later comments", async () => {
     const olderSuccess = olderCodeRabbitSuccess();
     for (
@@ -1700,6 +1840,62 @@ describe("automated review gate", () => {
         "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
       );
     }
+  });
+
+  it("keeps inline HTML backticks from masking visible evidence", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+    for (
+      const inlineHtml of [
+        "ordinary text <!-- ` -->",
+        'ordinary text <span title="`">',
+      ]
+    ) {
+      const newerVisibleCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          inlineHtml,
+          MALFORMED_CURRENT_RANGE,
+          "`",
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerVisibleCurrentRange],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
+
+    const newerCurrentRangeInsideCode = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "`code <!--",
+        MALFORMED_CURRENT_RANGE,
+        "-->`",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerCurrentRangeInsideCode],
+        },
+        HEAD_SHA,
+      ))?.url,
+      "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
+    );
   });
 
   it("keeps structural review markers outside unmatched inline code", async () => {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -546,6 +546,28 @@ describe("automated review gate", () => {
       ))?.source,
       "summary",
     );
+
+    const newerOutOfScopeCurrentRange = codeRabbitSummary({
+      body: [
+        `Reviewing files between ${STALE_SHA} and ${HEAD_SHA}.`,
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        codeRabbitReviewRange(HEAD_SHA, STALE_SHA),
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:04:00Z",
+      updated_at: "2026-08-22T12:04:00Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerOutOfScopeCurrentRange],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
   });
 
   it("rejects any current-head skip or request marker in a summary", async () => {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2047,7 +2047,26 @@ describe("automated review gate", () => {
       const hiddenRange of [
         ["- ordinary <!--", codeRabbitReviewRange(), "-->"],
         [
+          "- ordinary <!--",
+          "<span>continuation",
+          codeRabbitReviewRange(),
+          "-->",
+        ],
+        [
+          "- ordinary <!--",
+          "<span>",
+          codeRabbitReviewRange(),
+          "-->",
+        ],
+        [
+          "- ordinary <!--",
+          "</span>",
+          codeRabbitReviewRange(),
+          "-->",
+        ],
+        [
           "> - ordinary <!--",
+          "<span>continuation",
           codeRabbitReviewRange(),
           "> -->",
         ],
@@ -2082,7 +2101,15 @@ describe("automated review gate", () => {
       );
     }
 
-    for (const paragraphBreak of ["", "# next block", "- next item"]) {
+    for (
+      const paragraphBreak of [
+        "",
+        "# next block",
+        "- next item",
+        "<div>",
+        "<script></script>",
+      ]
+    ) {
       const newerVisibleRangeAfterBreak = codeRabbitSummary({
         body: [
           "<!-- recent_review_start -->",

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2660,6 +2660,71 @@ describe("automated review gate", () => {
     );
   });
 
+  it("keeps HTML terminator searches start-aware across scanner passes", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+    for (
+      const htmlAroundVisibleEvidence of [
+        [
+          '<a title="one">',
+          MALFORMED_CURRENT_RANGE,
+          '<b title="two">',
+        ],
+        [
+          '<a title="`">',
+          MALFORMED_CURRENT_RANGE,
+          '<b title="unterminated`',
+        ],
+      ]
+    ) {
+      const newerVisibleCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...htmlAroundVisibleEvidence,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerVisibleCurrentRange],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
+  });
+
+  it("lets escaped multi-backtick runs close matching code spans", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+    const newerHiddenCurrentRange = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "``unclosed code span",
+        MALFORMED_CURRENT_RANGE,
+        "\\``",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerHiddenCurrentRange],
+        },
+        HEAD_SHA,
+      ))?.url,
+      "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
+    );
+  });
+
   it("keeps non-code backticks from masking visible evidence", async () => {
     const olderSuccess = olderCodeRabbitSuccess();
 

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1842,6 +1842,337 @@ describe("automated review gate", () => {
     }
   });
 
+  it("excludes raw HTML block bodies from review evidence", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+
+    for (
+      const [openingTag, closingTag] of [
+        ["<script>", "</script>"],
+        ['<SCRIPT type="application/json">', "</SCRIPT>"],
+        ["<style>", "</style>"],
+        ["<textarea>", "</textarea>"],
+        ["<pre>", "</pre>"],
+      ]
+    ) {
+      const newerHiddenExactRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          openingTag,
+          codeRabbitReviewRange(),
+          closingTag,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          { reviews: [], comments: [newerHiddenExactRange] },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+
+      const newerHiddenMalformedRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          openingTag,
+          MALFORMED_CURRENT_RANGE,
+          closingTag,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerHiddenMalformedRange],
+          },
+          HEAD_SHA,
+        ))?.url,
+        "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
+      );
+    }
+
+    const currentSummaryWithHiddenMarkers = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        codeRabbitReviewRange(),
+        "<!-- recent_review_end -->",
+        "<script>",
+        `Requested commit: ${HEAD_SHA}.`,
+        `Review skipped for current commit ${HEAD_SHA}.`,
+        "</script>",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        { reviews: [], comments: [currentSummaryWithHiddenMarkers] },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+
+    const blockquotedRawHtml = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "> <style>",
+        `> ${MALFORMED_CURRENT_RANGE}`,
+        "> </style>",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        { reviews: [], comments: [olderSuccess, blockquotedRawHtml] },
+        HEAD_SHA,
+      ))?.url,
+      "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
+    );
+
+    for (
+      const visibleRangeAfterRawBacktick of [
+        [
+          "<script>",
+          "`raw code-like text </script>",
+          MALFORMED_CURRENT_RANGE,
+          "visible text closes`",
+        ],
+        [
+          "> <script>",
+          "> `raw code-like text </script>",
+          `> ${MALFORMED_CURRENT_RANGE}`,
+          "> visible text closes`",
+        ],
+      ]
+    ) {
+      const newerVisibleCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...visibleRangeAfterRawBacktick,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerVisibleCurrentRange],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
+  });
+
+  it("preserves lazy blockquote paragraphs for inline HTML comments", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+
+    for (
+      const hiddenRange of [
+        ["> quoted paragraph <!--", MALFORMED_CURRENT_RANGE, "-->"],
+        [
+          "> quoted paragraph",
+          "> continues <!--",
+          MALFORMED_CURRENT_RANGE,
+          "-->",
+        ],
+      ]
+    ) {
+      const newerHiddenCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...hiddenRange,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerHiddenCurrentRange],
+          },
+          HEAD_SHA,
+        ))?.url,
+        "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
+      );
+    }
+
+    const newerVisibleRangeAfterBlankLine = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "> quoted paragraph <!--",
+        "",
+        MALFORMED_CURRENT_RANGE,
+        "-->",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerVisibleRangeAfterBlankLine],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+  });
+
+  it("preserves lazy list-item paragraphs for inline HTML comments", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+
+    for (
+      const hiddenRange of [
+        ["- ordinary <!--", codeRabbitReviewRange(), "-->"],
+        [
+          "> - ordinary <!--",
+          codeRabbitReviewRange(),
+          "> -->",
+        ],
+      ]
+    ) {
+      const newerHiddenExactRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...hiddenRange,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          { reviews: [], comments: [newerHiddenExactRange] },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerHiddenExactRange],
+          },
+          HEAD_SHA,
+        ))?.url,
+        "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
+      );
+    }
+
+    for (const paragraphBreak of ["", "# next block", "- next item"]) {
+      const newerVisibleRangeAfterBreak = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          "- ordinary <!--",
+          paragraphBreak,
+          MALFORMED_CURRENT_RANGE,
+          "-->",
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerVisibleRangeAfterBreak],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
+  });
+
+  it("pairs multiline inline code across blockquote paragraph lines", async () => {
+    const olderSuccess = olderCodeRabbitSuccess();
+
+    for (
+      const hiddenRange of [
+        [
+          "> `code starts",
+          `> ${MALFORMED_CURRENT_RANGE}`,
+          "> code closes`",
+        ],
+        [
+          ">`code starts",
+          `>${MALFORMED_CURRENT_RANGE}`,
+          ">code closes`",
+        ],
+      ]
+    ) {
+      const newerHiddenCurrentRange = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...hiddenRange,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerHiddenCurrentRange],
+          },
+          HEAD_SHA,
+        ))?.url,
+        "https://github.com/veryfront/veryfront-code/pull/1#issuecomment-1",
+      );
+    }
+
+    const newerVisibleRangeAfterBlankLine = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        "> `code starts",
+        "",
+        `> ${MALFORMED_CURRENT_RANGE}`,
+        "> code closes`",
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:03:41Z",
+      updated_at: "2026-08-22T12:03:41Z",
+    });
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerVisibleRangeAfterBlankLine],
+        },
+        HEAD_SHA,
+      ),
+      undefined,
+    );
+  });
+
   it("keeps inline HTML backticks from masking visible evidence", async () => {
     const olderSuccess = olderCodeRabbitSuccess();
     for (
@@ -2439,6 +2770,36 @@ describe("automated review gate", () => {
     assert(
       performance.now() - denseInlineStartedAt < 1_000,
       "dense inline-code scanning must stay linear",
+    );
+
+    const newerDenseRawHtmlBlocks = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        ...Array.from(
+          { length: 5_000 },
+          (_, index) =>
+            `<script>\n\`raw-${index}</script>\n> paragraph-${index}`,
+        ),
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:02:03Z",
+      updated_at: "2026-08-22T12:02:03Z",
+    });
+    const denseRawHtmlStartedAt = performance.now();
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerDenseRawHtmlBlocks],
+        },
+        HEAD_SHA,
+      ))?.url,
+      olderSuccess.html_url,
+    );
+    assert(
+      performance.now() - denseRawHtmlStartedAt < 1_000,
+      "dense raw-HTML exclusion scanning must stay linear",
     );
   });
 

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -978,6 +978,24 @@ describe("automated review gate", () => {
           `>   ${malformedCurrentRange}`,
           ">   ```",
         ],
+        [
+          "- ```md",
+          "  - ```",
+          `  ${malformedCurrentRange}`,
+          "  ```",
+        ],
+        [
+          "- ```md",
+          "",
+          `  ${malformedCurrentRange}`,
+          "  ```",
+        ],
+        [
+          "> - ```md",
+          ">",
+          `>   ${malformedCurrentRange}`,
+          ">   ```",
+        ],
       ]
     ) {
       const newerMarkdownLookingCodeInsideFence = codeRabbitSummary({
@@ -999,6 +1017,39 @@ describe("automated review gate", () => {
           HEAD_SHA,
         ))?.source,
         "summary",
+      );
+    }
+
+    for (
+      const closedContainerFence of [
+        ["- ```text", "  example", "  ```", malformedCurrentRange],
+        [
+          "> - ```text",
+          ">   example",
+          ">   ```",
+          malformedCurrentRange,
+        ],
+      ]
+    ) {
+      const newerCurrentRangeAfterClosedFence = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...closedContainerFence,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+        created_at: "2026-08-22T12:03:41Z",
+        updated_at: "2026-08-22T12:03:41Z",
+      });
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [olderSuccess, newerCurrentRangeAfterClosedFence],
+          },
+          HEAD_SHA,
+        ),
+        undefined,
       );
     }
 
@@ -1545,6 +1596,32 @@ describe("automated review gate", () => {
     assert(
       performance.now() - startedAt < 1_000,
       "dense malformed range parsing must stay linear",
+    );
+
+    const newerBareCarriageReturnLine = codeRabbitSummary({
+      body: [
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        `${"x".repeat(40_000)}\rplain`,
+        "<!-- recent_review_end -->",
+      ].join("\n"),
+      created_at: "2026-08-22T12:02:01Z",
+      updated_at: "2026-08-22T12:02:01Z",
+    });
+    const bareCarriageReturnStartedAt = performance.now();
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [olderSuccess, newerBareCarriageReturnLine],
+        },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+    assert(
+      performance.now() - bareCarriageReturnStartedAt < 1_000,
+      "bare carriage-return line scanning must stay linear",
     );
   });
 

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -206,6 +206,59 @@ describe("automated review gate", () => {
     }
   });
 
+  it("requires one unambiguous range in the selected recent review", async () => {
+    for (
+      const ranges of [
+        [codeRabbitReviewRange(), codeRabbitReviewRange(HEAD_SHA, STALE_SHA)],
+        [codeRabbitReviewRange(HEAD_SHA, STALE_SHA), codeRabbitReviewRange()],
+        [codeRabbitReviewRange(), codeRabbitReviewRange()],
+        [
+          codeRabbitReviewRange(),
+          codeRabbitReviewRange() + " but this is not the final review.",
+        ],
+        [
+          codeRabbitReviewRange(),
+          codeRabbitReviewRange().replace("Reviewing", "reviewing"),
+        ],
+      ]
+    ) {
+      const ambiguousSummary = codeRabbitSummary({
+        body: [
+          "<!-- recent_review_start -->",
+          "No actionable comments were generated in the recent review.",
+          ...ranges,
+          "<!-- recent_review_end -->",
+        ].join("\n"),
+      });
+
+      assertEquals(
+        await findAutomatedReview(
+          { reviews: [], comments: [ambiguousSummary] },
+          HEAD_SHA,
+        ),
+        undefined,
+      );
+    }
+
+    const scopedSummary = codeRabbitSummary({
+      body: [
+        codeRabbitReviewRange(HEAD_SHA, STALE_SHA),
+        "<!-- recent_review_start -->",
+        "No actionable comments were generated in the recent review.",
+        codeRabbitReviewRange(),
+        "<!-- recent_review_end -->",
+        codeRabbitReviewRange() + " but this is not the final review.",
+      ].join("\n"),
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        { reviews: [], comments: [scopedSummary] },
+        HEAD_SHA,
+      ))?.source,
+      "summary",
+    );
+  });
+
   it("accepts an authenticated Codex no-finding comment for the current head", async () => {
     assertEquals(
       await findAutomatedReview(

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -497,6 +497,7 @@ describe("automated review gate", () => {
       const malformedCurrentRange of [
         `Reviewing files between ${STALE_SHA} and ${HEAD_SHA}.`,
         codeRabbitReviewRange() + " but this is not the final review.",
+        codeRabbitReviewRange() + ` Later requested ${STALE_SHA}.`,
         codeRabbitReviewRange().replace("Reviewing", "reviewing"),
         codeRabbitReviewRange().replace("files that", "files  that"),
         codeRabbitReviewRange().replace(HEAD_SHA, HEAD_SHA.toUpperCase()),
@@ -530,7 +531,7 @@ describe("automated review gate", () => {
         "<!-- recent_review_start -->",
         "No actionable comments were generated in the recent review.",
         codeRabbitReviewRange(HEAD_SHA, STALE_SHA) +
-        " but this is not the final review.",
+        ` but this is not the final review. Later requested ${STALE_SHA}.`,
         "<!-- recent_review_end -->",
       ].join("\n"),
       created_at: "2026-08-22T12:03:00Z",

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1726,6 +1726,26 @@ describe("automated review gate", () => {
         ["ordinary text <!--", MALFORMED_CURRENT_RANGE],
         ["ordinary text <!--", "", MALFORMED_CURRENT_RANGE, "-->"],
         ["ordinary text <!--", "# next block", MALFORMED_CURRENT_RANGE, "-->"],
+        [
+          "ordinary text <!--",
+          "<!doctype html>",
+          MALFORMED_CURRENT_RANGE,
+          "-->",
+        ],
+        ["ordinary text <!--", "<!xml>", MALFORMED_CURRENT_RANGE, "-->"],
+        [
+          "ordinary text <!--",
+          "<!DoCtYpE html>",
+          MALFORMED_CURRENT_RANGE,
+          "-->",
+        ],
+        ["- ordinary <!--", "<!doctype html>", MALFORMED_CURRENT_RANGE, "-->"],
+        [
+          "> ordinary <!--",
+          "> <!doctype html>",
+          `> ${MALFORMED_CURRENT_RANGE}`,
+          "> -->",
+        ],
       ]
     ) {
       const newerVisibleCurrentRange = codeRabbitSummary({


### PR DESCRIPTION
## Why

The automated-review gate added in #4019 rejects CodeRabbit current no-findings summary even when it contains the exact PR head. CodeRabbit now writes `Reviewing files that changed from the base of the PR and between <base> and <head>.`; the gate only accepted an older sentence. PR #4023 demonstrated the false red on completed exact-head evidence.

## Design

- accept only the complete, case-sensitive current range sentence as one line, including its final period
- reject the legacy sentence, spacing or casing changes, and trailing qualifiers
- keep parsing inside CodeRabbit `recent_review` markers
- require two full 40-character SHAs and compare the reviewed tip to the exact PR head
- keep current-head skip/request evidence authoritative

## Verification

- regression first reproduced the current-template false rejection
- hosted P1 trailing-qualifier case reproduced before the fix
- 17 gate steps now cover the exact sentence, legacy wording, altered casing, trailing qualifiers, stale heads, and skip/request chronology
- script-specific format, lint, typecheck, and diff checks pass
- original exact local review was CLEAR at 94%; refreshed exact-head review is pending
- the first full pre-push reached 4,172 passing tests; two unchanged aggregate-load flakes passed isolated
- the updated full pre-push gate is running on the review fix

## Scope

Two CI gate files only. No product/runtime behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated review validation for Markdown tables, nested lists, blockquotes, links, HTML, comments, code blocks, and escaped formatting.
  * More reliably recognizes review-range evidence across table cells and multiline content.
  * Improved handling of bounded numeric markers, malformed or ambiguous ranges, and unrelated commit references.
  * Preserves correct review status and precedence across complex review histories.

* **Tests**
  * Expanded coverage for table formatting, line endings, nested structures, malformed input, review chronology, and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->