### PR TITLE
Harden workflow DAG graph admission

### DIFF
--- a/src/workflow/executor/dag-executor.test.ts
+++ b/src/workflow/executor/dag-executor.test.ts
@@ -1,50 +1,18 @@
 import "#veryfront/schemas/_test-setup.ts";
-/**
- * DAG Executor Tests
- */
 
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
-import { delay } from "#std/async.ts";
-import { step } from "../dsl/step.ts";
-import { dependsOn } from "../dsl/workflow.ts";
-import type { WorkflowContext, WorkflowNode, WorkflowRun } from "../types.ts";
-import { DAGExecutor } from "./dag-executor.ts";
-import { StepExecutor } from "./step-executor.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
 import {
   getActiveSourceIntegrationPolicy,
   runWithExactSourceIntegrationPolicy,
 } from "#veryfront/integrations/source-policy-context.ts";
+import type { WorkflowContext, WorkflowNode, WorkflowRun } from "../types.ts";
+import { DAGExecutor as FacadeDAGExecutor } from "./dag-executor.ts";
+import { DAGExecutor as ModularDAGExecutor } from "./dag/index.ts";
+import { StepExecutor, type StepResult } from "./step-executor.ts";
 
 const UNRESTRICTED_SOURCE_INTEGRATION_POLICY = normalizeSourceIntegrationPolicy(undefined);
-
-function createMockStepExecutor(
-  executionOrder: string[] = [],
-  failingNodes: Set<string> = new Set(),
-): StepExecutor {
-  const executor = new StepExecutor({});
-
-  executor.execute = (node: WorkflowNode, _context: WorkflowContext) => {
-    executionOrder.push(node.id);
-
-    if (failingNodes.has(node.id)) {
-      return Promise.resolve({
-        success: false,
-        error: "Step failed",
-        executionTime: 10,
-      });
-    }
-
-    return Promise.resolve({
-      success: true,
-      output: { result: `output-${node.id}` },
-      executionTime: 10,
-    });
-  };
-
-  return executor;
-}
 
 function createTestRun(): WorkflowRun {
   return {
@@ -62,16 +30,24 @@ function createTestRun(): WorkflowRun {
   };
 }
 
-describe("DAGExecutor", () => {
-  let executor: DAGExecutor;
+class PolicyCapturingStepExecutor extends StepExecutor {
+  observedPolicy: unknown;
 
-  beforeEach(() => {
-    executor = new DAGExecutor({
-      stepExecutor: createMockStepExecutor(),
-    });
+  override execute(
+    _node: WorkflowNode,
+    _context: WorkflowContext,
+  ): Promise<StepResult> {
+    this.observedPolicy = getActiveSourceIntegrationPolicy();
+    return Promise.resolve({ success: true, output: {}, executionTime: 0 });
+  }
+}
+
+describe("DAGExecutor compatibility facade", () => {
+  it("re-exports the modular DAGExecutor constructor unchanged", () => {
+    assertEquals(FacadeDAGExecutor, ModularDAGExecutor);
   });
 
-  it("restores and narrows the run policy for direct DAG consumers", async () => {
+  it("restores and narrows run policy through the public facade", async () => {
     const persistedPolicy = normalizeSourceIntegrationPolicy({
       allow: {
         confluence: { allowedTools: ["get_page", "search_content"] },
@@ -88,174 +64,18 @@ describe("DAGExecutor", () => {
         confluence: { allowedTools: ["get_page"] },
       },
     });
-    let observedPolicy: unknown;
-    const stepExecutor = createMockStepExecutor();
-    stepExecutor.execute = () => {
-      observedPolicy = getActiveSourceIntegrationPolicy();
-      return Promise.resolve({ success: true, output: {}, executionTime: 0 });
-    };
-    executor = new DAGExecutor({ stepExecutor });
+    const stepExecutor = new PolicyCapturingStepExecutor();
+    const executor = new FacadeDAGExecutor({ stepExecutor });
 
     await runWithExactSourceIntegrationPolicy(
       activePolicy,
       () =>
         executor.execute(
-          [step("observe", { agent: "a" })],
+          [{ id: "observe", config: { type: "step" } as never }],
           { ...createTestRun(), sourceIntegrationPolicy: persistedPolicy },
         ),
     );
 
-    assertEquals(observedPolicy, expectedPolicy);
-  });
-
-  describe("Topological Sorting", () => {
-    it("should execute nodes in dependency order", async () => {
-      const executionOrder: string[] = [];
-
-      executor = new DAGExecutor({
-        stepExecutor: createMockStepExecutor(executionOrder),
-      });
-
-      const nodes: WorkflowNode[] = [
-        dependsOn(step("c", { agent: "a" }), "b"),
-        dependsOn(step("b", { agent: "a" }), "a"),
-        step("a", { agent: "a" }),
-      ];
-
-      await executor.execute(nodes, createTestRun());
-
-      const aIndex = executionOrder.indexOf("a");
-      const bIndex = executionOrder.indexOf("b");
-      const cIndex = executionOrder.indexOf("c");
-
-      assertEquals(aIndex < bIndex, true, "a should execute before b");
-      assertEquals(bIndex < cIndex, true, "b should execute before c");
-    });
-
-    it("should execute independent nodes in parallel", async () => {
-      const startTimes: Record<string, number> = {};
-      const stepExecutor = createMockStepExecutor();
-
-      stepExecutor.execute = async (node: WorkflowNode, _context: WorkflowContext) => {
-        startTimes[node.id] = Date.now();
-        await delay(50);
-        return {
-          success: true,
-          output: {},
-          executionTime: 50,
-        };
-      };
-
-      executor = new DAGExecutor({
-        stepExecutor,
-        maxConcurrency: 10,
-      });
-
-      const nodes: WorkflowNode[] = [
-        { ...step("parallel-1", { agent: "a" }), dependsOn: [] },
-        { ...step("parallel-2", { agent: "a" }), dependsOn: [] },
-        { ...step("parallel-3", { agent: "a" }), dependsOn: [] },
-      ];
-
-      await executor.execute(nodes, createTestRun());
-
-      const times = Object.values(startTimes);
-      const maxDiff = Math.max(...times) - Math.min(...times);
-      assertEquals(maxDiff < 30, true, "Independent nodes should start nearly simultaneously");
-    });
-  });
-
-  describe("Cycle Detection", () => {
-    it("should detect direct cycles", async () => {
-      const nodes: WorkflowNode[] = [
-        { ...step("a", { agent: "x" }), dependsOn: ["b"] },
-        { ...step("b", { agent: "x" }), dependsOn: ["a"] },
-      ];
-
-      const result = await executor.execute(nodes, createTestRun());
-
-      assertEquals(result.completed, false);
-      assertEquals(result.error?.toLowerCase().includes("cycle"), true);
-    });
-
-    it("should detect indirect cycles", async () => {
-      const nodes: WorkflowNode[] = [
-        { ...step("a", { agent: "x" }), dependsOn: ["c"] },
-        { ...step("b", { agent: "x" }), dependsOn: ["a"] },
-        { ...step("c", { agent: "x" }), dependsOn: ["b"] },
-      ];
-
-      const result = await executor.execute(nodes, createTestRun());
-
-      assertEquals(result.completed, false);
-      assertEquals(result.error?.toLowerCase().includes("cycle"), true);
-    });
-  });
-
-  describe("Error Handling", () => {
-    it("should handle step failures", async () => {
-      executor = new DAGExecutor({
-        stepExecutor: createMockStepExecutor([], new Set(["failing"])),
-      });
-
-      const nodes: WorkflowNode[] = [step("ok", { agent: "a" }), step("failing", { agent: "a" })];
-
-      const result = await executor.execute(nodes, createTestRun());
-
-      assertEquals(result.completed, false);
-      assertEquals(result.error?.includes("failing"), true);
-    });
-
-    it("should skip dependent nodes when dependency fails", async () => {
-      const executed: string[] = [];
-
-      executor = new DAGExecutor({
-        stepExecutor: createMockStepExecutor(executed, new Set(["failing"])),
-      });
-
-      const nodes: WorkflowNode[] = [
-        step("failing", { agent: "a" }),
-        dependsOn(step("dependent", { agent: "a" }), "failing"),
-      ];
-
-      await executor.execute(nodes, createTestRun());
-
-      assertEquals(executed.includes("failing"), true);
-      assertEquals(executed.includes("dependent"), false, "Dependent should be skipped");
-    });
-  });
-
-  describe("Resume from Checkpoint", () => {
-    it("should skip already completed nodes", async () => {
-      const executed: string[] = [];
-
-      executor = new DAGExecutor({
-        stepExecutor: createMockStepExecutor(executed),
-      });
-
-      const nodes: WorkflowNode[] = [
-        step("step1", { agent: "a" }),
-        step("step2", { agent: "a" }),
-        step("step3", { agent: "a" }),
-      ];
-
-      const run: WorkflowRun = {
-        ...createTestRun(),
-        nodeStates: {
-          step1: {
-            nodeId: "step1",
-            status: "completed",
-            output: { done: true },
-            attempt: 1,
-          },
-        },
-      };
-
-      await executor.execute(nodes, run);
-
-      assertEquals(executed.includes("step1"), false, "step1 should be skipped");
-      assertEquals(executed.includes("step2"), true);
-      assertEquals(executed.includes("step3"), true);
-    });
+    assertEquals(stepExecutor.observedPolicy, expectedPolicy);
   });
 });

--- a/src/workflow/executor/dag/graph.ts
+++ b/src/workflow/executor/dag/graph.ts
@@ -17,13 +17,25 @@ export function buildGraph(nodes: WorkflowNode[]): DAGGraph {
   const nodeMap = new Map<string, WorkflowNode>();
 
   for (const node of nodes) {
+    if (nodeMap.has(node.id)) {
+      throw INVALID_ARGUMENT.create({
+        detail: `Workflow graph has duplicate node ID "${node.id}"`,
+      });
+    }
     adjList.set(node.id, []);
     inDegree.set(node.id, 0);
     nodeMap.set(node.id, node);
   }
 
   for (const node of nodes) {
+    const dependencies = new Set<string>();
     for (const dep of node.dependsOn ?? []) {
+      if (dependencies.has(dep)) {
+        throw INVALID_ARGUMENT.create({
+          detail: `Workflow graph node "${node.id}" contains duplicate dependency "${dep}"`,
+        });
+      }
+      dependencies.add(dep);
       const dependents = adjList.get(dep);
       if (!dependents) {
         throw INVALID_ARGUMENT.create({

--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -32,6 +32,7 @@ import { StepExecutor, type StepResult } from "../step-executor.ts";
 import { CheckpointManager } from "../checkpoint-manager.ts";
 import type { WorkflowBackend } from "../../backends/types.ts";
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
+import { VeryfrontError } from "#veryfront/errors";
 import { __subscribeLogRecordEmitter, type LogEntry } from "#veryfront/utils/logger/index.ts";
 import { serializeWorkflowContext } from "../../context-serialization.ts";
 
@@ -156,6 +157,73 @@ describe("DAGExecutor", () => {
       const result = await exec.execute(nodes, createTestRun());
       assertEquals(result.completed, true);
       assertEquals(order, ["a", "b", "c"]);
+    });
+
+    it("executes a reverse-declared dependency chain in topological order", async () => {
+      const order: string[] = [];
+      const exec = new DAGExecutor({
+        stepExecutor: new MockStepExecutor(new Map(), (node) => {
+          order.push(node.id);
+          return { success: true, output: node.id, executionTime: 1 };
+        }),
+      });
+      const nodes: WorkflowNode[] = [
+        { id: "c", dependsOn: ["b"], config: { type: "step" } as never },
+        { id: "b", dependsOn: ["a"], config: { type: "step" } as never },
+        { id: "a", dependsOn: [], config: { type: "step" } as never },
+      ];
+
+      await exec.execute(nodes, createTestRun());
+
+      assertEquals(order, ["a", "b", "c"]);
+    });
+  });
+
+  describe("graph admission", () => {
+    it("rejects duplicate node IDs before executing either declaration", async () => {
+      let executions = 0;
+      const exec = new DAGExecutor({
+        stepExecutor: new MockStepExecutor(new Map(), () => {
+          executions++;
+          return { success: true, output: {}, executionTime: 1 };
+        }),
+      });
+      const nodes: WorkflowNode[] = [
+        { id: "duplicate", dependsOn: [], config: { type: "step" } as never },
+        { id: "duplicate", dependsOn: [], config: { type: "step" } as never },
+      ];
+
+      await assertRejects(
+        () => exec.execute(nodes, createTestRun()),
+        VeryfrontError,
+        'duplicate node ID "duplicate"',
+      );
+      assertEquals(executions, 0);
+    });
+
+    it("rejects duplicate dependencies before executing the graph", async () => {
+      let executions = 0;
+      const exec = new DAGExecutor({
+        stepExecutor: new MockStepExecutor(new Map(), () => {
+          executions++;
+          return { success: true, output: {}, executionTime: 1 };
+        }),
+      });
+      const nodes: WorkflowNode[] = [
+        { id: "root", dependsOn: [], config: { type: "step" } as never },
+        {
+          id: "dependent",
+          dependsOn: ["root", "root"],
+          config: { type: "step" } as never,
+        },
+      ];
+
+      await assertRejects(
+        () => exec.execute(nodes, createTestRun()),
+        VeryfrontError,
+        'node "dependent" contains duplicate dependency "root"',
+      );
+      assertEquals(executions, 0);
     });
   });
 


### PR DESCRIPTION
## Summary

- reject duplicate workflow node IDs and duplicate dependency declarations before execution
- replace duplicated compatibility-facade behavior tests with a constructor identity contract and the facade-specific source-policy contract
- preserve reverse-declared dependency ordering coverage in the modular DAG suite
- remove the facade suite wall-clock concurrency assertion

## Verification

- `deno task test:file src/workflow/executor/dag-executor.test.ts`
- `deno task test:file src/workflow/executor/dag/index.test.ts`
- `deno task test:file src/workflow/executor`
- `deno task test:file src/workflow`
- `deno task test:unit`
- `deno task test:integration`
- `deno task test:node`
- `deno task test:bun`
- `deno task typecheck`
- `deno task lint`
- `deno task docs`
- `deno task lint:test-typecheck`
- `deno task lint:anti-slop`
- `deno task lint:test-semantic-dispositions`
- `deno task lint:test-layout`
- `git diff --check`

The first full unit run passed all 4,183 assertions and 32,185 steps, then the test runner reported a pending-promise shutdown error. The touched executor directory passed independently, and a second full unit run exited cleanly.