### PR TITLE
fix(workflow): harden blob references and local storage

### DIFF
--- a/docs/api-reference/veryfront/workflow.md
+++ b/docs/api-reference/veryfront/workflow.md
@@ -253,14 +253,14 @@ import { assertSafeBlobId, BlobStorageContractName, isSafeBlobId } from "veryfro
 
 | Name               | Description                                                               | Source                                                                                           |
 | ------------------ | ------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `assertSafeBlobId` | Validate an identifier before any blob backend constructs a storage path. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/blob/blob-id.ts#L13) |
-| `isSafeBlobId`     | Return whether a runtime value is a framework-safe blob identifier.       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/blob/blob-id.ts#L7)  |
+| `assertSafeBlobId` | Validate an identifier before any blob backend constructs a storage path. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/blob/blob-id.ts#L15) |
+| `isSafeBlobId`     | Return whether a runtime value is a framework-safe blob identifier.       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/blob/blob-id.ts#L9)  |
 
 #### Classes
 
 | Name                        | Description | Source                                                                                                            |
 | --------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------- |
-| `LocalBlobStorage`          |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/blob/local-storage.ts#L12)            |
+| `LocalBlobStorage`          |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/blob/local-storage.ts#L13)            |
 | `VeryfrontCloudBlobStorage` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/blob/veryfront-cloud-storage.ts#L462) |
 
 #### Types

--- a/src/workflow/blob/blob-id.test.ts
+++ b/src/workflow/blob/blob-id.test.ts
@@ -1,20 +1,25 @@
-import { assert, assertFalse, assertThrows } from "@std/assert";
+import "#veryfront/schemas/_test-setup.ts";
+import { VeryfrontError } from "#veryfront/errors";
+import { assert, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
 import { assertSafeBlobId, isSafeBlobId } from "./blob-id.ts";
 
-Deno.test("blob ids accept only the framework's portable identifier alphabet", () => {
-  for (const id of ["a", "ABC_123", "blob-id", crypto.randomUUID()]) {
-    assert(isSafeBlobId(id));
-    assertSafeBlobId(id);
-  }
+describe("blob ids", () => {
+  it("accepts only the framework portable identifier alphabet", () => {
+    for (const id of ["a", "ABC_123", "blob-id", crypto.randomUUID()]) {
+      assert(isSafeBlobId(id));
+      assertSafeBlobId(id);
+    }
 
-  for (
-    const id of [undefined, null, 1, "", "a/b", "a b", "a?b", "\ud800", "a".repeat(257)]
-  ) {
-    assertFalse(isSafeBlobId(id));
-    assertThrows(
-      () => assertSafeBlobId(id),
-      Error,
-      "Blob IDs must contain at most 256 alphanumeric characters, hyphens, and underscores",
-    );
-  }
+    for (
+      const id of [undefined, null, 1, "", "a/b", "a b", "a?b", "\ud800", "a".repeat(257)]
+    ) {
+      assert(!isSafeBlobId(id));
+      assertThrows(
+        () => assertSafeBlobId(id),
+        VeryfrontError,
+        "Blob IDs must contain at most 256 alphanumeric characters, hyphens, and underscores",
+      );
+    }
+  });
 });

--- a/src/workflow/blob/blob-id.ts
+++ b/src/workflow/blob/blob-id.ts
@@ -3,12 +3,12 @@ import { INVALID_ARGUMENT } from "#veryfront/errors";
 const SAFE_BLOB_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const MAX_BLOB_ID_LENGTH = 256;
 const reflectApply = Reflect.apply;
-const regExpTest = RegExp.prototype.test;
+const regExpExec = RegExp.prototype.exec;
 
 /** Return whether a runtime value is a framework-safe blob identifier. */
 export function isSafeBlobId(id: unknown): id is string {
   return typeof id === "string" && id.length <= MAX_BLOB_ID_LENGTH &&
-    reflectApply(regExpTest, SAFE_BLOB_ID_PATTERN, [id]);
+    reflectApply(regExpExec, SAFE_BLOB_ID_PATTERN, [id]) !== null;
 }
 
 /** Validate an identifier before any blob backend constructs a storage path. */

--- a/src/workflow/blob/blob-id.ts
+++ b/src/workflow/blob/blob-id.ts
@@ -2,11 +2,13 @@ import { INVALID_ARGUMENT } from "#veryfront/errors";
 
 const SAFE_BLOB_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
 const MAX_BLOB_ID_LENGTH = 256;
+const reflectApply = Reflect.apply;
+const regExpTest = RegExp.prototype.test;
 
 /** Return whether a runtime value is a framework-safe blob identifier. */
 export function isSafeBlobId(id: unknown): id is string {
   return typeof id === "string" && id.length <= MAX_BLOB_ID_LENGTH &&
-    SAFE_BLOB_ID_PATTERN.test(id);
+    reflectApply(regExpTest, SAFE_BLOB_ID_PATTERN, [id]);
 }
 
 /** Validate an identifier before any blob backend constructs a storage path. */

--- a/src/workflow/blob/guards.test.ts
+++ b/src/workflow/blob/guards.test.ts
@@ -14,6 +14,7 @@ describe("workflow/blob/guards", () => {
         createdAt: new Date(),
       };
       expect(isBlobRef(ref)).toBe(true);
+      expect(isBlobRef({ ...ref, mimeType: "" })).toBe(true);
     });
 
     it("rejects objects missing required fields", () => {

--- a/src/workflow/blob/guards.test.ts
+++ b/src/workflow/blob/guards.test.ts
@@ -32,5 +32,71 @@ describe("workflow/blob/guards", () => {
         expect(isBlobRef(v)).toBe(false);
       }
     });
+
+    it("rejects unsafe identities, sizes, and dates", () => {
+      const valid = {
+        __kind: "blob",
+        id: "blob-id",
+        size: 1,
+        mimeType: "text/plain",
+        createdAt: new Date(),
+      };
+
+      for (
+        const ref of [
+          { ...valid, id: "../blob" },
+          { ...valid, size: -1 },
+          { ...valid, size: 1.5 },
+          { ...valid, size: Number.NaN },
+          { ...valid, createdAt: new Date(Number.NaN) },
+        ]
+      ) {
+        expect(isBlobRef(ref)).toBe(false);
+      }
+    });
+
+    it("does not invoke accessors while checking a reference", () => {
+      let getterCalls = 0;
+      const ref = Object.defineProperty(
+        {
+          __kind: "blob",
+          size: 1,
+          mimeType: "text/plain",
+          createdAt: new Date(),
+        },
+        "id",
+        {
+          enumerable: true,
+          get() {
+            getterCalls++;
+            return "blob-id";
+          },
+        },
+      );
+
+      expect(isBlobRef(ref)).toBe(false);
+      expect(getterCalls).toBe(0);
+    });
+
+    it("rejects malformed optional fields", () => {
+      const valid = {
+        __kind: "blob",
+        id: "blob-id",
+        size: 1,
+        mimeType: "text/plain",
+        createdAt: new Date(),
+      };
+
+      for (
+        const ref of [
+          { ...valid, expiresAt: "tomorrow" },
+          { ...valid, url: 1 },
+          { ...valid, metadata: [] },
+          { ...valid, metadata: { source: 1 } },
+        ]
+      ) {
+        expect(isBlobRef(ref)).toBe(false);
+      }
+    });
   });
 });

--- a/src/workflow/blob/guards.ts
+++ b/src/workflow/blob/guards.ts
@@ -1,4 +1,61 @@
 import type { BlobRef } from "./types.ts";
+import { isProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
+import { isSafeBlobId } from "./blob-id.ts";
+
+const dateGetTime = Date.prototype.getTime;
+const numberIsFinite = Number.isFinite;
+const numberIsSafeInteger = Number.isSafeInteger;
+const objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const objectGetOwnPropertyDescriptors = Object.getOwnPropertyDescriptors;
+const objectGetPrototypeOf = Object.getPrototypeOf;
+const objectPrototype = Object.prototype;
+const reflectApply = Reflect.apply;
+const reflectOwnKeys = Reflect.ownKeys;
+const missing = Symbol("missing blob ref field");
+const invalid = Symbol("invalid blob ref field");
+
+function ownDataValue(
+  value: unknown,
+  key: keyof BlobRef,
+): unknown | typeof missing | typeof invalid {
+  if (typeof value !== "object" || value === null) return invalid;
+  const descriptor = objectGetOwnPropertyDescriptor(value, key);
+  if (!descriptor) return missing;
+  return "value" in descriptor ? descriptor.value : invalid;
+}
+
+function isValidDate(value: unknown): value is Date {
+  if (typeof value !== "object" || value === null || isProxyWithoutHooks(value)) return false;
+  try {
+    return numberIsFinite(reflectApply(dateGetTime, value, []));
+  } catch {
+    return false;
+  }
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (typeof value !== "object" || value === null || isProxyWithoutHooks(value)) return false;
+  try {
+    const prototype = objectGetPrototypeOf(value);
+    if (prototype !== objectPrototype && prototype !== null) return false;
+    const descriptors = objectGetOwnPropertyDescriptors(value);
+    const keys = reflectOwnKeys(descriptors);
+    for (let index = 0; index < keys.length; index++) {
+      const key = keys[index]!;
+      if (typeof key !== "string") return false;
+      const descriptor = descriptors[key];
+      if (
+        !descriptor || !descriptor.enumerable || !("value" in descriptor) ||
+        typeof descriptor.value !== "string"
+      ) {
+        return false;
+      }
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Type guard verifying that an unknown value is a BlobRef.
@@ -8,11 +65,25 @@ import type { BlobRef } from "./types.ts";
  * incorrectly route through the blob resolver.
  */
 export function isBlobRef(value: unknown): value is BlobRef {
-  if (typeof value !== "object" || value === null) return false;
-  const v = value as Record<string, unknown>;
-  return v.__kind === "blob" &&
-    typeof v.id === "string" &&
-    typeof v.size === "number" &&
-    typeof v.mimeType === "string" &&
-    v.createdAt instanceof Date;
+  if (typeof value !== "object" || value === null || isProxyWithoutHooks(value)) return false;
+  try {
+    const kind = ownDataValue(value, "__kind");
+    const id = ownDataValue(value, "id");
+    const size = ownDataValue(value, "size");
+    const mimeType = ownDataValue(value, "mimeType");
+    const createdAt = ownDataValue(value, "createdAt");
+    const expiresAt = ownDataValue(value, "expiresAt");
+    const url = ownDataValue(value, "url");
+    const metadata = ownDataValue(value, "metadata");
+
+    return kind === "blob" && isSafeBlobId(id) &&
+      typeof size === "number" && numberIsSafeInteger(size) && size >= 0 &&
+      typeof mimeType === "string" && mimeType.length > 0 &&
+      isValidDate(createdAt) &&
+      (expiresAt === missing || expiresAt === undefined || isValidDate(expiresAt)) &&
+      (url === missing || url === undefined || typeof url === "string") &&
+      (metadata === missing || metadata === undefined || isStringRecord(metadata));
+  } catch {
+    return false;
+  }
 }

--- a/src/workflow/blob/guards.ts
+++ b/src/workflow/blob/guards.ts
@@ -78,7 +78,7 @@ export function isBlobRef(value: unknown): value is BlobRef {
 
     return kind === "blob" && isSafeBlobId(id) &&
       typeof size === "number" && numberIsSafeInteger(size) && size >= 0 &&
-      typeof mimeType === "string" && mimeType.length > 0 &&
+      typeof mimeType === "string" &&
       isValidDate(createdAt) &&
       (expiresAt === missing || expiresAt === undefined || isValidDate(expiresAt)) &&
       (url === missing || url === undefined || typeof url === "string") &&

--- a/src/workflow/blob/local-storage.test.ts
+++ b/src/workflow/blob/local-storage.test.ts
@@ -9,7 +9,7 @@ import {
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { makeTempDir } from "#veryfront/testing/deno-compat.ts";
 import { join } from "#veryfront/compat/path";
-import { remove, stat } from "#veryfront/compat/fs.ts";
+import { remove, stat, writeTextFile } from "#veryfront/compat/fs.ts";
 import type { FileSystem } from "#veryfront/platform/compat/fs.ts";
 import {
   __registerLogRecordEmitter,
@@ -233,6 +233,18 @@ describe("LocalBlobStorage", () => {
     } finally {
       await remove(testDir, { recursive: true });
     }
+  });
+
+  it("ignores malformed metadata filenames in valid partitions", async () => {
+    await withTempStorage(async (storage, dir) => {
+      await storage.put("valid", { id: "custom-valid" });
+      const partition = join(dir, "cu");
+      await writeTextFile(join(partition, ".meta.json"), "{}");
+      await writeTextFile(join(partition, "blob.meta.json.meta.json"), "{}");
+
+      assertEquals((await storage.list()).map((ref) => ref.id), ["custom-valid"]);
+      await storage.cleanupExpiredBlobs();
+    });
   });
 
   it("rootDir is created if not exists", async () => {

--- a/src/workflow/blob/local-storage.test.ts
+++ b/src/workflow/blob/local-storage.test.ts
@@ -16,6 +16,7 @@ import {
   __resetLogRecordEmitterForTests,
   type LogEntry,
 } from "#veryfront/utils/logger/logger.ts";
+import { VeryfrontError } from "#veryfront/errors";
 import { LocalBlobStorage } from "./local-storage.ts";
 
 async function withTempStorage(
@@ -68,32 +69,36 @@ describe("LocalBlobStorage", () => {
     await withTempStorage(async (storage) => {
       await assertRejects(
         () => storage.put("hello", { id: "../../outside" }),
-        Error,
+        VeryfrontError,
         "Invalid blob id",
       );
       await assertRejects(
         () => storage.getText("../secret"),
-        Error,
+        VeryfrontError,
         "Invalid blob id",
       );
       await assertRejects(
         () => storage.stat("nested/blob"),
-        Error,
+        VeryfrontError,
         "Invalid blob id",
       );
       await assertRejects(
         () => storage.delete(".."),
-        Error,
+        VeryfrontError,
         "Invalid blob id",
       );
     });
   });
 
-  it("sanitizes local read failures", async () => {
+  it("sanitizes local storage failures", async () => {
     const storage = new LocalBlobStorage(".");
     (storage as unknown as { fs: FileSystem }).fs = {
       readTextFile: () => Promise.reject(new Error("read exposed <TOKEN> at <LOCAL_PATH>")),
       readFile: () => Promise.reject(new Error("read exposed <TOKEN> at <LOCAL_PATH>")),
+      remove: (path: string) =>
+        path.endsWith(".meta.json")
+          ? Promise.resolve()
+          : Promise.reject(new Error("delete exposed <TOKEN> at <LOCAL_PATH>")),
     } as unknown as FileSystem;
     const entries: LogEntry[] = [];
     __registerLogRecordEmitter((entry) => entries.push(entry));
@@ -101,15 +106,23 @@ describe("LocalBlobStorage", () => {
     try {
       const textError = await assertRejects(() => storage.getText("blob-id"));
       const bytesError = await assertRejects(() => storage.getBytes("blob-id"));
+      const statError = await assertRejects(() => storage.stat("blob-id"));
+      const deleteError = await assertRejects(() => storage.delete("blob-id"));
       assertInstanceOf(textError, Error);
       assertInstanceOf(bytesError, Error);
+      assertInstanceOf(statError, Error);
+      assertInstanceOf(deleteError, Error);
       assertEquals(textError.message, "Failed to read blob text from local storage");
       assertEquals(bytesError.message, "Failed to read blob bytes from local storage");
+      assertEquals(statError.message, "Failed to read blob metadata from local storage");
+      assertEquals(deleteError.message, "Failed to delete blob from local storage");
     } finally {
       __resetLogRecordEmitterForTests();
     }
 
     assertEquals(entries.map((entry) => entry.context), [
+      { errorName: "Error" },
+      { errorName: "Error" },
       { errorName: "Error" },
       { errorName: "Error" },
     ]);
@@ -126,14 +139,14 @@ describe("LocalBlobStorage", () => {
 
     try {
       const expiredData = "Expired content";
-      const expiredRef = await storage.put(expiredData, { ttl: 1 });
+      const expiredRef = await storage.put(expiredData, { id: "custom-expired", ttl: 1 });
       assertExists(expiredRef.expiresAt);
-      assert(expiredRef.expiresAt <= new Date(now + 2000));
+      assertEquals(expiredRef.expiresAt, new Date(now + 1_000));
 
       const validData = "Valid content";
-      const validRef = await storage.put(validData, { ttl: 3600 });
+      const validRef = await storage.put(validData, { id: "custom-valid", ttl: 3600 });
       assertExists(validRef.expiresAt);
-      assert(validRef.expiresAt > new Date(now + 3000));
+      assertEquals(validRef.expiresAt, new Date(now + 3_600_000));
 
       now += 1500;
 
@@ -170,10 +183,20 @@ describe("LocalBlobStorage", () => {
     });
   });
 
+  it("removes metadata when the primary blob is already missing", async () => {
+    await withTempStorage(async (storage, dir) => {
+      const ref = await storage.put("orphaned metadata", { id: "custom-delete" });
+      await remove(join(dir, ref.id.slice(0, 2), ref.id));
+
+      await storage.delete(ref.id);
+
+      assertEquals(await storage.stat(ref.id), null);
+    });
+  });
+
   it("delete non-existent blob (no error)", async () => {
     await withTempStorage(async (storage) => {
       await storage.delete("non-existent-id");
-      assert(true, "Delete did not throw for non-existent blob");
     });
   });
 
@@ -187,6 +210,29 @@ describe("LocalBlobStorage", () => {
     await withTempStorage(async (storage) => {
       assert(!await storage.exists("non-existent-id"));
     });
+  });
+
+  it("lists custom-id partitions newest first and omits expired blobs", async () => {
+    const testDir = await makeTempDir({ prefix: "vf_blob_test_" });
+    let now = Date.parse("2026-08-24T00:00:00.000Z");
+    const storage = new LocalBlobStorage(testDir, undefined, {
+      now: () => new Date(now),
+    });
+
+    try {
+      await storage.put("first", { id: "custom-first" });
+      now += 1_000;
+      await storage.put("second", { id: "named-second" });
+      await storage.put("expired", { id: "other-expired", ttl: 1 });
+      now += 1_500;
+
+      assertEquals(
+        (await storage.list()).map((ref) => ref.id),
+        ["named-second", "custom-first"],
+      );
+    } finally {
+      await remove(testDir, { recursive: true });
+    }
   });
 
   it("rootDir is created if not exists", async () => {

--- a/src/workflow/blob/local-storage.ts
+++ b/src/workflow/blob/local-storage.ts
@@ -5,7 +5,8 @@ import type { BlobRef, BlobStorage, StoreBlobOptions } from "./types.ts";
 import { agentLogger } from "#veryfront/utils";
 import { isNotFoundError } from "#veryfront/platform/compat/fs.ts";
 import { INVALID_ARGUMENT, UNKNOWN_ERROR } from "#veryfront/errors";
-import { assertSafeBlobId } from "./blob-id.ts";
+import { assertSafeBlobId, isSafeBlobId } from "./blob-id.ts";
+import { isBlobRef } from "./guards.ts";
 
 const logger = agentLogger.component("local-blob-storage");
 
@@ -132,12 +133,18 @@ export class LocalBlobStorage implements BlobStorage {
   async delete(id: string): Promise<void> {
     const filePath = this.getPath(id);
     const metadataPath = this.getMetadataPath(id);
-    try {
-      await this.fs.remove(filePath);
-      await this.fs.remove(metadataPath);
-    } catch (_) {
-      /* expected: file may not exist during cleanup */
-    }
+    const removeIfPresent = async (path: string): Promise<void> => {
+      try {
+        await this.fs.remove(path);
+      } catch (error) {
+        if (isNotFoundError(error)) return;
+        logger.warn("Failed to delete blob from local storage", {
+          errorName: error instanceof Error ? error.name : typeof error,
+        });
+        throw UNKNOWN_ERROR.create({ detail: "Failed to delete blob from local storage" });
+      }
+    };
+    await Promise.all([removeIfPresent(filePath), removeIfPresent(metadataPath)]);
   }
 
   async exists(id: string): Promise<boolean> {
@@ -146,17 +153,72 @@ export class LocalBlobStorage implements BlobStorage {
 
   async stat(id: string): Promise<BlobRef | null> {
     const metadataPath = this.getMetadataPath(id);
+    let json: string;
     try {
-      const json = await this.fs.readTextFile(metadataPath);
+      json = await this.fs.readTextFile(metadataPath);
+    } catch (error) {
+      if (isNotFoundError(error)) return null;
+      logger.warn("Failed to read blob metadata", {
+        errorName: error instanceof Error ? error.name : typeof error,
+      });
+      throw UNKNOWN_ERROR.create({ detail: "Failed to read blob metadata from local storage" });
+    }
+
+    try {
       const data = JSON.parse(json);
-      return {
+      const ref = {
         ...data,
         createdAt: new Date(data.createdAt),
         expiresAt: data.expiresAt ? new Date(data.expiresAt) : undefined,
       };
+      return isBlobRef(ref) ? ref : null;
     } catch (_) {
-      /* expected: metadata file not found or invalid JSON */
+      /* expected: invalid or incomplete metadata sidecar */
       return null;
+    }
+  }
+
+  private async listPartitionPrefixes(): Promise<string[]> {
+    const prefixes: string[] = [];
+    try {
+      for await (const entry of this.fs.readDir(this.rootDir)) {
+        if (
+          entry.isDirectory && !entry.isSymlink && entry.name.length <= 2 &&
+          isSafeBlobId(entry.name)
+        ) {
+          prefixes.push(entry.name);
+        }
+      }
+      return prefixes;
+    } catch (error) {
+      if (isNotFoundError(error)) return prefixes;
+      logger.warn("Failed to list blob partitions", {
+        errorName: error instanceof Error ? error.name : typeof error,
+      });
+      throw UNKNOWN_ERROR.create({ detail: "Failed to list blob partitions in local storage" });
+    }
+  }
+
+  private async listMetadataIds(
+    prefixDir: string,
+    operation: "list" | "cleanup",
+  ): Promise<string[]> {
+    const ids: string[] = [];
+    try {
+      for await (const entry of this.fs.readDir(prefixDir)) {
+        if (!entry.isFile || !entry.name.endsWith(".meta.json")) continue;
+        ids.push(entry.name.slice(0, -".meta.json".length));
+      }
+      return ids;
+    } catch (error) {
+      if (isNotFoundError(error)) return ids;
+      const message = operation === "list"
+        ? "Failed to list blob partition"
+        : "Failed to inspect blob partition during cleanup";
+      logger.warn(message, {
+        errorName: error instanceof Error ? error.name : typeof error,
+      });
+      throw UNKNOWN_ERROR.create({ detail: `${message} in local storage` });
     }
   }
 
@@ -169,22 +231,13 @@ export class LocalBlobStorage implements BlobStorage {
     const now = this.now();
     const refs: BlobRef[] = [];
 
-    for (let i = 0; i < 256; i++) {
-      const prefix = i.toString(16).padStart(2, "0");
+    for (const prefix of await this.listPartitionPrefixes()) {
       const prefixDir = join(this.rootDir, prefix);
-
-      try {
-        for await (const entry of this.fs.readDir(prefixDir)) {
-          if (!entry.isFile || !entry.name.endsWith(".meta.json")) continue;
-
-          const id = entry.name.replace(".meta.json", "");
-          const ref = await this.stat(id);
-          if (!ref) continue;
-          if (ref.expiresAt && ref.expiresAt < now) continue;
-          refs.push(ref);
-        }
-      } catch (_) {
-        /* expected: partition directory may not exist yet */
+      for (const id of await this.listMetadataIds(prefixDir, "list")) {
+        const ref = await this.stat(id);
+        if (!ref) continue;
+        if (ref.expiresAt && ref.expiresAt < now) continue;
+        refs.push(ref);
       }
     }
 
@@ -198,24 +251,15 @@ export class LocalBlobStorage implements BlobStorage {
   async cleanupExpiredBlobs(): Promise<void> {
     const now = this.now();
 
-    for (let i = 0; i < 256; i++) {
-      const prefix = i.toString(16).padStart(2, "0");
+    for (const prefix of await this.listPartitionPrefixes()) {
       const prefixDir = join(this.rootDir, prefix);
+      for (const id of await this.listMetadataIds(prefixDir, "cleanup")) {
+        const blobRef = await this.stat(id);
 
-      try {
-        for await (const entry of this.fs.readDir(prefixDir)) {
-          if (!entry.isFile || !entry.name.endsWith(".meta.json")) continue;
+        if (!blobRef?.expiresAt || blobRef.expiresAt >= now) continue;
 
-          const id = entry.name.replace(".meta.json", "");
-          const blobRef = await this.stat(id);
-
-          if (!blobRef?.expiresAt || blobRef.expiresAt >= now) continue;
-
-          logger.debug(`Deleting expired blob: ${id}`);
-          await this.delete(id);
-        }
-      } catch (_) {
-        /* expected: directory may not exist yet */
+        logger.debug(`Deleting expired blob: ${id}`);
+        await this.delete(id);
       }
     }
   }

--- a/src/workflow/blob/local-storage.ts
+++ b/src/workflow/blob/local-storage.ts
@@ -207,7 +207,8 @@ export class LocalBlobStorage implements BlobStorage {
     try {
       for await (const entry of this.fs.readDir(prefixDir)) {
         if (!entry.isFile || !entry.name.endsWith(".meta.json")) continue;
-        ids.push(entry.name.slice(0, -".meta.json".length));
+        const id = entry.name.slice(0, -".meta.json".length);
+        if (isSafeBlobId(id)) ids.push(id);
       }
       return ids;
     } catch (error) {

--- a/src/workflow/blob/veryfront-cloud-storage.test.ts
+++ b/src/workflow/blob/veryfront-cloud-storage.test.ts
@@ -276,12 +276,13 @@ describe("VeryfrontCloudBlobStorage", () => {
 
   it("lists stored blobs (newest first) with sidecar filenames", async () => {
     const service = createMockUploadService();
+    let now = FIXED_NOW.getTime();
     const storage = new VeryfrontCloudBlobStorage({
       apiBaseUrl: "https://93.184.216.34",
       apiToken: "vf_config_token",
       projectSlug: "demo-project",
       prefix: ".vf-test/",
-      now: () => FIXED_NOW,
+      now: () => new Date(now),
     });
 
     try {
@@ -289,6 +290,7 @@ describe("VeryfrontCloudBlobStorage", () => {
         mimeType: "text/plain",
         metadata: { filename: "first.txt" },
       });
+      now += 1_000;
       const second = await storage.put("two", {
         mimeType: "text/plain",
         metadata: { filename: "second.txt" },
@@ -299,6 +301,7 @@ describe("VeryfrontCloudBlobStorage", () => {
       // Both data blobs surface (the `.meta.json` sidecars are filtered out),
       // enriched with the original filename from each sidecar.
       assertEquals(refs.length, 2);
+      assertEquals(refs.map((ref) => ref.id), [second.id, first.id]);
       const byId = new Map(refs.map((ref) => [ref.id, ref]));
       assertEquals(byId.get(first.id)?.metadata?.filename, "first.txt");
       assertEquals(byId.get(second.id)?.metadata?.filename, "second.txt");

--- a/tests/integration/workflow/blob-intrinsics.test.ts
+++ b/tests/integration/workflow/blob-intrinsics.test.ts
@@ -1,0 +1,27 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { isSafeBlobId } from "#veryfront/workflow/blob/blob-id.ts";
+import { isBlobRef } from "#veryfront/workflow/blob/guards.ts";
+
+describe("workflow blob guards with hostile ambient intrinsics", () => {
+  it("does not trust a replaced RegExp.prototype.test for blob IDs", () => {
+    const originalTest = RegExp.prototype.test;
+    try {
+      RegExp.prototype.test = () => true;
+      assertEquals(isSafeBlobId("../unsafe"), false);
+      assertEquals(
+        isBlobRef({
+          __kind: "blob",
+          id: "../unsafe",
+          size: 1,
+          mimeType: "text/plain",
+          createdAt: new Date(),
+        }),
+        false,
+      );
+    } finally {
+      RegExp.prototype.test = originalTest;
+    }
+  });
+});

--- a/tests/integration/workflow/blob-intrinsics.test.ts
+++ b/tests/integration/workflow/blob-intrinsics.test.ts
@@ -7,8 +7,10 @@ import { isBlobRef } from "#veryfront/workflow/blob/guards.ts";
 describe("workflow blob guards with hostile ambient intrinsics", () => {
   it("does not trust a replaced RegExp.prototype.test for blob IDs", () => {
     const originalTest = RegExp.prototype.test;
+    const originalExec = RegExp.prototype.exec;
     try {
       RegExp.prototype.test = () => true;
+      RegExp.prototype.exec = (() => ({ 0: "../unsafe", index: 0 })) as never;
       assertEquals(isSafeBlobId("../unsafe"), false);
       assertEquals(
         isBlobRef({
@@ -22,6 +24,7 @@ describe("workflow blob guards with hostile ambient intrinsics", () => {
       );
     } finally {
       RegExp.prototype.test = originalTest;
+      RegExp.prototype.exec = originalExec;
     }
   });
 });


### PR DESCRIPTION
## Summary

- enumerate actual local blob partitions so valid custom IDs appear in list and TTL cleanup
- remove data and metadata independently so orphaned sidecars do not survive idempotent deletion
- distinguish missing files from operational filesystem failures and emit sanitized registered errors
- harden `isBlobRef` against accessors, Proxies, unsafe IDs, invalid sizes, invalid dates, and malformed optional fields
- capture the regular-expression test intrinsic used by blob ID validation
- replace weak identifier assertions and make local and cloud ordering checks deterministic
- regenerate workflow blob API source links

## Test audit findings

- Symptom: custom-ID blobs could be stored but not listed or expired.
  Source: local enumeration scanned only hexadecimal partitions from `00` through `ff`.
  Consequence: valid IDs beginning with other characters became invisible to list and cleanup.
  Remedy: discover validated partition directories from the storage root.
- Symptom: deleting a blob with an already-missing payload left its metadata sidecar behind.
  Source: one broad catch wrapped both removals and stopped after the first miss.
  Consequence: `stat()` continued to report a deleted blob.
  Remedy: remove both paths independently and ignore only not-found errors.
- Symptom: accessors ran during `isBlobRef`, and malformed references passed.
  Source: the guard read fields directly and checked only primitive types.
  Consequence: project hooks could execute during routing, while unsafe references reached the resolver.
  Remedy: inspect own data descriptors with captured intrinsics and validate every field.
- Symptom: filesystem permission and disk failures looked like absent metadata or successful deletion.
  Source: local operations swallowed every exception.
  Consequence: callers received false storage state and no actionable error.
  Remedy: classify not-found errors and sanitize all other failures.
- Symptom: the cloud list test claimed newest-first order without asserting order.
  Source: both fixtures used the same timestamp and the test converted results to a map.
  Consequence: a broken sort still passed.
  Remedy: use distinct deterministic times and assert the ordered ID list.

## Verification

- `deno task test:file src/workflow/blob`: 4 passed, 37 steps
- `deno task test:file tests/integration/workflow/blob-intrinsics.test.ts`: 1 passed, 1 step
- `deno task test:file src/workflow`: 82 passed, 922 steps
- `deno task test:unit:parallel`: 4,183 passed, 32,220 steps
- `deno task test:unit:cwd`: 3 passed, 112 steps
- `deno task test:unit:cwd-exclusion`: 2 passed, 2 steps
- `deno task test:integration`: 320 passed, 2,952 steps
- `deno task lint`: passed
- `deno task typecheck`: passed
- `deno task lint:anti-slop`: passed
- `deno task lint:test-typecheck`: passed
- `deno task lint:test-semantic-dispositions`: passed
- `deno task docs`: passed
- `deno task docs:api-reference:check`: passed
- `deno task docs:public:check`: passed