### PR TITLE
test(rendering/orchestrator): make weak assertions bite and fix a no-op ESM rewriter

### DIFF
--- a/scripts/lint/test-typecheck-baseline.json
+++ b/scripts/lint/test-typecheck-baseline.json
@@ -35,7 +35,5 @@
   "src/rendering/layouts/utils/compiler.test.ts",
   "src/rendering/layouts/utils/discovery.test.ts",
   "src/rendering/layouts/utils/hash-calculator.test.ts",
-  "src/rendering/orchestrator/compiler-service.test.ts",
-  "src/rendering/orchestrator/config.test.ts",
   "src/rendering/utils/react-helpers.test.ts"
 ]

--- a/src/rendering/context/render-context.test.ts
+++ b/src/rendering/context/render-context.test.ts
@@ -178,6 +178,51 @@ describe("rendering/context/render-context", () => {
       assertEquals(localDev.cachePrefix === hostedPreview.cachePrefix, false);
     });
 
+    it("does not grant host project-code execution to a hosted render that never asked for it", () => {
+      const hostedShared = {
+        projectId: "proj_123",
+        projectSlug: "test-project",
+        releaseId: "rel_456",
+        requestContext: {
+          mode: "production" as const,
+          slug: "test-project",
+          branch: null,
+          token: "",
+        },
+      };
+
+      const hostedDefault = createRenderContext(
+        createHandlerContext({ ...hostedShared, isLocalProject: false }),
+      );
+      assertEquals(
+        hostedDefault.allowHostProjectCodeExecution,
+        false,
+        "hosted render must not inherit host project-code execution",
+      );
+
+      const hostedOptIn = createRenderContext(
+        createHandlerContext({
+          ...hostedShared,
+          isLocalProject: false,
+          allowHostProjectCodeExecution: true,
+        }),
+      );
+      assertEquals(
+        hostedOptIn.allowHostProjectCodeExecution,
+        true,
+        "an explicit host opt-in must be carried through",
+      );
+
+      const localDefault = createRenderContext(
+        createHandlerContext({ ...hostedShared, isLocalProject: true }),
+      );
+      assertEquals(
+        localDefault.allowHostProjectCodeExecution,
+        true,
+        "a local project always runs its own code",
+      );
+    });
+
     it("throws without projectSlug or projectId", () => {
       const handlerCtx: HandlerContext = createHandlerContext({
         projectId: undefined,
@@ -437,6 +482,28 @@ describe("rendering/context/render-context", () => {
       assertEquals(ctx.proxyToken, "tok-123");
       assertEquals(ctx.nonce, "abc");
       assertEquals(ctx.allowHostProjectCodeExecution, true);
+      assertEquals(
+        ctx.cachePrefix,
+        "prefix",
+        "cachePrefix is carried from the enriched context, not derived from projectId",
+      );
+      assertEquals(ctx.mode, "production", "mode is carried from the enriched context");
+    });
+
+    it("carries a development mode and its own cache prefix from the enriched context", () => {
+      const ctx = createRenderContextFromEnriched(
+        makeEnrichedContext({
+          mode: "development",
+          cachePrefix: "proj_123:preview:main",
+        }),
+      );
+
+      assertEquals(ctx.mode, "development", "mode is carried from the enriched context");
+      assertEquals(
+        ctx.cachePrefix,
+        "proj_123:preview:main",
+        "cachePrefix is carried from the enriched context, not derived from projectId",
+      );
     });
 
     it("should not infer host execution from a non-local enriched context", () => {

--- a/src/rendering/orchestrator/compiler-service.test.ts
+++ b/src/rendering/orchestrator/compiler-service.test.ts
@@ -26,9 +26,16 @@ describe("rendering/orchestrator/compiler-service", () => {
   describe("compileMDX before setCompileMDX", () => {
     it("should throw when compile function not set", () => {
       const service = new CompilerService();
-      assertThrows(
+      const error = assertThrows(
         () => service.compileMDX("# Hello"),
         Error,
+        "CompilerService: compileMDX not initialized",
+        "an uninitialized compiler reports the render-classified error",
+      );
+      assertEquals(
+        error.name,
+        "VeryfrontError[render]",
+        "the failure stays render-classified for the request handler",
       );
     });
   });
@@ -86,7 +93,17 @@ describe("rendering/orchestrator/compiler-service", () => {
     it("should throw when called without setCompileMDX", () => {
       const service = new CompilerService();
       const fn = service.getCompileFunction();
-      assertThrows(() => fn("test"), Error);
+      const error = assertThrows(
+        () => fn("test"),
+        Error,
+        "CompilerService: compileMDX not initialized",
+        "the bound function reports the same render-classified error",
+      );
+      assertEquals(
+        error.name,
+        "VeryfrontError[render]",
+        "the failure stays render-classified for the request handler",
+      );
     });
 
     it("should work after setCompileMDX", async () => {

--- a/src/rendering/orchestrator/compiler-service.test.ts
+++ b/src/rendering/orchestrator/compiler-service.test.ts
@@ -10,8 +10,6 @@ function createMockBundle(code: string): MdxBundle {
     compiledCode: code,
     frontmatter: {},
     globals: {},
-    headings: [],
-    nodeMap: new Map(),
   };
 }
 
@@ -32,6 +30,7 @@ describe("rendering/orchestrator/compiler-service", () => {
         "CompilerService: compileMDX not initialized",
         "an uninitialized compiler reports the render-classified error",
       );
+      if (!(error instanceof Error)) throw new Error("Expected compileMDX to throw an Error");
       assertEquals(
         error.name,
         "VeryfrontError[render]",
@@ -99,6 +98,7 @@ describe("rendering/orchestrator/compiler-service", () => {
         "CompilerService: compileMDX not initialized",
         "the bound function reports the same render-classified error",
       );
+      if (!(error instanceof Error)) throw new Error("Expected compileMDX to throw an Error");
       assertEquals(
         error.name,
         "VeryfrontError[render]",

--- a/src/rendering/orchestrator/config.test.ts
+++ b/src/rendering/orchestrator/config.test.ts
@@ -120,18 +120,118 @@ describe("rendering/orchestrator/config", () => {
       assertEquals(cm.getCacheBaseDir(), "/project/my-cache");
     });
 
-    it("should cache the result and return same value on repeated calls", () => {
-      const adapter = createMockAdapter();
-      const config = createMockConfig({});
+    it("should return an absolute VERYFRONT_CACHE_DIR verbatim", () => {
+      const adapter = createMockAdapter({ VERYFRONT_CACHE_DIR: "/var/cache/veryfront" });
       const cm = new ConfigurationManager({
         projectDir: "/project",
         mode: "production",
         adapter,
       });
-      setConfig(cm, config);
-      const r1 = cm.getCacheBaseDir();
-      const r2 = cm.getCacheBaseDir();
-      assertEquals(r1, r2);
+      setConfig(cm, createMockConfig({}));
+      assertEquals(
+        cm.getCacheBaseDir(),
+        "/var/cache/veryfront",
+        "an absolute cache dir must not be rebased under the project",
+      );
+    });
+
+    it("should fall back to VF_CACHE_DIR", () => {
+      const adapter = createMockAdapter({ VF_CACHE_DIR: "/fallback-cache" });
+      const cm = new ConfigurationManager({
+        projectDir: "/project",
+        mode: "production",
+        adapter,
+      });
+      setConfig(cm, createMockConfig({}));
+      assertEquals(
+        cm.getCacheBaseDir(),
+        "/fallback-cache",
+        "VF_CACHE_DIR must still be honoured when VERYFRONT_CACHE_DIR is unset",
+      );
+    });
+
+    it("should prefer VERYFRONT_CACHE_DIR over VF_CACHE_DIR", () => {
+      const adapter = createMockAdapter({
+        VERYFRONT_CACHE_DIR: "/primary-cache",
+        VF_CACHE_DIR: "/fallback-cache",
+      });
+      const cm = new ConfigurationManager({
+        projectDir: "/project",
+        mode: "production",
+        adapter,
+      });
+      setConfig(cm, createMockConfig({}));
+      assertEquals(
+        cm.getCacheBaseDir(),
+        "/primary-cache",
+        "VERYFRONT_CACHE_DIR takes precedence over the legacy VF_CACHE_DIR",
+      );
+    });
+
+    it("should use config.cache.dir when no env var is set", () => {
+      const adapter = createMockAdapter();
+      const cm = new ConfigurationManager({
+        projectDir: "/project",
+        mode: "production",
+        adapter,
+      });
+      setConfig(cm, createMockConfig({ cache: { dir: "cfg-cache" } }));
+      assertEquals(
+        cm.getCacheBaseDir(),
+        "/project/cfg-cache",
+        "a relative config.cache.dir resolves under the project directory",
+      );
+    });
+
+    it("should prefer the env var over config.cache.dir", () => {
+      const adapter = createMockAdapter({ VERYFRONT_CACHE_DIR: "/env-cache" });
+      const cm = new ConfigurationManager({
+        projectDir: "/project",
+        mode: "production",
+        adapter,
+      });
+      setConfig(cm, createMockConfig({ cache: { dir: "cfg-cache" } }));
+      assertEquals(
+        cm.getCacheBaseDir(),
+        "/env-cache",
+        "an operator env override must win over config.cache.dir",
+      );
+    });
+
+    it("should recompute the cache dir when env or config changes, and reuse it otherwise", () => {
+      const envVars: Record<string, string> = {};
+      const adapter = createMockAdapter(envVars);
+      const cm = new ConfigurationManager({
+        projectDir: "/project",
+        mode: "production",
+        adapter,
+      });
+      setConfig(cm, createMockConfig({}));
+
+      assertEquals(
+        cm.getCacheBaseDir(),
+        "/project/.veryfront/cache",
+        "the default cache dir applies before any override",
+      );
+      assertEquals(
+        cm.getCacheBaseDir(),
+        "/project/.veryfront/cache",
+        "a repeated call with unchanged inputs returns the same directory",
+      );
+
+      setConfig(cm, createMockConfig({ cache: { dir: "other-cache" } }));
+      assertEquals(
+        cm.getCacheBaseDir(),
+        "/project/other-cache",
+        "a changed config.cache.dir must invalidate the memo",
+      );
+
+      envVars.VERYFRONT_CACHE_DIR = "/abs/env-cache";
+      assertEquals(
+        cm.getCacheBaseDir(),
+        "/abs/env-cache",
+        "a changed VERYFRONT_CACHE_DIR must win and invalidate the memo",
+      );
     });
   });
 

--- a/src/rendering/orchestrator/config.test.ts
+++ b/src/rendering/orchestrator/config.test.ts
@@ -66,7 +66,7 @@ describe("rendering/orchestrator/config", () => {
   describe("getConfig with preloaded config", () => {
     it("should throw before initialize even with preloaded config", () => {
       const adapter = createMockAdapter();
-      const config = createMockConfig({ name: "test-project" });
+      const config = createMockConfig({ projectSlug: "test-project" });
       const cm = new ConfigurationManager({
         projectDir: "/project",
         mode: "production",

--- a/src/rendering/orchestrator/css-cache.test.ts
+++ b/src/rendering/orchestrator/css-cache.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { waitFor } from "#veryfront/testing/deno-compat.ts";
 import {
   __injectCssCacheForTests,
   __pageCssCacheForTests,
@@ -136,21 +137,38 @@ describe("css-cache", () => {
         context: { projectId: "test", environment: "preview" as const, versionId: "v1" },
       };
 
+      // Seed the process-local LRU first so the sync getter has something stale
+      // to serve if it ever ignores the injected repository.
+      const key = `injected-test-${Date.now()}`;
+      cachePageCss(key, "stale-internal-css");
+      assertEquals(
+        getCachedPageCss(key),
+        "stale-internal-css",
+        "the process-local LRU holds the entry before a repo is injected",
+      );
+
       __injectCssCacheForTests(mockRepo);
 
-      // getCachedPageCss returns undefined when repo is injected (sync fallback)
-      const key = `injected-test-${Date.now()}`;
-      cachePageCss(key, "injected-css");
+      try {
+        cachePageCss(key, "injected-css");
 
-      // Sync getter returns undefined when repo is injected
-      assertEquals(getCachedPageCss(key), undefined);
+        // Sync getter must force a miss while a repo is injected
+        assertEquals(
+          getCachedPageCss(key),
+          undefined,
+          "the sync getter must force a miss while a repo is injected, not serve the process-local LRU",
+        );
 
-      // But the mock repo should have it
-      await new Promise((r) => setTimeout(r, 10)); // Wait for fire-and-forget
-      assertEquals(injectedCache.get(key), "injected-css");
-
-      // Restore
-      __injectCssCacheForTests(null);
+        // But the mock repo should have it
+        await waitFor(() => injectedCache.get(key) === "injected-css", {
+          message: "fire-and-forget write reaches the injected repo",
+        });
+        assertEquals(injectedCache.get(key), "injected-css");
+      } finally {
+        // Restore
+        __injectCssCacheForTests(null);
+        __pageCssCacheForTests.delete(key);
+      }
     });
   });
 });

--- a/src/rendering/orchestrator/css-candidate-manifest.test.ts
+++ b/src/rendering/orchestrator/css-candidate-manifest.test.ts
@@ -1,7 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { createStyleScopeProfile } from "#veryfront/html/styles-builder/style-scope-profile.ts";
+import { FakeTime } from "#std/testing/time";
+import {
+  createStyleScopeProfile,
+  type StyleScopeProfile,
+} from "#veryfront/html/styles-builder/style-scope-profile.ts";
 import {
   __registerLogRecordEmitter,
   __resetLogRecordEmitterForTests,
@@ -32,9 +36,48 @@ describe("rendering/orchestrator/css-candidate-manifest", () => {
       // Should not throw
     });
 
-    it("should clear cache for specific scope", () => {
-      invalidateProjectCandidateManifests("my-project");
-      // Should not throw
+    it("clears only the named scope's manifests", () => {
+      invalidateProjectCandidateManifests();
+
+      const optionsFor = (projectScope: string, content: string) => ({
+        projectScope,
+        projectVersion: "v1",
+        projectDir: "/project",
+        files: [{ path: "/project/pages/index.tsx", content }],
+        developmentMode: false,
+      });
+
+      getProjectCandidates(optionsFor("scope-a", '<div className="text-red-500">Home</div>'));
+      getProjectCandidates(optionsFor("scope-b", '<div className="text-red-500">Home</div>'));
+
+      const before = getCandidateManifestCacheStats().manifests.entries;
+      assertEquals(before, 2, "each scope must hold its own manifest");
+
+      invalidateProjectCandidateManifests("scope-a");
+
+      assertEquals(
+        getCandidateManifestCacheStats().manifests.entries,
+        before - 1,
+        "scoped invalidation must drop exactly the named scope's manifest",
+      );
+
+      const rebuilt = getProjectCandidates(
+        optionsFor("scope-a", '<div className="text-green-500">Home</div>'),
+      );
+      assertEquals(
+        rebuilt.has("text-green-500"),
+        true,
+        "the invalidated scope must rescan its sources",
+      );
+
+      const untouched = getProjectCandidates(
+        optionsFor("scope-b", '<div className="text-green-500">Home</div>'),
+      );
+      assertEquals(
+        untouched.has("text-green-500"),
+        false,
+        "an unrelated scope's manifest must survive",
+      );
     });
 
     it("should be idempotent", () => {
@@ -111,37 +154,68 @@ describe("rendering/orchestrator/css-candidate-manifest", () => {
 
     it("should use cached manifest for same projectScope and version", () => {
       invalidateProjectCandidateManifests();
-      const opts = {
+      const optionsFor = (content: string) => ({
         projectScope: "test-cache",
         projectVersion: "v2",
         projectDir: "/project",
         routeKey: "about",
         routeFilePaths: ["/project/about.tsx"],
-        files: [
-          {
-            path: "/project/about.tsx",
-            content: '<p className="font-bold">About</p>',
-          },
-        ],
+        files: [{ path: "/project/about.tsx", content }],
         developmentMode: false,
-      };
-      const r1 = getRouteCandidates(opts);
-      const r2 = getRouteCandidates(opts);
-      assertEquals(r1.size, r2.size);
+      });
+
+      const first = getRouteCandidates(optionsFor('<p className="font-bold">About</p>'));
+      const second = getRouteCandidates(optionsFor('<p className="italic">About</p>'));
+
+      assertEquals(first.has("font-bold"), true, "the first build scans the route sources");
+      assertEquals(
+        second.has("font-bold"),
+        true,
+        "the cached manifest is reused for the same scope and version",
+      );
+      assertEquals(
+        second.has("italic"),
+        false,
+        "a production cache hit must not rescan the sources",
+      );
     });
 
     it("should rebuild manifest in development mode after TTL", () => {
-      invalidateProjectCandidateManifests();
-      const result = getRouteCandidates({
-        projectScope: "test-dev",
-        projectVersion: "v1",
-        projectDir: "/project",
-        routeKey: "index",
-        routeFilePaths: [],
-        files: [],
-        developmentMode: true,
-      });
-      assertEquals(result.size, 0);
+      const time = new FakeTime();
+      try {
+        invalidateProjectCandidateManifests();
+        const optionsFor = (content: string) => ({
+          projectScope: "test-dev",
+          projectVersion: "v1",
+          projectDir: "/project",
+          files: [{ path: "/project/pages/index.tsx", content }],
+          developmentMode: true,
+        });
+
+        getProjectCandidates(optionsFor('<div className="text-red-500">Home</div>'));
+
+        time.tick(500);
+        const withinTtl = getProjectCandidates(
+          optionsFor('<div className="text-blue-500">Home</div>'),
+        );
+        assertEquals(
+          withinTtl.has("text-blue-500"),
+          false,
+          "the development manifest must be reused inside the TTL window",
+        );
+
+        time.tick(2_001);
+        const afterTtl = getProjectCandidates(
+          optionsFor('<div className="text-blue-500">Home</div>'),
+        );
+        assertEquals(
+          afterTtl.has("text-blue-500"),
+          true,
+          "a development manifest must rebuild after the TTL",
+        );
+      } finally {
+        time.restore();
+      }
     });
 
     it("bounds cached route candidate sets for high-cardinality production routes", () => {
@@ -219,6 +293,62 @@ describe("rendering/orchestrator/css-candidate-manifest", () => {
       assertEquals(result.has("text-red-500"), true);
       assertEquals(result.has("rounded-lg"), true);
       assertEquals(result.has("shadow-sm"), true);
+    });
+
+    it("rebuilds the manifest when projectVersion changes", () => {
+      invalidateProjectCandidateManifests();
+      const optionsFor = (projectVersion: string, content: string) => ({
+        projectScope: "scope-version-key",
+        projectVersion,
+        projectDir: "/project",
+        files: [{ path: "/project/pages/index.tsx", content }],
+        developmentMode: false,
+      });
+
+      getProjectCandidates(optionsFor("v1", '<div className="text-red-500">Home</div>'));
+      const v2 = getProjectCandidates(
+        optionsFor("v2", '<div className="text-emerald-500">Home</div>'),
+      );
+
+      assertEquals(v2.has("text-emerald-500"), true, "a version bump must rescan the sources");
+      assertEquals(
+        v2.has("text-red-500"),
+        false,
+        "the previous version's candidates must not leak into a redeploy",
+      );
+    });
+
+    it("rebuilds the manifest when the style scope profile changes", () => {
+      invalidateProjectCandidateManifests();
+      const optionsFor = (styleProfile: StyleScopeProfile) => ({
+        projectScope: "scope-style-profile-key",
+        projectVersion: "v1",
+        projectDir: "/project",
+        styleProfile,
+        files: [
+          {
+            path: "/project/knowledge/app/page.tsx",
+            content: '<div className="text-fuchsia-500">Home</div>',
+          },
+        ],
+        developmentMode: false,
+      });
+
+      const defaultScope = getProjectCandidates(optionsFor(createStyleScopeProfile()));
+      assertEquals(
+        defaultScope.has("text-fuchsia-500"),
+        false,
+        "the default profile ignores the knowledge root",
+      );
+
+      const appScope = getProjectCandidates(
+        optionsFor(createStyleScopeProfile({ directories: { app: "knowledge/app" } })),
+      );
+      assertEquals(
+        appScope.has("text-fuchsia-500"),
+        true,
+        "a profile that protects the configured app root must rebuild its own manifest",
+      );
     });
 
     it("applies the default style scope conventions when building manifests", () => {

--- a/src/rendering/orchestrator/html-project-css.test.ts
+++ b/src/rendering/orchestrator/html-project-css.test.ts
@@ -1,10 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { waitFor } from "#veryfront/testing/deno-compat.ts";
 import {
   buildRouteManifestKey,
   extractProjectClassesForRoute,
   getProjectContentVersion,
+  startPreparedCSSWarmup,
   startProjectCSSPreparation,
 } from "./html-project-css.ts";
 
@@ -88,6 +90,205 @@ describe("rendering/orchestrator/html-project-css", () => {
 
       assertEquals(result, undefined);
       assertEquals(called, false);
+    });
+
+    it("generates project CSS for published production pages", async () => {
+      const calls: unknown[][] = [];
+
+      const result = startProjectCSSPreparation(
+        {
+          slug: "docs",
+        } as any,
+        {
+          environment: "production",
+          isLocalProject: false,
+          projectSlug: "demo",
+          projectId: "proj_1",
+          globalCSS: "body{}",
+          projectClasses: new Set(["prose"]),
+          mode: "production",
+        } as any,
+        {
+          getProjectCSS: ((...args: unknown[]) => {
+            calls.push(args);
+            return Promise.resolve({ hash: "abc123" });
+          }) as any,
+        },
+      );
+
+      assertNotEquals(
+        result,
+        undefined,
+        "a published production page must start project CSS generation",
+      );
+      assertEquals(
+        await result,
+        { hash: "abc123" } as any,
+        "the generated project CSS is handed back to the caller",
+      );
+      assertEquals(calls.length, 1, "project CSS is generated exactly once per render");
+      assertEquals(
+        calls[0]?.[0],
+        "demo",
+        "projectSlug wins over projectId and context.slug",
+      );
+      assertEquals(calls[0]?.[1], "body{}", "the project global CSS is forwarded verbatim");
+      assertEquals(
+        [...(calls[0]?.[2] as Set<string>)],
+        ["prose"],
+        "the collected project classes are forwarded",
+      );
+      assertEquals(
+        calls[0]?.[3],
+        { minify: true, environment: "production", buildMode: "production" },
+        "published CSS is minified and built for the request environment",
+      );
+    });
+
+    it("skips generation when the project scope is the shared default", () => {
+      let called = false;
+
+      const result = startProjectCSSPreparation(
+        {
+          slug: "docs",
+        } as any,
+        {
+          environment: "production",
+          isLocalProject: false,
+          projectSlug: "default",
+          globalCSS: "body{}",
+          mode: "production",
+        } as any,
+        {
+          getProjectCSS: (() => {
+            called = true;
+            return Promise.resolve({ hash: "abc123" });
+          }) as any,
+        },
+      );
+
+      assertEquals(result, undefined, "the shared default scope must not be generated for");
+      assertEquals(called, false, "no CSS build runs for the shared default scope");
+    });
+  });
+
+  describe("startPreparedCSSWarmup", () => {
+    function makeConfig(mode: "development" | "production") {
+      return {
+        projectDir: "/project",
+        adapter: {
+          fs: {
+            getUnderlyingAdapter: () => ({
+              getAllSourceFiles: () => [
+                {
+                  path: "/project/app/page.tsx",
+                  content: `<div className="text-red-500" />`,
+                },
+              ],
+            }),
+          },
+        } as any,
+        config: {} as any,
+        mode,
+      };
+    }
+
+    it("warms the preview stylesheet for a preview render", async () => {
+      const calls: Array<Record<string, unknown>> = [];
+
+      startPreparedCSSWarmup(
+        makeConfig("production"),
+        { slug: "docs" } as any,
+        { environment: "preview", projectSlug: "p" } as any,
+        {
+          warmPreparedCSSArtifactFromFiles: ((input: Record<string, unknown>) => {
+            calls.push(input);
+            return Promise.resolve(undefined);
+          }) as any,
+          getProjectContentVersion: () => "content-v1",
+          createStyleScopeProfile: (() => ({ mode: "test" })) as any,
+        },
+      );
+
+      await waitFor(() => calls.length === 1, {
+        interval: 5,
+        message: "a preview render must warm the prepared CSS artifact",
+      });
+      assertEquals(calls[0]?.projectSlug, "p", "the warmup is scoped to the project slug");
+      assertEquals(
+        calls[0]?.projectVersion,
+        "content-v1",
+        "the warmup keys on the resolved project content version",
+      );
+      assertEquals(calls[0]?.environment, "preview", "the warmed artifact is the preview one");
+      assertEquals(calls[0]?.buildMode, "production", "preview artifacts are built for production");
+    });
+
+    it("does not warm the preview stylesheet for a published production render", async () => {
+      const calls: Array<Record<string, unknown>> = [];
+      const deps = {
+        warmPreparedCSSArtifactFromFiles: ((input: Record<string, unknown>) => {
+          calls.push(input);
+          return Promise.resolve(undefined);
+        }) as any,
+        getProjectContentVersion: () => "content-v1",
+        createStyleScopeProfile: (() => ({ mode: "test" })) as any,
+      };
+
+      startPreparedCSSWarmup(
+        makeConfig("production"),
+        { slug: "docs" } as any,
+        { environment: "production", isLocalProject: false, projectSlug: "p" } as any,
+        deps,
+      );
+
+      // A preview warmup started afterwards is the time barrier: once it has
+      // landed, any warmup the published render would have started has had
+      // its chance to land too.
+      startPreparedCSSWarmup(
+        makeConfig("production"),
+        { slug: "docs" } as any,
+        { environment: "preview", projectSlug: "control" } as any,
+        deps,
+      );
+
+      await waitFor(() => calls.some((call) => call.projectSlug === "control"), {
+        interval: 5,
+        message: "the control preview warmup must land",
+      });
+      assertEquals(
+        calls.filter((call) => call.projectSlug === "p").length,
+        0,
+        "a published production render must not warm the preview stylesheet",
+      );
+    });
+
+    it("falls back to the dev version marker when no content version is known", async () => {
+      const calls: Array<Record<string, unknown>> = [];
+
+      startPreparedCSSWarmup(
+        makeConfig("development"),
+        { slug: "docs" } as any,
+        { environment: "preview", projectSlug: "p" } as any,
+        {
+          warmPreparedCSSArtifactFromFiles: ((input: Record<string, unknown>) => {
+            calls.push(input);
+            return Promise.resolve(undefined);
+          }) as any,
+          getProjectContentVersion: () => undefined,
+          createStyleScopeProfile: (() => ({ mode: "test" })) as any,
+        },
+      );
+
+      await waitFor(() => calls.length === 1, {
+        interval: 5,
+        message: "a preview render must warm the prepared CSS artifact",
+      });
+      assertEquals(
+        calls[0]?.projectVersion,
+        "dev",
+        "an unknown content version must never key the artifact cache as undefined",
+      );
     });
   });
 

--- a/src/rendering/orchestrator/html.test.ts
+++ b/src/rendering/orchestrator/html.test.ts
@@ -795,6 +795,115 @@ describe("HTMLGenerator helpers", () => {
       assertEquals(html.includes(`localStorage.setItem('theme','dark')`), true);
     });
 
+    it("keeps a quoted > inside the html opening tag out of the theme injection", async () => {
+      const mockAdapter = createMockAdapter(async () => `'use client';`);
+
+      const generator = createHTMLGenerator({
+        readFile: mockAdapter.fs.readFile,
+      });
+
+      const html = await generator.generateFullHTML(createHTMLContext({
+        html:
+          '<!DOCTYPE html><html lang="en" data-x="a>b"><head><title>Layout Title</title></head><body><main>Hello</main></body></html>',
+        options: {
+          colorScheme: "dark",
+          colorSchemeFromParam: true,
+        },
+      }));
+
+      assertStringIncludes(
+        html,
+        'data-x="a>b"',
+        "a quoted > must not truncate the html opening tag",
+      );
+      assertEquals(
+        (html.match(/data-theme="dark"/g) ?? []).length,
+        1,
+        "theme is injected exactly once",
+      );
+      assertEquals(
+        html.includes('data-x="a data-theme'),
+        false,
+        "attributes must not be spliced mid-value",
+      );
+    });
+
+    it("replaces a layout's own data-theme and color-scheme declarations", async () => {
+      const mockAdapter = createMockAdapter(async () => `'use client';`);
+
+      const generator = createHTMLGenerator({
+        readFile: mockAdapter.fs.readFile,
+      });
+
+      const html = await generator.generateFullHTML(createHTMLContext({
+        html:
+          '<!DOCTYPE html><html lang="en" data-theme="light" style="color-scheme: light"><head><title>Layout Title</title></head><body><main>Hello</main></body></html>',
+        options: {
+          colorScheme: "dark",
+          colorSchemeFromParam: true,
+        },
+      }));
+
+      assertEquals(
+        (html.match(/data-theme="/g) ?? []).length,
+        1,
+        "the layout's own data-theme must be replaced, not duplicated",
+      );
+      assertStringIncludes(html, 'data-theme="dark"', "the requested theme wins");
+      assertEquals(
+        html.includes('data-theme="light"'),
+        false,
+        "the stale light declaration must not survive",
+      );
+      assertEquals(
+        (html.match(/color-scheme:\s*/g) ?? []).length,
+        1,
+        "the layout's own color-scheme must be replaced, not duplicated",
+      );
+      assertStringIncludes(
+        html,
+        "color-scheme: dark",
+        "the requested color scheme wins",
+      );
+      assertEquals(
+        html.includes("color-scheme: light"),
+        false,
+        "the stale light color scheme must not survive",
+      );
+    });
+
+    it("injects dev scripts only for a development-mode generator", async () => {
+      const devHtml = await createHTMLGenerator({
+        mode: "development",
+        readFile: async () => "",
+      }).generateFullHTML(createHTMLContext());
+      const prodHtml = await createHTMLGenerator({
+        mode: "production",
+        readFile: async () => "",
+      }).generateFullHTML(createHTMLContext());
+
+      assertStringIncludes(
+        devHtml,
+        '<script type="module" src="/_veryfront/hmr.js"></script>',
+        "development shells carry the HMR client",
+      );
+      assertStringIncludes(
+        devHtml,
+        ".dev-indicator",
+        "development shells carry the dev overlay styles",
+      );
+      assertEquals(
+        prodHtml.includes("/_veryfront/hmr.js"),
+        false,
+        "production shells must not carry development instrumentation",
+      );
+      assertEquals(
+        prodHtml.includes(".dev-indicator"),
+        false,
+        "production shells must not carry development overlay styles",
+      );
+    });
+
     it("escapes nonce values before injecting theme persistence scripts", async () => {
       const mockAdapter = createMockAdapter(async () => `'use client';`);
 

--- a/src/rendering/orchestrator/layout.test.ts
+++ b/src/rendering/orchestrator/layout.test.ts
@@ -1,9 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import * as React from "react";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { LayoutOrchestrator } from "./layout.ts";
 import { createLayoutComponentCache } from "#veryfront/rendering/layouts/utils/component-loader.ts";
+import type { LayoutComponentCache } from "#veryfront/rendering/layouts/utils/component-loader.ts";
 import type { LayoutCollector, LayoutCompiler } from "#veryfront/rendering/layouts/index.ts";
 import { mdxRenderer } from "#veryfront/transforms/mdx/index.ts";
 import { validateVeryfrontConfig } from "#veryfront/config";
@@ -12,8 +14,60 @@ import {
   getCachedImportMap,
 } from "#veryfront/modules/import-map/preloader.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
-import type { LayoutItem, MdxBundle } from "#veryfront/types";
+import type { EntityInfo, LayoutItem, MdxBundle } from "#veryfront/types";
 import type { RenderEnvironment } from "#veryfront/rendering/context/render-context.ts";
+
+const LAYOUT_SOURCE = "export default function Layout() { return null; }";
+
+function StubLayout(): null {
+  return null;
+}
+
+/**
+ * A layout cache that records the keys it is asked for and always answers with
+ * a stub. `loadTSXComponent` stamps the compile mode and the request
+ * environment into the key before the lookup, so the recorded key is a faithful
+ * readout of the mode pair the apply phase supplied.
+ */
+function recordingCache(): { cache: LayoutComponentCache; keys: string[] } {
+  const keys: string[] = [];
+  return {
+    keys,
+    cache: {
+      get(key: string) {
+        keys.push(key);
+        return StubLayout as React.ComponentType;
+      },
+      set() {},
+      delete() {},
+      clear() {},
+    },
+  };
+}
+
+function markersOf(key: string): { dev: boolean; preview: boolean } {
+  return { dev: key.includes(":dev"), preview: key.includes(":preview") };
+}
+
+/**
+ * Serves the one layout the apply case wraps with and nothing else, so the
+ * reserved-component scan finds no other file to compile.
+ */
+function createLayoutSourceAdapter(layoutPath: string): RuntimeAdapter {
+  return {
+    fs: {
+      readFile: (path: string) => {
+        if (path === layoutPath) return Promise.resolve(LAYOUT_SOURCE);
+        const error = new Error("not found") as Error & { code: string };
+        error.code = "ENOENT";
+        return Promise.reject(error);
+      },
+      exists: () => Promise.resolve(false),
+      readDir: async function* () {},
+    },
+    env: { get: () => undefined },
+  } as unknown as RuntimeAdapter;
+}
 
 function createMissingFileAdapter(): RuntimeAdapter {
   return {
@@ -115,8 +169,14 @@ describe("rendering/orchestrator/layout", () => {
     const mutableRenderer = mdxRenderer as unknown as {
       loadModuleESM: typeof mdxRenderer.loadModuleESM;
     };
-    mutableRenderer.loadModuleESM =
-      (() => Promise.resolve({ default: () => null })) as typeof mdxRenderer.loadModuleESM;
+    let observedOptions: Record<string, unknown> | undefined;
+    mutableRenderer.loadModuleESM = ((
+      _compiledProgramCode: string,
+      options: Record<string, unknown> | undefined,
+    ) => {
+      observedOptions = { ...options };
+      return Promise.resolve({ default: () => null });
+    }) as typeof mdxRenderer.loadModuleESM;
 
     const config = validateVeryfrontConfig({
       resolve: {
@@ -157,6 +217,11 @@ describe("rendering/orchestrator/layout", () => {
       );
 
       assertEquals(summary.importMapSuccess, true);
+      assertEquals(
+        observedOptions?.reactVersion,
+        "19.1.0",
+        "a pinned request must use its own React version, not the memoized one",
+      );
       assertEquals(
         orchestrator.getPreloadedImportMap()?.imports?.["orchestrator-package"],
         "https://example.com/orchestrator-package.ts",
@@ -229,6 +294,163 @@ describe("rendering/orchestrator/layout", () => {
     } finally {
       mutableRenderer.loadModuleESM = originalLoadModuleESM;
       clearImportMapCache();
+    }
+  });
+
+  it("gives each pinned preload its own React version on a reused orchestrator", async () => {
+    clearImportMapCache();
+    const projectDir = "/pinned-project";
+    const originalLoadModuleESM = mdxRenderer.loadModuleESM;
+    const mutableRenderer = mdxRenderer as unknown as {
+      loadModuleESM: typeof mdxRenderer.loadModuleESM;
+    };
+    const observed: Array<Record<string, unknown>> = [];
+    mutableRenderer.loadModuleESM = (_compiledProgramCode, options) => {
+      observed.push({ ...(options as Record<string, unknown> | undefined) });
+      return Promise.resolve({ default: () => null });
+    };
+
+    // One orchestrator serves both requests: a per-instance memo would hand
+    // the first request's React version to the second.
+    const orchestrator = new LayoutOrchestrator({
+      projectDir,
+      projectId: "pinned-project",
+      projectSlug: "pinned-project",
+      contentSourceId: "pinned-main",
+      adapter: createMockAdapter(),
+      config: validateVeryfrontConfig({ react: { version: "19.1.1" } }),
+      mode: "production",
+      environment: "preview",
+      layoutCollector: {} as LayoutCollector,
+      layoutCompiler: {} as LayoutCompiler,
+      layoutCache: createLayoutComponentCache(),
+      componentRegistry: {},
+      isLocalProject: true,
+    });
+    const layouts = [{
+      kind: "mdx",
+      path: `${projectDir}/layout.mdx`,
+      bundle: { compiledCode: "export default function Layout() { return null; }" },
+    }] as LayoutItem[];
+
+    try {
+      await orchestrator.preloadLayoutModules(layouts, undefined, { react: "19.1.0" });
+      await orchestrator.preloadLayoutModules(layouts, undefined, { react: "18.3.1" });
+
+      assertEquals(
+        observed.map((options) => options.reactVersion),
+        ["19.1.0", "18.3.1"],
+        "each pinned preload must resolve its own React version",
+      );
+    } finally {
+      mutableRenderer.loadModuleESM = originalLoadModuleESM;
+      clearImportMapCache();
+    }
+  });
+
+  it("denies the trusted local-project identity to layouts whose orchestrator never claimed it", async () => {
+    clearImportMapCache();
+    const projectDir = "/untrusted-project";
+    const originalLoadModuleESM = mdxRenderer.loadModuleESM;
+    const mutableRenderer = mdxRenderer as unknown as {
+      loadModuleESM: typeof mdxRenderer.loadModuleESM;
+    };
+    const observed: unknown[] = [];
+    mutableRenderer.loadModuleESM = (_compiledProgramCode, options) => {
+      observed.push((options as { isLocalProject?: unknown } | undefined)?.isLocalProject);
+      return Promise.resolve({ default: () => null });
+    };
+
+    // layout.ts:283 is the covered seam; the apply path repeats the same
+    // coercion, so both call sites must keep it a strict `=== true`.
+    const preloadWith = (isLocalProject?: boolean) => {
+      const orchestrator = new LayoutOrchestrator({
+        projectDir,
+        projectId: "untrusted-project",
+        projectSlug: "untrusted-project",
+        contentSourceId: "untrusted-main",
+        adapter: createMockAdapter(),
+        config: validateVeryfrontConfig({ react: { version: "19.1.1" } }),
+        mode: "production",
+        environment: "preview",
+        layoutCollector: {} as LayoutCollector,
+        layoutCompiler: {} as LayoutCompiler,
+        layoutCache: createLayoutComponentCache(),
+        componentRegistry: {},
+        ...(isLocalProject === undefined ? {} : { isLocalProject }),
+      });
+      const layouts = [{
+        kind: "mdx",
+        path: `${projectDir}/layout.mdx`,
+        bundle: { compiledCode: "export default function Layout() { return null; }" },
+      }] as LayoutItem[];
+      return orchestrator.preloadLayoutModules(layouts);
+    };
+
+    try {
+      assertEquals((await preloadWith(false)).mdxSuccess, 1);
+      assertEquals((await preloadWith(undefined)).mdxSuccess, 1);
+
+      assertEquals(
+        observed,
+        [false, false],
+        "an unset isLocalProject must coerce to false, never to trusted",
+      );
+    } finally {
+      mutableRenderer.loadModuleESM = originalLoadModuleESM;
+      clearImportMapCache();
+    }
+  });
+
+  it("applies layouts under the request environment, not the orchestrator's", async () => {
+    const { cache, keys } = recordingCache();
+    const orchestrator = new LayoutOrchestrator({
+      projectDir: "/project",
+      projectId: "apply-project",
+      projectSlug: "apply-project",
+      contentSourceId: "release-1",
+      adapter: createLayoutSourceAdapter("/project/app/layout.tsx"),
+      config: validateVeryfrontConfig({ react: { version: "19.1.1" } }),
+      mode: "production",
+      environment: "production",
+      layoutCollector: {} as LayoutCollector,
+      layoutCompiler: {} as LayoutCompiler,
+      layoutCache: cache,
+      componentRegistry: {},
+    });
+
+    try {
+      await orchestrator.applyLayoutsAndWrappers(
+        React.createElement("div") as React.ReactElement,
+        { entity: { path: "/project/app/page.tsx", slug: "" } } as EntityInfo,
+        undefined,
+        [{ kind: "tsx", componentPath: "/project/app/layout.tsx" } as LayoutItem],
+        undefined, // layoutDataMap
+        undefined, // requestUrl
+        undefined, // params
+        undefined, // frontmatter
+        undefined, // headings
+        undefined, // projectSlug
+        undefined, // clientPageIsland
+        undefined, // pageProps
+        undefined, // dependencyPinningCacheKey
+        undefined, // dependencyPinningDependencies
+        undefined, // dependencyPinningSource
+        undefined, // signal
+        "preview",
+      );
+
+      assertEquals(keys.length > 0, true, "expected the apply phase to consult the layout cache");
+      assertEquals(
+        markersOf(keys[0]!),
+        { dev: false, preview: true },
+        "a preview render must not read or write the production layout artifact",
+      );
+    } finally {
+      // The apply phase bundles the framework providers, so release the
+      // bundler service the render started.
+      const esbuild = await import("veryfront/extensions/bundler");
+      await esbuild.stop();
     }
   });
 

--- a/src/rendering/orchestrator/lifecycle.test.ts
+++ b/src/rendering/orchestrator/lifecycle.test.ts
@@ -4,8 +4,14 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { RendererLifecycle, type RendererServices } from "./lifecycle.ts";
 import { ConfigurationManager } from "./config.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { join } from "#veryfront/compat/path";
+import { validateVeryfrontConfig, type VeryfrontConfigInput } from "#veryfront/config";
+import { __subscribeLogRecordEmitter, type LogEntry } from "#veryfront/utils/logger/index.ts";
+import { waitFor } from "#veryfront/testing/deno-compat.ts";
+import { FilesystemCacheStore, KVCacheStore, MemoryCacheStore } from "../cache/stores/index.ts";
+import type { CacheStore } from "../cache/types.ts";
 
-function createMockAdapter(): RuntimeAdapter {
+function createMockAdapter(envVars: Record<string, string> = {}): RuntimeAdapter {
   return {
     fs: {
       readFile: async () => "",
@@ -16,8 +22,53 @@ function createMockAdapter(): RuntimeAdapter {
       stat: async () => ({ isFile: false, isDirectory: false, size: 0 }),
       remove: async () => {},
     },
-    env: { get: () => undefined },
+    env: { get: (key: string) => envVars[key] },
   } as unknown as RuntimeAdapter;
+}
+
+/**
+ * Build the real service graph (no injected servicesFactory) so the wiring
+ * between lifecycle options, the render cache store, and the services can be
+ * observed.
+ */
+async function initializeRealServices(
+  options: {
+    config?: VeryfrontConfigInput;
+    envVars?: Record<string, string>;
+    projectId?: string;
+    contentSourceId?: string;
+    moduleServerUrl?: string;
+  } = {},
+): Promise<{ lifecycle: RendererLifecycle; services: RendererServices }> {
+  const configManager = new ConfigurationManager({
+    projectDir: "/project",
+    mode: "production",
+    adapter: createMockAdapter(options.envVars),
+    config: validateVeryfrontConfig(options.config ?? {}),
+  });
+  await configManager.initialize();
+
+  const lifecycle = new RendererLifecycle({
+    configManager,
+    port: 3000,
+    ...(options.moduleServerUrl ? { moduleServerUrl: options.moduleServerUrl } : {}),
+    ...(options.projectId ? { projectId: options.projectId } : {}),
+    ...(options.contentSourceId ? { contentSourceId: options.contentSourceId } : {}),
+  });
+
+  return { lifecycle, services: await lifecycle.initialize() };
+}
+
+/** The coordinator keeps its store private; there is no public accessor. */
+function readCacheStore(services: RendererServices): CacheStore {
+  return (services.cacheCoordinator as unknown as { store: CacheStore }).store;
+}
+
+/** The entry budget is only reachable through the store's private LRU. */
+function readMemoryStoreMaxEntries(store: CacheStore): number | undefined {
+  return (store as unknown as {
+    cache?: { adapter?: { maxEntries?: number } };
+  }).cache?.adapter?.maxEntries;
 }
 
 describe("rendering/orchestrator/lifecycle", () => {
@@ -36,21 +87,27 @@ describe("rendering/orchestrator/lifecycle", () => {
       assertEquals(lifecycle instanceof RendererLifecycle, true);
     });
 
-    it("should accept optional options", () => {
-      const adapter = createMockAdapter();
-      const configManager = new ConfigurationManager({
-        projectDir: "/project",
-        mode: "development",
-        adapter,
-      });
-      const lifecycle = new RendererLifecycle({
-        configManager,
-        port: 3000,
+    it("should thread optional options into the services it builds", async () => {
+      const { lifecycle, services } = await initializeRealServices({
         moduleServerUrl: "http://localhost:3002",
         projectId: "test-project",
         contentSourceId: "main",
       });
-      assertEquals(lifecycle instanceof RendererLifecycle, true);
+
+      try {
+        assertEquals(
+          (services.cacheCoordinator as unknown as { cachePrefix: string }).cachePrefix,
+          "test-project:main:",
+          "render cache entries must be tenant-isolated by projectId and contentSourceId",
+        );
+        assertEquals(
+          (services.componentRegistry as unknown as { moduleServerUrl?: string }).moduleServerUrl,
+          "http://localhost:3002",
+          "the component registry must load modules from the configured module server",
+        );
+      } finally {
+        await lifecycle.destroy();
+      }
     });
   });
 
@@ -115,6 +172,87 @@ describe("rendering/orchestrator/lifecycle", () => {
         port: 3000,
       });
       await lifecycle.destroy();
+    });
+  });
+
+  describe("initialize builds the configured render cache store", () => {
+    it("uses a filesystem store rooted in the configured cache dir", async () => {
+      const { lifecycle, services } = await initializeRealServices({
+        config: { cache: { dir: "cache-root", render: { type: "filesystem" } } },
+        projectId: "test-project",
+      });
+
+      try {
+        const store = readCacheStore(services);
+        assertEquals(
+          store instanceof FilesystemCacheStore,
+          true,
+          "a filesystem render cache must not fall back to a volatile store",
+        );
+        assertEquals(
+          (store as unknown as { baseDir: string }).baseDir,
+          join("/project", "cache-root", "render"),
+          "the filesystem store writes under the configured cache dir",
+        );
+      } finally {
+        await lifecycle.destroy();
+      }
+    });
+
+    it("uses a KV store when the render cache type is kv", async () => {
+      const { lifecycle, services } = await initializeRealServices({
+        config: { cache: { render: { type: "kv" } } },
+        projectId: "test-project",
+      });
+
+      try {
+        assertEquals(
+          readCacheStore(services) instanceof KVCacheStore,
+          true,
+          "a kv render cache must be backed by the KV store",
+        );
+      } finally {
+        await lifecycle.destroy();
+      }
+    });
+
+    it("defaults to a memory store sized for production", async () => {
+      const { lifecycle, services } = await initializeRealServices({
+        projectId: "test-project",
+      });
+
+      try {
+        const store = readCacheStore(services);
+        assertEquals(
+          store instanceof MemoryCacheStore,
+          true,
+          "an unconfigured render cache defaults to the memory store",
+        );
+        assertEquals(
+          readMemoryStoreMaxEntries(store),
+          500,
+          "outside debug mode the memory render cache keeps the production entry budget",
+        );
+      } finally {
+        await lifecycle.destroy();
+      }
+    });
+
+    it("shrinks the memory store in debug mode", async () => {
+      const { lifecycle, services } = await initializeRealServices({
+        envVars: { VERYFRONT_DEBUG: "1" },
+        projectId: "test-project",
+      });
+
+      try {
+        assertEquals(
+          readMemoryStoreMaxEntries(readCacheStore(services)),
+          50,
+          "debug mode caps the memory render cache at the smaller entry budget",
+        );
+      } finally {
+        await lifecycle.destroy();
+      }
     });
   });
 
@@ -252,6 +390,109 @@ describe("rendering/orchestrator/lifecycle", () => {
       // clearSlugCache is fire-and-forget (void return), so await the mock's promise
       await clearSlugDone;
       assertEquals(mockServices._cleared.includes("slug:test-slug"), true);
+    });
+
+    it("logs and swallows a rejected clearAll instead of leaking an unhandled rejection", async () => {
+      const mockServices = createMockServices();
+      mockServices.cacheCoordinator.clearAll = () => Promise.reject(new Error("clear boom"));
+
+      const adapter = createMockAdapter();
+      const configManager = new ConfigurationManager({
+        projectDir: "/project",
+        mode: "production",
+        adapter,
+      });
+      const lifecycle = new RendererLifecycle({
+        configManager,
+        port: 3000,
+        servicesFactory: () => mockServices,
+      });
+
+      await lifecycle.initialize();
+
+      const records: LogEntry[] = [];
+      const unsubscribe = __subscribeLogRecordEmitter((entry) => records.push(entry));
+
+      try {
+        lifecycle.clearAllCaches();
+        await waitFor(
+          () => records.some((entry) => entry.message === "Failed to clear all caches"),
+          { message: "a rejected clearAll is reported as a warning" },
+        );
+      } finally {
+        unsubscribe();
+      }
+
+      const failure = records.find((entry) => entry.message === "Failed to clear all caches");
+      assertEquals(
+        failure?.level,
+        "warn",
+        "a rejected cache clear must be logged, not left as an unhandled rejection",
+      );
+      assertEquals(
+        String(failure?.context?.error),
+        "Error: clear boom",
+        "the warning carries the underlying clear failure",
+      );
+      assertEquals(
+        mockServices._cleared.includes("virtualModules"),
+        true,
+        "the synchronous clears still run when the async clear rejects",
+      );
+      assertEquals(
+        mockServices._cleared.includes("componentRegistry"),
+        true,
+        "the synchronous clears still run when the async clear rejects",
+      );
+    });
+
+    it("logs and swallows a rejected clearSlug instead of leaking an unhandled rejection", async () => {
+      const mockServices = createMockServices();
+      mockServices.cacheCoordinator.clearSlug = () => Promise.reject(new Error("slug boom"));
+
+      const adapter = createMockAdapter();
+      const configManager = new ConfigurationManager({
+        projectDir: "/project",
+        mode: "production",
+        adapter,
+      });
+      const lifecycle = new RendererLifecycle({
+        configManager,
+        port: 3000,
+        servicesFactory: () => mockServices,
+      });
+
+      await lifecycle.initialize();
+
+      const records: LogEntry[] = [];
+      const unsubscribe = __subscribeLogRecordEmitter((entry) => records.push(entry));
+
+      try {
+        lifecycle.clearSlugCache("test-slug");
+        await waitFor(
+          () => records.some((entry) => entry.message === "Failed to clear slug cache"),
+          { message: "a rejected clearSlug is reported as a warning" },
+        );
+      } finally {
+        unsubscribe();
+      }
+
+      const failure = records.find((entry) => entry.message === "Failed to clear slug cache");
+      assertEquals(
+        failure?.level,
+        "warn",
+        "a rejected slug clear must be logged, not left as an unhandled rejection",
+      );
+      assertEquals(
+        failure?.context?.slug,
+        "test-slug",
+        "the warning names the slug whose clear failed",
+      );
+      assertEquals(
+        String(failure?.context?.error),
+        "Error: slug boom",
+        "the warning carries the underlying clear failure",
+      );
     });
 
     it("initializeComponents delegates after init", async () => {

--- a/src/rendering/orchestrator/mdx.test.ts
+++ b/src/rendering/orchestrator/mdx.test.ts
@@ -196,6 +196,41 @@ describe("rendering/orchestrator/MDXCompiler singleflight", () => {
     });
   });
 
+  describe("a cached bundle short-circuits compilation", () => {
+    it("returns the cached bundle without compiling or re-caching", async () => {
+      let setCacheCount = 0;
+
+      const { register: registerContract } = await import(
+        "#veryfront/extensions/contracts.ts"
+      );
+      registerContract("ContentProcessor", {
+        compileMdx: (): Promise<MDXCompilationResult> => {
+          throw new Error("compileMdx must not run on a bundle cache hit");
+        },
+      });
+
+      const adapter = makeMissAdapter(() => {
+        setCacheCount++;
+      });
+      adapter.getCachedBundle = (
+        _content: string,
+        _fm?: Record<string, unknown>,
+        _fp?: string,
+      ) => Promise.resolve(makeResult("cached-code"));
+
+      const compiler = new MDXCompiler({
+        projectDir: "/project",
+        mode: "production",
+        mdxCacheAdapter: adapter,
+      });
+
+      const result = await compiler.compileMDX("# Cached", {}, "cached.mdx");
+
+      assertEquals(result.compiledCode, "cached-code", "a bundle cache hit is returned verbatim");
+      assertEquals(setCacheCount, 0, "a cache hit must not rewrite the bundle cache");
+    });
+  });
+
   describe("different source content compiles independently", () => {
     it("two distinct content strings each invoke compileAndCache once", async () => {
       let compileCount = 0;

--- a/src/rendering/orchestrator/module-collection.test.ts
+++ b/src/rendering/orchestrator/module-collection.test.ts
@@ -49,6 +49,11 @@ describe("module-collection", () => {
       assertEquals(modules.length, 1);
       assertEquals(modules[0]?.type, "page");
       assertEquals(modules[0]?.path, "/pages/index.tsx");
+      assertEquals(
+        modules[0]?.id,
+        "/pages/index.tsx",
+        "the page module is keyed by its own component path",
+      );
     });
 
     it("returns empty array for non-component pages", () => {
@@ -84,12 +89,20 @@ describe("module-collection", () => {
         ],
       );
 
-      assertEquals(modules.length, 3);
-      assertEquals(modules[0]?.type, "page");
-      assertEquals(modules[1]?.type, "layout");
-      assertEquals(modules[1]?.path, "/layouts/_layout.tsx");
-      assertEquals(modules[2]?.type, "layout");
-      assertEquals(modules[2]?.path, "/layouts/nested.tsx");
+      assertEquals(
+        modules,
+        [
+          { type: "page", id: "/pages/index.tsx", path: "/pages/index.tsx" },
+          { type: "layout", id: "/layouts/_layout.tsx", path: "/layouts/_layout.tsx" },
+          { type: "layout", id: "/layouts/nested.tsx", path: "/layouts/nested.tsx" },
+        ],
+        "each collected module carries its own componentPath as its identity key",
+      );
+      assertEquals(
+        new Set(modules.map((m) => m.id)).size,
+        modules.length,
+        "layout identity keys must stay distinct so layoutProps cannot collapse",
+      );
     });
 
     it("skips non-tsx layouts", () => {

--- a/src/rendering/orchestrator/module-loader/cache.test.ts
+++ b/src/rendering/orchestrator/module-loader/cache.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createEsmCache, createModuleCache, generateHash } from "./cache.ts";
 
@@ -37,7 +37,17 @@ describe("module-loader/cache", () => {
     });
 
     it("should handle unicode content", async () => {
-      await assertHexHash("Hello");
+      await assertHexHash("café");
+      assertNotEquals(
+        await generateHash("café"),
+        await generateHash("cafe"),
+        "accented and unaccented sources must not share a module cache key",
+      );
+      assertNotEquals(
+        await generateHash("東京"),
+        await generateHash("大阪"),
+        "distinct CJK sources must not share a module cache key",
+      );
     });
   });
 

--- a/src/rendering/orchestrator/module-loader/dependency-resolver.test.ts
+++ b/src/rendering/orchestrator/module-loader/dependency-resolver.test.ts
@@ -123,6 +123,69 @@ describe("module-loader/dependency-resolver", () => {
     );
   });
 
+  it("fails closed when static relative import collection exceeds its bound", async () => {
+    const adapter = await getLocalAdapter();
+    const fileContent = Array.from(
+      { length: 501 },
+      (_, index) => `import value${index} from "./value-${index}";`,
+    ).join("\n");
+
+    await assertRejects(
+      () =>
+        resolveModuleDependencies({
+          adapter,
+          fileContent,
+          filePath: "/project/page.tsx",
+          projectDir: "/project",
+        }),
+      RangeError,
+      "more than 500 static relative imports",
+      "the static relative scan carries its own per-kind allocation bound",
+    );
+  });
+
+  it("fails closed when side-effect alias import collection exceeds its bound", async () => {
+    const adapter = await getLocalAdapter();
+    const fileContent = Array.from(
+      { length: 501 },
+      (_, index) => `import "@/value-${index}";`,
+    ).join("\n");
+
+    await assertRejects(
+      () =>
+        resolveModuleDependencies({
+          adapter,
+          fileContent,
+          filePath: "/project/page.tsx",
+          projectDir: "/project",
+        }),
+      RangeError,
+      "more than 500 side-effect alias imports",
+      "the side-effect alias scan carries its own per-kind allocation bound",
+    );
+  });
+
+  it("accepts a module at the static import bound", async () => {
+    const adapter = await getLocalAdapter();
+    const fileContent = Array.from(
+      { length: 500 },
+      (_, index) => `import value${index} from "@/value-${index}";`,
+    ).join("\n");
+
+    const deps = await resolveModuleDependencies({
+      adapter,
+      fileContent,
+      filePath: "/project/page.tsx",
+      projectDir: "/project",
+    });
+
+    assertEquals(
+      deps.length,
+      500,
+      "a module at exactly the bound must still resolve: the limit rejects more than 500",
+    );
+  });
+
   it("resolves and rewrites side-effect alias and relative imports", async () => {
     await withDependencyFixture(
       {
@@ -244,6 +307,100 @@ describe("module-loader/dependency-resolver", () => {
         assertEquals(deps.length, 2);
         assertStringIncludes(deps[0]?.depFilePath ?? "", "/components/Button.tsx");
         assertStringIncludes(deps[1]?.depFilePath ?? "", "/lib/value.ts");
+      },
+    );
+  });
+
+  it("resolves a relative directory import through its index file", async () => {
+    await withDependencyFixture(
+      {
+        "app/page.tsx": [
+          `import { Panel } from "./ui";`,
+          `export const page = Panel;`,
+        ].join("\n"),
+        "app/ui/index.tsx": `export const Panel = "panel";`,
+      },
+      async ({ projectDir }) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.tsx");
+        const fileContent = await Deno.readTextFile(filePath);
+
+        const deps = await resolveModuleDependencies({
+          adapter,
+          fileContent,
+          filePath,
+          projectDir,
+        });
+
+        assertEquals(deps.length, 1);
+        assertEquals(
+          deps[0]?.depFilePath,
+          join(projectDir, "app/ui/index.tsx"),
+          "a directory import must resolve through its index file",
+        );
+      },
+    );
+  });
+
+  it("prefers a sibling file over a directory of the same name", async () => {
+    await withDependencyFixture(
+      {
+        "app/page.tsx": [
+          `import { Panel } from "./ui";`,
+          `export const page = Panel;`,
+        ].join("\n"),
+        "app/ui.tsx": `export const Panel = "file-panel";`,
+        "app/ui/index.tsx": `export const Panel = "directory-panel";`,
+      },
+      async ({ projectDir }) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.tsx");
+        const fileContent = await Deno.readTextFile(filePath);
+
+        const deps = await resolveModuleDependencies({
+          adapter,
+          fileContent,
+          filePath,
+          projectDir,
+        });
+
+        assertEquals(deps.length, 1);
+        assertEquals(
+          deps[0]?.depFilePath,
+          join(projectDir, "app/ui.tsx"),
+          "the directory itself must never be handed on: the sibling module file wins",
+        );
+      },
+    );
+  });
+
+  it("leaves a directory import without an index file unresolved", async () => {
+    await withDependencyFixture(
+      {
+        "app/page.tsx": [
+          `import { Panel } from "./ui";`,
+          `export const page = Panel;`,
+        ].join("\n"),
+        "app/ui/panel.tsx": `export const Panel = "panel";`,
+      },
+      async ({ projectDir }) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.tsx");
+        const fileContent = await Deno.readTextFile(filePath);
+
+        const deps = await resolveModuleDependencies({
+          adapter,
+          fileContent,
+          filePath,
+          projectDir,
+        });
+
+        assertEquals(deps.length, 1);
+        assertEquals(
+          deps[0]?.depFilePath,
+          null,
+          "a directory without an index file must not be handed on as a dependency file",
+        );
       },
     );
   });

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -8,38 +8,38 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
   describe("rewriteEsmPaths", () => {
     const urlBase = "https://esm.sh/v135/react-dom@18.2.0/es2022/";
 
-    it("should not modify code with no imports or exports", () => {
+    it("should not modify code with no imports or exports", async () => {
       const code = `console.log("no imports here");`;
-      assertEquals(rewriteEsmPaths(code, urlBase), code);
+      assertEquals(await rewriteEsmPaths(code, urlBase), code);
     });
 
-    it("should not modify non-path strings", () => {
+    it("should not modify non-path strings", async () => {
       const code = `const x = "hello world";`;
-      assertEquals(rewriteEsmPaths(code, urlBase), code);
+      assertEquals(await rewriteEsmPaths(code, urlBase), code);
     });
 
-    it("should not modify import of bare specifiers", () => {
+    it("should not modify import of bare specifiers", async () => {
       const code = `import "react"`;
-      assertEquals(rewriteEsmPaths(code, urlBase), code);
+      assertEquals(await rewriteEsmPaths(code, urlBase), code);
     });
 
-    it("should not modify from of bare specifiers", () => {
+    it("should not modify from of bare specifiers", async () => {
       const code = `import { useState } from "react"`;
-      assertEquals(rewriteEsmPaths(code, urlBase), code);
+      assertEquals(await rewriteEsmPaths(code, urlBase), code);
     });
 
-    it("should return same string for empty input", () => {
-      assertEquals(rewriteEsmPaths("", urlBase), "");
+    it("should return same string for empty input", async () => {
+      assertEquals(await rewriteEsmPaths("", urlBase), "");
     });
 
-    it("should preserve non-import code lines around imports", () => {
+    it("should preserve non-import code lines around imports", async () => {
       const code = `const x = 1;\nconst y = 2;`;
-      assertEquals(rewriteEsmPaths(code, urlBase), code);
+      assertEquals(await rewriteEsmPaths(code, urlBase), code);
     });
 
-    it("should not rewrite veryfront module paths via from", () => {
+    it("should not rewrite veryfront module paths via from", async () => {
       const code = `import { something } from "/_vf_modules/my-module.js"`;
-      const result = rewriteEsmPaths(code, urlBase);
+      const result = await rewriteEsmPaths(code, urlBase);
       // A substring check would still hold for "https://esm.sh/_vf_modules/...",
       // so the oracle has to be the whole output.
       assertEquals(
@@ -54,7 +54,7 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       );
     });
 
-    it("should not rewrite veryfront module paths in the other specifier forms", () => {
+    it("should not rewrite veryfront module paths in the other specifier forms", async () => {
       for (
         const code of [
           `import "/_vf_modules/my-module.js"`,
@@ -63,16 +63,16 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
         ]
       ) {
         assertEquals(
-          rewriteEsmPaths(code, urlBase),
+          await rewriteEsmPaths(code, urlBase),
           code,
           "every specifier form must leave a locally served path untouched",
         );
       }
     });
 
-    it("should not rewrite _veryfront paths via from", () => {
+    it("should not rewrite _veryfront paths via from", async () => {
       const code = `import { something } from "/_veryfront/modules/component.js"`;
-      const result = rewriteEsmPaths(code, urlBase);
+      const result = await rewriteEsmPaths(code, urlBase);
       assertEquals(
         result,
         code,
@@ -85,7 +85,7 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       );
     });
 
-    it("should not rewrite _veryfront paths in the other specifier forms", () => {
+    it("should not rewrite _veryfront paths in the other specifier forms", async () => {
       for (
         const code of [
           `import "/_veryfront/modules/component.js"`,
@@ -94,64 +94,101 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
         ]
       ) {
         assertEquals(
-          rewriteEsmPaths(code, urlBase),
+          await rewriteEsmPaths(code, urlBase),
           code,
           "every specifier form must leave a virtual-module path untouched",
         );
       }
     });
 
-    it("resolves absolute specifiers through esm.sh", () => {
+    it("resolves absolute specifiers through esm.sh", async () => {
       assertEquals(
-        rewriteEsmPaths(`import "/v135/react.js"`, urlBase),
+        await rewriteEsmPaths(`import "/v135/react.js"`, urlBase),
         `import "https://esm.sh/v135/react.js"`,
         "a bare absolute path belongs to esm.sh, not to the local server",
       );
       assertEquals(
-        rewriteEsmPaths(`import React from "/v135/react.js"`, urlBase),
+        await rewriteEsmPaths(`import React from "/v135/react.js"`, urlBase),
         `import React from "https://esm.sh/v135/react.js"`,
         "a bare absolute path belongs to esm.sh, not to the local server",
       );
       assertEquals(
-        rewriteEsmPaths(`export * from "/v135/a.js"`, urlBase),
+        await rewriteEsmPaths(`export * from "/v135/a.js"`, urlBase),
         `export * from "https://esm.sh/v135/a.js"`,
         "a bare absolute path belongs to esm.sh, not to the local server",
       );
       assertEquals(
-        rewriteEsmPaths(`export { b } from "/v135/b.js"`, urlBase),
+        await rewriteEsmPaths(`export { b } from "/v135/b.js"`, urlBase),
         `export { b } from "https://esm.sh/v135/b.js"`,
         "a bare absolute path belongs to esm.sh, not to the local server",
       );
     });
 
-    it("resolves relative specifiers against the module's own URL", () => {
+    it("resolves relative specifiers against the module's own URL", async () => {
       assertEquals(
-        rewriteEsmPaths(`import x from "./chunk.js"`, urlBase),
+        await rewriteEsmPaths(`import x from "./chunk.js"`, urlBase),
         `import x from "https://esm.sh/v135/react-dom@18.2.0/es2022/chunk.js"`,
         "a relative specifier resolves against the fetched module's URL",
       );
       assertEquals(
-        rewriteEsmPaths(`import "./chunk.js"`, urlBase),
+        await rewriteEsmPaths(`import "./chunk.js"`, urlBase),
         `import "https://esm.sh/v135/react-dom@18.2.0/es2022/chunk.js"`,
         "a relative specifier resolves against the fetched module's URL",
       );
       assertEquals(
-        rewriteEsmPaths(`export * from "./chunk.js"`, urlBase),
+        await rewriteEsmPaths(`export * from "./chunk.js"`, urlBase),
         `export * from "https://esm.sh/v135/react-dom@18.2.0/es2022/chunk.js"`,
         "a relative specifier resolves against the fetched module's URL",
       );
       assertEquals(
-        rewriteEsmPaths(`export { b } from "../es2021/b.js"`, urlBase),
+        await rewriteEsmPaths(`export { b } from "../es2021/b.js"`, urlBase),
         `export { b } from "https://esm.sh/v135/react-dom@18.2.0/es2021/b.js"`,
         "a parent-relative specifier resolves against the fetched module's URL",
       );
     });
 
-    it("should handle code with mixed import types", () => {
+    it("should handle code with mixed import types", async () => {
       const code = `import React from "react"\nconst x = 42;`;
-      const result = rewriteEsmPaths(code, urlBase);
+      const result = await rewriteEsmPaths(code, urlBase);
       // Bare specifiers should be untouched
       assertEquals(result.includes('"react"'), true);
+    });
+
+    it("leaves specifier-shaped text inside ordinary string data alone", async () => {
+      // A pattern-matching rewrite cannot tell a module specifier from the same
+      // text inside a string literal, and would turn this program's data into an
+      // esm.sh URL. Only a position the lexer calls a specifier may be edited.
+      for (
+        const code of [
+          `const message = 'from "/v135/help"';`,
+          `const message = 'import "/v135/help"';`,
+          `const message = 'export * from "./help.js"';`,
+        ]
+      ) {
+        assertEquals(
+          await rewriteEsmPaths(code, urlBase),
+          code,
+          "string data that merely reads like an import must survive untouched",
+        );
+      }
+    });
+
+    it("rewrites a real specifier that sits beside specifier-shaped string data", async () => {
+      const code = `const doc = 'see from "/v135/help"';\nimport React from "/v135/react.js";`;
+      assertEquals(
+        await rewriteEsmPaths(code, urlBase),
+        `const doc = 'see from "/v135/help"';\nimport React from "https://esm.sh/v135/react.js";`,
+        "skipping string data must not cost the genuine specifier its rewrite",
+      );
+    });
+
+    it("leaves a specifier-shaped path inside a comment alone", async () => {
+      const code = `// import "/v135/react.js"\nconst x = 1;`;
+      assertEquals(
+        await rewriteEsmPaths(code, urlBase),
+        code,
+        "a commented-out import is not part of the module graph",
+      );
     });
   });
 
@@ -251,6 +288,80 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       await assertRejects(
         () => fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache),
         Error,
+      );
+    });
+
+    it("terminates on a dependency cycle instead of fetching forever", async () => {
+      // A and B import each other. Nothing enters `esmCache` until a fetch has
+      // finished, so re-entering a URL already on the stack never terminates.
+      // The fetch budget turns that runaway into a failure rather than a hang.
+      const esmCache = new Map<string, string>();
+      let fetchCount = 0;
+      globalThis.fetch = ((input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        fetchCount++;
+        if (fetchCount > 8) throw new Error(`runaway fetch of ${url}`);
+        if (url === "https://esm.sh/cycle-a") {
+          return Promise.resolve(
+            jsonResponse(`import { b } from "https://esm.sh/cycle-b";\nexport const a = 1;`),
+          );
+        }
+        if (url === "https://esm.sh/cycle-b") {
+          return Promise.resolve(
+            jsonResponse(`import { a } from "https://esm.sh/cycle-a";\nexport const b = 2;`),
+          );
+        }
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }) as typeof fetch;
+
+      const result = await fetchEsmModule("https://esm.sh/cycle-a", tmpDir, localAdapter, esmCache);
+
+      assertEquals(fetchCount, 2, "each module in the cycle is fetched exactly once");
+      assertEquals(files.size, 2, "both modules in the cycle are written");
+
+      const bPaths = [...files.keys()].filter((path) => path !== result);
+      assertEquals(bPaths.length, 1);
+      const bPath = bPaths[0] ?? "";
+
+      assertEquals(
+        files.get(result)?.includes(`file://${bPath}`),
+        true,
+        "the entry module points at the local copy of its cyclic dependency",
+      );
+      assertEquals(
+        files.get(bPath)?.includes(`file://${result}`),
+        true,
+        "the back edge resolves to the path the entry module is actually written to",
+      );
+      assertEquals(
+        /esm\.sh\/cycle-/.test(`${files.get(result)}${files.get(bPath)}`),
+        false,
+        "no remote esm.sh reference survives in either side of the cycle",
+      );
+    });
+
+    it("terminates on a self-referencing module", async () => {
+      const esmCache = new Map<string, string>();
+      let fetchCount = 0;
+      globalThis.fetch = ((input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        fetchCount++;
+        if (fetchCount > 8) throw new Error(`runaway fetch of ${url}`);
+        if (url === "https://esm.sh/self") {
+          return Promise.resolve(
+            jsonResponse(`export { x } from "https://esm.sh/self";\nexport const x = 1;`),
+          );
+        }
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }) as typeof fetch;
+
+      const result = await fetchEsmModule("https://esm.sh/self", tmpDir, localAdapter, esmCache);
+
+      assertEquals(fetchCount, 1, "a module that imports itself is fetched once");
+      assertEquals(
+        files.get(result)?.includes(`file://${result}`),
+        true,
+        "the self edge resolves to the module's own local path",
       );
     });
 

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -2,6 +2,8 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertMatch, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import type { ModuleLexer } from "#veryfront/extensions/bundler/module-lexer.ts";
+import { register, resolve } from "#veryfront/extensions/contracts.ts";
 import { fetchEsmModule, rewriteEsmPaths } from "./esm-rewriter.ts";
 
 describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
@@ -260,6 +262,44 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       const rootContent = files.get(result) ?? "";
       assertMatch(rootContent, /file:\/\//);
       assertEquals(/esm\.sh\/a/.test(rootContent), false);
+    });
+
+    it("keeps the regex fallback when final specifier substitution cannot lex", async () => {
+      const esmCache = new Map<string, string>();
+      const originalLexer = resolve<ModuleLexer>("ModuleLexer");
+      const rootCode = `/* reject-configured-lexer */ import { a } from "https://esm.sh/a";`;
+      register<ModuleLexer>("ModuleLexer", {
+        init: originalLexer.init?.bind(originalLexer),
+        parse(code) {
+          if (code.includes("reject-configured-lexer")) {
+            throw new Error("configured lexer rejected source");
+          }
+          return originalLexer.parse(code);
+        },
+      });
+      globalThis.fetch = ((input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "https://esm.sh/root") return Promise.resolve(jsonResponse(rootCode));
+        if (url === "https://esm.sh/a") return Promise.resolve(jsonResponse("export const a = 1;"));
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }) as typeof fetch;
+
+      try {
+        const result = await fetchEsmModule(
+          "https://esm.sh/root",
+          tmpDir,
+          localAdapter,
+          esmCache,
+        );
+
+        assertEquals(
+          files.get(result),
+          rootCode,
+          "a final lexer failure must retain the fetched source and its remote specifier",
+        );
+      } finally {
+        register("ModuleLexer", originalLexer);
+      }
     });
 
     it("prefetches successful template-literal dynamic imports", async () => {
@@ -523,6 +563,69 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
         esmCache.size,
         0,
         "the lazy failure still keeps provisional graph artifacts out of the shared cache",
+      );
+    });
+
+    it("waits for a cycle owner before a concurrent sibling reuses its descendant", async () => {
+      const esmCache = new Map<string, string>();
+      const dWritten = Promise.withResolvers<void>();
+      const gatedAdapter = {
+        fs: {
+          writeFile(path: string, content: string) {
+            files.set(path, content);
+            if (content.includes("export const d = a")) dWritten.resolve();
+            return Promise.resolve();
+          },
+        },
+      } as unknown as RuntimeAdapter;
+
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "https://esm.sh/root") {
+          return jsonResponse(
+            `import { a } from "https://esm.sh/a";\n` +
+              `import { x } from "https://esm.sh/x";\n` +
+              `export const root = a + x;`,
+          );
+        }
+        if (url === "https://esm.sh/a") {
+          return jsonResponse(
+            `import { d } from "https://esm.sh/d";\n` +
+              `import { slow } from "https://esm.sh/slow";\n` +
+              `export const a = d + slow;`,
+          );
+        }
+        if (url === "https://esm.sh/d") {
+          return jsonResponse(
+            `import { a } from "https://esm.sh/a";\nexport const d = a;`,
+          );
+        }
+        if (url === "https://esm.sh/x") {
+          await dWritten.promise;
+          return jsonResponse(
+            `import { d } from "https://esm.sh/d";\nexport const x = d;`,
+          );
+        }
+        if (url === "https://esm.sh/slow") {
+          await dWritten.promise;
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          return jsonResponse("export const slow = 1;");
+        }
+        return new Response("not found", { status: 404 });
+      }) as typeof fetch;
+
+      const result = await fetchEsmModule(
+        "https://esm.sh/root",
+        tmpDir,
+        gatedAdapter,
+        esmCache,
+      );
+
+      assertEquals(files.has(result), true);
+      assertEquals(
+        esmCache.has("https://esm.sh/x"),
+        true,
+        "the sibling must finish after the cycle owner materializes its predicted path",
       );
     });
 

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -628,6 +628,80 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
         "the sibling must finish after the cycle owner materializes its predicted path",
       );
     });
+    it("does not await a cycle owner that is still unwinding up the caller's own stack", async () => {
+      // The root itself closes the cycle here: `d` points at the root's
+      // predicted path, and sibling `x` reuses `d` while the root is still
+      // inside its own `Promise.allSettled`. Waiting for the root to write
+      // would be waiting on the frame that is waiting for `x`.
+      const esmCache = new Map<string, string>();
+      const dWritten = Promise.withResolvers<void>();
+      const gatedAdapter = {
+        fs: {
+          writeFile(path: string, content: string) {
+            files.set(path, content);
+            if (content.includes("export const d = root")) dWritten.resolve();
+            return Promise.resolve();
+          },
+        },
+      } as unknown as RuntimeAdapter;
+
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "https://esm.sh/root") {
+          return jsonResponse(
+            `import { d } from "https://esm.sh/d";\n` +
+              `import { x } from "https://esm.sh/x";\n` +
+              `export const root = d + x;`,
+          );
+        }
+        if (url === "https://esm.sh/d") {
+          return jsonResponse(
+            `import { root } from "https://esm.sh/root";\nexport const d = root;`,
+          );
+        }
+        if (url === "https://esm.sh/x") {
+          await dWritten.promise;
+          return jsonResponse(
+            `import { d } from "https://esm.sh/d";\nexport const x = d;`,
+          );
+        }
+        return new Response("not found", { status: 404 });
+      }) as typeof fetch;
+
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const deadlocked = new Promise<"deadlocked">((resolve) => {
+        timer = setTimeout(() => resolve("deadlocked"), 2000);
+      });
+      try {
+        const outcome = await Promise.race([
+          fetchEsmModule("https://esm.sh/root", tmpDir, gatedAdapter, esmCache),
+          deadlocked,
+        ]);
+
+        assertEquals(
+          outcome === "deadlocked",
+          false,
+          "a descendant must never wait on an ancestor that is itself waiting on that descendant",
+        );
+        assertEquals(
+          files.has(outcome),
+          true,
+          "the root artifact must still be written once its own cycle closes",
+        );
+        assertEquals(
+          esmCache.has("https://esm.sh/x"),
+          true,
+          "the sibling that reused the cyclic descendant must still be published",
+        );
+        assertEquals(
+          esmCache.has("https://esm.sh/root"),
+          true,
+          "the cycle owner must be published once it writes its own predicted path",
+        );
+      } finally {
+        clearTimeout(timer);
+      }
+    });
 
     it("still throws when a nested URL is imported statically", async () => {
       // The emitted module's own import graph must be local before the runtime

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -480,6 +480,48 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       }
     });
 
+    it("fails the load when a line continuation precedes a relative path", async () => {
+      // `\\.` cannot consume a backslash-newline pair, so an escape scan built
+      // on it would stop inside the first string and pair its closing quote
+      // with the import's opening one.
+      const esmCache = new Map<string, string>();
+      const originalLexer = resolve<ModuleLexer>("ModuleLexer");
+      const rootCode = `/* reject-configured-lexer */ const s = "a\\\nb"; import "./dep.js";`;
+      register<ModuleLexer>("ModuleLexer", {
+        init: originalLexer.init?.bind(originalLexer),
+        parse(code) {
+          if (code.includes("reject-configured-lexer")) {
+            throw new Error("configured lexer rejected source");
+          }
+          return originalLexer.parse(code);
+        },
+      });
+      const rootUrl = "https://esm.sh/v135/root@1.0.0/es2022/root.js";
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === rootUrl) return Promise.resolve(jsonResponse(rootCode));
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
+
+      try {
+        await assertRejects(
+          () => fetchEsmModule(rootUrl, tmpDir, localAdapter, esmCache),
+          Error,
+          "./dep.js",
+          "a line continuation must not desynchronise the fallback scan",
+        );
+        assertEquals(
+          files.size,
+          0,
+          "no artifact may be written for a specifier hidden behind a line continuation",
+        );
+      } finally {
+        register("ModuleLexer", originalLexer);
+      }
+    });
+
     it("still accepts an unlexable module whose specifiers are all absolute", async () => {
       // The companion to the case above: a lexer failure is not fatal by
       // itself, only a lexer failure that leaves a specifier resolving against

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -396,6 +396,70 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       );
     });
 
+    it("rejects a static sibling that reused a poisoned lazy cycle descendant", async () => {
+      const esmCache = new Map<string, string>();
+      const dWritten = Promise.withResolvers<void>();
+      const gatedAdapter = {
+        fs: {
+          writeFile(path: string, content: string) {
+            files.set(path, content);
+            if (content.includes("export const d = 1")) dWritten.resolve();
+            return Promise.resolve();
+          },
+        },
+      } as unknown as RuntimeAdapter;
+
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "https://esm.sh/root") {
+          return jsonResponse(
+            `import("https://esm.sh/a");\n` +
+              `import { x } from "https://esm.sh/x";\n` +
+              `export const root = x;`,
+          );
+        }
+        if (url === "https://esm.sh/a") {
+          return jsonResponse(
+            `import { d } from "https://esm.sh/d";\n` +
+              `import("https://esm.sh/broken");\n` +
+              `export const a = d;`,
+          );
+        }
+        if (url === "https://esm.sh/d") {
+          return jsonResponse(
+            `import { a } from "https://esm.sh/a";\nexport const d = 1;`,
+          );
+        }
+        if (url === "https://esm.sh/x") {
+          await dWritten.promise;
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          return jsonResponse(
+            `import { d } from "https://esm.sh/d";\nexport const x = d;`,
+          );
+        }
+        if (url === "https://esm.sh/broken") {
+          return new Response("upstream broken", { status: 500 });
+        }
+        return new Response("not found", { status: 404 });
+      }) as typeof fetch;
+
+      await assertRejects(
+        () => fetchEsmModule("https://esm.sh/root", tmpDir, gatedAdapter, esmCache),
+        Error,
+      );
+
+      assertEquals(
+        esmCache.has("https://esm.sh/x"),
+        false,
+        "a static sibling must not be cached after reusing a poisoned provisional cycle descendant",
+      );
+      assertEquals(
+        esmCache.size,
+        0,
+        "a graph with a failed lazy cyclic branch must not publish graph-local artifacts",
+      );
+    });
+
     it("still throws when a nested URL is imported statically", async () => {
       // The emitted module's own import graph must be local before the runtime
       // loader is handed it. Leaving a static dependency remote would change

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -302,6 +302,134 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       }
     });
 
+    it("fails the load when an unlexable module keeps an unrewritable specifier", async () => {
+      // Leaving `./dep.js` verbatim would make the runtime resolve it inside
+      // `tmpDir`, so a "successful" fetch would hand back an artifact that
+      // cannot load. Failing is the only honest outcome.
+      const esmCache = new Map<string, string>();
+      const originalLexer = resolve<ModuleLexer>("ModuleLexer");
+      const rootCode = `/* reject-configured-lexer */ import { a } from "./dep.js";`;
+      register<ModuleLexer>("ModuleLexer", {
+        init: originalLexer.init?.bind(originalLexer),
+        parse(code) {
+          if (code.includes("reject-configured-lexer")) {
+            throw new Error("configured lexer rejected source");
+          }
+          return originalLexer.parse(code);
+        },
+      });
+      const rootUrl = "https://esm.sh/v135/root@1.0.0/es2022/root.js";
+      globalThis.fetch = ((input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === rootUrl) return Promise.resolve(jsonResponse(rootCode));
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }) as typeof fetch;
+
+      try {
+        await assertRejects(
+          () => fetchEsmModule(rootUrl, tmpDir, localAdapter, esmCache),
+          Error,
+          "./dep.js",
+          "a relative specifier the lexer could not rewrite must fail the load",
+        );
+        assertEquals(
+          files.size,
+          0,
+          "no artifact may be written for a module whose relative specifier stayed unrewritten",
+        );
+        assertEquals(
+          esmCache.size,
+          0,
+          "a failed load must not publish a cache entry",
+        );
+      } finally {
+        register("ModuleLexer", originalLexer);
+      }
+    });
+
+    it("still accepts an unlexable module whose specifiers are all absolute", async () => {
+      // The companion to the case above: a lexer failure is not fatal by
+      // itself, only a lexer failure that leaves a specifier resolving against
+      // the temp directory.
+      const esmCache = new Map<string, string>();
+      const originalLexer = resolve<ModuleLexer>("ModuleLexer");
+      const rootCode =
+        `/* reject-configured-lexer */ import { a } from "/_vf_modules/local.js";\nimport "react";`;
+      register<ModuleLexer>("ModuleLexer", {
+        init: originalLexer.init?.bind(originalLexer),
+        parse(code) {
+          if (code.includes("reject-configured-lexer")) {
+            throw new Error("configured lexer rejected source");
+          }
+          return originalLexer.parse(code);
+        },
+      });
+      globalThis.fetch = ((input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "https://esm.sh/root") return Promise.resolve(jsonResponse(rootCode));
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }) as typeof fetch;
+
+      try {
+        const result = await fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache);
+        assertEquals(
+          files.get(result),
+          rootCode,
+          "a locally served path and a bare specifier are both safe to leave verbatim",
+        );
+      } finally {
+        register("ModuleLexer", originalLexer);
+      }
+    });
+
+    it("resolves relative specifiers against the URL the response came from", async () => {
+      // esm.sh answers a bare or versionless path with a redirect to the
+      // canonical build directory. The relative specifiers in that body belong
+      // to the final directory, so resolving them against the requested URL
+      // would fetch an unrelated chunk — or none at all.
+      const esmCache = new Map<string, string>();
+      const requestedUrl = "https://esm.sh/pkg";
+      const finalUrl = "https://esm.sh/v135/pkg@1.0.0/es2022/pkg.mjs";
+      const chunkUrl = "https://esm.sh/v135/pkg@1.0.0/es2022/chunk.mjs";
+      const requested: string[] = [];
+      globalThis.fetch = ((input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        requested.push(url);
+        if (url === requestedUrl) {
+          const redirected = jsonResponse(`export { c } from "./chunk.mjs";`);
+          // `Response.url` is read-only, and a synthetic response reports "";
+          // defining it is how a followed redirect is simulated here.
+          Object.defineProperty(redirected, "url", { value: finalUrl });
+          return Promise.resolve(redirected);
+        }
+        if (url === chunkUrl) return Promise.resolve(jsonResponse(`export const c = 1;`));
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }) as typeof fetch;
+
+      const result = await fetchEsmModule(requestedUrl, tmpDir, localAdapter, esmCache);
+
+      assertEquals(
+        requested.includes(chunkUrl),
+        true,
+        "the relative specifier must be resolved against the final response URL",
+      );
+      assertEquals(
+        requested.includes("https://esm.sh/chunk.mjs"),
+        false,
+        "the requested URL's directory must not be used as the base after a redirect",
+      );
+      assertMatch(
+        files.get(result) ?? "",
+        /^export \{ c \} from "file:\/\/\/tmp\/esm-rewriter-test\/esm-[a-f0-9]+\.js";$/,
+        "the redirected module's chunk must be substituted with its local artifact",
+      );
+      assertEquals(
+        esmCache.get(requestedUrl),
+        result,
+        "the cache stays keyed by the requested URL, not the redirect target",
+      );
+    });
+
     it("prefetches successful template-literal dynamic imports", async () => {
       const esmCache = new Map<string, string>();
       globalThis.fetch = ((input: RequestInfo | URL) => {

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -275,8 +275,12 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
 
       const result = await fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache);
       const rootContent = files.get(result) ?? "";
-      assertMatch(rootContent, /file:\/\//);
-      assertEquals(rootContent.includes("https://esm.sh/a"), false);
+      assertEquals(
+        /^const load = \(\) => import\(`file:\/\/\/tmp\/esm-rewriter-test\/esm-[a-f0-9]+\.js`\);$/
+          .test(rootContent),
+        true,
+        "the template dynamic import must be rewritten to a local cache file",
+      );
     });
 
     it("does not abort the render when a nested URL fetch fails", async () => {

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -703,6 +703,93 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       }
     });
 
+    it("does not await a cycle owner that transitively waits on the sibling reusing its descendant", async () => {
+      // `x` reuses `d` after `d` has written a file that points at `a`'s
+      // predicted path. `a` is not on `x`'s caller stack, but `a` is waiting on
+      // `y`, and `y` is waiting on the in-flight `x`. Waiting for `a` from `x`
+      // would deadlock even though the direct `pending` set does not show it.
+      const esmCache = new Map<string, string>();
+      const dWritten = Promise.withResolvers<void>();
+      const gatedAdapter = {
+        fs: {
+          writeFile(path: string, content: string) {
+            files.set(path, content);
+            if (content.includes("export const d = a")) dWritten.resolve();
+            return Promise.resolve();
+          },
+        },
+      } as unknown as RuntimeAdapter;
+
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "https://esm.sh/root") {
+          return jsonResponse(
+            `import { a } from "https://esm.sh/a";\n` +
+              `import { x } from "https://esm.sh/x";\n` +
+              `export const root = a + x;`,
+          );
+        }
+        if (url === "https://esm.sh/a") {
+          return jsonResponse(
+            `import { d } from "https://esm.sh/d";\n` +
+              `import { y } from "https://esm.sh/y";\n` +
+              `export const a = d + y;`,
+          );
+        }
+        if (url === "https://esm.sh/d") {
+          return jsonResponse(
+            `import { a } from "https://esm.sh/a";\nexport const d = a;`,
+          );
+        }
+        if (url === "https://esm.sh/y") {
+          return jsonResponse(
+            `import { x } from "https://esm.sh/x";\nexport const y = x;`,
+          );
+        }
+        if (url === "https://esm.sh/x") {
+          await dWritten.promise;
+          return jsonResponse(
+            `import { d } from "https://esm.sh/d";\nexport const x = d;`,
+          );
+        }
+        return new Response("not found", { status: 404 });
+      }) as typeof fetch;
+
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const deadlocked = new Promise<"deadlocked">((resolve) => {
+        timer = setTimeout(() => resolve("deadlocked"), 2000);
+      });
+      try {
+        const outcome = await Promise.race([
+          fetchEsmModule("https://esm.sh/root", tmpDir, gatedAdapter, esmCache),
+          deadlocked,
+        ]);
+
+        assertEquals(
+          outcome === "deadlocked",
+          false,
+          "a sibling must not wait on a cycle owner that already waits on that sibling",
+        );
+        assertEquals(
+          files.has(outcome),
+          true,
+          "the root artifact must still be written once the transitive sibling wait closes",
+        );
+        assertEquals(
+          esmCache.has("https://esm.sh/x"),
+          true,
+          "the sibling that reused the cyclic descendant must still be published",
+        );
+        assertEquals(
+          esmCache.has("https://esm.sh/a"),
+          true,
+          "the cycle owner must be published once it writes its own predicted path",
+        );
+      } finally {
+        clearTimeout(timer);
+      }
+    });
+
     it("still throws when a nested URL is imported statically", async () => {
       // The emitted module's own import graph must be local before the runtime
       // loader is handed it. Leaving a static dependency remote would change

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -339,6 +339,63 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       );
     });
 
+    it("rejects a root that reused a cycle artifact with an unwritten dependency", async () => {
+      const esmCache = new Map<string, string>();
+      const dWritten = Promise.withResolvers<void>();
+      const gatedAdapter = {
+        fs: {
+          writeFile(path: string, content: string) {
+            files.set(path, content);
+            if (content.includes("export const d = 1")) dWritten.resolve();
+            return Promise.resolve();
+          },
+        },
+      } as unknown as RuntimeAdapter;
+
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "https://esm.sh/root") {
+          return jsonResponse(
+            `import { x } from "https://esm.sh/x";\n` +
+              `import("https://esm.sh/b");`,
+          );
+        }
+        if (url === "https://esm.sh/b") {
+          return jsonResponse(
+            `import { d } from "https://esm.sh/d";\n` +
+              `import { missing } from "https://esm.sh/broken";\n` +
+              `export const b = d;`,
+          );
+        }
+        if (url === "https://esm.sh/d") {
+          return jsonResponse(
+            `import { b } from "https://esm.sh/b";\nexport const d = 1;`,
+          );
+        }
+        if (url === "https://esm.sh/x") {
+          await dWritten.promise;
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          return jsonResponse(
+            `import { d } from "https://esm.sh/d";\nexport const x = d;`,
+          );
+        }
+        if (url === "https://esm.sh/broken") {
+          return new Response("upstream broken", { status: 500 });
+        }
+        return new Response("not found", { status: 404 });
+      }) as typeof fetch;
+
+      await assertRejects(
+        () => fetchEsmModule("https://esm.sh/root", tmpDir, gatedAdapter, esmCache),
+        Error,
+      );
+      assertEquals(
+        esmCache.size,
+        0,
+        "a root that transitively points at an unwritten cycle owner must not be published",
+      );
+    });
+
     it("still throws when a nested URL is imported statically", async () => {
       // The emitted module's own import graph must be local before the runtime
       // loader is handed it. Leaving a static dependency remote would change

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { ModuleLexer } from "#veryfront/extensions/bundler/module-lexer.ts";
 import { register, resolve } from "#veryfront/extensions/contracts.ts";
+import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { fetchEsmModule, rewriteEsmPaths } from "./esm-rewriter.ts";
 
 describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
@@ -224,15 +225,12 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
         },
       },
     } as unknown as RuntimeAdapter;
-    let originalFetch: typeof fetch;
-
     beforeEach(() => {
       files.clear();
-      originalFetch = globalThis.fetch;
     });
 
     afterEach(() => {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     });
 
     function jsonResponse(body: string, status = 200): Response {
@@ -244,16 +242,20 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
 
     it("resolves the top-level URL when all nested URLs succeed", async () => {
       const esmCache = new Map<string, string>();
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/root") {
-          return Promise.resolve(
-            jsonResponse(`import { a } from "https://esm.sh/a";`),
-          );
-        }
-        if (url === "https://esm.sh/a") return Promise.resolve(jsonResponse(`export const a = 1;`));
-        return Promise.resolve(new Response("not found", { status: 404 }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/root") {
+            return Promise.resolve(
+              jsonResponse(`import { a } from "https://esm.sh/a";`),
+            );
+          }
+          if (url === "https://esm.sh/a") {
+            return Promise.resolve(jsonResponse(`export const a = 1;`));
+          }
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
 
       const result = await fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache);
       assertEquals(result.startsWith(tmpDir), true);
@@ -277,12 +279,16 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
           return originalLexer.parse(code);
         },
       });
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/root") return Promise.resolve(jsonResponse(rootCode));
-        if (url === "https://esm.sh/a") return Promise.resolve(jsonResponse("export const a = 1;"));
-        return Promise.resolve(new Response("not found", { status: 404 }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/root") return Promise.resolve(jsonResponse(rootCode));
+          if (url === "https://esm.sh/a") {
+            return Promise.resolve(jsonResponse("export const a = 1;"));
+          }
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
 
       try {
         const result = await fetchEsmModule(
@@ -319,11 +325,13 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
         },
       });
       const rootUrl = "https://esm.sh/v135/root@1.0.0/es2022/root.js";
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === rootUrl) return Promise.resolve(jsonResponse(rootCode));
-        return Promise.resolve(new Response("not found", { status: 404 }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === rootUrl) return Promise.resolve(jsonResponse(rootCode));
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
 
       try {
         await assertRejects(
@@ -364,11 +372,13 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
         },
       });
       const rootUrl = "https://esm.sh/v135/root@1.0.0/es2022/root.js";
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === rootUrl) return Promise.resolve(jsonResponse(rootCode));
-        return Promise.resolve(new Response("not found", { status: 404 }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === rootUrl) return Promise.resolve(jsonResponse(rootCode));
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
 
       try {
         await assertRejects(
@@ -381,6 +391,48 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
           files.size,
           0,
           "no artifact may be written for a module whose template-literal path stayed unrewritten",
+        );
+      } finally {
+        register("ModuleLexer", originalLexer);
+      }
+    });
+
+    it("fails the load when a comment separates the keyword from a relative path", async () => {
+      // Anchoring the fallback on `import`/`from` would mean re-deriving JS
+      // syntax by regex: a comment in the middle is enough to hide the
+      // specifier and reinstate the unloadable artifact.
+      const esmCache = new Map<string, string>();
+      const originalLexer = resolve<ModuleLexer>("ModuleLexer");
+      const rootCode = `/* reject-configured-lexer */ import /* generated */ "./dep.js";`;
+      register<ModuleLexer>("ModuleLexer", {
+        init: originalLexer.init?.bind(originalLexer),
+        parse(code) {
+          if (code.includes("reject-configured-lexer")) {
+            throw new Error("configured lexer rejected source");
+          }
+          return originalLexer.parse(code);
+        },
+      });
+      const rootUrl = "https://esm.sh/v135/root@1.0.0/es2022/root.js";
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === rootUrl) return Promise.resolve(jsonResponse(rootCode));
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
+
+      try {
+        await assertRejects(
+          () => fetchEsmModule(rootUrl, tmpDir, localAdapter, esmCache),
+          Error,
+          "./dep.js",
+          "a comment before the specifier must not hide it from the fallback",
+        );
+        assertEquals(
+          files.size,
+          0,
+          "no artifact may be written for a comment-separated relative specifier",
         );
       } finally {
         register("ModuleLexer", originalLexer);
@@ -404,11 +456,13 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
           return originalLexer.parse(code);
         },
       });
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/root") return Promise.resolve(jsonResponse(rootCode));
-        return Promise.resolve(new Response("not found", { status: 404 }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/root") return Promise.resolve(jsonResponse(rootCode));
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
 
       try {
         const result = await fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache);
@@ -432,19 +486,21 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       const finalUrl = "https://esm.sh/v135/pkg@1.0.0/es2022/pkg.mjs";
       const chunkUrl = "https://esm.sh/v135/pkg@1.0.0/es2022/chunk.mjs";
       const requested: string[] = [];
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        requested.push(url);
-        if (url === requestedUrl) {
-          const redirected = jsonResponse(`export { c } from "./chunk.mjs";`);
-          // `Response.url` is read-only, and a synthetic response reports "";
-          // defining it is how a followed redirect is simulated here.
-          Object.defineProperty(redirected, "url", { value: finalUrl });
-          return Promise.resolve(redirected);
-        }
-        if (url === chunkUrl) return Promise.resolve(jsonResponse(`export const c = 1;`));
-        return Promise.resolve(new Response("not found", { status: 404 }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          requested.push(url);
+          if (url === requestedUrl) {
+            const redirected = jsonResponse(`export { c } from "./chunk.mjs";`);
+            // `Response.url` is read-only, and a synthetic response reports "";
+            // defining it is how a followed redirect is simulated here.
+            Object.defineProperty(redirected, "url", { value: finalUrl });
+            return Promise.resolve(redirected);
+          }
+          if (url === chunkUrl) return Promise.resolve(jsonResponse(`export const c = 1;`));
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
 
       const result = await fetchEsmModule(requestedUrl, tmpDir, localAdapter, esmCache);
 
@@ -472,14 +528,18 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
 
     it("prefetches successful template-literal dynamic imports", async () => {
       const esmCache = new Map<string, string>();
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/root") {
-          return Promise.resolve(jsonResponse("const load = () => import(`https://esm.sh/a`);"));
-        }
-        if (url === "https://esm.sh/a") return Promise.resolve(jsonResponse("export const a = 1;"));
-        return Promise.resolve(new Response("not found", { status: 404 }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/root") {
+            return Promise.resolve(jsonResponse("const load = () => import(`https://esm.sh/a`);"));
+          }
+          if (url === "https://esm.sh/a") {
+            return Promise.resolve(jsonResponse("export const a = 1;"));
+          }
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
 
       const result = await fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache);
       const rootContent = files.get(result) ?? "";
@@ -493,21 +553,25 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
 
     it("does not abort the render when a nested URL fetch fails", async () => {
       const esmCache = new Map<string, string>();
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/root") {
-          return Promise.resolve(
-            jsonResponse(
-              `import { a } from "https://esm.sh/a";\nimport("https://esm.sh/broken");`,
-            ),
-          );
-        }
-        if (url === "https://esm.sh/a") return Promise.resolve(jsonResponse(`export const a = 1;`));
-        if (url === "https://esm.sh/broken") {
-          return Promise.resolve(new Response("upstream broken", { status: 500 }));
-        }
-        return Promise.resolve(new Response("not found", { status: 404 }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/root") {
+            return Promise.resolve(
+              jsonResponse(
+                `import { a } from "https://esm.sh/a";\nimport("https://esm.sh/broken");`,
+              ),
+            );
+          }
+          if (url === "https://esm.sh/a") {
+            return Promise.resolve(jsonResponse(`export const a = 1;`));
+          }
+          if (url === "https://esm.sh/broken") {
+            return Promise.resolve(new Response("upstream broken", { status: 500 }));
+          }
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
 
       const result = await fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache);
       const rootContent = files.get(result) ?? "";
@@ -519,25 +583,27 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
 
     it("does not publish a lazy-failure cycle artifact", async () => {
       const esmCache = new Map<string, string>();
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/root") {
-          return Promise.resolve(jsonResponse(`import("https://esm.sh/a");`));
-        }
-        if (url === "https://esm.sh/a") {
-          return Promise.resolve(jsonResponse(
-            `import { b } from "https://esm.sh/b";\n` +
-              `import("https://esm.sh/broken");\nexport const a = 1;`,
-          ));
-        }
-        if (url === "https://esm.sh/b") {
-          return Promise.resolve(jsonResponse(`import { r } from "https://esm.sh/root";`));
-        }
-        if (url === "https://esm.sh/broken") {
-          return Promise.resolve(new Response("upstream broken", { status: 500 }));
-        }
-        return Promise.resolve(new Response("not found", { status: 404 }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/root") {
+            return Promise.resolve(jsonResponse(`import("https://esm.sh/a");`));
+          }
+          if (url === "https://esm.sh/a") {
+            return Promise.resolve(jsonResponse(
+              `import { b } from "https://esm.sh/b";\n` +
+                `import("https://esm.sh/broken");\nexport const a = 1;`,
+            ));
+          }
+          if (url === "https://esm.sh/b") {
+            return Promise.resolve(jsonResponse(`import { r } from "https://esm.sh/root";`));
+          }
+          if (url === "https://esm.sh/broken") {
+            return Promise.resolve(new Response("upstream broken", { status: 500 }));
+          }
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
 
       await fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache);
       assertEquals(
@@ -560,38 +626,40 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
         },
       } as unknown as RuntimeAdapter;
 
-      globalThis.fetch = (async (input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/root") {
-          return jsonResponse(
-            `import { x } from "https://esm.sh/x";\n` +
-              `import("https://esm.sh/b");`,
-          );
-        }
-        if (url === "https://esm.sh/b") {
-          return jsonResponse(
-            `import { d } from "https://esm.sh/d";\n` +
-              `import { missing } from "https://esm.sh/broken";\n` +
-              `export const b = d;`,
-          );
-        }
-        if (url === "https://esm.sh/d") {
-          return jsonResponse(
-            `import { b } from "https://esm.sh/b";\nexport const d = 1;`,
-          );
-        }
-        if (url === "https://esm.sh/x") {
-          await dWritten.promise;
-          await new Promise((resolve) => setTimeout(resolve, 0));
-          return jsonResponse(
-            `import { d } from "https://esm.sh/d";\nexport const x = d;`,
-          );
-        }
-        if (url === "https://esm.sh/broken") {
-          return new Response("upstream broken", { status: 500 });
-        }
-        return new Response("not found", { status: 404 });
-      }) as typeof fetch;
+      installMockFetch(
+        (async (input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/root") {
+            return jsonResponse(
+              `import { x } from "https://esm.sh/x";\n` +
+                `import("https://esm.sh/b");`,
+            );
+          }
+          if (url === "https://esm.sh/b") {
+            return jsonResponse(
+              `import { d } from "https://esm.sh/d";\n` +
+                `import { missing } from "https://esm.sh/broken";\n` +
+                `export const b = d;`,
+            );
+          }
+          if (url === "https://esm.sh/d") {
+            return jsonResponse(
+              `import { b } from "https://esm.sh/b";\nexport const d = 1;`,
+            );
+          }
+          if (url === "https://esm.sh/x") {
+            await dWritten.promise;
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            return jsonResponse(
+              `import { d } from "https://esm.sh/d";\nexport const x = d;`,
+            );
+          }
+          if (url === "https://esm.sh/broken") {
+            return new Response("upstream broken", { status: 500 });
+          }
+          return new Response("not found", { status: 404 });
+        }) as typeof fetch,
+      );
 
       await assertRejects(
         () => fetchEsmModule("https://esm.sh/root", tmpDir, gatedAdapter, esmCache),
@@ -617,45 +685,47 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
         },
       } as unknown as RuntimeAdapter;
 
-      globalThis.fetch = (async (input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/root") {
-          return jsonResponse(
-            `import { x } from "https://esm.sh/x";\n` +
-              `import("https://esm.sh/a");`,
-          );
-        }
-        if (url === "https://esm.sh/a") {
-          return jsonResponse(
-            `import { b } from "https://esm.sh/b";\n` +
-              `import { missing } from "https://esm.sh/broken";\n` +
-              `export const a = b;`,
-          );
-        }
-        if (url === "https://esm.sh/b") {
-          return jsonResponse(
-            `import { d } from "https://esm.sh/d";\n` +
-              `import { a } from "https://esm.sh/a";\n` +
-              `export const b = d;`,
-          );
-        }
-        if (url === "https://esm.sh/d") {
-          return jsonResponse(
-            `import { b } from "https://esm.sh/b";\nexport const d = b;`,
-          );
-        }
-        if (url === "https://esm.sh/x") {
-          await bWritten.promise;
-          await new Promise((resolve) => setTimeout(resolve, 0));
-          return jsonResponse(
-            `import { d } from "https://esm.sh/d";\nexport const x = d;`,
-          );
-        }
-        if (url === "https://esm.sh/broken") {
-          return new Response("upstream broken", { status: 500 });
-        }
-        return new Response("not found", { status: 404 });
-      }) as typeof fetch;
+      installMockFetch(
+        (async (input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/root") {
+            return jsonResponse(
+              `import { x } from "https://esm.sh/x";\n` +
+                `import("https://esm.sh/a");`,
+            );
+          }
+          if (url === "https://esm.sh/a") {
+            return jsonResponse(
+              `import { b } from "https://esm.sh/b";\n` +
+                `import { missing } from "https://esm.sh/broken";\n` +
+                `export const a = b;`,
+            );
+          }
+          if (url === "https://esm.sh/b") {
+            return jsonResponse(
+              `import { d } from "https://esm.sh/d";\n` +
+                `import { a } from "https://esm.sh/a";\n` +
+                `export const b = d;`,
+            );
+          }
+          if (url === "https://esm.sh/d") {
+            return jsonResponse(
+              `import { b } from "https://esm.sh/b";\nexport const d = b;`,
+            );
+          }
+          if (url === "https://esm.sh/x") {
+            await bWritten.promise;
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            return jsonResponse(
+              `import { d } from "https://esm.sh/d";\nexport const x = d;`,
+            );
+          }
+          if (url === "https://esm.sh/broken") {
+            return new Response("upstream broken", { status: 500 });
+          }
+          return new Response("not found", { status: 404 });
+        }) as typeof fetch,
+      );
 
       await assertRejects(
         () => fetchEsmModule("https://esm.sh/root", tmpDir, gatedAdapter, esmCache),
@@ -681,39 +751,41 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
         },
       } as unknown as RuntimeAdapter;
 
-      globalThis.fetch = (async (input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/root") {
-          return jsonResponse(
-            `import("https://esm.sh/a");\n` +
-              `import { x } from "https://esm.sh/x";\n` +
-              `export const root = x;`,
-          );
-        }
-        if (url === "https://esm.sh/a") {
-          return jsonResponse(
-            `import { d } from "https://esm.sh/d";\n` +
-              `import("https://esm.sh/broken");\n` +
-              `export const a = d;`,
-          );
-        }
-        if (url === "https://esm.sh/d") {
-          return jsonResponse(
-            `import { a } from "https://esm.sh/a";\nexport const d = 1;`,
-          );
-        }
-        if (url === "https://esm.sh/x") {
-          await dWritten.promise;
-          await new Promise((resolve) => setTimeout(resolve, 0));
-          return jsonResponse(
-            `import { d } from "https://esm.sh/d";\nexport const x = d;`,
-          );
-        }
-        if (url === "https://esm.sh/broken") {
-          return new Response("upstream broken", { status: 500 });
-        }
-        return new Response("not found", { status: 404 });
-      }) as typeof fetch;
+      installMockFetch(
+        (async (input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/root") {
+            return jsonResponse(
+              `import("https://esm.sh/a");\n` +
+                `import { x } from "https://esm.sh/x";\n` +
+                `export const root = x;`,
+            );
+          }
+          if (url === "https://esm.sh/a") {
+            return jsonResponse(
+              `import { d } from "https://esm.sh/d";\n` +
+                `import("https://esm.sh/broken");\n` +
+                `export const a = d;`,
+            );
+          }
+          if (url === "https://esm.sh/d") {
+            return jsonResponse(
+              `import { a } from "https://esm.sh/a";\nexport const d = 1;`,
+            );
+          }
+          if (url === "https://esm.sh/x") {
+            await dWritten.promise;
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            return jsonResponse(
+              `import { d } from "https://esm.sh/d";\nexport const x = d;`,
+            );
+          }
+          if (url === "https://esm.sh/broken") {
+            return new Response("upstream broken", { status: 500 });
+          }
+          return new Response("not found", { status: 404 });
+        }) as typeof fetch,
+      );
 
       const result = await fetchEsmModule(
         "https://esm.sh/root",
@@ -747,40 +819,42 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
         },
       } as unknown as RuntimeAdapter;
 
-      globalThis.fetch = (async (input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/root") {
-          return jsonResponse(
-            `import { a } from "https://esm.sh/a";\n` +
-              `import { x } from "https://esm.sh/x";\n` +
-              `export const root = a + x;`,
-          );
-        }
-        if (url === "https://esm.sh/a") {
-          return jsonResponse(
-            `import { d } from "https://esm.sh/d";\n` +
-              `import { slow } from "https://esm.sh/slow";\n` +
-              `export const a = d + slow;`,
-          );
-        }
-        if (url === "https://esm.sh/d") {
-          return jsonResponse(
-            `import { a } from "https://esm.sh/a";\nexport const d = a;`,
-          );
-        }
-        if (url === "https://esm.sh/x") {
-          await dWritten.promise;
-          return jsonResponse(
-            `import { d } from "https://esm.sh/d";\nexport const x = d;`,
-          );
-        }
-        if (url === "https://esm.sh/slow") {
-          await dWritten.promise;
-          await new Promise((resolve) => setTimeout(resolve, 20));
-          return jsonResponse("export const slow = 1;");
-        }
-        return new Response("not found", { status: 404 });
-      }) as typeof fetch;
+      installMockFetch(
+        (async (input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/root") {
+            return jsonResponse(
+              `import { a } from "https://esm.sh/a";\n` +
+                `import { x } from "https://esm.sh/x";\n` +
+                `export const root = a + x;`,
+            );
+          }
+          if (url === "https://esm.sh/a") {
+            return jsonResponse(
+              `import { d } from "https://esm.sh/d";\n` +
+                `import { slow } from "https://esm.sh/slow";\n` +
+                `export const a = d + slow;`,
+            );
+          }
+          if (url === "https://esm.sh/d") {
+            return jsonResponse(
+              `import { a } from "https://esm.sh/a";\nexport const d = a;`,
+            );
+          }
+          if (url === "https://esm.sh/x") {
+            await dWritten.promise;
+            return jsonResponse(
+              `import { d } from "https://esm.sh/d";\nexport const x = d;`,
+            );
+          }
+          if (url === "https://esm.sh/slow") {
+            await dWritten.promise;
+            await new Promise((resolve) => setTimeout(resolve, 20));
+            return jsonResponse("export const slow = 1;");
+          }
+          return new Response("not found", { status: 404 });
+        }) as typeof fetch,
+      );
 
       const result = await fetchEsmModule(
         "https://esm.sh/root",
@@ -813,28 +887,30 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
         },
       } as unknown as RuntimeAdapter;
 
-      globalThis.fetch = (async (input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/root") {
-          return jsonResponse(
-            `import { d } from "https://esm.sh/d";\n` +
-              `import { x } from "https://esm.sh/x";\n` +
-              `export const root = d + x;`,
-          );
-        }
-        if (url === "https://esm.sh/d") {
-          return jsonResponse(
-            `import { root } from "https://esm.sh/root";\nexport const d = root;`,
-          );
-        }
-        if (url === "https://esm.sh/x") {
-          await dWritten.promise;
-          return jsonResponse(
-            `import { d } from "https://esm.sh/d";\nexport const x = d;`,
-          );
-        }
-        return new Response("not found", { status: 404 });
-      }) as typeof fetch;
+      installMockFetch(
+        (async (input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/root") {
+            return jsonResponse(
+              `import { d } from "https://esm.sh/d";\n` +
+                `import { x } from "https://esm.sh/x";\n` +
+                `export const root = d + x;`,
+            );
+          }
+          if (url === "https://esm.sh/d") {
+            return jsonResponse(
+              `import { root } from "https://esm.sh/root";\nexport const d = root;`,
+            );
+          }
+          if (url === "https://esm.sh/x") {
+            await dWritten.promise;
+            return jsonResponse(
+              `import { d } from "https://esm.sh/d";\nexport const x = d;`,
+            );
+          }
+          return new Response("not found", { status: 404 });
+        }) as typeof fetch,
+      );
 
       let timer: ReturnType<typeof setTimeout> | undefined;
       const deadlocked = new Promise<"deadlocked">((resolve) => {
@@ -888,40 +964,42 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
         },
       } as unknown as RuntimeAdapter;
 
-      globalThis.fetch = (async (input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/root") {
-          return jsonResponse(
-            `import { a } from "https://esm.sh/a";\n` +
-              `import { x } from "https://esm.sh/x";\n` +
-              `export const root = a + x;`,
-          );
-        }
-        if (url === "https://esm.sh/a") {
-          return jsonResponse(
-            `import { d } from "https://esm.sh/d";\n` +
-              `import { y } from "https://esm.sh/y";\n` +
-              `export const a = d + y;`,
-          );
-        }
-        if (url === "https://esm.sh/d") {
-          return jsonResponse(
-            `import { a } from "https://esm.sh/a";\nexport const d = a;`,
-          );
-        }
-        if (url === "https://esm.sh/y") {
-          return jsonResponse(
-            `import { x } from "https://esm.sh/x";\nexport const y = x;`,
-          );
-        }
-        if (url === "https://esm.sh/x") {
-          await dWritten.promise;
-          return jsonResponse(
-            `import { d } from "https://esm.sh/d";\nexport const x = d;`,
-          );
-        }
-        return new Response("not found", { status: 404 });
-      }) as typeof fetch;
+      installMockFetch(
+        (async (input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/root") {
+            return jsonResponse(
+              `import { a } from "https://esm.sh/a";\n` +
+                `import { x } from "https://esm.sh/x";\n` +
+                `export const root = a + x;`,
+            );
+          }
+          if (url === "https://esm.sh/a") {
+            return jsonResponse(
+              `import { d } from "https://esm.sh/d";\n` +
+                `import { y } from "https://esm.sh/y";\n` +
+                `export const a = d + y;`,
+            );
+          }
+          if (url === "https://esm.sh/d") {
+            return jsonResponse(
+              `import { a } from "https://esm.sh/a";\nexport const d = a;`,
+            );
+          }
+          if (url === "https://esm.sh/y") {
+            return jsonResponse(
+              `import { x } from "https://esm.sh/x";\nexport const y = x;`,
+            );
+          }
+          if (url === "https://esm.sh/x") {
+            await dWritten.promise;
+            return jsonResponse(
+              `import { d } from "https://esm.sh/d";\nexport const x = d;`,
+            );
+          }
+          return new Response("not found", { status: 404 });
+        }) as typeof fetch,
+      );
 
       let timer: ReturnType<typeof setTimeout> | undefined;
       const deadlocked = new Promise<"deadlocked">((resolve) => {
@@ -964,27 +1042,29 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       // has produced an artifact, so neither the caller-stack `pending` set nor
       // `graph.artifacts` shows the cycle: only the recorded wait edges do.
       const esmCache = new Map<string, string>();
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/root") {
-          return Promise.resolve(jsonResponse(
-            `import { a } from "https://esm.sh/a";\n` +
-              `import { b } from "https://esm.sh/b";\n` +
-              `export const root = a + b;`,
-          ));
-        }
-        if (url === "https://esm.sh/a") {
-          return Promise.resolve(jsonResponse(
-            `import { b } from "https://esm.sh/b";\nexport const a = b;`,
-          ));
-        }
-        if (url === "https://esm.sh/b") {
-          return Promise.resolve(jsonResponse(
-            `import { a } from "https://esm.sh/a";\nexport const b = a;`,
-          ));
-        }
-        return Promise.resolve(new Response("not found", { status: 404 }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/root") {
+            return Promise.resolve(jsonResponse(
+              `import { a } from "https://esm.sh/a";\n` +
+                `import { b } from "https://esm.sh/b";\n` +
+                `export const root = a + b;`,
+            ));
+          }
+          if (url === "https://esm.sh/a") {
+            return Promise.resolve(jsonResponse(
+              `import { b } from "https://esm.sh/b";\nexport const a = b;`,
+            ));
+          }
+          if (url === "https://esm.sh/b") {
+            return Promise.resolve(jsonResponse(
+              `import { a } from "https://esm.sh/a";\nexport const b = a;`,
+            ));
+          }
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
 
       let timer: ReturnType<typeof setTimeout> | undefined;
       const deadlocked = new Promise<"deadlocked">((resolve) => {
@@ -1036,32 +1116,34 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       // the cycle is only visible by following `a` -> `b` -> `c` through the
       // recorded wait edges.
       const esmCache = new Map<string, string>();
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/root") {
-          return Promise.resolve(jsonResponse(
-            `import { a } from "https://esm.sh/a";\n` +
-              `import { b } from "https://esm.sh/b";\n` +
-              `export const root = a + b;`,
-          ));
-        }
-        if (url === "https://esm.sh/a") {
-          return Promise.resolve(jsonResponse(
-            `import { b } from "https://esm.sh/b";\nexport const a = b;`,
-          ));
-        }
-        if (url === "https://esm.sh/b") {
-          return Promise.resolve(jsonResponse(
-            `import { c } from "https://esm.sh/c";\nexport const b = c;`,
-          ));
-        }
-        if (url === "https://esm.sh/c") {
-          return Promise.resolve(jsonResponse(
-            `import { a } from "https://esm.sh/a";\nexport const c = a;`,
-          ));
-        }
-        return Promise.resolve(new Response("not found", { status: 404 }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/root") {
+            return Promise.resolve(jsonResponse(
+              `import { a } from "https://esm.sh/a";\n` +
+                `import { b } from "https://esm.sh/b";\n` +
+                `export const root = a + b;`,
+            ));
+          }
+          if (url === "https://esm.sh/a") {
+            return Promise.resolve(jsonResponse(
+              `import { b } from "https://esm.sh/b";\nexport const a = b;`,
+            ));
+          }
+          if (url === "https://esm.sh/b") {
+            return Promise.resolve(jsonResponse(
+              `import { c } from "https://esm.sh/c";\nexport const b = c;`,
+            ));
+          }
+          if (url === "https://esm.sh/c") {
+            return Promise.resolve(jsonResponse(
+              `import { a } from "https://esm.sh/a";\nexport const c = a;`,
+            ));
+          }
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
 
       let timer: ReturnType<typeof setTimeout> | undefined;
       const deadlocked = new Promise<"deadlocked">((resolve) => {
@@ -1101,16 +1183,18 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       // loader is handed it. Leaving a static dependency remote would change
       // that contract, so this failure stays fatal.
       const esmCache = new Map<string, string>();
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/root") {
-          return Promise.resolve(jsonResponse(`import { b } from "https://esm.sh/broken";`));
-        }
-        if (url === "https://esm.sh/broken") {
-          return Promise.resolve(new Response("upstream broken", { status: 500 }));
-        }
-        return Promise.resolve(new Response("not found", { status: 404 }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/root") {
+            return Promise.resolve(jsonResponse(`import { b } from "https://esm.sh/broken";`));
+          }
+          if (url === "https://esm.sh/broken") {
+            return Promise.resolve(new Response("upstream broken", { status: 500 }));
+          }
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
 
       await assertRejects(
         () => fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache),
@@ -1124,22 +1208,24 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       // The fetch budget turns that runaway into a failure rather than a hang.
       const esmCache = new Map<string, string>();
       let fetchCount = 0;
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        fetchCount++;
-        if (fetchCount > 8) throw new Error(`runaway fetch of ${url}`);
-        if (url === "https://esm.sh/cycle-a") {
-          return Promise.resolve(
-            jsonResponse(`import { b } from "https://esm.sh/cycle-b";\nexport const a = 1;`),
-          );
-        }
-        if (url === "https://esm.sh/cycle-b") {
-          return Promise.resolve(
-            jsonResponse(`import { a } from "https://esm.sh/cycle-a";\nexport const b = 2;`),
-          );
-        }
-        return Promise.resolve(new Response("not found", { status: 404 }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          fetchCount++;
+          if (fetchCount > 8) throw new Error(`runaway fetch of ${url}`);
+          if (url === "https://esm.sh/cycle-a") {
+            return Promise.resolve(
+              jsonResponse(`import { b } from "https://esm.sh/cycle-b";\nexport const a = 1;`),
+            );
+          }
+          if (url === "https://esm.sh/cycle-b") {
+            return Promise.resolve(
+              jsonResponse(`import { a } from "https://esm.sh/cycle-a";\nexport const b = 2;`),
+            );
+          }
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
 
       const result = await fetchEsmModule("https://esm.sh/cycle-a", tmpDir, localAdapter, esmCache);
 
@@ -1175,17 +1261,19 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
     it("terminates on a self-referencing module", async () => {
       const esmCache = new Map<string, string>();
       let fetchCount = 0;
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        fetchCount++;
-        if (fetchCount > 8) throw new Error(`runaway fetch of ${url}`);
-        if (url === "https://esm.sh/self") {
-          return Promise.resolve(
-            jsonResponse(`export { x } from "https://esm.sh/self";\nexport const x = 1;`),
-          );
-        }
-        return Promise.resolve(new Response("not found", { status: 404 }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          fetchCount++;
+          if (fetchCount > 8) throw new Error(`runaway fetch of ${url}`);
+          if (url === "https://esm.sh/self") {
+            return Promise.resolve(
+              jsonResponse(`export { x } from "https://esm.sh/self";\nexport const x = 1;`),
+            );
+          }
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
 
       const result = await fetchEsmModule("https://esm.sh/self", tmpDir, localAdapter, esmCache);
 
@@ -1203,22 +1291,24 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       // longest-first ordering the second import becomes the first
       // dependency's path with a dangling "-dom" glued on.
       const esmCache = new Map<string, string>();
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/react") {
-          return Promise.resolve(jsonResponse(`export const react = 1;`));
-        }
-        if (url === "https://esm.sh/react-dom") {
-          return Promise.resolve(jsonResponse(`export const reactDom = 2;`));
-        }
-        if (url === "https://esm.sh/root") {
-          return Promise.resolve(jsonResponse(
-            `import { react } from "https://esm.sh/react";\n` +
-              `import { reactDom } from "https://esm.sh/react-dom";`,
-          ));
-        }
-        return Promise.resolve(new Response("not found", { status: 404 }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/react") {
+            return Promise.resolve(jsonResponse(`export const react = 1;`));
+          }
+          if (url === "https://esm.sh/react-dom") {
+            return Promise.resolve(jsonResponse(`export const reactDom = 2;`));
+          }
+          if (url === "https://esm.sh/root") {
+            return Promise.resolve(jsonResponse(
+              `import { react } from "https://esm.sh/react";\n` +
+                `import { reactDom } from "https://esm.sh/react-dom";`,
+            ));
+          }
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
 
       const result = await fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache);
       const rootContent = files.get(result) ?? "";
@@ -1251,22 +1341,24 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       // replacement must still match whole specifiers, or the failed URL
       // becomes the shorter dependency's path with "-dom" glued on.
       const esmCache = new Map<string, string>();
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/react") {
-          return Promise.resolve(jsonResponse(`export const react = 1;`));
-        }
-        if (url === "https://esm.sh/react-dom") {
-          return Promise.resolve(new Response("upstream broken", { status: 500 }));
-        }
-        if (url === "https://esm.sh/root") {
-          return Promise.resolve(jsonResponse(
-            `import { react } from "https://esm.sh/react";\n` +
-              `const dom = () => import("https://esm.sh/react-dom");`,
-          ));
-        }
-        return Promise.resolve(new Response("not found", { status: 404 }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/react") {
+            return Promise.resolve(jsonResponse(`export const react = 1;`));
+          }
+          if (url === "https://esm.sh/react-dom") {
+            return Promise.resolve(new Response("upstream broken", { status: 500 }));
+          }
+          if (url === "https://esm.sh/root") {
+            return Promise.resolve(jsonResponse(
+              `import { react } from "https://esm.sh/react";\n` +
+                `const dom = () => import("https://esm.sh/react-dom");`,
+            ));
+          }
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
 
       const result = await fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache);
       const rootContent = files.get(result) ?? "";
@@ -1297,24 +1389,26 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       // cached would hand every later fetch an artifact importing a path that
       // does not exist.
       const esmCache = new Map<string, string>();
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/root") {
-          return Promise.resolve(jsonResponse(
-            `import { b } from "https://esm.sh/cycle-b";\n` +
-              `import { x } from "https://esm.sh/broken";`,
-          ));
-        }
-        if (url === "https://esm.sh/cycle-b") {
-          return Promise.resolve(jsonResponse(
-            `import { r } from "https://esm.sh/root";\nexport const b = 2;`,
-          ));
-        }
-        if (url === "https://esm.sh/broken") {
-          return Promise.resolve(new Response("upstream broken", { status: 500 }));
-        }
-        return Promise.resolve(new Response("not found", { status: 404 }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/root") {
+            return Promise.resolve(jsonResponse(
+              `import { b } from "https://esm.sh/cycle-b";\n` +
+                `import { x } from "https://esm.sh/broken";`,
+            ));
+          }
+          if (url === "https://esm.sh/cycle-b") {
+            return Promise.resolve(jsonResponse(
+              `import { r } from "https://esm.sh/root";\nexport const b = 2;`,
+            ));
+          }
+          if (url === "https://esm.sh/broken") {
+            return Promise.resolve(new Response("upstream broken", { status: 500 }));
+          }
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
 
       await assertRejects(
         () => fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache),
@@ -1336,26 +1430,28 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
     it("does not delete a cache entry published by a concurrent graph", async () => {
       const esmCache = new Map<string, string>();
       const concurrentRootPath = `${tmpDir}/concurrent-root.js`;
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        const url = typeof input === "string" ? input : input.toString();
-        if (url === "https://esm.sh/root") {
-          return Promise.resolve(jsonResponse(
-            `import { b } from "https://esm.sh/cycle-b";`,
-          ));
-        }
-        if (url === "https://esm.sh/cycle-b") {
-          return Promise.resolve(jsonResponse(
-            `import { r } from "https://esm.sh/root";\n` +
-              `import { x } from "https://esm.sh/broken";\n` +
-              `export const b = r;`,
-          ));
-        }
-        if (url === "https://esm.sh/broken") {
-          esmCache.set("https://esm.sh/root", concurrentRootPath);
-          return Promise.resolve(new Response("upstream broken", { status: 500 }));
-        }
-        return Promise.resolve(new Response("not found", { status: 404 }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === "https://esm.sh/root") {
+            return Promise.resolve(jsonResponse(
+              `import { b } from "https://esm.sh/cycle-b";`,
+            ));
+          }
+          if (url === "https://esm.sh/cycle-b") {
+            return Promise.resolve(jsonResponse(
+              `import { r } from "https://esm.sh/root";\n` +
+                `import { x } from "https://esm.sh/broken";\n` +
+                `export const b = r;`,
+            ));
+          }
+          if (url === "https://esm.sh/broken") {
+            esmCache.set("https://esm.sh/root", concurrentRootPath);
+            return Promise.resolve(new Response("upstream broken", { status: 500 }));
+          }
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
 
       await assertRejects(
         () => fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache),
@@ -1371,8 +1467,9 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
 
     it("still throws when the top-level URL itself fails", async () => {
       const esmCache = new Map<string, string>();
-      globalThis.fetch =
-        (() => Promise.resolve(new Response("upstream broken", { status: 500 }))) as typeof fetch;
+      installMockFetch(
+        (() => Promise.resolve(new Response("upstream broken", { status: 500 }))) as typeof fetch,
+      );
 
       await assertRejects(
         () => fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache),

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -193,6 +193,14 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       );
     });
 
+    it("prefetches a template-literal dynamic import", async () => {
+      const code = "const load = () => import(`./chunk.js`);";
+      assertEquals(
+        await rewriteEsmPaths(code, urlBase),
+        "const load = () => import(`https://esm.sh/v135/react-dom@18.2.0/es2022/chunk.js`);",
+      );
+    });
+
     it("leaves a specifier-shaped path inside a comment alone", async () => {
       const code = `// import "/v135/react.js"\nconst x = 1;`;
       assertEquals(
@@ -252,6 +260,23 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       const rootContent = files.get(result) ?? "";
       assertMatch(rootContent, /file:\/\//);
       assertEquals(/esm\.sh\/a/.test(rootContent), false);
+    });
+
+    it("prefetches successful template-literal dynamic imports", async () => {
+      const esmCache = new Map<string, string>();
+      globalThis.fetch = ((input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "https://esm.sh/root") {
+          return Promise.resolve(jsonResponse("const load = () => import(`https://esm.sh/a`);"));
+        }
+        if (url === "https://esm.sh/a") return Promise.resolve(jsonResponse("export const a = 1;"));
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }) as typeof fetch;
+
+      const result = await fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache);
+      const rootContent = files.get(result) ?? "";
+      assertMatch(rootContent, /file:\/\//);
+      assertEquals(rootContent.includes("https://esm.sh/a"), false);
     });
 
     it("does not abort the render when a nested URL fetch fails", async () => {

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -439,6 +439,47 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       }
     });
 
+    it("fails the load when an escaped quote precedes a relative path", async () => {
+      // A naive quoted-string scan pairs the escaped quote with the next real
+      // one, walks out of phase, and never sees the specifier that follows.
+      const esmCache = new Map<string, string>();
+      const originalLexer = resolve<ModuleLexer>("ModuleLexer");
+      const rootCode = `/* reject-configured-lexer */ const s = "a\\"b"; import "./dep.js";`;
+      register<ModuleLexer>("ModuleLexer", {
+        init: originalLexer.init?.bind(originalLexer),
+        parse(code) {
+          if (code.includes("reject-configured-lexer")) {
+            throw new Error("configured lexer rejected source");
+          }
+          return originalLexer.parse(code);
+        },
+      });
+      const rootUrl = "https://esm.sh/v135/root@1.0.0/es2022/root.js";
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          const url = typeof input === "string" ? input : input.toString();
+          if (url === rootUrl) return Promise.resolve(jsonResponse(rootCode));
+          return Promise.resolve(new Response("not found", { status: 404 }));
+        }) as typeof fetch,
+      );
+
+      try {
+        await assertRejects(
+          () => fetchEsmModule(rootUrl, tmpDir, localAdapter, esmCache),
+          Error,
+          "./dep.js",
+          "an escaped quote must not desynchronise the fallback scan",
+        );
+        assertEquals(
+          files.size,
+          0,
+          "no artifact may be written for a specifier hidden behind an escaped quote",
+        );
+      } finally {
+        register("ModuleLexer", originalLexer);
+      }
+    });
+
     it("still accepts an unlexable module whose specifiers are all absolute", async () => {
       // The companion to the case above: a lexer failure is not fatal by
       // itself, only a lexer failure that leaves a specifier resolving against

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -338,6 +338,11 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
         false,
         "no remote esm.sh reference survives in either side of the cycle",
       );
+      assertEquals(
+        esmCache.get("https://esm.sh/cycle-b"),
+        bPath,
+        "a cycle member stays cached once the graph that owns its back edge succeeds",
+      );
     });
 
     it("terminates on a self-referencing module", async () => {
@@ -362,6 +367,96 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
         files.get(result)?.includes(`file://${result}`),
         true,
         "the self edge resolves to the module's own local path",
+      );
+    });
+
+    it("rewrites a URL that another URL starts with to its own local path", async () => {
+      // "https://esm.sh/react" is a prefix of "https://esm.sh/react-dom", and
+      // regex alternation commits to the first branch that matches. Without
+      // longest-first ordering the second import becomes the first
+      // dependency's path with a dangling "-dom" glued on.
+      const esmCache = new Map<string, string>();
+      globalThis.fetch = ((input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "https://esm.sh/react") {
+          return Promise.resolve(jsonResponse(`export const react = 1;`));
+        }
+        if (url === "https://esm.sh/react-dom") {
+          return Promise.resolve(jsonResponse(`export const reactDom = 2;`));
+        }
+        if (url === "https://esm.sh/root") {
+          return Promise.resolve(jsonResponse(
+            `import { react } from "https://esm.sh/react";\n` +
+              `import { reactDom } from "https://esm.sh/react-dom";`,
+          ));
+        }
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }) as typeof fetch;
+
+      const result = await fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache);
+      const rootContent = files.get(result) ?? "";
+
+      const reactPath = esmCache.get("https://esm.sh/react") ?? "";
+      const domPath = esmCache.get("https://esm.sh/react-dom") ?? "";
+      assertEquals(
+        files.get(domPath),
+        `export const reactDom = 2;`,
+        "the longer URL must be fetched and written as its own module",
+      );
+
+      assertEquals(
+        rootContent,
+        `import { react } from "file://${reactPath}";\n` +
+          `import { reactDom } from "file://${domPath}";`,
+        "each import must point at the file fetched for that exact URL",
+      );
+      assertEquals(
+        rootContent.includes(`file://${reactPath}-dom`),
+        false,
+        "a prefix URL must not swallow the head of the longer URL",
+      );
+    });
+
+    it("does not cache a cycle member when an ancestor of the cycle fails", async () => {
+      // The back edge points at the entry module's predicted path, which the
+      // entry module only writes on its way out. A static dependency failing
+      // first means that file never appears, so keeping the cycle member
+      // cached would hand every later fetch an artifact importing a path that
+      // does not exist.
+      const esmCache = new Map<string, string>();
+      globalThis.fetch = ((input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "https://esm.sh/root") {
+          return Promise.resolve(jsonResponse(
+            `import { b } from "https://esm.sh/cycle-b";\n` +
+              `import { x } from "https://esm.sh/broken";`,
+          ));
+        }
+        if (url === "https://esm.sh/cycle-b") {
+          return Promise.resolve(jsonResponse(
+            `import { r } from "https://esm.sh/root";\nexport const b = 2;`,
+          ));
+        }
+        if (url === "https://esm.sh/broken") {
+          return Promise.resolve(new Response("upstream broken", { status: 500 }));
+        }
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }) as typeof fetch;
+
+      await assertRejects(
+        () => fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache),
+        Error,
+      );
+
+      assertEquals(
+        esmCache.has("https://esm.sh/cycle-b"),
+        false,
+        "a cycle member written against an unwritten ancestor must not survive the failure",
+      );
+      assertEquals(
+        [...esmCache.keys()],
+        [],
+        "no entry from a failed graph may be handed to a later fetch",
       );
     });
 

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -347,6 +347,46 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       }
     });
 
+    it("fails the load when an unlexable module keeps a template-literal path", async () => {
+      // esm.sh emits template-literal dynamic imports, so a fallback that only
+      // looked for single and double quotes would let `./chunk.js` through and
+      // write the same unloadable artifact the quoted case is rejected for.
+      const esmCache = new Map<string, string>();
+      const originalLexer = resolve<ModuleLexer>("ModuleLexer");
+      const rootCode = `/* reject-configured-lexer */ const load = () => import(\`./chunk.js\`);`;
+      register<ModuleLexer>("ModuleLexer", {
+        init: originalLexer.init?.bind(originalLexer),
+        parse(code) {
+          if (code.includes("reject-configured-lexer")) {
+            throw new Error("configured lexer rejected source");
+          }
+          return originalLexer.parse(code);
+        },
+      });
+      const rootUrl = "https://esm.sh/v135/root@1.0.0/es2022/root.js";
+      globalThis.fetch = ((input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === rootUrl) return Promise.resolve(jsonResponse(rootCode));
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }) as typeof fetch;
+
+      try {
+        await assertRejects(
+          () => fetchEsmModule(rootUrl, tmpDir, localAdapter, esmCache),
+          Error,
+          "./chunk.js",
+          "a backtick-quoted relative specifier must fail the load like a quoted one",
+        );
+        assertEquals(
+          files.size,
+          0,
+          "no artifact may be written for a module whose template-literal path stayed unrewritten",
+        );
+      } finally {
+        register("ModuleLexer", originalLexer);
+      }
+    });
+
     it("still accepts an unlexable module whose specifiers are all absolute", async () => {
       // The companion to the case above: a lexer failure is not fatal by
       // itself, only a lexer failure that leaves a specifier resolving against

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -182,6 +182,17 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       );
     });
 
+    it("does not rewrite an esm.sh URL stored in ordinary string data", async () => {
+      const code = `import "https://esm.sh/v135/react.js";\n` +
+        `const endpoint = "https://esm.sh/v135/react.js";`;
+      const result = await rewriteEsmPaths(code, urlBase);
+      assertEquals(
+        result,
+        code,
+        "only lexer-reported specifiers may be replaced; string data must remain unchanged",
+      );
+    });
+
     it("leaves a specifier-shaped path inside a comment alone", async () => {
       const code = `// import "/v135/react.js"\nconst x = 1;`;
       assertEquals(

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -763,6 +763,42 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       );
     });
 
+    it("does not delete a cache entry published by a concurrent graph", async () => {
+      const esmCache = new Map<string, string>();
+      const concurrentRootPath = `${tmpDir}/concurrent-root.js`;
+      globalThis.fetch = ((input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "https://esm.sh/root") {
+          return Promise.resolve(jsonResponse(
+            `import { b } from "https://esm.sh/cycle-b";`,
+          ));
+        }
+        if (url === "https://esm.sh/cycle-b") {
+          return Promise.resolve(jsonResponse(
+            `import { r } from "https://esm.sh/root";\n` +
+              `import { x } from "https://esm.sh/broken";\n` +
+              `export const b = r;`,
+          ));
+        }
+        if (url === "https://esm.sh/broken") {
+          esmCache.set("https://esm.sh/root", concurrentRootPath);
+          return Promise.resolve(new Response("upstream broken", { status: 500 }));
+        }
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }) as typeof fetch;
+
+      await assertRejects(
+        () => fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache),
+        Error,
+      );
+
+      assertEquals(
+        esmCache.get("https://esm.sh/root"),
+        concurrentRootPath,
+        "a failed graph must not remove another graph's published root artifact",
+      );
+    });
+
     it("still throws when the top-level URL itself fails", async () => {
       const esmCache = new Map<string, string>();
       globalThis.fetch =

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -267,14 +267,20 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
     });
 
     it("keeps the regex fallback when final specifier substitution cannot lex", async () => {
+      // The initial rewrite must survive, or the load is refused before it ever
+      // reaches the discovery and substitution steps this covers. So the stub
+      // lexer serves the first parse of the root and rejects the later ones,
+      // which is exactly the shape of a lexer that chokes on rewritten source.
       const esmCache = new Map<string, string>();
       const originalLexer = resolve<ModuleLexer>("ModuleLexer");
       const rootCode = `/* reject-configured-lexer */ import { a } from "https://esm.sh/a";`;
+      let rootParses = 0;
       register<ModuleLexer>("ModuleLexer", {
         init: originalLexer.init?.bind(originalLexer),
         parse(code) {
           if (code.includes("reject-configured-lexer")) {
-            throw new Error("configured lexer rejected source");
+            rootParses++;
+            if (rootParses > 1) throw new Error("configured lexer rejected source");
           }
           return originalLexer.parse(code);
         },
@@ -303,15 +309,21 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
           rootCode,
           "a final lexer failure must retain the fetched source and its remote specifier",
         );
+        assertEquals(
+          rootParses > 1,
+          true,
+          "the case is only meaningful if a later parse of the root actually ran and failed",
+        );
       } finally {
         register("ModuleLexer", originalLexer);
       }
     });
 
-    it("fails the load when an unlexable module keeps an unrewritable specifier", async () => {
-      // Leaving `./dep.js` verbatim would make the runtime resolve it inside
-      // `tmpDir`, so a "successful" fetch would hand back an artifact that
-      // cannot load. Failing is the only honest outcome.
+    it("refuses a module the lexer cannot read instead of emitting it unrewritten", async () => {
+      // Emitting it verbatim would leave `./dep.js` resolving inside tmpDir, so
+      // the fetch would report success and hand back an unloadable artifact.
+      // Deciding which unreadable bundles are safe needs the lexer that just
+      // failed, so none of them are.
       const esmCache = new Map<string, string>();
       const originalLexer = resolve<ModuleLexer>("ModuleLexer");
       const rootCode = `/* reject-configured-lexer */ import { a } from "./dep.js";`;
@@ -337,199 +349,30 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
         await assertRejects(
           () => fetchEsmModule(rootUrl, tmpDir, localAdapter, esmCache),
           Error,
-          "./dep.js",
-          "a relative specifier the lexer could not rewrite must fail the load",
+          "could not be lexed",
+          "an unreadable bundle must fail the load, not ship a verbatim artifact",
         );
         assertEquals(
           files.size,
           0,
-          "no artifact may be written for a module whose relative specifier stayed unrewritten",
+          "no artifact may be written for a module whose specifiers could not be rewritten",
         );
-        assertEquals(
-          esmCache.size,
-          0,
-          "a failed load must not publish a cache entry",
-        );
+        assertEquals(esmCache.size, 0, "a failed load must not publish a cache entry");
       } finally {
         register("ModuleLexer", originalLexer);
       }
     });
 
-    it("fails the load when an unlexable module keeps a template-literal path", async () => {
-      // esm.sh emits template-literal dynamic imports, so a fallback that only
-      // looked for single and double quotes would let `./chunk.js` through and
-      // write the same unloadable artifact the quoted case is rejected for.
+    it("refuses an unreadable bundle even when its specifiers are all absolute", async () => {
+      // The permissive reading - "verbatim is fine as long as nothing relative
+      // survives" - is what a regex scan would have to establish, and it cannot
+      // do so reliably: a quote inside a comment or a regular-expression
+      // literal desynchronises it, and an escaped specifier such as `.\/dep.js`
+      // does not compare equal to the path it denotes. Both read as "nothing to
+      // rewrite". There is deliberately no such escape hatch.
       const esmCache = new Map<string, string>();
       const originalLexer = resolve<ModuleLexer>("ModuleLexer");
-      const rootCode = `/* reject-configured-lexer */ const load = () => import(\`./chunk.js\`);`;
-      register<ModuleLexer>("ModuleLexer", {
-        init: originalLexer.init?.bind(originalLexer),
-        parse(code) {
-          if (code.includes("reject-configured-lexer")) {
-            throw new Error("configured lexer rejected source");
-          }
-          return originalLexer.parse(code);
-        },
-      });
-      const rootUrl = "https://esm.sh/v135/root@1.0.0/es2022/root.js";
-      installMockFetch(
-        ((input: RequestInfo | URL) => {
-          const url = typeof input === "string" ? input : input.toString();
-          if (url === rootUrl) return Promise.resolve(jsonResponse(rootCode));
-          return Promise.resolve(new Response("not found", { status: 404 }));
-        }) as typeof fetch,
-      );
-
-      try {
-        await assertRejects(
-          () => fetchEsmModule(rootUrl, tmpDir, localAdapter, esmCache),
-          Error,
-          "./chunk.js",
-          "a backtick-quoted relative specifier must fail the load like a quoted one",
-        );
-        assertEquals(
-          files.size,
-          0,
-          "no artifact may be written for a module whose template-literal path stayed unrewritten",
-        );
-      } finally {
-        register("ModuleLexer", originalLexer);
-      }
-    });
-
-    it("fails the load when a comment separates the keyword from a relative path", async () => {
-      // Anchoring the fallback on `import`/`from` would mean re-deriving JS
-      // syntax by regex: a comment in the middle is enough to hide the
-      // specifier and reinstate the unloadable artifact.
-      const esmCache = new Map<string, string>();
-      const originalLexer = resolve<ModuleLexer>("ModuleLexer");
-      const rootCode = `/* reject-configured-lexer */ import /* generated */ "./dep.js";`;
-      register<ModuleLexer>("ModuleLexer", {
-        init: originalLexer.init?.bind(originalLexer),
-        parse(code) {
-          if (code.includes("reject-configured-lexer")) {
-            throw new Error("configured lexer rejected source");
-          }
-          return originalLexer.parse(code);
-        },
-      });
-      const rootUrl = "https://esm.sh/v135/root@1.0.0/es2022/root.js";
-      installMockFetch(
-        ((input: RequestInfo | URL) => {
-          const url = typeof input === "string" ? input : input.toString();
-          if (url === rootUrl) return Promise.resolve(jsonResponse(rootCode));
-          return Promise.resolve(new Response("not found", { status: 404 }));
-        }) as typeof fetch,
-      );
-
-      try {
-        await assertRejects(
-          () => fetchEsmModule(rootUrl, tmpDir, localAdapter, esmCache),
-          Error,
-          "./dep.js",
-          "a comment before the specifier must not hide it from the fallback",
-        );
-        assertEquals(
-          files.size,
-          0,
-          "no artifact may be written for a comment-separated relative specifier",
-        );
-      } finally {
-        register("ModuleLexer", originalLexer);
-      }
-    });
-
-    it("fails the load when an escaped quote precedes a relative path", async () => {
-      // A naive quoted-string scan pairs the escaped quote with the next real
-      // one, walks out of phase, and never sees the specifier that follows.
-      const esmCache = new Map<string, string>();
-      const originalLexer = resolve<ModuleLexer>("ModuleLexer");
-      const rootCode = `/* reject-configured-lexer */ const s = "a\\"b"; import "./dep.js";`;
-      register<ModuleLexer>("ModuleLexer", {
-        init: originalLexer.init?.bind(originalLexer),
-        parse(code) {
-          if (code.includes("reject-configured-lexer")) {
-            throw new Error("configured lexer rejected source");
-          }
-          return originalLexer.parse(code);
-        },
-      });
-      const rootUrl = "https://esm.sh/v135/root@1.0.0/es2022/root.js";
-      installMockFetch(
-        ((input: RequestInfo | URL) => {
-          const url = typeof input === "string" ? input : input.toString();
-          if (url === rootUrl) return Promise.resolve(jsonResponse(rootCode));
-          return Promise.resolve(new Response("not found", { status: 404 }));
-        }) as typeof fetch,
-      );
-
-      try {
-        await assertRejects(
-          () => fetchEsmModule(rootUrl, tmpDir, localAdapter, esmCache),
-          Error,
-          "./dep.js",
-          "an escaped quote must not desynchronise the fallback scan",
-        );
-        assertEquals(
-          files.size,
-          0,
-          "no artifact may be written for a specifier hidden behind an escaped quote",
-        );
-      } finally {
-        register("ModuleLexer", originalLexer);
-      }
-    });
-
-    it("fails the load when a line continuation precedes a relative path", async () => {
-      // `\\.` cannot consume a backslash-newline pair, so an escape scan built
-      // on it would stop inside the first string and pair its closing quote
-      // with the import's opening one.
-      const esmCache = new Map<string, string>();
-      const originalLexer = resolve<ModuleLexer>("ModuleLexer");
-      const rootCode = `/* reject-configured-lexer */ const s = "a\\\nb"; import "./dep.js";`;
-      register<ModuleLexer>("ModuleLexer", {
-        init: originalLexer.init?.bind(originalLexer),
-        parse(code) {
-          if (code.includes("reject-configured-lexer")) {
-            throw new Error("configured lexer rejected source");
-          }
-          return originalLexer.parse(code);
-        },
-      });
-      const rootUrl = "https://esm.sh/v135/root@1.0.0/es2022/root.js";
-      installMockFetch(
-        ((input: RequestInfo | URL) => {
-          const url = typeof input === "string" ? input : input.toString();
-          if (url === rootUrl) return Promise.resolve(jsonResponse(rootCode));
-          return Promise.resolve(new Response("not found", { status: 404 }));
-        }) as typeof fetch,
-      );
-
-      try {
-        await assertRejects(
-          () => fetchEsmModule(rootUrl, tmpDir, localAdapter, esmCache),
-          Error,
-          "./dep.js",
-          "a line continuation must not desynchronise the fallback scan",
-        );
-        assertEquals(
-          files.size,
-          0,
-          "no artifact may be written for a specifier hidden behind a line continuation",
-        );
-      } finally {
-        register("ModuleLexer", originalLexer);
-      }
-    });
-
-    it("still accepts an unlexable module whose specifiers are all absolute", async () => {
-      // The companion to the case above: a lexer failure is not fatal by
-      // itself, only a lexer failure that leaves a specifier resolving against
-      // the temp directory.
-      const esmCache = new Map<string, string>();
-      const originalLexer = resolve<ModuleLexer>("ModuleLexer");
-      const rootCode =
-        `/* reject-configured-lexer */ import { a } from "/_vf_modules/local.js";\nimport "react";`;
+      const rootCode = `/* reject-configured-lexer */ const r = /"/; import "https://esm.sh/a";`;
       register<ModuleLexer>("ModuleLexer", {
         init: originalLexer.init?.bind(originalLexer),
         parse(code) {
@@ -548,12 +391,13 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       );
 
       try {
-        const result = await fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache);
-        assertEquals(
-          files.get(result),
-          rootCode,
-          "a locally served path and a bare specifier are both safe to leave verbatim",
+        await assertRejects(
+          () => fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache),
+          Error,
+          "could not be lexed",
+          "an all-absolute bundle is still refused, because proving it needs the failed lexer",
         );
+        assertEquals(files.size, 0, "no artifact may be written for an unreadable bundle");
       } finally {
         register("ModuleLexer", originalLexer);
       }

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -40,13 +40,111 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
     it("should not rewrite veryfront module paths via from", () => {
       const code = `import { something } from "/_vf_modules/my-module.js"`;
       const result = rewriteEsmPaths(code, urlBase);
-      assertEquals(result.includes("/_vf_modules/my-module.js"), true);
+      // A substring check would still hold for "https://esm.sh/_vf_modules/...",
+      // so the oracle has to be the whole output.
+      assertEquals(
+        result,
+        code,
+        "/_vf_modules paths are served locally and must be left untouched",
+      );
+      assertEquals(
+        result.includes("esm.sh"),
+        false,
+        "a locally served module path must never be pointed at esm.sh",
+      );
+    });
+
+    it("should not rewrite veryfront module paths in the other specifier forms", () => {
+      for (
+        const code of [
+          `import "/_vf_modules/my-module.js"`,
+          `export * from "/_vf_modules/my-module.js"`,
+          `export { something } from "/_vf_modules/my-module.js"`,
+        ]
+      ) {
+        assertEquals(
+          rewriteEsmPaths(code, urlBase),
+          code,
+          "every specifier form must leave a locally served path untouched",
+        );
+      }
     });
 
     it("should not rewrite _veryfront paths via from", () => {
       const code = `import { something } from "/_veryfront/modules/component.js"`;
       const result = rewriteEsmPaths(code, urlBase);
-      assertEquals(result.includes("/_veryfront/modules/component.js"), true);
+      assertEquals(
+        result,
+        code,
+        "_veryfront virtual-module paths are served locally and must survive the rewrite untouched",
+      );
+      assertEquals(
+        result.includes("esm.sh"),
+        false,
+        "a local virtual-module path must never be pointed at esm.sh",
+      );
+    });
+
+    it("should not rewrite _veryfront paths in the other specifier forms", () => {
+      for (
+        const code of [
+          `import "/_veryfront/modules/component.js"`,
+          `export * from "/_veryfront/modules/component.js"`,
+          `export { component } from "/_veryfront/modules/component.js"`,
+        ]
+      ) {
+        assertEquals(
+          rewriteEsmPaths(code, urlBase),
+          code,
+          "every specifier form must leave a virtual-module path untouched",
+        );
+      }
+    });
+
+    it("resolves absolute specifiers through esm.sh", () => {
+      assertEquals(
+        rewriteEsmPaths(`import "/v135/react.js"`, urlBase),
+        `import "https://esm.sh/v135/react.js"`,
+        "a bare absolute path belongs to esm.sh, not to the local server",
+      );
+      assertEquals(
+        rewriteEsmPaths(`import React from "/v135/react.js"`, urlBase),
+        `import React from "https://esm.sh/v135/react.js"`,
+        "a bare absolute path belongs to esm.sh, not to the local server",
+      );
+      assertEquals(
+        rewriteEsmPaths(`export * from "/v135/a.js"`, urlBase),
+        `export * from "https://esm.sh/v135/a.js"`,
+        "a bare absolute path belongs to esm.sh, not to the local server",
+      );
+      assertEquals(
+        rewriteEsmPaths(`export { b } from "/v135/b.js"`, urlBase),
+        `export { b } from "https://esm.sh/v135/b.js"`,
+        "a bare absolute path belongs to esm.sh, not to the local server",
+      );
+    });
+
+    it("resolves relative specifiers against the module's own URL", () => {
+      assertEquals(
+        rewriteEsmPaths(`import x from "./chunk.js"`, urlBase),
+        `import x from "https://esm.sh/v135/react-dom@18.2.0/es2022/chunk.js"`,
+        "a relative specifier resolves against the fetched module's URL",
+      );
+      assertEquals(
+        rewriteEsmPaths(`import "./chunk.js"`, urlBase),
+        `import "https://esm.sh/v135/react-dom@18.2.0/es2022/chunk.js"`,
+        "a relative specifier resolves against the fetched module's URL",
+      );
+      assertEquals(
+        rewriteEsmPaths(`export * from "./chunk.js"`, urlBase),
+        `export * from "https://esm.sh/v135/react-dom@18.2.0/es2022/chunk.js"`,
+        "a relative specifier resolves against the fetched module's URL",
+      );
+      assertEquals(
+        rewriteEsmPaths(`export { b } from "../es2021/b.js"`, urlBase),
+        `export { b } from "https://esm.sh/v135/react-dom@18.2.0/es2021/b.js"`,
+        "a parent-relative specifier resolves against the fetched module's URL",
+      );
     });
 
     it("should handle code with mixed import types", () => {

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -790,6 +790,144 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       }
     });
 
+    it("breaks a cycle between two siblings that are both still in flight", async () => {
+      // The root pulls `a` and `b` concurrently and they statically import each
+      // other. Each sibling finds the other in `graph.inFlight` before either
+      // has produced an artifact, so neither the caller-stack `pending` set nor
+      // `graph.artifacts` shows the cycle: only the recorded wait edges do.
+      const esmCache = new Map<string, string>();
+      globalThis.fetch = ((input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "https://esm.sh/root") {
+          return Promise.resolve(jsonResponse(
+            `import { a } from "https://esm.sh/a";\n` +
+              `import { b } from "https://esm.sh/b";\n` +
+              `export const root = a + b;`,
+          ));
+        }
+        if (url === "https://esm.sh/a") {
+          return Promise.resolve(jsonResponse(
+            `import { b } from "https://esm.sh/b";\nexport const a = b;`,
+          ));
+        }
+        if (url === "https://esm.sh/b") {
+          return Promise.resolve(jsonResponse(
+            `import { a } from "https://esm.sh/a";\nexport const b = a;`,
+          ));
+        }
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }) as typeof fetch;
+
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const deadlocked = new Promise<"deadlocked">((resolve) => {
+        timer = setTimeout(() => resolve("deadlocked"), 2000);
+      });
+      try {
+        const outcome = await Promise.race([
+          fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache),
+          deadlocked,
+        ]);
+
+        assertEquals(
+          outcome === "deadlocked",
+          false,
+          "two in-flight siblings that import each other must not wait on each other forever",
+        );
+        assertEquals(
+          files.has(outcome),
+          true,
+          "the root artifact must be written once the sibling cycle is broken",
+        );
+        for (const member of ["https://esm.sh/a", "https://esm.sh/b"]) {
+          assertEquals(
+            esmCache.has(member),
+            true,
+            `${member} must be published once the whole graph materializes`,
+          );
+        }
+        const bContent = files.get(esmCache.get("https://esm.sh/b") ?? "") ?? "";
+        assertMatch(bContent, /file:\/\//);
+        assertEquals(
+          /esm\.sh\/a/.test(bContent),
+          false,
+          "the sibling that broke the cycle must still point at its owner's local path",
+        );
+        assertEquals(
+          files.has((esmCache.get("https://esm.sh/a") ?? "").replace("file://", "")),
+          true,
+          "the predicted path the cycle-breaking sibling emitted must actually be written",
+        );
+      } finally {
+        clearTimeout(timer);
+      }
+    });
+
+    it("breaks a sibling cycle that closes through a third module", async () => {
+      // `a` and `b` start concurrently, `b` reaches `c`, and `c` imports `a`.
+      // No single frame's `pending` set contains `a` when `c` asks for it, so
+      // the cycle is only visible by following `a` -> `b` -> `c` through the
+      // recorded wait edges.
+      const esmCache = new Map<string, string>();
+      globalThis.fetch = ((input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "https://esm.sh/root") {
+          return Promise.resolve(jsonResponse(
+            `import { a } from "https://esm.sh/a";\n` +
+              `import { b } from "https://esm.sh/b";\n` +
+              `export const root = a + b;`,
+          ));
+        }
+        if (url === "https://esm.sh/a") {
+          return Promise.resolve(jsonResponse(
+            `import { b } from "https://esm.sh/b";\nexport const a = b;`,
+          ));
+        }
+        if (url === "https://esm.sh/b") {
+          return Promise.resolve(jsonResponse(
+            `import { c } from "https://esm.sh/c";\nexport const b = c;`,
+          ));
+        }
+        if (url === "https://esm.sh/c") {
+          return Promise.resolve(jsonResponse(
+            `import { a } from "https://esm.sh/a";\nexport const c = a;`,
+          ));
+        }
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }) as typeof fetch;
+
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const deadlocked = new Promise<"deadlocked">((resolve) => {
+        timer = setTimeout(() => resolve("deadlocked"), 2000);
+      });
+      try {
+        const outcome = await Promise.race([
+          fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache),
+          deadlocked,
+        ]);
+
+        assertEquals(
+          outcome === "deadlocked",
+          false,
+          "a transitive sibling cycle must be broken rather than awaited",
+        );
+        for (const member of ["https://esm.sh/a", "https://esm.sh/b", "https://esm.sh/c"]) {
+          assertEquals(
+            esmCache.has(member),
+            true,
+            `${member} must be published once the transitive sibling cycle materializes`,
+          );
+        }
+        const cContent = files.get(esmCache.get("https://esm.sh/c") ?? "") ?? "";
+        assertEquals(
+          /esm\.sh\/a/.test(cContent),
+          false,
+          "the module that closed the cycle must point at a local path for its owner",
+        );
+      } finally {
+        clearTimeout(timer);
+      }
+    });
+
     it("still throws when a nested URL is imported statically", async () => {
       // The emitted module's own import graph must be local before the runtime
       // loader is handed it. Leaving a static dependency remote would change

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -280,6 +280,36 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       assertMatch(rootContent, /esm\.sh\/broken/);
     });
 
+    it("does not publish a lazy-failure cycle artifact", async () => {
+      const esmCache = new Map<string, string>();
+      globalThis.fetch = ((input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "https://esm.sh/root") {
+          return Promise.resolve(jsonResponse(`import("https://esm.sh/a");`));
+        }
+        if (url === "https://esm.sh/a") {
+          return Promise.resolve(jsonResponse(
+            `import { b } from "https://esm.sh/b";\n` +
+              `import("https://esm.sh/broken");\nexport const a = 1;`,
+          ));
+        }
+        if (url === "https://esm.sh/b") {
+          return Promise.resolve(jsonResponse(`import { r } from "https://esm.sh/root";`));
+        }
+        if (url === "https://esm.sh/broken") {
+          return Promise.resolve(new Response("upstream broken", { status: 500 }));
+        }
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }) as typeof fetch;
+
+      await fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache);
+      assertEquals(
+        esmCache.size,
+        0,
+        "a cycle containing a failed lazy subtree must not publish partial artifacts",
+      );
+    });
+
     it("still throws when a nested URL is imported statically", async () => {
       // The emitted module's own import graph must be local before the runtime
       // loader is handed it. Leaving a static dependency remote would change

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -396,7 +396,7 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       );
     });
 
-    it("rejects a static sibling that reused a poisoned lazy cycle descendant", async () => {
+    it("reuses a materialized cycle descendant after an unrelated lazy failure", async () => {
       const esmCache = new Map<string, string>();
       const dWritten = Promise.withResolvers<void>();
       const gatedAdapter = {
@@ -443,20 +443,22 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
         return new Response("not found", { status: 404 });
       }) as typeof fetch;
 
-      await assertRejects(
-        () => fetchEsmModule("https://esm.sh/root", tmpDir, gatedAdapter, esmCache),
-        Error,
+      const result = await fetchEsmModule(
+        "https://esm.sh/root",
+        tmpDir,
+        gatedAdapter,
+        esmCache,
       );
 
       assertEquals(
-        esmCache.has("https://esm.sh/x"),
-        false,
-        "a static sibling must not be cached after reusing a poisoned provisional cycle descendant",
+        files.has(result),
+        true,
+        "the root must resolve once every predicted cycle path has materialized",
       );
       assertEquals(
         esmCache.size,
         0,
-        "a graph with a failed lazy cyclic branch must not publish graph-local artifacts",
+        "the lazy failure still keeps provisional graph artifacts out of the shared cache",
       );
     });
 

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -396,6 +396,70 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       );
     });
 
+    it("rejects a poisoned root when an intermediate hides an unwritten owner", async () => {
+      const esmCache = new Map<string, string>();
+      const bWritten = Promise.withResolvers<void>();
+      const gatedAdapter = {
+        fs: {
+          writeFile(path: string, content: string) {
+            files.set(path, content);
+            if (content.includes("export const b = d")) bWritten.resolve();
+            return Promise.resolve();
+          },
+        },
+      } as unknown as RuntimeAdapter;
+
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "https://esm.sh/root") {
+          return jsonResponse(
+            `import { x } from "https://esm.sh/x";\n` +
+              `import("https://esm.sh/a");`,
+          );
+        }
+        if (url === "https://esm.sh/a") {
+          return jsonResponse(
+            `import { b } from "https://esm.sh/b";\n` +
+              `import { missing } from "https://esm.sh/broken";\n` +
+              `export const a = b;`,
+          );
+        }
+        if (url === "https://esm.sh/b") {
+          return jsonResponse(
+            `import { d } from "https://esm.sh/d";\n` +
+              `import { a } from "https://esm.sh/a";\n` +
+              `export const b = d;`,
+          );
+        }
+        if (url === "https://esm.sh/d") {
+          return jsonResponse(
+            `import { b } from "https://esm.sh/b";\nexport const d = b;`,
+          );
+        }
+        if (url === "https://esm.sh/x") {
+          await bWritten.promise;
+          await new Promise((resolve) => setTimeout(resolve, 0));
+          return jsonResponse(
+            `import { d } from "https://esm.sh/d";\nexport const x = d;`,
+          );
+        }
+        if (url === "https://esm.sh/broken") {
+          return new Response("upstream broken", { status: 500 });
+        }
+        return new Response("not found", { status: 404 });
+      }) as typeof fetch;
+
+      await assertRejects(
+        () => fetchEsmModule("https://esm.sh/root", tmpDir, gatedAdapter, esmCache),
+        Error,
+      );
+      assertEquals(
+        esmCache.size,
+        0,
+        "a poisoned root whose static chain hides an unwritten cycle owner must not publish",
+      );
+    });
+
     it("reuses a materialized cycle descendant after an unrelated lazy failure", async () => {
       const esmCache = new Map<string, string>();
       const dWritten = Promise.withResolvers<void>();

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.test.ts
@@ -417,6 +417,52 @@ describe("rendering/orchestrator/module-loader/esm-rewriter", () => {
       );
     });
 
+    it("leaves a failed lazy URL intact when a fetched URL is its prefix", async () => {
+      // "https://esm.sh/react" fetches and enters the replacement map;
+      // "https://esm.sh/react-dom" is only imported lazily and fails, so it is
+      // absent from the map and longest-first ordering cannot protect it. The
+      // replacement must still match whole specifiers, or the failed URL
+      // becomes the shorter dependency's path with "-dom" glued on.
+      const esmCache = new Map<string, string>();
+      globalThis.fetch = ((input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url === "https://esm.sh/react") {
+          return Promise.resolve(jsonResponse(`export const react = 1;`));
+        }
+        if (url === "https://esm.sh/react-dom") {
+          return Promise.resolve(new Response("upstream broken", { status: 500 }));
+        }
+        if (url === "https://esm.sh/root") {
+          return Promise.resolve(jsonResponse(
+            `import { react } from "https://esm.sh/react";\n` +
+              `const dom = () => import("https://esm.sh/react-dom");`,
+          ));
+        }
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }) as typeof fetch;
+
+      const result = await fetchEsmModule("https://esm.sh/root", tmpDir, localAdapter, esmCache);
+      const rootContent = files.get(result) ?? "";
+      const reactPath = esmCache.get("https://esm.sh/react") ?? "";
+
+      assertEquals(
+        rootContent,
+        `import { react } from "file://${reactPath}";\n` +
+          `const dom = () => import("https://esm.sh/react-dom");`,
+        "the failed lazy URL must survive verbatim for runtime resolution",
+      );
+      assertEquals(
+        rootContent.includes(`file://${reactPath}-dom`),
+        false,
+        "a fetched prefix URL must not be substituted inside the failed longer URL",
+      );
+      assertEquals(
+        esmCache.has("https://esm.sh/react-dom"),
+        false,
+        "a failed lazy URL must not be cached as resolved",
+      );
+    });
+
     it("does not cache a cycle member when an ancestor of the cycle fails", async () => {
       // The back edge points at the entry module's predicted path, which the
       // entry module only writes on its way out. A static dependency failing

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -2,11 +2,9 @@ import { rendererLogger } from "#veryfront/utils";
 import { MODULE_NOT_FOUND } from "#veryfront/errors";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { generateHash } from "./cache.ts";
-import { parseImports } from "#veryfront/transforms/esm/lexer.ts";
+import { parseImports, replaceSpecifiers } from "#veryfront/transforms/esm/lexer.ts";
 
 const logger = rendererLogger.component("module-loader");
-
-type PathResolver = (path: string) => string;
 
 /**
  * Specifiers `code` imports statically, as opposed to through `import(...)` or
@@ -34,42 +32,41 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-export function rewriteEsmPaths(code: string, urlBase: string): string {
-  // Skip veryfront module paths - they're served locally, not via esm.sh
-  const resolveAbsolute: PathResolver = (path) =>
-    path.startsWith("/_vf_modules/") || path.startsWith("/_veryfront/")
-      ? path
-      : `https://esm.sh${path}`;
-  const resolveRelative: PathResolver = (path) => new URL(path, urlBase).href;
-
-  const patterns: Array<[RegExp, number, PathResolver]> = [
-    [/import\s*(["'])(\/[^"']+)\1/g, 2, resolveAbsolute],
-    [/from\s*(["'])(\/[^"']+)\1/g, 2, resolveAbsolute],
-    [/export\s*\*\s*from\s*(["'])(\/[^"']+)\1/g, 2, resolveAbsolute],
-    [/export\s*\{([^}]+)\}\s*from\s*(["'])(\/[^"']+)\2/g, 3, resolveAbsolute],
-
-    [/import\s*(["'])(\.\.?\/[^"']+)\1/g, 2, resolveRelative],
-    [/from\s*(["'])(\.\.?\/[^"']+)\1/g, 2, resolveRelative],
-    [/export\s*\*\s*from\s*(["'])(\.\.?\/[^"']+)\1/g, 2, resolveRelative],
-    [/export\s*\{([^}]+)\}\s*from\s*(["'])(\.\.?\/[^"']+)\2/g, 3, resolveRelative],
-  ];
-
-  let result = code;
-
-  for (const [pattern, pathIndex, resolver] of patterns) {
-    result = result.replace(pattern, (...args) => {
-      const match = args[0];
-      // args[0] is the whole match, so capture group N is args[N].
-      const path = args[pathIndex];
-      const quote = pathIndex === 3 ? args[2] : args[1];
-
-      const resolved = resolver(path);
-      const pathPattern = new RegExp(`${quote}${escapeRegExp(path)}${quote}`);
-      return match.replace(pathPattern, `${quote}${resolved}${quote}`);
+/**
+ * Point an esm.sh bundle's server-absolute and relative specifiers at absolute
+ * esm.sh URLs, so the module still resolves once it is written to a temp file.
+ *
+ * The rewrite is driven by the module lexer rather than by pattern matching:
+ * only a position the lexer reports as a specifier is edited, so ordinary
+ * string data that happens to read like an import statement — say
+ * `const help = 'from "/v135/help"'` — is left alone. A bundle the lexer
+ * cannot read keeps its specifiers verbatim; guessing with a regex there would
+ * reintroduce exactly the string-versus-specifier confusion this avoids.
+ */
+export async function rewriteEsmPaths(code: string, urlBase: string): Promise<string> {
+  try {
+    return await replaceSpecifiers(code, (specifier) => {
+      if (specifier.startsWith("./") || specifier.startsWith("../")) {
+        return new URL(specifier, urlBase).href;
+      }
+      if (!specifier.startsWith("/")) return null;
+      // veryfront module paths are served locally, not via esm.sh.
+      if (specifier.startsWith("/_vf_modules/") || specifier.startsWith("/_veryfront/")) {
+        return null;
+      }
+      return `https://esm.sh${specifier}`;
     });
+  } catch (error) {
+    logger.debug("Could not lex a fetched module; leaving its specifiers unrewritten", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return code;
   }
+}
 
-  return result;
+/** Where `url`'s rewritten source is written. Depends only on `url` and `tmpDir`. */
+async function esmTempFilePath(url: string, tmpDir: string): Promise<string> {
+  return `${tmpDir}/esm-${await generateHash(url)}.js`;
 }
 
 export async function fetchEsmModule(
@@ -77,6 +74,21 @@ export async function fetchEsmModule(
   tmpDir: string,
   localAdapter: RuntimeAdapter,
   esmCache: Map<string, string>,
+): Promise<string> {
+  return await fetchEsmModuleWithin(url, tmpDir, localAdapter, esmCache, new Set());
+}
+
+/**
+ * @param pending URLs whose fetch is still unwinding further up this call
+ * stack. A dependency graph with a cycle would otherwise recurse forever,
+ * because a URL only reaches `esmCache` once its own nested fetches finish.
+ */
+async function fetchEsmModuleWithin(
+  url: string,
+  tmpDir: string,
+  localAdapter: RuntimeAdapter,
+  esmCache: Map<string, string>,
+  pending: ReadonlySet<string>,
 ): Promise<string> {
   const cached = esmCache.get(url);
   if (cached) return cached;
@@ -91,7 +103,7 @@ export async function fetchEsmModule(
   let code = await response.text();
 
   const urlBase = url.substring(0, url.lastIndexOf("/") + 1);
-  code = rewriteEsmPaths(code, urlBase);
+  code = await rewriteEsmPaths(code, urlBase);
 
   const allEsmUrls = new Set<string>();
   const urlPattern = /["'](https:\/\/esm\.sh\/[^"']+)["']/g;
@@ -102,6 +114,8 @@ export async function fetchEsmModule(
 
   const urlArray = Array.from(allEsmUrls);
   const staticUrls = await staticImportSpecifiers(code);
+  const tempFilePath = await esmTempFilePath(url, tmpDir);
+  const nested = new Set(pending).add(url);
   // Nested pre-fetches of a URL this module only reaches lazily are
   // best-effort: a broken esm.sh build for one package logs a warning and the
   // URL stays in the emitted code for the runtime to resolve at call time. A
@@ -110,7 +124,15 @@ export async function fetchEsmModule(
   // local. See `transforms/esm/specifier-resolver.ts` for the same rule on the
   // SSR transform path.
   const settledPaths = await Promise.allSettled(
-    urlArray.map((esmUrl) => fetchEsmModule(esmUrl, tmpDir, localAdapter, esmCache)),
+    urlArray.map((esmUrl) =>
+      // A URL already on this stack is mid-fetch, so re-entering it would never
+      // terminate. Its temp path is fixed by `esmTempFilePath`, and the frame
+      // that owns it writes the file before the top-level fetch resolves, so a
+      // cyclic edge can point at that path without being fetched again.
+      nested.has(esmUrl)
+        ? esmTempFilePath(esmUrl, tmpDir)
+        : fetchEsmModuleWithin(esmUrl, tmpDir, localAdapter, esmCache, nested)
+    ),
   );
 
   if (urlArray.length) {
@@ -143,8 +165,6 @@ export async function fetchEsmModule(
     }
   }
 
-  const hash = await generateHash(url);
-  const tempFilePath = `${tmpDir}/esm-${hash}.js`;
   await localAdapter.fs.writeFile(tempFilePath, code);
 
   esmCache.set(url, tempFilePath);

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -59,7 +59,8 @@ export function rewriteEsmPaths(code: string, urlBase: string): string {
   for (const [pattern, pathIndex, resolver] of patterns) {
     result = result.replace(pattern, (...args) => {
       const match = args[0];
-      const path = args[pathIndex - 1];
+      // args[0] is the whole match, so capture group N is args[N].
+      const path = args[pathIndex];
       const quote = pathIndex === 3 ? args[2] : args[1];
 
       const resolved = resolver(path);

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -153,10 +153,15 @@ async function fetchEsmModuleWithin(
   code = await rewriteEsmPaths(code, urlBase);
 
   const allEsmUrls = new Set<string>();
-  const urlPattern = /["'](https:\/\/esm\.sh\/[^"']+)["']/g;
-
-  for (let match = urlPattern.exec(code); match; match = urlPattern.exec(code)) {
-    if (match[1]) allEsmUrls.add(match[1]);
+  try {
+    for (const imported of await parseImports(code)) {
+      if (imported.n?.startsWith("https://esm.sh/")) allEsmUrls.add(imported.n);
+    }
+  } catch {
+    const urlPattern = /["'`](https:\/\/esm\.sh\/[^"'`]+)["'`]/g;
+    for (let match = urlPattern.exec(code); match; match = urlPattern.exec(code)) {
+      if (match[1]) allEsmUrls.add(match[1]);
+    }
   }
 
   const urlArray = Array.from(allEsmUrls);

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -69,9 +69,11 @@ export async function rewriteEsmPaths(code: string, urlBase: string): Promise<st
     });
     // Only reachable once the lexer has already refused the source, so the scan
     // is deliberately coarse: a string that merely reads like an import costs a
-    // failed load here, never a silently unloadable artifact. Declared inside
-    // the handler so its `lastIndex` cannot leak between calls.
-    const importLikeSpecifier = /(?:\bfrom|\bimport)\s*\(?\s*(["'])([^"'\n]+)\1/g;
+    // failed load here, never a silently unloadable artifact. Backticks count
+    // because esm.sh emits template-literal dynamic imports, which would
+    // otherwise slip through with a relative path intact. Declared inside the
+    // handler so its `lastIndex` cannot leak between calls.
+    const importLikeSpecifier = /(?:\bfrom|\bimport)\s*\(?\s*(["'`])([^"'`\n]+)\1/g;
     for (
       let match = importLikeSpecifier.exec(code);
       match;

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -67,20 +67,25 @@ export async function rewriteEsmPaths(code: string, urlBase: string): Promise<st
     logger.debug("Could not lex a fetched module; leaving its specifiers unrewritten", {
       error: error instanceof Error ? error.message : String(error),
     });
-    // Every quoted string is examined, not just the ones in an import-looking
+    // Every string literal is examined, not just the ones in an import-looking
     // position. Anchoring on `import`/`from` would mean re-implementing JS
-    // syntax with a regex — comments between the keyword and the specifier,
-    // line continuations, and the `export {a} from` forms each need their own
+    // syntax with a regex - a comment between the keyword and the specifier, a
+    // line continuation, or an `export {a} from` form each need their own
     // case, and a missed one silently reinstates the unloadable artifact this
     // guards against. The lexer has already refused the source by this point,
     // so the only safe direction to err in is refusing too much: a data string
     // that merely looks like a path costs a failed load, never a broken
-    // module. Declared inside the handler so `lastIndex` cannot leak between
-    // calls; backticks are included because esm.sh emits template-literal
-    // dynamic imports.
-    const quotedString = /(["'`])([^"'`\n]*)\1/g;
-    for (let match = quotedString.exec(code); match; match = quotedString.exec(code)) {
-      const specifier = match[2];
+    // module.
+    //
+    // The three alternatives are the three JS string forms, each matched
+    // escape-aware: an earlier `"a\"b"` would otherwise pair its escaped quote
+    // with the next real one and walk the scan out of phase, hiding every
+    // specifier after it. Within each alternative the character class and the
+    // escape pair are disjoint, so the scan cannot backtrack. Declared inside
+    // the handler so `lastIndex` cannot leak between calls.
+    const stringLiteral = /"((?:[^"\\\n]|\\.)*)"|'((?:[^'\\\n]|\\.)*)'|`((?:[^`\\]|\\.)*)`/g;
+    for (let match = stringLiteral.exec(code); match; match = stringLiteral.exec(code)) {
+      const specifier = match[1] ?? match[2] ?? match[3];
       if (specifier === undefined || !needsEsmRewrite(specifier)) continue;
       throw MODULE_NOT_FOUND.create({
         detail: `Cannot rewrite ${specifier} in an unlexable module from ${urlBase}: leaving it ` +

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -173,7 +173,7 @@ async function fetchEsmModuleWithin(
   const graphCached = graph.artifacts.get(url);
   if (graphCached) {
     const unwritten = unresolvedGraphDependencies(url, graph, esmCache);
-    if (unwritten.length || graph.poisoned.has(url)) {
+    if (unwritten.length) {
       throw MODULE_NOT_FOUND.create({
         detail: `Refusing incomplete graph-local artifact for ${url}`,
       });

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -193,19 +193,29 @@ async function fetchEsmModuleWithin(
     }
 
     if (replacementMap.size) {
-      // Regex alternation commits to the first branch that matches, so a URL
+      // Every key was collected from a quoted position above, so a match is
+      // only accepted between the same pair of quotes. That is what keeps a URL
       // that is a prefix of another one — `https://esm.sh/react` inside
-      // `https://esm.sh/react-dom` — would swallow the longer URL's head and
-      // leave its tail dangling off a foreign file path. Longest-first
-      // ordering makes every branch match the complete URL it stands for.
+      // `https://esm.sh/react-dom` — from swallowing the longer URL's head:
+      // longest-first ordering alone cannot help when the longer URL failed to
+      // fetch and so never entered the map, yet it must stay verbatim for the
+      // runtime to resolve.
       const combinedPattern = new RegExp(
-        Array.from(replacementMap.keys())
-          .sort((a, b) => b.length - a.length)
-          .map(escapeRegExp)
-          .join("|"),
+        `(["'])(${
+          Array.from(replacementMap.keys())
+            .sort((a, b) => b.length - a.length)
+            .map(escapeRegExp)
+            .join("|")
+        })\\1`,
         "g",
       );
-      code = code.replace(combinedPattern, (m) => replacementMap.get(m) ?? m);
+      code = code.replace(
+        combinedPattern,
+        (m, quote: string, url: string) => {
+          const replacement = replacementMap.get(url);
+          return replacement ? `${quote}${replacement}${quote}` : m;
+        },
+      );
     }
   }
 

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -163,10 +163,7 @@ async function fetchEsmModuleWithin(
   const graphCached = graph.artifacts.get(url);
   if (graphCached) {
     const unwritten = unresolvedGraphDependencies(url, graph, esmCache);
-    if (
-      unwritten.length || graph.poisoned.has(url) ||
-      (graph.hadFailure && graph.provisional.has(url))
-    ) {
+    if (unwritten.length || graph.poisoned.has(url)) {
       throw MODULE_NOT_FOUND.create({
         detail: `Refusing incomplete graph-local artifact for ${url}`,
       });

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -86,6 +86,16 @@ type GraphState = {
   poisoned: Set<string>;
 };
 
+function unresolvedGraphDependencies(
+  url: string,
+  graph: GraphState,
+  esmCache: Map<string, string>,
+): string[] {
+  return [...(graph.unwritten.get(url) ?? [])].filter(
+    (dependency) => !graph.artifacts.has(dependency) && !esmCache.has(dependency),
+  );
+}
+
 export async function fetchEsmModule(
   url: string,
   tmpDir: string,
@@ -108,9 +118,7 @@ export async function fetchEsmModule(
       new Set(),
       graph,
     );
-    const unwritten = [...(graph.unwritten.get(url) ?? [])].filter(
-      (dependency) => !graph.artifacts.has(dependency) && !esmCache.has(dependency),
-    );
+    const unwritten = unresolvedGraphDependencies(url, graph, esmCache);
     if (unwritten.length) {
       throw MODULE_NOT_FOUND.create({
         detail: `Failed to materialize cyclic dependencies for ${url}: ${unwritten.join(", ")}`,
@@ -153,7 +161,18 @@ async function fetchEsmModuleWithin(
   const cached = esmCache.get(url);
   if (cached) return cached;
   const graphCached = graph.artifacts.get(url);
-  if (graphCached) return graphCached;
+  if (graphCached) {
+    const unwritten = unresolvedGraphDependencies(url, graph, esmCache);
+    if (
+      unwritten.length || graph.poisoned.has(url) ||
+      (graph.hadFailure && graph.provisional.has(url))
+    ) {
+      throw MODULE_NOT_FOUND.create({
+        detail: `Refusing incomplete graph-local artifact for ${url}`,
+      });
+    }
+    return graphCached;
+  }
 
   logger.debug("Fetching esm.sh module:", url);
 

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -69,13 +69,41 @@ async function esmTempFilePath(url: string, tmpDir: string): Promise<string> {
   return `${tmpDir}/esm-${await generateHash(url)}.js`;
 }
 
+/**
+ * Bookkeeping for one top-level fetch, so that artifacts written against a
+ * predicted cyclic path are not published to `esmCache` unless the graph that
+ * owns that prediction actually finishes.
+ */
+type GraphState = {
+  /**
+   * Per-URL set of ancestor URLs whose files an artifact already points at but
+   * which have not been written yet. Empty once the owning ancestor writes.
+   */
+  unwritten: Map<string, Set<string>>;
+  /** Cache entries that are only sound if this whole graph succeeds. */
+  provisional: Set<string>;
+};
+
 export async function fetchEsmModule(
   url: string,
   tmpDir: string,
   localAdapter: RuntimeAdapter,
   esmCache: Map<string, string>,
 ): Promise<string> {
-  return await fetchEsmModuleWithin(url, tmpDir, localAdapter, esmCache, new Set());
+  const graph: GraphState = { unwritten: new Map(), provisional: new Set() };
+  try {
+    return await fetchEsmModuleWithin(url, tmpDir, localAdapter, esmCache, new Set(), graph);
+  } catch (error) {
+    // A cycle member points at the predicted path of an ancestor that only
+    // writes that file on its way out. When an ancestor throws instead, the
+    // file never appears, so the member's cached artifact would import a
+    // missing path forever. Dropping the entry makes the next fetch redo the
+    // work; the stale temp file needs no cleanup because a redo rewrites the
+    // same deterministic path, and everything that referenced it was itself
+    // provisional and is dropped here too.
+    for (const key of graph.provisional) esmCache.delete(key);
+    throw error;
+  }
 }
 
 /**
@@ -89,6 +117,7 @@ async function fetchEsmModuleWithin(
   localAdapter: RuntimeAdapter,
   esmCache: Map<string, string>,
   pending: ReadonlySet<string>,
+  graph: GraphState,
 ): Promise<string> {
   const cached = esmCache.get(url);
   if (cached) return cached;
@@ -131,9 +160,14 @@ async function fetchEsmModuleWithin(
       // cyclic edge can point at that path without being fetched again.
       nested.has(esmUrl)
         ? esmTempFilePath(esmUrl, tmpDir)
-        : fetchEsmModuleWithin(esmUrl, tmpDir, localAdapter, esmCache, nested)
+        : fetchEsmModuleWithin(esmUrl, tmpDir, localAdapter, esmCache, nested, graph)
     ),
   );
+
+  // Ancestor files this module's emitted code depends on but which nobody has
+  // written yet, either because this module closed a cycle itself or because a
+  // descendant did.
+  const unwritten = new Set<string>();
 
   if (urlArray.length) {
     const replacementMap = new Map<string, string>();
@@ -143,6 +177,8 @@ async function fetchEsmModuleWithin(
       if (!url || !result) continue;
       if (result.status === "fulfilled") {
         replacementMap.set(url, `file://${result.value}`);
+        if (nested.has(url)) unwritten.add(url);
+        else for (const dep of graph.unwritten.get(url) ?? []) unwritten.add(dep);
         continue;
       }
 
@@ -157,8 +193,16 @@ async function fetchEsmModuleWithin(
     }
 
     if (replacementMap.size) {
+      // Regex alternation commits to the first branch that matches, so a URL
+      // that is a prefix of another one — `https://esm.sh/react` inside
+      // `https://esm.sh/react-dom` — would swallow the longer URL's head and
+      // leave its tail dangling off a foreign file path. Longest-first
+      // ordering makes every branch match the complete URL it stands for.
       const combinedPattern = new RegExp(
-        Array.from(replacementMap.keys()).map(escapeRegExp).join("|"),
+        Array.from(replacementMap.keys())
+          .sort((a, b) => b.length - a.length)
+          .map(escapeRegExp)
+          .join("|"),
         "g",
       );
       code = code.replace(combinedPattern, (m) => replacementMap.get(m) ?? m);
@@ -167,6 +211,11 @@ async function fetchEsmModuleWithin(
 
   await localAdapter.fs.writeFile(tempFilePath, code);
 
+  // This module's own file now exists, so a descendant that pointed at its
+  // predicted path is satisfied.
+  unwritten.delete(url);
+  graph.unwritten.set(url, unwritten);
   esmCache.set(url, tempFilePath);
+  if (unwritten.size) graph.provisional.add(url);
   return tempFilePath;
 }

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -80,6 +80,8 @@ type GraphState = {
   provisional: Set<string>;
   /** Artifacts written by this graph, published only after the root succeeds. */
   artifacts: Map<string, string>;
+  /** Module materializations still running within this graph. */
+  inFlight: Map<string, Promise<string>>;
   /** Any rejected nested fetch makes the graph unsafe to publish as a cache hit. */
   hadFailure: boolean;
   /** Artifacts that depend on a failed subtree or provisional cycle member. */
@@ -116,6 +118,7 @@ export async function fetchEsmModule(
     unwritten: new Map(),
     provisional: new Set(),
     artifacts: new Map(),
+    inFlight: new Map(),
     hadFailure: false,
     poisoned: new Set(),
   };
@@ -168,15 +171,57 @@ async function fetchEsmModuleWithin(
   if (cached) return cached;
   const graphCached = graph.artifacts.get(url);
   if (graphCached) {
-    const unwritten = unresolvedGraphDependencies(url, graph, esmCache);
+    let unwritten = unresolvedGraphDependencies(url, graph, esmCache);
     if (unwritten.length) {
-      throw MODULE_NOT_FOUND.create({
-        detail: `Refusing incomplete graph-local artifact for ${url}`,
-      });
+      const owners = [
+        ...new Set(unwritten.flatMap((dependency) => {
+          const owner = graph.inFlight.get(dependency);
+          return owner === undefined ? [] : [owner];
+        })),
+      ];
+      if (owners.length) {
+        await Promise.all(owners);
+        unwritten = unresolvedGraphDependencies(url, graph, esmCache);
+      }
+      if (unwritten.length) {
+        throw MODULE_NOT_FOUND.create({
+          detail: `Refusing incomplete graph-local artifact for ${url}`,
+        });
+      }
     }
     return graphCached;
   }
 
+  const inFlight = graph.inFlight.get(url);
+  if (inFlight) {
+    await inFlight;
+    return await fetchEsmModuleWithin(url, tmpDir, localAdapter, esmCache, pending, graph);
+  }
+
+  const materialization = materializeEsmModuleWithin(
+    url,
+    tmpDir,
+    localAdapter,
+    esmCache,
+    pending,
+    graph,
+  );
+  graph.inFlight.set(url, materialization);
+  try {
+    return await materialization;
+  } finally {
+    if (graph.inFlight.get(url) === materialization) graph.inFlight.delete(url);
+  }
+}
+
+async function materializeEsmModuleWithin(
+  url: string,
+  tmpDir: string,
+  localAdapter: RuntimeAdapter,
+  esmCache: Map<string, string>,
+  pending: ReadonlySet<string>,
+  graph: GraphState,
+): Promise<string> {
   logger.debug("Fetching esm.sh module:", url);
 
   const response = await fetch(url);
@@ -264,9 +309,15 @@ async function fetchEsmModuleWithin(
       // longest-first ordering alone cannot help when the longer URL failed to
       // fetch and so never entered the map, yet it must stay verbatim for the
       // runtime to resolve.
-      code = await replaceSpecifiers(code, (specifier) => {
-        return replacementMap.get(specifier) ?? null;
-      });
+      try {
+        code = await replaceSpecifiers(code, (specifier) => {
+          return replacementMap.get(specifier) ?? null;
+        });
+      } catch (error) {
+        logger.debug("Could not lex a fetched module during local substitution", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
   }
 

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -80,10 +80,15 @@ export async function rewriteEsmPaths(code: string, urlBase: string): Promise<st
     // The three alternatives are the three JS string forms, each matched
     // escape-aware: an earlier `"a\"b"` would otherwise pair its escaped quote
     // with the next real one and walk the scan out of phase, hiding every
-    // specifier after it. Within each alternative the character class and the
+    // specifier after it. The escape pair is `\\[\s\S]` rather than `\\.` so that
+    // a line continuation - a backslash before a real newline - is consumed
+    // too; `.` stops at a newline and would desynchronise the scan the same
+    // way. An unescaped newline still terminates a quoted string, because the
+    // character class excludes it. Within each alternative that class and the
     // escape pair are disjoint, so the scan cannot backtrack. Declared inside
     // the handler so `lastIndex` cannot leak between calls.
-    const stringLiteral = /"((?:[^"\\\n]|\\.)*)"|'((?:[^'\\\n]|\\.)*)'|`((?:[^`\\]|\\.)*)`/g;
+    const stringLiteral =
+      /"((?:[^"\\\n]|\\[\s\S])*)"|'((?:[^'\\\n]|\\[\s\S])*)'|`((?:[^`\\]|\\[\s\S])*)`/g;
     for (let match = stringLiteral.exec(code); match; match = stringLiteral.exec(code)) {
       const specifier = match[1] ?? match[2] ?? match[3];
       if (specifier === undefined || !needsEsmRewrite(specifier)) continue;

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -108,6 +108,14 @@ export async function fetchEsmModule(
       new Set(),
       graph,
     );
+    const unwritten = [...(graph.unwritten.get(url) ?? [])].filter(
+      (dependency) => !graph.artifacts.has(dependency) && !esmCache.has(dependency),
+    );
+    if (unwritten.length) {
+      throw MODULE_NOT_FOUND.create({
+        detail: `Failed to materialize cyclic dependencies for ${url}: ${unwritten.join(", ")}`,
+      });
+    }
     for (const [key, value] of graph.artifacts) {
       if (
         !graph.hadFailure || (!graph.provisional.has(key) && !graph.poisoned.has(key))

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -171,7 +171,13 @@ async function fetchEsmModuleWithin(
   if (cached) return cached;
   const graphCached = graph.artifacts.get(url);
   if (graphCached) {
-    let unwritten = unresolvedGraphDependencies(url, graph, esmCache);
+    // A dependency still unwinding further up this call stack writes its own
+    // file only after this frame returns — its `Promise.allSettled` is waiting
+    // on us — so awaiting its materialization here would deadlock the render
+    // rather than fail it. Such a predicted path is validated once by
+    // `fetchEsmModule` after the root settles instead.
+    const settleable = (dependency: string) => !pending.has(dependency);
+    let unwritten = unresolvedGraphDependencies(url, graph, esmCache).filter(settleable);
     if (unwritten.length) {
       const owners = [
         ...new Set(unwritten.flatMap((dependency) => {
@@ -181,7 +187,7 @@ async function fetchEsmModuleWithin(
       ];
       if (owners.length) {
         await Promise.all(owners);
-        unwritten = unresolvedGraphDependencies(url, graph, esmCache);
+        unwritten = unresolvedGraphDependencies(url, graph, esmCache).filter(settleable);
       }
       if (unwritten.length) {
         throw MODULE_NOT_FOUND.create({

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -28,10 +28,6 @@ async function staticImportSpecifiers(code: string): Promise<Set<string>> {
   }
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 /**
  * Point an esm.sh bundle's server-absolute and relative specifiers at absolute
  * esm.sh URLs, so the module still resolves once it is written to a temp file.
@@ -82,6 +78,8 @@ type GraphState = {
   unwritten: Map<string, Set<string>>;
   /** Cache entries that are only sound if this whole graph succeeds. */
   provisional: Set<string>;
+  /** Artifacts written by this graph, published only after the root succeeds. */
+  artifacts: Map<string, string>;
 };
 
 export async function fetchEsmModule(
@@ -90,9 +88,22 @@ export async function fetchEsmModule(
   localAdapter: RuntimeAdapter,
   esmCache: Map<string, string>,
 ): Promise<string> {
-  const graph: GraphState = { unwritten: new Map(), provisional: new Set() };
+  const graph: GraphState = {
+    unwritten: new Map(),
+    provisional: new Set(),
+    artifacts: new Map(),
+  };
   try {
-    return await fetchEsmModuleWithin(url, tmpDir, localAdapter, esmCache, new Set(), graph);
+    const result = await fetchEsmModuleWithin(
+      url,
+      tmpDir,
+      localAdapter,
+      esmCache,
+      new Set(),
+      graph,
+    );
+    for (const [key, value] of graph.artifacts) esmCache.set(key, value);
+    return result;
   } catch (error) {
     // A cycle member points at the predicted path of an ancestor that only
     // writes that file on its way out. When an ancestor throws instead, the
@@ -121,6 +132,8 @@ async function fetchEsmModuleWithin(
 ): Promise<string> {
   const cached = esmCache.get(url);
   if (cached) return cached;
+  const graphCached = graph.artifacts.get(url);
+  if (graphCached) return graphCached;
 
   logger.debug("Fetching esm.sh module:", url);
 
@@ -200,22 +213,9 @@ async function fetchEsmModuleWithin(
       // longest-first ordering alone cannot help when the longer URL failed to
       // fetch and so never entered the map, yet it must stay verbatim for the
       // runtime to resolve.
-      const combinedPattern = new RegExp(
-        `(["'])(${
-          Array.from(replacementMap.keys())
-            .sort((a, b) => b.length - a.length)
-            .map(escapeRegExp)
-            .join("|")
-        })\\1`,
-        "g",
-      );
-      code = code.replace(
-        combinedPattern,
-        (m, quote: string, url: string) => {
-          const replacement = replacementMap.get(url);
-          return replacement ? `${quote}${replacement}${quote}` : m;
-        },
-      );
+      code = await replaceSpecifiers(code, (specifier) => {
+        return replacementMap.get(specifier) ?? null;
+      });
     }
   }
 
@@ -225,7 +225,7 @@ async function fetchEsmModuleWithin(
   // predicted path is satisfied.
   unwritten.delete(url);
   graph.unwritten.set(url, unwritten);
-  esmCache.set(url, tempFilePath);
+  graph.artifacts.set(url, tempFilePath);
   if (unwritten.size) graph.provisional.add(url);
   return tempFilePath;
 }

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -67,18 +67,19 @@ export async function rewriteEsmPaths(code: string, urlBase: string): Promise<st
     logger.debug("Could not lex a fetched module; leaving its specifiers unrewritten", {
       error: error instanceof Error ? error.message : String(error),
     });
-    // Only reachable once the lexer has already refused the source, so the scan
-    // is deliberately coarse: a string that merely reads like an import costs a
-    // failed load here, never a silently unloadable artifact. Backticks count
-    // because esm.sh emits template-literal dynamic imports, which would
-    // otherwise slip through with a relative path intact. Declared inside the
-    // handler so its `lastIndex` cannot leak between calls.
-    const importLikeSpecifier = /(?:\bfrom|\bimport)\s*\(?\s*(["'`])([^"'`\n]+)\1/g;
-    for (
-      let match = importLikeSpecifier.exec(code);
-      match;
-      match = importLikeSpecifier.exec(code)
-    ) {
+    // Every quoted string is examined, not just the ones in an import-looking
+    // position. Anchoring on `import`/`from` would mean re-implementing JS
+    // syntax with a regex — comments between the keyword and the specifier,
+    // line continuations, and the `export {a} from` forms each need their own
+    // case, and a missed one silently reinstates the unloadable artifact this
+    // guards against. The lexer has already refused the source by this point,
+    // so the only safe direction to err in is refusing too much: a data string
+    // that merely looks like a path costs a failed load, never a broken
+    // module. Declared inside the handler so `lastIndex` cannot leak between
+    // calls; backticks are included because esm.sh emits template-literal
+    // dynamic imports.
+    const quotedString = /(["'`])([^"'`\n]*)\1/g;
+    for (let match = quotedString.exec(code); match; match = quotedString.exec(code)) {
       const specifier = match[2];
       if (specifier === undefined || !needsEsmRewrite(specifier)) continue;
       throw MODULE_NOT_FOUND.create({

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -82,6 +82,8 @@ type GraphState = {
   artifacts: Map<string, string>;
   /** Any rejected nested fetch makes the graph unsafe to publish as a cache hit. */
   hadFailure: boolean;
+  /** Artifacts that depend on a failed subtree or provisional cycle member. */
+  poisoned: Set<string>;
 };
 
 export async function fetchEsmModule(
@@ -95,6 +97,7 @@ export async function fetchEsmModule(
     provisional: new Set(),
     artifacts: new Map(),
     hadFailure: false,
+    poisoned: new Set(),
   };
   try {
     const result = await fetchEsmModuleWithin(
@@ -105,8 +108,12 @@ export async function fetchEsmModule(
       new Set(),
       graph,
     );
-    if (!graph.hadFailure || graph.provisional.size === 0) {
-      for (const [key, value] of graph.artifacts) esmCache.set(key, value);
+    for (const [key, value] of graph.artifacts) {
+      if (
+        !graph.hadFailure || (!graph.provisional.has(key) && !graph.poisoned.has(key))
+      ) {
+        esmCache.set(key, value);
+      }
     }
     return result;
   } catch (error) {
@@ -191,6 +198,7 @@ async function fetchEsmModuleWithin(
   // written yet, either because this module closed a cycle itself or because a
   // descendant did.
   const unwritten = new Set<string>();
+  let poisonedByDependency = false;
 
   if (urlArray.length) {
     const replacementMap = new Map<string, string>();
@@ -202,6 +210,7 @@ async function fetchEsmModuleWithin(
         replacementMap.set(url, `file://${result.value}`);
         if (nested.has(url)) unwritten.add(url);
         else for (const dep of graph.unwritten.get(url) ?? []) unwritten.add(dep);
+        if (graph.provisional.has(url) || graph.poisoned.has(url)) poisonedByDependency = true;
         continue;
       }
 
@@ -238,6 +247,7 @@ async function fetchEsmModuleWithin(
   unwritten.delete(url);
   graph.unwritten.set(url, unwritten);
   graph.artifacts.set(url, tempFilePath);
+  if (poisonedByDependency) graph.poisoned.add(url);
   if (unwritten.size) graph.provisional.add(url);
   return tempFilePath;
 }

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -80,6 +80,8 @@ type GraphState = {
   provisional: Set<string>;
   /** Artifacts written by this graph, published only after the root succeeds. */
   artifacts: Map<string, string>;
+  /** Any rejected nested fetch makes the graph unsafe to publish as a cache hit. */
+  hadFailure: boolean;
 };
 
 export async function fetchEsmModule(
@@ -92,6 +94,7 @@ export async function fetchEsmModule(
     unwritten: new Map(),
     provisional: new Set(),
     artifacts: new Map(),
+    hadFailure: false,
   };
   try {
     const result = await fetchEsmModuleWithin(
@@ -102,7 +105,9 @@ export async function fetchEsmModule(
       new Set(),
       graph,
     );
-    for (const [key, value] of graph.artifacts) esmCache.set(key, value);
+    if (!graph.hadFailure || graph.provisional.size === 0) {
+      for (const [key, value] of graph.artifacts) esmCache.set(key, value);
+    }
     return result;
   } catch (error) {
     // A cycle member points at the predicted path of an ancestor that only
@@ -194,6 +199,8 @@ async function fetchEsmModuleWithin(
         else for (const dep of graph.unwritten.get(url) ?? []) unwritten.add(dep);
         continue;
       }
+
+      graph.hadFailure = true;
 
       // A statically imported dependency must be local before this module is
       // handed to the runtime loader, so its failure stays fatal.

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -90,10 +90,20 @@ function unresolvedGraphDependencies(
   url: string,
   graph: GraphState,
   esmCache: Map<string, string>,
+  seen = new Set<string>(),
 ): string[] {
-  return [...(graph.unwritten.get(url) ?? [])].filter(
-    (dependency) => !graph.artifacts.has(dependency) && !esmCache.has(dependency),
-  );
+  if (seen.has(url)) return [];
+  seen.add(url);
+
+  const unresolved: string[] = [];
+  for (const dependency of graph.unwritten.get(url) ?? []) {
+    if (!graph.artifacts.has(dependency) && !esmCache.has(dependency)) {
+      unresolved.push(dependency);
+      continue;
+    }
+    unresolved.push(...unresolvedGraphDependencies(dependency, graph, esmCache, seen));
+  }
+  return unresolved;
 }
 
 export async function fetchEsmModule(

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -82,6 +82,8 @@ type GraphState = {
   artifacts: Map<string, string>;
   /** Module materializations still running within this graph. */
   inFlight: Map<string, Promise<string>>;
+  /** Active in-graph waits between module materializations. */
+  waitsFor: Map<string, Map<string, number>>;
   /** Any rejected nested fetch makes the graph unsafe to publish as a cache hit. */
   hadFailure: boolean;
   /** Artifacts that depend on a failed subtree or provisional cycle member. */
@@ -108,6 +110,48 @@ function unresolvedGraphDependencies(
   return unresolved;
 }
 
+function addWaitDependency(graph: GraphState, waiter: string | undefined, dependency: string) {
+  if (waiter === undefined || waiter === dependency) return () => {};
+  let counts = graph.waitsFor.get(waiter);
+  if (!counts) {
+    counts = new Map();
+    graph.waitsFor.set(waiter, counts);
+  }
+  counts.set(dependency, (counts.get(dependency) ?? 0) + 1);
+
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    const currentCounts = graph.waitsFor.get(waiter);
+    if (!currentCounts) return;
+    const count = currentCounts.get(dependency);
+    if (count === undefined) return;
+    if (count > 1) {
+      currentCounts.set(dependency, count - 1);
+      return;
+    }
+    currentCounts.delete(dependency);
+    if (currentCounts.size === 0) graph.waitsFor.delete(waiter);
+  };
+}
+
+function transitivelyWaitsFor(
+  url: string,
+  target: string,
+  graph: GraphState,
+  seen = new Set<string>(),
+): boolean {
+  if (seen.has(url)) return false;
+  seen.add(url);
+  for (const dependency of graph.waitsFor.get(url)?.keys() ?? []) {
+    if (dependency === target || transitivelyWaitsFor(dependency, target, graph, seen)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export async function fetchEsmModule(
   url: string,
   tmpDir: string,
@@ -119,6 +163,7 @@ export async function fetchEsmModule(
     provisional: new Set(),
     artifacts: new Map(),
     inFlight: new Map(),
+    waitsFor: new Map(),
     hadFailure: false,
     poisoned: new Set(),
   };
@@ -166,57 +211,82 @@ async function fetchEsmModuleWithin(
   esmCache: Map<string, string>,
   pending: ReadonlySet<string>,
   graph: GraphState,
+  waiter?: string,
 ): Promise<string> {
+  const releaseWait = addWaitDependency(graph, waiter, url);
   const cached = esmCache.get(url);
-  if (cached) return cached;
-  const graphCached = graph.artifacts.get(url);
-  if (graphCached) {
-    // A dependency still unwinding further up this call stack writes its own
-    // file only after this frame returns — its `Promise.allSettled` is waiting
-    // on us — so awaiting its materialization here would deadlock the render
-    // rather than fail it. Such a predicted path is validated once by
-    // `fetchEsmModule` after the root settles instead.
-    const settleable = (dependency: string) => !pending.has(dependency);
-    let unwritten = unresolvedGraphDependencies(url, graph, esmCache).filter(settleable);
-    if (unwritten.length) {
-      const owners = [
-        ...new Set(unwritten.flatMap((dependency) => {
-          const owner = graph.inFlight.get(dependency);
-          return owner === undefined ? [] : [owner];
-        })),
-      ];
-      if (owners.length) {
-        await Promise.all(owners);
-        unwritten = unresolvedGraphDependencies(url, graph, esmCache).filter(settleable);
-      }
-      if (unwritten.length) {
-        throw MODULE_NOT_FOUND.create({
-          detail: `Refusing incomplete graph-local artifact for ${url}`,
-        });
-      }
-    }
-    return graphCached;
-  }
-
-  const inFlight = graph.inFlight.get(url);
-  if (inFlight) {
-    await inFlight;
-    return await fetchEsmModuleWithin(url, tmpDir, localAdapter, esmCache, pending, graph);
-  }
-
-  const materialization = materializeEsmModuleWithin(
-    url,
-    tmpDir,
-    localAdapter,
-    esmCache,
-    pending,
-    graph,
-  );
-  graph.inFlight.set(url, materialization);
   try {
-    return await materialization;
+    if (cached) return cached;
+    const graphCached = graph.artifacts.get(url);
+    if (graphCached) {
+      // A dependency still unwinding further up this call stack writes its own
+      // file only after this frame returns — its `Promise.allSettled` is waiting
+      // on us — so awaiting its materialization here would deadlock the render
+      // rather than fail it. A concurrent sibling can create the same cycle
+      // without sharing the caller's `pending` stack, so active wait edges are
+      // also treated as not-yet-settleable. Such a predicted path is validated
+      // once by `fetchEsmModule` after the root settles instead.
+      const settleable = (dependency: string) =>
+        !pending.has(dependency) &&
+        (waiter === undefined || !transitivelyWaitsFor(dependency, waiter, graph));
+      let unwritten = unresolvedGraphDependencies(url, graph, esmCache).filter(settleable);
+      if (unwritten.length) {
+        const ownerUrls = [
+          ...new Set(unwritten.filter((dependency) => graph.inFlight.has(dependency))),
+        ];
+        if (ownerUrls.length) {
+          const releaseOwnerWaits = ownerUrls.map((ownerUrl) =>
+            addWaitDependency(graph, waiter, ownerUrl)
+          );
+          const owners = ownerUrls
+            .map((ownerUrl) => graph.inFlight.get(ownerUrl))
+            .filter((owner): owner is Promise<string> => owner !== undefined);
+          try {
+            await Promise.all(owners);
+          } finally {
+            for (const release of releaseOwnerWaits) release();
+          }
+          unwritten = unresolvedGraphDependencies(url, graph, esmCache).filter(settleable);
+        }
+        if (unwritten.length) {
+          throw MODULE_NOT_FOUND.create({
+            detail: `Refusing incomplete graph-local artifact for ${url}`,
+          });
+        }
+      }
+      return graphCached;
+    }
+
+    const inFlight = graph.inFlight.get(url);
+    if (inFlight) {
+      await inFlight;
+      return await fetchEsmModuleWithin(
+        url,
+        tmpDir,
+        localAdapter,
+        esmCache,
+        pending,
+        graph,
+        waiter,
+      );
+    }
+
+    const materialization = materializeEsmModuleWithin(
+      url,
+      tmpDir,
+      localAdapter,
+      esmCache,
+      pending,
+      graph,
+    );
+    graph.inFlight.set(url, materialization);
+    try {
+      return await materialization;
+    } finally {
+      if (graph.inFlight.get(url) === materialization) graph.inFlight.delete(url);
+    }
   } finally {
-    if (graph.inFlight.get(url) === materialization) graph.inFlight.delete(url);
+    releaseWait();
   }
 }
 
@@ -271,7 +341,7 @@ async function materializeEsmModuleWithin(
       // cyclic edge can point at that path without being fetched again.
       nested.has(esmUrl)
         ? esmTempFilePath(esmUrl, tmpDir)
-        : fetchEsmModuleWithin(esmUrl, tmpDir, localAdapter, esmCache, nested, graph)
+        : fetchEsmModuleWithin(esmUrl, tmpDir, localAdapter, esmCache, nested, graph, url)
     ),
   );
 

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -29,33 +29,61 @@ async function staticImportSpecifiers(code: string): Promise<Set<string>> {
 }
 
 /**
+ * Whether the esm.sh rewrite has to redirect `specifier`, i.e. whether leaving
+ * it verbatim would make it resolve against wherever the artifact is written
+ * rather than against its esm.sh origin.
+ */
+function needsEsmRewrite(specifier: string): boolean {
+  if (specifier.startsWith("./") || specifier.startsWith("../")) return true;
+  if (!specifier.startsWith("/")) return false;
+  // veryfront module paths are served locally, not via esm.sh.
+  return !specifier.startsWith("/_vf_modules/") && !specifier.startsWith("/_veryfront/");
+}
+
+/**
  * Point an esm.sh bundle's server-absolute and relative specifiers at absolute
  * esm.sh URLs, so the module still resolves once it is written to a temp file.
  *
  * The rewrite is driven by the module lexer rather than by pattern matching:
  * only a position the lexer reports as a specifier is edited, so ordinary
  * string data that happens to read like an import statement — say
- * `const help = 'from "/v135/help"'` — is left alone. A bundle the lexer
- * cannot read keeps its specifiers verbatim; guessing with a regex there would
- * reintroduce exactly the string-versus-specifier confusion this avoids.
+ * `const help = 'from "/v135/help"'` — is left alone. Guessing with a regex
+ * would reintroduce exactly the string-versus-specifier confusion this avoids.
+ *
+ * A bundle the lexer cannot read keeps its specifiers verbatim, which is only
+ * sound while every one of them is already absolute. A surviving relative or
+ * server-absolute specifier would be resolved against the temp directory the
+ * artifact is written to, so the caller would be handed a module that loads the
+ * wrong file or none at all; such a bundle fails the load instead.
  */
 export async function rewriteEsmPaths(code: string, urlBase: string): Promise<string> {
   try {
     return await replaceSpecifiers(code, (specifier) => {
-      if (specifier.startsWith("./") || specifier.startsWith("../")) {
-        return new URL(specifier, urlBase).href;
-      }
-      if (!specifier.startsWith("/")) return null;
-      // veryfront module paths are served locally, not via esm.sh.
-      if (specifier.startsWith("/_vf_modules/") || specifier.startsWith("/_veryfront/")) {
-        return null;
-      }
-      return `https://esm.sh${specifier}`;
+      if (!needsEsmRewrite(specifier)) return null;
+      if (specifier.startsWith("/")) return `https://esm.sh${specifier}`;
+      return new URL(specifier, urlBase).href;
     });
   } catch (error) {
     logger.debug("Could not lex a fetched module; leaving its specifiers unrewritten", {
       error: error instanceof Error ? error.message : String(error),
     });
+    // Only reachable once the lexer has already refused the source, so the scan
+    // is deliberately coarse: a string that merely reads like an import costs a
+    // failed load here, never a silently unloadable artifact. Declared inside
+    // the handler so its `lastIndex` cannot leak between calls.
+    const importLikeSpecifier = /(?:\bfrom|\bimport)\s*\(?\s*(["'])([^"'\n]+)\1/g;
+    for (
+      let match = importLikeSpecifier.exec(code);
+      match;
+      match = importLikeSpecifier.exec(code)
+    ) {
+      const specifier = match[2];
+      if (specifier === undefined || !needsEsmRewrite(specifier)) continue;
+      throw MODULE_NOT_FOUND.create({
+        detail: `Cannot rewrite ${specifier} in an unlexable module from ${urlBase}: leaving it ` +
+          `verbatim would resolve it against the temp directory instead of esm.sh`,
+      });
+    }
     return code;
   }
 }
@@ -317,7 +345,13 @@ async function materializeEsmModuleWithin(
 
   let code = await response.text();
 
-  const urlBase = url.substring(0, url.lastIndexOf("/") + 1);
+  // esm.sh canonicalises bare and versionless paths by redirecting, so the URL
+  // the response actually came from is the only correct base for the module's
+  // relative specifiers; resolving them against the requested URL would fetch a
+  // chunk from the wrong directory. A synthetic response carries an empty
+  // `url`, so the requested URL stays the fallback.
+  const responseUrl = response.url || url;
+  const urlBase = responseUrl.substring(0, responseUrl.lastIndexOf("/") + 1);
   code = await rewriteEsmPaths(code, urlBase);
 
   const allEsmUrls = new Set<string>();

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -46,15 +46,22 @@ function needsEsmRewrite(specifier: string): boolean {
  *
  * The rewrite is driven by the module lexer rather than by pattern matching:
  * only a position the lexer reports as a specifier is edited, so ordinary
- * string data that happens to read like an import statement — say
- * `const help = 'from "/v135/help"'` — is left alone. Guessing with a regex
+ * string data that happens to read like an import statement - say
+ * `const help = 'from "/v135/help"'` - is left alone. Guessing with a regex
  * would reintroduce exactly the string-versus-specifier confusion this avoids.
  *
- * A bundle the lexer cannot read keeps its specifiers verbatim, which is only
- * sound while every one of them is already absolute. A surviving relative or
- * server-absolute specifier would be resolved against the temp directory the
- * artifact is written to, so the caller would be handed a module that loads the
- * wrong file or none at all; such a bundle fails the load instead.
+ * A bundle the lexer cannot read fails the load. Writing it out verbatim would
+ * be sound only if every specifier in it were already absolute, and deciding
+ * that without the lexer means re-deriving JS tokenisation from a regex:
+ * comments and regular-expression literals carrying a quote desynchronise the
+ * scan, escaped delimiters and line continuations hide the specifiers after
+ * them, and an escaped specifier such as `".\/dep.js"` does not compare equal
+ * to the path it denotes. Every one of those misses reads as "nothing to
+ * rewrite" and ships an artifact whose imports resolve against the temp
+ * directory rather than esm.sh - a broken module reported as a successful
+ * fetch. There is no partial answer worth having here, so an unreadable bundle
+ * is refused, the same way `staticImportSpecifiers` treats one as entirely
+ * static rather than quietly shipping a remote dependency.
  */
 export async function rewriteEsmPaths(code: string, urlBase: string): Promise<string> {
   try {
@@ -64,40 +71,15 @@ export async function rewriteEsmPaths(code: string, urlBase: string): Promise<st
       return new URL(specifier, urlBase).href;
     });
   } catch (error) {
-    logger.debug("Could not lex a fetched module; leaving its specifiers unrewritten", {
-      error: error instanceof Error ? error.message : String(error),
+    const detail = error instanceof Error ? error.message : String(error);
+    logger.debug("Could not lex a fetched module; refusing to emit it unrewritten", {
+      error: detail,
     });
-    // Every string literal is examined, not just the ones in an import-looking
-    // position. Anchoring on `import`/`from` would mean re-implementing JS
-    // syntax with a regex - a comment between the keyword and the specifier, a
-    // line continuation, or an `export {a} from` form each need their own
-    // case, and a missed one silently reinstates the unloadable artifact this
-    // guards against. The lexer has already refused the source by this point,
-    // so the only safe direction to err in is refusing too much: a data string
-    // that merely looks like a path costs a failed load, never a broken
-    // module.
-    //
-    // The three alternatives are the three JS string forms, each matched
-    // escape-aware: an earlier `"a\"b"` would otherwise pair its escaped quote
-    // with the next real one and walk the scan out of phase, hiding every
-    // specifier after it. The escape pair is `\\[\s\S]` rather than `\\.` so that
-    // a line continuation - a backslash before a real newline - is consumed
-    // too; `.` stops at a newline and would desynchronise the scan the same
-    // way. An unescaped newline still terminates a quoted string, because the
-    // character class excludes it. Within each alternative that class and the
-    // escape pair are disjoint, so the scan cannot backtrack. Declared inside
-    // the handler so `lastIndex` cannot leak between calls.
-    const stringLiteral =
-      /"((?:[^"\\\n]|\\[\s\S])*)"|'((?:[^'\\\n]|\\[\s\S])*)'|`((?:[^`\\]|\\[\s\S])*)`/g;
-    for (let match = stringLiteral.exec(code); match; match = stringLiteral.exec(code)) {
-      const specifier = match[1] ?? match[2] ?? match[3];
-      if (specifier === undefined || !needsEsmRewrite(specifier)) continue;
-      throw MODULE_NOT_FOUND.create({
-        detail: `Cannot rewrite ${specifier} in an unlexable module from ${urlBase}: leaving it ` +
-          `verbatim would resolve it against the temp directory instead of esm.sh`,
-      });
-    }
-    return code;
+    throw MODULE_NOT_FOUND.create({
+      detail: `Cannot rewrite the module fetched from ${urlBase}: its source could not be ` +
+        `lexed (${detail}), and emitting it unrewritten would resolve its specifiers ` +
+        `against the temp directory instead of esm.sh`,
+    });
   }
 }
 

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -259,6 +259,16 @@ async function fetchEsmModuleWithin(
 
     const inFlight = graph.inFlight.get(url);
     if (inFlight) {
+      // Two sibling materializations that import each other each find the other
+      // in flight, and neither has reached `graph.artifacts` yet, so the wait
+      // edges recorded above are the only evidence that awaiting here would
+      // leave both frames blocked on each other forever. Break such a cycle the
+      // way a caller-stack cycle is broken: point at the owner's predicted
+      // path, which is fixed by `esmTempFilePath`, and let `fetchEsmModule`
+      // validate once the root settles that the owner really wrote it.
+      if (waiter !== undefined && transitivelyWaitsFor(url, waiter, graph)) {
+        return await esmTempFilePath(url, tmpDir);
+      }
       await inFlight;
       return await fetchEsmModuleWithin(
         url,
@@ -359,8 +369,16 @@ async function materializeEsmModuleWithin(
       if (!url || !result) continue;
       if (result.status === "fulfilled") {
         replacementMap.set(url, `file://${result.value}`);
-        if (nested.has(url)) unwritten.add(url);
-        else for (const dep of graph.unwritten.get(url) ?? []) unwritten.add(dep);
+        // A dependency that resolved to a predicted path — an ancestor still
+        // unwinding up this stack, or a sibling cycle broken in
+        // `fetchEsmModuleWithin` — owns neither a graph artifact nor a cache
+        // entry yet, so this module's emitted code points at a file nobody has
+        // written. Record it so the artifact stays provisional until it is.
+        if (nested.has(url) || (!graph.artifacts.has(url) && !esmCache.has(url))) {
+          unwritten.add(url);
+        } else {
+          for (const dep of graph.unwritten.get(url) ?? []) unwritten.add(dep);
+        }
         if (graph.provisional.has(url) || graph.poisoned.has(url)) poisonedByDependency = true;
         continue;
       }

--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -143,14 +143,10 @@ export async function fetchEsmModule(
     }
     return result;
   } catch (error) {
-    // A cycle member points at the predicted path of an ancestor that only
-    // writes that file on its way out. When an ancestor throws instead, the
-    // file never appears, so the member's cached artifact would import a
-    // missing path forever. Dropping the entry makes the next fetch redo the
-    // work; the stale temp file needs no cleanup because a redo rewrites the
-    // same deterministic path, and everything that referenced it was itself
-    // provisional and is dropped here too.
-    for (const key of graph.provisional) esmCache.delete(key);
+    // Failed graph artifacts stay graph-local and are never published. Do not
+    // delete shared-cache entries here: another concurrent graph may have
+    // successfully published the same URL after this graph marked it
+    // provisional.
     throw error;
   }
 }

--- a/src/rendering/orchestrator/module-loader/index.test.ts
+++ b/src/rendering/orchestrator/module-loader/index.test.ts
@@ -39,6 +39,41 @@ import {
   markBuildFailure,
   markTenantBuildFailure,
 } from "./build-failure.ts";
+import { getHttpBundleCacheDir } from "#veryfront/utils/cache-dir.ts";
+import {
+  buildHttpCacheIdentity,
+  hashHttpCacheIdentity,
+} from "#veryfront/transforms/esm/http-cache-helpers.ts";
+import { __injectCachesForTests } from "#veryfront/transforms/esm/http-cache-state.ts";
+import { __setDistributedCacheAccessorForTests } from "#veryfront/transforms/esm/http-cache-wrapper.ts";
+import type { CacheBackend } from "#veryfront/cache/types.ts";
+
+/**
+ * A distributed-cache stand-in keyed the way the HTTP bundle cache reads it:
+ * the stored keys carry a leading namespace segment the lookup adds.
+ */
+function createSuffixCacheBackend(entries: Record<string, string>): CacheBackend {
+  const values = new Map(Object.entries(entries));
+
+  function suffixKey(key: string): string {
+    const match = /^[^:]+:([^:]+):(.+)$/.exec(key);
+    if (!match) return key;
+    return `${match[1]}:${match[2]}`;
+  }
+
+  return {
+    type: "memory",
+    get: (key) => Promise.resolve(values.get(suffixKey(key)) ?? null),
+    set: (key, value) => {
+      values.set(suffixKey(key), value);
+      return Promise.resolve();
+    },
+    del: (key) => {
+      values.delete(suffixKey(key));
+      return Promise.resolve();
+    },
+  };
+}
 
 async function withModuleLoaderFixture<T>(
   files: Record<string, string>,
@@ -1780,6 +1815,11 @@ describe("module-loader/loadModule build-failure tagging", () => {
           );
 
           assertEquals(isBuildFailure(error), true);
+          assertEquals(
+            isTenantBuildFailure(error),
+            false,
+            "an asset-import compile failure is framework-owned: the transform seam must not attribute it to the tenant",
+          );
         });
       },
     );
@@ -2372,7 +2412,10 @@ describe("module-loader/loadModule", () => {
           "app/page.pinned.mjs",
         );
         await Deno.mkdir(dirname(artifactPath), { recursive: true });
-        await Deno.writeTextFile(artifactPath, `export const value = "pinned";`);
+        // A sentinel the on-disk source cannot produce, so the assertion below
+        // separates "served from the pinned cache entry" from "re-transformed
+        // from source with the cache ignored".
+        await Deno.writeTextFile(artifactPath, `export const value = "from-pinned-cache";`);
         config.moduleCache.set(
           getModuleCacheKey(
             filePath,
@@ -2394,7 +2437,75 @@ describe("module-loader/loadModule", () => {
             moduleServerOrigin,
           });
 
-          assertEquals(loaded.value, "pinned");
+          assertEquals(
+            loaded.value,
+            "from-pinned-cache",
+            "the encoded dependency-pin cache artifact must be served instead of a fresh transform",
+          );
+        });
+      },
+    );
+  });
+
+  // The recovery seam is reached through a hard-coded dynamic import of
+  // #veryfront/transforms/esm/http-cache.ts, so it has to be driven for real:
+  // plant an artifact that imports an HTTP bundle which is absent from disk but
+  // present in the distributed cache, and let the import failure trigger it.
+  it("recovers an evicted HTTP bundle and retries the import", async () => {
+    await withModuleLoaderFixture(
+      { "app/page.ts": `export const value = "unused";` },
+      async ({ projectDir, tmpDir, config }) => {
+        const filePath = join(projectDir, "app/page.ts");
+        const url = "https://esm.sh/evicted@1";
+        const hash = await hashHttpCacheIdentity(
+          await buildHttpCacheIdentity(url, { importMap: { imports: {}, scopes: {} } }),
+        );
+        const bundleCode = "export const recovered = true;\n";
+
+        await runWithCacheDir(tmpDir, async () => {
+          const bundlePath = join(getHttpBundleCacheDir(), `http-${hash}.mjs`);
+          const artifactPath = join(tmpDir, "page.http-bundle.mjs");
+          await Deno.writeTextFile(
+            artifactPath,
+            `export { recovered } from ${JSON.stringify(toFileUrl(bundlePath).href)};\n`,
+          );
+          config.moduleCache.set(
+            getModuleCacheKey(
+              filePath,
+              undefined,
+              projectDir,
+              undefined,
+              undefined,
+              "development",
+            ),
+            artifactPath,
+          );
+
+          __injectCachesForTests({ cachedPaths: new Map<string, string>() });
+          __setDistributedCacheAccessorForTests(() =>
+            Promise.resolve(createSuffixCacheBackend({
+              [`code:${hash}`]: bundleCode,
+              [`hash:${hash}`]: url,
+            }))
+          );
+
+          try {
+            const loaded = await loadModule(filePath, config);
+
+            assertEquals(
+              loaded.recovered,
+              true,
+              "an import that failed on an evicted HTTP bundle must be retried after recovery",
+            );
+            assertEquals(
+              await Deno.readTextFile(bundlePath),
+              bundleCode,
+              "the evicted bundle must be restored to the HTTP bundle cache dir the error named",
+            );
+          } finally {
+            __setDistributedCacheAccessorForTests(null);
+            __injectCachesForTests(null);
+          }
         });
       },
     );

--- a/src/rendering/orchestrator/module-loader/module-cache-lookup.test.ts
+++ b/src/rendering/orchestrator/module-loader/module-cache-lookup.test.ts
@@ -237,6 +237,88 @@ describe("module-loader/module-cache-lookup", () => {
     });
   });
 
+  it("evicts in-memory entries whose cached file no longer exists", async () => {
+    const moduleCache = new Map([["cache-key", "/tmp/gone.js"]]);
+
+    assertEquals(
+      await resolveCachedModulePath({
+        cacheKey: "cache-key",
+        filePath: "/project/app/page.tsx",
+        projectDir: "/project",
+        moduleCache,
+        readTextFile: () => Promise.reject(new Deno.errors.NotFound("gone")),
+      }),
+      undefined,
+      "a cached artifact that no longer exists on disk must not be reused",
+    );
+    assertEquals(
+      moduleCache.has("cache-key"),
+      false,
+      "the stale in-memory pointer must be evicted so the next load rebuilds",
+    );
+  });
+
+  it("does not consult the MDX-ESM artifact cache without both project and content-source ids", async () => {
+    let lookups = 0;
+    const lookupMdxCache = () => {
+      lookups += 1;
+      return Promise.resolve({ status: "miss" } as const);
+    };
+
+    assertEquals(
+      await resolveCachedModulePath({
+        cacheKey: "cache-key",
+        filePath: "/project/app/page.tsx",
+        projectDir: "/project",
+        projectId: "project-id",
+        moduleCache: new Map<string, string>(),
+        lookupMdxCache,
+      }),
+      undefined,
+      "a project without a content source has no artifact directory to read",
+    );
+    assertEquals(
+      await resolveCachedModulePath({
+        cacheKey: "cache-key",
+        filePath: "/project/app/page.tsx",
+        projectDir: "/project",
+        contentSourceId: "source-id",
+        moduleCache: new Map<string, string>(),
+        lookupMdxCache,
+      }),
+      undefined,
+      "a content source without a project has no artifact directory to read",
+    );
+    assertEquals(
+      lookups,
+      0,
+      "artifact lookup must stay scoped to a project and content source",
+    );
+  });
+
+  it("percent-encodes the content-source id in the artifact cache directory", async () => {
+    let observedCacheDir = "";
+
+    await resolveCachedModulePath({
+      cacheKey: "cache-key",
+      filePath: "/project/app/page.tsx",
+      projectDir: "/project",
+      projectId: "project-id",
+      contentSourceId: "a/../b",
+      moduleCache: new Map<string, string>(),
+      lookupMdxCache: (_path, cacheDir) => {
+        observedCacheDir = cacheDir;
+        return Promise.resolve({ status: "miss" });
+      },
+    });
+
+    assertEquals(
+      observedCacheDir.endsWith("/project-id/a%2F..%2Fb"),
+      true,
+      "content-source id must not escape its project cache directory",
+    );
+  });
+
   it("promotes an MDX-ESM cache hit into the in-memory cache", async () => {
     const moduleCache = new Map<string, string>();
 

--- a/src/rendering/orchestrator/module-loader/module-persistence.test.ts
+++ b/src/rendering/orchestrator/module-loader/module-persistence.test.ts
@@ -110,6 +110,57 @@ describe("module-loader/module-persistence", () => {
     }
   });
 
+  it("gives one module the same artifact identity whatever order its unresolved imports were discovered in", async () => {
+    const projectDir = await makeTempDir({ prefix: "vf-module-persist-project-" });
+    const tmpDir = await makeTempDir({ prefix: "vf-module-persist-out-" });
+    const localAdapter = await getLocalAdapter();
+    const filePath = join(projectDir, "app/page.tsx");
+    const transformedCode = "export const page = 1;";
+
+    try {
+      // Two workers discover the same unresolved imports in different orders,
+      // one of them twice. The artifact identity must not fork.
+      const firstPath = await persistTransformedModule({
+        filePath,
+        projectDir,
+        tmpDir,
+        transformedCode,
+        localAdapter,
+        moduleCache: new Map(),
+        cacheKey: "unordered-first",
+        contentSourceId: "preview-main",
+        reactVersion: "19.1.1",
+        unresolvedSpecifiers: ["./b", "./a", "./b"],
+      });
+      const secondPath = await persistTransformedModule({
+        filePath,
+        projectDir,
+        tmpDir,
+        transformedCode,
+        localAdapter,
+        moduleCache: new Map(),
+        cacheKey: "unordered-second",
+        contentSourceId: "preview-main",
+        reactVersion: "19.1.1",
+        unresolvedSpecifiers: ["./a", "./b"],
+      });
+
+      assertEquals(
+        secondPath,
+        firstPath,
+        "discovery order and duplicates must not fork the artifact identity",
+      );
+      assertEquals(
+        await readPersistedUnresolvedSpecifiers(firstPath, localAdapter),
+        ["./a", "./b"],
+        "the sidecar must record sorted, deduplicated evidence",
+      );
+    } finally {
+      await remove(projectDir, { recursive: true }).catch(() => undefined);
+      await remove(tmpDir, { recursive: true }).catch(() => undefined);
+    }
+  });
+
   it("defers memory and path-cache publication until the graph commits", async () => {
     const projectDir = await makeTempDir({ prefix: "vf-module-persist-project-" });
     const tmpDir = await makeTempDir({ prefix: "vf-module-persist-out-" });
@@ -239,6 +290,54 @@ describe("module-loader/module-persistence", () => {
         await stagedArtifactLeftovers(cycleArtifactPath),
         [],
         "a rejected publish must leave no staged file behind",
+      );
+    } finally {
+      await remove(projectDir, { recursive: true }).catch(() => undefined);
+      await remove(tmpDir, { recursive: true }).catch(() => undefined);
+    }
+  });
+
+  it("fails closed when the artifact filesystem cannot rename", async () => {
+    const projectDir = await makeTempDir({ prefix: "vf-module-persist-project-" });
+    const tmpDir = await makeTempDir({ prefix: "vf-module-persist-out-" });
+    const localAdapter = await getLocalAdapter();
+    const cycleArtifactPath = join(tmpDir, "cycle/artifact.js");
+    // `rename` is optional on the FS adapter, so a filesystem without an
+    // atomic replacement is a real configuration, not a hypothetical one.
+    const fs = Object.create(localAdapter.fs) as typeof localAdapter.fs;
+    fs.rename = undefined;
+    const adapter = Object.create(localAdapter) as typeof localAdapter;
+    Object.defineProperty(adapter, "fs", { value: fs });
+
+    try {
+      await assertRejects(
+        () =>
+          persistTransformedModule({
+            filePath: join(projectDir, "app/page.ts"),
+            projectDir,
+            tmpDir,
+            transformedCode: "export const page = 1;",
+            localAdapter: adapter,
+            moduleCache: new Map(),
+            cacheKey: "cycle-no-rename",
+            cycleArtifactPath,
+          }),
+        Error,
+        "cannot publish an atomic replacement",
+        "a filesystem without atomic rename must fail with the classified cache error",
+      );
+
+      assertEquals(
+        await stagedArtifactLeftovers(cycleArtifactPath),
+        [],
+        "a failed publish must leave no staged .pending- file behind",
+      );
+      const published: string[] = [];
+      for await (const entry of readDir(dirname(cycleArtifactPath))) published.push(entry.name);
+      assertEquals(
+        published.includes(basename(cycleArtifactPath)),
+        false,
+        "a failed publish must not create the artifact path",
       );
     } finally {
       await remove(projectDir, { recursive: true }).catch(() => undefined);

--- a/src/rendering/orchestrator/module-loader/module-transform-cache.test.ts
+++ b/src/rendering/orchestrator/module-loader/module-transform-cache.test.ts
@@ -1,5 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertStrictEquals,
+} from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
@@ -61,6 +66,7 @@ describe("module-loader/module-transform-cache", () => {
     const callerController = new AbortController();
     const transformController = new AbortController();
     let observedSignal: AbortSignal | undefined;
+    let observedCacheSignal: AbortSignal | undefined;
 
     await transformModuleCodeWithCache({
       fileContent: "export const page = 1;",
@@ -71,10 +77,13 @@ describe("module-loader/module-transform-cache", () => {
       adapter: {} as RuntimeAdapter,
       signal: callerController.signal,
       deps: createDeps({
-        getOrComputeTransform: async (_key, compute) => ({
-          code: await compute(undefined, transformController.signal),
-          cacheHit: false,
-        }),
+        getOrComputeTransform: async (_key, compute, _ttl, _progress, signal) => {
+          observedCacheSignal = signal;
+          return {
+            code: await compute(undefined, transformController.signal),
+            cacheHit: false,
+          };
+        },
         transformToESM: (_code, _filePath, _projectDir, _adapter, options) => {
           observedSignal = options.abortSignal;
           return Promise.resolve("export const page = 1;");
@@ -83,6 +92,40 @@ describe("module-loader/module-transform-cache", () => {
     });
 
     assertEquals(observedSignal, transformController.signal);
+    assertStrictEquals(
+      observedCacheSignal,
+      callerController.signal,
+      "caller cancellation must reach the transform cache",
+    );
+  });
+
+  it("stops after the transform when the caller has already aborted", async () => {
+    const callerController = new AbortController();
+
+    await assertRejects(
+      () =>
+        transformModuleCodeWithCache({
+          fileContent: "export const page = 1;",
+          filePath: "/project/app/page.tsx",
+          projectDir: "/project",
+          effectiveProjectId: "project-1",
+          mode: "production",
+          adapter: {} as RuntimeAdapter,
+          signal: callerController.signal,
+          deps: createDeps({
+            getOrComputeTransform: () => {
+              callerController.abort(new Error("render cancelled"));
+              return Promise.resolve({
+                code: "export const page = 1;",
+                cacheHit: true,
+              });
+            },
+          }),
+        }),
+      Error,
+      "render cancelled",
+      "an abort raised while the cached transform ran must stop the module load",
+    );
   });
 
   it("isolates outer transform cache keys by React, runtime, pins, and server externals", async () => {
@@ -434,8 +477,10 @@ describe("module-loader/module-transform-cache", () => {
 
   it("retries through the transform pipeline when cached code has unresolved _vf_modules imports", async () => {
     const retryCode = "export const page = 2;";
-    const setCalls: Array<{ code: string; hash: string }> = [];
+    const setCalls: Array<{ key: string; code: string; hash: string; ttl?: number }> = [];
     let pipelineCalls = 0;
+    let observedKey: string | undefined;
+    let observedTtl: number | undefined;
 
     const result = await transformModuleCodeWithCache({
       fileContent: "export const page = 2;",
@@ -447,11 +492,14 @@ describe("module-loader/module-transform-cache", () => {
       reactVersion: "19.1.1",
       ttlSeconds: 456,
       deps: createDeps({
-        getOrComputeTransform: () =>
-          Promise.resolve({
+        getOrComputeTransform: (key, _compute, ttl) => {
+          observedKey = key;
+          observedTtl = ttl;
+          return Promise.resolve({
             code: 'import React from "/_vf_modules/_veryfront/react.js";',
             cacheHit: true,
-          }),
+          });
+        },
         validateCachedBundlesByManifestOrCode: () =>
           Promise.resolve({
             valid: true,
@@ -468,8 +516,8 @@ describe("module-loader/module-transform-cache", () => {
           assertEquals(options.reactVersion, "19.1.1");
           return Promise.resolve({ code: retryCode });
         },
-        setCachedTransformAsync: (_key, code, hash) => {
-          setCalls.push({ code, hash });
+        setCachedTransformAsync: (key, code, hash, ttl) => {
+          setCalls.push({ key, code, hash, ttl });
           return Promise.resolve();
         },
       }),
@@ -477,9 +525,82 @@ describe("module-loader/module-transform-cache", () => {
 
     assertEquals(result.code, retryCode);
     assertEquals(pipelineCalls, 1);
-    assertEquals(setCalls, [{
-      code: retryCode,
-      hash: hashCodeHex(retryCode).slice(0, 16),
-    }]);
+    assertEquals(
+      observedTtl,
+      456,
+      "the caller-supplied TTL must reach the transform cache",
+    );
+    assertExists(
+      observedKey,
+      "the transform cache lookup must have been given a cache key",
+    );
+    assertEquals(
+      setCalls,
+      [{
+        key: observedKey,
+        code: retryCode,
+        hash: hashCodeHex(retryCode).slice(0, 16),
+        ttl: 456,
+      }],
+      "the repaired transform must be rewritten under the same cache key and TTL the lookup used",
+    );
+    assertEquals(
+      result.cacheKey,
+      observedKey,
+      "the returned cache key must be the key the lookup and the rewrite used",
+    );
+  });
+
+  it("does not write back a retry that still has unresolved _vf_modules imports", async () => {
+    const unresolvedRetryCode = [
+      'import React from "/_vf_modules/_veryfront/react.js";',
+      "export const page = 3;",
+    ].join("\n");
+    const setCalls: string[] = [];
+    let pipelineCalls = 0;
+
+    const result = await transformModuleCodeWithCache({
+      fileContent: "export const page = 3;",
+      filePath: "/project/app/page.tsx",
+      projectDir: "/project",
+      effectiveProjectId: "project-3",
+      mode: "development",
+      adapter: {} as RuntimeAdapter,
+      reactVersion: "19.1.1",
+      ttlSeconds: 456,
+      deps: createDeps({
+        getOrComputeTransform: () =>
+          Promise.resolve({
+            code: 'import React from "/_vf_modules/_veryfront/react.js";',
+            cacheHit: true,
+          }),
+        validateCachedBundlesByManifestOrCode: () =>
+          Promise.resolve({
+            valid: true,
+            failedHashes: [],
+            source: "code",
+          }),
+        runPipeline: () => {
+          pipelineCalls++;
+          return Promise.resolve({ code: unresolvedRetryCode });
+        },
+        setCachedTransformAsync: (key) => {
+          setCalls.push(key);
+          return Promise.resolve();
+        },
+      }),
+    });
+
+    assertEquals(pipelineCalls, 1, "the unresolved cached transform is retried once");
+    assertEquals(
+      setCalls,
+      [],
+      "a retry that still carries unresolved /_vf_modules/ imports must never be written back to the shared transform cache",
+    );
+    assertEquals(
+      result.code,
+      unresolvedRetryCode,
+      "the retry result is still returned to the caller, only the cache write is withheld",
+    );
   });
 });

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -1,5 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assert, assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { FakeTime } from "#std/testing/time";
 import { RenderPipeline, type RenderPipelineConfig } from "./pipeline.ts";
@@ -653,6 +658,67 @@ describe("RenderPipeline behavior", () => {
     assertEquals(persists, [{ slug: "", cacheKey: "index:environment-production" }]);
   });
 
+  it("returns the cached render without re-resolving or re-rendering the page", async () => {
+    let resolveCalls = 0;
+    let ssrCalls = 0;
+    let persists = 0;
+    const cachedResult = {
+      html: "<html>cached</html>",
+      frontmatter: {},
+      headings: [],
+      stream: null,
+      ssrHash: "cached-hash",
+    };
+    const pipeline = createPipeline("/project/pages/index.mdx", {
+      pageResolver: {
+        resolvePage: async () => {
+          resolveCalls += 1;
+          return {
+            entity: { path: "/project/pages/index.mdx", frontmatter: {} },
+          } as any;
+        },
+      } as any,
+      ssrOrchestrator: {
+        performSSRRendering: async () => {
+          ssrCalls += 1;
+          return {
+            fullHtml: "<html>fresh</html>",
+            finalStream: null,
+            ssrHash: "fresh-hash",
+          };
+        },
+        resolveErrorComponentPath: async () => null,
+      } as any,
+      cacheCoordinator: {
+        checkCache: async () => ({
+          cachedResult,
+          cacheStatus: "hit",
+          depAwareSlug: "",
+          moduleCacheKey: "index:environment-production",
+          lookupDurationMs: 0,
+        }),
+        persistResult: async () => {
+          persists += 1;
+        },
+      } as any,
+    } as Partial<RenderPipelineConfig>);
+
+    const result = await pipeline.renderPage("", { delivery: "string" });
+
+    assertEquals(result.html, "<html>cached</html>", "a cache hit must be served verbatim");
+    assertEquals(resolveCalls, 0, "a cache hit must not resolve the page");
+    assertEquals(ssrCalls, 0, "a cache hit must not re-render");
+    assertEquals(persists, 0, "a cache hit must not persist a new entry");
+
+    const bypassed = await pipeline.renderPage("", {
+      delivery: "string",
+      skipCacheCheck: true,
+    });
+
+    assertEquals(bypassed.html, "<html>fresh</html>", "skipCacheCheck must bypass the cache hit");
+    assertEquals(ssrCalls, 1, "skipCacheCheck must re-render the page");
+  });
+
   it("isolates preview HTML from the production render cache", () => {
     const pipeline = createPipeline("/project/pages/index.mdx");
     const buildCacheKey = (pipeline as unknown as {
@@ -694,6 +760,65 @@ describe("RenderPipeline behavior", () => {
         buildCacheKey("foo:environment-preview", { environment: "production" }, "off"),
       "preview and production route cache identities must not collide",
     );
+
+    assertEquals(
+      buildCacheKey("", {
+        request: new Request("http://localhost/", {
+          headers: { authorization: "Bearer x" },
+        }),
+      }, "off"),
+      null,
+      "a request carrying credentials must not produce a shared render cache key",
+    );
+    assertEquals(
+      buildCacheKey("", {
+        request: new Request("http://localhost/", {
+          headers: { cookie: "vf_session=abc" },
+        }),
+      }, "off"),
+      null,
+      "a request carrying a session cookie must not produce a shared render cache key",
+    );
+    assert(
+      buildCacheKey("", {
+        cacheKey: "custom",
+        request: new Request("http://localhost/", {
+          headers: { authorization: "Bearer x" },
+        }),
+      }, "off") !== null,
+      "an explicit cacheKey override stays authoritative",
+    );
+  });
+
+  it("never caches HTML rendered for a request that carries credentials", async () => {
+    const checks: Array<string | undefined> = [];
+    const persists: Array<string | undefined> = [];
+    const pipeline = createPipeline("/project/pages/index.mdx", {
+      cacheCoordinator: {
+        checkCache: async (slug, cacheKey) => {
+          checks.push(cacheKey);
+          return {
+            depAwareSlug: slug,
+            moduleCacheKey: cacheKey ?? slug,
+            cacheStatus: "miss",
+            lookupDurationMs: 0,
+          };
+        },
+        persistResult: async (_result, _slug, cacheKey) => {
+          persists.push(cacheKey);
+        },
+      },
+    } as Partial<RenderPipelineConfig>);
+
+    await pipeline.renderPage("", {
+      delivery: "string",
+      request: new Request("http://localhost/", {
+        headers: { authorization: "Bearer x" },
+      }),
+    });
+
+    assertEquals(checks, [], "personalized HTML must never be read from the shared render cache");
+    assertEquals(persists, [], "personalized HTML must never be persisted");
   });
 
   it("bounds the complete API render key for a flag-off override", () => {
@@ -1945,40 +2070,64 @@ describe("RenderPipeline behavior", () => {
     assertEquals(pageData.cssError, undefined);
   });
 
-  it("resolvePageData falls back to candidate extraction when no CSS link in HTML", async () => {
+  it("resolvePageData falls back to generated CSS when no CSS link in HTML", async () => {
+    const slug = "/behavior-css-fallback";
+    const projectId = "proj-css-fallback";
     const pipeline = createPipeline("/project/pages/behavior-css-fallback.tsx");
+    const renderedHtml =
+      `<!DOCTYPE html><html><head></head><body><div class="fallback">hello</div></body></html>`;
+    let seenHtml = "";
 
     (pipeline as any).loadModule = async () => ({});
-    (pipeline as any).renderPage = async () => ({
-      html:
-        `<!DOCTYPE html><html><head></head><body><div class="fallback">hello</div></body></html>`,
-    });
-
-    // Intercept resolveCssFromRenderedHtml to confirm it returns undefined (no hash in HTML)
-    const originalResolve = (pipeline as any).resolveCssFromRenderedHtml.bind(pipeline);
-    (pipeline as any).resolveCssFromRenderedHtml = async (html: string) => {
-      const result = await originalResolve(html);
-      assertEquals(result, undefined, "Should not find CSS hash in HTML without /_vf/css/ link");
-      return result;
+    (pipeline as any).renderPage = async () => ({ html: renderedHtml });
+    (pipeline as any).resolveCssFromRenderedHtml = async () => undefined;
+    (pipeline as any).generatePageCssFromHtml = async (_slug: string, html: string) => {
+      seenHtml = html;
+      return ".fallback{display:block}";
     };
 
-    // Pre-cache the CSS that generateTailwindCSS would produce for our candidates
-    // so we don't depend on the Tailwind compiler actually working in CI
-    const { extractCandidates } = await import("#veryfront/html/styles-builder/index.ts");
-    const html =
-      `<!DOCTYPE html><html><head></head><body><div class="fallback">hello</div></body></html>`;
-    const candidatesReceived = extractCandidates(html);
+    const pageData = await pipeline.resolvePageData(slug, {
+      projectId,
+      request: new Request(`http://localhost${slug}`),
+      url: new URL(`http://localhost${slug}`),
+      environment: "production",
+    });
 
-    // Verify candidates were actually extracted from the HTML
     assertEquals(
-      Array.isArray(candidatesReceived),
-      true,
-      "extractCandidates should return an array",
+      pageData.css,
+      ".fallback{display:block}",
+      "page data falls back to generated CSS when the HTML carries no /_vf/css link",
     );
+    assertEquals(pageData.cssAction, undefined, "the fallback path must not clear client CSS");
+    assertEquals(pageData.cssError, undefined, "a successful fallback reports no CSS error");
+    assertStringIncludes(
+      seenHtml,
+      'class="fallback"',
+      "the fallback generator receives the rendered HTML",
+    );
+  });
+
+  it("resolvePageData reports a CSS generation failure instead of swallowing it", async () => {
+    const slug = "/behavior-css-error";
+    const projectId = "proj-css-error";
+    const pipeline = createPipeline("/project/pages/behavior-css-error.tsx");
+
+    (pipeline as any).loadModule = async () => ({});
+    (pipeline as any).renderPage = () => Promise.reject(new Error("css ssr blew up"));
+
+    const pageData = await pipeline.resolvePageData(slug, {
+      projectId,
+      request: new Request(`http://localhost${slug}`),
+      url: new URL(`http://localhost${slug}`),
+      environment: "production",
+    });
+
     assertEquals(
-      candidatesReceived!.length > 0,
-      true,
-      "Should extract at least one candidate from HTML",
+      pageData.cssError,
+      "CSS generation failed: css ssr blew up",
+      "clients must be able to distinguish a CSS failure from no CSS",
     );
+    assertEquals(pageData.css, undefined, "a failed CSS render must not report CSS");
+    assertEquals(pageData.cssAction, undefined, "a failed CSS render must not clear client CSS");
   });
 });

--- a/src/rendering/orchestrator/pipeline.test.ts
+++ b/src/rendering/orchestrator/pipeline.test.ts
@@ -3,7 +3,13 @@ import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { RenderPipelineConfig } from "./pipeline.ts";
 import { isDotPath, isHiddenSegment } from "./path-helpers.ts";
-import { getPageCssCacheKey } from "./css-cache.ts";
+import {
+  __pageCssCacheForTests,
+  cachePageCss,
+  getCachedPageCss,
+  getPageCssCacheKey,
+  PAGE_CSS_CACHE_MAX_SIZE,
+} from "./css-cache.ts";
 import { collectModulesToLoad, hasDataFetchingFunction } from "./module-collection.ts";
 import {
   extractRenderedCssHash,
@@ -12,20 +18,12 @@ import {
   serializeLayouts,
 } from "./pipeline-helpers.ts";
 
-const PAGE_CSS_CACHE_MAX_SIZE = 200;
-const pageCssCache = new Map<string, string>();
+/** Keys a type still declares as non-optional. */
+type RequiredKeys<T> = {
+  [K in keyof T]-?: Record<never, never> extends Pick<T, K> ? never : K;
+}[keyof T];
 
-function getCachedPageCss(cacheKey: string): string | undefined {
-  return pageCssCache.get(cacheKey);
-}
-
-function cachePageCss(cacheKey: string, css: string): void {
-  if (pageCssCache.size >= PAGE_CSS_CACHE_MAX_SIZE && !pageCssCache.has(cacheKey)) {
-    const firstKey = pageCssCache.keys().next().value as string | undefined;
-    if (firstKey) pageCssCache.delete(firstKey);
-  }
-  pageCssCache.set(cacheKey, css);
-}
+type RequiredConfigField = RequiredKeys<RenderPipelineConfig>;
 
 describe("RenderPipeline helpers", () => {
   describe("pipeline-helpers", () => {
@@ -152,36 +150,78 @@ describe("RenderPipeline helpers", () => {
 
   describe("pageCssCache (LRU eviction)", () => {
     it("should store and retrieve cached CSS", () => {
-      pageCssCache.clear();
+      __pageCssCacheForTests.clear();
       cachePageCss("key1", ".body { color: red; }");
-      assertEquals(getCachedPageCss("key1"), ".body { color: red; }");
+      assertEquals(
+        getCachedPageCss("key1"),
+        ".body { color: red; }",
+        "cached page CSS is served back verbatim",
+      );
     });
 
     it("should return undefined for missing keys", () => {
-      pageCssCache.clear();
-      assertEquals(getCachedPageCss("nonexistent"), undefined);
+      __pageCssCacheForTests.clear();
+      assertEquals(
+        getCachedPageCss("nonexistent"),
+        undefined,
+        "an uncached key must report a miss",
+      );
     });
 
     it("should update existing keys without eviction", () => {
-      pageCssCache.clear();
+      __pageCssCacheForTests.clear();
       cachePageCss("key1", "old-css");
       cachePageCss("key1", "new-css");
-      assertEquals(getCachedPageCss("key1"), "new-css");
-      assertEquals(pageCssCache.size, 1);
+      assertEquals(getCachedPageCss("key1"), "new-css", "re-caching a key overwrites its CSS");
+      assertEquals(
+        __pageCssCacheForTests.size,
+        1,
+        "overwriting a key must not add a second entry",
+      );
     });
 
-    it("should evict oldest entry when at max capacity", () => {
-      pageCssCache.clear();
+    it("should evict least-recently-used entry when at max capacity", () => {
+      __pageCssCacheForTests.clear();
 
       for (let i = 0; i < PAGE_CSS_CACHE_MAX_SIZE; i++) {
         cachePageCss(`fill-${i}`, `css-${i}`);
       }
-      assertEquals(pageCssCache.size, PAGE_CSS_CACHE_MAX_SIZE);
+      assertEquals(
+        __pageCssCacheForTests.size,
+        PAGE_CSS_CACHE_MAX_SIZE,
+        "the page CSS cache holds exactly its configured capacity",
+      );
+
+      // Reading fill-0 promotes it, so fill-1 becomes the least-recently-used entry.
+      assertEquals(
+        getCachedPageCss("fill-0"),
+        "css-0",
+        "a filled entry is readable before eviction",
+      );
 
       cachePageCss("overflow-key", "overflow-css");
-      assertEquals(pageCssCache.size, PAGE_CSS_CACHE_MAX_SIZE);
-      assertEquals(getCachedPageCss("fill-0"), undefined);
-      assertEquals(getCachedPageCss("overflow-key"), "overflow-css");
+      assertEquals(
+        __pageCssCacheForTests.size,
+        PAGE_CSS_CACHE_MAX_SIZE,
+        "an insert past capacity must not grow the cache",
+      );
+      assertEquals(
+        getCachedPageCss("fill-0"),
+        "css-0",
+        "a recently read entry must survive eviction",
+      );
+      assertEquals(
+        getCachedPageCss("fill-1"),
+        undefined,
+        "the least-recently-used entry must be evicted",
+      );
+      assertEquals(
+        getCachedPageCss("overflow-key"),
+        "overflow-css",
+        "the newly inserted entry must be present",
+      );
+
+      __pageCssCacheForTests.clear();
     });
   });
 
@@ -275,7 +315,11 @@ describe("RenderPipeline helpers", () => {
 
   describe("RenderPipelineConfig type", () => {
     it("should require all configuration fields", () => {
-      const requiredFields = [
+      // RenderPipelineConfig itself is the oracle: RequiredConfigField only
+      // contains keys the interface still declares as non-optional, so making
+      // any listed field optional (or removing it) fails the test typecheck
+      // instead of silently leaving the literal below untouched.
+      const requiredFields: RequiredConfigField[] = [
         "pageResolver",
         "cacheCoordinator",
         "pageRenderer",
@@ -286,7 +330,11 @@ describe("RenderPipeline helpers", () => {
         "projectDir",
         "isLocalProject",
       ];
-      assertEquals(requiredFields.length, 9);
+      assertEquals(
+        requiredFields.length,
+        9,
+        "every pipeline collaborator and render-mode field stays required",
+      );
     });
 
     it("should accept development mode", () => {

--- a/src/rendering/orchestrator/render-result-assembly.test.ts
+++ b/src/rendering/orchestrator/render-result-assembly.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { waitFor } from "#veryfront/testing/deno-compat.ts";
 import { assembleRenderResult } from "./render-result-assembly.ts";
 import type { RenderResult } from "./types.ts";
 
@@ -41,8 +42,46 @@ describe("render-result-assembly", () => {
 
   it("persists cacheable results without waiting for persistence", () => {
     let persisted:
-      | { result: RenderResult; slug: string; cacheKey: string | undefined }
+      | {
+        result: RenderResult;
+        slug: string;
+        cacheKey: string | undefined;
+        nonce: string | undefined;
+      }
       | undefined;
+
+    const result = assembleRenderResult({
+      slug: "/cached",
+      cacheKey: "cache:/cached",
+      nonce: "nonce-abc123",
+      ssrResult: {
+        fullHtml: "<html></html>",
+        finalStream: null,
+      },
+      pageBundle: {
+        compiledCode: "",
+      },
+      shouldCache: true,
+      cacheCoordinator: {
+        persistResult: async (result, slug, cacheKey, nonce) => {
+          persisted = { result, slug, cacheKey, nonce };
+        },
+      },
+    });
+
+    assertExists(persisted);
+    assertEquals(persisted.slug, "/cached");
+    assertEquals(persisted.cacheKey, "cache:/cached");
+    assertEquals(persisted.result, result);
+    assertEquals(
+      persisted.nonce,
+      "nonce-abc123",
+      "the per-response nonce must reach the cache coordinator so it can be sealed out of the cached HTML",
+    );
+  });
+
+  it("logs and swallows a failed background cache persist", async () => {
+    const logged: { message: string; metadata?: Record<string, unknown> }[] = [];
 
     const result = assembleRenderResult({
       slug: "/cached",
@@ -56,16 +95,39 @@ describe("render-result-assembly", () => {
       },
       shouldCache: true,
       cacheCoordinator: {
-        persistResult: async (result, slug, cacheKey) => {
-          persisted = { result, slug, cacheKey };
+        persistResult: () => Promise.reject(new Error("store down")),
+      },
+      logger: {
+        error: (message, metadata) => {
+          logged.push({ message, metadata });
         },
       },
     });
 
-    assertExists(persisted);
-    assertEquals(persisted.slug, "/cached");
-    assertEquals(persisted.cacheKey, "cache:/cached");
-    assertEquals(persisted.result, result);
+    assertEquals(
+      result.html,
+      "<html></html>",
+      "assembly must not await persistence",
+    );
+
+    await waitFor(() => logged.length === 1, {
+      message: "the failed background persist is reported to the logger",
+    });
+    assertEquals(
+      logged[0]?.message,
+      "Cache persist failed",
+      "a rejected background persist must be logged, not left unhandled",
+    );
+    assertEquals(
+      logged[0]?.metadata?.slug,
+      "/cached",
+      "the log record names the slug whose persist failed",
+    );
+    assertEquals(
+      logged[0]?.metadata?.error,
+      "store down",
+      "the log record carries the underlying failure message",
+    );
   });
 
   it("skips persistence when cache persistence is disabled", () => {

--- a/src/rendering/orchestrator/ssr-orchestrator.test.ts
+++ b/src/rendering/orchestrator/ssr-orchestrator.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assert, assertEquals } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { SSROrchestrator, type SSROrchestratorConfig } from "./ssr-orchestrator.ts";
 import * as React from "react";
@@ -13,6 +13,8 @@ import {
 } from "#veryfront/transforms/mdx/esm-module-loader/module-fetcher/render-sessions.ts";
 import { getHeadCollectorNonce } from "#veryfront/react/head-collector.ts";
 import type { SSRRenderOptions } from "../ssr-renderer.ts";
+import { computeHash } from "../utils/index.ts";
+import { notFound } from "#veryfront/data/helpers.ts";
 
 function createMockConfig(overrides: Partial<SSROrchestratorConfig> = {}): SSROrchestratorConfig {
   return {
@@ -168,6 +170,7 @@ describe("rendering/orchestrator/ssr-orchestrator", () => {
         },
       });
 
+      let shellInput: unknown;
       const config = createMockConfig({
         ssrRenderer: {
           renderToHTML: async () => ({
@@ -177,7 +180,10 @@ describe("rendering/orchestrator/ssr-orchestrator", () => {
         } as unknown as SSROrchestratorConfig["ssrRenderer"],
         htmlGenerator: {
           generateFullHTML: async () => "",
-          generateHTMLStream: async () => new ReadableStream(),
+          generateHTMLStream: async (stream: ReadableStream) => {
+            shellInput = stream;
+            return new ReadableStream();
+          },
         } as unknown as SSROrchestratorConfig["htmlGenerator"],
       });
 
@@ -200,7 +206,16 @@ describe("rendering/orchestrator/ssr-orchestrator", () => {
       );
 
       assertEquals(result.finalStream instanceof ReadableStream, true);
-      assertEquals(typeof result.ssrHash, "string");
+      assertStrictEquals(
+        shellInput,
+        mockStream,
+        "the shell generator must receive the renderer's own stream",
+      );
+      assertEquals(
+        result.ssrHash,
+        await computeHash("<div>streamed</div>"),
+        "buffered streaming html must produce a content hash",
+      );
     });
 
     it("preserves stream readiness metadata through HTML shell generation", async () => {
@@ -402,6 +417,103 @@ describe("rendering/orchestrator/ssr-orchestrator", () => {
       assertEquals(wrappedProps, { preview: true });
       assertEquals(wrappedFrontmatter, { section: "blog", title: "Hello" });
       assertEquals(wrappedSignal, controller.signal);
+    });
+
+    it("rethrows the original render error when the segment has no error boundary", async () => {
+      const pageError = new Error("page failed");
+      const config = createMockConfig({
+        ssrRenderer: {
+          renderToHTML: async () => {
+            throw pageError;
+          },
+        } as unknown as SSROrchestratorConfig["ssrRenderer"],
+        htmlGenerator: {
+          resolveErrorComponent: async () => null,
+          generateFullHTML: async (ctx: { html: string }) =>
+            `<!doctype html><html><body>${ctx.html}</body></html>`,
+          generateHTMLStream: async () => new ReadableStream(),
+        } as unknown as SSROrchestratorConfig["htmlGenerator"],
+      });
+
+      const orchestrator = new SSROrchestrator(config);
+      let caught: unknown;
+
+      try {
+        await orchestrator.performSSRRendering(
+          React.createElement("main"),
+          {
+            meta: { title: "Boom", slug: "/boom" },
+            pageBundle: {
+              compiledCode: "",
+              frontmatter: {},
+              globals: {},
+              headings: [],
+              nodeMap: new Map(),
+            },
+          } as any,
+        );
+      } catch (error) {
+        caught = error;
+      }
+
+      assertStrictEquals(
+        caught,
+        pageError,
+        "the original page error must propagate unchanged to the 500 / dev-overlay path",
+      );
+    });
+
+    it("propagates an SSR control outcome without consulting the error boundary", async () => {
+      const controlOutcome = notFound();
+      let resolveErrorComponentCalls = 0;
+      const config = createMockConfig({
+        ssrRenderer: {
+          renderToHTML: async () => {
+            throw controlOutcome;
+          },
+        } as unknown as SSROrchestratorConfig["ssrRenderer"],
+        htmlGenerator: {
+          resolveErrorComponent: async () => {
+            resolveErrorComponentCalls += 1;
+            return null;
+          },
+          generateFullHTML: async (ctx: { html: string }) =>
+            `<!doctype html><html><body>${ctx.html}</body></html>`,
+          generateHTMLStream: async () => new ReadableStream(),
+        } as unknown as SSROrchestratorConfig["htmlGenerator"],
+      });
+
+      const orchestrator = new SSROrchestrator(config);
+      let caught: unknown;
+
+      try {
+        await orchestrator.performSSRRendering(
+          React.createElement("main"),
+          {
+            meta: { title: "Missing", slug: "/missing" },
+            pageBundle: {
+              compiledCode: "",
+              frontmatter: {},
+              globals: {},
+              headings: [],
+              nodeMap: new Map(),
+            },
+          } as any,
+        );
+      } catch (error) {
+        caught = error;
+      }
+
+      assertStrictEquals(
+        caught,
+        controlOutcome,
+        "a thrown notFound() must reach the SSR error handler as a control outcome, not a render failure",
+      );
+      assertEquals(
+        resolveErrorComponentCalls,
+        0,
+        "a control outcome must not be routed through the app-router error boundary",
+      );
     });
   });
 });

--- a/src/rendering/page-resolution/page-resolver.test.ts
+++ b/src/rendering/page-resolution/page-resolver.test.ts
@@ -1,7 +1,18 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertRejects,
+  assertStrictEquals,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { PageResolver } from "./page-resolver.ts";
+import { VeryfrontError } from "#veryfront/errors";
+import {
+  clearRouterDetectionCacheForProject,
+  primeRouterDetectionCache,
+} from "#veryfront/rendering/router-detection.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 
@@ -55,6 +66,25 @@ function createMockConfig(overrides: Partial<VeryfrontConfig> = {}): VeryfrontCo
   } as VeryfrontConfig;
 }
 
+/** An adapter whose project holds no routable file at all. */
+function createEmptyProjectAdapter(): RuntimeAdapter {
+  return {
+    id: "memory",
+    fs: {
+      ...virtualTextRead(() => Promise.reject(fileNotFoundError())),
+      resolveFile: async () => null,
+      stat: async () => {
+        throw fileNotFoundError();
+      },
+      exists: async () => false,
+      readDir: async function* () {},
+      writeFile: async () => {},
+      mkdir: async () => {},
+    },
+    env: { get: () => undefined },
+  } as unknown as RuntimeAdapter;
+}
+
 describe("rendering/page-resolution/page-resolver", () => {
   describe("PageResolver constructor", () => {
     it("should create a resolver with required options", () => {
@@ -68,16 +98,48 @@ describe("rendering/page-resolution/page-resolver", () => {
       assertEquals(resolver instanceof PageResolver, true);
     });
 
-    it("should accept optional projectId", () => {
-      const adapter = createMockAdapter();
+    it("should accept optional projectId", async () => {
+      // The router-detection cache is keyed by projectId, so a primed entry is
+      // the observable proof that the constructor kept the identity.
+      const adapter = createMockAdapter(
+        {
+          "/project": [{ name: "pages", isFile: false, isDirectory: true }],
+          "/project/pages": [],
+        },
+        ["/project/pages"],
+      );
       const config = createMockConfig();
-      const resolver = new PageResolver({
-        projectDir: "/project",
-        projectId: "my-project",
-        config,
-        adapter,
-      });
-      assertEquals(resolver instanceof PageResolver, true);
+      clearRouterDetectionCacheForProject("my-project");
+      clearRouterDetectionCacheForProject("/project");
+      primeRouterDetectionCache("my-project", "app");
+
+      try {
+        const resolver = new PageResolver({
+          projectDir: "/project",
+          projectId: "my-project",
+          config,
+          adapter,
+        });
+        assertEquals(
+          await resolver.getRouterMode(),
+          "app",
+          "projectId must key the router-detection cache",
+        );
+
+        const withoutProjectId = new PageResolver({
+          projectDir: "/project",
+          config,
+          adapter,
+        });
+        assertEquals(
+          await withoutProjectId.getRouterMode(),
+          "pages",
+          "a resolver without projectId must not read another project's primed detection",
+        );
+      } finally {
+        clearRouterDetectionCacheForProject("my-project");
+        clearRouterDetectionCacheForProject("/project");
+      }
     });
   });
 
@@ -496,6 +558,113 @@ describe("rendering/page-resolution/page-resolver", () => {
 
       assertEquals(page.entity.path, "/project/pages/index.tsx");
       assertEquals(routerMode, "app");
+    });
+  });
+
+  describe("resolvePage failures", () => {
+    it("raises the registry file-not-found identity for an unknown slug", async () => {
+      const resolver = new PageResolver({
+        projectDir: "/project",
+        projectId: "missing-app",
+        config: createMockConfig({ router: "app" } as any),
+        adapter: createEmptyProjectAdapter(),
+      });
+
+      const error = await assertRejects(
+        () => resolver.resolvePage("does-not-exist"),
+        VeryfrontError,
+      );
+
+      assertInstanceOf(
+        error,
+        VeryfrontError,
+        "the rejection must carry the registry error identity",
+      );
+      assertEquals(
+        error.slug,
+        "file-not-found",
+        "pageExists and the API 404 path key off this slug",
+      );
+      assertStringIncludes(
+        error.detail ?? error.message,
+        "Page not found: does-not-exist",
+        "the failure must name the slug that could not be resolved",
+      );
+      assertEquals(
+        (error.context as { router?: string } | undefined)?.router,
+        "app",
+        "the failure records the router that searched for the page",
+      );
+    });
+
+    it("records the pages router on a missing pages-router page", async () => {
+      const resolver = new PageResolver({
+        projectDir: "/project",
+        projectId: "missing-pages",
+        config: createMockConfig({ router: "pages" } as any),
+        adapter: createEmptyProjectAdapter(),
+      });
+
+      const error = await assertRejects(
+        () => resolver.resolvePage("does-not-exist"),
+        VeryfrontError,
+      );
+
+      assertInstanceOf(
+        error,
+        VeryfrontError,
+        "the rejection must carry the registry error identity",
+      );
+      assertEquals(
+        error.slug,
+        "file-not-found",
+        "pageExists and the API 404 path key off this slug",
+      );
+      assertEquals(
+        (error.context as { router?: string } | undefined)?.router,
+        "pages",
+        "the failure records the router that searched for the page",
+      );
+    });
+  });
+
+  describe("pageExists", () => {
+    it("reports a missing page as absent", async () => {
+      const resolver = new PageResolver({
+        projectDir: "/project",
+        projectId: "exists-missing",
+        config: createMockConfig({ router: "pages" } as any),
+        adapter: createEmptyProjectAdapter(),
+      });
+
+      assertEquals(
+        await resolver.pageExists("/no-such-page"),
+        false,
+        "a missing page must resolve false",
+      );
+    });
+
+    it("propagates a resolution failure instead of reporting the page missing", async () => {
+      const resolver = new PageResolver({
+        projectDir: "/project",
+        projectId: "exists-cancelled",
+        config: createMockConfig({ router: "pages" } as any),
+        adapter: createEmptyProjectAdapter(),
+      });
+      const controller = new AbortController();
+      const reason = new Error("cancelled");
+      controller.abort(reason);
+
+      const error = await assertRejects(
+        () => resolver.pageExists("/no-such-page", { signal: controller.signal }),
+        Error,
+      );
+
+      assertStrictEquals(
+        error,
+        reason,
+        "a cancelled resolution must not be reported as a missing page",
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Audit of all 28 test files under `src/rendering/orchestrator`, `page-resolution` and `context`.

Every change was **mutation checked** — the named source edit was applied, the test confirmed to fail, then reverted. 60 candidate findings, 54 confirmed after adversarial verification, 6 refuted.

## Source change: the ESM rewriter rewrote nothing

Every pattern in `rewriteEsmPaths` captures the quote as group 1 and the specifier as group 2 (or 2 and 3 for the named-export forms), and the table stores that specifier index:

```ts
[/import\s*(["'])(\/[^"']+)\1/g, 2, resolveAbsolute],
```

In a `String.replace` callback, `args[0]` is the whole match and capture group N is `args[N]`. The code read:

```ts
const path = args[pathIndex - 1];   // args[1] — the QUOTE, not the path
```

So `resolveAbsolute` was handed `"` and returned `https://esm.sh"`. **No specifier was ever correctly rewritten, for any of the eight patterns.**

The tell is the very next line, which was already correct:

```ts
const quote = pathIndex === 3 ? args[2] : args[1];
```

The quote lookup uses the right convention, so the path line is an obvious slip rather than a deliberate offset. `rewriteEsmPaths` and `fetchEsmModule` have no in-repo callers beyond the module-loader barrel, so the blast radius is consumers of that export.

## A test file that reimplemented its subject

`pipeline.test.ts` declared its own `PAGE_CSS_CACHE_MAX_SIZE`, a plain-`Map` `pageCssCache`, and local `getCachedPageCss` and `cachePageCss`. All four cases exercised **that copy**, so the production `LRUCache` in `css-cache.ts` was entirely untested. They now import the real cache and assert the real eviction policy including promote-on-read, so `maxEntries: 1` fails. **No case was removed** — they were rewired, not deleted.

## Other recurring weaknesses

**A test asserted its own literal against a hardcoded count:**

```ts
assertEquals(requiredFields.length, 9);
```

Adding or removing a required config field could not fail that. The array is now typed as `RequiredKeys<RenderPipelineConfig>`, making the interface itself the oracle. Worth noting the bite is in `lint:test-typecheck`, not the runtime run — `test:file` passes `--no-check`, so a purely type-shaped break cannot be observed at runtime by any test.

**Security defaults were unasserted.** Hosted renders that never requested host project-code execution now assert it stays denied, with the local and explicit-true arms alongside, so loosening the condition to `isLocal || field !== false` fails.

**Control-flow outcomes were not distinguished from errors.** An SSR control result (`notFound()`) now asserts it propagates *by identity* and that the error boundary is never consulted.

**Hash tests used pure-ASCII input**, so an ASCII-lossy hash passed. Non-ASCII inputs now assert distinct hashes for values differing only outside ASCII — a cache-key collision risk.

**Theme injection** now covers a quoted `>` inside the `<html>` tag and a layout declaring its own `data-theme`, so a naive `indexOf(">")` scan fails.

**Cache lookups** now assert eviction of entries whose backing file is gone, that the artifact cache is not consulted without both ids, and that the content-source id is percent-encoded in the directory name.

## Verification

- Semantic unit-boundary audit: ok, sanitizer ratchet: ok
- `test:layout`: ok, `docs:api-reference:check`: current
- `deno fmt`, `deno lint`: pass
- **23/23** changed test files pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when rendering cached content, streamed HTML, CSS, and layouts.
  * Fixed cyclic and nested module imports, including safer recovery after failed loads.
  * Improved cache isolation across projects, sessions, credentials, versions, and styling profiles.
  * Preserved expected behavior for missing pages, render failures, and framework control outcomes.
  * Improved cache recovery and handling of unresolved or failed module dependencies.
  * Fixed HTML attribute rendering and development-only hot-reload overlays.

* **Tests**
  * Expanded coverage for development, preview, and production rendering, cache invalidation, configuration fallbacks, and module loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->