### PR TITLE
Harden workflow registry metadata capture

### DIFF
--- a/docs/api-reference/veryfront/workflow.md
+++ b/docs/api-reference/veryfront/workflow.md
@@ -136,8 +136,8 @@ Options accepted by parallel.
 | `deriveRunEvents`          | Events describing how a run got from `previous` to `next`.                                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/events.ts#L170)                  |
 | `doWhile`                  | Create a do-while workflow loop.                                                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/loop.ts#L105)                |
 | `generateId`               | Generate a unique workflow ID                                                                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/types.ts#L652)                   |
-| `getAllWorkflowIds`        | List registered workflow IDs for the current project scope.                                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L438)                |
-| `getWorkflow`              | Get metadata for a registered workflow by ID.                                                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L433)                |
+| `getAllWorkflowIds`        | List registered workflow IDs for the current project scope.                                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L527)                |
+| `getWorkflow`              | Get metadata for a registered workflow by ID.                                                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L522)                |
 | `getWorkflowTenant`        | Get the current workflow tenant context. Returns undefined if not executing within a workflow step. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/executor/step-executor.ts#L56)   |
 | `hasRunObservationSupport` | Check whether atomic run observation is available.                                                  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/backends/types.ts#L278)          |
 | `hasWorkerSupport`         | Check whether worker support is present.                                                            | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/backends/types.ts#L303)          |
@@ -180,7 +180,7 @@ Options accepted by parallel.
 | `CapturedTenantContext`       | Captured tenant context for multi-tenant workflow execution. Allows tools and framework utilities to access the current tenant without explicit parameter passing. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/types.ts#L335)                      |
 | `LoopOptions`                 | Options accepted by loop.                                                                                                                                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/loop.ts#L20)                    |
 | `MapOptions`                  | Options accepted by map.                                                                                                                                           | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/map.ts#L13)                     |
-| `NodeInfo`                    | Metadata for one node in a registered workflow graph.                                                                                                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L18)                    |
+| `NodeInfo`                    | Metadata for one node in a registered workflow graph.                                                                                                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L74)                    |
 | `ParallelOptions`             | Options accepted by parallel.                                                                                                                                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/parallel.ts#L12)                |
 | `RedisAdapter`                | Standardized Redis Adapter Interface Normalizes differences between Deno and Node Redis clients                                                                    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/platform/adapters/redis/interface.ts#L5)     |
 | `RedisBackendConfig`          | Redis backend configuration                                                                                                                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/backends/redis/types.ts#L22)        |
@@ -206,7 +206,7 @@ Options accepted by parallel.
 | `WorkflowHandle`              | Controller for a running workflow.                                                                                                                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/executor/workflow-executor.ts#L102) |
 | `WorkflowHandlerOptions`      | Options for `createWorkflowHandler`.                                                                                                                               | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/http/handler.ts#L35)                |
 | `WorkflowHandlers`            | Route handlers to re-export from a catch-all route module.                                                                                                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/http/handler.ts#L44)                |
-| `WorkflowMetadata`            | Public metadata captured for a registered workflow.                                                                                                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L36)                    |
+| `WorkflowMetadata`            | Public metadata captured for a registered workflow.                                                                                                                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L92)                    |
 | `WorkflowNode`                | Workflow node                                                                                                                                                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/types.ts#L295)                      |
 | `WorkflowNodeConfig`          | Union of all workflow node configurations                                                                                                                          | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/types.ts#L283)                      |
 | `WorkflowOptions`             | Options accepted by workflow.                                                                                                                                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/dsl/workflow.ts#L23)                |
@@ -229,7 +229,7 @@ Options accepted by parallel.
 | Name               | Description                                                    | Source                                                                                        |
 | ------------------ | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
 | `api`              | Context-aware API that automatically uses the current tenant.  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/api.ts#L114)      |
-| `workflowRegistry` | Project-scoped registry for workflow metadata and definitions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L425) |
+| `workflowRegistry` | Project-scoped registry for workflow metadata and definitions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L514) |
 
 ## Deep imports
 
@@ -514,22 +514,22 @@ import { getAllWorkflowIds, getWorkflow, registerWorkflow } from "veryfront/work
 
 | Name                | Description                                                  | Source                                                                                        |
 | ------------------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| `getAllWorkflowIds` | List registered workflow IDs for the current project scope.  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L438) |
-| `getWorkflow`       | Get metadata for a registered workflow by ID.                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L433) |
-| `registerWorkflow`  | Register a workflow definition in the current project scope. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L428) |
+| `getAllWorkflowIds` | List registered workflow IDs for the current project scope.  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L527) |
+| `getWorkflow`       | Get metadata for a registered workflow by ID.                | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L522) |
+| `registerWorkflow`  | Register a workflow definition in the current project scope. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L517) |
 
 #### Types
 
 | Name               | Description                                           | Source                                                                                       |
 | ------------------ | ----------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `NodeInfo`         | Metadata for one node in a registered workflow graph. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L18) |
-| `WorkflowMetadata` | Public metadata captured for a registered workflow.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L36) |
+| `NodeInfo`         | Metadata for one node in a registered workflow graph. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L74) |
+| `WorkflowMetadata` | Public metadata captured for a registered workflow.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L92) |
 
 #### Constants
 
 | Name               | Description                                                    | Source                                                                                        |
 | ------------------ | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `workflowRegistry` | Project-scoped registry for workflow metadata and definitions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L425) |
+| `workflowRegistry` | Project-scoped registry for workflow metadata and definitions. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/registry.ts#L514) |
 
 ### `veryfront/workflow/worker`
 

--- a/src/workflow/registry.ts
+++ b/src/workflow/registry.ts
@@ -5,14 +5,70 @@ import { snapshotThrowableDiagnostic } from "#veryfront/errors/safe-diagnostics.
 import { isProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
 import { ScopedRegistryFacade } from "#veryfront/registry/scoped-registry-facade.ts";
 import { ProjectScopedRegistryManager } from "#veryfront/registry/project-scoped-registry-manager.ts";
-import type { Workflow, WorkflowDefinition, WorkflowNode } from "./types.ts";
+import type { StepBuilderContext, Workflow, WorkflowDefinition, WorkflowNode } from "./types.ts";
 import {
   captureWorkflowDefinition,
   captureWorkflowNodes,
   captureWorkflowStaticValue,
 } from "./executor/workflow-definition-snapshot.ts";
 
+const arrayIsArray = Array.isArray;
+const dateToISOString = Date.prototype.toISOString;
+const mapForEach = Map.prototype.forEach;
+const NativeDate = Date;
+const NativeProxy = Proxy;
+const NativeSet = Set;
+const objectDefineProperty = Object.defineProperty;
 const objectFreeze = Object.freeze;
+const objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const objectHasOwn = Object.hasOwn;
+const reflectApply = Reflect.apply;
+const setAdd = Set.prototype.add;
+const setForEach = Set.prototype.forEach;
+
+function setOwnDataProperty(
+  target: NodeInfo | Record<string, number> | unknown[],
+  key: PropertyKey,
+  value: unknown,
+): void {
+  objectDefineProperty(target, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+}
+
+function appendArrayValue<T>(values: T[], value: T): void {
+  setOwnDataProperty(values, values.length, value);
+}
+
+function appendArrayValues<T>(target: T[], values: readonly T[]): void {
+  for (let index = 0; index < values.length; index++) {
+    appendArrayValue(target, values[index]);
+  }
+}
+
+function copyArray<T>(values: readonly T[]): T[] {
+  const copy: T[] = [];
+  appendArrayValues(copy, values);
+  return copy;
+}
+
+function getOwnDataProperty<T>(value: unknown, key: PropertyKey): T | undefined {
+  if (
+    (typeof value !== "object" && typeof value !== "function") ||
+    value === null
+  ) return undefined;
+  const descriptor = objectGetOwnPropertyDescriptor(value, key);
+  return descriptor && objectHasOwn(descriptor, "value") ? descriptor.value as T : undefined;
+}
+
+function setToArray<T>(values: ReadonlySet<T>): T[] {
+  const entries: T[] = [];
+  reflectApply(setForEach, values, [(value: T) => appendArrayValue(entries, value)]);
+  return entries;
+}
 
 /** Metadata for one node in a registered workflow graph. */
 export interface NodeInfo {
@@ -64,7 +120,7 @@ export interface WorkflowMetadata {
 }
 
 function createProxy(): unknown {
-  return new Proxy(
+  return new NativeProxy(
     {},
     {
       get: (_target, prop) => (typeof prop === "string" ? createProxy() : undefined),
@@ -78,8 +134,8 @@ function getWorkflowDefinition(workflow: Workflow | WorkflowDefinition): Workflo
     workflow !== null && !isProxyWithoutHooks(workflow)
   ) {
     try {
-      const descriptor = Object.getOwnPropertyDescriptor(workflow, "definition");
-      if (descriptor && "value" in descriptor) {
+      const descriptor = objectGetOwnPropertyDescriptor(workflow, "definition");
+      if (descriptor && objectHasOwn(descriptor, "value")) {
         return descriptor.value as WorkflowDefinition;
       }
     } catch {
@@ -98,8 +154,9 @@ function getCollaboratorId(value: unknown): string | undefined {
   }
 
   try {
-    const descriptor = Object.getOwnPropertyDescriptor(value, "id");
-    return descriptor && "value" in descriptor && typeof descriptor.value === "string"
+    const descriptor = objectGetOwnPropertyDescriptor(value, "id");
+    return descriptor && objectHasOwn(descriptor, "value") &&
+        typeof descriptor.value === "string"
       ? descriptor.value
       : undefined;
   } catch {
@@ -112,16 +169,18 @@ function extractMetadata(definition: WorkflowDefinition): WorkflowMetadata {
   let dynamicSteps = false;
   let introspectionSkipped = false;
   let introspectionError: string | undefined;
+  const id = getOwnDataProperty<string>(definition, "id") as string;
+  const steps = getOwnDataProperty<WorkflowDefinition["steps"]>(definition, "steps");
 
-  if (Array.isArray(definition.steps)) {
-    workflowNodes = definition.steps;
-  } else if (typeof definition.steps === "function") {
+  if (arrayIsArray(steps)) {
+    workflowNodes = steps;
+  } else if (typeof steps === "function") {
     dynamicSteps = true;
 
-    if (!definition.introspect) {
+    if (!getOwnDataProperty<boolean>(definition, "introspect")) {
       introspectionSkipped = true;
       logger.debug(
-        `[WorkflowRegistry] Skipping dynamic steps introspection for "${definition.id}" (introspect=false)`,
+        `[WorkflowRegistry] Skipping dynamic steps introspection for "${id}" (introspect=false)`,
       );
     } else {
       try {
@@ -129,43 +188,35 @@ function extractMetadata(definition: WorkflowDefinition): WorkflowMetadata {
         const dummyContext: Record<string, unknown> = { input: createProxy() };
 
         workflowNodes = captureWorkflowNodes(
-          definition.steps(
+          reflectApply(steps, definition, [
             {
               input: dummyInput,
               context: dummyContext,
-            } as Parameters<typeof definition.steps>[0],
-          ),
-          `Workflow "${definition.id}" introspection`,
+            } as StepBuilderContext,
+          ]),
+          `Workflow "${id}" introspection`,
         );
       } catch (error) {
         introspectionError = snapshotThrowableDiagnostic(error);
         logger.warn(
-          `[WorkflowRegistry] Failed to introspect steps for "${definition.id}": ${introspectionError}`,
+          `[WorkflowRegistry] Failed to introspect steps for "${id}": ${introspectionError}`,
         );
       }
     }
   }
 
-  const nodeTypes = new Set<string>();
+  const nodeTypes = new NativeSet<string>();
   const nodeInfoList: NodeInfo[] = [];
-  const agentRefs = new Set<string>();
-  const toolRefs = new Set<string>();
+  const agentRefs = new NativeSet<string>();
+  const toolRefs = new NativeSet<string>();
 
   function extractNodeInfo(nodeList: WorkflowNode[]): string[] {
     const ids: string[] = [];
 
-    for (const node of nodeList) {
-      const type = node.config.type;
-      nodeTypes.add(type);
-      ids.push(node.id);
-
-      const nodeInfo: NodeInfo = {
-        id: node.id,
-        type,
-        dependsOn: node.dependsOn === undefined ? undefined : objectFreeze([...node.dependsOn]),
-      };
-
-      const config = node.config as {
+    for (let index = 0; index < nodeList.length; index++) {
+      const node = nodeList[index]!;
+      const config = getOwnDataProperty<WorkflowNode["config"]>(node, "config") as {
+        type: string;
         agent?: unknown;
         tool?: unknown;
         message?: unknown;
@@ -175,51 +226,70 @@ function extractMetadata(definition: WorkflowDefinition): WorkflowMetadata {
         else?: unknown;
         steps?: unknown;
       };
+      const type = getOwnDataProperty<string>(config, "type") as string;
+      const nodeId = getOwnDataProperty<string>(node, "id") as string;
+      reflectApply(setAdd, nodeTypes, [type]);
+      appendArrayValue(ids, nodeId);
 
-      if (typeof config.description === "string") {
-        nodeInfo.description = config.description;
+      const dependencies = getOwnDataProperty<readonly string[]>(node, "dependsOn");
+
+      const nodeInfo: NodeInfo = {
+        id: nodeId,
+        type,
+        dependsOn: dependencies === undefined ? undefined : objectFreeze(copyArray(dependencies)),
+      };
+
+      const description = getOwnDataProperty<unknown>(config, "description");
+      if (typeof description === "string") {
+        setOwnDataProperty(nodeInfo, "description", description);
       }
 
       if (type === "step") {
-        const agentValue = config.agent;
+        const agentValue = getOwnDataProperty<unknown>(config, "agent");
         const agentRef = getCollaboratorId(agentValue);
 
         if (agentRef) {
-          nodeInfo.agent = agentRef;
-          agentRefs.add(agentRef);
+          setOwnDataProperty(nodeInfo, "agent", agentRef);
+          reflectApply(setAdd, agentRefs, [agentRef]);
         }
 
-        const toolValue = config.tool;
+        const toolValue = getOwnDataProperty<unknown>(config, "tool");
         const toolRef = getCollaboratorId(toolValue);
 
         if (toolRef) {
-          nodeInfo.tool = toolRef;
-          toolRefs.add(toolRef);
+          setOwnDataProperty(nodeInfo, "tool", toolRef);
+          reflectApply(setAdd, toolRefs, [toolRef]);
         }
       }
 
-      if (type === "wait" && "message" in config) {
-        nodeInfo.message = config.message as string;
+      if (type === "wait" && objectHasOwn(config, "message")) {
+        setOwnDataProperty(nodeInfo, "message", getOwnDataProperty(config, "message"));
       }
 
       const children: string[] = [];
 
-      if (Array.isArray(config.nodes)) {
-        children.push(...extractNodeInfo(config.nodes as WorkflowNode[]));
+      const nodes = getOwnDataProperty<unknown>(config, "nodes");
+      if (arrayIsArray(nodes)) {
+        appendArrayValues(children, extractNodeInfo(nodes as WorkflowNode[]));
       }
-      if (Array.isArray(config.then)) {
-        children.push(...extractNodeInfo(config.then as WorkflowNode[]));
+      const thenNodes = getOwnDataProperty<unknown>(config, "then");
+      if (arrayIsArray(thenNodes)) {
+        appendArrayValues(children, extractNodeInfo(thenNodes as WorkflowNode[]));
       }
-      if (Array.isArray(config.else)) {
-        children.push(...extractNodeInfo(config.else as WorkflowNode[]));
+      const elseNodes = getOwnDataProperty<unknown>(config, "else");
+      if (arrayIsArray(elseNodes)) {
+        appendArrayValues(children, extractNodeInfo(elseNodes as WorkflowNode[]));
       }
-      if (Array.isArray(config.steps)) {
-        children.push(...extractNodeInfo(config.steps as WorkflowNode[]));
+      const loopSteps = getOwnDataProperty<unknown>(config, "steps");
+      if (arrayIsArray(loopSteps)) {
+        appendArrayValues(children, extractNodeInfo(loopSteps as WorkflowNode[]));
       }
 
-      if (children.length) nodeInfo.children = objectFreeze(children);
+      if (children.length) {
+        setOwnDataProperty(nodeInfo, "children", objectFreeze(children));
+      }
 
-      nodeInfoList.push(objectFreeze(nodeInfo));
+      appendArrayValue(nodeInfoList, objectFreeze(nodeInfo));
     }
 
     return ids;
@@ -229,39 +299,50 @@ function extractMetadata(definition: WorkflowDefinition): WorkflowMetadata {
 
   let inputSchemaJson: Record<string, unknown> | undefined;
   let inputSchemaError: string | undefined;
-  if (definition.inputSchema) {
+  const inputSchema = getOwnDataProperty<WorkflowDefinition["inputSchema"]>(
+    definition,
+    "inputSchema",
+  );
+  const outputSchema = getOwnDataProperty<WorkflowDefinition["outputSchema"]>(
+    definition,
+    "outputSchema",
+  );
+  if (inputSchema) {
     try {
       inputSchemaJson = captureWorkflowStaticValue(
-        zodToJsonSchema(definition.inputSchema) as Record<string, unknown>,
-        `Workflow "${definition.id}" input schema metadata`,
+        zodToJsonSchema(inputSchema) as Record<string, unknown>,
+        `Workflow "${id}" input schema metadata`,
       );
     } catch (error) {
       inputSchemaError = snapshotThrowableDiagnostic(error);
       logger.warn(
-        `[WorkflowRegistry] Failed to convert input schema for "${definition.id}": ${inputSchemaError}`,
+        `[WorkflowRegistry] Failed to convert input schema for "${id}": ${inputSchemaError}`,
       );
     }
   }
 
   return objectFreeze({
-    id: definition.id,
-    description: definition.description,
-    version: definition.version,
-    timeout: definition.timeout,
-    integrationRequirements: definition.integrationRequirements,
+    id,
+    description: getOwnDataProperty<WorkflowMetadata["description"]>(definition, "description"),
+    version: getOwnDataProperty<WorkflowMetadata["version"]>(definition, "version"),
+    timeout: getOwnDataProperty<WorkflowMetadata["timeout"]>(definition, "timeout"),
+    integrationRequirements: getOwnDataProperty<WorkflowMetadata["integrationRequirements"]>(
+      definition,
+      "integrationRequirements",
+    ),
     dynamicSteps,
     introspectionSkipped,
     introspectionError,
     nodeCount: workflowNodes.length,
-    nodeTypes: objectFreeze(Array.from(nodeTypes)),
+    nodeTypes: objectFreeze(setToArray(nodeTypes)),
     nodes: objectFreeze(nodeInfoList),
-    agentRefs: objectFreeze(Array.from(agentRefs)),
-    toolRefs: objectFreeze(Array.from(toolRefs)),
-    hasInputSchema: !!definition.inputSchema,
-    hasOutputSchema: !!definition.outputSchema,
+    agentRefs: objectFreeze(setToArray(agentRefs)),
+    toolRefs: objectFreeze(setToArray(toolRefs)),
+    hasInputSchema: !!inputSchema,
+    hasOutputSchema: !!outputSchema,
     inputSchemaJson,
     inputSchemaError,
-    registeredAt: new Date().toISOString(),
+    registeredAt: reflectApply(dateToISOString, new NativeDate(), []),
   });
 }
 
@@ -319,7 +400,11 @@ class WorkflowRegistryInternal {
   }
 
   getAllAsArray(): WorkflowMetadata[] {
-    return Array.from(this.getAll().values());
+    const metadata: WorkflowMetadata[] = [];
+    reflectApply(mapForEach, this.getAll(), [
+      (value: WorkflowMetadata) => appendArrayValue(metadata, value),
+    ]);
+    return metadata;
   }
 
   getStats(): {
@@ -332,16 +417,20 @@ class WorkflowRegistryInternal {
     let withInputSchema = 0;
     let withOutputSchema = 0;
 
-    for (const metadata of this.getAll().values()) {
-      for (const nodeType of metadata.nodeTypes) {
-        byNodeType[nodeType] = (byNodeType[nodeType] ?? 0) + 1;
+    const all = this.getAllAsArray();
+    for (let index = 0; index < all.length; index++) {
+      const metadata = all[index]!;
+      for (let nodeIndex = 0; nodeIndex < metadata.nodeTypes.length; nodeIndex++) {
+        const nodeType = metadata.nodeTypes[nodeIndex]!;
+        const existing = getOwnDataProperty<number>(byNodeType, nodeType) ?? 0;
+        setOwnDataProperty(byNodeType, nodeType, existing + 1);
       }
       if (metadata.hasInputSchema) withInputSchema++;
       if (metadata.hasOutputSchema) withOutputSchema++;
     }
 
     return {
-      total: this.getAll().size,
+      total: all.length,
       byNodeType,
       withInputSchema,
       withOutputSchema,

--- a/tests/integration/workflow/registry-intrinsics.test.ts
+++ b/tests/integration/workflow/registry-intrinsics.test.ts
@@ -1,0 +1,172 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { VeryfrontError } from "#veryfront/errors";
+import {
+  assertEquals,
+  assertExists,
+  assertInstanceOf,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { workflowRegistry } from "#veryfront/workflow/registry.ts";
+import type { WorkflowNode } from "#veryfront/workflow/types.ts";
+
+function stepNode(id: string): WorkflowNode {
+  return { id, config: { type: "step", tool: `${id}-tool` } };
+}
+
+describe("workflow registry with hostile ambient intrinsics", () => {
+  afterEach(() => workflowRegistry.clear());
+
+  it("extracts dynamic metadata after the builder replaces primordials", () => {
+    const originalArrayIsArray = Array.isArray;
+    const originalGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+    const originalToISOString = Date.prototype.toISOString;
+    const originalAgent = Object.getOwnPropertyDescriptor(Object.prototype, "agent");
+    const originalDescription = Object.getOwnPropertyDescriptor(
+      Object.prototype,
+      "description",
+    );
+    const originalInputSchema = Object.getOwnPropertyDescriptor(
+      Object.prototype,
+      "inputSchema",
+    );
+    const originalOutputSchema = Object.getOwnPropertyDescriptor(
+      Object.prototype,
+      "outputSchema",
+    );
+    try {
+      workflowRegistry.register({
+        id: "hostile-dynamic-metadata",
+        introspect: true,
+        steps: () => {
+          const node: WorkflowNode = {
+            id: "dynamic-step",
+            config: { type: "step", tool: { id: "dynamic-step-tool" } },
+          };
+          Array.isArray = (() => false) as unknown as typeof Array.isArray;
+          Object.getOwnPropertyDescriptor = () => undefined;
+          Date.prototype.toISOString = () => "forged-time";
+          Object.defineProperty(Object.prototype, "agent", {
+            configurable: true,
+            value: "forged-agent",
+          });
+          Object.defineProperty(Object.prototype, "description", {
+            configurable: true,
+            value: "forged-description",
+          });
+          Object.defineProperty(Object.prototype, "inputSchema", {
+            configurable: true,
+            value: {},
+          });
+          Object.defineProperty(Object.prototype, "outputSchema", {
+            configurable: true,
+            value: {},
+          });
+          return [node];
+        },
+      });
+    } finally {
+      Array.isArray = originalArrayIsArray;
+      Object.getOwnPropertyDescriptor = originalGetOwnPropertyDescriptor;
+      Date.prototype.toISOString = originalToISOString;
+      if (originalAgent) Object.defineProperty(Object.prototype, "agent", originalAgent);
+      else Reflect.deleteProperty(Object.prototype, "agent");
+      if (originalDescription) {
+        Object.defineProperty(Object.prototype, "description", originalDescription);
+      } else Reflect.deleteProperty(Object.prototype, "description");
+      if (originalInputSchema) {
+        Object.defineProperty(Object.prototype, "inputSchema", originalInputSchema);
+      } else Reflect.deleteProperty(Object.prototype, "inputSchema");
+      if (originalOutputSchema) {
+        Object.defineProperty(Object.prototype, "outputSchema", originalOutputSchema);
+      } else Reflect.deleteProperty(Object.prototype, "outputSchema");
+    }
+
+    const metadata = workflowRegistry.get("hostile-dynamic-metadata");
+    assertExists(metadata);
+    assertEquals(metadata.nodeTypes, ["step"]);
+    assertEquals(metadata.nodes, [{
+      id: "dynamic-step",
+      type: "step",
+      dependsOn: undefined,
+      tool: "dynamic-step-tool",
+    }]);
+    assertEquals(metadata.agentRefs, []);
+    assertEquals(metadata.toolRefs, ["dynamic-step-tool"]);
+    assertEquals(metadata.description, undefined);
+    assertEquals(metadata.hasInputSchema, false);
+    assertEquals(metadata.hasOutputSchema, false);
+    assertEquals(metadata.registeredAt === "forged-time", false);
+    assertEquals(Number.isNaN(Date.parse(metadata.registeredAt)), false);
+  });
+
+  it("requires descriptor value fields to be own properties", () => {
+    const originalValue = Object.getOwnPropertyDescriptor(Object.prototype, "value");
+    let pollutionGetterCalls = 0;
+    let definitionGetterCalls = 0;
+    const wrapper = Object.defineProperty({ id: "wrapper" }, "definition", {
+      enumerable: true,
+      get() {
+        definitionGetterCalls++;
+        return { id: "accessor-definition", steps: [stepNode("step")] };
+      },
+    });
+    let error: unknown;
+    try {
+      Object.defineProperty(Object.prototype, "value", {
+        configurable: true,
+        get() {
+          pollutionGetterCalls++;
+          return { id: "polluted-definition", steps: [stepNode("step")] };
+        },
+      });
+      error = assertThrows(() => workflowRegistry.register(wrapper as never));
+    } finally {
+      if (originalValue) Object.defineProperty(Object.prototype, "value", originalValue);
+      else Reflect.deleteProperty(Object.prototype, "value");
+    }
+
+    assertInstanceOf(error, VeryfrontError);
+    assertEquals(pollutionGetterCalls, 0);
+    assertEquals(definitionGetterCalls, 0);
+    assertEquals(workflowRegistry.has("polluted-definition"), false);
+  });
+
+  it("computes arrays and statistics without live Map and Array helpers", () => {
+    workflowRegistry.register({ id: "one", steps: [stepNode("first")] });
+    workflowRegistry.register({ id: "two", steps: [stepNode("second")] });
+    const originalArrayFrom = Array.from;
+    const originalMapForEach = Map.prototype.forEach;
+    const originalMapValues = Map.prototype.values;
+    let all;
+    let stats;
+    try {
+      Array.from = (() => []) as typeof Array.from;
+      Map.prototype.forEach = () => {
+        throw new Error("ambient Map.prototype.forEach must not be called");
+      };
+      Map.prototype.values = function () {
+        return {
+          next: () => ({ value: undefined, done: true }),
+          [Symbol.iterator]() {
+            return this;
+          },
+        } as never;
+      };
+      all = workflowRegistry.getAllAsArray();
+      stats = workflowRegistry.getStats();
+    } finally {
+      Array.from = originalArrayFrom;
+      Map.prototype.forEach = originalMapForEach;
+      Map.prototype.values = originalMapValues;
+    }
+
+    assertEquals(all.map((metadata) => metadata.id), ["one", "two"]);
+    assertEquals(stats, {
+      total: 2,
+      byNodeType: { step: 2 },
+      withInputSchema: 0,
+      withOutputSchema: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- capture registry intrinsics before project workflow builders can replace them
- read canonical workflow metadata through own data descriptors and reject inherited descriptor fields
- make registry array and statistics queries independent of live collection helpers
- add hostile-runtime integration coverage and refresh generated workflow API references

## Verification

- `deno task test:file tests/integration/workflow/registry-intrinsics.test.ts`
- `deno task test:file src/workflow/registry.test.ts`
- `deno task test:file src/workflow` (83 passed, 919 steps)
- `deno task test:unit` (4,183 passed, 32,217 steps)
- `deno task test:integration` (320 passed, 2,954 steps)
- `deno task typecheck`
- `deno task lint`
- `deno task lint:test-typecheck`
- `deno task lint:anti-slop`
- `deno task lint:test-semantic-dispositions`
- `deno task docs:api-reference:check`
- `deno task docs:public:check`
- `git diff --check`