### PR TITLE
test(rendering): replace tests of local copies with tests of the real modules

### DIFF
--- a/scripts/lint/check-skipped-tests-baseline.ts
+++ b/scripts/lint/check-skipped-tests-baseline.ts
@@ -28,7 +28,7 @@ import {
 
 // Lower this when you re-enable or delete skipped tests. Raising it means new
 // dead coverage is being added — prefer fixing or deleting the test instead.
-export const SKIPPED_TEST_BASELINE = 18;
+export const SKIPPED_TEST_BASELINE = 15;
 
 // Method form: it.skip( / describe.ignore( / test.skip( / Deno.test.ignore(
 const METHOD_FORM = /\b(?:it|describe|test|Deno\.test)\.(?:skip|ignore)\s*\(/g;

--- a/src/rendering/chunk-optimizer/suggestions.test.ts
+++ b/src/rendering/chunk-optimizer/suggestions.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { CHUNK_SIZE_ESTIMATES } from "./limits.ts";
 import { generateChunkSuggestions } from "./suggestions.ts";
 
 describe("generateChunkSuggestions", () => {
@@ -21,8 +22,14 @@ describe("generateChunkSuggestions", () => {
     );
 
     assertEquals(
-      suggestions.find((suggestion) => suggestion.name === "react-vendor")?.deps,
-      [dependency],
+      suggestions.find((suggestion) => suggestion.name === "react-vendor"),
+      {
+        name: "react-vendor",
+        deps: [dependency],
+        pages: ["/app/page.tsx"],
+        benefit: CHUNK_SIZE_ESTIMATES.reactRuntime,
+      },
+      "react vendor chunk must list its deps, the pages that import them, and its benefit",
     );
   });
 
@@ -82,8 +89,98 @@ describe("generateChunkSuggestions", () => {
     );
 
     assertEquals(
-      suggestions.find((suggestion) => suggestion.name === "ui-vendor")?.deps,
-      ["framer-motion/motion", "https://esm.sh/framer-motion/motion"],
+      suggestions.find((suggestion) => suggestion.name === "ui-vendor"),
+      {
+        name: "ui-vendor",
+        deps: ["framer-motion/motion", "https://esm.sh/framer-motion/motion"],
+        pages: ["/app/page.tsx", "/app/remote.tsx"],
+        benefit: 2 * CHUNK_SIZE_ESTIMATES.uiLibrary,
+      },
+      "ui vendor chunk must list its deps, the union of the pages that import them, and its benefit",
+    );
+  });
+
+  it("ranks suggestions by benefit descending", () => {
+    const suggestions = generateChunkSuggestions(
+      new Map([
+        [
+          "/a",
+          {
+            path: "/a",
+            local: [],
+            remote: [],
+            shared: ["react", "framer-motion", "lodash"],
+          },
+        ],
+        [
+          "/b",
+          {
+            path: "/b",
+            local: [],
+            remote: [],
+            shared: ["lodash"],
+          },
+        ],
+      ]),
+      new Map([
+        ["react", 2],
+        ["framer-motion", 1],
+        ["lodash", 2],
+      ]),
+    );
+
+    assertEquals(
+      suggestions.map((suggestion) => suggestion.name),
+      ["react-vendor", "ui-vendor", "common"],
+      "suggestions must be ranked by benefit descending",
+    );
+    assertEquals(
+      suggestions.map((suggestion) => suggestion.benefit),
+      [200_000, 150_000, 50_000],
+      "benefit must be reactRuntime, uiLibrary per ui dep, and dependency estimate times deps times pages",
+    );
+  });
+
+  it("breaks a benefit tie by chunk name", () => {
+    const shared = ["axios", "lodash", "zod"];
+    const suggestions = generateChunkSuggestions(
+      new Map([
+        [
+          "/a",
+          {
+            path: "/a",
+            local: [],
+            remote: [],
+            shared: [...shared, "framer-motion"],
+          },
+        ],
+        [
+          "/b",
+          {
+            path: "/b",
+            local: [],
+            remote: [],
+            shared,
+          },
+        ],
+      ]),
+      new Map([
+        ["axios", 2],
+        ["lodash", 2],
+        ["zod", 2],
+        ["framer-motion", 1],
+      ]),
+    );
+
+    assertEquals(
+      suggestions.map((suggestion) => suggestion.benefit),
+      [150_000, 150_000],
+      "this fixture must produce two chunks of equal benefit so the name tiebreak is observable",
+    );
+    assertEquals(
+      suggestions.map((suggestion) => suggestion.name),
+      ["common", "ui-vendor"],
+      "chunks of equal benefit must be ordered by name ascending",
     );
   });
 });

--- a/src/rendering/element-validator/element-inspector.test.ts
+++ b/src/rendering/element-validator/element-inspector.test.ts
@@ -62,9 +62,51 @@ describe("rendering/element-validator/element-inspector", () => {
       );
     });
 
+    it("should throw for an invalid object inside a children array", () => {
+      assertThrows(
+        () => deepInspectElement(["text", { bad: 1 }], "root", 0, defaultOptions),
+        Error,
+        "root[1]",
+        "an invalid object inside a children array must be reported with its array index path",
+      );
+    });
+
+    it("should throw for an invalid object inside an element's array children", () => {
+      // React's prop types reject a plain object as a child, which is exactly the
+      // runtime shape this inspector has to report on, so the array is widened.
+      const invalidChildren = ["ok", { bad: 1 }] as unknown as React.ReactNode;
+
+      assertThrows(
+        () =>
+          deepInspectElement(
+            React.createElement("div", null, invalidChildren),
+            "root",
+            0,
+            defaultOptions,
+          ),
+        Error,
+        "root.children[1]",
+        "invalid children inside an element's array children must be reported",
+      );
+    });
+
     it("should stop at max depth", () => {
       const shallowOptions: InspectionOptions = { maxDepth: 0, debugMode: false };
       deepInspectElement({ foo: "bar" }, "root", 1, shallowOptions);
+    });
+
+    it("should inspect a node at exactly maxDepth but skip anything deeper", () => {
+      const opts: InspectionOptions = { maxDepth: 2, debugMode: false };
+
+      assertThrows(
+        () => deepInspectElement({ bad: 1 }, "root", 2, opts),
+        Error,
+        "Invalid React child",
+        "a node at exactly maxDepth must still be inspected",
+      );
+
+      // One level past maxDepth is skipped, so the same invalid object is ignored.
+      deepInspectElement({ bad: 1 }, "root", 3, opts);
     });
 
     it("should respect maxDepth and stop recursing", () => {
@@ -83,6 +125,19 @@ describe("rendering/element-validator/element-inspector", () => {
         "root",
         0,
         defaultOptions,
+      );
+    });
+
+    it("skips objects carrying an unrecognised React symbol instead of throwing", () => {
+      // Bundled or legacy React copies use a numeric $$typeof.
+      deepInspectElement({ $$typeof: 0xeac7 }, "root", 0, defaultOptions);
+      deepInspectElement({ $$typeof: Symbol.for("react.future_thing") }, "root", 0, defaultOptions);
+
+      assertThrows(
+        () => deepInspectElement({ $$typeof: "not-a-symbol" }, "root", 0, defaultOptions),
+        Error,
+        "Invalid React child",
+        "a non-symbol, non-numeric $$typeof is still an invalid child",
       );
     });
 

--- a/src/rendering/element-validator/element-normalizer.test.ts
+++ b/src/rendering/element-validator/element-normalizer.test.ts
@@ -35,12 +35,22 @@ describe("rendering/element-validator/element-normalizer", () => {
       const result = ensureValidReactElement("hello world", baseOptions);
       assertEquals(React.isValidElement(result), true);
       assertEquals(result.type, React.Fragment);
+      assertEquals(
+        (result.props as { children?: unknown }).children,
+        "hello world",
+        "the Fragment must carry the wrapped string",
+      );
     });
 
     it("should wrap a number in a Fragment", () => {
       const result = ensureValidReactElement(42, baseOptions);
       assertEquals(React.isValidElement(result), true);
       assertEquals(result.type, React.Fragment);
+      assertEquals(
+        (result.props as { children?: unknown }).children,
+        42,
+        "the Fragment must carry the wrapped number",
+      );
     });
 
     it("should wrap null in a Fragment", () => {
@@ -65,6 +75,11 @@ describe("rendering/element-validator/element-normalizer", () => {
       ];
       const result = ensureValidReactElement(arr, baseOptions);
       assertEquals(React.isValidElement(result), true);
+      assertEquals(
+        (result.props as { children?: unknown }).children,
+        arr,
+        "the Fragment must carry the normalized array children",
+      );
     });
 
     it("should perform deep inspection when enabled", () => {

--- a/src/rendering/element-validator/primitive-checks.test.ts
+++ b/src/rendering/element-validator/primitive-checks.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { expect } from "#std/expect.ts";
 import * as React from "react";
 import {
+  getElementDebugInfo,
   getElementTypeName,
   getObjectKeys,
   getObjectSample,
@@ -100,13 +101,22 @@ describe("primitive-checks", () => {
       expect(getElementTypeName(element)).toBe("MyComponent");
     });
 
-    it("should return displayName if available", () => {
+    it("should prefer the function name over displayName", () => {
       function Component() {
         return React.createElement("div", null, "test");
       }
       Component.displayName = "CustomDisplayName";
       const element = React.createElement(Component, null);
       expect(getElementTypeName(element)).toBe("Component");
+    });
+
+    it("should return displayName when the function name is empty", () => {
+      // An empty type.name is the only input that reaches the displayName fallback.
+      const Anon = () => React.createElement("div", null, "test");
+      Object.defineProperty(Anon, "name", { value: "" });
+      (Anon as { displayName?: string }).displayName = "CustomDisplayName";
+      const element = React.createElement(Anon, null);
+      expect(getElementTypeName(element)).toBe("CustomDisplayName");
     });
 
     it("should return <Anonymous> for anonymous function components", () => {
@@ -225,6 +235,57 @@ describe("primitive-checks", () => {
 
     it("should handle undefined", () => {
       expect(getObjectSample(undefined)).toBe("[Unable to stringify]");
+    });
+  });
+
+  describe("getElementDebugInfo", () => {
+    it("should report an empty shape for null", () => {
+      expect(getElementDebugInfo(null)).toEqual({
+        type: "undefined",
+        hasSymbol: false,
+        symbolValue: undefined,
+        typeValue: undefined,
+      });
+    });
+
+    it("should report an empty shape for non-objects", () => {
+      expect(getElementDebugInfo("div")).toEqual({
+        type: "undefined",
+        hasSymbol: false,
+        symbolValue: undefined,
+        typeValue: undefined,
+      });
+    });
+
+    it("should name a function type by its function name", () => {
+      expect(getElementDebugInfo({ type: function Foo() {} }).type).toBe("Foo");
+    });
+
+    it("should name an unnamed function type AnonymousFunction", () => {
+      // Built from a factory so the function does not inherit a property name.
+      expect(getElementDebugInfo({ type: (() => () => {})() }).type).toBe("AnonymousFunction");
+    });
+
+    it("should stringify a non-function type", () => {
+      expect(getElementDebugInfo({ type: "div" }).type).toBe("div");
+      expect(getElementDebugInfo({ type: "div" }).typeValue).toBe("div");
+    });
+
+    it("should report the React element marker the caller logs", () => {
+      const info = getElementDebugInfo({ $$typeof: "not-a-symbol", type: "div" });
+      expect(info.hasSymbol).toBe(true);
+    });
+
+    it("should report the React element marker value", () => {
+      const marker = Symbol.for("react.transitional.element");
+      const info = getElementDebugInfo({ $$typeof: marker, type: "div" });
+      expect(info.symbolValue).toBe(marker);
+    });
+
+    it("should report no marker for a plain object", () => {
+      const info = getElementDebugInfo({ foo: "bar" });
+      expect(info.hasSymbol).toBe(false);
+      expect(info.symbolValue).toBe(undefined);
     });
   });
 });

--- a/src/rendering/element-validator/primitive-checks.test.ts
+++ b/src/rendering/element-validator/primitive-checks.test.ts
@@ -274,6 +274,14 @@ describe("primitive-checks", () => {
     it("should report the React element marker the caller logs", () => {
       const info = getElementDebugInfo({ $$typeof: "not-a-symbol", type: "div" });
       expect(info.hasSymbol).toBe(true);
+      expect(info.symbolValue).toBe("not-a-symbol");
+    });
+
+    it("should report a legacy numeric marker verbatim", () => {
+      // Pre-symbol React builds tag elements with the number 0xeac7.
+      const info = getElementDebugInfo({ $$typeof: 0xeac7, type: "div" });
+      expect(info.hasSymbol).toBe(true);
+      expect(info.symbolValue).toBe(0xeac7);
     });
 
     it("should report the React element marker value", () => {

--- a/src/rendering/element-validator/primitive-checks.ts
+++ b/src/rendering/element-validator/primitive-checks.ts
@@ -86,7 +86,9 @@ export function getObjectSample(obj: unknown): string {
 }
 
 interface ReactElementInternal {
-  $$typeof?: symbol;
+  // React markers are symbols in modern React but numbers in legacy builds, and
+  // arbitrary values reach here from non-React objects, so this stays unnarrowed.
+  $$typeof?: unknown;
   type?: unknown;
   props?: unknown;
 }
@@ -94,7 +96,7 @@ interface ReactElementInternal {
 export function getElementDebugInfo(child: unknown): {
   type: string;
   hasSymbol: boolean;
-  symbolValue?: symbol;
+  symbolValue?: unknown;
   typeValue?: unknown;
 } {
   if (child == null || typeof child !== "object") {

--- a/src/rendering/element-validator/primitive-checks.ts
+++ b/src/rendering/element-validator/primitive-checks.ts
@@ -86,7 +86,7 @@ export function getObjectSample(obj: unknown): string {
 }
 
 interface ReactElementInternal {
-  $typeof?: symbol;
+  $$typeof?: symbol;
   type?: unknown;
   props?: unknown;
 }
@@ -117,8 +117,8 @@ export function getElementDebugInfo(child: unknown): {
 
   return {
     type,
-    hasSymbol: "$typeof" in child,
-    symbolValue: internal.$typeof,
+    hasSymbol: "$$typeof" in child,
+    symbolValue: internal.$$typeof,
     typeValue: internal.type,
   };
 }

--- a/src/rendering/element-validator/validator-core.test.ts
+++ b/src/rendering/element-validator/validator-core.test.ts
@@ -40,18 +40,42 @@ describe("rendering/element-validator/validator-core", () => {
         );
       });
 
-      it("should use custom path and depth", () => {
+      it("should forward the caller path into inspection errors", () => {
         const validator = new ElementValidator();
-        validator.deepInspectElement(
-          React.createElement("span", null, "test"),
-          "custom.path",
-          2,
+        assertThrows(
+          () =>
+            validator.deepInspectElement(
+              React.createElement("div", null, {} as React.ReactNode),
+              "page.layout",
+              0,
+            ),
+          Error,
+          "Invalid React child found at page.layout.children",
+          "the caller-supplied path must be forwarded into the inspection error",
         );
       });
 
       it("should respect maxDepth option", () => {
         const validator = new ElementValidator({ maxDepth: 0 });
         validator.deepInspectElement({ foo: "bar" }, "root", 1);
+      });
+
+      it("should reach invalid objects nested five levels down by default", () => {
+        let tree: React.ReactNode = { bad: "object" } as unknown as React.ReactNode;
+        for (let i = 0; i < 5; i++) tree = React.createElement("div", null, tree);
+        assertThrows(
+          () => new ElementValidator().deepInspectElement(tree),
+          Error,
+          "Invalid React child",
+          "the default maxDepth must be deep enough to reach an invalid object five levels down",
+        );
+      });
+
+      it("should stop before that depth when maxDepth narrows it", () => {
+        let tree: React.ReactNode = { bad: "object" } as unknown as React.ReactNode;
+        for (let i = 0; i < 5; i++) tree = React.createElement("div", null, tree);
+        // maxDepth 2 must cut the walk short before the invalid object at depth 5.
+        new ElementValidator({ maxDepth: 2 }).deepInspectElement(tree);
       });
     });
 
@@ -85,6 +109,22 @@ describe("rendering/element-validator/validator-core", () => {
           true,
         );
         assertEquals(React.isValidElement(result), true);
+      });
+
+      it("should default to lenient normalization when inspection is not requested", () => {
+        const validator = new ElementValidator();
+        const el = React.createElement(
+          "div",
+          null,
+          { not: "a react child" } as unknown as React.ReactNode,
+        );
+        const result = validator.ensureValidReactElement(el);
+        assertEquals(
+          React.isValidElement(result),
+          true,
+          "inspection must be off by default, so an invalid child passes through untouched",
+        );
+        assertEquals(result.type, "div", "the original element must be returned unwrapped");
       });
 
       it("should throw during inspection for invalid children", () => {

--- a/src/rendering/layouts/layout-applicator.test.ts
+++ b/src/rendering/layouts/layout-applicator.test.ts
@@ -1,80 +1,82 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
-import { flattenRouteParams } from "#veryfront/routing";
 import { type LayoutApplicationOptions, LayoutApplicator } from "./layout-applicator.ts";
 import * as React from "react";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { EntityInfo, LayoutItem, MdxBundle } from "#veryfront/types";
+import type { VeryfrontConfig } from "#veryfront/config";
+import { mdxRenderer } from "#veryfront/transforms/mdx/index.ts";
 import { createLayoutComponentCache } from "./utils/component-loader.ts";
 import {
   __setServerModuleLoaderForTests,
   resetReactCache,
 } from "#veryfront/react/compat/ssr-adapter/server-loader.ts";
 
-function buildSSRRouter(
-  requestUrl: URL | undefined,
-  pageFilePath: string,
-  pageSlug: string,
-  params?: Record<string, string | string[]>,
-): {
-  domain: string;
-  path: string;
-  pathname: string;
-  params: Record<string, string>;
-  query: Record<string, string>;
-  isPreview: false;
-  isMounted: false;
-  navigate: () => void;
-  push: () => void;
-  replace: () => void;
-  reload: () => void;
-} {
-  // Mirror production: reuse the shared helper so this test can't drift back
-  // to the old first-segment-only contract (issue #2742).
-  const flatParams = flattenRouteParams(params);
+/** Passthrough stand-ins for the framework providers, so the tree stays readable. */
+const Pass = ({ children }: { children?: React.ReactNode }) => children;
 
+type ProviderModules = {
+  PageContextProvider: React.ComponentType<Record<string, unknown>>;
+  RouterProvider: React.ComponentType<Record<string, unknown>>;
+};
+
+function createAdapter(files: Record<string, string> = {}): RuntimeAdapter {
   return {
-    domain: requestUrl?.origin ?? "",
-    path: requestUrl?.pathname ?? pageFilePath,
-    pathname: requestUrl?.pathname ?? `/${pageSlug}`,
-    params: flatParams,
-    query: requestUrl ? Object.fromEntries(requestUrl.searchParams) : {},
-    isPreview: false,
-    isMounted: false,
-    navigate: () => {},
-    push: () => {},
-    replace: () => {},
-    reload: () => {},
-  };
+    fs: {
+      exists: (path: string) => Promise.resolve(path in files),
+      readFile: (path: string) => {
+        const content = files[path];
+        if (content === undefined) return Promise.reject(new Error(`not found: ${path}`));
+        return Promise.resolve(content);
+      },
+      readDir: async function* () {},
+      writeFile: () => Promise.resolve(),
+      mkdir: () => Promise.resolve(),
+    },
+    env: { get: () => undefined },
+  } as unknown as RuntimeAdapter;
 }
 
-type Heading = { id: string; text: string; level: number };
-
-function buildPageContext(
-  slug: string,
+function createPageInfo(
   path: string,
-  params: Record<string, string>,
-  query: Record<string, string>,
-  frontmatter: Record<string, unknown>,
-  headings: Heading[],
-): {
-  slug: string;
-  path: string;
-  params: Record<string, string>;
-  query: Record<string, string>;
-  frontmatter: Record<string, unknown>;
-  headings: Heading[];
-  mdxHeadings: Heading[];
-} {
+  slug: string,
+  frontmatter: Record<string, unknown> = {},
+): EntityInfo {
   return {
-    slug,
-    path,
-    params,
-    query,
-    frontmatter,
-    headings,
-    mdxHeadings: headings,
-  };
+    entity: { id: path, path, slug, type: "page", content: "", frontmatter },
+  } as unknown as EntityInfo;
+}
+
+/**
+ * Builds an applicator whose framework providers are pre-seeded, so applyLayouts
+ * can be driven end to end without compiling the real context/router modules.
+ */
+function createApplicator(
+  overrides: Partial<LayoutApplicationOptions> = {},
+): LayoutApplicator {
+  const applicator = new LayoutApplicator({
+    projectDir: "/project",
+    projectId: "project",
+    projectSlug: "project",
+    contentSourceId: "preview-main",
+    adapter: createAdapter(),
+    config: {} as VeryfrontConfig,
+    layoutCache: createLayoutComponentCache(),
+    mergedComponents: {},
+    mode: "production",
+    environment: "production",
+    reactVersion: "19.1.1",
+    ...overrides,
+  });
+
+  (applicator as unknown as { frameworkProviderModulesPromise: Promise<ProviderModules> })
+    .frameworkProviderModulesPromise = Promise.resolve({
+      PageContextProvider: Pass as React.ComponentType<Record<string, unknown>>,
+      RouterProvider: Pass as React.ComponentType<Record<string, unknown>>,
+    });
+
+  return applicator;
 }
 
 describe("LayoutApplicator helpers", () => {
@@ -83,88 +85,104 @@ describe("LayoutApplicator helpers", () => {
     __setServerModuleLoaderForTests(null);
   });
 
-  describe("buildSSRRouter", () => {
-    it("should build router from URL", () => {
-      const url = new URL("https://example.com/about?foo=bar");
-      const router = buildSSRRouter(url, "/pages/about.tsx", "about");
-      assertEquals(router.domain, "https://example.com");
-      assertEquals(router.pathname, "/about");
-      assertEquals(router.query, { foo: "bar" });
-      assertEquals(router.isPreview, false);
-      assertEquals(router.isMounted, false);
-    });
-
-    it("should use fallback values when URL is undefined", () => {
-      const router = buildSSRRouter(undefined, "/pages/about.tsx", "about");
-      assertEquals(router.domain, "");
-      assertEquals(router.path, "/pages/about.tsx");
-      assertEquals(router.pathname, "/about");
-      assertEquals(router.query, {});
-    });
-
-    it("should join catch-all params instead of dropping segments", () => {
-      const url = new URL("https://example.com/blog/123/extra");
-      const router = buildSSRRouter(url, "/pages/blog/[...id].tsx", "blog/123/extra", {
-        id: ["123", "extra"],
+  describe("applyLayouts SSR router", () => {
+    it("builds the router from the request URL and route params", async () => {
+      __setServerModuleLoaderForTests(() => Promise.resolve({ default: React }));
+      const applicator = createApplicator({
+        requestUrl: new URL("https://example.com/about?foo=bar"),
+        params: { id: ["123", "extra"] },
       });
-      assertEquals(router.params, { id: "123/extra" });
+
+      const result = await applicator.applyLayouts(
+        React.createElement("main"),
+        createPageInfo("/project/pages/about.tsx", "about"),
+        undefined,
+        [],
+      );
+
+      const router = (result.props as { router: Record<string, unknown> }).router;
+      assertEquals(
+        router.params,
+        { id: "123/extra" },
+        "catch-all params must reach the SSR router joined, not first-segment-only",
+      );
+      assertEquals(
+        router.pathname,
+        "/about",
+        "SSR router pathname must come from the request URL",
+      );
+      assertEquals(
+        router.domain,
+        "https://example.com",
+        "SSR router domain must be the request origin",
+      );
+      assertEquals(
+        router.query,
+        { foo: "bar" },
+        "SSR router query must come from the request search params",
+      );
     });
 
-    it("should handle URL with multiple search params", () => {
-      const url = new URL("https://example.com/search?q=test&page=2&lang=en");
-      const router = buildSSRRouter(url, "/pages/search.tsx", "search");
-      assertEquals(router.query, { q: "test", page: "2", lang: "en" });
-    });
+    it("falls back to the page file path and slug without a request URL", async () => {
+      __setServerModuleLoaderForTests(() => Promise.resolve({ default: React }));
+      const applicator = createApplicator();
 
-    it("should provide async navigate/push/replace/reload methods", async () => {
-      const router = buildSSRRouter(undefined, "/page.tsx", "page");
-      await router.navigate();
-      await router.push();
-      await router.replace();
-      await router.reload();
+      const result = await applicator.applyLayouts(
+        React.createElement("main"),
+        createPageInfo("/project/pages/about.tsx", "about"),
+        undefined,
+        [],
+      );
+
+      const router = (result.props as { router: Record<string, unknown> }).router;
+      assertEquals(
+        router.domain,
+        "",
+        "the SSR router domain is empty without a request URL",
+      );
+      assertEquals(
+        router.path,
+        "/project/pages/about.tsx",
+        "path falls back to the page file path",
+      );
+      assertEquals(router.pathname, "/about", "pathname falls back to the entity slug");
+      assertEquals(router.query, {}, "query is empty without a request URL");
     });
   });
 
-  describe("buildPageContext", () => {
-    it("should build context with all fields", () => {
-      const headings = [{ id: "intro", text: "Introduction", level: 1 }];
-      const ctx = buildPageContext(
-        "about",
-        "/pages/about.tsx",
-        { id: "123" },
-        { tab: "details" },
-        { title: "About" },
-        headings,
+  describe("applyLayouts page context", () => {
+    it("exposes getServerData props and the entity frontmatter", async () => {
+      __setServerModuleLoaderForTests(() => Promise.resolve({ default: React }));
+      const applicator = createApplicator({
+        config: { react: { version: "19.1.1" } } as VeryfrontConfig,
+        pageProps: { user: "kim" },
+      });
+
+      const result = await applicator.applyLayouts(
+        React.createElement("main"),
+        createPageInfo("/project/pages/about.tsx", "about", { title: "About" }),
+        undefined,
+        [],
       );
-      assertEquals(ctx.slug, "about");
-      assertEquals(ctx.path, "/pages/about.tsx");
-      assertEquals(ctx.params, { id: "123" });
-      assertEquals(ctx.query, { tab: "details" });
-      assertEquals(ctx.frontmatter, { title: "About" });
-      assertEquals(ctx.headings, headings);
-      assertEquals(ctx.mdxHeadings, headings);
-    });
 
-    it("should preserve empty params and query", () => {
-      const ctx = buildPageContext("home", "/pages/index.tsx", {}, {}, {}, []);
-      assertEquals(ctx.params, {});
-      assertEquals(ctx.query, {});
-    });
-
-    it("should handle empty frontmatter", () => {
-      const ctx = buildPageContext("test", "/test.tsx", {}, {}, {}, []);
-      assertEquals(ctx.frontmatter, {});
-    });
-
-    it("should handle multiple headings", () => {
-      const headings = [
-        { id: "h1", text: "Title", level: 1 },
-        { id: "h2", text: "Subtitle", level: 2 },
-        { id: "h3", text: "Section", level: 3 },
-      ];
-      const ctx = buildPageContext("docs", "/docs.tsx", {}, {}, {}, headings);
-      assertEquals(ctx.headings.length, 3);
-      assertEquals(ctx.mdxHeadings.length, 3);
+      const contextElement = (result.props as { children: React.ReactElement }).children;
+      const ctx = (contextElement.props as { pageContext: Record<string, unknown> }).pageContext;
+      assertEquals(
+        ctx.data,
+        { user: "kim" },
+        "getServerData props must reach the page context as `data`",
+      );
+      assertEquals(
+        ctx.frontmatter,
+        { title: "About" },
+        "frontmatter must fall back to pageInfo.entity.frontmatter when options.frontmatter is absent",
+      );
+      assertEquals(ctx.slug, "about", "the page context carries the entity slug");
+      assertEquals(
+        ctx.path,
+        "/project/pages/about.tsx",
+        "the page context carries the page file path",
+      );
     });
   });
 
@@ -215,29 +233,89 @@ describe("LayoutApplicator helpers", () => {
     });
   });
 
-  describe("ESM vs function-body layout mode detection", () => {
-    it("should detect ESM mode from config", () => {
-      const config: { experimental?: { esmLayouts?: boolean } } = {
-        experimental: { esmLayouts: true },
+  describe("ESM vs function-body layout routing", () => {
+    /**
+     * The two paths differ on how they render an MDX layout: applyLayoutsESM
+     * goes through applyMDXLayout -> mdxRenderer.loadModuleESM, while
+     * applyLayoutsFunctionBody calls mdxRenderer.render directly.
+     */
+    const recordLayoutPath = async (config: VeryfrontConfig): Promise<string[]> => {
+      __setServerModuleLoaderForTests(() => Promise.resolve({ default: React }));
+      const calls: string[] = [];
+      const originalLoadModuleESM = mdxRenderer.loadModuleESM;
+      const originalRender = mdxRenderer.render;
+      const mutableRenderer = mdxRenderer as unknown as {
+        loadModuleESM: typeof mdxRenderer.loadModuleESM;
+        render: typeof mdxRenderer.render;
       };
-      assertEquals(Boolean(config.experimental?.esmLayouts), true);
-    });
 
-    it("should default to function-body mode when not set", () => {
-      const config: { experimental?: { esmLayouts?: boolean } } = {};
-      assertEquals(Boolean(config.experimental?.esmLayouts), false);
-    });
-
-    it("should default to function-body mode when experimental is undefined", () => {
-      const config: { experimental?: { esmLayouts?: boolean } } = { experimental: undefined };
-      assertEquals(Boolean(config.experimental?.esmLayouts), false);
-    });
-
-    it("should default to function-body mode when esmLayouts is false", () => {
-      const config: { experimental?: { esmLayouts?: boolean } } = {
-        experimental: { esmLayouts: false },
+      mutableRenderer.loadModuleESM = () => {
+        calls.push("loadModuleESM");
+        return Promise.resolve({ default: () => null });
       };
-      assertEquals(Boolean(config.experimental?.esmLayouts), false);
+      mutableRenderer.render = () => {
+        calls.push("render");
+        return React.createElement("div");
+      };
+
+      try {
+        await (applicator(config) as unknown as {
+          applyLayoutsOnly(
+            pageElement: React.ReactElement,
+            layoutBundle: MdxBundle | undefined,
+            nestedLayouts: LayoutItem[],
+            layoutDataMap?: Map<string, Record<string, unknown>>,
+            reactVersion?: string,
+          ): Promise<React.ReactElement>;
+        }).applyLayoutsOnly(
+          React.createElement("main"),
+          undefined,
+          [{
+            kind: "mdx",
+            path: "/project/app/layout.mdx",
+            bundle: {
+              compiledCode: "export default function NestedLayout() { return null; }",
+            },
+          }] as LayoutItem[],
+          undefined,
+          "19.1.1",
+        );
+      } finally {
+        mutableRenderer.loadModuleESM = originalLoadModuleESM;
+        mutableRenderer.render = originalRender;
+      }
+
+      return calls;
+    };
+
+    const applicator = (config: VeryfrontConfig) => createApplicator({ config });
+
+    it("routes to applyLayoutsESM when experimental.esmLayouts is set", async () => {
+      assertEquals(
+        await recordLayoutPath(
+          { experimental: { esmLayouts: true } } as unknown as VeryfrontConfig,
+        ),
+        ["loadModuleESM"],
+        "experimental.esmLayouts: true must route to applyLayoutsESM",
+      );
+    });
+
+    it("routes to applyLayoutsFunctionBody without the flag", async () => {
+      assertEquals(
+        await recordLayoutPath({} as VeryfrontConfig),
+        ["render"],
+        "an absent esmLayouts flag must route to applyLayoutsFunctionBody",
+      );
+    });
+
+    it("routes to applyLayoutsFunctionBody when esmLayouts is false", async () => {
+      assertEquals(
+        await recordLayoutPath(
+          { experimental: { esmLayouts: false } } as unknown as VeryfrontConfig,
+        ),
+        ["render"],
+        "experimental.esmLayouts: false must route to applyLayoutsFunctionBody",
+      );
     });
   });
 
@@ -335,5 +413,68 @@ describe("LayoutApplicator helpers", () => {
       true,
     );
     assertEquals(reads.some((path) => path.startsWith("/project/app/")), false);
+  });
+
+  it("wraps the page in the discovered loading and error boundaries", async () => {
+    const Loading = () => React.createElement("p", null, "Loading");
+    const ErrorPage = () => React.createElement("p", null, "Error");
+    const adapter = createAdapter({
+      "/project/src/site/loading.tsx": "export default function Loading() {}",
+      "/project/src/site/error.tsx": "export default function ErrorPage() {}",
+    });
+    __setServerModuleLoaderForTests(() => Promise.resolve({ default: React }));
+
+    const applicator = new LayoutApplicator(
+      {
+        projectDir: "/project",
+        projectId: "project",
+        projectSlug: "project",
+        contentSourceId: "preview-main",
+        adapter,
+        config: {
+          directories: { app: "src/site" },
+          react: { version: "19.1.1" },
+        } as VeryfrontConfig,
+        layoutCache: createLayoutComponentCache(),
+        mergedComponents: {},
+        mode: "production",
+        environment: "production",
+        reactVersion: "19.1.1",
+      },
+      {
+        loadComponentFromSource: (_source, path) =>
+          Promise.resolve(
+            (path.endsWith("loading.tsx") ? Loading : ErrorPage) as React.ComponentType<
+              Record<string, unknown>
+            >,
+          ),
+      },
+    );
+
+    const page = React.createElement("main");
+    const result = await (applicator as unknown as {
+      wrapWithReservedComponents(
+        element: React.ReactElement,
+        path: string,
+      ): Promise<React.ReactElement>;
+    }).wrapWithReservedComponents(page, "/project/src/site/blog/page.tsx");
+
+    assertEquals(
+      typeof result.type,
+      "function",
+      "error.tsx must wrap the page in an error boundary",
+    );
+    const inner = (result.props as { children: React.ReactElement }).children;
+    assertEquals(inner.type, React.Suspense, "loading.tsx must wrap the page in Suspense");
+    assertEquals(
+      (inner.props as { fallback: React.ReactElement }).fallback.type,
+      Loading,
+      "Suspense fallback must be the loading component",
+    );
+    assertEquals(
+      (inner.props as { children: React.ReactElement }).children,
+      page,
+      "the page element must stay inside both boundaries",
+    );
   });
 });

--- a/src/rendering/layouts/layout-applicator.ts
+++ b/src/rendering/layouts/layout-applicator.ts
@@ -564,6 +564,7 @@ export class LayoutApplicator {
             this.config?.directories?.app ?? "app",
           );
           const searchDirs = await collectAncestorDirs(segmentDir, appRootDir);
+          const reservedDeps = { loadComponentFromSource: await this.getComponentSourceLoader() };
 
           const [loadingComp, errorComp] = await Promise.all([
             tryLoadReservedInDirs(
@@ -581,6 +582,7 @@ export class LayoutApplicator {
               this.requestUrl?.origin,
               this.config?.build?.serverExternalPackages,
               this.signal,
+              reservedDeps,
             ),
             tryLoadReservedInDirs(
               searchDirs,
@@ -597,6 +599,7 @@ export class LayoutApplicator {
               this.requestUrl?.origin,
               this.config?.build?.serverExternalPackages,
               this.signal,
+              reservedDeps,
             ),
           ]);
 

--- a/src/rendering/layouts/layout-collector.test.ts
+++ b/src/rendering/layouts/layout-collector.test.ts
@@ -5,35 +5,57 @@ import {
   discoverComponentsLayoutPath,
   extractTsxLayoutSignal,
   type FileExistenceChecker,
+  LayoutCollector,
   resolveLayoutRouterRootDir,
 } from "./layout-collector.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { EntityInfo, MdxBundle } from "#veryfront/types";
 
-function getLayoutKind(path: string): "mdx" | "tsx" {
-  return path.endsWith(".mdx") || path.endsWith(".md") ? "mdx" : "tsx";
-}
+const LAYOUT_BUNDLE = { compiledCode: "LAYOUT_CODE" } as unknown as MdxBundle;
 
-interface LayoutItem {
-  kind: "mdx" | "tsx";
-  bundle?: unknown;
-  component?: unknown;
-  componentPath?: string;
-  path: string;
-}
-
-function createLayoutItem(layoutPath: string, bundle?: unknown): LayoutItem {
-  const kind = getLayoutKind(layoutPath);
-
-  if (kind === "mdx") {
-    return { kind, bundle, path: layoutPath };
-  }
-
+/**
+ * Adapter that reports exactly the staged files as existing. Every other stat
+ * rejects, so a collector that walks past its short circuits is visible both in
+ * the result and in `statPaths`.
+ */
+function createCollectorAdapter(
+  files: Record<string, string>,
+  statPaths: string[] = [],
+): RuntimeAdapter {
   return {
-    kind,
-    component: undefined,
-    componentPath: layoutPath,
-    path: layoutPath,
-  };
+    fs: {
+      stat: (path: string) => {
+        statPaths.push(path);
+        if (path in files) return Promise.resolve({ isFile: true, isDirectory: false, size: 0 });
+        return Promise.reject(new Error(`File not found: ${path}`));
+      },
+      readFile: (path: string) => {
+        const content = files[path];
+        if (content === undefined) return Promise.reject(new Error(`File not found: ${path}`));
+        return Promise.resolve(content);
+      },
+      exists: (path: string) => Promise.resolve(path in files),
+      readDir: async function* () {},
+      writeFile: () => Promise.resolve(),
+      mkdir: () => Promise.resolve(),
+      remove: () => Promise.resolve(),
+    },
+    env: { get: () => undefined },
+  } as unknown as RuntimeAdapter;
+}
+
+function createPageInfo(path: string, frontmatter: Record<string, unknown> = {}): EntityInfo {
+  return {
+    entity: {
+      id: path,
+      path,
+      slug: "",
+      type: "page",
+      content: "",
+      frontmatter,
+    },
+  } as unknown as EntityInfo;
 }
 
 describe("LayoutCollector", () => {
@@ -52,63 +74,59 @@ describe("LayoutCollector", () => {
     );
   });
 
-  describe("getLayoutKind", () => {
-    it("should return 'mdx' for .mdx files", () => {
-      assertEquals(getLayoutKind("/project/layouts/main.mdx"), "mdx");
-    });
-
-    it("should return 'mdx' for .md files", () => {
-      assertEquals(getLayoutKind("/project/layouts/docs.md"), "mdx");
-    });
-
-    it("should return 'tsx' for .tsx files", () => {
-      assertEquals(getLayoutKind("/project/layouts/main.tsx"), "tsx");
-    });
-
-    it("should return 'tsx' for .jsx files", () => {
-      assertEquals(getLayoutKind("/project/layouts/main.jsx"), "tsx");
-    });
-
-    it("should return 'tsx' for .ts files", () => {
-      assertEquals(getLayoutKind("/project/layouts/main.ts"), "tsx");
-    });
-
-    it("should return 'tsx' for .js files", () => {
-      assertEquals(getLayoutKind("/project/layouts/main.js"), "tsx");
-    });
-
-    it("should return 'tsx' for unknown extensions", () => {
-      assertEquals(getLayoutKind("/project/layouts/main.css"), "tsx");
-    });
+  it("falls back to app/ and pages/ when directories are unconfigured", () => {
+    assertEquals(
+      resolveLayoutRouterRootDir("/project", true, {} as VeryfrontConfig),
+      "/project/app",
+      "App Router defaults to <projectDir>/app when directories.app is unset",
+    );
+    assertEquals(
+      resolveLayoutRouterRootDir("/project", false, {} as VeryfrontConfig),
+      "/project/pages",
+      "Pages Router defaults to <projectDir>/pages when directories.pages is unset",
+    );
   });
 
-  describe("createLayoutItem", () => {
-    it("should create mdx layout item with bundle", () => {
-      const bundle = { compiledCode: "code" };
-      const item = createLayoutItem("/project/layouts/main.mdx", bundle);
-      assertEquals(item.kind, "mdx");
-      assertEquals(item.bundle, bundle);
-      assertEquals(item.path, "/project/layouts/main.mdx");
+  describe("layout item creation", () => {
+    const collect = async (projectDir: string, layoutFile: string) => {
+      const layoutPath = `${projectDir}/components/${layoutFile}`;
+      const collector = new LayoutCollector({
+        projectDir,
+        adapter: createCollectorAdapter({ [layoutPath]: "# layout" }),
+        config: {} as VeryfrontConfig,
+        compileMDX: () => Promise.resolve(LAYOUT_BUNDLE),
+      });
+      const result = await collector.collectLayouts(
+        createPageInfo(`${projectDir}/pages/index.mdx`),
+      );
+      return { layoutPath, result };
+    };
+
+    it("creates an mdx item carrying the compiled bundle for .mdx layouts", async () => {
+      const { layoutPath, result } = await collect("/project-mdx", "layout.mdx");
+      assertEquals(
+        result.nestedLayouts,
+        [{ kind: "mdx", bundle: LAYOUT_BUNDLE, path: layoutPath }],
+        "an mdx layout item must carry the compiled bundle or the layout renders empty",
+      );
     });
 
-    it("should create mdx layout item without bundle", () => {
-      const item = createLayoutItem("/project/layouts/main.md");
-      assertEquals(item.kind, "mdx");
-      assertEquals(item.bundle, undefined);
+    it("creates an mdx item for .md layouts too", async () => {
+      const { layoutPath, result } = await collect("/project-md", "layout.md");
+      assertEquals(
+        result.nestedLayouts,
+        [{ kind: "mdx", bundle: LAYOUT_BUNDLE, path: layoutPath }],
+        ".md layouts must compile as MDX",
+      );
     });
 
-    it("should create tsx layout item with componentPath", () => {
-      const item = createLayoutItem("/project/layouts/main.tsx");
-      assertEquals(item.kind, "tsx");
-      assertEquals(item.componentPath, "/project/layouts/main.tsx");
-      assertEquals(item.component, undefined);
-      assertEquals(item.path, "/project/layouts/main.tsx");
-    });
-
-    it("should create tsx layout for .jsx files", () => {
-      const item = createLayoutItem("/project/layouts/main.jsx");
-      assertEquals(item.kind, "tsx");
-      assertEquals(item.componentPath, "/project/layouts/main.jsx");
+    it("creates a tsx item with a componentPath and no bundle for .tsx layouts", async () => {
+      const { layoutPath, result } = await collect("/project-tsx", "layout.tsx");
+      assertEquals(
+        result.nestedLayouts,
+        [{ kind: "tsx", component: undefined, componentPath: layoutPath, path: layoutPath }],
+        "a tsx layout item must expose its componentPath and skip MDX compilation",
+      );
     });
   });
 
@@ -187,34 +205,63 @@ describe("LayoutCollector", () => {
   });
 
   describe("layout frontmatter handling", () => {
-    const isLayoutDisabled = (value: string | boolean | undefined): boolean =>
-      value === false || value === "false";
+    const collectWithDisabledLayout = async (
+      projectDir: string,
+      layoutValue: string | boolean,
+    ) => {
+      const collector = new LayoutCollector({
+        projectDir,
+        // An ancestor layout is staged so a collector that skips the disable
+        // check has something to pick up.
+        adapter: createCollectorAdapter({
+          [`${projectDir}/pages/layout.tsx`]: "export default () => null;",
+        }),
+        config: { layout: "main" } as VeryfrontConfig,
+        compileMDX: () => {
+          throw new Error("compileMDX must not be called for a layout-disabled page");
+        },
+      });
 
-    const hasExplicitLayout = (value: string | boolean | undefined): boolean =>
-      typeof value === "string" && value.length > 0;
+      return await collector.collectLayouts(
+        createPageInfo(`${projectDir}/pages/blog/post.mdx`, { layout: layoutValue }),
+      );
+    };
 
-    it("should treat layout:false as disabled", () => {
-      assertEquals(isLayoutDisabled(false), true);
+    it("should treat layout:false as disabled", async () => {
+      assertEquals(
+        await collectWithDisabledLayout("/project-layout-false", false),
+        { layoutBundle: undefined, nestedLayouts: [] },
+        "frontmatter layout: false must disable every layout, including config.layout and ancestor layouts",
+      );
     });
 
-    it("should treat layout:'false' string as disabled", () => {
-      assertEquals(isLayoutDisabled("false"), true);
+    it("should treat layout:'false' string as disabled", async () => {
+      assertEquals(
+        await collectWithDisabledLayout("/project-layout-false-string", "false"),
+        { layoutBundle: undefined, nestedLayouts: [] },
+        "frontmatter layout: 'false' must disable every layout, including config.layout and ancestor layouts",
+      );
     });
 
-    it("should detect explicit frontmatter layout", () => {
-      assertEquals(hasExplicitLayout("main"), true);
-    });
+    it("applies the ancestor layout when the page does not opt out", async () => {
+      const projectDir = "/project-layout-enabled";
+      const layoutPath = `${projectDir}/pages/layout.tsx`;
+      const collector = new LayoutCollector({
+        projectDir,
+        adapter: createCollectorAdapter({ [layoutPath]: "export default () => null;" }),
+        config: {} as VeryfrontConfig,
+        compileMDX: () => Promise.resolve(LAYOUT_BUNDLE),
+      });
 
-    it("should not detect empty string as explicit layout", () => {
-      assertEquals(hasExplicitLayout(""), false);
-    });
+      const result = await collector.collectLayouts(
+        createPageInfo(`${projectDir}/pages/blog/post.mdx`),
+      );
 
-    it("should not detect undefined as explicit layout", () => {
-      assertEquals(hasExplicitLayout(undefined), false);
-    });
-
-    it("should not detect true as explicit layout", () => {
-      assertEquals(hasExplicitLayout(true), false);
+      assertEquals(
+        result.nestedLayouts.map((item) => item.path),
+        [layoutPath],
+        "without an opt-out the staged ancestor layout must be collected, so the disabled cases prove the opt-out",
+      );
     });
   });
 
@@ -232,6 +279,23 @@ describe("LayoutCollector", () => {
       assertEquals(
         await extract('const name = "special"; export const layout = `${name}`;'),
         undefined,
+      );
+    });
+
+    it("prefers a frontmatter layout over a direct layout export", async () => {
+      assertEquals(
+        await extract(
+          'export const layout = "special"; export const frontmatter = { layout: false };',
+        ),
+        false,
+        "frontmatter.layout must win over a direct layout export so a page can opt out of layouts",
+      );
+      assertEquals(
+        await extract(
+          'export const frontmatter = { layout: false }; export const layout = "special";',
+        ),
+        false,
+        "precedence must not depend on statement order",
       );
     });
 
@@ -317,16 +381,59 @@ export const layout = falseLayout;`),
   });
 
   describe(".veryfront path detection", () => {
-    const isVeryfrontPath = (path: string): boolean =>
-      path.includes("/.veryfront/") || path.includes(".veryfront/");
+    it("should not collect any layout for .veryfront pages", async () => {
+      const projectDir = "/project-veryfront";
+      const statPaths: string[] = [];
+      const collector = new LayoutCollector({
+        projectDir,
+        // An ancestor layout is staged, so a collector without the guard would
+        // find one.
+        adapter: createCollectorAdapter(
+          { [`${projectDir}/pages/layout.tsx`]: "export default () => null;" },
+          statPaths,
+        ),
+        config: {} as VeryfrontConfig,
+        compileMDX: () => {
+          throw new Error("compileMDX must not run for .veryfront pages");
+        },
+      });
 
-    it("should detect .veryfront paths", () => {
-      assertEquals(isVeryfrontPath("/project/.veryfront/chat/page.tsx"), true);
-      assertEquals(isVeryfrontPath("/project/pages/.veryfront/index.tsx"), true);
+      const result = await collector.collectLayouts(
+        createPageInfo(`${projectDir}/.veryfront/chat/page.tsx`),
+      );
+
+      assertEquals(
+        result.layoutBundle,
+        undefined,
+        ".veryfront pages must not receive a layout bundle",
+      );
+      assertEquals(result.nestedLayouts, [], ".veryfront pages must not inherit nested layouts");
+      assertEquals(
+        statPaths,
+        [],
+        "the .veryfront short circuit must happen before any filesystem access",
+      );
     });
 
-    it("should not flag non-.veryfront paths", () => {
-      assertEquals(isVeryfrontPath("/project/pages/about.tsx"), false);
+    it("should not flag non-.veryfront paths", async () => {
+      const projectDir = "/project-not-veryfront";
+      const layoutPath = `${projectDir}/pages/layout.tsx`;
+      const collector = new LayoutCollector({
+        projectDir,
+        adapter: createCollectorAdapter({ [layoutPath]: "export default () => null;" }),
+        config: {} as VeryfrontConfig,
+        compileMDX: () => Promise.resolve(LAYOUT_BUNDLE),
+      });
+
+      const result = await collector.collectLayouts(
+        createPageInfo(`${projectDir}/pages/about.tsx`),
+      );
+
+      assertEquals(
+        result.nestedLayouts.map((item) => item.path),
+        [layoutPath],
+        "an ordinary page must still inherit its ancestor layout",
+      );
     });
   });
 });

--- a/src/rendering/layouts/utils/app-resolver.test.ts
+++ b/src/rendering/layouts/utils/app-resolver.test.ts
@@ -87,24 +87,30 @@ describe("rendering/layouts/utils/app-resolver", () => {
       await assertRejects(
         () => resolveAppComponentPath("/project", adapter, config),
         VeryfrontError,
+        "does not exist",
+        "a missing config.app file must be rejected by the existence check",
       );
     });
 
     it("should throw for invalid extension in config.app", async () => {
-      const adapter = createMockAdapter();
+      const adapter = createMockAdapter(new Set(["/project/app.css"]));
       const config = { app: "app.css" } as unknown as VeryfrontConfig;
       await assertRejects(
         () => resolveAppComponentPath("/project", adapter, config),
         VeryfrontError,
+        'Invalid app component path: "app.css"',
+        "an existing file with a non-component extension must be rejected by the extension check, not the existence check",
       );
     });
 
     it("should throw for config.app without extension", async () => {
-      const adapter = createMockAdapter();
+      const adapter = createMockAdapter(new Set(["/project/app"]));
       const config = { app: "app" } as unknown as VeryfrontConfig;
       await assertRejects(
         () => resolveAppComponentPath("/project", adapter, config),
         VeryfrontError,
+        'Invalid app component path: "app"',
+        "an existing extension-less file must be rejected by the extension check, not the existence check",
       );
     });
 

--- a/src/rendering/layouts/utils/applicator.test.ts
+++ b/src/rendering/layouts/utils/applicator.test.ts
@@ -3,7 +3,7 @@ import * as ReactDOMServer from "react-dom/server";
 import "#veryfront/schemas/_test-setup.ts";
 // Node position injection needs the babel CodeParser contract registered.
 import "#veryfront/transforms/plugins/__tests__/code-parser-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { renderToStringAdapter } from "#veryfront/react";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
@@ -14,6 +14,7 @@ import { mdxRenderer } from "#veryfront/transforms/mdx/index.ts";
 import { applyLayoutsESM, applyLayoutsFunctionBody } from "./applicator.ts";
 import { createLayoutComponentCache } from "./component-loader.ts";
 import {
+  __injectProjectReactForTests,
   __injectReactDOMServerForTests,
   __setServerModuleLoaderForTests,
   resetReactCache,
@@ -55,6 +56,19 @@ const LAYOUT_SOURCE =
 }
 `;
 
+/** Renders the props the layout receives, so layoutDataMap threading is visible in the HTML. */
+const LAYOUT_SOURCE_WITH_DATA =
+  `export default function RootLayout({ children, title }: { children: React.ReactNode; title?: string }) {
+  return <div id="tsx-layout"><h1>{title}</h1>{children}</div>;
+}
+`;
+
+// Sanitizers are disabled for the whole suite because two process-wide
+// singletons this suite starts outlive any single case and cannot be closed
+// from here: the esbuild bundler service child process that compiles the TSX
+// layouts, and the React 19 ReactDOMServer MessagePort that renderToString
+// keeps open. std/bdd checks leaks once per describe, not per step, so these
+// cannot be narrowed to the cases that cause them.
 describe(
   "rendering/layouts/utils/applicator",
   { sanitizeOps: false, sanitizeResources: false },
@@ -234,6 +248,60 @@ describe(
           mutableRenderer.loadModuleESM = originalLoadModuleESM;
         }
       });
+
+      it("passes layoutDataMap entries to the layout component", async () => {
+        const adapter = createMockAdapter();
+        adapter.fs.readFile = () => Promise.resolve(LAYOUT_SOURCE_WITH_DATA);
+
+        const result = await applyLayoutsESM(
+          React.createElement("p", { id: "page-body" }, "Text"),
+          undefined,
+          [{ kind: "tsx", componentPath: "/project/app/layout.tsx" } as LayoutItem],
+          "/project",
+          {},
+          createLayoutComponentCache(),
+          adapter,
+          new Map([["/project/app/layout.tsx", { title: "From layout data" }]]),
+          "project-esm-layout-data",
+          "project-slug",
+          "content-source-id",
+          PRODUCTION_MODES,
+        );
+
+        __injectReactDOMServerForTests(ReactDOMServer);
+        const html = await renderToStringAdapter(result);
+        assertEquals(
+          html.includes("From layout data"),
+          true,
+          "layoutDataMap entries keyed by componentPath must be passed as the layout component's props",
+        );
+      });
+
+      it("propagates a failing layout instead of rendering without it", async () => {
+        const adapter = createMockAdapter();
+        adapter.fs.readFile = () => Promise.reject(new Error("layout read exploded"));
+
+        await assertRejects(
+          () =>
+            applyLayoutsESM(
+              React.createElement("p", { id: "page-body" }, "Text"),
+              undefined,
+              [{ kind: "tsx", componentPath: "/project/app/layout.tsx" } as LayoutItem],
+              "/project",
+              {},
+              createLayoutComponentCache(),
+              adapter,
+              undefined,
+              "project-esm-failing-layout",
+              "project-slug",
+              "content-source-id",
+              PRODUCTION_MODES,
+            ),
+          Error,
+          "layout read exploded",
+          "applyLayoutsESM must propagate a broken layout rather than render without it",
+        );
+      });
     });
 
     /**
@@ -364,6 +432,97 @@ describe(
         assertEquals(html.includes("<body>"), true);
         assertEquals(html.includes('data-testid="document-layout"'), true);
         assertEquals(html.includes('id="counter"'), true);
+      });
+
+      it("builds the layout element with the project React instance", async () => {
+        const projectReact = {
+          ...React,
+          createElement: (type: unknown, props: unknown, ...children: unknown[]) => ({
+            __builtBy: "project",
+            type,
+            props,
+            children,
+          }),
+        } as unknown as typeof React;
+        __injectProjectReactForTests(projectReact);
+
+        const adapter = createMockAdapter();
+        adapter.fs.readFile = () => Promise.resolve(LAYOUT_SOURCE);
+
+        const result = await applyLayoutsFunctionBody(
+          React.createElement("p", { id: "page-body" }, "Text"),
+          undefined,
+          [{ kind: "tsx", componentPath: "/project/app/layout.tsx" } as LayoutItem],
+          {},
+          createLayoutComponentCache(),
+          "/project",
+          adapter,
+          undefined,
+          "project-fb-react-instance",
+          "project-slug",
+          "content-source-id",
+          PRODUCTION_MODES,
+        );
+
+        assertEquals(
+          (result as unknown as { __builtBy?: string }).__builtBy,
+          "project",
+          "the layout element must be created by the project React instance, not the bundled copy",
+        );
+      });
+
+      it("passes layoutDataMap entries to the layout component", async () => {
+        const adapter = createMockAdapter();
+        adapter.fs.readFile = () => Promise.resolve(LAYOUT_SOURCE_WITH_DATA);
+
+        const result = await applyLayoutsFunctionBody(
+          React.createElement("p", { id: "page-body" }, "Text"),
+          undefined,
+          [{ kind: "tsx", componentPath: "/project/app/layout.tsx" } as LayoutItem],
+          {},
+          createLayoutComponentCache(),
+          "/project",
+          adapter,
+          new Map([["/project/app/layout.tsx", { title: "From layout data" }]]),
+          "project-fb-layout-data",
+          "project-slug",
+          "content-source-id",
+          PRODUCTION_MODES,
+        );
+
+        __injectReactDOMServerForTests(ReactDOMServer);
+        const html = await renderToStringAdapter(result);
+        assertEquals(
+          html.includes("From layout data"),
+          true,
+          "layoutDataMap entries keyed by componentPath must be passed as the layout component's props",
+        );
+      });
+
+      it("propagates a failing layout instead of rendering without it", async () => {
+        const adapter = createMockAdapter();
+        adapter.fs.readFile = () => Promise.reject(new Error("layout read exploded"));
+
+        await assertRejects(
+          () =>
+            applyLayoutsFunctionBody(
+              React.createElement("p", { id: "page-body" }, "Text"),
+              undefined,
+              [{ kind: "tsx", componentPath: "/project/app/layout.tsx" } as LayoutItem],
+              {},
+              createLayoutComponentCache(),
+              "/project",
+              adapter,
+              undefined,
+              "project-fb-failing-layout",
+              "project-slug",
+              "content-source-id",
+              PRODUCTION_MODES,
+            ),
+          Error,
+          "layout read exploded",
+          "applyLayoutsFunctionBody must propagate a broken layout rather than render without it",
+        );
       });
     });
   },

--- a/src/rendering/layouts/utils/compiler.test.ts
+++ b/src/rendering/layouts/utils/compiler.test.ts
@@ -22,18 +22,27 @@ function createMockAdapter(files: Record<string, string> = {}): RuntimeAdapter {
   } as unknown as RuntimeAdapter;
 }
 
-function createMockCompileMDX(): (
+type CompileCall = [string, Record<string, unknown> | undefined, string | undefined];
+
+function createMockCompileMDX(calls: CompileCall[] = []): (
   content: string,
   frontmatter?: Record<string, unknown>,
   filePath?: string,
 ) => Promise<MdxBundle> {
-  return async (content: string) => ({
-    compiledCode: `compiled:${content}`,
-    frontmatter: {},
-    globals: {},
-    headings: [],
-    nodeMap: new Map(),
-  });
+  return async (
+    content: string,
+    frontmatter?: Record<string, unknown>,
+    filePath?: string,
+  ) => {
+    calls.push([content, frontmatter, filePath]);
+    return {
+      compiledCode: `compiled:${content}`,
+      frontmatter: {},
+      globals: {},
+      headings: [],
+      nodeMap: new Map(),
+    };
+  };
 }
 
 describe("rendering/layouts/utils/compiler", () => {
@@ -56,7 +65,8 @@ describe("rendering/layouts/utils/compiler", () => {
 
     it("should skip mdx layouts that already have a bundle", async () => {
       const adapter = createMockAdapter({ "/layout.mdx": "# Hello" });
-      const compile = createMockCompileMDX();
+      const calls: CompileCall[] = [];
+      const compile = createMockCompileMDX(calls);
       const existingBundle = {
         compiledCode: "already compiled",
         frontmatter: {},
@@ -69,6 +79,7 @@ describe("rendering/layouts/utils/compiler", () => {
       ];
       await compileMDXLayouts(layouts, compile, adapter);
       assertEquals(layouts[0].bundle?.compiledCode, "already compiled");
+      assertEquals(calls.length, 0, "an already-bundled layout must not be recompiled");
     });
 
     it("should skip mdx layouts without a path", async () => {
@@ -83,12 +94,24 @@ describe("rendering/layouts/utils/compiler", () => {
 
     it("should compile mdx layouts and assign bundles", async () => {
       const adapter = createMockAdapter({ "/layout.mdx": "# Title\n\nContent" });
-      const compile = createMockCompileMDX();
+      const calls: CompileCall[] = [];
+      const compile = createMockCompileMDX(calls);
       const layouts: LayoutItem[] = [
         { kind: "mdx", path: "/layout.mdx" } as unknown as LayoutItem,
       ];
       await compileMDXLayouts(layouts, compile, adapter);
       assertEquals(layouts[0].bundle?.compiledCode, "compiled:# Title\n\nContent");
+      assertEquals(calls.length, 1, "one compile call per uncompiled mdx layout");
+      assertEquals(
+        calls[0][1],
+        { isLayout: true },
+        "layout MDX must be compiled with the isLayout frontmatter flag so it is not reclassified as a page",
+      );
+      assertEquals(
+        calls[0][2],
+        "/layout.mdx",
+        "compileMDX must receive the layout file path for compile-error reporting",
+      );
     });
 
     it("should compile multiple mdx layouts in parallel", async () => {

--- a/src/rendering/layouts/utils/component-loader.test.ts
+++ b/src/rendering/layouts/utils/component-loader.test.ts
@@ -1,6 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import * as React from "react";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { FakeTime } from "#std/testing/time";
 import {
@@ -345,6 +345,45 @@ describe("rendering/layouts/utils/component-loader", () => {
       const child = React.Children.only(result.props.children) as React.ReactElement;
       assertEquals(child.type, "button");
     });
+
+    it("should fall back to the passed children when the root renders no body", () => {
+      function RootLayout({ children }: { children?: React.ReactNode }) {
+        return React.createElement("html", null, children);
+      }
+
+      const WrappedLayout = unwrapAppRouterDocumentLayout(React, RootLayout);
+      const passedChildren = React.createElement("button", { id: "counter" }, "Count: 0");
+      const result = WrappedLayout({ children: passedChildren });
+
+      assertStrictEquals(
+        result,
+        passedChildren,
+        "a root layout without a direct <body> must fall back to the children it was given, not render blank",
+      );
+    });
+
+    it("should pass through a root layout that does not render html", () => {
+      function RootLayout({ children }: { children?: React.ReactNode }) {
+        return React.createElement("div", { id: "shell" }, children);
+      }
+
+      const WrappedLayout = unwrapAppRouterDocumentLayout(React, RootLayout);
+      const passedChildren = React.createElement("button", { id: "counter" }, "Count: 0");
+      const result = WrappedLayout({ children: passedChildren }) as React.ReactElement<
+        { children?: React.ReactNode }
+      >;
+
+      assertEquals(
+        result.type,
+        "div",
+        "a root layout that does not render <html> must be passed through unchanged",
+      );
+      assertStrictEquals(
+        React.Children.only(result.props.children),
+        passedChildren,
+        "the passed children must survive the pass-through unchanged",
+      );
+    });
   });
 
   describe("loadTSXComponent", () => {
@@ -492,6 +531,48 @@ describe("rendering/layouts/utils/component-loader", () => {
       assertEquals(loadCalls, 2);
     });
 
+    it("rejects a load that resolves nothing instead of caching undefined", async () => {
+      const cache = createLayoutComponentCache();
+      let loadCalls = 0;
+      function Layout() {
+        return null;
+      }
+      const deps = {
+        loadComponentFromSource: () => {
+          loadCalls++;
+          return loadCalls === 1
+            ? Promise.resolve(undefined as unknown as React.ComponentType)
+            : Promise.resolve(Layout);
+        },
+      };
+      const args = [
+        "/project/app/empty-layout.tsx",
+        "/project",
+        cache,
+        layoutAdapter("export default function Layout() { return null; }"),
+        "project-1",
+        "project-slug",
+        "release-1",
+        PRODUCTION_MODES,
+        "19.1.0",
+        deps,
+      ] as const;
+
+      await assertRejects(
+        () => loadTSXComponent(...args),
+        Error,
+        "Component loading failed",
+        "an empty component load must surface as a classified render error",
+      );
+
+      assertEquals(
+        await loadTSXComponent(...args),
+        Layout,
+        "a retry after an empty load must resolve the real component",
+      );
+      assertEquals(loadCalls, 2, "a failed load must not poison the layout component cache");
+    });
+
     it("does not let a stale load overwrite its replacement cache entry", async () => {
       using time = new FakeTime();
       const cache = createLayoutComponentCache();
@@ -590,6 +671,68 @@ describe("rendering/layouts/utils/component-loader", () => {
       assertEquals(moduleReactVersion, "18.3.1");
       assertEquals(modulePinKey, SNAPSHOT_A_PIN_KEY);
       assertEquals(moduleDependencies, SNAPSHOT_A_DEPENDENCIES);
+    } finally {
+      mutableRenderer.loadModuleESM = originalLoadModuleESM;
+    }
+  });
+
+  it("resolves MDX layout exports in MDXLayout, MainLayout, default order", async () => {
+    const originalLoadModuleESM = mdxRenderer.loadModuleESM;
+    const mutableRenderer = mdxRenderer as unknown as {
+      loadModuleESM: typeof mdxRenderer.loadModuleESM;
+    };
+    function MDXLayoutExport() {
+      return null;
+    }
+    function MainLayoutExport() {
+      return null;
+    }
+    function DefaultExport() {
+      return null;
+    }
+    const stubModule = (mod: Record<string, unknown>) => {
+      mutableRenderer.loadModuleESM =
+        (() => Promise.resolve(mod)) as typeof mdxRenderer.loadModuleESM;
+    };
+    const baseOptions = {
+      bundle: {
+        compiledCode: "export default function Layout() { return null; }",
+      } as MdxBundle,
+      projectDir: "/project",
+      adapter: { fs: {} } as unknown as RuntimeAdapter,
+      projectId: "export-order-project",
+      projectSlug: "project-slug",
+      contentSourceId: "release-1",
+      modes: PRODUCTION_MODES,
+      preloadedImportMap: { imports: {} },
+      reactVersion: "19.1.1",
+    };
+
+    try {
+      stubModule({
+        MDXLayout: MDXLayoutExport,
+        MainLayout: MainLayoutExport,
+        default: DefaultExport,
+      });
+      assertStrictEquals(
+        await loadMDXLayout(baseOptions),
+        MDXLayoutExport,
+        "MDXLayout must win over MainLayout and default",
+      );
+
+      stubModule({ MainLayout: MainLayoutExport, default: DefaultExport });
+      assertStrictEquals(
+        await loadMDXLayout(baseOptions),
+        MainLayoutExport,
+        "MainLayout must win over default",
+      );
+
+      stubModule({ default: DefaultExport });
+      assertStrictEquals(
+        await loadMDXLayout(baseOptions),
+        DefaultExport,
+        "the default export must be used when no named layout export exists",
+      );
     } finally {
       mutableRenderer.loadModuleESM = originalLoadModuleESM;
     }

--- a/src/rendering/layouts/utils/discovery.test.ts
+++ b/src/rendering/layouts/utils/discovery.test.ts
@@ -10,6 +10,7 @@ import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 
 function createMockAdapter(
   existingFiles: Set<string> = new Set(),
+  counter: { statCalls: number } = { statCalls: 0 },
 ): RuntimeAdapter {
   return {
     fs: {
@@ -22,6 +23,7 @@ function createMockAdapter(
       writeFile: async () => {},
       mkdir: async () => {},
       stat: async (path: string) => {
+        counter.statCalls++;
         if (existingFiles.has(path)) {
           return { isFile: true, isDirectory: false, size: 100 };
         }
@@ -41,8 +43,70 @@ describe("rendering/layouts/utils/discovery", () => {
       assertEquals(stats.size, 0);
     });
 
-    it("should clear cache for specific project", () => {
-      clearLayoutDiscoveryCache("/project");
+    it("should clear cache for specific project", async () => {
+      clearLayoutDiscoveryCache();
+      const counterA = { statCalls: 0 };
+      const counterB = { statCalls: 0 };
+      const adapterA = createMockAdapter(
+        new Set(["/project-a/pages/layout.mdx"]),
+        counterA,
+      );
+      const adapterB = createMockAdapter(
+        new Set(["/project-b/pages/layout.mdx"]),
+        counterB,
+      );
+
+      await discoverNestedLayouts(
+        "/project-a/pages/index.mdx",
+        "/project-a",
+        "/project-a",
+        adapterA,
+      );
+      await discoverNestedLayouts(
+        "/project-b/pages/index.mdx",
+        "/project-b",
+        "/project-b",
+        adapterB,
+      );
+      assertEquals(
+        getLayoutDiscoveryCacheStats().size,
+        2,
+        "each project must get its own discovery cache entry",
+      );
+
+      clearLayoutDiscoveryCache("/project-a");
+      assertEquals(
+        getLayoutDiscoveryCacheStats().size,
+        1,
+        "clearing one project must evict only that project's entries",
+      );
+
+      const statCallsA = counterA.statCalls;
+      const statCallsB = counterB.statCalls;
+
+      await discoverNestedLayouts(
+        "/project-a/pages/index.mdx",
+        "/project-a",
+        "/project-a",
+        adapterA,
+      );
+      assertEquals(
+        counterA.statCalls > statCallsA,
+        true,
+        "the cleared project must re-stat the filesystem instead of serving a stale cache entry",
+      );
+
+      await discoverNestedLayouts(
+        "/project-b/pages/index.mdx",
+        "/project-b",
+        "/project-b",
+        adapterB,
+      );
+      assertEquals(
+        counterB.statCalls,
+        statCallsB,
+        "clearing one project must leave another project's cache entry intact",
+      );
     });
   });
 
@@ -95,6 +159,16 @@ describe("rendering/layouts/utils/discovery", () => {
       );
       assertEquals(layouts.length, 1);
       assertEquals(layouts[0].kind, "tsx");
+      assertEquals(
+        layouts[0].path,
+        "/project/pages/layout.tsx",
+        "tsx layout path must be the discovered file",
+      );
+      assertEquals(
+        layouts[0].componentPath,
+        "/project/pages/layout.tsx",
+        "tsx layouts must carry componentPath or the compiler and applicator skip them",
+      );
     });
 
     it("should discover layout in root directory", async () => {
@@ -124,12 +198,22 @@ describe("rendering/layouts/utils/discovery", () => {
         "/project",
         adapter,
       );
-      assertEquals(layouts.length >= 1, true);
+      assertEquals(
+        layouts.map((l) => l.path),
+        ["/project/pages/layout.tsx", "/project/pages/blog/layout.mdx"],
+        "ancestor layouts must be ordered outermost (root) first so the applicator wraps the innermost layout last",
+      );
+      assertEquals(
+        layouts.map((l) => l.kind),
+        ["tsx", "mdx"],
+        "each discovered layout must keep the kind matching its extension",
+      );
     });
 
     it("should use cache on repeated calls", async () => {
       const files = new Set(["/project/layout.mdx"]);
-      const adapter = createMockAdapter(files);
+      const counter = { statCalls: 0 };
+      const adapter = createMockAdapter(files, counter);
       clearLayoutDiscoveryCache();
 
       const layouts1 = await discoverNestedLayouts(
@@ -138,6 +222,7 @@ describe("rendering/layouts/utils/discovery", () => {
         "/project",
         adapter,
       );
+      const statCallsAfterFirst = counter.statCalls;
       const layouts2 = await discoverNestedLayouts(
         "/project/page.mdx",
         "/project",
@@ -145,6 +230,16 @@ describe("rendering/layouts/utils/discovery", () => {
         adapter,
       );
       assertEquals(layouts1.length, layouts2.length);
+      assertEquals(
+        layouts1 === layouts2,
+        true,
+        "repeat discovery must return the cached layout array, not a recomputed one",
+      );
+      assertEquals(
+        counter.statCalls,
+        statCallsAfterFirst,
+        "a cached discovery must not re-stat the ancestor chain",
+      );
       const stats = getLayoutDiscoveryCacheStats();
       assertEquals(stats.size >= 1, true);
     });

--- a/src/rendering/layouts/utils/ensure-valid-child.test.ts
+++ b/src/rendering/layouts/utils/ensure-valid-child.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { ensureValidChild } from "./ensure-valid-child.ts";
 import * as React from "react";
@@ -41,14 +41,22 @@ describe("rendering/layouts/utils/ensure-valid-child", () => {
 
     it("should return valid React elements as-is", () => {
       const el = React.createElement("div", null, "test");
-      const result = ensureValidChild(el);
-      assertEquals(React.isValidElement(result), true);
+      assertStrictEquals(
+        ensureValidChild(el),
+        el,
+        "a valid element must be returned unchanged, not cloned",
+      );
     });
 
     it("should return React elements with props", () => {
       const el = React.createElement("span", { className: "foo" });
       const result = ensureValidChild(el);
-      assertEquals(React.isValidElement(result), true);
+      assertStrictEquals(result, el, "element identity must survive");
+      assertEquals(
+        (result as React.ReactElement<{ className: string }>).props.className,
+        "foo",
+        "props must be preserved",
+      );
     });
 
     it("should return null for non-element objects without React symbol", () => {

--- a/src/rendering/layouts/utils/hash-calculator.test.ts
+++ b/src/rendering/layouts/utils/hash-calculator.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { computeHash } from "#veryfront/utils";
 import { computeDepsHash } from "./hash-calculator.ts";
 import type { LayoutItem, MdxBundle } from "#veryfront/types";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
@@ -72,8 +73,32 @@ describe("rendering/layouts/utils/hash-calculator", () => {
         { componentPath: "/layout.tsx" } as unknown as LayoutItem,
       ];
       const result = await computeDepsHash(undefined, nestedLayouts, adapter);
-      assertEquals(typeof result, "string");
-      assertEquals(result.length > 0, true);
+      assertEquals(
+        result,
+        await computeHash("export default () => {}"),
+        "nested tsx layouts must hash their file contents, not their path",
+      );
+    });
+
+    it("should change the hash when a nested layout file is edited", async () => {
+      const nestedLayouts: LayoutItem[] = [
+        { componentPath: "/layout.tsx" } as unknown as LayoutItem,
+      ];
+      const resultA = await computeDepsHash(
+        undefined,
+        nestedLayouts,
+        createMockAdapter({ "/layout.tsx": "export default () => {}" }),
+      );
+      const resultB = await computeDepsHash(
+        undefined,
+        nestedLayouts,
+        createMockAdapter({ "/layout.tsx": "export default () => null" }),
+      );
+      assertNotEquals(
+        resultA,
+        resultB,
+        "editing a nested layout file must change the dependency hash",
+      );
     });
 
     it("should include nested layout bundle code in hash", async () => {
@@ -82,8 +107,30 @@ describe("rendering/layouts/utils/hash-calculator", () => {
         { bundle: createMdxBundle("layout code") } as unknown as LayoutItem,
       ];
       const result = await computeDepsHash(undefined, nestedLayouts, adapter);
-      assertEquals(typeof result, "string");
-      assertEquals(result.length > 0, true);
+      assertEquals(
+        result,
+        await computeHash("layout code"),
+        "nested MDX layouts must hash bundle.compiledCode",
+      );
+    });
+
+    it("should change the hash when nested layout bundle code differs", async () => {
+      const adapter = createMockAdapter();
+      const resultA = await computeDepsHash(
+        undefined,
+        [{ bundle: createMdxBundle("layout code") } as unknown as LayoutItem],
+        adapter,
+      );
+      const resultB = await computeDepsHash(
+        undefined,
+        [{ bundle: createMdxBundle("other layout code") } as unknown as LayoutItem],
+        adapter,
+      );
+      assertNotEquals(
+        resultA,
+        resultB,
+        "a changed nested bundle must change the dependency hash",
+      );
     });
 
     it("should skip null items in nested layouts", async () => {
@@ -99,7 +146,21 @@ describe("rendering/layouts/utils/hash-calculator", () => {
         { componentPath: "/nonexistent.tsx" } as unknown as LayoutItem,
       ];
       const result = await computeDepsHash(undefined, nestedLayouts, adapter);
-      assertEquals(typeof result, "string");
+      assertEquals(result, "", "an unreadable component path must contribute no hash part");
+    });
+
+    it("should keep other dependency hashes when one component path is unreadable", async () => {
+      const adapter = createMockAdapter({});
+      const bundle = createMdxBundle("main layout");
+      const nestedLayouts: LayoutItem[] = [
+        { componentPath: "/missing.tsx" } as unknown as LayoutItem,
+      ];
+      const result = await computeDepsHash(bundle, nestedLayouts, adapter);
+      assertEquals(
+        result,
+        await computeHash("main layout"),
+        "one unreadable nested layout must not discard the other dependency hashes",
+      );
     });
 
     it("should combine layout bundle hash with nested layout hashes", async () => {
@@ -121,8 +182,16 @@ describe("rendering/layouts/utils/hash-calculator", () => {
         } as unknown as LayoutItem,
       ];
       const result = await computeDepsHash(undefined, nestedLayouts, adapter);
-      assertEquals(typeof result, "string");
-      assertEquals(result.length > 0, true);
+      assertEquals(
+        result,
+        await computeHash("component source"),
+        "componentPath source must win over the nested bundle code",
+      );
+      assertNotEquals(
+        result,
+        await computeHash("should be ignored"),
+        "nested bundle code must not be hashed when componentPath is present",
+      );
     });
 
     it("should skip nested layouts without componentPath or bundle", async () => {

--- a/src/rendering/shared/context-aware-cache.test.ts
+++ b/src/rendering/shared/context-aware-cache.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertNotStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { ContextAwareCacheCoordinator } from "./context-aware-cache.ts";
 import type { CachePayload, CacheStore } from "../cache/types.ts";
@@ -171,6 +171,81 @@ describe("rendering/shared/context-aware-cache", () => {
       assertEquals(lookup.cachedResult?.html.includes("veryfront-cache-nonce"), false);
     });
 
+    it("rejects and evicts an unsealed entry when the response enforces a nonce", async () => {
+      const store = createInMemoryStore();
+      const cache = new ContextAwareCacheCoordinator({ store });
+      const ctx = makeMockCtx();
+      const renderResult = {
+        html: "<script>framework()</script>",
+        frontmatter: {},
+        headings: [],
+        stream: null,
+      };
+
+      // Persisted without a nonce, so the entry carries no sealed placeholder.
+      await cache.persistResult(renderResult as any, "legacy-nonce-page", ctx);
+
+      const lookup = await cache.checkCache(
+        "legacy-nonce-page",
+        ctx,
+        undefined,
+        undefined,
+        "nonce-x",
+      );
+
+      assertEquals(
+        lookup.status,
+        "miss",
+        "an entry stored without a nonce placeholder must not be served to a nonce-enforcing response",
+      );
+      assertEquals(lookup.hit, false, "an unsealed entry must not count as a hit");
+      assertEquals(lookup.cachedResult, undefined, "an unsealed entry must not return HTML");
+      assertEquals(
+        store.data.has(lookup.cacheKey),
+        false,
+        "the incompatible entry must be evicted, not left to poison later lookups",
+      );
+    });
+
+    it("serves a sealed entry without a nonce by stripping the cached slots", async () => {
+      const store = createInMemoryStore();
+      const cache = new ContextAwareCacheCoordinator({ store });
+      const ctx = makeMockCtx();
+      const renderResult = {
+        html: '<script nonce="nonce-a">framework()</script>',
+        frontmatter: {},
+        headings: [],
+        stream: null,
+      };
+
+      await cache.persistResult(
+        renderResult as any,
+        "sealed-nonce-page",
+        ctx,
+        undefined,
+        undefined,
+        "nonce-a",
+      );
+
+      const lookup = await cache.checkCache("sealed-nonce-page", ctx);
+
+      assertEquals(
+        lookup.hit,
+        true,
+        "a sealed entry stays usable for a response that enforces no nonce",
+      );
+      assertEquals(
+        lookup.cachedResult?.html.includes("nonce="),
+        false,
+        "a response without a nonce must not receive a nonce attribute",
+      );
+      assertEquals(
+        lookup.cachedResult?.html.includes("vf-cache-"),
+        false,
+        "the cache placeholder must never reach the response",
+      );
+    });
+
     it("should not cache results with streams", async () => {
       const store = createInMemoryStore();
       const cache = new ContextAwareCacheCoordinator({ store });
@@ -321,6 +396,71 @@ describe("rendering/shared/context-aware-cache", () => {
 
       const noThemeLookup = await cache.checkCache("themed", ctx);
       assertEquals(noThemeLookup.hit, false);
+    });
+
+    it("honours cacheKeyOverride when keying entries", async () => {
+      const store = createInMemoryStore();
+      const cache = new ContextAwareCacheCoordinator({ store });
+      const ctx = makeMockCtx();
+
+      const renderResult = {
+        html: "<h1>Variant A</h1>",
+        frontmatter: {},
+        headings: [],
+        stream: null,
+        ssrHash: "variant-a",
+      };
+
+      await cache.persistResult(
+        renderResult as any,
+        "index",
+        ctx,
+        undefined,
+        "page:index:variant-a",
+      );
+
+      const sameOverride = await cache.checkCache("index", ctx, undefined, "page:index:variant-a");
+      assertEquals(sameOverride.hit, true, "the same override must hit");
+
+      const otherOverride = await cache.checkCache("index", ctx, undefined, "page:index:variant-b");
+      assertEquals(otherOverride.hit, false, "a different override must miss");
+
+      const noOverride = await cache.checkCache("index", ctx);
+      assertEquals(
+        noOverride.hit,
+        false,
+        "an override entry must not be served to callers passing no override",
+      );
+    });
+
+    it("does not double-suffix an override that already carries a theme", async () => {
+      const store = createInMemoryStore();
+      const cache = new ContextAwareCacheCoordinator({ store });
+      const ctx = makeMockCtx();
+
+      const renderResult = {
+        html: "<h1>Themed override</h1>",
+        frontmatter: {},
+        headings: [],
+        stream: null,
+        ssrHash: "themed-override",
+      };
+
+      await cache.persistResult(
+        renderResult as any,
+        "index",
+        ctx,
+        "light",
+        "page:index:theme-light",
+      );
+
+      const lookup = await cache.checkCache("index", ctx, "light", "page:index:theme-light");
+      assertEquals(lookup.hit, true, "the themed override must hit its own entry");
+      assertEquals(
+        lookup.cacheKey.match(/:theme-light/g)?.length,
+        1,
+        "an override already carrying a theme suffix must not be double-suffixed",
+      );
     });
 
     it("should clear all cached data", async () => {
@@ -501,6 +641,7 @@ describe("rendering/shared/context-aware-cache", () => {
         html: "<h1>Original</h1>",
         frontmatter: { title: "Original" },
         headings: [{ level: 1, text: "Original" }],
+        nodeMap: new Map<number, unknown>([[1, {}]]),
         stream: null,
         ssrHash: "orig",
       };
@@ -512,10 +653,27 @@ describe("rendering/shared/context-aware-cache", () => {
 
       if (lookup.cachedResult) {
         lookup.cachedResult.html = "MUTATED";
+        lookup.cachedResult.headings!.push({ id: "injected", level: 2, text: "Injected" });
+        (lookup.cachedResult.frontmatter as Record<string, unknown>).title = "MUTATED";
       }
 
       const reLookup = await cache.checkCache("clone-test", ctx);
       assertEquals(reLookup.cachedResult?.html, "<h1>Original</h1>");
+      assertEquals(
+        reLookup.cachedResult?.headings?.length,
+        1,
+        "a cached headings array must not be shared with a previous caller",
+      );
+      assertEquals(
+        reLookup.cachedResult?.frontmatter.title,
+        "Original",
+        "a cached frontmatter object must not be shared with a previous caller",
+      );
+      assertNotStrictEquals(
+        lookup.cachedResult?.nodeMap,
+        reLookup.cachedResult?.nodeMap,
+        "each lookup must receive its own nodeMap instance",
+      );
     });
   });
 });

--- a/src/rendering/shared/shared-services.test.ts
+++ b/src/rendering/shared/shared-services.test.ts
@@ -1,6 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertStrictEquals,
+  assertStringIncludes,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import * as React from "react";
 import {
   areSharedServicesInitialized,
   destroySharedServices,
@@ -20,9 +26,20 @@ describe("rendering/shared/shared-services", () => {
   describe("getSharedServices before initialization", () => {
     it("should throw when not initialized", () => {
       destroySharedServices();
-      assertThrows(
+      const error = assertThrows(
         () => getSharedServices(),
         VeryfrontError,
+      ) as VeryfrontError;
+      assertEquals(
+        error.slug,
+        "initialization-error",
+        "uninitialized access must raise the initialization error",
+      );
+      assertEquals(error.status, 500, "uninitialized access must map to HTTP 500");
+      assertStringIncludes(
+        error.detail ?? "",
+        "Call initializeSharedServices() first",
+        "the error must carry actionable guidance",
       );
     });
   });
@@ -47,7 +64,30 @@ describe("rendering/shared/shared-services", () => {
     it("should return same instance on repeated calls", async () => {
       const s1 = await initializeSharedServices();
       const s2 = await initializeSharedServices();
-      assertEquals(s1, s2);
+      assertStrictEquals(
+        s1,
+        s2,
+        "initializeSharedServices must return the identical singleton on repeated calls",
+      );
+      assertStrictEquals(
+        s1.compilerService,
+        getSharedServices().compilerService,
+        "the object handed to callers must be the module singleton getSharedServices reads",
+      );
+    });
+
+    it("should dedupe concurrent initialization", async () => {
+      destroySharedServices();
+      const [a, b] = await Promise.all([
+        initializeSharedServices(),
+        initializeSharedServices(),
+      ]);
+      assertStrictEquals(
+        a,
+        b,
+        "concurrent callers must share one in-flight initialization promise",
+      );
+      assertStrictEquals(a, getSharedServices(), "the deduped result must be the module singleton");
     });
 
     it("should accept debug mode option", async () => {
@@ -57,9 +97,24 @@ describe("rendering/shared/shared-services", () => {
     });
 
     it("should accept custom maxValidationDepth", async () => {
+      // An invalid child buried 25 levels down: reachable at depth 50, not at the default 20.
+      let tree: unknown = { bad: 1 };
+      for (let i = 0; i < 25; i++) {
+        tree = React.createElement("div", null, tree as React.ReactNode);
+      }
+
       destroySharedServices();
-      const services = await initializeSharedServices({ maxValidationDepth: 50 });
-      assertEquals(typeof services.elementValidator, "object");
+      const deep = await initializeSharedServices({ maxValidationDepth: 50 });
+      assertThrows(
+        () => deep.elementValidator.deepInspectElement(tree),
+        Error,
+        "Invalid React child",
+        "maxValidationDepth: 50 must let inspection reach an invalid child 25 levels down",
+      );
+
+      destroySharedServices();
+      const shallow = await initializeSharedServices({});
+      shallow.elementValidator.deepInspectElement(tree);
     });
 
     it("should make getSharedServices work after initialization", async () => {

--- a/src/rendering/ssr-globals/dom-stubs.test.ts
+++ b/src/rendering/ssr-globals/dom-stubs.test.ts
@@ -22,6 +22,25 @@ describe("rendering/ssr-globals/dom-stubs", () => {
       assertEquals(el.querySelectorAll().length, 0);
     });
 
+    // Regression: libraries read `el.dataset.<key>`, attach listeners and measure
+    // rects during SSR (Floating UI, Radix, theme scripts); a missing member throws
+    // "Cannot read properties of undefined" or "is not a function" mid-render.
+    it("should expose dataset, event listeners and rect helpers", () => {
+      const el = createElementStub();
+      assertEquals(typeof el.dataset, "object", "libraries read el.dataset.<key> during SSR");
+      assertEquals(
+        el.getClientRects().length,
+        0,
+        "Floating UI calls el.getClientRects() during render",
+      );
+      assertEquals(typeof el.addEventListener, "function", "libraries subscribe during render");
+      assertEquals(typeof el.removeEventListener, "function", "libraries unsubscribe on teardown");
+      el.addEventListener();
+      el.removeEventListener();
+      assertEquals(typeof el.setAttributeNS, "function", "SVG helpers write namespaced attributes");
+      assertEquals(el.getAttributeNS(), null, "SVG helpers read namespaced attributes");
+    });
+
     it("should have zero dimensions", () => {
       const el = createElementStub();
       assertEquals(el.offsetWidth, 0);

--- a/src/rendering/ssr/component-registry.test.ts
+++ b/src/rendering/ssr/component-registry.test.ts
@@ -5,13 +5,7 @@ import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { hashString } from "#veryfront/cache/hash.ts";
 import type { VirtualModuleSystem } from "../virtual-module-system.ts";
 import { ComponentRegistry } from "./component-registry.ts";
-import type * as React from "react";
-
-// ComponentRegistry imports VirtualModuleSystem which spawns esbuild (child process),
-// causing resource leak detection failures. Instead, we test the pure logic helpers
-// by inlining them here.
-
-type SkipEntryResult = { skip: boolean; reason?: string };
+import * as React from "react";
 
 function cacheKeyForDependencies(
   dependencies: Readonly<Record<string, string>>,
@@ -22,248 +16,126 @@ function cacheKeyForDependencies(
   return `on:${hashString(JSON.stringify(sortedEntries))}`;
 }
 
-function createErrorFallbackComponent(
-  componentName: string,
-  error: string,
-): { displayName: string; componentName: string; error: string } {
-  return {
-    displayName: `ErrorFallback(${componentName})`,
-    componentName,
-    error,
-  };
-}
+/** Registry whose single component always fails to load, so it falls back. */
+async function createRegistryWithFailingComponent(
+  errorMessage: string,
+): Promise<{ registry: ComponentRegistry; snapshotKey: string }> {
+  const adapter = createMockAdapter();
+  adapter.fs.files.set(
+    "/project/components/Button.tsx",
+    "export default function Button() { return null; }",
+  );
+  const registry = new ComponentRegistry(
+    { registerModule: () => Promise.resolve() } as unknown as VirtualModuleSystem,
+    3001,
+    adapter,
+    undefined,
+    undefined,
+    "project-id",
+    "branch:main",
+    () => Promise.reject(new Error(errorMessage)),
+  );
 
-function extractComponentName(fileName: string): string {
-  return fileName.replace(/\.(tsx|jsx|ts|js)$/, "");
-}
-
-function shouldSkipEntry(
-  entryName: string,
-  isDirectory: boolean,
-  parentDir: string,
-): SkipEntryResult {
-  if (entryName === "node_modules") return { skip: true, reason: "node_modules" };
-
-  if (entryName.startsWith(".") && entryName !== ".veryfront") {
-    return { skip: true, reason: "hidden directory" };
-  }
-
-  if (!isDirectory) return { skip: false };
-
-  const vfSystemDirs = new Set([
-    "cache",
-    "compiled",
-    "tmp",
-    "temp",
-    "output",
-    "optimized-images",
-    "css",
-  ]);
-
-  if (parentDir.includes(".veryfront") && vfSystemDirs.has(entryName)) {
-    return { skip: true, reason: ".veryfront system dir" };
-  }
-
-  return { skip: false };
-}
-
-function isComponentFile(fileName: string): boolean {
-  return /\.(tsx|jsx|ts|js)$/.test(fileName);
-}
-
-function isIndexFile(fileName: string): boolean {
-  return extractComponentName(fileName) === "index";
-}
-
-function resolveProjectRoot(dir: string): string {
-  if (!dir.endsWith("/components") && !dir.endsWith("\\components")) return dir;
-  return dir.replace(/[/\\]components$/, "");
+  await registry.loadFromDirectory("/project/components", true);
+  const snapshotKey = await registry.prepareDependencySnapshot("off");
+  return { registry, snapshotKey };
 }
 
 describe("ComponentRegistry logic", () => {
-  describe("createErrorFallbackComponent", () => {
-    it("should create a fallback with component name and error", () => {
-      const fallback = createErrorFallbackComponent("Button", "Module not found");
-      assertEquals(fallback.displayName, "ErrorFallback(Button)");
-      assertEquals(fallback.componentName, "Button");
-      assertEquals(fallback.error, "Module not found");
-    });
+  describe("component discovery", () => {
+    it("registers only component files and resolves the project root", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/project/components/index.tsx",
+        "export default function Index() { return null; }",
+      );
+      adapter.fs.files.set(
+        "/project/components/Button.tsx",
+        "export default function Button() { return null; }",
+      );
+      adapter.fs.files.set("/project/components/style.css", ".button {}");
+      adapter.fs.files.set(
+        "/project/components/node_modules/Evil.tsx",
+        "export default function Evil() { return null; }",
+      );
 
-    it("should handle special characters in component names", () => {
-      const fallback = createErrorFallbackComponent("My.Component", "Error");
-      assertEquals(fallback.displayName, "ErrorFallback(My.Component)");
-    });
-  });
+      let seenProjectRoot: string | undefined;
+      const registry = new ComponentRegistry(
+        { registerModule: () => Promise.resolve() } as unknown as VirtualModuleSystem,
+        3001,
+        adapter,
+        undefined,
+        undefined,
+        "project-id",
+        "branch:main",
+        (_source, _filePath, projectRoot) => {
+          seenProjectRoot = projectRoot;
+          const Component: React.ComponentType<Record<string, unknown>> = () => null;
+          return Promise.resolve(Component);
+        },
+      );
 
-  describe("extractComponentName", () => {
-    it("should strip .tsx extension", () => {
-      assertEquals(extractComponentName("Button.tsx"), "Button");
-    });
+      await registry.loadFromDirectory("/project/components", true);
+      const snapshotKey = await registry.prepareDependencySnapshot("off");
 
-    it("should strip .jsx extension", () => {
-      assertEquals(extractComponentName("Card.jsx"), "Card");
-    });
-
-    it("should strip .ts extension", () => {
-      assertEquals(extractComponentName("utils.ts"), "utils");
-    });
-
-    it("should strip .js extension", () => {
-      assertEquals(extractComponentName("helper.js"), "helper");
-    });
-
-    it("should leave other extensions untouched", () => {
-      assertEquals(extractComponentName("style.css"), "style.css");
-    });
-
-    it("should handle dotted names", () => {
-      assertEquals(extractComponentName("Button.stories.tsx"), "Button.stories");
-    });
-  });
-
-  describe("shouldSkipEntry", () => {
-    it("should skip node_modules", () => {
-      const result = shouldSkipEntry("node_modules", true, "/project/components");
-      assertEquals(result.skip, true);
-      assertEquals(result.reason, "node_modules");
-    });
-
-    it("should skip hidden directories", () => {
-      assertEquals(shouldSkipEntry(".git", true, "/project").skip, true);
-      assertEquals(shouldSkipEntry(".hidden", true, "/project").skip, true);
-    });
-
-    it("should not skip .veryfront", () => {
-      assertEquals(shouldSkipEntry(".veryfront", true, "/project").skip, false);
-    });
-
-    it("should skip .veryfront system subdirs", () => {
-      const systemDirs = [
-        "cache",
-        "compiled",
-        "tmp",
-        "temp",
-        "output",
-        "optimized-images",
-        "css",
-      ];
-
-      for (const dir of systemDirs) {
-        assertEquals(shouldSkipEntry(dir, true, "/project/.veryfront").skip, true);
-      }
-    });
-
-    it("should not skip regular directories inside .veryfront", () => {
-      assertEquals(shouldSkipEntry("components", true, "/project/.veryfront").skip, false);
-    });
-
-    it("should not skip regular files in normal directories", () => {
-      assertEquals(shouldSkipEntry("Button.tsx", false, "/project/components").skip, false);
+      assertEquals(
+        Object.keys(registry.getAllAsComponents(snapshotKey)).sort(),
+        ["Button"],
+        "index.tsx, .css files and node_modules entries must not register as components",
+      );
+      assertEquals(
+        seenProjectRoot,
+        "/project",
+        "a components/ directory must resolve the project root to its parent",
+      );
     });
   });
 
-  describe("isComponentFile", () => {
-    it("should accept .tsx files", () => {
-      assertEquals(isComponentFile("Button.tsx"), true);
-    });
+  describe("component load failures", () => {
+    it("records the failure, serves the fallback and resets on clear", async () => {
+      const { registry, snapshotKey } = await createRegistryWithFailingComponent("boom");
 
-    it("should accept .jsx files", () => {
-      assertEquals(isComponentFile("Card.jsx"), true);
-    });
+      assertEquals(
+        registry.hasFailed("Button"),
+        true,
+        "a component whose source fails to load must be recorded as failed",
+      );
+      assertEquals(
+        registry.getFailedComponents()[0]?.filePath,
+        "/project/components/Button.tsx",
+        "the failure record must carry the source path",
+      );
+      assertEquals(
+        registry.getAllAsComponents(snapshotKey).Button?.displayName,
+        "ErrorFallback(Button)",
+        "a failed component must be replaced by the error fallback",
+      );
 
-    it("should accept .ts files", () => {
-      assertEquals(isComponentFile("utils.ts"), true);
-    });
+      // A second snapshot keeps its own component map, so clear() has to reset the
+      // whole snapshot store rather than just the map of the latest snapshot.
+      const pinnedDependencies = { lodash: "1.0.0" };
+      const pinnedSnapshotKey = await registry.prepareDependencySnapshot(
+        cacheKeyForDependencies(pinnedDependencies),
+        pinnedDependencies,
+      );
 
-    it("should accept .js files", () => {
-      assertEquals(isComponentFile("helper.js"), true);
-    });
+      registry.clear();
 
-    it("should reject non-component files", () => {
-      const nonComponentFiles = ["style.css", "readme.md", "data.json", "image.png"];
-      for (const file of nonComponentFiles) {
-        assertEquals(isComponentFile(file), false);
-      }
-    });
-  });
-
-  describe("isIndexFile", () => {
-    it("should detect index.tsx", () => {
-      assertEquals(isIndexFile("index.tsx"), true);
-    });
-
-    it("should detect index.jsx", () => {
-      assertEquals(isIndexFile("index.jsx"), true);
-    });
-
-    it("should detect index.ts", () => {
-      assertEquals(isIndexFile("index.ts"), true);
-    });
-
-    it("should not flag non-index files", () => {
-      assertEquals(isIndexFile("Button.tsx"), false);
-      assertEquals(isIndexFile("indexer.tsx"), false);
-    });
-  });
-
-  describe("resolveProjectRoot", () => {
-    it("should strip /components suffix", () => {
-      assertEquals(resolveProjectRoot("/project/components"), "/project");
-    });
-
-    it("should strip \\components suffix (Windows)", () => {
-      assertEquals(resolveProjectRoot("C:\\project\\components"), "C:\\project");
-    });
-
-    it("should return dir as-is for non-components paths", () => {
-      assertEquals(resolveProjectRoot("/project/pages"), "/project/pages");
-    });
-
-    it("should handle nested components directories", () => {
-      assertEquals(resolveProjectRoot("/project/src/components"), "/project/src");
-    });
-  });
-
-  describe("component registry Map operations (simulated)", () => {
-    it("should store and retrieve components", () => {
-      const components = new Map<string, unknown>();
-      const mockComponent = () => null;
-
-      components.set("Button", mockComponent);
-
-      assertEquals(components.has("Button"), true);
-      assertEquals(components.get("Button"), mockComponent);
-    });
-
-    it("should track failed components separately", () => {
-      const failed = new Map<string, { name: string; error: string; timestamp: number }>();
-
-      failed.set("BrokenComponent", {
-        name: "BrokenComponent",
-        error: "Syntax error",
-        timestamp: Date.now(),
-      });
-
-      assertEquals(failed.has("BrokenComponent"), true);
-      assertEquals(failed.get("BrokenComponent")?.error, "Syntax error");
-    });
-
-    it("should clear all state", () => {
-      const components = new Map<string, unknown>();
-      const sources = new Map<string, unknown>();
-      const failed = new Map<string, unknown>();
-
-      components.set("A", () => null);
-      sources.set("B", { source: "" });
-      failed.set("C", { error: "fail" });
-
-      components.clear();
-      sources.clear();
-      failed.clear();
-
-      assertEquals(components.size, 0);
-      assertEquals(sources.size, 0);
-      assertEquals(failed.size, 0);
+      assertEquals(
+        registry.has("Button", snapshotKey),
+        false,
+        "clear() must drop snapshot-scoped components",
+      );
+      assertEquals(
+        registry.has("Button", pinnedSnapshotKey),
+        false,
+        "clear() must drop every retained dependency snapshot, not just the latest",
+      );
+      assertEquals(
+        registry.getFailedComponents().length,
+        0,
+        "clear() must reset failure tracking",
+      );
     });
   });
 

--- a/src/rendering/utils/react-helpers.test.ts
+++ b/src/rendering/utils/react-helpers.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import * as React from "react";
 import { createDefaultMDXComponents, normalizeChild } from "./react-helpers.ts";
@@ -47,6 +47,15 @@ describe("normalizeChild", () => {
 
     assertEquals(result1, result2);
     assertEquals(result1, child);
+
+    // Mutating the object after the first call proves the cache is consulted:
+    // a recomputing implementation would now see two keys and return the wrapper.
+    (wrapped as Record<string, unknown>).other = "added";
+    assertStrictEquals(
+      normalizeChild(wrapped),
+      child,
+      "normalizeChild must serve the memoized unwrap for an object it has already seen instead of re-reading its keys",
+    );
   });
 
   it("handles arrays", () => {

--- a/src/rendering/utils/stream-utils.test.ts
+++ b/src/rendering/utils/stream-utils.test.ts
@@ -24,6 +24,11 @@ describe("streamToString", () => {
 
     const result = await streamToString(stream);
     assertEquals(result, "Hello World");
+    assertEquals(
+      stream.locked,
+      false,
+      "streamToString must release the reader lock after a successful read",
+    );
   });
 
   it("handles empty stream", async () => {
@@ -64,10 +69,21 @@ describe("streamToString", () => {
 
   it("handles null values in stream", async () => {
     const encoder = new TextEncoder();
-    const stream = createStream([encoder.encode("Before"), null, encoder.encode("After")]);
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("Before"));
+        controller.enqueue(undefined as unknown as Uint8Array);
+        controller.enqueue(encoder.encode("After"));
+        controller.close();
+      },
+    });
 
     const result = await streamToString(stream);
-    assertEquals(result, "BeforeAfter");
+    assertEquals(
+      result,
+      "BeforeAfter",
+      "a stream that yields an empty value must be skipped rather than dereferenced",
+    );
   });
 
   it("times out on slow streams", async () => {
@@ -119,6 +135,11 @@ describe("streamToString", () => {
       "timed out after 1ms",
     );
     assertStrictEquals(cancelReason, thrown);
+    assertEquals(
+      stream.locked,
+      false,
+      "streamToString must release the reader lock after a failed read",
+    );
   });
 
   it("cancels with the owned failure when buffered output exceeds its limit", async () => {
@@ -146,6 +167,11 @@ describe("streamToString", () => {
       "limit of 4 bytes",
     );
     assertStrictEquals(cancelReason, thrown);
+    assertEquals(
+      stream.locked,
+      false,
+      "streamToString must release the reader lock after a failed read",
+    );
   });
 
   it("rejects invalid timeout and byte limits before locking the stream", async () => {

--- a/src/rendering/utils/timeout-enforcement.test.ts
+++ b/src/rendering/utils/timeout-enforcement.test.ts
@@ -24,6 +24,13 @@ function hang<T>(): Promise<T> {
   return new Promise(() => {});
 }
 
+/** Drains the microtask queue so a promise that never settles can be told apart. */
+async function flushMicrotasks(): Promise<void> {
+  for (let index = 0; index < 25; index += 1) {
+    await Promise.resolve();
+  }
+}
+
 describe("Timeout Enforcement", () => {
   describe("withTimeoutThrow (hard timeout)", () => {
     it("resolves normally when operation completes before timeout", async () => {
@@ -105,6 +112,35 @@ describe("Timeout Enforcement", () => {
       assertEquals(error, reason);
     });
 
+    it("rejects immediately when the caller signal is already aborted", async () => {
+      // Time is never advanced, so the 1000ms deadline cannot fire: only the
+      // already-aborted fast path can settle this call.
+      using _time = new FakeTime();
+      const controller = new AbortController();
+      const reason = new Error("client already disconnected");
+      controller.abort(reason);
+      let observedReason: unknown;
+
+      const pending = withTimeoutThrow(hang(), 1000, "pre-aborted", {
+        signal: controller.signal,
+        onAbort: (abortReason) => {
+          observedReason = abortReason;
+        },
+      });
+
+      const outcome = await Promise.race([
+        pending.then((): unknown => "resolved", (error: unknown) => error),
+        flushMicrotasks().then((): unknown => "still pending"),
+      ]);
+
+      assertEquals(
+        outcome,
+        reason,
+        "a pre-aborted caller signal must reject with the caller's reason, not a TimeoutError",
+      );
+      assertEquals(observedReason, reason, "onAbort must fire for an already-aborted signal");
+    });
+
     it("invokes onTimeout exactly when the local timeout fires", async () => {
       let observedError: TimeoutError | undefined;
 
@@ -141,6 +177,35 @@ describe("Timeout Enforcement", () => {
   });
 
   describe("withProgressTimeoutThrow (bounded idle timeout)", () => {
+    it("rejects an invalid timeout pair before the operation runs", async () => {
+      let started = false;
+      const operation = (): Promise<string> => {
+        started = true;
+        return Promise.resolve("unexpected");
+      };
+
+      for (
+        const options of [
+          { label: "zero idle deadline", idleTimeoutMs: 0 },
+          { label: "zero hard cap", idleTimeoutMs: 50, hardTimeoutMs: 0 },
+          { label: "inverted deadlines", idleTimeoutMs: 50, hardTimeoutMs: 20 },
+        ]
+      ) {
+        await assertRejects(
+          () => withProgressTimeoutThrow(operation, options),
+          RangeError,
+          "hardTimeoutMs >= idleTimeoutMs",
+          "an invalid timeout pair must be rejected before the operation runs",
+        );
+      }
+
+      assertEquals(
+        started,
+        false,
+        "the operation must never start when the timeout options are invalid",
+      );
+    });
+
     it("allows total work beyond the idle deadline while progress continues", async () => {
       using time = new FakeTime();
       let markStarted!: () => void;

--- a/tests/integration/renderer/component-registry-error-fallback.test.ts
+++ b/tests/integration/renderer/component-registry-error-fallback.test.ts
@@ -1,0 +1,74 @@
+/**
+ * The ComponentRegistry error fallback reads NODE_ENV at render time, so this
+ * case mutates the process environment and lives here rather than beside the
+ * unit tests, which have to stay hermetic.
+ */
+
+import "../../_helpers/contract-init.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert";
+import { describe, it } from "#veryfront/testing/bdd";
+import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
+import { withEnv } from "#veryfront/testing/deno-compat.ts";
+import { renderToString } from "react-dom/server";
+import { ComponentRegistry } from "#veryfront/rendering/ssr/component-registry.ts";
+import type { VirtualModuleSystem } from "#veryfront/rendering/virtual-module-system.ts";
+import * as React from "react";
+
+/** Registry whose single component always fails to load, so it falls back. */
+async function createRegistryWithFailingComponent(
+  errorMessage: string,
+): Promise<{ registry: ComponentRegistry; snapshotKey: string }> {
+  const adapter = createMockAdapter();
+  adapter.fs.files.set(
+    "/project/components/Button.tsx",
+    "export default function Button() { return null; }",
+  );
+  const registry = new ComponentRegistry(
+    { registerModule: () => Promise.resolve() } as unknown as VirtualModuleSystem,
+    3001,
+    adapter,
+    undefined,
+    undefined,
+    "project-id",
+    "branch:main",
+    () => Promise.reject(new Error(errorMessage)),
+  );
+
+  await registry.loadFromDirectory("/project/components", true);
+  const snapshotKey = await registry.prepareDependencySnapshot("off");
+  return { registry, snapshotKey };
+}
+
+describe("ComponentRegistry error fallback", () => {
+  it("reveals the loader error in the fallback only in development", async () => {
+    const { registry, snapshotKey } = await createRegistryWithFailingComponent(
+      "Module not found",
+    );
+    const Fallback = registry.getAllAsComponents(snapshotKey).Button;
+    assertEquals(typeof Fallback, "function", "the fallback must be a renderable component");
+
+    await withEnv({ NODE_ENV: "production" }, () => {
+      assertEquals(
+        renderToString(React.createElement(Fallback!)),
+        "",
+        "the fallback must render nothing outside development so loader errors never reach end users",
+      );
+      return Promise.resolve();
+    });
+
+    await withEnv({ NODE_ENV: "development" }, () => {
+      const html = renderToString(React.createElement(Fallback!));
+      assertStringIncludes(
+        html,
+        "Button",
+        "the development fallback must name the failing component",
+      );
+      assertStringIncludes(
+        html,
+        "Module not found",
+        "the development fallback must surface the loader error",
+      );
+      return Promise.resolve();
+    });
+  });
+});

--- a/tests/integration/renderer/component-registry-error-fallback.test.ts
+++ b/tests/integration/renderer/component-registry-error-fallback.test.ts
@@ -5,8 +5,8 @@
  */
 
 import "../../_helpers/contract-init.ts";
-import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert";
-import { describe, it } from "#veryfront/testing/bdd";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { withEnv } from "#veryfront/testing/deno-compat.ts";
 import { renderToString } from "react-dom/server";


### PR DESCRIPTION
## Summary

Audit of all 22 test files under `src/rendering/layouts`, `element-validator`, `chunk-optimizer`, `shared`, `ssr`, `ssr-globals` and `utils`.

Every change was **mutation checked** — the named source edit was applied, the test confirmed to fail, then reverted. 67 candidate findings, 55 confirmed after adversarial verification, 12 refuted.

## The dominant finding: test files that reimplement their own subject

`component-registry.test.ts` defined **seven local functions** — `shouldSkipEntry`, `isComponentFile`, `isIndexFile`, `resolveProjectRoot`, `extractComponentName`, `cacheKeyForDependencies`, `createErrorFallbackComponent` — and imported only `ComponentRegistry` from the module under test.

Most of its 35 cases exercised code **the test file itself wrote**. `component-registry.ts` could have been deleted outright and they would all still pass. Names like `should accept .jsx files` and `should not skip .veryfront` were asserting against a private copy, not the shipped implementation.

Same shape in `layout-collector.test.ts`, which defined its own `getLayoutKind` and `createLayoutItem` — neither of which the module exports at all.

> **Read the test count honestly:** that file goes from 35 cases to 7. Those 7 drive the real `ComponentRegistry` (43 call sites) and cover the same behaviors *through it* — file filtering, project-root resolution, the error fallback, clear. The reduction is in fake coverage, not real coverage. The one local helper kept is `cacheKeyForDependencies`, retained deliberately as an **independent expected-value oracle** rather than as a stand-in for the code under test.

## Source changes

**`element-validator/primitive-checks.ts`** read React's element marker as `$typeof` (single dollar) in `getElementDebugInfo` and its interface, so `hasSymbol` was permanently `false` and `symbolValue` permanently `undefined`. The same file already uses `$$typeof` correctly at three other sites. That export had **no tests at all**, which is why a one-character typo survived.

**`layouts/layout-applicator.ts`** now passes the loader through to `tryLoadReservedInDirs`. Worth being precise about why this is not a testability hack: `LoadReservedDeps` already existed on that function, and `LayoutApplicator` already accepts `dependencies.loadComponentFromSource` in its constructor — but the reserved-components path ignored it and always resolved the default by dynamic import, so **an injected loader was silently dropped there**. The import is runtime-cached and already resolved twice on the same path, so the cost is nil.

## Test changes

- **Hash tests asserted shape** (`typeof`, `length`) rather than value. They now compare against an independently computed hash plus a differs-when-input-differs companion, so hashing the *path* instead of the *contents* fails.
- **Identity was asserted by `React.isValidElement`**, which holds for a clone. Now `assertStrictEquals`, so a clone-and-rekey fails.
- **Defaults were unpinned:** the validator's default `maxDepth` of 15 and its lenient normalization default are now asserted.
- **A mistitled test was renamed** to the precedence it actually pins, and the case that reaches the `displayName` fallback was added.
- **Opt-out handling asserted an inline predicate** rather than the collector; both spellings now run through `LayoutCollector`.

Skipped-test baseline drops to **15** as three skips inside the removed local-copy describes go with them.

## Verification

- Semantic unit-boundary audit: ok, sanitizer ratchet: ok, skipped-tests: 15/15
- `test:layout`: ok, `docs:api-reference:check`: current
- `deno fmt`, `deno lint`: pass
- **22/22** changed test files pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved React element validation, including clearer error paths, depth handling, and correct element identification.
  - Strengthened layout loading, discovery, compilation, and fallback behavior across supported layout formats.
  - Improved cache handling for nonce-protected content, cache-key overrides, and returned data isolation.
  - Improved SSR component fallback behavior and stream resource cleanup.

- **Tests**
  - Added extensive coverage for rendering, layouts, caching, SSR, timeout handling, and DOM stubs.

- **Chores**
  - Tightened the allowed skipped-test threshold from 18 to 15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->