### PR TITLE
fix(workflow): canonicalize discovery results

### DIFF
--- a/docs/api-reference/veryfront/workflow.md
+++ b/docs/api-reference/veryfront/workflow.md
@@ -492,17 +492,17 @@ import {
 
 | Name                     | Description                                          | Source                                                                                                            |
 | ------------------------ | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `createWorkflowRegistry` | Create a workflow registry from discovered workflows | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/discovery/workflow-discovery.ts#L235) |
-| `discoverWorkflows`      | Discover all workflows in a project                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/discovery/workflow-discovery.ts#L124) |
-| `findWorkflowById`       | Find a specific workflow by ID                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/discovery/workflow-discovery.ts#L224) |
+| `createWorkflowRegistry` | Create a workflow registry from discovered workflows | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/discovery/workflow-discovery.ts#L328) |
+| `discoverWorkflows`      | Discover all workflows in a project                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/discovery/workflow-discovery.ts#L207) |
+| `findWorkflowById`       | Find a specific workflow by ID                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/discovery/workflow-discovery.ts#L314) |
 
 #### Types
 
-| Name                       | Description                    | Source                                                                                                           |
-| -------------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| `DiscoveredWorkflow`       | Discovered workflow info       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/discovery/workflow-discovery.ts#L38) |
-| `WorkflowDiscoveryOptions` | Options for workflow discovery | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/discovery/workflow-discovery.ts#L55) |
-| `WorkflowDiscoveryResult`  | Result of workflow discovery   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/discovery/workflow-discovery.ts#L78) |
+| Name                       | Description                    | Source                                                                                                            |
+| -------------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| `DiscoveredWorkflow`       | Discovered workflow info       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/discovery/workflow-discovery.ts#L70)  |
+| `WorkflowDiscoveryOptions` | Options for workflow discovery | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/discovery/workflow-discovery.ts#L87)  |
+| `WorkflowDiscoveryResult`  | Result of workflow discovery   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/discovery/workflow-discovery.ts#L110) |
 
 ### `veryfront/workflow/registry`
 

--- a/src/workflow/discovery/workflow-discovery.test.ts
+++ b/src/workflow/discovery/workflow-discovery.test.ts
@@ -1,10 +1,13 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { VeryfrontError } from "#veryfront/errors";
+import { assertEquals, assertStringIncludes, assertThrows } from "#veryfront/testing/assert.ts";
 import { afterAll, afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { FileSystemAdapter, RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 import { clearTranspileCache } from "#veryfront/discovery/transpiler.ts";
 import {
+  createWorkflowRegistry,
+  type DiscoveredWorkflow,
   discoverWorkflows as discoverWorkflowsRaw,
   findWorkflowById as findWorkflowByIdRaw,
 } from "./workflow-discovery.ts";
@@ -219,6 +222,137 @@ describe(
 
       assertEquals(result.errors, []);
       assertEquals(result.workflows, []);
+    });
+
+    it("returns an empty result when the workflow directory is absent", async () => {
+      const result = await discoverWorkflows({
+        projectDir: "/project",
+        adapter: createRuntimeAdapter({}),
+        config: { fs: { type: "veryfront-api" } } as never,
+      });
+
+      assertEquals(result, { workflows: [], errors: [] });
+    });
+
+    it("keeps valid sibling exports after rejecting malformed definitions", async () => {
+      const adapter = createRuntimeAdapter({
+        "/project/workflows/mixed.ts": [
+          "const accessor = Object.defineProperty({ steps: [] }, 'id', {",
+          "  enumerable: true,",
+          "  get() { throw new Error('workflow id accessor executed'); },",
+          "});",
+          "export { accessor };",
+          "export const malformed = { id: 'malformed', steps: null };",
+          "export const valid = { id: 'valid', steps: [] };",
+        ].join("\n"),
+      });
+
+      const result = await discoverWorkflows({
+        projectDir: "/project",
+        adapter,
+        config: { fs: { type: "veryfront-api" } } as never,
+      });
+
+      assertEquals(result.workflows.map((workflow) => workflow.id), ["valid"]);
+      assertEquals(Object.isFrozen(result.workflows[0]?.definition), true);
+      assertEquals(result.errors.length, 2);
+      assertEquals(
+        result.errors.some((entry) => entry.error.includes("accessor executed")),
+        false,
+      );
+    });
+
+    it("rejects duplicate workflow IDs deterministically", async () => {
+      const adapter = createRuntimeAdapter({
+        "/project/workflows/z.ts": "export default { id: 'duplicate', steps: [] };",
+        "/project/workflows/a.ts": "export default { id: 'duplicate', steps: [] };",
+      });
+
+      const result = await discoverWorkflows({
+        projectDir: "/project",
+        adapter,
+        config: { fs: { type: "veryfront-api" } } as never,
+      });
+
+      assertEquals(result.workflows, []);
+      assertEquals(result.errors.map((entry) => entry.filePath), [
+        "workflows/a.ts",
+        "workflows/z.ts",
+      ]);
+      assertEquals(
+        result.errors.every((entry) => entry.error.includes('Duplicate workflow id "duplicate"')),
+        true,
+      );
+      assertEquals(
+        await findWorkflowById("duplicate", {
+          projectDir: "/project",
+          adapter,
+          config: { fs: { type: "veryfront-api" } } as never,
+        }),
+        null,
+      );
+    });
+
+    it("sorts discovered workflows independently of adapter enumeration order", async () => {
+      const adapter = createRuntimeAdapter({
+        "/project/workflows/z.ts": "export default { id: 'zeta', steps: [] };",
+        "/project/workflows/a.ts": "export default { id: 'alpha', steps: [] };",
+      });
+
+      const result = await discoverWorkflows({
+        projectDir: "/project",
+        adapter,
+        config: { fs: { type: "veryfront-api" } } as never,
+      });
+
+      assertEquals(result.workflows.map((workflow) => workflow.id), ["alpha", "zeta"]);
+    });
+
+    it("rejects workflow roots that escape the project", async () => {
+      const adapter = createRuntimeAdapter({});
+      let existsCalls = 0;
+      adapter.fs.exists = () => {
+        existsCalls++;
+        return Promise.resolve(false);
+      };
+
+      const result = await discoverWorkflows({
+        projectDir: "/project",
+        workflowsDir: "../outside",
+        adapter,
+      });
+
+      assertEquals(result.workflows, []);
+      assertEquals(result.errors.length, 1);
+      assertStringIncludes(result.errors[0]!.error, "stay within the project");
+      assertEquals(existsCalls, 0);
+    });
+
+    it("requires explicit authority before executing project workflow code", async () => {
+      const result = await discoverWorkflowsRaw({
+        projectDir: "/project",
+        adapter: createRuntimeAdapter({
+          "/project/workflows/ping.ts": "export default { id: 'ping', steps: [] };",
+        }),
+        config: { fs: { type: "veryfront-api" } } as never,
+      });
+
+      assertEquals(result.workflows, []);
+      assertEquals(result.errors.length, 1);
+    });
+
+    it("creates a registry without silently overwriting duplicate IDs", () => {
+      const definition = { id: "duplicate", steps: [] };
+      const workflows: DiscoveredWorkflow[] = [
+        { id: "duplicate", filePath: "workflows/a.ts", exportName: "default", definition },
+        { id: "duplicate", filePath: "workflows/b.ts", exportName: "default", definition },
+      ];
+
+      assertThrows(
+        () => createWorkflowRegistry(workflows),
+        VeryfrontError,
+        'Duplicate workflow id "duplicate"',
+      );
     });
   },
 );

--- a/src/workflow/discovery/workflow-discovery.test.ts
+++ b/src/workflow/discovery/workflow-discovery.test.ts
@@ -354,5 +354,37 @@ describe(
         'Duplicate workflow id "duplicate"',
       );
     });
+
+    it("snapshots each registry id before checking and inserting it", () => {
+      let idReads = 0;
+      const shifting = Object.defineProperty(
+        {
+          filePath: "workflows/a.ts",
+          exportName: "default",
+          definition: { id: "duplicate", steps: [] },
+        },
+        "id",
+        {
+          enumerable: true,
+          get() {
+            idReads++;
+            return idReads === 1 ? "duplicate" : idReads === 2 ? "other" : "duplicate";
+          },
+        },
+      ) as DiscoveredWorkflow;
+      const duplicate: DiscoveredWorkflow = {
+        id: "duplicate",
+        filePath: "workflows/b.ts",
+        exportName: "default",
+        definition: { id: "duplicate", steps: [] },
+      };
+
+      assertThrows(
+        () => createWorkflowRegistry([shifting, duplicate]),
+        VeryfrontError,
+        'Duplicate workflow id "duplicate"',
+      );
+      assertEquals(idReads, 1);
+    });
   },
 );

--- a/src/workflow/discovery/workflow-discovery.test.ts
+++ b/src/workflow/discovery/workflow-discovery.test.ts
@@ -371,7 +371,7 @@ describe(
             return idReads === 1 ? "duplicate" : idReads === 2 ? "other" : "duplicate";
           },
         },
-      ) as DiscoveredWorkflow;
+      ) as unknown as DiscoveredWorkflow;
       const duplicate: DiscoveredWorkflow = {
         id: "duplicate",
         filePath: "workflows/b.ts",

--- a/src/workflow/discovery/workflow-discovery.ts
+++ b/src/workflow/discovery/workflow-discovery.ts
@@ -29,8 +29,40 @@ import type { VeryfrontConfig } from "#veryfront/config";
 import { collectFiles } from "#veryfront/utils/file-discovery.ts";
 import { importDiscoveryModule } from "#veryfront/discovery/module-import.ts";
 import type { WorkflowDefinition } from "../types.ts";
+import { captureWorkflowDefinition } from "../executor/workflow-definition-snapshot.ts";
+import { isProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
+import { snapshotThrowableDiagnostic } from "#veryfront/errors/safe-diagnostics.ts";
+import { INVALID_ARGUMENT } from "#veryfront/errors";
+import { normalizeProjectRelativeDiscoveryPath } from "#veryfront/utils/discovery-path-policy.ts";
 
 const logger = baseLogger.component("workflow-discovery");
+const arrayIsArray = Array.isArray;
+const arrayJoin = Array.prototype.join;
+const arrayPush = Array.prototype.push;
+const arraySlice = Array.prototype.slice;
+const arraySort = Array.prototype.sort;
+const MapConstructor = Map;
+const mapHas = Map.prototype.has;
+const mapSet = Map.prototype.set;
+const objectEntries = Object.entries;
+const objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const reflectApply = Reflect.apply;
+
+function append<T>(values: T[], value: T): void {
+  reflectApply(arrayPush, values, [value]);
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function sortValues<T>(values: T[], compare: (left: T, right: T) => number): T[] {
+  return reflectApply(arraySort, values, [compare]) as T[];
+}
+
+function toErrorMessage(error: unknown): string {
+  return snapshotThrowableDiagnostic(error);
+}
 
 /**
  * Discovered workflow info
@@ -83,39 +115,90 @@ export interface WorkflowDiscoveryResult {
   errors: Array<{ filePath: string; error: string }>;
 }
 
-/**
- * Check if a value looks like a workflow definition
- */
-function isWorkflowDefinition(value: unknown): value is WorkflowDefinition {
-  if (!value || typeof value !== "object") return false;
-  const obj = value as Record<string, unknown>;
-  return typeof obj.id === "string" && typeof obj.steps !== "undefined";
-}
-
-/**
- * Check if a value is a workflow wrapper (from workflow() DSL)
- */
-function isWorkflowWrapper(value: unknown): value is { definition: WorkflowDefinition } {
-  if (!value || typeof value !== "object") return false;
-  const obj = value as Record<string, unknown>;
-  return isWorkflowDefinition(obj.definition);
+function isWorkflowDefinitionCandidate(value: unknown): value is WorkflowDefinition {
+  if (
+    typeof value !== "object" || value === null || arrayIsArray(value) ||
+    isProxyWithoutHooks(value)
+  ) {
+    return false;
+  }
+  try {
+    return objectGetOwnPropertyDescriptor(value, "id") !== undefined &&
+      objectGetOwnPropertyDescriptor(value, "steps") !== undefined;
+  } catch {
+    return false;
+  }
 }
 
 /**
  * Extract workflow definition from a module export
  */
 function extractWorkflowDefinition(value: unknown): WorkflowDefinition | null {
-  // Direct WorkflowDefinition
-  if (isWorkflowDefinition(value)) {
-    return value;
+  if (
+    typeof value !== "object" || value === null || arrayIsArray(value) ||
+    isProxyWithoutHooks(value)
+  ) {
+    return null;
   }
 
-  // Workflow wrapper (from workflow() DSL)
-  if (isWorkflowWrapper(value)) {
-    return value.definition;
+  let candidate: unknown = value;
+  const definitionDescriptor = objectGetOwnPropertyDescriptor(value, "definition");
+  if (definitionDescriptor !== undefined) {
+    if (!("value" in definitionDescriptor)) {
+      throw new TypeError("Workflow wrapper definition must be a data property");
+    }
+    candidate = definitionDescriptor.value;
   }
 
-  return null;
+  if (!isWorkflowDefinitionCandidate(candidate)) return null;
+  return captureWorkflowDefinition(candidate, { allowEmptySteps: true });
+}
+
+function finalizeWorkflowDiscoveryResult(
+  workflows: DiscoveredWorkflow[],
+  errors: WorkflowDiscoveryResult["errors"],
+): WorkflowDiscoveryResult {
+  const sorted = sortValues(
+    reflectApply(arraySlice, workflows, []) as DiscoveredWorkflow[],
+    (left, right) =>
+      compareText(left.id, right.id) ||
+      compareText(left.filePath, right.filePath) ||
+      compareText(left.exportName, right.exportName),
+  );
+  const unique: DiscoveredWorkflow[] = [];
+
+  for (let index = 0; index < sorted.length;) {
+    let end = index + 1;
+    while (end < sorted.length && sorted[end]!.id === sorted[index]!.id) end++;
+    if (end === index + 1) {
+      append(unique, sorted[index]!);
+      index = end;
+      continue;
+    }
+
+    const declarations: string[] = [];
+    for (let declarationIndex = index; declarationIndex < end; declarationIndex++) {
+      const workflow = sorted[declarationIndex]!;
+      append(declarations, `${workflow.filePath} (export ${workflow.exportName})`);
+    }
+    const message = `Duplicate workflow id "${sorted[index]!.id}" was declared by: ${
+      reflectApply(arrayJoin, declarations, [", "])
+    }`;
+    for (let declarationIndex = index; declarationIndex < end; declarationIndex++) {
+      append(errors, {
+        filePath: sorted[declarationIndex]!.filePath,
+        error: message,
+      });
+    }
+    index = end;
+  }
+
+  sortValues(
+    errors,
+    (left, right) =>
+      compareText(left.filePath, right.filePath) || compareText(left.error, right.error),
+  );
+  return { workflows: unique, errors };
 }
 
 /**
@@ -128,7 +211,7 @@ export async function discoverWorkflows(
     projectDir,
     adapter,
     config,
-    workflowsDir = "workflows",
+    workflowsDir: configuredWorkflowsDir = "workflows",
     debug = false,
     allowHostProjectCodeExecution,
   } = options;
@@ -136,23 +219,25 @@ export async function discoverWorkflows(
   const workflows: DiscoveredWorkflow[] = [];
   const errors: Array<{ filePath: string; error: string }> = [];
 
-  // For remote adapters, use relative paths
-  const fsType = config?.fs?.type ?? "local";
-  const useRelativePaths = fsType === "github" || fsType === "veryfront-api";
-  const baseDir = useRelativePaths ? workflowsDir : join(projectDir, workflowsDir);
-
-  if (debug) {
-    logger.info(`Scanning ${baseDir} for workflows`);
-  }
+  let baseDir = configuredWorkflowsDir;
 
   try {
+    const workflowsDir = normalizeProjectRelativeDiscoveryPath(configuredWorkflowsDir);
+    const fsType = config?.fs?.type ?? "local";
+    const useRelativePaths = fsType === "github" || fsType === "veryfront-api";
+    baseDir = useRelativePaths ? workflowsDir : join(projectDir, workflowsDir);
+
+    if (debug) {
+      logger.info(`Scanning ${baseDir} for workflows`);
+    }
+
     // Check if workflows directory exists
     const dirExists = await adapter.fs.exists(baseDir);
     if (!dirExists) {
       if (debug) {
         logger.info(`No workflows directory found at ${baseDir}`);
       }
-      return { workflows, errors };
+      return finalizeWorkflowDiscoveryResult(workflows, errors);
     }
 
     // Discover workflow files
@@ -163,13 +248,15 @@ export async function discoverWorkflows(
       ignorePatterns: ["node_modules", ".git", "__tests__", "*.test.*", "*.spec.*"],
       adapter,
     });
+    sortValues(files, (left, right) => compareText(left.path, right.path));
 
     if (debug) {
       logger.info(`Found ${files.length} potential workflow files`);
     }
 
     // Load and extract workflows from each file
-    for (const file of files) {
+    for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
+      const file = files[fileIndex]!;
       try {
         const module = await importDiscoveryModule(file.path, {
           adapter,
@@ -178,10 +265,14 @@ export async function discoverWorkflows(
         });
 
         // Extract workflows from module exports
-        for (const [exportName, value] of Object.entries(module)) {
-          const definition = extractWorkflowDefinition(value);
-          if (definition) {
-            workflows.push({
+        const exports = objectEntries(module);
+        sortValues(exports, (left, right) => compareText(left[0], right[0]));
+        for (let exportIndex = 0; exportIndex < exports.length; exportIndex++) {
+          const [exportName, value] = exports[exportIndex]!;
+          try {
+            const definition = extractWorkflowDefinition(value);
+            if (!definition) continue;
+            append(workflows, {
               id: definition.id,
               filePath: file.path,
               exportName,
@@ -193,29 +284,28 @@ export async function discoverWorkflows(
                 `[WorkflowDiscovery] Found workflow "${definition.id}" in ${file.path} (export: ${exportName})`,
               );
             }
+          } catch (error) {
+            append(errors, { filePath: file.path, error: toErrorMessage(error) });
           }
         }
       } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : String(error);
-        errors.push({ filePath: file.path, error: errorMsg });
+        const errorMsg = toErrorMessage(error);
+        append(errors, { filePath: file.path, error: errorMsg });
 
         if (debug) {
           logger.warn(`Failed to load ${file.path}: ${errorMsg}`);
         }
       }
     }
-
-    if (debug) {
-      logger.info(`Discovered ${workflows.length} workflows`);
-    }
-
-    return { workflows, errors };
   } catch (error) {
-    const errorMsg = error instanceof Error ? error.message : String(error);
+    const errorMsg = toErrorMessage(error);
     logger.error(`Discovery failed: ${errorMsg}`);
-    errors.push({ filePath: baseDir, error: errorMsg });
-    return { workflows, errors };
+    append(errors, { filePath: baseDir, error: errorMsg });
   }
+
+  const result = finalizeWorkflowDiscoveryResult(workflows, errors);
+  if (debug) logger.info(`Discovered ${result.workflows.length} workflows`);
+  return result;
 }
 
 /**
@@ -226,7 +316,10 @@ export async function findWorkflowById(
   options: WorkflowDiscoveryOptions,
 ): Promise<DiscoveredWorkflow | null> {
   const { workflows } = await discoverWorkflows(options);
-  return workflows.find((w) => w.id === workflowId) ?? null;
+  for (let index = 0; index < workflows.length; index++) {
+    if (workflows[index]!.id === workflowId) return workflows[index]!;
+  }
+  return null;
 }
 
 /**
@@ -235,9 +328,15 @@ export async function findWorkflowById(
 export function createWorkflowRegistry(
   workflows: DiscoveredWorkflow[],
 ): Map<string, DiscoveredWorkflow> {
-  const registry = new Map<string, DiscoveredWorkflow>();
-  for (const workflow of workflows) {
-    registry.set(workflow.id, workflow);
+  const registry = new MapConstructor<string, DiscoveredWorkflow>();
+  for (let index = 0; index < workflows.length; index++) {
+    const workflow = workflows[index]!;
+    if (reflectApply(mapHas, registry, [workflow.id])) {
+      throw INVALID_ARGUMENT.create({
+        detail: `Duplicate workflow id "${workflow.id}" cannot be added to the registry`,
+      });
+    }
+    reflectApply(mapSet, registry, [workflow.id, workflow]);
   }
   return registry;
 }

--- a/src/workflow/discovery/workflow-discovery.ts
+++ b/src/workflow/discovery/workflow-discovery.ts
@@ -331,12 +331,18 @@ export function createWorkflowRegistry(
   const registry = new MapConstructor<string, DiscoveredWorkflow>();
   for (let index = 0; index < workflows.length; index++) {
     const workflow = workflows[index]!;
-    if (reflectApply(mapHas, registry, [workflow.id])) {
+    const id = workflow.id;
+    if (typeof id !== "string" || id.length === 0) {
       throw INVALID_ARGUMENT.create({
-        detail: `Duplicate workflow id "${workflow.id}" cannot be added to the registry`,
+        detail: "Discovered workflow id must be a non-empty string",
       });
     }
-    reflectApply(mapSet, registry, [workflow.id, workflow]);
+    if (reflectApply(mapHas, registry, [id])) {
+      throw INVALID_ARGUMENT.create({
+        detail: `Duplicate workflow id "${id}" cannot be added to the registry`,
+      });
+    }
+    reflectApply(mapSet, registry, [id, workflow]);
   }
   return registry;
 }


### PR DESCRIPTION
## Summary

- validate and detach every discovered workflow through canonical workflow capture
- inspect wrapper and definition descriptors without invoking project accessors
- keep valid sibling exports when another export is malformed
- reject duplicate workflow IDs consistently across discovery, lookup, and registry creation
- sort files, exports, workflows, and errors deterministically
- validate custom workflow roots before filesystem access
- preserve the explicit host authority gate and sanitize discovery diagnostics
- regenerate workflow discovery API source links

## Test audit findings

- Symptom: workflow candidates were classified through direct property reads.
  Source: shallow guards read `id`, `steps`, and `definition` from project exports.
  Consequence: accessors and Proxies could execute during classification.
  Remedy: inspect descriptors with captured intrinsics and run canonical capture only for real candidates.
- Symptom: malformed workflow shapes were returned as valid definitions.
  Source: any string `id` plus any defined `steps` value passed.
  Consequence: invalid definitions failed later and remained caller-owned.
  Remedy: use `captureWorkflowDefinition` with the discovery empty-step allowance.
- Symptom: duplicate IDs had three different outcomes.
  Source: discovery kept both, lookup chose the first, and registry construction kept the last.
  Consequence: the selected workflow depended on the consumer and enumeration order.
  Remedy: exclude duplicate groups with deterministic errors and reject registry overwrites.
- Symptom: adapter insertion order controlled discovery order.
  Source: files and module exports were consumed without sorting.
  Consequence: metadata and first-match lookup varied across adapters.
  Remedy: sort each boundary with captured primitives.
- Symptom: `workflowsDir` could escape the project root.
  Source: it was joined without project-relative path validation.
  Consequence: local discovery could scan outside the configured project.
  Remedy: normalize the discovery root before any filesystem call.

## Verification

- `deno task test:file src/workflow/discovery`: 1 passed, 11 steps
- `deno task test:file src/workflow`: 82 passed, 923 steps
- `deno task test:unit`: passed, including parallel, cwd, and cwd-exclusion profiles
- `deno task test:integration`: 319 passed, 2,951 steps
- `deno task lint`: passed
- `deno task typecheck`: passed
- `deno task lint:anti-slop`: passed
- `deno task lint:test-typecheck`: passed
- `deno task lint:test-semantic-dispositions`: passed
- `deno task docs`: passed
- `deno task docs:api-reference:check`: passed
- `deno task docs:public:check`: passed