### PR TITLE
Harden workflow step retry boundaries

### DIFF
--- a/src/workflow/executor/retry-policy.test.ts
+++ b/src/workflow/executor/retry-policy.test.ts
@@ -1,0 +1,80 @@
+import "#veryfront/schemas/_test-setup.ts";
+
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { calculateRetryDelay, isRetryableWorkflowError } from "./retry-policy.ts";
+
+describe("workflow retry policy", () => {
+  it("lets an explicit retry predicate override built-in classification", () => {
+    assertEquals(
+      isRetryableWorkflowError(new Error("ordinary failure"), {
+        retryIf: () => true,
+      }),
+      true,
+    );
+    assertEquals(
+      isRetryableWorkflowError(new Error("ECONNRESET"), {
+        retryIf: () => false,
+      }),
+      false,
+    );
+  });
+
+  it("fails closed when a custom retry predicate throws", () => {
+    const original = new Error("original step failure");
+
+    const retryable = isRetryableWorkflowError(original, {
+      retryIf: () => {
+        throw new Error("predicate failed");
+      },
+    });
+
+    assertEquals(retryable, false);
+  });
+
+  it("does not invoke an accessor while reading a system error code", () => {
+    let accessorCalls = 0;
+    const error = Object.defineProperty(new Error("ordinary failure"), "code", {
+      get() {
+        accessorCalls++;
+        throw new Error("code accessor must not run");
+      },
+    });
+
+    assertEquals(isRetryableWorkflowError(error, undefined), false);
+    assertEquals(accessorCalls, 0);
+  });
+
+  it("applies fixed, linear, and exponential backoff within the jitter bounds", () => {
+    const cases = [
+      { backoff: "fixed" as const, attempt: 3, minimum: 90, maximum: 109 },
+      { backoff: "linear" as const, attempt: 3, minimum: 270, maximum: 329 },
+      { backoff: "exponential" as const, attempt: 4, minimum: 720, maximum: 879 },
+    ];
+
+    for (const { backoff, attempt, minimum, maximum } of cases) {
+      for (let sample = 0; sample < 20; sample++) {
+        const delay = calculateRetryDelay(attempt, {
+          backoff,
+          initialDelay: 100,
+          maxDelay: 1_000,
+        });
+        assert(delay >= minimum, `${backoff} delay ${delay} is below ${minimum}`);
+        assert(delay <= maximum, `${backoff} delay ${delay} is above ${maximum}`);
+      }
+    }
+  });
+
+  it("caps retry delay after applying jitter", () => {
+    for (let sample = 0; sample < 20; sample++) {
+      assertEquals(
+        calculateRetryDelay(2, {
+          backoff: "linear",
+          initialDelay: 100,
+          maxDelay: 100,
+        }),
+        100,
+      );
+    }
+  });
+});

--- a/src/workflow/executor/retry-policy.ts
+++ b/src/workflow/executor/retry-policy.ts
@@ -1,9 +1,34 @@
-import { isVeryfrontError } from "#veryfront/errors/http-error.ts";
+import { isVeryfrontErrorInstance } from "#veryfront/errors/types.ts";
 import {
   hasTransientErrorCode,
   telemetryErrorType,
 } from "#veryfront/observability/telemetry-error.ts";
 import type { RetryConfig } from "../types.ts";
+
+const apply = Reflect.apply;
+const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const mathFloor = Math.floor;
+const mathMin = Math.min;
+const mathPow = Math.pow;
+const objectHasOwnProperty = Object.prototype.hasOwnProperty;
+const setHas = Set.prototype.has;
+
+function hasOwn(descriptor: PropertyDescriptor, key: PropertyKey): boolean {
+  return apply(objectHasOwnProperty, descriptor, [key]) as boolean;
+}
+
+function readOwnDataField(value: unknown, key: PropertyKey): unknown {
+  if (
+    (typeof value !== "object" && typeof value !== "function") ||
+    value === null
+  ) return undefined;
+  try {
+    const descriptor = getOwnPropertyDescriptor(value, key);
+    return descriptor && hasOwn(descriptor, "value") ? descriptor.value : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 /** Default initial delay before first retry attempt */
 export const DEFAULT_RETRY_INITIAL_DELAY_MS = 1_000;
@@ -18,18 +43,30 @@ const RETRYABLE_STATUSES = new Set([408, 425, 429, 500, 502, 503, 504]);
  * responsible for non-cooperative-error bookkeeping before consulting this.
  */
 export function isRetryableWorkflowError(error: Error, config: RetryConfig | undefined): boolean {
-  if (config?.retryIf) return config.retryIf(error);
+  const retryIf = readOwnDataField(config, "retryIf");
+  if (typeof retryIf === "function") {
+    try {
+      return apply(retryIf, config, [error]) === true;
+    } catch {
+      return false;
+    }
+  }
 
   // Prefer structured signals over substring-matching the message: an error
   // whose text merely contains "429" or "timeout" (e.g. "Found 429 items")
   // must NOT be retried. VeryfrontError carries an HTTP-style status, so HTTP
   // conditions (429/503/timeout) are classified by status, not text.
-  if (isVeryfrontError(error)) return RETRYABLE_STATUSES.has(error.status);
+  if (isVeryfrontErrorInstance(error)) {
+    const status = readOwnDataField(error, "status");
+    return typeof status === "number" &&
+      apply(setHas, RETRYABLE_STATUSES, [status]) === true;
+  }
 
   // System/network errors: use the stable `code` when present, else fall back
   // to the message but only for the specific code tokens above.
-  const code = (error as { code?: unknown }).code;
-  const subject = typeof code === "string" ? code : error.message;
+  const code = readOwnDataField(error, "code");
+  const message = readOwnDataField(error, "message");
+  const subject = typeof code === "string" ? code : (typeof message === "string" ? message : "");
   return hasTransientErrorCode(subject);
 }
 
@@ -49,9 +86,12 @@ export function calculateRetryDelay(attempt: number, config: RetryConfig | undef
   const maxDelay = config?.maxDelay ?? DEFAULT_RETRY_MAX_DELAY_MS;
 
   let baseDelay = initialDelay;
-  if (config?.backoff === "exponential") baseDelay = initialDelay * Math.pow(2, attempt - 1);
+  if (config?.backoff === "exponential") baseDelay = initialDelay * mathPow(2, attempt - 1);
   else if (config?.backoff === "linear") baseDelay = initialDelay * attempt;
 
+  // Keep randomness injectable through Math.random. Tracing tests and hosts use
+  // this seam to make the one jitter draw deterministic; the arithmetic around
+  // that draw is captured so project code cannot replace the delay calculation.
   const jitter = baseDelay * 0.1 * (Math.random() * 2 - 1);
-  return Math.floor(Math.min(baseDelay + jitter, maxDelay));
+  return mathFloor(mathMin(baseDelay + jitter, maxDelay));
 }

--- a/src/workflow/executor/step-executor.test.ts
+++ b/src/workflow/executor/step-executor.test.ts
@@ -5,10 +5,11 @@ import "#veryfront/schemas/_test-setup.ts";
 
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { FakeTime } from "#std/testing/time";
 import { step } from "../dsl/step.ts";
-import type { RetryConfig, WorkflowContext, WorkflowNode } from "../types.ts";
+import type { NodeState, RetryConfig, WorkflowContext, WorkflowNode } from "../types.ts";
 import { runWithWorkflowTenant, StepExecutor } from "./step-executor.ts";
-import { TIMEOUT_ERROR } from "#veryfront/errors";
+import { TIMEOUT_ERROR, VeryfrontError } from "#veryfront/errors";
 import {
   runWithCacheKeyContext,
   tryGetCacheKeyContext,
@@ -101,7 +102,7 @@ describe("StepExecutor retry validation", () => {
 
     await assertRejects(
       () => executor.execute(node, makeContext()),
-      Error,
+      VeryfrontError,
       "maxAttempts",
     );
   });
@@ -116,7 +117,7 @@ describe("StepExecutor retry validation", () => {
 
     await assertRejects(
       () => executor.execute(node, makeContext()),
-      Error,
+      VeryfrontError,
       "initialDelay",
     );
   });
@@ -131,7 +132,7 @@ describe("StepExecutor retry validation", () => {
 
     await assertRejects(
       () => executor.execute(node, makeContext()),
-      Error,
+      VeryfrontError,
       "backoff",
     );
   });
@@ -191,11 +192,104 @@ describe("StepExecutor retry classification", () => {
     assertEquals(result.success, false);
     assertEquals(getCalls(), 3);
   });
+
+  it("does not re-execute a successful tool when the completion hook fails", async () => {
+    let toolCalls = 0;
+    let errorHooks = 0;
+    const executor = new StepExecutor({
+      onStepComplete: () => {
+        throw TIMEOUT_ERROR.create({ detail: "completion hook failed" });
+      },
+      onStepError: () => errorHooks++,
+    });
+    const node = step("successful-side-effect", {
+      tool: {
+        id: "side-effect",
+        description: "Counts successful side effects",
+        execute: () => {
+          toolCalls++;
+          return { ok: true };
+        },
+      } as never,
+      retry: {
+        maxAttempts: 3,
+        backoff: "fixed",
+        initialDelay: 0,
+        maxDelay: 0,
+      },
+    });
+
+    const result = await executor.execute(node, makeContext());
+
+    assertEquals(result.success, false);
+    assertEquals(result.error, "completion hook failed");
+    assertEquals(toolCalls, 1);
+    assertEquals(errorHooks, 1);
+  });
+});
+
+describe("StepExecutor admission", () => {
+  it("rejects a raw step with both an agent and a tool before either executes", async () => {
+    let agentCalls = 0;
+    let toolCalls = 0;
+    const node = {
+      id: "ambiguous-step",
+      config: {
+        type: "step",
+        agent: {
+          id: "agent",
+          generate: () => {
+            agentCalls++;
+            return Promise.resolve({ text: "agent", status: "completed" });
+          },
+        },
+        tool: {
+          id: "tool",
+          execute: () => {
+            toolCalls++;
+            return { source: "tool" };
+          },
+        },
+      },
+    } as unknown as WorkflowNode;
+
+    await assertRejects(
+      () => new StepExecutor({}).execute(node, makeContext()),
+      VeryfrontError,
+      "exactly one of 'agent' or 'tool'",
+    );
+    assertEquals(agentCalls, 0);
+    assertEquals(toolCalls, 0);
+  });
+
+  it("rejects a zero step timeout before executing the tool", async () => {
+    let toolCalls = 0;
+    const node = step("zero-timeout", {
+      tool: {
+        id: "tool",
+        description: "Must not execute",
+        execute: () => {
+          toolCalls++;
+          return { ok: true };
+        },
+      } as never,
+      timeout: 0,
+    });
+
+    await assertRejects(
+      () => new StepExecutor({}).execute(node, makeContext()),
+      VeryfrontError,
+      "timeout must be greater than zero",
+    );
+    assertEquals(toolCalls, 0);
+  });
 });
 
 describe("StepExecutor timeout isolation", () => {
   it("stops waiting after the cancellation grace when a timed-out tool never settles", async () => {
+    using time = new FakeTime();
     const operation = Promise.withResolvers<unknown>();
+    const started = Promise.withResolvers<void>();
     let receivedSignal: AbortSignal | undefined;
     let completions = 0;
     let attempts = 0;
@@ -210,6 +304,7 @@ describe("StepExecutor timeout isolation", () => {
         execute: (_input: unknown, context?: { abortSignal?: AbortSignal }) => {
           attempts++;
           receivedSignal = context?.abortSignal;
+          started.resolve();
           return operation.promise;
         },
         // deno-lint-ignore no-explicit-any
@@ -224,22 +319,16 @@ describe("StepExecutor timeout isolation", () => {
     });
 
     let result;
-    let watchdogId: ReturnType<typeof setTimeout> | undefined;
     try {
-      result = await Promise.race([
-        executor.execute(node, makeContext()),
-        new Promise<never>((_, reject) =>
-          watchdogId = setTimeout(
-            () => reject(new Error("Step execution did not stop after timeout")),
-            100,
-          )
-        ),
-      ]);
+      const execution = executor.execute(node, makeContext());
+      await started.promise;
+      await time.tickAsync(5);
+      await time.tickAsync(5);
+      result = await execution;
     } finally {
-      if (watchdogId !== undefined) clearTimeout(watchdogId);
       // A late rejection must remain observed after the public execution settles.
       operation.reject(new Error("late tool rejection"));
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      await Promise.resolve();
     }
 
     assertEquals(result.success, false);
@@ -251,6 +340,10 @@ describe("StepExecutor timeout isolation", () => {
   });
 
   it("does not overlap retries when a timed-out tool ignores cancellation", async () => {
+    using time = new FakeTime();
+    const firstStarted = Promise.withResolvers<void>();
+    const secondStarted = Promise.withResolvers<void>();
+    const operations: Array<PromiseWithResolvers<void>> = [];
     let attempts = 0;
     let active = 0;
     let maxActive = 0;
@@ -264,9 +357,15 @@ describe("StepExecutor timeout isolation", () => {
           active++;
           maxActive = Math.max(maxActive, active);
           signals.push(context?.abortSignal);
-          await new Promise((resolve) => setTimeout(resolve, 20));
-          active--;
-          return { ok: true };
+          const operation = Promise.withResolvers<void>();
+          operations.push(operation);
+          (attempts === 1 ? firstStarted : secondStarted).resolve();
+          try {
+            await operation.promise;
+            return { ok: true };
+          } finally {
+            active--;
+          }
         },
         // deno-lint-ignore no-explicit-any
       } as any,
@@ -279,8 +378,17 @@ describe("StepExecutor timeout isolation", () => {
       },
     });
 
-    const result = await new StepExecutor({}).execute(node, makeContext());
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    const execution = new StepExecutor({}).execute(node, makeContext());
+    await firstStarted.promise;
+    await time.tickAsync(5);
+    assertEquals(attempts, 1);
+    assertEquals(active, 1);
+    operations[0]!.resolve();
+    await time.tickAsync(1);
+    await secondStarted.promise;
+    await time.tickAsync(5);
+    operations[1]!.resolve();
+    const result = await execution;
 
     assertEquals(result.success, false);
     assertEquals(attempts, 2);
@@ -426,5 +534,43 @@ describe("StepExecutor agent structured output", () => {
     // no key and the fields it did produce are untouched.
     assertEquals(Object.hasOwn(result.output as object, "object"), false);
     assertEquals((result.output as { usage?: unknown }).usage, { totalTokens: 3 });
+  });
+});
+
+describe("StepExecutor node states", () => {
+  it("removes stale terminal fields when a step changes outcome", () => {
+    const executor = new StepExecutor({});
+    const failed: NodeState = {
+      nodeId: "step",
+      status: "failed",
+      attempt: 1,
+      startedAt: new Date(0),
+      completedAt: new Date(1),
+      error: "old failure",
+    };
+    const completed: NodeState = {
+      nodeId: "step",
+      status: "completed",
+      attempt: 1,
+      startedAt: new Date(0),
+      completedAt: new Date(1),
+      output: { stale: true },
+    };
+
+    const success = executor.createCompletedState(
+      { success: true, output: { fresh: true }, executionTime: 1 },
+      failed,
+    );
+    const failure = executor.createCompletedState(
+      { success: false, error: "new failure", executionTime: 1 },
+      completed,
+    );
+
+    assertEquals(success.status, "completed");
+    assertEquals(success.output, { fresh: true });
+    assertEquals(Object.hasOwn(success, "error"), false);
+    assertEquals(failure.status, "failed");
+    assertEquals(failure.error, "new failure");
+    assertEquals(Object.hasOwn(failure, "output"), false);
   });
 });

--- a/src/workflow/executor/step-executor.ts
+++ b/src/workflow/executor/step-executor.ts
@@ -32,7 +32,7 @@ import type {
   WorkflowContext,
   WorkflowNode,
 } from "../types.ts";
-import { parseDuration, validateRetryConfig } from "../types.ts";
+import { parsePositiveDurationWithLabel, validateRetryConfig } from "../types.ts";
 import {
   addActiveSpanEvent,
   setActiveSpanAttributes,
@@ -203,9 +203,24 @@ export class StepExecutor {
       });
     }
 
+    const hasAgent = config.agent != null;
+    const hasTool = config.tool != null;
+    if (hasAgent === hasTool) {
+      throw INVALID_ARGUMENT.create({
+        detail: `Step "${node.id}" must configure exactly one of 'agent' or 'tool'`,
+      });
+    }
+
     if (config.retry) {
       validateRetryConfig(config.retry);
     }
+
+    const timeout = parsePositiveDurationWithLabel(
+      config.timeout === undefined
+        ? (this.config.defaultTimeout ?? DEFAULT_STEP_TIMEOUT_MS)
+        : config.timeout,
+      `Step "${node.id}" timeout`,
+    );
 
     const retryConfig = { ...DEFAULT_RETRY, ...config.retry };
     const maxAttempts = retryConfig.maxAttempts ?? 1;
@@ -215,16 +230,13 @@ export class StepExecutor {
 
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       abortSignal?.throwIfAborted();
+      let operationCompleted = false;
 
       try {
         const output = await runWithWorkflowTenant(tenant, async () => {
           const resolvedInput = await this.resolveInput(config.input, context);
           abortSignal?.throwIfAborted();
           this.config.onStepStart?.(node.id, resolvedInput, runId);
-
-          const timeout = config.timeout
-            ? parseDuration(config.timeout)
-            : (this.config.defaultTimeout ?? DEFAULT_STEP_TIMEOUT_MS);
 
           return this.executeWithTimeout(
             (attemptSignal) => this.executeStep(config, resolvedInput, context, attemptSignal),
@@ -234,8 +246,7 @@ export class StepExecutor {
           );
         });
         abortSignal?.throwIfAborted();
-
-        abortSignal?.throwIfAborted();
+        operationCompleted = true;
         setActiveSpanAttributes({ "workflow.node.attempts": attempt });
         this.config.onStepComplete?.(node.id, output, runId);
 
@@ -248,7 +259,10 @@ export class StepExecutor {
         abortSignal?.throwIfAborted();
         lastError = ensureError(error);
 
-        if (attempt < maxAttempts && this.isRetryableError(lastError, retryConfig)) {
+        if (
+          !operationCompleted && attempt < maxAttempts &&
+          this.isRetryableError(lastError, retryConfig)
+        ) {
           const delay = calculateRetryDelay(attempt, retryConfig);
           addActiveSpanEvent("workflow.node.retry", {
             "workflow.node.attempt": attempt,
@@ -479,12 +493,18 @@ export class StepExecutor {
 
   createCompletedState(result: StepResult, previousState: NodeState): NodeState {
     const completedAt = new Date();
+    const {
+      completedAt: _previousCompletedAt,
+      error: _previousError,
+      output: _previousOutput,
+      ...activeState
+    } = previousState;
 
     if (result.success) {
-      return { ...previousState, status: "completed", output: result.output, completedAt };
+      return { ...activeState, status: "completed", output: result.output, completedAt };
     }
 
-    return { ...previousState, status: "failed", error: result.error, completedAt };
+    return { ...activeState, status: "failed", error: result.error, completedAt };
   }
 
   createSkippedState(nodeId: string): NodeState {

--- a/tests/integration/workflow/retry-policy-intrinsics.test.ts
+++ b/tests/integration/workflow/retry-policy-intrinsics.test.ts
@@ -1,0 +1,51 @@
+import "#veryfront/schemas/_test-setup.ts";
+
+import { TIMEOUT_ERROR } from "#veryfront/errors";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  calculateRetryDelay,
+  isRetryableWorkflowError,
+} from "#veryfront/workflow/executor/retry-policy.ts";
+
+describe("workflow retry policy with hostile ambient intrinsics", () => {
+  it("classifies an error and calculates backoff after retry intrinsics are replaced", () => {
+    const error = TIMEOUT_ERROR.create({ detail: "transient failure" });
+    const originalMathFloor = Math.floor;
+    const originalMathMin = Math.min;
+    const originalMathPow = Math.pow;
+    const originalMathRandom = Math.random;
+    const originalSetHas = Set.prototype.has;
+    let poisonCalls = 0;
+    const poison = (): never => {
+      poisonCalls++;
+      throw new Error("ambient retry intrinsic must not run");
+    };
+    let retryable: boolean | undefined;
+    let delay: number | undefined;
+
+    try {
+      Math.floor = poison;
+      Math.min = poison;
+      Math.pow = poison;
+      Math.random = () => 0.5;
+      Set.prototype.has = poison;
+      retryable = isRetryableWorkflowError(error, undefined);
+      delay = calculateRetryDelay(2, {
+        backoff: "exponential",
+        initialDelay: 0,
+        maxDelay: 0,
+      });
+    } finally {
+      Math.floor = originalMathFloor;
+      Math.min = originalMathMin;
+      Math.pow = originalMathPow;
+      Math.random = originalMathRandom;
+      Set.prototype.has = originalSetHas;
+    }
+
+    assertEquals(poisonCalls, 0);
+    assertEquals(retryable, true);
+    assertEquals(delay, 0);
+  });
+});


### PR DESCRIPTION
## Summary

- prevent completion-hook failures from re-executing successful tool or agent side effects
- require exactly one step collaborator and a positive timeout at direct executor admission
- make retry predicates fail closed and classify error metadata without invoking accessors
- capture deterministic retry arithmetic while preserving the established injectable jitter source
- clear stale terminal state fields and replace wall-clock timeout tests with deterministic fake time
- add direct retry-policy and hostile-runtime coverage

## Verification

- `deno task test:file src/workflow/executor/step-executor.test.ts` (21 steps)
- `deno task test:file src/workflow/executor/retry-policy.test.ts` (5 steps)
- `deno task test:file tests/integration/workflow/retry-policy-intrinsics.test.ts` (1 step)
- `deno task test:file src/workflow` (85 passed, 924 steps)
- `deno task test:unit`
- `deno task test:integration` (321 passed, 2,981 steps)
- `deno task test:node`
- `deno task test:bun` (1,402 test files passed)
- `deno task typecheck`
- `deno task lint`
- `deno task test:layout`
- `deno task lint:test-typecheck`
- `deno task lint:anti-slop`
- `deno task lint:test-semantic-dispositions`
- `deno task docs:api-reference:check`
- `deno task docs:public:check`
- `git diff --check`