### PR TITLE
test(provider): one scripted ModelRuntime fake instead of thirty-eight

### DIFF
--- a/src/agent/factory-call-context.test.ts
+++ b/src/agent/factory-call-context.test.ts
@@ -4,11 +4,7 @@ import { FakeTime } from "#std/testing/time";
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
-import {
-  type ModelRuntime,
-  registerModelProvider,
-  runWithVeryfrontCloudContextAsync,
-} from "#veryfront/provider";
+import { registerModelProvider, runWithVeryfrontCloudContextAsync } from "#veryfront/provider";
 import { deleteEnv, getEnv, setEnv } from "#veryfront/compat/process.ts";
 import { registerSkill } from "#veryfront/skill/registry.ts";
 import { tool } from "#veryfront/tool";
@@ -16,30 +12,8 @@ import { defineSchema } from "#veryfront/schemas/index.ts";
 import { agent } from "./index.ts";
 import { agentRegistry } from "./composition/index.ts";
 import { getEffectiveAgentSystem } from "./runtime/effective-agent-system.ts";
+import { scriptedModel } from "./runtime/model-runtime.test-helpers.ts";
 import type { AgentConfig, RuntimeStateRequest } from "./types.ts";
-
-function createRuntimeStream(parts: unknown[]) {
-  return new ReadableStream<unknown>({
-    start(controller) {
-      for (const part of parts) {
-        controller.enqueue(part);
-      }
-      controller.close();
-    },
-  });
-}
-
-function extractSystemPrompt(options: unknown): string {
-  const prompt = (options as { prompt?: Array<{ role?: string; content?: unknown }> }).prompt;
-  if (!Array.isArray(prompt)) {
-    return "";
-  }
-
-  return prompt
-    .filter((entry) => entry?.role === "system" && typeof entry.content === "string")
-    .map((entry) => entry.content as string)
-    .join("\n\n");
-}
 
 /** Runs one generate() call through a stub provider and returns the system prompt it saw. */
 async function captureFactorySystemPrompt(
@@ -48,25 +22,7 @@ async function captureFactorySystemPrompt(
   mode: "generate" | "stream" = "generate",
   observeStreamBody?: (body: string) => void,
 ): Promise<string> {
-  let observed = "";
-  const model: ModelRuntime = {
-    provider: "hosted",
-    modelId: "hosted/call-context",
-    // deno-lint-ignore require-await
-    async doGenerate(options: unknown) {
-      observed = extractSystemPrompt(options);
-      return {
-        content: [{ type: "text", text: "done" }],
-        finishReason: "stop",
-        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-      };
-    },
-    // deno-lint-ignore require-await
-    async doStream(options: unknown) {
-      observed = extractSystemPrompt(options);
-      return { stream: createRuntimeStream([{ type: "finish", finishReason: "stop" }]) };
-    },
-  } as unknown as ModelRuntime;
+  const model = scriptedModel([{ text: "done" }], { modelId: "hosted/call-context" });
 
   const assistant = agent({
     ...config,
@@ -84,7 +40,7 @@ async function captureFactorySystemPrompt(
     await assistant.generate({ input: "Where does this project live?", context });
   }
 
-  return observed;
+  return model.systemPrompts().at(-1) ?? "";
 }
 
 describe("agent/factory call context", () => {
@@ -210,26 +166,10 @@ describe("agent/factory call context", () => {
   });
 
   it("uses the effective runtime provider key for structured cache metadata", async () => {
-    let observedSystem: unknown;
-    const runtime: ModelRuntime = {
+    const runtime = scriptedModel([{ text: "done" }], {
       provider: "claude",
       modelId: "claude-sonnet",
-      // deno-lint-ignore require-await
-      async doGenerate(options: unknown) {
-        observedSystem = (options as {
-          prompt?: Array<{ role?: string; content?: unknown; providerOptions?: unknown }>;
-        }).prompt?.filter((message) => message.role === "system");
-        return {
-          content: [{ type: "text", text: "done" }],
-          finishReason: "stop",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
-      },
-      // deno-lint-ignore require-await
-      async doStream() {
-        return { stream: createRuntimeStream([{ type: "finish", finishReason: "stop" }]) };
-      },
-    } as unknown as ModelRuntime;
+    });
     const unregister = registerModelProvider("bedrock", () => runtime);
 
     try {
@@ -251,6 +191,8 @@ describe("agent/factory call context", () => {
 
       await assistant.generate({ input: "Hello" });
 
+      const observedSystem = runtime.calls[0]?.prompt
+        .filter((message) => message.role === "system");
       if (!Array.isArray(observedSystem)) {
         throw new Error("Expected the model runtime to receive system messages");
       }

--- a/src/agent/runtime/delegate-remote-tool-context.test.ts
+++ b/src/agent/runtime/delegate-remote-tool-context.test.ts
@@ -1,6 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import type { ModelRuntime } from "#veryfront/provider";
 import type { RemoteToolSource, ToolExecutionContext } from "#veryfront/tool";
 import { agent } from "../index.ts";
 import { agentRegistry } from "../composition/index.ts";
@@ -8,37 +7,16 @@ import {
   type RuntimeRemoteToolConfig,
   VERYFRONT_STUDIO_MCP_SOURCE_ID,
 } from "./mcp-server-tool-sources.ts";
+import { scriptedModel } from "./model-runtime.test-helpers.ts";
 
 function eagerAgent(config: Parameters<typeof agent>[0]): ReturnType<typeof agent> {
   return agent({ ...config, __vfToolLoadingMode: "eager" } as Parameters<typeof agent>[0]);
 }
 
-function createRuntimeStream(parts: unknown[]) {
-  return new ReadableStream<unknown>({
-    start(controller) {
-      for (const part of parts) controller.enqueue(part);
-      controller.close();
-    },
-  });
-}
-
-function getRuntimeToolNames(options: unknown): string[] {
-  const tools = (options as { tools?: unknown }).tools;
-  return Array.isArray(tools)
-    ? tools.map((entry) =>
-      (entry as { name?: string; id?: string }).name ??
-        (entry as { name?: string; id?: string }).id ?? ""
-    )
-    : Object.keys((tools as Record<string, unknown> | undefined) ?? {});
-}
-
 Deno.test("local delegates inherit the trusted request-scoped MCP source", async () => {
   const childId = "request-scoped-mcp-child";
   const rootId = "request-scoped-mcp-root";
-  let childModelCalls = 0;
-  let rootModelCalls = 0;
   const listedBy: string[] = [];
-  let childRuntimeToolNames: string[] = [];
 
   const injectedStudioSource: RemoteToolSource = {
     id: VERYFRONT_STUDIO_MCP_SOURCE_ID,
@@ -60,59 +38,19 @@ Deno.test("local delegates inherit the trusted request-scoped MCP source", async
     executeTool: () => Promise.resolve({ ok: true }),
   };
 
-  const childModel: ModelRuntime = {
-    provider: "test",
-    modelId: "test/delegate-child",
-    doGenerate: () => Promise.reject(new Error("unused")),
-    doStream(options) {
-      childModelCalls++;
-      childRuntimeToolNames = getRuntimeToolNames(options);
-      return Promise.resolve({
-        stream: createRuntimeStream([
-          { type: "text-delta", text: "child completed" },
-          {
-            type: "finish",
-            finishReason: "stop",
-            usage: { inputTokens: 1, outputTokens: 1 },
-          },
-        ]),
-      });
+  const childModel = scriptedModel([
+    { text: "child completed" },
+  ], { provider: "test", modelId: "test/delegate-child", only: "stream" });
+  const rootModel = scriptedModel([
+    {
+      toolCalls: [{
+        id: "delegate-call-1",
+        name: `agent_${childId}`,
+        input: { input: "Read the project file" },
+      }],
     },
-  };
-  const rootModel: ModelRuntime = {
-    provider: "test",
-    modelId: "test/delegate-root",
-    doGenerate: () => Promise.reject(new Error("unused")),
-    doStream() {
-      rootModelCalls++;
-      return Promise.resolve({
-        stream: createRuntimeStream(
-          rootModelCalls === 1
-            ? [
-              {
-                type: "tool-call",
-                toolCallId: "delegate-call-1",
-                toolName: `agent_${childId}`,
-                input: { input: "Read the project file" },
-              },
-              {
-                type: "finish",
-                finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
-              },
-            ]
-            : [
-              { type: "text-delta", text: "root completed" },
-              {
-                type: "finish",
-                finishReason: "stop",
-                usage: { inputTokens: 1, outputTokens: 1 },
-              },
-            ],
-        ),
-      });
-    },
-  };
+    { text: "root completed" },
+  ], { provider: "test", modelId: "test/delegate-root", only: "stream" });
 
   eagerAgent({
     id: childId,
@@ -139,11 +77,11 @@ Deno.test("local delegates inherit the trusted request-scoped MCP source", async
       .toDataStreamResponse()
       .text();
 
-    assertEquals(childModelCalls, 1);
-    assertEquals(rootModelCalls, 2);
+    assertEquals(childModel.callCount, 1);
+    assertEquals(rootModel.callCount, 2);
     assertEquals(listedBy.includes(childId), true);
-    assertEquals(childRuntimeToolNames.includes("get_file"), true);
-    assertEquals(childRuntimeToolNames.includes("delete_file"), false);
+    assertEquals(childModel.toolNames(0).includes("get_file"), true);
+    assertEquals(childModel.toolNames(0).includes("delete_file"), false);
     assertEquals(body.includes("root completed"), true);
     assertEquals(body.includes('"type":"error"'), false);
   } finally {
@@ -155,8 +93,6 @@ Deno.test("local delegates inherit the trusted request-scoped MCP source", async
 Deno.test("local delegates execute inherited MCP tools with the parent credential identity", async () => {
   const childId = "request-scoped-auth-child";
   const rootId = "request-scoped-auth-root";
-  let childModelCalls = 0;
-  let rootModelCalls = 0;
   let executeContext: ToolExecutionContext | undefined;
 
   const injectedStudioSource: RemoteToolSource = {
@@ -173,74 +109,26 @@ Deno.test("local delegates execute inherited MCP tools with the parent credentia
     },
   };
 
-  const childModel: ModelRuntime = {
-    provider: "test",
-    modelId: "test/delegate-auth-child",
-    doGenerate: () => Promise.reject(new Error("unused")),
-    doStream() {
-      childModelCalls++;
-      return Promise.resolve({
-        stream: createRuntimeStream(
-          childModelCalls === 1
-            ? [
-              {
-                type: "tool-call",
-                toolCallId: "get-file-call-1",
-                toolName: "get_file",
-                input: { path: "README.md" },
-              },
-              {
-                type: "finish",
-                finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
-              },
-            ]
-            : [
-              { type: "text-delta", text: "child completed" },
-              {
-                type: "finish",
-                finishReason: "stop",
-                usage: { inputTokens: 1, outputTokens: 1 },
-              },
-            ],
-        ),
-      });
+  const childModel = scriptedModel([
+    {
+      toolCalls: [{
+        id: "get-file-call-1",
+        name: "get_file",
+        input: { path: "README.md" },
+      }],
     },
-  };
-  const rootModel: ModelRuntime = {
-    provider: "test",
-    modelId: "test/delegate-auth-root",
-    doGenerate: () => Promise.reject(new Error("unused")),
-    doStream() {
-      rootModelCalls++;
-      return Promise.resolve({
-        stream: createRuntimeStream(
-          rootModelCalls === 1
-            ? [
-              {
-                type: "tool-call",
-                toolCallId: "delegate-call-1",
-                toolName: `agent_${childId}`,
-                input: { input: "Read the project file" },
-              },
-              {
-                type: "finish",
-                finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
-              },
-            ]
-            : [
-              { type: "text-delta", text: "root completed" },
-              {
-                type: "finish",
-                finishReason: "stop",
-                usage: { inputTokens: 1, outputTokens: 1 },
-              },
-            ],
-        ),
-      });
+    { text: "child completed" },
+  ], { provider: "test", modelId: "test/delegate-auth-child", only: "stream" });
+  const rootModel = scriptedModel([
+    {
+      toolCalls: [{
+        id: "delegate-call-1",
+        name: `agent_${childId}`,
+        input: { input: "Read the project file" },
+      }],
     },
-  };
+    { text: "root completed" },
+  ], { provider: "test", modelId: "test/delegate-auth-root", only: "stream" });
 
   eagerAgent({
     id: childId,
@@ -273,8 +161,8 @@ Deno.test("local delegates execute inherited MCP tools with the parent credentia
       },
     })).toDataStreamResponse().text();
 
-    assertEquals(childModelCalls, 2);
-    assertEquals(rootModelCalls, 2);
+    assertEquals(childModel.callCount, 2);
+    assertEquals(rootModel.callCount, 2);
     assertEquals(body.includes("root completed"), true);
     assertEquals(executeContext?.authToken, "parent-token");
     assertEquals(executeContext?.runId, "parent-run");
@@ -290,11 +178,7 @@ Deno.test("local-only delegates preserve the trusted MCP source for a grandchild
   const grandchildId = "request-scoped-mcp-grandchild";
   const childId = "request-scoped-local-child";
   const rootId = "request-scoped-mcp-nested-root";
-  let grandchildModelCalls = 0;
-  let childModelCalls = 0;
-  let rootModelCalls = 0;
   const listedBy: string[] = [];
-  let grandchildRuntimeToolNames: string[] = [];
 
   const injectedStudioSource: RemoteToolSource = {
     id: VERYFRONT_STUDIO_MCP_SOURCE_ID,
@@ -309,93 +193,29 @@ Deno.test("local-only delegates preserve the trusted MCP source for a grandchild
     executeTool: () => Promise.resolve({ ok: true }),
   };
 
-  const grandchildModel: ModelRuntime = {
-    provider: "test",
-    modelId: "test/delegate-grandchild",
-    doGenerate: () => Promise.reject(new Error("unused")),
-    doStream(options) {
-      grandchildModelCalls++;
-      grandchildRuntimeToolNames = getRuntimeToolNames(options);
-      return Promise.resolve({
-        stream: createRuntimeStream([
-          { type: "text-delta", text: "grandchild completed" },
-          {
-            type: "finish",
-            finishReason: "stop",
-            usage: { inputTokens: 1, outputTokens: 1 },
-          },
-        ]),
-      });
+  const grandchildModel = scriptedModel([
+    { text: "grandchild completed" },
+  ], { provider: "test", modelId: "test/delegate-grandchild", only: "stream" });
+  const childModel = scriptedModel([
+    {
+      toolCalls: [{
+        id: "grandchild-call-1",
+        name: `agent_${grandchildId}`,
+        input: { input: "Read the project file" },
+      }],
     },
-  };
-  const childModel: ModelRuntime = {
-    provider: "test",
-    modelId: "test/delegate-intermediate",
-    doGenerate: () => Promise.reject(new Error("unused")),
-    doStream() {
-      childModelCalls++;
-      return Promise.resolve({
-        stream: createRuntimeStream(
-          childModelCalls === 1
-            ? [
-              {
-                type: "tool-call",
-                toolCallId: "grandchild-call-1",
-                toolName: `agent_${grandchildId}`,
-                input: { input: "Read the project file" },
-              },
-              {
-                type: "finish",
-                finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
-              },
-            ]
-            : [
-              { type: "text-delta", text: "child completed" },
-              {
-                type: "finish",
-                finishReason: "stop",
-                usage: { inputTokens: 1, outputTokens: 1 },
-              },
-            ],
-        ),
-      });
+    { text: "child completed" },
+  ], { provider: "test", modelId: "test/delegate-intermediate", only: "stream" });
+  const rootModel = scriptedModel([
+    {
+      toolCalls: [{
+        id: "child-call-1",
+        name: `agent_${childId}`,
+        input: { input: "Delegate to the grandchild" },
+      }],
     },
-  };
-  const rootModel: ModelRuntime = {
-    provider: "test",
-    modelId: "test/delegate-nested-root",
-    doGenerate: () => Promise.reject(new Error("unused")),
-    doStream() {
-      rootModelCalls++;
-      return Promise.resolve({
-        stream: createRuntimeStream(
-          rootModelCalls === 1
-            ? [
-              {
-                type: "tool-call",
-                toolCallId: "child-call-1",
-                toolName: `agent_${childId}`,
-                input: { input: "Delegate to the grandchild" },
-              },
-              {
-                type: "finish",
-                finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
-              },
-            ]
-            : [
-              { type: "text-delta", text: "root completed" },
-              {
-                type: "finish",
-                finishReason: "stop",
-                usage: { inputTokens: 1, outputTokens: 1 },
-              },
-            ],
-        ),
-      });
-    },
-  };
+    { text: "root completed" },
+  ], { provider: "test", modelId: "test/delegate-nested-root", only: "stream" });
 
   eagerAgent({
     id: grandchildId,
@@ -431,11 +251,11 @@ Deno.test("local-only delegates preserve the trusted MCP source for a grandchild
       .toDataStreamResponse()
       .text();
 
-    assertEquals(grandchildModelCalls, 1);
-    assertEquals(childModelCalls, 2);
-    assertEquals(rootModelCalls, 2);
+    assertEquals(grandchildModel.callCount, 1);
+    assertEquals(childModel.callCount, 2);
+    assertEquals(rootModel.callCount, 2);
     assertEquals(listedBy.includes(grandchildId), true);
-    assertEquals(grandchildRuntimeToolNames.includes("get_file"), true);
+    assertEquals(grandchildModel.toolNames(0).includes("get_file"), true);
     assertEquals(body.includes("root completed"), true);
     assertEquals(body.includes('"type":"error"'), false);
   } finally {

--- a/src/agent/runtime/memory-isolation.test.ts
+++ b/src/agent/runtime/memory-isolation.test.ts
@@ -3,15 +3,7 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { type ModelRuntime } from "#veryfront/provider";
 import { agent } from "../index.ts";
-
-function createRuntimeStream(parts: unknown[]) {
-  return new ReadableStream<unknown>({
-    start(controller) {
-      for (const part of parts) controller.enqueue(part);
-      controller.close();
-    },
-  });
-}
+import { type ScriptedModel, scriptedModel } from "./model-runtime.test-helpers.ts";
 
 /**
  * Read the most recent user-turn text from the model-runtime prompt. The stub
@@ -42,46 +34,15 @@ function lastUserText(options: unknown): string {
 
 /** A model that echoes the latest user message verbatim. */
 function echoModel(modelId: string): ModelRuntime {
-  return {
-    provider: "hosted",
-    modelId,
-    doGenerate(options: unknown) {
-      return Promise.resolve({
-        content: [{ type: "text", text: lastUserText(options) }],
-        finishReason: "stop",
-        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-      });
-    },
-    doStream(options: unknown) {
-      return Promise.resolve({
-        stream: createRuntimeStream([
-          { type: "text-delta", text: lastUserText(options) },
-          { type: "finish", finishReason: "stop", usage: { inputTokens: 1, outputTokens: 1 } },
-        ]),
-      });
-    },
-  } as ModelRuntime;
+  return scriptedModel(
+    [(options) => ({ text: lastUserText(options) })],
+    { modelId },
+  );
 }
 
 /** A model that records the maxOutputTokens the runtime resolved for the call. */
-function capturingModel(modelId: string, captured: { maxOutputTokens?: number }): ModelRuntime {
-  return {
-    provider: "hosted",
-    modelId,
-    doGenerate(options: unknown) {
-      captured.maxOutputTokens = (options as { maxOutputTokens?: number }).maxOutputTokens;
-      return Promise.resolve({
-        content: [{ type: "text", text: "ok" }],
-        finishReason: "stop",
-        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-      });
-    },
-    doStream() {
-      return Promise.resolve({
-        stream: createRuntimeStream([{ type: "finish", finishReason: "stop" }]),
-      });
-    },
-  } as ModelRuntime;
+function capturingModel(modelId: string): ScriptedModel {
+  return scriptedModel([{ text: "ok" }], { modelId });
 }
 
 const WORDS = ["APPLE", "BANANA", "CHERRY"];
@@ -167,31 +128,29 @@ describe("agent memory isolation (issue 2336)", () => {
   it("memory.enabled === false ignores leftover maxTokens for the output limit", async () => {
     // A disabled memory config must behave exactly like omitting `memory`: its
     // maxTokens (a conversation-window size) must not cap model output.
-    const disabledCapture: { maxOutputTokens?: number } = {};
+    const disabledModel = capturingModel("hosted/cap-disabled");
     const disabled = agent({
       id: "echo-disabled-maxtokens",
       model: "hosted/echo-disabled-maxtokens",
       system: "x",
       maxSteps: 1,
       memory: { type: "conversation", enabled: false, maxTokens: 100 },
-      resolveModelTransport: () =>
-        Promise.resolve({ model: capturingModel("hosted/cap-disabled", disabledCapture) }),
+      resolveModelTransport: () => Promise.resolve({ model: disabledModel }),
     });
 
-    const omittedCapture: { maxOutputTokens?: number } = {};
+    const omittedModel = capturingModel("hosted/cap-omitted");
     const omitted = agent({
       id: "echo-omitted-memory",
       model: "hosted/echo-omitted-memory",
       system: "x",
       maxSteps: 1,
-      resolveModelTransport: () =>
-        Promise.resolve({ model: capturingModel("hosted/cap-omitted", omittedCapture) }),
+      resolveModelTransport: () => Promise.resolve({ model: omittedModel }),
     });
 
     await disabled.generate({ input: "hi" });
     await omitted.generate({ input: "hi" });
 
-    assertEquals(disabledCapture.maxOutputTokens, omittedCapture.maxOutputTokens);
-    assertEquals(disabledCapture.maxOutputTokens === 100, false);
+    assertEquals(disabledModel.calls[0]?.maxOutputTokens, omittedModel.calls[0]?.maxOutputTokens);
+    assertEquals(disabledModel.calls[0]?.maxOutputTokens === 100, false);
   });
 });

--- a/src/agent/runtime/model-runtime.test-helpers.test.ts
+++ b/src/agent/runtime/model-runtime.test-helpers.test.ts
@@ -1,0 +1,68 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { scriptedModel, type ScriptedModelOptions } from "./model-runtime.test-helpers.ts";
+
+const CALL_OPTIONS = { prompt: [] } as const;
+
+describe("scriptedModel turn exhaustion", () => {
+  it("rejects an unexpected generate call", async () => {
+    const model = scriptedModel([{ text: "only turn" }], { only: "generate" });
+
+    await model.doGenerate(CALL_OPTIONS);
+    await assertRejects(
+      async () => await model.doGenerate(CALL_OPTIONS),
+      Error,
+      "scripted model: exhausted 1 turn(s); unexpected call 2",
+    );
+    assertEquals(model.callCount, 2);
+  });
+
+  it("rejects an unexpected stream call", async () => {
+    const model = scriptedModel([{ text: "only turn" }], { only: "stream" });
+
+    await model.doStream(CALL_OPTIONS);
+    await assertRejects(
+      async () => await model.doStream(CALL_OPTIONS),
+      Error,
+      "scripted model: exhausted 1 turn(s); unexpected call 2",
+    );
+    assertEquals(model.callCount, 2);
+  });
+
+  it("repeats the final turn only when explicitly requested", async () => {
+    const generateModel = scriptedModel([{ text: "repeat me" }], {
+      only: "generate",
+      repeatLastTurn: true,
+    });
+    const streamModel = scriptedModel([{ text: "repeat me" }], {
+      only: "stream",
+      repeatLastTurn: true,
+    });
+
+    const firstGenerate = await generateModel.doGenerate(CALL_OPTIONS);
+    const repeatedGenerate = await generateModel.doGenerate(CALL_OPTIONS);
+    const firstStream = await streamModel.doStream(CALL_OPTIONS);
+    const repeatedStream = await streamModel.doStream(CALL_OPTIONS);
+
+    assertEquals(repeatedGenerate, firstGenerate);
+    assertEquals(
+      await Array.fromAsync(repeatedStream.stream),
+      await Array.fromAsync(firstStream.stream),
+    );
+    assertEquals(generateModel.callCount, 2);
+    assertEquals(streamModel.callCount, 2);
+  });
+});
+
+const malformedOptions = {
+  // @ts-expect-error Provider metadata reconcilers must return metadata, not a string.
+  reconcileProviderMetadata: () => "invalid",
+} satisfies ScriptedModelOptions;
+void malformedOptions;
+
+const misspelledOptions = {
+  // @ts-expect-error Misspelled runtime extension options are rejected.
+  reconcileProviderMetdata: () => undefined,
+} satisfies ScriptedModelOptions;
+void misspelledOptions;

--- a/src/agent/runtime/model-runtime.test-helpers.ts
+++ b/src/agent/runtime/model-runtime.test-helpers.ts
@@ -10,7 +10,7 @@
  * stream decoder — impossible to compile.
  */
 import type { ModelRuntime, ModelRuntimeCallOptions } from "#veryfront/provider/types.ts";
-import type { RuntimeStreamPart } from "./runtime-tool-types.ts";
+import type { RuntimeStreamPart } from "#veryfront/agent/runtime/runtime-tool-types.ts";
 
 export type ScriptedUsage = NonNullable<
   Extract<RuntimeStreamPart, { type: "finish" }>["totalUsage"]

--- a/src/agent/runtime/model-runtime.test-helpers.ts
+++ b/src/agent/runtime/model-runtime.test-helpers.ts
@@ -1,0 +1,271 @@
+/**
+ * Shared scripted {@link ModelRuntime} fake for agent runtime tests.
+ *
+ * Tests script the model as a list of turns (the last turn repeats on further
+ * calls) instead of hand-writing `doGenerate`/`doStream` literals. Both hooks
+ * derive from the same script: `doGenerate` returns content parts and
+ * `doStream` emits {@link RuntimeStreamPart}s ending in a well-formed
+ * `finish` part. Typing the stream parts makes the historical
+ * `{ type: "text-delta", delta: ... }` mistake — silently dropped by the
+ * stream decoder — impossible to compile.
+ */
+import type { ModelRuntime, ModelRuntimeCallOptions } from "#veryfront/provider/types.ts";
+import type { RuntimeStreamPart } from "./runtime-tool-types.ts";
+
+export type ScriptedUsage = NonNullable<
+  Extract<RuntimeStreamPart, { type: "finish" }>["totalUsage"]
+>;
+
+export interface ScriptedToolCall {
+  id: string;
+  name: string;
+  /** Objects are JSON-stringified for `doGenerate` and passed raw to `doStream`. */
+  input: Record<string, unknown> | string;
+}
+
+export type ScriptedTurn =
+  | { text: string; finishReason?: string; providerMetadata?: Record<string, unknown> }
+  | {
+    toolCalls: readonly ScriptedToolCall[];
+    finishReason?: string;
+    providerMetadata?: Record<string, unknown>;
+  }
+  /** Stream-only escape hatch: the parts are emitted verbatim, nothing is appended. */
+  | { parts: readonly RuntimeStreamPart[] }
+  /** Generate-only escape hatch: the content parts are returned verbatim. */
+  | {
+    content: readonly unknown[];
+    finishReason?: string;
+    providerMetadata?: Record<string, unknown>;
+  }
+  /** Emit `parts` (if any), then stay open until the call's abort signal fires. */
+  | { hangUntilAbort: true; parts?: readonly RuntimeStreamPart[] };
+
+/** A turn, or a function deriving one from the captured call options. */
+export type ScriptedTurnScript =
+  | ScriptedTurn
+  | ((options: ModelRuntimeCallOptions, call: number) => ScriptedTurn);
+
+export interface ScriptedModelOptions {
+  provider?: string;
+  modelId?: string;
+  specificationVersion?: string;
+  /** Usage reported on every finish part and generate result. */
+  usage?: ScriptedUsage;
+  /** Restrict which hook the run may use; the other rejects loudly. */
+  only?: "generate" | "stream";
+  /** Extra runtime properties, e.g. `_reconcileProviderMetadata`. */
+  properties?: Record<string, unknown>;
+}
+
+export interface ScriptedModel extends ModelRuntime<ModelRuntimeCallOptions> {
+  /** Options of every model call, generate and stream alike, in call order. */
+  readonly calls: readonly ModelRuntimeCallOptions[];
+  readonly callCount: number;
+  /** The concatenated system-message text seen by each call. */
+  systemPrompts(): string[];
+  /** Sorted runtime tool names exposed to one call (default: the first). */
+  toolNames(call?: number): string[];
+}
+
+/** Close over `parts` in a stream, mirroring the copied `createRuntimeStream` family. */
+export function runtimeStream(parts: readonly RuntimeStreamPart[]): ReadableStream<unknown> {
+  return new ReadableStream<unknown>({
+    start(controller) {
+      for (const part of parts) controller.enqueue(part);
+      controller.close();
+    },
+  });
+}
+
+/** The concatenated system-message text in a model call's options. */
+export function systemPromptOf(options: unknown): string {
+  const prompt = (options as { prompt?: Array<{ role?: string; content?: unknown }> }).prompt;
+  if (!Array.isArray(prompt)) return "";
+  return prompt
+    .filter((entry) => entry?.role === "system" && typeof entry.content === "string")
+    .map((entry) => entry.content as string)
+    .join("\n\n");
+}
+
+/** Sorted runtime tool names in a model call's options. */
+export function toolNamesOf(options: unknown): string[] {
+  const tools = (options as { tools?: unknown }).tools;
+  if (Array.isArray(tools)) {
+    return tools.map((entry) => {
+      const toolEntry = entry as { name?: unknown; id?: unknown };
+      return typeof toolEntry.name === "string"
+        ? toolEntry.name
+        : typeof toolEntry.id === "string"
+        ? toolEntry.id
+        : "";
+    }).toSorted();
+  }
+  return Object.keys((tools as Record<string, unknown> | undefined) ?? {}).toSorted();
+}
+
+const DEFAULT_USAGE: ScriptedUsage = { inputTokens: 1, outputTokens: 1, totalTokens: 2 };
+
+function pendingStream(
+  abortSignal: AbortSignal | undefined,
+  parts: readonly RuntimeStreamPart[],
+): ReadableStream<unknown> {
+  return new ReadableStream<unknown>({
+    start(controller) {
+      for (const part of parts) controller.enqueue(part);
+      if (!abortSignal) return;
+      if (abortSignal.aborted) {
+        controller.error(abortSignal.reason);
+        return;
+      }
+      abortSignal.addEventListener("abort", () => {
+        controller.error(abortSignal.reason);
+      }, { once: true });
+    },
+  });
+}
+
+export function scriptedModel(
+  turns: readonly ScriptedTurnScript[],
+  options: ScriptedModelOptions = {},
+): ScriptedModel {
+  if (turns.length === 0) {
+    throw new Error("scriptedModel needs at least one turn");
+  }
+  const usage = options.usage ?? DEFAULT_USAGE;
+  const calls: ModelRuntimeCallOptions[] = [];
+
+  const nextTurn = (callOptions: ModelRuntimeCallOptions): ScriptedTurn => {
+    const call = calls.length;
+    calls.push(callOptions);
+    const scripted = turns[Math.min(call, turns.length - 1)]!;
+    return typeof scripted === "function" ? scripted(callOptions, call) : scripted;
+  };
+
+  return {
+    ...options.properties,
+    provider: options.provider ?? "hosted",
+    modelId: options.modelId ?? "hosted/scripted-model",
+    ...(options.specificationVersion === undefined
+      ? {}
+      : { specificationVersion: options.specificationVersion }),
+    get calls(): readonly ModelRuntimeCallOptions[] {
+      return calls;
+    },
+    get callCount(): number {
+      return calls.length;
+    },
+    systemPrompts(): string[] {
+      return calls.map(systemPromptOf);
+    },
+    toolNames(call = 0): string[] {
+      return toolNamesOf(calls[call] ?? {});
+    },
+    doGenerate(callOptions: ModelRuntimeCallOptions) {
+      if (options.only === "stream") {
+        return Promise.reject(new Error("scripted model: doGenerate must not be called"));
+      }
+      let turn: ScriptedTurn;
+      try {
+        turn = nextTurn(callOptions);
+      } catch (error) {
+        return Promise.reject(error);
+      }
+      if ("hangUntilAbort" in turn) {
+        return new Promise<never>((_, reject) => {
+          const signal = callOptions.abortSignal;
+          if (!signal) return;
+          if (signal.aborted) {
+            reject(signal.reason);
+            return;
+          }
+          signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        });
+      }
+      if ("parts" in turn) {
+        return Promise.reject(
+          new Error("scripted model: a parts turn is stream-only; script text or toolCalls"),
+        );
+      }
+      const metadata = turn.providerMetadata === undefined
+        ? {}
+        : { providerMetadata: turn.providerMetadata };
+      if ("content" in turn) {
+        return Promise.resolve({
+          content: [...turn.content],
+          finishReason: turn.finishReason ?? "stop",
+          usage,
+          ...metadata,
+        });
+      }
+      if ("text" in turn) {
+        return Promise.resolve({
+          content: [{ type: "text", text: turn.text }],
+          finishReason: turn.finishReason ?? "stop",
+          usage,
+          ...metadata,
+        });
+      }
+      return Promise.resolve({
+        content: turn.toolCalls.map((call) => ({
+          type: "tool-call",
+          toolCallId: call.id,
+          toolName: call.name,
+          input: typeof call.input === "string" ? call.input : JSON.stringify(call.input),
+        })),
+        finishReason: turn.finishReason ?? "tool-calls",
+        usage,
+        ...metadata,
+      });
+    },
+    doStream(callOptions: ModelRuntimeCallOptions) {
+      if (options.only === "generate") {
+        return Promise.reject(new Error("scripted model: doStream must not be called"));
+      }
+      let turn: ScriptedTurn;
+      try {
+        turn = nextTurn(callOptions);
+      } catch (error) {
+        return Promise.reject(error);
+      }
+      if ("hangUntilAbort" in turn) {
+        return Promise.resolve({
+          stream: pendingStream(callOptions.abortSignal, turn.parts ?? []),
+        });
+      }
+      if ("parts" in turn) {
+        return Promise.resolve({ stream: runtimeStream(turn.parts) });
+      }
+      if ("content" in turn) {
+        return Promise.reject(
+          new Error(
+            "scripted model: a content turn is generate-only; script text, toolCalls, or parts",
+          ),
+        );
+      }
+      const parts: RuntimeStreamPart[] = [];
+      let finishReason: string;
+      if ("text" in turn) {
+        parts.push({ type: "text-delta", text: turn.text });
+        finishReason = turn.finishReason ?? "stop";
+      } else {
+        for (const call of turn.toolCalls) {
+          parts.push({
+            type: "tool-call",
+            toolCallId: call.id,
+            toolName: call.name,
+            input: call.input,
+          });
+        }
+        finishReason = turn.finishReason ?? "tool-calls";
+      }
+      parts.push({
+        type: "finish",
+        finishReason,
+        totalUsage: usage,
+        ...(turn.providerMetadata === undefined ? {} : { providerMetadata: turn.providerMetadata }),
+      });
+      return Promise.resolve({ stream: runtimeStream(parts) });
+    },
+  };
+}

--- a/src/agent/runtime/model-runtime.test-helpers.ts
+++ b/src/agent/runtime/model-runtime.test-helpers.ts
@@ -1,8 +1,8 @@
 /**
  * Shared scripted {@link ModelRuntime} fake for agent runtime tests.
  *
- * Tests script the model as a list of turns (the last turn repeats on further
- * calls) instead of hand-writing `doGenerate`/`doStream` literals. Both hooks
+ * Tests script the model as a list of turns instead of hand-writing
+ * `doGenerate`/`doStream` literals. Both hooks
  * derive from the same script: `doGenerate` returns content parts and
  * `doStream` emits {@link RuntimeStreamPart}s ending in a well-formed
  * `finish` part. Typing the stream parts makes the historical
@@ -46,6 +46,11 @@ export type ScriptedTurnScript =
   | ScriptedTurn
   | ((options: ModelRuntimeCallOptions, call: number) => ScriptedTurn);
 
+export type ScriptedProviderMetadataReconciler = (input: {
+  providerMetadata: Record<string, unknown>;
+  suppressedToolCalls: readonly { id: string; name: string }[];
+}) => Record<string, unknown> | undefined;
+
 export interface ScriptedModelOptions {
   provider?: string;
   modelId?: string;
@@ -54,8 +59,10 @@ export interface ScriptedModelOptions {
   usage?: ScriptedUsage;
   /** Restrict which hook the run may use; the other rejects loudly. */
   only?: "generate" | "stream";
-  /** Extra runtime properties, e.g. `_reconcileProviderMetadata`. */
-  properties?: Record<string, unknown>;
+  /** Explicitly repeat the final scripted turn after the script is exhausted. */
+  repeatLastTurn?: boolean;
+  /** Reconcile provider metadata after the runtime suppresses tool calls. */
+  reconcileProviderMetadata?: ScriptedProviderMetadataReconciler;
 }
 
 export interface ScriptedModel extends ModelRuntime<ModelRuntimeCallOptions> {
@@ -138,12 +145,19 @@ export function scriptedModel(
   const nextTurn = (callOptions: ModelRuntimeCallOptions): ScriptedTurn => {
     const call = calls.length;
     calls.push(callOptions);
-    const scripted = turns[Math.min(call, turns.length - 1)]!;
+    const scripted = turns[call] ?? (options.repeatLastTurn ? turns.at(-1) : undefined);
+    if (scripted === undefined) {
+      throw new Error(
+        `scripted model: exhausted ${turns.length} turn(s); unexpected call ${call + 1}`,
+      );
+    }
     return typeof scripted === "function" ? scripted(callOptions, call) : scripted;
   };
 
   return {
-    ...options.properties,
+    ...(options.reconcileProviderMetadata === undefined
+      ? {}
+      : { _reconcileProviderMetadata: options.reconcileProviderMetadata }),
     provider: options.provider ?? "hosted",
     modelId: options.modelId ?? "hosted/scripted-model",
     ...(options.specificationVersion === undefined

--- a/src/agent/runtime/provider-metadata-continuation.test.ts
+++ b/src/agent/runtime/provider-metadata-continuation.test.ts
@@ -1,7 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import type { ModelRuntime } from "#veryfront/provider";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { tool } from "#veryfront/tool";
 import { agent } from "../index.ts";
@@ -9,6 +8,7 @@ import type { AgentRunModelCallContextEvent } from "../../runtime/model-call-con
 import { runWithRunEventSink } from "../../runtime/run-event-sink-context.ts";
 import { createGoogleModelRuntime } from "../../../extensions/ext-llm-google/src/google-provider.ts";
 import { reconcileGoogleProviderMetadata } from "../../../extensions/ext-llm-google/src/google-thought-signatures.ts";
+import { scriptedModel } from "./model-runtime.test-helpers.ts";
 
 function readRequestBody(init: unknown): string {
   return String((init as { body?: unknown } | undefined)?.body);
@@ -48,15 +48,6 @@ function readAllAssistantProviderMetadata(options: unknown): unknown[] {
   );
 }
 
-function streamFrom(parts: unknown[]): ReadableStream<unknown> {
-  return new ReadableStream({
-    start(controller) {
-      for (const part of parts) controller.enqueue(part);
-      controller.close();
-    },
-  });
-}
-
 async function withStreamLifecycleMode(
   mode: "legacy" | "active",
   operation: () => Promise<void>,
@@ -73,39 +64,14 @@ async function withStreamLifecycleMode(
 
 describe("agent provider metadata continuation", () => {
   it("replays generate provider metadata on the tool-result leg", async () => {
-    let callCount = 0;
-    let continuedProviderMetadata: unknown;
     const modelCallEvents: AgentRunModelCallContextEvent[] = [];
-    const model: ModelRuntime = {
-      provider: "google",
-      modelId: "gemini-3.5-flash",
-      async doGenerate(options: unknown) {
-        callCount++;
-        if (callCount === 1) {
-          return {
-            content: [{
-              type: "tool-call",
-              toolCallId: "lookup-1",
-              toolName: "lookup",
-              input: '{"query":"Veryfront"}',
-            }],
-            finishReason: "tool-calls",
-            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-            providerMetadata,
-          };
-        }
-
-        continuedProviderMetadata = readAssistantProviderMetadata(options);
-        return {
-          content: [{ type: "text", text: "Done" }],
-          finishReason: "stop",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
+    const model = scriptedModel([
+      {
+        toolCalls: [{ id: "lookup-1", name: "lookup", input: '{"query":"Veryfront"}' }],
+        providerMetadata,
       },
-      async doStream() {
-        throw new Error("not used");
-      },
-    };
+      { text: "Done" },
+    ], { provider: "google", modelId: "gemini-3.5-flash", only: "generate" });
     const assistant = agent({
       model: "google/gemini-3.5-flash",
       system: "Use the lookup tool.",
@@ -122,8 +88,8 @@ describe("agent provider metadata continuation", () => {
     );
 
     assertEquals(result.text, "Done");
-    assertEquals(callCount, 2);
-    assertEquals(continuedProviderMetadata, providerMetadata);
+    assertEquals(model.callCount, 2);
+    assertEquals(readAssistantProviderMetadata(model.calls[1]), providerMetadata);
     assertEquals(JSON.stringify(result.messages).includes("test-thought-signature"), false);
     assertEquals(JSON.stringify(modelCallEvents).includes("test-thought-signature"), false);
   });
@@ -141,53 +107,17 @@ describe("agent provider metadata continuation", () => {
         }],
       },
     };
-    let callCount = 0;
-    let secondRequestMetadata: unknown[] = [];
-    let thirdRequestMetadata: unknown[] = [];
-    const model: ModelRuntime = {
-      provider: "google",
-      modelId: "gemini-3.5-flash",
-      async doGenerate(options: unknown) {
-        callCount++;
-        if (callCount === 1) {
-          return {
-            content: [{
-              type: "tool-call",
-              toolCallId: "lookup-1",
-              toolName: "lookup",
-              input: '{"query":"Veryfront"}',
-            }],
-            finishReason: "tool-calls",
-            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-            providerMetadata,
-          };
-        }
-        if (callCount === 2) {
-          secondRequestMetadata = readAllAssistantProviderMetadata(options);
-          return {
-            content: [{
-              type: "tool-call",
-              toolCallId: "lookup-2",
-              toolName: "lookup",
-              input: '{"query":"Gemini"}',
-            }],
-            finishReason: "tool-calls",
-            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-            providerMetadata: secondProviderMetadata,
-          };
-        }
-
-        thirdRequestMetadata = readAllAssistantProviderMetadata(options);
-        return {
-          content: [{ type: "text", text: "Done" }],
-          finishReason: "stop",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
+    const model = scriptedModel([
+      {
+        toolCalls: [{ id: "lookup-1", name: "lookup", input: '{"query":"Veryfront"}' }],
+        providerMetadata,
       },
-      async doStream() {
-        throw new Error("not used");
+      {
+        toolCalls: [{ id: "lookup-2", name: "lookup", input: '{"query":"Gemini"}' }],
+        providerMetadata: secondProviderMetadata,
       },
-    };
+      { text: "Done" },
+    ], { provider: "google", modelId: "gemini-3.5-flash", only: "generate" });
     const assistant = agent({
       model: "google/gemini-3.5-flash",
       system: "Use the lookup tool twice.",
@@ -199,57 +129,25 @@ describe("agent provider metadata continuation", () => {
     const result = await assistant.generate({ input: "Look up Veryfront and Gemini" });
 
     assertEquals(result.text, "Done");
-    assertEquals(callCount, 3);
-    assertEquals(secondRequestMetadata, [providerMetadata]);
-    assertEquals(thirdRequestMetadata, [providerMetadata, secondProviderMetadata]);
+    assertEquals(model.callCount, 3);
+    assertEquals(readAllAssistantProviderMetadata(model.calls[1]), [providerMetadata]);
+    assertEquals(
+      readAllAssistantProviderMetadata(model.calls[2]),
+      [providerMetadata, secondProviderMetadata],
+    );
     assertEquals(JSON.stringify(result.messages).includes("test-thought-signature"), false);
   });
 
   for (const lifecycleMode of ["legacy", "active"] as const) {
     it(`replays streamed provider metadata through the ${lifecycleMode} lifecycle`, () =>
       withStreamLifecycleMode(lifecycleMode, async () => {
-        let callCount = 0;
-        let continuedProviderMetadata: unknown;
-        const model: ModelRuntime = {
-          provider: "google",
-          modelId: "gemini-3.5-flash",
-          async doGenerate() {
-            throw new Error("not used");
+        const model = scriptedModel([
+          {
+            toolCalls: [{ id: "lookup-1", name: "lookup", input: '{"query":"Veryfront"}' }],
+            providerMetadata,
           },
-          async doStream(options: unknown) {
-            callCount++;
-            if (callCount === 1) {
-              return {
-                stream: streamFrom([
-                  {
-                    type: "tool-call",
-                    toolCallId: "lookup-1",
-                    toolName: "lookup",
-                    input: '{"query":"Veryfront"}',
-                  },
-                  {
-                    type: "finish",
-                    finishReason: "tool-calls",
-                    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-                    providerMetadata,
-                  },
-                ]),
-              };
-            }
-
-            continuedProviderMetadata = readAssistantProviderMetadata(options);
-            return {
-              stream: streamFrom([
-                { type: "text-delta", delta: "Done" },
-                {
-                  type: "finish",
-                  finishReason: "stop",
-                  usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-                },
-              ]),
-            };
-          },
-        };
+          { text: "Done" },
+        ], { provider: "google", modelId: "gemini-3.5-flash", only: "stream" });
         const assistant = agent({
           model: "google/gemini-3.5-flash",
           system: "Use the lookup tool.",
@@ -262,8 +160,12 @@ describe("agent provider metadata continuation", () => {
           .toDataStreamResponse()
           .text();
 
-        assertEquals(callCount, 2);
-        assertEquals(continuedProviderMetadata, providerMetadata);
+        assertEquals(model.callCount, 2);
+        assertEquals(readAssistantProviderMetadata(model.calls[1]), providerMetadata);
+        // The mistyped `{ delta: "Done" }` part this fake used to emit was
+        // silently dropped by the active lifecycle decoder; the typed helper
+        // emits `{ text: "Done" }`, so the reply must now reach the client.
+        assertStringIncludes(body, "Done");
         assertEquals(body.includes("test-thought-signature"), false);
       }));
   }
@@ -345,62 +247,30 @@ describe("agent provider metadata continuation", () => {
   });
 
   it("asks the model runtime to reconcile metadata after suppressing a tool call", async () => {
-    let callCount = 0;
-    let continuedProviderMetadata: unknown = "unread";
     let reconciledSuppressions: unknown;
-    const model: ModelRuntime = {
+    const model = scriptedModel([
+      {
+        toolCalls: [
+          { id: "stale-1", name: "missing_tool", input: '{"query":"stale"}' },
+          { id: "lookup-1", name: "lookup", input: '{"query":"Veryfront"}' },
+        ],
+        providerMetadata,
+      },
+      { text: "Done" },
+    ], {
       provider: "google",
       modelId: "gemini-3.5-flash",
-      _reconcileProviderMetadata({ providerMetadata: metadata, suppressedToolCalls }: {
-        providerMetadata: Record<string, unknown>;
-        suppressedToolCalls: readonly { id: string; name: string }[];
-      }) {
-        reconciledSuppressions = suppressedToolCalls;
-        return metadata;
+      only: "stream",
+      properties: {
+        _reconcileProviderMetadata({ providerMetadata: metadata, suppressedToolCalls }: {
+          providerMetadata: Record<string, unknown>;
+          suppressedToolCalls: readonly { id: string; name: string }[];
+        }) {
+          reconciledSuppressions = suppressedToolCalls;
+          return metadata;
+        },
       },
-      async doGenerate() {
-        throw new Error("not used");
-      },
-      async doStream(options: unknown) {
-        callCount++;
-        if (callCount === 1) {
-          return {
-            stream: streamFrom([
-              {
-                type: "tool-call",
-                toolCallId: "stale-1",
-                toolName: "missing_tool",
-                input: '{"query":"stale"}',
-              },
-              {
-                type: "tool-call",
-                toolCallId: "lookup-1",
-                toolName: "lookup",
-                input: '{"query":"Veryfront"}',
-              },
-              {
-                type: "finish",
-                finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-                providerMetadata,
-              },
-            ]),
-          };
-        }
-
-        continuedProviderMetadata = readAssistantProviderMetadata(options);
-        return {
-          stream: streamFrom([
-            { type: "text-delta", delta: "Done" },
-            {
-              type: "finish",
-              finishReason: "stop",
-              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-            },
-          ]),
-        };
-      },
-    };
+    });
     const assistant = agent({
       model: "google/gemini-3.5-flash",
       system: "Use the lookup tool.",
@@ -413,61 +283,26 @@ describe("agent provider metadata continuation", () => {
       .toDataStreamResponse()
       .text();
 
-    assertEquals(callCount, 2);
+    assertEquals(model.callCount, 2);
     assertEquals(reconciledSuppressions, [{ id: "stale-1", name: "missing_tool" }]);
-    assertEquals(continuedProviderMetadata, providerMetadata);
+    assertEquals(readAssistantProviderMetadata(model.calls[1]), providerMetadata);
+    // Previously unasserted: the fake's mistyped `delta:` reply never reached
+    // the stream; the typed helper makes the reply observable.
+    assertStringIncludes(body, "Done");
     assertEquals(body.includes("test-thought-signature"), false);
   });
 
   it("falls back to synthesized replay for runtimes without a metadata reconciler", async () => {
-    let callCount = 0;
-    let continuedProviderMetadata: unknown = "unread";
-    const model: ModelRuntime = {
-      provider: "custom",
-      modelId: "custom-model",
-      async doGenerate() {
-        throw new Error("not used");
+    const model = scriptedModel([
+      {
+        toolCalls: [
+          { id: "stale-1", name: "missing_tool", input: '{"query":"stale"}' },
+          { id: "lookup-1", name: "lookup", input: '{"query":"Veryfront"}' },
+        ],
+        providerMetadata,
       },
-      async doStream(options: unknown) {
-        callCount++;
-        if (callCount === 1) {
-          return {
-            stream: streamFrom([
-              {
-                type: "tool-call",
-                toolCallId: "stale-1",
-                toolName: "missing_tool",
-                input: '{"query":"stale"}',
-              },
-              {
-                type: "tool-call",
-                toolCallId: "lookup-1",
-                toolName: "lookup",
-                input: '{"query":"Veryfront"}',
-              },
-              {
-                type: "finish",
-                finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-                providerMetadata,
-              },
-            ]),
-          };
-        }
-
-        continuedProviderMetadata = readAssistantProviderMetadata(options);
-        return {
-          stream: streamFrom([
-            { type: "text-delta", delta: "Done" },
-            {
-              type: "finish",
-              finishReason: "stop",
-              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-            },
-          ]),
-        };
-      },
-    };
+      { text: "Done" },
+    ], { provider: "custom", modelId: "custom-model", only: "stream" });
     const assistant = agent({
       model: "custom/custom-model",
       system: "Use the lookup tool.",
@@ -481,8 +316,8 @@ describe("agent provider metadata continuation", () => {
       .text();
 
     assertStringIncludes(body, "Done");
-    assertEquals(callCount, 2);
-    assertEquals(continuedProviderMetadata, undefined);
+    assertEquals(model.callCount, 2);
+    assertEquals(readAssistantProviderMetadata(model.calls[1]), undefined);
   });
 
   it("preserves the signed surviving Gemini call after suppressing an unavailable call", async () => {
@@ -582,65 +417,48 @@ describe("agent provider metadata continuation", () => {
     const signedProviderMetadata = {
       google: { rawAssistantParts: [signedThoughtPart, staleRawPart] },
     };
-    let callCount = 0;
-    let continuedProviderMetadata: unknown = "unread";
-    const model: ModelRuntime = {
+    const model = scriptedModel([
+      {
+        parts: [
+          { type: "reasoning-start", id: "reasoning-0" },
+          {
+            type: "reasoning-delta",
+            id: "reasoning-0",
+            delta: "Private reasoning.",
+          },
+          {
+            type: "reasoning-end",
+            id: "reasoning-0",
+            signature: "surviving-thought-signature",
+          },
+          {
+            type: "tool-call",
+            toolCallId: "stale-1",
+            toolName: "missing_tool",
+            input: '{"query":"stale"}',
+          },
+          {
+            type: "finish",
+            finishReason: "tool-calls",
+            totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            providerMetadata: signedProviderMetadata,
+          },
+        ],
+      },
+      { text: "Done" },
+    ], {
       provider: "google",
       modelId: "gemini-3.5-flash",
-      _reconcileProviderMetadata({ providerMetadata, suppressedToolCalls }: {
-        providerMetadata: Record<string, unknown>;
-        suppressedToolCalls: readonly { id: string; name: string }[];
-      }) {
-        return reconcileGoogleProviderMetadata(providerMetadata, suppressedToolCalls);
+      only: "stream",
+      properties: {
+        _reconcileProviderMetadata({ providerMetadata, suppressedToolCalls }: {
+          providerMetadata: Record<string, unknown>;
+          suppressedToolCalls: readonly { id: string; name: string }[];
+        }) {
+          return reconcileGoogleProviderMetadata(providerMetadata, suppressedToolCalls);
+        },
       },
-      async doGenerate() {
-        throw new Error("not used");
-      },
-      async doStream(options: unknown) {
-        callCount++;
-        if (callCount === 1) {
-          return {
-            stream: streamFrom([
-              { type: "reasoning-start", id: "reasoning-0" },
-              {
-                type: "reasoning-delta",
-                id: "reasoning-0",
-                delta: "Private reasoning.",
-              },
-              {
-                type: "reasoning-end",
-                id: "reasoning-0",
-                signature: "surviving-thought-signature",
-              },
-              {
-                type: "tool-call",
-                toolCallId: "stale-1",
-                toolName: "missing_tool",
-                input: '{"query":"stale"}',
-              },
-              {
-                type: "finish",
-                finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-                providerMetadata: signedProviderMetadata,
-              },
-            ]),
-          };
-        }
-
-        continuedProviderMetadata = readAssistantProviderMetadata(options);
-        return {
-          stream: streamFrom([
-            { type: "text-delta", delta: "Done" },
-            {
-              type: "finish",
-              finishReason: "stop",
-              usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-            },
-          ]),
-        };
-      },
-    };
+    });
     const assistant = agent({
       model: "google/gemini-3.5-flash",
       system: "Use the lookup tool.",
@@ -654,8 +472,8 @@ describe("agent provider metadata continuation", () => {
       .text();
 
     assertStringIncludes(body, "Done");
-    assertEquals(callCount, 2);
-    assertEquals(continuedProviderMetadata, {
+    assertEquals(model.callCount, 2);
+    assertEquals(readAssistantProviderMetadata(model.calls[1]), {
       google: {
         rawAssistantParts: [signedThoughtPart],
         rawAssistantPartIndexes: [0],

--- a/src/agent/runtime/provider-metadata-continuation.test.ts
+++ b/src/agent/runtime/provider-metadata-continuation.test.ts
@@ -261,14 +261,9 @@ describe("agent provider metadata continuation", () => {
       provider: "google",
       modelId: "gemini-3.5-flash",
       only: "stream",
-      properties: {
-        _reconcileProviderMetadata({ providerMetadata: metadata, suppressedToolCalls }: {
-          providerMetadata: Record<string, unknown>;
-          suppressedToolCalls: readonly { id: string; name: string }[];
-        }) {
-          reconciledSuppressions = suppressedToolCalls;
-          return metadata;
-        },
+      reconcileProviderMetadata({ providerMetadata: metadata, suppressedToolCalls }) {
+        reconciledSuppressions = suppressedToolCalls;
+        return metadata;
       },
     });
     const assistant = agent({
@@ -450,13 +445,8 @@ describe("agent provider metadata continuation", () => {
       provider: "google",
       modelId: "gemini-3.5-flash",
       only: "stream",
-      properties: {
-        _reconcileProviderMetadata({ providerMetadata, suppressedToolCalls }: {
-          providerMetadata: Record<string, unknown>;
-          suppressedToolCalls: readonly { id: string; name: string }[];
-        }) {
-          return reconcileGoogleProviderMetadata(providerMetadata, suppressedToolCalls);
-        },
+      reconcileProviderMetadata({ providerMetadata, suppressedToolCalls }) {
+        return reconcileGoogleProviderMetadata(providerMetadata, suppressedToolCalls);
       },
     });
     const assistant = agent({

--- a/src/agent/runtime/provider-transport.test.ts
+++ b/src/agent/runtime/provider-transport.test.ts
@@ -1,11 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
-import { clearModelProviders, type ModelRuntime, registerModelProvider } from "#veryfront/provider";
+import { clearModelProviders, registerModelProvider } from "#veryfront/provider";
 import { agent } from "../factory.ts";
 import type { AgentRunModelCallContextEvent } from "../../runtime/model-call-context.ts";
 import { runWithRunEventSink } from "../../runtime/run-event-sink-context.ts";
 import type { ModelTransportRequest } from "../types.ts";
+import { scriptedModel } from "./model-runtime.test-helpers.ts";
 import {
   __registerLogRecordEmitter,
   __resetLoggerConfigForTests,
@@ -21,22 +22,6 @@ function captureLogs(): LogEntry[] {
   __resetLoggerConfigForTests();
   __registerLogRecordEmitter((entry) => entries.push(entry));
   return entries;
-}
-
-function createTextStream(
-  parts: Array<
-    | { type: "text-delta"; text: string }
-    | { type: "finish"; finishReason?: string; totalUsage?: Record<string, unknown> }
-  >,
-) {
-  return new ReadableStream<unknown>({
-    start(controller) {
-      for (const part of parts) {
-        controller.enqueue(part);
-      }
-      controller.close();
-    },
-  });
 }
 
 function normalizeRunRuntimeContext(
@@ -68,26 +53,11 @@ describe("agent provider transport hooks", () => {
   });
 
   it("lets hosts override the model runtime and transport options for generate()", async () => {
-    const captured: {
-      request?: ModelTransportRequest;
-      generateOptions?: Record<string, unknown>;
-    } = {};
-
-    const transportModel: ModelRuntime = {
-      provider: "hosted",
+    const captured: { request?: ModelTransportRequest } = {};
+    const transportModel = scriptedModel([{ text: "hooked generate" }], {
       modelId: "hosted/gateway-model",
-      async doGenerate(options: unknown) {
-        captured.generateOptions = options as Record<string, unknown>;
-        return {
-          content: [{ type: "text", text: "hooked generate" }],
-          finishReason: "stop",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
-      },
-      async doStream() {
-        return { stream: createTextStream([{ type: "finish" }]) };
-      },
-    };
+      only: "generate",
+    });
 
     const assistant = agent({
       model: "host/test-model",
@@ -120,13 +90,14 @@ describe("agent provider transport hooks", () => {
       mode: "generate",
     });
 
-    assertExists(captured.generateOptions);
-    assertEquals(captured.generateOptions.temperature, 0);
+    const generateOptions = transportModel.calls[0];
+    assertExists(generateOptions);
+    assertEquals(generateOptions.temperature, 0);
     assertEquals(
-      new Headers(captured.generateOptions.headers as HeadersInit).get("Authorization"),
+      new Headers(generateOptions.headers).get("Authorization"),
       "Bearer vf_test",
     );
-    assertEquals(captured.generateOptions.providerOptions, {
+    assertEquals(generateOptions.providerOptions, {
       veryfront: { projectSlug: "demo-project" },
     });
   });
@@ -135,24 +106,12 @@ describe("agent provider transport hooks", () => {
     const contexts: AgentRunModelCallContextEvent[] = [];
 
     for (const provider of ["cloud", "local"] as const) {
-      let runtimePrompt: unknown;
-      const runtime: ModelRuntime = {
-        provider,
-        modelId: `${provider}/context-parity`,
-        async doGenerate(options: unknown) {
-          const prompt = (options as { prompt: unknown }).prompt;
-          runtimePrompt = prompt;
-          assertEquals(contexts.at(-1)?.messages, prompt);
-          return {
-            content: [{ type: "text", text: "done" }],
-            finishReason: "stop",
-            usage: {},
-          };
+      const runtime = scriptedModel([
+        (options) => {
+          assertEquals<unknown>(contexts.at(-1)?.messages, options.prompt);
+          return { text: "done" };
         },
-        async doStream() {
-          return { stream: createTextStream([{ type: "finish" }]) };
-        },
-      };
+      ], { provider, modelId: `${provider}/context-parity`, only: "generate" });
       const assistant = agent({
         model: `${provider}/context-parity`,
         system: "Follow the same instructions.",
@@ -167,7 +126,7 @@ describe("agent provider transport hooks", () => {
         () => assistant.generate({ input: "Use the same normalized input." }),
       );
 
-      assertEquals(contexts.at(-1)?.messages, runtimePrompt);
+      assertEquals<unknown>(contexts.at(-1)?.messages, runtime.calls[0]?.prompt);
     }
 
     assertEquals(contexts.length, 2);
@@ -219,20 +178,11 @@ describe("agent provider transport hooks", () => {
 
   it("logs generate model remap diagnostics at debug level", async () => {
     const entries = captureLogs();
-    registerModelProvider("google", (modelId) => ({
-      provider: "google",
-      modelId: `google/${modelId}`,
-      async doGenerate() {
-        return {
-          content: [{ type: "text", text: "remapped generate" }],
-          finishReason: "stop",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
-      },
-      async doStream() {
-        return { stream: createTextStream([{ type: "finish" }]) };
-      },
-    }));
+    registerModelProvider("google", (modelId) =>
+      scriptedModel([{ text: "remapped generate" }], {
+        provider: "google",
+        modelId: `google/${modelId}`,
+      }));
 
     const assistant = agent({
       model: "google-ai-studio/gemini-3.1-pro-preview",
@@ -249,25 +199,10 @@ describe("agent provider transport hooks", () => {
   });
 
   it("uses the agent-configured temperature for generate()", async () => {
-    const captured: {
-      generateOptions?: Record<string, unknown>;
-    } = {};
-
-    const transportModel: ModelRuntime = {
-      provider: "hosted",
+    const transportModel = scriptedModel([{ text: "custom temperature" }], {
       modelId: "hosted/gateway-model",
-      async doGenerate(options: unknown) {
-        captured.generateOptions = options as Record<string, unknown>;
-        return {
-          content: [{ type: "text", text: "custom temperature" }],
-          finishReason: "stop",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
-      },
-      async doStream() {
-        return { stream: createTextStream([{ type: "finish" }]) };
-      },
-    };
+      only: "generate",
+    });
 
     const assistant = agent({
       model: "host/test-model",
@@ -278,30 +213,16 @@ describe("agent provider transport hooks", () => {
 
     await assistant.generate({ input: "Hello" });
 
-    assertExists(captured.generateOptions);
-    assertEquals(captured.generateOptions.temperature, 0.2);
+    const generateOptions = transportModel.calls[0];
+    assertExists(generateOptions);
+    assertEquals(generateOptions.temperature, 0.2);
   });
 
   it("omits temperature for Claude Opus 4.8 generate requests", async () => {
-    const captured: {
-      generateOptions?: Record<string, unknown>;
-    } = {};
-
-    const transportModel: ModelRuntime = {
-      provider: "hosted",
+    const transportModel = scriptedModel([{ text: "opus generate" }], {
       modelId: "hosted/gateway-model",
-      async doGenerate(options: unknown) {
-        captured.generateOptions = options as Record<string, unknown>;
-        return {
-          content: [{ type: "text", text: "opus generate" }],
-          finishReason: "stop",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
-      },
-      async doStream() {
-        return { stream: createTextStream([{ type: "finish" }]) };
-      },
-    };
+      only: "generate",
+    });
 
     const assistant = agent({
       model: "anthropic/claude-opus-4-8",
@@ -312,35 +233,16 @@ describe("agent provider transport hooks", () => {
 
     await assistant.generate({ input: "Hello" });
 
-    assertExists(captured.generateOptions);
-    assertEquals("temperature" in captured.generateOptions, false);
+    const generateOptions = transportModel.calls[0];
+    assertExists(generateOptions);
+    assertEquals("temperature" in generateOptions, false);
   });
 
   it("omits temperature for Claude Opus 4.8 stream requests", async () => {
-    const captured: {
-      streamOptions?: Record<string, unknown>;
-    } = {};
-
-    const transportModel: ModelRuntime = {
-      provider: "hosted",
+    const transportModel = scriptedModel([{ text: "opus stream" }], {
       modelId: "hosted/gateway-model",
-      async doGenerate() {
-        return {
-          content: [{ type: "text", text: "unused" }],
-          finishReason: "stop",
-          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-        };
-      },
-      async doStream(options: unknown) {
-        captured.streamOptions = options as Record<string, unknown>;
-        return {
-          stream: createTextStream([
-            { type: "text-delta", text: "opus stream" },
-            { type: "finish" },
-          ]),
-        };
-      },
-    };
+      only: "stream",
+    });
 
     const assistant = agent({
       model: "anthropic/claude-opus-4-8",
@@ -353,39 +255,22 @@ describe("agent provider transport hooks", () => {
     const body = await response.text();
 
     assertStringIncludes(body, "opus stream");
-    assertExists(captured.streamOptions);
-    assertEquals("temperature" in captured.streamOptions, false);
+    const streamOptions = transportModel.calls[0];
+    assertExists(streamOptions);
+    assertEquals("temperature" in streamOptions, false);
   });
 
   it("emits accumulated usage on stream message-finish events", async () => {
-    const transportModel: ModelRuntime = {
-      provider: "hosted",
+    const transportModel = scriptedModel([{ text: "usage stream" }], {
       modelId: "hosted/gateway-model",
-      async doGenerate() {
-        return {
-          content: [{ type: "text", text: "unused" }],
-          finishReason: "stop",
-          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-        };
+      only: "stream",
+      usage: {
+        inputTokens: 12,
+        outputTokens: 8,
+        totalTokens: 20,
+        costCredits: 0.25,
       },
-      async doStream() {
-        return {
-          stream: createTextStream([
-            { type: "text-delta", text: "usage stream" },
-            {
-              type: "finish",
-              finishReason: "stop",
-              totalUsage: {
-                inputTokens: 12,
-                outputTokens: 8,
-                totalTokens: 20,
-                costCredits: 0.25,
-              },
-            },
-          ]),
-        };
-      },
-    };
+    });
 
     const assistant = agent({
       model: "host/test-model",
@@ -405,25 +290,10 @@ describe("agent provider transport hooks", () => {
   });
 
   it("omits temperature for Veryfront Cloud Claude Opus 4.8 generate requests", async () => {
-    const captured: {
-      generateOptions?: Record<string, unknown>;
-    } = {};
-
-    const transportModel: ModelRuntime = {
-      provider: "hosted",
+    const transportModel = scriptedModel([{ text: "cloud opus generate" }], {
       modelId: "hosted/gateway-model",
-      async doGenerate(options: unknown) {
-        captured.generateOptions = options as Record<string, unknown>;
-        return {
-          content: [{ type: "text", text: "cloud opus generate" }],
-          finishReason: "stop",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
-      },
-      async doStream() {
-        return { stream: createTextStream([{ type: "finish" }]) };
-      },
-    };
+      only: "generate",
+    });
 
     const assistant = agent({
       model: "veryfront-cloud/anthropic/claude-opus-4-8",
@@ -434,30 +304,16 @@ describe("agent provider transport hooks", () => {
 
     await assistant.generate({ input: "Hello" });
 
-    assertExists(captured.generateOptions);
-    assertEquals("temperature" in captured.generateOptions, false);
+    const generateOptions = transportModel.calls[0];
+    assertExists(generateOptions);
+    assertEquals("temperature" in generateOptions, false);
   });
 
   it("uses fixed temperature for Veryfront Cloud Kimi 2.6 generate requests", async () => {
-    const captured: {
-      generateOptions?: Record<string, unknown>;
-    } = {};
-
-    const transportModel: ModelRuntime = {
-      provider: "hosted",
+    const transportModel = scriptedModel([{ text: "kimi generate" }], {
       modelId: "hosted/gateway-model",
-      async doGenerate(options: unknown) {
-        captured.generateOptions = options as Record<string, unknown>;
-        return {
-          content: [{ type: "text", text: "kimi generate" }],
-          finishReason: "stop",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
-      },
-      async doStream() {
-        return { stream: createTextStream([{ type: "finish" }]) };
-      },
-    };
+      only: "generate",
+    });
 
     const assistant = agent({
       model: "veryfront-cloud/moonshotai/kimi-k2.6",
@@ -468,30 +324,16 @@ describe("agent provider transport hooks", () => {
 
     await assistant.generate({ input: "Hello" });
 
-    assertExists(captured.generateOptions);
-    assertEquals(captured.generateOptions.temperature, 1);
+    const generateOptions = transportModel.calls[0];
+    assertExists(generateOptions);
+    assertEquals(generateOptions.temperature, 1);
   });
 
   it("uses non-thinking fixed temperature for Veryfront Cloud Kimi 2.6 generate requests", async () => {
-    const captured: {
-      generateOptions?: Record<string, unknown>;
-    } = {};
-
-    const transportModel: ModelRuntime = {
-      provider: "hosted",
+    const transportModel = scriptedModel([{ text: "kimi non-thinking generate" }], {
       modelId: "hosted/gateway-model",
-      async doGenerate(options: unknown) {
-        captured.generateOptions = options as Record<string, unknown>;
-        return {
-          content: [{ type: "text", text: "kimi non-thinking generate" }],
-          finishReason: "stop",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
-      },
-      async doStream() {
-        return { stream: createTextStream([{ type: "finish" }]) };
-      },
-    };
+      only: "generate",
+    });
 
     const providerOptions = {
       openai: {
@@ -509,9 +351,10 @@ describe("agent provider transport hooks", () => {
 
     await assistant.generate({ input: "Hello" });
 
-    assertExists(captured.generateOptions);
-    assertEquals(captured.generateOptions.temperature, 0.6);
-    assertEquals(captured.generateOptions.providerOptions, providerOptions);
+    const generateOptions = transportModel.calls[0];
+    assertExists(generateOptions);
+    assertEquals(generateOptions.temperature, 0.6);
+    assertEquals(generateOptions.providerOptions, providerOptions);
   });
 
   it("preserves temperature for other hosted models", async () => {
@@ -522,25 +365,10 @@ describe("agent provider transport hooks", () => {
     ];
 
     for (const testCase of cases) {
-      const captured: {
-        generateOptions?: Record<string, unknown>;
-      } = {};
-
-      const transportModel: ModelRuntime = {
-        provider: "hosted",
+      const transportModel = scriptedModel([{ text: "other model generate" }], {
         modelId: "hosted/gateway-model",
-        async doGenerate(options: unknown) {
-          captured.generateOptions = options as Record<string, unknown>;
-          return {
-            content: [{ type: "text", text: "other model generate" }],
-            finishReason: "stop",
-            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-          };
-        },
-        async doStream() {
-          return { stream: createTextStream([{ type: "finish" }]) };
-        },
-      };
+        only: "generate",
+      });
 
       const assistant = agent({
         model: testCase.model,
@@ -551,37 +379,21 @@ describe("agent provider transport hooks", () => {
 
       await assistant.generate({ input: "Hello" });
 
-      assertExists(captured.generateOptions);
-      assertEquals(captured.generateOptions.temperature, testCase.temperature);
+      const generateOptions = transportModel.calls[0];
+      assertExists(generateOptions);
+      assertEquals(generateOptions.temperature, testCase.temperature);
     }
   });
 
   it("lets hosts attach request-aware transport options while still using the registered provider runtime for stream()", async () => {
-    const captured: {
-      request?: ModelTransportRequest;
-      streamOptions?: Record<string, unknown>;
-    } = {};
-
-    registerModelProvider("transport-stream-test", (_modelId) => ({
+    const captured: { request?: ModelTransportRequest } = {};
+    const providerModel = scriptedModel([{ text: "streamed via provider hook" }], {
       provider: "transport-stream-test",
       modelId: "transport-stream-test/demo",
-      async doGenerate() {
-        return {
-          content: [{ type: "text", text: "unused" }],
-          finishReason: "stop",
-          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-        };
-      },
-      async doStream(options: unknown) {
-        captured.streamOptions = options as Record<string, unknown>;
-        return {
-          stream: createTextStream([
-            { type: "text-delta", text: "streamed via provider hook" },
-            { type: "finish" },
-          ]),
-        };
-      },
-    }));
+      only: "stream",
+    });
+
+    registerModelProvider("transport-stream-test", (_modelId) => providerModel);
 
     const assistant = agent({
       model: "transport-stream-test/demo",
@@ -614,37 +426,25 @@ describe("agent provider transport hooks", () => {
       mode: "stream",
     });
 
-    assertExists(captured.streamOptions);
+    const streamOptions = providerModel.calls[0];
+    assertExists(streamOptions);
     assertEquals(
-      new Headers(captured.streamOptions.headers as HeadersInit).get("x-veryfront-project"),
+      new Headers(streamOptions.headers).get("x-veryfront-project"),
       "demo-project",
     );
-    assertEquals(captured.streamOptions.providerOptions, {
+    assertEquals(streamOptions.providerOptions, {
       gateway: { branchId: "branch_123" },
     });
   });
 
   it("logs stream model remap diagnostics at debug level", async () => {
     const entries = captureLogs();
-    registerModelProvider("google", (modelId) => ({
-      provider: "google",
-      modelId: `google/${modelId}`,
-      async doGenerate() {
-        return {
-          content: [{ type: "text", text: "unused" }],
-          finishReason: "stop",
-          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-        };
-      },
-      async doStream() {
-        return {
-          stream: createTextStream([
-            { type: "text-delta", text: "remapped stream" },
-            { type: "finish" },
-          ]),
-        };
-      },
-    }));
+    registerModelProvider("google", (modelId) =>
+      scriptedModel([{ text: "remapped stream" }], {
+        provider: "google",
+        modelId: `google/${modelId}`,
+        only: "stream",
+      }));
 
     const assistant = agent({
       model: "google-ai-studio/gemini-3.1-pro-preview",

--- a/src/agent/runtime/refresh.test.ts
+++ b/src/agent/runtime/refresh.test.ts
@@ -15,6 +15,12 @@ import type {
   ToolExecutionResultRequest,
 } from "../types.ts";
 import type { RuntimeRemoteToolConfig } from "./mcp-server-tool-sources.ts";
+import {
+  runtimeStream,
+  scriptedModel,
+  systemPromptOf,
+  toolNamesOf,
+} from "./model-runtime.test-helpers.ts";
 import type { TextGenerationRuntimeMessage } from "./text-generation-runtime-message-types.ts";
 import { flattenSystemInstructions, withRuntimeToolInventory } from "./tool-inventory.ts";
 import { getRuntimeProjectSkillCatalog } from "./project-skill-catalog.ts";
@@ -262,17 +268,6 @@ describe("runtime-state mutable data cloning", () => {
   });
 });
 
-function createRuntimeStream(parts: unknown[]) {
-  return new ReadableStream<unknown>({
-    start(controller) {
-      for (const part of parts) {
-        controller.enqueue(part);
-      }
-      controller.close();
-    },
-  });
-}
-
 async function readResponseBody(
   response: Response,
   onText?: (text: string) => void,
@@ -291,34 +286,6 @@ async function readResponseBody(
     body += text;
     onText?.(body);
   }
-}
-
-function extractSystemPrompt(options: unknown): string {
-  const prompt = (options as { prompt?: Array<{ role?: string; content?: unknown }> })
-    .prompt;
-  if (!Array.isArray(prompt)) {
-    return "";
-  }
-
-  return prompt
-    .filter((entry) => entry?.role === "system" && typeof entry.content === "string")
-    .map((entry) => entry.content as string)
-    .join("\n\n");
-}
-
-function extractRuntimeToolNames(options: unknown): string[] {
-  const tools = (options as { tools?: unknown }).tools;
-  if (Array.isArray(tools)) {
-    return tools.map((entry) => {
-      const toolEntry = entry as { name?: unknown; id?: unknown };
-      return typeof toolEntry.name === "string"
-        ? toolEntry.name
-        : typeof toolEntry.id === "string"
-        ? toolEntry.id
-        : "";
-    }).sort();
-  }
-  return Object.keys((tools as Record<string, unknown> | undefined) ?? {}).sort();
 }
 
 function supplierInvoiceEvidenceMessages(): Message[] {
@@ -400,37 +367,13 @@ function submittedFormWithActiveSkillMessages(): Message[] {
 describe("agent runtime refresh hooks", () => {
   it("keeps one authoritative UTC snapshot across refreshed scheduled-run steps", async () => {
     using time = new FakeTime(new Date("2026-07-19T07:30:00.000Z"));
-    const observedSystems: string[] = [];
-    let callCount = 0;
-    const model: ModelRuntime = {
-      provider: "hosted",
-      modelId: "hosted/runtime-context-snapshot",
-      async doGenerate(options: unknown) {
-        observedSystems.push(extractSystemPrompt(options));
-        callCount++;
-        if (callCount === 1) {
-          time.tick(24 * 60 * 60 * 1_000);
-          return {
-            content: [{
-              type: "tool-call",
-              toolCallId: "continue-1",
-              toolName: "continue_run",
-              input: "{}",
-            }],
-            finishReason: "tool-calls",
-            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-          };
-        }
-        return {
-          content: [{ type: "text", text: "2026-07-19" }],
-          finishReason: "stop",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
+    const model = scriptedModel([
+      () => {
+        time.tick(24 * 60 * 60 * 1_000);
+        return { toolCalls: [{ id: "continue-1", name: "continue_run", input: {} }] };
       },
-      async doStream() {
-        return { stream: createRuntimeStream([{ type: "finish", finishReason: "stop" }]) };
-      },
-    };
+      { text: "2026-07-19" },
+    ], { modelId: "hosted/runtime-context-snapshot", only: "generate" });
     const continueRun = tool({
       id: "continue_run",
       description: "Continue the run",
@@ -455,6 +398,7 @@ describe("agent runtime refresh hooks", () => {
       context: { scheduleId: "schedule-1" },
     });
 
+    const observedSystems = model.systemPrompts();
     assertEquals(observedSystems.length, 2);
     for (const system of observedSystems) {
       assertEquals(system.match(/<runtime_context>/g)?.length, 1);
@@ -492,7 +436,7 @@ describe("agent runtime refresh hooks", () => {
 
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               { type: "text-delta", text: "I will reload the skill." },
               { type: "tool-input-start", id: "tc-stale", toolName: "stale_tool" },
               { type: "tool-input-delta", id: "tc-stale", delta: '{"query":"create-agent"}' },
@@ -509,7 +453,7 @@ describe("agent runtime refresh hooks", () => {
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "Recovered." },
             { type: "finish", finishReason: "stop" },
           ]),
@@ -582,7 +526,7 @@ describe("agent runtime refresh hooks", () => {
 
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               {
                 type: "tool-call",
                 toolCallId: "tc-stale",
@@ -607,7 +551,7 @@ describe("agent runtime refresh hooks", () => {
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "Recovered." },
             { type: "finish", finishReason: "stop" },
           ]),
@@ -692,30 +636,15 @@ describe("agent runtime refresh hooks", () => {
 
   it("notifies configured hooks after generate() executes a tool", async () => {
     const toolResults: ToolExecutionResultRequest[] = [];
-    const model: ModelRuntime = {
-      provider: "hosted",
-      modelId: "hosted/tool-result-generate",
-      async doGenerate() {
-        return {
-          content: [{
-            type: "tool-call",
-            toolCallId: "write-1",
-            toolName: "write_report",
-            input: '{"path":"research/report.md"}',
-          }],
-          finishReason: "tool-calls",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
+    const model = scriptedModel([
+      {
+        toolCalls: [{
+          id: "write-1",
+          name: "write_report",
+          input: '{"path":"research/report.md"}',
+        }],
       },
-      async doStream() {
-        return {
-          stream: createRuntimeStream([{
-            type: "finish",
-            finishReason: "stop",
-          }]),
-        };
-      },
-    };
+    ], { modelId: "hosted/tool-result-generate", only: "generate" });
 
     const writeReport = tool({
       id: "write_report",
@@ -755,37 +684,16 @@ describe("agent runtime refresh hooks", () => {
   });
 
   it("preserves the finish reason when generate() stops without final text", async () => {
-    let callCount = 0;
-    const model: ModelRuntime = {
-      provider: "hosted",
-      modelId: "hosted/empty-final-text",
-      async doGenerate() {
-        callCount++;
-        if (callCount === 1) {
-          return {
-            content: [{
-              type: "tool-call",
-              toolCallId: "write-1",
-              toolName: "write_report",
-              input: '{"path":"research/report.md"}',
-            }],
-            finishReason: "tool-calls",
-            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-          };
-        }
-
-        return {
-          content: [],
-          finishReason: "stop",
-          usage: { inputTokens: 1, outputTokens: 0, totalTokens: 1 },
-        };
+    const model = scriptedModel([
+      {
+        toolCalls: [{
+          id: "write-1",
+          name: "write_report",
+          input: '{"path":"research/report.md"}',
+        }],
       },
-      async doStream() {
-        return {
-          stream: createRuntimeStream([{ type: "finish", finishReason: "stop" }]),
-        };
-      },
-    };
+      { content: [], finishReason: "stop" },
+    ], { modelId: "hosted/empty-final-text", only: "generate" });
 
     const writeReport = tool({
       id: "write_report",
@@ -804,7 +712,7 @@ describe("agent runtime refresh hooks", () => {
 
     const response = await assistant.generate({ input: "Write a report" });
 
-    assertEquals(callCount, 2);
+    assertEquals(model.callCount, 2);
     assertEquals(response.status, "completed");
     assertEquals(response.text, "");
     assertEquals(response.metadata?.finishReason, "stop");
@@ -812,47 +720,16 @@ describe("agent runtime refresh hooks", () => {
   });
 
   it("classifies structured errors returned during generate()", async () => {
-    const toolNamesByStep: string[][] = [];
-    let callCount = 0;
-    const model: ModelRuntime = {
-      provider: "anthropic",
-      modelId: "claude-sonnet-4-6",
-      async doGenerate(options) {
-        const rawTools = (options as { tools?: unknown }).tools;
-        const toolNames = Array.isArray(rawTools)
-          ? rawTools.map((entry) =>
-            (entry as { name?: string; id?: string }).name ??
-              (entry as { name?: string; id?: string }).id ?? ""
-          )
-          : Object.keys((rawTools as Record<string, unknown> | undefined) ?? {});
-        toolNamesByStep.push(toolNames);
-        callCount++;
-
-        if (callCount === 1) {
-          return {
-            content: [{
-              type: "tool-call",
-              toolCallId: "update-agent-generate-error-1",
-              toolName: "update_agent",
-              input: '{"id":"jira-agent"}',
-            }],
-            finishReason: "tool-calls",
-            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-          };
-        }
-
-        return {
-          content: [{ type: "text", text: "I can retry with the required input." }],
-          finishReason: "stop",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
+    const model = scriptedModel([
+      {
+        toolCalls: [{
+          id: "update-agent-generate-error-1",
+          name: "update_agent",
+          input: '{"id":"jira-agent"}',
+        }],
       },
-      async doStream() {
-        return {
-          stream: createRuntimeStream([{ type: "finish", finishReason: "stop" }]),
-        };
-      },
-    };
+      { text: "I can retry with the required input." },
+    ], { provider: "anthropic", modelId: "claude-sonnet-4-6", only: "generate" });
 
     const updateError = {
       error: "tool_error",
@@ -879,73 +756,34 @@ describe("agent runtime refresh hooks", () => {
       input: "Attach the project skill to my Jira agent",
     });
 
-    assertEquals(toolNamesByStep.length, 2);
-    assertEquals(toolNamesByStep[1]?.includes("update_agent"), true);
-    assertEquals(toolNamesByStep[1]?.includes("web_search"), true);
-    assertEquals(toolNamesByStep[1]?.includes("web_fetch"), true);
+    assertEquals(model.callCount, 2);
+    assertEquals(model.toolNames(1).includes("update_agent"), true);
+    assertEquals(model.toolNames(1).includes("web_search"), true);
+    assertEquals(model.toolNames(1).includes("web_fetch"), true);
     assertEquals(response.toolCalls[0]?.status, "error");
     assertEquals(response.toolCalls[0]?.error, updateError.message);
     assertEquals(response.toolCalls[0]?.result, updateError);
   });
 
   it("forces a final response after create_agent succeeds during generate()", async () => {
-    const toolNamesByStep: string[][] = [];
-    const systemPromptsByStep: string[] = [];
-    let callCount = 0;
     let executionCount = 0;
-    const model: ModelRuntime = {
-      provider: "anthropic",
-      modelId: "claude-sonnet-4-6",
-      async doGenerate(options) {
-        systemPromptsByStep.push(extractSystemPrompt(options));
-        const rawTools = (options as { tools?: unknown }).tools;
-        const toolNames = Array.isArray(rawTools)
-          ? rawTools.map((entry) =>
-            (entry as { name?: string; id?: string }).name ??
-              (entry as { name?: string; id?: string }).id ?? ""
-          )
-          : Object.keys((rawTools as Record<string, unknown> | undefined) ?? {});
-        toolNamesByStep.push(toolNames);
-        callCount++;
-
-        if (callCount === 1) {
-          return {
-            content: [{
-              type: "tool-call",
-              toolCallId: "create-agent-generate-1",
-              toolName: "create_agent",
-              input: '{"id":"gmail-assistant-e2e"}',
-            }],
-            finishReason: "tool-calls",
-            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-          };
-        }
-
-        if (callCount === 2) {
-          return {
-            content: [{
-              type: "tool-call",
-              toolCallId: "create-agent-generate-guessed-2",
-              toolName: "create_agent",
-              input: '{"id":"guessed-second-agent"}',
-            }],
-            finishReason: "tool-calls",
-            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-          };
-        }
-
-        return {
-          content: [{ type: "text", text: "Created Gmail Assistant." }],
-          finishReason: "stop",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
+    const model = scriptedModel([
+      {
+        toolCalls: [{
+          id: "create-agent-generate-1",
+          name: "create_agent",
+          input: '{"id":"gmail-assistant-e2e"}',
+        }],
       },
-      async doStream() {
-        return {
-          stream: createRuntimeStream([{ type: "finish", finishReason: "stop" }]),
-        };
+      {
+        toolCalls: [{
+          id: "create-agent-generate-guessed-2",
+          name: "create_agent",
+          input: '{"id":"guessed-second-agent"}',
+        }],
       },
-    };
+      { text: "Created Gmail Assistant." },
+    ], { provider: "anthropic", modelId: "claude-sonnet-4-6", only: "generate" });
 
     const createAgent = tool({
       id: "create_agent",
@@ -978,13 +816,13 @@ describe("agent runtime refresh hooks", () => {
 
     const response = await assistant.generate({ input: "Create a Gmail agent" });
 
-    assertEquals(toolNamesByStep.length, 3);
-    assertEquals(toolNamesByStep[0]?.includes("create_agent"), true);
-    assertEquals(toolNamesByStep[0]?.includes("web_search"), true);
-    assertEquals(toolNamesByStep[0]?.includes("web_fetch"), true);
-    assertEquals(toolNamesByStep[1], ["load_skill"]);
-    assertEquals(systemPromptsByStep[1]?.includes("- create_agent"), false);
-    assertEquals(systemPromptsByStep[1]?.includes("- load_skill"), true);
+    assertEquals(model.callCount, 3);
+    assertEquals(model.toolNames(0).includes("create_agent"), true);
+    assertEquals(model.toolNames(0).includes("web_search"), true);
+    assertEquals(model.toolNames(0).includes("web_fetch"), true);
+    assertEquals(model.toolNames(1), ["load_skill"]);
+    assertEquals(model.systemPrompts()[1]?.includes("- create_agent"), false);
+    assertEquals(model.systemPrompts()[1]?.includes("- load_skill"), true);
     assertEquals(executionCount, 1);
     assertEquals(response.toolCalls[1]?.status, "error");
     assertEquals(
@@ -994,22 +832,10 @@ describe("agent runtime refresh hooks", () => {
   });
 
   it("omits provider-native tools unsupported by the configured model", async () => {
-    let capturedSystem = "";
-    const model: ModelRuntime = {
-      provider: "google",
-      modelId: "gemini-3.5-flash",
-      async doGenerate(options) {
-        capturedSystem = extractSystemPrompt(options);
-        return {
-          content: [{ type: "text", text: "done" }],
-          finishReason: "stop",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
-      },
-      async doStream() {
-        return { stream: createRuntimeStream([{ type: "finish", finishReason: "stop" }]) };
-      },
-    };
+    const model = scriptedModel(
+      [{ text: "done" }],
+      { provider: "google", modelId: "gemini-3.5-flash", only: "generate" },
+    );
 
     const assistant = eagerAgent({
       model: "google/gemini-3.5-flash",
@@ -1023,6 +849,7 @@ describe("agent runtime refresh hooks", () => {
     await assistant.generate({ input: "Search the web" });
 
     // Google exposes neither native tool, so neither may reach the inventory.
+    const capturedSystem = model.systemPrompts()[0] ?? "";
     assertEquals(capturedSystem.includes("- web_search"), false);
     assertEquals(capturedSystem.includes("- web_fetch"), false);
   });
@@ -1037,7 +864,7 @@ describe("agent runtime refresh hooks", () => {
       async doGenerate() {
         if (callCount === 2) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               {
                 type: "tool-call",
                 toolCallId: "create-agent-guessed-2",
@@ -1047,7 +874,7 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
+                totalUsage: { inputTokens: 1, outputTokens: 1 },
               },
             ]),
           };
@@ -1072,7 +899,7 @@ describe("agent runtime refresh hooks", () => {
 
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               {
                 type: "tool-call",
                 toolCallId: "create-agent-1",
@@ -1082,19 +909,19 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
+                totalUsage: { inputTokens: 1, outputTokens: 1 },
               },
             ]),
           };
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "Created Gmail Assistant." },
             {
               type: "finish",
               finishReason: "stop",
-              usage: { inputTokens: 1, outputTokens: 1 },
+              totalUsage: { inputTokens: 1, outputTokens: 1 },
             },
           ]),
         };
@@ -1166,7 +993,7 @@ describe("agent runtime refresh hooks", () => {
 
           if (callCount === 1) {
             return {
-              stream: createRuntimeStream([
+              stream: runtimeStream([
                 {
                   type: "tool-call",
                   toolCallId: "agent-write-1",
@@ -1176,7 +1003,7 @@ describe("agent runtime refresh hooks", () => {
                 {
                   type: "finish",
                   finishReason: "tool-calls",
-                  usage: { inputTokens: 1, outputTokens: 1 },
+                  totalUsage: { inputTokens: 1, outputTokens: 1 },
                 },
               ]),
             };
@@ -1184,7 +1011,7 @@ describe("agent runtime refresh hooks", () => {
 
           if (callCount === 2 && toolNames.includes("create_schedule")) {
             return {
-              stream: createRuntimeStream([
+              stream: runtimeStream([
                 {
                   type: "tool-call",
                   toolCallId: "create-schedule-1",
@@ -1205,19 +1032,19 @@ describe("agent runtime refresh hooks", () => {
                 {
                   type: "finish",
                   finishReason: "tool-calls",
-                  usage: { inputTokens: 1, outputTokens: 1 },
+                  totalUsage: { inputTokens: 1, outputTokens: 1 },
                 },
               ]),
             };
           }
 
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               { type: "text-delta", text: "Scheduled agent created." },
               {
                 type: "finish",
                 finishReason: "stop",
-                usage: { inputTokens: 1, outputTokens: 1 },
+                totalUsage: { inputTokens: 1, outputTokens: 1 },
               },
             ]),
           };
@@ -1322,7 +1149,7 @@ describe("agent runtime refresh hooks", () => {
 
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               {
                 type: "tool-call",
                 toolCallId: "create-agent-1",
@@ -1332,19 +1159,19 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
+                totalUsage: { inputTokens: 1, outputTokens: 1 },
               },
             ]),
           };
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "I can retry with corrected agent input." },
             {
               type: "finish",
               finishReason: "stop",
-              usage: { inputTokens: 1, outputTokens: 1 },
+              totalUsage: { inputTokens: 1, outputTokens: 1 },
             },
           ]),
         };
@@ -1409,7 +1236,7 @@ describe("agent runtime refresh hooks", () => {
 
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               {
                 type: "tool-call",
                 toolCallId: "update-agent-error-1",
@@ -1419,19 +1246,19 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
+                totalUsage: { inputTokens: 1, outputTokens: 1 },
               },
             ]),
           };
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "I can retry with the required input." },
             {
               type: "finish",
               finishReason: "stop",
-              usage: { inputTokens: 1, outputTokens: 1 },
+              totalUsage: { inputTokens: 1, outputTokens: 1 },
             },
           ]),
         };
@@ -1498,7 +1325,7 @@ describe("agent runtime refresh hooks", () => {
         callCount++;
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               {
                 type: "tool-call",
                 toolCallId: "gmail-list-emails-auth-1",
@@ -1508,19 +1335,19 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
+                totalUsage: { inputTokens: 1, outputTokens: 1 },
               },
             ]),
           };
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "Connect Gmail to continue." },
             {
               type: "finish",
               finishReason: "stop",
-              usage: { inputTokens: 1, outputTokens: 1 },
+              totalUsage: { inputTokens: 1, outputTokens: 1 },
             },
           ]),
         };
@@ -1598,7 +1425,7 @@ describe("agent runtime refresh hooks", () => {
 
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               {
                 type: "tool-call",
                 toolCallId: "load-missing-skill",
@@ -1608,19 +1435,19 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
+                totalUsage: { inputTokens: 1, outputTokens: 1 },
               },
             ]),
           };
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "I could not load that skill." },
             {
               type: "finish",
               finishReason: "stop",
-              usage: { inputTokens: 1, outputTokens: 1 },
+              totalUsage: { inputTokens: 1, outputTokens: 1 },
             },
           ]),
         };
@@ -1689,7 +1516,7 @@ describe("agent runtime refresh hooks", () => {
 
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               {
                 type: "tool-call",
                 toolCallId: "update-agent-1",
@@ -1699,19 +1526,19 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
+                totalUsage: { inputTokens: 1, outputTokens: 1 },
               },
             ]),
           };
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "Updated Gmail Assistant." },
             {
               type: "finish",
               finishReason: "stop",
-              usage: { inputTokens: 1, outputTokens: 1 },
+              totalUsage: { inputTokens: 1, outputTokens: 1 },
             },
           ]),
         };
@@ -1769,7 +1596,7 @@ describe("agent runtime refresh hooks", () => {
 
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               {
                 type: "tool-call",
                 toolCallId: "write-stream-1",
@@ -1779,19 +1606,19 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
+                totalUsage: { inputTokens: 1, outputTokens: 1 },
               },
             ]),
           };
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "stream complete" },
             {
               type: "finish",
               finishReason: "stop",
-              usage: { inputTokens: 1, outputTokens: 1 },
+              totalUsage: { inputTokens: 1, outputTokens: 1 },
             },
           ]),
         };
@@ -1856,7 +1683,7 @@ describe("agent runtime refresh hooks", () => {
 
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               { type: "text-delta", text: "Applying the requested updates." },
               {
                 type: "tool-input-start",
@@ -1871,7 +1698,7 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "stop",
-                usage: { inputTokens: 0, outputTokens: 0 },
+                totalUsage: { inputTokens: 0, outputTokens: 0 },
               },
             ]),
           };
@@ -1879,7 +1706,7 @@ describe("agent runtime refresh hooks", () => {
 
         if (callCount === 2) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               {
                 type: "tool-call",
                 toolCallId: "retry-file",
@@ -1901,19 +1728,19 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
+                totalUsage: { inputTokens: 1, outputTokens: 1 },
               },
             ]),
           };
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "Recovered after interrupted tool batch." },
             {
               type: "finish",
               finishReason: "stop",
-              usage: { inputTokens: 1, outputTokens: 1 },
+              totalUsage: { inputTokens: 1, outputTokens: 1 },
             },
           ]),
         };
@@ -1983,7 +1810,7 @@ describe("agent runtime refresh hooks", () => {
           callCount++;
           if (callCount > 1) {
             return {
-              stream: createRuntimeStream([
+              stream: runtimeStream([
                 { type: "text-delta", text: "Unexpected recovery." },
                 { type: "finish", finishReason: "stop" },
               ]),
@@ -1991,7 +1818,7 @@ describe("agent runtime refresh hooks", () => {
           }
 
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               {
                 type: "tool-call",
                 toolCallId: "exposed-file",
@@ -2000,7 +1827,7 @@ describe("agent runtime refresh hooks", () => {
               },
               ...(hasFinalResult
                 ? [{
-                  type: "tool-result",
+                  type: "tool-result" as const,
                   toolCallId: "exposed-file",
                   toolName: "issue466_update_file",
                   output: { revision: "already-applied" },
@@ -2019,7 +1846,7 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "stop",
-                usage: { inputTokens: 0, outputTokens: 0 },
+                totalUsage: { inputTokens: 0, outputTokens: 0 },
               },
             ]),
           };
@@ -2105,7 +1932,7 @@ describe("agent runtime refresh hooks", () => {
         callCount++;
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               {
                 type: "tool-call",
                 toolCallId: "issue3737-committed",
@@ -2115,13 +1942,13 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
+                totalUsage: { inputTokens: 1, outputTokens: 1 },
               },
             ]),
           };
         }
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             {
               type: "tool-input-start",
               id: "issue3737-truncated",
@@ -2135,7 +1962,7 @@ describe("agent runtime refresh hooks", () => {
             {
               type: "finish",
               finishReason: "tool-calls",
-              usage: { inputTokens: 1, outputTokens: 1 },
+              totalUsage: { inputTokens: 1, outputTokens: 1 },
             },
           ]),
         };
@@ -2210,7 +2037,7 @@ describe("agent runtime refresh hooks", () => {
       async doStream() {
         callCount++;
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             ...(callCount === 1
               ? [{ type: "text-delta" as const, text: "Starting the work." }]
               : []),
@@ -2223,7 +2050,7 @@ describe("agent runtime refresh hooks", () => {
             {
               type: "finish",
               finishReason: "tool-calls",
-              usage: { inputTokens: 1, outputTokens: 1 },
+              totalUsage: { inputTokens: 1, outputTokens: 1 },
             },
           ]),
         };
@@ -2280,7 +2107,7 @@ describe("agent runtime refresh hooks", () => {
         callCount++;
         if (callCount === 2) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               { type: "text-delta", text: "Created the Outlook " },
               { type: "text-delta", text: "assistant." },
               {
@@ -2292,14 +2119,14 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
+                totalUsage: { inputTokens: 1, outputTokens: 1 },
               },
             ]),
           };
         }
         if (callCount > 2) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               { type: "text-delta", text: "Unexpected second recovery." },
               { type: "finish", finishReason: "stop" },
             ]),
@@ -2307,7 +2134,7 @@ describe("agent runtime refresh hooks", () => {
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "Created the Outlook assistant." },
             {
               type: "tool-input-start",
@@ -2318,7 +2145,7 @@ describe("agent runtime refresh hooks", () => {
             {
               type: "finish",
               finishReason: "tool-calls",
-              usage: { inputTokens: 1, outputTokens: 1 },
+              totalUsage: { inputTokens: 1, outputTokens: 1 },
             },
           ]),
         };
@@ -2456,7 +2283,7 @@ describe("agent runtime refresh hooks", () => {
         callCount++;
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               { type: "text-delta", text: "Preparing the Studio suggestions." },
               {
                 type: "tool-input-start",
@@ -2469,7 +2296,7 @@ describe("agent runtime refresh hooks", () => {
           };
         }
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             {
               type: "tool-call",
               toolCallId: "toolu_reconstructed_suggestions",
@@ -2577,7 +2404,7 @@ describe("agent runtime refresh hooks", () => {
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "Initial partial answer." },
             {
               type: "tool-input-start",
@@ -2674,7 +2501,7 @@ describe("agent runtime refresh hooks", () => {
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "Initial partial answer." },
             {
               type: "tool-input-start",
@@ -2770,7 +2597,7 @@ describe("agent runtime refresh hooks", () => {
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "Created the assistant." },
             {
               type: "tool-input-start",
@@ -2848,7 +2675,7 @@ describe("agent runtime refresh hooks", () => {
         callCount++;
         if (callCount === 2) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               { type: "text-delta", text: "Created the " },
               { type: "text-delta", text: "workflow." },
               { type: "reasoning-delta", id: "recovery-reasoning", delta: "Check result." },
@@ -2860,7 +2687,7 @@ describe("agent runtime refresh hooks", () => {
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "Created the assistant." },
             {
               type: "tool-input-start",
@@ -2951,7 +2778,7 @@ describe("agent runtime refresh hooks", () => {
         callCount++;
         if (callCount === 2) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               { type: "text-delta", text: "Created the " },
               { type: "finish", finishReason: "stop" },
             ]),
@@ -2959,7 +2786,7 @@ describe("agent runtime refresh hooks", () => {
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "Created the assistant." },
             {
               type: "tool-input-start",
@@ -3027,7 +2854,7 @@ describe("agent runtime refresh hooks", () => {
         callCount++;
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               { type: "text-delta", text: "Checking the requested update." },
               {
                 type: "tool-input-start",
@@ -3041,7 +2868,7 @@ describe("agent runtime refresh hooks", () => {
         }
         if (callCount === 2) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               { type: "text-delta", text: "The provider lookup completed." },
               {
                 type: "tool-call",
@@ -3062,7 +2889,7 @@ describe("agent runtime refresh hooks", () => {
           };
         }
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "Unexpected continuation." },
             { type: "finish", finishReason: "stop" },
           ]),
@@ -3126,7 +2953,7 @@ describe("agent runtime refresh hooks", () => {
         callCount++;
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               { type: "text-delta", text: "Checking the requested update." },
               {
                 type: "tool-input-start",
@@ -3233,7 +3060,7 @@ describe("agent runtime refresh hooks", () => {
         callCount++;
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               { type: "text-delta", text: "Checking the requested update." },
               {
                 type: "tool-input-start",
@@ -3348,7 +3175,7 @@ describe("agent runtime refresh hooks", () => {
         callCount++;
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               { type: "text-delta", text: "Checking the update." },
               {
                 type: "tool-input-start",
@@ -3366,7 +3193,7 @@ describe("agent runtime refresh hooks", () => {
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "Checking " },
             {
               type: "tool-call",
@@ -3444,7 +3271,7 @@ describe("agent runtime refresh hooks", () => {
       async doStream() {
         callCount++;
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "reasoning-start", id: "reasoning-before-interruption" },
             {
               type: "reasoning-delta",
@@ -3552,7 +3379,7 @@ describe("agent runtime refresh hooks", () => {
         callCount++;
         if (callCount > 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               { type: "text-delta", text: "Unexpected recovery." },
               { type: "finish", finishReason: "stop" },
             ]),
@@ -3560,7 +3387,7 @@ describe("agent runtime refresh hooks", () => {
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "reasoning-start", id: "reasoning-before-remote" },
             {
               type: "reasoning-delta",
@@ -3667,7 +3494,7 @@ describe("agent runtime refresh hooks", () => {
         callCount++;
         if (callCount > 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               { type: "text-delta", text: "Done." },
               { type: "finish", finishReason: "stop" },
             ]),
@@ -3675,7 +3502,7 @@ describe("agent runtime refresh hooks", () => {
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "reasoning-start", id: "reasoning-before-rename" },
             {
               type: "reasoning-delta",
@@ -3751,7 +3578,7 @@ describe("agent runtime refresh hooks", () => {
         callCount++;
         if (callCount > 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               { type: "text-delta", text: "Unexpected recovery." },
               { type: "finish", finishReason: "stop" },
             ]),
@@ -3759,7 +3586,7 @@ describe("agent runtime refresh hooks", () => {
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "reasoning-start", id: "reasoning-before-placeholder" },
             {
               type: "reasoning-delta",
@@ -3777,7 +3604,7 @@ describe("agent runtime refresh hooks", () => {
             {
               type: "finish",
               finishReason: "tool-calls",
-              usage: { inputTokens: 1, outputTokens: 1 },
+              totalUsage: { inputTokens: 1, outputTokens: 1 },
             },
           ]),
         };
@@ -3868,7 +3695,7 @@ describe("agent runtime refresh hooks", () => {
         callCount++;
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               { type: "text-delta", text: "Checking the requested update." },
               {
                 type: "tool-input-start",
@@ -3990,7 +3817,7 @@ describe("agent runtime refresh hooks", () => {
         };
       },
       async doStream() {
-        return { stream: createRuntimeStream([{ type: "finish", finishReason: "stop" }]) };
+        return { stream: runtimeStream([{ type: "finish", finishReason: "stop" }]) };
       },
     };
     const loadSkill = tool({
@@ -4058,7 +3885,7 @@ describe("agent runtime refresh hooks", () => {
 
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               {
                 type: "tool-call",
                 toolCallId: "load-build-stream-1",
@@ -4068,7 +3895,7 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
+                totalUsage: { inputTokens: 1, outputTokens: 1 },
               },
             ]),
           };
@@ -4076,7 +3903,7 @@ describe("agent runtime refresh hooks", () => {
 
         if (callCount === 2) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               {
                 type: "tool-call",
                 toolCallId: "invoke-stream-1",
@@ -4087,16 +3914,20 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
+                totalUsage: { inputTokens: 1, outputTokens: 1 },
               },
             ]),
           };
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "done" },
-            { type: "finish", finishReason: "stop", usage: { inputTokens: 1, outputTokens: 1 } },
+            {
+              type: "finish",
+              finishReason: "stop",
+              totalUsage: { inputTokens: 1, outputTokens: 1 },
+            },
           ]),
         };
       },
@@ -4167,7 +3998,7 @@ describe("agent runtime refresh hooks", () => {
 
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               {
                 type: "tool-call",
                 toolCallId: "invoke-resumed-1",
@@ -4178,16 +4009,20 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
+                totalUsage: { inputTokens: 1, outputTokens: 1 },
               },
             ]),
           };
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "done" },
-            { type: "finish", finishReason: "stop", usage: { inputTokens: 1, outputTokens: 1 } },
+            {
+              type: "finish",
+              finishReason: "stop",
+              totalUsage: { inputTokens: 1, outputTokens: 1 },
+            },
           ]),
         };
       },
@@ -4297,7 +4132,7 @@ describe("agent runtime refresh hooks", () => {
         };
       },
       async doStream() {
-        return { stream: createRuntimeStream([{ type: "finish", finishReason: "stop" }]) };
+        return { stream: runtimeStream([{ type: "finish", finishReason: "stop" }]) };
       },
     };
     const invokeAgent = tool({
@@ -4349,7 +4184,7 @@ describe("agent runtime refresh hooks", () => {
         callCount++;
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               {
                 type: "tool-call",
                 toolCallId: "invoke-payment-1",
@@ -4364,16 +4199,20 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
+                totalUsage: { inputTokens: 1, outputTokens: 1 },
               },
             ]),
           };
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "blocked" },
-            { type: "finish", finishReason: "stop", usage: { inputTokens: 1, outputTokens: 1 } },
+            {
+              type: "finish",
+              finishReason: "stop",
+              totalUsage: { inputTokens: 1, outputTokens: 1 },
+            },
           ]),
         };
       },
@@ -4422,7 +4261,7 @@ describe("agent runtime refresh hooks", () => {
       modelId: "hosted/runtime-refresh-generate",
       async doGenerate(options: unknown) {
         callCount++;
-        observedSystems.push(extractSystemPrompt(options));
+        observedSystems.push(systemPromptOf(options));
 
         if (callCount === 1) {
           return {
@@ -4458,7 +4297,7 @@ describe("agent runtime refresh hooks", () => {
       },
       async doStream() {
         return {
-          stream: createRuntimeStream([{
+          stream: runtimeStream([{
             type: "finish",
             finishReason: "stop",
           }]),
@@ -4562,11 +4401,11 @@ describe("agent runtime refresh hooks", () => {
       },
       async doStream(options: unknown) {
         callCount++;
-        observedSystems.push(extractSystemPrompt(options));
+        observedSystems.push(systemPromptOf(options));
 
         if (callCount === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               {
                 type: "tool-call",
                 toolCallId: "switch-stream-1",
@@ -4576,19 +4415,19 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
+                totalUsage: { inputTokens: 1, outputTokens: 1 },
               },
             ]),
           };
         }
 
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "stream done" },
             {
               type: "finish",
               finishReason: "stop",
-              usage: { inputTokens: 1, outputTokens: 1 },
+              totalUsage: { inputTokens: 1, outputTokens: 1 },
             },
           ]),
         };
@@ -4654,7 +4493,7 @@ describe("agent runtime refresh hooks", () => {
       provider: "hosted",
       modelId: "hosted/runtime-state-string-contract",
       async doGenerate(options) {
-        observedProviderSystem = extractSystemPrompt(options);
+        observedProviderSystem = systemPromptOf(options);
         return {
           content: [{ type: "text", text: "done" }],
           finishReason: "stop",
@@ -4662,7 +4501,7 @@ describe("agent runtime refresh hooks", () => {
         };
       },
       async doStream() {
-        return { stream: createRuntimeStream([{ type: "finish", finishReason: "stop" }]) };
+        return { stream: runtimeStream([{ type: "finish", finishReason: "stop" }]) };
       },
     };
     const assistant = eagerAgent({
@@ -4699,7 +4538,7 @@ describe("agent runtime refresh hooks", () => {
       provider: "hosted",
       modelId: "hosted/runtime-state-structured-copy",
       async doGenerate(options) {
-        observedProviderSystem = extractSystemPrompt(options);
+        observedProviderSystem = systemPromptOf(options);
         observedProviderPrompt = (options as { prompt?: unknown }).prompt;
         return {
           content: [{ type: "text", text: "done" }],
@@ -4708,7 +4547,7 @@ describe("agent runtime refresh hooks", () => {
         };
       },
       async doStream() {
-        return { stream: createRuntimeStream([{ type: "finish", finishReason: "stop" }]) };
+        return { stream: runtimeStream([{ type: "finish", finishReason: "stop" }]) };
       },
     };
     const assistant = eagerAgent({
@@ -4767,7 +4606,7 @@ describe("agent runtime refresh hooks", () => {
       provider: "hosted",
       modelId: "hosted/post-form-skill-reference",
       async doGenerate(options: unknown) {
-        generateToolNames.push(extractRuntimeToolNames(options));
+        generateToolNames.push(toolNamesOf(options));
         generateCalls++;
         if (generateCalls === 1) {
           return {
@@ -4788,11 +4627,11 @@ describe("agent runtime refresh hooks", () => {
         };
       },
       async doStream(options: unknown) {
-        streamToolNames.push(extractRuntimeToolNames(options));
+        streamToolNames.push(toolNamesOf(options));
         streamCalls++;
         if (streamCalls === 1) {
           return {
-            stream: createRuntimeStream([
+            stream: runtimeStream([
               {
                 type: "tool-call",
                 toolCallId: "read-plan-guide-stream",
@@ -4802,18 +4641,18 @@ describe("agent runtime refresh hooks", () => {
               {
                 type: "finish",
                 finishReason: "tool-calls",
-                usage: { inputTokens: 1, outputTokens: 1 },
+                totalUsage: { inputTokens: 1, outputTokens: 1 },
               },
             ]),
           };
         }
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             { type: "text-delta", text: "stream done" },
             {
               type: "finish",
               finishReason: "stop",
-              usage: { inputTokens: 1, outputTokens: 1 },
+              totalUsage: { inputTokens: 1, outputTokens: 1 },
             },
           ]),
         };
@@ -4941,7 +4780,7 @@ describe("agent runtime refresh hooks", () => {
       async doStream() {
         streamCalls++;
         return {
-          stream: createRuntimeStream([
+          stream: runtimeStream([
             {
               type: "tool-call",
               toolCallId: `root-skill-stream-${streamCalls}`,

--- a/src/agent/runtime/runtime-stream-cancel.test.ts
+++ b/src/agent/runtime/runtime-stream-cancel.test.ts
@@ -1,10 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assert } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { type ModelRuntime } from "#veryfront/provider";
 import { tool } from "#veryfront/tool";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { agent } from "../index.ts";
+import { scriptedModel } from "./model-runtime.test-helpers.ts";
 
 /**
  * Regression coverage for #2334: cancelling an in-flight agent run must be
@@ -23,45 +23,13 @@ function flushMicrotasks(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 20));
 }
 
-/** A model stream that stays open until the run is aborted, then rejects its
- * pending read with the abort reason — mirroring a real provider fetch body. */
-function createPendingModelStream(abortSignal: AbortSignal | undefined): ReadableStream<unknown> {
-  return new ReadableStream<unknown>({
-    start(controller) {
-      controller.enqueue({ type: "text-start", id: "t" });
-      controller.enqueue({ type: "text-delta", id: "t", delta: "thinking" });
-
-      if (!abortSignal) {
-        return;
-      }
-      if (abortSignal.aborted) {
-        controller.error(abortSignal.reason);
-        return;
-      }
-      abortSignal.addEventListener("abort", () => {
-        controller.error(abortSignal.reason);
-      }, { once: true });
-    },
-  });
-}
-
 describe("agent runtime stream cancellation (#2334)", () => {
   it("cancelling a model-streaming run does not raise an unhandled AbortError", async () => {
-    const model: ModelRuntime = {
-      provider: "hosted",
-      modelId: "hosted/cancel-crash-model",
-      async doGenerate() {
-        return {
-          content: [],
-          finishReason: "stop",
-          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-        };
-      },
-      async doStream(options: unknown) {
-        const abortSignal = (options as { abortSignal?: AbortSignal }).abortSignal;
-        return { stream: createPendingModelStream(abortSignal) };
-      },
-    };
+    // The model stream stays open until the run is aborted, then rejects its
+    // pending read with the abort reason — mirroring a real provider fetch body.
+    const model = scriptedModel([
+      { hangUntilAbort: true, parts: [{ type: "text-delta", text: "thinking" }] },
+    ], { modelId: "hosted/cancel-crash-model", only: "stream" });
 
     const assistant = agent({
       model: "hosted/cancel-crash-model",
@@ -104,41 +72,12 @@ describe("agent runtime stream cancellation (#2334)", () => {
       },
     });
 
-    let call = 0;
-    const model: ModelRuntime = {
-      provider: "hosted",
-      modelId: "hosted/cancel-crash-tool",
-      async doGenerate() {
-        return {
-          content: [],
-          finishReason: "stop",
-          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-        };
-      },
-      async doStream(options: unknown) {
-        call += 1;
-        const abortSignal = (options as { abortSignal?: AbortSignal }).abortSignal;
-        if (call === 1) {
-          // First step: emit a tool call so a tool execution opens.
-          return {
-            stream: new ReadableStream<unknown>({
-              start(controller) {
-                controller.enqueue({
-                  type: "tool-call",
-                  toolCallId: "slow-1",
-                  toolName: "slow_tool",
-                  input: "{}",
-                });
-                controller.enqueue({ type: "finish", finishReason: "tool-calls" });
-                controller.close();
-              },
-            }),
-          };
-        }
-        // Any later step stays open until aborted.
-        return { stream: createPendingModelStream(abortSignal) };
-      },
-    };
+    const model = scriptedModel([
+      // First step: emit a tool call so a tool execution opens.
+      { toolCalls: [{ id: "slow-1", name: "slow_tool", input: {} }] },
+      // Any later step stays open until aborted.
+      { hangUntilAbort: true },
+    ], { modelId: "hosted/cancel-crash-tool", only: "stream" });
 
     const assistant = agent({
       model: "hosted/cancel-crash-tool",

--- a/src/agent/runtime/skill-policy-same-step.test.ts
+++ b/src/agent/runtime/skill-policy-same-step.test.ts
@@ -1,12 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import type { ModelRuntime } from "#veryfront/provider";
 import { defineSchema } from "#veryfront/schemas";
 import { type Tool, tool } from "#veryfront/tool";
 import { toolRegistry } from "#veryfront/tool/registry.ts";
 import { agent } from "../index.ts";
 import type { AgentConfig } from "../types.ts";
+import { scriptedModel, type ScriptedTurn } from "./model-runtime.test-helpers.ts";
 import type { RuntimeToolFilterConfig } from "./runtime-tool-config.ts";
 
 // Asserting on message text would pin wording that no longer exists: the
@@ -16,82 +16,6 @@ import type { RuntimeToolFilterConfig } from "./runtime-tool-config.ts";
 // all, which catches any future blocking however it is phrased.
 
 type RuntimeMode = "generate" | "stream";
-
-type ScriptedToolCall = { id: string; name: string; input: Record<string, unknown> };
-
-type ScriptedStep =
-  | { toolCalls: ScriptedToolCall[] }
-  | { text: string };
-
-function createRuntimeStream(parts: unknown[]) {
-  return new ReadableStream<unknown>({
-    start(controller) {
-      for (const part of parts) controller.enqueue(part);
-      controller.close();
-    },
-  });
-}
-
-function stepContent(step: ScriptedStep): {
-  content: unknown[];
-  finishReason: "tool-calls" | "stop";
-} {
-  if ("text" in step) {
-    return { content: [{ type: "text", text: step.text }], finishReason: "stop" };
-  }
-  return {
-    content: step.toolCalls.map((call) => ({
-      type: "tool-call",
-      toolCallId: call.id,
-      toolName: call.name,
-      input: call.input,
-    })),
-    finishReason: "tool-calls",
-  };
-}
-
-function scriptedModel(modelId: string, steps: readonly ScriptedStep[]): ModelRuntime {
-  let index = 0;
-  const nextOutput = () => {
-    const step = steps[Math.min(index, steps.length - 1)]!;
-    index += 1;
-    return stepContent(step);
-  };
-
-  return {
-    provider: "hosted",
-    modelId,
-    // deno-lint-ignore require-await -- ModelRuntime.doGenerate is async by contract
-    async doGenerate() {
-      const output = nextOutput();
-      return {
-        ...output,
-        content: output.content.map((part) =>
-          typeof part === "object" && part !== null &&
-            (part as { type?: unknown }).type === "tool-call"
-            ? { ...part, input: JSON.stringify((part as { input: unknown }).input) }
-            : part
-        ),
-        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-      };
-    },
-    // deno-lint-ignore require-await -- ModelRuntime.doStream is async by contract
-    async doStream() {
-      const output = nextOutput();
-      return {
-        stream: createRuntimeStream([
-          ...output.content.map((part) =>
-            typeof part === "object" && part !== null &&
-              (part as { type?: unknown }).type === "text"
-              ? { type: "text-delta", text: (part as { text: string }).text }
-              : part
-          ),
-          { type: "finish", finishReason: output.finishReason },
-        ]),
-      };
-    },
-  };
-}
 
 type BatchRun = {
   /** Every surfaced tool error, joined; the transports report errors differently. */
@@ -107,7 +31,7 @@ type BatchRun = {
 async function runBatch(options: {
   scenario: string;
   mode: RuntimeMode;
-  steps: readonly ScriptedStep[];
+  steps: readonly ScriptedTurn[];
   loadSkillResult: () => Record<string, unknown>;
   probeToolIds: readonly string[];
 }): Promise<BatchRun> {
@@ -147,7 +71,7 @@ async function runBatch(options: {
         tools,
         maxSteps: 4,
         resolveModelTransport: () => ({
-          model: scriptedModel(`hosted/same-step-${suffix}`, steps),
+          model: scriptedModel(steps, { modelId: `hosted/same-step-${suffix}` }),
         }),
         __vfToolLoadingMode: "eager",
       } as AgentConfig & RuntimeToolFilterConfig,

--- a/src/agent/runtime/stream-tool-authority.test.ts
+++ b/src/agent/runtime/stream-tool-authority.test.ts
@@ -1,37 +1,13 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { it } from "#veryfront/testing/bdd.ts";
-import type { ModelRuntime } from "#veryfront/provider";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { type Tool, tool } from "#veryfront/tool";
 import { agent } from "../index.ts";
-
-function createRuntimeStream(parts: unknown[]) {
-  return new ReadableStream<unknown>({
-    start(controller) {
-      for (const part of parts) {
-        controller.enqueue(part);
-      }
-      controller.close();
-    },
-  });
-}
-
-function getRuntimeToolNames(options: unknown): string[] {
-  const rawTools = (options as { tools?: unknown }).tools;
-  return Array.isArray(rawTools)
-    ? rawTools.map((entry) =>
-      (entry as { name?: string; id?: string }).name ??
-        (entry as { name?: string; id?: string }).id ?? ""
-    )
-    : Object.keys((rawTools as Record<string, unknown> | undefined) ?? {});
-}
+import { scriptedModel } from "./model-runtime.test-helpers.ts";
 
 it("suppresses an OpenAI streamed tool call dropped by provider tool conversion", async () => {
   const toolExecutions: Record<string, number> = {};
-  const runtimeToolNamesByStep: string[][] = [];
-  const promptsByStep: unknown[] = [];
-  let streamCalls = 0;
   const tools: Record<string, Tool> = Object.fromEntries(
     Array.from({ length: 150 }, (_, index) => {
       const id = `tool_${index}`;
@@ -47,51 +23,10 @@ it("suppresses an OpenAI streamed tool call dropped by provider tool conversion"
       return [id, definition];
     }),
   );
-  const model: ModelRuntime = {
-    provider: "openai",
-    modelId: "veryfront-cloud/openai/gpt-5.2",
-    async doGenerate() {
-      return {
-        content: [{ type: "text", text: "unused" }],
-        finishReason: "stop",
-        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-      };
-    },
-    async doStream(options) {
-      streamCalls++;
-      runtimeToolNamesByStep.push(getRuntimeToolNames(options));
-      promptsByStep.push((options as { prompt?: unknown }).prompt);
-
-      if (streamCalls === 1) {
-        return {
-          stream: createRuntimeStream([
-            {
-              type: "tool-call",
-              toolCallId: "dropped-tool-call",
-              toolName: "tool_128",
-              input: {},
-            },
-            {
-              type: "finish",
-              finishReason: "tool-calls",
-              usage: { inputTokens: 1, outputTokens: 1 },
-            },
-          ]),
-        };
-      }
-
-      return {
-        stream: createRuntimeStream([
-          { type: "text-delta", text: "Recovered without executing the dropped tool." },
-          {
-            type: "finish",
-            finishReason: "stop",
-            usage: { inputTokens: 1, outputTokens: 1 },
-          },
-        ]),
-      };
-    },
-  };
+  const model = scriptedModel([
+    { toolCalls: [{ id: "dropped-tool-call", name: "tool_128", input: {} }] },
+    { text: "Recovered without executing the dropped tool." },
+  ], { provider: "openai", modelId: "veryfront-cloud/openai/gpt-5.2", only: "stream" });
 
   const assistant = agent({
     id: "openai-stream-tool-authority-agent",
@@ -105,12 +40,12 @@ it("suppresses an OpenAI streamed tool call dropped by provider tool conversion"
   const response = await assistant.stream({ input: "Call the dropped tool" });
   const streamBody = await response.toDataStreamResponse().text();
 
-  assertEquals(streamCalls, 2);
-  assertEquals(runtimeToolNamesByStep[0]?.length, 128);
-  assertEquals(runtimeToolNamesByStep[0]?.includes("tool_127"), true);
-  assertEquals(runtimeToolNamesByStep[0]?.includes("tool_128"), false);
+  assertEquals(model.callCount, 2);
+  assertEquals(model.toolNames(0).length, 128);
+  assertEquals(model.toolNames(0).includes("tool_127"), true);
+  assertEquals(model.toolNames(0).includes("tool_128"), false);
   assertEquals(
-    JSON.stringify(promptsByStep[1]).includes("ignored unavailable tool call(s): tool_128"),
+    JSON.stringify(model.calls[1]?.prompt).includes("ignored unavailable tool call(s): tool_128"),
     true,
   );
   assertEquals(toolExecutions.tool_128 ?? 0, 0);

--- a/src/agent/runtime/tool-exposure-durability.test.ts
+++ b/src/agent/runtime/tool-exposure-durability.test.ts
@@ -1,11 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { it } from "#veryfront/testing/bdd.ts";
-import type { ModelRuntime } from "#veryfront/provider";
 import { defineSchema } from "#veryfront/schemas";
 import { tool } from "#veryfront/tool";
 import { agent } from "../index.ts";
 import type { AgentConfig } from "../types.ts";
+import { scriptedModel } from "./model-runtime.test-helpers.ts";
 import type { RuntimeToolFilterConfig } from "./runtime-tool-config.ts";
 import type { ToolExposureCheckpoint } from "./tool-exposure.ts";
 
@@ -30,25 +30,6 @@ function listProjectsTool() {
   });
 }
 
-function createRuntimeStream(parts: unknown[]) {
-  return new ReadableStream<unknown>({
-    start(controller) {
-      for (const part of parts) controller.enqueue(part);
-      controller.close();
-    },
-  });
-}
-
-function toolNames(options: unknown): string[] {
-  const value = (options as { tools?: unknown }).tools;
-  return Array.isArray(value)
-    ? value.map((entry) =>
-      (entry as { name?: string; id?: string }).name ??
-        (entry as { name?: string; id?: string }).id ?? ""
-    )
-    : Object.keys((value as Record<string, unknown> | undefined) ?? {});
-}
-
 type RuntimeMode = "generate" | "stream";
 
 async function runRuntime(
@@ -68,55 +49,21 @@ function checkpoint(...loadedToolNames: string[]): ToolExposureCheckpoint {
 for (const mode of ["generate", "stream"] as const) {
   it(`${mode} awaits checkpoint persistence before the next model step`, async () => {
     const callOrder: string[] = [];
-    let step = 0;
-    const nextStep = () => {
-      step++;
-      if (step === 1) {
+    const model = scriptedModel([
+      () => {
         callOrder.push("tool_search");
         return {
-          content: [{
-            type: "tool-call",
-            toolCallId: "search-1",
-            toolName: "tool_search",
-            input: mode === "generate"
-              ? JSON.stringify({ query: "get_release" })
-              : { query: "get_release" },
-          }],
-          finishReason: "tool-calls",
+          toolCalls: [{ id: "search-1", name: "tool_search", input: { query: "get_release" } }],
         };
-      }
-      if (step === 2) {
+      },
+      () => {
         callOrder.push("next_model_step");
         return mode === "generate"
-          ? {
-            content: [{
-              type: "tool-call",
-              toolCallId: "release-1",
-              toolName: "get_release",
-              input: "{}",
-            }],
-            finishReason: "tool-calls",
-          }
-          : { content: [{ type: "text-delta", text: "done" }], finishReason: "stop" };
-      }
-      return { content: [{ type: "text", text: "done" }], finishReason: "stop" };
-    };
-    const model: ModelRuntime = {
-      provider: "hosted",
-      modelId: `hosted/${mode}-durability-order`,
-      async doGenerate() {
-        return nextStep();
+          ? { toolCalls: [{ id: "release-1", name: "get_release", input: {} }] }
+          : { text: "done" };
       },
-      async doStream() {
-        const result = nextStep();
-        return {
-          stream: createRuntimeStream([
-            ...result.content,
-            { type: "finish", finishReason: result.finishReason },
-          ]),
-        };
-      },
-    };
+      { text: "done" },
+    ], { modelId: `hosted/${mode}-durability-order` });
     const config = {
       id: `${mode}-durability-order`,
       model: `hosted/${mode}-durability-order`,
@@ -148,28 +95,10 @@ for (const mode of ["generate", "stream"] as const) {
 
 it("a new runtime restores a persisted checkpoint and calls the target without another search", async () => {
   let checkpoint: ToolExposureCheckpoint | undefined;
-  let firstStep = 0;
-  const firstModel: ModelRuntime = {
-    provider: "hosted",
-    modelId: "hosted/checkpoint-first-invocation",
-    async doGenerate() {
-      firstStep++;
-      return firstStep === 1
-        ? {
-          content: [{
-            type: "tool-call",
-            toolCallId: "search-1",
-            toolName: "tool_search",
-            input: JSON.stringify({ query: "get_release" }),
-          }],
-          finishReason: "tool-calls",
-        }
-        : { content: [{ type: "text", text: "pause" }], finishReason: "stop" };
-    },
-    async doStream() {
-      return { stream: new ReadableStream() };
-    },
-  };
+  const firstModel = scriptedModel([
+    { toolCalls: [{ id: "search-1", name: "tool_search", input: { query: "get_release" } }] },
+    { text: "pause" },
+  ], { modelId: "hosted/checkpoint-first-invocation", only: "generate" });
   const baseConfig = {
     model: "hosted/checkpoint-first-invocation",
     system: "Use tools.",
@@ -191,31 +120,10 @@ it("a new runtime restores a persisted checkpoint and calls the target without a
   ).generate({ input: "Find the release" });
 
   let targetExecutions = 0;
-  let resumedStep = 0;
-  const resumedModel: ModelRuntime = {
-    provider: "hosted",
-    modelId: "hosted/checkpoint-second-invocation",
-    async doGenerate(options: unknown) {
-      resumedStep++;
-      const names = toolNames(options);
-      if (resumedStep === 1) {
-        assertEquals(names.includes("get_release"), true);
-        return {
-          content: [{
-            type: "tool-call",
-            toolCallId: "release-1",
-            toolName: "get_release",
-            input: "{}",
-          }],
-          finishReason: "tool-calls",
-        };
-      }
-      return { content: [{ type: "text", text: "done" }], finishReason: "stop" };
-    },
-    async doStream() {
-      return { stream: new ReadableStream() };
-    },
-  };
+  const resumedModel = scriptedModel([
+    { toolCalls: [{ id: "release-1", name: "get_release", input: {} }] },
+    { text: "done" },
+  ], { modelId: "hosted/checkpoint-second-invocation", only: "generate" });
   const response = await agent(
     {
       ...baseConfig,
@@ -227,43 +135,17 @@ it("a new runtime restores a persisted checkpoint and calls the target without a
     } as AgentConfig & RuntimeToolFilterConfig,
   ).generate({ input: "Continue" });
 
+  assertEquals(resumedModel.toolNames(0).includes("get_release"), true);
   assertEquals(targetExecutions, 1);
   assertEquals(response.toolCalls.some((call) => call.name === "tool_search"), false);
 });
 
 it("stream exposes a restored tool on step zero without another search", async () => {
-  const observedTools: string[][] = [];
-  let step = 0;
   let targetExecutions = 0;
-  const model: ModelRuntime = {
-    provider: "hosted",
-    modelId: "hosted/stream-restored-checkpoint",
-    async doGenerate() {
-      return { content: [{ type: "text", text: "unused" }] };
-    },
-    async doStream(options: unknown) {
-      observedTools.push(toolNames(options));
-      step++;
-      return {
-        stream: createRuntimeStream(
-          step === 1
-            ? [
-              {
-                type: "tool-call",
-                toolCallId: "release-1",
-                toolName: "get_release",
-                input: {},
-              },
-              { type: "finish", finishReason: "tool-calls" },
-            ]
-            : [
-              { type: "text-delta", text: "done" },
-              { type: "finish", finishReason: "stop" },
-            ],
-        ),
-      };
-    },
-  };
+  const model = scriptedModel([
+    { toolCalls: [{ id: "release-1", name: "get_release", input: {} }] },
+    { text: "done" },
+  ], { modelId: "hosted/stream-restored-checkpoint", only: "stream" });
 
   await runRuntime(
     "stream",
@@ -281,36 +163,16 @@ it("stream exposes a restored tool on step zero without another search", async (
     "Continue",
   );
 
-  assertEquals(observedTools[0], ["get_release"]);
+  assertEquals(model.toolNames(0), ["get_release"]);
   assertEquals(targetExecutions, 1);
 });
 
 for (const mode of ["generate", "stream"] as const) {
   it(`${mode} drops restored tools removed from the authorized catalog`, async () => {
-    let observedTools: string[] = [];
-    const observe = (options: unknown) => {
-      observedTools = toolNames(options);
-      return { finishReason: "stop" as const };
-    };
-    const model: ModelRuntime = {
-      provider: "hosted",
-      modelId: `hosted/${mode}-revoked-checkpoint`,
-      async doGenerate(options: unknown) {
-        return {
-          ...observe(options),
-          content: [{ type: "text", text: "done" }],
-        };
-      },
-      async doStream(options: unknown) {
-        const result = observe(options);
-        return {
-          stream: createRuntimeStream([
-            { type: "text-delta", text: "done" },
-            { type: "finish", finishReason: result.finishReason },
-          ]),
-        };
-      },
-    };
+    const model = scriptedModel(
+      [{ text: "done" }],
+      { modelId: `hosted/${mode}-revoked-checkpoint` },
+    );
 
     await runRuntime(
       mode,
@@ -328,37 +190,15 @@ for (const mode of ["generate", "stream"] as const) {
       "Continue",
     );
 
-    assertEquals(observedTools, ["tool_search"]);
+    assertEquals(model.toolNames(model.callCount - 1), ["tool_search"]);
   });
 }
 
 it("restores the invocation checkpoint only on step zero", async () => {
-  let step = 0;
-  const model: ModelRuntime = {
-    provider: "hosted",
-    modelId: "hosted/checkpoint-step-zero",
-    async doGenerate(options: unknown) {
-      step++;
-      if (step === 1) {
-        assertEquals(toolNames(options).includes("get_release"), true);
-        return {
-          content: [{
-            type: "tool-call",
-            toolCallId: "search-1",
-            toolName: "tool_search",
-            input: JSON.stringify({ query: "list_projects" }),
-          }],
-          finishReason: "tool-calls",
-        };
-      }
-      assertEquals(toolNames(options).includes("get_release"), true);
-      assertEquals(toolNames(options).includes("list_projects"), true);
-      return { content: [{ type: "text", text: "done" }], finishReason: "stop" };
-    },
-    async doStream() {
-      return { stream: new ReadableStream() };
-    },
-  };
+  const model = scriptedModel([
+    { toolCalls: [{ id: "search-1", name: "tool_search", input: { query: "list_projects" } }] },
+    { text: "done" },
+  ], { modelId: "hosted/checkpoint-step-zero", only: "generate" });
   const config = {
     id: "checkpoint-step-zero",
     model: "hosted/checkpoint-step-zero",
@@ -378,31 +218,17 @@ it("restores the invocation checkpoint only on step zero", async () => {
   } as AgentConfig & RuntimeToolFilterConfig;
 
   await agent(config).generate({ input: "Continue" });
+
+  assertEquals(model.toolNames(0).includes("get_release"), true);
+  assertEquals(model.toolNames(1).includes("get_release"), true);
+  assertEquals(model.toolNames(1).includes("list_projects"), true);
 });
 
 it("required durable checkpoint persistence fails closed when the callback is absent", async () => {
-  let modelCalls = 0;
-  const model: ModelRuntime = {
-    provider: "hosted",
-    modelId: "hosted/missing-checkpoint-persister",
-    async doGenerate() {
-      modelCalls++;
-      return modelCalls === 1
-        ? {
-          content: [{
-            type: "tool-call",
-            toolCallId: "search-1",
-            toolName: "tool_search",
-            input: JSON.stringify({ query: "get_release" }),
-          }],
-          finishReason: "tool-calls",
-        }
-        : { content: [{ type: "text", text: "must not run" }], finishReason: "stop" };
-    },
-    async doStream() {
-      return { stream: new ReadableStream() };
-    },
-  };
+  const model = scriptedModel([
+    { toolCalls: [{ id: "search-1", name: "tool_search", input: { query: "get_release" } }] },
+    { text: "must not run" },
+  ], { modelId: "hosted/missing-checkpoint-persister", only: "generate" });
   const config = {
     id: "missing-checkpoint-persister",
     model: "hosted/missing-checkpoint-persister",
@@ -420,41 +246,15 @@ it("required durable checkpoint persistence fails closed when the callback is ab
     Error,
     "checkpoint persistence is required",
   );
-  assertEquals(modelCalls, 1);
+  assertEquals(model.callCount, 1);
 });
 
 it("checkpoint persistence rejection aborts before continuation and target execution", async () => {
-  let modelCalls = 0;
   let targetExecutions = 0;
-  const model: ModelRuntime = {
-    provider: "hosted",
-    modelId: "hosted/rejected-checkpoint-persister",
-    async doGenerate() {
-      modelCalls++;
-      return modelCalls === 1
-        ? {
-          content: [{
-            type: "tool-call",
-            toolCallId: "search-1",
-            toolName: "tool_search",
-            input: JSON.stringify({ query: "get_release" }),
-          }],
-          finishReason: "tool-calls",
-        }
-        : {
-          content: [{
-            type: "tool-call",
-            toolCallId: "release-1",
-            toolName: "get_release",
-            input: "{}",
-          }],
-          finishReason: "tool-calls",
-        };
-    },
-    async doStream() {
-      return { stream: new ReadableStream() };
-    },
-  };
+  const model = scriptedModel([
+    { toolCalls: [{ id: "search-1", name: "tool_search", input: { query: "get_release" } }] },
+    { toolCalls: [{ id: "release-1", name: "get_release", input: {} }] },
+  ], { modelId: "hosted/rejected-checkpoint-persister", only: "generate" });
   const config = {
     id: "rejected-checkpoint-persister",
     model: "hosted/rejected-checkpoint-persister",
@@ -473,40 +273,15 @@ it("checkpoint persistence rejection aborts before continuation and target execu
     Error,
     "checkpoint rejected",
   );
-  assertEquals(modelCalls, 1);
+  assertEquals(model.callCount, 1);
   assertEquals(targetExecutions, 0);
 });
 
 it("stream checkpoint persistence rejection is reported before continuation", async () => {
-  let modelCalls = 0;
-  const model: ModelRuntime = {
-    provider: "hosted",
-    modelId: "hosted/rejected-stream-checkpoint-persister",
-    async doGenerate() {
-      return { content: [{ type: "text", text: "unused" }] };
-    },
-    async doStream() {
-      modelCalls++;
-      return {
-        stream: createRuntimeStream(
-          modelCalls === 1
-            ? [
-              {
-                type: "tool-call",
-                toolCallId: "search-1",
-                toolName: "tool_search",
-                input: { query: "get_release" },
-              },
-              { type: "finish", finishReason: "tool-calls" },
-            ]
-            : [
-              { type: "text-delta", text: "must not run" },
-              { type: "finish", finishReason: "stop" },
-            ],
-        ),
-      };
-    },
-  };
+  const model = scriptedModel([
+    { toolCalls: [{ id: "search-1", name: "tool_search", input: { query: "get_release" } }] },
+    { text: "must not run" },
+  ], { modelId: "hosted/rejected-stream-checkpoint-persister", only: "stream" });
   const body = await runRuntime(
     "stream",
     {
@@ -523,6 +298,6 @@ it("stream checkpoint persistence rejection is reported before continuation", as
     } as AgentConfig & RuntimeToolFilterConfig,
   );
 
-  assertEquals(modelCalls, 1);
+  assertEquals(model.callCount, 1);
   assertEquals(String(body).includes("checkpoint rejected"), true);
 });

--- a/src/agent/runtime/tool-exposure-runtime.test.ts
+++ b/src/agent/runtime/tool-exposure-runtime.test.ts
@@ -1,7 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { it } from "#veryfront/testing/bdd.ts";
-import type { ModelRuntime } from "#veryfront/provider";
 import { defineSchema } from "#veryfront/schemas";
 import { tool } from "#veryfront/tool";
 import {
@@ -10,82 +9,20 @@ import {
 } from "#veryfront/utils/logger/index.ts";
 import { agent } from "../index.ts";
 import type { AgentConfig } from "../types.ts";
+import { type ScriptedModel, scriptedModel } from "./model-runtime.test-helpers.ts";
 import type { RuntimeToolFilterConfig } from "./runtime-tool-config.ts";
 import { flattenSystemInstructions, withRuntimeToolInventory } from "./tool-inventory.ts";
 
-function toolNames(options: unknown): string[] {
-  const value = (options as { tools?: unknown }).tools;
-  return Array.isArray(value)
-    ? value.map((tool) =>
-      (tool as { name?: string; id?: string }).name ??
-        (tool as { name?: string; id?: string }).id ?? ""
-    ).sort()
-    : Object.keys((value as Record<string, unknown> | undefined) ?? {}).sort();
-}
-
-function createRuntimeStream(parts: unknown[]): ReadableStream<unknown> {
-  return new ReadableStream({
-    start(controller) {
-      for (const part of parts) controller.enqueue(part);
-      controller.close();
-    },
-  });
-}
-
-function systemPrompt(options: unknown): string {
-  const prompt = (options as { prompt?: Array<{ role?: string; content?: unknown }> }).prompt;
-  if (!Array.isArray(prompt)) return "";
-  return prompt
-    .filter((entry) => entry?.role === "system" && typeof entry.content === "string")
-    .map((entry) => entry.content as string)
-    .join("\n");
+function observedToolNames(model: ScriptedModel): string[][] {
+  return model.calls.map((_, call) => model.toolNames(call));
 }
 
 it("deferred generate searches, exposes on the next step, and executes once", async () => {
-  const observedTools: string[][] = [];
-  const observedSystems: string[] = [];
-  let step = 0;
-  const model: ModelRuntime = {
-    provider: "hosted",
-    modelId: "hosted/deferred-tools",
-    async doGenerate(options: unknown) {
-      observedTools.push(toolNames(options));
-      observedSystems.push(systemPrompt(options));
-      step++;
-      if (step === 1) {
-        return {
-          content: [{
-            type: "tool-call",
-            toolCallId: "search-1",
-            toolName: "tool_search",
-            input: JSON.stringify({ query: "release marker" }),
-          }],
-          finishReason: "tool-calls",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
-      }
-      if (step === 2) {
-        return {
-          content: [{
-            type: "tool-call",
-            toolCallId: "marker-1",
-            toolName: "read_release_marker",
-            input: "{}",
-          }],
-          finishReason: "tool-calls",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
-      }
-      return {
-        content: [{ type: "text", text: "Release marker marker-1" }],
-        finishReason: "stop",
-        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-      };
-    },
-    async doStream() {
-      return { stream: new ReadableStream() };
-    },
-  };
+  const model = scriptedModel([
+    { toolCalls: [{ id: "search-1", name: "tool_search", input: { query: "release marker" } }] },
+    { toolCalls: [{ id: "marker-1", name: "read_release_marker", input: {} }] },
+    { text: "Release marker marker-1" },
+  ], { modelId: "hosted/deferred-tools", only: "generate" });
   let executionCount = 0;
   const assistant = agent(
     {
@@ -123,8 +60,9 @@ it("deferred generate searches, exposes on the next step, and executes once", as
 
   const response = await assistant.generate({ input: "Read the release marker" });
 
-  assertEquals(observedTools[0], ["load_skill", "tool_search"]);
-  assertEquals(observedTools[1], [
+  const observedSystems = model.systemPrompts();
+  assertEquals(model.toolNames(0), ["load_skill", "tool_search"]);
+  assertEquals(model.toolNames(1), [
     "load_skill",
     "read_release_marker",
     "tool_search",
@@ -137,50 +75,25 @@ it("deferred generate searches, exposes on the next step, and executes once", as
 });
 
 it("deferred generate can reload create_agent after a successful agent write", async () => {
-  const observedTools: string[][] = [];
-  const observedSystems: string[] = [];
-  let step = 0;
-  const model: ModelRuntime = {
-    provider: "hosted",
-    modelId: "hosted/deferred-agent-authoring",
-    async doGenerate(options: unknown) {
-      observedTools.push(toolNames(options));
-      observedSystems.push(systemPrompt(options));
-      step++;
-      if (step === 1 || step === 3) {
-        return {
-          content: [{
-            type: "tool-call",
-            toolCallId: `search-create-agent-${step}`,
-            toolName: "tool_search",
-            input: JSON.stringify({ query: "create_agent" }),
-          }],
-          finishReason: "tool-calls",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
-      }
-      if (step === 2 || step === 4) {
-        return {
-          content: [{
-            type: "tool-call",
-            toolCallId: `create-agent-${step}`,
-            toolName: "create_agent",
-            input: JSON.stringify({ id: `agent-${step}` }),
-          }],
-          finishReason: "tool-calls",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
-      }
-      return {
-        content: [{ type: "text", text: "Created both agents." }],
-        finishReason: "stop",
-        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-      };
+  const model = scriptedModel([
+    {
+      toolCalls: [{
+        id: "search-create-agent-1",
+        name: "tool_search",
+        input: { query: "create_agent" },
+      }],
     },
-    async doStream() {
-      return { stream: new ReadableStream() };
+    { toolCalls: [{ id: "create-agent-2", name: "create_agent", input: { id: "agent-2" } }] },
+    {
+      toolCalls: [{
+        id: "search-create-agent-3",
+        name: "tool_search",
+        input: { query: "create_agent" },
+      }],
     },
-  };
+    { toolCalls: [{ id: "create-agent-4", name: "create_agent", input: { id: "agent-4" } }] },
+    { text: "Created both agents." },
+  ], { modelId: "hosted/deferred-agent-authoring", only: "generate" });
   let executionCount = 0;
   const assistant = agent(
     {
@@ -223,7 +136,8 @@ it("deferred generate can reload create_agent after a successful agent write", a
 
   const response = await assistant.generate({ input: "Create two project agents" });
 
-  assertEquals(observedTools, [
+  const observedSystems = model.systemPrompts();
+  assertEquals(observedToolNames(model), [
     ["load_skill", "tool_search"],
     ["create_agent", "load_skill", "tool_search"],
     ["load_skill", "tool_search"],
@@ -243,53 +157,25 @@ it("deferred generate can reload create_agent after a successful agent write", a
 });
 
 it("deferred stream can reload another agent write tool after a successful write", async () => {
-  const observedTools: string[][] = [];
-  const observedSystems: string[] = [];
-  let step = 0;
-  const model: ModelRuntime = {
-    provider: "hosted",
-    modelId: "hosted/deferred-agent-authoring-stream",
-    async doGenerate() {
-      return { content: [{ type: "text", text: "unused" }] };
+  const model = scriptedModel([
+    {
+      toolCalls: [{
+        id: "search-create-agent-1",
+        name: "tool_search",
+        input: { query: "create_agent" },
+      }],
     },
-    async doStream(options: unknown) {
-      observedTools.push(toolNames(options));
-      observedSystems.push(systemPrompt(options));
-      step++;
-      if (step === 1 || step === 3) {
-        return {
-          stream: createRuntimeStream([
-            {
-              type: "tool-call",
-              toolCallId: `search-create-agent-${step}`,
-              toolName: "tool_search",
-              input: { query: step === 1 ? "create_agent" : "update_agent" },
-            },
-            { type: "finish", finishReason: "tool-calls" },
-          ]),
-        };
-      }
-      if (step === 2 || step === 4) {
-        return {
-          stream: createRuntimeStream([
-            {
-              type: "tool-call",
-              toolCallId: `create-agent-${step}`,
-              toolName: step === 2 ? "create_agent" : "update_agent",
-              input: { id: `agent-${step}` },
-            },
-            { type: "finish", finishReason: "tool-calls" },
-          ]),
-        };
-      }
-      return {
-        stream: createRuntimeStream([
-          { type: "text-delta", text: "Created both agents." },
-          { type: "finish", finishReason: "stop" },
-        ]),
-      };
+    { toolCalls: [{ id: "create-agent-2", name: "create_agent", input: { id: "agent-2" } }] },
+    {
+      toolCalls: [{
+        id: "search-create-agent-3",
+        name: "tool_search",
+        input: { query: "update_agent" },
+      }],
     },
-  };
+    { toolCalls: [{ id: "create-agent-4", name: "update_agent", input: { id: "agent-4" } }] },
+    { text: "Created both agents." },
+  ], { modelId: "hosted/deferred-agent-authoring-stream", only: "stream" });
   const executionCounts = { create: 0, update: 0 };
   const assistant = agent(
     {
@@ -342,7 +228,8 @@ it("deferred stream can reload another agent write tool after a successful write
   const response = await assistant.stream({ input: "Create two project agents" });
   const body = await response.toDataStreamResponse().text();
 
-  assertEquals(observedTools, [
+  const observedSystems = model.systemPrompts();
+  assertEquals(observedToolNames(model), [
     ["load_skill", "tool_search"],
     ["create_agent", "load_skill", "tool_search"],
     ["load_skill", "tool_search"],
@@ -362,59 +249,28 @@ it("deferred stream can reload another agent write tool after a successful write
 });
 
 it("deferred generate activates and executes provider-native web search on demand", async () => {
-  const observedTools: string[][] = [];
-  const observedSystems: string[] = [];
-  let step = 0;
-  const model: ModelRuntime = {
-    provider: "anthropic",
-    modelId: "claude-sonnet-4-6",
-    async doGenerate(options: unknown) {
-      observedTools.push(toolNames(options));
-      observedSystems.push(systemPrompt(options));
-      step++;
-      if (step === 1) {
-        return {
-          content: [{
-            type: "tool-call",
-            toolCallId: "search-native-1",
-            toolName: "tool_search",
-            input: JSON.stringify({ query: "web_search" }),
-          }],
-          finishReason: "tool-calls",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
-      }
-      if (step === 2) {
-        return {
-          content: [
-            {
-              type: "tool-call",
-              toolCallId: "web-search-1",
-              toolName: "web_search",
-              input: JSON.stringify({ query: "Veryfront" }),
-            },
-            {
-              type: "tool-result",
-              toolCallId: "web-search-1",
-              toolName: "web_search",
-              result: { results: [{ title: "Veryfront" }] },
-              providerExecuted: true,
-            },
-          ],
-          finishReason: "tool-calls",
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-        };
-      }
-      return {
-        content: [{ type: "text", text: "Found Veryfront." }],
-        finishReason: "stop",
-        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-      };
+  const model = scriptedModel([
+    { toolCalls: [{ id: "search-native-1", name: "tool_search", input: { query: "web_search" } }] },
+    {
+      content: [
+        {
+          type: "tool-call",
+          toolCallId: "web-search-1",
+          toolName: "web_search",
+          input: JSON.stringify({ query: "Veryfront" }),
+        },
+        {
+          type: "tool-result",
+          toolCallId: "web-search-1",
+          toolName: "web_search",
+          result: { results: [{ title: "Veryfront" }] },
+          providerExecuted: true,
+        },
+      ],
+      finishReason: "tool-calls",
     },
-    async doStream() {
-      return { stream: new ReadableStream() };
-    },
-  };
+    { text: "Found Veryfront." },
+  ], { provider: "anthropic", modelId: "claude-sonnet-4-6", only: "generate" });
   const assistant = agent(
     {
       id: "deferred-provider-native-test",
@@ -431,9 +287,10 @@ it("deferred generate activates and executes provider-native web search on deman
 
   const response = await assistant.generate({ input: "Search the web for Veryfront" });
 
-  assertEquals(observedTools[0], ["tool_search"]);
-  assertEquals(observedTools[1], ["tool_search", "web_search"]);
-  assertEquals(observedTools[2], ["tool_search", "web_search"]);
+  const observedSystems = model.systemPrompts();
+  assertEquals(model.toolNames(0), ["tool_search"]);
+  assertEquals(model.toolNames(1), ["tool_search", "web_search"]);
+  assertEquals(model.toolNames(2), ["tool_search", "web_search"]);
   assertEquals((observedSystems[0] ?? "").includes("web_search"), false);
   assertEquals((observedSystems[0] ?? "").includes("web_fetch"), false);
   assertEquals((observedSystems[1] ?? "").includes("web_search"), false);
@@ -445,33 +302,11 @@ it("deferred generate activates and executes provider-native web search on deman
 });
 
 it("deferred generate rejects a guessed tool that was not exposed", async () => {
-  let step = 0;
   let executionCount = 0;
-  const model: ModelRuntime = {
-    provider: "hosted",
-    modelId: "hosted/deferred-guessed-tool",
-    async doGenerate() {
-      step++;
-      if (step === 1) {
-        return {
-          content: [{
-            type: "tool-call",
-            toolCallId: "guessed-1",
-            toolName: "get_release",
-            input: "{}",
-          }],
-          finishReason: "tool-calls",
-        };
-      }
-      return {
-        content: [{ type: "text", text: "done" }],
-        finishReason: "stop",
-      };
-    },
-    async doStream() {
-      return { stream: new ReadableStream() };
-    },
-  };
+  const model = scriptedModel([
+    { toolCalls: [{ id: "guessed-1", name: "get_release", input: {} }] },
+    { text: "done" },
+  ], { modelId: "hosted/deferred-guessed-tool", only: "generate" });
   const assistant = agent(
     {
       id: "deferred-guessed-generate",

--- a/tests/chat/chat-handler-fallback.test.ts
+++ b/tests/chat/chat-handler-fallback.test.ts
@@ -7,27 +7,17 @@ import "#veryfront/schemas/_test-setup.ts";
 import { describe, it } from "#veryfront/testing/bdd";
 import { assertEquals } from "#veryfront/testing/assert";
 import { deleteEnv, getEnv, setEnv } from "#veryfront/testing/deno-compat";
-import type { ModelRuntime } from "../../src/provider/types.ts";
+import { scriptedModel } from "../../src/agent/runtime/model-runtime.test-helpers.ts";
 
 import { createError, fromError, toError } from "#veryfront/errors";
 
-function createMockStreamingModel(
-  provider: string,
-  modelId: string,
-  parts: unknown[],
-): ModelRuntime {
-  return {
+function createMockStreamingModel(provider: string, modelId: string, text: string) {
+  return scriptedModel([{ text }], {
     provider,
     modelId,
     specificationVersion: "v3",
-    doGenerate: async () => ({
-      content: [],
-      finishReason: { unified: "stop", raw: "stop" },
-    }),
-    doStream: async () => ({
-      stream: ReadableStream.from(parts),
-    }),
-  };
+    only: "stream",
+  });
 }
 
 describe("no_ai_available error type", () => {
@@ -219,17 +209,7 @@ describe("runtime inference mode metadata", () => {
       );
       clearModelProviders();
 
-      const mockModel = createMockStreamingModel("mock", "mock-model", [
-        { type: "text-delta", delta: "Hi" },
-        {
-          type: "finish",
-          finishReason: { unified: "stop", raw: "stop" },
-          usage: {
-            inputTokens: { total: 5 },
-            outputTokens: { total: 1 },
-          },
-        },
-      ]);
+      const mockModel = createMockStreamingModel("mock", "mock-model", "Hi");
 
       // Register as "mock" provider to test cloud inferenceMode detection
       registerModelProvider("mock", () => mockModel);
@@ -350,17 +330,7 @@ describe("runtime inference mode metadata", () => {
       );
       clearModelProviders();
 
-      const mockLocal = createMockStreamingModel("local", "qwen3.5-0.8b", [
-        { type: "text-delta", delta: "Hi" },
-        {
-          type: "finish",
-          finishReason: { unified: "stop", raw: "stop" },
-          usage: {
-            inputTokens: { total: 5 },
-            outputTokens: { total: 1 },
-          },
-        },
-      ]);
+      const mockLocal = createMockStreamingModel("local", "qwen3.5-0.8b", "Hi");
 
       registerModelProvider("local", () => mockLocal);
 
@@ -429,17 +399,7 @@ describe("runtime inference mode metadata", () => {
       );
       clearModelProviders();
 
-      const mockLocal = createMockStreamingModel("local", "qwen3.5-0.8b", [
-        { type: "text-delta", delta: "Hi from local" },
-        {
-          type: "finish",
-          finishReason: { unified: "stop", raw: "stop" },
-          usage: {
-            inputTokens: { total: 5 },
-            outputTokens: { total: 3 },
-          },
-        },
-      ]);
+      const mockLocal = createMockStreamingModel("local", "qwen3.5-0.8b", "Hi from local");
 
       registerModelProvider("local", () => mockLocal);
 

--- a/tests/chat/chat-handler-fallback.test.ts
+++ b/tests/chat/chat-handler-fallback.test.ts
@@ -7,7 +7,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { describe, it } from "#veryfront/testing/bdd";
 import { assertEquals } from "#veryfront/testing/assert";
 import { deleteEnv, getEnv, setEnv } from "#veryfront/testing/deno-compat";
-import { scriptedModel } from "../../src/agent/runtime/model-runtime.test-helpers.ts";
+import { scriptedModel } from "#veryfront/agent/runtime/model-runtime.test-helpers.ts";
 
 import { createError, fromError, toError } from "#veryfront/errors";
 


### PR DESCRIPTION
## Why

38 test files each declare their own fake LLM provider as a `ModelRuntime` object literal (~148 `doStream` literals); `createRuntimeStream` is hand-copied in 8 files with 6 more cousins, and the request-capture extractors exist in 5+ copies. Worse, four fakes emitted `{type:"text-delta", delta:}` where production reads `.text`, so the part was silently dropped and the tests passed without their reply ever reaching the client.

## What

- **`src/agent/runtime/model-runtime.test-helpers.ts`**: `scriptedModel(turns, options)` returning a typed `ScriptedModel` with `calls`, `callCount`, `systemPrompts()`, `toolNames()`; turns are `text | toolCalls | parts | content | hangUntilAbort`, or a function deriving a turn from the captured call (echo/probe models); `only: "generate" | "stream"` covers the "must not be called" idiom; plus shared `runtimeStream(parts)`, `systemPromptOf`, `toolNamesOf`. Placed in agent/runtime (not provider) because `RuntimeStreamPart` lives there and the provider layer must not import agent internals. Parts are typed, so the `delta:` vs `text:` mistake no longer compiles.
- **12 files migrated** (11 fully; `refresh.test.ts` partially: its 41 bespoke stream literals stay, now typed through `runtimeStream`). Every obsoleted local helper deleted; both `as unknown as ModelRuntime` casts gone. Net **-1,183 lines**.
- **The vacuous-assertion defect is closed and strengthened**: the lifecycle-loop and reconcile tests now assert their "Done" reply actually reaches the client, honest under both `VF_STREAM_LIFECYCLE_MODE` paths.

## Deliberately untouched

The wire-shape family (real `createGoogleModelRuntime` + recorded SSE + fake fetch), type-level `provider/types.test.ts`, the property-descriptor probes, and `orchestrate.test.ts`. ~26 more files with hand-rolled fakes can adopt the helper incrementally.

## Verification

All 12 files pass individually with identical test names and step counts, and together under `--parallel` (30 passed, 111 steps). Semantic dispositions unchanged (2141/762); `test:layout`, anti-slop, dependency/module boundaries, sanitizer 404, skipped 18, ban-test-only, cwd-reads: all ok. Pre-push gate passed on push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added shared scripted model utilities for consistent testing of generated text, tool calls, streams, metadata, usage, cancellation, and call tracking.
  * Migrated agent runtime and chat fallback tests to the shared helpers without changing covered behavior.
  * Expanded validation for exhausted scripts, invalid configurations, repeated turns, provider metadata, streaming, cancellation, tool exposure, and delegation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->