### PR TITLE
fix(runs): harden durable run contracts

### DIFF
--- a/docs/api-reference/veryfront/runs.md
+++ b/docs/api-reference/veryfront/runs.md
@@ -54,7 +54,7 @@ const events = await runs.events(accepted.run.run_id);
 
 | Name               | Description           | Source                                                                                       |
 | ------------------ | --------------------- | -------------------------------------------------------------------------------------------- |
-| `createRunsClient` | Create a runs client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L499) |
+| `createRunsClient` | Create a runs client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L500) |
 
 ### Classes
 

--- a/docs/api-reference/veryfront/runs.md
+++ b/docs/api-reference/veryfront/runs.md
@@ -40,15 +40,15 @@ const events = await runs.events(accepted.run.run_id);
 
 ### Components
 
-| Name                              | Description                                              | Source                                                                                   |
-| --------------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `CancelRunResponseSchema`         | Zod schema for a cancel-run response.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L187) |
-| `CreateRunResponseSchema`         | Zod schema for a create-run response.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L181) |
-| `RunEventListSchema`              | Zod schema for a paginated run-event response.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L191) |
-| `RunEventSchema`                  | Zod schema for a run event.                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L189) |
-| `RunListSchema`                   | Zod schema for a paginated project-run response.         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L193) |
-| `RunSchema`                       | Zod schema for a canonical durable run.                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L179) |
-| `ScheduleRunCreateResponseSchema` | Zod schema for a schedule-triggered create-run response. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L183) |
+| Name                              | Description                                                                                                                                                              | Source                                                                                   |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| `CancelRunResponseSchema`         | Zod schema for a cancel-run response.                                                                                                                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L194) |
+| `CreateRunResponseSchema`         | Zod schema for a create-run response.                                                                                                                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L185) |
+| `RunEventListSchema`              | Zod schema for a paginated run-event response.                                                                                                                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L198) |
+| `RunEventSchema`                  | Zod schema for a run event whose `event_id` is a non-negative integer.                                                                                                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L196) |
+| `RunListSchema`                   | Zod schema for a paginated project-run response.                                                                                                                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L200) |
+| `RunSchema`                       | Zod schema for a canonical durable run whose `duration_ms` and `backoff_limit` are non-negative integers and whose `timeout_seconds` is a positive integer when present. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L183) |
+| `ScheduleRunCreateResponseSchema` | Zod schema for a schedule-triggered create-run response.                                                                                                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L187) |
 
 ### Functions
 
@@ -66,9 +66,9 @@ const events = await runs.events(accepted.run.run_id);
 
 | Name                                 | Description                                                             | Source                                                                                       |
 | ------------------------------------ | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `CancelRunResponse`                  | Response returned when a run is cancelled.                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L216)     |
+| `CancelRunResponse`                  | Response returned when a run is cancelled.                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L223)     |
 | `CreateEvalRunInput`                 | Input payload for creating an eval run.                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L80)  |
-| `CreateRunResponse`                  | Response returned when a run is accepted.                               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L210)     |
+| `CreateRunResponse`                  | Response returned when a run is accepted.                               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L217)     |
 | `CreateScheduleRunFromSourceInput`   | Input for resolving and triggering one pushed source-defined schedule.  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L95)  |
 | `CreateScheduleRunFromSourceResult`  | Cloud schedule metadata returned with an accepted source-triggered run. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L102) |
 | `CreateScheduleRunInput`             | Input for triggering one persisted schedule by its canonical UUID.      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L88)  |
@@ -80,15 +80,15 @@ const events = await runs.events(accepted.run.run_id);
 | `ListRunEventsOptions`               |                                                                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L131) |
 | `ListRunsOptions`                    |                                                                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L126) |
 | `ProjectScopedOptions`               | Options accepted by project-scoped run requests.                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L43)  |
-| `Run`                                | Canonical durable run.                                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L208)     |
-| `RunEvent`                           | Event emitted by a run.                                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L218)     |
-| `RunExecutionError`                  | Error payload recorded for failed task and workflow runs.               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L206)     |
-| `RunKind`                            | Canonical durable run kind.                                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L196)     |
-| `RunList`                            | Paginated project run response.                                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L222)     |
-| `RunOwner`                           | Canonical durable run owner.                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L200)     |
+| `Run`                                | Canonical durable run.                                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L215)     |
+| `RunEvent`                           | Event emitted by a run.                                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L225)     |
+| `RunExecutionError`                  | Error payload recorded for failed task and workflow runs.               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L213)     |
+| `RunKind`                            | Canonical durable run kind.                                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L203)     |
+| `RunList`                            | Paginated project run response.                                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L229)     |
+| `RunOwner`                           | Canonical durable run owner.                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L207)     |
 | `RunRuntimeTargetKind`               | Runtime target for a task, workflow, or eval run.                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L48)  |
 | `RunRuntimeTargetOptions`            | Runtime target fields accepted by run creation APIs.                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L51)  |
-| `RunStatus`                          | Canonical durable run status.                                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L198)     |
-| `RunTriggerKind`                     | Trigger kind recorded on scheduled or externally-started runs.          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L204)     |
-| `ScheduleRunCreateResponse`          | Response returned when a schedule-triggered run is accepted.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L212)     |
+| `RunStatus`                          | Canonical durable run status.                                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L205)     |
+| `RunTriggerKind`                     | Trigger kind recorded on scheduled or externally-started runs.          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L211)     |
+| `ScheduleRunCreateResponse`          | Response returned when a schedule-triggered run is accepted.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/schemas.ts#L219)     |
 | `VeryfrontRunsClientConfig`          | Configuration used by the Veryfront runs client.                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/runs/runs-client.ts#L35)  |

--- a/src/runs/index.test.ts
+++ b/src/runs/index.test.ts
@@ -1,0 +1,47 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import * as runsModule from "./index.ts";
+import * as publicRunsModule from "veryfront/runs";
+import * as clientModule from "./runs-client.ts";
+import * as schemaModule from "./schemas.ts";
+
+const expectedRuntimeExports = [
+  "CancelRunResponseSchema",
+  "CreateRunResponseSchema",
+  "RunEventListSchema",
+  "RunEventSchema",
+  "RunListSchema",
+  "RunSchema",
+  "ScheduleRunCreateResponseSchema",
+  "VeryfrontRunsClient",
+  "createRunsClient",
+];
+
+describe("runs/index.ts exports", () => {
+  it("preserves the runtime export surface for veryfront/runs", () => {
+    assertEquals(Object.keys(runsModule).sort(), expectedRuntimeExports);
+    assertEquals(Object.keys(publicRunsModule).sort(), expectedRuntimeExports);
+  });
+
+  it("keeps public exports wired to their owning modules", () => {
+    assertStrictEquals(runsModule.createRunsClient, clientModule.createRunsClient);
+    assertStrictEquals(runsModule.VeryfrontRunsClient, clientModule.VeryfrontRunsClient);
+    assertStrictEquals(runsModule.RunSchema, schemaModule.RunSchema);
+    assertStrictEquals(runsModule.RunEventSchema, schemaModule.RunEventSchema);
+    assertStrictEquals(runsModule.RunEventListSchema, schemaModule.RunEventListSchema);
+    assertStrictEquals(runsModule.RunListSchema, schemaModule.RunListSchema);
+    assertStrictEquals(
+      runsModule.CreateRunResponseSchema,
+      schemaModule.CreateRunResponseSchema,
+    );
+    assertStrictEquals(
+      runsModule.ScheduleRunCreateResponseSchema,
+      schemaModule.ScheduleRunCreateResponseSchema,
+    );
+    assertStrictEquals(
+      runsModule.CancelRunResponseSchema,
+      schemaModule.CancelRunResponseSchema,
+    );
+  });
+});

--- a/src/runs/runs-client.test.ts
+++ b/src/runs/runs-client.test.ts
@@ -689,15 +689,22 @@ describe("VeryfrontRunsClient", () => {
   });
 
   it("fails fast when project reference is missing for project listing", async () => {
-    const client = new VeryfrontRunsClient({
-      apiUrl: "https://93.184.216.34",
-      authToken: "test-token",
-    });
+    mockFetch([]);
+    await withEnv(
+      { VERYFRONT_PROJECT_SLUG: "" },
+      async () => {
+        const client = new VeryfrontRunsClient({
+          apiUrl: "https://93.184.216.34",
+          authToken: "test-token",
+        });
 
-    await assertRejects(
-      () => client.list(),
-      Error,
-      "Runs project reference not configured",
+        await assertRejects(
+          () => client.list(),
+          Error,
+          "Runs project reference not configured",
+        );
+      },
     );
+    assertEquals(fetchCalls.length, 0);
   });
 });

--- a/src/runs/runs-client.test.ts
+++ b/src/runs/runs-client.test.ts
@@ -7,15 +7,30 @@ import {
   assertRejects,
   assertStringIncludes,
 } from "#veryfront/testing/assert";
-import { deleteEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import { withEnv } from "#veryfront/testing/deno-compat.ts";
 import { runWithVeryfrontCloudContext } from "#veryfront/provider";
-import { createRunsClient, VeryfrontRunsClient } from "./runs-client.ts";
+import {
+  createRunsClient,
+  VeryfrontRunsClient,
+  type VeryfrontRunsClientConfig,
+} from "./runs-client.ts";
 
 let fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
 let fetchResponses: Array<Response | (() => Response)> = [];
 
 const projectId = "22222222-2222-4222-8222-222222222222";
 const scheduleId = "33333333-3333-4333-8333-333333333333";
+
+function createTestClient(
+  overrides: Partial<VeryfrontRunsClientConfig> = {},
+): VeryfrontRunsClient {
+  return new VeryfrontRunsClient({
+    apiUrl: "https://93.184.216.34",
+    authToken: "test-token",
+    projectReference: "dreamy-haven",
+    ...overrides,
+  });
+}
 
 function mockFetch(responses: Array<Response | (() => Response)>): void {
   fetchCalls = [];
@@ -106,22 +121,6 @@ function makeRun(overrides: Record<string, unknown> = {}) {
   };
 }
 
-const RUNS_ENV_KEYS = [
-  "VERYFRONT_API_URL",
-  "VERYFRONT_API_TOKEN",
-  "VERYFRONT_PROJECT_SLUG",
-] as const;
-
-function clearRunsEnv(): void {
-  for (const key of RUNS_ENV_KEYS) {
-    try {
-      deleteEnv(key);
-    } catch {
-      // env may already be unset
-    }
-  }
-}
-
 describe("VeryfrontRunsClient", () => {
   beforeEach(() => {
     fetchCalls = [];
@@ -130,22 +129,23 @@ describe("VeryfrontRunsClient", () => {
 
   afterEach(() => {
     restoreMockFetch();
-    clearRunsEnv();
   });
 
   it("exports a client factory", () => {
+    const client = createRunsClient({
+      apiUrl: "https://93.184.216.34",
+      authToken: "test-token",
+    });
+
     assertExists(createRunsClient);
     assertEquals(typeof createRunsClient, "function");
+    assertEquals(client instanceof VeryfrontRunsClient, true);
   });
 
   it("creates task runs through canonical /runs", async () => {
     mockFetch([jsonResponse({ accepted: true, run: makeRun() }, 202)]);
 
-    const client = new VeryfrontRunsClient({
-      apiUrl: "https://93.184.216.34",
-      authToken: "test-token",
-      projectReference: "dreamy-haven",
-    });
+    const client = createTestClient();
 
     const response = await client.createTaskRun({
       projectId,
@@ -179,6 +179,18 @@ describe("VeryfrontRunsClient", () => {
     });
   });
 
+  it("normalizes a trailing slash in the configured API URL", async () => {
+    mockFetch([jsonResponse(makeRun())]);
+    const client = createTestClient({ apiUrl: "https://93.184.216.34/" });
+
+    await client.get("run_11111111-1111-4111-8111-111111111111");
+
+    assertEquals(
+      call(0).url,
+      "https://93.184.216.34/runs/run_11111111-1111-4111-8111-111111111111",
+    );
+  });
+
   it("creates workflow runs through canonical /runs", async () => {
     mockFetch([
       jsonResponse({
@@ -187,11 +199,7 @@ describe("VeryfrontRunsClient", () => {
       }, 202),
     ]);
 
-    const client = new VeryfrontRunsClient({
-      apiUrl: "https://93.184.216.34",
-      authToken: "test-token",
-      projectReference: "dreamy-haven",
-    });
+    const client = createTestClient();
 
     await client.createWorkflowRun({
       projectId,
@@ -226,11 +234,7 @@ describe("VeryfrontRunsClient", () => {
       }, 202),
     ]);
 
-    const client = new VeryfrontRunsClient({
-      apiUrl: "https://93.184.216.34",
-      authToken: "test-token",
-      projectReference: "dreamy-haven",
-    });
+    const client = createTestClient();
 
     await client.createEvalRun({
       projectId,
@@ -310,11 +314,7 @@ describe("VeryfrontRunsClient", () => {
       }, 201),
     ]);
 
-    const client = new VeryfrontRunsClient({
-      apiUrl: "https://93.184.216.34",
-      authToken: "test-token",
-      projectReference: "dreamy-haven",
-    });
+    const client = createTestClient();
 
     const response = await client.createScheduleRunFromSource({
       sourceTriggerId: "process-job-submissions",
@@ -360,10 +360,7 @@ describe("VeryfrontRunsClient", () => {
         schedule_id: scheduleId,
       }, 201),
     ]);
-    const client = new VeryfrontRunsClient({
-      apiUrl: "https://93.184.216.34",
-      authToken: "test-token",
-      projectReference: "dreamy-haven",
+    const client = createTestClient({
       retry: {
         maxRetries: 1,
         initialDelay: 1,
@@ -396,11 +393,7 @@ describe("VeryfrontRunsClient", () => {
         source_schedules: [],
       }),
     ]);
-    const client = new VeryfrontRunsClient({
-      apiUrl: "https://93.184.216.34",
-      authToken: "test-token",
-      projectReference: "dreamy-haven",
-    });
+    const client = createTestClient();
 
     await assertRejects(
       () =>
@@ -455,11 +448,7 @@ describe("VeryfrontRunsClient", () => {
         schedule_id: matchingScheduleId,
       }, 201),
     ]);
-    const client = new VeryfrontRunsClient({
-      apiUrl: "https://93.184.216.34",
-      authToken: "test-token",
-      projectReference: "dreamy-haven",
-    });
+    const client = createTestClient();
 
     const response = await client.createScheduleRunFromSource({
       sourceTriggerId: "process-job-submissions",
@@ -489,11 +478,7 @@ describe("VeryfrontRunsClient", () => {
         }],
       }),
     ]);
-    const client = new VeryfrontRunsClient({
-      apiUrl: "https://93.184.216.34",
-      authToken: "test-token",
-      projectReference: "dreamy-haven",
-    });
+    const client = createTestClient();
 
     await assertRejects(
       () =>
@@ -507,19 +492,28 @@ describe("VeryfrontRunsClient", () => {
     assertEquals(fetchCalls.length, 1);
   });
 
-  it("creates knowledge ingest task runs", async () => {
-    mockFetch([jsonResponse({ accepted: true, run: makeRun() }, 202)]);
+  it("creates every knowledge ingest task-run variant", async () => {
+    mockFetch([
+      jsonResponse({ accepted: true, run: makeRun() }, 202),
+      jsonResponse({ accepted: true, run: makeRun() }, 202),
+      jsonResponse({ accepted: true, run: makeRun() }, 202),
+    ]);
 
-    const client = new VeryfrontRunsClient({
-      apiUrl: "https://93.184.216.34",
-      authToken: "test-token",
-      projectReference: "dreamy-haven",
-    });
+    const client = createTestClient();
 
     await client.knowledge.ingestByUploadIds({
       projectId,
       uploadIds: ["33333333-3333-4333-8333-333333333333"],
       batchId: "66666666-6666-4666-8666-666666666666",
+    });
+    await client.knowledge.ingestByUploadPaths({
+      projectId,
+      uploadPaths: ["guides/getting-started.md"],
+      name: "Ingest selected guides",
+    });
+    await client.knowledge.ingestByUploadPrefix({
+      projectId,
+      uploadPrefix: "handbook/",
     });
 
     assertEquals(jsonBody(0), {
@@ -534,6 +528,24 @@ describe("VeryfrontRunsClient", () => {
         },
       },
     });
+    assertEquals(jsonBody(1), {
+      kind: "task",
+      owner: { kind: "project", id: projectId },
+      request: {
+        name: "Ingest selected guides",
+        target: "task:knowledge-ingest",
+        config: { paths: ["guides/getting-started.md"] },
+      },
+    });
+    assertEquals(jsonBody(2), {
+      kind: "task",
+      owner: { kind: "project", id: projectId },
+      request: {
+        name: "Ingest knowledge",
+        target: "task:knowledge-ingest",
+        config: { path_prefix: "handbook/" },
+      },
+    });
   });
 
   it("lists project runs with project-reference routing", async () => {
@@ -544,11 +556,7 @@ describe("VeryfrontRunsClient", () => {
       }),
     ]);
 
-    const client = new VeryfrontRunsClient({
-      apiUrl: "https://93.184.216.34",
-      authToken: "test-token",
-      projectReference: "dreamy-haven",
-    });
+    const client = createTestClient();
 
     const response = await client.list({ limit: 50 });
 
@@ -557,76 +565,108 @@ describe("VeryfrontRunsClient", () => {
     assertStringIncludes(call(0).url, "limit=50");
   });
 
-  it("reads run detail, events, and cancellation through canonical run routes", async () => {
-    mockFetch([
-      jsonResponse(makeRun()),
-      jsonResponse({
-        data: [{
-          event_id: 1,
-          event_type: "RUN_STARTED",
-          payload: {},
-          created_at: "2026-03-20T12:00:01.000Z",
-        }],
-        page_info: { self: null, first: null, next: null, prev: null },
-      }),
-      jsonResponse({ cancelled: true, run: makeRun({ status: "cancelled" }) }),
-    ]);
-
-    const client = new VeryfrontRunsClient({
-      apiUrl: "https://93.184.216.34",
-      authToken: "test-token",
-      projectReference: "dreamy-haven",
-    });
+  it("reads run detail through the canonical route", async () => {
+    mockFetch([jsonResponse(makeRun())]);
+    const client = createTestClient();
 
     const run = await client.get("run_11111111-1111-4111-8111-111111111111");
-    const events = await client.events(run.run_id, { afterEventId: 1, limit: 10 });
-    const cancelled = await client.cancel(run.run_id);
 
     assertEquals(run.output, null);
     assertEquals(run.artifacts, []);
+    assertEquals(
+      call(0).url,
+      "https://93.184.216.34/runs/run_11111111-1111-4111-8111-111111111111",
+    );
+    assertEquals(call(0).init?.method, "GET");
+  });
+
+  it("lists run events through the canonical paginated route", async () => {
+    mockFetch([jsonResponse({
+      data: [{
+        event_id: 1,
+        event_type: "RUN_STARTED",
+        payload: {},
+        created_at: "2026-03-20T12:00:01.000Z",
+      }],
+      page_info: { self: null, first: null, next: null, prev: null },
+    })]);
+    const client = createTestClient();
+
+    const events = await client.events(
+      "run_11111111-1111-4111-8111-111111111111",
+      { afterEventId: 1, limit: 10 },
+    );
+
     assertEquals(events.data[0]?.event_type, "RUN_STARTED");
+    assertEquals(
+      call(0).url,
+      "https://93.184.216.34/runs/run_11111111-1111-4111-8111-111111111111/events?after_event_id=1&limit=10",
+    );
+    assertEquals(call(0).init?.method, "GET");
+  });
+
+  it("cancels a run through the canonical action route", async () => {
+    mockFetch([
+      jsonResponse({ cancelled: true, run: makeRun({ status: "cancelled" }) }),
+    ]);
+    const client = createTestClient();
+
+    const cancelled = await client.cancel("run_11111111-1111-4111-8111-111111111111");
+
     assertEquals(cancelled.cancelled, true);
-    assertStringIncludes(call(0).url, "/runs/run_11111111-1111-4111-8111-111111111111");
-    assertStringIncludes(call(1).url, "/events?after_event_id=1&limit=10");
-    assertStringIncludes(call(2).url, "/cancel");
-    assertEquals(call(2).init?.method, "POST");
+    assertEquals(
+      call(0).url,
+      "https://93.184.216.34/runs/run_11111111-1111-4111-8111-111111111111/cancel",
+    );
+    assertEquals(call(0).init?.method, "POST");
   });
 
   it("uses environment defaults when config is omitted", async () => {
-    setEnv("VERYFRONT_API_URL", "https://93.184.216.34");
-    setEnv("VERYFRONT_API_TOKEN", "env-token");
-    setEnv("VERYFRONT_PROJECT_SLUG", "env-project");
-
     mockFetch([jsonResponse(makeRun())]);
 
-    const client = new VeryfrontRunsClient();
-    await client.get("run_11111111-1111-4111-8111-111111111111");
+    await withEnv(
+      {
+        VERYFRONT_API_URL: "https://93.184.216.34",
+        VERYFRONT_API_TOKEN: "env-token",
+        VERYFRONT_PROJECT_SLUG: "env-project",
+      },
+      async () => {
+        const client = new VeryfrontRunsClient();
+        await client.get("run_11111111-1111-4111-8111-111111111111");
+      },
+    );
 
     assertStringIncludes(call(0).url, "https://93.184.216.34/runs/");
     assertEquals(headerValue(0, "Authorization"), "Bearer env-token");
   });
 
   it("never pairs a request token with a source-selected cloud endpoint", async () => {
-    setEnv("VERYFRONT_API_URL", "https://93.184.216.34");
-    setEnv("VERYFRONT_API_TOKEN", "host-token");
     mockFetch([jsonResponse(makeRun())]);
 
-    await runWithVeryfrontCloudContext(
+    await withEnv(
       {
-        apiBaseUrl: "https://93.184.216.35",
-        projectSlug: "tenant-project",
+        VERYFRONT_API_URL: "https://93.184.216.34",
+        VERYFRONT_API_TOKEN: "host-token",
       },
       async () => {
-        const unpaired = new VeryfrontRunsClient();
-        await assertRejects(
-          () => unpaired.get("run_11111111-1111-4111-8111-111111111111"),
-          Error,
-          "Runs auth not configured",
-        );
+        await runWithVeryfrontCloudContext(
+          {
+            apiBaseUrl: "https://93.184.216.35",
+            projectSlug: "tenant-project",
+          },
+          async () => {
+            const unpaired = new VeryfrontRunsClient();
+            await assertRejects(
+              () => unpaired.get("run_11111111-1111-4111-8111-111111111111"),
+              Error,
+              "Runs auth not configured",
+            );
 
-        const requestScoped = new VeryfrontRunsClient();
-        requestScoped.setRequestToken("request-token");
-        await requestScoped.get("run_11111111-1111-4111-8111-111111111111");
+            const requestScoped = new VeryfrontRunsClient();
+            requestScoped.setRequestToken("request-token");
+            await requestScoped.get("run_11111111-1111-4111-8111-111111111111");
+          },
+        );
       },
     );
 

--- a/src/runs/runs-client.ts
+++ b/src/runs/runs-client.ts
@@ -474,9 +474,10 @@ export class VeryfrontRunsClient {
     } = {},
   ): Promise<T> {
     const { apiUrl, authToken } = this.resolveConnection();
-    const apiOrigin = new URL(apiUrl).origin;
+    const normalizedApiUrl = apiUrl.replace(/\/+$/, "");
+    const apiOrigin = new URL(normalizedApiUrl).origin;
     const raw = await requestWithRetry(
-      `${apiUrl}${path}`,
+      `${normalizedApiUrl}${path}`,
       authToken,
       this.retryConfig,
       {

--- a/src/runs/runtime-env.test.ts
+++ b/src/runs/runtime-env.test.ts
@@ -27,6 +27,14 @@ describe("runs/runtime-env", () => {
     );
   });
 
+  it("filters unsafe keys from the ambient environment too", () => {
+    const allEnv = JSON.parse(
+      '{"SAFE_VALUE":"ok","__proto__":"polluted","constructor":"polluted","prototype":"polluted"}',
+    ) as Record<string, string>;
+
+    assertEquals(buildTaskContextEnv(allEnv), { SAFE_VALUE: "ok" });
+  });
+
   it("builds task context env from visible and allowlisted injected values", () => {
     assertEquals(
       buildTaskContextEnv(

--- a/src/runs/runtime-env.test.ts
+++ b/src/runs/runtime-env.test.ts
@@ -27,12 +27,13 @@ describe("runs/runtime-env", () => {
     );
   });
 
-  it("filters unsafe keys from the ambient environment too", () => {
-    const allEnv = JSON.parse(
-      '{"SAFE_VALUE":"ok","__proto__":"polluted","constructor":"polluted","prototype":"polluted"}',
+  it("applies the same safety policy to ambient and existing workflow env", () => {
+    const unsafeEnv = JSON.parse(
+      '{"SAFE_VALUE":"ok","VERYFRONT_API_TOKEN":"secret","TENANT_SECRET":"tenant-secret","nonString":123,"__proto__":"polluted","constructor":"polluted","prototype":"polluted"}',
     ) as Record<string, string>;
 
-    assertEquals(buildTaskContextEnv(allEnv), { SAFE_VALUE: "ok" });
+    assertEquals(buildTaskContextEnv(unsafeEnv), { SAFE_VALUE: "ok" });
+    assertEquals(mergeInjectedWorkflowEnv(unsafeEnv, {}), { SAFE_VALUE: "ok" });
   });
 
   it("builds task context env from visible and allowlisted injected values", () => {

--- a/src/runs/runtime-env.ts
+++ b/src/runs/runtime-env.ts
@@ -73,10 +73,7 @@ export function buildTaskContextEnv(
   const allowedEnvKeys = envAllowlist ? new Set(envAllowlist) : null;
   const taskContextEnv: Record<string, string> = {};
 
-  for (const [key, value] of Object.entries(allEnv)) {
-    if (UNSAFE_INJECTED_ENV_KEYS.has(key) || isReservedTaskEnvKey(key)) {
-      continue;
-    }
+  for (const [key, value] of Object.entries(filterSafeWorkflowEnv(allEnv))) {
     if (allowedEnvKeys && !allowedEnvKeys.has(key)) {
       continue;
     }

--- a/src/runs/runtime-env.ts
+++ b/src/runs/runtime-env.ts
@@ -74,7 +74,7 @@ export function buildTaskContextEnv(
   const taskContextEnv: Record<string, string> = {};
 
   for (const [key, value] of Object.entries(allEnv)) {
-    if (isReservedTaskEnvKey(key)) {
+    if (UNSAFE_INJECTED_ENV_KEYS.has(key) || isReservedTaskEnvKey(key)) {
       continue;
     }
     if (allowedEnvKeys && !allowedEnvKeys.has(key)) {

--- a/src/runs/schemas.test.ts
+++ b/src/runs/schemas.test.ts
@@ -3,7 +3,12 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { isTriggerTarget } from "#veryfront/trigger/target.ts";
 import type { Run } from "./schemas.ts";
-import { getRunKindSchema, getScheduleReferenceListSchema, RunSchema } from "./schemas.ts";
+import {
+  getRunEventSchema,
+  getRunKindSchema,
+  getScheduleReferenceListSchema,
+  RunSchema,
+} from "./schemas.ts";
 
 function makeRun(overrides: Partial<Run> = {}): Run {
   return {
@@ -55,6 +60,69 @@ describe("runs/schemas", () => {
     });
 
     assertEquals(RunSchema.parse(run), run);
+  });
+
+  it("rejects impossible numeric run state", () => {
+    for (
+      const [field, value] of [
+        ["duration_ms", -1],
+        ["timeout_seconds", 0],
+        ["timeout_seconds", -1],
+        ["backoff_limit", -1],
+      ] as const
+    ) {
+      assertEquals(
+        RunSchema.safeParse(makeRun({ [field]: value })).success,
+        false,
+        `${field}=${value} is rejected`,
+      );
+    }
+
+    assertEquals(RunSchema.safeParse(makeRun({ duration_ms: 0 })).success, true);
+    assertEquals(RunSchema.safeParse(makeRun({ timeout_seconds: 1 })).success, true);
+    assertEquals(RunSchema.safeParse(makeRun({ backoff_limit: 0 })).success, true);
+  });
+
+  it("requires run event ids to be non-negative integers", () => {
+    const event = {
+      event_id: 0,
+      event_type: "RUN_STARTED",
+      payload: {},
+      created_at: "2026-06-20T08:00:00.000Z",
+    };
+
+    assertEquals(getRunEventSchema().safeParse(event).success, true);
+    assertEquals(
+      getRunEventSchema().safeParse({ ...event, event_id: -1 }).success,
+      false,
+    );
+    assertEquals(
+      getRunEventSchema().safeParse({ ...event, event_id: 1.5 }).success,
+      false,
+    );
+  });
+
+  it("requires source schedule timeouts to be positive integers", () => {
+    const response = (timeout_seconds: number) => ({
+      schedules: [{
+        id: "schedule_1",
+        name: "Sync helpdesk",
+        status: "active",
+        target: { kind: "task", id: "sync-helpdesk" },
+        definition_source: "source",
+        source_trigger_id: "sync-helpdesk",
+        timeout_seconds,
+      }],
+    });
+
+    assertEquals(getScheduleReferenceListSchema().safeParse(response(1)).success, true);
+    for (const timeout of [-1, 0, 1.5]) {
+      assertEquals(
+        getScheduleReferenceListSchema().safeParse(response(timeout)).success,
+        false,
+        `timeout_seconds=${timeout} is rejected`,
+      );
+    }
   });
 
   // A schedules-list response is the one place a target crosses the wire from

--- a/src/runs/schemas.ts
+++ b/src/runs/schemas.ts
@@ -56,11 +56,11 @@ export const getRunSchema = defineSchema((v) =>
     error: getRunExecutionErrorSchema().nullable(),
     logs: v.string().nullable(),
     artifacts: v.array(v.unknown()),
-    duration_ms: v.number().int().nullable(),
+    duration_ms: v.number().int().nonnegative().nullable(),
     exit_code: v.number().int().nullable(),
     start_mode: v.string().nullable(),
-    timeout_seconds: v.number().int().nullable(),
-    backoff_limit: v.number().int().nullable(),
+    timeout_seconds: v.number().int().positive().nullable(),
+    backoff_limit: v.number().int().nonnegative().nullable(),
     trigger_kind: getRunTriggerKindSchema().nullable(),
     trigger_id: v.string().nullable(),
     created_by: v.string().nullable(),
@@ -130,7 +130,7 @@ export const getScheduleReferenceListSchema = defineSchema((v) =>
         }),
         definition_source: v.enum(["manual", "source"] as const),
         source_trigger_id: v.string().nullable(),
-        timeout_seconds: v.number().int(),
+        timeout_seconds: v.number().int().positive(),
       }),
     ),
   })
@@ -145,7 +145,7 @@ export const getCancelRunResponseSchema = defineSchema((v) =>
 
 export const getRunEventSchema = defineSchema((v) =>
   v.object({
-    event_id: v.number(),
+    event_id: v.number().int().nonnegative(),
     event_type: v.string(),
     payload: v.unknown(),
     created_at: v.string(),

--- a/src/runs/schemas.ts
+++ b/src/runs/schemas.ts
@@ -175,17 +175,24 @@ export const getRunListSchema = defineSchema((v) =>
   })
 );
 
-/** Zod schema for a canonical durable run. */
+/**
+ * Zod schema for a canonical durable run whose `duration_ms` and
+ * `backoff_limit` are non-negative integers and whose `timeout_seconds` is a
+ * positive integer when present.
+ */
 export const RunSchema = lazySchema(getRunSchema);
 /** Zod schema for a create-run response. */
 export const CreateRunResponseSchema = lazySchema(getCreateRunResponseSchema);
 /** Zod schema for a schedule-triggered create-run response. */
 export const ScheduleRunCreateResponseSchema = lazySchema(getScheduleRunCreateResponseSchema);
-/** Zod schema for the schedule references needed to trigger source schedules. */
+/**
+ * Zod schema for the schedule references needed to trigger source schedules.
+ * Each source-schedule `timeout_seconds` value is a positive integer.
+ */
 export const ScheduleReferenceListSchema = lazySchema(getScheduleReferenceListSchema);
 /** Zod schema for a cancel-run response. */
 export const CancelRunResponseSchema = lazySchema(getCancelRunResponseSchema);
-/** Zod schema for a run event. */
+/** Zod schema for a run event whose `event_id` is a non-negative integer. */
 export const RunEventSchema = lazySchema(getRunEventSchema);
 /** Zod schema for a paginated run-event response. */
 export const RunEventListSchema = lazySchema(getRunEventListSchema);


### PR DESCRIPTION
## Why

A module-level review of all 28 existing `src/runs` test steps found several false-confidence gaps:

- the injected project-env path rejected `__proto__`, `constructor`, and `prototype`, but the ambient-env path copied all three into task context;
- run events accepted fractional and negative IDs;
- run and schedule response schemas accepted negative durations and retries, plus zero or negative timeouts;
- an explicit API base URL ending in `/` generated `//runs` routes;
- the knowledge namespace test exercised only one of its three public methods;
- one eager test coupled run detail, event listing, and cancellation through response queue order;
- the public `veryfront/runs` runtime barrel had no contract test.

Direct probes reproduced the unsafe keys and invalid numeric values. Focused tests were added before each production fix and failed on the old behavior.

## What

- Apply the same unsafe-key policy to ambient and injected task environment sources.
- Require non-negative run durations and retry limits, positive run and source-schedule timeouts, and non-negative integer event IDs.
- Normalize trailing slashes before joining runs API paths.
- Execute all upload ID, upload path, and upload prefix knowledge-ingest variants with distinct expected request bodies.
- Split detail, event, and cancellation coverage into independent tests with exact URLs and methods.
- Replace manual host-env cleanup with the scoped test environment helper.
- Add a runtime export and owner-wiring contract for `veryfront/runs`.
- Reuse one authenticated client fixture for repeated request tests.
- Regenerate the runs API reference.

The existing `process` and `network` semantic disposition for `runs-client.test.ts` remains intentionally unchanged. The repository-sanctioned mock-fetch boundary still installs the outbound transport process-wide; replacing that seam belongs to the existing agent-runtime migration rather than a runs-only abstraction.

## Verification

- `deno task test:file src/runs`: 4 files, 37 steps passed
- `src/task/runner.test.ts`: 15 steps passed
- `cli/commands/schedule/handler.test.ts`: 32 steps passed
- `tests/docs/guide-examples.test.ts`: 47 steps passed
- `deno task test:unit:parallel`: 4,175 passed, 32,096 steps, 1 ignored
- `deno task test:unit:cwd`: 11 passed, 213 steps
- `deno task test:unit:cwd-exclusion`: 2 passed
- `deno task test:integration`: 315 passed, 2,923 steps
- focused `deno check`: passed
- `deno task typecheck`: passed
- `deno task lint`, `deno task fmt:check`: passed
- `deno task test:layout`: 2,357 executable tests, passed
- `deno task lint:test-semantic-dispositions`: 2,142 unit executables, 762 disposed files, passed
- test typecheck, anti-slop, sanitizer, cwd-read, module, dependency, API-doc, and public-doc gates: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API request handling when configured endpoints include trailing slashes.
  * Prevented unsafe, reserved, or invalid environment values from being passed into task contexts.
  * Strengthened validation for run durations, retries, timeouts, event IDs, and schedule settings.

* **Documentation**
  * Updated the Runs API reference with clearer schema descriptions, validation rules, and source links.

* **Tests**
  * Expanded coverage for API routes, configuration defaults, exports, environment filtering, and schema validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->