### PR TITLE
fix(webhook): capture filter enforcement intrinsics

### DIFF
--- a/docs/api-reference/veryfront/webhook.md
+++ b/docs/api-reference/veryfront/webhook.md
@@ -44,15 +44,15 @@ export default webhook({
 | -------------------------- | ----------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | `discoverWebhooks`         | Discover and validate source-defined webhooks across configured directories.  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/webhook/discovery.ts#L29)   |
 | `isWebhookDefinition`      | Return true only when every webhook field and nested invariant is valid.      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/webhook/types.ts#L85)       |
-| `isWebhookId`              | Return true for source webhook identifiers accepted by hosted reconciliation. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/webhook/validation.ts#L246) |
-| `prepareWebhookInvocation` | Revalidate and own a definition and payload before local webhook execution.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/webhook/runtime.ts#L168)    |
+| `isWebhookId`              | Return true for source webhook identifiers accepted by hosted reconciliation. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/webhook/validation.ts#L248) |
+| `prepareWebhookInvocation` | Revalidate and own a definition and payload before local webhook execution.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/webhook/runtime.ts#L273)    |
 | `webhook`                  | Validate and normalize a source-defined webhook configuration.                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/webhook/factory.ts#L10)     |
 
 ### Types
 
 | Name                           | Description                                                          | Source                                                                                       |
 | ------------------------------ | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `PreparedWebhookInvocation`    | Owned, cloud-compatible inputs for one local webhook target run.     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/webhook/runtime.ts#L16)   |
+| `PreparedWebhookInvocation`    | Owned, cloud-compatible inputs for one local webhook target run.     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/webhook/runtime.ts#L36)   |
 | `WebhookAgentConversationMode` | Hosted conversation behavior for an agent-target webhook.            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/webhook/types.ts#L38)     |
 | `WebhookAgentMessageMapping`   | Prompt and optional hosted conversation mapping for an agent target. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/webhook/types.ts#L41)     |
 | `WebhookConfig`                | Author-facing webhook configuration accepted by `webhook`.           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/webhook/types.ts#L79)     |

--- a/src/webhook/runtime.ts
+++ b/src/webhook/runtime.ts
@@ -11,6 +11,19 @@ import { normalizeWebhookDefinition } from "./validation.ts";
 const MAX_WEBHOOK_PAYLOAD_BYTES = 64 * 1_024;
 const PROMPT_PLACEHOLDER_PATTERN = /\{\{\s*payload(?:\.([a-zA-Z0-9_.-]+))?\s*\}\}/g;
 const UTF8_ENCODER = new TextEncoder();
+const arrayIsArray = Array.isArray;
+const arrayPop = Array.prototype.pop;
+const arrayPush = Array.prototype.push;
+const jsonStringify = JSON.stringify;
+const objectHasOwn = Object.hasOwn;
+const objectKeys = Object.keys;
+const reflectApply = Reflect.apply;
+const reflectGetOwnPropertyDescriptor = Reflect.getOwnPropertyDescriptor;
+const stringIncludes = String.prototype.includes;
+const stringReplace = String.prototype.replace;
+const stringSplit = String.prototype.split;
+const stringTrim = String.prototype.trim;
+const textEncoderEncode = TextEncoder.prototype.encode;
 
 /** Owned, cloud-compatible inputs for one local webhook target run. */
 export interface PreparedWebhookInvocation {
@@ -33,8 +46,11 @@ function invalidPayload(detail: string): never {
 function snapshotWebhookPayload(value: unknown): BoundedJsonValue {
   const snapshot = snapshotSerializable(value ?? {}, "Webhook payload");
 
-  const serialized = JSON.stringify(snapshot);
-  if (UTF8_ENCODER.encode(serialized).byteLength > MAX_WEBHOOK_PAYLOAD_BYTES) {
+  const serialized = jsonStringify(snapshot);
+  if (
+    (reflectApply(textEncoderEncode, UTF8_ENCODER, [serialized]) as Uint8Array)
+      .byteLength > MAX_WEBHOOK_PAYLOAD_BYTES
+  ) {
     invalidPayload("Webhook payload must be 64 KiB or smaller.");
   }
   return snapshot;
@@ -42,15 +58,17 @@ function snapshotWebhookPayload(value: unknown): BoundedJsonValue {
 
 function readPath(payload: BoundedJsonValue, path: string): unknown {
   let current: unknown = payload;
-  for (const segment of path.split(".")) {
+  const segments = reflectApply(stringSplit, path, ["."]) as string[];
+  for (let index = 0; index < segments.length; index++) {
+    const segment = segments[index]!;
     if (
       current === null ||
       typeof current !== "object" ||
-      Array.isArray(current)
+      arrayIsArray(current)
     ) {
       return undefined;
     }
-    const descriptor = Reflect.getOwnPropertyDescriptor(current, segment);
+    const descriptor = reflectGetOwnPropertyDescriptor(current, segment);
     if (!descriptor || !("value" in descriptor)) return undefined;
     current = descriptor.value;
   }
@@ -60,7 +78,7 @@ function readPath(payload: BoundedJsonValue, path: string): unknown {
 function stableEquals(left: unknown, right: unknown): boolean {
   const pending: Array<readonly [unknown, unknown]> = [[left, right]];
   while (pending.length > 0) {
-    const pair = pending.pop();
+    const pair = reflectApply(arrayPop, pending, []) as readonly [unknown, unknown] | undefined;
     if (!pair) break;
     const [currentLeft, currentRight] = pair;
     if (currentLeft === currentRight) continue;
@@ -73,26 +91,27 @@ function stableEquals(left: unknown, right: unknown): boolean {
       return false;
     }
 
-    const leftIsArray = Array.isArray(currentLeft);
-    if (leftIsArray !== Array.isArray(currentRight)) return false;
+    const leftIsArray = arrayIsArray(currentLeft);
+    if (leftIsArray !== arrayIsArray(currentRight)) return false;
     if (leftIsArray) {
       const leftArray = currentLeft as unknown[];
       const rightArray = currentRight as unknown[];
       if (leftArray.length !== rightArray.length) return false;
       for (let index = 0; index < leftArray.length; index++) {
-        pending.push([leftArray[index], rightArray[index]]);
+        reflectApply(arrayPush, pending, [[leftArray[index], rightArray[index]]]);
       }
       continue;
     }
 
     const leftRecord = currentLeft as Record<string, unknown>;
     const rightRecord = currentRight as Record<string, unknown>;
-    const leftKeys = Object.keys(leftRecord);
-    const rightKeys = Object.keys(rightRecord);
+    const leftKeys = objectKeys(leftRecord);
+    const rightKeys = objectKeys(rightRecord);
     if (leftKeys.length !== rightKeys.length) return false;
-    for (const key of leftKeys) {
-      if (!Object.hasOwn(rightRecord, key)) return false;
-      pending.push([leftRecord[key], rightRecord[key]]);
+    for (let index = 0; index < leftKeys.length; index++) {
+      const key = leftKeys[index]!;
+      if (!objectHasOwn(rightRecord, key)) return false;
+      reflectApply(arrayPush, pending, [[leftRecord[key], rightRecord[key]]]);
     }
   }
   return true;
@@ -108,9 +127,13 @@ function matchesCondition(
       return stableEquals(actual, condition.value);
     case "not_equals":
       return !stableEquals(actual, condition.value);
-    case "in":
-      return Array.isArray(condition.value) &&
-        condition.value.some((value) => stableEquals(actual, value));
+    case "in": {
+      if (!arrayIsArray(condition.value)) return false;
+      for (let index = 0; index < condition.value.length; index++) {
+        if (stableEquals(actual, condition.value[index])) return true;
+      }
+      return false;
+    }
     case "exists":
       return actual !== undefined;
     case "contains":
@@ -118,10 +141,13 @@ function matchesCondition(
         typeof actual === "string" &&
         typeof condition.value === "string"
       ) {
-        return actual.includes(condition.value);
+        return reflectApply(stringIncludes, actual, [condition.value]) as boolean;
       }
-      return Array.isArray(actual) &&
-        actual.some((value) => stableEquals(value, condition.value));
+      if (!arrayIsArray(actual)) return false;
+      for (let index = 0; index < actual.length; index++) {
+        if (stableEquals(actual[index], condition.value)) return true;
+      }
+      return false;
   }
 }
 
@@ -131,15 +157,22 @@ export function matchesWebhookEventFilter(
   payload: BoundedJsonValue,
 ): boolean {
   if (!filter || filter.conditions.length === 0) return true;
-  return filter.mode === "any"
-    ? filter.conditions.some((condition) => matchesCondition(condition, payload))
-    : filter.conditions.every((condition) => matchesCondition(condition, payload));
+  if (filter.mode === "any") {
+    for (let index = 0; index < filter.conditions.length; index++) {
+      if (matchesCondition(filter.conditions[index]!, payload)) return true;
+    }
+    return false;
+  }
+  for (let index = 0; index < filter.conditions.length; index++) {
+    if (!matchesCondition(filter.conditions[index]!, payload)) return false;
+  }
+  return true;
 }
 
 function toPromptValue(value: unknown): string {
   if (typeof value === "string") return value;
   if (value === null || value === undefined) return "";
-  return JSON.stringify(value, null, 2);
+  return jsonStringify(value, null, 2);
 }
 
 /** Render an agent webhook prompt exactly as the hosted runtime does. */
@@ -148,17 +181,17 @@ export function renderWebhookPromptTemplate(
   payload: BoundedJsonValue,
 ): string {
   let replacedPlaceholder = false;
-  const rendered = template.replace(
+  const rendered = reflectApply(stringReplace, template, [
     PROMPT_PLACEHOLDER_PATTERN,
-    (_match, path: string | undefined) => {
+    (_match: string, path: string | undefined) => {
       replacedPlaceholder = true;
-      if (!path) return JSON.stringify(payload, null, 2);
+      if (!path) return jsonStringify(payload, null, 2);
       return toPromptValue(readPath(payload, path));
     },
-  );
+  ]) as string;
   if (replacedPlaceholder) return rendered;
-  return `${template.trim()}\n\nWebhook payload:\n\`\`\`json\n${
-    JSON.stringify(payload, null, 2)
+  return `${reflectApply(stringTrim, template, [])}\n\nWebhook payload:\n\`\`\`json\n${
+    jsonStringify(payload, null, 2)
   }\n\`\`\``;
 }
 

--- a/src/webhook/runtime.ts
+++ b/src/webhook/runtime.ts
@@ -19,11 +19,18 @@ const objectHasOwn = Object.hasOwn;
 const objectKeys = Object.keys;
 const reflectApply = Reflect.apply;
 const reflectGetOwnPropertyDescriptor = Reflect.getOwnPropertyDescriptor;
+const reflectGetPrototypeOf = Reflect.getPrototypeOf;
+const regExpExec = RegExp.prototype.exec;
 const stringIncludes = String.prototype.includes;
-const stringReplace = String.prototype.replace;
+const stringRepeat = String.prototype.repeat;
+const stringSlice = String.prototype.slice;
 const stringSplit = String.prototype.split;
 const stringTrim = String.prototype.trim;
 const textEncoderEncode = TextEncoder.prototype.encode;
+const typedArrayByteLengthGetter = reflectGetOwnPropertyDescriptor(
+  reflectGetPrototypeOf(Uint8Array.prototype)!,
+  "byteLength",
+)!.get!;
 
 /** Owned, cloud-compatible inputs for one local webhook target run. */
 export interface PreparedWebhookInvocation {
@@ -46,11 +53,10 @@ function invalidPayload(detail: string): never {
 function snapshotWebhookPayload(value: unknown): BoundedJsonValue {
   const snapshot = snapshotSerializable(value ?? {}, "Webhook payload");
 
-  const serialized = jsonStringify(snapshot);
-  if (
-    (reflectApply(textEncoderEncode, UTF8_ENCODER, [serialized]) as Uint8Array)
-      .byteLength > MAX_WEBHOOK_PAYLOAD_BYTES
-  ) {
+  const serialized = stringifyWebhookJson(snapshot);
+  const encoded = reflectApply(textEncoderEncode, UTF8_ENCODER, [serialized]) as Uint8Array;
+  const byteLength = reflectApply(typedArrayByteLengthGetter, encoded, []) as number;
+  if (byteLength > MAX_WEBHOOK_PAYLOAD_BYTES) {
     invalidPayload("Webhook payload must be 64 KiB or smaller.");
   }
   return snapshot;
@@ -80,7 +86,8 @@ function stableEquals(left: unknown, right: unknown): boolean {
   while (pending.length > 0) {
     const pair = reflectApply(arrayPop, pending, []) as readonly [unknown, unknown] | undefined;
     if (!pair) break;
-    const [currentLeft, currentRight] = pair;
+    const currentLeft = pair[0];
+    const currentRight = pair[1];
     if (currentLeft === currentRight) continue;
     if (
       currentLeft === null ||
@@ -172,7 +179,60 @@ export function matchesWebhookEventFilter(
 function toPromptValue(value: unknown): string {
   if (typeof value === "string") return value;
   if (value === null || value === undefined) return "";
-  return jsonStringify(value, null, 2);
+  return stringifyWebhookJson(value as BoundedJsonValue, 2);
+}
+
+function stringifyWebhookJson(
+  value: BoundedJsonValue,
+  spaces = 0,
+  depth = 0,
+): string {
+  if (
+    value === null || typeof value === "string" || typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return jsonStringify(value);
+  }
+
+  const currentIndent = spaces > 0
+    ? reflectApply(stringRepeat, " ", [depth * spaces]) as string
+    : "";
+  const childIndent = spaces > 0
+    ? reflectApply(stringRepeat, " ", [(depth + 1) * spaces]) as string
+    : "";
+  const separator = spaces > 0 ? ",\n" : ",";
+  const beforeValue = spaces > 0 ? " " : "";
+
+  if (arrayIsArray(value)) {
+    if (value.length === 0) return "[]";
+    let serialized = spaces > 0 ? "[\n" : "[";
+    for (let index = 0; index < value.length; index++) {
+      if (index > 0) serialized += separator;
+      const descriptor = reflectGetOwnPropertyDescriptor(value, String(index));
+      serialized += childIndent + stringifyWebhookJson(
+        descriptor!.value as BoundedJsonValue,
+        spaces,
+        depth + 1,
+      );
+    }
+    return `${serialized}${spaces > 0 ? `\n${currentIndent}` : ""}]`;
+  }
+
+  const keys = objectKeys(value);
+  if (keys.length === 0) return "{}";
+  let serialized = spaces > 0 ? "{\n" : "{";
+  for (let index = 0; index < keys.length; index++) {
+    if (index > 0) serialized += separator;
+    const key = keys[index]!;
+    const descriptor = reflectGetOwnPropertyDescriptor(value, key);
+    serialized += childIndent + jsonStringify(key) + `:${beforeValue}` +
+      stringifyWebhookJson(
+        descriptor!.value as BoundedJsonValue,
+        spaces,
+        depth + 1,
+      );
+  }
+  return `${serialized}${spaces > 0 ? `\n${currentIndent}` : ""}}`;
 }
 
 /** Render an agent webhook prompt exactly as the hosted runtime does. */
@@ -180,18 +240,30 @@ export function renderWebhookPromptTemplate(
   template: string,
   payload: BoundedJsonValue,
 ): string {
+  let rendered = "";
+  let lastIndex = 0;
   let replacedPlaceholder = false;
-  const rendered = reflectApply(stringReplace, template, [
-    PROMPT_PLACEHOLDER_PATTERN,
-    (_match: string, path: string | undefined) => {
-      replacedPlaceholder = true;
-      if (!path) return jsonStringify(payload, null, 2);
-      return toPromptValue(readPath(payload, path));
-    },
-  ]) as string;
-  if (replacedPlaceholder) return rendered;
+  PROMPT_PLACEHOLDER_PATTERN.lastIndex = 0;
+  for (
+    let match = reflectApply(regExpExec, PROMPT_PLACEHOLDER_PATTERN, [template]) as
+      | RegExpExecArray
+      | null;
+    match;
+    match = reflectApply(regExpExec, PROMPT_PLACEHOLDER_PATTERN, [template]) as
+      | RegExpExecArray
+      | null
+  ) {
+    replacedPlaceholder = true;
+    rendered += reflectApply(stringSlice, template, [lastIndex, match.index]) as string;
+    const path = match[1];
+    rendered += path ? toPromptValue(readPath(payload, path)) : stringifyWebhookJson(payload, 2);
+    lastIndex = match.index + match[0].length;
+  }
+  if (replacedPlaceholder) {
+    return rendered + (reflectApply(stringSlice, template, [lastIndex]) as string);
+  }
   return `${reflectApply(stringTrim, template, [])}\n\nWebhook payload:\n\`\`\`json\n${
-    jsonStringify(payload, null, 2)
+    stringifyWebhookJson(payload, 2)
   }\n\`\`\``;
 }
 

--- a/src/webhook/runtime.ts
+++ b/src/webhook/runtime.ts
@@ -208,7 +208,7 @@ function stringifyWebhookJson(
     let serialized = spaces > 0 ? "[\n" : "[";
     for (let index = 0; index < value.length; index++) {
       if (index > 0) serialized += separator;
-      const descriptor = reflectGetOwnPropertyDescriptor(value, String(index));
+      const descriptor = reflectGetOwnPropertyDescriptor(value, `${index}`);
       serialized += childIndent + stringifyWebhookJson(
         descriptor!.value as BoundedJsonValue,
         spaces,

--- a/src/webhook/validation.ts
+++ b/src/webhook/validation.ts
@@ -47,6 +47,8 @@ const MAX_EVENT_FILTER_PATH_LENGTH = 255;
 const MAX_PROMPT_TEMPLATE_LENGTH = 20_000;
 const MAX_DIAGNOSTIC_KEY_LENGTH = 80;
 const SIMPLE_DIAGNOSTIC_KEY_PATTERN = /^[A-Za-z_$][A-Za-z0-9_$-]*$/;
+const reflectApply = Reflect.apply;
+const setHas = Set.prototype.has;
 
 function invalid(detail: string, cause?: unknown): never {
   throw WEBHOOK_CONFIG_INVALID.create({
@@ -303,7 +305,11 @@ function normalizeFilterCondition(
   );
   const path = requireEventFilterPath(condition.path, `${label} path`);
   const operator = condition.operator;
-  if (!EVENT_FILTER_OPERATORS.has(operator as WebhookEventFilterOperator)) {
+  if (
+    !reflectApply(setHas, EVENT_FILTER_OPERATORS, [
+      operator as WebhookEventFilterOperator,
+    ])
+  ) {
     invalid(`${label} operator is not supported.`);
   }
 

--- a/tests/integration/webhook/ambient-intrinsics.test.ts
+++ b/tests/integration/webhook/ambient-intrinsics.test.ts
@@ -143,9 +143,13 @@ describe("webhook validation with hostile ambient intrinsics", () => {
       matched = matchesWebhookEventFilter(
         {
           mode: "all",
-          conditions: [{ path: "action", operator: "equals", value: "opened" }],
+          conditions: [{
+            path: "action",
+            operator: "equals",
+            value: ["opened", "expected"],
+          }],
         },
-        { action: "closed" },
+        { action: ["opened", "actual"] },
       );
     } finally {
       Array.prototype[Symbol.iterator] = originalIterator;

--- a/tests/integration/webhook/ambient-intrinsics.test.ts
+++ b/tests/integration/webhook/ambient-intrinsics.test.ts
@@ -1,0 +1,84 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { VeryfrontError } from "#veryfront/errors";
+import { webhook } from "#veryfront/webhook";
+import { prepareWebhookInvocation } from "#veryfront/webhook/runtime.ts";
+import { assertEquals, assertInstanceOf, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+
+describe("webhook validation with hostile ambient intrinsics", () => {
+  it("does not trust a replaced Set.prototype.has when admitting operators", () => {
+    const originalSetHas = Set.prototype.has;
+    let error: unknown;
+
+    try {
+      Set.prototype.has = function (this: Set<unknown>, value: unknown): boolean {
+        if (
+          Reflect.apply(originalSetHas, this, ["equals"]) &&
+          Reflect.apply(originalSetHas, this, ["contains"])
+        ) {
+          return true;
+        }
+        return Reflect.apply(originalSetHas, this, [value]) as boolean;
+      };
+      webhook({
+        id: "unsupported-operator",
+        target: { kind: "task", id: "process-event" },
+        eventFilter: {
+          mode: "all",
+          conditions: [{ path: "action", operator: "always" as never }],
+        },
+      });
+    } catch (cause) {
+      error = cause;
+    } finally {
+      Set.prototype.has = originalSetHas;
+    }
+
+    assertInstanceOf(error, VeryfrontError);
+    assertEquals(error.slug, "webhook-config-invalid");
+    assertStringIncludes(error.message, "operator is not supported");
+  });
+
+  it("does not trust a replaced Array.prototype.every when filtering", () => {
+    const definition = webhook({
+      id: "closed-event",
+      target: { kind: "task", id: "process-event" },
+      eventFilter: {
+        mode: "all",
+        conditions: [{ path: "action", operator: "equals", value: "opened" }],
+      },
+    });
+    const originalEvery = Array.prototype.every;
+    let matched: boolean | undefined;
+
+    try {
+      Array.prototype.every = (() => true) as typeof Array.prototype.every;
+      matched = prepareWebhookInvocation(definition, { action: "closed" }).matched;
+    } finally {
+      Array.prototype.every = originalEvery;
+    }
+
+    assertEquals(matched, false);
+  });
+
+  it("does not trust a replaced JSON.stringify when bounding payloads", () => {
+    const definition = webhook({
+      id: "oversized-event",
+      target: { kind: "task", id: "process-event" },
+    });
+    const originalStringify = JSON.stringify;
+    let error: unknown;
+
+    try {
+      JSON.stringify = (() => "{}") as typeof JSON.stringify;
+      prepareWebhookInvocation(definition, { data: "x".repeat(64 * 1_024) });
+    } catch (cause) {
+      error = cause;
+    } finally {
+      JSON.stringify = originalStringify;
+    }
+
+    assertInstanceOf(error, VeryfrontError);
+    assertStringIncludes(error.message, "Webhook payload must be 64 KiB or smaller.");
+  });
+});

--- a/tests/integration/webhook/ambient-intrinsics.test.ts
+++ b/tests/integration/webhook/ambient-intrinsics.test.ts
@@ -1,7 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { VeryfrontError } from "#veryfront/errors";
 import { webhook } from "#veryfront/webhook";
-import { prepareWebhookInvocation } from "#veryfront/webhook/runtime.ts";
+import {
+  matchesWebhookEventFilter,
+  prepareWebhookInvocation,
+  renderWebhookPromptTemplate,
+} from "#veryfront/webhook/runtime.ts";
 import { assertEquals, assertInstanceOf, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 
@@ -67,18 +71,79 @@ describe("webhook validation with hostile ambient intrinsics", () => {
       target: { kind: "task", id: "process-event" },
     });
     const originalStringify = JSON.stringify;
+    const originalArrayToJson = Object.getOwnPropertyDescriptor(Array.prototype, "toJSON");
+    const originalByteLength = Object.getOwnPropertyDescriptor(
+      Uint8Array.prototype,
+      "byteLength",
+    );
     let error: unknown;
 
     try {
       JSON.stringify = (() => "{}") as typeof JSON.stringify;
-      prepareWebhookInvocation(definition, { data: "x".repeat(64 * 1_024) });
+      Object.defineProperty(Array.prototype, "toJSON", {
+        configurable: true,
+        value: () => null,
+      });
+      Object.defineProperty(Uint8Array.prototype, "byteLength", {
+        configurable: true,
+        get: () => 0,
+      });
+      prepareWebhookInvocation(definition, {
+        data: Array.from({ length: 40_000 }, () => "x"),
+      });
     } catch (cause) {
       error = cause;
     } finally {
       JSON.stringify = originalStringify;
+      if (originalArrayToJson) {
+        Object.defineProperty(Array.prototype, "toJSON", originalArrayToJson);
+      } else {
+        Reflect.deleteProperty(Array.prototype, "toJSON");
+      }
+      if (originalByteLength) {
+        Object.defineProperty(Uint8Array.prototype, "byteLength", originalByteLength);
+      } else {
+        Reflect.deleteProperty(Uint8Array.prototype, "byteLength");
+      }
     }
 
     assertInstanceOf(error, VeryfrontError);
     assertStringIncludes(error.message, "Webhook payload must be 64 KiB or smaller.");
+  });
+
+  it("does not trust the live array iterator for structural equality", () => {
+    const originalIterator = Array.prototype[Symbol.iterator];
+    let matched: boolean | undefined;
+    try {
+      Array.prototype[Symbol.iterator] = function* () {
+        yield this[0];
+        yield this[0];
+      };
+      matched = matchesWebhookEventFilter(
+        {
+          mode: "all",
+          conditions: [{ path: "action", operator: "equals", value: "opened" }],
+        },
+        { action: "closed" },
+      );
+    } finally {
+      Array.prototype[Symbol.iterator] = originalIterator;
+    }
+    assertEquals(matched, false);
+  });
+
+  it("renders placeholders without the live RegExp replace protocol", () => {
+    const originalReplace = RegExp.prototype[Symbol.replace];
+    let rendered: string | undefined;
+    try {
+      RegExp.prototype[Symbol.replace] = () => "poisoned";
+      rendered = renderWebhookPromptTemplate(
+        "Review {{payload.action}}.",
+        { action: "opened" },
+      );
+    } finally {
+      RegExp.prototype[Symbol.replace] = originalReplace;
+    }
+    assertEquals(rendered, "Review opened.");
   });
 });

--- a/tests/integration/webhook/ambient-intrinsics.test.ts
+++ b/tests/integration/webhook/ambient-intrinsics.test.ts
@@ -111,6 +111,27 @@ describe("webhook validation with hostile ambient intrinsics", () => {
     assertStringIncludes(error.message, "Webhook payload must be 64 KiB or smaller.");
   });
 
+  it("does not trust the live String constructor for array payload sizing", () => {
+    const definition = webhook({
+      id: "oversized-array-event",
+      target: { kind: "task", id: "process-event" },
+    });
+    const originalString = globalThis.String;
+    let error: unknown;
+
+    try {
+      globalThis.String = (() => "0") as unknown as StringConstructor;
+      prepareWebhookInvocation(definition, ["", "x".repeat(64 * 1_024)]);
+    } catch (cause) {
+      error = cause;
+    } finally {
+      globalThis.String = originalString;
+    }
+
+    assertInstanceOf(error, VeryfrontError);
+    assertStringIncludes(error.message, "Webhook payload must be 64 KiB or smaller.");
+  });
+
   it("does not trust the live array iterator for structural equality", () => {
     const originalIterator = Array.prototype[Symbol.iterator];
     let matched: boolean | undefined;


### PR DESCRIPTION
## Summary

- capture filter-operator membership before project code can replace `Set.prototype.has`
- evaluate webhook `all`, `any`, `in`, and `contains` semantics without live array iteration methods
- capture JSON serialization and UTF-8 encoding used by the 64 KiB payload boundary
- route structural equality, path lookup, and prompt rendering through captured runtime primitives
- add isolated hostile-ambient integration regressions for admission, filtering, and payload sizing

## Verification

- `deno task test:file src/webhook` (4 passed, 32 steps)
- `deno task test:file tests/integration/webhook/ambient-intrinsics.test.ts` (1 passed, 3 steps)
- `deno task test:unit:parallel` (4,183 passed, 32,214 steps)
- `deno task test:unit:cwd` (3 passed, 112 steps)
- `deno task test:unit:cwd-exclusion` (2 passed, 2 steps)
- `deno task test:integration` (320 passed, 2,954 steps)
- `deno task typecheck`
- `deno task lint:test-typecheck`
- `deno task lint:test-semantic-dispositions`
- `deno task lint:anti-slop`
- `deno task lint:dependency-boundaries`
- `deno task lint:module-boundaries`
- `deno task test:layout`
- `deno fmt --check src/webhook tests/integration/webhook`
- `deno lint src/webhook tests/integration/webhook`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook reliability when standard JavaScript methods or built-in behaviors are modified.
  * Preserved webhook validation, filtering, payload-size checks, structural comparisons, and prompt rendering behavior under unusual runtime conditions.

* **Tests**
  * Added integration coverage for webhook processing with altered or unavailable built-in behaviors.

* **Documentation**
  * Updated webhook API reference links to point to the current implementation locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->