### PR TITLE
test(security): make weak assertions bite across the security surface

### DIFF
--- a/scripts/test/run-suite.test.ts
+++ b/scripts/test/run-suite.test.ts
@@ -84,6 +84,18 @@ describe("suite planning parity", () => {
     );
   });
 
+  it("runs the sandbox runtime guard in the Node and Bun suites", async () => {
+    const guardFile = "tests/integration/security/sandbox-runtime-guard.test.ts";
+
+    for (const suite of ["runtime:node", "runtime:bun"] as const) {
+      const plan = await planSuiteFiles({ suite });
+      assert(
+        plan.files.includes(guardFile),
+        `${suite} must select the sandbox runtime guard coverage`,
+      );
+    }
+  });
+
   it("keeps eight coverage shards complete, disjoint, and ordered", async () => {
     const paths = Array.from(
       { length: 27 },
@@ -402,12 +414,14 @@ async function legacyRuntimeFiles(runtime: "node" | "bun"): Promise<string[]> {
       "extensions/ext-bundler-esbuild/src/binary.test.ts",
       "tests/ensure-npm-links.test.mjs",
       "tests/test-file-utils.test.mjs",
+      "tests/integration/security/sandbox-runtime-guard.test.ts",
     ]
     : [
       "src/",
       "tests/bun/dynamic-alias-resolution.test.ts",
       "tests/bun/npm-protocol-resolution.test.ts",
       "tests/bun/workspace-resolution.test.ts",
+      "tests/integration/security/sandbox-runtime-guard.test.ts",
     ];
   const incompatible = runtime === "node"
     ? [

--- a/scripts/test/run-suite.ts
+++ b/scripts/test/run-suite.ts
@@ -84,12 +84,14 @@ const RUNTIME_PATTERNS = {
     "extensions/ext-bundler-esbuild/src/binary.test.ts",
     "tests/ensure-npm-links.test.mjs",
     "tests/test-file-utils.test.mjs",
+    "tests/integration/security/sandbox-runtime-guard.test.ts",
   ],
   bun: [
     "src/",
     "tests/bun/dynamic-alias-resolution.test.ts",
     "tests/bun/npm-protocol-resolution.test.ts",
     "tests/bun/workspace-resolution.test.ts",
+    "tests/integration/security/sandbox-runtime-guard.test.ts",
   ],
 } as const;
 const RUNTIME_EXCLUSIONS = {

--- a/src/security/client/html-sanitizer.test.ts
+++ b/src/security/client/html-sanitizer.test.ts
@@ -112,6 +112,35 @@ describe("validateTrustedHtml", () => {
       );
     });
   });
+
+  describe("default (no options) call shape", () => {
+    // Every case above opts into strict mode, but the three innerHTML sinks
+    // (rsc/client-dom.ts, rsc/client-boot.ts, routing/client/page-transition.ts)
+    // call this with no options at all, so the no-options shape is pinned here.
+    //
+    // The dev/production arms of that shape cannot be pinned from a unit test:
+    // the module-private isDevMode() reads globalThis.__VERYFRONT_DEV__ and
+    // Deno.env.get("VERYFRONT_ENV") directly and the options bag exposes no
+    // override, so those arms live in
+    // tests/integration/security/html-sanitizer-dev-mode.test.ts.
+    it("returns clean HTML unchanged when called without options", () => {
+      const html = "<div><p>Hello <strong>world</strong></p></div>";
+      assertEquals(
+        validateTrustedHtml(html),
+        html,
+        "production callers pass no options and must get their HTML back untouched",
+      );
+    });
+
+    it("throws in strict mode even when warnings are disabled", () => {
+      assertThrows(
+        () => validateTrustedHtml('<svg onload="alert(1)"></svg>', { strict: true, warn: false }),
+        Error,
+        "event handler",
+        "warn only controls logging; strict alone decides whether the call throws",
+      );
+    });
+  });
 });
 
 describe("jsonForInlineScript", () => {

--- a/src/security/csrf/helpers.test.ts
+++ b/src/security/csrf/helpers.test.ts
@@ -219,6 +219,50 @@ describe("security/csrf/helpers", () => {
       assertEquals(setCookie!.includes("Secure"), true);
     });
 
+    it("should not mark a non-__Host cookie Secure over plain http", () => {
+      const req = new Request("http://localhost/", {
+        headers: { accept: "text/html" },
+      });
+      const headers = new Headers();
+      applyCsrfCookie(req, headers, { cookieName: "vf_csrf" });
+
+      assertEquals(
+        headers.get("set-cookie")!.includes("Secure"),
+        false,
+        "a non-__Host cookie over plain http must not be marked Secure",
+      );
+    });
+
+    it("should mark a non-__Host cookie Secure on an https request URL", () => {
+      const req = new Request("https://example.com/", {
+        headers: { accept: "text/html" },
+      });
+      const headers = new Headers();
+      applyCsrfCookie(req, headers, { cookieName: "vf_csrf" });
+
+      assertEquals(
+        headers.get("set-cookie")!.includes("Secure"),
+        true,
+        "an https request URL must mark the CSRF cookie Secure",
+      );
+    });
+
+    // The trusted-topology arm of this branch needs a real process env mutation
+    // and lives in tests/integration/security/csrf-proxy-topology.test.ts.
+    it("should ignore x-forwarded-proto while the proxy topology is untrusted", () => {
+      const req = new Request("http://localhost/", {
+        headers: { "x-forwarded-proto": "https", accept: "text/html" },
+      });
+      const headers = new Headers();
+      applyCsrfCookie(req, headers, { cookieName: "vf_csrf" });
+
+      assertEquals(
+        headers.get("set-cookie")!.includes("Secure"),
+        false,
+        "a spoofable forwarded-proto header must not control the Secure flag while the proxy topology is untrusted",
+      );
+    });
+
     it("should set cookie on HEAD when absent", () => {
       const req = new Request("http://localhost/", {
         method: "HEAD",

--- a/src/security/deno-permissions.test.ts
+++ b/src/security/deno-permissions.test.ts
@@ -32,6 +32,11 @@ describe("deno-permissions", () => {
       assertEquals(WORKFLOW_RUN_PERMISSIONS.includes("--allow-write"), true);
       assertEquals(WORKFLOW_RUN_PERMISSIONS.includes("--allow-net"), true);
       assertEquals(WORKFLOW_RUN_PERMISSIONS.includes("--allow-env"), true);
+      assertEquals(
+        [...WORKFLOW_RUN_PERMISSIONS],
+        ["--allow-read", "--allow-write", "--allow-net", "--allow-env"],
+        "restricted workflow profile is exhaustive: any added flag must be reviewed",
+      );
     });
 
     it("does NOT grant run, ffi, or sys", () => {

--- a/src/security/host-execution-policy.test.ts
+++ b/src/security/host-execution-policy.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { withEnv } from "#veryfront/testing";
+import { runWithProjectEnv } from "#veryfront/server/project-env/storage.ts";
 import {
   HOST_PROJECT_EXECUTION_OVERRIDE_ENV,
   isHostProjectExecutionOverrideEnabled,
@@ -69,13 +70,27 @@ describe("security/host-execution-policy operator override", () => {
 
   it("uses the host environment rather than project env", async () => {
     // getHostEnv deliberately bypasses the project env overlay, so a project
-    // environment variable of the same name cannot grant host execution.
+    // environment variable of the same name cannot grant host execution. A
+    // competing project scope has to be registered for that to mean anything.
     await withEnv({ [HOST_PROJECT_EXECUTION_OVERRIDE_ENV]: "0" }, () => {
-      assertEquals(
-        isHostProjectExecutionOverrideEnabled(),
-        false,
-        "only the host environment decides this grant",
-      );
+      runWithProjectEnv({ [HOST_PROJECT_EXECUTION_OVERRIDE_ENV]: "1" }, () => {
+        assertEquals(
+          isHostProjectExecutionOverrideEnabled(),
+          false,
+          "a project env value must never grant host-realm project execution",
+        );
+      });
+      return Promise.resolve();
+    });
+
+    await withEnv({ [HOST_PROJECT_EXECUTION_OVERRIDE_ENV]: "1" }, () => {
+      runWithProjectEnv({ [HOST_PROJECT_EXECUTION_OVERRIDE_ENV]: "0" }, () => {
+        assertEquals(
+          isHostProjectExecutionOverrideEnabled(),
+          true,
+          "the host grant must still win while a project overlay is active",
+        );
+      });
       return Promise.resolve();
     });
   });

--- a/src/security/http/application-request.test.ts
+++ b/src/security/http/application-request.test.ts
@@ -20,22 +20,58 @@ describe("security/http/application-request", () => {
           "x-environment-id": "infrastructure-environment",
           "x-token": "host-secret",
           "x-veryfront-future-control-secret": "future-secret",
+          "cf-connecting-ip": "203.0.113.9",
+          "fastly-client-ip": "203.0.113.9",
+          "forwarded": "for=203.0.113.9",
+          "true-client-ip": "203.0.113.9",
+          "x-real-ip": "203.0.113.9",
+          "x-authoritative": "1",
+          "x-environment": "production",
         },
       }),
     );
 
-    assertEquals(application.headers.get("authorization"), "Bearer public-user");
-    assertEquals(application.headers.get("cookie"), "session=public");
-    assertEquals(application.headers.get("x-application-role"), "editor");
-    assertEquals(application.headers.get("proxy-authorization"), null);
-    assertEquals(application.headers.get("x-forwarded-host"), null);
-    assertEquals(application.headers.get("x-project-id"), null);
-    assertEquals(application.headers.get("x-branch-name"), null);
-    assertEquals(application.headers.get("x-release-id"), null);
-    assertEquals(application.headers.get("x-content-source-id"), null);
-    assertEquals(application.headers.get("x-environment-id"), null);
-    assertEquals(application.headers.get("x-token"), null);
-    assertEquals(application.headers.get("x-veryfront-future-control-secret"), null);
+    assertEquals(
+      application.headers.get("authorization"),
+      "Bearer public-user",
+      "the end-user credential is part of the application contract",
+    );
+    assertEquals(
+      application.headers.get("cookie"),
+      "session=public",
+      "the end-user session cookie is part of the application contract",
+    );
+    assertEquals(
+      application.headers.get("x-application-role"),
+      "editor",
+      "an application-owned header must cross the project boundary",
+    );
+    for (
+      const name of [
+        "proxy-authorization",
+        "x-forwarded-host",
+        "x-project-id",
+        "x-branch-name",
+        "x-release-id",
+        "x-content-source-id",
+        "x-environment-id",
+        "x-token",
+        "x-veryfront-future-control-secret",
+        "cf-connecting-ip",
+        "fastly-client-ip",
+        "forwarded",
+        "true-client-ip",
+        "x-real-ip",
+        "x-authoritative",
+        "x-environment",
+      ]
+    ) {
+      assertEquals(
+        application.headers.get(name),
+        null,
+        `${name} is infrastructure-only and must not cross the project boundary`,
+      );
+    }
   });
 
   it("detaches the request body and header list from the host request", async () => {

--- a/src/security/http/auth.test.ts
+++ b/src/security/http/auth.test.ts
@@ -79,6 +79,31 @@ describe("AuthHandler realm sanitization", () => {
     expect(header).toBe('Basic realm="12345"');
   });
 
+  it("exempts CORS preflight from the credential gate", async () => {
+    // The preflight exemption must stay: a browser sends no credentials on an
+    // OPTIONS preflight, so gating it breaks CORS on every auth-protected site.
+    const handler = createHandler();
+    const result = await handler.handle(
+      new Request("http://localhost/test", { method: "OPTIONS" }),
+      createCtx(),
+    );
+
+    expect(result.continue).toBe(true);
+    expect(result.response).toBeUndefined();
+  });
+
+  it("does not widen the method exemption past OPTIONS", async () => {
+    const handler = createHandler();
+    const result = await handler.handle(
+      new Request("http://localhost/test", { method: "HEAD" }),
+      createCtx(),
+    );
+
+    expect(result.continue).not.toBe(true);
+    expect(result.response?.status).toBe(401);
+    expect(result.response?.headers.get("WWW-Authenticate")).toBe('Basic realm="Secure Area"');
+  });
+
   it("does not invoke conversion hooks on an invalid realm value", async () => {
     const handler = createHandler();
     let conversions = 0;

--- a/src/security/http/base-handler.test.ts
+++ b/src/security/http/base-handler.test.ts
@@ -368,6 +368,12 @@ describe("BaseHandler.withProxyContext", () => {
   it("emits metrics with project and environment labels in multi-project request context", async () => {
     const handler = new TestHandler();
     const counterCalls: unknown[] = [];
+    let observedContext: {
+      slug: string;
+      token: string;
+      projectId?: string;
+      options?: Record<string, unknown>;
+    } | undefined;
 
     setGlobalMetricsAPI({
       getMeter() {
@@ -404,17 +410,18 @@ describe("BaseHandler.withProxyContext", () => {
           setRequestBranch() {},
           isMultiProjectMode: () => true,
           runWithContext: async (
-            _slug: string,
-            _token: string,
+            slug: string,
+            token: string,
             fn: () => Promise<unknown>,
-            _projectId?: string,
+            projectId?: string,
             options?: Record<string, unknown>,
           ) => {
+            observedContext = { slug, token, projectId, options };
             return await runWithRequestContext(
               {
-                projectSlug: "my-project",
-                token: "vf_proxy_token",
-                projectId: "project-123",
+                projectSlug: slug,
+                token,
+                projectId,
                 productionMode: options?.productionMode === true,
                 releaseId: options?.releaseId as string | undefined,
                 branch: options?.branch as string | undefined,
@@ -434,6 +441,22 @@ describe("BaseHandler.withProxyContext", () => {
       });
       return { continue: true };
     });
+
+    assertEquals(
+      observedContext,
+      {
+        slug: "my-project",
+        token: "vf_proxy_token",
+        projectId: "project-123",
+        options: {
+          productionMode: true,
+          releaseId: "release-123",
+          branch: null,
+          environmentName: "Staging",
+        },
+      },
+      "withProxyContext must hand the request tenant slug, request credential, project id and environment options to runWithContext",
+    );
 
     assertEquals(counterCalls, [
       {

--- a/src/security/http/client-hints.test.ts
+++ b/src/security/http/client-hints.test.ts
@@ -7,33 +7,43 @@ function assertScheme(
   req: Request,
   expectedScheme: "light" | "dark",
   expectedFromParam: boolean,
+  expectedFromHeader: boolean,
   url?: URL,
 ): void {
   const result = getColorSchemeFromRequest(req, url);
-  assertEquals(result.scheme, expectedScheme);
-  assertEquals(result.fromParam, expectedFromParam);
+  assertEquals(result.scheme, expectedScheme, "scheme must match the resolved color scheme");
+  assertEquals(
+    result.fromParam,
+    expectedFromParam,
+    "fromParam must record whether the query parameter decided the scheme",
+  );
+  assertEquals(
+    result.fromHeader,
+    expectedFromHeader,
+    "fromHeader must record whether the client hint header decided the scheme",
+  );
 }
 
 describe("security/http/client-hints", () => {
   describe("getColorSchemeFromRequest", () => {
     it("should default to light when no hints are present", () => {
-      assertScheme(new Request("http://localhost/"), "light", false);
+      assertScheme(new Request("http://localhost/"), "light", false, false);
     });
 
     it("should return dark from color_mode query param", () => {
-      assertScheme(new Request("http://localhost/?color_mode=dark"), "dark", true);
+      assertScheme(new Request("http://localhost/?color_mode=dark"), "dark", true, false);
     });
 
     it("should return light from color_mode query param", () => {
-      assertScheme(new Request("http://localhost/?color_mode=light"), "light", true);
+      assertScheme(new Request("http://localhost/?color_mode=light"), "light", true, false);
     });
 
     it("should handle color_mode param with extra whitespace", () => {
-      assertScheme(new Request("http://localhost/?color_mode=%20dark%20"), "dark", true);
+      assertScheme(new Request("http://localhost/?color_mode=%20dark%20"), "dark", true, false);
     });
 
     it("should handle color_mode param case-insensitively", () => {
-      assertScheme(new Request("http://localhost/?color_mode=DARK"), "dark", true);
+      assertScheme(new Request("http://localhost/?color_mode=DARK"), "dark", true, false);
     });
 
     it("should return dark from Sec-CH-Prefers-Color-Scheme header", () => {
@@ -43,6 +53,7 @@ describe("security/http/client-hints", () => {
         }),
         "dark",
         false,
+        true,
       );
     });
 
@@ -53,6 +64,7 @@ describe("security/http/client-hints", () => {
         }),
         "dark",
         false,
+        true,
       );
     });
 
@@ -63,6 +75,7 @@ describe("security/http/client-hints", () => {
         }),
         "light",
         false,
+        true,
       );
     });
 
@@ -73,6 +86,7 @@ describe("security/http/client-hints", () => {
         }),
         "light",
         true,
+        false,
       );
     });
 
@@ -81,12 +95,13 @@ describe("security/http/client-hints", () => {
         new Request("http://localhost/"),
         "dark",
         true,
+        false,
         new URL("http://localhost/?color_mode=dark"),
       );
     });
 
     it("should fall back to light for unrecognized color_mode param", () => {
-      assertScheme(new Request("http://localhost/?color_mode=sepia"), "light", false);
+      assertScheme(new Request("http://localhost/?color_mode=sepia"), "light", false, false);
     });
   });
 });

--- a/src/security/http/cors/headers.test.ts
+++ b/src/security/http/cors/headers.test.ts
@@ -52,6 +52,51 @@ describe("security/http/cors/headers", () => {
     assertEquals(response?.headers.get("Access-Control-Expose-Headers"), null);
   });
 
+  it("emits a configured exposed-header policy verbatim", async () => {
+    const response = await applyCORSHeaders({
+      request: new Request("http://localhost/", {
+        headers: { origin: "https://app.example.com" },
+      }),
+      response: new Response("ok"),
+      config: {
+        origin: "https://app.example.com",
+        exposedHeaders: ["X-Total-Count", "X-Page"],
+      },
+    });
+
+    assertEquals(
+      response?.headers.get("Access-Control-Allow-Origin"),
+      "https://app.example.com",
+      "a valid policy is applied",
+    );
+    assertEquals(
+      response?.headers.get("Access-Control-Expose-Headers"),
+      "X-Total-Count, X-Page",
+      "a configured exposedHeaders policy is emitted verbatim in order",
+    );
+  });
+
+  it("replaces a stale exposed-header value rather than merging it", async () => {
+    const response = await applyCORSHeaders({
+      request: new Request("http://localhost/", {
+        headers: { origin: "https://app.example.com" },
+      }),
+      response: new Response("ok", {
+        headers: { "Access-Control-Expose-Headers": "X-Stale" },
+      }),
+      config: {
+        origin: "https://app.example.com",
+        exposedHeaders: ["X-Total-Count", "X-Page"],
+      },
+    });
+
+    assertEquals(
+      response?.headers.get("Access-Control-Expose-Headers"),
+      "X-Total-Count, X-Page",
+      "an upstream exposed-header value is replaced by the policy, never merged with it",
+    );
+  });
+
   it("does not partially apply malformed or unknown CORS configuration", async () => {
     const request = new Request("http://localhost/", {
       headers: { origin: "https://app.example.com" },

--- a/src/security/http/cors/preflight.test.ts
+++ b/src/security/http/cors/preflight.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { DEFAULT_METHODS } from "./constants.ts";
+import { DEFAULT_MAX_AGE, DEFAULT_METHODS } from "./constants.ts";
 import {
   handleCORSPreflight,
   isPreflightRequest,
@@ -180,6 +180,105 @@ describe("security/http/cors/preflight", () => {
 
       assertEquals(denied.status, 403);
       assertEquals(denied.headers.get("Access-Control-Max-Age"), null);
+
+      const allowedRequest = new Request("http://localhost/", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://allowed.example.com",
+          "access-control-request-method": "GET",
+        },
+      });
+
+      const allowed = await handleCORSPreflight({
+        request: allowedRequest,
+        config: {
+          origin: "https://allowed.example.com",
+          maxAge: 7,
+        },
+      });
+
+      assertEquals(allowed.status, 204, "an allowed preflight succeeds");
+      assertEquals(
+        allowed.headers.get("Access-Control-Max-Age"),
+        "7",
+        "the configured maxAge is emitted, not the default",
+      );
+
+      const defaulted = await handleCORSPreflight({
+        request: allowedRequest,
+        config: { origin: "https://allowed.example.com" },
+      });
+
+      assertEquals(
+        defaulted.headers.get("Access-Control-Max-Age"),
+        String(DEFAULT_MAX_AGE),
+        "an unconfigured preflight emits the default max age constant",
+      );
+    });
+
+    it("emits allow-credentials only for a credentialed origin-specific preflight", async () => {
+      const request = new Request("http://localhost/", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://app.example.com",
+          "access-control-request-method": "GET",
+        },
+      });
+
+      const credentialed = await handleCORSPreflight({
+        request,
+        config: { origin: "https://app.example.com", credentials: true },
+      });
+
+      assertEquals(credentialed.status, 204, "a credentialed preflight succeeds");
+      assertEquals(
+        credentialed.headers.get("Access-Control-Allow-Credentials"),
+        "true",
+        "a credentialed origin-specific preflight must allow credentials",
+      );
+
+      const uncredentialed = await handleCORSPreflight({
+        request,
+        config: { origin: "https://app.example.com" },
+      });
+
+      assertEquals(
+        uncredentialed.headers.get("Access-Control-Allow-Credentials"),
+        null,
+        "a preflight without configured credentials must not allow them",
+      );
+    });
+
+    it("varies cached preflights on Origin", async () => {
+      const request = new Request("http://localhost/", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://app.example.com",
+          "access-control-request-method": "GET",
+        },
+      });
+
+      const specific = await handleCORSPreflight({
+        request,
+        config: { origin: "https://app.example.com" },
+      });
+
+      assertEquals(
+        specific.headers.get("Vary"),
+        "Origin",
+        "an origin-specific preflight must vary on Origin so a shared cache cannot reuse it for another origin",
+      );
+
+      const wildcard = await handleCORSPreflight({
+        request,
+        config: { origin: "*" },
+      });
+
+      assertEquals(
+        wildcard.headers.get("Vary"),
+        null,
+        "a wildcard preflight is origin-independent and must not claim to vary on Origin",
+      );
     });
 
     it("normalizes unknown non-string capability inputs without throwing", () => {

--- a/src/security/http/cors/validators.test.ts
+++ b/src/security/http/cors/validators.test.ts
@@ -74,6 +74,29 @@ describe("validateOriginSync", () => {
     });
   });
 
+  describe("missing request origin", () => {
+    it("should deny a missing origin under a restrictive policy", () => {
+      const list = validateOriginSync(null, { origin: ["https://app.example.com"] });
+      assertEquals(
+        list.allowedOrigin,
+        null,
+        "a missing Origin must not receive a wildcard under an allowlist policy",
+      );
+      assertEquals(
+        list.allowCredentials,
+        false,
+        "a denied result must not carry credentials",
+      );
+
+      const single = validateOriginSync(null, { origin: "https://app.example.com" });
+      assertEquals(
+        single.allowedOrigin,
+        null,
+        "a missing Origin must not receive a wildcard under a string-origin policy",
+      );
+    });
+  });
+
   describe("string origin", () => {
     it("should allow matching origin", () => {
       const result = validateOriginSync("https://example.com", {

--- a/src/security/http/csrf/csrf-handler.test.ts
+++ b/src/security/http/csrf/csrf-handler.test.ts
@@ -507,6 +507,19 @@ describe("security/http/csrf/csrf-handler", () => {
       const result = await handler.handle(req, ctx);
       assertEquals(result.response?.status, 403);
     });
+
+    it("should not skip paths that merely start with an excludePath", async () => {
+      const ctx = createCtx({ excludePaths: ["/api/webhooks"] });
+      for (const path of ["/api/webhooks-admin/delete", "/api/webhooksevil"]) {
+        const req = new Request(`http://localhost${path}`, { method: "POST" });
+        const result = await handler.handle(req, ctx);
+        assertEquals(
+          result.response?.status,
+          403,
+          `${path} is a name collision, not a path-segment child, and must stay CSRF gated`,
+        );
+      }
+    });
   });
 
   describe("metadata", () => {

--- a/src/security/http/local-control-request.test.ts
+++ b/src/security/http/local-control-request.test.ts
@@ -1,5 +1,7 @@
+import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { waitFor } from "#veryfront/testing";
 import { recordRequestPeerFromTransport } from "#veryfront/platform/adapters/runtime/shared/request-peer.ts";
 import {
   createLocalControlAccessDeniedResponse,
@@ -23,11 +25,56 @@ function requestFromPeer(hostname?: string, headers: HeadersInit = {}): Request 
 }
 
 describe("local control request admission", () => {
-  it("prevents content sniffing on access-denied responses", () => {
+  it("prevents content sniffing on access-denied responses", async () => {
     const response = createLocalControlAccessDeniedResponse(requestFromPeer("127.0.0.1"));
 
     assertEquals(response.status, 403);
     assertEquals(response.headers.get("X-Content-Type-Options"), "nosniff");
+    assertEquals(
+      response.headers.get("Cache-Control"),
+      "no-store",
+      "a privileged-control denial must never be cached",
+    );
+    assertEquals(
+      await response.text(),
+      "Local control access requires a direct loopback connection and a trusted local-development host",
+      "the denial body must stay the fixed uniform message",
+    );
+  });
+
+  it("omits the body and cancels the request stream on a rejected request", async () => {
+    const head = new Request("http://localhost/_dev", {
+      method: "HEAD",
+      headers: { host: "localhost" },
+    });
+    assertEquals(
+      createLocalControlAccessDeniedResponse(head).body,
+      null,
+      "a HEAD denial must carry no body",
+    );
+
+    let cancelReason: unknown;
+    const body = new ReadableStream<Uint8Array>({
+      cancel(reason) {
+        cancelReason = reason;
+      },
+    });
+    const post = new Request("http://localhost/_dev", {
+      method: "POST",
+      headers: { host: "localhost" },
+      body,
+      duplex: "half",
+    } as RequestInit);
+
+    assertEquals(createLocalControlAccessDeniedResponse(post).status, 403);
+    await waitFor(() => cancelReason !== undefined, {
+      message: "an unread body on a rejected local-control request must be cancelled",
+    });
+    assertEquals(
+      cancelReason instanceof Error,
+      true,
+      "the cancellation must carry the rejection detail",
+    );
   });
 
   it("requires transport-authenticated loopback provenance", () => {

--- a/src/security/http/outbound-fetch.test.ts
+++ b/src/security/http/outbound-fetch.test.ts
@@ -400,6 +400,41 @@ describe("guardedOutboundFetch", () => {
     assertEquals(await captured?.text(), '{"message":"hello"}');
   });
 
+  it("blocks cross-origin provider requests before credentials leave the boundary", async () => {
+    let calls = 0;
+    const fetchImpl: typeof fetch = () => {
+      calls++;
+      return Promise.resolve(Response.json({ ok: true }));
+    };
+    const providerFetch = createTestBoundary(fetchImpl).createOriginBoundFetch(
+      "https://93.184.216.34/v1",
+    );
+
+    await assertRejects(
+      () =>
+        providerFetch("https://93.184.216.35/v1/messages", {
+          headers: { "x-api-key": "provider-secret" },
+        }),
+      OutboundRequestBlockedError,
+      "destination origin is not authorized",
+      "a string input pointing at another origin must not reach the transport",
+    );
+    assertEquals(calls, 0, "a cross-origin provider request must never reach the transport");
+
+    await assertRejects(
+      () =>
+        providerFetch(
+          new Request("https://93.184.216.35/v1/messages", {
+            headers: { "x-api-key": "provider-secret" },
+          }),
+        ),
+      OutboundRequestBlockedError,
+      "destination origin is not authorized",
+      "a Request input bypasses the base rewrite and must be authorized too",
+    );
+    assertEquals(calls, 0, "the Request branch must not reach the transport either");
+  });
+
   it("rejects provider redirects before API-key credentials can leave the origin", async () => {
     let calls = 0;
     const fetchImpl: typeof fetch = () => {

--- a/src/security/http/response/response-methods.test.ts
+++ b/src/security/http/response/response-methods.test.ts
@@ -28,7 +28,18 @@ describe("security/http/response/response-methods", () => {
     });
 
     it("should use default status from context", () => {
-      assertEquals(json.call(createContext(200), {}).status, 200);
+      // 200 is also the Response constructor default, so a non-default status
+      // is the only value that can observe the context read.
+      assertEquals(
+        json.call(createContext(404), {}).status,
+        404,
+        "json must inherit the status from its builder context",
+      );
+      assertEquals(
+        build.call(createContext(201)).status,
+        201,
+        "build must inherit the status from its builder context",
+      );
     });
 
     it("should override status when provided", () => {

--- a/src/security/http/response/security-handler.test.ts
+++ b/src/security/http/response/security-handler.test.ts
@@ -723,10 +723,25 @@ describe("security/http/response/security-handler", () => {
     it("should set HSTS in production", () => {
       const headers = applyHeaders();
 
-      const hsts = headers.get("Strict-Transport-Security");
-      assert(hsts !== null);
-      assert(hsts.includes("max-age="));
-      assert(hsts.includes("includeSubDomains"));
+      assertEquals(
+        headers.get("Strict-Transport-Security"),
+        "max-age=31536000; includeSubDomains",
+        "production HSTS must pin the one-year max-age with subdomains",
+      );
+    });
+
+    it("should let the security.hsts config drive every HSTS directive", () => {
+      const headers = applyHeaders({
+        config: {
+          hsts: { maxAge: 600, includeSubDomains: false, preload: true },
+        } as SecurityConfig,
+      });
+
+      assertEquals(
+        headers.get("Strict-Transport-Security"),
+        "max-age=600; preload",
+        "security.hsts config must drive max-age, includeSubDomains, and preload",
+      );
     });
 
     it("should not set HSTS in dev mode", () => {

--- a/src/security/http/studio-origin-policy.test.ts
+++ b/src/security/http/studio-origin-policy.test.ts
@@ -27,6 +27,21 @@ describe("security/http/studio-origin-policy", () => {
     assertEquals(resolveTrustedStudioOrigin("https://localhost:3443"), "https://localhost:3443");
     assertEquals(resolveTrustedStudioOrigin("ftp://localhost:3000"), null);
     assertEquals(resolveTrustedStudioOrigin("http://127.0.0.1:3000"), null);
+    assertEquals(
+      resolveTrustedStudioOrigin("https://localhost.attacker.com"),
+      null,
+      "a hostname that merely starts with localhost must not be trusted",
+    );
+    assertEquals(
+      resolveTrustedStudioOrigin("https://evil-localhost.com"),
+      null,
+      "a hostname that merely contains localhost must not be trusted",
+    );
+    assertEquals(
+      resolveTrustedStudioOrigin("https://attacker.localhost"),
+      null,
+      "localhost subdomains are not trusted Studio origins",
+    );
   });
 
   it("generates a helper from the exact hosted-origin policy", () => {
@@ -49,6 +64,11 @@ describe("security/http/studio-origin-policy", () => {
     assertEquals(
       resolveTarget({ referrer: "https://attacker.preview.veryfront.org/project" }, window),
       window.location.origin,
+    );
+    assertEquals(
+      resolveTarget({ referrer: "https://localhost.attacker.com/project" }, window),
+      window.location.origin,
+      "the generated helper must match the localhost hostname exactly, never by prefix",
     );
   });
 });

--- a/src/security/input-validation/handler.test.ts
+++ b/src/security/input-validation/handler.test.ts
@@ -6,6 +6,7 @@ import {
   assertThrows,
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { waitFor } from "#veryfront/testing/deno-compat.ts";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { createContext } from "#veryfront/routing";
 import { createValidatedHandler } from "./handler.ts";
@@ -421,6 +422,60 @@ describe("security/input-validation/handler", () => {
 
       assertEquals(response.status, 400);
       assertEquals(invoked, false);
+    });
+
+    it("should cancel a still-open chunked body it rejects for size", async () => {
+      let cancelled = false;
+      const handler = createValidatedHandler(
+        { limits: { maxBodySize: 10 } },
+        () => new Response("OK"),
+      );
+      const request = streamingRequest(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("x".repeat(6)));
+            controller.enqueue(new TextEncoder().encode("x".repeat(6)));
+            // Left open on purpose: a sender that keeps pushing must not be
+            // able to hold the stream after the request has been rejected.
+          },
+          cancel() {
+            cancelled = true;
+          },
+        }),
+      );
+
+      const response = await handler(request);
+
+      assertEquals(response.status, 400);
+      await waitFor(() => cancelled, {
+        message: "the rejected request body must be cancelled, not left open",
+      });
+    });
+
+    it("should cancel a still-open body that understates its Content-Length", async () => {
+      let cancelled = false;
+      const handler = createValidatedHandler(
+        { limits: { maxBodySize: 10 } },
+        () => new Response("OK"),
+      );
+      const request = streamingRequest(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("x".repeat(100)));
+          },
+          cancel() {
+            cancelled = true;
+          },
+        }),
+        { "content-length": "1" },
+      );
+
+      const response = await handler(request);
+
+      assertEquals(response.status, 400);
+      await waitFor(() => cancelled, {
+        message: "the rejected request body must be cancelled, not left open",
+      });
     });
 
     it("should leave an accepted unparsed body available to the handler", async () => {

--- a/src/security/input-validation/limits.test.ts
+++ b/src/security/input-validation/limits.test.ts
@@ -627,5 +627,31 @@ describe("security/input-validation/limits", () => {
       );
       assertEquals(getterCalls, 0);
     });
+
+    it("rejects an invalid byte limit before reading the body", async () => {
+      for (
+        const limit of [
+          -1,
+          Number.NaN,
+          1.5,
+          Number.POSITIVE_INFINITY,
+          null as unknown as number,
+        ]
+      ) {
+        const req = new Request("http://localhost/", { method: "POST", body: "abc" });
+
+        await assertRejects(
+          () => readBodyBytesWithLimit(req, limit),
+          RangeError,
+          "must be a non-negative safe integer",
+          `${String(limit)} is not a usable byte limit and must be rejected outright`,
+        );
+        assertEquals(
+          req.bodyUsed,
+          false,
+          "an invalid limit must be rejected before the body is consumed",
+        );
+      }
+    });
   });
 });

--- a/src/security/input-validation/parsers.test.ts
+++ b/src/security/input-validation/parsers.test.ts
@@ -245,6 +245,59 @@ describe("parseFormData", () => {
     );
   });
 
+  it("rejects a form body that fails its schema", async () => {
+    const request = new Request("http://localhost/form", {
+      method: "POST",
+      body: "age=30",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+    });
+
+    const error = await assertRejects(
+      () => parseFormData(request, schema),
+      VeryfrontError,
+      "Form validation failed",
+      "a form body that fails its schema must be rejected, never returned to the caller",
+    ) as VeryfrontError;
+
+    const details = error.context as { details?: { errors?: unknown[] } } | undefined;
+    assertEquals(
+      Array.isArray(details?.details?.errors),
+      true,
+      "the rejection must carry the schema issues",
+    );
+    assertEquals(
+      (details!.details!.errors as unknown[]).length > 0,
+      true,
+      "the schema issue list must not be empty",
+    );
+  });
+
+  it("rejects an uploaded file above the configured per-file limit", async () => {
+    const body = new FormData();
+    body.append("name", "Alice");
+    body.append("avatar", new File(["0123456789"], "avatar.bin"));
+    const request = new Request("http://localhost/form", { method: "POST", body });
+
+    const error = await assertRejects(
+      () => parseFormData(request, schema, { limits: { maxFileSize: 4 } }),
+      VeryfrontError,
+      "File avatar too large",
+      "an upload above maxFileSize must be rejected before the schema sees it",
+    ) as VeryfrontError;
+
+    const details = error.context as { details: { maxSize: number; actualSize: number } };
+    assertEquals(
+      details.details.maxSize,
+      4,
+      "the rejection must report the configured per-file limit",
+    );
+    assertEquals(
+      details.details.actualSize,
+      10,
+      "the rejection must report the actual file size",
+    );
+  });
+
   it("collects special form field names without changing the input prototype", async () => {
     let captured: Record<string, unknown> | undefined;
     const captureSchema = {

--- a/src/security/input-validation/sanitizers.test.ts
+++ b/src/security/input-validation/sanitizers.test.ts
@@ -19,6 +19,14 @@ describe("sanitizeData compatibility", () => {
     });
   });
 
+  it("HTML-encodes quotes that would break out of an attribute", () => {
+    assertEquals(
+      sanitizeData({ v: `<a href="x" onclick='y'>` }),
+      { v: "&lt;a href=&quot;x&quot; onclick=&#x27;y&#x27;&gt;" },
+      "double and single quotes must be encoded so sanitized values cannot break out of an HTML attribute",
+    );
+  });
+
   it("uses null-prototype objects and rejects prototype-chain keys", () => {
     const value = sanitizeData(
       JSON.parse('{"safe":"ok","__proto__":{"polluted":true},"constructor":"bad"}'),

--- a/src/security/path-validation.test.ts
+++ b/src/security/path-validation.test.ts
@@ -11,6 +11,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import {
   createValidator,
+  isWithinDirectory,
   PathValidationError,
   sanitizePathForDisplay,
   validateLexicalPath,
@@ -148,18 +149,43 @@ describe("Path Validation - OWASP Attack Vectors", () => {
 
   describe("Encoding attacks", () => {
     const testCases = [
-      { name: "URL encoded dots", path: "%2e%2e%2f%2e%2e%2fetc%2fpasswd" },
-      { name: "Mixed encoding", path: "..%2f..%2fetc%2fpasswd" },
-      { name: "Double encoded", path: "%252e%252e%252f" },
-      { name: "Unicode", path: "\u2024\u2024/etc/passwd" },
+      {
+        name: "URL encoded dots",
+        path: "%2e%2e%2f%2e%2e%2fetc%2fpasswd",
+        expected: "/var/www/project/%2e%2e%2f%2e%2e%2fetc%2fpasswd",
+      },
+      {
+        name: "Mixed encoding",
+        path: "..%2f..%2fetc%2fpasswd",
+        expected: "/var/www/project/..%2f..%2fetc%2fpasswd",
+      },
+      {
+        name: "Double encoded",
+        path: "%252e%252e%252f",
+        expected: "/var/www/project/%252e%252e%252f",
+      },
+      {
+        name: "Unicode",
+        path: "\u2024\u2024/etc/passwd",
+        expected: "/var/www/project/\u2024\u2024/etc/passwd",
+      },
     ];
 
-    for (const { name, path } of testCases) {
+    for (const { name, path, expected } of testCases) {
       it(`should handle: ${name}`, () => {
         const result = validateLexicalPath(path, { baseDir });
 
-        if (!result.valid) return;
-        assertExists(result.canonicalPath);
+        assertEquals(result.valid, true, `${name} must be admitted as a literal segment`);
+        assertEquals(
+          result.canonicalPath,
+          expected,
+          `${name}: percent and Unicode escapes must stay literal and never be decoded into a traversal`,
+        );
+        assertEquals(
+          isWithinDirectory(baseDir, result.canonicalPath!),
+          true,
+          `${name} must resolve inside the base directory`,
+        );
       });
     }
   });
@@ -183,22 +209,34 @@ describe("Path Validation - OWASP Attack Vectors", () => {
 
   describe("Windows-specific attacks", () => {
     const testCases = [
-      { name: "Backslash traversal", path: "..\\..\\..\\windows\\system32\\config" },
-      { name: "Mixed separators", path: "../\\../\\../etc/passwd" },
-      { name: "UNC path", path: "\\\\server\\share\\file" },
-      { name: "Drive letter", path: "C:\\windows\\system32\\config" },
+      {
+        name: "Backslash traversal",
+        path: "..\\..\\..\\windows\\system32\\config",
+        expected: PathValidationError.OUTSIDE_BASE,
+      },
+      {
+        name: "Mixed separators",
+        path: "../\\../\\../etc/passwd",
+        expected: PathValidationError.OUTSIDE_BASE,
+      },
+      {
+        name: "UNC path",
+        path: "\\\\server\\share\\file",
+        expected: PathValidationError.ABSOLUTE_PATH_DENIED,
+      },
+      {
+        name: "Drive letter",
+        path: "C:\\windows\\system32\\config",
+        expected: PathValidationError.ABSOLUTE_PATH_DENIED,
+      },
     ];
 
-    for (const { name, path } of testCases) {
+    for (const { name, path, expected } of testCases) {
       it(`should handle: ${name}`, () => {
         const result = validateLexicalPath(path, { baseDir });
 
-        if (result.valid) {
-          assertExists(result.canonicalPath);
-          return;
-        }
-
-        assertExists(result.code);
+        assertEquals(result.valid, false, `${name} must be denied`);
+        assertEquals(result.code, expected, `${name} must be denied as ${expected}`);
       });
     }
   });

--- a/src/security/path-validation/canonical.test.ts
+++ b/src/security/path-validation/canonical.test.ts
@@ -83,6 +83,39 @@ describe("security/path-validation/canonical", () => {
       }
     });
 
+    it("should fail closed when a missing traversal segment has no canonical ancestor", async () => {
+      // Returning null here would drop the caller into purely lexical
+      // resolution, which is exactly the escape the physical walk prevents.
+      const mockAdapter = createAdapterWithFs({
+        realPath: () => Promise.reject(Object.assign(new Error("missing"), { code: "ENOENT" })),
+      });
+
+      await assertRejects(
+        () => getCanonicalPath("/project/missing/../new.txt", mockAdapter),
+        Error,
+        "missing traversal segment",
+        "a missing component in front of a traversal segment must fail closed",
+      );
+    });
+
+    it("should resolve ancestors physically on the collapsed traversal retry", async () => {
+      const mockAdapter = createAdapterWithFs({
+        realPath: (path: string) => {
+          if (path === "/project/new.txt") return Promise.resolve("/physical/new.txt");
+          if (path === "/project") return Promise.resolve("/physical");
+          return Promise.reject(Object.assign(new Error("missing"), { code: "ENOENT" }));
+        },
+      });
+
+      const result = await getCanonicalPath("/project/missing/../new.txt", mockAdapter);
+
+      assertEquals(
+        result.path,
+        "/physical/new.txt",
+        "the collapsed retry must still resolve ancestors physically",
+      );
+    });
+
     it("should preserve the root while walking a missing Windows drive path", async () => {
       const candidates: string[] = [];
       const mockAdapter = createAdapterWithFs({

--- a/src/security/path-validation/index.test.ts
+++ b/src/security/path-validation/index.test.ts
@@ -439,6 +439,30 @@ describe("security/path-validation/index", () => {
         validatePathSync("../outside.ts", options).code,
         PathValidationError.OUTSIDE_BASE,
       );
+      assertEquals(
+        validatePathSync("/etc/passwd", options).code,
+        PathValidationError.ABSOLUTE_PATH_DENIED,
+        "legacy policy fields must not weaken absolute-path containment",
+      );
+    });
+
+    it("forwards an explicit allowAbsolute without widening base containment", () => {
+      const options = {
+        baseDir: "/project",
+        allowAbsolute: true,
+        adapter: createMockAdapter(),
+      };
+
+      assertEquals(
+        validatePathSync("/project/src/file.ts", options).valid,
+        true,
+        "an explicit allowAbsolute admits an in-base absolute path",
+      );
+      assertEquals(
+        validatePathSync("/etc/passwd", options).code,
+        PathValidationError.OUTSIDE_BASE,
+        "allowAbsolute still enforces base containment",
+      );
     });
 
     it("rejects hostile compatibility policy objects without invoking accessors", () => {

--- a/src/security/path-validation/normalization.test.ts
+++ b/src/security/path-validation/normalization.test.ts
@@ -101,6 +101,24 @@ describe("security/path-validation/normalization", () => {
       assertEquals(isWithinDirectory("/project-a", "/project-b"), false);
     });
 
+    it("should reject a sibling that shares the base prefix", () => {
+      assertEquals(
+        isWithinDirectory("/project", "/project-secrets/creds.env"),
+        false,
+        "a sibling sharing the base prefix must not be inside the base",
+      );
+      assertEquals(
+        isWithinDirectory("/project", "/projectevil"),
+        false,
+        "containment must require a separator after the base",
+      );
+      assertEquals(
+        isWithinDirectory("/project", "/project/secrets"),
+        true,
+        "a real child must still be inside the base",
+      );
+    });
+
     it("should handle trailing slashes", () => {
       assertEquals(isWithinDirectory("/project/", "/project/src"), true);
     });

--- a/src/security/path-validation/rules.test.ts
+++ b/src/security/path-validation/rules.test.ts
@@ -24,9 +24,18 @@ describe("security/path-validation/rules", () => {
       assertEquals(code, PathValidationError.PATH_TOO_LONG);
     });
 
-    it("should reject paths with forbidden patterns", () => {
+    it("treats dotfiles as ordinary path segments (no forbidden-pattern rule)", () => {
       const result = validatePathBasics("/project/.env");
-      assertEquals(typeof result.valid, "boolean");
+      assertEquals(
+        result.valid,
+        true,
+        "validatePathBasics applies no forbidden-pattern rule; dotfile policy belongs to the allowlist layer",
+      );
+      assertEquals(
+        result.code,
+        undefined,
+        "no FORBIDDEN_PATTERN code is produced anywhere in src",
+      );
     });
 
     it("should reject excessive traversal depth", () => {

--- a/src/security/repository-hardening.test.ts
+++ b/src/security/repository-hardening.test.ts
@@ -257,9 +257,14 @@ describe("repository hardening", () => {
 
       for (const jobName of jobs) {
         const block = jobBlock(workflow, jobName);
+        const jobIf = block.split("\n").find((line) => /^ {4}if:/.test(line));
         assert(
-          block.includes(WORKFLOW_PR_GUARD),
-          `expected ${path} job ${jobName} to gate fork pull requests`,
+          jobIf !== undefined,
+          `expected ${path} job ${jobName} to declare a job-level if: condition`,
+        );
+        assert(
+          jobIf.includes(WORKFLOW_PR_GUARD),
+          `expected ${path} job ${jobName} to carry the fork guard on its own job-level if:, not on a step`,
         );
       }
     }

--- a/src/security/sandbox/deno-sandbox.test.ts
+++ b/src/security/sandbox/deno-sandbox.test.ts
@@ -1,7 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { isDeno } from "#veryfront/platform/compat/runtime.ts";
+import { VeryfrontError } from "#veryfront/errors";
 import {
   BUN_SANDBOX_ALLOW_UNSAFE_ENV,
   isBunSandboxAllowedUnsafe,
@@ -54,6 +55,9 @@ describe("deno-sandbox input validation", () => {
 // SEC-008: Node.js Workers do not support permission isolation. The opt-in
 // decision helper must be strict — only the literal "1" enables unsafe mode.
 // Unit-testing the pure helper means coverage works under any runtime.
+// The end-to-end guard case (runInWorker actually refusing on Node.js with the
+// env var absent) needs host env mutation, so it lives in
+// tests/integration/security/sandbox-runtime-guard.test.ts.
 describe("deno-sandbox Node opt-in guard (SEC-008)", () => {
   it("exposes the documented env var name", () => {
     assertEquals(NODE_SANDBOX_ALLOW_UNSAFE_ENV, "VERYFRONT_NODE_SANDBOX_ALLOW_UNSAFE");
@@ -88,6 +92,8 @@ describe("deno-sandbox Node opt-in guard (SEC-008)", () => {
 // SEC-008: Bun Workers have no permission isolation. The opt-in decision helper
 // must be strict — only the literal "1" enables unsafe mode. Unit-testing the
 // pure helper means coverage works under any runtime.
+// The end-to-end guard case lives in
+// tests/integration/security/sandbox-runtime-guard.test.ts (host env mutation).
 describe("deno-sandbox Bun opt-in guard (SEC-008)", () => {
   it("exposes the documented env var name", () => {
     assertEquals(BUN_SANDBOX_ALLOW_UNSAFE_ENV, "VERYFRONT_BUN_SANDBOX_ALLOW_UNSAFE");
@@ -135,6 +141,38 @@ testSuite("deno-sandbox", () => {
       const message = String((e as Error)?.message ?? e);
       assertEquals(message.includes("boom"), true);
     }
+  });
+
+  it("denies filesystem and network access inside the worker", async () => {
+    // `permissions: "none"` is the whole isolation guarantee on the only
+    // runtime this sandbox claims to be safe on. Match the permission family
+    // rather than one exact wording so the case survives runtime upgrades.
+    const fsError = await assertRejects(
+      () => runInWorker<string>("return Deno.readTextFile('/etc/hosts');"),
+      VeryfrontError,
+      undefined,
+      "a worker denied every permission must not read the host filesystem",
+    ) as VeryfrontError;
+    assert(
+      /NotCapable|PermissionDenied|read access/i.test(fsError.message),
+      "worker filesystem read must be denied by permissions: none",
+    );
+    assertEquals(
+      fsError.message.includes("localhost"),
+      false,
+      "no /etc/hosts content may reach the host",
+    );
+
+    const netError = await assertRejects(
+      () => runInWorker("return fetch('http://127.0.0.1:1/').then((r) => r.status);"),
+      VeryfrontError,
+      undefined,
+      "a worker denied every permission must not open outbound sockets",
+    ) as VeryfrontError;
+    assert(
+      /NotCapable|PermissionDenied|net access/i.test(netError.message),
+      "worker network access must be denied by permissions: none",
+    );
   });
 
   it("runInWorker enforces timeout", async () => {

--- a/src/security/sandbox/isolation-posture.test.ts
+++ b/src/security/sandbox/isolation-posture.test.ts
@@ -66,6 +66,37 @@ describe("security/sandbox isolation posture reporting", () => {
     assertEquals(warning?.context?.effectiveSurfaces, 0);
   });
 
+  it("warns when a surface flag is set without the master switch", async () => {
+    await __resetPoolForTests();
+    setEnv("WORKER_ISOLATION_SSR", "1");
+    const entries = captureLogs();
+
+    assertEquals(
+      isWorkerIsolationEnabled(),
+      false,
+      "a surface flag alone must not enable isolation",
+    );
+
+    const warning = entries.find((entry) =>
+      entry.level === "warn" &&
+      entry.message.includes("WORKER_ISOLATION_ENABLED is not")
+    );
+    assertExists(
+      warning,
+      "expected a warning that surface flags are inert without the master switch",
+    );
+    assertEquals(
+      warning?.context?.effectiveSurfaces,
+      0,
+      "the warning must report that no surface resolved on",
+    );
+    assertEquals(
+      warning?.context?.workerIsolationSsr,
+      true,
+      "the warning must name the flag the operator actually set",
+    );
+  });
+
   it("reports requested and effective state for every surface", async () => {
     await __resetPoolForTests();
     setEnv("WORKER_ISOLATION_ENABLED", "1");

--- a/src/security/sandbox/permission-system.test.ts
+++ b/src/security/sandbox/permission-system.test.ts
@@ -259,9 +259,15 @@ describe("Permission System", () => {
       }
     });
 
-    it("should be resilient to unusual permission names (type safety)", () => {
-      const validPermissions: Permission[] = ["net", "fs", "env", "run", "read", "write"];
-      assertEquals(validPermissions.length, 6);
+    denoOnlyIt("should deny permission names outside this module's contract", async () => {
+      for (const name of ["sys", "ffi", "import"]) {
+        const result = await requestPermission({ name: name as Permission });
+        assertEquals(
+          result.state,
+          "denied",
+          `${name} is outside this module's contract and must be denied`,
+        );
+      }
     });
   });
 

--- a/src/security/sandbox/worker-byte-encoding.test.ts
+++ b/src/security/sandbox/worker-byte-encoding.test.ts
@@ -76,6 +76,33 @@ describe("sandbox worker byte encoding", () => {
     }
   });
 
+  it("round-trips a payload that crosses a base64 chunk boundary", () => {
+    const source = new Uint8Array(BASE64_CHUNK_BYTES + 5);
+    for (let index = 0; index < source.length; index++) {
+      source[index] = index % 256;
+    }
+
+    const encoded = encodeSandboxBytesAsBase64(source);
+
+    assertEquals(
+      /=/.test(encoded.slice(0, -4)),
+      false,
+      "padding may appear only in the final base64 quantum, never at a chunk seam",
+    );
+
+    const decoded = Uint8Array.from(atob(encoded), (character) => character.charCodeAt(0));
+    assertEquals(
+      decoded.length,
+      source.length,
+      "decoded length must match the source",
+    );
+    assertEquals(
+      decoded.every((byte, index) => byte === source[index]),
+      true,
+      "atob must reproduce the exact source bytes across the chunk boundary",
+    );
+  });
+
   it("encodes tenant bytes when project code hooks species and length", () => {
     const source = new Uint8Array(BASE64_CHUNK_BYTES + 5);
     for (let index = 0; index < source.length; index++) {

--- a/src/security/sandbox/worker-egress-guard.test.ts
+++ b/src/security/sandbox/worker-egress-guard.test.ts
@@ -1,5 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assert, assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { observeFetchRequestInit } from "#veryfront/testing/mock-fetch.ts";
 import {
@@ -483,6 +488,67 @@ describe("worker-egress-guard admission and shutdown", () => {
         Promise.all([broker.closed, settledRequests]).then(() => undefined),
         "broker flood did not drain during cleanup",
       );
+      await targetServer.shutdown();
+    }
+  });
+
+  it("rejects broker requests without the per-broker authentication token", async () => {
+    let upstreamHits = 0;
+    const targetServer = Deno.serve(
+      { hostname: "127.0.0.1", port: 0, onListen: () => {} },
+      () => {
+        upstreamHits++;
+        return new Response("ok");
+      },
+    );
+    const targetAddress = targetServer.addr;
+    if (targetAddress.transport !== "tcp") {
+      await targetServer.shutdown();
+      throw new Error("expected a TCP target server");
+    }
+
+    const broker = startWorkerEgressBroker({ allowInternalEgress: true });
+
+    try {
+      for (const forgedToken of [undefined, "wrong-token"]) {
+        const headers = new Headers({
+          "x-veryfront-egress-target": `http://127.0.0.1:${targetAddress.port}/`,
+        });
+        if (forgedToken !== undefined) {
+          headers.set("x-veryfront-egress-auth", forgedToken);
+        }
+
+        const response = await beforeDeadline(
+          fetch(broker.config.httpBroker.url, { headers }),
+          "the broker did not answer an unauthenticated request",
+        );
+        const body = await response.text();
+
+        assertEquals(
+          response.status,
+          403,
+          "the broker must reject an unauthenticated egress request",
+        );
+        assertEquals(
+          response.headers.get("x-veryfront-egress-error"),
+          "1",
+          "the rejection must be marked as a broker error",
+        );
+        assertStringIncludes(
+          body,
+          "authentication failed",
+          "the rejection must name the broker authentication gate",
+        );
+      }
+
+      assertEquals(
+        upstreamHits,
+        0,
+        "no upstream request may be made for an unauthenticated broker call",
+      );
+    } finally {
+      broker.close();
+      await beforeDeadline(broker.closed, "broker did not drain after close");
       await targetServer.shutdown();
     }
   });

--- a/src/security/sandbox/worker-error-boundary.test.ts
+++ b/src/security/sandbox/worker-error-boundary.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assert, assertEquals, assertInstanceOf } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { SERVICE_OVERLOADED, VeryfrontError } from "#veryfront/errors";
+import { ERROR_DIAGNOSTIC_MAX_LENGTH_CHARS } from "#veryfront/errors/safe-diagnostics.ts";
 import { deserializeWorkerError } from "./worker-error-boundary.ts";
 
 describe("worker error boundary", () => {
@@ -32,6 +33,96 @@ describe("worker error boundary", () => {
     assertEquals(error.message, "dependency overloaded");
     assert(error.stack?.includes("postgres://admin:[REDACTED]@db.internal/query"));
     assertEquals(error.stack?.includes("secret"), false);
+  });
+
+  it("redacts and bounds every worker-controlled diagnostic field", () => {
+    const tainted = `postgres://admin:secret@db.internal/query ${
+      "x".repeat(ERROR_DIAGNOSTIC_MAX_LENGTH_CHARS + 100)
+    }`;
+    const error = deserializeWorkerError({
+      message: tainted,
+      name: "VeryfrontError",
+      problem: {
+        slug: SERVICE_OVERLOADED.slug,
+        category: SERVICE_OVERLOADED.category,
+        status: 429,
+        title: SERVICE_OVERLOADED.title,
+        suggestion: SERVICE_OVERLOADED.suggestion,
+        detail: tainted,
+        cause: tainted,
+        instance: tainted,
+      },
+    });
+
+    assertInstanceOf(error, VeryfrontError);
+    const fields: readonly (readonly [string, unknown])[] = [
+      ["message", error.message],
+      ["detail", error.detail],
+      ["cause", error.cause],
+      ["instance", error.instance],
+    ];
+
+    for (const [name, value] of fields) {
+      assertEquals(typeof value, "string", `${name} must be decoded as a string`);
+      const text = value as string;
+      assert(
+        text.includes("[REDACTED]"),
+        `${name} must be sanitized before it reaches the problem document`,
+      );
+      assertEquals(
+        text.includes("secret"),
+        false,
+        `${name} must not carry the credential`,
+      );
+      assert(
+        text.length <= ERROR_DIAGNOSTIC_MAX_LENGTH_CHARS,
+        `${name} must be bounded by ERROR_DIAGNOSTIC_MAX_LENGTH_CHARS`,
+      );
+    }
+  });
+
+  it("fails closed on an out-of-range or non-integer status", () => {
+    for (
+      const status of [200, 999, 429.5, "429", Number.NaN, Number.MAX_SAFE_INTEGER + 2]
+    ) {
+      const error = deserializeWorkerError({
+        message: "project failure",
+        name: "VeryfrontError",
+        problem: {
+          slug: SERVICE_OVERLOADED.slug,
+          category: SERVICE_OVERLOADED.category,
+          title: SERVICE_OVERLOADED.title,
+          suggestion: SERVICE_OVERLOADED.suggestion,
+          status,
+        },
+      });
+
+      assertEquals(
+        error instanceof VeryfrontError,
+        false,
+        `status ${String(status)} must not yield a registered error`,
+      );
+      assertEquals(
+        error.message,
+        "project failure",
+        "the decoded error falls back to a plain Error",
+      );
+    }
+
+    const inRange = deserializeWorkerError({
+      message: "project failure",
+      name: "VeryfrontError",
+      problem: {
+        slug: SERVICE_OVERLOADED.slug,
+        category: SERVICE_OVERLOADED.category,
+        title: SERVICE_OVERLOADED.title,
+        suggestion: SERVICE_OVERLOADED.suggestion,
+        status: 429,
+      },
+    });
+
+    assertInstanceOf(inRange, VeryfrontError);
+    assertEquals(inRange.status, 429, "an in-range status must still be accepted");
   });
 
   it("fails closed on forged registered metadata", () => {

--- a/src/security/sandbox/worker-pool.test.ts
+++ b/src/security/sandbox/worker-pool.test.ts
@@ -24,6 +24,7 @@ import {
   type WorkerPoolDependencies,
 } from "./worker-pool.ts";
 import type {
+  ExecuteAppRouteRequest,
   RenderSSRRequest,
   WorkerPoolConfig,
   WorkerRequest,
@@ -92,6 +93,25 @@ function makeRequest(
   };
 }
 
+/**
+ * Narrow a request the pool forwarded to its app-route member.
+ *
+ * `ControlledWorker.requests` is typed as the whole `WorkerRequest` union, so
+ * `projectDir` / `projectEnv` are only reachable once the discriminant is
+ * pinned. Failing here is itself part of the contract: the pool must hand the
+ * worker the exact request shape it was given.
+ */
+function appRouteRequest(request: WorkerRequest | undefined): ExecuteAppRouteRequest {
+  if (request?.type !== "execute-app-route") {
+    throw new Error(
+      `the pool must forward the execute-app-route request it was given; received ${
+        request?.type ?? "no request"
+      }`,
+    );
+  }
+  return request;
+}
+
 function makeSSRRequest(
   id: string,
   overrides: Partial<RenderSSRRequest> = {},
@@ -115,6 +135,7 @@ class ControlledWorker {
   readonly permissions: ProjectWorkerOptions["permissions"];
   readonly isolatedSsrRendererModuleUrl: string | undefined;
   status: "idle" | "busy" | "crashed" | "terminated" = "idle";
+  readonly requests: WorkerRequest[] = [];
   requestCount = 0;
   terminateCalls = 0;
   healthCheckCalls = 0;
@@ -160,6 +181,7 @@ class ControlledWorker {
   }
 
   execute(request: WorkerRequest): Promise<WorkerResponse> {
+    this.requests.push(request);
     this.requestCount++;
     this.status = "busy";
     return new Promise((resolve, reject) => {
@@ -168,6 +190,7 @@ class ControlledWorker {
   }
 
   executeStream(request: WorkerRequest): ReadableStream<Uint8Array> {
+    this.requests.push(request);
     this.requestCount++;
     this.status = "busy";
     return new ReadableStream<Uint8Array>({
@@ -384,6 +407,32 @@ testSuite("WorkerPool", () => {
     assertEquals(
       (worker as unknown as ControlledWorker).allowInternalEgress,
       true,
+    );
+  });
+
+  it("blocks internal egress for workers when the host decision is off", async () => {
+    const blocked = createControlledPool(
+      { allowInternalEgress: false } as Partial<WorkerPoolConfig>,
+    );
+    await pool.shutdown();
+    pool = blocked.pool;
+
+    const blockedWorker = pool.getOrCreateWorker("blocked-egress-project", []);
+    assertEquals(
+      (blockedWorker as unknown as ControlledWorker).allowInternalEgress,
+      false,
+      "a worker must inherit a blocked internal-egress decision from the pool config",
+    );
+
+    const defaulted = createControlledPool();
+    await pool.shutdown();
+    pool = defaulted.pool;
+
+    const defaultedWorker = pool.getOrCreateWorker("default-egress-project", []);
+    assertEquals(
+      (defaultedWorker as unknown as ControlledWorker).allowInternalEgress,
+      false,
+      "an omitted internal-egress decision must normalize to blocked",
     );
   });
 
@@ -611,34 +660,47 @@ testSuite("WorkerPool", () => {
   });
 });
 
-testSuite("WorkerPool - RFC 9457 error metadata", () => {
+testSuite("WorkerPool - worker request forwarding", () => {
   let pool: WorkerPool;
 
-  beforeEach(() => {
-    pool = new WorkerPool({
-      maxPoolSize: 3,
-      idleTimeoutMs: 1_000,
-      requestTimeoutMs: 5_000,
-      healthCheckIntervalMs: 60_000,
-      maxRequestsPerWorker: 100,
-    });
-  });
-
   afterEach(async () => {
-    await pool.shutdown();
+    await pool?.shutdown();
   });
 
-  it("execute-app-route request includes projectDir", () => {
-    // Verify the request type accepts projectDir
-    const worker = pool.getOrCreateWorker("test-proj", ["/tmp/test"]);
-    assertExists(worker);
-    assertEquals(worker.projectId, "test-proj");
+  it("execute-app-route request includes projectDir", async () => {
+    const controlled = createControlledPool();
+    pool = controlled.pool;
+
+    const pending = pool.execute("test-proj", ["/tmp"], makeRequest("dir-1"));
+    const worker = latestWorker(controlled.workers, "test-proj");
+    worker.complete("dir-1");
+    await pending;
+
+    assertEquals(
+      appRouteRequest(worker.requests[0]).projectDir,
+      "/tmp",
+      "the pool must forward projectDir to the worker request",
+    );
   });
 
-  it("execute-app-route request accepts projectEnv", () => {
-    // Verify the request type accepts projectEnv field
-    const worker = pool.getOrCreateWorker("test-proj", ["/tmp/test"]);
-    assertExists(worker);
+  it("execute-app-route request accepts projectEnv", async () => {
+    const controlled = createControlledPool();
+    pool = controlled.pool;
+
+    const pending = pool.execute(
+      "test-proj",
+      ["/tmp"],
+      makeRequest("env-1", { TENANT: "a" }),
+    );
+    const worker = latestWorker(controlled.workers, "test-proj");
+    worker.complete("env-1");
+    await pending;
+
+    assertEquals(
+      appRouteRequest(worker.requests[0]).projectEnv,
+      { TENANT: "a" },
+      "the pool must forward projectEnv to the worker request",
+    );
   });
 });
 
@@ -1273,6 +1335,45 @@ testSuite("WorkerPool - bounded admission and retirement", () => {
     assertEquals(controlled.workers.get("scope-a")?.length, 2);
   });
 
+  it("retires a live worker that fails its health ping", async () => {
+    const controlled = createControlledPool();
+    pool = controlled.pool;
+
+    pool.getOrCreateWorker("scope-a", []);
+    const workerA = latestWorker(controlled.workers, "scope-a");
+    workerA.healthCheckResult = false;
+
+    await runHealthCheck(pool);
+
+    assertEquals(workerA.healthCheckCalls, 1, "an idle worker must be pinged");
+    assertEquals(
+      workerA.terminateCalls,
+      1,
+      "a worker that fails its health ping must be terminated",
+    );
+    assertEquals(
+      pool.getStats().workers["scope-a"],
+      undefined,
+      "a worker that failed its health ping must not stay in the pool",
+    );
+
+    pool.getOrCreateWorker("scope-b", []);
+    const workerB = latestWorker(controlled.workers, "scope-b");
+    workerB.healthCheckResult = Promise.reject(new Error("health ping transport failed"));
+    await runHealthCheck(pool);
+
+    assertEquals(
+      workerB.terminateCalls,
+      1,
+      "a health ping that throws must retire the worker as well",
+    );
+    assertEquals(
+      pool.getStats().workers["scope-b"],
+      undefined,
+      "a worker whose health ping threw must not stay in the pool",
+    );
+  });
+
   it("defers explicit eviction and terminates exactly once after settlement", async () => {
     const controlled = createControlledPool();
     pool = controlled.pool;
@@ -1402,23 +1503,44 @@ testSuite("WorkerPool - bounded admission and retirement", () => {
 
   it("retires only idle workers when real host heap pressure is high", async () => {
     const controlled = createControlledPool(
-      { maxPoolSize: 4 },
+      { maxPoolSize: 5 },
       {},
       { getHeapUsedPercent: () => 75 },
     );
     pool = controlled.pool;
 
+    // The busy worker is created first so it is also the least recently used,
+    // which is exactly the entry the eviction sort would reach for first.
+    const active = pool.execute("scope-busy", ["/tmp"], makeRequest("busy-1"));
+    const busyWorker = latestWorker(controlled.workers, "scope-busy");
     for (const scope of ["scope-a", "scope-b", "scope-c", "scope-d"]) {
       pool.getOrCreateWorker(scope, ["/tmp"]);
     }
 
     await runHealthCheck(pool);
 
-    assertEquals(pool.getStats().poolSize, 3);
+    assertEquals(
+      busyWorker.terminateCalls,
+      0,
+      "host heap pressure must never terminate a worker with an in-flight tenant request",
+    );
+    assertEquals(
+      pool.getStats().workers["scope-busy"]?.retiring,
+      false,
+      "the busy least-recently-used worker must not be marked retiring under heap pressure",
+    );
+    assertEquals(
+      pool.getStats().poolSize,
+      4,
+      "only one of the four idle workers may be retired",
+    );
     const terminated = [...controlled.workers.values()]
       .flat()
       .filter((worker) => worker.terminateCalls === 1);
-    assertEquals(terminated.length, 1);
+    assertEquals(terminated.length, 1, "only idle workers may be retired");
+
+    busyWorker.complete("busy-1");
+    await active;
   });
 });
 

--- a/src/security/sandbox/worker-script-bootstrap.test.ts
+++ b/src/security/sandbox/worker-script-bootstrap.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { readTextFile } from "#veryfront/platform/compat/fs.ts";
 import { fromFileUrl } from "#veryfront/platform/compat/path/index.ts";
-import { assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 
 describe("worker-script bootstrap source", () => {
@@ -9,9 +9,26 @@ describe("worker-script bootstrap source", () => {
     const source = await readTextFile(
       fromFileUrl(new URL("./worker-script.ts", import.meta.url)),
     );
-    assertStringIncludes(
-      source,
-      'import "#veryfront/platform/compat/process/env.ts";',
+    const envImport = 'import "#veryfront/platform/compat/process/env.ts";';
+    const envIndex = source.indexOf(envImport);
+    assertEquals(
+      envIndex >= 0,
+      true,
+      "worker-script.ts must side-effect import the host env primordials",
+    );
+
+    const otherImportIndexes = [...source.matchAll(/^import (?!type )[^\n]*$/gm)]
+      .map((match) => match.index!)
+      .filter((index) => index !== envIndex);
+    assertEquals(
+      otherImportIndexes.length > 0,
+      true,
+      "worker-script.ts must still carry the value imports this ordering guards",
+    );
+    assertEquals(
+      otherImportIndexes.every((index) => envIndex < index),
+      true,
+      "the host-environment primordial capture must be the first evaluated import in worker-script.ts, before any module that project code can influence",
     );
   });
 });

--- a/src/security/secure-fs.test.ts
+++ b/src/security/secure-fs.test.ts
@@ -7,6 +7,7 @@ import {
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createSecureFs, SecureFs, wrapAdapterWithSecurity } from "./secure-fs.ts";
+import type { SecurityEvent } from "./secure-fs.ts";
 import { wrapFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
 import { VeryfrontError } from "#veryfront/errors/types.ts";
 import { DenoAdapter } from "#veryfront/platform/adapters/runtime/deno/adapter.ts";
@@ -713,6 +714,48 @@ describe("SecureFs", () => {
       });
 
       assertEquals(await secureFs.readFile("file.txt"), "ok");
+    } finally {
+      await Deno.remove(baseDir, { recursive: true });
+    }
+  });
+
+  it("labels and sanitizes the security events it reports to an observer", async () => {
+    const baseDir = await Deno.makeTempDir();
+    try {
+      await Deno.writeTextFile(`${baseDir}/file.txt`, "ok");
+      const events: SecurityEvent[] = [];
+      const secureFs = createSecureFs({
+        baseDir,
+        adapter: new DenoAdapter(),
+        context: "internal",
+        onSecurityEvent: (event) => {
+          events.push(event);
+        },
+      });
+
+      assertEquals(await secureFs.readFile("file.txt"), "ok");
+      await assertRejects(() => secureFs.readFile("../../etc/passwd"), VeryfrontError);
+
+      assertEquals(
+        events.map((event) => event.type),
+        ["validation-passed", "validation-failed"],
+        "secure-fs must label the allowed read and the rejected traversal distinctly",
+      );
+      assertEquals(
+        events.map((event) => event.operation),
+        ["readFile", "readFile"],
+        "each event carries the originating operation",
+      );
+      assertEquals(
+        events[0]?.path,
+        "file.txt",
+        "an in-root path is reported relative to the trust root",
+      );
+      assertEquals(
+        events[1]?.path,
+        "passwd",
+        "a rejected traversal is reported sanitized, never as a host absolute path",
+      );
     } finally {
       await Deno.remove(baseDir, { recursive: true });
     }

--- a/tests/integration/security/csrf-proxy-topology.test.ts
+++ b/tests/integration/security/csrf-proxy-topology.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Integration coverage for the trusted-proxy arm of `applyCsrfCookie`.
+ *
+ * This case cannot live beside the unit under test: `applyCsrfCookie` resolves
+ * the proxy-topology decision through `isProxyTopologyTrusted()`, which reads
+ * `VERYFRONT_TRUST_FORWARDED_HEADERS` from the process environment on every
+ * call. Neither `CsrfConfig` nor `applyCsrfCookie` exposes a trust override, so
+ * the only way to exercise the trusted arm is to mutate real process env — a
+ * host effect that colocated unit tests are not allowed to perform. Every
+ * hermetic CSRF assertion, including the untrusted-topology arm of this same
+ * branch, stays in src/security/csrf/helpers.test.ts.
+ */
+
+import "#veryfront/schemas/_test-setup.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { withEnv } from "#veryfront/testing";
+import { applyCsrfCookie } from "#veryfront/security/csrf/helpers.ts";
+
+describe("security/csrf/helpers applyCsrfCookie proxy topology", () => {
+  it("should honour x-forwarded-proto once the proxy topology is trusted", async () => {
+    await withEnv({ VERYFRONT_TRUST_FORWARDED_HEADERS: "1" }, () => {
+      const req = new Request("http://localhost/", {
+        headers: { "x-forwarded-proto": "https", accept: "text/html" },
+      });
+      const headers = new Headers();
+      applyCsrfCookie(req, headers, { cookieName: "vf_csrf" });
+
+      assertEquals(
+        headers.get("set-cookie")!.includes("Secure"),
+        true,
+        "a trusted proxy topology must let x-forwarded-proto mark the cookie Secure",
+      );
+      return Promise.resolve();
+    });
+  });
+});

--- a/tests/integration/security/html-sanitizer-dev-mode.test.ts
+++ b/tests/integration/security/html-sanitizer-dev-mode.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Integration coverage for the dev-mode branch of `validateTrustedHtml`.
+ *
+ * These cases cannot live beside the unit under test: `validateTrustedHtml`
+ * resolves the dev/production decision through the module-private `isDevMode()`
+ * (src/security/client/html-sanitizer.ts), which reads
+ * `globalThis.__VERYFRONT_DEV__` and `Deno.env.get("VERYFRONT_ENV")` on every
+ * call. `ValidateTrustedHtmlOptions` exposes only `strict`, `warn` and
+ * `allowInlineScripts`, and the module ships no factory or `*ForTesting` hook,
+ * so pinning either arm requires mutating the real global object and the real
+ * process environment — host effects a colocated unit test may not perform.
+ *
+ * This branch is worth pinning because the three production innerHTML sinks
+ * (rendering/rsc/client-dom.ts, rendering/rsc/client-boot.ts,
+ * routing/client/page-transition.ts) all call `validateTrustedHtml(html)` with
+ * no options at all, so the no-options shape is the one that actually protects
+ * users. Every hermetic assertion stays in
+ * src/security/client/html-sanitizer.test.ts.
+ */
+
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { withEnv } from "#veryfront/testing";
+import { validateTrustedHtml } from "#veryfront/security/client/html-sanitizer.ts";
+
+/** Run `fn` with the client dev flag forced to `value` (absent when undefined). */
+function withDevFlag<T>(value: boolean | undefined, fn: () => T): T {
+  const globals = globalThis as Record<string, unknown>;
+  const hadFlag = "__VERYFRONT_DEV__" in globals;
+  const previousFlag = globals.__VERYFRONT_DEV__;
+  if (value === undefined) delete globals.__VERYFRONT_DEV__;
+  else globals.__VERYFRONT_DEV__ = value;
+  try {
+    return fn();
+  } finally {
+    if (hadFlag) globals.__VERYFRONT_DEV__ = previousFlag;
+    else delete globals.__VERYFRONT_DEV__;
+  }
+}
+
+describe("security/client/html-sanitizer validateTrustedHtml dev mode", () => {
+  it("throws outside dev mode when called without options", async () => {
+    await withEnv({ VERYFRONT_ENV: "production" }, () => {
+      withDevFlag(undefined, () => {
+        assertThrows(
+          () => validateTrustedHtml('<svg onload="alert(1)"></svg>'),
+          Error,
+          "event handler",
+          "production callers pass no options and must still be protected",
+        );
+      });
+      return Promise.resolve();
+    });
+  });
+
+  it("warns and passes suspicious HTML through in dev mode", async () => {
+    await withEnv({ VERYFRONT_ENV: "production" }, () => {
+      withDevFlag(true, () => {
+        const svg = '<svg onload="alert(1)"></svg>';
+        assertEquals(
+          validateTrustedHtml(svg, { warn: false }),
+          svg,
+          "dev mode must warn and pass suspicious HTML through instead of throwing",
+        );
+      });
+      return Promise.resolve();
+    });
+  });
+
+  it("throws in dev mode when the caller opts into strict validation", async () => {
+    await withEnv({ VERYFRONT_ENV: "development" }, () => {
+      withDevFlag(true, () => {
+        assertThrows(
+          () => validateTrustedHtml('<svg onload="alert(1)"></svg>', { strict: true }),
+          Error,
+          "event handler",
+          "strict must override the dev-mode pass-through",
+        );
+      });
+      return Promise.resolve();
+    });
+  });
+
+  it("treats VERYFRONT_ENV=development as dev mode without the global flag", async () => {
+    await withEnv({ VERYFRONT_ENV: "development" }, () => {
+      withDevFlag(undefined, () => {
+        const svg = '<svg onload="alert(1)"></svg>';
+        assertEquals(
+          validateTrustedHtml(svg, { warn: false }),
+          svg,
+          "the server-side dev signal is VERYFRONT_ENV, not the client global",
+        );
+      });
+      return Promise.resolve();
+    });
+  });
+});

--- a/tests/integration/security/html-sanitizer-dev-mode.test.ts
+++ b/tests/integration/security/html-sanitizer-dev-mode.test.ts
@@ -57,12 +57,22 @@ describe("security/client/html-sanitizer validateTrustedHtml dev mode", () => {
   it("warns and passes suspicious HTML through in dev mode", async () => {
     await withEnv({ VERYFRONT_ENV: "production" }, () => {
       withDevFlag(true, () => {
+        const originalWarn = console.warn;
+        const warnings: unknown[][] = [];
         const svg = '<svg onload="alert(1)"></svg>';
-        assertEquals(
-          validateTrustedHtml(svg, { warn: false }),
-          svg,
-          "dev mode must warn and pass suspicious HTML through instead of throwing",
-        );
+        console.warn = (...args: unknown[]) => warnings.push(args);
+        try {
+          assertEquals(
+            validateTrustedHtml(svg),
+            svg,
+            "dev mode must warn and pass suspicious HTML through instead of throwing",
+          );
+          assertEquals(warnings, [[
+            "[Security] Suspicious event handler attribute detected in server HTML",
+          ]]);
+        } finally {
+          console.warn = originalWarn;
+        }
       });
       return Promise.resolve();
     });

--- a/tests/integration/security/local-control-request-proxy-topology.test.ts
+++ b/tests/integration/security/local-control-request-proxy-topology.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Default-arm proxy-topology admission for privileged local controls.
+ *
+ * These cases cannot live beside the unit under test. `isTrustedLocalControlRequest`
+ * resolves its default `proxyTopologyTrusted` through `isProxyTopologyTrusted()`
+ * (src/security/http/local-control-request.ts), which reads the process
+ * environment variable `VERYFRONT_TRUST_FORWARDED_HEADERS` with no injectable
+ * seam. Pinning that arm therefore requires mutating real process env, a host
+ * effect the colocated unit suite is not allowed to perform. Every arm that
+ * accepts an explicit `proxyTopologyTrusted` option stays hermetic in
+ * src/security/http/local-control-request.test.ts.
+ *
+ * @module tests/integration/security/local-control-request-proxy-topology
+ */
+
+import { assertEquals } from "#veryfront/testing/assert";
+import { describe, it } from "#veryfront/testing/bdd";
+import { deleteEnv, getEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import { recordRequestPeerFromTransport } from "#veryfront/platform/adapters/runtime/shared/request-peer.ts";
+import { isTrustedLocalControlRequest } from "#veryfront/security/http/local-control-request.ts";
+
+const TRUST_FORWARDED_HEADERS_ENV = "VERYFRONT_TRUST_FORWARDED_HEADERS";
+
+function loopbackRequest(): Request {
+  const request = new Request("http://localhost/_dev", {
+    headers: { host: "localhost" },
+  });
+  recordRequestPeerFromTransport(request, {
+    runtime: "node",
+    transport: "tcp",
+    hostname: "127.0.0.1",
+  });
+  return request;
+}
+
+function withProxyTopologyEnv<T>(value: string | undefined, fn: () => T): T {
+  const original = getEnv(TRUST_FORWARDED_HEADERS_ENV);
+  if (value === undefined) deleteEnv(TRUST_FORWARDED_HEADERS_ENV);
+  else setEnv(TRUST_FORWARDED_HEADERS_ENV, value);
+  try {
+    return fn();
+  } finally {
+    if (original === undefined) deleteEnv(TRUST_FORWARDED_HEADERS_ENV);
+    else setEnv(TRUST_FORWARDED_HEADERS_ENV, original);
+  }
+}
+
+describe("local control request default proxy topology arm", () => {
+  it("consults the process proxy topology when the caller states no preference", () => {
+    withProxyTopologyEnv(undefined, () => {
+      assertEquals(
+        isTrustedLocalControlRequest(loopbackRequest()),
+        true,
+        "an untrusted proxy topology must admit a transport-authenticated loopback peer by default",
+      );
+    });
+
+    withProxyTopologyEnv("1", () => {
+      assertEquals(
+        isTrustedLocalControlRequest(loopbackRequest()),
+        false,
+        "with a trusted proxy topology configured, the default arm must deny local-control admission because a proxied peer can look like loopback",
+      );
+    });
+  });
+});

--- a/tests/integration/security/permission-system.test.ts
+++ b/tests/integration/security/permission-system.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Integration coverage for the sandbox permission system's fail-closed branches.
+ *
+ * These cases cannot live in the colocated unit test at
+ * `src/security/sandbox/permission-system.test.ts`: the module resolves the
+ * runtime permission API through `globalThis.Deno.permissions` on every call
+ * (see `getDenoPermissions()` in `src/security/sandbox/permission-system.ts`),
+ * and deliberately exposes no injection point — `requestPermission` takes only a
+ * `PermissionRequest`, and the module exports no factory or testing hook. That
+ * is intentional for a permission-sensitive module: an overridable permissions
+ * API would itself be a sandbox-escape seam.
+ *
+ * Observing the denied / two-call / throwing-API branches therefore requires
+ * swapping the real `Deno.permissions` global, which is a host (process) effect
+ * and is only permitted at the integration level. The suite itself runs under
+ * --allow-all, where those branches never trigger on their own.
+ */
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { isDeno } from "#veryfront/platform/compat/runtime.ts";
+import {
+  type Permission,
+  type PermissionResult,
+  requestPermission,
+} from "#veryfront/security/sandbox/permission-system.ts";
+
+const denoOnlyIt = isDeno ? it : it.skip;
+
+type StubbedDescriptor = { name: string; host?: string; path?: string };
+
+/**
+ * Swap the runtime permission API for a stub so the fail-closed branches can be
+ * observed; the suite itself runs under --allow-all, where they never trigger.
+ */
+async function withStubbedDenoPermissions<T>(
+  request: (descriptor: StubbedDescriptor) => Promise<{ state: PermissionResult["state"] }>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const deno = (globalThis as { Deno?: Record<string, unknown> }).Deno!;
+  const original = Object.getOwnPropertyDescriptor(deno, "permissions");
+  Object.defineProperty(deno, "permissions", {
+    configurable: true,
+    writable: true,
+    enumerable: true,
+    value: { request },
+  });
+
+  try {
+    return await fn();
+  } finally {
+    if (original) {
+      Object.defineProperty(deno, "permissions", original);
+    } else {
+      delete deno.permissions;
+    }
+  }
+}
+
+describe("Permission System (runtime permission API)", () => {
+  denoOnlyIt("fs fails closed when read is denied", async () => {
+    const asked: string[] = [];
+
+    await withStubbedDenoPermissions(
+      (descriptor) => {
+        asked.push(descriptor.name);
+        return Promise.resolve({
+          state: descriptor.name === "read" ? "denied" as const : "granted" as const,
+        });
+      },
+      async () => {
+        const result = await requestPermission({ name: "fs", path: "/tmp" });
+        assertEquals(result.state, "denied", "fs must report the denied read status");
+        assertEquals(asked, ["read"], "fs must not request write once read is denied");
+      },
+    );
+  });
+
+  denoOnlyIt("fs reports the write status once read is granted", async () => {
+    const asked: string[] = [];
+
+    await withStubbedDenoPermissions(
+      (descriptor) => {
+        asked.push(descriptor.name);
+        return Promise.resolve({
+          state: descriptor.name === "read" ? "granted" as const : "denied" as const,
+        });
+      },
+      async () => {
+        const result = await requestPermission({ name: "fs", path: "/tmp" });
+        assertEquals(result.state, "denied", "fs must report the denied write status");
+        assertEquals(
+          asked,
+          ["read", "write"],
+          "fs must request read first and only then write",
+        );
+      },
+    );
+  });
+
+  denoOnlyIt(
+    "an off-contract permission name never reaches the runtime permission API",
+    async () => {
+      const asked: StubbedDescriptor[] = [];
+
+      await withStubbedDenoPermissions(
+        (descriptor) => {
+          asked.push(descriptor);
+          return Promise.resolve({ state: "granted" as const });
+        },
+        async () => {
+          for (const name of ["sys", "ffi", "import"]) {
+            const result = await requestPermission({ name: name as Permission });
+            assertEquals(
+              result.state,
+              "denied",
+              `${name} is outside this module's contract and must be denied, never forwarded to the runtime permission API`,
+            );
+          }
+
+          assertEquals(
+            asked,
+            [],
+            "an off-contract permission name must never reach the runtime permission API",
+          );
+        },
+      );
+    },
+  );
+
+  denoOnlyIt("fails closed when the permission API throws", async () => {
+    await withStubbedDenoPermissions(
+      () => {
+        throw new Error("permission API unavailable");
+      },
+      async () => {
+        assertEquals(
+          (await requestPermission({ name: "net" })).state,
+          "denied",
+          "a throwing permission API must fail closed rather than auto-granting",
+        );
+        assertEquals(
+          (await requestPermission({ name: "fs", path: "/tmp" })).state,
+          "denied",
+          "the two-call fs path must fail closed on a throwing permission API too",
+        );
+      },
+    );
+  });
+});

--- a/tests/integration/security/sandbox-runtime-guard.test.ts
+++ b/tests/integration/security/sandbox-runtime-guard.test.ts
@@ -1,3 +1,4 @@
+// @veryfront-test runtime-guarded-deno
 /**
  * SEC-008 end-to-end runtime guard for `runInWorker`.
  *

--- a/tests/integration/security/sandbox-runtime-guard.test.ts
+++ b/tests/integration/security/sandbox-runtime-guard.test.ts
@@ -1,0 +1,77 @@
+/**
+ * SEC-008 end-to-end runtime guard for `runInWorker`.
+ *
+ * Why this cannot be a colocated unit test: `runInWorker` reads the operator
+ * opt-in through `getHostEnv(...)` inline (src/security/sandbox/deno-sandbox.ts:113,
+ * :125) and branches on the module-level `isNode` / `isBun` constants.
+ * `SandboxOptions` carries no env or runtime override and the module exports no
+ * testing seam, so pinning "the guard actually fires when the env var is absent"
+ * requires deleting the variable from the real host environment — a `process`
+ * effect that the semantic unit-boundary ratchet forbids under src/.
+ *
+ * The pure decision helpers (`isNodeSandboxAllowedUnsafe` /
+ * `isBunSandboxAllowedUnsafe`) stay covered hermetically in
+ * src/security/sandbox/deno-sandbox.test.ts; only the wiring lives here.
+ *
+ * These cases are runtime-gated: they assert behaviour that only exists on
+ * Node.js and Bun, so they skip under Deno.
+ */
+
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { isBun, isNode } from "#veryfront/platform/compat/runtime.ts";
+import { deleteEnv, getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
+import { NOT_SUPPORTED, VeryfrontError } from "#veryfront/errors";
+import {
+  BUN_SANDBOX_ALLOW_UNSAFE_ENV,
+  NODE_SANDBOX_ALLOW_UNSAFE_ENV,
+  runInWorker,
+} from "#veryfront/security/sandbox/deno-sandbox.ts";
+
+const nodeOnlyIt = isNode ? it : it.skip;
+const bunOnlyIt = isBun ? it : it.skip;
+
+/** Run `fn` with `name` absent from the host environment, then restore it. */
+async function withoutHostEnv<T>(name: string, fn: () => Promise<T>): Promise<T> {
+  const previous = getHostEnv(name);
+  deleteEnv(name);
+  try {
+    return await fn();
+  } finally {
+    if (previous !== undefined) setEnv(name, previous);
+  }
+}
+
+describe("sandbox runtime opt-in guard (SEC-008)", () => {
+  nodeOnlyIt("refuses execution on Node.js without the opt-in env var", async () => {
+    await withoutHostEnv(NODE_SANDBOX_ALLOW_UNSAFE_ENV, async () => {
+      const error = await assertRejects(
+        () => runInWorker("return 1;"),
+        VeryfrontError,
+        "not safely supported on Node.js",
+        "valid code must still be refused on Node.js without an operator opt-in",
+      ) as VeryfrontError;
+      assertEquals(
+        error.slug,
+        NOT_SUPPORTED.slug,
+        "the Node sandbox guard must fail closed with the registered NOT_SUPPORTED identity",
+      );
+    });
+  });
+
+  bunOnlyIt("refuses execution on Bun without the opt-in env var", async () => {
+    await withoutHostEnv(BUN_SANDBOX_ALLOW_UNSAFE_ENV, async () => {
+      const error = await assertRejects(
+        () => runInWorker("return 1;"),
+        VeryfrontError,
+        "not safely supported on Bun",
+        "valid code must still be refused on Bun without an operator opt-in",
+      ) as VeryfrontError;
+      assertEquals(
+        error.slug,
+        NOT_SUPPORTED.slug,
+        "the Bun sandbox guard must fail closed with the registered NOT_SUPPORTED identity",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Audit of all 62 test files under `src/security` for tests that stay green when the behavior they claim to cover breaks.

The bar for every change: name a concrete source edit that breaks documented behavior yet leaves the test passing. Every change was **mutation checked** — the named edit was applied, the test confirmed to fail, then the edit reverted.

53 candidate findings, 48 confirmed after adversarial verification, 50 applied, 5 refuted.

**No product defects were found.** Every mutation check showed the implementation already correct and only the test blind to it. That is the useful result for a module like this one: the guards work, but a regression in several of them would not have been caught. **Test files only, no source changes.**

## Guards that were implemented but unasserted

**Path prefix confusion.** Nothing pinned that `/project-secrets/creds.env` is outside `/project`. Replacing the boundary check with a raw `startsWith` now fails.

**CORS missing-origin denial.** A null request origin was never exercised, so replacing the branch with an unconditional `corsResult("*", false)` passed. Now denied under both allowlist and string-origin policies.

**Egress broker token gate.** Missing and wrong tokens now assert 403, the egress error header, a body containing "authentication failed", and that the upstream received **zero hits**, so deleting the constant-time token comparison fails.

**Worker diagnostic redaction and bounds.** A credentialed postgres URL plus overlong filler through `message`, `detail`, `cause` and `instance` now asserts each field is redacted, does not contain the secret, and is length bounded.

**Worker status fail-closed.** Out-of-range, non-integer and string statuses (`200`, `999`, `429.5`, `"429"`, `NaN`, `MAX_SAFE_INTEGER + 2`) now assert a plain `Error`, with a positive companion confirming `429` still yields a `VeryfrontError`.

**Restricted workflow permissions** are pinned exhaustively, so appending `--allow-all` fails.

**Base64 chunk boundary.** The old case compared the encoder against itself, which passes for any self-consistent encoder. It now decodes independently with `atob()` and compares every byte.

**Form validation and per-file upload limits**, neither previously reached.

**Bootstrap import order** is asserted positionally, so moving the host env preload after project modules fails.

## Test placement

Four files became effect-bearing units and tripped `lint:test-semantic-dispositions`. Per the repo rule, **none was added to the migration list**.

Each resolves a dev-mode or proxy-topology decision through a module-private host read with no injectable seam — `isDevMode()` reads `globalThis.__VERYFRONT_DEV__` and `Deno.env` inline; `isProxyTopologyTrusted()` reads `getHostEnv` with no override. Adding a production API purely to satisfy the ratchet would be the wrong trade, so only the offending cases **moved** to `tests/integration`, keeping every assertion and message verbatim.

Both arms of each branch remain covered: the hermetic arm stays in the unit file with a pointer comment. The relocated `local-control-request` case is now **stronger** than before, pinning both arms explicitly instead of leaving the untrusted arm dependent on ambient environment.

## Verification

- Semantic unit-boundary audit: ok (2144 considered, 757 disposed)
- `test:layout`: ok
- `deno fmt`, `deno lint`: pass
- **41/41** changed test files pass via `deno task test:file`
- `anti-slop`, `cwd-relative-test-reads`, `test-typecheck`, `sanitizer-baseline`, `skipped-tests`, `ban-test-only`: all pass

No test was deleted, skipped, or weakened. No sanitizer opt-out was added.