### PR TITLE
test(mcp,studio,internal-agents,client): make weak assertions bite

### DIFF
--- a/src/client/spa/ClientApp.reactivity.test.tsx
+++ b/src/client/spa/ClientApp.reactivity.test.tsx
@@ -297,6 +297,8 @@ describe("client/spa/ClientApp (reactive)", () => {
 
   it("does not let the initial component load overwrite a completed navigation", async () => {
     await withTempDir(async (tempDir) => {
+      // The initial page resolves only after the navigation below has already
+      // failed, so its late result must be discarded rather than committed.
       await writeModule(
         tempDir,
         "pages/initial.tsx",
@@ -304,16 +306,12 @@ describe("client/spa/ClientApp (reactive)", () => {
          await new Promise((resolve) => setTimeout(resolve, 40));
          export default function Page() { return React.createElement("span", null, "initial"); }`,
       );
-      await writeModule(
-        tempDir,
-        "pages/fast.tsx",
-        `import React from "react";
-         export default function Page() { return React.createElement("span", null, "fast"); }`,
-      );
 
       const restore = installDom("https://example.com/initial");
       testGlobal.MODULE_SERVER_URL = `file://${tempDir}`;
       clearComponentCache();
+      const originalError = console.error;
+      console.error = () => {};
       try {
         const initialData: PageDataResponse = {
           slug: "/initial",
@@ -326,12 +324,6 @@ describe("client/spa/ClientApp (reactive)", () => {
           params: {},
           layoutProps: {},
         };
-        const fastData: PageDataResponse = {
-          ...initialData,
-          slug: "/fast",
-          pagePath: "pages/fast.tsx",
-          frontmatter: { title: "Fast" },
-        };
 
         const rootElement = document.getElementById("root")!;
         const root = createRoot(rootElement);
@@ -340,14 +332,37 @@ describe("client/spa/ClientApp (reactive)", () => {
         const navigate = testGlobal.__VERYFRONT_SPA_NAVIGATE__;
         assertEquals(typeof navigate, "function");
 
-        await navigate!(fastData);
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        // `pages/missing.tsx` was never written, so this navigation completes in
+        // its error state and never re-runs the initial-load effect.
+        await navigate!({
+          ...initialData,
+          slug: "/missing",
+          pagePath: "pages/missing.tsx",
+          frontmatter: { title: "Missing" },
+        });
+        await waitForText(rootElement, "Something went wrong");
 
-        assertStringIncludes(rootElement.textContent ?? "", "fast");
-        assertEquals(document.title, "Fast");
+        // Join the slow initial import deterministically instead of waiting out
+        // its timer, then let its discarded continuation run.
+        await loadComponent("pages/initial.tsx");
+        // The import is already joined, so this only yields a fixed number of
+        // event-loop turns for the discarded continuation and React's flush.
+        for (let turn = 0; turn < 6; turn++) await tick();
+
+        assertStringIncludes(
+          rootElement.textContent ?? "",
+          "Failed to load page component: pages/missing.tsx",
+          "a stale initial page load must not overwrite a completed navigation's error state",
+        );
+        assertEquals(
+          (rootElement.textContent ?? "").includes("initial"),
+          false,
+          "the superseded initial component must never render",
+        );
 
         root.unmount();
       } finally {
+        console.error = originalError;
         clearComponentCache();
         delete testGlobal.MODULE_SERVER_URL;
         restore();
@@ -934,6 +949,42 @@ describe("client/spa/ClientApp (reactive)", () => {
       root.unmount();
 
       assertStrictEquals(testGlobal.__VERYFRONT_SPA_NAVIGATE__, previousHandler);
+    } finally {
+      delete testGlobal.__VERYFRONT_SPA_NAVIGATE__;
+      restore();
+    }
+  });
+
+  it("removes the global navigation handler when the last app unmounts", () => {
+    const restore = installDom("https://example.com/");
+    try {
+      assertEquals(
+        typeof testGlobal.__VERYFRONT_SPA_NAVIGATE__,
+        "undefined",
+        "precondition: no pre-existing handler",
+      );
+      const rootElement = document.getElementById("root")!;
+      const root = createRoot(rootElement);
+      const initialData: PageDataResponse = {
+        slug: "/",
+        pagePath: "",
+        pageType: "tsx",
+        layouts: [],
+        providers: [],
+        frontmatter: {},
+        props: {},
+        params: {},
+        layoutProps: {},
+      };
+
+      flushSync(() => root.render(<ClientApp initialData={initialData} />));
+      root.unmount();
+
+      assertEquals(
+        Object.hasOwn(testGlobal, "__VERYFRONT_SPA_NAVIGATE__"),
+        false,
+        "last unmount must delete the global handler, not leave a stale one",
+      );
     } finally {
       delete testGlobal.__VERYFRONT_SPA_NAVIGATE__;
       restore();

--- a/src/client/spa/ClientApp.test.tsx
+++ b/src/client/spa/ClientApp.test.tsx
@@ -1,5 +1,5 @@
 import { renderToString } from "react-dom/server";
-import { assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { mkdir, withTempDir, writeTextFile } from "#veryfront/testing/deno-compat.ts";
 import { ClientApp, type PageDataResponse } from "./ClientApp.tsx";
@@ -90,5 +90,50 @@ describe("client/spa/ClientApp", () => {
         assertStringIncludes(html, "&quot;slug&quot;:[&quot;guide&quot;,&quot;intro&quot;]");
       });
     }, { prefix: "vf-client-app-" });
+  });
+
+  it("rejects hostile initial page data before it reaches the render path", async () => {
+    await withTempDir(async (tempDir) => {
+      await writeModule(
+        tempDir,
+        "pages/docs.tsx",
+        "export default function Page(props) { return JSON.stringify({ title: props.title }); }",
+      );
+
+      await withModuleServerUrl(tempDir, async () => {
+        await loadComponent("pages/docs.tsx");
+
+        let reads = 0;
+        const initialData: PageDataResponse = {
+          slug: "/docs",
+          pagePath: "pages/docs.tsx",
+          pageType: "tsx",
+          layouts: [],
+          providers: [],
+          frontmatter: {},
+          props: {},
+          params: {},
+          layoutProps: {},
+        };
+        Object.defineProperty(initialData.props, "title", {
+          enumerable: true,
+          get() {
+            reads++;
+            return "Welcome";
+          },
+        });
+
+        const html = renderToString(<ClientApp initialData={initialData} />);
+
+        assertStringIncludes(html, "Invalid SPA page data");
+        assertStringIncludes(html, "veryfront-page-error");
+        assertEquals(
+          html.includes("&quot;title&quot;"),
+          false,
+          "page props must not reach the render path when the snapshot gate rejects them",
+        );
+        assertEquals(reads, 0, "the accessor must never run");
+      });
+    }, { prefix: "vf-client-app-hostile-" });
   });
 });

--- a/src/client/spa/component-loader.test.ts
+++ b/src/client/spa/component-loader.test.ts
@@ -343,18 +343,32 @@ describe("client/spa/component-loader", () => {
 
   it("accepts React exotic component types", async () => {
     await withTempDir(async (tempDir) => {
-      await writeModule(
-        tempDir,
-        "components/Memo.js",
-        `import React from ${JSON.stringify(import.meta.resolve("react"))};
-         function Component() { return React.createElement("span", null, "memo"); }
-         export default React.memo(Component);`,
-      );
+      const react = JSON.stringify(import.meta.resolve("react"));
+      // One case per accepted exotic marker: a page whose default export is a
+      // forwardRef or a lazy component must hydrate just like a memo one.
+      const wrappers = {
+        Memo: "React.memo(Component)",
+        ForwardRef: "React.forwardRef(function Wrapped(props, ref) { return Component(props); })",
+        Lazy: "React.lazy(() => Promise.resolve({ default: Component }))",
+      };
+
+      for (const [name, wrapper] of Object.entries(wrappers)) {
+        await writeModule(
+          tempDir,
+          `components/${name}.js`,
+          `import React from ${react};
+         function Component() { return React.createElement("span", null, ${JSON.stringify(name)}); }
+         export default ${wrapper};`,
+        );
+      }
 
       await withModuleServerUrl(tempDir, async () => {
-        const component = await loadComponent("components/Memo.tsx");
-        assertEquals(component !== null, true);
-        assertStrictEquals(getCachedComponent("components/Memo.tsx"), component);
+        for (const name of Object.keys(wrappers)) {
+          const path = `components/${name}.tsx`;
+          const component = await loadComponent(path);
+          assertEquals(component !== null, true, `${path} must be accepted as a React component`);
+          assertStrictEquals(getCachedComponent(path), component);
+        }
       });
     }, { prefix: "vf-client-loader-exotic-" });
   });

--- a/src/client/spa/page-data.test.ts
+++ b/src/client/spa/page-data.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { PageDataResponse } from "./page-data.ts";
+import { MAX_SPA_RESOURCE_KEY_LENGTH } from "./validation.ts";
 import { snapshotPageData } from "./page-data.ts";
 
 function validPageData(): PageDataResponse {
@@ -128,13 +129,140 @@ describe("client/spa/page-data", () => {
     assertThrows(() => snapshotPageData(pageData), TypeError);
   });
 
-  it("rejects page-authored data beyond the aggregate entry budget", () => {
+  it("rejects page-authored arrays beyond the per-array length cap", () => {
     const pageData = validPageData();
     pageData.props = {
       values: Array.from({ length: 65_537 }, (_, index) => index),
     };
 
-    assertThrows(() => snapshotPageData(pageData), TypeError);
+    assertThrows(
+      () => snapshotPageData(pageData),
+      TypeError,
+      "props must contain at most 65535 entries",
+      "a single array longer than the remaining budget is rejected by the length check",
+    );
+  });
+
+  it("rejects page-authored data that exceeds the aggregate budget across containers", () => {
+    const wide = (size: number) =>
+      Object.fromEntries(Array.from({ length: size }, (_, index) => [String(index), 0]));
+
+    const siblings = validPageData();
+    siblings.props = { a: wide(40_000), b: wide(40_000) };
+    assertThrows(
+      () => snapshotPageData(siblings),
+      TypeError,
+      "65536",
+      "the aggregate entry budget must reject two containers that are each individually legal",
+    );
+
+    const split = validPageData();
+    split.frontmatter = { a: wide(40_000) };
+    split.props = { b: wide(40_000) };
+    assertThrows(
+      () => snapshotPageData(split),
+      TypeError,
+      "65536",
+      "the aggregate entry budget is shared by frontmatter, props and layoutProps",
+    );
+  });
+
+  it("rejects page-authored data nested beyond the depth cap", () => {
+    const nest = (levels: number) => {
+      let node: Record<string, unknown> = {};
+      for (let index = 0; index < levels; index++) node = { child: node };
+      return node;
+    };
+
+    const tooDeep = validPageData();
+    tooDeep.props = { root: nest(63) };
+    assertThrows(
+      () => snapshotPageData(tooDeep),
+      TypeError,
+      "nested at most 64 levels",
+      "data past the depth cap is rejected by the module rather than the runtime stack",
+    );
+
+    const withinCap = validPageData();
+    withinCap.props = { root: nest(62) };
+    assertEquals(
+      typeof snapshotPageData(withinCap).props.root,
+      "object",
+      "data just inside the depth cap is still captured",
+    );
+  });
+
+  it("captures and validates the redirect branch", () => {
+    const withRedirect = validPageData();
+    withRedirect.redirect = { destination: "/next", permanent: true };
+
+    const snapshot = snapshotPageData(withRedirect);
+    assertEquals(
+      snapshot.redirect,
+      { destination: "/next", permanent: true },
+      "a valid redirect survives the snapshot",
+    );
+    assertEquals(Object.isFrozen(snapshot.redirect), true, "the captured redirect is frozen");
+
+    assertThrows(
+      () => snapshotPageData({ ...validPageData(), redirect: { destination: "/next\n" } }),
+      TypeError,
+      "redirect.destination",
+      "a control character in the redirect destination is rejected",
+    );
+    assertThrows(
+      () =>
+        snapshotPageData({
+          ...validPageData(),
+          redirect: { destination: `/${"x".repeat(MAX_SPA_RESOURCE_KEY_LENGTH)}` },
+        }),
+      TypeError,
+      "redirect.destination",
+      "an over-long redirect destination is rejected",
+    );
+
+    const looseFlag = validPageData();
+    looseFlag.redirect = { destination: "/next", permanent: "yes" as unknown as boolean };
+    assertEquals(
+      snapshotPageData(looseFlag).redirect,
+      { destination: "/next" },
+      "a non-boolean permanent is dropped rather than copied",
+    );
+  });
+
+  it("freezes the control-surface collections it rebuilds", () => {
+    const pageData = validPageData();
+    pageData.layouts = [{ kind: "tsx", path: "layouts/main.tsx" }];
+    pageData.providers = ["providers/theme.tsx"];
+    pageData.params = { slug: "home", tags: ["a", "b"] };
+
+    const snapshot = snapshotPageData(pageData);
+
+    assertEquals(
+      Object.isFrozen(snapshot.layouts),
+      true,
+      "the layouts array is frozen so a later caller cannot append a layout",
+    );
+    assertEquals(
+      Object.isFrozen(snapshot.layouts[0]),
+      true,
+      "each layout entry is frozen so its path cannot be rewritten after capture",
+    );
+    assertEquals(
+      Object.isFrozen(snapshot.providers),
+      true,
+      "the providers array is frozen so a later caller cannot append a provider",
+    );
+    assertEquals(
+      Object.isFrozen(snapshot.params),
+      true,
+      "the params record is frozen so a later caller cannot add a route parameter",
+    );
+    assertEquals(
+      Object.isFrozen(snapshot.params.tags),
+      true,
+      "multi-segment route parameters are frozen too",
+    );
   });
 
   it("rejects sparse or accessor-backed arrays at admission", () => {

--- a/src/client/spa/path-utils.test.ts
+++ b/src/client/spa/path-utils.test.ts
@@ -73,6 +73,26 @@ function withReleaseAssetModules<T>(value: unknown, fn: () => T): T {
   }
 }
 
+function withGlobalFlag<T>(
+  key: "__veryfrontStudioEmbed" | "__veryfrontHMRRefreshTimestamp",
+  value: boolean | string,
+  fn: () => T,
+): T {
+  const globalRecord = globalThis as unknown as MutableTestGlobal;
+  const previous = globalRecord[key];
+  (globalRecord as Record<string, unknown>)[key] = value;
+
+  try {
+    return fn();
+  } finally {
+    if (previous === undefined) {
+      delete globalRecord[key];
+    } else {
+      (globalRecord as Record<string, unknown>)[key] = previous;
+    }
+  }
+}
+
 describe("client/spa/path-utils", () => {
   describe("getModuleServerUrl", () => {
     it("uses the browser-configured module server url when available", () => {
@@ -152,6 +172,38 @@ describe("client/spa/path-utils", () => {
           );
         },
       );
+    });
+
+    it("never pins release assets during Studio embed or HMR sessions", () => {
+      const assetUrl = "/_vf/assets/" + "d".repeat(64) + ".js";
+
+      withReleaseAssetModules({ "pages/index.tsx": assetUrl }, () => {
+        withGlobalFlag("__veryfrontStudioEmbed", true, () => {
+          assertEquals(
+            pathToModuleUrl("pages/index.tsx"),
+            "/_vf_modules/pages/index.js",
+            "Studio embed loads freshly compiled modules, not pinned release assets",
+          );
+          assertEquals(
+            runGeneratedPathToModuleUrl("pages/index.tsx"),
+            "/_vf_modules/pages/index.js",
+            "the generated helper also skips pinned release assets during Studio embed",
+          );
+        });
+
+        withGlobalFlag("__veryfrontHMRRefreshTimestamp", "42", () => {
+          assertEquals(
+            pathToModuleUrl("pages/index.tsx"),
+            "/_vf_modules/pages/index.js",
+            "HMR sessions load freshly compiled modules, not pinned release assets",
+          );
+          assertEquals(
+            runGeneratedPathToModuleUrl("pages/index.tsx"),
+            "/_vf_modules/pages/index.js",
+            "the generated helper also skips pinned release assets during HMR sessions",
+          );
+        });
+      });
     });
 
     it("does not fall back to a sibling release asset for an explicit source path", () => {

--- a/src/internal-agents/ag-ui-sse.test.ts
+++ b/src/internal-agents/ag-ui-sse.test.ts
@@ -398,6 +398,29 @@ describe("internal-agents/ag-ui-sse", () => {
       true,
       `elapsedMs must reach the wire, got ${JSON.stringify(stamped)}`,
     );
+    assertEquals(
+      /"emittedAt":\d+/.test(stamped),
+      true,
+      `every frame must carry an absolute emittedAt even when none is supplied, got ${
+        JSON.stringify(stamped)
+      }`,
+    );
+
+    const sanitized = new TextDecoder().decode(
+      formatAgUiEvent("StepStarted", { stepName: "step-1", emittedAt: -1, elapsedMs: -5 }),
+    );
+    assertEquals(
+      /"emittedAt":[1-9]\d*/.test(sanitized),
+      true,
+      `an invalid emittedAt must be replaced with a real timestamp, got ${
+        JSON.stringify(sanitized)
+      }`,
+    );
+    assertEquals(
+      sanitized.includes("elapsedMs"),
+      false,
+      `a negative elapsedMs must be dropped rather than sent, got ${JSON.stringify(sanitized)}`,
+    );
 
     const withEmittedAt = new TextDecoder().decode(
       formatAgUiEvent("StepStarted", { stepName: "step-1", emittedAt: 1_786_000_000_123 }),

--- a/src/internal-agents/request-body.test.ts
+++ b/src/internal-agents/request-body.test.ts
@@ -34,4 +34,28 @@ describe("internal-agents/request-body", () => {
       "Payload too large",
     );
   });
+
+  it("rethrows transport failures instead of reporting an empty body", async () => {
+    const body = new ReadableStream({
+      start(controller) {
+        controller.error(new Error("stream failed"));
+      },
+    });
+    const request = new Request("https://veryfront.test/api/control-plane/runs/run_1/stream", {
+      method: "POST",
+      body,
+      duplex: "half",
+    } as RequestInit);
+
+    const error = await assertRejects(
+      () => readInternalAgentRequestBody(request),
+      Error,
+      "stream failed",
+    );
+    assertEquals(
+      error instanceof InternalAgentRequestBodyTooLargeError,
+      false,
+      "a stream failure must not be reclassified as a payload-too-large error",
+    );
+  });
 });

--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -1812,6 +1812,66 @@ describe("internal-agents/run-stream", () => {
     assertEquals(capturedToolNames, ["read_baseline"]);
   });
 
+  it("strips invoke_agent from the remote tool grants when delegation is denied", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    let capturedAllowedRemoteTools: string[] | undefined;
+    let capturedToolNames: string[] = [];
+
+    const agent = {
+      id: "ops-agent",
+      config: {
+        id: "ops-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+        __vfAllowedRemoteTools: ["invoke_agent"],
+        tools: {
+          read_baseline: { description: "Read the telemetry baseline" },
+          invoke_agent: { description: "Delegate to another agent" },
+        },
+      },
+    } as unknown as Agent;
+
+    const input = {
+      agentId: "ops-agent",
+      threadId: crypto.randomUUID(),
+      runId: "run_1",
+      messages: [],
+      tools: [],
+      context: [],
+      allowDelegation: false,
+      forwardedProps: {
+        runtimeOverrides: {
+          allowedTools: ["search_knowledge"],
+        },
+      },
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    await createRuntimeAgentStreamResponse(input, agent, {
+      sessionManager,
+      createRuntime: (runtimeAgent, mergedTools) => {
+        capturedAllowedRemoteTools = (
+          runtimeAgent.config as Agent["config"] & { __vfAllowedRemoteTools?: string[] }
+        ).__vfAllowedRemoteTools;
+        capturedToolNames = Object.keys(mergedTools ?? {}).sort();
+        return {
+          stream: async () =>
+            new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.close();
+              },
+            }),
+        };
+      },
+    });
+
+    assertEquals(
+      capturedAllowedRemoteTools,
+      ["search_knowledge"],
+      "a signed request denying delegation must strip invoke_agent from the remote grants too",
+    );
+    assertEquals(capturedToolNames.includes("invoke_agent"), false);
+  });
+
   it("preserves invoke_agent delegation when visible skills are hidden from the catalog", async () => {
     registerSkill("handoff", {
       id: "handoff",
@@ -2792,6 +2852,86 @@ describe("internal-agents/run-stream", () => {
     assertEquals(runtimeCancelCalls, 1);
     assertEquals(runtimeStream?.locked, false);
     assertEquals(sessionManager.getRunStatus(input.runId), null);
+  });
+
+  it("pre-registers the tool-result wait when a tool call starts streaming", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    const agent = {
+      id: "tool-wait-agent",
+      config: {
+        id: "tool-wait-agent",
+        model: "anthropic/claude-opus-4-6",
+        system: "test",
+      },
+    } as unknown as Agent;
+    const input = {
+      agentId: agent.id,
+      threadId: crypto.randomUUID(),
+      runId: "run_tool_wait",
+      messages: [],
+      tools: [],
+      context: [],
+    } as Parameters<typeof createRuntimeAgentStreamResponse>[0];
+
+    let runtimeController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const response = await createRuntimeAgentStreamResponse(input, agent, {
+      sessionManager,
+      createRuntime: () => ({
+        stream: async () =>
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              runtimeController = controller;
+              controller.enqueue(
+                new TextEncoder().encode(
+                  'data: {"type":"tool-input-start","toolCallId":"tool-1","toolName":"bash"}\n\n',
+                ),
+              );
+            },
+          }),
+      }),
+    });
+
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error("Expected a runtime response body");
+    }
+
+    const decoder = new TextDecoder();
+    let streamed = "";
+    while (!streamed.includes("event: ToolCallStart")) {
+      const chunk = await reader.read();
+      if (chunk.done) {
+        break;
+      }
+      streamed += decoder.decode(chunk.value, { stream: true });
+    }
+    assertStringIncludes(streamed, "event: ToolCallStart");
+
+    // A Studio client can POST its result before the runtime invokes the tool,
+    // so the wait has to exist as soon as the frame reaches the client.
+    let thrown: unknown;
+    try {
+      sessionManager.submitToolResult(input.runId, {
+        toolCallId: "tool-1",
+        result: { ok: true },
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    assertEquals(
+      thrown,
+      undefined,
+      "the tool-result wait must be pre-registered when ToolCallStart is emitted",
+    );
+
+    runtimeController?.close();
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) {
+        break;
+      }
+    }
+    reader.releaseLock();
   });
 
   it("cancels an active runtime stream when the client disconnects before a tool wait", async () => {

--- a/src/internal-agents/runtime-owner.test.ts
+++ b/src/internal-agents/runtime-owner.test.ts
@@ -57,6 +57,107 @@ describe("internal-agents/runtime-owner", () => {
     assertEquals(ownerUrl, "http://10.0.0.9:20000/channels/invoke");
   });
 
+  it("prefers VERYFRONT_RUNTIME_OWNER_HOST over POD_IP", async () => {
+    const request = new Request(
+      "https://demo-project.preview.veryfront.org/api/control-plane/runs/run_1/stream",
+    );
+
+    const ownerUrl = await resolveRuntimeOwnerInvokeUrl(request, {
+      getHostEnv: (key) => {
+        if (key === "VERYFRONT_RUNTIME_OWNER_HOST") return "10.9.9.9";
+        if (key === "POD_IP") return "10.0.0.7";
+        if (key === "VERYFRONT_RUNTIME_OWNER_PORT") return "20000";
+        return undefined;
+      },
+      getDenoNetworkInterfaces: () => [],
+      dynamicImport: createDynamicImportStub({
+        networkInterfaces: () => ({}),
+      }),
+    });
+
+    assertEquals(
+      ownerUrl,
+      "http://10.9.9.9:20000/channels/invoke",
+      "VERYFRONT_RUNTIME_OWNER_HOST outranks POD_IP",
+    );
+  });
+
+  it("prefers VERYFRONT_SERVER_PORT over the request url port", async () => {
+    const request = new Request(
+      "https://demo-project.preview.veryfront.org:21000/api/control-plane/runs/run_1/stream",
+    );
+
+    const ownerUrl = await resolveRuntimeOwnerInvokeUrl(request, {
+      getHostEnv: (key) => {
+        if (key === "POD_IP") return "10.0.0.7";
+        if (key === "VERYFRONT_SERVER_PORT") return "20500";
+        return undefined;
+      },
+      getDenoNetworkInterfaces: () => [],
+      dynamicImport: createDynamicImportStub({
+        networkInterfaces: () => ({}),
+      }),
+    });
+
+    assertEquals(
+      ownerUrl,
+      "http://10.0.0.7:20500/channels/invoke",
+      "VERYFRONT_SERVER_PORT outranks the request url port",
+    );
+  });
+
+  it("falls back to node:os interfaces when the Deno probe yields nothing", async () => {
+    const request = new Request(
+      "https://demo-project.preview.veryfront.org/api/control-plane/runs/run_1/stream",
+    );
+
+    const ownerUrl = await resolveRuntimeOwnerInvokeUrl(request, {
+      getHostEnv: (key) => {
+        if (key === "PROXY_MODE") return "1";
+        return undefined;
+      },
+      getDenoNetworkInterfaces: () => [],
+      dynamicImport: createDynamicImportStub({
+        networkInterfaces: () => ({
+          lo: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+          eth0: [{ address: "10.1.2.3", family: "IPv4", internal: false }],
+        }),
+      }),
+    });
+
+    assertEquals(
+      ownerUrl,
+      "http://10.1.2.3:20000/channels/invoke",
+      "the node:os interface host must reach the owner url",
+    );
+  });
+
+  it("skips a loopback address that is not reported as internal", async () => {
+    const request = new Request(
+      "https://demo-project.preview.veryfront.org/api/control-plane/runs/run_1/stream",
+    );
+
+    const ownerUrl = await resolveRuntimeOwnerInvokeUrl(request, {
+      getHostEnv: (key) => {
+        if (key === "PROXY_MODE") return "1";
+        return undefined;
+      },
+      getDenoNetworkInterfaces: () => [
+        { address: "127.0.0.1", family: "IPv4", internal: false },
+        { address: "10.0.0.9", family: "IPv4", internal: false },
+      ],
+      dynamicImport: createDynamicImportStub({
+        networkInterfaces: () => ({}),
+      }),
+    });
+
+    assertEquals(
+      ownerUrl,
+      "http://10.0.0.9:20000/channels/invoke",
+      "a loopback address is never advertised as the runtime owner host even when the interface is not flagged internal",
+    );
+  });
+
   it("does not let a generic PORT env override the runtime listener port", async () => {
     const request = new Request(
       "https://demo-project.preview.veryfront.org:21000/api/control-plane/runs/run_1/stream",

--- a/src/internal-agents/schema.test.ts
+++ b/src/internal-agents/schema.test.ts
@@ -374,6 +374,90 @@ describe("internal-agents/schema", () => {
     );
   });
 
+  it("caps runtime collections on control-plane stream requests", () => {
+    const base = {
+      agentId: "agent_1",
+      threadId: "10000000-1000-4000-8000-100000000001",
+      runId: "run_1",
+      ...MAIN_BRANCH_TARGET,
+      agentSource: { type: "branch", branch: "main" },
+      messages: [],
+    };
+    const messages = (count: number) =>
+      Array.from({ length: count }, (_, index) => ({
+        id: `m${index}`,
+        role: "user" as const,
+        parts: [],
+      }));
+    const tools = (count: number) =>
+      Array.from({ length: count }, (_, index) => ({
+        name: `tool_${index}`,
+        parameters: {},
+      }));
+    const context = (count: number) =>
+      Array.from({ length: count }, () => ({ type: "text" as const, text: "x" }));
+
+    assertEquals(
+      getInternalAgentStreamRequestSchema().parse({ ...base, messages: messages(100) })
+        .messages.length,
+      100,
+      "the message cap itself must still parse",
+    );
+    assertThrows(
+      () => getInternalAgentStreamRequestSchema().parse({ ...base, messages: messages(101) }),
+      Error,
+      "expected array to have <=100 items",
+    );
+
+    assertEquals(
+      getInternalAgentStreamRequestSchema().parse({ ...base, tools: tools(50) }).tools.length,
+      50,
+      "the injected tool cap itself must still parse",
+    );
+    assertThrows(
+      () => getInternalAgentStreamRequestSchema().parse({ ...base, tools: tools(51) }),
+      Error,
+      "expected array to have <=50 items",
+    );
+
+    assertEquals(
+      getInternalAgentStreamRequestSchema().parse({ ...base, context: context(10) })
+        .context.length,
+      10,
+      "the context cap itself must still parse",
+    );
+    assertThrows(
+      () => getInternalAgentStreamRequestSchema().parse({ ...base, context: context(11) }),
+      Error,
+      "expected array to have <=10 items",
+    );
+  });
+
+  it("rejects agent ids outside the id character and length contract", () => {
+    const base = {
+      threadId: "10000000-1000-4000-8000-100000000001",
+      runId: "run_1",
+      ...MAIN_BRANCH_TARGET,
+      agentSource: { type: "branch", branch: "main" },
+      messages: [],
+    };
+
+    for (const agentId of ["../escape", "agents/one", "agent id", "", "a".repeat(129)]) {
+      assertThrows(
+        () => getInternalAgentStreamRequestSchema().parse({ ...base, agentId }),
+        Error,
+        undefined,
+        `agentId ${JSON.stringify(agentId)} must be rejected`,
+      );
+    }
+
+    assertEquals(
+      getInternalAgentStreamRequestSchema().parse({ ...base, agentId: "agent_1-2" }).agentId,
+      "agent_1-2",
+      "ids inside the contract must still parse",
+    );
+  });
+
   it("rejects mismatched agent config on control-plane stream payloads", () => {
     assertThrows(
       () =>

--- a/src/internal-agents/session-manager.test.ts
+++ b/src/internal-agents/session-manager.test.ts
@@ -40,6 +40,74 @@ describe("internal-agents/session-manager", () => {
     );
   });
 
+  it("treats key-reordered tool results as the same result", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    const pending = sessionManager.waitForToolResult("run_1", "tool_1");
+
+    assertEquals(
+      sessionManager.submitToolResult("run_1", {
+        toolCallId: "tool_1",
+        result: { a: 1, b: 2, nested: { x: 1, y: 2 } },
+      }),
+      { accepted: true },
+    );
+    await pending;
+
+    assertEquals(
+      sessionManager.submitToolResult("run_1", {
+        toolCallId: "tool_1",
+        result: { nested: { y: 2, x: 1 }, b: 2, a: 1 },
+      }),
+      { accepted: true, duplicate: true },
+      "a retry with reordered JSON keys is the same result, not a conflict",
+    );
+
+    await assertRejects(
+      async () => {
+        sessionManager.submitToolResult("run_1", {
+          toolCallId: "tool_1",
+          result: { a: 1, b: 3, nested: { x: 1, y: 2 } },
+        });
+      },
+      ToolResultConflictError,
+    );
+    sessionManager.completeRun("run_1");
+  });
+
+  it("hands a client-reported tool failure to the agent as an error", async () => {
+    const sessionManager = new AgentRunSessionManager();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    const pending = sessionManager.waitForToolResult("run_1", "tool_1");
+
+    assertEquals(
+      sessionManager.submitToolResult("run_1", {
+        toolCallId: "tool_1",
+        result: { message: "permission denied" },
+        isError: true,
+      }),
+      { accepted: true },
+    );
+    assertEquals(
+      await pending,
+      { result: { message: "permission denied" }, isError: true },
+      "a failed client tool call must reach the agent flagged as an error",
+    );
+
+    await assertRejects(
+      async () => {
+        sessionManager.submitToolResult("run_1", {
+          toolCallId: "tool_1",
+          result: { message: "permission denied" },
+        });
+      },
+      ToolResultConflictError,
+    );
+    sessionManager.completeRun("run_1");
+  });
+
   it("buffers submissions that arrive before the tool call starts waiting", async () => {
     const sessionManager = new AgentRunSessionManager();
     sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });

--- a/src/mcp/elicitation.test.ts
+++ b/src/mcp/elicitation.test.ts
@@ -37,6 +37,11 @@ describe("mcp/elicitation", () => {
     });
     assertEquals(request.method, "elicitation/create");
     assertEquals(request.params.mode, "url");
+    assertEquals(
+      request.params.message,
+      "Please authorize with GitHub",
+      "url elicitation forwards the caller's message to the client",
+    );
     assertEquals(request.params.url, "https://example.com/auth");
     assertEquals(request.params.elicitationId, "elicit-123");
   });

--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -248,6 +248,32 @@ describe("mcp/server", () => {
 
       assertEquals(response.status, 401);
     });
+
+    it("rejects Authorization headers that are not a well-formed Bearer credential", async () => {
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "bearer", validate: async (token: string) => token === "valid-token" },
+      });
+
+      const handler = server.createHTTPHandler();
+      const cases: [string, string][] = [
+        ["valid-token", "a no-scheme credential is not a bearer token"],
+        ["Basic valid-token", "a non-Bearer scheme is rejected rather than passed through"],
+        ["Bearer   ", "an empty bearer token is rejected"],
+      ];
+
+      for (const [authorization, message] of cases) {
+        const response = await handler(
+          jsonRpcRequest(
+            { jsonrpc: "2.0", id: 1, method: "tools/list" },
+            { ...JSON_HEADERS, Authorization: authorization },
+          ),
+        );
+
+        assertEquals(response.status, 401, message);
+        await response.body?.cancel();
+      }
+    });
   });
 
   describe("request body size limit", () => {
@@ -602,6 +628,51 @@ describe("mcp/server", () => {
 
       assertEquals(response.status, 200);
     });
+
+    it("rejects non-loopback origins on a server with no configured origins", async () => {
+      // The default branch is the actual DNS-rebinding defense: an unconfigured
+      // local `auth: "none"` server must not be reachable from a remote page.
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
+
+      const handler = server.createHTTPHandler();
+      const response = await handler(
+        jsonRpcRequest(
+          { jsonrpc: "2.0", id: 1, method: "tools/list" },
+          { ...JSON_HEADERS, Origin: "https://evil.example" },
+        ),
+      );
+
+      assertEquals(response.status, 403, "an unconfigured server rejects non-loopback origins");
+      const body = await response.json();
+      assertEquals(body.error.message, "Forbidden: Origin not allowed");
+    });
+
+    it("allows loopback origins on a server with no configured origins", async () => {
+      const server = createMCPServer({
+        enabled: true,
+        auth: { type: "none", allowUnauthenticated: true },
+      });
+
+      const handler = server.createHTTPHandler();
+      for (const origin of ["http://127.0.0.1:5173", "http://localhost:5173"]) {
+        const response = await handler(
+          jsonRpcRequest(
+            { jsonrpc: "2.0", id: 1, method: "tools/list" },
+            { ...JSON_HEADERS, Origin: origin },
+          ),
+        );
+
+        assertEquals(
+          response.status,
+          200,
+          `loopback origins remain allowed on an unconfigured server: ${origin}`,
+        );
+        await response.body?.cancel();
+      }
+    });
   });
 
   describe("notifications/initialized", () => {
@@ -677,6 +748,111 @@ describe("mcp/server", () => {
       idempotentHint: true,
       openWorldHint: false,
     });
+  });
+
+  it("hides agent-owned tools from tools/list", async () => {
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
+
+    registerTool("test:owned", {
+      ...dynamicTool({
+        id: "test:owned",
+        description: "Agent-owned",
+        inputSchema: defineSchema((v) => v.object({}))(),
+        execute: async () => ({ ok: true }),
+      }),
+      ownerAgentId: "agent_1",
+    });
+    registerTool(
+      "test:unowned",
+      dynamicTool({
+        id: "test:unowned",
+        description: "Project-wide",
+        inputSchema: defineSchema((v) => v.object({}))(),
+        execute: async () => ({ ok: true }),
+      }),
+    );
+
+    const response = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+    });
+
+    const tools = (response.result as { tools: ToolListEntry[] }).tools;
+    assertEquals(
+      tools.some((t) => t.name === "test:owned"),
+      false,
+      "agent-owned tools must never be listed to MCP clients",
+    );
+    assertEquals(
+      tools.some((t) => t.name === "test:unowned"),
+      true,
+      "unowned tools stay listed",
+    );
+  });
+
+  it("hides and rejects tools disabled for MCP", async () => {
+    const server = createMCPServer({
+      enabled: true,
+      auth: { type: "none", allowUnauthenticated: true },
+    });
+
+    registerTool(
+      "test:mcp-disabled",
+      dynamicTool({
+        id: "test:mcp-disabled",
+        description: "Not offered over MCP",
+        inputSchema: defineSchema((v) => v.object({}))(),
+        execute: async () => ({ ok: true }),
+        mcp: { enabled: false },
+      }),
+    );
+    registerTool(
+      "test:mcp-enabled",
+      dynamicTool({
+        id: "test:mcp-enabled",
+        description: "Offered over MCP",
+        inputSchema: defineSchema((v) => v.object({}))(),
+        execute: async () => ({ ok: true }),
+        mcp: { enabled: true },
+      }),
+    );
+
+    const listed = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+    });
+
+    const tools = (listed.result as { tools: ToolListEntry[] }).tools;
+    assertEquals(
+      tools.some((t) => t.name === "test:mcp-disabled"),
+      false,
+      "MCP-disabled tools must not be listed",
+    );
+    assertEquals(
+      tools.some((t) => t.name === "test:mcp-enabled"),
+      true,
+      "MCP-enabled tools stay listed",
+    );
+
+    const called = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: { name: "test:mcp-disabled", arguments: {} },
+    });
+
+    assertExists(called.error);
+    assertEquals(
+      called.error.code,
+      -32601,
+      "MCP-disabled tools must be rejected at call time",
+    );
+    assertStringIncludes(called.error.message, "Unknown tool");
   });
 
   it("omits title and annotations from tools/list when not configured", async () => {

--- a/src/mcp/session.test.ts
+++ b/src/mcp/session.test.ts
@@ -9,7 +9,22 @@ describe("mcp/session", () => {
     const id = manager.create();
     assertExists(id);
     assertEquals(typeof id, "string");
-    assertEquals(id.length > 16, true); // UUIDs are 36 chars
+    assertEquals(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+        .test(id),
+      true,
+      "session id must be a random v4 UUID",
+    );
+
+    const ids = new Set<string>([id]);
+    for (const source of [manager, new SessionManager()]) {
+      for (let index = 0; index < 200; index++) ids.add(source.create());
+    }
+    assertEquals(
+      ids.size,
+      401,
+      "session ids must never repeat or follow a per-manager sequence",
+    );
   });
 
   it("validates an active session", () => {
@@ -87,5 +102,25 @@ describe("mcp/session", () => {
 
     manager.terminate(id);
     assertEquals(manager.requiresSessionHeader(), false);
+  });
+
+  it("keeps the session header required while other sessions are active", () => {
+    const manager = new SessionManager();
+    const first = manager.create();
+    const second = manager.create();
+
+    manager.terminate(first);
+    assertEquals(
+      manager.requiresSessionHeader(),
+      true,
+      "the session header stays required while another session is still active",
+    );
+
+    manager.terminate(second);
+    assertEquals(
+      manager.requiresSessionHeader(),
+      false,
+      "the session header requirement clears once the last session is terminated",
+    );
   });
 });

--- a/src/mcp/task-store.test.ts
+++ b/src/mcp/task-store.test.ts
@@ -13,6 +13,11 @@ describe("mcp/task-store", () => {
     assertExists(task.createdAt);
     assertExists(task.lastUpdatedAt);
     assertEquals(task.ttl, 60000);
+    assertEquals(
+      task.pollInterval,
+      2000,
+      "created tasks must advertise the default poll interval to MCP clients",
+    );
   });
 
   it("gets a task by ID", () => {
@@ -54,6 +59,11 @@ describe("mcp/task-store", () => {
     const cancelled = store.cancel(task.taskId);
     assertEquals(cancelled, true);
     assertEquals(store.get(task.taskId)!.status, "cancelled");
+    assertEquals(
+      store.get(task.taskId)!.statusMessage,
+      "The task was cancelled by request.",
+      "cancelled tasks must carry a cancellation reason",
+    );
   });
 
   it("rejects cancel on already-completed task", () => {
@@ -70,6 +80,22 @@ describe("mcp/task-store", () => {
     store.create(60000);
     const tasks = store.list();
     assertEquals(tasks.length, 2);
+  });
+
+  it("does not list tasks that get() reports as expired", () => {
+    using time = new FakeTime();
+    const store = new TaskStore();
+    const task = store.create(1);
+    store.complete(task.taskId, { ok: true });
+
+    time.tick(2);
+
+    assertEquals(
+      store.list().length,
+      0,
+      "tasks/list must not advertise a task tasks/get answers not-found for",
+    );
+    assertEquals(store.get(task.taskId), undefined, "the same task is gone from get()");
   });
 
   it("retrieves result for completed task", () => {

--- a/src/mcp/task-store.ts
+++ b/src/mcp/task-store.ts
@@ -91,7 +91,17 @@ export class TaskStore {
 
   list(): Task[] {
     this.lazySweep();
-    return Array.from(this.tasks.values());
+    const tasks: Task[] = [];
+    for (const [id, task] of this.tasks) {
+      // Mirror get(): an expired terminal task is gone, never advertised.
+      if (this.isExpired(task)) {
+        this.tasks.delete(id);
+        this.results.delete(id);
+        continue;
+      }
+      tasks.push(task);
+    }
+    return tasks;
   }
 
   clear(): void {

--- a/src/studio/bridge/bridge-config.test.ts
+++ b/src/studio/bridge/bridge-config.test.ts
@@ -66,6 +66,45 @@ describe("studio/bridge/bridge-config", () => {
     initConfig();
 
     assertEquals(getConfig().studioMode, "simple");
+    assertEquals(
+      getConfig().pagePath,
+      "page-1.mdx",
+      "an explicitly injected pagePath wins over pageId",
+    );
+  });
+
+  it("honors the injected simple mode without a query override", () => {
+    setTestWindow("");
+    setInjectedConfig({
+      projectId: "project-1",
+      pageId: "page-1",
+      studioMode: "simple",
+    });
+
+    initConfig();
+
+    assertEquals(
+      getConfig().studioMode,
+      "simple",
+      "injected studioMode simple must win with an empty query string",
+    );
+  });
+
+  it("falls back to advanced for an unrecognized injected mode", () => {
+    setTestWindow("");
+    setInjectedConfig({
+      projectId: "project-1",
+      pageId: "page-1",
+      studioMode: "SIMPLE",
+    });
+
+    initConfig();
+
+    assertEquals(
+      getConfig().studioMode,
+      "advanced",
+      "only the exact value simple selects simple mode",
+    );
   });
 
   it("normalizes injected config values and falls back pagePath to pageId", () => {

--- a/src/studio/bridge/bridge-message-handler.test.ts
+++ b/src/studio/bridge/bridge-message-handler.test.ts
@@ -3,7 +3,8 @@ import "#veryfront/schemas/_test-setup.ts";
  * Tests for bridge-message-handler: URL validation and route handling.
  */
 
-import { assertEquals } from "@std/assert";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
 import { waitFor } from "#veryfront/testing/deno-compat.ts";
 import { setConfigForTest } from "./bridge-config.ts";
 import {
@@ -140,427 +141,441 @@ async function withScreenshotDom(run: () => Promise<void>): Promise<void> {
 // isSafeNavigationUrl
 // ---------------------------------------------------------------------------
 
-Deno.test("isSafeNavigationUrl: allows relative URLs", () => {
-  assertEquals(isSafeNavigationUrl("/page"), true);
-  assertEquals(isSafeNavigationUrl("/some/deep/path"), true);
-});
-
-Deno.test("isSafeNavigationUrl: allows same-origin https URLs", () => {
-  assertEquals(isSafeNavigationUrl("https://test.veryfront.com/page"), true);
-});
-
-Deno.test("isSafeNavigationUrl: allows veryfront.com URLs", () => {
-  assertEquals(isSafeNavigationUrl("https://veryfront.com/page"), true);
-  assertEquals(isSafeNavigationUrl("https://slug.preview.veryfront.com/page"), true);
-});
-
-Deno.test("isSafeNavigationUrl: blocks protocol-relative URLs", () => {
-  assertEquals(isSafeNavigationUrl("//evil.com/path"), false);
-  assertEquals(isSafeNavigationUrl("//evil.com"), false);
-});
-
-Deno.test("isSafeNavigationUrl: blocks non-veryfront URLs", () => {
-  assertEquals(isSafeNavigationUrl("https://example.com/page"), false);
-  assertEquals(isSafeNavigationUrl("http://evil.com/page"), false);
-});
-
-Deno.test("isSafeNavigationUrl: blocks javascript: URLs", () => {
-  assertEquals(isSafeNavigationUrl("javascript:alert(1)"), false);
-  assertEquals(isSafeNavigationUrl("JavaScript:alert(1)"), false);
-});
-
-Deno.test("isSafeNavigationUrl: blocks data: URLs", () => {
-  assertEquals(isSafeNavigationUrl("data:text/html,<script>alert(1)</script>"), false);
-});
-
-Deno.test("isSafeNavigationUrl: blocks vbscript: URLs", () => {
-  assertEquals(isSafeNavigationUrl("vbscript:msgbox"), false);
-});
-
-Deno.test("isSafeNavigationUrl: blocks non-web protocols", () => {
-  assertEquals(isSafeNavigationUrl("mailto:user@example.com"), false);
-  assertEquals(isSafeNavigationUrl("intent://example.com"), false);
-  assertEquals(isSafeNavigationUrl("ftp://example.com/file"), false);
-});
-
-// ---------------------------------------------------------------------------
-// routeChange: URL validation
-// ---------------------------------------------------------------------------
-
-Deno.test("routeChange: navigates for safe relative URL", () => {
-  resetState();
-  let navigatedTo = "";
-  (globalThis as any).location.href = "https://test.veryfront.com/test";
-  Object.defineProperty(globalThis.location, "href", {
-    set(v: string) {
-      navigatedTo = v;
-    },
-    get() {
-      return "https://test.veryfront.com/test";
-    },
-    configurable: true,
+describe("studio/bridge/bridge-message-handler", () => {
+  it("isSafeNavigationUrl: allows relative URLs", () => {
+    assertEquals(isSafeNavigationUrl("/page"), true);
+    assertEquals(isSafeNavigationUrl("/some/deep/path"), true);
   });
 
-  handleStudioMessage(makeEvent({ action: "routeChange", url: "/new-page" }));
-  assertEquals(navigatedTo, "https://test.veryfront.com/new-page");
-
-  // Restore
-  Object.defineProperty(globalThis.location, "href", {
-    value: "https://test.veryfront.com/test",
-    writable: true,
-    configurable: true,
-  });
-});
-
-Deno.test("routeChange: ignores a message from an untrusted origin", () => {
-  resetState();
-  state.selectedNodeId = "node-123";
-  state.selectionOverlay = makeOverlay();
-  const navigation = captureNavigation();
-
-  try {
-    handleStudioMessage(
-      {
-        data: { action: "routeChange", url: "/new-page" },
-        origin: "https://evil.com",
-        source: fakeParentWindow,
-        ports: [],
-      } as unknown as MessageEvent,
-    );
-
-    assertEquals(
-      navigation.navigatedTo(),
-      "",
-      "a message from an untrusted origin must not navigate",
-    );
-    assertEquals(
-      state.selectedNodeId,
-      "node-123",
-      "the origin guard must run before any state is mutated",
-    );
-  } finally {
-    navigation.restore();
-  }
-});
-
-Deno.test("routeChange: ignores a message from a window other than the studio parent", () => {
-  resetState();
-  const navigation = captureNavigation();
-
-  try {
-    handleStudioMessage(
-      {
-        data: { action: "routeChange", url: "/new-page" },
-        origin: "https://veryfront.com",
-        source: { postMessage(): void {} } as unknown as Window,
-        ports: [],
-      } as unknown as MessageEvent,
-    );
-
-    assertEquals(
-      navigation.navigatedTo(),
-      "",
-      "a message from a window other than the studio parent must not navigate",
-    );
-  } finally {
-    navigation.restore();
-  }
-});
-
-Deno.test("routeChange: blocks protocol-relative URL", () => {
-  resetState();
-  let navigatedTo = "";
-  Object.defineProperty(globalThis.location, "href", {
-    set(v: string) {
-      navigatedTo = v;
-    },
-    get() {
-      return "https://test.veryfront.com/test";
-    },
-    configurable: true,
+  it("isSafeNavigationUrl: allows same-origin https URLs", () => {
+    assertEquals(isSafeNavigationUrl("https://test.veryfront.com/page"), true);
   });
 
-  handleStudioMessage(makeEvent({ action: "routeChange", url: "//evil.com/path" }));
-  assertEquals(navigatedTo, ""); // Should NOT navigate
-
-  // Restore
-  Object.defineProperty(globalThis.location, "href", {
-    value: "https://test.veryfront.com/test",
-    writable: true,
-    configurable: true,
-  });
-});
-
-Deno.test("routeChange: blocks javascript: URL", () => {
-  resetState();
-  let navigatedTo = "";
-  Object.defineProperty(globalThis.location, "href", {
-    set(v: string) {
-      navigatedTo = v;
-    },
-    get() {
-      return "https://test.veryfront.com/test";
-    },
-    configurable: true,
+  it("isSafeNavigationUrl: allows veryfront.com URLs", () => {
+    assertEquals(isSafeNavigationUrl("https://veryfront.com/page"), true);
+    assertEquals(isSafeNavigationUrl("https://slug.preview.veryfront.com/page"), true);
   });
 
-  handleStudioMessage(makeEvent({ action: "routeChange", url: "javascript:alert(1)" }));
-  assertEquals(navigatedTo, ""); // Should NOT navigate
-
-  // Restore
-  Object.defineProperty(globalThis.location, "href", {
-    value: "https://test.veryfront.com/test",
-    writable: true,
-    configurable: true,
-  });
-});
-
-Deno.test("routeChange: assigns normalized URL, not raw input", () => {
-  resetState();
-  let navigatedTo = "";
-  Object.defineProperty(globalThis.location, "href", {
-    set(v: string) {
-      navigatedTo = v;
-    },
-    get() {
-      return "https://test.veryfront.com/test";
-    },
-    configurable: true,
+  it("isSafeNavigationUrl: blocks protocol-relative URLs", () => {
+    assertEquals(isSafeNavigationUrl("//evil.com/path"), false);
+    assertEquals(isSafeNavigationUrl("//evil.com"), false);
   });
 
-  // Path traversal gets normalized by new URL().href — proves the handler uses
-  // the sanitized value rather than the raw postMessage input.
-  handleStudioMessage(
-    makeEvent({ action: "routeChange", url: "https://test.veryfront.com/a/../b" }),
-  );
-  assertEquals(navigatedTo, "https://test.veryfront.com/b");
-
-  Object.defineProperty(globalThis.location, "href", {
-    value: "https://test.veryfront.com/test",
-    writable: true,
-    configurable: true,
-  });
-});
-
-Deno.test("routeChange: clears existing selection before navigating", () => {
-  resetState();
-  state.selectedNodeId = "node-123";
-  state.selectionOverlay = makeOverlay();
-
-  let navigatedTo = "";
-  Object.defineProperty(globalThis.location, "href", {
-    set(v: string) {
-      navigatedTo = v;
-    },
-    get() {
-      return "https://test.veryfront.com/test";
-    },
-    configurable: true,
+  it("isSafeNavigationUrl: blocks non-veryfront URLs", () => {
+    assertEquals(isSafeNavigationUrl("https://example.com/page"), false);
+    assertEquals(isSafeNavigationUrl("http://evil.com/page"), false);
   });
 
-  handleStudioMessage(makeEvent({ action: "routeChange", url: "/new-page" }));
-
-  assertEquals(state.selectedNodeId, null);
-  assertEquals(state.selectionOverlay?.style.display, "none");
-  assertEquals(navigatedTo, "https://test.veryfront.com/new-page");
-  assertEquals(
-    postedToStudio[0],
-    { action: "setSelectedNode", id: null },
-    "the preview tells Studio the selection was dropped before navigating",
-  );
-  assertEquals(
-    postedToStudio[1],
-    {
-      action: "onPageTransitionStart",
-      url: "https://test.veryfront.com/new-page",
-      projectId: "proj-id",
-    },
-    "Studio is notified with the sanitized URL, not the raw input",
-  );
-
-  Object.defineProperty(globalThis.location, "href", {
-    value: "https://test.veryfront.com/test",
-    writable: true,
-    configurable: true,
+  it("isSafeNavigationUrl: blocks javascript: URLs", () => {
+    assertEquals(isSafeNavigationUrl("javascript:alert(1)"), false);
+    assertEquals(isSafeNavigationUrl("JavaScript:alert(1)"), false);
   });
-});
 
-Deno.test("toggleInspectMode: disabling inspect mode clears hover state only", () => {
-  resetState();
-  state.inspectMode = true;
-  state.hoveredNodeId = "hovered-node";
-  state.selectedNodeId = "selected-node";
-  state.hoverOverlay = makeOverlay();
-  state.selectionOverlay = makeOverlay();
+  it("isSafeNavigationUrl: blocks data: URLs", () => {
+    assertEquals(isSafeNavigationUrl("data:text/html,<script>alert(1)</script>"), false);
+  });
 
-  handleStudioMessage(makeEvent({ action: "toggleInspectMode", value: false }));
+  it("isSafeNavigationUrl: blocks vbscript: URLs", () => {
+    assertEquals(isSafeNavigationUrl("vbscript:msgbox"), false);
+  });
 
-  assertEquals(state.inspectMode, false);
-  assertEquals(state.hoveredNodeId, null);
-  assertEquals(state.hoverOverlay?.style.display, "none");
-  assertEquals(state.selectedNodeId, "selected-node");
-  assertEquals(state.selectionOverlay?.style.display, "block");
-});
+  it("isSafeNavigationUrl: blocks non-web protocols", () => {
+    assertEquals(isSafeNavigationUrl("mailto:user@example.com"), false);
+    assertEquals(isSafeNavigationUrl("intent://example.com"), false);
+    assertEquals(isSafeNavigationUrl("ftp://example.com/file"), false);
+  });
 
-Deno.test("toggleInspectMode: deselectElements also clears selection", () => {
-  resetState();
-  state.inspectMode = true;
-  state.selectedNodeId = "selected-node";
-  state.selectionOverlay = makeOverlay();
+  // ---------------------------------------------------------------------------
+  // routeChange: URL validation
+  // ---------------------------------------------------------------------------
 
-  handleStudioMessage(
-    makeEvent({ action: "toggleInspectMode", value: false, deselectElements: true }),
-  );
-
-  assertEquals(state.inspectMode, false);
-  assertEquals(state.selectedNodeId, null);
-  assertEquals(state.selectionOverlay?.style.display, "none");
-});
-
-Deno.test("screenshot: answers a single-capture request with a screenshotResult", async () => {
-  resetState();
-
-  await withScreenshotDom(async () => {
-    handleStudioMessage(makeEvent({ action: "screenshot", requestId: "req-1" }));
-    await waitFor(() => postedToStudio.length > 0, {
-      message: "Studio's screenshot request was never answered",
+  it("routeChange: navigates for safe relative URL", () => {
+    resetState();
+    let navigatedTo = "";
+    (globalThis as any).location.href = "https://test.veryfront.com/test";
+    Object.defineProperty(globalThis.location, "href", {
+      set(v: string) {
+        navigatedTo = v;
+      },
+      get() {
+        return "https://test.veryfront.com/test";
+      },
+      configurable: true,
     });
 
-    assertEquals(postedToStudio.length, 1, "a screenshot request is answered exactly once");
-    assertEquals(
-      postedToStudio[0]?.action,
-      "screenshotResult",
-      "the reply must be a screenshotResult",
-    );
-    assertEquals(postedToStudio[0]?.requestId, "req-1", "the reply must carry the requestId back");
-    assertEquals(postedToStudio[0]?.multiple, false, "a single capture is not a multi-section one");
-    assertEquals(postedToStudio[0]?.success, true, "the capture succeeded");
+    handleStudioMessage(makeEvent({ action: "routeChange", url: "/new-page" }));
+    assertEquals(navigatedTo, "https://test.veryfront.com/new-page");
+
+    // Restore
+    Object.defineProperty(globalThis.location, "href", {
+      value: "https://test.veryfront.com/test",
+      writable: true,
+      configurable: true,
+    });
   });
-});
 
-Deno.test("screenshot: routes a multipleSections request to the multi-section capture", async () => {
-  resetState();
+  it("routeChange: ignores a message from an untrusted origin", () => {
+    resetState();
+    state.selectedNodeId = "node-123";
+    state.selectionOverlay = makeOverlay();
+    const navigation = captureNavigation();
 
-  await withScreenshotDom(async () => {
-    handleStudioMessage(
-      makeEvent({
-        action: "screenshot",
-        requestId: "req-2",
-        multipleSections: true,
-        sectionCount: 1,
-      }),
-    );
-    await waitFor(() => postedToStudio.length > 0, {
-      message: "Studio's multi-section screenshot request was never answered",
+    try {
+      handleStudioMessage(
+        {
+          data: { action: "routeChange", url: "/new-page" },
+          origin: "https://evil.com",
+          source: fakeParentWindow,
+          ports: [],
+        } as unknown as MessageEvent,
+      );
+
+      assertEquals(
+        navigation.navigatedTo(),
+        "",
+        "a message from an untrusted origin must not navigate",
+      );
+      assertEquals(
+        state.selectedNodeId,
+        "node-123",
+        "the origin guard must run before any state is mutated",
+      );
+    } finally {
+      navigation.restore();
+    }
+  });
+
+  it("routeChange: ignores a message from a window other than the studio parent", () => {
+    resetState();
+    const navigation = captureNavigation();
+
+    try {
+      handleStudioMessage(
+        {
+          data: { action: "routeChange", url: "/new-page" },
+          origin: "https://veryfront.com",
+          source: { postMessage(): void {} } as unknown as Window,
+          ports: [],
+        } as unknown as MessageEvent,
+      );
+
+      assertEquals(
+        navigation.navigatedTo(),
+        "",
+        "a message from a window other than the studio parent must not navigate",
+      );
+    } finally {
+      navigation.restore();
+    }
+  });
+
+  it("routeChange: blocks protocol-relative URL", () => {
+    resetState();
+    let navigatedTo = "";
+    Object.defineProperty(globalThis.location, "href", {
+      set(v: string) {
+        navigatedTo = v;
+      },
+      get() {
+        return "https://test.veryfront.com/test";
+      },
+      configurable: true,
     });
 
-    assertEquals(postedToStudio.length, 1, "a screenshot request is answered exactly once");
-    assertEquals(
-      postedToStudio[0]?.action,
-      "screenshotResult",
-      "the reply must be a screenshotResult",
+    handleStudioMessage(makeEvent({ action: "routeChange", url: "//evil.com/path" }));
+    assertEquals(navigatedTo, ""); // Should NOT navigate
+
+    // Restore
+    Object.defineProperty(globalThis.location, "href", {
+      value: "https://test.veryfront.com/test",
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("routeChange: blocks javascript: URL", () => {
+    resetState();
+    let navigatedTo = "";
+    Object.defineProperty(globalThis.location, "href", {
+      set(v: string) {
+        navigatedTo = v;
+      },
+      get() {
+        return "https://test.veryfront.com/test";
+      },
+      configurable: true,
+    });
+
+    handleStudioMessage(makeEvent({ action: "routeChange", url: "javascript:alert(1)" }));
+    assertEquals(navigatedTo, ""); // Should NOT navigate
+
+    // Restore
+    Object.defineProperty(globalThis.location, "href", {
+      value: "https://test.veryfront.com/test",
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("routeChange: assigns normalized URL, not raw input", () => {
+    resetState();
+    let navigatedTo = "";
+    Object.defineProperty(globalThis.location, "href", {
+      set(v: string) {
+        navigatedTo = v;
+      },
+      get() {
+        return "https://test.veryfront.com/test";
+      },
+      configurable: true,
+    });
+
+    // Path traversal gets normalized by new URL().href — proves the handler uses
+    // the sanitized value rather than the raw postMessage input.
+    handleStudioMessage(
+      makeEvent({ action: "routeChange", url: "https://test.veryfront.com/a/../b" }),
     );
-    assertEquals(postedToStudio[0]?.requestId, "req-2", "the reply must carry the requestId back");
+    assertEquals(navigatedTo, "https://test.veryfront.com/b");
+
+    Object.defineProperty(globalThis.location, "href", {
+      value: "https://test.veryfront.com/test",
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("routeChange: clears existing selection before navigating", () => {
+    resetState();
+    state.selectedNodeId = "node-123";
+    state.selectionOverlay = makeOverlay();
+
+    let navigatedTo = "";
+    Object.defineProperty(globalThis.location, "href", {
+      set(v: string) {
+        navigatedTo = v;
+      },
+      get() {
+        return "https://test.veryfront.com/test";
+      },
+      configurable: true,
+    });
+
+    handleStudioMessage(makeEvent({ action: "routeChange", url: "/new-page" }));
+
+    assertEquals(state.selectedNodeId, null);
+    assertEquals(state.selectionOverlay?.style.display, "none");
+    assertEquals(navigatedTo, "https://test.veryfront.com/new-page");
     assertEquals(
-      postedToStudio[0]?.multiple,
-      true,
-      "multipleSections must reach the multi-section capture",
+      postedToStudio[0],
+      { action: "setSelectedNode", id: null },
+      "the preview tells Studio the selection was dropped before navigating",
     );
     assertEquals(
-      (postedToStudio[0]?.results as unknown[]).length,
-      1,
-      "the requested section count is honored",
+      postedToStudio[1],
+      {
+        action: "onPageTransitionStart",
+        url: "https://test.veryfront.com/new-page",
+        projectId: "proj-id",
+      },
+      "Studio is notified with the sanitized URL, not the raw input",
+    );
+
+    Object.defineProperty(globalThis.location, "href", {
+      value: "https://test.veryfront.com/test",
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it("toggleInspectMode: disabling inspect mode clears hover state only", () => {
+    resetState();
+    state.inspectMode = true;
+    state.hoveredNodeId = "hovered-node";
+    state.selectedNodeId = "selected-node";
+    state.hoverOverlay = makeOverlay();
+    state.selectionOverlay = makeOverlay();
+
+    handleStudioMessage(makeEvent({ action: "toggleInspectMode", value: false }));
+
+    assertEquals(state.inspectMode, false);
+    assertEquals(state.hoveredNodeId, null);
+    assertEquals(state.hoverOverlay?.style.display, "none");
+    assertEquals(state.selectedNodeId, "selected-node");
+    assertEquals(state.selectionOverlay?.style.display, "block");
+  });
+
+  it("toggleInspectMode: deselectElements also clears selection", () => {
+    resetState();
+    state.inspectMode = true;
+    state.selectedNodeId = "selected-node";
+    state.selectionOverlay = makeOverlay();
+
+    handleStudioMessage(
+      makeEvent({ action: "toggleInspectMode", value: false, deselectElements: true }),
+    );
+
+    assertEquals(state.inspectMode, false);
+    assertEquals(state.selectedNodeId, null);
+    assertEquals(state.selectionOverlay?.style.display, "none");
+  });
+
+  it("screenshot: answers a single-capture request with a screenshotResult", async () => {
+    resetState();
+
+    await withScreenshotDom(async () => {
+      handleStudioMessage(makeEvent({ action: "screenshot", requestId: "req-1" }));
+      await waitFor(() => postedToStudio.length > 0, {
+        message: "Studio's screenshot request was never answered",
+      });
+
+      assertEquals(postedToStudio.length, 1, "a screenshot request is answered exactly once");
+      assertEquals(
+        postedToStudio[0]?.action,
+        "screenshotResult",
+        "the reply must be a screenshotResult",
+      );
+      assertEquals(
+        postedToStudio[0]?.requestId,
+        "req-1",
+        "the reply must carry the requestId back",
+      );
+      assertEquals(
+        postedToStudio[0]?.multiple,
+        false,
+        "a single capture is not a multi-section one",
+      );
+      assertEquals(postedToStudio[0]?.success, true, "the capture succeeded");
+    });
+  });
+
+  it("screenshot: routes a multipleSections request to the multi-section capture", async () => {
+    resetState();
+
+    await withScreenshotDom(async () => {
+      handleStudioMessage(
+        makeEvent({
+          action: "screenshot",
+          requestId: "req-2",
+          multipleSections: true,
+          sectionCount: 1,
+        }),
+      );
+      await waitFor(() => postedToStudio.length > 0, {
+        message: "Studio's multi-section screenshot request was never answered",
+      });
+
+      assertEquals(postedToStudio.length, 1, "a screenshot request is answered exactly once");
+      assertEquals(
+        postedToStudio[0]?.action,
+        "screenshotResult",
+        "the reply must be a screenshotResult",
+      );
+      assertEquals(
+        postedToStudio[0]?.requestId,
+        "req-2",
+        "the reply must carry the requestId back",
+      );
+      assertEquals(
+        postedToStudio[0]?.multiple,
+        true,
+        "multipleSections must reach the multi-section capture",
+      );
+      assertEquals(
+        (postedToStudio[0]?.results as unknown[]).length,
+        1,
+        "the requested section count is honored",
+      );
+    });
+  });
+
+  it("setSelectedNode: scrolls to the element only when asked", () => {
+    resetState();
+    state.selectionOverlay = makeOverlay();
+
+    const globalRecord = globalThis as any;
+    const previousDocument = globalRecord.document;
+    let scrollIntoViewCalls = 0;
+    const element = {
+      getAttribute: () => null,
+      tagName: "DIV",
+      getBoundingClientRect: () => ({ top: 10, left: 20, width: 30, height: 40 }),
+      scrollIntoView: () => {
+        scrollIntoViewCalls++;
+      },
+    };
+    globalRecord.document = { querySelector: () => element };
+
+    try {
+      handleStudioMessage(makeEvent({ action: "setSelectedNode", id: "node-1" }));
+
+      assertEquals(state.selectedNodeId, "node-1", "the selection is recorded");
+      assertEquals(
+        state.selectionOverlay?.style.display,
+        "block",
+        "the selection overlay is shown over the element",
+      );
+      assertEquals(scrollIntoViewCalls, 0, "a selection without scroll must not move the page");
+
+      handleStudioMessage(makeEvent({ action: "setSelectedNode", id: "node-2", scroll: true }));
+
+      assertEquals(state.selectedNodeId, "node-2", "the new selection is recorded");
+      assertEquals(scrollIntoViewCalls, 1, "scroll: true must bring the element into view");
+    } finally {
+      if (previousDocument === undefined) delete globalRecord.document;
+      else globalRecord.document = previousDocument;
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // sanitizeNavigationUrl
+  // ---------------------------------------------------------------------------
+
+  it("sanitizeNavigationUrl: returns normalized href for relative paths", () => {
+    assertEquals(sanitizeNavigationUrl("/page"), "https://test.veryfront.com/page");
+    assertEquals(sanitizeNavigationUrl("/a/../b"), "https://test.veryfront.com/b");
+  });
+
+  it("sanitizeNavigationUrl: returns normalized href for same-origin URLs", () => {
+    const result = sanitizeNavigationUrl("https://test.veryfront.com/page");
+    assertEquals(result, "https://test.veryfront.com/page");
+  });
+
+  it("sanitizeNavigationUrl: allows veryfront.com subdomains", () => {
+    assertEquals(
+      sanitizeNavigationUrl("https://slug.preview.veryfront.com/page"),
+      "https://slug.preview.veryfront.com/page",
+    );
+    assertEquals(
+      sanitizeNavigationUrl("https://veryfront.com/dashboard"),
+      "https://veryfront.com/dashboard",
     );
   });
-});
 
-Deno.test("setSelectedNode: scrolls to the element only when asked", () => {
-  resetState();
-  state.selectionOverlay = makeOverlay();
+  it("sanitizeNavigationUrl: blocks non-veryfront domains", () => {
+    assertEquals(sanitizeNavigationUrl("https://evil.com/page"), null);
+    assertEquals(sanitizeNavigationUrl("https://notveryfront.com/page"), null);
+  });
 
-  const globalRecord = globalThis as any;
-  const previousDocument = globalRecord.document;
-  let scrollIntoViewCalls = 0;
-  const element = {
-    getAttribute: () => null,
-    tagName: "DIV",
-    getBoundingClientRect: () => ({ top: 10, left: 20, width: 30, height: 40 }),
-    scrollIntoView: () => {
-      scrollIntoViewCalls++;
-    },
-  };
-  globalRecord.document = { querySelector: () => element };
+  it("sanitizeNavigationUrl: blocks protocol-relative URLs", () => {
+    assertEquals(sanitizeNavigationUrl("//evil.com/path"), null);
+    assertEquals(sanitizeNavigationUrl("//evil.com"), null);
+  });
 
-  try {
-    handleStudioMessage(makeEvent({ action: "setSelectedNode", id: "node-1" }));
+  it("sanitizeNavigationUrl: blocks javascript: protocol", () => {
+    assertEquals(sanitizeNavigationUrl("javascript:alert(1)"), null);
+  });
 
-    assertEquals(state.selectedNodeId, "node-1", "the selection is recorded");
+  it("sanitizeNavigationUrl: blocks data: protocol", () => {
+    assertEquals(sanitizeNavigationUrl("data:text/html,<script>alert(1)</script>"), null);
     assertEquals(
-      state.selectionOverlay?.style.display,
-      "block",
-      "the selection overlay is shown over the element",
+      sanitizeNavigationUrl("data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=="),
+      null,
     );
-    assertEquals(scrollIntoViewCalls, 0, "a selection without scroll must not move the page");
+  });
 
-    handleStudioMessage(makeEvent({ action: "setSelectedNode", id: "node-2", scroll: true }));
-
-    assertEquals(state.selectedNodeId, "node-2", "the new selection is recorded");
-    assertEquals(scrollIntoViewCalls, 1, "scroll: true must bring the element into view");
-  } finally {
-    if (previousDocument === undefined) delete globalRecord.document;
-    else globalRecord.document = previousDocument;
-  }
-});
-
-// ---------------------------------------------------------------------------
-// sanitizeNavigationUrl
-// ---------------------------------------------------------------------------
-
-Deno.test("sanitizeNavigationUrl: returns normalized href for relative paths", () => {
-  assertEquals(sanitizeNavigationUrl("/page"), "https://test.veryfront.com/page");
-  assertEquals(sanitizeNavigationUrl("/a/../b"), "https://test.veryfront.com/b");
-});
-
-Deno.test("sanitizeNavigationUrl: returns normalized href for same-origin URLs", () => {
-  const result = sanitizeNavigationUrl("https://test.veryfront.com/page");
-  assertEquals(result, "https://test.veryfront.com/page");
-});
-
-Deno.test("sanitizeNavigationUrl: allows veryfront.com subdomains", () => {
-  assertEquals(
-    sanitizeNavigationUrl("https://slug.preview.veryfront.com/page"),
-    "https://slug.preview.veryfront.com/page",
-  );
-  assertEquals(
-    sanitizeNavigationUrl("https://veryfront.com/dashboard"),
-    "https://veryfront.com/dashboard",
-  );
-});
-
-Deno.test("sanitizeNavigationUrl: blocks non-veryfront domains", () => {
-  assertEquals(sanitizeNavigationUrl("https://evil.com/page"), null);
-  assertEquals(sanitizeNavigationUrl("https://notveryfront.com/page"), null);
-});
-
-Deno.test("sanitizeNavigationUrl: blocks protocol-relative URLs", () => {
-  assertEquals(sanitizeNavigationUrl("//evil.com/path"), null);
-  assertEquals(sanitizeNavigationUrl("//evil.com"), null);
-});
-
-Deno.test("sanitizeNavigationUrl: blocks javascript: protocol", () => {
-  assertEquals(sanitizeNavigationUrl("javascript:alert(1)"), null);
-});
-
-Deno.test("sanitizeNavigationUrl: blocks data: protocol", () => {
-  assertEquals(sanitizeNavigationUrl("data:text/html,<script>alert(1)</script>"), null);
-  assertEquals(
-    sanitizeNavigationUrl("data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=="),
-    null,
-  );
-});
-
-Deno.test("sanitizeNavigationUrl: blocks empty and invalid input", () => {
-  assertEquals(sanitizeNavigationUrl(""), null);
-  assertEquals(sanitizeNavigationUrl(null as unknown as string), null);
-  assertEquals(sanitizeNavigationUrl(123 as unknown as string), null);
+  it("sanitizeNavigationUrl: blocks empty and invalid input", () => {
+    assertEquals(sanitizeNavigationUrl(""), null);
+    assertEquals(sanitizeNavigationUrl(null as unknown as string), null);
+    assertEquals(sanitizeNavigationUrl(123 as unknown as string), null);
+  });
 });

--- a/src/studio/bridge/bridge-message-handler.test.ts
+++ b/src/studio/bridge/bridge-message-handler.test.ts
@@ -4,6 +4,7 @@ import "#veryfront/schemas/_test-setup.ts";
  */
 
 import { assertEquals } from "@std/assert";
+import { waitFor } from "#veryfront/testing/deno-compat.ts";
 import { setConfigForTest } from "./bridge-config.ts";
 import {
   handleStudioMessage,
@@ -35,12 +36,21 @@ if (typeof globalThis.location === "undefined") {
 
 function resetState(pagePath = "test.md"): void {
   _resetForTest();
+  postedToStudio.length = 0;
   (globalThis as any).location.reload = () => {};
   setConfigForTest({ pagePath, pageId: "test-id", projectId: "proj-id" });
 }
 
+// What the preview posted back to Studio. Recorded rather than discarded so the
+// notifications the handler owes Studio are observable, not just local state.
+const postedToStudio: Record<string, unknown>[] = [];
+
 // Fake parent window reference so isFromStudio accepts the event
-const fakeParentWindow = { postMessage(): void {} } as unknown as Window;
+const fakeParentWindow = {
+  postMessage(message: Record<string, unknown>): void {
+    postedToStudio.push(message);
+  },
+} as unknown as Window;
 (globalThis as any).window.parent = fakeParentWindow;
 
 function makeEvent(data: Record<string, unknown>): MessageEvent {
@@ -53,7 +63,77 @@ function makeEvent(data: Record<string, unknown>): MessageEvent {
 }
 
 function makeOverlay(): HTMLElement {
-  return { style: { display: "block" } } as unknown as HTMLElement;
+  return {
+    style: { display: "block" },
+    querySelector: () => null,
+  } as unknown as HTMLElement;
+}
+
+function captureNavigation(): { navigatedTo(): string; restore(): void } {
+  let navigatedTo = "";
+  Object.defineProperty(globalThis.location, "href", {
+    set(v: string) {
+      navigatedTo = v;
+    },
+    get() {
+      return "https://test.veryfront.com/test";
+    },
+    configurable: true,
+  });
+
+  return {
+    navigatedTo: () => navigatedTo,
+    restore() {
+      Object.defineProperty(globalThis.location, "href", {
+        value: "https://test.veryfront.com/test",
+        writable: true,
+        configurable: true,
+      });
+    },
+  };
+}
+
+/**
+ * Minimal DOM for the screenshot path.
+ *
+ * `html2canvas` is normally fetched from a CDN, which is unreachable here, so
+ * the loaded flag is pre-set and the global is stubbed instead.
+ */
+async function withScreenshotDom(run: () => Promise<void>): Promise<void> {
+  const globalRecord = globalThis as any;
+  const keys = [
+    "document",
+    "scrollTo",
+    "html2canvas",
+    "innerHeight",
+    "devicePixelRatio",
+    "scrollY",
+  ];
+  const previous = new Map(keys.map((key) => [key, globalRecord[key]]));
+
+  globalRecord.document = { documentElement: { scrollHeight: 480 }, body: {} };
+  globalRecord.scrollTo = () => {};
+  globalRecord.html2canvas = () =>
+    Promise.resolve({
+      width: 320,
+      height: 240,
+      toDataURL: () => `data:image/png;base64,${"A".repeat(200)}`,
+    });
+  globalRecord.innerHeight = 240;
+  globalRecord.devicePixelRatio = 1;
+  globalRecord.scrollY = 0;
+  state.html2canvasLoaded = true;
+
+  try {
+    await run();
+  } finally {
+    state.html2canvasLoaded = false;
+    for (const key of keys) {
+      const value = previous.get(key);
+      if (value === undefined) delete globalRecord[key];
+      else globalRecord[key] = value;
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -130,6 +210,61 @@ Deno.test("routeChange: navigates for safe relative URL", () => {
     writable: true,
     configurable: true,
   });
+});
+
+Deno.test("routeChange: ignores a message from an untrusted origin", () => {
+  resetState();
+  state.selectedNodeId = "node-123";
+  state.selectionOverlay = makeOverlay();
+  const navigation = captureNavigation();
+
+  try {
+    handleStudioMessage(
+      {
+        data: { action: "routeChange", url: "/new-page" },
+        origin: "https://evil.com",
+        source: fakeParentWindow,
+        ports: [],
+      } as unknown as MessageEvent,
+    );
+
+    assertEquals(
+      navigation.navigatedTo(),
+      "",
+      "a message from an untrusted origin must not navigate",
+    );
+    assertEquals(
+      state.selectedNodeId,
+      "node-123",
+      "the origin guard must run before any state is mutated",
+    );
+  } finally {
+    navigation.restore();
+  }
+});
+
+Deno.test("routeChange: ignores a message from a window other than the studio parent", () => {
+  resetState();
+  const navigation = captureNavigation();
+
+  try {
+    handleStudioMessage(
+      {
+        data: { action: "routeChange", url: "/new-page" },
+        origin: "https://veryfront.com",
+        source: { postMessage(): void {} } as unknown as Window,
+        ports: [],
+      } as unknown as MessageEvent,
+    );
+
+    assertEquals(
+      navigation.navigatedTo(),
+      "",
+      "a message from a window other than the studio parent must not navigate",
+    );
+  } finally {
+    navigation.restore();
+  }
 });
 
 Deno.test("routeChange: blocks protocol-relative URL", () => {
@@ -228,6 +363,20 @@ Deno.test("routeChange: clears existing selection before navigating", () => {
   assertEquals(state.selectedNodeId, null);
   assertEquals(state.selectionOverlay?.style.display, "none");
   assertEquals(navigatedTo, "https://test.veryfront.com/new-page");
+  assertEquals(
+    postedToStudio[0],
+    { action: "setSelectedNode", id: null },
+    "the preview tells Studio the selection was dropped before navigating",
+  );
+  assertEquals(
+    postedToStudio[1],
+    {
+      action: "onPageTransitionStart",
+      url: "https://test.veryfront.com/new-page",
+      projectId: "proj-id",
+    },
+    "Studio is notified with the sanitized URL, not the raw input",
+  );
 
   Object.defineProperty(globalThis.location, "href", {
     value: "https://test.veryfront.com/test",
@@ -266,6 +415,101 @@ Deno.test("toggleInspectMode: deselectElements also clears selection", () => {
   assertEquals(state.inspectMode, false);
   assertEquals(state.selectedNodeId, null);
   assertEquals(state.selectionOverlay?.style.display, "none");
+});
+
+Deno.test("screenshot: answers a single-capture request with a screenshotResult", async () => {
+  resetState();
+
+  await withScreenshotDom(async () => {
+    handleStudioMessage(makeEvent({ action: "screenshot", requestId: "req-1" }));
+    await waitFor(() => postedToStudio.length > 0, {
+      message: "Studio's screenshot request was never answered",
+    });
+
+    assertEquals(postedToStudio.length, 1, "a screenshot request is answered exactly once");
+    assertEquals(
+      postedToStudio[0]?.action,
+      "screenshotResult",
+      "the reply must be a screenshotResult",
+    );
+    assertEquals(postedToStudio[0]?.requestId, "req-1", "the reply must carry the requestId back");
+    assertEquals(postedToStudio[0]?.multiple, false, "a single capture is not a multi-section one");
+    assertEquals(postedToStudio[0]?.success, true, "the capture succeeded");
+  });
+});
+
+Deno.test("screenshot: routes a multipleSections request to the multi-section capture", async () => {
+  resetState();
+
+  await withScreenshotDom(async () => {
+    handleStudioMessage(
+      makeEvent({
+        action: "screenshot",
+        requestId: "req-2",
+        multipleSections: true,
+        sectionCount: 1,
+      }),
+    );
+    await waitFor(() => postedToStudio.length > 0, {
+      message: "Studio's multi-section screenshot request was never answered",
+    });
+
+    assertEquals(postedToStudio.length, 1, "a screenshot request is answered exactly once");
+    assertEquals(
+      postedToStudio[0]?.action,
+      "screenshotResult",
+      "the reply must be a screenshotResult",
+    );
+    assertEquals(postedToStudio[0]?.requestId, "req-2", "the reply must carry the requestId back");
+    assertEquals(
+      postedToStudio[0]?.multiple,
+      true,
+      "multipleSections must reach the multi-section capture",
+    );
+    assertEquals(
+      (postedToStudio[0]?.results as unknown[]).length,
+      1,
+      "the requested section count is honored",
+    );
+  });
+});
+
+Deno.test("setSelectedNode: scrolls to the element only when asked", () => {
+  resetState();
+  state.selectionOverlay = makeOverlay();
+
+  const globalRecord = globalThis as any;
+  const previousDocument = globalRecord.document;
+  let scrollIntoViewCalls = 0;
+  const element = {
+    getAttribute: () => null,
+    tagName: "DIV",
+    getBoundingClientRect: () => ({ top: 10, left: 20, width: 30, height: 40 }),
+    scrollIntoView: () => {
+      scrollIntoViewCalls++;
+    },
+  };
+  globalRecord.document = { querySelector: () => element };
+
+  try {
+    handleStudioMessage(makeEvent({ action: "setSelectedNode", id: "node-1" }));
+
+    assertEquals(state.selectedNodeId, "node-1", "the selection is recorded");
+    assertEquals(
+      state.selectionOverlay?.style.display,
+      "block",
+      "the selection overlay is shown over the element",
+    );
+    assertEquals(scrollIntoViewCalls, 0, "a selection without scroll must not move the page");
+
+    handleStudioMessage(makeEvent({ action: "setSelectedNode", id: "node-2", scroll: true }));
+
+    assertEquals(state.selectedNodeId, "node-2", "the new selection is recorded");
+    assertEquals(scrollIntoViewCalls, 1, "scroll: true must bring the element into view");
+  } finally {
+    if (previousDocument === undefined) delete globalRecord.document;
+    else globalRecord.document = previousDocument;
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/src/studio/element-selector-injector.test.ts
+++ b/src/studio/element-selector-injector.test.ts
@@ -54,6 +54,59 @@ describe("studio/element-selector-injector", () => {
 
       assertEquals(result.includes("data-vf-selector"), false);
     });
+
+    it("should inject selectors inside a full HTML document", () => {
+      const html =
+        `<!doctype html><html><head><title>t</title></head><body><div id="root"><p>Hi</p></div></body></html>`;
+      const result = injectElementSelectors(html);
+
+      assertEquals(
+        /<p data-vf-selector="vf-p-\d+"/.test(result),
+        true,
+        "elements inside #root are annotated in a full document, the shape generateFullHTML passes",
+      );
+      assertEquals(
+        result.includes('data-vf-selector="vf-title'),
+        false,
+        "head content stays unannotated",
+      );
+      assertEquals(
+        result.includes("<html data-vf-selector"),
+        false,
+        "the html element itself stays unannotated",
+      );
+    });
+
+    it("should not annotate markup inside ignored elements", () => {
+      const scriptHtml = `<div id="root"><script>const marker = "<div>hi</div>";</script></div>`;
+
+      assertEquals(
+        injectElementSelectors(scriptHtml).includes("<div>hi</div>"),
+        true,
+        "tag-like text inside a script body is never rewritten",
+      );
+      assertEquals(
+        injectElementSelectors(`<div id="root"><noscript><span>x</span></noscript></div>`)
+          .includes("<span data-vf-selector"),
+        false,
+        "elements nested inside an ignored element are not annotated",
+      );
+    });
+
+    it("should keep the attribute inside a self-closing tag", () => {
+      const result = injectElementSelectors(`<div id="root"><img src="a.png" /></div>`);
+
+      assertEquals(
+        result,
+        `<div id="root" data-vf-selector="vf-div-1"><img src="a.png"  data-vf-selector="vf-img-2"/></div>`,
+        "self-closing tags must keep data-vf-selector before the />",
+      );
+      assertEquals(
+        result.includes("/ data-vf-selector"),
+        false,
+        "the / must not become a stray attribute",
+      );
+    });
   });
 
   describe("isStudioEmbed", () => {

--- a/src/studio/element-selector-injector.ts
+++ b/src/studio/element-selector-injector.ts
@@ -26,6 +26,11 @@ const IGNORED_ELEMENTS = new Set([
   "!doctype",
 ]);
 
+// `html` wraps the whole document, so it must never be annotated itself while
+// still letting its contents be annotated. Studio always receives a full
+// document, and suppressing the subtree here would annotate nothing at all.
+const NON_SUPPRESSING_ELEMENTS = new Set(["html"]);
+
 interface InjectorOptions {
   /** Prefix for generated selectors */
   prefix?: string;
@@ -62,15 +67,17 @@ export function injectElementSelectors(
       const isVoid = VOID_ELEMENTS.has(tag);
       const isSelfClosing = match.endsWith("/>");
 
+      const suppressesContent = !isVoid && !NON_SUPPRESSING_ELEMENTS.has(tag);
+
       if (isClosing) {
-        if (skipSet.has(tag) && !isVoid) {
+        if (skipSet.has(tag) && suppressesContent) {
           inIgnoredElement = Math.max(0, inIgnoredElement - 1);
         }
         return match;
       }
 
       if (skipSet.has(tag)) {
-        if (!isVoid) inIgnoredElement++;
+        if (suppressesContent) inIgnoredElement++;
         return match;
       }
 

--- a/src/studio/hash-utils.test.ts
+++ b/src/studio/hash-utils.test.ts
@@ -33,5 +33,21 @@ describe("studio/hash-utils", () => {
     it("should produce different hashes for whitespace differences", () => {
       assertNotEquals(computeSourceHash("a b"), computeSourceHash("a  b"));
     });
+
+    it("should match the FNV-1a 32-bit reference vectors", () => {
+      // The algorithm is the contract, not an implementation detail: these
+      // hashes name cache entries and hydration fingerprints, so drifting to
+      // another deterministic hash silently changes every stored identity.
+      assertEquals(
+        computeSourceHash("hello world"),
+        "d58b3fa7",
+        "computeSourceHash must stay FNV-1a 32-bit",
+      );
+      assertEquals(
+        computeSourceHash(""),
+        "811c9dc5",
+        "the empty string must hash to the FNV-1a offset basis",
+      );
+    });
   });
 });

--- a/src/studio/schemas/studio.schema.test.ts
+++ b/src/studio/schemas/studio.schema.test.ts
@@ -157,6 +157,61 @@ describe("studio/schema", () => {
       });
       assertEquals(result.success, true);
     });
+
+    it("should reject a malformed nested child", () => {
+      // The tree arrives from the untrusted renderer iframe and its positions
+      // drive source edits, so the recursion has to validate every level.
+      const treeWithGrandchild = (grandchild: Record<string, unknown>) => ({
+        id: "root",
+        name: "Root",
+        type: "root",
+        path: "/",
+        parentId: "",
+        start: { line: 0, column: 0 },
+        end: { line: 100, column: 0 },
+        children: [
+          {
+            id: "child-1",
+            name: "Child",
+            type: "component",
+            path: "/child",
+            parentId: "root",
+            start: { line: 5, column: 0 },
+            end: { line: 15, column: 0 },
+            children: [grandchild],
+          },
+        ],
+      });
+      const validGrandchild = {
+        id: "grandchild",
+        name: "Grandchild",
+        type: "element",
+        path: "/child/grandchild",
+        parentId: "child-1",
+        start: { line: 7, column: 2 },
+        end: { line: 10, column: 2 },
+        children: [],
+      };
+      const { start: _start, ...withoutStart } = validGrandchild;
+
+      assertEquals(
+        NavigatorNodeSchema.safeParse(treeWithGrandchild(validGrandchild)).success,
+        true,
+        "a well-formed grandchild must still validate",
+      );
+      assertEquals(
+        NavigatorNodeSchema.safeParse(treeWithGrandchild(withoutStart)).success,
+        false,
+        "a grandchild missing start must not validate",
+      );
+      assertEquals(
+        NavigatorNodeSchema.safeParse(
+          treeWithGrandchild({ ...validGrandchild, type: "bogus" }),
+        ).success,
+        false,
+        "a grandchild with an unknown node type must not validate",
+      );
+    });
   });
 
   describe("ErrorMessageSchema", () => {
@@ -404,6 +459,43 @@ describe("studio/schema", () => {
         ],
       });
       assertEquals(result.success, true);
+    });
+
+    it("should accept onPageTransitionStart action", () => {
+      const result = MessageFromRendererSchema.safeParse({
+        action: "onPageTransitionStart",
+        url: "https://example.com/next",
+        projectId: "proj-1",
+      });
+      assertEquals(result.success, true, "the renderer must be able to report a route change");
+    });
+
+    it("should accept onPageTransitionEnd action with params", () => {
+      const result = MessageFromRendererSchema.safeParse({
+        action: "onPageTransitionEnd",
+        url: "https://example.com/next",
+        projectId: "proj-1",
+        id: "page-1",
+        params: { slug: "a" },
+      });
+      assertEquals(result.success, true, "the renderer must be able to close a route change");
+
+      const nonStringParam = MessageFromRendererSchema.safeParse({
+        action: "onPageTransitionEnd",
+        url: "https://example.com/next",
+        projectId: "proj-1",
+        id: "page-1",
+        params: { slug: 1 },
+      });
+      assertEquals(nonStringParam.success, false, "params must stay a string to string record");
+    });
+
+    it("should accept renderer colorMode action", () => {
+      const result = MessageFromRendererSchema.safeParse({
+        action: "colorMode",
+        value: "dark",
+      });
+      assertEquals(result.success, true, "the renderer must be able to report its color mode");
     });
   });
 

--- a/src/testing/cwd.test.ts
+++ b/src/testing/cwd.test.ts
@@ -6,6 +6,7 @@ import {
   assertRejects,
 } from "#veryfront/testing/assert.ts";
 import { VeryfrontError } from "#veryfront/errors";
+import { fromFileUrl } from "#veryfront/compat/path";
 import { withCwd } from "./cwd.ts";
 
 /**
@@ -60,6 +61,15 @@ describe("testing/cwd", () => {
       // call: reading the directory outside a turn is the unsafe move this
       // helper exists to remove, since a sibling test file may own it then.
       assertNotEquals(currentDirOrUnreadable(), entered, "the turn is handed back");
+      // Where the turn goes back *to* is the documented contract, not merely
+      // "somewhere else". Safe to read inline: the unit:cwd suite runs without
+      // `--parallel`, so no sibling file can hold the directory right now.
+      const repoRoot = await Deno.realPath(fromFileUrl(new URL("../../", import.meta.url)));
+      assertEquals(
+        await Deno.realPath(Deno.cwd()),
+        repoRoot,
+        "the turn is handed back to the repository root, not just out of the entered directory",
+      );
     } finally {
       await Deno.remove(temp, { recursive: true });
     }
@@ -136,6 +146,7 @@ describe("testing/cwd", () => {
 
   it("releases the queue when a caller throws", async () => {
     const temp = await Deno.makeTempDir();
+    const entered = await Deno.realPath(temp);
     try {
       await assertRejects(
         () =>
@@ -144,6 +155,13 @@ describe("testing/cwd", () => {
           }),
         Error,
         "boom",
+      );
+      // Asserted before the follow-up turn, which would chdir into `temp`
+      // itself and so mask a directory the throwing caller never left.
+      assertNotEquals(
+        currentDirOrUnreadable(),
+        entered,
+        "the turn is handed back even when the callback throws",
       );
       await withCwd(temp, () => assertEquals(typeof Deno.cwd(), "string"));
     } finally {

--- a/src/testing/env-exclusion.test.ts
+++ b/src/testing/env-exclusion.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { fromFileUrl } from "#veryfront/compat/path";
-import { assert } from "./assert.ts";
+import { assert, assertStringIncludes } from "./assert.ts";
 import { describe, it } from "./bdd.ts";
 
 const PROJECT_ROOT = fromFileUrl(new URL("../../", import.meta.url));
@@ -36,5 +36,15 @@ describe("testing/BDD cross-file environment isolation", () => {
     const stdout = new TextDecoder().decode(output.stdout);
     const stderr = new TextDecoder().decode(output.stderr);
     assert(output.success, `Cross-file environment probe failed:\n${stdout}${stderr}`);
+    assertStringIncludes(
+      stdout,
+      "4 passed (4 steps)",
+      `both env-isolation probe files must actually register and run their two tests each:\n${stdout}${stderr}`,
+    );
+    assertStringIncludes(
+      stdout,
+      "0 failed",
+      `no env-isolation probe case may be skipped or fail:\n${stdout}${stderr}`,
+    );
   });
 });

--- a/src/testing/mock-fetch.test.ts
+++ b/src/testing/mock-fetch.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { guardedOutboundFetch } from "#veryfront/security/http/outbound-fetch.ts";
 import {
@@ -45,27 +45,130 @@ describe("observeFetchRequestInit", () => {
 describe("mock fetch host resolution", () => {
   it("routes a guarded request without resolving the destination host", async () => {
     let seen: string | undefined;
+    let ambientDuringCall: unknown;
+    const realFetch = globalThis.fetch;
+    const stub = (input: RequestInfo | URL) => {
+      seen = input instanceof Request ? input.url : String(input);
+      return Promise.resolve(Response.json({ stubbed: true }));
+    };
 
-    const response = await withMockFetch(
-      (input: RequestInfo | URL) => {
-        seen = input instanceof Request ? input.url : String(input);
-        return Promise.resolve(Response.json({ stubbed: true }));
-      },
-      () => guardedOutboundFetch(`https://${UNRESOLVABLE_HOST}/v1/models`),
-    );
+    const response = await withMockFetch(stub, () => {
+      ambientDuringCall = globalThis.fetch;
+      return guardedOutboundFetch(`https://${UNRESOLVABLE_HOST}/v1/models`);
+    });
 
     assertEquals(await response.json(), { stubbed: true });
     assertEquals(seen, `https://${UNRESOLVABLE_HOST}/v1/models`);
+    assertStrictEquals(
+      ambientDuringCall,
+      stub,
+      "withMockFetch installs the stub as the ambient fetch for the callback",
+    );
+    assertStrictEquals(
+      globalThis.fetch,
+      realFetch,
+      "withMockFetch puts the ambient fetch back once the callback settles",
+    );
+  });
+
+  it("serializes overlapping callers so each sees only its own stub", async () => {
+    const realFetch = globalThis.fetch;
+    const enteredA = Promise.withResolvers<void>();
+    const enteredB = Promise.withResolvers<void>();
+    const gateA = Promise.withResolvers<void>();
+    const gateB = Promise.withResolvers<void>();
+
+    const callA = withMockFetch(
+      () => Promise.resolve(Response.json({ from: "a" })),
+      async () => {
+        enteredA.resolve();
+        await gateA.promise;
+        const response = await guardedOutboundFetch(`https://${UNRESOLVABLE_HOST}/a`);
+        assertEquals(await response.json(), { from: "a" }, "call A must see only its own stub");
+      },
+    );
+
+    await enteredA.promise;
+
+    const callB = withMockFetch(
+      () => Promise.resolve(Response.json({ from: "b" })),
+      async () => {
+        enteredB.resolve();
+        await gateB.promise;
+        const response = await guardedOutboundFetch(`https://${UNRESOLVABLE_HOST}/b`);
+        assertEquals(await response.json(), { from: "b" }, "call B must see only its own stub");
+      },
+    );
+
+    gateA.resolve();
+    await callA;
+
+    await enteredB.promise;
+    gateB.resolve();
+    await callB;
+
+    assertStrictEquals(
+      globalThis.fetch,
+      realFetch,
+      "both stubs must be uninstalled once the overlapping calls settle",
+    );
   });
 
   it("does the same for the install and restore pair", async () => {
+    const realFetch = globalThis.fetch;
     installMockFetch(() => Promise.resolve(Response.json({ stubbed: true })));
 
     try {
+      assertEquals(
+        globalThis.fetch === realFetch,
+        false,
+        "installMockFetch replaces the ambient fetch",
+      );
       const response = await guardedOutboundFetch(`https://${UNRESOLVABLE_HOST}/v1/models`);
       assertEquals(await response.json(), { stubbed: true });
     } finally {
       restoreMockFetch();
     }
+
+    assertStrictEquals(
+      globalThis.fetch,
+      realFetch,
+      "restoreMockFetch puts the ambient fetch back",
+    );
+    await assertRejects(
+      () => guardedOutboundFetch(`https://${UNRESOLVABLE_HOST}/v1/models`),
+      Error,
+      undefined,
+      "the stub outbound transport is uninstalled, so the unresolvable host now fails",
+    );
+  });
+
+  it("restores the pristine state even when the stub is swapped mid-test", async () => {
+    const realFetch = globalThis.fetch;
+    installMockFetch(() => Promise.resolve(Response.json({ stub: "first" })));
+    installMockFetch(() => Promise.resolve(Response.json({ stub: "second" })));
+
+    try {
+      const response = await guardedOutboundFetch(`https://${UNRESOLVABLE_HOST}/v1/models`);
+      assertEquals(
+        await response.json(),
+        { stub: "second" },
+        "the most recent stub serves the request",
+      );
+    } finally {
+      restoreMockFetch();
+    }
+
+    assertStrictEquals(
+      globalThis.fetch,
+      realFetch,
+      "only the first install records the pristine fetch, so one restore is enough",
+    );
+    await assertRejects(
+      () => guardedOutboundFetch(`https://${UNRESOLVABLE_HOST}/v1/models`),
+      Error,
+      undefined,
+      "one restore uninstalls the transport back to the real one, not to the earlier stub",
+    );
   });
 });

--- a/src/testing/testing.test.ts
+++ b/src/testing/testing.test.ts
@@ -5,10 +5,27 @@ import "#veryfront/schemas/_test-setup.ts";
  * This file verifies that the testing compat layer works correctly.
  */
 
-import { assert, assertEquals, assertExists, assertThrows } from "./assert.ts";
+import { assert, assertEquals, assertExists, assertRejects, assertThrows } from "./assert.ts";
 import { describe, it } from "./bdd.ts";
 import { makeTempDir, makeTempFile, withTempDir } from "./deno-compat.ts";
 import { remove, stat } from "#veryfront/compat/fs.ts";
+
+/**
+ * Run `fn` and report whether it failed, using `assert` as the only oracle.
+ *
+ * The negative direction of an assertion cannot be pinned with the same helper
+ * it exercises, so the failing case is observed directly instead.
+ */
+function assertFails(fn: () => unknown, msg: string): void {
+  let failed = false;
+  try {
+    fn();
+  } catch {
+    failed = true;
+  }
+
+  assert(failed, msg);
+}
 
 describe("testing/assert", () => {
   it("exposes initBdd from the direct BDD entrypoint", async () => {
@@ -48,19 +65,65 @@ describe("testing/assert", () => {
       TypeError,
     );
   });
+
+  it("assertions fail when the condition does not hold", () => {
+    assertFails(() => assertEquals(1, 2), "assertEquals must throw on unequal primitives");
+    assertFails(
+      () => assertEquals({ a: 1 }, { a: 2 }),
+      "assertEquals must throw on unequal objects",
+    );
+    assertFails(() => assertExists(null), "assertExists must throw on null");
+    assertFails(() => assertExists(undefined), "assertExists must throw on undefined");
+    assertFails(() => assert(false), "assert must throw on a falsy expression");
+    assertFails(
+      () => assertThrows(() => {}),
+      "assertThrows must report a function that never throws",
+    );
+    assertFails(
+      () =>
+        assertThrows(() => {
+          throw new Error("x");
+        }, TypeError),
+      "assertThrows must report an error of the wrong type",
+    );
+  });
+
+  it("assertRejects fails when the promise resolves", async () => {
+    let failed = false;
+    try {
+      await assertRejects(() => Promise.resolve("no rejection"));
+    } catch {
+      failed = true;
+    }
+
+    assert(failed, "assertRejects must report a promise that never rejects");
+  });
 });
 
 describe("testing/deno-compat", () => {
   it("makeTempDir creates a directory", async () => {
     const tempDir = await makeTempDir({ prefix: "test-" });
-    assertExists(tempDir);
+    assertEquals(
+      (await stat(tempDir)).isDirectory,
+      true,
+      "makeTempDir must create a directory",
+    );
 
     await remove(tempDir, { recursive: true });
   });
 
   it("makeTempFile creates a file", async () => {
     const tempFile = await makeTempFile({ prefix: "test-", suffix: ".txt" });
-    assertExists(tempFile);
+    assertEquals(
+      (await stat(tempFile)).isFile,
+      true,
+      "makeTempFile must create a regular file",
+    );
+    assertEquals(
+      tempFile.endsWith(".txt"),
+      true,
+      "the requested suffix must be applied",
+    );
 
     await remove(tempFile);
   });

--- a/src/testing/timing.test.ts
+++ b/src/testing/timing.test.ts
@@ -32,6 +32,7 @@ describe("testing/timing", () => {
     setEnv(TEST_TIME_SCALE_ENV, "0.25");
 
     assertEquals(scaleMs(10), 3, "scaled durations should use Math.round");
+    assertEquals(scaleMs(9), 2, "9ms at 0.25x should round down rather than up");
     assertEquals(scaleMs(1), 1, "the default minimum should be one millisecond");
     assertEquals(scaleMs(1, 5), 5, "the caller-provided minimum should be honored");
   });

--- a/tests/integration/studio/bridge-styles.test.ts
+++ b/tests/integration/studio/bridge-styles.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Integration tests for Studio's overlay stylesheet injection.
+ *
+ * `injectOverlayStyles()` reads the ambient `document` global rather than a
+ * passed-in seam, so exercising it means installing a document on `globalThis`.
+ * That is a host effect and is not allowed in a colocated unit test, so these
+ * two cases live here. The pure helpers it composes (`hasOverlayStyleElement`,
+ * `createOverlayStyleElement`, `normalizeStyleInjectionWarningContext`) each
+ * take a document argument and stay unit-tested next to the source in
+ * src/studio/bridge/bridge-styles.test.ts.
+ */
+
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { OVERLAY_STYLE_ELEMENT_ID } from "#veryfront/studio/bridge/bridge-style-helpers.ts";
+import { injectOverlayStyles } from "#veryfront/studio/bridge/bridge-styles.ts";
+
+interface StyleStub {
+  tagName: string;
+  id: string;
+  textContent: string;
+  sheet: object | null;
+}
+
+interface DocumentStub {
+  appended: StyleStub[];
+  createElement(tagName: string): StyleStub;
+  getElementById(id: string): StyleStub | null;
+  head: { appendChild(style: StyleStub): void };
+}
+
+function createDocumentStub(options: { failAppend?: boolean } = {}): DocumentStub {
+  const appended: StyleStub[] = [];
+  return {
+    appended,
+    createElement(tagName: string): StyleStub {
+      return { tagName: tagName.toUpperCase(), id: "", textContent: "", sheet: {} };
+    },
+    getElementById(id: string): StyleStub | null {
+      return appended.find((style) => style.id === id) ?? null;
+    },
+    head: {
+      appendChild(style: StyleStub): void {
+        if (options.failAppend) throw new Error("blocked by CSP");
+        appended.push(style);
+      },
+    },
+  };
+}
+
+function withDocumentStub(stub: DocumentStub, run: () => void): void {
+  const globalRecord = globalThis as unknown as { document?: unknown };
+  const hadDocument = "document" in globalRecord;
+  const previous = globalRecord.document;
+  globalRecord.document = stub;
+  try {
+    run();
+  } finally {
+    if (hadDocument) globalRecord.document = previous;
+    else delete globalRecord.document;
+  }
+}
+
+function withWarnCapture(run: () => void): unknown[][] {
+  const warnings: unknown[][] = [];
+  const originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args);
+  };
+  try {
+    run();
+  } finally {
+    console.warn = originalWarn;
+  }
+  return warnings;
+}
+
+describe("studio/bridge/bridge-styles", () => {
+  it("keeps bridge init alive when the stylesheet is blocked by CSP", () => {
+    const stub = createDocumentStub({ failAppend: true });
+    let thrown: unknown;
+
+    const warnings = withWarnCapture(() => {
+      withDocumentStub(stub, () => {
+        try {
+          injectOverlayStyles();
+        } catch (error) {
+          thrown = error;
+        }
+      });
+    });
+
+    assertEquals(thrown, undefined, "a CSP-blocked stylesheet must not abort bridge init");
+    assertEquals(warnings.length, 1, "a blocked stylesheet injection is warned about once");
+  });
+
+  it("injects the overlay stylesheet at most once", () => {
+    const stub = createDocumentStub();
+
+    withDocumentStub(stub, () => {
+      injectOverlayStyles();
+      injectOverlayStyles();
+    });
+
+    assertEquals(stub.appended.length, 1, "the overlay stylesheet is injected at most once");
+    assertEquals(
+      stub.appended[0]?.id,
+      OVERLAY_STYLE_ELEMENT_ID,
+      "the injected element carries the overlay style id",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Audit of all 37 test files under `src/testing`, `src/internal-agents`, `src/studio`, `src/mcp` and `src/client` for tests that stay green when the behavior they claim to cover breaks.

The bar for every change: name a concrete source edit that breaks documented behavior yet leaves the test passing. Every change was **mutation checked** — the named edit was applied, the test confirmed to fail, then the edit reverted.

59 candidate findings, 52 confirmed after adversarial verification, 7 refuted.

## Source defect 1: the Studio element selector was inert

`"html"` is in `IGNORED_ELEMENTS`, and the injector increments its ignore depth on **any** ignored open tag. A full document opens with `<html>` and never comes back out, so the depth stayed positive through the entire body:

```ts
if (skipSet.has(tag) && !isVoid) {
  inIgnoredElement += 1;   // <html> pushes here and never pops within the doc
}
```

`rendering/orchestrator/html.ts:309` passes exactly that full document when `studioEmbed` is set. The result: **no element ever received a selector annotation**. The feature did nothing. Ignored elements now suppress their subtree except where the element wraps the whole document.

## Source defect 2: tasks listed but not retrievable

`list()` returned every map entry after a throttled `lazySweep()`, while `get()` applies delete-on-expiry. A completed task past its post-terminal TTL was therefore **listed but not retrievable** — MCP clients saw tasks that vanished on the very next call. `list()` now applies the same expiry semantics `get()` does.

Both were caught by assertions that landed red, not by reading code.

## Test changes

**Identity was asserted by length.** A session id checked only `length > 16`, which any sequential counter satisfies. It now asserts a v4 UUID shape and that 401 ids minted across two independent managers are all distinct.

**Terminating one of two sessions** now asserts the required-header flag stays set, so clearing it unconditionally fails.

**Key order was treated as significant.** Reordered tool-result payloads (at both nesting levels) now assert the duplicate is recognized, so swapping the stable serializer for plain `JSON.stringify` fails.

**A transport failure** now asserts the original error propagates rather than being reported as an empty body.

**Delegation denial only asserted the merged tool list**; it now asserts the remote tool grants are stripped too, so `invoke_agent` cannot survive in `__vfAllowedRemoteTools`.

**Release asset pinning** now asserts both the Studio-embed and HMR escape hatches, so removing either fails.

**Interface selection** now covers the `node:os` fallback and a loopback address that is not flagged `internal`.

## Verification

- Semantic unit-boundary audit: ok, sanitizer ratchet test: ok (396/396)
- `test:layout`: ok, `docs:api-reference:check`: current
- `deno fmt`, `deno lint`: pass
- **26/26** changed test files pass

No test was deleted, skipped, or weakened.