### PR TITLE
test(observability,metrics): make weak assertions bite across telemetry

### DIFF
--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -301,6 +301,91 @@ describe("metrics public SDK", () => {
     );
   });
 
+  it("keeps exporting after a non-ok collector response", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    let status = 500;
+
+    Deno.env.set("OTEL_METRICS_ENABLED", "true");
+    Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.example/otlp");
+    Deno.env.set("OTEL_SERVICE_NAME", "veryfront-server");
+
+    globalThis.fetch = ((url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init });
+      return Promise.resolve(new Response("", { status }));
+    }) as typeof fetch;
+
+    try {
+      metrics.counter("vf_rejected_batch_total", 1, { project_id: "project-123" });
+      assertEquals(
+        await (metrics as unknown as { __flushForTests(): Promise<void> }).__flushForTests(),
+        undefined,
+        "a non-ok collector response must not reject the flush",
+      );
+      assertEquals(requests.length, 1, "the rejected batch must still have been sent once");
+
+      status = 200;
+      metrics.counter("vf_recovered_batch_total", 1, { project_id: "project-123" });
+      await (metrics as unknown as { __flushForTests(): Promise<void> }).__flushForTests();
+    } finally {
+      globalThis.fetch = originalFetch;
+      Deno.env.delete("OTEL_METRICS_ENABLED");
+      Deno.env.delete("OTEL_EXPORTER_OTLP_ENDPOINT");
+      Deno.env.delete("OTEL_SERVICE_NAME");
+    }
+
+    assertEquals(requests.length, 2, "the next batch must still be exported");
+    const body = JSON.parse(String(requests[1]?.init?.body));
+    assertEquals(
+      body.resourceMetrics[0].scopeMetrics[0].metrics.map((entry: { name: string }) => entry.name),
+      ["vf_recovered_batch_total"],
+      "a non-ok collector response degrades silently and does not poison the queue",
+    );
+  });
+
+  it("keeps exporting after the collector request rejects", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    let failing = true;
+
+    Deno.env.set("OTEL_METRICS_ENABLED", "true");
+    Deno.env.set("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.example/otlp");
+    Deno.env.set("OTEL_SERVICE_NAME", "veryfront-server");
+
+    globalThis.fetch = ((url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init });
+      if (failing) return Promise.reject(new TypeError("network down"));
+      return Promise.resolve(new Response("{}", { status: 200 }));
+    }) as typeof fetch;
+
+    try {
+      metrics.counter("vf_unreachable_batch_total", 1, { project_id: "project-123" });
+      assertEquals(
+        await (metrics as unknown as { __flushForTests(): Promise<void> }).__flushForTests(),
+        undefined,
+        "a failed collector request must not reject out of the flush timer",
+      );
+      assertEquals(requests.length, 1, "the failed batch must still have been attempted once");
+
+      failing = false;
+      metrics.counter("vf_reachable_batch_total", 1, { project_id: "project-123" });
+      await (metrics as unknown as { __flushForTests(): Promise<void> }).__flushForTests();
+    } finally {
+      globalThis.fetch = originalFetch;
+      Deno.env.delete("OTEL_METRICS_ENABLED");
+      Deno.env.delete("OTEL_EXPORTER_OTLP_ENDPOINT");
+      Deno.env.delete("OTEL_SERVICE_NAME");
+    }
+
+    assertEquals(requests.length, 2, "the next batch must still be exported");
+    const body = JSON.parse(String(requests[1]?.init?.body));
+    assertEquals(
+      body.resourceMetrics[0].scopeMetrics[0].metrics.map((entry: { name: string }) => entry.name),
+      ["vf_reachable_batch_total"],
+      "a network failure degrades silently and does not poison the queue",
+    );
+  });
+
   it("routes hosted project metrics through the internal API proxy", async () => {
     const originalFetch = globalThis.fetch;
     const requests: Array<{ url: string; init?: RequestInit }> = [];
@@ -457,11 +542,14 @@ describe("metrics public SDK", () => {
     assertEquals(metric.histogram.dataPoints[0].count, 2);
     assertEquals(metric.histogram.dataPoints[0].sum, 162);
     assertEquals(
-      metric.histogram.dataPoints[0].bucketCounts.reduce(
-        (sum: number, count: number) => sum + count,
-        0,
-      ),
-      2,
+      metric.histogram.dataPoints[0].explicitBounds,
+      [0, 10, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
+      "exported histogram must carry the documented bucket boundaries",
+    );
+    assertEquals(
+      metric.histogram.dataPoints[0].bucketCounts,
+      [0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0],
+      "42ms lands in the (10,50] bucket and 120ms in the (100,250] bucket",
     );
   });
 

--- a/src/observability/application-errors.test.ts
+++ b/src/observability/application-errors.test.ts
@@ -13,6 +13,7 @@ import {
   setApplicationErrorReporter,
 } from "./application-errors.ts";
 import type { ApplicationErrorContext as SharedApplicationErrorContext } from "./application-error-contract.ts";
+import { MAX_APPLICATION_ERROR_CONTEXT_VALUE_LENGTH } from "./limits.ts";
 import {
   ASSET_OPTIMIZATION_ERROR,
   BUILD_FAILED,
@@ -82,6 +83,49 @@ it("application error reporter receives unexpected failures and correlation cont
   }]);
   assertEquals(await flushApplicationErrors(1_500), true);
   assertEquals(flushTimeout, 1_500);
+});
+
+it("application error context is redacted and length bounded before it reaches the reporter", () => {
+  const snapshots: SharedApplicationErrorContext[] = [];
+  setApplicationErrorReporter({
+    capture(_error, context) {
+      snapshots.push(context);
+      return "event-id";
+    },
+    flush: () => Promise.resolve(true),
+  });
+
+  captureApplicationError(new Error("boom"), {
+    boundary: "renderer.request",
+    requestId: "https://user:password@example.test/x?token=secret",
+    attributes: { apiKey: "secret", safe: "value" },
+  });
+
+  const redacted = snapshots[0];
+  assertEquals(
+    redacted?.attributes?.apiKey,
+    "[REDACTED]",
+    "credential-like attribute keys must be redacted before reaching the reporter",
+  );
+  assertEquals(
+    redacted?.attributes?.safe,
+    "value",
+    "non-sensitive attributes must survive sanitization",
+  );
+  assertEquals(
+    redacted?.requestId,
+    "https://user:[REDACTED]@example.test/x?token=[REDACTED]",
+    "URL credentials must be stripped from context values",
+  );
+
+  captureApplicationError(new Error("boom"), {
+    boundary: "b".repeat(MAX_APPLICATION_ERROR_CONTEXT_VALUE_LENGTH + 50),
+  });
+  assertEquals(
+    snapshots[1]?.boundary.length,
+    MAX_APPLICATION_ERROR_CONTEXT_VALUE_LENGTH,
+    "context values are truncated to the documented cap",
+  );
 });
 
 it("application error context exports process role from the shared contract", () => {

--- a/src/observability/auto-instrument.test.ts
+++ b/src/observability/auto-instrument.test.ts
@@ -13,8 +13,13 @@ import "#veryfront/schemas/_test-setup.ts";
  * - Edge cases and error scenarios
  */
 
-import { assertEquals, assertExists, assertStrictEquals } from "#veryfront/testing/assert.ts";
-import { beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertStrictEquals,
+} from "#veryfront/testing/assert.ts";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { delay } from "#std/async.ts";
 import { scaleMs } from "#veryfront/testing/timing.ts";
 
@@ -32,13 +37,95 @@ import {
 import { __resetAutoInstrumentForTests } from "./auto-instrument/orchestrator.ts";
 import { metricsManager } from "./metrics/manager.ts";
 import {
+  _resetShimForTests,
+  type AttributeValue,
+  setGlobalTracerProvider,
+  type Span,
+  type Tracer,
+} from "./tracing/api-shim.ts";
+import { initTracing, shutdownTracing } from "./tracing/index.ts";
+import {
   createResolvedFetch,
   createThrowingFetch,
   withMockFetch,
 } from "./auto-instrument.test-helpers.ts";
 
+type RecordedSpan = {
+  name: string;
+  attributes: Record<string, AttributeValue>;
+};
+
+function createRecordingTracer(recorded: RecordedSpan[]): Tracer {
+  const openSpan = (name: string, attributes: Record<string, AttributeValue>): Span => {
+    const record: RecordedSpan = { name, attributes: { ...attributes } };
+    recorded.push(record);
+    const span: Span = {
+      setAttribute(key, value) {
+        record.attributes[key] = value;
+        return span;
+      },
+      setAttributes(attrs) {
+        Object.assign(record.attributes, attrs);
+        return span;
+      },
+      setStatus() {
+        return span;
+      },
+      recordException() {},
+      addEvent() {
+        return span;
+      },
+      end() {},
+      spanContext() {
+        return { traceId: "1".repeat(32), spanId: "1".repeat(16), traceFlags: 1 };
+      },
+      updateName() {},
+    };
+    return span;
+  };
+
+  return {
+    startSpan(name: string, options?: { attributes?: Record<string, AttributeValue> }) {
+      return openSpan(name, options?.attributes ?? {});
+    },
+    startActiveSpan(
+      name: string,
+      optionsOrFn: { attributes?: Record<string, AttributeValue> } | ((span: Span) => unknown),
+      contextOrFn?: unknown,
+      fn?: (span: Span) => unknown,
+    ) {
+      const options = typeof optionsOrFn === "function" ? {} : optionsOrFn;
+      const callback = typeof optionsOrFn === "function"
+        ? optionsOrFn
+        : typeof contextOrFn === "function"
+        ? contextOrFn as (span: Span) => unknown
+        : fn!;
+      return callback(openSpan(name, options.attributes ?? {}));
+    },
+  } as unknown as Tracer;
+}
+
+/** Record spans opened through the api-shim tracer (HTTP/fetch instrumentation). */
+function installRecordingTracer(): RecordedSpan[] {
+  const recorded: RecordedSpan[] = [];
+  setGlobalTracerProvider({ getTracer: () => createRecordingTracer(recorded) });
+  return recorded;
+}
+
+/** Record spans opened through the tracing manager (wrappers, React instrumentation). */
+async function installRecordingTracerRuntime(): Promise<RecordedSpan[]> {
+  const recorded = installRecordingTracer();
+  await initTracing({ enabled: true, exporter: "console" });
+  return recorded;
+}
+
 beforeEach((): void => {
   __resetAutoInstrumentForTests();
+});
+
+afterEach((): void => {
+  shutdownTracing();
+  _resetShimForTests();
 });
 
 describe("Auto-Instrumentation", () => {
@@ -339,9 +426,15 @@ describe("Auto-Instrumentation", () => {
 
   describe("instrumentFetch", () => {
     it("should instrument global fetch", () => {
-      withMockFetch(globalThis.fetch, () => {
-        instrumentFetch();
-        assertEquals(typeof globalThis.fetch, "function");
+      const baseFetch = createResolvedFetch(new Response("OK"));
+      withMockFetch(baseFetch, () => {
+        const instrumented = instrumentFetch();
+        assertEquals(typeof instrumented, "function");
+        assertEquals(
+          instrumented === baseFetch,
+          false,
+          "instrumentFetch must return a wrapper around the base fetch",
+        );
       });
     });
 
@@ -351,86 +444,175 @@ describe("Auto-Instrumentation", () => {
       });
     });
 
-    it("should create span for fetch calls with string URL", () => {
-      withMockFetch(createResolvedFetch(new Response("OK")), () => {
-        instrumentFetch();
-        assertExists(globalThis.fetch);
+    it("should create span for fetch calls with string URL", async () => {
+      const recorded = installRecordingTracer();
+      await withMockFetch(createResolvedFetch(new Response("OK")), async () => {
+        await instrumentFetch()("https://example.test/string-url");
       });
+
+      assertEquals(
+        recorded[0]?.name,
+        "http.client.fetch",
+        "a string URL fetch must open a client span",
+      );
+      assertEquals(
+        recorded[0]?.attributes["http.target"],
+        "/string-url",
+        "the client span records the requested path",
+      );
     });
 
-    it("should create span for fetch calls with URL object", () => {
-      withMockFetch(createResolvedFetch(new Response("OK")), () => {
-        instrumentFetch();
-        assertExists(globalThis.fetch);
+    it("should create span for fetch calls with URL object", async () => {
+      const recorded = installRecordingTracer();
+      await withMockFetch(createResolvedFetch(new Response("OK")), async () => {
+        await instrumentFetch()(new URL("https://example.test/url-object"));
       });
+
+      assertEquals(
+        recorded[0]?.attributes["http.target"],
+        "/url-object",
+        "a URL object fetch records the requested path",
+      );
+      assertEquals(
+        recorded[0]?.attributes["http.host"],
+        "example.test",
+        "a URL object fetch records the requested host",
+      );
     });
 
-    it("should create span for fetch calls with Request object", () => {
-      withMockFetch(createResolvedFetch(new Response("OK")), () => {
-        instrumentFetch();
-        assertExists(globalThis.fetch);
+    it("should create span for fetch calls with Request object", async () => {
+      const recorded = installRecordingTracer();
+      await withMockFetch(createResolvedFetch(new Response("OK")), async () => {
+        await instrumentFetch()(
+          new Request("https://example.test/request-object", { method: "PUT" }),
+        );
       });
+
+      assertEquals(
+        recorded[0]?.attributes["http.target"],
+        "/request-object",
+        "a Request object fetch records the requested path",
+      );
+      assertEquals(
+        recorded[0]?.attributes["http.method"],
+        "PUT",
+        "a Request object fetch records its own method",
+      );
     });
 
-    it("should record HTTP method from init options", () => {
-      withMockFetch(createResolvedFetch(new Response("OK")), () => {
-        instrumentFetch();
-        assertExists(globalThis.fetch);
+    it("should record HTTP method from init options", async () => {
+      const recorded = installRecordingTracer();
+      await withMockFetch(createResolvedFetch(new Response("OK")), async () => {
+        await instrumentFetch()("https://example.test/items", { method: "POST" });
       });
+
+      assertEquals(
+        recorded[0]?.attributes["http.method"],
+        "POST",
+        "the client span records the method from init options",
+      );
     });
 
-    it("should default to GET method when not specified", () => {
-      withMockFetch(createResolvedFetch(new Response("OK")), () => {
-        instrumentFetch();
-        assertExists(globalThis.fetch);
+    it("should default to GET method when not specified", async () => {
+      const recorded = installRecordingTracer();
+      await withMockFetch(createResolvedFetch(new Response("OK")), async () => {
+        await instrumentFetch()("https://example.test/items");
       });
+
+      assertEquals(
+        recorded[0]?.attributes["http.method"],
+        "GET",
+        "fetch span defaults the method to GET",
+      );
     });
 
-    it("should record response status and content length", () => {
-      withMockFetch(
+    it("should record response status and content length", async () => {
+      const recorded = installRecordingTracer();
+      await withMockFetch(
         createResolvedFetch(
           new Response("test", {
             status: 200,
             headers: { "content-length": "4" },
           }),
         ),
-        () => {
-          instrumentFetch();
-          assertExists(globalThis.fetch);
+        async () => {
+          await instrumentFetch()("https://example.test/items");
         },
+      );
+
+      assertEquals(
+        recorded[0]?.attributes["http.status_code"],
+        200,
+        "fetch span records the response status",
+      );
+      assertEquals(
+        recorded[0]?.attributes["http.response.size"],
+        4,
+        "fetch span records the response content-length",
       );
     });
 
-    it("should measure fetch duration", () => {
-      withMockFetch(
+    it("should measure fetch duration", async () => {
+      const recorded = installRecordingTracer();
+      await withMockFetch(
         (async () => {
           await delay(10);
           return new Response("OK");
         }) as typeof fetch,
-        () => {
-          instrumentFetch();
-          assertExists(globalThis.fetch);
+        async () => {
+          await instrumentFetch()("https://example.test/slow");
         },
+      );
+
+      assertEquals(
+        Number(recorded[0]?.attributes["http.duration_ms"]) >= scaleMs(8),
+        true,
+        "fetch span records the measured request duration",
       );
     });
 
-    it("should handle fetch errors", () => {
-      withMockFetch(
+    it("should handle fetch errors", async () => {
+      const recorded = installRecordingTracer();
+      await withMockFetch(
         createThrowingFetch(new Error("Network error")),
-        () => {
-          instrumentFetch();
-          assertExists(globalThis.fetch);
+        async () => {
+          await assertRejects(
+            () => instrumentFetch()("https://example.test/items"),
+            Error,
+            "Network error",
+          );
         },
+      );
+
+      assertEquals(
+        recorded[0]?.attributes["error"],
+        "true",
+        "a failed fetch marks its span as errored",
+      );
+      assertEquals(
+        recorded[0]?.attributes["error.message"],
+        "Network error",
+        "a failed fetch records the failure message",
       );
     });
 
-    it("should record error type on fetch failure", () => {
-      withMockFetch(
+    it("should record error type on fetch failure", async () => {
+      const recorded = installRecordingTracer();
+      await withMockFetch(
         createThrowingFetch(new TypeError("Failed to fetch")),
-        () => {
-          instrumentFetch();
-          assertExists(globalThis.fetch);
+        async () => {
+          await assertRejects(
+            () => instrumentFetch()("https://example.test/items"),
+            TypeError,
+            "Failed to fetch",
+          );
         },
+      );
+
+      assertEquals(
+        recorded[0]?.attributes["error.type"],
+        "TypeError",
+        "fetch failures record the error type",
       );
     });
   });
@@ -567,36 +749,57 @@ describe("Auto-Instrumentation", () => {
     });
 
     it("should instrument error handler without span capture", async () => {
+      const recorded = await installRecordingTracerRuntime();
       const handler = (error: Error): Response => new Response(error.message, { status: 500 });
       const instrumented = instrumentErrorHandler(handler, false);
 
       const error = new Error("Test error");
       const response = await instrumented(error);
 
-      assertExists(response);
+      assertEquals(await response.text(), "Test error");
+      assertEquals(recorded.length, 0, "captureToSpan=false must not open an error span");
     });
 
     it("should record error type and message", async () => {
+      const recorded = await installRecordingTracerRuntime();
       const handler = (_error: Error): Response => new Response("Error handled", { status: 500 });
       const instrumented = instrumentErrorHandler(handler);
 
       const error = new Error("Custom error");
       await instrumented(error);
 
-      assertExists(instrumented);
+      assertEquals(recorded[0]?.name, "error.handler", "error capture opens an error.handler span");
+      assertEquals(
+        recorded[0]?.attributes["error.type"],
+        "Error",
+        "the captured span records the error type",
+      );
+      assertEquals(
+        recorded[0]?.attributes["error.message"],
+        "Custom error",
+        "the captured span records the error message",
+      );
     });
 
     it("should record error stack trace", async () => {
+      const recorded = await installRecordingTracerRuntime();
       const handler = (): Response => new Response("OK", { status: 500 });
       const instrumented = instrumentErrorHandler(handler);
 
       const error = new Error("Error with stack");
       await instrumented(error);
 
-      assertExists(instrumented);
+      const stack = recorded[0]?.attributes["error.stack"];
+      assertEquals(typeof stack, "string", "the captured span records a stack trace");
+      assertEquals(
+        String(stack).includes("Error with stack"),
+        true,
+        "the recorded stack belongs to the captured error",
+      );
     });
 
     it("should include request context when provided", async () => {
+      const recorded = await installRecordingTracerRuntime();
       const handler = (): Response => new Response("Error", { status: 500 });
       const instrumented = instrumentErrorHandler(handler);
 
@@ -604,10 +807,20 @@ describe("Auto-Instrumentation", () => {
       const request = new Request("http://localhost:3000/error-path");
       await instrumented(error, request);
 
-      assertExists(instrumented);
+      assertEquals(
+        recorded[0]?.attributes["http.path"],
+        "/error-path",
+        "request context adds the request path to the error span",
+      );
+      assertEquals(
+        recorded[0]?.attributes["http.method"],
+        "GET",
+        "request context adds the request method to the error span",
+      );
     });
 
     it("should record HTTP method and URL from request", async () => {
+      const recorded = await installRecordingTracerRuntime();
       const handler = (): Response => new Response("Error", { status: 500 });
       const instrumented = instrumentErrorHandler(handler);
 
@@ -615,7 +828,16 @@ describe("Auto-Instrumentation", () => {
       const request = new Request("http://localhost:3000/api/fail", { method: "POST" });
       await instrumented(error, request);
 
-      assertExists(instrumented);
+      assertEquals(
+        recorded[0]?.attributes["http.method"],
+        "POST",
+        "the error span records the request method",
+      );
+      assertEquals(
+        recorded[0]?.attributes["http.path"],
+        "/api/fail",
+        "the error span records the request path",
+      );
     });
   });
 
@@ -743,29 +965,33 @@ describe("Auto-Instrumentation", () => {
 
     it("should respect batch size", async () => {
       const items = Array.from({ length: 25 }, (_, i) => i);
-      const batches: number[][] = [];
-      let currentBatch: number[] = [];
+      const processed: number[] = [];
+      let inFlight = 0;
+      let maxInFlight = 0;
 
       await instrumentBatch(
         "sized.batch",
         items,
-        // deno-lint-ignore require-await
         async (item: number) => {
-          currentBatch.push(item);
-          if (currentBatch.length !== 10) return;
-
-          batches.push([...currentBatch]);
-          currentBatch = [];
+          inFlight++;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await Promise.resolve();
+          processed.push(item);
+          inFlight--;
         },
-        { batchSize: 10 },
+        { batchSize: 4 },
       );
 
-      if (currentBatch.length) batches.push(currentBatch);
-
-      assertExists(instrumentBatch);
+      assertEquals(
+        maxInFlight,
+        4,
+        "instrumentBatch must run at most batchSize items concurrently",
+      );
+      assertEquals(processed.length, 25, "all items must still be processed");
     });
 
     it("should record batch metadata", async () => {
+      const recorded = await installRecordingTracerRuntime();
       const items = Array.from({ length: 15 }, (_, i) => i);
 
       await instrumentBatch("metadata.batch", items, () => Promise.resolve(), {
@@ -773,7 +999,32 @@ describe("Auto-Instrumentation", () => {
         attributes: { operation: "test", source: "unit-test" },
       });
 
-      assertExists(instrumentBatch);
+      const batchSpan = recorded.find((span) => span.name === "metadata.batch");
+      assertEquals(
+        batchSpan?.attributes["batch.total_items"],
+        15,
+        "the batch span records the total item count",
+      );
+      assertEquals(
+        batchSpan?.attributes["batch.size"],
+        5,
+        "the batch span records the caller-requested batch size",
+      );
+      assertEquals(
+        batchSpan?.attributes["batch.total_batches"],
+        3,
+        "the batch span records the number of batches it will run",
+      );
+      assertEquals(
+        batchSpan?.attributes["operation"],
+        "test",
+        "caller attributes are merged into the batch span",
+      );
+      assertEquals(
+        recorded.filter((span) => span.name === "metadata.batch.batch").length,
+        3,
+        "one child span is opened per processed batch",
+      );
     });
 
     it("should handle batch processing errors", async () => {
@@ -802,16 +1053,35 @@ describe("Auto-Instrumentation", () => {
     });
 
     it("should handle empty batch", async () => {
-      await instrumentBatch("empty.batch", [], async () => {});
-      assertExists(instrumentBatch);
+      let processorRan = false;
+      // deno-lint-ignore require-await
+      await instrumentBatch("empty.batch", [], async () => {
+        processorRan = true;
+      });
+
+      assertEquals(processorRan, false, "an empty batch must never invoke the processor");
     });
 
     it("should calculate correct batch count", async () => {
       const items = Array.from({ length: 23 }, (_, i) => i);
+      const processed: number[] = [];
+      let inFlight = 0;
+      let maxInFlight = 0;
 
-      await instrumentBatch("counted.batch", items, async () => {}, { batchSize: 7 });
+      await instrumentBatch("counted.batch", items, async (item: number) => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await Promise.resolve();
+        processed.push(item);
+        inFlight--;
+      }, { batchSize: 7 });
 
-      assertExists(instrumentBatch);
+      assertEquals(
+        maxInFlight,
+        7,
+        "a 23 item run at batchSize 7 must never exceed 7 concurrent items",
+      );
+      assertEquals(processed.length, 23, "all items must still be processed");
     });
   });
 

--- a/src/observability/auto-instrument/http-instrumentation.test.ts
+++ b/src/observability/auto-instrument/http-instrumentation.test.ts
@@ -4,12 +4,15 @@ import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   _resetShimForTests,
   type AttributeValue,
+  propagation,
   setGlobalContextAccessor,
   setGlobalTracerProvider,
   type Span,
   type Tracer,
 } from "../tracing/api-shim.ts";
 import { createInstrumentedFetch, instrumentHttpHandler } from "./http-instrumentation.ts";
+
+const TEST_TRACEPARENT = `00-${"1".repeat(32)}-${"1".repeat(16)}-01`;
 
 type SpanFailure = "setAttributes" | "recordException" | "end";
 type ActiveSpanBehavior = "duplicate" | "omit" | "replace" | "throw-after";
@@ -122,6 +125,13 @@ describe("observability/auto-instrument/http-instrumentation", () => {
     installTracer(undefined, (attributes) => {
       spanAttributes = attributes;
     });
+    propagation.setGlobalPropagator({
+      inject: (_ctx, carrier, setter) => {
+        setter?.set(carrier, "traceparent", TEST_TRACEPARENT);
+      },
+      extract: (ctx) => ctx,
+      fields: () => ["traceparent"],
+    });
 
     let received: Request | undefined;
     const baseFetch = ((input: RequestInfo | URL, init?: RequestInit) => {
@@ -143,6 +153,11 @@ describe("observability/auto-instrument/http-instrumentation", () => {
     assertEquals(received?.headers.get("authorization"), "Bearer <TOKEN>");
     assertEquals(received?.headers.get("x-request-id"), "request-1");
     assertEquals(spanAttributes["http.method"], "POST");
+    assertEquals(
+      received?.headers.get("traceparent"),
+      TEST_TRACEPARENT,
+      "outbound fetch must carry the injected trace context",
+    );
   });
 
   it("runs HTTP handlers exactly once despite adversarial active-span providers", async () => {

--- a/src/observability/auto-instrument/orchestrator.test.ts
+++ b/src/observability/auto-instrument/orchestrator.test.ts
@@ -1,15 +1,21 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
-import { beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   __resetAutoInstrumentForTests,
   initAutoInstrumentation,
   isAutoInstrumentEnabled,
 } from "./orchestrator.ts";
+import { getTracingState, shutdownTracing } from "../tracing/index.ts";
 
 describe("observability/auto-instrument/orchestrator", () => {
   beforeEach(() => {
     __resetAutoInstrumentForTests();
+    shutdownTracing();
+  });
+
+  afterEach(() => {
+    shutdownTracing();
   });
 
   describe("isAutoInstrumentEnabled", () => {
@@ -56,13 +62,48 @@ describe("observability/auto-instrument/orchestrator", () => {
       assertEquals(isAutoInstrumentEnabled(), true);
     });
 
+    it("should start the tracing runtime when tracing is enabled", async () => {
+      await initAutoInstrumentation({
+        tracing: { enabled: true, exporter: "console" },
+        metrics: { enabled: false },
+      });
+
+      assertEquals(
+        getTracingState().initialized,
+        true,
+        "enabled tracing config must reach initTracing",
+      );
+    });
+
+    it("should leave the tracing runtime down when tracing is disabled", async () => {
+      await initAutoInstrumentation({ tracing: { enabled: false } });
+
+      assertEquals(
+        getTracingState().initialized,
+        false,
+        "disabled tracing config must not start the tracer",
+      );
+    });
+
     it("should not reinitialize if already initialized", async () => {
       await initAutoInstrumentation({ tracing: { enabled: false } });
       assertEquals(isAutoInstrumentEnabled(), true);
+      shutdownTracing();
+      assertEquals(
+        getTracingState().initialized,
+        false,
+        "precondition: the tracing runtime is down",
+      );
 
       await initAutoInstrumentation({
         tracing: { enabled: true, exporter: "console" },
       });
+
+      assertEquals(
+        getTracingState().initialized,
+        false,
+        "a duplicate initAutoInstrumentation must not start tracing",
+      );
       assertEquals(isAutoInstrumentEnabled(), true);
     });
 

--- a/src/observability/auto-instrument/wrappers.test.ts
+++ b/src/observability/auto-instrument/wrappers.test.ts
@@ -1,7 +1,91 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertRejects,
+  assertStrictEquals,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  _resetShimForTests,
+  installGlobalTelemetryAPI,
+  type Span,
+  SpanKind,
+  SpanStatusCode,
+  type Tracer,
+  type TracerProvider,
+} from "../tracing/api-shim.ts";
+import { initTracing, shutdownTracing } from "../tracing/index.ts";
 import { instrument, instrumentBatch, instrumentSync } from "./wrappers.ts";
+
+interface RecordedSpan {
+  name: string;
+  kind: unknown;
+  attributes: Record<string, unknown>;
+  exceptions: unknown[];
+  status: { code: number; message?: string } | undefined;
+  ended: boolean;
+}
+
+function createRecordingProvider(recorded: RecordedSpan[]): TracerProvider {
+  const tracer: Tracer = {
+    startSpan(name, options) {
+      const entry: RecordedSpan = {
+        name,
+        kind: options?.kind,
+        attributes: { ...(options?.attributes ?? {}) },
+        exceptions: [],
+        status: undefined,
+        ended: false,
+      };
+      recorded.push(entry);
+      const span: Span = {
+        setAttribute(key, value) {
+          entry.attributes[key] = value;
+          return span;
+        },
+        setAttributes(attrs) {
+          Object.assign(entry.attributes, attrs);
+          return span;
+        },
+        setStatus(status) {
+          entry.status = status;
+          return span;
+        },
+        recordException(error) {
+          entry.exceptions.push(error);
+        },
+        addEvent: () => span,
+        end() {
+          entry.ended = true;
+        },
+        spanContext: () => ({ traceId: "0".repeat(32), spanId: "0".repeat(16), traceFlags: 1 }),
+        updateName: () => {},
+      };
+      return span;
+    },
+    startActiveSpan: ((_name: string, ...args: unknown[]) => {
+      const callback = args.find((arg) => typeof arg === "function") as (span: Span) => unknown;
+      return callback(tracer.startSpan(_name));
+    }) as Tracer["startActiveSpan"],
+  };
+  return { getTracer: () => tracer };
+}
+
+/** Run `body` against a live tracer that records every span the wrappers emit. */
+async function withRecordingTracer(
+  body: (recorded: RecordedSpan[]) => void | Promise<void>,
+): Promise<void> {
+  const recorded: RecordedSpan[] = [];
+  installGlobalTelemetryAPI({ tracerProvider: createRecordingProvider(recorded) });
+  try {
+    await initTracing({ enabled: true, serviceName: "wrappers-test" });
+    await body(recorded);
+  } finally {
+    shutdownTracing();
+    _resetShimForTests();
+  }
+}
 
 describe("observability/auto-instrument/wrappers", () => {
   describe("instrument (async wrapper)", () => {
@@ -38,19 +122,77 @@ describe("observability/auto-instrument/wrappers", () => {
     });
 
     it("should accept instrument options with kind", async () => {
-      const fn = (): Promise<string> => Promise.resolve("ok");
-      const wrapped = instrument(fn, "test.server", { kind: "server" });
-      const result = await wrapped();
-      assertEquals(result, "ok");
+      await withRecordingTracer(async (recorded) => {
+        const fn = (): Promise<string> => Promise.resolve("ok");
+        const wrapped = instrument(fn, "test.server", { kind: "server" });
+        const result = await wrapped();
+        assertEquals(result, "ok");
+        assertEquals(recorded.length, 1, "the wrapped call starts exactly one span");
+        assertEquals(recorded[0]?.name, "test.server", "the span name reaches the tracer");
+        assertEquals(
+          recorded[0]?.kind,
+          SpanKind.SERVER,
+          "options.kind must reach startSpan as SpanKind.SERVER",
+        );
+      });
+    });
+
+    it("defaults the span kind to internal when no kind is supplied", async () => {
+      await withRecordingTracer(async (recorded) => {
+        const wrapped = instrument(() => Promise.resolve("ok"), "test.default-kind");
+        assertEquals(await wrapped(), "ok");
+        assertEquals(
+          recorded[0]?.kind,
+          SpanKind.INTERNAL,
+          "a missing kind must reach startSpan as SpanKind.INTERNAL",
+        );
+      });
     });
 
     it("should accept instrument options with attributes factory", async () => {
-      const fn = (userId: string): Promise<string> => Promise.resolve(userId);
-      const wrapped = instrument(fn, "test.user", {
-        attributes: (args) => ({ userId: args[0] as string }),
+      await withRecordingTracer(async (recorded) => {
+        const fn = (userId: string): Promise<string> => Promise.resolve(userId);
+        const wrapped = instrument(fn, "test.user", {
+          attributes: (args) => ({ userId: args[0] as string }),
+        });
+        const result = await wrapped("u-123");
+        assertEquals(result, "u-123");
+        assertEquals(
+          recorded[0]?.attributes.userId,
+          "u-123",
+          "the attributes factory output must reach the started span",
+        );
+        assertEquals(
+          typeof recorded[0]?.attributes.duration_ms,
+          "number",
+          "instrument must record duration_ms on the span",
+        );
+        assertEquals(
+          (recorded[0]?.attributes.duration_ms as number) >= 0,
+          true,
+          "duration_ms must be a non-negative measurement",
+        );
       });
-      const result = await wrapped("u-123");
-      assertEquals(result, "u-123");
+    });
+
+    it("records the thrown error on the span before rethrowing", async () => {
+      await withRecordingTracer(async (recorded) => {
+        const boom = new Error("async failure");
+        const wrapped = instrument((): Promise<never> => {
+          throw boom;
+        }, "test.fail-span");
+        await assertRejects(() => wrapped(), Error, "async failure");
+        assertStrictEquals(
+          (recorded[0]?.exceptions[0] as Error | undefined)?.message,
+          boom.message,
+          "a failed span must record the thrown error",
+        );
+        assertEquals(
+          recorded[0]?.status?.code,
+          SpanStatusCode.ERROR,
+          "a failed span must close with error status",
+        );
+      });
     });
 
     it("should handle functions that return resolved promises", async () => {
@@ -103,6 +245,26 @@ describe("observability/auto-instrument/wrappers", () => {
       const fn = (): string => "ok";
       const wrapped = instrumentSync(fn, "test.internal", { kind: "internal" });
       assertEquals(wrapped(), "ok");
+    });
+
+    it("records the thrown error on the span before rethrowing", async () => {
+      await withRecordingTracer((recorded) => {
+        const boom = new Error("sync failure");
+        const wrapped = instrumentSync((): never => {
+          throw boom;
+        }, "test.fail-span");
+        assertThrows(() => wrapped(), Error, "sync failure");
+        assertStrictEquals(
+          (recorded[0]?.exceptions[0] as Error | undefined)?.message,
+          boom.message,
+          "a failed span must record the thrown error",
+        );
+        assertEquals(
+          recorded[0]?.status?.code,
+          SpanStatusCode.ERROR,
+          "a failed span must close with error status",
+        );
+      });
     });
 
     it("should accept instrument options with attributes factory", () => {
@@ -162,27 +324,39 @@ describe("observability/auto-instrument/wrappers", () => {
     it("should respect custom batch size", async () => {
       const items = Array.from({ length: 15 }, (_, i) => i);
       const processed: number[] = [];
+      let inFlight = 0;
+      let peak = 0;
       await instrumentBatch(
         "test.sized",
         items,
-        // deno-lint-ignore require-await
         async (item) => {
+          inFlight++;
+          peak = Math.max(peak, inFlight);
           processed.push(item);
+          await Promise.resolve();
+          inFlight--;
         },
         { batchSize: 5 },
       );
       assertEquals(processed.length, 15);
       assertEquals(processed, items);
+      assertEquals(peak, 5, "batchSize 5 must cap concurrent processors at 5");
     });
 
     it("should default to batch size of 10", async () => {
       const items = Array.from({ length: 25 }, (_, i) => i);
       const processed: number[] = [];
-      // deno-lint-ignore require-await
+      let inFlight = 0;
+      let peak = 0;
       await instrumentBatch("test.default-size", items, async (item) => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
         processed.push(item);
+        await Promise.resolve();
+        inFlight--;
       });
       assertEquals(processed.length, 25);
+      assertEquals(peak, 10, "the default batchSize must cap concurrent processors at 10");
     });
 
     it("should rethrow errors from processor", async () => {
@@ -198,8 +372,23 @@ describe("observability/auto-instrument/wrappers", () => {
     });
 
     it("should accept batch attributes", async () => {
-      await instrumentBatch("test.attrs", [1], async () => {}, {
-        attributes: { operation: "test", source: "unit" },
+      await withRecordingTracer(async (recorded) => {
+        await instrumentBatch("test.attrs", [1], async () => {}, {
+          attributes: { operation: "test", source: "unit" },
+        });
+
+        const batchSpan = recorded.find((span) => span.name === "test.attrs");
+        assertEquals(
+          batchSpan?.attributes,
+          {
+            "batch.total_items": 1,
+            "batch.size": 10,
+            "batch.total_batches": 1,
+            operation: "test",
+            source: "unit",
+          },
+          "caller batch attributes merge into the batch span",
+        );
       });
     });
 

--- a/src/observability/error-collector.test.ts
+++ b/src/observability/error-collector.test.ts
@@ -120,6 +120,11 @@ describe("cli/mc./error-collector", () => {
       ec.add({ type: "compile", category: "BUILD", message: "3" });
 
       assertEquals(ec.count, 2);
+      assertEquals(
+        ec.getAll().map((error) => error.message),
+        ["2", "3"],
+        "maxErrors must evict the oldest entry, not the newest",
+      );
     });
 
     it("should filter by type", () => {
@@ -159,6 +164,67 @@ describe("cli/mc./error-collector", () => {
 
       assertEquals(ec.getAll({ file: pattern }).length, 2);
       assertEquals(ec.getAll({ file: pattern }).length, 2);
+    });
+
+    it("should filter by since timestamp", () => {
+      const ec = new ErrorCollector();
+      const first = ec.addCompileError("a");
+      const second = ec.addCompileError("b");
+
+      assertEquals(
+        ec.getAll({ since: first.timestamp }).length,
+        2,
+        "since is inclusive of the cutoff timestamp",
+      );
+      assertEquals(
+        ec.getAll({ since: second.timestamp + 1 }).length,
+        0,
+        "since drops every error recorded before the cutoff",
+      );
+      assertEquals(
+        ec.getAll({ since: first.timestamp, type: "runtime" }).length,
+        0,
+        "since composes with the type filter instead of replacing it",
+      );
+    });
+
+    it("should filter by an array of types", () => {
+      const ec = new ErrorCollector();
+      ec.addCompileError("a");
+      ec.addRuntimeError("b");
+      ec.addHMRError("c");
+
+      assertEquals(
+        ec.getAll({ type: ["compile", "runtime"] }).map((error) => error.message),
+        ["a", "b"],
+        "an array type filter matches every listed type",
+      );
+    });
+
+    it("should filter by an array of categories", () => {
+      const ec = new ErrorCollector();
+      ec.addCompileError("a");
+      ec.addRuntimeError("b");
+      ec.addHMRError("c");
+
+      assertEquals(
+        ec.getAll({ category: ["BUILD", "RUNTIME"] }).map((error) => error.message),
+        ["a", "b"],
+        "an array category filter matches every listed category",
+      );
+    });
+
+    it("should filter by an array of slugs", () => {
+      const ec = new ErrorCollector();
+      ec.addCompileError("a", "src/a.ts", 1, 1, "slug-a");
+      ec.addRuntimeError("b", undefined, undefined, "slug-b");
+      ec.addRuntimeError("c", undefined, undefined, "slug-c");
+
+      assertEquals(
+        ec.getAll({ slug: ["slug-a", "slug-b"] }).map((error) => error.message),
+        ["a", "b"],
+        "an array slug filter matches every listed slug",
+      );
     });
 
     it("should redact retained error details without mutating caller context", () => {
@@ -411,6 +477,11 @@ describe("cli/mc./error-collector", () => {
       assertEquals(result?.file, "src/app.ts");
       assertEquals(result?.line, 10);
       assertEquals(result?.column, 5);
+      assertEquals(
+        result?.message,
+        "Cannot find name",
+        "TypeScript branch must extract the diagnostic text, not the file path",
+      );
     });
 
     it("should parse esbuild error format", () => {
@@ -420,6 +491,12 @@ describe("cli/mc./error-collector", () => {
       assertEquals(result?.category, "BUILD");
       assertEquals(result?.file, "mod.js");
       assertEquals(result?.line, 5);
+      assertEquals(result?.column, 12, "esbuild branch must extract the column");
+      assertEquals(
+        result?.message,
+        "Unexpected token",
+        "esbuild branch must extract the diagnostic text",
+      );
     });
 
     it("should parse generic error messages", () => {

--- a/src/observability/file-log-subscriber.test.ts
+++ b/src/observability/file-log-subscriber.test.ts
@@ -275,9 +275,11 @@ describe("observability/file-log-subscriber", () => {
     it("should rotate when file exceeds maxSize", async () => {
       const dir = await makeTempDir();
       const logPath = `${dir}/test.log`;
+      // Comfortably above three records so a rotated file must retain a run,
+      // not a single entry.
       const sub = new FileLogSubscriber(makeConfig({
         path: logPath,
-        maxSize: 100,
+        maxSize: 400,
         maxFiles: 3,
       }));
 
@@ -292,8 +294,32 @@ describe("observability/file-log-subscriber", () => {
       const mainExists = await fileExists(logPath);
       assertEquals(mainExists, true);
 
-      const rotated1 = await fileExists(`${logPath}.1`);
-      assertEquals(rotated1, true);
+      const rotated1Exists = await fileExists(`${logPath}.1`);
+      assertEquals(rotated1Exists, true);
+
+      const rotated1 = await readLoggedMessages(`${logPath}.1`);
+      assertEquals(
+        rotated1.length > 1,
+        true,
+        "a rotated file must hold every record written before the size limit, not one per entry",
+      );
+
+      const combined = [
+        ...(await fileExists(`${logPath}.2`) ? await readLoggedMessages(`${logPath}.2`) : []),
+        ...rotated1,
+        ...await readLoggedMessages(logPath),
+      ];
+      const oldestIndex = Number(combined[0]?.slice("message-".length));
+      assertEquals(
+        combined,
+        Array.from({ length: combined.length }, (_, offset) => `message-${oldestIndex + offset}`),
+        "rotation must not drop records mid-run",
+      );
+      assertEquals(
+        combined.at(-1),
+        "message-9",
+        "rotation must retain the newest record in the active file",
+      );
 
       await sub.close();
     });
@@ -880,6 +906,14 @@ describe("observability/file-log-subscriber", () => {
     });
   });
 });
+
+async function readLoggedMessages(path: string): Promise<string[]> {
+  const content = await Deno.readTextFile(path);
+  return content
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => (JSON.parse(line) as { message: string }).message);
+}
 
 async function fileExists(path: string): Promise<boolean> {
   try {

--- a/src/observability/instruments/error-instruments.test.ts
+++ b/src/observability/instruments/error-instruments.test.ts
@@ -5,11 +5,45 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { describe, it } from "#veryfront/testing/bdd";
 import { assertEquals, assertExists } from "#veryfront/testing/assert";
-import { recordError } from "./error-instruments.ts";
+import { createErrorInstruments, recordError } from "./error-instruments.ts";
 import { CONFIG_NOT_FOUND, RENDER_ERROR } from "#veryfront/errors/error-registry.ts";
-import type { Counter } from "#veryfront/observability/tracing/api-shim.ts";
+import type { Counter, Meter } from "#veryfront/observability/tracing/api-shim.ts";
 
 describe("error-instruments", () => {
+  describe("createErrorInstruments", () => {
+    it("names the error counter with the configured prefix", () => {
+      const recorded: Array<{ name: string; description?: string; unit?: string }> = [];
+      const counter = { add: () => {} } as Counter;
+      const meter = {
+        createCounter: (name: string, options?: { description?: string; unit?: string }) => {
+          recorded.push({ name, description: options?.description, unit: options?.unit });
+          return counter;
+        },
+      } as unknown as Meter;
+
+      const instruments = createErrorInstruments(meter, {
+        enabled: true,
+        exporter: "console",
+        prefix: "test",
+      });
+
+      assertEquals(
+        recorded,
+        [{
+          name: "test.error.count",
+          description: "Total errors by slug and category",
+          unit: "errors",
+        }],
+        "error counter name, description and unit are a dashboard contract",
+      );
+      assertEquals(
+        instruments.errorCounter,
+        counter,
+        "createErrorInstruments must return the counter the meter produced",
+      );
+    });
+  });
+
   describe("recordError", () => {
     it("should record error with slug, category, and status labels", () => {
       const calls: Array<{ value: number; attributes: Record<string, string> }> = [];

--- a/src/observability/instruments/memory-instruments.test.ts
+++ b/src/observability/instruments/memory-instruments.test.ts
@@ -1,6 +1,53 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { parseV8HeapLimitBytes } from "./memory-instruments.ts";
+import {
+  _resetEnvironmentConfig,
+  _setEnvironmentConfigForTesting,
+} from "#veryfront/config/environment-config.ts";
+import type {
+  Meter,
+  ObservableGauge,
+  ObservableResult,
+} from "#veryfront/observability/tracing/api-shim.ts";
+import { getMemoryUsage } from "../metrics/config.ts";
+import type { MetricsConfig } from "../metrics/types.ts";
+import {
+  createMemoryInstruments,
+  createMemoryObservableBindings,
+  parseV8HeapLimitBytes,
+} from "./memory-instruments.ts";
+
+const CONFIG: MetricsConfig = { enabled: true, exporter: "console", prefix: "test" };
+
+/** Heap limit pinned through the configured V8 flags so the percentage has a known denominator. */
+const CONFIGURED_HEAP_LIMIT_MIB = 16;
+const CONFIGURED_HEAP_LIMIT_BYTES = CONFIGURED_HEAP_LIMIT_MIB * 1024 * 1024;
+
+function createRecordingMeter(
+  created: Array<{ name: string; unit: string | undefined }>,
+): Meter {
+  const writableInstrument = { add() {}, record() {} };
+  return {
+    createCounter: () => writableInstrument,
+    createUpDownCounter: () => writableInstrument,
+    createHistogram: () => writableInstrument,
+    createObservableGauge: (name, options): ObservableGauge => {
+      created.push({ name, unit: options?.unit });
+      return { addCallback() {}, removeCallback() {} };
+    },
+  };
+}
+
+function observeBinding(callback: (result: ObservableResult) => void): Promise<number | undefined> {
+  let observed: number | undefined;
+  const result: ObservableResult = {
+    observe(value) {
+      observed = value;
+    },
+  };
+  const outcome = callback(result) as unknown;
+  return outcome instanceof Promise ? outcome.then(() => observed) : Promise.resolve(observed);
+}
 
 describe("observability/instruments/memory-instruments", () => {
   it("parses explicit V8 heap limits without deployment-specific defaults", () => {
@@ -12,5 +59,89 @@ describe("observability/instruments/memory-instruments", () => {
     assertEquals(parseV8HeapLimitBytes(""), undefined);
     assertEquals(parseV8HeapLimitBytes("--max-old-space-size=0"), undefined);
     assertEquals(parseV8HeapLimitBytes("--max-old-space-size=invalid"), undefined);
+  });
+
+  it("creates the memory gauge names and units the dashboards read", () => {
+    const created: Array<{ name: string; unit: string | undefined }> = [];
+
+    createMemoryInstruments(createRecordingMeter(created), CONFIG);
+
+    assertEquals(
+      created,
+      [
+        { name: "test.memory.usage", unit: "bytes" },
+        { name: "test.memory.heap", unit: "bytes" },
+        { name: "test.memory.heap_total", unit: "bytes" },
+        { name: "test.memory.heap_percent", unit: "percent" },
+      ],
+      "memory gauge names and units are the dashboard contract",
+    );
+  });
+
+  it("observes rss, heap, and heap utilization through their matching gauges", async () => {
+    const instruments = createMemoryInstruments(createRecordingMeter([]), CONFIG);
+    const bindings = createMemoryObservableBindings(instruments);
+
+    assertEquals(bindings.length, 4, "every memory gauge is bound to a callback");
+    assertStrictEquals(
+      bindings[0]?.instrument,
+      instruments.memoryUsageGauge,
+      "the first binding observes through the memory usage gauge",
+    );
+    assertStrictEquals(
+      bindings[1]?.instrument,
+      instruments.heapUsageGauge,
+      "the second binding observes through the heap usage gauge",
+    );
+    assertStrictEquals(
+      bindings[2]?.instrument,
+      instruments.heapTotalGauge,
+      "the third binding observes through the heap total gauge",
+    );
+    assertStrictEquals(
+      bindings[3]?.instrument,
+      instruments.heapPercentGauge,
+      "the fourth binding observes through the heap percent gauge",
+    );
+
+    _setEnvironmentConfigForTesting({
+      denoV8Flags: `--max-old-space-size=${CONFIGURED_HEAP_LIMIT_MIB}`,
+    });
+    let rss: number | undefined;
+    let heapUsed: number | undefined;
+    let heapTotal: number | undefined;
+    let heapPercent: number | undefined;
+    try {
+      rss = await observeBinding(bindings[0]!.callback);
+      heapUsed = await observeBinding(bindings[1]!.callback);
+      heapTotal = await observeBinding(bindings[2]!.callback);
+      heapPercent = await observeBinding(bindings[3]!.callback);
+    } finally {
+      _resetEnvironmentConfig();
+    }
+
+    assert(heapUsed !== undefined && heapUsed > 0, "the heap gauge observes used heap bytes");
+    assert(
+      heapTotal !== undefined && heapTotal >= heapUsed,
+      "the heap_total gauge observes allocated heap, never less than the used heap",
+    );
+    assert(
+      rss !== undefined && rss > heapTotal,
+      "the usage gauge observes resident memory, which exceeds the allocated V8 heap",
+    );
+
+    const usage = getMemoryUsage();
+    assert(usage !== null, "the host runtime reports memory usage");
+    const expectedPercent = (usage.heapUsed / CONFIGURED_HEAP_LIMIT_BYTES) * 100;
+    assert(heapPercent !== undefined, "the heap_percent gauge observes a value");
+    assert(
+      Math.abs(heapPercent - expectedPercent) <= expectedPercent * 0.02,
+      `heap_percent must be heapUsed/limit*100, expected about ${expectedPercent}, observed ${heapPercent}`,
+    );
+    assertEquals(
+      heapPercent,
+      Math.round(heapPercent * 100) / 100,
+      "heap_percent must be rounded to two decimals",
+    );
   });
 });

--- a/src/observability/instruments/stream-lifecycle-instruments.test.ts
+++ b/src/observability/instruments/stream-lifecycle-instruments.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { Meter } from "#veryfront/observability/tracing/api-shim.ts";
+import { DURATION_HISTOGRAM_BOUNDARIES_MS } from "#veryfront/config/defaults.ts";
 import type { MetricsConfig } from "../metrics/types.ts";
 import { createStreamLifecycleInstruments } from "./stream-lifecycle-instruments.ts";
 
@@ -9,14 +10,16 @@ describe("stream lifecycle instruments", () => {
   it("creates the exact bounded instrument names under the prefix", () => {
     const counters: string[] = [];
     const histograms: string[] = [];
+    const histogramOptions = new Map<string, Record<string, unknown> | undefined>();
     const meter = {
       createCounter(name: string) {
         counters.push(name);
-        return { add() {} };
+        return { name, add() {} };
       },
-      createHistogram(name: string) {
+      createHistogram(name: string, options?: Record<string, unknown>) {
         histograms.push(name);
-        return { record() {} };
+        histogramOptions.set(name, options);
+        return { name, record() {} };
       },
       createUpDownCounter() {
         return { add() {} };
@@ -26,7 +29,7 @@ describe("stream lifecycle instruments", () => {
       },
     } as unknown as Meter;
 
-    createStreamLifecycleInstruments(meter, {
+    const instruments = createStreamLifecycleInstruments(meter, {
       prefix: "veryfront",
     } as MetricsConfig);
 
@@ -44,5 +47,38 @@ describe("stream lifecycle instruments", () => {
       "veryfront.stream.lifecycle.tool_input.duration",
       "veryfront.stream.lifecycle.tool_execution.duration",
     ]);
+
+    assertEquals(
+      Object.fromEntries(
+        Object.entries(instruments).map(([field, instrument]) => [
+          field,
+          (instrument as { name?: string } | null)?.name ?? null,
+        ]),
+      ),
+      {
+        streamLifecycleOutcomeCounter: "veryfront.stream.lifecycle.outcomes",
+        streamLifecycleDeadlineCounter: "veryfront.stream.lifecycle.deadlines",
+        streamLifecycleTelemetryCounter: "veryfront.stream.lifecycle.telemetry",
+        streamLifecycleRepairCounter: "veryfront.stream.lifecycle.repairs",
+        streamLifecycleShadowDivergenceCounter: "veryfront.stream.lifecycle.shadow.divergences",
+        streamLifecycleAttemptDuration: "veryfront.stream.lifecycle.attempt.duration",
+        streamLifecycleFirstProgressDuration: "veryfront.stream.lifecycle.first_progress.duration",
+        streamLifecycleSemanticIdleDuration: "veryfront.stream.lifecycle.semantic_idle.duration",
+        streamLifecycleToolInputDuration: "veryfront.stream.lifecycle.tool_input.duration",
+        streamLifecycleToolExecutionDuration: "veryfront.stream.lifecycle.tool_execution.duration",
+      },
+      "every returned field is wired to the instrument created under its own name",
+    );
+
+    for (const name of histograms) {
+      const options = histogramOptions.get(name);
+      assertEquals(options?.unit, "ms", `${name} must be recorded in milliseconds`);
+      assertEquals(
+        (options?.advice as { explicitBucketBoundaries?: number[] } | undefined)
+          ?.explicitBucketBoundaries,
+        [...DURATION_HISTOGRAM_BOUNDARIES_MS],
+        `${name} must use the shared duration bucket boundaries`,
+      );
+    }
   });
 });

--- a/src/observability/log-buffer.test.ts
+++ b/src/observability/log-buffer.test.ts
@@ -6,6 +6,7 @@ import {
   assertThrows,
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { FakeTime } from "#std/testing/time";
 import { MAX_STRING_DISPLAY_LENGTH } from "#veryfront/utils/constants/index.ts";
 import { MAX_OBSERVABILITY_NAME_LENGTH } from "./limits.ts";
 import { interceptConsole, LogBuffer } from "./log-buffer.ts";
@@ -227,7 +228,11 @@ describe("observability/log-buffer", () => {
       buf.info("b", "src2");
 
       const results = buf.query({ source: "src1" });
-      assertEquals(results.length, 1);
+      assertEquals(
+        results.map((entry) => entry.message),
+        ["a"],
+        "source filter must return the matching entry, not the complement",
+      );
     });
 
     it("should query by string pattern", () => {
@@ -236,7 +241,39 @@ describe("observability/log-buffer", () => {
       buf.info("goodbye");
 
       const results = buf.query({ pattern: "hello" });
-      assertEquals(results.length, 1);
+      assertEquals(
+        results.map((entry) => entry.message),
+        ["hello world"],
+        "pattern filter must return the matching entry",
+      );
+    });
+
+    it("should query by since", () => {
+      using time = new FakeTime(1_000);
+      const buf = new LogBuffer();
+      buf.info("first");
+      time.tick(1_000);
+      buf.info("second");
+
+      const [first, second] = buf.getAll();
+      assertExists(first);
+      assertExists(second);
+
+      assertEquals(
+        buf.query({ since: second.timestamp }).map((entry) => entry.message),
+        ["second"],
+        "since must exclude entries older than the cutoff",
+      );
+      assertEquals(
+        buf.query({ since: second.timestamp + 1 }).length,
+        0,
+        "since must exclude entries at or before a later cutoff",
+      );
+      assertEquals(
+        buf.query({ since: first.timestamp }).map((entry) => entry.message),
+        ["first", "second"],
+        "since must keep every entry at or after the cutoff",
+      );
     });
 
     it("should query by regex pattern", () => {

--- a/src/observability/metrics/config.test.ts
+++ b/src/observability/metrics/config.test.ts
@@ -17,7 +17,11 @@ describe("observability/metrics/config", () => {
       assertEquals(DEFAULT_CONFIG.enabled, false);
       assertEquals(DEFAULT_CONFIG.exporter, "console");
       assertEquals(DEFAULT_CONFIG.prefix, "veryfront");
-      assertEquals(typeof DEFAULT_CONFIG.collectInterval, "number");
+      assertEquals(
+        DEFAULT_CONFIG.collectInterval,
+        60000,
+        "default metrics collection interval must stay at 60s",
+      );
       assertEquals(DEFAULT_CONFIG.debug, false);
     });
   });
@@ -28,6 +32,11 @@ describe("observability/metrics/config", () => {
       assertEquals(result.enabled, false);
       assertEquals(result.exporter, "console");
       assertEquals(result.prefix, "veryfront");
+      assertEquals(
+        result.collectInterval,
+        60000,
+        "empty config must resolve to the 60s default interval",
+      );
     });
 
     it("should merge user config", () => {
@@ -53,6 +62,32 @@ describe("observability/metrics/config", () => {
       assertEquals(result.enabled, true);
       assertEquals(result.endpoint, "http://localhost:4318");
       assertEquals(result.exporter, "otlp");
+    });
+
+    it("treats only the literal true as an enabling value", () => {
+      for (const value of ["false", "0", ""]) {
+        assertEquals(
+          loadConfig(
+            {},
+            adapterWithEnv({
+              get: (key) => (key === "OTEL_METRICS_ENABLED" ? value : undefined),
+            }),
+          ).enabled,
+          false,
+          `OTEL_METRICS_ENABLED=${JSON.stringify(value)} must not enable metrics`,
+        );
+      }
+
+      assertEquals(
+        loadConfig(
+          {},
+          adapterWithEnv({
+            get: (key) => (key === "OTEL_METRICS_ENABLED" ? " TRUE " : undefined),
+          }),
+        ).enabled,
+        true,
+        "OTEL_METRICS_ENABLED must be trimmed and matched case-insensitively",
+      );
     });
 
     it("should enable via VERYFRONT_OTEL=1", () => {
@@ -121,8 +156,22 @@ describe("observability/metrics/config", () => {
         }),
       );
 
-      assertEquals(result.enabled, false);
-      assertEquals(result.prefix, "configured");
+      assertEquals(
+        result.enabled,
+        false,
+        "an adapter env failure must leave enabled at the caller value",
+      );
+      assertEquals(
+        result.exporter,
+        "console",
+        "an adapter env failure must leave the exporter at the default",
+      );
+      assertEquals(
+        result.endpoint,
+        undefined,
+        "an adapter env failure must leave the endpoint unset",
+      );
+      assertEquals(result.prefix, "configured", "caller config is preserved");
     });
   });
 });

--- a/src/observability/metrics/manager.test.ts
+++ b/src/observability/metrics/manager.test.ts
@@ -91,10 +91,102 @@ describe("observability/metrics/manager", () => {
     });
 
     it("should skip duplicate initialization", async () => {
-      await manager.initialize({ enabled: false });
-      await manager.initialize({ enabled: true });
+      const calls: string[] = [];
+      const provider = createMetricsApi("A", calls);
+      let getMeterCalls = 0;
+      installGlobalTelemetryAPI({
+        metricsApi: {
+          getMeter: (name, version) => {
+            getMeterCalls++;
+            return provider.getMeter(name, version);
+          },
+        },
+      });
 
-      assertEquals(manager.isEnabled(), false);
+      await manager.initialize({ enabled: true, prefix: "first" });
+      await manager.initialize({ enabled: true, prefix: "second" });
+      manager.getRecorder()?.recordHttpRequest();
+
+      assertEquals(
+        calls,
+        ["A:first.http.requests", "A:first.http.requests.active"],
+        "a duplicate initialize is ignored: instruments keep the first prefix",
+      );
+      assertEquals(getMeterCalls, 1, "a duplicate initialize does not re-invoke getMeter");
+    });
+
+    it("keeps a disabled first initialization when a later call enables metrics", async () => {
+      const calls: string[] = [];
+      installGlobalTelemetryAPI({ metricsApi: createMetricsApi("A", calls) });
+
+      await manager.initialize({ enabled: false });
+      await manager.initialize({ enabled: true, prefix: "second" });
+
+      assertEquals(manager.isEnabled(), false, "a duplicate initialize must not enable metrics");
+      assertEquals(calls, [], "a duplicate initialize must not create instruments");
+    });
+
+    it("recovers after a transient instrument failure", async () => {
+      const calls: string[] = [];
+      const provider = createMetricsApi("A", calls);
+      let failing = true;
+      installGlobalTelemetryAPI({
+        metricsApi: {
+          getMeter: (name, version) => {
+            const meter = provider.getMeter(name, version);
+            return {
+              ...meter,
+              createHistogram: (histogramName, options) => {
+                if (failing) throw new Error("histogram backend unavailable");
+                return meter.createHistogram(histogramName, options);
+              },
+            };
+          },
+        },
+      });
+
+      await manager.initialize({ enabled: true, prefix: "test" });
+      assertEquals(
+        manager.isEnabled(),
+        false,
+        "a partial instrument set must not be treated as enabled",
+      );
+
+      failing = false;
+      assertEquals(
+        manager.isEnabled(),
+        true,
+        "a later call must retry after a transient provider failure",
+      );
+      manager.getRecorder()?.recordHttpRequest();
+      assertEquals(
+        calls,
+        ["A:test.http.requests", "A:test.http.requests.active"],
+        "the retried instruments record through the recovered provider",
+      );
+    });
+
+    it("stays fail-open when the metrics provider throws", async () => {
+      installGlobalTelemetryAPI({
+        metricsApi: {
+          getMeter: () => {
+            throw new Error("meter unavailable");
+          },
+        },
+      });
+
+      await manager.initialize({ enabled: true, prefix: "test" });
+
+      assertEquals(
+        manager.isEnabled(),
+        false,
+        "a throwing getMeter must not propagate to callers",
+      );
+      assertEquals(
+        manager.getState().initialized,
+        true,
+        "getState must remain callable after a provider failure",
+      );
     });
 
     it("should accept empty config", async () => {
@@ -125,19 +217,41 @@ describe("observability/metrics/manager", () => {
       const calls: string[] = [];
       installGlobalTelemetryAPI({ metricsApi: createMetricsApi("A", calls) });
       await manager.initialize({ enabled: true, prefix: "test" });
+      manager.getRecorder()?.recordHttpRequest();
+      manager.getRecorder()?.setCacheSize(7);
+      assertEquals(
+        manager.getState(),
+        { initialized: true, cacheSize: 7, activeRequests: 1 },
+        "runtime counters are live before shutdown",
+      );
+
       manager.shutdown();
 
-      assertEquals(manager.getState(), {
-        initialized: false,
-        cacheSize: 0,
-        activeRequests: 0,
-      });
+      assertEquals(
+        manager.getState(),
+        {
+          initialized: false,
+          cacheSize: 0,
+          activeRequests: 0,
+        },
+        "shutdown resets runtime counters so they do not leak into the next initialization",
+      );
       assertEquals(manager.isEnabled(), false);
 
       installGlobalTelemetryAPI({ metricsApi: createMetricsApi("B", calls) });
       await manager.initialize({ enabled: true, prefix: "test" });
+      assertEquals(
+        manager.getState(),
+        { initialized: true, cacheSize: 0, activeRequests: 0 },
+        "a fresh initialization starts from zeroed runtime counters",
+      );
       manager.getRecorder()?.recordHttpRequest();
-      assertEquals(calls, ["B:test.http.requests", "B:test.http.requests.active"]);
+      assertEquals(calls, [
+        "A:test.http.requests",
+        "A:test.http.requests.active",
+        "B:test.http.requests",
+        "B:test.http.requests.active",
+      ]);
     });
 
     it("should not throw when not initialized", () => {

--- a/src/observability/metrics/metrics.test.ts
+++ b/src/observability/metrics/metrics.test.ts
@@ -1,7 +1,31 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  _resetShimForTests,
+  installGlobalTelemetryAPI,
+  type Meter,
+  type MetricsAPI,
+} from "#veryfront/observability/tracing/api-shim.ts";
 import { MetricsManager } from "./manager.ts";
+
+/** Metrics API double that records every instrument the manager creates. */
+function createRecordingMetricsApi(created: string[]): MetricsAPI {
+  const instrument = (name: string) => {
+    created.push(name);
+    return { add: () => {}, record: () => {} };
+  };
+  const meter: Meter = {
+    createCounter: (name) => instrument(name),
+    createUpDownCounter: (name) => instrument(name),
+    createHistogram: (name) => instrument(name),
+    createObservableGauge: (name) => {
+      created.push(name);
+      return { addCallback: () => {}, removeCallback: () => {} };
+    },
+  };
+  return { getMeter: () => meter };
+}
 
 function createMockAdapter(
   envVars: Record<string, string> = {},
@@ -149,9 +173,30 @@ describe("Metrics Module", () => {
     });
 
     it("should skip duplicate initialization attempts", async () => {
-      await manager.initialize({ enabled: false });
-      await manager.initialize({ enabled: true });
-      assertEquals(manager.isEnabled(), false);
+      const created: string[] = [];
+      const owner = installGlobalTelemetryAPI({
+        metricsApi: createRecordingMetricsApi(created),
+      });
+
+      try {
+        await manager.initialize({ enabled: false, prefix: "first" });
+        await manager.initialize({ enabled: true, prefix: "second" });
+
+        assertEquals(
+          created,
+          [],
+          "a duplicate initialize must not create instruments from the second config",
+        );
+        assertEquals(
+          manager.isEnabled(),
+          false,
+          "the first disabled configuration still owns the manager",
+        );
+      } finally {
+        manager.shutdown();
+        owner.dispose();
+        _resetShimForTests();
+      }
     });
 
     it("should accept partial config", async () => {

--- a/src/observability/metrics/recorder.test.ts
+++ b/src/observability/metrics/recorder.test.ts
@@ -70,6 +70,17 @@ function createMockInstruments(): MetricsInstruments & {
   _dataFetchErrorCounter: MockCounter;
   _corsRejectionCounter: MockCounter;
   _securityHeadersCounter: MockCounter;
+  _errorCounter: MockCounter;
+  _streamLifecycleOutcomeCounter: MockCounter;
+  _streamLifecycleDeadlineCounter: MockCounter;
+  _streamLifecycleTelemetryCounter: MockCounter;
+  _streamLifecycleRepairCounter: MockCounter;
+  _streamLifecycleShadowDivergenceCounter: MockCounter;
+  _streamLifecycleAttemptDuration: MockHistogram;
+  _streamLifecycleFirstProgressDuration: MockHistogram;
+  _streamLifecycleSemanticIdleDuration: MockHistogram;
+  _streamLifecycleToolInputDuration: MockHistogram;
+  _streamLifecycleToolExecutionDuration: MockHistogram;
 } {
   const httpRequestCounter = createMockCounter();
   const httpRequestDuration = createMockHistogram();
@@ -102,6 +113,17 @@ function createMockInstruments(): MetricsInstruments & {
   const dataFetchErrorCounter = createMockCounter();
   const corsRejectionCounter = createMockCounter();
   const securityHeadersCounter = createMockCounter();
+  const errorCounter = createMockCounter();
+  const streamLifecycleOutcomeCounter = createMockCounter();
+  const streamLifecycleDeadlineCounter = createMockCounter();
+  const streamLifecycleTelemetryCounter = createMockCounter();
+  const streamLifecycleRepairCounter = createMockCounter();
+  const streamLifecycleShadowDivergenceCounter = createMockCounter();
+  const streamLifecycleAttemptDuration = createMockHistogram();
+  const streamLifecycleFirstProgressDuration = createMockHistogram();
+  const streamLifecycleSemanticIdleDuration = createMockHistogram();
+  const streamLifecycleToolInputDuration = createMockHistogram();
+  const streamLifecycleToolExecutionDuration = createMockHistogram();
 
   return {
     httpRequestCounter: httpRequestCounter as never,
@@ -136,21 +158,21 @@ function createMockInstruments(): MetricsInstruments & {
     dataFetchErrorCounter: dataFetchErrorCounter as never,
     corsRejectionCounter: corsRejectionCounter as never,
     securityHeadersCounter: securityHeadersCounter as never,
-    errorCounter: null,
+    errorCounter: errorCounter as never,
     memoryUsageGauge: null,
     heapUsageGauge: null,
     heapTotalGauge: null,
     heapPercentGauge: null,
-    streamLifecycleOutcomeCounter: null,
-    streamLifecycleDeadlineCounter: null,
-    streamLifecycleTelemetryCounter: null,
-    streamLifecycleRepairCounter: null,
-    streamLifecycleShadowDivergenceCounter: null,
-    streamLifecycleAttemptDuration: null,
-    streamLifecycleFirstProgressDuration: null,
-    streamLifecycleSemanticIdleDuration: null,
-    streamLifecycleToolInputDuration: null,
-    streamLifecycleToolExecutionDuration: null,
+    streamLifecycleOutcomeCounter: streamLifecycleOutcomeCounter as never,
+    streamLifecycleDeadlineCounter: streamLifecycleDeadlineCounter as never,
+    streamLifecycleTelemetryCounter: streamLifecycleTelemetryCounter as never,
+    streamLifecycleRepairCounter: streamLifecycleRepairCounter as never,
+    streamLifecycleShadowDivergenceCounter: streamLifecycleShadowDivergenceCounter as never,
+    streamLifecycleAttemptDuration: streamLifecycleAttemptDuration as never,
+    streamLifecycleFirstProgressDuration: streamLifecycleFirstProgressDuration as never,
+    streamLifecycleSemanticIdleDuration: streamLifecycleSemanticIdleDuration as never,
+    streamLifecycleToolInputDuration: streamLifecycleToolInputDuration as never,
+    streamLifecycleToolExecutionDuration: streamLifecycleToolExecutionDuration as never,
 
     _httpRequestCounter: httpRequestCounter,
     _httpRequestDuration: httpRequestDuration,
@@ -183,6 +205,17 @@ function createMockInstruments(): MetricsInstruments & {
     _dataFetchErrorCounter: dataFetchErrorCounter,
     _corsRejectionCounter: corsRejectionCounter,
     _securityHeadersCounter: securityHeadersCounter,
+    _errorCounter: errorCounter,
+    _streamLifecycleOutcomeCounter: streamLifecycleOutcomeCounter,
+    _streamLifecycleDeadlineCounter: streamLifecycleDeadlineCounter,
+    _streamLifecycleTelemetryCounter: streamLifecycleTelemetryCounter,
+    _streamLifecycleRepairCounter: streamLifecycleRepairCounter,
+    _streamLifecycleShadowDivergenceCounter: streamLifecycleShadowDivergenceCounter,
+    _streamLifecycleAttemptDuration: streamLifecycleAttemptDuration,
+    _streamLifecycleFirstProgressDuration: streamLifecycleFirstProgressDuration,
+    _streamLifecycleSemanticIdleDuration: streamLifecycleSemanticIdleDuration,
+    _streamLifecycleToolInputDuration: streamLifecycleToolInputDuration,
+    _streamLifecycleToolExecutionDuration: streamLifecycleToolExecutionDuration,
   };
 }
 
@@ -613,6 +646,104 @@ describe("observability/metrics/recorder", () => {
     });
   });
 
+  describe("recordError", () => {
+    it("should increment the application error counter", () => {
+      recorder.recordError({ type: "boom" });
+
+      assertEquals(
+        instruments._errorCounter._value,
+        1,
+        "recordError must increment errorCounter",
+      );
+      assertEquals(
+        instruments._errorCounter._lastAttributes,
+        { type: "boom" },
+        "recordError must forward its attributes to errorCounter",
+      );
+      assertEquals(
+        instruments._renderErrorCounter._value,
+        0,
+        "recordError must not write to the render error counter",
+      );
+    });
+  });
+
+  describe("stream lifecycle", () => {
+    const attributes = { project_id: "project-123" };
+
+    const counters = [
+      ["outcome", "_streamLifecycleOutcomeCounter"],
+      ["deadline", "_streamLifecycleDeadlineCounter"],
+      ["telemetry", "_streamLifecycleTelemetryCounter"],
+      ["repair", "_streamLifecycleRepairCounter"],
+      ["shadowDivergence", "_streamLifecycleShadowDivergenceCounter"],
+    ] as const;
+
+    const durations = [
+      ["attempt", "_streamLifecycleAttemptDuration"],
+      ["first_progress", "_streamLifecycleFirstProgressDuration"],
+      ["semantic_idle", "_streamLifecycleSemanticIdleDuration"],
+      ["tool_input", "_streamLifecycleToolInputDuration"],
+      ["tool_execution", "_streamLifecycleToolExecutionDuration"],
+    ] as const;
+
+    it("should route each lifecycle event to its own counter", () => {
+      for (const [event, handle] of counters) {
+        const scoped = createMockInstruments();
+        const scopedRecorder = new MetricsRecorder(scoped, runtimeState);
+
+        if (event === "outcome") scopedRecorder.recordStreamLifecycleOutcome(attributes);
+        if (event === "deadline") scopedRecorder.recordStreamLifecycleDeadline(attributes);
+        if (event === "telemetry") scopedRecorder.recordStreamLifecycleTelemetry(attributes);
+        if (event === "repair") scopedRecorder.recordStreamLifecycleRepair(attributes);
+        if (event === "shadowDivergence") {
+          scopedRecorder.recordStreamLifecycleShadowDivergence(attributes);
+        }
+
+        assertEquals(scoped[handle]._value, 1, `${event} must increment ${handle}`);
+        assertEquals(
+          scoped[handle]._lastAttributes,
+          attributes,
+          `${event} must forward its attributes to ${handle}`,
+        );
+        for (const [, other] of counters) {
+          if (other === handle) continue;
+          assertEquals(scoped[other]._value, 0, `${event} must not increment ${other}`);
+        }
+      }
+    });
+
+    it("should route each duration kind to its own histogram", () => {
+      for (const [kind, handle] of durations) {
+        const scoped = createMockInstruments();
+        const scopedRecorder = new MetricsRecorder(scoped, runtimeState);
+
+        scopedRecorder.recordStreamLifecycleDuration(kind, 25, attributes);
+
+        assertEquals(scoped[handle]._value, 25, `${kind} must be recorded into ${handle}`);
+        assertEquals(
+          scoped[handle]._lastAttributes,
+          attributes,
+          `${kind} must forward its attributes to ${handle}`,
+        );
+        for (const [, other] of durations) {
+          if (other === handle) continue;
+          assertEquals(scoped[other]._value, 0, `${kind} must not be recorded into ${other}`);
+        }
+      }
+    });
+
+    it("should clamp negative durations to zero", () => {
+      recorder.recordStreamLifecycleDuration("attempt", -5, attributes);
+
+      assertEquals(
+        instruments._streamLifecycleAttemptDuration._value,
+        0,
+        "negative durations clamp to 0",
+      );
+    });
+  });
+
   describe("null instruments", () => {
     it("should handle all null instruments gracefully", () => {
       const nullInstruments: MetricsInstruments = {
@@ -690,6 +821,16 @@ describe("observability/metrics/recorder", () => {
       nullRecorder.recordCorsRejection();
       nullRecorder.recordSecurityHeaders();
       nullRecorder.recordError();
+      nullRecorder.recordStreamLifecycleOutcome({});
+      nullRecorder.recordStreamLifecycleDeadline({});
+      nullRecorder.recordStreamLifecycleTelemetry({});
+      nullRecorder.recordStreamLifecycleRepair({});
+      nullRecorder.recordStreamLifecycleShadowDivergence({});
+      nullRecorder.recordStreamLifecycleDuration("attempt", 1, {});
+      nullRecorder.recordStreamLifecycleDuration("first_progress", 1, {});
+      nullRecorder.recordStreamLifecycleDuration("semantic_idle", 1, {});
+      nullRecorder.recordStreamLifecycleDuration("tool_input", 1, {});
+      nullRecorder.recordStreamLifecycleDuration("tool_execution", 1, {});
     });
   });
 });

--- a/src/observability/request-profiler.test.ts
+++ b/src/observability/request-profiler.test.ts
@@ -11,6 +11,7 @@ import {
   isRequestProfilingEnabled,
   markRequestProfilePhase,
   profilePhase,
+  profileSyncPhase,
   resetRequestProfiles,
   runWithRequestProfiling,
   snapshotRequestProfiles,
@@ -51,26 +52,94 @@ describe("request profiler", () => {
 
     assertEquals(isRequestProfilingEnabled("/"), true);
 
-    const result = await runWithRequestProfiling(
-      {
-        category: "html",
-        method: "GET",
-        pathname: "/",
-      },
-      async () => {
-        updateRequestProfileContext({ projectSlug: "site", requestMode: "production" });
-        await profilePhase("runtime.resolve_project", () => Promise.resolve());
-        markRequestProfilePhase("render.cache_hit");
-        return finalizeRequestProfiling(200);
-      },
-    );
+    // A controlled clock turns the measured durations into exact expectations.
+    const realNow = performance.now;
+    let clock = 0;
+    performance.now = () => clock;
 
-    assertExists(result);
-    assertEquals(result.projectSlug, "site");
-    assertEquals(result.requestMode, "production");
-    assertEquals(result.status, 200);
-    assert("runtime.resolve_project" in result.phases);
-    assertEquals(result.phases["render.cache_hit"], 0);
+    try {
+      const result = await runWithRequestProfiling(
+        {
+          category: "html",
+          method: "GET",
+          pathname: "/",
+        },
+        async () => {
+          updateRequestProfileContext({ projectSlug: "site", requestMode: "production" });
+          await profilePhase("runtime.resolve_project", () => {
+            clock += 7;
+            return Promise.resolve();
+          });
+          markRequestProfilePhase("render.cache_hit");
+          clock += 3;
+          return finalizeRequestProfiling(200);
+        },
+      );
+
+      assertExists(result);
+      assertEquals(result.projectSlug, "site");
+      assertEquals(result.requestMode, "production");
+      assertEquals(result.status, 200);
+      assertEquals(
+        result.phases["runtime.resolve_project"],
+        7,
+        "profilePhase must record the time elapsed inside the awaited callback",
+      );
+      assertEquals(result.phases["render.cache_hit"], 0);
+      assertEquals(
+        result.totalMs,
+        10,
+        "totalMs must be the time elapsed from session start to finalization",
+      );
+    } finally {
+      performance.now = realNow;
+    }
+  });
+
+  it("records synchronous phases and returns the callback result", async () => {
+    const realNow = performance.now;
+    let clock = 0;
+    performance.now = () => clock;
+
+    try {
+      const result = await runWithRequestProfiling(
+        {
+          category: "html",
+          method: "GET",
+          pathname: "/sync",
+        },
+        async () => {
+          const value = profileSyncPhase("sync.phase", () => {
+            clock += 4;
+            return "value";
+          });
+          assertEquals(value, "value", "profileSyncPhase must return the callback result");
+          return finalizeRequestProfiling(200);
+        },
+      );
+
+      assertExists(result);
+      assertEquals(
+        result.phases["sync.phase"],
+        4,
+        "profileSyncPhase must record its phase on the active session",
+      );
+    } finally {
+      performance.now = realNow;
+    }
+  });
+
+  it("passes synchronous phases through when no profiling session is active", () => {
+    assertEquals(
+      profileSyncPhase("orphan.phase", () => 7),
+      7,
+      "profileSyncPhase must pass through when no profiling session is active",
+    );
+    assertEquals(
+      snapshotRequestProfiles().records.length,
+      0,
+      "a phase recorded outside a session must not create a record",
+    );
   });
 
   it("returns detached records and normalizes explicit phase durations", async () => {
@@ -223,5 +292,24 @@ describe("request profiler", () => {
     Deno.env.set("VERYFRONT_ENABLE_SERVER_TIMING", "1");
     const withFlag = withServerTimingHeader(new Response("ok"), record);
     assertEquals(withFlag.headers.get("Server-Timing"), "total;dur=10.00");
+
+    const redirect = Response.redirect("https://example.test/", 302);
+    const timed = withServerTimingHeader(redirect, record);
+    assertEquals(
+      timed.headers.get("Server-Timing"),
+      "total;dur=10.00",
+      "immutable responses still get Server-Timing via a clone",
+    );
+    assertEquals(timed.status, 302, "the cloned response preserves the original status");
+    assertEquals(
+      timed.headers.get("location"),
+      "https://example.test/",
+      "the cloned response preserves the original headers",
+    );
+    assertEquals(
+      timed === redirect,
+      false,
+      "an immutable response must be replaced, not mutated",
+    );
   });
 });

--- a/src/observability/sentry.test.ts
+++ b/src/observability/sentry.test.ts
@@ -175,12 +175,20 @@ describe("observability/sentry", () => {
     const previousDsn = Deno.env.get("SENTRY_DSN");
     const previousServiceName = Deno.env.get("SENTRY_SERVICE_NAME");
     const previousOtelServiceName = Deno.env.get("OTEL_SERVICE_NAME");
+    const previousEnvironment = Deno.env.get("SENTRY_ENVIRONMENT");
+    const previousRelease = Deno.env.get("SENTRY_RELEASE");
+    const previousOtelEnvironment = Deno.env.get("OTEL_DEPLOYMENT_ENVIRONMENT");
+    const previousOtelServiceVersion = Deno.env.get("OTEL_SERVICE_VERSION");
     try {
       Deno.env.set("SENTRY_ENABLED", "true");
       Deno.env.set("VERYFRONT_ERROR_REPORTER", "sentry");
       Deno.env.set("SENTRY_DSN", "https://public@example.ingest.sentry.io/1");
       Deno.env.set("SENTRY_SERVICE_NAME", "   ");
       Deno.env.delete("OTEL_SERVICE_NAME");
+      Deno.env.delete("SENTRY_ENVIRONMENT");
+      Deno.env.delete("SENTRY_RELEASE");
+      Deno.env.delete("OTEL_DEPLOYMENT_ENVIRONMENT");
+      Deno.env.delete("OTEL_SERVICE_VERSION");
 
       assertEquals(resolveSentryConfigFromEnv("veryfront-proxy"), {
         dsn: "https://public@example.ingest.sentry.io/1",
@@ -194,6 +202,62 @@ describe("observability/sentry", () => {
       restoreEnv("SENTRY_DSN", previousDsn);
       restoreEnv("SENTRY_SERVICE_NAME", previousServiceName);
       restoreEnv("OTEL_SERVICE_NAME", previousOtelServiceName);
+      restoreEnv("SENTRY_ENVIRONMENT", previousEnvironment);
+      restoreEnv("SENTRY_RELEASE", previousRelease);
+      restoreEnv("OTEL_DEPLOYMENT_ENVIRONMENT", previousOtelEnvironment);
+      restoreEnv("OTEL_SERVICE_VERSION", previousOtelServiceVersion);
+    }
+  });
+
+  it("Sentry environment configuration resolves environment and release through the OTEL fallbacks", () => {
+    const previousEnabled = Deno.env.get("SENTRY_ENABLED");
+    const previousProvider = Deno.env.get("VERYFRONT_ERROR_REPORTER");
+    const previousDsn = Deno.env.get("SENTRY_DSN");
+    const previousEnvironment = Deno.env.get("SENTRY_ENVIRONMENT");
+    const previousRelease = Deno.env.get("SENTRY_RELEASE");
+    const previousOtelEnvironment = Deno.env.get("OTEL_DEPLOYMENT_ENVIRONMENT");
+    const previousOtelServiceVersion = Deno.env.get("OTEL_SERVICE_VERSION");
+    try {
+      Deno.env.set("SENTRY_ENABLED", "true");
+      Deno.env.set("VERYFRONT_ERROR_REPORTER", "sentry");
+      Deno.env.set("SENTRY_DSN", "https://public@example.ingest.sentry.io/1");
+      Deno.env.set("SENTRY_ENVIRONMENT", "production");
+      Deno.env.set("SENTRY_RELEASE", "v1.2.3");
+      Deno.env.set("OTEL_DEPLOYMENT_ENVIRONMENT", "staging");
+      Deno.env.set("OTEL_SERVICE_VERSION", "v9");
+
+      assertEquals(
+        resolveSentryConfigFromEnv()?.environment,
+        "production",
+        "SENTRY_ENVIRONMENT wins over the OTEL deployment environment",
+      );
+      assertEquals(
+        resolveSentryConfigFromEnv()?.release,
+        "v1.2.3",
+        "SENTRY_RELEASE wins over the OTEL service version",
+      );
+
+      Deno.env.delete("SENTRY_ENVIRONMENT");
+      Deno.env.delete("SENTRY_RELEASE");
+
+      assertEquals(
+        resolveSentryConfigFromEnv()?.environment,
+        "staging",
+        "OTEL_DEPLOYMENT_ENVIRONMENT is the environment fallback",
+      );
+      assertEquals(
+        resolveSentryConfigFromEnv()?.release,
+        "v9",
+        "OTEL_SERVICE_VERSION is the release fallback",
+      );
+    } finally {
+      restoreEnv("SENTRY_ENABLED", previousEnabled);
+      restoreEnv("VERYFRONT_ERROR_REPORTER", previousProvider);
+      restoreEnv("SENTRY_DSN", previousDsn);
+      restoreEnv("SENTRY_ENVIRONMENT", previousEnvironment);
+      restoreEnv("SENTRY_RELEASE", previousRelease);
+      restoreEnv("OTEL_DEPLOYMENT_ENVIRONMENT", previousOtelEnvironment);
+      restoreEnv("OTEL_SERVICE_VERSION", previousOtelServiceVersion);
     }
   });
 

--- a/src/observability/simple-metrics/metrics-recorder.test.ts
+++ b/src/observability/simple-metrics/metrics-recorder.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { resetMetrics, state } from "./metrics-state.ts";
+import { getSSRBoundaries, resetMetrics, state } from "./metrics-state.ts";
 import {
   recordApiRequest,
   recordApiRetry,
@@ -160,9 +160,34 @@ describe("observability/simple-metrics/metrics-recorder", () => {
 
     it("should record duration in histogram bucket", () => {
       resetMetrics();
+      const boundaries = getSSRBoundaries();
+      const expectedIndex = boundaries.findIndex((boundary) => 50 <= boundary);
+
       recordSSR(50);
-      const bucket50 = state._ssrCounts.find((c) => c > 0);
-      assertEquals(bucket50 !== undefined, true);
+
+      assertEquals(boundaries[expectedIndex], 50, "50ms is the boundary of its own bucket");
+      assertEquals(
+        state._ssrCounts[expectedIndex],
+        1,
+        "50ms lands in the bucket its boundary selects",
+      );
+      assertEquals(
+        state._ssrCounts.filter((count) => count > 0).length,
+        1,
+        "exactly one bucket increments per recordSSR call",
+      );
+    });
+
+    it("records durations above the last boundary in the overflow bucket", () => {
+      resetMetrics();
+
+      recordSSR(20000);
+
+      assertEquals(
+        state._ssrCounts.at(-1),
+        1,
+        "durations above the last boundary land in the overflow bucket",
+      );
     });
 
     it("records non-finite durations as zero instead of corrupting state", () => {
@@ -256,6 +281,30 @@ describe("observability/simple-metrics/metrics-recorder", () => {
       assertEquals(state.contentNetworkFetchMsTotal, Number.MAX_SAFE_INTEGER);
       assertEquals(state.contentPreviewRequests, Number.MAX_SAFE_INTEGER);
       assertEquals(state._contentNetworkCounts[lastBucket], Number.MAX_SAFE_INTEGER);
+    });
+
+    it("counts preview and production fetches separately", () => {
+      resetMetrics();
+
+      recordContentNetworkFetch(10, true);
+      recordContentNetworkFetch(20, false);
+      recordContentNetworkFetch(30, false);
+
+      assertEquals(
+        state.contentPreviewRequests,
+        1,
+        "a preview fetch must increment the preview counter",
+      );
+      assertEquals(
+        state.contentProductionRequests,
+        2,
+        "a production fetch must increment the production counter",
+      );
+      assertEquals(
+        state.contentNetworkFetches,
+        3,
+        "every fetch must increment the total counter",
+      );
     });
   });
 });

--- a/src/observability/simple-metrics/metrics-state.test.ts
+++ b/src/observability/simple-metrics/metrics-state.test.ts
@@ -46,23 +46,59 @@ describe("observability/simple-metrics/metrics-state", () => {
   describe("createSnapshot", () => {
     it("should return all metric fields", () => {
       resetMetrics();
-      const snap = createSnapshot();
-      assertEquals(typeof snap.requests, "number");
-      assertEquals(typeof snap.cacheGets, "number");
-      assertEquals(typeof snap.cacheHits, "number");
-      assertEquals(typeof snap.cacheMisses, "number");
-      assertEquals(typeof snap.moduleServeTotal, "number");
-      assertEquals(typeof snap.moduleTransformTotal, "number");
-      assertEquals(typeof snap.routeManifestLruHits, "number");
-      assertEquals(typeof snap.corsRejections, "number");
+      const numericKeys = Object.keys(state).filter(
+        (key) => !key.startsWith("_") && typeof state[key as keyof typeof state] === "number",
+      );
+      const counters = state as unknown as Record<string, number>;
+      numericKeys.forEach((key, index) => {
+        counters[key] = index + 1;
+      });
+
+      const snap = createSnapshot() as unknown as Record<string, number>;
+      const expected = Object.fromEntries(numericKeys.map((key, index) => [key, index + 1]));
+      const actual = Object.fromEntries(numericKeys.map((key) => [key, snap[key]]));
+
+      assertEquals(actual, expected, "each snapshot field must copy its own state counter");
+      assertEquals(
+        numericKeys.filter((key) => !(key in snap)),
+        [],
+        "createSnapshot must not drop a state counter",
+      );
+      resetMetrics();
     });
 
     it("should return ssrHistogram with boundaries and counts", () => {
       resetMetrics();
+      state._ssrCounts[0] = 3;
+      state._contentNetworkCounts[0] = 4;
       const snap = createSnapshot();
+      resetMetrics();
+
       assertExists(snap.ssrHistogram);
       assertEquals(Array.isArray(snap.ssrHistogram.boundaries), true);
       assertEquals(Array.isArray(snap.ssrHistogram.counts), true);
+      assertEquals(
+        snap.ssrHistogram.boundaries,
+        getSSRBoundaries(),
+        "snapshot boundaries must match the published SSR boundaries",
+      );
+      assertEquals(
+        snap.ssrHistogram.counts[0],
+        3,
+        "snapshot histogram counts must survive a later resetMetrics",
+      );
+      assertEquals(
+        snap.contentNetworkHistogram?.counts[0],
+        4,
+        "snapshot content-network counts must survive a later resetMetrics",
+      );
+
+      snap.ssrHistogram.counts[1] = 99;
+      assertEquals(
+        state._ssrCounts[1],
+        0,
+        "mutating a snapshot must not write back into live state",
+      );
     });
 
     it("should return a copy (not reference)", () => {

--- a/src/observability/simple-metrics/observability-loader.test.ts
+++ b/src/observability/simple-metrics/observability-loader.test.ts
@@ -1,5 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertNotStrictEquals,
+  assertStrictEquals,
+} from "#veryfront/testing/assert.ts";
 import { beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { getObservabilityMetrics, resetObservabilityLoader } from "./observability-loader.ts";
 
@@ -24,7 +29,11 @@ describe("observability/simple-metrics/observability-loader", () => {
       const first = await getObservabilityMetrics();
       const second = await getObservabilityMetrics();
 
-      assertEquals(first, second);
+      assertStrictEquals(
+        first,
+        second,
+        "second call returns the cached instance, not a rebuilt facade",
+      );
     });
 
     it("should return same instance across multiple calls", async () => {
@@ -34,19 +43,20 @@ describe("observability/simple-metrics/observability-loader", () => {
         getObservabilityMetrics(),
       ]);
 
-      assertEquals(first, second);
-      assertEquals(second, third);
+      assertStrictEquals(first, second, "concurrent callers share one cached instance");
+      assertStrictEquals(second, third, "concurrent callers share one cached instance");
     });
   });
 
   describe("resetObservabilityLoader", () => {
     it("should reset the loader state", async () => {
-      await getObservabilityMetrics();
+      const before = await getObservabilityMetrics();
 
       resetObservabilityLoader();
 
-      const metrics = await getObservabilityMetrics();
-      assertExists(metrics);
+      const after = await getObservabilityMetrics();
+      assertExists(after);
+      assertNotStrictEquals(after, before, "reset forces a fresh load");
     });
 
     it("should be callable multiple times", () => {

--- a/src/observability/simple-metrics/otel-instruments.test.ts
+++ b/src/observability/simple-metrics/otel-instruments.test.ts
@@ -35,10 +35,28 @@ describe("observability/simple-metrics/otel-instruments", () => {
     it("should clear all instruments", () => {
       const instruments = getOtelInstruments();
       instruments.meter = "fake-meter" as never;
+      instruments.requestCounter = { add() {} } as never;
+      instruments.ssrHistogram = { record() {} } as never;
+      instruments.routeManifestLookupCounter = { add() {} } as never;
 
       resetOtelInstruments();
 
+      assertEquals(
+        Object.keys(getOtelInstruments()).length,
+        0,
+        "reset clears every instrument field, not just meter",
+      );
       assertEquals(getOtelInstruments().meter, undefined);
+      assertEquals(
+        getOtelInstruments().requestCounter,
+        undefined,
+        "counters from a previous provider revision must not survive a reset",
+      );
+      assertEquals(
+        getOtelInstruments().ssrHistogram,
+        undefined,
+        "histograms from a previous provider revision must not survive a reset",
+      );
     });
 
     it("should be callable multiple times", () => {
@@ -67,6 +85,11 @@ describe("observability/simple-metrics/otel-instruments", () => {
       await pending;
 
       assertEquals(getOtelInstruments().meter, undefined);
+      assertEquals(
+        Object.keys(getOtelInstruments()).length,
+        0,
+        "a superseded candidate must not publish any instrument field",
+      );
     });
   });
 

--- a/src/observability/telemetry-error.test.ts
+++ b/src/observability/telemetry-error.test.ts
@@ -3,6 +3,7 @@ import { API_CLIENT_ERROR } from "#veryfront/errors";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  LOG_PREVIEW_MAX_LENGTH_CHARS,
   MAX_STRING_DISPLAY_LENGTH,
   MAX_TRACE_ATTRIBUTE_VALUE_SIZE,
 } from "#veryfront/utils/constants/index.ts";
@@ -15,6 +16,7 @@ import {
   sanitizeErrorForTelemetry,
   sanitizeStructuredTelemetryData,
   sanitizeTelemetryAttributes,
+  sanitizeTelemetryAttributeValue,
   type TelemetryAttributeValue,
   telemetryErrorType,
 } from "./telemetry-error.ts";
@@ -145,6 +147,20 @@ describe("observability/telemetry-error", () => {
 
     assertEquals(telemetryErrorType(accessorBacked), "Error");
     assertEquals(accessorCalls, 0);
+  });
+
+  it("classifies non-Error throws as Unknown", () => {
+    assertEquals(
+      telemetryErrorType("boom"),
+      "Unknown",
+      "a bare string throw must not be labelled an Error",
+    );
+    assertEquals(telemetryErrorType(null), "Unknown", "a null throw must be classified Unknown");
+    assertEquals(
+      telemetryErrorType({ code: "ECONNRESET" }),
+      "Unknown",
+      "a plain object must not be classified by its code field",
+    );
   });
 
   it("classifies error codes through a captured RegExp matcher", () => {
@@ -410,6 +426,63 @@ describe("observability/telemetry-error", () => {
     assertEquals(sanitized.message, "stack round trip");
     assertEquals(typeof sanitized.stack, "string");
     assertEquals(sanitized.stack?.includes("telemetryStackProbeFrame"), true);
+  });
+
+  it("suppresses the stack when the error only classifies the failure", () => {
+    function telemetryStackProbeFrame(): never {
+      throw new Error("stack suppression");
+    }
+
+    let thrown: unknown;
+    try {
+      telemetryStackProbeFrame();
+    } catch (error) {
+      thrown = error;
+    }
+
+    assertEquals(
+      sanitizeErrorForTelemetry(thrown, "withoutStack").stack,
+      undefined,
+      "withoutStack must not export reporting-site frames",
+    );
+    assertEquals(
+      typeof sanitizeErrorForTelemetry(thrown).stack,
+      "string",
+      "withStack must keep the failure frames",
+    );
+    assertEquals(
+      sanitizeErrorForTelemetry(thrown).stack?.includes("telemetryStackProbeFrame"),
+      true,
+      "withStack must keep the probe frame",
+    );
+  });
+
+  it("names non-Error telemetry snapshots from the supplied classification", () => {
+    assertEquals(
+      sanitizeErrorForTelemetry("boom", "withoutStack", "ECONNRESET").name,
+      "ECONNRESET",
+      "safeName becomes the snapshot name for non-Error values",
+    );
+    assertEquals(
+      sanitizeErrorForTelemetry("boom", "withoutStack").name,
+      "Unknown",
+      "an omitted safeName still falls back to Unknown",
+    );
+    assertEquals(
+      sanitizeErrorForTelemetry(
+        "boom",
+        "withoutStack",
+        "x".repeat(LOG_PREVIEW_MAX_LENGTH_CHARS + 50),
+      )
+        .name.length,
+      LOG_PREVIEW_MAX_LENGTH_CHARS,
+      "safeName is truncated to the preview cap",
+    );
+    assertEquals(
+      sanitizeErrorForTelemetry(new Error("real"), "withoutStack", "ECONNRESET").name,
+      "Error",
+      "a real error keeps its own name over safeName",
+    );
   });
 
   it("bounds a real thrown error's stack", () => {
@@ -743,6 +816,32 @@ describe("observability/telemetry-error", () => {
       MAX_TRACE_ATTRIBUTE_VALUE_SIZE,
     );
     assertEquals(snapshot.array, "[REDACTED]");
+  });
+
+  it("redacts credentials inside under-cap array attribute values", () => {
+    const result = sanitizeTelemetryAttributeValue("urls", [
+      "https://user:password@example.test/path?token=secret",
+      "plain",
+    ]);
+
+    assertEquals(Array.isArray(result), true, "under-cap arrays stay arrays");
+    const values = result as readonly string[];
+    assertEquals(
+      values[0]?.includes("password"),
+      false,
+      "URL credentials in array elements are redacted",
+    );
+    assertEquals(
+      values[0]?.includes("secret"),
+      false,
+      "query-string secrets in array elements are redacted",
+    );
+    assertEquals(values[1], "plain", "safe elements pass through");
+    assertEquals(
+      sanitizeTelemetryAttributeValue("sizes", [1, Number.NaN]),
+      "[REDACTED]",
+      "non-finite numbers force the whole array to be redacted",
+    );
   });
 
   it("bounds structured telemetry returned by custom serializers", () => {

--- a/src/observability/tracing/api-shim.test.ts
+++ b/src/observability/tracing/api-shim.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   _resetShimForTests,
@@ -113,18 +113,61 @@ describe("observability/tracing/api-shim", () => {
     it("installs and clears one complete provider generation atomically", () => {
       const tracerProvider = { getTracer: () => getTracer("fallback") };
       const metricsApi = { getMeter: () => ({}) } as unknown as MetricsAPI;
-      const owner = installGlobalTelemetryAPI({ tracerProvider, metricsApi });
+      const contextAccessor = {
+        active: () => context.active(),
+        with: <T>(_ctx: Context, fn: () => T): T => fn(),
+      };
+      const span = { updateName() {} } as unknown as Span;
+      const activeSpanAccessor = {
+        getActiveSpan: () => span,
+        getSpan: () => span,
+        setSpan: (ctx: Context) => ctx,
+      };
+      const propagator: TextMapPropagator = {
+        inject: () => {},
+        extract: (ctx: Context) => ctx,
+        fields: () => [],
+      };
+      const owner = installGlobalTelemetryAPI({
+        tracerProvider,
+        metricsApi,
+        contextAccessor,
+        activeSpanAccessor,
+        propagator,
+      });
 
       const installed = getGlobalTelemetryAPISnapshot();
       assertEquals(installed.generation, owner.generation);
       assertEquals(installed.tracerProvider, tracerProvider);
       assertEquals(installed.metricsApi, metricsApi);
+      assertStrictEquals(
+        installed.contextAccessor,
+        contextAccessor,
+        "install must publish the context accessor",
+      );
+      assertStrictEquals(
+        installed.activeSpanAccessor,
+        activeSpanAccessor,
+        "install must publish the active-span accessor",
+      );
+      assertStrictEquals(
+        installed.propagator,
+        propagator,
+        "install must publish the propagator",
+      );
 
       assertEquals(owner.dispose(), true);
       assertEquals(owner.dispose(), false);
       const cleared = getGlobalTelemetryAPISnapshot();
       assertEquals(cleared.generation > owner.generation, true);
       assertEquals(cleared.metricsApi, null);
+      assertEquals(cleared.contextAccessor, null, "dispose clears the context accessor");
+      assertEquals(
+        cleared.activeSpanAccessor,
+        null,
+        "dispose clears the active-span accessor",
+      );
+      assertEquals(cleared.propagator, null, "dispose clears the propagator");
       assertEquals(
         cleared.tracerProvider.getTracer("cleared").startSpan("span").spanContext().traceId,
         "00000000000000000000000000000000",
@@ -198,6 +241,24 @@ describe("observability/tracing/api-shim", () => {
 
       assertEquals(trace.getSpan(scoped), real);
       assertEquals(context.with(scoped, () => trace.getActiveSpan()), real);
+    });
+
+    it("refuses to store a no-op span in context", () => {
+      const noop = getTracer("t").startSpan("s");
+      const active = context.active();
+      const scoped = trace.setSpan(active, noop);
+
+      assertEquals(scoped === active, true, "a no-op span must leave the context unchanged");
+      assertEquals(
+        trace.getSpan(scoped),
+        undefined,
+        "a no-op span must not become the active span",
+      );
+      assertEquals(
+        context.with(scoped, () => trace.getActiveSpan()),
+        undefined,
+        "getActiveSpan must stay undefined for a no-op span",
+      );
     });
   });
 

--- a/src/observability/tracing/config.test.ts
+++ b/src/observability/tracing/config.test.ts
@@ -1,6 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  _resetEnvironmentConfig,
+  _setEnvironmentConfigForTesting,
+} from "#veryfront/config/environment-config.ts";
 import { loadConfig } from "./config.ts";
 
 type RuntimeAdapter = import("#veryfront/platform/adapters/base.ts").RuntimeAdapter;
@@ -92,6 +96,43 @@ describe("observability/tracing/config", () => {
         TypeError,
         "serviceName",
       );
+    });
+
+    it("applies the host environment when no adapter is supplied", () => {
+      _setEnvironmentConfigForTesting({
+        otelEnabled: true,
+        otelServiceName: "host-svc",
+        otelTracesEndpoint: "http://traces:4318/v1/traces",
+        otelEndpoint: "http://generic:4318",
+        otelTracesExporter: "otlp",
+      });
+
+      try {
+        const result = loadConfig({});
+
+        assertEquals(
+          result.enabled,
+          true,
+          "host OTEL_TRACES_ENABLED applies when no adapter is given",
+        );
+        assertEquals(
+          result.serviceName,
+          "host-svc",
+          "host OTEL_SERVICE_NAME applies when no adapter is given",
+        );
+        assertEquals(
+          result.endpoint,
+          "http://traces:4318/v1/traces",
+          "tracesEndpoint must map to signalEndpoint and win over the generic endpoint",
+        );
+        assertEquals(
+          result.exporter,
+          "otlp",
+          "host OTEL_TRACES_EXPORTER applies when no adapter is given",
+        );
+      } finally {
+        _resetEnvironmentConfig();
+      }
     });
 
     it("contains adapter environment failures without consulting another environment", () => {

--- a/src/observability/tracing/context-propagation.test.ts
+++ b/src/observability/tracing/context-propagation.test.ts
@@ -85,8 +85,38 @@ describe("observability/tracing/context-propagation", () => {
       const headers = new Headers({
         traceparent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
       });
-      const result = ctx.extractContext(headers);
-      assertEquals(result !== undefined, true);
+      const extracted = { _type: "extracted-context" } as unknown as Context;
+      let seenContext: unknown;
+      let seenCarrier: Record<string, string> | undefined;
+      const apiWithCapture: OpenTelemetryAPI = {
+        ...api,
+        propagation: {
+          ...api.propagation,
+          extract: (context: Context, carrier: Record<string, string>) => {
+            seenContext = context;
+            seenCarrier = carrier;
+            return extracted;
+          },
+        },
+      };
+
+      const result = new ContextPropagation(apiWithCapture, propagator).extractContext(headers);
+
+      assertEquals(
+        seenCarrier,
+        { traceparent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" },
+        "incoming headers must be converted into the propagator carrier",
+      );
+      assertEquals(
+        seenContext,
+        api.context.active(),
+        "extraction must start from the active context",
+      );
+      assertStrictEquals(
+        result,
+        extracted,
+        "extractContext must return the propagator's context",
+      );
     });
 
     it("should extract context from empty headers", () => {
@@ -279,6 +309,53 @@ describe("observability/tracing/context-propagation", () => {
       });
 
       assertEquals(executed, true);
+    });
+
+    it("activates the started span on the context handed to the provider", async () => {
+      const span = createMockSpan();
+      const spanContext = { _type: "span-context" } as unknown as Context;
+      let setSpanContext: Context | null = null;
+      let setSpanSpan: Span | null = null;
+      let withContext: Context | null = null;
+      const apiWithCapture: OpenTelemetryAPI = {
+        ...api,
+        trace: {
+          ...api.trace,
+          setSpan: (context: Context, activated: Span) => {
+            setSpanContext = context;
+            setSpanSpan = activated;
+            return spanContext;
+          },
+        },
+        context: {
+          ...api.context,
+          with: <T>(context: Context, fn: () => T): T => {
+            withContext = context;
+            return fn();
+          },
+        },
+      };
+
+      await new ContextPropagation(apiWithCapture, propagator).withActiveSpan(
+        span,
+        () => Promise.resolve(),
+      );
+
+      assertStrictEquals(
+        withContext,
+        spanContext,
+        "withActiveSpan must run the callback in the span context",
+      );
+      assertStrictEquals(
+        setSpanSpan,
+        span,
+        "setSpan must receive the exact span passed in",
+      );
+      assertEquals(
+        setSpanContext,
+        { _type: "active-context" },
+        "setSpan must extend the active context",
+      );
     });
 
     it("should return function result", async () => {

--- a/src/observability/tracing/manager.test.ts
+++ b/src/observability/tracing/manager.test.ts
@@ -106,9 +106,20 @@ describe("observability/tracing/manager", () => {
     });
 
     it("should skip duplicate initialization", async () => {
+      installGlobalTelemetryAPI({ tracerProvider: createProvider("A", []) });
       await manager.initialize({ enabled: false });
-      await manager.initialize({ enabled: true });
-      assertEquals(manager.isEnabled(), false);
+      await manager.initialize({ enabled: true, serviceName: "second" });
+      assertEquals(manager.isEnabled(), false, "a duplicate initialize must not enable tracing");
+      assertEquals(
+        manager.getState().api,
+        null,
+        "a duplicate initialize must not build a tracer runtime",
+      );
+      assertEquals(
+        manager.getState().tracer,
+        null,
+        "a duplicate initialize must not create a tracer",
+      );
     });
 
     it("shares one readiness promise across concurrent initialization", async () => {
@@ -170,6 +181,33 @@ describe("observability/tracing/manager", () => {
     it("should return false when disabled config", async () => {
       await manager.initialize({ enabled: false });
       assertEquals(manager.isDegraded(), false);
+    });
+
+    it("reports degraded mode instead of throwing when a provider's getTracer fails", async () => {
+      installGlobalTelemetryAPI({ tracerProvider: createProvider("A", []) });
+      await manager.initialize({ enabled: true, serviceName: "test" });
+      assertEquals(manager.isEnabled(), true, "a healthy provider enables tracing");
+
+      installGlobalTelemetryAPI({
+        tracerProvider: {
+          getTracer: () => {
+            throw new Error("provider failed");
+          },
+        },
+      });
+
+      assertEquals(
+        manager.isEnabled(),
+        false,
+        "a failing getTracer must not report tracing as enabled",
+      );
+      assertEquals(manager.getSpanOperations(), null, "a failed refresh clears span operations");
+      assertEquals(
+        manager.getContextPropagation(),
+        null,
+        "a failed refresh clears context propagation",
+      );
+      assertEquals(manager.isDegraded(), true, "a failing getTracer must be reported as degraded");
     });
   });
 

--- a/src/observability/tracing/service-tracer.test.ts
+++ b/src/observability/tracing/service-tracer.test.ts
@@ -69,6 +69,7 @@ class FakeSpan {
 function createHarness() {
   let activeContext: FakeContext = {};
   const startedSpans: FakeSpan[] = [];
+  const startContexts: FakeContext[] = [];
   const contextApi = {
     active: () => activeContext,
     with: <T>(context: FakeContext, fn: () => T): T => {
@@ -86,10 +87,11 @@ function createHarness() {
       startSpan: (
         name: string,
         _options: FakeSpanOptions | undefined,
-        _context: FakeContext,
+        context: FakeContext,
       ): FakeSpan => {
         const span = new FakeSpan(name);
         startedSpans.push(span);
+        startContexts.push(context);
         return span;
       },
       startActiveSpan: <T>(name: string, fn: (span: FakeSpan) => T): T => {
@@ -106,6 +108,7 @@ function createHarness() {
     contextApi,
     traceApi,
     startedSpans,
+    startContexts,
   };
 }
 
@@ -244,8 +247,17 @@ describe("observability/tracing/service-tracer", () => {
     }
   });
 
-  it("runs traced code once despite adversarial active-span providers", () => {
-    for (const behavior of ["duplicate", "omit", "replace", "throw-after"] as const) {
+  it("runs traced code once despite adversarial active-span providers", async () => {
+    for (
+      const behavior of [
+        "duplicate",
+        "omit",
+        "replace",
+        "throw-after",
+        "replace-with-rejected-promise",
+        "replace-with-resolved-promise",
+      ] as const
+    ) {
       const harness = createHarness();
       const baseTracer = harness.traceApi.getTracer("test-service");
       harness.traceApi.getTracer = () => ({
@@ -258,6 +270,12 @@ describe("observability/tracing/service-tracer", () => {
           if (behavior === "duplicate") callback(span);
           if (behavior === "throw-after") throw new Error("provider failed after callback");
           if (behavior === "replace") return "provider replacement" as T;
+          if (behavior === "replace-with-rejected-promise") {
+            return Promise.reject(new Error("provider promise")) as T;
+          }
+          if (behavior === "replace-with-resolved-promise") {
+            return Promise.resolve("provider replacement") as T;
+          }
           return applicationResult;
         },
       });
@@ -275,8 +293,16 @@ describe("observability/tracing/service-tracer", () => {
         return expected;
       });
 
-      assertStrictEquals(result, expected);
-      assertEquals(calls, 1);
+      assertStrictEquals(
+        result,
+        expected,
+        `a discarded ${behavior} provider result does not replace the application result`,
+      );
+      assertEquals(calls, 1, `the traced callback runs exactly once under ${behavior}`);
+      // Surface any provider promise the tracer discarded without settling it:
+      // an unattached rejection would reach the runtime as an unhandled rejection.
+      await Promise.resolve();
+      await Promise.resolve();
     }
   });
 
@@ -541,6 +567,55 @@ describe("observability/tracing/service-tracer", () => {
       number: 1,
       undefinedValue: "",
     });
+  });
+
+  it("starts a childOf span in its declared parent's context", () => {
+    const harness = createHarness();
+    const serviceTracer = createOpenTelemetryServiceTracer({
+      serviceName: "test-service",
+      context: harness.contextApi,
+      trace: harness.traceApi,
+      errorStatusCode: 2,
+    });
+
+    const parent = serviceTracer.tracer.startSpan("parent-operation");
+    serviceTracer.tracer.startSpan("child-operation", { childOf: parent });
+
+    assertStrictEquals(
+      harness.startContexts[0]?.span,
+      undefined,
+      "a span without childOf starts in the ambient context",
+    );
+    assertStrictEquals(
+      harness.startContexts[1]?.span,
+      harness.startedSpans[0],
+      "a childOf span starts in its declared parent's context, not the ambient one",
+    );
+  });
+
+  it("creates the span anyway when a childOf accessor throws", () => {
+    const harness = createHarness();
+    const serviceTracer = createOpenTelemetryServiceTracer({
+      serviceName: "test-service",
+      context: harness.contextApi,
+      trace: harness.traceApi,
+      errorStatusCode: 2,
+    });
+    const hostileOptions = {
+      get childOf(): never {
+        throw new Error("hostile childOf accessor");
+      },
+    };
+
+    const span = serviceTracer.tracer.startSpan("hostile-operation", hostileOptions as never);
+
+    assertEquals(span.context()?.toSpanId(), "hostile-operation-span");
+    assertEquals(harness.startedSpans.length, 1, "a hostile parent option still creates a span");
+    assertStrictEquals(
+      harness.startContexts[0]?.span,
+      undefined,
+      "a hostile childOf accessor leaves the span in the ambient context",
+    );
   });
 
   it("bounds manual span names, attribute names, and attribute cardinality", () => {

--- a/src/observability/tracing/span-operations.test.ts
+++ b/src/observability/tracing/span-operations.test.ts
@@ -336,6 +336,26 @@ describe("observability/tracing/span-operations", () => {
       assertEquals(mockSpan._attributes.count, 42);
     });
 
+    it("redacts sensitive and URL credential attribute values", () => {
+      const mockSpan = createMockSpan();
+
+      ops.setAttributes(mockSpan, {
+        apiKey: "secret",
+        endpoint: "https://example.test/path?token=secret",
+      });
+
+      assertEquals(
+        mockSpan._attributes.apiKey,
+        "[REDACTED]",
+        "setAttributes must redact secret values",
+      );
+      assertEquals(
+        mockSpan._attributes.endpoint,
+        "https://example.test/path?token=[REDACTED]",
+        "setAttributes must redact URL credentials",
+      );
+    });
+
     it("should handle null span gracefully", () => {
       ops.setAttributes(null, { key: "value" });
     });
@@ -367,6 +387,23 @@ describe("observability/tracing/span-operations", () => {
       assertEquals(mockSpan._events[0]?.name, "user.action");
     });
 
+    it("redacts sensitive event attributes", () => {
+      const mockSpan = createMockSpan();
+
+      ops.addEvent(mockSpan, "user.action", { apiKey: "secret", "user.id": "123" });
+
+      assertEquals(
+        mockSpan._events[0]?.attributes?.apiKey,
+        "[REDACTED]",
+        "event attributes must be sanitized",
+      );
+      assertEquals(
+        mockSpan._events[0]?.attributes?.["user.id"],
+        "123",
+        "non-sensitive event attributes must survive sanitization",
+      );
+    });
+
     it("should add an event without attributes", () => {
       const mockSpan = createMockSpan();
       ops.addEvent(mockSpan, "checkpoint");
@@ -392,13 +429,56 @@ describe("observability/tracing/span-operations", () => {
   describe("createChildSpan", () => {
     it("should create a child span from parent", () => {
       const parentSpan = createMockSpan();
+      const expectedContext = { _type: "parent-context" } as never;
+      let setSpanArgument: unknown;
+      let receivedContext: unknown;
+      api.trace.setSpan = (_context, span) => {
+        setSpanArgument = span;
+        return expectedContext;
+      };
+      tracer = {
+        startSpan: (_name, _options, context) => {
+          receivedContext = context;
+          return createMockSpan();
+        },
+        startActiveSpan: (() => {}) as never,
+      };
+      ops = new SpanOperations(api, tracer);
+
       const child = ops.createChildSpan(parentSpan, "child.operation");
+
       assertEquals(child !== null, true);
+      assertStrictEquals(
+        setSpanArgument,
+        parentSpan,
+        "the parent span is the one handed to trace.setSpan",
+      );
+      assertStrictEquals(
+        receivedContext,
+        expectedContext,
+        "a child span must be started in the parent context produced by trace.setSpan",
+      );
     });
 
     it("should create root span when parent is null", () => {
+      let receivedContext: unknown = "unset";
+      tracer = {
+        startSpan: (_name, _options, context) => {
+          receivedContext = context;
+          return createMockSpan();
+        },
+        startActiveSpan: (() => {}) as never,
+      };
+      ops = new SpanOperations(api, tracer);
+
       const span = ops.createChildSpan(null, "root.operation");
+
       assertEquals(span !== null, true);
+      assertEquals(
+        receivedContext,
+        undefined,
+        "a span without a parent must be started with no parent context",
+      );
     });
 
     it("should accept span options for child span", () => {
@@ -429,34 +509,58 @@ describe("observability/tracing/span-operations", () => {
   });
 
   describe("mapSpanKind (via startSpan)", () => {
+    let receivedKind: unknown;
+
+    beforeEach(() => {
+      receivedKind = undefined;
+      tracer = {
+        startSpan: (_name, options) => {
+          receivedKind = options?.kind;
+          return createMockSpan();
+        },
+        startActiveSpan: (() => {}) as never,
+      };
+      ops = new SpanOperations(api, tracer);
+    });
+
     it("should map 'internal' kind", () => {
       const span = ops.startSpan("test", { kind: "internal" });
       assertEquals(span !== null, true);
+      assertEquals(receivedKind, api.SpanKind.INTERNAL, "'internal' maps to SpanKind.INTERNAL");
     });
 
     it("should map 'server' kind", () => {
       const span = ops.startSpan("test", { kind: "server" });
       assertEquals(span !== null, true);
+      assertEquals(receivedKind, api.SpanKind.SERVER, "'server' maps to SpanKind.SERVER");
     });
 
     it("should map 'client' kind", () => {
       const span = ops.startSpan("test", { kind: "client" });
       assertEquals(span !== null, true);
+      assertEquals(receivedKind, api.SpanKind.CLIENT, "'client' maps to SpanKind.CLIENT");
     });
 
     it("should map 'producer' kind", () => {
       const span = ops.startSpan("test", { kind: "producer" });
       assertEquals(span !== null, true);
+      assertEquals(receivedKind, api.SpanKind.PRODUCER, "'producer' maps to SpanKind.PRODUCER");
     });
 
     it("should map 'consumer' kind", () => {
       const span = ops.startSpan("test", { kind: "consumer" });
       assertEquals(span !== null, true);
+      assertEquals(receivedKind, api.SpanKind.CONSUMER, "'consumer' maps to SpanKind.CONSUMER");
     });
 
     it("should default to INTERNAL when kind is undefined", () => {
       const span = ops.startSpan("test", {});
       assertEquals(span !== null, true);
+      assertEquals(
+        receivedKind,
+        api.SpanKind.INTERNAL,
+        "a missing kind defaults to SpanKind.INTERNAL",
+      );
     });
   });
 });

--- a/src/observability/tracing/tracing.test.ts
+++ b/src/observability/tracing/tracing.test.ts
@@ -2,7 +2,58 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { delay } from "#std/async.ts";
+import {
+  _resetShimForTests,
+  type Context,
+  getTracer,
+  installGlobalTelemetryAPI,
+  type Span,
+  type SpanStartOptions,
+  trace,
+  type Tracer,
+} from "./api-shim.ts";
 import { TracingManager } from "./manager.ts";
+
+interface StartedSpanRecord {
+  name: string;
+  options?: SpanStartOptions;
+  parentContext?: Context;
+}
+
+/** Recording tracer double: captures every startSpan call the SDK layer makes. */
+function createRecordingTracer(started: StartedSpanRecord[]): Tracer {
+  let spanCount = 0;
+  const createSpan = (): Span => {
+    spanCount += 1;
+    const spanId = String(spanCount).padStart(16, "0");
+    const span: Span = {
+      setAttribute: () => span,
+      setAttributes: () => span,
+      setStatus: () => span,
+      recordException: () => {},
+      addEvent: () => span,
+      end: () => {},
+      spanContext: () => ({
+        traceId: "0af7651916cd43dd8448eb211c80319c",
+        spanId,
+        traceFlags: 1,
+        isRemote: false,
+      }),
+      updateName: () => {},
+    };
+    return span;
+  };
+
+  return {
+    startSpan(name: string, options?: SpanStartOptions, parentContext?: Context): Span {
+      started.push({ name, options, parentContext });
+      return createSpan();
+    },
+    startActiveSpan: (() => {
+      throw new Error("startActiveSpan is not used by these tests");
+    }) as Tracer["startActiveSpan"],
+  };
+}
 
 async function importTracingModule(): Promise<Record<string, unknown>> {
   return await import("./index.ts");
@@ -133,8 +184,34 @@ describe("Tracing Module", () => {
     });
 
     it("should skip duplicate initialization attempts", async () => {
-      await manager.initialize({ enabled: false });
-      await manager.initialize({ enabled: true }); // Second init should be skipped
+      const owner = installGlobalTelemetryAPI({
+        tracerProvider: { getTracer: () => getTracer("duplicate-init") },
+      });
+
+      try {
+        await manager.initialize({ enabled: false });
+        await manager.initialize({ enabled: true }); // Second init should be skipped
+
+        assertEquals(
+          manager.getState().api,
+          null,
+          "second initialize must be skipped and must not bring up the SDK",
+        );
+        assertEquals(
+          manager.getSpanOperations(),
+          null,
+          "a skipped initialize must not build span operations",
+        );
+        assertEquals(
+          manager.isEnabled(),
+          false,
+          "the first (disabled) configuration must win",
+        );
+      } finally {
+        manager.shutdown();
+        owner.dispose();
+        _resetShimForTests();
+      }
     });
   });
 
@@ -512,6 +589,49 @@ describe("Tracing Module", () => {
       createChildSpan(child, "grandchild");
 
       assert(true, "Should support nested children");
+    });
+
+    it("should start the child under the parent span context when tracing is enabled", async () => {
+      const started: StartedSpanRecord[] = [];
+      const tracer = createRecordingTracer(started);
+      const owner = installGlobalTelemetryAPI({ tracerProvider: { getTracer: () => tracer } });
+      const { createChildSpan, initTracing, shutdownTracing, startSpan } = await import(
+        "./index.ts"
+      );
+
+      try {
+        await initTracing({ enabled: true, serviceName: "test" });
+
+        const parent = startSpan("parent-span");
+        assertExists(parent, "tracing must be enabled for this case");
+
+        const child = createChildSpan(parent, "child-span", {
+          kind: "client",
+          attributes: { operation: "fetch" },
+        });
+
+        assertExists(child, "createChildSpan must return a span when tracing is enabled");
+        assertEquals(started.length, 2, "the parent and the child must each start one span");
+        assertEquals(started[1]?.name, "child-span", "the child span must be started by name");
+        assertExists(
+          started[1]?.parentContext,
+          "the child span must be started under a parent context",
+        );
+        assertEquals(
+          trace.getSpan(started[1]?.parentContext as Context),
+          parent,
+          "the child span must be started under the parent's context",
+        );
+        assertEquals(
+          started[1]?.options?.attributes,
+          { operation: "fetch" },
+          "the child span must carry the requested attributes",
+        );
+      } finally {
+        shutdownTracing();
+        owner.dispose();
+        _resetShimForTests();
+      }
     });
   });
 

--- a/tests/integration/observability/metrics-config-host-env.test.ts
+++ b/tests/integration/observability/metrics-config-host-env.test.ts
@@ -1,0 +1,72 @@
+import { assertEquals } from "#veryfront/testing/assert";
+import { describe, it } from "#veryfront/testing/bdd";
+import { loadConfig } from "#veryfront/observability/metrics/config.ts";
+
+type RuntimeAdapter = import("#veryfront/platform/adapters/base.ts").RuntimeAdapter;
+
+function adapterWithEnv(env: { get: (key: string) => string | undefined }): RuntimeAdapter {
+  return { env } as unknown as RuntimeAdapter;
+}
+
+const HOST_OTEL_ENV: Record<string, string> = {
+  VERYFRONT_OTEL: "1",
+  OTEL_METRICS_ENABLED: "true",
+  OTEL_METRICS_EXPORTER: "otlp",
+  OTEL_EXPORTER_OTLP_ENDPOINT: "https://host.example/otlp",
+};
+
+function withHostEnv<T>(values: Record<string, string>, fn: () => T): T {
+  const previous = new Map<string, string | undefined>();
+  for (const [name, value] of Object.entries(values)) {
+    previous.set(name, Deno.env.get(name));
+    Deno.env.set(name, value);
+  }
+  try {
+    return fn();
+  } finally {
+    for (const [name, value] of previous) {
+      if (value === undefined) Deno.env.delete(name);
+      else Deno.env.set(name, value);
+    }
+  }
+}
+
+describe("observability/metrics config host environment", () => {
+  it("applies the host environment when no adapter is supplied", () => {
+    const result = withHostEnv(HOST_OTEL_ENV, () => loadConfig({ prefix: "configured" }));
+
+    assertEquals(result.enabled, true, "host OTEL_METRICS_ENABLED applies without an adapter");
+    assertEquals(
+      result.exporter,
+      "otlp",
+      "host OTEL_METRICS_EXPORTER applies without an adapter",
+    );
+    assertEquals(
+      result.endpoint,
+      "https://host.example/otlp",
+      "host OTLP endpoint applies without an adapter",
+    );
+    assertEquals(result.prefix, "configured", "caller config is preserved");
+  });
+
+  it("does not fall through to the host environment when the adapter environment throws", () => {
+    const result = withHostEnv(HOST_OTEL_ENV, () =>
+      loadConfig(
+        { enabled: false, prefix: "configured" },
+        adapterWithEnv({
+          get() {
+            throw new Error("environment unavailable");
+          },
+        }),
+      ));
+
+    assertEquals(
+      result.enabled,
+      false,
+      "adapter env failure must not fall through to the host OTEL flags",
+    );
+    assertEquals(result.exporter, "console", "host OTEL_METRICS_EXPORTER must not leak in");
+    assertEquals(result.endpoint, undefined, "host OTLP endpoint must not leak in");
+    assertEquals(result.prefix, "configured", "caller config is preserved");
+  });
+});


### PR DESCRIPTION
## Summary

Audit of all 39 test files under `src/observability` and `src/metrics` for tests that stay green when the behavior they claim to cover breaks.

The bar for every change: name a concrete source edit that breaks documented behavior yet leaves the test passing. Every change was **mutation checked** — the named edit was applied, the test confirmed to fail, then the edit reverted.

69 candidate findings, 61 confirmed after adversarial verification, 60 applied, 8 refuted. **No product defects found. Test files only.**

## Why this module had the most findings of any batch so far

Telemetry tests are unusually prone to passing without proving anything: the instruments are mocks, so an assertion that stops at "something was recorded" holds no matter *which* instrument moved or *what* value landed in it. Most of the fixes below are that same shape.

**Instrument routing was never pinned.** Every stream lifecycle event and every duration kind now asserts its own counter or histogram incremented **and that the other four stayed at zero**, so pointing `case "first_progress"` at the wrong histogram fails. `recordError` likewise now asserts the application counter moved and the render counter did not.

**Histogram buckets were asserted by summing to a total**, which holds for any distribution that adds up. They now pin the exact `bucketCounts` and `explicitBounds` arrays, so moving a value into the wrong bucket fails.

**Span context propagation asserted only that a result was defined.** It now captures what the provider was handed and asserts identity: the span passed to `setSpan`, the context it was set on, and that the returned context is strictly the one produced. Swapping `resolveSpanContext(span)` for `getActiveContext()` now fails.

**Header extraction asserted non-undefined**, so replacing the carrier with `{}` passed. It now asserts the exact carrier contents and the starting context.

**Caching identity used structural equality**, which cannot distinguish a cached instance from an equal fresh one — the whole point of the cache. Now `assertStrictEquals`, with `assertNotStrictEquals` after a reset so a no-op reset fails.

**Query filters asserted result counts.** An inverted predicate that returns a different single row passed a `length === 1` check. They now assert the returned messages, and the previously untested `since` filter is covered with `FakeTime`.

**Durations were asserted as "a number".** A controlled `performance.now` clock makes them exact, so returning zero fails.

**Exporter resilience was untested.** A non-ok collector response and a rejected request now both assert the flush still resolves and that the *next* flush exports, so removing the try/catch or re-enqueueing on non-ok fails.

## Verification

- Semantic unit-boundary audit: ok
- Sanitizer ratchet test: ok (baseline unchanged at 396)
- `test:layout`: ok, `docs:api-reference:check`: current
- `deno fmt`, `deno lint`: pass
- **31/31** changed test files pass
- `anti-slop`, `cwd-relative-test-reads`, `test-typecheck`, `check-awaits`, `cross-runtime-jsr`, `skipped-tests`, `ban-test-only`: all pass

No test was deleted, skipped, or weakened.