### PR TITLE
Harden module resolution and component discovery

### DIFF
--- a/src/modules/component-registry/edge-cases.test.ts
+++ b/src/modules/component-registry/edge-cases.test.ts
@@ -691,6 +691,45 @@ describe("ComponentRegistry - Edge Cases and Error Handling", () => {
       );
     });
 
+    it("should preserve a removal made after discovery collected the component", async () => {
+      const adapter = createMockAdapter();
+      const projectDir = "/test/remove-during-discover";
+      const componentsDir = `${projectDir}/components`;
+      adapter.fs.files.set(`${componentsDir}/Button.tsx`, "button");
+
+      let releaseReadDir = () => {};
+      const gate = new Promise<void>((resolve) => {
+        releaseReadDir = resolve;
+      });
+      let componentCollected = () => {};
+      const collected = new Promise<void>((resolve) => {
+        componentCollected = resolve;
+      });
+      const originalReadDir = adapter.fs.readDir.bind(adapter.fs);
+      adapter.fs.readDir = async function* (path: string) {
+        for await (const entry of originalReadDir(path)) {
+          yield entry;
+          if (path === componentsDir && entry.name === "Button.tsx") {
+            componentCollected();
+            await gate;
+          }
+        }
+      };
+
+      const registry = new ComponentRegistry({ projectDir, adapter });
+      const discovery = registry.discover();
+      await collected;
+      registry.remove("Button");
+      releaseReadDir();
+      await discovery;
+
+      assertEquals(
+        registry.has("Button"),
+        false,
+        "discovery must not resurrect a component removed after it was collected",
+      );
+    });
+
     it("should not overwrite an entry replaced while its source was being read", async () => {
       const adapter = createMockAdapter();
       const projectDir = "/test/replace-during-load";

--- a/src/modules/component-registry/edge-cases.test.ts
+++ b/src/modules/component-registry/edge-cases.test.ts
@@ -1,5 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists, assertStrictEquals } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertStrictEquals,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { ComponentRegistry } from "./index.ts";
@@ -69,6 +74,23 @@ describe("ComponentRegistry - Edge Cases and Error Handling", () => {
       await registry.discover();
 
       assertEquals(registry.has("PrimaryButton"), true);
+    });
+
+    it("should propagate operational directory read errors", async () => {
+      const adapter = createMockAdapter();
+      const failure = new Error("Directory backend unavailable");
+      adapter.fs.readDir = () => {
+        throw failure;
+      };
+      const registry = new ComponentRegistry({
+        projectDir: "/test/read-dir-error",
+        componentDirs: ["components"],
+        adapter,
+      });
+
+      const error = await assertRejects(() => registry.discover());
+
+      assertEquals(error, failure);
     });
   });
 
@@ -140,7 +162,7 @@ describe("ComponentRegistry - Edge Cases and Error Handling", () => {
       assertEquals(registry.has("index"), false);
     });
 
-    it("should handle files with same name in different directories", async () => {
+    it("should reject files with the same component name", async () => {
       const adapter = createMockAdapter();
       const projectDir = "/test/duplicate-names";
 
@@ -159,19 +181,12 @@ describe("ComponentRegistry - Edge Cases and Error Handling", () => {
         componentDirs: ["components", "islands"],
       });
 
-      await registry.discover();
-
-      assertEquals(registry.has("Button"), true);
-      assertEquals(
-        registry.getAll().size,
-        1,
-        "same-named components in different dirs collapse to one entry",
+      await assertRejects(
+        () => registry.discover(),
+        Error,
+        "Component name 'Button' is already registered",
       );
-      assertEquals(
-        registry.get("Button")?.path,
-        `${projectDir}/islands/Button.tsx`,
-        "the later entry in componentDirs wins a name collision",
-      );
+      assertEquals(registry.getAll().size, 0);
     });
 
     it("should only match tsx and jsx extensions", async () => {
@@ -221,16 +236,20 @@ describe("ComponentRegistry - Edge Cases and Error Handling", () => {
       assertEquals(component, null);
     });
 
-    it("should handle file read errors", async () => {
+    it("should propagate operational file read errors", async () => {
       const adapter = createMockAdapter();
       const projectDir = "/test/read-error";
 
       adapter.fs.files.set(`${projectDir}/components/Error.tsx`, "content");
+      const failure = {
+        code: "ENOENT",
+        message: "Storage backend unavailable",
+      };
 
       const originalReadFile = adapter.fs.readFile.bind(adapter.fs);
       adapter.fs.readFile = async (path: string) => {
         if (path.includes("Error.tsx")) {
-          throw new Error("Permission denied");
+          throw failure;
         }
         return await originalReadFile(path);
       };
@@ -239,8 +258,8 @@ describe("ComponentRegistry - Edge Cases and Error Handling", () => {
 
       await registry.discover();
 
-      const component = await registry.loadComponent("Error");
-      assertEquals(component, null);
+      const error = await assertRejects(() => registry.loadComponent("Error"));
+      assertEquals(error, failure);
     });
 
     it("should cache loaded components", async () => {
@@ -294,6 +313,19 @@ describe("ComponentRegistry - Edge Cases and Error Handling", () => {
       assertEquals(registry.get("Input")?.isLoaded, true);
     });
 
+    it("should wait for in-flight discovery before loading all components", async () => {
+      const adapter = createMockAdapter();
+      const projectDir = "/test/load-all-during-discovery";
+      adapter.fs.files.set(`${projectDir}/components/Button.tsx`, "button");
+      const registry = new ComponentRegistry({ projectDir, adapter });
+
+      const discovery = registry.discover();
+      const loading = registry.loadAll();
+      await Promise.all([discovery, loading]);
+
+      assertEquals(registry.get("Button")?.isLoaded, true);
+    });
+
     it("should handle concurrent component loads", async () => {
       const adapter = createMockAdapter();
       const projectDir = "/test/concurrent-load";
@@ -336,6 +368,21 @@ describe("ComponentRegistry - Edge Cases and Error Handling", () => {
       const component = registry.get("VirtualButton");
       assertEquals(component?.isLoaded, true);
       assertEquals(component?.path, "virtual:VirtualButton");
+    });
+
+    it("should load path-only manual components from the adapter", async () => {
+      const adapter = createMockAdapter();
+      const projectDir = "/test/manual-path";
+      const componentPath = `${projectDir}/external/Button.tsx`;
+      adapter.fs.files.set(componentPath, "export default function Button() {}");
+      const registry = new ComponentRegistry({ projectDir, adapter });
+
+      registry.add("Button", { path: componentPath });
+
+      assertEquals(registry.get("Button")?.isLoaded, false);
+      const component = await registry.loadComponent("Button");
+      assertEquals(component?.content, "export default function Button() {}");
+      assertEquals(component?.isLoaded, true);
     });
 
     it("should remove components", async () => {
@@ -386,9 +433,59 @@ describe("ComponentRegistry - Edge Cases and Error Handling", () => {
       await registry.discover();
       assertEquals(registry.getAll().size, 1);
     });
+
+    it("should reconcile discovered files while preserving manual components", async () => {
+      const adapter = createMockAdapter();
+      const projectDir = "/test/reconcile";
+      const buttonPath = `${projectDir}/components/Button.tsx`;
+      adapter.fs.files.set(buttonPath, "button");
+
+      const registry = new ComponentRegistry({ projectDir, adapter });
+      registry.add("Manual", { content: "manual" });
+      await registry.discover();
+
+      adapter.fs.files.delete(buttonPath);
+      adapter.fs.files.set(`${projectDir}/components/Card.tsx`, "card");
+      await registry.discover();
+
+      assertEquals(registry.has("Button"), false);
+      assertEquals(registry.has("Card"), true);
+      assertEquals(registry.has("Manual"), true);
+    });
+
+    it("should reload changed component source after discovery", async () => {
+      const adapter = createMockAdapter();
+      const projectDir = "/test/reload-discovered";
+      const componentPath = `${projectDir}/components/Button.tsx`;
+      adapter.fs.files.set(componentPath, "version one");
+      const registry = new ComponentRegistry({ projectDir, adapter });
+      await registry.discover();
+      assertEquals((await registry.loadComponent("Button"))?.content, "version one");
+
+      adapter.fs.files.set(componentPath, "version two");
+      await registry.discover();
+
+      assertEquals((await registry.loadComponent("Button"))?.content, "version two");
+    });
   });
 
   describe("Component metadata", () => {
+    it("should keep discovered component metadata immutable", async () => {
+      const adapter = createMockAdapter();
+      const projectDir = "/test/immutable-metadata";
+      adapter.fs.files.set(`${projectDir}/components/Button.tsx`, "inside");
+      adapter.fs.files.set("/outside/Button.tsx", "outside");
+      const registry = new ComponentRegistry({ projectDir, adapter });
+      await registry.discover();
+
+      const component = registry.get("Button");
+      assertExists(component);
+      assertEquals(Reflect.set(component, "path", "/outside/Button.tsx"), false);
+
+      const loaded = await registry.loadComponent("Button");
+      assertEquals(loaded?.content, "inside");
+    });
+
     it("should list components with metadata", async () => {
       const adapter = createMockAdapter();
       const projectDir = "/test/metadata";
@@ -568,14 +665,22 @@ describe("ComponentRegistry - Edge Cases and Error Handling", () => {
     it("should handle concurrent discover calls", async () => {
       const adapter = createMockAdapter();
       const projectDir = "/test/concurrent-discover";
+      const componentsDir = `${projectDir}/components`;
 
-      adapter.fs.files.set(`${projectDir}/components/Button.tsx`, "button");
+      adapter.fs.files.set(`${componentsDir}/Button.tsx`, "button");
+      const originalReadDir = adapter.fs.readDir.bind(adapter.fs);
+      let componentDirectoryReads = 0;
+      adapter.fs.readDir = (path: string) => {
+        if (path === componentsDir) componentDirectoryReads++;
+        return originalReadDir(path);
+      };
 
       const registry = new ComponentRegistry({ projectDir, adapter });
 
       await Promise.all([registry.discover(), registry.discover(), registry.discover()]);
 
       assertEquals(registry.has("Button"), true);
+      assertEquals(componentDirectoryReads, 1);
     });
   });
 });

--- a/src/modules/component-registry/edge-cases.test.ts
+++ b/src/modules/component-registry/edge-cases.test.ts
@@ -662,6 +662,108 @@ describe("ComponentRegistry - Edge Cases and Error Handling", () => {
       assertExists(componentAfter);
     });
 
+    it("should not repopulate components when clear() runs during discovery", async () => {
+      const adapter = createMockAdapter();
+      const projectDir = "/test/clear-during-discover";
+      adapter.fs.files.set(`${projectDir}/components/Button.tsx`, "button");
+
+      let releaseReadDir = () => {};
+      const gate = new Promise<void>((resolve) => {
+        releaseReadDir = resolve;
+      });
+      const originalReadDir = adapter.fs.readDir.bind(adapter.fs);
+      adapter.fs.readDir = async function* (path: string) {
+        await gate;
+        yield* originalReadDir(path);
+      };
+
+      const registry = new ComponentRegistry({ projectDir, adapter });
+      const discovery = registry.discover();
+      registry.clear();
+      releaseReadDir();
+      await discovery;
+
+      assertEquals(
+        registry.getAll().size,
+        0,
+        "discovery finishing after clear() must not restore cleared components",
+      );
+    });
+
+    it("should not overwrite an entry replaced while its source was being read", async () => {
+      const adapter = createMockAdapter();
+      const projectDir = "/test/replace-during-load";
+      adapter.fs.files.set(`${projectDir}/components/Button.tsx`, "discovered content");
+
+      let releaseRead = () => {};
+      const gate = new Promise<void>((resolve) => {
+        releaseRead = resolve;
+      });
+      let readStarted = () => {};
+      const readFileStarted = new Promise<void>((resolve) => {
+        readStarted = resolve;
+      });
+      const originalReadFile = adapter.fs.readFile.bind(adapter.fs);
+      adapter.fs.readFile = async (path: string) => {
+        readStarted();
+        await gate;
+        return await originalReadFile(path);
+      };
+
+      const registry = new ComponentRegistry({ projectDir, adapter });
+      await registry.discover();
+
+      const loading = registry.loadComponent("Button");
+      await readFileStarted;
+      registry.add("Button", { content: "manual content", exports: { default: () => {} } });
+      releaseRead();
+      const loaded = await loading;
+
+      assertEquals(
+        registry.get("Button")?.content,
+        "manual content",
+        "a manual entry added during load must not be overwritten by stale file content",
+      );
+      assertEquals(loaded?.content, "manual content");
+    });
+
+    it("should not restore a component removed while its source was being read", async () => {
+      const adapter = createMockAdapter();
+      const projectDir = "/test/remove-during-load";
+      adapter.fs.files.set(`${projectDir}/components/Button.tsx`, "button");
+
+      let releaseRead = () => {};
+      const gate = new Promise<void>((resolve) => {
+        releaseRead = resolve;
+      });
+      let readStarted = () => {};
+      const readFileStarted = new Promise<void>((resolve) => {
+        readStarted = resolve;
+      });
+      const originalReadFile = adapter.fs.readFile.bind(adapter.fs);
+      adapter.fs.readFile = async (path: string) => {
+        readStarted();
+        await gate;
+        return await originalReadFile(path);
+      };
+
+      const registry = new ComponentRegistry({ projectDir, adapter });
+      await registry.discover();
+
+      const loading = registry.loadComponent("Button");
+      await readFileStarted;
+      registry.remove("Button");
+      releaseRead();
+      const loaded = await loading;
+
+      assertEquals(loaded, null, "load finishing after remove() must not return the removed entry");
+      assertEquals(
+        registry.has("Button"),
+        false,
+        "load finishing after remove() must not restore the removed entry",
+      );
+    });
+
     it("should handle concurrent discover calls", async () => {
       const adapter = createMockAdapter();
       const projectDir = "/test/concurrent-discover";

--- a/src/modules/component-registry/edge-cases.test.ts
+++ b/src/modules/component-registry/edge-cases.test.ts
@@ -7,6 +7,7 @@ import {
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
+import { FILE_NOT_FOUND } from "#veryfront/errors/error-registry/general.ts";
 import { ComponentRegistry } from "./index.ts";
 
 describe("ComponentRegistry - Edge Cases and Error Handling", () => {
@@ -725,6 +726,42 @@ describe("ComponentRegistry - Edge Cases and Error Handling", () => {
         "a manual entry added during load must not be overwritten by stale file content",
       );
       assertEquals(loaded?.content, "manual content");
+    });
+
+    it("should load a replacement entry when the stale source disappears during its read", async () => {
+      const adapter = createMockAdapter();
+      const projectDir = "/test/replace-after-stale-read-failure";
+      const componentPath = `${projectDir}/components/Button.tsx`;
+      adapter.fs.files.set(componentPath, "discovered content");
+
+      let releaseRead = () => {};
+      const gate = new Promise<void>((resolve) => {
+        releaseRead = resolve;
+      });
+      let readStarted = () => {};
+      const readFileStarted = new Promise<void>((resolve) => {
+        readStarted = resolve;
+      });
+      adapter.fs.readFile = async () => {
+        readStarted();
+        await gate;
+        throw FILE_NOT_FOUND.create({
+          detail: "The stale component source disappeared",
+          context: { operation: "readFile" },
+        });
+      };
+
+      const registry = new ComponentRegistry({ projectDir, adapter });
+      await registry.discover();
+
+      const loading = registry.loadComponent("Button");
+      await readFileStarted;
+      registry.add("Button", { content: "replacement content", exports: { default: () => {} } });
+      releaseRead();
+      const loaded = await loading;
+
+      assertEquals(loaded?.content, "replacement content");
+      assertEquals(registry.get("Button")?.content, "replacement content");
     });
 
     it("should not restore a component removed while its source was being read", async () => {

--- a/src/modules/component-registry/registry.ts
+++ b/src/modules/component-registry/registry.ts
@@ -42,6 +42,8 @@ export class ComponentRegistry {
   private componentDirs: string[];
   private initializedPromise: Promise<void> | null = null;
   private discoveryInFlight: Promise<void> | null = null;
+  // Bumped by clear() so async work started before it discards its result.
+  private lifecycleGeneration = 0;
   private adapter: RuntimeAdapter;
 
   constructor(private options: ComponentRegistryOptions) {
@@ -57,10 +59,12 @@ export class ComponentRegistry {
   discover(): Promise<void> {
     if (this.discoveryInFlight) return this.discoveryInFlight;
 
+    const generation = this.lifecycleGeneration;
     const discovery = withSpan(
       "modules.componentRegistry.discover",
       async () => {
         const discovered = await this._discoverInternal();
+        if (generation !== this.lifecycleGeneration) return;
         const nextComponents = new Map<string, ComponentInfo>();
 
         for (const name of this.manualComponents) {
@@ -167,9 +171,15 @@ export class ComponentRegistry {
         if (component.isLoaded) return component;
 
         try {
+          const content = await this.adapter.fs.readFile(component.path);
+          if (this.components.get(name) !== component) {
+            // The entry changed while the source was being read; load the
+            // current entry instead of storing stale metadata.
+            return this.loadComponent(name);
+          }
           const loaded = immutableComponentInfo({
             ...component,
-            content: await this.adapter.fs.readFile(component.path),
+            content,
             isLoaded: true,
           });
           this.components.set(name, loaded);
@@ -242,9 +252,11 @@ export class ComponentRegistry {
   }
 
   clear(): void {
+    this.lifecycleGeneration++;
     this.components.clear();
     this.manualComponents.clear();
     this.initializedPromise = null;
+    this.discoveryInFlight = null;
   }
 
   getComponentNames(): string[] {

--- a/src/modules/component-registry/registry.ts
+++ b/src/modules/component-registry/registry.ts
@@ -42,6 +42,7 @@ export class ComponentRegistry {
   private componentDirs: string[];
   private initializedPromise: Promise<void> | null = null;
   private discoveryInFlight: Promise<void> | null = null;
+  private discoveryMutations: Set<string> | null = null;
   // Bumped by clear() so async work started before it discards its result.
   private lifecycleGeneration = 0;
   private adapter: RuntimeAdapter;
@@ -60,6 +61,8 @@ export class ComponentRegistry {
     if (this.discoveryInFlight) return this.discoveryInFlight;
 
     const generation = this.lifecycleGeneration;
+    const mutations = new Set<string>();
+    this.discoveryMutations = mutations;
     const discovery = withSpan(
       "modules.componentRegistry.discover",
       async () => {
@@ -72,7 +75,7 @@ export class ComponentRegistry {
           if (component) nextComponents.set(name, component);
         }
         for (const [name, component] of discovered) {
-          if (this.manualComponents.has(name)) continue;
+          if (this.manualComponents.has(name) || mutations.has(name)) continue;
           nextComponents.set(name, component);
         }
 
@@ -81,7 +84,10 @@ export class ComponentRegistry {
       { "registry.projectDir": this.options.projectDir },
     );
     const trackedDiscovery = discovery.finally(() => {
-      if (this.discoveryInFlight === trackedDiscovery) this.discoveryInFlight = null;
+      if (this.discoveryInFlight === trackedDiscovery) {
+        this.discoveryInFlight = null;
+        if (this.discoveryMutations === mutations) this.discoveryMutations = null;
+      }
     });
     this.discoveryInFlight = trackedDiscovery;
     this.initializedPromise = trackedDiscovery;
@@ -238,6 +244,7 @@ export class ComponentRegistry {
   }
 
   add(name: string, info: Partial<ComponentInfo>): void {
+    this.discoveryMutations?.add(name);
     this.manualComponents.add(name);
     this.components.set(
       name,
@@ -252,6 +259,7 @@ export class ComponentRegistry {
   }
 
   remove(name: string): void {
+    this.discoveryMutations?.add(name);
     this.manualComponents.delete(name);
     this.components.delete(name);
   }
@@ -262,6 +270,7 @@ export class ComponentRegistry {
     this.manualComponents.clear();
     this.initializedPromise = null;
     this.discoveryInFlight = null;
+    this.discoveryMutations = null;
   }
 
   getComponentNames(): string[] {

--- a/src/modules/component-registry/registry.ts
+++ b/src/modules/component-registry/registry.ts
@@ -186,6 +186,11 @@ export class ComponentRegistry {
           logger.debug(`Loaded component: ${name}`);
           return loaded;
         } catch (error) {
+          if (this.components.get(name) !== component) {
+            // The failed read belonged to a stale entry. A replacement may
+            // already be loadable even though the old source disappeared.
+            return this.loadComponent(name);
+          }
           if (isCanonicalNotFoundError(error)) return null;
           throw error;
         }

--- a/src/modules/component-registry/registry.ts
+++ b/src/modules/component-registry/registry.ts
@@ -3,6 +3,8 @@ import { basename, join } from "#veryfront/compat/path/index.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type * as React from "react";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
+import { ALREADY_EXISTS } from "#veryfront/errors/error-registry/general.ts";
+import { isCanonicalNotFoundError } from "#veryfront/platform/compat/not-found-error.ts";
 
 export interface ComponentExports {
   default?: unknown;
@@ -10,11 +12,15 @@ export interface ComponentExports {
 }
 
 export interface ComponentInfo {
-  name: string;
-  path: string;
-  content?: string;
-  isLoaded: boolean;
-  exports?: ComponentExports;
+  readonly name: string;
+  readonly path: string;
+  readonly content?: string;
+  readonly isLoaded: boolean;
+  readonly exports?: ComponentExports;
+}
+
+function immutableComponentInfo(info: ComponentInfo): ComponentInfo {
+  return Object.freeze(info);
 }
 
 export interface ComponentRegistryOptions {
@@ -32,10 +38,11 @@ export type ComponentLoader = {
 
 export class ComponentRegistry {
   private components = new Map<string, ComponentInfo>();
+  private manualComponents = new Set<string>();
   private componentDirs: string[];
   private initializedPromise: Promise<void> | null = null;
+  private discoveryInFlight: Promise<void> | null = null;
   private adapter: RuntimeAdapter;
-  private initialized = false;
 
   constructor(private options: ComponentRegistryOptions) {
     this.adapter = options.adapter;
@@ -48,43 +55,58 @@ export class ComponentRegistry {
   }
 
   discover(): Promise<void> {
-    return withSpan(
+    if (this.discoveryInFlight) return this.discoveryInFlight;
+
+    const discovery = withSpan(
       "modules.componentRegistry.discover",
       async () => {
-        this.initialized = false;
-        this.initializedPromise = (async () => {
-          await this._discoverInternal();
-          this.initialized = true;
-        })();
-        await this.initializedPromise;
+        const discovered = await this._discoverInternal();
+        const nextComponents = new Map<string, ComponentInfo>();
+
+        for (const name of this.manualComponents) {
+          const component = this.components.get(name);
+          if (component) nextComponents.set(name, component);
+        }
+        for (const [name, component] of discovered) {
+          if (this.manualComponents.has(name)) continue;
+          nextComponents.set(name, component);
+        }
+
+        this.components = nextComponents;
       },
       { "registry.projectDir": this.options.projectDir },
     );
+    const trackedDiscovery = discovery.finally(() => {
+      if (this.discoveryInFlight === trackedDiscovery) this.discoveryInFlight = null;
+    });
+    this.discoveryInFlight = trackedDiscovery;
+    this.initializedPromise = trackedDiscovery;
+    return trackedDiscovery;
   }
 
-  private async _discoverInternal(): Promise<void> {
+  private async _discoverInternal(): Promise<Map<string, ComponentInfo>> {
     logger.debug(`Discovering components in: ${this.componentDirs.join(", ")}`);
+    const discovered = new Map<string, ComponentInfo>();
 
     for (const dir of this.componentDirs) {
       const fullPath = join(this.options.projectDir, dir);
 
       try {
-        await this.walkDirectory(fullPath);
+        await this.walkDirectory(fullPath, discovered);
       } catch (error) {
-        // Silently skip missing directories - they're optional
-        const code = (error as NodeJS.ErrnoException | undefined)?.code;
-        const isNotFound = code === "ENOENT" ||
-          (error instanceof Error && error.name === "NotFound");
-        if (isNotFound) continue;
-
-        logger.warn(`Failed to discover components in ${fullPath}:`, error);
+        if (isCanonicalNotFoundError(error)) continue;
+        throw error;
       }
     }
 
-    logger.debug(`Discovered ${this.components.size} components`);
+    logger.debug(`Discovered ${discovered.size} components`);
+    return discovered;
   }
 
-  private async walkDirectory(dir: string): Promise<void> {
+  private async walkDirectory(
+    dir: string,
+    discovered: Map<string, ComponentInfo>,
+  ): Promise<void> {
     const entries = this.adapter.fs.readDir(dir);
 
     for await (const entry of entries) {
@@ -99,7 +121,7 @@ export class ComponentRegistry {
       const fullPath = join(dir, entry.name);
 
       if (entry.isDirectory) {
-        await this.walkDirectory(fullPath);
+        await this.walkDirectory(fullPath, discovered);
         continue;
       }
 
@@ -109,11 +131,22 @@ export class ComponentRegistry {
       const componentName = basename(entry.name, ext);
       if (componentName === "index") continue;
 
-      this.components.set(componentName, {
-        name: componentName,
-        path: fullPath,
-        isLoaded: false,
-      });
+      const existing = discovered.get(componentName);
+      if (existing && existing.path !== fullPath) {
+        throw ALREADY_EXISTS.create({
+          detail: `Component name '${componentName}' is already registered`,
+          context: { componentName },
+        });
+      }
+
+      discovered.set(
+        componentName,
+        immutableComponentInfo({
+          name: componentName,
+          path: fullPath,
+          isLoaded: false,
+        }),
+      );
 
       logger.debug(`Discovered component: ${componentName} at ${fullPath}`);
     }
@@ -134,13 +167,17 @@ export class ComponentRegistry {
         if (component.isLoaded) return component;
 
         try {
-          component.content = await this.adapter.fs.readFile(component.path);
-          component.isLoaded = true;
+          const loaded = immutableComponentInfo({
+            ...component,
+            content: await this.adapter.fs.readFile(component.path),
+            isLoaded: true,
+          });
+          this.components.set(name, loaded);
           logger.debug(`Loaded component: ${name}`);
-          return component;
+          return loaded;
         } catch (error) {
-          logger.error(`Failed to load component ${name}:`, error);
-          return null;
+          if (isCanonicalNotFoundError(error)) return null;
+          throw error;
         }
       },
       { "registry.componentName": name },
@@ -151,6 +188,7 @@ export class ComponentRegistry {
     return withSpan(
       "modules.componentRegistry.loadAll",
       async () => {
+        await this.initializedPromise;
         await Promise.all(Array.from(this.components.keys(), (name) => this.loadComponent(name)));
       },
       { "registry.componentCount": this.components.size },
@@ -185,22 +223,27 @@ export class ComponentRegistry {
   }
 
   add(name: string, info: Partial<ComponentInfo>): void {
-    this.components.set(name, {
+    this.manualComponents.add(name);
+    this.components.set(
       name,
-      path: info.path ?? `virtual:${name}`,
-      content: info.content,
-      isLoaded: true,
-      exports: info.exports,
-    });
+      immutableComponentInfo({
+        name,
+        path: info.path ?? `virtual:${name}`,
+        content: info.content,
+        isLoaded: info.isLoaded ?? (info.content !== undefined || info.exports !== undefined),
+        exports: info.exports,
+      }),
+    );
   }
 
   remove(name: string): void {
+    this.manualComponents.delete(name);
     this.components.delete(name);
   }
 
   clear(): void {
     this.components.clear();
-    this.initialized = false;
+    this.manualComponents.clear();
     this.initializedPromise = null;
   }
 

--- a/src/modules/module-resolver.test.ts
+++ b/src/modules/module-resolver.test.ts
@@ -200,6 +200,26 @@ describe("modules/module-resolver", () => {
       );
     });
 
+    it("should normalize native Windows canonical paths before returning them", async () => {
+      const adapter = createMockAdapter();
+      const projectDir = "C:/project";
+      const componentPath = `${projectDir}/components/Button.tsx`;
+      adapter.fs.files.set(componentPath, "export default function Button() {}");
+      Reflect.deleteProperty(adapter.fs, "symlinkSemantics");
+      adapter.fs.realPath = (path: string) => {
+        if (path === projectDir) return Promise.resolve("C:\\project");
+        if (path === componentPath) {
+          return Promise.resolve("C:\\project\\components\\Button.tsx");
+        }
+        return Promise.resolve(path);
+      };
+      const resolver = new ModuleResolver({ projectDir, adapter });
+
+      const result = await resolver.resolve("./components/Button.tsx", `${projectDir}/index.ts`);
+
+      assertEquals(result?.path, componentPath);
+    });
+
     it("should propagate canonicalization failures", async () => {
       const adapter = createMockAdapter();
       adapter.fs.files.set("/project/components/Button.tsx", "export default function Button() {}");

--- a/src/modules/module-resolver.test.ts
+++ b/src/modules/module-resolver.test.ts
@@ -174,6 +174,32 @@ describe("modules/module-resolver", () => {
       assertEquals(result, null);
     });
 
+    it("should cache the canonical file path instead of a retargetable symlink path", async () => {
+      const adapter = createMockAdapter();
+      const linkedPath = "/project/components/Linked.tsx";
+      const canonicalPath = "/canonical/project/components/Linked.tsx";
+      adapter.fs.files.set(linkedPath, "export default function Linked() {}");
+      Reflect.deleteProperty(adapter.fs, "symlinkSemantics");
+      let canonicalCandidate = canonicalPath;
+      adapter.fs.realPath = (path: string) => {
+        if (path === "/project") return Promise.resolve("/canonical/project");
+        if (path === linkedPath) return Promise.resolve(canonicalCandidate);
+        return Promise.resolve(path);
+      };
+      const resolver = new ModuleResolver({ projectDir: "/project", adapter });
+
+      const first = await resolver.resolve("./components/Linked.tsx", "/project/index.ts");
+      canonicalCandidate = "/canonical/outside/Secret.tsx";
+      const cached = await resolver.resolve("./components/Linked.tsx", "/project/index.ts");
+
+      assertEquals(first?.path, canonicalPath);
+      assertStrictEquals(
+        cached,
+        first,
+        "the cached result must retain the verified canonical path",
+      );
+    });
+
     it("should propagate canonicalization failures", async () => {
       const adapter = createMockAdapter();
       adapter.fs.files.set("/project/components/Button.tsx", "export default function Button() {}");

--- a/src/modules/module-resolver.test.ts
+++ b/src/modules/module-resolver.test.ts
@@ -192,6 +192,35 @@ describe("modules/module-resolver", () => {
       assertEquals(error, failure);
     });
 
+    it("should propagate an operational canonicalization failure masked by a concurrent not-found", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set("/project/components/Button.tsx", "export default function Button() {}");
+      Reflect.deleteProperty(adapter.fs, "symlinkSemantics");
+      const failure = new Error("canonical path backend unavailable");
+      adapter.fs.realPath = (path: string) => {
+        if (path === "/project") {
+          return Promise.resolve().then(() => Promise.reject(failure));
+        }
+        return Promise.reject(
+          FILE_NOT_FOUND.create({
+            detail: "File not found during canonicalization",
+            context: { operation: "realPath" },
+          }),
+        );
+      };
+      const resolver = new ModuleResolver({ projectDir: "/project", adapter });
+
+      const error = await assertRejects(() =>
+        resolver.resolve("./components/Button.tsx", "/project/index.ts")
+      );
+
+      assertEquals(
+        error,
+        failure,
+        "an operational realPath failure must surface even when the other realPath call rejects with not-found first",
+      );
+    });
+
     it("should return null when a file disappears during canonicalization", async () => {
       const adapter = createMockAdapter();
       const componentPath = "/project/components/Button.tsx";

--- a/src/modules/module-resolver.test.ts
+++ b/src/modules/module-resolver.test.ts
@@ -1,7 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
+import { FILE_NOT_FOUND } from "#veryfront/errors/error-registry/general.ts";
 import { ModuleResolver } from "./module-resolver.ts";
 
 describe("modules/module-resolver", () => {
@@ -135,6 +136,83 @@ describe("modules/module-resolver", () => {
       const resolver = createResolver({ projectDir: "/project" });
 
       const result = await resolver.resolve("./nonexistent");
+      assertEquals(result, null);
+    });
+
+    it("should block relative imports that escape the project root", async () => {
+      const resolver = createResolver({
+        projectDir: "/project",
+        files: { "/outside.ts": "export const secret = true;" },
+      });
+
+      const result = await resolver.resolve("../../outside.ts", "/project/src/index.ts");
+
+      assertEquals(result, null);
+    });
+
+    it("should block relative imports that escape through a symlink", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/project/components/Linked.tsx",
+        "export default function Linked() {}",
+      );
+      Reflect.deleteProperty(adapter.fs, "symlinkSemantics");
+      adapter.fs.realPath = (path: string) => {
+        if (path === "/project") return Promise.resolve("/canonical/project");
+        if (path === "/project/components/Linked.tsx") {
+          return Promise.resolve("/canonical/outside/Linked.tsx");
+        }
+        return Promise.resolve(path);
+      };
+      const resolver = new ModuleResolver({ projectDir: "/project", adapter });
+
+      const result = await resolver.resolve(
+        "./components/Linked.tsx",
+        "/project/index.ts",
+      );
+
+      assertEquals(result, null);
+    });
+
+    it("should propagate canonicalization failures", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set("/project/components/Button.tsx", "export default function Button() {}");
+      Reflect.deleteProperty(adapter.fs, "symlinkSemantics");
+      const failure = {
+        code: "ENOENT",
+        message: "canonical path backend unavailable",
+      };
+      adapter.fs.realPath = () => Promise.reject(failure);
+      const resolver = new ModuleResolver({ projectDir: "/project", adapter });
+
+      const error = await assertRejects(() =>
+        resolver.resolve("./components/Button.tsx", "/project/index.ts")
+      );
+
+      assertEquals(error, failure);
+    });
+
+    it("should return null when a file disappears during canonicalization", async () => {
+      const adapter = createMockAdapter();
+      const componentPath = "/project/components/Button.tsx";
+      adapter.fs.files.set(componentPath, "export default function Button() {}");
+      Reflect.deleteProperty(adapter.fs, "symlinkSemantics");
+      adapter.fs.realPath = (path: string) => {
+        if (path === "/project") return Promise.resolve(path);
+        return Promise.reject(
+          FILE_NOT_FOUND.create({
+            detail: "File not found during canonicalization",
+            context: { operation: "realPath" },
+          }),
+        );
+      };
+      const resolver = new ModuleResolver({ projectDir: "/project", adapter });
+
+      const result = await resolver.resolve(
+        "./components/Button.tsx",
+        "/project/index.ts",
+      );
+
       assertEquals(result, null);
     });
   });

--- a/src/modules/module-resolver.ts
+++ b/src/modules/module-resolver.ts
@@ -83,8 +83,8 @@ export class ModuleResolver {
     if (projectResult.status !== "fulfilled" || candidateResult.status !== "fulfilled") {
       return null;
     }
-    const canonicalProjectDir = projectResult.value;
-    const canonicalCandidate = candidateResult.value;
+    const canonicalProjectDir = normalize(projectResult.value);
+    const canonicalCandidate = normalize(candidateResult.value);
     if (!isPathContainedBy(canonicalCandidate, canonicalProjectDir)) {
       logger.warn(`Canonical path escape blocked: ${specifier}`);
       return null;

--- a/src/modules/module-resolver.ts
+++ b/src/modules/module-resolver.ts
@@ -66,17 +66,22 @@ export class ModuleResolver {
     const realPath = this.adapter.fs.realPath;
     if (!realPath) return true;
 
-    let canonicalProjectDir: string;
-    let canonicalCandidate: string;
-    try {
-      [canonicalProjectDir, canonicalCandidate] = await Promise.all([
-        realPath.call(this.adapter.fs, projectDir),
-        realPath.call(this.adapter.fs, normalizedCandidate),
-      ]);
-    } catch (error) {
-      if (isCanonicalNotFoundError(error)) return false;
-      throw error;
+    const [projectResult, candidateResult] = await Promise.allSettled([
+      realPath.call(this.adapter.fs, projectDir),
+      realPath.call(this.adapter.fs, normalizedCandidate),
+    ]);
+    // A canonical not-found from one path must not mask an operational
+    // failure from the other, regardless of which settles first.
+    for (const result of [projectResult, candidateResult]) {
+      if (result.status === "rejected" && !isCanonicalNotFoundError(result.reason)) {
+        throw result.reason;
+      }
     }
+    if (projectResult.status !== "fulfilled" || candidateResult.status !== "fulfilled") {
+      return false;
+    }
+    const canonicalProjectDir = projectResult.value;
+    const canonicalCandidate = candidateResult.value;
     if (!isPathContainedBy(canonicalCandidate, canonicalProjectDir)) {
       logger.warn(`Canonical path escape blocked: ${specifier}`);
       return false;

--- a/src/modules/module-resolver.ts
+++ b/src/modules/module-resolver.ts
@@ -1,11 +1,13 @@
 import { serverLogger as logger } from "#veryfront/utils";
-import { dirname, isAbsolute, join, normalize, relative } from "#veryfront/compat/path/index.ts";
+import { dirname, isAbsolute, join, normalize } from "#veryfront/compat/path/index.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { buildModuleResolveCacheKey } from "#veryfront/cache/keys.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 import { registerLRUCache } from "#veryfront/cache";
 import { CACHE_MAX_ENTRIES_LARGE } from "#veryfront/utils/constants/limits.ts";
+import { isPathContainedBy } from "#veryfront/platform/adapters/path-containment.ts";
+import { isCanonicalNotFoundError } from "#veryfront/platform/compat/not-found-error.ts";
 
 export interface ResolvedModule {
   path: string;
@@ -47,6 +49,42 @@ export class ModuleResolver {
     return resolved;
   }
 
+  private isContainedPath(candidatePath: string): boolean {
+    const projectDir = normalize(this.options.projectDir);
+    const normalizedCandidate = normalize(candidatePath);
+    return isPathContainedBy(normalizedCandidate, projectDir);
+  }
+
+  private async isContainedFile(candidatePath: string, specifier: string): Promise<boolean> {
+    const projectDir = normalize(this.options.projectDir);
+    const normalizedCandidate = normalize(candidatePath);
+
+    if (!this.isContainedPath(normalizedCandidate)) return false;
+
+    if (!await this.adapter.fs.exists(normalizedCandidate)) return false;
+
+    const realPath = this.adapter.fs.realPath;
+    if (!realPath) return true;
+
+    let canonicalProjectDir: string;
+    let canonicalCandidate: string;
+    try {
+      [canonicalProjectDir, canonicalCandidate] = await Promise.all([
+        realPath.call(this.adapter.fs, projectDir),
+        realPath.call(this.adapter.fs, normalizedCandidate),
+      ]);
+    } catch (error) {
+      if (isCanonicalNotFoundError(error)) return false;
+      throw error;
+    }
+    if (!isPathContainedBy(canonicalCandidate, canonicalProjectDir)) {
+      logger.warn(`Canonical path escape blocked: ${specifier}`);
+      return false;
+    }
+
+    return true;
+  }
+
   resolve(specifier: string, referrer?: string): Promise<ResolvedModule | null> {
     return withSpan(
       "modules.resolver.resolve",
@@ -82,10 +120,14 @@ export class ModuleResolver {
 
           const basePath = refPath ? dirname(refPath) : this.options.projectDir;
           const fullPath = normalize(join(basePath, specifier));
+          if (!this.isContainedPath(fullPath)) {
+            logger.warn(`Path traversal attempt blocked: ${specifier}`);
+            return null;
+          }
 
           for (const ext of MODULE_EXTENSIONS) {
             const pathWithExt = fullPath + ext;
-            if (await this.adapter.fs.exists(pathWithExt)) {
+            if (await this.isContainedFile(pathWithExt, specifier)) {
               return this.cacheAndReturn(cacheKey, { path: pathWithExt, type: "file" });
             }
           }
@@ -95,14 +137,11 @@ export class ModuleResolver {
 
         if (specifier.startsWith("/")) {
           const fullPath = join(this.options.projectDir, specifier);
-          const relativePath = relative(this.options.projectDir, fullPath);
-
-          if (relativePath.startsWith("..") || isAbsolute(relativePath)) {
+          if (!this.isContainedPath(fullPath)) {
             logger.warn(`Path traversal attempt blocked: ${specifier}`);
             return null;
           }
-
-          if (await this.adapter.fs.exists(fullPath)) {
+          if (await this.isContainedFile(fullPath, specifier)) {
             return this.cacheAndReturn(cacheKey, { path: fullPath, type: "file" });
           }
 

--- a/src/modules/module-resolver.ts
+++ b/src/modules/module-resolver.ts
@@ -55,16 +55,19 @@ export class ModuleResolver {
     return isPathContainedBy(normalizedCandidate, projectDir);
   }
 
-  private async isContainedFile(candidatePath: string, specifier: string): Promise<boolean> {
+  private async resolveContainedFile(
+    candidatePath: string,
+    specifier: string,
+  ): Promise<string | null> {
     const projectDir = normalize(this.options.projectDir);
     const normalizedCandidate = normalize(candidatePath);
 
-    if (!this.isContainedPath(normalizedCandidate)) return false;
+    if (!this.isContainedPath(normalizedCandidate)) return null;
 
-    if (!await this.adapter.fs.exists(normalizedCandidate)) return false;
+    if (!await this.adapter.fs.exists(normalizedCandidate)) return null;
 
     const realPath = this.adapter.fs.realPath;
-    if (!realPath) return true;
+    if (!realPath) return normalizedCandidate;
 
     const [projectResult, candidateResult] = await Promise.allSettled([
       realPath.call(this.adapter.fs, projectDir),
@@ -78,16 +81,16 @@ export class ModuleResolver {
       }
     }
     if (projectResult.status !== "fulfilled" || candidateResult.status !== "fulfilled") {
-      return false;
+      return null;
     }
     const canonicalProjectDir = projectResult.value;
     const canonicalCandidate = candidateResult.value;
     if (!isPathContainedBy(canonicalCandidate, canonicalProjectDir)) {
       logger.warn(`Canonical path escape blocked: ${specifier}`);
-      return false;
+      return null;
     }
 
-    return true;
+    return canonicalCandidate;
   }
 
   resolve(specifier: string, referrer?: string): Promise<ResolvedModule | null> {
@@ -132,8 +135,9 @@ export class ModuleResolver {
 
           for (const ext of MODULE_EXTENSIONS) {
             const pathWithExt = fullPath + ext;
-            if (await this.isContainedFile(pathWithExt, specifier)) {
-              return this.cacheAndReturn(cacheKey, { path: pathWithExt, type: "file" });
+            const resolvedPath = await this.resolveContainedFile(pathWithExt, specifier);
+            if (resolvedPath) {
+              return this.cacheAndReturn(cacheKey, { path: resolvedPath, type: "file" });
             }
           }
 
@@ -146,8 +150,9 @@ export class ModuleResolver {
             logger.warn(`Path traversal attempt blocked: ${specifier}`);
             return null;
           }
-          if (await this.isContainedFile(fullPath, specifier)) {
-            return this.cacheAndReturn(cacheKey, { path: fullPath, type: "file" });
+          const resolvedPath = await this.resolveContainedFile(fullPath, specifier);
+          if (resolvedPath) {
+            return this.cacheAndReturn(cacheKey, { path: resolvedPath, type: "file" });
           }
 
           return null;

--- a/tests/integration/core/registry.test.ts
+++ b/tests/integration/core/registry.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert";
+import { assert, assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { join } from "#veryfront/compat/path";
 import { describe, it } from "#veryfront/testing/bdd";
 import { mkdir, remove, writeTextFile } from "#veryfront/testing/deno-compat";

--- a/tests/integration/core/registry.test.ts
+++ b/tests/integration/core/registry.test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, assertExists } from "#veryfront/testing/assert";
+import { assert, assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert";
 import { join } from "#veryfront/compat/path";
 import { describe, it } from "#veryfront/testing/bdd";
 import { mkdir, remove, writeTextFile } from "#veryfront/testing/deno-compat";
@@ -548,7 +548,7 @@ describe("ComponentRegistry", () => {
       });
     });
 
-    it("should handle component name conflicts by last-write-wins", async () => {
+    it("should reject component name conflicts in nested directories", async () => {
       await withTestContext("registry-conflict", async (context) => {
         const componentsDir = join(context.projectDir, "components");
         const dir1 = join(componentsDir, "dir1");
@@ -559,14 +559,15 @@ describe("ComponentRegistry", () => {
         await writeTextFile(join(dir2, "Component.tsx"), "export default function C2(){}");
 
         const reg = await createRegistry(context.projectDir);
-        await reg.discover();
-
-        assertEquals(reg.getComponentNames().length, 1);
-        assert(reg.has("Component"));
+        await assertRejects(
+          () => reg.discover(),
+          Error,
+          "Component name 'Component' is already registered",
+        );
       });
     });
 
-    it("should handle invalid component paths", async () => {
+    it("should return null for missing path-only manual components", async () => {
       await withTestContext("registry-invalid-path", async (context) => {
         const reg = await createRegistry(context.projectDir);
         await reg.discover();
@@ -574,8 +575,8 @@ describe("ComponentRegistry", () => {
         reg.add("Invalid", { path: "/invalid/path/that/does/not/exist.tsx" });
 
         const component = await reg.loadComponent("Invalid");
-        assertExists(component);
-        assertEquals(component.isLoaded, true);
+        assertEquals(component, null);
+        assertEquals(reg.get("Invalid")?.isLoaded, false);
       });
     });
 
@@ -592,7 +593,7 @@ describe("ComponentRegistry", () => {
       });
     });
 
-    it("should handle components with same name in different directories", async () => {
+    it("should reject component name conflicts across component directories", async () => {
       await withTestContext("registry-same-name", async (context) => {
         const componentsDir = join(context.projectDir, "components");
         const islandsDir = join(context.projectDir, "islands");
@@ -602,9 +603,11 @@ describe("ComponentRegistry", () => {
         await writeTextFile(join(islandsDir, "Button.tsx"), "export default function B2(){}");
 
         const reg = await createRegistry(context.projectDir);
-        await reg.discover();
-
-        assertEquals(reg.getComponentNames().filter((n) => n === "Button").length, 1);
+        await assertRejects(
+          () => reg.discover(),
+          Error,
+          "Component name 'Button' is already registered",
+        );
       });
     });
 
@@ -685,19 +688,6 @@ describe("ComponentRegistry", () => {
       });
     });
 
-    it("should expose loader after discovery", async () => {
-      await withTestContext("registry-loader", async (context) => {
-        const reg = await createRegistry(context.projectDir);
-
-        assertEquals(reg.getLoader(), undefined);
-
-        await reg.discover();
-
-        const _loader = reg.getLoader();
-        void _loader;
-      });
-    });
-
     it("should handle component with special characters in name", async () => {
       await withTestContext("registry-special-chars", async (context) => {
         const componentsDir = join(context.projectDir, "components");
@@ -732,42 +722,6 @@ describe("ComponentRegistry", () => {
 
         assertEquals(reg.has("Manual"), true);
         assertEquals(reg.has("Discovered"), true);
-      });
-    });
-  });
-
-  describe("ComponentLoader Integration", () => {
-    it("should initialize loader during discovery", async () => {
-      await withTestContext("registry-loader-init", async (context) => {
-        const reg = await createRegistry(context.projectDir);
-
-        await reg.discover();
-
-        const _loader = reg.getLoader();
-        void _loader;
-      });
-    });
-
-    it("should handle loader initialization failure gracefully", async () => {
-      await withTestContext("registry-loader-fail", async (context) => {
-        const reg = await createRegistry(context.projectDir);
-
-        await reg.discover();
-        assertEquals(reg.getComponentNames().length, 0);
-      });
-    });
-
-    it("should preserve loader across multiple discoveries", async () => {
-      await withTestContext("registry-loader-preserve", async (context) => {
-        const reg = await createRegistry(context.projectDir);
-
-        await reg.discover();
-        const firstLoader = reg.getLoader();
-
-        await reg.discover();
-        const secondLoader = reg.getLoader();
-
-        assertEquals(firstLoader, secondLoader);
       });
     });
   });

--- a/tests/integration/core/resolver.test.ts
+++ b/tests/integration/core/resolver.test.ts
@@ -1172,13 +1172,22 @@ describe("ModuleResolver", () => {
       });
     });
 
-    it("should handle relative import attempting to escape project root", async () => {
+    it("should block relative imports that resolve to existing files outside the project", async () => {
       await withTestContext("relative-escape-root", async (context) => {
-        const r = await createTestResolver(context);
+        const projectDir = join(context.projectDir, "project");
+        await mkdir(join(projectDir, "src"), { recursive: true });
+        await writeTextFile(
+          join(context.projectDir, "outside.ts"),
+          "export const outside = true;",
+        );
+        const r = new ModuleResolver({
+          projectDir,
+          adapter: await getAdapter(),
+        });
 
         const resolved = await r.resolve(
-          "../../../../../../../../nonexistent-file-xyz.ts",
-          "src/main.ts",
+          "../../outside.ts",
+          join(projectDir, "src/main.ts"),
         );
         assertEquals(resolved, null);
       });


### PR DESCRIPTION
## Description

This PR hardens the public module boundary found during the full test audit.

- Contain relative and absolute module candidates lexically, then verify canonical containment when the adapter supports realPath.
- Return null for canonical not-found races while propagating operational adapter failures.
- Make component discovery atomic and single-flight, reconcile deleted files, preserve manual entries, and reload changed sources.
- Reject duplicate component basenames with a typed already-exists error.
- Keep component metadata immutable and load path-only manual registrations from their adapter path.
- Replace false-confidence registry and resolver assertions, and remove loader tests that asserted no behavior.

This PR is stacked on #4058 because that audit PR strengthens the same two unit-test files. The production files and core integration tests do not overlap. Retarget this PR to main after #4058 merges.

## Related Issue(s)

No linked issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Verification

- deno task test:file src/modules: 60 passed, 728 steps
- deno task test:file tests/integration/core: 22 passed, 384 steps
- deno task fmt:check
- deno task lint
- deno task typecheck
- deno task lint:module-boundaries
- deno task test:layout
- deno task lint:sanitizer-baseline
- deno task lint:test-semantic-dispositions
- deno task lint:anti-slop
- deno task docs:api-reference:check
- git diff --check

The repository-wide deno task test run reached 4,566 passing tests and reproduced three existing CLI fixture failures: one deploy bootstrap case and two up end-to-end cases. The same three failures reproduce on clean origin/main in their focused files, so they are unrelated to this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented module resolution from accessing files outside the project directory, including through symlinks.
  * Improved handling of missing files and filesystem errors during component loading and module resolution.
  * Component discovery now rejects duplicate component names instead of silently replacing entries.
  * Manual components are preserved during rediscovery, while removed components are correctly cleared.
  * Component metadata is protected from unintended modification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->