### PR TITLE
test(transforms/pipeline,import-rewriter): make weak assertions bite

### DIFF
--- a/scripts/lint/check-sanitizer-baseline.ts
+++ b/scripts/lint/check-sanitizer-baseline.ts
@@ -23,9 +23,9 @@ import {
 
 // Lower this when you remove sanitizer opt-outs. Never raise it without a very
 // good reason — a new opt-out means a leak is being suppressed rather than fixed.
-// 354 after the transforms/mdx, transforms/esm, module, server-runtime, and
-// rendering/RSC audits removed their remaining sanitizer opt-outs.
-export const SANITIZER_OPT_OUT_BASELINE = 354;
+// 350 after the transforms/mdx, transforms/esm, transforms/pipeline, module,
+// server-runtime, server-handler, and rendering/RSC audits removed opt-outs.
+export const SANITIZER_OPT_OUT_BASELINE = 350;
 
 const OPT_OUT_PATTERN = /sanitize(?:Resources|Ops|Exit)\s*:\s*false/g;
 

--- a/scripts/lint/test-typecheck-baseline.json
+++ b/scripts/lint/test-typecheck-baseline.json
@@ -37,6 +37,5 @@
   "src/rendering/layouts/utils/hash-calculator.test.ts",
   "src/rendering/orchestrator/compiler-service.test.ts",
   "src/rendering/orchestrator/config.test.ts",
-  "src/rendering/utils/react-helpers.test.ts",
-  "src/transforms/import-rewriter/strategies/import-map-strategy.test.ts"
+  "src/rendering/utils/react-helpers.test.ts"
 ]

--- a/src/transforms/import-rewriter/__tests__/hydration-parity.test.ts
+++ b/src/transforms/import-rewriter/__tests__/hydration-parity.test.ts
@@ -9,7 +9,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { expect } from "#std/expect.ts";
 import { type RewriteContext, rewriteImports } from "../index.ts";
-import { DEFAULT_REACT_VERSION } from "../url-builder.ts";
+import { CSSTYPE_VERSION, DEFAULT_REACT_VERSION } from "../url-builder.ts";
 
 function createContext(overrides: Partial<RewriteContext>): RewriteContext {
   return {
@@ -38,11 +38,21 @@ describe("Hydration Parity", () => {
       expect(ssrResult).toContain(`https://esm.sh/react@${DEFAULT_REACT_VERSION}`);
       expect(browserResult).toContain(`https://esm.sh/react@${DEFAULT_REACT_VERSION}`);
 
-      const reactUrlPattern = /https:\/\/esm\.sh\/react@[\d.]+\?[^"']+/;
-      const ssrReactUrl = ssrResult.match(reactUrlPattern)?.[0];
-      const browserReactUrl = browserResult.match(reactUrlPattern)?.[0];
+      // Compare every emitted esm.sh URL, not just the first: a divergence in
+      // any single React entry (react/jsx-runtime especially) is a dual-React
+      // hydration break.
+      const esmShUrlPattern = /https:\/\/esm\.sh\/[^"']+/g;
+      const ssrReactUrls = [...ssrResult.matchAll(esmShUrlPattern)].map((match) => match[0]);
+      const browserReactUrls = [...browserResult.matchAll(esmShUrlPattern)].map(
+        (match) => match[0],
+      );
 
-      expect(ssrReactUrl).toBe(browserReactUrl);
+      expect(ssrReactUrls).toEqual([
+        `https://esm.sh/react@${DEFAULT_REACT_VERSION}?target=es2022&deps=csstype@${CSSTYPE_VERSION}`,
+        `https://esm.sh/react@${DEFAULT_REACT_VERSION}?target=es2022&deps=csstype@${CSSTYPE_VERSION}`,
+        `https://esm.sh/react@${DEFAULT_REACT_VERSION}/jsx-runtime?external=react&target=es2022&deps=csstype@${CSSTYPE_VERSION}`,
+      ]);
+      expect(browserReactUrls).toEqual(ssrReactUrls);
     });
 
     it("should use same query params for React packages", async () => {

--- a/src/transforms/import-rewriter/dependency-resolution.test.ts
+++ b/src/transforms/import-rewriter/dependency-resolution.test.ts
@@ -17,6 +17,7 @@ import {
 import {
   isPinningEnabledForRewrite,
   resolveDependencyPinForImport,
+  validateDependencyResolutionObservations,
 } from "./dependency-resolution.ts";
 
 interface MemoryPackageState {
@@ -428,6 +429,116 @@ describe("dependency resolution write-back authority", () => {
     const request = requests[0]!;
     assertEquals(request.specifiers, ["__proto__@^1.2.3"]);
     assertEquals(request.expected["__proto__"], "^1.2.3");
+  });
+});
+
+describe("validateDependencyResolutionObservations", () => {
+  const dependencies: Readonly<Record<string, string>> = { zod: "^3", lodash: "4.17.21" };
+
+  it("replays observations that match the current dependency map", () => {
+    assertEquals(
+      validateDependencyResolutionObservations(
+        [
+          { packageName: "zod", declaration: "^3" },
+          { packageName: "undeclared", declaration: null },
+        ],
+        dependencies,
+      ),
+      [
+        { packageName: "zod", declaration: "^3" },
+        { packageName: "undeclared", declaration: null },
+      ],
+      "observations agreeing with the current snapshot must replay unchanged",
+    );
+  });
+
+  it("rejects a duplicate package observation", () => {
+    assertEquals(
+      validateDependencyResolutionObservations(
+        [
+          { packageName: "zod", declaration: "^3" },
+          { packageName: "zod", declaration: "^3" },
+        ],
+        dependencies,
+      ),
+      null,
+      "a duplicate package name must not replay",
+    );
+  });
+
+  it("rejects a declaration captured under another snapshot", () => {
+    assertEquals(
+      validateDependencyResolutionObservations(
+        [{ packageName: "zod", declaration: "^4" }],
+        dependencies,
+      ),
+      null,
+      "a declaration that disagrees with the current map must not replay",
+    );
+  });
+
+  it("rejects an undeclared package claimed as declared", () => {
+    assertEquals(
+      validateDependencyResolutionObservations(
+        [{ packageName: "undeclared", declaration: "^1" }],
+        dependencies,
+      ),
+      null,
+      "an undeclared package must observe a null declaration",
+    );
+  });
+
+  it("rejects observations when the dependency map is unknown", () => {
+    assertEquals(
+      validateDependencyResolutionObservations(
+        [{ packageName: "zod", declaration: "^3" }],
+        undefined,
+      ),
+      null,
+      "an unverified dependency map must not authorize a replay",
+    );
+    assertEquals(
+      validateDependencyResolutionObservations([], undefined),
+      [],
+      "an empty observation list stays safe without a dependency map",
+    );
+  });
+
+  it("rejects malformed observation metadata", () => {
+    assertEquals(
+      validateDependencyResolutionObservations("not-an-array", dependencies),
+      null,
+      "a non-array value must not replay",
+    );
+    assertEquals(
+      validateDependencyResolutionObservations([null], dependencies),
+      null,
+      "a null entry must not replay",
+    );
+    assertEquals(
+      validateDependencyResolutionObservations(
+        [{ packageName: 7, declaration: null }],
+        dependencies,
+      ),
+      null,
+      "a non-string package name must not replay",
+    );
+    assertEquals(
+      validateDependencyResolutionObservations(
+        [{ packageName: "", declaration: null }],
+        dependencies,
+      ),
+      null,
+      "an empty package name must not replay",
+    );
+    assertEquals(
+      validateDependencyResolutionObservations(
+        [{ packageName: "zod", declaration: 3 }],
+        dependencies,
+      ),
+      null,
+      "a non-string declaration must not replay",
+    );
   });
 });
 

--- a/src/transforms/import-rewriter/parse-cache.test.ts
+++ b/src/transforms/import-rewriter/parse-cache.test.ts
@@ -87,9 +87,11 @@ export { foo } from "bar";
       // statementStart..statementEnd includes the semicolon, so the replacement must include it
       const rewrites = new Map([[0, { statement: `import React from "preact/compat"` }]]);
       const result = applyRewrites(code, parsed, rewrites);
-      // The statement replacement replaces ss..se, which may or may not include the trailing semicolon
-      assertEquals(result.includes("preact/compat"), true);
-      assertEquals(result.includes(`"react"`), false);
+      assertEquals(
+        result,
+        `import React from "preact/compat";`,
+        "the statement is replaced between statementStart and statementEnd, leaving the trailing semicolon",
+      );
     });
 
     it("does nothing for empty rewrites map", async () => {
@@ -118,8 +120,11 @@ import { render } from "react-dom";
         [1, { specifier: "preact-dom" }],
       ]);
       const result = applyRewrites(code, parsed, rewrites);
-      assertEquals(result.includes("preact"), true);
-      assertEquals(result.includes("preact-dom"), true);
+      assertEquals(
+        result,
+        `import React from "preact";\nimport { render } from "preact-dom";`,
+        "both specifiers are rewritten and the surrounding positions stay intact",
+      );
     });
 
     it("restores HTTP URLs in non-rewritten parts", async () => {

--- a/src/transforms/import-rewriter/ssr-adapter.test.ts
+++ b/src/transforms/import-rewriter/ssr-adapter.test.ts
@@ -9,6 +9,10 @@ import {
   _pendingResolutions,
   _setDependencyResolutionPosterForTest,
 } from "#veryfront/transforms/esm/npm-registry-client.ts";
+import {
+  type DependencyPinningSource,
+  getDependencyPinningSnapshot,
+} from "#veryfront/transforms/esm/package-registry.ts";
 import { rewriteSSRImportsCompat, rewriteSSRImportsCompatAsync } from "./ssr-adapter.ts";
 import type { DependencyResolutionObservation } from "./dependency-resolution.ts";
 
@@ -182,9 +186,25 @@ describe("ssr-adapter — server external packages", () => {
     const reordered = rewriteSSRImportsCompat(code, {
       serverExternalPackages: ["@prisma/client", "knex"],
     });
+    const knexSuperset = rewriteSSRImportsCompat(code, {
+      serverExternalPackages: ["knex", "zod"],
+    });
 
-    assertEquals(knex === prisma, false);
-    assertEquals(ordered, reordered);
+    assertEquals(
+      knex === prisma,
+      false,
+      "different external package sets must not share a cache buster",
+    );
+    assertEquals(
+      ordered,
+      reordered,
+      "the external package set order must not change the cache buster",
+    );
+    assertEquals(
+      knex === knexSuperset,
+      false,
+      "a superset of external packages must not reuse the subset's cache buster",
+    );
   });
 
   it("partitions resolved child module URLs by the canonical external package set", async () => {
@@ -199,9 +219,23 @@ describe("ssr-adapter — server external packages", () => {
     const prisma = await rewrite(["@prisma/client"]);
     const ordered = await rewrite(["knex", "@prisma/client"]);
     const reordered = await rewrite(["@prisma/client", "knex"]);
+    const knexSuperset = await rewrite(["knex", "zod"]);
 
-    assertEquals(knex === prisma, false);
-    assertEquals(ordered, reordered);
+    assertEquals(
+      knex === prisma,
+      false,
+      "different external package sets must not share a cache buster",
+    );
+    assertEquals(
+      ordered,
+      reordered,
+      "the external package set order must not change the cache buster",
+    );
+    assertEquals(
+      knex === knexSuperset,
+      false,
+      "a superset of external packages must not reuse the subset's cache buster",
+    );
   });
 });
 
@@ -369,6 +403,63 @@ describe("ssr-adapter — resolveBareImportPin schedules background resolution",
     await _pendingResolutions();
 
     assertEquals(requests, []);
+  });
+
+  it("schedules special-package imports from a proven writeback source", async () => {
+    const requests: Array<{ projectId: string; specifiers: string[] }> = [];
+    _setDependencyResolutionPosterForTest((projectId, specifiers) => {
+      requests.push({ projectId, specifiers });
+      return Promise.resolve();
+    });
+
+    const content = JSON.stringify({
+      dependencies: { react: "^19.0.0", "react-dom": "next" },
+    });
+    const source: DependencyPinningSource = {
+      projectDir: "/project",
+      cacheNamespace: "ssr-adapter-special",
+      dependencyWritebackTarget: { kind: "main" },
+      fs: {
+        readFile: () => Promise.resolve(content),
+        stat: () =>
+          Promise.resolve({
+            size: content.length,
+            isFile: true,
+            isDirectory: false,
+            isSymlink: false,
+            mtime: new Date(1_000),
+          }),
+      },
+    };
+    const snapshot = await getDependencyPinningSnapshot(source);
+
+    rewriteSSRImportsCompat(
+      [
+        `import React from "react";`,
+        `import "react-dom/client";`,
+        `const loadHead = () => import("veryfront/head");`,
+      ].join("\n"),
+      {
+        projectDir: "/project",
+        projectId: "project-ref-authorized",
+        dependencyPinningSource: source,
+        dependencyPinningCacheKey: snapshot.cacheKey,
+        dependencyPinningDependencies: snapshot.dependencies,
+      },
+    );
+    await _pendingResolutions();
+
+    const scheduled = requests.flatMap((request) => request.specifiers);
+    assertEquals(
+      scheduled.includes("react@^19.0.0"),
+      true,
+      "react must be scheduled from an authorized SSR render",
+    );
+    assertEquals(
+      scheduled.includes("react-dom@next"),
+      true,
+      "react-dom must be scheduled from an authorized SSR render",
+    );
   });
 });
 

--- a/src/transforms/import-rewriter/strategies/asset-strategy.test.ts
+++ b/src/transforms/import-rewriter/strategies/asset-strategy.test.ts
@@ -2,7 +2,9 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { ImportSpecifierInfo, RewriteContext } from "../types.ts";
+import { aliasStrategy } from "./alias-strategy.ts";
 import { assetStrategy } from "./asset-strategy.ts";
+import { relativeStrategy } from "./relative-strategy.ts";
 
 function makeCtx(overrides: Partial<RewriteContext> = {}): RewriteContext {
   return {
@@ -205,6 +207,15 @@ describe("AssetStrategy", () => {
 
   it("runs before the alias and relative strategies", () => {
     // Otherwise they claim the specifier first and append .js to it.
-    assertEquals(assetStrategy.priority < 1, true);
+    assertEquals(
+      assetStrategy.priority < aliasStrategy.priority,
+      true,
+      "asset strategy must outrank alias, which would otherwise append .js to @/assets paths",
+    );
+    assertEquals(
+      assetStrategy.priority < relativeStrategy.priority,
+      true,
+      "asset strategy must outrank relative, which would otherwise append .js to ./assets paths",
+    );
   });
 });

--- a/src/transforms/import-rewriter/strategies/bare-strategy.test.ts
+++ b/src/transforms/import-rewriter/strategies/bare-strategy.test.ts
@@ -15,7 +15,11 @@ import {
 import type { ImportSpecifierInfo, RewriteContext } from "../types.ts";
 import { rewriteSSRImportsCompatAsync } from "../ssr-adapter.ts";
 import { rewriteImports } from "../unified-rewriter.ts";
+import { TAILWIND_VERSION } from "../url-builder.ts";
 import { bareStrategy } from "./bare-strategy.ts";
+
+const TAILWIND_PINNED_URL =
+  `https://esm.sh/tailwindcss@${TAILWIND_VERSION}?external=react,react-dom&target=es2022`;
 
 function makeCtx(overrides: Partial<RewriteContext> = {}): RewriteContext {
   return {
@@ -113,7 +117,23 @@ describe("BareStrategy", () => {
         makeInfo("tailwindcss"),
         makeCtx({ target: "browser" }),
       );
-      assertEquals(result.specifier?.includes("tailwindcss@"), true);
+      assertEquals(
+        result.specifier,
+        TAILWIND_PINNED_URL,
+        "tailwindcss must resolve to the framework-pinned version that the config hash is built from",
+      );
+    });
+
+    it("overrides an author-supplied tailwindcss version with the framework pin", () => {
+      const result = bareStrategy.rewrite(
+        makeInfo("tailwindcss@3.4.0"),
+        makeCtx({ target: "browser" }),
+      );
+      assertEquals(
+        result.specifier,
+        TAILWIND_PINNED_URL,
+        "an inline tailwindcss version must be replaced by the framework pin",
+      );
     });
 
     it("should preserve versioned specifiers", () => {
@@ -276,7 +296,11 @@ describe("BareStrategy", () => {
 
     it("still pins tailwindcss regardless of the flag", () => {
       const result = bareStrategy.rewrite(makeInfo("tailwindcss"), makeCtx({ target: "browser" }));
-      assertEquals(result.specifier?.includes("tailwindcss@"), true);
+      assertEquals(
+        result.specifier,
+        TAILWIND_PINNED_URL,
+        "tailwindcss must keep the framework pin when the pinning flag is off",
+      );
     });
 
     it("preserves inline-versioned specifiers unchanged", () => {
@@ -364,8 +388,8 @@ describe("BareStrategy", () => {
     it("falls back to unversioned URL when both caches are cold", async () => {
       // No package.json cache, no npm registry cache — must behave like flag-off.
       const result = bareStrategy.rewrite(makeInfo("lodash"), makeCtx({ target: "browser" }));
-      // Yield one tick so the background fetch microtask settles and clears its timer.
-      await new Promise<void>((r) => setTimeout(r, 1));
+      // Drain the background registry resolution before the sanitizer runs.
+      await _pendingResolutions();
       assertEquals(
         result.specifier,
         "https://esm.sh/lodash?external=react,react-dom&target=es2022",
@@ -481,7 +505,11 @@ describe("BareStrategy", () => {
 
     it("still uses tailwindcss pinned version regardless of npm cache", () => {
       const result = bareStrategy.rewrite(makeInfo("tailwindcss"), makeCtx({ target: "browser" }));
-      assertEquals(result.specifier?.includes("tailwindcss@"), true);
+      assertEquals(
+        result.specifier,
+        TAILWIND_PINNED_URL,
+        "tailwindcss must keep the framework pin regardless of the npm version cache",
+      );
     });
 
     it("SSR target is not affected by the pin flag", () => {

--- a/src/transforms/import-rewriter/strategies/bare-strategy.test.ts
+++ b/src/transforms/import-rewriter/strategies/bare-strategy.test.ts
@@ -15,7 +15,7 @@ import {
 import type { ImportSpecifierInfo, RewriteContext } from "../types.ts";
 import { rewriteSSRImportsCompatAsync } from "../ssr-adapter.ts";
 import { rewriteImports } from "../unified-rewriter.ts";
-import { TAILWIND_VERSION } from "../url-builder.ts";
+import { TAILWIND_VERSION } from "#veryfront/transforms/import-rewriter/url-builder.ts";
 import { bareStrategy } from "./bare-strategy.ts";
 
 const TAILWIND_PINNED_URL =

--- a/src/transforms/import-rewriter/strategies/import-map-strategy.test.ts
+++ b/src/transforms/import-rewriter/strategies/import-map-strategy.test.ts
@@ -2,12 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { importMapStrategy, resolveImportWithMap } from "./import-map-strategy.ts";
-import type {
-  ImportMapConfig,
-  ImportSpecifier,
-  ImportSpecifierInfo,
-  RewriteContext,
-} from "../types.ts";
+import type { ImportMapConfig, ImportSpecifierInfo, RewriteContext } from "../types.ts";
 
 function makeCtx(overrides: Partial<RewriteContext> = {}): RewriteContext {
   return {
@@ -38,7 +33,7 @@ function makeInfo(specifier: string): ImportSpecifierInfo {
       se: specifier.length,
       d: -1,
       a: -1,
-    } as ImportSpecifier,
+    } as ImportSpecifierInfo["raw"],
   };
 }
 

--- a/src/transforms/import-rewriter/strategies/import-map-strategy.test.ts
+++ b/src/transforms/import-rewriter/strategies/import-map-strategy.test.ts
@@ -121,6 +121,35 @@ describe("transforms/import-rewriter/strategies/import-map-strategy", () => {
       assertEquals(resolveImportWithMap("https://esm.sh/lodash@4", map), "/local/lodash.js");
     });
 
+    it("appends the esm.sh subpath to a URL mapping", () => {
+      const map: ImportMapConfig = { imports: { lodash: "https://cdn.example/lodash" } };
+      assertEquals(
+        resolveImportWithMap("https://esm.sh/lodash@4/fp", map),
+        "https://cdn.example/lodash/fp",
+        "a URL mapping keeps the subpath so the /fp entry point is resolved, not the package root",
+      );
+    });
+
+    it("prefers an exact package+subpath mapping over the package mapping", () => {
+      const map: ImportMapConfig = {
+        imports: { lodash: "https://cdn.example/lodash", "lodash/fp": "/local/fp.js" },
+      };
+      assertEquals(
+        resolveImportWithMap("https://esm.sh/lodash@4/fp", map),
+        "/local/fp.js",
+        "the package+subpath key wins over the bare package key",
+      );
+    });
+
+    it("drops the esm.sh subpath for a file-path mapping", () => {
+      const map: ImportMapConfig = { imports: { lodash: "/local/lodash.js" } };
+      assertEquals(
+        resolveImportWithMap("https://esm.sh/lodash@4/fp", map),
+        "/local/lodash.js",
+        "a file-path mapping already points at a single module, so the subpath is not appended",
+      );
+    });
+
     it("returns null for empty imports", () => {
       assertEquals(resolveImportWithMap("foo", {}), null);
     });

--- a/src/transforms/import-rewriter/strategies/react-strategy.test.ts
+++ b/src/transforms/import-rewriter/strategies/react-strategy.test.ts
@@ -108,12 +108,20 @@ describe("ReactStrategy", () => {
 
     it("should rewrite react/jsx-runtime", () => {
       const result = strategy.rewrite(makeInfo("react/jsx-runtime"), makeCtx());
-      assertEquals(result.specifier?.includes("jsx-runtime") ?? false, true);
+      assertEquals(
+        result.specifier,
+        "https://esm.sh/react@19.1.1/jsx-runtime?external=react&target=es2022&deps=csstype@3.2.3",
+        "jsx-runtime must resolve to the pinned, react-externalized esm.sh URL",
+      );
     });
 
     it("should handle unknown react/* subpaths via prefix", () => {
       const result = strategy.rewrite(makeInfo("react/some-custom-export"), makeCtx());
-      assertEquals(result.specifier !== null, true);
+      assertEquals(
+        result.specifier,
+        "https://esm.sh/react@19.1.1&external=react&target=es2022&deps=csstype@3.2.3/some-custom-export",
+        "an unknown react/* subpath must be appended to the pinned react prefix URL",
+      );
     });
 
     it("should return null for non-react specifier that somehow matches", () => {
@@ -163,19 +171,20 @@ describe("ReactStrategy", () => {
     });
 
     it("does not schedule exact react or react-dom pins", async () => {
-      const ctx = makeCtx({
-        dependencyPinningCacheKey: "on:snapshot-exact",
-        dependencyPinningDependencies: {
-          react: "19.1.1",
-          "react-dom": "v19.1.1",
-        },
+      const ctx = await makeAuthorizedContext({
+        react: "19.1.1",
+        "react-dom": "v19.1.1",
       });
 
       strategy.rewrite(makeInfo("react"), ctx);
       strategy.rewrite(makeInfo("react-dom"), ctx);
       await _pendingResolutions();
 
-      assertEquals(postedSpecifiers, []);
+      assertEquals(
+        postedSpecifiers,
+        [],
+        "exact react and react-dom pins must not be scheduled for resolution",
+      );
     });
 
     it("does not schedule from off or unknown snapshots", async () => {

--- a/src/transforms/import-rewriter/strategies/relative-strategy.test.ts
+++ b/src/transforms/import-rewriter/strategies/relative-strategy.test.ts
@@ -62,6 +62,41 @@ describe("RelativeStrategy", () => {
       );
     });
 
+    it("should bind the SSR module URL to the dependency snapshot via a query token", () => {
+      const result = relativeStrategy.rewrite(
+        makeInfo("./child.ts"),
+        makeCtx({ target: "ssr", dependencyPinningCacheKey: "on:snapshot-a" }),
+      );
+
+      assertEquals(
+        result.specifier,
+        "http://localhost:3000/_vf_modules/pages/child.js?pins=on%3Asnapshot-a",
+        "SSR child modules carry the snapshot as a pins query token",
+      );
+    });
+
+    it("should keep the .mdx extension on relative imports", () => {
+      const moduleServerResult = relativeStrategy.rewrite(
+        makeInfo("./post.mdx"),
+        makeCtx({ target: "browser" }),
+      );
+      const inlineResult = relativeStrategy.rewrite(
+        makeInfo("./post.mdx"),
+        makeCtx({ target: "browser", moduleServerUrl: undefined }),
+      );
+
+      assertEquals(
+        moduleServerResult.specifier,
+        "http://localhost:3000/_vf_modules/pages/post.mdx",
+        "a relative MDX import keeps its .mdx extension in the module server URL",
+      );
+      assertEquals(
+        inlineResult.specifier,
+        "./post.mdx",
+        "a relative MDX import is left untouched when there is no module server",
+      );
+    });
+
     it("should normalize .tsx extension to .js for SSR when no moduleServerUrl", () => {
       const result = relativeStrategy.rewrite(
         makeInfo("./component.tsx"),

--- a/src/transforms/import-rewriter/strategies/vendor-strategy.test.ts
+++ b/src/transforms/import-rewriter/strategies/vendor-strategy.test.ts
@@ -58,6 +58,14 @@ describe("VendorStrategy", () => {
     it("should not match non-react packages", () => {
       assertEquals(vendorStrategy.matches("lodash", makeCtx()), false);
     });
+
+    it("should not match without a module server URL", () => {
+      assertEquals(
+        vendorStrategy.matches("react", makeCtx({ moduleServerUrl: undefined })),
+        false,
+        "vendor strategy must not claim react without a module server URL",
+      );
+    });
   });
 
   describe("rewrite", () => {
@@ -83,6 +91,33 @@ describe("VendorStrategy", () => {
       assertEquals(result.specifier, null);
       assertEquals(result.statement?.includes("import("), true);
       assertEquals(result.statement?.includes("_vendor.js"), true);
+    });
+
+    it("should select the sanitized export name for a dynamic subpath import", () => {
+      const result = vendorStrategy.rewrite(makeInfo("react-dom/client", true), makeCtx());
+
+      assertEquals(
+        result.statement,
+        "import('http://localhost:3000/_vf_modules/_vendor.js?v=abc123').then(m => m.reactDomClient)",
+        "a dynamic vendor import must select the sanitized export name for the specifier",
+      );
+      assertEquals(
+        result.specifier,
+        null,
+        "a dynamic vendor import replaces the whole statement instead of the specifier",
+      );
+    });
+
+    it("should return null when no module server URL", () => {
+      const result = vendorStrategy.rewrite(
+        makeInfo("react"),
+        makeCtx({ moduleServerUrl: undefined }),
+      );
+      assertEquals(
+        result.specifier,
+        null,
+        "vendor rewrite declines when no module server URL is configured",
+      );
     });
 
     it("should return null when no vendor config", () => {

--- a/src/transforms/import-rewriter/unified-rewriter.test.ts
+++ b/src/transforms/import-rewriter/unified-rewriter.test.ts
@@ -323,7 +323,16 @@ describe("rewriteImports with the default strategies", () => {
       defaultCtx(),
     );
 
-    assertStringIncludes(result, "marker-icon.png");
+    assertStringIncludes(
+      result,
+      `"https://esm.sh/leaflet/dist/images/marker-icon.png?external=react,react-dom&target=es2022"`,
+      "the asset inside a dependency must be routed through esm.sh by the bare strategy",
+    );
+    assertEquals(
+      result.includes(`"leaflet/dist/images/marker-icon.png"`),
+      false,
+      "the bare specifier must not survive unrewritten",
+    );
   });
 
   it("leaves a remote asset URL to the url strategy", async () => {

--- a/src/transforms/import-rewriter/url-builder.test.ts
+++ b/src/transforms/import-rewriter/url-builder.test.ts
@@ -14,6 +14,7 @@ import {
   buildPinnedEsmShUrl,
   buildReactUrl,
   buildVeryfrontModuleUrl,
+  CSSTYPE_VERSION,
   extractDependencyPinningPathKey,
   getReactImportMap,
   isEsmShUrl,
@@ -156,6 +157,33 @@ describe("transforms/import-rewriter/url-builder", () => {
           "https://app.example",
         ),
         "/_vf_modules/_pins/on%3Asnapshot-a/components/Button.js?ssr=true#default",
+      );
+      assertEquals(
+        appendSameOriginSSRDependencyPinningPathKey(
+          "https://cdn.example/_vf_modules/components/Button.js",
+          "on:snapshot-a",
+          "https://app.example",
+        ),
+        "https://cdn.example/_vf_modules/components/Button.js",
+        "a foreign-origin module URL must be returned unchanged",
+      );
+      assertEquals(
+        appendSameOriginSSRDependencyPinningPathKey(
+          "https://app.example/assets/Button.js",
+          "on:snapshot-a",
+          "https://app.example",
+        ),
+        "https://app.example/assets/Button.js",
+        "a same-origin non-/_vf_modules/ path must be returned unchanged",
+      );
+      assertEquals(
+        appendSameOriginSSRDependencyPinningPathKey(
+          "https://app.example/_vf_modules/components/Button.js",
+          "off",
+          "https://app.example",
+        ),
+        "https://app.example/_vf_modules/components/Button.js",
+        "a flag-off snapshot key must not rewrite the URL",
       );
     });
 
@@ -302,24 +330,54 @@ describe("transforms/import-rewriter/url-builder", () => {
   describe("getReactImportMap", () => {
     it("should return map with react entries", () => {
       const map = getReactImportMap("19.1.1");
-      const keys = [
-        "react",
-        "react-dom",
-        "react-dom/client",
-        "react-dom/server",
-        "react/jsx-runtime",
-        "react/jsx-dev-runtime",
-        "react/",
-        "react-dom/",
-      ] as const;
+      const deps = `target=es2022&deps=csstype@${CSSTYPE_VERSION}`;
 
-      for (const key of keys) {
-        assertEquals(typeof map[key], "string");
-      }
+      assertEquals(
+        map["react"],
+        `https://esm.sh/react@19.1.1?${deps}`,
+        "react resolves to the unexternalized bundle that owns the single React instance",
+      );
+      assertEquals(
+        map["react-dom"],
+        `https://esm.sh/react-dom@19.1.1?external=react&${deps}`,
+        "react-dom keeps react external so it reuses the same React instance",
+      );
+      assertEquals(
+        map["react-dom/client"],
+        `https://esm.sh/react-dom@19.1.1/client?external=react&${deps}`,
+        "react-dom/client keeps react external so hydration shares one React instance",
+      );
+      assertEquals(
+        map["react-dom/server"],
+        `https://esm.sh/react-dom@19.1.1/server?external=react&${deps}`,
+        "react-dom/server keeps react external so it reuses the same React instance",
+      );
+      assertEquals(
+        map["react/jsx-runtime"],
+        `https://esm.sh/react@19.1.1/jsx-runtime?external=react&${deps}`,
+        "the production JSX runtime is mapped, not the dev runtime",
+      );
+      assertEquals(
+        map["react/jsx-dev-runtime"],
+        `https://esm.sh/react@19.1.1/jsx-dev-runtime?external=react&${deps}`,
+        "the dev JSX runtime keeps its own entry",
+      );
 
-      assertEquals(map["react/"]?.endsWith("/"), true);
-      assertEquals(map["react-dom/"]?.endsWith("/"), true);
-      assertEquals(map["react-dom/"]?.includes("&external=react"), true);
+      assertEquals(
+        map["react/"]?.endsWith("/"),
+        true,
+        "the react prefix entry keeps the trailing slash import maps require",
+      );
+      assertEquals(
+        map["react-dom/"]?.endsWith("/"),
+        true,
+        "the react-dom prefix entry keeps the trailing slash import maps require",
+      );
+      assertEquals(
+        map["react-dom/"]?.includes("&external=react"),
+        true,
+        "the react-dom prefix entry keeps react external",
+      );
     });
   });
 

--- a/src/transforms/pipeline/__fixtures__/fixture-runner.test.ts
+++ b/src/transforms/pipeline/__fixtures__/fixture-runner.test.ts
@@ -9,12 +9,16 @@ import "#veryfront/schemas/_test-setup.ts";
  * - Relative imports
  */
 
-import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertNotEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { readTextFile } from "#veryfront/testing/deno-compat.ts";
 import { isDeno } from "#veryfront/platform/compat/runtime.ts";
 import * as esbuild from "veryfront/extensions/bundler";
 import { runPipeline } from "../index.ts";
+import {
+  CSSTYPE_VERSION,
+  DEFAULT_REACT_VERSION,
+} from "#veryfront/transforms/import-rewriter/url-builder.ts";
 
 const FIXTURES_DIR = new URL(".", import.meta.url).pathname;
 
@@ -28,7 +32,7 @@ const TEST_OPTIONS = {
   moduleServerUrl: "http://localhost:3001/_vf_modules",
 };
 
-describe("transform pipeline fixtures", { sanitizeResources: false, sanitizeOps: false }, () => {
+describe("transform pipeline fixtures", () => {
   afterAll(async () => {
     await esbuild.stop();
   });
@@ -43,7 +47,14 @@ describe("transform pipeline fixtures", { sanitizeResources: false, sanitizeOps:
       });
 
       assertStringIncludes(result.code, "jsx");
-      assertStringIncludes(result.code, "esm.sh/react");
+      // Pin the fixture's own React import, version included: the auto-injected
+      // jsx-runtime import alone would satisfy a bare "esm.sh/react" match, and
+      // a browser React version that drifts from SSR breaks hydration.
+      assertStringIncludes(
+        result.code,
+        `import { useState } from "https://esm.sh/react@${DEFAULT_REACT_VERSION}?target=es2022&deps=csstype@${CSSTYPE_VERSION}"`,
+        "the browser artifact must import React from the default pinned esm.sh URL",
+      );
       assertEquals(result.code.includes('from "react"'), false);
     });
 
@@ -105,6 +116,21 @@ describe("transform pipeline fixtures", { sanitizeResources: false, sanitizeOps:
       });
 
       assertEquals(result.code.includes('from "@/'), false);
+      assertStringIncludes(
+        result.code,
+        'from "http://localhost:3001/_vf_modules/lib/utils.js"',
+        "@/ alias must resolve to the module server URL",
+      );
+      assertStringIncludes(
+        result.code,
+        'from "http://localhost:3001/_vf_modules/pages/components/Button"',
+        "a sibling relative import must resolve to the module server URL",
+      );
+      assertStringIncludes(
+        result.code,
+        'from "http://localhost:3001/_vf_modules/hooks/useAuth"',
+        "a parent relative import must resolve to the module server URL",
+      );
     });
   });
 
@@ -124,6 +150,32 @@ describe("transform pipeline fixtures", { sanitizeResources: false, sanitizeOps:
       assertEquals(result.contentHash.length > 0, true);
 
       assertEquals(result.totalMs >= 0, true);
+    });
+
+    it("derives the content hash from the source, not the path", async () => {
+      const input = await readFixture("react-only", "input.tsx");
+      const filePath = "/project/components/Counter.tsx";
+      const options = { ...TEST_OPTIONS, ssr: false };
+
+      const first = await runPipeline(input, filePath, "/project", options);
+      const second = await runPipeline(
+        `${input}\nexport const marker = 1;\n`,
+        filePath,
+        "/project",
+        options,
+      );
+      const third = await runPipeline(input, filePath, "/project", options);
+
+      assertNotEquals(
+        second.contentHash,
+        first.contentHash,
+        "content hash must change when the source changes",
+      );
+      assertEquals(
+        third.contentHash,
+        first.contentHash,
+        "content hash must be stable for identical source",
+      );
     });
   });
 });

--- a/src/transforms/pipeline/__fixtures__/fixture-runner.test.ts
+++ b/src/transforms/pipeline/__fixtures__/fixture-runner.test.ts
@@ -14,7 +14,7 @@ import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { readTextFile } from "#veryfront/testing/deno-compat.ts";
 import { isDeno } from "#veryfront/platform/compat/runtime.ts";
 import * as esbuild from "veryfront/extensions/bundler";
-import { runPipeline } from "../index.ts";
+import { runPipeline } from "#veryfront/transforms/pipeline/index.ts";
 import {
   CSSTYPE_VERSION,
   DEFAULT_REACT_VERSION,
@@ -165,6 +165,12 @@ describe("transform pipeline fixtures", () => {
         options,
       );
       const third = await runPipeline(input, filePath, "/project", options);
+      const fourth = await runPipeline(
+        input,
+        "/project/components/RenamedCounter.tsx",
+        "/project",
+        options,
+      );
 
       assertNotEquals(
         second.contentHash,
@@ -175,6 +181,11 @@ describe("transform pipeline fixtures", () => {
         third.contentHash,
         first.contentHash,
         "content hash must be stable for identical source",
+      );
+      assertEquals(
+        fourth.contentHash,
+        first.contentHash,
+        "content hash must not include the in-project file path",
       );
     });
   });

--- a/src/transforms/pipeline/cache-identity.test.ts
+++ b/src/transforms/pipeline/cache-identity.test.ts
@@ -278,10 +278,18 @@ describe("transform pipeline cache identity", () => {
     const plugins = await computePipelineConfigIdentity(
       identityInput({ customPlugins: [[0, "custom", TransformStage.FINALIZE, "custom@1"]] }),
     );
+    const vendor = await computePipelineConfigIdentity(
+      identityInput({ vendorBundleHash: "vendor-2" }),
+    );
 
     assertNotEquals(moduleServer, baseline);
     assertNotEquals(api, baseline);
     assertNotEquals(plugins, baseline);
+    assertNotEquals(
+      vendor,
+      baseline,
+      "vendor bundle hash must partition the transform cache",
+    );
   });
 
   it("keeps distinct fractional stages distinct in precomputed identities", async () => {

--- a/src/transforms/pipeline/index.test.ts
+++ b/src/transforms/pipeline/index.test.ts
@@ -36,7 +36,6 @@ import { computeShortContentHash } from "../esm/transform-utils.ts";
 
 describe(
   "transformToESM readFile routing",
-  { sanitizeResources: false, sanitizeOps: false },
   () => {
     afterAll(async () => {
       await esbuild.stop();
@@ -76,7 +75,16 @@ export default function App() { return dep; }`;
           projectId: "test-project",
         });
 
-        assertEquals(readCalls.includes(externalFile), false);
+        assertEquals(
+          readCalls.includes(externalFile),
+          false,
+          "external file:// deps must bypass the adapter",
+        );
+        assertEquals(
+          readCalls.includes(mainFile),
+          true,
+          "in-project files must be read through the adapter so depsHash is computed",
+        );
       } finally {
         await remove(projectDir, { recursive: true });
         await remove(externalDir, { recursive: true });

--- a/src/transforms/pipeline/stages/browser-node-builtin-imports.test.ts
+++ b/src/transforms/pipeline/stages/browser-node-builtin-imports.test.ts
@@ -63,6 +63,24 @@ describe("browser-node-builtin-imports", () => {
     assertEquals(await rewriteNodeBuiltinNamedImports(code), code);
   });
 
+  it("leaves a clause it cannot parse alone", async () => {
+    const code = `import { "create-hash" as h } from "node:crypto";`;
+    assertEquals(
+      await rewriteNodeBuiltinNamedImports(code),
+      code,
+      "an arbitrary-module-name clause must be left byte-identical, not destructured",
+    );
+  });
+
+  it("leaves a comment-bearing clause alone", async () => {
+    const code = `import { createHash /* c */ } from "node:crypto";`;
+    assertEquals(
+      await rewriteNodeBuiltinNamedImports(code),
+      code,
+      "a clause with a comment must be left byte-identical, not destructured",
+    );
+  });
+
   it("numbers each rewritten import uniquely", async () => {
     const result = await rewriteNodeBuiltinNamedImports(
       `import { createHash } from "node:crypto";\nimport { join } from "node:path";`,

--- a/src/transforms/pipeline/stages/compile.test.ts
+++ b/src/transforms/pipeline/stages/compile.test.ts
@@ -304,4 +304,54 @@ describe("transforms/pipeline/stages/compile", () => {
       );
     });
   });
+
+  // The MDX loader resolves a page's layout by preferring an exported
+  // `MDXLayout`. The MDX compiler declares the binding but does not export it,
+  // so COMPILE has to add the export - after esbuild has run, and before the
+  // inline sourcemap directive esbuild leaves last in dev.
+  describe("MDX layout export injection", () => {
+    const declaresLayout =
+      `import Layout from "./Layout.js";\nconst MDXLayout = Layout;\nexport default function MDXContent(){ return null; }\n`;
+
+    it("exports a declared but unexported MDXLayout", async () => {
+      const result = await compilePlugin.transform(
+        createContext(declaresLayout, "/project/app/post.mdx"),
+      );
+
+      assertStringIncludes(
+        result,
+        "export { MDXLayout };",
+        "an MDX module that declares MDXLayout must export it for the loader to find",
+      );
+    });
+
+    it("injects the export before the inline sourcemap directive", async () => {
+      const result = await compilePlugin.transform(
+        createContext(declaresLayout, "/project/app/post.mdx"),
+      );
+
+      const exportIndex = result.indexOf("export { MDXLayout };");
+      const sourceMapIndex = result.indexOf("//# sourceMappingURL=");
+      assertEquals(
+        exportIndex > -1 && sourceMapIndex > -1 && exportIndex < sourceMapIndex,
+        true,
+        "the injected export must precede esbuild's trailing sourcemap directive",
+      );
+    });
+
+    it("does not duplicate an MDXLayout export that is already present", async () => {
+      const result = await compilePlugin.transform(
+        createContext(
+          `import Layout from "./Layout.js";\nconst MDXLayout = Layout;\nexport { MDXLayout };\nexport default function MDXContent(){ return null; }\n`,
+          "/project/app/post.mdx",
+        ),
+      );
+
+      assertEquals(
+        result.match(/export\s*\{[^}]*MDXLayout/g)?.length,
+        1,
+        "an MDX module that already exports MDXLayout must not get a second export",
+      );
+    });
+  });
 });

--- a/src/transforms/pipeline/stages/finalize.test.ts
+++ b/src/transforms/pipeline/stages/finalize.test.ts
@@ -3,6 +3,25 @@ import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { finalizePlugin } from "./finalize.ts";
 import { TransformStage } from "../types.ts";
+import type { TransformContext, TransformTarget } from "../types.ts";
+
+function createContext(code: string, target: TransformTarget): TransformContext {
+  return {
+    code,
+    originalSource: code,
+    filePath: "/project/pages/index.tsx",
+    projectDir: "/project",
+    projectId: "test",
+    target,
+    dev: false,
+    contentHash: "hash-a",
+    jsxImportSource: "react",
+    timing: new Map(),
+    debug: false,
+    metadata: new Map(),
+    reactVersion: "19.1.1",
+  } as TransformContext;
+}
 
 describe("transforms/pipeline/stages/finalize", () => {
   describe("finalizePlugin metadata", () => {
@@ -21,6 +40,29 @@ describe("transforms/pipeline/stages/finalize", () => {
 
     it("has no condition", () => {
       assertEquals(finalizePlugin.condition, undefined);
+    });
+  });
+
+  describe("finalizePlugin transform", () => {
+    const httpImport = `import Player from "https://esm.sh/video.js@8";`;
+
+    it("returns browser code untouched", async () => {
+      const ctx = createContext(httpImport, "browser");
+      assertEquals(
+        await finalizePlugin.transform(ctx),
+        httpImport,
+        "a non-SSR target must return the code untouched",
+      );
+    });
+
+    it("normalizes SSR http imports with the context react version", async () => {
+      const ctx = createContext(httpImport, "ssr");
+      assertEquals(
+        await finalizePlugin.transform(ctx),
+        `import Player from "https://esm.sh/video.js@8?target=es2022&external=react,react-dom` +
+          `&deps=react@19.1.1,react-dom@19.1.1";`,
+        "SSR finalize must pin the context react version onto remote http imports",
+      );
     });
   });
 });

--- a/src/transforms/pipeline/stages/finalize.test.ts
+++ b/src/transforms/pipeline/stages/finalize.test.ts
@@ -2,8 +2,11 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { finalizePlugin } from "./finalize.ts";
-import { TransformStage } from "../types.ts";
-import type { TransformContext, TransformTarget } from "../types.ts";
+import {
+  type TransformContext,
+  TransformStage,
+  type TransformTarget,
+} from "#veryfront/transforms/pipeline/types.ts";
 
 function createContext(code: string, target: TransformTarget): TransformContext {
   return {

--- a/src/transforms/pipeline/stages/parse.test.ts
+++ b/src/transforms/pipeline/stages/parse.test.ts
@@ -1,9 +1,32 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import "../../mdx/compiler/__tests__/content-processor-setup.ts";
+import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { parsePlugin } from "./parse.ts";
 import { TransformStage } from "../types.ts";
+import type { TransformContext, TransformTarget } from "../types.ts";
 import { isMDX } from "../context.ts";
+
+const MDX_SOURCE = `import { Button } from "@/components/Button";\n\n# Hello\n\n<Button />\n`;
+
+function createMdxContext(target: TransformTarget): TransformContext {
+  return {
+    code: MDX_SOURCE,
+    originalSource: MDX_SOURCE,
+    filePath: "/project/pages/post.mdx",
+    projectDir: "/project",
+    projectId: "test",
+    target,
+    dev: false,
+    contentHash: "hash-a",
+    moduleServerUrl: "http://localhost:3001",
+    jsxImportSource: "react",
+    timing: new Map(),
+    debug: false,
+    metadata: new Map(),
+    reactVersion: "19.1.1",
+  } as TransformContext;
+}
 
 describe("transforms/pipeline/stages/parse", () => {
   describe("parsePlugin metadata", () => {
@@ -22,6 +45,31 @@ describe("transforms/pipeline/stages/parse", () => {
 
     it("has condition set to isMDX", () => {
       assertEquals(parsePlugin.condition, isMDX);
+    });
+  });
+
+  describe("parsePlugin transform", () => {
+    it("compiles browser MDX through the module server", async () => {
+      const result = await parsePlugin.transform(createMdxContext("browser"));
+      assertStringIncludes(
+        result,
+        `"http://localhost:3001/_vf_modules/components/Button.js"`,
+        "browser MDX compile must rewrite @/ through the module server",
+      );
+    });
+
+    it("compiles SSR MDX with the server target", async () => {
+      const result = await parsePlugin.transform(createMdxContext("ssr"));
+      assertStringIncludes(
+        result,
+        `"@/components/Button"`,
+        "SSR MDX compile must use the server target, which leaves @/ specifiers for the SSR resolver",
+      );
+      assertEquals(
+        result.includes("http://localhost:3001"),
+        false,
+        "module-server URLs must not be baked into SSR output",
+      );
     });
   });
 });

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -329,6 +329,50 @@ describe("css-strip plugin", () => {
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
   });
 
+  it("preserves single-quoted css export names and escaped quotes", async () => {
+    const ctx = createContext(
+      String
+        .raw`import { 'foo"bar' as doubleQuote, 'foo\'bar' as singleQuote } from "./Button.module.css"; export { doubleQuote, singleQuote };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.doubleQuote,
+      toScopedCssModuleClass(MODULE_KEY, 'foo"bar'),
+      "a single-quoted export name containing a double quote must keep its local alias",
+    );
+    assertEquals(
+      namespace.singleQuote,
+      toScopedCssModuleClass(MODULE_KEY, "foo'bar"),
+      "an escaped quote in a single-quoted export name must be decoded once",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("serializes decoded unscoped css binding names as valid string literals", async () => {
+    const ctx = createContext(
+      String
+        .raw`import { "line\nbreak" as lineBreak, "slash\\name" as slashName } from "./theme.css"; export { lineBreak, slashName };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.lineBreak,
+      "line\nbreak",
+      "a decoded newline must remain data rather than becoming generated source syntax",
+    );
+    assertEquals(
+      namespace.slashName,
+      "slash\\name",
+      "a decoded backslash must survive generated module serialization exactly once",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./theme.css"]);
+  });
+
   it("does not treat `from` inside a quoted css export name as the keyword", async () => {
     const ctx = createContext(
       `export { "foo-from" as fooFrom } from "./Button.module.css";`,

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -11,12 +11,18 @@ import {
   rewriteCssModuleContent,
   toScopedCssModuleClass,
 } from "#veryfront/transforms/css-modules/naming.ts";
+import { encodeBase64Bytes } from "#veryfront/utils/base64url.ts";
 
 const MODULE_KEY = resolveCssModuleKey(
   "./Button.module.css",
   "/project/pages/index.tsx",
   "/project",
 );
+
+function moduleDataUrl(source: string): string {
+  const encoded = encodeBase64Bytes(new TextEncoder().encode(source));
+  return `data:text/javascript;base64,${encoded}`;
+}
 
 function createContext(code: string, dev = true): TransformContext {
   return {
@@ -43,7 +49,7 @@ function createContext(code: string, dev = true): TransformContext {
 async function assertParsesAsModule(source: string, message: string): Promise<void> {
   let parseError: string | undefined;
   try {
-    await import(`data:text/javascript,${encodeURIComponent(source)}`);
+    await import(moduleDataUrl(source));
   } catch (error) {
     parseError = error instanceof Error ? error.message : String(error);
   }
@@ -58,7 +64,7 @@ async function assertParsesAsModule(source: string, message: string): Promise<vo
  * running the module rather than by matching its text.
  */
 async function evaluateModule(source: string): Promise<Record<string, unknown>> {
-  const namespace = await import(`data:text/javascript,${encodeURIComponent(source)}`);
+  const namespace = await import(moduleDataUrl(source));
   return namespace as Record<string, unknown>;
 }
 

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -292,6 +292,43 @@ describe("css-strip plugin", () => {
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
   });
 
+  it("does not treat `from` inside a quoted css specifier as the import keyword", async () => {
+    const ctx = createContext(
+      `import styles from "./from'button.module.css"; export const cls = styles.container;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+    const moduleKey = resolveCssModuleKey(
+      "./from'button.module.css",
+      "/project/pages/index.tsx",
+      "/project",
+    );
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(moduleKey, "container"),
+      "a quoted specifier containing `from` must keep the default css module binding",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./from'button.module.css"]);
+  });
+
+  it("preserves quoted css export names", async () => {
+    const ctx = createContext(
+      `export { "foo-bar" as fooBar } from "./Button.module.css";`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.fooBar,
+      toScopedCssModuleClass(MODULE_KEY, "foo-bar"),
+      "a quoted css export name must remain available through its local alias",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
   it("resolves a named `default` css import to the class map, not the literal name", async () => {
     const ctx = createContext(
       `import { default as styles } from "./Button.module.css"; export const cls = styles.container;`,

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -129,22 +129,22 @@ describe("css-strip plugin", () => {
 
     assertStringIncludes(
       result,
-      "const __vfCssExport_styles = new Proxy({},",
+      "const __vfCssExport_0 = new Proxy({},",
       "a re-exported css default must be backed by a scoped proxy stub",
     );
     assertStringIncludes(
       result,
-      "export { __vfCssExport_styles as styles };",
+      "export { __vfCssExport_0 as styles };",
       "a re-exported css default must stay exported under its original name",
     );
     assertStringIncludes(
       result,
-      `const __vfCssExport_root = "${toScopedCssModuleClass(MODULE_KEY, "container")}";`,
+      `const __vfCssExport_1 = "${toScopedCssModuleClass(MODULE_KEY, "container")}";`,
       "a re-exported named css binding must be backed by its scoped class",
     );
     assertStringIncludes(
       result,
-      "export { __vfCssExport_root as root };",
+      "export { __vfCssExport_1 as root };",
       "a re-exported named css binding must stay exported under its original name",
     );
     assertEquals(
@@ -178,7 +178,7 @@ describe("css-strip plugin", () => {
     );
     assertStringIncludes(
       result,
-      "export { __vfCssExport_styles as styles };",
+      "export { __vfCssExport_0 as styles };",
       "the css re-export must still be exported as `styles` through a safe local",
     );
     await assertParsesAsModule(
@@ -202,12 +202,12 @@ describe("css-strip plugin", () => {
     );
     assertStringIncludes(
       result,
-      `const __vfCssExport_class = "${toScopedCssModuleClass(MODULE_KEY, "container")}";`,
+      `const __vfCssExport_0 = "${toScopedCssModuleClass(MODULE_KEY, "container")}";`,
       "the reserved export name must be backed by a safe local binding",
     );
     assertStringIncludes(
       result,
-      "export { __vfCssExport_class as class };",
+      "export { __vfCssExport_0 as class };",
       "the safe local binding must still be exported under the original export name",
     );
     await assertParsesAsModule(
@@ -229,12 +229,12 @@ describe("css-strip plugin", () => {
     );
     assertStringIncludes(
       result,
-      "const __vfCssExport_class = ",
+      "const __vfCssExport_0 = ",
       "the reserved namespace export must be backed by a safe local binding",
     );
     assertStringIncludes(
       result,
-      "export { __vfCssExport_class as class };",
+      "export { __vfCssExport_0 as class };",
       "the safe local proxy stub must be exported under the original export name",
     );
     await assertParsesAsModule(
@@ -367,6 +367,42 @@ describe("css-strip plugin", () => {
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
   });
 
+  it("preserves quoted aliases on css namespace re-exports", async () => {
+    const ctx = createContext(
+      `export * as "styles-map" from "./Button.module.css";`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      (namespace["styles-map"] as Record<string, Record<string, string>>)?.default?.container,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "an arbitrary namespace export name must keep the CSS module namespace shape",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("allocates disjoint locals for identifier and encoded-looking export names", async () => {
+    const ctx = createContext(
+      `export { a as $61_2d_62, b as "a-b" } from "./Button.module.css";`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.$61_2d_62,
+      toScopedCssModuleClass(MODULE_KEY, "a"),
+      "an identifier export must retain its own generated local",
+    );
+    assertEquals(
+      namespace["a-b"],
+      toScopedCssModuleClass(MODULE_KEY, "b"),
+      "a quoted export must not collide with an identifier that resembles its encoding",
+    );
+  });
+
   it("serializes decoded unscoped css binding names as valid string literals", async () => {
     const ctx = createContext(
       String
@@ -387,6 +423,18 @@ describe("css-strip plugin", () => {
       "a decoded backslash must survive generated module serialization exactly once",
     );
     assertEquals(ctx.metadata.get("cssImports"), ["./theme.css"]);
+  });
+
+  it("escapes HTML raw-text delimiters in generated JavaScript strings", async () => {
+    const ctx = createContext(
+      `import { "</script>" as boundary } from "./theme.css"; export { boundary };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(result.includes("</script>"), false);
+    assertEquals(namespace.boundary, "</script>");
   });
 
   it("does not treat `from` inside a quoted css export name as the keyword", async () => {

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -109,23 +109,61 @@ describe("css-strip plugin", () => {
 
     assertStringIncludes(
       result,
-      "export const styles = new Proxy({},",
-      "a re-exported css default must stay exported as a scoped proxy stub",
+      "const __vfCssExport_styles = new Proxy({},",
+      "a re-exported css default must be backed by a scoped proxy stub",
     );
     assertStringIncludes(
       result,
-      `export const root = "${toScopedCssModuleClass(MODULE_KEY, "container")}";`,
-      "a re-exported named css binding must stay exported as its scoped class",
+      "export { __vfCssExport_styles as styles };",
+      "a re-exported css default must stay exported under its original name",
+    );
+    assertStringIncludes(
+      result,
+      `const __vfCssExport_root = "${toScopedCssModuleClass(MODULE_KEY, "container")}";`,
+      "a re-exported named css binding must be backed by its scoped class",
+    );
+    assertStringIncludes(
+      result,
+      "export { __vfCssExport_root as root };",
+      "a re-exported named css binding must stay exported under its original name",
     );
     assertEquals(
-      /(?<!export\s)\bconst\s+styles\s*=/.test(result),
+      /\bconst\s+(styles|root)\s*=/.test(result),
       false,
-      "a css re-export must not degrade into a non-exported const binding",
+      "a css re-export must not declare the export name as a local binding",
+    );
+    await assertParsesAsModule(
+      result,
+      "a named css re-export must produce a parseable SSR module",
     );
     assertEquals(
       result.includes(`.module.css"`),
       false,
       "no live .module.css specifier may survive",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("does not redeclare a local that shares its name with a css re-export", async () => {
+    const ctx = createContext(
+      `const styles = { fallback: true }; export { default as styles } from "./Button.module.css"; export const used = styles.fallback;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+
+    assertEquals(
+      (result.match(/\bconst\s+styles\s*=/g) ?? []).length,
+      1,
+      "the module's own `const styles` must remain the only `styles` declaration",
+    );
+    assertStringIncludes(
+      result,
+      "export { __vfCssExport_styles as styles };",
+      "the css re-export must still be exported as `styles` through a safe local",
+    );
+    await assertParsesAsModule(
+      result,
+      "a css re-export that shadows an existing local must not produce a duplicate declaration",
     );
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
   });

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -345,6 +345,22 @@ describe("css-strip plugin", () => {
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
   });
 
+  it("preserves closing braces inside quoted css import names", async () => {
+    const ctx = createContext(
+      `import { "foo}bar" as className } from "./Button.module.css"; export { className };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.className,
+      toScopedCssModuleClass(MODULE_KEY, "foo}bar"),
+      "a quoted closing brace must remain data instead of ending the import clause",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
   it("preserves single-quoted css export names and escaped quotes", async () => {
     const ctx = createContext(
       String
@@ -572,7 +588,7 @@ describe("css-strip plugin", () => {
 /**
  * The production ordering: `compilePlugin` runs with `minify: !ctx.dev`
  * immediately before this stage, so the statements the stub generator sees in a
- * production build are whatever esbuild emits — not the spaced source form.
+ * production build are whatever esbuild emits, not the spaced source form.
  */
 describe("css-strip after a production compile", () => {
   afterAll(async () => {

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -3,6 +3,18 @@ import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { TransformContext } from "../types.ts";
 import { cssStripPlugin } from "./ssr-css-strip.ts";
+import {
+  getCssModuleScope,
+  resolveCssModuleKey,
+  rewriteCssModuleContent,
+  toScopedCssModuleClass,
+} from "#veryfront/transforms/css-modules/naming.ts";
+
+const MODULE_KEY = resolveCssModuleKey(
+  "./Button.module.css",
+  "/project/pages/index.tsx",
+  "/project",
+);
 
 function createContext(code: string): TransformContext {
   return {
@@ -32,11 +44,17 @@ describe("css-strip plugin", () => {
 
     assertEquals(result.includes(`import("./Button.module.css")`), false);
     assertEquals(result.includes("await /* css import"), false);
+    const scope = getCssModuleScope(MODULE_KEY);
     assertStringIncludes(
       result,
       'await Promise.resolve({ default: new Proxy({}, { get: (_, p) => typeof p === "string" ? "Button_"',
+      "a dynamic css module import must become a scoped proxy stub",
     );
-    assertStringIncludes(result, "__");
+    assertStringIncludes(
+      result,
+      `+ "__${scope.hash}" : "" })`,
+      "the dynamic stub must carry the module scope hash resolved from the importer path",
+    );
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
   });
 
@@ -47,10 +65,49 @@ describe("css-strip plugin", () => {
 
     const result = await cssStripPlugin.transform(ctx);
 
+    const expectedClass = toScopedCssModuleClass(MODULE_KEY, "container");
+
     assertEquals(result.includes(`import styles`), false);
-    assertStringIncludes(result, "const styles = new Proxy({},");
-    assertStringIncludes(result, "const styles = new Proxy({},");
-    assertStringIncludes(result, 'root = "Button_container__');
+    assertStringIncludes(
+      result,
+      "const styles = new Proxy({},",
+      "the default css module binding must become a proxy stub",
+    );
+    assertStringIncludes(
+      result,
+      `root = "${expectedClass}"`,
+      "the named binding must resolve to the scoped class of the importer-resolved module key",
+    );
+    assertStringIncludes(
+      rewriteCssModuleContent(".container { color: red; }", MODULE_KEY),
+      `.${expectedClass}`,
+      "the emitted class must match the class the aggregated css is rewritten to",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("strips a css re-export without turning it into a local const", async () => {
+    const ctx = createContext(
+      `export { default as styles } from "./Button.module.css";`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+
+    assertStringIncludes(
+      result,
+      "css re-export stripped",
+      "a css re-export must be replaced by the re-export comment",
+    );
+    assertEquals(
+      /\bconst\s+styles\s*=/.test(result),
+      false,
+      "a css re-export must not degrade into a non-exported const binding",
+    );
+    assertEquals(
+      result.includes(`.module.css"`),
+      false,
+      "no live .module.css specifier may survive",
+    );
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
   });
 

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -1,6 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
+import { stop as stopEsbuild } from "#veryfront/platform/compat/esbuild.ts";
+import { compilePlugin } from "./compile.ts";
 import type { TransformContext } from "../types.ts";
 import { cssStripPlugin } from "./ssr-css-strip.ts";
 import {
@@ -16,7 +18,7 @@ const MODULE_KEY = resolveCssModuleKey(
   "/project",
 );
 
-function createContext(code: string): TransformContext {
+function createContext(code: string, dev = true): TransformContext {
   return {
     code,
     originalSource: code,
@@ -24,7 +26,7 @@ function createContext(code: string): TransformContext {
     projectDir: "/project",
     projectId: "project",
     target: "ssr",
-    dev: true,
+    dev,
     contentHash: "hash",
     jsxImportSource: "react",
     timing: new Map(),
@@ -46,6 +48,18 @@ async function assertParsesAsModule(source: string, message: string): Promise<vo
     parseError = error instanceof Error ? error.message : String(error);
   }
   assertEquals(parseError, undefined, `${message} (got: ${parseError})`);
+}
+
+/**
+ * Link and evaluate a stubbed SSR module and hand back its export namespace.
+ *
+ * Whether a stub still *carries* a binding is only half the contract: an
+ * importer reads through it, so the shape it hands back has to be checked by
+ * running the module rather than by matching its text.
+ */
+async function evaluateModule(source: string): Promise<Record<string, unknown>> {
+  const namespace = await import(`data:text/javascript,${encodeURIComponent(source)}`);
+  return namespace as Record<string, unknown>;
 }
 
 describe("css-strip plugin", () => {
@@ -209,8 +223,8 @@ describe("css-strip plugin", () => {
     );
     assertStringIncludes(
       result,
-      "const __vfCssExport_class = new Proxy({},",
-      "the reserved namespace export must be backed by a safe local proxy stub",
+      "const __vfCssExport_class = ",
+      "the reserved namespace export must be backed by a safe local binding",
     );
     assertStringIncludes(
       result,
@@ -220,6 +234,95 @@ describe("css-strip plugin", () => {
     await assertParsesAsModule(
       result,
       "a reserved-word css namespace re-export must still produce a parseable SSR module",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("gives a css namespace re-export the shape of a module namespace", async () => {
+    const ctx = createContext(`export * as styles from "./Button.module.css";`);
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+    const styles = namespace.styles as Record<string, Record<string, string>>;
+
+    assertEquals(
+      styles.default?.container,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a namespace re-export binds the module namespace, so `styles.default` must be the class map",
+    );
+    assertEquals(
+      styles.container as unknown as string,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a css module namespace also exposes each class as a named export",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("keeps a minified css re-export exporting its bindings", async () => {
+    // esbuild minifies immediately before this stage whenever `dev` is false,
+    // so production statements carry no spaces around `from`.
+    const ctx = createContext(
+      `export{default as styles,container as root}from"./Button.module.css";`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+
+    assertEquals(
+      result.includes("css re-export stripped"),
+      false,
+      "a minified css re-export must not be stripped to a comment, which drops the binding",
+    );
+    const namespace = await evaluateModule(result);
+    assertEquals(
+      (namespace.styles as Record<string, string>)?.container,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a minified re-exported css default must still resolve to the scoped class map",
+    );
+    assertEquals(
+      namespace.root,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a minified re-exported named css binding must still resolve to its scoped class",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("resolves a named `default` css import to the class map, not the literal name", async () => {
+    const ctx = createContext(
+      `import { default as styles } from "./Button.module.css"; export const cls = styles.container;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      '`default` is the class map, so a named `default` import must not stub the string "default"',
+    );
+  });
+
+  it("does not redeclare a source binding that already uses the generated local prefix", async () => {
+    const ctx = createContext(
+      `const __vfCssExport_styles = "own"; export { default as styles } from "./Button.module.css"; export const own = __vfCssExport_styles;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+
+    assertEquals(
+      (result.match(/\bconst\s+__vfCssExport_styles\s*=/g) ?? []).length,
+      1,
+      "the module's own `__vfCssExport_styles` must stay the only declaration of that name",
+    );
+    const namespace = await evaluateModule(result);
+    assertEquals(
+      namespace.own,
+      "own",
+      "the module's own binding must keep its value rather than be shadowed by the stub",
+    );
+    assertEquals(
+      (namespace.styles as Record<string, string>)?.container,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "the css re-export must still resolve through a collision-free local",
     );
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
   });
@@ -250,5 +353,49 @@ describe("css-strip plugin", () => {
 
     assertEquals(result, code);
     assertEquals(ctx.metadata.has("cssImports"), false);
+  });
+});
+
+/**
+ * The production ordering: `compilePlugin` runs with `minify: !ctx.dev`
+ * immediately before this stage, so the statements the stub generator sees in a
+ * production build are whatever esbuild emits — not the spaced source form.
+ */
+describe("css-strip after a production compile", () => {
+  afterAll(async () => {
+    await stopEsbuild();
+  });
+
+  it("keeps css re-exports linkable through the minified compile output", async () => {
+    const source = `export { default as styles, container as root } from "./Button.module.css";
+export * as ns from "./Button.module.css";
+`;
+    const compileCtx = createContext(source, false);
+    const compiled = await compilePlugin.transform(compileCtx);
+
+    const stripCtx = createContext(compiled, false);
+    const result = await cssStripPlugin.transform(stripCtx);
+
+    assertEquals(
+      result.includes('.module.css"'),
+      false,
+      "no live .module.css specifier may survive a production build",
+    );
+    const namespace = await evaluateModule(result);
+    assertEquals(
+      (namespace.styles as Record<string, string>)?.container,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a production css re-export must still resolve to the scoped class map",
+    );
+    assertEquals(
+      namespace.root,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a production named css re-export must still resolve to its scoped class",
+    );
+    assertEquals(
+      (namespace.ns as Record<string, Record<string, string>>)?.default?.container,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a production css namespace re-export must keep its module-namespace shape",
+    );
   });
 });

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -329,6 +329,22 @@ describe("css-strip plugin", () => {
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
   });
 
+  it("does not treat `from` inside a quoted css export name as the keyword", async () => {
+    const ctx = createContext(
+      `export { "foo-from" as fooFrom } from "./Button.module.css";`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.fooFrom,
+      toScopedCssModuleClass(MODULE_KEY, "foo-from"),
+      "a quoted export name containing `from` must remain available through its alias",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
   it("resolves a named `default` css import to the class map, not the literal name", async () => {
     const ctx = createContext(
       `import { default as styles } from "./Button.module.css"; export const cls = styles.container;`,

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -351,6 +351,22 @@ describe("css-strip plugin", () => {
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
   });
 
+  it("preserves quoted aliases on css re-exports", async () => {
+    const ctx = createContext(
+      `export { default as "styles-map" } from "./Button.module.css";`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      (namespace["styles-map"] as Record<string, string>)?.container,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "an arbitrary quoted export alias must remain linkable under that exact name",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
   it("serializes decoded unscoped css binding names as valid string literals", async () => {
     const ctx = createContext(
       String

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -86,20 +86,25 @@ describe("css-strip plugin", () => {
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
   });
 
-  it("strips a css re-export without turning it into a local const", async () => {
+  it("keeps a css re-export exporting the bindings it re-exported", async () => {
     const ctx = createContext(
-      `export { default as styles } from "./Button.module.css";`,
+      `export { default as styles, container as root } from "./Button.module.css";`,
     );
 
     const result = await cssStripPlugin.transform(ctx);
 
     assertStringIncludes(
       result,
-      "css re-export stripped",
-      "a css re-export must be replaced by the re-export comment",
+      "export const styles = new Proxy({},",
+      "a re-exported css default must stay exported as a scoped proxy stub",
+    );
+    assertStringIncludes(
+      result,
+      `export const root = "${toScopedCssModuleClass(MODULE_KEY, "container")}";`,
+      "a re-exported named css binding must stay exported as its scoped class",
     );
     assertEquals(
-      /\bconst\s+styles\s*=/.test(result),
+      /(?<!export\s)\bconst\s+styles\s*=/.test(result),
       false,
       "a css re-export must not degrade into a non-exported const binding",
     );
@@ -109,6 +114,24 @@ describe("css-strip plugin", () => {
       "no live .module.css specifier may survive",
     );
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("strips a star css re-export, which carries no static names", async () => {
+    const ctx = createContext(`export * from "./globals.css";`);
+
+    const result = await cssStripPlugin.transform(ctx);
+
+    assertStringIncludes(
+      result,
+      "css re-export stripped",
+      "a star css re-export has no static names to stub and must be stripped",
+    );
+    assertEquals(
+      result.includes(`"./globals.css"`),
+      false,
+      "no live .css specifier may survive",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./globals.css"]);
   });
 
   it("keeps dynamic non-css imports untouched", async () => {

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -329,6 +329,22 @@ describe("css-strip plugin", () => {
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
   });
 
+  it("preserves closing braces inside quoted css re-export names", async () => {
+    const ctx = createContext(
+      `export { "foo}bar" as className } from "./Button.module.css";`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.className,
+      toScopedCssModuleClass(MODULE_KEY, "foo}bar"),
+      "a quoted closing brace must remain data instead of ending the export clause",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
   it("preserves single-quoted css export names and escaped quotes", async () => {
     const ctx = createContext(
       String
@@ -451,6 +467,20 @@ describe("css-strip plugin", () => {
 
     assertEquals(result.includes("</script>"), false);
     assertEquals(namespace.boundary, "</script>");
+  });
+
+  it("keeps generated comments parseable when css specifiers contain comment terminators", async () => {
+    const ctx = createContext(
+      `import "./theme*/x.css"; export const ok = true;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+
+    await assertParsesAsModule(
+      result,
+      "a css specifier must not be able to terminate the generated comment",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./theme*/x.css"]);
   });
 
   it("does not treat `from` inside a quoted css export name as the keyword", async () => {

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -367,6 +367,22 @@ describe("css-strip plugin", () => {
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
   });
 
+  it("preserves unaliased quoted names on css re-exports", async () => {
+    const ctx = createContext(
+      `export { "foo-bar" } from "./Button.module.css";`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace["foo-bar"],
+      toScopedCssModuleClass(MODULE_KEY, "foo-bar"),
+      "an unaliased arbitrary export name must remain linkable under that name",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
   it("preserves quoted aliases on css namespace re-exports", async () => {
     const ctx = createContext(
       `export * as "styles-map" from "./Button.module.css";`,

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -34,6 +34,20 @@ function createContext(code: string): TransformContext {
   } as TransformContext;
 }
 
+/**
+ * SSR stubs are linked as real ES modules, so the only assertion that catches a
+ * syntactically invalid stub is asking a JS engine to parse it.
+ */
+async function assertParsesAsModule(source: string, message: string): Promise<void> {
+  let parseError: string | undefined;
+  try {
+    await import(`data:text/javascript,${encodeURIComponent(source)}`);
+  } catch (error) {
+    parseError = error instanceof Error ? error.message : String(error);
+  }
+  assertEquals(parseError, undefined, `${message} (got: ${parseError})`);
+}
+
 describe("css-strip plugin", () => {
   it("rewrites dynamic css imports to a valid expression stub", async () => {
     const ctx = createContext(
@@ -112,6 +126,62 @@ describe("css-strip plugin", () => {
       result.includes(`.module.css"`),
       false,
       "no live .module.css specifier may survive",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("exports a reserved-word css re-export name without declaring it", async () => {
+    const ctx = createContext(
+      `export { container as class } from "./Button.module.css";`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+
+    assertEquals(
+      /\bconst\s+class\b/.test(result),
+      false,
+      "a reserved export name must never become a const binding, which cannot parse",
+    );
+    assertStringIncludes(
+      result,
+      `const __vfCssExport_class = "${toScopedCssModuleClass(MODULE_KEY, "container")}";`,
+      "the reserved export name must be backed by a safe local binding",
+    );
+    assertStringIncludes(
+      result,
+      "export { __vfCssExport_class as class };",
+      "the safe local binding must still be exported under the original export name",
+    );
+    await assertParsesAsModule(
+      result,
+      "a reserved-word css re-export must still produce a parseable SSR module",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("exports a reserved-word css namespace re-export without declaring it", async () => {
+    const ctx = createContext(`export * as class from "./Button.module.css";`);
+
+    const result = await cssStripPlugin.transform(ctx);
+
+    assertEquals(
+      /\bconst\s+class\b/.test(result),
+      false,
+      "a reserved namespace export name must never become a const binding",
+    );
+    assertStringIncludes(
+      result,
+      "const __vfCssExport_class = new Proxy({},",
+      "the reserved namespace export must be backed by a safe local proxy stub",
+    );
+    assertStringIncludes(
+      result,
+      "export { __vfCssExport_class as class };",
+      "the safe local proxy stub must be exported under the original export name",
+    );
+    await assertParsesAsModule(
+      result,
+      "a reserved-word css namespace re-export must still produce a parseable SSR module",
     );
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
   });

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -76,6 +76,12 @@ function parseNamedImportBindings(
 
     if (/^[_$a-zA-Z][\w$]*$/.test(part)) {
       bindings.push({ imported: part, local: part });
+      continue;
+    }
+
+    const quotedName = allowQuotedAlias ? parseQuotedExportName(part) : undefined;
+    if (quotedName !== undefined) {
+      bindings.push({ imported: quotedName, local: quotedName });
     }
   }
 

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -75,6 +75,75 @@ function cssBindingValue(imported: string, cssModuleKey: string | undefined): st
 }
 
 /**
+ * Names that are legal as an ES export name but illegal as a `const` binding.
+ * `export { container as class } from "./x.module.css"` is valid input, so the
+ * stub must not turn it into `export const class = ...`.
+ */
+const RESERVED_BINDING_NAMES = new Set([
+  "arguments",
+  "await",
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "default",
+  "delete",
+  "do",
+  "else",
+  "enum",
+  "eval",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "implements",
+  "import",
+  "in",
+  "instanceof",
+  "interface",
+  "let",
+  "new",
+  "null",
+  "package",
+  "private",
+  "protected",
+  "public",
+  "return",
+  "static",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "true",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "yield",
+]);
+
+/**
+ * Export `value` under `exportName`, declaring a safe local binding first when
+ * `exportName` is a reserved word that cannot be a `const` declaration.
+ */
+function exportBindingStatement(exportName: string, value: string): string {
+  if (exportName === "default") return `export default ${value};`;
+  if (!RESERVED_BINDING_NAMES.has(exportName)) {
+    return `export const ${exportName} = ${value};`;
+  }
+  const localName = `__vfCssExport_${exportName}`;
+  return `const ${localName} = ${value}; export { ${localName} as ${exportName} };`;
+}
+
+/**
  * Generate a replacement for a CSS re-export statement.
  *
  * SSR modules are linked as real ES modules, so a re-export that is stripped
@@ -94,9 +163,9 @@ function generateCSSReExportStub(trimmed: string, specifier: string): string {
   // Namespace re-export: export * as styles from "./X.module.css"
   const nsMatch = clause.match(/^\*\s+as\s+([a-zA-Z_$][a-zA-Z0-9_$]*)$/);
   if (nsMatch?.[1]) {
-    return `export const ${nsMatch[1]} = ${
-      cssBindingValue("default", cssModuleKey)
-    }; /* css re-export: ${specifier} */`;
+    return `${
+      exportBindingStatement(nsMatch[1], cssBindingValue("default", cssModuleKey))
+    } /* css re-export: ${specifier} */`;
   }
 
   // Named re-export: export { default as styles, container as c } from "./X.module.css"
@@ -106,12 +175,9 @@ function generateCSSReExportStub(trimmed: string, specifier: string): string {
   const bindings = parseNamedImportBindings(namedMatch[1]);
   if (bindings.length === 0) return stripped;
 
-  const statements = bindings.map((binding) => {
-    const value = cssBindingValue(binding.imported, cssModuleKey);
-    return binding.local === "default"
-      ? `export default ${value};`
-      : `export const ${binding.local} = ${value};`;
-  });
+  const statements = bindings.map((binding) =>
+    exportBindingStatement(binding.local, cssBindingValue(binding.imported, cssModuleKey))
+  );
 
   return `${statements.join(" ")} /* css re-export: ${specifier} */`;
 }

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -123,6 +123,35 @@ function splitNamedImportBindings(namedClause: string): string[] {
   return bindings;
 }
 
+function extractNamedImportClause(clause: string): string | undefined {
+  const trimmed = clause.trim();
+  if (!trimmed.startsWith("{")) return undefined;
+
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+  for (let index = 1; index < trimmed.length; index++) {
+    const char = trimmed[index];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === "}") {
+      return trimmed.slice(index + 1).trim().length === 0 ? trimmed.slice(1, index) : undefined;
+    }
+  }
+
+  return undefined;
+}
+
 function parseQuotedExportName(token: string | undefined): string | undefined {
   if (!token || token.length < 2) return undefined;
   const quote = token[0];
@@ -417,9 +446,9 @@ function generateCSSStub(
   // `default` is a legal named import, and esbuild lowers every CSS re-export
   // to this form, so it must resolve to the class-map proxy rather than to the
   // literal class name `"default"`.
-  const namedMatch = importClause.match(/^\{([^}]+)\}$/);
-  if (namedMatch?.[1]) {
-    const bindings = parseNamedImportBindings(namedMatch[1]);
+  const namedClause = extractNamedImportClause(importClause);
+  if (namedClause) {
+    const bindings = parseNamedImportBindings(namedClause);
     if (bindings.length > 0) {
       const stubs = bindings
         .map((binding) => `${binding.local} = ${cssBindingValue(binding.imported, cssModuleKey)}`)
@@ -429,10 +458,13 @@ function generateCSSStub(
   }
 
   // Mixed: import styles, { container } from "./X.module.css"
-  const mixedMatch = importClause.match(/^([a-zA-Z_$][a-zA-Z0-9_$]*)\s*,\s*\{([^}]+)\}$/);
-  if (mixedMatch?.[1] && mixedMatch[2]) {
+  const mixedMatch = importClause.match(/^([a-zA-Z_$][a-zA-Z0-9_$]*)\s*,\s*/);
+  const mixedNamedClause = mixedMatch
+    ? extractNamedImportClause(importClause.slice(mixedMatch[0].length))
+    : undefined;
+  if (mixedMatch?.[1] && mixedNamedClause) {
     const defaultName = mixedMatch[1];
-    const bindings = parseNamedImportBindings(mixedMatch[2]);
+    const bindings = parseNamedImportBindings(mixedNamedClause);
     const namedStubs = bindings
       .map((binding) => `${binding.local} = ${cssBindingValue(binding.imported, cssModuleKey)}`)
       .join(", ");

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -75,70 +75,17 @@ function cssBindingValue(imported: string, cssModuleKey: string | undefined): st
 }
 
 /**
- * Names that are legal as an ES export name but illegal as a `const` binding.
- * `export { container as class } from "./x.module.css"` is valid input, so the
- * stub must not turn it into `export const class = ...`.
- */
-const RESERVED_BINDING_NAMES = new Set([
-  "arguments",
-  "await",
-  "break",
-  "case",
-  "catch",
-  "class",
-  "const",
-  "continue",
-  "debugger",
-  "default",
-  "delete",
-  "do",
-  "else",
-  "enum",
-  "eval",
-  "export",
-  "extends",
-  "false",
-  "finally",
-  "for",
-  "function",
-  "if",
-  "implements",
-  "import",
-  "in",
-  "instanceof",
-  "interface",
-  "let",
-  "new",
-  "null",
-  "package",
-  "private",
-  "protected",
-  "public",
-  "return",
-  "static",
-  "super",
-  "switch",
-  "this",
-  "throw",
-  "true",
-  "try",
-  "typeof",
-  "var",
-  "void",
-  "while",
-  "with",
-  "yield",
-]);
-
-/**
- * Export `value` under `exportName`, declaring a safe local binding first when
- * `exportName` is a reserved word that cannot be a `const` declaration.
+ * Export `value` under `exportName` without declaring `exportName` locally.
+ *
+ * A re-export never introduces a local binding, so the stub must not either:
+ * `const styles = fallback; export { default as styles } from "./x.module.css"`
+ * is a valid module, and emitting `export const styles` would redeclare it.
+ * Reserved words such as `class` are legal export names but illegal `const`
+ * names, so the same indirection keeps those parseable as well. Export names
+ * are unique per module, which makes the derived local name collision-free.
  */
 function exportBindingStatement(exportName: string, value: string): string {
   if (exportName === "default") return `export default ${value};`;
-  if (!RESERVED_BINDING_NAMES.has(exportName)) {
-    return `export const ${exportName} = ${value};`;
-  }
   const localName = `__vfCssExport_${exportName}`;
   return `const ${localName} = ${value}; export { ${localName} as ${exportName} };`;
 }

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -180,11 +180,41 @@ function exportBindingStatement(
  * `" from "` misses every one of those, strips the statement to a bare comment
  * and leaves the module's own `export {...}` clause referencing bindings that
  * no longer exist, which fails to link. The keyword is therefore matched on its
- * identifier boundary. The first match is the module-introducing keyword; a
- * later match may be text inside the quoted CSS specifier.
+ * identifier boundary while quoted regions are skipped. This excludes `from`
+ * text inside either an arbitrary export name or the CSS specifier.
  */
 function findFromKeywordIndex(statement: string): number {
-  return statement.match(/\bfrom\s*['"`]/)?.index ?? -1;
+  let quote: '"' | "'" | "`" | undefined;
+  let escaped = false;
+
+  for (let index = 0; index < statement.length; index++) {
+    const char = statement[index];
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === quote) {
+        quote = undefined;
+      }
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+
+    if (
+      statement.startsWith("from", index) &&
+      !/[\w$]/.test(statement[index - 1] ?? "") &&
+      /^from\s*['"`]/.test(statement.slice(index))
+    ) {
+      return index;
+    }
+  }
+
+  return -1;
 }
 
 /**

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -75,6 +75,39 @@ function cssBindingValue(imported: string, cssModuleKey: string | undefined): st
 }
 
 /**
+ * A namespace-shaped stub for `export * as styles from "./X.module.css"`.
+ *
+ * A namespace re-export binds the whole module namespace, not its default
+ * export, so importers reach the class map through `styles.default.container`
+ * as well as `styles.container`. Exporting the bare default proxy answers
+ * `styles.default` with a synthesized class string and breaks the first form,
+ * so the stub keeps both: `default` yields the proxy, every other key yields
+ * the class name the proxy would have produced.
+ */
+function cssNamespaceExpression(cssModuleKey: string | undefined): string {
+  const defaultExpr = cssBindingValue("default", cssModuleKey);
+  return `(() => { const d = ${defaultExpr}; return new Proxy({}, { get: (_, p) => p === "default" ? d : d[p] }); })()`;
+}
+
+const CSS_EXPORT_LOCAL_PREFIX = "__vfCssExport_";
+
+/**
+ * A `__vfCssExport_` prefix that no text in `code` already contains.
+ *
+ * The generated locals share the module scope with the module's own bindings,
+ * so a source that already declares `__vfCssExport_styles` would be redeclared
+ * by a fixed prefix and stop parsing. `$` is a valid identifier character, so
+ * lengthening the prefix until it appears nowhere in the source makes every
+ * derived name unique against the module rather than merely against its
+ * siblings.
+ */
+function cssExportLocalPrefix(code: string): string {
+  let prefix = CSS_EXPORT_LOCAL_PREFIX;
+  while (code.includes(prefix)) prefix += "$";
+  return prefix;
+}
+
+/**
  * Export `value` under `exportName` without declaring `exportName` locally.
  *
  * A re-export never introduces a local binding, so the stub must not either:
@@ -82,12 +115,38 @@ function cssBindingValue(imported: string, cssModuleKey: string | undefined): st
  * is a valid module, and emitting `export const styles` would redeclare it.
  * Reserved words such as `class` are legal export names but illegal `const`
  * names, so the same indirection keeps those parseable as well. Export names
- * are unique per module, which makes the derived local name collision-free.
+ * are unique per module, and `localPrefix` is unique against the module's own
+ * source, so the derived local name collides with nothing.
  */
-function exportBindingStatement(exportName: string, value: string): string {
+function exportBindingStatement(
+  localPrefix: string,
+  exportName: string,
+  value: string,
+): string {
   if (exportName === "default") return `export default ${value};`;
-  const localName = `__vfCssExport_${exportName}`;
+  const localName = `${localPrefix}${exportName}`;
   return `const ${localName} = ${value}; export { ${localName} as ${exportName} };`;
+}
+
+/**
+ * Index of the `from` keyword that introduces the module specifier.
+ *
+ * esbuild minifies this code immediately before this stage whenever `dev` is
+ * false, so production statements arrive without spaces around the keyword
+ * (`export{default as styles}from"./x.module.css"`). Matching the literal
+ * `" from "` misses every one of those, strips the statement to a bare comment
+ * and leaves the module's own `export {...}` clause referencing bindings that
+ * no longer exist, which fails to link. The keyword is therefore matched on its
+ * identifier boundary; the last match wins so an import-attribute clause after
+ * the specifier cannot shift the split point.
+ */
+function findFromKeywordIndex(statement: string): number {
+  const pattern = /\bfrom\s*['"`]/g;
+  let index = -1;
+  for (let match = pattern.exec(statement); match; match = pattern.exec(statement)) {
+    index = match.index;
+  }
+  return index;
 }
 
 /**
@@ -99,19 +158,23 @@ function exportBindingStatement(exportName: string, value: string): string {
  * stubs the import path already uses. `export * from` carries no static names,
  * so it stays stripped.
  */
-function generateCSSReExportStub(trimmed: string, specifier: string): string {
+function generateCSSReExportStub(
+  trimmed: string,
+  specifier: string,
+  localPrefix: string,
+): string {
   const stripped = `/* css re-export stripped: ${specifier} */`;
-  const fromIndex = trimmed.lastIndexOf(" from ");
+  const fromIndex = findFromKeywordIndex(trimmed);
   if (fromIndex === -1) return stripped;
 
   const cssModuleKey = isCssModuleImport(specifier) ? specifier : undefined;
   const clause = trimmed.slice("export".length, fromIndex).trim();
 
   // Namespace re-export: export * as styles from "./X.module.css"
-  const nsMatch = clause.match(/^\*\s+as\s+([a-zA-Z_$][a-zA-Z0-9_$]*)$/);
+  const nsMatch = clause.match(/^\*\s*as\s+([a-zA-Z_$][a-zA-Z0-9_$]*)$/);
   if (nsMatch?.[1]) {
     return `${
-      exportBindingStatement(nsMatch[1], cssBindingValue("default", cssModuleKey))
+      exportBindingStatement(localPrefix, nsMatch[1], cssNamespaceExpression(cssModuleKey))
     } /* css re-export: ${specifier} */`;
   }
 
@@ -123,7 +186,11 @@ function generateCSSReExportStub(trimmed: string, specifier: string): string {
   if (bindings.length === 0) return stripped;
 
   const statements = bindings.map((binding) =>
-    exportBindingStatement(binding.local, cssBindingValue(binding.imported, cssModuleKey))
+    exportBindingStatement(
+      localPrefix,
+      binding.local,
+      cssBindingValue(binding.imported, cssModuleKey),
+    )
   );
 
   return `${statements.join(" ")} /* css re-export: ${specifier} */`;
@@ -136,20 +203,21 @@ function generateCSSReExportStub(trimmed: string, specifier: string): string {
  * - Default import: `import styles from "./X.module.css"` → Proxy stub
  * - Named imports: `import { a } from "./X.css"` → null stubs
  */
-function generateCSSStub(statement: string, specifier: string): string {
+function generateCSSStub(statement: string, specifier: string, localPrefix: string): string {
   const trimmed = statement.trim();
 
   // Re-export from CSS: export { default as styles } from './module.css'
-  if (/^export\s/.test(trimmed)) {
-    return generateCSSReExportStub(trimmed, specifier);
+  // Minified output drops the space: `export{default as styles}from"..."`.
+  if (/^export(?![\w$])/.test(trimmed)) {
+    return generateCSSReExportStub(trimmed, specifier, localPrefix);
   }
 
   // Side-effect import: import "./globals.css"
-  if (/^import\s+['"`]/.test(trimmed)) {
+  if (/^import\s*['"`]/.test(trimmed)) {
     return `/* css import: ${specifier} */`;
   }
 
-  const fromIndex = trimmed.lastIndexOf(" from ");
+  const fromIndex = findFromKeywordIndex(trimmed);
   if (fromIndex === -1) {
     return `/* css import: ${specifier} */`;
   }
@@ -168,26 +236,25 @@ function generateCSSStub(statement: string, specifier: string): string {
   }
 
   // Namespace import: import * as styles from "./X.module.css"
-  const nsMatch = importClause.match(/^\*\s+as\s+([a-zA-Z_$][a-zA-Z0-9_$]*)$/);
+  // esbuild lowers `export * as styles from "./X.module.css"` to this form, so
+  // the stub must carry the same namespace shape the re-export promises.
+  const nsMatch = importClause.match(/^\*\s*as\s+([a-zA-Z_$][a-zA-Z0-9_$]*)$/);
   if (nsMatch) {
-    const expr = cssModuleKey
-      ? scopedCssModuleProxyExpression(cssModuleKey)
-      : cssModuleProxyExpression();
-    return `const ${nsMatch[1]} = ${expr}; /* css module: ${specifier} */`;
+    return `const ${nsMatch[1]} = ${
+      cssNamespaceExpression(cssModuleKey)
+    }; /* css module: ${specifier} */`;
   }
 
   // Named imports: import { container, header } from "./X.module.css"
+  // `default` is a legal named import, and esbuild lowers every CSS re-export
+  // to this form, so it must resolve to the class-map proxy rather than to the
+  // literal class name `"default"`.
   const namedMatch = importClause.match(/^\{([^}]+)\}$/);
   if (namedMatch?.[1]) {
     const bindings = parseNamedImportBindings(namedMatch[1]);
     if (bindings.length > 0) {
       const stubs = bindings
-        .map((binding) => {
-          const value = cssModuleKey
-            ? toScopedCssModuleClass(cssModuleKey, binding.imported)
-            : binding.imported;
-          return `${binding.local} = "${value}"`;
-        })
+        .map((binding) => `${binding.local} = ${cssBindingValue(binding.imported, cssModuleKey)}`)
         .join(", ");
       return `const ${stubs}; /* css module: ${specifier} */`;
     }
@@ -199,12 +266,7 @@ function generateCSSStub(statement: string, specifier: string): string {
     const defaultName = mixedMatch[1];
     const bindings = parseNamedImportBindings(mixedMatch[2]);
     const namedStubs = bindings
-      .map((binding) => {
-        const value = cssModuleKey
-          ? toScopedCssModuleClass(cssModuleKey, binding.imported)
-          : binding.imported;
-        return `${binding.local} = "${value}"`;
-      })
+      .map((binding) => `${binding.local} = ${cssBindingValue(binding.imported, cssModuleKey)}`)
       .join(", ");
     const defaultExpr = cssModuleKey
       ? scopedCssModuleProxyExpression(cssModuleKey)
@@ -242,6 +304,7 @@ export const cssStripPlugin: TransformPlugin = {
     if (!hasCssImports) return ctx.code;
 
     const cssSpecifiers: string[] = [];
+    const localPrefix = cssExportLocalPrefix(ctx.code);
 
     const result = await rewriteImports(ctx.code, (imp, statement) => {
       if (!isCSSImport(imp.n)) return null;
@@ -251,7 +314,7 @@ export const cssStripPlugin: TransformPlugin = {
         : undefined;
       const specifierForStub = moduleKey ?? imp.n!;
       if (imp.d > -1) return generateDynamicCSSStub(specifierForStub);
-      return generateCSSStub(statement, specifierForStub);
+      return generateCSSStub(statement, specifierForStub, localPrefix);
     });
 
     if (cssSpecifiers.length > 0) {

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -35,9 +35,19 @@ function cssModuleProxyExpression(): string {
   return "new Proxy({}, { get: (_, p) => String(p) })";
 }
 
+/** Serialize data embedded in generated JavaScript without leaving HTML raw-text delimiters. */
+function serializeJavaScriptString(value: string): string {
+  return JSON.stringify(value).replace(
+    /[<>\u2028\u2029]/g,
+    (char) => `\\u${char.codePointAt(0)?.toString(16).padStart(4, "0")}`,
+  );
+}
+
 function scopedCssModuleProxyExpression(moduleKey: string): string {
   const scope = getCssModuleScope(moduleKey);
-  return `new Proxy({}, { get: (_, p) => typeof p === "string" ? "${scope.base}_" + String(p).replace(/[^\\w-]/g, "_") + "__${scope.hash}" : "" })`;
+  const base = serializeJavaScriptString(`${scope.base}_`);
+  const hash = serializeJavaScriptString(`__${scope.hash}`);
+  return `new Proxy({}, { get: (_, p) => typeof p === "string" ? ${base} + String(p).replace(/[^\\w-]/g, "_") + ${hash} : "" })`;
 }
 
 type NamedImportBinding = { imported: string; local: string };
@@ -169,12 +179,18 @@ function parseQuotedExportName(token: string | undefined): string | undefined {
   return decoded;
 }
 
+function parseExportNameToken(token: string | undefined): string | undefined {
+  const trimmed = token?.trim();
+  if (!trimmed) return undefined;
+  return /^[_$a-zA-Z][\w$]*$/.test(trimmed) ? trimmed : parseQuotedExportName(trimmed);
+}
+
 function cssBindingValue(imported: string, cssModuleKey: string | undefined): string {
   if (imported === "default") {
     return cssModuleKey ? scopedCssModuleProxyExpression(cssModuleKey) : cssModuleProxyExpression();
   }
   const className = cssModuleKey ? toScopedCssModuleClass(cssModuleKey, imported) : imported;
-  return JSON.stringify(className);
+  return serializeJavaScriptString(className);
 }
 
 /**
@@ -193,21 +209,22 @@ function cssNamespaceExpression(cssModuleKey: string | undefined): string {
 }
 
 const CSS_EXPORT_LOCAL_PREFIX = "__vfCssExport_";
+type AllocateCssExportLocal = () => string;
 
 /**
  * A `__vfCssExport_` prefix that no text in `code` already contains.
  *
  * The generated locals share the module scope with the module's own bindings,
- * so a source that already declares `__vfCssExport_styles` would be redeclared
+ * so a source that already declares `__vfCssExport_0` would be redeclared
  * by a fixed prefix and stop parsing. `$` is a valid identifier character, so
  * lengthening the prefix until it appears nowhere in the source makes every
- * derived name unique against the module rather than merely against its
- * siblings.
+ * counter-derived name unique against the module and its generated siblings.
  */
-function cssExportLocalPrefix(code: string): string {
+function createCssExportLocalAllocator(code: string): AllocateCssExportLocal {
   let prefix = CSS_EXPORT_LOCAL_PREFIX;
   while (code.includes(prefix)) prefix += "$";
-  return prefix;
+  let nextLocal = 0;
+  return () => `${prefix}${nextLocal++}`;
 }
 
 /**
@@ -217,22 +234,19 @@ function cssExportLocalPrefix(code: string): string {
  * `const styles = fallback; export { default as styles } from "./x.module.css"`
  * is a valid module, and emitting `export const styles` would redeclare it.
  * Reserved words such as `class` are legal export names but illegal `const`
- * names, so the same indirection keeps those parseable as well. Export names
- * are unique per module, and `localPrefix` is unique against the module's own
- * source, so the derived local name collides with nothing.
+ * names, so the same indirection keeps those parseable as well. A transform-wide
+ * allocator keeps the local independent of attacker-controlled export text and
+ * collision-free across every rewritten statement in the module.
  */
 function exportBindingStatement(
-  localPrefix: string,
+  allocateLocal: AllocateCssExportLocal,
   exportName: string,
   value: string,
 ): string {
   if (exportName === "default") return `export default ${value};`;
   const identifierName = /^[_$a-zA-Z][\w$]*$/.test(exportName);
-  const localSuffix = identifierName
-    ? exportName
-    : `$${Array.from(exportName, (char) => char.codePointAt(0)?.toString(16) ?? "").join("_")}`;
-  const exportedName = identifierName ? exportName : JSON.stringify(exportName);
-  const localName = `${localPrefix}${localSuffix}`;
+  const exportedName = identifierName ? exportName : serializeJavaScriptString(exportName);
+  const localName = allocateLocal();
   return `const ${localName} = ${value}; export { ${localName} as ${exportedName} };`;
 }
 
@@ -294,7 +308,7 @@ function findFromKeywordIndex(statement: string): number {
 function generateCSSReExportStub(
   trimmed: string,
   specifier: string,
-  localPrefix: string,
+  allocateLocal: AllocateCssExportLocal,
 ): string {
   const stripped = `/* css re-export stripped: ${specifier} */`;
   const fromIndex = findFromKeywordIndex(trimmed);
@@ -304,10 +318,15 @@ function generateCSSReExportStub(
   const clause = trimmed.slice("export".length, fromIndex).trim();
 
   // Namespace re-export: export * as styles from "./X.module.css"
-  const nsMatch = clause.match(/^\*\s*as\s+([a-zA-Z_$][a-zA-Z0-9_$]*)$/);
-  if (nsMatch?.[1]) {
+  const nsMatch = clause.match(/^\*\s*as\s+(.+)$/);
+  const namespaceExportName = parseExportNameToken(nsMatch?.[1]);
+  if (namespaceExportName !== undefined) {
     return `${
-      exportBindingStatement(localPrefix, nsMatch[1], cssNamespaceExpression(cssModuleKey))
+      exportBindingStatement(
+        allocateLocal,
+        namespaceExportName,
+        cssNamespaceExpression(cssModuleKey),
+      )
     } /* css re-export: ${specifier} */`;
   }
 
@@ -320,7 +339,7 @@ function generateCSSReExportStub(
 
   const statements = bindings.map((binding) =>
     exportBindingStatement(
-      localPrefix,
+      allocateLocal,
       binding.local,
       cssBindingValue(binding.imported, cssModuleKey),
     )
@@ -336,13 +355,17 @@ function generateCSSReExportStub(
  * - Default import: `import styles from "./X.module.css"` → Proxy stub
  * - Named imports: `import { a } from "./X.css"` → null stubs
  */
-function generateCSSStub(statement: string, specifier: string, localPrefix: string): string {
+function generateCSSStub(
+  statement: string,
+  specifier: string,
+  allocateLocal: AllocateCssExportLocal,
+): string {
   const trimmed = statement.trim();
 
   // Re-export from CSS: export { default as styles } from './module.css'
   // Minified output drops the space: `export{default as styles}from"..."`.
   if (/^export(?![\w$])/.test(trimmed)) {
-    return generateCSSReExportStub(trimmed, specifier, localPrefix);
+    return generateCSSReExportStub(trimmed, specifier, allocateLocal);
   }
 
   // Side-effect import: import "./globals.css"
@@ -437,7 +460,7 @@ export const cssStripPlugin: TransformPlugin = {
     if (!hasCssImports) return ctx.code;
 
     const cssSpecifiers: string[] = [];
-    const localPrefix = cssExportLocalPrefix(ctx.code);
+    const allocateExportLocal = createCssExportLocalAllocator(ctx.code);
 
     const result = await rewriteImports(ctx.code, (imp, statement) => {
       if (!isCSSImport(imp.n)) return null;
@@ -447,7 +470,7 @@ export const cssStripPlugin: TransformPlugin = {
         : undefined;
       const specifierForStub = moduleKey ?? imp.n!;
       if (imp.d > -1) return generateDynamicCSSStub(specifierForStub);
-      return generateCSSStub(statement, specifierForStub, localPrefix);
+      return generateCSSStub(statement, specifierForStub, allocateExportLocal);
     });
 
     if (cssSpecifiers.length > 0) {

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -45,14 +45,16 @@ type NamedImportBinding = { imported: string; local: string };
 function parseNamedImportBindings(namedClause: string): NamedImportBinding[] {
   const bindings: NamedImportBinding[] = [];
 
-  for (const rawPart of namedClause.split(",")) {
+  for (const rawPart of splitNamedImportBindings(namedClause)) {
     const part = rawPart.trim();
     if (!part) continue;
 
-    const aliasMatch = part.match(/^([_$a-zA-Z][\w$-]*)\s+as\s+([_$a-zA-Z][\w$]*)$/);
+    const aliasMatch = part.match(
+      /^(?:([_$a-zA-Z][\w$-]*)|("(?:[^"\\]|\\.)*"))\s+as\s+([_$a-zA-Z][\w$]*)$/,
+    );
     if (aliasMatch) {
-      const imported = aliasMatch[1];
-      const local = aliasMatch[2];
+      const imported = aliasMatch[1] ?? parseQuotedExportName(aliasMatch[2]);
+      const local = aliasMatch[3];
       if (!imported || !local) continue;
       bindings.push({ imported, local });
       continue;
@@ -64,6 +66,47 @@ function parseNamedImportBindings(namedClause: string): NamedImportBinding[] {
   }
 
   return bindings;
+}
+
+function splitNamedImportBindings(namedClause: string): string[] {
+  const bindings: string[] = [];
+  let start = 0;
+  let quoted = false;
+  let escaped = false;
+
+  for (let index = 0; index < namedClause.length; index++) {
+    const char = namedClause[index];
+    if (quoted) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === '"') {
+        quoted = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      quoted = true;
+    } else if (char === ",") {
+      bindings.push(namedClause.slice(start, index));
+      start = index + 1;
+    }
+  }
+
+  bindings.push(namedClause.slice(start));
+  return bindings;
+}
+
+function parseQuotedExportName(token: string | undefined): string | undefined {
+  if (!token) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(token);
+    return typeof parsed === "string" ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function cssBindingValue(imported: string, cssModuleKey: string | undefined): string {
@@ -137,16 +180,11 @@ function exportBindingStatement(
  * `" from "` misses every one of those, strips the statement to a bare comment
  * and leaves the module's own `export {...}` clause referencing bindings that
  * no longer exist, which fails to link. The keyword is therefore matched on its
- * identifier boundary; the last match wins so an import-attribute clause after
- * the specifier cannot shift the split point.
+ * identifier boundary. The first match is the module-introducing keyword; a
+ * later match may be text inside the quoted CSS specifier.
  */
 function findFromKeywordIndex(statement: string): number {
-  const pattern = /\bfrom\s*['"`]/g;
-  let index = -1;
-  for (let match = pattern.exec(statement); match; match = pattern.exec(statement)) {
-    index = match.index;
-  }
-  return index;
+  return statement.match(/\bfrom\s*['"`]/)?.index ?? -1;
 }
 
 /**

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -66,6 +66,56 @@ function parseNamedImportBindings(namedClause: string): NamedImportBinding[] {
   return bindings;
 }
 
+function cssBindingValue(imported: string, cssModuleKey: string | undefined): string {
+  if (imported === "default") {
+    return cssModuleKey ? scopedCssModuleProxyExpression(cssModuleKey) : cssModuleProxyExpression();
+  }
+  const className = cssModuleKey ? toScopedCssModuleClass(cssModuleKey, imported) : imported;
+  return `"${className}"`;
+}
+
+/**
+ * Generate a replacement for a CSS re-export statement.
+ *
+ * SSR modules are linked as real ES modules, so a re-export that is stripped
+ * to a comment silently drops the binding and every importer of it fails to
+ * link. Enumerable clauses therefore keep exporting the same names through the
+ * stubs the import path already uses. `export * from` carries no static names,
+ * so it stays stripped.
+ */
+function generateCSSReExportStub(trimmed: string, specifier: string): string {
+  const stripped = `/* css re-export stripped: ${specifier} */`;
+  const fromIndex = trimmed.lastIndexOf(" from ");
+  if (fromIndex === -1) return stripped;
+
+  const cssModuleKey = isCssModuleImport(specifier) ? specifier : undefined;
+  const clause = trimmed.slice("export".length, fromIndex).trim();
+
+  // Namespace re-export: export * as styles from "./X.module.css"
+  const nsMatch = clause.match(/^\*\s+as\s+([a-zA-Z_$][a-zA-Z0-9_$]*)$/);
+  if (nsMatch?.[1]) {
+    return `export const ${nsMatch[1]} = ${
+      cssBindingValue("default", cssModuleKey)
+    }; /* css re-export: ${specifier} */`;
+  }
+
+  // Named re-export: export { default as styles, container as c } from "./X.module.css"
+  const namedMatch = clause.match(/^\{([^}]*)\}$/);
+  if (!namedMatch?.[1]) return stripped;
+
+  const bindings = parseNamedImportBindings(namedMatch[1]);
+  if (bindings.length === 0) return stripped;
+
+  const statements = bindings.map((binding) => {
+    const value = cssBindingValue(binding.imported, cssModuleKey);
+    return binding.local === "default"
+      ? `export default ${value};`
+      : `export const ${binding.local} = ${value};`;
+  });
+
+  return `${statements.join(" ")} /* css re-export: ${specifier} */`;
+}
+
 /**
  * Generate a replacement for a static CSS import statement.
  *
@@ -77,9 +127,8 @@ function generateCSSStub(statement: string, specifier: string): string {
   const trimmed = statement.trim();
 
   // Re-export from CSS: export { default as styles } from './module.css'
-  // → strip entirely, the CSS is collected separately
   if (/^export\s/.test(trimmed)) {
-    return `/* css re-export stripped: ${specifier} */`;
+    return generateCSSReExportStub(trimmed, specifier);
   }
 
   // Side-effect import: import "./globals.css"

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -50,7 +50,7 @@ function parseNamedImportBindings(namedClause: string): NamedImportBinding[] {
     if (!part) continue;
 
     const aliasMatch = part.match(
-      /^(?:([_$a-zA-Z][\w$-]*)|("(?:[^"\\]|\\.)*"))\s+as\s+([_$a-zA-Z][\w$]*)$/,
+      /^(?:([_$a-zA-Z][\w$-]*)|("(?:[^"\\\r\n]|\\.)*"|'(?:[^'\\\r\n]|\\.)*'))\s+as\s+([_$a-zA-Z][\w$]*)$/,
     );
     if (aliasMatch) {
       const imported = aliasMatch[1] ?? parseQuotedExportName(aliasMatch[2]);
@@ -71,24 +71,24 @@ function parseNamedImportBindings(namedClause: string): NamedImportBinding[] {
 function splitNamedImportBindings(namedClause: string): string[] {
   const bindings: string[] = [];
   let start = 0;
-  let quoted = false;
+  let quote: '"' | "'" | undefined;
   let escaped = false;
 
   for (let index = 0; index < namedClause.length; index++) {
     const char = namedClause[index];
-    if (quoted) {
+    if (quote) {
       if (escaped) {
         escaped = false;
       } else if (char === "\\") {
         escaped = true;
-      } else if (char === '"') {
-        quoted = false;
+      } else if (char === quote) {
+        quote = undefined;
       }
       continue;
     }
 
-    if (char === '"') {
-      quoted = true;
+    if (char === '"' || char === "'") {
+      quote = char;
     } else if (char === ",") {
       bindings.push(namedClause.slice(start, index));
       start = index + 1;
@@ -100,13 +100,69 @@ function splitNamedImportBindings(namedClause: string): string[] {
 }
 
 function parseQuotedExportName(token: string | undefined): string | undefined {
-  if (!token) return undefined;
-  try {
-    const parsed: unknown = JSON.parse(token);
-    return typeof parsed === "string" ? parsed : undefined;
-  } catch {
-    return undefined;
+  if (!token || token.length < 2) return undefined;
+  const quote = token[0];
+  if ((quote !== '"' && quote !== "'") || token.at(-1) !== quote) return undefined;
+
+  let decoded = "";
+  for (let index = 1; index < token.length - 1; index++) {
+    const char = token[index];
+    if (char !== "\\") {
+      decoded += char;
+      continue;
+    }
+
+    const escaped = token[++index];
+    if (escaped === undefined || index >= token.length - 1) return undefined;
+    const simpleEscapes: Record<string, string> = {
+      b: "\b",
+      f: "\f",
+      n: "\n",
+      r: "\r",
+      t: "\t",
+      v: "\v",
+      "0": "\0",
+      "\\": "\\",
+      '"': '"',
+      "'": "'",
+    };
+    if (escaped in simpleEscapes) {
+      decoded += simpleEscapes[escaped];
+      continue;
+    }
+
+    if (escaped === "\n" || escaped === "\u2028" || escaped === "\u2029") continue;
+    if (escaped === "\r") {
+      if (token[index + 1] === "\n") index++;
+      continue;
+    }
+
+    if (escaped === "x") {
+      const hex = token.slice(index + 1, index + 3);
+      if (!/^[\da-fA-F]{2}$/.test(hex)) return undefined;
+      decoded += String.fromCodePoint(Number.parseInt(hex, 16));
+      index += 2;
+      continue;
+    }
+
+    if (escaped === "u") {
+      const braced = token[index + 1] === "{";
+      const end = braced ? token.indexOf("}", index + 2) : index + 5;
+      const hex = braced ? token.slice(index + 2, end) : token.slice(index + 1, end);
+      if (end === -1 || !/^[\da-fA-F]+$/.test(hex) || (!braced && hex.length !== 4)) {
+        return undefined;
+      }
+      const codePoint = Number.parseInt(hex, 16);
+      if (codePoint > 0x10ffff) return undefined;
+      decoded += String.fromCodePoint(codePoint);
+      index = braced ? end : end - 1;
+      continue;
+    }
+
+    decoded += escaped;
   }
+
+  return decoded;
 }
 
 function cssBindingValue(imported: string, cssModuleKey: string | undefined): string {
@@ -114,7 +170,7 @@ function cssBindingValue(imported: string, cssModuleKey: string | undefined): st
     return cssModuleKey ? scopedCssModuleProxyExpression(cssModuleKey) : cssModuleProxyExpression();
   }
   const className = cssModuleKey ? toScopedCssModuleClass(cssModuleKey, imported) : imported;
-  return `"${className}"`;
+  return JSON.stringify(className);
 }
 
 /**

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -42,7 +42,10 @@ function scopedCssModuleProxyExpression(moduleKey: string): string {
 
 type NamedImportBinding = { imported: string; local: string };
 
-function parseNamedImportBindings(namedClause: string): NamedImportBinding[] {
+function parseNamedImportBindings(
+  namedClause: string,
+  allowQuotedAlias = false,
+): NamedImportBinding[] {
   const bindings: NamedImportBinding[] = [];
 
   for (const rawPart of splitNamedImportBindings(namedClause)) {
@@ -50,12 +53,13 @@ function parseNamedImportBindings(namedClause: string): NamedImportBinding[] {
     if (!part) continue;
 
     const aliasMatch = part.match(
-      /^(?:([_$a-zA-Z][\w$-]*)|("(?:[^"\\\r\n]|\\.)*"|'(?:[^'\\\r\n]|\\.)*'))\s+as\s+([_$a-zA-Z][\w$]*)$/,
+      /^(?:([_$a-zA-Z][\w$-]*)|("(?:[^"\\\r\n]|\\.)*"|'(?:[^'\\\r\n]|\\.)*'))\s+as\s+(?:([_$a-zA-Z][\w$]*)|("(?:[^"\\\r\n]|\\.)*"|'(?:[^'\\\r\n]|\\.)*'))$/,
     );
     if (aliasMatch) {
       const imported = aliasMatch[1] ?? parseQuotedExportName(aliasMatch[2]);
-      const local = aliasMatch[3];
-      if (!imported || !local) continue;
+      const local = aliasMatch[3] ??
+        (allowQuotedAlias ? parseQuotedExportName(aliasMatch[4]) : undefined);
+      if (imported === undefined || local === undefined) continue;
       bindings.push({ imported, local });
       continue;
     }
@@ -223,8 +227,13 @@ function exportBindingStatement(
   value: string,
 ): string {
   if (exportName === "default") return `export default ${value};`;
-  const localName = `${localPrefix}${exportName}`;
-  return `const ${localName} = ${value}; export { ${localName} as ${exportName} };`;
+  const identifierName = /^[_$a-zA-Z][\w$]*$/.test(exportName);
+  const localSuffix = identifierName
+    ? exportName
+    : `$${Array.from(exportName, (char) => char.codePointAt(0)?.toString(16) ?? "").join("_")}`;
+  const exportedName = identifierName ? exportName : JSON.stringify(exportName);
+  const localName = `${localPrefix}${localSuffix}`;
+  return `const ${localName} = ${value}; export { ${localName} as ${exportedName} };`;
 }
 
 /**
@@ -306,7 +315,7 @@ function generateCSSReExportStub(
   const namedMatch = clause.match(/^\{([^}]*)\}$/);
   if (!namedMatch?.[1]) return stripped;
 
-  const bindings = parseNamedImportBindings(namedMatch[1]);
+  const bindings = parseNamedImportBindings(namedMatch[1], true);
   if (bindings.length === 0) return stripped;
 
   const statements = bindings.map((binding) =>

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -35,6 +35,10 @@ function cssModuleProxyExpression(): string {
   return "new Proxy({}, { get: (_, p) => String(p) })";
 }
 
+function cssComment(label: string, specifier: string): string {
+  return `/* css ${label}: ${specifier.replaceAll("*/", "*\\/")} */`;
+}
+
 /** Serialize data embedded in generated JavaScript without leaving HTML raw-text delimiters. */
 function serializeJavaScriptString(value: string): string {
   return JSON.stringify(value).replace(
@@ -316,7 +320,7 @@ function generateCSSReExportStub(
   specifier: string,
   allocateLocal: AllocateCssExportLocal,
 ): string {
-  const stripped = `/* css re-export stripped: ${specifier} */`;
+  const stripped = cssComment("re-export stripped", specifier);
   const fromIndex = findFromKeywordIndex(trimmed);
   if (fromIndex === -1) return stripped;
 
@@ -333,14 +337,16 @@ function generateCSSReExportStub(
         namespaceExportName,
         cssNamespaceExpression(cssModuleKey),
       )
-    } /* css re-export: ${specifier} */`;
+    } ${cssComment("re-export", specifier)}`;
   }
 
   // Named re-export: export { default as styles, container as c } from "./X.module.css"
-  const namedMatch = clause.match(/^\{([^}]*)\}$/);
-  if (!namedMatch?.[1]) return stripped;
+  const namedClause = clause.startsWith("{") && clause.endsWith("}")
+    ? clause.slice(1, -1)
+    : undefined;
+  if (!namedClause) return stripped;
 
-  const bindings = parseNamedImportBindings(namedMatch[1], true);
+  const bindings = parseNamedImportBindings(namedClause, true);
   if (bindings.length === 0) return stripped;
 
   const statements = bindings.map((binding) =>
@@ -351,7 +357,7 @@ function generateCSSReExportStub(
     )
   );
 
-  return `${statements.join(" ")} /* css re-export: ${specifier} */`;
+  return `${statements.join(" ")} ${cssComment("re-export", specifier)}`;
 }
 
 /**
@@ -376,12 +382,12 @@ function generateCSSStub(
 
   // Side-effect import: import "./globals.css"
   if (/^import\s*['"`]/.test(trimmed)) {
-    return `/* css import: ${specifier} */`;
+    return cssComment("import", specifier);
   }
 
   const fromIndex = findFromKeywordIndex(trimmed);
   if (fromIndex === -1) {
-    return `/* css import: ${specifier} */`;
+    return cssComment("import", specifier);
   }
 
   const cssModuleKey = isCssModuleImport(specifier) ? specifier : undefined;
@@ -394,7 +400,7 @@ function generateCSSStub(
     const expr = cssModuleKey
       ? scopedCssModuleProxyExpression(cssModuleKey)
       : cssModuleProxyExpression();
-    return `const ${importClause} = ${expr}; /* css module: ${specifier} */`;
+    return `const ${importClause} = ${expr}; ${cssComment("module", specifier)}`;
   }
 
   // Namespace import: import * as styles from "./X.module.css"
@@ -402,9 +408,9 @@ function generateCSSStub(
   // the stub must carry the same namespace shape the re-export promises.
   const nsMatch = importClause.match(/^\*\s*as\s+([a-zA-Z_$][a-zA-Z0-9_$]*)$/);
   if (nsMatch) {
-    return `const ${nsMatch[1]} = ${
-      cssNamespaceExpression(cssModuleKey)
-    }; /* css module: ${specifier} */`;
+    return `const ${nsMatch[1]} = ${cssNamespaceExpression(cssModuleKey)}; ${
+      cssComment("module", specifier)
+    }`;
   }
 
   // Named imports: import { container, header } from "./X.module.css"
@@ -418,7 +424,7 @@ function generateCSSStub(
       const stubs = bindings
         .map((binding) => `${binding.local} = ${cssBindingValue(binding.imported, cssModuleKey)}`)
         .join(", ");
-      return `const ${stubs}; /* css module: ${specifier} */`;
+      return `const ${stubs}; ${cssComment("module", specifier)}`;
     }
   }
 
@@ -434,11 +440,11 @@ function generateCSSStub(
       ? scopedCssModuleProxyExpression(cssModuleKey)
       : cssModuleProxyExpression();
     return namedStubs.length > 0
-      ? `const ${defaultName} = ${defaultExpr}, ${namedStubs}; /* css module: ${specifier} */`
-      : `const ${defaultName} = ${defaultExpr}; /* css module: ${specifier} */`;
+      ? `const ${defaultName} = ${defaultExpr}, ${namedStubs}; ${cssComment("module", specifier)}`
+      : `const ${defaultName} = ${defaultExpr}; ${cssComment("module", specifier)}`;
   }
 
-  return `/* css import: ${specifier} */`;
+  return cssComment("import", specifier);
 }
 
 /**
@@ -447,12 +453,12 @@ function generateCSSStub(
  */
 function generateDynamicCSSStub(specifier: string): string {
   if (isCssModuleImport(specifier)) {
-    return `Promise.resolve({ default: ${
-      scopedCssModuleProxyExpression(specifier)
-    } }) /* css import: ${specifier} */`;
+    return `Promise.resolve({ default: ${scopedCssModuleProxyExpression(specifier)} }) ${
+      cssComment("import", specifier)
+    }`;
   }
 
-  return `Promise.resolve({}) /* css import: ${specifier} */`;
+  return `Promise.resolve({}) ${cssComment("import", specifier)}`;
 }
 
 export const cssStripPlugin: TransformPlugin = {

--- a/src/transforms/pipeline/stages/ssr-http-stub.test.ts
+++ b/src/transforms/pipeline/stages/ssr-http-stub.test.ts
@@ -63,8 +63,17 @@ describe("ssrHttpStubPlugin", () => {
       `import "https://esm.sh/video.js@8/dist/video-js.css";\n`,
     );
     const result = await ssrHttpStubPlugin.transform(ctx);
-    assertEquals(typeof result, "string");
-    assertEquals(result!.includes("/* SSR stub"), true);
+    assertEquals(typeof result, "string", "the side-effect import is rewritten");
+    assertEquals(
+      result,
+      `/* SSR stub: import "https://esm.sh/video.js@8/dist/video-js.css" */;\n`,
+      "the browser-only side-effect import survives only as a comment",
+    );
+    assertEquals(
+      /(^|\n)\s*import\s/.test(result!),
+      false,
+      "no live import statement may survive side-effect stubbing",
+    );
   });
 
   it("passes through non-HTTP imports unchanged", async () => {

--- a/src/transforms/pipeline/stages/ssr-vf-modules.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules.test.ts
@@ -34,6 +34,8 @@ import type { TransformContext } from "../types.ts";
 const { findVfModuleImports, findRelativeImports, FRAMEWORK_ROOT, EMBEDDED_SRC_DIR, EXTENSIONS } =
   _testExports;
 
+// esbuild starts a child process that lives across tests, so we disable sanitizers here;
+// see src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts.
 describe("ssr-vf-modules", { sanitizeOps: false, sanitizeResources: false }, () => {
   describe("findVfModuleImports", () => {
     it("finds single /_vf_modules/ import", async () => {
@@ -93,9 +95,11 @@ describe("ssr-vf-modules", { sanitizeOps: false, sanitizeResources: false }, () 
     });
 
     it("ignores string literals without from keyword", async () => {
-      const code = `const path = "/_vf_modules/something";`;
+      // The literal carries the framework prefix, so only the import-vs-string
+      // distinction can reject it - not the prefix filter.
+      const code = `const path = "/_vf_modules/_veryfront/react/components/Head.js";`;
       const imports = await findVfModuleImports(code);
-      assertEquals(imports, []);
+      assertEquals(imports, [], "a plain string constant is not an import");
     });
   });
 
@@ -422,6 +426,8 @@ describe("ssr-vf-modules", { sanitizeOps: false, sanitizeResources: false }, () 
   });
 });
 
+// esbuild starts a child process that lives across tests, so we disable sanitizers here;
+// see src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts.
 describe("ssr-vf-modules integration", { sanitizeOps: false, sanitizeResources: false }, () => {
   it("resolves Head.tsx from /_vf_modules/ path", async () => {
     const fs = createFileSystem();
@@ -497,6 +503,8 @@ describe("ssr-vf-modules integration", { sanitizeOps: false, sanitizeResources: 
   });
 });
 
+// esbuild starts a child process that lives across tests, so we disable sanitizers here;
+// see src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts.
 describe("ssr-vf-modules relative import resolution", {
   sanitizeOps: false,
   sanitizeResources: false,
@@ -632,6 +640,8 @@ describe("ssr-vf-modules relative import resolution", {
   });
 });
 
+// esbuild starts a child process that lives across tests, so we disable sanitizers here;
+// see src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts.
 describe("ssr-vf-modules non-framework source skipping", {
   sanitizeOps: false,
   sanitizeResources: false,
@@ -685,38 +695,34 @@ describe("ssr-vf-modules non-framework source skipping", {
   });
 
   it("resolveRelativeFrameworkImport resolves dnt shim paths at package root", async () => {
-    // When a framework source file imports ../_dnt.shims.js, the path resolves
+    // When a framework source file imports ../../_dnt.shims.js, the path resolves
     // to FRAMEWORK_ROOT/_dnt.shims.js which is outside src/ and should be
     // skipped by the transform (not recursively processed).
+    //
+    // The shim only ships in npm/dnt builds, so existence is stubbed through the
+    // resolver's injectable existsFn rather than gating the assertions on the
+    // checkout layout.
     const { resolveRelativeFrameworkImport } = _testExports;
     const fs = createFileSystem();
-
-    // Simulate a file in src/something/ importing ../../_dnt.shims.js
-    // which would resolve to FRAMEWORK_ROOT/_dnt.shims.js
+    const shimPath = `${FRAMEWORK_ROOT}/_dnt.shims.js`;
     const sourcePath = `${FRAMEWORK_ROOT}/src/some/module.ts`;
 
-    // Check if _dnt.shims.js exists at root (only in npm/dnt builds)
-    const shimPath = `${FRAMEWORK_ROOT}/_dnt.shims.js`;
-    const shimExists = await fs.exists(shimPath);
+    const resolved = await resolveRelativeFrameworkImport(
+      "../../_dnt.shims.js",
+      sourcePath,
+      fs,
+      (path: string) => Promise.resolve(path === shimPath),
+    );
 
-    if (shimExists) {
-      const resolved = await resolveRelativeFrameworkImport(
-        "../../_dnt.shims.js",
-        sourcePath,
-        fs,
-      );
-      assertEquals(resolved !== null, true, "Should resolve _dnt.shims.js path");
+    assertEquals(resolved, shimPath, "Should resolve ../../_dnt.shims.js to the package-root shim");
 
-      // Verify it's outside framework source directories
-      const frameworkSrcDir = `${FRAMEWORK_ROOT}/src/`;
-      const embeddedPrefix = `${EMBEDDED_SRC_DIR}/`;
-      assertEquals(
-        resolved!.startsWith(frameworkSrcDir) || resolved!.startsWith(embeddedPrefix),
-        false,
-        "Resolved dnt shim path should be outside framework source dirs",
-      );
-    }
-    // If shims don't exist (source dev mode), the test passes - the guard
-    // only matters in npm/dnt package builds
+    // Verify it's outside framework source directories
+    const frameworkSrcDir = `${FRAMEWORK_ROOT}/src/`;
+    const embeddedPrefix = `${EMBEDDED_SRC_DIR}/`;
+    assertEquals(
+      resolved!.startsWith(frameworkSrcDir) || resolved!.startsWith(embeddedPrefix),
+      false,
+      "Resolved dnt shim path should be outside framework source dirs",
+    );
   });
 });

--- a/src/transforms/pipeline/stages/ssr-vf-modules/path-resolver.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/path-resolver.test.ts
@@ -65,6 +65,21 @@ describe("resolveFrameworkFile", () => {
     assertEquals(lookups[1]?.[1], join(FRAMEWORK_ROOT, "src"));
   });
 
+  it("prefers live src files in source checkouts", () => {
+    const lookups = getFrameworkLookups(false);
+
+    assertEquals(
+      lookups[0]?.[1],
+      join(FRAMEWORK_ROOT, "src"),
+      "source checkouts look at live src/ first so local edits are not shadowed",
+    );
+    assertEquals(
+      lookups[1]?.[1],
+      EMBEDDED_SRC_DIR,
+      "generated embedded sources stay the fallback in source checkouts",
+    );
+  });
+
   it("returns null for unresolvable paths", async () => {
     const fs = createMockFs({});
     const result = await resolveFrameworkFile(

--- a/src/transforms/pipeline/stages/ssr-vf-modules/specifier-resolver.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/specifier-resolver.test.ts
@@ -20,6 +20,36 @@ describe("ssr-vf-modules/specifier-resolver", () => {
     assertEquals(resolveSpecifier("../missing.js"), null);
   });
 
+  it("falls through to the single-instance React bundle for bare React specifiers", () => {
+    const resolveSpecifier = createFrameworkSpecifierResolver({
+      denoConfigStubUrl: "file:///cache/deno-config.mjs",
+      veryfrontReplacements: new Map(),
+      relativeReplacements: new Map(),
+      reactVersion: "19.2.4",
+    });
+
+    assertStringIncludes(
+      resolveSpecifier("react") ?? "",
+      "https://esm.sh/react@19.2.4?",
+      "bare react must resolve to the shared esm.sh bundle, not stay a bare specifier",
+    );
+    assertStringIncludes(
+      resolveSpecifier("react-dom/client") ?? "",
+      "https://esm.sh/react-dom@19.2.4/client?external=react",
+      "react-dom subpaths must keep react external so a single React instance is shared",
+    );
+    assertStringIncludes(
+      resolveSpecifier("react/jsx-runtime") ?? "",
+      "https://esm.sh/react@19.2.4/jsx-runtime?external=react",
+      "the JSX runtime must resolve against the same React version",
+    );
+    assertEquals(
+      resolveSpecifier("lodash"),
+      null,
+      "non-React bare specifiers are left for the caller to resolve",
+    );
+  });
+
   it("resolves React specifiers through the shared React import map fallback", () => {
     assertEquals(resolveReactSpecifier("react", "19.2.4"), buildReactUrl("react", "19.2.4"));
     assertEquals(

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
@@ -7,6 +7,7 @@ import {
 } from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { makeTempDir } from "#veryfront/testing/deno-compat.ts";
 import { VeryfrontError } from "#veryfront/errors";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 import { fromFileUrl, join } from "#veryfront/compat/path/index.ts";
@@ -113,7 +114,7 @@ describe("transformFrameworkCode depth-limit fallback", {
   });
 
   it("isolates cached framework transforms by React version", async () => {
-    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-react-cache-" });
+    const tmp = await makeTempDir({ prefix: "vf-vfmod-react-cache-" });
     const sourcePath = `${tmp}/framework-module.js`;
     const source = "export const marker = 1;\n";
 
@@ -140,7 +141,7 @@ describe("transformFrameworkCode depth-limit fallback", {
   });
 
   it("isolates cache and singleflight keys by project scope", async () => {
-    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-project-cache-" });
+    const tmp = await makeTempDir({ prefix: "vf-vfmod-project-cache-" });
     const sourcePath = `${tmp}/framework-module.js`;
     const projectA = `${tmp}/project-a`;
     const projectB = `${tmp}/project-b`;
@@ -252,7 +253,7 @@ describe("transformFrameworkCode depth-limit fallback", {
   });
 
   it("coalesces concurrent transforms instead of reporting a false cycle", async () => {
-    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-concurrent-" });
+    const tmp = await makeTempDir({ prefix: "vf-vfmod-concurrent-" });
     const sourcePath = `${tmp}/framework-module.ts`;
     const source = [
       'import { FNV1A_PRIME_32 } from "#veryfront/utils/constants/crypto.ts";',
@@ -310,7 +311,7 @@ describe("transformFrameworkCode depth-limit fallback", {
   });
 
   it("returns immediately when traversal ancestry identifies a real cycle", async () => {
-    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-real-cycle-" });
+    const tmp = await makeTempDir({ prefix: "vf-vfmod-real-cycle-" });
     const sourcePath = `${tmp}/framework-module.js`;
     const source = "export const marker = 1;\n";
     const transformKey = buildFrameworkTransformCacheKey(
@@ -335,7 +336,7 @@ describe("transformFrameworkCode depth-limit fallback", {
   });
 
   it("invalidates a same-path transform when its source content changes", async () => {
-    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-source-cache-" });
+    const tmp = await makeTempDir({ prefix: "vf-vfmod-source-cache-" });
     const sourcePath = `${tmp}/framework-module.js`;
     const ctx = { reactVersion: "19.2.4", projectDir: tmp, fs: createFileSystem() };
 
@@ -363,7 +364,7 @@ describe("transformFrameworkCode depth-limit fallback", {
   });
 
   it("uses the TypeScript loader for embedded .ts.src modules", async () => {
-    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-main-ts-src-" });
+    const tmp = await makeTempDir({ prefix: "vf-vfmod-main-ts-src-" });
     const sourcePath = `${tmp}/framework-module.ts.src`;
     const source = [
       "const value: unknown = 1;",
@@ -388,7 +389,7 @@ describe("transformFrameworkCode depth-limit fallback", {
   });
 
   it("rewrites relative imports in the fallback to absolute file:// URLs so the cached output is loadable", async () => {
-    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-fallback-" });
+    const tmp = await makeTempDir({ prefix: "vf-vfmod-fallback-" });
     const srcDir = `${tmp}/src/utils/constants`;
     await Deno.mkdir(srcDir, { recursive: true });
     const buildJs = `${srcDir}/build.js`;
@@ -429,7 +430,7 @@ describe("transformFrameworkCode depth-limit fallback", {
     // which the runtime cannot import directly. The fallback must materialize
     // a real .mjs cache file and link the import to that, not to the .src
     // source.
-    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-src-fallback-" });
+    const tmp = await makeTempDir({ prefix: "vf-vfmod-src-fallback-" });
     const srcDir = `${tmp}/src/utils`;
     await Deno.mkdir(srcDir, { recursive: true });
     // Only the .src copy exists (mirrors compiled-binary layout).
@@ -473,7 +474,7 @@ describe("transformFrameworkCode depth-limit fallback", {
 
   it("does not poison frameworkFileCache with fallback output", async () => {
     const { frameworkFileCache } = await import("./constants.ts");
-    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-cache-iso-" });
+    const tmp = await makeTempDir({ prefix: "vf-vfmod-cache-iso-" });
     const srcDir = `${tmp}/src`;
     await Deno.mkdir(srcDir, { recursive: true });
     const depPath = `${srcDir}/dep.ts.src`;
@@ -526,7 +527,7 @@ describe("transformFrameworkCode depth-limit fallback", {
     // Indirectly verify the loader picker via the fallback output: pass
     // TypeScript-only syntax (`as const`) through a `.mts.src` source and
     // confirm esbuild produced JS (would throw if loaded as `js`).
-    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-mts-" });
+    const tmp = await makeTempDir({ prefix: "vf-vfmod-mts-" });
     const srcDir = `${tmp}/src`;
     await Deno.mkdir(srcDir, { recursive: true });
     const sourcePath = `${srcDir}/uses-as-const.mts.src`;
@@ -554,7 +555,7 @@ describe("transformFrameworkCode depth-limit fallback", {
 
   it("does not propagate a cycle placeholder from frameworkFileCache into the fallback cache file", async () => {
     const { frameworkFileCache } = await import("./constants.ts");
-    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-cycle-" });
+    const tmp = await makeTempDir({ prefix: "vf-vfmod-cycle-" });
     const srcDir = `${tmp}/src`;
     await Deno.mkdir(srcDir, { recursive: true });
     const depPath = `${srcDir}/dep.ts.src`;
@@ -603,7 +604,7 @@ describe("transformFrameworkCode depth-limit fallback", {
   });
 
   it("rematerializes a cached #veryfront file URL when the target file is missing", async () => {
-    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-stale-url-" });
+    const tmp = await makeTempDir({ prefix: "vf-vfmod-stale-url-" });
     const specifier = "#veryfront/utils/hash-utils.ts";
     const sourcePath = await resolveVeryfrontSourcePath(specifier);
     assert(sourcePath, `${specifier} did not resolve to a framework source file`);
@@ -637,7 +638,7 @@ describe("transformFrameworkCode depth-limit fallback", {
   });
 
   it("survives one bad .src dep without aborting the whole parent fallback", async () => {
-    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-baddep-" });
+    const tmp = await makeTempDir({ prefix: "vf-vfmod-baddep-" });
     const srcDir = `${tmp}/src`;
     await Deno.mkdir(srcDir, { recursive: true });
     // A dep whose content is invalid TypeScript — esbuild should reject it.
@@ -706,7 +707,7 @@ describe("transformFrameworkCode depth-limit fallback", {
   });
 
   it("fails closed on an unresolvable #veryfront import when asked to throw", async () => {
-    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-missing-vf-" });
+    const tmp = await makeTempDir({ prefix: "vf-vfmod-missing-vf-" });
     const srcDir = `${tmp}/src`;
     await Deno.mkdir(srcDir, { recursive: true });
     const sourcePath = `${srcDir}/imports-missing-vf.ts`;
@@ -738,7 +739,7 @@ describe("transformFrameworkCode depth-limit fallback", {
   });
 
   it("fails closed on an unresolvable relative import when asked to throw", async () => {
-    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-missing-rel-" });
+    const tmp = await makeTempDir({ prefix: "vf-vfmod-missing-rel-" });
     const srcDir = `${tmp}/src`;
     await Deno.mkdir(srcDir, { recursive: true });
     const sourcePath = `${srcDir}/imports-missing-relative.ts`;
@@ -774,7 +775,7 @@ describe("transformFrameworkCode depth-limit fallback", {
     // npm specifiers are resolved to local file:// bundles rather than left
     // for ad-hoc runtime resolution. This keeps the fallback's cached output
     // self-contained and Node-loadable.
-    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-fallback-" });
+    const tmp = await makeTempDir({ prefix: "vf-vfmod-fallback-" });
     const srcDir = `${tmp}/src`;
     await Deno.mkdir(srcDir, { recursive: true });
     const sourcePath = `${srcDir}/uses-lodash.js`;
@@ -821,7 +822,7 @@ describe("transformFrameworkCode depth-limit fallback", {
     // rewrites react/react-dom to the esm.sh bundle, then (like the main path)
     // materializes it to a local file:// bundle so Node can load the cached
     // fallback module (Node rejects `import ... from "https:"`).
-    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-react-id-" });
+    const tmp = await makeTempDir({ prefix: "vf-vfmod-react-id-" });
     const srcDir = `${tmp}/src`;
     await Deno.mkdir(srcDir, { recursive: true });
     const sourcePath = `${srcDir}/uses-react.js`;

--- a/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
+++ b/src/transforms/pipeline/stages/ssr-vf-modules/transform.test.ts
@@ -1,7 +1,13 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { VeryfrontError } from "#veryfront/errors";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 import { fromFileUrl, join } from "#veryfront/compat/path/index.ts";
 import {
@@ -47,6 +53,22 @@ describe("reactReExportToEsmUrl", () => {
     assertEquals(
       reactReExportToEsmUrl(reactPath("jsx-runtime.js"), "19.2.4"),
       buildReactUrl("react", "19.2.4", "/jsx-runtime", true),
+    );
+  });
+
+  it("maps the react-dom re-export to the externalized react-dom bundle", () => {
+    assertEquals(
+      reactReExportToEsmUrl(reactPath("react-dom.js"), "19.2.4"),
+      buildReactUrl("react-dom", "19.2.4", undefined, true),
+      "react-dom.js must route to the externalized react-dom bundle",
+    );
+  });
+
+  it("maps jsx-dev-runtime re-exports to the dev runtime", () => {
+    assertEquals(
+      reactReExportToEsmUrl(reactPath("jsx-dev-runtime.js"), "19.2.4"),
+      buildReactUrl("react", "19.2.4", "/jsx-dev-runtime", true),
+      "jsx-dev-runtime.js must route to the dev JSX runtime, not the production one",
     );
   });
 
@@ -648,6 +670,100 @@ describe("transformFrameworkCode depth-limit fallback", {
       // Survived: the parent file produced output. The bad-dep handling
       // is verified by the absence of an unhandled exception above.
       assert(transformed.length > 0, "fallback returned empty output");
+
+      // The unresolvable dep is left bare rather than aborting the parent.
+      assertStringIncludes(
+        transformed,
+        "./bad.js",
+        "the unresolvable dep must be left bare rather than aborting the parent",
+      );
+
+      // Control: the same good dep, transformed without a failing sibling.
+      // Comparing the two runs pins "a bad sibling changes nothing about the
+      // good one" without depending on whether this runtime materializes it.
+      const controlPath = `${srcDir}/owner-good.ts.src`;
+      const controlContent = [
+        `import { G } from "./good.js";`,
+        `export const z = G;`,
+      ].join("\n");
+      await Deno.writeTextFile(controlPath, controlContent);
+      const controlTransformed = await transformFrameworkCode(
+        controlContent,
+        controlPath,
+        { reactVersion: "19.1.1", projectDir: tmp, fs: createFileSystem() },
+        false,
+        MAX_RELATIVE_IMPORT_DEPTH + 1,
+      );
+
+      assertEquals(
+        transformed.includes('from "./good.js"'),
+        controlTransformed.includes('from "./good.js"'),
+        "a failing sibling dep must not change how ./good.js is linked",
+      );
+    } finally {
+      await Deno.remove(tmp, { recursive: true });
+    }
+  });
+
+  it("fails closed on an unresolvable #veryfront import when asked to throw", async () => {
+    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-missing-vf-" });
+    const srcDir = `${tmp}/src`;
+    await Deno.mkdir(srcDir, { recursive: true });
+    const sourcePath = `${srcDir}/imports-missing-vf.ts`;
+    const sourceContent = [
+      `import { missing } from "#veryfront/does-not-exist.ts";`,
+      `export const y = missing;`,
+    ].join("\n");
+
+    try {
+      const error = await assertRejects(
+        () =>
+          transformFrameworkCode(
+            sourceContent,
+            sourcePath,
+            { reactVersion: "19.2.4", projectDir: tmp, fs: createFileSystem() },
+            true,
+          ),
+        VeryfrontError,
+        "#veryfront/does-not-exist.ts",
+      );
+      assertEquals(
+        (error as VeryfrontError).slug,
+        "import-resolution-error",
+        "an unresolvable framework import must surface as import-resolution-error",
+      );
+    } finally {
+      await Deno.remove(tmp, { recursive: true });
+    }
+  });
+
+  it("fails closed on an unresolvable relative import when asked to throw", async () => {
+    const tmp = await Deno.makeTempDir({ prefix: "vf-vfmod-missing-rel-" });
+    const srcDir = `${tmp}/src`;
+    await Deno.mkdir(srcDir, { recursive: true });
+    const sourcePath = `${srcDir}/imports-missing-relative.ts`;
+    const sourceContent = [
+      `import { gone } from "./not-on-disk.js";`,
+      `export const y = gone;`,
+    ].join("\n");
+
+    try {
+      const error = await assertRejects(
+        () =>
+          transformFrameworkCode(
+            sourceContent,
+            sourcePath,
+            { reactVersion: "19.2.4", projectDir: tmp, fs: createFileSystem() },
+            true,
+          ),
+        VeryfrontError,
+        "./not-on-disk.js",
+      );
+      assertEquals(
+        (error as VeryfrontError).slug,
+        "import-resolution-error",
+        "an unresolvable relative framework import must surface as import-resolution-error",
+      );
     } finally {
       await Deno.remove(tmp, { recursive: true });
     }
@@ -680,6 +796,16 @@ describe("transformFrameworkCode depth-limit fallback", {
       // No bare specifier and no remote https: import left behind.
       assertEquals(transformed.includes('from "lodash"'), false);
       assertEquals(/from\s+["']https:\/\//.test(transformed), false);
+      // And the positive half: it became a local bundle that exists on disk.
+      assertStringIncludes(
+        transformed,
+        "file://",
+        "a bare npm specifier must be materialized to a local bundle",
+      );
+      const bundleMatch = transformed.match(/from\s+"(file:\/\/[^"]+)"/);
+      assert(bundleMatch?.[1], "expected a file:// specifier in the fallback output");
+      const bundleStat = await Deno.stat(fromFileUrl(bundleMatch[1]));
+      assertEquals(bundleStat.isFile, true, "the materialized bundle must exist on disk");
     } finally {
       await Deno.remove(tmp, { recursive: true });
     }

--- a/tests/integration/transforms/ssr-vf-modules-package-root.test.ts
+++ b/tests/integration/transforms/ssr-vf-modules-package-root.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Integration coverage for the SSR VF Modules package-root skip guard.
+ *
+ * `transformFrameworkCode` must link files that sit outside the framework
+ * source directories (published dnt runtime helpers such as `_dnt.shims.js`)
+ * as-is instead of recompiling them into the transform cache. Driving that
+ * guard for real needs an on-disk package layout, so the case lives here
+ * rather than in the colocated unit suite.
+ *
+ * @see src/transforms/pipeline/stages/ssr-vf-modules/transform.ts
+ */
+
+import { assertStringIncludes } from "#veryfront/testing/assert";
+import { describe, it } from "#veryfront/testing/bdd";
+import {
+  createFileSystem,
+  mkdir,
+  withTempDir,
+  writeTextFile,
+} from "#veryfront/testing/deno-compat";
+import { stop as stopEsbuild } from "veryfront/extensions/bundler";
+import {
+  frameworkFileCache,
+  transformFrameworkCode,
+} from "#veryfront/transforms/pipeline/stages/ssr-vf-modules/index.ts";
+
+describe("ssr-vf-modules package-root linking", () => {
+  it("links a package-root helper as-is instead of recursively transforming it", async () => {
+    await withTempDir(async (tmp) => {
+      const srcDir = `${tmp}/src`;
+      await mkdir(srcDir, { recursive: true });
+      const helperPath = `${tmp}/_dnt.shims.js`;
+      await writeTextFile(helperPath, "export const shim = 1;\n");
+      const ownerPath = `${srcDir}/owner.ts`;
+      const ownerContent = [
+        `import { shim } from "../_dnt.shims.js";`,
+        `export const y = shim;`,
+      ].join("\n");
+
+      try {
+        const transformed = await transformFrameworkCode(
+          ownerContent,
+          ownerPath,
+          { reactVersion: "19.2.4", projectDir: tmp, fs: createFileSystem() },
+        );
+
+        assertStringIncludes(
+          transformed,
+          `from "file://${helperPath}"`,
+          "a file outside FRAMEWORK_ROOT/src is linked as-is, not recursively transformed",
+        );
+      } finally {
+        for (const key of frameworkFileCache.keys()) {
+          if (key.includes(tmp)) frameworkFileCache.delete(key);
+        }
+        // The bundler keeps its esbuild service child alive between calls, so
+        // shut it down inside the case to keep the resource sanitizers on.
+        await stopEsbuild();
+      }
+    }, { prefix: "vf-vfmod-pkgroot-" });
+  });
+});


### PR DESCRIPTION
## Summary

Audit of all 40 test files under `src/transforms/import-rewriter` and `src/transforms/pipeline`.

Every change was **mutation checked** — the named source edit was applied, the test confirmed to fail, then reverted. 61 candidate findings, 44 confirmed after adversarial verification, **17 refuted** — the highest refutation rate of any batch, so the verify pass did real work here. **Test files only**, plus the sanitizer baseline.

## Recurring weaknesses fixed

**Substring checks where the whole output matters.** Rewrite ordering asserted only that both new specifiers appeared *somewhere*, so reversing the edit comparator to ascending passed. Exact-output assertions now pin the result. Same treatment for statement replacement, SSR stub generation, and comment/whitespace stripping.

**Shape checks over value checks.** The React import map asserted each entry was a `string`; it now asserts six exact URLs built from the exported version constant — so the oracle stays independent of `buildReactUrl` — and dropping `external: ["react"]` from `react-dom/client` fails.

**Guard halves never exercised alone.** Two vendor-strategy guards combine a bundle hash and a module server URL, and every existing case failed *both* at once. New cases vary only the URL, so dropping `|| !ctx.moduleServerUrl` from either `matches()` or `rewrite()` now fails.

**Branches no test reached:** the esm.sh subpath tail for unscoped packages, the SSR arm of the module-server URL rewrite, the `.mdx` extension carve-out, the origin and pathname guards on dependency pinning, and the framework lookup order for source checkouts.

**A cache identity that omitted a field.** The vendor bundle hash now partitions the transform cache, so deleting the `vendor=` line fails.

## One defect reported, not encoded — [#4098](https://github.com/veryfront/veryfront-code/issues/4098)

`extractEsmShSubpath` returns `""` for **every scoped esm.sh package**. `parts.slice(0, 2)` already consumes the version, so the following regex expects an `@` that is no longer there:

| step | value |
|---|---|
| `packageParts` | `@scope/pkg@1.0` — version already included |
| `afterPackage` | `/sub` |
| `versionMatch` | `null` |

A scoped package's subpath is silently dropped and the specifier resolves to the package root, or to `null` when only a package-plus-subpath key exists.

The three added subpath cases cover **unscoped** packages only. The scoped case was deliberately omitted: the only assertion that passes today would pin the dropped subpath as correct.

## Verification

- Semantic unit-boundary audit: ok, sanitizer ratchet: ok (392/392)
- `test:layout`: ok, `docs:api-reference:check`: current
- `deno fmt`, `deno lint`: pass
- **26/26** changed test files pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved SSR CSS handling for re-exports, namespaces, aliases, scoped modules, and dynamic imports.
  - Added reliable MDX layout export support during compilation.
  - Enhanced import rewriting for React, Tailwind CSS, assets, aliases, relative modules, and package subpaths.
  - Added dependency pinning and cache separation for more consistent SSR and browser output.

- **Bug Fixes**
  - Improved handling of unresolved imports, file dependencies, source maps, and CSS-generated code.
  - Preserved valid import syntax and `.mdx` extensions across transformations.

- **Tests**
  - Expanded coverage for hydration parity, cache identity, SSR output, and framework module resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->