### PR TITLE
Redact CLI runtime command output

### DIFF
--- a/cli/commands/start/command.test.ts
+++ b/cli/commands/start/command.test.ts
@@ -3,6 +3,7 @@ import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { saveToken } from "../../auth/token-store.ts";
 import {
+  createGlobalErrorLogContext,
   hasProxyCredentials,
   hydrateStartRuntimeAuth,
   selectStartProject,
@@ -48,6 +49,26 @@ describe("commands/start/command", () => {
 
     it("accepts a single StartOptions parameter", () => {
       assertEquals(startCommand.length, 1);
+    });
+  });
+
+  describe("global error logging", () => {
+    it("withholds stacks unless verbose output is enabled", () => {
+      const error = new Error("render failed");
+      error.stack = "Error: render failed\n    at <PROJECT_ROOT>/app.ts:1:1";
+
+      assertEquals(
+        createGlobalErrorLogContext(error, "unhandledRejection", false, false),
+        {
+          message: "render failed",
+          type: "unhandledRejection",
+          fatal: false,
+        },
+      );
+      assertEquals(
+        createGlobalErrorLogContext(error, "unhandledRejection", false, true).stack,
+        error.stack,
+      );
     });
   });
 

--- a/cli/commands/start/command.test.ts
+++ b/cli/commands/start/command.test.ts
@@ -53,21 +53,17 @@ describe("commands/start/command", () => {
   });
 
   describe("global error logging", () => {
-    it("withholds stacks unless verbose output is enabled", () => {
+    it("withholds stacks from user-facing start output", () => {
       const error = new Error("render failed");
       error.stack = "Error: render failed\n    at <PROJECT_ROOT>/app.ts:1:1";
 
       assertEquals(
-        createGlobalErrorLogContext(error, "unhandledRejection", false, false),
+        createGlobalErrorLogContext(error, "unhandledRejection", false),
         {
           message: "render failed",
           type: "unhandledRejection",
           fatal: false,
         },
-      );
-      assertEquals(
-        createGlobalErrorLogContext(error, "unhandledRejection", false, true).stack,
-        error.stack,
       );
     });
   });

--- a/cli/commands/start/command.ts
+++ b/cli/commands/start/command.ts
@@ -1,7 +1,7 @@
 import { cwd, getEnv, onGlobalError } from "veryfront/platform";
 import { createFileSystem } from "veryfront/platform";
 import { isAbsolute, join, resolve } from "veryfront/platform/path";
-import { cliLogger } from "#cli/utils";
+import { cliLogger, isVerbose } from "#cli/utils";
 import { exitProcess, registerTerminationSignals } from "#cli/utils";
 import { generateDefaultProjectId } from "../../utils/project.ts";
 import { clearAllLocalCaches } from "veryfront/transforms/mdx-cache";
@@ -30,6 +30,20 @@ interface ProxySetup {
 export interface StartProjectSelection {
   projectDir: string;
   projectSlug: string | undefined;
+}
+
+export function createGlobalErrorLogContext(
+  error: Error,
+  type: string,
+  fatal: boolean,
+  includeStack: boolean,
+): { message: string; type: string; fatal: boolean; stack?: string } {
+  return {
+    message: error.message,
+    type,
+    fatal,
+    ...(includeStack && error.stack ? { stack: error.stack } : {}),
+  };
 }
 
 function getProjectSlug(path: string): string {
@@ -199,12 +213,10 @@ export async function startCommand(options: StartOptions): Promise<void> {
       error.message.includes("out of memory") ||
       error.message.includes("allocation failed");
 
-    logger.error(`${type}: Application error caught`, {
-      message: error.message,
-      stack: error.stack,
-      type,
-      fatal: isFatal,
-    });
+    logger.error(
+      `${type}: Application error caught`,
+      createGlobalErrorLogContext(error, type, isFatal, isVerbose()),
+    );
 
     if (isFatal) {
       logger.error("Fatal error detected, allowing process exit");

--- a/cli/commands/start/command.ts
+++ b/cli/commands/start/command.ts
@@ -1,7 +1,7 @@
 import { cwd, getEnv, onGlobalError } from "veryfront/platform";
 import { createFileSystem } from "veryfront/platform";
 import { isAbsolute, join, resolve } from "veryfront/platform/path";
-import { cliLogger, isVerbose } from "#cli/utils";
+import { cliLogger } from "#cli/utils";
 import { exitProcess, registerTerminationSignals } from "#cli/utils";
 import { generateDefaultProjectId } from "../../utils/project.ts";
 import { clearAllLocalCaches } from "veryfront/transforms/mdx-cache";
@@ -36,13 +36,11 @@ export function createGlobalErrorLogContext(
   error: Error,
   type: string,
   fatal: boolean,
-  includeStack: boolean,
 ): { message: string; type: string; fatal: boolean; stack?: string } {
   return {
     message: error.message,
     type,
     fatal,
-    ...(includeStack && error.stack ? { stack: error.stack } : {}),
   };
 }
 
@@ -215,7 +213,7 @@ export async function startCommand(options: StartOptions): Promise<void> {
 
     logger.error(
       `${type}: Application error caught`,
-      createGlobalErrorLogContext(error, type, isFatal, isVerbose()),
+      createGlobalErrorLogContext(error, type, isFatal),
     );
 
     if (isFatal) {

--- a/cli/commands/task/command.test.ts
+++ b/cli/commands/task/command.test.ts
@@ -8,7 +8,7 @@ describe("commands/task/command", () => {
     assertEquals(parseTaskConfig('{"limit":3}'), { limit: 3 });
     assertEquals(parseTaskConfig(undefined), {});
 
-    for (const value of ["null", "[]", '"scalar"', "42", "true"]) {
+    for (const value of ["{", "null", "[]", '"scalar"', "42", "true"]) {
       assertThrows(
         () => parseTaskConfig(value),
         Error,

--- a/cli/commands/task/command.test.ts
+++ b/cli/commands/task/command.test.ts
@@ -1,0 +1,25 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { parseTaskConfig, taskDiscoverySourceLabel } from "./command.ts";
+
+describe("commands/task/command", () => {
+  it("accepts only JSON objects for --config", () => {
+    assertEquals(parseTaskConfig('{"limit":3}'), { limit: 3 });
+    assertEquals(parseTaskConfig(undefined), {});
+
+    for (const value of ["null", "[]", '"scalar"', "42", "true"]) {
+      assertThrows(
+        () => parseTaskConfig(value),
+        Error,
+        "Invalid --config JSON: must be a valid JSON object",
+      );
+    }
+  });
+
+  it("describes local discovery without exposing the project path", () => {
+    assertEquals(taskDiscoverySourceLabel(undefined), "tasks/...");
+    assertEquals(taskDiscoverySourceLabel({}), "main");
+    assertEquals(taskDiscoverySourceLabel({ branchRef: "feature-x" }), "branch feature-x");
+  });
+});

--- a/cli/commands/task/command.ts
+++ b/cli/commands/task/command.ts
@@ -15,6 +15,33 @@ import type { TaskArgs } from "./handler.ts";
 
 export interface TaskOptions extends TaskArgs {}
 
+export function parseTaskConfig(value: string | undefined): Record<string, unknown> {
+  if (value === undefined) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw INVALID_ARGUMENT.create({
+      detail: "Invalid --config JSON: must be a valid JSON object",
+    });
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw INVALID_ARGUMENT.create({
+      detail: "Invalid --config JSON: must be a valid JSON object",
+    });
+  }
+  return parsed as Record<string, unknown>;
+}
+
+export function taskDiscoverySourceLabel(
+  proxyContext: { branchRef?: string | null } | null | undefined,
+): string {
+  if (proxyContext?.branchRef) return `branch ${proxyContext.branchRef}`;
+  return proxyContext ? "main" : "tasks/...";
+}
+
 function logRuntimeDiscoveryWarnings(
   errors: Array<{ file: string; error: Error }>,
   debug: boolean | undefined,
@@ -49,11 +76,7 @@ export async function taskCommand(options: TaskOptions): Promise<void> {
   await withProjectSourceContext(
     projectDir,
     async ({ adapter, config, configCacheKey, projectId, proxyContext }) => {
-      const sourceLabel = proxyContext?.branchRef
-        ? `branch ${proxyContext.branchRef}`
-        : proxyContext
-        ? "main"
-        : `${projectDir}/tasks/...`;
+      const sourceLabel = taskDiscoverySourceLabel(proxyContext);
 
       cliLogger.info(`Discovering tasks in ${sourceLabel}`);
 
@@ -88,16 +111,7 @@ export async function taskCommand(options: TaskOptions): Promise<void> {
         throw RESOURCE_NOT_FOUND.create({ detail: `Task "${taskName}" not found.` });
       }
 
-      let taskConfig: Record<string, unknown> = {};
-      if (options.config) {
-        try {
-          taskConfig = JSON.parse(options.config);
-        } catch {
-          throw INVALID_ARGUMENT.create({
-            detail: "Invalid --config JSON: must be a valid JSON object",
-          });
-        }
-      }
+      const taskConfig = parseTaskConfig(options.config);
 
       cliLogger.info(`Running task: ${task.name} (${task.id})`);
       cliLogger.info("");

--- a/cli/commands/worker/command.test.ts
+++ b/cli/commands/worker/command.test.ts
@@ -1,0 +1,19 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { formatRedisLogTarget } from "./command.ts";
+
+describe("commands/worker/command", () => {
+  it("removes Redis credentials and query values from user-facing output", () => {
+    assertEquals(
+      formatRedisLogTarget("rediss://worker:REDACTED@example.com:6380/2?token=REDACTED"),
+      "rediss://example.com:6380/2",
+    );
+    assertEquals(formatRedisLogTarget("redis://localhost:6379"), "redis://localhost:6379");
+    assertEquals(
+      formatRedisLogTarget("redis://example.com/non-database-path"),
+      "redis://example.com",
+    );
+    assertEquals(formatRedisLogTarget("not a URL"), "<configured>");
+  });
+});

--- a/cli/commands/worker/command.test.ts
+++ b/cli/commands/worker/command.test.ts
@@ -7,13 +7,10 @@ describe("commands/worker/command", () => {
   it("removes Redis credentials and query values from user-facing output", () => {
     assertEquals(
       formatRedisLogTarget("rediss://worker:REDACTED@example.com:6380/2?token=REDACTED"),
-      "rediss://example.com:6380/2",
+      "<configured>",
     );
-    assertEquals(formatRedisLogTarget("redis://localhost:6379"), "redis://localhost:6379");
-    assertEquals(
-      formatRedisLogTarget("redis://example.com/non-database-path"),
-      "redis://example.com",
-    );
+    assertEquals(formatRedisLogTarget("redis://localhost:6379"), "<configured>");
+    assertEquals(formatRedisLogTarget("redis://example.com/non-database-path"), "<configured>");
     assertEquals(formatRedisLogTarget("not a URL"), "<configured>");
   });
 });

--- a/cli/commands/worker/command.test.ts
+++ b/cli/commands/worker/command.test.ts
@@ -10,6 +10,7 @@ describe("commands/worker/command", () => {
       "<configured>",
     );
     assertEquals(formatRedisLogTarget("redis://localhost:6379"), "<configured>");
+    assertEquals(formatRedisLogTarget("https://example.com/cache"), "<configured>");
     assertEquals(formatRedisLogTarget("redis://example.com/non-database-path"), "<configured>");
     assertEquals(formatRedisLogTarget("not a URL"), "<configured>");
   });

--- a/cli/commands/worker/command.ts
+++ b/cli/commands/worker/command.ts
@@ -12,6 +12,17 @@ import type { WorkerArgs } from "./handler.ts";
 
 export interface WorkerOptions extends WorkerArgs {}
 
+export function formatRedisLogTarget(redisUrl: string): string {
+  try {
+    const url = new URL(redisUrl);
+    if (url.protocol !== "redis:" && url.protocol !== "rediss:") return "<configured>";
+    const databasePath = /^\/\d+$/.test(url.pathname) ? url.pathname : "";
+    return `${url.protocol}//${url.host}${databasePath}`;
+  } catch {
+    return "<configured>";
+  }
+}
+
 export async function workerCommand(options: WorkerOptions): Promise<void> {
   showHeader();
 
@@ -26,7 +37,7 @@ export async function workerCommand(options: WorkerOptions): Promise<void> {
   );
 
   cliLogger.info("Starting workflow worker...");
-  cliLogger.info(`  Redis:       ${options.redisUrl}`);
+  cliLogger.info(`  Redis:       ${formatRedisLogTarget(options.redisUrl)}`);
   cliLogger.info(`  Executor:    ${options.executor}`);
   cliLogger.info(`  Concurrency: ${options.concurrency}`);
   cliLogger.info(`  Poll:        ${options.pollInterval}ms`);

--- a/cli/commands/worker/command.ts
+++ b/cli/commands/worker/command.ts
@@ -12,14 +12,8 @@ import type { WorkerArgs } from "./handler.ts";
 
 export interface WorkerOptions extends WorkerArgs {}
 
-export function formatRedisLogTarget(redisUrl: string): string {
-  try {
-    const url = new URL(redisUrl);
-    if (url.protocol !== "redis:" && url.protocol !== "rediss:") return "<configured>";
-    return "<configured>";
-  } catch {
-    return "<configured>";
-  }
+export function formatRedisLogTarget(_redisUrl: string): string {
+  return "<configured>";
 }
 
 export async function workerCommand(options: WorkerOptions): Promise<void> {

--- a/cli/commands/worker/command.ts
+++ b/cli/commands/worker/command.ts
@@ -16,8 +16,7 @@ export function formatRedisLogTarget(redisUrl: string): string {
   try {
     const url = new URL(redisUrl);
     if (url.protocol !== "redis:" && url.protocol !== "rediss:") return "<configured>";
-    const databasePath = /^\/\d+$/.test(url.pathname) ? url.pathname : "";
-    return `${url.protocol}//${url.host}${databasePath}`;
+    return "<configured>";
   } catch {
     return "<configured>";
   }


### PR DESCRIPTION
## Summary

- reject null, array, and scalar `task --config` JSON values
- describe local task discovery without printing an absolute project path
- strip credentials, query values, and non-database paths from worker Redis output
- include global `start` error stacks only when verbose output is enabled

## Stack

This PR is based on #4106 so the restored CLI integration lane verifies these command paths.

## Verification

- task command tests (2 steps passed)
- worker command and handler tests (3 steps passed)
- start command and handler tests (48 steps passed)
- `deno check` on all changed production modules
- `deno task lint` on changed files
- `deno task lint:cli-boundary`
- `deno task fmt:check`
- `git diff --check` against the stacked base