### PR TITLE
fix(workflow): harden context serialization

### DIFF
--- a/src/workflow/context-serialization.test.ts
+++ b/src/workflow/context-serialization.test.ts
@@ -1,5 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { VeryfrontError } from "#veryfront/errors";
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   __resetLoggerConfigForTests,
@@ -305,6 +311,7 @@ describe("serializeWorkflowContext", () => {
   });
 
   it("keeps prototype diagnostics best-effort for proxies", () => {
+    let prototypeTrapCalls = 0;
     const output = new Proxy({ value: 7 }, {
       get: (target, key, receiver) => {
         if (key === Symbol.toStringTag || key === "constructor") {
@@ -313,6 +320,7 @@ describe("serializeWorkflowContext", () => {
         return Reflect.get(target, key, receiver);
       },
       getPrototypeOf: () => {
+        prototypeTrapCalls++;
         throw new Error("prototype metadata is unavailable");
       },
     });
@@ -320,6 +328,7 @@ describe("serializeWorkflowContext", () => {
     const serialized = serializeWorkflowContext(contextWith(output));
 
     assertEquals(JSON.parse(serialized).step, { value: 7 });
+    assertEquals(prototypeTrapCalls, 0);
   });
 
   it("captures an array's length before reading its elements", () => {
@@ -380,6 +389,18 @@ describe("serializeWorkflowContext", () => {
 
     assertEquals(JSON.parse(nested).step, 123);
     assertEquals(root, "456");
+  });
+
+  it("rejects root values that do not produce a JSON document", () => {
+    for (const value of [undefined, () => 1, Symbol("root")]) {
+      const error = assertThrows(
+        () => serializeWorkflowJson(value, "output"),
+        VeryfrontError,
+      );
+      assertInstanceOf(error, VeryfrontError);
+      assertStringIncludes(error.message, "output");
+      assertStringIncludes(error.message, "cannot be persisted");
+    }
   });
 
   describe("values larger than a diagnostic can describe", () => {
@@ -600,7 +621,7 @@ describe("serializeWorkflowContext", () => {
       const divergences: string[] = [];
       try {
         for (let seed = 0; seed < 3000; seed++) {
-          let expected: string;
+          let expected: string | undefined;
           try {
             expected = JSON.stringify(generateValue(seededRandom(seed), 4));
           } catch {
@@ -611,7 +632,13 @@ describe("serializeWorkflowContext", () => {
           try {
             actual = serializeWorkflowJson(generateValue(seededRandom(seed), 4), "root");
           } catch (error) {
-            divergences.push(`seed ${seed} threw ${(error as Error).message}`);
+            if (expected !== undefined) {
+              divergences.push(`seed ${seed} threw ${(error as Error).message}`);
+            }
+            continue;
+          }
+          if (expected === undefined) {
+            divergences.push(`seed ${seed}: returned ${actual} without a JSON document`);
             continue;
           }
           if (actual !== expected) {

--- a/src/workflow/context-serialization.ts
+++ b/src/workflow/context-serialization.ts
@@ -1,8 +1,52 @@
 import { ORCHESTRATION_ERROR } from "#veryfront/errors";
+import { isProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
 import { agentLogger } from "#veryfront/utils";
 import type { WorkflowContext } from "./types.ts";
 
 const logger = agentLogger.component("workflow-context");
+const arrayIsArray = Array.isArray;
+const BigIntValueOf = BigInt.prototype.valueOf;
+const BooleanValueOf = Boolean.prototype.valueOf;
+const dateGetTime = Date.prototype.getTime;
+const jsonIsRawJSON = typeof (JSON as JsonRawSupport).isRawJSON === "function"
+  ? (JSON as JsonRawSupport).isRawJSON
+  : undefined;
+const jsonStringify = JSON.stringify;
+const mathFloor = Math.floor;
+const mathMin = Math.min;
+const MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER;
+const numberIsFinite = Number.isFinite;
+const numberIsNaN = Number.isNaN;
+const NumberValueOf = Number.prototype.valueOf;
+const ObjectConstructor = Object;
+const objectCreate = Object.create;
+const objectDefineProperty = Object.defineProperty;
+const objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const objectGetPrototypeOf = Object.getPrototypeOf;
+const objectHasOwn = Object.hasOwn;
+const objectKeys = Object.keys;
+const objectPrototype = Object.prototype;
+const objectToString = Object.prototype.toString;
+const POSITIVE_INFINITY = Number.POSITIVE_INFINITY;
+const reflectApply = Reflect.apply;
+const reflectGet = Reflect.get;
+const regExpExec = RegExp.prototype.exec;
+const SetConstructor = Set;
+const setAdd = Set.prototype.add;
+const setDelete = Set.prototype.delete;
+const setHas = Set.prototype.has;
+const StringConstructor = String;
+const StringValueOf = String.prototype.valueOf;
+const symbolToStringTag = Symbol.toStringTag;
+
+function defineArrayElement<T>(values: T[], index: number, value: T): void {
+  objectDefineProperty(values, index, {
+    value,
+    enumerable: true,
+    configurable: true,
+    writable: true,
+  });
+}
 
 /** How many paths a diagnostic names before it stops enumerating. */
 const MAX_REPORTED_PATHS = 5;
@@ -36,7 +80,7 @@ export const MAX_TRAVERSAL_DEPTH = 1000;
 const SAFE_PATH_SEGMENT = /^[A-Za-z_$][A-Za-z0-9_$]{0,39}$/;
 
 function redactPathSegment(key: string): string {
-  return SAFE_PATH_SEGMENT.test(key) ? key : "<redacted>";
+  return reflectApply(regExpExec, SAFE_PATH_SEGMENT, [key]) !== null ? key : "<redacted>";
 }
 
 /** A value the durable codec cannot carry, named by where it sits. */
@@ -99,15 +143,16 @@ function describe(value: unknown): string {
   if (typeof value === "bigint") return "BigInt";
   if (typeof value === "function") return "function";
   if (typeof value === "symbol") return "symbol";
-  if (typeof value === "number") return Number.isFinite(value) ? "number" : `number (${value})`;
+  if (typeof value === "number") return numberIsFinite(value) ? "number" : `number (${value})`;
   return "object";
 }
 
 /** Whether a value is a plain `{}` object rather than a class instance. */
 function isPlainObject(value: JsonTraversalReference): boolean {
+  if (isProxyWithoutHooks(value)) return false;
   try {
-    const prototype = Object.getPrototypeOf(value);
-    return prototype === Object.prototype || prototype === null;
+    const prototype = objectGetPrototypeOf(value);
+    return prototype === objectPrototype || prototype === null;
   } catch {
     return false;
   }
@@ -117,7 +162,7 @@ function describeToJsonValue(value: unknown): string {
   if (typeof value === "bigint") return "BigInt";
   if (typeof value === "object") {
     try {
-      Date.prototype.getTime.call(value);
+      reflectApply(dateGetTime, value, []);
       return "Date";
     } catch {
       // The value is not a Date.
@@ -130,9 +175,23 @@ function toJsonLength(value: unknown): number {
   // Unary plus uses the specification's ToNumber operation, which rejects a
   // BigInt directly or returned by an object's primitive conversion.
   const number = +(value as number);
-  if (Number.isNaN(number) || number <= 0) return 0;
-  if (number === Number.POSITIVE_INFINITY) return Number.MAX_SAFE_INTEGER;
-  return Math.min(Math.floor(number), Number.MAX_SAFE_INTEGER);
+  if (numberIsNaN(number) || number <= 0) return 0;
+  if (number === POSITIVE_INFINITY) return MAX_SAFE_INTEGER;
+  return mathMin(mathFloor(number), MAX_SAFE_INTEGER);
+}
+
+function hasToStringTagWithoutHooks(value: JsonTraversalReference): boolean {
+  let current: object | null = value;
+  for (let depth = 0; current !== null && depth < 100; depth++) {
+    if (isProxyWithoutHooks(current)) return true;
+    try {
+      if (objectGetOwnPropertyDescriptor(current, symbolToStringTag)) return true;
+      current = objectGetPrototypeOf(current);
+    } catch {
+      return true;
+    }
+  }
+  return current !== null;
 }
 
 /**
@@ -145,8 +204,8 @@ function toJsonLength(value: unknown): number {
  */
 function couldHoldPrimitiveSlot(value: JsonTraversalReference): boolean {
   try {
-    if (Symbol.toStringTag in value) return true;
-    const tag = Object.prototype.toString.call(value);
+    if (hasToStringTagWithoutHooks(value)) return true;
+    const tag = reflectApply(objectToString, value, []);
     return tag === "[object Number]" || tag === "[object String]" ||
       tag === "[object Boolean]" || tag === "[object BigInt]";
   } catch {
@@ -169,25 +228,25 @@ type BoxedPrimitiveSlot = "number" | "string" | "boolean" | "bigint";
 function boxedPrimitiveSlot(value: JsonTraversalReference): BoxedPrimitiveSlot | null {
   if (!couldHoldPrimitiveSlot(value)) return null;
   try {
-    Number.prototype.valueOf.call(value);
+    reflectApply(NumberValueOf, value, []);
     return "number";
   } catch {
     // Try the next boxed primitive brand.
   }
   try {
-    String.prototype.valueOf.call(value);
+    reflectApply(StringValueOf, value, []);
     return "string";
   } catch {
     // Try the next boxed primitive brand.
   }
   try {
-    Boolean.prototype.valueOf.call(value);
+    reflectApply(BooleanValueOf, value, []);
     return "boolean";
   } catch {
     // Try the next boxed primitive brand.
   }
   try {
-    BigInt.prototype.valueOf.call(value);
+    reflectApply(BigIntValueOf, value, []);
     return "bigint";
   } catch {
     return null;
@@ -215,9 +274,9 @@ function unboxAsJsonWould(
 ): string | number | boolean | bigint {
   if (slot === "number") return +(value as number);
   if (slot === "string") return `${value as string}`;
-  if (slot === "boolean") return Boolean.prototype.valueOf.call(value as boolean);
+  if (slot === "boolean") return reflectApply(BooleanValueOf, value as boolean, []);
   // JSON refuses a BigInt box outright, and the walk reports it by its path.
-  return BigInt.prototype.valueOf.call(value as bigint);
+  return reflectApply(BigIntValueOf, value as bigint, []);
 }
 
 /** Build the exact value JSON will encode, collecting what it cannot carry. */
@@ -229,11 +288,13 @@ function normalizeAndFindUnrepresentableValues(
   unrepresentable: UnrepresentableValues;
 } {
   const found: UnrepresentableValues = { fatal: [], lossy: [], fatalCount: 0, lossyCount: 0 };
-  const active = new Set<JsonTraversalReference>();
+  const active = new SetConstructor<JsonTraversalReference>();
 
   const recordFatal = (path: string, kind: string) => {
     found.fatalCount++;
-    if (found.fatal.length < MAX_REPORTED_PATHS) found.fatal.push({ path, kind });
+    if (found.fatal.length < MAX_REPORTED_PATHS) {
+      defineArrayElement(found.fatal, found.fatal.length, { path, kind });
+    }
   };
 
   // `index` is appended here rather than by the caller, so an array with more
@@ -241,7 +302,10 @@ function normalizeAndFindUnrepresentableValues(
   const recordLossy = (path: string, kind: string, index?: number) => {
     found.lossyCount++;
     if (found.lossy.length >= MAX_REPORTED_PATHS) return;
-    found.lossy.push({ path: index === undefined ? path : `${path}[${index}]`, kind });
+    defineArrayElement(found.lossy, found.lossy.length, {
+      path: index === undefined ? path : `${path}[${index}]`,
+      kind,
+    });
   };
 
   const normalize = (
@@ -256,8 +320,8 @@ function normalizeAndFindUnrepresentableValues(
     const type = typeof value;
     if (
       type === "object" &&
-      typeof jsonRawSupport.isRawJSON === "function" &&
-      jsonRawSupport.isRawJSON(value)
+      jsonIsRawJSON !== undefined &&
+      reflectApply(jsonIsRawJSON, jsonRawSupport, [value])
     ) {
       return value as RawJsonValue;
     }
@@ -265,10 +329,12 @@ function normalizeAndFindUnrepresentableValues(
       applyToJson &&
       (type === "object" || type === "function" || type === "bigint")
     ) {
-      const receiver = type === "bigint" ? Object(value) : value as JsonTraversalReference;
-      const toJson = Reflect.get(receiver, "toJSON");
+      const receiver = type === "bigint"
+        ? ObjectConstructor(value)
+        : value as JsonTraversalReference;
+      const toJson = reflectGet(receiver, "toJSON");
       if (typeof toJson === "function") {
-        const replacement = Reflect.apply(toJson, value, [key]);
+        const replacement = reflectApply(toJson, value, [key]);
         recordLossy(path, describeToJsonValue(value));
         return normalize(replacement, path, key, false, depth);
       }
@@ -276,7 +342,7 @@ function normalizeAndFindUnrepresentableValues(
 
     if (type === "string" || type === "boolean") return value as string | boolean;
     if (type === "number") {
-      if (!Number.isFinite(value)) {
+      if (!numberIsFinite(value)) {
         recordLossy(path, describe(value));
         return null;
       }
@@ -292,12 +358,12 @@ function normalizeAndFindUnrepresentableValues(
     }
 
     const nested = value as JsonTraversalReference;
-    if (active.has(nested)) {
+    if (reflectApply(setHas, active, [nested])) {
       recordFatal(path, "circular reference");
       return null;
     }
 
-    const isArray = Array.isArray(nested);
+    const isArray = arrayIsArray(nested);
     if (!isArray) {
       const slot = boxedPrimitiveSlot(nested);
       if (slot !== null) {
@@ -312,23 +378,25 @@ function normalizeAndFindUnrepresentableValues(
     // that answers differently on its second call would then persist a value
     // this check never saw. Nothing below here is reported, which is the price.
     if (depth >= MAX_TRAVERSAL_DEPTH) return nested as NormalizedJsonValue;
-    active.add(nested);
+    reflectApply(setAdd, active, [nested]);
     try {
       if (isArray) {
         const result: NormalizedJsonValue[] = [];
-        const length = toJsonLength(Reflect.get(nested, "length"));
+        const length = toJsonLength(reflectGet(nested, "length"));
         for (let index = 0; index < length; index++) {
-          const indexKey = String(index);
-          const child = Reflect.get(nested, indexKey);
+          const indexKey = StringConstructor(index);
+          const child = reflectGet(nested, indexKey);
           let isHole = false;
-          try {
-            isHole = !Object.hasOwn(nested, indexKey);
-          } catch {
-            // Hole diagnostics are best-effort; the captured value still wins.
+          if (!isProxyWithoutHooks(nested)) {
+            try {
+              isHole = !objectHasOwn(nested, indexKey);
+            } catch {
+              // Hole diagnostics are best-effort; the captured value still wins.
+            }
           }
           if (isHole) recordLossy(path, "array hole", index);
           if (isHole && child === undefined) {
-            result.push(null);
+            defineArrayElement(result, result.length, null);
             continue;
           }
           const normalized = normalize(
@@ -338,15 +406,21 @@ function normalizeAndFindUnrepresentableValues(
             true,
             depth + 1,
           );
-          result.push(normalized === OMIT_JSON_VALUE ? null : normalized);
+          defineArrayElement(
+            result,
+            result.length,
+            normalized === OMIT_JSON_VALUE ? null : normalized,
+          );
         }
         return result;
       }
 
-      const result: NormalizedJsonObject = Object.create(null);
-      for (const childKey of Object.keys(nested)) {
+      const result: NormalizedJsonObject = objectCreate(null);
+      const childKeys = objectKeys(nested);
+      for (let childIndex = 0; childIndex < childKeys.length; childIndex++) {
+        const childKey = childKeys[childIndex]!;
         const normalized = normalize(
-          Reflect.get(nested, childKey),
+          reflectGet(nested, childKey),
           `${path}.${redactPathSegment(childKey)}`,
           childKey,
           true,
@@ -359,7 +433,7 @@ function normalizeAndFindUnrepresentableValues(
       if (!isPlainObject(nested)) recordLossy(path, describe(nested));
       return result;
     } finally {
-      active.delete(nested);
+      reflectApply(setDelete, active, [nested]);
     }
   };
 
@@ -372,9 +446,14 @@ function normalizeAndFindUnrepresentableValues(
 }
 
 function formatPaths(samples: readonly UnrepresentableValue[], total: number): string {
-  const shown = samples.map(({ path, kind }) => `${path} (${kind})`).join(", ");
+  let shown = "";
+  for (let index = 0; index < samples.length; index++) {
+    if (index > 0) shown += ", ";
+    shown += `${samples[index]!.path} (${samples[index]!.kind})`;
+  }
   const remaining = total - samples.length;
-  return remaining > 0 ? `${shown}, and ${remaining} more` : shown;
+  if (remaining <= 0) return shown;
+  return shown ? `${shown}, and ${remaining} more` : `and ${remaining} more`;
 }
 
 /**
@@ -425,6 +504,18 @@ export function prepareWorkflowJson(
     });
   }
 
+  const serialized = jsonStringify(normalized);
+  if (serialized === undefined) {
+    const paths = lossyCount > 0
+      ? formatPaths(lossy, lossyCount)
+      : `${label} (value omitted by JSON)`;
+    throw ORCHESTRATION_ERROR.create({
+      detail: `Workflow run cannot be persisted: ${paths}. Workflow state must produce a JSON ` +
+        `document, because a run that suspends is stored as JSON. Return a plain object from ` +
+        `the step that produced this value.`,
+    });
+  }
+
   if (lossyCount > 0) {
     logger.warn(
       "Workflow state holds values that do not survive persistence unchanged",
@@ -437,7 +528,7 @@ export function prepareWorkflowJson(
 
   // Encoded only once the fatal check has passed, so a value JSON refuses is
   // named by this module rather than by the anonymous error JSON raises.
-  return { normalized, serialized: JSON.stringify(normalized) };
+  return { normalized, serialized };
 }
 
 export function serializeWorkflowJson(value: unknown, label: string, runId?: string): string {

--- a/src/workflow/context-serialization.ts
+++ b/src/workflow/context-serialization.ts
@@ -1,5 +1,8 @@
 import { ORCHESTRATION_ERROR } from "#veryfront/errors";
-import { isProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
+import {
+  canIdentifyProxyWithoutHooks,
+  isProxyWithoutHooks,
+} from "#veryfront/platform/compat/error-introspection.ts";
 import { agentLogger } from "#veryfront/utils";
 import type { WorkflowContext } from "./types.ts";
 
@@ -149,7 +152,7 @@ function describe(value: unknown): string {
 
 /** Whether a value is a plain `{}` object rather than a class instance. */
 function isPlainObject(value: JsonTraversalReference): boolean {
-  if (isProxyWithoutHooks(value)) return false;
+  if (!canIdentifyProxyWithoutHooks || isProxyWithoutHooks(value)) return false;
   try {
     const prototype = objectGetPrototypeOf(value);
     return prototype === objectPrototype || prototype === null;
@@ -181,6 +184,7 @@ function toJsonLength(value: unknown): number {
 }
 
 function hasToStringTagWithoutHooks(value: JsonTraversalReference): boolean {
+  if (!canIdentifyProxyWithoutHooks) return true;
   let current: object | null = value;
   for (let depth = 0; current !== null && depth < 100; depth++) {
     if (isProxyWithoutHooks(current)) return true;
@@ -387,7 +391,7 @@ function normalizeAndFindUnrepresentableValues(
           const indexKey = StringConstructor(index);
           const child = reflectGet(nested, indexKey);
           let isHole = false;
-          if (!isProxyWithoutHooks(nested)) {
+          if (canIdentifyProxyWithoutHooks && !isProxyWithoutHooks(nested)) {
             try {
               isHole = !objectHasOwn(nested, indexKey);
             } catch {

--- a/tests/integration/workflow/context-serialization-intrinsics.test.ts
+++ b/tests/integration/workflow/context-serialization-intrinsics.test.ts
@@ -10,6 +10,69 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { serializeWorkflowContext } from "#veryfront/workflow/context-serialization.ts";
 
 describe("workflow context serialization with hostile ambient intrinsics", () => {
+  it("skips diagnostic-only Proxy metadata when brand checks are unavailable", async () => {
+    const script = `
+      Object.defineProperty(globalThis, "caches", {
+        configurable: true,
+        value: {},
+      });
+      Object.defineProperty(globalThis, "WebSocketPair", {
+        configurable: true,
+        value: function WebSocketPair() {},
+      });
+
+      const { canIdentifyProxyWithoutHooks } = await import(
+        "./src/platform/compat/error-introspection.ts"
+      );
+      const { serializeWorkflowContext } = await import(
+        "./src/workflow/context-serialization.ts"
+      );
+      let prototypeTrapCalls = 0;
+      let descriptorTrapCalls = 0;
+      let ownKeysCalls = 0;
+      const value = new Proxy({}, {
+        getPrototypeOf() {
+          prototypeTrapCalls += 1;
+          throw new Error("diagnostic prototype trap must not run");
+        },
+        getOwnPropertyDescriptor() {
+          descriptorTrapCalls += 1;
+          throw new Error("diagnostic descriptor trap must not run");
+        },
+        ownKeys() {
+          ownKeysCalls += 1;
+          return [];
+        },
+      });
+      const serialized = serializeWorkflowContext({ input: {}, step: value });
+      console.log(JSON.stringify({
+        canIdentifyProxyWithoutHooks,
+        serialized,
+        prototypeTrapCalls,
+        descriptorTrapCalls,
+        ownKeysCalls,
+      }));
+    `;
+    const output = await new Deno.Command(Deno.execPath(), {
+      args: ["eval", "--config=deno.json", script],
+      cwd: new URL("../../../", import.meta.url),
+      stdout: "piped",
+      stderr: "piped",
+    }).output();
+    const stderr = new TextDecoder().decode(output.stderr);
+    assertEquals(output.code, 0, stderr);
+    assertEquals(
+      JSON.parse(new TextDecoder().decode(output.stdout)),
+      {
+        canIdentifyProxyWithoutHooks: false,
+        serialized: '{"input":{},"step":{}}',
+        prototypeTrapCalls: 0,
+        descriptorTrapCalls: 0,
+        ownKeysCalls: 1,
+      },
+    );
+  });
+
   it("uses admitted JSON, object, reflection, and array primitives", () => {
     const originalStringify = JSON.stringify;
     const originalKeys = Object.keys;

--- a/tests/integration/workflow/context-serialization-intrinsics.test.ts
+++ b/tests/integration/workflow/context-serialization-intrinsics.test.ts
@@ -1,0 +1,89 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { VeryfrontError } from "#veryfront/errors";
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { serializeWorkflowContext } from "#veryfront/workflow/context-serialization.ts";
+
+describe("workflow context serialization with hostile ambient intrinsics", () => {
+  it("uses admitted JSON, object, reflection, and array primitives", () => {
+    const originalStringify = JSON.stringify;
+    const originalKeys = Object.keys;
+    const originalGet = Reflect.get;
+    const originalPush = Array.prototype.push;
+    let serialized = "";
+    try {
+      JSON.stringify = (() => "{}") as typeof JSON.stringify;
+      Object.keys = (() => []) as typeof Object.keys;
+      Reflect.get = (() => undefined) as typeof Reflect.get;
+      Array.prototype.push = function () {
+        return this.length;
+      };
+      serialized = serializeWorkflowContext({
+        input: {},
+        step: { values: [1, 2], nested: { ok: true } },
+      });
+    } finally {
+      JSON.stringify = originalStringify;
+      Object.keys = originalKeys;
+      Reflect.get = originalGet;
+      Array.prototype.push = originalPush;
+    }
+
+    assertEquals(JSON.parse(serialized), {
+      input: {},
+      step: { values: [1, 2], nested: { ok: true } },
+    });
+  });
+
+  it("detects cycles after Set methods are replaced", () => {
+    const originalHas = Set.prototype.has;
+    const originalAdd = Set.prototype.add;
+    const originalDelete = Set.prototype.delete;
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    let error: unknown;
+    try {
+      Set.prototype.has = () => false;
+      Set.prototype.add = function () {
+        return this;
+      };
+      Set.prototype.delete = () => false;
+      error = assertThrows(
+        () => serializeWorkflowContext({ input: {}, step: cyclic }),
+      );
+    } finally {
+      Set.prototype.has = originalHas;
+      Set.prototype.add = originalAdd;
+      Set.prototype.delete = originalDelete;
+    }
+
+    assertInstanceOf(error, VeryfrontError);
+    assertStringIncludes(error.message, "context.step.self");
+    assertStringIncludes(error.message, "circular reference");
+  });
+
+  it("keeps sensitive path segments redacted after RegExp execution is replaced", () => {
+    const originalExec = RegExp.prototype.exec;
+    let error: unknown;
+    try {
+      RegExp.prototype.exec = (() => ({ 0: "matched", index: 0 })) as never;
+      error = assertThrows(() =>
+        serializeWorkflowContext({
+          input: {},
+          step: { "user@example.com": 1n },
+        })
+      );
+    } finally {
+      RegExp.prototype.exec = originalExec;
+    }
+
+    assertInstanceOf(error, VeryfrontError);
+    assertEquals(error.message.includes("user@example.com"), false);
+    assertStringIncludes(error.message, "<redacted>");
+  });
+});


### PR DESCRIPTION
## Summary

- capture JSON, reflection, object, array, numeric, regexp, and Set primordials before project code can replace them
- construct normalized arrays and retained diagnostics with own data properties
- avoid diagnostic-only Proxy prototype and hole inspection
- keep sensitive diagnostic path segments redacted under regexp poisoning
- reject root values that produce no JSON document instead of returning runtime `undefined` through a string contract
- update the differential generator so root `undefined` no longer makes an invalid implementation look equal to native JSON
- add isolated hostile-runtime regressions

## Test audit findings

- Symptom: serialization tests exercised hostile values but not hostile shared-realm primordials.
  Source: mutable global JSON, reflection, object, array, Set, and regexp operations remained live after module admission.
  Consequence: project code could corrupt durable state, disable cycle detection, or expose a sensitive property key in diagnostics.
  Remedy: capture the persistence primordials and exercise replacements in a separate integration owner.
- Symptom: best-effort diagnostics invoked a Proxy prototype trap that native JSON did not need.
  Source: prototype classification ran after snapshotting without first rejecting a direct Proxy.
  Consequence: merely describing lossiness executed an extra project hook.
  Remedy: classify a direct Proxy as non-plain without invoking its prototype trap.
- Symptom: the differential generator accepted `undefined === undefined` for root values.
  Source: both native JSON and the supposedly string-returning helper produced runtime `undefined`, while the test annotated both as strings.
  Consequence: a persistence helper violated its return contract and the comparison reported agreement.
  Remedy: reject root values that produce no JSON document and make the generator model `string | undefined` explicitly.

## Verification

- `deno task test:file src/workflow/context-serialization.test.ts tests/integration/workflow/context-serialization-intrinsics.test.ts`: 2 passed, 45 steps
- `deno task test:file src/workflow`: 82 passed, 917 steps
- `deno task test:unit`: passed, including parallel, cwd, and cwd-exclusion profiles
- `deno task test:integration`: 320 passed, 2,954 steps
- `deno task lint`: passed
- `deno task typecheck`: passed
- `deno task lint:anti-slop`: passed
- `deno task lint:test-typecheck`: passed
- `deno task lint:test-semantic-dispositions`: passed
- `deno task docs`: passed
- `deno task docs:api-reference:check`: passed
- `deno task docs:public:check`: passed

## Red-green evidence

Before implementation, the owner test failed on the Proxy prototype trap, all three hostile-runtime tests failed for their intended reasons, and direct plus generated root-document tests exposed runtime `undefined`. The same focused command now passes all 45 steps.