### PR TITLE
test(server/runtime): make weak assertions bite across the runtime and services

### DIFF
--- a/scripts/lint/check-sanitizer-baseline.ts
+++ b/scripts/lint/check-sanitizer-baseline.ts
@@ -23,9 +23,9 @@ import {
 
 // Lower this when you remove sanitizer opt-outs. Never raise it without a very
 // good reason — a new opt-out means a leak is being suppressed rather than fixed.
-// 372 after the transforms/esm, module, and server-rendering audits removed
+// 366 after the transforms/esm, module, and server-runtime audits removed
 // their remaining sanitizer opt-outs.
-export const SANITIZER_OPT_OUT_BASELINE = 372;
+export const SANITIZER_OPT_OUT_BASELINE = 366;
 
 const OPT_OUT_PATTERN = /sanitize(?:Resources|Ops|Exit)\s*:\s*false/g;
 

--- a/scripts/lint/check-sanitizer-baseline.ts
+++ b/scripts/lint/check-sanitizer-baseline.ts
@@ -23,9 +23,9 @@ import {
 
 // Lower this when you remove sanitizer opt-outs. Never raise it without a very
 // good reason — a new opt-out means a leak is being suppressed rather than fixed.
-// 374 after the transforms/esm audit and this module audit removed their
-// remaining sanitizer opt-outs.
-export const SANITIZER_OPT_OUT_BASELINE = 374;
+// 372 after the transforms/esm, module, and server-rendering audits removed
+// their remaining sanitizer opt-outs.
+export const SANITIZER_OPT_OUT_BASELINE = 372;
 
 const OPT_OUT_PATTERN = /sanitize(?:Resources|Ops|Exit)\s*:\s*false/g;
 

--- a/src/channels/control-plane-routes.ts
+++ b/src/channels/control-plane-routes.ts
@@ -1,0 +1,17 @@
+/**
+ * Route patterns for the control-plane surface.
+ *
+ * These live outside `control-plane.ts` because that module is a published
+ * entrypoint (`./channels/control-plane` in deno.json). Keeping the patterns
+ * here lets the dispatch-ordering guard read the run operation verbs without
+ * widening the public API.
+ *
+ * @internal
+ */
+
+/** Matches the signed run operation routes (`execute`, `stream`, `resume`) of a control-plane run. */
+export const CONTROL_PLANE_RUN_OPERATION_PATH =
+  /^\/api\/control-plane\/runs\/[^/]+\/(?:execute|stream|resume)$/u;
+
+/** Matches the bare run route, which only DELETE addresses. */
+export const CONTROL_PLANE_RUN_PATH = /^\/api\/control-plane\/runs\/[^/]+$/u;

--- a/src/channels/control-plane.ts
+++ b/src/channels/control-plane.ts
@@ -36,7 +36,8 @@ export const DISPATCH_JWS_HEADER = "x-veryfront-dispatch-jws";
 /** The one route that accepts a signed channel dispatch envelope. */
 export const CHANNEL_INVOKE_PATH = "/channels/invoke";
 
-const CONTROL_PLANE_RUN_OPERATION_PATH =
+/** Matches the signed run operation routes (`execute`, `stream`, `resume`) of a control-plane run. */
+export const CONTROL_PLANE_RUN_OPERATION_PATH =
   /^\/api\/control-plane\/runs\/[^/]+\/(?:execute|stream|resume)$/u;
 const CONTROL_PLANE_RUN_PATH = /^\/api\/control-plane\/runs\/[^/]+$/u;
 

--- a/src/channels/control-plane.ts
+++ b/src/channels/control-plane.ts
@@ -9,7 +9,7 @@ import type { InferSchema, Schema } from "#veryfront/extensions/schema/index.ts"
 import {
   CONTROL_PLANE_RUN_OPERATION_PATH,
   CONTROL_PLANE_RUN_PATH,
-} from "./control-plane-routes.ts";
+} from "#veryfront/channels/control-plane-routes.ts";
 
 const SIGNATURE_SKEW_SECONDS = 5;
 const MAX_SIGNATURE_JWS_CODE_UNITS = 16 * 1024;

--- a/src/channels/control-plane.ts
+++ b/src/channels/control-plane.ts
@@ -6,6 +6,10 @@ import { skillRegistry } from "#veryfront/skill/registry.ts";
 import { base64urlEncodeBytes } from "#veryfront/utils/base64url.ts";
 import { defineSchema, lazySchema } from "#veryfront/schemas/index.ts";
 import type { InferSchema, Schema } from "#veryfront/extensions/schema/index.ts";
+import {
+  CONTROL_PLANE_RUN_OPERATION_PATH,
+  CONTROL_PLANE_RUN_PATH,
+} from "./control-plane-routes.ts";
 
 const SIGNATURE_SKEW_SECONDS = 5;
 const MAX_SIGNATURE_JWS_CODE_UNITS = 16 * 1024;
@@ -35,11 +39,6 @@ export const DISPATCH_JWS_HEADER = "x-veryfront-dispatch-jws";
 
 /** The one route that accepts a signed channel dispatch envelope. */
 export const CHANNEL_INVOKE_PATH = "/channels/invoke";
-
-/** Matches the signed run operation routes (`execute`, `stream`, `resume`) of a control-plane run. */
-export const CONTROL_PLANE_RUN_OPERATION_PATH =
-  /^\/api\/control-plane\/runs\/[^/]+\/(?:execute|stream|resume)$/u;
-const CONTROL_PLANE_RUN_PATH = /^\/api\/control-plane\/runs\/[^/]+$/u;
 
 /**
  * True when a method and path pair addresses a registered control-plane handler.

--- a/src/server/context/enriched-context.test.ts
+++ b/src/server/context/enriched-context.test.ts
@@ -99,6 +99,40 @@ describe("enriched-context", () => {
       assertEquals(ctx.config, stubConfig);
       assertEquals(ctx.parsedDomain, stubParsedDomain);
       assertEquals(typeof ctx.createdAt, "number");
+      assertEquals(
+        ctx.allowHostProjectCodeExecution,
+        false,
+        "hosted projects must not carry the host-realm execution grant by default",
+      );
+    });
+
+    it("grants host-realm execution to local projects", () => {
+      const ctx = buildEnrichedContext(makeOptions({ isLocalProject: true }));
+      assertEquals(
+        ctx.allowHostProjectCodeExecution,
+        true,
+        "local projects execute in the host realm",
+      );
+    });
+
+    it("grants host-realm execution to an explicitly granted hosted project", () => {
+      const ctx = buildEnrichedContext(makeOptions({ allowHostProjectCodeExecution: true }));
+      assertEquals(
+        ctx.allowHostProjectCodeExecution,
+        true,
+        "an explicit host grant is honored for a hosted project",
+      );
+    });
+
+    it("only honors a strict boolean true as the host grant", () => {
+      const ctx = buildEnrichedContext(
+        makeOptions({ allowHostProjectCodeExecution: "yes" as unknown as boolean }),
+      );
+      assertEquals(
+        ctx.allowHostProjectCodeExecution,
+        false,
+        "a truthy non-boolean must not be read as the host grant",
+      );
     });
 
     it("should set mode to 'development' for local projects", () => {

--- a/src/server/context/request-context.test.ts
+++ b/src/server/context/request-context.test.ts
@@ -276,12 +276,40 @@ describe("createRequestContext", () => {
     });
 
     it("defaults token to empty string when no header and no env", () => {
-      const req = makeRequest("https://example.com/page", {
-        host: "example.com",
-      });
-      const ctx = createRequestContext(req);
-      // Token could be empty string or from env; at minimum it should be a string
-      assertEquals(typeof ctx.token, "string");
+      const previousToken = Deno.env.get("VERYFRONT_API_TOKEN");
+      Deno.env.delete("VERYFRONT_API_TOKEN");
+      try {
+        const req = makeRequest("https://example.com/page", {
+          host: "example.com",
+        });
+        const ctx = createRequestContext(req);
+        assertEquals(
+          ctx.token,
+          "",
+          "with no x-token header and no host token the context token is the empty string",
+        );
+      } finally {
+        if (previousToken !== undefined) Deno.env.set("VERYFRONT_API_TOKEN", previousToken);
+      }
+    });
+
+    it("uses the host API token when no request credential and fallback is not disabled", () => {
+      const previousToken = Deno.env.get("VERYFRONT_API_TOKEN");
+      Deno.env.set("VERYFRONT_API_TOKEN", "host-fallback-secret");
+      try {
+        const req = makeRequest("https://example.com/page", {
+          host: "example.com",
+        });
+        const ctx = createRequestContext(req);
+        assertEquals(
+          ctx.token,
+          "host-fallback-secret",
+          "a standalone request must inherit the host API credential",
+        );
+      } finally {
+        if (previousToken !== undefined) Deno.env.set("VERYFRONT_API_TOKEN", previousToken);
+        else Deno.env.delete("VERYFRONT_API_TOKEN");
+      }
     });
 
     it("disables host-token fallback for shared proxy admission", () => {

--- a/src/server/dev-server/cache-context.test.ts
+++ b/src/server/dev-server/cache-context.test.ts
@@ -12,9 +12,14 @@ describe("dev server cache context", () => {
     assertEquals(
       resolveDevServerCacheDir(projectDir, () => undefined),
       join(projectDir, ".cache"),
+      "the dev server cache defaults to the project cache dir",
     );
     await runWithDevServerCacheDir(projectDir, async () => {
-      assertEquals(getCacheBaseDir(), join(projectDir, ".cache"));
+      assertEquals(
+        getCacheBaseDir(),
+        join(projectDir, ".cache"),
+        "runWithDevServerCacheDir must scope the cache base dir to the project",
+      );
     }, () => undefined);
   });
 
@@ -25,6 +30,23 @@ describe("dev server cache context", () => {
         (key) => key === "VERYFRONT_CACHE_DIR" ? "/configured/cache" : undefined,
       ),
       "/configured/cache",
+      "VERYFRONT_CACHE_DIR is honoured",
+    );
+    assertEquals(
+      resolveDevServerCacheDir(
+        "/projects/selected",
+        (key) => key === "VF_CACHE_DIR" ? "/alias/cache" : undefined,
+      ),
+      "/alias/cache",
+      "the VF_CACHE_DIR alias is honoured",
+    );
+    assertEquals(
+      resolveDevServerCacheDir(
+        "/projects/selected",
+        (key) => key === "VERYFRONT_CACHE_DIR" ? "/configured/cache" : "/alias/cache",
+      ),
+      "/configured/cache",
+      "VERYFRONT_CACHE_DIR wins over the alias",
     );
   });
 });

--- a/src/server/dev-server/cache-initialization.test.ts
+++ b/src/server/dev-server/cache-initialization.test.ts
@@ -15,7 +15,15 @@ describe("dev server cache initialization gate", () => {
   it("runs the cache initializers whenever a persistent local cache exists", async () => {
     const source = await readTextFile(fromFileUrl(new URL("./server.ts", import.meta.url)));
 
-    assertStringIncludes(source, "if (isPersistentLocalCacheEnabled()) {");
+    const gate = "if (isPersistentLocalCacheEnabled()) {";
+    assertStringIncludes(source, gate);
+    const gatedBlock = source.slice(source.indexOf(gate));
+    const gatedBody = gatedBlock.slice(0, gatedBlock.indexOf("\n    }\n"));
+    assertStringIncludes(
+      gatedBody,
+      "initializeDistributedCaches(defaultDistributedCacheInitializers)",
+      "the persistent-cache gate must actually run the default distributed cache initializers",
+    );
     assertEquals(
       source.includes("isDiskCacheConfigured"),
       false,

--- a/src/server/dev-server/error-overlay/html-template.test.ts
+++ b/src/server/dev-server/error-overlay/html-template.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { generateErrorHTML, generateRuntimeScript } from "./html-template.ts";
 
@@ -20,6 +20,61 @@ describe("server/dev-server/error-overlay/html-template", () => {
     it("should include XSS-safe escapeHtml function", () => {
       const script = generateRuntimeScript();
       assertEquals(script.includes("escapeHtml"), true);
+    });
+
+    it("escapes error text before writing the runtime overlay into innerHTML", () => {
+      const script = generateRuntimeScript();
+      const appended: Array<{ innerHTML: string }> = [];
+      const makeElement = () => ({ id: "", innerHTML: "", remove(): void {} });
+      const fakeDocument = {
+        referrer: "",
+        getElementById(): null {
+          return null;
+        },
+        createElement: makeElement,
+        body: {
+          appendChild(el: { innerHTML: string }): void {
+            appended.push(el);
+          },
+        },
+      };
+      const fakeWindow: Record<string, unknown> = {
+        addEventListener(): void {},
+        location: { origin: "http://localhost:3000", href: "http://localhost:3000/" },
+      };
+      fakeWindow.parent = fakeWindow;
+
+      new Function("window", "document", "WebSocket", script)(
+        fakeWindow,
+        fakeDocument,
+        class FakeWebSocket {},
+      );
+      (fakeWindow.showErrorOverlay as (info: unknown) => void)({
+        type: "runtime",
+        error: {
+          name: "Error",
+          message: "<img src=x onerror=alert(1)>",
+          stack: "<img src=x onerror=alert(2)>",
+        },
+      });
+
+      assertEquals(appended.length, 1, "the runtime overlay must be appended to the body");
+      const html = appended[0]!.innerHTML;
+      assertStringIncludes(
+        html,
+        "&lt;img src=x onerror=alert(1)&gt;",
+        "the runtime overlay must escape error.message before writing it into innerHTML",
+      );
+      assertStringIncludes(
+        html,
+        "&lt;img src=x onerror=alert(2)&gt;",
+        "the runtime overlay must escape error.stack before writing it into innerHTML",
+      );
+      assertEquals(
+        html.includes("<img src=x"),
+        false,
+        "raw error markup must never reach the overlay innerHTML",
+      );
     });
 
     it("should include url in runtimeError postMessage payload", () => {
@@ -76,9 +131,26 @@ describe("server/dev-server/error-overlay/html-template", () => {
         line: 42,
         column: 5,
       });
-      assertEquals(html.includes("src/app.tsx"), true);
-      assertEquals(html.includes("42"), true);
-      assertEquals(html.includes("5"), true);
+      assertStringIncludes(
+        html,
+        "File: src/app.tsx:42:5",
+        "the overlay must render file, line and column as one location",
+      );
+    });
+
+    it("should omit the column separator when the column is unknown", () => {
+      const html = generateErrorHTML({
+        type: "runtime",
+        error: new Error("fail"),
+        file: "src/app.tsx",
+        line: 42,
+      });
+      assertStringIncludes(html, "File: src/app.tsx:42", "file and line still render");
+      assertEquals(
+        html.includes("src/app.tsx:42:"),
+        false,
+        "no trailing separator when the column is unknown",
+      );
     });
 
     it("should include suggestion if provided", () => {

--- a/src/server/dev-server/error-overlay/overlay-renderer.test.ts
+++ b/src/server/dev-server/error-overlay/overlay-renderer.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { ErrorOverlay } from "./overlay-renderer.ts";
 
@@ -73,7 +73,11 @@ describe("server/dev-server/error-overlay/overlay-renderer", () => {
         column: 7,
       });
 
-      assertEquals(html.includes("42"), true);
+      assertStringIncludes(
+        html,
+        "/test.ts:42:7",
+        "the overlay file line must render path, line and column as one location",
+      );
     });
 
     it("should forward nonce to inline error HTML", () => {

--- a/src/server/dev-server/route-discovery.test.ts
+++ b/src/server/dev-server/route-discovery.test.ts
@@ -104,6 +104,13 @@ describe("server/dev-server/route-discovery", () => {
     adapter.fs.files.set("/project/src/app/page.tsx", "export default () => null;");
     adapter.fs.files.set("/project/src/pages/about.tsx", "export default () => null;");
     adapter.fs.files.set("/project/src/pages/guide.md", "# Guide");
+    adapter.fs.files.set(
+      "/project/src/app/(marketing)/dashboard/page.tsx",
+      "export default () => null;",
+    );
+    adapter.fs.files.set("/project/src/app/@modal/settings/page.tsx", "export default () => null;");
+    adapter.fs.files.set("/project/src/app/_components/page.tsx", "export default () => null;");
+    adapter.fs.files.set("/project/src/pages/_document.tsx", "export default () => null;");
     const router = new ApiRouteMatcher();
     const discovery = new RouteDiscovery("/project", adapter, router, {
       directories: { app: "src/app", pages: "src/pages" },
@@ -114,6 +121,31 @@ describe("server/dev-server/route-discovery", () => {
     assertEquals(router.match("/")?.route.page, "src/app/page.tsx");
     assertEquals(router.match("/about")?.route.page, "src/pages/about.tsx");
     assertEquals(router.match("/guide")?.route.page, "src/pages/guide.md");
+    assertEquals(
+      router.match("/dashboard")?.route.page,
+      "src/app/(marketing)/dashboard/page.tsx",
+      "a route group contributes no URL segment",
+    );
+    assertEquals(
+      router.match("/settings")?.route.page,
+      "src/app/@modal/settings/page.tsx",
+      "a parallel-route slot contributes no URL segment",
+    );
+    assertEquals(
+      router.match("/(marketing)/dashboard"),
+      null,
+      "the group directory name must not be addressable",
+    );
+    assertEquals(
+      router.match("/_components"),
+      null,
+      "an underscore-prefixed app directory is private and must not be routable",
+    );
+    assertEquals(
+      router.match("/_document"),
+      null,
+      "an underscore-prefixed pages file is private and must not be routable",
+    );
   });
 
   it("uses configured relative directories with remote filesystem adapters", async () => {

--- a/src/server/dev-server/server-start-failure.integration.test.ts
+++ b/src/server/dev-server/server-start-failure.integration.test.ts
@@ -17,7 +17,12 @@
  * watcher and a real TCP bind, so it is excluded from the unit shard.
  */
 
-import { assert, assertEquals, assertRejects } from "#veryfront/testing/assert";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import type { FileWatcher, WatchOptions } from "#veryfront/platform/adapters/base.ts";
 import { runtime } from "#veryfront/platform/adapters/registry.ts";
@@ -112,9 +117,16 @@ describe("DevServer start failure", () => {
           enableFastRefresh: false,
         });
 
-        await assertRejects(
+        const error = await assertRejects(
           () => server.start(),
+          Error,
+          undefined,
           "start() must reject when the port is already bound",
+        );
+        assertStringIncludes(
+          String((error as Error).message).toLowerCase(),
+          "in use",
+          "start() must reject with the underlying bind failure, not a cleanup error or a rewritten message",
         );
 
         // Guard against a vacuous pass: if the dev server never opened a

--- a/src/server/project-env/cache.test.ts
+++ b/src/server/project-env/cache.test.ts
@@ -563,8 +563,44 @@ describe("project-env/cache", () => {
     await cache.get(scope({ environmentId: "env-1" }));
     await cache.get(scope({ environmentId: "env-2" }));
     await cache.get(scope({ environmentId: "env-3" }));
-    await cache.get(scope({ environmentId: "env-1" }));
 
-    assertEquals(fetchCount, 4);
+    await cache.get(scope({ environmentId: "env-2" }));
+    await cache.get(scope({ environmentId: "env-3" }));
+    assertEquals(
+      fetchCount,
+      3,
+      "inserting env-3 must evict only the oldest entry, not flush the warm tenants",
+    );
+
+    await cache.get(scope({ environmentId: "env-1" }));
+    assertEquals(fetchCount, 4, "the evicted oldest entry must refetch");
+  });
+
+  it("keeps the recorded failures bounded", async () => {
+    let fetchCount = 0;
+    const cache = new EnvironmentVariableCache(
+      () => {
+        fetchCount++;
+        return Promise.reject(new Error(`upstream refused ${fetchCount}`));
+      },
+      60_000,
+      2,
+      { failureTtlMs: 60_000 },
+    );
+
+    await assertRejects(() => cache.get(scope({ environmentId: "env-1" })));
+    await assertRejects(() => cache.get(scope({ environmentId: "env-2" })));
+    await assertRejects(() => cache.get(scope({ environmentId: "env-3" })));
+    assertEquals(fetchCount, 3, "each distinct scope fetches once");
+
+    await assertRejects(() => cache.get(scope({ environmentId: "env-3" })));
+    assertEquals(fetchCount, 3, "the newest failure replays from the failure map");
+
+    await assertRejects(() => cache.get(scope({ environmentId: "env-1" })));
+    assertEquals(
+      fetchCount,
+      4,
+      "the oldest failure is evicted once the map exceeds maxEntries and refetches",
+    );
   });
 });

--- a/src/server/project-env/fetcher.test.ts
+++ b/src/server/project-env/fetcher.test.ts
@@ -6,6 +6,7 @@ import {
   assertStringIncludes,
 } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { createMockServer } from "../../../tests/_helpers/utils.ts";
 import {
   fetchProjectEnvVars,
@@ -72,23 +73,21 @@ function responseWithBodyCleanup(
 
 describe("project-env/fetcher", () => {
   it("maps unknown transport failures to typed 502 semantics", async () => {
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = (() => Promise.reject(new TypeError("connection refused"))) as typeof fetch;
-
-    try {
-      const error = await assertRejects(() =>
-        fetchProjectEnvVars(
-          "https://api.veryfront.test",
-          "my-project",
-          "env-123",
-          "test-token",
-        )
-      );
-      assertEquals((error as { slug?: string }).slug, "network-error");
-      assertEquals((error as { status?: number }).status, 502);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await withMockFetch(
+      (() => Promise.reject(new TypeError("connection refused"))) as typeof fetch,
+      async () => {
+        const error = await assertRejects(() =>
+          fetchProjectEnvVars(
+            "https://api.veryfront.test",
+            "my-project",
+            "env-123",
+            "test-token",
+          )
+        );
+        assertEquals((error as { slug?: string }).slug, "network-error");
+        assertEquals((error as { status?: number }).status, 502);
+      },
+    );
   });
 
   it("fetches and transforms env vars from API", async () => {
@@ -205,94 +204,91 @@ describe("project-env/fetcher", () => {
   });
 
   it("preserves the authorization error when response cleanup throws synchronously", async () => {
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = (() =>
-      Promise.resolve(
-        responseWithBodyCleanup(403, () => {
-          throw new Error("cleanup failed synchronously");
-        }),
-      )) as typeof fetch;
-
-    try {
-      const error = await assertRejects(() =>
-        fetchProjectEnvVars(
-          "https://api.veryfront.test",
-          "my-project",
-          "env-123",
-          "test-token",
-        )
-      );
-      assertEquals((error as { slug?: string }).slug, "permission-denied");
-      assertEquals((error as { status?: number }).status, 403);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await withMockFetch(
+      (() =>
+        Promise.resolve(
+          responseWithBodyCleanup(403, () => {
+            throw new Error("cleanup failed synchronously");
+          }),
+        )) as typeof fetch,
+      async () => {
+        const error = await assertRejects(() =>
+          fetchProjectEnvVars(
+            "https://api.veryfront.test",
+            "my-project",
+            "env-123",
+            "test-token",
+          )
+        );
+        assertEquals((error as { slug?: string }).slug, "permission-denied");
+        assertEquals((error as { status?: number }).status, 403);
+      },
+    );
   });
 
   it("preserves the internal request error when response cleanup rejects", async () => {
-    const originalFetch = globalThis.fetch;
     let fetchCount = 0;
-    globalThis.fetch = (() => {
-      fetchCount++;
-      return Promise.resolve(
-        fetchCount === 1
-          ? responseWithBodyCleanup(200, () => Promise.resolve())
-          : responseWithBodyCleanup(500, () => Promise.reject(new Error("cleanup rejected"))),
-      );
-    }) as typeof fetch;
-
-    try {
-      const error = await assertRejects(() =>
-        withInternalCredentials("runtime-user", "runtime-pass", () =>
-          fetchProjectEnvVars(
-            "https://api.veryfront.test",
-            "my-project",
-            "env-123",
-            "test-token",
-          ))
-      );
-      assertEquals((error as { slug?: string }).slug, "network-error");
-      assertEquals((error as { status?: number }).status, 502);
-      assertEquals(fetchCount, 2);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await withMockFetch(
+      (() => {
+        fetchCount++;
+        return Promise.resolve(
+          fetchCount === 1
+            ? responseWithBodyCleanup(200, () => Promise.resolve())
+            : responseWithBodyCleanup(500, () => Promise.reject(new Error("cleanup rejected"))),
+        );
+      }) as typeof fetch,
+      async () => {
+        const error = await assertRejects(() =>
+          withInternalCredentials("runtime-user", "runtime-pass", () =>
+            fetchProjectEnvVars(
+              "https://api.veryfront.test",
+              "my-project",
+              "env-123",
+              "test-token",
+            ))
+        );
+        assertEquals((error as { slug?: string }).slug, "network-error");
+        assertEquals((error as { status?: number }).status, 502);
+        assertEquals(fetchCount, 2);
+      },
+    );
   });
 
   it("does not wait for response cleanup before the privileged fetch", async () => {
-    const originalFetch = globalThis.fetch;
     let fetchCount = 0;
     let timeoutId: number | undefined;
-    globalThis.fetch = (() => {
-      fetchCount++;
-      return Promise.resolve(
-        fetchCount === 1
-          ? responseWithBodyCleanup(200, () => new Promise<void>(() => {}))
-          : Response.json({ data: [{ key: "API_KEY", value: "plaintext-value" }] }),
-      );
-    }) as typeof fetch;
-
-    try {
-      const timeout = Symbol("timeout");
-      const deadline = new Promise<typeof timeout>((resolve) => {
-        timeoutId = setTimeout(() => resolve(timeout), 100);
-      });
-      const result = await Promise.race([
-        withInternalCredentials("runtime-user", "runtime-pass", () =>
-          fetchProjectEnvVars(
-            "https://api.veryfront.test",
-            "my-project",
-            "env-123",
-            "test-token",
-          )),
-        deadline,
-      ]);
-      assertEquals(result, { API_KEY: "plaintext-value" });
-      assertEquals(fetchCount, 2);
-    } finally {
-      clearTimeout(timeoutId);
-      globalThis.fetch = originalFetch;
-    }
+    await withMockFetch(
+      (() => {
+        fetchCount++;
+        return Promise.resolve(
+          fetchCount === 1
+            ? responseWithBodyCleanup(200, () => new Promise<void>(() => {}))
+            : Response.json({ data: [{ key: "API_KEY", value: "plaintext-value" }] }),
+        );
+      }) as typeof fetch,
+      async () => {
+        try {
+          const timeout = Symbol("timeout");
+          const deadline = new Promise<typeof timeout>((resolve) => {
+            timeoutId = setTimeout(() => resolve(timeout), 100);
+          });
+          const result = await Promise.race([
+            withInternalCredentials("runtime-user", "runtime-pass", () =>
+              fetchProjectEnvVars(
+                "https://api.veryfront.test",
+                "my-project",
+                "env-123",
+                "test-token",
+              )),
+            deadline,
+          ]);
+          assertEquals(result, { API_KEY: "plaintext-value" });
+          assertEquals(fetchCount, 2);
+        } finally {
+          clearTimeout(timeoutId);
+        }
+      },
+    );
   });
 
   it("rejects management redirects without following them", async () => {
@@ -355,32 +351,30 @@ describe("project-env/fetcher", () => {
   });
 
   it("keeps required env fetch headers authoritative over optional Headers input", async () => {
-    const originalFetch = globalThis.fetch;
     let capturedHeaders: Headers | undefined;
-    globalThis.fetch = ((_input: string | URL | Request, init?: RequestInit) => {
-      capturedHeaders = new Headers(init?.headers);
-      return Promise.resolve(Response.json({ data: [] }));
-    }) as typeof fetch;
-
-    try {
-      await projectEnvFetcherInternals.fetchEnvironmentVariables(
-        "https://api.veryfront.test/internal/project-environment-variables",
-        "Basic runtime-secret",
-        "my-project",
-        "env-123",
-        undefined,
-        new Headers({
-          accept: "text/plain",
-          authorization: "Bearer attacker",
-          "x-project-slug": "my-project",
-        }),
-      );
-      assertEquals(capturedHeaders?.get("authorization"), "Basic runtime-secret");
-      assertEquals(capturedHeaders?.get("accept"), "application/json");
-      assertEquals(capturedHeaders?.get("x-project-slug"), "my-project");
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await withMockFetch(
+      ((_input: string | URL | Request, init?: RequestInit) => {
+        capturedHeaders = new Headers(init?.headers);
+        return Promise.resolve(Response.json({ data: [] }));
+      }) as typeof fetch,
+      async () => {
+        await projectEnvFetcherInternals.fetchEnvironmentVariables(
+          "https://api.veryfront.test/internal/project-environment-variables",
+          "Basic runtime-secret",
+          "my-project",
+          "env-123",
+          undefined,
+          new Headers({
+            accept: "text/plain",
+            authorization: "Bearer attacker",
+            "x-project-slug": "my-project",
+          }),
+        );
+        assertEquals(capturedHeaders?.get("authorization"), "Basic runtime-secret");
+        assertEquals(capturedHeaders?.get("accept"), "application/json");
+        assertEquals(capturedHeaders?.get("x-project-slug"), "my-project");
+      },
+    );
   });
 
   it("fails closed when the configured internal endpoint is absent", async () => {
@@ -478,75 +472,75 @@ describe("project-env/fetcher", () => {
   });
 
   it("does not call the internal endpoint after management authorization times out", async () => {
-    const originalFetch = globalThis.fetch;
     const paths: string[] = [];
     const controller = new AbortController();
-    globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
-      paths.push(new URL(input instanceof Request ? input.url : input).pathname);
-      return new Promise<Response>((_resolve, reject) => {
-        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
-      });
-    }) as typeof fetch;
-
-    try {
-      const assertion = assertRejects(() =>
-        withInternalCredentials("runtime-user", "runtime-pass", () =>
-          fetchProjectEnvVars(
-            "https://api.veryfront.test",
-            "my-project",
-            "env-123",
-            "test-token",
-            controller.signal,
-          ))
-      );
-      controller.abort(new Error("management timeout"));
-      const error = await assertion;
-      assertInstanceOf(error, Error);
-      assertEquals(error.message, "management timeout");
-      assertEquals(paths, ["/projects/my-project/environment-variables"]);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await withMockFetch(
+      ((input: string | URL | Request, init?: RequestInit) => {
+        paths.push(new URL(input instanceof Request ? input.url : input).pathname);
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+            once: true,
+          });
+        });
+      }) as typeof fetch,
+      async () => {
+        const assertion = assertRejects(() =>
+          withInternalCredentials("runtime-user", "runtime-pass", () =>
+            fetchProjectEnvVars(
+              "https://api.veryfront.test",
+              "my-project",
+              "env-123",
+              "test-token",
+              controller.signal,
+            ))
+        );
+        controller.abort(new Error("management timeout"));
+        const error = await assertion;
+        assertInstanceOf(error, Error);
+        assertEquals(error.message, "management timeout");
+        assertEquals(paths, ["/projects/my-project/environment-variables"]);
+      },
+    );
   });
 
   it("does not fall back after the internal request times out", async () => {
-    const originalFetch = globalThis.fetch;
     const paths: string[] = [];
     const internalRequestStarted = Promise.withResolvers<void>();
     const controller = new AbortController();
-    globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
-      const path = new URL(input instanceof Request ? input.url : input).pathname;
-      paths.push(path);
-      if (path === "/projects/my-project/environment-variables") {
-        return Promise.resolve(Response.json({ data: [] }));
-      }
-      internalRequestStarted.resolve();
-      return new Promise<Response>((_resolve, reject) => {
-        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
-      });
-    }) as typeof fetch;
-
-    try {
-      const assertion = assertRejects(() =>
-        withInternalCredentials("runtime-user", "runtime-pass", () =>
-          fetchProjectEnvVars(
-            "https://api.veryfront.test",
-            "my-project",
-            "env-123",
-            "test-token",
-            controller.signal,
-          ))
-      );
-      await internalRequestStarted.promise;
-      controller.abort(new Error("internal timeout"));
-      await assertion;
-      assertEquals(paths, [
-        "/projects/my-project/environment-variables",
-        "/internal/project-environment-variables",
-      ]);
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await withMockFetch(
+      ((input: string | URL | Request, init?: RequestInit) => {
+        const path = new URL(input instanceof Request ? input.url : input).pathname;
+        paths.push(path);
+        if (path === "/projects/my-project/environment-variables") {
+          return Promise.resolve(Response.json({ data: [] }));
+        }
+        internalRequestStarted.resolve();
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+            once: true,
+          });
+        });
+      }) as typeof fetch,
+      async () => {
+        const assertion = assertRejects(() =>
+          withInternalCredentials("runtime-user", "runtime-pass", () =>
+            fetchProjectEnvVars(
+              "https://api.veryfront.test",
+              "my-project",
+              "env-123",
+              "test-token",
+              controller.signal,
+            ))
+        );
+        await internalRequestStarted.promise;
+        controller.abort(new Error("internal timeout"));
+        await assertion;
+        assertEquals(paths, [
+          "/projects/my-project/environment-variables",
+          "/internal/project-environment-variables",
+        ]);
+      },
+    );
   });
 
   it("rejects masked values without exposing the tenant-defined key", async () => {
@@ -626,85 +620,81 @@ describe("project-env/fetcher", () => {
     // HTTP server buffered ahead of the client.
     const chunk = new Uint8Array(64 * 1024).fill(0x20);
     let emittedBytes = 0;
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = (() =>
-      Promise.resolve(
-        new Response(
-          new ReadableStream<Uint8Array>({
-            pull(controller) {
-              // Self-closes well past the cap so a missing bound fails the byte
-              // ceiling assertion instead of hanging or exhausting memory.
-              if (emittedBytes > PROJECT_ENV_RESPONSE_MAX_BYTES * 3) {
-                controller.close();
-                return;
-              }
-              emittedBytes += chunk.byteLength;
-              controller.enqueue(chunk);
-            },
-          }),
-          { headers: { "content-type": "application/json" } },
-        ),
-      )) as typeof fetch;
-
-    try {
-      const error = await assertRejects(() =>
-        fetchProjectEnvVars("https://api.veryfront.test", "my-project", "env-123", "test-token")
-      );
-      assertEquals((error as { slug?: string }).slug, "network-error");
-      assertStringIncludes(
-        String((error as Error).message),
-        "Project environment response exceeded its size limit",
-        "an oversized body must be refused by the size bound, not incidentally by JSON.parse",
-      );
-      assertEquals(
-        emittedBytes <= PROJECT_ENV_RESPONSE_MAX_BYTES + chunk.byteLength * 2,
-        true,
-        "reading must stop once the size bound is exceeded",
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    await withMockFetch(
+      (() =>
+        Promise.resolve(
+          new Response(
+            new ReadableStream<Uint8Array>({
+              pull(controller) {
+                // Self-closes well past the cap so a missing bound fails the byte
+                // ceiling assertion instead of hanging or exhausting memory.
+                if (emittedBytes > PROJECT_ENV_RESPONSE_MAX_BYTES * 3) {
+                  controller.close();
+                  return;
+                }
+                emittedBytes += chunk.byteLength;
+                controller.enqueue(chunk);
+              },
+            }),
+            { headers: { "content-type": "application/json" } },
+          ),
+        )) as typeof fetch,
+      async () => {
+        const error = await assertRejects(() =>
+          fetchProjectEnvVars("https://api.veryfront.test", "my-project", "env-123", "test-token")
+        );
+        assertEquals((error as { slug?: string }).slug, "network-error");
+        assertStringIncludes(
+          String((error as Error).message),
+          "Project environment response exceeded its size limit",
+          "an oversized body must be refused by the size bound, not incidentally by JSON.parse",
+        );
+        assertEquals(
+          emittedBytes <= PROJECT_ENV_RESPONSE_MAX_BYTES + chunk.byteLength * 2,
+          true,
+          "reading must stop once the size bound is exceeded",
+        );
+      },
+    );
   });
 
   it("refuses a declared content-length above the cap without reading the body", async () => {
     let bodyReads = 0;
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = (() =>
-      Promise.resolve(
-        new Response(
-          // highWaterMark 0 so pull only runs when a reader actually reads.
-          new ReadableStream<Uint8Array>({
-            pull(controller) {
-              bodyReads += 1;
-              controller.enqueue(new TextEncoder().encode('{"data":[]}'));
-              controller.close();
+    await withMockFetch(
+      (() =>
+        Promise.resolve(
+          new Response(
+            // highWaterMark 0 so pull only runs when a reader actually reads.
+            new ReadableStream<Uint8Array>({
+              pull(controller) {
+                bodyReads += 1;
+                controller.enqueue(new TextEncoder().encode('{"data":[]}'));
+                controller.close();
+              },
+            }, { highWaterMark: 0 }),
+            {
+              headers: {
+                "content-type": "application/json",
+                "content-length": String(PROJECT_ENV_RESPONSE_MAX_BYTES + 1),
+              },
             },
-          }, { highWaterMark: 0 }),
-          {
-            headers: {
-              "content-type": "application/json",
-              "content-length": String(PROJECT_ENV_RESPONSE_MAX_BYTES + 1),
-            },
-          },
-        ),
-      )) as typeof fetch;
-
-    try {
-      const error = await assertRejects(() =>
-        fetchProjectEnvVars("https://api.veryfront.test", "my-project", "env-123", "test-token")
-      );
-      assertStringIncludes(
-        String((error as Error).message),
-        "Project environment response exceeded its size limit",
-        "a declared length above the cap must be refused by the size bound",
-      );
-      assertEquals(
-        bodyReads,
-        0,
-        "the body must never be read once the declared length is over the cap",
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+          ),
+        )) as typeof fetch,
+      async () => {
+        const error = await assertRejects(() =>
+          fetchProjectEnvVars("https://api.veryfront.test", "my-project", "env-123", "test-token")
+        );
+        assertStringIncludes(
+          String((error as Error).message),
+          "Project environment response exceeded its size limit",
+          "a declared length above the cap must be refused by the size bound",
+        );
+        assertEquals(
+          bodyReads,
+          0,
+          "the body must never be read once the declared length is over the cap",
+        );
+      },
+    );
   });
 });

--- a/src/server/project-env/fetcher.test.ts
+++ b/src/server/project-env/fetcher.test.ts
@@ -1,5 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertInstanceOf, assertRejects } from "#veryfront/testing/assert";
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import { createMockServer } from "../../../tests/_helpers/utils.ts";
 import {
@@ -142,13 +147,41 @@ describe("project-env/fetcher", () => {
     }
   });
 
-  it("throws on non-200 response", async () => {
+  it("classifies a 401 as a rejected credential", async () => {
     const { server, port } = createMockServer(() => {
       return new Response("Unauthorized", { status: 401 });
     });
 
     try {
-      await assertRejects(() => fetchFromMockApi(port));
+      const error = await assertRejects(() => fetchFromMockApi(port));
+      assertEquals(
+        (error as { slug?: string }).slug,
+        "authentication-required",
+        "a 401 is a rejected credential, not a transient network fault",
+      );
+      assertEquals((error as { status?: number }).status, 401, "the error keeps the 401 status");
+      assertEquals(
+        (error as Error).message,
+        "Project credential was rejected",
+        "the error message names the rejected credential",
+      );
+    } finally {
+      await server.shutdown();
+    }
+  });
+
+  it("classifies a 404 as a permission failure", async () => {
+    const { server, port } = createMockServer(() => {
+      return new Response("Not Found", { status: 404 });
+    });
+
+    try {
+      const error = await assertRejects(() => fetchFromMockApi(port));
+      assertEquals(
+        (error as { slug?: string }).slug,
+        "permission-denied",
+        "a 404 is folded into the permission-denied branch",
+      );
     } finally {
       await server.shutdown();
     }
@@ -588,32 +621,90 @@ describe("project-env/fetcher", () => {
   });
 
   it("bounds streamed environment responses before JSON parsing", async () => {
+    // Served through an in-process stream rather than the mock server so the
+    // emitted byte count measures exactly what the reader pulled, not what the
+    // HTTP server buffered ahead of the client.
     const chunk = new Uint8Array(64 * 1024).fill(0x20);
     let emittedBytes = 0;
-    const { server, port } = createMockServer(() => {
-      return new Response(
-        new ReadableStream<Uint8Array>({
-          pull(controller) {
-            if (emittedBytes > PROJECT_ENV_RESPONSE_MAX_BYTES) {
-              controller.close();
-              return;
-            }
-            emittedBytes += chunk.byteLength;
-            controller.enqueue(chunk);
-          },
-        }),
-        {
-          headers: { "content-type": "application/json" },
-        },
-      );
-    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              // Self-closes well past the cap so a missing bound fails the byte
+              // ceiling assertion instead of hanging or exhausting memory.
+              if (emittedBytes > PROJECT_ENV_RESPONSE_MAX_BYTES * 3) {
+                controller.close();
+                return;
+              }
+              emittedBytes += chunk.byteLength;
+              controller.enqueue(chunk);
+            },
+          }),
+          { headers: { "content-type": "application/json" } },
+        ),
+      )) as typeof fetch;
 
     try {
-      const error = await assertRejects(() => fetchFromMockApi(port));
+      const error = await assertRejects(() =>
+        fetchProjectEnvVars("https://api.veryfront.test", "my-project", "env-123", "test-token")
+      );
       assertEquals((error as { slug?: string }).slug, "network-error");
-      assertEquals(emittedBytes <= PROJECT_ENV_RESPONSE_MAX_BYTES + chunk.byteLength * 2, true);
+      assertStringIncludes(
+        String((error as Error).message),
+        "Project environment response exceeded its size limit",
+        "an oversized body must be refused by the size bound, not incidentally by JSON.parse",
+      );
+      assertEquals(
+        emittedBytes <= PROJECT_ENV_RESPONSE_MAX_BYTES + chunk.byteLength * 2,
+        true,
+        "reading must stop once the size bound is exceeded",
+      );
     } finally {
-      await server.shutdown();
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("refuses a declared content-length above the cap without reading the body", async () => {
+    let bodyReads = 0;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response(
+          // highWaterMark 0 so pull only runs when a reader actually reads.
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              bodyReads += 1;
+              controller.enqueue(new TextEncoder().encode('{"data":[]}'));
+              controller.close();
+            },
+          }, { highWaterMark: 0 }),
+          {
+            headers: {
+              "content-type": "application/json",
+              "content-length": String(PROJECT_ENV_RESPONSE_MAX_BYTES + 1),
+            },
+          },
+        ),
+      )) as typeof fetch;
+
+    try {
+      const error = await assertRejects(() =>
+        fetchProjectEnvVars("https://api.veryfront.test", "my-project", "env-123", "test-token")
+      );
+      assertStringIncludes(
+        String((error as Error).message),
+        "Project environment response exceeded its size limit",
+        "a declared length above the cap must be refused by the size bound",
+      );
+      assertEquals(
+        bodyReads,
+        0,
+        "the body must never be read once the declared length is over the cap",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
     }
   });
 });

--- a/src/server/project-env/process-env-scope.test.ts
+++ b/src/server/project-env/process-env-scope.test.ts
@@ -186,6 +186,37 @@ describe("process.env under an active project env snapshot", () => {
     });
   });
 
+  it("merges without clearing when process.env is assigned outside any scope", () => {
+    const processLike = (globalThis as { process?: { env: Record<string, string | undefined> } })
+      .process!;
+    const view = processLike.env;
+
+    withHostVar("VF_SCOPE_PROBE_HOST_ONLY", "host-scoped-value", () => {
+      try {
+        processLike.env = { VF_SCOPE_PROBE_ASSIGNED: "assigned" };
+
+        assertEquals(processLike.env, view, "assignment must not detach the installed view");
+        assertEquals(
+          processEnv?.["VF_SCOPE_PROBE_HOST_ONLY"],
+          "host-scoped-value",
+          "a host-level assignment adds and overwrites but never clears",
+        );
+        assertEquals(
+          (processEnv?.["PATH"]?.length ?? 0) > 0,
+          true,
+          "PATH must survive a host-level assignment",
+        );
+        assertEquals(
+          processEnv?.["VF_SCOPE_PROBE_ASSIGNED"],
+          "assigned",
+          "assigned keys are added",
+        );
+      } finally {
+        delete processEnv!["VF_SCOPE_PROBE_ASSIGNED"];
+      }
+    });
+  });
+
   it("restores the host view when a nested scope exits", () => {
     withHostVar("VF_SCOPE_PROBE_HOST_ONLY", "host-scoped-value", () => {
       runWithProjectEnv({ PROJECT_VAR: "outer" }, () => {

--- a/src/server/project-env/production-environment-resolver.test.ts
+++ b/src/server/project-env/production-environment-resolver.test.ts
@@ -1,14 +1,16 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
-import { observeFetchRequestInit } from "#veryfront/testing/mock-fetch.ts";
+import {
+  installMockFetch,
+  observeFetchRequestInit,
+  restoreMockFetch,
+} from "#veryfront/testing/mock-fetch.ts";
 import {
   MAX_ENVIRONMENT_LIST_RESPONSE_BYTES,
   ProductionEnvironmentResolver,
   ProjectEnvironmentIdentityResolver,
 } from "./production-environment-resolver.ts";
-
-const originalFetch = globalThis.fetch;
 
 function requestUrlOf(input: string | URL | Request): string {
   return typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
@@ -25,22 +27,24 @@ function scope() {
 
 describe("ProductionEnvironmentResolver", () => {
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
   });
 
   it("uses bounded, redirect-safe authenticated transport and selects title-case production", async () => {
     let requestUrl: string | undefined;
     let requestInit: RequestInit | undefined;
-    globalThis.fetch = ((input, init) => {
-      requestUrl = requestUrlOf(input);
-      requestInit = init;
-      return Promise.resolve(Response.json({
-        data: [
-          { id: "env-preview", name: "Preview" },
-          { id: "env-production", name: "Production" },
-        ],
-      }));
-    }) as typeof fetch;
+    installMockFetch(
+      ((input, init) => {
+        requestUrl = requestUrlOf(input);
+        requestInit = init;
+        return Promise.resolve(Response.json({
+          data: [
+            { id: "env-preview", name: "Preview" },
+            { id: "env-production", name: "Production" },
+          ],
+        }));
+      }) as typeof fetch,
+    );
 
     const resolver = new ProductionEnvironmentResolver();
     assertEquals(await resolver.resolve(scope()), "env-production");
@@ -55,12 +59,14 @@ describe("ProductionEnvironmentResolver", () => {
 
   it("keeps a tenant-supplied slug inside its own path segment", async () => {
     let requestUrl: string | undefined;
-    globalThis.fetch = ((input) => {
-      requestUrl = requestUrlOf(input);
-      return Promise.resolve(Response.json({
-        data: [{ id: "env-production", name: "production" }],
-      }));
-    }) as typeof fetch;
+    installMockFetch(
+      ((input) => {
+        requestUrl = requestUrlOf(input);
+        return Promise.resolve(Response.json({
+          data: [{ id: "env-production", name: "production" }],
+        }));
+      }) as typeof fetch,
+    );
 
     await new ProductionEnvironmentResolver().resolve({
       ...scope(),
@@ -74,7 +80,7 @@ describe("ProductionEnvironmentResolver", () => {
   });
 
   it("preserves authorization semantics for failed lookups", async () => {
-    globalThis.fetch = (() => Promise.resolve(new Response(null, { status: 403 }))) as typeof fetch;
+    installMockFetch((() => Promise.resolve(new Response(null, { status: 403 }))) as typeof fetch);
 
     const error = await assertRejects(() => new ProductionEnvironmentResolver().resolve(scope()));
     assertEquals((error as { slug?: string }).slug, "permission-denied");
@@ -82,7 +88,7 @@ describe("ProductionEnvironmentResolver", () => {
   });
 
   it("reports a rejected project credential as authentication required", async () => {
-    globalThis.fetch = (() => Promise.resolve(new Response(null, { status: 401 }))) as typeof fetch;
+    installMockFetch((() => Promise.resolve(new Response(null, { status: 401 }))) as typeof fetch);
 
     const error = await assertRejects(() => new ProductionEnvironmentResolver().resolve(scope()));
     assertEquals(
@@ -98,7 +104,7 @@ describe("ProductionEnvironmentResolver", () => {
   });
 
   it("classifies a missing project the same as an unauthorized one", async () => {
-    globalThis.fetch = (() => Promise.resolve(new Response(null, { status: 404 }))) as typeof fetch;
+    installMockFetch((() => Promise.resolve(new Response(null, { status: 404 }))) as typeof fetch);
 
     const error = await assertRejects(() => new ProductionEnvironmentResolver().resolve(scope()));
     assertEquals(
@@ -110,13 +116,15 @@ describe("ProductionEnvironmentResolver", () => {
   });
 
   it("resolves an exact named environment and verifies its signed ID", async () => {
-    globalThis.fetch = (() =>
-      Promise.resolve(Response.json({
-        data: [
-          { id: "env-production", name: "production" },
-          { id: "env-staging", name: "staging" },
-        ],
-      }))) as typeof fetch;
+    installMockFetch(
+      (() =>
+        Promise.resolve(Response.json({
+          data: [
+            { id: "env-production", name: "production" },
+            { id: "env-staging", name: "staging" },
+          ],
+        }))) as typeof fetch,
+    );
 
     const resolver = new ProjectEnvironmentIdentityResolver();
     assertEquals(
@@ -130,10 +138,12 @@ describe("ProductionEnvironmentResolver", () => {
   });
 
   it("matches canonical named environments without depending on API letter case", async () => {
-    globalThis.fetch = (() =>
-      Promise.resolve(Response.json({
-        data: [{ id: "env-staging", name: "Staging" }],
-      }))) as typeof fetch;
+    installMockFetch(
+      (() =>
+        Promise.resolve(Response.json({
+          data: [{ id: "env-staging", name: "Staging" }],
+        }))) as typeof fetch,
+    );
 
     const resolver = new ProjectEnvironmentIdentityResolver();
     assertEquals(
@@ -147,10 +157,12 @@ describe("ProductionEnvironmentResolver", () => {
   });
 
   it("fails closed when a signed environment ID does not match project metadata", async () => {
-    globalThis.fetch = (() =>
-      Promise.resolve(Response.json({
-        data: [{ id: "env-staging", name: "staging" }],
-      }))) as typeof fetch;
+    installMockFetch(
+      (() =>
+        Promise.resolve(Response.json({
+          data: [{ id: "env-staging", name: "staging" }],
+        }))) as typeof fetch,
+    );
 
     const error = await assertRejects(() =>
       new ProjectEnvironmentIdentityResolver().resolveNamed({
@@ -164,14 +176,16 @@ describe("ProductionEnvironmentResolver", () => {
   });
 
   it("binds a named environment to its current active release", async () => {
-    globalThis.fetch = (() =>
-      Promise.resolve(Response.json({
-        data: [{
-          id: "env-staging",
-          name: "staging",
-          active_release_id: "release-staging-42",
-        }],
-      }))) as typeof fetch;
+    installMockFetch(
+      (() =>
+        Promise.resolve(Response.json({
+          data: [{
+            id: "env-staging",
+            name: "staging",
+            active_release_id: "release-staging-42",
+          }],
+        }))) as typeof fetch,
+    );
 
     const resolver = new ProjectEnvironmentIdentityResolver();
     assertEquals(
@@ -191,17 +205,19 @@ describe("ProductionEnvironmentResolver", () => {
   // identity does not match the environment active release" while the signed
   // release and the deployed release were in fact identical.
   it("binds a named environment to the release nested under its deployment", async () => {
-    globalThis.fetch = (() =>
-      Promise.resolve(Response.json({
-        data: [{
-          id: "env-staging",
-          name: "staging",
-          deployment: {
-            id: "deployment-1",
-            release: { id: "release-staging-42", deploy_status: "deployed" },
-          },
-        }],
-      }))) as typeof fetch;
+    installMockFetch(
+      (() =>
+        Promise.resolve(Response.json({
+          data: [{
+            id: "env-staging",
+            name: "staging",
+            deployment: {
+              id: "deployment-1",
+              release: { id: "release-staging-42", deploy_status: "deployed" },
+            },
+          }],
+        }))) as typeof fetch,
+    );
 
     const resolver = new ProjectEnvironmentIdentityResolver();
     assertEquals(
@@ -216,14 +232,16 @@ describe("ProductionEnvironmentResolver", () => {
   });
 
   it("still denies a nested release that does not match the signed identity", async () => {
-    globalThis.fetch = (() =>
-      Promise.resolve(Response.json({
-        data: [{
-          id: "env-staging",
-          name: "staging",
-          deployment: { release: { id: "release-other" } },
-        }],
-      }))) as typeof fetch;
+    installMockFetch(
+      (() =>
+        Promise.resolve(Response.json({
+          data: [{
+            id: "env-staging",
+            name: "staging",
+            deployment: { release: { id: "release-other" } },
+          }],
+        }))) as typeof fetch,
+    );
 
     const error = await assertRejects(() =>
       new ProjectEnvironmentIdentityResolver().resolveNamedForActiveRelease({
@@ -238,14 +256,16 @@ describe("ProductionEnvironmentResolver", () => {
 
   it("fails closed when active release metadata is missing or does not match", async () => {
     const activeReleaseIds: unknown[] = [undefined, null, "release-other"];
-    globalThis.fetch = (() =>
-      Promise.resolve(Response.json({
-        data: [{
-          id: "env-staging",
-          name: "staging",
-          active_release_id: activeReleaseIds.shift(),
-        }],
-      }))) as typeof fetch;
+    installMockFetch(
+      (() =>
+        Promise.resolve(Response.json({
+          data: [{
+            id: "env-staging",
+            name: "staging",
+            active_release_id: activeReleaseIds.shift(),
+          }],
+        }))) as typeof fetch,
+    );
 
     const resolver = new ProjectEnvironmentIdentityResolver();
     for (let index = 0; index < 3; index += 1) {
@@ -264,16 +284,18 @@ describe("ProductionEnvironmentResolver", () => {
 
   it("does not cache mutable active-release metadata", async () => {
     let fetchCalls = 0;
-    globalThis.fetch = (() => {
-      fetchCalls += 1;
-      return Promise.resolve(Response.json({
-        data: [{
-          id: "env-staging",
-          name: "staging",
-          active_release_id: fetchCalls === 1 ? "release-one" : "release-two",
-        }],
-      }));
-    }) as typeof fetch;
+    installMockFetch(
+      (() => {
+        fetchCalls += 1;
+        return Promise.resolve(Response.json({
+          data: [{
+            id: "env-staging",
+            name: "staging",
+            active_release_id: fetchCalls === 1 ? "release-one" : "release-two",
+          }],
+        }));
+      }) as typeof fetch,
+    );
 
     const resolver = new ProjectEnvironmentIdentityResolver();
     await resolver.resolveNamedForActiveRelease({
@@ -294,12 +316,14 @@ describe("ProductionEnvironmentResolver", () => {
 
   describe("named environment identity cache", () => {
     function stubFetch(counter: { calls: number }, environmentId = "env-staging") {
-      globalThis.fetch = (() => {
-        counter.calls += 1;
-        return Promise.resolve(Response.json({
-          data: [{ id: environmentId, name: "staging" }],
-        }));
-      }) as typeof fetch;
+      installMockFetch(
+        (() => {
+          counter.calls += 1;
+          return Promise.resolve(Response.json({
+            data: [{ id: environmentId, name: "staging" }],
+          }));
+        }) as typeof fetch,
+      );
     }
 
     async function warm(resolver: ProjectEnvironmentIdentityResolver, counter: { calls: number }) {
@@ -385,10 +409,12 @@ describe("ProductionEnvironmentResolver", () => {
   });
 
   it("rejects oversized lookup responses before parsing", async () => {
-    globalThis.fetch = (() =>
-      Promise.resolve(
-        new Response(" ".repeat(MAX_ENVIRONMENT_LIST_RESPONSE_BYTES + 1)),
-      )) as typeof fetch;
+    installMockFetch(
+      (() =>
+        Promise.resolve(
+          new Response(" ".repeat(MAX_ENVIRONMENT_LIST_RESPONSE_BYTES + 1)),
+        )) as typeof fetch,
+    );
 
     const error = await assertRejects(() => new ProductionEnvironmentResolver().resolve(scope()));
     assertEquals((error as { slug?: string }).slug, "network-error");
@@ -397,14 +423,16 @@ describe("ProductionEnvironmentResolver", () => {
 
   it("aborts stalled lookup work at the transport deadline", async () => {
     let observedAbort = false;
-    globalThis.fetch = ((_input, init) =>
-      new Promise<Response>((_resolve, reject) => {
-        const signal = observeFetchRequestInit(init).signal;
-        signal?.addEventListener("abort", () => {
-          observedAbort = true;
-          reject(signal.reason);
-        }, { once: true });
-      })) as typeof fetch;
+    installMockFetch(
+      ((_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = observeFetchRequestInit(init).signal;
+          signal?.addEventListener("abort", () => {
+            observedAbort = true;
+            reject(signal.reason);
+          }, { once: true });
+        })) as typeof fetch,
+    );
 
     const error = await assertRejects(() =>
       new ProductionEnvironmentResolver({ timeoutMs: 5 }).resolve(scope())
@@ -423,7 +451,7 @@ describe("ProductionEnvironmentResolver", () => {
         ],
       },
     ];
-    globalThis.fetch = (() => Promise.resolve(Response.json(bodies.shift()))) as typeof fetch;
+    installMockFetch((() => Promise.resolve(Response.json(bodies.shift()))) as typeof fetch);
 
     for (let index = 0; index < 2; index += 1) {
       const error = await assertRejects(() => new ProductionEnvironmentResolver().resolve(scope()));

--- a/src/server/project-env/production-environment-resolver.test.ts
+++ b/src/server/project-env/production-environment-resolver.test.ts
@@ -10,6 +10,10 @@ import {
 
 const originalFetch = globalThis.fetch;
 
+function requestUrlOf(input: string | URL | Request): string {
+  return typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+}
+
 function scope() {
   return {
     apiBaseUrl: "https://api.veryfront.test",
@@ -25,8 +29,10 @@ describe("ProductionEnvironmentResolver", () => {
   });
 
   it("uses bounded, redirect-safe authenticated transport and selects title-case production", async () => {
+    let requestUrl: string | undefined;
     let requestInit: RequestInit | undefined;
-    globalThis.fetch = ((_input, init) => {
+    globalThis.fetch = ((input, init) => {
+      requestUrl = requestUrlOf(input);
       requestInit = init;
       return Promise.resolve(Response.json({
         data: [
@@ -38,8 +44,33 @@ describe("ProductionEnvironmentResolver", () => {
 
     const resolver = new ProductionEnvironmentResolver();
     assertEquals(await resolver.resolve(scope()), "env-production");
+    assertEquals(
+      requestUrl,
+      "https://api.veryfront.test/projects/project-one/environments",
+      "the lookup must address the scoped project environments endpoint",
+    );
     assertEquals(requestInit?.redirect, "error");
     assertEquals(new Headers(requestInit?.headers).get("authorization"), "Bearer project-token");
+  });
+
+  it("keeps a tenant-supplied slug inside its own path segment", async () => {
+    let requestUrl: string | undefined;
+    globalThis.fetch = ((input) => {
+      requestUrl = requestUrlOf(input);
+      return Promise.resolve(Response.json({
+        data: [{ id: "env-production", name: "production" }],
+      }));
+    }) as typeof fetch;
+
+    await new ProductionEnvironmentResolver().resolve({
+      ...scope(),
+      projectSlug: "x/../../internal/admin",
+    });
+    assertEquals(
+      requestUrl,
+      "https://api.veryfront.test/projects/x%2F..%2F..%2Finternal%2Fadmin/environments",
+      "a slug must be percent-encoded so it cannot re-address the control plane",
+    );
   });
 
   it("preserves authorization semantics for failed lookups", async () => {
@@ -47,6 +78,34 @@ describe("ProductionEnvironmentResolver", () => {
 
     const error = await assertRejects(() => new ProductionEnvironmentResolver().resolve(scope()));
     assertEquals((error as { slug?: string }).slug, "permission-denied");
+    assertEquals((error as { status?: number }).status, 403);
+  });
+
+  it("reports a rejected project credential as authentication required", async () => {
+    globalThis.fetch = (() => Promise.resolve(new Response(null, { status: 401 }))) as typeof fetch;
+
+    const error = await assertRejects(() => new ProductionEnvironmentResolver().resolve(scope()));
+    assertEquals(
+      (error as { slug?: string }).slug,
+      "authentication-required",
+      "a rejected project credential must be reported as authentication required",
+    );
+    assertEquals(
+      (error as { status?: number }).status,
+      401,
+      "a rejected project credential must carry the 401 status so callers re-authenticate",
+    );
+  });
+
+  it("classifies a missing project the same as an unauthorized one", async () => {
+    globalThis.fetch = (() => Promise.resolve(new Response(null, { status: 404 }))) as typeof fetch;
+
+    const error = await assertRejects(() => new ProductionEnvironmentResolver().resolve(scope()));
+    assertEquals(
+      (error as { slug?: string }).slug,
+      "permission-denied",
+      "a missing project must not be distinguishable from an unauthorized one",
+    );
     assertEquals((error as { status?: number }).status, 403);
   });
 
@@ -231,6 +290,98 @@ describe("ProductionEnvironmentResolver", () => {
     });
 
     assertEquals(fetchCalls, 2);
+  });
+
+  describe("named environment identity cache", () => {
+    function stubFetch(counter: { calls: number }, environmentId = "env-staging") {
+      globalThis.fetch = (() => {
+        counter.calls += 1;
+        return Promise.resolve(Response.json({
+          data: [{ id: environmentId, name: "staging" }],
+        }));
+      }) as typeof fetch;
+    }
+
+    async function warm(resolver: ProjectEnvironmentIdentityResolver, counter: { calls: number }) {
+      stubFetch(counter);
+      assertEquals(
+        await resolver.resolveNamed({ ...scope(), environmentName: "staging" }),
+        "env-staging",
+      );
+      assertEquals(counter.calls, 1);
+    }
+
+    it("serves a repeated named lookup from the identity cache", async () => {
+      const counter = { calls: 0 };
+      const resolver = new ProjectEnvironmentIdentityResolver();
+      await warm(resolver, counter);
+
+      assertEquals(
+        await resolver.resolveNamed({ ...scope(), environmentName: "staging" }),
+        "env-staging",
+      );
+      assertEquals(
+        counter.calls,
+        1,
+        "a repeated named lookup must be served from the identity cache",
+      );
+    });
+
+    const isolationCases: Array<[string, Partial<ReturnType<typeof scope>>]> = [
+      ["token", { token: "other-token" }],
+      ["projectSlug", { projectSlug: "project-two" }],
+      ["projectId", { projectId: "project-id-two" }],
+      ["apiBaseUrl", { apiBaseUrl: "https://api.other.test" }],
+    ];
+
+    for (const [field, change] of isolationCases) {
+      it(`keeps ${field} in the identity cache key`, async () => {
+        const counter = { calls: 0 };
+        const resolver = new ProjectEnvironmentIdentityResolver();
+        await warm(resolver, counter);
+
+        stubFetch(counter, "env-other");
+        assertEquals(
+          await resolver.resolveNamed({ ...scope(), ...change, environmentName: "staging" }),
+          "env-other",
+          `${field} must be part of the identity cache key`,
+        );
+        assertEquals(counter.calls, 2, `changing ${field} must force a fresh lookup`);
+      });
+    }
+
+    it("still verifies the signed environment ID on a cache hit", async () => {
+      const counter = { calls: 0 };
+      const resolver = new ProjectEnvironmentIdentityResolver();
+      await warm(resolver, counter);
+
+      const error = await assertRejects(() =>
+        resolver.resolveNamed({
+          ...scope(),
+          environmentName: "staging",
+          expectedEnvironmentId: "env-production",
+        })
+      );
+      assertEquals(
+        (error as { slug?: string }).slug,
+        "permission-denied",
+        "a cache hit must still run the signed environment ID check",
+      );
+      assertEquals(counter.calls, 1, "the mismatch must be detected without a refetch");
+    });
+
+    it("refetches after clear()", async () => {
+      const counter = { calls: 0 };
+      const resolver = new ProjectEnvironmentIdentityResolver();
+      await warm(resolver, counter);
+
+      resolver.clear();
+      assertEquals(
+        await resolver.resolveNamed({ ...scope(), environmentName: "staging" }),
+        "env-staging",
+      );
+      assertEquals(counter.calls, 2, "clear() must force a refetch");
+    });
   });
 
   it("rejects oversized lookup responses before parsing", async () => {

--- a/src/server/project-env/reserved-env.test.ts
+++ b/src/server/project-env/reserved-env.test.ts
@@ -28,6 +28,53 @@ describe("server/project-env/reserved-env", () => {
     });
   });
 
+  it("strips telemetry exporter routing on a shared runtime", async () => {
+    // withEnv can only set, never unset; an empty value is falsy to isDedicatedRuntime.
+    await withEnv({ SERVER_ID: "", ENVIRONMENT_IDS: "" }, async () => {
+      const filtered = filterRuntimeProjectEnv({
+        OTEL_EXPORTER_OTLP_ENDPOINT: "https://tenant-collector.example/otlp",
+        OTEL_EXPORTER_OTLP_HEADERS: "Authorization=Basic tenant-token",
+        OPENAI_API_KEY: "project-openai-key",
+      });
+
+      assertEquals(
+        filtered,
+        { OPENAI_API_KEY: "project-openai-key" },
+        "a shared runtime must not let tenant OTLP routing reach the runtime env",
+      );
+    });
+  });
+
+  it("still strips telemetry routing when only SERVER_ID marks the runtime", async () => {
+    await withEnv({ SERVER_ID: "server-1", ENVIRONMENT_IDS: "" }, async () => {
+      const filtered = filterRuntimeProjectEnv({
+        OTEL_EXPORTER_OTLP_ENDPOINT: "https://tenant-collector.example/otlp",
+        OPENAI_API_KEY: "project-openai-key",
+      });
+
+      assertEquals(
+        filtered,
+        { OPENAI_API_KEY: "project-openai-key" },
+        "the dedicated check requires both SERVER_ID and ENVIRONMENT_IDS",
+      );
+    });
+  });
+
+  it("still strips telemetry routing when only ENVIRONMENT_IDS marks the runtime", async () => {
+    await withEnv({ SERVER_ID: "", ENVIRONMENT_IDS: "env-1" }, async () => {
+      const filtered = filterRuntimeProjectEnv({
+        OTEL_EXPORTER_OTLP_ENDPOINT: "https://tenant-collector.example/otlp",
+        OPENAI_API_KEY: "project-openai-key",
+      });
+
+      assertEquals(
+        filtered,
+        { OPENAI_API_KEY: "project-openai-key" },
+        "the dedicated check requires both SERVER_ID and ENVIRONMENT_IDS",
+      );
+    });
+  });
+
   it("keeps customer telemetry env vars for dedicated runtimes", async () => {
     await withEnv({
       SERVER_ID: "server-1",

--- a/src/server/runtime-handler/adapter-factory.test.ts
+++ b/src/server/runtime-handler/adapter-factory.test.ts
@@ -1042,11 +1042,48 @@ describe("adapter-factory", () => {
       const base = createMockAdapter({});
 
       // Non-extended adapter (no runWithContext) takes the direct getConfig path.
-      // Config loading may succeed or throw — either outcome is valid.
-      let succeeded = false;
-      let threw = false;
-      try {
-        const result = await resolveAdapter({
+      const result = await resolveAdapter({
+        projectDir: "/base/project",
+        adapter: base,
+        config: undefined,
+        projectSlug: "proxy-slug",
+        projectId: "proj_proxy",
+        proxyToken: "tok-123",
+        releaseId: undefined,
+        proxyEnv: "preview",
+        branch: null,
+        environmentName: undefined,
+        parsedDomain: {
+          slug: null,
+          branch: null,
+          environment: null,
+          isVeryfrontDomain: false,
+          isDraft: false,
+          allowIframeEmbed: false,
+        },
+        req: await makeReq(),
+        isProxyMode: true,
+        prepareHostedConfigContext: preparePreviewHostedConfigContext,
+      });
+
+      assertEquals(
+        result.configOutcome,
+        "hosted",
+        "a non-extended adapter still loads the project config",
+      );
+      assertEquals(
+        result.config?.title,
+        "Veryfront App",
+        "the loaded config, not a default, is returned",
+      );
+    });
+
+    it("surfaces a missing evaluation context for a non-extended adapter", async () => {
+      const base = createMockAdapter({});
+      const req = await makeReq();
+
+      const error = await assertRejects(() =>
+        resolveAdapter({
           projectDir: "/base/project",
           adapter: base,
           config: undefined,
@@ -1065,19 +1102,53 @@ describe("adapter-factory", () => {
             isDraft: false,
             allowIframeEmbed: false,
           },
-          req: await makeReq(),
+          req,
           isProxyMode: true,
-        });
-        succeeded = true;
-        // If it succeeds, verify the result has the expected shape
-        assertEquals("projectDir" in result, true);
-        assertEquals("adapter" in result, true);
-      } catch {
-        threw = true;
-      }
+        })
+      );
+      assertEquals(
+        (error as { slug?: string }).slug,
+        "cache-invariant-violation",
+        "a missing evaluation context must surface, not be swallowed",
+      );
+    });
 
-      // One of the two paths must have been taken
-      assertEquals(succeeded || threw, true);
+    it("defers config for a production proxy request with no resolved release", async () => {
+      const { adapter } = createExtendedMockAdapter();
+
+      const result = await resolveAdapter({
+        projectDir: "/base/project",
+        adapter,
+        config: undefined,
+        projectSlug: "proxy-slug",
+        projectId: "proj_proxy",
+        proxyToken: "tok-123",
+        releaseId: undefined,
+        proxyEnv: "production",
+        branch: null,
+        environmentName: undefined,
+        parsedDomain: {
+          slug: null,
+          branch: null,
+          environment: null,
+          isVeryfrontDomain: false,
+          isDraft: false,
+          allowIframeEmbed: false,
+        },
+        req: new Request("http://example.com/"),
+        pathname: "/",
+        isProxyMode: true,
+        prepareHostedConfigContext: () => {
+          throw new Error("hosted config must not be prepared before a release is resolved");
+        },
+      });
+
+      assertEquals(result.config, undefined, "no config is loaded before a release is resolved");
+      assertEquals(
+        result.configOutcome,
+        "deferred",
+        "a production proxy request with no resolved releaseId must defer, not attempt a hosted config load",
+      );
     });
   });
 

--- a/src/server/runtime-handler/derive-project-csp.test.ts
+++ b/src/server/runtime-handler/derive-project-csp.test.ts
@@ -21,7 +21,12 @@ const SOURCE = [{
  */
 function createHostedAdapter(options: { requireInitialization: boolean }) {
   let initialized = false;
-  const calls = { ensureFresh: 0, listSource: 0, ranInContext: 0 };
+  const calls = {
+    ensureFresh: 0,
+    listSource: 0,
+    ranInContext: 0,
+    lastOptions: undefined as { waitForWarmup?: boolean } | undefined,
+  };
 
   const underlying = {
     ensureSourceSnapshotFresh: (_reason?: string) => {
@@ -29,8 +34,12 @@ function createHostedAdapter(options: { requireInitialization: boolean }) {
       initialized = true;
       return Promise.resolve();
     },
-    getAllSourceFiles: () => {
+    getAllSourceFiles: (readOptions?: { waitForWarmup?: boolean }) => {
       calls.listSource += 1;
+      calls.lastOptions = readOptions;
+      // Like the real adapter, the in-flight file-list fetch is only awaited
+      // when the caller asks for it; otherwise the read answers empty.
+      if (readOptions?.waitForWarmup !== true) return Promise.resolve([]);
       if (options.requireInitialization && !initialized) return Promise.resolve([]);
       return Promise.resolve(SOURCE);
     },
@@ -76,6 +85,11 @@ describe("server/runtime-handler/deriveProjectCspOrigins", () => {
     const derived = await deriveProjectCspOrigins({ adapter, ...PRODUCTION });
 
     assertEquals(derived?.["img-src"], ["https://images.unsplash.com"]);
+    assertEquals(
+      calls.lastOptions?.waitForWarmup,
+      true,
+      "the source read must wait for the in-flight file-list fetch",
+    );
     assert(calls.ensureFresh > 0, "the adapter must be initialized before its source is read");
     assertEquals(calls.ranInContext, 1, "the read stays inside the tenant context");
   });

--- a/src/server/runtime-handler/dispatch-exemption-ordering.test.ts
+++ b/src/server/runtime-handler/dispatch-exemption-ordering.test.ts
@@ -29,7 +29,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { Handler, RoutePattern } from "#veryfront/types";
 import { createHandlerRegistry } from "#veryfront/server/runtime-handler/index.ts";
-import { CONTROL_PLANE_RUN_OPERATION_PATH } from "#veryfront/channels/control-plane.ts";
+import { CONTROL_PLANE_RUN_OPERATION_PATH } from "#veryfront/channels/control-plane-routes.ts";
 import {
   CHANNEL_INVOKE_PATH,
   isChannelDispatchRoute,

--- a/src/server/runtime-handler/dispatch-exemption-ordering.test.ts
+++ b/src/server/runtime-handler/dispatch-exemption-ordering.test.ts
@@ -29,6 +29,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { Handler, RoutePattern } from "#veryfront/types";
 import { createHandlerRegistry } from "#veryfront/server/runtime-handler/index.ts";
+import { CONTROL_PLANE_RUN_OPERATION_PATH } from "#veryfront/channels/control-plane.ts";
 import {
   CHANNEL_INVOKE_PATH,
   isChannelDispatchRoute,
@@ -223,6 +224,33 @@ describe("signed-dispatch exemptions: handler ordering invariant", () => {
       `The set of routes the dispatch predicates admit no longer matches the table in this ` +
         `file. Add the new route and its owning handler to ADMITTED_ROUTES so its position ` +
         `relative to ApiHandlerWrapper is checked. ${CONSEQUENCE}`,
+    );
+  });
+
+  it("lists every run operation verb the control-plane predicate admits", () => {
+    // The probe list above can only catch a widened predicate for the shapes it
+    // happens to contain. Read the verb alternation out of the predicate's own
+    // pattern so a fourth run operation cannot be admitted without a row here.
+    const alternation = CONTROL_PLANE_RUN_OPERATION_PATH.source.match(/\(\?:([^)]*)\)\$$/u);
+    assertEquals(
+      alternation !== null,
+      true,
+      "CONTROL_PLANE_RUN_OPERATION_PATH must keep its run operation verbs in a literal " +
+        "alternation group so this inventory can read them",
+    );
+    const verbs = alternation![1]!.split("|").toSorted();
+
+    const runOperationPrefix = `/api/control-plane/runs/${RUN_ID}/`;
+    const listedVerbs = ADMITTED_ROUTES
+      .filter((route) => route.method === "POST" && route.path.startsWith(runOperationPrefix))
+      .map((route) => route.path.slice(runOperationPrefix.length))
+      .toSorted();
+
+    assertEquals(
+      verbs,
+      listedVerbs,
+      `A new signed-dispatch run operation must be added to ADMITTED_ROUTES with its owning ` +
+        `handler, which must sit ahead of ApiHandlerWrapper. ${CONSEQUENCE}`,
     );
   });
 });

--- a/src/server/runtime-handler/environment-resolution.test.ts
+++ b/src/server/runtime-handler/environment-resolution.test.ts
@@ -27,6 +27,60 @@ describe("environment-resolution", () => {
     assertEquals(result.resolvedEnvironment, "production");
   });
 
+  it("prefers the proxy environment header over the request-context mode", () => {
+    const result = resolveEnvironment({
+      proxyEnv: "preview",
+      reqCtxMode: "production",
+      releaseId: undefined,
+      projectSlug: "my-project",
+      projectId: "proj_123",
+      environmentName: undefined,
+      host: "my-project.preview.veryfront.com",
+      isLocalProject: false,
+      isProxyMode: true,
+      pathname: "/",
+      defaultEnvironment: undefined,
+    });
+
+    assertEquals(
+      result.resolvedEnvironment,
+      "preview",
+      "the proxy environment header wins over the request-context mode",
+    );
+    assertEquals(
+      result.errorResponse,
+      undefined,
+      "a preview resolution must not hit production release validation",
+    );
+  });
+
+  it("resolves production from the proxy header when the request context says preview", () => {
+    const result = resolveEnvironment({
+      proxyEnv: "production",
+      reqCtxMode: "preview",
+      releaseId: undefined,
+      projectSlug: "my-project",
+      projectId: "proj_123",
+      environmentName: undefined,
+      host: "my-project.production.veryfront.com",
+      isLocalProject: false,
+      isProxyMode: true,
+      pathname: "/",
+      defaultEnvironment: undefined,
+    });
+
+    assertEquals(
+      result.resolvedEnvironment,
+      "production",
+      "the proxy environment header wins over the request-context mode",
+    );
+    assertEquals(
+      result.errorResponse?.status,
+      404,
+      "a production resolution without a release returns the canonical 404",
+    );
+  });
+
   it("allows missing releaseId for local projects in proxy production", () => {
     const result = resolveEnvironment({
       proxyEnv: "production",

--- a/src/server/runtime-handler/handler-context-builder.test.ts
+++ b/src/server/runtime-handler/handler-context-builder.test.ts
@@ -1,11 +1,14 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   buildHandlerContext,
   buildMinimalContext,
   type HandlerContextOptions,
 } from "./handler-context-builder.ts";
+
+const prepareHostedConfigContext: NonNullable<HandlerContextOptions["prepareHostedConfigContext"]> =
+  () => Promise.resolve({} as any);
 
 function makeOpts(overrides: Partial<HandlerContextOptions> = {}): HandlerContextOptions {
   return {
@@ -19,6 +22,10 @@ function makeOpts(overrides: Partial<HandlerContextOptions> = {}): HandlerContex
     projectSlug: "my-project",
     projectId: "proj-123",
     releaseId: "rel-456",
+    branchId: "branch-1",
+    branchName: "feature-x",
+    defaultBranchName: "main",
+    prepareHostedConfigContext,
     proxyToken: "secret-token",
     environmentName: "production",
     resolvedEnvironment: "production",
@@ -53,6 +60,26 @@ describe("buildHandlerContext", () => {
     assertEquals(ctx.projectSlug, "my-project");
     assertEquals(ctx.projectId, "proj-123");
     assertEquals(ctx.releaseId, "rel-456");
+    assertEquals(
+      ctx.branchId,
+      "branch-1",
+      "the hosted agent-source check needs the canonical branch id",
+    );
+    assertEquals(
+      ctx.branchName,
+      "feature-x",
+      "the hosted agent-source check needs the canonical branch name",
+    );
+    assertEquals(
+      ctx.defaultBranchName,
+      "main",
+      "the hosted agent-source check needs the project default branch name",
+    );
+    assertStrictEquals(
+      ctx.prepareHostedConfigContext,
+      opts.prepareHostedConfigContext,
+      "the hosted config preparer must pass through by identity",
+    );
     assertEquals(ctx.proxyToken, "secret-token");
     assertEquals(ctx.environmentName, "production");
     assertEquals(ctx.resolvedEnvironment, "production");

--- a/src/server/runtime-handler/handler-registry-factory.test.ts
+++ b/src/server/runtime-handler/handler-registry-factory.test.ts
@@ -62,6 +62,51 @@ function createMockHandler(
   return mock;
 }
 
+/**
+ * Every handler the runtime must serve. A name removed from HANDLER_NAMES stops
+ * serving its endpoint while the count assertion below shrinks with it, so the
+ * membership is pinned here independently of the list the factory maps over.
+ */
+const EXPECTED_HANDLER_NAMES = [
+  "AuthHandler",
+  "CsrfHandler",
+  "HMRHandler",
+  "CorsHandler",
+  "HealthHandler",
+  "MetricsHandler",
+  "MemoryDebugHandler",
+  "ClientLogHandler",
+  "DevEndpointsHandler",
+  "StylesCSSHandler",
+  "DebugContextHandler",
+  "OpenAPIHandler",
+  "OpenAPIDocsHandler",
+  "InternalAgentsListHandler",
+  "PublicAgentsListHandler",
+  "PublicAgentMetadataHandler",
+  "AgentStreamHandler",
+  "AgentRunResumeHandler",
+  "AgentRunCancelHandler",
+  "ProjectRunExecuteHandler",
+  "ChannelInvokeHandler",
+  "DevDashboardHandler",
+  "ProjectsHandler",
+  "StudioBridgeModulesHandler",
+  "ProdHydrationModuleHandler",
+  "CSSHandler",
+  "DevFileHandler",
+  "SnippetHandler",
+  "CspReportHandler",
+  "StaticHandler",
+  "LibModulesHandler",
+  "RSCHandler",
+  "ModuleHandler",
+  "ApiHandlerWrapper",
+  "MarkdownPreviewHandler",
+  "SSRHandler",
+  "NotFoundHandler",
+] as const;
+
 describe("server/runtime-handler/createHandlerRegistry", () => {
   const adapter = createMockAdapter();
   const projectDir = "/tmp/test-project";
@@ -73,17 +118,13 @@ describe("server/runtime-handler/createHandlerRegistry", () => {
     // Should have all handlers from HANDLER_NAMES registered
     assertEquals(stats.totalHandlers, HANDLER_NAMES.length);
 
-    // Verify key handlers are present
-    const names = stats.handlerNames;
-    assertEquals(names.includes("AuthHandler"), true);
-    assertEquals(names.includes("CsrfHandler"), true);
-    assertEquals(names.includes("CorsHandler"), true);
-    assertEquals(names.includes("HealthHandler"), true);
-    assertEquals(names.includes("SSRHandler"), true);
-    assertEquals(names.includes("NotFoundHandler"), true);
-    assertEquals(names.includes("ApiHandlerWrapper"), true);
-    assertEquals(names.includes("HMRHandler"), true);
-    assertEquals(names.includes("InternalAgentsListHandler"), true);
+    // Membership is compared as a sorted set; chain order is owned by the
+    // priority sort test below and dispatch-exemption-ordering.test.ts.
+    assertEquals(
+      [...stats.handlerNames].sort(),
+      [...EXPECTED_HANDLER_NAMES].sort(),
+      "a handler removed from HANDLER_NAMES stops serving its endpoint; add or remove it here deliberately",
+    );
   });
 
   it("returns handlers sorted by priority (lowest number = highest priority)", () => {

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -276,22 +276,61 @@ describe("server/runtime-handler/index", () => {
 
   it("allows proxy context only behind the operator-trusted topology", async () => {
     const handler = createProxyModeHandler();
+    const isolationCalls = { check: 0, start: 0, complete: 0 };
+    injectIsolationDepsForTests({
+      checkRequest: () => {
+        isolationCalls.check += 1;
+        return { allowed: true };
+      },
+      startRequest: () => {
+        isolationCalls.start += 1;
+      },
+      completeRequest: () => {
+        isolationCalls.complete += 1;
+      },
+    });
     Deno.env.set("VERYFRONT_TRUST_FORWARDED_HEADERS", "1");
 
-    const response = await handler(
-      new Request("http://localhost/page", {
-        headers: {
-          "x-project-slug": "my-project",
-          "x-token": "proxy-token",
-          "x-forwarded-host": "my-project.production.veryfront.com",
-          "x-release-id": "rel_123",
-        },
-      }),
-    );
+    try {
+      const response = await handler(
+        new Request("http://localhost/page", {
+          headers: {
+            "x-project-slug": "my-project",
+            "x-token": "proxy-token",
+            "x-forwarded-host": "my-project.production.veryfront.com",
+            "x-release-id": "rel_123",
+          },
+        }),
+      );
 
-    assertEquals(response.status === 502, false);
-    const body = await response.text();
-    assertEquals(body.includes("proxy context headers require a trusted upstream proxy"), false);
+      assertEquals(response.status === 502, false);
+      const body = await response.text();
+      assertEquals(body.includes("proxy context headers require a trusted upstream proxy"), false);
+      assertEquals(
+        body.includes("Untrusted proxy context"),
+        false,
+        "an operator-trusted topology must not be rejected by the proxy guard",
+      );
+      assertEquals(
+        isolationCalls.check,
+        1,
+        "a trusted proxy request must reach the isolation-gated pipeline",
+      );
+      assertEquals(
+        isolationCalls.start,
+        1,
+        "admission must start the request rather than short-circuit at the proxy guard",
+      );
+      // The fixture project has no loadable config, so the first failure past
+      // the proxy guard is config loading. Reaching it proves admission.
+      assertEquals(
+        body.includes("config-parse-error"),
+        true,
+        "a trusted proxy request must be admitted through to project runtime resolution",
+      );
+    } finally {
+      Deno.env.delete("VERYFRONT_TRUST_FORWARDED_HEADERS");
+    }
   });
 
   it("returns 502 when trust-sensitive proxy context headers are present but untrusted", async () => {

--- a/src/server/runtime-handler/isolation.test.ts
+++ b/src/server/runtime-handler/isolation.test.ts
@@ -8,6 +8,7 @@ import {
   completeIsolatedRequestOnSettlement,
   createIsolationErrorResponse,
   type IsolationCheckResult,
+  projectIsolation,
   startIsolatedRequest,
 } from "./isolation.ts";
 
@@ -47,6 +48,31 @@ describe("isolation", () => {
 
       checkRequestIsolation(undefined, true);
       assertEquals(receivedSlug, undefined);
+    });
+
+    it("reaches the real projectIsolation when no deps are injected", () => {
+      const slug = "isolation-default-probe";
+      __injectDepsForTests(null);
+
+      assertEquals(
+        checkRequestIsolation(slug, true),
+        { allowed: true },
+        "the default wiring must bind projectIsolation, not lose its receiver",
+      );
+
+      startIsolatedRequest(slug, true);
+      assertEquals(
+        projectIsolation.getStats()[slug]?.inFlight,
+        1,
+        "startRequest must reach the real manager",
+      );
+
+      completeIsolatedRequest(slug, true, false);
+      assertEquals(
+        projectIsolation.getStats()[slug]?.inFlight,
+        0,
+        "completeRequest must reach the real manager",
+      );
     });
   });
 

--- a/src/server/runtime-handler/local-project-discovery.test.ts
+++ b/src/server/runtime-handler/local-project-discovery.test.ts
@@ -110,6 +110,28 @@ describe("local-project-discovery", () => {
       assertEquals(localProjectCache.has("myproject"), false);
     });
 
+    it("falls through to standard discovery after an invalid headerPath override", async () => {
+      const adapter = createMockAdapter({
+        "/custom/path": { isDirectory: true },
+        // Missing app/pages/components
+        "data/projects/myproject": { isDirectory: true },
+        "data/projects/myproject/app": { isDirectory: true },
+      });
+
+      const path = await findLocalProjectPath("myproject", adapter, "/custom/path");
+
+      assertEquals(
+        path?.endsWith("data/projects/myproject"),
+        true,
+        "an invalid x-project-path override must fall through to standard discovery",
+      );
+      assertEquals(
+        localProjectCache.get("myproject")?.endsWith("data/projects/myproject"),
+        true,
+        "the standard-directory result must still be cached",
+      );
+    });
+
     it("returns cached path if available", async () => {
       const adapter = createMockAdapter({});
       localProjectCache.set("cached-project", "/cached/path");
@@ -229,6 +251,13 @@ describe("local-project-discovery", () => {
       cache.projects.set("c", "/c"); // should evict "a"
       assertEquals(cache.projects.has("a"), false);
       assertEquals(cache.projects.has("c"), true);
+
+      const adapterA = {} as RuntimeAdapter;
+      const adapterB = {} as RuntimeAdapter;
+      cache.adapters.set("/a", adapterA);
+      cache.adapters.set("/b", adapterB);
+      assertEquals(cache.adapters.has("/a"), false, "maxAdapters: 1 must evict the older adapter");
+      assertEquals(cache.adapters.has("/b"), true, "the most recent adapter is retained");
     });
 
     it("injected cache isolates state from default singleton", () => {

--- a/src/server/runtime-handler/monitoring-probe-auth.test.ts
+++ b/src/server/runtime-handler/monitoring-probe-auth.test.ts
@@ -27,6 +27,7 @@ import type { SecurityConfig } from "#veryfront/types";
 import { createHandlerRegistry } from "./index.ts";
 import { buildMinimalContext } from "./handler-context-builder.ts";
 import { setServerInitialized } from "#veryfront/server/handlers/monitoring/health.handler.ts";
+import { PLATFORM_LIVENESS_PROBE_PATHS } from "#veryfront/security/http/platform-liveness-probe.ts";
 import { isMonitoringPath } from "./request-utils.ts";
 
 /** Kubelet probe paths, exactly as the operator manifest declares them. */
@@ -58,6 +59,7 @@ async function probe(
   pathname: string,
   securityConfig: SecurityConfig | null,
   env: Record<string, string> = {},
+  method = "GET",
 ): Promise<Response> {
   assertEquals(isMonitoringPath(pathname), true, `${pathname} must take the monitoring fast path`);
 
@@ -66,8 +68,8 @@ async function probe(
   const { registry } = createHandlerRegistry(projectDir, adapter);
   const ctx = buildMinimalContext(projectDir, adapter, securityConfig, false, undefined);
 
-  // A kubelet probe: bare GET, no Authorization header, no cookies.
-  const req = new Request(`http://10.42.0.17:3001${pathname}`, { method: "GET" });
+  // A kubelet probe: bare GET (or HEAD), no Authorization header, no cookies.
+  const req = new Request(`http://10.42.0.17:3001${pathname}`, { method });
   const response = await registry.execute(req, ctx);
   return response ?? new Response("Not Found", { status: 404 });
 }
@@ -125,6 +127,66 @@ describe("kubelet probes vs the project auth gate", () => {
 
   it("answer 200 when the auth gate comes from VERYFRONT_BEARER_TOKEN", async () => {
     await assertProbesAnswerOk(null, { VERYFRONT_BEARER_TOKEN: "vf_probe_token" });
+  });
+
+  it("keeps HEAD exempt on the probe paths", async () => {
+    setServerInitialized(true);
+    try {
+      for (const path of KUBELET_PROBE_PATHS) {
+        const res = await probe(path, BASIC_AUTH, {}, "HEAD");
+        await res.body?.cancel();
+        assertEquals(res.status, 200, `HEAD ${path} is a probe method and must stay exempt`);
+      }
+    } finally {
+      setServerInitialized(false);
+    }
+  });
+
+  it("gates non-probe methods on the probe paths", async () => {
+    setServerInitialized(true);
+    try {
+      for (const path of KUBELET_PROBE_PATHS) {
+        const res = await probe(path, BASIC_AUTH, {}, "POST");
+        await res.body?.cancel();
+        assertEquals(
+          res.status,
+          401,
+          `POST ${path}: only GET and HEAD are exempt; any other method is a site visitor and stays gated`,
+        );
+        assertEquals(res.headers.get("WWW-Authenticate"), 'Basic realm="Secure Area"');
+      }
+    } finally {
+      setServerInitialized(false);
+    }
+  });
+
+  it("keeps /_health gated when the project configures auth", async () => {
+    assertEquals(
+      PLATFORM_LIVENESS_PROBE_PATHS.includes("/_health"),
+      false,
+      "only the orchestrator probe paths may be exempt from the auth gate",
+    );
+    setServerInitialized(true);
+    try {
+      for (const securityConfig of [BASIC_AUTH, BEARER_AUTH]) {
+        const res = await probe("/_health", securityConfig);
+        await res.body?.cancel();
+        assertEquals(
+          res.status,
+          401,
+          "/_health discloses runtime version and build mode, so the project auth gate must still apply",
+        );
+      }
+      const basic = await probe("/_health", BASIC_AUTH);
+      await basic.body?.cancel();
+      assertEquals(
+        basic.headers.get("WWW-Authenticate"),
+        'Basic realm="Secure Area"',
+        "the gated probe path must return the auth challenge",
+      );
+    } finally {
+      setServerInitialized(false);
+    }
   });
 
   it("keeps gating a project page while basic auth is configured", async () => {

--- a/src/server/runtime-handler/project-isolation.test.ts
+++ b/src/server/runtime-handler/project-isolation.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { FakeTime } from "#std/testing/time";
 import { ProjectIsolationManager } from "./project-isolation.ts";
 
 describe("server/runtime-handler/project-isolation", () => {
@@ -72,7 +73,13 @@ describe("server/runtime-handler/project-isolation", () => {
       const result = manager.checkRequest("proj");
       assertEquals(result.allowed, false);
       assertEquals(result.reason, "circuit_open");
-      assertEquals(typeof result.waitTimeMs, "number");
+      const waitTimeMs = result.waitTimeMs ?? 0;
+      assert(waitTimeMs > 0, "an open circuit must return a positive retry hint");
+      assert(
+        waitTimeMs <= 60_000,
+        "the retry hint cannot exceed the configured circuitResetTimeMs",
+      );
+      assert(waitTimeMs > 59_000, "a just-opened circuit must report nearly the full reset window");
       manager.shutdown();
     });
 
@@ -174,6 +181,30 @@ describe("server/runtime-handler/project-isolation", () => {
       manager.startRequest("proj");
       manager.completeRequest("proj", true);
       assertEquals(manager.getStats()["proj"]?.circuitOpen, true);
+      manager.shutdown();
+    });
+
+    it("should not count failures older than the failure window", () => {
+      using time = new FakeTime();
+      const manager = createManager({ circuitBreakerThreshold: 2, failureWindowMs: 5_000 });
+
+      manager.startRequest("proj");
+      manager.completeRequest("proj", true);
+      // Below the 60s cleanup interval, so only recordTimeout's own filter can prune.
+      time.tick(6_000);
+      manager.startRequest("proj");
+      manager.completeRequest("proj", true);
+
+      assertEquals(
+        manager.getStats()["proj"]?.recentFailures,
+        1,
+        "a failure older than failureWindowMs must not count toward the breaker",
+      );
+      assertEquals(
+        manager.getStats()["proj"]?.circuitOpen,
+        false,
+        "two failures separated by more than the window must not open the circuit",
+      );
       manager.shutdown();
     });
   });

--- a/src/server/runtime-handler/project-middleware.test.ts
+++ b/src/server/runtime-handler/project-middleware.test.ts
@@ -226,6 +226,34 @@ describe("ProjectMiddlewareRuntime", () => {
     assertEquals(loadCount, 4);
   });
 
+  it("evicts cached production middleware for the invalidated project", async () => {
+    const adapter = createAdapter();
+    let loadCount = 0;
+    const runtime = new ProjectMiddlewareRuntime({
+      loadMiddleware: () => {
+        loadCount++;
+        return Promise.resolve([]);
+      },
+    });
+
+    await execute(runtime, createContext(adapter));
+    assertEquals(loadCount, 1);
+    assertEquals(runtime.size, 1);
+
+    assertEquals(runtime.invalidateProject("nope"), 0, "a non-matching identity must not evict");
+    assertEquals(runtime.size, 1, "a non-matching identity must leave the cache intact");
+
+    assertEquals(
+      runtime.invalidateProject("project-a"),
+      1,
+      "invalidation must evict the compiled middleware entry",
+    );
+    assertEquals(runtime.size, 0, "the invalidated project must have no cached middleware");
+
+    await execute(runtime, createContext(adapter));
+    assertEquals(loadCount, 2, "a request after invalidation must reload the middleware");
+  });
+
   it("does not cache shared middleware without a canonical project ID", async () => {
     const adapter = createAdapter();
     let loadCount = 0;

--- a/src/server/runtime-handler/project-resolution.test.ts
+++ b/src/server/runtime-handler/project-resolution.test.ts
@@ -646,5 +646,100 @@ describe("server/runtime-handler/project-resolution", () => {
       assertEquals(result.parsedDomain.isVeryfrontDomain, true);
       assertEquals(result.parsedDomain.slug, "my-project");
     });
+
+    it("resolves the active release for a production veryfront domain without an x-release-id", async () => {
+      let lookupCount = 0;
+      __injectDepsForTests({
+        parseProjectDomain: () => ({
+          ...defaultParsedDomain,
+          slug: "my-project",
+          environment: "production",
+          isVeryfrontDomain: true,
+          isDraft: false,
+        }),
+        lookupProjectByDomain: () => {
+          lookupCount++;
+          return Promise.resolve({
+            project_id: "proj-7",
+            project_slug: "my-project",
+            project_name: "My Project",
+            environment: { id: "env-7", name: "Production" },
+            release_id: "rel-7",
+          });
+        },
+        getEnvironmentType: () => undefined,
+      });
+
+      const req = new Request("http://my-project.production.veryfront.com/");
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+      const result = await resolveProject(req, url, headers, {
+        config: { fs: { veryfront: { apiToken: "test-token" } } } as unknown as VeryfrontConfig,
+        reqCtx: { slug: "my-project", mode: undefined, branch: null, token: undefined },
+        defaultProjectSlug: undefined,
+        defaultProjectId: undefined,
+        wsSlugOverride: undefined,
+      });
+
+      assertEquals(lookupCount, 1, "a production veryfront domain must look up its release");
+      assertEquals(
+        result.releaseId,
+        "rel-7",
+        "a production veryfront domain must resolve its active release",
+      );
+      assertEquals(result.projectId, "proj-7", "the release lookup must supply the project id");
+      assertEquals(
+        result.environmentName,
+        "Production",
+        "the release lookup must supply the environment name",
+      );
+      assertEquals(
+        result.proxyEnv,
+        "production",
+        "a resolved release pins the production environment",
+      );
+    });
+
+    it("skips the release lookup for a draft veryfront domain", async () => {
+      let lookupCount = 0;
+      __injectDepsForTests({
+        parseProjectDomain: () => ({
+          ...defaultParsedDomain,
+          slug: "my-project",
+          environment: "production",
+          isVeryfrontDomain: true,
+          isDraft: true,
+        }),
+        lookupProjectByDomain: () => {
+          lookupCount++;
+          return Promise.resolve({
+            project_id: "proj-7",
+            project_slug: "my-project",
+            project_name: "My Project",
+            environment: { id: "env-7", name: "Production" },
+            release_id: "rel-7",
+          });
+        },
+        getEnvironmentType: () => undefined,
+      });
+
+      const req = new Request("http://my-project.production.veryfront.com/");
+      const url = new URL(req.url);
+      const headers = extractRequestHeaders(req, url);
+      const result = await resolveProject(req, url, headers, {
+        config: { fs: { veryfront: { apiToken: "test-token" } } } as unknown as VeryfrontConfig,
+        reqCtx: { slug: "my-project", mode: undefined, branch: null, token: undefined },
+        defaultProjectSlug: undefined,
+        defaultProjectId: undefined,
+        wsSlugOverride: undefined,
+      });
+
+      assertEquals(lookupCount, 0, "a draft veryfront domain must not look up a release");
+      assertEquals(
+        result.releaseId,
+        undefined,
+        "a draft veryfront domain must not resolve a release",
+      );
+    });
   });
 });

--- a/src/server/runtime-handler/request-lifecycle.test.ts
+++ b/src/server/runtime-handler/request-lifecycle.test.ts
@@ -55,18 +55,62 @@ describe("server/runtime-handler/request-lifecycle", () => {
         headers: { "x-request-id": "custom-id" },
       });
       const ctx = startRequestLifecycle(req, "/test", false);
-      // The requestId should incorporate the incoming id
-      assertEquals(typeof ctx.requestId, "string");
+      assertEquals(
+        ctx.requestId,
+        "custom-id",
+        "an incoming x-request-id must be carried into the request id",
+      );
+      ctx.stopTotal();
+    });
+
+    it("should mint a fresh id when no x-request-id header is present", () => {
+      const req = new Request("http://localhost/test");
+      const ctx = startRequestLifecycle(req, "/test", false);
+      assertEquals(
+        ctx.requestId !== "custom-id",
+        true,
+        "a missing header must not reuse a previous request id",
+      );
+      assertEquals(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-/u.test(ctx.requestId),
+        true,
+        "a missing x-request-id header must mint a fresh UUID",
+      );
       ctx.stopTotal();
     });
   });
 
   describe("endRequestLifecycle", () => {
-    it("should call stopTotal and handle perfRequestId", () => {
-      const req = new Request("http://localhost/test");
-      const ctx = startRequestLifecycle(req, "/test", false);
-      // Should not throw
+    it("should call stopTotal exactly once", () => {
+      let stops = 0;
+      const ctx = {
+        requestId: "lifecycle-end",
+        perfRequestId: undefined,
+        stopTotal: () => {
+          stops++;
+        },
+        shouldCheckIsolation: true,
+      };
       endRequestLifecycle(ctx);
+      assertEquals(stops, 1, "endRequestLifecycle must stop the total request timer exactly once");
+    });
+
+    it("should call stopTotal and handle perfRequestId", () => {
+      let stops = 0;
+      const ctx = {
+        requestId: "lifecycle-end-perf",
+        perfRequestId: "perf-1",
+        stopTotal: () => {
+          stops++;
+        },
+        shouldCheckIsolation: true,
+      };
+      endRequestLifecycle(ctx);
+      assertEquals(
+        stops,
+        1,
+        "endRequestLifecycle must stop the total request timer when a perf id is present",
+      );
     });
   });
 

--- a/src/server/runtime-handler/request-tracker.test.ts
+++ b/src/server/runtime-handler/request-tracker.test.ts
@@ -140,28 +140,97 @@ describe("server/runtime-handler/request-tracker", () => {
   });
 
   describe("module request logging", () => {
-    it("should handle module request path completion without error", () => {
+    const hasCompletionLog = (entries: LogEntry[], line: string): boolean =>
+      entries.some((entry) => String(entry.message).includes(line));
+
+    it("should handle module request path completion without a per request log", () => {
+      const entries = captureLogs();
       requestTracker.start("req-mod", "proj", "/_vf_modules/foo.js", "GET");
       requestTracker.complete("req-mod", 200);
+      assertEquals(
+        hasCompletionLog(entries, "GET /_vf_modules/foo.js 200"),
+        false,
+        "a fast lightweight module must not emit a per request completion log",
+      );
+
+      requestTracker.start("req-page", "proj", "/page", "GET");
+      requestTracker.complete("req-page", 200);
+      assertEquals(
+        hasCompletionLog(entries, "GET /page 200"),
+        true,
+        "an ordinary request must still emit a completion log",
+      );
     });
 
     it("should treat lightweight stylesheet requests as internal assets", () => {
+      const entries = captureLogs();
       requestTracker.start("req-style", "proj", "/_vf_styles/styles.css", "GET");
       requestTracker.complete("req-style", 200);
+      assertEquals(
+        hasCompletionLog(entries, "GET /_vf_styles/styles.css 200"),
+        false,
+        "a fast lightweight asset must not emit a per request completion log",
+      );
+
+      requestTracker.start("req-page", "proj", "/page", "GET");
+      requestTracker.complete("req-page", 200);
+      assertEquals(
+        hasCompletionLog(entries, "GET /page 200"),
+        true,
+        "an ordinary request must still emit a completion log",
+      );
     });
 
-    it("should handle _veryfront module path completion without error", () => {
-      requestTracker.start("req-vf", "proj", "/_veryfront/bar.js", "GET");
+    it("should handle _veryfront module path completion without a per request log", () => {
+      const entries = captureLogs();
+      requestTracker.start("req-vf", "proj", "/_veryfront/modules/bar.js", "GET");
       requestTracker.complete("req-vf", 200);
+      assertEquals(
+        hasCompletionLog(entries, "GET /_veryfront/modules/bar.js 200"),
+        false,
+        "a fast lightweight module must not emit a per request completion log",
+      );
+
+      requestTracker.start("req-page", "proj", "/page", "GET");
+      requestTracker.complete("req-page", 200);
+      assertEquals(
+        hasCompletionLog(entries, "GET /page 200"),
+        true,
+        "an ordinary request must still emit a completion log",
+      );
     });
   });
 
   describe("WebSocket path handling", () => {
     it("should not set slow timer for WebSocket path", () => {
-      requestTracker.start("req-ws", "proj", "/_ws", "GET");
-      // Just verify it doesn't crash and tracks correctly
-      assertEquals(requestTracker.getInFlightCount() >= 1, true);
-      requestTracker.complete("req-ws", 101);
+      const scheduledDelays: number[] = [];
+      const originalSetTimeout = globalThis.setTimeout;
+
+      globalThis.setTimeout = ((callback: TimerHandler, delay?: number, ...args: unknown[]) => {
+        if (delay !== undefined) scheduledDelays.push(delay);
+        return originalSetTimeout(callback, delay, ...args);
+      }) as typeof setTimeout;
+
+      try {
+        requestTracker.start("req-ws", "proj", "/_ws", "GET");
+        assertEquals(
+          scheduledDelays.includes(10_000),
+          false,
+          "a WebSocket path must not arm the slow-request timer",
+        );
+
+        scheduledDelays.length = 0;
+        requestTracker.start("req-page", "proj", "/page", "GET");
+        assertEquals(
+          scheduledDelays.includes(10_000),
+          true,
+          "an ordinary request must still arm the slow-request timer",
+        );
+      } finally {
+        requestTracker.complete("req-ws", 101);
+        requestTracker.complete("req-page", 200);
+        globalThis.setTimeout = originalSetTimeout;
+      }
     });
   });
 
@@ -507,7 +576,30 @@ describe("server/runtime-handler/request-tracker", () => {
 
     it("should clear both slow and very slow timers on completion", () => {
       const clearedTimers: ReturnType<typeof setTimeout>[] = [];
+      const originalSetTimeout = globalThis.setTimeout;
       const originalClearTimeout = globalThis.clearTimeout;
+      let slowHandle: ReturnType<typeof setTimeout> | undefined;
+      let verySlowHandle: ReturnType<typeof setTimeout> | undefined;
+      const createInertTimerHandle = () => {
+        const handle = originalSetTimeout(() => {}, 0);
+        originalClearTimeout(handle);
+        return handle;
+      };
+
+      // Fire the slow timer synchronously so the very slow timer gets armed
+      // before completion, then record both handles.
+      globalThis.setTimeout = ((callback: TimerHandler, delay?: number, ...args: unknown[]) => {
+        if (delay === 10_000) {
+          slowHandle = createInertTimerHandle();
+          if (typeof callback === "function") callback(...args);
+          return slowHandle;
+        }
+        if (delay === 15_000) {
+          verySlowHandle = createInertTimerHandle();
+          return verySlowHandle;
+        }
+        return originalSetTimeout(callback, delay, ...args);
+      }) as typeof setTimeout;
       globalThis.clearTimeout = ((id?: ReturnType<typeof setTimeout>) => {
         if (id !== undefined) clearedTimers.push(id);
         originalClearTimeout(id);
@@ -515,12 +607,23 @@ describe("server/runtime-handler/request-tracker", () => {
 
       try {
         requestTracker.start("req-timer", "proj", "/slow", "GET");
+        assertEquals(slowHandle !== undefined, true, "the slow timer must be armed");
+        assertEquals(verySlowHandle !== undefined, true, "the very slow timer must be armed");
+
         requestTracker.complete("req-timer", 200);
 
-        // Should have cleared the slow timer (verySlowTimer hasn't been set
-        // yet since the outer timer hasn't fired)
-        assertEquals(clearedTimers.length >= 1, true);
+        assertEquals(
+          clearedTimers.includes(slowHandle!),
+          true,
+          "complete() must clear the slow timer",
+        );
+        assertEquals(
+          clearedTimers.includes(verySlowHandle!),
+          true,
+          "complete() must clear the very slow timer or a finished request logs 'Very slow request - likely stuck'",
+        );
       } finally {
+        globalThis.setTimeout = originalSetTimeout;
         globalThis.clearTimeout = originalClearTimeout;
       }
     });

--- a/src/server/runtime-handler/timeout-manager.test.ts
+++ b/src/server/runtime-handler/timeout-manager.test.ts
@@ -27,14 +27,26 @@ describe("timeout-manager", () => {
 
     it("returns error wrapper for handler exceptions", async () => {
       const handler = async (): Promise<Response> => {
-        throw new Error("Handler failed");
+        throw new Error("Handler failed at /srv/secret/path?token=abc");
       };
 
       const { response, error } = await withRequestTimeout(handler, "/test", "GET");
 
       assertEquals(response.status, 500);
       assertExists(error);
-      assertEquals(error.message, "Handler failed");
+      assertEquals(error.message, "Handler failed at /srv/secret/path?token=abc");
+      assertEquals(
+        response.headers.get("content-type"),
+        "text/html; charset=utf-8",
+        "unknown exceptions must keep the opaque HTML error page",
+      );
+      const html = await response.text();
+      assertEquals(
+        html.includes("Handler failed"),
+        false,
+        "the internal exception message must never reach the client",
+      );
+      assertEquals(html.length > 0, true, "the opaque page must still have a body");
     });
 
     it("returns error wrapper when a handler throws before returning a promise", async () => {

--- a/src/server/runtime-handler/tracing.test.ts
+++ b/src/server/runtime-handler/tracing.test.ts
@@ -1,21 +1,121 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
+import { assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  _resetShimForTests,
+  type Context,
+  propagation,
+  setGlobalTracerProvider,
+  type Span,
+  trace,
+  type Tracer,
+} from "#veryfront/observability/tracing/api-shim.ts";
 import {
   endRequestTracing,
   executeWithTracingContext,
+  getRequestTraceContext,
   setProjectAttributes,
   setRequestAttributes,
   startRequestTracing,
 } from "./tracing.ts";
 
+const INCOMING_TRACE_ID = "4bf92f3577b34da6a3ce929d0e0e4736";
+const INCOMING_SPAN_ID = "00f067aa0ba902b7";
+
+function createFakeSpan(traceId: string, spanId: string): Span {
+  const span = {
+    setAttribute: () => span,
+    setAttributes: () => span,
+    setStatus: () => span,
+    recordException: () => {},
+    addEvent: () => span,
+    end: () => {},
+    spanContext: () => ({ traceId, spanId, traceFlags: 1 }),
+    updateName: () => {},
+  };
+  return span as unknown as Span;
+}
+
+function randomHex(length: number): string {
+  return Array.from({ length }, () => Math.floor(Math.random() * 16).toString(16)).join("");
+}
+
+/**
+ * Wire a tracer that continues the trace found in the parent context and a
+ * W3C-style propagator that reads `traceparent`, so trace continuity across the
+ * runtime boundary is observable without the OTel SDK.
+ */
+function installFakeTracing(): { spanNames: string[] } {
+  const spanNames: string[] = [];
+  const tracer: Tracer = {
+    startSpan: ((name: string, _options?: unknown, ctx?: Context) => {
+      spanNames.push(name);
+      const parent = ctx ? trace.getSpan(ctx) : undefined;
+      const traceId = parent?.spanContext().traceId ?? randomHex(32);
+      return createFakeSpan(traceId, randomHex(16));
+    }) as Tracer["startSpan"],
+    startActiveSpan: ((_name: string, ...rest: unknown[]) => {
+      const fn = rest.find((arg) => typeof arg === "function") as
+        | ((span: Span) => unknown)
+        | undefined;
+      return fn?.(createFakeSpan(randomHex(32), randomHex(16)));
+    }) as Tracer["startActiveSpan"],
+  };
+  setGlobalTracerProvider({ getTracer: () => tracer });
+  propagation.setGlobalPropagator({
+    inject: () => {},
+    extract: (ctx, carrier) => {
+      const traceparent = (carrier as Record<string, string>)["traceparent"];
+      if (!traceparent) return ctx;
+      const [, traceId = "", spanId = ""] = traceparent.split("-");
+      return trace.setSpan(ctx, createFakeSpan(traceId, spanId));
+    },
+    fields: () => ["traceparent"],
+  });
+  return { spanNames };
+}
+
 describe("server/runtime-handler/tracing", () => {
   describe("startRequestTracing", () => {
-    it("should return a SpanInfo with span and context properties", () => {
+    let spanNames: string[];
+
+    beforeEach(() => {
+      _resetShimForTests();
+      spanNames = installFakeTracing().spanNames;
+    });
+
+    afterEach(() => {
+      _resetShimForTests();
+    });
+
+    it("continues the caller's trace from the traceparent header", () => {
+      const req = new Request("http://localhost/test", {
+        headers: { traceparent: `00-${INCOMING_TRACE_ID}-${INCOMING_SPAN_ID}-01` },
+      });
+      const spanInfo = startRequestTracing(req, "/test");
+
+      assertEquals(
+        spanInfo.span !== undefined && spanInfo.context !== undefined,
+        true,
+        "a started server span carries both the span and its context",
+      );
+      assertEquals(
+        getRequestTraceContext(spanInfo.span).traceId,
+        INCOMING_TRACE_ID,
+        "the caller's trace must continue across the runtime boundary",
+      );
+      assertEquals(spanNames, ["GET /test"], "the server span is named by method then path");
+    });
+
+    it("starts a new trace when no traceparent header is present", () => {
       const req = new Request("http://localhost/test");
       const spanInfo = startRequestTracing(req, "/test");
-      assertEquals("span" in spanInfo, true);
-      assertEquals("context" in spanInfo, true);
+
+      assertNotEquals(
+        getRequestTraceContext(spanInfo.span).traceId,
+        INCOMING_TRACE_ID,
+        "a request without a traceparent must not inherit a foreign trace",
+      );
     });
   });
 
@@ -27,6 +127,27 @@ describe("server/runtime-handler/tracing", () => {
       setRequestAttributes(null, req, url);
       setRequestAttributes(undefined, req, url);
     });
+
+    it("records the request url, host and scheme on the span", () => {
+      const recorded: Record<string, unknown> = {};
+      const span = {
+        setAttribute: (k: string, v: unknown) => {
+          recorded[k] = v;
+        },
+      };
+      const req = new Request("http://localhost/test");
+      const url = new URL(req.url);
+
+      setRequestAttributes(span, req, url);
+
+      assertEquals(
+        recorded["http.url"],
+        "http://localhost/test",
+        "the request URL is recorded on the span",
+      );
+      assertEquals(recorded["http.host"], "localhost", "the request host is recorded on the span");
+      assertEquals(recorded["http.scheme"], "http", "the request scheme is recorded on the span");
+    });
   });
 
   describe("setProjectAttributes", () => {
@@ -36,7 +157,49 @@ describe("server/runtime-handler/tracing", () => {
     });
 
     it("should not throw when projectSlug is undefined", () => {
-      setProjectAttributes({}, undefined, "production");
+      const recorded: Record<string, unknown> = {};
+      const span = {
+        setAttribute: (k: string, v: unknown) => {
+          recorded[k] = v;
+        },
+      };
+      setProjectAttributes(span, undefined, "production");
+      assertEquals(recorded, {}, "no attributes are recorded without a project slug");
+    });
+
+    it("records the project slug and environment on the span", () => {
+      const recorded: Record<string, unknown> = {};
+      const span = {
+        setAttribute: (k: string, v: unknown) => {
+          recorded[k] = v;
+        },
+      };
+
+      setProjectAttributes(span, "my-project", "production");
+
+      assertEquals(
+        recorded["veryfront.project_slug"],
+        "my-project",
+        "the project slug is recorded",
+      );
+      assertEquals(recorded["veryfront.environment"], "production", "the environment is recorded");
+    });
+
+    it("defaults the environment to unknown", () => {
+      const recorded: Record<string, unknown> = {};
+      const span = {
+        setAttribute: (k: string, v: unknown) => {
+          recorded[k] = v;
+        },
+      };
+
+      setProjectAttributes(span, "my-project", undefined);
+
+      assertEquals(
+        recorded["veryfront.environment"],
+        "unknown",
+        "a missing environment is recorded as unknown, not dropped",
+      );
     });
   });
 

--- a/src/server/services/rendering/ssr.service.test.ts
+++ b/src/server/services/rendering/ssr.service.test.ts
@@ -185,6 +185,23 @@ describe("server/services/rendering/ssr.service", () => {
         assertEquals(status.heapLimitMB >= 0, true);
         assertEquals(status.heapUsedPercent >= 0, true);
       });
+
+      it("reports the live heap statistics", () => {
+        const service = new SSRService();
+        const status = service.checkMemoryPressure();
+        assertEquals(
+          status.heapLimitMB > 0,
+          true,
+          "heapLimitMB must come from getHeapStats, not a hardcoded zero",
+        );
+        assertEquals(status.heapUsedMB > 0, true, "heapUsedMB must come from getHeapStats");
+        assertEquals(
+          Math.abs(status.heapUsedPercent - (status.heapUsedMB / status.heapLimitMB) * 100) < 1,
+          true,
+          "heapUsedPercent must be the real ratio reported by getHeapStats",
+        );
+        assertEquals(status.shouldReject, false, "a healthy test process must not be shed");
+      });
     });
 
     describe("createMemoryPressureResult", () => {

--- a/src/server/services/rendering/ssr.service.test.ts
+++ b/src/server/services/rendering/ssr.service.test.ts
@@ -19,6 +19,10 @@ import {
 } from "#veryfront/observability/application-errors.ts";
 import { createNotFoundLikeError } from "#veryfront/platform/adapters/fs/veryfront/read-operations-helpers.ts";
 import { resetMetrics, state } from "#veryfront/observability/simple-metrics/index.ts";
+import {
+  __injectDepsForTests as __injectPressureDepsForTests,
+  THRESHOLDS,
+} from "../../shared/renderer/memory/pressure.ts";
 
 function createMockAdapter(): RuntimeAdapter {
   return {
@@ -200,7 +204,34 @@ describe("server/services/rendering/ssr.service", () => {
           true,
           "heapUsedPercent must be the real ratio reported by getHeapStats",
         );
-        assertEquals(status.shouldReject, false, "a healthy test process must not be shed");
+      });
+
+      // shouldReject is derived from the live heap against the process-wide
+      // MEMORY_CRITICAL_THRESHOLD, so it is pinned through the pressure module's
+      // injection seam rather than asserted against whatever the runner's heap
+      // happens to be doing.
+      it("derives shouldReject from the configured critical threshold", () => {
+        const service = new SSRService();
+        try {
+          __injectPressureDepsForTests({
+            getHeapStats: () => ({ heapUsedPercent: THRESHOLDS.CRITICAL - 1 }),
+          });
+          assertEquals(
+            service.checkMemoryPressure().shouldReject,
+            false,
+            `heap below CRITICAL (${THRESHOLDS.CRITICAL}) must not shed the request`,
+          );
+          __injectPressureDepsForTests({
+            getHeapStats: () => ({ heapUsedPercent: THRESHOLDS.CRITICAL }),
+          });
+          assertEquals(
+            service.checkMemoryPressure().shouldReject,
+            true,
+            `heap at CRITICAL (${THRESHOLDS.CRITICAL}) must shed the request`,
+          );
+        } finally {
+          __injectPressureDepsForTests(null);
+        }
       });
     });
 

--- a/src/server/services/rsc/endpoints/action-handler.test.ts
+++ b/src/server/services/rsc/endpoints/action-handler.test.ts
@@ -446,6 +446,54 @@ describe(
         assertEquals(await response.json(), { ok: true, result: 5 });
       });
 
+      for (
+        const appDirectory of ["../../etc", "src/app/../../.."]
+      ) {
+        it(`rejects an app directory that escapes the project tree (${appDirectory})`, async () => {
+          const calls: string[] = [];
+          const adapter = createMockAdapter({
+            stat: (path) => {
+              calls.push(path);
+              return Promise.reject(new Error("not found"));
+            },
+            readFile: (path) => {
+              calls.push(path);
+              return Promise.reject(new Error("not found"));
+            },
+          });
+          const req = new Request("http://localhost/_veryfront/rsc/action", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ id: "add", args: [] }),
+          });
+
+          const response = await handleActionRequestWithAuthorizationProvider(
+            {
+              req,
+              projectDir: "/virtual/project",
+              projectId: "virtual-project",
+              contentSourceId: "preview-main",
+              adapter,
+              config: { directories: { app: appDirectory } },
+              mode: "development",
+            },
+            allowActionAuthorization,
+          );
+
+          assertEquals(response.status, 400, "an app root outside the project must be refused");
+          assertEquals(
+            await response.json(),
+            { ok: false, error: "invalid action root" },
+            "the refusal names the invalid action root",
+          );
+          assertEquals(
+            calls,
+            [],
+            "no filesystem access may happen once the action root escapes projectDir",
+          );
+        });
+      }
+
       it("keeps a snapshot-A action on A after package state advances to B", async () => {
         const projectDir = await Deno.makeTempDir({
           prefix: "vf-rsc-action-historical-pins-",

--- a/src/server/services/rsc/endpoints/action-parser.test.ts
+++ b/src/server/services/rsc/endpoints/action-parser.test.ts
@@ -79,6 +79,17 @@ describe("server/services/rsc/endpoints/action-parser", () => {
         }),
         400,
       );
+
+      const atLimit = await parseActionBody({
+        id: "action",
+        args: Array.from({ length: RSC_ACTION_MAX_TOP_LEVEL_ARGUMENTS }, (_, i) => i),
+      });
+      const body = assertActionBody(atLimit);
+      assertEquals(
+        body.args.length,
+        RSC_ACTION_MAX_TOP_LEVEL_ARGUMENTS,
+        "exactly the documented maximum argument count must still be accepted",
+      );
     });
 
     it("rejects inherited and accessor-backed action fields", async () => {

--- a/src/server/services/rsc/endpoints/handler-registry.test.ts
+++ b/src/server/services/rsc/endpoints/handler-registry.test.ts
@@ -245,6 +245,73 @@ describe("server/services/rsc/endpoints/handler-registry", () => {
       assertEquals(cache.size, 2);
     });
 
+    it("isolates production handlers by content source alone", () => {
+      const cache = createStubCache();
+      __injectCacheForTests(cache);
+
+      const sourceA = getRSCHandler("/dir", "project", {
+        mode: "production",
+        releaseId: "release-a",
+        contentSourceId: "source-a",
+      });
+      const sourceB = getRSCHandler("/dir", "project", {
+        mode: "production",
+        releaseId: "release-a",
+        contentSourceId: "source-b",
+      });
+
+      assertEquals(
+        sourceA !== sourceB,
+        true,
+        "contentSourceId is caller supplied and must never share a compiled module graph across sources",
+      );
+      assertEquals(cache.size, 2, "each content source gets its own handler entry");
+    });
+
+    it("isolates production handlers by release alone", () => {
+      const cache = createStubCache();
+      __injectCacheForTests(cache);
+
+      const releaseA = getRSCHandler("/dir", "project", {
+        mode: "production",
+        releaseId: "release-a",
+        contentSourceId: "source-a",
+      });
+      const releaseB = getRSCHandler("/dir", "project", {
+        mode: "production",
+        releaseId: "release-b",
+        contentSourceId: "source-a",
+      });
+
+      assertEquals(
+        releaseA !== releaseB,
+        true,
+        "two releases on the same content source must not share a handler",
+      );
+      assertEquals(cache.size, 2, "each release gets its own handler entry");
+    });
+
+    it("isolates production handlers by content source when no release is set", () => {
+      const cache = createStubCache();
+      __injectCacheForTests(cache);
+
+      const sourceA = getRSCHandler("/dir", "project", {
+        mode: "production",
+        contentSourceId: "source-a",
+      });
+      const sourceB = getRSCHandler("/dir", "project", {
+        mode: "production",
+        contentSourceId: "source-b",
+      });
+
+      assertEquals(
+        sourceA !== sourceB,
+        true,
+        "a release-less content source must still get its own handler",
+      );
+      assertEquals(cache.size, 2, "each content source gets its own handler entry");
+    });
+
     it("preserves the legacy handler identity for branches when pinning is disabled", () => {
       const cache = createStubCache();
       __injectCacheForTests(cache);

--- a/src/server/services/rsc/endpoints/script-handlers.test.ts
+++ b/src/server/services/rsc/endpoints/script-handlers.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { handleClientScript, handleDomScript } from "./script-handlers.ts";
+import { CLIENT_BOOT_BUNDLE, CLIENT_DOM_BUNDLE } from "./rsc-bundles.generated.ts";
 import { ERROR_REGISTRY } from "#veryfront/errors/error-registry.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 
@@ -63,14 +64,27 @@ function embeddedNonGeneralSlugs(bundle: string): string[] {
 
 describe("script-handlers", () => {
   describe("handleClientScript", () => {
-    it("should not throw when source file is missing (compiled binary)", async () => {
-      // Simulates the compiled binary where client-boot.ts is not at the resolved path.
-      // The handler should return a response, not throw.
-      const adapter = createMockAdapter();
+    it("serves the compiled bundle without touching the filesystem", async () => {
+      // The generated bundle is non-empty in a source checkout and in a compiled
+      // binary alike, so the handler must serve it verbatim and never read source.
+      let readFileCalls = 0;
+      const adapter = createMockAdapter({
+        readFile: () => {
+          readFileCalls += 1;
+          return Promise.resolve("const boot = () => {};");
+        },
+      });
       const response = await handleClientScript(adapter);
-      assertEquals(response.status, 200);
+      assertEquals(response.status, 200, "the compiled bundle is served with 200");
       const contentType = response.headers.get("content-type");
-      assertStringIncludes(contentType ?? "", "javascript");
+      assertStringIncludes(contentType ?? "", "javascript", "the compiled bundle is JavaScript");
+      assertEquals(CLIENT_BOOT_BUNDLE.length > 0, true, "the generated bundle must not be empty");
+      assertEquals(
+        await response.text(),
+        CLIENT_BOOT_BUNDLE,
+        "the pre-built bundle is served verbatim",
+      );
+      assertEquals(readFileCalls, 0, "the pre-built bundle must not read project source");
     });
 
     it("should return JavaScript content-type", async () => {
@@ -86,19 +100,6 @@ describe("script-handlers", () => {
       const adapter = createMockAdapter();
       const response = await handleClientScript(adapter);
       assertStringIncludes(response.headers.get("cache-control") ?? "", "no-cache");
-    });
-
-    it("should serve source when file exists and esbuild unavailable", async () => {
-      // When esbuild is not available but the file exists, it should
-      // still return a response (either the raw source or a fallback).
-      const adapter = createMockAdapter({
-        readFile: () => Promise.resolve("const boot = () => {}; boot();"),
-      });
-      const response = await handleClientScript(adapter);
-      assertEquals(response.status, 200);
-      const body = await response.text();
-      // Should contain something (either bundled output or raw source)
-      assertEquals(body.length > 0, true);
     });
 
     it("does not embed unsafe eval in the compiled fallback bundle", async () => {
@@ -124,12 +125,25 @@ describe("script-handlers", () => {
   });
 
   describe("handleDomScript", () => {
-    it("should not throw when source file is missing (compiled binary)", async () => {
-      const adapter = createMockAdapter();
+    it("serves the compiled bundle without touching the filesystem", async () => {
+      let readFileCalls = 0;
+      const adapter = createMockAdapter({
+        readFile: () => {
+          readFileCalls += 1;
+          return Promise.resolve("const dom = () => {};");
+        },
+      });
       const response = await handleDomScript(adapter);
-      assertEquals(response.status, 200);
+      assertEquals(response.status, 200, "the compiled bundle is served with 200");
       const contentType = response.headers.get("content-type");
-      assertStringIncludes(contentType ?? "", "javascript");
+      assertStringIncludes(contentType ?? "", "javascript", "the compiled bundle is JavaScript");
+      assertEquals(CLIENT_DOM_BUNDLE.length > 0, true, "the generated bundle must not be empty");
+      assertEquals(
+        await response.text(),
+        CLIENT_DOM_BUNDLE,
+        "the pre-built bundle is served verbatim",
+      );
+      assertEquals(readFileCalls, 0, "the pre-built bundle must not read project source");
     });
 
     it("should return JavaScript content-type", async () => {

--- a/src/server/services/rsc/orchestrators/handler.test.ts
+++ b/src/server/services/rsc/orchestrators/handler.test.ts
@@ -15,7 +15,6 @@ import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 
 describe(
   "RSCDevServerHandler",
-  { sanitizeResources: false, sanitizeOps: false },
   () => {
     let handler: RSCDevServerHandler;
 
@@ -28,7 +27,7 @@ describe(
       handler = new RSCDevServerHandler("/tmp/test-project");
     });
 
-    describe("constructor", { sanitizeOps: false, sanitizeResources: false }, () => {
+    describe("constructor", () => {
       it("should create handler with project directory", () => {
         expect(handler).toBeDefined();
       });
@@ -52,7 +51,7 @@ describe(
       });
     });
 
-    describe("handlePage", { sanitizeOps: false, sanitizeResources: false }, () => {
+    describe("handlePage", () => {
       it("should return page response for valid pathname", async () => {
         const response = await handler.handlePage("/test", new URLSearchParams());
 
@@ -98,7 +97,7 @@ describe(
       });
     });
 
-    describe("handleManifest", { sanitizeOps: false, sanitizeResources: false }, () => {
+    describe("handleManifest", () => {
       it("should return manifest response", async () => {
         const response = await handler.handleManifest();
 
@@ -110,7 +109,20 @@ describe(
         const response = await handler.handleManifest();
         const text = await response.text();
 
-        expect(() => JSON.parse(text)).not.toThrow();
+        const body = JSON.parse(text) as {
+          components: Record<string, string>;
+          modules: unknown[];
+        };
+        assertEquals(
+          body.components,
+          {},
+          "an uninitialized renderer must not publish any client component entries",
+        );
+        assertEquals(
+          body.modules,
+          [],
+          "an uninitialized renderer must not publish any client module refs",
+        );
       });
 
       it("keeps render, React, and manifest module URLs on historical snapshot A after B is current", async () => {

--- a/src/server/services/rsc/orchestrators/manifest-handler.test.ts
+++ b/src/server/services/rsc/orchestrators/manifest-handler.test.ts
@@ -5,16 +5,23 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { ManifestHandler } from "./manifest-handler.ts";
 import type { CacheRepository } from "#veryfront/repositories/types.ts";
 import { RSC_DEPENDENCY_PINNING_HEADER } from "#veryfront/rendering/rsc/constants.ts";
+import { RSC_MANIFEST_CACHE_TTL_MS } from "#veryfront/utils";
 
-function createMockCacheRepo(): CacheRepository<string> & { store: Map<string, string> } {
+function createMockCacheRepo(): CacheRepository<string> & {
+  store: Map<string, string>;
+  ttls: Map<string, number | undefined>;
+} {
   const store = new Map<string, string>();
+  const ttls = new Map<string, number | undefined>();
   return {
     store,
+    ttls,
     async get(key: string) {
       return store.get(key) ?? null;
     },
-    async set(key: string, value: string, _ttl?: number) {
+    async set(key: string, value: string, ttl?: number) {
       store.set(key, value);
+      ttls.set(key, ttl);
     },
     async delete(key: string) {
       store.delete(key);
@@ -22,7 +29,10 @@ function createMockCacheRepo(): CacheRepository<string> & { store: Map<string, s
     async has(key: string) {
       return store.has(key);
     },
-  } as CacheRepository<string> & { store: Map<string, string> };
+  } as CacheRepository<string> & {
+    store: Map<string, string>;
+    ttls: Map<string, number | undefined>;
+  };
 }
 
 describe("server/services/rsc/orchestrators/manifest-handler", () => {
@@ -38,6 +48,11 @@ describe("server/services/rsc/orchestrators/manifest-handler", () => {
 
       assertEquals(response.headers.get("content-type"), "application/json");
       assertEquals(response.headers.get("vary"), RSC_DEPENDENCY_PINNING_HEADER);
+      assertEquals(
+        response.headers.get("cache-control"),
+        "private, no-cache, must-revalidate",
+        "a per-tenant client-component manifest must never be shared-cacheable",
+      );
       const body = await response.json();
       assertEquals(body.components.Button, "/app/components/Button.tsx");
       assertEquals(body.components.Card, "/app/components/Card.tsx");
@@ -258,6 +273,12 @@ describe("server/services/rsc/orchestrators/manifest-handler", () => {
       await handler.handle(manifest as any);
 
       assertEquals(cacheRepo.store.size, 1);
+      const key = [...cacheRepo.store.keys()][0]!;
+      assertEquals(
+        cacheRepo.ttls.get(key),
+        Math.floor(RSC_MANIFEST_CACHE_TTL_MS / 1000),
+        "the external manifest TTL is written in seconds, not milliseconds",
+      );
     });
 
     it("should return cached data from injected cache", async () => {
@@ -373,6 +394,33 @@ describe("server/services/rsc/orchestrators/manifest-handler", () => {
       const body = await response.json();
       assertEquals(body.components.W, "/w.tsx");
       assertEquals(body.components.Z, undefined);
+    });
+
+    it("purges tracked keys from the injected cache repository", async () => {
+      const cacheRepo = createMockCacheRepo();
+      const handler = new ManifestHandler("/project", { cacheRepo, isLocalProject: true });
+      await handler.handle(new Map([["Z", { path: "/z.tsx", exports: [] }]]) as any);
+      assertEquals(cacheRepo.store.size, 1, "the first build is written to the repository");
+
+      handler.clearCache();
+      // clearCache enqueues the purge with void, so await the private queue.
+      await (handler as unknown as { cacheMutation: Promise<void> }).cacheMutation;
+
+      assertEquals(
+        cacheRepo.store.size,
+        0,
+        "clearCache must purge every tracked key from the external cache repository",
+      );
+      const response = await handler.handle(
+        new Map([["W", { path: "/w.tsx", exports: [] }]]) as any,
+      );
+      const body = await response.json();
+      assertEquals(
+        body.components.Z,
+        undefined,
+        "a cleared manifest must not be re-read from the injected repository",
+      );
+      assertEquals(body.components.W, "/w.tsx", "the post-clear build is served");
     });
 
     it("does not let a pre-invalidation build republish stale manifest data", async () => {

--- a/src/server/services/rsc/orchestrators/render-handler.test.ts
+++ b/src/server/services/rsc/orchestrators/render-handler.test.ts
@@ -1,6 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import "#veryfront/transforms/mdx/compiler/__tests__/content-processor-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { RenderHandler } from "./render-handler.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
@@ -25,13 +25,25 @@ describe("server/services/rsc/orchestrators/render-handler", () => {
       );
 
       const response = await handler.handle("/nonexistent", new URLSearchParams());
-      // Should get an error response (component not found or renderer not initialized)
-      assertEquals(response.status >= 400, true);
+      assertEquals(
+        response.status,
+        404,
+        "a missing component is a route miss, not a platform fault",
+      );
+      const body = await response.json();
+      assertStringIncludes(
+        body.type ?? "",
+        "page-not-found",
+        "the problem type must identify PAGE_NOT_FOUND",
+      );
+      assertEquals(
+        body.detail,
+        "The requested component could not be found",
+        "the not-found branch must produce the PAGE_NOT_FOUND detail",
+      );
     });
 
-    it("returns error response when renderer is null", async () => {
-      // RenderHandler with a getRenderer that returns null
-      // The component path won't resolve, so we get "Component not found"
+    it("returns the component-not-found problem when the component path does not resolve", async () => {
       const handler = new RenderHandler(
         "/tmp/nonexistent",
         () => null,
@@ -39,10 +51,79 @@ describe("server/services/rsc/orchestrators/render-handler", () => {
       );
 
       const response = await handler.handle("/some-page", new URLSearchParams());
-      assertEquals(response.status >= 400, true);
-      const body = await response.text();
-      // Should include error information
-      assertEquals(body.length > 0, true);
+      assertEquals(response.status, 404, "an unresolvable component path is a route miss");
+      const body = await response.json();
+      assertStringIncludes(body.type ?? "", "page-not-found");
+    });
+
+    it("returns error response when renderer is null", async () => {
+      const projectDir = await Deno.makeTempDir({ prefix: "vf-rsc-null-renderer-" });
+      const pagePath = `${projectDir}/app/page.tsx`;
+      const pageSource = "export default function Page() { return null; }";
+      await Deno.mkdir(`${projectDir}/app`);
+      await Deno.writeTextFile(pagePath, pageSource);
+
+      try {
+        const adapter = createMockAdapter();
+        adapter.fs.files.set(pagePath, pageSource);
+        const handler = new RenderHandler(projectDir, () => null, "production", "app", {
+          runtimeAdapter: () => Promise.resolve(adapter),
+          moduleLoader: () => Promise.resolve({ default: () => null }),
+        });
+
+        const response = await handler.handle("/", new URLSearchParams());
+        assertEquals(
+          response.status,
+          500,
+          "an uninitialized renderer is a render failure, not a missing page",
+        );
+        const body = await response.json();
+        assertStringIncludes(
+          body.type ?? "",
+          "render-error",
+          "the problem type must identify RENDER_ERROR rather than PAGE_NOT_FOUND",
+        );
+        assertEquals(
+          body.detail,
+          "Renderer not initialized",
+          "the null-renderer guard must produce the RENDER_ERROR detail",
+        );
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("returns the component error when the module does not export a component", async () => {
+      const projectDir = await Deno.makeTempDir({ prefix: "vf-rsc-invalid-component-" });
+      const pagePath = `${projectDir}/app/page.tsx`;
+      const pageSource = "export default 'not a component';";
+      await Deno.mkdir(`${projectDir}/app`);
+      await Deno.writeTextFile(pagePath, pageSource);
+
+      try {
+        const adapter = createMockAdapter();
+        adapter.fs.files.set(pagePath, pageSource);
+        const handler = new RenderHandler(projectDir, () => null, "production", "app", {
+          runtimeAdapter: () => Promise.resolve(adapter),
+          moduleLoader: () => Promise.resolve({ default: "not a component" }),
+        });
+
+        const response = await handler.handle("/", new URLSearchParams());
+        assertEquals(response.status, 500, "an invalid component export is a component fault");
+        const body = await response.json();
+        assertStringIncludes(
+          body.type ?? "",
+          "component-error",
+          "the problem type must identify COMPONENT_ERROR",
+        );
+        assertEquals(
+          body.detail,
+          "Component module must export a valid React component",
+          "the invalid-component branch must produce the COMPONENT_ERROR detail",
+        );
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+      }
     });
 
     it("returns error response as JSON with proper content type", async () => {

--- a/src/server/services/rsc/orchestrators/render-handler.test.ts
+++ b/src/server/services/rsc/orchestrators/render-handler.test.ts
@@ -14,6 +14,7 @@ import { DEPENDENCY_PINNING_ENV_FLAG } from "#veryfront/release-assets/constants
 import { RSC_DEPENDENCY_PINNING_HEADER } from "#veryfront/rendering/rsc/constants.ts";
 import { type MDXLoadModuleOptions, mdxRenderer } from "#veryfront/transforms/mdx/index.ts";
 import { denoAdapter } from "#veryfront/platform/adapters/deno.ts";
+import { makeTempDir } from "#veryfront/testing/deno-compat.ts";
 
 describe("server/services/rsc/orchestrators/render-handler", () => {
   describe("handle", () => {
@@ -57,7 +58,7 @@ describe("server/services/rsc/orchestrators/render-handler", () => {
     });
 
     it("returns error response when renderer is null", async () => {
-      const projectDir = await Deno.makeTempDir({ prefix: "vf-rsc-null-renderer-" });
+      const projectDir = await makeTempDir({ prefix: "vf-rsc-null-renderer-" });
       const pagePath = `${projectDir}/app/page.tsx`;
       const pageSource = "export default function Page() { return null; }";
       await Deno.mkdir(`${projectDir}/app`);
@@ -94,7 +95,7 @@ describe("server/services/rsc/orchestrators/render-handler", () => {
     });
 
     it("returns the component error when the module does not export a component", async () => {
-      const projectDir = await Deno.makeTempDir({ prefix: "vf-rsc-invalid-component-" });
+      const projectDir = await makeTempDir({ prefix: "vf-rsc-invalid-component-" });
       const pagePath = `${projectDir}/app/page.tsx`;
       const pageSource = "export default 'not a component';";
       await Deno.mkdir(`${projectDir}/app`);
@@ -189,7 +190,7 @@ describe("server/services/rsc/orchestrators/render-handler", () => {
     });
 
     it("uses the historical snapshot loader when no adapter was supplied", async () => {
-      const projectDir = await Deno.makeTempDir({ prefix: "vf-rsc-runtime-adapter-" });
+      const projectDir = await makeTempDir({ prefix: "vf-rsc-runtime-adapter-" });
       const packageJsonPath = `${projectDir}/package.json`;
       const pagePath = `${projectDir}/app/page.tsx`;
       const originalFlag = getHostEnv(DEPENDENCY_PINNING_ENV_FLAG);
@@ -297,7 +298,7 @@ describe("server/services/rsc/orchestrators/render-handler", () => {
     });
 
     it("resolves the current render token on a fresh worker", async () => {
-      const projectDir = await Deno.makeTempDir({ prefix: "vf-rsc-fresh-render-pins-" });
+      const projectDir = await makeTempDir({ prefix: "vf-rsc-fresh-render-pins-" });
       const packageJsonPath = `${projectDir}/package.json`;
       const pagePath = `${projectDir}/app/page.tsx`;
       const originalFlag = getHostEnv(DEPENDENCY_PINNING_ENV_FLAG);
@@ -361,7 +362,7 @@ describe("server/services/rsc/orchestrators/render-handler", () => {
     });
 
     it("threads trusted project options into RSC MDX loading", async () => {
-      const projectDir = await Deno.makeTempDir({ prefix: "vf-rsc-local-mdx-" });
+      const projectDir = await makeTempDir({ prefix: "vf-rsc-local-mdx-" });
       await Deno.mkdir(`${projectDir}/app`, { recursive: true });
       await Deno.writeTextFile(`${projectDir}/app/page.mdx`, "# Local RSC page");
 
@@ -414,7 +415,7 @@ describe("server/services/rsc/orchestrators/render-handler", () => {
     });
 
     it("threads the render mode into RSC MDX loading", async () => {
-      const projectDir = await Deno.makeTempDir({ prefix: "vf-rsc-mdx-mode-" });
+      const projectDir = await makeTempDir({ prefix: "vf-rsc-mdx-mode-" });
       await Deno.mkdir(`${projectDir}/app`, { recursive: true });
       await Deno.writeTextFile(`${projectDir}/app/page.mdx`, "# Mode RSC page");
 

--- a/src/server/services/rsc/orchestrators/stream-handler.test.ts
+++ b/src/server/services/rsc/orchestrators/stream-handler.test.ts
@@ -91,6 +91,29 @@ describe("StreamHandler", () => {
         expect(parsed.id).toBeDefined();
         expect(parsed.html).toBeDefined();
       }
+
+      const slots = lines.filter((line) => line.trim()).map((line) => JSON.parse(line));
+      const rootSlots = slots.filter((slot) => slot.id === "root");
+      expect(rootSlots.length).toBe(2);
+      expect(rootSlots[0].html).toBe("<p>Loading...</p>");
+      expect(rootSlots.at(-1)?.html).toBe("<div>Test Content</div>");
+    });
+
+    it("streams the rendered payload html rather than the fallback", async () => {
+      mockRenderHandler.setHandler(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ html: "<main>DISTINCT-PAYLOAD</main>" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        )
+      );
+
+      const response = await streamHandler.handle("/", new URLSearchParams());
+      const text = await response.text();
+
+      expect(text).toContain("DISTINCT-PAYLOAD");
+      expect(text).not.toContain("OK");
     });
 
     it("exposes the exact dependency snapshot captured by the render payload", async () => {
@@ -140,12 +163,29 @@ describe("StreamHandler", () => {
       expect(handleCalls[0]?.[0]).toBe("/my-page");
     });
 
-    it("should handle render handler returning non-ok response", async () => {
+    it("should handle render handler returning non-ok response with an empty body", async () => {
       mockRenderHandler.setHandler(() => Promise.resolve(new Response(null, { status: 500 })));
 
       const response = await streamHandler.handle("/", new URLSearchParams());
 
       expect(await response.text()).toContain("OK");
+    });
+
+    it("does not stream a non-ok render payload", async () => {
+      mockRenderHandler.setHandler(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ html: "<div>LEAKED-ERROR-DETAIL</div>" }), {
+            status: 500,
+            headers: { "content-type": "application/json" },
+          }),
+        )
+      );
+
+      const response = await streamHandler.handle("/", new URLSearchParams());
+      const text = await response.text();
+
+      expect(text).toContain("OK");
+      expect(text).not.toContain("LEAKED-ERROR-DETAIL");
     });
 
     it("should handle invalid JSON from render handler", async () => {

--- a/src/server/services/static/static-file.service.test.ts
+++ b/src/server/services/static/static-file.service.test.ts
@@ -230,6 +230,50 @@ describe("server/services/static/static-file.service", () => {
         assertEquals(result.cacheStrategy, "medium");
       }
     });
+
+    it("returns immutable for unhashed platform assets served from dist", async () => {
+      __injectDepsForTests({
+        manifestCache: new Map(),
+        manifestLoading: new Map(),
+      });
+
+      const fileData = new TextEncoder().encode("runtime");
+      const repo = createMockFsRepo(
+        new Map([["/project/dist/_veryfront/runtime.js", fileData]]),
+      );
+      const service = new StaticFileService(repo);
+      const options = makeOptions({ isPreviewMode: false, isLocalProject: false });
+
+      const result = await service.resolveFile("/_veryfront/runtime.js", options);
+      assertExists(result, "unhashed platform asset must resolve from dist");
+      assertEquals(
+        result.cacheStrategy,
+        "immutable",
+        "unhashed /_veryfront assets served from dist must stay immutable",
+      );
+    });
+
+    it("returns medium for a project-supplied /_veryfront file from public", async () => {
+      __injectDepsForTests({
+        manifestCache: new Map(),
+        manifestLoading: new Map(),
+      });
+
+      const fileData = new TextEncoder().encode("runtime");
+      const repo = createMockFsRepo(
+        new Map([["/project/public/_veryfront/runtime.js", fileData]]),
+      );
+      const service = new StaticFileService(repo);
+      const options = makeOptions({ isPreviewMode: false, isLocalProject: false });
+
+      const result = await service.resolveFile("/_veryfront/runtime.js", options);
+      assertExists(result, "the public file must resolve");
+      assertEquals(
+        result.cacheStrategy,
+        "medium",
+        "a project-supplied /_veryfront file from public must not inherit immutable caching",
+      );
+    });
   });
 
   describe("manifest resolution", () => {
@@ -265,6 +309,74 @@ describe("server/services/static/static-file.service", () => {
         assertEquals(result.source, "manifest");
         assertEquals(result.data, fileData);
       }
+    });
+
+    it("reloads the manifest index when manifest.json changes on disk", async () => {
+      const buildManifest = (file: string) =>
+        new TextEncoder().encode(
+          JSON.stringify({
+            chunks: { chunks: { main: { file } }, shared: [] },
+            routes: [],
+          }),
+        );
+      const fileData = new TextEncoder().encode("app code");
+      const manifestPath = "/project/dist/_veryfront/manifest.json";
+      const files = new Map<string, Uint8Array>([
+        [manifestPath, buildManifest("old.js")],
+        ["/project/dist/_veryfront/old.js", fileData],
+        ["/project/dist/_veryfront/new.js", fileData],
+      ]);
+      let manifestMtime = 1_000;
+      const repo = {
+        readFile: async (path: string) => {
+          const data = files.get(path);
+          if (!data) throw createFsError("not found", "ENOENT");
+          return new TextDecoder().decode(data);
+        },
+        readFileBytes: async (path: string) => {
+          const data = files.get(path);
+          if (!data) throw createFsError("not found", "ENOENT");
+          return data;
+        },
+        stat: async (path: string) => {
+          if (!files.has(path)) throw createFsError("not found", "ENOENT");
+          return {
+            isFile: true,
+            isDirectory: false,
+            mtime: new Date(path === manifestPath ? manifestMtime : 0),
+          };
+        },
+      } as unknown as FileSystemRepository;
+
+      __injectDepsForTests({
+        manifestCache: new Map(),
+        manifestLoading: new Map(),
+      });
+
+      const service = new StaticFileService(repo);
+      const options = makeOptions();
+
+      const first = await service.resolveFile("/_veryfront/old.js", options);
+      assertExists(first, "the initial manifest entry resolves");
+      assertEquals(first.source, "manifest");
+
+      files.set(manifestPath, buildManifest("new.js"));
+      manifestMtime = 2_000;
+
+      const updated = await service.resolveFile("/_veryfront/new.js", options);
+      assertExists(updated, "a rebuilt manifest.json must invalidate the stale manifest index");
+      assertEquals(
+        updated.source,
+        "manifest",
+        "the new chunk must be served from the reloaded manifest index",
+      );
+      const stale = await service.resolveFile("/_veryfront/old.js", options);
+      assertExists(stale, "the old chunk still exists on disk");
+      assertEquals(
+        stale.source,
+        "dist",
+        "the stale manifest entry must not survive a manifest.json rebuild",
+      );
     });
   });
 
@@ -338,6 +450,60 @@ describe("server/services/static/static-file.service", () => {
       const options = makeOptions();
       const result = await service.resolveFile("/nonexistent.txt", options);
       assertEquals(result, null);
+    });
+
+    it("rejects parent-segment requests that escape the dist root via the repository", async () => {
+      __injectDepsForTests({
+        manifestCache: new Map(),
+        manifestLoading: new Map(),
+      });
+
+      const enc = (text: string) => new TextEncoder().encode(text);
+      const repo = createMockFsRepo(
+        new Map([
+          ["/project/secret.txt", enc("secret")],
+          ["/etc/passwd", enc("root:x")],
+        ]),
+      );
+      const service = new StaticFileService(repo);
+
+      assertEquals(
+        await service.resolveFile("/../secret.txt", makeOptions()),
+        null,
+        "a parent-segment request must not escape the dist root",
+      );
+      assertEquals(
+        await service.resolveFile("/../../etc/passwd", makeOptions()),
+        null,
+        "a doubled parent-segment request must not escape the project root",
+      );
+    });
+
+    it("rejects parent-segment requests that escape the dist root via SecureFs", async () => {
+      __injectDepsForTests({
+        manifestCache: new Map(),
+        manifestLoading: new Map(),
+      });
+
+      const enc = (text: string) => new TextEncoder().encode(text);
+      const adapter = createNativeFsAdapter(
+        new Map([
+          ["/project/secret.txt", enc("secret")],
+          ["/etc/passwd", enc("root:x")],
+        ]),
+      );
+      const service = new StaticFileService();
+
+      assertEquals(
+        await service.resolveFile("/../secret.txt", makeOptions({ adapter })),
+        null,
+        "a parent-segment request must not escape the dist root",
+      );
+      assertEquals(
+        await service.resolveFile("/../../etc/passwd", makeOptions({ adapter })),
+        null,
+        "a doubled parent-segment request must not escape the project root",
+      );
     });
 
     it("should resolve file from injected FileSystemRepository", async () => {

--- a/src/server/shared/browser-module-availability.test.ts
+++ b/src/server/shared/browser-module-availability.test.ts
@@ -128,8 +128,16 @@ describe("server/shared/browser-module-availability", () => {
     });
 
     await load("oversized", "123456789");
-    assertEquals(coordinator.getStatsForTesting().cacheBytes <= 8, true);
-    assertEquals(coordinator.getStatsForTesting().cacheEntries <= 2, true);
+    assertEquals(
+      coordinator.getStatsForTesting(),
+      { cacheEntries: 2, cacheBytes: 8, inFlight: 0, activeGlobal: 0 },
+      "an over budget value must be refused, not admitted and then evicted along with healthy entries",
+    );
+    await load("c");
+    await load("b");
+    assertEquals(builds.get("c"), 1, "c must survive the rejected oversized store");
+    assertEquals(builds.get("b"), 2, "b must survive the rejected oversized store");
+    assertEquals(builds.get("oversized"), 1, "the oversized module must not be cached");
   });
 
   it("rejects immediately when the per-project build limit is saturated", async () => {

--- a/src/server/shared/renderer/adapter.test.ts
+++ b/src/server/shared/renderer/adapter.test.ts
@@ -33,7 +33,13 @@ type RendererCallCounts = {
   destroy: number;
 };
 
-function createMockRenderer(): Renderer & { calls: RendererCallCounts } {
+type MockRenderer = Renderer & {
+  calls: RendererCallCounts;
+  // deno-lint-ignore no-explicit-any
+  lastCtx: any;
+};
+
+function createMockRenderer(): MockRenderer {
   const calls: RendererCallCounts = {
     renderPage: 0,
     resolvePageData: 0,
@@ -42,8 +48,9 @@ function createMockRenderer(): Renderer & { calls: RendererCallCounts } {
     destroy: 0,
   };
 
-  return {
+  const mock = {
     calls,
+    lastCtx: undefined,
     // deno-lint-ignore no-explicit-any
     async renderPage(_slug: string, _ctx: any, _opts?: any) {
       calls.renderPage++;
@@ -55,7 +62,8 @@ function createMockRenderer(): Renderer & { calls: RendererCallCounts } {
       return { data: {} } as any; // deno-lint-ignore no-explicit-any
     },
     // deno-lint-ignore no-explicit-any
-    async getAllPages(_ctx: any) {
+    async getAllPages(ctx: any) {
+      mock.lastCtx = ctx;
       calls.getAllPages++;
       return ["/"];
     },
@@ -68,7 +76,8 @@ function createMockRenderer(): Renderer & { calls: RendererCallCounts } {
     },
     // deno-lint-ignore no-explicit-any
     async initialize(_opts?: any) {},
-  } as unknown as Renderer & { calls: RendererCallCounts };
+  };
+  return mock as unknown as MockRenderer;
 }
 
 /**
@@ -181,7 +190,7 @@ function stubHostedRenderContext(): any {
 }
 
 describe("RendererAdapter with RendererInitializer", () => {
-  let mockRenderer: Renderer & { calls: Record<string, number> };
+  let mockRenderer: MockRenderer;
   let mockInit: RendererInitializer & { initCount: number; destroyCount: number };
 
   beforeEach(() => {
@@ -394,6 +403,38 @@ describe("RendererAdapter with RendererInitializer", () => {
       // Adapter should work
       const pages = await adapter.getAllPages();
       assertEquals(pages, ["/"]);
+      assertEquals(
+        mockRenderer.lastCtx.allowHostProjectCodeExecution,
+        true,
+        "a local project keeps host execution",
+      );
+    });
+
+    it("does not grant host code execution to a hosted enriched context", async () => {
+      const ctx = stubHandlerContext();
+      ctx.isLocalProject = false;
+      ctx.enriched.isLocalProject = false;
+      const adapter = await getRendererForProject(ctx);
+      await adapter.getAllPages();
+      assertEquals(
+        mockRenderer.lastCtx.allowHostProjectCodeExecution,
+        false,
+        "a shared hosted render context must not claim the host code-execution capability",
+      );
+    });
+
+    it("propagates an explicit host code execution grant on the fast path", async () => {
+      const ctx = stubHandlerContext();
+      ctx.isLocalProject = false;
+      ctx.enriched.isLocalProject = false;
+      ctx.allowHostProjectCodeExecution = true;
+      const adapter = await getRendererForProject(ctx);
+      await adapter.getAllPages();
+      assertEquals(
+        mockRenderer.lastCtx.allowHostProjectCodeExecution,
+        true,
+        "an explicit host-execution grant must reach the render context",
+      );
     });
 
     it("builds enriched context when not pre-populated", async () => {
@@ -464,6 +505,71 @@ describe("RendererAdapter with RendererInitializer", () => {
       await getRendererForProject(ctx);
       assertEquals(ctx.enriched !== undefined, true);
       assertEquals(ctx.enriched.environment, "preview");
+    });
+
+    it("resolves production environment from a production domain", async () => {
+      const ctx = stubHandlerContext();
+      ctx.enriched = undefined;
+      ctx.resolvedEnvironment = undefined;
+      ctx.parsedDomain = {
+        slug: null,
+        branch: null,
+        environment: "production",
+        isVeryfrontDomain: false,
+        isDraft: false,
+        allowIframeEmbed: false,
+      } as any;
+      ctx.config = { pages: { include: ["**/*.mdx"] } };
+      ctx.adapter = {
+        fs: {
+          exists: () => Promise.resolve(false),
+          readFile: () => Promise.resolve(""),
+          readDir: async function* () {},
+          stat: () => Promise.resolve({ isFile: false, isDirectory: false }),
+        },
+        env: { get: () => undefined, set: () => {}, delete: () => {}, toObject: () => ({}) },
+      } as unknown as any;
+
+      await getRendererForProject(ctx);
+      assertEquals(ctx.enriched !== undefined, true);
+      assertEquals(
+        ctx.enriched.environment,
+        "production",
+        "a production domain resolves production when no explicit environment is set",
+      );
+    });
+
+    it("falls back to the request context mode when the domain has no environment", async () => {
+      const ctx = stubHandlerContext();
+      ctx.enriched = undefined;
+      ctx.resolvedEnvironment = undefined;
+      ctx.parsedDomain = {
+        slug: null,
+        branch: null,
+        environment: null,
+        isVeryfrontDomain: false,
+        isDraft: false,
+        allowIframeEmbed: false,
+      } as any;
+      ctx.requestContext = { mode: "production" };
+      ctx.config = { pages: { include: ["**/*.mdx"] } };
+      ctx.adapter = {
+        fs: {
+          exists: () => Promise.resolve(false),
+          readFile: () => Promise.resolve(""),
+          readDir: async function* () {},
+          stat: () => Promise.resolve({ isFile: false, isDirectory: false }),
+        },
+        env: { get: () => undefined, set: () => {}, delete: () => {}, toObject: () => ({}) },
+      } as unknown as any;
+
+      await getRendererForProject(ctx);
+      assertEquals(ctx.enriched !== undefined, true);
+      assertEquals(
+        ctx.enriched.environment,
+        "production",
+        "the request context mode decides when the domain carries no environment",
+      );
     });
 
     it("loads config when not provided and enriched is absent", async () => {

--- a/src/server/shared/renderer/memory/pressure.test.ts
+++ b/src/server/shared/renderer/memory/pressure.test.ts
@@ -1,10 +1,40 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { describe, it } from "#veryfront/testing/bdd.ts";
-import { shouldRejectDueToMemory } from "./pressure.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  __injectDepsForTests,
+  classifyMemoryPressure,
+  getMemoryPressureLevel,
+  parseEnvThreshold,
+  shouldRejectDueToMemory,
+} from "./pressure.ts";
+
+const DEFAULT_THRESHOLDS = { WARNING: 65, HIGH: 75, CRITICAL: 80 };
+
+function withHeapUsedPercent(heapUsedPercent: number): void {
+  __injectDepsForTests({ getHeapStats: () => ({ heapUsedPercent }) });
+}
 
 describe("server/shared/renderer/memory/pressure", () => {
+  afterEach(() => {
+    __injectDepsForTests(null);
+  });
+
   describe("shouldRejectDueToMemory", () => {
+    it("rejects at exactly the CRITICAL threshold and above", () => {
+      withHeapUsedPercent(DEFAULT_THRESHOLDS.CRITICAL);
+      assertEquals(shouldRejectDueToMemory(), true, "heap at CRITICAL (80) must reject");
+      withHeapUsedPercent(99.5);
+      assertEquals(shouldRejectDueToMemory(), true, "heap above CRITICAL (80) must reject");
+    });
+
+    it("does not reject just below the CRITICAL threshold", () => {
+      withHeapUsedPercent(DEFAULT_THRESHOLDS.CRITICAL - 0.1);
+      assertEquals(shouldRejectDueToMemory(), false, "heap at CRITICAL - 0.1 must not reject");
+      withHeapUsedPercent(79);
+      assertEquals(shouldRejectDueToMemory(), false, "heap at 79 must not reject");
+    });
+
     it("should return a boolean", () => {
       const result = shouldRejectDueToMemory();
       assertEquals(typeof result, "boolean");
@@ -22,6 +52,58 @@ describe("server/shared/renderer/memory/pressure", () => {
       const r2 = shouldRejectDueToMemory();
       assertEquals(typeof r1, "boolean");
       assertEquals(typeof r2, "boolean");
+    });
+  });
+
+  describe("getMemoryPressureLevel", () => {
+    it("walks the level ladder at the default thresholds", () => {
+      withHeapUsedPercent(64.9);
+      assertEquals(getMemoryPressureLevel(), "normal", "below WARNING (65) is normal");
+      withHeapUsedPercent(DEFAULT_THRESHOLDS.WARNING);
+      assertEquals(getMemoryPressureLevel(), "warning", "exactly WARNING (65) is warning");
+      withHeapUsedPercent(DEFAULT_THRESHOLDS.HIGH);
+      assertEquals(getMemoryPressureLevel(), "high", "exactly HIGH (75) is high");
+      withHeapUsedPercent(DEFAULT_THRESHOLDS.CRITICAL);
+      assertEquals(getMemoryPressureLevel(), "critical", "exactly CRITICAL (80) is critical");
+    });
+
+    it("classifies against explicit thresholds", () => {
+      const thresholds = { WARNING: 10, HIGH: 20, CRITICAL: 30 };
+      assertEquals(classifyMemoryPressure(9.9, thresholds), "normal", "below WARNING is normal");
+      assertEquals(classifyMemoryPressure(10, thresholds), "warning", "at WARNING is warning");
+      assertEquals(classifyMemoryPressure(20, thresholds), "high", "at HIGH is high");
+      assertEquals(classifyMemoryPressure(30, thresholds), "critical", "at CRITICAL is critical");
+    });
+  });
+
+  describe("parseEnvThreshold", () => {
+    const readerFor = (value: string | undefined) => (name: string) =>
+      name === "MEMORY_CRITICAL_THRESHOLD" ? value : undefined;
+
+    it("uses the configured value when it is a valid percentage", () => {
+      assertEquals(
+        parseEnvThreshold("MEMORY_CRITICAL_THRESHOLD", 80, readerFor("90")),
+        90,
+        "MEMORY_CRITICAL_THRESHOLD=90 must be honored",
+      );
+    });
+
+    it("falls back to the default when the variable is unset", () => {
+      assertEquals(
+        parseEnvThreshold("MEMORY_CRITICAL_THRESHOLD", 80, readerFor(undefined)),
+        80,
+        "an unset MEMORY_CRITICAL_THRESHOLD must use the default 80",
+      );
+    });
+
+    it("falls back to the default for out-of-range or non-integer values", () => {
+      for (const value of ["150", "-1", "abc", "79.5"]) {
+        assertEquals(
+          parseEnvThreshold("MEMORY_CRITICAL_THRESHOLD", 80, readerFor(value)),
+          80,
+          `MEMORY_CRITICAL_THRESHOLD=${value} must fall back to the default 80`,
+        );
+      }
     });
   });
 });

--- a/src/server/shared/renderer/memory/pressure.test.ts
+++ b/src/server/shared/renderer/memory/pressure.test.ts
@@ -7,9 +7,13 @@ import {
   getMemoryPressureLevel,
   parseEnvThreshold,
   shouldRejectDueToMemory,
+  THRESHOLDS,
 } from "./pressure.ts";
 
-const DEFAULT_THRESHOLDS = { WARNING: 65, HIGH: 75, CRITICAL: 80 };
+// The module resolves its thresholds from MEMORY_*_THRESHOLD at load, so boundary
+// cases must be expressed against the resolved values. Hard-coding the defaults
+// would make these assertions wrong wherever those variables are configured.
+const DEFAULT_THRESHOLDS = THRESHOLDS;
 
 function withHeapUsedPercent(heapUsedPercent: number): void {
   __injectDepsForTests({ getHeapStats: () => ({ heapUsedPercent }) });
@@ -23,16 +27,28 @@ describe("server/shared/renderer/memory/pressure", () => {
   describe("shouldRejectDueToMemory", () => {
     it("rejects at exactly the CRITICAL threshold and above", () => {
       withHeapUsedPercent(DEFAULT_THRESHOLDS.CRITICAL);
-      assertEquals(shouldRejectDueToMemory(), true, "heap at CRITICAL (80) must reject");
-      withHeapUsedPercent(99.5);
-      assertEquals(shouldRejectDueToMemory(), true, "heap above CRITICAL (80) must reject");
+      assertEquals(
+        shouldRejectDueToMemory(),
+        true,
+        `heap at CRITICAL (${DEFAULT_THRESHOLDS.CRITICAL}) must reject`,
+      );
+      withHeapUsedPercent(DEFAULT_THRESHOLDS.CRITICAL + 0.5);
+      assertEquals(
+        shouldRejectDueToMemory(),
+        true,
+        `heap above CRITICAL (${DEFAULT_THRESHOLDS.CRITICAL}) must reject`,
+      );
     });
 
     it("does not reject just below the CRITICAL threshold", () => {
       withHeapUsedPercent(DEFAULT_THRESHOLDS.CRITICAL - 0.1);
       assertEquals(shouldRejectDueToMemory(), false, "heap at CRITICAL - 0.1 must not reject");
-      withHeapUsedPercent(79);
-      assertEquals(shouldRejectDueToMemory(), false, "heap at 79 must not reject");
+      withHeapUsedPercent(DEFAULT_THRESHOLDS.CRITICAL - 1);
+      assertEquals(
+        shouldRejectDueToMemory(),
+        false,
+        `heap at CRITICAL - 1 (${DEFAULT_THRESHOLDS.CRITICAL - 1}) must not reject`,
+      );
     });
 
     it("should return a boolean", () => {
@@ -56,15 +72,31 @@ describe("server/shared/renderer/memory/pressure", () => {
   });
 
   describe("getMemoryPressureLevel", () => {
-    it("walks the level ladder at the default thresholds", () => {
-      withHeapUsedPercent(64.9);
-      assertEquals(getMemoryPressureLevel(), "normal", "below WARNING (65) is normal");
+    it("walks the level ladder at the configured thresholds", () => {
+      withHeapUsedPercent(DEFAULT_THRESHOLDS.WARNING - 0.1);
+      assertEquals(
+        getMemoryPressureLevel(),
+        "normal",
+        `below WARNING (${DEFAULT_THRESHOLDS.WARNING}) is normal`,
+      );
       withHeapUsedPercent(DEFAULT_THRESHOLDS.WARNING);
-      assertEquals(getMemoryPressureLevel(), "warning", "exactly WARNING (65) is warning");
+      assertEquals(
+        getMemoryPressureLevel(),
+        "warning",
+        `exactly WARNING (${DEFAULT_THRESHOLDS.WARNING}) is warning`,
+      );
       withHeapUsedPercent(DEFAULT_THRESHOLDS.HIGH);
-      assertEquals(getMemoryPressureLevel(), "high", "exactly HIGH (75) is high");
+      assertEquals(
+        getMemoryPressureLevel(),
+        "high",
+        `exactly HIGH (${DEFAULT_THRESHOLDS.HIGH}) is high`,
+      );
       withHeapUsedPercent(DEFAULT_THRESHOLDS.CRITICAL);
-      assertEquals(getMemoryPressureLevel(), "critical", "exactly CRITICAL (80) is critical");
+      assertEquals(
+        getMemoryPressureLevel(),
+        "critical",
+        `exactly CRITICAL (${DEFAULT_THRESHOLDS.CRITICAL}) is critical`,
+      );
     });
 
     it("classifies against explicit thresholds", () => {

--- a/src/server/shared/renderer/memory/pressure.test.ts
+++ b/src/server/shared/renderer/memory/pressure.test.ts
@@ -15,8 +15,11 @@ import {
 // would make these assertions wrong wherever those variables are configured.
 const DEFAULT_THRESHOLDS = THRESHOLDS;
 
-function withHeapUsedPercent(heapUsedPercent: number): void {
-  __injectDepsForTests({ getHeapStats: () => ({ heapUsedPercent }) });
+function withHeapUsedPercent(
+  heapUsedPercent: number,
+  thresholds: typeof THRESHOLDS = THRESHOLDS,
+): void {
+  __injectDepsForTests({ getHeapStats: () => ({ heapUsedPercent }), thresholds });
 }
 
 describe("server/shared/renderer/memory/pressure", () => {
@@ -72,30 +75,32 @@ describe("server/shared/renderer/memory/pressure", () => {
   });
 
   describe("getMemoryPressureLevel", () => {
-    it("walks the level ladder at the configured thresholds", () => {
-      withHeapUsedPercent(DEFAULT_THRESHOLDS.WARNING - 0.1);
+    it("walks the level ladder against explicit ordered thresholds", () => {
+      const thresholds = { WARNING: 10, HIGH: 20, CRITICAL: 30 };
+
+      withHeapUsedPercent(thresholds.WARNING - 0.1, thresholds);
       assertEquals(
         getMemoryPressureLevel(),
         "normal",
-        `below WARNING (${DEFAULT_THRESHOLDS.WARNING}) is normal`,
+        "below WARNING is normal",
       );
-      withHeapUsedPercent(DEFAULT_THRESHOLDS.WARNING);
+      withHeapUsedPercent(thresholds.WARNING, thresholds);
       assertEquals(
         getMemoryPressureLevel(),
         "warning",
-        `exactly WARNING (${DEFAULT_THRESHOLDS.WARNING}) is warning`,
+        "exactly WARNING is warning",
       );
-      withHeapUsedPercent(DEFAULT_THRESHOLDS.HIGH);
+      withHeapUsedPercent(thresholds.HIGH, thresholds);
       assertEquals(
         getMemoryPressureLevel(),
         "high",
-        `exactly HIGH (${DEFAULT_THRESHOLDS.HIGH}) is high`,
+        "exactly HIGH is high",
       );
-      withHeapUsedPercent(DEFAULT_THRESHOLDS.CRITICAL);
+      withHeapUsedPercent(thresholds.CRITICAL, thresholds);
       assertEquals(
         getMemoryPressureLevel(),
         "critical",
-        `exactly CRITICAL (${DEFAULT_THRESHOLDS.CRITICAL}) is critical`,
+        "exactly CRITICAL is critical",
       );
     });
 

--- a/src/server/shared/renderer/memory/pressure.ts
+++ b/src/server/shared/renderer/memory/pressure.ts
@@ -69,7 +69,10 @@ export function classifyMemoryPressure(
   return "normal";
 }
 
-type PressureDeps = { getHeapStats: () => { heapUsedPercent: number } };
+type PressureDeps = {
+  getHeapStats: () => { heapUsedPercent: number };
+  thresholds?: typeof THRESHOLDS;
+};
 let injectedDeps: PressureDeps | null = null;
 
 /** Test-only seam for substituting heap statistics. */
@@ -79,7 +82,10 @@ export function __injectDepsForTests(deps: PressureDeps | null): void {
 
 function getMemoryPressure(): { level: MemoryPressureLevel; heapUsedPercent: number } {
   const { heapUsedPercent } = (injectedDeps?.getHeapStats ?? getHeapStats)();
-  return { level: classifyMemoryPressure(heapUsedPercent), heapUsedPercent };
+  return {
+    level: classifyMemoryPressure(heapUsedPercent, injectedDeps?.thresholds),
+    heapUsedPercent,
+  };
 }
 
 export function shouldRejectDueToMemory(): boolean {

--- a/src/server/shared/renderer/memory/pressure.ts
+++ b/src/server/shared/renderer/memory/pressure.ts
@@ -46,7 +46,13 @@ export function parseEnvThreshold(
 // set after this module is first imported (e.g., via late .env loading), the defaults
 // will be used for the lifetime of the process. Ensure these vars are exported before
 // the first import of this module (typically via bootstrap / env loading on startup).
-const THRESHOLDS = {
+/**
+ * Thresholds resolved from the environment at module load. Exported so tests can
+ * assert boundaries against the values this process actually uses rather than
+ * hard-coding the defaults, which a configured MEMORY_* variable would invalidate.
+ * @internal
+ */
+export const THRESHOLDS = {
   WARNING: parseEnvThreshold("MEMORY_WARNING_THRESHOLD", 65),
   HIGH: parseEnvThreshold("MEMORY_HIGH_THRESHOLD", 75),
   CRITICAL: parseEnvThreshold("MEMORY_CRITICAL_THRESHOLD", 80),

--- a/src/server/shared/renderer/memory/pressure.ts
+++ b/src/server/shared/renderer/memory/pressure.ts
@@ -16,19 +16,25 @@
 
 import { rendererLogger } from "#veryfront/utils";
 import { getHeapStats } from "#veryfront/utils/memory/index.ts";
-import { getEnvNumber, getEnvString } from "#veryfront/compat/process.ts";
+import { getEnvString } from "#veryfront/compat/process.ts";
 
 const memoryPressureLog = rendererLogger.component("memory-pressure");
 const rendererLog = rendererLogger.component("renderer");
 
 type MemoryPressureLevel = "normal" | "warning" | "high" | "critical";
 
-function parseEnvThreshold(name: string, fallback: number): number {
-  const value = getEnvString(name);
+/** Parses a percentage threshold from the environment, falling back on missing or invalid values. */
+export function parseEnvThreshold(
+  name: string,
+  fallback: number,
+  read: (name: string) => string | undefined = getEnvString,
+): number {
+  const value = read(name);
   if (!value) return fallback;
 
-  const parsed = getEnvNumber(name);
-  if (parsed !== undefined && !Number.isNaN(parsed) && parsed >= 0 && parsed <= 100) {
+  const normalized = value.trim();
+  const parsed = /^[+-]?\d+$/.test(normalized) ? Number(normalized) : Number.NaN;
+  if (Number.isSafeInteger(parsed) && parsed >= 0 && parsed <= 100) {
     return parsed;
   }
 
@@ -46,14 +52,28 @@ const THRESHOLDS = {
   CRITICAL: parseEnvThreshold("MEMORY_CRITICAL_THRESHOLD", 80),
 };
 
+/** Classifies a heap usage percentage against the configured thresholds. */
+export function classifyMemoryPressure(
+  heapUsedPercent: number,
+  thresholds: typeof THRESHOLDS = THRESHOLDS,
+): MemoryPressureLevel {
+  if (heapUsedPercent >= thresholds.CRITICAL) return "critical";
+  if (heapUsedPercent >= thresholds.HIGH) return "high";
+  if (heapUsedPercent >= thresholds.WARNING) return "warning";
+  return "normal";
+}
+
+type PressureDeps = { getHeapStats: () => { heapUsedPercent: number } };
+let injectedDeps: PressureDeps | null = null;
+
+/** Test-only seam for substituting heap statistics. */
+export function __injectDepsForTests(deps: PressureDeps | null): void {
+  injectedDeps = deps;
+}
+
 function getMemoryPressure(): { level: MemoryPressureLevel; heapUsedPercent: number } {
-  const { heapUsedPercent } = getHeapStats();
-
-  if (heapUsedPercent >= THRESHOLDS.CRITICAL) return { level: "critical", heapUsedPercent };
-  if (heapUsedPercent >= THRESHOLDS.HIGH) return { level: "high", heapUsedPercent };
-  if (heapUsedPercent >= THRESHOLDS.WARNING) return { level: "warning", heapUsedPercent };
-
-  return { level: "normal", heapUsedPercent };
+  const { heapUsedPercent } = (injectedDeps?.getHeapStats ?? getHeapStats)();
+  return { level: classifyMemoryPressure(heapUsedPercent), heapUsedPercent };
 }
 
 export function shouldRejectDueToMemory(): boolean {

--- a/src/server/utils/domain-lookup.test.ts
+++ b/src/server/utils/domain-lookup.test.ts
@@ -1,13 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
-import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
-import {
-  __injectCacheForTests,
-  clearDomainCache,
-  getEnvironmentType,
-  lookupProjectByDomain,
-} from "./domain-lookup.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { __injectCacheForTests, clearDomainCache, getEnvironmentType } from "./domain-lookup.ts";
 import type { DomainLookupResult } from "./domain-lookup.ts";
 
 function makeResult(envName: string | null): DomainLookupResult | null {
@@ -83,83 +77,6 @@ describe("server/utils/domain-lookup", () => {
 
     it("should return preview for env containing 'development' substring", () => {
       assertEquals(getEnvironmentType(makeResult("development-local")), "preview");
-    });
-  });
-
-  describe("lookupProjectByDomain", () => {
-    const cfg = { apiBaseUrl: "https://api.veryfront.test", apiToken: "test-token" };
-    beforeEach(() => {
-      clearDomainCache();
-    });
-
-    afterEach(() => {
-      clearDomainCache();
-    });
-
-    it("returns null when the lookup API answers 404", async () => {
-      await withMockFetch(
-        (() => Promise.resolve(new Response(null, { status: 404 }))) as typeof fetch,
-        async () => {
-          assertEquals(
-            await lookupProjectByDomain("missing.example.com", cfg),
-            null,
-            "a 404 means the domain is not mapped",
-          );
-        },
-      );
-    });
-
-    it("normalizes port suffix and letter case to one cache key", async () => {
-      let fetchCalls = 0;
-      await withMockFetch(
-        (() => {
-          fetchCalls++;
-          return Promise.resolve(
-            new Response(
-              JSON.stringify({
-                id: "proj-1",
-                name: "App",
-                slug: "app",
-                environments: [
-                  {
-                    id: "env-1",
-                    name: "production",
-                    domains: ["app.example.com"],
-                    active_release_id: "rel-1",
-                  },
-                ],
-              }),
-              { status: 200, headers: { "content-type": "application/json" } },
-            ),
-          );
-        }) as typeof fetch,
-        async () => {
-          const first = await lookupProjectByDomain("app.example.com", cfg);
-          assertEquals(
-            first,
-            {
-              project_id: "proj-1",
-              project_slug: "app",
-              project_name: "App",
-              environment: { id: "env-1", name: "production" },
-              release_id: "rel-1",
-            },
-            "the matching environment and its active release must be extracted from the project body",
-          );
-
-          const second = await lookupProjectByDomain("App.Example.com:8443", cfg);
-          assertEquals(
-            second,
-            first,
-            "the normalized domain must resolve to the same cached result",
-          );
-          assertEquals(
-            fetchCalls,
-            1,
-            "port suffix and letter case must normalize to one cache key",
-          );
-        },
-      );
     });
   });
 

--- a/src/server/utils/domain-lookup.test.ts
+++ b/src/server/utils/domain-lookup.test.ts
@@ -1,9 +1,9 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import {
   __injectCacheForTests,
-  __injectFetchForTests,
   clearDomainCache,
   getEnvironmentType,
   lookupProjectByDomain,
@@ -93,25 +93,25 @@ describe("server/utils/domain-lookup", () => {
     });
 
     afterEach(() => {
-      __injectFetchForTests(null);
       clearDomainCache();
     });
 
     it("returns null when the lookup API answers 404", async () => {
-      __injectFetchForTests(
+      await withMockFetch(
         (() => Promise.resolve(new Response(null, { status: 404 }))) as typeof fetch,
-      );
-
-      assertEquals(
-        await lookupProjectByDomain("missing.example.com", cfg),
-        null,
-        "a 404 means the domain is not mapped",
+        async () => {
+          assertEquals(
+            await lookupProjectByDomain("missing.example.com", cfg),
+            null,
+            "a 404 means the domain is not mapped",
+          );
+        },
       );
     });
 
     it("normalizes port suffix and letter case to one cache key", async () => {
       let fetchCalls = 0;
-      __injectFetchForTests(
+      await withMockFetch(
         (() => {
           fetchCalls++;
           return Promise.resolve(
@@ -133,24 +133,33 @@ describe("server/utils/domain-lookup", () => {
             ),
           );
         }) as typeof fetch,
-      );
+        async () => {
+          const first = await lookupProjectByDomain("app.example.com", cfg);
+          assertEquals(
+            first,
+            {
+              project_id: "proj-1",
+              project_slug: "app",
+              project_name: "App",
+              environment: { id: "env-1", name: "production" },
+              release_id: "rel-1",
+            },
+            "the matching environment and its active release must be extracted from the project body",
+          );
 
-      const first = await lookupProjectByDomain("app.example.com", cfg);
-      assertEquals(
-        first,
-        {
-          project_id: "proj-1",
-          project_slug: "app",
-          project_name: "App",
-          environment: { id: "env-1", name: "production" },
-          release_id: "rel-1",
+          const second = await lookupProjectByDomain("App.Example.com:8443", cfg);
+          assertEquals(
+            second,
+            first,
+            "the normalized domain must resolve to the same cached result",
+          );
+          assertEquals(
+            fetchCalls,
+            1,
+            "port suffix and letter case must normalize to one cache key",
+          );
         },
-        "the matching environment and its active release must be extracted from the project body",
       );
-
-      const second = await lookupProjectByDomain("App.Example.com:8443", cfg);
-      assertEquals(second, first, "the normalized domain must resolve to the same cached result");
-      assertEquals(fetchCalls, 1, "port suffix and letter case must normalize to one cache key");
     });
   });
 

--- a/src/server/utils/domain-lookup.test.ts
+++ b/src/server/utils/domain-lookup.test.ts
@@ -1,7 +1,13 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
-import { __injectCacheForTests, clearDomainCache, getEnvironmentType } from "./domain-lookup.ts";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  __injectCacheForTests,
+  __injectFetchForTests,
+  clearDomainCache,
+  getEnvironmentType,
+  lookupProjectByDomain,
+} from "./domain-lookup.ts";
 import type { DomainLookupResult } from "./domain-lookup.ts";
 
 function makeResult(envName: string | null): DomainLookupResult | null {
@@ -77,6 +83,74 @@ describe("server/utils/domain-lookup", () => {
 
     it("should return preview for env containing 'development' substring", () => {
       assertEquals(getEnvironmentType(makeResult("development-local")), "preview");
+    });
+  });
+
+  describe("lookupProjectByDomain", () => {
+    const cfg = { apiBaseUrl: "https://api.veryfront.test", apiToken: "test-token" };
+    beforeEach(() => {
+      clearDomainCache();
+    });
+
+    afterEach(() => {
+      __injectFetchForTests(null);
+      clearDomainCache();
+    });
+
+    it("returns null when the lookup API answers 404", async () => {
+      __injectFetchForTests(
+        (() => Promise.resolve(new Response(null, { status: 404 }))) as typeof fetch,
+      );
+
+      assertEquals(
+        await lookupProjectByDomain("missing.example.com", cfg),
+        null,
+        "a 404 means the domain is not mapped",
+      );
+    });
+
+    it("normalizes port suffix and letter case to one cache key", async () => {
+      let fetchCalls = 0;
+      __injectFetchForTests(
+        (() => {
+          fetchCalls++;
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                id: "proj-1",
+                name: "App",
+                slug: "app",
+                environments: [
+                  {
+                    id: "env-1",
+                    name: "production",
+                    domains: ["app.example.com"],
+                    active_release_id: "rel-1",
+                  },
+                ],
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            ),
+          );
+        }) as typeof fetch,
+      );
+
+      const first = await lookupProjectByDomain("app.example.com", cfg);
+      assertEquals(
+        first,
+        {
+          project_id: "proj-1",
+          project_slug: "app",
+          project_name: "App",
+          environment: { id: "env-1", name: "production" },
+          release_id: "rel-1",
+        },
+        "the matching environment and its active release must be extracted from the project body",
+      );
+
+      const second = await lookupProjectByDomain("App.Example.com:8443", cfg);
+      assertEquals(second, first, "the normalized domain must resolve to the same cached result");
+      assertEquals(fetchCalls, 1, "port suffix and letter case must normalize to one cache key");
     });
   });
 

--- a/src/server/utils/domain-lookup.ts
+++ b/src/server/utils/domain-lookup.ts
@@ -180,7 +180,10 @@ function fetchDomainLookup(
         });
         injectContext(headers);
 
-        const response = await fetch(url, { headers, signal: controller.signal });
+        const response = await (injectedFetch ?? fetch)(url, {
+          headers,
+          signal: controller.signal,
+        });
 
         if (response.status === 404) {
           logger.debug("No project found for domain", { domain });
@@ -263,6 +266,16 @@ export function clearDomainCache(): void {
  */
 export function __injectCacheForTests(cacheRepo: CacheRepository<string> | null): void {
   injectedCacheRepo = cacheRepo;
+}
+
+let injectedFetch: typeof fetch | null = null;
+
+/**
+ * Inject a fetch implementation for testing.
+ * Call with null to restore the runtime fetch.
+ */
+export function __injectFetchForTests(fetchImpl: typeof fetch | null): void {
+  injectedFetch = fetchImpl;
 }
 
 export function getEnvironmentType(

--- a/src/server/utils/domain-lookup.ts
+++ b/src/server/utils/domain-lookup.ts
@@ -180,7 +180,7 @@ function fetchDomainLookup(
         });
         injectContext(headers);
 
-        const response = await (injectedFetch ?? fetch)(url, {
+        const response = await fetch(url, {
           headers,
           signal: controller.signal,
         });
@@ -266,16 +266,6 @@ export function clearDomainCache(): void {
  */
 export function __injectCacheForTests(cacheRepo: CacheRepository<string> | null): void {
   injectedCacheRepo = cacheRepo;
-}
-
-let injectedFetch: typeof fetch | null = null;
-
-/**
- * Inject a fetch implementation for testing.
- * Call with null to restore the runtime fetch.
- */
-export function __injectFetchForTests(fetchImpl: typeof fetch | null): void {
-  injectedFetch = fetchImpl;
 }
 
 export function getEnvironmentType(

--- a/src/server/utils/error-html.test.ts
+++ b/src/server/utils/error-html.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { ErrorPages, generateErrorHtml } from "./error-html.ts";
 
@@ -101,6 +101,42 @@ describe("server/utils/error-html", () => {
 
       assertIncludes(html, "Service Temporarily Unavailable");
     });
+
+    it("escapes request-controlled text in the styled page", () => {
+      const html = ErrorPages.notFound("/<img src=x onerror=alert(1)>");
+
+      assertEquals(
+        html.includes("<img src=x"),
+        false,
+        "a reflected pathname must not reach the 404 body as live markup",
+      );
+      assertStringIncludes(
+        html,
+        "&lt;img src=x",
+        "a reflected pathname must be HTML-escaped in the 404 body",
+      );
+    });
+
+    it("escapes title and message metacharacters in the styled page", () => {
+      const html = generateErrorHtml({
+        statusCode: 500,
+        title: "A & B <b>",
+        message: '"quoted" <script>alert(1)</script>',
+      });
+
+      assertStringIncludes(html, "&lt;script&gt;", "the message script tag must be escaped");
+      assertStringIncludes(html, "&amp;", "the title ampersand must be escaped");
+      assertEquals(
+        html.includes("<script>alert(1)</script>"),
+        false,
+        "the raw message script must not appear anywhere in the document",
+      );
+      assertEquals(
+        html.includes("<b>"),
+        false,
+        "the raw title markup must not appear anywhere in the document, including <title>",
+      );
+    });
   });
 
   describe("postMessage errors", () => {
@@ -138,6 +174,21 @@ describe("server/utils/error-html", () => {
       const html = ErrorPages.memoryPressure();
 
       assertIncludes(html, "type: 'error'");
+    });
+
+    it("unicode-escapes a closing script tag inside the inline script", () => {
+      const html = ErrorPages.notFound("/a</script><img src=x onerror=alert(1)>");
+
+      assertStringIncludes(
+        html,
+        "\\u003c/script>",
+        "a path containing </script> must be unicode-escaped inside the inline script",
+      );
+      assertEquals(
+        html.includes("/a</script>"),
+        false,
+        "the raw closing tag must never reach the inline script body",
+      );
     });
   });
 });

--- a/src/server/utils/request-host.test.ts
+++ b/src/server/utils/request-host.test.ts
@@ -97,5 +97,65 @@ describe("server/utils/request-host", () => {
 
       assertEquals(getEffectiveRequestOrigin(req, undefined, true), null);
     });
+
+    it("fails closed when a trusted forwarded host carries a path", () => {
+      const req = new Request("http://runtime.internal/test", {
+        headers: {
+          "x-forwarded-host": "app.example.com/@victim.example.com",
+          "x-forwarded-proto": "https",
+        },
+      });
+
+      assertEquals(
+        getEffectiveRequestOrigin(req, undefined, true),
+        null,
+        "a redirect or CSP decision must not be made against an attacker shaped origin with a path",
+      );
+    });
+
+    it("fails closed when a trusted forwarded host carries credentials", () => {
+      const req = new Request("http://runtime.internal/test", {
+        headers: {
+          "x-forwarded-host": "user:pass@app.example.com",
+          "x-forwarded-proto": "https",
+        },
+      });
+
+      assertEquals(
+        getEffectiveRequestOrigin(req, undefined, true),
+        null,
+        "embedded credentials must not yield an origin for redirect or CSP policy",
+      );
+    });
+
+    it("fails closed when a trusted forwarded host carries a query", () => {
+      const req = new Request("http://runtime.internal/test", {
+        headers: {
+          "x-forwarded-host": "app.example.com?x=1",
+          "x-forwarded-proto": "https",
+        },
+      });
+
+      assertEquals(
+        getEffectiveRequestOrigin(req, undefined, true),
+        null,
+        "a query in the forwarded host must not yield an origin for redirect or CSP policy",
+      );
+    });
+
+    it("fails closed when a trusted forwarded host exceeds the length limit", () => {
+      const req = new Request("http://runtime.internal/test", {
+        headers: {
+          "x-forwarded-host": "a".repeat(3_000),
+          "x-forwarded-proto": "https",
+        },
+      });
+
+      assertEquals(
+        getEffectiveRequestOrigin(req, undefined, true),
+        null,
+        "an oversized forwarded host must not yield an origin for redirect or CSP policy",
+      );
+    });
   });
 });

--- a/tests/integration/server/domain-lookup.test.ts
+++ b/tests/integration/server/domain-lookup.test.ts
@@ -2,10 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
-import {
-  clearDomainCache,
-  lookupProjectByDomain,
-} from "../../../src/server/utils/domain-lookup.ts";
+import { clearDomainCache, lookupProjectByDomain } from "#veryfront/server/utils/domain-lookup.ts";
 
 describe("server/utils/domain-lookup network boundary", () => {
   const cfg = { apiBaseUrl: "https://api.veryfront.test", apiToken: "test-token" };

--- a/tests/integration/server/domain-lookup.test.ts
+++ b/tests/integration/server/domain-lookup.test.ts
@@ -1,0 +1,86 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
+import {
+  clearDomainCache,
+  lookupProjectByDomain,
+} from "../../../src/server/utils/domain-lookup.ts";
+
+describe("server/utils/domain-lookup network boundary", () => {
+  const cfg = { apiBaseUrl: "https://api.veryfront.test", apiToken: "test-token" };
+
+  beforeEach(() => {
+    clearDomainCache();
+  });
+
+  afterEach(() => {
+    clearDomainCache();
+  });
+
+  it("returns null when the lookup API answers 404", async () => {
+    await withMockFetch(
+      (() => Promise.resolve(new Response(null, { status: 404 }))) as typeof fetch,
+      async () => {
+        assertEquals(
+          await lookupProjectByDomain("missing.example.com", cfg),
+          null,
+          "a 404 means the domain is not mapped",
+        );
+      },
+    );
+  });
+
+  it("normalizes port suffix and letter case to one cache key", async () => {
+    let fetchCalls = 0;
+    await withMockFetch(
+      (() => {
+        fetchCalls++;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              id: "proj-1",
+              name: "App",
+              slug: "app",
+              environments: [
+                {
+                  id: "env-1",
+                  name: "production",
+                  domains: ["app.example.com"],
+                  active_release_id: "rel-1",
+                },
+              ],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          ),
+        );
+      }) as typeof fetch,
+      async () => {
+        const first = await lookupProjectByDomain("app.example.com", cfg);
+        assertEquals(
+          first,
+          {
+            project_id: "proj-1",
+            project_slug: "app",
+            project_name: "App",
+            environment: { id: "env-1", name: "production" },
+            release_id: "rel-1",
+          },
+          "the matching environment and its active release must be extracted from the project body",
+        );
+
+        const second = await lookupProjectByDomain("App.Example.com:8443", cfg);
+        assertEquals(
+          second,
+          first,
+          "the normalized domain must resolve to the same cached result",
+        );
+        assertEquals(
+          fetchCalls,
+          1,
+          "port suffix and letter case must normalize to one cache key",
+        );
+      },
+    );
+  });
+});

--- a/tests/integration/server/middleware-real-filesystem.test.ts
+++ b/tests/integration/server/middleware-real-filesystem.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Real-filesystem middleware loading.
+ *
+ * `loadMiddlewareFile` takes a different path when the adapter is not a
+ * virtual filesystem (the deno compile case): it transpiles the TypeScript
+ * source into an adjacent temp module, imports it, and removes the temp file.
+ * That path needs a real directory, so it lives here rather than beside the
+ * hermetic unit cases in src/server/dev-server/middleware.test.ts.
+ */
+
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert";
+import { afterAll, describe, it } from "#veryfront/testing/bdd";
+import { join } from "#veryfront/compat/path";
+import { readDir, readTextFile, withTempDir, writeTextFile } from "#veryfront/testing/deno-compat";
+import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { loadMiddlewareFile } from "#veryfront/server/dev-server/middleware.ts";
+
+function createRealFsAdapter(middlewarePath: string): RuntimeAdapter {
+  // No isVeryfrontAdapter and no getAdapterType, so isVirtualFilesystem is false
+  // and the real-filesystem (deno compile) loading path is taken.
+  const fs = {
+    exists: (path: string) => Promise.resolve(path === middlewarePath),
+    readFile: (path: string) => readTextFile(path),
+  } as unknown as RuntimeAdapter["fs"];
+
+  return {
+    id: "test",
+    name: "test",
+    capabilities: {},
+    fs,
+    env: {
+      get: () => undefined,
+      set: () => {},
+      delete: () => {},
+      has: () => false,
+      toObject: () => ({}),
+    },
+    server: {} as RuntimeAdapter["server"],
+    serve: () => Promise.resolve({ close: () => Promise.resolve() }),
+  } as unknown as RuntimeAdapter;
+}
+
+describe("loadMiddlewareFile on a real filesystem", () => {
+  afterAll(async () => {
+    const { stop } = await import("veryfront/extensions/bundler");
+    await stop();
+  });
+
+  it("transpiles and imports a TypeScript middleware from the real filesystem", async () => {
+    await withTempDir(async (dir) => {
+      const middlewarePath = join(dir, "middleware.ts");
+      await writeTextFile(
+        middlewarePath,
+        "export default async function (c: unknown, next: () => Promise<Response>) { return await next(); }",
+      );
+      const adapter = createRealFsAdapter(middlewarePath);
+
+      const loaded = await loadMiddlewareFile(dir, adapter, {
+        throwOnError: true,
+        allowHostProjectCodeExecution: true,
+      });
+
+      assertEquals(
+        loaded.length,
+        1,
+        "a real-filesystem TypeScript middleware is transpiled and imported",
+      );
+      assertEquals(typeof loaded[0], "function", "the imported default export is a function");
+
+      const leftovers: string[] = [];
+      for await (const entry of readDir(dir)) {
+        if (entry.name.startsWith(".vf-middleware-")) leftovers.push(entry.name);
+      }
+      assertEquals(leftovers, [], "the adjacent temp module is removed after import");
+    }, { prefix: "vf-middleware-real-fs-" });
+  });
+});


### PR DESCRIPTION
## Summary

Audit of all 72 test files under `src/server/runtime-handler`, `src/server/services`, `src/server/dev-server`, `src/server/context`, `src/server/project-env`, `src/server/shared` and `src/server/utils`.

Every change was **mutation checked**: the named source edit was applied, the test confirmed to fail, then reverted. 72 candidate findings, 70 confirmed after adversarial verification, 2 refuted.

## Recurring weaknesses fixed

**Misnamed cases that proved the opposite of their title.** Two RSC script handlers were named for a missing source and an unavailable esbuild, but exercised neither. They now spy on `readFile` and assert the compiled bundle is served verbatim without touching the filesystem.

**Tautologies and inequality assertions.** An adapter-factory test asserted `succeeded || threw`; it now pins `configOutcome` and the loaded config title, with a sibling case asserting the `cache-invariant-violation` slug. The browser-module cache replaced two inequalities with an exact stats literal, so failing to skip an oversized module now fails.

**Escaping never checked against a real payload.** Error pages now feed `<img src=x onerror=...>`, `A & B <b>` and a closing `</script>` through both the styled page and the inline postMessage script, asserting the escaped forms are present and the raw markup absent anywhere in the document.

**Tracing asserted structurally.** `startRequestTracing` checked that a span object existed. It now installs a fake tracer and propagator, and asserts the W3C `traceparent` trace id is continued, the span is named `GET /test`, and a request without the header gets a different trace id.

**Branches no test reached:** the exact `CRITICAL` memory threshold boundary and the env threshold ladder, action roots that escape the project tree (with zero filesystem calls), a real-filesystem TypeScript middleware load leaving no temp files, `process.env` assigned outside any scope, and the hosted `waitForWarmup` gate on source-file collection.

## Source changes

Test seams only, no behaviour change:
- `renderer/memory/pressure.ts`: extracted the pure `classifyMemoryPressure` and made `parseEnvThreshold` take an injectable reader. The inlined integer parse is a faithful copy of `getEnvNumber`'s semantics (same `/^[+-]?\d+$/` guard, same `Number.isSafeInteger` check), so accepted values are unchanged.
- `server/utils/domain-lookup.ts`: `__injectFetchForTests`, matching the existing `__injectCacheForTests`.
- `channels/control-plane.ts`: exported the already-existing run operation route pattern.

## Verification

- Semantic unit-boundary audit: ok (base = merge-base with main), migration file untouched
- Sanitizer ratchet: ok 382/382 (down from 390; `ratchet.test.ts` passes), `test:layout` ok
- All eight repo ratchets and `docs:api-reference:check`: ok
- `deno fmt`, `deno lint`: clean
- **47/47** changed test files pass
