### PR TITLE
Harden virtual module request boundaries

### DIFF
--- a/src/rendering/virtual-module-system.ts
+++ b/src/rendering/virtual-module-system.ts
@@ -109,18 +109,65 @@ export class VirtualModuleSystem {
 
   handleRequest(request: Request): Response | null {
     const url = new URL(request.url);
-    if (!url.pathname.startsWith(this.baseUrl)) return null;
+    if (url.pathname !== this.baseUrl && !url.pathname.startsWith(`${this.baseUrl}/`)) {
+      return null;
+    }
 
-    const moduleId = decodeURIComponent(url.pathname.slice(this.baseUrl.length + 1));
+    const allowedMethods = "GET, HEAD, OPTIONS";
+    const corsHeaders = {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": allowedMethods,
+    };
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, {
+        status: 204,
+        headers: {
+          ...corsHeaders,
+          "Allow": allowedMethods,
+          "Cache-Control": "no-store",
+        },
+      });
+    }
+
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("Method not allowed", {
+        status: 405,
+        headers: {
+          ...corsHeaders,
+          "Allow": allowedMethods,
+          "Cache-Control": "no-store",
+        },
+      });
+    }
+
+    let moduleId: string;
+    try {
+      moduleId = decodeURIComponent(url.pathname.slice(this.baseUrl.length + 1));
+    } catch (error) {
+      if (!(error instanceof URIError)) throw error;
+      return new Response(request.method === "HEAD" ? null : "Malformed module identifier", {
+        status: 400,
+        headers: {
+          ...corsHeaders,
+          "Cache-Control": "no-store",
+        },
+      });
+    }
+
     const module = this.modules.get(moduleId);
-    if (!module) return new Response("Module not found", { status: 404 });
+    if (!module) {
+      return new Response(request.method === "HEAD" ? null : "Module not found", {
+        status: 404,
+        headers: corsHeaders,
+      });
+    }
 
-    return new Response(module.transformed ?? module.source, {
+    return new Response(request.method === "HEAD" ? null : module.transformed ?? module.source, {
       headers: {
         "Content-Type": module.contentType,
         "Cache-Control": "no-cache",
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Methods": "GET, OPTIONS",
+        ...corsHeaders,
       },
     });
   }

--- a/tests/integration/renderer/virtual-module-system-comprehensive.test.ts
+++ b/tests/integration/renderer/virtual-module-system-comprehensive.test.ts
@@ -274,4 +274,41 @@ describe("VirtualModuleSystem", () => {
       assertEquals(res, null);
     }
   });
+
+  it("does not claim paths that only share the base path prefix", () => {
+    const adapter = createMockAdapter();
+    const vms = new VirtualModuleSystem("/_veryfront/modules", adapter);
+
+    const response = vms.handleRequest(
+      new Request("http://localhost/_veryfront/modules-evil/component:Example"),
+    );
+
+    assertEquals(response, null);
+  });
+
+  it("rejects unsupported methods before resolving a module", () => {
+    const adapter = createMockAdapter();
+    const vms = new VirtualModuleSystem("/_veryfront/modules", adapter);
+
+    const response = vms.handleRequest(
+      new Request("http://localhost/_veryfront/modules/component:Example", {
+        method: "POST",
+      }),
+    );
+
+    assertEquals(response?.status, 405);
+    assertEquals(response?.headers.get("Allow"), "GET, HEAD, OPTIONS");
+  });
+
+  it("returns a bad request response for malformed module identifiers", () => {
+    const adapter = createMockAdapter();
+    const vms = new VirtualModuleSystem("/_veryfront/modules", adapter);
+
+    const response = vms.handleRequest(
+      new Request("http://localhost/_veryfront/modules/%E0%A4%A"),
+    );
+
+    assertEquals(response?.status, 400);
+    assertEquals(response?.headers.get("Cache-Control"), "no-store");
+  });
 });


### PR DESCRIPTION
## Summary

- match the virtual-module namespace on an exact path boundary
- return explicit responses for unsupported methods and malformed module identifiers
- preserve GET, HEAD, and OPTIONS semantics with consistent CORS headers

## Verification

- `deno fmt --check src/rendering/virtual-module-system.ts tests/integration/renderer/virtual-module-system-comprehensive.test.ts`
- `deno task test:file tests/integration/renderer/virtual-module-system-comprehensive.test.ts` (13 steps passed)
- `deno task test:file tests/integration/renderer/virtual-module-system-smoke.test.ts` (3 steps passed)
- `deno check src/rendering/virtual-module-system.ts`
- `deno task lint src/rendering/virtual-module-system.ts tests/integration/renderer/virtual-module-system-comprehensive.test.ts`
- `git diff --check origin/main...HEAD`