### PR TITLE
test(html): make weak assertions bite and fix two generator defects

### DIFF
--- a/src/html/dev-scripts.test.ts
+++ b/src/html/dev-scripts.test.ts
@@ -120,7 +120,58 @@ describe("html/dev-scripts", () => {
         pageId: "pg",
         pagePath: "/app/page.tsx",
       });
-      assertEquals(scripts.includes("pagePath"), true);
+      assertEquals(
+        scripts.includes('"pagePath":"/app/page.tsx"'),
+        true,
+        "the supplied pagePath must be the value published to the bridge",
+      );
+    });
+
+    it("should fall back to pageId when pagePath is omitted", () => {
+      const scripts = getStudioScripts({ projectId: "p", pageId: "pg" });
+      assertEquals(
+        scripts.includes('"pagePath":"pg"'),
+        true,
+        "pagePath must fall back to pageId",
+      );
+    });
+
+    it("should escape angle brackets in the inline bridge config", () => {
+      const hostile = "</script><script>alert(1)</script>";
+      const scripts = getStudioScripts({
+        projectId: hostile,
+        pageId: "pg",
+        pagePath: hostile,
+      });
+      assertEquals(
+        scripts.includes("<script>alert(1)</script>"),
+        false,
+        "inline bridge JSON must not close the script element",
+      );
+      assertEquals(
+        scripts.includes("\\u003c/script"),
+        true,
+        "< in bridge config must be escaped as \\u003c",
+      );
+    });
+
+    it("should escape angle brackets in the sourceHash script", () => {
+      const hostile = "</script><script>alert(1)</script>";
+      const scripts = getStudioScripts({
+        projectId: "p",
+        pageId: "pg",
+        sourceHash: hostile,
+      });
+      assertEquals(
+        scripts.includes("<script>alert(1)</script>"),
+        false,
+        "the sourceHash literal must not close the script element",
+      );
+      assertEquals(
+        scripts.includes("\\u003c/script"),
+        true,
+        "< in the sourceHash literal must be escaped as \\u003c",
+      );
     });
   });
 });

--- a/src/html/html-detection.test.ts
+++ b/src/html/html-detection.test.ts
@@ -82,11 +82,20 @@ describe("html-detection", () => {
         html: `<p>Learn about <html></html> tags</p>`,
         expected: false,
       },
+      {
+        name: "should return false when a doctype appears inside the content",
+        html: `<div>Example: <!DOCTYPE html></div><html>x</html>`,
+        expected: false,
+      },
     ];
 
     for (const testCase of cases) {
       it(testCase.name, () => {
-        assertEquals(isFullHTMLDocument(testCase.html), testCase.expected);
+        assertEquals(
+          isFullHTMLDocument(testCase.html),
+          testCase.expected,
+          testCase.name,
+        );
       });
     }
   });

--- a/src/html/html-escape.test.ts
+++ b/src/html/html-escape.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   buildAttributes,
@@ -102,6 +102,80 @@ describe("html-escape", () => {
           "aria-label": 'Say "Hello"',
         }),
         'data-value="test &amp; value" aria-label="Say &quot;Hello&quot;"',
+      );
+    });
+
+    it("should reject attribute names that break out of the attribute", () => {
+      assertThrows(
+        () => buildAttributes({ 'a" onload="x': "1" }),
+        TypeError,
+        "HTML attribute name is invalid",
+        "an injecting attribute name must be rejected, not interpolated raw",
+      );
+      assertThrows(
+        () => buildAttributes({ "data value": "1" }),
+        TypeError,
+        "HTML attribute name is invalid",
+        "an attribute name containing a space must be rejected",
+      );
+      assertThrows(
+        () => buildAttributes({ "data>value": "1" }),
+        TypeError,
+        "HTML attribute name is invalid",
+        "an attribute name containing > must be rejected",
+      );
+    });
+
+    it("should reject attribute names beyond the name size limit", () => {
+      assertThrows(
+        () => buildAttributes({ ["a".repeat(257)]: "1" }),
+        TypeError,
+        "HTML attribute name is invalid",
+        "an attribute name over the byte limit must be rejected",
+      );
+    });
+
+    it("should reject more attributes than the entry limit", () => {
+      assertThrows(
+        () =>
+          buildAttributes(
+            Object.fromEntries(
+              Array.from({ length: 129 }, (_, index) => [`data-k${index}`, "1"]),
+            ),
+          ),
+        Error,
+        "HTML attributes exceed the entry limit",
+        "an attribute set over the entry limit must be rejected",
+      );
+    });
+
+    it("should reject attribute containers that are not plain objects", () => {
+      assertThrows(
+        () => buildAttributes(["id"] as unknown as Record<string, unknown>),
+        Error,
+        "HTML attributes must be an object",
+        "an array must not be treated as an attribute map",
+      );
+      class Attrs {
+        id = "x";
+      }
+      assertThrows(
+        () => buildAttributes(new Attrs() as unknown as Record<string, unknown>),
+        Error,
+        "HTML attributes must be a plain object",
+        "a class instance must not be treated as an attribute map",
+      );
+    });
+
+    it("should reject accessor-backed attribute values", () => {
+      assertThrows(
+        () =>
+          buildAttributes(
+            Object.defineProperty({}, "id", { get: () => "x", enumerable: true }),
+          ),
+        Error,
+        "HTML attribute value cannot be inspected",
+        "a getter-backed attribute value must not be invoked during rendering",
       );
     });
   });

--- a/src/html/html-injection.test.ts
+++ b/src/html/html-injection.test.ts
@@ -157,11 +157,17 @@ describe("html/html-injection", () => {
           mode: "production",
           slug: "test",
           importMapJson: hostileImportMap,
+          nonce: "nonce-123",
         },
       );
 
       assertEquals(html.includes("</script><script>"), false);
       assertEquals(html.includes("\\u003c/script"), true);
+      assertEquals(
+        html.includes('<script type="importmap" nonce="nonce-123">'),
+        true,
+        "the import map must carry the CSP nonce or a nonce-enforcing policy blocks module resolution",
+      );
     });
 
     it("should clear dev placeholders in production mode", () => {

--- a/src/html/html-shell-generator.test.ts
+++ b/src/html/html-shell-generator.test.ts
@@ -605,6 +605,28 @@ describe("html-generation/html-shell-generator", () => {
       assertStringIncludes(result, "veryfront-error-overlay");
     });
 
+    it("escapes the overlay project slug so it cannot close the inline script", async () => {
+      const result = await wrapInHTMLShell(
+        "<div>Content</div>",
+        createMeta(),
+        createOptions({
+          isLocalProject: true,
+          projectId: "</script><script>alert(1)</script>",
+        }),
+      );
+
+      assertStringIncludes(
+        result,
+        'window.__VF_PROJECT_SLUG__="\\u003c/script',
+        "the overlay slug must be emitted with < escaped",
+      );
+      assertEquals(
+        result.includes("</script><script>alert(1)"),
+        false,
+        "the overlay slug must not close the inline script",
+      );
+    });
+
     it("should include production scripts in prod mode", async () => {
       const result = await wrapInHTMLShell(
         "<div>Content</div>",
@@ -648,6 +670,76 @@ describe("html-generation/html-shell-generator", () => {
       );
 
       assert(!result.includes("preview-hmr.js"));
+    });
+
+    it("emits the preview hmr script for a preview render", async () => {
+      const result = await wrapInHTMLShell(
+        "<div>Content</div>",
+        createMeta(),
+        createOptions({
+          mode: "production",
+          environment: "preview",
+          isLocalProject: true,
+        }),
+      );
+
+      assertStringIncludes(
+        result,
+        '<script src="/_veryfront/preview-hmr.js"',
+        "preview renders must load preview-hmr.js",
+      );
+    });
+
+    it("ships the markdown preview styles and mermaid bootstrap for an md page", async () => {
+      const result = await wrapInHTMLShell(
+        "<div>Content</div>",
+        createMeta(),
+        createOptions({ pageType: "md", pagePath: "README.md" }),
+      );
+
+      assertStringIncludes(
+        result,
+        "https://cdn.veryfront.com/styles/github-markdown.min.css",
+        "md previews must ship the prose stylesheet",
+      );
+      assertStringIncludes(
+        result,
+        "https://cdn.veryfront.com/styles/github-syntax-highlighting.min.css",
+        "md previews must ship the syntax highlighting stylesheet",
+      );
+      assertStringIncludes(
+        result,
+        "https://cdn.veryfront.com/styles/mermaid.min.css",
+        "md previews must ship the mermaid stylesheet",
+      );
+      assertStringIncludes(
+        result,
+        "https://esm.sh/mermaid@11",
+        "md previews must bootstrap mermaid",
+      );
+    });
+
+    it("opts an md page out of the markdown preview assets when prose is false", async () => {
+      const result = await wrapInHTMLShell(
+        "<div>Content</div>",
+        createMeta(),
+        createOptions({
+          pageType: "md",
+          pagePath: "README.md",
+          frontmatter: { prose: false },
+        }),
+      );
+
+      assertEquals(
+        result.includes("cdn.veryfront.com/styles/github-markdown.min.css"),
+        false,
+        "prose:false must opt out of the markdown preview styles",
+      );
+      assertEquals(
+        result.includes("https://esm.sh/mermaid@11"),
+        false,
+        "prose:false must opt out of the mermaid bootstrap",
+      );
     });
 
     it("should handle layout disabled", async () => {

--- a/src/html/html-shell-manifest.test.ts
+++ b/src/html/html-shell-manifest.test.ts
@@ -328,6 +328,33 @@ describe("html shell release asset manifest consumption", () => {
     assertEquals(imports["@/"], "/_vf_modules/");
   });
 
+  it("never consumes the release manifest for a studio embed", async () => {
+    setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    registerManifestFetcherForRelease(
+      "rel-1",
+      () => Promise.resolve({ state: "ready", manifest_version: 1, manifest: manifest() }),
+    );
+
+    const result = await generateHTMLShellParts(
+      meta(),
+      prodOptions({ releaseId: "rel-1", studioEmbed: true }),
+    );
+
+    assertEquals(
+      result.start.includes("/_vf/assets/"),
+      false,
+      "studio embeds must never emit content-addressed release asset URLs",
+    );
+    const pageModulePreloads = extractModulePreloadHrefs(result.start).filter((href) =>
+      href.startsWith("/_vf_modules/") || href.startsWith("/_vf/assets/")
+    );
+    assertEquals(
+      pageModulePreloads,
+      ["/_vf_modules/pages/index.js?studio_embed=true"],
+      "studio embeds must preload through the module server so live edits reach the iframe",
+    );
+  });
+
   it("falls back to the existing URL for an uncovered page when the flag is on", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
     registerManifestFetcherForRelease(

--- a/src/html/hydration-script-builder/dev-error-logger.test.ts
+++ b/src/html/hydration-script-builder/dev-error-logger.test.ts
@@ -55,12 +55,30 @@ describe("hydration-script-builder/dev-error-logger", () => {
 
     it("should override console.error", () => {
       const result = generateDevErrorLoggerScript();
-      assertEquals(result.includes("console.error"), true);
+      assertEquals(
+        result.includes("console.error = function("),
+        true,
+        "the dev logger must install a console.error override",
+      );
+      assertEquals(
+        result.includes("logToServer('error', 'Console error'"),
+        true,
+        "the console.error override must forward to the dev log endpoint",
+      );
     });
 
     it("should override console.warn", () => {
       const result = generateDevErrorLoggerScript();
-      assertEquals(result.includes("console.warn"), true);
+      assertEquals(
+        result.includes("console.warn = function("),
+        true,
+        "the dev logger must install a console.warn override",
+      );
+      assertEquals(
+        result.includes("logToServer('warn', 'Console warning'"),
+        true,
+        "the console.warn override must forward to the dev log endpoint",
+      );
     });
 
     it("should include page loaded log", () => {

--- a/src/html/hydration-script-builder/dev-scripts.test.ts
+++ b/src/html/hydration-script-builder/dev-scripts.test.ts
@@ -55,8 +55,18 @@ describe("hydration-script-builder/dev-scripts", () => {
 
     it("should include nonce in all scripts when provided", () => {
       const result = getDevScripts("page", baseConfig, undefined, undefined, "test-nonce");
-      const nonceCount = (result.match(/nonce="test-nonce"/g) ?? []).length;
-      assertEquals(nonceCount >= 3, true);
+      const scriptCount = (result.match(/<script/g) ?? []).length;
+      assertEquals(
+        scriptCount,
+        5,
+        "dev mode emits five scripts: dev flag, error logger, component manifest, " +
+          "client renderer, HMR",
+      );
+      assertEquals(
+        (result.match(/nonce="test-nonce"/g) ?? []).length,
+        scriptCount,
+        "every dev script tag must carry the CSP nonce",
+      );
     });
 
     it("should handle empty config", () => {

--- a/src/html/hydration-script-builder/hydration-data-generator.test.ts
+++ b/src/html/hydration-script-builder/hydration-data-generator.test.ts
@@ -141,6 +141,26 @@ describe("hydration-data-generator", () => {
       assertEquals(parsed.appRouterRoot, "src/app");
     });
 
+    it("omits a traversal-relative App Router root", () => {
+      const parsed = parseHydrationData("page", {}, {}, {
+        ...baseOptions,
+        projectDir: "/project",
+        pagePath: "../outside/page.tsx",
+        config: { directories: { app: "../shared/app" } },
+      }) as { appRouterRoot?: string; pagePath?: string };
+
+      assertEquals(
+        parsed.appRouterRoot,
+        "",
+        "a traversal-relative app directory must not be published",
+      );
+      assertEquals(
+        parsed.pagePath,
+        undefined,
+        "a traversal-relative page path must be omitted from the payload",
+      );
+    });
+
     it("publishes isolated client-page ownership", () => {
       const parsed = parseHydrationData(
         "page",

--- a/src/html/hydration-script-builder/prod-hydration.test.ts
+++ b/src/html/hydration-script-builder/prod-hydration.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { generateProdHydrationScript } from "./prod-hydration.ts";
 
@@ -66,7 +66,11 @@ describe("hydration-script-builder/prod-hydration", () => {
 
     it("should serialize empty props by default", () => {
       const result = generateProdHydrationScript("index");
-      assertEquals(result.includes("{}"), true);
+      assertEquals(
+        result.includes("React.createElement(Page, {})"),
+        true,
+        "absent props must hydrate the page with an empty object literal",
+      );
     });
 
     it("should serialize provided props", () => {
@@ -97,6 +101,29 @@ describe("hydration-script-builder/prod-hydration", () => {
       assertEquals(
         result.includes("import { Layout } from '@/components/layout'"),
         true,
+      );
+    });
+
+    it("should emit a script body that parses as an ES module", async () => {
+      const result = generateProdHydrationScript("index");
+      const body = result.match(/<script type="module"[^>]*>([\s\S]*?)<\/script>/)?.[1] ?? "";
+      assertEquals(body.length > 0, true, "the generated tag must contain a script body");
+
+      // Bare specifiers cannot resolve outside the browser, so drop the import
+      // lines; everything after them must still parse as a module.
+      const stripped = body.replace(/^\s*import[^\n]*\n/gm, "");
+      let caught: unknown;
+      try {
+        await import(`data:text/javascript,${encodeURIComponent(stripped)}`);
+      } catch (error) {
+        caught = error;
+      }
+
+      // A ReferenceError for the missing browser globals proves the body parsed;
+      // any other failure means the emitted module never runs at all.
+      assert(
+        caught === undefined || caught instanceof ReferenceError,
+        `emitted hydration script must parse as a module, got: ${caught}`,
       );
     });
 

--- a/src/html/hydration-script-builder/prod-hydration.ts
+++ b/src/html/hydration-script-builder/prod-hydration.ts
@@ -21,23 +21,23 @@ export function generateProdHydrationScript(
     import { Page } from ${pageSpecifier};
 
     const root = document.getElementById('root');
-    if (!root) return;
-
-    const tree = React.createElement(
-      App,
-      {},
-      React.createElement(
-        Layout,
+    if (root) {
+      const tree = React.createElement(
+        App,
         {},
-        React.createElement(Page, ${pageProps})
-      )
-    );
+        React.createElement(
+          Layout,
+          {},
+          React.createElement(Page, ${pageProps})
+        )
+      );
 
-    // identifierPrefix must match SSR to prevent useId() mismatch
-    // Suppress recoverable hydration errors - common with animation libraries
-    ReactDOM.hydrateRoot(root, tree, {
-      identifierPrefix: 'vf',
-      onRecoverableError: () => {}, // Silently ignore hydration mismatches
-    });
+      // identifierPrefix must match SSR to prevent useId() mismatch
+      // Suppress recoverable hydration errors - common with animation libraries
+      ReactDOM.hydrateRoot(root, tree, {
+        identifierPrefix: 'vf',
+        onRecoverableError: () => {}, // Silently ignore hydration mismatches
+      });
+    }
   </script>`;
 }

--- a/src/html/hydration-script-builder/prod-scripts.test.ts
+++ b/src/html/hydration-script-builder/prod-scripts.test.ts
@@ -169,6 +169,12 @@ describe("hydration-script-builder/prod-scripts", () => {
       const result = generateProdHydrationModule();
       assertEquals(result.includes("renderPage"), true);
       assertEquals(result.includes("createHydrationRenderer"), true);
+      // The identifiers survive any refactor; only the invocation hydrates a page.
+      assertEquals(
+        /createHydrationRenderer\(\{[\s\S]*?\}\)\.start\(\)/.test(result),
+        true,
+        "the runtime entry must invoke start() on the hydration renderer",
+      );
     });
 
     it("should not ship the type-only hydration data contract", () => {

--- a/src/html/hydration-script-builder/runtime/component-loader.test.ts
+++ b/src/html/hydration-script-builder/runtime/component-loader.test.ts
@@ -167,13 +167,31 @@ describe("hydration-script-builder/runtime/component-loader", () => {
       assertEquals(loader.pathToModuleUrl("pages/blog.mdx"), assetUrl);
     });
 
-    it("ignores release assets while Studio embed or HMR is serving fresh modules", () => {
+    it("ignores release assets while HMR is serving fresh modules", () => {
       const assetUrl = "/_vf/assets/" + "d".repeat(64) + ".js";
       const { loader } = createLoaderHarness();
       loader.setReleaseAssetModules({ "pages/blog.mdx": assetUrl });
       loader.setHMRRefreshTimestamp("77");
 
       assertEquals(loader.pathToModuleUrl("pages/blog.mdx"), "/_vf_modules/pages/blog.js?t=77");
+    });
+
+    it("ignores release assets while Studio embed is serving fresh modules", () => {
+      const assetUrl = "/_vf/assets/" + "e".repeat(64) + ".js";
+      const { loader } = createLoaderHarness();
+      loader.setReleaseAssetModules({ "pages/blog.mdx": assetUrl });
+      loader.setStudioEmbed(true);
+
+      assertEquals(
+        loader.pathToModuleUrl("pages/blog.mdx"),
+        "/_vf_modules/pages/blog.js",
+        "studio embed must bypass immutable release assets so Studio edits appear",
+      );
+      assertEquals(
+        loader.pathToModuleUrl("pages/blog.mdx", true),
+        "/_vf_modules/pages/blog.js?studio_embed=true",
+        "an explicit studio-embed request must also bypass release assets",
+      );
     });
   });
 
@@ -307,10 +325,21 @@ describe("hydration-script-builder/runtime/component-loader", () => {
     it("forwards allowDocumentReload:false so a speculative load cannot reload the page", async () => {
       const { loader, reloadRequests, importedUrls } = createLoaderHarness();
 
+      await loader.loadComponent("pages/default.tsx");
+      assertEquals(
+        reloadRequests,
+        ["/_vf_modules/pages/default.js"],
+        "a foreground load must permit document-reload recovery",
+      );
+
       await loader.loadComponent("pages/a.tsx", undefined, { allowDocumentReload: false });
 
-      assertEquals(importedUrls.length, 1);
-      assertEquals(reloadRequests, []);
+      assertEquals(importedUrls.length, 2);
+      assertEquals(
+        reloadRequests,
+        ["/_vf_modules/pages/default.js"],
+        "allowDocumentReload:false must not request a document reload",
+      );
     });
 
     it("clears one path or the whole cache", async () => {

--- a/src/html/hydration-script-builder/runtime/module-urls.test.ts
+++ b/src/html/hydration-script-builder/runtime/module-urls.test.ts
@@ -48,6 +48,25 @@ describe("hydration-script-builder/runtime/module-urls", () => {
       );
     });
 
+    it("pins absolute module-server urls on the path, not the query", () => {
+      assertEquals(
+        appendDependencyPinningVersion(
+          "https://site.example/_vf_modules/pages/blog.js?t=1",
+          { dependencyPinningCacheKey: "on:sha-a" },
+        ),
+        "https://site.example/_vf_modules/_pins/on%3Asha-a/pages/blog.js?t=1",
+        "an absolute module-server url must be pinned via the _pins path segment",
+      );
+      assertEquals(
+        appendDependencyPinningVersion(
+          "/proxy/_vf_modules/pages/blog.js",
+          { dependencyPinningCacheKey: "on:sha-a" },
+        ),
+        "/proxy/_vf_modules/pages/blog.js?pins=on%3Asha-a",
+        "a non-origin prefix must fall back to the pins query parameter",
+      );
+    });
+
     it("pins non-module-server urls with a query parameter", () => {
       assertEquals(
         appendDependencyPinningVersion(

--- a/src/html/hydration-script-builder/runtime/navigation-store.test.ts
+++ b/src/html/hydration-script-builder/runtime/navigation-store.test.ts
@@ -19,6 +19,28 @@ async function withCleanRegistry(run: () => void | Promise<void>): Promise<void>
   }
 }
 
+/**
+ * `globalThis.location` is an own writable, configurable property under Deno
+ * whose value is undefined, so a test can define a stub and restore the
+ * original descriptor afterwards.
+ */
+async function withLocation(
+  value: unknown,
+  run: () => void | Promise<void>,
+): Promise<void> {
+  const original = Object.getOwnPropertyDescriptor(globalThis, "location");
+  Object.defineProperty(globalThis, "location", { value, writable: true, configurable: true });
+  try {
+    await run();
+  } finally {
+    if (original) {
+      Object.defineProperty(globalThis, "location", original);
+    } else {
+      delete (globalThis as unknown as Record<string, unknown>).location;
+    }
+  }
+}
+
 describe("hydration-script-builder/runtime/navigation-store", () => {
   it("uses the router asset's own export when it has one", () => {
     const store = { subscribe: () => () => {} } as unknown as NavigationStore;
@@ -37,6 +59,11 @@ describe("hydration-script-builder/runtime/navigation-store", () => {
 
       assertEquals(resolved.usesRegistryFallback, true);
       assertEquals(resolved.getNavigationStore() === resolved.getNavigationStore(), true);
+      assertEquals(
+        (globalThis as unknown as StoreRegistry)[REGISTRY_KEY] === resolved.getNavigationStore(),
+        true,
+        "the fallback store must be published under the shared registry symbol so a pinned router asset binds to the same object",
+      );
     });
   });
 
@@ -97,6 +124,47 @@ describe("hydration-script-builder/runtime/navigation-store", () => {
       await store.navigate("/docs", { history: "push" });
 
       assertEquals(navigated, [{ href: "/docs", options: { history: "push" } }]);
+    });
+  });
+
+  it("reports the full location href including search and hash", async () => {
+    await withCleanRegistry(async () => {
+      await withLocation({ pathname: "/docs", search: "?q=1", hash: "#top" }, () => {
+        assertEquals(
+          resolveNavigationStore({}).getNavigationStore().getHref(),
+          "/docs?q=1#top",
+          "getHref must include search and hash so search-only navigations change the snapshot",
+        );
+      });
+    });
+  });
+
+  it('falls back to "/" when there is no location', async () => {
+    await withCleanRegistry(async () => {
+      await withLocation(undefined, () => {
+        assertEquals(
+          resolveNavigationStore({}).getNavigationStore().getHref(),
+          "/",
+          "getHref must fall back to the documented root path off-document",
+        );
+      });
+    });
+  });
+
+  it("falls back to a document navigation before a navigator is registered", async () => {
+    await withCleanRegistry(async () => {
+      const assigned: string[] = [];
+
+      await withLocation({ assign: (href: string) => assigned.push(href) }, async () => {
+        const store = resolveNavigationStore({}).getNavigationStore();
+        await store.navigate("/docs");
+      });
+
+      assertEquals(
+        assigned,
+        ["/docs"],
+        "navigate must fall back to a real page load until a navigator registers",
+      );
     });
   });
 });

--- a/src/html/hydration-script-builder/runtime/renderer-modules.test.ts
+++ b/src/html/hydration-script-builder/runtime/renderer-modules.test.ts
@@ -316,6 +316,30 @@ describe("hydration-script-builder/runtime/renderer", () => {
       assertEquals(requested, ["http://modules/pages/index.js"]);
     });
 
+    it("does not retry for a nested index slug", async () => {
+      const requested: string[] = [];
+      const original = notFound("http://modules/pages/docs/index.js");
+
+      const thrown = await captureRejection(
+        loadPageModuleWithIndexFallback(
+          "http://modules/pages/docs/index",
+          "docs/index",
+          null,
+          (url) => {
+            requested.push(url);
+            return Promise.reject(original);
+          },
+        ),
+      );
+
+      assertEquals(thrown, original, "a nested index slug must surface the original error");
+      assertEquals(
+        requested,
+        ["http://modules/pages/docs/index.js"],
+        "a nested index slug must not probe <route>/index/index.js",
+      );
+    });
+
     it("prefers a link error over a stale hydration-data fetch failure", async () => {
       // Hydration data can carry a pagePath that no longer resolves. That 404
       // must never outrank an error proving the fallback reached a module.

--- a/src/html/hydration-script-builder/runtime/route-timing.test.ts
+++ b/src/html/hydration-script-builder/runtime/route-timing.test.ts
@@ -1,15 +1,50 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import type { RuntimeResponse } from "./env.ts";
+import type { RuntimeResponse, RuntimeWindow } from "./env.ts";
+import type { RuntimeLogging } from "./shared.ts";
 import {
+  createRouteTimingRecorder,
   extractResourceTiming,
+  MAX_ROUTE_TIMINGS,
   MAX_SERVER_TIMING_LENGTH,
   parseServerTimingMetrics,
   readResponseServerTiming,
+  type RouteTimingRecorder,
   sanitizeServerTimingHeader,
   sanitizeServerTimingMetricName,
 } from "./route-timing.ts";
+
+function silentLogging(): RuntimeLogging {
+  return {
+    DEBUG: false,
+    log: () => {},
+    logError: () => {},
+    logBackgroundFetchFailure: () => {},
+    perfStart: () => {},
+    perfEnd: () => 0,
+  };
+}
+
+interface RecorderHarness {
+  recorder: RouteTimingRecorder;
+  window: RuntimeWindow;
+  dispatched: CustomEvent[];
+}
+
+function createRecorderHarness(options: { throwOnDispatch?: boolean } = {}): RecorderHarness {
+  const dispatched: CustomEvent[] = [];
+  const window = {
+    location: { href: "https://example.test/docs" },
+    dispatchEvent: (event: unknown) => {
+      if (options.throwOnDispatch) throw new Error("dispatch is unavailable");
+      dispatched.push(event as CustomEvent);
+      return true;
+    },
+  } as unknown as RuntimeWindow;
+
+  return { recorder: createRouteTimingRecorder(window, silentLogging()), window, dispatched };
+}
 
 describe("hydration-script-builder/runtime/route-timing", () => {
   describe("sanitizeServerTimingHeader", () => {
@@ -101,11 +136,38 @@ describe("hydration-script-builder/runtime/route-timing", () => {
 
   describe("readResponseServerTiming", () => {
     it("returns the sanitized header", () => {
+      let requested: string | undefined;
       const response = {
-        headers: { get: () => "db;dur=2" },
+        headers: {
+          get: (name: string) => {
+            requested = name;
+            return "db;dur=2";
+          },
+        },
       } as unknown as RuntimeResponse;
 
-      assertEquals(readResponseServerTiming(response), "db;dur=2.00");
+      assertEquals(
+        readResponseServerTiming(response),
+        "db;dur=2.00",
+        "the header value must come back sanitized",
+      );
+      assertEquals(
+        requested,
+        "server-timing",
+        "the Server-Timing header must be read by its standard name",
+      );
+    });
+
+    it("returns null when the response carries no Server-Timing header", () => {
+      const response = {
+        headers: { get: () => null },
+      } as unknown as RuntimeResponse;
+
+      assertEquals(
+        readResponseServerTiming(response),
+        null,
+        "a response without the header must report no server timing",
+      );
     });
 
     it("returns null when headers.get throws", () => {
@@ -118,6 +180,90 @@ describe("hydration-script-builder/runtime/route-timing", () => {
       } as unknown as RuntimeResponse;
 
       assertEquals(readResponseServerTiming(response), null);
+    });
+  });
+
+  describe("createRouteTimingRecorder", () => {
+    it("caps the route timing buffer and drops the oldest entries first", () => {
+      const { recorder, window } = createRecorderHarness();
+
+      for (let index = 0; index < MAX_ROUTE_TIMINGS + 5; index++) {
+        recorder.emitRouteTiming("page-data", "p" + index, 0);
+      }
+
+      assertEquals(
+        window.__veryfrontRouteTimings?.length,
+        MAX_ROUTE_TIMINGS,
+        "the route timing buffer must stay capped",
+      );
+      assertEquals(
+        window.__veryfrontRouteTimings?.[0]?.path,
+        "p5",
+        "the oldest entries must be dropped first",
+      );
+    });
+
+    it("dispatches the documented route timing event for every entry", () => {
+      const { recorder, dispatched } = createRecorderHarness();
+
+      const entry = recorder.emitRouteTiming("page-data", "/docs", 0, { source: "network" });
+
+      assertEquals(dispatched.length, 1, "each timing must dispatch exactly one event");
+      assertEquals(
+        dispatched[0]?.type,
+        "veryfront:route-timing",
+        "each timing must dispatch the documented event",
+      );
+      assertEquals(
+        dispatched[0]?.detail,
+        entry,
+        "the entry must ride on the event detail",
+      );
+      assertEquals(entry.phase, "page-data", "the entry must carry the emitted phase");
+      assertEquals(entry.source, "network", "the caller detail must be merged into the entry");
+    });
+
+    it("still records the entry when the event dispatch throws", () => {
+      const { recorder, window } = createRecorderHarness({ throwOnDispatch: true });
+
+      const entry = recorder.emitRouteTiming("page-data", "/docs", 0);
+
+      assertEquals(
+        window.__veryfrontRouteTimings,
+        [entry],
+        "a failing dispatch must not lose the recorded timing",
+      );
+    });
+  });
+
+  describe("buildPageDataTimingDetail", () => {
+    it("attaches the sanitized server timing and its parsed metrics", () => {
+      const { recorder } = createRecorderHarness();
+      const response = {
+        status: 200,
+        url: "",
+        headers: { get: () => "db;dur=2" },
+      } as unknown as RuntimeResponse;
+
+      const detail = recorder.buildPageDataTimingDetail(
+        response,
+        "/_vf/page-data/docs",
+        0,
+        "network",
+      );
+
+      assertEquals(detail.source, "network", "the detail must record the fetch source");
+      assertEquals(detail.status, 200, "the detail must record the response status");
+      assertEquals(
+        detail.serverTiming,
+        "db;dur=2.00",
+        "the sanitized Server-Timing header must reach the detail",
+      );
+      assertEquals(
+        detail.serverTimingMetrics,
+        { db: 2 },
+        "the parsed Server-Timing metrics must reach the detail",
+      );
     });
   });
 });

--- a/src/html/hydration-script-builder/runtime/router.test.ts
+++ b/src/html/hydration-script-builder/runtime/router.test.ts
@@ -591,6 +591,56 @@ describe("hydration-script-builder/runtime/router", () => {
     assertEquals(thirdParty.getAttribute("content"), "Third party");
   });
 
+  it("owns the SPA stylesheet lifecycle across navigations", async () => {
+    const harness = createRouterHarness();
+    // getDocumentNonce reads the nonce off whatever the shell already emitted.
+    const shellScript = harness.document.createElement("script");
+    shellScript.setAttribute("nonce", "n-1");
+    harness.document.head.appendChild(shellScript);
+    harness.window.__veryfrontHydrationComplete?.();
+
+    await harness.runtime.renderPageFromData(
+      { pagePath: "page-a", params: {}, css: ".a{}" },
+      "/page-a",
+    );
+
+    const styleEl = harness.document.getElementById("veryfront-spa-css");
+    if (!styleEl) throw new Error("the SPA stylesheet was never injected");
+    assertEquals(
+      styleEl.getAttribute("nonce"),
+      "n-1",
+      "the SPA stylesheet must carry the document nonce or CSP blocks it",
+    );
+    assertEquals(styleEl.textContent, ".a{}", "the injected stylesheet must carry the route CSS");
+
+    await harness.runtime.renderPageFromData(
+      { pagePath: "page-b", params: {}, css: ".b{}" },
+      "/page-b",
+    );
+
+    assertEquals(
+      harness.headElements.filter((element) => element.id === "veryfront-spa-css").length,
+      1,
+      "the SPA stylesheet must be updated in place, not duplicated",
+    );
+    assertEquals(
+      harness.document.getElementById("veryfront-spa-css")?.textContent,
+      ".b{}",
+      "the next route's CSS must replace the previous route's CSS",
+    );
+
+    await harness.runtime.renderPageFromData(
+      { pagePath: "page-c", params: {}, cssAction: "clear" },
+      "/page-c",
+    );
+
+    assertEquals(
+      harness.document.getElementById("veryfront-spa-css"),
+      null,
+      "a release-stylesheet route must drop the previous route's inline CSS",
+    );
+  });
+
   it("refreshes params from history state on popstate navigation", async () => {
     const harness = createRouterHarness({
       pathname: "/posts/42",
@@ -1074,6 +1124,182 @@ describe("hydration-script-builder/runtime/router", () => {
         1,
         "a background refresh of a route we are leaving the document for is wasted work",
       );
+    });
+  });
+
+  // The document click interceptor decides which clicks the SPA owns. Every
+  // bail-out below must reach the browser untouched, or the link stops
+  // behaving like a link.
+  describe("link interception", () => {
+    function makeLink(href: string): TestRuntimeElement {
+      const link = makeElement("a");
+      link.setAttribute("href", href);
+      return link;
+    }
+
+    function clickLink(
+      harness: RouterHarness,
+      link: TestRuntimeElement,
+      modifiers: Partial<RuntimeEvent> = {},
+    ): { prevented: number } {
+      const handler = harness.listeners.click?.[0];
+      if (!handler) throw new Error("click handler was not registered");
+      const state = { prevented: 0 };
+      handler({
+        ...modifiers,
+        target: { closest: () => link } as unknown as RuntimeElement,
+        preventDefault: () => {
+          state.prevented++;
+        },
+      } as RuntimeEvent);
+      return state;
+    }
+
+    const bailOuts: Array<{
+      name: string;
+      reason: string;
+      link: () => TestRuntimeElement;
+      modifiers?: Partial<RuntimeEvent>;
+    }> = [
+      {
+        name: "a meta-clicked internal link",
+        reason: "a meta-click must reach the browser so the link opens in a new tab",
+        link: () => makeLink("/about"),
+        modifiers: { metaKey: true },
+      },
+      {
+        name: "a ctrl-clicked internal link",
+        reason: "a ctrl-click must reach the browser so the link opens in a new tab",
+        link: () => makeLink("/about"),
+        modifiers: { ctrlKey: true },
+      },
+      {
+        name: "a shift-clicked internal link",
+        reason: "a shift-click must reach the browser so the link opens in a new window",
+        link: () => makeLink("/about"),
+        modifiers: { shiftKey: true },
+      },
+      {
+        name: "an alt-clicked internal link",
+        reason: "an alt-click must reach the browser so the link is downloaded",
+        link: () => makeLink("/about"),
+        modifiers: { altKey: true },
+      },
+      {
+        name: "a link targeting a new tab",
+        reason: 'a target="_blank" link must reach the browser',
+        link: () => {
+          const link = makeLink("/about");
+          link.target = "_blank";
+          return link;
+        },
+      },
+      {
+        name: "a download link",
+        reason: "a download link must reach the browser",
+        link: () => {
+          const link = makeLink("/report.pdf");
+          link.setAttribute("download", "");
+          return link;
+        },
+      },
+      {
+        name: "a protocol-relative link",
+        reason: "a protocol-relative link leaves the origin and must reach the browser",
+        link: () => makeLink("//other.example/x"),
+      },
+      {
+        name: "an absolute external link",
+        reason: "an external link must reach the browser",
+        link: () => makeLink("https://other.example/x"),
+      },
+    ];
+
+    for (const bailOut of bailOuts) {
+      it("leaves " + bailOut.name + " to the browser", async () => {
+        const harness = createRouterHarness();
+        harness.window.__veryfrontHydrationComplete?.();
+
+        const state = clickLink(harness, bailOut.link(), bailOut.modifiers);
+        for (let i = 0; i < 5; i++) await flushMicrotasks();
+
+        assertEquals(state.prevented, 0, bailOut.reason);
+        assertEquals(
+          harness.fetchCalls.length,
+          0,
+          bailOut.reason + ", so it must not trigger a page-data fetch",
+        );
+        assertEquals(
+          harness.historyCalls,
+          [],
+          bailOut.reason + ", so it must not mutate history",
+        );
+      });
+    }
+
+    it("soft navigates a plain internal link", async () => {
+      const harness = createRouterHarness();
+      harness.window.__veryfrontHydrationComplete?.();
+      harness.setNextPageData({ pagePath: "page", params: {} });
+
+      const state = clickLink(harness, makeLink("/about"));
+      await flushUntil(() => harness.router.pathname === "/about");
+
+      assertEquals(state.prevented, 1, "a plain internal link must be soft navigated");
+      assertEquals(
+        harness.fetchCalls.length,
+        1,
+        "a soft navigated link must fetch the target route's page data",
+      );
+      assertEquals(
+        harness.fetchCalls[0]?.url.includes("about"),
+        true,
+        "the page-data request must target the clicked route",
+      );
+      assertEquals(harness.router.pathname, "/about", "the SPA router must own the clicked route");
+    });
+
+    it("scrolls to the fragment target instead of navigating for a hash link", async () => {
+      const harness = createRouterHarness();
+      harness.window.__veryfrontHydrationComplete?.();
+      const section = makeElement("section");
+      section.id = "details";
+      let scrolled = 0;
+      section.scrollIntoView = () => {
+        scrolled++;
+      };
+      harness.document.head.appendChild(section);
+
+      const state = clickLink(harness, makeLink("#details"));
+      for (let i = 0; i < 5; i++) await flushMicrotasks();
+
+      assertEquals(state.prevented, 1, "an in-page hash link must be handled by the router");
+      assertEquals(scrolled, 1, "an in-page hash link must scroll its target into view");
+      assertEquals(
+        harness.fetchCalls.length,
+        0,
+        "an in-page hash link must not fetch page data",
+      );
+      assertEquals(
+        harness.historyCalls,
+        [{ method: "push", href: "#details" }],
+        "an in-page hash link must record exactly one history entry",
+      );
+    });
+
+    it("leaves a hash link with no matching target to the browser", async () => {
+      const harness = createRouterHarness();
+      harness.window.__veryfrontHydrationComplete?.();
+
+      const state = clickLink(harness, makeLink("#missing"));
+      for (let i = 0; i < 5; i++) await flushMicrotasks();
+
+      assertEquals(
+        state.prevented,
+        0,
+        "a hash link with no target in the document must reach the browser",
+      );
+      assertEquals(harness.historyCalls, [], "an unhandled hash link must not mutate history");
     });
   });
 

--- a/src/html/hydration-script-builder/runtime/snapshot-modules.test.ts
+++ b/src/html/hydration-script-builder/runtime/snapshot-modules.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { ModuleNamespace, RuntimeResponse } from "./env.ts";
 import {
@@ -56,6 +56,42 @@ describe("hydration-script-builder/runtime/snapshot-modules", () => {
   });
 
   describe("importSnapshotBoundModule", () => {
+    it("returns the imported namespace untouched when the module loads", async () => {
+      const namespace = { default: { name: "Page" } } as unknown as ModuleNamespace;
+      const recoveryState: Record<string, unknown> = {};
+      let probes = 0;
+      let reloads = 0;
+
+      const { importSnapshotBoundModule } = createSnapshotModuleImporter({
+        importModule: () => Promise.resolve(namespace),
+        fetchModule: () => {
+          probes++;
+          return Promise.resolve(conflictResponse("Unknown dependency snapshot"));
+        },
+        reloadDocument: () => {
+          reloads++;
+        },
+        recoveryState,
+      });
+
+      const loaded = await importSnapshotBoundModule(
+        "/_vf_modules/_pins/on%3Asnapshot-a/app/page.js",
+      );
+
+      assertStrictEquals(
+        loaded,
+        namespace,
+        "a successful import must return the module namespace it loaded",
+      );
+      assertEquals(probes, 0, "a successful import must not probe the module server");
+      assertEquals(reloads, 0, "a successful import must not reload the document");
+      assertEquals(
+        recoveryState.__VF_DEPENDENCY_SNAPSHOT_RECOVERY_STARTED__,
+        undefined,
+        "a successful import must not arm snapshot recovery",
+      );
+    });
+
     it("reloads once when pinned page, layout, app, and error imports hit snapshot eviction", async () => {
       const importedUrls: string[] = [];
       const probedUrls: string[] = [];

--- a/src/html/metadata-builder.test.ts
+++ b/src/html/metadata-builder.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import type { RenderMetadata } from "#veryfront/types";
+import { deserializeManagedHeadPayload } from "./managed-head-protocol.ts";
 import { processMetadata } from "./metadata-builder.ts";
 
 describe("html-generation/metadata-builder", () => {
@@ -110,6 +111,36 @@ describe("html-generation/metadata-builder", () => {
       const result = processMetadata(meta);
 
       assertEquals(result.effectiveTitle, "Veryfront App");
+    });
+
+    it("carries the effective title and frontmatter-declared links and styles into the head output", () => {
+      const meta: RenderMetadata = {
+        title: "Doc Title",
+        slug: "doc",
+        // The head pipeline reads the richer MDX frontmatter shape, whose styles
+        // and links are objects. RenderMetadata still points at the narrow
+        // scalar-only declaration, so the cast bridges the two.
+        frontmatter: {
+          styles: [{ content: ".x{}" }],
+          links: [{ rel: "canonical", href: "/x" }],
+        } as unknown as RenderMetadata["frontmatter"],
+      };
+
+      const result = processMetadata(meta);
+      const titleDescriptor = deserializeManagedHeadPayload(result.managedHeadPayload)
+        .find((descriptor) => descriptor.tagName === "title");
+
+      assertEquals(
+        titleDescriptor?.content,
+        "Doc Title",
+        "the managed head payload must carry the effective title, not the raw frontmatter title",
+      );
+      assertStringIncludes(result.styleTags, ".x{}", "frontmatter styles must reach styleTags");
+      assertStringIncludes(
+        result.linkTags,
+        'rel="canonical"',
+        "frontmatter links must reach linkTags",
+      );
     });
   });
 });

--- a/src/html/metadata-builder.test.ts
+++ b/src/html/metadata-builder.test.ts
@@ -121,6 +121,7 @@ describe("html-generation/metadata-builder", () => {
         // and links are objects. RenderMetadata still points at the narrow
         // scalar-only declaration, so the cast bridges the two.
         frontmatter: {
+          title: "Frontmatter Title",
           styles: [{ content: ".x{}" }],
           links: [{ rel: "canonical", href: "/x" }],
         } as unknown as RenderMetadata["frontmatter"],
@@ -132,8 +133,8 @@ describe("html-generation/metadata-builder", () => {
 
       assertEquals(
         titleDescriptor?.content,
-        "Doc Title",
-        "the managed head payload must carry the effective title, not the raw frontmatter title",
+        "Frontmatter Title",
+        "the managed head payload must carry the effective title with frontmatter title precedence",
       );
       assertStringIncludes(result.styleTags, ".x{}", "frontmatter styles must reach styleTags");
       assertStringIncludes(

--- a/src/html/nonce-injection.test.ts
+++ b/src/html/nonce-injection.test.ts
@@ -5,6 +5,7 @@ import {
   addNonceToHtmlStream,
   addNonceToHtmlTags,
   bindHtmlNonceFromCache,
+  isHtmlNonceCacheCompatible,
   sealHtmlNonceForCache,
 } from "./nonce-injection.ts";
 
@@ -257,5 +258,30 @@ describe("html/nonce-injection", () => {
         value: originalToLowerCase,
       });
     }
+  });
+
+  it("rejects unsealed cache entries when the response enforces a nonce", () => {
+    assertEquals(
+      isHtmlNonceCacheCompatible(undefined, "nonce-a"),
+      false,
+      "a legacy entry with no placeholder must not be served to a nonce-enforcing response",
+    );
+    assertEquals(
+      isHtmlNonceCacheCompatible("not-a-placeholder", "nonce-a"),
+      false,
+      "only an internally minted placeholder may opt an entry into nonce rebinding",
+    );
+
+    const sealed = sealHtmlNonceForCache('<script nonce="nonce-a">f()</script>', "nonce-a");
+    assertEquals(
+      isHtmlNonceCacheCompatible(sealed.placeholder, "nonce-b"),
+      true,
+      "a sealed entry must be rebindable to a new response nonce",
+    );
+    assertEquals(
+      isHtmlNonceCacheCompatible(undefined, undefined),
+      true,
+      "responses without a nonce must still hit the cache",
+    );
   });
 });

--- a/src/html/styles-builder/css-pregeneration.test.ts
+++ b/src/html/styles-builder/css-pregeneration.test.ts
@@ -1,15 +1,26 @@
 import "#veryfront/schemas/_test-setup.ts";
+import "./__tests__/css-processor-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { waitFor } from "#veryfront/testing/deno-compat.ts";
 import { mkdir, remove, writeTextFile } from "#veryfront/compat/fs.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { createStyleScopeProfile } from "./style-scope-profile.ts";
 import {
+  buildPreparedCSSArtifactFromFiles,
   collectLocalProjectSourceFiles,
   findGlobalStylesheet,
   findStylesheetFromFiles,
   readLocalProjectStylesheet,
+  warmPreparedCSSArtifactFromFiles,
 } from "./css-pregeneration.ts";
+import { acquireCSSGenerationSession, extractCandidatesFromFiles } from "./tailwind-compiler.ts";
+import { hashCandidates } from "./css-identity.ts";
+import {
+  createPreparedProjectCSSContext,
+  invalidatePreparedProjectCSS,
+  tryGetPreparedProjectCSS,
+} from "./prepared-project-css-cache.ts";
 
 describe("styles-builder/css-pregeneration", () => {
   describe("findGlobalStylesheet", () => {
@@ -112,7 +123,21 @@ describe("styles-builder/css-pregeneration", () => {
     it("should not match files that end with globals.css but have different prefix", () => {
       assertEquals(
         findGlobalStylesheet([{ path: "my-globals.css", content: "should not match" }]),
-        "should not match",
+        undefined,
+        "a prefixed filename must not be treated as the global stylesheet",
+      );
+    });
+
+    it("should still match a globals stylesheet under a nested repo root", () => {
+      assertEquals(
+        findGlobalStylesheet([{ path: "styles/globals.css", content: "nested" }]),
+        "nested",
+        "a conventional nested path must remain a global stylesheet match",
+      );
+      assertEquals(
+        findGlobalStylesheet([{ path: "project/src/globals.css", content: "deep" }]),
+        "deep",
+        "a globals stylesheet under a nested repo root must remain a match",
       );
     });
   });
@@ -263,6 +288,152 @@ describe("styles-builder/css-pregeneration", () => {
         );
       } finally {
         await remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("falls back to a convention-named globals stylesheet", async () => {
+      const projectDir = await Deno.makeTempDir({ prefix: "vf-css-pregeneration-" });
+
+      try {
+        await mkdir(join(projectDir, "styles"), { recursive: true });
+        await writeTextFile(join(projectDir, "styles", "globals.css"), ".globals { color: blue; }");
+
+        assertEquals(
+          await readLocalProjectStylesheet(projectDir),
+          ".globals { color: blue; }",
+          "an unset tailwind.stylesheet must fall back to the conventional globals stylesheet",
+        );
+      } finally {
+        await remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("returns undefined when the configured stylesheet is missing", async () => {
+      const projectDir = await Deno.makeTempDir({ prefix: "vf-css-pregeneration-" });
+
+      try {
+        await writeTextFile(join(projectDir, "globals.css"), ".globals { color: blue; }");
+
+        assertEquals(
+          await readLocalProjectStylesheet(projectDir, "styles/custom.css"),
+          undefined,
+          "a configured stylesheet path is exclusive and does not fall back to globals",
+        );
+      } finally {
+        await remove(projectDir, { recursive: true });
+      }
+    });
+  });
+
+  describe("warmPreparedCSSArtifactFromFiles", () => {
+    const STYLESHEET = `@import "tailwindcss";`;
+    const SOURCE_FILE = {
+      path: "pages/index.tsx",
+      content: `<div className="text-red-500" />`,
+    };
+
+    function warmOptions(projectSlug: string) {
+      return {
+        projectSlug,
+        projectVersion: "warm-version",
+        files: [SOURCE_FILE],
+        styleProfile: createStyleScopeProfile(),
+        stylesheet: STYLESHEET,
+        minify: false,
+      };
+    }
+
+    /**
+     * Rebuild the cache context the warm path derives, so a test can wait for
+     * the background build to store its artifact without starting a second one.
+     */
+    function preparedContextFor(options: ReturnType<typeof warmOptions>) {
+      const candidates = extractCandidatesFromFiles(options.files, {
+        styleProfile: options.styleProfile,
+      });
+      const session = acquireCSSGenerationSession(options.minify);
+      return createPreparedProjectCSSContext(
+        options.projectSlug,
+        options.projectVersion,
+        options.stylesheet,
+        options.styleProfile.hash,
+        {
+          cssPipelineIdentity: session.cacheIdentity,
+          candidatesHash: hashCandidates(candidates),
+          minify: options.minify,
+          environment: "preview",
+          buildMode: "production",
+        },
+      );
+    }
+
+    it("joins an in-flight build instead of starting a second compile", async () => {
+      const projectSlug = `warm-inflight-${crypto.randomUUID()}`;
+      const options = warmOptions(projectSlug);
+
+      try {
+        assertEquals(
+          await warmPreparedCSSArtifactFromFiles(options),
+          true,
+          "the first warm call must start the build",
+        );
+        assertEquals(
+          await warmPreparedCSSArtifactFromFiles(options),
+          false,
+          "a second warm call must join the in-flight build instead of recompiling",
+        );
+
+        await waitFor(
+          async () => (await tryGetPreparedProjectCSS(preparedContextFor(options))) !== undefined,
+          { message: "the warm build never stored its prepared artifact" },
+        );
+      } finally {
+        invalidatePreparedProjectCSS(projectSlug);
+      }
+    });
+
+    it("does not rebuild an artifact that is already prepared", async () => {
+      const projectSlug = `warm-cached-${crypto.randomUUID()}`;
+      const options = warmOptions(projectSlug);
+
+      try {
+        await buildPreparedCSSArtifactFromFiles(options);
+
+        assertEquals(
+          await warmPreparedCSSArtifactFromFiles(options),
+          false,
+          "a cached artifact must not be rebuilt",
+        );
+      } finally {
+        invalidatePreparedProjectCSS(projectSlug);
+      }
+    });
+
+    it("prefers an explicit stylesheet over one discovered in the files", async () => {
+      const projectSlug = `warm-stylesheet-${crypto.randomUUID()}`;
+      const options = warmOptions(projectSlug);
+
+      try {
+        // Prepare the artifact under the identity an explicit stylesheet
+        // implies, with no competing stylesheet in the file list at all.
+        await buildPreparedCSSArtifactFromFiles(options);
+
+        // The same warm request, now carrying a globals.css that resolves to
+        // different CSS, must still recognise the prepared artifact. It only
+        // can when `options.stylesheet` outranks findStylesheetFromFiles.
+        assertEquals(
+          await warmPreparedCSSArtifactFromFiles({
+            ...options,
+            files: [
+              SOURCE_FILE,
+              { path: "globals.css", content: `@import "tailwindcss";\n.from-files{}` },
+            ],
+          }),
+          false,
+          "an explicit stylesheet must outrank one discovered in the files",
+        );
+      } finally {
+        invalidatePreparedProjectCSS(projectSlug);
       }
     });
   });

--- a/src/html/styles-builder/css-pregeneration.test.ts
+++ b/src/html/styles-builder/css-pregeneration.test.ts
@@ -5,6 +5,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { waitFor } from "#veryfront/testing/deno-compat.ts";
 import { mkdir, remove, writeTextFile } from "#veryfront/compat/fs.ts";
 import { join } from "#veryfront/compat/path/index.ts";
+import { makeTempDir } from "#veryfront/platform/compat/fs.ts";
 import { createStyleScopeProfile } from "./style-scope-profile.ts";
 import {
   buildPreparedCSSArtifactFromFiles,
@@ -236,7 +237,7 @@ describe("styles-builder/css-pregeneration", () => {
 
   describe("local project helpers", () => {
     it("collects local source files while skipping ignored roots", async () => {
-      const projectDir = await Deno.makeTempDir({ prefix: "vf-css-pregeneration-" });
+      const projectDir = await makeTempDir({ prefix: "vf-css-pregeneration-" });
 
       try {
         await mkdir(join(projectDir, "pages"), { recursive: true });
@@ -275,7 +276,7 @@ describe("styles-builder/css-pregeneration", () => {
     });
 
     it("reads the configured stylesheet path before default globals fallbacks", async () => {
-      const projectDir = await Deno.makeTempDir({ prefix: "vf-css-pregeneration-" });
+      const projectDir = await makeTempDir({ prefix: "vf-css-pregeneration-" });
 
       try {
         await mkdir(join(projectDir, "styles"), { recursive: true });
@@ -292,7 +293,7 @@ describe("styles-builder/css-pregeneration", () => {
     });
 
     it("falls back to a convention-named globals stylesheet", async () => {
-      const projectDir = await Deno.makeTempDir({ prefix: "vf-css-pregeneration-" });
+      const projectDir = await makeTempDir({ prefix: "vf-css-pregeneration-" });
 
       try {
         await mkdir(join(projectDir, "styles"), { recursive: true });
@@ -309,7 +310,7 @@ describe("styles-builder/css-pregeneration", () => {
     });
 
     it("returns undefined when the configured stylesheet is missing", async () => {
-      const projectDir = await Deno.makeTempDir({ prefix: "vf-css-pregeneration-" });
+      const projectDir = await makeTempDir({ prefix: "vf-css-pregeneration-" });
 
       try {
         await writeTextFile(join(projectDir, "globals.css"), ".globals { color: blue; }");

--- a/src/html/styles-builder/css-pregeneration.ts
+++ b/src/html/styles-builder/css-pregeneration.ts
@@ -357,13 +357,15 @@ export function findStylesheetFromFiles(
 export function findGlobalStylesheet(
   files: Array<{ path: string; content?: string }>,
 ): string | undefined {
+  // Anchored to a path-segment boundary so a prefixed filename such as
+  // `theme-globals.css` is not mistaken for the project's global stylesheet.
   const stylesheetPatterns = [
-    /globals\.css$/,
-    /global\.css$/,
-    /styles\/globals\.css$/,
-    /app\/globals\.css$/,
-    /src\/globals\.css$/,
-    /src\/styles\/globals\.css$/,
+    /(^|\/)globals\.css$/,
+    /(^|\/)global\.css$/,
+    /(^|\/)styles\/globals\.css$/,
+    /(^|\/)app\/globals\.css$/,
+    /(^|\/)src\/globals\.css$/,
+    /(^|\/)src\/styles\/globals\.css$/,
   ];
 
   for (const pattern of stylesheetPatterns) {

--- a/src/html/styles-builder/prepared-project-css-cache.test.ts
+++ b/src/html/styles-builder/prepared-project-css-cache.test.ts
@@ -44,10 +44,26 @@ describe("styles-builder/prepared-project-css-cache", () => {
         ...baseProfile,
         cssPipelineIdentity: "pipeline-B",
       }),
+      createPreparedProjectCSSContext("project", "version-A", "sheet-A", styleProfile, {
+        ...baseProfile,
+        minify: false,
+      }),
+      createPreparedProjectCSSContext("project", "version-A", "sheet-A", styleProfile, {
+        ...baseProfile,
+        buildMode: "development" as const,
+      }),
+      createPreparedProjectCSSContext("project", "version-A", "sheet-A", styleProfile, {
+        ...baseProfile,
+        environment: "production",
+      }),
     ];
 
     for (const variant of variants) {
-      assertEquals(variant.cacheKey === base.cacheKey, false);
+      assertEquals(
+        variant.cacheKey === base.cacheKey,
+        false,
+        "every output-affecting identity field must partition the prepared CSS cache key",
+      );
     }
     const safelyFramed = createPreparedProjectCSSContext(
       "project:*:scope",
@@ -135,7 +151,32 @@ describe("styles-builder/prepared-project-css-cache", () => {
     const css = ".alpha{display:block}";
 
     invalidatePreparedProjectCSS(projectSlug);
-    await storePreparedProjectCSS(context, { css, hash: hashCSS(css) });
-    assertEquals(await tryGetPreparedProjectCSS(context), undefined);
+    try {
+      await storePreparedProjectCSS(context, { css, hash: hashCSS(css) });
+      assertEquals(await tryGetPreparedProjectCSS(context), undefined);
+
+      const fresh = createPreparedProjectCSSContext(
+        projectSlug,
+        "version",
+        "sheet",
+        hashString("style-profile"),
+        {
+          cssPipelineIdentity: "pipeline",
+          candidatesHash: hashCandidates(["alpha"]),
+        },
+      );
+      assertEquals(
+        fresh.cacheKey,
+        context.cacheKey,
+        "a post-invalidation context with identical inputs reuses the same cache key",
+      );
+      assertEquals(
+        await tryGetPreparedProjectCSS(fresh),
+        undefined,
+        "a pre-invalidation write must not repopulate the cache for a current-epoch reader",
+      );
+    } finally {
+      invalidatePreparedProjectCSS(projectSlug);
+    }
   });
 });

--- a/src/html/styles-builder/project-css-cache.test.ts
+++ b/src/html/styles-builder/project-css-cache.test.ts
@@ -63,6 +63,22 @@ describe("styles-builder/project-css-cache", () => {
       candidates,
     );
     assertEquals(await tryGetProjectCSSFromLocalFallback(context, candidates), undefined);
+
+    // The stale context is refused by the reader on its own, so the write guard
+    // is only observable through a fresh post-invalidation context, which
+    // resolves to the same epoch-independent cache key.
+    const freshContext = createProjectCSSRequestContext(
+      projectSlug,
+      TEST_STYLESHEET,
+      candidates,
+      { cssPipelineIdentity: "pipeline" },
+    );
+    assertEquals(freshContext.cacheKey, context.cacheKey);
+    assertEquals(
+      await tryGetProjectCSSFromLocalFallback(freshContext, candidates),
+      undefined,
+      "a generation that started before invalidateProjectCSS must not seed the local fallback for later requests",
+    );
   });
 
   it("populates hash-level cache on fresh generation so other pods can serve CSS", async () => {

--- a/src/html/styles-builder/style-scope-profile.test.ts
+++ b/src/html/styles-builder/style-scope-profile.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   createStyleScopeProfile,
@@ -75,6 +75,19 @@ describe("styles-builder/style-scope-profile", () => {
     assertEquals(
       shouldIncludeStylePath(profile, "/project/knowledge/theme/globals.css", "/project"),
       true,
+    );
+  });
+
+  it("derives a cache key from the scan scope", () => {
+    assertEquals(
+      createStyleScopeProfile().hash,
+      createStyleScopeProfile().hash,
+      "the profile hash must be deterministic for identical scan scopes",
+    );
+    assertNotEquals(
+      createStyleScopeProfile({ directories: { app: "knowledge/app" } }).hash,
+      createStyleScopeProfile().hash,
+      "a different scan scope must produce a different prepared-CSS cache key",
     );
   });
 });

--- a/src/html/styles-builder/tailwind-compiler-regression.test.ts
+++ b/src/html/styles-builder/tailwind-compiler-regression.test.ts
@@ -75,6 +75,38 @@ describe("styles-builder/tailwind-compiler regressions", () => {
       }
     });
 
+    it("refuses regenerated CSS that does not reproduce the requested hash", async () => {
+      const restoreFetch = forbidNetwork();
+
+      try {
+        const stylesheet = '@import "tailwindcss";/*vf-hash-mismatch-regression*/';
+        const projectSlug = "vf-hash-mismatch-regression";
+        const candidatesA = ["text-red-500"];
+        const candidatesB = ["font-bold"];
+
+        const generatedA = await generateTailwindCSS(stylesheet, candidatesA, {
+          minify: true,
+          projectSlug,
+        });
+        const hashA = hashCSS(generatedA.css);
+        // The entry keeps A's output under A's hash but B's inputs, so the
+        // regenerated CSS can no longer reproduce the requested content hash.
+        await cacheCSSAsync(generatedA.css, hashA, {
+          candidates: candidatesB,
+          stylesheet,
+          pipelineIdentity: generatedA.cacheIdentity,
+        });
+
+        assertEquals(
+          await regenerateCSSByHash(hashA, projectSlug),
+          undefined,
+          "CSS that does not reproduce the requested content hash must not be served at an immutable URL",
+        );
+      } finally {
+        restoreFetch();
+      }
+    });
+
     it("returns undefined when cached inputs are missing", async () => {
       const regenerated = await regenerateCSSByHash("vf-missing-regeneration-hash", undefined);
       assertEquals(regenerated, undefined);

--- a/src/html/styles-builder/tailwind-compiler.test.ts
+++ b/src/html/styles-builder/tailwind-compiler.test.ts
@@ -1,9 +1,13 @@
 import "#veryfront/schemas/_test-setup.ts";
 import "./__tests__/css-processor-setup.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { MAX_CSS_SELECTOR_TOKEN_CHARACTERS } from "#veryfront/utils/constants/css.ts";
 import {
+  MAX_CSS_FILES,
+  MAX_CSS_SELECTOR_TOKEN_CHARACTERS,
+} from "#veryfront/utils/constants/css.ts";
+import {
+  cacheCSSAsync,
   clearCSSCache,
   extractCandidates,
   extractCandidatesFromFiles,
@@ -255,6 +259,15 @@ describe("styles-builder/tailwind-compiler", () => {
       const candidates = extractCandidatesFromFiles([]);
       assertEquals(candidates.size, 0);
     });
+
+    it("rejects more files than the cap", () => {
+      assertThrows(
+        () => extractCandidatesFromFiles(new Array(MAX_CSS_FILES + 1)),
+        TypeError,
+        String(MAX_CSS_FILES),
+        "the file-count cap must reject oversized input before any file is read",
+      );
+    });
   });
 
   describe("hashCSS", () => {
@@ -377,11 +390,29 @@ describe("styles-builder/tailwind-compiler", () => {
     it("should return undefined for unknown hash", () => {
       clearCSSCache();
       assertEquals(getCSSByHash("nonexistent"), undefined);
+      assertEquals(
+        getCSSByHash("0".repeat(64)),
+        undefined,
+        "a valid digest with no entry must miss",
+      );
     });
 
-    it("should clear all caches", () => {
+    it("should clear all caches", async () => {
       clearCSSCache();
-      assertEquals(getCSSByHash("any-hash"), undefined);
+      const css = ".vf-clear-probe { color: red; }";
+      const hash = hashCSS(css);
+      await cacheCSSAsync(css, hash);
+      assertEquals(
+        getCSSByHash(hash),
+        css,
+        "a cached entry must be readable by its content hash",
+      );
+      clearCSSCache();
+      assertEquals(
+        getCSSByHash(hash),
+        undefined,
+        "clearCSSCache must drop cached entries",
+      );
     });
   });
 

--- a/src/html/tag-generators.test.ts
+++ b/src/html/tag-generators.test.ts
@@ -37,6 +37,39 @@ describe("tag-generators", () => {
     assertEquals(output.includes("spoofed"), false);
   });
 
+  it("does not let structured metadata smuggle inline event handlers into the head", () => {
+    const handlerAttributes = {
+      onload: "alert(1)",
+      onClick: "alert(2)",
+      ONERROR: "alert(3)",
+    };
+    const output = [
+      generateMetaTags({
+        meta: [{ name: "author", content: "A", ...handlerAttributes }],
+      } as never),
+      generateLinkTags({
+        links: [{ rel: "preload", href: "/asset", ...handlerAttributes }],
+      } as never),
+      generateScriptTags({
+        scripts: [{ src: "/asset.js", ...handlerAttributes }],
+      } as never),
+      generateStyleTags({
+        styles: [{ content: ".safe{}", ...handlerAttributes }],
+      } as never),
+    ].join("\n");
+
+    assertEquals(
+      output.includes("alert("),
+      false,
+      "inline event handler values must never reach the head",
+    );
+    assertEquals(
+      /\son[a-z]+=/i.test(output),
+      false,
+      "no on* attribute may be serialized into a head tag",
+    );
+  });
+
   it("marks every structured route head entry except charset as shell-owned", () => {
     const metas = generateMetaTags({
       description: "Description",


### PR DESCRIPTION
## Summary

Audit of all 41 test files under `src/html` for tests that stay green when the behavior they claim to cover breaks.

The bar for every change: name a concrete source edit that breaks documented behavior yet leaves the test passing. Every change was **mutation checked** — the named edit was applied, the test confirmed to fail, then the edit reverted.

50 candidate findings, 40 confirmed after adversarial verification, 40 applied, 10 refuted.

## Source change 1: the production hydration script never parsed

`generateProdHydrationScript` emitted this inside a `<script type="module">`:

```js
const root = document.getElementById('root');
if (!root) return;
```

A top-level `return` is an **Illegal return statement** in an ES module. The whole script failed to parse, so none of it ran — not the imports, not the element tree, not `hydrateRoot`. Verified directly rather than assumed:

```
node -e "import('data:text/javascript,'+encodeURIComponent('const r=null; if(!r) return;'))"
MODULE PARSE: SyntaxError Illegal return statement
```

Restructured to `if (root) { ... }`.

**Scope:** `generateProdHydrationScript` has no internal caller and is reached only through the barrel export, so this broke consumers of the helper rather than the framework's own render path. Flagging that explicitly so nobody reads this as a live hydration outage.

## Source change 2: a test that pinned the bug its own name described

`findGlobalStylesheet` matched with unanchored patterns:

```ts
const stylesheetPatterns = [/globals\.css$/, /global\.css$/, ...];
```

So `theme-globals.css` was selected as the project's Tailwind entry stylesheet. The existing test was named:

> `should not match files that end with globals.css but have different prefix`

…and its assertion pinned the **opposite** behavior. This is the highest-value category in the audit: a test whose name states the contract and whose assertion freezes the violation, so the bug reads as intended behavior forever.

Every pattern is now anchored to a path-segment boundary, the assertion flipped to match the name, and a companion case added so the anchoring cannot be over-tightened (`styles/globals.css` and `project/src/globals.css` must still match). Checked that no Windows-style absolute path reaches this matcher: only `.tsx/.jsx/.mdx/.ts/.js` are collected locally, and control-plane file lists are posix-relative.

## Test changes

**Script injection guards were unasserted.** Studio bridge config and `sourceHash` now feed a `</script><script>alert(1)</script>` payload and assert it never appears unescaped, split into two cases so each `.replace(/</g, "\\u003c")` site is isolated. Structured metadata now asserts no inline event handler (`onload`, `onClick`, `ONERROR`) can reach the head.

**A nonce count asserted `>= 3`** against five script tags, so dropping the nonce from two generators passed. It now pins the tag count and asserts the nonce count equals it.

**An assertion-free `clearCSSCache` body** now caches a real entry, reads it back by content hash, and asserts the clear drops it.

**Cache partitioning** now varies `minify`, `buildMode` and `environment` individually, so dropping any one from the profile hash fails.

**A test name that overclaimed was split:** the HMR arm and the Studio embed arm are now separate cases, so neither name covers behavior it does not test.

## Deliberately not applied

One finding required reaching a `MAX_CSS_TOTAL_BYTES` branch. That constant is 64 MiB and not injectable, so the test would have to allocate 64 MiB to bite. Left alone.

## Verification

- Semantic unit-boundary audit: ok
- Sanitizer ratchet test: ok (baseline unchanged at 396)
- `test:layout`: ok, `docs:api-reference:check`: current
- `deno fmt`, `deno lint`: pass
- **27/27** changed test files pass
- `anti-slop`, `cwd-relative-test-reads`, `test-typecheck`, `check-awaits`, `cross-runtime-jsr`, `skipped-tests`, `ban-test-only`: all pass

No test was deleted, skipped, or weakened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTML and script escaping to prevent unsafe markup injection.
  - Fixed hydration behavior when a page root is unavailable.
  - Improved SPA navigation, stylesheet replacement, hash scrolling, and nested route handling.
  - Corrected studio embed asset loading and development-mode behavior.
  - Prevented invalid or stale CSS and metadata from being served.
  - Improved CSP nonce propagation across generated scripts and styles.

- **Tests**
  - Added broad regression coverage for routing, hydration, HTML safety, caching, CSS generation, metadata, and navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->