### PR TITLE
fix(schedule): isolate validation from ambient state

### DIFF
--- a/scripts/test/test-semantic-audit-migration.ts
+++ b/scripts/test/test-semantic-audit-migration.ts
@@ -5863,15 +5863,6 @@ export const TEST_SEMANTIC_AUDIT_MIGRATION_ENTRIES:
         "Inject an environment/runtime-state boundary (and transport fake where applicable) instead of reading or mutating Deno.env, process.env, signals, exits, or global runtime objects.",
       "removalPr": "PR 4n",
     }),
-    entry("src/schedule/factory.test.ts", ["process"], {
-      "disposition": "replaceable-fake",
-      "owner": "core-runtime",
-      "rationale":
-        "Depends on or mutates process-global environment/runtime state and cannot run safely beside concurrent unit tests.",
-      "replacement":
-        "Inject an environment/runtime-state boundary (and transport fake where applicable) instead of reading or mutating Deno.env, process.env, signals, exits, or global runtime objects.",
-      "removalPr": "PR 4n",
-    }),
     entry("src/schemas/primitives.test.ts", ["process"], {
       "disposition": "replaceable-fake",
       "owner": "core-runtime",

--- a/src/schedule/calendar.test.ts
+++ b/src/schedule/calendar.test.ts
@@ -1,0 +1,48 @@
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { isSupportedIanaTimezone, normalizeCronExpression } from "./calendar.ts";
+
+describe("schedule calendar", () => {
+  describe("normalizeCronExpression()", () => {
+    it("canonicalizes numeric, named, range, list, and step fields", () => {
+      assertEquals(
+        normalizeCronExpression("  00  */06  01-15/02  jan,mar  mon-fri  "),
+        "0 */6 1-15/2 JAN,MAR MON-FRI",
+      );
+    });
+
+    it("accepts both portable Sunday numbers", () => {
+      assertEquals(normalizeCronExpression("0 0 * * 0,7"), "0 0 * * 0,7");
+    });
+
+    it("rejects unsupported or out-of-range syntax", () => {
+      for (
+        const expression of [
+          "0 0 * *",
+          "0 0 * * * *",
+          "0\t0 * * *",
+          "0 0 * * FUNDAY",
+          "0 0 * * MON-SUN",
+          "*/61 0 * * *",
+          "0 0 * * MON/0",
+          "0 0 * * MON,,FRI",
+        ]
+      ) {
+        assertEquals(normalizeCronExpression(expression), null);
+      }
+    });
+  });
+
+  describe("isSupportedIanaTimezone()", () => {
+    it("accepts UTC and recognized area-based zones", () => {
+      assertEquals(isSupportedIanaTimezone("UTC"), true);
+      assertEquals(isSupportedIanaTimezone("Europe/Stockholm"), true);
+    });
+
+    it("rejects offsets, malformed names, and unknown zones", () => {
+      for (const timezone of ["+02:00", "Stockholm", "../UTC", "Mars/Olympus"]) {
+        assertEquals(isSupportedIanaTimezone(timezone), false);
+      }
+    });
+  });
+});

--- a/src/schedule/calendar.ts
+++ b/src/schedule/calendar.ts
@@ -4,6 +4,8 @@ interface CronField {
   readonly names?: ReadonlyMap<string, number>;
 }
 
+const DateTimeFormat = Intl.DateTimeFormat;
+
 const MONTHS = new Map([
   ["JAN", 1],
   ["FEB", 2],
@@ -139,7 +141,7 @@ export function normalizeCronExpression(value: string): string | null {
 export function isSupportedIanaTimezone(value: string): boolean {
   if (value !== "UTC" && !IANA_TIMEZONE_PATTERN.test(value)) return false;
   try {
-    new Intl.DateTimeFormat("en-US", { timeZone: value }).format(0);
+    new DateTimeFormat("en-US", { timeZone: value });
     return true;
   } catch {
     return false;

--- a/src/schedule/factory.test.ts
+++ b/src/schedule/factory.test.ts
@@ -4,7 +4,6 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { VeryfrontError } from "#veryfront/errors";
 import { schedule } from "./factory.ts";
 import { isScheduleDefinition } from "./types.ts";
-import { captureScheduleIntegrationRequirementsConfig } from "./validation.ts";
 
 describe("schedule/factory", () => {
   it("normalizes cron into schedule", () => {
@@ -301,7 +300,7 @@ describe("schedule/factory", () => {
             target: { kind: "task", id: "run-triage-sweep" },
             health: health as never,
           }),
-        Error,
+        VeryfrontError,
       );
     }
   });
@@ -368,105 +367,6 @@ describe("schedule/factory", () => {
     requirement.resources[0]!.parent.id = "mutated";
 
     assertEquals(definition.integrationRequirements, [{
-      integration: "slack",
-      requiredScopes: ["channels:read"],
-      resources: [{
-        kind: "channel",
-        id: "C012345",
-        parent: { kind: "workspace", id: "T012345" },
-      }],
-    }]);
-  });
-
-  it("captures integration requirements without ambient collection methods", () => {
-    const originalArrayIterator = Array.prototype[Symbol.iterator];
-    const originalArrayMap = Array.prototype.map;
-    const originalArrayPush = Array.prototype.push;
-    const originalArraySome = Array.prototype.some;
-    const originalArrayZeroDescriptor = Object.getOwnPropertyDescriptor(Array.prototype, "0");
-    const originalDefineProperty = Object.defineProperty;
-    const originalDeleteProperty = Reflect.deleteProperty;
-    const originalRegExpExec = RegExp.prototype.exec;
-    const originalRegExpTest = RegExp.prototype.test;
-    const originalSetAdd = Set.prototype.add;
-    const originalSetHas = Set.prototype.has;
-    const originalStringConstructor = globalThis.String;
-    const originalStringCharCodeAt = String.prototype.charCodeAt;
-    const originalStringSlice = String.prototype.slice;
-    const originalStringTrim = String.prototype.trim;
-    let poisonCalls = 0;
-    const poison = (): never => {
-      poisonCalls += 1;
-      throw new Error("ambient metadata collection method must not run");
-    };
-    let captured: ReturnType<typeof captureScheduleIntegrationRequirementsConfig>;
-
-    try {
-      originalDefineProperty(Array.prototype, "0", {
-        configurable: true,
-        set(this: unknown[], next: unknown) {
-          if (
-            typeof next === "object" && next !== null &&
-            (next as { integration?: unknown }).integration === "slack"
-          ) {
-            poisonCalls += 1;
-            return;
-          }
-          originalDefineProperty(this, "0", {
-            value: next,
-            enumerable: true,
-            configurable: true,
-            writable: true,
-          });
-        },
-      });
-      Array.prototype[Symbol.iterator] = poison as typeof originalArrayIterator;
-      Array.prototype.map = poison as typeof Array.prototype.map;
-      Array.prototype.push = poison as typeof Array.prototype.push;
-      Array.prototype.some = poison as typeof Array.prototype.some;
-      RegExp.prototype.exec = poison as typeof RegExp.prototype.exec;
-      RegExp.prototype.test = poison as typeof RegExp.prototype.test;
-      Set.prototype.add = poison as typeof Set.prototype.add;
-      Set.prototype.has = poison as typeof Set.prototype.has;
-      String.prototype.charCodeAt = poison as typeof String.prototype.charCodeAt;
-      String.prototype.slice = poison as typeof String.prototype.slice;
-      String.prototype.trim = poison as typeof String.prototype.trim;
-      globalThis.String = poison as unknown as StringConstructor;
-
-      captured = captureScheduleIntegrationRequirementsConfig(
-        [{
-          integration: "slack",
-          requiredScopes: ["channels:read"],
-          resources: [{
-            kind: "channel",
-            id: "C012345",
-            parent: { kind: "workspace", id: "T012345" },
-          }],
-        }],
-        "Task",
-      );
-    } finally {
-      Array.prototype[Symbol.iterator] = originalArrayIterator;
-      Array.prototype.map = originalArrayMap;
-      Array.prototype.push = originalArrayPush;
-      Array.prototype.some = originalArraySome;
-      RegExp.prototype.exec = originalRegExpExec;
-      RegExp.prototype.test = originalRegExpTest;
-      Set.prototype.add = originalSetAdd;
-      Set.prototype.has = originalSetHas;
-      globalThis.String = originalStringConstructor;
-      String.prototype.charCodeAt = originalStringCharCodeAt;
-      String.prototype.slice = originalStringSlice;
-      String.prototype.trim = originalStringTrim;
-      if (originalArrayZeroDescriptor) {
-        originalDefineProperty(Array.prototype, "0", originalArrayZeroDescriptor);
-      } else {
-        originalDeleteProperty(Array.prototype, "0");
-      }
-    }
-
-    assertEquals(poisonCalls, 0);
-    assertEquals(captured, [{
       integration: "slack",
       requiredScopes: ["channels:read"],
       resources: [{
@@ -552,7 +452,7 @@ describe("schedule/factory", () => {
             },
           ] as never,
         }),
-      Error,
+      VeryfrontError,
       "resources[0].id is required.",
     );
 
@@ -570,7 +470,7 @@ describe("schedule/factory", () => {
             },
           ] as never,
         }),
-      Error,
+      VeryfrontError,
       "resources[0].parent must be an object.",
     );
 
@@ -588,7 +488,7 @@ describe("schedule/factory", () => {
             },
           ],
         }),
-      Error,
+      VeryfrontError,
       "resources[0].parent.kind is required.",
     );
 
@@ -610,7 +510,7 @@ describe("schedule/factory", () => {
             },
           ],
         }),
-      Error,
+      VeryfrontError,
       "resources[0].parent.id is required.",
     );
 
@@ -628,7 +528,7 @@ describe("schedule/factory", () => {
             },
           ],
         }),
-      Error,
+      VeryfrontError,
       "integration must use a lowercase integration identifier",
     );
 
@@ -646,7 +546,7 @@ describe("schedule/factory", () => {
             },
           ],
         }),
-      Error,
+      VeryfrontError,
       "resources[0].kind must use a lowercase resource kind",
     );
   });
@@ -671,7 +571,7 @@ describe("schedule/factory", () => {
             },
           ],
         }),
-      Error,
+      VeryfrontError,
       "duplicate integration slack",
     );
   });
@@ -692,44 +592,23 @@ describe("schedule/factory", () => {
       "Schedule integrationRequirements[0].requiredScopes contains duplicate scope channels:read.",
     );
 
-    const originalArrayToJsonDescriptor = Object.getOwnPropertyDescriptor(
-      Array.prototype,
-      "toJSON",
+    assertThrows(
+      () =>
+        schedule({
+          id: "duplicate-resources",
+          schedule: "0 9 * * 1-5",
+          target: { kind: "workflow", id: "post-slack-digest" },
+          integrationRequirements: [{
+            integration: "slack",
+            resources: [
+              { kind: "channel", id: "C012345" },
+              { kind: "channel", id: "C012345" },
+            ],
+          }],
+        }),
+      VeryfrontError,
+      "Schedule integrationRequirements[0].resources contains a duplicate resource identity.",
     );
-    let toJsonCalls = 0;
-    try {
-      Object.defineProperty(Array.prototype, "toJSON", {
-        configurable: true,
-        value() {
-          toJsonCalls += 1;
-          return [toJsonCalls];
-        },
-      });
-      assertThrows(
-        () =>
-          schedule({
-            id: "duplicate-resources",
-            schedule: "0 9 * * 1-5",
-            target: { kind: "workflow", id: "post-slack-digest" },
-            integrationRequirements: [{
-              integration: "slack",
-              resources: [
-                { kind: "channel", id: "C012345" },
-                { kind: "channel", id: "C012345" },
-              ],
-            }],
-          }),
-        VeryfrontError,
-        "Schedule integrationRequirements[0].resources contains a duplicate resource identity.",
-      );
-    } finally {
-      if (originalArrayToJsonDescriptor) {
-        Object.defineProperty(Array.prototype, "toJSON", originalArrayToJsonDescriptor);
-      } else {
-        Reflect.deleteProperty(Array.prototype, "toJSON");
-      }
-    }
-    assertEquals(toJsonCalls, 0);
   });
 
   it("enforces bounded integration declarations", () => {
@@ -780,7 +659,7 @@ describe("schedule/factory", () => {
             tokenId: "must-not-be-source-owned",
           }] as never,
         }),
-      Error,
+      VeryfrontError,
       "integrationRequirements[0].tokenId is not supported",
     );
   });

--- a/tests/integration/schedule/ambient-intrinsics.test.ts
+++ b/tests/integration/schedule/ambient-intrinsics.test.ts
@@ -1,0 +1,177 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { VeryfrontError } from "#veryfront/errors";
+import { schedule } from "#veryfront/schedule";
+import { captureScheduleIntegrationRequirementsConfig } from "#veryfront/schedule/validation.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+
+describe("schedule validation with hostile ambient intrinsics", () => {
+  it("does not trust a replaced Intl.DateTimeFormat constructor", () => {
+    const originalDateTimeFormat = Intl.DateTimeFormat;
+    class PoisonedDateTimeFormat {
+      format(): string {
+        return "accepted";
+      }
+    }
+
+    try {
+      Intl.DateTimeFormat = PoisonedDateTimeFormat as unknown as typeof Intl.DateTimeFormat;
+
+      assertThrows(
+        () =>
+          schedule({
+            id: "invalid-timezone",
+            schedule: "0 8 * * *",
+            timezone: "Mars/Olympus",
+            target: { kind: "task", id: "run-calendar-sweep" },
+          }),
+        VeryfrontError,
+        "Schedule timezone must be a supported IANA timezone name.",
+      );
+    } finally {
+      Intl.DateTimeFormat = originalDateTimeFormat;
+    }
+  });
+
+  it("captures integration requirements without ambient collection methods", () => {
+    const originalArrayIterator = Array.prototype[Symbol.iterator];
+    const originalArrayMap = Array.prototype.map;
+    const originalArrayPush = Array.prototype.push;
+    const originalArraySome = Array.prototype.some;
+    const originalArrayZeroDescriptor = Object.getOwnPropertyDescriptor(Array.prototype, "0");
+    const originalDefineProperty = Object.defineProperty;
+    const originalDeleteProperty = Reflect.deleteProperty;
+    const originalRegExpExec = RegExp.prototype.exec;
+    const originalRegExpTest = RegExp.prototype.test;
+    const originalSetAdd = Set.prototype.add;
+    const originalSetHas = Set.prototype.has;
+    const originalStringConstructor = globalThis.String;
+    const originalStringCharCodeAt = String.prototype.charCodeAt;
+    const originalStringSlice = String.prototype.slice;
+    const originalStringTrim = String.prototype.trim;
+    let poisonCalls = 0;
+    const poison = (): never => {
+      poisonCalls += 1;
+      throw new Error("ambient metadata collection method must not run");
+    };
+    let captured: ReturnType<typeof captureScheduleIntegrationRequirementsConfig>;
+
+    try {
+      originalDefineProperty(Array.prototype, "0", {
+        configurable: true,
+        set(this: unknown[], next: unknown) {
+          if (
+            typeof next === "object" && next !== null &&
+            (next as { integration?: unknown }).integration === "slack"
+          ) {
+            poisonCalls += 1;
+            return;
+          }
+          originalDefineProperty(this, "0", {
+            value: next,
+            enumerable: true,
+            configurable: true,
+            writable: true,
+          });
+        },
+      });
+      Array.prototype[Symbol.iterator] = poison as typeof originalArrayIterator;
+      Array.prototype.map = poison as typeof Array.prototype.map;
+      Array.prototype.push = poison as typeof Array.prototype.push;
+      Array.prototype.some = poison as typeof Array.prototype.some;
+      RegExp.prototype.exec = poison as typeof RegExp.prototype.exec;
+      RegExp.prototype.test = poison as typeof RegExp.prototype.test;
+      Set.prototype.add = poison as typeof Set.prototype.add;
+      Set.prototype.has = poison as typeof Set.prototype.has;
+      String.prototype.charCodeAt = poison as typeof String.prototype.charCodeAt;
+      String.prototype.slice = poison as typeof String.prototype.slice;
+      String.prototype.trim = poison as typeof String.prototype.trim;
+      globalThis.String = poison as unknown as StringConstructor;
+
+      captured = captureScheduleIntegrationRequirementsConfig(
+        [{
+          integration: "slack",
+          requiredScopes: ["channels:read"],
+          resources: [{
+            kind: "channel",
+            id: "C012345",
+            parent: { kind: "workspace", id: "T012345" },
+          }],
+        }],
+        "Task",
+      );
+    } finally {
+      Array.prototype[Symbol.iterator] = originalArrayIterator;
+      Array.prototype.map = originalArrayMap;
+      Array.prototype.push = originalArrayPush;
+      Array.prototype.some = originalArraySome;
+      RegExp.prototype.exec = originalRegExpExec;
+      RegExp.prototype.test = originalRegExpTest;
+      Set.prototype.add = originalSetAdd;
+      Set.prototype.has = originalSetHas;
+      globalThis.String = originalStringConstructor;
+      String.prototype.charCodeAt = originalStringCharCodeAt;
+      String.prototype.slice = originalStringSlice;
+      String.prototype.trim = originalStringTrim;
+      if (originalArrayZeroDescriptor) {
+        originalDefineProperty(Array.prototype, "0", originalArrayZeroDescriptor);
+      } else {
+        originalDeleteProperty(Array.prototype, "0");
+      }
+    }
+
+    assertEquals(poisonCalls, 0);
+    assertEquals(captured, [{
+      integration: "slack",
+      requiredScopes: ["channels:read"],
+      resources: [{
+        kind: "channel",
+        id: "C012345",
+        parent: { kind: "workspace", id: "T012345" },
+      }],
+    }]);
+  });
+
+  it("compares duplicate resources without ambient array serialization", () => {
+    const originalArrayToJsonDescriptor = Object.getOwnPropertyDescriptor(
+      Array.prototype,
+      "toJSON",
+    );
+    let toJsonCalls = 0;
+
+    try {
+      Object.defineProperty(Array.prototype, "toJSON", {
+        configurable: true,
+        value() {
+          toJsonCalls += 1;
+          return [toJsonCalls];
+        },
+      });
+      assertThrows(
+        () =>
+          schedule({
+            id: "duplicate-resources",
+            schedule: "0 9 * * 1-5",
+            target: { kind: "workflow", id: "post-slack-digest" },
+            integrationRequirements: [{
+              integration: "slack",
+              resources: [
+                { kind: "channel", id: "C012345" },
+                { kind: "channel", id: "C012345" },
+              ],
+            }],
+          }),
+        VeryfrontError,
+        "Schedule integrationRequirements[0].resources contains a duplicate resource identity.",
+      );
+    } finally {
+      if (originalArrayToJsonDescriptor) {
+        Object.defineProperty(Array.prototype, "toJSON", originalArrayToJsonDescriptor);
+      } else {
+        Reflect.deleteProperty(Array.prototype, "toJSON");
+      }
+    }
+
+    assertEquals(toJsonCalls, 0);
+  });
+});


### PR DESCRIPTION
## Summary

- capture the runtime timezone constructor before project code can replace it and bypass IANA timezone validation
- give cron normalization and timezone support a focused calendar test owner
- move global intrinsic poisoning checks from the parallel unit suite to an isolated integration test
- remove the schedule factory process-effect migration waiver after proving the unit file is hermetic
- require structured `VeryfrontError` failures at public schedule validation boundaries

## Verification

- `deno task test:file src/schedule` (4 passed, 51 steps)
- `deno task test:file tests/integration/schedule/ambient-intrinsics.test.ts` (1 passed, 3 steps)
- `deno task test:unit:parallel` (4,184 passed, 32,220 steps)
- `deno task test:unit:cwd` (3 passed, 112 steps)
- `deno task test:unit:cwd-exclusion` (2 passed, 2 steps)
- `deno task test:integration` (320 passed, 2,954 steps)
- `deno task typecheck`
- `deno task lint`
- `deno task lint:test-typecheck`
- `deno task lint:test-semantic-dispositions` (waiver removed, 756 effect-bearing files disposed)
- `deno task lint:anti-slop`
- `deno task lint:dependency-boundaries`
- `deno task lint:module-boundaries`
- `deno task test:layout`
- `deno task docs:api-reference:check`
- `git diff --check`
