### PR TITLE
test(discovery,middleware,release-assets): make weak assertions bite

### DIFF
--- a/src/discovery/agent-scoped-capabilities.test.ts
+++ b/src/discovery/agent-scoped-capabilities.test.ts
@@ -328,7 +328,7 @@ Deno.test({
       await Deno.mkdir(`${root}/agents/researcher/tools`, { recursive: true });
       await Deno.writeTextFile(
         `${root}/agents/researcher/AGENT.md`,
-        `---\nname: Researcher\ntools: [fetch-paper]\n---\nResearch.\n`,
+        `---\nname: Researcher\ntools: [fetch-paper, summarize]\n---\nResearch.\n`,
       );
       await Deno.writeTextFile(
         `${root}/agents/researcher/tools/fetch-paper.ts`,
@@ -355,14 +355,56 @@ Deno.test({
 };
 `,
       );
+      // Authored the idiomatic way: `tool()` with no explicit id, so the
+      // factory stamps a generated `tool_<epoch>_<n>` id that must not become
+      // the agent-facing short name.
+      await Deno.writeTextFile(
+        `${root}/agents/researcher/tools/summarize.ts`,
+        `import { tool } from "veryfront/tool";
+
+export default tool({
+  description: "Summarize a paper",
+  inputSchema: { type: "object", properties: {} },
+  execute: () => Promise.resolve({ ok: true }),
+});
+`,
+      );
+      // A module whose explicit id namespaces into a provider-unsafe tool
+      // name is rejected at registration instead of reaching the registry.
+      await Deno.writeTextFile(
+        `${root}/agents/researcher/tools/aa-unsafe.ts`,
+        `export const unsafe = {
+  id: "fetch.paper",
+  type: "function",
+  description: "Dotted id is not provider safe",
+  inputSchema: { type: "object", properties: {} },
+  execute: () => Promise.resolve({ ok: false, unsafe: true }),
+};
+`,
+      );
 
       const result = await discoverAll({ baseDir: root });
       const duplicateErrors = result.errors.filter((entry) =>
         String(entry.error).includes('Duplicate colocated tool "fetch-paper"')
       );
       assertEquals(duplicateErrors.length, 1);
+      const unsafeErrors = result.errors.filter((entry) =>
+        String(entry.error).includes('invalid tool name "researcher--fetch.paper"')
+      );
       assertEquals(
-        result.errors.filter((entry) => !duplicateErrors.includes(entry)),
+        unsafeErrors.length,
+        1,
+        "an unsafe namespaced tool name must be reported at discovery",
+      );
+      assertEquals(
+        toolRegistry.get("researcher--fetch.paper"),
+        undefined,
+        "a provider-unsafe tool name must not reach the registry",
+      );
+      assertEquals(
+        result.errors.filter((entry) =>
+          !duplicateErrors.includes(entry) && !unsafeErrors.includes(entry)
+        ),
         [],
       );
 
@@ -384,6 +426,25 @@ Deno.test({
         assertEquals(String(error).includes("not found"), true);
       }
       assertEquals(rejected, true);
+
+      // A tool authored without an explicit id falls back to its filename for
+      // the agent-facing short name instead of leaking the generated id.
+      const generated = toolRegistry.get("researcher--summarize");
+      assertEquals(
+        generated?.shortName,
+        "summarize",
+        "a generated tool id must fall back to the filename short name",
+      );
+      assertEquals(
+        generated?.ownerAgentId,
+        "researcher",
+        "colocated tools must carry owner metadata",
+      );
+      assertEquals(
+        await executeTool("researcher--summarize", {}, { agentId: "researcher" }),
+        { ok: true },
+        "the owner must be able to execute its filename-named tool",
+      );
     } finally {
       skillRegistryInternal.clearAll();
       clearMCPRegistry();

--- a/src/discovery/auto-discovery.integration.test.ts
+++ b/src/discovery/auto-discovery.integration.test.ts
@@ -59,7 +59,11 @@ describe(
       });
 
       assertEquals(result.tools.size >= 2, true);
-      assertExists(result.tools.get("greet") ?? result.tools.get("searchWeb"));
+      assertEquals(
+        Array.from(result.tools.keys()).sort(),
+        ["greet", "searchWeb"],
+        "kebab-cased tool filenames must derive camelCase ids",
+      );
     });
 
     it("should discover project-authored tools with raw JSON schemas", async () => {
@@ -135,6 +139,15 @@ describe(
       });
 
       assertEquals(result.resources.size >= 1, true);
+      assertEquals(
+        result.resources.get("profile")?.pattern,
+        "/users/:userId/profile",
+        "dynamic [param] segments must become :param in the derived resource pattern",
+      );
+      assertExists(
+        resourceRegistry.get("profile"),
+        "a discovered resource must be registered in the MCP resource registry",
+      );
     });
 
     it("should discover prompts from prompts/ directory", async () => {
@@ -162,8 +175,9 @@ describe(
         verbose: false,
       });
 
-      assertExists(result);
-      assertExists(result.errors);
+      assertEquals(result.errors, [], "a missing baseDir is not a discovery error");
+      assertEquals(result.tools.size, 0, "a missing baseDir must yield an empty tool map");
+      assertEquals(result.agents.size, 0, "a missing baseDir must yield an empty agent map");
     });
 
     it("discovers source-defined schedules and webhooks", async () => {

--- a/src/discovery/import-rewriter.test.ts
+++ b/src/discovery/import-rewriter.test.ts
@@ -178,6 +178,7 @@ describe("discovery/import-rewriter", () => {
         'import fs from "node:fs";',
         'import path from "node:path";',
         'import local from "./helpers.ts";',
+        'import bundled from "file:///abs/vendor/lib.js";',
         'import remote from "https://esm.sh/some-pkg";',
       ].join("\n"),
       "/project/tools",
@@ -186,7 +187,34 @@ describe("discovery/import-rewriter", () => {
     assertStringIncludes(transformed, 'from "node:fs"');
     assertStringIncludes(transformed, 'from "node:path"');
     assertStringIncludes(transformed, 'from "./helpers.ts"');
+    assertStringIncludes(transformed, 'from "file:///abs/vendor/lib.js"');
     assertStringIncludes(transformed, 'from "https://esm.sh/some-pkg"');
+  });
+
+  it("resolves parent-relative specifiers to absolute file:// URLs for Deno", () => {
+    const transformed = rewriteForDeno(
+      [
+        'import { helper } from "../lib/util.ts";',
+        'export { shared } from "../../shared/index.ts";',
+      ].join("\n"),
+      "/project/tools",
+    );
+
+    assertStringIncludes(
+      transformed,
+      'from "file:///project/lib/util.ts"',
+      "a ../ specifier must resolve against fileDir, not the temp module dir",
+    );
+    assertStringIncludes(
+      transformed,
+      'from "file:///shared/index.ts"',
+      "a ../../ specifier must resolve against fileDir, not the temp module dir",
+    );
+    assertEquals(
+      transformed.includes('from "../lib/util.ts"'),
+      false,
+      "no parent-relative specifier may survive the Deno rewrite",
+    );
   });
 
   it("resolves bare-package subpath imports via package.json#exports in the Node discovery path", async () => {
@@ -395,6 +423,62 @@ describe("discovery/import-rewriter", () => {
       assertStringIncludes(after, "late-installed/index.js");
     } finally {
       await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("keeps resolved-specifier cache entries scoped to their project root", async () => {
+    const projectA = await Deno.makeTempDir({ prefix: "vf-rewriter-test-a-" });
+    const projectB = await Deno.makeTempDir({ prefix: "vf-rewriter-test-b-" });
+    const code = 'import { z } from "zod";';
+
+    const writeZod = async (projectDir: string, entry: string) => {
+      const pkgDir = `${projectDir}/node_modules/zod`;
+      await Deno.mkdir(pkgDir, { recursive: true });
+      await Deno.writeTextFile(
+        `${pkgDir}/package.json`,
+        JSON.stringify({ name: "zod", main: `./${entry}` }),
+      );
+      await Deno.writeTextFile(`${pkgDir}/${entry}`, "");
+    };
+
+    try {
+      await writeZod(projectA, "a.js");
+      await writeZod(projectB, "b.js");
+
+      const firstPass = await rewriteDiscoveryImports(
+        code,
+        projectA,
+        createFileSystem(),
+        `${projectA}/app`,
+      );
+      const secondPass = await rewriteDiscoveryImports(
+        code,
+        projectB,
+        createFileSystem(),
+        `${projectB}/app`,
+      );
+
+      assertStringIncludes(
+        firstPass,
+        `${projectA}/node_modules/zod/a.js`,
+        "the first project must resolve zod from its own node_modules",
+      );
+      assert(
+        !firstPass.includes(projectB),
+        "the first project must not resolve zod from another project's node_modules",
+      );
+      assertStringIncludes(
+        secondPass,
+        `${projectB}/node_modules/zod/b.js`,
+        "the second project must resolve zod from its own node_modules",
+      );
+      assert(
+        !secondPass.includes(projectA),
+        "a second project must not inherit the first project's cached zod resolution",
+      );
+    } finally {
+      await Deno.remove(projectA, { recursive: true });
+      await Deno.remove(projectB, { recursive: true });
     }
   });
 

--- a/src/discovery/index.test.ts
+++ b/src/discovery/index.test.ts
@@ -1,8 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { clearTrackedAgents, clearTranspileCache } from "./index.ts";
-import type { DiscoveryConfig, DiscoveryResult } from "./index.ts";
+import { clearTrackedAgents, clearTranspileCache, createEmptyDiscoveryResult } from "./index.ts";
+import type { DiscoveryConfig } from "./index.ts";
 
 describe("src/discovery/index", () => {
   describe("clearTranspileCache", () => {
@@ -55,31 +55,35 @@ describe("src/discovery/index", () => {
   });
 
   describe("DiscoveryResult type", () => {
-    it("should have all expected map fields", () => {
-      const result: DiscoveryResult = {
-        tools: new Map(),
-        agents: new Map(),
-        skills: new Map(),
-        resources: new Map(),
-        prompts: new Map(),
-        workflows: new Map(),
-        tasks: new Map(),
-        schedules: new Map(),
-        webhooks: new Map(),
-        evals: new Map(),
-        errors: [],
-      };
+    // Every primitive map the factory must expose; `errors` is the one
+    // non-map field and is checked separately.
+    const EMPTY_RESULT_MAP_FIELDS = [
+      "agents",
+      "evals",
+      "prompts",
+      "resources",
+      "schedules",
+      "skills",
+      "tasks",
+      "tools",
+      "webhooks",
+      "workflows",
+    ] as const;
 
-      assertEquals(result.tools.size, 0);
-      assertEquals(result.agents.size, 0);
-      assertEquals(result.resources.size, 0);
-      assertEquals(result.prompts.size, 0);
-      assertEquals(result.workflows.size, 0);
-      assertEquals(result.tasks.size, 0);
-      assertEquals(result.schedules.size, 0);
-      assertEquals(result.webhooks.size, 0);
-      assertEquals(result.evals.size, 0);
-      assertEquals(result.errors.length, 0);
+    it("should have all expected map fields", () => {
+      const result = createEmptyDiscoveryResult();
+
+      assertEquals(
+        Object.keys(result).sort(),
+        [...EMPTY_RESULT_MAP_FIELDS, "errors"].sort(),
+        "createEmptyDiscoveryResult must expose every result field",
+      );
+      for (const field of EMPTY_RESULT_MAP_FIELDS) {
+        const value: unknown = result[field];
+        assert(value instanceof Map, `${field} must be a Map on an empty discovery result`);
+        assertEquals(value.size, 0, `${field} must start empty`);
+      }
+      assertEquals(result.errors, [], "errors must start as an empty array");
     });
   });
 });

--- a/src/discovery/registry-replacement.test.ts
+++ b/src/discovery/registry-replacement.test.ts
@@ -57,6 +57,16 @@ describe("replaceDiscoveredProjectPrimitives", () => {
     );
 
     assertInstanceOf(failure, DiscoveryGenerationError);
+    assertEquals(
+      failure.message.includes("/project/"),
+      false,
+      "DiscoveryGenerationError must not embed local paths in its message",
+    );
+    assertEquals(
+      failure.message.includes("broken prompt module"),
+      false,
+      "DiscoveryGenerationError must not embed project-authored error text in its message",
+    );
     assertEquals(failure.result.errors[0]?.error instanceof Error, true);
     assertStrictEquals(promptRegistry.get("stable"), storedStable);
     assertEquals(promptRegistry.get("broken"), undefined);
@@ -73,6 +83,63 @@ describe("replaceDiscoveredProjectPrimitives", () => {
     assertEquals(recovered.errors, []);
     assertStrictEquals(promptRegistry.get("stable"), storedStable);
     assertEquals(promptRegistry.get("broken")?.description, "Recovered");
+  });
+
+  it("rolls back primitives already registered when a later file fails", async () => {
+    const adapter = createMockAdapter();
+    const stable = prompt({
+      id: "stable",
+      description: "Last known good prompt",
+      content: "stable",
+    });
+    promptRegistry.register(stable.id, stable);
+    const storedStable = promptRegistry.get("stable");
+
+    // The rejected generation registers "valid" live before "broken" fails,
+    // so only the transaction can keep it out of the published registry.
+    await adapter.fs.writeFile(
+      "/project/prompts/valid.ts",
+      [
+        'import { prompt } from "veryfront/prompt";',
+        'export default prompt({ description: "Valid", content: "ok" });',
+      ].join("\n"),
+    );
+    await adapter.fs.writeFile(
+      "/project/prompts/broken.ts",
+      "throw new Error('broken prompt module');",
+    );
+
+    await assertRejects(
+      () =>
+        replaceDiscoveredProjectPrimitives({
+          baseDir: "/project",
+          fsAdapter: adapter.fs,
+          toolDirs: [],
+          agentDirs: [],
+          skillDirs: [],
+          resourceDirs: [],
+          promptDirs: ["prompts"],
+          workflowDirs: [],
+          taskDirs: [],
+          scheduleDirs: [],
+          webhookDirs: [],
+          evalDirs: [],
+          allowHostProjectCodeExecution: true,
+        }),
+      DiscoveryGenerationError,
+      "rejected with 1 error",
+    );
+
+    assertEquals(
+      promptRegistry.get("valid"),
+      undefined,
+      "a rejected generation must not leave a successfully registered primitive live",
+    );
+    assertStrictEquals(
+      promptRegistry.get("stable"),
+      storedStable,
+      "the previous complete generation stays live after a rejected replacement",
+    );
   });
 
   it("can atomically publish the valid subset for an error-reporting runtime", async () => {

--- a/src/discovery/runtime-modules-bootstrap.test.ts
+++ b/src/discovery/runtime-modules-bootstrap.test.ts
@@ -4,37 +4,49 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { DISCOVERY_GLOBAL_VERYFRONT_MODULES } from "./import-rewriter.ts";
 import "./runtime-modules-bootstrap.ts";
 import { getDiscoveryRuntimeModules } from "./runtime-modules.ts";
+import type { DiscoveryRuntimeModuleName } from "./runtime-modules.ts";
+
+/**
+ * One export per registered name that only that namespace provides, so a
+ * copy-paste slip swapping two entries of the bootstrap literal is caught.
+ * The Record type keeps the table honest: a new registered module without a
+ * signature export is a type error.
+ *
+ * veryfront-issue-inbox#217: API routes import the middleware pipeline from
+ * "veryfront/middleware"; a compiled binary must register the right namespace
+ * so the generated subpath shim re-exports MiddlewarePipeline instead of 500ing.
+ */
+const SIGNATURE_EXPORTS: Record<DiscoveryRuntimeModuleName, string> = {
+  "veryfront": "createValidatedHandler",
+  "veryfront/agent": "AgentRuntime",
+  "veryfront/tool": "dynamicTool",
+  "veryfront/platform": "createFSAdapter",
+  "veryfront/prompt": "prompt",
+  "veryfront/resource": "resource",
+  "veryfront/embedding": "createUploadHandler",
+  "veryfront/knowledge": "projectKnowledge",
+  "veryfront/workflow": "createWorkflowClient",
+  "veryfront/eval": "evalAgent",
+  "veryfront/metrics": "counter",
+  "veryfront/schemas": "defineSchema",
+  "veryfront/integrations": "executeRemoteIntegrationTool",
+  "veryfront/middleware": "MiddlewarePipeline",
+  "veryfront/chat/uploads": "createChatUploadHandler",
+};
 
 describe("compiled discovery runtime modules", () => {
   it("registers every module rewritten to a compiled-binary global", () => {
     const modules = getDiscoveryRuntimeModules();
 
     assertEquals(Object.keys(modules).sort(), [...DISCOVERY_GLOBAL_VERYFRONT_MODULES].sort());
-    assertEquals(
-      typeof (modules.veryfront as { createValidatedHandler?: unknown })
-        .createValidatedHandler,
-      "function",
-    );
-    assertEquals(
-      typeof (modules["veryfront/agent"] as { agent?: unknown }).agent,
-      "function",
-    );
-    assertEquals(
-      typeof (modules["veryfront/eval"] as { evalAgent?: unknown }).evalAgent,
-      "function",
-    );
-    assertEquals(
-      typeof (modules["veryfront/embedding"] as { createUploadHandler?: unknown })
-        .createUploadHandler,
-      "function",
-    );
-    // veryfront-issue-inbox#217: API routes import the middleware pipeline from
-    // "veryfront/middleware"; a compiled binary must register it so the generated
-    // subpath shim re-exports MiddlewarePipeline instead of 500ing.
-    assertEquals(
-      typeof (modules["veryfront/middleware"] as { MiddlewarePipeline?: unknown })
-        .MiddlewarePipeline,
-      "function",
-    );
+
+    for (const name of DISCOVERY_GLOBAL_VERYFRONT_MODULES) {
+      const exportName = SIGNATURE_EXPORTS[name];
+      assertEquals(
+        typeof (modules[name] as Record<string, unknown>)[exportName],
+        "function",
+        `${name} must be registered with its own namespace (missing ${exportName})`,
+      );
+    }
   });
 });

--- a/src/discovery/skill-discovery.test.ts
+++ b/src/discovery/skill-discovery.test.ts
@@ -1,6 +1,11 @@
 import { skillRegistryInternal } from "#veryfront/skill/registry.ts";
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists, assertStrictEquals } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertStrictEquals,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { skillRegistry } from "#veryfront/skill/registry.ts";
 import { createSkillTestAdapter } from "#veryfront/skill/testing.ts";
@@ -148,6 +153,49 @@ Use the cloud-backed skill.`,
     assertStrictEquals(
       skillRegistryInternal.get("cloud-skill")?.fsAdapter,
       adapter,
+    );
+  });
+
+  it("reports a malformed SKILL.md in result.errors while publishing the valid siblings", async () => {
+    const files = {
+      "/project/skills/good/SKILL.md": `---
+name: good
+description: A valid sibling skill
+---
+Use the valid skill.`,
+      "/project/skills/bad/SKILL.md": `---
+name: bad
+description: A skill with conflicting tool declarations
+allowed-tools: Read
+allowed_tools: Write
+---
+Use the invalid skill.`,
+    };
+
+    const result = await discoverAll({
+      baseDir: "/project",
+      toolDirs: [],
+      agentDirs: [],
+      resourceDirs: [],
+      promptDirs: [],
+      workflowDirs: [],
+      taskDirs: [],
+      skillDirs: ["skills"],
+      fsAdapter: createSkillTestAdapter(files),
+      verbose: false,
+    });
+
+    assertEquals(result.skills.has("good"), true, "a valid sibling must still publish");
+    assertEquals(
+      result.errors.length,
+      1,
+      "a SKILL.md that fails validation must surface exactly one discovery error",
+    );
+    assertEquals(result.errors[0]?.file, "/project/skills/bad/SKILL.md");
+    assertStringIncludes(
+      String(result.errors[0]?.error),
+      "must not declare both",
+      "the discovery error must carry the validation cause",
     );
   });
 });

--- a/src/discovery/transpiler.test.ts
+++ b/src/discovery/transpiler.test.ts
@@ -315,6 +315,36 @@ describe("discovery/transpiler", { sanitizeOps: false, sanitizeResources: false 
       assertEquals(third === second, true);
     });
 
+    it("should isolate identical sources by cache namespace", async () => {
+      // Hosted runs address the VFS with baseDir "", so the explicit cache
+      // namespace is the only tenant separator: two projects whose entry
+      // module has byte-identical source must not share a module instance
+      // (and therefore must not share its module-level state).
+      const path = "/project/tools/x.ts";
+      const source = `export default { value: 1 };`;
+      const contextFor = (cacheNamespace: string): FileDiscoveryContext => ({
+        platform: "node",
+        fsAdapter: createMockAdapter({ [path]: source }),
+        baseDir: "",
+        cacheNamespace,
+      });
+
+      const projectA = await importModule(`file://${path}`, contextFor("project-a"));
+      const projectB = await importModule(`file://${path}`, contextFor("project-b"));
+      assertEquals(
+        projectA === projectB,
+        false,
+        "different cache namespaces must not share a module instance",
+      );
+
+      const projectAAgain = await importModule(`file://${path}`, contextFor("project-a"));
+      assertEquals(
+        projectAAgain === projectA,
+        true,
+        "the same cache namespace must reuse the cached module",
+      );
+    });
+
     it("should not serve a stale cached module when a bundled dependency changes", async () => {
       // esbuild inlines relative imports into the bundle, so an unchanged
       // entry file does not mean an unchanged module: a release that only

--- a/src/middleware/builtin/logger.test.ts
+++ b/src/middleware/builtin/logger.test.ts
@@ -1,6 +1,14 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  __registerLogRecordEmitter,
+  __resetLoggerConfigForTests,
+  __resetLogRecordEmitterForTests,
+  type LogEntry,
+  LogLevel,
+  setLogLevel,
+} from "#veryfront/utils/logger/logger.ts";
 import { devLogger, logger, prodLogger, sanitizeHeaderForLog } from "./logger.ts";
 
 function makeCtx(
@@ -21,6 +29,24 @@ function next404(): Promise<Response> {
 
 function next500(): Promise<Response> {
   return Promise.resolve(new Response("error", { status: 500 }));
+}
+
+/**
+ * Capture the structured records the default `serverLogger` sink receives.
+ * `devLogger`/`prodLogger` pass no `log` callback, so this is the only way to
+ * observe the record they actually emit. The level is lowered through the
+ * `setLogLevel` seam rather than an env var so the case stays hermetic.
+ */
+function captureLogRecords(): LogEntry[] {
+  const entries: LogEntry[] = [];
+  setLogLevel(LogLevel.DEBUG);
+  __registerLogRecordEmitter((entry) => entries.push(entry));
+  return entries;
+}
+
+function restoreLogRecordCapture(): void {
+  __resetLoggerConfigForTests();
+  __resetLogRecordEmitterForTests();
 }
 
 function getFirstLog(logs: string[]): string {
@@ -360,22 +386,72 @@ describe("middleware/builtin/logger", () => {
   });
 
   describe("devLogger", () => {
+    afterEach(restoreLogRecordCapture);
+
     it("should create a logger with dev format", async () => {
+      const entries = captureLogRecords();
       const mw = devLogger();
 
       const res = await mw(makeCtx(), nextOk);
 
       assertEquals(res?.status, 200);
+      const entry = entries[0];
+      assertExists(entry, "devLogger must emit a request log record");
+      assert(
+        entry.message.includes("\x1b["),
+        `devLogger must emit the colorized dev format, got: ${entry.message}`,
+      );
     });
   });
 
   describe("prodLogger", () => {
+    afterEach(restoreLogRecordCapture);
+
     it("should create a logger with json format", async () => {
+      const entries = captureLogRecords();
       const mw = prodLogger();
 
-      const res = await mw(makeCtx(), nextOk);
+      const res = await mw(
+        makeCtx("http://localhost/api/data", {
+          "x-request-id": "req-42",
+          "x-forwarded-for": "203.0.113.7",
+        }),
+        nextOk,
+      );
 
       assertEquals(res?.status, 200);
+      const entry = entries[0];
+      assertExists(entry, "prodLogger must emit a structured request log record");
+      assertEquals(
+        entry.message,
+        "GET /api/data 200",
+        "the json format must summarize method, path and status",
+      );
+      assertEquals(
+        entry.request_id,
+        "req-42",
+        "the structured record must carry the incoming x-request-id",
+      );
+      assertEquals(
+        entry.request_url,
+        "/api/data",
+        "the structured record must carry the request path",
+      );
+      assertEquals(
+        entry.context?.method,
+        "GET",
+        "the structured record must carry the request method",
+      );
+      assertEquals(
+        entry.context?.statusCode,
+        200,
+        "the structured record must carry the response status code",
+      );
+      assertEquals(
+        entry.context?.remoteAddr,
+        "203.0.113.7",
+        "the structured record must carry the forwarded remote address",
+      );
     });
   });
 });

--- a/src/middleware/builtin/security/cors-simple.test.ts
+++ b/src/middleware/builtin/security/cors-simple.test.ts
@@ -16,10 +16,19 @@ describe("corsSimple", () => {
     it("should respond to OPTIONS with 204", async () => {
       const middleware = corsSimple("*");
       const ctx = createContext("OPTIONS", "https://other.com");
+      let calledNext = false;
 
-      const response = await middleware(ctx, () => Promise.resolve(new Response("OK")));
+      const response = await middleware(ctx, () => {
+        calledNext = true;
+        return Promise.resolve(new Response("OK"));
+      });
 
       assertEquals(response?.status, 204);
+      assertEquals(
+        calledNext,
+        false,
+        "an allowed preflight must be answered by the middleware without reaching the downstream handler",
+      );
     });
 
     it("should include CORS headers in preflight response", async () => {
@@ -70,6 +79,37 @@ describe("corsSimple", () => {
       assertEquals(response?.headers.get("Access-Control-Allow-Origin"), "*");
     });
 
+    it("should not add a CORS header for a disallowed origin on a normal request", async () => {
+      const middleware = corsSimple("https://allowed.com");
+      const ctx = createContext("GET", "https://evil.com");
+
+      const response = await middleware(ctx, () => Promise.resolve(new Response("OK")));
+
+      assertEquals(
+        response?.headers.get("Access-Control-Allow-Origin"),
+        null,
+        "a rejected origin must never receive Access-Control-Allow-Origin",
+      );
+      assertEquals(
+        await response?.text(),
+        "OK",
+        "the downstream response must still pass through untouched",
+      );
+    });
+
+    it("should add the CORS header for an allowed origin on a normal request", async () => {
+      const middleware = corsSimple("https://allowed.com");
+      const ctx = createContext("GET", "https://allowed.com");
+
+      const response = await middleware(ctx, () => Promise.resolve(new Response("OK")));
+
+      assertEquals(
+        response?.headers.get("Access-Control-Allow-Origin"),
+        "https://allowed.com",
+        "an allowed origin must receive its own origin in Access-Control-Allow-Origin",
+      );
+    });
+
     it("should preserve original response body", async () => {
       const middleware = corsSimple("*");
       const ctx = createContext("GET", "https://other.com");
@@ -108,12 +148,21 @@ describe("corsSimple", () => {
     it("should accept string origin", async () => {
       const middleware = corsSimple("https://allowed.com");
       const ctx = createContext("OPTIONS", "https://allowed.com");
+      let calledNext = false;
 
-      const response = await middleware(ctx, () => Promise.resolve(new Response("OK")));
+      const response = await middleware(ctx, () => {
+        calledNext = true;
+        return Promise.resolve(new Response("OK"));
+      });
 
       assertEquals(
         response?.headers.get("Access-Control-Allow-Origin"),
         "https://allowed.com",
+      );
+      assertEquals(
+        calledNext,
+        false,
+        "an allowed preflight must be answered by the middleware without reaching the downstream handler",
       );
     });
 

--- a/src/middleware/builtin/security/csp.test.ts
+++ b/src/middleware/builtin/security/csp.test.ts
@@ -44,13 +44,22 @@ describe("contentSecurityPolicy", () => {
 
   it("should add nonce to script-src", async () => {
     const middleware = contentSecurityPolicy(
-      { "script-src": "'self'" },
+      { "script-src": "'self'", "style-src": "'self'" },
       { nonce: "abc123" },
     );
 
     const response = await runMiddleware(middleware, new Response("OK"));
 
-    assertStringIncludes(getCsp(response), "'nonce-abc123'");
+    assertEquals(
+      getCsp(response),
+      "script-src 'self' 'nonce-abc123'; style-src 'self'",
+      "the nonce must be inserted into script-src, not appended to the last directive",
+    );
+    assertEquals(
+      getCsp(response).split("; ").find((directive) => directive.startsWith("style-src")),
+      "style-src 'self'",
+      "style-src must not receive the script nonce",
+    );
   });
 
   it("should merge with existing CSP", async () => {
@@ -81,6 +90,37 @@ describe("contentSecurityPolicy", () => {
     const response = await runMiddleware(middleware, new Response("Original Body"));
 
     assertEquals(await response?.text(), "Original Body");
+  });
+
+  it("preserves upstream response headers alongside the CSP header", async () => {
+    const middleware = contentSecurityPolicy({ "default-src": "'self'" });
+    const response = await runMiddleware(
+      middleware,
+      new Response("OK", {
+        headers: {
+          "set-cookie": "sid=abc; HttpOnly",
+          "content-type": "application/json",
+          "cache-control": "no-store",
+        },
+      }),
+    );
+
+    assertEquals(
+      response?.headers.get("set-cookie"),
+      "sid=abc; HttpOnly",
+      "the middleware must not drop upstream Set-Cookie",
+    );
+    assertEquals(
+      response?.headers.get("content-type"),
+      "application/json",
+      "the middleware must not drop upstream Content-Type",
+    );
+    assertEquals(
+      response?.headers.get("cache-control"),
+      "no-store",
+      "the middleware must not drop upstream Cache-Control",
+    );
+    assertStringIncludes(getCsp(response), "default-src 'self'");
   });
 
   it("should handle undefined response from next", async () => {

--- a/src/middleware/builtin/security/csrf.test.ts
+++ b/src/middleware/builtin/security/csrf.test.ts
@@ -11,58 +11,106 @@ function makeCtx(method: string, headers: Record<string, string> = {}): {
   };
 }
 
-function nextOk(): Promise<Response> {
-  return Promise.resolve(new Response("ok", { status: 200 }));
+/**
+ * A downstream handler that records whether it ran. Status alone cannot tell
+ * "the forged request was blocked" from "the handler ran and its response was
+ * discarded", which is the whole property CSRF protection provides.
+ */
+function countingNext(): { next: () => Promise<Response>; getCalls: () => number } {
+  let calls = 0;
+  return {
+    next: () => {
+      calls++;
+      return Promise.resolve(new Response("ok", { status: 200 }));
+    },
+    getCalls: () => calls,
+  };
 }
 
 describe("middleware/builtin/security/csrf", () => {
   describe("csrfProtection", () => {
     it("should allow GET requests without token", async () => {
       const mw = csrfProtection(() => true);
-      const res = await mw(makeCtx("GET"), nextOk);
+      const { next, getCalls } = countingNext();
+      const res = await mw(makeCtx("GET"), next);
       assertEquals(res?.status, 200);
+      assertEquals(
+        getCalls(),
+        1,
+        "an accepted request must reach the downstream handler exactly once",
+      );
     });
 
     it("should allow HEAD requests without token", async () => {
       const mw = csrfProtection(() => true);
-      const res = await mw(makeCtx("HEAD"), nextOk);
+      const { next, getCalls } = countingNext();
+      const res = await mw(makeCtx("HEAD"), next);
       assertEquals(res?.status, 200);
+      assertEquals(
+        getCalls(),
+        1,
+        "an accepted request must reach the downstream handler exactly once",
+      );
     });
 
     it("should reject POST without token", async () => {
       const mw = csrfProtection(() => true);
-      const res = await mw(makeCtx("POST"), nextOk);
+      const { next, getCalls } = countingNext();
+      const res = await mw(makeCtx("POST"), next);
       assertEquals(res?.status, 403);
+      assertEquals(getCalls(), 0, "a rejected CSRF request must not invoke the downstream handler");
     });
 
     it("should reject POST with invalid token", async () => {
       const mw = csrfProtection((t) => t === "valid");
-      const res = await mw(makeCtx("POST", { "X-CSRF-Token": "invalid" }), nextOk);
+      const { next, getCalls } = countingNext();
+      const res = await mw(makeCtx("POST", { "X-CSRF-Token": "invalid" }), next);
       assertEquals(res?.status, 403);
+      assertEquals(getCalls(), 0, "a rejected CSRF request must not invoke the downstream handler");
     });
 
     it("should allow POST with valid token", async () => {
       const mw = csrfProtection((t) => t === "valid");
-      const res = await mw(makeCtx("POST", { "X-CSRF-Token": "valid" }), nextOk);
+      const { next, getCalls } = countingNext();
+      const res = await mw(makeCtx("POST", { "X-CSRF-Token": "valid" }), next);
       assertEquals(res?.status, 200);
+      assertEquals(
+        getCalls(),
+        1,
+        "an accepted request must reach the downstream handler exactly once",
+      );
     });
 
     it("should check PUT requests", async () => {
       const mw = csrfProtection((t) => t === "ok");
-      const res = await mw(makeCtx("PUT", { "X-CSRF-Token": "ok" }), nextOk);
+      const { next, getCalls } = countingNext();
+      const res = await mw(makeCtx("PUT", { "X-CSRF-Token": "ok" }), next);
       assertEquals(res?.status, 200);
+      assertEquals(
+        getCalls(),
+        1,
+        "an accepted request must reach the downstream handler exactly once",
+      );
     });
 
     it("should check DELETE requests", async () => {
       const mw = csrfProtection(() => false);
-      const res = await mw(makeCtx("DELETE", { "X-CSRF-Token": "any" }), nextOk);
+      const { next, getCalls } = countingNext();
+      const res = await mw(makeCtx("DELETE", { "X-CSRF-Token": "any" }), next);
       assertEquals(res?.status, 403);
+      assertEquals(getCalls(), 0, "a rejected CSRF request must not invoke the downstream handler");
     });
 
     it("should check PATCH requests", async () => {
       const mw = csrfProtection((t) => t === "patch-token");
-      const res = await mw(makeCtx("PATCH", { "X-CSRF-Token": "patch-token" }), nextOk);
+      const { next, getCalls } = countingNext();
+      const res = await mw(makeCtx("PATCH", { "X-CSRF-Token": "patch-token" }), next);
       assertEquals(res?.status, 200);
+      assertEquals(
+        getCalls(),
+        1,
+        "an accepted request must reach the downstream handler exactly once",
+      );
     });
   });
 });

--- a/src/middleware/builtin/security/rate-limit.test.ts
+++ b/src/middleware/builtin/security/rate-limit.test.ts
@@ -10,6 +10,7 @@ import { delay } from "#std/async.ts";
 import { scaleMs } from "#veryfront/testing/timing.ts";
 import { deleteEnv, getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import { __subscribeLogRecordEmitter, type LogEntry } from "#veryfront/utils/logger/index.ts";
+import { MS_PER_MINUTE } from "#veryfront/utils/constants/http.ts";
 import { MiddlewareContext } from "../../core/context.ts";
 import { MAX_RATE_LIMIT_KEY_LENGTH } from "./rate-limit-validation.ts";
 import {
@@ -61,10 +62,24 @@ describe("MemoryRateLimitStore", () => {
       const entry1 = await store.increment("test-key", shortWindow);
       assertEquals(entry1.count, 1);
 
-      await delay(120);
+      await delay(scaleMs(120));
 
       const entry2 = await store.increment("test-key", shortWindow);
-      assertEquals(entry2.count, 1);
+      assertEquals(entry2.count, 1, "an entry past its window must start a fresh count");
+    });
+
+    it("should not treat an entry inside its window as expired", async () => {
+      const entry1 = await store.increment("boundary-key", 5_000);
+      assertEquals(entry1.count, 1);
+
+      await delay(scaleMs(20));
+
+      const entry2 = await store.increment("boundary-key", 5_000);
+      assertEquals(
+        entry2.count,
+        2,
+        "an entry still inside its window must not be treated as expired",
+      );
     });
   });
 
@@ -275,6 +290,25 @@ describe("rateLimit middleware", () => {
       TypeError,
       "maxEntries",
     );
+
+    // A non-boolean trustProxy must not be coerced: a truthy string would
+    // silently enable proxy trust and let a rotating X-Forwarded-For header
+    // mint a fresh bucket per request.
+    assertThrows(
+      () => rateLimit({ trustProxy: "false" as never }),
+      TypeError,
+      "trustProxy",
+    );
+    assertThrows(
+      () => rateLimit({ keyGenerator: {} as never }),
+      TypeError,
+      "keyGenerator",
+    );
+    assertThrows(
+      () => rateLimit("5" as never),
+      TypeError,
+      "number or options object",
+    );
   });
 
   it("keeps active identities available and fails closed for overflow identities", async () => {
@@ -329,6 +363,7 @@ describe("rateLimit middleware", () => {
 
   it("should throttle repeated rate-limit store failure logs", async () => {
     const originalConsoleError = console.error;
+    const realNow = performance.now.bind(performance);
     let loggedFailures = 0;
     console.error = () => {
       loggedFailures++;
@@ -354,7 +389,22 @@ describe("rateLimit middleware", () => {
       assertEquals(first?.status, 503);
       assertEquals(second?.status, 503);
       assertEquals(loggedFailures, 1);
+
+      // Throttled, not silenced: once the interval elapses the same middleware
+      // must log the recurring outage again.
+      performance.now = () => realNow() + MS_PER_MINUTE + 1_000;
+      const third = await middleware(
+        createContext(),
+        () => Promise.resolve(new Response("OK")),
+      );
+      assertEquals(third?.status, 503);
+      assertEquals(
+        loggedFailures,
+        2,
+        "store-failure logging must resume after the throttle interval",
+      );
     } finally {
+      performance.now = realNow;
       console.error = originalConsoleError;
     }
   });

--- a/src/middleware/builtin/security/redis-rate-limit.test.ts
+++ b/src/middleware/builtin/security/redis-rate-limit.test.ts
@@ -47,6 +47,7 @@ function createMockRedisClient(
 function createStoreWithMock(
   options?: RedisRateLimitOptions,
   client = createMockRedisClient(),
+  closeError?: Error,
 ): {
   store: RedisRateLimitStore;
   client: MockRedisClient;
@@ -72,7 +73,7 @@ function createStoreWithMock(
         closeCalls++;
         closed = true;
       }
-      return Promise.resolve();
+      return closeError ? Promise.reject(closeError) : Promise.resolve();
     },
   };
   return {
@@ -281,6 +282,36 @@ describe("provider-backed RedisRateLimitStore", () => {
       assertEquals(isVeryfrontError(error), true);
       assertEquals(isVeryfrontError(error) ? error.slug : undefined, TIMEOUT_ERROR.slug);
       assertEquals(closeCalls(), 1);
+    });
+
+    it("swallows a close failure while retiring a timed-out connection", async () => {
+      const client = createMockRedisClient();
+      client.eval = () => new Promise<never>(() => {});
+      const { store, closeCalls } = createStoreWithMock(
+        { operationTimeoutMs: 1 },
+        client,
+        new Error("close failed"),
+      );
+
+      const error = await withTimeoutRefGuard(() =>
+        assertRejects(
+          () => store.increment("key", 1_000),
+          Error,
+          "timed out",
+        )
+      );
+
+      assertEquals(
+        isVeryfrontError(error) ? error.slug : undefined,
+        TIMEOUT_ERROR.slug,
+        "a bounded operation must still reject with the timeout error",
+      );
+      assertEquals(
+        closeCalls(),
+        1,
+        "the timed-out connection must still be retired once",
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
     });
 
     it("unrefs the operation timeout so it does not hold the process open", async () => {

--- a/src/middleware/builtin/security/security-headers.test.ts
+++ b/src/middleware/builtin/security/security-headers.test.ts
@@ -35,11 +35,65 @@ describe("middleware/builtin/security/security-headers", () => {
       );
     });
 
+    it("should preserve the upstream status, body, and headers", async () => {
+      const mw = securityHeaders();
+      const res = await mw(
+        makeCtx(),
+        () =>
+          Promise.resolve(
+            new Response("not found", {
+              status: 404,
+              headers: { "content-type": "text/plain", "x-upstream": "origin" },
+            }),
+          ),
+      );
+
+      assertEquals(
+        res?.status,
+        404,
+        "securityHeaders must not rewrite the upstream status",
+      );
+      assertEquals(
+        await res?.text(),
+        "not found",
+        "securityHeaders must not drop the upstream body",
+      );
+      assertEquals(
+        res?.headers.get("x-upstream"),
+        "origin",
+        "upstream headers must survive the rebuild",
+      );
+      assertEquals(
+        res?.headers.get("X-Frame-Options"),
+        "DENY",
+        "the security headers must still be applied to the rebuilt response",
+      );
+    });
+
     it("should allow custom X-Frame-Options", async () => {
       const mw = securityHeaders({ frameOptions: "SAMEORIGIN" });
       const res = await mw(makeCtx(), nextOk);
 
       assertEquals(res?.headers.get("X-Frame-Options"), "SAMEORIGIN");
+    });
+
+    it("should allow custom Referrer-Policy and Permissions-Policy", async () => {
+      const mw = securityHeaders({
+        referrerPolicy: "no-referrer",
+        permissionsPolicy: "camera=(self)",
+      });
+      const res = await mw(makeCtx(), nextOk);
+
+      assertEquals(
+        res?.headers.get("Referrer-Policy"),
+        "no-referrer",
+        "a supplied referrerPolicy must override the default",
+      );
+      assertEquals(
+        res?.headers.get("Permissions-Policy"),
+        "camera=(self)",
+        "a supplied permissionsPolicy must override the default",
+      );
     });
 
     it("should allow disabling nosniff", async () => {

--- a/src/middleware/builtin/timeout.test.ts
+++ b/src/middleware/builtin/timeout.test.ts
@@ -41,21 +41,29 @@ describe("middleware/builtin/timeout", () => {
     });
 
     it("should exclude health check paths", async () => {
-      const mw = timeout({ timeoutMs: 5000 });
-      const res = await mw(
-        makeCtx("http://localhost/healthz"),
-        () => Promise.resolve(new Response("healthy")),
+      const mw = timeout({ timeoutMs: 10 });
+      const slow = makeSlowNext(200);
+      const res = await mw(makeCtx("http://localhost/healthz"), slow.next);
+      assertEquals(
+        res?.status,
+        200,
+        "an excluded path must bypass the timeout race entirely",
       );
-      assertEquals(await res?.text(), "healthy");
+      assertEquals(await res?.text(), "late");
+      slow.clear();
     });
 
     it("should exclude readyz path by default", async () => {
-      const mw = timeout({ timeoutMs: 5000 });
-      const res = await mw(
-        makeCtx("http://localhost/readyz"),
-        () => Promise.resolve(new Response("ready")),
+      const mw = timeout({ timeoutMs: 10 });
+      const slow = makeSlowNext(200);
+      const res = await mw(makeCtx("http://localhost/readyz"), slow.next);
+      assertEquals(
+        res?.status,
+        200,
+        "an excluded path must bypass the timeout race entirely",
       );
-      assertEquals(await res?.text(), "ready");
+      assertEquals(await res?.text(), "late");
+      slow.clear();
     });
 
     it("should use custom message", async () => {
@@ -68,21 +76,29 @@ describe("middleware/builtin/timeout", () => {
     });
 
     it("should use custom exclude paths", async () => {
-      const mw = timeout({ timeoutMs: 5000, exclude: ["/custom"] });
-      const res = await mw(
-        makeCtx("http://localhost/custom"),
-        () => Promise.resolve(new Response("ok")),
+      const mw = timeout({ timeoutMs: 10, exclude: ["/custom"] });
+      const slow = makeSlowNext(200);
+      const res = await mw(makeCtx("http://localhost/custom"), slow.next);
+      assertEquals(
+        res?.status,
+        200,
+        "an excluded path must bypass the timeout race entirely",
       );
-      assertEquals(await res?.text(), "ok");
+      assertEquals(await res?.text(), "late");
+      slow.clear();
     });
 
     it("should exclude nested paths for configured prefixes", async () => {
-      const mw = timeout({ timeoutMs: 5000, exclude: ["/custom"] });
-      const res = await mw(
-        makeCtx("http://localhost/custom/deep/path"),
-        () => Promise.resolve(new Response("ok")),
+      const mw = timeout({ timeoutMs: 10, exclude: ["/custom"] });
+      const slow = makeSlowNext(200);
+      const res = await mw(makeCtx("http://localhost/custom/deep/path"), slow.next);
+      assertEquals(
+        res?.status,
+        200,
+        "an excluded path must bypass the timeout race entirely",
       );
-      assertEquals(await res?.text(), "ok");
+      assertEquals(await res?.text(), "late");
+      slow.clear();
     });
 
     it("should propagate non-timeout errors", async () => {

--- a/src/middleware/core/context.test.ts
+++ b/src/middleware/core/context.test.ts
@@ -85,6 +85,11 @@ describe("MiddlewareContext", () => {
       const response = ctx.text("Created", { status: 201 });
 
       assertEquals(response.status, 201);
+      assertEquals(
+        response.headers.get("content-type"),
+        "text/plain; charset=utf-8",
+        "content-type must survive a custom init",
+      );
     });
   });
 
@@ -103,6 +108,27 @@ describe("MiddlewareContext", () => {
       const response = ctx.html("<h1>Error</h1>", { status: 500 });
 
       assertEquals(response.status, 500);
+      assertEquals(
+        response.headers.get("content-type"),
+        "text/html; charset=utf-8",
+        "content-type must survive a custom init",
+      );
+    });
+
+    it("should merge caller headers with the default content-type", () => {
+      const ctx = createCtx();
+      const response = ctx.html("<h1>Hi</h1>", { headers: { "x-trace": "1" } });
+
+      assertEquals(
+        response.headers.get("x-trace"),
+        "1",
+        "caller headers must be preserved",
+      );
+      assertEquals(
+        response.headers.get("content-type"),
+        "text/html; charset=utf-8",
+        "the default content-type must merge with caller headers",
+      );
     });
   });
 

--- a/src/middleware/core/pipeline/executor.test.ts
+++ b/src/middleware/core/pipeline/executor.test.ts
@@ -48,6 +48,16 @@ describe("middleware/core/pipeline/executor", () => {
       assertEquals(body.error, "Internal Server Error");
       assertEquals(body.method, "GET");
       assertEquals(body.url, "http://localhost/");
+      assertEquals(
+        body.message,
+        undefined,
+        "error message must be redacted when no adapter reports NODE_ENV",
+      );
+      assertEquals(
+        body.stack,
+        undefined,
+        "stack must be redacted when no adapter reports NODE_ENV",
+      );
     });
 
     it("should include error details in development mode", async () => {
@@ -152,17 +162,43 @@ describe("middleware/core/pipeline/executor", () => {
       assertEquals(res.status, 500);
       const body = await res.json();
       assertEquals(body.error, "Internal Server Error");
+      assertEquals(
+        body.message,
+        undefined,
+        "error message must be redacted when no adapter reports NODE_ENV",
+      );
+      assertEquals(
+        body.stack,
+        undefined,
+        "stack must be redacted when no adapter reports NODE_ENV",
+      );
     });
 
     it("should handle async middleware that rejects", async () => {
-      const handler: MiddlewareHandler = () => {
-        throw new Error("async fail");
-      };
+      const handler: MiddlewareHandler = () => Promise.reject(new Error("async fail"));
       const res = await executeMiddlewarePipeline(
         new Request("http://localhost/"),
         handler,
       );
       assertEquals(res.status, 500);
+      assertEquals(
+        (await res.json()).error,
+        "Internal Server Error",
+        "a rejected middleware promise must be converted to the 500 JSON body, not rethrown",
+      );
+    });
+
+    it("should await an async middleware that resolves a Response", async () => {
+      const handler: MiddlewareHandler = () => Promise.resolve(new Response("async ok"));
+      const res = await executeMiddlewarePipeline(
+        new Request("http://localhost/"),
+        handler,
+      );
+      assertEquals(
+        await res.text(),
+        "async ok",
+        "the pipeline must await the middleware result instead of leaking a promise",
+      );
     });
   });
 });

--- a/src/middleware/core/pipeline/pipeline.test.ts
+++ b/src/middleware/core/pipeline/pipeline.test.ts
@@ -1,5 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assert, assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertStrictEquals,
+} from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   _resetShimForTests,
@@ -129,16 +135,27 @@ describe("middleware/core/pipeline/MiddlewarePipeline", () => {
     it("should pass env and executionCtx to the context", async () => {
       const pipeline = new MiddlewarePipeline();
       let capturedEnv: Record<string, unknown> | undefined;
+      let capturedCtx: unknown;
 
       pipeline.use((c) => {
         capturedEnv = c.env;
+        capturedCtx = c.executionCtx;
         return new Response("ok");
       });
 
       const env = { MY_VAR: "test" };
-      await pipeline.execute(new Request("http://localhost/"), env);
+      const execCtx = {
+        waitUntil: () => {},
+        passThroughOnException: () => {},
+      };
+      await pipeline.execute(new Request("http://localhost/"), env, execCtx);
 
       assertEquals(capturedEnv?.MY_VAR, "test");
+      assertStrictEquals(
+        capturedCtx,
+        execCtx,
+        "pipeline.execute must forward executionCtx to the middleware context",
+      );
     });
 
     it("should execute middlewares in the correct order", async () => {

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -633,6 +633,44 @@ describe("release asset build executor", () => {
     assertEquals(manifest.modules["pages/scratch.tsx"], undefined);
   });
 
+  it("drops a route whose layout is missing from the manifest instead of publishing a hole", async () => {
+    // An App Router layout is an extra closure entrypoint the page never
+    // imports, so a page can be admitted while its closure still has a hole.
+    // Shipping that route would hand the browser an import map pointing at a
+    // module the admission boundary refuses.
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const client = makeClient([
+      { path: "app/page.tsx", content: "export default () => null;" },
+      {
+        path: "app/layout.tsx",
+        content: "export default function Layout({ children }) { return children; }",
+      },
+      { path: "pages/ok.tsx", content: "export default () => null;" },
+    ], rec);
+    const transform = (source: string, sourceFile: string) => {
+      if (sourceFile.endsWith("app/layout.tsx")) {
+        return Promise.reject(new Error("Invalid left-hand side in prefix operation. (1:2)"));
+      }
+      return Promise.resolve(source);
+    };
+
+    const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    assertEquals(result.success, true, "one unbuildable layout must not fail the release");
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(
+      manifest.routes["/"],
+      undefined,
+      "a route whose closure member has no manifest entry must be omitted, not published without it",
+    );
+    // The page itself was admitted, so the route really was a candidate and
+    // the drop came from the closure gap rather than from the page failing.
+    assertExists(manifest.modules["app/page.tsx"]);
+    assertEquals(manifest.modules["app/layout.tsx"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"], "healthy routes still publish");
+  });
+
   it("still fails closed when every page fails to transform", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const client = makeClient([

--- a/src/release-assets/constants.test.ts
+++ b/src/release-assets/constants.test.ts
@@ -12,7 +12,23 @@ describe("release asset constants", () => {
   it("builds URLs only from canonical content identities", () => {
     const hash = "a".repeat(64);
     assertEquals(releaseAssetUrl(hash, "js"), `/_vf/assets/${hash}.js`);
-    assertThrows(() => releaseAssetUrl("../asset", "js"));
+    assertThrows(() => releaseAssetUrl("../asset", "js"), TypeError, "64 lowercase hexadecimal");
+    // Near misses: only exactly 64 lowercase hex characters is an identity.
+    assertThrows(
+      () => releaseAssetUrl("A".repeat(64), "js"),
+      TypeError,
+      "64 lowercase hexadecimal",
+    );
+    assertThrows(
+      () => releaseAssetUrl("a".repeat(63), "js"),
+      TypeError,
+      "64 lowercase hexadecimal",
+    );
+    assertThrows(
+      () => releaseAssetUrl("a".repeat(65), "js"),
+      TypeError,
+      "64 lowercase hexadecimal",
+    );
     assertThrows(() => releaseAssetUrl(hash, "map" as "js"));
   });
 

--- a/src/release-assets/css-compile.test.ts
+++ b/src/release-assets/css-compile.test.ts
@@ -7,7 +7,9 @@ import {
   assert,
   assertEquals,
   assertExists,
+  assertNotEquals,
   assertRejects,
+  assertStringIncludes,
   assertThrows,
 } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
@@ -20,6 +22,7 @@ import {
   isStyleProfileHash,
 } from "#veryfront/utils/css-artifact-identity.ts";
 import { acquireCSSGenerationSession } from "#veryfront/html/styles-builder/tailwind-compiler.ts";
+import { createStyleScopeProfile } from "#veryfront/html/styles-builder/style-scope-profile.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { createCompileProjectCss } from "./css-compile.ts";
 
@@ -46,14 +49,53 @@ describe("release-assets/css-compile", () => {
 
     assert(result !== null, "expected a compiled result");
     assert(result.css.length > 0, "expected non-empty CSS output");
-    // The compiled output should reference at least one requested utility.
-    assert(
-      result.css.includes("padding") || result.css.includes(".p-4"),
-      "expected the p-4 utility to be present in the compiled CSS",
+    // The requested candidates must actually reach the compiler: Tailwind
+    // preflight alone already contains the word "padding", so only the
+    // generated utility selectors prove the candidate set was compiled.
+    assertStringIncludes(
+      result.css,
+      ".p-4",
+      "expected the p-4 utility selector to be present in the compiled CSS",
     );
-    assert(isStyleProfileHash(result.styleProfileHash));
-    assert(isCSSPipelineIdentity(result.cssPipelineIdentity));
+    assertStringIncludes(
+      result.css,
+      ".flex",
+      "expected the flex utility selector to be present in the compiled CSS",
+    );
+    assert(
+      isStyleProfileHash(result.styleProfileHash),
+      "compiled result must publish a well-formed style profile hash",
+    );
+    assert(
+      isCSSPipelineIdentity(result.cssPipelineIdentity),
+      "compiled result must publish a well-formed CSS pipeline identity",
+    );
     assertEquals(result.cssPipelineIdentity, expectedPipelineIdentity);
+  });
+
+  it("derives the style profile hash from the release config", async () => {
+    const configA = { tailwind: { stylesheet: "app/a.css" } } as VeryfrontConfig;
+    const configB = { tailwind: { stylesheet: "app/b.css" } } as VeryfrontConfig;
+    const candidates = new Set(["p-4"]);
+    const stylesheet = '@import "tailwindcss";';
+
+    const compileA = createCompileProjectCss({ projectScope: "css-compile-profile-a" });
+    const first = await compileA(candidates, stylesheet, { config: configA });
+    const compileB = createCompileProjectCss({ projectScope: "css-compile-profile-b" });
+    const second = await compileB(candidates, stylesheet, { config: configB });
+
+    assertExists(first, "expected a compiled result for the first config");
+    assertExists(second, "expected a compiled result for the second config");
+    assertEquals(
+      first.styleProfileHash,
+      createStyleScopeProfile(configA).hash,
+      "published hash must equal the canonical style scope profile hash",
+    );
+    assertNotEquals(
+      first.styleProfileHash,
+      second.styleProfileHash,
+      "style profile hash must track the release config, or two releases share cached CSS",
+    );
   });
 
   it("returns null only when there are no candidates AND no stylesheet", async () => {
@@ -90,6 +132,22 @@ describe("release-assets/css-compile", () => {
       );
     } finally {
       restoreFailingEngine();
+    }
+  });
+
+  it("rejects an empty compiler result instead of publishing a CSS gap", async () => {
+    const restore = installTestCSSOptimizationEngine(
+      createTestCSSOptimizationEngine(() => ({ css: "" }), "empty-css-optimization-engine@1"),
+    );
+    try {
+      const compile = createCompileProjectCss({ projectScope: "css-compile-empty-output" });
+      await assertRejects(
+        () => compile(new Set(["p-4"]), '@import "tailwindcss";', RELEASE_CONFIG),
+        Error,
+        "empty output",
+      );
+    } finally {
+      restore();
     }
   });
 

--- a/src/release-assets/dependency-artifact-builder.test.ts
+++ b/src/release-assets/dependency-artifact-builder.test.ts
@@ -167,6 +167,29 @@ describe("release-assets/dependency-artifact-builder", () => {
     assertEquals((rootCode.match(/\/_vf\/assets\/[0-9a-f]{64}\.js/g) ?? []).length, 2);
   });
 
+  it("fails an import of a package outside the profile's declared externals", async () => {
+    const rootUrl = dependencyArtifactUpstreamUrl(standardIdentity);
+    const calls: string[] = [];
+    const { client, events } = recordingClient();
+    const result = await runDependencyArtifactBuild(buildTaskInput(), client, {
+      fetch: fixtureFetch({
+        [rootUrl]: response('import _ from "lodash"; export const value = 1;'),
+      }, calls),
+    });
+
+    assertEquals(
+      failureCodeOf(result),
+      "undeclared_external",
+      "a bare import outside the profile externals must fail the build",
+    );
+    assertEquals(calls, [rootUrl], "no further upstream fetch after an undeclared external");
+    assertEquals(
+      events.map((event) => event.kind),
+      ["result"],
+      "no asset upload for a rejected closure",
+    );
+  });
+
   it("rejects foreign hosts before fetching them", async () => {
     const rootUrl = dependencyArtifactUpstreamUrl(standardIdentity);
     const calls: string[] = [];
@@ -335,16 +358,27 @@ describe("release-assets/dependency-artifact-builder", () => {
     for (
       const [body, contentType, failureCode, maxAssetBytes] of [
         ["<!DOCTYPE html><title>ESM build failed</title>", "text/html", "upstream_html", 1024],
+        [
+          "<!DOCTYPE html><title>ESM build failed</title>",
+          "text/javascript",
+          "upstream_html",
+          1024,
+        ],
         ["export const value = 'too large';", "text/javascript", "asset_size_limit", 8],
       ] as const
     ) {
-      const { client } = recordingClient();
+      const { client, events } = recordingClient();
       const result = await runDependencyArtifactBuild(buildTaskInput(), client, {
         fetch: fixtureFetch({ [rootUrl]: response(body, contentType) }),
         limits: { maxAssetBytes },
       });
       assertEquals(result.success, false);
       assertEquals(failureCodeOf(result), failureCode);
+      assertEquals(
+        events.filter((event) => event.kind === "upload").length,
+        0,
+        "an upstream HTML body must never be uploaded as a dependency asset",
+      );
     }
   });
 
@@ -656,5 +690,48 @@ describe("release-assets/dependency-artifact-builder", () => {
         "Invalid dependency artifact build input",
       );
     }
+
+    for (const exactVersion of ["latest", "1.2"]) {
+      try {
+        parseDependencyArtifactBuildTaskInput({
+          ...buildTaskInput(),
+          identity: { ...standardIdentity, exact_version: exactVersion },
+        });
+        throw new Error("expected validation failure");
+      } catch (error) {
+        assertStringIncludes(
+          error instanceof Error ? error.message : String(error),
+          "Invalid dependency artifact build input",
+        );
+      }
+    }
+
+    try {
+      parseDependencyArtifactBuildTaskInput({
+        ...buildTaskInput(),
+        identity: { ...standardIdentity, package_name: "react" },
+      });
+      throw new Error("expected validation failure");
+    } catch (error) {
+      assertStringIncludes(
+        error instanceof Error ? error.message : String(error),
+        "Invalid dependency artifact build input",
+      );
+    }
+
+    try {
+      parseDependencyArtifactBuildTaskInput({
+        ...buildTaskInput(),
+        artifact_id: "not-a-uuid",
+      });
+      throw new Error("expected validation failure");
+    } catch (error) {
+      assertStringIncludes(
+        error instanceof Error ? error.message : String(error),
+        "Invalid dependency artifact build input",
+      );
+    }
+
+    assertEquals(parsed.identity.profile, "standard-v1");
   });
 });

--- a/src/release-assets/dependency-artifact-mode.test.ts
+++ b/src/release-assets/dependency-artifact-mode.test.ts
@@ -48,6 +48,30 @@ describe("dependency artifact rollout mode", () => {
     }
   });
 
+  it("activates the configured mode for allowlisted projects from host env", () => {
+    const original = new Map(ROLLOUT_ENV_KEYS.map((key) => [key, getHostEnv(key)]));
+    try {
+      // Percent 0 plus an allowlist pins each env key to its own field: a
+      // swapped key leaves the project outside both the mode and the cohort.
+      setEnv(DEPENDENCY_ARTIFACT_MODE_ENV, "prefer");
+      setEnv(DEPENDENCY_ARTIFACT_ROLLOUT_PERCENT_ENV, "0");
+      setEnv(DEPENDENCY_ARTIFACT_PROJECTS_ENV, "project-alpha");
+
+      assertEquals(
+        getDependencyArtifactModeForProject("project-alpha"),
+        "prefer",
+        "an allowlisted project must pick up the host-configured mode",
+      );
+      assertEquals(
+        getDependencyArtifactModeForProject("project-gamma"),
+        "off",
+        "a project outside the allowlist and cohort stays off",
+      );
+    } finally {
+      restoreEnv(original);
+    }
+  });
+
   it("accepts only the four rollout modes", () => {
     for (const mode of ["off", "shadow", "prefer", "require"] as const) {
       assertEquals(

--- a/src/release-assets/html-consumption.test.ts
+++ b/src/release-assets/html-consumption.test.ts
@@ -152,10 +152,16 @@ describe("manifest cache gating", () => {
     resetRequestProfiles();
   });
 
-  it("returns null when the flag is off (byte-identical fallback)", () => {
+  it("returns null when the flag is off (byte-identical fallback)", async () => {
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "");
-    registerManifestFetcherForRelease("r", () => Promise.resolve(readyManifestResponse()));
+    let fetchCount = 0;
+    registerManifestFetcherForRelease("r", () => {
+      fetchCount++;
+      return Promise.resolve(readyManifestResponse());
+    });
     assertEquals(getReadyManifestForRender("r"), null);
+    await Promise.resolve();
+    assertEquals(fetchCount, 0, "a disabled flag must not reach the control plane");
   });
 
   it("returns null when no fetcher is registered", () => {

--- a/src/release-assets/manifest-cache.test.ts
+++ b/src/release-assets/manifest-cache.test.ts
@@ -5,6 +5,8 @@ import { __subscribeLogRecordEmitter, type LogEntry } from "#veryfront/utils/log
 import {
   clearCachedReleaseAssetManifests,
   clearReleaseAssetManifestCache,
+  getReadyManifestForBrowserModuleAdmission,
+  getReadyManifestForRender,
   getReadyManifestForRenderAsync,
   registerManifestFetcherForRelease,
 } from "./manifest-cache.ts";
@@ -182,6 +184,37 @@ describe("release asset manifest fetcher ownership", () => {
     assertEquals((await getReadyManifestForRenderAsync("release"))?.releaseId, "release");
     assertEquals((await getReadyManifestForRenderAsync("release:1"))?.releaseId, "release:1");
     assertEquals(calls, ["release", "release:1"]);
+
+    // A non-ready result for the delimiter-shaped sibling writes to its own
+    // plain cache slot. Under a delimiter-joined key that slot is the same
+    // string as `release` at manifestVersion 1, so the sibling would evict it.
+    registerManifestFetcherForRelease("release:1", () => Promise.resolve(null));
+    await getReadyManifestForRenderAsync("release:1");
+    assertEquals(
+      getReadyManifestForRender("release")?.manifestVersion,
+      1,
+      "a delimiter-shaped sibling release must not evict this release's cached ready manifest",
+    );
+  });
+
+  it("admits browser modules regardless of the release-manifest rollout flag", async () => {
+    clearReleaseAssetManifestCache();
+    Deno.env.delete("VERYFRONT_RELEASE_ASSET_MANIFEST");
+    registerManifestFetcherForRelease(
+      "release-1",
+      () => Promise.resolve(readyManifestResponse("release-1", 1)),
+    );
+
+    assertEquals(
+      (await getReadyManifestForBrowserModuleAdmission("release-1"))?.releaseId,
+      "release-1",
+      "browser-module admission must never be gated by the rollout flag",
+    );
+    assertEquals(
+      await getReadyManifestForRenderAsync("release-1"),
+      null,
+      "render reads stay gated by the rollout flag",
+    );
   });
 
   it("does not let a superseded in-flight fetch publish stale state", async () => {

--- a/src/release-assets/manifest-schema.test.ts
+++ b/src/release-assets/manifest-schema.test.ts
@@ -255,6 +255,17 @@ describe("release asset manifest schema", () => {
     assertEquals(parsed.state, "ready");
     assertEquals(parsed.manifest_version, manifest.manifestVersion);
     assertEquals(parsed.manifest, manifest);
+
+    for (const state of ["building", "partial", "failed", "superseded", "", "READY"]) {
+      assertEquals(
+        parseReadyReleaseAssetManifestResponse(
+          { state, manifest_version: manifest.manifestVersion, manifest },
+          manifest.releaseId,
+        ),
+        null,
+        `a ${state || "(empty)"} envelope must not parse as ready`,
+      );
+    }
   });
 
   it("rejects missing or mismatched response manifest versions", () => {
@@ -440,6 +451,34 @@ describe("release asset manifest schema", () => {
     const extraField = { ...validManifest(), unexpected: true };
     assertEquals(getReleaseAssetManifestSchema().safeParse(extraField).success, false);
     assertEquals(parseReleaseAssetManifest(extraField), null);
+
+    for (const builderVersion of ["0.1.765\u0000", "0.1.765\r\nX-Injected: 1"]) {
+      const ctrl = validManifest();
+      ctrl.builderVersion = builderVersion;
+      assertEquals(
+        parseReleaseAssetManifest(ctrl),
+        null,
+        "control characters must not pass builderVersion",
+      );
+      assertEquals(
+        getReleaseAssetManifestSchema().safeParse(ctrl).success,
+        false,
+        "the zod validator must reject a control character in builderVersion",
+      );
+    }
+
+    const untrimmed = validManifest();
+    untrimmed.projectId = " 11111111-1111-1111-1111-111111111111 ";
+    assertEquals(
+      parseReleaseAssetManifest(untrimmed),
+      null,
+      "identifiers must be trimmed",
+    );
+    assertEquals(
+      getReleaseAssetManifestSchema().safeParse(untrimmed).success,
+      false,
+      "identifiers must be trimmed",
+    );
   });
 
   it("never throws for hostile object input", () => {
@@ -551,6 +590,24 @@ describe("describeReadyReleaseAssetManifestRejection", () => {
     assertStringIncludes(
       describeReadyReleaseAssetManifestRejection({ state: "ready" }, "r1"),
       "no usable manifest_version",
+    );
+
+    const m = validManifest();
+    assertStringIncludes(
+      describeReadyReleaseAssetManifestRejection(
+        { state: "ready", manifest_version: m.manifestVersion, manifest: m },
+        "33333333-3333-3333-3333-333333333333",
+      ),
+      "identifies a different release",
+      "a release-identity mismatch must be named, not reported as unrecognized",
+    );
+    assertStringIncludes(
+      describeReadyReleaseAssetManifestRejection(
+        { state: "ready", manifest_version: m.manifestVersion + 1, manifest: m },
+        m.releaseId,
+      ),
+      "disagree on the manifest version",
+      "an envelope/body version disagreement must be named",
     );
   });
 

--- a/src/release-assets/module-consumption.test.ts
+++ b/src/release-assets/module-consumption.test.ts
@@ -330,15 +330,41 @@ describe("rewriteReleaseDependencyImportsForModule", () => {
   });
 
   it("does not rewrite when the dependency import-map flag is off", async () => {
+    // Everything the rewrite needs is in place except the flag: a ready
+    // manifest that maps the bundle's embedded source URL to an asset, so the
+    // kill switch is the only thing keeping the import untouched.
     setEnv(RELEASE_ASSET_MANIFEST_ENV_FLAG, "1");
+    const sourceUrl = "https://esm.sh/react@19.2.4?deps=csstype%403.2.3&target=es2022";
+    registerManifestFetcherForRelease("release-id", () =>
+      Promise.resolve({
+        state: "ready",
+        manifest_version: 1,
+        manifest: manifest({
+          [sourceUrl]: {
+            contentHash: HASH_A,
+            size: 100,
+            contentType: "text/javascript",
+          },
+        }),
+      }));
     const code = 'import React from "file:///tmp/veryfront-http-bundle/http-123abc.mjs";';
 
     const result = await rewriteReleaseDependencyImportsForModule(code, {
       releaseId: "release-id",
       dependencyCacheRoot: "/tmp/veryfront-http-bundle",
-      readDependencySource: () => Promise.reject(new Error("unused")),
+      readDependencySource: () =>
+        Promise.resolve(`/*! @vf-source: ${sourceUrl} */\nexport default {};`),
     });
 
-    assertEquals(result, code);
+    assertEquals(
+      result,
+      code,
+      "the disabled dependency import-map flag must leave imports untouched",
+    );
+    assertEquals(
+      result.includes(HASH_A),
+      false,
+      "no asset URL may be substituted while the flag is off",
+    );
   });
 });

--- a/src/release-assets/route-path.test.ts
+++ b/src/release-assets/route-path.test.ts
@@ -41,4 +41,21 @@ describe("release-assets/route-path", () => {
     assertEquals(configuredRoutePath("src\\site\\page.tsx", directories, "app"), "app/page.tsx");
     assertEquals(routeForConfiguredPage("src\\pages\\about.tsx", directories), "/about");
   });
+
+  it("tries the pages root when the app root matches but the file is not an app route", () => {
+    // Nested roots: every pages file also lives below the app root, so the
+    // app lookup must fall through instead of deciding the answer.
+    const nested = { app: "src", pages: "src/pages" };
+
+    assertEquals(
+      routeForConfiguredPage("src/page.tsx", nested),
+      "/",
+      "the app root must still win when the file is an app route",
+    );
+    assertEquals(
+      routeForConfiguredPage("src/pages/about.tsx", nested),
+      "/about",
+      "a path below the app root that is not an app route must still resolve under the pages root",
+    );
+  });
 });

--- a/src/release-assets/scaffolded-project-build.test.ts
+++ b/src/release-assets/scaffolded-project-build.test.ts
@@ -269,8 +269,12 @@ describe("release assets: scaffolded project build", () => {
       // build succeeds either way: before the fix these scaffolds published
       // platform/compat/dynamic-import.ts as its own chunk and every test here
       // still passed.
-      const evalOffenders = rec.uploads
-        .filter((upload) => upload.contentType.includes("javascript"))
+      const jsUploads = rec.uploads.filter((upload) => upload.contentType.includes("javascript"));
+      assert(
+        jsUploads.length > 0,
+        `${templateName} published no JS assets, so the new Function guard would pass vacuously`,
+      );
+      const evalOffenders = jsUploads
         .filter((upload) => /\bnew Function\s*\(/.test(new TextDecoder().decode(upload.bytes)));
       assertEquals(
         evalOffenders.map((upload) => upload.hash),
@@ -285,6 +289,10 @@ describe("release assets: scaffolded project build", () => {
 
       const manifest = parseReleaseAssetManifest(rec.manifest);
       assertExists(manifest);
+      assert(
+        Object.keys(manifest.modules).length > 0,
+        `${templateName} manifest must list browser modules`,
+      );
       assertEquals(
         manifest.css.length,
         1,


### PR DESCRIPTION
## Summary

Audit of all 38 test files under `src/release-assets`, `src/discovery` and `src/middleware` for tests that stay green when the behavior they claim to cover breaks.

The bar for every change: name a concrete source edit that breaks documented behavior yet leaves the test passing. Every change was **mutation checked** — the named edit was applied, the test confirmed to fail, then the edit reverted.

57 candidate findings, 49 confirmed after adversarial verification, 49 applied, 8 refuted. **No product defects found. Test files only.**

## Recurring weaknesses fixed

**A test named for behavior it never exercised.** `should pass env and executionCtx to the context` never passed an `executionCtx` at all, so the pipeline could drop it entirely and the test stayed green. It now builds one and asserts the middleware context receives that exact object by identity.

**A self-constructed fixture standing in for the factory under test.** The discovery result shape test built its own object literal and asserted against that, so the real `createEmptyDiscoveryResult` could stop initializing a map and nothing failed. It now calls the factory and asserts the full 11-key set and that every map is empty.

**Transaction rollback was never observed.** No test placed a *successfully registered* primitive in the same rejected generation as a failure, so the rollback could be removed entirely and every test passed. A new case registers a live primitive alongside a failing one and asserts the live one is gone after the rejection.

**Error messages were asserted only for what they contain.** The rejection message now also asserts what it must *not* contain — local paths and upstream failure text — pinning the JSDoc contract about not leaking those.

**Branch fall-through was untested.** Route resolution now uses a nested layout where every pages file also sits under the app root, pinning both the app-root win *and* the fall-through to the pages root.

**Env wiring was pinned per key** by combining a zero rollout percent with an allowlist, so crossing two env vars fails.

**Name generation and provider-safety gating** for colocated tools now assert the generated short name and that an unsafe namespaced name (`researcher--fetch.paper`) is rejected with a specific error and never registered.

## Deliberately not applied

Two findings were dropped rather than forced:

- One needed a new test file outside the owning agent's file set; two agents editing one file is how merges get corrupted.
- The other proposed a mutation that **does not actually stay green** — deleting `registerPrompt` fails an existing test elsewhere — so strengthening against it would have proved nothing.

## Verification

- Semantic unit-boundary audit: ok
- Sanitizer ratchet test: ok, `test:layout`: ok, `docs:api-reference:check`: current
- `deno fmt`, `deno lint`: pass
- **30/30** changed test files pass
- `anti-slop`, `cwd-relative-test-reads`, `test-typecheck`, `check-awaits`, `cross-runtime-jsr`, `skipped-tests`, `ban-test-only`: all pass

No test was deleted, skipped, or weakened.