### PR TITLE
Remove local paths from MCP resources

### DIFF
--- a/cli/commands/start/command-help.ts
+++ b/cli/commands/start/command-help.ts
@@ -29,10 +29,10 @@ export const startHelp: CommandHelp = {
   notes: [
     "Veryfront supports two modes:",
     "",
-    "  Single project — run inside a project directory, or use --project <path>.",
+    "  Single project: run inside a project directory, or use --project <path>.",
     "  A project is any folder with an app/, pages/, or components/ directory.",
     "",
-    "  Workspace — run from a parent directory containing a projects/ folder.",
+    "  Workspace: run from a parent directory containing a projects/ folder.",
     "  Each subfolder in projects/ that has app/, pages/, or components/ is",
     "  auto-discovered and served. A project picker UI is shown at the root URL.",
     "",

--- a/cli/help/public-copy.test.ts
+++ b/cli/help/public-copy.test.ts
@@ -1,0 +1,10 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { COMMANDS } from "./command-definitions.ts";
+
+describe("CLI help public copy", () => {
+  it("uses ASCII punctuation", () => {
+    assertEquals(/[\u2013\u2014]/.test(JSON.stringify(COMMANDS)), false);
+  });
+});

--- a/cli/mcp/server.test.ts
+++ b/cli/mcp/server.test.ts
@@ -303,6 +303,27 @@ describe("cli/mcp/server", { sanitizeOps: false, sanitizeResources: false }, () 
       }
     });
 
+    it("should omit local skill directories from the skills resource", async () => {
+      const portNum = 19903;
+      server = new MCPDevServer({ httpPort: portNum });
+      server.start();
+      await waitForServerBind();
+
+      const response = await postMcp(portNum, {
+        jsonrpc: "2.0",
+        id: 42,
+        method: "resources/read",
+        params: { uri: "veryfront://skills" },
+      });
+      const data = await response.json();
+      const skills = JSON.parse(data.result.contents[0].text);
+
+      assertEquals(skills.length > 0, true);
+      for (const skill of skills) {
+        assertEquals(Object.hasOwn(skill, "directory"), false);
+      }
+    });
+
     it("should return prompts list", async () => {
       const portNum = 19880;
       server = new MCPDevServer({ httpPort: portNum });

--- a/cli/mcp/server.ts
+++ b/cli/mcp/server.ts
@@ -503,7 +503,6 @@ export class MCPDevServer {
             name: s.metadata.name,
             description: s.metadata.description,
             allowedTools: s.metadata.allowedTools,
-            directory: s.directory,
           }));
           return {
             contents: [{

--- a/cli/mcp/standalone.test.ts
+++ b/cli/mcp/standalone.test.ts
@@ -159,6 +159,21 @@ describe("mcp/standalone", () => {
       const names = skills.map((s: { name: string }) => s.name);
       assertEquals(names.includes("scaffold-app"), true);
       assertEquals(names.includes("deploy-safely"), true);
+      for (const skill of skills) {
+        assertEquals(Object.hasOwn(skill, "directory"), false);
+      }
+    });
+
+    it("uses ASCII punctuation in public MCP and CLI schema copy", async () => {
+      const server = new StandaloneMCPServer();
+      const [tools, resources, schema] = await Promise.all([
+        dispatch(server, "tools/list"),
+        dispatch(server, "resources/list"),
+        dispatch(server, "resources/read", { uri: "veryfront://schema" }),
+      ]);
+      const publicCopy = JSON.stringify([tools.result, resources.result, schema.result]);
+
+      assertEquals(/[\u2013\u2014]/.test(publicCopy), false);
     });
 
     it("resources/read unknown URI returns error", async () => {

--- a/cli/mcp/standalone.ts
+++ b/cli/mcp/standalone.ts
@@ -201,7 +201,6 @@ export class StandaloneMCPServer {
         name: s.metadata.name,
         description: s.metadata.description,
         allowedTools: s.metadata.allowedTools,
-        directory: s.directory,
       }));
       return {
         contents: [{

--- a/cli/mcp/tools.test.ts
+++ b/cli/mcp/tools.test.ts
@@ -39,6 +39,13 @@ describe("mcp/tools", () => {
       assertEquals(names.length, uniqueNames.size, "Tool names must be unique");
     });
 
+    it("uses ASCII punctuation in public tool copy", () => {
+      const publicCopy = JSON.stringify(
+        allTools.map(({ title, description }) => ({ title, description })),
+      );
+      assertEquals(/[\u2013\u2014]/.test(publicCopy), false);
+    });
+
     it("every tool has title and annotations", () => {
       for (const tool of allTools) {
         assertExists(tool.title, `Tool ${tool.name} missing title`);

--- a/cli/mcp/tools.ts
+++ b/cli/mcp/tools.ts
@@ -57,7 +57,7 @@ export const vfGetErrors: MCPTool<GetErrorsInput, DevError[]> = {
   title: "Get Errors",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need to check for compilation, runtime, bundle, HMR, or module errors in the dev server. Returns error details including file path, line number, and message. Do not use for server logs — use vf_get_logs instead.",
+    "Use this when you need to check for compilation, runtime, bundle, HMR, or module errors in the dev server. Returns error details including file path, line number, and message. Do not use for server logs. Use vf_get_logs instead.",
   inputSchema: getErrorsInput,
   execute: async (input) => {
     const errors = getErrorCollector().getAll({
@@ -98,7 +98,7 @@ export const vfGetLogs: MCPTool<GetLogsInput, LogEntry[]> = {
   title: "Get Logs",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need to inspect server logs to understand runtime behavior or debug request handling. Returns log entries with timestamp, level, source, and message. Do not use for build/compile errors — use vf_get_errors instead.",
+    "Use this when you need to inspect server logs to understand runtime behavior or debug request handling. Returns log entries with timestamp, level, source, and message. Do not use for build/compile errors. Use vf_get_errors instead.",
   inputSchema: getLogsInput,
   execute: async (input) => {
     return getLogBuffer().query({
@@ -137,7 +137,7 @@ export const vfClearCache: MCPTool<ClearCacheInput, ClearCacheOutput> = {
     openWorldHint: false,
   },
   description:
-    "Use this when the dev server shows stale modules or MDX content. Returns the list of cleared cache directories. Do not use to fix code errors — those require code changes.",
+    "Use this when the dev server shows stale modules or MDX content. Returns the list of cleared cache directories. Do not use to fix code errors. Code errors require code changes.",
   inputSchema: clearCacheInput,
   execute: async (input) => {
     const fs = createFileSystem();
@@ -181,7 +181,7 @@ export function createVfGetStatus(
     title: "Server Status",
     annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
     description:
-      "Use this when you need a quick summary of the dev server's uptime, error counts, and warning counts. Note: always reports running=true when the MCP server is reachable. Do not use for detailed error info — use vf_get_errors instead.",
+      "Use this when you need a quick summary of the dev server's uptime, error counts, and warning counts. Note: always reports running=true when the MCP server is reachable. Do not use for detailed error info. Use vf_get_errors instead.",
     inputSchema: getStatusInput,
     execute: async () => {
       const errors = getErrorCollector();
@@ -232,7 +232,7 @@ export const vfClearErrors: MCPTool<ClearErrorsInput, ClearErrorsOutput> = {
     openWorldHint: false,
   },
   description:
-    "Use this when you need to clear accumulated errors from the error collector, optionally filtering by file or type. Returns the number of cleared errors. Do not use for viewing errors — use vf_get_errors instead.",
+    "Use this when you need to clear accumulated errors from the error collector, optionally filtering by file or type. Returns the number of cleared errors. Do not use for viewing errors. Use vf_get_errors instead.",
   inputSchema: clearErrorsInput,
   execute: async (input) => {
     const collector = getErrorCollector();

--- a/cli/mcp/tools/bootstrap-tool.ts
+++ b/cli/mcp/tools/bootstrap-tool.ts
@@ -43,7 +43,7 @@ export const vfBootstrap: MCPTool<BootstrapInput, BootstrapResult> = {
     "Returns project structure, coding conventions, current errors, and server status. " +
     "Equivalent to calling vf_get_project_context + vf_get_conventions + vf_get_errors + " +
     "vf_get_status separately, but in a single round-trip. " +
-    "Do not use repeatedly — call once at session bootstrap.",
+    "Do not use repeatedly. Call once at session bootstrap.",
   inputSchema: bootstrapInput,
   execute: async (input) => {
     const [project, conventions] = await Promise.all([

--- a/cli/mcp/tools/build-tool.ts
+++ b/cli/mcp/tools/build-tool.ts
@@ -73,8 +73,8 @@ export const vfBuild: MCPTool<BuildInput, BuildResult> = {
   description: "Use this when you need to run a production build for the current project. " +
     "Bundles, optimises, and writes output to the dist directory. " +
     "Use dryRun=true to preview the build without writing files. " +
-    "Do not use for development — use the dev server tools instead. " +
-    "Do not use for lint checks — use vf_run_lint instead.",
+    "Do not use for development. Use the dev server tools instead. " +
+    "Do not use for lint checks. Use vf_run_lint instead.",
   inputSchema: buildInput,
   execute: (input) =>
     withSpan(

--- a/cli/mcp/tools/catalog-tools.ts
+++ b/cli/mcp/tools/catalog-tools.ts
@@ -242,7 +242,7 @@ export const vfListExamples: MCPTool<ListExamplesInput, ExampleInfo[]> = {
   title: "List Examples",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need to browse example projects that demonstrate Veryfront features and integrations. Returns an array of example info with name, description, and category. Do not use for project templates — use vf_list_templates instead.",
+    "Use this when you need to browse example projects that demonstrate Veryfront features and integrations. Returns an array of example info with name, description, and category. Do not use for project templates. Use vf_list_templates instead.",
   inputSchema: listExamplesInput,
   execute: () => Promise.resolve(EXAMPLES),
 };
@@ -261,7 +261,7 @@ export const vfListTemplates: MCPTool<ListTemplatesInput, TemplateInfo[]> = {
   title: "List Templates",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: true }, // openWorldHint: templates come from remote catalog API
   description:
-    "Use this when you need to list available project templates for creating new projects. Returns an array of template info with name and description. Do not use for example projects — use vf_list_examples instead.",
+    "Use this when you need to list available project templates for creating new projects. Returns an array of template info with name and description. Do not use for example projects. Use vf_list_examples instead.",
   inputSchema: listTemplatesInput,
   execute: () => Promise.resolve(TEMPLATES),
 };
@@ -301,7 +301,7 @@ export const vfListIntegrations: MCPTool<ListIntegrationsInput, IntegrationInfo[
   title: "List Integrations",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need to list available service integrations (Gmail, Slack, GitHub, etc.) that can be added to AI projects. Returns an array of integration info with name, category, and description. Do not use for adding integrations to a project — use vf_create_project with the integrations parameter instead.",
+    "Use this when you need to list available service integrations (Gmail, Slack, GitHub, etc.) that can be added to AI projects. Returns an array of integration info with name, category, and description. Do not use for adding integrations to a project. Use vf_create_project with the integrations parameter instead.",
   inputSchema: listIntegrationsInput,
   execute: (input) => {
     const { category } = input;
@@ -325,7 +325,7 @@ export const vfListUsecases: MCPTool<ListUsecasesInput, UsecaseInfo[]> = {
   title: "List Use Cases",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need to browse pre-configured use-case templates with recommended integrations and UI layouts. Returns an array of use-case info with name, integrations, and layout. Do not use for raw templates — use vf_list_templates instead.",
+    "Use this when you need to browse pre-configured use-case templates with recommended integrations and UI layouts. Returns an array of use-case info with name, integrations, and layout. Do not use for raw templates. Use vf_list_templates instead.",
   inputSchema: listUsecasesInput,
   execute: () => Promise.resolve(USECASES),
 };
@@ -384,7 +384,7 @@ export const vfCreateProject: MCPTool<CreateProjectInput, CreateProjectResult> =
   title: "Create Project",
   annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
   description:
-    "Use this when you need to create a new Veryfront project from a template. Returns the project directory and next steps. Do not use for scaffolding individual files — use vf_scaffold instead.",
+    "Use this when you need to create a new Veryfront project from a template. Returns the project directory and next steps. Do not use for scaffolding individual files. Use vf_scaffold instead.",
   inputSchema: createProjectInput,
   execute: (input) =>
     withSpan(

--- a/cli/mcp/tools/cicd-tools.ts
+++ b/cli/mcp/tools/cicd-tools.ts
@@ -1,5 +1,5 @@
 /**
- * CI/CD MCP tools — placeholder
+ * CI/CD MCP tools placeholder
  *
  * These tools require backend API support that is not yet available.
  * They were previously registered as stubs returning "not_implemented",

--- a/cli/mcp/tools/dev-tools.ts
+++ b/cli/mcp/tools/dev-tools.ts
@@ -130,7 +130,7 @@ export const vfGetDebugContext: MCPTool<GetDebugContextInput, DebugContextResult
   title: "Debug Context",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need the dev server's debug context including project slug, environment, request context mode, and multi-project configuration. Returns project info and server mode. Do not use for error details — use vf_get_errors instead.",
+    "Use this when you need the dev server's debug context including project slug, environment, request context mode, and multi-project configuration. Returns project info and server mode. Do not use for error details. Use vf_get_errors instead.",
   inputSchema: getDebugContextInput,
   execute: (input) =>
     withSpan(
@@ -194,7 +194,7 @@ export const vfTriggerHmr: MCPTool<TriggerHmrInput, TriggerHmrResult> = {
     openWorldHint: false,
   },
   description:
-    "Use this when you need to force an HMR update for a specific file path. Sends a WebSocket reload notification to connected browsers. Returns success status and active listener count. Do not use if no browser is connected — check vf_get_flywheel_status first.",
+    "Use this when you need to force an HMR update for a specific file path. Sends a WebSocket reload notification to connected browsers. Returns success status and active listener count. Do not use if no browser is connected. Check vf_get_flywheel_status first.",
   inputSchema: triggerHmrInput,
   execute: (input) => {
     const metrics = ReloadNotifier.getMetrics();
@@ -254,7 +254,7 @@ export const vfPreviewRoute: MCPTool<PreviewRouteInput, PreviewRouteResult> = {
   title: "Preview Route",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need to test-render a route and inspect the response. Returns rendered output, HTTP status, and render time. Note: API routes may have side effects. Do not use for listing routes — use vf_list_routes instead.",
+    "Use this when you need to test-render a route and inspect the response. Returns rendered output, HTTP status, and render time. Note: API routes may have side effects. Do not use for listing routes. Use vf_list_routes instead.",
   inputSchema: previewRouteInput,
   execute: (input) =>
     withSpan(
@@ -340,7 +340,7 @@ export const vfWaitForReady: MCPTool<WaitForReadyInput, WaitForReadyResult> = {
   title: "Wait for Ready",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need to wait for the dev server to become ready after restart. Polls the health endpoint until responsive. Returns success status and elapsed time. Do not use for error counts or uptime — use vf_get_status instead.",
+    "Use this when you need to wait for the dev server to become ready after restart. Polls the health endpoint until responsive. Returns success status and elapsed time. Do not use for error counts or uptime. Use vf_get_status instead.",
   inputSchema: waitForReadyInput,
   execute: (input) =>
     withSpan(
@@ -433,7 +433,7 @@ export const vfGetFlywheelStatus: MCPTool<GetFlywheelStatusInput, FlywheelStatus
   title: "Flywheel Status",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need a comprehensive status overview combining server health, error counts, and HMR statistics. Returns server status, error/log counts, and HMR metrics in one response. Do not use for detailed error or log content — use vf_get_errors or vf_get_logs instead.",
+    "Use this when you need a comprehensive status overview combining server health, error counts, and HMR statistics. Returns server status, error/log counts, and HMR metrics in one response. Do not use for detailed error or log content. Use vf_get_errors or vf_get_logs instead.",
   inputSchema: getFlywheelStatusInput,
   execute: (input) =>
     withSpan(

--- a/cli/mcp/tools/introspection-tools.ts
+++ b/cli/mcp/tools/introspection-tools.ts
@@ -16,7 +16,7 @@ const vfGetSchema: MCPTool = {
   title: "Get CLI Schema",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need to discover available CLI commands, their arguments, and flags. Returns the command schema as JSON. Do not use for project info — use vf_get_project_info instead.",
+    "Use this when you need to discover available CLI commands, their arguments, and flags. Returns the command schema as JSON. Do not use for project info. Use vf_get_project_info instead.",
   inputSchema: getSchemaInput,
   execute: async (input: { command?: string; category?: string }) => {
     if (input.command) {
@@ -33,7 +33,7 @@ const vfGetProjectInfo: MCPTool = {
   title: "Get Project Info",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need project metadata including project slug, version, and environment. Returns slug, version, and environment config. Do not use for CLI commands — use vf_get_schema instead.",
+    "Use this when you need project metadata including project slug, version, and environment. Returns slug, version, and environment config. Do not use for CLI commands. Use vf_get_schema instead.",
   inputSchema: getProjectInfoInput,
   execute: async () => {
     const { getEnvironmentConfig } = await import("veryfront/config");

--- a/cli/mcp/tools/project-tools.ts
+++ b/cli/mcp/tools/project-tools.ts
@@ -44,7 +44,7 @@ export const vfListRoutes: MCPTool<ListRoutesInput, RouteInfo[]> = {
   title: "List Routes",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need to discover all routes in the project including pages, API routes, layouts, error, loading, and not-found routes. Returns an array of route info with path, type, and file. Do not use for rendering a route — use vf_preview_route instead.",
+    "Use this when you need to discover all routes in the project including pages, API routes, layouts, error, loading, and not-found routes. Returns an array of route info with path, type, and file. Do not use for rendering a route. Use vf_preview_route instead.",
   inputSchema: listRoutesInput,
   execute: (input) =>
     withSpan(
@@ -191,7 +191,7 @@ export const vfGetProjectContext: MCPTool<GetProjectContextInput, ProjectContext
   title: "Project Context",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need to understand the project structure, conventions, and capabilities at the start of a coding session. Also returns route information. Do not use for detailed per-route rendering — use vf_preview_route instead.",
+    "Use this when you need to understand the project structure, conventions, and capabilities at the start of a coding session. Also returns route information. Do not use for detailed per-route rendering. Use vf_preview_route instead.",
   inputSchema: getProjectContextInput,
   execute: (input) =>
     withSpan(
@@ -272,7 +272,7 @@ export const vfGetComponentTree: MCPTool<GetComponentTreeInput, ComponentTreeRes
   title: "Component Tree",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need to analyze the component hierarchy for a specific route including layouts, providers, and nested components. Returns the component tree structure. Do not use for listing all routes — use vf_list_routes instead.",
+    "Use this when you need to analyze the component hierarchy for a specific route including layouts, providers, and nested components. Returns the component tree structure. Do not use for listing all routes. Use vf_list_routes instead.",
   inputSchema: getComponentTreeInput,
   execute: (input) =>
     withSpan(
@@ -433,7 +433,7 @@ export const vfListLocalProjects: MCPTool<ListLocalProjectsInput, LocalProjectIn
   title: "List Local Projects",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need to discover Veryfront projects on the local filesystem by scanning for veryfront.config.ts files. Returns project info including template type and integrations. Do not use for project structure details — use vf_get_project_context instead.",
+    "Use this when you need to discover Veryfront projects on the local filesystem by scanning for veryfront.config.ts files. Returns project info including template type and integrations. Do not use for project structure details. Use vf_get_project_context instead.",
   inputSchema: listLocalProjectsInput,
   execute: (input) =>
     withSpan(

--- a/cli/mcp/tools/scaffold-tools.ts
+++ b/cli/mcp/tools/scaffold-tools.ts
@@ -224,7 +224,7 @@ export const vfGetConventions: MCPTool<GetConventionsInput, Convention[]> = {
   title: "Get Conventions",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need Veryfront coding conventions and best practices for routing, API, components, AI, or styling. Do not use for project structure — use vf_get_project_context instead.",
+    "Use this when you need Veryfront coding conventions and best practices for routing, API, components, AI, or styling. Do not use for project structure. Use vf_get_project_context instead.",
   inputSchema: getConventionsInput,
   execute: (input) => {
     if (input.topic === "all") return Promise.resolve(Object.values(CONVENTIONS));

--- a/cli/mcp/tools/skill-tools.ts
+++ b/cli/mcp/tools/skill-tools.ts
@@ -97,7 +97,7 @@ export const vfGetSkills: MCPTool<GetSkillsInput, GetSkillsResult> = {
   title: "Get Skills",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need to discover available Agent Skills or load a specific skill's procedural knowledge. Returns skill names and descriptions, or full skill content when name is provided. Do not use for skill reference docs — use vf_get_skill_reference instead.",
+    "Use this when you need to discover available Agent Skills or load a specific skill's procedural knowledge. Returns skill names and descriptions, or full skill content when name is provided. Do not use for skill reference docs. Use vf_get_skill_reference instead.",
   inputSchema: getSkillsInput,
   execute: (input) =>
     withSpan(
@@ -178,7 +178,7 @@ export const vfGetSkillReference: MCPTool<GetSkillReferenceInput, GetSkillRefere
   title: "Get Skill Reference",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need to load a specific reference document from a skill. Returns the document content as text. Do not use for skill discovery — use vf_get_skills instead.",
+    "Use this when you need to load a specific reference document from a skill. Returns the document content as text. Do not use for skill discovery. Use vf_get_skills instead.",
   inputSchema: getSkillReferenceInput,
   execute: async (input) => {
     const fs = getFs();

--- a/src/issues/core.ts
+++ b/src/issues/core.ts
@@ -50,7 +50,7 @@ export function parseFrontmatter(content: string): { frontmatter: string; body: 
  * block arrays (`-` items). Keys may contain letters, digits, `_` and `-`.
  * Values may contain colons (e.g. URLs) since only the first `:` splits the
  * line. Nested maps, multi-line/block scalars, anchors, and quoted keys are
- * NOT supported — use a real YAML parser if the schema grows beyond this.
+ * NOT supported. Use a real YAML parser if the schema grows beyond this.
  */
 export function parseYaml(yaml: string): Record<string, unknown> {
   const result: Record<string, unknown> = {};

--- a/src/issues/mcp.ts
+++ b/src/issues/mcp.ts
@@ -63,7 +63,7 @@ const issuesCreate: MCPTool<IssuesCreateInput, Issue> = {
   annotations: { readOnlyHint: false, destructiveHint: false, openWorldHint: false },
   description: "Use this when you need to create a new issue, task, or plan as a markdown file. " +
     "Use prefix 'TASK' for small work items, 'PLAN' for proposals/RFCs, 'ISSUE' for bugs/features. " +
-    "Returns the created issue. Do not use for updating — use issues_update instead.",
+    "Returns the created issue. Do not use for updating. Use issues_update instead.",
   inputSchema: issuesCreateInput,
   execute: async (input) => {
     const manager = getManager(input.projectDir);
@@ -96,7 +96,7 @@ const issuesGet: MCPTool<IssuesGetInput, Issue | null> = {
   title: "Get Issue",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description:
-    "Use this when you need to retrieve a specific issue by its ID. Returns the issue or null if not found. Do not use for listing — use issues_list instead.",
+    "Use this when you need to retrieve a specific issue by its ID. Returns the issue or null if not found. Do not use for listing. Use issues_list instead.",
   inputSchema: issuesGetInput,
   execute: async (input) => {
     const manager = getManager(input.projectDir);
@@ -136,7 +136,7 @@ const issuesUpdate: MCPTool<IssuesUpdateInput, Issue | null> = {
   },
   description:
     "Use this when you need to modify an existing issue. Only provided fields are updated. " +
-    "Returns the updated issue or null if not found. Do not use to close — use issues_close instead.",
+    "Returns the updated issue or null if not found. Do not use to close. Use issues_close instead.",
   inputSchema: issuesUpdateInput,
   execute: async (input) => {
     const manager = getManager(input.projectDir);
@@ -187,7 +187,7 @@ const issuesList: MCPTool<IssuesListInput, IssuesListOutput> = {
   title: "List Issues",
   annotations: { readOnlyHint: true, idempotentHint: true, openWorldHint: false },
   description: "Use this when you need to find issues matching criteria. " +
-    "Returns matching issues and total count. Do not use to get a single known issue — use issues_get instead.",
+    "Returns matching issues and total count. Do not use to get a single known issue. Use issues_get instead.",
   inputSchema: issuesListInput,
   execute: async (input) => {
     const manager = getManager(input.projectDir);
@@ -227,7 +227,7 @@ const issuesClose: MCPTool<IssuesCloseInput, Issue | null> = {
     openWorldHint: false,
   },
   description:
-    "Use this when you need to close an issue. Returns the updated issue or null if not found. Do not use to delete — use issues_delete instead.",
+    "Use this when you need to close an issue. Returns the updated issue or null if not found. Do not use to delete. Use issues_delete instead.",
   inputSchema: issuesCloseInput,
   execute: async (input) => {
     const manager = getManager(input.projectDir);
@@ -264,7 +264,7 @@ const issuesDelete: MCPTool<IssuesDeleteInput, IssuesDeleteOutput> = {
   description:
     "Use this when you need to permanently delete an issue. Returns {deleted: true/false}. " +
     "WARNING: this is irreversible and cannot be undone. Prefer issues_close unless permanent deletion is explicitly requested. " +
-    "Do not use to close — use issues_close instead.",
+    "Do not use to close. Use issues_close instead.",
   inputSchema: issuesDeleteInput,
   execute: async (input) => {
     const manager = getManager(input.projectDir);


### PR DESCRIPTION
## Summary

- remove filesystem directory fields from both standalone and HTTP `veryfront://skills` resources
- enforce ASCII punctuation across registered CLI help and MCP tool copy
- update affected tool guidance to direct sentence-case instructions

## Stack

This PR is based on #4107 as the final focused slice of the CLI safety batch.

## Verification

- standalone MCP suite (29 steps passed)
- HTTP MCP server suite (47 steps passed)
- MCP tool registry suite (33 steps passed)
- CLI public-copy test (1 step passed)
- CLI schema suite (13 steps passed)
- issues core suite (35 passed)
- `deno check` on changed production modules
- `deno task lint` on changed files
- `deno task lint:cli-boundary`
- `deno task fmt:check`
- `deno task docs:api-reference:check`
- `git diff --check` against the stacked base