### PR TITLE
Fix checkpoint resume readiness

### DIFF
--- a/src/workflow/executor/checkpoint-manager.test.ts
+++ b/src/workflow/executor/checkpoint-manager.test.ts
@@ -1,11 +1,18 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { VeryfrontError } from "#veryfront/errors";
+import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
 import { CheckpointManager } from "./checkpoint-manager.ts";
 import { MemoryBackend } from "../backends/memory.ts";
 import type { WorkflowBackend } from "../backends/types.ts";
-import type { Checkpoint, WorkflowNode, WorkflowRun } from "../types.ts";
+import type {
+  Checkpoint,
+  NodeState,
+  WorkflowContext,
+  WorkflowNode,
+  WorkflowRun,
+} from "../types.ts";
 
 function checkpoint(id: string, nodeId: string, timestamp: Date): Checkpoint {
   return { id, nodeId, timestamp, context: { input: {} }, nodeStates: {} };
@@ -29,6 +36,16 @@ function run(id: string): WorkflowRun {
 
 function stepNode(id: string): WorkflowNode {
   return { id, config: { type: "step", tool: "noop" } };
+}
+
+function nodeState(nodeId: string, status: NodeState["status"]): NodeState {
+  return {
+    nodeId,
+    status,
+    attempt: 1,
+    startedAt: new Date(0),
+    ...(status === "completed" ? { completedAt: new Date(1) } : {}),
+  };
 }
 
 async function seed(runId: string, count: number): Promise<MemoryBackend> {
@@ -117,5 +134,177 @@ describe("CheckpointManager", () => {
     const all = await new CheckpointManager({ backend }).getAll("fallback");
 
     assertEquals(all.map(({ id }) => id), ["cp-1"]);
+  });
+
+  it("resumes at a dependency-ready node instead of an earlier blocked declaration", async () => {
+    const runId = "dependency-resume";
+    const backend = new MemoryBackend();
+    await backend.createRun(run(runId));
+    await backend.saveCheckpoint(runId, {
+      id: "after-first",
+      nodeId: "first",
+      timestamp: new Date(0),
+      context: { input: {} },
+      nodeStates: {
+        first: nodeState("first", "completed"),
+        blocked: nodeState("blocked", "pending"),
+        prerequisite: nodeState("prerequisite", "pending"),
+      },
+    });
+    const nodes: WorkflowNode[] = [
+      { ...stepNode("first"), dependsOn: [] },
+      { ...stepNode("blocked"), dependsOn: ["prerequisite"] },
+      { ...stepNode("prerequisite"), dependsOn: ["first"] },
+    ];
+
+    const resume = await new CheckpointManager({ backend }).prepareResume(runId, nodes);
+
+    assertExists(resume);
+    assertEquals(resume.startFromNode, "prerequisite");
+  });
+
+  it("rejects invalid cleanup counts without deleting checkpoint history", async () => {
+    const backend = await seed("invalid-cleanup", 2);
+    const manager = new CheckpointManager({ backend });
+
+    for (const keepCount of [-1, 1.5, Number.NaN]) {
+      await assertRejects(
+        () => manager.cleanup("invalid-cleanup", keepCount),
+        VeryfrontError,
+        "keepCount must be a non-negative safe integer",
+      );
+    }
+
+    assertEquals(
+      (await backend.getCheckpoints("invalid-cleanup")).map(({ id }) => id),
+      ["cp-0", "cp-1"],
+    );
+  });
+
+  it("creates detached checkpoints and persists the same snapshot", async () => {
+    const backend = await seed("create-checkpoint", 0);
+    const manager = new CheckpointManager({ backend });
+    const context: WorkflowContext = { input: { topic: "original" } };
+    const nodeStates = { first: nodeState("first", "completed") };
+
+    const created = await manager.createCheckpoint(
+      "create-checkpoint",
+      "first",
+      context,
+      nodeStates,
+    );
+    (context.input as { topic: string }).topic = "changed";
+    nodeStates.first.status = "failed";
+
+    assertEquals(created.context.input, { topic: "original" });
+    assertEquals(created.nodeStates.first?.status, "completed");
+    const persisted = await manager.getLatest("create-checkpoint");
+    assertExists(persisted);
+    assertEquals(persisted.context.input, { topic: "original" });
+    assertEquals(persisted.nodeStates.first?.status, "completed");
+  });
+
+  it("forwards owned saves through the fenced backend method with its receiver", async () => {
+    let receiver: unknown;
+    let received: unknown[] | undefined;
+    let unfencedCalls = 0;
+    const backend = {
+      saveCheckpoint() {
+        unfencedCalls++;
+        return Promise.resolve();
+      },
+      saveCheckpointIfStatusAndWorker(
+        storageRunId: string,
+        ownershipRunId: string,
+        expectedStatuses: string[],
+        expectedWorkerId: string,
+        savedCheckpoint: Checkpoint,
+      ) {
+        receiver = this;
+        received = [
+          storageRunId,
+          ownershipRunId,
+          expectedStatuses,
+          expectedWorkerId,
+          savedCheckpoint.id,
+        ];
+        return Promise.resolve(true);
+      },
+    } as unknown as WorkflowBackend;
+    const manager = new CheckpointManager({ backend });
+    const saved = checkpoint("owned", "first", new Date(0));
+
+    const result = await manager.save("storage-run", saved, {
+      runId: "canonical-run",
+      workerId: "worker-1",
+    });
+
+    assertEquals(result, true);
+    assertEquals(receiver, backend);
+    assertEquals(received, [
+      "storage-run",
+      "canonical-run",
+      ["running"],
+      "worker-1",
+      "owned",
+    ]);
+    assertEquals(unfencedCalls, 0);
+  });
+
+  it("uses explicit checkpoint policy and ignores inherited agent fields", () => {
+    const backend = {} as WorkflowBackend;
+    const manager = new CheckpointManager({ backend });
+    let accessorCalls = 0;
+    const inheritedAgentConfig = Object.assign(
+      Object.create({ agent: "inherited-agent" }),
+      { type: "step", tool: "noop" },
+    );
+    const accessorConfig = Object.defineProperty(
+      { type: "step", tool: "noop" },
+      "checkpoint",
+      {
+        get() {
+          accessorCalls++;
+          return true;
+        },
+      },
+    );
+
+    assertEquals(
+      manager.shouldCheckpoint({
+        id: "inherited-agent",
+        config: inheritedAgentConfig,
+      } as WorkflowNode),
+      false,
+    );
+    assertEquals(
+      manager.shouldCheckpoint({
+        id: "explicit",
+        config: { type: "step", tool: "noop", checkpoint: true },
+      }),
+      true,
+    );
+    assertEquals(
+      manager.shouldCheckpoint({
+        id: "accessor",
+        config: accessorConfig,
+      } as WorkflowNode),
+      false,
+    );
+    assertEquals(accessorCalls, 0);
+    assertEquals(
+      manager.shouldCheckpoint({
+        id: "wait",
+        config: { type: "wait", waitType: "approval" },
+      }),
+      true,
+    );
+    assertEquals(
+      manager.shouldCheckpoint({
+        id: "branch",
+        config: { type: "branch", condition: () => true, then: [] },
+      }),
+      false,
+    );
   });
 });

--- a/src/workflow/executor/checkpoint-manager.ts
+++ b/src/workflow/executor/checkpoint-manager.ts
@@ -1,9 +1,27 @@
 import { logger as baseLogger } from "#veryfront/utils";
+import { INVALID_ARGUMENT } from "#veryfront/errors";
 import type { Checkpoint, NodeState, WorkflowContext, WorkflowNode } from "../types.ts";
 import { generateId } from "../types.ts";
 import type { WorkflowBackend } from "../backends/types.ts";
+import { buildGraph, getReadyNodes, updateInDegreesForCompletedNodes } from "./dag/graph.ts";
 
 const logger = baseLogger.component("checkpoint-manager");
+const numberIsSafeInteger = Number.isSafeInteger;
+const objectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const objectHasOwn = Object.hasOwn;
+
+function getOwnDataProperty<T>(value: unknown, key: PropertyKey): T | undefined {
+  if (
+    (typeof value !== "object" && typeof value !== "function") ||
+    value === null
+  ) return undefined;
+  try {
+    const descriptor = objectGetOwnPropertyDescriptor(value, key);
+    return descriptor && objectHasOwn(descriptor, "value") ? descriptor.value as T : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 export interface CheckpointManagerConfig {
   backend: WorkflowBackend;
@@ -108,41 +126,38 @@ export class CheckpointManager {
 
   private findNextNode(nodes: WorkflowNode[], checkpoint: Checkpoint): string | null {
     const { nodeId: completedNodeId, nodeStates } = checkpoint;
-
-    const nodeIndex = new Map<string, number>();
-    for (let i = 0; i < nodes.length; i++) {
-      const node = nodes[i];
-      if (node) nodeIndex.set(node.id, i);
-    }
-
-    const checkpointIndex = nodeIndex.get(completedNodeId);
-    if (checkpointIndex === undefined) return nodes[0]?.id ?? null;
-
-    for (let i = checkpointIndex + 1; i < nodes.length; i++) {
-      const node = nodes[i];
-      if (!node) continue;
-
-      const state = nodeStates[node.id];
-      if (!state || state.status === "pending") return node.id;
-    }
-
-    for (const node of nodes) {
-      if (!node.dependsOn?.includes(completedNodeId)) continue;
-
-      const state = nodeStates[node.id];
-      if (!state || state.status === "pending") return node.id;
-    }
-
-    return null;
+    const { adjList, inDegree } = buildGraph(nodes);
+    const existingCompletedState = nodeStates[completedNodeId];
+    const completedState: NodeState = existingCompletedState
+      ? {
+        ...existingCompletedState,
+        status: "completed",
+        completedAt: existingCompletedState.completedAt ?? checkpoint.timestamp,
+      }
+      : {
+        nodeId: completedNodeId,
+        status: "completed",
+        attempt: 1,
+        startedAt: checkpoint.timestamp,
+        completedAt: checkpoint.timestamp,
+      };
+    const readinessStates = {
+      ...nodeStates,
+      [completedNodeId]: completedState,
+    };
+    updateInDegreesForCompletedNodes(readinessStates, adjList, inDegree);
+    return getReadyNodes(inDegree, readinessStates)[0] ?? null;
   }
 
   shouldCheckpoint(node: WorkflowNode): boolean {
     const { config } = node;
+    const explicitCheckpoint = getOwnDataProperty<unknown>(config, "checkpoint");
 
-    if (config.checkpoint !== undefined) return config.checkpoint;
+    if (explicitCheckpoint !== undefined) return explicitCheckpoint === true;
 
-    if (config.type === "step") {
-      return "agent" in config && !!config.agent;
+    const configType = getOwnDataProperty<string>(config, "type");
+    if (configType === "step") {
+      return !!getOwnDataProperty(config, "agent");
     }
 
     const checkpointDefaults: Record<string, boolean> = {
@@ -152,11 +167,18 @@ export class CheckpointManager {
       branch: false,
     };
 
-    return checkpointDefaults[config.type] ?? false;
+    return configType && objectHasOwn(checkpointDefaults, configType)
+      ? checkpointDefaults[configType]!
+      : false;
   }
 
   /** Retain the newest appended checkpoints, independent of their durable timestamps. */
   async cleanup(runId: string, keepCount: number = 5): Promise<void> {
+    if (!numberIsSafeInteger(keepCount) || keepCount < 0) {
+      throw INVALID_ARGUMENT.create({
+        detail: "Checkpoint keepCount must be a non-negative safe integer",
+      });
+    }
     const all = await this.getAll(runId);
     if (all.length <= keepCount) return;
 


### PR DESCRIPTION
## Summary

- select checkpoint resume nodes with the executor canonical DAG readiness calculation
- reject invalid cleanup retention counts before checkpoint deletion
- read checkpoint policy from own data fields without invoking accessors or trusting inherited agent fields
- add focused coverage for checkpoint creation, owned persistence, dependency ordering, cleanup validation, and policy defaults

## Verification

- `deno task test:file src/workflow/executor/checkpoint-manager.test.ts` (10 steps)
- `deno task test:file src/workflow` (82 passed, 921 steps)
- `deno task test:unit` (4,183 passed, 32,222 steps on the clean rerun)
- `deno task test:integration` (319 passed, 2,951 steps)
- `deno task typecheck`
- `deno task lint`
- `deno task test:layout`
- `deno task lint:test-typecheck`
- `deno task lint:anti-slop`
- `deno task lint:test-semantic-dispositions`
- `deno task docs:api-reference:check`
- `deno task docs:public:check`
- `git diff --check`