### PR TITLE
feat(platform): name the Host Runtime seam with live and in-memory adapters

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -112,3 +112,20 @@ children. The `parallel`, `branch`, and `map` record IDs derive from the composi
 generated component. None of those local records are persisted or available for lookup. Only
 the root persisted ID identifies a run outside the process, so callers, the backends, and
 observability all key on it.
+
+## Host Runtime
+
+The single owner of how framework code sees the process it runs in:
+`src/platform/compat/process/host-runtime.ts` (`HostRuntime`). It covers
+environment variables, the working directory, command-line arguments, process
+exit, and termination signals — nothing else. CLI command handlers and shared
+CLI helpers consult it through an optional `host` parameter that defaults to
+the live adapter (`options.host ?? liveHostRuntime()`), the same shape as
+`projectDir ?? cwd()`. There are exactly two adapters: `liveHostRuntime()`
+delegates to the cross-runtime compat functions and is the production path;
+`createInMemoryHostRuntime()` holds an isolated env map, a fixed cwd and argv,
+recorded exits, and signal subscribers a test fires itself. Code that takes a
+host never reads or mutates `Deno.env`, `process.env`, `Deno.args`,
+`Deno.exit`, or signal listeners directly, so it is live in production and
+in-memory in tests without saving and restoring global state. Outbound
+transport is a separate seam and is not folded in here.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -118,7 +118,7 @@ observability all key on it.
 The single owner of how framework code sees the process it runs in:
 `src/platform/compat/process/host-runtime.ts` (`HostRuntime`). It covers
 environment variables, the working directory, command-line arguments, process
-exit, and termination signals — nothing else. CLI command handlers and shared
+exit, and termination signals, nothing else. CLI command handlers and shared
 CLI helpers consult it through an optional `host` parameter that defaults to
 the live adapter (`options.host ?? liveHostRuntime()`), the same shape as
 `projectDir ?? cwd()`. There are exactly two adapters: `liveHostRuntime()`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -119,9 +119,9 @@ The single owner of how framework code sees the process it runs in:
 `src/platform/compat/process/host-runtime.ts` (`HostRuntime`). It covers
 environment variables, the working directory, command-line arguments, process
 exit, and termination signals, nothing else. CLI command handlers and shared
-CLI helpers consult it through an optional `host` parameter that defaults to
-the live adapter (`options.host ?? liveHostRuntime()`), the same shape as
-`projectDir ?? cwd()`. There are exactly two adapters: `liveHostRuntime()`
+CLI helpers receive it as a positional `host` parameter that defaults to the
+live adapter (`parseServeArgs(args, host: HostRuntime = liveHostRuntime())`).
+There are exactly two adapters: `liveHostRuntime()`
 delegates to the cross-runtime compat functions and is the production path;
 `createInMemoryHostRuntime()` holds an isolated env map, a fixed cwd and argv,
 recorded exits, and signal subscribers a test fires itself. Code that takes a

--- a/cli/commands/dev/handler.test.ts
+++ b/cli/commands/dev/handler.test.ts
@@ -4,7 +4,8 @@ import "#veryfront/schemas/_test-setup.ts";
  */
 
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createInMemoryHostRuntime } from "#veryfront/platform/compat/process.ts";
 import { parseCliArgs } from "#cli/shared/args";
 import { handleDevCommand, parseDevArgs } from "./handler.ts";
 import type { ParsedArgs } from "#cli/shared/types";
@@ -78,91 +79,68 @@ describe("commands/dev/handler", () => {
   });
 
   describe("PORT env var", () => {
-    let savedPort: string | undefined;
-    let savedVeryfrontPort: string | undefined;
-
-    beforeEach(() => {
-      savedPort = Deno.env.get("PORT");
-      savedVeryfrontPort = Deno.env.get("VERYFRONT_PORT");
-      Deno.env.delete("PORT");
-      Deno.env.delete("VERYFRONT_PORT");
-    });
-
-    afterEach(() => {
-      if (savedPort === undefined) Deno.env.delete("PORT");
-      else Deno.env.set("PORT", savedPort);
-      if (savedVeryfrontPort === undefined) Deno.env.delete("VERYFRONT_PORT");
-      else Deno.env.set("VERYFRONT_PORT", savedVeryfrontPort);
-    });
+    function parseDevWithEnv(argv: string[], env: Record<string, string>) {
+      return parseDevArgs(parseCliArgs(argv), createInMemoryHostRuntime({ env }));
+    }
 
     it("uses PORT env var as the default port when --port is not passed", () => {
-      Deno.env.set("PORT", "3001");
-      const result = parseDevArgs(parseCliArgs(["dev"]));
-      assertEquals(result.success, true);
-      if (result.success) assertEquals(result.data.port, 3001);
+      const result = parseDevWithEnv(["dev"], { PORT: "3001" });
+      assertEquals(result.success, true, "parsing succeeds");
+      if (result.success) assertEquals(result.data.port, 3001, "PORT supplies the default");
     });
 
     it("--port flag wins over PORT env var", () => {
-      Deno.env.set("PORT", "3001");
-      const result = parseDevArgs(parseCliArgs(["dev", "--port", "4000"]));
-      assertEquals(result.success, true);
-      if (result.success) assertEquals(result.data.port, 4000);
+      const result = parseDevWithEnv(["dev", "--port", "4000"], { PORT: "3001" });
+      assertEquals(result.success, true, "parsing succeeds");
+      if (result.success) assertEquals(result.data.port, 4000, "the flag wins");
     });
 
     it("-p alias also wins over PORT env var", () => {
-      Deno.env.set("PORT", "3001");
-      const result = parseDevArgs(parseCliArgs(["dev", "-p", "4000"]));
-      assertEquals(result.success, true);
-      if (result.success) assertEquals(result.data.port, 4000);
+      const result = parseDevWithEnv(["dev", "-p", "4000"], { PORT: "3001" });
+      assertEquals(result.success, true, "parsing succeeds");
+      if (result.success) assertEquals(result.data.port, 4000, "the alias wins");
     });
 
     it("uses VERYFRONT_PORT when PORT is not set", () => {
-      Deno.env.set("VERYFRONT_PORT", "3001");
-      const result = parseDevArgs(parseCliArgs(["dev"]));
-      assertEquals(result.success, true);
-      if (result.success) assertEquals(result.data.port, 3001);
+      const result = parseDevWithEnv(["dev"], { VERYFRONT_PORT: "3001" });
+      assertEquals(result.success, true, "parsing succeeds");
+      if (result.success) assertEquals(result.data.port, 3001, "VERYFRONT_PORT is honoured");
     });
 
     it("PORT takes precedence over VERYFRONT_PORT", () => {
-      Deno.env.set("PORT", "4000");
-      Deno.env.set("VERYFRONT_PORT", "3001");
-      const result = parseDevArgs(parseCliArgs(["dev"]));
-      assertEquals(result.success, true);
-      if (result.success) assertEquals(result.data.port, 4000);
+      const result = parseDevWithEnv(["dev"], { PORT: "4000", VERYFRONT_PORT: "3001" });
+      assertEquals(result.success, true, "parsing succeeds");
+      if (result.success) assertEquals(result.data.port, 4000, "PORT outranks VERYFRONT_PORT");
     });
 
     it("falls back to 3000 when PORT is not a valid integer", () => {
-      Deno.env.set("PORT", "not-a-port");
-      const result = parseDevArgs(parseCliArgs(["dev"]));
-      assertEquals(result.success, true);
-      if (result.success) assertEquals(result.data.port, 3000);
+      const result = parseDevWithEnv(["dev"], { PORT: "not-a-port" });
+      assertEquals(result.success, true, "parsing succeeds");
+      if (result.success) assertEquals(result.data.port, 3000, "garbage falls back");
     });
 
     it("rejects PORT with trailing garbage (PORT=3001abc) — full string must be digits", () => {
-      Deno.env.set("PORT", "3001abc");
-      const result = parseDevArgs(parseCliArgs(["dev"]));
-      assertEquals(result.success, true);
-      if (result.success) assertEquals(result.data.port, 3000);
+      const result = parseDevWithEnv(["dev"], { PORT: "3001abc" });
+      assertEquals(result.success, true, "parsing succeeds");
+      if (result.success) assertEquals(result.data.port, 3000, "no prefix parsing");
     });
 
     it("rejects PORT=0 as outside the valid range (1-65535)", () => {
-      Deno.env.set("PORT", "0");
-      const result = parseDevArgs(parseCliArgs(["dev"]));
-      assertEquals(result.success, true);
-      if (result.success) assertEquals(result.data.port, 3000);
+      const result = parseDevWithEnv(["dev"], { PORT: "0" });
+      assertEquals(result.success, true, "parsing succeeds");
+      if (result.success) assertEquals(result.data.port, 3000, "0 is out of range");
     });
 
     it("rejects PORT=65536 as outside the valid range (1-65535)", () => {
-      Deno.env.set("PORT", "65536");
-      const result = parseDevArgs(parseCliArgs(["dev"]));
-      assertEquals(result.success, true);
-      if (result.success) assertEquals(result.data.port, 3000);
+      const result = parseDevWithEnv(["dev"], { PORT: "65536" });
+      assertEquals(result.success, true, "parsing succeeds");
+      if (result.success) assertEquals(result.data.port, 3000, "65536 is out of range");
     });
 
     it("uses default 3000 when neither PORT nor VERYFRONT_PORT are set", () => {
-      const result = parseDevArgs(parseCliArgs(["dev"]));
-      assertEquals(result.success, true);
-      if (result.success) assertEquals(result.data.port, 3000);
+      const result = parseDevWithEnv(["dev"], {});
+      assertEquals(result.success, true, "parsing succeeds");
+      if (result.success) assertEquals(result.data.port, 3000, "the hardcoded default applies");
     });
   });
 });

--- a/cli/commands/dev/handler.test.ts
+++ b/cli/commands/dev/handler.test.ts
@@ -119,7 +119,7 @@ describe("commands/dev/handler", () => {
       if (result.success) assertEquals(result.data.port, 3000, "garbage falls back");
     });
 
-    it("rejects PORT with trailing garbage (PORT=3001abc) — full string must be digits", () => {
+    it("rejects PORT with trailing garbage because the full string must be digits", () => {
       const result = parseDevWithEnv(["dev"], { PORT: "3001abc" });
       assertEquals(result.success, true, "parsing succeeds");
       if (result.success) assertEquals(result.data.port, 3000, "no prefix parsing");

--- a/cli/commands/dev/handler.ts
+++ b/cli/commands/dev/handler.ts
@@ -4,7 +4,7 @@
 
 import { defineSchema, lazySchema } from "veryfront/schemas";
 import { isAbsolute, join } from "veryfront/platform/path";
-import { cwd, getEnv, setEnv } from "veryfront/platform";
+import { cwd, type HostRuntime, liveHostRuntime, setEnv } from "veryfront/platform";
 import { createFileSystem } from "veryfront/platform";
 import { cliLogger, DEFAULT_DEV_SERVER_PORT, logWarning, showHeader } from "#cli/utils";
 import { refreshLoggerConfig } from "veryfront/utils";
@@ -21,8 +21,8 @@ import type { ParsedArgs } from "#cli/shared/types";
  * `Number.parseInt("3001abc")` silently returns 3001, so this function requires
  * the entire trimmed string to be digits before converting — no prefix parsing.
  */
-function parsePortEnv(name: string): number | undefined {
-  const raw = getEnv(name);
+function parsePortEnv(host: HostRuntime, name: string): number | undefined {
+  const raw = host.env.get(name);
   if (raw === undefined) return undefined;
   const trimmed = raw.trim();
   if (trimmed === "") return undefined;
@@ -43,8 +43,8 @@ function parsePortEnv(name: string): number | undefined {
  * absent or contains a value that fails strict validation (non-integer string,
  * trailing garbage, or a value outside the 1-65535 range).
  */
-function readPortEnv(name: string, fallback: number): number {
-  return parsePortEnv(name) ?? fallback;
+function readPortEnv(host: HostRuntime, name: string, fallback: number): number {
+  return parsePortEnv(host, name) ?? fallback;
 }
 
 /**
@@ -54,8 +54,8 @@ function readPortEnv(name: string, fallback: number): number {
  * Used to determine whether the port came from an explicit env var rather than
  * falling through to the hardcoded default.
  */
-function isValidPortEnv(name: string): boolean {
-  const raw = getEnv(name);
+function isValidPortEnv(host: HostRuntime, name: string): boolean {
+  const raw = host.env.get(name);
   if (!raw) return false;
   const t = raw.trim();
   if (!/^\d+$/.test(t)) return false;
@@ -75,9 +75,9 @@ function isValidPortEnv(name: string): boolean {
  * This matches how `veryfront serve` handles the same env vars, and how
  * Next.js, Vite, Create React App, Heroku, and Railway all treat `PORT`.
  */
-function getDefaultDevPort(): number {
-  const veryfrontPort = readPortEnv("VERYFRONT_PORT", DEFAULT_DEV_SERVER_PORT);
-  return readPortEnv("PORT", veryfrontPort);
+function getDefaultDevPort(host: HostRuntime): number {
+  const veryfrontPort = readPortEnv(host, "VERYFRONT_PORT", DEFAULT_DEV_SERVER_PORT);
+  return readPortEnv(host, "PORT", veryfrontPort);
 }
 
 const getDevArgsSchema = defineSchema((v) =>
@@ -106,7 +106,10 @@ const parseDevArgsBase = createArgParser(DevArgsSchema, {
  * Parses dev command arguments, honouring `PORT` / `VERYFRONT_PORT` as
  * lower-precedence defaults when no explicit `--port` / `-p` is given.
  */
-export const parseDevArgs: typeof parseDevArgsBase = (args) => {
+export function parseDevArgs(
+  args: ParsedArgs,
+  host: HostRuntime = liveHostRuntime(),
+): ReturnType<typeof parseDevArgsBase> {
   const result = parseDevArgsBase(args);
   if (!result.success) return result;
 
@@ -115,11 +118,11 @@ export const parseDevArgs: typeof parseDevArgsBase = (args) => {
     data: {
       ...result.data,
       port: args.port === undefined && args.p === undefined
-        ? getDefaultDevPort()
+        ? getDefaultDevPort(host)
         : result.data.port,
     },
   };
-};
+}
 
 async function resolveProjectDir(projectArg: string | undefined): Promise<string> {
   if (projectArg) {
@@ -144,6 +147,7 @@ async function resolveProjectDir(projectArg: string | undefined): Promise<string
 }
 
 export async function handleDevCommand(args: ParsedArgs): Promise<void> {
+  const host = liveHostRuntime();
   const opts = parseArgsOrThrow(parseDevArgs, "dev", args);
   showHeader();
 
@@ -159,10 +163,10 @@ export async function handleDevCommand(args: ParsedArgs): Promise<void> {
   // env var that happens to equal the default value.
   const portExplicit = args.port !== undefined ||
     args.p !== undefined ||
-    isValidPortEnv("PORT") ||
-    isValidPortEnv("VERYFRONT_PORT");
+    isValidPortEnv(host, "PORT") ||
+    isValidPortEnv(host, "VERYFRONT_PORT");
   if (args.port !== undefined || args.p !== undefined) {
-    const portFromEnv = parsePortEnv("PORT");
+    const portFromEnv = parsePortEnv(host, "PORT");
     if (portFromEnv !== undefined && opts.port !== portFromEnv) {
       logWarning(
         `PORT=${portFromEnv} is set but --port ${opts.port} takes precedence`,

--- a/cli/commands/dev/handler.ts
+++ b/cli/commands/dev/handler.ts
@@ -10,75 +10,8 @@ import { cliLogger, DEFAULT_DEV_SERVER_PORT, logWarning, showHeader } from "#cli
 import { refreshLoggerConfig } from "veryfront/utils";
 import { createArgParser, parseArgsOrThrow } from "#cli/shared/args";
 import { ensureCliBundlerContracts } from "#cli/shared/default-contracts";
+import { isValidPortEnv, parsePortEnv, resolveEnvironmentPort } from "#cli/shared/port-env";
 import type { ParsedArgs } from "#cli/shared/types";
-
-/**
- * Parse a port from an env var string.  Returns `undefined` when the var is
- * absent, empty, not an all-digit integer, or outside the valid port range
- * 1–65535.  Invalid values emit a warning so the developer sees exactly what
- * was rejected rather than getting a silent fallback.
- *
- * `Number.parseInt("3001abc")` silently returns 3001, so this function requires
- * the entire trimmed string to be digits before converting — no prefix parsing.
- */
-function parsePortEnv(host: HostRuntime, name: string): number | undefined {
-  const raw = host.env.get(name);
-  if (raw === undefined) return undefined;
-  const trimmed = raw.trim();
-  if (trimmed === "") return undefined;
-  if (!/^\d+$/.test(trimmed)) {
-    logWarning(`${name}=${JSON.stringify(raw)} is not a valid port number; ignoring`);
-    return undefined;
-  }
-  const port = Number(trimmed);
-  if (port < 1 || port > 65535) {
-    logWarning(`${name}=${port} is outside the valid port range (1-65535); ignoring`);
-    return undefined;
-  }
-  return port;
-}
-
-/**
- * Read a numeric port from an env var, returning `fallback` when the var is
- * absent or contains a value that fails strict validation (non-integer string,
- * trailing garbage, or a value outside the 1-65535 range).
- */
-function readPortEnv(host: HostRuntime, name: string, fallback: number): number {
-  return parsePortEnv(host, name) ?? fallback;
-}
-
-/**
- * Returns true when the named env var holds a valid port number (all-digit
- * string within 1–65535).  This is a pure predicate — it never emits warnings,
- * because those were already emitted by `parsePortEnv` during arg parsing.
- * Used to determine whether the port came from an explicit env var rather than
- * falling through to the hardcoded default.
- */
-function isValidPortEnv(host: HostRuntime, name: string): boolean {
-  const raw = host.env.get(name);
-  if (!raw) return false;
-  const t = raw.trim();
-  if (!/^\d+$/.test(t)) return false;
-  const n = Number(t);
-  return n >= 1 && n <= 65535;
-}
-
-/**
- * The default port to use for `veryfront dev`, resolved from env vars.
- *
- * Priority (highest → lowest):
- *   1. `--port` / `-p` flag — explicit, handled by `parseDevArgs`
- *   2. `PORT`              — the near-universal PaaS / framework convention
- *   3. `VERYFRONT_PORT`   — Veryfront-specific override
- *   4. 3000               — hardcoded default
- *
- * This matches how `veryfront serve` handles the same env vars, and how
- * Next.js, Vite, Create React App, Heroku, and Railway all treat `PORT`.
- */
-function getDefaultDevPort(host: HostRuntime): number {
-  const veryfrontPort = readPortEnv(host, "VERYFRONT_PORT", DEFAULT_DEV_SERVER_PORT);
-  return readPortEnv(host, "PORT", veryfrontPort);
-}
 
 const getDevArgsSchema = defineSchema((v) =>
   v.object({
@@ -118,7 +51,7 @@ export function parseDevArgs(
     data: {
       ...result.data,
       port: args.port === undefined && args.p === undefined
-        ? getDefaultDevPort(host)
+        ? resolveEnvironmentPort(host, DEFAULT_DEV_SERVER_PORT)
         : result.data.port,
     },
   };
@@ -158,7 +91,7 @@ export async function handleDevCommand(args: ParsedArgs): Promise<void> {
   // developers arriving from Next.js, Vite, Heroku, and Railway expect to work.
   //
   // `portExplicit` is also used to carry provenance into devCommand so that
-  // `PORT=3000` is honoured even when 3000 equals the hardcoded default — the
+  // `PORT=3000` is honoured even when 3000 equals the hardcoded default. The
   // sentinel `port !== 3000` check in devCommand must not swallow an explicit
   // env var that happens to equal the default value.
   const portExplicit = args.port !== undefined ||
@@ -193,7 +126,7 @@ export async function handleDevCommand(args: ParsedArgs): Promise<void> {
     open: opts.open,
     // Clear stale ESM caches to prevent module resolution issues from previous
     // runs. devCommand does this only once it has resolved the dev port and
-    // found it free — the caches are shared with any dev server already running
+    // found it free. The caches are shared with any dev server already running
     // against this project.
     clearLocalCaches: true,
   });

--- a/cli/commands/serve/handler.test.ts
+++ b/cli/commands/serve/handler.test.ts
@@ -1,33 +1,13 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { parseCliArgs } from "#cli/shared/args";
 import type { ParsedArgs } from "#cli/shared/types";
-import { deleteEnv, getEnv, setEnv } from "#veryfront/compat/process.ts";
+import { createInMemoryHostRuntime } from "#veryfront/platform/compat/process.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { handleServeCommand, parseServeArgs } from "./handler.ts";
 
-function withServeEnv(
-  values: { PORT?: string; VERYFRONT_PORT?: string; BIND_ADDRESS?: string },
-  run: () => void,
-): void {
-  const previous = {
-    PORT: getEnv("PORT"),
-    VERYFRONT_PORT: getEnv("VERYFRONT_PORT"),
-    BIND_ADDRESS: getEnv("BIND_ADDRESS"),
-  };
-
-  try {
-    for (const [key, value] of Object.entries(values)) {
-      if (value === undefined) deleteEnv(key);
-      else setEnv(key, value);
-    }
-    run();
-  } finally {
-    for (const [key, value] of Object.entries(previous)) {
-      if (value === undefined) deleteEnv(key);
-      else setEnv(key, value);
-    }
-  }
+function serveHost(env: Record<string, string>) {
+  return createInMemoryHostRuntime({ env });
 }
 
 describe("commands/serve/handler", () => {
@@ -75,52 +55,54 @@ describe("commands/serve/handler", () => {
 
     describe("port handling", () => {
       it("uses deployment environment defaults when flags are omitted", () => {
-        withServeEnv(
-          { PORT: "4321", VERYFRONT_PORT: undefined, BIND_ADDRESS: "0.0.0.0" },
-          () => {
-            const parsed = parseServeArgs({ _: ["serve"] });
-
-            assertEquals(parsed.success, true);
-            assertExists(parsed.data);
-            assertEquals(parsed.data.port, 4321);
-            assertEquals(parsed.data.hostname, "0.0.0.0");
-          },
+        const parsed = parseServeArgs(
+          { _: ["serve"] },
+          serveHost({ PORT: "4321", BIND_ADDRESS: "0.0.0.0" }),
         );
+
+        assertEquals(parsed.success, true, "parsing succeeds");
+        assertExists(parsed.data);
+        assertEquals(parsed.data.port, 4321, "PORT supplies the default port");
+        assertEquals(parsed.data.hostname, "0.0.0.0", "BIND_ADDRESS supplies the hostname");
       });
 
       it("uses VERYFRONT_PORT when PORT is absent", () => {
-        withServeEnv(
-          { PORT: undefined, VERYFRONT_PORT: "4322", BIND_ADDRESS: undefined },
-          () => {
-            const parsed = parseServeArgs({ _: ["serve"] });
+        const parsed = parseServeArgs({ _: ["serve"] }, serveHost({ VERYFRONT_PORT: "4322" }));
 
-            assertEquals(parsed.success, true);
-            assertExists(parsed.data);
-            assertEquals(parsed.data.port, 4322);
-          },
+        assertEquals(parsed.success, true, "parsing succeeds");
+        assertExists(parsed.data);
+        assertEquals(parsed.data.port, 4322, "VERYFRONT_PORT is honoured");
+      });
+
+      it("prefers PORT over VERYFRONT_PORT", () => {
+        const parsed = parseServeArgs(
+          { _: ["serve"] },
+          serveHost({ PORT: "4321", VERYFRONT_PORT: "4322" }),
         );
+
+        assertEquals(parsed.success, true, "parsing succeeds");
+        assertExists(parsed.data);
+        assertEquals(parsed.data.port, 4321, "PORT outranks VERYFRONT_PORT");
       });
 
       it("keeps explicit network flags ahead of environment defaults", () => {
-        withServeEnv(
-          { PORT: "4321", VERYFRONT_PORT: undefined, BIND_ADDRESS: "0.0.0.0" },
-          () => {
-            const parsed = parseServeArgs({
-              _: ["serve"],
-              port: 8080,
-              hostname: "127.0.0.1",
-            });
-
-            assertEquals(parsed.success, true);
-            assertExists(parsed.data);
-            assertEquals(parsed.data.port, 8080);
-            assertEquals(parsed.data.hostname, "127.0.0.1");
+        const parsed = parseServeArgs(
+          {
+            _: ["serve"],
+            port: 8080,
+            hostname: "127.0.0.1",
           },
+          serveHost({ PORT: "4321", BIND_ADDRESS: "0.0.0.0" }),
         );
+
+        assertEquals(parsed.success, true, "parsing succeeds");
+        assertExists(parsed.data);
+        assertEquals(parsed.data.port, 8080, "the port flag wins");
+        assertEquals(parsed.data.hostname, "127.0.0.1", "the hostname flag wins");
       });
 
       it("keeps -p as a compatibility alias for --port", () => {
-        const parsed = parseServeArgs(parseCliArgs(["serve", "-p", "8081"]));
+        const parsed = parseServeArgs(parseCliArgs(["serve", "-p", "8081"]), serveHost({}));
 
         assertEquals(parsed.success, true);
         assertExists(parsed.data);
@@ -131,7 +113,7 @@ describe("commands/serve/handler", () => {
     describe("boolean flag extraction", () => {
       it("parses --binary without consuming the following positional", () => {
         const args = parseCliArgs(["serve", "--binary", "project"]);
-        const parsed = parseServeArgs(args);
+        const parsed = parseServeArgs(args, serveHost({}));
 
         assertEquals(parsed.success, true);
         assertExists(parsed.data);
@@ -167,21 +149,24 @@ describe("commands/serve/handler", () => {
 
     describe("hostname/host/bindAddress resolution", () => {
       it("defaults production mode to all interfaces", () => {
-        withServeEnv(
-          { PORT: undefined, VERYFRONT_PORT: undefined, BIND_ADDRESS: undefined },
-          () => {
-            const parsed = parseServeArgs({ _: ["serve"] });
+        const parsed = parseServeArgs({ _: ["serve"] }, serveHost({}));
 
-            assertEquals(parsed.success, true);
-            assertExists(parsed.data);
-            assertEquals(parsed.data.hostname, "0.0.0.0");
-          },
-        );
+        assertEquals(parsed.success, true, "parsing succeeds");
+        assertExists(parsed.data);
+        assertEquals(parsed.data.hostname, "0.0.0.0", "no BIND_ADDRESS binds all interfaces");
+      });
+
+      it("ignores a blank BIND_ADDRESS", () => {
+        const parsed = parseServeArgs({ _: ["serve"] }, serveHost({ BIND_ADDRESS: "   " }));
+
+        assertEquals(parsed.success, true, "parsing succeeds");
+        assertExists(parsed.data);
+        assertEquals(parsed.data.hostname, "0.0.0.0", "whitespace falls back to all interfaces");
       });
 
       it("uses --hostname when provided", () => {
         const args: ParsedArgs = { _: ["serve"], hostname: "127.0.0.1" };
-        const parsed = parseServeArgs(args);
+        const parsed = parseServeArgs(args, serveHost({}));
         assertEquals(parsed.success, true);
         assertExists(parsed.data);
         assertEquals(parsed.data.hostname, "127.0.0.1");
@@ -189,7 +174,7 @@ describe("commands/serve/handler", () => {
 
       it("uses --host when provided", () => {
         const args: ParsedArgs = { _: ["serve"], host: "localhost" };
-        const parsed = parseServeArgs(args);
+        const parsed = parseServeArgs(args, serveHost({}));
         assertEquals(parsed.success, true);
         assertExists(parsed.data);
         assertEquals(parsed.data.hostname, "localhost");
@@ -201,7 +186,7 @@ describe("commands/serve/handler", () => {
           hostname: "10.0.0.1",
           host: "192.168.1.1",
         };
-        const parsed = parseServeArgs(args);
+        const parsed = parseServeArgs(args, serveHost({}));
         assertEquals(parsed.success, true);
         assertExists(parsed.data);
         assertEquals(parsed.data.hostname, "10.0.0.1");

--- a/cli/commands/serve/handler.test.ts
+++ b/cli/commands/serve/handler.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { parseCliArgs } from "#cli/shared/args";
 import type { ParsedArgs } from "#cli/shared/types";
+import { DEFAULT_DEV_SERVER_PORT } from "#cli/utils";
 import { createInMemoryHostRuntime } from "#veryfront/platform/compat/process.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
@@ -107,6 +108,41 @@ describe("commands/serve/handler", () => {
         assertEquals(parsed.success, true);
         assertExists(parsed.data);
         assertEquals(parsed.data.port, 8081);
+      });
+
+      it("rejects malformed and out-of-range environment ports", () => {
+        for (const value of ["3001abc", "-1", "0", "65536", "", "1e3"]) {
+          const parsed = parseServeArgs({ _: ["serve"] }, serveHost({ PORT: value }));
+
+          assertEquals(parsed.success, true, `PORT=${JSON.stringify(value)} parses`);
+          assertExists(parsed.data);
+          assertEquals(
+            parsed.data.port,
+            DEFAULT_DEV_SERVER_PORT,
+            `PORT=${JSON.stringify(value)} falls back`,
+          );
+        }
+      });
+
+      it("accepts trimmed environment ports at the valid boundaries", () => {
+        for (const [value, expected] of [["1", 1], ["65535", 65535], [" 3001 ", 3001]] as const) {
+          const parsed = parseServeArgs({ _: ["serve"] }, serveHost({ PORT: value }));
+
+          assertEquals(parsed.success, true, `PORT=${JSON.stringify(value)} parses`);
+          assertExists(parsed.data);
+          assertEquals(parsed.data.port, expected, `PORT=${JSON.stringify(value)} is accepted`);
+        }
+      });
+
+      it("falls through an invalid PORT to a valid VERYFRONT_PORT", () => {
+        const parsed = parseServeArgs(
+          { _: ["serve"] },
+          serveHost({ PORT: "invalid", VERYFRONT_PORT: "4322" }),
+        );
+
+        assertEquals(parsed.success, true, "parsing succeeds");
+        assertExists(parsed.data);
+        assertEquals(parsed.data.port, 4322, "the valid lower-precedence port is used");
       });
     });
 

--- a/cli/commands/serve/handler.ts
+++ b/cli/commands/serve/handler.ts
@@ -1,25 +1,25 @@
 import { defineSchema, lazySchema } from "veryfront/schemas";
-import { getEnv } from "veryfront/platform";
+import { type HostRuntime, liveHostRuntime } from "veryfront/platform";
 import { DEFAULT_DEV_SERVER_PORT } from "#cli/utils";
 import { ServerModeSchema } from "#cli/shared/types";
 import { createArgParser, parseArgsOrThrow } from "#cli/shared/args";
 import { ensureCliBundlerContracts } from "#cli/shared/default-contracts";
 import type { ParsedArgs } from "#cli/shared/types";
 
-function readPortEnv(name: string, fallback: number): number {
-  const value = getEnv(name);
+function readPortEnv(host: HostRuntime, name: string, fallback: number): number {
+  const value = host.env.get(name);
   if (value === undefined) return fallback;
   const port = Number.parseInt(value, 10);
   return Number.isNaN(port) ? fallback : port;
 }
 
-function getDefaultServePort(): number {
-  const veryfrontPort = readPortEnv("VERYFRONT_PORT", DEFAULT_DEV_SERVER_PORT);
-  return readPortEnv("PORT", veryfrontPort);
+function getDefaultServePort(host: HostRuntime): number {
+  const veryfrontPort = readPortEnv(host, "VERYFRONT_PORT", DEFAULT_DEV_SERVER_PORT);
+  return readPortEnv(host, "PORT", veryfrontPort);
 }
 
-function getDefaultBindAddress(): string {
-  return getEnv("BIND_ADDRESS")?.trim() || "0.0.0.0";
+function getDefaultBindAddress(host: HostRuntime): string {
+  return host.env.get("BIND_ADDRESS")?.trim() || "0.0.0.0";
 }
 
 const getServeArgsSchema = defineSchema((v) =>
@@ -46,7 +46,15 @@ const parseServeArgsBase = createArgParser(ServeArgsSchema, {
   debug: { keys: ["debug"], type: "boolean" },
 });
 
-export const parseServeArgs: typeof parseServeArgsBase = (args) => {
+/**
+ * Parses serve command arguments, honouring `PORT` / `VERYFRONT_PORT` and
+ * `BIND_ADDRESS` from the host as lower-precedence defaults when the matching
+ * flags are omitted.
+ */
+export function parseServeArgs(
+  args: ParsedArgs,
+  host: HostRuntime = liveHostRuntime(),
+): ReturnType<typeof parseServeArgsBase> {
   const result = parseServeArgsBase(args);
   if (!result.success) return result;
 
@@ -55,14 +63,14 @@ export const parseServeArgs: typeof parseServeArgsBase = (args) => {
     data: {
       ...result.data,
       port: args.port === undefined && args.p === undefined
-        ? getDefaultServePort()
+        ? getDefaultServePort(host)
         : result.data.port,
       hostname: args.hostname === undefined && args.host === undefined
-        ? getDefaultBindAddress()
+        ? getDefaultBindAddress(host)
         : result.data.hostname,
     },
   };
-};
+}
 
 export async function handleServeCommand(args: ParsedArgs): Promise<void> {
   const opts = parseArgsOrThrow(parseServeArgs, "serve", args);

--- a/cli/commands/serve/handler.ts
+++ b/cli/commands/serve/handler.ts
@@ -4,19 +4,8 @@ import { DEFAULT_DEV_SERVER_PORT } from "#cli/utils";
 import { ServerModeSchema } from "#cli/shared/types";
 import { createArgParser, parseArgsOrThrow } from "#cli/shared/args";
 import { ensureCliBundlerContracts } from "#cli/shared/default-contracts";
+import { resolveEnvironmentPort } from "#cli/shared/port-env";
 import type { ParsedArgs } from "#cli/shared/types";
-
-function readPortEnv(host: HostRuntime, name: string, fallback: number): number {
-  const value = host.env.get(name);
-  if (value === undefined) return fallback;
-  const port = Number.parseInt(value, 10);
-  return Number.isNaN(port) ? fallback : port;
-}
-
-function getDefaultServePort(host: HostRuntime): number {
-  const veryfrontPort = readPortEnv(host, "VERYFRONT_PORT", DEFAULT_DEV_SERVER_PORT);
-  return readPortEnv(host, "PORT", veryfrontPort);
-}
 
 function getDefaultBindAddress(host: HostRuntime): string {
   return host.env.get("BIND_ADDRESS")?.trim() || "0.0.0.0";
@@ -63,7 +52,7 @@ export function parseServeArgs(
     data: {
       ...result.data,
       port: args.port === undefined && args.p === undefined
-        ? getDefaultServePort(host)
+        ? resolveEnvironmentPort(host, DEFAULT_DEV_SERVER_PORT)
         : result.data.port,
       hostname: args.hostname === undefined && args.host === undefined
         ? getDefaultBindAddress(host)

--- a/cli/deno.json
+++ b/cli/deno.json
@@ -11,6 +11,7 @@
     "#cli/shared/constants": "./shared/constants.ts",
     "#cli/shared/config": "./shared/config.ts",
     "#cli/shared/default-contracts": "./shared/default-contracts.ts",
+    "#cli/shared/port-env": "./shared/port-env.ts",
     "#cli/shared/project-source-context": "./shared/project-source-context.ts",
     "#cli/shared/slug": "./shared/slug.ts",
     "#cli/shared/reserve-slug": "./shared/reserve-slug.ts",

--- a/cli/shared/animation.test.ts
+++ b/cli/shared/animation.test.ts
@@ -1,50 +1,44 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { createInMemoryHostRuntime } from "#veryfront/platform/compat/process.ts";
 import { isAnimationDisabled, setAnimationDisabled } from "./animation.ts";
 
 describe("animation", () => {
-  let originalTerm: string | undefined;
-
-  beforeEach(() => {
-    originalTerm = Deno.env.get("TERM");
-  });
+  const colorTerminal = createInMemoryHostRuntime({ env: { TERM: "xterm-256color" } });
 
   afterEach(() => {
-    if (originalTerm !== undefined) {
-      Deno.env.set("TERM", originalTerm);
-    } else {
-      Deno.env.delete("TERM");
-    }
     setAnimationDisabled(false);
   });
 
   it("defaults to false", () => {
-    Deno.env.set("TERM", "xterm-256color");
-    assertEquals(isAnimationDisabled(), false);
+    assertEquals(isAnimationDisabled(colorTerminal), false, "animation is enabled by default");
   });
 
   it("can be set to true", () => {
     setAnimationDisabled(true);
-    assertEquals(isAnimationDisabled(), true);
+    assertEquals(isAnimationDisabled(colorTerminal), true, "the flag disables animation");
   });
 
   it("can toggle back to false", () => {
-    Deno.env.set("TERM", "xterm-256color");
     setAnimationDisabled(true);
     setAnimationDisabled(false);
-    assertEquals(isAnimationDisabled(), false);
+    assertEquals(isAnimationDisabled(colorTerminal), false, "clearing the flag re-enables");
   });
 
   describe("TERM=dumb detection", () => {
     it("returns true when TERM=dumb", () => {
-      Deno.env.set("TERM", "dumb");
-      assertEquals(isAnimationDisabled(), true);
+      const host = createInMemoryHostRuntime({ env: { TERM: "dumb" } });
+      assertEquals(isAnimationDisabled(host), true, "a dumb terminal disables animation");
     });
 
     it("returns false when TERM is not dumb", () => {
-      Deno.env.set("TERM", "xterm-256color");
-      assertEquals(isAnimationDisabled(), false);
+      assertEquals(isAnimationDisabled(colorTerminal), false, "a capable terminal animates");
+    });
+
+    it("returns false when TERM is unset", () => {
+      const host = createInMemoryHostRuntime();
+      assertEquals(isAnimationDisabled(host), false, "no TERM does not disable animation");
     });
   });
 });

--- a/cli/shared/animation.ts
+++ b/cli/shared/animation.ts
@@ -7,7 +7,7 @@
  * @module cli/shared/animation
  */
 
-import { getEnv } from "veryfront/platform";
+import { type HostRuntime, liveHostRuntime } from "veryfront/platform";
 
 let _animationDisabled = false;
 
@@ -15,7 +15,7 @@ export function setAnimationDisabled(disabled: boolean): void {
   _animationDisabled = disabled;
 }
 
-export function isAnimationDisabled(): boolean {
+export function isAnimationDisabled(host: HostRuntime = liveHostRuntime()): boolean {
   if (_animationDisabled) return true;
-  return getEnv("TERM") === "dumb";
+  return host.env.get("TERM") === "dumb";
 }

--- a/cli/shared/interactive.test.ts
+++ b/cli/shared/interactive.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createInMemoryHostRuntime } from "#veryfront/platform/compat/process.ts";
 import {
   detectCI,
   isAutoConfirmEnabled,
@@ -39,6 +40,26 @@ describe("interactive", () => {
   describe("detectCI", () => {
     it("returns a boolean", () => {
       assertEquals(typeof detectCI(), "boolean");
+    });
+
+    it("treats any known CI variable with a truthy value as CI", () => {
+      for (
+        const key of ["CI", "GITHUB_ACTIONS", "GITLAB_CI", "JENKINS_URL", "CIRCLECI", "BUILDKITE"]
+      ) {
+        const host = createInMemoryHostRuntime({ env: { [key]: "1" } });
+        assertEquals(detectCI(host), true, `${key}=1 is CI`);
+      }
+    });
+
+    it("ignores CI variables that are empty, 0, or false", () => {
+      const host = createInMemoryHostRuntime({
+        env: { CI: "", GITHUB_ACTIONS: "0", GITLAB_CI: "false" },
+      });
+      assertEquals(detectCI(host), false, "explicitly disabled markers are not CI");
+    });
+
+    it("is not CI when no marker is present", () => {
+      assertEquals(detectCI(createInMemoryHostRuntime()), false, "an empty env is not CI");
     });
   });
 

--- a/cli/shared/interactive.ts
+++ b/cli/shared/interactive.ts
@@ -8,7 +8,7 @@
  * @module cli/shared/interactive
  */
 
-import { getEnv } from "veryfront/platform";
+import { type HostRuntime, liveHostRuntime } from "veryfront/platform";
 
 let _nonInteractive = false;
 let _autoConfirm = false;
@@ -38,9 +38,9 @@ export function resetInteractiveMode(): void {
 
 const CI_ENV_VARS = ["CI", "GITHUB_ACTIONS", "GITLAB_CI", "JENKINS_URL", "CIRCLECI", "BUILDKITE"];
 
-export function detectCI(): boolean {
+export function detectCI(host: HostRuntime = liveHostRuntime()): boolean {
   return CI_ENV_VARS.some((v) => {
-    const val = getEnv(v);
+    const val = host.env.get(v);
     return val !== undefined && val !== "" && val !== "0" && val !== "false";
   });
 }

--- a/cli/shared/port-env.ts
+++ b/cli/shared/port-env.ts
@@ -1,0 +1,46 @@
+import type { HostRuntime } from "veryfront/platform";
+import { logWarning } from "#cli/utils";
+
+const DECIMAL_PORT_PATTERN = /^\d+$/;
+const MIN_TCP_PORT = 1;
+const MAX_TCP_PORT = 65_535;
+
+function parsePortValue(raw: string): number | undefined {
+  const value = raw.trim();
+  if (value === "" || !DECIMAL_PORT_PATTERN.test(value)) return undefined;
+
+  const port = Number(value);
+  return port >= MIN_TCP_PORT && port <= MAX_TCP_PORT ? port : undefined;
+}
+
+/** Read one strictly validated TCP port from the host environment. */
+export function parsePortEnv(
+  host: HostRuntime,
+  name: string,
+): number | undefined {
+  const raw = host.env.get(name);
+  if (raw === undefined || raw.trim() === "") return undefined;
+
+  const port = parsePortValue(raw);
+  if (port !== undefined) return port;
+
+  logWarning(
+    `${name}=${JSON.stringify(raw)} must be a complete decimal port from 1 to 65535; ignoring`,
+  );
+  return undefined;
+}
+
+/** Return whether one host environment value is a valid TCP port. */
+export function isValidPortEnv(host: HostRuntime, name: string): boolean {
+  const raw = host.env.get(name);
+  return raw !== undefined && parsePortValue(raw) !== undefined;
+}
+
+/** Resolve PORT, then VERYFRONT_PORT, then the supplied default. */
+export function resolveEnvironmentPort(
+  host: HostRuntime,
+  fallback: number,
+): number {
+  const veryfrontPort = parsePortEnv(host, "VERYFRONT_PORT") ?? fallback;
+  return parsePortEnv(host, "PORT") ?? veryfrontPort;
+}

--- a/cli/shared/server-startup.test.ts
+++ b/cli/shared/server-startup.test.ts
@@ -1,54 +1,16 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createInMemoryHostRuntime } from "#veryfront/platform/compat/process.ts";
 import {
   buildDiscoveryConfig,
   buildProxyRuntimeProjectIdentity,
   prepareCliProxyModeEnvironment,
 } from "./server-startup.ts";
 
-const originalApiToken = Deno.env.get("VERYFRONT_API_TOKEN");
-const originalProjectSlug = Deno.env.get("VERYFRONT_PROJECT_SLUG");
-const originalProxyMode = Deno.env.get("PROXY_MODE");
-const originalLocalProxyMode = Deno.env.get("VERYFRONT_CLI_LOCAL_PROXY_MODE");
-const originalNodeEnv = Deno.env.get("NODE_ENV");
-const originalDenoEnv = Deno.env.get("DENO_ENV");
-
-function restoreEnv(): void {
-  if (originalApiToken === undefined) {
-    Deno.env.delete("VERYFRONT_API_TOKEN");
-  } else {
-    Deno.env.set("VERYFRONT_API_TOKEN", originalApiToken);
-  }
-
-  if (originalProjectSlug === undefined) {
-    Deno.env.delete("VERYFRONT_PROJECT_SLUG");
-  } else {
-    Deno.env.set("VERYFRONT_PROJECT_SLUG", originalProjectSlug);
-  }
-
-  for (
-    const [key, value] of [
-      ["PROXY_MODE", originalProxyMode],
-      ["VERYFRONT_CLI_LOCAL_PROXY_MODE", originalLocalProxyMode],
-      ["NODE_ENV", originalNodeEnv],
-      ["DENO_ENV", originalDenoEnv],
-    ] as const
-  ) {
-    if (value === undefined) {
-      Deno.env.delete(key);
-    } else {
-      Deno.env.set(key, value);
-    }
-  }
-}
-
 describe("buildDiscoveryConfig", () => {
-  afterEach(restoreEnv);
-
   it("does not scope an unlinked local project to its directory slug", () => {
-    Deno.env.set("VERYFRONT_API_TOKEN", "stored-token");
-    Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+    const host = createInMemoryHostRuntime({ env: { VERYFRONT_API_TOKEN: "stored-token" } });
 
     const config = buildDiscoveryConfig({
       port: 3000,
@@ -57,15 +19,14 @@ describe("buildDiscoveryConfig", () => {
       requestInterceptor: (request: Request) => request,
       defaultProjectId: "local-my-agent",
       linkedProjectSlug: undefined,
-    });
+    }, host);
 
-    assertEquals(config.projectSlug, undefined);
-    assertEquals(config.apiToken, "stored-token");
+    assertEquals(config.projectSlug, undefined, "no slug is inferred from the directory");
+    assertEquals(config.apiToken, "stored-token", "the stored token is forwarded");
   });
 
   it("uses a persisted project link for cloud discovery", () => {
-    Deno.env.set("VERYFRONT_API_TOKEN", "stored-token");
-    Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+    const host = createInMemoryHostRuntime({ env: { VERYFRONT_API_TOKEN: "stored-token" } });
 
     const config = buildDiscoveryConfig({
       port: 3000,
@@ -74,9 +35,39 @@ describe("buildDiscoveryConfig", () => {
       requestInterceptor: (request: Request) => request,
       defaultProjectId: "local-my-agent",
       linkedProjectSlug: "linked-project",
+    }, host);
+
+    assertEquals(config.projectSlug, "linked-project", "the persisted link names the project");
+  });
+
+  it("lets VERYFRONT_PROJECT_SLUG override a persisted project link", () => {
+    const host = createInMemoryHostRuntime({
+      env: { VERYFRONT_API_TOKEN: "stored-token", VERYFRONT_PROJECT_SLUG: "env-project" },
     });
 
-    assertEquals(config.projectSlug, "linked-project");
+    const config = buildDiscoveryConfig({
+      port: 3000,
+      projectDir: "/tmp/my-agent",
+      signal: new AbortController().signal,
+      requestInterceptor: (request: Request) => request,
+      defaultProjectId: "local-my-agent",
+      linkedProjectSlug: "linked-project",
+    }, host);
+
+    assertEquals(config.projectSlug, "env-project", "the environment wins over the link");
+  });
+
+  it("omits an absent token rather than forwarding an empty string", () => {
+    const config = buildDiscoveryConfig({
+      port: 3000,
+      projectDir: "/tmp/my-agent",
+      signal: new AbortController().signal,
+      requestInterceptor: (request: Request) => request,
+      defaultProjectId: "local-my-agent",
+    }, createInMemoryHostRuntime());
+
+    assertEquals(config.apiToken, undefined, "no token is reported as absent");
+    assertEquals(config.baseDir, "/tmp/my-agent", "the project directory is the base");
   });
 });
 
@@ -91,37 +82,39 @@ describe("buildProxyRuntimeProjectIdentity", () => {
         defaultProjectSlug: "local-my-agent",
         defaultProjectId: "local-my-agent",
       },
+      "the local id doubles as the slug",
     );
   });
 });
 
 describe("prepareCliProxyModeEnvironment", () => {
-  afterEach(restoreEnv);
-
   it("marks local CLI proxy mode before bootstrap and defaults NODE_ENV to development", () => {
-    Deno.env.delete("PROXY_MODE");
-    Deno.env.delete("VERYFRONT_CLI_LOCAL_PROXY_MODE");
-    Deno.env.delete("NODE_ENV");
-    Deno.env.delete("DENO_ENV");
+    const host = createInMemoryHostRuntime();
 
-    prepareCliProxyModeEnvironment();
+    prepareCliProxyModeEnvironment(host);
 
-    assertEquals(Deno.env.get("PROXY_MODE"), "1");
-    assertEquals(Deno.env.get("VERYFRONT_CLI_LOCAL_PROXY_MODE"), "1");
-    assertEquals(Deno.env.get("NODE_ENV"), "development");
+    assertEquals(host.env.get("PROXY_MODE"), "1", "proxy mode is on");
+    assertEquals(host.env.get("VERYFRONT_CLI_LOCAL_PROXY_MODE"), "1", "local proxy mode is on");
+    assertEquals(host.env.get("NODE_ENV"), "development", "NODE_ENV defaults to development");
   });
 
   it("preserves an existing runtime environment while marking local CLI proxy mode", () => {
-    Deno.env.delete("PROXY_MODE");
-    Deno.env.delete("VERYFRONT_CLI_LOCAL_PROXY_MODE");
-    Deno.env.delete("NODE_ENV");
-    Deno.env.set("DENO_ENV", "test");
+    const host = createInMemoryHostRuntime({ env: { DENO_ENV: "test" } });
 
-    prepareCliProxyModeEnvironment();
+    prepareCliProxyModeEnvironment(host);
 
-    assertEquals(Deno.env.get("PROXY_MODE"), "1");
-    assertEquals(Deno.env.get("VERYFRONT_CLI_LOCAL_PROXY_MODE"), "1");
-    assertEquals(Deno.env.get("NODE_ENV"), undefined);
-    assertEquals(Deno.env.get("DENO_ENV"), "test");
+    assertEquals(host.env.get("PROXY_MODE"), "1", "proxy mode is on");
+    assertEquals(host.env.get("VERYFRONT_CLI_LOCAL_PROXY_MODE"), "1", "local proxy mode is on");
+    assertEquals(host.env.get("NODE_ENV"), undefined, "NODE_ENV stays unset beside DENO_ENV");
+    assertEquals(host.env.get("DENO_ENV"), "test", "DENO_ENV is untouched");
+  });
+
+  it("never touches the process it was not given", () => {
+    const host = createInMemoryHostRuntime();
+    const bystander = createInMemoryHostRuntime();
+
+    prepareCliProxyModeEnvironment(host);
+
+    assertEquals(bystander.env.toObject(), {}, "another host sees no writes");
   });
 });

--- a/cli/shared/server-startup.ts
+++ b/cli/shared/server-startup.ts
@@ -1,4 +1,4 @@
-import { getEnv, runtime, setEnv } from "veryfront/platform";
+import { type HostRuntime, liveHostRuntime, runtime } from "veryfront/platform";
 import {
   type DevServerOptions,
   type DiscoveryOptions,
@@ -30,16 +30,16 @@ export interface StartCliProxyModeServerOptions {
 
 const LOCAL_CLI_PROXY_MODE_ENV = "VERYFRONT_CLI_LOCAL_PROXY_MODE";
 
-export function prepareCliProxyModeEnvironment(): void {
+export function prepareCliProxyModeEnvironment(host: HostRuntime = liveHostRuntime()): void {
   // Proxy mode must be set before config loading/bootstrap.
-  setEnv("PROXY_MODE", "1");
-  setEnv(LOCAL_CLI_PROXY_MODE_ENV, "1");
+  host.env.set("PROXY_MODE", "1");
+  host.env.set(LOCAL_CLI_PROXY_MODE_ENV, "1");
 
   // Ensure NODE_ENV is set for local proxy mode (the `start` command uses
   // startProductionServer with PROXY_MODE=1, but this is a local dev scenario,
   // not a deployed pod). Without this, validateProductionEnvironment throws.
-  if (!getEnv("NODE_ENV") && !getEnv("DENO_ENV")) {
-    setEnv("NODE_ENV", "development");
+  if (!host.env.get("NODE_ENV") && !host.env.get("DENO_ENV")) {
+    host.env.set("NODE_ENV", "development");
   }
 }
 
@@ -52,9 +52,12 @@ export function buildProxyRuntimeProjectIdentity(
   };
 }
 
-export function buildDiscoveryConfig(options: StartCliProxyModeServerOptions): DiscoveryOptions {
-  const token = getEnv("VERYFRONT_API_TOKEN") ?? "";
-  const slug = getEnv("VERYFRONT_PROJECT_SLUG") ?? options.linkedProjectSlug ?? "";
+export function buildDiscoveryConfig(
+  options: StartCliProxyModeServerOptions,
+  host: HostRuntime = liveHostRuntime(),
+): DiscoveryOptions {
+  const token = host.env.get("VERYFRONT_API_TOKEN") ?? "";
+  const slug = host.env.get("VERYFRONT_PROJECT_SLUG") ?? options.linkedProjectSlug ?? "";
 
   return {
     baseDir: options.projectDir,

--- a/cli/shared/update-check.test.ts
+++ b/cli/shared/update-check.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { createInMemoryHostRuntime } from "#veryfront/platform/compat/process.ts";
 import {
   checkForUpdates,
   compareVersions,
@@ -44,82 +45,39 @@ describe("update-check", () => {
   });
 
   describe("shouldSkip", () => {
-    function restoreEnv(keys: string[], saved: (string | undefined)[]) {
-      keys.forEach((k, i) => {
-        if (saved[i] === undefined) Deno.env.delete(k);
-        else Deno.env.set(k, saved[i]!);
-      });
+    afterEach(() => {
       setJsonMode(false);
       setQuietMode(false);
-    }
+    });
 
     it("skips when VERYFRONT_NO_UPDATE_CHECK=1", () => {
-      const saved = Deno.env.get("VERYFRONT_NO_UPDATE_CHECK");
-      Deno.env.set("VERYFRONT_NO_UPDATE_CHECK", "1");
-      try {
-        assertEquals(shouldSkip(), true);
-      } finally {
-        restoreEnv(["VERYFRONT_NO_UPDATE_CHECK"], [saved]);
-      }
+      const host = createInMemoryHostRuntime({ env: { VERYFRONT_NO_UPDATE_CHECK: "1" } });
+      assertEquals(shouldSkip(host), true, "the opt-out variable skips the check");
     });
 
     it("skips when CI=true", () => {
-      const saved = Deno.env.get("CI");
-      Deno.env.set("CI", "true");
-      try {
-        assertEquals(shouldSkip(), true);
-      } finally {
-        restoreEnv(["CI"], [saved]);
-      }
+      const host = createInMemoryHostRuntime({ env: { CI: "true" } });
+      assertEquals(shouldSkip(host), true, "CI skips the check");
     });
 
     it("skips when GITHUB_ACTIONS is set", () => {
-      const saved = Deno.env.get("GITHUB_ACTIONS");
-      Deno.env.set("GITHUB_ACTIONS", "true");
-      try {
-        assertEquals(shouldSkip(), true);
-      } finally {
-        restoreEnv(["GITHUB_ACTIONS"], [saved]);
-      }
+      const host = createInMemoryHostRuntime({ env: { GITHUB_ACTIONS: "true" } });
+      assertEquals(shouldSkip(host), true, "GitHub Actions counts as CI");
     });
 
     it("skips in JSON mode", () => {
       setJsonMode(true);
-      try {
-        assertEquals(shouldSkip(), true);
-      } finally {
-        setJsonMode(false);
-      }
+      assertEquals(shouldSkip(createInMemoryHostRuntime()), true, "JSON output skips the check");
     });
 
     it("skips in quiet mode", () => {
       setQuietMode(true);
-      try {
-        assertEquals(shouldSkip(), true);
-      } finally {
-        setQuietMode(false);
-      }
+      assertEquals(shouldSkip(createInMemoryHostRuntime()), true, "quiet mode skips the check");
     });
 
     it("does not skip under normal conditions", () => {
-      const keys = [
-        "VERYFRONT_NO_UPDATE_CHECK",
-        "CI",
-        "GITHUB_ACTIONS",
-        "GITLAB_CI",
-        "JENKINS_URL",
-        "CIRCLECI",
-        "BUILDKITE",
-      ];
-      const saved = keys.map((k) => Deno.env.get(k));
-      keys.forEach((k) => Deno.env.delete(k));
-      setJsonMode(false);
-      setQuietMode(false);
-      try {
-        assertEquals(shouldSkip(), false);
-      } finally {
-        restoreEnv(keys, saved);
-      }
+      const host = createInMemoryHostRuntime({ env: { CI: "false", GITLAB_CI: "0" } });
+      assertEquals(shouldSkip(host), false, "an interactive non-CI shell checks for updates");
     });
   });
 

--- a/cli/shared/update-check.ts
+++ b/cli/shared/update-check.ts
@@ -7,8 +7,12 @@
  * @module cli/shared/update-check
  */
 
-import { getEnv } from "veryfront/platform";
-import { createFileSystem, type FileSystem } from "veryfront/platform";
+import {
+  createFileSystem,
+  type FileSystem,
+  type HostRuntime,
+  liveHostRuntime,
+} from "veryfront/platform";
 import { join } from "veryfront/platform/path";
 import { getEnvironmentConfig } from "veryfront/config";
 import { isJsonMode } from "./json-output.ts";
@@ -68,9 +72,9 @@ export function compareVersions(current: string, latest: string): boolean {
   return false;
 }
 
-export function shouldSkip(): boolean {
-  if (getEnv("VERYFRONT_NO_UPDATE_CHECK") === "1") return true;
-  if (detectCI()) return true;
+export function shouldSkip(host: HostRuntime = liveHostRuntime()): boolean {
+  if (host.env.get("VERYFRONT_NO_UPDATE_CHECK") === "1") return true;
+  if (detectCI(host)) return true;
   if (isJsonMode()) return true;
   if (isQuiet()) return true;
   return false;

--- a/scripts/test/test-semantic-audit-migration.ts
+++ b/scripts/test/test-semantic-audit-migration.ts
@@ -244,15 +244,6 @@ export const TEST_SEMANTIC_AUDIT_MIGRATION_ENTRIES:
         "tests/integration/semantic-unit-boundary/cli/commands/dev/dev.test.ts",
       "removalPr": "PR 4a",
     }),
-    entry("cli/commands/dev/handler.test.ts", ["process"], {
-      "disposition": "replaceable-fake",
-      "owner": "cli",
-      "rationale":
-        "Depends on or mutates process-global environment/runtime state and cannot run safely beside concurrent unit tests.",
-      "replacement":
-        "Inject an environment/runtime-state boundary (and transport fake where applicable) instead of reading or mutating Deno.env, process.env, signals, exits, or global runtime objects.",
-      "removalPr": "PR 4a",
-    }),
     entry("cli/commands/dev/port-fallback.test.ts", [
       "filesystem-read",
       "server",
@@ -596,15 +587,6 @@ export const TEST_SEMANTIC_AUDIT_MIGRATION_ENTRIES:
         "tests/integration/semantic-unit-boundary/cli/commands/schedule/handler.test.ts",
       "removalPr": "PR 4a",
     }),
-    entry("cli/commands/serve/handler.test.ts", ["process"], {
-      "disposition": "replaceable-fake",
-      "owner": "cli",
-      "rationale":
-        "Depends on or mutates process-global environment/runtime state and cannot run safely beside concurrent unit tests.",
-      "replacement":
-        "Inject an environment/runtime-state boundary (and transport fake where applicable) instead of reading or mutating Deno.env, process.env, signals, exits, or global runtime objects.",
-      "removalPr": "PR 4a",
-    }),
     entry(
       "cli/commands/serve/proxy-extension-composition.test.ts",
       ["process"],
@@ -876,15 +858,6 @@ export const TEST_SEMANTIC_AUDIT_MIGRATION_ENTRIES:
         "tests/integration/semantic-unit-boundary/cli/scaffold/engine.test.ts",
       "removalPr": "PR 4a",
     }),
-    entry("cli/shared/animation.test.ts", ["process"], {
-      "disposition": "replaceable-fake",
-      "owner": "cli",
-      "rationale":
-        "Depends on or mutates process-global environment/runtime state and cannot run safely beside concurrent unit tests.",
-      "replacement":
-        "Inject an environment/runtime-state boundary (and transport fake where applicable) instead of reading or mutating Deno.env, process.env, signals, exits, or global runtime objects.",
-      "removalPr": "PR 4a",
-    }),
     entry("cli/shared/config.test.ts", [
       "filesystem-write",
       "process",
@@ -1007,24 +980,6 @@ export const TEST_SEMANTIC_AUDIT_MIGRATION_ENTRIES:
         "Exercises filesystem mutation, process, server, network, browser, or multi-component runtime behavior outside the colocated unit boundary.",
       "destination":
         "tests/integration/semantic-unit-boundary/cli/shared/runtime-auth.test.ts",
-      "removalPr": "PR 4a",
-    }),
-    entry("cli/shared/server-startup.test.ts", ["process"], {
-      "disposition": "replaceable-fake",
-      "owner": "cli",
-      "rationale":
-        "Depends on or mutates process-global environment/runtime state and cannot run safely beside concurrent unit tests.",
-      "replacement":
-        "Inject an environment/runtime-state boundary (and transport fake where applicable) instead of reading or mutating Deno.env, process.env, signals, exits, or global runtime objects.",
-      "removalPr": "PR 4a",
-    }),
-    entry("cli/shared/update-check.test.ts", ["process"], {
-      "disposition": "replaceable-fake",
-      "owner": "cli",
-      "rationale":
-        "Depends on or mutates process-global environment/runtime state and cannot run safely beside concurrent unit tests.",
-      "replacement":
-        "Inject an environment/runtime-state boundary (and transport fake where applicable) instead of reading or mutating Deno.env, process.env, signals, exits, or global runtime objects.",
       "removalPr": "PR 4a",
     }),
     entry("cli/skills/loader.test.ts", ["filesystem-write"], {

--- a/src/platform/compat/process.ts
+++ b/src/platform/compat/process.ts
@@ -34,5 +34,17 @@ export {
   writeStdout,
   writeStdoutAsync,
 } from "./process/lifecycle.ts";
+export {
+  createInMemoryHostRuntime,
+  HostExit,
+  type HostRuntime,
+  type HostRuntimeEnv,
+  type HostSignal,
+  IN_MEMORY_HOST_CWD,
+  type InMemoryHostRuntime,
+  type InMemoryHostRuntimeInit,
+  isHostExit,
+  liveHostRuntime,
+} from "./process/host-runtime.ts";
 export { testHasRuntimeProcess } from "./process/runtime-process.ts";
 export { type CommandOptions, type CommandResult, runCommand } from "./process/command.ts";

--- a/src/platform/compat/process/host-runtime.test.ts
+++ b/src/platform/compat/process/host-runtime.test.ts
@@ -1,5 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assert, assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertStrictEquals,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { getEnv } from "./env.ts";
 import {
@@ -132,7 +137,10 @@ describe("platform/compat/process/host-runtime", () => {
 
   describe("liveHostRuntime", () => {
     it("is a single shared instance", () => {
-      assert(liveHostRuntime() === liveHostRuntime(), "the live host is a singleton");
+      const first = liveHostRuntime();
+      const second = liveHostRuntime();
+
+      assertStrictEquals(first, second, "the live host is a singleton");
     });
 
     it("reads and writes the same environment as getEnv", () => {

--- a/src/platform/compat/process/host-runtime.test.ts
+++ b/src/platform/compat/process/host-runtime.test.ts
@@ -1,0 +1,144 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assert, assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { getEnv } from "./env.ts";
+import {
+  createInMemoryHostRuntime,
+  HostExit,
+  type HostRuntime,
+  IN_MEMORY_HOST_CWD,
+  isHostExit,
+  liveHostRuntime,
+} from "./host-runtime.ts";
+
+describe("platform/compat/process/host-runtime", () => {
+  describe("createInMemoryHostRuntime", () => {
+    it("starts from the given env, cwd, and args", () => {
+      const host = createInMemoryHostRuntime({
+        env: { PORT: "3001" },
+        cwd: "/work/app",
+        args: ["dev", "--open"],
+      });
+
+      assertEquals(host.env.get("PORT"), "3001", "seeded env key is readable");
+      assertEquals(host.env.has("PORT"), true, "seeded env key reports present");
+      assertEquals(host.env.toObject(), { PORT: "3001" }, "toObject returns only seeded keys");
+      assertEquals(host.cwd(), "/work/app", "cwd is the seeded directory");
+      assertEquals(host.args(), ["dev", "--open"], "args are the seeded argv");
+    });
+
+    it("defaults to an empty env, a fixed cwd, and no args", () => {
+      const host = createInMemoryHostRuntime();
+
+      assertEquals(host.env.toObject(), {}, "env starts empty");
+      assertEquals(host.env.get("HOME"), undefined, "no key leaks in from the real process");
+      assertEquals(host.cwd(), IN_MEMORY_HOST_CWD, "cwd is the documented default");
+      assertEquals(host.args(), [], "args start empty");
+      assertEquals(host.exits, [], "no exit has been recorded");
+    });
+
+    it("keeps env writes isolated between instances", () => {
+      const first = createInMemoryHostRuntime({ env: { SHARED: "first" } });
+      const second = createInMemoryHostRuntime({ env: { SHARED: "second" } });
+
+      first.env.set("ONLY_FIRST", "1");
+      second.env.delete("SHARED");
+
+      assertEquals(first.env.get("SHARED"), "first", "first keeps its own value");
+      assertEquals(first.env.has("ONLY_FIRST"), true, "first sees its own write");
+      assertEquals(second.env.has("ONLY_FIRST"), false, "second never sees first's write");
+      assertEquals(second.env.has("SHARED"), false, "second's delete is local to second");
+    });
+
+    it("does not let a seed object or a returned snapshot alias the env", () => {
+      const seed: Record<string, string> = { A: "1" };
+      const host = createInMemoryHostRuntime({ env: seed });
+
+      seed.B = "2";
+      const snapshot = host.env.toObject();
+      snapshot.C = "3";
+
+      assertEquals(host.env.has("B"), false, "later seed mutation is not observed");
+      assertEquals(host.env.has("C"), false, "snapshot mutation is not observed");
+    });
+
+    it("records exits and throws a recognisable host exit instead of terminating", () => {
+      const host = createInMemoryHostRuntime();
+
+      const error = assertThrows(() => host.exit(2), HostExit, "code 2");
+
+      assert(isHostExit(error), "exit throws a HostExit");
+      assertEquals(error.code, 2, "the thrown exit carries its code");
+      assertEquals(host.exits, [2], "the exit is recorded");
+
+      const defaultExit = assertThrows(() => host.exit(), HostExit, "code 0");
+
+      assert(isHostExit(defaultExit), "a bare exit also throws a HostExit");
+      assertEquals(defaultExit.code, 0, "exit defaults to code 0");
+      assertEquals(host.exits, [2, 0], "every exit is recorded in order");
+    });
+
+    it("delivers emitted signals to subscribers until they unsubscribe", () => {
+      const host = createInMemoryHostRuntime();
+      const seen: string[] = [];
+      const stopInt = host.onSignal("SIGINT", () => seen.push("int"));
+      host.onSignal("SIGTERM", () => seen.push("term"));
+
+      assertEquals(host.emitSignal("SIGINT"), 1, "one SIGINT handler ran");
+      assertEquals(host.emitSignal("SIGTERM"), 1, "one SIGTERM handler ran");
+      assertEquals(seen, ["int", "term"], "each signal reached only its own subscriber");
+
+      stopInt();
+      stopInt();
+
+      assertEquals(host.emitSignal("SIGINT"), 0, "an unsubscribed handler no longer runs");
+      assertEquals(host.emitSignal("SIGTERM"), 1, "other subscriptions are unaffected");
+      assertEquals(seen, ["int", "term", "term"], "unsubscribe is idempotent and local");
+    });
+
+    it("runs subscribers in subscription order and tolerates unsubscribe during emit", () => {
+      const host = createInMemoryHostRuntime();
+      const order: number[] = [];
+      const stopSecond = host.onSignal("SIGTERM", () => order.push(2));
+      host.onSignal("SIGTERM", () => {
+        order.push(1);
+        stopSecond();
+      });
+
+      assertEquals(host.emitSignal("SIGTERM"), 2, "both handlers ran this emit");
+      assertEquals(order, [2, 1], "handlers ran in subscription order");
+      assertEquals(host.emitSignal("SIGTERM"), 1, "the handler removed mid-emit is gone");
+    });
+  });
+
+  describe("liveHostRuntime", () => {
+    it("is a single shared instance", () => {
+      assert(liveHostRuntime() === liveHostRuntime(), "the live host is a singleton");
+    });
+
+    it("reads and writes the same environment as getEnv", () => {
+      const host: HostRuntime = liveHostRuntime();
+      const key = "VERYFRONT_HOST_RUNTIME_CONTRACT_TEST";
+
+      assertEquals(host.env.get(key), getEnv(key), "an unset key agrees before any write");
+      host.env.set(key, "live");
+
+      assertEquals(getEnv(key), "live", "a host write is visible through getEnv");
+      assertEquals(host.env.get(key), "live", "a host write is visible through the host");
+      assertEquals(host.env.has(key), true, "has tracks the written key");
+      assertEquals(host.env.toObject()[key], "live", "toObject includes the written key");
+
+      host.env.delete(key);
+
+      assertEquals(getEnv(key), undefined, "a host delete is visible through getEnv");
+      assertEquals(host.env.has(key), false, "has tracks the deleted key");
+    });
+
+    it("reports a real working directory and argv", () => {
+      const host = liveHostRuntime();
+
+      assert(host.cwd().length > 0, "cwd is non-empty");
+      assert(Array.isArray(host.args()), "args is an array");
+    });
+  });
+});

--- a/src/platform/compat/process/host-runtime.test.ts
+++ b/src/platform/compat/process/host-runtime.test.ts
@@ -96,6 +96,25 @@ describe("platform/compat/process/host-runtime", () => {
       assertEquals(seen, ["int", "term", "term"], "unsubscribe is idempotent and local");
     });
 
+    it("keeps two subscriptions of the same handler independent", () => {
+      const host = createInMemoryHostRuntime();
+      let calls = 0;
+      const handler = () => {
+        calls += 1;
+      };
+      const stopFirst = host.onSignal("SIGINT", handler);
+      host.onSignal("SIGINT", handler);
+
+      assertEquals(host.emitSignal("SIGINT"), 2, "both subscriptions deliver");
+      assertEquals(calls, 2, "the handler ran once per subscription");
+
+      stopFirst();
+      stopFirst();
+
+      assertEquals(host.emitSignal("SIGINT"), 1, "the second subscription stays live");
+      assertEquals(calls, 3, "only one delivery remains after disposing the first");
+    });
+
     it("runs subscribers in subscription order and tolerates unsubscribe during emit", () => {
       const host = createInMemoryHostRuntime();
       const order: number[] = [];

--- a/src/platform/compat/process/host-runtime.ts
+++ b/src/platform/compat/process/host-runtime.ts
@@ -1,0 +1,171 @@
+/**
+ * Host Runtime — the one seam between framework code and the process it runs
+ * in: environment variables, the working directory, command-line arguments,
+ * process exit, and termination signals.
+ *
+ * Code that takes a `HostRuntime` never touches `Deno.env`, `process.env`,
+ * `Deno.args`, `Deno.exit`, or signal listeners directly, so it runs against
+ * the live process in production and against an isolated in-memory host in
+ * tests without any global state being read, mutated, or restored.
+ *
+ * Two adapters exist and no others should: {@link liveHostRuntime} delegates
+ * to the cross-runtime compat functions in this directory, and
+ * {@link createInMemoryHostRuntime} holds everything in plain data.
+ *
+ * @module platform/compat/process/host-runtime
+ */
+
+import { deleteEnv, env, getEnv, setEnv } from "./env.ts";
+import { cwd, exit, getArgs, onSignal } from "./lifecycle.ts";
+
+/** Signals a host can deliver to a subscriber. */
+export type HostSignal = "SIGINT" | "SIGTERM";
+
+/**
+ * Environment access through a host. Structurally a superset of
+ * `EnvironmentAdapter` in `platform/adapters/base.ts`, so a host env satisfies
+ * that contract too.
+ */
+export interface HostRuntimeEnv {
+  get(key: string): string | undefined;
+  set(key: string, value: string): void;
+  delete(key: string): void;
+  has(key: string): boolean;
+  toObject(): Record<string, string>;
+}
+
+/** The process a unit of framework code runs in, as seen by that code. */
+export interface HostRuntime {
+  readonly env: HostRuntimeEnv;
+  /** Current working directory. */
+  cwd(): string;
+  /** Command-line arguments after the executable and entrypoint. */
+  args(): readonly string[];
+  /** End the process. The live host never returns; the in-memory host throws. */
+  exit(code?: number): never;
+  /**
+   * Subscribe to a termination signal.
+   *
+   * @returns An idempotent disposer for exactly this subscription.
+   */
+  onSignal(signal: HostSignal, handler: () => void): () => void;
+}
+
+let liveHost: HostRuntime | undefined;
+
+/**
+ * The production adapter: every member delegates to the compat functions, so
+ * behaviour is identical to calling them directly.
+ */
+export function liveHostRuntime(): HostRuntime {
+  liveHost ??= {
+    env: {
+      get: (key) => getEnv(key),
+      set: (key, value) => setEnv(key, value),
+      delete: (key) => deleteEnv(key),
+      has: (key) => getEnv(key) !== undefined,
+      toObject: () => env(),
+    },
+    cwd: () => cwd(),
+    args: () => getArgs(),
+    exit: (code) => exit(code),
+    onSignal: (signal, handler) => onSignal(signal, handler),
+  };
+  return liveHost;
+}
+
+const hostExits = new WeakSet<object>();
+
+/**
+ * Thrown by an in-memory host's `exit` so the calling code stops where the
+ * real process would have ended. Identify it with {@link isHostExit}.
+ */
+export class HostExit extends Error {
+  override readonly name = "HostExit";
+  readonly code: number;
+
+  constructor(code: number) {
+    super(`Host exited with code ${code}`);
+    this.code = code;
+    hostExits.add(this);
+  }
+}
+
+/** Return whether a value is an exit raised by an in-memory host. */
+export function isHostExit(value: unknown): value is HostExit {
+  return typeof value === "object" && value !== null && hostExits.has(value);
+}
+
+/** Initial state for {@link createInMemoryHostRuntime}. Everything is optional. */
+export interface InMemoryHostRuntimeInit {
+  env?: Readonly<Record<string, string>>;
+  cwd?: string;
+  args?: readonly string[];
+}
+
+/** The in-memory adapter, with the hooks a test needs to observe and drive it. */
+export interface InMemoryHostRuntime extends HostRuntime {
+  /** Exit codes passed to `exit`, oldest first. */
+  readonly exits: readonly number[];
+  /**
+   * Deliver a signal to every current subscriber, in subscription order.
+   *
+   * @returns How many handlers ran.
+   */
+  emitSignal(signal: HostSignal): number;
+}
+
+/** Default working directory for an in-memory host. */
+export const IN_MEMORY_HOST_CWD = "/in-memory";
+
+/**
+ * The test adapter: an isolated env map, a fixed cwd and argv, recorded exits,
+ * and signal subscribers a test fires with `emitSignal`. Two instances never
+ * share state, and nothing here reads or writes the real process.
+ */
+export function createInMemoryHostRuntime(
+  init: InMemoryHostRuntimeInit = {},
+): InMemoryHostRuntime {
+  const envVars = new Map(Object.entries(init.env ?? {}));
+  const workingDirectory = init.cwd ?? IN_MEMORY_HOST_CWD;
+  const args = Object.freeze([...(init.args ?? [])]);
+  const exits: number[] = [];
+  const subscribers = new Map<HostSignal, Set<() => void>>();
+
+  return {
+    env: {
+      get: (key) => envVars.get(key),
+      set: (key, value) => {
+        envVars.set(key, value);
+      },
+      delete: (key) => {
+        envVars.delete(key);
+      },
+      has: (key) => envVars.has(key),
+      toObject: () => Object.fromEntries(envVars),
+    },
+    cwd: () => workingDirectory,
+    args: () => args,
+    exit: (code = 0) => {
+      exits.push(code);
+      throw new HostExit(code);
+    },
+    onSignal: (signal, handler) => {
+      let handlers = subscribers.get(signal);
+      if (!handlers) {
+        handlers = new Set();
+        subscribers.set(signal, handlers);
+      }
+      handlers.add(handler);
+      return () => {
+        handlers.delete(handler);
+      };
+    },
+    exits,
+    emitSignal: (signal) => {
+      const handlers = [...(subscribers.get(signal) ?? [])];
+      for (const handler of handlers) handler();
+      return handlers.length;
+    },
+  };
+}

--- a/src/platform/compat/process/host-runtime.ts
+++ b/src/platform/compat/process/host-runtime.ts
@@ -1,7 +1,7 @@
 /**
- * Host Runtime — the one seam between framework code and the process it runs
- * in: environment variables, the working directory, command-line arguments,
- * process exit, and termination signals.
+ * Host Runtime: the one seam between framework code and the process it runs
+ * in. It covers environment variables, the working directory, command-line
+ * arguments, process exit, and termination signals.
  *
  * Code that takes a `HostRuntime` never touches `Deno.env`, `process.env`,
  * `Deno.args`, `Deno.exit`, or signal listeners directly, so it runs against
@@ -130,7 +130,7 @@ export function createInMemoryHostRuntime(
   const workingDirectory = init.cwd ?? IN_MEMORY_HOST_CWD;
   const args = Object.freeze([...(init.args ?? [])]);
   const exits: number[] = [];
-  const subscribers = new Map<HostSignal, Set<() => void>>();
+  const subscribers = new Map<HostSignal, Array<{ readonly handler: () => void }>>();
 
   return {
     env: {
@@ -151,21 +151,25 @@ export function createInMemoryHostRuntime(
       throw new HostExit(code);
     },
     onSignal: (signal, handler) => {
-      let handlers = subscribers.get(signal);
-      if (!handlers) {
-        handlers = new Set();
-        subscribers.set(signal, handlers);
+      let entries = subscribers.get(signal);
+      if (!entries) {
+        entries = [];
+        subscribers.set(signal, entries);
       }
-      handlers.add(handler);
+      // One entry per subscription, so subscribing the same handler twice
+      // yields two deliveries and two independent disposers.
+      const entry = { handler };
+      entries.push(entry);
       return () => {
-        handlers.delete(handler);
+        const index = entries.indexOf(entry);
+        if (index !== -1) entries.splice(index, 1);
       };
     },
     exits,
     emitSignal: (signal) => {
-      const handlers = [...(subscribers.get(signal) ?? [])];
-      for (const handler of handlers) handler();
-      return handlers.length;
+      const entries = [...(subscribers.get(signal) ?? [])];
+      for (const entry of entries) entry.handler();
+      return entries.length;
     },
   };
 }

--- a/src/platform/index.test.ts
+++ b/src/platform/index.test.ts
@@ -33,6 +33,13 @@ describe("platform/index.ts exports", () => {
   });
 
   describe("compat re-exports", () => {
+    it("should export the host runtime seam", async () => {
+      const { createInMemoryHostRuntime, isHostExit, liveHostRuntime } = await importIndex();
+      assertEquals(typeof liveHostRuntime, "function", "live adapter factory is exported");
+      assertEquals(typeof createInMemoryHostRuntime, "function", "in-memory factory is exported");
+      assertEquals(typeof isHostExit, "function", "host exit guard is exported");
+    });
+
     it("should export createKVStore", async () => {
       const { createKVStore } = await importIndex();
       assertExists(createKVStore);

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -37,6 +37,19 @@ export {
   writeStdoutAsync,
 } from "./compat/process.ts";
 
+// Compat: host runtime seam (live in production, in-memory in tests)
+export {
+  createInMemoryHostRuntime,
+  HostExit,
+  type HostRuntime,
+  type HostRuntimeEnv,
+  type HostSignal,
+  type InMemoryHostRuntime,
+  type InMemoryHostRuntimeInit,
+  isHostExit,
+  liveHostRuntime,
+} from "./compat/process/host-runtime.ts";
+
 // Compat: filesystem
 export {
   createFileSystem,


### PR DESCRIPTION
## Why

340 `replaceable-fake` dispositions in the semantic unit-boundary inventory cite the same missing module: an environment/runtime-state boundary to inject instead of reading or mutating `Deno.env`, `process.env`, signals, exits, or global runtime objects. Without a named seam, the file-by-file migration PRs would each invent a local fake.

## What

- **`HostRuntime`** (`src/platform/compat/process/host-runtime.ts`): env access, `cwd()`, `args()`, `exit()`, signal subscription. Exactly two adapters: `liveHostRuntime()` delegating to the existing compat functions (behaviour identical), and `createInMemoryHostRuntime(init?)` holding isolated in-memory state with recorded exits (`HostExit` + `isHostExit`) and test-fired signals (`emitSignal`).
- Callers take `host: HostRuntime = liveHostRuntime()` — no behaviour change when omitted.
- **Five scheduled exemplars migrated** (all `replaceable-fake`/`process`, PR 4a set): `cli/shared/animation`, `cli/shared/update-check` (+ `detectCI` in `interactive.ts`), `cli/commands/serve` arg parsing, `cli/commands/dev` arg parsing, `cli/shared/server-startup`. Their tests construct an in-memory host instead of mutating process env; their five inventory entries went stale and are removed: **762 → 757 disposed**.
- `CONTEXT.md` gains the **Host Runtime** glossary entry.

## Verification

- `host-runtime.test.ts` (in-memory semantics + live-adapter contract): 12 steps pass; all seven touched test files green; consumers (`cli/router`, `cli/ui/progress`) pass.
- `lint:test-semantic-dispositions` first reported exactly the five entries stale, then ok at 2142/757.
- `test:layout`, `lint:dependency-boundaries`, `lint:module-boundaries`, `lint:anti-slop` (no growth), `lint:cwd-relative-test-reads`, `lint:test-typecheck`, `docs:public:check`: pass.
- `docs:api-reference:check` not run to completion locally (pinned Deno 2.7.7 vs local 2.7.12 — known false-positive staleness; `veryfront/platform` has no reference page and the generator skips the platform deep import).

## Follow-ups

335 process-effect dispositions remain for the migration PRs to consume through this seam.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a host runtime abstraction for environment variables, working directory, command-line arguments, process exits, and termination signals.
  * Added live and isolated in-memory runtime implementations, now publicly available through platform exports.

* **Bug Fixes**
  * Improved development and serving configuration handling for ports, bind addresses, environment variables, and CLI flags.
  * Preserved existing animation, CI detection, update-check, proxy, and discovery behavior while improving environment isolation.

* **Tests**
  * Expanded coverage for environment precedence, validation, signal handling, process exits, and runtime isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->