### PR TITLE
test(proxy): make weak assertions bite across the proxy surface

### DIFF
--- a/scripts/lint/check-sanitizer-baseline.ts
+++ b/scripts/lint/check-sanitizer-baseline.ts
@@ -23,11 +23,12 @@ import {
 
 // Lower this when you remove sanitizer opt-outs. Never raise it without a very
 // good reason — a new opt-out means a leak is being suppressed rather than fixed.
-// 342 after the transforms/mdx, transforms/esm, transforms/pipeline, module,
-// server-runtime, server-handler, rendering/RSC, and platform/compat audits
-// removed opt-outs. Platform/compat process and opaque-deps suites now restore
-// the globals and child processes they touch instead of suppressing leak reports.
-export const SANITIZER_OPT_OUT_BASELINE = 342;
+// Lowered as the transforms/mdx, transforms/esm, transforms/pipeline, module,
+// server-runtime, server-handler, rendering/RSC, platform/compat, and proxy
+// audits removed opt-outs. Platform/compat process and opaque-deps suites now
+// restore the globals and child processes they touch instead of suppressing
+// leak reports.
+export const SANITIZER_OPT_OUT_BASELINE = 340;
 
 const OPT_OUT_PATTERN = /sanitize(?:Resources|Ops|Exit)\s*:\s*false/g;
 

--- a/src/proxy/asset-handler.test.ts
+++ b/src/proxy/asset-handler.test.ts
@@ -63,13 +63,16 @@ describe("proxy release asset handler", () => {
 
   it("serves a JS asset with immutable + nosniff headers (happy path)", async () => {
     const source = "export const x = 1;";
-    const fetchImpl = makeFetch(() =>
-      new Response(source, {
+    let requestedUrl = "";
+    const fetchImpl = makeFetch((url) => {
+      requestedUrl = url;
+      return new Response(source, {
         status: 200,
         headers: { "Content-Type": "text/javascript" },
-      })
-    );
-    const url = await assetUrl(source, "js");
+      });
+    });
+    const hash = await computeHashBytes(textEncoder.encode(source));
+    const url = new URL(`https://site.example/_vf/assets/${hash}.js`);
 
     const res = await handle(url, { apiBaseUrl: API_BASE, fetchImpl });
 
@@ -81,6 +84,56 @@ describe("proxy release asset handler", () => {
     );
     assertEquals(res?.headers.get("X-Content-Type-Options"), "nosniff");
     assertEquals(await res?.text(), "export const x = 1;");
+    assertEquals(
+      requestedUrl,
+      `https://api.example.com/release-assets/${hash}`,
+      "a cold asset load must hit the public release-assets endpoint",
+    );
+  });
+
+  it("keeps the path prefix of a based asset API URL", async () => {
+    const source = "export const based = 1;";
+    let requestedUrl = "";
+    const fetchImpl = makeFetch((url) => {
+      requestedUrl = url;
+      return new Response(source, {
+        status: 200,
+        headers: { "Content-Type": "text/javascript" },
+      });
+    });
+    const hash = await computeHashBytes(textEncoder.encode(source));
+    const url = new URL(`https://site.example/_vf/assets/${hash}.js`);
+
+    const res = await handle(url, { apiBaseUrl: "https://api.example.com/v1", fetchImpl });
+
+    assertEquals(res?.status, 200);
+    assertEquals(
+      requestedUrl,
+      `https://api.example.com/v1/release-assets/${hash}`,
+      "a based API URL must keep its path prefix",
+    );
+  });
+
+  it("fails closed on an unsafe asset API base URL", async () => {
+    for (
+      const apiBaseUrl of [
+        "https://user:pass@api.example.com",
+        "https://user@api.example.com",
+        "file:///etc",
+      ]
+    ) {
+      let fetches = 0;
+      const fetchImpl = makeFetch(() => {
+        fetches++;
+        return new Response("never");
+      });
+      const url = new URL(`https://site.example/_vf/assets/${HASH}.js`);
+
+      const res = await handle(url, { apiBaseUrl, fetchImpl });
+
+      assertEquals(res?.status, 502, `${apiBaseUrl} must fail closed with 502`);
+      assertEquals(fetches, 0, `${apiBaseUrl} must not reach the asset origin`);
+    }
   });
 
   it("serves a CSS asset with the css content type", async () => {

--- a/src/proxy/cache/index.test.ts
+++ b/src/proxy/cache/index.test.ts
@@ -126,6 +126,36 @@ describe("proxy cache factory", () => {
     assertEquals(registered.closed, false);
   });
 
+  it("rejects extension-store composition that contradicts CACHE_TYPE", async () => {
+    Deno.env.set("CACHE_TYPE", "extension");
+    await assertRejects(
+      () =>
+        createCacheFromEnv({
+          extensionStore: Object.freeze({ kind: "disabled", store: null }),
+        }),
+      TypeError,
+      "requires an acquired extension store",
+    );
+
+    Deno.env.set("CACHE_TYPE", "memory");
+    await assertRejects(
+      () =>
+        createCacheFromEnv({
+          extensionStore: Object.freeze({ kind: "created", store: new FakeTokenCache() }),
+        }),
+      TypeError,
+      "cannot be supplied when CACHE_TYPE=memory",
+    );
+    await assertRejects(
+      () =>
+        createCacheFromEnv({
+          extensionStore: Object.freeze({ kind: "borrowed", store: new FakeTokenCache() }),
+        }),
+      TypeError,
+      "cannot be supplied when CACHE_TYPE=memory",
+    );
+  });
+
   it("rejects unknown cache types and obsolete inline Extension options", async () => {
     await assertRejects(
       () => createCache({ type: "unknown" } as never),

--- a/src/proxy/cache/resilient-cache.test.ts
+++ b/src/proxy/cache/resilient-cache.test.ts
@@ -1,7 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
-import { waitFor } from "#veryfront/testing";
 import { ResilientCache } from "./resilient-cache.ts";
 import type { CacheStats, TokenCache, TokenCacheEntry } from "./types.ts";
 
@@ -404,49 +403,53 @@ describe("ResilientCache", () => {
 
   it("deletes rather than replays a journaled write that expired while the circuit was open", async () => {
     let now = 0;
+    let expiryNow = 1_800_000_000_000;
     const primary = new FakeCache("extension");
     const fallback = new FakeCache("memory");
     primary.failures.add("set");
     const cache = new ResilientCache(primary, fallback, {
       openDurationMs: 10,
       now: () => now,
+      wallNow: () => expiryNow,
     });
-    // The replay's expiry check reads the real clock, so the journaled entry
-    // needs a real short TTL rather than the injected test clock.
-    const expiresAt = Date.now() + 25;
 
-    await cache.set("key", { token: "stale", expiresAt, scope: "production" });
-    assertEquals(
-      cache.getStatus().state,
-      "open",
-      "the failed primary write must open the circuit",
-    );
+    try {
+      const expiresAt = expiryNow + 25;
 
-    primary.failures.delete("set");
-    await waitFor(() => Date.now() >= expiresAt, {
-      interval: 5,
-      timeout: 1_000,
-      message: "the journaled entry never reached its expiry",
-    });
-    now = 10;
-    await cache.get("key");
+      await cache.set("key", {
+        token: "stale",
+        expiresAt,
+        scope: "production",
+      });
+      assertEquals(
+        cache.getStatus().state,
+        "open",
+        "the failed primary write must open the circuit",
+      );
 
-    assertEquals(
-      primary.entries.has("key"),
-      false,
-      "an entry that expired while the circuit was open must be deleted, not replayed, on recovery",
-    );
-    assertEquals(
-      primary.calls.get("delete"),
-      1,
-      "recovery must issue exactly one delete for the expired journal entry",
-    );
-    assertEquals(
-      cache.getStatus().pendingMutations,
-      0,
-      "the journal must be drained once the replay completes",
-    );
-    await cache.close();
+      primary.failures.delete("set");
+      expiryNow = expiresAt;
+      now = 10;
+      await cache.get("key");
+
+      assertEquals(
+        primary.entries.has("key"),
+        false,
+        "an entry that expired while the circuit was open must be deleted, not replayed, on recovery",
+      );
+      assertEquals(
+        primary.calls.get("delete"),
+        1,
+        "recovery must issue exactly one delete for the expired journal entry",
+      );
+      assertEquals(
+        cache.getStatus().pendingMutations,
+        0,
+        "the journal must be drained once the replay completes",
+      );
+    } finally {
+      await cache.close();
+    }
   });
 
   it("replays a failed clear before trusting recovered primary data", async () => {
@@ -551,6 +554,14 @@ describe("ResilientCache", () => {
         }),
       TypeError,
       "invalid time",
+    );
+    assertThrows(
+      () =>
+        new ResilientCache(primary, new FakeCache("memory"), {
+          wallNow: () => Number.NaN,
+        }),
+      TypeError,
+      "wall clock",
     );
 
     let accessorReads = 0;

--- a/src/proxy/cache/resilient-cache.test.ts
+++ b/src/proxy/cache/resilient-cache.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
+import { waitFor } from "#veryfront/testing";
 import { ResilientCache } from "./resilient-cache.ts";
 import type { CacheStats, TokenCache, TokenCacheEntry } from "./types.ts";
 
@@ -398,6 +399,53 @@ describe("ResilientCache", () => {
 
     assertEquals((await cache.get("key"))?.token, "original");
     assertEquals(cache.getStatus().pendingMutations, 0);
+    await cache.close();
+  });
+
+  it("deletes rather than replays a journaled write that expired while the circuit was open", async () => {
+    let now = 0;
+    const primary = new FakeCache("extension");
+    const fallback = new FakeCache("memory");
+    primary.failures.add("set");
+    const cache = new ResilientCache(primary, fallback, {
+      openDurationMs: 10,
+      now: () => now,
+    });
+    // The replay's expiry check reads the real clock, so the journaled entry
+    // needs a real short TTL rather than the injected test clock.
+    const expiresAt = Date.now() + 25;
+
+    await cache.set("key", { token: "stale", expiresAt, scope: "production" });
+    assertEquals(
+      cache.getStatus().state,
+      "open",
+      "the failed primary write must open the circuit",
+    );
+
+    primary.failures.delete("set");
+    await waitFor(() => Date.now() >= expiresAt, {
+      interval: 5,
+      timeout: 1_000,
+      message: "the journaled entry never reached its expiry",
+    });
+    now = 10;
+    await cache.get("key");
+
+    assertEquals(
+      primary.entries.has("key"),
+      false,
+      "an entry that expired while the circuit was open must be deleted, not replayed, on recovery",
+    );
+    assertEquals(
+      primary.calls.get("delete"),
+      1,
+      "recovery must issue exactly one delete for the expired journal entry",
+    );
+    assertEquals(
+      cache.getStatus().pendingMutations,
+      0,
+      "the journal must be drained once the replay completes",
+    );
     await cache.close();
   });
 

--- a/src/proxy/cache/resilient-cache.ts
+++ b/src/proxy/cache/resilient-cache.ts
@@ -19,6 +19,7 @@ const MAX_PENDING_MUTATIONS = 10_000;
 const MAX_QUEUED_MUTATIONS = 10_000;
 const RECOVERY_PROBE_KEY = "__veryfront_cache_recovery_probe__";
 const monotonicNow = () => performance.now();
+const wallNow = () => Date.now();
 
 const logger = proxyLogger.child({ module: "cache" });
 
@@ -30,6 +31,7 @@ type PendingMutation =
 export interface ResilientCacheOptions {
   failureThreshold?: number;
   openDurationMs?: number;
+  wallNow?: () => number;
   now?: () => number;
 }
 
@@ -81,6 +83,7 @@ export class ResilientCache implements TokenCache {
   private readonly failureThreshold: number;
   private readonly openDurationMs: number;
   private readonly now: () => number;
+  private readonly wallNow: () => number;
   private state: ResilientCacheCircuitState = "closed";
   private failureCount = 0;
   private circuitOpenedAt: number | null = null;
@@ -104,7 +107,7 @@ export class ResilientCache implements TokenCache {
     assertCacheOptionsObject(
       options,
       "Resilient cache options",
-      ["failureThreshold", "openDurationMs", "now"],
+      ["failureThreshold", "openDurationMs", "wallNow", "now"],
     );
     this.primary = snapshotTokenCacheOperations(
       primary,
@@ -133,7 +136,13 @@ export class ResilientCache implements TokenCache {
       throw new TypeError("Resilient cache now must be a function");
     }
     this.now = (now as (() => number) | undefined) ?? monotonicNow;
+    const expiryNow = readOwnOption(options, "wallNow");
+    if (expiryNow !== undefined && typeof expiryNow !== "function") {
+      throw new TypeError("Resilient cache wallNow must be a function");
+    }
+    this.wallNow = (expiryNow as (() => number) | undefined) ?? wallNow;
     this.readClock();
+    this.readWallClock();
   }
 
   async get(key: string): Promise<TokenCacheEntry | null> {
@@ -166,7 +175,7 @@ export class ResilientCache implements TokenCache {
         const cacheKey = requireTokenCacheKey(key);
         const cachedEntry = snapshotTokenCacheEntry(entry);
         await this.enqueueMutation(async () => {
-          if (Date.now() >= cachedEntry.expiresAt) {
+          if (this.readWallClock() >= cachedEntry.expiresAt) {
             await this.deleteFromBackends(cacheKey);
             return;
           }
@@ -379,7 +388,7 @@ export class ResilientCache implements TokenCache {
     }
     for (const [key, mutation] of this.pendingMutations) {
       if (mutation.kind === "set") {
-        if (Date.now() >= mutation.entry.expiresAt) {
+        if (this.readWallClock() >= mutation.entry.expiresAt) {
           await this.primary.delete(key);
         } else {
           await this.primary.set(key, mutation.entry);
@@ -468,6 +477,18 @@ export class ResilientCache implements TokenCache {
       value < 0
     ) {
       throw new TypeError("Resilient cache clock returned an invalid time");
+    }
+    return value;
+  }
+
+  private readWallClock(): number {
+    const value = this.wallNow();
+    if (
+      typeof value !== "number" ||
+      !Number.isFinite(value) ||
+      value < 0
+    ) {
+      throw new TypeError("Resilient cache wall clock returned an invalid time");
     }
     return value;
   }

--- a/src/proxy/control-plane-signature.api-contract.test.ts
+++ b/src/proxy/control-plane-signature.api-contract.test.ts
@@ -1,7 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertInstanceOf, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  ControlPlaneBranchBindingError,
   isAuthenticInternalControlPlaneCandidate,
   isVerifiedInternalControlPlaneRequest,
   resolveVerifiedControlPlaneBranchBinding,
@@ -181,11 +182,28 @@ describe("control-plane signature: body binding", () => {
   });
 
   it("rejects a body that does not match the signed request_hash", async () => {
-    await assertRejects(() =>
-      resolveBinding(
-        RUN_BODY,
-        JSON.stringify({ run: { project: {} }, agentSource: { type: "release" }, tampered: true }),
-      )
+    const error = await assertRejects(
+      () =>
+        resolveBinding(
+          RUN_BODY,
+          JSON.stringify({
+            run: { project: {} },
+            agentSource: { type: "release" },
+            tampered: true,
+          }),
+        ),
+      ControlPlaneBranchBindingError,
+      "Invalid control-plane signature",
+    );
+    assertInstanceOf(
+      error,
+      ControlPlaneBranchBindingError,
+      "the rejection must be the typed control-plane binding error, not a bare Error",
+    );
+    assertEquals(
+      error.status,
+      401,
+      "a body-hash mismatch must be the typed 401 the proxy handler can map to a sanitized response",
     );
   });
 });

--- a/src/proxy/error-response.test.ts
+++ b/src/proxy/error-response.test.ts
@@ -19,7 +19,32 @@ describe("createProxyErrorResponse", () => {
     const body = await response.text();
     assertStringIncludes(body, "<title>404 Not Found");
     assertStringIncludes(body, "The page you requested could not be found.");
-    assertEquals(body.includes("x-token header is required in proxy mode"), false);
+    assertEquals(
+      body.includes("Preview project not found"),
+      false,
+      "the 404 page must not echo the internal error message",
+    );
+  });
+
+  it("renders the same not found HTML page for a missing release", async () => {
+    const response = createProxyErrorResponse({
+      status: 502,
+      message: "Release not found for project",
+      slug: "release-not-found",
+    });
+
+    assertEquals(response.status, 404);
+    assertEquals(response.headers.get("Content-Type"), "text/html; charset=utf-8");
+    assertEquals(response.headers.get("Cache-Control"), "no-store");
+
+    const body = await response.text();
+    assertStringIncludes(body, "<title>404 Not Found");
+    assertStringIncludes(body, "The page you requested could not be found.");
+    assertEquals(
+      body.includes("Release not found for project"),
+      false,
+      "the 404 page must not echo the internal error message",
+    );
   });
 
   it("preserves sign-in redirects for protected projects", () => {

--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -688,6 +688,16 @@ describe("Proxy Handler", () => {
         const afterActivation = await handler.processRequest(req());
 
         assertEquals(beforeActivation.error?.status, 404);
+        assertEquals(
+          beforeActivation.error?.message,
+          "No active release found",
+          "the release-not-found branch must keep its distinguishing message",
+        );
+        assertEquals(
+          beforeActivation.error?.slug,
+          "release-not-found",
+          "the slug is what selects the branded HTML 404 page in error-response.ts",
+        );
         assertEquals(afterActivation.error, undefined);
         assertEquals(afterActivation.releaseId, "rel-456");
         assertEquals(afterActivation.environmentId, "env-1");

--- a/src/proxy/hop-by-hop-headers.test.ts
+++ b/src/proxy/hop-by-hop-headers.test.ts
@@ -7,7 +7,9 @@ Deno.test("proxy hop-by-hop headers", () => {
     new Headers({
       Connection: "keep-alive, x-connection-owned",
       "Keep-Alive": "timeout=5",
+      "Proxy-Authenticate": 'Basic realm="upstream"',
       "Proxy-Authorization": "Basic secret",
+      "Proxy-Connection": "keep-alive",
       TE: "trailers",
       Trailer: "x-checksum",
       "Transfer-Encoding": "chunked",
@@ -17,5 +19,29 @@ Deno.test("proxy hop-by-hop headers", () => {
     }),
   );
 
-  assertEquals([...headers], [["x-end-to-end", "preserve"]]);
+  assertEquals(
+    [...headers],
+    [["x-end-to-end", "preserve"]],
+    "only end-to-end headers may survive the hop",
+  );
+});
+
+Deno.test("proxy hop-by-hop headers ignore a malformed Connection token", () => {
+  const headers = createProxyEndToEndHeaders(
+    new Headers({
+      // The client chooses this value, and "a b" is not a valid HTTP token, so
+      // handing it to Headers.delete() would throw and turn an attacker-chosen
+      // header into a 500.
+      Connection: "keep-alive, a b, x-connection-owned",
+      "Keep-Alive": "timeout=5",
+      "X-Connection-Owned": "remove",
+      "X-End-To-End": "preserve",
+    }),
+  );
+
+  assertEquals(
+    [...headers],
+    [["x-end-to-end", "preserve"]],
+    "a malformed connection token must be skipped, not raised as an error",
+  );
 });

--- a/src/proxy/hop-by-hop-headers.test.ts
+++ b/src/proxy/hop-by-hop-headers.test.ts
@@ -1,47 +1,50 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createProxyEndToEndHeaders } from "./hop-by-hop-headers.ts";
 
-Deno.test("proxy hop-by-hop headers", () => {
-  const headers = createProxyEndToEndHeaders(
-    new Headers({
-      Connection: "keep-alive, x-connection-owned",
-      "Keep-Alive": "timeout=5",
-      "Proxy-Authenticate": 'Basic realm="upstream"',
-      "Proxy-Authorization": "Basic secret",
-      "Proxy-Connection": "keep-alive",
-      TE: "trailers",
-      Trailer: "x-checksum",
-      "Transfer-Encoding": "chunked",
-      Upgrade: "h2c",
-      "X-Connection-Owned": "remove",
-      "X-End-To-End": "preserve",
-    }),
-  );
+describe("proxy hop-by-hop headers", () => {
+  it("removes hop-by-hop headers", () => {
+    const headers = createProxyEndToEndHeaders(
+      new Headers({
+        Connection: "keep-alive, x-connection-owned",
+        "Keep-Alive": "timeout=5",
+        "Proxy-Authenticate": 'Basic realm="upstream"',
+        "Proxy-Authorization": "Basic secret",
+        "Proxy-Connection": "keep-alive",
+        TE: "trailers",
+        Trailer: "x-checksum",
+        "Transfer-Encoding": "chunked",
+        Upgrade: "h2c",
+        "X-Connection-Owned": "remove",
+        "X-End-To-End": "preserve",
+      }),
+    );
 
-  assertEquals(
-    [...headers],
-    [["x-end-to-end", "preserve"]],
-    "only end-to-end headers may survive the hop",
-  );
-});
+    assertEquals(
+      [...headers],
+      [["x-end-to-end", "preserve"]],
+      "only end-to-end headers may survive the hop",
+    );
+  });
 
-Deno.test("proxy hop-by-hop headers ignore a malformed Connection token", () => {
-  const headers = createProxyEndToEndHeaders(
-    new Headers({
-      // The client chooses this value, and "a b" is not a valid HTTP token, so
-      // handing it to Headers.delete() would throw and turn an attacker-chosen
-      // header into a 500.
-      Connection: "keep-alive, a b, x-connection-owned",
-      "Keep-Alive": "timeout=5",
-      "X-Connection-Owned": "remove",
-      "X-End-To-End": "preserve",
-    }),
-  );
+  it("ignores a malformed Connection token", () => {
+    const headers = createProxyEndToEndHeaders(
+      new Headers({
+        // The client chooses this value, and "a b" is not a valid HTTP token, so
+        // handing it to Headers.delete() would throw and turn an attacker-chosen
+        // header into a 500.
+        Connection: "keep-alive, a b, x-connection-owned",
+        "Keep-Alive": "timeout=5",
+        "X-Connection-Owned": "remove",
+        "X-End-To-End": "preserve",
+      }),
+    );
 
-  assertEquals(
-    [...headers],
-    [["x-end-to-end", "preserve"]],
-    "a malformed connection token must be skipped, not raised as an error",
-  );
+    assertEquals(
+      [...headers],
+      [["x-end-to-end", "preserve"]],
+      "a malformed connection token must be skipped, not raised as an error",
+    );
+  });
 });

--- a/src/proxy/local-project-resolver.test.ts
+++ b/src/proxy/local-project-resolver.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "#veryfront/testing/assert";
+import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import { createLocalProjectResolver } from "./local-project-resolver.ts";
 
@@ -38,29 +38,73 @@ describe("local project resolver", () => {
       },
     };
 
-    const resolverA = createLocalProjectResolver({
+    let workspace = workspaceA;
+    const resolver = createLocalProjectResolver({
       localProjects: {},
-      basePath: () => workspaceA,
+      basePath: () => workspace,
       fs,
     });
 
-    const firstPath = await resolverA.find("shop");
+    const firstPath = await resolver.find("shop");
     existsCalls.length = 0;
-    const cachedPath = await resolverA.find("shop");
+    const cachedPath = await resolver.find("shop");
 
     assertEquals(firstPath, `${workspaceA}/projects/shop`);
     assertEquals(cachedPath, `${workspaceA}/projects/shop`);
     assertEquals(existsCalls, []);
 
-    const resolverB = createLocalProjectResolver({
-      localProjects: {},
-      basePath: () => workspaceB,
-      fs,
+    // The same resolver, now pointed at another workspace whose directory
+    // carries no Veryfront source marker.
+    workspace = workspaceB;
+
+    assertEquals(
+      await resolver.find("shop"),
+      undefined,
+      "the discovery cache must be keyed by base path, not slug alone",
+    );
+  });
+
+  it("rejects unsafe configured local project entries", () => {
+    assertThrows(
+      () => createLocalProjectResolver({ localProjects: { shop: "relative/path" } }),
+      TypeError,
+      "Invalid configured local project entry: shop",
+    );
+    assertThrows(
+      () => createLocalProjectResolver({ localProjects: { shop: "/a/../b" } }),
+      TypeError,
+      "Invalid configured local project entry: shop",
+    );
+    assertThrows(
+      () => createLocalProjectResolver({ localProjects: { Shop: "/configured/shop" } }),
+      TypeError,
+      "Invalid configured local project entry: Shop",
+    );
+    assertThrows(
+      () =>
+        createLocalProjectResolver({
+          localProjects: { shop: 42 as unknown as string },
+        }),
+      TypeError,
+      "Invalid configured local project entry: shop",
+    );
+  });
+
+  it("rejects a non-canonical discovery base path before filesystem access", async () => {
+    const resolver = createLocalProjectResolver({
+      basePath: () => "relative",
+      fs: {
+        exists(): boolean {
+          throw new Error("must not touch the filesystem");
+        },
+      },
     });
 
-    const workspaceBPath = await resolverB.find("shop");
-
-    assertEquals(workspaceBPath, undefined);
+    await assertRejects(
+      () => resolver.find("shop"),
+      TypeError,
+      "canonical and absolute",
+    );
   });
 
   it("discovers a project whose source roots are declared in config", async () => {

--- a/src/proxy/main.test.ts
+++ b/src/proxy/main.test.ts
@@ -14,6 +14,22 @@ describe("proxy main request URL parsing", () => {
 
     assertStringIncludes(source, "getReplayableRequestBodies(req, maxRetries)");
     assertStringIncludes(source, "upstreamBodies[attempt] ?? null");
+
+    // Teeing inside the loop would hand every retry a consumed body, so pin the
+    // replay array to the scope outside the attempt loop.
+    const teeIndex = source.indexOf(
+      "const upstreamBodies = getReplayableRequestBodies(req, maxRetries);",
+    );
+    const retryLoopIndex = source.indexOf(
+      "for (let attempt = 0; attempt <= maxRetries; attempt++)",
+    );
+    assertEquals(teeIndex >= 0, true, "the replay array must be teed from the incoming request");
+    assertEquals(retryLoopIndex >= 0, true, "the upstream attempts must run in a retry loop");
+    assertEquals(
+      teeIndex < retryLoopIndex,
+      true,
+      "the replay array must be teed once before the retry loop, not per attempt",
+    );
   });
 
   it("drains tracked responses before closing the proxy server", async () => {
@@ -27,6 +43,19 @@ describe("proxy main request URL parsing", () => {
     assertStringIncludes(
       source,
       "proxyRequestDrainTracker.completeOnResponseEnd(requestId, response)",
+    );
+
+    // The call must carry the configured drain budget: waiting for zero would
+    // close the server underneath in-flight responses.
+    assertStringIncludes(
+      source,
+      "await proxyRequestDrainTracker.waitForDrain(SHUTDOWN_DRAIN_TIMEOUT_MS)",
+      "shutdown must wait for the configured drain budget, not a zero timeout",
+    );
+    assertStringIncludes(
+      source,
+      "const DEFAULT_SHUTDOWN_DRAIN_TIMEOUT_MS = 25_000;",
+      "the default drain budget must stay a real waiting window",
     );
 
     const drainIndex = source.indexOf("await proxyRequestDrainTracker.waitForDrain");
@@ -49,13 +78,22 @@ describe("proxy main request URL parsing", () => {
     assertStringIncludes(source, "onInvalidate: proxyHandler.invalidateAndConfirmRoutingLookup");
     assertStringIncludes(source, "handleProxyRoutingInvalidationRequest");
     assertStringIncludes(source, "if (isProduction() && !routingInvalidationBus)");
+    // Each production guard must fail closed. Pinning the `throw` alongside the
+    // message keeps a downgrade to a warning from passing as a guard.
     assertStringIncludes(
       source,
-      "VERYFRONT_PROXY_EXPECTED_REPLICAS must be a positive integer in production",
+      'throw new Error("VERYFRONT_PROXY_EXPECTED_REPLICAS must be a positive integer in production");',
+      "a missing replica count must fail startup closed in production",
     );
     assertStringIncludes(
       source,
-      "VERYFRONT_PROXY_ROUTING_INVALIDATION_SECRET must contain at least 32 bytes in production",
+      'throw new Error(\n    "VERYFRONT_PROXY_ROUTING_INVALIDATION_SECRET must contain at least 32 bytes in production",\n  );',
+      "a short integrity secret must fail startup closed in production",
+    );
+    assertStringIncludes(
+      source,
+      "if (isProduction() && !routingInvalidationBus) {\n  throw new Error(",
+      "a missing invalidation bus must fail startup closed in production",
     );
     assertStringIncludes(source, "integritySecret: routingInvalidationSecret");
 

--- a/src/proxy/mode-parity.test.ts
+++ b/src/proxy/mode-parity.test.ts
@@ -15,6 +15,10 @@ import {
   type ProxyContext,
 } from "./handler.ts";
 import { createMockServer } from "../../tests/_helpers/utils.ts";
+import {
+  decodeIdentityHeaderValue,
+  encodeIdentityHeaderValue,
+} from "#veryfront/utils/header-identity.ts";
 
 function extractProxyHeaders(req: Request): Record<string, string | null> {
   return {
@@ -274,6 +278,89 @@ describe("Proxy-Renderer Mode Parity", () => {
       assertEquals(injected.headers.get("accept"), "text/html");
     });
 
+    it("identity-encodes a non Latin-1 branch name", () => {
+      const ctx: ProxyContext = {
+        projectSlug: "proj",
+        projectId: "proj-id",
+        branchId: "branch-id",
+        branchName: "\u529f\u80fd/\u65b0",
+        environment: "preview",
+        contentSourceId: "preview-branch-id",
+        host: "proj.preview.veryfront.com",
+        parsedDomain: {
+          slug: "proj",
+          isVeryfrontDomain: true,
+          environment: "preview",
+          branch: null,
+          isDraft: true,
+          allowIframeEmbed: true,
+        },
+        isLocalProject: false,
+      };
+
+      const injected = injectContextHeaders(
+        new Request("http://proj.preview.veryfront.com/page"),
+        ctx,
+      );
+
+      assertEquals(
+        injected.headers.get("x-branch-name"),
+        encodeIdentityHeaderValue("\u529f\u80fd/\u65b0"),
+        "a non Latin-1 branch name must be identity-encoded",
+      );
+      assertEquals(
+        injected.headers.get("x-branch-name")?.startsWith("vf-utf8:"),
+        true,
+        "the encoded branch name must carry the vf-utf8 prefix",
+      );
+      assertEquals(
+        decodeIdentityHeaderValue(injected.headers.get("x-branch-name")),
+        "\u529f\u80fd/\u65b0",
+        "the renderer must decode back to the original branch name",
+      );
+    });
+
+    it("identity-encodes a non Latin-1 default branch name", () => {
+      const ctx: ProxyContext = {
+        projectSlug: "proj",
+        projectId: "proj-id",
+        defaultBranchName: "\u529f\u80fd/\u65b0",
+        environment: "preview",
+        contentSourceId: "preview-default",
+        host: "proj.preview.veryfront.com",
+        parsedDomain: {
+          slug: "proj",
+          isVeryfrontDomain: true,
+          environment: "preview",
+          branch: null,
+          isDraft: true,
+          allowIframeEmbed: true,
+        },
+        isLocalProject: false,
+      };
+
+      const injected = injectContextHeaders(
+        new Request("http://proj.preview.veryfront.com/page"),
+        ctx,
+      );
+
+      assertEquals(
+        injected.headers.get("x-default-branch-name"),
+        encodeIdentityHeaderValue("\u529f\u80fd/\u65b0"),
+        "a non Latin-1 default branch name must be identity-encoded",
+      );
+      assertEquals(
+        injected.headers.get("x-default-branch-name")?.startsWith("vf-utf8:"),
+        true,
+        "the encoded default branch name must carry the vf-utf8 prefix",
+      );
+      assertEquals(
+        decodeIdentityHeaderValue(injected.headers.get("x-default-branch-name")),
+        "\u529f\u80fd/\u65b0",
+        "the renderer must decode back to the original default branch name",
+      );
+    });
+
     it("injects a trusted non-main default branch without preview identity", () => {
       const ctx: ProxyContext = {
         projectSlug: "proj",
@@ -455,7 +542,16 @@ describe("Proxy-Renderer Mode Parity", () => {
 
         assertEquals(headers["x-project-slug"], "test-project");
         assertEquals(headers["x-environment"], "preview");
-        assertEquals(typeof headers["x-content-source-id"], "string");
+        assertEquals(
+          headers["x-token"],
+          "shared-token",
+          "the end-to-end path must forward the token minted by /auth/token",
+        );
+        assertEquals(
+          headers["x-content-source-id"],
+          "preview-main",
+          "preview requests must carry the preview-derived content source",
+        );
         assertEquals(headers["x-forwarded-host"], "test-project.preview.veryfront.com:8443");
 
         assertEquals(ctx.projectSlug, "test-project");

--- a/src/proxy/oauth-client.test.ts
+++ b/src/proxy/oauth-client.test.ts
@@ -221,7 +221,7 @@ describe("OAuth Client", () => {
       }
     });
 
-    it("bounds and sanitizes upstream error text", async () => {
+    it("bounds oversized upstream error text", async () => {
       const { fetchOAuthToken, OAuthTokenRequestError } = await import("./oauth-client.ts");
       const { server, port } = createMockServer(
         () =>
@@ -250,6 +250,86 @@ describe("OAuth Client", () => {
       }
     });
 
+    it("redacts credentials in a normal-sized upstream error body", async () => {
+      const { fetchOAuthToken, OAuthTokenRequestError } = await import("./oauth-client.ts");
+      const { server, port } = createMockServer(
+        () =>
+          new Response(
+            "client_secret=do-not-log https://user:password@example.test/path",
+            { status: 401 },
+          ),
+      );
+
+      try {
+        const error = await assertRejects(
+          () =>
+            fetchOAuthToken({
+              apiBaseUrl: `http://127.0.0.1:${port}`,
+              apiClientId: "test",
+              apiClientSecret: "test",
+            }),
+          OAuthTokenRequestError,
+        );
+        if (!(error instanceof OAuthTokenRequestError)) {
+          throw new Error("Expected OAuthTokenRequestError");
+        }
+        assertEquals(
+          error.responseText,
+          "client_secret=[REDACTED] https://user:[REDACTED]@example.test/path",
+          "upstream error text must have URL credentials and client secrets redacted before it reaches the error message",
+        );
+      } finally {
+        await server.shutdown();
+      }
+    });
+
+    it("sends a client_credentials body bound to the configured project", async () => {
+      const { fetchOAuthToken } = await import("./oauth-client.ts");
+      const bodies: Array<Record<string, unknown>> = [];
+      const { server, port } = createMockServer(async (req: Request) => {
+        bodies.push(await req.json() as Record<string, unknown>);
+        return Response.json({
+          access_token: "test-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+        });
+      });
+
+      try {
+        await fetchOAuthToken({
+          apiBaseUrl: `http://127.0.0.1:${port}`,
+          apiClientId: "test",
+          apiClientSecret: "test",
+          projectSlug: "demo-project",
+          customDomain: "demo.example",
+        });
+        assertEquals(
+          bodies[0],
+          {
+            grant_type: "client_credentials",
+            client_id: "test",
+            client_secret: "test",
+            project_slug: "demo-project",
+            custom_domain: "demo.example",
+          },
+          "the token request must carry the client_credentials grant and the project binding",
+        );
+
+        await fetchOAuthToken({
+          apiBaseUrl: `http://127.0.0.1:${port}`,
+          apiClientId: "test",
+          apiClientSecret: "test",
+        });
+        assertEquals(
+          "project_slug" in (bodies[1] ?? {}),
+          false,
+          "an unbound token request must omit project_slug",
+        );
+      } finally {
+        await server.shutdown();
+      }
+    });
+
     it("rejects non-HTTP API bases and unsafe timeout policy", async () => {
       const { fetchOAuthToken } = await import("./oauth-client.ts");
 
@@ -262,6 +342,26 @@ describe("OAuth Client", () => {
           }),
         TypeError,
         "HTTP(S)",
+      );
+      await assertRejects(
+        () =>
+          fetchOAuthToken({
+            apiBaseUrl: "https://user:pass@api.example.test",
+            apiClientId: "test",
+            apiClientSecret: "test",
+          }),
+        TypeError,
+        "without credentials",
+      );
+      await assertRejects(
+        () =>
+          fetchOAuthToken({
+            apiBaseUrl: "https://user@api.example.test",
+            apiClientId: "test",
+            apiClientSecret: "test",
+          }),
+        TypeError,
+        "without credentials",
       );
       await assertRejects(
         () =>

--- a/src/proxy/project-metadata-client.test.ts
+++ b/src/proxy/project-metadata-client.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert";
+import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import {
   createProjectMetadataClient,
@@ -24,6 +24,18 @@ function routingMetadata() {
       name: "production",
       domains: ["STORE.example.com."],
       active_release_id: "release-1",
+    }],
+  };
+}
+
+function accessMetadata() {
+  return {
+    id: "project-1",
+    slug: "storefront",
+    environments: [{
+      id: "environment-1",
+      name: "production",
+      protected: false,
     }],
   };
 }
@@ -75,6 +87,35 @@ describe("proxy project metadata client", () => {
     );
     assertEquals((failure as ProxyLookupFailure).publicStatus, 502);
     assertEquals((failure as ProxyLookupFailure).upstreamStatus, 500);
+
+    const forbidden = createProjectMetadataClient({
+      apiBaseUrl: "https://api.example.com",
+      fetchImpl: makeFetch(() => new Response(null, { status: 403 })),
+    });
+    const forbiddenError = await assertRejects(
+      () => forbidden.lookupRouting("storefront", "token"),
+      ProxyLookupAuthError,
+    );
+    assertEquals(
+      (forbiddenError as ProxyLookupAuthError).status,
+      403,
+      "a forbidden metadata response is an authorization rejection, not an upstream outage",
+    );
+
+    const rateLimited = createProjectMetadataClient({
+      apiBaseUrl: "https://api.example.com",
+      fetchImpl: makeFetch(() => new Response(null, { status: 429 })),
+    });
+    const rateLimitFailure = await assertRejects(
+      () => rateLimited.lookupRouting("storefront", "token"),
+      ProxyLookupFailure,
+    );
+    assertEquals(
+      (rateLimitFailure as ProxyLookupFailure).publicStatus,
+      503,
+      "an upstream rate limit must surface with retry semantics, not as a bad gateway",
+    );
+    assertEquals((rateLimitFailure as ProxyLookupFailure).upstreamStatus, 429);
   });
 
   it("records only non-sensitive upstream diagnostics", async () => {
@@ -200,6 +241,63 @@ describe("proxy project metadata client", () => {
     );
   });
 
+  it("requests the member list only when the caller asks for it", async () => {
+    let requestedUrl: URL | undefined;
+    const client = createProjectMetadataClient({
+      apiBaseUrl: "https://api.example.com",
+      fetchImpl: makeFetch((url) => {
+        requestedUrl = url;
+        return Response.json(accessMetadata());
+      }),
+    });
+
+    await client.lookupAccess("storefront", "token", true);
+    assertEquals(
+      requestedUrl?.searchParams.get("include_users"),
+      "true",
+      "an access lookup that needs the member list must request it",
+    );
+
+    await client.lookupAccess("storefront", "token", false);
+    assertEquals(
+      requestedUrl?.searchParams.get("include_users"),
+      "false",
+      "the member-list flag must round-trip rather than being hard-coded",
+    );
+  });
+
+  it("rejects member lists that cannot gate a protected-access decision", async () => {
+    const duplicateUsers = createProjectMetadataClient({
+      apiBaseUrl: "https://api.example.com",
+      fetchImpl: makeFetch(() =>
+        Response.json({
+          ...accessMetadata(),
+          users: [{ id: "usr_1" }, { id: "usr_1" }],
+        })
+      ),
+    });
+    await assertRejects(
+      () => duplicateUsers.lookupAccess("storefront", "token", true),
+      ProxyLookupFailure,
+      "invalid response",
+    );
+
+    const missingUserId = createProjectMetadataClient({
+      apiBaseUrl: "https://api.example.com",
+      fetchImpl: makeFetch(() =>
+        Response.json({
+          ...accessMetadata(),
+          users: [{}],
+        })
+      ),
+    });
+    await assertRejects(
+      () => missingUserId.lookupAccess("storefront", "token", true),
+      ProxyLookupFailure,
+      "invalid response",
+    );
+  });
+
   it("enforces the deadline even when an injected fetch ignores abort", async () => {
     let calls = 0;
     const client = createProjectMetadataClient({
@@ -290,6 +388,24 @@ describe("proxy project metadata client", () => {
         ),
       TypeError,
       "HTTP(S)",
+    );
+
+    // A base URL carrying credentials, a query or a fragment would leak into or
+    // mis-resolve every metadata fetch URL.
+    assertThrows(
+      () => createProjectMetadataClient({ apiBaseUrl: "https://svc:s3cret@api.example.com" }),
+      TypeError,
+      "without credentials",
+    );
+    assertThrows(
+      () => createProjectMetadataClient({ apiBaseUrl: "https://api.example.com/?x=1" }),
+      TypeError,
+      "without credentials",
+    );
+    assertThrows(
+      () => createProjectMetadataClient({ apiBaseUrl: "https://api.example.com/#frag" }),
+      TypeError,
+      "without credentials",
     );
 
     const client = createProjectMetadataClient({

--- a/src/proxy/proxy-auth-provider.test.ts
+++ b/src/proxy/proxy-auth-provider.test.ts
@@ -5,10 +5,7 @@ import { register, reset, resolve, tryResolve } from "../extensions/contracts.ts
 import { createAuthProvider } from "../../extensions/ext-auth-jwt/src/index.ts";
 import type { AuthProvider } from "../extensions/auth/index.ts";
 
-describe("Proxy AuthProvider contract registration", {
-  sanitizeOps: false,
-  sanitizeResources: false,
-}, () => {
+describe("Proxy AuthProvider contract registration", () => {
   it("ext-auth-jwt registers a valid AuthProvider", () => {
     reset();
     const provider = createAuthProvider({});

--- a/src/proxy/proxy-token-resolution.test.ts
+++ b/src/proxy/proxy-token-resolution.test.ts
@@ -86,6 +86,29 @@ describe("proxy/proxy-token-resolution", () => {
     assertEquals(result.tokenSource, "service");
   });
 
+  it("classifies both documented missing-project statuses", () => {
+    assertEquals(
+      isMissingProxyProjectError(new OAuthTokenRequestError(404, "{}")),
+      true,
+      "404 must classify as a missing project",
+    );
+    assertEquals(
+      isMissingProxyProjectError(new OAuthTokenRequestError(400, "{}")),
+      true,
+      "400 remains the legacy missing-project status",
+    );
+    assertEquals(
+      isMissingProxyProjectError(new OAuthTokenRequestError(500, "{}")),
+      false,
+      "an upstream outage must not be swallowed as a missing project",
+    );
+    assertEquals(
+      isMissingProxyProjectError(new Error("boom")),
+      false,
+      "only typed OAuth errors classify",
+    );
+  });
+
   it("returns custom-domain token fetch errors without logging expected misses as errors", async () => {
     const loggedErrors: string[] = [];
     const notFoundError = new OAuthTokenRequestError(

--- a/src/proxy/request-host.test.ts
+++ b/src/proxy/request-host.test.ts
@@ -42,6 +42,7 @@ describe("proxy request host normalization", () => {
   });
 
   it("rejects credentials and non-authority components", () => {
+    assertEquals(normalizeProxyRequestHost("example.com"), "example.com");
     for (
       const authority of [
         "",
@@ -51,12 +52,17 @@ describe("proxy request host normalization", () => {
         "example.com?query",
         "example.com#fragment",
         "example.com\\path",
+        "exam" + String.fromCharCode(9) + "ple.com",
+        "example.com" + String.fromCharCode(0),
+        "exam" + String.fromCharCode(13, 10) + "ple.com",
+        "a".repeat(1025) + ".example",
       ]
     ) {
       assertThrows(
         () => normalizeProxyRequestHost(authority),
         TypeError,
         "Host header is invalid",
+        "a Host authority with embedded control characters or over the length bound must be rejected, not silently normalized",
       );
     }
   });

--- a/src/proxy/request-lifecycle.test.ts
+++ b/src/proxy/request-lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { Context, Span } from "#veryfront/observability/tracing/api-shim.ts";
 import { runProxyRequestLifecycle } from "./request-lifecycle.ts";
@@ -73,25 +73,31 @@ describe("proxy request lifecycle", () => {
     const span = {} as Span;
     const ended: string[] = [];
 
-    try {
-      await runProxyRequestLifecycle({
-        req,
-        url: new URL(req.url),
-        extractContext: () => undefined,
-        startServerSpan: () => ({ span, context: {} as Context }),
-        withContext: (_context, fn) => fn(),
-        endSpan(_span, statusCode, error) {
-          ended.push(`${statusCode}:${error?.message ?? ""}`);
-        },
-        handle: () => {
-          throw new Error("boom");
-        },
-      });
-    } catch (error) {
-      assertEquals(error instanceof Error ? error.message : String(error), "boom");
-    }
+    const error = await assertRejects(
+      () =>
+        runProxyRequestLifecycle({
+          req,
+          url: new URL(req.url),
+          extractContext: () => undefined,
+          startServerSpan: () => ({ span, context: {} as Context }),
+          withContext: (_context, fn) => fn(),
+          endSpan(_span, statusCode, spanError) {
+            ended.push(`${statusCode}:${spanError?.message ?? ""}`);
+          },
+          handle: () => {
+            throw new Error("boom");
+          },
+        }),
+      Error,
+      "boom",
+    );
 
-    assertEquals(ended, ["500:boom"]);
+    assertEquals(
+      error instanceof Error ? error.message : String(error),
+      "boom",
+      "the original handler error must propagate to the caller",
+    );
+    assertEquals(ended, ["500:boom"], "the span must be ended once with the thrown error");
   });
 
   it("contains hostile non-Error throws while preserving the original rejection", async () => {

--- a/src/proxy/response-body.test.ts
+++ b/src/proxy/response-body.test.ts
@@ -45,13 +45,20 @@ describe("proxy response body reader", () => {
     );
   });
 
-  // Zero-length chunks skip the byte accounting entirely, so only the chunk
-  // guard can stop an upstream that streams them forever.
-  it("rejects an upstream stream that emits unbounded empty chunks", async () => {
+  // Zero-length chunks skip the byte accounting entirely, so the fixture emits
+  // one more than MAX_RESPONSE_BODY_CHUNKS to exercise the independent guard.
+  // Keeping it finite makes a broken guard fail the rejection assertion instead
+  // of hanging the test worker forever.
+  it("rejects an upstream stream that emits too many empty chunks", async () => {
     let emitted = 0;
+    const totalChunks = 65_537;
     const response = new Response(
       new ReadableStream<Uint8Array>({
         pull(controller) {
+          if (emitted >= totalChunks) {
+            controller.close();
+            return;
+          }
           emitted++;
           controller.enqueue(new Uint8Array(0));
         },
@@ -63,12 +70,10 @@ describe("proxy response body reader", () => {
       ProxyResponseBodyError,
       "too-many-chunks",
     );
-    // MAX_RESPONSE_BODY_CHUNKS is 65_536, plus the chunk that trips the guard
-    // and one the stream queues ahead.
     assertEquals(
-      emitted <= 65_538,
-      true,
-      "the chunk guard must trip at MAX_RESPONSE_BODY_CHUNKS instead of reading forever",
+      emitted,
+      totalChunks,
+      "the chunk guard must trip on the first chunk beyond MAX_RESPONSE_BODY_CHUNKS",
     );
   });
 

--- a/src/proxy/response-body.test.ts
+++ b/src/proxy/response-body.test.ts
@@ -45,6 +45,33 @@ describe("proxy response body reader", () => {
     );
   });
 
+  // Zero-length chunks skip the byte accounting entirely, so only the chunk
+  // guard can stop an upstream that streams them forever.
+  it("rejects an upstream stream that emits unbounded empty chunks", async () => {
+    let emitted = 0;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        pull(controller) {
+          emitted++;
+          controller.enqueue(new Uint8Array(0));
+        },
+      }),
+    );
+
+    await assertRejects(
+      () => readProxyResponseBytes(response, 16),
+      ProxyResponseBodyError,
+      "too-many-chunks",
+    );
+    // MAX_RESPONSE_BODY_CHUNKS is 65_536, plus the chunk that trips the guard
+    // and one the stream queues ahead.
+    assertEquals(
+      emitted <= 65_538,
+      true,
+      "the chunk guard must trip at MAX_RESPONSE_BODY_CHUNKS instead of reading forever",
+    );
+  });
+
   it("rejects invalid UTF-8 instead of replacing bytes", async () => {
     const response = new Response(new Uint8Array([0xc3, 0x28]));
 

--- a/src/proxy/response-headers.test.ts
+++ b/src/proxy/response-headers.test.ts
@@ -48,6 +48,37 @@ describe("proxy response headers", () => {
     assertEquals(getSetCookies(response.headers), ["session=keep; Path=/; HttpOnly"]);
   });
 
+  it("removes the sticky cookie from an s-maxage only shared-cacheable response", () => {
+    const headers = new Headers({
+      "Cache-Control": "public, s-maxage=600",
+      "Content-Type": "text/html",
+    });
+    headers.append("Set-Cookie", "lb=server-a; Path=/; HttpOnly");
+    headers.append("Set-Cookie", "session=keep; Path=/; HttpOnly");
+
+    const response = removeStickyCookieFromPublicCacheableResponse(
+      new Response("html", { headers }),
+    );
+
+    assertEquals(
+      getSetCookies(response.headers),
+      ["session=keep; Path=/; HttpOnly"],
+      "s-maxage marks the response shared-cacheable so lb must be stripped",
+    );
+
+    const zeroHeaders = new Headers({ "Cache-Control": "public, s-maxage=0" });
+    zeroHeaders.append("Set-Cookie", "lb=server-a; Path=/; HttpOnly");
+    const zeroResponse = removeStickyCookieFromPublicCacheableResponse(
+      new Response("html", { headers: zeroHeaders }),
+    );
+
+    assertEquals(
+      getSetCookies(zeroResponse.headers),
+      ["lb=server-a; Path=/; HttpOnly"],
+      "s-maxage=0 is not a shared-cacheable lifetime",
+    );
+  });
+
   it("leaves non-cacheable sticky-cookie responses untouched", () => {
     const headers = new Headers({
       "Cache-Control": "private, no-store",

--- a/src/proxy/retry.test.ts
+++ b/src/proxy/retry.test.ts
@@ -246,6 +246,39 @@ describe("shouldRetryUpstreamRequest", () => {
     );
   });
 
+  it("retries a bodyless run stream invocation on any retryable connection error", () => {
+    const request = new Request(RUN_STREAM_URL, {
+      method: "POST",
+      headers: { "content-length": "0" },
+    });
+
+    assertEquals(
+      shouldRetryUpstreamRequest(request, RUN_STREAM_PATH, new Error("connection reset")),
+      true,
+      "a bodyless run stream POST must fail over on a reset connection",
+    );
+    assertEquals(
+      shouldRetryUpstreamRequest(request, RUN_STREAM_PATH, new Error("connection closed")),
+      true,
+      "a bodyless run stream POST must fail over on a closed connection",
+    );
+    assertEquals(
+      shouldRetryUpstreamRequest(request, RUN_STREAM_PATH, new Error("connection refused")),
+      true,
+      "a bodyless run stream POST must fail over on a refused connection",
+    );
+    assertEquals(
+      shouldRetryUpstreamRequest(request, RUN_STREAM_PATH, new Error("Not found")),
+      false,
+      "a non-connection failure must not be replayed",
+    );
+    assertEquals(
+      getUpstreamRetryCount(request, RUN_STREAM_PATH, 3),
+      1,
+      "a bodyless run stream POST gets exactly one retry",
+    );
+  });
+
   it("retains broad connection retries for bodyless idempotent requests", () => {
     const request = new Request("http://proxy.test/");
     assertEquals(

--- a/src/proxy/routing-invalidation-redis.test.ts
+++ b/src/proxy/routing-invalidation-redis.test.ts
@@ -71,12 +71,22 @@ function createFakeRedisServer() {
     | ((channel: string, message: string) => void | Promise<void>)
     | undefined;
 
+  const deliveredPerChannel = new Map<string, number>();
+
   const publishRaw = async (channel: string, message: string): Promise<number> => {
     await onPublish?.(channel, message);
     const listeners = [...subscriptions.values()]
       .map((channels) => channels.get(channel))
       .filter((listener): listener is RedisListener => Boolean(listener));
-    for (const listener of listeners) queueMicrotask(() => listener(message, channel));
+    for (const listener of listeners) {
+      queueMicrotask(() => {
+        try {
+          listener(message, channel);
+        } finally {
+          deliveredPerChannel.set(channel, (deliveredPerChannel.get(channel) ?? 0) + 1);
+        }
+      });
+    }
     return listeners.length;
   };
 
@@ -118,6 +128,17 @@ function createFakeRedisServer() {
   return {
     clients,
     createClient,
+    /**
+     * Number of listener invocations that have already returned for a channel.
+     *
+     * A subscriber listener is synchronous up to its first suspension point, so
+     * an increment here means every synchronous step that listener performs for
+     * that message - including dispatching its WebCrypto verification - has
+     * already happened.
+     */
+    deliveredCount(channel: string): number {
+      return deliveredPerChannel.get(channel) ?? 0;
+    },
     emitClientEvent(clientIndex: number, event: string, value?: unknown) {
       const client = clients[clientIndex];
       if (!client) throw new Error(`Missing Redis client ${clientIndex}`);
@@ -193,41 +214,105 @@ function deferred(): {
 
 const SENTINEL_EVENT_ID = "sentinel-event";
 
+async function spinUntil(
+  predicate: () => boolean,
+  failure: string,
+  turns = 200,
+): Promise<void> {
+  for (let turn = 0; turn < turns; turn++) {
+    if (predicate()) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+  if (predicate()) return;
+  throw new Error(`${failure} within ${turns} event-loop turns`);
+}
+
+async function settleEventLoop(turns = 5): Promise<void> {
+  for (let turn = 0; turn < turns; turn++) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+}
+
 /**
- * Publishes a well-formed invalidation and waits until the replica applies it.
+ * Publishes an envelope the bus must reject, then a sentinel it must apply, and
+ * returns only once both listener pipelines have finished.
  *
  * A rejected envelope produces no observable signal, so a negative assertion
- * made after a single event-loop turn passes even when the guard under test is
- * gone and the event is merely applied a few turns later. Draining a sentinel
- * that must be applied proves the subscriber finished the asynchronous
- * signature pipeline for everything published before it.
+ * made a few turns after publishing passes even when the guard under test is
+ * gone and the event is merely applied later. Waiting for a sentinel is not
+ * sufficient on its own either: the fake server queues every listener
+ * independently and the production subscriber starts `verifySignedEnvelope`
+ * without awaiting it, so the sentinel's WebCrypto verification can settle
+ * before the rejected envelope's and prove nothing about it.
+ *
+ * The two are therefore serialised. `verifySignedEnvelope` reaches
+ * `crypto.subtle.verify` before its first suspension, so once the fake server
+ * reports the rejected envelope's listener invocation as returned, any
+ * verification that envelope triggers is already counted in
+ * `pendingVerifications`; draining that counter to zero and settling the queued
+ * continuations means the rejected envelope has been fully processed before the
+ * sentinel is even published.
  */
-async function drainInvalidationsWithSentinel(
+async function publishRejectedEnvelopeAndDrain(
   redis: ReturnType<typeof createFakeRedisServer>,
   integritySecret: string,
   observed: ProxyRoutingInvalidationEvent[],
+  rejectedEnvelope: string,
 ): Promise<void> {
-  await redis.publishRaw(
-    ROUTING_INVALIDATION_CHANNEL,
-    await signTestEnvelope(
-      EVENT_SIGNATURE_DOMAIN,
-      JSON.stringify(createEvent(SENTINEL_EVENT_ID)),
-      integritySecret,
-    ),
-  );
-  for (let turn = 0; turn < 200; turn++) {
-    if (observed.some((event) => event.eventId === SENTINEL_EVENT_ID)) {
-      // Let any straggling delivery surface before the caller asserts.
-      for (let settle = 0; settle < 5; settle++) {
-        await new Promise<void>((resolve) => setTimeout(resolve, 0));
-      }
-      return;
+  const originalVerify = crypto.subtle.verify.bind(crypto.subtle);
+  const originalVerifyDescriptor = Object.getOwnPropertyDescriptor(crypto.subtle, "verify");
+  let pendingVerifications = 0;
+  Object.defineProperty(crypto.subtle, "verify", {
+    configurable: true,
+    value: (...args: Parameters<SubtleCrypto["verify"]>) => {
+      pendingVerifications++;
+      return originalVerify(...args).finally(() => {
+        pendingVerifications--;
+      });
+    },
+  });
+
+  try {
+    const deliveredBefore = redis.deliveredCount(ROUTING_INVALIDATION_CHANNEL);
+    await redis.publishRaw(ROUTING_INVALIDATION_CHANNEL, rejectedEnvelope);
+    await spinUntil(
+      () => redis.deliveredCount(ROUTING_INVALIDATION_CHANNEL) > deliveredBefore,
+      "the rejected envelope was never delivered to the subscriber",
+    );
+    await spinUntil(
+      () => pendingVerifications === 0,
+      "the rejected envelope's signature verification never settled",
+    );
+    await settleEventLoop();
+
+    await redis.publishRaw(
+      ROUTING_INVALIDATION_CHANNEL,
+      await signTestEnvelope(
+        EVENT_SIGNATURE_DOMAIN,
+        JSON.stringify(createEvent(SENTINEL_EVENT_ID)),
+        integritySecret,
+      ),
+    );
+    await spinUntil(
+      () => observed.some((event) => event.eventId === SENTINEL_EVENT_ID),
+      "the sentinel invalidation was never applied",
+    );
+    await spinUntil(
+      () => pendingVerifications === 0,
+      "the sentinel's signature verification never settled",
+    );
+    // Let any straggling delivery surface before the caller asserts.
+    await settleEventLoop();
+  } finally {
+    if (originalVerifyDescriptor) {
+      Object.defineProperty(crypto.subtle, "verify", originalVerifyDescriptor);
+    } else {
+      Object.defineProperty(crypto.subtle, "verify", {
+        configurable: true,
+        value: originalVerify,
+      });
     }
-    await new Promise<void>((resolve) => setTimeout(resolve, 0));
   }
-  throw new Error(
-    "the sentinel invalidation was never applied within 200 event-loop turns",
-  );
 }
 
 describe("proxy routing invalidation Redis bus", () => {
@@ -594,15 +679,16 @@ describe("proxy routing invalidation Redis bus", () => {
       },
     });
 
-    await redis.publishRaw(
-      ROUTING_INVALIDATION_CHANNEL,
+    await publishRejectedEnvelopeAndDrain(
+      redis,
+      integritySecret,
+      replicaEvents,
       await signTestEnvelope(
         ACK_SIGNATURE_DOMAIN,
         JSON.stringify(createEvent()),
         integritySecret,
       ),
     );
-    await drainInvalidationsWithSentinel(redis, integritySecret, replicaEvents);
 
     assertEquals(
       replicaEvents.map((event) => event.eventId),
@@ -629,8 +715,10 @@ describe("proxy routing invalidation Redis bus", () => {
       },
     });
 
-    await redis.publishRaw(
-      ROUTING_INVALIDATION_CHANNEL,
+    await publishRejectedEnvelopeAndDrain(
+      redis,
+      integritySecret,
+      replicaEvents,
       await signTestEnvelope(
         EVENT_SIGNATURE_DOMAIN,
         JSON.stringify(createEvent()),
@@ -638,7 +726,6 @@ describe("proxy routing invalidation Redis bus", () => {
         TEST_NOW_MS - 61_000,
       ),
     );
-    await drainInvalidationsWithSentinel(redis, integritySecret, replicaEvents);
 
     assertEquals(
       replicaEvents.map((event) => event.eventId),
@@ -665,8 +752,10 @@ describe("proxy routing invalidation Redis bus", () => {
       },
     });
 
-    await redis.publishRaw(
-      ROUTING_INVALIDATION_CHANNEL,
+    await publishRejectedEnvelopeAndDrain(
+      redis,
+      integritySecret,
+      replicaEvents,
       await signTestEnvelope(
         EVENT_SIGNATURE_DOMAIN,
         JSON.stringify(createEvent()),
@@ -674,7 +763,6 @@ describe("proxy routing invalidation Redis bus", () => {
         TEST_NOW_MS + 6_000,
       ),
     );
-    await drainInvalidationsWithSentinel(redis, integritySecret, replicaEvents);
 
     assertEquals(
       replicaEvents.map((event) => event.eventId),

--- a/src/proxy/routing-invalidation-redis.test.ts
+++ b/src/proxy/routing-invalidation-redis.test.ts
@@ -307,10 +307,9 @@ async function publishRejectedEnvelopeAndDrain(
     if (originalVerifyDescriptor) {
       Object.defineProperty(crypto.subtle, "verify", originalVerifyDescriptor);
     } else {
-      Object.defineProperty(crypto.subtle, "verify", {
-        configurable: true,
-        value: originalVerify,
-      });
+      // `verify` is inherited from `SubtleCrypto.prototype`: delete the override
+      // instead of redefining it, so later tests can still stub `verify`.
+      Reflect.deleteProperty(crypto.subtle, "verify");
     }
   }
 }
@@ -372,10 +371,9 @@ function answerEventWithRejectedAcknowledgement(
       if (originalVerifyDescriptor) {
         Object.defineProperty(crypto.subtle, "verify", originalVerifyDescriptor);
       } else {
-        Object.defineProperty(crypto.subtle, "verify", {
-          configurable: true,
-          value: originalVerify,
-        });
+        // `verify` is inherited from `SubtleCrypto.prototype`: delete the override
+        // instead of redefining it, so later tests can still stub `verify`.
+        Reflect.deleteProperty(crypto.subtle, "verify");
       }
     },
   };
@@ -617,10 +615,9 @@ describe("proxy routing invalidation Redis bus", () => {
       if (originalVerifyDescriptor) {
         Object.defineProperty(crypto.subtle, "verify", originalVerifyDescriptor);
       } else {
-        Object.defineProperty(crypto.subtle, "verify", {
-          configurable: true,
-          value: originalVerify,
-        });
+        // `verify` is inherited from `SubtleCrypto.prototype`: delete the override
+        // instead of redefining it, so later tests can still stub `verify`.
+        Reflect.deleteProperty(crypto.subtle, "verify");
       }
       await busA?.close();
       await busB?.close();

--- a/src/proxy/routing-invalidation-redis.test.ts
+++ b/src/proxy/routing-invalidation-redis.test.ts
@@ -191,6 +191,45 @@ function deferred(): {
   return { promise, reject, resolve };
 }
 
+const SENTINEL_EVENT_ID = "sentinel-event";
+
+/**
+ * Publishes a well-formed invalidation and waits until the replica applies it.
+ *
+ * A rejected envelope produces no observable signal, so a negative assertion
+ * made after a single event-loop turn passes even when the guard under test is
+ * gone and the event is merely applied a few turns later. Draining a sentinel
+ * that must be applied proves the subscriber finished the asynchronous
+ * signature pipeline for everything published before it.
+ */
+async function drainInvalidationsWithSentinel(
+  redis: ReturnType<typeof createFakeRedisServer>,
+  integritySecret: string,
+  observed: ProxyRoutingInvalidationEvent[],
+): Promise<void> {
+  await redis.publishRaw(
+    ROUTING_INVALIDATION_CHANNEL,
+    await signTestEnvelope(
+      EVENT_SIGNATURE_DOMAIN,
+      JSON.stringify(createEvent(SENTINEL_EVENT_ID)),
+      integritySecret,
+    ),
+  );
+  for (let turn = 0; turn < 200; turn++) {
+    if (observed.some((event) => event.eventId === SENTINEL_EVENT_ID)) {
+      // Let any straggling delivery surface before the caller asserts.
+      for (let settle = 0; settle < 5; settle++) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      }
+      return;
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error(
+    "the sentinel invalidation was never applied within 200 event-loop turns",
+  );
+}
+
 describe("proxy routing invalidation Redis bus", () => {
   it("warns for a managed socket recycle and reports successful resubscription", async () => {
     const redis = createFakeRedisServer();
@@ -563,9 +602,13 @@ describe("proxy routing invalidation Redis bus", () => {
         integritySecret,
       ),
     );
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await drainInvalidationsWithSentinel(redis, integritySecret, replicaEvents);
 
-    assertEquals(replicaEvents, []);
+    assertEquals(
+      replicaEvents.map((event) => event.eventId),
+      [SENTINEL_EVENT_ID],
+      "an envelope signed for the acknowledgement domain must not be applied",
+    );
     await bus?.close();
   });
 
@@ -595,9 +638,13 @@ describe("proxy routing invalidation Redis bus", () => {
         TEST_NOW_MS - 61_000,
       ),
     );
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await drainInvalidationsWithSentinel(redis, integritySecret, replicaEvents);
 
-    assertEquals(replicaEvents, []);
+    assertEquals(
+      replicaEvents.map((event) => event.eventId),
+      [SENTINEL_EVENT_ID],
+      "an envelope issued beyond the maximum age must not be applied",
+    );
     await bus?.close();
   });
 
@@ -627,11 +674,11 @@ describe("proxy routing invalidation Redis bus", () => {
         TEST_NOW_MS + 6_000,
       ),
     );
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await drainInvalidationsWithSentinel(redis, integritySecret, replicaEvents);
 
     assertEquals(
-      replicaEvents,
-      [],
+      replicaEvents.map((event) => event.eventId),
+      [SENTINEL_EVENT_ID],
       "an envelope issued beyond the clock-skew allowance must not be applied",
     );
     await bus?.close();

--- a/src/proxy/routing-invalidation-redis.test.ts
+++ b/src/proxy/routing-invalidation-redis.test.ts
@@ -315,6 +315,72 @@ async function publishRejectedEnvelopeAndDrain(
   }
 }
 
+/**
+ * Installs a fake-server publish hook that answers the bus's invalidation
+ * event with an acknowledgement the bus must reject, and only lets the event
+ * publish complete once that acknowledgement has been fully processed.
+ *
+ * The production `publish()` starts its `acknowledgementTimeoutMs` timer only
+ * after `publishClient.publish` resolves, and the fake server awaits this hook
+ * before resolving it. Delivering the rejected acknowledgement here, waiting
+ * for its listener invocation to return, draining every WebCrypto verification
+ * it started, and settling the queued continuations therefore guarantees that
+ * the acknowledgement's fate is decided before the timer is even armed. If the
+ * guard under test were removed, `acknowledgedReplicas` would already hold the
+ * forged replica when `publish()` checks it, and the result would report
+ * `acknowledged: 1` regardless of how long verification took. Without this
+ * ordering a slow verification could lose the race against the timeout and let
+ * the negative assertion pass vacuously.
+ *
+ * Returns a restore function the caller must invoke once `publish()` settles.
+ */
+function answerEventWithRejectedAcknowledgement(
+  redis: ReturnType<typeof createFakeRedisServer>,
+  buildAcknowledgement: () => Promise<string>,
+): { restore: () => void } {
+  const originalVerify = crypto.subtle.verify.bind(crypto.subtle);
+  const originalVerifyDescriptor = Object.getOwnPropertyDescriptor(crypto.subtle, "verify");
+  let pendingVerifications = 0;
+  Object.defineProperty(crypto.subtle, "verify", {
+    configurable: true,
+    value: (...args: Parameters<SubtleCrypto["verify"]>) => {
+      pendingVerifications++;
+      return originalVerify(...args).finally(() => {
+        pendingVerifications--;
+      });
+    },
+  });
+
+  redis.setOnPublish(async (channel) => {
+    if (channel !== ROUTING_INVALIDATION_CHANNEL) return;
+    const acknowledgementChannel = `${ROUTING_INVALIDATION_ACK_PREFIX}event-1`;
+    const deliveredBefore = redis.deliveredCount(acknowledgementChannel);
+    await redis.publishRaw(acknowledgementChannel, await buildAcknowledgement());
+    await spinUntil(
+      () => redis.deliveredCount(acknowledgementChannel) > deliveredBefore,
+      "the rejected acknowledgement was never delivered to the publisher",
+    );
+    await spinUntil(
+      () => pendingVerifications === 0,
+      "the rejected acknowledgement's signature verification never settled",
+    );
+    await settleEventLoop();
+  });
+
+  return {
+    restore() {
+      if (originalVerifyDescriptor) {
+        Object.defineProperty(crypto.subtle, "verify", originalVerifyDescriptor);
+      } else {
+        Object.defineProperty(crypto.subtle, "verify", {
+          configurable: true,
+          value: originalVerify,
+        });
+      }
+    },
+  };
+}
+
 describe("proxy routing invalidation Redis bus", () => {
   it("warns for a managed socket recycle and reports successful resubscription", async () => {
     const redis = createFakeRedisServer();
@@ -775,17 +841,15 @@ describe("proxy routing invalidation Redis bus", () => {
   it("ignores forged Redis acknowledgements", async () => {
     const redis = createFakeRedisServer();
     const integritySecret = createIntegritySecret();
-    redis.setOnPublish(async (channel) => {
-      if (channel !== ROUTING_INVALIDATION_CHANNEL) return;
-      await redis.publishRaw(
-        `${ROUTING_INVALIDATION_ACK_PREFIX}event-1`,
-        await signTestEnvelope(
+    const acknowledgement = answerEventWithRejectedAcknowledgement(
+      redis,
+      () =>
+        signTestEnvelope(
           EVENT_SIGNATURE_DOMAIN,
           JSON.stringify({ eventId: "event-1", replicaId: "replica-b" }),
           integritySecret,
         ),
-      );
-    });
+    );
     const bus = await startProxyRoutingInvalidationBus({
       redisUrl: "redis://example.test:6379",
       expectedReplicas: 1,
@@ -799,27 +863,33 @@ describe("proxy routing invalidation Redis bus", () => {
       },
     });
 
-    const result = await bus?.publish(createEvent());
+    try {
+      const result = await bus?.publish(createEvent());
 
-    assertEquals(result, { acknowledged: 0, converged: false, recipients: 1 });
-    await bus?.close();
+      assertEquals(
+        result,
+        { acknowledged: 0, converged: false, recipients: 1 },
+        "an acknowledgement signed under the event domain must not count toward convergence",
+      );
+    } finally {
+      acknowledgement.restore();
+      await bus?.close();
+    }
   });
 
   it("ignores expired Redis acknowledgements", async () => {
     const redis = createFakeRedisServer();
     const integritySecret = createIntegritySecret();
-    redis.setOnPublish(async (channel) => {
-      if (channel !== ROUTING_INVALIDATION_CHANNEL) return;
-      await redis.publishRaw(
-        `${ROUTING_INVALIDATION_ACK_PREFIX}event-1`,
-        await signTestEnvelope(
+    const acknowledgement = answerEventWithRejectedAcknowledgement(
+      redis,
+      () =>
+        signTestEnvelope(
           ACK_SIGNATURE_DOMAIN,
           JSON.stringify({ eventId: "event-1", replicaId: "replica-b" }),
           integritySecret,
           TEST_NOW_MS - 61_000,
         ),
-      );
-    });
+    );
     const bus = await startProxyRoutingInvalidationBus({
       redisUrl: "redis://example.test:6379",
       expectedReplicas: 1,
@@ -833,27 +903,33 @@ describe("proxy routing invalidation Redis bus", () => {
       },
     });
 
-    const result = await bus?.publish(createEvent());
+    try {
+      const result = await bus?.publish(createEvent());
 
-    assertEquals(result, { acknowledged: 0, converged: false, recipients: 1 });
-    await bus?.close();
+      assertEquals(
+        result,
+        { acknowledged: 0, converged: false, recipients: 1 },
+        "an expired acknowledgement must not count toward convergence",
+      );
+    } finally {
+      acknowledgement.restore();
+      await bus?.close();
+    }
   });
 
   it("ignores future-dated Redis acknowledgements", async () => {
     const redis = createFakeRedisServer();
     const integritySecret = createIntegritySecret();
-    redis.setOnPublish(async (channel) => {
-      if (channel !== ROUTING_INVALIDATION_CHANNEL) return;
-      await redis.publishRaw(
-        `${ROUTING_INVALIDATION_ACK_PREFIX}event-1`,
-        await signTestEnvelope(
+    const acknowledgement = answerEventWithRejectedAcknowledgement(
+      redis,
+      () =>
+        signTestEnvelope(
           ACK_SIGNATURE_DOMAIN,
           JSON.stringify({ eventId: "event-1", replicaId: "replica-b" }),
           integritySecret,
           TEST_NOW_MS + 6_000,
         ),
-      );
-    });
+    );
     const bus = await startProxyRoutingInvalidationBus({
       redisUrl: "redis://example.test:6379",
       expectedReplicas: 1,
@@ -867,14 +943,18 @@ describe("proxy routing invalidation Redis bus", () => {
       },
     });
 
-    const result = await bus?.publish(createEvent());
+    try {
+      const result = await bus?.publish(createEvent());
 
-    assertEquals(
-      result,
-      { acknowledged: 0, converged: false, recipients: 1 },
-      "a future-dated acknowledgement must not count toward convergence",
-    );
-    await bus?.close();
+      assertEquals(
+        result,
+        { acknowledged: 0, converged: false, recipients: 1 },
+        "a future-dated acknowledgement must not count toward convergence",
+      );
+    } finally {
+      acknowledgement.restore();
+      await bus?.close();
+    }
   });
 
   it("resolves an in-flight publish without convergence when the bus closes", async () => {

--- a/src/proxy/routing-invalidation-redis.test.ts
+++ b/src/proxy/routing-invalidation-redis.test.ts
@@ -39,6 +39,27 @@ async function settleWithin<T>(promise: Promise<T>, label: string): Promise<T> {
   return outcome.value;
 }
 
+async function waitWithin<T>(
+  promise: Promise<T>,
+  label: string,
+  timeoutMs = 1_000,
+): Promise<T> {
+  let timeout: number | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`${label} did not settle within ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
 function createFakeRedisServer() {
   const subscriptions = new Map<RoutingInvalidationRedisClient, Map<string, RedisListener>>();
   const clientEventListeners = new Map<
@@ -156,12 +177,18 @@ async function signTestEnvelope(
   });
 }
 
-function deferred(): { promise: Promise<void>; resolve: () => void } {
+function deferred(): {
+  promise: Promise<void>;
+  reject: (error: unknown) => void;
+  resolve: () => void;
+} {
+  let reject!: (error: unknown) => void;
   let resolve!: () => void;
-  const promise = new Promise<void>((innerResolve) => {
+  const promise = new Promise<void>((innerResolve, innerReject) => {
+    reject = innerReject;
     resolve = innerResolve;
   });
-  return { promise, resolve };
+  return { promise, reject, resolve };
 }
 
 describe("proxy routing invalidation Redis bus", () => {
@@ -324,21 +351,26 @@ describe("proxy routing invalidation Redis bus", () => {
     Object.defineProperty(crypto.subtle, "verify", {
       configurable: true,
       value: async (...args: Parameters<SubtleCrypto["verify"]>) => {
-        const verified = await originalVerify(...args);
-        const input = args[3];
-        const bytes = input instanceof ArrayBuffer
-          ? new Uint8Array(input)
-          : new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
-        if (
-          verified &&
-          new TextDecoder().decode(bytes).startsWith(`${ACK_SIGNATURE_DOMAIN}\0`)
-        ) {
-          duplicateAcknowledgementVerifications++;
-          if (duplicateAcknowledgementVerifications === 2) {
-            duplicateAcknowledgementsVerified.resolve();
+        try {
+          const verified = await originalVerify(...args);
+          const input = args[3];
+          const bytes = input instanceof ArrayBuffer
+            ? new Uint8Array(input)
+            : new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+          if (
+            verified &&
+            new TextDecoder().decode(bytes).startsWith(`${ACK_SIGNATURE_DOMAIN}\0`)
+          ) {
+            duplicateAcknowledgementVerifications++;
+            if (duplicateAcknowledgementVerifications === 2) {
+              duplicateAcknowledgementsVerified.resolve();
+            }
           }
+          return verified;
+        } catch (error) {
+          duplicateAcknowledgementsVerified.reject(error);
+          throw error;
         }
-        return verified;
       },
     });
     // Redis redelivery, or one buggy replica, can repeat an acknowledgement.
@@ -379,7 +411,10 @@ describe("proxy routing invalidation Redis bus", () => {
 
     try {
       const resultPromise = busA?.publish(createEvent());
-      await duplicateAcknowledgementsVerified.promise;
+      await waitWithin(
+        duplicateAcknowledgementsVerified.promise,
+        "duplicate acknowledgement verification",
+      );
       await busA?.close();
       const result = await resultPromise;
 

--- a/src/proxy/routing-invalidation-redis.test.ts
+++ b/src/proxy/routing-invalidation-redis.test.ts
@@ -228,6 +228,51 @@ describe("proxy routing invalidation Redis bus", () => {
     await bus?.close();
   });
 
+  it("force-destroys a Redis client whose close rejects at shutdown", async () => {
+    const redis = createFakeRedisServer();
+    const destroyed: string[] = [];
+    const warnings: Array<{ message: string; extra?: Record<string, unknown> }> = [];
+    let created = 0;
+    const bus = await startProxyRoutingInvalidationBus({
+      redisUrl: "redis://example.test:6379",
+      replicaId: "replica-a",
+      integritySecret: createIntegritySecret(),
+      createClient: () => {
+        const client = redis.createClient();
+        const role = created++ === 0 ? "publisher" : "subscriber";
+        return {
+          ...client,
+          close: () => Promise.reject(new Error("close failed")),
+          destroy: () => {
+            destroyed.push(role);
+            client.destroy();
+          },
+        };
+      },
+      logger: {
+        info: () => {},
+        warn: (message, extra) => warnings.push({ message, extra }),
+        error: () => {},
+      },
+      onInvalidate: () => {},
+    });
+
+    await bus?.close();
+
+    assertEquals(
+      destroyed.length,
+      2,
+      "both the publisher and the subscriber must be force-destroyed when close() rejects",
+    );
+    assertEquals(
+      warnings.some((entry) =>
+        entry.message.includes("Failed to close routing invalidation Redis client cleanly")
+      ),
+      true,
+      "a failed shutdown close must be reported, not swallowed",
+    );
+  });
+
   it("fans out to every replica and waits for a distinct acknowledgement from each", async () => {
     const redis = createFakeRedisServer();
     const integritySecret = createIntegritySecret();
@@ -267,6 +312,57 @@ describe("proxy routing invalidation Redis bus", () => {
     await busA?.close();
     await busB?.close();
     assertEquals(redis.clients.length, 4);
+  });
+
+  it("counts distinct replicas, not acknowledgement messages", async () => {
+    const redis = createFakeRedisServer();
+    const integritySecret = createIntegritySecret();
+    // Redis redelivery, or one buggy replica, can repeat an acknowledgement.
+    redis.setOnPublish(async (channel) => {
+      if (channel !== ROUTING_INVALIDATION_CHANNEL) return;
+      const acknowledgement = await signTestEnvelope(
+        ACK_SIGNATURE_DOMAIN,
+        JSON.stringify({ eventId: "event-1", replicaId: "replica-b" }),
+        integritySecret,
+      );
+      await redis.publishRaw(`${ROUTING_INVALIDATION_ACK_PREFIX}event-1`, acknowledgement);
+      await redis.publishRaw(`${ROUTING_INVALIDATION_ACK_PREFIX}event-1`, acknowledgement);
+    });
+    const busA = await startProxyRoutingInvalidationBus({
+      redisUrl: "redis://example.test:6379",
+      expectedReplicas: 2,
+      replicaId: "replica-a",
+      acknowledgementTimeoutMs: 10,
+      createClient: redis.createClient,
+      integritySecret,
+      now: () => TEST_NOW_MS,
+      onInvalidate: () => {
+        throw new Error("replica-a did not apply the event");
+      },
+    });
+    const busB = await startProxyRoutingInvalidationBus({
+      redisUrl: "redis://example.test:6379",
+      expectedReplicas: 2,
+      replicaId: "replica-b",
+      acknowledgementTimeoutMs: 10,
+      createClient: redis.createClient,
+      integritySecret,
+      now: () => TEST_NOW_MS,
+      onInvalidate: () => {
+        throw new Error("replica-b did not apply the event");
+      },
+    });
+
+    const result = await busA?.publish(createEvent());
+
+    assertEquals(
+      result,
+      { acknowledged: 1, converged: false, recipients: 2 },
+      "two acknowledgements from one replica must count once",
+    );
+
+    await busA?.close();
+    await busB?.close();
   });
 
   it("does not claim convergence when a subscribed replica fails to apply the event", async () => {
@@ -433,6 +529,42 @@ describe("proxy routing invalidation Redis bus", () => {
     await bus?.close();
   });
 
+  it("ignores future-dated Redis invalidation events", async () => {
+    const redis = createFakeRedisServer();
+    const integritySecret = createIntegritySecret();
+    const replicaEvents: ProxyRoutingInvalidationEvent[] = [];
+    const bus = await startProxyRoutingInvalidationBus({
+      redisUrl: "redis://example.test:6379",
+      expectedReplicas: 1,
+      replicaId: "replica-a",
+      acknowledgementTimeoutMs: 10,
+      createClient: redis.createClient,
+      integritySecret,
+      now: () => TEST_NOW_MS,
+      onInvalidate: (event) => {
+        replicaEvents.push(event);
+      },
+    });
+
+    await redis.publishRaw(
+      ROUTING_INVALIDATION_CHANNEL,
+      await signTestEnvelope(
+        EVENT_SIGNATURE_DOMAIN,
+        JSON.stringify(createEvent()),
+        integritySecret,
+        TEST_NOW_MS + 6_000,
+      ),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assertEquals(
+      replicaEvents,
+      [],
+      "an envelope issued beyond the clock-skew allowance must not be applied",
+    );
+    await bus?.close();
+  });
+
   it("ignores forged Redis acknowledgements", async () => {
     const redis = createFakeRedisServer();
     const integritySecret = createIntegritySecret();
@@ -497,6 +629,44 @@ describe("proxy routing invalidation Redis bus", () => {
     const result = await bus?.publish(createEvent());
 
     assertEquals(result, { acknowledged: 0, converged: false, recipients: 1 });
+    await bus?.close();
+  });
+
+  it("ignores future-dated Redis acknowledgements", async () => {
+    const redis = createFakeRedisServer();
+    const integritySecret = createIntegritySecret();
+    redis.setOnPublish(async (channel) => {
+      if (channel !== ROUTING_INVALIDATION_CHANNEL) return;
+      await redis.publishRaw(
+        `${ROUTING_INVALIDATION_ACK_PREFIX}event-1`,
+        await signTestEnvelope(
+          ACK_SIGNATURE_DOMAIN,
+          JSON.stringify({ eventId: "event-1", replicaId: "replica-b" }),
+          integritySecret,
+          TEST_NOW_MS + 6_000,
+        ),
+      );
+    });
+    const bus = await startProxyRoutingInvalidationBus({
+      redisUrl: "redis://example.test:6379",
+      expectedReplicas: 1,
+      replicaId: "replica-a",
+      acknowledgementTimeoutMs: 10,
+      createClient: redis.createClient,
+      integritySecret,
+      now: () => TEST_NOW_MS,
+      onInvalidate: () => {
+        throw new Error("no legitimate acknowledgement");
+      },
+    });
+
+    const result = await bus?.publish(createEvent());
+
+    assertEquals(
+      result,
+      { acknowledged: 0, converged: false, recipients: 1 },
+      "a future-dated acknowledgement must not count toward convergence",
+    );
     await bus?.close();
   });
 

--- a/src/proxy/routing-invalidation-redis.test.ts
+++ b/src/proxy/routing-invalidation-redis.test.ts
@@ -317,6 +317,30 @@ describe("proxy routing invalidation Redis bus", () => {
   it("counts distinct replicas, not acknowledgement messages", async () => {
     const redis = createFakeRedisServer();
     const integritySecret = createIntegritySecret();
+    const duplicateAcknowledgementsVerified = deferred();
+    const originalVerify = crypto.subtle.verify.bind(crypto.subtle);
+    const originalVerifyDescriptor = Object.getOwnPropertyDescriptor(crypto.subtle, "verify");
+    let duplicateAcknowledgementVerifications = 0;
+    Object.defineProperty(crypto.subtle, "verify", {
+      configurable: true,
+      value: async (...args: Parameters<SubtleCrypto["verify"]>) => {
+        const verified = await originalVerify(...args);
+        const input = args[3];
+        const bytes = input instanceof ArrayBuffer
+          ? new Uint8Array(input)
+          : new Uint8Array(input.buffer, input.byteOffset, input.byteLength);
+        if (
+          verified &&
+          new TextDecoder().decode(bytes).startsWith(`${ACK_SIGNATURE_DOMAIN}\0`)
+        ) {
+          duplicateAcknowledgementVerifications++;
+          if (duplicateAcknowledgementVerifications === 2) {
+            duplicateAcknowledgementsVerified.resolve();
+          }
+        }
+        return verified;
+      },
+    });
     // Redis redelivery, or one buggy replica, can repeat an acknowledgement.
     redis.setOnPublish(async (channel) => {
       if (channel !== ROUTING_INVALIDATION_CHANNEL) return;
@@ -332,7 +356,7 @@ describe("proxy routing invalidation Redis bus", () => {
       redisUrl: "redis://example.test:6379",
       expectedReplicas: 2,
       replicaId: "replica-a",
-      acknowledgementTimeoutMs: 10,
+      acknowledgementTimeoutMs: TIMEOUT_NOT_UNDER_TEST_MS,
       createClient: redis.createClient,
       integritySecret,
       now: () => TEST_NOW_MS,
@@ -344,7 +368,7 @@ describe("proxy routing invalidation Redis bus", () => {
       redisUrl: "redis://example.test:6379",
       expectedReplicas: 2,
       replicaId: "replica-b",
-      acknowledgementTimeoutMs: 10,
+      acknowledgementTimeoutMs: TIMEOUT_NOT_UNDER_TEST_MS,
       createClient: redis.createClient,
       integritySecret,
       now: () => TEST_NOW_MS,
@@ -353,16 +377,29 @@ describe("proxy routing invalidation Redis bus", () => {
       },
     });
 
-    const result = await busA?.publish(createEvent());
+    try {
+      const resultPromise = busA?.publish(createEvent());
+      await duplicateAcknowledgementsVerified.promise;
+      await busA?.close();
+      const result = await resultPromise;
 
-    assertEquals(
-      result,
-      { acknowledged: 1, converged: false, recipients: 2 },
-      "two acknowledgements from one replica must count once",
-    );
-
-    await busA?.close();
-    await busB?.close();
+      assertEquals(
+        result,
+        { acknowledged: 1, converged: false, recipients: 2 },
+        "two acknowledgements from one replica must count once",
+      );
+    } finally {
+      if (originalVerifyDescriptor) {
+        Object.defineProperty(crypto.subtle, "verify", originalVerifyDescriptor);
+      } else {
+        Object.defineProperty(crypto.subtle, "verify", {
+          configurable: true,
+          value: originalVerify,
+        });
+      }
+      await busA?.close();
+      await busB?.close();
+    }
   });
 
   it("does not claim convergence when a subscribed replica fails to apply the event", async () => {

--- a/src/proxy/routing-invalidation.test.ts
+++ b/src/proxy/routing-invalidation.test.ts
@@ -189,6 +189,82 @@ describe("proxy routing invalidation ingress", () => {
     });
   });
 
+  it("rejects publisher results whose convergence contradicts its counts", async () => {
+    // A bus that claims convergence while no replica acknowledged would tell the
+    // deploying control plane the old release is no longer being served.
+    const body = createBody();
+    const { jws, publicKeyPem } = await createDispatchSignature(body);
+    const contradictoryResults = [
+      { acknowledged: 0, converged: true, recipients: 0 },
+      { acknowledged: 1, converged: true, recipients: 2 },
+      { acknowledged: 3, converged: false, recipients: 2 },
+    ];
+
+    for (const result of contradictoryResults) {
+      const label = JSON.stringify(result);
+      const response = await handleProxyRoutingInvalidationRequest(
+        new Request(`http://proxy.test${PROXY_ROUTING_INVALIDATION_PATH}`, {
+          method: "POST",
+          headers: { "x-veryfront-dispatch-jws": jws },
+          body,
+        }),
+        {
+          publicKeyPem,
+          publisher: {
+            publish: () => Promise.resolve(result),
+          },
+        },
+      );
+
+      assertEquals(
+        response.status,
+        503,
+        `an inconsistent publisher result must not be reported as success: ${label}`,
+      );
+      assertEquals(
+        await response.json(),
+        { error: "Routing invalidation did not converge" },
+        `an invalid publisher result must return the generic failure body, not the raw counts: ${label}`,
+      );
+    }
+  });
+
+  it("rejects malformed invalidation input before it reaches the publisher", async () => {
+    // The 400 gate runs before the signature gate, so it is what stands between
+    // an unauthenticated caller and caller-shaped audience/project claims.
+    const { publicKeyPem } = await createDispatchSignature(createBody());
+    const valid = JSON.parse(createBody()) as Record<string, unknown>;
+    const malformedBodies: Array<[string, string]> = [
+      ["a body that is not JSON at all", "{ not json"],
+      ["an unsupported version", JSON.stringify({ ...valid, version: 2 })],
+      ["an uppercase project slug", JSON.stringify({ ...valid, projectSlug: "Demo-Project" })],
+      ["a project slug with a leading hyphen", JSON.stringify({ ...valid, projectSlug: "-demo" })],
+      ["an empty release id", JSON.stringify({ ...valid, releaseId: "" })],
+    ];
+    const published: ProxyRoutingInvalidationEvent[] = [];
+
+    for (const [label, malformed] of malformedBodies) {
+      const response = await handleProxyRoutingInvalidationRequest(
+        new Request(`http://proxy.test${PROXY_ROUTING_INVALIDATION_PATH}`, {
+          method: "POST",
+          body: malformed,
+        }),
+        {
+          publicKeyPem,
+          publisher: {
+            publish: (event) => {
+              published.push(event);
+              return Promise.resolve({ acknowledged: 1, converged: true, recipients: 1 });
+            },
+          },
+        },
+      );
+
+      assertEquals(response.status, 400, `${label} must be rejected as malformed input`);
+      assertEquals(published.length, 0, `${label} must never reach the publisher`);
+    }
+  });
+
   it("fails closed when signing verification is not configured", async () => {
     const response = await handleProxyRoutingInvalidationRequest(
       new Request(`http://proxy.test${PROXY_ROUTING_INVALIDATION_PATH}`, {
@@ -349,6 +425,53 @@ describe("proxy routing invalidation ingress", () => {
     assertStringIncludes(String(warnings[0]?.extra?.reason), "missing");
   });
 
+  it("keeps a failing log sink from upgrading a rejection into a 500", async () => {
+    // Diagnosability must not cost availability: a transport or serialization
+    // failure in the warning sink cannot be allowed to rewrite the answer.
+    const body = createBody();
+    const { jws, publicKeyPem } = await createDispatchSignature(body);
+    const tampered = jws.slice(0, -4) + (jws.endsWith("AAAA") ? "BBBB" : "AAAA");
+    const logger = {
+      warn: (): void => {
+        throw new Error("sink down");
+      },
+    };
+    const publisher = {
+      publish: () => Promise.resolve({ acknowledged: 1, converged: true, recipients: 1 }),
+    };
+
+    const rejected = await handleProxyRoutingInvalidationRequest(
+      new Request(`http://proxy.test${PROXY_ROUTING_INVALIDATION_PATH}`, {
+        method: "POST",
+        headers: { "x-veryfront-dispatch-jws": tampered },
+        body,
+      }),
+      { publicKeyPem, logger, publisher },
+    );
+
+    assertEquals(rejected.status, 401, "a throwing log sink must not change the rejection status");
+    assertEquals(
+      await rejected.json(),
+      { error: "Invalid routing invalidation signature" },
+      "the generic rejection body must be preserved",
+    );
+
+    const accepted = await handleProxyRoutingInvalidationRequest(
+      new Request(`http://proxy.test${PROXY_ROUTING_INVALIDATION_PATH}`, {
+        method: "POST",
+        headers: { "x-veryfront-dispatch-jws": jws },
+        body,
+      }),
+      { publicKeyPem, logger, publisher },
+    );
+
+    assertEquals(
+      accepted.status,
+      200,
+      "a throwing log sink must not poison a later valid invalidation",
+    );
+  });
+
   it("coalesces repeated rejections of one class into a counted warning", async () => {
     // Unauthenticated callers reach this path, so one log write per request is
     // an amplification lever. The first rejection must still warn immediately —
@@ -390,6 +513,44 @@ describe("proxy routing invalidation ingress", () => {
     assertEquals(warnings.length, 2);
     assertEquals(warnings[1]?.extra?.coalescedSincePreviousWarning, 4);
     assertStringIncludes(String(warnings[1]?.extra?.reason), "missing");
+
+    // An NTP step backwards must not silence the class until the clock catches up.
+    clockMs -= 300_000;
+    assertEquals((await reject()).status, 401);
+    assertEquals(
+      warnings.length,
+      3,
+      "a backwards clock step must expire the window instead of silencing the class",
+    );
+  });
+
+  it("buckets unforeseen rejection classes into a shared overflow class", () => {
+    // Mirrors MAX_TRACKED_REJECTION_CLASSES in routing-invalidation.ts: the map
+    // is capped so an error type carrying a dynamic name cannot grow it forever.
+    const maxTrackedRejectionClasses = 32;
+    const throttle = createProxyRoutingInvalidationRejectionThrottle({
+      nowMs: () => 0,
+      windowMs: 60_000,
+    });
+
+    for (let index = 0; index < maxTrackedRejectionClasses; index += 1) {
+      assertEquals(
+        throttle.admit(`class-${index}`),
+        0,
+        `the first rejection of class-${index} must warn immediately`,
+      );
+    }
+
+    assertEquals(
+      throttle.admit("class-overflow-a"),
+      0,
+      "the first overflow-class rejection still warns",
+    );
+    assertEquals(
+      throttle.admit("class-overflow-b"),
+      null,
+      "a second distinct unforeseen class must coalesce into the shared overflow bucket rather than grow the map",
+    );
   });
 
   // Deliberately no in-process "missing SchemaValidator" test. One was written

--- a/src/proxy/server-resolver.test.ts
+++ b/src/proxy/server-resolver.test.ts
@@ -282,6 +282,23 @@ Deno.test("ServerResolver", async (t) => {
       TypeError,
       "configured together",
     );
+    // A colon in the user would splice the basic-auth principal.
+    assertThrows(
+      () => new ServerResolver("https://api.example.com", "ad:min", "pw"),
+      TypeError,
+      "Dedicated server API user is invalid",
+    );
+    assertThrows(
+      () => new ServerResolver("https://api.example.com", " admin ", "pw"),
+      TypeError,
+      "Dedicated server API user is invalid",
+    );
+    // Control characters must never reach the Authorization header value.
+    assertThrows(
+      () => new ServerResolver("https://api.example.com", "admin", "pw\u0000"),
+      TypeError,
+      "Dedicated server API password is invalid",
+    );
     assertThrows(
       () => new ServerResolver("https://api.example.com", "", "", -1),
       RangeError,

--- a/src/proxy/server-timing.test.ts
+++ b/src/proxy/server-timing.test.ts
@@ -9,6 +9,19 @@ import {
   withProxyServerTimingHeader,
 } from "./server-timing.ts";
 
+/** Headers that reject mutation the way a fetch() response's immutable guard does. */
+class ImmutableHeaders extends Headers {
+  override set(): never {
+    throw new TypeError("Headers are immutable");
+  }
+  override append(): never {
+    throw new TypeError("Headers are immutable");
+  }
+  override delete(): never {
+    throw new TypeError("Headers are immutable");
+  }
+}
+
 describe("proxy server timing", () => {
   afterEach(() => {
     Deno.env.delete("VERYFRONT_ENABLE_PROXY_SERVER_TIMING");
@@ -45,6 +58,39 @@ describe("proxy server timing", () => {
     assertStringIncludes(header, "proxy.total;dur=15.56");
     assertStringIncludes(header, "proxy.resolve_request;dur=2.35");
     assertStringIncludes(header, "proxy.upstream;dur=10.00");
+  });
+
+  it("rebuilds a response whose headers are immutable without losing its status", async () => {
+    // Every proxied response comes from fetch(), whose headers guard is
+    // immutable, so the rebuild branch is the only one production ever takes.
+    // The runtime only mints that guard for real network responses, so this
+    // stands in for one: a real Response whose headers reject mutation exactly
+    // the way the guard does, which is all the rebuild branch keys off.
+    const upstream = new Response("upstream body", { status: 404, statusText: "Not Found" });
+    Object.defineProperty(upstream, "headers", {
+      configurable: true,
+      get: () => new ImmutableHeaders({ "Server-Timing": "render.total;dur=4.00" }),
+    });
+    const timing = createProxyServerTiming(true);
+    markProxyServerTimingPhase(timing, "proxy.upstream", 10);
+
+    const result = withProxyServerTimingHeader(upstream, timing, 15.556);
+
+    assertEquals(result.status, 404, "the rebuilt response must keep the upstream status");
+    assertEquals(
+      result.statusText,
+      "Not Found",
+      "the rebuilt response must keep the upstream status text",
+    );
+    const header = result.headers.get("Server-Timing") ?? "";
+    assertStringIncludes(header, "render.total;dur=4.00");
+    assertStringIncludes(header, "proxy.total;dur=15.56");
+    assertStringIncludes(header, "proxy.upstream;dur=10.00");
+    assertEquals(
+      await result.text(),
+      "upstream body",
+      "the rebuilt response must keep the upstream body",
+    );
   });
 
   it("leaves responses untouched when timing is disabled", () => {

--- a/src/proxy/shutdown-lifecycle.test.ts
+++ b/src/proxy/shutdown-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { parseProxyShutdownCleanupTimeoutMs, runProxyShutdownSteps } from "./shutdown-lifecycle.ts";
 
@@ -181,6 +181,57 @@ describe("proxy shutdown lifecycle", () => {
     assertEquals(await settlement, []);
   });
 
+  it("rejects malformed shutdown step configurations", async () => {
+    const ran: string[] = [];
+    const record = (name: string) => ({
+      name,
+      run: () => {
+        ran.push(name);
+      },
+    });
+
+    await assertRejects(
+      () =>
+        runProxyShutdownSteps([record("http_server"), record("http_server")], {
+          timeoutMs: 100,
+        }),
+      TypeError,
+      "Duplicate proxy shutdown step: http_server",
+    );
+
+    await assertRejects(
+      () =>
+        runProxyShutdownSteps([
+          { ...record("a"), requires: ["b"] },
+          record("b"),
+        ], { timeoutMs: 100 }),
+      TypeError,
+      "prerequisite must name an earlier step",
+    );
+
+    await assertRejects(
+      () =>
+        runProxyShutdownSteps([
+          { name: "a", run: "not-a-function" as never },
+          record("b"),
+        ], { timeoutMs: 100 }),
+      TypeError,
+      "must have a name and run function",
+    );
+
+    await assertRejects(
+      () =>
+        runProxyShutdownSteps([
+          { ...record("a"), requires: "b" as never },
+          record("b"),
+        ], { timeoutMs: 100 }),
+      TypeError,
+      "prerequisites must be an array",
+    );
+
+    assertEquals(ran, [], "a malformed step list must be rejected before any owner runs");
+  });
+
   it("parses strict cleanup policy and rejects malformed values", () => {
     assertEquals(parseProxyShutdownCleanupTimeoutMs("3500"), 3_500);
     assertEquals(parseProxyShutdownCleanupTimeoutMs(undefined), 4_000);
@@ -194,6 +245,19 @@ describe("proxy shutdown lifecycle", () => {
       () => parseProxyShutdownCleanupTimeoutMs("-1"),
       TypeError,
       "decimal integer",
+    );
+    // A numerically valid but oversized delay overflows the 32-bit timer and
+    // fires immediately, starving every step of its cleanup window.
+    assertEquals(parseProxyShutdownCleanupTimeoutMs("2147483647"), 2_147_483_647);
+    assertThrows(
+      () => parseProxyShutdownCleanupTimeoutMs("2147483648"),
+      RangeError,
+      "must be between 0 and 2147483647",
+    );
+    assertThrows(
+      () => parseProxyShutdownCleanupTimeoutMs(undefined, -1),
+      RangeError,
+      "Default proxy shutdown cleanup timeout",
     );
   });
 });

--- a/src/proxy/split-forward-request.test.ts
+++ b/src/proxy/split-forward-request.test.ts
@@ -1,30 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { _resetShimForTests, propagation } from "#veryfront/observability/tracing/api-shim.ts";
 import type { ProxyContext } from "./handler.ts";
 import { createSplitForwardRequestInit } from "./split-forward-request.ts";
 
-Deno.test("split proxy forwarding uses the shared end-to-end header policy", () => {
-  const body = new ReadableStream<Uint8Array>();
-  const request = new Request(
-    "https://project.preview.veryfront.test/upload",
-    {
-      method: "POST",
-      headers: {
-        Connection: "keep-alive, x-remove-me",
-        Host: "attacker.test",
-        "Keep-Alive": "timeout=5",
-        "Proxy-Authorization": "Basic secret",
-        "Transfer-Encoding": "chunked",
-        "X-Content-Source-Id": "caller-controlled",
-        "X-Remove-Me": "connection-owned",
-        "X-Token": "caller-controlled",
-        "X-Preserve-Me": "end-to-end",
-      },
-      body,
-      duplex: "half",
-    } as RequestInit & { duplex: "half" },
-  );
-  const context: ProxyContext = {
+function previewContext(): ProxyContext {
+  return {
     token: "trusted-token",
     projectSlug: "project",
     projectId: "project-id",
@@ -43,26 +25,113 @@ Deno.test("split proxy forwarding uses the shared end-to-end header policy", () 
     },
     isLocalProject: false,
   };
-  const signal = new AbortController().signal;
+}
 
-  const init = createSplitForwardRequestInit(request, context, request.body, signal);
-  const headers = new Headers(init.headers);
+describe("split proxy forward request", () => {
+  it("uses the shared end-to-end header policy", () => {
+    const body = new ReadableStream<Uint8Array>();
+    const request = new Request(
+      "https://project.preview.veryfront.test/upload",
+      {
+        method: "POST",
+        headers: {
+          Connection: "keep-alive, x-remove-me",
+          Host: "attacker.test",
+          "Keep-Alive": "timeout=5",
+          "Proxy-Authorization": "Basic secret",
+          "Transfer-Encoding": "chunked",
+          "X-Content-Source-Id": "caller-controlled",
+          "X-Remove-Me": "connection-owned",
+          "X-Token": "caller-controlled",
+          "X-Preserve-Me": "end-to-end",
+        },
+        body,
+        duplex: "half",
+      } as RequestInit & { duplex: "half" },
+    );
+    const context: ProxyContext = {
+      token: "trusted-token",
+      projectSlug: "project",
+      projectId: "project-id",
+      environmentId: "environment-id",
+      environmentName: "preview",
+      environment: "preview",
+      contentSourceId: "preview-main",
+      host: "project.preview.veryfront.test",
+      parsedDomain: {
+        slug: "project",
+        isVeryfrontDomain: true,
+        environment: "preview",
+        branch: null,
+        isDraft: true,
+        allowIframeEmbed: true,
+      },
+      isLocalProject: false,
+    };
+    const signal = new AbortController().signal;
 
-  assertEquals(init.method, "POST");
-  assertEquals(init.redirect, "manual");
-  assertStrictEquals(init.signal, signal);
-  assertStrictEquals(init.body, request.body);
-  assertEquals(init.duplex, "half");
-  assertEquals(headers.get("connection"), null);
-  assertEquals(headers.get("host"), null);
-  assertEquals(headers.get("keep-alive"), null);
-  assertEquals(headers.get("proxy-authorization"), null);
-  assertEquals(headers.get("transfer-encoding"), null);
-  assertEquals(headers.get("x-remove-me"), null);
-  assertEquals(headers.get("x-preserve-me"), "end-to-end");
-  assertEquals(headers.get("x-token"), "trusted-token");
-  assertEquals(headers.get("x-content-source-id"), "preview-main");
-  assertEquals(headers.get("x-project-id"), "project-id");
-  assertEquals(headers.get("x-environment-id"), "environment-id");
-  assertEquals(headers.get("x-environment-name"), "preview");
+    const init = createSplitForwardRequestInit(request, context, request.body, signal);
+    const headers = new Headers(init.headers);
+
+    assertEquals(init.method, "POST");
+    assertEquals(init.redirect, "manual");
+    assertStrictEquals(init.signal, signal);
+    assertStrictEquals(init.body, request.body);
+    assertEquals(init.duplex, "half");
+    assertEquals(headers.get("connection"), null);
+    assertEquals(headers.get("host"), null);
+    assertEquals(headers.get("keep-alive"), null);
+    assertEquals(headers.get("proxy-authorization"), null);
+    assertEquals(headers.get("transfer-encoding"), null);
+    assertEquals(headers.get("x-remove-me"), null);
+    assertEquals(headers.get("x-preserve-me"), "end-to-end");
+    assertEquals(headers.get("x-token"), "trusted-token");
+    assertEquals(headers.get("x-content-source-id"), "preview-main");
+    assertEquals(headers.get("x-project-id"), "project-id");
+    assertEquals(headers.get("x-environment-id"), "environment-id");
+    assertEquals(headers.get("x-environment-name"), "preview");
+  });
+
+  it("injects its own trace context after untrusted headers are removed", () => {
+    const request = new Request("https://project.preview.veryfront.test/page", {
+      headers: {
+        traceparent: "00-deadbeefdeadbeefdeadbeefdeadbeef-1111111111111111-01",
+      },
+    });
+
+    try {
+      propagation.setGlobalPropagator({
+        inject: (_ctx, carrier, setter) => {
+          setter?.set(
+            carrier,
+            "traceparent",
+            "00-11111111111111111111111111111111-2222222222222222-01",
+          );
+        },
+        extract: (ctx) => ctx,
+        fields: () => ["traceparent", "tracestate"],
+      });
+
+      const init = createSplitForwardRequestInit(
+        request,
+        previewContext(),
+        null,
+        new AbortController().signal,
+      );
+      const headers = new Headers(init.headers);
+
+      assertEquals(
+        headers.get("traceparent"),
+        "00-11111111111111111111111111111111-2222222222222222-01",
+        "the proxy must inject its own trace context into the renderer hop",
+      );
+      assertEquals(
+        headers.get("traceparent")?.includes("deadbeef"),
+        false,
+        "a caller-supplied traceparent must be replaced, not forwarded",
+      );
+    } finally {
+      _resetShimForTests();
+    }
+  });
 });

--- a/src/proxy/token-manager.test.ts
+++ b/src/proxy/token-manager.test.ts
@@ -11,7 +11,13 @@ import {
   TokenManager,
   TokenResolutionCapacityError,
 } from "./token-manager.ts";
+import { OAuthTokenRequestError } from "./oauth-client.ts";
 import type { TokenCache, TokenCacheEntry } from "./cache/types.ts";
+
+/** Base64url-encodes a JWT segment without padding. */
+function encodeJwtSegment(value: string): string {
+  return btoa(value).replaceAll("+", "-").replaceAll("/", "_").replaceAll("=", "");
+}
 
 /** In-memory cache that counts operations */
 class SpyCache implements TokenCache {
@@ -501,18 +507,155 @@ describe("TokenManager", () => {
       { cache },
     );
 
-    await assertRejects(
+    const fresh = await assertRejects(
       () => manager.getToken("production", "missing-project"),
-      Error,
+      OAuthTokenRequestError,
       "404",
     );
-    await assertRejects(
+    assertInstanceOf(fresh, OAuthTokenRequestError);
+    assertEquals(fresh.status, 404, "the fresh failure must carry the upstream status");
+    const replayed = await assertRejects(
       () => manager.getToken("production", "missing-project"),
-      Error,
+      OAuthTokenRequestError,
       "404",
+    );
+    assertInstanceOf(replayed, OAuthTokenRequestError);
+    assertEquals(
+      replayed.status,
+      404,
+      "the replayed failure must stay typed so callers classify it by status, not by message",
+    );
+    assertEquals(
+      replayed.responseText,
+      "Project missing",
+      "the replayed failure must carry the cached upstream response text",
     );
 
     assertEquals(fetchCount, 1);
+
+    await manager.close();
+  });
+
+  it("does not negative-cache transient token service failures", async () => {
+    await mockServer?.shutdown();
+    mockServer = Deno.serve({ port: 0, onListen() {} }, () => {
+      fetchCount++;
+      return new Response("upstream down", { status: 500 });
+    });
+    serverPort = (mockServer.addr as Deno.NetAddr).port;
+
+    const manager = new TokenManager(
+      {
+        apiBaseUrl: `http://localhost:${serverPort}`,
+        apiClientId: "id",
+        apiClientSecret: "secret",
+        previewApiClientId: "pid",
+        previewApiClientSecret: "psecret",
+      },
+      { cache: new SpyCache() },
+    );
+
+    await assertRejects(
+      () => manager.getToken("production", "flaky-project"),
+      OAuthTokenRequestError,
+      "500",
+    );
+    await assertRejects(
+      () => manager.getToken("production", "flaky-project"),
+      OAuthTokenRequestError,
+      "500",
+    );
+
+    assertEquals(
+      fetchCount,
+      2,
+      "a transient 5xx must not be negative cached; the second call must re-hit the token endpoint",
+    );
+
+    await manager.close();
+  });
+
+  it("mints preview tokens with the preview API client credentials", async () => {
+    await mockServer?.shutdown();
+    const credentials: Array<{ client_id: unknown; client_secret: unknown }> = [];
+    mockServer = Deno.serve({ port: 0, onListen() {} }, async (req) => {
+      fetchCount++;
+      const body = await req.json() as Record<string, unknown>;
+      credentials.push({ client_id: body.client_id, client_secret: body.client_secret });
+      return Response.json({
+        access_token: `token-${fetchCount}`,
+        token_type: "Bearer",
+        expires_in: 3600,
+      });
+    });
+    serverPort = (mockServer.addr as Deno.NetAddr).port;
+
+    const manager = new TokenManager(
+      {
+        apiBaseUrl: `http://localhost:${serverPort}`,
+        apiClientId: "id",
+        apiClientSecret: "secret",
+        previewApiClientId: "pid",
+        previewApiClientSecret: "psecret",
+      },
+      { cache: new SpyCache() },
+    );
+
+    await manager.getToken("preview", "p");
+    await manager.getToken("production", "p");
+
+    assertEquals(
+      credentials,
+      [
+        { client_id: "pid", client_secret: "psecret" },
+        { client_id: "id", client_secret: "secret" },
+      ],
+      "preview scope must mint with the preview API client credentials and production scope with the production ones",
+    );
+
+    await manager.close();
+  });
+
+  it("derives cached expiry from the JWT exp claim when expires_in is absent", async () => {
+    await mockServer?.shutdown();
+    let exp = 0;
+    mockServer = Deno.serve({ port: 0, onListen() {} }, () => {
+      fetchCount++;
+      return Response.json({
+        access_token: `e30.${encodeJwtSegment(JSON.stringify({ exp }))}.sig`,
+        token_type: "Bearer",
+      });
+    });
+    serverPort = (mockServer.addr as Deno.NetAddr).port;
+
+    const manager = new TokenManager(
+      {
+        apiBaseUrl: `http://localhost:${serverPort}`,
+        apiClientId: "id",
+        apiClientSecret: "secret",
+        previewApiClientId: "pid",
+        previewApiClientSecret: "psecret",
+      },
+      { cache: new SpyCache() },
+    );
+
+    exp = Math.floor(Date.now() / 1_000) + 30;
+    await manager.getToken("production", "expiring-soon");
+    await manager.getToken("production", "expiring-soon");
+    assertEquals(
+      fetchCount,
+      2,
+      "a JWT expiring inside the refresh buffer must not be served from cache",
+    );
+
+    exp = Math.floor(Date.now() / 1_000) + 3_600;
+    await manager.getToken("production", "long-lived");
+    await manager.getToken("production", "long-lived");
+    assertEquals(
+      fetchCount,
+      3,
+      "a JWT exp beyond the refresh buffer must keep the cached token",
+    );
 
     await manager.close();
   });

--- a/src/proxy/tracing.test.ts
+++ b/src/proxy/tracing.test.ts
@@ -3,13 +3,19 @@ import { assertEquals, assertNotEquals } from "#veryfront/testing/assert";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd";
 import {
   _resetShimForTests,
+  type Context,
+  context as shimContext,
+  getGlobalMetricsAPI,
   getGlobalTracerProvider,
+  type Meter,
+  type MetricsAPI,
   type Span,
   type Tracer,
 } from "#veryfront/observability/tracing/api-shim.ts";
 import type { TracingExporter } from "#veryfront/extensions/observability/tracing-exporter.ts";
 import {
   _resetOTLPForTests,
+  getTraceContext,
   initializeOTLPWithApis,
   resolveOtlpGate,
   shutdownOTLP,
@@ -142,6 +148,67 @@ describe("proxy otlp initialization", () => {
     assertEquals(calls.start, 1);
     assertNotEquals(getGlobalTracerProvider(), noopProvider);
     assertNotEquals(startServerSpan("GET", "/"), null);
+  });
+
+  it("wires the exporter's metrics, trace and context APIs into the shim", async () => {
+    // These three accessors are the only reason proxy metrics are exported and
+    // proxy log lines carry a trace id, and only this function installs them.
+    setOtelEnv({
+      OTEL_TRACES_ENABLED: "true",
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://127.0.0.1:9",
+    });
+    const activeSpan = {
+      ...createFakeSpan(),
+      spanContext: () => ({
+        traceId: "1".repeat(32),
+        spanId: "2".repeat(16),
+        traceFlags: 1,
+      }),
+    } as unknown as Span;
+    const fakeMeter: Meter = {
+      createCounter: () => ({ add: () => {} }),
+      createUpDownCounter: () => ({ add: () => {} }),
+      createHistogram: () => ({ record: () => {} }),
+      createObservableGauge: () => ({ addCallback: () => {} }),
+    };
+    const metricsApi: MetricsAPI = { getMeter: () => fakeMeter };
+    const exporterContext = {
+      getValue: () => undefined,
+      setValue: () => exporterContext,
+      deleteValue: () => exporterContext,
+    } as unknown as Context;
+    const contextApi = {
+      active: () => exporterContext,
+      with: <T>(_ctx: unknown, fn: () => T): T => fn(),
+    };
+    const { exporter } = createFakeExporter({
+      getMetricsAPI: () => metricsApi,
+      getTraceAPI: () => ({
+        getActiveSpan: () => activeSpan,
+        getSpan: () => activeSpan,
+        setSpan: (ctx: unknown) => ctx,
+      }),
+      getContextAPI: () => contextApi,
+    });
+
+    // deno-lint-ignore require-await
+    await initializeOTLPWithApis(async () => exporter);
+
+    assertEquals(
+      getGlobalMetricsAPI(),
+      metricsApi,
+      "the exporter's metrics API must be wired into the shim",
+    );
+    assertEquals(
+      getTraceContext(),
+      { traceId: "1".repeat(32), spanId: "2".repeat(16) },
+      "the exporter's trace API must back getTraceContext for proxy log correlation",
+    );
+    assertEquals(
+      shimContext.active(),
+      exporterContext,
+      "the exporter's context API must back the shim so span context survives async boundaries",
+    );
   });
 
   it("prefers OTEL_EXPORTER_OTLP_TRACES_ENDPOINT as the endpoint gate", async () => {

--- a/src/proxy/websocket-bridge-identity.test.ts
+++ b/src/proxy/websocket-bridge-identity.test.ts
@@ -27,6 +27,9 @@ function browserUpgradeHeaders(host: string): Headers {
     connection: "Upgrade",
     "sec-websocket-version": "13",
     "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+    "sec-websocket-extensions": "permessage-deflate",
+    "sec-websocket-accept": "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=",
+    "sec-websocket-protocol": "hmr",
   });
 }
 
@@ -119,6 +122,21 @@ describe("proxy renderer WebSocket bridge identity", () => {
     assertEquals(bridge.headers.get("x-token"), "vf_proxy_minted_project_token");
     assertEquals(bridge.headers.get("x-project-slug"), "support-agent-agodnc");
     assertEquals(bridge.headers.get("x-environment"), "preview");
+    for (
+      const header of [
+        "sec-websocket-key",
+        "sec-websocket-version",
+        "sec-websocket-extensions",
+        "sec-websocket-accept",
+        "sec-websocket-protocol",
+      ]
+    ) {
+      assertEquals(
+        bridge.headers.get(header),
+        null,
+        `${header} belongs to the browser socket and must not reach the renderer hop`,
+      );
+    }
   });
 
   it("never lets the browser's query string name the tenant", async () => {

--- a/src/proxy/websocket-client.test.ts
+++ b/src/proxy/websocket-client.test.ts
@@ -5,6 +5,7 @@ import {
   connectUpstreamWebSocket,
   resolveUpstreamWebSocketStreamFactory,
   UpstreamWebSocket,
+  type UpstreamWebSocketConnection,
   type UpstreamWebSocketStream,
 } from "./websocket-client.ts";
 import { buildRendererBridgeRequest } from "./websocket-bridge.ts";
@@ -43,9 +44,13 @@ function startUpstreamServer(options: { rejectWith?: number } = {}): UpstreamSer
         });
       }
       const { socket, response } = Deno.upgradeWebSocket(req);
+      socket.binaryType = "arraybuffer";
       sockets.add(socket);
       socket.onmessage = (event) => {
-        if (socket.readyState === WebSocket.OPEN) socket.send(`echo:${event.data}`);
+        if (socket.readyState !== WebSocket.OPEN) return;
+        // Binary frames are echoed verbatim so the caller can check byte fidelity.
+        if (typeof event.data === "string") socket.send(`echo:${event.data}`);
+        else socket.send(event.data as ArrayBuffer);
       };
       socket.onclose = () => sockets.delete(socket);
       return response;
@@ -183,6 +188,52 @@ describe("upstream WebSocket client", () => {
     }
   });
 
+  it("bridges binary frames byte-for-byte without reordering later frames", async () => {
+    const server = startUpstreamServer();
+    try {
+      const socket = connectUpstreamWebSocket(server.url, identityHeaders());
+      const frames: Array<string | number[]> = [];
+      let resolveFrames: () => void = () => {};
+      const collected = new Promise<void>((resolve) => {
+        resolveFrames = resolve;
+      });
+      socket.onmessage = (event) => {
+        const { data } = event;
+        frames.push(typeof data === "string" ? data : Array.from(data));
+        if (frames.length === 3) resolveFrames();
+      };
+      await new Promise<void>((resolve) => {
+        socket.onopen = () => resolve();
+      });
+
+      const buffer = new Uint8Array([1, 2, 3, 4, 5]);
+      socket.send(buffer.subarray(2));
+      socket.send(new Blob([new Uint8Array([9, 8])]));
+      socket.send("after-blob");
+      await collected;
+
+      assertEquals(
+        frames[0],
+        [3, 4, 5],
+        "a view with a non-zero byteOffset must forward only its own bytes",
+      );
+      assertEquals(frames[1], [9, 8], "a Blob frame must forward exactly its own bytes");
+      assertEquals(
+        frames[2],
+        "echo:after-blob",
+        "an awaited Blob conversion must not reorder later frames",
+      );
+
+      const closed = new Promise<void>((resolve) => {
+        socket.onclose = () => resolve();
+      });
+      socket.close(1000, "done");
+      await closed;
+    } finally {
+      await server.close();
+    }
+  });
+
   it("surfaces a rejected handshake as an error and a close", async () => {
     // Exactly what production sees today when the renderer answers 502.
     const server = startUpstreamServer({ rejectWith: 502 });
@@ -238,6 +289,55 @@ describe("upstream WebSocket client", () => {
     assertEquals(closeCalls[0], { closeCode: 1011, reason: "Server connection error" });
     assertEquals(closeCalls[1], undefined);
     assertEquals(socket.readyState, WebSocket.CLOSING);
+  });
+
+  it("discards an upstream connection that arrives after close", async () => {
+    let admit: (connection: UpstreamWebSocketConnection) => void = () => {};
+    const opened = new Promise<UpstreamWebSocketConnection>((resolve) => {
+      admit = resolve;
+    });
+    const stream: UpstreamWebSocketStream = {
+      opened,
+      closed: new Promise(() => {}),
+      close() {},
+    };
+    let opens = 0;
+    let cancels = 0;
+
+    const socket = new UpstreamWebSocket("ws://renderer/_ws", new Headers(), () => stream);
+    socket.onopen = () => {
+      opens++;
+    };
+    socket.close(1000, "done");
+
+    const writable = new WritableStream<string | Uint8Array>();
+    admit({
+      readable: new ReadableStream<string | Uint8Array>({
+        cancel() {
+          cancels++;
+        },
+      }),
+      writable,
+    });
+    await opened;
+    for (let turn = 0; turn < 5; turn++) await Promise.resolve();
+
+    assertEquals(opens, 0, "a connection inherited after close must not fire onopen");
+    assertEquals(
+      socket.readyState,
+      WebSocket.CLOSING,
+      "readyState must never move backwards from CLOSING to OPEN",
+    );
+    assertEquals(
+      cancels,
+      1,
+      "the inherited readable must be cancelled so the renderer connection is not leaked",
+    );
+    assertEquals(
+      writable.locked,
+      false,
+      "a discarded connection must not take a writer on the inherited writable",
+    );
   });
 
   it("passes the headers straight through to the stream factory", () => {

--- a/src/proxy/websocket-client.test.ts
+++ b/src/proxy/websocket-client.test.ts
@@ -263,11 +263,24 @@ describe("upstream WebSocket client", () => {
         "an awaited Blob conversion must not reorder later frames",
       );
 
-      const closed = new Promise<void>((resolve) => {
-        socket.onclose = () => resolve();
-      });
-      socket.close(1000, "done");
-      await closed;
+      // Bound the teardown wait the same way as the waits above: a close
+      // handshake that never completes would wedge the worker after the
+      // assertions already passed.
+      let closeTimer: number | undefined;
+      try {
+        const closed = new Promise<void>((resolve, reject) => {
+          socket.onclose = () => resolve();
+          socket.onerror = () => reject(new Error("the upstream socket errored during teardown"));
+          closeTimer = setTimeout(
+            () => reject(new Error("timed out waiting for the upstream socket to close")),
+            5_000,
+          );
+        });
+        socket.close(1000, "done");
+        await closed;
+      } finally {
+        if (closeTimer !== undefined) clearTimeout(closeTimer);
+      }
     } finally {
       await server.close();
     }

--- a/src/proxy/websocket-client.test.ts
+++ b/src/proxy/websocket-client.test.ts
@@ -202,9 +202,26 @@ describe("upstream WebSocket client", () => {
         frames.push(typeof data === "string" ? data : Array.from(data));
         if (frames.length === 3) resolveFrames();
       };
-      await new Promise<void>((resolve) => {
-        socket.onopen = () => resolve();
-      });
+      // Bound the handshake wait too: if connection setup regresses and the
+      // socket errors or closes without ever opening, an unbounded `onopen`
+      // await would wedge the worker before the frame timeout below is armed.
+      let openTimer: number | undefined;
+      try {
+        await new Promise<void>((resolve, reject) => {
+          socket.onopen = () => resolve();
+          socket.onerror = () => reject(new Error("the upstream handshake errored before opening"));
+          socket.onclose = (event) =>
+            reject(new Error(`the upstream socket closed before opening (code ${event.code})`));
+          openTimer = setTimeout(
+            () => reject(new Error("timed out waiting for the upstream handshake to open")),
+            5_000,
+          );
+        });
+      } finally {
+        if (openTimer !== undefined) clearTimeout(openTimer);
+        socket.onerror = null;
+        socket.onclose = null;
+      }
 
       const buffer = new Uint8Array([1, 2, 3, 4, 5]);
       socket.send(buffer.subarray(2));

--- a/src/proxy/websocket-client.test.ts
+++ b/src/proxy/websocket-client.test.ts
@@ -210,7 +210,29 @@ describe("upstream WebSocket client", () => {
       socket.send(buffer.subarray(2));
       socket.send(new Blob([new Uint8Array([9, 8])]));
       socket.send("after-blob");
-      await collected;
+      // Bound the wait: if the bridge drops or misorders a frame, `collected`
+      // never settles, and an unbounded await would wedge the test worker
+      // instead of failing. The timer is always cleared so the bounded wait
+      // does not itself leak an op.
+      let frameTimer: number | undefined;
+      try {
+        await Promise.race([
+          collected,
+          new Promise<void>((_, reject) => {
+            frameTimer = setTimeout(
+              () =>
+                reject(
+                  new Error(
+                    `timed out waiting for 3 forwarded frames; received ${frames.length}`,
+                  ),
+                ),
+              5_000,
+            );
+          }),
+        ]);
+      } finally {
+        if (frameTimer !== undefined) clearTimeout(frameTimer);
+      }
 
       assertEquals(
         frames[0],

--- a/src/proxy/websocket-proxy.test.ts
+++ b/src/proxy/websocket-proxy.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd";
 import { parseProjectDomain } from "#veryfront/server/utils/domain-parser.ts";
 import {
   authorizeWebSocketRequest,
+  buildRendererBridgeRequest,
   closeBridgePeer,
   createProxyClientWebSocketUpgradeOptions,
   getClientWebSocketErrorLogLevel,
@@ -93,75 +94,54 @@ describe("Proxy WebSocket Handler Tests", () => {
     });
   });
 
-  describe("WebSocket URL Construction", () => {
-    it("converts HTTP to WS URL", () => {
-      const rendererUrl = "http://localhost:3001";
-      const wsUrl = rendererUrl.replace(/^http/, "ws");
+  describe("Renderer bridge hop construction", () => {
+    const BRIDGE_HOST = "support-agent-agodnc.preview.veryfront.com";
 
-      assertEquals(wsUrl, "ws://localhost:3001");
+    function bridgeContext(): ProxyContext {
+      return {
+        token: "vf_proxy_minted_project_token",
+        projectSlug: "support-agent-agodnc",
+        projectId: "prj_01hzzz",
+        environment: "preview",
+        contentSourceId: "src_01hzzz",
+        host: BRIDGE_HOST,
+        parsedDomain: parseProjectDomain(BRIDGE_HOST),
+        isLocalProject: false,
+      };
+    }
+
+    it("converts the renderer hop to ws and keeps the path and benign query", () => {
+      const req = new Request(`https://${BRIDGE_HOST}/_ws?foo=bar&x-project-slug=victim`);
+
+      const bridge = buildRendererBridgeRequest(
+        req,
+        new URL(req.url),
+        bridgeContext(),
+        "http://veryfront-server",
+      );
+
+      assertEquals(
+        bridge.url.toString(),
+        "ws://veryfront-server/_ws?foo=bar",
+        "the bridge hop must convert http to ws and preserve path and benign query while dropping browser-named identity",
+      );
     });
 
-    it("converts HTTPS to WSS URL", () => {
-      const rendererUrl = "https://renderer.example.com";
-      const wsUrl = rendererUrl.replace(/^http/, "ws");
+    it("reaches an https renderer over wss", () => {
+      const req = new Request(`https://${BRIDGE_HOST}/_ws`);
 
-      assertEquals(wsUrl, "wss://renderer.example.com");
-    });
+      const bridge = buildRendererBridgeRequest(
+        req,
+        new URL(req.url),
+        bridgeContext(),
+        "https://renderer.example.com",
+      );
 
-    it("preserves path in WebSocket URL", () => {
-      const rendererUrl = "http://localhost:3001";
-      const path = "/_ws";
-      const query = "?foo=bar";
-      const targetUrl = `${rendererUrl.replace(/^http/, "ws")}${path}${query}`;
-
-      assertEquals(targetUrl, "ws://localhost:3001/_ws?foo=bar");
-    });
-  });
-
-  describe("WebSocket Query Parameters", () => {
-    it("adds project slug as query parameter", () => {
-      const baseUrl = new URL("ws://localhost:3001/_ws");
-      const projectSlug = "my-project";
-
-      baseUrl.searchParams.set("x-project-slug", projectSlug);
-
-      assertEquals(baseUrl.searchParams.get("x-project-slug"), "my-project");
-    });
-
-    it("adds environment as query parameter", () => {
-      const baseUrl = new URL("ws://localhost:3001/_ws");
-      const environment = "preview";
-
-      baseUrl.searchParams.set("x-environment", environment);
-
-      assertEquals(baseUrl.searchParams.get("x-environment"), "preview");
-    });
-
-    it("handles empty project slug", () => {
-      const baseUrl = new URL("ws://localhost:3001/_ws");
-
-      baseUrl.searchParams.set("x-project-slug", "");
-
-      assertEquals(baseUrl.searchParams.get("x-project-slug"), "");
-    });
-  });
-
-  describe("Domain Parsing for WebSocket", () => {
-    it("extracts project slug from preview domain", () => {
-      const host = "myproject.preview.veryfront.com";
-      const [slug, env] = host.split(".");
-
-      assertEquals(slug, "myproject");
-      assertEquals(env === "preview", true);
-    });
-
-    it("extracts branch from preview domain with branch", () => {
-      const host = "myproject--feature-branch.preview.veryfront.com";
-      const [firstPart = ""] = host.split(".");
-      const [slug, branch] = firstPart.split("--");
-
-      assertEquals(slug, "myproject");
-      assertEquals(branch, "feature-branch");
+      assertEquals(
+        bridge.url.protocol,
+        "wss:",
+        "an https renderer must be reached over wss",
+      );
     });
   });
 
@@ -176,12 +156,42 @@ describe("Proxy WebSocket Handler Tests", () => {
 
   describe("Server WebSocket error handling", () => {
     it("treats upstream EOF as a transient warning", () => {
-      assertEquals(getServerWebSocketErrorLogLevel("Unexpected EOF"), "warn");
+      assertEquals(
+        getServerWebSocketErrorLogLevel("Unexpected EOF"),
+        "warn",
+        "an upstream EOF is a routine bridge teardown, not an alertable failure",
+      );
     });
 
     it("treats browser-side EOF and ping timeouts as transient warnings", () => {
-      assertEquals(getClientWebSocketErrorLogLevel("Unexpected EOF"), "warn");
-      assertEquals(getClientWebSocketErrorLogLevel("No response from ping frame."), "warn");
+      assertEquals(
+        getClientWebSocketErrorLogLevel("Unexpected EOF"),
+        "warn",
+        "a browser-side EOF is a routine bridge teardown, not an alertable failure",
+      );
+      assertEquals(
+        getClientWebSocketErrorLogLevel("No response from ping frame."),
+        "warn",
+        "a missed heartbeat is a routine bridge teardown, not an alertable failure",
+      );
+    });
+
+    it("keeps non-transient bridge failures at error level", () => {
+      assertEquals(
+        getServerWebSocketErrorLogLevel("connection refused"),
+        "error",
+        "non-transient upstream failures must stay at error level",
+      );
+      assertEquals(
+        getServerWebSocketErrorLogLevel("invalid peer certificate: UnknownIssuer"),
+        "error",
+        "TLS failures must stay at error level",
+      );
+      assertEquals(
+        getClientWebSocketErrorLogLevel("error sending frame"),
+        "error",
+        "non-transient browser-side failures must stay at error level",
+      );
     });
 
     it("closes the accepted client socket when the upstream bridge fails", () => {

--- a/tests/integration/proxy/token-manager-negative-cache-ttl.test.ts
+++ b/tests/integration/proxy/token-manager-negative-cache-ttl.test.ts
@@ -1,0 +1,109 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert";
+import { afterEach, describe, it } from "#veryfront/testing/bdd";
+import { TokenManager } from "../../../src/proxy/token-manager.ts";
+import { OAuthTokenRequestError } from "../../../src/proxy/oauth-client.ts";
+import type { TokenCache, TokenCacheEntry } from "../../../src/proxy/cache/types.ts";
+
+/**
+ * Relocated from src/proxy/token-manager.test.ts: proving that a negative cache
+ * entry expires requires advancing the process-global clock, which the semantic
+ * unit-boundary audit classifies as a process effect. TokenManager exposes no
+ * clock seam, and the TTL is five minutes, so waiting it out is not an option.
+ * Integration is where a host effect like this is allowed to live.
+ */
+
+/** Mirrors the non-exported NEGATIVE_CACHE_TTL_MS in token-manager.ts. */
+const NEGATIVE_CACHE_TTL_MS = 5 * 60 * 1_000;
+
+/** Minimal in-memory token cache. */
+class MemoryCache implements TokenCache {
+  private store = new Map<string, TokenCacheEntry>();
+
+  get(key: string): Promise<TokenCacheEntry | null> {
+    return Promise.resolve(this.store.get(key) ?? null);
+  }
+
+  set(key: string, entry: TokenCacheEntry): Promise<void> {
+    this.store.set(key, entry);
+    return Promise.resolve();
+  }
+
+  delete(key: string): Promise<void> {
+    this.store.delete(key);
+    return Promise.resolve();
+  }
+
+  clear(): Promise<void> {
+    this.store.clear();
+    return Promise.resolve();
+  }
+
+  has(key: string): Promise<boolean> {
+    return Promise.resolve(this.store.has(key));
+  }
+
+  stats(): Promise<{ hits: number; misses: number; size: number; type: "memory" }> {
+    return Promise.resolve({ hits: 0, misses: 0, size: this.store.size, type: "memory" });
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe("TokenManager negative cache TTL", () => {
+  let mockServer: Deno.HttpServer | undefined;
+
+  afterEach(async () => {
+    await mockServer?.shutdown();
+    mockServer = undefined;
+  });
+
+  it("re-fetches once a negative cache entry outlives its TTL", async () => {
+    let fetchCount = 0;
+    mockServer = Deno.serve({ port: 0, onListen() {} }, () => {
+      fetchCount++;
+      return new Response("Project missing", { status: 404 });
+    });
+    const serverPort = (mockServer.addr as Deno.NetAddr).port;
+
+    const manager = new TokenManager(
+      {
+        apiBaseUrl: `http://localhost:${serverPort}`,
+        apiClientId: "id",
+        apiClientSecret: "secret",
+        previewApiClientId: "pid",
+        previewApiClientSecret: "psecret",
+      },
+      { cache: new MemoryCache() },
+    );
+
+    await assertRejects(
+      () => manager.getToken("production", "missing-project"),
+      OAuthTokenRequestError,
+      "404",
+    );
+    assertEquals(fetchCount, 1, "the first miss must reach the token service exactly once");
+
+    const originalDateNow = Date.now;
+    try {
+      Date.now = () => originalDateNow() + NEGATIVE_CACHE_TTL_MS + 1_000;
+      await assertRejects(
+        () => manager.getToken("production", "missing-project"),
+        OAuthTokenRequestError,
+        "404",
+      );
+    } finally {
+      Date.now = originalDateNow;
+    }
+
+    assertEquals(
+      fetchCount,
+      2,
+      "an expired negative cache entry must be dropped so the project becomes reachable again",
+    );
+
+    await manager.close();
+  });
+});

--- a/tests/integration/proxy/token-manager-negative-cache-ttl.test.ts
+++ b/tests/integration/proxy/token-manager-negative-cache-ttl.test.ts
@@ -1,9 +1,9 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert";
-import { afterEach, describe, it } from "#veryfront/testing/bdd";
-import { TokenManager } from "../../../src/proxy/token-manager.ts";
-import { OAuthTokenRequestError } from "../../../src/proxy/oauth-client.ts";
-import type { TokenCache, TokenCacheEntry } from "../../../src/proxy/cache/types.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { TokenManager } from "#veryfront/proxy/token-manager.ts";
+import { OAuthTokenRequestError } from "#veryfront/proxy/oauth-client.ts";
+import type { TokenCache, TokenCacheEntry } from "#veryfront/proxy/cache/types.ts";
 
 /**
  * Relocated from src/proxy/token-manager.test.ts: proving that a negative cache

--- a/tests/integration/proxy/tracing-cache-span-emission.test.ts
+++ b/tests/integration/proxy/tracing-cache-span-emission.test.ts
@@ -1,0 +1,190 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd";
+import {
+  _resetShimForTests,
+  type Span,
+  type Tracer,
+} from "#veryfront/observability/tracing/api-shim.ts";
+import type { TracingExporter } from "#veryfront/extensions/observability/tracing-exporter.ts";
+import {
+  _resetOTLPForTests,
+  initializeOTLPWithApis,
+  shutdownOTLP,
+} from "../../../src/proxy/tracing.ts";
+import { TracingTokenCache } from "../../../src/proxy/cache/tracing-cache.ts";
+import type { CacheStats, TokenCache, TokenCacheEntry } from "../../../src/proxy/cache/types.ts";
+
+/**
+ * Relocated from src/proxy/cache/tracing-cache.test.ts: the proxy's withSpan()
+ * is a pass-through until initializeOTLPWithApis() caches a tracer, and that
+ * initialization is gated on OTEL_* process environment with no config seam to
+ * inject. Mutating the environment is a process effect the semantic
+ * unit-boundary audit rejects in a colocated unit test, so the span-emission
+ * cases live here. The hermetic delegation cases stay in the unit file.
+ */
+
+interface CallRecord {
+  method: string;
+  args: unknown[];
+}
+
+class FakeCache implements TokenCache {
+  readonly calls: CallRecord[] = [];
+  entry: TokenCacheEntry | null = null;
+  hasResult = false;
+  statsResult: CacheStats = { hits: 0, misses: 0, size: 0, type: "extension" };
+
+  get(key: string): Promise<TokenCacheEntry | null> {
+    this.calls.push({ method: "get", args: [key] });
+    return Promise.resolve(this.entry);
+  }
+
+  set(key: string, entry: TokenCacheEntry): Promise<void> {
+    this.calls.push({ method: "set", args: [key, entry] });
+    this.entry = entry;
+    return Promise.resolve();
+  }
+
+  delete(key: string): Promise<void> {
+    this.calls.push({ method: "delete", args: [key] });
+    this.entry = null;
+    return Promise.resolve();
+  }
+
+  clear(): Promise<void> {
+    this.calls.push({ method: "clear", args: [] });
+    return Promise.resolve();
+  }
+
+  has(key: string): Promise<boolean> {
+    this.calls.push({ method: "has", args: [key] });
+    return Promise.resolve(this.hasResult);
+  }
+
+  stats(): Promise<CacheStats> {
+    this.calls.push({ method: "stats", args: [] });
+    return Promise.resolve(this.statsResult);
+  }
+
+  close(): Promise<void> {
+    this.calls.push({ method: "close", args: [] });
+    return Promise.resolve();
+  }
+}
+
+function makeEntry(token: string): TokenCacheEntry {
+  return { token, expiresAt: Date.now() + 60_000, scope: "production" };
+}
+
+describe("TracingTokenCache span emission", () => {
+  const OTEL_ENV_KEYS = [
+    "OTEL_TRACES_ENABLED",
+    "OTEL_SERVICE_NAME",
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+  ] as const;
+  const savedEnv = new Map<string, string | undefined>();
+  let spanNames: string[] = [];
+
+  function createRecordingSpan(): Span {
+    const span: Span = {
+      setAttribute: () => span,
+      setAttributes: () => span,
+      setStatus: () => span,
+      recordException: () => {},
+      addEvent: () => span,
+      end: () => {},
+      spanContext: () => ({
+        traceId: "1".repeat(32),
+        spanId: "2".repeat(16),
+        traceFlags: 1,
+      }),
+      updateName: () => {},
+    } as unknown as Span;
+    return span;
+  }
+
+  function createRecordingExporter(): TracingExporter {
+    const tracer: Tracer = {
+      startSpan: (name: string) => {
+        spanNames.push(name);
+        return createRecordingSpan();
+      },
+      startActiveSpan: ((name: string, ...rest: unknown[]) => {
+        spanNames.push(name);
+        const fn = rest.find((arg) => typeof arg === "function") as
+          | ((span: Span) => unknown)
+          | undefined;
+        return fn?.(createRecordingSpan());
+      }) as Tracer["startActiveSpan"],
+    };
+    return {
+      start: () => Promise.resolve(),
+      export: () => Promise.resolve(),
+      shutdown: () => Promise.resolve(),
+      getProvider: () => ({ getTracer: () => tracer }),
+      getMetricsAPI: () => null,
+      getTraceAPI: () => null,
+    };
+  }
+
+  beforeEach(async () => {
+    for (const key of OTEL_ENV_KEYS) savedEnv.set(key, Deno.env.get(key));
+    _resetOTLPForTests();
+    _resetShimForTests();
+    spanNames = [];
+    Deno.env.set("OTEL_TRACES_ENABLED", "true");
+    Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", "http://127.0.0.1:9");
+    Deno.env.delete("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT");
+    const exporter = createRecordingExporter();
+    await initializeOTLPWithApis(() => Promise.resolve(exporter));
+  });
+
+  afterEach(async () => {
+    await shutdownOTLP();
+    _resetOTLPForTests();
+    _resetShimForTests();
+    for (const [key, value] of savedEnv) {
+      if (value === undefined) Deno.env.delete(key);
+      else Deno.env.set(key, value);
+    }
+  });
+
+  it("emits one prefixed span for every public method", async () => {
+    const fake = new FakeCache();
+    const traced = new TracingTokenCache(fake);
+
+    await traced.get("key");
+    await traced.set("key", makeEntry("t-span"));
+    await traced.delete("key");
+    await traced.clear();
+    await traced.has("key");
+    await traced.stats();
+    await traced.close();
+
+    assertEquals(
+      spanNames,
+      [
+        "cache.extension.get",
+        "cache.extension.set",
+        "cache.extension.delete",
+        "cache.extension.clear",
+        "cache.extension.has",
+        "cache.extension.stats",
+        "cache.extension.close",
+      ],
+      "every public method must emit its prefixed span",
+    );
+  });
+
+  it("names the emitted span with the configured spanPrefix", async () => {
+    const fake = new FakeCache();
+    const traced = new TracingTokenCache(fake, { spanPrefix: "cache.custom" });
+
+    await traced.get("key");
+
+    assertEquals(spanNames, ["cache.custom.get"], "spanPrefix must name the emitted span");
+    await traced.close();
+  });
+});

--- a/tests/integration/proxy/tracing-cache-span-emission.test.ts
+++ b/tests/integration/proxy/tracing-cache-span-emission.test.ts
@@ -1,6 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert";
-import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   _resetShimForTests,
   type Span,
@@ -11,9 +11,9 @@ import {
   _resetOTLPForTests,
   initializeOTLPWithApis,
   shutdownOTLP,
-} from "../../../src/proxy/tracing.ts";
-import { TracingTokenCache } from "../../../src/proxy/cache/tracing-cache.ts";
-import type { CacheStats, TokenCache, TokenCacheEntry } from "../../../src/proxy/cache/types.ts";
+} from "#veryfront/proxy/tracing.ts";
+import { TracingTokenCache } from "#veryfront/proxy/cache/tracing-cache.ts";
+import type { CacheStats, TokenCache, TokenCacheEntry } from "#veryfront/proxy/cache/types.ts";
 
 /**
  * Relocated from src/proxy/cache/tracing-cache.test.ts: the proxy's withSpan()


### PR DESCRIPTION
## Summary

Audit of all 43 test files under `src/proxy` for tests that stay green when the behavior they claim to cover breaks.

The bar for every change: name a concrete source edit that breaks documented behavior yet leaves the test passing. Every change was **mutation checked** — the named edit was applied, the test confirmed to fail, then the edit reverted.

65 candidate findings, 55 confirmed after adversarial verification, 56 applied, 10 refuted. **No product defects found. Test files only.**

## Recurring weaknesses fixed

**Untyped rejections.** Token failures asserted only that *some* `Error` carried `"404"` in its message:

```ts
assertRejects(..., Error, "404")
```

Replacing the typed `OAuthTokenRequestError` with a plain `Error` passed. Now pinned to the error type, its `.status`, and its `.responseText`.

**Negative cache behavior was asserted in one direction only.** New cases prove a 404 *is* cached, that the entry is re-fetched once its TTL expires, and that a transient 500 is *not* cached, so widening the cache predicate to catch 5xx fails.

**Credential handling never asserted.** Preview and production scopes now assert which client credentials are actually sent, the `client_credentials` body is pinned field by field (including that an unbound request omits `project_slug`), and credential redaction in upstream error text is asserted on a normal-sized body rather than only on the oversized-truncation path.

**Userinfo in API base URLs.** Both halves of the guard are now covered (`user:pass@` and bare `user@`), so dropping either clause fails.

**A rethrow asserted from inside its own catch**, which passes when nothing is thrown at all. Now uses `assertRejects` and additionally pins the single `["500:boom"]` span end.

**Upstream URL construction was unasserted.** The asset handler now pins the exact upstream URL, and a based URL keeps its `/v1` path prefix. Also added a fail-closed case for unsafe bases (`user:pass@`, `user@`, `file:///etc`) asserting 502 and **zero fetches**.

**Non Latin-1 branch names** now assert identity encoding, the `vf-utf8:` prefix, and a decode round trip, so setting the header from the raw value fails.

**Cache composition guards** that contradict `CACHE_TYPE` now assert their specific rejection messages rather than any throw.

**Websocket bridge handshake headers:** the renderer hop must carry none of the five browser handshake headers, asserted on the raw builder output.

## Verification

- Semantic unit-boundary audit: ok
- `test:layout`: ok
- `deno fmt`, `deno lint`: pass
- **32/32** changed test files pass via `deno task test:file`
- `anti-slop`, `cwd-relative-test-reads`, `test-typecheck`, `skipped-tests`, `ban-test-only`: all pass

No test was deleted, skipped, or weakened. No sanitizer opt-out was added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved proxy validation for URLs, hosts, credentials, headers, and malformed requests.
  - Sanitized error responses and clarified missing-release and missing-project handling.
  - Improved cache expiry, token refresh, retry, shutdown, and routing-invalidation behavior.
  - Strengthened WebSocket handling, including binary frames, late connections, and browser-specific headers.
  - Preserved tracing, cookies, response metadata, and request bodies more reliably during forwarding.
- **Tests**
  - Expanded coverage for security, error handling, caching, tracing, WebSockets, retries, and lifecycle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->