### PR TITLE
Harden workflow cancellation and timeout admission

### DIFF
--- a/src/workflow/executor/workflow-executor.test.ts
+++ b/src/workflow/executor/workflow-executor.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { VeryfrontError } from "#veryfront/errors";
 import type { Tool } from "#veryfront/tool";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { MemoryBackend } from "../backends/memory.ts";
@@ -168,6 +169,33 @@ class DelayedCancellationBackend extends MemoryBackend {
       await this.persistCancellation.promise;
     }
     await super.updateRun(runId, patch);
+  }
+}
+
+class CancellationCompletionRaceBackend extends MemoryBackend {
+  readonly cancellationWriteStarted = Promise.withResolvers<void>();
+  readonly releaseCancellationWrite = Promise.withResolvers<void>();
+  private delayCancellationWrite = true;
+
+  private async waitBeforeCancellationWrite(patch: Partial<WorkflowRun>): Promise<void> {
+    if (patch.status !== "cancelled" || !this.delayCancellationWrite) return;
+    this.delayCancellationWrite = false;
+    this.cancellationWriteStarted.resolve();
+    await this.releaseCancellationWrite.promise;
+  }
+
+  override async updateRun(runId: string, patch: Partial<WorkflowRun>): Promise<void> {
+    await this.waitBeforeCancellationWrite(patch);
+    await super.updateRun(runId, patch);
+  }
+
+  override async updateRunIfStatus(
+    runId: string,
+    expectedStatuses: WorkflowRun["status"][],
+    patch: Partial<WorkflowRun>,
+  ): Promise<boolean> {
+    await this.waitBeforeCancellationWrite(patch);
+    return await super.updateRunIfStatus(runId, expectedStatuses, patch);
   }
 }
 
@@ -1210,6 +1238,7 @@ describe("workflow/executor/workflow-executor", () => {
       },
     });
     const started = Promise.withResolvers<void>();
+    const abortObserved = Promise.withResolvers<void>();
     const blockingTool: Tool = {
       id: "delayed-cancellation",
       type: "function",
@@ -1219,7 +1248,10 @@ describe("workflow/executor/workflow-executor", () => {
         started.resolve();
         return new Promise((_resolve, reject) => {
           const signal = context?.abortSignal;
-          signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+          signal?.addEventListener("abort", () => {
+            abortObserved.resolve();
+            reject(signal.reason);
+          }, { once: true });
         });
       },
     };
@@ -1234,7 +1266,8 @@ describe("workflow/executor/workflow-executor", () => {
     await started.promise;
     const cancellation = handle.cancel();
     await backend.cancellationStarted.promise;
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await abortObserved.promise;
+    await Promise.resolve();
 
     try {
       assertEquals(errorCallbacks, 0);
@@ -1278,9 +1311,94 @@ describe("workflow/executor/workflow-executor", () => {
     assertEquals(cancelledRun.status, "cancelled");
   });
 
-  it("does not schedule more nodes after a workflow timeout", async () => {
+  it("does not overwrite completion when cancellation loses the status race", async () => {
+    const backend = new CancellationCompletionRaceBackend();
+    const executor = new WorkflowExecutor({ backend });
+    const run = { ...createRun("cancel-loses-completion-race"), status: "running" as const };
+    const completedAt = new Date("2026-08-24T10:00:00.000Z");
+    await backend.createRun(run);
+
+    const cancellation = assertRejects(
+      () => executor.cancel(run.id),
+      Error,
+      'current status is "completed"',
+    );
+    await backend.cancellationWriteStarted.promise;
+
+    try {
+      await backend.updateRun(run.id, {
+        status: "completed",
+        output: { winner: "completion" },
+        completedAt,
+      });
+    } finally {
+      backend.releaseCancellationWrite.resolve();
+    }
+    await cancellation;
+
+    const persisted = await backend.getRun(run.id);
+    assertExists(persisted);
+    assertEquals(persisted.status, "completed");
+    assertEquals(persisted.output, { winner: "completion" });
+    assertEquals(persisted.completedAt, completedAt);
+  });
+
+  it("does not rewrite an already cancelled terminal run", async () => {
     const backend = new MemoryBackend();
     const executor = new WorkflowExecutor({ backend });
+    const completedAt = new Date("2026-08-24T10:00:00.000Z");
+    const run = {
+      ...createRun("cancelled-is-terminal"),
+      status: "cancelled" as const,
+      completedAt,
+    };
+    await backend.createRun(run);
+
+    const conflict = await assertRejects(
+      () => executor.cancel(run.id),
+      VeryfrontError,
+      'current status is "cancelled"',
+    );
+    assertEquals((conflict as VeryfrontError).status, 409);
+
+    const persisted = await backend.getRun(run.id);
+    assertExists(persisted);
+    assertEquals(persisted.status, "cancelled");
+    assertEquals(persisted.completedAt, completedAt);
+  });
+
+  it("rejects an invalid workflow timeout before executing a node", async () => {
+    const backend = new MemoryBackend();
+    const executor = new WorkflowExecutor({ backend, enableLocking: false });
+    let executions = 0;
+    executor.register({
+      id: "invalid-workflow-timeout",
+      timeout: "not-a-duration",
+      steps: [
+        step("side-effect", {
+          tool: createTool("side-effect", () => {
+            executions++;
+            return { shouldNotRun: true };
+          }),
+        }),
+      ],
+    });
+
+    const handle = await executor.start("invalid-workflow-timeout", {});
+    await handle.settled();
+
+    const persisted = await backend.getRun(handle.runId);
+    assertExists(persisted);
+    assertEquals(executions, 0);
+    assertEquals(persisted.status, "failed");
+    assertEquals(persisted.error?.message, "Invalid duration format: not-a-duration");
+  });
+
+  it("does not schedule more nodes after a workflow timeout", async () => {
+    using time = new FakeTime();
+    const backend = new MemoryBackend();
+    const executor = new WorkflowExecutor({ backend });
+    const slowStarted = Promise.withResolvers<void>();
     let receivedSignal: AbortSignal | undefined;
     let dependentExecutions = 0;
     const slowTool: Tool = {
@@ -1290,6 +1408,7 @@ describe("workflow/executor/workflow-executor", () => {
       inputSchema: defineSchema((v) => v.object({}).passthrough())(),
       execute: async (_input, context) => {
         receivedSignal = context?.abortSignal;
+        slowStarted.resolve();
         await new Promise((resolve) => setTimeout(resolve, 20));
         return { ok: true };
       },
@@ -1312,12 +1431,16 @@ describe("workflow/executor/workflow-executor", () => {
     const run = createRun("workflow-timeout");
     await backend.createRun(run);
 
-    await assertRejects(
+    const execution = assertRejects(
       () => executor.executeAsync(run.id),
       Error,
       "Workflow timed out",
     );
-    await new Promise((resolve) => setTimeout(resolve, 25));
+    await slowStarted.promise;
+    await time.tickAsync(5);
+    assertEquals(receivedSignal?.aborted, true);
+    await time.tickAsync(15);
+    await execution;
 
     const timedOutRun = await backend.getRun(run.id);
     assertExists(timedOutRun);

--- a/src/workflow/executor/workflow-executor.ts
+++ b/src/workflow/executor/workflow-executor.ts
@@ -622,6 +622,7 @@ export class WorkflowExecutor {
     executionController: AbortController,
   ): Promise<T> {
     executionController.signal.throwIfAborted();
+    const timeoutMs = timeout === undefined ? undefined : parseDuration(timeout);
     const operation = Promise.resolve().then(fn);
     const fencedOperation = operation.then((value) => {
       executionController.signal.throwIfAborted();
@@ -635,8 +636,7 @@ export class WorkflowExecutor {
       else executionController.signal.addEventListener("abort", rejectAbort, { once: true });
     });
 
-    if (timeout) {
-      const timeoutMs = parseDuration(timeout);
+    if (timeoutMs) {
       const timeoutError = TIMEOUT_ERROR.create({
         detail: `Workflow timed out after ${timeoutMs}ms`,
       });
@@ -737,19 +737,37 @@ export class WorkflowExecutor {
     const run = await this.config.backend.getRun(runId);
     if (!run) throw RESOURCE_NOT_FOUND.create({ detail: `Run not found: ${runId}` });
 
-    if (run.status === "completed" || run.status === "failed") {
+    const cancellableStatuses: WorkflowStatus[] = ["pending", "running", "waiting"];
+    if (!cancellableStatuses.includes(run.status)) {
       throw ORCHESTRATION_ERROR.create({
-        detail: `Cannot cancel workflow run "${runId}": run has already ${run.status}. ` +
+        status: 409,
+        detail: `Cannot cancel workflow run "${runId}": current status is "${run.status}". ` +
           `Only active runs (pending, running, waiting) can be cancelled.`,
       });
     }
 
-    const cancellationUpdate = Promise.resolve().then(() =>
-      this.config.backend.updateRun(runId, {
-        status: "cancelled",
-        completedAt: new Date(),
-      })
-    );
+    const cancellationUpdate = Promise.resolve().then(async () => {
+      const cancelled = await updateRunIfStatus(
+        this.config.backend,
+        runId,
+        cancellableStatuses,
+        {
+          status: "cancelled",
+          completedAt: new Date(),
+        },
+      );
+      if (cancelled) return;
+
+      const current = await this.config.backend.getRun(runId);
+      if (!current) {
+        throw RESOURCE_NOT_FOUND.create({ detail: `Run not found: ${runId}` });
+      }
+      throw ORCHESTRATION_ERROR.create({
+        status: 409,
+        detail: `Cannot cancel workflow run "${runId}": current status is "${current.status}". ` +
+          `Only active runs (pending, running, waiting) can be cancelled.`,
+      });
+    });
     this.cancellationUpdates.set(runId, cancellationUpdate);
 
     this.activeRunControllers.get(runId)?.abort(


### PR DESCRIPTION
## Summary

- cancel workflow runs through a conditional active-status transition so concurrent completion cannot be overwritten
- reject repeated cancellation of terminal runs as a 409 conflict
- validate a raw workflow definition timeout before queueing any node execution
- replace scheduler-dependent cancellation and timeout waits with promise gates and fake time

## Verification

- `deno task test:file src/workflow/executor/workflow-executor.test.ts`
- `deno task test:file src/workflow/executor`
- `deno task test:file src/workflow/runtime/workflow-run-control.test.ts`
- `deno task test:file src/workflow/http/handler.test.ts`
- `deno task test:file src/workflow`
- `deno task test:unit`
- `deno task test:integration` (320 files, 2,980 steps)
- `deno task test:node`
- `deno task test:bun` (1,401 files)
- `deno task typecheck`
- `deno task lint`
- `deno task docs`
- `deno task lint:test-typecheck`
- `deno task lint:anti-slop`
- `deno task lint:test-semantic-dispositions`
- `deno task test:layout`
- `git diff --check`

After rebasing onto the latest main, the exact head passed all 218 workflow executor steps plus targeted format, lint, and type checks.