### PR TITLE
fix(ci): hold the automated-review gate pending and re-request on push

### DIFF
--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -111,15 +111,15 @@ jobs:
             return result.state;
       # A pending status on a trusted push event means no review exists for
       # this head yet, and nothing would request one: the Codex connector
-      # reviews on open and on ready for review, not on a push to an open pull
-      # request. Post the "@codex review" request here so the pending status
-      # can resolve without a human comment. Drafts are excluded because
-      # review bots skip them until they leave draft.
+      # handles open and ready-for-review events, but not a push to an open
+      # pull request. Post the "@codex review" request only for synchronize.
+      # The helper re-fetches the PR immediately before posting so a queued
+      # stale event cannot bind its marker to a request for a newer head.
       - name: Request an automated review of the current commit
         if: >-
           github.event_name == 'pull_request_target' &&
           github.event.pull_request.draft == false &&
-          contains(fromJSON('["opened", "synchronize", "reopened", "ready_for_review"]'), github.event.action) &&
+          github.event.action == 'synchronize' &&
           steps.publish.outputs.result == 'pending'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -141,5 +141,7 @@ jobs:
             core.notice(
               result.requested
                 ? `Requested an automated review of ${pullRequest.head.sha.slice(0, 12)}.`
+                : result.reason === "stale-head"
+                ? "Skipped an automated review request from a stale synchronize event."
                 : "An automated review request for this head commit already exists.",
             );

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -11,7 +11,13 @@ on:
 permissions:
   contents: read
   issues: read
-  pull-requests: read
+  # pull-requests: write lets the gate post the "@codex review" comment when a
+  # push leaves the head commit without a review. This workflow runs with
+  # pull_request_target authority, so the write scope stays safe only because
+  # the workflow checks out the trusted default branch, never executes files
+  # from the pull request head, and the posted comment body is a fixed string
+  # plus the verified head commit SHA with no pull request controlled content.
+  pull-requests: write
   statuses: write
 
 concurrency:
@@ -44,9 +50,11 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
       - name: Require an automated review for the current commit
+        id: publish
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           retries: 3
+          result-encoding: string
           script: |
             const { pathToFileURL } = require("node:url");
             const gateUrl = pathToFileURL(
@@ -92,9 +100,7 @@ jobs:
               isDraft: pullRequest.draft === true,
             });
             if (result.state === "pending") {
-              core.notice(
-                "Draft pull request: the automated review status stays pending.",
-              );
+              core.notice(`${result.description}.`);
             } else if (result.review) {
               core.notice(
                 `Automated review submitted by ${result.review.reviewer} for ${headSha.slice(0, 12)}.`,
@@ -102,3 +108,38 @@ jobs:
             } else {
               core.warning(result.failure.message);
             }
+            return result.state;
+      # A pending status on a trusted push event means no review exists for
+      # this head yet, and nothing would request one: the Codex connector
+      # reviews on open and on ready for review, not on a push to an open pull
+      # request. Post the "@codex review" request here so the pending status
+      # can resolve without a human comment. Drafts are excluded because
+      # review bots skip them until they leave draft.
+      - name: Request an automated review of the current commit
+        if: >-
+          github.event_name == 'pull_request_target' &&
+          github.event.pull_request.draft == false &&
+          contains(fromJSON('["opened", "synchronize", "reopened", "ready_for_review"]'), github.event.action) &&
+          steps.publish.outputs.result == 'pending'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          retries: 3
+          script: |
+            const { pathToFileURL } = require("node:url");
+            const gateUrl = pathToFileURL(
+              `${process.env.GITHUB_WORKSPACE}/scripts/ci/automated-review-gate.mjs`,
+            ).href;
+            const { requestAutomatedReview } = await import(gateUrl);
+            const pullRequest = context.payload.pull_request;
+            const result = await requestAutomatedReview({
+              github,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pullNumber: pullRequest.number,
+              headSha: pullRequest.head.sha,
+            });
+            core.notice(
+              result.requested
+                ? `Requested an automated review of ${pullRequest.head.sha.slice(0, 12)}.`
+                : "An automated review request for this head commit already exists.",
+            );

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -237,16 +237,22 @@ export async function publishAutomatedReviewStatus({
   // Review bots skip drafts, so a draft has no verdict yet. Publish pending so
   // "not reviewed yet" never renders as a pass and never as a missing status.
   if (isDraft) {
+    const description = "Draft pull request waits for ready for review";
     await github.rest.repos.createCommitStatus({
       owner,
       repo,
       sha: headSha,
       state: "pending",
       context: AUTOMATED_REVIEW_STATUS_CONTEXT,
-      description: "Draft pull request waits for ready for review",
+      description,
       target_url: pullUrl,
     });
-    return { state: "pending", review: undefined, failure: undefined };
+    return {
+      state: "pending",
+      review: undefined,
+      failure: undefined,
+      description,
+    };
   }
 
   let review;
@@ -283,29 +289,77 @@ export async function publishAutomatedReviewStatus({
         }
       },
     }, headSha);
-    if (!review) {
-      failure = new Error(
-        `No automated review was submitted for current commit ${
-          headSha.slice(0, 12)
-        }. ` +
-          "CodeRabbit and Codex skip or rate-limit comments do not count as reviews.",
-      );
-    }
   } catch (error) {
     failure = error instanceof Error ? error : new Error(String(error));
   }
 
-  const state = review ? "success" : "failure";
+  // No review for the current head is the normal state right after a push,
+  // while the review bots are still working. Publish pending, not failure: a
+  // required pending status blocks merging exactly like a failure does, and it
+  // resolves itself as soon as a review for this head arrives. Only an error
+  // while computing the decision stays a failure, because that red must be
+  // looked at instead of waited out.
+  const state = review ? "success" : failure ? "failure" : "pending";
+  const description = review
+    ? `Reviewed by ${review.reviewer}`
+    : failure
+    ? "Could not determine the automated review status"
+    : `Waiting for an automated review of ${headSha.slice(0, 12)}`;
   await github.rest.repos.createCommitStatus({
     owner,
     repo,
     sha: headSha,
     state,
     context: AUTOMATED_REVIEW_STATUS_CONTEXT,
-    description: review
-      ? `Reviewed by ${review.reviewer}`
-      : "No CodeRabbit or Codex review for current commit",
+    description,
     target_url: review?.url ?? pullUrl,
   });
-  return { state, review, failure };
+  return { state, review, failure, description };
+}
+
+/**
+ * Ask Codex to review the current head commit, at most once per commit.
+ *
+ * The Codex connector reviews a pull request when it opens or leaves draft,
+ * but a push to an open pull request does not trigger a new review. Posting
+ * the literal "@codex review" comment is how a new review is requested. The
+ * marker comment keeps the request idempotent: a rerun for the same head
+ * finds the marker in an existing comment and does not post again, while a
+ * new head carries a new marker and gets its own request.
+ */
+export async function requestAutomatedReview({
+  github,
+  owner,
+  repo,
+  pullNumber,
+  headSha,
+}) {
+  // The comment body must stay a fixed instruction plus a verified commit
+  // SHA. Never interpolate pull request controlled content here: this runs
+  // with pull_request_target authority.
+  if (typeof headSha !== "string" || !FULL_COMMIT_PATTERN.test(headSha)) {
+    throw new Error(
+      "Refusing to request an automated review of a malformed head commit",
+    );
+  }
+  const marker = `<!-- automated-review-request: ${headSha.toLowerCase()} -->`;
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: pullNumber,
+    per_page: 100,
+  });
+  const alreadyRequested = comments.some((comment) =>
+    typeof comment?.body === "string" && comment.body.includes(marker)
+  );
+  if (alreadyRequested) {
+    return { requested: false, marker };
+  }
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: pullNumber,
+    body: `${marker}\n@codex review`,
+  });
+  return { requested: true, marker };
 }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -19,6 +19,7 @@ const CODEX_NO_FINDING_PREFIX = "Codex Review: Didn't find any major issues.";
 const CODEX_REVIEWED_COMMIT_PATTERN =
   /\*\*Reviewed commit:\*\*\s*`([0-9a-f]{10})`/i;
 const FULL_COMMIT_PATTERN = /^[0-9a-f]{40}$/i;
+const WORKFLOW_COMMENT_LOGIN = "github-actions[bot]";
 /** @type {(ref: string) => Promise<string | undefined>} */
 const NO_COMMIT_RESOLVER = () => Promise.resolve(undefined);
 export const AUTOMATED_REVIEW_STATUS_CONTEXT = "Automated review";
@@ -326,6 +327,11 @@ export async function publishAutomatedReviewStatus({
  * marker comment keeps the request idempotent: a rerun for the same head
  * finds the marker in an existing comment and does not post again, while a
  * new head carries a new marker and gets its own request.
+ *
+ * Only marker comments authored by the workflow itself count. A pull request
+ * participant can paste the marker text into their own comment, and letting
+ * that suppress the request would let anyone silence the review nudge for a
+ * head commit.
  */
 export async function requestAutomatedReview({
   github,
@@ -350,7 +356,10 @@ export async function requestAutomatedReview({
     per_page: 100,
   });
   const alreadyRequested = comments.some((comment) =>
-    typeof comment?.body === "string" && comment.body.includes(marker)
+    comment?.user?.login === WORKFLOW_COMMENT_LOGIN &&
+    comment?.user?.type === "Bot" &&
+    typeof comment?.body === "string" &&
+    comment.body.includes(marker)
   );
   if (alreadyRequested) {
     return { requested: false, marker };

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -28,7 +28,7 @@ const SUBMITTED_REVIEW_STATES = new Set([
   "COMMENTED",
 ]);
 
-/** Find an actual automated review submitted against the current PR head. */
+/** Decide the newest automated-review outcome for the current PR head. */
 export async function findAutomatedReview(
   {
     reviews,
@@ -69,7 +69,7 @@ export async function findAutomatedReview(
       event.time === undefined &&
       (await outcomeFor(event)).kind !== "not-head"
     ) {
-      return undefined;
+      return { kind: "failure" };
     }
   }
   const timedEvents = Map.groupBy(
@@ -86,7 +86,7 @@ export async function findAutomatedReview(
     if (
       exactHeadOutcomes.length > 1 &&
       exactHeadOutcomes.some((outcome) => outcome.kind !== "success")
-    ) return undefined;
+    ) return { kind: "failure" };
   }
   events.sort((left, right) => {
     if (left.time === undefined) {
@@ -99,9 +99,9 @@ export async function findAutomatedReview(
   for (const event of events) {
     const outcome = await outcomeFor(event);
     if (outcome.kind === "not-head") continue;
-    return outcome.kind === "success" ? outcome.review : undefined;
+    return outcome;
   }
-  return undefined;
+  return { kind: "waiting" };
 }
 
 function automatedReviewEventTime(value) {
@@ -133,13 +133,17 @@ async function classifyAutomatedReviewEvent(
       review?.commit_id !== headSha
     ) return { kind: "not-head" };
     const state = review?.state;
+    if (typeof state !== "string") return { kind: "failure" };
+    if (state.toUpperCase() === "PENDING") return { kind: "waiting" };
     if (
-      typeof state !== "string" ||
       typeof review?.submitted_at !== "string" ||
       review.submitted_at.length === 0
-    ) return { kind: "invalid" };
+    ) return { kind: "failure" };
     if (!SUBMITTED_REVIEW_STATES.has(state.toUpperCase())) {
-      return { kind: "failure" };
+      return {
+        kind: "failure",
+        url: typeof review.html_url === "string" ? review.html_url : undefined,
+      };
     }
     return {
       kind: "success",
@@ -183,7 +187,12 @@ async function classifyAutomatedReviewEvent(
             : undefined,
         },
       }
-      : { kind: "failure" };
+      : {
+        kind: "failure",
+        url: typeof comment.html_url === "string"
+          ? comment.html_url
+          : undefined,
+      };
   }
   if (login.toLowerCase() !== CODERABBIT_LOGIN) {
     return { kind: "not-head" };
@@ -194,7 +203,12 @@ async function classifyAutomatedReviewEvent(
   if (
     skippedTip?.toLowerCase() === headSha.toLowerCase() ||
     requestedTip?.toLowerCase() === headSha.toLowerCase()
-  ) return { kind: "failure" };
+  ) {
+    return {
+      kind: "failure",
+      url: typeof comment.html_url === "string" ? comment.html_url : undefined,
+    };
+  }
   const reviewedTip = recentReview?.match(
     CODERABBIT_REVIEW_RANGE_PATTERN,
   )?.[2];
@@ -213,7 +227,10 @@ async function classifyAutomatedReviewEvent(
           : undefined,
       },
     }
-    : { kind: "failure" };
+    : {
+      kind: "failure",
+      url: typeof comment.html_url === "string" ? comment.html_url : undefined,
+    };
 }
 
 function codeRabbitRecentReview(body) {
@@ -256,7 +273,7 @@ export async function publishAutomatedReviewStatus({
     };
   }
 
-  let review;
+  let decision = { kind: "waiting" };
   let failure;
   try {
     const reviews = await github.paginate(github.rest.pulls.listReviews, {
@@ -271,23 +288,20 @@ export async function publishAutomatedReviewStatus({
       issue_number: pullNumber,
       per_page: 100,
     });
-    review = await findAutomatedReview({
+    decision = await findAutomatedReview({
       reviews,
       comments,
       resolveCommit: async (ref) => {
-        try {
-          const response = await github.rest.repos.getCommit({
-            owner,
-            repo,
-            ref,
-          });
-          const sha = response?.data?.sha;
-          return typeof sha === "string" && FULL_COMMIT_PATTERN.test(sha)
-            ? sha
-            : undefined;
-        } catch {
-          return undefined;
+        const response = await github.rest.repos.getCommit({
+          owner,
+          repo,
+          ref,
+        });
+        const sha = response?.data?.sha;
+        if (typeof sha !== "string" || !FULL_COMMIT_PATTERN.test(sha)) {
+          throw new Error("Commit lookup returned a malformed commit SHA");
         }
+        return sha;
       },
     }, headSha);
   } catch (error) {
@@ -295,14 +309,18 @@ export async function publishAutomatedReviewStatus({
   }
 
   // No review for the current head is the normal state right after a push,
-  // while the review bots are still working. Publish pending, not failure: a
-  // required pending status blocks merging exactly like a failure does, and it
-  // resolves itself as soon as a review for this head arrives. Only an error
-  // while computing the decision stays a failure, because that red must be
-  // looked at instead of waited out.
+  // while the review bots are still working. Publish pending only for that
+  // absent-or-waiting decision. Completed negative evidence and errors while
+  // computing the decision stay failures so they are looked at, not waited out.
+  if (decision.kind === "failure" && !failure) {
+    failure = new Error("Automated review reported a negative outcome");
+  }
+  const review = decision.kind === "success" ? decision.review : undefined;
   const state = review ? "success" : failure ? "failure" : "pending";
   const description = review
     ? `Reviewed by ${review.reviewer}`
+    : decision.kind === "failure"
+    ? "Automated review did not pass the current commit"
     : failure
     ? "Could not determine the automated review status"
     : `Waiting for an automated review of ${headSha.slice(0, 12)}`;
@@ -313,7 +331,7 @@ export async function publishAutomatedReviewStatus({
     state,
     context: AUTOMATED_REVIEW_STATUS_CONTEXT,
     description,
-    target_url: review?.url ?? pullUrl,
+    target_url: review?.url ?? decision.url ?? pullUrl,
   });
   return { state, review, failure, description };
 }
@@ -332,6 +350,11 @@ export async function publishAutomatedReviewStatus({
  * participant can paste the marker text into their own comment, and letting
  * that suppress the request would let anyone silence the review nudge for a
  * head commit.
+ *
+ * Immediately before posting, re-fetch the pull request and require its
+ * current head to match the event head. That prevents a queued synchronize
+ * run from marking an old SHA while its unqualified request targets a newer
+ * current head.
  */
 export async function requestAutomatedReview({
   github,
@@ -363,6 +386,21 @@ export async function requestAutomatedReview({
   );
   if (alreadyRequested) {
     return { requested: false, marker };
+  }
+  const response = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: pullNumber,
+  });
+  const currentHeadSha = response?.data?.head?.sha;
+  if (
+    typeof currentHeadSha !== "string" ||
+    !FULL_COMMIT_PATTERN.test(currentHeadSha)
+  ) {
+    throw new Error("Could not verify the current pull request head commit");
+  }
+  if (currentHeadSha.toLowerCase() !== headSha.toLowerCase()) {
+    return { requested: false, marker, reason: "stale-head" };
   }
   await github.rest.issues.createComment({
     owner,

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -7,7 +7,7 @@ import {
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { parse } from "#std/yaml/parse";
 import {
-  findAutomatedReview,
+  findAutomatedReview as findAutomatedReviewDecision,
   publishAutomatedReviewStatus,
   requestAutomatedReview,
 } from "./automated-review-gate.mjs";
@@ -81,7 +81,43 @@ function record(value: unknown, label: string): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
+async function findAutomatedReview(
+  options: {
+    reviews: Array<Record<string, unknown>>;
+    comments: Array<Record<string, unknown>>;
+    resolveCommit?: (ref: string) => Promise<string | undefined>;
+  },
+  headSha: string,
+) {
+  const decision = await findAutomatedReviewDecision(options, headSha);
+  return decision.kind === "success" ? decision.review : undefined;
+}
+
 describe("automated review gate", () => {
+  it("keeps success, failure, and waiting decisions distinct", async () => {
+    assertEquals(
+      (await findAutomatedReviewDecision(
+        { reviews: [review()], comments: [] },
+        HEAD_SHA,
+      )).kind,
+      "success",
+    );
+    assertEquals(
+      (await findAutomatedReviewDecision(
+        { reviews: [review({ state: "CHANGES_REQUESTED" })], comments: [] },
+        HEAD_SHA,
+      )).kind,
+      "failure",
+    );
+    assertEquals(
+      (await findAutomatedReviewDecision(
+        { reviews: [], comments: [] },
+        HEAD_SHA,
+      )).kind,
+      "waiting",
+    );
+  });
+
   it("accepts submitted CodeRabbit and Codex reviews for the current head", async () => {
     assertEquals(
       (await findAutomatedReview(
@@ -580,6 +616,67 @@ describe("automated review gate", () => {
     );
   });
 
+  it("publishes failure for completed negative exact-head outcomes", async () => {
+    const negativeEvidence = [
+      { reviews: [review({ state: "CHANGES_REQUESTED" })], comments: [] },
+      {
+        reviews: [],
+        comments: [codexNoFindingComment({
+          body: [
+            "Codex Review: Found an actionable issue.",
+            `**Reviewed commit:** \`${HEAD_SHA.slice(0, 10)}\``,
+          ].join("\n\n"),
+        })],
+      },
+      {
+        reviews: [],
+        comments: [codeRabbitSummary({
+          body: [
+            "<!-- recent_review_start -->",
+            "Actionable comments were generated in the recent review.",
+            `Reviewing files between ${STALE_SHA} and ${HEAD_SHA}.`,
+            "<!-- recent_review_end -->",
+          ].join("\n"),
+        })],
+      },
+    ];
+
+    for (const evidence of negativeEvidence) {
+      const statuses: Array<Record<string, unknown>> = [];
+      const listReviews = () => Promise.resolve();
+      const listComments = () => Promise.resolve();
+      const github = {
+        paginate: (endpoint: unknown) =>
+          Promise.resolve(
+            endpoint === listReviews ? evidence.reviews : evidence.comments,
+          ),
+        rest: {
+          issues: { listComments },
+          pulls: { listReviews },
+          repos: {
+            createCommitStatus: (status: Record<string, unknown>) => {
+              statuses.push(status);
+              return Promise.resolve();
+            },
+            getCommit: () => Promise.resolve({ data: { sha: HEAD_SHA } }),
+          },
+        },
+      };
+
+      const result = await publishAutomatedReviewStatus({
+        github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        pullNumber: 1,
+        headSha: HEAD_SHA,
+        pullUrl: "https://github.com/veryfront/veryfront-code/pull/1",
+      });
+
+      assertEquals(result.state, "failure");
+      assertEquals(statuses[0]?.state, "failure");
+    }
+  });
+
   it("resolves a Codex comment to the exact commit before publishing success", async () => {
     const statuses: Array<Record<string, unknown>> = [];
     const resolvedRefs: string[] = [];
@@ -624,52 +721,48 @@ describe("automated review gate", () => {
     );
   });
 
-  it("holds the status pending when a Codex commit cannot be resolved exactly", async () => {
-    const statuses: Array<Record<string, unknown>> = [];
-    const listReviews = () => Promise.resolve();
-    const listComments = () => Promise.resolve();
-    const github = {
-      paginate: (endpoint: unknown) =>
-        Promise.resolve(
-          endpoint === listComments ? [codexNoFindingComment()] : [],
-        ),
-      rest: {
-        issues: { listComments },
-        pulls: { listReviews },
-        repos: {
-          createCommitStatus: (status: Record<string, unknown>) => {
-            statuses.push(status);
-            return Promise.resolve();
+  it("fails closed when Codex commit resolution is rejected", async () => {
+    for (const status of [403, 429, 500]) {
+      const statuses: Array<Record<string, unknown>> = [];
+      const listReviews = () => Promise.resolve();
+      const listComments = () => Promise.resolve();
+      const github = {
+        paginate: (endpoint: unknown) =>
+          Promise.resolve(
+            endpoint === listComments ? [codexNoFindingComment()] : [],
+          ),
+        rest: {
+          issues: { listComments },
+          pulls: { listReviews },
+          repos: {
+            createCommitStatus: (commitStatus: Record<string, unknown>) => {
+              statuses.push(commitStatus);
+              return Promise.resolve();
+            },
+            getCommit: () =>
+              Promise.reject(Object.assign(new Error(`HTTP ${status}`), {
+                status,
+              })),
           },
-          getCommit: () =>
-            Promise.reject(Object.assign(new Error("ambiguous commit"), {
-              status: 422,
-            })),
         },
-      },
-    };
+      };
 
-    const result = await publishAutomatedReviewStatus({
-      github,
-      owner: "veryfront",
-      repo: "veryfront-code",
-      pullNumber: 1,
-      headSha: HEAD_SHA,
-      pullUrl: "https://github.com/veryfront/veryfront-code/pull/1",
-    });
+      const result = await publishAutomatedReviewStatus({
+        github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        pullNumber: 1,
+        headSha: HEAD_SHA,
+        pullUrl: "https://github.com/veryfront/veryfront-code/pull/1",
+      });
 
-    // The unresolved commit means no review exists for the current head, and
-    // that reads as still waiting: the status self-heals when a resolvable
-    // review arrives, and a required pending status still blocks merging.
-    assertEquals(result.state, "pending");
-    assertEquals(result.review, undefined);
-    assertEquals(result.failure, undefined);
-    assertEquals(statuses[0]?.state, "pending");
-    assertEquals(statuses[0]?.sha, HEAD_SHA);
-    assertStringIncludes(
-      String(statuses[0]?.description),
-      HEAD_SHA.slice(0, 12),
-    );
+      assertEquals(result.state, "failure");
+      assertEquals(statuses[0]?.state, "failure");
+      assert(
+        result.failure instanceof Error &&
+          result.failure.message.includes(String(status)),
+      );
+    }
   });
 
   it("fails closed when the review lookup throws", async () => {
@@ -757,6 +850,9 @@ describe("automated review gate", () => {
             return Promise.resolve();
           },
         },
+        pulls: {
+          get: () => Promise.resolve({ data: { head: { sha: HEAD_SHA } } }),
+        },
       },
     };
     const request = (headSha: string) =>
@@ -803,12 +899,45 @@ describe("automated review gate", () => {
     assertEquals(posted.length, 2);
 
     // A new head commit carries a new marker and gets its own request.
+    github.rest.pulls.get = () =>
+      Promise.resolve({ data: { head: { sha: STALE_SHA } } });
     const third = await request(STALE_SHA);
     assertEquals(third.requested, true);
     assertEquals(
       posted[2]?.body,
       `<!-- automated-review-request: ${STALE_SHA} -->\n@codex review`,
     );
+  });
+
+  it("does not post from a stale queued synchronize event", async () => {
+    let posted = false;
+    const github = {
+      paginate: () => Promise.resolve([]),
+      rest: {
+        issues: {
+          listComments: () => Promise.resolve(),
+          createComment: () => {
+            posted = true;
+            return Promise.resolve();
+          },
+        },
+        pulls: {
+          get: () => Promise.resolve({ data: { head: { sha: STALE_SHA } } }),
+        },
+      },
+    };
+
+    const result = await requestAutomatedReview({
+      github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD_SHA,
+    });
+
+    assertEquals(result.requested, false);
+    assertEquals(result.reason, "stale-head");
+    assertEquals(posted, false);
   });
 
   it("refuses to request a review of a malformed head commit", async () => {
@@ -821,6 +950,7 @@ describe("automated review gate", () => {
             throw new Error("must not post for a malformed commit");
           },
         },
+        pulls: { get: () => Promise.resolve() },
       },
     };
     for (
@@ -966,7 +1096,7 @@ describe("automated review gate", () => {
       const guard of [
         "github.event_name == 'pull_request_target'",
         "github.event.pull_request.draft == false",
-        `'["opened", "synchronize", "reopened", "ready_for_review"]'`,
+        "github.event.action == 'synchronize'",
         "steps.publish.outputs.result == 'pending'",
       ]
     ) {
@@ -976,6 +1106,11 @@ describe("automated review gate", () => {
         "a review request is posted only for a trusted non-draft push that left the status pending",
       );
     }
+    assert(
+      !requestCondition.includes("ready_for_review") &&
+        !requestCondition.includes("opened"),
+      "open and ready-for-review events are already handled by the connector",
+    );
     const requestScript = String(
       record(request.with, "automated review request inputs").script,
     );

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1,9 +1,15 @@
-import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { parse } from "#std/yaml/parse";
 import {
   findAutomatedReview,
   publishAutomatedReviewStatus,
+  requestAutomatedReview,
 } from "./automated-review-gate.mjs";
 
 const HEAD_SHA = "a".repeat(40);
@@ -563,14 +569,15 @@ describe("automated review gate", () => {
       headSha: STALE_SHA,
       pullUrl: "https://github.com/veryfront/veryfront-code/pull/1",
     });
-    assertEquals(missing.state, "failure");
-    assert(
-      missing.failure instanceof Error &&
-        missing.failure.message.includes(STALE_SHA.slice(0, 12)),
-      "the failure must name the unreviewed head commit",
-    );
+    assertEquals(missing.state, "pending");
+    assertEquals(missing.review, undefined);
+    assertEquals(missing.failure, undefined);
     assertEquals(statuses[1]?.sha, STALE_SHA);
-    assertEquals(statuses[1]?.state, "failure");
+    assertEquals(statuses[1]?.state, "pending");
+    assertEquals(
+      statuses[1]?.description,
+      `Waiting for an automated review of ${STALE_SHA.slice(0, 12)}`,
+    );
   });
 
   it("resolves a Codex comment to the exact commit before publishing success", async () => {
@@ -617,7 +624,7 @@ describe("automated review gate", () => {
     );
   });
 
-  it("publishes failure when a Codex commit cannot be resolved exactly", async () => {
+  it("holds the status pending when a Codex commit cannot be resolved exactly", async () => {
     const statuses: Array<Record<string, unknown>> = [];
     const listReviews = () => Promise.resolve();
     const listComments = () => Promise.resolve();
@@ -651,10 +658,18 @@ describe("automated review gate", () => {
       pullUrl: "https://github.com/veryfront/veryfront-code/pull/1",
     });
 
-    assertEquals(result.state, "failure");
+    // The unresolved commit means no review exists for the current head, and
+    // that reads as still waiting: the status self-heals when a resolvable
+    // review arrives, and a required pending status still blocks merging.
+    assertEquals(result.state, "pending");
     assertEquals(result.review, undefined);
-    assertEquals(statuses[0]?.state, "failure");
+    assertEquals(result.failure, undefined);
+    assertEquals(statuses[0]?.state, "pending");
     assertEquals(statuses[0]?.sha, HEAD_SHA);
+    assertStringIncludes(
+      String(statuses[0]?.description),
+      HEAD_SHA.slice(0, 12),
+    );
   });
 
   it("fails closed when the review lookup throws", async () => {
@@ -728,6 +743,93 @@ describe("automated review gate", () => {
     assertEquals(statuses[0]?.sha, HEAD_SHA);
   });
 
+  it("requests an automated review at most once per head commit", async () => {
+    const posted: Array<Record<string, unknown>> = [];
+    const existing: Array<Record<string, unknown>> = [];
+    const listComments = () => Promise.resolve();
+    const github = {
+      paginate: () => Promise.resolve(existing),
+      rest: {
+        issues: {
+          listComments,
+          createComment: (comment: Record<string, unknown>) => {
+            posted.push(comment);
+            return Promise.resolve();
+          },
+        },
+      },
+    };
+    const request = (headSha: string) =>
+      requestAutomatedReview({
+        github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        pullNumber: 1,
+        headSha,
+      });
+
+    const first = await request(HEAD_SHA);
+    assertEquals(first.requested, true);
+    assertEquals(posted, [{
+      owner: "veryfront",
+      repo: "veryfront-code",
+      issue_number: 1,
+      body: `<!-- automated-review-request: ${HEAD_SHA} -->\n@codex review`,
+    }]);
+
+    // A rerun for the same head finds the marker and does not post again,
+    // regardless of who posted the marker comment.
+    existing.push({
+      user: { login: "github-actions[bot]" },
+      body: posted[0]?.body,
+    });
+    const second = await request(HEAD_SHA);
+    assertEquals(second.requested, false);
+    assertEquals(posted.length, 1);
+
+    // A new head commit carries a new marker and gets its own request.
+    const third = await request(STALE_SHA);
+    assertEquals(third.requested, true);
+    assertEquals(
+      posted[1]?.body,
+      `<!-- automated-review-request: ${STALE_SHA} -->\n@codex review`,
+    );
+  });
+
+  it("refuses to request a review of a malformed head commit", async () => {
+    const github = {
+      paginate: () => Promise.resolve([]),
+      rest: {
+        issues: {
+          listComments: () => Promise.resolve(),
+          createComment: () => {
+            throw new Error("must not post for a malformed commit");
+          },
+        },
+      },
+    };
+    for (
+      const malformed of [
+        HEAD_SHA.slice(0, 39),
+        `${HEAD_SHA} --><script>`,
+        "@codex review",
+      ]
+    ) {
+      await assertRejects(
+        () =>
+          requestAutomatedReview({
+            github,
+            owner: "veryfront",
+            repo: "veryfront-code",
+            pullNumber: 1,
+            headSha: malformed,
+          }),
+        Error,
+        "malformed head commit",
+      );
+    }
+  });
+
   it("uses trusted base code and reruns when a real review is submitted", async () => {
     const workflow = record(
       parse(await Deno.readTextFile(WORKFLOW_PATH)),
@@ -754,7 +856,7 @@ describe("automated review gate", () => {
     assertEquals(permissions, {
       contents: "read",
       issues: "read",
-      "pull-requests": "read",
+      "pull-requests": "write",
       statuses: "write",
     });
 
@@ -827,6 +929,44 @@ describe("automated review gate", () => {
       script.includes("Review gate is unavailable on the default branch") &&
         script.includes('state: "failure"'),
       "a gate that fails to load must publish a failure status, not no status",
+    );
+    assertEquals(
+      gate.id,
+      "publish",
+      "the request step reads the published state from this step's output",
+    );
+    assertEquals(
+      record(gate.with, "automated review gate inputs")["result-encoding"],
+      "string",
+      "the published state must land in the step output as a plain string",
+    );
+
+    const request = record(steps[2], "automated review request step");
+    assertEquals(
+      request.uses,
+      "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3",
+    );
+    const requestCondition = String(request.if);
+    for (
+      const guard of [
+        "github.event_name == 'pull_request_target'",
+        "github.event.pull_request.draft == false",
+        `'["opened", "synchronize", "reopened", "ready_for_review"]'`,
+        "steps.publish.outputs.result == 'pending'",
+      ]
+    ) {
+      assertStringIncludes(
+        requestCondition,
+        guard,
+        "a review request is posted only for a trusted non-draft push that left the status pending",
+      );
+    }
+    const requestScript = String(
+      record(request.with, "automated review request inputs").script,
+    );
+    assert(
+      requestScript.includes("requestAutomatedReview"),
+      "the workflow must post review requests through the tested gate helper",
     );
   });
 });

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -777,21 +777,36 @@ describe("automated review gate", () => {
       body: `<!-- automated-review-request: ${HEAD_SHA} -->\n@codex review`,
     }]);
 
-    // A rerun for the same head finds the marker and does not post again,
-    // regardless of who posted the marker comment.
+    // A participant pasting the marker text must not suppress the request:
+    // only a workflow-authored marker comment counts, pinned by login and
+    // account type the way the gate pins the Codex bot.
+    existing.push(
+      { user: { login: "maintainer", type: "User" }, body: posted[0]?.body },
+      {
+        user: { login: "github-actions[bot]", type: "User" },
+        body: posted[0]?.body,
+      },
+      { body: posted[0]?.body },
+    );
+    const impersonated = await request(HEAD_SHA);
+    assertEquals(impersonated.requested, true);
+    assertEquals(posted.length, 2);
+
+    // A rerun for the same head finds the workflow-authored marker and does
+    // not post again.
     existing.push({
-      user: { login: "github-actions[bot]" },
+      user: { login: "github-actions[bot]", type: "Bot" },
       body: posted[0]?.body,
     });
     const second = await request(HEAD_SHA);
     assertEquals(second.requested, false);
-    assertEquals(posted.length, 1);
+    assertEquals(posted.length, 2);
 
     // A new head commit carries a new marker and gets its own request.
     const third = await request(STALE_SHA);
     assertEquals(third.requested, true);
     assertEquals(
-      posted[1]?.body,
+      posted[2]?.body,
       `<!-- automated-review-request: ${STALE_SHA} -->\n@codex review`,
     );
   });


### PR DESCRIPTION
## Why

The "Automated review" status is red on every freshly opened PR and after every push: the gate publishes `failure` whenever no automated review exists yet for the head, and nothing re-requests a review on `synchronize`, so after fixing review findings the status stays red until someone comments `@codex review` by hand.

## What

- **Pending while waiting**: no review for the head now publishes `pending` ("Waiting for an automated review of <sha12>") instead of `failure`. A required pending status blocks merging exactly like failure, so nothing that previously blocked can now merge — the change is purely presentational plus self-healing for CodeRabbit skip/rate-limit windows. `failure` remains for real problems: the review lookup throwing, or the gate failing to load from the default branch.
- **Auto-request on push**: when the published state is pending on `opened|synchronize|reopened|ready_for_review` (non-draft), the workflow posts `<!-- automated-review-request: <sha> -->\n@codex review` — at most once per head SHA (marker-comment idempotency), implemented as an exported, unit-tested `requestAutomatedReview`. The head SHA is validated against the 40-hex pattern before it reaches the comment body, and the workflow keeps its `pull_request_target` hardening: default-branch checkout only, nothing executed from the PR head, fixed comment text.
- `permissions: pull-requests` moves read → write for the comment, with the safety argument inline in the workflow.

## Semantics

| Situation | Before | After |
|---|---|---|
| Review found for head | success | success |
| Draft | pending | pending |
| No review yet (bots working) | **failure** | **pending** + auto-request |
| CodeRabbit skip/rate-limit for head | **failure** | **pending** (self-heals) |
| Lookup throws / gate unloadable | failure | failure |

## Notes

- No CodeRabbit/Codex parsing patterns touched — textually and semantically disjoint from #4025.
- Tests: 18 steps covering the new pending cases, request idempotency (once per SHA, again for a new SHA), malformed-SHA refusal, and the workflow structure (permissions, step guards).