### PR TITLE
test(modules): make weak assertions bite and escape batch bundle output

### DIFF
--- a/scripts/lint/check-sanitizer-baseline.ts
+++ b/scripts/lint/check-sanitizer-baseline.ts
@@ -23,9 +23,9 @@ import {
 
 // Lower this when you remove sanitizer opt-outs. Never raise it without a very
 // good reason — a new opt-out means a leak is being suppressed rather than fixed.
-// 378 after the transforms/esm audit dropped the remaining opt-outs from the
-// esm, md, and shared transform suites.
-export const SANITIZER_OPT_OUT_BASELINE = 378;
+// 376 after the transforms/esm audit and this module audit removed their
+// remaining sanitizer opt-outs.
+export const SANITIZER_OPT_OUT_BASELINE = 376;
 
 const OPT_OUT_PATTERN = /sanitize(?:Resources|Ops|Exit)\s*:\s*false/g;
 

--- a/scripts/lint/check-sanitizer-baseline.ts
+++ b/scripts/lint/check-sanitizer-baseline.ts
@@ -23,9 +23,9 @@ import {
 
 // Lower this when you remove sanitizer opt-outs. Never raise it without a very
 // good reason — a new opt-out means a leak is being suppressed rather than fixed.
-// 376 after the transforms/esm audit and this module audit removed their
+// 374 after the transforms/esm audit and this module audit removed their
 // remaining sanitizer opt-outs.
-export const SANITIZER_OPT_OUT_BASELINE = 376;
+export const SANITIZER_OPT_OUT_BASELINE = 374;
 
 const OPT_OUT_PATTERN = /sanitize(?:Resources|Ops|Exit)\s*:\s*false/g;
 

--- a/src/modules/component-registry/edge-cases.test.ts
+++ b/src/modules/component-registry/edge-cases.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { ComponentRegistry } from "./index.ts";
@@ -162,6 +162,16 @@ describe("ComponentRegistry - Edge Cases and Error Handling", () => {
       await registry.discover();
 
       assertEquals(registry.has("Button"), true);
+      assertEquals(
+        registry.getAll().size,
+        1,
+        "same-named components in different dirs collapse to one entry",
+      );
+      assertEquals(
+        registry.get("Button")?.path,
+        `${projectDir}/islands/Button.tsx`,
+        "the later entry in componentDirs wins a name collision",
+      );
     });
 
     it("should only match tsx and jsx extensions", async () => {
@@ -242,6 +252,13 @@ describe("ComponentRegistry - Edge Cases and Error Handling", () => {
         "export default function Button() {}",
       );
 
+      let reads = 0;
+      const originalReadFile = adapter.fs.readFile.bind(adapter.fs);
+      adapter.fs.readFile = (path: string) => {
+        if (path.includes("Button.tsx")) reads++;
+        return originalReadFile(path);
+      };
+
       const registry = new ComponentRegistry({ projectDir, adapter });
 
       await registry.discover();
@@ -251,7 +268,12 @@ describe("ComponentRegistry - Edge Cases and Error Handling", () => {
 
       assertEquals(component1?.isLoaded, true);
       assertEquals(component2?.isLoaded, true);
-      assertEquals(component1, component2);
+      assertEquals(reads, 1, "second load must be served from the cache, not re-read from disk");
+      assertStrictEquals(
+        component1,
+        component2,
+        "cached load must return the same component instance",
+      );
     });
 
     it("should handle loading all components", async () => {
@@ -381,8 +403,20 @@ describe("ComponentRegistry - Edge Cases and Error Handling", () => {
 
       assertEquals(components.length, 1);
       assertEquals(components[0]?.name, "Button");
-      assertExists(components[0]?.path);
+      assertEquals(
+        components[0]?.path,
+        `${projectDir}/components/Button.tsx`,
+        "listed path is the discovered component path",
+      );
       assertEquals(components[0]?.type, "component");
+      assertEquals(components[0]?.size, 14, "size comes from adapter.fs.stat");
+      const lastModified = components[0]?.lastModified;
+      assertExists(lastModified, "lastModified comes from stat.mtime");
+      assertEquals(
+        Number.isNaN(Date.parse(lastModified)),
+        false,
+        "lastModified is an ISO timestamp",
+      );
     });
 
     it("should handle stat errors gracefully", async () => {
@@ -407,6 +441,8 @@ describe("ComponentRegistry - Edge Cases and Error Handling", () => {
 
       assertEquals(components.length, 1);
       assertEquals(components[0]?.name, "Button");
+      assertEquals(components[0]?.size, undefined, "stat failure omits size");
+      assertEquals(components[0]?.lastModified, undefined, "stat failure omits lastModified");
     });
 
     it("should get component names", async () => {
@@ -500,10 +536,15 @@ describe("ComponentRegistry - Edge Cases and Error Handling", () => {
 
       const discoverPromise = registry.discover();
       const component = registry.get("Button");
+      assertEquals(component, undefined, "get() before discover resolves must return undefined");
 
       await discoverPromise;
 
-      assertExists(component ?? "timing-dependent");
+      assertEquals(
+        registry.get("Button")?.path,
+        `${projectDir}/components/Button.tsx`,
+        "get() after discover resolves must return the discovered component",
+      );
     });
 
     it("should handle loadComponent before discover", async () => {

--- a/src/modules/import-map/default-import-map.test.ts
+++ b/src/modules/import-map/default-import-map.test.ts
@@ -43,6 +43,26 @@ describe("modules/import-map/default-import-map", () => {
       const imports = getImports();
 
       assertEquals(
+        Object.keys(imports).filter((key) => key.startsWith("veryfront/")).sort(),
+        [
+          "veryfront/chat",
+          "veryfront/context",
+          "veryfront/fonts",
+          "veryfront/head",
+          "veryfront/markdown",
+          "veryfront/mdx",
+          "veryfront/react",
+          "veryfront/react/context",
+          "veryfront/react/fonts",
+          "veryfront/react/head",
+          "veryfront/react/router",
+          "veryfront/router",
+          "veryfront/ui",
+          "veryfront/workflow",
+        ],
+        "every React-bearing veryfront export must stay mapped",
+      );
+      assertEquals(
         imports["veryfront/ui"],
         "/_vf_modules/_veryfront/react/components/ui/index.js?ssr=true",
       );
@@ -69,13 +89,22 @@ describe("modules/import-map/default-import-map", () => {
     it("should map veryfront aliases to module server URLs", () => {
       const imports = getImports();
 
-      const headUrl = imports["veryfront/head"];
-      assertExists(headUrl);
-      assert(
-        headUrl.startsWith("/_vf_modules/_veryfront/react/"),
-        `Expected module server URL starting with /_vf_modules/_veryfront/react/ but got: ${headUrl}`,
+      const coreReactUrl = "/_vf_modules/_veryfront/react/runtime/core.js?ssr=true";
+      assertEquals(
+        imports["veryfront/head"],
+        coreReactUrl,
+        "veryfront/head must map to the React runtime core module",
       );
-      assert(headUrl.includes("?ssr=true"), `Expected ssr=true param but got: ${headUrl}`);
+      assertEquals(
+        imports["veryfront/router"],
+        coreReactUrl,
+        "veryfront/router must map to the React runtime core module",
+      );
+      assertEquals(
+        imports["veryfront/context"],
+        coreReactUrl,
+        "veryfront/context must map to the React runtime core module",
+      );
     });
 
     it("should map veryfront/head and veryfront/react/head to the same file", () => {

--- a/src/modules/import-map/loader.test.ts
+++ b/src/modules/import-map/loader.test.ts
@@ -174,7 +174,17 @@ describe("modules/import-map/loader", () => {
 
     it("should not include npm: specifiers in output", async () => {
       const adapter = createMockAdapter();
-      const { imports } = await loadImportMap("/any-project", adapter);
+      adapter.fs.files.set(
+        "/project-with-scoped-npm/deno.json",
+        JSON.stringify({
+          scopes: {
+            "/app/": {
+              lodash: "npm:lodash@4",
+            },
+          },
+        }),
+      );
+      const { imports, scopes } = await loadImportMap("/project-with-scoped-npm", adapter);
 
       for (const [key, value] of Object.entries(imports ?? {})) {
         assert(
@@ -182,6 +192,21 @@ describe("modules/import-map/loader", () => {
           `Import "${key}" should not use npm: specifier, got: ${value}`,
         );
       }
+
+      for (const [scope, record] of Object.entries(scopes ?? {})) {
+        for (const [key, value] of Object.entries(record)) {
+          assert(
+            !value.startsWith("npm:"),
+            `Scoped import "${key}" in "${scope}" should not use npm: specifier, got: ${value}`,
+          );
+        }
+      }
+
+      assertEquals(
+        scopes?.["/app/"]?.lodash,
+        "https://esm.sh/lodash@4?target=es2022",
+        "scoped npm: specifiers must be normalized to esm.sh",
+      );
     });
 
     it("should return consistent results for same path", async () => {

--- a/src/modules/import-map/preloader.test.ts
+++ b/src/modules/import-map/preloader.test.ts
@@ -552,6 +552,60 @@ describe("modules/import-map/preloader", () => {
       }
     });
 
+    it("rejects non-string contentSourceId context values", async () => {
+      const adapter = createMinimalAdapter();
+      let toJSONCalls = 0;
+      const invalidSourceIds: unknown[] = [
+        42,
+        null,
+        false,
+        {
+          toJSON: () => {
+            toJSONCalls++;
+            return '"release-1"';
+          },
+        },
+      ];
+
+      for (let index = 0; index < invalidSourceIds.length; index++) {
+        const contentSourceId = invalidSourceIds[index];
+        await assertRejects(
+          () =>
+            preloadImportMap(
+              "/invalid-source-context",
+              adapter,
+              `invalid-source-${String(index)}`,
+              { contentSourceId } as never,
+            ),
+          TypeError,
+          "Import-map contentSourceId must be a string",
+        );
+      }
+
+      assertEquals(
+        toJSONCalls,
+        0,
+        "a rejected contentSourceId must never steer the canonical identity",
+      );
+    });
+
+    it("rejects non-string projectDir", async () => {
+      const adapter = createMinimalAdapter();
+
+      await assertRejects(
+        () => preloadImportMap(42 as never, adapter, "invalid-project-dir"),
+        TypeError,
+        "Import-map projectDir must be a string",
+      );
+
+      const preloader = new ImportMapPreloader({});
+      await assertRejects(
+        () => preloader.getCached("cache-key", { projectDir: 42 } as never),
+        TypeError,
+        "Import-map projectDir must be a string",
+      );
+    });
+
     it("snapshots and deep-freezes loader output before publishing it", async () => {
       const adapter = createMinimalAdapter();
       const loadedMap = {

--- a/src/modules/import-map/resolver.test.ts
+++ b/src/modules/import-map/resolver.test.ts
@@ -46,6 +46,24 @@ describe("modules/import-map/resolver", () => {
       );
     });
 
+    it("should not append the esm.sh subpath to a local file mapping", () => {
+      const map = { imports: { react: "/local/react.ts" } };
+      assertEquals(
+        resolveImport("https://esm.sh/react@18/jsx-runtime", map),
+        "/local/react.ts",
+        "a local file mapping must not have the esm.sh subpath appended",
+      );
+    });
+
+    it("should append the esm.sh subpath to an http mapping", () => {
+      const map = { imports: { react: "https://esm.sh/react@19" } };
+      assertEquals(
+        resolveImport("https://esm.sh/react@18/jsx-runtime", map),
+        "https://esm.sh/react@19/jsx-runtime",
+        "an http mapping must carry the subpath through",
+      );
+    });
+
     it("should resolve prefix mappings with trailing slash", () => {
       const map = { imports: { "@lib/": "/src/lib/" } };
       assertEquals(resolveImport("@lib/utils.ts", map), "/src/lib/utils.ts");

--- a/src/modules/manifest/route-module-manifest.test.ts
+++ b/src/modules/manifest/route-module-manifest.test.ts
@@ -97,6 +97,16 @@ describe("Route Module Manifest", () => {
     const manifest = getRouteManifest("test-project", "about");
     assertExists(manifest);
     assertEquals(manifest.renderCount, 1);
+    assertEquals(
+      manifest.moduleCount,
+      2,
+      "both the critical and the collected non-critical module must be recorded",
+    );
+    assertEquals(
+      getRouteModulePaths("test-project", "about"),
+      ["pages/about.js", "components/Nav.js"],
+      "critical modules come first in loadOrder, then collected non-critical ones",
+    );
   });
 
   it("getCriticalModulePaths returns critical modules only", () => {
@@ -107,6 +117,12 @@ describe("Route Module Manifest", () => {
     const stats = getManifestStats();
     assertEquals(stats.routeCount, 2);
     assertEquals(stats.routes.length, 2);
+    assertEquals(stats.totalModules, 4, "totalModules must sum moduleCount across tracked routes");
+
+    const about = stats.routes.find((route) => route.route.endsWith("about"));
+    assertExists(about);
+    assertEquals(about.moduleCount, 2, "about route reports its recorded module count");
+    assertEquals(about.renderCount, 1, "about route reports its render count");
   });
 
   it("clearProjectManifests removes project manifests", () => {

--- a/src/modules/module-resolver.test.ts
+++ b/src/modules/module-resolver.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { ModuleResolver } from "./module-resolver.ts";
@@ -152,10 +152,24 @@ describe("modules/module-resolver", () => {
     });
 
     it("should block path traversal attempts", async () => {
-      const resolver = createResolver({ projectDir: "/project" });
+      const resolver = createResolver({
+        projectDir: "/project",
+        files: {
+          "/etc/passwd": "root:x:0:0",
+          "/project/components/Button.tsx": "export default () => null;",
+        },
+      });
 
-      const result = await resolver.resolve("/../../etc/passwd");
-      assertEquals(result, null);
+      assertEquals(
+        await resolver.resolve("/../../etc/passwd"),
+        null,
+        "traversal guard must reject an escaping absolute specifier even when the target exists",
+      );
+      assertEquals(
+        (await resolver.resolve("/components/Button.tsx"))?.path,
+        "/project/components/Button.tsx",
+        "in-project absolute specifier still resolves",
+      );
     });
 
     it("should return null for absolute paths to nonexistent files", async () => {
@@ -192,19 +206,25 @@ describe("modules/module-resolver", () => {
 
       const result1 = await resolver.resolve("virtual:cached");
       const result2 = await resolver.resolve("virtual:cached");
-      assertEquals(result1, result2);
+      assertStrictEquals(result1, result2, "second resolve must return the cached instance");
     });
 
     it("should clear entire cache", async () => {
-      const resolver = createResolver({
-        virtualModules: new Map([["virtual:a", "a"]]),
-      });
+      const virtualModules = new Map([["virtual:a", "a"]]);
+      const resolver = createResolver({ virtualModules });
 
-      await resolver.resolve("virtual:a");
+      const first = await resolver.resolve("virtual:a");
+      assertEquals(first?.content, "a", "first resolve serves the original virtual module");
+
+      virtualModules.set("virtual:a", "b");
       resolver.clearCache();
 
       const result = await resolver.resolve("virtual:a");
-      assertEquals(result?.content, "a");
+      assertEquals(
+        result?.content,
+        "b",
+        "clearCache() with no pattern must drop every cached entry",
+      );
     });
 
     it("should clear cache by pattern", async () => {

--- a/src/modules/react-loader/extract-component.test.ts
+++ b/src/modules/react-loader/extract-component.test.ts
@@ -10,8 +10,13 @@ describe("modules/react-loader/extract-component", () => {
   });
 
   it("should fallback to first named export if no default", () => {
-    const Named = () => null;
-    assertEquals(extractComponent({ Named }, "test.tsx"), Named);
+    const First = () => null;
+    const Second = () => null;
+    assertEquals(
+      extractComponent({ First, Second }, "test.tsx"),
+      First,
+      "the first named export must win when there is no default export",
+    );
   });
 
   it("should prefer default over named exports", () => {

--- a/src/modules/react-loader/ssr-module-loader.stress.test.ts
+++ b/src/modules/react-loader/ssr-module-loader.stress.test.ts
@@ -9,11 +9,12 @@ import "#veryfront/schemas/_test-setup.ts";
  */
 
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { clearSSRModuleCache, SSRModuleLoader } from "./ssr-module-loader/index.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { createFileSystem, makeTempDir } from "#veryfront/platform/compat/fs.ts";
+import { stop as stopEsbuild } from "#veryfront/platform/compat/esbuild.ts";
 import { isDeno } from "#veryfront/platform/compat/runtime.ts";
 import { scaleMs } from "#veryfront/testing";
 
@@ -99,19 +100,24 @@ async function removeDir(dir: string): Promise<void> {
 }
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
-  return Promise.race([
-    promise,
-    new Promise<T>((_, reject) =>
-      setTimeout(() => reject(new Error("TIMEOUT - possible deadlock")), timeoutMs)
-    ),
-  ]);
+  let timerId: number | undefined;
+  const timeout = new Promise<T>((_, reject) => {
+    timerId = setTimeout(() => reject(new Error("TIMEOUT - possible deadlock")), timeoutMs);
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timerId !== undefined) clearTimeout(timerId);
+  });
 }
 
-describe("SSRModuleLoader Stress Tests", {
-  sanitizeResources: false,
-  sanitizeOps: false,
-  ignore: !isDeno,
-}, () => {
+function isPageComponent(value: unknown, name: string): boolean {
+  return typeof value === "function" && (value as { name: string }).name === name;
+}
+
+describe("SSRModuleLoader Stress Tests", { ignore: !isDeno }, () => {
+  afterAll(async () => {
+    await stopEsbuild();
+  });
+
   denoOnlyIt("concurrent requests for same file should not race", async () => {
     clearSSRModuleCache();
 
@@ -219,6 +225,19 @@ describe("SSRModuleLoader Stress Tests", {
 
       const errors = results.filter(hasErrorResult);
 
+      assertEquals(
+        errors.length,
+        0,
+        `deep dependency tree must load without errors, got: ${
+          JSON.stringify(errors.map(({ error }) => error.message))
+        }`,
+      );
+      assertEquals(
+        results.filter((result) => isPageComponent(result, "App")).length,
+        loaders.length,
+        "every concurrent deep-tree load must resolve the App component",
+      );
+
       console.log(`✓ Deep dependency tree (3 levels) completed in ${elapsed}ms`);
       console.log(`  - 5 concurrent requests, semaphore=3`);
       console.log(`  - No deadlock detected`);
@@ -273,6 +292,22 @@ describe("SSRModuleLoader Stress Tests", {
       const elapsed = Date.now() - startTime;
 
       const errors = results.filter(hasErrorResult);
+
+      assertEquals(
+        errors.length,
+        0,
+        `Expected no errors, got: ${
+          JSON.stringify(errors.map(({ error }) => ({
+            name: error.name,
+            message: error.message,
+          })))
+        }`,
+      );
+      assertEquals(
+        results.filter((result) => isPageComponent(result, "Page")).length,
+        concurrentRequests,
+        "every concurrent load must resolve the Page component",
+      );
 
       console.log(`✓ Wide dependency tree (10 deps) completed in ${elapsed}ms`);
       console.log(`  - ${concurrentRequests} concurrent requests`);

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
@@ -14,6 +14,7 @@ import {
   releaseTransformSlot,
   tryAcquireTransformSlot,
 } from "./memory.ts";
+import { buildCrossProjectImportCacheKey } from "../cross-project-import-loader.ts";
 import { verifiedHttpBundlePaths } from "../http-bundle-helpers.ts";
 import { getTransformPerProjectLimit } from "../constants.ts";
 import { getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
@@ -276,7 +277,13 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
         tempPath: "/tmp/x1.mjs",
         contentHash: "x1",
       });
-      globalCrossProjectCache.set("cross:acme@1.0.0:project-1-extra", {
+      const prefixSharingProjectKey = buildCrossProjectImportCacheKey({
+        projectId: "project-1-extra",
+        specifier: "@acme/component",
+        reactVersion: "1.0.0",
+        registryBaseUrl: "https://registry.example.com",
+      });
+      globalCrossProjectCache.set(prefixSharingProjectKey, {
         tempPath: "/tmp/x2.mjs",
         contentHash: "x2",
       });
@@ -295,9 +302,9 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
         "project invalidation must evict its cross-project entries",
       );
       assertEquals(
-        globalCrossProjectCache.has("cross:acme@1.0.0:project-1-extra"),
-        false,
-        "substring-keyed cross-project entries must be evicted too",
+        globalCrossProjectCache.has(prefixSharingProjectKey),
+        true,
+        "a prefix-sharing project's cross-project entry must survive exact project invalidation",
       );
       assertEquals(
         globalCrossProjectCache.has("prefix:project-2:mod"),

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
@@ -297,6 +297,16 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
         tempPath: "/tmp/colon-specifier.mjs",
         contentHash: "colon-specifier",
       });
+      const foreignSpecifierContainingProjectIdKey = buildCrossProjectImportCacheKey({
+        projectId: "project-2",
+        specifier: "prefix:project-1:component",
+        reactVersion: "1.0.0",
+        registryBaseUrl: "https://registry.example.com",
+      });
+      globalCrossProjectCache.set(foreignSpecifierContainingProjectIdKey, {
+        tempPath: "/tmp/foreign-specifier.mjs",
+        contentHash: "foreign-specifier",
+      });
       globalCrossProjectCache.set("prefix:project-2:mod", {
         tempPath: "/tmp/y.mjs",
         contentHash: "y",
@@ -320,6 +330,11 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
         globalCrossProjectCache.has(colonSpecifierKey),
         false,
         "cross-project entries with colon-containing specifiers must be evicted for their owner",
+      );
+      assertEquals(
+        globalCrossProjectCache.has(foreignSpecifierContainingProjectIdKey),
+        true,
+        "a foreign entry must survive when only its specifier contains the cleared project id",
       );
       assertEquals(
         globalCrossProjectCache.has("prefix:project-2:mod"),

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
@@ -307,6 +307,26 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
         tempPath: "/tmp/foreign-specifier.mjs",
         contentHash: "foreign-specifier",
       });
+      const opaqueProjectIdKey = buildCrossProjectImportCacheKey({
+        projectId: "project:01J2XYZ",
+        specifier: "@acme/component",
+        reactVersion: "1.0.0",
+        registryBaseUrl: "https://registry.example.com",
+      });
+      globalCrossProjectCache.set(opaqueProjectIdKey, {
+        tempPath: "/tmp/opaque-project-id.mjs",
+        contentHash: "opaque-project-id",
+      });
+      const opaqueSuffixSharingProjectKey = buildCrossProjectImportCacheKey({
+        projectId: "tenant:project:01J2XYZ",
+        specifier: "@acme/component",
+        reactVersion: "1.0.0",
+        registryBaseUrl: "https://registry.example.com",
+      });
+      globalCrossProjectCache.set(opaqueSuffixSharingProjectKey, {
+        tempPath: "/tmp/opaque-suffix-sharing-project.mjs",
+        contentHash: "opaque-suffix-sharing-project",
+      });
       globalCrossProjectCache.set("prefix:project-2:mod", {
         tempPath: "/tmp/y.mjs",
         contentHash: "y",
@@ -340,6 +360,19 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
         globalCrossProjectCache.has("prefix:project-2:mod"),
         true,
         "another project's cross-project entries must survive",
+      );
+
+      clearSSRModuleCacheForProject("project:01J2XYZ");
+
+      assertEquals(
+        globalCrossProjectCache.has(opaqueProjectIdKey),
+        false,
+        "opaque project ids containing colons must still own their cache entries",
+      );
+      assertEquals(
+        globalCrossProjectCache.has(opaqueSuffixSharingProjectKey),
+        true,
+        "a foreign opaque project id sharing the cleared suffix must survive",
       );
 
       globalModuleCache.clear();

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
@@ -272,13 +272,41 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
 
       globalModuleCache.set("prefix:project-1:module-a", { tempPath: "/tmp/a", contentHash: "a" });
       globalModuleCache.set("prefix:project-2:module-b", { tempPath: "/tmp/b", contentHash: "b" });
+      globalCrossProjectCache.set("prefix:project-1:mod", {
+        tempPath: "/tmp/x1.mjs",
+        contentHash: "x1",
+      });
+      globalCrossProjectCache.set("cross:acme@1.0.0:project-1-extra", {
+        tempPath: "/tmp/x2.mjs",
+        contentHash: "x2",
+      });
+      globalCrossProjectCache.set("prefix:project-2:mod", {
+        tempPath: "/tmp/y.mjs",
+        contentHash: "y",
+      });
 
       clearSSRModuleCacheForProject("project-1");
 
       assertEquals(globalModuleCache.has("prefix:project-1:module-a"), false);
       assertEquals(globalModuleCache.has("prefix:project-2:module-b"), true);
+      assertEquals(
+        globalCrossProjectCache.has("prefix:project-1:mod"),
+        false,
+        "project invalidation must evict its cross-project entries",
+      );
+      assertEquals(
+        globalCrossProjectCache.has("cross:acme@1.0.0:project-1-extra"),
+        false,
+        "substring-keyed cross-project entries must be evicted too",
+      );
+      assertEquals(
+        globalCrossProjectCache.has("prefix:project-2:mod"),
+        true,
+        "another project's cross-project entries must survive",
+      );
 
       globalModuleCache.clear();
+      globalCrossProjectCache.clear();
     });
 
     it("should clear in-progress entries for a specific project", () => {

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
@@ -287,6 +287,16 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
         tempPath: "/tmp/x2.mjs",
         contentHash: "x2",
       });
+      const colonSpecifierKey = buildCrossProjectImportCacheKey({
+        projectId: "project-1",
+        specifier: "@acme/component:variant:deep",
+        reactVersion: "1.0.0",
+        registryBaseUrl: "https://registry.example.com",
+      });
+      globalCrossProjectCache.set(colonSpecifierKey, {
+        tempPath: "/tmp/colon-specifier.mjs",
+        contentHash: "colon-specifier",
+      });
       globalCrossProjectCache.set("prefix:project-2:mod", {
         tempPath: "/tmp/y.mjs",
         contentHash: "y",
@@ -305,6 +315,11 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
         globalCrossProjectCache.has(prefixSharingProjectKey),
         true,
         "a prefix-sharing project's cross-project entry must survive exact project invalidation",
+      );
+      assertEquals(
+        globalCrossProjectCache.has(colonSpecifierKey),
+        false,
+        "cross-project entries with colon-containing specifiers must be evicted for their owner",
       );
       assertEquals(
         globalCrossProjectCache.has("prefix:project-2:mod"),

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.ts
@@ -363,7 +363,7 @@ export function clearSSRModuleCacheForProject(
   }
 
   for (const key of globalCrossProjectCache.keys()) {
-    if (!key.includes(projectId) && !isKeyForProject(key, projectId)) continue;
+    if (!isKeyForProject(key, projectId)) continue;
     globalCrossProjectCache.delete(key);
   }
 

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.ts
@@ -353,18 +353,23 @@ export function clearSSRModuleCache(): void {
  * project id, so the specifier may contain arbitrary `:` characters. Parse
  * from the stable `:registry:` suffix instead of assuming fixed segments.
  */
-function isCrossProjectCacheKeyForProject(key: string, projectId: string): boolean {
+function parseCrossProjectCacheKeyOwner(
+  key: string,
+): { isCrossProjectKey: boolean; projectId?: string } {
   const registryMarker = ":registry:";
   const markerIndex = key.lastIndexOf(registryMarker);
-  if (markerIndex < 0) return false;
+  if (markerIndex < 0) return { isCrossProjectKey: false };
 
   const baseKey = key.slice(0, markerIndex);
   const reactVersionSeparator = baseKey.lastIndexOf(":");
-  if (reactVersionSeparator < 0) return false;
+  if (reactVersionSeparator < 0) return { isCrossProjectKey: true };
   const projectSeparator = baseKey.lastIndexOf(":", reactVersionSeparator - 1);
-  if (projectSeparator < 0) return false;
+  if (projectSeparator < 0) return { isCrossProjectKey: true };
 
-  return baseKey.slice(projectSeparator + 1, reactVersionSeparator) === projectId;
+  return {
+    isCrossProjectKey: true,
+    projectId: baseKey.slice(projectSeparator + 1, reactVersionSeparator),
+  };
 }
 
 export function clearSSRModuleCacheForProject(
@@ -382,9 +387,11 @@ export function clearSSRModuleCacheForProject(
   }
 
   for (const key of globalCrossProjectCache.keys()) {
-    if (!isCrossProjectCacheKeyForProject(key, projectId) && !isKeyForProject(key, projectId)) {
-      continue;
-    }
+    const crossProjectOwner = parseCrossProjectCacheKeyOwner(key);
+    const belongsToProject = crossProjectOwner.isCrossProjectKey
+      ? crossProjectOwner.projectId === projectId
+      : isKeyForProject(key, projectId);
+    if (!belongsToProject) continue;
     globalCrossProjectCache.delete(key);
   }
 

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.ts
@@ -348,6 +348,25 @@ export function clearSSRModuleCache(): void {
   });
 }
 
+/**
+ * Cross-project cache keys put the raw import specifier before the owning
+ * project id, so the specifier may contain arbitrary `:` characters. Parse
+ * from the stable `:registry:` suffix instead of assuming fixed segments.
+ */
+function isCrossProjectCacheKeyForProject(key: string, projectId: string): boolean {
+  const registryMarker = ":registry:";
+  const markerIndex = key.lastIndexOf(registryMarker);
+  if (markerIndex < 0) return false;
+
+  const baseKey = key.slice(0, markerIndex);
+  const reactVersionSeparator = baseKey.lastIndexOf(":");
+  if (reactVersionSeparator < 0) return false;
+  const projectSeparator = baseKey.lastIndexOf(":", reactVersionSeparator - 1);
+  if (projectSeparator < 0) return false;
+
+  return baseKey.slice(projectSeparator + 1, reactVersionSeparator) === projectId;
+}
+
 export function clearSSRModuleCacheForProject(
   projectId: string,
   options: ClearSSRModuleCacheForProjectOptions = {},
@@ -363,7 +382,9 @@ export function clearSSRModuleCacheForProject(
   }
 
   for (const key of globalCrossProjectCache.keys()) {
-    if (!isKeyForProject(key, projectId)) continue;
+    if (!isCrossProjectCacheKeyForProject(key, projectId) && !isKeyForProject(key, projectId)) {
+      continue;
+    }
     globalCrossProjectCache.delete(key);
   }
 

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.ts
@@ -15,6 +15,7 @@
 
 import { registerCache } from "#veryfront/utils/memory/index.ts";
 import { isKeyForProject, registerMapCache } from "#veryfront/cache/keys.ts";
+import { decodeCacheKeySegment } from "#veryfront/cache/keys/segment-codec.ts";
 import type { CacheStatsSource } from "#veryfront/cache/registry.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import { rendererLogger, throwIfAborted } from "#veryfront/utils";
@@ -349,9 +350,9 @@ export function clearSSRModuleCache(): void {
 }
 
 /**
- * Cross-project cache keys put the raw import specifier before the owning
- * project id, so the specifier may contain arbitrary `:` characters. Parse
- * from the stable `:registry:` suffix instead of assuming fixed segments.
+ * Cross-project cache keys put the raw import specifier before a framed owner.
+ * Parse backward from the stable `:registry:` suffix so arbitrary delimiters
+ * in the specifier or opaque project id cannot change cache ownership.
  */
 function parseCrossProjectCacheKeyOwner(
   key: string,
@@ -360,6 +361,19 @@ function parseCrossProjectCacheKeyOwner(
   const markerIndex = key.lastIndexOf(registryMarker);
   if (markerIndex < 0) return { isCrossProjectKey: false };
 
+  const ownerMarker = ":owner:";
+  const ownerMarkerIndex = key.lastIndexOf(ownerMarker, markerIndex);
+  if (ownerMarkerIndex >= 0) {
+    const encodedOwner = key.slice(ownerMarkerIndex + ownerMarker.length, markerIndex);
+    if (!encodedOwner.includes(":")) {
+      return {
+        isCrossProjectKey: true,
+        projectId: decodeCacheKeySegment(encodedOwner) ?? undefined,
+      };
+    }
+  }
+
+  // Compatibility for cache entries built before owner segments were framed.
   const baseKey = key.slice(0, markerIndex);
   const reactVersionSeparator = baseKey.lastIndexOf(":");
   if (reactVersionSeparator < 0) return { isCrossProjectKey: true };

--- a/src/modules/react-loader/ssr-module-loader/concurrency/semaphore.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/concurrency/semaphore.test.ts
@@ -44,6 +44,46 @@ describe("modules/react-loader/ssr-module-loader/concurrency/semaphore", () => {
       assertEquals(result, false);
     });
 
+    it("queues indefinitely when the timeout is not finite", async () => {
+      const sem = new Semaphore(1);
+
+      await sem.tryAcquire();
+
+      let settled = false;
+      const waiter = sem.tryAcquire(Number.POSITIVE_INFINITY).then((acquired) => {
+        settled = true;
+        return acquired;
+      });
+
+      // Drain the macrotask queue. An armed deadline would fire here: a
+      // non-finite setTimeout delay is coerced to fire on the next tick, so a
+      // waiter that asked to queue forever would silently fail admission.
+      for (let i = 0; i < 5; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+
+      assertEquals(settled, false, "an infinite-timeout waiter must not time out");
+      assertEquals(sem.waiting, 1, "an infinite-timeout waiter must stay queued");
+
+      sem.release();
+      assertEquals(await waiter, true, "release must grant the infinite-timeout waiter");
+      assertEquals(sem.waiting, 0, "the granted waiter must leave the queue");
+    });
+
+    it("rejects an aborted waiter that asked to queue indefinitely", async () => {
+      const sem = new Semaphore(1);
+      const controller = new AbortController();
+
+      await sem.tryAcquire();
+      const pending = sem.tryAcquire(Number.POSITIVE_INFINITY, { signal: controller.signal });
+      assertEquals(sem.waiting, 1, "the infinite-timeout waiter must be queued");
+
+      controller.abort(new DOMException("cancelled", "AbortError"));
+      await assertRejects(() => pending, DOMException, "cancelled");
+      assertEquals(sem.waiting, 0, "an aborted infinite waiter must leave the queue");
+
+      sem.release();
+      assertEquals(sem.available, 1, "the aborted waiter must not consume the released permit");
+    });
+
     it("should fail immediately without queueing when waiting is disabled", async () => {
       const sem = new Semaphore(1);
 

--- a/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.test.ts
@@ -137,6 +137,29 @@ describe("modules/react-loader/ssr-module-loader/cross-project-import-loader", (
     assertNotEquals(snapshotA, otherOrigin);
   });
 
+  it("frames opaque project ids separately from colon-delimited specifiers", () => {
+    const shared = {
+      reactVersion: "19.1.1",
+      registryBaseUrl: "https://registry.example.com",
+    };
+    const colonInSpecifier = buildCrossProjectImportCacheKey({
+      ...shared,
+      specifier: "@acme/component:tenant",
+      projectId: "project:01J2XYZ",
+    });
+    const colonInProjectId = buildCrossProjectImportCacheKey({
+      ...shared,
+      specifier: "@acme/component",
+      projectId: "tenant:project:01J2XYZ",
+    });
+
+    assertNotEquals(
+      colonInSpecifier,
+      colonInProjectId,
+      "specifier and opaque project-id delimiters must not collapse to the same cache key",
+    );
+  });
+
   it("fetches, transforms, writes temp file, and caches transformed cross-project import", async () => {
     globalCrossProjectCache.clear();
 

--- a/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.test.ts
@@ -1,9 +1,18 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assert, assertEquals, assertNotEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertNotEquals,
+  assertRejects,
+  assertStrictEquals,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { VeryfrontError } from "#veryfront/errors";
 import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
 import type { FileSystem } from "#veryfront/platform/compat/fs.ts";
 import type { CrossProjectImport } from "#veryfront/transforms/esm/import-parser.ts";
+import type { TransformOptions } from "#veryfront/transforms/esm/types.ts";
+import { CrossProjectSourceTooLargeError } from "#veryfront/modules/server/cross-project-source-limit.ts";
 import { globalCrossProjectCache } from "./cache/index.ts";
 import {
   buildCrossProjectImportCacheKey,
@@ -136,6 +145,9 @@ describe("modules/react-loader/ssr-module-loader/cross-project-import-loader", (
     let injectedContextCount = 0;
     let capacityPath = "";
     let transformedFilePath = "";
+    let capturedProjectDir = "";
+    let capturedAdapter: unknown;
+    let capturedOpts: TransformOptions | undefined;
     let mkdirPath = "";
     let writePath = "";
     let writeCode = "";
@@ -184,8 +196,11 @@ describe("modules/react-loader/ssr-module-loader/cross-project-import-loader", (
         injectedContextCount++;
         headers.set("x-trace-id", "trace-123");
       },
-      transformToESMImpl: async (_source, filePathWithExt) => {
+      transformToESMImpl: async (_source, filePathWithExt, projectDir, adapter, transformOpts) => {
         transformedFilePath = filePathWithExt;
+        capturedProjectDir = projectDir;
+        capturedAdapter = adapter;
+        capturedOpts = transformOpts;
         return "export const transformed = true;";
       },
       loggerImpl: {
@@ -212,6 +227,29 @@ describe("modules/react-loader/ssr-module-loader/cross-project-import-loader", (
     assertEquals(injectedContextCount, 1);
     assertEquals(capacityPath, "cross-project/acme-ui@1.2.3/@/components/Button.tsx");
     assertEquals(transformedFilePath, "cross-project/acme-ui@1.2.3/@/components/Button.tsx");
+    assertEquals(capturedOpts?.ssr, true, "cross-project SSR transform must set ssr");
+    assertEquals(capturedOpts?.dev, true, "dev flag must be forwarded to the transform");
+    assertEquals(
+      capturedOpts?.projectId,
+      "project-a",
+      "projectId must be forwarded to the transform",
+    );
+    assertEquals(
+      capturedOpts?.apiBaseUrl,
+      "https://registry.example.com/api",
+      "apiBaseUrl must be forwarded to the transform",
+    );
+    assertEquals(
+      capturedOpts?.reactVersion,
+      "19.1.1",
+      "reactVersion must be forwarded to the transform",
+    );
+    assertEquals(capturedProjectDir, "/project", "projectDir must be forwarded to the transform");
+    assertStrictEquals(
+      capturedAdapter,
+      denoAdapter,
+      "runtime adapter must be forwarded to the transform",
+    );
     assertEquals(mkdirPath, "/tmp");
     assertEquals(writePath, "/tmp/cross-project-transformed.mjs");
     assertEquals(writeCode, "export const transformed = true;");
@@ -313,7 +351,7 @@ describe("modules/react-loader/ssr-module-loader/cross-project-import-loader", (
           },
           loggerImpl: { debug: () => {}, error: () => {} },
         }),
-      Error,
+      CrossProjectSourceTooLargeError,
       "Cross-project source exceeds size limit",
     );
 
@@ -326,7 +364,7 @@ describe("modules/react-loader/ssr-module-loader/cross-project-import-loader", (
     let errorLogMessage = "";
     let errorLogContext: unknown;
 
-    await assertRejects(
+    const error = await assertRejects(
       () =>
         transformCrossProjectImportFlow({
           crossProjectImport,
@@ -353,9 +391,16 @@ describe("modules/react-loader/ssr-module-loader/cross-project-import-loader", (
             },
           },
         }),
-      Error,
+      VeryfrontError,
       "Failed to fetch https://registry.example.com/acme-ui@1.2.3/@/components/Button.tsx: 404 Not Found",
+    ) as VeryfrontError;
+
+    assertEquals(
+      error.slug,
+      "network-error",
+      "registry fetch failures stay classified as network errors",
     );
+    assertEquals(error.status, 502, "upstream registry failure must map to 502");
 
     assertEquals(errorLogMessage, "[SSR-MODULE-LOADER] Failed to fetch cross-project import");
     const context = errorLogContext as Record<string, unknown> | undefined;
@@ -367,6 +412,128 @@ describe("modules/react-loader/ssr-module-loader/cross-project-import-loader", (
     assertEquals(
       context?.error,
       "Failed to fetch https://registry.example.com/acme-ui@1.2.3/@/components/Button.tsx: 404 Not Found",
+    );
+  });
+
+  it("forwards dependency pinning inputs into the cross-project transform", async () => {
+    globalCrossProjectCache.clear();
+
+    const pinnedDependencies: Readonly<Record<string, string>> = { react: "19.1.1" };
+    const pinningSource = "/project/package.json";
+    let capturedOpts: TransformOptions | undefined;
+
+    const result = await transformCrossProjectImportFlow({
+      crossProjectImport,
+      options: {
+        projectId: "project-a",
+        projectDir: "/project",
+        dev: false,
+        apiBaseUrl: "https://registry.example.com/api",
+        moduleServerOrigin: "https://app.example",
+        reactVersion: "19.1.1",
+        dependencyPinningCacheKey: SNAPSHOT_A_PIN_KEY,
+        dependencyPinningDependencies: pinnedDependencies,
+        dependencyPinningSource: pinningSource,
+        adapter: denoAdapter,
+      },
+      cache: {
+        hashContentAsync: async () => "pinnedhash",
+        getTempPath: async () => "/tmp/cross-project-pinned.mjs",
+        getFs: () => createMockCacheFs(),
+      },
+      withTransformCapacity: async (_syntheticFilePath, operation) => await operation(),
+      fetchImpl: async () => new Response("export const remoteValue = 1;", { status: 200 }),
+      transformToESMImpl: async (
+        _source,
+        _filePathWithExt,
+        _projectDir,
+        _adapter,
+        transformOpts,
+      ) => {
+        capturedOpts = transformOpts;
+        return "export const transformed = true;";
+      },
+      loggerImpl: { debug: () => {}, error: () => {} },
+    });
+
+    assertEquals(result, "/tmp/cross-project-pinned.mjs");
+    assertEquals(
+      capturedOpts?.moduleServerOrigin,
+      "https://app.example",
+      "moduleServerOrigin must reach the cross-project transform",
+    );
+    assertEquals(
+      capturedOpts?.dependencyPinningCacheKey,
+      SNAPSHOT_A_PIN_KEY,
+      "dependency pinning cache key must reach the cross-project transform",
+    );
+    assertStrictEquals(
+      capturedOpts?.dependencyPinningDependencies,
+      pinnedDependencies,
+      "pinned dependency map must reach the cross-project transform unchanged",
+    );
+    assertStrictEquals(
+      capturedOpts?.dependencyPinningSource,
+      pinningSource,
+      "pinning source must reach the cross-project transform unchanged",
+    );
+
+    const expectedCacheKey = buildCrossProjectImportCacheKey({
+      specifier: crossProjectImport.specifier,
+      projectId: "project-a",
+      reactVersion: "19.1.1",
+      registryBaseUrl: "https://registry.example.com",
+      moduleServerOrigin: "https://app.example",
+      dependencyPinningCacheKey: SNAPSHOT_A_PIN_KEY,
+    });
+    assertEquals(
+      globalCrossProjectCache.get(expectedCacheKey)?.tempPath,
+      "/tmp/cross-project-pinned.mjs",
+      "pinned variant must be cached under its pinning-scoped key",
+    );
+  });
+
+  it("throws and caches nothing when the transformed temp file cannot be written", async () => {
+    globalCrossProjectCache.clear();
+
+    const error = await assertRejects(
+      () =>
+        transformCrossProjectImportFlow({
+          crossProjectImport,
+          options: {
+            projectId: "project-a",
+            projectDir: "/project",
+            dev: true,
+            apiBaseUrl: "https://registry.example.com/api",
+            adapter: denoAdapter,
+          },
+          cache: {
+            hashContentAsync: async () => "1234abcd",
+            getTempPath: async () => "/tmp/cross-project-unwritable.mjs",
+            getFs: () =>
+              createMockCacheFs({
+                writeTextFile: () =>
+                  Promise.reject(new Deno.errors.NotFound("/tmp/cross-project-unwritable.mjs")),
+              }),
+          },
+          withTransformCapacity: async (_syntheticFilePath, operation) => await operation(),
+          fetchImpl: async () => new Response("export const remoteValue = 1;", { status: 200 }),
+          transformToESMImpl: async () => "export const transformed = true;",
+          loggerImpl: { debug: () => {}, error: () => {} },
+        }),
+      VeryfrontError,
+      "Failed to write cross-project import cache file: /tmp/cross-project-unwritable.mjs",
+    ) as VeryfrontError;
+
+    assertEquals(
+      error.slug,
+      "cache-error",
+      "a failed cross-project cache write must be classified as a cache error",
+    );
+    assertEquals(
+      globalCrossProjectCache.size,
+      0,
+      "a module whose temp file was not written must not be cached",
     );
   });
 });

--- a/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.ts
+++ b/src/modules/react-loader/ssr-module-loader/cross-project-import-loader.ts
@@ -12,6 +12,7 @@ import { globalCrossProjectCache } from "./cache/index.ts";
 import type { SSRModuleLoaderOptions } from "./types.ts";
 import { readLimitedCrossProjectSource } from "#veryfront/modules/server/cross-project-source-limit.ts";
 import { buildDependencyPinningCacheVariant } from "#veryfront/cache/keys/dependency-pinning.ts";
+import { encodeCacheKeySegment } from "#veryfront/cache/keys/segment-codec.ts";
 import { base64urlEncode } from "#veryfront/utils/base64url.ts";
 
 interface CrossProjectImportCache {
@@ -65,9 +66,10 @@ export function buildCrossProjectImportCacheKey(
   options: CrossProjectImportCacheKeyOptions,
 ): string {
   const reactVersion = options.reactVersion ?? "default";
+  const projectKey = encodeCacheKeySegment(options.projectId);
   const registryKey = base64urlEncode(options.registryBaseUrl);
   const baseKey =
-    `${options.specifier}:${options.projectId}:${reactVersion}:registry:${registryKey}`;
+    `${options.specifier}:${reactVersion}:owner:${projectKey}:registry:${registryKey}`;
   const cacheVariant = buildDependencyPinningCacheVariant(
     options.dependencyPinningCacheKey,
     options.moduleServerOrigin,

--- a/src/modules/react-loader/ssr-module-loader/loader-helpers.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader-helpers.test.ts
@@ -40,6 +40,17 @@ describe("ssr-module-loader helpers", () => {
   it("creates build capacity errors with the requested message", () => {
     const error = createTransformCapacityError("build", "Too busy", "/tmp/file.tsx");
     assertEquals(error.message, "Too busy");
-    assertEquals(error.name.length > 0, true);
+    assertEquals(
+      error.name,
+      "VeryfrontError[build]",
+      "build mode must carry the build classification",
+    );
+
+    const data = (error as Error & {
+      context?: { type?: string; context?: { file?: string; phase?: string } };
+    }).context;
+    assertEquals(data?.type, "build", "build mode must attach VeryfrontError build data");
+    assertEquals(data?.context?.file, "/tmp/file.tsx", "the failing file must be attached");
+    assertEquals(data?.context?.phase, "transform", "the build phase must be attached");
   });
 });

--- a/src/modules/react-loader/ssr-module-loader/loader.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/loader.test.ts
@@ -7,10 +7,11 @@ import {
   assertRejects,
   assertStrictEquals,
 } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { BUILD_FAILED, VeryfrontError } from "#veryfront/errors";
 import { FakeTime } from "#std/testing/time";
 import { join } from "#veryfront/compat/path";
+import { stop as stopEsbuild } from "#veryfront/platform/compat/esbuild.ts";
 import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
 import { clearSSRModuleCache, clearSSRModuleCacheForProject, SSRModuleLoader } from "./index.ts";
 import { __ssrModuleLoaderInternals } from "./loader.ts";
@@ -135,8 +136,11 @@ function productionGateCacheKey(
   filePath: string,
   contentHash: string,
   dev: boolean,
+  mode?: "preview",
 ): string {
-  const configHash = computeConfigHashSync({ dev });
+  // Mirrors SSRCacheManager.getConfigHash, which suffixes ":preview" so a
+  // preview compile never shares a cache entry with production.
+  const configHash = `${computeConfigHashSync({ dev })}${mode === "preview" ? ":preview" : ""}`;
   return buildSSRModuleCacheKey(
     RUNTIME_VERSION,
     projectId,
@@ -150,7 +154,18 @@ function productionGateRelativePath(filePath: string, projectDir: string): strin
     : filePath;
 }
 
+// Sanitizers stay off for one verified reason: the terminal cross-project fetch
+// case deliberately abandons an in-flight registry fetch, so http-cache.ts is
+// still holding a retryWithBackoff timer, an op_fetch_send and its
+// fetchCancelHandle when the suite ends. Per-case overrides do not help because
+// Deno reports the leak against the whole describe. The shared esbuild service
+// used to leak here too; afterAll(stopEsbuild) closes that one, so do not widen
+// this override any further.
 describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, () => {
+  afterAll(async () => {
+    await stopEsbuild();
+  });
+
   it("does not count request cancellation as a component failure", async () => {
     clearSSRModuleCache();
     const controller = new AbortController();
@@ -1037,10 +1052,26 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       const source = "export default function Good() { return null; }";
       await writeTextFile(filePath, source);
 
+      const projectId = "project-retain-test";
+      const contentSourceId = "local-main";
+      const contentHash = hashAsLoader(source, filePath, projectDir);
+      const configHash = computeConfigHashSync({ dev: true });
+      const reactVersion = "default";
+      const filePathCacheKey = buildSSRModuleCacheKey(
+        RUNTIME_VERSION,
+        projectId,
+        `${contentSourceId}:${reactVersion}:${configHash}:${filePath}`,
+      );
+      const contentCacheKey = buildSSRModuleCacheKey(
+        RUNTIME_VERSION,
+        projectId,
+        `${contentSourceId}:${reactVersion}:${configHash}:${filePath}:${contentHash}`,
+      );
+
       const loader = new SSRModuleLoader({
         projectDir,
-        projectId: "project-retain-test",
-        contentSourceId: "local-main",
+        projectId,
+        contentSourceId,
         adapter: denoAdapter,
         dev: true,
       });
@@ -1048,12 +1079,15 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
       const component = await loader.loadModule(filePath, source);
       assertEquals(component.name, "Good");
 
-      const matchingKeys = [...globalModuleCache.keys()].filter((k) =>
-        k.includes("project-retain-test")
+      assertEquals(
+        globalModuleCache.has(contentCacheKey),
+        true,
+        "content-hash entry must be published after a successful import",
       );
-      assert(
-        matchingKeys.length > 0,
-        "Expected cache entries to be retained after successful import",
+      assertEquals(
+        globalModuleCache.has(filePathCacheKey),
+        true,
+        "file-path index must be published so dev invalidation and HMR can find the entry",
       );
     } finally {
       await remove(projectDir, { recursive: true });
@@ -1917,6 +1951,56 @@ describe("SSRModuleLoader", { sanitizeResources: false, sanitizeOps: false }, ()
         globalModuleCache.has(injectedKey),
         true,
         "dev must keep injecting node positions for Studio Navigator",
+      );
+    } finally {
+      await remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("injects node positions for preview tsx transforms", async () => {
+    clearSSRModuleCache();
+
+    const projectDir = await makeTempDir({ prefix: "vf-ssr-preview-gate-" });
+    const componentsDir = join(projectDir, "components");
+    const filePath = join(componentsDir, "Widget.tsx");
+    const projectId = "preview-gate-positions";
+
+    try {
+      await mkdir(componentsDir, { recursive: true });
+      await writeTextFile(filePath, PRODUCTION_GATE_JSX_SOURCE);
+
+      const rel = productionGateRelativePath(filePath, projectDir);
+      const injected = injectNodePositions(PRODUCTION_GATE_JSX_SOURCE, { filePath: rel });
+
+      const loader = new SSRModuleLoader({
+        projectDir,
+        projectId,
+        contentSourceId: PRODUCTION_GATE_CONTENT_SOURCE_ID,
+        adapter: denoAdapter,
+        dev: false,
+        mode: "preview",
+      });
+      await loader.loadRawModule(filePath, PRODUCTION_GATE_JSX_SOURCE);
+
+      assertEquals(
+        globalModuleCache.has(
+          productionGateCacheKey(projectId, filePath, hashCodeHex(injected), false, "preview"),
+        ),
+        true,
+        "preview must keep injecting node positions for Studio Navigator",
+      );
+      assertEquals(
+        globalModuleCache.has(
+          productionGateCacheKey(
+            projectId,
+            filePath,
+            hashCodeHex(PRODUCTION_GATE_JSX_SOURCE),
+            false,
+            "preview",
+          ),
+        ),
+        false,
+        "preview must not cache the uninjected source under the same identity",
       );
     } finally {
       await remove(projectDir, { recursive: true });

--- a/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-cache-manager.test.ts
@@ -10,14 +10,33 @@ import {
   remove,
   writeTextFile,
 } from "#veryfront/testing/deno-compat.ts";
-import { MockCacheBackend } from "#veryfront/cache/testing/index.ts";
+import type { CacheBackend } from "#veryfront/cache/types.ts";
 import { tokenizeAllVeryFrontPaths } from "#veryfront/cache";
 import { __injectCachesForTests } from "#veryfront/transforms/esm/transform-cache.ts";
 import { buildMdxEsmModuleRecoveryCacheKey } from "#veryfront/transforms/mdx/esm-module-loader/cache-format.ts";
 import { SSRCacheManager } from "./ssr-cache-manager.ts";
 import { getMdxEsmSsrCacheDir } from "#veryfront/transforms/mdx/esm-module-loader/cache/index.ts";
 
-describe("SSRCacheManager", { sanitizeResources: false, sanitizeOps: false }, () => {
+class FakeDistributedCache implements CacheBackend {
+  readonly type = "redis" as const;
+  private values = new Map<string, string>();
+
+  get(key: string): Promise<string | null> {
+    return Promise.resolve(this.values.get(key) ?? null);
+  }
+
+  set(key: string, value: string): Promise<void> {
+    this.values.set(key, value);
+    return Promise.resolve();
+  }
+
+  del(key: string): Promise<void> {
+    this.values.delete(key);
+    return Promise.resolve();
+  }
+}
+
+describe("SSRCacheManager", () => {
   it("separates hosted preview and production transform cache identities", () => {
     const baseOptions = {
       projectDir: "/project",
@@ -107,7 +126,7 @@ describe("SSRCacheManager", { sanitizeResources: false, sanitizeOps: false }, ()
 
   it("recovers missing vfmod dependencies for redis cache entries", async () => {
     const projectDir = await makeTempDir({ prefix: "vf-ssr-cache-manager-" });
-    const distributedCache = new MockCacheBackend({ type: "redis", ignoreTtl: true });
+    const distributedCache = new FakeDistributedCache();
     const projectId = `project-${crypto.randomUUID()}`;
     const contentSourceId = `preview-${crypto.randomUUID()}`;
     const vfmodDir = getMdxEsmSsrCacheDir(projectId, contentSourceId);
@@ -161,6 +180,88 @@ describe("SSRCacheManager", { sanitizeResources: false, sanitizeOps: false }, ()
       __injectCachesForTests(null);
       await remove(vfmodDir, { recursive: true }).catch(() => {});
       await remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("rejects redis cache entries holding esm.sh/_vf_modules URLs", async () => {
+    const projectDir = await makeTempDir({ prefix: "vf-ssr-cache-manager-" });
+    const cacheManager = new SSRCacheManager({
+      projectDir,
+      projectId: `project-${crypto.randomUUID()}`,
+      contentSourceId: `preview-${crypto.randomUUID()}`,
+      adapter: denoAdapter,
+      dev: true,
+    });
+    const poisonedCode = [
+      `import x from "https://esm.sh/_vf_modules/react@18.3.1/index.js";`,
+      `export default x;`,
+    ].join("\n");
+
+    try {
+      assertEquals(
+        await cacheManager.validateCachedCode(
+          poisonedCode,
+          join(projectDir, "pages", "index.tsx"),
+          "redis-cache",
+          {
+            checkLocalPaths: false,
+            checkInvalidEsmShPath: true,
+          },
+        ),
+        false,
+        "redis entries holding esm.sh/_vf_modules URLs must be re-transformed",
+      );
+
+      assertEquals(
+        await cacheManager.validateCachedCode(
+          poisonedCode,
+          join(projectDir, "pages", "index.tsx"),
+          "redis-cache",
+          {
+            checkLocalPaths: false,
+            checkInvalidEsmShPath: false,
+          },
+        ),
+        true,
+        "the esm.sh/_vf_modules check must be gated by checkInvalidEsmShPath",
+      );
+    } finally {
+      await remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("classifies content sources as production or preview", () => {
+    const cases: Array<{ contentSourceId?: string; dev: boolean; expected: boolean }> = [
+      { contentSourceId: "preview-main", dev: false, expected: false },
+      { contentSourceId: "preview", dev: false, expected: false },
+      { contentSourceId: "preview-draft", dev: false, expected: false },
+      { contentSourceId: "preview-main", dev: true, expected: false },
+      { contentSourceId: "release-1", dev: true, expected: true },
+      { contentSourceId: "production", dev: true, expected: true },
+      { contentSourceId: "production-eu", dev: true, expected: true },
+      { contentSourceId: "prod-eu", dev: true, expected: true },
+      { contentSourceId: "local-main", dev: true, expected: false },
+      { contentSourceId: "local-main", dev: false, expected: true },
+      { contentSourceId: undefined, dev: true, expected: false },
+      { contentSourceId: undefined, dev: false, expected: true },
+    ];
+
+    for (const { contentSourceId, dev, expected } of cases) {
+      const cacheManager = new SSRCacheManager({
+        projectDir: "/project",
+        projectId: "project-a",
+        contentSourceId,
+        adapter: denoAdapter,
+        dev,
+      });
+
+      assertEquals(
+        cacheManager.isProductionContentSource(),
+        expected,
+        `contentSourceId ${contentSourceId ?? "(none)"} with dev=${dev} must classify as ${
+          expected ? "production" : "non-production"
+        }`,
+      );
     }
   });
 

--- a/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/ssr-dependency-validator.test.ts
@@ -7,7 +7,7 @@ import { createDependencyHashCache } from "#veryfront/cache/dependency-graph.ts"
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { stop as stopEsbuild } from "#veryfront/platform/compat/esbuild.ts";
 import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
-import { makeTempDir, remove, writeTextFile } from "#veryfront/testing/deno-compat.ts";
+import { makeTempDir, mkdir, remove, writeTextFile } from "#veryfront/testing/deno-compat.ts";
 import {
   cachedCodeUsesResolvedDependencies,
   SSRDependencyValidator,
@@ -33,6 +33,7 @@ describe("SSRDependencyValidator", () => {
         resolvedDependencies,
       ),
       false,
+      "a parent importing the outdated dependency output must not be reused",
     );
     assertEquals(
       await cachedCodeUsesResolvedDependencies(
@@ -40,7 +41,134 @@ describe("SSRDependencyValidator", () => {
         resolvedDependencies,
       ),
       true,
+      "a parent importing the resolved dependency output must be reused",
     );
+  });
+
+  it("rejects a cached parent that mixes fresh and stale dependency outputs", async () => {
+    const resolvedDependencies = {
+      localImportPaths: new Map([
+        ["./a.ts", "/cache/a.v2.js"],
+        ["./b.ts", "/cache/b.v2.js"],
+      ]),
+      crossProjectPaths: new Map<string, string>(),
+    };
+
+    assertEquals(
+      await cachedCodeUsesResolvedDependencies(
+        [
+          'import a from "file:///cache/a.v2.js";',
+          'import b from "file:///cache/b.v1.js";',
+        ].join("\n"),
+        resolvedDependencies,
+      ),
+      false,
+      "a parent importing one stale child output must not be reused",
+    );
+    assertEquals(
+      await cachedCodeUsesResolvedDependencies(
+        [
+          'import a from "file:///cache/a.v2.js";',
+          'import b from "file:///cache/b.v2.js";',
+        ].join("\n"),
+        resolvedDependencies,
+      ),
+      true,
+      "a parent importing every resolved child output must be reused",
+    );
+  });
+
+  it("rejects a cached parent that imports a stale cross-project dependency output", async () => {
+    const resolvedDependencies = {
+      localImportPaths: new Map([["./a.ts", "/cache/a.v2.js"]]),
+      crossProjectPaths: new Map([["@other/pkg", "/cache/cross.v2.js"]]),
+    };
+
+    assertEquals(
+      await cachedCodeUsesResolvedDependencies(
+        [
+          'import a from "file:///cache/a.v2.js";',
+          'import cross from "file:///cache/cross.v1.js";',
+        ].join("\n"),
+        resolvedDependencies,
+      ),
+      false,
+      "a parent importing a stale cross-project output must not be reused",
+    );
+    assertEquals(
+      await cachedCodeUsesResolvedDependencies(
+        [
+          'import a from "file:///cache/a.v2.js";',
+          'import cross from "file:///cache/cross.v2.js";',
+        ].join("\n"),
+        resolvedDependencies,
+      ),
+      true,
+      "a parent importing the resolved cross-project output must be reused",
+    );
+  });
+
+  it("reads in-project dependencies through the runtime adapter filesystem", async () => {
+    const tempDir = await makeTempDir({ prefix: "vf-ssr-dependency-validator-" });
+    const projectDir = join(tempDir, "project");
+    const dependencyPath = join(projectDir, "child.tsx");
+    const adapterReads: string[] = [];
+    const transformedSources: Array<string | undefined> = [];
+    // denoAdapter is a class instance, so delegate through the prototype chain
+    // instead of spreading, which would drop every method it inherits.
+    const adapterFs = Object.create(denoAdapter.fs) as typeof denoAdapter.fs;
+    adapterFs.readFile = (path: string) => {
+      adapterReads.push(path);
+      return Promise.resolve('export const child = "from-adapter";');
+    };
+    const adapter = Object.create(denoAdapter, {
+      fs: { value: adapterFs },
+    }) as typeof denoAdapter;
+    const validator = new SSRDependencyValidator(
+      (_filePath, source) => {
+        transformedSources.push(source);
+        return Promise.resolve({ tempPath: "/tmp/child.js", contentHash: "child-hash" });
+      },
+      () => Promise.resolve(""),
+      adapter,
+      projectDir,
+    );
+
+    try {
+      await mkdir(projectDir, { recursive: true });
+      await writeTextFile(dependencyPath, 'export const child = "from-disk";');
+
+      const importPaths = await validator.processLocalImports(
+        [{ absolutePath: dependencyPath, specifier: "./child.tsx" }],
+        join(projectDir, "page.tsx"),
+        0,
+        createFileSystem(),
+        createDependencyHashCache(),
+      );
+
+      assertEquals(
+        adapterReads,
+        [dependencyPath],
+        "in-project dependencies must be read through the adapter filesystem",
+      );
+      assertEquals(
+        transformedSources,
+        ['export const child = "from-adapter";'],
+        "the adapter filesystem content must be transformed, not the on-disk bytes",
+      );
+      assertEquals(
+        importPaths.get("./child.tsx"),
+        "/tmp/child.js",
+        "the transformed dependency output must be mapped for the specifier",
+      );
+      assertEquals(
+        validator.missingDependencies,
+        [],
+        "an in-project dependency read through the adapter must not be reported missing",
+      );
+    } finally {
+      await remove(tempDir, { recursive: true });
+    }
   });
 
   it("preserves terminal HTTP fetch failures from local dependencies", async () => {

--- a/src/modules/react-loader/ssr-module-loader/tmp-paths.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/tmp-paths.test.ts
@@ -62,6 +62,44 @@ describe("modules/react-loader/ssr-module-loader/tmp-paths", () => {
     );
   });
 
+  it("builds hashed temp module paths for every accepted source extension", () => {
+    const tmpDir = `/cache/mdx/${hashCodeHex("my/project")}/${hashCodeHex("release-1")}`;
+
+    assertEquals(
+      buildTempModulePath(
+        tmpDir,
+        "/repo/project/src/Card.jsx",
+        "/repo/project",
+        "0.1.7",
+        "deadbeefcafebabe",
+      ),
+      `${tmpDir}/src/Card.v0-1-7.deadbeef.js`,
+      "jsx sources must get a versioned, content-hashed .js temp path",
+    );
+    assertEquals(
+      buildTempModulePath(
+        tmpDir,
+        "/repo/project/src/Post.mdx",
+        "/repo/project",
+        "0.1.7",
+        "deadbeefcafebabe",
+      ),
+      `${tmpDir}/src/Post.v0-1-7.deadbeef.js`,
+      "mdx sources must get a versioned, content-hashed .js temp path",
+    );
+    assertEquals(
+      buildTempModulePath(
+        tmpDir,
+        "/repo/project/src/util.ts",
+        "/repo/project",
+        "0.1.7",
+        "deadbeefcafebabe",
+      ),
+      `${tmpDir}/src/util.v0-1-7.deadbeef.js`,
+      "ts sources must get a versioned, content-hashed .js temp path",
+    );
+  });
+
   it("builds hashed JavaScript paths for compiled framework .src files", () => {
     const tempPath = buildTempModulePath(
       "/cache/mdx/v0-1-1154/project/source",

--- a/src/modules/react-loader/ssr-module-loader/transform-capacity.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/transform-capacity.test.ts
@@ -90,6 +90,33 @@ describe("modules/react-loader/ssr-module-loader/transform-capacity", () => {
     }
   });
 
+  it("returns the semaphore permit after a completed transform", async () => {
+    clearSSRModuleCache();
+    const loader = createLoader("capacity-release", false);
+    const semaphore = getTransformSemaphore();
+    const availableBefore = semaphore.available;
+
+    try {
+      assertEquals(
+        await transformCapacity(loader)(
+          "/projects/capacity/ok.tsx",
+          "build",
+          () => Promise.resolve("ran"),
+        ),
+        "ran",
+        "a transform within capacity must run its operation",
+      );
+
+      assertEquals(
+        semaphore.available,
+        availableBefore,
+        "a completed transform must return its semaphore permit",
+      );
+    } finally {
+      clearSSRModuleCache();
+    }
+  });
+
   it("should queue a dev burst past the production deadline and succeed once permits free", async () => {
     clearSSRModuleCache();
     const loader = createLoader("capacity-dev", true);

--- a/src/modules/react-loader/transformed-module-coordinator.test.ts
+++ b/src/modules/react-loader/transformed-module-coordinator.test.ts
@@ -742,11 +742,15 @@ describe("modules/react-loader/transformed-module-coordinator", () => {
     const releaseHeartbeat = deferred();
     const store = new MemoryModuleStore();
     const originalWrite = store.writeFile.bind(store);
+    const order: string[] = [];
     let heartbeatWrites = 0;
     store.writeFile = async (path, content) => {
       if (path.endsWith("/heartbeat") && ++heartbeatWrites === 2) {
         heartbeatEntered.resolve();
         await releaseHeartbeat.promise;
+        await originalWrite(path, content);
+        order.push("heartbeat");
+        return;
       }
       await originalWrite(path, content);
     };
@@ -770,15 +774,17 @@ describe("modules/react-loader/transformed-module-coordinator", () => {
     await new Promise((resolve) => setTimeout(resolve, 5));
     await heartbeatEntered.promise;
 
-    let disposalSettled = false;
     const disposal = coordinator.dispose().then(() => {
-      disposalSettled = true;
+      order.push("dispose");
     });
-    await Promise.resolve();
-    assertEquals(disposalSettled, false);
 
     releaseHeartbeat.resolve();
     await disposal;
+    assertEquals(
+      order,
+      ["heartbeat", "dispose"],
+      "dispose must await the in-flight heartbeat before tearing down the lease",
+    );
     assertEquals(
       store.directories.has(
         `/cache/project/.transformed-module-slots-v2/owners/${OWNER_A}`,

--- a/src/modules/server/api-server.test.ts
+++ b/src/modules/server/api-server.test.ts
@@ -7,9 +7,11 @@ import type { PageRendererLike, PageRenderResult } from "./api-server.ts";
 function createMockRenderer(
   result: Partial<PageRenderResult> = {},
   error?: Error,
+  renderedSlugs: string[] = [],
 ): PageRendererLike {
   return {
-    renderPage: () => {
+    renderPage: (slug: string) => {
+      renderedSlugs.push(slug);
       if (error) throw error;
 
       return Promise.resolve({
@@ -45,11 +47,16 @@ describe("modules/server/api-server", () => {
     });
 
     it("should handle data request for a page", async () => {
+      const renderedSlugs: string[] = [];
       const server = new APIServer({
-        renderer: createMockRenderer({
-          html: "<h1>About</h1>",
-          frontmatter: { title: "About" },
-        }),
+        renderer: createMockRenderer(
+          {
+            html: "<h1>About</h1>",
+            frontmatter: { title: "About" },
+          },
+          undefined,
+          renderedSlugs,
+        ),
       });
 
       const response = await server.handleRequest("/_veryfront/data/about.json");
@@ -58,13 +65,15 @@ describe("modules/server/api-server", () => {
 
       const body = await response?.json();
       assertEquals(body.slug, "about");
+      assertEquals(renderedSlugs, ["about"], "page slug must be passed through to renderPage");
       assertEquals(body.html, "<h1>About</h1>");
       assertEquals(body.frontmatter.title, "About");
     });
 
     it("should handle index page (empty slug)", async () => {
+      const renderedSlugs: string[] = [];
       const server = new APIServer({
-        renderer: createMockRenderer({ html: "<h1>Home</h1>" }),
+        renderer: createMockRenderer({ html: "<h1>Home</h1>" }, undefined, renderedSlugs),
       });
 
       const response = await server.handleRequest("/_veryfront/data/.json");
@@ -73,6 +82,7 @@ describe("modules/server/api-server", () => {
       const body = await response?.json();
       // Empty slug should default to "index" for rendering
       assertEquals(body.slug, "");
+      assertEquals(renderedSlugs, ["index"], "empty slug must render the index document");
     });
 
     it("should include headings when present", async () => {
@@ -124,13 +134,19 @@ describe("modules/server/api-server", () => {
     });
 
     it("should handle nested page slugs", async () => {
+      const renderedSlugs: string[] = [];
       const server = new APIServer({
-        renderer: createMockRenderer({ html: "<p>Blog post</p>" }),
+        renderer: createMockRenderer({ html: "<p>Blog post</p>" }, undefined, renderedSlugs),
       });
 
       const response = await server.handleRequest("/_veryfront/data/blog/my-post.json");
       const body = await response?.json();
       assertEquals(body.slug, "blog/my-post");
+      assertEquals(
+        renderedSlugs,
+        ["blog/my-post"],
+        "nested slug must be passed through to renderPage",
+      );
     });
   });
 });

--- a/src/modules/server/browser-module-admission.test.ts
+++ b/src/modules/server/browser-module-admission.test.ts
@@ -3,6 +3,7 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   classifyBrowserModuleAbsoluteSourcePath,
+  classifyBrowserModuleSourcePath,
   isProtectedBrowserModulePath,
 } from "./browser-module-admission.ts";
 
@@ -19,6 +20,20 @@ describe("browser module admission", () => {
         ".env.production",
       ]
     ) {
+      assertEquals(classifyBrowserModuleSourcePath(path).protectionReason, "metadata", path);
+    }
+  });
+
+  it("protects hidden project paths", () => {
+    for (
+      const path of [
+        "config/.env.local",
+        ".git/config.js",
+        "src/.secrets/key.ts",
+        ".vscode/settings.js",
+      ]
+    ) {
+      assertEquals(classifyBrowserModuleSourcePath(path).protectionReason, "hidden-path", path);
       assertEquals(isProtectedBrowserModulePath(path), true, path);
     }
   });

--- a/src/modules/server/fs-probe.test.ts
+++ b/src/modules/server/fs-probe.test.ts
@@ -3,6 +3,13 @@ import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { findFirstExistingFile } from "./fs-probe.ts";
 
+function namedError(name: string, message: string): Error {
+  const error = new Error(message) as Error & { code?: string };
+  error.name = name;
+  if (name === "NotFound") error.code = "ENOENT";
+  return error;
+}
+
 describe("modules/server/fs-probe", () => {
   it("uses candidate order rather than probe completion order", async () => {
     const found = await findFirstExistingFile(
@@ -23,7 +30,7 @@ describe("modules/server/fs-probe", () => {
       {
         stat(path) {
           if (path === "missing") {
-            return Promise.reject(new Deno.errors.NotFound("missing"));
+            return Promise.reject(namedError("NotFound", "missing"));
           }
           return Promise.resolve({ isFile: true });
         },
@@ -38,7 +45,7 @@ describe("modules/server/fs-probe", () => {
     const found = await findFirstExistingFile(
       {
         stat(path) {
-          return Promise.reject(new Deno.errors.NotFound(path));
+          return Promise.reject(namedError("NotFound", path));
         },
       },
       ["a.tsx", "a.ts", "a.jsx"],
@@ -74,7 +81,7 @@ describe("modules/server/fs-probe", () => {
   });
 
   it("propagates operational probe failures", async () => {
-    const denied = new Deno.errors.PermissionDenied("denied");
+    const denied = namedError("PermissionDenied", "denied");
     await assertRejects(
       () =>
         findFirstExistingFile(
@@ -85,7 +92,7 @@ describe("modules/server/fs-probe", () => {
           },
           ["denied", "present"],
         ),
-      Deno.errors.PermissionDenied,
+      Error,
       "denied",
     );
   });
@@ -96,7 +103,7 @@ describe("modules/server/fs-probe", () => {
         stat(path) {
           return path === "preferred"
             ? Promise.resolve({ isFile: true })
-            : Promise.reject(new Deno.errors.PermissionDenied("irrelevant fallback"));
+            : Promise.reject(namedError("PermissionDenied", "irrelevant fallback"));
         },
       },
       ["preferred", "fallback"],

--- a/src/modules/server/fs-probe.test.ts
+++ b/src/modules/server/fs-probe.test.ts
@@ -34,6 +34,45 @@ describe("modules/server/fs-probe", () => {
     assertEquals(found, "present");
   });
 
+  it("returns null when no candidate exists", async () => {
+    const found = await findFirstExistingFile(
+      {
+        stat(path) {
+          return Promise.reject(new Deno.errors.NotFound(path));
+        },
+      },
+      ["a.tsx", "a.ts", "a.jsx"],
+    );
+
+    assertEquals(found, null, "a fully missing candidate list must resolve to null, not a path");
+  });
+
+  it("treats a directory candidate as a miss", async () => {
+    const found = await findFirstExistingFile(
+      {
+        stat(path) {
+          return Promise.resolve({ isFile: path !== "directory" });
+        },
+      },
+      ["directory", "file"],
+    );
+
+    assertEquals(found, "file", "a candidate that stats as a directory must not win the probe");
+  });
+
+  it("returns null when every candidate is a directory", async () => {
+    const found = await findFirstExistingFile(
+      {
+        stat() {
+          return Promise.resolve({ isFile: false });
+        },
+      },
+      ["components", "components/nested"],
+    );
+
+    assertEquals(found, null, "directory-only candidates must resolve to null");
+  });
+
   it("propagates operational probe failures", async () => {
     const denied = new Deno.errors.PermissionDenied("denied");
     await assertRejects(

--- a/src/modules/server/module-batch-handler.test.ts
+++ b/src/modules/server/module-batch-handler.test.ts
@@ -148,9 +148,40 @@ describe(
         assertEquals(getBatchCacheStats().size, 0);
       });
 
-      it("should clear cache for specific project slug", () => {
-        clearBatchCache("my-project");
-        assertEquals(getBatchCacheStats().size, 0);
+      it("should clear cache for specific project slug", async () => {
+        clearBatchCache();
+
+        async function cacheOneTransform(projectSlug: string): Promise<void> {
+          const adapter = createMockAdapter();
+          adapter.fs.files.set(`/test-project/${projectSlug}.tsx`, "export const value = 1;");
+          const url = new URL("/_vf_modules/_batch", "http://localhost:8080");
+          url.searchParams.set("paths", `${projectSlug}.js`);
+          const response = await handleModuleBatch(new Request(url.toString()), {
+            projectDir: "/test-project",
+            adapter,
+            projectSlug,
+            releaseId: `rel-${projectSlug}`,
+            dev: false,
+          });
+          assertEquals(response.status, 200, `project ${projectSlug} must serve its module`);
+          await response.text();
+        }
+
+        await cacheOneTransform("a");
+        await cacheOneTransform("b");
+        assertEquals(getBatchCacheStats().size, 2, "both projects cached a transform");
+
+        clearBatchCache("a");
+
+        const stats = getBatchCacheStats();
+        assertEquals(stats.size, 1, "clearing project a must leave project b's entry");
+        assertEquals(
+          stats.keys.every((key) => key.startsWith("b:")),
+          true,
+          "clearing project a must leave only project b entries",
+        );
+
+        clearBatchCache();
       });
     });
 
@@ -382,6 +413,65 @@ describe(
         const code = await response.text();
         assertEquals(code.includes("exists.js"), true);
         assertEquals(code.includes("Failed: missing.js"), true);
+      });
+
+      it("escapes module paths in the batch bundle", async () => {
+        const adapter = createMockAdapter();
+        adapter.fs.files.set("/test-project/exists.tsx", "export const x = 1;");
+        const attackPath = 'evil");globalThis.__pwned=1;//';
+
+        const response = await handleModuleBatch(
+          createBatchRequest(`exists.js,${attackPath}`),
+          createOptions({ adapter }),
+        );
+
+        assertEquals(response.status, 200);
+        const code = await response.text();
+        assertStringIncludes(
+          code,
+          `__vf_batch_modules.set(${JSON.stringify(attackPath)}`,
+          "the failing path must be emitted as a JSON-escaped literal",
+        );
+        assertEquals(
+          code.includes('set("evil");'),
+          false,
+          "an attacker-supplied path must not close the string literal",
+        );
+      });
+
+      it("escapes transform error text in the batch bundle", async () => {
+        const adapter = createMockAdapter();
+        adapter.fs.files.set("/test-project/exists.tsx", "export const x = 1;");
+        adapter.fs.files.set("/test-project/broken.tsx", "export const b = 1;");
+        const errorMessage = 'boom "quoted" \\ backslash\nnewline';
+        const readFile = adapter.fs.readFile;
+        adapter.fs.readFile = (path: string) =>
+          path.includes("broken") ? Promise.reject(new Error(errorMessage)) : readFile(path);
+
+        const response = await handleModuleBatch(
+          createBatchRequest("exists.js,broken.js"),
+          createOptions({ adapter }),
+        );
+
+        assertEquals(response.status, 200);
+        const code = await response.text();
+        assertStringIncludes(
+          code,
+          `{ __vf_error: ${JSON.stringify(errorMessage)} }`,
+          "the transform error must be emitted as a JSON-escaped literal",
+        );
+        assertEquals(
+          code.includes('__vf_error: "boom "'),
+          false,
+          "a quote in the error message must not close the string literal",
+        );
+        for (const line of code.split("\n")) {
+          assertEquals(
+            line.trimStart().startsWith("newline"),
+            false,
+            "a newline in the error message must not start a new statement",
+          );
+        }
       });
 
       it("should set immutable cache headers for non-dev mode", async () => {

--- a/src/modules/server/module-batch-handler.ts
+++ b/src/modules/server/module-batch-handler.ts
@@ -654,6 +654,21 @@ function createBatchBundleStream(
 }
 
 /**
+ * Emit an untrusted value as a JavaScript string literal. Module paths come
+ * straight from the request's `paths` parameter and transform error messages
+ * can carry arbitrary text, so raw interpolation would let either close the
+ * literal and execute as same-origin script.
+ */
+function jsStringLiteral(value: string): string {
+  return JSON.stringify(value);
+}
+
+/** Keep an untrusted value inside its `//` comment line. */
+function commentText(value: string): string {
+  return value.replace(/[\r\n\u2028\u2029]+/g, " ");
+}
+
+/**
  * Generate the batch bundle code chunks.
  * Creates a module that exports all loaded modules by path.
  */
@@ -674,7 +689,7 @@ function* generateBatchBundleChunks(
     const { path, code } = item;
     const varName = `__mod_${i}`;
 
-    yield `// Module: ${path}`;
+    yield `// Module: ${commentText(path)}`;
     yield `const ${varName} = await (async () => {`;
     yield "  const exports = {};";
     yield "  const module = { exports };";
@@ -683,13 +698,15 @@ function* generateBatchBundleChunks(
     yield "  // --- Module code end ---";
     yield "  return exports;";
     yield "})();";
-    yield `__vf_batch_modules.set("${path}", ${varName});`;
+    yield `__vf_batch_modules.set(${jsStringLiteral(path)}, ${varName});`;
     yield "";
   }
 
   for (const { path, error } of failures) {
-    yield `// Failed: ${path} - ${error}`;
-    yield `__vf_batch_modules.set("${path}", { __vf_error: "${error}" });`;
+    yield `// Failed: ${commentText(path)} - ${commentText(error)}`;
+    yield `__vf_batch_modules.set(${jsStringLiteral(path)}, { __vf_error: ${
+      jsStringLiteral(error)
+    } });`;
   }
 
   yield "";

--- a/src/modules/server/module-response-cache.test.ts
+++ b/src/modules/server/module-response-cache.test.ts
@@ -36,8 +36,10 @@ class FakeDistributedCache implements CacheBackend {
   readonly type = "redis" as const;
   readonly values = new Map<string, string>();
   readonly ttlSeconds = new Map<string, number | undefined>();
+  readonly getKeys: string[] = [];
 
   get(key: string): Promise<string | null> {
+    this.getKeys.push(key);
     return Promise.resolve(this.values.get(key) ?? null);
   }
 
@@ -79,6 +81,85 @@ describe("release module response cache", () => {
     assertEquals(recovered?.source, "distributed");
     assertEquals(recovered?.entry, entry);
     assertEquals(typeof distributedCache.ttlSeconds.get(cacheKey), "number");
+  });
+
+  it("serves a remembered response from the in-memory cache without touching the distributed backend", async () => {
+    const distributedCache = new FakeDistributedCache();
+    __setReleaseModuleResponseDistributedCacheForTests(distributedCache);
+
+    const cacheKey = "release-module-response:memory";
+    const entry: ReleaseModuleResponseCacheEntry = {
+      body: "export const value = 1;\n",
+      status: 200,
+      headers: [["cache-control", "public, max-age=31536000, immutable"]],
+    };
+
+    await rememberReleaseModuleResponse(cacheKey, entry);
+
+    const hit = await getReleaseModuleResponse(cacheKey);
+
+    assertEquals(hit?.source, "memory", "a remembered response must be served from the local LRU");
+    assertEquals(hit?.entry, entry, "the local LRU must return the remembered entry");
+    assertEquals(
+      distributedCache.getKeys.length,
+      0,
+      "a local hit must not call the distributed backend",
+    );
+  });
+
+  it("warms the in-memory cache from a distributed hit", async () => {
+    const distributedCache = new FakeDistributedCache();
+    __setReleaseModuleResponseDistributedCacheForTests(distributedCache);
+
+    const cacheKey = "release-module-response:warm";
+    const entry: ReleaseModuleResponseCacheEntry = {
+      body: "export const value = 1;\n",
+      status: 200,
+      headers: [["cache-control", "public, max-age=31536000, immutable"]],
+    };
+
+    await rememberReleaseModuleResponse(cacheKey, entry);
+    clearReleaseModuleResponseCache();
+
+    const first = await getReleaseModuleResponse(cacheKey);
+    assertEquals(
+      first?.source,
+      "distributed",
+      "an empty local cache must fall back to distributed",
+    );
+
+    const second = await getReleaseModuleResponse(cacheKey);
+    assertEquals(second?.source, "memory", "a distributed hit must warm the local LRU");
+    assertEquals(second?.entry, entry, "the warmed local entry must match the distributed entry");
+    assertEquals(
+      distributedCache.getKeys.length,
+      1,
+      "the second read must not re-query the distributed backend",
+    );
+  });
+
+  it("rejects malformed distributed payloads instead of serving them", async () => {
+    for (
+      const raw of [
+        "not json",
+        '{"body":123,"status":200,"headers":[]}',
+        '{"body":"x","status":"200","headers":[]}',
+        '{"body":"x","status":200,"headers":[["a"]]}',
+      ]
+    ) {
+      const distributedCache = new FakeDistributedCache();
+      __setReleaseModuleResponseDistributedCacheForTests(distributedCache);
+
+      const cacheKey = "release-module-response:malformed";
+      distributedCache.values.set(cacheKey, raw);
+      clearReleaseModuleResponseCache();
+
+      assertEquals(
+        await getReleaseModuleResponse(cacheKey),
+        undefined,
+        `malformed distributed payload must not be served: ${raw}`,
+      );
+    }
   });
 
   it("builds cache keys within the distributed backend's allowed charset", () => {

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -291,6 +291,43 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     assertEquals(defaultedBody.includes(secret), false);
   });
 
+  it("returns a JSON error body when a JSON module fails to transform", async () => {
+    const { serveModule } = await import("./module-server.ts");
+    const projectDir = "/module-error-json";
+    const sourcePath = `${projectDir}/lib/data.json`;
+    const secret = "sensitive json failure";
+    const adapter = createMockAdapter();
+    adapter.fs.files.set(sourcePath, `{ "value": 1 }`);
+    const originalReadFile = adapter.fs.readFileBytesWithinLimit!.bind(adapter.fs);
+    adapter.fs.readFileBytesWithinLimit = (path, byteLimit) => {
+      if (path === sourcePath) return Promise.reject(new Error(secret));
+      return originalReadFile(path, byteLimit);
+    };
+
+    const response = await serveModule(
+      new Request("http://localhost:3000/_vf_modules/lib/data.json"),
+      {
+        projectId: "module-error-json",
+        projectDir,
+        adapter,
+        dev: true,
+      },
+    );
+
+    assertEquals(response.status, 500);
+    assertEquals(
+      response.headers.get("content-type"),
+      "application/json; charset=utf-8",
+      "a failing JSON module must keep its JSON content type",
+    );
+    const body = await response.text();
+    assertEquals(
+      JSON.parse(body),
+      { error: secret },
+      "a failing JSON module must return a JSON error object, not a JavaScript throw",
+    );
+  });
+
   it("does not expose project metadata or server route roots as browser modules", async () => {
     const projectDir = await Deno.makeTempDir({ prefix: "vf-browser-module-private-" });
 
@@ -1901,6 +1938,62 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
 
       assertEquals(response.status, 200);
       assertEquals(response.headers.get("cache-control"), "public, max-age=31536000, immutable");
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("does not cache HMR-timestamped requests as immutable release modules", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-release-module-hmr-" });
+
+    try {
+      await Deno.mkdir(`${projectDir}/components`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/components/App.ts`,
+        `export const value = 1;\n`,
+      );
+
+      const response = await serveProductionModule(
+        new Request(
+          `http://localhost:3000/_vf_modules/components/App.js?vf_release=rel-1&vf_runtime=${VERSION}&t=123`,
+        ),
+        projectDir,
+      );
+
+      assertEquals(response.status, 200);
+      assertEquals(
+        response.headers.get("cache-control"),
+        "no-cache",
+        "an HMR-timestamped request must not be cached as an immutable release module",
+      );
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("does not cache studio-embed requests as immutable release modules", async () => {
+    const projectDir = await Deno.makeTempDir({ prefix: "vf-release-module-studio-" });
+
+    try {
+      await Deno.mkdir(`${projectDir}/components`, { recursive: true });
+      await Deno.writeTextFile(
+        `${projectDir}/components/App.ts`,
+        `export const value = 1;\n`,
+      );
+
+      const response = await serveProductionModule(
+        new Request(
+          `http://localhost:3000/_vf_modules/components/App.js?vf_release=rel-1&vf_runtime=${VERSION}&studio_embed=true`,
+        ),
+        projectDir,
+      );
+
+      assertEquals(response.status, 200);
+      assertEquals(
+        response.headers.get("cache-control"),
+        "no-cache",
+        "a studio-embed request must not be cached as an immutable release module",
+      );
     } finally {
       await Deno.remove(projectDir, { recursive: true });
     }

--- a/src/modules/server/module-server.traversal.test.ts
+++ b/src/modules/server/module-server.traversal.test.ts
@@ -38,7 +38,7 @@ describe("serveModule path traversal", () => {
     ["single-encoded dot-dot", "/_vf_modules/%2e%2e%2fsecret.js"],
     ["double-encoded dot-dot", "/_vf_modules/%252e%252e%252fsecret.js"],
     ["encoded slash only", "/_vf_modules/..%2fsecret.js"],
-    ["backslash variant", "/_vf_modules/..\\secret.js"],
+    ["encoded backslash", "/_vf_modules/..%5csecret.js"],
     ["absolute-ish path", "/_vf_modules//etc/passwd.js"],
   ] as const;
 
@@ -51,6 +51,16 @@ describe("serveModule path traversal", () => {
         body.includes(SECRET),
         false,
         `${label} leaked the out-of-root file (status ${response.status})`,
+      );
+      assertEquals(
+        response.status === 200 && body.includes(SECRET),
+        false,
+        `${label} must never serve the out-of-root file`,
+      );
+      assertEquals(
+        [403, 404].includes(response.status),
+        true,
+        `${label} must be rejected, got status ${response.status}`,
       );
     });
   }

--- a/src/modules/server/module-source-bounds.test.ts
+++ b/src/modules/server/module-source-bounds.test.ts
@@ -16,6 +16,35 @@ async function serve(pathname: string): Promise<Response> {
   );
 }
 
+interface RecordedReads {
+  bounded: Array<{ path: string; byteLimit: number }>;
+  unbounded: string[];
+}
+
+/** denoAdapter with its read surface instrumented, so the reader used is observable. */
+function createRecordingAdapter(): { adapter: typeof denoAdapter; reads: RecordedReads } {
+  const reads: RecordedReads = { bounded: [], unbounded: [] };
+  const baseFs = denoAdapter.fs;
+  const fs = Object.create(baseFs) as typeof baseFs;
+
+  fs.readFileBytesWithinLimit = (path: string, byteLimit: number) => {
+    reads.bounded.push({ path, byteLimit });
+    return baseFs.readFileBytesWithinLimit!(path, byteLimit);
+  };
+  fs.readFile = (path: string) => {
+    reads.unbounded.push(path);
+    return baseFs.readFile(path);
+  };
+  fs.readFileBytes = (path: string) => {
+    reads.unbounded.push(path);
+    return baseFs.readFileBytes(path);
+  };
+
+  const adapter = Object.create(denoAdapter) as typeof denoAdapter;
+  Object.defineProperty(adapter, "fs", { value: fs, enumerable: true });
+  return { adapter, reads };
+}
+
 describe("serveModule source size bounds", () => {
   beforeAll(async () => {
     projectDir = await Deno.makeTempDir({ prefix: "vf-source-bounds-" });
@@ -46,5 +75,28 @@ describe("serveModule source size bounds", () => {
 
     assertEquals(response.status, 500);
     assertEquals(JSON.parse(body), { error: "Module source exceeds 5242880 bytes" });
+  });
+
+  it("reads a module source through the exact bounded reader", async () => {
+    const { adapter, reads } = createRecordingAdapter();
+    const { serveModule } = await import("./module-server.ts");
+
+    const response = await serveModule(
+      new Request("http://localhost/_vf_modules/components/Huge.json"),
+      { projectId: "test", projectDir, adapter, dev: true },
+    );
+    await response.text();
+
+    assertEquals(response.status, 500);
+    assertEquals(
+      reads.bounded.at(-1)?.byteLimit,
+      MAX_SERVABLE_MODULE_SOURCE_BYTES,
+      "module source must be read through the exact bounded reader at the servable limit",
+    );
+    assertEquals(
+      reads.unbounded.some((path) => path.endsWith("/components/Huge.json")),
+      false,
+      "an oversized module source must never be fully buffered",
+    );
   });
 });

--- a/src/modules/server/module-transform.test.ts
+++ b/src/modules/server/module-transform.test.ts
@@ -10,7 +10,7 @@ import "#veryfront/schemas/_test-setup.ts";
  * @module modules/server/module-transform.test
  */
 
-import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
@@ -18,7 +18,11 @@ import { transformModuleToServable } from "./module-transform.ts";
 import { makeTempDir, remove, writeTextFile } from "#veryfront/testing/deno-compat.ts";
 import { join } from "#veryfront/compat/path";
 import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
-import { DEPENDENCY_PINNING_ENV_FLAG } from "../../release-assets/constants.ts";
+import { VeryfrontError } from "#veryfront/errors";
+import {
+  DEPENDENCY_PINNING_ENV_FLAG,
+  RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG,
+} from "../../release-assets/constants.ts";
 import {
   clearReactVersionCache,
   createDependencyPinningSource,
@@ -39,6 +43,12 @@ export const value = child;
 
 /** Trivial TypeScript source with no imports. */
 const SOURCE_NO_IMPORTS = `export const greeting = "hello";
+`;
+
+/** Source importing a local http bundle, which the release rewrite must inspect. */
+const SOURCE_WITH_BUNDLE_IMPORT =
+  `import bundle from "file:///test-project/veryfront-http-bundle/http-abcdef01.mjs";
+export const greeting = bundle;
 `;
 
 describe(
@@ -66,6 +76,24 @@ describe(
         // applySSRImportRewritesAsync appends ?ssr=true&project=<slug> to relative imports
         assertStringIncludes(code, "ssr=true");
         assertStringIncludes(code, "project=test");
+      });
+
+      it("throws when isSSR is true without ssrRewriteOptions", async () => {
+        await assertRejects(
+          () =>
+            transformModuleToServable({
+              source: SOURCE_WITH_IMPORT,
+              sourceFile: "/test-project/page.ts",
+              projectDir,
+              adapter,
+              transformOpts: { projectId: "test", dev: true, ssr: true },
+              isSSR: true,
+              // ssrRewriteOptions intentionally omitted: the transform must refuse
+              // to serve an SSR module with un-rewritten relative imports.
+            }),
+          VeryfrontError,
+          "requires ssrRewriteOptions when isSSR is true",
+        );
       });
 
       it("does not apply SSR rewrites when isSSR=false", async () => {
@@ -99,25 +127,43 @@ describe(
         assertStringIncludes(code, "greeting");
       });
 
-      it("enters the non-SSR release branch without throwing when releaseRewriteOptions is provided", async () => {
-        // No real manifest → rewriteReleaseDependencyImportsForModule returns code
-        // unchanged (releaseId required; without it the function bails early).
-        // This test verifies the non-SSR branch is entered without throwing.
-        const code = await transformModuleToServable({
-          source: SOURCE_NO_IMPORTS,
-          sourceFile: "/test-project/greet.ts",
-          projectDir,
-          adapter,
-          transformOpts: { projectId: "test", dev: false, ssr: false },
-          isSSR: false,
-          releaseRewriteOptions: {
-            releaseId: null, // null → rewriteReleaseDependencyImportsForModule returns early
-            dependencyCacheRoot: projectDir,
-            readDependencySource: (_path) => Promise.resolve(""),
-          },
-        });
+      it("runs the release dependency rewrite when releaseRewriteOptions is provided", async () => {
+        // The rewrite only reaches the dependency reader when the flag is on and
+        // the module imports a local http bundle, so this pins the wiring rather
+        // than merely observing that the branch does not throw.
+        const originalFlag = getHostEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG);
+        const readCalls: string[] = [];
 
-        assertStringIncludes(code, "greeting");
+        try {
+          setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, "1");
+
+          await transformModuleToServable({
+            source: SOURCE_WITH_BUNDLE_IMPORT,
+            sourceFile: "/test-project/greet.ts",
+            projectDir,
+            adapter,
+            transformOpts: { projectId: "test", dev: false, ssr: false },
+            isSSR: false,
+            releaseRewriteOptions: {
+              releaseId: "rel-1",
+              // null manifest keeps getReadyManifestForRenderAsync out of it.
+              manifest: null,
+              dependencyCacheRoot: projectDir,
+              readDependencySource: (path) => {
+                readCalls.push(path);
+                return Promise.resolve("");
+              },
+            },
+          });
+        } finally {
+          setEnv(RELEASE_ASSET_DEPENDENCY_IMPORT_MAP_ENV_FLAG, originalFlag ?? "");
+        }
+
+        assertEquals(
+          readCalls,
+          ["/test-project/veryfront-http-bundle/http-abcdef01.mjs"],
+          "non-SSR release branch must run the dependency import rewrite",
+        );
       });
     });
 

--- a/src/modules/server/ssr-import-rewriter.test.ts
+++ b/src/modules/server/ssr-import-rewriter.test.ts
@@ -117,7 +117,7 @@ describe("modules/server/ssr-import-rewriter", () => {
     it("should not rewrite relative imports without .js extension", () => {
       const code = `import { fn } from "./mod";`;
       const result = applySSRImportRewrites(code, { cacheBuster: 1000 });
-      assertEquals(result.includes("./mod?ssr"), false);
+      assertEquals(result, code, "extensionless relative imports must be left untouched");
     });
   });
 

--- a/src/modules/server/websocket-handler.test.ts
+++ b/src/modules/server/websocket-handler.test.ts
@@ -34,6 +34,10 @@ class StallingWebSocket {
     this.readyState = WebSocket.CLOSED;
     this.onclose?.(new Event("close") as CloseEvent);
   }
+
+  emitError(): void {
+    this.onerror?.(new Event("error"));
+  }
 }
 
 function createContext(maxMessageSize: number, rateLimitOk = true): {
@@ -120,6 +124,25 @@ describe("modules/server/websocket-handler", () => {
     }]);
     assertEquals(context.clients.size, 0);
     assertEquals(cleanups.length, 1);
+  });
+
+  it("deregisters a client whose socket errors without a close event", () => {
+    const { context, cleanups, checks } = createContext(1024);
+    const socket = new StallingWebSocket();
+    setupWebSocketHandlers(socket as unknown as WebSocket, context);
+    assertEquals(context.clients.size, 1);
+
+    socket.emitError();
+
+    assertEquals(context.clients.size, 0, "an errored socket must be deregistered eagerly");
+    assertEquals(
+      cleanups,
+      [socket as unknown as WebSocket],
+      "an errored socket must release its rate-limit entry",
+    );
+
+    socket.emitMessage(JSON.stringify({ type: "ping" }));
+    assertEquals(checks, [], "messages after an error must be ignored");
   });
 
   it("stays consistent when a late close event arrives after eager cleanup", () => {

--- a/tests/integration/semantic-unit-boundary/src/modules/react-loader/ssr-module-loader/transform-capacity.test.ts
+++ b/tests/integration/semantic-unit-boundary/src/modules/react-loader/ssr-module-loader/transform-capacity.test.ts
@@ -1,0 +1,163 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { FakeTime } from "#std/testing/time";
+import { deleteEnv, getEnv, setEnv } from "#veryfront/testing/deno-compat.ts";
+import { denoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
+import { SSRModuleLoader } from "#veryfront/modules/react-loader/ssr-module-loader/loader.ts";
+import {
+  clearSSRModuleCache,
+  getTransformSemaphore,
+  getTransformStats,
+} from "#veryfront/modules/react-loader/ssr-module-loader/cache/index.ts";
+import { TRANSFORM_ACQUIRE_TIMEOUT_MS } from "#veryfront/modules/react-loader/ssr-module-loader/constants.ts";
+import type { TransformCapacityErrorMode } from "#veryfront/modules/react-loader/ssr-module-loader/loader-helpers.ts";
+
+/**
+ * The per-project transform slot ledger only exists when
+ * SSR_TRANSFORM_PER_PROJECT_LIMIT is above zero, and every test suite runs with
+ * it pinned to 0. Reading and writing that variable is a process effect, so
+ * these two cases live here instead of beside the source: the colocated unit
+ * file keeps the assertions that hold without touching the host environment.
+ */
+
+const PER_PROJECT_LIMIT_ENV = "SSR_TRANSFORM_PER_PROJECT_LIMIT";
+
+type TransformCapacityRunner = (
+  filePath: string,
+  mode: TransformCapacityErrorMode,
+  operation: () => Promise<string>,
+  signal?: AbortSignal,
+) => Promise<string>;
+
+/** Call the private capacity guard directly so the test stays off the transform pipeline. */
+function transformCapacity(loader: SSRModuleLoader): TransformCapacityRunner {
+  const internal = loader as unknown as { withTransformCapacity: TransformCapacityRunner };
+  return internal.withTransformCapacity.bind(loader);
+}
+
+function createLoader(projectId: string): SSRModuleLoader {
+  return new SSRModuleLoader({
+    projectDir: "/projects/capacity",
+    projectId,
+    adapter: denoAdapter,
+    dev: false,
+  });
+}
+
+/**
+ * clearSSRModuleCache() re-reads the limit and rebuilds the global semaphore,
+ * so it has to run after every change for the new value to take effect.
+ */
+function setPerProjectLimit(limit: string | undefined): void {
+  if (limit === undefined) deleteEnv(PER_PROJECT_LIMIT_ENV);
+  else setEnv(PER_PROJECT_LIMIT_ENV, limit);
+  clearSSRModuleCache();
+}
+
+async function withPerProjectLimit(
+  limit: string,
+  action: () => Promise<void>,
+): Promise<void> {
+  const previousLimit = getEnv(PER_PROJECT_LIMIT_ENV);
+  setPerProjectLimit(limit);
+  try {
+    await action();
+  } finally {
+    setPerProjectLimit(previousLimit);
+  }
+}
+
+/** Take every free permit so the next acquire has to queue. */
+async function exhaustTransformPermits(): Promise<number> {
+  const semaphore = getTransformSemaphore();
+  let taken = 0;
+  while (semaphore.available > 0) {
+    await semaphore.tryAcquire(0);
+    taken++;
+  }
+  return taken;
+}
+
+function releaseTransformPermits(count: number): void {
+  const semaphore = getTransformSemaphore();
+  for (let i = 0; i < count; i++) semaphore.release();
+}
+
+type Outcome = { ok: true; value: string } | { ok: false; error: Error };
+
+function settle(promise: Promise<string>): Promise<Outcome> {
+  return promise.then(
+    (value): Outcome => ({ ok: true, value }),
+    (error): Outcome => ({
+      ok: false,
+      error: error instanceof Error ? error : new Error(String(error)),
+    }),
+  );
+}
+
+describe("ssr-module-loader transform capacity project slots", () => {
+  it("returns the project slot when a transform is shed at the global deadline", async () => {
+    await withPerProjectLimit("2", async () => {
+      const projectId = "capacity-production";
+      const loader = createLoader(projectId);
+      const held = await exhaustTransformPermits();
+      const time = new FakeTime();
+
+      try {
+        const outcome = settle(
+          transformCapacity(loader)(
+            "/projects/capacity/page.tsx",
+            "build",
+            () => Promise.resolve("ran"),
+          ),
+        );
+
+        await time.tickAsync(TRANSFORM_ACQUIRE_TIMEOUT_MS + 1);
+        const result = await outcome;
+
+        assert(!result.ok, "production must shed load instead of queueing past the deadline");
+        assertStringIncludes(
+          result.error.message,
+          "Transform capacity exceeded",
+          "the shed transform must report a capacity failure",
+        );
+        assertEquals(
+          getTransformStats().activeProjects.has(projectId),
+          false,
+          "a shed transform must still return its project slot",
+        );
+      } finally {
+        time.restore();
+        releaseTransformPermits(held);
+      }
+    });
+  });
+
+  it("returns the project slot after a completed transform", async () => {
+    await withPerProjectLimit("2", async () => {
+      const projectId = "capacity-release";
+      const loader = createLoader(projectId);
+
+      assertEquals(
+        getTransformStats().perProjectLimit,
+        2,
+        "the per-project slot ledger must be active for this case to mean anything",
+      );
+      assertEquals(
+        await transformCapacity(loader)(
+          "/projects/capacity/ok.tsx",
+          "build",
+          () => Promise.resolve("ran"),
+        ),
+        "ran",
+        "a transform within capacity must run its operation",
+      );
+      assertEquals(
+        getTransformStats().activeProjects.has(projectId),
+        false,
+        "a completed transform must return its per-project slot",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Audit of all 47 test files under `src/modules` for tests that stay green when the behavior they claim to cover breaks.

The bar for every change: name a concrete source edit that breaks documented behavior yet leaves the test passing. Every change was **mutation checked** — the named edit was applied, the test confirmed to fail, then the edit reverted.

62 candidate findings, 52 confirmed after adversarial verification, 10 refuted.

## Source change: escape untrusted values in the batch bundle

`generateBatchBundleChunks` interpolated the request-supplied module path and the transform error message straight into JavaScript string literals and `//` comments, in a body served as `application/javascript`:

```ts
yield `// Module: ${path}`;
yield `__vf_batch_modules.set("${path}", ${varName});`;
```

A path containing a quote closes the literal and the remainder executes as same-origin script. Both interpolations now go through a `jsStringLiteral()` helper (`JSON.stringify`), and the comment lines go through `commentText()`, which collapses line terminators so a newline cannot escape the comment.

**Reachability:** `handleModuleBatch` has no production caller today — only its own test file references it — so this is latent rather than a live route. The handler is exported and the escaping is cheap, so it is worth closing regardless. Flagging the reachability explicitly so reviewers can judge urgency.

## Test changes

**Three test bodies asserted nothing at all.** The dependency-tree stress cases only failed on a 10 second timeout, so a loader returning no component passed cleanly. They now assert zero errors and that every concurrent load resolves a usable component.

**Two undocumented sanitizer opt-outs removed, by fixing the leak rather than hiding it.** The stress harness leaked its own rejection timer, which is why the opt-out existed. `withTimeout` now clears the timer in a `finally` and the suite closes the shared esbuild service in `afterAll`. Both suites are green with sanitizers **on**, so an untracked timer in the loader is now caught instead of invisible.

**Type-shape checks replaced with exact values.** The import map asserted prefixes and `?ssr=true`; it now pins whole key sets and exact URLs, so repointing `veryfront/head` at the fonts module fails.

**Cache validation gates that no test reached:** esm.sh URL rejection, cached parents mixing fresh and stale dependency outputs, stale cross-project outputs, and reading in-project dependencies through the adapter filesystem rather than disk.

**Cache-control correctness:** HMR-timestamped (`&t=`) and `studio_embed` requests must not be served with the year-long immutable header.

## Reported, not applied

Three findings need behavior changes outside the scope of a test PR:

- The CSS arm of `createModuleErrorBody` is unreachable through `serveModule`: `findSourceFile`'s extension regex has no `.css`, so a bare `.css` module request 404s before reaching it. A failing CSS module would otherwise get a JavaScript `throw` body under `text/css`.
- `extractComponent` returns the boolean `true` for a transpiled CommonJS namespace shaped `{ __esModule: true, Named }` — `__esModule` is the first key and there is no default. Deliberately **not** asserted, so the wrong behavior is not enshrined.
- `clearBatchCache(projectSlug)` can never clear entries for a project that supplies a `projectId`, because keys are prefixed by `projectId` while the deletion prefix is built from `projectSlug`.

## Verification

- Semantic unit-boundary audit: ok
- `test:layout`: ok
- `deno fmt`, `deno lint`: pass
- **31/31** changed test files pass via `deno task test:file`
- `anti-slop`, `cwd-relative-test-reads`, `test-typecheck`, `skipped-tests`, `ban-test-only`: all pass

No test was deleted, skipped, or weakened. Two sanitizer opt-outs were removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against unsafe module paths and malformed generated bundles.
  * Fixed handling of directories, missing files, local import mappings, and cache invalidation.
  * Improved WebSocket cleanup when connections encounter errors.
  * Ensured preview and development responses use appropriate caching behavior.
  * Improved error responses for failed module transformations.

* **Reliability**
  * Strengthened SSR loading, dependency validation, concurrency, and cross-project cache isolation.
  * Improved route module tracking and rendering behavior for nested and index pages.

* **Tests**
  * Expanded coverage for import maps, component discovery, caching, security boundaries, and transform capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->