### PR TITLE
Restore CLI integration verification in CI

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -120,6 +120,8 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 10
           command: VF_DISABLE_LRU_INTERVAL=1 deno task test:integration --no-lock
+      - name: Run CLI integration tests
+        run: deno task test:integration:cli --no-lock
 
   tests-node:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/cli/commands/deploy/command.integration.test.ts
+++ b/cli/commands/deploy/command.integration.test.ts
@@ -73,6 +73,7 @@ async function withDeployEnv<T>(
   fn: (context: { commitSha: string; sourceDigest: string }) => Promise<T>,
 ): Promise<T> {
   const envKeys = [
+    "GITHUB_SHA",
     "VERYFRONT_API_TOKEN",
     "VERYFRONT_API_URL",
     "VERYFRONT_PROJECT_SLUG",
@@ -93,6 +94,7 @@ async function withDeployEnv<T>(
     Deno.env.set("VERYFRONT_API_TOKEN", "test-token");
     Deno.env.set("VERYFRONT_API_URL", "https://control.example.test/api");
     Deno.env.set("VERYFRONT_PROJECT_SLUG", "my-project");
+    Deno.env.set("GITHUB_SHA", commitSha);
     Deno.env.delete("VERYFRONT_PROJECT_ID");
     _resetEnvironmentConfig();
 

--- a/cli/commands/deploy/command.integration.test.ts
+++ b/cli/commands/deploy/command.integration.test.ts
@@ -119,6 +119,7 @@ function createDeployFetchHandler(options: {
 }) {
   let environmentReads = 0;
   const releaseSource = options.releaseSource ?? PUSHED_SOURCE;
+  const uploadedFiles = new Map<string, string>();
 
   return async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
     const request = input instanceof Request ? input : new Request(input, init);
@@ -153,10 +154,16 @@ function createDeployFetchHandler(options: {
       });
     }
     if (request.method === "GET" && url.pathname === "/api/projects/my-project/files") {
-      return Response.json({ data: [], page_info: {} });
+      return Response.json({
+        data: [...uploadedFiles].map(([path, content]) => ({ path, content })),
+        page_info: {},
+      });
     }
     if (request.method === "GET" && url.pathname === `/api/projects/${PROJECT_ID}/files`) {
-      return Response.json({ data: [], page_info: {} });
+      return Response.json({
+        data: [...uploadedFiles].map(([path, content]) => ({ path, content })),
+        page_info: {},
+      });
     }
     if (request.method === "GET" && url.pathname === `/api/projects/${PROJECT_ID}`) {
       return Response.json({ id: PROJECT_ID, slug: "my-project" });
@@ -174,7 +181,10 @@ function createDeployFetchHandler(options: {
       (url.pathname.startsWith(`/api/projects/${PROJECT_ID}/files/`) ||
         url.pathname.startsWith("/api/projects/my-project/files/"))
     ) {
-      options.uploadedPaths?.push(decodeURIComponent(url.pathname.split("/files/")[1] ?? ""));
+      const path = decodeURIComponent(url.pathname.split("/files/")[1] ?? "");
+      const body = await request.clone().json() as { content: string };
+      uploadedFiles.set(path, body.content);
+      options.uploadedPaths?.push(path);
       return Response.json({});
     }
     if (request.method === "GET" && url.pathname.endsWith("/environments")) {

--- a/cli/commands/up/up.integration.test.ts
+++ b/cli/commands/up/up.integration.test.ts
@@ -288,7 +288,10 @@ async function runUp(options: UpRunOptions = {}): Promise<UpRun> {
           return Response.json({ id: PROJECT_ID, slug: PROJECT_SLUG });
         }
         if (request.method === "GET" && url.pathname.endsWith("/files")) {
-          return Response.json({ data: [], page_info: {} });
+          return Response.json({
+            data: [...pushedFiles].map(([path, content]) => ({ path, content })),
+            page_info: {},
+          });
         }
         if (request.method === "PUT" && url.pathname.includes("/files/")) {
           const path = decodeURIComponent(url.pathname.split("/files/")[1] ?? "");

--- a/scripts/test/run-suite.test.ts
+++ b/scripts/test/run-suite.test.ts
@@ -403,6 +403,17 @@ describe("migration command surface", () => {
     assert(config.tasks[match[1]], `${match[1]} must exist in deno.json`);
   });
 
+  it("runs the CLI integration suite in CI", async () => {
+    const workflow = await Deno.readTextFile(
+      new URL("../../.github/workflows/cicd.yml", import.meta.url),
+    );
+
+    assert(
+      workflow.includes("deno task test:integration:cli --no-lock"),
+      "CI must execute the CLI integration suite",
+    );
+  });
+
   it("routes the Dev UI browser bundle test through the browser E2E lane", async () => {
     const config = JSON.parse(
       await Deno.readTextFile(new URL("../../deno.json", import.meta.url)),


### PR DESCRIPTION
## Summary

- make deploy and up integration fixtures expose uploaded files during final read-back
- restore the three deterministic integration cases that the post-upload safety check correctly rejected
- run the existing `test:integration:cli` suite in the integration CI job
- guard the CI routing with a focused runner test

## Stack

This PR is based on #4101 because that PR owns the shared test-suite runner used by the new CI lane.

## Verification

- `deno task test:integration:cli --no-lock` (44 tests, 217 steps passed)
- `deno task test:file cli/commands/deploy/command.integration.test.ts` (20 passed)
- `deno task test:file cli/commands/up/up.integration.test.ts` (19 steps passed)
- `deno task test:file scripts/test/run-suite.test.ts` (19 steps passed)
- `deno task test:layout`
- `deno task lint` on changed test files
- `deno task fmt:check`
- `git diff --check` against the stacked base

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a dedicated CLI integration test suite to the CI pipeline.
  - Improved deployment and source-push integration tests to verify uploaded and pushed file contents.
  - Added coverage confirming CI configuration runs the CLI integration tests correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->