### PR TITLE
test(extensions): make weak assertions bite across the extension contracts

### DIFF
--- a/src/extensions/abort-signal.test.ts
+++ b/src/extensions/abort-signal.test.ts
@@ -4,6 +4,27 @@ import { composeAbortSignals } from "./abort-signal.ts";
 Deno.test("composeAbortSignals propagates the first exact abort reason", () => {
   const first = new AbortController();
   const second = new AbortController();
+  const add = second.signal.addEventListener.bind(second.signal);
+  const remove = second.signal.removeEventListener.bind(second.signal);
+  let attached: EventListenerOrEventListenerObject | undefined;
+  let removals = 0;
+  second.signal.addEventListener = (
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: AddEventListenerOptions | boolean,
+  ): void => {
+    if (type === "abort") attached = listener;
+    add(type, listener, options);
+  };
+  second.signal.removeEventListener = (
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: EventListenerOptions | boolean,
+  ): void => {
+    if (type === "abort" && listener === attached) removals++;
+    remove(type, listener, options);
+  };
+
   const signal = composeAbortSignals([first.signal, second.signal]);
   const firstReason = new Error("first cancellation");
 
@@ -12,6 +33,11 @@ Deno.test("composeAbortSignals propagates the first exact abort reason", () => {
 
   assertEquals(signal.aborted, true);
   assertStrictEquals(signal.reason, firstReason);
+  assertEquals(
+    removals,
+    1,
+    "aborting one source must detach the composed listener from every remaining source",
+  );
 });
 
 Deno.test("composeAbortSignals handles an already-aborted source", () => {

--- a/src/extensions/auth/rsc-action-authorization-provider.test.ts
+++ b/src/extensions/auth/rsc-action-authorization-provider.test.ts
@@ -156,6 +156,33 @@ describe("extensions/auth/rsc-action-authorization-provider", () => {
     assertEquals(descriptorTraps, 0);
   });
 
+  it("rejects a Proxy authorize function", () => {
+    const { proxy } = Proxy.revocable(() => true, {});
+    assertThrows(
+      () => snapshotRscActionAuthorizationProvider({ authorize: proxy }),
+      TypeError,
+      "non-Proxy function",
+      "a revocable proxy authorizer must be rejected at capture",
+    );
+
+    let applyCalls = 0;
+    assertThrows(
+      () =>
+        snapshotRscActionAuthorizationProvider({
+          authorize: new Proxy(() => true, {
+            apply() {
+              applyCalls++;
+              return true;
+            },
+          }),
+        }),
+      TypeError,
+      "non-Proxy function",
+      "an apply-trap proxy authorizer must be rejected at capture",
+    );
+    assertEquals(applyCalls, 0, "capture must not invoke an extension-owned apply trap");
+  });
+
   it("rejects extra registration fields instead of retaining mutable policy", () => {
     assertThrows(
       () =>

--- a/src/extensions/browser/immutable-browser-bundle.test.ts
+++ b/src/extensions/browser/immutable-browser-bundle.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { snapshotImmutableBrowserBundleProvider } from "./immutable-browser-bundle.ts";
 
 Deno.test("immutable browser bundle inspection is independent of replaced globals", () => {
@@ -16,7 +16,7 @@ Deno.test("immutable browser bundle inspection is independent of replaced global
     });
     Object.defineProperty(Array, "isArray", {
       configurable: true,
-      value: () => false,
+      value: () => true,
     });
     assertEquals(
       snapshotImmutableBrowserBundleProvider(
@@ -24,10 +24,22 @@ Deno.test("immutable browser bundle inspection is independent of replaced global
         { bundleLabel: "bundle", providerLabel: "provider", maxBytes: 1_024 },
       ).browserBundle,
       "console.log('safe');",
+      "inspection must use the captured intrinsics, not the replaced globals",
     );
   } finally {
     if (descriptors) Object.defineProperty(Object, "getOwnPropertyDescriptors", descriptors);
     if (ownKeys) Object.defineProperty(Reflect, "ownKeys", ownKeys);
     if (isArray) Object.defineProperty(Array, "isArray", isArray);
   }
+
+  assertThrows(
+    () =>
+      snapshotImmutableBrowserBundleProvider(
+        Object.assign([], { browserBundle: "console.log('x');" }),
+        { bundleLabel: "bundle", providerLabel: "provider", maxBytes: 1_024 },
+      ),
+    TypeError,
+    "provider must be an object",
+    "an array carrying a browserBundle property must be rejected",
+  );
 });

--- a/src/extensions/builtin-extensions.test.ts
+++ b/src/extensions/builtin-extensions.test.ts
@@ -279,6 +279,37 @@ describe("createBuiltinExtensions", () => {
     assertEquals(logs.some((message) => message.includes("ext-missing")), true);
   });
 
+  it("rethrows a package-backed load failure that is not a missing implementation", async () => {
+    // The module resolves; only the identity check fails. A swallowed failure
+    // here would drop a real first-party builtin from the runtime while
+    // claiming its package is not installed.
+    const candidate = createDeferredBuiltinExtension({
+      name: "ext-name-drift",
+      origin: "veryfront/ext-yaml",
+      sourceDirectory: "ext-yaml",
+      availability: "package",
+    });
+
+    const logs: string[] = [];
+    await assertRejects(
+      () =>
+        getDeferredExtensionState(candidate)!.load({
+          debug: (message) => logs.push(message),
+          info: () => {},
+          warn: () => {},
+          error: () => {},
+        }),
+      Error,
+      'returned extension "ext-yaml"',
+      "a package-backed builtin must rethrow a non-missing load failure",
+    );
+    assertEquals(
+      logs.some((message) => message.includes("is not available from the root package")),
+      false,
+      `a resolvable package must not be reported as not installed, got: ${logs.join(" | ")}`,
+    );
+  });
+
   it("rejects an invalid root-bundled deferred factory result", async () => {
     const candidate = createDeferredBuiltinExtension({
       name: "ext-invalid",

--- a/src/extensions/bundler/helper.test.ts
+++ b/src/extensions/bundler/helper.test.ts
@@ -5,11 +5,11 @@ import "#veryfront/schemas/_test-setup.ts";
  * @module extensions/bundler/helper.test
  */
 
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { it } from "#veryfront/testing/bdd.ts";
 import { register, tryResolve, unregister } from "../contracts.ts";
-import type { Bundler, TransformOptions } from "./bundler.ts";
-import { transform } from "./helper.ts";
+import type { BundleOptions, Bundler, TransformOptions } from "./bundler.ts";
+import { context, stop, transform } from "./helper.ts";
 
 it("transform keeps the positional source authoritative over runtime options", async () => {
   const previous = tryResolve<Bundler>("Bundler");
@@ -33,6 +33,55 @@ it("transform keeps the positional source authoritative over runtime options", a
       code: "authoritative source",
       loader: "ts",
     });
+  } finally {
+    unregister("Bundler");
+    if (previous !== undefined) register("Bundler", previous);
+  }
+});
+
+it("stop() forwards to the registered bundler teardown exactly once and tolerates its absence", async () => {
+  const previous = tryResolve<Bundler>("Bundler");
+  let stopCalls = 0;
+  const bundle = () => Promise.resolve({ outputFiles: [], warnings: [], errors: [] });
+  const transformStub: Bundler["transform"] = (options) =>
+    Promise.resolve({ code: options.code, warnings: [] });
+
+  try {
+    register<Bundler>("Bundler", {
+      bundle,
+      transform: transformStub,
+      stop() {
+        stopCalls++;
+        return Promise.resolve();
+      },
+    });
+    await stop();
+    assertEquals(stopCalls, 1, "helper.stop() must invoke the registered bundler's stop()");
+
+    unregister("Bundler");
+    register<Bundler>("Bundler", { bundle, transform: transformStub });
+    await stop();
+    assertEquals(stopCalls, 1, "a bundler without stop() must leave the counter untouched");
+  } finally {
+    unregister("Bundler");
+    if (previous !== undefined) register("Bundler", previous);
+  }
+});
+
+it("context() reports a bundler without incremental support", () => {
+  const previous = tryResolve<Bundler>("Bundler");
+  try {
+    register<Bundler>("Bundler", {
+      bundle: () => Promise.resolve({ outputFiles: [], warnings: [], errors: [] }),
+      transform: (options) => Promise.resolve({ code: options.code, warnings: [] }),
+    });
+
+    assertThrows(
+      () => context({} as BundleOptions),
+      Error,
+      "does not support context()",
+      "a bundler without context() must fail with the capability error, not a TypeError",
+    );
   } finally {
     unregister("Bundler");
     if (previous !== undefined) register("Bundler", previous);

--- a/src/extensions/capabilities.test.ts
+++ b/src/extensions/capabilities.test.ts
@@ -73,6 +73,40 @@ describe("capabilities", () => {
       assertEquals(perms, ["--allow-read=./src,./public"]);
     });
 
+    it("maps fs:write to a scoped --allow-write and keeps read and write flags separate", () => {
+      assertEquals(
+        mapToDenoPermissions([{ type: "fs:write", paths: ["./dist", "./cache"] }]),
+        ["--allow-write=./dist,./cache"],
+        "fs:write must emit a path-scoped --allow-write",
+      );
+      assertEquals(
+        mapToDenoPermissions([
+          { type: "fs:read", paths: ["./src"] },
+          { type: "fs:write", paths: ["./dist"] },
+        ]),
+        ["--allow-read=./src", "--allow-write=./dist"],
+        "fs:read and fs:write scopes must not merge into one flag",
+      );
+      assertEquals(
+        mapToDenoPermissions([{ type: "fs:write" }]),
+        ["--allow-write"],
+        "an unscoped fs:write stays unscoped",
+      );
+    });
+
+    it("maps native:ffi to exactly --allow-ffi", () => {
+      assertEquals(
+        mapToDenoPermissions([{ type: "native:ffi" }]),
+        ["--allow-ffi"],
+        "native:ffi must map to --allow-ffi and nothing broader",
+      );
+      assertEquals(
+        mapToDenoPermissions([{ type: "native:ffi" }, { type: "env:read", keys: ["A"] }]),
+        ["--allow-ffi", "--allow-env=A"],
+        "an unscoped ffi flag must aggregate alongside scoped flags, not replace them",
+      );
+    });
+
     it("should map net:outbound to --allow-net with hosts", () => {
       const caps: Capability[] = [{ type: "net:outbound", hosts: ["api.example.com"] }];
       const perms = mapToDenoPermissions(caps);

--- a/src/extensions/contract-registry-internal.test.ts
+++ b/src/extensions/contract-registry-internal.test.ts
@@ -5,7 +5,7 @@ import "#veryfront/schemas/_test-setup.ts";
  * @module extensions/contract-registry-internal.test
  */
 
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   acquireContractLease,
@@ -13,6 +13,7 @@ import {
   commitContractGeneration,
   completeContractGenerationRetirement,
   drainContractGeneration,
+  failContractGeneration,
   isContractGenerationDrained,
   registerUnmanagedContract,
   resetContractRegistry,
@@ -119,6 +120,18 @@ describe("contract registry lifecycle state", () => {
     const published = tryResolveRegisteredContract("InheritedOwnerCandidate");
     assertEquals(failure, undefined);
     assertEquals(published, candidate);
+    assertEquals(
+      tryResolveRegisteredContract("InheritedOwnerUnmanaged"),
+      unmanaged,
+      "an ownerless compatibility entry must survive an unrelated generation commit",
+    );
+    assertEquals(
+      trySnapshotGenerationOwnedContractForUse("InheritedOwnerUnmanaged"),
+      undefined,
+      "the committing generation must not adopt an ownerless entry through an inherited generation property",
+    );
+    sealContractGeneration(generation);
+    completeContractGenerationRetirement(generation);
   });
 
   it("ignores an inherited candidate overlay during successful teardown", async () => {
@@ -428,5 +441,83 @@ describe("contract registry lifecycle state", () => {
       true,
     );
     assertEquals(published, undefined);
+  });
+
+  it("refuses to publish over an active generation", () => {
+    const first = Object.freeze({ id: "first" });
+    const second = Object.freeze({ id: "second" });
+    const activeGeneration = createCommittedGeneration("ActiveFencedContract", first);
+    const candidate = beginContractGeneration();
+    stageContract(candidate, "ActiveFencedContract", second);
+
+    assertThrows(
+      () => commitContractGeneration(candidate),
+      Error,
+      "before the active generation retires",
+      "a candidate must not publish while another generation is still active",
+    );
+    assertEquals(
+      tryResolveRegisteredContract("ActiveFencedContract"),
+      first,
+      "a fenced commit must leave the active generation's entries published",
+    );
+
+    failContractGeneration(candidate);
+    sealContractGeneration(activeGeneration);
+    completeContractGenerationRetirement(activeGeneration);
+  });
+
+  it("refuses to publish while a prior generation still owns published entries", () => {
+    const retiring = Object.freeze({ id: "retiring" });
+    const replacement = Object.freeze({ id: "replacement" });
+    const retiringGeneration = createCommittedGeneration("OwnedFencedContract", retiring);
+    sealContractGeneration(retiringGeneration);
+    const candidate = beginContractGeneration();
+    stageContract(candidate, "ReplacementFencedContract", replacement);
+
+    assertThrows(
+      () => commitContractGeneration(candidate),
+      Error,
+      "while a prior generation remains owned",
+      "a candidate must not publish while a retiring generation still owns entries",
+    );
+    assertEquals(
+      tryResolveRegisteredContract("ReplacementFencedContract"),
+      undefined,
+      "a fenced commit must publish none of its staged entries",
+    );
+    assertEquals(
+      tryResolveRegisteredContract("OwnedFencedContract"),
+      retiring,
+      "a fenced commit must leave the retiring generation's entries untouched",
+    );
+
+    failContractGeneration(candidate);
+    completeContractGenerationRetirement(retiringGeneration);
+  });
+
+  it("keeps contract absence fail-closed after a failed generation", () => {
+    const generation = beginContractGeneration();
+    failContractGeneration(generation);
+
+    assertThrows(
+      () => trySnapshotContractForUse("FailedGenerationContract"),
+      Error,
+      "unavailable because the previous generation failed",
+      "a failed generation must stay fail-closed instead of reporting an absent registration",
+    );
+
+    const recovered = beginContractGeneration();
+    stageContract(recovered, "RecoveredContract", Object.freeze({ id: "recovered" }));
+    commitContractGeneration(recovered);
+
+    assertEquals(
+      trySnapshotContractForUse("UnrelatedContract"),
+      undefined,
+      "a successful commit must clear the fail-closed flag",
+    );
+
+    sealContractGeneration(recovered);
+    completeContractGenerationRetirement(recovered);
   });
 });

--- a/src/extensions/contracts.test.ts
+++ b/src/extensions/contracts.test.ts
@@ -5,6 +5,7 @@ import "#veryfront/schemas/_test-setup.ts";
  * @module extensions/contracts.test
  */
 
+import { VeryfrontError } from "#veryfront/errors/types.ts";
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { register, reset, resolve, tryResolve, unregister } from "./contracts.ts";
@@ -22,18 +23,46 @@ describe("extensions/contracts", () => {
     });
 
     it("throws MissingExtensionError for unregistered contract", () => {
-      assertThrows(
+      const error = assertThrows(
         () => resolve("UnknownContract"),
-        Error,
+        VeryfrontError,
         'Missing extension for contract "UnknownContract"',
+        "resolve must raise the registry missing-extension error",
+      ) as VeryfrontError;
+      assertEquals(
+        error.slug,
+        "missing-extension",
+        "resolve must raise the registry missing-extension error",
+      );
+      assertEquals(error.status, 500, "missing extension must map to 500");
+      assertEquals(
+        error.category,
+        "RUNTIME",
+        "missing extension must stay in the RUNTIME category",
+      );
+      assertEquals(
+        error.detail,
+        undefined,
+        "a contract without a recommendation must not carry an install detail",
       );
     });
 
     it("includes recommendation in error message when available", () => {
-      assertThrows(
+      const error = assertThrows(
         () => resolve("Bundler"),
-        Error,
+        VeryfrontError,
         "deno add @veryfront/ext-bundler-esbuild",
+        "a recommended contract must still raise the registry missing-extension error",
+      ) as VeryfrontError;
+      assertEquals(
+        error.slug,
+        "missing-extension",
+        "a recommended contract must keep the missing-extension slug",
+      );
+      assertEquals(
+        error.detail,
+        "Install it with: deno add @veryfront/ext-bundler-esbuild",
+        "detail must name the package to install",
       );
     });
 

--- a/src/extensions/css/css-optimization-engine.test.ts
+++ b/src/extensions/css/css-optimization-engine.test.ts
@@ -84,6 +84,30 @@ describe("CSSOptimizationEngine contract", () => {
       TypeError,
       "properties could not be read",
     );
+
+    let optimizeReads = 0;
+    const accessorOptimize = { cacheIdentity: "accessor-optimize@1" };
+    Object.defineProperty(accessorOptimize, "optimize", {
+      get() {
+        optimizeReads++;
+        return engine().optimize;
+      },
+    });
+
+    assertThrows(
+      () => assertCSSOptimizationEngine(accessorOptimize),
+      TypeError,
+      "optimize must be a data property",
+      "an accessor-backed optimize must be rejected before core can invoke it",
+    );
+    assertEquals(optimizeReads, 0, "optimize getter must not run");
+
+    assertThrows(
+      () => assertCSSOptimizationEngine({ ...engine(), optimize: 42 }),
+      TypeError,
+      "must implement optimize()",
+      "a non-function optimize must be rejected at the contract boundary",
+    );
   });
 
   it("rejects accessor descriptors even when Object.prototype is polluted", () => {
@@ -100,6 +124,14 @@ describe("CSSOptimizationEngine contract", () => {
       },
     });
     Object.defineProperty(accessor, "optimize", { value: engine().optimize });
+    let optimizeReads = 0;
+    const accessorOptimize = { cacheIdentity: "accessor-optimize@1" };
+    Object.defineProperty(accessorOptimize, "optimize", {
+      get() {
+        optimizeReads++;
+        return engine().optimize;
+      },
+    });
     try {
       Object.defineProperty(Object.prototype, "value", {
         configurable: true,
@@ -116,6 +148,23 @@ describe("CSSOptimizationEngine contract", () => {
       );
       assertEquals(inheritedValueReads, 0);
       assertEquals(identityReads, 0);
+
+      assertThrows(
+        () => assertCSSOptimizationEngine(accessorOptimize),
+        TypeError,
+        "optimize must be a data property",
+        "a forged inherited value must not turn an accessor-backed optimize into a data property",
+      );
+      assertEquals(
+        inheritedValueReads,
+        0,
+        "the forged inherited value must never be read while rejecting an accessor optimize",
+      );
+      assertEquals(
+        optimizeReads,
+        0,
+        "the accessor-backed optimize getter must never be invoked during validation",
+      );
     } finally {
       if (previous === undefined) {
         Reflect.deleteProperty(Object.prototype, "value");

--- a/src/extensions/css/css-processor.test.ts
+++ b/src/extensions/css/css-processor.test.ts
@@ -44,6 +44,32 @@ describe("CSSProcessor contract", () => {
     assertEquals(compiler.build(["alpha", "beta"]), "captured:input.css:alpha,beta");
   });
 
+  it("captures a prototype-defined compile from a class implementation", async () => {
+    // The first-party Tailwind processor is a class instance: `compile` lives on
+    // the prototype, so an own-property lookup would reject it outright.
+    class ClassCSSProcessor {
+      cacheIdentity = "class-css-processor@1";
+      defaultStylesheet = '@import "test";';
+      marker = "captured";
+      compile(stylesheet: string) {
+        const marker = this.marker;
+        return Promise.resolve({
+          build: (candidates: string[]) => `${marker}:${stylesheet}:${candidates.join(",")}`,
+        });
+      }
+    }
+
+    const instance = new ClassCSSProcessor();
+    const captured = captureCSSProcessor(instance);
+    const compiler = await captured.compile("input.css");
+
+    assertEquals(
+      compiler.build(["alpha"]),
+      "captured:input.css:alpha",
+      "a prototype-defined compile must be captured and invoked with the instance as this",
+    );
+  });
+
   it("rejects property accessors and Proxies without invoking their hooks", () => {
     let identityReads = 0;
     const accessor = Object.defineProperty(

--- a/src/extensions/css/css-purging-engine.test.ts
+++ b/src/extensions/css/css-purging-engine.test.ts
@@ -34,6 +34,11 @@ describe("CSSPurgingEngine contract", () => {
 
     assertEquals(captured.cacheIdentity, "test-css-purging-engine@1");
     assertEquals(
+      Object.isFrozen(captured),
+      true,
+      "captured purging engine must be a frozen snapshot",
+    );
+    assertEquals(
       (await captured.purge({
         css: "input",
         content: [],

--- a/src/extensions/dev-ui/dev-ui-asset-provider.test.ts
+++ b/src/extensions/dev-ui/dev-ui-asset-provider.test.ts
@@ -62,4 +62,17 @@ Deno.test("Development UI asset provider enforces canonical source and byte limi
     RangeError,
     `${MAX_DEV_UI_BUNDLE_BYTES}-byte limit`,
   );
+
+  const multiByte = "\u{1F600}".repeat(MAX_DEV_UI_BUNDLE_BYTES / 4 + 1);
+  assertEquals(
+    multiByte.length <= MAX_DEV_UI_BUNDLE_BYTES,
+    true,
+    "the multi-byte fixture must pass the UTF-16 length pre-check",
+  );
+  assertThrows(
+    () => createDevUiAssetProvider(multiByte),
+    RangeError,
+    `${MAX_DEV_UI_BUNDLE_BYTES}-byte limit`,
+    "a multi-byte bundle must be measured in UTF-8 bytes",
+  );
 });

--- a/src/extensions/distributed/owned-redis-client.test.ts
+++ b/src/extensions/distributed/owned-redis-client.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { waitFor } from "#veryfront/testing/index.ts";
 import { register, unregister } from "../contracts.ts";
 import { OwnedRedisClientConnection } from "./owned-redis-client.ts";
 import type {
@@ -159,7 +160,14 @@ describe("OwnedRedisClientConnection", () => {
       async () => {
         const connection = new OwnedRedisClientConnection();
         await connection.getClient();
-        await Promise.all([connection.close(), connection.close()]);
+        const first = connection.close();
+        const second = connection.close();
+        assertStrictEquals(
+          first,
+          second,
+          "concurrent close() calls must share one in-flight close promise",
+        );
+        await Promise.all([first, second]);
         await connection.close();
         assertEquals(closeCalls, 1);
       },
@@ -205,6 +213,199 @@ describe("OwnedRedisClientConnection", () => {
         assertEquals(opens, 2);
         assertEquals(firstCloseCalls, 1);
         assertEquals(await duplicate, replacementClient);
+        await connection.close();
+      },
+    );
+  });
+
+  it("closes a handle that arrives after close superseded the generation", async () => {
+    // `signal` is optional in RedisRuntimeProvider, so a provider that ignores
+    // it is contract-legal and still delivers a live socket after close won.
+    const client = createClient();
+    let closeCalls = 0;
+    let openStartedResolve: (() => void) | undefined;
+    const openStarted = new Promise<void>((resolve) => {
+      openStartedResolve = resolve;
+    });
+    let releaseOpen: (() => void) | undefined;
+    const opened = new Promise<void>((resolve) => {
+      releaseOpen = resolve;
+    });
+    await withProvider(
+      createProvider(() => {
+        openStartedResolve?.();
+        return opened.then(() => ({
+          client,
+          close() {
+            closeCalls++;
+            return Promise.resolve();
+          },
+        }));
+      }),
+      async () => {
+        const connection = new OwnedRedisClientConnection();
+        const opening = connection.getClient();
+        await openStarted;
+        const closing = connection.close();
+        releaseOpen?.();
+        await closing;
+
+        assertEquals(
+          closeCalls,
+          1,
+          "a handle delivered after the generation changed must be closed exactly once",
+        );
+        await assertRejects(() => opening, Error, "superseded");
+        await connection.close();
+        assertEquals(closeCalls, 1, "a drained handle must not be closed a second time");
+      },
+    );
+  });
+
+  it("makes a later getClient wait for the in-flight close", async () => {
+    const clients = [createClient(), createClient()];
+    let opens = 0;
+    let releaseClose: (() => void) | undefined;
+    const closeGate = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
+    await withProvider(
+      createProvider(() => {
+        const index = opens++;
+        return Promise.resolve({
+          client: clients[index]!,
+          close: () => (index === 0 ? closeGate : Promise.resolve()),
+        });
+      }),
+      async () => {
+        const connection = new OwnedRedisClientConnection();
+        await connection.getClient();
+        const closing = connection.close();
+        const reopened = connection.getClient();
+        for (let turn = 0; turn < 50; turn++) await Promise.resolve();
+        assertEquals(
+          opens,
+          1,
+          "getClient must not open a replacement while close is still draining",
+        );
+
+        releaseClose?.();
+        await closing;
+        await reopened;
+        assertEquals(opens, 2, "exactly one replacement handle must be opened");
+        assertEquals(
+          clients[1]!.listenerCount("error"),
+          1,
+          "getClient must resume on the second client once close settles",
+        );
+        await connection.close();
+      },
+    );
+  });
+
+  it("notifies the owner's lifecycle callbacks when the active client fails or ends", async () => {
+    const clients = [createClient(), createClient()];
+    let opens = 0;
+    const errors: unknown[] = [];
+    let ends = 0;
+    await withProvider(
+      createProvider(() =>
+        Promise.resolve({ client: clients[opens++]!, close: () => Promise.resolve() })
+      ),
+      async () => {
+        const connection = new OwnedRedisClientConnection({}, {
+          onError: (error) => errors.push(error),
+          onEnd: () => {
+            ends++;
+          },
+        });
+        await connection.getClient();
+        const socketError = new Error("socket lost");
+        clients[0]!.emit("error", socketError);
+
+        assertEquals(errors.length, 1, "onError must fire once for the active client's error");
+        assertStrictEquals(errors[0], socketError, "onError must receive the client's error");
+        assertEquals(ends, 0, "a socket error must not be reported as a clean end");
+
+        await connection.getClient();
+        clients[1]!.emit("end");
+        assertEquals(ends, 1, "onEnd must fire when the active client ends");
+        assertEquals(errors.length, 1, "a clean end must not be reported as an error");
+        await connection.close();
+      },
+    );
+  });
+
+  it("retains a handle whose close failed and reports the failure to the owner", async () => {
+    const client = createClient();
+    const closeFailure = new Error("close failed");
+    let closeCalls = 0;
+    const closeErrors: unknown[] = [];
+    await withProvider(
+      createProvider(() =>
+        Promise.resolve({
+          client,
+          close() {
+            closeCalls++;
+            return Promise.reject(closeFailure);
+          },
+        })
+      ),
+      async () => {
+        const connection = new OwnedRedisClientConnection({}, {
+          onCloseError: (error) => closeErrors.push(error),
+        });
+        await connection.getClient();
+        client.emit("error", new Error("socket lost"));
+        await waitFor(() => closeErrors.length === 1, {
+          interval: 1,
+          message: "onCloseError must receive a failed retirement close",
+        });
+        assertStrictEquals(
+          closeErrors[0],
+          closeFailure,
+          "onCloseError must receive the close rejection reason",
+        );
+        assertEquals(closeCalls, 1, "retirement must attempt the close once");
+
+        await assertRejects(
+          () => connection.close(),
+          Error,
+          "close failed",
+          "a handle whose close failed must be retried and its failure surfaced",
+        );
+        assertEquals(closeCalls, 2, "a failed close must be retried, not dropped");
+      },
+    );
+  });
+
+  it("retires the active client even when the owner's callback throws", async () => {
+    const clients = [createClient(), createClient()];
+    let opens = 0;
+    await withProvider(
+      createProvider(() =>
+        Promise.resolve({ client: clients[opens++]!, close: () => Promise.resolve() })
+      ),
+      async () => {
+        const connection = new OwnedRedisClientConnection({}, {
+          onError: () => {
+            throw new Error("diagnostics failed");
+          },
+        });
+        await connection.getClient();
+        clients[0]!.emit("error", new Error("socket lost"));
+
+        await connection.getClient();
+        assertEquals(
+          opens,
+          2,
+          "a throwing lifecycle callback must not block retirement of the failed client",
+        );
+        assertEquals(
+          clients[1]!.listenerCount("error"),
+          1,
+          "the replacement client must be wired for lifecycle events",
+        );
         await connection.close();
       },
     );

--- a/src/extensions/distributed/redis-runtime-provider.test.ts
+++ b/src/extensions/distributed/redis-runtime-provider.test.ts
@@ -1,4 +1,10 @@
-import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertRejects,
+  assertStringIncludes,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { register, unregister } from "../contracts.ts";
 import { ensureRedisRuntimeProvider } from "./defaults.ts";
@@ -27,6 +33,50 @@ function createClient(): RedisClient {
   };
 }
 
+/** Data-property stubs for every method `captureNodeRedisClient` must snapshot. */
+const NODE_REDIS_CLIENT_METHODS = [
+  "connect",
+  "hSet",
+  "hGetAll",
+  "hDel",
+  "del",
+  "sAdd",
+  "sRem",
+  "sMembers",
+  "rPush",
+  "lRange",
+  "lIndex",
+  "lSet",
+  "lLen",
+  "xAdd",
+  "xGroupCreate",
+  "xReadGroup",
+  "xAck",
+  "keys",
+  "exists",
+  "expire",
+  "set",
+  "get",
+  "publish",
+  "subscribe",
+  "unsubscribe",
+  "eval",
+  "close",
+  "destroy",
+  "on",
+] as const;
+
+function createModuleClient(
+  omitted?: typeof NODE_REDIS_CLIENT_METHODS[number],
+): Record<string, unknown> {
+  const client: Record<string, unknown> = {};
+  for (const name of NODE_REDIS_CLIENT_METHODS) {
+    if (name === omitted) continue;
+    client[name] = () => Promise.resolve(null);
+  }
+  return client;
+}
+
 function createProvider(): RedisRuntimeProvider {
   return {
     id: "test-redis",
@@ -49,16 +99,33 @@ function createProvider(): RedisRuntimeProvider {
 }
 
 describe("RedisRuntimeProvider", () => {
-  it("keeps error-only Redis event listeners source compatible", () => {
-    const on: NodeRedisClient["on"] = (
-      event: "error",
-      listener: (error: unknown) => void,
-    ): unknown => {
-      void listener;
-      return event;
+  it("forwards module-client error listeners with their own receiver", async () => {
+    const calls: Array<{ receiver: unknown; args: unknown[] }> = [];
+    const client = createModuleClient();
+    client.on = function (this: unknown, ...args: unknown[]) {
+      calls.push({ receiver: this, args });
+      return "registered";
     };
+    const provider = createProvider();
+    provider.loadModule = () => Promise.resolve({ createClient: () => client } as never);
 
-    assertEquals(on("error", () => {}), "error");
+    const module = await captureRedisRuntimeProvider(provider).loadModule();
+    const captured: NodeRedisClient = module.createClient({});
+    const listener = () => {};
+    const result = captured.on("error", listener);
+
+    assertEquals(calls.length, 1, "on must be forwarded exactly once");
+    assertEquals(
+      calls[0]?.receiver === client,
+      true,
+      "the underlying client must stay the receiver of on",
+    );
+    assertEquals(
+      calls[0]?.args,
+      ["error", listener],
+      "on must forward the event name and listener unchanged",
+    );
+    assertEquals(result, "registered", "on must return the underlying return value");
   });
 
   it("captures provider methods without losing their receiver", async () => {
@@ -96,6 +163,28 @@ describe("RedisRuntimeProvider", () => {
       "own data property",
     );
     assertEquals(getterCalls, 0);
+  });
+
+  it("rejects hostile provider ids", () => {
+    for (
+      const id of [
+        "",
+        " padded ",
+        // One code unit past the 256-code-unit bound.
+        "x".repeat(257),
+        "id\0",
+        "id\n",
+        // Decomposed "e" + combining acute: not NFC.
+        "e\u0301xt",
+      ]
+    ) {
+      assertThrows(
+        () => captureRedisRuntimeProvider({ ...createProvider(), id }),
+        TypeError,
+        "bounded canonical string",
+        `provider id ${JSON.stringify(id)} must be rejected at capture`,
+      );
+    }
   });
 
   it("rejects unexpected provider properties", () => {
@@ -154,6 +243,40 @@ describe("RedisRuntimeProvider", () => {
       "must be a data property",
     );
     assertEquals(getterCalls, 0);
+  });
+
+  it("rejects module-client accessors and missing methods without invoking them", async () => {
+    let getterCalls = 0;
+    const client = createModuleClient();
+    Object.defineProperty(client, "get", {
+      enumerable: true,
+      get() {
+        getterCalls++;
+        return () => Promise.resolve(null);
+      },
+    });
+    const provider = createProvider();
+    provider.loadModule = () => Promise.resolve({ createClient: () => client } as never);
+
+    const module = await captureRedisRuntimeProvider(provider).loadModule();
+    assertThrows(
+      () => module.createClient({}),
+      TypeError,
+      "must be a data property",
+      "an accessor-backed module client method must be rejected",
+    );
+    assertEquals(getterCalls, 0, "module client getters must never run");
+
+    const incomplete = createProvider();
+    incomplete.loadModule = () =>
+      Promise.resolve({ createClient: () => createModuleClient("destroy") } as never);
+    const incompleteModule = await captureRedisRuntimeProvider(incomplete).loadModule();
+    assertThrows(
+      () => incompleteModule.createClient({}),
+      TypeError,
+      "must be exposed",
+      "a module client missing destroy must be rejected",
+    );
   });
 
   it("snapshots proxy-backed clients without reading Redis methods through get", async () => {
@@ -266,6 +389,107 @@ describe("RedisRuntimeProvider", () => {
     );
     assertEquals(getterCalls, 0);
     assertEquals(closeCalls, 1);
+  });
+
+  it("forwards captured publisher calls with their own receiver and requires a disposer", async () => {
+    const receivers: unknown[] = [];
+    const dispose = () => undefined;
+    const implementation = {
+      publish(this: unknown) {
+        receivers.push(this);
+        return Promise.resolve();
+      },
+      subscribe(this: unknown) {
+        receivers.push(this);
+        return Promise.resolve(dispose);
+      },
+      close(this: unknown) {
+        receivers.push(this);
+        return Promise.resolve();
+      },
+    };
+    const provider = createProvider();
+    provider.createEventPublisher = () => Promise.resolve(implementation as never);
+
+    const publisher = await captureRedisRuntimeProvider(provider).createEventPublisher({
+      url: "redis://cache.example.test",
+    });
+    await publisher.publish({ type: "ping" } as never);
+    const disposer = await publisher.subscribe("run-1", () => {});
+    await publisher.close();
+
+    assertEquals(receivers.length, 3, "publish, subscribe, and close must each be forwarded once");
+    for (const receiver of receivers) {
+      assertEquals(
+        receiver === implementation,
+        true,
+        "the publisher implementation must stay the receiver of its own methods",
+      );
+    }
+    assertEquals(disposer === dispose, true, "subscribe must resolve the disposer it returned");
+
+    const invalid = createProvider();
+    invalid.createEventPublisher = () =>
+      Promise.resolve({
+        publish: () => Promise.resolve(),
+        subscribe: () => Promise.resolve("not-a-disposer"),
+        close: () => Promise.resolve(),
+      } as never);
+    const invalidPublisher = await captureRedisRuntimeProvider(invalid).createEventPublisher({
+      url: "redis://cache.example.test",
+    });
+    await assertRejects(
+      () => invalidPublisher.subscribe("run-1", () => {}),
+      TypeError,
+      "must return a disposer",
+    );
+  });
+
+  it("preserves the validation error when handle cleanup also fails", async () => {
+    let getterCalls = 0;
+    let closeCalls = 0;
+    const client = createClient();
+    Object.defineProperty(client, "connect", {
+      enumerable: true,
+      get() {
+        getterCalls++;
+        return () => Promise.resolve();
+      },
+    });
+    const provider = createProvider();
+    provider.openClient = () =>
+      Promise.resolve({
+        client,
+        close() {
+          closeCalls++;
+          return Promise.reject(new Error("close failed"));
+        },
+      });
+    const captured = captureRedisRuntimeProvider(provider);
+
+    const error = await assertRejects(
+      () => captured.openClient(),
+      AggregateError,
+      "Redis client handle validation and cleanup failed",
+    ) as AggregateError;
+
+    assertInstanceOf(
+      error.errors[0],
+      TypeError,
+      "the validation failure must be the first aggregated error",
+    );
+    assertStringIncludes(
+      error.errors[0].message,
+      "must be a data property",
+      "the validation failure must survive a failing cleanup",
+    );
+    assertStringIncludes(
+      String(error.errors[1]),
+      "close failed",
+      "the cleanup failure must be aggregated alongside it",
+    );
+    assertEquals(getterCalls, 0, "cleanup must not invoke the rejected accessor");
+    assertEquals(closeCalls, 1, "the rejected handle must still be closed once");
   });
 
   it("resolves a provider registered through explicit orchestration", async () => {

--- a/src/extensions/eval/eval-report-exporter.test.ts
+++ b/src/extensions/eval/eval-report-exporter.test.ts
@@ -295,6 +295,26 @@ describe("EvalReportExporterRegistry", () => {
     );
   });
 
+  it("register is first-write-wins for duplicate exporter ids", () => {
+    const registry = createEvalReportExporterRegistry();
+    const first = { id: "braintrust", export() {} };
+    const second = { id: "braintrust", export() {} };
+
+    registry.register(first);
+    registry.register(second);
+
+    assertEquals(
+      registry.get("braintrust"),
+      first,
+      "duplicate registration must not replace the first exporter",
+    );
+    assertEquals(
+      registry.list().length,
+      1,
+      "a duplicate exporter id must not add a second registration",
+    );
+  });
+
   it("redacts export context metadata unless keys are explicitly allowed", async () => {
     const registry = createEvalReportExporterRegistry();
     const exportedContexts: unknown[] = [];
@@ -334,6 +354,8 @@ describe("EvalReportExporterRegistry", () => {
         context.redaction.includeInputs = true;
         context.redaction.metadataAllowlist?.push("tenantId");
         context.metadata = { tenantId: "mutated" };
+        context.tags?.push("leaked");
+        if (context.trace) context.trace.traceId = "leaked";
       },
     });
     registry.register({
@@ -345,6 +367,8 @@ describe("EvalReportExporterRegistry", () => {
     });
 
     const context = {
+      tags: ["nightly"],
+      trace: { traceId: "trace-1", spanId: "span-1" },
       metadata: {
         topic: "planning",
         tenantId: "tenant-secret",
@@ -360,11 +384,15 @@ describe("EvalReportExporterRegistry", () => {
     assertEquals(exportedRecord.metadata, { topic: "planning" });
     assertEquals(exportedContexts, [
       {
+        tags: ["nightly"],
+        trace: { traceId: "trace-1", spanId: "span-1" },
         metadata: { topic: "planning" },
         redaction: { metadataAllowlist: ["topic"] },
       },
     ]);
     assertEquals(context, {
+      tags: ["nightly"],
+      trace: { traceId: "trace-1", spanId: "span-1" },
       metadata: {
         topic: "planning",
         tenantId: "tenant-secret",
@@ -424,6 +452,16 @@ describe("EvalReportExporterRegistry", () => {
       output: "The plan changed.",
       reference: "Plan update",
     });
+    assertEquals(
+      record.metrics?.[0]?.label,
+      'Answer contained "the private launch codename"',
+      "metric label must survive when includeMetricEvidence allows evidence",
+    );
+    assertEquals(
+      redacted.summary.metrics[0]?.label,
+      'Answer contained "the private launch codename"',
+      "summary metric label must survive when includeMetricEvidence allows evidence",
+    );
     assertEquals(redacted.dataset, {
       kind: "json",
       path: "private/evals/deep-research.json",

--- a/src/extensions/factory-loader.test.ts
+++ b/src/extensions/factory-loader.test.ts
@@ -6,6 +6,7 @@ import "#veryfront/schemas/_test-setup.ts";
  */
 
 import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
+import { VeryfrontError } from "#veryfront/errors/types.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { toFileUrl } from "#veryfront/compat/path";
 import { join } from "@std/path";
@@ -70,10 +71,25 @@ describe("loadExtensionFactory()", () => {
       `export const named = () => ({ name: "x", version: "1.0.0", capabilities: [] });`,
     );
 
-    await assertRejects(
+    const error = await assertRejects(
       () => loadExtensionFactory(path, "local-file"),
-      Error,
+      VeryfrontError,
       "no default export",
+    ) as VeryfrontError;
+    assertEquals(
+      error.slug,
+      "extension-validation",
+      "factory-loader failures must carry the registry slug",
+    );
+    assertEquals(
+      error.status,
+      422,
+      "factory-loader failures must carry the registry status",
+    );
+    assertEquals(
+      error.category,
+      "CONFIG",
+      "factory-loader failures must carry the registry category",
     );
   });
 
@@ -84,10 +100,25 @@ describe("loadExtensionFactory()", () => {
       `export default { name: "not-fn", version: "1.0.0", capabilities: [] };`,
     );
 
-    await assertRejects(
+    const error = await assertRejects(
       () => loadExtensionFactory(path, "local-file"),
-      Error,
+      VeryfrontError,
       "default export is not a function",
+    ) as VeryfrontError;
+    assertEquals(
+      error.slug,
+      "extension-validation",
+      "factory-loader failures must carry the registry slug",
+    );
+    assertEquals(
+      error.status,
+      422,
+      "factory-loader failures must carry the registry status",
+    );
+    assertEquals(
+      error.category,
+      "CONFIG",
+      "factory-loader failures must carry the registry category",
     );
   });
 
@@ -98,20 +129,50 @@ describe("loadExtensionFactory()", () => {
       `export default () => { throw new Error("boom"); };`,
     );
 
-    await assertRejects(
+    const error = await assertRejects(
       () => loadExtensionFactory(path, "local-file"),
-      Error,
+      VeryfrontError,
       "boom",
+    ) as VeryfrontError;
+    assertEquals(
+      error.slug,
+      "extension-validation",
+      "factory-loader failures must carry the registry slug",
+    );
+    assertEquals(
+      error.status,
+      422,
+      "factory-loader failures must carry the registry status",
+    );
+    assertEquals(
+      error.category,
+      "CONFIG",
+      "factory-loader failures must carry the registry category",
     );
   });
 
   it("throws EXTENSION_VALIDATION_ERROR when import fails (missing file)", async () => {
     const path = join(tmp, "does-not-exist.extension.ts");
 
-    await assertRejects(
+    const error = await assertRejects(
       () => loadExtensionFactory(path, "local-file"),
-      Error,
+      VeryfrontError,
       "Failed to import extension",
+    ) as VeryfrontError;
+    assertEquals(
+      error.slug,
+      "extension-validation",
+      "factory-loader failures must carry the registry slug",
+    );
+    assertEquals(
+      error.status,
+      422,
+      "factory-loader failures must carry the registry status",
+    );
+    assertEquals(
+      error.category,
+      "CONFIG",
+      "factory-loader failures must carry the registry category",
     );
   });
 
@@ -176,6 +237,34 @@ describe("loadExtensionFactory()", () => {
       () => loadExtensionFactory(binding.path, "project", undefined, binding),
       Error,
       "target identity changed",
+    );
+  });
+
+  it("rejects a binding captured for a different entrypoint than the import target", async () => {
+    const boundOwnerPath = join(tmp, "bound-owner");
+    const otherOwnerPath = join(tmp, "other-owner");
+    const otherPath = join(otherOwnerPath, "index.ts");
+    await Deno.mkdir(boundOwnerPath, { recursive: true });
+    await Deno.mkdir(otherOwnerPath, { recursive: true });
+    await Deno.writeTextFile(
+      join(boundOwnerPath, "index.ts"),
+      'export default () => ({ name: "bound", version: "1", capabilities: [] });',
+    );
+    // Importing this module throws at module scope, so the rejection message
+    // doubles as proof that the guard refused before any import happened.
+    await Deno.writeTextFile(
+      otherPath,
+      'throw new Error("other module must not be imported");',
+    );
+    const binding = await bindExtensionEntrypoint(
+      await captureExtensionOwner(boundOwnerPath),
+      "./index.ts",
+    );
+
+    await assertRejects(
+      () => loadExtensionFactory(otherPath, "project", undefined, binding),
+      Error,
+      "Extension discovery binding does not match import target",
     );
   });
 

--- a/src/extensions/first-party-import.test.ts
+++ b/src/extensions/first-party-import.test.ts
@@ -822,8 +822,8 @@ describe("first-party extension imports", () => {
       );
       assertEquals(getterCalls, 0);
 
-      const nonEnumerableOptions = {};
-      Object.defineProperty(nonEnumerableOptions, "sourceEntry", {
+      const nonEnumerableSourceEntry = {};
+      Object.defineProperty(nonEnumerableSourceEntry, "sourceEntry", {
         value: "parser-only",
         enumerable: false,
       });
@@ -832,9 +832,32 @@ describe("first-party extension imports", () => {
           importFirstPartyExtensionModule(
             "ext-parser-babel",
             "@veryfront/ext-parser-babel",
-            nonEnumerableOptions,
+            nonEnumerableSourceEntry,
           ),
         TypeError,
+        "Invalid first-party extension import options",
+        "a non-enumerable option field must be rejected by the descriptor guard",
+      );
+
+      const nonEnumerableOptions = {};
+      Object.defineProperty(nonEnumerableOptions, "sourceEntry", {
+        value: "parser-only",
+        enumerable: false,
+      });
+      Object.defineProperty(nonEnumerableOptions, "packageSubpath", {
+        value: "parser-only",
+        enumerable: false,
+      });
+      await assertRejects(
+        () =>
+          importFirstPartyExtensionModule(
+            "ext-parser-babel",
+            "@veryfront/ext-parser-babel",
+            nonEnumerableOptions as never,
+          ),
+        TypeError,
+        "Invalid first-party extension import options",
+        "non-enumerable option fields must be rejected by the descriptor guard, not by the alignment check",
       );
 
       for (

--- a/src/extensions/image/image-optimization-engine.test.ts
+++ b/src/extensions/image/image-optimization-engine.test.ts
@@ -89,6 +89,40 @@ describe("ImageOptimizationEngine contract", () => {
     );
   });
 
+  it("rejects a prototype-inherited cacheIdentity but accepts an inherited optimize", async () => {
+    // The asymmetry is deliberate: a shared prototype must not supply one cache
+    // identity to differently configured instances, while a class implementation
+    // may still define optimize() on its prototype.
+    assertThrows(
+      () =>
+        assertImageOptimizationEngine(
+          Object.assign(Object.create({ cacheIdentity: "inherited@1" }), {
+            optimize: engine().optimize,
+          }),
+        ),
+      TypeError,
+      "cacheIdentity must be an own data property",
+      "cacheIdentity must be owned by the engine instance, not inherited",
+    );
+
+    const inheritedOptimize = Object.assign(
+      Object.create({ optimize: engine().optimize }),
+      { cacheIdentity: "prototype-optimize@1" },
+    );
+    const captured = captureImageOptimizationEngine(inheritedOptimize);
+    assertEquals(
+      (await captured.optimize({
+        input: new Uint8Array([1]),
+        targetWidths: Object.freeze([1]),
+        formats: Object.freeze(["png"]),
+        quality: 80,
+        signal: new AbortController().signal,
+      })).sourceWidth,
+      1,
+      "a prototype-defined optimize must still be captured",
+    );
+  });
+
   it("rejects unstable and oversized identities", () => {
     for (
       const cacheIdentity of [

--- a/src/extensions/install-command.test.ts
+++ b/src/extensions/install-command.test.ts
@@ -129,6 +129,25 @@ describe("extensions/install-command", () => {
     });
   });
 
+  it("finds the workspace-root lockfile from the deepest documented member nesting", async () => {
+    // The documented reach is `<root>/<group>/<scope>/<member>`; a member that
+    // deep must still resolve to the workspace client, not print `npm install`
+    // into a pnpm workspace.
+    await withTempDir(async (root) => {
+      await writeTextFile(join(root, "package.json"), `{"name":"root"}`);
+      await writeTextFile(join(root, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+      const member = join(root, "group", "scope", "member");
+      await mkdir(member, { recursive: true });
+      await writeTextFile(join(member, "package.json"), `{"name":"member"}`);
+
+      assertEquals(
+        detectProjectInstallTarget(member),
+        "pnpm",
+        "a pnpm member three directories below the workspace root must resolve to pnpm",
+      );
+    });
+  });
+
   it("does not let an enclosing deno.lock claim a Node package", async () => {
     // A `--runtime node` scaffold checked out inside a Deno repository is still
     // a Node project. `deno add` there writes a deno.json its own `npm ci`

--- a/src/extensions/llm/llm-provider-registry.test.ts
+++ b/src/extensions/llm/llm-provider-registry.test.ts
@@ -117,5 +117,15 @@ describe("LLMProviderRegistry", () => {
       TypeError,
       'optional method "createEmbedding"',
     );
+    assertThrows(
+      () =>
+        reg.register({
+          ...fakeProvider("bad-responses"),
+          createResponses: "not a function",
+        } as never),
+      TypeError,
+      'optional method "createResponses"',
+      "a non-function createResponses must be rejected at the registration boundary",
+    );
   });
 });

--- a/src/extensions/loader.test.ts
+++ b/src/extensions/loader.test.ts
@@ -7,6 +7,7 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { FakeTime } from "#std/testing/time";
 import { ExtensionLoader } from "./loader.ts";
 import {
   register,
@@ -855,15 +856,34 @@ describe("ExtensionLoader", () => {
     });
 
     it("should disable timeout when setupTimeoutMs is 0", async () => {
-      // A setup that takes longer than a tight timeout would catch,
-      // but we call with 0 (disabled) so it must not throw.
+      // A setup held open past the 30 s default deadline proves that 0 arms no
+      // deadline at all, rather than quietly falling back to the default.
+      using time = new FakeTime();
+      const gate = Promise.withResolvers<void>();
       const slow = makeExt("slow", {
-        setup: () => new Promise<void>((resolve) => setTimeout(resolve, 20)),
+        setup: () => gate.promise,
       });
 
       const loader = new ExtensionLoader(noopLogger);
-      // With a 5 ms timeout this would fail; with 0 (disabled) it must succeed.
-      await loader.setupAll([makeResolved(slow)], {}, { setupTimeoutMs: 0 });
+      let settled: "resolved" | "rejected" | undefined;
+      const setupAll = loader.setupAll([makeResolved(slow)], {}, { setupTimeoutMs: 0 })
+        .then(() => {
+          settled = "resolved";
+        }, () => {
+          settled = "rejected";
+        });
+
+      await time.tickAsync(120_000);
+      assertEquals(
+        settled,
+        undefined,
+        "setupTimeoutMs 0 must arm no deadline, even past the 30s default",
+      );
+
+      gate.resolve();
+      await setupAll;
+      assertEquals(settled, "resolved", "setup must complete once released");
+      await loader.teardownAll();
     });
   });
 
@@ -1496,6 +1516,21 @@ describe("ExtensionLoader", () => {
         () => loader.flattenPresets([makeResolved(preset)]),
         Error,
         "nesting exceeds 32 levels",
+      );
+    });
+
+    it("bounds total preset graph work when subgraphs are shared across siblings", () => {
+      // Sibling repetition of one extension object is legal, so a graph well
+      // inside the depth and children limits can still expand without bound.
+      const leaf = makeExt("leaf");
+      const mid = makeExt("mid", { extends: Array.from({ length: 256 }, () => leaf) });
+      const top = makeExt("top", { extends: Array.from({ length: 20 }, () => mid) });
+
+      const loader = new ExtensionLoader(noopLogger);
+      assertThrows(
+        () => loader.flattenPresets([makeResolved(top)]),
+        Error,
+        "graph exceeds 4096 nodes",
       );
     });
   });

--- a/src/extensions/manifest-reader.test.ts
+++ b/src/extensions/manifest-reader.test.ts
@@ -222,6 +222,30 @@ describe("parseExtensionManifest()", () => {
       parseExtensionManifest(`{\u00a0\"activation\":\"explicit\"}`, "json")
     );
     assertEquals(strictError.slug, "extension-manifest-parse-failed");
+
+    const stringSafeWhitespace = [
+      0x85,
+      0xa0,
+      0x1680,
+      ...Array.from({ length: 11 }, (_, index) => 0x2000 + index),
+      0x2028,
+      0x2029,
+      0x202f,
+      0x205f,
+      0x3000,
+    ];
+    for (const codePoint of stringSafeWhitespace) {
+      const whitespace = String.fromCodePoint(codePoint);
+      const manifest = parseExtensionManifest<{ value: string }>(
+        `{\"value\":\"a${whitespace}b\"}`,
+        "jsonc",
+      );
+      assertEquals(
+        manifest.value,
+        `a${whitespace}b`,
+        "Deno whitespace inside a JSONC string must survive verbatim",
+      );
+    }
   });
 
   it("matches Deno line-comment termination semantics", () => {
@@ -480,6 +504,120 @@ describe("readExtensionManifest() file identity", () => {
     assertEquals(error.slug, "extension-manifest-file-invalid");
     assertEquals(state.openCalls, 0);
   });
+
+  it("applies identity and size validation to bigint stat results", async () => {
+    const data = encoder.encode('{"activation":"explicit"}');
+    const bigintInfo = fileInfo(BigInt(data.length), { dev: 11n, ino: 29n });
+    const accepted = createFakeFileSystem({
+      data,
+      handleInfo: bigintInfo,
+      pathInfos: [bigintInfo, bigintInfo, bigintInfo],
+    });
+
+    const result = await readExtensionManifest<{ activation: string }>("manifest.json", {
+      syntax: "json",
+      fileSystem: accepted.fileSystem,
+    });
+
+    assertEquals(
+      result.kind,
+      "found",
+      "a bigint dev and ino pair must verify the same way as numbers",
+    );
+    if (result.kind === "found") {
+      assertEquals(
+        result.manifest.activation,
+        "explicit",
+        "the parsed manifest must survive a bigint stat result unchanged",
+      );
+      assertEquals(
+        result.bytesRead,
+        data.length,
+        "bytesRead must report the byte length the bigint size described",
+      );
+    }
+    assertEquals(
+      accepted.state.closeCalls,
+      1,
+      "an accepted bigint stat read must still close its handle exactly once",
+    );
+
+    const oversized = fileInfo(BigInt(MAX_EXTENSION_MANIFEST_BYTES + 1), {
+      dev: 11n,
+      ino: 29n,
+    });
+    const large = createFakeFileSystem({ pathInfos: [oversized] });
+    const sizeFailure = await captureManifestError(() =>
+      readExtensionManifest("manifest.json", {
+        syntax: "json",
+        fileSystem: large.fileSystem,
+      })
+    );
+
+    assertEquals(
+      sizeFailure.slug,
+      "extension-manifest-too-large",
+      "the bigint pre-open size gate must reject an oversized manifest",
+    );
+    assertEquals(
+      large.state.openCalls,
+      0,
+      "an oversized manifest must be rejected before the file is opened",
+    );
+
+    const original = fileInfo(2n, { dev: 1n, ino: 10n });
+    const replacement = fileInfo(2n, { dev: 1n, ino: 11n });
+    const swapped = createFakeFileSystem({
+      handleInfo: original,
+      pathInfos: [original, replacement],
+    });
+    const identityFailure = await captureManifestError(() =>
+      readExtensionManifest("manifest.json", {
+        syntax: "json",
+        fileSystem: swapped.fileSystem,
+      })
+    );
+
+    assertEquals(
+      identityFailure.slug,
+      "extension-manifest-file-invalid",
+      "a bigint identity swap must surface as an invalid manifest file",
+    );
+    assertStringIncludes(
+      identityFailure.message,
+      "identity changed",
+      "a bigint identity swap must be detected, not silently accepted",
+    );
+    assertEquals(
+      swapped.state.closeCalls,
+      1,
+      "a rejected identity swap must still close the handle exactly once",
+    );
+
+    const negative = createFakeFileSystem({ pathInfos: [fileInfo(-1n)] });
+    const negativeFailure = await captureManifestError(() =>
+      readExtensionManifest("manifest.json", {
+        syntax: "json",
+        fileSystem: negative.fileSystem,
+      })
+    );
+
+    assertEquals(
+      negativeFailure.slug,
+      "extension-manifest-file-invalid",
+      "a negative bigint size must surface as an invalid manifest file",
+    );
+    assertStringIncludes(
+      negativeFailure.message,
+      "invalid negative size",
+      "a negative bigint size must fail closed before the file is opened",
+    );
+    assertEquals(
+      negative.state.openCalls,
+      0,
+      "a negative size must be rejected before the file is opened",
+    );
+  });
 });
 
 describe("readExtensionManifest() cleanup and errors", () => {
@@ -497,14 +635,9 @@ describe("readExtensionManifest() cleanup and errors", () => {
     assertEquals(state.openCalls, 0);
   });
 
-  it("closes the handle after success, stat, path, read, and parse failures", async () => {
+  it("closes the handle after success and parse failures", async () => {
     const cases: FakeFileSystemOptions[] = [
       {},
-      { statError: new Error("stat failed") },
-      {
-        pathInfos: [fileInfo(2), new Error("path failed")],
-      },
-      { readError: new Error("read failed") },
       { data: encoder.encode("{") },
     ];
 
@@ -518,6 +651,71 @@ describe("readExtensionManifest() cleanup and errors", () => {
       assertEquals(state.openCalls, 1);
       assertEquals(state.closeCalls, 1);
     }
+  });
+
+  it("classifies stat, path, and read I/O failures as typed read errors", async () => {
+    const cases: Array<{ options: FakeFileSystemOptions; cause: string }> = [
+      { options: { statError: new Error("stat failed") }, cause: "stat failed" },
+      {
+        options: { pathInfos: [fileInfo(2), new Error("path failed")] },
+        cause: "path failed",
+      },
+      { options: { readError: new Error("read failed") }, cause: "read failed" },
+    ];
+
+    for (const { options, cause } of cases) {
+      const { fileSystem, state } = createFakeFileSystem(options);
+      const error = await captureManifestError(() =>
+        readExtensionManifest("manifest.json", { syntax: "json", fileSystem })
+      );
+
+      assertEquals(
+        error.slug,
+        "extension-manifest-read-failed",
+        "an I/O failure must be a typed read error, never a truncated manifest",
+      );
+      assertEquals(
+        (error.context as { operation: string }).operation,
+        "read",
+        "the typed read error must carry the read operation in its context",
+      );
+      assertStringIncludes(
+        String(error.cause),
+        cause,
+        "the originating I/O failure must be preserved as the error cause",
+      );
+      assertEquals(
+        state.openCalls,
+        1,
+        "a classified I/O failure must open the file exactly once",
+      );
+      assertEquals(
+        state.closeCalls,
+        1,
+        "a classified I/O failure must still close the handle exactly once",
+      );
+    }
+  });
+
+  it("never accepts a failed read as an empty JSONC manifest", async () => {
+    const { fileSystem, state } = createFakeFileSystem({
+      readError: new Error("read failed"),
+    });
+
+    const error = await captureManifestError(() =>
+      readExtensionManifest("manifest.jsonc", { syntax: "jsonc", fileSystem })
+    );
+
+    assertEquals(
+      error.slug,
+      "extension-manifest-read-failed",
+      "a mid-stream read failure must not be reported as an empty JSONC manifest",
+    );
+    assertEquals(
+      state.closeCalls,
+      1,
+      "a failed JSONC read must still close the handle exactly once",
+    );
   });
 
   it("surfaces close failure as a contextual typed error", async () => {

--- a/src/extensions/observability/application-error-reporter.test.ts
+++ b/src/extensions/observability/application-error-reporter.test.ts
@@ -7,10 +7,33 @@ import {
   ApplicationErrorReporterInitializerName,
 } from "./index.ts";
 
+type CanonicalFieldParity<TExtension, TCanonical> = [keyof TExtension] extends [keyof TCanonical]
+  ? ([keyof TCanonical] extends [keyof TExtension] ? true : never)
+  : never;
+
 Deno.test("application-error initializer re-exports the canonical context contract", async () => {
+  const fieldParity: CanonicalFieldParity<
+    ApplicationErrorContext,
+    CanonicalApplicationErrorContext
+  > = true;
+  if (!fieldParity) {
+    throw new Error(
+      "the extension entry point must re-export the canonical ApplicationErrorContext, not a local duplicate",
+    );
+  }
+
+  // Annotated as a literal so excess-property checking fails the typecheck if
+  // the re-exported context ever drops one of the canonical fields.
   const extensionContext: ApplicationErrorContext = {
     boundary: "worker.request",
+    method: "POST",
     processRole: "worker",
+    requestId: "req-1",
+    spanId: "span-1",
+    traceId: "trace-1",
+    errorClass: "tenant-build",
+    level: "error",
+    attributes: { tenant: "acme", attempt: 2, retried: true },
   };
   const canonicalContext: CanonicalApplicationErrorContext = extensionContext;
   const roundTripContext: ApplicationErrorContext = canonicalContext;

--- a/src/extensions/orchestrate.test.ts
+++ b/src/extensions/orchestrate.test.ts
@@ -505,7 +505,7 @@ describe("orchestrateExtensions()", () => {
   it("does not activate a retry while timed-out setup is still running", async () => {
     const firstStarted = Promise.withResolvers<void>();
     const releaseFirst = Promise.withResolvers<void>();
-    const retryStarted = Promise.withResolvers<void>();
+    const order: string[] = [];
     const first = orchestrateExtensions({
       projectDir: "/fake",
       config: {
@@ -513,6 +513,7 @@ describe("orchestrateExtensions()", () => {
           async setup() {
             firstStarted.resolve();
             await releaseFirst.promise;
+            order.push("late-setup-done");
           },
         })],
       },
@@ -528,23 +529,29 @@ describe("orchestrateExtensions()", () => {
       config: {
         extensions: [stubExt("replacement", {
           setup() {
-            retryStarted.resolve();
+            order.push("retry-setup");
           },
         })],
       },
       logger: noopLogger,
       discovery: emptyDiscovery(),
     });
-    const retryStartedBeforeLateSetupSettled = await Promise.race([
-      retryStarted.promise.then(() => true),
-      new Promise<false>((resolve) => setTimeout(() => resolve(false), 20)),
-    ]);
+    for (let index = 0; index < 100; index++) await Promise.resolve();
+    assertEquals(
+      order,
+      [],
+      "the retry must not run setup while the timed-out setup is still pending",
+    );
 
     releaseFirst.resolve();
     const retryLoader = await retry;
     await retryLoader.teardownAll();
 
-    assertEquals(retryStartedBeforeLateSetupSettled, false);
+    assertEquals(
+      order,
+      ["late-setup-done", "retry-setup"],
+      "the replacement generation must activate only after the late setup and its cleanup settle",
+    );
   });
 
   it("filters disable directives from config.extensions", async () => {

--- a/src/extensions/parser/skill-document-parser.test.ts
+++ b/src/extensions/parser/skill-document-parser.test.ts
@@ -247,6 +247,57 @@ Deno.test("Skill document parser provider observes rejected async results before
   assertEquals(unhandledRejections, 0);
 });
 
+Deno.test("Skill document parser provider observes a rejection behind a configurable own constructor", async () => {
+  let unhandledRejections = 0;
+  let hostileCalls = 0;
+  const onUnhandledRejection = (event: PromiseRejectionEvent): void => {
+    unhandledRejections += 1;
+    event.preventDefault();
+  };
+  globalThis.addEventListener("unhandledrejection", onUnhandledRejection);
+
+  const hostile = function HostileConstructor(): void {
+    hostileCalls += 1;
+  } as unknown as PromiseConstructor;
+  const promise = Promise.reject(new Error("async parser failure"));
+  Object.defineProperty(promise, "constructor", {
+    configurable: true,
+    enumerable: false,
+    writable: true,
+    value: hostile,
+  });
+
+  try {
+    const asyncParser = createSkillDocumentParserProvider(() => promise);
+    assertThrows(
+      () => asyncParser.parseFrontmatter("name: demo"),
+      TypeError,
+      "must be synchronous",
+    );
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  } finally {
+    globalThis.removeEventListener("unhandledrejection", onUnhandledRejection);
+  }
+
+  assertEquals(
+    unhandledRejections,
+    0,
+    "a rejected result with a configurable own constructor must still be observed",
+  );
+  assertEquals(hostileCalls, 0, "the extension-owned constructor must never be invoked");
+
+  const restored = Object.getOwnPropertyDescriptor(promise, "constructor");
+  assertStrictEquals(restored?.value, hostile, "restoration must return the original value");
+  assertEquals(restored?.configurable, true, "restoration must keep the original configurable");
+  assertEquals(restored?.writable, true, "restoration must keep the original writable");
+  assertEquals(
+    restored?.enumerable,
+    false,
+    "clonePropertyDescriptor must restore every original flag",
+  );
+});
+
 Deno.test("Skill document parser provider rejects hostile Promise constructors without invoking them", () => {
   const asynchronousResult = Promise.resolve({});
   let constructorGetterCalls = 0;

--- a/src/extensions/property-inspection.test.ts
+++ b/src/extensions/property-inspection.test.ts
@@ -86,5 +86,42 @@ describe("extension property inspection", () => {
     assertEquals(isStableExtensionCacheIdentity("engine-\uD800", 64), false);
     assertEquals(isStableExtensionCacheIdentity("engine-\uDC00", 64), false);
     assertEquals(isStableExtensionCacheIdentity("engine-\uD800x", 64), false);
+    assertEquals(
+      isStableExtensionCacheIdentity("x".repeat(64), 64),
+      true,
+      "an identity of exactly maxCharacters must be accepted",
+    );
+    assertEquals(
+      isStableExtensionCacheIdentity("x".repeat(65), 64),
+      false,
+      "an identity one character over maxCharacters must be rejected",
+    );
+    // An identity becomes a cache key and a log line, so an interior control
+    // character or line separator must be rejected rather than trimmed away.
+    assertEquals(
+      isStableExtensionCacheIdentity("engine\u0000v1", 64),
+      false,
+      "an interior NUL must be rejected",
+    );
+    assertEquals(
+      isStableExtensionCacheIdentity("engine\nv1", 64),
+      false,
+      "an interior newline must be rejected",
+    );
+    assertEquals(
+      isStableExtensionCacheIdentity("engine\u2028v1", 64),
+      false,
+      "an interior line separator must be rejected",
+    );
+    assertEquals(
+      isStableExtensionCacheIdentity("engine-e\u0301", 64),
+      false,
+      "a decomposed identity must be rejected so one engine cannot own two keys",
+    );
+    assertEquals(
+      isStableExtensionCacheIdentity("engine-\u00e9", 64),
+      true,
+      "the composed NFC form of the same identity must be accepted",
+    );
   });
 });

--- a/src/extensions/rendering/isolated-ssr-renderer.test.ts
+++ b/src/extensions/rendering/isolated-ssr-renderer.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import {
+  MAX_ISOLATED_SSR_RENDERER_READ_ROOTS,
   snapshotIsolatedSsrRendererProvider,
   validateIsolatedSsrRendererModuleUrl,
 } from "./isolated-ssr-renderer.ts";
@@ -157,4 +158,65 @@ Deno.test("isolated SSR renderer provider inspection is independent of replaced 
     if (ownKeys) Object.defineProperty(Reflect, "ownKeys", ownKeys);
     if (isArray) Object.defineProperty(Array, "isArray", isArray);
   }
+});
+
+Deno.test("isolated SSR renderer provider rejects non-directory and non-local read roots", () => {
+  for (
+    const value of [
+      "ext-react-ssr/",
+      "https://cdn.example/",
+      "file:///opt/veryfront/?v=1",
+      "file:///opt/veryfront/#root",
+      "file://server/share/",
+      "file:///opt/veryfront/worker-renderer.ts",
+    ]
+  ) {
+    assertThrows(
+      () =>
+        snapshotIsolatedSsrRendererProvider({
+          moduleUrl: "file:///opt/veryfront/worker-renderer.ts",
+          readRootUrls: ["file:///opt/veryfront/", value],
+        }),
+      TypeError,
+      "readRootUrls[1] must be an absolute local file URL",
+      `read root ${value} must be rejected as a sandbox read root`,
+    );
+  }
+});
+
+Deno.test("isolated SSR renderer provider rejects empty and oversized read root arrays", () => {
+  assertThrows(
+    () =>
+      snapshotIsolatedSsrRendererProvider({
+        moduleUrl: "file:///opt/veryfront/worker-renderer.ts",
+        readRootUrls: [],
+      }),
+    TypeError,
+    "dense bounded array",
+    "a provider must declare at least one read root",
+  );
+  assertThrows(
+    () =>
+      snapshotIsolatedSsrRendererProvider({
+        moduleUrl: "file:///opt/veryfront/worker-renderer.ts",
+        readRootUrls: Array.from(
+          { length: MAX_ISOLATED_SSR_RENDERER_READ_ROOTS + 1 },
+          (_unused, index) => `file:///opt/veryfront/root-${index}/`,
+        ),
+      }),
+    TypeError,
+    "dense bounded array",
+    "read roots beyond the documented cap must be rejected",
+  );
+  assertEquals(
+    snapshotIsolatedSsrRendererProvider({
+      moduleUrl: "file:///opt/veryfront/worker-renderer.ts",
+      readRootUrls: Array.from(
+        { length: MAX_ISOLATED_SSR_RENDERER_READ_ROOTS },
+        (_unused, index) => `file:///opt/veryfront/root-${index}/`,
+      ),
+    }).readRootUrls.length,
+    MAX_ISOLATED_SSR_RENDERER_READ_ROOTS,
+    "read roots exactly at the cap must be accepted",
+  );
 });

--- a/src/extensions/setup-hint.test.ts
+++ b/src/extensions/setup-hint.test.ts
@@ -147,6 +147,46 @@ describe("extensions/setup-hint", () => {
     });
   });
 
+  it("names the higher-precedence config file when a project keeps two", async () => {
+    // Precedence is the loader's, not this module's to re-order: a project
+    // that keeps two files is told to edit the one findVeryfrontConfigFile
+    // actually loads. Spelled out rather than iterated over the constant so a
+    // reordered list cannot make the test agree with the regression.
+    await withTempDir(async (directory) => {
+      await writeTextFile(join(directory, "package.json"), `{"name":"js-and-ts"}`);
+      await writeTextFile(join(directory, "veryfront.config.js"), "export default {};\n");
+      await writeTextFile(join(directory, "veryfront.config.ts"), "export default {};\n");
+
+      const hint = formatExtensionSetupHint("@veryfront/ext-css-lightning", {
+        projectDirectory: directory,
+      });
+
+      assertEquals(hint.includes("veryfront.config.js"), true, hint);
+      assertEquals(
+        hint.includes("veryfront.config.ts"),
+        false,
+        `.ts must not be named while .js shadows it, got: ${hint}`,
+      );
+    });
+
+    await withTempDir(async (directory) => {
+      await writeTextFile(join(directory, "package.json"), `{"name":"ts-and-mjs"}`);
+      await writeTextFile(join(directory, "veryfront.config.ts"), "export default {};\n");
+      await writeTextFile(join(directory, "veryfront.config.mjs"), "export default {};\n");
+
+      const hint = formatExtensionSetupHint("@veryfront/ext-css-lightning", {
+        projectDirectory: directory,
+      });
+
+      assertEquals(hint.includes("veryfront.config.ts"), true, hint);
+      assertEquals(
+        hint.includes("veryfront.config.mjs"),
+        false,
+        `.mjs must not be named while .ts shadows it, got: ${hint}`,
+      );
+    });
+  });
+
   it("derives a binding that is a valid identifier for any recommendation", async () => {
     // Every first-party extension exports its factory as the module default,
     // so the local binding is the hint's to choose; it only has to be a legal

--- a/src/extensions/validation.test.ts
+++ b/src/extensions/validation.test.ts
@@ -5,9 +5,14 @@ import "#veryfront/schemas/_test-setup.ts";
  * @module extensions/validation.test
  */
 
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { detectConflicts, SOURCE_PRIORITY, validateExtension } from "./validation.ts";
+import {
+  detectConflicts,
+  selectContractProviders,
+  SOURCE_PRIORITY,
+  validateExtension,
+} from "./validation.ts";
 import type { Capability, Extension, ResolvedExtension } from "./types.ts";
 
 describe("validateExtension", () => {
@@ -559,6 +564,44 @@ describe("validateExtension", () => {
 describe("SOURCE_PRIORITY", () => {
   it("is immutable process-wide policy", () => {
     assertEquals(Object.isFrozen(SOURCE_PRIORITY), true);
+    assertEquals(
+      SOURCE_PRIORITY,
+      { config: 0, package: 1, project: 2, "local-file": 3, builtin: 4 },
+      "source priority order is process-wide policy: lower number wins",
+    );
+  });
+});
+
+describe("selectContractProviders", () => {
+  it("ranks a project extension above a local-file extension", () => {
+    const projectExt: ResolvedExtension = {
+      extension: {
+        name: "ext-project",
+        version: "1.0.0",
+        capabilities: [],
+        provides: { Bundler: {} },
+      },
+      source: "project",
+      origin: "extensions/ext-project/src/index.ts",
+    };
+    const localExt: ResolvedExtension = {
+      extension: {
+        name: "ext-local",
+        version: "1.0.0",
+        capabilities: [],
+        provides: { Bundler: {} },
+      },
+      source: "local-file",
+      origin: "bundler.extension.ts",
+    };
+
+    for (const candidates of [[localExt, projectExt], [projectExt, localExt]]) {
+      assertStrictEquals(
+        selectContractProviders(candidates).get("Bundler"),
+        projectExt,
+        "a project extension outranks a local-file extension regardless of iteration order",
+      );
+    }
   });
 });
 

--- a/src/extensions/websocket/node-websocket-server-provider.test.ts
+++ b/src/extensions/websocket/node-websocket-server-provider.test.ts
@@ -4,12 +4,16 @@ import {
   assertStringIncludes,
   assertThrows,
 } from "#veryfront/testing/assert.ts";
+import { FIRST_PARTY_DEFERRED_BUILTIN_EXTENSION_POLICIES } from "#veryfront/extensions/first-party-defaults.ts";
+import { getRecommendation } from "#veryfront/extensions/recommendations.ts";
 import {
   captureNodeWebSocketServer,
   createNodeWebSocketServerProvider,
   NODE_WEBSOCKET_SERVER_PROVIDER_MISSING_MESSAGE,
   NODE_WEBSOCKET_SERVER_PROVIDER_PACKAGE,
+  type NodeWebSocketConnection,
   type NodeWebSocketServer,
+  NodeWebSocketServerProviderName,
   snapshotNodeWebSocketServerProvider,
 } from "./node-websocket-server-provider.ts";
 
@@ -18,19 +22,38 @@ const SERVER = {} as NodeWebSocketServer;
 Deno.test("Node WebSocket server capture pins callable methods and client ownership", () => {
   let closeCalls = 0;
   const clients = new Set<never>();
+  const records: { receiver: unknown; args: unknown[] }[] = [];
   const source = {
     clients,
-    on() {
+    on(...args: unknown[]) {
+      records.push({ receiver: this, args });
       return source;
     },
     close(callback?: (error?: Error) => void) {
       closeCalls++;
       callback?.();
     },
-    handleUpgrade() {},
-    emit() {},
+    handleUpgrade(...args: unknown[]) {
+      records.push({ receiver: this, args });
+    },
+    emit(...args: unknown[]) {
+      records.push({ receiver: this, args });
+    },
   };
   const captured = captureNodeWebSocketServer(source);
+  const listener = (_headers: string[], _request: unknown) => {};
+  const request = { url: "/socket" };
+  const socket = {} as NodeWebSocketConnection;
+  const head = new Uint8Array(0);
+  const callback = (_socket: NodeWebSocketConnection) => {};
+
+  assertStrictEquals(
+    captured.on("headers", listener),
+    captured,
+    "on must return the captured facade so handshake listeners can chain",
+  );
+  captured.handleUpgrade(request, socket, head, callback);
+  captured.emit("connection", socket, request);
 
   source.close = () => {
     throw new Error("mutated close must not run");
@@ -38,6 +61,23 @@ Deno.test("Node WebSocket server capture pins callable methods and client owners
   captured.close();
 
   assertEquals(closeCalls, 1);
+  assertEquals(records.length, 3, "every captured method must forward to the source");
+  for (const record of records) {
+    assertStrictEquals(
+      record.receiver,
+      source,
+      "the underlying implementation must remain the receiver",
+    );
+  }
+  assertEquals(
+    records.map((record) => record.args),
+    [
+      ["headers", listener],
+      [request, socket, head, callback],
+      ["connection", socket, request],
+    ],
+    "every captured method must forward its arguments unchanged",
+  );
   assertStrictEquals(captured.clients, clients);
   assertEquals(Object.isFrozen(captured), true);
 });
@@ -64,6 +104,33 @@ Deno.test("Node WebSocket server capture rejects proxies, accessors, and missing
       "must expose data-function",
     );
   }
+
+  for (
+    const value of [
+      { ...valid, clients: 42 },
+      { ...valid, clients: new Proxy(new Set(), {}) },
+      Object.defineProperty({ ...valid }, "clients", {
+        enumerable: true,
+        get() {
+          return new Set();
+        },
+      }),
+    ]
+  ) {
+    assertThrows(
+      () => captureNodeWebSocketServer(value),
+      TypeError,
+      "must expose data-function",
+      "a non-iterable, proxied, or accessor-backed clients set must be rejected at capture time",
+    );
+  }
+
+  const captured = captureNodeWebSocketServer({ ...valid, clients: undefined });
+  assertEquals(
+    Object.hasOwn(captured, "clients"),
+    false,
+    "an absent clients set must not become an own property of the captured server",
+  );
 });
 
 Deno.test("Node WebSocket provider captures one immutable factory generation", () => {
@@ -119,9 +186,18 @@ Deno.test("Node WebSocket provider helper and missing-contract diagnostic are ac
     provider.createServer({ noServer: true, handleProtocols: () => false }),
     SERVER,
   );
-  assertStringIncludes(
-    NODE_WEBSOCKET_SERVER_PROVIDER_MISSING_MESSAGE,
+  const policy = FIRST_PARTY_DEFERRED_BUILTIN_EXTENSION_POLICIES.find(
+    (candidate) => candidate.name === "ext-node-websocket-ws",
+  );
+  assertEquals(
     NODE_WEBSOCKET_SERVER_PROVIDER_PACKAGE,
+    `@veryfront/${policy?.sourceDirectory}`,
+    "diagnostic package must match the first-party deferred builtin policy",
+  );
+  assertEquals(
+    getRecommendation(NodeWebSocketServerProviderName),
+    NODE_WEBSOCKET_SERVER_PROVIDER_PACKAGE,
+    "diagnostic package must match the contract recommendation",
   );
   assertStringIncludes(
     NODE_WEBSOCKET_SERVER_PROVIDER_MISSING_MESSAGE,


### PR DESCRIPTION
## Summary

Audit of all 40 test files under `src/extensions` for tests that stay green when the behavior they claim to cover breaks.

The bar for every change: name a concrete source edit that breaks documented behavior yet leaves the test passing. Every change was **mutation checked** — the named edit was applied, the test confirmed to fail, then the edit reverted.

55 candidate findings, 50 confirmed after adversarial verification, 52 applied, 5 refuted. **No product defects found. Test files only.**

## Recurring weaknesses fixed

**A genuinely tautological assertion.** The Node websocket diagnostic asserted that its message constant contained its package constant — both derived from the same source, so it held for *any* value including a wrong one. It now checks the package name against two independent sources: the `sourceDirectory` in `FIRST_PARTY_DEFERRED_BUILTIN_EXTENSION_POLICIES`, and `getRecommendation(NodeWebSocketServerProviderName)`. Renaming the constant to `@veryfront/ext-ws` now fails.

**Permission mapping was only partly pinned.** `native:ffi` and scoped `fs:write` now assert their exact flags, so widening `native:ffi` to `--allow-all`, or dropping the scope from `fs:write`, fails. Read and write scopes are also asserted to stay in separate flags.

**Registry errors asserted only that something threw.** They now assert the registry identity — slug `missing-extension`, status 500, category `RUNTIME`, and the install recommendation detail — so replacing `MISSING_EXTENSION_ERROR.create` with a plain `Error` fails.

**Contract registry lifecycle guards were unreached.** Publishing over an active generation, publishing while a prior generation still owns published entries, and fail-closed behavior after a failed generation now each assert their specific rejection *and* that the registry contents are unchanged.

**Receiver binding was unasserted.** The websocket capture now records the receiver of every forwarded call and asserts it is strictly the source object, so dropping the `Reflect.apply` or rebinding the receiver to `undefined` fails. This is the same class of defect as the unbound backend methods in #4056.

**Descriptor validation** now covers accessor-backed properties and proxies, and asserts the getters are never invoked — including under `Object.prototype` pollution.

**Listener cleanup is now counted**, so deleting `detachAll()` leaves the removal count wrong and fails.

## Note on one skipped item

One finding asked for a mirrored case in `css-purging-engine.test.ts`, which belonged to a different agent's file set in the same run. It was reported rather than applied, since two agents editing one file is how you get a corrupted merge. Worth picking up separately.

## Verification

- Semantic unit-boundary audit: ok
- Sanitizer ratchet test: ok (baseline unchanged at 396)
- `test:layout`: ok, `docs:api-reference:check`: current
- `deno fmt`, `deno lint`: pass
- **30/30** changed test files pass
- `anti-slop`, `cwd-relative-test-reads`, `test-typecheck`, `check-awaits`, `cross-runtime-jsr`, `skipped-tests`, `ban-test-only`: all pass

No test was deleted, skipped, or weakened.