### PR TITLE
fix(cli): accept --project-dir in schedule and webhook, retire their cwd lane

### DIFF
--- a/cli/app/operations/project-creation.test.ts
+++ b/cli/app/operations/project-creation.test.ts
@@ -3,7 +3,6 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
-import { withCwd } from "#veryfront/testing/cwd.ts";
 import { join } from "veryfront/platform/path";
 import { createProject } from "./project-creation.ts";
 import { createInitialState } from "../state.ts";
@@ -56,14 +55,11 @@ describe("TUI project creation", () => {
         throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
       }) as typeof fetch;
 
-      // Only the call itself needs the directory: it resolves the new project
-      // relative to the process cwd. Everything around it uses absolute paths.
-      const state = await withCwd(workDir, () =>
-        createProject(
-          { state: createInitialState(), render: () => {} },
-          "My App",
-          "minimal",
-        ));
+      const state = await createProject(
+        { state: createInitialState(), render: () => {}, baseDir: workDir },
+        "My App",
+        "minimal",
+      );
 
       const link = JSON.parse(
         await Deno.readTextFile(
@@ -128,12 +124,11 @@ describe("TUI project creation", () => {
         throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
       }) as typeof fetch;
 
-      const state = await withCwd(workDir, () =>
-        createProject(
-          { state: createInitialState(), render: () => {} },
-          "My App",
-          "minimal",
-        ));
+      const state = await createProject(
+        { state: createInitialState(), render: () => {}, baseDir: workDir },
+        "My App",
+        "minimal",
+      );
 
       assertEquals(
         state.logs.some((entry) => entry.message.includes("projects/my-app already exists")),

--- a/cli/app/operations/project-creation.ts
+++ b/cli/app/operations/project-creation.ts
@@ -24,6 +24,8 @@ import type { InitTemplate } from "../../commands/init/types.ts";
 export interface ProjectCreationContext {
   state: AppState;
   render: () => void;
+  /** Directory whose `projects/` folder receives the new project. Defaults to the working directory. */
+  baseDir?: string;
 }
 
 /**
@@ -37,6 +39,7 @@ export async function createProject(
   let { state } = ctx;
 
   try {
+    const baseDir = ctx.baseDir ?? cwd();
     state = addLog("info", "Creating project...")(state);
     ctx.render();
 
@@ -54,7 +57,7 @@ export async function createProject(
     // slug, and `resolveOrCreateProject` below writes the link for it. Adopting
     // an existing `projects/<slug>` would point a directory that is already
     // someone else's project at the project just reserved.
-    const projectDir = join(cwd(), "projects", slug);
+    const projectDir = join(baseDir, "projects", slug);
     if (await createFileSystem().exists(projectDir)) {
       return addLog(
         "error",
@@ -64,7 +67,7 @@ export async function createProject(
 
     const creation = await createSharedProject({
       name: slug,
-      parentDir: join(cwd(), "projects"),
+      parentDir: join(baseDir, "projects"),
       template,
       runtime: "node",
       integrations: [],
@@ -101,7 +104,7 @@ export async function createProject(
     state = setProjects(currentProjects)(state);
 
     const result = await fetchRemoteProjects();
-    state = setRemoteProjects(result.projects)(state);
+    state = setRemoteProjects(result.projects, baseDir)(state);
 
     return addLog("info", `Created ${slug}`)(state);
   } catch (error) {

--- a/cli/app/state.ts
+++ b/cli/app/state.ts
@@ -160,10 +160,12 @@ export function setProjects(
 
 /**
  * Remote projects are the same concept as local ones and navigate through the
- * same list module. A remote project's path is where a pull would put it.
+ * same list module. A remote project's path is where a pull would put it,
+ * under `baseDir/projects/` (the working directory by default).
  */
 export function setRemoteProjects(
   projects: Array<{ slug: string }>,
+  baseDir: string = cwd(),
 ): StateUpdater {
   return (state) =>
     withSelectableActiveList({
@@ -172,15 +174,15 @@ export function setRemoteProjects(
         projects.map((p) => ({
           id: p.slug,
           label: p.slug,
-          data: { slug: p.slug, path: remoteProjectPath(p.slug), type: "remote" as const },
+          data: { slug: p.slug, path: remoteProjectPath(p.slug, baseDir), type: "remote" as const },
         })),
       ),
     });
 }
 
 /** Where `pull` places a remote project, and what the IDE opens. */
-export function remoteProjectPath(slug: string): string {
-  return join(cwd(), "projects", slug);
+export function remoteProjectPath(slug: string, baseDir: string = cwd()): string {
+  return join(baseDir, "projects", slug);
 }
 
 export function setTemplates(

--- a/cli/commands/schedule/command-help.ts
+++ b/cli/commands/schedule/command-help.ts
@@ -16,6 +16,10 @@ export const scheduleHelp: CommandHelp = {
         "Run the pushed source schedule in the Veryfront cloud runtime; cannot be combined with --input (run only)",
     },
     {
+      flag: "-d, --dir <path>",
+      description: "Project directory (default: current directory)",
+    },
+    {
       flag: "--json",
       description: "Output as JSON",
     },

--- a/cli/commands/schedule/handler.test.ts
+++ b/cli/commands/schedule/handler.test.ts
@@ -11,7 +11,6 @@ import { clearProjectAgentRuntimeRegistries } from "../../../src/agent/project/a
 import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 import { VeryfrontError } from "veryfront/errors";
-import { withCwd } from "#veryfront/testing/cwd.ts";
 import type { CreateScheduleRunFromSourceResult, Run, VeryfrontRunsClient } from "veryfront/runs";
 import type { ScheduleDefinition } from "veryfront/schedule";
 import { setJsonMode } from "../../shared/json-output.ts";
@@ -127,8 +126,6 @@ function restoreEnvironment(): void {
 
 describe("schedule command", () => {
   afterEach(() => {
-    // No chdir here: withCwd already handed the directory back, and reaching
-    // for it outside a turn would yank it from whichever test file holds it now.
     // deno-lint-ignore no-explicit-any
     (Deno as any).exit = originalExit;
     restoreMockFetch();
@@ -216,19 +213,17 @@ describe("schedule command", () => {
       };
 
       let exitCode: number | undefined;
-      // Held only for the command, which resolves veryfront.json from the cwd.
-      await withCwd(projectDir, async () => {
-        try {
-          await handleScheduleCommand({
-            _: ["schedule", "run", "process-job-submissions"],
-            remote: true,
-            json: true,
-          } as ParsedArgs);
-        } catch (error) {
-          if (!(error instanceof ExitSentinel)) throw error;
-          exitCode = error.code;
-        }
-      });
+      try {
+        await handleScheduleCommand({
+          _: ["schedule", "run", "process-job-submissions"],
+          "project-dir": projectDir,
+          remote: true,
+          json: true,
+        } as ParsedArgs);
+      } catch (error) {
+        if (!(error instanceof ExitSentinel)) throw error;
+        exitCode = error.code;
+      }
 
       assertEquals(exitCode, 0);
       assertEquals(requests.map((request) => request.url), [
@@ -330,19 +325,16 @@ describe("schedule command", () => {
       };
 
       let exitCode: number | undefined;
-      // Held only for the command, which discovers schedules/ and tasks/
-      // relative to the cwd.
-      await withCwd(projectDir, async () => {
-        try {
-          await handleScheduleCommand({
-            _: ["schedule", "run", "timed-task"],
-            json: true,
-          } as ParsedArgs);
-        } catch (error) {
-          if (!(error instanceof ExitSentinel)) throw error;
-          exitCode = error.code;
-        }
-      });
+      try {
+        await handleScheduleCommand({
+          _: ["schedule", "run", "timed-task"],
+          "project-dir": projectDir,
+          json: true,
+        } as ParsedArgs);
+      } catch (error) {
+        if (!(error instanceof ExitSentinel)) throw error;
+        exitCode = error.code;
+      }
 
       assertEquals(exitCode, 0);
       assertEquals(JSON.parse(output.at(-1) ?? "{}").data.output, {

--- a/cli/commands/schedule/handler.ts
+++ b/cli/commands/schedule/handler.ts
@@ -1,4 +1,4 @@
-import { createArgParser, parseArgsOrThrow } from "#cli/shared/args";
+import { CommonArgs, createArgParser, parseArgsOrThrow } from "#cli/shared/args";
 import { resolveConfigWithAuth } from "#cli/shared/config";
 import { withProjectSourceContext } from "#cli/shared/project-source-context";
 import type { ParsedArgs } from "#cli/shared/types";
@@ -48,6 +48,7 @@ const getScheduleArgsSchema = defineSchema((v) =>
     action: v.enum(["run", "list"]).optional(),
     id: v.string().optional(),
     input: v.string().optional(),
+    projectDir: v.string().optional(),
     remote: v.boolean().default(false),
     debug: v.boolean().default(false),
   })
@@ -61,6 +62,7 @@ const parseScheduleArgs = createArgParser(ScheduleArgsSchema, {
   action: { keys: ["action"], type: "string", positional: 0 },
   id: { keys: ["id"], type: "string", positional: 1 },
   input: { keys: ["input"], type: "string" },
+  projectDir: CommonArgs.projectDir,
   remote: { keys: ["remote"], type: "boolean" },
   debug: { keys: ["debug"], type: "boolean" },
 });
@@ -69,8 +71,7 @@ function formatSchedule(schedule: ScheduleDefinition): string {
   return `${schedule.id} -> ${schedule.target.kind}:${schedule.target.id} (${schedule.schedule})`;
 }
 
-async function handleScheduleList(_args: ParsedArgs): Promise<void> {
-  const projectDir = Deno.cwd();
+async function handleScheduleList(projectDir: string): Promise<void> {
   await withProjectSourceContext(projectDir, async ({ adapter, config }) => {
     const result = await discoverSchedules({
       projectDir,
@@ -395,10 +396,11 @@ async function runRemoteSchedule(
 
 export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
   const opts: ScheduleArgs = parseArgsOrThrow(parseScheduleArgs, "schedule", args);
+  const projectDir = opts.projectDir ?? Deno.cwd();
 
   // Dispatch "list" (also the default when no action is given)
   if (!opts.action || opts.action === "list") {
-    await handleScheduleList(args);
+    await handleScheduleList(projectDir);
     return;
   }
 
@@ -407,7 +409,6 @@ export async function handleScheduleCommand(args: ParsedArgs): Promise<void> {
     throw INVALID_ARGUMENT.create({ detail: "Usage: veryfront schedule run <id>" });
   }
 
-  const projectDir = Deno.cwd();
   if (!isTriggerId(opts.id)) {
     throw INVALID_ARGUMENT.create({ detail: `Invalid schedule id: "${opts.id}".` });
   }

--- a/cli/commands/webhook/command-help.ts
+++ b/cli/commands/webhook/command-help.ts
@@ -12,6 +12,10 @@ export const webhookHelp: CommandHelp = {
         "JSON payload fixture (run only; 64 KiB maximum; filters and agent templates are applied)",
     },
     {
+      flag: "-d, --dir <path>",
+      description: "Project directory (default: current directory)",
+    },
+    {
       flag: "--json",
       description: "Output as JSON",
     },

--- a/cli/commands/webhook/handler.test.ts
+++ b/cli/commands/webhook/handler.test.ts
@@ -10,7 +10,6 @@ import { clearProjectAgentRuntimeRegistries } from "#veryfront/agent/project/age
 import { clearTranspileCache } from "#veryfront/discovery/transpiler.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 import { VeryfrontError } from "veryfront/errors";
-import { withCwd } from "#veryfront/testing/cwd.ts";
 import { setJsonMode } from "../../shared/json-output.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
 import { handleWebhookCommand, toWebhookAgentOptions } from "./handler.ts";
@@ -46,20 +45,18 @@ async function runCommand(args: ParsedArgs): Promise<{
   return { exitCode, output };
 }
 
-function runCommandInProjectCwd(
+function runCommandInProject(
   projectDir: string,
   args: ParsedArgs,
 ): Promise<{
   exitCode: number | undefined;
   output: string[];
 }> {
-  return withCwd(projectDir, () => runCommand(args));
+  return runCommand({ ...args, "project-dir": projectDir });
 }
 
 describe("webhook command", () => {
   afterEach(() => {
-    // No chdir here: withCwd already handed the directory back, and reaching
-    // for it outside a turn would yank it from whichever test file holds it now.
     // deno-lint-ignore no-explicit-any
     (Deno as any).exit = originalExit;
     console.log = originalConsoleLog;
@@ -104,9 +101,9 @@ describe("webhook command", () => {
         JSON.stringify({ action: "closed" }),
       );
 
-      const result = await runCommandInProjectCwd(projectDir, {
+      const result = await runCommandInProject(projectDir, {
         _: ["webhook", "run", "pull-request"],
-        payload: "closed.json",
+        payload: `${projectDir}/closed.json`,
         json: true,
       } as ParsedArgs);
 
@@ -181,9 +178,9 @@ describe("webhook command", () => {
         }),
       );
 
-      const result = await runCommandInProjectCwd(projectDir, {
+      const result = await runCommandInProject(projectDir, {
         _: ["webhook", "run", "pull-request"],
-        payload: "opened.json",
+        payload: `${projectDir}/opened.json`,
         json: true,
       } as ParsedArgs);
 

--- a/cli/commands/webhook/handler.ts
+++ b/cli/commands/webhook/handler.ts
@@ -1,4 +1,4 @@
-import { createArgParser, parseArgsOrThrow } from "#cli/shared/args";
+import { CommonArgs, createArgParser, parseArgsOrThrow } from "#cli/shared/args";
 import { withProjectSourceContext } from "#cli/shared/project-source-context";
 import type { ParsedArgs } from "#cli/shared/types";
 import { cliLogger, exitProcess } from "#cli/utils";
@@ -23,6 +23,7 @@ const getWebhookArgsSchema = defineSchema((v) =>
     action: v.enum(["run", "list"]).optional(),
     id: v.string().optional(),
     payload: v.string().optional(),
+    projectDir: v.string().optional(),
     debug: v.boolean().default(false),
   })
 );
@@ -35,6 +36,7 @@ const parseWebhookArgs = createArgParser(WebhookArgsSchema, {
   action: { keys: ["action"], type: "string", positional: 0 },
   id: { keys: ["id"], type: "string", positional: 1 },
   payload: { keys: ["payload"], type: "string" },
+  projectDir: CommonArgs.projectDir,
   debug: { keys: ["debug"], type: "boolean" },
 });
 
@@ -99,8 +101,7 @@ function formatWebhook(webhook: WebhookDefinition): string {
   return `${webhook.id} -> ${webhook.target.kind}:${webhook.target.id}`;
 }
 
-async function handleWebhookList(_args: ParsedArgs): Promise<void> {
-  const projectDir = Deno.cwd();
+async function handleWebhookList(projectDir: string): Promise<void> {
   await withProjectSourceContext(projectDir, async ({ adapter, config }) => {
     const result = await discoverWebhooks({
       projectDir,
@@ -119,10 +120,11 @@ async function handleWebhookList(_args: ParsedArgs): Promise<void> {
 
 export async function handleWebhookCommand(args: ParsedArgs): Promise<void> {
   const opts: WebhookArgs = parseArgsOrThrow(parseWebhookArgs, "webhook", args);
+  const projectDir = opts.projectDir ?? Deno.cwd();
 
   // Dispatch "list" (also the default when no action is given)
   if (!opts.action || opts.action === "list") {
-    await handleWebhookList(args);
+    await handleWebhookList(projectDir);
     return;
   }
 
@@ -137,7 +139,6 @@ export async function handleWebhookCommand(args: ParsedArgs): Promise<void> {
     throw INVALID_ARGUMENT.create({ detail: `Invalid webhook id: "${opts.id}".` });
   }
 
-  const projectDir = Deno.cwd();
   const payload = await readJsonFile(opts.payload, "--payload JSON file");
 
   await withProjectSourceContext(projectDir, async (context) => {

--- a/cli/router.test.ts
+++ b/cli/router.test.ts
@@ -2,7 +2,6 @@ import "#veryfront/schemas/_test-setup.ts";
 import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { withCwd } from "#veryfront/testing/cwd.ts";
 import { COMMANDS } from "./help/command-definitions.ts";
 import { parseLoginMethod } from "./auth/utils.ts";
 import { routeCommand } from "./router.ts";
@@ -675,14 +674,12 @@ describe("cli/router helpers", () => {
         Deno.env.set("XDG_CONFIG_HOME", configHome);
         _resetEnvironmentConfig();
 
-        // Scoped to the call that resolves veryfront.json from the cwd, rather
-        // than held across the whole test.
-        const code = await withCwd(projectDir, () =>
-          runAndCaptureExit({
-            _: ["schedule", "run", "process-job-submissions"],
-            remote: true,
-            json: true,
-          } as ParsedArgs));
+        const code = await runAndCaptureExit({
+          _: ["schedule", "run", "process-job-submissions"],
+          "project-dir": projectDir,
+          remote: true,
+          json: true,
+        } as ParsedArgs);
         assertEquals(code, 1);
         assertEquals(consoleOutput.length, 1);
         const parsed = JSON.parse(consoleOutput[0] ?? "{}");

--- a/scripts/test/run-suite.test.ts
+++ b/scripts/test/run-suite.test.ts
@@ -26,11 +26,7 @@ import {
 } from "./run-suite.ts";
 
 const UNIT_CWD_FILES = [
-  "cli/router.test.ts",
-  "cli/app/operations/project-creation.test.ts",
-  "cli/commands/schedule/handler.test.ts",
   "cli/commands/skills/validate.test.ts",
-  "cli/commands/webhook/handler.test.ts",
   "src/platform/compat/process.test.ts",
   "src/testing/cwd.test.ts",
 ];
@@ -199,7 +195,7 @@ describe("migration command surface", () => {
       "src/a test.test.ts",
     ]);
     const cwd = buildDenoSuiteCommandArgs("unit:cwd", [
-      "cli/router.test.ts",
+      "src/testing/cwd.test.ts",
     ]);
     const integration = buildDenoSuiteCommandArgs(
       "integration:legacy-tests-root",

--- a/scripts/test/run-suite.ts
+++ b/scripts/test/run-suite.ts
@@ -66,11 +66,7 @@ const UNIT_ROOTS = (() => {
   return unit.pathSelectors.filter((root) => !UNPLANNABLE_UNIT_ROOTS.has(root));
 })();
 const UNIT_CWD_FILES = [
-  "cli/router.test.ts",
-  "cli/app/operations/project-creation.test.ts",
-  "cli/commands/schedule/handler.test.ts",
   "cli/commands/skills/validate.test.ts",
-  "cli/commands/webhook/handler.test.ts",
   "src/platform/compat/process.test.ts",
   "src/testing/cwd.test.ts",
 ];


### PR DESCRIPTION
## Why

`schedule`, `webhook`, and the TUI's project creation read the process working directory with no way to pass a directory in. Their tests therefore had to `Deno.chdir` through `withCwd`, which kept four files in the serial `unit:cwd` test lane and a cross-isolate disk lock in play for every unit-suite run.

## What

- `schedule` and `webhook` accept the project directory argument the rest of the CLI already has (`CommonArgs.projectDir`: `--project-dir`, `--dir`, `-d`), resolving `opts.projectDir ?? Deno.cwd()`. Help text updated.
- TUI `createProject` accepts an optional `baseDir` on its context; `remoteProjectPath` / `setRemoteProjects` take an optional `baseDir`. All default to the working directory — no caller changes behaviour.
- The four tests pass the directory instead of entering it, drop `withCwd`, and return to `unit:parallel`. `UNIT_CWD_FILES` in `scripts/test/run-suite.ts` shrinks to the three files that are genuinely about cwd itself (`skills/validate` tests a literal `"."`, `platform/compat/process` and `testing/cwd` test the primitives).

## Notes

- Semantic unit-boundary audit: unchanged (2141/762) — these entries never carried `shared-cwd`.
- Follow-up candidates (out of scope): `cli/commands/build/embedded-preset-flags.test.ts` and `cli/auth/login.test.ts` still use `withCwd` from the parallel lane (safe under its disk lock, but the same parameter treatment applies).

## Verification

- The four migrated files + `src/testing/cwd.test.ts` + run-suite/suites pin tests: pass.
- `deno task test:unit:cwd` (now 3 files): pass. The four files run under `--parallel --trace-leaks` alongside five unrelated cli tests: 14 passed (277 steps), no leaks.
- `deno task lint:test-semantic-dispositions`, `deno task test:layout`, `deno task lint:cwd-relative-test-reads`: ok.
- Pre-push gate (fmt, lint, check, `test:unit`): passed on push.