### PR TITLE
test(oauth,integrations,webhook,channels): make weak assertions bite

### DIFF
--- a/src/channels/control-plane.test.ts
+++ b/src/channels/control-plane.test.ts
@@ -908,7 +908,7 @@ describe("channels/control-plane", () => {
   });
 });
 
-Deno.test("resolveAgentSkills includes the agent's own skills and excludes others'", () => {
+it("resolveAgentSkills includes the agent's own skills and excludes others'", () => {
   skillRegistryInternal.clearAll();
   try {
     registerSkill("global-howto", {

--- a/src/channels/control-plane.test.ts
+++ b/src/channels/control-plane.test.ts
@@ -189,6 +189,34 @@ describe("channels/control-plane", () => {
       assertEquals(claims.request_hash, await sha256Base64url(body));
     });
 
+    it("rejects a control-plane signature minted for another surface", async () => {
+      const body = JSON.stringify({
+        requestId: "agents-1",
+        projectId: "proj-1",
+        surface: "channels",
+      });
+      const { jws, publicKeyPem } = await createControlPlaneSignature(body, {
+        surface: "channels",
+      });
+
+      await assertRejects(
+        () =>
+          verifyControlPlaneJws(jws, body, {
+            audience: "demo-project",
+            expectedProjectId: "proj-1",
+            expectedSubject: "agents-1",
+            expectedSurface: "studio",
+            publicKeyPem,
+            maxAgeSeconds: 60,
+            requestMethod: "POST",
+            requestPath: CONTROL_PLANE_AGENTS_LIST_PATH,
+          }),
+        Error,
+        "surface mismatch",
+        "an envelope minted for another surface must not satisfy a studio-scoped verification",
+      );
+    });
+
     it("rejects a control-plane signature when the body hash does not match", async () => {
       const body = JSON.stringify({
         requestId: "agents-1",
@@ -284,6 +312,42 @@ describe("channels/control-plane", () => {
           requestMethod: "POST",
           requestPath: "/api/control-plane/./agents/list",
         })
+      );
+
+      const nonCanonicalMethod = await createControlPlaneSignature(body, {
+        requestMethod: "post",
+      });
+      await assertRejects(
+        () =>
+          verifyControlPlaneJws(nonCanonicalMethod.jws, body, {
+            audience: "demo-project",
+            expectedProjectId: "proj-1",
+            publicKeyPem: nonCanonicalMethod.publicKeyPem,
+            maxAgeSeconds: 60,
+            requestMethod: "post",
+            requestPath: CONTROL_PLANE_AGENTS_LIST_PATH,
+          }),
+        Error,
+        "canonical HTTP method",
+        "a lowercase signed method must be rejected as non-canonical, not merely mismatched",
+      );
+
+      const nonCanonicalPath = await createControlPlaneSignature(body, {
+        requestPath: "/api/control-plane/./agents/list",
+      });
+      await assertRejects(
+        () =>
+          verifyControlPlaneJws(nonCanonicalPath.jws, body, {
+            audience: "demo-project",
+            expectedProjectId: "proj-1",
+            publicKeyPem: nonCanonicalPath.publicKeyPem,
+            maxAgeSeconds: 60,
+            requestMethod: "POST",
+            requestPath: "/api/control-plane/./agents/list",
+          }),
+        Error,
+        "canonical URL pathname",
+        "a dot-segment signed path must be rejected as non-canonical",
       );
 
       let bindingGetterCalls = 0;
@@ -872,7 +936,10 @@ Deno.test("resolveAgentSkills includes the agent's own skills and excludes other
     assertEquals(resolveAgentSkills(defaultWriter).map((skill) => skill.id), ["global-howto"]);
 
     const emptyWriter = { id: "writer", config: { skills: [] } } as unknown as Agent;
-    assertEquals(resolveAgentSkills(emptyWriter), []);
+    assertEquals(resolveAgentSkills(emptyWriter), [], "skills: [] advertises no skills");
+
+    const disabledWriter = { id: "writer", config: { skills: false } } as unknown as Agent;
+    assertEquals(resolveAgentSkills(disabledWriter), [], "skills: false advertises no skills");
   } finally {
     skillRegistryInternal.clearAll();
   }

--- a/src/channels/invoke.test.ts
+++ b/src/channels/invoke.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { createEmptyDiscoveryResult } from "#veryfront/discovery";
 import type { Agent, AgentMessage as Message, AgentResponse } from "#veryfront/agent";
+import { VeryfrontError } from "#veryfront/errors";
 import { createError, toError } from "#veryfront/errors/veryfront-error.ts";
 import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
@@ -199,18 +200,47 @@ describe("channels/invoke", () => {
       const payload = createPayload();
       const body = JSON.stringify(payload);
       const now = Math.floor(Date.now() / 1000);
+      // Issued now so only the exp check can reject: a stale iat would also
+      // trip the replay window and hide a missing expiry check.
       const { jws, publicKeyPem } = await createDispatchSignature(body, {
-        iat: now - 120,
-        exp: now - 60,
+        iat: now,
+        exp: now - 1,
       });
 
-      await assertRejects(() =>
-        verifyDispatchJws(jws, body, {
-          audience: "demo-project",
-          publicKeyPem,
-          maxAgeSeconds: 60,
-          expectedProjectId: "proj-1",
-        })
+      await assertRejects(
+        () =>
+          verifyDispatchJws(jws, body, {
+            audience: "demo-project",
+            publicKeyPem,
+            maxAgeSeconds: 60,
+            expectedProjectId: "proj-1",
+          }),
+        VeryfrontError,
+        "expired",
+        "a freshly issued signature whose exp has passed must be rejected as expired",
+      );
+    });
+
+    it("rejects a stale but unexpired dispatch signature", async () => {
+      const payload = createPayload();
+      const body = JSON.stringify(payload);
+      const now = Math.floor(Date.now() / 1000);
+      const { jws, publicKeyPem } = await createDispatchSignature(body, {
+        iat: now - 600,
+        exp: now + 600,
+      });
+
+      await assertRejects(
+        () =>
+          verifyDispatchJws(jws, body, {
+            audience: "demo-project",
+            publicKeyPem,
+            maxAgeSeconds: 60,
+            expectedProjectId: "proj-1",
+          }),
+        VeryfrontError,
+        "too old",
+        "a signature minted outside the replay window must be rejected even while unexpired",
       );
     });
 
@@ -445,6 +475,59 @@ describe("channels/invoke", () => {
       ]);
     });
 
+    it("reports a failed tool call as an errored tool result", () => {
+      const response = createAgentResponse("Done", {
+        toolCalls: [{
+          id: "tool-1",
+          name: "search",
+          args: { query: "docs" },
+          status: "error",
+          error: "boom",
+        }],
+      });
+
+      assertEquals(
+        buildChannelResponseParts(response),
+        [
+          {
+            type: "tool_call",
+            id: "tool-1",
+            name: "search",
+            input: { query: "docs" },
+            state: "error",
+          },
+          {
+            type: "tool_result",
+            tool_call_id: "tool-1",
+            output: { error: "boom" },
+            is_error: true,
+          },
+          { type: "text", text: "Done" },
+        ],
+        "a failed tool call must be flagged as an errored tool result",
+      );
+
+      const withoutMessage = createAgentResponse("Done", {
+        toolCalls: [{
+          id: "tool-2",
+          name: "search",
+          args: { query: "docs" },
+          status: "error",
+        }],
+      });
+
+      assertEquals(
+        buildChannelResponseParts(withoutMessage)[1],
+        {
+          type: "tool_result",
+          tool_call_id: "tool-2",
+          output: { error: "Tool execution failed" },
+          is_error: true,
+        },
+        "a failed tool call without an error message must carry the default failure text",
+      );
+    });
+
     it("falls back to response text when no assistant message is present", () => {
       const response = createAgentResponse("Fallback answer", {
         messages: [{
@@ -521,8 +604,9 @@ describe("channels/invoke", () => {
         getAllAgentIds: () => ["agent-1"],
       };
 
+      const payload = createPayload({ generation: { maxResponseTokens: 321 } });
       const response = await executeChannelInvoke(
-        createPayload({ generation: { maxResponseTokens: 321 } }),
+        payload,
         createHandlerContext(),
         deps,
       );
@@ -531,6 +615,33 @@ describe("channels/invoke", () => {
       assertEquals(clearMemoryCalls, 1);
       assertExists(capturedGenerateInput);
       assertEquals(capturedGenerateInput.maxOutputTokens, 321);
+      assertEquals(
+        capturedGenerateInput.input,
+        [{
+          id: "msg-user-1",
+          role: "user",
+          parts: [{ type: "text", text: "Hello from Slack" }],
+          timestamp: Date.parse("2026-03-13T10:00:00.000Z"),
+        }],
+        "runtime agent must receive the normalized conversation history",
+      );
+      assertEquals(
+        capturedGenerateInput.context,
+        {
+          requestId: "dispatch-1",
+          dispatchId: "dispatch-1",
+          conversationId: "conversation-1",
+          projectId: "proj-1",
+          assistantId: "agent-1",
+          channel: {
+            text: "Hello from Slack",
+            userId: "U123",
+            userName: "Alice",
+            isDirectMessage: false,
+          },
+        },
+        "runtime agent must receive the dispatch context and inbound channel message",
+      );
       assertEquals(response, {
         ignored: false,
         responseParts: [{ type: "text", text: "Runtime answer" }],
@@ -561,6 +672,41 @@ describe("channels/invoke", () => {
         ignored: false,
         error: { code: "provider_error", retryable: false },
       });
+    });
+
+    it("classifies upstream provider failures as provider_error", async () => {
+      async function invokeWith(thrown: Error) {
+        return await executeChannelInvoke(
+          createPayload(),
+          createHandlerContext(),
+          {
+            ensureProjectDiscovery: async () => createEmptyDiscoveryResult(),
+            getAgent: () =>
+              createAgent({
+                generate: () => {
+                  throw thrown;
+                },
+              }),
+            getAllAgentIds: () => ["agent-1"],
+          },
+        );
+      }
+
+      assertEquals(
+        await invokeWith(toError(createError({ type: "api", message: "provider 503" }))),
+        { ignored: false, error: { code: "provider_error", retryable: true } },
+        "api provider failures must keep the provider_error taxonomy",
+      );
+      assertEquals(
+        await invokeWith(toError(createError({ type: "network", message: "connect timeout" }))),
+        { ignored: false, error: { code: "provider_error", retryable: true } },
+        "network provider failures must keep the provider_error taxonomy",
+      );
+      assertEquals(
+        await invokeWith(new Error("boom")),
+        { ignored: false, error: { code: "internal_error", retryable: true } },
+        "unclassified runtime failures must stay internal_error",
+      );
     });
 
     it("fails closed when the requested assistant is not registered on the runtime", async () => {

--- a/src/integrations/_data.test.ts
+++ b/src/integrations/_data.test.ts
@@ -1,5 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { airtableConfig } from "../oauth/providers/common.ts";
 import { connectors, icons } from "./_data.ts";
@@ -609,6 +614,9 @@ describe("integration endpoint specs", () => {
   });
 
   it("publishes all connector tool IDs with their integration namespace prefix", () => {
+    const seenToolIds = new Set<string>();
+    let toolCount = 0;
+
     for (const connector of connectors) {
       const prefix = `${connector.name}__`;
 
@@ -624,45 +632,68 @@ describe("integration endpoint specs", () => {
           tool.id.lastIndexOf("__"),
           `Expected ${connector.name}:${tool.id} to contain a single namespace separator`,
         );
+        assertEquals(
+          seenToolIds.has(tool.id),
+          false,
+          `Duplicate canonical tool ID ${tool.id} (second occurrence in ${connector.name})`,
+        );
+        seenToolIds.add(tool.id);
+        toolCount += 1;
       }
     }
 
+    assertEquals(
+      seenToolIds.size,
+      toolCount,
+      "every catalog tool ID must be unique across all connectors",
+    );
     assertExists(getTool("harvest", "harvest__list_accounts"));
   });
 
   it("keeps source connector template tool IDs prefixed before generation", async () => {
+    let inspectedTemplates = 0;
+    let checkedToolIds = 0;
+
     for await (const entry of Deno.readDir("templates/integrations")) {
       if (!entry.isDirectory || entry.name === "_base") continue;
 
+      let raw: string;
       try {
-        const raw = await Deno.readTextFile(
+        raw = await Deno.readTextFile(
           `templates/integrations/${entry.name}/connector.json`,
         );
-        const connector = JSON.parse(raw) as {
-          name?: string;
-          tools?: Array<{ id?: string }>;
-        };
-        const connectorName = connector.name ?? entry.name;
-        const prefix = `${connectorName}__`;
-
-        for (const tool of connector.tools ?? []) {
-          if (!tool.id) continue;
-          assertEquals(
-            tool.id.startsWith(prefix),
-            true,
-            `Expected ${entry.name}:${tool.id} to start with ${prefix}`,
-          );
-          assertEquals(
-            tool.id.indexOf("__"),
-            tool.id.lastIndexOf("__"),
-            `Expected ${entry.name}:${tool.id} to contain a single namespace separator`,
-          );
-        }
       } catch (error) {
-        if (error instanceof Deno.errors.NotFound) continue;
+        if (error instanceof Deno.errors.NotFound) {
+          throw new Error(`templates/integrations/${entry.name} has no connector.json`);
+        }
         throw error;
       }
+      const connector = JSON.parse(raw) as {
+        name?: string;
+        tools?: Array<{ id?: string }>;
+      };
+      inspectedTemplates += 1;
+      const connectorName = connector.name ?? entry.name;
+      const prefix = `${connectorName}__`;
+
+      for (const tool of connector.tools ?? []) {
+        if (!tool.id) continue;
+        assertEquals(
+          tool.id.startsWith(prefix),
+          true,
+          `Expected ${entry.name}:${tool.id} to start with ${prefix}`,
+        );
+        assertEquals(
+          tool.id.indexOf("__"),
+          tool.id.lastIndexOf("__"),
+          `Expected ${entry.name}:${tool.id} to contain a single namespace separator`,
+        );
+        checkedToolIds += 1;
+      }
     }
+
+    assert(inspectedTemplates > 0, "expected at least one connector template to be inspected");
+    assert(checkedToolIds > 0, "expected at least one template tool id to be checked");
   });
 
   it("uses the documented SAP supplier invoice release function import", () => {

--- a/src/integrations/local-credential-auth.test.ts
+++ b/src/integrations/local-credential-auth.test.ts
@@ -164,6 +164,35 @@ describe("local integration credential auth", () => {
     assertEquals(resolved.headers["X-Billbee-Api-Key"], "billbee-application-key");
   });
 
+  it("resolves Basic connectors whose catalog password is optional or defaulted", async () => {
+    const chargebeePlan = createLocalCredentialAuthPlan(connector("chargebee"));
+    assertEquals(chargebeePlan.requiredEnvironmentVariables, [
+      "CHARGEBEE_API_KEY",
+      "CHARGEBEE_API_PASSWORD",
+    ]);
+
+    const chargebee = await resolveLocalCredentialAuth(
+      chargebeePlan,
+      providerFrom({ CHARGEBEE_API_KEY: "cb-key" }),
+    );
+    assertEquals(
+      chargebee.headers.Authorization,
+      `Basic ${btoa("cb-key:")}`,
+      "an optional catalog password must resolve to an empty Basic password",
+    );
+
+    const freshdeskPlan = createLocalCredentialAuthPlan(connector("freshdesk"));
+    const freshdesk = await resolveLocalCredentialAuth(
+      freshdeskPlan,
+      providerFrom({ FRESHDESK_API_KEY: "fd-key" }),
+    );
+    assertEquals(
+      freshdesk.headers.Authorization,
+      `Basic ${btoa("fd-key:X")}`,
+      "the catalog-declared default password must be used",
+    );
+  });
+
   it("builds a PayPal client-credentials token request", async () => {
     const plan = createLocalCredentialAuthPlan(connector("paypal"));
     assertEquals(plan.requiredEnvironmentVariables, [
@@ -188,6 +217,42 @@ describe("local integration credential auth", () => {
       "Content-Type": "application/x-www-form-urlencoded",
     });
     assertEquals(resolved.body, "grant_type=client_credentials");
+  });
+
+  it("joins catalog-declared scopes into the client-credentials token body", async () => {
+    const plan = createLocalCredentialAuthPlan(connector("ramp"));
+    const resolved = await resolveLocalCredentialAuth(
+      plan,
+      providerFrom({
+        RAMP_CLIENT_ID: "ramp-client",
+        RAMP_CLIENT_SECRET: SECRET,
+      }),
+    );
+
+    assert(resolved.kind === "token-request");
+    assertEquals(
+      resolved.body,
+      "grant_type=client_credentials&scope=transactions%3Aread%20cards%3Aread%20users%3Aread%20reimbursements%3Aread",
+      "ramp token body must carry the declared scopes space-joined in catalog order",
+    );
+  });
+
+  it("places the scope entry ahead of request-body client credentials", async () => {
+    const plan = createLocalCredentialAuthPlan(connector("moss"));
+    const resolved = await resolveLocalCredentialAuth(
+      plan,
+      providerFrom({
+        MOSS_CLIENT_ID: "moss-client",
+        MOSS_CLIENT_SECRET: SECRET,
+      }),
+    );
+
+    assert(resolved.kind === "token-request");
+    assertEquals(
+      resolved.body,
+      `grant_type=client_credentials&scope=read&client_id=moss-client&client_secret=${SECRET}`,
+      "the scope entry must precede request-body client credentials",
+    );
   });
 
   it("form-encodes OAuth Basic client credentials before encoding the header", async () => {
@@ -241,6 +306,45 @@ describe("local integration credential auth", () => {
       resolved.body,
       `grant_type=client_credentials&client_id=trusted-shops-client&client_secret=${SECRET}&audience=https%3A%2F%2Fapi.etrusted.com`,
     );
+  });
+
+  it("rejects reserved and empty token parameter names", () => {
+    for (const parameterName of ["grant_type", "client_id", "client_secret", "scope", ""]) {
+      const invalidParams = {
+        name: "ramp",
+        auth: {
+          type: "oauth2",
+          grantType: "client_credentials",
+          tokenUrl: "https://oauth.example.test/token",
+          tokenAuthMethod: "basic",
+          additionalParams: { [parameterName]: "catalog-supplied" },
+        },
+        envVars: [{
+          name: "RAMP_CLIENT_ID",
+          description: "client id",
+          required: true,
+        }, {
+          name: "RAMP_CLIENT_SECRET",
+          description: "client secret",
+          required: true,
+        }],
+      } satisfies Pick<IntegrationConfig, "auth" | "envVars" | "name">;
+
+      const error = assertThrows(
+        () => createLocalCredentialAuthPlan(invalidParams),
+        VeryfrontError,
+      );
+      assertInstanceOf(error, VeryfrontError);
+      assertEquals(
+        error.slug,
+        "local-integration-config-invalid",
+        `token parameter "${parameterName}" must be rejected as invalid catalog metadata`,
+      );
+      assert(
+        error.message.includes("invalid token parameter"),
+        `token parameter "${parameterName}" must be reported as an invalid token parameter`,
+      );
+    }
   });
 
   it("builds a Salesforce service-account token request from its distinct vocabulary", async () => {

--- a/src/integrations/local-endpoint-executor.test.ts
+++ b/src/integrations/local-endpoint-executor.test.ts
@@ -371,6 +371,42 @@ describe("local integration endpoint executor", () => {
     assert(authorized);
   });
 
+  it("keeps minted credentials ahead of model-supplied header arguments", async () => {
+    let authorization: string | null = null;
+    await executeLocalIntegrationEndpoint({
+      endpoint: endpoint({
+        method: "GET",
+        url: "https://api.example.test/items",
+        params: {
+          override: {
+            type: "string",
+            in: "header",
+            headerName: "Authorization",
+            description: "Model-supplied authorization override",
+          },
+        },
+      }),
+      args: { override: "Bearer attacker-token" },
+      authHeaders: { Authorization: `Bearer ${SECRET}` },
+      allowedOrigin: "https://api.example.test",
+      transport: (request) => {
+        authorization = new Headers(request.init.headers).get("authorization");
+        return Promise.resolve(Response.json({ ok: true }));
+      },
+    });
+
+    assertEquals(
+      authorization,
+      `Bearer ${SECRET}`,
+      "credential headers must override model-supplied header arguments",
+    );
+    assertEquals(
+      String(authorization).includes("attacker-token"),
+      false,
+      "a model-supplied header argument must never reach the provider as a credential",
+    );
+  });
+
   it("cleans up rejected provider bodies through captured stream primordials", async () => {
     const response = new Response("provider failure", { status: 500 });
     const restorers: Array<() => void> = [];

--- a/src/integrations/local-tool-source.test.ts
+++ b/src/integrations/local-tool-source.test.ts
@@ -20,8 +20,12 @@ import { runWithProjectEnv } from "#veryfront/server/project-env/storage.ts";
 import { EXPERIMENTAL_INTEGRATIONS_ENV } from "./feature-flags.ts";
 import { createLocalIntegrationToolSource, getConnector } from "./index.ts";
 import { HOST_LOCAL_INTEGRATION_CREDENTIALS_ENV } from "./local-credential-host-policy.ts";
+import { MAX_LOCAL_INTEGRATION_TOOLS } from "./limits.ts";
 import type { LocalIntegrationEndpointTransport } from "./local-endpoint-executor.ts";
-import { _createLocalIntegrationToolSourceForTesting } from "./local-tool-source.ts";
+import {
+  _createLocalIntegrationToolSourceForTesting,
+  type LocalIntegrationToolSourceOptions,
+} from "./local-tool-source.ts";
 
 const TEST_CREDENTIAL = "LOCAL_INTEGRATION_SECRET_MUST_NOT_LEAK";
 const testCredentialProvider = () => TEST_CREDENTIAL;
@@ -314,6 +318,50 @@ describe("createLocalIntegrationToolSource", () => {
       });
       await duplicateSource.listTools();
     }, "duplicate");
+  });
+
+  it("rejects malformed source options", async () => {
+    await assertConfigurationError(async () => {
+      const oversizedSource = createLocalIntegrationToolSource({
+        tools: Array.from(
+          { length: MAX_LOCAL_INTEGRATION_TOOLS + 1 },
+          (_unused, index) => `vercel__list_projects_${index}`,
+        ),
+        credentialProvider: testCredentialProvider,
+      });
+      await oversizedSource.listTools();
+    }, `${MAX_LOCAL_INTEGRATION_TOOLS} tool limit`);
+
+    await assertConfigurationError(async () => {
+      const emptySource = createLocalIntegrationToolSource({
+        tools: [],
+        credentialProvider: testCredentialProvider,
+      });
+      await emptySource.listTools();
+    }, "at least one");
+
+    await assertConfigurationError(async () => {
+      const providerSource = createLocalIntegrationToolSource(
+        {
+          tools: ["vercel__list_projects"],
+          credentialProvider: "nope",
+        } as unknown as LocalIntegrationToolSourceOptions,
+      );
+      await providerSource.listTools();
+    }, "credentialProvider must be a function");
+
+    const accessorOptions = { credentialProvider: testCredentialProvider };
+    defineProperty(accessorOptions, "tools", {
+      configurable: true,
+      enumerable: true,
+      get: () => ["vercel__list_projects"],
+    });
+    await assertConfigurationError(async () => {
+      const accessorSource = createLocalIntegrationToolSource(
+        accessorOptions as unknown as LocalIntegrationToolSourceOptions,
+      );
+      await accessorSource.listTools();
+    }, 'option "tools" must be a data property');
   });
 
   it("denies unmarked deployment modes through listing and execution", async () => {

--- a/src/integrations/remote-tools.hardening.test.ts
+++ b/src/integrations/remote-tools.hardening.test.ts
@@ -22,6 +22,7 @@ import {
 import {
   executeRemoteIntegrationTool,
   getRemoteIntegrationToolDefinitions,
+  getRemoteIntegrationToolDiscovery,
 } from "./remote-tools.ts";
 
 const ENV_KEYS = [
@@ -184,8 +185,10 @@ describe("integrations/remote-tools hardening", () => {
         listener: EventListenerOrEventListenerObject,
         options?: boolean | AddEventListenerOptions,
       ) => {
-        originalAdd(type, listener, options);
+        // Abort inside the window the source re-checks: the {once:true}
+        // listener is registered after the event has already fired.
         if (type === "abort") caller.abort(reason);
+        originalAdd(type, listener, options);
       }) as AbortSignal["addEventListener"],
     });
     let fetchCalls = 0;
@@ -358,11 +361,47 @@ describe("integrations/remote-tools hardening", () => {
       () => getRemoteIntegrationToolDefinitions(),
     );
 
-    assertEquals(definitions, []);
+    assertEquals(definitions, [], "a body that is not valid UTF-8 must admit no tools");
+
+    // Valid JSON only after lenient U+FFFD replacement, so a repaired decode
+    // would admit the tool with corrupted metadata instead of failing closed.
+    const prefix = encoder.encode('{"tools":[{"name":"github__ok_tool","description":"a');
+    const suffix = encoder.encode('b","inputSchema":{}}]}');
+    const repairableBody = new Uint8Array(prefix.length + 1 + suffix.length);
+    repairableBody.set(prefix, 0);
+    repairableBody[prefix.length] = 0xff;
+    repairableBody.set(suffix, prefix.length + 1);
+
+    const discovery = await withMockFetch(
+      async () => new Response(repairableBody),
+      () => getRemoteIntegrationToolDiscovery(),
+    );
+
+    assertEquals(
+      discovery,
+      { status: "unavailable", reason: "request_failed" },
+      "malformed UTF-8 in the discovery body must fail closed rather than be repaired",
+    );
   });
 
   it("admits remote tool definitions atomically within count limits", async () => {
     configureRemoteTools();
+    const atLimitTools = Array.from(
+      { length: MAX_REMOTE_INTEGRATION_TOOL_DEFINITIONS },
+      (_, index) => createToolDefinition({ name: `github__tool_${index}` }),
+    );
+
+    const atLimitDefinitions = await withMockFetch(
+      async () => Response.json({ tools: atLimitTools }),
+      () => getRemoteIntegrationToolDefinitions(),
+    );
+
+    assertEquals(
+      atLimitDefinitions.length,
+      MAX_REMOTE_INTEGRATION_TOOL_DEFINITIONS,
+      "a catalog at exactly the definition ceiling must be admitted in full",
+    );
+
     const tools = Array.from(
       { length: MAX_REMOTE_INTEGRATION_TOOL_DEFINITIONS + 1 },
       (_, index) => createToolDefinition({ name: `github__tool_${index}` }),
@@ -373,7 +412,7 @@ describe("integrations/remote-tools hardening", () => {
       () => getRemoteIntegrationToolDefinitions(),
     );
 
-    assertEquals(definitions, []);
+    assertEquals(definitions, [], "a catalog past the definition ceiling must be rejected whole");
   });
 
   it("rejects duplicate remote tool names atomically", async () => {

--- a/src/integrations/remote-tools.test.ts
+++ b/src/integrations/remote-tools.test.ts
@@ -146,10 +146,11 @@ describe("integrations/remote-tools", () => {
         fetchCalls++;
         const authorization = request.headers.get("Authorization");
         const tenant = authorization === "Bearer tenant-a-token" ? "a" : "b";
+        const project = request.headers.get("x-veryfront-project-slug") ?? "none";
         return Response.json({
           tools: [{
-            name: `github__tenant_${tenant}`,
-            description: `Tenant ${tenant}`,
+            name: `github__tenant_${tenant}_${project}`,
+            description: `Tenant ${tenant} ${project}`,
             inputSchema: {},
           }],
         });
@@ -167,17 +168,21 @@ describe("integrations/remote-tools", () => {
           const repeatFetchCalls = fetchCalls;
           const tenantB = await getRemoteIntegrationToolDiscovery({
             authToken: "tenant-b-token",
+            projectSlug: "project-a",
+          });
+          const projectB = await getRemoteIntegrationToolDiscovery({
+            authToken: "tenant-a-token",
             projectSlug: "project-b",
           });
-          return { tenantA, tenantARepeat, repeatFetchCalls, tenantB };
+          return { tenantA, tenantARepeat, repeatFetchCalls, tenantB, projectB };
         }),
     );
 
     const tenantACatalog: RemoteIntegrationToolDiscoveryResult = {
       status: "ok",
       tools: [{
-        name: "github__tenant_a",
-        description: "Tenant a",
+        name: "github__tenant_a_project-a",
+        description: "Tenant a project-a",
         parameters: { type: "object", properties: {} },
       }],
     };
@@ -189,8 +194,8 @@ describe("integrations/remote-tools", () => {
     );
     assertEquals(
       fetchCalls,
-      2,
-      "a different credential and project must miss the per-run cache",
+      3,
+      "different credentials and projects must independently miss the per-run cache",
     );
     assertEquals(results.tenantA, tenantACatalog, "tenant A must receive its own catalog");
     assertEquals(
@@ -203,12 +208,24 @@ describe("integrations/remote-tools", () => {
       {
         status: "ok",
         tools: [{
-          name: "github__tenant_b",
-          description: "Tenant b",
+          name: "github__tenant_b_project-a",
+          description: "Tenant b project-a",
           parameters: { type: "object", properties: {} },
         }],
       },
-      "tenant B must never be served tenant A's catalog",
+      "a different credential with the same project must never be served tenant A's catalog",
+    );
+    assertEquals(
+      results.projectB,
+      {
+        status: "ok",
+        tools: [{
+          name: "github__tenant_a_project-b",
+          description: "Tenant a project-b",
+          parameters: { type: "object", properties: {} },
+        }],
+      },
+      "the same credential with a different project must miss the per-run cache",
     );
   });
 

--- a/src/integrations/remote-tools.test.ts
+++ b/src/integrations/remote-tools.test.ts
@@ -19,6 +19,7 @@ import {
   getRemoteIntegrationToolDefinitions,
   getRemoteIntegrationToolDiscovery,
   isRemoteIntegrationTool,
+  type RemoteIntegrationToolDiscoveryResult,
   runWithRemoteIntegrationToolDiscoveryScope,
 } from "./remote-tools.ts";
 
@@ -130,6 +131,85 @@ describe("integrations/remote-tools", () => {
       { status: "ok", tools: [] },
       { status: "ok", tools: [] },
     ]);
+  });
+
+  it("keys the per-run discovery cache by credential and project", async () => {
+    setRemoteToolEnv({
+      VERYFRONT_API_BASE_URL: "https://api.test",
+      VERYFRONT_API_TOKEN: "env-token",
+    });
+
+    let fetchCalls = 0;
+    const results = await withMockFetch(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        fetchCalls++;
+        const authorization = request.headers.get("Authorization");
+        const tenant = authorization === "Bearer tenant-a-token" ? "a" : "b";
+        return Response.json({
+          tools: [{
+            name: `github__tenant_${tenant}`,
+            description: `Tenant ${tenant}`,
+            inputSchema: {},
+          }],
+        });
+      },
+      () =>
+        runWithRemoteIntegrationToolDiscoveryScope(async () => {
+          const tenantA = await getRemoteIntegrationToolDiscovery({
+            authToken: "tenant-a-token",
+            projectSlug: "project-a",
+          });
+          const tenantARepeat = await getRemoteIntegrationToolDiscovery({
+            authToken: "tenant-a-token",
+            projectSlug: "project-a",
+          });
+          const repeatFetchCalls = fetchCalls;
+          const tenantB = await getRemoteIntegrationToolDiscovery({
+            authToken: "tenant-b-token",
+            projectSlug: "project-b",
+          });
+          return { tenantA, tenantARepeat, repeatFetchCalls, tenantB };
+        }),
+    );
+
+    const tenantACatalog: RemoteIntegrationToolDiscoveryResult = {
+      status: "ok",
+      tools: [{
+        name: "github__tenant_a",
+        description: "Tenant a",
+        parameters: { type: "object", properties: {} },
+      }],
+    };
+
+    assertEquals(
+      results.repeatFetchCalls,
+      1,
+      "repeating the same credential and project must hit the per-run cache",
+    );
+    assertEquals(
+      fetchCalls,
+      2,
+      "a different credential and project must miss the per-run cache",
+    );
+    assertEquals(results.tenantA, tenantACatalog, "tenant A must receive its own catalog");
+    assertEquals(
+      results.tenantARepeat,
+      tenantACatalog,
+      "the cached tenant A catalog must be replayed unchanged",
+    );
+    assertEquals(
+      results.tenantB,
+      {
+        status: "ok",
+        tools: [{
+          name: "github__tenant_b",
+          description: "Tenant b",
+          parameters: { type: "object", properties: {} },
+        }],
+      },
+      "tenant B must never be served tenant A's catalog",
+    );
   });
 
   it("caches a transient failure for the current run and retries the next run", async () => {
@@ -709,6 +789,46 @@ describe("integrations/remote-tools", () => {
     });
   });
 
+  it("rejects a malformed MCP error marker instead of reporting success", async () => {
+    setRemoteToolEnv({
+      VERYFRONT_API_BASE_URL: "https://api.test",
+      VERYFRONT_API_TOKEN: "env-token",
+    });
+
+    await withMockFetch(
+      async () =>
+        Response.json({
+          isError: "true",
+          content: [{ type: "text", text: "permission denied" }],
+        }),
+      () =>
+        assertRejects(
+          () => executeRemoteIntegrationTool("github__list_repos", {}),
+          TypeError,
+          "malformed MCP error marker",
+          "a non-boolean isError must not be coerced into a successful tool result",
+        ),
+    );
+
+    const structuredError = await withMockFetch(
+      async () =>
+        Response.json({
+          isError: true,
+          content: [{
+            type: "text",
+            text: JSON.stringify({ error: "authentication_required" }),
+          }],
+        }),
+      () => executeRemoteIntegrationTool("github__list_repos", {}),
+    );
+
+    assertEquals(
+      structuredError,
+      { error: "authentication_required" },
+      "a well-formed MCP error must still resolve to its parsed structured payload",
+    );
+  });
+
   it("addresses execution by integration and tool path without duplicating identity in the body", async () => {
     setRemoteToolEnv({
       VERYFRONT_API_BASE_URL: "https://api.test",
@@ -744,6 +864,36 @@ describe("integrations/remote-tools", () => {
       run_id: "run-123",
       agent_id: "agent-123",
     });
+  });
+
+  it("rejects noncanonical run and agent identifiers before any request", async () => {
+    setRemoteToolEnv({
+      VERYFRONT_API_BASE_URL: "https://api.test",
+      VERYFRONT_API_TOKEN: "env-token",
+    });
+
+    let fetchCalls = 0;
+    for (const context of [{ runId: "run\n1" }, { runId: " run-1 " }, { agentId: "" }]) {
+      await withMockFetch(
+        async () => {
+          fetchCalls++;
+          return Response.json({ structuredContent: { ok: true } });
+        },
+        () =>
+          assertRejects(
+            () => executeRemoteIntegrationTool("github__list_repos", {}, context),
+            TypeError,
+            "must be a canonical identifier",
+            "a noncanonical run or agent identity must be rejected",
+          ),
+      );
+    }
+
+    assertEquals(
+      fetchCalls,
+      0,
+      "a noncanonical identity must fail before the integrations API is called",
+    );
   });
 
   it("forwards the request project slug when executing a remote integration tool", async () => {

--- a/src/integrations/salesforce-service-account.test.ts
+++ b/src/integrations/salesforce-service-account.test.ts
@@ -430,6 +430,95 @@ describe("Salesforce service-account integration source", () => {
     );
   });
 
+  async function assertCacheKeyDimensionMintsSeparately(
+    first: Record<string, string>,
+    second: Record<string, string>,
+    dimension: string,
+  ): Promise<void> {
+    setCredentials();
+    let tokenRequests = 0;
+    const transport = createTransport(({ body, request }) => {
+      if (request.url.endsWith("/services/oauth2/token")) {
+        tokenRequests++;
+        // Both credential sets share a login origin, so the minted identity is
+        // keyed off the posted client credentials rather than the request URL.
+        const form = new URLSearchParams(body);
+        const isFirst = form.get("client_id") === first[CLIENT_ID_ENV] &&
+          form.get("client_secret") === first[CLIENT_SECRET_ENV];
+        return Response.json({
+          access_token: isFirst ? "token-first" : "token-second",
+          instance_url: isFirst
+            ? "https://na-first.salesforce.com"
+            : "https://na-second.salesforce.com",
+        });
+      }
+      return Response.json({ totalSize: 0, records: [] });
+    });
+    const source = createSalesforceServiceAccountToolSourceWithTransport({
+      allowedTools: ["salesforce__list_cases"],
+      createOriginBoundFetch: transport.createOriginBoundFetch,
+    });
+
+    await runWithProjectEnv(first, () => source.executeTool("salesforce__list_cases", {}));
+    await runWithProjectEnv(second, () => source.executeTool("salesforce__list_cases", {}));
+
+    assertEquals(
+      tokenRequests,
+      2,
+      `a changed ${dimension} must mint its own token`,
+    );
+    const providerRequests = transport.captures.filter((capture) =>
+      capture.request.url.includes("/services/data/")
+    );
+    assertEquals(
+      providerRequests.length,
+      2,
+      `a changed ${dimension} must issue its own provider request`,
+    );
+    assertEquals(
+      providerRequests[1]?.request.headers.get("authorization"),
+      "Bearer token-second",
+      `a changed ${dimension} must not reuse the cached bearer token`,
+    );
+    assertEquals(
+      new URL(providerRequests[1]!.request.url).origin,
+      "https://na-second.salesforce.com",
+      `a changed ${dimension} must not reuse the cached instance origin`,
+    );
+  }
+
+  it("mints a fresh token when only the client id changes on one login origin", async () => {
+    await assertCacheKeyDimensionMintsSeparately(
+      {
+        [CLIENT_ID_ENV]: "client-a",
+        [CLIENT_SECRET_ENV]: "shared-secret",
+        [LOGIN_URL_ENV]: "https://shared.my.salesforce.com",
+      },
+      {
+        [CLIENT_ID_ENV]: "client-b",
+        [CLIENT_SECRET_ENV]: "shared-secret",
+        [LOGIN_URL_ENV]: "https://shared.my.salesforce.com",
+      },
+      "client id",
+    );
+  });
+
+  it("mints a fresh token when only the client secret changes on one login origin", async () => {
+    await assertCacheKeyDimensionMintsSeparately(
+      {
+        [CLIENT_ID_ENV]: "shared-client",
+        [CLIENT_SECRET_ENV]: "secret-a",
+        [LOGIN_URL_ENV]: "https://shared.my.salesforce.com",
+      },
+      {
+        [CLIENT_ID_ENV]: "shared-client",
+        [CLIENT_SECRET_ENV]: "secret-b",
+        [LOGIN_URL_ENV]: "https://shared.my.salesforce.com",
+      },
+      "client secret",
+    );
+  });
+
   it("rejects oversized token and provider responses before buffering them", async () => {
     setCredentials({
       [CLIENT_ID_ENV]: "client-id",

--- a/src/integrations/salesforce-service-account.test.ts
+++ b/src/integrations/salesforce-service-account.test.ts
@@ -17,12 +17,15 @@ import {
 import { VeryfrontError } from "#veryfront/errors";
 import type { ToolExecutionContext } from "#veryfront/tool";
 import { HOST_LOCAL_INTEGRATION_CREDENTIALS_ENV } from "./local-credential-host-policy.ts";
+import { MAX_INTEGRATION_TOOL_CALL_RESPONSE_BYTES } from "./limits.ts";
 import {
   createSalesforceServiceAccountToolSourceWithTransport,
   SALESFORCE_SERVICE_ACCOUNT_ENV_VARS,
 } from "./salesforce-service-account.ts";
 
 const [CLIENT_ID_ENV, CLIENT_SECRET_ENV, LOGIN_URL_ENV] = SALESFORCE_SERVICE_ACCOUNT_ENV_VARS;
+/** Mirrors the module-private token response cap in salesforce-service-account.ts. */
+const TOKEN_RESPONSE_LIMIT_BYTES = 64 * 1024;
 const trackedEnv = [...SALESFORCE_SERVICE_ACCOUNT_ENV_VARS] as const;
 const originalEnv = new Map(trackedEnv.map((name) => [name, getEnv(name)]));
 
@@ -364,6 +367,143 @@ describe("Salesforce service-account integration source", () => {
     const query = new URL(providerRequests[0]!.request.url).searchParams.get("q");
     assertStringIncludes(query ?? "", "FROM Case");
     assertStringIncludes(query ?? "", "LIMIT 50");
+  });
+
+  it("mints a fresh token when a second credential set reuses the same source", async () => {
+    setCredentials();
+    let tokenRequests = 0;
+    const transport = createTransport(({ baseUrl, request }) => {
+      if (request.url.endsWith("/services/oauth2/token")) {
+        tokenRequests++;
+        return baseUrl === "https://a.my.salesforce.com"
+          ? Response.json({
+            access_token: "token-a",
+            instance_url: "https://na-a.salesforce.com",
+          })
+          : Response.json({
+            access_token: "token-b",
+            instance_url: "https://na-b.salesforce.com",
+          });
+      }
+      return Response.json({ totalSize: 0, records: [] });
+    });
+    const source = createSalesforceServiceAccountToolSourceWithTransport({
+      allowedTools: ["salesforce__list_cases"],
+      createOriginBoundFetch: transport.createOriginBoundFetch,
+    });
+
+    await runWithProjectEnv(
+      {
+        [CLIENT_ID_ENV]: "client-a",
+        [CLIENT_SECRET_ENV]: "secret-a",
+        [LOGIN_URL_ENV]: "https://a.my.salesforce.com",
+      },
+      () => source.executeTool("salesforce__list_cases", {}),
+    );
+    await runWithProjectEnv(
+      {
+        [CLIENT_ID_ENV]: "client-b",
+        [CLIENT_SECRET_ENV]: "secret-b",
+        [LOGIN_URL_ENV]: "https://b.my.salesforce.com",
+      },
+      () => source.executeTool("salesforce__list_cases", {}),
+    );
+
+    assertEquals(tokenRequests, 2, "a second credential set must mint its own token");
+    const providerRequests = transport.captures.filter((capture) =>
+      capture.request.url.includes("/services/data/")
+    );
+    assertEquals(
+      providerRequests.length,
+      2,
+      "each credential set must issue its own provider request",
+    );
+    assertEquals(
+      providerRequests[1]?.request.headers.get("authorization"),
+      "Bearer token-b",
+      "the second project must not reuse the first project's bearer token",
+    );
+    assertEquals(
+      new URL(providerRequests[1]!.request.url).origin,
+      "https://na-b.salesforce.com",
+      "the second project must not reuse the first project's instance origin",
+    );
+  });
+
+  it("rejects oversized token and provider responses before buffering them", async () => {
+    setCredentials({
+      [CLIENT_ID_ENV]: "client-id",
+      [CLIENT_SECRET_ENV]: "client-secret",
+      [LOGIN_URL_ENV]: "https://acme.my.salesforce.com",
+    });
+    const oversizedTokenTransport = createTransport(({ request }) => {
+      if (!request.url.endsWith("/services/oauth2/token")) return Response.json({ Id: "leaked" });
+      return new Response(
+        JSON.stringify({
+          access_token: "access-token",
+          instance_url: "https://na123.salesforce.com",
+        }),
+        {
+          headers: {
+            "content-length": String(TOKEN_RESPONSE_LIMIT_BYTES + 1),
+            "content-type": "application/json",
+          },
+        },
+      );
+    });
+    const oversizedTokenSource = createSalesforceServiceAccountToolSourceWithTransport({
+      allowedTools: ["salesforce__get_case"],
+      createOriginBoundFetch: oversizedTokenTransport.createOriginBoundFetch,
+    });
+
+    const oversizedToken = await oversizedTokenSource.executeTool("salesforce__get_case", {
+      caseId: "500000000000001",
+    });
+
+    assertEquals(
+      oversizedToken,
+      {
+        error: "salesforce_api_error",
+        integration: "salesforce",
+        message: "Salesforce API request failed.",
+      },
+      "an over-length token response must fail before it is buffered",
+    );
+    assertEquals(
+      oversizedTokenTransport.captures.filter((capture) =>
+        capture.request.url.includes("/services/data/")
+      ).length,
+      0,
+      "the content-length pre-check must fire before any provider call",
+    );
+
+    const oversizedProviderTransport = createTransport(({ request }) => {
+      if (request.url.endsWith("/services/oauth2/token")) {
+        return Response.json({
+          access_token: "access-token",
+          instance_url: "https://na123.salesforce.com",
+        });
+      }
+      return new Response("x".repeat(MAX_INTEGRATION_TOOL_CALL_RESPONSE_BYTES + 1));
+    });
+    const oversizedProviderSource = createSalesforceServiceAccountToolSourceWithTransport({
+      allowedTools: ["salesforce__get_case"],
+      createOriginBoundFetch: oversizedProviderTransport.createOriginBoundFetch,
+    });
+
+    const oversizedProvider = await oversizedProviderSource.executeTool("salesforce__get_case", {
+      caseId: "500000000000001",
+    });
+
+    assertEquals(
+      oversizedProvider,
+      {
+        error: "salesforce_api_error",
+        integration: "salesforce",
+        message: "Salesforce API request failed.",
+      },
+      "an over-length provider response must be rejected instead of returned",
+    );
   });
 
   it("refreshes once after a provider 401 and sends only declared write fields", async () => {

--- a/src/integrations/source-policy.test.ts
+++ b/src/integrations/source-policy.test.ts
@@ -183,6 +183,7 @@ describe("source integration policy", () => {
     const right = normalizeSourceIntegrationPolicy({
       allow: {
         gmail: { allowedTools: ["delete_email", "list_emails"] },
+        github: {},
         confluence: {},
       },
     });
@@ -191,6 +192,7 @@ describe("source integration policy", () => {
       schemaVersion: 1,
       mode: "allowlist",
       integrations: {
+        github: { allowedToolIds: null },
         gmail: { allowedToolIds: ["list_emails"] },
       },
     });
@@ -200,6 +202,37 @@ describe("source integration policy", () => {
         right,
       ),
       right,
+    );
+    assertEquals(
+      intersectSourceIntegrationPolicies(
+        left,
+        { schemaVersion: 1, mode: "unrestricted" },
+      ),
+      left,
+      "an unrestricted right-hand policy must keep the left restrictions untouched",
+    );
+  });
+
+  it("keeps the narrower tool allowlist when one side allows every tool", () => {
+    const allowAll = normalizeSourceIntegrationPolicy({ allow: { github: {} } });
+    const narrowed = normalizeSourceIntegrationPolicy({
+      allow: { github: { allowedTools: ["list_repos"] } },
+    });
+    const expected = {
+      schemaVersion: 1,
+      mode: "allowlist",
+      integrations: { github: { allowedToolIds: ["list_repos"] } },
+    } as const;
+
+    assertEquals(
+      intersectSourceIntegrationPolicies(allowAll, narrowed),
+      expected,
+      "an allow-all left side must not discard the right side's tool allowlist",
+    );
+    assertEquals(
+      intersectSourceIntegrationPolicies(narrowed, allowAll),
+      expected,
+      "an allow-all right side must not discard the left side's tool allowlist",
     );
   });
 });

--- a/src/oauth/core-runtime.test.ts
+++ b/src/oauth/core-runtime.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createOAuthStatusHandler } from "./handlers/init-handler.ts";
 import { MemoryTokenStore } from "./token-store/memory.ts";
 import type { OAuthServiceConfig, StoredOAuthState, TokenStore } from "./types.ts";
+import { MAX_OAUTH_URL_LENGTH } from "./limits.ts";
 import { isOAuthRedirectUrl, isSecureOAuthEndpointUrl } from "./url-validation.ts";
 
 const TEST_CONFIG: OAuthServiceConfig = {
@@ -29,6 +30,29 @@ describe("OAuth cross-runtime contracts", () => {
     assertEquals(isOAuthRedirectUrl("http://127.0.0.1:8787/oauth/callback"), true);
     assertEquals(isOAuthRedirectUrl("http://localhost:8787/oauth/callback"), true);
     assertEquals(isOAuthRedirectUrl("http://app.test/oauth/callback"), false);
+
+    // Text the WHATWG parser silently rewrites must be refused before parsing,
+    // so validation never depends on parser normalization.
+    for (
+      const value of [
+        "https://provider.test\\@evil.test/token",
+        "https://prov\nider.test/token",
+        "https://provider.test/to\tken",
+        " https://provider.test/token",
+        `https://provider.test/${"x".repeat(MAX_OAUTH_URL_LENGTH)}`,
+      ]
+    ) {
+      assertEquals(
+        isSecureOAuthEndpointUrl(value),
+        false,
+        `endpoint validation must reject ${JSON.stringify(value)}`,
+      );
+      assertEquals(
+        isOAuthRedirectUrl(value),
+        false,
+        `redirect validation must reject ${JSON.stringify(value)}`,
+      );
+    }
   });
 
   it("keeps in-memory tokens detached and consumes OAuth state exactly once", async () => {

--- a/src/oauth/handlers/callback-handler.test.ts
+++ b/src/oauth/handlers/callback-handler.test.ts
@@ -417,35 +417,59 @@ Deno.test("callback-handler: stores tokens keyed by (serviceId, userId) — bob'
     createdAt: Date.now(),
   });
 
-  await withTokenExchange(
-    () =>
-      Response.json({
-        access_token: "alice-access-token",
-        refresh_token: "alice-refresh-token",
-        expires_in: 3600,
-        token_type: "Bearer",
-        scope: "read",
-      }),
-    async () => {
-      const handler = createOAuthCallbackHandler(TEST_CONFIG, {
-        tokenStore,
-        baseUrl: "http://localhost:3000",
-        envReader: (key) => ENV[key],
-      });
+  // Captured inside the mock but asserted after it resolves: a throw inside the
+  // fetch mock is swallowed by the handler and surfaces as a callback_error redirect.
+  const exchange: { url?: string; method?: string; body?: URLSearchParams } = {};
 
-      const response = await handler(
-        makeRequest({ code: "auth-code-abc", state: "alice-state" }),
-      );
-      assertEquals(response.status, 302);
+  await withMockFetch(async (input, init) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    exchange.url = request.url;
+    exchange.method = request.method;
+    exchange.body = new URLSearchParams(await request.text());
+    return Response.json({
+      access_token: "alice-access-token",
+      refresh_token: "alice-refresh-token",
+      expires_in: 3600,
+      token_type: "Bearer",
+      scope: "read",
+    });
+  }, async () => {
+    const handler = createOAuthCallbackHandler(TEST_CONFIG, {
+      tokenStore,
+      baseUrl: "http://localhost:3000",
+      envReader: (key) => ENV[key],
+    });
 
-      // Alice's tokens stored under her userId
-      const aliceTokens = await tokenStore.getTokens(TEST_CONFIG.serviceId, "alice");
-      assertEquals(aliceTokens?.accessToken, "alice-access-token");
+    const response = await handler(
+      makeRequest({ code: "auth-code-abc", state: "alice-state" }),
+    );
+    assertEquals(response.status, 302);
 
-      // Bob's slot untouched
-      const bobTokens = await tokenStore.getTokens(TEST_CONFIG.serviceId, "bob");
-      assertEquals(bobTokens?.accessToken, "bob-existing-token");
-    },
+    // Alice's tokens stored under her userId
+    const aliceTokens = await tokenStore.getTokens(TEST_CONFIG.serviceId, "alice");
+    assertEquals(aliceTokens?.accessToken, "alice-access-token");
+
+    // Bob's slot untouched
+    const bobTokens = await tokenStore.getTokens(TEST_CONFIG.serviceId, "bob");
+    assertEquals(bobTokens?.accessToken, "bob-existing-token");
+  });
+
+  assertEquals(exchange.url, TEST_CONFIG.tokenUrl, "the exchange must target the token URL");
+  assertEquals(exchange.method, "POST", "the exchange must be a POST");
+  assertEquals(
+    exchange.body?.get("code_verifier"),
+    CODE_VERIFIER,
+    "exchange must carry the consumed state's PKCE verifier",
+  );
+  assertEquals(
+    exchange.body?.get("code"),
+    "auth-code-abc",
+    "exchange must redeem the callback code",
+  );
+  assertEquals(
+    exchange.body?.get("redirect_uri"),
+    "http://localhost:3000/api/auth/test-provider/callback",
+    "exchange must reuse the state's redirect URI",
   );
 });
 
@@ -663,6 +687,47 @@ Deno.test("callback-handler: redirect responses prevent caching and referrer lea
   const response = await handler(makeRequest({ code: "code" }));
   assertEquals(response.headers.get("cache-control"), "no-store");
   assertEquals(response.headers.get("referrer-policy"), "no-referrer");
+});
+
+Deno.test("callback-handler: success redirects prevent caching and referrer leakage", async () => {
+  const storedState: StoredOAuthState = {
+    userId: "alice",
+    serviceId: TEST_CONFIG.serviceId,
+    codeVerifier: CODE_VERIFIER,
+    redirectUri: "http://localhost:3000/api/auth/test-provider/callback",
+    scopes: ["read"],
+    createdAt: Date.now(),
+  };
+  const tokenStore = createConsumedStateStore(storedState);
+
+  await withTokenExchange(
+    () => Response.json({ access_token: "provider-token" }),
+    async () => {
+      const handler = createOAuthCallbackHandler(TEST_CONFIG, {
+        tokenStore,
+        baseUrl: "http://localhost:3000",
+        envReader: (key) => ENV[key],
+      });
+      const response = await handler(makeRequest({ code: "code", state: "state" }));
+
+      assertEquals(response.status, 302, "a completed connection must redirect");
+      assertEquals(
+        new URL(response.headers.get("location")!).searchParams.get("connected"),
+        TEST_CONFIG.serviceId,
+        "the success redirect must report the connected service",
+      );
+      assertEquals(
+        response.headers.get("cache-control"),
+        "no-store",
+        "the success redirect must not be cached",
+      );
+      assertEquals(
+        response.headers.get("referrer-policy"),
+        "no-referrer",
+        "the success redirect must not leak the authorization code through the referrer",
+      );
+    },
+  );
 });
 
 Deno.test("callback-handler: detaches persisted tokens from post-commit hooks", async () => {

--- a/src/oauth/handlers/callback-handler.test.ts
+++ b/src/oauth/handlers/callback-handler.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { it } from "#veryfront/testing/bdd.ts";
 import { assertEquals, assertNotEquals, assertThrows } from "#std/assert";
 import { FakeTime } from "#std/testing/time";
 import { createTestEnvironmentConfig } from "#veryfront/config/environment-config.ts";
@@ -83,7 +84,7 @@ function createConsumedStateStore(state: StoredOAuthState): TokenStore {
   };
 }
 
-Deno.test("callback-handler rejects non-GET requests before consuming state", async () => {
+it("callback-handler rejects non-GET requests before consuming state", async () => {
   let consumeCalls = 0;
   const tokenStore = new MemoryTokenStore();
   tokenStore.consumeState = () => {
@@ -106,7 +107,7 @@ Deno.test("callback-handler rejects non-GET requests before consuming state", as
   assertEquals(consumeCalls, 0);
 });
 
-Deno.test("callback-handler: rejects request when state parameter is missing", async () => {
+it("callback-handler: rejects request when state parameter is missing", async () => {
   const tokenStore = new MemoryTokenStore();
   const handler = createOAuthCallbackHandler(TEST_CONFIG, {
     tokenStore,
@@ -121,7 +122,7 @@ Deno.test("callback-handler: rejects request when state parameter is missing", a
   assertEquals(location.searchParams.get("error"), "invalid_state");
 });
 
-Deno.test("callback-handler: rejects request when state is unknown (forged)", async () => {
+it("callback-handler: rejects request when state is unknown (forged)", async () => {
   const tokenStore = new MemoryTokenStore();
   const handler = createOAuthCallbackHandler(TEST_CONFIG, {
     tokenStore,
@@ -138,7 +139,7 @@ Deno.test("callback-handler: rejects request when state is unknown (forged)", as
   assertEquals(location.searchParams.get("error"), "invalid_state");
 });
 
-Deno.test("callback-handler: rejects request when state serviceId does not match", async () => {
+it("callback-handler: rejects request when state serviceId does not match", async () => {
   const tokenStore = new MemoryTokenStore();
 
   await tokenStore.setState("valid-state", {
@@ -165,7 +166,7 @@ Deno.test("callback-handler: rejects request when state serviceId does not match
   assertEquals(location.searchParams.get("error"), "invalid_state");
 });
 
-Deno.test("callback-handler: rejects request when state has expired", async () => {
+it("callback-handler: rejects request when state has expired", async () => {
   const tokenStore = createConsumedStateStore({
     userId: "alice",
     serviceId: TEST_CONFIG.serviceId,
@@ -190,7 +191,7 @@ Deno.test("callback-handler: rejects request when state has expired", async () =
   assertEquals(location.searchParams.get("error"), "invalid_state");
 });
 
-Deno.test("callback-handler: rejects state that expired inside the token store", async () => {
+it("callback-handler: rejects state that expired inside the token store", async () => {
   using time = new FakeTime();
   const tokenStore = new MemoryTokenStore();
   await tokenStore.setState("expired-state", {
@@ -219,7 +220,7 @@ Deno.test("callback-handler: rejects state that expired inside the token store",
   assertEquals(location.searchParams.get("error"), "invalid_state");
 });
 
-Deno.test("callback-handler: rejects stored state without a valid PKCE verifier", async () => {
+it("callback-handler: rejects stored state without a valid PKCE verifier", async () => {
   const tokenStore = createConsumedStateStore({
     userId: "alice",
     serviceId: TEST_CONFIG.serviceId,
@@ -243,7 +244,7 @@ Deno.test("callback-handler: rejects stored state without a valid PKCE verifier"
   );
 });
 
-Deno.test("callback-handler rejects legacy state rows without transaction bindings", async () => {
+it("callback-handler rejects legacy state rows without transaction bindings", async () => {
   const legacyState: StoredOAuthState = {
     userId: "alice",
     serviceId: TEST_CONFIG.serviceId,
@@ -267,7 +268,7 @@ Deno.test("callback-handler rejects legacy state rows without transaction bindin
   );
 });
 
-Deno.test("callback-handler accepts verifier-free state for a provider without PKCE", async () => {
+it("callback-handler accepts verifier-free state for a provider without PKCE", async () => {
   const config = { ...TEST_CONFIG, pkceMode: "unsupported" as const };
   const tokenStore = createConsumedStateStore({
     userId: "alice",
@@ -296,7 +297,7 @@ Deno.test("callback-handler accepts verifier-free state for a provider without P
   );
 });
 
-Deno.test("callback-handler: consumes state once (double-use rejected)", async () => {
+it("callback-handler: consumes state once (double-use rejected)", async () => {
   const tokenStore = new MemoryTokenStore();
 
   await tokenStore.setState("valid-state", {
@@ -329,7 +330,7 @@ Deno.test("callback-handler: consumes state once (double-use rejected)", async (
   assertEquals(location.searchParams.get("error"), "invalid_state");
 });
 
-Deno.test("callback-handler: rejects the unsafe state-validation bypass", () => {
+it("callback-handler: rejects the unsafe state-validation bypass", () => {
   assertThrows(
     () =>
       createOAuthCallbackHandler(TEST_CONFIG, {
@@ -344,7 +345,7 @@ Deno.test("callback-handler: rejects the unsafe state-validation bypass", () => 
   );
 });
 
-Deno.test("callback-handler: calls onError with invalid_state when state is missing", async () => {
+it("callback-handler: calls onError with invalid_state when state is missing", async () => {
   const tokenStore = new MemoryTokenStore();
   let errorServiceId = "";
   let errorCode = "";
@@ -365,7 +366,7 @@ Deno.test("callback-handler: calls onError with invalid_state when state is miss
   assertEquals(errorCode, "invalid_state");
 });
 
-Deno.test("callback-handler: proceeds with valid state matching serviceId", async () => {
+it("callback-handler: proceeds with valid state matching serviceId", async () => {
   const tokenStore = new MemoryTokenStore();
 
   await tokenStore.setState("valid-state-abc", {
@@ -400,7 +401,7 @@ Deno.test("callback-handler: proceeds with valid state matching serviceId", asyn
   }
 });
 
-Deno.test("callback-handler: stores tokens keyed by (serviceId, userId) — bob's slot untouched", async () => {
+it("callback-handler: stores tokens keyed by (serviceId, userId) — bob's slot untouched", async () => {
   const tokenStore = new MemoryTokenStore();
   // Bob already connected
   await tokenStore.setTokens(TEST_CONFIG.serviceId, "bob", {
@@ -473,7 +474,7 @@ Deno.test("callback-handler: stores tokens keyed by (serviceId, userId) — bob'
   );
 });
 
-Deno.test("callback-handler: validates and consumes state before handling provider errors", async () => {
+it("callback-handler: validates and consumes state before handling provider errors", async () => {
   const tokenStore = new MemoryTokenStore();
   const handler = createOAuthCallbackHandler(TEST_CONFIG, {
     tokenStore,
@@ -512,7 +513,7 @@ Deno.test("callback-handler: validates and consumes state before handling provid
   assertEquals(new URL(replay.headers.get("location")!).searchParams.get("error"), "invalid_state");
 });
 
-Deno.test("callback-handler: rejects duplicate security-sensitive query parameters", async () => {
+it("callback-handler: rejects duplicate security-sensitive query parameters", async () => {
   const tokenStore = new MemoryTokenStore();
   await tokenStore.setState("first", {
     userId: "alice",
@@ -541,7 +542,7 @@ Deno.test("callback-handler: rejects duplicate security-sensitive query paramete
   assertEquals((await tokenStore.consumeState("first"))?.userId, "alice");
 });
 
-Deno.test("callback-handler: rejects oversized state before touching the store", async () => {
+it("callback-handler: rejects oversized state before touching the store", async () => {
   const tokenStore = new MemoryTokenStore();
   let consumeCalls = 0;
   tokenStore.consumeState = () => {
@@ -565,7 +566,7 @@ Deno.test("callback-handler: rejects oversized state before touching the store",
   assertEquals(consumeCalls, 0);
 });
 
-Deno.test("callback-handler: rejects oversized codes before token exchange", async () => {
+it("callback-handler: rejects oversized codes before token exchange", async () => {
   const tokenStore = new MemoryTokenStore();
   await tokenStore.setState("valid-state", {
     userId: "alice",
@@ -602,7 +603,7 @@ Deno.test("callback-handler: rejects oversized codes before token exchange", asy
   }
 });
 
-Deno.test("callback-handler: rejects a state bound to a different redirect URI", async () => {
+it("callback-handler: rejects a state bound to a different redirect URI", async () => {
   const tokenStore = new MemoryTokenStore();
   await tokenStore.setState("wrong-redirect", {
     userId: "alice",
@@ -638,7 +639,7 @@ Deno.test("callback-handler: rejects a state bound to a different redirect URI",
   }
 });
 
-Deno.test("callback-handler: rejects cross-origin completion redirects", () => {
+it("callback-handler: rejects cross-origin completion redirects", () => {
   assertThrows(
     () =>
       createOAuthCallbackHandler(TEST_CONFIG, {
@@ -677,7 +678,7 @@ Deno.test("callback-handler: rejects cross-origin completion redirects", () => {
   );
 });
 
-Deno.test("callback-handler: redirect responses prevent caching and referrer leakage", async () => {
+it("callback-handler: redirect responses prevent caching and referrer leakage", async () => {
   const handler = createOAuthCallbackHandler(TEST_CONFIG, {
     tokenStore: new MemoryTokenStore(),
     baseUrl: "http://localhost:3000",
@@ -689,7 +690,7 @@ Deno.test("callback-handler: redirect responses prevent caching and referrer lea
   assertEquals(response.headers.get("referrer-policy"), "no-referrer");
 });
 
-Deno.test("callback-handler: success redirects prevent caching and referrer leakage", async () => {
+it("callback-handler: success redirects prevent caching and referrer leakage", async () => {
   const storedState: StoredOAuthState = {
     userId: "alice",
     serviceId: TEST_CONFIG.serviceId,
@@ -730,7 +731,7 @@ Deno.test("callback-handler: success redirects prevent caching and referrer leak
   );
 });
 
-Deno.test("callback-handler: detaches persisted tokens from post-commit hooks", async () => {
+it("callback-handler: detaches persisted tokens from post-commit hooks", async () => {
   const storedState: StoredOAuthState = {
     userId: "alice",
     serviceId: TEST_CONFIG.serviceId,
@@ -773,7 +774,7 @@ Deno.test("callback-handler: detaches persisted tokens from post-commit hooks", 
   );
 });
 
-Deno.test("callback-handler: error hook failures do not replace the OAuth response", async () => {
+it("callback-handler: error hook failures do not replace the OAuth response", async () => {
   const handler = createOAuthCallbackHandler(TEST_CONFIG, {
     tokenStore: new MemoryTokenStore(),
     baseUrl: "http://localhost:3000",

--- a/src/oauth/handlers/callback-handler.test.ts
+++ b/src/oauth/handlers/callback-handler.test.ts
@@ -1,6 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { it } from "#veryfront/testing/bdd.ts";
-import { assertEquals, assertNotEquals, assertThrows } from "#std/assert";
+import { assertEquals, assertNotEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { FakeTime } from "#std/testing/time";
 import { createTestEnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";

--- a/src/oauth/handlers/init-handler.test.ts
+++ b/src/oauth/handlers/init-handler.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { it } from "#veryfront/testing/bdd.ts";
 import { assertEquals, assertMatch, assertThrows } from "#std/assert";
 import type { EnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import { getEnvironmentConfig } from "#veryfront/config/environment-config.ts";
@@ -77,7 +78,7 @@ function createFailingStateStore(message: string): TokenStore {
   };
 }
 
-Deno.test("init handler: returns 401 when getUserId is not provided (fail-closed)", async () => {
+it("init handler: returns 401 when getUserId is not provided (fail-closed)", async () => {
   // deno-lint-ignore no-explicit-any
   const handler = createOAuthInitHandler(TEST_CONFIG, {
     env: makeEnv(),
@@ -90,7 +91,7 @@ Deno.test("init handler: returns 401 when getUserId is not provided (fail-closed
   assertEquals(response.status, 401);
 });
 
-Deno.test("init handler: returns 401 when isAuthenticated returns false", async () => {
+it("init handler: returns 401 when isAuthenticated returns false", async () => {
   const store = new MemoryTokenStore();
   const handler = createOAuthInitHandler(TEST_CONFIG, {
     tokenStore: store,
@@ -104,7 +105,7 @@ Deno.test("init handler: returns 401 when isAuthenticated returns false", async 
   assertEquals(response.status, 401);
 });
 
-Deno.test("init handler: returns 401 when getUserId returns null", async () => {
+it("init handler: returns 401 when getUserId returns null", async () => {
   const store = new MemoryTokenStore();
   const handler = createOAuthInitHandler(TEST_CONFIG, {
     tokenStore: store,
@@ -117,7 +118,7 @@ Deno.test("init handler: returns 401 when getUserId returns null", async () => {
   assertEquals(response.status, 401);
 });
 
-Deno.test("init handler: returns 401 when getUserId returns empty string", async () => {
+it("init handler: returns 401 when getUserId returns empty string", async () => {
   const store = new MemoryTokenStore();
   const handler = createOAuthInitHandler(TEST_CONFIG, {
     tokenStore: store,
@@ -130,7 +131,7 @@ Deno.test("init handler: returns 401 when getUserId returns empty string", async
   assertEquals(response.status, 401);
 });
 
-Deno.test("OAuth handlers reject oversized user identifiers before store access", async () => {
+it("OAuth handlers reject oversized user identifiers before store access", async () => {
   const oversizedUserId = "u".repeat(MAX_OAUTH_USER_ID_LENGTH + 1);
   let storeOperations = 0;
   const store: TokenStore = {
@@ -172,7 +173,7 @@ Deno.test("OAuth handlers reject oversized user identifiers before store access"
   assertEquals(storeOperations, 0);
 });
 
-Deno.test("init handler: returns 503 when oauth is not configured", async () => {
+it("init handler: returns 503 when oauth is not configured", async () => {
   const handler = createOAuthInitHandler(TEST_CONFIG, {
     env: makeEnv(),
     envReader: () => undefined,
@@ -188,7 +189,7 @@ Deno.test("init handler: returns 503 when oauth is not configured", async () => 
   });
 });
 
-Deno.test("init handler: not-configured response does not leak env var names (SEC-009)", async () => {
+it("init handler: not-configured response does not leak env var names (SEC-009)", async () => {
   const handler = createOAuthInitHandler(TEST_CONFIG, {
     env: makeEnv(),
     envReader: () => undefined,
@@ -210,7 +211,7 @@ Deno.test("init handler: not-configured response does not leak env var names (SE
   assertEquals("details" in body, false);
 });
 
-Deno.test("init handler: stores state with userId and redirects to the provider", async () => {
+it("init handler: stores state with userId and redirects to the provider", async () => {
   const store = new MemoryTokenStore();
   const appUrl = "https://example.test";
   const handler = createOAuthInitHandler(TEST_CONFIG, {
@@ -273,7 +274,7 @@ Deno.test("init handler: stores state with userId and redirects to the provider"
   );
 });
 
-Deno.test("init handler binds provider state to an explicit shared callback route", async () => {
+it("init handler binds provider state to an explicit shared callback route", async () => {
   const store = new MemoryTokenStore();
   const appUrl = "https://example.test";
   const handler = createOAuthInitHandler(TEST_CONFIG, {
@@ -293,7 +294,7 @@ Deno.test("init handler binds provider state to an explicit shared callback rout
   assertEquals((await store.consumeState(state))?.redirectUri, expectedRedirectUri);
 });
 
-Deno.test("init handler validates an explicit callback route eagerly", () => {
+it("init handler validates an explicit callback route eagerly", () => {
   assertThrows(
     () =>
       createOAuthInitHandler(TEST_CONFIG, {
@@ -307,7 +308,7 @@ Deno.test("init handler validates an explicit callback route eagerly", () => {
   );
 });
 
-Deno.test("init handler: supports async isAuthenticated and getUserId", async () => {
+it("init handler: supports async isAuthenticated and getUserId", async () => {
   const store = new MemoryTokenStore();
   const handler = createOAuthInitHandler(TEST_CONFIG, {
     tokenStore: store,
@@ -325,7 +326,7 @@ Deno.test("init handler: supports async isAuthenticated and getUserId", async ()
   assertEquals(storedState?.userId, "bob");
 });
 
-Deno.test("init handler: returns 500 when state persistence fails", async () => {
+it("init handler: returns 500 when state persistence fails", async () => {
   const handler = createOAuthInitHandler(TEST_CONFIG, {
     tokenStore: createFailingStateStore("state store failed"),
     env: makeEnv(),
@@ -343,7 +344,7 @@ Deno.test("init handler: returns 500 when state persistence fails", async () => 
   });
 });
 
-Deno.test("status handler: returns 401 when getUserId is not provided (fail-closed)", async () => {
+it("status handler: returns 401 when getUserId is not provided (fail-closed)", async () => {
   const store = new MemoryTokenStore();
   const handler = createOAuthStatusHandler(TEST_CONFIG, {
     tokenStore: store,
@@ -355,7 +356,7 @@ Deno.test("status handler: returns 401 when getUserId is not provided (fail-clos
   assertEquals(res.status, 401);
 });
 
-Deno.test("status handler: returns 401 when getUserId returns null", async () => {
+it("status handler: returns 401 when getUserId returns null", async () => {
   const store = new MemoryTokenStore();
   const handler = createOAuthStatusHandler(TEST_CONFIG, {
     tokenStore: store,
@@ -367,7 +368,7 @@ Deno.test("status handler: returns 401 when getUserId returns null", async () =>
   assertEquals(res.status, 401);
 });
 
-Deno.test("status handler: returns status for authenticated user", async () => {
+it("status handler: returns status for authenticated user", async () => {
   const store = new MemoryTokenStore();
   const handler = createOAuthStatusHandler(TEST_CONFIG, {
     tokenStore: store,
@@ -382,7 +383,7 @@ Deno.test("status handler: returns status for authenticated user", async () => {
   assertEquals(body.connected, false);
 });
 
-Deno.test("status handler: returns 401 when isAuthenticated returns false", async () => {
+it("status handler: returns 401 when isAuthenticated returns false", async () => {
   const store = new MemoryTokenStore();
   const handler = createOAuthStatusHandler(TEST_CONFIG, {
     tokenStore: store,
@@ -397,7 +398,7 @@ Deno.test("status handler: returns 401 when isAuthenticated returns false", asyn
   assertEquals(body.error, "Unauthorized");
 });
 
-Deno.test("status handler: scopes token lookup to caller userId", async () => {
+it("status handler: scopes token lookup to caller userId", async () => {
   const store = new MemoryTokenStore();
   await store.setTokens(TEST_CONFIG.serviceId, "alice", { accessToken: "alice-token" });
   await store.setTokens(TEST_CONFIG.serviceId, "bob", { accessToken: "bob-token" });
@@ -417,7 +418,7 @@ Deno.test("status handler: scopes token lookup to caller userId", async () => {
   assertEquals((await store.getTokens(TEST_CONFIG.serviceId, "bob"))?.accessToken, "bob-token");
 });
 
-Deno.test("status handler: treats expired access as connected when refresh token exists", async () => {
+it("status handler: treats expired access as connected when refresh token exists", async () => {
   const store = new MemoryTokenStore();
   await store.setTokens(TEST_CONFIG.serviceId, "alice", {
     accessToken: "access-token",
@@ -439,7 +440,7 @@ Deno.test("status handler: treats expired access as connected when refresh token
   assertEquals(body.hasRefreshToken, true);
 });
 
-Deno.test("status handler does not claim expired refreshable access without credentials", async () => {
+it("status handler does not claim expired refreshable access without credentials", async () => {
   const store = new MemoryTokenStore();
   await store.setTokens(TEST_CONFIG.serviceId, "alice", {
     accessToken: "expired",
@@ -459,7 +460,7 @@ Deno.test("status handler does not claim expired refreshable access without cred
   assertEquals(body.refreshCapable, true);
 });
 
-Deno.test("status handler does not claim an expired token is usable without refresh capabilities", async () => {
+it("status handler does not claim an expired token is usable without refresh capabilities", async () => {
   const store: TokenStore = {
     getTokens: () =>
       Promise.resolve({
@@ -485,7 +486,7 @@ Deno.test("status handler does not claim an expired token is usable without refr
   assertEquals(body.refreshCapable, false);
 });
 
-Deno.test("status handler: treats an epoch expiry as expired", async () => {
+it("status handler: treats an epoch expiry as expired", async () => {
   const store = new MemoryTokenStore();
   await store.setTokens(TEST_CONFIG.serviceId, "alice", {
     accessToken: "expired-access-token",
@@ -501,7 +502,7 @@ Deno.test("status handler: treats an epoch expiry as expired", async () => {
   assertEquals((await response.json()).connected, false);
 });
 
-Deno.test("status handler: supports async isAuthenticated and getUserId", async () => {
+it("status handler: supports async isAuthenticated and getUserId", async () => {
   const store = new MemoryTokenStore();
   const handler = createOAuthStatusHandler(TEST_CONFIG, {
     tokenStore: store,
@@ -514,7 +515,7 @@ Deno.test("status handler: supports async isAuthenticated and getUserId", async 
   assertEquals(res.status, 401);
 });
 
-Deno.test("disconnect handler: returns 401 when getUserId is not provided (fail-closed)", async () => {
+it("disconnect handler: returns 401 when getUserId is not provided (fail-closed)", async () => {
   const store = new MemoryTokenStore();
   const handler = createOAuthDisconnectHandler(TEST_CONFIG, {
     tokenStore: store,
@@ -526,7 +527,7 @@ Deno.test("disconnect handler: returns 401 when getUserId is not provided (fail-
   assertEquals(res.status, 401);
 });
 
-Deno.test("disconnect handler: clears only the calling user's tokens", async () => {
+it("disconnect handler: clears only the calling user's tokens", async () => {
   const store = new MemoryTokenStore();
   await store.setTokens(TEST_CONFIG.serviceId, "alice", { accessToken: "alice-token" });
   await store.setTokens(TEST_CONFIG.serviceId, "bob", { accessToken: "bob-token" });
@@ -550,7 +551,7 @@ Deno.test("disconnect handler: clears only the calling user's tokens", async () 
   );
 });
 
-Deno.test("disconnect handler: returns 401 when isAuthenticated returns false", async () => {
+it("disconnect handler: returns 401 when isAuthenticated returns false", async () => {
   const store = new MemoryTokenStore();
   const handler = createOAuthDisconnectHandler(TEST_CONFIG, {
     tokenStore: store,
@@ -565,7 +566,7 @@ Deno.test("disconnect handler: returns 401 when isAuthenticated returns false", 
   assertEquals(body.error, "Unauthorized");
 });
 
-Deno.test("disconnect handler: supports async isAuthenticated and getUserId", async () => {
+it("disconnect handler: supports async isAuthenticated and getUserId", async () => {
   const store = new MemoryTokenStore();
   const handler = createOAuthDisconnectHandler(TEST_CONFIG, {
     tokenStore: store,
@@ -578,7 +579,7 @@ Deno.test("disconnect handler: supports async isAuthenticated and getUserId", as
   assertEquals(res.status, 401);
 });
 
-Deno.test("OAuth handlers reject unexpected HTTP methods before application callbacks", async () => {
+it("OAuth handlers reject unexpected HTTP methods before application callbacks", async () => {
   let callbackCalls = 0;
   const options = {
     tokenStore: new MemoryTokenStore(),
@@ -610,7 +611,7 @@ Deno.test("OAuth handlers reject unexpected HTTP methods before application call
   assertEquals(callbackCalls, 0);
 });
 
-Deno.test("disconnect handler rejects missing and cross-origin CSRF origins", async () => {
+it("disconnect handler rejects missing and cross-origin CSRF origins", async () => {
   const store = new MemoryTokenStore();
   await store.setTokens(TEST_CONFIG.serviceId, "alice", { accessToken: "token" });
   let userIdCalls = 0;
@@ -633,7 +634,7 @@ Deno.test("disconnect handler rejects missing and cross-origin CSRF origins", as
   assertEquals((await store.getTokens(TEST_CONFIG.serviceId, "alice"))?.accessToken, "token");
 });
 
-Deno.test("init handler: rejects whitespace-only user identifiers", async () => {
+it("init handler: rejects whitespace-only user identifiers", async () => {
   const handler = createOAuthInitHandler(TEST_CONFIG, {
     env: makeEnv(),
     envReader: (key) => ENV[key],
@@ -643,7 +644,7 @@ Deno.test("init handler: rejects whitespace-only user identifiers", async () => 
   assertEquals((await handler(makeRequest())).status, 401);
 });
 
-Deno.test("init handler: rejects noncanonical user identifier whitespace", async () => {
+it("init handler: rejects noncanonical user identifier whitespace", async () => {
   const store = new MemoryTokenStore();
   const handler = createOAuthInitHandler(TEST_CONFIG, {
     tokenStore: store,
@@ -656,7 +657,7 @@ Deno.test("init handler: rejects noncanonical user identifier whitespace", async
   assertEquals(response.status, 401);
 });
 
-Deno.test("init handler: rejects caller-supplied state instead of weakening CSRF entropy", () => {
+it("init handler: rejects caller-supplied state instead of weakening CSRF entropy", () => {
   assertThrows(
     () =>
       createOAuthInitHandler(TEST_CONFIG, {
@@ -670,7 +671,7 @@ Deno.test("init handler: rejects caller-supplied state instead of weakening CSRF
   );
 });
 
-Deno.test("init handler rejects malformed or handler-owned authorization options eagerly", () => {
+it("init handler rejects malformed or handler-owned authorization options eagerly", () => {
   for (
     const [authOptions, expectedMessage] of [
       [{ redirectUri: "https://other.test/callback" }, "redirectUri"],
@@ -692,7 +693,7 @@ Deno.test("init handler rejects malformed or handler-owned authorization options
   }
 });
 
-Deno.test("init handler: requires PKCE instead of permitting a handler-level downgrade", () => {
+it("init handler: requires PKCE instead of permitting a handler-level downgrade", () => {
   assertThrows(
     () =>
       createOAuthInitHandler(TEST_CONFIG, {
@@ -706,7 +707,7 @@ Deno.test("init handler: requires PKCE instead of permitting a handler-level dow
   );
 });
 
-Deno.test("init handler omits PKCE only for providers declaring it unsupported", async () => {
+it("init handler omits PKCE only for providers declaring it unsupported", async () => {
   const store = new MemoryTokenStore();
   const config = { ...TEST_CONFIG, pkceMode: "unsupported" as const };
   const handler = createOAuthInitHandler(config, {
@@ -724,7 +725,7 @@ Deno.test("init handler omits PKCE only for providers declaring it unsupported",
   assertEquals(state?.codeVerifier, undefined);
 });
 
-Deno.test("init handler: snapshots authorization options at construction", async () => {
+it("init handler: snapshots authorization options at construction", async () => {
   const authOptions = {
     scopes: ["read"],
     additionalParams: { audience: "original" },
@@ -748,7 +749,7 @@ Deno.test("init handler: snapshots authorization options at construction", async
   assertEquals(location.searchParams.get("state") === "attacker-controlled", false);
 });
 
-Deno.test("init handler rejects accessor-backed auth options without invoking them", () => {
+it("init handler rejects accessor-backed auth options without invoking them", () => {
   let getterCalls = 0;
   const authOptions = Object.defineProperty({}, "additionalParams", {
     enumerable: true,
@@ -773,7 +774,7 @@ Deno.test("init handler rejects accessor-backed auth options without invoking th
   assertEquals(getterCalls, 0);
 });
 
-Deno.test("init handler: rejects invalid application base URLs eagerly", () => {
+it("init handler: rejects invalid application base URLs eagerly", () => {
   for (
     const baseUrl of [
       "javascript:alert(1)",
@@ -798,7 +799,7 @@ Deno.test("init handler: rejects invalid application base URLs eagerly", () => {
   }
 });
 
-Deno.test("init handler: authentication resolver failures return a generic 500", async () => {
+it("init handler: authentication resolver failures return a generic 500", async () => {
   const handler = createOAuthInitHandler(TEST_CONFIG, {
     env: makeEnv(),
     envReader: (key) => ENV[key],
@@ -812,7 +813,7 @@ Deno.test("init handler: authentication resolver failures return a generic 500",
   assertEquals(await response.json(), { error: "Failed to initiate OAuth flow" });
 });
 
-Deno.test("init handler: authorization redirects prevent caching and referrer leakage", async () => {
+it("init handler: authorization redirects prevent caching and referrer leakage", async () => {
   const handler = createOAuthInitHandler(TEST_CONFIG, {
     tokenStore: new MemoryTokenStore(),
     env: makeEnv(),
@@ -825,7 +826,7 @@ Deno.test("init handler: authorization redirects prevent caching and referrer le
   assertEquals(response.headers.get("referrer-policy"), "no-referrer");
 });
 
-Deno.test("status handler: token-store failures are sanitized and non-cacheable", async () => {
+it("status handler: token-store failures are sanitized and non-cacheable", async () => {
   const tokenStore = createFailingStateStore("unused");
   tokenStore.getTokens = () => Promise.reject(new Error("private database detail"));
   const handler = createOAuthStatusHandler(TEST_CONFIG, {
@@ -840,7 +841,7 @@ Deno.test("status handler: token-store failures are sanitized and non-cacheable"
   assertEquals(response.headers.get("cache-control"), "no-store");
 });
 
-Deno.test("status handler: malformed token-store rows fail closed", async () => {
+it("status handler: malformed token-store rows fail closed", async () => {
   const tokenStore = createFailingStateStore("unused");
   tokenStore.getTokens = () => Promise.resolve({ accessToken: "   " });
   const handler = createOAuthStatusHandler(TEST_CONFIG, {
@@ -854,7 +855,7 @@ Deno.test("status handler: malformed token-store rows fail closed", async () => 
   assertEquals(await response.json(), { error: "Failed to read OAuth status" });
 });
 
-Deno.test("disconnect handler: token-store failures do not report success", async () => {
+it("disconnect handler: token-store failures do not report success", async () => {
   const tokenStore = createFailingStateStore("unused");
   tokenStore.clearTokens = () => Promise.reject(new Error("private database detail"));
   const handler = createOAuthDisconnectHandler(TEST_CONFIG, {
@@ -869,7 +870,7 @@ Deno.test("disconnect handler: token-store failures do not report success", asyn
   assertEquals(response.headers.get("cache-control"), "no-store");
 });
 
-Deno.test("OAuth handlers require an explicit shared store outside development/test", () => {
+it("OAuth handlers require an explicit shared store outside development/test", () => {
   const env = makeDeploymentEnv("production");
   assertThrows(
     () =>
@@ -902,7 +903,7 @@ Deno.test("OAuth handlers require an explicit shared store outside development/t
   );
 });
 
-Deno.test("OAuth application URLs require HTTPS outside explicit local environments", () => {
+it("OAuth application URLs require HTTPS outside explicit local environments", () => {
   for (const nodeEnv of ["production", "staging", "preview", "custom"]) {
     assertThrows(
       () =>
@@ -929,7 +930,7 @@ Deno.test("OAuth application URLs require HTTPS outside explicit local environme
   );
 });
 
-Deno.test("status handler uses provider credential normalization", async () => {
+it("status handler uses provider credential normalization", async () => {
   const handler = createOAuthStatusHandler(TEST_CONFIG, {
     tokenStore: new MemoryTokenStore(),
     envReader: () => "   ",
@@ -940,7 +941,7 @@ Deno.test("status handler uses provider credential normalization", async () => {
   assertEquals((await response.json()).configured, false);
 });
 
-Deno.test("handler factories snapshot mutable provider configuration", async () => {
+it("handler factories snapshot mutable provider configuration", async () => {
   const config: OAuthServiceConfig = {
     ...TEST_CONFIG,
     defaultScopes: [...TEST_CONFIG.defaultScopes],

--- a/src/oauth/handlers/init-handler.test.ts
+++ b/src/oauth/handlers/init-handler.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertThrows } from "#std/assert";
+import { assertEquals, assertMatch, assertThrows } from "#std/assert";
 import type { EnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import { getEnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import {
@@ -234,6 +234,13 @@ Deno.test("init handler: stores state with userId and redirects to the provider"
   assertEquals(location.searchParams.get("scope"), "read");
   assertEquals(location.searchParams.get("code_challenge_method"), "S256");
 
+  const codeChallenge = location.searchParams.get("code_challenge");
+  assertMatch(
+    codeChallenge ?? "",
+    /^[A-Za-z0-9_-]{43}$/,
+    "an S256 authorization redirect must carry a 43-char base64url code_challenge",
+  );
+
   const state = location.searchParams.get("state");
   if (!state) {
     throw new Error("expected redirect state parameter to be present");
@@ -245,6 +252,25 @@ Deno.test("init handler: stores state with userId and redirects to the provider"
   assertEquals(storedState?.serviceId, "test-provider");
   assertEquals(storedState?.redirectUri, `${appUrl}/api/auth/test-provider/callback`);
   assertEquals(storedState?.scopes, ["read"]);
+
+  assertMatch(
+    storedState?.codeVerifier ?? "",
+    /^[A-Za-z0-9._~-]{43,128}$/,
+    "the persisted PKCE verifier must be a canonical code verifier",
+  );
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(storedState?.codeVerifier ?? ""),
+  );
+  const expectedChallenge = btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  assertEquals(
+    codeChallenge,
+    expectedChallenge,
+    "the redirect code_challenge must be S256 of the persisted code verifier",
+  );
 });
 
 Deno.test("init handler binds provider state to an explicit shared callback route", async () => {

--- a/src/oauth/providers/atlassian.test.ts
+++ b/src/oauth/providers/atlassian.test.ts
@@ -21,24 +21,33 @@ describe("Atlassian OAuth provider configs", () => {
   });
 
   it("keeps each scaffold on its generated product callback", async () => {
-    for (const serviceId of ["jira", "confluence"]) {
+    for (const config of [jiraConfig, confluenceConfig]) {
       const connector = JSON.parse(
         await Deno.readTextFile(
-          `templates/integrations/${serviceId}/connector.json`,
+          `templates/integrations/${config.serviceId}/connector.json`,
         ),
       ) as {
         auth: {
           callbackPath?: string;
           tokenAuthMethod?: string;
-          additionalParams?: Record<string, string>;
+          additionalAuthParams?: Record<string, string>;
         };
       };
       assertEquals(
         connector.auth.callbackPath,
-        `/api/auth/${serviceId}/callback`,
+        `/api/auth/${config.serviceId}/callback`,
+        `${config.serviceId} scaffold must use its generated product callback`,
       );
-      assertEquals(connector.auth.tokenAuthMethod, "body");
-      assertEquals(connector.auth.additionalParams, undefined);
+      assertEquals(
+        connector.auth.tokenAuthMethod,
+        "body",
+        `${config.serviceId} scaffold must post its client credentials in the body`,
+      );
+      assertEquals(
+        connector.auth.additionalAuthParams,
+        config.additionalAuthParams,
+        `${config.serviceId} scaffold must carry the runtime additional auth params`,
+      );
     }
   });
 

--- a/src/oauth/providers/base.test.ts
+++ b/src/oauth/providers/base.test.ts
@@ -1,7 +1,13 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { it } from "#veryfront/testing/bdd.ts";
 import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
-import { assert, assertEquals, assertNotEquals, assertRejects, assertThrows } from "#std/assert";
+import {
+  assert,
+  assertEquals,
+  assertNotEquals,
+  assertRejects,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { OAuthProvider, OAuthService } from "./base.ts";
 import type {
   AuthorizationUrlOptions,

--- a/src/oauth/providers/base.test.ts
+++ b/src/oauth/providers/base.test.ts
@@ -8,6 +8,7 @@ import type {
   OAuthTokens,
   StoredOAuthState,
   TokenExchangeOptions,
+  TokenExchangeResult,
   TokenStore,
 } from "../types.ts";
 import { MemoryTokenStore } from "../token-store/memory.ts";
@@ -24,6 +25,9 @@ const TEST_CONFIG: OAuthServiceConfig = {
   defaultScopes: ["read"],
   apiBaseUrl: "https://93.184.216.34",
 };
+
+/** Public IP literal so redirect hops never need DNS resolution. */
+const REDIRECT_TARGET_ORIGIN = "https://93.184.216.35";
 
 const ENV: Record<string, string> = {
   TEST_CLIENT_ID: "test-id",
@@ -1295,20 +1299,60 @@ Deno.test("OAuthProvider rejects cross-origin HTTP redirects for secret-bearing 
     (key) => ENV[key],
   );
   const redirects: Array<RequestRedirect | undefined> = [];
+  let fetchCalls = 0;
   installMockFetch(
-    ((_input: string | URL | Request, init?: RequestInit) => {
+    ((input: string | URL | Request, init?: RequestInit) => {
+      fetchCalls++;
       redirects.push(init?.redirect);
-      return Promise.resolve(Response.json({ access_token: "token" }));
+      const url = String(input instanceof Request ? input.url : input);
+      // Anything reached past the first hop is the redirect target, and it
+      // answers with a usable token so a followed hop would look successful.
+      if (url.startsWith(REDIRECT_TARGET_ORIGIN)) {
+        return Promise.resolve(Response.json({ access_token: "followed-token" }));
+      }
+      return Promise.resolve(
+        new Response(null, {
+          status: 302,
+          headers: { location: `${REDIRECT_TARGET_ORIGIN}/steal` },
+        }),
+      );
     }) as typeof fetch,
   );
 
+  let exchange: TokenExchangeResult;
+  let revoked: boolean;
   try {
-    await provider.exchangeCode({ code: "code", redirectUri: "https://app.test/callback" });
-    await provider.revokeToken("token");
+    exchange = await provider.exchangeCode({
+      code: "code",
+      redirectUri: "https://app.test/callback",
+    });
+    const callsAfterExchange = fetchCalls;
+    revoked = await provider.revokeToken("token");
+    assertEquals(
+      callsAfterExchange,
+      1,
+      "a 302 from the token endpoint must not be followed to a second host",
+    );
+    assertEquals(
+      fetchCalls,
+      2,
+      "a 302 from the revocation endpoint must not be followed to a second host",
+    );
   } finally {
     restoreMockFetch();
   }
 
+  assertEquals(
+    exchange.success,
+    false,
+    "a redirected token exchange must not report success",
+  );
+  assertEquals(
+    exchange.error,
+    "network_error",
+    "a redirected token exchange must fail as a network error",
+  );
+  assertEquals(revoked, false, "a redirected revocation must not report success");
   assertEquals(redirects, ["manual", "manual"]);
 });
 
@@ -1455,15 +1499,32 @@ Deno.test("OAuthProvider revocation logging does not coerce hostile thrown value
 Deno.test("OAuthService.fetch cannot be configured to follow redirects", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (key) => ENV[key]);
   let redirect: RequestRedirect | undefined;
+  let fetchCalls = 0;
   installMockFetch(
-    ((_input: string | URL | Request, init?: RequestInit) => {
+    ((input: string | URL | Request, init?: RequestInit) => {
+      fetchCalls++;
       redirect = init?.redirect;
-      return Promise.resolve(Response.json({ ok: true }));
+      const url = String(input instanceof Request ? input.url : input);
+      if (url.startsWith(REDIRECT_TARGET_ORIGIN)) {
+        return Promise.resolve(Response.json({ ok: true }));
+      }
+      return Promise.resolve(
+        new Response(null, {
+          status: 302,
+          headers: { location: `${REDIRECT_TARGET_ORIGIN}/attacker` },
+        }),
+      );
     }) as typeof fetch,
   );
 
   try {
-    await service.fetch("alice", "/me", { redirect: "follow" });
+    await assertRejects(
+      () => service.fetch("alice", "/me", { redirect: "follow" }),
+      Error,
+      "API request failed",
+      "a provider redirect must be refused even when the caller asks to follow",
+    );
+    assertEquals(fetchCalls, 1, "the redirect target must never be fetched");
   } finally {
     restoreMockFetch();
   }
@@ -1676,6 +1737,76 @@ Deno.test(
     try {
       await assertRejects(() => service.getAccessToken("alice"), Error, "atomic token refresh");
       assertEquals(fetchCalls, 0);
+    } finally {
+      restoreMockFetch();
+    }
+  },
+);
+
+Deno.test(
+  "OAuthService.getAccessToken proactively refreshes inside the expiry buffer",
+  async () => {
+    const store = new MemoryTokenStore();
+    await store.setTokens(TEST_CONFIG.serviceId, "alice", {
+      accessToken: "near-expiry",
+      refreshToken: "refresh",
+      expiresAt: Date.now() + 60_000,
+    });
+    const service = new OAuthService(TEST_CONFIG, store, (key) => ENV[key]);
+    let tokenEndpointCalls = 0;
+    installMockFetch(
+      ((): Promise<Response> => {
+        tokenEndpointCalls++;
+        return Promise.resolve(Response.json({ access_token: "refreshed", expires_in: 3_600 }));
+      }) as typeof fetch,
+    );
+
+    try {
+      assertEquals(
+        await service.getAccessToken("alice"),
+        "refreshed",
+        "a token expiring inside the 5-minute buffer must be refreshed proactively",
+      );
+      assertEquals(
+        tokenEndpointCalls,
+        1,
+        "proactive refresh must hit the token endpoint exactly once",
+      );
+    } finally {
+      restoreMockFetch();
+    }
+  },
+);
+
+Deno.test(
+  "OAuthService.getAccessToken keeps a token that expires past the refresh buffer",
+  async () => {
+    const store = new MemoryTokenStore();
+    await store.setTokens(TEST_CONFIG.serviceId, "alice", {
+      accessToken: "long-lived",
+      refreshToken: "refresh",
+      expiresAt: Date.now() + 3_600_000,
+    });
+    const service = new OAuthService(TEST_CONFIG, store, (key) => ENV[key]);
+    let tokenEndpointCalls = 0;
+    installMockFetch(
+      ((): Promise<Response> => {
+        tokenEndpointCalls++;
+        return Promise.resolve(Response.json({ access_token: "refreshed", expires_in: 3_600 }));
+      }) as typeof fetch,
+    );
+
+    try {
+      assertEquals(
+        await service.getAccessToken("alice"),
+        "long-lived",
+        "a token expiring past the 5-minute buffer must be returned unchanged",
+      );
+      assertEquals(
+        tokenEndpointCalls,
+        0,
+        "a token outside the refresh buffer must not hit the token endpoint",
+      );
     } finally {
       restoreMockFetch();
     }

--- a/src/oauth/providers/base.test.ts
+++ b/src/oauth/providers/base.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { it } from "#veryfront/testing/bdd.ts";
 import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { assert, assertEquals, assertNotEquals, assertRejects, assertThrows } from "#std/assert";
 import { OAuthProvider, OAuthService } from "./base.ts";
@@ -94,7 +95,7 @@ async function withStubbedFetch(
   }
 }
 
-Deno.test("OAuthService.fetch: relative endpoint resolves against apiBaseUrl", async () => {
+it("OAuthService.fetch: relative endpoint resolves against apiBaseUrl", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);
   const captured: string[] = [];
 
@@ -106,7 +107,7 @@ Deno.test("OAuthService.fetch: relative endpoint resolves against apiBaseUrl", a
   assertEquals(captured, ["https://93.184.216.34/v1/me"]);
 });
 
-Deno.test("OAuthService.fetch: joins relative endpoints without requiring a leading slash", async () => {
+it("OAuthService.fetch: joins relative endpoints without requiring a leading slash", async () => {
   const service = new OAuthService(
     { ...TEST_CONFIG, apiBaseUrl: "https://93.184.216.34/v1" },
     makeAuthedTokenStore(),
@@ -121,7 +122,7 @@ Deno.test("OAuthService.fetch: joins relative endpoints without requiring a lead
   assertEquals(captured, ["https://93.184.216.34/v1/me"]);
 });
 
-Deno.test("OAuthService.fetch: preserves Headers instances and caller content types", async () => {
+it("OAuthService.fetch: preserves Headers instances and caller content types", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);
   let capturedHeaders: Headers | undefined;
   installMockFetch(
@@ -152,7 +153,7 @@ Deno.test("OAuthService.fetch: preserves Headers instances and caller content ty
   assertEquals(capturedHeaders?.get("x-request-id"), "request-1");
 });
 
-Deno.test("OAuthService.fetch does not invent a content type for caller-owned bodies", async () => {
+it("OAuthService.fetch does not invent a content type for caller-owned bodies", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (key) => ENV[key]);
   let capturedHeaders: Headers | undefined;
   installMockFetch(
@@ -175,7 +176,7 @@ Deno.test("OAuthService.fetch does not invent a content type for caller-owned bo
   assertEquals(capturedHeaders?.has("content-type"), false);
 });
 
-Deno.test("OAuthService.fetch applies provider API headers and owns Authorization", async () => {
+it("OAuthService.fetch applies provider API headers and owns Authorization", async () => {
   const config = {
     ...TEST_CONFIG,
     apiHeaders: { "X-Provider-Version": "2026-01-01" },
@@ -202,7 +203,7 @@ Deno.test("OAuthService.fetch applies provider API headers and owns Authorizatio
   assertEquals(capturedHeaders?.get("x-request-id"), "request-1");
 });
 
-Deno.test("OAuthService.fetch bounds successful JSON responses and accepts the exact limit", async () => {
+it("OAuthService.fetch bounds successful JSON responses and accepts the exact limit", async () => {
   const exactJson = '{"ok":1}';
   const config = {
     ...TEST_CONFIG,
@@ -225,7 +226,7 @@ Deno.test("OAuthService.fetch bounds successful JSON responses and accepts the e
   }
 });
 
-Deno.test("OAuthService.fetch rejects malformed UTF-8 response bodies", async () => {
+it("OAuthService.fetch rejects malformed UTF-8 response bodies", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (key) => ENV[key]);
   installMockFetch(
     (() =>
@@ -244,7 +245,7 @@ Deno.test("OAuthService.fetch rejects malformed UTF-8 response bodies", async ()
   }
 });
 
-Deno.test("OAuthService.fetch snapshots RequestInit before asynchronous token lookup", async () => {
+it("OAuthService.fetch snapshots RequestInit before asynchronous token lookup", async () => {
   let releaseTokenRead!: () => void;
   const tokenGate = new Promise<void>((resolve) => {
     releaseTokenRead = resolve;
@@ -281,7 +282,7 @@ Deno.test("OAuthService.fetch snapshots RequestInit before asynchronous token lo
   }
 });
 
-Deno.test("OAuthService.fetch supports successful no-content responses", async () => {
+it("OAuthService.fetch supports successful no-content responses", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (key) => ENV[key]);
   installMockFetch((() => Promise.resolve(new Response(null, { status: 204 }))) as typeof fetch);
 
@@ -295,7 +296,7 @@ Deno.test("OAuthService.fetch supports successful no-content responses", async (
   }
 });
 
-Deno.test("OAuthService.fetch bounds token lookup and non-cooperative API fetches", async () => {
+it("OAuthService.fetch bounds token lookup and non-cooperative API fetches", async () => {
   const stalledStore = makeAuthedTokenStore();
   stalledStore.getTokens = () => new Promise<OAuthTokens | null>(() => {});
   const stalledLookupService = new OAuthService(
@@ -326,7 +327,7 @@ Deno.test("OAuthService.fetch bounds token lookup and non-cooperative API fetche
   }
 });
 
-Deno.test("OAuthService.fetch preserves caller cancellation during provider fetch", async () => {
+it("OAuthService.fetch preserves caller cancellation during provider fetch", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (key) => ENV[key]);
   let markFetchStarted!: () => void;
   const fetchStarted = new Promise<void>((resolve) => {
@@ -358,7 +359,7 @@ Deno.test("OAuthService.fetch preserves caller cancellation during provider fetc
   }
 });
 
-Deno.test("OAuthService.fetch preserves caller cancellation during provider body read", async () => {
+it("OAuthService.fetch preserves caller cancellation during provider body read", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (key) => ENV[key]);
   let markBodyReadStarted!: () => void;
   const bodyReadStarted = new Promise<void>((resolve) => {
@@ -392,7 +393,7 @@ Deno.test("OAuthService.fetch preserves caller cancellation during provider body
   }
 });
 
-Deno.test("OAuthService.fetch timeout cancels a stalled API body", async () => {
+it("OAuthService.fetch timeout cancels a stalled API body", async () => {
   const service = new OAuthService(
     { ...TEST_CONFIG, requestTimeoutMs: 5 },
     makeAuthedTokenStore(),
@@ -425,7 +426,7 @@ Deno.test("OAuthService.fetch timeout cancels a stalled API body", async () => {
   }
 });
 
-Deno.test("OAuthProvider preserves existing authorization endpoint query parameters", async () => {
+it("OAuthProvider preserves existing authorization endpoint query parameters", async () => {
   const provider = new OAuthProvider(
     { ...TEST_CONFIG, authorizationUrl: "https://93.184.216.34/auth?audience=existing" },
     (key) => ENV[key],
@@ -442,7 +443,7 @@ Deno.test("OAuthProvider preserves existing authorization endpoint query paramet
   assertEquals(url.searchParams.get("state"), result.state.state);
 });
 
-Deno.test("OAuthProvider rejects reserved authorization parameter overrides", async () => {
+it("OAuthProvider rejects reserved authorization parameter overrides", async () => {
   const provider = new OAuthProvider(TEST_CONFIG, (key) => ENV[key]);
 
   await assertRejects(
@@ -459,7 +460,7 @@ Deno.test("OAuthProvider rejects reserved authorization parameter overrides", as
   );
 });
 
-Deno.test("OAuthProvider enforces explicit PKCE capability modes", async () => {
+it("OAuthProvider enforces explicit PKCE capability modes", async () => {
   const unsupportedConfig = { ...TEST_CONFIG, pkceMode: "unsupported" as const };
   const unsupported = new OAuthProvider(unsupportedConfig, (key) => ENV[key]);
   const noPkce = await unsupported.createAuthorizationUrl({
@@ -522,7 +523,7 @@ Deno.test("OAuthProvider enforces explicit PKCE capability modes", async () => {
   }
 });
 
-Deno.test("OAuthProvider rejects reserved config-level parameter overrides eagerly", () => {
+it("OAuthProvider rejects reserved config-level parameter overrides eagerly", () => {
   for (const key of ["client_id", "CLIENT_ID"]) {
     assertThrows(
       () =>
@@ -554,7 +555,7 @@ Deno.test("OAuthProvider rejects reserved config-level parameter overrides eager
   }
 });
 
-Deno.test("OAuthProvider bounds configuration-controlled wire fields", () => {
+it("OAuthProvider bounds configuration-controlled wire fields", () => {
   for (
     const config of [
       { ...TEST_CONFIG, providerId: "provider id" },
@@ -576,7 +577,7 @@ Deno.test("OAuthProvider bounds configuration-controlled wire fields", () => {
   }
 });
 
-Deno.test("OAuthProvider snapshots authorization parameters before asynchronous PKCE work", async () => {
+it("OAuthProvider snapshots authorization parameters before asynchronous PKCE work", async () => {
   const provider = new OAuthProvider(TEST_CONFIG, (key) => ENV[key]);
   const additionalParams: Record<string, string> = { audience: "original" };
 
@@ -592,7 +593,7 @@ Deno.test("OAuthProvider snapshots authorization parameters before asynchronous 
   assertNotEquals(url.searchParams.get("state"), "attacker-controlled");
 });
 
-Deno.test("OAuthProvider snapshots nested configuration values", async () => {
+it("OAuthProvider snapshots nested configuration values", async () => {
   const defaultScopes = ["read"];
   const additionalAuthParams = { audience: "original" };
   const config: OAuthServiceConfig = {
@@ -612,7 +613,7 @@ Deno.test("OAuthProvider snapshots nested configuration values", async () => {
   assertEquals(url.searchParams.get("audience"), "original");
 });
 
-Deno.test("OAuthProvider rejects accessor-backed configuration without invoking it", () => {
+it("OAuthProvider rejects accessor-backed configuration without invoking it", () => {
   for (const nested of [false, true]) {
     let getterCalls = 0;
     const config = { ...TEST_CONFIG } as OAuthServiceConfig;
@@ -642,7 +643,7 @@ Deno.test("OAuthProvider rejects accessor-backed configuration without invoking 
   }
 });
 
-Deno.test("OAuthService rejects accessor-backed authorization options without invoking them", async () => {
+it("OAuthService rejects accessor-backed authorization options without invoking them", async () => {
   const service = new OAuthService(TEST_CONFIG, undefined, (key) => ENV[key]);
   let getterCalls = 0;
   const options = Object.defineProperty({}, "redirectUri", {
@@ -661,7 +662,7 @@ Deno.test("OAuthService rejects accessor-backed authorization options without in
   assertEquals(getterCalls, 0);
 });
 
-Deno.test("OAuthService.fetch: absolute endpoint matching apiBaseUrl origin is allowed", async () => {
+it("OAuthService.fetch: absolute endpoint matching apiBaseUrl origin is allowed", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);
   const captured: string[] = [];
   const sameOrigin = "https://93.184.216.34/v1/me";
@@ -674,7 +675,7 @@ Deno.test("OAuthService.fetch: absolute endpoint matching apiBaseUrl origin is a
   assertEquals(captured, [sameOrigin]);
 });
 
-Deno.test("OAuthService.fetch: absolute endpoint on different origin is rejected before fetch", async () => {
+it("OAuthService.fetch: absolute endpoint on different origin is rejected before fetch", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);
   const captured: string[] = [];
   // Classic cloud-metadata SSRF target.
@@ -692,7 +693,7 @@ Deno.test("OAuthService.fetch: absolute endpoint on different origin is rejected
   assertEquals(captured, []);
 });
 
-Deno.test("OAuthService.fetch validates endpoints before reading token storage", async () => {
+it("OAuthService.fetch validates endpoints before reading token storage", async () => {
   const store = makeAuthedTokenStore();
   let tokenReads = 0;
   store.getTokens = () => {
@@ -709,7 +710,7 @@ Deno.test("OAuthService.fetch validates endpoints before reading token storage",
   assertEquals(tokenReads, 0);
 });
 
-Deno.test("OAuthService.fetch: rejects endpoint credentials and fragments before fetch", async () => {
+it("OAuthService.fetch: rejects endpoint credentials and fragments before fetch", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (key) => ENV[key]);
   const captured: string[] = [];
 
@@ -731,7 +732,7 @@ Deno.test("OAuthService.fetch: rejects endpoint credentials and fragments before
   assertEquals(captured, []);
 });
 
-Deno.test("OAuthService.fetch rejects parser-normalized endpoint text", async () => {
+it("OAuthService.fetch rejects parser-normalized endpoint text", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (key) => ENV[key]);
   for (
     const endpoint of [
@@ -774,7 +775,7 @@ async function withErrorFetch(
   }
 }
 
-Deno.test(
+it(
   "OAuthService.fetch: provider error body is not leaked into thrown error (SEC-010)",
   async () => {
     const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);
@@ -825,7 +826,7 @@ async function withTokenFetch(
   }
 }
 
-Deno.test("OAuthProvider uses form-encoded UTF-8 credentials for HTTP Basic auth", async () => {
+it("OAuthProvider uses form-encoded UTF-8 credentials for HTTP Basic auth", async () => {
   const provider = new OAuthProvider(
     { ...TEST_CONFIG, useBasicAuth: true },
     (key) => key === TEST_CONFIG.clientIdEnvVar ? "user: ä" : "s%écret",
@@ -858,7 +859,7 @@ Deno.test("OAuthProvider uses form-encoded UTF-8 credentials for HTTP Basic auth
   }
 });
 
-Deno.test("OAuthProvider supports JSON token bodies and required static headers", async () => {
+it("OAuthProvider supports JSON token bodies and required static headers", async () => {
   const config = {
     ...TEST_CONFIG,
     useBasicAuth: true,
@@ -894,7 +895,7 @@ Deno.test("OAuthProvider supports JSON token bodies and required static headers"
   }
 });
 
-Deno.test("OAuthProvider rejects malformed runtime config instead of silently changing protocol", () => {
+it("OAuthProvider rejects malformed runtime config instead of silently changing protocol", () => {
   for (
     const [field, value, expectedMessage] of [
       ["tokenRequestFormat", "xml", "tokenRequestFormat"],
@@ -938,7 +939,7 @@ Deno.test("OAuthProvider rejects malformed runtime config instead of silently ch
   }
 });
 
-Deno.test("OAuthProvider rejects malformed authorization options without coercion", async () => {
+it("OAuthProvider rejects malformed authorization options without coercion", async () => {
   const provider = new OAuthProvider(TEST_CONFIG, (key) => ENV[key]);
   const redirectUri = "https://app.test/callback";
 
@@ -958,7 +959,7 @@ Deno.test("OAuthProvider rejects malformed authorization options without coercio
   }
 });
 
-Deno.test("OAuthProvider treats malformed credential reader values as unconfigured", () => {
+it("OAuthProvider treats malformed credential reader values as unconfigured", () => {
   const provider = new OAuthProvider(
     TEST_CONFIG,
     (() => 42) as unknown as (key: string) => string | undefined,
@@ -969,7 +970,7 @@ Deno.test("OAuthProvider treats malformed credential reader values as unconfigur
   assertEquals(provider.isConfigured(), false);
 });
 
-Deno.test("OAuthProvider rejects static headers that override transport ownership", () => {
+it("OAuthProvider rejects static headers that override transport ownership", () => {
   for (const field of ["tokenRequestHeaders", "apiHeaders"] as const) {
     assertThrows(
       () =>
@@ -983,7 +984,7 @@ Deno.test("OAuthProvider rejects static headers that override transport ownershi
   }
 });
 
-Deno.test("OAuthProvider rejects token responses larger than its configured bound", async () => {
+it("OAuthProvider rejects token responses larger than its configured bound", async () => {
   const provider = new OAuthProvider(
     { ...TEST_CONFIG, maxTokenResponseBytes: 32 },
     (key) => ENV[key],
@@ -1004,7 +1005,7 @@ Deno.test("OAuthProvider rejects token responses larger than its configured boun
   }
 });
 
-Deno.test("OAuthProvider accepts a valid token response exactly at its configured bound", async () => {
+it("OAuthProvider accepts a valid token response exactly at its configured bound", async () => {
   const body = JSON.stringify({ access_token: "token" });
   const provider = new OAuthProvider(
     { ...TEST_CONFIG, maxTokenResponseBytes: new TextEncoder().encode(body).byteLength },
@@ -1024,7 +1025,7 @@ Deno.test("OAuthProvider accepts a valid token response exactly at its configure
   }
 });
 
-Deno.test("OAuthProvider rejects malformed UTF-8 token responses", async () => {
+it("OAuthProvider rejects malformed UTF-8 token responses", async () => {
   const provider = new OAuthProvider(TEST_CONFIG, (key) => ENV[key]);
   installMockFetch(
     (() =>
@@ -1069,7 +1070,7 @@ Deno.test("OAuthProvider rejects malformed UTF-8 token responses", async () => {
   }
 });
 
-Deno.test("OAuthProvider aborts token requests at the configured timeout", async () => {
+it("OAuthProvider aborts token requests at the configured timeout", async () => {
   const provider = new OAuthProvider(
     { ...TEST_CONFIG, requestTimeoutMs: 5 },
     (key) => ENV[key],
@@ -1101,7 +1102,7 @@ Deno.test("OAuthProvider aborts token requests at the configured timeout", async
   }
 });
 
-Deno.test("OAuthProvider timeout wins when fetch ignores AbortSignal", async () => {
+it("OAuthProvider timeout wins when fetch ignores AbortSignal", async () => {
   const provider = new OAuthProvider(
     { ...TEST_CONFIG, requestTimeoutMs: 5 },
     (key) => ENV[key],
@@ -1121,7 +1122,7 @@ Deno.test("OAuthProvider timeout wins when fetch ignores AbortSignal", async () 
   }
 });
 
-Deno.test("OAuthProvider timeout bounds stalled bodies and cancels late responses", async () => {
+it("OAuthProvider timeout bounds stalled bodies and cancels late responses", async () => {
   const provider = new OAuthProvider(
     { ...TEST_CONFIG, requestTimeoutMs: 5 },
     (key) => ENV[key],
@@ -1154,7 +1155,7 @@ Deno.test("OAuthProvider timeout bounds stalled bodies and cancels late response
   }
 });
 
-Deno.test("OAuthProvider cancels a response that arrives after strict timeout", async () => {
+it("OAuthProvider cancels a response that arrives after strict timeout", async () => {
   const provider = new OAuthProvider(
     { ...TEST_CONFIG, requestTimeoutMs: 5 },
     (key) => ENV[key],
@@ -1191,7 +1192,7 @@ Deno.test("OAuthProvider cancels a response that arrives after strict timeout", 
   }
 });
 
-Deno.test("OAuthProvider validates security-sensitive token request inputs", async () => {
+it("OAuthProvider validates security-sensitive token request inputs", async () => {
   const provider = new OAuthProvider(TEST_CONFIG, (key) => ENV[key]);
 
   await assertRejects(
@@ -1212,7 +1213,7 @@ Deno.test("OAuthProvider validates security-sensitive token request inputs", asy
   await assertRejects(() => provider.refreshTokens(" "), Error, "refresh token");
 });
 
-Deno.test("OAuthProvider rejects accessor-backed token options without invoking them", async () => {
+it("OAuthProvider rejects accessor-backed token options without invoking them", async () => {
   const provider = new OAuthProvider(TEST_CONFIG, (key) => ENV[key]);
   let getterCalls = 0;
   const options = Object.defineProperty(
@@ -1237,7 +1238,7 @@ Deno.test("OAuthProvider rejects accessor-backed token options without invoking 
   assertEquals(getterCalls, 0);
 });
 
-Deno.test("OAuthProvider requires HTTPS provider endpoints", () => {
+it("OAuthProvider requires HTTPS provider endpoints", () => {
   for (const field of ["authorizationUrl", "tokenUrl", "apiBaseUrl"] as const) {
     assertThrows(
       () =>
@@ -1252,7 +1253,7 @@ Deno.test("OAuthProvider requires HTTPS provider endpoints", () => {
   }
 });
 
-Deno.test("OAuthProvider blocks an internal token endpoint before credentials leave the process", async () => {
+it("OAuthProvider blocks an internal token endpoint before credentials leave the process", async () => {
   const provider = new OAuthProvider(
     { ...TEST_CONFIG, tokenUrl: "https://169.254.169.254/token" },
     (key) => ENV[key],
@@ -1278,7 +1279,7 @@ Deno.test("OAuthProvider blocks an internal token endpoint before credentials le
   }
 });
 
-Deno.test("OAuthProvider rejects reserved token endpoint query parameters", () => {
+it("OAuthProvider rejects reserved token endpoint query parameters", () => {
   assertThrows(
     () =>
       new OAuthProvider(
@@ -1293,7 +1294,7 @@ Deno.test("OAuthProvider rejects reserved token endpoint query parameters", () =
   );
 });
 
-Deno.test("OAuthProvider rejects cross-origin HTTP redirects for secret-bearing requests", async () => {
+it("OAuthProvider rejects cross-origin HTTP redirects for secret-bearing requests", async () => {
   const provider = new OAuthProvider(
     { ...TEST_CONFIG, revocationUrl: "https://93.184.216.34/revoke" },
     (key) => ENV[key],
@@ -1356,7 +1357,7 @@ Deno.test("OAuthProvider rejects cross-origin HTTP redirects for secret-bearing 
   assertEquals(redirects, ["manual", "manual"]);
 });
 
-Deno.test("OAuthProvider bounds revocation tokens before fetch and releases response bodies", async () => {
+it("OAuthProvider bounds revocation tokens before fetch and releases response bodies", async () => {
   const provider = new OAuthProvider(
     { ...TEST_CONFIG, revocationUrl: "https://93.184.216.34/revoke" },
     (key) => ENV[key],
@@ -1394,7 +1395,7 @@ Deno.test("OAuthProvider bounds revocation tokens before fetch and releases resp
   }
 });
 
-Deno.test("OAuthProvider authenticates revocation with client credentials in the body", async () => {
+it("OAuthProvider authenticates revocation with client credentials in the body", async () => {
   const provider = new OAuthProvider(
     { ...TEST_CONFIG, revocationUrl: "https://93.184.216.34/revoke" },
     (key) => ENV[key],
@@ -1422,7 +1423,7 @@ Deno.test("OAuthProvider authenticates revocation with client credentials in the
   assertEquals(headers.get("Authorization"), null);
 });
 
-Deno.test("OAuthProvider authenticates revocation with Basic auth when configured", async () => {
+it("OAuthProvider authenticates revocation with Basic auth when configured", async () => {
   const provider = new OAuthProvider(
     { ...TEST_CONFIG, revocationUrl: "https://93.184.216.34/revoke", useBasicAuth: true },
     (key) => ENV[key],
@@ -1450,7 +1451,7 @@ Deno.test("OAuthProvider authenticates revocation with Basic auth when configure
   assertEquals(body.get("client_secret"), null);
 });
 
-Deno.test("OAuthProvider skips revocation when client credentials are missing", async () => {
+it("OAuthProvider skips revocation when client credentials are missing", async () => {
   const provider = new OAuthProvider(
     { ...TEST_CONFIG, revocationUrl: "https://93.184.216.34/revoke" },
     () => undefined,
@@ -1472,7 +1473,7 @@ Deno.test("OAuthProvider skips revocation when client credentials are missing", 
   assertEquals(fetchCalls, 0);
 });
 
-Deno.test("OAuthProvider revocation logging does not coerce hostile thrown values", async () => {
+it("OAuthProvider revocation logging does not coerce hostile thrown values", async () => {
   const provider = new OAuthProvider(
     { ...TEST_CONFIG, revocationUrl: "https://93.184.216.34/revoke" },
     (key) => ENV[key],
@@ -1496,7 +1497,7 @@ Deno.test("OAuthProvider revocation logging does not coerce hostile thrown value
   }
 });
 
-Deno.test("OAuthService.fetch cannot be configured to follow redirects", async () => {
+it("OAuthService.fetch cannot be configured to follow redirects", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (key) => ENV[key]);
   let redirect: RequestRedirect | undefined;
   let fetchCalls = 0;
@@ -1532,7 +1533,7 @@ Deno.test("OAuthService.fetch cannot be configured to follow redirects", async (
   assertEquals(redirect, "manual");
 });
 
-Deno.test("OAuthService rejects oversized authorization codes before fetch", async () => {
+it("OAuthService rejects oversized authorization codes before fetch", async () => {
   const provider = new OAuthProvider(TEST_CONFIG, (key) => ENV[key]);
   let fetchCalls = 0;
   installMockFetch(
@@ -1558,7 +1559,7 @@ Deno.test("OAuthService rejects oversized authorization codes before fetch", asy
   }
 });
 
-Deno.test(
+it(
   "OAuthService.getAccessToken: concurrent expired-token reads share one refresh",
   async () => {
     let storedTokens: OAuthTokens = {
@@ -1640,7 +1641,7 @@ Deno.test(
   },
 );
 
-Deno.test("OAuthService aborting one waiter does not evict a shared refresh leader", async () => {
+it("OAuthService aborting one waiter does not evict a shared refresh leader", async () => {
   const store = new MemoryTokenStore();
   await store.setTokens(TEST_CONFIG.serviceId, "alice", {
     accessToken: "expired",
@@ -1682,7 +1683,7 @@ Deno.test("OAuthService aborting one waiter does not evict a shared refresh lead
   }
 });
 
-Deno.test("OAuthService.getAccessToken treats an epoch expiry as expired", async () => {
+it("OAuthService.getAccessToken treats an epoch expiry as expired", async () => {
   const store = makeAuthedTokenStore();
   store.getTokens = () => Promise.resolve({ accessToken: "expired", expiresAt: 0 });
   const service = new OAuthService(TEST_CONFIG, store, (key) => ENV[key]);
@@ -1690,7 +1691,7 @@ Deno.test("OAuthService.getAccessToken treats an epoch expiry as expired", async
   assertEquals(await service.getAccessToken("alice"), null);
 });
 
-Deno.test("OAuthService.getAccessToken uses a non-refreshable token until its real expiry", async () => {
+it("OAuthService.getAccessToken uses a non-refreshable token until its real expiry", async () => {
   const store = makeAuthedTokenStore();
   store.getTokens = () =>
     Promise.resolve({
@@ -1702,7 +1703,7 @@ Deno.test("OAuthService.getAccessToken uses a non-refreshable token until its re
   assertEquals(await service.getAccessToken("alice"), "still-valid");
 });
 
-Deno.test("OAuthService uses a still-valid refreshable token when the store lacks CAS", async () => {
+it("OAuthService uses a still-valid refreshable token when the store lacks CAS", async () => {
   const store = makeAuthedTokenStore();
   store.getTokens = () =>
     Promise.resolve({
@@ -1715,7 +1716,7 @@ Deno.test("OAuthService uses a still-valid refreshable token when the store lack
   assertEquals(await service.getAccessToken("alice"), "still-valid");
 });
 
-Deno.test(
+it(
   "OAuthService.getAccessToken fails before refresh when the store lacks revisioned CAS",
   async () => {
     const expired: OAuthTokens = {
@@ -1743,7 +1744,7 @@ Deno.test(
   },
 );
 
-Deno.test(
+it(
   "OAuthService.getAccessToken proactively refreshes inside the expiry buffer",
   async () => {
     const store = new MemoryTokenStore();
@@ -1778,7 +1779,7 @@ Deno.test(
   },
 );
 
-Deno.test(
+it(
   "OAuthService.getAccessToken keeps a token that expires past the refresh buffer",
   async () => {
     const store = new MemoryTokenStore();
@@ -1813,7 +1814,7 @@ Deno.test(
   },
 );
 
-Deno.test(
+it(
   "OAuthService.getAccessToken keeps a still-valid token after transient proactive refresh failure",
   async () => {
     const store = new MemoryTokenStore();
@@ -1830,7 +1831,7 @@ Deno.test(
   },
 );
 
-Deno.test(
+it(
   "OAuthService.getAccessToken cannot overwrite reauthorization during the atomic replace boundary",
   async () => {
     let row: { revision: string; tokens: OAuthTokens } | null = {
@@ -1900,7 +1901,7 @@ Deno.test(
   },
 );
 
-Deno.test("OAuthService.getAccessToken rejects malformed persistent-store rows", async () => {
+it("OAuthService.getAccessToken rejects malformed persistent-store rows", async () => {
   const store = makeAuthedTokenStore();
   store.getTokens = () => Promise.resolve({ accessToken: "   " });
   const service = new OAuthService(TEST_CONFIG, store, (key) => ENV[key]);
@@ -1912,7 +1913,7 @@ Deno.test("OAuthService.getAccessToken rejects malformed persistent-store rows",
   );
 });
 
-Deno.test("OAuthService.getAccessToken rejects oversized user IDs before store access", async () => {
+it("OAuthService.getAccessToken rejects oversized user IDs before store access", async () => {
   const store = makeAuthedTokenStore();
   let reads = 0;
   store.getTokens = () => {
@@ -1929,7 +1930,7 @@ Deno.test("OAuthService.getAccessToken rejects oversized user IDs before store a
   assertEquals(reads, 0);
 });
 
-Deno.test(
+it(
   "OAuthService.exchangeCode: 200 with no access_token is treated as failure (H11)",
   async () => {
     const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);
@@ -1947,7 +1948,7 @@ Deno.test(
   },
 );
 
-Deno.test(
+it(
   "OAuthService.exchangeCode: 200 with empty body is treated as failure (H11)",
   async () => {
     const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);
@@ -1963,7 +1964,7 @@ Deno.test(
   },
 );
 
-Deno.test(
+it(
   "OAuthService.exchangeCode: 200 with body-level ok:false/error is a failure (H12)",
   async () => {
     const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);
@@ -1981,7 +1982,7 @@ Deno.test(
   },
 );
 
-Deno.test(
+it(
   "OAuthService.exchangeCode: 200 with a valid access_token still succeeds",
   async () => {
     const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);
@@ -2001,7 +2002,7 @@ Deno.test(
   },
 );
 
-Deno.test(
+it(
   "OAuthService.fetch: provider error body is not leaked into logs (SEC-010)",
   async () => {
     const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (k) => ENV[k]);
@@ -2032,7 +2033,7 @@ Deno.test(
   },
 );
 
-Deno.test(
+it(
   "OAuthService.getAccessToken: separate service instances share refresh by token store",
   async () => {
     let storedTokens: OAuthTokens = {
@@ -2103,7 +2104,7 @@ Deno.test(
   },
 );
 
-Deno.test(
+it(
   "OAuthService.getAccessToken: separate store wrappers dedupe through the shared backend lock",
   async () => {
     const backend = new MemoryTokenStore();
@@ -2153,7 +2154,7 @@ Deno.test(
   },
 );
 
-Deno.test(
+it(
   "OAuthService.getAccessToken: separate token stores do not share refresh promises",
   async () => {
     function makeExpiredStore(refreshToken: string): TokenStore {
@@ -2229,7 +2230,7 @@ Deno.test(
   },
 );
 
-Deno.test(
+it(
   "OAuthService.getAccessToken: a completed refresh cannot resurrect a disconnected slot",
   async () => {
     let storedTokens: OAuthTokens | null = {
@@ -2297,7 +2298,7 @@ Deno.test(
   },
 );
 
-Deno.test(
+it(
   "OAuthService.getAccessToken: a completed refresh cannot overwrite a newer authorization",
   async () => {
     let storedTokens: OAuthTokens = {
@@ -2363,7 +2364,7 @@ Deno.test(
   },
 );
 
-Deno.test("OAuthService.exchangeCode: expires_in zero remains immediately expired", async () => {
+it("OAuthService.exchangeCode: expires_in zero remains immediately expired", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (key) => ENV[key]);
   const before = Date.now();
   let result: Awaited<ReturnType<typeof service.exchangeCode>> | undefined;
@@ -2380,7 +2381,7 @@ Deno.test("OAuthService.exchangeCode: expires_in zero remains immediately expire
   );
 });
 
-Deno.test("OAuthService.exchangeCode: rejects malformed token expiry values", async () => {
+it("OAuthService.exchangeCode: rejects malformed token expiry values", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (key) => ENV[key]);
 
   for (const expiresIn of [-1, 1.5, "", "not-a-number", "1e9999"]) {
@@ -2393,7 +2394,7 @@ Deno.test("OAuthService.exchangeCode: rejects malformed token expiry values", as
   }
 });
 
-Deno.test("OAuthService.exchangeCode: rejects whitespace-only access tokens", async () => {
+it("OAuthService.exchangeCode: rejects whitespace-only access tokens", async () => {
   const service = new OAuthService(TEST_CONFIG, makeAuthedTokenStore(), (key) => ENV[key]);
   let result: Awaited<ReturnType<typeof service.exchangeCode>> | undefined;
 
@@ -2405,7 +2406,7 @@ Deno.test("OAuthService.exchangeCode: rejects whitespace-only access tokens", as
   assertEquals(result?.error, "invalid_token_response");
 });
 
-Deno.test("OAuthProvider rejects control characters in token fields", async () => {
+it("OAuthProvider rejects control characters in token fields", async () => {
   const provider = new OAuthProvider(TEST_CONFIG, (key) => ENV[key]);
   for (
     const body of [
@@ -2423,7 +2424,7 @@ Deno.test("OAuthProvider rejects control characters in token fields", async () =
   }
 });
 
-Deno.test("OAuthProvider rejects present-but-malformed optional token fields", async () => {
+it("OAuthProvider rejects present-but-malformed optional token fields", async () => {
   const provider = new OAuthProvider(TEST_CONFIG, (key) => ENV[key]);
   for (
     const body of [
@@ -2441,7 +2442,7 @@ Deno.test("OAuthProvider rejects present-but-malformed optional token fields", a
   }
 });
 
-Deno.test("OAuthProvider treats an explicit null refresh token as deliberate absence", async () => {
+it("OAuthProvider treats an explicit null refresh token as deliberate absence", async () => {
   const provider = new OAuthProvider(TEST_CONFIG, (key) => ENV[key]);
   await withTokenFetch(200, { access_token: "token", refresh_token: null }, async () => {
     const result = await provider.refreshTokens("existing-refresh-token");

--- a/src/oauth/providers/config-isolation.test.ts
+++ b/src/oauth/providers/config-isolation.test.ts
@@ -1,14 +1,76 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertNotStrictEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertNotStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { confluenceConfig, jiraConfig } from "./atlassian.ts";
-import { calendarConfig, gmailConfig } from "./google.ts";
-import { outlookConfig, teamsConfig } from "./microsoft.ts";
+import { atlassianServices, confluenceConfig, jiraConfig } from "./atlassian.ts";
+import {
+  calendarConfig,
+  driveConfig,
+  gmailConfig,
+  googleServices,
+  sheetsConfig,
+} from "./google.ts";
+import { microsoftServices, outlookConfig, teamsConfig } from "./microsoft.ts";
+
+const authParamOwners: Array<readonly [string, Record<string, string>]> = Object
+  .entries({ ...googleServices, ...microsoftServices, ...atlassianServices })
+  .flatMap(([serviceId, config]) =>
+    config.additionalAuthParams ? [[serviceId, config.additionalAuthParams] as const] : []
+  );
 
 describe("OAuth provider configuration isolation", () => {
   it("does not share nested authorization parameter maps between services", () => {
     assertNotStrictEquals(gmailConfig.additionalAuthParams, calendarConfig.additionalAuthParams);
     assertNotStrictEquals(outlookConfig.additionalAuthParams, teamsConfig.additionalAuthParams);
     assertNotStrictEquals(jiraConfig.additionalAuthParams, confluenceConfig.additionalAuthParams);
+
+    for (let left = 0; left < authParamOwners.length; left++) {
+      for (let right = left + 1; right < authParamOwners.length; right++) {
+        const [leftId, leftParams] = authParamOwners[left]!;
+        const [rightId, rightParams] = authParamOwners[right]!;
+        assertNotStrictEquals(
+          leftParams,
+          rightParams,
+          `${leftId} and ${rightId} share one additionalAuthParams object`,
+        );
+      }
+    }
+  });
+
+  it("gives each service exclusive ownership of its authorization parameters", () => {
+    // Reference inequality alone cannot tell a real copy from a delegating
+    // alias, so mutate one service and prove its siblings keep their values.
+    const restored = driveConfig.additionalAuthParams?.prompt;
+    try {
+      driveConfig.additionalAuthParams!.prompt = "select_account";
+      assertEquals(
+        sheetsConfig.additionalAuthParams?.prompt,
+        "consent",
+        "mutating Drive's additionalAuthParams must not rewrite Google Sheets consent behavior",
+      );
+      assertEquals(
+        gmailConfig.additionalAuthParams?.prompt,
+        "consent",
+        "mutating Drive's additionalAuthParams must not rewrite Gmail consent behavior",
+      );
+    } finally {
+      driveConfig.additionalAuthParams!.prompt = restored!;
+    }
+
+    for (const [serviceId, params] of authParamOwners) {
+      const sentinel = `isolation-probe-${serviceId}`;
+      try {
+        params[sentinel] = "set";
+        for (const [otherId, otherParams] of authParamOwners) {
+          if (otherId === serviceId) continue;
+          assertEquals(
+            Object.hasOwn(otherParams, sentinel) || otherParams[sentinel] !== undefined,
+            false,
+            `${otherId} observed a parameter written to ${serviceId}`,
+          );
+        }
+      } finally {
+        delete params[sentinel];
+      }
+    }
   });
 });

--- a/src/oauth/providers/google.test.ts
+++ b/src/oauth/providers/google.test.ts
@@ -39,8 +39,55 @@ describe("Google OAuth provider configs", () => {
         await Deno.readTextFile(
           `templates/integrations/${config.serviceId}/connector.json`,
         ),
-      ) as { auth: { scopes: string[] } };
+      ) as { auth: { authorizationUrl: string; scopes: string[]; tokenUrl: string } };
       assertEquals(config.defaultScopes, connector.auth.scopes);
+      assertEquals(
+        config.authorizationUrl,
+        connector.auth.authorizationUrl,
+        `${config.serviceId} must authorize at the endpoint its connector advertises`,
+      );
+      assertEquals(
+        config.tokenUrl,
+        connector.auth.tokenUrl,
+        `${config.serviceId} must exchange codes at the endpoint its connector advertises`,
+      );
+    }
+  });
+
+  it("pins the shared Google authorization contract for every service", () => {
+    for (
+      const config of [gmailConfig, calendarConfig, sheetsConfig, driveConfig, docsGoogleConfig]
+    ) {
+      assertEquals(
+        config.additionalAuthParams,
+        { access_type: "offline", prompt: "consent" },
+        `${config.serviceId} must request offline access with a forced consent screen`,
+      );
+      assertEquals(
+        config.pkceMode,
+        "supported",
+        `${config.serviceId} must keep PKCE enabled`,
+      );
+      assertEquals(
+        config.authorizationUrl,
+        "https://accounts.google.com/o/oauth2/v2/auth",
+        `${config.serviceId} must use the Google authorization endpoint`,
+      );
+      assertEquals(
+        config.tokenUrl,
+        "https://oauth2.googleapis.com/token",
+        `${config.serviceId} must use the Google token endpoint`,
+      );
+      assertEquals(
+        config.clientIdEnvVar,
+        "GOOGLE_CLIENT_ID",
+        `${config.serviceId} must read the shared Google client id`,
+      );
+      assertEquals(
+        config.clientSecretEnvVar,
+        "GOOGLE_CLIENT_SECRET",
+        `${config.serviceId} must read the shared Google client secret`,
+      );
     }
   });
 });

--- a/src/oauth/providers/protocols.test.ts
+++ b/src/oauth/providers/protocols.test.ts
@@ -61,6 +61,29 @@ describe("built-in OAuth provider wire contracts", () => {
     assertEquals(result.success, true);
   });
 
+  it("sends Notion's required owner parameter on the authorize URL", async () => {
+    const credentials: Record<string, string> = {
+      [notionConfig.clientIdEnvVar]: "client-id",
+      [notionConfig.clientSecretEnvVar]: "client-secret",
+    };
+    const service = new OAuthService(notionConfig, undefined, (key) => credentials[key]);
+    const authorization = await service.createAuthorizationUrl({
+      redirectUri: "https://app.test/oauth/callback",
+    });
+    const authorizationUrl = new URL(authorization.url);
+
+    assertEquals(
+      authorizationUrl.searchParams.get("owner"),
+      "user",
+      "Notion authorize URL must request user-owned access",
+    );
+    assertEquals(
+      authorizationUrl.searchParams.has("code_challenge"),
+      false,
+      "Notion does not support PKCE on the authorize side",
+    );
+  });
+
   it("sends Atlassian's JSON token request with body credentials", async () => {
     const { request } = await captureExchange(jiraConfig);
 

--- a/src/oauth/schemas/oauth.schema.test.ts
+++ b/src/oauth/schemas/oauth.schema.test.ts
@@ -1,6 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { it } from "#veryfront/testing/bdd.ts";
-import { assertEquals } from "#std/assert";
+import { assertEquals } from "#veryfront/testing/assert.ts";
 import {
   getAuthorizationUrlOptionsSchema,
   getOAuthProviderConfigSchema,

--- a/src/oauth/schemas/oauth.schema.test.ts
+++ b/src/oauth/schemas/oauth.schema.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { it } from "#veryfront/testing/bdd.ts";
 import { assertEquals } from "#std/assert";
 import {
   getAuthorizationUrlOptionsSchema,
@@ -20,7 +21,7 @@ const PROVIDER_CONFIG = {
   clientSecretEnvVar: "CLIENT_SECRET",
 };
 
-Deno.test("OAuth schemas accept the hardened public contracts", () => {
+it("OAuth schemas accept the hardened public contracts", () => {
   const parsedConfig = getOAuthServiceConfigSchema().safeParse({
     ...PROVIDER_CONFIG,
     serviceId: "provider.service-1",
@@ -56,7 +57,7 @@ Deno.test("OAuth schemas accept the hardened public contracts", () => {
   );
 });
 
-Deno.test("OAuth schemas reject values that constructors reject", () => {
+it("OAuth schemas reject values that constructors reject", () => {
   for (
     const config of [
       { ...PROVIDER_CONFIG, additionalAuthParams: { state: "fixed" } },
@@ -95,7 +96,7 @@ Deno.test("OAuth schemas reject values that constructors reject", () => {
   );
 });
 
-Deno.test("OAuth provider schemas reject unsafe URLs and invalid numeric bounds", () => {
+it("OAuth provider schemas reject unsafe URLs and invalid numeric bounds", () => {
   for (
     const authorizationUrl of [
       "not a URL",
@@ -134,7 +135,7 @@ Deno.test("OAuth provider schemas reject unsafe URLs and invalid numeric bounds"
   }
 });
 
-Deno.test("OAuth schemas reject blank credentials, tokens, codes, and scopes", () => {
+it("OAuth schemas reject blank credentials, tokens, codes, and scopes", () => {
   assertEquals(
     getOAuthProviderConfigSchema().safeParse({
       ...PROVIDER_CONFIG,
@@ -174,7 +175,7 @@ Deno.test("OAuth schemas reject blank credentials, tokens, codes, and scopes", (
   );
 });
 
-Deno.test("OAuth request schemas bound state and validate redirects and PKCE", () => {
+it("OAuth request schemas bound state and validate redirects and PKCE", () => {
   assertEquals(
     getAuthorizationUrlOptionsSchema().safeParse({ state: "x".repeat(1_025) }).success,
     false,
@@ -273,7 +274,7 @@ Deno.test("OAuth request schemas bound state and validate redirects and PKCE", (
   assertEquals(getterCalls, 0);
 });
 
-Deno.test("OAuth token exchange results enforce success and failure invariants", () => {
+it("OAuth token exchange results enforce success and failure invariants", () => {
   assertEquals(
     getTokenExchangeResultSchema().safeParse({
       success: true,
@@ -299,7 +300,7 @@ Deno.test("OAuth token exchange results enforce success and failure invariants",
   }
 });
 
-Deno.test("every built-in OAuth provider config satisfies the public service schema", () => {
+it("every built-in OAuth provider config satisfies the public service schema", () => {
   const configs = Object.entries(providerCatalog).filter(([name]) => name.endsWith("Config"));
   assertEquals(configs.length > 0, true);
 

--- a/src/oauth/schemas/oauth.schema.test.ts
+++ b/src/oauth/schemas/oauth.schema.test.ts
@@ -183,6 +183,41 @@ Deno.test("OAuth request schemas bound state and validate redirects and PKCE", (
     getAuthorizationUrlOptionsSchema().safeParse({ redirectUri: "javascript:alert(1)" }).success,
     false,
   );
+  for (
+    const [schemaName, accepts] of [
+      [
+        "the OAuth state schema",
+        (redirectUri: string) =>
+          getOAuthStateSchema().safeParse({
+            state: "state",
+            redirectUri,
+            scopes: ["read"],
+            createdAt: Date.now(),
+          }).success,
+      ],
+      [
+        "the authorization URL options schema",
+        (redirectUri: string) =>
+          getAuthorizationUrlOptionsSchema().safeParse({ redirectUri }).success,
+      ],
+      [
+        "the token exchange options schema",
+        (redirectUri: string) =>
+          getTokenExchangeOptionsSchema().safeParse({ code: "code", redirectUri }).success,
+      ],
+    ] as const
+  ) {
+    assertEquals(
+      accepts("http://attacker.test/callback"),
+      false,
+      `${schemaName} must reject plain HTTP on a non-loopback host`,
+    );
+    assertEquals(
+      accepts("http://127.0.0.1:8787/callback"),
+      true,
+      `${schemaName} must accept explicit loopback HTTP`,
+    );
+  }
   assertEquals(
     getAuthorizationUrlOptionsSchema().safeParse({
       additionalParams: { STATE: "attacker-controlled" },

--- a/src/oauth/token-store/memory.test.ts
+++ b/src/oauth/token-store/memory.test.ts
@@ -140,11 +140,43 @@ Deno.test("MemoryTokenStore warns once when persisting tokens in production (#19
 
     const matched = warnings.filter((w) => w.includes("MemoryTokenStore"));
     // Warned exactly once despite two writes.
-    assertEquals(matched.length, 1);
+    assertEquals(matched.length, 1, "two production token writes must warn exactly once");
   } finally {
     console.warn = originalWarn;
     if (prevNodeEnv === undefined) Deno.env.delete("NODE_ENV");
     else Deno.env.set("NODE_ENV", prevNodeEnv);
+  }
+});
+
+Deno.test("MemoryTokenStore stays silent outside production", async () => {
+  const previous = new Map(
+    (["VERYFRONT_ENV", "NODE_ENV", "DENO_ENV"] as const).map((
+      name,
+    ) => [name, Deno.env.get(name)]),
+  );
+  const originalWarn = console.warn;
+  const warnings: string[] = [];
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(" "));
+  };
+  try {
+    // resolveEnvironment prefers VERYFRONT_ENV, then NODE_ENV, then DENO_ENV.
+    Deno.env.delete("VERYFRONT_ENV");
+    Deno.env.delete("DENO_ENV");
+    Deno.env.set("NODE_ENV", "development");
+    await new MemoryTokenStore().setTokens("svc", "alice", tokens("a-token"));
+
+    assertEquals(
+      warnings.filter((w) => w.includes("MemoryTokenStore")).length,
+      0,
+      "development token writes must not warn",
+    );
+  } finally {
+    console.warn = originalWarn;
+    for (const [name, value] of previous) {
+      if (value === undefined) Deno.env.delete(name);
+      else Deno.env.set(name, value);
+    }
   }
 });
 

--- a/src/oauth/token-store/memory.test.ts
+++ b/src/oauth/token-store/memory.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { it } from "#veryfront/testing/bdd.ts";
 import { assertEquals, assertNotEquals, assertRejects, assertThrows } from "#std/assert";
 import { FakeTime } from "#std/testing/time";
 import { MemoryTokenStore } from "./memory.ts";
@@ -19,7 +20,7 @@ function oauthState(userId: string, createdAt = Date.now()): StoredOAuthState {
   };
 }
 
-Deno.test("MemoryTokenStore stores and retrieves tokens per (serviceId, userId)", async () => {
+it("MemoryTokenStore stores and retrieves tokens per (serviceId, userId)", async () => {
   const store = new MemoryTokenStore();
   await store.setTokens("svc", "alice", tokens("a-token"));
   await store.setTokens("svc", "bob", tokens("b-token"));
@@ -29,14 +30,14 @@ Deno.test("MemoryTokenStore stores and retrieves tokens per (serviceId, userId)"
   assertEquals(await store.getTokens("svc", "carol"), null);
 });
 
-Deno.test("MemoryTokenStore clears a single user's tokens", async () => {
+it("MemoryTokenStore clears a single user's tokens", async () => {
   const store = new MemoryTokenStore();
   await store.setTokens("svc", "alice", tokens("a-token"));
   await store.clearTokens("svc", "alice");
   assertEquals(await store.getTokens("svc", "alice"), null);
 });
 
-Deno.test("MemoryTokenStore isConnected: fresh, expired-without-refresh, expired-with-refresh", async () => {
+it("MemoryTokenStore isConnected: fresh, expired-without-refresh, expired-with-refresh", async () => {
   const store = new MemoryTokenStore();
   await store.setTokens("svc", "fresh", tokens("t", { expiresAt: Date.now() + 60_000 }));
   await store.setTokens("svc", "stale", tokens("t", { expiresAt: Date.now() - 1 }));
@@ -52,7 +53,7 @@ Deno.test("MemoryTokenStore isConnected: fresh, expired-without-refresh, expired
   assertEquals(store.isConnected("svc", "unknown"), false);
 });
 
-Deno.test("MemoryTokenStore consumeState is one-shot and rejects unknown", async () => {
+it("MemoryTokenStore consumeState is one-shot and rejects unknown", async () => {
   const store = new MemoryTokenStore();
   const meta = oauthState("alice");
   await store.setState("state-1", meta);
@@ -63,7 +64,7 @@ Deno.test("MemoryTokenStore consumeState is one-shot and rejects unknown", async
   assertEquals(await store.consumeState("never-set"), null);
 });
 
-Deno.test("MemoryTokenStore consumeState rejects and drops expired state", async () => {
+it("MemoryTokenStore consumeState rejects and drops expired state", async () => {
   using time = new FakeTime();
   const store = new MemoryTokenStore();
   await store.setState("old", oauthState("alice"));
@@ -75,7 +76,7 @@ Deno.test("MemoryTokenStore consumeState rejects and drops expired state", async
   assertEquals(await store.consumeState("old"), null);
 });
 
-Deno.test("MemoryTokenStore bounds OAuth states via oldest-entry eviction", async () => {
+it("MemoryTokenStore bounds OAuth states via oldest-entry eviction", async () => {
   const store = new MemoryTokenStore("default", { maxStateEntries: 2 });
 
   await store.setState("state-1", oauthState("u1"));
@@ -87,7 +88,7 @@ Deno.test("MemoryTokenStore bounds OAuth states via oldest-entry eviction", asyn
   assertEquals((await store.consumeState("state-3"))?.userId, "u3");
 });
 
-Deno.test("MemoryTokenStore scopes keys by projectId", async () => {
+it("MemoryTokenStore scopes keys by projectId", async () => {
   const a = new MemoryTokenStore("project-a");
   const b = new MemoryTokenStore("project-b");
   await a.setTokens("svc", "alice", tokens("a-token"));
@@ -96,7 +97,7 @@ Deno.test("MemoryTokenStore scopes keys by projectId", async () => {
   assertEquals(a.getConnectedServices(), ["svc:alice"]);
 });
 
-Deno.test("MemoryTokenStore bounds the token map via LRU eviction (#1989)", async () => {
+it("MemoryTokenStore bounds the token map via LRU eviction (#1989)", async () => {
   const store = new MemoryTokenStore("default", { maxEntries: 3 });
 
   for (const user of ["u1", "u2", "u3"]) {
@@ -115,7 +116,7 @@ Deno.test("MemoryTokenStore bounds the token map via LRU eviction (#1989)", asyn
   assertEquals(store.getConnectedServices().length, 3);
 });
 
-Deno.test("MemoryTokenStore clearAll empties tokens and states", async () => {
+it("MemoryTokenStore clearAll empties tokens and states", async () => {
   const store = new MemoryTokenStore();
   await store.setTokens("svc", "alice", tokens("a-token"));
   await store.setState("s", oauthState("alice"));
@@ -125,62 +126,56 @@ Deno.test("MemoryTokenStore clearAll empties tokens and states", async () => {
   assertEquals(store.getConnectedServices().length, 0);
 });
 
-Deno.test("MemoryTokenStore warns once when persisting tokens in production (#1989)", async () => {
-  const prevNodeEnv = Deno.env.get("NODE_ENV");
-  const originalWarn = console.warn;
-  const warnings: string[] = [];
-  console.warn = (...args: unknown[]) => {
-    warnings.push(args.map(String).join(" "));
-  };
-  try {
-    Deno.env.set("NODE_ENV", "production");
+it("MemoryTokenStore warns once when persisting tokens in production (#1989)", async () => {
+  const script = `
+    const warnings = [];
+    console.warn = (...args) => warnings.push(args.map(String).join(" "));
+    const { MemoryTokenStore } = await import("./src/oauth/token-store/memory.ts");
     const store = new MemoryTokenStore();
-    await store.setTokens("svc", "alice", tokens("a-token"));
-    await store.setTokens("svc", "bob", tokens("b-token"));
+    await store.setTokens("svc", "alice", { accessToken: "a-token" });
+    await store.setTokens("svc", "bob", { accessToken: "b-token" });
+    const matched = warnings.filter((warning) => warning.includes("MemoryTokenStore"));
+    console.log(JSON.stringify({ matched: matched.length }));
+  `;
+  const output = await new Deno.Command(Deno.execPath(), {
+    args: ["eval", script],
+    clearEnv: true,
+    cwd: new URL("../../../", import.meta.url).pathname,
+    env: { NODE_ENV: "production" },
+  }).output();
 
-    const matched = warnings.filter((w) => w.includes("MemoryTokenStore"));
-    // Warned exactly once despite two writes.
-    assertEquals(matched.length, 1, "two production token writes must warn exactly once");
-  } finally {
-    console.warn = originalWarn;
-    if (prevNodeEnv === undefined) Deno.env.delete("NODE_ENV");
-    else Deno.env.set("NODE_ENV", prevNodeEnv);
-  }
+  assertEquals(
+    output.success,
+    true,
+    new TextDecoder().decode(output.stderr),
+  );
+  assertEquals(
+    JSON.parse(new TextDecoder().decode(output.stdout)).matched,
+    1,
+    "two production token writes must warn exactly once",
+  );
 });
 
-Deno.test("MemoryTokenStore stays silent outside production", async () => {
-  const previous = new Map(
-    (["VERYFRONT_ENV", "NODE_ENV", "DENO_ENV"] as const).map((
-      name,
-    ) => [name, Deno.env.get(name)]),
-  );
+it("MemoryTokenStore stays silent outside production", async () => {
   const originalWarn = console.warn;
   const warnings: string[] = [];
   console.warn = (...args: unknown[]) => {
     warnings.push(args.map(String).join(" "));
   };
   try {
-    // resolveEnvironment prefers VERYFRONT_ENV, then NODE_ENV, then DENO_ENV.
-    Deno.env.delete("VERYFRONT_ENV");
-    Deno.env.delete("DENO_ENV");
-    Deno.env.set("NODE_ENV", "development");
     await new MemoryTokenStore().setTokens("svc", "alice", tokens("a-token"));
 
     assertEquals(
       warnings.filter((w) => w.includes("MemoryTokenStore")).length,
       0,
-      "development token writes must not warn",
+      "non-production token writes must not warn",
     );
   } finally {
     console.warn = originalWarn;
-    for (const [name, value] of previous) {
-      if (value === undefined) Deno.env.delete(name);
-      else Deno.env.set(name, value);
-    }
   }
 });
 
-Deno.test("MemoryTokenStore encodes tuple keys without delimiter collisions", async () => {
+it("MemoryTokenStore encodes tuple keys without delimiter collisions", async () => {
   const store = new MemoryTokenStore("project");
   await store.setTokens("service:a", "user", tokens("first"));
   await store.setTokens("service", "a:user", tokens("second"));
@@ -190,7 +185,7 @@ Deno.test("MemoryTokenStore encodes tuple keys without delimiter collisions", as
   assertEquals(store.getConnectedServices().sort(), ["service%3Aa:user", "service:a%3Auser"]);
 });
 
-Deno.test("MemoryTokenStore detaches stored and returned token objects", async () => {
+it("MemoryTokenStore detaches stored and returned token objects", async () => {
   const store = new MemoryTokenStore();
   const input = tokens("original", { refreshToken: "refresh" });
   await store.setTokens("svc", "alice", input);
@@ -203,7 +198,7 @@ Deno.test("MemoryTokenStore detaches stored and returned token objects", async (
   assertEquals((await store.getTokens("svc", "alice"))?.accessToken, "original");
 });
 
-Deno.test("MemoryTokenStore conditionally replaces only the observed token revision", async () => {
+it("MemoryTokenStore conditionally replaces only the observed token revision", async () => {
   const store = new MemoryTokenStore();
   await store.setTokens("svc", "alice", tokens("original", { refreshToken: "refresh" }));
   const snapshot = await store.getTokenSnapshot("svc", "alice");
@@ -224,7 +219,7 @@ Deno.test("MemoryTokenStore conditionally replaces only the observed token revis
   assertEquals((await store.getTokens("svc", "alice"))?.accessToken, "replacement");
 });
 
-Deno.test("MemoryTokenStore bounds and canonicalizes expected token revisions", async () => {
+it("MemoryTokenStore bounds and canonicalizes expected token revisions", async () => {
   const store = new MemoryTokenStore();
   await store.setTokens("svc", "alice", tokens("original"));
   for (const revision of ["", " revision", "rev\nision", "x".repeat(257)]) {
@@ -237,7 +232,7 @@ Deno.test("MemoryTokenStore bounds and canonicalizes expected token revisions", 
   assertEquals((await store.getTokens("svc", "alice"))?.accessToken, "original");
 });
 
-Deno.test("MemoryTokenStore revisions prevent ABA after disconnect and reauthorization", async () => {
+it("MemoryTokenStore revisions prevent ABA after disconnect and reauthorization", async () => {
   const store = new MemoryTokenStore();
   await store.setTokens("svc", "alice", tokens("same-token"));
   const first = await store.getTokenSnapshot("svc", "alice");
@@ -256,7 +251,7 @@ Deno.test("MemoryTokenStore revisions prevent ABA after disconnect and reauthori
   assertEquals((await store.getTokens("svc", "alice"))?.accessToken, "same-token");
 });
 
-Deno.test("MemoryTokenStore serializes refresh work per token slot", async () => {
+it("MemoryTokenStore serializes refresh work per token slot", async () => {
   const store = new MemoryTokenStore();
   const events: string[] = [];
   let releaseFirst!: () => void;
@@ -282,7 +277,7 @@ Deno.test("MemoryTokenStore serializes refresh work per token slot", async () =>
   assertEquals(events, ["first:start", "first:end", "second:start", "second:end"]);
 });
 
-Deno.test("MemoryTokenStore releases a refresh lock after operation rejection", async () => {
+it("MemoryTokenStore releases a refresh lock after operation rejection", async () => {
   const store = new MemoryTokenStore();
   await assertRejects(
     () =>
@@ -297,7 +292,7 @@ Deno.test("MemoryTokenStore releases a refresh lock after operation rejection", 
   );
 });
 
-Deno.test("MemoryTokenStore permits refresh work for different slots concurrently", async () => {
+it("MemoryTokenStore permits refresh work for different slots concurrently", async () => {
   const store = new MemoryTokenStore();
   let releaseAlice!: () => void;
   const aliceGate = new Promise<void>((resolve) => {
@@ -317,7 +312,7 @@ Deno.test("MemoryTokenStore permits refresh work for different slots concurrentl
   await alice;
 });
 
-Deno.test("MemoryTokenStore rejects malformed and accessor-backed token rows", async () => {
+it("MemoryTokenStore rejects malformed and accessor-backed token rows", async () => {
   const store = new MemoryTokenStore();
   for (
     const malformed of [
@@ -352,7 +347,7 @@ Deno.test("MemoryTokenStore rejects malformed and accessor-backed token rows", a
   assertEquals(getterCalls, 0);
 });
 
-Deno.test("MemoryTokenStore rejects token fields that exceed storage bounds", async () => {
+it("MemoryTokenStore rejects token fields that exceed storage bounds", async () => {
   const store = new MemoryTokenStore();
   await assertRejects(
     () => store.setTokens("github", "alice", { accessToken: "x".repeat(65_537) }),
@@ -361,7 +356,7 @@ Deno.test("MemoryTokenStore rejects token fields that exceed storage bounds", as
   );
 });
 
-Deno.test("MemoryTokenStore detaches state metadata from callers", async () => {
+it("MemoryTokenStore detaches state metadata from callers", async () => {
   const store = new MemoryTokenStore();
   const meta: StoredOAuthState = {
     ...oauthState("alice"),
@@ -378,7 +373,7 @@ Deno.test("MemoryTokenStore detaches state metadata from callers", async () => {
   assertEquals(consumed?.metadata, { nested: { value: "original" } });
 });
 
-Deno.test("MemoryTokenStore rejects non-data and oversized state metadata", async () => {
+it("MemoryTokenStore rejects non-data and oversized state metadata", async () => {
   const store = new MemoryTokenStore();
   let getterCalls = 0;
   const accessorMetadata = Object.defineProperty({}, "secret", {
@@ -416,7 +411,7 @@ Deno.test("MemoryTokenStore rejects non-data and oversized state metadata", asyn
   assertEquals(getterCalls, 0);
 });
 
-Deno.test("MemoryTokenStore rejects duplicate live state values", async () => {
+it("MemoryTokenStore rejects duplicate live state values", async () => {
   const store = new MemoryTokenStore();
   await store.setState("duplicate", oauthState("alice"));
 
@@ -428,7 +423,7 @@ Deno.test("MemoryTokenStore rejects duplicate live state values", async () => {
   assertEquals((await store.consumeState("duplicate"))?.userId, "alice");
 });
 
-Deno.test("MemoryTokenStore rejects invalid capacity options", () => {
+it("MemoryTokenStore rejects invalid capacity options", () => {
   for (const value of [0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
     assertThrows(
       () => new MemoryTokenStore("project", { maxStateEntries: value }),
@@ -445,7 +440,7 @@ Deno.test("MemoryTokenStore rejects invalid capacity options", () => {
   }
 });
 
-Deno.test("MemoryTokenStore rejects invalid state rows before insertion", async () => {
+it("MemoryTokenStore rejects invalid state rows before insertion", async () => {
   const store = new MemoryTokenStore();
   for (
     const [state, value] of [
@@ -464,7 +459,7 @@ Deno.test("MemoryTokenStore rejects invalid state rows before insertion", async 
   }
 });
 
-Deno.test("MemoryTokenStore invalid state cannot evict a live transaction", async () => {
+it("MemoryTokenStore invalid state cannot evict a live transaction", async () => {
   const store = new MemoryTokenStore("default", { maxStateEntries: 1 });
   await store.setState("live", oauthState("alice"));
   await assertRejects(
@@ -475,7 +470,7 @@ Deno.test("MemoryTokenStore invalid state cannot evict a live transaction", asyn
   assertEquals((await store.consumeState("live"))?.userId, "alice");
 });
 
-Deno.test("MemoryTokenStore rejects non-canonical key identifiers", async () => {
+it("MemoryTokenStore rejects non-canonical key identifiers", async () => {
   const store = new MemoryTokenStore();
   for (
     const [serviceId, userId] of [[" svc", "alice"], ["svc", " alice "]] as const

--- a/src/oauth/token-store/memory.test.ts
+++ b/src/oauth/token-store/memory.test.ts
@@ -1,5 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { it } from "#veryfront/testing/bdd.ts";
+import { withEnv } from "#veryfront/testing/deno-compat.ts";
 import { assertEquals, assertNotEquals, assertRejects, assertThrows } from "#std/assert";
 import { FakeTime } from "#std/testing/time";
 import { MemoryTokenStore } from "./memory.ts";
@@ -126,62 +127,42 @@ it("MemoryTokenStore clearAll empties tokens and states", async () => {
   assertEquals(store.getConnectedServices().length, 0);
 });
 
-it("MemoryTokenStore warns once when persisting tokens in production (#1989)", async () => {
-  const script = `
-    const warnings = [];
-    console.warn = (...args) => warnings.push(args.map(String).join(" "));
-    const { MemoryTokenStore } = await import("./src/oauth/token-store/memory.ts");
-    const store = new MemoryTokenStore();
-    await store.setTokens("svc", "alice", { accessToken: "a-token" });
-    await store.setTokens("svc", "bob", { accessToken: "b-token" });
-    const matched = warnings.filter((warning) => warning.includes("MemoryTokenStore"));
-    console.log(JSON.stringify({ matched: matched.length }));
-  `;
-  const output = await new Deno.Command(Deno.execPath(), {
-    args: ["eval", script],
-    clearEnv: true,
-    cwd: new URL("../../../", import.meta.url).pathname,
-    env: { NODE_ENV: "production" },
-  }).output();
+async function captureWarnings(run: () => Promise<void>): Promise<string[]> {
+  const warnings: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(" "));
+  };
+  try {
+    await run();
+  } finally {
+    console.warn = originalWarn;
+  }
+  return warnings.filter((warning) => warning.includes("MemoryTokenStore"));
+}
 
-  assertEquals(
-    output.success,
-    true,
-    new TextDecoder().decode(output.stderr),
+it("MemoryTokenStore warns once when persisting tokens in production (#1989)", async () => {
+  // VERYFRONT_ENV is resolved ahead of NODE_ENV, so this pins the posture
+  // regardless of what the host runner exported.
+  const matched = await captureWarnings(() =>
+    withEnv({ VERYFRONT_ENV: "production" }, async () => {
+      const store = new MemoryTokenStore();
+      await store.setTokens("svc", "alice", tokens("a-token"));
+      await store.setTokens("svc", "bob", tokens("b-token"));
+    })
   );
-  assertEquals(
-    JSON.parse(new TextDecoder().decode(output.stdout)).matched,
-    1,
-    "two production token writes must warn exactly once",
-  );
+
+  assertEquals(matched.length, 1, "two production token writes must warn exactly once");
 });
 
 it("MemoryTokenStore stays silent outside production", async () => {
-  const script = `
-    const warnings = [];
-    console.warn = (...args) => warnings.push(args.map(String).join(" "));
-    const { MemoryTokenStore } = await import("./src/oauth/token-store/memory.ts");
-    await new MemoryTokenStore().setTokens("svc", "alice", { accessToken: "a-token" });
-    const matched = warnings.filter((warning) => warning.includes("MemoryTokenStore"));
-    console.log(JSON.stringify({ matched: matched.length }));
-  `;
-  const output = await new Deno.Command(Deno.execPath(), {
-    args: ["eval", script],
-    clearEnv: true,
-    cwd: new URL("../../../", import.meta.url).pathname,
-    env: { NODE_ENV: "development" },
-  }).output();
+  const matched = await captureWarnings(() =>
+    withEnv({ VERYFRONT_ENV: "development" }, async () => {
+      await new MemoryTokenStore().setTokens("svc", "alice", tokens("a-token"));
+    })
+  );
 
-  assertEquals(
-    output.success,
-    true,
-    new TextDecoder().decode(output.stderr),
-  );
-  assertEquals(
-    JSON.parse(new TextDecoder().decode(output.stdout)).matched,
-    0,
-    "non-production token writes must not warn",
-  );
+  assertEquals(matched.length, 0, "non-production token writes must not warn");
 });
 
 it("MemoryTokenStore encodes tuple keys without delimiter collisions", async () => {

--- a/src/oauth/token-store/memory.test.ts
+++ b/src/oauth/token-store/memory.test.ts
@@ -1,7 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { it } from "#veryfront/testing/bdd.ts";
 import { withEnv } from "#veryfront/testing/deno-compat.ts";
-import { assertEquals, assertNotEquals, assertRejects, assertThrows } from "#std/assert";
+import {
+  assertEquals,
+  assertNotEquals,
+  assertRejects,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { FakeTime } from "#std/testing/time";
 import { MemoryTokenStore } from "./memory.ts";
 import type { OAuthTokens, StoredOAuthState } from "../types.ts";

--- a/src/oauth/token-store/memory.test.ts
+++ b/src/oauth/token-store/memory.test.ts
@@ -157,22 +157,31 @@ it("MemoryTokenStore warns once when persisting tokens in production (#1989)", a
 });
 
 it("MemoryTokenStore stays silent outside production", async () => {
-  const originalWarn = console.warn;
-  const warnings: string[] = [];
-  console.warn = (...args: unknown[]) => {
-    warnings.push(args.map(String).join(" "));
-  };
-  try {
-    await new MemoryTokenStore().setTokens("svc", "alice", tokens("a-token"));
+  const script = `
+    const warnings = [];
+    console.warn = (...args) => warnings.push(args.map(String).join(" "));
+    const { MemoryTokenStore } = await import("./src/oauth/token-store/memory.ts");
+    await new MemoryTokenStore().setTokens("svc", "alice", { accessToken: "a-token" });
+    const matched = warnings.filter((warning) => warning.includes("MemoryTokenStore"));
+    console.log(JSON.stringify({ matched: matched.length }));
+  `;
+  const output = await new Deno.Command(Deno.execPath(), {
+    args: ["eval", script],
+    clearEnv: true,
+    cwd: new URL("../../../", import.meta.url).pathname,
+    env: { NODE_ENV: "development" },
+  }).output();
 
-    assertEquals(
-      warnings.filter((w) => w.includes("MemoryTokenStore")).length,
-      0,
-      "non-production token writes must not warn",
-    );
-  } finally {
-    console.warn = originalWarn;
-  }
+  assertEquals(
+    output.success,
+    true,
+    new TextDecoder().decode(output.stderr),
+  );
+  assertEquals(
+    JSON.parse(new TextDecoder().decode(output.stdout)).matched,
+    0,
+    "non-production token writes must not warn",
+  );
 });
 
 it("MemoryTokenStore encodes tuple keys without delimiter collisions", async () => {

--- a/src/webhook/factory.test.ts
+++ b/src/webhook/factory.test.ts
@@ -132,6 +132,51 @@ describe("webhook/factory", () => {
     assertEquals(matchAll.eventFilter, { mode: "any", conditions: [] });
   });
 
+  it("rejects unsupported filter modes and operators", () => {
+    assertThrows(
+      () =>
+        webhook({
+          id: "ticket-created",
+          target: { kind: "task", id: "process-ticket" },
+          eventFilter: {
+            mode: "ANY",
+            conditions: [{ path: "action", operator: "exists" }],
+          },
+        } as never),
+      VeryfrontError,
+      "Webhook eventFilter mode must be all or any.",
+      "an unrecognized filter mode must be rejected instead of silently meaning all",
+    );
+    assertThrows(
+      () =>
+        webhook({
+          id: "ticket-created",
+          target: { kind: "task", id: "process-ticket" },
+          eventFilter: {
+            mode: "all",
+            conditions: [{ path: "count", operator: "gt", value: 1 }],
+          },
+        } as never),
+      VeryfrontError,
+      "Webhook eventFilter condition 0 operator is not supported.",
+      "an operator outside the hosted allowlist must be rejected at definition time",
+    );
+  });
+
+  it("accepts a multi-line webhook description", () => {
+    const definition = webhook({
+      id: "ticket-created",
+      description: "Line one.\nLine two.",
+      target: { kind: "task", id: "process-ticket" },
+    });
+
+    assertEquals(
+      definition.description,
+      "Line one.\nLine two.",
+      "a multi-line description must round-trip verbatim",
+    );
+  });
+
   it("trims filter paths before enforcing the hosted length bound", () => {
     const definition = webhook({
       id: "ticket-created",
@@ -404,6 +449,14 @@ describe("webhook/factory", () => {
             agentMessage: { promptTemplate: "p".repeat(20_001) },
           },
           "Webhook agentMessage.promptTemplate must be at most 20000 characters.",
+        ],
+        [
+          {
+            id: "ticket-created",
+            description: "d".repeat(4_097),
+            target: { kind: "task", id: "process-ticket" },
+          },
+          "Webhook description must be at most 4096 characters.",
         ],
       ] as const
     ) {

--- a/src/webhook/runtime.test.ts
+++ b/src/webhook/runtime.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { VeryfrontError } from "#veryfront/errors";
 import { webhook } from "./factory.ts";
 import { prepareWebhookInvocation, renderWebhookPromptTemplate } from "./runtime.ts";
+import type { WebhookEventFilterCondition } from "./types.ts";
 
 describe("webhook/runtime", () => {
   it("normalizes JSONPath root prefixes before evaluating filters", () => {
@@ -69,6 +70,100 @@ describe("webhook/runtime", () => {
     });
 
     assertEquals(invocation.matched, true);
+  });
+
+  it("rejects payloads that fail each hosted filter operator", () => {
+    function matched(
+      condition: WebhookEventFilterCondition,
+      payload: Record<string, unknown>,
+    ): boolean {
+      const definition = webhook({
+        id: "operator-negative",
+        target: { kind: "task", id: "process-event" },
+        eventFilter: { mode: "all", conditions: [condition] },
+      });
+      return prepareWebhookInvocation(definition, payload).matched;
+    }
+
+    assertEquals(
+      matched({ path: "action", operator: "equals", value: "opened" }, { action: "closed" }),
+      false,
+      "equals must reject a different value",
+    );
+    assertEquals(
+      matched(
+        { path: "pull_request.draft", operator: "not_equals", value: true },
+        { pull_request: { draft: true } },
+      ),
+      false,
+      "not_equals must reject a payload holding the excluded value",
+    );
+    assertEquals(
+      matched(
+        { path: "action", operator: "in", value: ["opened", "reopened", "synchronize"] },
+        { action: "closed" },
+      ),
+      false,
+      "in must reject a value outside the declared set",
+    );
+    assertEquals(
+      matched({ path: "pull_request.number", operator: "exists" }, { pull_request: {} }),
+      false,
+      "exists must reject a payload missing the demanded path",
+    );
+    assertEquals(
+      matched(
+        { path: "pull_request.labels", operator: "contains", value: "backend" },
+        { pull_request: { labels: ["needs-review"] } },
+      ),
+      false,
+      "contains must reject an array without the demanded member",
+    );
+    assertEquals(
+      matched(
+        { path: "repository.full_name", operator: "contains", value: "veryfront/" },
+        { repository: { full_name: "other/veryfront-code" } },
+      ),
+      false,
+      "contains must reject a string without the demanded substring",
+    );
+  });
+
+  it("rejects a payload object that omits keys the condition demands", () => {
+    const base = {
+      id: "structural-equality",
+      target: { kind: "task" as const, id: "process-event" },
+    };
+    const equals = webhook({
+      ...base,
+      eventFilter: {
+        mode: "all",
+        conditions: [{ path: "metadata", operator: "equals", value: { first: 1, second: 2 } }],
+      },
+    });
+    const notEquals = webhook({
+      ...base,
+      eventFilter: {
+        mode: "all",
+        conditions: [{ path: "metadata", operator: "not_equals", value: { first: 1, second: 2 } }],
+      },
+    });
+
+    assertEquals(
+      prepareWebhookInvocation(equals, { metadata: { first: 1 } }).matched,
+      false,
+      "equals must not match a payload object missing a demanded key",
+    );
+    assertEquals(
+      prepareWebhookInvocation(notEquals, { metadata: { first: 1 } }).matched,
+      true,
+      "not_equals must treat a payload object missing a demanded key as different",
+    );
+    assertEquals(
+      prepareWebhookInvocation(equals, { metadata: { first: 1, second: 2, third: 3 } }).matched,
+      false,
+      "equals must not match a payload object carrying extra keys",
+    );
   });
 
   it("preserves all, any, empty-filter, and missing-path semantics", () => {
@@ -168,9 +263,10 @@ describe("webhook/runtime", () => {
     assertEquals(
       renderWebhookPromptTemplate(
         "{{payload.literal}}",
-        { literal: "{{payload.literal}}" },
+        { literal: "{{payload.secret}}", secret: "leaked" },
       ),
-      "{{payload.literal}}",
+      "{{payload.secret}}",
+      "rendered payload values must never be re-expanded as placeholders",
     );
   });
 

--- a/tests/integration/integrations/local-endpoint-egress.test.ts
+++ b/tests/integration/integrations/local-endpoint-egress.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Egress guard coverage for the local integration endpoint executor.
+ *
+ * Lives under tests/integration because it binds a real loopback listener to
+ * prove the default transport never opens a connection to an internal host.
+ * The hermetic argument and header assertions stay colocated in
+ * src/integrations/local-endpoint-executor.test.ts.
+ */
+
+import "#veryfront/schemas/_test-setup.ts";
+import { VeryfrontError } from "#veryfront/errors";
+import { assertEquals, assertInstanceOf, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { IntegrationToolMeta } from "#veryfront/integrations/schema.ts";
+import { executeLocalIntegrationEndpoint } from "#veryfront/integrations/local-endpoint-executor.ts";
+
+type IntegrationEndpoint = NonNullable<IntegrationToolMeta["endpoint"]>;
+
+describe("local integration endpoint egress guard", () => {
+  it("defaults to the guarded egress transport when no transport is injected", async () => {
+    let providerCalls = 0;
+    // Port 0 asks the OS for an ephemeral port, so nothing here is hard coded.
+    const server = Deno.serve({ port: 0, hostname: "127.0.0.1", onListen: () => {} }, () => {
+      providerCalls += 1;
+      return Response.json({ ok: true });
+    });
+    const origin = `http://127.0.0.1:${(server.addr as Deno.NetAddr).port}`;
+    const endpoint: IntegrationEndpoint = {
+      method: "GET",
+      url: `${origin}/latest/meta-data`,
+    };
+    try {
+      const error = await assertRejects(
+        () =>
+          executeLocalIntegrationEndpoint({
+            connectorName: "example",
+            toolId: "example__test",
+            endpoint,
+            args: {},
+            authHeaders: {},
+            allowedOrigin: origin,
+          }),
+        VeryfrontError,
+      );
+      assertInstanceOf(error, VeryfrontError);
+      assertEquals(
+        error.slug,
+        "local-integration-request-failed",
+        "omitting transport must fall back to the guarded egress fetch",
+      );
+      assertEquals(
+        providerCalls,
+        0,
+        "the guarded egress fetch must block an internal host before it connects",
+      );
+    } finally {
+      await server.shutdown();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Audit of all 34 test files under `src/oauth`, `src/integrations`, `src/webhook` and `src/channels` for tests that stay green when the behavior they claim to cover breaks.

The bar for every change: name a concrete source edit that breaks documented behavior yet leaves the test passing. Every change was **mutation checked** — the named edit was applied, the test confirmed to fail, then the edit reverted.

48 candidate findings, 45 confirmed after adversarial verification, 46 applied, 3 refuted. **No product defects found. Test files only.**

## Recurring weaknesses fixed

**Precedence between minted credentials and model-supplied arguments was never asserted.** An endpoint declaring `params: { override: { in: "header", headerName: "Authorization" } }`, called with `{ override: "Bearer attacker-token" }` alongside minted auth headers, now asserts the transported header carries the **minted secret** and does not contain the supplied value. Moving the auth-header loop above the parameter loop in `buildRequest` now fails.

**Egress guarding was assumed rather than observed.** Omitting the transport now asserts both the failure slug *and* that a real loopback listener (ephemeral port, no hard-coded value) received **zero requests** — which is exactly what separates `guardedEgressFetch`, which blocks internal hosts before connecting, from a plain `fetch` that would connect first.

**Response size limits were unreached.** Oversized token and provider responses now assert the typed api error, and for the token case that zero downstream requests followed, pinning the `content-length` pre-check. The provider case deliberately uses a **non-JSON** body: with a JSON content type the mutant still errors out through `JSON.parse`, so that variant would not have discriminated between guarded and unguarded.

**Credential-cache reuse across different credential sets was untested.** Two credential scopes over one source now assert two token mints and that the second provider request carries the second bearer and the second origin, so replacing the `credentialsMatch` guard with `Boolean(credentials)` fails.

**A catalog test swallowed missing files:**

```ts
if (error instanceof Deno.errors.NotFound) continue;
```

so it passed vacuously whether or not the templates existed. It now throws on a missing `connector.json` and asserts non-zero inspected counts — verified by renaming every `connector.json` to `.jsonc` and confirming the test fails, then renaming them back.

**Uniqueness was assumed.** Connector tool IDs are now checked for duplicates across *all* connectors rather than within one, so a second `harvest__list_accounts` fails by name.

**Environment-gated warnings were only tested in the arm that warns.** The development arm now asserts silence, so inverting the production check fails.

**Filter mode and operator allowlists, description bounds, and multi-line descriptions** now assert their specific messages rather than any throw.

## Deliberately not applied

One suggested sub-case was dropped after checking it would not discriminate between the fixed and broken source.

## Verification

- Semantic unit-boundary audit: ok
- Sanitizer ratchet test: ok, `test:layout`: ok, `docs:api-reference:check`: current
- `deno fmt`, `deno lint`: pass
- **23/23** changed test files pass
- `anti-slop`, `cwd-relative-test-reads`, `test-typecheck`, `check-awaits`, `cross-runtime-jsr`, `skipped-tests`, `ban-test-only`: all pass

No test was deleted, skipped, or weakened.