### PR TITLE
Harden workflow definition snapshots

### DIFF
--- a/src/workflow/executor/workflow-definition-snapshot.test.ts
+++ b/src/workflow/executor/workflow-definition-snapshot.test.ts
@@ -1,9 +1,18 @@
 import "#veryfront/schemas/_test-setup.ts";
 
+import { VeryfrontError } from "#veryfront/errors";
 import { assert, assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { WaitNodeConfig, WorkflowDefinition, WorkflowNode } from "../types.ts";
-import { captureWorkflowDefinition } from "./workflow-definition-snapshot.ts";
+import {
+  captureWorkflowDefinition,
+  captureWorkflowDefinitions,
+  captureWorkflowMapItems,
+  captureWorkflowNodes,
+  captureWorkflowStaticValue,
+  captureWorkflowStringList,
+  cloneCapturedWorkflowStaticValue,
+} from "./workflow-definition-snapshot.ts";
 
 function workflowWith(node: WorkflowNode): WorkflowDefinition {
   return { id: "test-workflow", steps: [node] };
@@ -124,7 +133,7 @@ describe("workflow definition snapshot", () => {
           timeout: hostile as unknown as number,
           steps: [step()],
         }),
-      Error,
+      VeryfrontError,
       "timeout must be a string or number",
     );
     assertThrows(
@@ -132,7 +141,7 @@ describe("workflow definition snapshot", () => {
         captureWorkflowDefinition(workflowWith(step({
           retry: { backoff: hostile },
         }))),
-      Error,
+      VeryfrontError,
       "retry backoff must be a string",
     );
     assertThrows(
@@ -147,7 +156,7 @@ describe("workflow definition snapshot", () => {
             iterationTimeout: hostile as unknown as number,
           },
         })),
-      Error,
+      VeryfrontError,
       "iterationTimeout must be a string or number",
     );
 
@@ -157,17 +166,17 @@ describe("workflow definition snapshot", () => {
   it("rejects invalid executable step contracts at admission", () => {
     assertThrows(
       () => captureWorkflowDefinition(workflowWith(step({ tool: undefined }))),
-      Error,
+      VeryfrontError,
       "must configure exactly one of agent or tool",
     );
     assertThrows(
       () => captureWorkflowDefinition(workflowWith(step({ agent: "agent" }))),
-      Error,
+      VeryfrontError,
       "must configure exactly one of agent or tool",
     );
     assertThrows(
       () => captureWorkflowDefinition(workflowWith(step({ timeout: 0 }))),
-      Error,
+      VeryfrontError,
       "timeout must be greater than zero",
     );
   });
@@ -201,8 +210,91 @@ describe("workflow definition snapshot", () => {
 
     assertThrows(
       () => captureWorkflowDefinition({ id: "proxy-builder", steps: builder }),
-      Error,
+      VeryfrontError,
       "steps builder must be a non-Proxy function",
+    );
+    assertEquals(calls, 0);
+  });
+
+  it("captures and clones static helper values without retaining caller state", () => {
+    const source = { nested: { count: 1 } };
+    const captured = captureWorkflowStaticValue(source, "Static value");
+    const clone = cloneCapturedWorkflowStaticValue(captured, "Static value clone");
+    const mapItems = captureWorkflowMapItems([{ id: "one" }], "Map items");
+
+    source.nested.count = 2;
+    clone.nested.count = 3;
+
+    assertEquals(captured, { nested: { count: 1 } });
+    assertEquals(clone, { nested: { count: 3 } });
+    assertEquals(Object.isFrozen(captured), true);
+    assertEquals(Object.isFrozen(captured.nested), true);
+    assertEquals(mapItems, [{ id: "one" }]);
+    assertEquals(Object.isFrozen(mapItems), true);
+  });
+
+  it("captures definition batches and rejects duplicate workflow IDs", () => {
+    const captured = captureWorkflowDefinitions([
+      { id: "first", steps: [step()] },
+      { id: "second", steps: [step({ tool: "second-tool" })] },
+    ]);
+
+    assertEquals(captured.map((workflow) => workflow.id), ["first", "second"]);
+    assertEquals(Object.isFrozen(captured), true);
+    assertThrows(
+      () =>
+        captureWorkflowDefinitions([
+          { id: "duplicate", steps: [step()] },
+          { id: "duplicate", steps: [step({ tool: "other-tool" })] },
+        ]),
+      VeryfrontError,
+      "Workflow already registered in batch",
+    );
+  });
+
+  it("captures canonical string lists and rejects duplicate entries", () => {
+    const source = ["first", "second"];
+    const captured = captureWorkflowStringList(source, "Approvers", {
+      requireNonEmpty: true,
+    });
+
+    source[0] = "changed";
+
+    assertEquals(captured, ["first", "second"]);
+    assertEquals(Object.isFrozen(captured), true);
+    assertThrows(
+      () => captureWorkflowStringList(["duplicate", "duplicate"], "Approvers"),
+      VeryfrontError,
+      "must not contain duplicate values",
+    );
+  });
+
+  it("validates helper options without invoking accessors", () => {
+    let calls = 0;
+    const nodeOptions = Object.defineProperty({}, "allowEmpty", {
+      enumerable: true,
+      get() {
+        calls++;
+        return true;
+      },
+    });
+    const stringOptions = Object.defineProperty({}, "allowUndefined", {
+      enumerable: true,
+      get() {
+        calls++;
+        return true;
+      },
+    });
+
+    assertThrows(
+      () => captureWorkflowNodes([], "Dynamic nodes", nodeOptions as never),
+      VeryfrontError,
+      "must be an own data property",
+    );
+    assertThrows(
+      () => captureWorkflowStringList(undefined, "Approvers", stringOptions as never),
+      VeryfrontError,
+      "must be an own data property",
     );
     assertEquals(calls, 0);
   });

--- a/src/workflow/executor/workflow-definition-snapshot.ts
+++ b/src/workflow/executor/workflow-definition-snapshot.ts
@@ -25,19 +25,90 @@ import {
 import { INTERNAL_DELAY_EVENT_NAME, INTERNAL_WAIT_KIND_FIELD } from "../timed-wait-state.ts";
 
 const arrayIsArray = Array.isArray;
+const arrayIterator = Array.prototype[Symbol.iterator];
+const dateGetTime = Date.prototype.getTime;
 const MapConstructor = Map;
+const mapForEach = Map.prototype.forEach;
 const mapGet = Map.prototype.get;
 const mapHas = Map.prototype.has;
 const mapSet = Map.prototype.set;
+const NativeSet = Set;
+const NativeWeakSet = WeakSet;
+const numberIsFinite = Number.isFinite;
 const numberIsSafeInteger = Number.isSafeInteger;
 const objectDefineProperty = Object.defineProperty;
 const objectFreeze = Object.freeze;
 const objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 const objectGetPrototypeOf = Object.getPrototypeOf;
+const objectHasOwn = Object.hasOwn;
 const reflectApply = Reflect.apply;
 const reflectOwnKeys = Reflect.ownKeys;
+const setAdd = Set.prototype.add;
 const setHas = Set.prototype.has;
 const StringConstructor = String;
+const stringEndsWith = String.prototype.endsWith;
+const stringTrim = String.prototype.trim;
+const structuredCloneValue = structuredClone;
+const weakSetAdd = WeakSet.prototype.add;
+const weakSetDelete = WeakSet.prototype.delete;
+const weakSetHas = WeakSet.prototype.has;
+
+const structuredCloneTransferList: ArrayBuffer[] = [];
+objectDefineProperty(structuredCloneTransferList, Symbol.iterator, {
+  configurable: false,
+  enumerable: false,
+  value: arrayIterator,
+  writable: false,
+});
+objectFreeze(structuredCloneTransferList);
+const structuredCloneOptions = objectFreeze({ transfer: structuredCloneTransferList });
+
+function appendArrayValue<T>(values: T[], value: T): void {
+  objectDefineProperty(values, values.length, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+}
+
+function mapGetValue<K, V>(values: ReadonlyMap<K, V>, key: K): V | undefined {
+  return reflectApply(mapGet, values, [key]);
+}
+
+function mapHasKey<K, V>(values: ReadonlyMap<K, V>, key: K): boolean {
+  return reflectApply(mapHas, values, [key]) as boolean;
+}
+
+function mapSetValue<K, V>(values: Map<K, V>, key: K, value: V): void {
+  reflectApply(mapSet, values, [key, value]);
+}
+
+function setHasValue<T>(values: ReadonlySet<T>, value: T): boolean {
+  return reflectApply(setHas, values, [value]) as boolean;
+}
+
+function setAddValue<T>(values: Set<T>, value: T): void {
+  reflectApply(setAdd, values, [value]);
+}
+
+function weakSetHasValue<T extends object>(values: WeakSet<T>, value: T): boolean {
+  return reflectApply(weakSetHas, values, [value]) as boolean;
+}
+
+function weakSetAddValue<T extends object>(values: WeakSet<T>, value: T): void {
+  reflectApply(weakSetAdd, values, [value]);
+}
+
+function weakSetDeleteValue<T extends object>(values: WeakSet<T>, value: T): void {
+  reflectApply(weakSetDelete, values, [value]);
+}
+
+function hasDescriptorValue(
+  descriptor: PropertyDescriptor,
+): descriptor is PropertyDescriptor & { value: unknown } {
+  return objectHasOwn(descriptor, "value");
+}
 
 const DEFINITION_KEYS = new Set([
   "id",
@@ -54,6 +125,8 @@ const DEFINITION_KEYS = new Set([
   "onComplete",
 ]);
 const CAPTURE_DEFINITION_OPTION_KEYS = new Set(["allowEmptySteps"]);
+const CAPTURE_NODE_OPTION_KEYS = new Set(["allowEmpty", "emptyElementName"]);
+const CAPTURE_STRING_LIST_OPTION_KEYS = new Set(["allowUndefined", "requireNonEmpty"]);
 const NODE_KEYS = new Set(["id", "config", "dependsOn"]);
 const RETRY_KEYS = new Set([
   "maxAttempts",
@@ -97,6 +170,17 @@ const CONFIG_KEYS = {
     "delay",
   ]),
 } as const;
+const ALL_CONFIG_KEYS = new Set([
+  ...CONFIG_KEYS.step,
+  ...CONFIG_KEYS.parallel,
+  ...CONFIG_KEYS.branch,
+  ...CONFIG_KEYS.wait,
+  ...CONFIG_KEYS.subWorkflow,
+  ...CONFIG_KEYS.map,
+  ...CONFIG_KEYS.loop,
+]);
+const MAP_PROCESSOR_KEYS = new Set([...DEFINITION_KEYS, ...NODE_KEYS]);
+const PARALLEL_STRATEGIES = new Set(["all", "race", "allSettled"]);
 
 const RESERVED_CONTEXT_NODE_IDS = new Set(["input", "env", "_tenant", "_loop"]);
 const LOOP_STATE_SUFFIX = "_loop_state";
@@ -164,8 +248,8 @@ interface ExactRecord {
 
 function createCaptureState(): CaptureState {
   return {
-    activeDefinitions: new WeakSet(),
-    activeNodes: new WeakSet(),
+    activeDefinitions: new NativeWeakSet(),
+    activeNodes: new NativeWeakSet(),
     staticBudget: { bytes: 0, values: 0 },
     nodeCount: 0,
   };
@@ -256,7 +340,7 @@ function inspectExactRecord(
     } catch (cause) {
       fail(`${label} field "${key}" could not be inspected`, cause);
     }
-    if (!descriptor || !("value" in descriptor)) {
+    if (!descriptor || !hasDescriptorValue(descriptor)) {
       fail(`${label} field "${key}" must be an own data property`);
     }
     reflectApply(mapSet, fields, [key, descriptor.value]);
@@ -291,7 +375,7 @@ function inspectDenseArrayValues(value: unknown, label: string): unknown[] {
   } catch (cause) {
     fail(`${label} could not be inspected`, cause);
   }
-  const length = lengthDescriptor && "value" in lengthDescriptor
+  const length = lengthDescriptor && hasDescriptorValue(lengthDescriptor)
     ? lengthDescriptor.value
     : undefined;
   if (!numberIsSafeInteger(length) || length < 0) fail(`${label} has an invalid length`);
@@ -316,7 +400,7 @@ function inspectDenseArrayValues(value: unknown, label: string): unknown[] {
     } catch (cause) {
       fail(`${label} entry ${index} could not be inspected`, cause);
     }
-    if (!descriptor || !("value" in descriptor)) {
+    if (!descriptor || !hasDescriptorValue(descriptor)) {
       fail(`${label} must be dense; entry ${index} is missing or is an accessor`);
     }
     objectDefineProperty(values, index, {
@@ -337,7 +421,8 @@ function assertString(
 ): asserts value is string {
   if (
     typeof value !== "string" || value.length > maxLength ||
-    (requireCanonical && (value.length === 0 || value.trim() !== value))
+    (requireCanonical &&
+      (value.length === 0 || reflectApply(stringTrim, value, []) !== value))
   ) {
     fail(
       requireCanonical
@@ -384,14 +469,17 @@ function assertDurationValue(
 
 function assertNodeId(value: unknown, label: string): asserts value is string {
   assertString(value, label, MAX_WORKFLOW_DEFINITION_ID_CODE_UNITS, true);
-  if (RESERVED_CONTEXT_NODE_IDS.has(value) || value.endsWith(LOOP_STATE_SUFFIX)) {
+  if (
+    setHasValue(RESERVED_CONTEXT_NODE_IDS, value) ||
+    reflectApply(stringEndsWith, value, [LOOP_STATE_SUFFIX])
+  ) {
     fail(`${label} uses reserved workflow context namespace "${value}"`);
   }
 }
 
 function callGetter(getter: ((this: unknown) => unknown) | undefined, value: object): unknown {
   if (!getter) return undefined;
-  return Reflect.apply(getter, value, []);
+  return reflectApply(getter, value, []);
 }
 
 function tryGetter(
@@ -409,7 +497,7 @@ function tryGetter(
 function assertNoOwnFields(value: object, label: string): void {
   let keys: PropertyKey[];
   try {
-    keys = Reflect.ownKeys(value);
+    keys = reflectOwnKeys(value);
   } catch (cause) {
     fail(`${label} could not be inspected`, cause);
   }
@@ -444,14 +532,14 @@ function inspectStaticValue(
   if (typeof value !== "object" || isProxyWithoutHooks(value)) {
     fail(`${label} must contain only non-Proxy structured-cloneable data`);
   }
-  if (state.active.has(value)) fail(`${label} must not contain recursive references`);
-  if (state.seen.has(value)) return;
-  state.seen.add(value);
-  state.active.add(value);
+  if (weakSetHasValue(state.active, value)) fail(`${label} must not contain recursive references`);
+  if (weakSetHasValue(state.seen, value)) return;
+  weakSetAddValue(state.seen, value);
+  weakSetAddValue(state.active, value);
   addBudget(state.budget, label);
 
   try {
-    if (Array.isArray(value)) {
+    if (arrayIsArray(value)) {
       const entries = inspectDenseArrayValues(value, label);
       for (let index = 0; index < entries.length; index++) {
         inspectStaticValue(entries[index], `${label}[${index}]`, state, depth + 1);
@@ -461,13 +549,13 @@ function inspectStaticValue(
 
     const date = (() => {
       try {
-        return { matched: true, value: Date.prototype.getTime.call(value) };
+        return { matched: true, value: reflectApply(dateGetTime, value, []) };
       } catch {
         return { matched: false, value: 0 };
       }
     })();
     if (date.matched) {
-      if (!Number.isFinite(date.value)) fail(`${label} must not contain an invalid Date`);
+      if (!numberIsFinite(date.value)) fail(`${label} must not contain an invalid Date`);
       assertNoOwnFields(value, label);
       addBudget(state.budget, label, 0, 8);
       return;
@@ -476,20 +564,20 @@ function inspectStaticValue(
     const mapSize = tryGetter(mapSizeGetter, value);
     if (mapSize.matched) {
       const size = mapSize.value;
-      if (!Number.isSafeInteger(size) || (size as number) < 0) {
+      if (!numberIsSafeInteger(size) || (size as number) < 0) {
         fail(`${label} has invalid Map size`);
       }
       if ((size as number) > MAX_WORKFLOW_DEFINITION_COLLECTION_ENTRIES) {
         fail(`${label} Map contains too many entries`);
       }
       assertNoOwnFields(value, label);
-      const iterator = Reflect.apply(mapEntries, value, []) as IterableIterator<[
+      const iterator = reflectApply(mapEntries, value, []) as IterableIterator<[
         unknown,
         unknown,
       ]>;
       let index = 0;
       while (true) {
-        const next = Reflect.apply(mapIteratorNext, iterator, []) as IteratorResult<[
+        const next = reflectApply(mapIteratorNext, iterator, []) as IteratorResult<[
           unknown,
           unknown,
         ]>;
@@ -504,17 +592,17 @@ function inspectStaticValue(
     const setSize = tryGetter(setSizeGetter, value);
     if (setSize.matched) {
       const size = setSize.value;
-      if (!Number.isSafeInteger(size) || (size as number) < 0) {
+      if (!numberIsSafeInteger(size) || (size as number) < 0) {
         fail(`${label} has invalid Set size`);
       }
       if ((size as number) > MAX_WORKFLOW_DEFINITION_COLLECTION_ENTRIES) {
         fail(`${label} Set contains too many entries`);
       }
       assertNoOwnFields(value, label);
-      const iterator = Reflect.apply(setValues, value, []) as IterableIterator<unknown>;
+      const iterator = reflectApply(setValues, value, []) as IterableIterator<unknown>;
       let index = 0;
       while (true) {
-        const next = Reflect.apply(setIteratorNext, iterator, []) as IteratorResult<unknown>;
+        const next = reflectApply(setIteratorNext, iterator, []) as IteratorResult<unknown>;
         if (next.done) break;
         inspectStaticValue(next.value, `${label} Set value ${index}`, state, depth + 1);
         index++;
@@ -544,7 +632,7 @@ function inspectStaticValue(
     const typedLength = tryGetter(typedArrayLengthGetter, value);
     if (typedLength.matched) {
       const length = typedLength.value as number;
-      if (!Number.isSafeInteger(length) || length < 0) {
+      if (!numberIsSafeInteger(length) || length < 0) {
         fail(`${label} has invalid typed-array length`);
       }
       if (length > MAX_WORKFLOW_DEFINITION_COLLECTION_ENTRIES) {
@@ -555,14 +643,14 @@ function inspectStaticValue(
       if (isSharedArrayBuffer(buffer)) fail(`${label} must not view shared memory`);
       let keys: PropertyKey[];
       try {
-        keys = Reflect.ownKeys(value);
+        keys = reflectOwnKeys(value);
       } catch (cause) {
         fail(`${label} could not be inspected`, cause);
       }
       if (keys.length !== length) fail(`${label} typed array must not contain custom properties`);
       for (let index = 0; index < length; index++) {
-        const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
-        if (!descriptor || !("value" in descriptor)) {
+        const descriptor = objectGetOwnPropertyDescriptor(value, StringConstructor(index));
+        if (!descriptor || !hasDescriptorValue(descriptor)) {
           fail(`${label} typed-array entry ${index} is not canonical`);
         }
       }
@@ -572,60 +660,63 @@ function inspectStaticValue(
 
     const regexp = tryGetter(regexpSourceGetter, value);
     if (regexp.matched) {
-      const keys = Reflect.ownKeys(value);
+      const keys = reflectOwnKeys(value);
       if (keys.length !== 1 || keys[0] !== "lastIndex") {
         fail(`${label} RegExp must not contain custom properties`);
       }
-      const lastIndex = Object.getOwnPropertyDescriptor(value, "lastIndex");
-      if (!lastIndex || !("value" in lastIndex) || lastIndex.value !== 0) {
+      const lastIndex = objectGetOwnPropertyDescriptor(value, "lastIndex");
+      if (!lastIndex || !hasDescriptorValue(lastIndex) || lastIndex.value !== 0) {
         fail(`${label} RegExp lastIndex must be zero`);
       }
-      addBudget(state.budget, label, 0, String(regexp.value).length * 2);
+      addBudget(state.budget, label, 0, StringConstructor(regexp.value).length * 2);
       return;
     }
 
     assertPlainStructuralRecord(value, label);
     let keys: PropertyKey[];
     try {
-      keys = Reflect.ownKeys(value);
+      keys = reflectOwnKeys(value);
     } catch (cause) {
       fail(`${label} could not be inspected`, cause);
     }
     if (keys.length > MAX_WORKFLOW_DEFINITION_COLLECTION_ENTRIES) {
       fail(`${label} record contains too many fields`);
     }
-    for (const key of keys) {
+    for (let index = 0; index < keys.length; index++) {
+      const key = keys[index]!;
       if (typeof key !== "string") fail(`${label} must not contain symbol keys`);
       if (key.length > MAX_WORKFLOW_DEFINITION_TEXT_CODE_UNITS) {
         fail(`${label} contains an overlong record key`);
       }
-      const descriptor = Object.getOwnPropertyDescriptor(value, key);
-      if (!descriptor || !("value" in descriptor) || descriptor.enumerable !== true) {
+      const descriptor = objectGetOwnPropertyDescriptor(value, key);
+      if (!descriptor || !hasDescriptorValue(descriptor) || descriptor.enumerable !== true) {
         fail(`${label} field "${key}" must be an enumerable own data property`);
       }
       addBudget(state.budget, label, 0, key.length * 2);
       inspectStaticValue(descriptor.value, `${label}.${key}`, state, depth + 1);
     }
   } finally {
-    state.active.delete(value);
+    weakSetDeleteValue(state.active, value);
   }
 }
 
-function freezeStaticSnapshot<T>(value: T, seen = new WeakSet<object>()): T {
-  if (typeof value !== "object" || value === null || seen.has(value)) return value;
-  seen.add(value);
-  if (Array.isArray(value)) {
-    for (const entry of value) freezeStaticSnapshot(entry, seen);
+function freezeStaticSnapshot<T>(value: T, seen = new NativeWeakSet<object>()): T {
+  if (typeof value !== "object" || value === null || weakSetHasValue(seen, value)) return value;
+  weakSetAddValue(seen, value);
+  if (arrayIsArray(value)) {
+    for (let index = 0; index < value.length; index++) {
+      freezeStaticSnapshot(value[index], seen);
+    }
     return objectFreeze(value);
   }
   const mapSize = tryGetter(mapSizeGetter, value);
   if (mapSize.matched) {
-    const iterator = Reflect.apply(mapEntries, value, []) as IterableIterator<[
+    const iterator = reflectApply(mapEntries, value, []) as IterableIterator<[
       unknown,
       unknown,
     ]>;
     while (true) {
-      const next = Reflect.apply(mapIteratorNext, iterator, []) as IteratorResult<[
+      const next = reflectApply(mapIteratorNext, iterator, []) as IteratorResult<[
         unknown,
         unknown,
       ]>;
@@ -637,18 +728,21 @@ function freezeStaticSnapshot<T>(value: T, seen = new WeakSet<object>()): T {
   }
   const setSize = tryGetter(setSizeGetter, value);
   if (setSize.matched) {
-    const iterator = Reflect.apply(setValues, value, []) as IterableIterator<unknown>;
+    const iterator = reflectApply(setValues, value, []) as IterableIterator<unknown>;
     while (true) {
-      const next = Reflect.apply(setIteratorNext, iterator, []) as IteratorResult<unknown>;
+      const next = reflectApply(setIteratorNext, iterator, []) as IteratorResult<unknown>;
       if (next.done) break;
       freezeStaticSnapshot(next.value, seen);
     }
     return objectFreeze(value);
   }
   if (tryGetter(typedArrayLengthGetter, value).matched) return value;
-  for (const key of Reflect.ownKeys(value)) {
-    const descriptor = Object.getOwnPropertyDescriptor(value, key);
-    if (descriptor && "value" in descriptor) freezeStaticSnapshot(descriptor.value, seen);
+  const keys = reflectOwnKeys(value);
+  for (let index = 0; index < keys.length; index++) {
+    const descriptor = objectGetOwnPropertyDescriptor(value, keys[index]!);
+    if (descriptor && hasDescriptorValue(descriptor)) {
+      freezeStaticSnapshot(descriptor.value, seen);
+    }
   }
   return objectFreeze(value);
 }
@@ -661,11 +755,11 @@ function captureStaticValueWithBudget<T>(
   inspectStaticValue(
     value,
     label,
-    { active: new WeakSet(), seen: new WeakSet(), budget },
+    { active: new NativeWeakSet(), seen: new NativeWeakSet(), budget },
     0,
   );
   try {
-    return freezeStaticSnapshot(structuredClone(value));
+    return freezeStaticSnapshot(structuredCloneValue(value, structuredCloneOptions));
   } catch (cause) {
     fail(`${label} must contain only structured-cloneable values`, cause);
   }
@@ -681,11 +775,15 @@ export function cloneCapturedWorkflowStaticValue<T>(value: T, label: string): T 
   inspectStaticValue(
     value,
     label,
-    { active: new WeakSet(), seen: new WeakSet(), budget: { bytes: 0, values: 0 } },
+    {
+      active: new NativeWeakSet(),
+      seen: new NativeWeakSet(),
+      budget: { bytes: 0, values: 0 },
+    },
     0,
   );
   try {
-    return structuredClone(value);
+    return structuredCloneValue(value, structuredCloneOptions);
   } catch (cause) {
     fail(`${label} must contain only structured-cloneable values`, cause);
   }
@@ -702,16 +800,30 @@ export function captureWorkflowStringList(
   label: string,
   options: CaptureWorkflowStringListOptions = {},
 ): string[] | undefined {
-  if (value === undefined && options.allowUndefined) return undefined;
+  const optionFields = inspectExactRecord(
+    options,
+    `${label} capture options`,
+    CAPTURE_STRING_LIST_OPTION_KEYS,
+  );
+  const allowUndefined = optionFields.get("allowUndefined");
+  const requireNonEmpty = optionFields.get("requireNonEmpty");
+  if (allowUndefined !== undefined && typeof allowUndefined !== "boolean") {
+    fail(`${label} capture option allowUndefined must be a boolean`);
+  }
+  if (requireNonEmpty !== undefined && typeof requireNonEmpty !== "boolean") {
+    fail(`${label} capture option requireNonEmpty must be a boolean`);
+  }
+  if (value === undefined && allowUndefined) return undefined;
   const entries = inspectDenseArrayValues(value, label);
-  if (options.requireNonEmpty && entries.length === 0) fail(`${label} must not be empty`);
+  if (requireNonEmpty && entries.length === 0) fail(`${label} must not be empty`);
   const captured: string[] = [];
-  const seen = new Set<string>();
-  for (const entry of entries) {
+  const seen = new NativeSet<string>();
+  for (let index = 0; index < entries.length; index++) {
+    const entry = entries[index];
     assertString(entry, `${label} entry`, MAX_WORKFLOW_DEFINITION_ID_CODE_UNITS, true);
-    if (seen.has(entry)) fail(`${label} must not contain duplicate values`);
-    seen.add(entry);
-    captured.push(entry);
+    if (setHasValue(seen, entry)) fail(`${label} must not contain duplicate values`);
+    setAddValue(seen, entry);
+    appendArrayValue(captured, entry);
   }
   return objectFreeze(captured) as string[];
 }
@@ -750,7 +862,9 @@ function captureRetryConfig(value: unknown, label: string): RetryConfig | undefi
 function captureDependencies(value: unknown, label: string): string[] | undefined {
   if (value === undefined) return undefined;
   const captured = captureWorkflowStringList(value, `${label} dependsOn`) ?? [];
-  for (const dependency of captured) assertNodeId(dependency, `${label} dependency`);
+  for (let index = 0; index < captured.length; index++) {
+    assertNodeId(captured[index], `${label} dependency`);
+  }
   return captured;
 }
 
@@ -785,11 +899,11 @@ function captureNodeConfig(
   const typeFields = inspectExactRecord(
     value,
     `${label} config`,
-    new Set(Object.values(CONFIG_KEYS).flatMap((keys) => [...keys])),
+    ALL_CONFIG_KEYS,
     ["type"],
   );
   const type = typeFields.get("type");
-  if (typeof type !== "string" || !Object.hasOwn(CONFIG_KEYS, type)) {
+  if (typeof type !== "string" || !objectHasOwn(CONFIG_KEYS, type)) {
     fail(`${label} has unsupported config type`);
   }
   const fields = inspectExactRecord(
@@ -841,7 +955,10 @@ function captureNodeConfig(
     }
     case "parallel": {
       const strategy = fields.get("strategy");
-      if (strategy !== undefined && !["all", "race", "allSettled"].includes(strategy as string)) {
+      if (
+        strategy !== undefined &&
+        !setHasValue(PARALLEL_STRATEGIES, strategy as string)
+      ) {
         fail(`${label} parallel strategy is invalid`);
       }
       return objectFreeze({
@@ -965,7 +1082,7 @@ function captureNodeConfig(
     case "map": {
       const items = fields.get("items");
       if (items === undefined) fail(`${label} map items are required`);
-      if (typeof items !== "function" && !Array.isArray(items)) {
+      if (typeof items !== "function" && !arrayIsArray(items)) {
         fail(`${label} map items must be an array or builder function`);
       }
       if (typeof items === "function") assertFunction(items, `${label} map items builder`);
@@ -976,7 +1093,7 @@ function captureNodeConfig(
       const processorFields = inspectExactRecord(
         processor,
         `${label} map processor`,
-        new Set([...DEFINITION_KEYS, ...NODE_KEYS]),
+        MAP_PROCESSOR_KEYS,
       );
       const capturedProcessor = processorFields.has("steps")
         ? captureDefinition(processor as WorkflowDefinition, state, depth + 1, true)
@@ -984,7 +1101,7 @@ function captureNodeConfig(
       const concurrency = fields.get("concurrency");
       if (
         concurrency !== undefined &&
-        (!Number.isSafeInteger(concurrency) || (concurrency as number) < 1)
+        (!numberIsSafeInteger(concurrency) || (concurrency as number) < 1)
       ) {
         fail(`${label} map concurrency must be a positive safe integer`);
       }
@@ -1000,13 +1117,13 @@ function captureNodeConfig(
       const condition = fields.get("while");
       assertFunction(condition, `${label} loop while`);
       const steps = fields.get("steps");
-      if (typeof steps !== "function" && !Array.isArray(steps)) {
+      if (typeof steps !== "function" && !arrayIsArray(steps)) {
         fail(`${label} loop steps must be an array or builder function`);
       }
       if (typeof steps === "function") assertFunction(steps, `${label} loop steps builder`);
       const maxIterations = fields.get("maxIterations");
       if (
-        !Number.isSafeInteger(maxIterations) || (maxIterations as number) < 1 ||
+        !numberIsSafeInteger(maxIterations) || (maxIterations as number) < 1 ||
         (maxIterations as number) > 100
       ) {
         fail(`${label} loop maxIterations must be an integer between 1 and 100`);
@@ -1055,8 +1172,10 @@ function captureNode(
     fail(`Workflow definition cannot contain more than ${MAX_WORKFLOW_DEFINITION_NODES} nodes`);
   }
   const object = value as object;
-  if (state.activeNodes.has(object)) fail(`${label} contains a recursive node reference`);
-  state.activeNodes.add(object);
+  if (weakSetHasValue(state.activeNodes, object)) {
+    fail(`${label} contains a recursive node reference`);
+  }
+  weakSetAddValue(state.activeNodes, object);
   try {
     return objectFreeze({
       id,
@@ -1066,37 +1185,51 @@ function captureNode(
         : {}),
     });
   } finally {
-    state.activeNodes.delete(object);
+    weakSetDeleteValue(state.activeNodes, object);
   }
 }
 
 function validateDependencyGraph(nodes: readonly WorkflowNode[], label: string): void {
-  const byId = new Map<string, WorkflowNode>();
-  const dependents = new Map<string, string[]>();
-  const indegree = new Map<string, number>();
-  for (const node of nodes) {
-    if (byId.has(node.id)) fail(`${label} has duplicate node ID "${node.id}"`);
-    byId.set(node.id, node);
-    dependents.set(node.id, []);
-    indegree.set(node.id, 0);
+  const byId = new MapConstructor<string, WorkflowNode>();
+  const dependents = new MapConstructor<string, string[]>();
+  const indegree = new MapConstructor<string, number>();
+  for (let index = 0; index < nodes.length; index++) {
+    const node = nodes[index]!;
+    if (mapHasKey(byId, node.id)) fail(`${label} has duplicate node ID "${node.id}"`);
+    mapSetValue(byId, node.id, node);
+    mapSetValue(dependents, node.id, []);
+    mapSetValue(indegree, node.id, 0);
   }
-  for (const node of nodes) {
-    for (const dependency of node.dependsOn ?? []) {
-      const targets = dependents.get(dependency);
+  for (let index = 0; index < nodes.length; index++) {
+    const node = nodes[index]!;
+    const dependencies = objectHasOwn(node, "dependsOn") ? node.dependsOn ?? [] : [];
+    for (let dependencyIndex = 0; dependencyIndex < dependencies.length; dependencyIndex++) {
+      const dependency = dependencies[dependencyIndex]!;
+      const targets = mapGetValue(dependents, dependency);
       if (!targets) fail(`${label} node "${node.id}" depends on unknown node "${dependency}"`);
-      targets.push(node.id);
-      indegree.set(node.id, (indegree.get(node.id) ?? 0) + 1);
+      appendArrayValue(targets, node.id);
+      mapSetValue(indegree, node.id, (mapGetValue(indegree, node.id) ?? 0) + 1);
     }
   }
   const queue: string[] = [];
-  for (const [id, degree] of indegree) if (degree === 0) queue.push(id);
+  reflectApply(mapForEach, indegree, [
+    (degree: number, id: string) => {
+      if (degree === 0) appendArrayValue(queue, id);
+    },
+  ]);
   let visited = 0;
   for (let index = 0; index < queue.length; index++) {
     visited++;
-    for (const dependent of dependents.get(queue[index]!) ?? []) {
-      const next = (indegree.get(dependent) ?? 0) - 1;
-      indegree.set(dependent, next);
-      if (next === 0) queue.push(dependent);
+    const currentDependents = mapGetValue(dependents, queue[index]!) ?? [];
+    for (
+      let dependentIndex = 0;
+      dependentIndex < currentDependents.length;
+      dependentIndex++
+    ) {
+      const dependent = currentDependents[dependentIndex]!;
+      const next = (mapGetValue(indegree, dependent) ?? 0) - 1;
+      mapSetValue(indegree, dependent, next);
+      if (next === 0) appendArrayValue(queue, dependent);
     }
   }
   if (visited !== nodes.length) fail(`${label} contains a dependency cycle`);
@@ -1117,7 +1250,10 @@ function captureNodeList(
   }
   const captured: WorkflowNode[] = [];
   for (let index = 0; index < values.length; index++) {
-    captured.push(captureNode(values[index], `${label} node at index ${index}`, state, depth));
+    appendArrayValue(
+      captured,
+      captureNode(values[index], `${label} node at index ${index}`, state, depth),
+    );
   }
   validateDependencyGraph(captured, label);
   return objectFreeze(captured) as WorkflowNode[];
@@ -1165,10 +1301,10 @@ function captureDefinition<TInput, TOutput>(
   }
 
   const object = value as object;
-  if (state.activeDefinitions.has(object)) {
+  if (weakSetHasValue(state.activeDefinitions, object)) {
     fail(`Workflow "${id}" contains a recursive static definition reference`);
   }
-  state.activeDefinitions.add(object);
+  weakSetAddValue(state.activeDefinitions, object);
   try {
     const steps = typeof stepsValue === "function" ? stepsValue : captureNodeList(
       stepsValue,
@@ -1193,7 +1329,7 @@ function captureDefinition<TInput, TOutput>(
       ...(fields.has("onComplete") ? { onComplete } : {}),
     }) as WorkflowDefinition<TInput, TOutput>;
   } finally {
-    state.activeDefinitions.delete(object);
+    weakSetDeleteValue(state.activeDefinitions, object);
   }
 }
 
@@ -1231,12 +1367,15 @@ export function captureWorkflowDefinitions(
   const values = inspectDenseArrayValues(workflows, "Workflow definitions");
   const state = createCaptureState();
   const captured: WorkflowDefinition[] = [];
-  const seenIds = new Set<string>();
-  for (const value of values) {
+  const seenIds = new NativeSet<string>();
+  for (let index = 0; index < values.length; index++) {
+    const value = values[index];
     const workflow = captureDefinition(value, state, 0);
-    if (seenIds.has(workflow.id)) fail(`Workflow already registered in batch: ${workflow.id}`);
-    seenIds.add(workflow.id);
-    captured.push(workflow);
+    if (setHasValue(seenIds, workflow.id)) {
+      fail(`Workflow already registered in batch: ${workflow.id}`);
+    }
+    setAddValue(seenIds, workflow.id);
+    appendArrayValue(captured, workflow);
   }
   return objectFreeze(captured) as WorkflowDefinition[];
 }
@@ -1250,13 +1389,29 @@ export function captureWorkflowNodes(
     emptyElementName?: "node" | "step";
   }> = {},
 ): WorkflowNode[] {
+  const optionFields = inspectExactRecord(
+    options,
+    `${label} capture options`,
+    CAPTURE_NODE_OPTION_KEYS,
+  );
+  const allowEmpty = optionFields.get("allowEmpty");
+  const emptyElementName = optionFields.get("emptyElementName");
+  if (allowEmpty !== undefined && typeof allowEmpty !== "boolean") {
+    fail(`${label} capture option allowEmpty must be a boolean`);
+  }
+  if (
+    emptyElementName !== undefined &&
+    emptyElementName !== "node" && emptyElementName !== "step"
+  ) {
+    fail(`${label} capture option emptyElementName must be "node" or "step"`);
+  }
   return captureNodeList(
     value,
     label,
     createCaptureState(),
     0,
-    options.allowEmpty ?? false,
-    options.emptyElementName ?? "node",
+    allowEmpty ?? false,
+    emptyElementName ?? "node",
   );
 }
 

--- a/tests/integration/workflow/workflow-definition-snapshot-intrinsics.test.ts
+++ b/tests/integration/workflow/workflow-definition-snapshot-intrinsics.test.ts
@@ -1,0 +1,225 @@
+import "#veryfront/schemas/_test-setup.ts";
+
+import { VeryfrontError } from "#veryfront/errors";
+import { assertEquals, assertInstanceOf, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  captureWorkflowDefinition,
+  captureWorkflowStaticValue,
+} from "#veryfront/workflow/executor/workflow-definition-snapshot.ts";
+import type { WorkflowDefinition, WorkflowNode } from "#veryfront/workflow/types.ts";
+
+function stepNode(id: string): WorkflowNode {
+  return { id, config: { type: "step", tool: `${id}-tool` } };
+}
+
+describe("workflow definition snapshots with hostile ambient intrinsics", () => {
+  it("captures structured values without live reflection and brand helpers", () => {
+    const input = {
+      array: [{ nested: "value" }],
+      bytes: new Uint8Array([1, 2]),
+      date: new Date("2026-01-02T03:04:05.000Z"),
+      map: new Map([["key", { count: 1 }]]),
+      regexp: /value/u,
+      set: new Set(["entry"]),
+    };
+    const originalArrayIsArray = Array.isArray;
+    const originalDateGetTime = Date.prototype.getTime;
+    const originalNumberIsFinite = Number.isFinite;
+    const originalNumberIsSafeInteger = Number.isSafeInteger;
+    const originalGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+    const originalReflectApply = Reflect.apply;
+    const originalReflectOwnKeys = Reflect.ownKeys;
+    const OriginalString = String;
+    let poisonCalls = 0;
+    const poison = (): never => {
+      poisonCalls++;
+      throw new Error("ambient static-value intrinsic must not run");
+    };
+    let captured: typeof input | undefined;
+
+    try {
+      Array.isArray = poison as unknown as typeof Array.isArray;
+      Date.prototype.getTime = poison;
+      Number.isFinite = poison;
+      Number.isSafeInteger = poison;
+      Object.getOwnPropertyDescriptor = poison as typeof Object.getOwnPropertyDescriptor;
+      Reflect.apply = poison as typeof Reflect.apply;
+      Reflect.ownKeys = poison as typeof Reflect.ownKeys;
+      globalThis.String = poison as unknown as StringConstructor;
+      captured = captureWorkflowStaticValue(input, "Static input");
+    } finally {
+      Array.isArray = originalArrayIsArray;
+      Date.prototype.getTime = originalDateGetTime;
+      Number.isFinite = originalNumberIsFinite;
+      Number.isSafeInteger = originalNumberIsSafeInteger;
+      Object.getOwnPropertyDescriptor = originalGetOwnPropertyDescriptor;
+      Reflect.apply = originalReflectApply;
+      Reflect.ownKeys = originalReflectOwnKeys;
+      globalThis.String = OriginalString;
+    }
+
+    assertEquals(poisonCalls, 0);
+    assertEquals(captured, input);
+    assertEquals(captured === input, false);
+  });
+
+  it("captures nested arrays without live clone, iterator, or WeakSet helpers", () => {
+    const input = [{ nested: ["value"] }];
+    const originalArrayIterator = Array.prototype[Symbol.iterator];
+    const originalStructuredClone = structuredClone;
+    const OriginalWeakSet = WeakSet;
+    const originalWeakSetAdd = WeakSet.prototype.add;
+    const originalWeakSetDelete = WeakSet.prototype.delete;
+    const originalWeakSetHas = WeakSet.prototype.has;
+    let poisonCalls = 0;
+    const poison = (): never => {
+      poisonCalls++;
+      throw new Error("ambient static-value traversal must not run");
+    };
+    let captured: typeof input | undefined;
+
+    try {
+      Array.prototype[Symbol.iterator] = poison;
+      globalThis.structuredClone = poison;
+      WeakSet.prototype.add = poison;
+      WeakSet.prototype.delete = poison;
+      WeakSet.prototype.has = poison;
+      globalThis.WeakSet = poison as unknown as WeakSetConstructor;
+      captured = captureWorkflowStaticValue(input, "Nested input");
+    } finally {
+      Array.prototype[Symbol.iterator] = originalArrayIterator;
+      globalThis.structuredClone = originalStructuredClone;
+      globalThis.WeakSet = OriginalWeakSet;
+      WeakSet.prototype.add = originalWeakSetAdd;
+      WeakSet.prototype.delete = originalWeakSetDelete;
+      WeakSet.prototype.has = originalWeakSetHas;
+    }
+
+    assertEquals(poisonCalls, 0);
+    assertEquals(captured, input);
+    assertEquals(Object.isFrozen(captured), true);
+    assertEquals(Object.isFrozen(captured?.[0]), true);
+  });
+
+  it("rejects accessors under descriptor prototype pollution without invoking hooks", () => {
+    const originalValue = Object.getOwnPropertyDescriptor(Object.prototype, "value");
+    let accessorCalls = 0;
+    let pollutionCalls = 0;
+    const input = Object.defineProperty({}, "secret", {
+      enumerable: true,
+      get() {
+        accessorCalls++;
+        return "secret";
+      },
+    });
+    let error: unknown;
+
+    try {
+      Object.defineProperty(Object.prototype, "value", {
+        configurable: true,
+        get() {
+          pollutionCalls++;
+          return "forged";
+        },
+      });
+      error = assertThrows(() => captureWorkflowStaticValue(input, "Accessor input"));
+    } finally {
+      if (originalValue) Object.defineProperty(Object.prototype, "value", originalValue);
+      else Reflect.deleteProperty(Object.prototype, "value");
+    }
+
+    assertInstanceOf(error, VeryfrontError);
+    assertEquals(accessorCalls, 0);
+    assertEquals(pollutionCalls, 0);
+  });
+
+  it("captures workflow graphs without live collection and string helpers", () => {
+    const workflow: WorkflowDefinition = {
+      id: "hostile-graph",
+      steps: [{
+        id: "parallel",
+        config: {
+          type: "parallel",
+          strategy: "all",
+          nodes: [stepNode("nested")],
+        },
+      }, {
+        id: "loop",
+        dependsOn: ["parallel"],
+        config: {
+          type: "loop",
+          while: () => false,
+          steps: [],
+          maxIterations: 1,
+        },
+      }],
+    };
+    const OriginalMap = Map;
+    const originalMapGet = Map.prototype.get;
+    const originalMapHas = Map.prototype.has;
+    const originalMapSet = Map.prototype.set;
+    const originalNumberIsSafeInteger = Number.isSafeInteger;
+    const originalObjectHasOwn = Object.hasOwn;
+    const originalObjectValues = Object.values;
+    const OriginalSet = Set;
+    const originalSetAdd = Set.prototype.add;
+    const originalSetHas = Set.prototype.has;
+    const originalArrayFlatMap = Array.prototype.flatMap;
+    const originalArrayIncludes = Array.prototype.includes;
+    const originalArrayIterator = Array.prototype[Symbol.iterator];
+    const originalArrayPush = Array.prototype.push;
+    const originalStringEndsWith = String.prototype.endsWith;
+    const originalStringTrim = String.prototype.trim;
+    let poisonCalls = 0;
+    const poison = (): never => {
+      poisonCalls++;
+      throw new Error("ambient workflow graph intrinsic must not run");
+    };
+    let captured: WorkflowDefinition | undefined;
+
+    try {
+      Map.prototype.get = poison;
+      Map.prototype.has = poison;
+      Map.prototype.set = poison;
+      Number.isSafeInteger = poison;
+      Object.hasOwn = poison;
+      Object.values = poison;
+      Set.prototype.add = poison;
+      Set.prototype.has = poison;
+      Array.prototype.flatMap = poison;
+      Array.prototype.includes = poison;
+      Array.prototype[Symbol.iterator] = poison;
+      Array.prototype.push = poison;
+      String.prototype.endsWith = poison;
+      String.prototype.trim = poison;
+      globalThis.Map = poison as unknown as MapConstructor;
+      globalThis.Set = poison as unknown as SetConstructor;
+      captured = captureWorkflowDefinition(workflow);
+    } finally {
+      globalThis.Map = OriginalMap;
+      Map.prototype.get = originalMapGet;
+      Map.prototype.has = originalMapHas;
+      Map.prototype.set = originalMapSet;
+      Number.isSafeInteger = originalNumberIsSafeInteger;
+      Object.hasOwn = originalObjectHasOwn;
+      Object.values = originalObjectValues;
+      globalThis.Set = OriginalSet;
+      Set.prototype.add = originalSetAdd;
+      Set.prototype.has = originalSetHas;
+      Array.prototype.flatMap = originalArrayFlatMap;
+      Array.prototype.includes = originalArrayIncludes;
+      Array.prototype[Symbol.iterator] = originalArrayIterator;
+      Array.prototype.push = originalArrayPush;
+      String.prototype.endsWith = originalStringEndsWith;
+      String.prototype.trim = originalStringTrim;
+    }
+
+    assertEquals(poisonCalls, 0);
+    assertEquals(captured?.id, "hostile-graph");
+    assertEquals((captured?.steps as WorkflowNode[]).map((node) => node.id), [
+      "parallel",
+      "loop",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- capture workflow snapshot intrinsics before project code can replace them
- reject inherited descriptor values and validate helper options without invoking accessors
- traverse static values and dependency graphs without live collection, iterator, reflection, or string helpers
- add direct contract coverage for every exported snapshot helper and hostile-runtime integration coverage

## Verification

- `deno task test:file src/workflow/executor/workflow-definition-snapshot.test.ts` (10 steps)
- `deno task test:file tests/integration/workflow/workflow-definition-snapshot-intrinsics.test.ts` (4 steps)
- `deno task test:file src/workflow` (82 passed, 920 steps)
- `deno task test:unit` (4,183 passed, 32,221 steps)
- `deno task test:integration` (320 passed, 2,955 steps)
- `deno task test:node` (4,435 passed, 10 skipped in the final runtime partition; all partitions passed)
- `deno task test:bun` (1,397 test files passed)
- `deno task typecheck`
- `deno task lint`
- `deno task test:layout`
- `deno task lint:test-typecheck`
- `deno task lint:anti-slop`
- `deno task lint:test-semantic-dispositions`
- `deno task docs:api-reference:check`
- `deno task docs:public:check`
- `git diff --check`