### PR TITLE
test(agent/runtime): make weak assertions bite across the agent runtime

### DIFF
--- a/src/agent/runtime/ag-ui-contract.test.ts
+++ b/src/agent/runtime/ag-ui-contract.test.ts
@@ -104,6 +104,35 @@ describe("agent/runtime-ag-ui-contract", () => {
     assertEquals("state" in normalized, false);
   });
 
+  it("keeps plain-object state while applying runtime request defaults", () => {
+    const normalized = normalizeAgUiRuntimeRequest(
+      getAgUiRuntimeRequestSchema().parse({
+        threadId: crypto.randomUUID(),
+        runId: "run_1",
+        state: { phase: "draft" },
+        messages: [
+          {
+            id: "user_1",
+            role: "user",
+            content: "Hello",
+          },
+        ],
+        context: [],
+        tools: [],
+      }),
+      {
+        runId: "run_override",
+      },
+    );
+
+    assertEquals(
+      normalized.state,
+      { phase: "draft" },
+      "plain-object state must survive normalization",
+    );
+    assertEquals(normalized.runId, "run_override", "defaults must still override runId");
+  });
+
   it("returns a 400 response for malformed runtime AG-UI JSON bodies", async () => {
     const result = await parseAgUiRuntimeRequestOrError(
       new Request("http://localhost/api/ag-ui", {

--- a/src/agent/runtime/agent-definition-files.test.ts
+++ b/src/agent/runtime/agent-definition-files.test.ts
@@ -110,18 +110,39 @@ Draft concise copy.
 
 Deno.test("runtime agent definition file helpers reject traversal-prone names", () => {
   withTempDir((rootDir) => {
-    assertThrows(() =>
-      resolveRuntimeAgentDefinitionsDir({
-        baseDir: rootDir,
-        id: "../escape",
-      })
+    const agentsDir = resolve(rootDir, "agents");
+    Deno.mkdirSync(agentsDir, { recursive: true });
+    // Put a real definition at the traversal target so a missing-file error
+    // cannot masquerade as the schema guard firing.
+    Deno.writeTextFileSync(
+      resolve(rootDir, "support.md"),
+      "---\nname: Support\n---\nHelp users.",
     );
-    assertThrows(() =>
-      loadRuntimeAgentMarkdownDefinitionFromFile({
-        agentsDir: rootDir,
-        id: "support",
-        fileName: "../support.md",
-      })
+    Deno.writeTextFileSync(
+      resolve(rootDir, "escape.md"),
+      "---\nname: Escape\n---\nHelp users.",
+    );
+
+    assertThrows(
+      () =>
+        resolveRuntimeAgentDefinitionsDir({
+          baseDir: agentsDir,
+          id: "../escape",
+        }),
+      Error,
+      "id",
+      "traversal-prone id must fail schema validation",
+    );
+    assertThrows(
+      () =>
+        loadRuntimeAgentMarkdownDefinitionFromFile({
+          agentsDir,
+          id: "support",
+          fileName: "../support.md",
+        }),
+      Error,
+      "fileName",
+      "traversal-prone fileName must fail schema validation, not file IO",
     );
   });
 });

--- a/src/agent/runtime/agent-definition.test.ts
+++ b/src/agent/runtime/agent-definition.test.ts
@@ -169,6 +169,29 @@ describe("createRuntimeAgentSystemMessages", () => {
     assertEquals(result[0]?.content, "Keep the authored instructions.");
   });
 
+  it("forwards the agent's provider alias so an authored cache breakpoint is recognized", () => {
+    const result = createRuntimeAgentSystemMessages({
+      agent: {
+        id: "bedrock-agent",
+        name: "Bedrock",
+        description: "d",
+        instructions: "ignored",
+        model: "bedrock/claude-sonnet",
+        system: [{
+          role: "system",
+          content: "Base",
+          providerOptions: { bedrock: { cacheControl: { type: "ephemeral" } } },
+        }],
+      },
+    });
+
+    assertEquals(
+      result[0]?.providerOptions,
+      { bedrock: { cacheControl: { type: "ephemeral" } } },
+      "the authored bedrock breakpoint is retained and no duplicate anthropic breakpoint is appended",
+    );
+  });
+
   it("keeps the prompt prefix static and moves runtime blocks before the authored tail", () => {
     const result = createRuntimeAgentSystemMessages({
       agent: {

--- a/src/agent/runtime/agent-delegation.test.ts
+++ b/src/agent/runtime/agent-delegation.test.ts
@@ -196,6 +196,11 @@ describe("invoke_agent", () => {
       "published child events must carry the parent toolCallId",
     );
     assertEquals(parsed?.agentId, "writer", "published child events must name the invoked agent");
+    assertEquals(
+      parsed?.event,
+      { type: "text-delta", id: "child-1", delta: "hi" },
+      "published child events must preserve the child stream payload",
+    );
   });
 
   it("reports an error when the invoked agent id is unknown", async () => {

--- a/src/agent/runtime/agent-delegation.test.ts
+++ b/src/agent/runtime/agent-delegation.test.ts
@@ -15,6 +15,7 @@ import {
 import { runWithExactSourceIntegrationPolicy } from "#veryfront/integrations/source-policy-context.ts";
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
 import { getAvailableTools } from "./tool-helpers.ts";
+import { parseInvokeAgentStreamValue } from "#veryfront/chat/invoke-agent-stream.ts";
 
 it("buildAgentDelegateTools exposes one tool per delegate, excluding self and dupes", () => {
   const tools = buildAgentDelegateTools({
@@ -149,6 +150,71 @@ describe("invoke_agent", () => {
       'Draft a concise reply.\n\n<structured_context>\n{"case_id":"500-test"}\n</structured_context>',
     );
     assertEquals(result, { text: "drafted copy", toolCalls: 0, status: "completed" });
+  });
+
+  it("publishes child stream events to the parent tool call", async () => {
+    const writer = {
+      id: "writer",
+      config: {},
+      stream: (input: { onFinish?: (response: unknown) => void }) => {
+        input.onFinish?.({ text: "hi", toolCalls: [], status: "completed" });
+        return Promise.resolve({
+          toDataStreamResponse: () =>
+            new Response(
+              'data: {"type":"text-delta","id":"child-1","delta":"hi"}\n\n',
+              { headers: { "Content-Type": "text/event-stream" } },
+            ),
+        });
+      },
+    } as unknown as Agent;
+    const published: unknown[] = [];
+    const invokeAgent = createInvokeAgentTool({
+      selfId: "orchestrator",
+      resolveAgent: (id) => id === "writer" ? writer : undefined,
+    });
+
+    await invokeAgent.execute({
+      agent_id: "writer",
+      description: "Draft reply",
+      prompt: "Draft it.",
+    }, {
+      toolCallId: "call-1",
+      publishDataEvent: (event) => {
+        published.push(event.value);
+      },
+    });
+
+    assertEquals(
+      published.length >= 1,
+      true,
+      "invoke_agent must publish child stream events to the parent tool call",
+    );
+    const parsed = parseInvokeAgentStreamValue(published[0]);
+    assertEquals(
+      parsed?.toolCallId,
+      "call-1",
+      "published child events must carry the parent toolCallId",
+    );
+    assertEquals(parsed?.agentId, "writer", "published child events must name the invoked agent");
+  });
+
+  it("reports an error when the invoked agent id is unknown", async () => {
+    const invokeAgent = createInvokeAgentTool({
+      selfId: "orchestrator",
+      resolveAgent: () => undefined,
+    });
+
+    const result = await invokeAgent.execute({
+      agent_id: "ghost",
+      description: "Draft reply",
+      prompt: "Draft it.",
+    });
+
+    assertEquals(
+      result,
+      { text: 'Agent "ghost" is not available.', toolCalls: 0, status: "error" },
+      "an unresolvable agent_id must return a recoverable error result, not throw",
+    );
   });
 
   it("rejects self-invocation", async () => {

--- a/src/agent/runtime/agent-invocation-contract.test.ts
+++ b/src/agent/runtime/agent-invocation-contract.test.ts
@@ -138,13 +138,32 @@ describe("agent/runtime-agent-invocation-contract", () => {
   });
 
   it("requires an immutable release for environment agent sources", () => {
-    assertThrows(() =>
-      RuntimeAgentRunInvocationSchema.parse(createInvocation({
-        agentSource: {
-          type: "environment",
-          environmentName: "Production",
+    const unpinned = createInvocation({
+      run: {
+        ...createInvocation().run,
+        project: {
+          projectId,
+          projectSlug: "demo-project",
+          runtimeTargetKind: "environment",
+          runtimeTargetEnvironmentId: environmentId,
         },
-      }))
+      },
+      agentSource: {
+        type: "environment",
+        environmentName: "Production",
+      },
+    });
+    assertThrows(
+      () => RuntimeAgentRunInvocationSchema.parse(unpinned),
+      Error,
+      "releaseId",
+      "environment agent sources must be pinned to an immutable release",
+    );
+    const unpinnedResult = RuntimeAgentRunInvocationSchema.safeParse(unpinned);
+    assertEquals(
+      unpinnedResult.success ? undefined : unpinnedResult.issues[0]?.path,
+      ["agentSource", "releaseId"],
+      "the only rejection must be the missing releaseId, not the target binding rule",
     );
 
     const parsed = RuntimeAgentRunInvocationSchema.parse(createInvocation({
@@ -191,9 +210,76 @@ describe("agent/runtime-agent-invocation-contract", () => {
     );
   });
 
+  it("rejects a release agent source outside a main-branch runtime target", () => {
+    assertThrows(
+      () =>
+        RuntimeAgentRunInvocationSchema.parse(createInvocation({
+          agentSource: { type: "release", releaseId: "release-1" },
+        })),
+      Error,
+      "release agent source requires a main-branch runtime target",
+      "a release source must not bind to a preview branch target",
+    );
+
+    assertThrows(
+      () =>
+        RuntimeAgentRunInvocationSchema.parse(createInvocation({
+          run: {
+            ...createInvocation().run,
+            project: {
+              projectId,
+              projectSlug: "demo-project",
+              runtimeTargetKind: "environment",
+              runtimeTargetEnvironmentId: environmentId,
+            },
+          },
+          agentSource: { type: "release", releaseId: "release-1" },
+        })),
+      Error,
+      "release agent source requires a main-branch runtime target",
+      "a release source must not bind to an environment target",
+    );
+  });
+
+  it("accepts a release agent source on a main-branch runtime target", () => {
+    const parsed = RuntimeAgentRunInvocationSchema.parse(createInvocation({
+      run: {
+        ...createInvocation().run,
+        project: { projectId, projectSlug: "demo-project" },
+      },
+      agentSource: { type: "release", releaseId: "release-1" },
+    }));
+
+    assertEquals(
+      parsed.agentSource,
+      { type: "release", releaseId: "release-1" },
+      "a release source must bind to a main-branch target",
+    );
+    const request = buildRuntimeAgentControlPlaneStreamRequestFromInvocation(parsed);
+    assertEquals(
+      request.agentSource,
+      { type: "release", releaseId: "release-1" },
+      "the release source must reach the control-plane request unchanged",
+    );
+  });
+
   it("requires an exact source for every runtime invocation", () => {
-    assertThrows(() =>
-      RuntimeAgentRunInvocationSchema.parse(createInvocation({ agentSource: undefined }))
+    const result = RuntimeAgentRunInvocationSchema.safeParse(
+      createInvocation({ agentSource: undefined }),
+    );
+    assertEquals(
+      result.success,
+      false,
+      "an invocation without an agentSource must be rejected by validation",
+    );
+    assertEquals(
+      result.success
+        ? false
+        : result.issues.some((issue) =>
+          issue.path.join(".") === "agentSource" && issue.code === "invalid_type"
+        ),
+      true,
+      "a missing agentSource must surface as an invalid_type issue on agentSource, not a refinement crash",
     );
   });
 

--- a/src/agent/runtime/agent-invocation-contract.test.ts
+++ b/src/agent/runtime/agent-invocation-contract.test.ts
@@ -161,8 +161,8 @@ describe("agent/runtime-agent-invocation-contract", () => {
     );
     const unpinnedResult = RuntimeAgentRunInvocationSchema.safeParse(unpinned);
     assertEquals(
-      unpinnedResult.success ? undefined : unpinnedResult.issues[0]?.path,
-      ["agentSource", "releaseId"],
+      unpinnedResult.success ? [] : unpinnedResult.issues.map((issue) => issue.path),
+      [["agentSource", "releaseId"]],
       "the only rejection must be the missing releaseId, not the target binding rule",
     );
 

--- a/src/agent/runtime/agent-loop-skill-state.test.ts
+++ b/src/agent/runtime/agent-loop-skill-state.test.ts
@@ -142,33 +142,47 @@ describe("src/agent/runtime AgentLoopSkillState", () => {
   });
 
   describe("markFormInputSubmitted", () => {
-    it("narrows the active policy and sets the flag when submitted is true", () => {
+    it("sets the flag and leaves the policy untouched when submitted is true", () => {
       const state = AgentLoopSkillState.hydrate(
         [
           loadSkillResultMessage({
             skillId: "review",
             instructions: "# Review",
             allowedTools: ["Read", "form_input"],
-            references: [],
-            scripts: [],
+            references: ["references/notes.md"],
+            scripts: ["scripts/check.sh"],
           }),
         ],
         undefined,
       );
-      assertEquals(state.hasSubmittedFormInput, false);
+      assertEquals(state.hasSubmittedFormInput, false, "hydrated history has no submission");
 
       state.markFormInputSubmitted(true);
-      assertEquals(state.hasSubmittedFormInput, true);
+      assertEquals(state.hasSubmittedFormInput, true, "a submission must set the flag");
+      assertEquals(
+        state.activeSkillToolAvailability,
+        {
+          hasActiveSkill: true,
+          references: ["references/notes.md"],
+          scripts: ["scripts/check.sh"],
+        },
+        "marking a form submission must leave the active skill policy untouched",
+      );
+      assertEquals(
+        state.activeSkillId,
+        "review",
+        "marking a form submission must not deactivate the skill",
+      );
     });
 
-    it("updates the policy without setting the flag when submitted is false", () => {
+    it("leaves the flag and policy untouched when submitted is false", () => {
       const state = AgentLoopSkillState.hydrate(
         [
           loadSkillResultMessage({
             skillId: "review",
             instructions: "# Review",
             allowedTools: ["Read", "form_input"],
-            references: [],
+            references: ["references/notes.md"],
             scripts: [],
           }),
         ],
@@ -176,25 +190,48 @@ describe("src/agent/runtime AgentLoopSkillState", () => {
       );
 
       state.markFormInputSubmitted(false);
-      assertEquals(state.hasSubmittedFormInput, false);
+      assertEquals(state.hasSubmittedFormInput, false, "a non-submission must not set the flag");
+      assertEquals(
+        state.activeSkillToolAvailability,
+        { hasActiveSkill: true, references: ["references/notes.md"], scripts: [] },
+        "a non-submission must leave the active skill policy untouched",
+      );
+      assertEquals(state.activeSkillId, "review", "a non-submission must not deactivate the skill");
     });
 
-    it("leaves the policy untouched for non-form_input tool results", () => {
+    it("keeps hydrated delegation overrides and availability after a submission", () => {
       const state = AgentLoopSkillState.hydrate(
         [
           loadSkillResultMessage({
             skillId: "review",
             instructions: "# Review",
             allowedTools: ["Read", "form_input"],
-            references: [],
-            scripts: [],
+            references: ["references/notes.md"],
+            scripts: ["scripts/check.sh"],
+            model: "anthropic/claude-sonnet-4-5",
+            thinking: false,
+            maxSteps: 6,
           }),
         ],
         undefined,
       );
 
-      state.markFormInputSubmitted(false);
-      assertEquals(state.hasSubmittedFormInput, false);
+      state.markFormInputSubmitted(true);
+      assertEquals(state.hasSubmittedFormInput, true, "a submission must set the flag");
+      assertEquals(
+        state.activeSkillToolAvailability,
+        {
+          hasActiveSkill: true,
+          references: ["references/notes.md"],
+          scripts: ["scripts/check.sh"],
+        },
+        "a submission must keep the hydrated tool availability",
+      );
+      assertEquals(
+        state.activeSkillDelegationOverrides,
+        { model: "anthropic/claude-sonnet-4-5", thinking: false, maxSteps: 6 },
+        "a submission must keep the hydrated delegation overrides",
+      );
     });
   });
 

--- a/src/agent/runtime/agent-runtime-step.test.ts
+++ b/src/agent/runtime/agent-runtime-step.test.ts
@@ -276,6 +276,72 @@ describe("agent/runtime-step", () => {
     );
   });
 
+  it("tells the model once when integration discovery is unavailable with a structured system prompt", async () => {
+    const getAvailableTools: RuntimeStepToolLoader = async (_toolsConfig, options) => {
+      options?.onIntegrationToolDiscovery?.({
+        status: "unavailable",
+        reason: "request_failed",
+      });
+      return [];
+    };
+    const baseSystemPrompt = [{ role: "system" as const, content: "Base" }];
+    const input = {
+      agentId: "agent_1",
+      activeSkillToolAvailability: undefined,
+      allowedRemoteToolNames: undefined,
+      config: { model: "auto", system: baseSystemPrompt, tools: true } as AgentConfig,
+      forwardedRemoteToolDefinitions: undefined,
+      getAvailableTools,
+      supportsToolCalling: true,
+      messages: [],
+      mode: "generate" as const,
+      remoteToolSources: undefined,
+      runtimeContext: undefined,
+      step: 0,
+      systemPrompt: baseSystemPrompt,
+      toolContextBase: undefined,
+    };
+
+    const first = await prepareAgentRuntimeStep({
+      ...input,
+      resolveRuntimeState: async () => ({ systemPrompt: baseSystemPrompt }),
+    });
+    const firstSystemPrompt = withIntegrationToolDiscoveryStatus(
+      first.systemPrompt,
+      first.integrationToolDiscovery,
+    );
+    const second = await prepareAgentRuntimeStep({
+      ...input,
+      systemPrompt: firstSystemPrompt,
+      resolveRuntimeState: async () => ({ systemPrompt: firstSystemPrompt }),
+    });
+    const secondSystemPrompt = withIntegrationToolDiscoveryStatus(
+      second.systemPrompt,
+      second.integrationToolDiscovery,
+    );
+
+    if (typeof secondSystemPrompt === "string") {
+      throw new Error("Expected a structured system prompt to stay structured");
+    }
+    assertEquals(
+      secondSystemPrompt.map((m) => m.content).join("\n").split(
+        "Integration tool discovery status:",
+      ).length - 1,
+      1,
+      "a structured prompt must not accumulate one status block per step",
+    );
+    assertEquals(
+      secondSystemPrompt.length,
+      2,
+      "stripping must drop the emptied status message rather than keep an empty system message",
+    );
+    assertEquals(
+      secondSystemPrompt[0],
+      { role: "system", content: "Base" },
+      "the authored system message must survive the strip-and-reappend",
+    );
+  });
+
   it("replaces an integration discovery status block before prompt suffix content", () => {
     const unavailable = {
       status: "unavailable" as const,

--- a/src/agent/runtime/call-context.test.ts
+++ b/src/agent/runtime/call-context.test.ts
@@ -489,6 +489,62 @@ describe("agent/runtime/call-context", () => {
       assertEquals(providerOptionsReads, 0);
     });
 
+    it("rejects structured providerOptions proxies without invoking their traps", () => {
+      let traps = 0;
+      const proxy = new Proxy({ anthropic: { cacheControl: { type: "ephemeral" } } }, {
+        ownKeys(target) {
+          traps += 1;
+          return Reflect.ownKeys(target);
+        },
+        getOwnPropertyDescriptor(target, key) {
+          traps += 1;
+          return Reflect.getOwnPropertyDescriptor(target, key);
+        },
+      });
+
+      assertThrows(
+        () =>
+          buildAgentCallContext({
+            instructions: [{
+              role: "system",
+              content: "Structured prompt",
+              providerOptions: proxy,
+            }],
+          }),
+        TypeError,
+        "Structured system message 0 providerOptions must not be a Proxy",
+      );
+      assertEquals(traps, 0, "provider options proxy traps must never run");
+    });
+
+    it("rejects structured provider bucket proxies without invoking their traps", () => {
+      let traps = 0;
+      const anthropic = new Proxy({ cacheControl: { type: "ephemeral" } }, {
+        ownKeys(target) {
+          traps += 1;
+          return Reflect.ownKeys(target);
+        },
+        getOwnPropertyDescriptor(target, key) {
+          traps += 1;
+          return Reflect.getOwnPropertyDescriptor(target, key);
+        },
+      });
+
+      assertThrows(
+        () =>
+          buildAgentCallContext({
+            instructions: [{
+              role: "system",
+              content: "Structured prompt",
+              providerOptions: { anthropic },
+            }],
+          }),
+        TypeError,
+        "providerOptions.anthropic must not be a Proxy",
+      );
+      assertEquals(traps, 0, "provider bucket proxy traps must never run");
+    });
+
     it("ignores structured Anthropic cache-control accessors without invoking them", () => {
       let cacheControlReads = 0;
       const anthropic = { beta: "prompt-caching" };

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -849,7 +849,7 @@ describe("chat-stream-handler", () => {
     it("cuts off a local tool input that idles past the configured timeout", async () => {
       const { events, controller, encoder } = createSSECollector();
       const state = createStreamState();
-      let nextTimerId = 0;
+      let nextTimerId = -1;
       const clearedTimeouts: number[] = [];
       let resolveLocalDeadline: (deadline: {
         callback: () => void;
@@ -904,6 +904,11 @@ describe("chat-stream-handler", () => {
       );
       deadline.callback();
       await processing;
+      assertEquals(
+        clearedTimeouts.filter((id) => id === 0).length,
+        1,
+        "the initial stream deadline must clear the valid zero timer handle",
+      );
       assertEquals(
         clearedTimeouts.filter((id) => id === deadline.id).length,
         1,

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -849,6 +849,20 @@ describe("chat-stream-handler", () => {
     it("cuts off a local tool input that idles past the configured timeout", async () => {
       const { events, controller, encoder } = createSSECollector();
       const state = createStreamState();
+      let nextTimerId = 0;
+      const clearedTimeouts: number[] = [];
+      let resolveLocalDeadline: (deadline: {
+        callback: () => void;
+        id: number;
+        timeoutMs: number;
+      }) => void = () => {};
+      const localDeadline = new Promise<{
+        callback: () => void;
+        id: number;
+        timeoutMs: number;
+      }>((resolve) => {
+        resolveLocalDeadline = resolve;
+      });
       const result = {
         fullStream: {
           async *[Symbol.asyncIterator]() {
@@ -868,9 +882,33 @@ describe("chat-stream-handler", () => {
         textStream: emptyAsyncIterable(),
       };
 
-      await processStream(result, state, controller, encoder, "t", {
+      const processing = processStream(result, state, controller, encoder, "t", {
         localToolInputIdleTimeoutMs: 10,
+        setTimeoutFn: ((callback: () => void, timeoutMs?: number) => {
+          const id = ++nextTimerId;
+          if (state.toolCalls.has("tc-slow")) {
+            resolveLocalDeadline({ callback, id, timeoutMs: timeoutMs ?? 0 });
+          }
+          return id;
+        }) as typeof setTimeout,
+        clearTimeoutFn: ((id: number) => {
+          clearedTimeouts.push(id);
+        }) as typeof clearTimeout,
       });
+
+      const deadline = await localDeadline;
+      assertEquals(
+        deadline.timeoutMs,
+        10,
+        "the active local tool input must schedule the configured 10ms idle deadline",
+      );
+      deadline.callback();
+      await processing;
+      assertEquals(
+        clearedTimeouts.filter((id) => id === deadline.id).length,
+        1,
+        "the settled idle deadline must be cleared exactly once",
+      );
 
       assertEquals(
         state.toolCalls.get("tc-slow")?.inputAvailable,

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -786,6 +786,10 @@ describe("chat-stream-handler", () => {
     it("does not cut off a slow active local tool input before the provider finishes it", async () => {
       const { events, controller, encoder } = createSSECollector();
       const state = createStreamState();
+      let releasePause: () => void = () => {};
+      const paused = new Promise<void>((resolve) => {
+        releasePause = resolve;
+      });
       const result = {
         fullStream: {
           async *[Symbol.asyncIterator]() {
@@ -799,7 +803,7 @@ describe("chat-stream-handler", () => {
               id: "tc-slow",
               delta: '{"uploadId":"upload-1",',
             };
-            await new Promise((resolve) => setTimeout(resolve, 2_100));
+            await paused;
             yield {
               type: "tool-input-delta",
               id: "tc-slow",
@@ -812,9 +816,19 @@ describe("chat-stream-handler", () => {
         textStream: emptyAsyncIterable(),
       };
 
-      await processStream(result, state, controller, encoder, "t", undefined);
+      const processing = processStream(result, state, controller, encoder, "t", {
+        localToolInputIdleTimeoutMs: 1_000,
+      });
+      // Let the handler park on the pending delta before the provider resumes.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      releasePause();
+      await processing;
 
-      assertEquals(state.toolCalls.get("tc-slow")?.inputAvailable, true);
+      assertEquals(
+        state.toolCalls.get("tc-slow")?.inputAvailable,
+        true,
+        "a paused local tool input that resumes within the idle timeout must complete",
+      );
       assertEquals(
         events.filter((event) => event.type === "tool-input-available"),
         [
@@ -828,6 +842,50 @@ describe("chat-stream-handler", () => {
             },
           },
         ],
+        "the resumed deltas must merge into a single tool-input-available event",
+      );
+    });
+
+    it("cuts off a local tool input that idles past the configured timeout", async () => {
+      const { events, controller, encoder } = createSSECollector();
+      const state = createStreamState();
+      const result = {
+        fullStream: {
+          async *[Symbol.asyncIterator]() {
+            yield {
+              type: "tool-input-start",
+              id: "tc-slow",
+              toolName: "retrieveDocumentEvidence",
+            };
+            yield {
+              type: "tool-input-delta",
+              id: "tc-slow",
+              delta: '{"uploadId":"upload-1",',
+            };
+            await new Promise(() => {});
+          },
+        },
+        textStream: emptyAsyncIterable(),
+      };
+
+      await processStream(result, state, controller, encoder, "t", {
+        localToolInputIdleTimeoutMs: 10,
+      });
+
+      assertEquals(
+        state.toolCalls.get("tc-slow")?.inputAvailable,
+        false,
+        "a local tool input that idles past the configured timeout must not be marked available",
+      );
+      assertEquals(
+        events.filter((event) => event.type === "tool-input-available"),
+        [],
+        "a cut-off local tool input must not emit tool-input-available",
+      );
+      assertEquals(
+        state.finishReason,
+        "tool-calls",
+        "a cut-off local tool input still ends the step",
       );
     });
 

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -851,32 +851,47 @@ describe("chat-stream-handler", () => {
       const state = createStreamState();
       let nextTimerId = -1;
       const clearedTimeouts: number[] = [];
-      let resolveLocalDeadline: (deadline: {
+      const pendingTimers = new Map<number, {
         callback: () => void;
-        id: number;
         timeoutMs: number;
-      }) => void = () => {};
-      const localDeadline = new Promise<{
-        callback: () => void;
-        id: number;
-        timeoutMs: number;
-      }>((resolve) => {
-        resolveLocalDeadline = resolve;
+      }>();
+      let markPendingReadStarted: () => void = () => {};
+      const pendingReadStarted = new Promise<void>((resolve) => {
+        markPendingReadStarted = resolve;
       });
+      let releasePendingRead: () => void = () => {};
+      const pendingRead = new Promise<IteratorResult<unknown>>((resolve) => {
+        releasePendingRead = () => resolve({ done: true, value: undefined });
+      });
+      const parts = [
+        {
+          type: "tool-input-start",
+          id: "tc-slow",
+          toolName: "retrieveDocumentEvidence",
+        },
+        {
+          type: "tool-input-delta",
+          id: "tc-slow",
+          delta: '{"uploadId":"upload-1",',
+        },
+      ];
+      let nextPartIndex = 0;
       const result = {
         fullStream: {
-          async *[Symbol.asyncIterator]() {
-            yield {
-              type: "tool-input-start",
-              id: "tc-slow",
-              toolName: "retrieveDocumentEvidence",
+          [Symbol.asyncIterator]() {
+            return {
+              next(): Promise<IteratorResult<unknown>> {
+                const part = parts[nextPartIndex++];
+                if (part !== undefined) {
+                  return Promise.resolve({ done: false, value: part });
+                }
+                markPendingReadStarted();
+                return pendingRead;
+              },
+              return(): Promise<IteratorResult<unknown>> {
+                return Promise.resolve({ done: true, value: undefined });
+              },
             };
-            yield {
-              type: "tool-input-delta",
-              id: "tc-slow",
-              delta: '{"uploadId":"upload-1",',
-            };
-            await new Promise(() => {});
           },
         },
         textStream: emptyAsyncIterable(),
@@ -886,31 +901,49 @@ describe("chat-stream-handler", () => {
         localToolInputIdleTimeoutMs: 10,
         setTimeoutFn: ((callback: () => void, timeoutMs?: number) => {
           const id = ++nextTimerId;
-          if (state.toolCalls.has("tc-slow")) {
-            resolveLocalDeadline({ callback, id, timeoutMs: timeoutMs ?? 0 });
-          }
+          pendingTimers.set(id, { callback, timeoutMs: timeoutMs ?? 0 });
           return id;
         }) as typeof setTimeout,
         clearTimeoutFn: ((id: number) => {
           clearedTimeouts.push(id);
+          pendingTimers.delete(id);
         }) as typeof clearTimeout,
       });
 
-      const deadline = await localDeadline;
-      assertEquals(
-        deadline.timeoutMs,
-        10,
-        "the active local tool input must schedule the configured 10ms idle deadline",
-      );
-      deadline.callback();
-      await processing;
+      let deadlineId = -1;
+      try {
+        await pendingReadStarted;
+        const pendingDeadlines = [...pendingTimers.entries()];
+        assertEquals(
+          pendingDeadlines.length,
+          1,
+          "only the deadline around the pending iterator read may remain active",
+        );
+        const pendingDeadline = pendingDeadlines[0];
+        if (pendingDeadline === undefined) {
+          throw new Error("the pending iterator read did not schedule a deadline");
+        }
+        const [id, deadline] = pendingDeadline;
+        deadlineId = id;
+        assertEquals(
+          deadline.timeoutMs,
+          10,
+          "the pending local tool input must schedule the configured 10ms idle deadline",
+        );
+        deadline.callback();
+        await processing;
+      } finally {
+        for (const deadline of pendingTimers.values()) deadline.callback();
+        releasePendingRead();
+        await processing.catch(() => {});
+      }
       assertEquals(
         clearedTimeouts.filter((id) => id === 0).length,
         1,
         "the initial stream deadline must clear the valid zero timer handle",
       );
       assertEquals(
-        clearedTimeouts.filter((id) => id === deadline.id).length,
+        clearedTimeouts.filter((id) => id === deadlineId).length,
         1,
         "the settled idle deadline must be cleared exactly once",
       );

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -361,7 +361,7 @@ async function readNextStreamPartWithTimeout(
       }),
     ]);
   } finally {
-    if (timeoutId) {
+    if (timeoutId !== undefined) {
       clearTimeoutFn(timeoutId);
     }
   }

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -207,6 +207,10 @@ export interface ChatStreamCallbacks {
   streamLifecycleMode?: StreamLifecycleMode;
   streamLifecyclePolicy?: Partial<StreamLifecyclePolicy>;
   onLifecycleShadowReport?: (report: StreamLifecycleShadowReport) => void;
+  /** @internal Host timer seam for deterministic stream-lifecycle tests. */
+  setTimeoutFn?: typeof setTimeout;
+  /** @internal Host timer seam for deterministic stream-lifecycle tests. */
+  clearTimeoutFn?: typeof clearTimeout;
   traceSpanName?: string;
   traceAttributes?: Record<string, TraceAttributeValue>;
 }
@@ -345,18 +349,20 @@ async function readNextStreamPartWithTimeout(
   iterator: AsyncIterator<unknown>,
   state: ChatStreamState,
   timeoutMs: number,
+  setTimeoutFn: typeof setTimeout = setTimeout,
+  clearTimeoutFn: typeof clearTimeout = clearTimeout,
 ): Promise<IteratorResult<unknown> | "timeout"> {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   try {
     return await Promise.race([
       readNextStreamPart(iterator, state),
       new Promise<"timeout">((resolve) => {
-        timeoutId = setTimeout(() => resolve("timeout"), timeoutMs);
+        timeoutId = setTimeoutFn(() => resolve("timeout"), timeoutMs);
       }),
     ]);
   } finally {
     if (timeoutId) {
-      clearTimeout(timeoutId);
+      clearTimeoutFn(timeoutId);
     }
   }
 }
@@ -957,24 +963,32 @@ export function processStreamInternal(
             streamIterator,
             state,
             callbacks?.localToolInputIdleTimeoutMs ?? LOCAL_TOOL_INPUT_IDLE_MS,
+            callbacks?.setTimeoutFn,
+            callbacks?.clearTimeoutFn,
           )
           : shouldStopForCommittedLocalToolCallNow
           ? await readNextStreamPartWithTimeout(
             streamIterator,
             state,
             callbacks?.localToolCommitGraceMs ?? LOCAL_TOOL_COMMIT_GRACE_MS,
+            callbacks?.setTimeoutFn,
+            callbacks?.clearTimeoutFn,
           )
           : shouldStopForIdleOutput
           ? await readNextStreamPartWithTimeout(
             streamIterator,
             state,
             callbacks?.streamIdleTimeoutMs ?? STREAM_OUTPUT_IDLE_MS,
+            callbacks?.setTimeoutFn,
+            callbacks?.clearTimeoutFn,
           )
           : shouldStopForIdleStart
           ? await readNextStreamPartWithTimeout(
             streamIterator,
             state,
             callbacks?.streamIdleTimeoutMs ?? STREAM_START_IDLE_MS,
+            callbacks?.setTimeoutFn,
+            callbacks?.clearTimeoutFn,
           )
           : await readNextStreamPart(streamIterator, state);
         if (next === "timeout") {

--- a/src/agent/runtime/client-profile.test.ts
+++ b/src/agent/runtime/client-profile.test.ts
@@ -84,3 +84,23 @@ Deno.test("clientAllowsStudioMcp allows trusted studio-capable clients", () => {
   });
   assertEquals(clientAllowsStudioMcp(profile), true);
 });
+
+Deno.test("clientAllowsStudioMcp requires both trust and a studio UI capability", () => {
+  assertEquals(
+    clientAllowsStudioMcp(
+      resolveRuntimeClientProfile({ veryfront: { client: { id: "veryfront-cli" } } }),
+    ),
+    false,
+    "a trusted CLI client with no UI capabilities must not receive studio MCP tools",
+  );
+  assertEquals(
+    clientAllowsStudioMcp({ id: "x", type: "api", trusted: false, capabilities: ["ui_panels"] }),
+    false,
+    "an untrusted client must not receive studio MCP tools even with UI capabilities",
+  );
+  assertEquals(
+    clientAllowsStudioMcp({ id: "y", type: "web", trusted: true, capabilities: ["form_input"] }),
+    true,
+    "a trusted client with form_input must receive studio MCP tools",
+  );
+});

--- a/src/agent/runtime/input-utils.test.ts
+++ b/src/agent/runtime/input-utils.test.ts
@@ -2,6 +2,8 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { accumulateUsage, getMaxSteps, normalizeInput } from "./input-utils.ts";
+
+type UsageTotal = Parameters<typeof accumulateUsage>[0];
 import {
   isRuntimeGeneratedUserMessage,
   markRuntimeGeneratedUserMessage,
@@ -122,11 +124,87 @@ describe("input-utils", () => {
     });
 
     it("handles partial usage fields", () => {
-      const total = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+      const total: UsageTotal = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
       accumulateUsage(total, { promptTokens: 5 });
       assertEquals(total.promptTokens, 5);
       assertEquals(total.completionTokens, 0);
       assertEquals(total.totalTokens, 0);
+    });
+
+    it("accumulates provider cost and billing amounts", () => {
+      const total: UsageTotal = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+      accumulateUsage(total, {
+        costUsd: 0.002,
+        providerCostUsd: 0.0015,
+        veryfrontBilledUsd: 0.002,
+        costCredits: 2,
+      });
+      accumulateUsage(total, {
+        costUsd: 0.003,
+        providerCostUsd: 0.001,
+        veryfrontBilledUsd: 0.004,
+        costCredits: 3,
+      });
+      assertEquals(total.costUsd, 0.005, "per-step costUsd must aggregate into the run total");
+      assertEquals(
+        total.providerCostUsd,
+        0.0025,
+        "per-step providerCostUsd must aggregate into the run total",
+      );
+      assertEquals(
+        total.veryfrontBilledUsd,
+        0.006,
+        "per-step veryfrontBilledUsd must aggregate into the run total",
+      );
+      assertEquals(total.costCredits, 5, "per-step costCredits must aggregate into the run total");
+    });
+
+    it("collapses disagreeing cost attribution and keeps deferred billing sticky", () => {
+      const total: UsageTotal = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+      accumulateUsage(total, {
+        costSource: "gateway",
+        billingMode: "deferred",
+        usageCaptureStatus: "complete",
+      });
+      accumulateUsage(total, {
+        costSource: "missing",
+        billingMode: "direct",
+        usageCaptureStatus: "partial",
+      });
+      assertEquals(
+        total.costSource,
+        "partial",
+        "a run mixing priced and unpriced steps must report partial attribution",
+      );
+      assertEquals(
+        total.billingMode,
+        "deferred",
+        "deferred billing must stay sticky once any step defers",
+      );
+      assertEquals(
+        total.usageCaptureStatus,
+        "partial",
+        "disagreeing capture status must collapse to partial",
+      );
+
+      const agreeing: UsageTotal = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
+      accumulateUsage(agreeing, {
+        costSource: "gateway",
+        billingMode: "direct",
+        usageCaptureStatus: "complete",
+      });
+      accumulateUsage(agreeing, {
+        costSource: "gateway",
+        billingMode: "direct",
+        usageCaptureStatus: "complete",
+      });
+      assertEquals(agreeing.costSource, "gateway", "matching cost sources must be preserved");
+      assertEquals(agreeing.billingMode, "direct", "direct billing must stay direct");
+      assertEquals(
+        agreeing.usageCaptureStatus,
+        "complete",
+        "matching capture status must be preserved",
+      );
     });
   });
 

--- a/src/agent/runtime/mcp-server-tool-sources.cross-runtime.test.ts
+++ b/src/agent/runtime/mcp-server-tool-sources.cross-runtime.test.ts
@@ -61,4 +61,48 @@ describe("bindRuntimeRemoteToolSourcesToCredentialOwner", () => {
       runId: "owner-run",
     });
   });
+
+  it("keeps a nested non-binding marker when the credential owner is not run-tracked", async () => {
+    let executeContext: ToolExecutionContext | undefined;
+    const bound = bindRuntimeRemoteToolSourcesToCredentialOwner([
+      createCapturingSource((context) => executeContext = context),
+    ], { authToken: "owner-token" });
+
+    await bound?.[0]?.executeTool("get_file", {}, {
+      runId: "nested-run",
+      runIdBindsToolAuthorization: false,
+    });
+
+    assertEquals(
+      executeContext,
+      {
+        authToken: "owner-token",
+        runId: "nested-run",
+        runIdBindsToolAuthorization: false,
+      },
+      "an owner without a run id must not strip the nested run's non-binding marker",
+    );
+  });
+
+  it("keeps a nested binding marker when the credential owner is not run-tracked", async () => {
+    let executeContext: ToolExecutionContext | undefined;
+    const bound = bindRuntimeRemoteToolSourcesToCredentialOwner([
+      createCapturingSource((context) => executeContext = context),
+    ], { authToken: "owner-token" });
+
+    await bound?.[0]?.executeTool("get_file", {}, {
+      runId: "nested-run",
+      runIdBindsToolAuthorization: true,
+    });
+
+    assertEquals(
+      executeContext,
+      {
+        authToken: "owner-token",
+        runId: "nested-run",
+        runIdBindsToolAuthorization: true,
+      },
+      "an owner without a run id must leave the nested run's binding marker unchanged",
+    );
+  });
 });

--- a/src/agent/runtime/mcp-server-tool-sources.test.ts
+++ b/src/agent/runtime/mcp-server-tool-sources.test.ts
@@ -27,6 +27,26 @@ Deno.test("getRequestedUnresolvedBooleanToolNames keeps legacy delegation local"
   );
 });
 
+Deno.test("getRequestedUnresolvedBooleanToolNames does not request tools already available locally", () => {
+  assertEquals(
+    getRequestedUnresolvedBooleanToolNames({
+      tools: { get_file: true, sleep: true },
+      agentId: "a",
+    }),
+    ["get_file", "sleep"],
+    "without availableToolNames every unregistered boolean tool is still requested",
+  );
+  assertEquals(
+    getRequestedUnresolvedBooleanToolNames({
+      tools: { get_file: true, sleep: true },
+      agentId: "a",
+      availableToolNames: ["get_file"],
+    }),
+    ["sleep"],
+    "a tool already provided locally must not be requested from the remote Veryfront MCP server",
+  );
+});
+
 type FetchCall = {
   url: string;
   init: RequestInit;

--- a/src/agent/runtime/mcp-server-tool-sources.test.ts
+++ b/src/agent/runtime/mcp-server-tool-sources.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import { it } from "#veryfront/testing/bdd.ts";
 import type {
   RemoteMCPToolSourceConfig,
   RemoteToolSource,
@@ -27,7 +28,7 @@ Deno.test("getRequestedUnresolvedBooleanToolNames keeps legacy delegation local"
   );
 });
 
-Deno.test("getRequestedUnresolvedBooleanToolNames does not request tools already available locally", () => {
+it("getRequestedUnresolvedBooleanToolNames does not request tools already available locally", () => {
   assertEquals(
     getRequestedUnresolvedBooleanToolNames({
       tools: { get_file: true, sleep: true },

--- a/src/agent/runtime/message-adapter.test.ts
+++ b/src/agent/runtime/message-adapter.test.ts
@@ -216,6 +216,43 @@ describe("agent runtime message adapter", () => {
     assertStringIncludes(text, "application/pdf");
   });
 
+  it("omits inline data URLs from the uploaded files annotation", () => {
+    const agentRuntimeMessages = convertProviderMessagesToAgentRuntimeMessages([
+      providerMessage({
+        role: "user",
+        content: [
+          { type: "text", text: "look" },
+          {
+            type: "image",
+            data: "data:image/png;base64,ABCPAYLOAD==",
+            url: "data:image/png;base64,ABCPAYLOAD==",
+            mediaType: "image/png",
+            filename: "inline.png",
+          },
+        ],
+      }),
+    ]);
+
+    const parts = agentRuntimeMessages[0]?.parts ?? [];
+    const text = parts
+      .flatMap((part) => part.type === "text" && "text" in part ? [part.text] : [])
+      .join("\n");
+
+    assertStringIncludes(text, "<uploaded_files>", "the attachment must still be annotated");
+    assertStringIncludes(text, "inline.png", "the annotation must name the attachment");
+    assertEquals(
+      text.includes("base64,ABCPAYLOAD"),
+      false,
+      "inline data URLs must never be copied into the uploaded_files annotation",
+    );
+    const imagePart = parts.find((part) => part.type === "image");
+    assertEquals(
+      imagePart && "url" in imagePart ? imagePart.url : undefined,
+      "data:image/png;base64,ABCPAYLOAD==",
+      "the bytes must still ride in the native image part",
+    );
+  });
+
   it("does not append a second uploaded files annotation during provider round trips", () => {
     const agentRuntimeMessages = convertProviderMessagesToAgentRuntimeMessages([
       providerMessage({

--- a/src/agent/runtime/message-file-url-refresh.test.ts
+++ b/src/agent/runtime/message-file-url-refresh.test.ts
@@ -22,6 +22,7 @@ Deno.test("resolveRuntimeMessageFileUrls refreshes upload file URLs once", async
           mediaType: "text/plain",
           filename: "notes.txt",
           uploadId: "upload-1",
+          uploadPath: "_chat/user/notes.txt",
           url: "https://files.example.com/original.txt",
         },
         {
@@ -47,6 +48,7 @@ Deno.test("resolveRuntimeMessageFileUrls refreshes upload file URLs once", async
       mediaType: "text/plain",
       filename: "notes.txt",
       uploadId: "upload-1",
+      uploadPath: "_chat/user/notes.txt",
       url: "https://signed.example.com/file.txt",
     },
     {
@@ -56,7 +58,36 @@ Deno.test("resolveRuntimeMessageFileUrls refreshes upload file URLs once", async
       uploadId: "upload-1",
       url: "https://signed.example.com/file.txt",
     },
-  ]);
+  ], "a refreshed upload must keep its storage path alongside the new url");
+});
+
+Deno.test("resolveRuntimeMessageFileUrls canonicalizes a snake_case upload_path", async () => {
+  const messages = await resolveRuntimeMessageFileUrls(
+    [
+      userMessage([
+        {
+          type: "file",
+          mediaType: "text/plain",
+          filename: "notes.txt",
+          uploadId: "upload-1",
+          upload_path: "_chat/user/notes.txt",
+          url: "https://files.example.com/original.txt",
+        } as unknown as ChatUiMessage["parts"][number],
+      ]),
+    ],
+    () => Promise.resolve("https://signed.example.com/file.txt"),
+  );
+
+  assertEquals(messages[0]?.parts, [
+    {
+      type: "file",
+      mediaType: "text/plain",
+      filename: "notes.txt",
+      uploadId: "upload-1",
+      uploadPath: "_chat/user/notes.txt",
+      url: "https://signed.example.com/file.txt",
+    },
+  ], "a snake_case upload_path must be carried forward as the canonical uploadPath");
 });
 
 Deno.test("resolveRuntimeMessageFileUrls keeps existing parts when resolver returns no URL", async () => {
@@ -67,15 +98,27 @@ Deno.test("resolveRuntimeMessageFileUrls keeps existing parts when resolver retu
         mediaType: "text/plain",
         filename: "notes.txt",
         uploadId: "upload-1",
+        uploadPath: "_chat/user/notes.txt",
         url: "https://files.example.com/original.txt",
       },
     ]),
   ];
 
-  assertEquals(
-    await resolveRuntimeMessageFileUrls(messages, () => Promise.resolve(undefined)),
+  const resolved = await resolveRuntimeMessageFileUrls(
     messages,
+    () => Promise.resolve(undefined),
   );
+
+  assertEquals(resolved[0]?.parts, [
+    {
+      type: "file",
+      mediaType: "text/plain",
+      filename: "notes.txt",
+      uploadId: "upload-1",
+      uploadPath: "_chat/user/notes.txt",
+      url: "https://files.example.com/original.txt",
+    },
+  ], "an unresolved upload must keep its storage path");
 });
 
 Deno.test("composeAbortSignals aborts immediately when a source signal is already aborted", () => {

--- a/src/agent/runtime/message-file-url-refresh.test.ts
+++ b/src/agent/runtime/message-file-url-refresh.test.ts
@@ -1,5 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
+import { it } from "#veryfront/testing/bdd.ts";
 import type { ChatUiMessage } from "../../chat/types.ts";
 import { composeAbortSignals, resolveRuntimeMessageFileUrls } from "./message-file-url-refresh.ts";
 
@@ -61,7 +62,7 @@ Deno.test("resolveRuntimeMessageFileUrls refreshes upload file URLs once", async
   ], "a refreshed upload must keep its storage path alongside the new url");
 });
 
-Deno.test("resolveRuntimeMessageFileUrls canonicalizes a snake_case upload_path", async () => {
+it("resolveRuntimeMessageFileUrls canonicalizes a snake_case upload_path", async () => {
   const messages = await resolveRuntimeMessageFileUrls(
     [
       userMessage([

--- a/src/agent/runtime/message-preparation.test.ts
+++ b/src/agent/runtime/message-preparation.test.ts
@@ -1,5 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { it } from "#veryfront/testing/bdd.ts";
 import { observeFetchRequestInit } from "#veryfront/testing/mock-fetch.ts";
 import type { ChatUiMessage } from "../../chat/types.ts";
 import { generateText } from "../../runtime/runtime-bridge.ts";
@@ -68,7 +69,7 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages returns an empty-conversati
   assertEquals(messages[0]?.parts, [{ type: "text", text: "Suggest next steps." }]);
 });
 
-Deno.test("prepareAgentRuntimeMessagesFromUiMessages uses the default empty-conversation prompt", async () => {
+it("prepareAgentRuntimeMessagesFromUiMessages uses the default empty-conversation prompt", async () => {
   const messages = await prepareAgentRuntimeMessagesFromUiMessages({ messages: [] });
 
   assertEquals(messages.length, 1, "an empty conversation yields exactly one prompt message");
@@ -84,7 +85,7 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages uses the default empty-conv
   );
 });
 
-Deno.test("prepareAgentRuntimeMessagesFromUiMessages treats a whitespace-only user turn as empty", async () => {
+it("prepareAgentRuntimeMessagesFromUiMessages treats a whitespace-only user turn as empty", async () => {
   const messages = await prepareAgentRuntimeMessagesFromUiMessages({
     messages: [userMessage([{ type: "text", text: "   " }])],
   });
@@ -101,7 +102,7 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages treats a whitespace-only us
   );
 });
 
-Deno.test("prepareAgentRuntimeMessagesFromUiMessages keeps an attachment-only user turn", async () => {
+it("prepareAgentRuntimeMessagesFromUiMessages keeps an attachment-only user turn", async () => {
   const messages = await prepareAgentRuntimeMessagesFromUiMessages({
     messages: [
       userMessage([

--- a/src/agent/runtime/message-preparation.test.ts
+++ b/src/agent/runtime/message-preparation.test.ts
@@ -68,6 +68,69 @@ Deno.test("prepareAgentRuntimeMessagesFromUiMessages returns an empty-conversati
   assertEquals(messages[0]?.parts, [{ type: "text", text: "Suggest next steps." }]);
 });
 
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages uses the default empty-conversation prompt", async () => {
+  const messages = await prepareAgentRuntimeMessagesFromUiMessages({ messages: [] });
+
+  assertEquals(messages.length, 1, "an empty conversation yields exactly one prompt message");
+  assertEquals(messages[0]?.role, "user", "the default prompt is sent as a user turn");
+  assertEquals(
+    messages[0]?.parts,
+    [{
+      type: "text",
+      text:
+        "Please provide 3-4 specific suggestions for what I could build or improve based on the current project context.",
+    }],
+    "the literal default prompt must reach the model",
+  );
+});
+
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages treats a whitespace-only user turn as empty", async () => {
+  const messages = await prepareAgentRuntimeMessagesFromUiMessages({
+    messages: [userMessage([{ type: "text", text: "   " }])],
+  });
+
+  assertEquals(messages.length, 1, "a whitespace-only turn is replaced by one prompt message");
+  assertEquals(
+    messages[0]?.parts,
+    [{
+      type: "text",
+      text:
+        "Please provide 3-4 specific suggestions for what I could build or improve based on the current project context.",
+    }],
+    "a whitespace-only user turn must be substituted with the default prompt",
+  );
+});
+
+Deno.test("prepareAgentRuntimeMessagesFromUiMessages keeps an attachment-only user turn", async () => {
+  const messages = await prepareAgentRuntimeMessagesFromUiMessages({
+    messages: [
+      userMessage([
+        {
+          type: "file",
+          mediaType: "image/png",
+          filename: "shot.png",
+          url: "data:image/png;base64,iVBORw0KGgo=",
+        },
+      ]),
+    ],
+  });
+
+  const parts = messages[0]?.parts ?? [];
+  assertEquals(
+    parts.some((part) => part.type === "image" || part.type === "file"),
+    true,
+    "an attachment-only user turn must not be treated as an empty conversation",
+  );
+  const text = parts
+    .flatMap((part) => part.type === "text" && "text" in part ? [part.text] : [])
+    .join("\n");
+  assertEquals(
+    text.includes("specific suggestions"),
+    false,
+    "the canned suggestions prompt must not replace an attachment",
+  );
+});
+
 Deno.test("prepareAgentRuntimeMessagesFromUiMessages preserves source message ids", async () => {
   const messages = await prepareAgentRuntimeMessagesFromUiMessages({
     messages: [

--- a/src/agent/runtime/model-resolution.test.ts
+++ b/src/agent/runtime/model-resolution.test.ts
@@ -1,5 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
+import { VeryfrontError } from "#veryfront/errors";
 import { deleteEnv, setEnv } from "#veryfront/compat/process.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { VERYFRONT_CLOUD_CHAT_MODELS } from "#veryfront/provider/veryfront-cloud/model-catalog.ts";
@@ -53,9 +59,12 @@ describe("agent/runtime/model-resolution", () => {
   it("reports a default-model mismatch when only another provider has a key", () => {
     setEnv("ANTHROPIC_API_KEY", "sk-ant-test");
 
-    const err = assertThrows(() => resolveRuntimeModel());
-    const message = err instanceof Error ? err.message : String(err);
-    assertEquals(message.includes("anthropic"), true, message);
+    const err = assertThrows(() => resolveRuntimeModel(), VeryfrontError);
+    assertInstanceOf(err, VeryfrontError, "the mismatch must be a VeryfrontError");
+    assertEquals(err.slug, "default-model-credential-mismatch", err.message);
+    assertEquals(err.status, 400, "the mismatch must stay a 400 client error");
+    assertStringIncludes(err.message, "needs a openai credential", err.message);
+    assertStringIncludes(err.message, "Found anthropic", err.message);
   });
 
   it("still routes the default model directly when its own provider has a key", () => {

--- a/src/agent/runtime/model-runtime.test-helpers.test.ts
+++ b/src/agent/runtime/model-runtime.test-helpers.test.ts
@@ -30,6 +30,45 @@ describe("scriptedModel turn exhaustion", () => {
     assertEquals(model.callCount, 2);
   });
 
+  it("rejects the hook the transport restriction forbids", async () => {
+    const generateOnly = scriptedModel([{ text: "x" }], { only: "generate" });
+    const streamOnly = scriptedModel([{ text: "x" }], { only: "stream" });
+
+    await assertRejects(
+      async () => await generateOnly.doStream(CALL_OPTIONS),
+      Error,
+      "scripted model: doStream must not be called",
+    );
+    await assertRejects(
+      async () => await streamOnly.doGenerate(CALL_OPTIONS),
+      Error,
+      "scripted model: doGenerate must not be called",
+    );
+    assertEquals(
+      generateOnly.callCount,
+      0,
+      "a forbidden hook must reject before consuming a scripted turn",
+    );
+    assertEquals(
+      streamOnly.callCount,
+      0,
+      "a forbidden hook must reject before consuming a scripted turn",
+    );
+  });
+
+  it("rejects cross-mode turn shapes", async () => {
+    await assertRejects(
+      async () => await scriptedModel([{ parts: [] }]).doGenerate(CALL_OPTIONS),
+      Error,
+      "a parts turn is stream-only",
+    );
+    await assertRejects(
+      async () => await scriptedModel([{ content: [] }]).doStream(CALL_OPTIONS),
+      Error,
+      "a content turn is generate-only",
+    );
+  });
+
   it("repeats the final turn only when explicitly requested", async () => {
     const generateModel = scriptedModel([{ text: "repeat me" }], {
       only: "generate",

--- a/src/agent/runtime/model-tool-converter.test.ts
+++ b/src/agent/runtime/model-tool-converter.test.ts
@@ -98,11 +98,24 @@ describe("model-tool-converter", () => {
         description: "Get current weather",
         parameters: { type: "object", properties: {} },
       },
+      {
+        name: "forecast",
+        description: "Get a five day forecast",
+        parameters: { type: "object", properties: {} },
+      },
     ];
 
     const result = convertToolsToRuntimeTools(tools)!;
-    // The runtime tool entry should preserve the execute handler.
-    assertEquals("weather" in result, true);
+    assertEquals(
+      (result.weather as { description?: string }).description,
+      "Get current weather",
+      "converted runtime tool must keep the source tool description",
+    );
+    assertEquals(
+      (result.forecast as { description?: string }).description,
+      "Get a five day forecast",
+      "each converted runtime tool must keep its own description",
+    );
   });
 
   it("handles tools with complex schemas", () => {

--- a/src/agent/runtime/project-skill-catalog.test.ts
+++ b/src/agent/runtime/project-skill-catalog.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import "#veryfront/skill/_test-setup.ts";
 import { assertEquals, assertExists, assertRejects, assertThrows } from "@std/assert";
+import { it } from "#veryfront/testing/bdd.ts";
 import { resolve } from "node:path";
 import {
   SKILL_CATALOG_MAX_DOCUMENT_CHARACTERS,
@@ -826,7 +827,7 @@ Deno.test("a mismatched project-file response path fails closed for the claimed 
   }]);
 });
 
-Deno.test("an oversized project skill document fails closed without resurrecting the built-in", async () => {
+it("an oversized project skill document fails closed without resurrecting the built-in", async () => {
   const errors: Array<[string, Record<string, unknown> | undefined]> = [];
   const skills = await getRuntimeProjectSkillCatalog({
     ...PROJECT_CONTEXT,

--- a/src/agent/runtime/project-skill-catalog.test.ts
+++ b/src/agent/runtime/project-skill-catalog.test.ts
@@ -826,6 +826,42 @@ Deno.test("a mismatched project-file response path fails closed for the claimed 
   }]);
 });
 
+Deno.test("an oversized project skill document fails closed without resurrecting the built-in", async () => {
+  const errors: Array<[string, Record<string, unknown> | undefined]> = [];
+  const skills = await getRuntimeProjectSkillCatalog({
+    ...PROJECT_CONTEXT,
+    builtinSkills: [{
+      id: "shared",
+      name: "shared",
+      description: "Builtin shared",
+      instructions: "# Builtin shared",
+      allowedTools: [],
+    }],
+    getProjectFiles: async () => [{ path: "skills/shared/SKILL.md" }],
+    getProjectFile: async () => ({
+      path: "skills/shared/SKILL.md",
+      // Over the per-file byte budget while staying under the character budget.
+      content: "\u{1F600}".repeat(Math.floor(SKILL_TEXT_FILE_MAX_BYTES / 4) + 1),
+    }),
+    logger: {
+      error: (message, metadata) => errors.push([message, metadata]),
+    },
+  });
+
+  assertEquals(
+    skills,
+    [],
+    "a skill whose content exceeds the per-file byte budget must be dropped, not fall back to the built-in",
+  );
+  assertEquals(
+    errors,
+    [["Project skill content exceeded its budget; skipping skill", {
+      path: "skills/shared/SKILL.md",
+    }]],
+    "the byte budget guard must log the skipped skill path",
+  );
+});
+
 Deno.test("getRuntimeProjectSkillCatalog still parses legacy hidden project skills", async () => {
   const { catalog, fileCalls } = createSkillCatalog({
     paths: [".veryfront/skills/legacy/SKILL.md"],

--- a/src/agent/runtime/provider-tool-compat.test.ts
+++ b/src/agent/runtime/provider-tool-compat.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { ToolDefinition } from "#veryfront/tool";
 import {
@@ -27,6 +27,42 @@ function containsKey(value: unknown, key: string): boolean {
 }
 
 describe("provider-tool-compat", () => {
+  it("leaves non-sanitizing provider schemas untouched", () => {
+    const schema = {
+      type: "object",
+      properties: { "bad key": { type: "string" }, ok: { type: "string" } },
+      required: ["bad key", "ok"],
+    } as never;
+
+    assertStrictEquals(
+      sanitizeProviderToolSchema(schema, { model: "openai/gpt-5.2" }),
+      schema,
+      "OpenAI tool schemas must be returned by identity, never property-key sanitized",
+    );
+    assertStrictEquals(
+      sanitizeProviderToolSchema(schema, { model: "some-local-model" }),
+      schema,
+      "unknown-provider tool schemas must be returned by identity",
+    );
+    assertStrictEquals(
+      sanitizeProviderToolSchema(schema, {}),
+      schema,
+      "tool schemas with no model must be returned by identity",
+    );
+
+    const sanitized = sanitizeProviderToolSchema(schema, { model: "anthropic/claude-opus-4-6" });
+    assertEquals(
+      Object.keys(sanitized.properties ?? {}),
+      ["ok"],
+      "sanitizing providers must drop property keys that fail the provider pattern",
+    );
+    assertEquals(
+      sanitized.required,
+      ["ok"],
+      "sanitizing providers must drop the required entry of a dropped property",
+    );
+  });
+
   it("returns independent permissive fallback schemas", () => {
     for (
       const createFallback of [

--- a/src/agent/runtime/repair-tool-call.test.ts
+++ b/src/agent/runtime/repair-tool-call.test.ts
@@ -42,7 +42,7 @@ describe("repair-tool-call", () => {
       toolCallId: "tool-1",
       toolName: "web_search",
       type: "tool-call",
-    });
+    }, "raw string input must be wrapped into a query object");
   });
 
   it("repairs JSON string literal web_search input into the expected object shape", async () => {
@@ -74,7 +74,7 @@ describe("repair-tool-call", () => {
       toolCallId: "tool-2",
       toolName: "web_search",
       type: "tool-call",
-    });
+    }, "JSON string literal input must be unwrapped into a query object");
   });
 
   it("repairs numeric JSON literals by preserving the raw query text", async () => {
@@ -106,7 +106,7 @@ describe("repair-tool-call", () => {
       toolCallId: "tool-3",
       toolName: "web_search",
       type: "tool-call",
-    });
+    }, "numeric JSON literals must keep the raw query text");
   });
 
   it("returns null for client-executed tools named web_search", async () => {
@@ -132,7 +132,7 @@ describe("repair-tool-call", () => {
       tools: {},
     });
 
-    assertEquals(repaired, null);
+    assertEquals(repaired, null, "client-executed web_search calls must not be repaired");
   });
 
   it("returns null for unsupported tools", async () => {
@@ -151,6 +151,36 @@ describe("repair-tool-call", () => {
       tools: {},
     });
 
-    assertEquals(repaired, null);
+    assertEquals(repaired, null, "tools other than web_search must not be repaired");
+  });
+
+  it("returns null for errors that are not invalid-tool-input errors", async () => {
+    const repaired = await repairToolCall({
+      error: new Error("boom"),
+      inputSchema: async () => ({
+        additionalProperties: false,
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+        type: "object",
+      }),
+      messages: [],
+      system: undefined,
+      toolCall: {
+        input: "Veryfront",
+        providerExecuted: true,
+        toolCallId: "tool-6",
+        toolName: "web_search",
+        type: "tool-call",
+      },
+      tools: {},
+    });
+
+    assertEquals(
+      repaired,
+      null,
+      "only invalid-tool-input errors may be repaired; other failures must not fabricate a query",
+    );
   });
 });

--- a/src/agent/runtime/resume-session.test.ts
+++ b/src/agent/runtime/resume-session.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  RunAlreadyExistsError,
   RunCancelledError,
   RunResumeSessionManager,
   WaitConflictError,
@@ -63,6 +64,33 @@ describe("agent/runtime/resume-session", () => {
     );
   });
 
+  it("rejects a second startRun for a live runId and keeps the first session's signal", async () => {
+    const manager = new RunResumeSessionManager<{ ok: boolean }>();
+    const first = manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    const pending = manager.waitForSignal("run_1", "tool_1");
+
+    assertThrows(
+      () => manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() }),
+      RunAlreadyExistsError,
+      "already active",
+      "a live runId must not be admitted twice",
+    );
+    assertEquals(first.aborted, false, "the rejected duplicate must not disturb the live session");
+
+    assertEquals(
+      manager.cancelRun("run_1"),
+      true,
+      "the original session must still be cancellable",
+    );
+    assertEquals(first.aborted, true, "cancelRun must still reach the original AbortController");
+    await assertRejects(
+      () => pending,
+      RunCancelledError,
+      undefined,
+      "the original parked waiter must still be settled by the cancel",
+    );
+  });
+
   it("rejects submissions for wait keys that are not currently pending", () => {
     const manager = new RunResumeSessionManager<{ ok: boolean }>();
     manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
@@ -108,6 +136,31 @@ describe("agent/runtime/resume-session", () => {
       RunCancelledError,
     );
     assertEquals(manager.getRunStatus("run_1"), null);
+  });
+
+  it("rejects a second parked wait for a different wait key", async () => {
+    const manager = new RunResumeSessionManager<{ ok: boolean }>();
+    manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    const pending = manager.waitForSignal("run_1", "tool_1");
+
+    // Race against settled microtasks instead of awaiting the second wait
+    // directly: a displaced wait would never settle and hang the test.
+    const collision = await Promise.race([
+      manager.waitForSignal("run_1", "tool_2").then(() => "resolved", (error) => error),
+      Promise.resolve().then(() => Promise.resolve()).then(() => "still pending"),
+    ]);
+    assertEquals(
+      collision instanceof WaitNotPendingError,
+      true,
+      "a second wait key must not silently displace the parked wait",
+    );
+
+    assertEquals(
+      manager.submitSignal("run_1", { waitKey: "tool_1", value: { ok: true } }),
+      { accepted: true },
+      "the original wait must still be resolvable",
+    );
+    assertEquals(await pending, { ok: true }, "the first parked caller must receive its signal");
   });
 
   it("expires waiting runs after the configured TTL", async () => {
@@ -158,6 +211,40 @@ describe("agent/runtime/resume-session", () => {
       Error,
       "Maximum concurrent sessions (1) reached",
     );
+  });
+
+  it("frees the session slot when a run completes", () => {
+    const manager = new RunResumeSessionManager<{ ok: boolean }>({ maxConcurrentSessions: 1 });
+    manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    manager.completeRun("run_1");
+
+    assertEquals(manager.getRunStatus("run_1"), null, "a completed run must leave the session map");
+    manager.startRun({ runId: "run_2", threadId: crypto.randomUUID() });
+    assertEquals(manager.getRunStatus("run_2"), "running", "the freed slot must admit a new run");
+  });
+
+  it("frees the session slot when a run fails", () => {
+    const manager = new RunResumeSessionManager<{ ok: boolean }>({ maxConcurrentSessions: 1 });
+    manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    manager.failRun("run_1");
+
+    assertEquals(manager.getRunStatus("run_1"), null, "a failed run must leave the session map");
+    manager.startRun({ runId: "run_2", threadId: crypto.randomUUID() });
+    assertEquals(manager.getRunStatus("run_2"), "running", "the freed slot must admit a new run");
+  });
+
+  it("does not leak session slots across repeated completed runs", () => {
+    const maxConcurrentSessions = 2;
+    const manager = new RunResumeSessionManager<{ ok: boolean }>({ maxConcurrentSessions });
+
+    for (let index = 0; index <= maxConcurrentSessions; index += 1) {
+      const runId = `run_${index}`;
+      manager.startRun({ runId, threadId: crypto.randomUUID() });
+      manager.completeRun(runId);
+      assertEquals(manager.getRunStatus(runId), null, `${runId} must be released after completion`);
+    }
   });
 
   it("aborts the run signal with a DOMException AbortError so downstream fetch consumers don't leak unhandled rejections", () => {

--- a/src/agent/runtime/runtime-message-origin.test.ts
+++ b/src/agent/runtime/runtime-message-origin.test.ts
@@ -58,6 +58,16 @@ describe("agent/runtime message origin", () => {
       );
       assertEquals(isRuntimeGeneratedUserMessage(revokedMessage.proxy), false);
       assertEquals(isGenuineUserTurnMessage(revokedMessage.proxy), false);
+      assertEquals(
+        isGenuineUserTurnMessage(accessorRole),
+        false,
+        "an accessor-backed role must not count as a genuine user turn under a polluted Object.prototype.value",
+      );
+      assertEquals(
+        isGenuineUserTurnMessage({ role: "user", metadata: revoked.proxy }),
+        true,
+        "a real own-data role must still register as a user turn while the prototype is polluted",
+      );
       assertEquals(reads, 0);
     } finally {
       if (original) {

--- a/src/agent/runtime/runtime-stream-cancel.test.ts
+++ b/src/agent/runtime/runtime-stream-cancel.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assert } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { waitFor } from "#veryfront/testing/deno-compat.ts";
 import { tool } from "#veryfront/tool";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { agent } from "../index.ts";
@@ -19,8 +20,16 @@ import { scriptedModel } from "./model-runtime.test-helpers.ts";
  * rejection, so these tests fail loudly if the regression returns.
  */
 
-function flushMicrotasks(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 20));
+function decodeChunks(chunks: readonly Uint8Array[]): string {
+  const decoder = new TextDecoder();
+  return chunks.map((chunk) => decoder.decode(chunk, { stream: true })).join("");
+}
+
+async function waitForRunAbort(model: ReturnType<typeof scriptedModel>): Promise<void> {
+  await waitFor(
+    () => model.calls.some((call) => call.abortSignal?.aborted === true),
+    { message: "the run's shared signal must be aborted by the client disconnect" },
+  );
 }
 
 describe("agent runtime stream cancellation (#2334)", () => {
@@ -43,14 +52,23 @@ describe("agent runtime stream cancellation (#2334)", () => {
     assert(body !== null, "expected a streaming response body");
 
     const reader = body.getReader();
+    const chunks: Uint8Array[] = [];
     // Pull the opening frames so the run is genuinely mid-stream.
-    await reader.read();
+    const first = await reader.read();
+    if (first.value !== undefined) chunks.push(first.value);
     // The client disconnects: cancel with a foreign AbortError reason, exactly
     // as Deno hands to the stream's cancel algorithm.
     await reader.cancel(new DOMException("client disconnected", "AbortError"));
+    const afterCancel = await reader.read();
+    if (afterCancel.value !== undefined) chunks.push(afterCancel.value);
 
-    await flushMicrotasks();
-    assert(true, "cancellation completed without an unhandled rejection");
+    await waitForRunAbort(model);
+    assertEquals(afterCancel.done, true, "the body must close on cancel");
+    assertEquals(
+      decodeChunks(chunks).includes('"type":"error"'),
+      false,
+      "a client disconnect must not emit an error frame",
+    );
   });
 
   it("cancelling while a tool is executing does not raise an unhandled AbortError", async () => {
@@ -92,12 +110,46 @@ describe("agent runtime stream cancellation (#2334)", () => {
     assert(body !== null, "expected a streaming response body");
 
     const reader = body.getReader();
-    await reader.read();
+    const chunks: Uint8Array[] = [];
+    const first = await reader.read();
+    if (first.value !== undefined) chunks.push(first.value);
     await toolStarted.promise;
     await reader.cancel(new DOMException("client disconnected", "AbortError"));
     releaseTool?.();
+    const afterCancel = await reader.read();
+    if (afterCancel.value !== undefined) chunks.push(afterCancel.value);
 
-    await flushMicrotasks();
-    assert(true, "cancellation during tool execution completed cleanly");
+    await waitForRunAbort(model);
+    assertEquals(afterCancel.done, true, "the body must close on cancel during a tool call");
+    assertEquals(
+      decodeChunks(chunks).includes('"type":"error"'),
+      false,
+      "a client disconnect during tool execution must not emit an error frame",
+    );
+  });
+
+  it("closes the response body once a mid-stream reader is cancelled", async () => {
+    const model = scriptedModel([
+      { hangUntilAbort: true, parts: [{ type: "text-delta", text: "still streaming" }] },
+    ], { modelId: "hosted/cancel-close-model", only: "stream" });
+
+    const assistant = agent({
+      model: "hosted/cancel-close-model",
+      system: "cancel close test",
+      maxSteps: 1,
+      resolveModelTransport: async () => ({ model }),
+    });
+
+    const response = (await assistant.stream({ input: "hi" })).toDataStreamResponse();
+    const body = response.body;
+    assert(body !== null, "expected a streaming response body");
+
+    const reader = body.getReader();
+    const first = await reader.read();
+    assertEquals(first.done, false, "the run must be mid-stream before cancelling");
+    await reader.cancel(new DOMException("client disconnected", "AbortError"));
+
+    assertEquals((await reader.read()).done, true, "the body must close on cancel");
+    await waitForRunAbort(model);
   });
 });

--- a/src/agent/runtime/runtime-stream-cancel.test.ts
+++ b/src/agent/runtime/runtime-stream-cancel.test.ts
@@ -1,7 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { waitFor } from "#veryfront/testing/deno-compat.ts";
+import { delay, waitFor } from "#veryfront/testing/deno-compat.ts";
+import { __subscribeLogRecordEmitter, type LogEntry } from "#veryfront/utils/logger/index.ts";
 import { tool } from "#veryfront/tool";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { agent } from "../index.ts";
@@ -18,18 +19,71 @@ import { scriptedModel } from "./model-runtime.test-helpers.ts";
  * foreign reason, and the resulting rejection propagated with no handler,
  * crashing the process under Deno. Deno's test runner fails on any unhandled
  * rejection, so these tests fail loudly if the regression returns.
+ *
+ * The stream body cannot report what the runtime does after the disconnect: a
+ * cancelled reader discards the queue and every later `read()` resolves
+ * `done: true`, and `sendSSE` swallows the "controller is already closed"
+ * TypeError an out-of-band error frame would raise. The server-side branch is
+ * therefore observed through its log record — the runtime's error path in
+ * `AgentRuntime.stream` logs "Agent stream error" before it emits the error
+ * frame — plus the abort reason handed to the run and the absence of an
+ * `onFinish` callback.
  */
+
+const STREAM_ERROR_LOG_MESSAGE = "Agent stream error";
 
 function decodeChunks(chunks: readonly Uint8Array[]): string {
   const decoder = new TextDecoder();
   return chunks.map((chunk) => decoder.decode(chunk, { stream: true })).join("");
 }
 
-async function waitForRunAbort(model: ReturnType<typeof scriptedModel>): Promise<void> {
+/** Collect the runtime's stream-error log records for the duration of a run. */
+function captureStreamErrorLogs(): { records: LogEntry[]; stop: () => void } {
+  const records: LogEntry[] = [];
+  const unsubscribe = __subscribeLogRecordEmitter((entry) => {
+    if (entry.component === "agent" && entry.message === STREAM_ERROR_LOG_MESSAGE) {
+      records.push(entry);
+    }
+  });
+  return { records, stop: unsubscribe };
+}
+
+function describeRecords(records: readonly LogEntry[]): string {
+  return records.map((entry) => JSON.stringify(entry.context ?? entry.error ?? {})).join("; ");
+}
+
+async function waitForRunAbort(model: ReturnType<typeof scriptedModel>): Promise<AbortSignal> {
   await waitFor(
     () => model.calls.some((call) => call.abortSignal?.aborted === true),
     { message: "the run's shared signal must be aborted by the client disconnect" },
   );
+  const aborted = model.calls.find((call) => call.abortSignal?.aborted === true)?.abortSignal;
+  assert(aborted !== undefined, "the aborted run signal must be recoverable from the model call");
+  return aborted;
+}
+
+/** The disconnect reason the runtime received, as the client spelled it. */
+function assertClientDisconnectReason(signal: AbortSignal): void {
+  const reason = signal.reason;
+  assert(
+    reason instanceof DOMException,
+    `the run must be aborted with the client's reason, got ${String(reason)}`,
+  );
+  assertEquals(reason.name, "AbortError", "the client disconnect reason must stay an AbortError");
+  assertEquals(
+    reason.message,
+    "client disconnected",
+    "the client's cancel reason must reach the run's shared signal unchanged",
+  );
+}
+
+/**
+ * Let the aborted agent loop settle. The loop rejects as soon as the shared
+ * signal aborts, and the runtime's `catch` logs before it writes an error
+ * frame, so a misclassified disconnect has landed by the time this resolves.
+ */
+function settleAbortedRun(): Promise<void> {
+  return delay(50);
 }
 
 describe("agent runtime stream cancellation (#2334)", () => {
@@ -40,6 +94,7 @@ describe("agent runtime stream cancellation (#2334)", () => {
       { hangUntilAbort: true, parts: [{ type: "text-delta", text: "thinking" }] },
     ], { modelId: "hosted/cancel-crash-model", only: "stream" });
 
+    let finished = 0;
     const assistant = agent({
       model: "hosted/cancel-crash-model",
       system: "cancel crash test",
@@ -47,28 +102,48 @@ describe("agent runtime stream cancellation (#2334)", () => {
       resolveModelTransport: async () => ({ model }),
     });
 
-    const response = (await assistant.stream({ input: "hi" })).toDataStreamResponse();
-    const body = response.body;
-    assert(body !== null, "expected a streaming response body");
+    const streamErrors = captureStreamErrorLogs();
+    try {
+      const response = (await assistant.stream({
+        input: "hi",
+        onFinish: () => {
+          finished += 1;
+        },
+      })).toDataStreamResponse();
+      const body = response.body;
+      assert(body !== null, "expected a streaming response body");
 
-    const reader = body.getReader();
-    const chunks: Uint8Array[] = [];
-    // Pull the opening frames so the run is genuinely mid-stream.
-    const first = await reader.read();
-    if (first.value !== undefined) chunks.push(first.value);
-    // The client disconnects: cancel with a foreign AbortError reason, exactly
-    // as Deno hands to the stream's cancel algorithm.
-    await reader.cancel(new DOMException("client disconnected", "AbortError"));
-    const afterCancel = await reader.read();
-    if (afterCancel.value !== undefined) chunks.push(afterCancel.value);
+      const reader = body.getReader();
+      const chunks: Uint8Array[] = [];
+      // Pull the opening frames so the run is genuinely mid-stream.
+      const first = await reader.read();
+      assertEquals(first.done, false, "the run must be mid-stream before cancelling");
+      if (first.value !== undefined) chunks.push(first.value);
+      assertEquals(
+        decodeChunks(chunks).includes('"type":"error"'),
+        false,
+        "the frames delivered before the disconnect must not be an error frame",
+      );
+      // The client disconnects: cancel with a foreign AbortError reason, exactly
+      // as Deno hands to the stream's cancel algorithm.
+      await reader.cancel(new DOMException("client disconnected", "AbortError"));
+      assertEquals((await reader.read()).done, true, "the body must close on cancel");
 
-    await waitForRunAbort(model);
-    assertEquals(afterCancel.done, true, "the body must close on cancel");
-    assertEquals(
-      decodeChunks(chunks).includes('"type":"error"'),
-      false,
-      "a client disconnect must not emit an error frame",
-    );
+      const signal = await waitForRunAbort(model);
+      assertClientDisconnectReason(signal);
+      await settleAbortedRun();
+
+      assertEquals(
+        streamErrors.records.length,
+        0,
+        `a client disconnect must take the clean-stop branch, not the error branch that emits an error frame; logged: ${
+          describeRecords(streamErrors.records)
+        }`,
+      );
+      assertEquals(finished, 0, "a cancelled run must not report a finished response");
+    } finally {
+      streamErrors.stop();
+    }
   });
 
   it("cancelling while a tool is executing does not raise an unhandled AbortError", async () => {
@@ -97,6 +172,7 @@ describe("agent runtime stream cancellation (#2334)", () => {
       { hangUntilAbort: true },
     ], { modelId: "hosted/cancel-crash-tool", only: "stream" });
 
+    let finished = 0;
     const assistant = agent({
       model: "hosted/cancel-crash-tool",
       system: "cancel crash tool test",
@@ -105,27 +181,51 @@ describe("agent runtime stream cancellation (#2334)", () => {
       resolveModelTransport: async () => ({ model }),
     });
 
-    const response = (await assistant.stream({ input: "run the tool" })).toDataStreamResponse();
-    const body = response.body;
-    assert(body !== null, "expected a streaming response body");
+    const streamErrors = captureStreamErrorLogs();
+    try {
+      const response = (await assistant.stream({
+        input: "run the tool",
+        onFinish: () => {
+          finished += 1;
+        },
+      })).toDataStreamResponse();
+      const body = response.body;
+      assert(body !== null, "expected a streaming response body");
 
-    const reader = body.getReader();
-    const chunks: Uint8Array[] = [];
-    const first = await reader.read();
-    if (first.value !== undefined) chunks.push(first.value);
-    await toolStarted.promise;
-    await reader.cancel(new DOMException("client disconnected", "AbortError"));
-    releaseTool?.();
-    const afterCancel = await reader.read();
-    if (afterCancel.value !== undefined) chunks.push(afterCancel.value);
+      const reader = body.getReader();
+      const chunks: Uint8Array[] = [];
+      const first = await reader.read();
+      assertEquals(first.done, false, "the run must be mid-stream before cancelling");
+      if (first.value !== undefined) chunks.push(first.value);
+      assertEquals(
+        decodeChunks(chunks).includes('"type":"error"'),
+        false,
+        "the frames delivered before the disconnect must not be an error frame",
+      );
+      await toolStarted.promise;
+      await reader.cancel(new DOMException("client disconnected", "AbortError"));
+      releaseTool?.();
+      assertEquals(
+        (await reader.read()).done,
+        true,
+        "the body must close on cancel during a tool call",
+      );
 
-    await waitForRunAbort(model);
-    assertEquals(afterCancel.done, true, "the body must close on cancel during a tool call");
-    assertEquals(
-      decodeChunks(chunks).includes('"type":"error"'),
-      false,
-      "a client disconnect during tool execution must not emit an error frame",
-    );
+      const signal = await waitForRunAbort(model);
+      assertClientDisconnectReason(signal);
+      await settleAbortedRun();
+
+      assertEquals(
+        streamErrors.records.length,
+        0,
+        `a client disconnect during tool execution must take the clean-stop branch, not the error branch that emits an error frame; logged: ${
+          describeRecords(streamErrors.records)
+        }`,
+      );
+      assertEquals(finished, 0, "a cancelled tool run must not report a finished response");
+    } finally {
+      streamErrors.stop();
+    }
   });
 
   it("closes the response body once a mid-stream reader is cancelled", async () => {
@@ -150,6 +250,7 @@ describe("agent runtime stream cancellation (#2334)", () => {
     await reader.cancel(new DOMException("client disconnected", "AbortError"));
 
     assertEquals((await reader.read()).done, true, "the body must close on cancel");
-    await waitForRunAbort(model);
+    const signal = await waitForRunAbort(model);
+    assertClientDisconnectReason(signal);
   });
 });

--- a/src/agent/runtime/skill-delegation-overrides.test.ts
+++ b/src/agent/runtime/skill-delegation-overrides.test.ts
@@ -133,6 +133,28 @@ describe("skill delegation overrides", () => {
     );
   });
 
+  it("keeps an explicit invoke_agent model and thinking over the loaded skill's defaults", () => {
+    assertEquals(
+      applySkillDelegationOverridesToToolInput(
+        "invoke_agent",
+        { prompt: "p", description: "d", model: "sonnet", thinking: 4096 },
+        { model: "opus", thinking: false, maxSteps: 160 },
+      ),
+      { prompt: "p", description: "d", model: "sonnet", thinking: 4096, max_steps: 160 },
+      "caller-chosen model and thinking win; only max_steps is floored",
+    );
+
+    assertEquals(
+      applySkillDelegationOverridesToToolInput(
+        "invoke_agent",
+        { prompt: "p", description: "d", model: "   " },
+        { model: "opus" },
+      ).model,
+      "opus",
+      "a blank model is treated as omitted",
+    );
+  });
+
   it("does not inject hosted child overrides into direct invoke_agent", () => {
     const input = {
       prompt: "Research reference system",

--- a/src/agent/runtime/skill-metadata.test.ts
+++ b/src/agent/runtime/skill-metadata.test.ts
@@ -1091,7 +1091,7 @@ Deno.test("buildStrictRuntimeLoadedSkillResponse bounds direct response inputs",
   );
 });
 
-Deno.test("buildStrictRuntimeLoadedSkillResponse rejects references outside readable skill directories", () => {
+it("buildStrictRuntimeLoadedSkillResponse rejects references outside readable skill directories", () => {
   const base = {
     skillId: "bounded",
     instructions: "Body",

--- a/src/agent/runtime/skill-metadata.test.ts
+++ b/src/agent/runtime/skill-metadata.test.ts
@@ -1091,6 +1091,42 @@ Deno.test("buildStrictRuntimeLoadedSkillResponse bounds direct response inputs",
   );
 });
 
+Deno.test("buildStrictRuntimeLoadedSkillResponse rejects references outside readable skill directories", () => {
+  const base = {
+    skillId: "bounded",
+    instructions: "Body",
+  };
+
+  assertThrows(
+    () =>
+      buildStrictRuntimeLoadedSkillResponse({
+        ...base,
+        references: ["scripts/run.ts"],
+      }),
+    TypeError,
+    "references are invalid",
+    "references outside the readable skill directories must be rejected",
+  );
+  assertThrows(
+    () =>
+      buildStrictRuntimeLoadedSkillResponse({
+        ...base,
+        references: ["notes.md"],
+      }),
+    TypeError,
+    "references are invalid",
+    "bare top-level references must be rejected",
+  );
+  assertEquals(
+    buildStrictRuntimeLoadedSkillResponse({
+      ...base,
+      references: ["references/a.md", "resources/schema.json", "assets/logo.png"],
+    }).references,
+    ["assets/logo.png", "references/a.md", "resources/schema.json"],
+    "references inside every readable skill directory must be returned intact",
+  );
+});
+
 Deno.test("strict loaded responses reject direct accessors without invoking them", () => {
   let inputGetterReads = 0;
   const input = {

--- a/src/agent/runtime/skill-policy.test.ts
+++ b/src/agent/runtime/skill-policy.test.ts
@@ -87,7 +87,15 @@ describe("src/agent/runtime skill policy helpers", () => {
 
     it("should always allow load_skill regardless of policy", () => {
       assertEquals(enforceSkillPolicy("load_skill"), { allowed: true });
-      assertEquals(enforceSkillPolicy("load_skill_reference").allowed, false);
+      assertEquals(
+        enforceSkillPolicy("load_skill_reference"),
+        {
+          allowed: false,
+          error:
+            'Tool "load_skill_reference" is unavailable because no skill is loaded. Call load_skill first.',
+        },
+        "no-skill-loaded denial must point the model at load_skill",
+      );
       assertEquals(enforceSkillPolicy("execute_skill_script").allowed, false);
     });
 
@@ -113,7 +121,15 @@ describe("src/agent/runtime skill policy helpers", () => {
           },
         },
       );
-      assertEquals(result.allowed, false);
+      assertEquals(
+        result,
+        {
+          allowed: false,
+          error:
+            'Tool "load_skill_reference" is unavailable because the active skill advertises no matching file.',
+        },
+        "an active skill with no matching file must not tell the model to retry load_skill",
+      );
     });
 
     it("allows execute_skill_script only when the active skill advertises a script", () => {
@@ -138,7 +154,15 @@ describe("src/agent/runtime skill policy helpers", () => {
           },
         },
       );
-      assertEquals(result.allowed, false);
+      assertEquals(
+        result,
+        {
+          allowed: false,
+          error:
+            'Tool "execute_skill_script" is unavailable because the active skill advertises no matching file.',
+        },
+        "an active skill with no matching script must not tell the model to retry load_skill",
+      );
     });
   });
 

--- a/src/agent/runtime/stream-lifecycle-shadow.test.ts
+++ b/src/agent/runtime/stream-lifecycle-shadow.test.ts
@@ -84,28 +84,158 @@ describe("stream lifecycle shadow", () => {
       { count: 0, categories: [] },
     );
 
+    const legacyToolCalls = () =>
+      new Map([[
+        "tool-1",
+        {
+          id: "tool-1",
+          name: "web_search",
+          arguments: '{"query":"jobs"}',
+          providerExecuted: true,
+          inputAvailable: true,
+        },
+      ]]);
+
     assertEquals(
       shadow.compareLegacySnapshot({
         ...createStreamState(),
-        toolCalls: new Map([[
-          "tool-1",
-          {
-            id: "tool-1",
-            name: "web_search",
-            arguments: '{"query":"jobs"}',
-            providerExecuted: true,
-            inputAvailable: true,
-          },
-        ]]),
+        toolCalls: legacyToolCalls(),
         toolResults: [{
           toolCallId: "tool-1",
-          toolName: "web_lookup",
-          error: { count: 2, entries: ["a", "b"] },
+          toolName: "web_search",
+          output: { count: 2, entries: ["a", "b"] },
           providerExecuted: true,
           preliminary: true,
         }],
       }),
       { count: 1, categories: ["tool_result"] },
+      "preliminary divergence must be reported on its own",
+    );
+
+    assertEquals(
+      shadow.compareLegacySnapshot({
+        ...createStreamState(),
+        toolCalls: legacyToolCalls(),
+        toolResults: [{
+          toolCallId: "tool-1",
+          toolName: "web_search",
+          error: { count: 2, entries: ["a", "b"] },
+          providerExecuted: true,
+          preliminary: false,
+        }],
+      }),
+      { count: 1, categories: ["tool_result"] },
+      "error-instead-of-output divergence must be reported on its own",
+    );
+
+    assertEquals(
+      shadow.compareLegacySnapshot({
+        ...createStreamState(),
+        toolCalls: legacyToolCalls(),
+        toolResults: [{
+          toolCallId: "tool-1",
+          toolName: "web_search",
+          output: { count: 2, entries: ["a", "b"] },
+          providerExecuted: true,
+          preliminary: false,
+          dynamic: true,
+        }],
+      }),
+      { count: 1, categories: ["tool_result"] },
+      "dynamic divergence must be reported on its own",
+    );
+  });
+
+  it("reports a decoder crash as shadow_error instead of claiming agreement", () => {
+    const shadow = createStreamLifecycleShadow({
+      availableToolNames: [],
+      providerExecutedToolNames: [],
+    });
+    shadow.observePart({
+      type: "text-delta",
+      get text(): string {
+        throw new Error("decoder crash");
+      },
+    });
+    const report = shadow.compareLegacySnapshot(createStreamState());
+    assertEquals(
+      report.categories.includes("shadow_error"),
+      true,
+      "a decoder crash must be reported as shadow_error",
+    );
+    assertEquals(report.count >= 1, true, "a crashed shadow must never report zero divergence");
+  });
+
+  it("reports tool input divergence", () => {
+    const shadow = createStreamLifecycleShadow({
+      availableToolNames: ["web_search"],
+      providerExecutedToolNames: ["web_search"],
+    });
+    shadow.observePart({
+      type: "tool-input-start",
+      id: "tool-1",
+      toolName: "web_search",
+    });
+    shadow.observePart({
+      type: "tool-input-available",
+      id: "tool-1",
+      toolName: "web_search",
+      input: { query: "jobs" },
+      providerExecuted: true,
+    });
+    const report = shadow.compareLegacySnapshot({
+      ...createStreamState(),
+      toolCalls: new Map([[
+        "tool-1",
+        {
+          id: "tool-1",
+          name: "web_search",
+          arguments: '{"query":"cats"}',
+          providerExecuted: true,
+          inputAvailable: true,
+        },
+      ]]),
+    });
+    assertEquals(
+      report.categories.includes("tool_input"),
+      true,
+      "differing tool arguments must be reported as tool_input",
+    );
+    assertEquals(
+      JSON.stringify(report).includes("cats"),
+      false,
+      "reports must not leak input text",
+    );
+  });
+
+  it("reports reasoning divergence", () => {
+    const shadow = createStreamLifecycleShadow({
+      availableToolNames: [],
+      providerExecutedToolNames: [],
+    });
+    shadow.observePart({ type: "reasoning-start", id: "r-1" });
+    shadow.observePart({ type: "reasoning-delta", id: "r-1", delta: "shadow secret" });
+    const report = shadow.compareLegacySnapshot({
+      ...createStreamState(),
+      reasoningParts: [{ id: "r-1", text: "different secret" }],
+    });
+    assertEquals(
+      report.categories.includes("reasoning"),
+      true,
+      "differing reasoning text must be reported as reasoning",
+    );
+    assertEquals(
+      JSON.stringify(report).includes("secret"),
+      false,
+      "reports must not leak reasoning text",
+    );
+    assertEquals(
+      shadow.compareLegacySnapshot({
+        ...createStreamState(),
+        reasoningParts: [{ id: "r-1", text: "shadow secret" }],
+      }),
+      { count: 0, categories: [] },
+      "matching reasoning text must not be reported",
     );
   });
 

--- a/src/agent/runtime/text-generation-runtime-message-converter.test.ts
+++ b/src/agent/runtime/text-generation-runtime-message-converter.test.ts
@@ -88,6 +88,45 @@ describe("text-generation-runtime-message-converter", () => {
       assertStringIncludes(text, "application/pdf");
     });
 
+    it("keeps inline data: attachment bytes in the native file part only", () => {
+      const msg = {
+        id: "u-inline",
+        role: "user",
+        parts: [
+          { type: "text", text: "look" },
+          {
+            type: "file",
+            url: "data:image/png;base64,ABCPAYLOAD==",
+            mediaType: "image/png",
+            filename: "inline.png",
+          },
+        ],
+      } as unknown as Message;
+
+      const result = convertToTextGenerationRuntimeMessage(msg);
+
+      const content = (result as TextGenerationRuntimeUserMessage).content;
+      if (!Array.isArray(content)) {
+        throw new Error("Expected user content to preserve native file parts");
+      }
+      assertEquals(content[1], {
+        type: "file",
+        mediaType: "image/png",
+        url: "data:image/png;base64,ABCPAYLOAD==",
+        filename: "inline.png",
+      }, "inline bytes must ride in the native file part");
+      const annotation = content.flatMap((part) => part.type === "text" ? [part.text] : []).join(
+        "\n",
+      );
+      assertStringIncludes(annotation, "inline.png");
+      assertStringIncludes(annotation, "image/png");
+      assertEquals(
+        annotation.includes("data:"),
+        false,
+        "the uploaded_files annotation must never inline a data: URL",
+      );
+    });
+
     it("names the attachment when its URL is one no provider can fetch", () => {
       // The chat upload handler mints this URL: with a storage backend that
       // has no external URL of its own it falls back to the app's own origin
@@ -971,6 +1010,33 @@ describe("text-generation-runtime-message-converter", () => {
       const requestMessages = convertToTextGenerationRuntimeRequestMessages(messages);
       assertEquals(requestMessages.at(-1)?.role, "tool");
       assertEquals(requestMessages.length, historyMessages.length - 1);
+    });
+
+    it("strips every trailing assistant message, including a split unanswered tool call", () => {
+      const messages: Message[] = [
+        { id: "u1", role: "user", parts: [{ type: "text", text: "hi" }] },
+        {
+          id: "a1",
+          role: "assistant",
+          parts: [
+            { type: "tool-search", toolCallId: "tc1", toolName: "search", args: { q: "x" } },
+            { type: "text", text: "trailing" },
+          ],
+        },
+      ];
+
+      const history = convertToTextGenerationRuntimeMessages(messages);
+      assertEquals(
+        history.map((m) => m.role),
+        ["user", "assistant", "assistant"],
+        "an unanswered tool call splits the assistant turn in two",
+      );
+
+      assertEquals(
+        convertToTextGenerationRuntimeRequestMessages(messages),
+        [{ role: "user", content: "hi" }],
+        "every trailing assistant message must be stripped so the request never ends on an unanswered tool call",
+      );
     });
   });
 

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -1046,5 +1046,40 @@ describe("tool-helpers", () => {
         toolRegistryInternal.clearAll();
       }
     });
+
+    it("drops a remote tool source whose listTools rejects instead of failing the load", async () => {
+      toolRegistryInternal.clearAll();
+
+      const failing: RemoteToolSource = {
+        id: "down",
+        listTools: () => Promise.reject(new Error("remote MCP unreachable")),
+        executeTool: () => Promise.resolve({}),
+      };
+      const healthy: RemoteToolSource = {
+        id: "docs",
+        listTools: () =>
+          Promise.resolve([{
+            name: "search_docs",
+            description: "Search documentation",
+            parameters: { type: "object", properties: {} },
+          }]),
+        executeTool: () => Promise.resolve({}),
+      };
+
+      try {
+        const defs = await getAvailableTools(true, {
+          includeIntegrationTools: false,
+          remoteToolSources: [failing, healthy],
+        });
+
+        assertEquals(
+          defs.map((def) => def.name),
+          ["search_docs"],
+          "a remote source whose listTools rejects must be dropped, not fail the whole tool load",
+        );
+      } finally {
+        toolRegistryInternal.clearAll();
+      }
+    });
   });
 });

--- a/src/agent/runtime/tool-helpers.test.ts
+++ b/src/agent/runtime/tool-helpers.test.ts
@@ -2,6 +2,7 @@ import { toolRegistryInternal } from "#veryfront/tool/registry.ts";
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { __subscribeLogRecordEmitter, type LogEntry } from "#veryfront/utils/logger/index.ts";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import {
   createRemoteMCPToolSource,
@@ -1049,6 +1050,15 @@ describe("tool-helpers", () => {
 
     it("drops a remote tool source whose listTools rejects instead of failing the load", async () => {
       toolRegistryInternal.clearAll();
+      const warnings: LogEntry[] = [];
+      const unsubscribe = __subscribeLogRecordEmitter((entry) => {
+        if (
+          entry.component === "agent" && entry.level === "warn" &&
+          entry.message === "Failed to fetch remote tool definitions from source"
+        ) {
+          warnings.push(entry);
+        }
+      });
 
       const failing: RemoteToolSource = {
         id: "down",
@@ -1077,7 +1087,13 @@ describe("tool-helpers", () => {
           ["search_docs"],
           "a remote source whose listTools rejects must be dropped, not fail the whole tool load",
         );
+        assertEquals(
+          warnings.map((entry) => entry.context),
+          [{ sourceId: "down", error: "remote MCP unreachable" }],
+          "the fallback warning must identify the failed source and preserve its error",
+        );
       } finally {
+        unsubscribe();
         toolRegistryInternal.clearAll();
       }
     });

--- a/src/agent/runtime/tool-result-continuation.test.ts
+++ b/src/agent/runtime/tool-result-continuation.test.ts
@@ -46,6 +46,37 @@ describe("agent runtime streamed tool result collection", () => {
     assertEquals(shouldContinue, true);
   });
 
+  it("stops when a suppressed tool call is followed by a stop finish", () => {
+    const shouldContinue = shouldContinueAfterStreamStep({
+      accumulatedText: "",
+      finishReason: "stop",
+      toolCalls: new Map(),
+      toolResults: [],
+      suppressedToolCalls: [{ id: "tc-stale", name: "load_skill" }],
+    });
+
+    assertEquals(
+      shouldContinue,
+      false,
+      "a suppressed call must not re-invoke the model once the stream finished with stop",
+    );
+  });
+
+  it("stops on a tool-calls finish that produced no tool calls", () => {
+    const shouldContinue = shouldContinueAfterStreamStep({
+      accumulatedText: "",
+      finishReason: "tool-calls",
+      toolCalls: new Map(),
+      toolResults: [],
+    });
+
+    assertEquals(
+      shouldContinue,
+      false,
+      "a tool-calls finish with nothing streamed and nothing suppressed must terminate the run",
+    );
+  });
+
   it("continues after provider-executed tool results arrive without assistant text", () => {
     const shouldContinue = shouldContinueAfterStreamStep({
       accumulatedText: "",

--- a/src/agent/runtime/upload-url-client.test.ts
+++ b/src/agent/runtime/upload-url-client.test.ts
@@ -1,11 +1,14 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertInstanceOf, assertRejects } from "#veryfront/testing/assert.ts";
+import { VeryfrontError } from "#veryfront/errors";
 import { getRuntimeUploadUrl } from "./upload-url-client.ts";
 
 Deno.test("getRuntimeUploadUrl fetches project-scoped signed upload URLs", async () => {
   const requestedUrls: string[] = [];
-  const fetchUploadUrl = (url: string, _init: RequestInit): Promise<Response> => {
+  const inits: RequestInit[] = [];
+  const fetchUploadUrl = (url: string, init: RequestInit): Promise<Response> => {
     requestedUrls.push(url);
+    inits.push(init);
     return Promise.resolve(
       new Response(JSON.stringify({ signed_url: "https://signed.example.com/file.txt" }), {
         status: 200,
@@ -25,12 +28,24 @@ Deno.test("getRuntimeUploadUrl fetches project-scoped signed upload URLs", async
   assertEquals(requestedUrls, [
     "https://api.example.com/projects/project-1/uploads/uploads%2Fnotes.txt/url",
   ]);
+  assertEquals(
+    new Headers(inits[0]?.headers).get("Authorization"),
+    "Bearer token-1",
+    "the signed upload URL request must carry the caller's bearer credential",
+  );
+  assertEquals(
+    inits[0]?.signal instanceof AbortSignal,
+    true,
+    "the signed upload URL request must carry an abort signal so the default timeout applies",
+  );
 });
 
 Deno.test("getRuntimeUploadUrl fetches global signed upload URLs", async () => {
   const requestedUrls: string[] = [];
-  const fetchUploadUrl = (url: string, _init: RequestInit): Promise<Response> => {
+  const inits: RequestInit[] = [];
+  const fetchUploadUrl = (url: string, init: RequestInit): Promise<Response> => {
     requestedUrls.push(url);
+    inits.push(init);
     return Promise.resolve(
       new Response(JSON.stringify({ signed_url: "https://signed.example.com/global.txt" }), {
         status: 200,
@@ -47,6 +62,11 @@ Deno.test("getRuntimeUploadUrl fetches global signed upload URLs", async () => {
 
   assertEquals(signedUrl, "https://signed.example.com/global.txt");
   assertEquals(requestedUrls, ["https://api.example.com/uploads/upload-1/url"]);
+  assertEquals(
+    new Headers(inits[0]?.headers).get("Authorization"),
+    "Bearer token-1",
+    "the global signed upload URL request must carry the caller's bearer credential",
+  );
 });
 
 Deno.test("getRuntimeUploadUrl reports API errors", async () => {
@@ -57,7 +77,7 @@ Deno.test("getRuntimeUploadUrl reports API errors", async () => {
       }),
     );
 
-  await assertRejects(
+  const err = await assertRejects(
     () =>
       getRuntimeUploadUrl({
         apiUrl: "https://api.example.com",
@@ -65,9 +85,12 @@ Deno.test("getRuntimeUploadUrl reports API errors", async () => {
         uploadId: "upload-1",
         fetch: fetchUploadUrl,
       }),
-    Error,
+    VeryfrontError,
     "not allowed",
   );
+  assertInstanceOf(err, VeryfrontError, "upload-URL failures must be a VeryfrontError");
+  assertEquals(err.slug, "network-error", err.message);
+  assertEquals(err.status, 502, "upload-URL failures must map to 502 at the HTTP boundary");
 });
 
 Deno.test("getRuntimeUploadUrl rejects invalid responses", async () => {
@@ -78,7 +101,7 @@ Deno.test("getRuntimeUploadUrl rejects invalid responses", async () => {
       }),
     );
 
-  await assertRejects(
+  const err = await assertRejects(
     () =>
       getRuntimeUploadUrl({
         apiUrl: "https://api.example.com",
@@ -86,7 +109,14 @@ Deno.test("getRuntimeUploadUrl rejects invalid responses", async () => {
         uploadId: "upload-1",
         fetch: fetchUploadUrl,
       }),
-    Error,
+    VeryfrontError,
     "invalid API response",
+  );
+  assertInstanceOf(err, VeryfrontError, "invalid upload-URL responses must be a VeryfrontError");
+  assertEquals(err.slug, "network-error", err.message);
+  assertEquals(
+    err.status,
+    502,
+    "invalid upload-URL responses must map to 502 at the HTTP boundary",
   );
 });

--- a/tests/integration/agent/stream-lifecycle-mode-env.test.ts
+++ b/tests/integration/agent/stream-lifecycle-mode-env.test.ts
@@ -1,0 +1,51 @@
+import { assertEquals } from "#veryfront/testing/assert";
+import { afterEach, describe, it } from "#veryfront/testing/bdd";
+import { deleteEnv, getEnv, setEnv } from "#veryfront/compat/process.ts";
+import { resolveStreamLifecycleModeFromEnv } from "#veryfront/agent/runtime/stream-lifecycle-mode.ts";
+
+const ENV_KEY = "VF_STREAM_LIFECYCLE_MODE";
+
+describe("resolveStreamLifecycleModeFromEnv", () => {
+  const previous = getEnv(ENV_KEY);
+
+  afterEach(() => {
+    if (previous === undefined) {
+      deleteEnv(ENV_KEY);
+    } else {
+      setEnv(ENV_KEY, previous);
+    }
+  });
+
+  it("defaults to legacy when the variable is unset", () => {
+    deleteEnv(ENV_KEY);
+    assertEquals(
+      resolveStreamLifecycleModeFromEnv(),
+      "legacy",
+      "an unset VF_STREAM_LIFECYCLE_MODE must keep the legacy rollout default",
+    );
+  });
+
+  it("selects the active and shadow lifecycles from the variable", () => {
+    setEnv(ENV_KEY, "active");
+    assertEquals(
+      resolveStreamLifecycleModeFromEnv(),
+      "active",
+      "VF_STREAM_LIFECYCLE_MODE=active must select the active lifecycle",
+    );
+    setEnv(ENV_KEY, "shadow");
+    assertEquals(
+      resolveStreamLifecycleModeFromEnv(),
+      "shadow",
+      "VF_STREAM_LIFECYCLE_MODE=shadow must select the shadow lifecycle",
+    );
+  });
+
+  it("falls back to legacy for unknown values", () => {
+    setEnv(ENV_KEY, "bogus");
+    assertEquals(
+      resolveStreamLifecycleModeFromEnv(),
+      "legacy",
+      "an unknown VF_STREAM_LIFECYCLE_MODE must fall back to legacy",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Audit of all 71 test files under `src/agent/runtime`.

Every change was **mutation checked**: the named source edit was applied, the test confirmed to fail, then reverted. 50 candidate findings, 42 confirmed after adversarial verification, 8 refuted, 41 applied. **Test files only**; no source changes. One env-mutating case moved to `tests/integration/agent/stream-lifecycle-mode-env.test.ts` so the colocated unit file stays hermetic under the semantic unit-boundary audit.

## Recurring weaknesses fixed

**Bare `assertThrows` with no class or message.** Invocation-contract and model-resolution failures now pin the `VeryfrontError` slug, status and both halves of the detail message, or use `safeParse` and assert the exact issue path, so an unrelated `TypeError` no longer satisfies the test.

**Negative cases that failed for two reasons at once.** The missing-`releaseId` case also had a wrong target kind, so making `releaseId` optional still failed on the other check. It now varies only the field under test.

**Session lifecycle never exercised past start.** New cases assert `completeRun`/`failRun` free the concurrency slot (including a loop past `maxConcurrentSessions`), that a second parked wait for a different key is rejected without displacing the first, and that a duplicate `startRun` keeps the first session's abort signal.

**Branches no test reached:** data URLs kept out of the `<uploaded_files>` annotation, release sources bound to main-branch targets only, nested run-tracking markers surviving a non-run-tracked owner, oversized project skill documents failing closed without resurrecting the built-in, the default empty-conversation prompt for whitespace-only and attachment-only turns, caller model and thinking winning over skill defaults, provider alias forwarding for authored cache breakpoints, and the two distinct skill-policy remedy strings.

**Filesystem-backed traversal checks** now write real files at the traversal targets so an ENOENT can no longer stand in for the rejection.

## Verification

- Semantic unit-boundary audit: ok (base = merge-base with main), migration file untouched
- Sanitizer ratchet: ok 390/390, `test:layout` ok
- `lint:anti-slop`, `lint:test-typecheck`, `lint:skipped-tests`, `lint:ban-test-only`, `lint:cwd-relative-test-reads`, `lint:check-awaits`, `lint:cross-runtime-jsr`, `docs:api-reference:check`: all ok
- `deno fmt`, `deno lint`: clean
- **34/34** changed test files pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for agent delegation, session resumption, cancellation, streaming timeouts, and tool execution.
  * Strengthened validation for agent sources, skill references, uploaded files, provider tool schemas, and runtime inputs.
  * Improved handling of inline attachments, refreshed file URLs, structured status messages, and model errors.
  * Prevented duplicate live runs and ensured unavailable remote tools fail gracefully without affecting healthy tools.

* **Tests**
  * Expanded regression coverage across agent runtime, streaming, skills, tools, uploads, and lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->