### PR TITLE
fix(workflow): harden runtime projection state

### DIFF
--- a/src/workflow/runtime-state.test.ts
+++ b/src/workflow/runtime-state.test.ts
@@ -3,6 +3,8 @@ import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { WorkflowContext } from "./types.ts";
 import {
+  captureWorkflowContextProjection,
+  captureWorkflowProjectionPaths,
   FRAMEWORK_CONTEXT_PROJECTION_KIND,
   getWorkflowContextRootProjection,
   replaceWorkflowContextRootProjection,
@@ -232,5 +234,41 @@ describe("workflow/runtime-state", () => {
       path: [],
     }]);
     assertEquals(Object.getPrototypeOf(projection), Object.prototype);
+  });
+
+  it("does not invoke accessors while capturing projection metadata", () => {
+    let getterCalls = 0;
+    const path = Object.defineProperty({ path: [] }, "kind", {
+      enumerable: true,
+      get() {
+        getterCalls++;
+        return FRAMEWORK_CONTEXT_PROJECTION_KIND;
+      },
+    });
+    const contextProjection = Object.defineProperty({}, "nested", {
+      enumerable: true,
+      get() {
+        getterCalls++;
+        return [{ kind: FRAMEWORK_CONTEXT_PROJECTION_KIND, path: [] }];
+      },
+    });
+
+    assertEquals(captureWorkflowProjectionPaths([path]), []);
+    assertEquals(captureWorkflowContextProjection(contextProjection), {});
+    assertEquals(getterCalls, 0);
+  });
+
+  it("does not invoke projection root accessors while reading", () => {
+    let getterCalls = 0;
+    const projection = Object.defineProperty({}, "nested", {
+      enumerable: true,
+      get() {
+        getterCalls++;
+        return [{ kind: FRAMEWORK_CONTEXT_PROJECTION_KIND, path: [] }];
+      },
+    }) as WorkflowContextProjection;
+
+    assertEquals(getWorkflowContextRootProjection(projection, "nested"), []);
+    assertEquals(getterCalls, 0);
   });
 });

--- a/src/workflow/runtime-state.ts
+++ b/src/workflow/runtime-state.ts
@@ -29,6 +29,32 @@ import { isDeepStrictEqual } from "node:util";
 import { isProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
 import type { WorkflowContext } from "./types.ts";
 
+const arrayIsArray = Array.isArray;
+const MapConstructor = Map;
+const mapGet = Map.prototype.get;
+const mapSet = Map.prototype.set;
+const numberIsSafeInteger = Number.isSafeInteger;
+const objectCreate = Object.create;
+const objectDefineProperty = Object.defineProperty;
+const objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const objectHasOwn = Object.hasOwn;
+const objectIs = Object.is;
+const reflectApply = Reflect.apply;
+const reflectDeleteProperty = Reflect.deleteProperty;
+const reflectOwnKeys = Reflect.ownKeys;
+const SetConstructor = Set;
+const setAdd = Set.prototype.add;
+const setHas = Set.prototype.has;
+
+function defineArrayElement<T>(values: T[], index: number, value: T): void {
+  objectDefineProperty(values, index, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+}
+
 /** Internal run/checkpoint sidecar carrying public projection ownership. */
 export const INTERNAL_WORKFLOW_PROJECTION_STATE_FIELD = "_workflowProjection";
 
@@ -79,7 +105,8 @@ export const INTERNAL_WORKFLOW_RUNTIME_STATE_VERSION_FIELD = "_runtimeStateVersi
 export const INTERNAL_WORKFLOW_TRACE_CONTEXT_FIELD = "_traceContext";
 
 function isRuntimeRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  return typeof value === "object" && value !== null && !arrayIsArray(value) &&
+    !isProxyWithoutHooks(value);
 }
 
 /** Cycle-safe structural equality for detached durable workflow values. */
@@ -91,35 +118,60 @@ export function workflowRuntimeValuesEqual(
 }
 
 function isProjectionPathComponent(value: unknown): value is string | number {
-  return typeof value === "string" || (typeof value === "number" && Number.isSafeInteger(value));
+  return typeof value === "string" || (typeof value === "number" && numberIsSafeInteger(value));
 }
 
-function isWorkflowProjectionPath(value: unknown): value is WorkflowProjectionPath {
-  if (!isRuntimeRecord(value) || !Array.isArray(value.path)) return false;
+function readOwnData(value: unknown, key: PropertyKey): unknown {
+  if (typeof value !== "object" || value === null) return undefined;
+  const descriptor = objectGetOwnPropertyDescriptor(value, key);
+  return descriptor && objectHasOwn(descriptor, "value") ? descriptor.value : undefined;
+}
+
+function captureProjectionPath(value: unknown): WorkflowProjectionPath | null {
+  if (!isRuntimeRecord(value)) return null;
+  const kind = readOwnData(value, "kind");
+  const sourcePath = readOwnData(value, "path");
   if (
-    value.kind !== FRAMEWORK_CONTEXT_PROJECTION_KIND &&
-    value.kind !== INTERNAL_RUNTIME_PROJECTION_KIND
-  ) return false;
-  return value.path.every(isProjectionPathComponent);
+    (kind !== FRAMEWORK_CONTEXT_PROJECTION_KIND && kind !== INTERNAL_RUNTIME_PROJECTION_KIND) ||
+    !arrayIsArray(sourcePath) || isProxyWithoutHooks(sourcePath)
+  ) return null;
+
+  const path: Array<string | number> = [];
+  for (let index = 0; index < sourcePath.length; index++) {
+    const component = readOwnData(sourcePath, index);
+    if (!isProjectionPathComponent(component)) return null;
+    defineArrayElement(path, index, component);
+  }
+  return { kind, path };
 }
 
 /** Detach a validated list of internal output-projection paths. */
 export function captureWorkflowProjectionPaths(value: unknown): WorkflowProjectionPath[] {
-  if (!Array.isArray(value) || !value.every(isWorkflowProjectionPath)) return [];
-  return value.map((entry) => ({ kind: entry.kind, path: [...entry.path] }));
+  if (!arrayIsArray(value) || isProxyWithoutHooks(value)) return [];
+  const paths: WorkflowProjectionPath[] = [];
+  for (let index = 0; index < value.length; index++) {
+    const entry = captureProjectionPath(readOwnData(value, index));
+    if (!entry) return [];
+    defineArrayElement(paths, index, entry);
+  }
+  return paths;
 }
 
 /** Detach a validated context projection sidecar. */
 export function captureWorkflowContextProjection(value: unknown): WorkflowContextProjection {
   if (!isRuntimeRecord(value)) return {};
-  const projection = Object.create(null) as WorkflowContextProjection;
-  for (const [root, paths] of Object.entries(value)) {
-    if (!Array.isArray(paths) || !paths.every(isWorkflowProjectionPath)) continue;
-    defineProjectionRoot(
-      projection,
-      root,
-      paths.map((entry) => ({ kind: entry.kind, path: [...entry.path] })),
-    );
+  const projection = objectCreate(null) as WorkflowContextProjection;
+  const roots = reflectOwnKeys(value);
+  for (let index = 0; index < roots.length; index++) {
+    const root = roots[index]!;
+    if (typeof root !== "string") continue;
+    const descriptor = objectGetOwnPropertyDescriptor(value, root);
+    if (!descriptor?.enumerable || !objectHasOwn(descriptor, "value")) continue;
+    const paths = captureWorkflowProjectionPaths(descriptor.value);
+    if (paths.length === 0 && (!arrayIsArray(descriptor.value) || descriptor.value.length > 0)) {
+      continue;
+    }
+    defineProjectionRoot(projection, root, paths);
   }
   return projection;
 }
@@ -129,7 +181,11 @@ export function getWorkflowContextRootProjection(
   projection: WorkflowContextProjection,
   root: string,
 ): WorkflowProjectionPath[] {
-  return captureWorkflowProjectionPaths(projection[root]);
+  try {
+    return captureWorkflowProjectionPaths(readOwnData(projection, root));
+  } catch {
+    return [];
+  }
 }
 
 /** Replace the projection paths owned by one top-level workflow context slot. */
@@ -138,13 +194,10 @@ export function replaceWorkflowContextRootProjection(
   root: string,
   paths: readonly WorkflowProjectionPath[],
 ): void {
-  if (paths.length === 0) Reflect.deleteProperty(projection, root);
+  const captured = captureWorkflowProjectionPaths(paths);
+  if (captured.length === 0) reflectDeleteProperty(projection, root);
   else {
-    defineProjectionRoot(
-      projection,
-      root,
-      paths.map((entry) => ({ kind: entry.kind, path: [...entry.path] })),
-    );
+    defineProjectionRoot(projection, root, captured);
   }
 }
 
@@ -153,7 +206,7 @@ function defineProjectionRoot(
   root: string,
   paths: WorkflowProjectionPath[],
 ): void {
-  Object.defineProperty(projection, root, {
+  objectDefineProperty(projection, root, {
     value: paths,
     enumerable: true,
     configurable: true,
@@ -174,17 +227,18 @@ function getOwnPathValue(
   path: readonly (string | number)[],
 ): { exists: boolean; value: unknown } {
   let value: unknown = context;
-  for (const part of [root, ...path]) {
+  for (let index = -1; index < path.length; index++) {
+    const part = index === -1 ? root : path[index]!;
     if (typeof value !== "object" || value === null || isProxyWithoutHooks(value)) {
       return { exists: false, value: undefined };
     }
     let descriptor: PropertyDescriptor | undefined;
     try {
-      descriptor = Object.getOwnPropertyDescriptor(value, part);
+      descriptor = objectGetOwnPropertyDescriptor(value, part);
     } catch {
       return { exists: false, value: undefined };
     }
-    if (!descriptor || !("value" in descriptor)) {
+    if (!descriptor || !objectHasOwn(descriptor, "value")) {
       return { exists: false, value: undefined };
     }
     value = descriptor.value;
@@ -196,13 +250,21 @@ function captureProjectionTargets(
   context: WorkflowContext,
   projection: WorkflowContextProjection,
 ): ProjectionTargetSnapshot[] {
-  return Object.entries(projection).flatMap(([root, paths]) =>
-    paths.map((entry, index) => ({
-      root,
-      index,
-      ...getOwnPathValue(context, root, entry.path),
-    }))
-  );
+  const snapshots: ProjectionTargetSnapshot[] = [];
+  const roots = reflectOwnKeys(projection);
+  for (let rootIndex = 0; rootIndex < roots.length; rootIndex++) {
+    const root = roots[rootIndex]!;
+    if (typeof root !== "string") continue;
+    const paths = getWorkflowContextRootProjection(projection, root);
+    for (let index = 0; index < paths.length; index++) {
+      defineArrayElement(snapshots, snapshots.length, {
+        root,
+        index,
+        ...getOwnPathValue(context, root, paths[index]!.path),
+      });
+    }
+  }
+  return snapshots;
 }
 
 function reconcileProjectionTargets(
@@ -210,21 +272,36 @@ function reconcileProjectionTargets(
   projection: WorkflowContextProjection,
   snapshots: readonly ProjectionTargetSnapshot[],
 ): void {
-  const invalid = new Map<string, Set<number>>();
-  for (const snapshot of snapshots) {
+  const invalid = new MapConstructor<string, Set<number>>();
+  const invalidRoots: string[] = [];
+  for (let snapshotIndex = 0; snapshotIndex < snapshots.length; snapshotIndex++) {
+    const snapshot = snapshots[snapshotIndex]!;
+    const paths = getWorkflowContextRootProjection(projection, snapshot.root);
     const current = getOwnPathValue(
       context,
       snapshot.root,
-      projection[snapshot.root]?.[snapshot.index]?.path ?? [],
+      paths[snapshot.index]?.path ?? [],
     );
-    if (!snapshot.exists || !current.exists || !Object.is(snapshot.value, current.value)) {
-      const indexes = invalid.get(snapshot.root) ?? new Set<number>();
-      indexes.add(snapshot.index);
-      invalid.set(snapshot.root, indexes);
+    if (!snapshot.exists || !current.exists || !objectIs(snapshot.value, current.value)) {
+      let indexes = reflectApply(mapGet, invalid, [snapshot.root]) as Set<number> | undefined;
+      if (!indexes) {
+        indexes = new SetConstructor<number>();
+        reflectApply(mapSet, invalid, [snapshot.root, indexes]);
+        defineArrayElement(invalidRoots, invalidRoots.length, snapshot.root);
+      }
+      reflectApply(setAdd, indexes, [snapshot.index]);
     }
   }
-  for (const [root, indexes] of invalid) {
-    const retained = (projection[root] ?? []).filter((_entry, index) => !indexes.has(index));
+  for (let rootIndex = 0; rootIndex < invalidRoots.length; rootIndex++) {
+    const root = invalidRoots[rootIndex]!;
+    const indexes = reflectApply(mapGet, invalid, [root]) as Set<number>;
+    const paths = getWorkflowContextRootProjection(projection, root);
+    const retained: WorkflowProjectionPath[] = [];
+    for (let index = 0; index < paths.length; index++) {
+      if (!reflectApply(setHas, indexes, [index])) {
+        defineArrayElement(retained, retained.length, paths[index]!);
+      }
+    }
     replaceWorkflowContextRootProjection(projection, root, retained);
   }
 }

--- a/tests/integration/workflow/runtime-state-intrinsics.test.ts
+++ b/tests/integration/workflow/runtime-state-intrinsics.test.ts
@@ -1,0 +1,93 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  FRAMEWORK_CONTEXT_PROJECTION_KIND,
+  getWorkflowContextRootProjection,
+  runWithWorkflowContextProjectionTracking,
+  type WorkflowContextProjection,
+} from "#veryfront/workflow/runtime-state.ts";
+import type { WorkflowContext } from "#veryfront/workflow/types.ts";
+
+function fixture(): {
+  context: WorkflowContext;
+  projection: WorkflowContextProjection;
+} {
+  return {
+    context: { input: {}, nested: { secret: true } },
+    projection: {
+      nested: [{ kind: FRAMEWORK_CONTEXT_PROJECTION_KIND, path: [] }],
+    },
+  };
+}
+
+describe("workflow runtime state with hostile ambient intrinsics", () => {
+  it("does not trust a replaced Object.is during reconciliation", async () => {
+    const { context, projection } = fixture();
+    const originalIs = Object.is;
+    try {
+      await runWithWorkflowContextProjectionTracking(context, projection, (tracked) => {
+        tracked.nested = { userOwned: true };
+        Object.is = () => true;
+      });
+    } finally {
+      Object.is = originalIs;
+    }
+
+    assertEquals(getWorkflowContextRootProjection(projection, "nested"), []);
+  });
+
+  it("does not trust a replaced Array.prototype.filter during reconciliation", async () => {
+    const { context, projection } = fixture();
+    const originalFilter = Array.prototype.filter;
+    try {
+      await runWithWorkflowContextProjectionTracking(context, projection, (tracked) => {
+        tracked.nested = { userOwned: true };
+        Array.prototype.filter = function () {
+          return this;
+        };
+      });
+    } finally {
+      Array.prototype.filter = originalFilter;
+    }
+
+    assertEquals(getWorkflowContextRootProjection(projection, "nested"), []);
+  });
+
+  it("does not trust live descriptor, Map, or Set methods during reconciliation", async () => {
+    const { context, projection } = fixture();
+    const originalDescriptor = Object.getOwnPropertyDescriptor;
+    const originalMapGet = Map.prototype.get;
+    const originalMapSet = Map.prototype.set;
+    const originalSetAdd = Set.prototype.add;
+    const originalSetHas = Set.prototype.has;
+    try {
+      await runWithWorkflowContextProjectionTracking(context, projection, (tracked) => {
+        tracked.nested = { userOwned: true };
+        Object.getOwnPropertyDescriptor = () => {
+          throw new Error("poisoned descriptor inspection");
+        };
+        Map.prototype.get = () => {
+          throw new Error("poisoned Map.get");
+        };
+        Map.prototype.set = () => {
+          throw new Error("poisoned Map.set");
+        };
+        Set.prototype.add = () => {
+          throw new Error("poisoned Set.add");
+        };
+        Set.prototype.has = () => {
+          throw new Error("poisoned Set.has");
+        };
+      });
+    } finally {
+      Object.getOwnPropertyDescriptor = originalDescriptor;
+      Map.prototype.get = originalMapGet;
+      Map.prototype.set = originalMapSet;
+      Set.prototype.add = originalSetAdd;
+      Set.prototype.has = originalSetHas;
+    }
+
+    assertEquals(getWorkflowContextRootProjection(projection, "nested"), []);
+  });
+});


### PR DESCRIPTION
## Summary

- capture projection paths and context sidecars through own data descriptors
- reject Proxies and accessor-backed projection metadata without invoking hooks
- preserve reserved projection roots with own-property definition
- reconcile projected object identity with captured equality, descriptor, Map, Set, and array primitives
- avoid callback-time iterable, filter, and collection method dispatch
- add owner tests for projection accessors and hostile-runtime tests for callback-time primordial poisoning

## Test audit findings

- Symptom: projection capture invoked metadata getters.
  Source: validation read `kind`, `path`, and projection roots directly through live array and object helpers.
  Consequence: persisted or caller-owned sidecars could execute code while being classified.
  Remedy: inspect own data descriptors and copy dense path components with own-property definition.
- Symptom: user callbacks could corrupt reconciliation after returning.
  Source: the `finally` path called live `Object.is`, array filter/map/iteration, descriptor inspection, and Map/Set methods.
  Consequence: a callback could keep framework ownership after replacing a private projected value.
  Remedy: capture every primordial at module admission and use indexed reconciliation.
- Symptom: projection root reads trusted inherited or accessor-backed values.
  Source: root lookup used ordinary bracket access.
  Consequence: ownership could be forged or a getter could execute during public projection.
  Remedy: read only own data-valued roots and fail closed.
- Symptom: callback-time primordial mutation had no owner tests.
  Source: existing tests focused on context accessors and Proxies.
  Consequence: the shared-realm threat model remained unverified.
  Remedy: poison equality, filtering, descriptors, Map, and Set methods inside the callback and verify ownership is still cleared.

## Verification

- `deno task test:file src/workflow/runtime-state.test.ts`: 1 passed, 11 steps
- `deno task test:file tests/integration/workflow/runtime-state-intrinsics.test.ts`: 1 passed, 3 steps
- `deno task test:file src/workflow`: 82 passed, 918 steps
- `deno task test:unit:parallel`: 4,183 passed, 32,216 steps
- `deno task test:integration`: 320 passed, 2,954 steps
- `deno task lint`: passed
- `deno task typecheck`: passed
- `deno task lint:anti-slop`: passed
- `deno task lint:test-typecheck`: passed
- `deno task lint:test-semantic-dispositions`: passed
- `deno task docs`: passed
- `deno task docs:api-reference:check`: passed
- `deno task docs:public:check`: passed

## Verification note

The first full unit profile reported 4,181 passing tests and zero failures, then Deno emitted a pending-promise shutdown diagnostic. An immediate full rerun completed cleanly with 4,183 passing tests and 32,216 steps.