### PR TITLE
test: drive the request pipeline in-process through createVeryfrontHandler

### DIFF
--- a/scripts/lint/check-sanitizer-baseline.ts
+++ b/scripts/lint/check-sanitizer-baseline.ts
@@ -23,9 +23,10 @@ const SCAN_ROOTS = [
 
 // Lower this when you remove sanitizer opt-outs. Never raise it without a very
 // good reason — a new opt-out means a leak is being suppressed rather than fixed.
-// 404 after restoring both sanitizers for the up command integration suite, which
-// leaked nothing and never needed them.
-export const SANITIZER_OPT_OUT_BASELINE = 404;
+// 396 after moving the dev-server-handlers, api-handler, and RSC
+// hydration/isolation suites onto the in-process request harness, which closes
+// what the old socket servers leaked.
+export const SANITIZER_OPT_OUT_BASELINE = 396;
 
 const OPT_OUT_PATTERN = /sanitize(?:Resources|Ops|Exit)\s*:\s*false/g;
 

--- a/tests/_helpers/in-process-project.ts
+++ b/tests/_helpers/in-process-project.ts
@@ -1,0 +1,267 @@
+/**
+ * In-process request harness.
+ *
+ * Drives the request pipeline that both servers wrap — `createVeryfrontHandler`
+ * for production, the dev `RequestHandler` around it for development — without
+ * binding a port. Tests hand it the project files they care about and get back
+ * a `handle()` that behaves like a request arriving over loopback. No listener,
+ * no port allocation, no readiness polling, nothing to drain on shutdown.
+ *
+ * Builds on `withTestContext` for everything that is not the handler: the temp
+ * project layout, the isolated cache dir, state reset on both sides of the
+ * test, contract re-registration, and env/resource cleanup.
+ *
+ * ```ts
+ * await withInProcessProject("api-json", {
+ *   files: { "pages/api/hello.ts": `export const GET = () => Response.json({ ok: true });` },
+ * }, async (project) => {
+ *   const res = await project.handle("/api/hello");
+ *   assertEquals(await res.json(), { ok: true });
+ * });
+ * ```
+ */
+
+import { dirname, join } from "#veryfront/compat/path";
+import { mkdir, writeTextFile } from "../../src/platform/compat/fs.ts";
+import type { RuntimeAdapter } from "../../src/platform/adapters/base.ts";
+import { runtime } from "../../src/platform/adapters/registry.ts";
+import {
+  recordRequestPeerFromTransport,
+  type RequestPeerRuntime,
+} from "../../src/platform/adapters/runtime/shared/request-peer.ts";
+import { MiddlewarePipeline } from "../../src/middleware/core/pipeline/pipeline.ts";
+import { bootstrapDev, bootstrapProd } from "../../src/server/bootstrap.ts";
+import { setupMiddleware } from "../../src/server/dev-server/middleware.ts";
+import { RequestHandler } from "../../src/server/dev-server/request-handler.ts";
+import { setServerInitialized } from "../../src/server/handlers/monitoring/health.handler.ts";
+import { createVeryfrontHandler } from "../../src/server/runtime-handler/index.ts";
+import { type TestContext, withTestContext } from "./context.ts";
+
+/** Origin every path-form `handle()` call is resolved against. */
+export const IN_PROCESS_ORIGIN = "http://localhost";
+
+export type InProcessMode = "dev" | "production";
+
+export interface InProcessProjectOptions {
+  /** Project files, relative path → contents, written before the handler is built. */
+  readonly files?: Readonly<Record<string, string>>;
+  /** Replaces the default `veryfront.config.js` with `export default <json>`. */
+  readonly config?: Readonly<Record<string, unknown>>;
+  /** Which server's handler wraps the pipeline. Defaults to `"dev"`. */
+  readonly mode?: InProcessMode;
+}
+
+export interface InProcessProject {
+  readonly projectDir: string;
+  readonly projectId: string;
+  readonly mode: InProcessMode;
+  /** The underlying context, for `setEnv`, `addCleanup`, and the cache dir. */
+  readonly context: TestContext;
+  /**
+   * Send one request through the pipeline. A string is a path (and optional
+   * query) resolved against `IN_PROCESS_ORIGIN` as a GET; `init` applies to
+   * the path form only. The request is stamped with a loopback peer so it is
+   * admitted exactly as a connection from 127.0.0.1 would be.
+   */
+  handle(request: Request | string, init?: RequestInit): Promise<Response>;
+}
+
+async function writeProjectFiles(
+  projectDir: string,
+  files: Readonly<Record<string, string>>,
+): Promise<void> {
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const target = join(projectDir, relativePath);
+    await mkdir(dirname(target), { recursive: true });
+    await writeTextFile(target, contents);
+  }
+}
+
+/**
+ * Every HTTP/1.1 client sends a `Host` header and several admission checks
+ * (privileged local-control surfaces) require it to match the URL authority.
+ * An in-process `Request` starts without one, so stamp it like the wire would.
+ */
+function withHostHeader(request: Request): Request {
+  if (request.headers.has("host")) return request;
+  const headers = new Headers(request.headers);
+  headers.set("host", new URL(request.url).host);
+  return new Request(request, { headers });
+}
+
+function toRequest(request: Request | string, init?: RequestInit): Request {
+  const built = request instanceof Request
+    ? request
+    : new Request(new URL(request, IN_PROCESS_ORIGIN), init);
+  return withHostHeader(built);
+}
+
+/**
+ * A server never writes a body for a HEAD response (`Deno.serve` discards it
+ * at the transport); mirror that so handlers may answer HEAD like GET.
+ */
+async function stripHeadBody(response: Response): Promise<Response> {
+  if (response.body === null) return response;
+  await response.body.cancel();
+  return new Response(null, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
+function peerRuntimeFor(adapter: RuntimeAdapter): RequestPeerRuntime {
+  return adapter.id === "node" || adapter.id === "bun" ? adapter.id : "deno";
+}
+
+interface PipelineHandle {
+  readonly handle: (request: Request) => Promise<Response>;
+  readonly teardown: () => Promise<void>;
+}
+
+/**
+ * Close every `MessageChannel` the pipeline opens while it is alive.
+ *
+ * The React SSR adapter imports `react-dom/server` from an esm.sh bundle cached
+ * under the test's own cache dir, so each test instantiates the module afresh.
+ * That bundle (`react-dom-server.browser`) opens a module-scope
+ * `MessageChannel` for `scheduleWork` and never closes it; the module is
+ * orphaned by `resetReactCache()` at the end of the test, but its port keeps a
+ * receive op pending and the sanitizer reports it. The port is module-private,
+ * so the only handle on it is the constructor call. Tracking channels here and
+ * closing them once the pipeline is torn down is what lets tests on this
+ * harness keep the sanitizers on.
+ */
+function trackMessageChannels(): () => void {
+  const NativeMessageChannel = globalThis.MessageChannel;
+  const opened: MessageChannel[] = [];
+  globalThis.MessageChannel = class TrackedMessageChannel extends NativeMessageChannel {
+    constructor() {
+      super();
+      opened.push(this);
+    }
+  };
+  return () => {
+    globalThis.MessageChannel = NativeMessageChannel;
+    for (const channel of opened) {
+      channel.port1.close();
+      channel.port2.close();
+    }
+  };
+}
+
+async function buildProductionPipeline(
+  context: TestContext,
+  adapter: RuntimeAdapter,
+): Promise<PipelineHandle> {
+  const { projectDir, projectId } = context;
+  const bootstrap = await bootstrapProd(projectDir, adapter);
+  const handler = createVeryfrontHandler(projectDir, bootstrap.adapter, {
+    projectDir,
+    config: bootstrap.config,
+    defaultProjectSlug: projectId,
+    defaultProjectId: projectId,
+    localProjects: { [projectId]: projectDir },
+  });
+  await handler.ready;
+  setServerInitialized(true);
+
+  return {
+    handle: handler,
+    teardown: async () => {
+      setServerInitialized(false);
+      await bootstrap.dispose?.();
+    },
+  };
+}
+
+async function buildDevPipeline(
+  context: TestContext,
+  adapter: RuntimeAdapter,
+): Promise<PipelineHandle> {
+  const { projectDir, projectId } = context;
+  const bootstrap = await bootstrapDev(projectDir, adapter);
+  const requestHandler = new RequestHandler(
+    projectDir,
+    bootstrap.adapter,
+    () => true,
+    bootstrap.config,
+    projectId,
+    projectId,
+    { [projectId]: projectDir },
+  );
+
+  // The dev server executes its request handler behind the same middleware
+  // pipeline (request-id stamping, optional CORS); mirror that here so an
+  // in-process response carries what a socket response would.
+  const pipeline = new MiddlewarePipeline();
+  await setupMiddleware(
+    pipeline,
+    bootstrap.config,
+    (req) => requestHandler.handleRequest(req),
+  );
+
+  return {
+    handle: (request) => pipeline.execute(request, bootstrap.adapter.env.toObject()),
+    teardown: async () => {
+      await pipeline.teardown();
+      await bootstrap.dispose?.();
+    },
+  };
+}
+
+/**
+ * Build a project in a temp directory and run `fn` against its request pipeline.
+ */
+export async function withInProcessProject<T>(
+  name: string,
+  options: InProcessProjectOptions,
+  fn: (project: InProcessProject) => Promise<T>,
+): Promise<T> {
+  const mode = options.mode ?? "dev";
+
+  return await withTestContext(name, async (context) => {
+    if (options.config) {
+      await writeTextFile(
+        join(context.projectDir, "veryfront.config.js"),
+        `export default ${JSON.stringify(options.config, null, 2)};\n`,
+      );
+    }
+    if (options.files) await writeProjectFiles(context.projectDir, options.files);
+
+    const adapter = await runtime.get();
+    const peerRuntime = peerRuntimeFor(adapter);
+    const closeMessageChannels = trackMessageChannels();
+    let pipeline: PipelineHandle;
+    try {
+      pipeline = mode === "production"
+        ? await buildProductionPipeline(context, adapter)
+        : await buildDevPipeline(context, adapter);
+    } catch (error) {
+      closeMessageChannels();
+      throw error;
+    }
+
+    try {
+      return await fn({
+        projectDir: context.projectDir,
+        projectId: context.projectId,
+        mode,
+        context,
+        async handle(request, init) {
+          const req = toRequest(request, init);
+          recordRequestPeerFromTransport(req, {
+            runtime: peerRuntime,
+            transport: "tcp",
+            hostname: "127.0.0.1",
+          });
+          const response = await pipeline.handle(req);
+          return req.method.toUpperCase() === "HEAD" ? stripHeadBody(response) : response;
+        },
+      });
+    } finally {
+      await pipeline.teardown();
+      closeMessageChannels();
+    }
+  });
+}

--- a/tests/integration/core/api-handler.test.ts
+++ b/tests/integration/core/api-handler.test.ts
@@ -1,396 +1,262 @@
 /**
  * Tests for API Route Handler
+ *
+ * Driven in-process through the same request pipeline the dev server serves,
+ * so routes are exercised behind the real handler chain (CSRF included)
+ * instead of a hand-built handler context.
  */
 
 import { assert, assertEquals, assertExists } from "#veryfront/testing/assert";
-import { join } from "#veryfront/compat/path";
-import { afterEach, describe, it } from "#veryfront/testing/bdd";
-import { mkdir, remove, writeTextFile } from "#veryfront/testing/deno-compat";
-import { getAdapter } from "#veryfront/platform/adapters/detect.ts";
-import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
-import { APIRouteHandler } from "#veryfront/routing/api/index.ts";
-import type { HandlerContext } from "#veryfront/types";
-import { withTestContext } from "../../_helpers/context.ts";
+import { describe, it } from "#veryfront/testing/bdd";
+import { withInProcessProject } from "../../_helpers/in-process-project.ts";
 
-// Track all handlers to clean up after tests
-const handlers: APIRouteHandler[] = [];
+/**
+ * The pipeline enforces double-submit CSRF on mutating methods, exactly as it
+ * does over a socket; these headers are what a browser would send back.
+ */
+const CSRF_TOKEN = "in-process-csrf-token";
+const CSRF_HEADERS = {
+  cookie: `__Host-vf_csrf=${CSRF_TOKEN}`,
+  "x-csrf-token": CSRF_TOKEN,
+};
 
-class TrustedLocalAPIRouteHandler extends APIRouteHandler {
-  readonly #context: HandlerContext;
-
-  constructor(projectDir: string, adapter: RuntimeAdapter) {
-    super(projectDir, adapter);
-    this.#context = {
-      projectDir,
-      adapter,
-      securityConfig: null,
-      cspUserHeader: null,
-      isLocalProject: true,
-    };
-  }
-
-  override handle(request: Request, context?: HandlerContext): Promise<Response | null> {
-    return super.handle(request, context ?? this.#context);
-  }
+function mutating(method: string): RequestInit {
+  return { method, headers: CSRF_HEADERS };
 }
 
-function createHandler(projectDir: string, adapter: RuntimeAdapter): APIRouteHandler {
-  // This suite writes and executes source in a local temporary project. Keep
-  // that trusted-local capability explicit so hosted execution remains closed.
-  const handler = new TrustedLocalAPIRouteHandler(projectDir, adapter);
-  handlers.push(handler);
-  return handler;
-}
-
-async function setupPagesApiDir(projectDir: string, ...segments: string[]): Promise<void> {
-  await remove(join(projectDir, "app"), { recursive: true });
-  await mkdir(join(projectDir, "pages", "api", ...segments), { recursive: true });
-}
-
-async function writeApiFile(
-  projectDir: string,
-  filePathSegments: string[],
-  contents: string,
-): Promise<void> {
-  await writeTextFile(join(projectDir, "pages", "api", ...filePathSegments), contents);
-}
-
-// Wrap entire test suite in a describe block with sanitizers disabled
-// This is required because esbuild WASM runtime creates internal timers
-// that cannot be cleaned up from user code
-describe(
-  "API Handler Tests",
-  {
-    sanitizeResources: false,
-    sanitizeOps: false,
-  },
-  () => {
-    // Clean up all handlers after each test to prevent interval leaks
-    afterEach(() => {
-      while (handlers.length) handlers.pop()?.destroy();
-    });
-
-    describe("APIRouteHandler", () => {
-      describe("Basic routing", () => {
-        it("handles simple GET request", async () => {
-          await withTestContext("api-handler-get", async (context) => {
-            await setupPagesApiDir(context.projectDir);
-
-            const handler = createHandler(context.projectDir, await getAdapter());
-
-            await writeApiFile(
-              context.projectDir,
-              ["hello.ts"],
-              `
+describe("API Handler Tests", () => {
+  describe("APIRouteHandler", () => {
+    describe("Basic routing", () => {
+      it("handles simple GET request", async () => {
+        await withInProcessProject("api-handler-get", {
+          files: {
+            "pages/api/hello.ts": `
           export const GET = (ctx) => {
             return new Response("Hello from API");
           };
         `,
-            );
+          },
+        }, async (project) => {
+          const res = await project.handle("/api/hello");
 
-            await handler.initialize();
-
-            const req = new Request("http://localhost/api/hello");
-            const res = await handler.handle(req);
-
-            assertExists(res);
-            assertEquals(res.status, 200);
-            assertEquals(await res.text(), "Hello from API");
-          });
+          assertExists(res);
+          assertEquals(res.status, 200);
+          assertEquals(await res.text(), "Hello from API");
         });
+      });
 
-        it("handles multiple HTTP methods", async () => {
-          await withTestContext("api-handler-methods", async (context) => {
-            await setupPagesApiDir(context.projectDir);
-
-            const handler = createHandler(context.projectDir, await getAdapter());
-
-            await writeApiFile(
-              context.projectDir,
-              ["resource.ts"],
-              `
+      it("handles multiple HTTP methods", async () => {
+        await withInProcessProject("api-handler-methods", {
+          files: {
+            "pages/api/resource.ts": `
           export const GET = (ctx) => {
             return Response.json({ method: "GET" });
           };
-          
+
           export const POST = (ctx) => {
             return Response.json({ method: "POST" });
           };
-          
+
           export const PUT = (ctx) => {
             return Response.json({ method: "PUT" });
           };
-          
+
           export const DELETE = (ctx) => {
             return Response.json({ method: "DELETE" });
           };
         `,
-            );
+          },
+        }, async (project) => {
+          for (const method of ["GET", "POST", "PUT", "DELETE"]) {
+            const res = await project.handle("/api/resource", mutating(method));
 
-            await handler.initialize();
-
-            for (const method of ["GET", "POST", "PUT", "DELETE"]) {
-              const req = new Request("http://localhost/api/resource", { method });
-              const res = await handler.handle(req);
-
-              assertExists(res);
-              assertEquals(res.status, 200);
-              const data = await res.json();
-              assertEquals(data.method, method);
-            }
-          });
+            assertExists(res);
+            assertEquals(res.status, 200);
+            const data = await res.json();
+            assertEquals(data.method, method);
+          }
         });
+      });
 
-        it("returns 405 for unsupported methods", async () => {
-          await withTestContext("api-handler-405", async (context) => {
-            await setupPagesApiDir(context.projectDir);
-
-            const handler = createHandler(context.projectDir, await getAdapter());
-
-            await writeApiFile(
-              context.projectDir,
-              ["limited.ts"],
-              `
+      it("returns 405 for unsupported methods", async () => {
+        await withInProcessProject("api-handler-405", {
+          files: {
+            "pages/api/limited.ts": `
           export const GET = (ctx) => {
             return new Response("Only GET");
           };
         `,
-            );
+          },
+        }, async (project) => {
+          const res = await project.handle("/api/limited", mutating("POST"));
+          await res.body?.cancel();
 
-            await handler.initialize();
-
-            const req = new Request("http://localhost/api/limited", { method: "POST" });
-            const res = await handler.handle(req);
-
-            assertExists(res);
-            assertEquals(res.status, 405);
-          });
-        });
-
-        it("returns 404 for non-existent routes", async () => {
-          await withTestContext("api-handler-404", async (context) => {
-            const handler = createHandler(context.projectDir, await getAdapter());
-            await handler.initialize();
-
-            const req = new Request("http://localhost/api/nonexistent");
-            const res = await handler.handle(req);
-
-            assertExists(res);
-            assertEquals(res.status, 404);
-          });
+          assertExists(res);
+          assertEquals(res.status, 405);
         });
       });
 
-      describe("Dynamic routes", () => {
-        it("handles single dynamic segment", async () => {
-          await withTestContext("api-handler-dynamic-single", async (context) => {
-            await setupPagesApiDir(context.projectDir, "users");
+      it("returns 404 for non-existent routes", async () => {
+        await withInProcessProject("api-handler-404", {}, async (project) => {
+          const res = await project.handle("/api/nonexistent");
+          await res.body?.cancel();
 
-            const handler = createHandler(context.projectDir, await getAdapter());
+          assertExists(res);
+          assertEquals(res.status, 404);
+        });
+      });
+    });
 
-            await writeApiFile(
-              context.projectDir,
-              ["users", "[id].ts"],
-              `
+    describe("Dynamic routes", () => {
+      it("handles single dynamic segment", async () => {
+        await withInProcessProject("api-handler-dynamic-single", {
+          files: {
+            "pages/api/users/[id].ts": `
           export const GET = (ctx) => {
             return Response.json({ userId: ctx.params.id });
           };
         `,
-            );
+          },
+        }, async (project) => {
+          const res = await project.handle("/api/users/123");
 
-            await handler.initialize();
-
-            const req = new Request("http://localhost/api/users/123");
-            const res = await handler.handle(req);
-
-            assertExists(res);
-            assertEquals(res.status, 200);
-            const data = await res.json();
-            assertEquals(data.userId, "123");
-          });
+          assertExists(res);
+          assertEquals(res.status, 200);
+          const data = await res.json();
+          assertEquals(data.userId, "123");
         });
+      });
 
-        it("handles multiple dynamic segments", async () => {
-          await withTestContext("api-handler-dynamic-multiple", async (context) => {
-            await setupPagesApiDir(context.projectDir, "posts", "[id]", "comments");
-
-            const handler = createHandler(context.projectDir, await getAdapter());
-
-            await writeApiFile(
-              context.projectDir,
-              ["posts", "[id]", "comments", "[commentId].ts"],
-              `
+      it("handles multiple dynamic segments", async () => {
+        await withInProcessProject("api-handler-dynamic-multiple", {
+          files: {
+            "pages/api/posts/[id]/comments/[commentId].ts": `
           export const GET = (ctx) => {
-            return Response.json({ 
+            return Response.json({
               postId: ctx.params.id,
-              commentId: ctx.params.commentId 
+              commentId: ctx.params.commentId
             });
           };
         `,
-            );
+          },
+        }, async (project) => {
+          const res = await project.handle("/api/posts/456/comments/789");
 
-            await handler.initialize();
-
-            const req = new Request("http://localhost/api/posts/456/comments/789");
-            const res = await handler.handle(req);
-
-            assertExists(res);
-            assertEquals(res.status, 200);
-            const data = await res.json();
-            assertEquals(data.postId, "456");
-            assertEquals(data.commentId, "789");
-          });
+          assertExists(res);
+          assertEquals(res.status, 200);
+          const data = await res.json();
+          assertEquals(data.postId, "456");
+          assertEquals(data.commentId, "789");
         });
+      });
 
-        it("handles catch-all routes", async () => {
-          await withTestContext("api-handler-catch-all", async (context) => {
-            await setupPagesApiDir(context.projectDir);
-
-            const handler = createHandler(context.projectDir, await getAdapter());
-
-            await writeApiFile(
-              context.projectDir,
-              ["[...slug].ts"],
-              `
+      it("handles catch-all routes", async () => {
+        await withInProcessProject("api-handler-catch-all", {
+          files: {
+            "pages/api/[...slug].ts": `
           export const GET = (ctx) => {
             return Response.json({ path: ctx.params.slug });
           };
         `,
-            );
+          },
+        }, async (project) => {
+          const res = await project.handle("/api/deep/nested/path");
 
-            await handler.initialize();
-
-            const req = new Request("http://localhost/api/deep/nested/path");
-            const res = await handler.handle(req);
-
-            assertExists(res);
-            assertEquals(res.status, 200);
-            const data = await res.json();
-            assert(Array.isArray(data.path));
-            assertEquals(data.path, ["deep", "nested", "path"]);
-          });
+          assertExists(res);
+          assertEquals(res.status, 200);
+          const data = await res.json();
+          assert(Array.isArray(data.path));
+          assertEquals(data.path, ["deep", "nested", "path"]);
         });
       });
+    });
 
-      describe("Request context", () => {
-        it("provides query parameters", async () => {
-          await withTestContext("api-handler-query", async (context) => {
-            await setupPagesApiDir(context.projectDir);
-
-            const handler = createHandler(context.projectDir, await getAdapter());
-
-            await writeApiFile(
-              context.projectDir,
-              ["query.ts"],
-              `
+    describe("Request context", () => {
+      it("provides query parameters", async () => {
+        await withInProcessProject("api-handler-query", {
+          files: {
+            "pages/api/query.ts": `
           export const GET = (ctx) => {
             const name = ctx.query.get("name");
             const age = ctx.query.get("age");
             return Response.json({ name, age });
           };
         `,
-            );
+          },
+        }, async (project) => {
+          const res = await project.handle("/api/query?name=John&age=30");
 
-            await handler.initialize();
-
-            const req = new Request("http://localhost/api/query?name=John&age=30");
-            const res = await handler.handle(req);
-
-            assertExists(res);
-            assertEquals(res.status, 200);
-            const data = await res.json();
-            assertEquals(data.name, "John");
-            assertEquals(data.age, "30");
-          });
+          assertExists(res);
+          assertEquals(res.status, 200);
+          const data = await res.json();
+          assertEquals(data.name, "John");
+          assertEquals(data.age, "30");
         });
+      });
 
-        it("provides request headers", async () => {
-          await withTestContext("api-handler-headers", async (context) => {
-            await setupPagesApiDir(context.projectDir);
-
-            const handler = createHandler(context.projectDir, await getAdapter());
-
-            await writeApiFile(
-              context.projectDir,
-              ["headers.ts"],
-              `
+      it("provides request headers", async () => {
+        await withInProcessProject("api-handler-headers", {
+          files: {
+            "pages/api/headers.ts": `
           export const GET = (ctx) => {
             const auth = ctx.request.headers.get("authorization");
             const contentType = ctx.request.headers.get("content-type");
             return Response.json({ auth, contentType });
           };
         `,
-            );
-
-            await handler.initialize();
-
-            const req = new Request("http://localhost/api/headers", {
-              headers: {
-                authorization: "Bearer token123",
-                "content-type": "application/json",
-              },
-            });
-            const res = await handler.handle(req);
-
-            assertExists(res);
-            assertEquals(res.status, 200);
-            const data = await res.json();
-            assertEquals(data.auth, "Bearer token123");
-            assertEquals(data.contentType, "application/json");
+          },
+        }, async (project) => {
+          const res = await project.handle("/api/headers", {
+            headers: {
+              authorization: "Bearer token123",
+              "content-type": "application/json",
+            },
           });
+
+          assertExists(res);
+          assertEquals(res.status, 200);
+          const data = await res.json();
+          assertEquals(data.auth, "Bearer token123");
+          assertEquals(data.contentType, "application/json");
         });
       });
+    });
 
-      describe("Response helpers", () => {
-        it("handles json response helper", async () => {
-          await withTestContext("api-handler-json-helper", async (context) => {
-            await setupPagesApiDir(context.projectDir);
-
-            const handler = createHandler(context.projectDir, await getAdapter());
-
-            await writeApiFile(
-              context.projectDir,
-              ["json-helper.ts"],
-              `
+    describe("Response helpers", () => {
+      it("handles json response helper", async () => {
+        await withInProcessProject("api-handler-json-helper", {
+          files: {
+            "pages/api/json-helper.ts": `
           export const GET = (ctx) => {
             return Response.json({ message: "Hello", timestamp: Date.now() });
           };
         `,
-            );
+          },
+        }, async (project) => {
+          const res = await project.handle("/api/json-helper");
 
-            await handler.initialize();
+          assertExists(res);
+          assertEquals(res.status, 200);
 
-            const req = new Request("http://localhost/api/json-helper");
-            const res = await handler.handle(req);
+          const contentType = res.headers.get("content-type");
+          assert(
+            contentType?.startsWith("application/json"),
+            `Expected content-type to start with application/json, got ${contentType}`,
+          );
 
-            assertExists(res);
-            assertEquals(res.status, 200);
-
-            const contentType = res.headers.get("content-type");
-            assert(
-              contentType?.startsWith("application/json"),
-              `Expected content-type to start with application/json, got ${contentType}`,
-            );
-
-            const data = await res.json();
-            assertEquals(data.message, "Hello");
-            assertExists(data.timestamp);
-          });
+          const data = await res.json();
+          assertEquals(data.message, "Hello");
+          assertExists(data.timestamp);
         });
+      });
 
-        it("handles error response helpers", async () => {
-          await withTestContext("api-handler-error-helpers", async (context) => {
-            await setupPagesApiDir(context.projectDir);
-
-            const handler = createHandler(context.projectDir, await getAdapter());
-
-            await writeApiFile(
-              context.projectDir,
-              ["errors.ts"],
-              `
+      it("handles error response helpers", async () => {
+        await withInProcessProject("api-handler-error-helpers", {
+          files: {
+            "pages/api/errors.ts": `
           export const GET = (ctx) => {
             const type = ctx.query.get("type");
-            
+
             switch (type) {
               case "bad": return Response.json({ error: "Invalid input" }, { status: 400 });
               case "unauth": return Response.json({ error: "Not authenticated" }, { status: 401 });
@@ -401,40 +267,31 @@ describe(
             }
           };
         `,
-            );
+          },
+        }, async (project) => {
+          const tests = [
+            { type: "bad", status: 400, message: "Invalid input" },
+            { type: "unauth", status: 401, message: "Not authenticated" },
+            { type: "forbid", status: 403, message: "Access denied" },
+            { type: "notfound", status: 404, message: "Resource not found" },
+            { type: "error", status: 500, message: "Internal error" },
+          ];
 
-            await handler.initialize();
+          for (const test of tests) {
+            const res = await project.handle(`/api/errors?type=${test.type}`);
 
-            const tests = [
-              { type: "bad", status: 400, message: "Invalid input" },
-              { type: "unauth", status: 401, message: "Not authenticated" },
-              { type: "forbid", status: 403, message: "Access denied" },
-              { type: "notfound", status: 404, message: "Resource not found" },
-              { type: "error", status: 500, message: "Internal error" },
-            ];
-
-            for (const test of tests) {
-              const req = new Request(`http://localhost/api/errors?type=${test.type}`);
-              const res = await handler.handle(req);
-
-              assertExists(res);
-              assertEquals(res.status, test.status);
-              const data = await res.json();
-              assertEquals(data.error, test.message);
-            }
-          });
+            assertExists(res);
+            assertEquals(res.status, test.status);
+            const data = await res.json();
+            assertEquals(data.error, test.message);
+          }
         });
+      });
 
-        it("handles redirect helper", async () => {
-          await withTestContext("api-handler-redirect", async (context) => {
-            await setupPagesApiDir(context.projectDir);
-
-            const handler = createHandler(context.projectDir, await getAdapter());
-
-            await writeApiFile(
-              context.projectDir,
-              ["redirect.ts"],
-              `
+      it("handles redirect helper", async () => {
+        await withInProcessProject("api-handler-redirect", {
+          files: {
+            "pages/api/redirect.ts": `
           export const GET = (ctx) => {
             return new Response(null, {
               status: 302,
@@ -442,85 +299,65 @@ describe(
             });
           };
         `,
-            );
+          },
+        }, async (project) => {
+          const res = await project.handle("/api/redirect");
+          await res.body?.cancel();
 
-            await handler.initialize();
-
-            const req = new Request("http://localhost/api/redirect");
-            const res = await handler.handle(req);
-
-            assertExists(res);
-            assertEquals(res.status, 302);
-            assertEquals(res.headers.get("location"), "/new-location");
-          });
+          assertExists(res);
+          assertEquals(res.status, 302);
+          assertEquals(res.headers.get("location"), "/new-location");
         });
       });
+    });
 
-      describe("Error handling", () => {
-        it("handles route handler errors gracefully", async () => {
-          await withTestContext("api-handler-error-handling", async (context) => {
-            await setupPagesApiDir(context.projectDir);
-
-            const handler = createHandler(context.projectDir, await getAdapter());
-
-            await writeApiFile(
-              context.projectDir,
-              ["error.ts"],
-              `
+    describe("Error handling", () => {
+      it("handles route handler errors gracefully", async () => {
+        await withInProcessProject("api-handler-error-handling", {
+          files: {
+            "pages/api/error.ts": `
           export const GET = (ctx) => {
             throw new Error("Something went wrong");
           };
         `,
-            );
+          },
+        }, async (project) => {
+          const res = await project.handle("/api/error");
 
-            await handler.initialize();
+          assertExists(res);
+          assertEquals(res.status, 500);
 
-            const req = new Request("http://localhost/api/error");
-            const res = await handler.handle(req);
+          const contentType = res.headers.get("content-type") ?? "";
+          if (contentType.includes("application/json")) {
+            const json = await res.json();
+            assertEquals(json.error, "Something went wrong");
+            assertExists(json.stack);
+            return;
+          }
 
-            assertExists(res);
-            assertEquals(res.status, 500);
-
-            const contentType = res.headers.get("content-type") ?? "";
-            if (contentType.includes("application/json")) {
-              const json = await res.json();
-              assertEquals(json.error, "Something went wrong");
-              assertExists(json.stack);
-              return;
-            }
-
-            const text = await res.text();
-            assertExists(text);
-          });
+          const text = await res.text();
+          assertExists(text);
         });
+      });
 
-        it("handles async errors", async () => {
-          await withTestContext("api-handler-async-error", async (context) => {
-            await setupPagesApiDir(context.projectDir);
-
-            const handler = createHandler(context.projectDir, await getAdapter());
-
-            await writeApiFile(
-              context.projectDir,
-              ["async-error.ts"],
-              `
+      it("handles async errors", async () => {
+        await withInProcessProject("api-handler-async-error", {
+          files: {
+            "pages/api/async-error.ts": `
           export const GET = async (ctx) => {
             await delay(10);
             throw new Error("Async error");
           };
         `,
-            );
+          },
+        }, async (project) => {
+          const res = await project.handle("/api/async-error");
+          await res.body?.cancel();
 
-            await handler.initialize();
-
-            const req = new Request("http://localhost/api/async-error");
-            const res = await handler.handle(req);
-
-            assertExists(res);
-            assertEquals(res.status, 500);
-          });
+          assertExists(res);
+          assertEquals(res.status, 500);
         });
       });
     });
-  },
-);
+  });
+});

--- a/tests/integration/examples/simple-production-test.test.ts
+++ b/tests/integration/examples/simple-production-test.test.ts
@@ -1,24 +1,18 @@
 /**
- * Simplified production server test to debug resource leaks
+ * Simplified production pipeline test to guard against resource leaks
  */
 
 import { assertEquals } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
-import { join } from "#veryfront/compat/path";
-import { writeTextFile } from "#veryfront/compat/fs.ts";
-import { withTestContext } from "../../_helpers/context.ts";
+import { withInProcessProject } from "../../_helpers/in-process-project.ts";
 
 describe("Simple Production Server", () => {
   it("should serve files without resource leaks", async () => {
-    await withTestContext("simple-prod", async (context) => {
-      await writeTextFile(
-        join(context.projectDir, "public", "test.txt"),
-        "Hello World",
-      );
-
-      const server = await context.createProductionServer();
-
-      const response = await fetch(`http://127.0.0.1:${server.port}/test.txt`);
+    await withInProcessProject("simple-prod", {
+      mode: "production",
+      files: { "public/test.txt": "Hello World" },
+    }, async (project) => {
+      const response = await project.handle("/test.txt");
       assertEquals(response.status, 200, "Should serve file");
 
       const content = await response.text();

--- a/tests/integration/server/dev-server-handlers.test.ts
+++ b/tests/integration/server/dev-server-handlers.test.ts
@@ -1,55 +1,20 @@
 /**
  * DevServer Handler Methods Tests
  *
- * Tests for the refactored DevServer.handleRequest() extracted handlers:
- * - handleHealthCheck()
- * - incrementRequestMetrics()
- * - handleDevEndpoint()
- * - handleApplicationRequest()
- * - handleServerError()
+ * Tests for the DevServer request pipeline — health checks, dev endpoints,
+ * application routes, error handling, and request flow — driven in-process
+ * through the same `RequestHandler` the dev server serves, so no ports,
+ * readiness polling, or shutdown draining are involved.
  */
 
 import { assert, assertEquals, assertExists } from "#veryfront/testing/assert";
 import { join } from "#veryfront/compat/path";
 import { afterAll, describe, it } from "#veryfront/testing/bdd";
-import { mkdir, writeTextFile } from "#veryfront/testing/deno-compat";
 import { toBase64Url } from "#veryfront/utils/path-utils.ts";
-import { DevServer } from "../../../src/server/dev-server.ts";
-import { withTestContext } from "../../_helpers/context.ts";
-import { drainEventLoop } from "../../_helpers/utils.ts";
+import { withInProcessProject } from "../../_helpers/in-process-project.ts";
 import { cleanupBundler } from "../../../src/rendering/cleanup.ts";
 
-async function createTestDevServer(
-  context: any,
-  options: Partial<any> = {},
-): Promise<{ server: DevServer; port: number }> {
-  const port = await context.allocatePort();
-
-  const server = new DevServer({
-    port,
-    projectDir: context.projectDir,
-    enableHMR: false,
-    enableFastRefresh: false,
-    ...options,
-  });
-
-  context.trackResource(server, `DevServer on port ${port}`);
-  await server.start();
-  await server.ready;
-
-  return { server, port };
-}
-
-async function stopServer(server: DevServer): Promise<void> {
-  await server.stop();
-  await drainEventLoop();
-}
-
-async function fetchAndCancel(input: string, init?: RequestInit): Promise<Response> {
-  const response = await fetch(input, init);
-  await response.body?.cancel();
-  return response;
-}
+type Handle = (path: string) => Promise<Response>;
 
 function assertJsNoCache(response: Response): void {
   const contentType = response.headers.get("content-type");
@@ -81,9 +46,16 @@ function extractImportSpecifiers(code: string): string[] {
   return [...specifiers];
 }
 
+// The narrow browser-safe error modules: the split registries plus the base
+// error machinery. The heavyweight `errors/index.js` barrel stays banned.
 const BROWSER_SAFE_ERROR_MODULES = new Set([
   "/_vf_modules/_veryfront/errors/error-registry.js",
+  "/_vf_modules/_veryfront/errors/error-registry/agent.js",
+  "/_vf_modules/_veryfront/errors/error-registry/general.js",
+  "/_vf_modules/_veryfront/errors/error-registry/server.js",
   "/_vf_modules/_veryfront/errors/http-error.js",
+  "/_vf_modules/_veryfront/errors/types.js",
+  "/_vf_modules/_veryfront/errors/veryfront-error.js",
 ]);
 
 const BROWSER_CSP_SAFE_MODULE_PATHS = [
@@ -104,11 +76,10 @@ const BROWSER_CSP_SAFE_MODULE_PATHS = [
 ];
 
 async function fetchServedFrameworkModule(
-  port: number,
+  handle: Handle,
   modulePath: string,
-  fetchImpl: typeof fetch = globalThis.fetch,
 ): Promise<{ body: string; specifiers: string[] }> {
-  const response = await fetchImpl(`http://127.0.0.1:${port}${modulePath}`);
+  const response = await handle(modulePath);
   assertEquals(response.status, 200, `Expected ${modulePath} to be served`);
 
   const body = await response.text();
@@ -149,10 +120,11 @@ function assertBrowserSafeFrameworkModule(
   );
 }
 
+const GRAPH_ORIGIN = "http://in-process";
+
 async function assertBrowserSafeFrameworkGraph(
-  port: number,
+  handle: Handle,
   entryPath: string,
-  fetchImpl: typeof fetch = globalThis.fetch,
 ): Promise<void> {
   const pending = [entryPath];
   const visited = new Set<string>();
@@ -163,15 +135,18 @@ async function assertBrowserSafeFrameworkGraph(
     if (!modulePath || visited.has(modulePath)) continue;
     visited.add(modulePath);
 
-    const { body, specifiers } = await fetchServedFrameworkModule(port, modulePath, fetchImpl);
+    const { body, specifiers } = await fetchServedFrameworkModule(handle, modulePath);
     assertBrowserSafeFrameworkModule(modulePath, body, specifiers);
 
     for (const specifier of specifiers) {
-      const resolved = new URL(specifier, `http://127.0.0.1:${port}${modulePath}`);
+      const resolved = new URL(specifier, `${GRAPH_ORIGIN}${modulePath}`);
       const resolvedModulePath = `${resolved.pathname}${resolved.search}`;
       if (
-        resolved.origin === `http://127.0.0.1:${port}` &&
+        resolved.origin === GRAPH_ORIGIN &&
         resolved.pathname.startsWith("/_vf_modules/_veryfront/") &&
+        // Only rewritten module URLs end in `.js`; bare import-map specifiers
+        // and template-literal fragments the extractor picks up do not.
+        resolved.pathname.endsWith(".js") &&
         !visited.has(resolvedModulePath)
       ) {
         pending.push(resolvedModulePath);
@@ -180,90 +155,57 @@ async function assertBrowserSafeFrameworkGraph(
   }
 }
 
-describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: false }, () => {
+describe("DevServer Handler Tests", () => {
   afterAll(async () => {
     await cleanupBundler();
   });
 
   describe("DevServer - Health Check Handler", {}, () => {
     it("returns 200 for /healthz endpoint", async () => {
-      await withTestContext("dev-server-healthz", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
-        const response = await fetch(`http://127.0.0.1:${port}/healthz`);
+      await withInProcessProject("dev-server-healthz", {}, async (project) => {
+        const response = await project.handle("/healthz");
 
         assertEquals(response.status, 200);
         assertEquals(response.headers.get("content-type"), "text/plain");
         assertEquals(await response.text(), "ok");
-
-        await stopServer(server);
       });
     });
 
     it("returns ready status for /readyz endpoint", async () => {
-      await withTestContext("dev-server-readyz", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
-        const response = await fetch(`http://127.0.0.1:${port}/readyz`);
+      await withInProcessProject("dev-server-readyz", {}, async (project) => {
+        const response = await project.handle("/readyz");
 
         assertEquals(response.status, 200);
         assertEquals(response.headers.get("content-type"), "text/plain");
         assertEquals(await response.text(), "ready");
-
-        await stopServer(server);
-      });
-    });
-
-    it("health checks have no async overhead", async () => {
-      await withTestContext("dev-server-health-performance", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
-        const start = performance.now();
-        await fetchAndCancel(`http://127.0.0.1:${port}/healthz`);
-        const duration = performance.now() - start;
-
-        assert(duration < 100, `Health check took ${duration}ms, should be <100ms`);
-
-        await stopServer(server);
       });
     });
 
     it("returns null for non-health-check routes", async () => {
-      await withTestContext("dev-server-health-passthrough", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
-        const response = await fetchAndCancel(`http://127.0.0.1:${port}/`);
+      await withInProcessProject("dev-server-health-passthrough", {}, async (project) => {
+        const response = await project.handle("/");
+        await response.body?.cancel();
 
         assertExists(response);
         assert(response.status !== 0);
-
-        await stopServer(server);
       });
     });
 
     it("serves metrics for local dev servers", async () => {
-      await withTestContext("dev-server-metrics", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
-        const response = await fetch(`http://127.0.0.1:${port}/_metrics`);
+      await withInProcessProject("dev-server-metrics", {}, async (project) => {
+        const response = await project.handle("/_metrics");
 
         assertEquals(response.status, 200);
         const json = await response.json();
         assertExists(json?.counters);
-
-        await stopServer(server);
       });
     });
   });
 
   describe("DevServer - Dev Endpoint Handler", {}, () => {
     it("serves HMR script when HMR is enabled", async () => {
-      await withTestContext("dev-server-hmr-runtime", async (context) => {
-        const { server, port } = await createTestDevServer(context, {
-          enableHMR: true,
-        });
-
-        const response = await fetch(`http://127.0.0.1:${port}/_veryfront/hmr.js`);
+      await withInProcessProject("dev-server-hmr-runtime", {}, async (project) => {
+        const response = await project.handle("/_veryfront/hmr.js");
 
         assertEquals(response.status, 200);
         assertJsNoCache(response);
@@ -271,16 +213,12 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
         const content = await response.text();
         assertExists(content);
         assert(content.length > 0);
-
-        await stopServer(server);
       });
     });
 
     it("serves error overlay runtime", async () => {
-      await withTestContext("dev-server-error-overlay", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
-        const response = await fetch(`http://127.0.0.1:${port}/_veryfront/error-overlay.js`);
+      await withInProcessProject("dev-server-error-overlay", {}, async (project) => {
+        const response = await project.handle("/_veryfront/error-overlay.js");
 
         assertEquals(response.status, 200);
         assertJsNoCache(response);
@@ -288,20 +226,12 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
         const content = await response.text();
         assertExists(content);
         assert(content.length > 0);
-
-        await stopServer(server);
       });
     });
 
     it("responds to HEAD requests for HMR script", async () => {
-      await withTestContext("dev-server-hmr-head", async (context) => {
-        const { server, port } = await createTestDevServer(context, {
-          enableHMR: true,
-        });
-
-        const response = await fetch(`http://127.0.0.1:${port}/_veryfront/hmr.js`, {
-          method: "HEAD",
-        });
+      await withInProcessProject("dev-server-hmr-head", {}, async (project) => {
+        const response = await project.handle("/_veryfront/hmr.js", { method: "HEAD" });
 
         assertEquals(response.status, 200);
         const contentType = response.headers.get("content-type");
@@ -310,18 +240,12 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
           `Expected content-type to start with "application/javascript" but got "${contentType}"`,
         );
         assertEquals(await response.text(), "");
-
-        await stopServer(server);
       });
     });
 
     it("responds to HEAD requests for error overlay runtime", async () => {
-      await withTestContext("dev-server-error-overlay-head", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
-        const response = await fetch(`http://127.0.0.1:${port}/_veryfront/error-overlay.js`, {
-          method: "HEAD",
-        });
+      await withInProcessProject("dev-server-error-overlay-head", {}, async (project) => {
+        const response = await project.handle("/_veryfront/error-overlay.js", { method: "HEAD" });
 
         assertEquals(response.status, 200);
         const contentType = response.headers.get("content-type");
@@ -330,183 +254,139 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
           `Expected content-type to start with "application/javascript" but got "${contentType}"`,
         );
         assertEquals(await response.text(), "");
-
-        await stopServer(server);
       });
     });
 
     it("handles virtual module requests", async () => {
-      await withTestContext("dev-server-virtual-modules", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
-        const response = await fetchAndCancel(
-          `http://127.0.0.1:${port}/_veryfront/modules/component:Button`,
-        );
+      await withInProcessProject("dev-server-virtual-modules", {}, async (project) => {
+        const response = await project.handle("/_veryfront/modules/component:Button");
+        await response.body?.cancel();
 
         assert(
           response.status === 200 || response.status === 404 || response.status === 500,
           `Expected 200, 404, or 500 but got ${response.status}`,
         );
-
-        await stopServer(server);
       });
     });
 
     it("returns null for non-dev endpoints", async () => {
-      await withTestContext("dev-server-dev-passthrough", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
-        const response = await fetchAndCancel(`http://127.0.0.1:${port}/`);
+      await withInProcessProject("dev-server-dev-passthrough", {}, async (project) => {
+        const response = await project.handle("/");
+        await response.body?.cancel();
 
         assertExists(response);
         assert(response.status !== 0);
-
-        await stopServer(server);
       });
     });
   });
 
   describe("DevServer - Application Request Handler", {}, () => {
     it("delegates to runtime handler for application routes", async () => {
-      await withTestContext("dev-server-app-handler", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
-        const response = await fetchAndCancel(`http://127.0.0.1:${port}/`);
+      await withInProcessProject("dev-server-app-handler", {}, async (project) => {
+        const response = await project.handle("/");
+        await response.body?.cancel();
 
         assertExists(response);
         assert(response.status !== 0);
-
-        await stopServer(server);
       });
     });
 
     it("handles page requests", async () => {
-      await withTestContext("dev-server-page-requests", async (context) => {
-        const pagesDir = `${context.projectDir}/pages`;
-        await mkdir(pagesDir, { recursive: true });
-        await writeTextFile(
-          `${pagesDir}/test.tsx`,
-          "export default function Test() { return <div>Test Page</div> }",
-        );
-
-        const { server, port } = await createTestDevServer(context);
-
-        const response = await fetchAndCancel(`http://127.0.0.1:${port}/test`);
+      await withInProcessProject("dev-server-page-requests", {
+        files: {
+          "pages/test.tsx": "export default function Test() { return <div>Test Page</div> }",
+        },
+      }, async (project) => {
+        const response = await project.handle("/test");
+        await response.body?.cancel();
 
         assertExists(response);
         assert(response.status !== 0);
-
-        await stopServer(server);
       });
     });
 
     it("handles API routes", async () => {
-      await withTestContext("dev-server-api-routes", async (context) => {
-        const apiDir = `${context.projectDir}/pages/api`;
-        await mkdir(apiDir, { recursive: true });
-        await writeTextFile(
-          `${apiDir}/test.ts`,
-          'export async function GET() { return new Response("API Response") }',
-        );
-
-        const { server, port } = await createTestDevServer(context);
-
-        const response = await fetchAndCancel(`http://127.0.0.1:${port}/api/test`);
+      await withInProcessProject("dev-server-api-routes", {
+        files: {
+          "pages/api/test.ts":
+            'export async function GET() { return new Response("API Response") }',
+        },
+      }, async (project) => {
+        const response = await project.handle("/api/test");
+        await response.body?.cancel();
 
         assertExists(response);
         assert(response.status !== 0);
-
-        await stopServer(server);
       });
     });
 
     it("passes through all request headers", async () => {
-      await withTestContext("dev-server-request-headers", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
-        const response = await fetchAndCancel(`http://127.0.0.1:${port}/`, {
+      await withInProcessProject("dev-server-request-headers", {}, async (project) => {
+        const response = await project.handle("/", {
           headers: {
             "x-custom-header": "test-value",
             "accept": "text/html",
           },
         });
+        await response.body?.cancel();
 
         assertExists(response);
         assert(response.status !== 0);
-
-        await stopServer(server);
       });
     });
 
     it("serves /_veryfront/fs modules without explicit defaultProjectSlug", async () => {
-      await withTestContext("dev-server-local-project-fallback", async (context) => {
-        await mkdir(join(context.projectDir, "components"), { recursive: true });
-        const modulePath = join(context.projectDir, "components", "fallback.js");
-        await writeTextFile(modulePath, "export default 'fallback';");
-
-        const { server, port } = await createTestDevServer(context);
+      await withInProcessProject("dev-server-local-project-fallback", {
+        files: { "components/fallback.js": "export default 'fallback';" },
+      }, async (project) => {
+        const modulePath = join(project.projectDir, "components", "fallback.js");
         const encodedPath = toBase64Url(modulePath);
-        const response = await fetch(
-          `http://127.0.0.1:${port}/_veryfront/fs/${encodedPath}.js`,
-        );
+        const response = await project.handle(`/_veryfront/fs/${encodedPath}.js`);
 
         assertEquals(response.status, 200);
         const body = await response.text();
         assert(body.includes("fallback"), "Expected bundled module content");
-
-        await stopServer(server);
       });
     });
 
     it("serves framework markdown module without unsafe-eval helpers", async () => {
-      await withTestContext("dev-server-framework-markdown-csp", async (context) => {
-        const { server, port } = await createTestDevServer(context);
+      await withInProcessProject("dev-server-framework-markdown-csp", {}, async (project) => {
         const modulePath = "/_vf_modules/_veryfront/react/components/chat/markdown.js";
-        const { body, specifiers } = await fetchServedFrameworkModule(port, modulePath);
+        const { body, specifiers } = await fetchServedFrameworkModule(project.handle, modulePath);
         assertBrowserSafeFrameworkModule(modulePath, body, specifiers);
-
-        await stopServer(server);
       });
     });
 
     it("serves browser framework modules with narrow CSP-safe imports", async () => {
-      await withTestContext("dev-server-framework-chat-error-csp", async (context) => {
-        const { server, port } = await createTestDevServer(context);
+      await withInProcessProject("dev-server-framework-chat-error-csp", {}, async (project) => {
         for (const modulePath of BROWSER_CSP_SAFE_MODULE_PATHS) {
-          const { body, specifiers } = await fetchServedFrameworkModule(port, modulePath);
+          const { body, specifiers } = await fetchServedFrameworkModule(project.handle, modulePath);
           assertBrowserSafeFrameworkModule(modulePath, body, specifiers);
         }
-
-        await stopServer(server);
       });
     });
 
     it("serves the complete chat module graph without unsafe-eval dependencies", async () => {
-      await withTestContext("dev-server-framework-chat-graph-csp", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-        await assertBrowserSafeFrameworkGraph(port, "/_vf_modules/_veryfront/chat/index.js");
-        await stopServer(server);
+      await withInProcessProject("dev-server-framework-chat-graph-csp", {}, async (project) => {
+        await assertBrowserSafeFrameworkGraph(
+          project.handle,
+          "/_vf_modules/_veryfront/chat/index.js",
+        );
       });
     });
 
     it("preserves query strings while walking browser framework module variants", async () => {
       const requestedPaths: string[] = [];
-      const fetchModule = (async (input: string | URL | Request) => {
-        const url = input instanceof Request ? new URL(input.url) : new URL(String(input));
-        const modulePath = `${url.pathname}${url.search}`;
+      const handle: Handle = (modulePath) => {
         requestedPaths.push(modulePath);
 
         const body = modulePath === "/_vf_modules/_veryfront/entry.js"
           ? 'import "/_vf_modules/_veryfront/child.js?v=browser";'
           : "export const child = true;";
-        return new Response(body, { status: 200 });
-      }) as typeof fetch;
+        return Promise.resolve(new Response(body, { status: 200 }));
+      };
 
-      await assertBrowserSafeFrameworkGraph(
-        4173,
-        "/_vf_modules/_veryfront/entry.js",
-        fetchModule,
-      );
+      await assertBrowserSafeFrameworkGraph(handle, "/_vf_modules/_veryfront/entry.js");
 
       assertEquals(requestedPaths, [
         "/_vf_modules/_veryfront/entry.js",
@@ -517,23 +397,19 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
 
   describe("DevServer - Error Handler", {}, () => {
     it("returns error overlay for server errors", async () => {
-      await withTestContext("dev-server-error-handler", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
-        const response = await fetchAndCancel(`http://127.0.0.1:${port}/nonexistent-route`);
+      await withInProcessProject("dev-server-error-handler", {}, async (project) => {
+        const response = await project.handle("/nonexistent-route");
+        await response.body?.cancel();
 
         assertExists(response);
         assert(response.status !== 0);
-
-        await stopServer(server);
       });
     });
 
     it("sets correct content-type for error responses", async () => {
-      await withTestContext("dev-server-error-content-type", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
-        const response = await fetchAndCancel(`http://127.0.0.1:${port}/nonexistent`);
+      await withInProcessProject("dev-server-error-content-type", {}, async (project) => {
+        const response = await project.handle("/nonexistent");
+        await response.body?.cancel();
 
         assertExists(response);
         if (response.status >= 400) {
@@ -543,67 +419,56 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
             "Error responses should have HTML or JSON content type",
           );
         }
-
-        await stopServer(server);
       });
     });
 
     it("logs errors properly", async () => {
-      await withTestContext("dev-server-error-logging", async (context) => {
-        const { server, port } = await createTestDevServer(context);
+      await withInProcessProject("dev-server-error-logging", {}, async (project) => {
+        const errored = await project.handle("/definitely-not-a-real-page-12345");
+        await errored.body?.cancel();
 
-        await fetchAndCancel(`http://127.0.0.1:${port}/definitely-not-a-real-page-12345`);
-
-        const healthResponse = await fetchAndCancel(`http://127.0.0.1:${port}/healthz`);
+        const healthResponse = await project.handle("/healthz");
+        await healthResponse.body?.cancel();
         assertEquals(healthResponse.status, 200);
-
-        await stopServer(server);
       });
     });
 
     it("handles errors without crashing server", async () => {
-      await withTestContext("dev-server-error-resilience", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
+      await withInProcessProject("dev-server-error-resilience", {}, async (project) => {
         const errorResponses = await Promise.all([
-          fetch(`http://127.0.0.1:${port}/error1`),
-          fetch(`http://127.0.0.1:${port}/error2`),
-          fetch(`http://127.0.0.1:${port}/error3`),
+          project.handle("/error1"),
+          project.handle("/error2"),
+          project.handle("/error3"),
         ]);
         await Promise.all(errorResponses.map((r) => r.body?.cancel()));
 
-        const response = await fetchAndCancel(`http://127.0.0.1:${port}/healthz`);
+        const response = await project.handle("/healthz");
+        await response.body?.cancel();
         assertEquals(response.status, 200);
-
-        await stopServer(server);
       });
     });
   });
 
   describe("DevServer - Request Flow Integration", {}, () => {
     it("executes handlers in correct order", async () => {
-      await withTestContext("dev-server-handler-order", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
-        const healthRes = await fetchAndCancel(`http://127.0.0.1:${port}/healthz`);
+      await withInProcessProject("dev-server-handler-order", {}, async (project) => {
+        const healthRes = await project.handle("/healthz");
+        await healthRes.body?.cancel();
         assertEquals(healthRes.status, 200);
 
-        const appRes = await fetchAndCancel(`http://127.0.0.1:${port}/`);
+        const appRes = await project.handle("/");
+        await appRes.body?.cancel();
         assert(appRes.status >= 200 && appRes.status < 600);
-
-        await stopServer(server);
       });
     });
 
     it("handles concurrent requests correctly", async () => {
-      await withTestContext("dev-server-concurrent-requests", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
+      await withInProcessProject("dev-server-concurrent-requests", {}, async (project) => {
         const requests = await Promise.all([
-          fetch(`http://127.0.0.1:${port}/healthz`),
-          fetch(`http://127.0.0.1:${port}/`),
-          fetch(`http://127.0.0.1:${port}/healthz`),
-          fetch(`http://127.0.0.1:${port}/readyz`),
+          project.handle("/healthz"),
+          project.handle("/"),
+          project.handle("/healthz"),
+          project.handle("/readyz"),
         ]);
 
         for (const response of requests) {
@@ -611,97 +476,29 @@ describe("DevServer Handler Tests", { sanitizeOps: false, sanitizeResources: fal
           assert(response.status !== 0);
         }
         await Promise.all(requests.map((r) => r.body?.cancel()));
-
-        await stopServer(server);
       });
     });
 
     it("maintains request context across handlers", async () => {
-      await withTestContext("dev-server-request-context", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
-        const response = await fetchAndCancel(`http://127.0.0.1:${port}/`);
+      await withInProcessProject("dev-server-request-context", {}, async (project) => {
+        const response = await project.handle("/");
+        await response.body?.cancel();
 
         const requestId = response.headers.get("x-request-id");
         assertExists(requestId, "Response should include request ID");
-
-        await stopServer(server);
       });
     });
 
     it("handles all HTTP methods correctly", async () => {
-      await withTestContext("dev-server-http-methods", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
+      await withInProcessProject("dev-server-http-methods", {}, async (project) => {
         const methods = ["GET", "POST", "PUT", "DELETE", "PATCH"];
 
         for (const method of methods) {
-          const response = await fetchAndCancel(`http://127.0.0.1:${port}/`, { method });
+          const response = await project.handle("/", { method });
+          await response.body?.cancel();
           assertExists(response);
           assert(response.status !== 0);
         }
-
-        await stopServer(server);
-      });
-    });
-  });
-
-  describe("DevServer - Handler Performance", {}, () => {
-    it("health checks complete in <100ms", async () => {
-      await withTestContext("dev-server-health-perf", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
-        const timings: number[] = [];
-
-        for (let i = 0; i < 10; i++) {
-          const start = performance.now();
-          await fetchAndCancel(`http://127.0.0.1:${port}/healthz`);
-          timings.push(performance.now() - start);
-        }
-
-        const avgTime = timings.reduce((a, b) => a + b, 0) / timings.length;
-        assert(avgTime < 100, `Average health check time ${avgTime}ms should be <100ms`);
-
-        await stopServer(server);
-      });
-    });
-
-    it("metrics increment is non-blocking", async () => {
-      await withTestContext("dev-server-metrics-nonblocking", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
-        const start = performance.now();
-        const response = await fetchAndCancel(`http://127.0.0.1:${port}/`);
-        const duration = performance.now() - start;
-
-        assertExists(response);
-        assert(duration < 5000, `Request took ${duration}ms, should be <5000ms`);
-
-        await stopServer(server);
-      });
-    });
-
-    it("error handling does not add significant overhead", async () => {
-      await withTestContext("dev-server-error-perf", async (context) => {
-        const { server, port } = await createTestDevServer(context);
-
-        const successStart = performance.now();
-        await fetchAndCancel(`http://127.0.0.1:${port}/healthz`);
-        const successDuration = performance.now() - successStart;
-
-        const errorStart = performance.now();
-        await fetchAndCancel(`http://127.0.0.1:${port}/nonexistent`);
-        const errorDuration = performance.now() - errorStart;
-
-        const absoluteCeilingMs = 5000;
-        assert(
-          errorDuration < absoluteCeilingMs,
-          `Error handling took ${
-            errorDuration.toFixed(0)
-          }ms, exceeding ${absoluteCeilingMs}ms ceiling (success: ${successDuration.toFixed(0)}ms)`,
-        );
-
-        await stopServer(server);
       });
     });
   });

--- a/tests/integration/server/in-process-project.test.ts
+++ b/tests/integration/server/in-process-project.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The in-process harness must reach the same pipeline the servers serve, for
+ * both modes, and leave nothing behind. Sanitizers stay on here on purpose:
+ * a leak from the handler is a harness defect, not something to opt out of.
+ */
+
+import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert";
+import { afterAll, describe, it } from "#veryfront/testing/bdd";
+import { cleanupBundler } from "../../../src/rendering/cleanup.ts";
+import { IN_PROCESS_ORIGIN, withInProcessProject } from "../../_helpers/in-process-project.ts";
+
+const PAGE = `export default function Home() { return <h1>In-process home</h1>; }`;
+const API = `export const GET = (ctx) => Response.json({ ok: true, q: ctx.query.get("q") });`;
+
+describe("in-process project harness", () => {
+  afterAll(async () => {
+    await cleanupBundler();
+  });
+
+  it("renders a page and answers an API route through the dev handler", async () => {
+    await withInProcessProject("in-process-dev", {
+      files: { "pages/index.tsx": PAGE, "pages/api/hello.ts": API },
+    }, async (project) => {
+      assertEquals(project.mode, "dev");
+
+      const page = await project.handle("/");
+      assertEquals(page.status, 200);
+      assertStringIncludes(page.headers.get("content-type") ?? "", "text/html");
+      assertStringIncludes(await page.text(), "In-process home");
+
+      const api = await project.handle("/api/hello?q=one");
+      assertEquals(api.status, 200);
+      assertEquals(await api.json(), { ok: true, q: "one" });
+
+      const health = await project.handle("/healthz");
+      assertEquals(health.status, 200);
+      assertEquals(await health.text(), "ok");
+    });
+  });
+
+  it("serves the same project through the production handler", async () => {
+    await withInProcessProject("in-process-prod", {
+      mode: "production",
+      files: {
+        "pages/index.tsx": PAGE,
+        "pages/api/hello.ts": API,
+        "public/hello.txt": "static bytes",
+      },
+    }, async (project) => {
+      const page = await project.handle("/");
+      assertEquals(page.status, 200);
+      assertStringIncludes(await page.text(), "In-process home");
+
+      const api = await project.handle("/api/hello");
+      assertEquals(api.status, 200);
+      assertEquals(await api.json(), { ok: true, q: null });
+
+      const asset = await project.handle("/hello.txt");
+      assertEquals(asset.status, 200);
+      assertEquals(await asset.text(), "static bytes");
+
+      const health = await project.handle("/healthz");
+      assertEquals(health.status, 200);
+      assertEquals((await health.json()).status, "ok");
+    });
+  });
+
+  it("accepts a prebuilt Request and a path with init", async () => {
+    await withInProcessProject("in-process-request-forms", {
+      files: {
+        "pages/api/echo.ts": `export const GET = (ctx) =>
+          Response.json({ method: ctx.request.method, header: ctx.request.headers.get("x-probe") });
+        export const POST = (ctx) => Response.json({ method: ctx.request.method });`,
+      },
+    }, async (project) => {
+      const viaPath = await project.handle("/api/echo", { headers: { "x-probe": "path" } });
+      assertEquals(await viaPath.json(), { method: "GET", header: "path" });
+
+      const viaRequest = await project.handle(
+        new Request(`${IN_PROCESS_ORIGIN}/api/echo`, { headers: { "x-probe": "request" } }),
+      );
+      assertEquals(await viaRequest.json(), { method: "GET", header: "request" });
+
+      // The whole handler chain is in the loop, not just the route: a POST with
+      // no CSRF token is refused before project code runs.
+      const forged = await project.handle("/api/echo", { method: "POST" });
+      assertEquals(forged.status, 403);
+      assertStringIncludes(await forged.text(), "CSRF");
+    });
+  });
+
+  it("writes the config override and honours it", async () => {
+    await withInProcessProject("in-process-config", {
+      config: { title: "Overridden" },
+      files: { "pages/index.tsx": PAGE },
+    }, async (project) => {
+      const config = await Deno.readTextFile(`${project.projectDir}/veryfront.config.js`);
+      assert(config.includes(`"title": "Overridden"`));
+
+      const page = await project.handle("/");
+      assertEquals(page.status, 200);
+      await page.body?.cancel();
+    });
+  });
+});

--- a/tests/integration/server/rsc/handler-isolation.test.ts
+++ b/tests/integration/server/rsc/handler-isolation.test.ts
@@ -1,26 +1,24 @@
-import { assertNotEquals } from "#veryfront/testing/assert";
+import { assertEquals } from "#veryfront/testing/assert";
 import { afterAll, describe, it } from "#veryfront/testing/bdd";
-import { join } from "#veryfront/compat/path";
-import { writeTextFile } from "#veryfront/compat/fs.ts";
-import { withTestContext } from "../../../_helpers/context.ts";
+import { withInProcessProject } from "../../../_helpers/in-process-project.ts";
 import { cleanupBundler } from "../../../../src/rendering/cleanup.ts";
 
-describe("RSC Handler Isolation Tests", { sanitizeOps: false, sanitizeResources: false }, () => {
+describe("RSC Handler Isolation Tests", () => {
   afterAll(async () => {
     await cleanupBundler();
   });
 
   describe("RSC handler isolation", () => {
     it("creates a fresh handler after reset for different projectDir", async () => {
-      await withTestContext("rsc-iso-1", async (ctx1) => {
-        await writeTextFile(
-          join(ctx1.projectDir, "veryfront.config.js"),
-          `export default { experimental: { rsc: true } };`,
-        );
+      const manifestStatuses: number[] = [];
 
-        const s1 = await ctx1.createProductionServer();
-        const r1 = await fetch(`http://127.0.0.1:${s1.port}/_veryfront/rsc/manifest`);
-        r1.body?.cancel();
+      await withInProcessProject("rsc-iso-1", {
+        mode: "production",
+        config: { experimental: { rsc: true } },
+      }, async (project) => {
+        const r1 = await project.handle("/_veryfront/rsc/manifest");
+        manifestStatuses.push(r1.status);
+        await r1.body?.cancel();
       });
 
       const { __resetRSCHandlerForTests } = await import(
@@ -28,20 +26,18 @@ describe("RSC Handler Isolation Tests", { sanitizeOps: false, sanitizeResources:
       );
       __resetRSCHandlerForTests();
 
-      await withTestContext("rsc-iso-2", async (ctx2) => {
-        await writeTextFile(
-          join(ctx2.projectDir, "veryfront.config.js"),
-          `export default { experimental: { rsc: true } };`,
-        );
-
-        const s2 = await ctx2.createProductionServer();
-        assertNotEquals(s2.port, 0);
-
-        const r2 = await fetch(`http://127.0.0.1:${s2.port}/_veryfront/rsc/manifest`);
-        r2.body?.cancel();
+      await withInProcessProject("rsc-iso-2", {
+        mode: "production",
+        config: { experimental: { rsc: true } },
+      }, async (project) => {
+        const r2 = await project.handle("/_veryfront/rsc/manifest");
+        manifestStatuses.push(r2.status);
+        await r2.body?.cancel();
       });
 
       __resetRSCHandlerForTests();
+
+      assertEquals(manifestStatuses.length, 2);
     });
   });
 });

--- a/tests/integration/server/rsc/hydration.test.ts
+++ b/tests/integration/server/rsc/hydration.test.ts
@@ -1,25 +1,20 @@
 import { assertEquals, assertMatch } from "#veryfront/testing/assert";
 import { afterAll, describe, it } from "#veryfront/testing/bdd";
-import { join } from "#veryfront/compat/path";
-import { writeTextFile } from "#veryfront/compat/fs.ts";
-import { withTestContext } from "../../../_helpers/context.ts";
+import { withInProcessProject } from "../../../_helpers/in-process-project.ts";
 import { cleanupBundler } from "../../../../src/rendering/cleanup.ts";
 
-describe("RSC Hydration Tests", { sanitizeOps: false, sanitizeResources: false }, () => {
+describe("RSC Hydration Tests", () => {
   afterAll(async () => {
     await cleanupBundler();
   });
 
   describe("RSC client.js", () => {
     it("serves canonical client javascript and removes legacy hydrator endpoint", async () => {
-      await withTestContext("rsc-client", async (context) => {
-        await writeTextFile(
-          join(context.projectDir, "veryfront.config.js"),
-          `export default { experimental: { rsc: true } };`,
-        );
-
-        const server = await context.createProductionServer();
-        const res = await fetch(`http://127.0.0.1:${server.port}/_veryfront/rsc/client.js`);
+      await withInProcessProject("rsc-client", {
+        mode: "production",
+        config: { experimental: { rsc: true } },
+      }, async (project) => {
+        const res = await project.handle("/_veryfront/rsc/client.js");
 
         assertEquals(res.status, 200);
         assertMatch(res.headers.get("content-type") ?? "", /javascript/i);
@@ -27,9 +22,7 @@ describe("RSC Hydration Tests", { sanitizeOps: false, sanitizeResources: false }
 
         await res.body?.cancel();
 
-        const legacy = await fetch(
-          `http://127.0.0.1:${server.port}/_veryfront/rsc/hydrator.js`,
-        );
+        const legacy = await project.handle("/_veryfront/rsc/hydrator.js");
         assertEquals(legacy.status, 404);
         await legacy.body?.cancel();
       });


### PR DESCRIPTION
## Why

`createVeryfrontHandler` is already the port-free `(Request) => Promise<Response>` both servers wrap, but no harness could reach it, so request-pipeline tests paid for sockets: port allocation, readiness polling, shutdown drains, wall-clock assertions, and sanitizer opt-outs.

## What

- **`tests/_helpers/in-process-project.ts`**: `withInProcessProject(name, { files, config?, mode? }, fn)` → `project.handle(request | path)`. Composes `withTestContext` (cache-dir isolation, state reset, contract re-registration, cleanup) — no fork. `mode: "production"` = `bootstrapProd` + `createVeryfrontHandler` with the production server's option set; `mode: "dev"` = `bootstrapDev` + the dev `RequestHandler` behind the real `MiddlewarePipeline`. The harness supplies what the transport used to: loopback peer provenance, a matching Host header, HEAD body stripping. No `as any` anywhere.
- **Five suites migrated** (`dev-server-handlers`, `core/api-handler`, `examples/simple-production-test`, `rsc/hydration`, `rsc/handler-isolation`): dropped ports, polling, drains, the `TrustedLocalAPIRouteHandler` private-field-injection subclass, six sanitizer opt-outs, and the wall-clock assertions (`/healthz < 100ms` and the timing-only "Handler Performance" trio whose non-timing remnants duplicated existing behavioural tests).
- **Sanitizer baseline 404 → 396**, with the long-standing root cause found and closed: the esm.sh `react-dom-server.browser` bundle opens a module-scope `MessageChannel` for `scheduleWork` and never closes it. The harness tracks channels opened during the pipeline's lifetime and closes them at teardown — the harness's own test runs with sanitizers ON.

## Genuine coverage wins

- The socket tests sent `user-agent: Deno/*`, which `isSSRModuleRequest` treats as the SSR transport — so every "browser CSP-safe module" assertion was exercising the wrong module flavor and passing vacuously. In-process, the tests now walk the real ~290-module browser graph (allow-list updated to the split error registries it actually imports; verified no `new Function` in the walk).
- `api-handler` tests now traverse the full chain: mutating methods carry a real double-submit CSRF pair the old direct-handler tests bypassed.

## Timings

`dev-server-handlers` 10.9s → 5.6s while doing strictly more work; the five files together under `--parallel`: 61 steps in ~3s test time. (`api-handler` 0.3s → 1s — it now bootstraps the real pipeline per test; bought full-chain coverage + sanitizers on.)

## Follow-ups

`production-server.test.ts` (5-concurrent `< 200ms`), `server/production/ssr.test.ts`, `full-lifecycle.test.ts` are natural next migrations.

## Verification

Harness test + five migrated files pass individually and together under the integration flag set; `lint:sanitizer-baseline` ok 396/396; `test:layout`, `lint:cwd-relative-test-reads`, `lint:test-semantic-dispositions`, `lint:anti-slop` all ok; focused check/lint/fmt clean. Pre-push gate passed on push.