### PR TITLE
Align generated build runtime artifacts

### DIFF
--- a/scripts/lint/check-skipped-tests-baseline.ts
+++ b/scripts/lint/check-skipped-tests-baseline.ts
@@ -28,7 +28,7 @@ import {
 
 // Lower this when you re-enable or delete skipped tests. Raising it means new
 // dead coverage is being added — prefer fixing or deleting the test instead.
-export const SKIPPED_TEST_BASELINE = 15;
+export const SKIPPED_TEST_BASELINE = 11;
 
 // Method form: it.skip( / describe.ignore( / test.skip( / Deno.test.ignore(
 const METHOD_FORM = /\b(?:it|describe|test|Deno\.test)\.(?:skip|ignore)\s*\(/g;

--- a/src/build/production-build/client-runtime.test.ts
+++ b/src/build/production-build/client-runtime.test.ts
@@ -37,9 +37,9 @@ describe(
         assertEquals(result.includes(JSON.stringify(VERSION)), true);
       });
 
-      it("should contain hydrate export", () => {
+      it("should contain an async hydrate export", () => {
         const result = getResult();
-        assertEquals(result.includes("export function hydrate"), true);
+        assertEquals(result.includes("export async function hydrate"), true);
       });
 
       it("should contain window.__veryfront setup", () => {
@@ -237,7 +237,7 @@ describe(
     describe("generateAppModule edge cases", () => {
       it("should expose the compatibility API without a placeholder IIFE", () => {
         const result = generateAppModule();
-        assertEquals(result.includes("export function hydrate"), true);
+        assertEquals(result.includes("export async function hydrate"), true);
         assertEquals(result.includes("(() => {"), false);
       });
 

--- a/src/build/production-build/client-runtime.test.ts
+++ b/src/build/production-build/client-runtime.test.ts
@@ -10,6 +10,7 @@ import {
   generatePrefetchScript,
   generateRouterScript,
 } from "./client-runtime.ts";
+import { VERSION } from "#veryfront/utils/version-constant.ts";
 
 describe(
   "build/production-build/client-runtime",
@@ -33,12 +34,12 @@ describe(
       it("should contain version export", () => {
         const result = getResult();
         assertEquals(result.includes("export const version"), true);
-        assertEquals(result.includes("2.0.0"), true);
+        assertEquals(result.includes(JSON.stringify(VERSION)), true);
       });
 
       it("should contain hydrate export", () => {
         const result = getResult();
-        assertEquals(result.includes("export const hydrate"), true);
+        assertEquals(result.includes("export function hydrate"), true);
       });
 
       it("should contain window.__veryfront setup", () => {
@@ -47,18 +48,11 @@ describe(
         assertEquals(result.includes("__veryfront.initialized"), true);
       });
 
-      it("should set data-hydrated attribute on root element", () => {
+      it("should delegate hydration to the generated router runtime", () => {
         const result = getResult();
-        assertStringIncludes(
-          result,
-          "root.setAttribute('data-hydrated', 'true')",
-          "app module must mark the root element as hydrated",
-        );
-        assertStringIncludes(
-          result,
-          "const root = document.getElementById('root');",
-          "app module must resolve the root element before hydrating",
-        );
+        assertEquals(result.includes("import { boot } from './router.js'"), true);
+        assertEquals(result.includes("return boot({ ...options, slug })"), true);
+        assertEquals(result.includes("data-hydrated"), false);
       });
     });
 
@@ -241,16 +235,16 @@ describe(
     });
 
     describe("generateAppModule edge cases", () => {
-      it("should include IIFE wrapper", () => {
+      it("should expose the compatibility API without a placeholder IIFE", () => {
         const result = generateAppModule();
-        assertEquals(result.includes("(() => {"), true);
-        assertEquals(result.includes("})()"), true);
+        assertEquals(result.includes("export function hydrate"), true);
+        assertEquals(result.includes("(() => {"), false);
       });
 
       it("should include hydration support", () => {
         const result = generateAppModule();
-        assertEquals(result.includes("window.hydrate"), true);
-        assertEquals(result.includes("async function"), true);
+        assertEquals(result.includes("window.hydrate = hydrate"), true);
+        assertEquals(result.includes("return boot({ ...options, slug })"), true);
       });
     });
   },

--- a/src/build/production-build/client-runtime.ts
+++ b/src/build/production-build/client-runtime.ts
@@ -16,6 +16,7 @@ import type { OnResolveArgs, Plugin } from "veryfront/extensions/bundler";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { createError, toError } from "#veryfront/errors";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { VERSION } from "#veryfront/utils/version-constant.ts";
 
 // Try to import pre-bundled client scripts (available in npm builds)
 let CLIENT_ROUTER_BUNDLE: string | undefined;
@@ -82,30 +83,20 @@ const clientAliasPaths = new Map([
 export function generateAppModule(): string {
   return `
 // Veryfront App Module
-(() => {
-  console.log('[Veryfront] App module loaded');
+import { boot } from './router.js';
 
-  // Export for ES modules
-  if (typeof window !== 'undefined') {
-    window.__veryfront = window.__veryfront || {};
-    window.__veryfront.version = '2.0.0';
-    window.__veryfront.initialized = true;
-  }
+export const version = ${JSON.stringify(VERSION)};
 
-  // Basic hydration support
-  window.hydrate = async function(slug, options = {}) {
-    console.log('[Veryfront] Hydrating page:', slug, options);
+export function hydrate(slug, options = {}) {
+  return boot({ ...options, slug });
+}
 
-    // Mark as hydrated
-    const root = document.getElementById('root');
-    if (root) {
-      root.setAttribute('data-hydrated', 'true');
-    }
-  };
-})();
-
-export const version = '2.0.0';
-export const hydrate = window.hydrate;
+if (typeof window !== 'undefined') {
+  window.__veryfront = window.__veryfront || {};
+  window.__veryfront.version = version;
+  window.__veryfront.initialized = true;
+  window.hydrate = hydrate;
+}
 `;
 }
 

--- a/src/build/production-build/client-runtime.ts
+++ b/src/build/production-build/client-runtime.ts
@@ -87,7 +87,9 @@ import { boot } from './router.js';
 
 export const version = ${JSON.stringify(VERSION)};
 
-export function hydrate(slug, options = {}) {
+// Async so callers keep the Promise-based contract of the previous runtime
+// (window.hydrate(...).then(...)) while resolving to the router from boot().
+export async function hydrate(slug, options = {}) {
   return boot({ ...options, slug });
 }
 

--- a/src/build/production-build/manifest.test.ts
+++ b/src/build/production-build/manifest.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { generateManifest, generateRedirects } from "./manifest.ts";
+import { VERSION } from "#veryfront/utils/version-constant.ts";
 
 describe("build/production-build/manifest", () => {
   describe("generateManifest", () => {
@@ -27,7 +28,7 @@ describe("build/production-build/manifest", () => {
 
     it("should generate manifest with correct version", () => {
       const result = generateManifest(baseOptions);
-      assertEquals(result.version, "2.0.0");
+      assertEquals(result.version, VERSION);
     });
 
     it("should include buildTime as ISO string", () => {

--- a/src/build/production-build/manifest.ts
+++ b/src/build/production-build/manifest.ts
@@ -1,5 +1,6 @@
 import type { AppRouteInfo, BuildStats, RouteInfo } from "#veryfront/server/build-types.ts";
 import { bundlerLogger } from "#veryfront/utils";
+import { VERSION } from "#veryfront/utils/version-constant.ts";
 
 export interface ManifestChunkInfo {
   file: string;
@@ -94,7 +95,7 @@ export function generateManifest(options: ManifestOptions): BuildManifest {
   }
 
   return {
-    version: "2.0.0",
+    version: VERSION,
     buildTime: new Date().toISOString(),
     features: {
       streaming: true,

--- a/src/server/build-service-worker.ts
+++ b/src/server/build-service-worker.ts
@@ -64,7 +64,6 @@ export function generateServiceWorker(manifest: BuildManifest): string {
 // Generated at: ${new Date().toISOString()}
 
 const CACHE_VERSION = '${cacheVersion}';
-const RUNTIME_CACHE = 'veryfront-runtime';
 
 // Static resources to cache
 const STATIC_CACHE_URLS = ${JSON.stringify(staticAssets, null, 2)};
@@ -99,7 +98,7 @@ self.addEventListener('activate', (event) => {
     caches.keys()
       .then(cacheNames => Promise.all(
         cacheNames
-          .filter(name => name !== CACHE_VERSION && name !== RUNTIME_CACHE)
+          .filter(name => name !== CACHE_VERSION)
           .map(name => caches.delete(name))
       ))
       .then(() => self.clients.claim())
@@ -126,7 +125,7 @@ self.addEventListener('fetch', (event) => {
 });
 
 async function handleRequest(request, strategy) {
-  const cache = await caches.open(RUNTIME_CACHE);
+  const cache = await caches.open(CACHE_VERSION);
 
   switch (strategy) {
     case 'networkFirst':

--- a/tests/integration/server/build-service-worker.test.ts
+++ b/tests/integration/server/build-service-worker.test.ts
@@ -71,10 +71,11 @@ describe(
         );
       });
 
-      it("should include runtime cache constant", () => {
+      it("should read runtime requests from the preloaded versioned cache", () => {
         const code = generateServiceWorker(createTestManifest());
 
-        assert(code.includes("const RUNTIME_CACHE = 'veryfront-runtime'"));
+        assert(!code.includes("RUNTIME_CACHE"));
+        assertEquals(code.match(/caches\.open\(CACHE_VERSION\)/g)?.length, 2);
       });
 
       it("should include static cache URLs", () => {
@@ -170,7 +171,6 @@ describe(
         const code = generateServiceWorker(createTestManifest());
 
         assert(code.includes("name !== CACHE_VERSION"));
-        assert(code.includes("name !== RUNTIME_CACHE"));
       });
 
       it("should include fetch event listener", () => {
@@ -197,7 +197,7 @@ describe(
         const code = generateServiceWorker(createTestManifest());
 
         assert(code.includes("async function handleRequest(request, strategy)"));
-        assert(code.includes("caches.open(RUNTIME_CACHE)"));
+        assert(code.includes("caches.open(CACHE_VERSION)"));
       });
 
       it("should implement networkFirst strategy", () => {
@@ -286,7 +286,7 @@ describe(
 
         assert(code.includes("self.addEventListener"));
         assert(code.includes("CACHE_VERSION"));
-        assert(code.includes("RUNTIME_CACHE"));
+        assert(!code.includes("RUNTIME_CACHE"));
         assertEquals(typeof code, "string");
         assert(code.length > 500);
       });
@@ -363,7 +363,6 @@ describe(
 
         assert(code.includes("caches.keys()"));
         assert(code.includes("name !== CACHE_VERSION"));
-        assert(code.includes("name !== RUNTIME_CACHE"));
         assert(code.includes("caches.delete(name)"));
         assert(code.includes("Promise.all"));
       });
@@ -404,12 +403,11 @@ describe(
         assert(code.includes("return cache.match(request)"));
       });
 
-      it("should create runtime cache for dynamic content", () => {
+      it("should keep dynamic content in the versioned cache", () => {
         const code = generateServiceWorker(createTestManifest());
 
-        assert(code.includes("const RUNTIME_CACHE = 'veryfront-runtime'"));
-        assert(code.includes("caches.open(RUNTIME_CACHE)"));
-        assert(code.includes("name !== RUNTIME_CACHE"));
+        assert(!code.includes("RUNTIME_CACHE"));
+        assert(code.includes("caches.open(CACHE_VERSION)"));
       });
 
       it("should use versioned cache names", () => {

--- a/tests/integration/server/build/build.test.ts
+++ b/tests/integration/server/build/build.test.ts
@@ -228,8 +228,7 @@ describe("Build Production Tests", { sanitizeOps: false, sanitizeResources: fals
       });
     });
 
-    // TODO: Re-enable after investigating App Router SSG regression
-    it.ignore("statically renders App Router literal routes", async () => {
+    it("statically renders App Router literal routes", async () => {
       await withTestContext("build-app-router-ssg", async (context) => {
         const outputDir = join(context.projectDir, "dist");
 
@@ -257,8 +256,7 @@ describe("Build Production Tests", { sanitizeOps: false, sanitizeResources: fals
       });
     });
 
-    // TODO: Re-enable after investigating App Router SSG regression
-    it.ignore(
+    it(
       "App Router SSG respects dynamic hint: force-dynamic skips SSG, force-static included",
       async () => {
         await withTestContext("build-app-router-dynamic", async (context) => {
@@ -341,8 +339,7 @@ describe("Build Production Tests", { sanitizeOps: false, sanitizeResources: fals
   });
 
   describe("buildProduction - SSG Filters and Router Detection", () => {
-    // TODO: Re-enable after investigating App Router SSG regression
-    it.ignore("dry-run SSG includes/excludes and app router detection", async () => {
+    it("dry-run SSG includes/excludes and app router detection", async () => {
       await withTestContext("build-ssg-dryrun", async (context) => {
         await removeAppDir(context.projectDir);
         await remove(join(context.projectDir, "pages"), { recursive: true });
@@ -370,22 +367,16 @@ describe("Build Production Tests", { sanitizeOps: false, sanitizeResources: fals
           dryRun: true,
           ssg: true,
         });
-        assert((res as any).ssgPaths);
-        console.log("All SSG paths without filter:", (res as any).ssgPaths);
+        assertEquals(res.ssgPaths, ["/", "/blog", "/docs"]);
 
         const resInc = await buildProduction({
           projectDir: context.projectDir,
           outputDir: join(context.projectDir, "dist2"),
           dryRun: true,
           ssg: true,
-          include: ["/", "/docs"],
+          include: ["/docs"],
         });
-        const inc = (resInc as any).ssgPaths as string[];
-        console.log("SSG paths with include filter:", inc);
-
-        assert(inc.includes("/docs"));
-        assertEquals(inc.includes("/blog"), false);
-        assertEquals(inc.includes("/"), false);
+        assertEquals(resInc.ssgPaths, ["/docs"]);
 
         const resExc = await buildProduction({
           projectDir: context.projectDir,
@@ -394,8 +385,7 @@ describe("Build Production Tests", { sanitizeOps: false, sanitizeResources: fals
           ssg: true,
           exclude: ["/blog"],
         });
-        const exc = (resExc as any).ssgPaths as string[];
-        assertEquals(exc.includes("/blog"), false);
+        assertEquals(resExc.ssgPaths, ["/", "/docs"]);
       });
     });
   });
@@ -500,8 +490,7 @@ describe("Build Production Tests", { sanitizeOps: false, sanitizeResources: fals
       });
     });
 
-    // TODO: Re-enable after investigating App Router SSG regression
-    it.ignore("handles mixed Pages and App Router", async () => {
+    it("handles mixed Pages and App Router", async () => {
       await withTestContext("build-mixed-router", async (context) => {
         const outputDir = join(context.projectDir, "dist");
 

--- a/tests/integration/server/build/client-runtime.test.ts
+++ b/tests/integration/server/build/client-runtime.test.ts
@@ -6,6 +6,7 @@ import {
   generateImportMap,
 } from "../../../../src/build/production-build/index.ts";
 import { cleanupBundler } from "../../../../src/rendering/cleanup.ts";
+import { VERSION } from "#veryfront/utils/version-constant.ts";
 
 describe(
   "Client Runtime Generation",
@@ -27,21 +28,21 @@ describe(
       it("should include Veryfront version", () => {
         const code = generateAppModule();
 
-        assertStringIncludes(code, "version = '2.0.0'");
+        assertStringIncludes(code, `version = ${JSON.stringify(VERSION)}`);
       });
 
       it("should initialize window.__veryfront object", () => {
         const code = generateAppModule();
 
         assertStringIncludes(code, "window.__veryfront = window.__veryfront || {}");
-        assertStringIncludes(code, "window.__veryfront.version = '2.0.0'");
+        assertStringIncludes(code, "window.__veryfront.version = version");
         assertStringIncludes(code, "window.__veryfront.initialized = true");
       });
 
       it("should define hydrate function", () => {
         const code = generateAppModule();
 
-        assertStringIncludes(code, "window.hydrate = async function");
+        assertStringIncludes(code, "export function hydrate");
         assertStringIncludes(code, "slug, options = {}");
       });
 
@@ -49,21 +50,20 @@ describe(
         const code = generateAppModule();
 
         assertStringIncludes(code, "export const version");
-        assertStringIncludes(code, "export const hydrate");
+        assertStringIncludes(code, "export function hydrate");
       });
 
-      it("should include console logging", () => {
+      it("should delegate to the router runtime", () => {
         const code = generateAppModule();
 
-        assertStringIncludes(code, "[Veryfront] App module loaded");
-        assertStringIncludes(code, "[Veryfront] Hydrating page:");
+        assertStringIncludes(code, "import { boot } from './router.js'");
+        assertStringIncludes(code, "return boot({ ...options, slug })");
       });
 
-      it("should set data-hydrated attribute", () => {
+      it("should not claim hydration by setting a marker", () => {
         const code = generateAppModule();
 
-        assertStringIncludes(code, "document.getElementById('root')");
-        assertStringIncludes(code, "setAttribute('data-hydrated', 'true')");
+        assert(!code.includes("data-hydrated"));
       });
 
       it("should check for window object", () => {
@@ -72,17 +72,17 @@ describe(
         assertStringIncludes(code, "typeof window !== 'undefined'");
       });
 
-      it("should be wrapped in IIFE", () => {
+      it("should use an ESM compatibility module", () => {
         const code = generateAppModule();
 
-        assertStringIncludes(code, "(() => {");
-        assertStringIncludes(code, "})();");
+        assertStringIncludes(code, "export const version");
+        assert(!code.includes("(() => {"));
       });
 
       it("should handle hydration with slug parameter", () => {
         const code = generateAppModule();
 
-        assertStringIncludes(code, "Hydrating page:");
+        assertStringIncludes(code, "return boot({ ...options, slug })");
         assertStringIncludes(code, "slug");
       });
     });
@@ -190,7 +190,7 @@ describe(
         const appCode = generateAppModule();
 
         assert(importMap.includes("19.2.4"));
-        assertStringIncludes(appCode, "2.0.0");
+        assertStringIncludes(appCode, VERSION);
       });
     });
   },

--- a/tests/integration/server/build/client-runtime.test.ts
+++ b/tests/integration/server/build/client-runtime.test.ts
@@ -39,10 +39,10 @@ describe(
         assertStringIncludes(code, "window.__veryfront.initialized = true");
       });
 
-      it("should define hydrate function", () => {
+      it("should define an async hydrate function", () => {
         const code = generateAppModule();
 
-        assertStringIncludes(code, "export function hydrate");
+        assertStringIncludes(code, "export async function hydrate");
         assertStringIncludes(code, "slug, options = {}");
       });
 
@@ -50,7 +50,7 @@ describe(
         const code = generateAppModule();
 
         assertStringIncludes(code, "export const version");
-        assertStringIncludes(code, "export function hydrate");
+        assertStringIncludes(code, "export async function hydrate");
       });
 
       it("should delegate to the router runtime", () => {


### PR DESCRIPTION
## Summary

- make service-worker strategies read and write the same versioned cache populated at install time
- replace the placeholder app-module hydration marker with delegation to the real router boot path while preserving the async compatibility contract
- derive app-module and build-manifest versions from the shared release version constant
- re-enable all four App Router SSG integration cases and correct the include-filter fixture
- lower the skipped-test baseline from 15 to 11

## Base

Rebased directly onto `main` at `70ffed761e28d8d07111add926338f2c2aff3757`. The diff contains only this build-artifact batch.

## Verification

- pinned Deno 2.7.7
- `deno task lint:skipped-tests` (11/11)
- changed-file `deno fmt --check`
- changed-file `deno lint`
- `deno check` on the three changed production modules
- service-worker, client-runtime, manifest, and production-build focused suites all pass
- `git diff --check origin/main...HEAD`

The repository-wide pre-push typecheck currently reports eight unrelated baseline errors in React wrappers and timer-handle types; no reported diagnostic is in this PR's nine-file diff.
