### PR TITLE
fix(resource): preserve path-absolute URI templates

### DIFF
--- a/src/mcp/server.test.ts
+++ b/src/mcp/server.test.ts
@@ -1247,6 +1247,13 @@ describe("mcp/server", () => {
         paramsSchema: defineSchema((v) => v.object({ collection: v.string(), id: v.string() }))(),
         load: async () => ({}),
       });
+      registerResource("test:path-absolute-file", {
+        id: "test:path-absolute-file",
+        pattern: "custom:/files/file-:id",
+        description: "Path-absolute file",
+        paramsSchema: defineSchema((v) => v.object({ id: v.string() }))(),
+        load: (params) => params,
+      });
 
       const response = await server.handleRequest({
         jsonrpc: "2.0",
@@ -1277,6 +1284,20 @@ describe("mcp/server", () => {
         templates.find((entry) => entry.name === "test:nested-file")?.uriTemplate,
         "custom:collections/{collection}/file-{id}",
       );
+      assertEquals(
+        templates.find((entry) => entry.name === "test:path-absolute-file")?.uriTemplate,
+        "custom:/files/file-{id}",
+      );
+
+      const readResponse = await server.handleRequest({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "resources/read",
+        params: { uri: "custom:/files/file-42" },
+      });
+      assertEquals(readResponse.error, undefined);
+      const result = readResponse.result as { contents: Array<{ text: string }> };
+      assertEquals(JSON.parse(result.contents[0]!.text), { id: "42" });
     });
 
     it("excludes scheme-only colons like openapi://spec", async () => {

--- a/src/resource/pattern.ts
+++ b/src/resource/pattern.ts
@@ -96,7 +96,7 @@ function parseResourcePattern(pattern: string): ParsedResourcePattern {
   const firstSchemeComponentEnd = findFirstSchemeComponentEnd(pattern, schemeDelimiter);
   const urnScheme = isUrnScheme(pattern, schemeDelimiter);
   const hierarchicalScheme = schemeDelimiter >= 0 &&
-    pattern[schemeDelimiter + 1] === "/" && pattern[schemeDelimiter + 2] === "/";
+    pattern[schemeDelimiter + 1] === "/";
   const rootlessTemplatePath = schemeDelimiter >= 0 && !urnScheme && !hierarchicalScheme &&
     hasRootlessTemplateBoundary(pattern, schemeDelimiter, firstSchemeComponentEnd);
   let component: ResourceComponent = "path";

--- a/src/resource/registry.test.ts
+++ b/src/resource/registry.test.ts
@@ -303,6 +303,26 @@ describe("resource registry", () => {
         ),
         { id: "42" },
       );
+
+      const pathAbsoluteFile = resource({
+        pattern: "custom:/files/file-:id",
+        description: "Path-absolute file",
+        paramsSchema: defineSchema((v) => v.object({ id: v.string() }))(),
+        load: async () => ({}),
+      });
+      resourceRegistry.clearAll();
+      resourceRegistry.register(pathAbsoluteFile.id, pathAbsoluteFile);
+      assertEquals(
+        resourceRegistry.findByPattern("custom:/files/file-42"),
+        pathAbsoluteFile,
+      );
+      assertEquals(
+        resourceRegistry.extractParams(
+          "custom:/files/file-42",
+          pathAbsoluteFile.pattern,
+        ),
+        { id: "42" },
+      );
     });
 
     it("should support caller-scoped visibility without changing default lookup", () => {


### PR DESCRIPTION
## Summary

- treat single-slash scheme paths such as `custom:/files/file-:id` as hierarchical resource templates
- preserve parameter extraction and MCP template advertisement for path-absolute scheme URIs
- cover registry matching plus MCP list/read behavior

## Context

Follow-up to #4037. Automated review identified the single-slash scheme boundary while #4037 was already completing the protected merge queue.

## Verification

- `deno task test:file src/resource/registry.test.ts`
- `deno task test:file src/mcp/server.test.ts`
- `deno task test:file src/resource`
- `deno task typecheck`
- `deno task lint`
- `deno fmt --check src/resource/pattern.ts src/resource/registry.test.ts src/mcp/server.test.ts`
- full pre-push suite reached 4,206 passing tests; two runs each hit a different unrelated flaky test, both passing in focused reruns