### PR TITLE
fix(workflow): bound per-run approval lists in both backends

### DIFF
--- a/docs/api-reference/veryfront/workflow.md
+++ b/docs/api-reference/veryfront/workflow.md
@@ -167,7 +167,7 @@ Options accepted by parallel.
 | Name               | Description                | Source                                                                                                          |
 | ------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `MemoryBackend`    | Implement memory backend.  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/backends/memory.ts#L112)            |
-| `RedisBackend`     | Implement redis backend.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/backends/redis/index.ts#L508)       |
+| `RedisBackend`     | Implement redis backend.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/backends/redis/index.ts#L503)       |
 | `WorkflowClient`   | Implement workflow client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/api/workflow-client.ts#L48)         |
 | `WorkflowExecutor` | Workflow Executor class    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/executor/workflow-executor.ts#L124) |
 

--- a/docs/api-reference/veryfront/workflow.md
+++ b/docs/api-reference/veryfront/workflow.md
@@ -166,8 +166,8 @@ Options accepted by parallel.
 
 | Name               | Description                | Source                                                                                                          |
 | ------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `MemoryBackend`    | Implement memory backend.  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/backends/memory.ts#L111)            |
-| `RedisBackend`     | Implement redis backend.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/backends/redis/index.ts#L411)       |
+| `MemoryBackend`    | Implement memory backend.  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/backends/memory.ts#L112)            |
+| `RedisBackend`     | Implement redis backend.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/backends/redis/index.ts#L508)       |
 | `WorkflowClient`   | Implement workflow client. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/api/workflow-client.ts#L48)         |
 | `WorkflowExecutor` | Workflow Executor class    | [source](https://github.com/veryfront/veryfront-code/blob/main/src/workflow/executor/workflow-executor.ts#L124) |
 

--- a/src/workflow/backends/approval-retention.test.ts
+++ b/src/workflow/backends/approval-retention.test.ts
@@ -1,0 +1,197 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { PendingApproval, WorkflowRun } from "../types.ts";
+import { MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES } from "../limits.ts";
+import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
+import { appendRetainedPendingApproval } from "./approval-retention.ts";
+import { MemoryBackend } from "./memory.ts";
+
+function approval(id: string, overrides: Partial<PendingApproval> = {}): PendingApproval {
+  return {
+    id,
+    nodeId: "wait-node",
+    status: "pending",
+    message: "Approve this?",
+    payload: {},
+    requestedAt: new Date(0),
+    ...overrides,
+  };
+}
+
+function run(id: string, workerId?: string): WorkflowRun {
+  return {
+    id,
+    workflowId: "approval-retention",
+    status: workerId ? "waiting" : "pending",
+    ...(workerId ? { workerId } : {}),
+    input: {},
+    nodeStates: {},
+    currentNodes: [],
+    context: { input: {} },
+    checkpoints: [],
+    pendingApprovals: [],
+    createdAt: new Date(),
+    sourceIntegrationPolicy: normalizeSourceIntegrationPolicy(undefined),
+  };
+}
+
+describe("workflow approval retention", () => {
+  it("appends a detached snapshot below the shared bound", () => {
+    const history = [approval("first")];
+    const second = approval("second");
+
+    appendRetainedPendingApproval(history, second);
+
+    assertEquals(history.map(({ id }) => id), ["first", "second"]);
+    second.id = "mutated-source";
+    assertEquals(history.at(-1)?.id, "second");
+  });
+
+  it("evicts the oldest decided record before any live one", () => {
+    const history = [
+      approval("live-oldest"),
+      approval("decided-a", { status: "approved" }),
+      approval("decided-b", { status: "rejected" }),
+    ];
+    while (history.length < MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES) {
+      history.push(approval(`live-${history.length}`));
+    }
+
+    appendRetainedPendingApproval(history, approval("newest"));
+
+    assertEquals(history.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);
+    assertEquals(history[0]?.id, "live-oldest");
+    assertEquals(history.some(({ id }) => id === "decided-a"), false);
+    assertEquals(history.some(({ id }) => id === "decided-b"), true);
+    assertEquals(history.at(-1)?.id, "newest");
+  });
+
+  it("evicts an expired record when no decided record remains", () => {
+    const history = [
+      approval("live-oldest"),
+      approval("expired", { expiresAt: new Date(Date.now() - 60_000) }),
+    ];
+    while (history.length < MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES) {
+      history.push(approval(`live-${history.length}`));
+    }
+
+    appendRetainedPendingApproval(history, approval("newest"));
+
+    assertEquals(history.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);
+    assertEquals(history[0]?.id, "live-oldest");
+    assertEquals(history.some(({ id }) => id === "expired"), false);
+    assertEquals(history.at(-1)?.id, "newest");
+  });
+
+  it("refuses the append when every retained record is live", () => {
+    const history = Array.from(
+      { length: MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES },
+      (_, index) => approval(`live-${index}`),
+    );
+
+    assertThrows(
+      () => appendRetainedPendingApproval(history, approval("overflow")),
+      Error,
+      "still pending",
+    );
+
+    assertEquals(history.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);
+    assertEquals(history[0]?.id, "live-0");
+    assertEquals(history.some(({ id }) => id === "overflow"), false);
+  });
+
+  it("leaves existing history unchanged when approval capture fails", () => {
+    const history = [approval("stable")];
+    const invalid = approval("invalid");
+    (invalid.payload as Record<string, unknown>).uncloneable = () => undefined;
+
+    assertThrows(() => appendRetainedPendingApproval(history, invalid));
+    assertEquals(history.map(({ id }) => id), ["stable"]);
+  });
+
+  it("bounds unconditional MemoryBackend appends by evicting decided records first", async () => {
+    const backend = new MemoryBackend();
+    await backend.createRun(run("unconditional"));
+    await backend.savePendingApproval("unconditional", approval("live-oldest"));
+    await backend.savePendingApproval("unconditional", approval("decided"));
+    await backend.updateApproval("unconditional", "decided", {
+      approved: true,
+      approver: "ops",
+    });
+    for (let index = 2; index < MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES; index++) {
+      await backend.savePendingApproval("unconditional", approval(`live-${index}`));
+    }
+
+    await backend.savePendingApproval("unconditional", approval("newest"));
+
+    assertEquals(await backend.getPendingApproval("unconditional", "decided"), null);
+    const retained = await backend.getPendingApprovals("unconditional");
+    assertEquals(retained.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);
+    assertEquals(retained[0]?.id, "live-oldest");
+    assertEquals(retained.at(-1)?.id, "newest");
+  });
+
+  it("refuses unconditional MemoryBackend appends when every record is live", async () => {
+    const backend = new MemoryBackend();
+    await backend.createRun(run("full"));
+    for (let index = 0; index < MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES; index++) {
+      await backend.savePendingApproval("full", approval(`live-${index}`));
+    }
+
+    await assertRejects(
+      () => backend.savePendingApproval("full", approval("overflow")),
+      Error,
+      "still pending",
+    );
+
+    const retained = await backend.getPendingApprovals("full");
+    assertEquals(retained.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);
+    assertEquals(retained[0]?.id, "live-0");
+    assertEquals(retained.some(({ id }) => id === "overflow"), false);
+  });
+
+  it("bounds owned MemoryBackend appends and leaves failed fences unchanged", async () => {
+    const backend = new MemoryBackend();
+    const workerId = "run-execution:retention-owner";
+    await backend.createRun(run("owned", workerId));
+    const saveOwned = (approvalRecord: PendingApproval) =>
+      backend.savePendingApprovalIfStatusAndWorker(
+        "owned",
+        ["waiting"],
+        workerId,
+        approvalRecord,
+      );
+
+    assertEquals(await saveOwned(approval("live-oldest")), true);
+    assertEquals(await saveOwned(approval("decided")), true);
+    await backend.updateApproval("owned", "decided", { approved: false, approver: "ops" });
+    for (let index = 2; index < MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES; index++) {
+      assertEquals(await saveOwned(approval(`live-${index}`)), true);
+    }
+
+    assertEquals(await saveOwned(approval("newest")), true);
+    assertEquals(await backend.getPendingApproval("owned", "decided"), null);
+
+    await assertRejects(
+      () => saveOwned(approval("overflow")),
+      Error,
+      "still pending",
+    );
+    const beforeFailedFence = await backend.getPendingApprovals("owned");
+    assertEquals(beforeFailedFence.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);
+    assertEquals(beforeFailedFence[0]?.id, "live-oldest");
+    assertEquals(beforeFailedFence.at(-1)?.id, "newest");
+
+    assertEquals(
+      await backend.savePendingApprovalIfStatusAndWorker(
+        "owned",
+        ["waiting"],
+        "run-execution:stale-owner",
+        approval("must-not-append"),
+      ),
+      false,
+    );
+    assertEquals(await backend.getPendingApprovals("owned"), beforeFailedFence);
+  });
+});

--- a/src/workflow/backends/approval-retention.test.ts
+++ b/src/workflow/backends/approval-retention.test.ts
@@ -67,7 +67,7 @@ describe("workflow approval retention", () => {
     assertEquals(history.at(-1)?.id, "newest");
   });
 
-  it("evicts an expired record when no decided record remains", () => {
+  it("retains expired pending records until expiration reconciliation decides them", () => {
     const history = [
       approval("live-oldest"),
       approval("expired", { expiresAt: new Date(Date.now() - 60_000) }),
@@ -76,10 +76,19 @@ describe("workflow approval retention", () => {
       history.push(approval(`live-${history.length}`));
     }
 
-    appendRetainedPendingApproval(history, approval("newest"));
+    assertThrows(
+      () => appendRetainedPendingApproval(history, approval("newest")),
+      Error,
+      "pending approval",
+    );
 
     assertEquals(history.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);
     assertEquals(history[0]?.id, "live-oldest");
+    assertEquals(history.some(({ id }) => id === "expired"), true);
+    assertEquals(history.some(({ id }) => id === "newest"), false);
+
+    history.find(({ id }) => id === "expired")!.status = "rejected";
+    appendRetainedPendingApproval(history, approval("newest"));
     assertEquals(history.some(({ id }) => id === "expired"), false);
     assertEquals(history.at(-1)?.id, "newest");
   });
@@ -93,12 +102,32 @@ describe("workflow approval retention", () => {
     assertThrows(
       () => appendRetainedPendingApproval(history, approval("overflow")),
       Error,
-      "still pending",
+      "pending approval",
     );
 
     assertEquals(history.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);
     assertEquals(history[0]?.id, "live-0");
     assertEquals(history.some(({ id }) => id === "overflow"), false);
+  });
+
+  it("does not partially prune legacy overflow when too few records are decided", () => {
+    const history = [
+      approval("decided-a", { status: "approved" }),
+      approval("decided-b", { status: "rejected" }),
+      ...Array.from(
+        { length: MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES },
+        (_, index) => approval(`live-${index}`),
+      ),
+    ];
+    const before = history.map(({ id }) => id);
+
+    assertThrows(
+      () => appendRetainedPendingApproval(history, approval("overflow")),
+      Error,
+      "pending approval",
+    );
+
+    assertEquals(history.map(({ id }) => id), before);
   });
 
   it("leaves existing history unchanged when approval capture fails", () => {
@@ -142,7 +171,7 @@ describe("workflow approval retention", () => {
     await assertRejects(
       () => backend.savePendingApproval("full", approval("overflow")),
       Error,
-      "still pending",
+      "pending approval",
     );
 
     const retained = await backend.getPendingApprovals("full");
@@ -176,7 +205,7 @@ describe("workflow approval retention", () => {
     await assertRejects(
       () => saveOwned(approval("overflow")),
       Error,
-      "still pending",
+      "pending approval",
     );
     const beforeFailedFence = await backend.getPendingApprovals("owned");
     assertEquals(beforeFailedFence.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);

--- a/src/workflow/backends/approval-retention.ts
+++ b/src/workflow/backends/approval-retention.ts
@@ -1,0 +1,46 @@
+import type { PendingApproval } from "../types.ts";
+import { MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES } from "../limits.ts";
+import { ORCHESTRATION_ERROR } from "#veryfront/errors";
+
+function isDecided(approval: PendingApproval): boolean {
+  return approval.status !== "pending";
+}
+
+function isExpired(approval: PendingApproval, now: Date): boolean {
+  return approval.status === "pending" &&
+    approval.expiresAt !== undefined &&
+    approval.expiresAt <= now;
+}
+
+/**
+ * Append a detached approval record and retain a bounded history. The per-run
+ * approval list is append-only: decisions rewrite records in place, so decided
+ * approvals stay in the list and dominate its growth.
+ *
+ * Retention is state-aware because a live pending approval must never be
+ * evicted: a run waiting on an evicted ID could never be decided or expired
+ * and would wait forever. At the bound, the oldest decided record is evicted
+ * first, then the oldest expired one. When every retained record is still
+ * live, the append is rejected instead of silently dropping a live approval.
+ */
+export function appendRetainedPendingApproval(
+  approvals: PendingApproval[],
+  approval: PendingApproval,
+): void {
+  const snapshot = structuredClone(approval);
+  const now = new Date();
+  while (approvals.length >= MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES) {
+    const decidedIndex = approvals.findIndex(isDecided);
+    const evictIndex = decidedIndex !== -1
+      ? decidedIndex
+      : approvals.findIndex((entry) => isExpired(entry, now));
+    if (evictIndex === -1) {
+      throw ORCHESTRATION_ERROR.create({
+        detail: `Approval list full (max: ${MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES}) and ` +
+          `every retained approval is still pending. Cannot append approval: ${approval.id}`,
+      });
+    }
+    approvals.splice(evictIndex, 1);
+  }
+  approvals.push(snapshot);
+}

--- a/src/workflow/backends/approval-retention.ts
+++ b/src/workflow/backends/approval-retention.ts
@@ -6,12 +6,6 @@ function isDecided(approval: PendingApproval): boolean {
   return approval.status !== "pending";
 }
 
-function isExpired(approval: PendingApproval, now: Date): boolean {
-  return approval.status === "pending" &&
-    approval.expiresAt !== undefined &&
-    approval.expiresAt <= now;
-}
-
 /**
  * Append a detached approval record and retain a bounded history. The per-run
  * approval list is append-only: decisions rewrite records in place, so decided
@@ -20,27 +14,35 @@ function isExpired(approval: PendingApproval, now: Date): boolean {
  * Retention is state-aware because a live pending approval must never be
  * evicted: a run waiting on an evicted ID could never be decided or expired
  * and would wait forever. At the bound, the oldest decided record is evicted
- * first, then the oldest expired one. When every retained record is still
- * live, the append is rejected instead of silently dropping a live approval.
+ * first. An expired record remains pending until expiration reconciliation
+ * decides it, so it is retained too. When there are not enough decided records
+ * to make room, the append is rejected without changing existing history
+ * instead of silently dropping a decidable approval.
  */
 export function appendRetainedPendingApproval(
   approvals: PendingApproval[],
   approval: PendingApproval,
 ): void {
   const snapshot = structuredClone(approval);
-  const now = new Date();
-  while (approvals.length >= MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES) {
-    const decidedIndex = approvals.findIndex(isDecided);
-    const evictIndex = decidedIndex !== -1
-      ? decidedIndex
-      : approvals.findIndex((entry) => isExpired(entry, now));
-    if (evictIndex === -1) {
-      throw ORCHESTRATION_ERROR.create({
-        detail: `Approval list full (max: ${MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES}) and ` +
-          `every retained approval is still pending. Cannot append approval: ${approval.id}`,
-      });
-    }
-    approvals.splice(evictIndex, 1);
+  const evictionsRequired = approvals.length - MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES + 1;
+  if (evictionsRequired <= 0) {
+    approvals.push(snapshot);
+    return;
+  }
+  const decidedIndexes: number[] = [];
+  for (let index = 0; index < approvals.length; index++) {
+    if (isDecided(approvals[index]!)) decidedIndexes.push(index);
+    if (decidedIndexes.length === evictionsRequired) break;
+  }
+  if (decidedIndexes.length < evictionsRequired) {
+    throw ORCHESTRATION_ERROR.create({
+      detail: `Approval list full (max: ${MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES}) and ` +
+        `not enough decided records can be evicted without dropping a pending approval. ` +
+        `Cannot append approval: ${approval.id}`,
+    });
+  }
+  for (let index = decidedIndexes.length - 1; index >= 0; index--) {
+    approvals.splice(decidedIndexes[index]!, 1);
   }
   approvals.push(snapshot);
 }

--- a/src/workflow/backends/memory.ts
+++ b/src/workflow/backends/memory.ts
@@ -27,6 +27,7 @@ import {
   appendRetainedCheckpoint,
   deleteOldestCheckpointOccurrences,
 } from "./checkpoint-retention.ts";
+import { appendRetainedPendingApproval } from "./approval-retention.ts";
 import { ORCHESTRATION_ERROR, RESOURCE_NOT_FOUND } from "#veryfront/errors";
 import { requireWorkflowSourceIntegrationPolicy } from "../source-integration-policy.ts";
 
@@ -442,7 +443,11 @@ export class MemoryBackend implements WorkflowBackend {
   savePendingApproval(runId: string, approval: PendingApproval): Promise<void> {
     logger.debug("Saving approval", { approvalId: approval.id, runId });
     const approvals = this.approvals.get(runId) ?? [];
-    approvals.push(structuredClone(approval));
+    try {
+      appendRetainedPendingApproval(approvals, approval);
+    } catch (error) {
+      return Promise.reject(error);
+    }
     this.approvals.set(runId, approvals);
     return Promise.resolve();
   }
@@ -461,7 +466,11 @@ export class MemoryBackend implements WorkflowBackend {
     }
 
     const approvals = this.approvals.get(runId) ?? [];
-    approvals.push(structuredClone(approval));
+    try {
+      appendRetainedPendingApproval(approvals, approval);
+    } catch (error) {
+      return Promise.reject(error);
+    }
     this.approvals.set(runId, approvals);
     return Promise.resolve(true);
   }

--- a/src/workflow/backends/redis/index.test.ts
+++ b/src/workflow/backends/redis/index.test.ts
@@ -211,7 +211,7 @@ class MockRedisAdapter implements RedisAdapter {
         list = [];
         this.lists.set(key, list);
       }
-      if (!this.retainApprovals(list, Number(args[1]), args[2]!)) return Promise.resolve(0);
+      if (!this.retainApprovals(list, Number(args[1]))) return Promise.resolve(0);
       list.push(args[0]!);
       return Promise.resolve(1);
     }
@@ -223,7 +223,6 @@ class MockRedisAdapter implements RedisAdapter {
       const storageKey = args[expectedCount + 2]!;
       const value = args[expectedCount + 3]!;
       const maxEntries = Number(args[expectedCount + 4]);
-      const now = args[expectedCount + 5]!;
       const hash = this.hashes.get(key);
       if (
         !hash || !expectedStatuses.includes(hash.get("status") ?? "") ||
@@ -237,7 +236,7 @@ class MockRedisAdapter implements RedisAdapter {
         list = [];
         this.lists.set(storageKey, list);
       }
-      if (!this.retainApprovals(list, maxEntries, now)) return Promise.resolve(2);
+      if (!this.retainApprovals(list, maxEntries)) return Promise.resolve(2);
       list.push(value);
       return Promise.resolve(1);
     }
@@ -494,26 +493,20 @@ class MockRedisAdapter implements RedisAdapter {
   }
 
   /** Mirrors the retainApprovals routine in the approval append Lua scripts. */
-  private retainApprovals(list: string[], maxEntries: number, now: string): boolean {
-    while (list.length >= maxEntries) {
-      let decidedIndex = -1;
-      let expiredIndex = -1;
-      for (let i = 0; i < list.length; i++) {
-        const approval = JSON.parse(list[i]!);
-        if (approval.status !== "pending") {
-          decidedIndex = i;
-          break;
-        }
-        if (
-          expiredIndex === -1 && typeof approval.expiresAt === "string" &&
-          approval.expiresAt <= now
-        ) {
-          expiredIndex = i;
-        }
+  private retainApprovals(list: string[], maxEntries: number): boolean {
+    const evictionsRequired = list.length - maxEntries + 1;
+    if (evictionsRequired <= 0) return true;
+    const decidedIndexes: number[] = [];
+    for (let index = 0; index < list.length; index++) {
+      const approval = JSON.parse(list[index]!);
+      if (approval.status !== "pending") {
+        decidedIndexes.push(index);
+        if (decidedIndexes.length === evictionsRequired) break;
       }
-      const evictIndex = decidedIndex !== -1 ? decidedIndex : expiredIndex;
-      if (evictIndex === -1) return false;
-      list.splice(evictIndex, 1);
+    }
+    if (decidedIndexes.length < evictionsRequired) return false;
+    for (let index = decidedIndexes.length - 1; index >= 0; index--) {
+      list.splice(decidedIndexes[index]!, 1);
     }
     return true;
   }
@@ -1719,7 +1712,7 @@ describe("RedisBackend", () => {
       assertEquals(retained.at(-1)?.id, "ap-newest");
     });
 
-    it("evicts an expired record when no decided record remains", async () => {
+    it("retains expired pending records until expiration reconciliation decides them", async () => {
       await backend.createRun(createTestRun("run-ap-expired"));
       await backend.savePendingApproval("run-ap-expired", makeApproval("ap-live-oldest"));
       await backend.savePendingApproval("run-ap-expired", {
@@ -1730,12 +1723,28 @@ describe("RedisBackend", () => {
         await backend.savePendingApproval("run-ap-expired", makeApproval(`ap-${index}`));
       }
 
-      await backend.savePendingApproval("run-ap-expired", makeApproval("ap-newest"));
+      await assertRejects(
+        () => backend.savePendingApproval("run-ap-expired", makeApproval("ap-newest")),
+        Error,
+        "pending approval",
+      );
 
       const stored = mockRedis.lists.get("test:schema-v1:approvals:run-ap-expired")!;
       assertEquals(stored.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);
-      assertEquals(stored.some((raw) => JSON.parse(raw).id === "ap-expired"), false);
+      assertEquals(stored.some((raw) => JSON.parse(raw).id === "ap-expired"), true);
       assertEquals(JSON.parse(stored[0]!).id, "ap-live-oldest");
+      assertEquals(stored.some((raw) => JSON.parse(raw).id === "ap-newest"), false);
+
+      assertEquals(
+        await backend.updateApproval("run-ap-expired", "ap-expired", {
+          approved: false,
+          approver: "system",
+          comment: "Approval expired",
+        }),
+        true,
+      );
+      await backend.savePendingApproval("run-ap-expired", makeApproval("ap-newest"));
+      assertEquals(stored.some((raw) => JSON.parse(raw).id === "ap-expired"), false);
       assertEquals(JSON.parse(stored.at(-1)!).id, "ap-newest");
     });
 
@@ -1748,13 +1757,39 @@ describe("RedisBackend", () => {
       await assertRejects(
         () => backend.savePendingApproval("run-ap-full", makeApproval("ap-overflow")),
         Error,
-        "still pending",
+        "pending approval",
       );
 
       const stored = mockRedis.lists.get("test:schema-v1:approvals:run-ap-full")!;
       assertEquals(stored.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);
       assertEquals(JSON.parse(stored[0]!).id, "ap-0");
       assertEquals(stored.some((raw) => JSON.parse(raw).id === "ap-overflow"), false);
+    });
+
+    it("does not partially prune legacy overflow when too few records are decided", async () => {
+      const storageKey = "test:schema-v1:approvals:run-ap-legacy-overflow";
+      const legacy = [
+        JSON.stringify({ ...makeApproval("decided-a"), status: "approved" }),
+        JSON.stringify({ ...makeApproval("decided-b"), status: "rejected" }),
+        ...Array.from(
+          { length: MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES },
+          (_, index) => JSON.stringify(makeApproval(`live-${index}`)),
+        ),
+      ];
+      const before = [...legacy];
+      mockRedis.lists.set(storageKey, legacy);
+
+      await assertRejects(
+        () =>
+          backend.savePendingApproval(
+            "run-ap-legacy-overflow",
+            makeApproval("ap-overflow"),
+          ),
+        Error,
+        "pending approval",
+      );
+
+      assertEquals(mockRedis.lists.get(storageKey), before);
     });
 
     it("bounds owned approval appends with the same state-aware retention", async () => {
@@ -1790,7 +1825,7 @@ describe("RedisBackend", () => {
       await assertRejects(
         () => saveOwned(makeApproval("owned-overflow")),
         Error,
-        "still pending",
+        "pending approval",
       );
       assertEquals(stored.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);
 

--- a/src/workflow/backends/redis/index.test.ts
+++ b/src/workflow/backends/redis/index.test.ts
@@ -21,7 +21,10 @@ import { __subscribeLogRecordEmitter, type LogEntry } from "#veryfront/utils/log
 import { RedisBackend } from "./index.ts";
 import type { RedisAdapter } from "#veryfront/platform/adapters/redis/index.ts";
 import type { PendingApproval, WorkflowRun } from "../../types.ts";
-import { MAX_WORKFLOW_CHECKPOINT_HISTORY_ENTRIES } from "../../limits.ts";
+import {
+  MAX_WORKFLOW_CHECKPOINT_HISTORY_ENTRIES,
+  MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES,
+} from "../../limits.ts";
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
 import { WorkflowRunManager } from "../../worker/run-manager.ts";
 import type {
@@ -200,6 +203,43 @@ class MockRedisAdapter implements RedisAdapter {
       const maxEntries = Number(args[1]);
       if (list.length > maxEntries) list.splice(0, list.length - maxEntries);
       return Promise.resolve(list.length);
+    }
+
+    if (script.includes("state-aware-approval-append")) {
+      let list = this.lists.get(key);
+      if (!list) {
+        list = [];
+        this.lists.set(key, list);
+      }
+      if (!this.retainApprovals(list, Number(args[1]), args[2]!)) return Promise.resolve(0);
+      list.push(args[0]!);
+      return Promise.resolve(1);
+    }
+
+    if (script.includes("conditional-owned-approval-append")) {
+      const expectedCount = Number(args[0]);
+      const expectedStatuses = args.slice(1, expectedCount + 1);
+      const expectedWorkerId = args[expectedCount + 1]!;
+      const storageKey = args[expectedCount + 2]!;
+      const value = args[expectedCount + 3]!;
+      const maxEntries = Number(args[expectedCount + 4]);
+      const now = args[expectedCount + 5]!;
+      const hash = this.hashes.get(key);
+      if (
+        !hash || !expectedStatuses.includes(hash.get("status") ?? "") ||
+        hash.get("workerId") !== expectedWorkerId
+      ) {
+        return Promise.resolve(0);
+      }
+
+      let list = this.lists.get(storageKey);
+      if (!list) {
+        list = [];
+        this.lists.set(storageKey, list);
+      }
+      if (!this.retainApprovals(list, maxEntries, now)) return Promise.resolve(2);
+      list.push(value);
+      return Promise.resolve(1);
     }
 
     if (script.includes("conditional-stalled-run-claim")) {
@@ -451,6 +491,31 @@ class MockRedisAdapter implements RedisAdapter {
       Number(message.id.split("-")[0]) > after
     ).slice(0, options.count);
     return Promise.resolve(messages.length > 0 ? [{ key: requested.key, messages }] : []);
+  }
+
+  /** Mirrors the retainApprovals routine in the approval append Lua scripts. */
+  private retainApprovals(list: string[], maxEntries: number, now: string): boolean {
+    while (list.length >= maxEntries) {
+      let decidedIndex = -1;
+      let expiredIndex = -1;
+      for (let i = 0; i < list.length; i++) {
+        const approval = JSON.parse(list[i]!);
+        if (approval.status !== "pending") {
+          decidedIndex = i;
+          break;
+        }
+        if (
+          expiredIndex === -1 && typeof approval.expiresAt === "string" &&
+          approval.expiresAt <= now
+        ) {
+          expiredIndex = i;
+        }
+      }
+      const evictIndex = decidedIndex !== -1 ? decidedIndex : expiredIndex;
+      if (evictIndex === -1) return false;
+      list.splice(evictIndex, 1);
+    }
+    return true;
   }
 
   private appendRunObservation(
@@ -1629,6 +1694,116 @@ describe("RedisBackend", () => {
       assertEquals(pending.length, 1);
       assertEquals(pending[0]!.id, "ap-1");
       assertEquals(pending[0]!.status, "pending");
+    });
+
+    it("bounds approval appends by evicting decided records before live ones", async () => {
+      await backend.createRun(createTestRun("run-ap-bounded"));
+      await backend.savePendingApproval("run-ap-bounded", makeApproval("ap-live-oldest"));
+      await backend.savePendingApproval("run-ap-bounded", makeApproval("ap-decided"));
+      await backend.updateApproval("run-ap-bounded", "ap-decided", {
+        approved: true,
+        approver: "admin",
+      });
+      for (let index = 2; index < MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES; index++) {
+        await backend.savePendingApproval("run-ap-bounded", makeApproval(`ap-${index}`));
+      }
+
+      await backend.savePendingApproval("run-ap-bounded", makeApproval("ap-newest"));
+
+      const stored = mockRedis.lists.get("test:schema-v1:approvals:run-ap-bounded")!;
+      assertEquals(stored.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);
+      assertEquals(stored.some((raw) => JSON.parse(raw).id === "ap-decided"), false);
+      const retained = await backend.getPendingApprovals("run-ap-bounded");
+      assertEquals(retained.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);
+      assertEquals(retained[0]?.id, "ap-live-oldest");
+      assertEquals(retained.at(-1)?.id, "ap-newest");
+    });
+
+    it("evicts an expired record when no decided record remains", async () => {
+      await backend.createRun(createTestRun("run-ap-expired"));
+      await backend.savePendingApproval("run-ap-expired", makeApproval("ap-live-oldest"));
+      await backend.savePendingApproval("run-ap-expired", {
+        ...makeApproval("ap-expired"),
+        expiresAt: new Date(Date.now() - 60_000),
+      });
+      for (let index = 2; index < MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES; index++) {
+        await backend.savePendingApproval("run-ap-expired", makeApproval(`ap-${index}`));
+      }
+
+      await backend.savePendingApproval("run-ap-expired", makeApproval("ap-newest"));
+
+      const stored = mockRedis.lists.get("test:schema-v1:approvals:run-ap-expired")!;
+      assertEquals(stored.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);
+      assertEquals(stored.some((raw) => JSON.parse(raw).id === "ap-expired"), false);
+      assertEquals(JSON.parse(stored[0]!).id, "ap-live-oldest");
+      assertEquals(JSON.parse(stored.at(-1)!).id, "ap-newest");
+    });
+
+    it("refuses the append when every retained approval is live", async () => {
+      await backend.createRun(createTestRun("run-ap-full"));
+      for (let index = 0; index < MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES; index++) {
+        await backend.savePendingApproval("run-ap-full", makeApproval(`ap-${index}`));
+      }
+
+      await assertRejects(
+        () => backend.savePendingApproval("run-ap-full", makeApproval("ap-overflow")),
+        Error,
+        "still pending",
+      );
+
+      const stored = mockRedis.lists.get("test:schema-v1:approvals:run-ap-full")!;
+      assertEquals(stored.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);
+      assertEquals(JSON.parse(stored[0]!).id, "ap-0");
+      assertEquals(stored.some((raw) => JSON.parse(raw).id === "ap-overflow"), false);
+    });
+
+    it("bounds owned approval appends with the same state-aware retention", async () => {
+      await backend.createRun(createTestRun("run-ap-owned-bounded", {
+        status: "waiting",
+        workerId: "worker-new",
+      }));
+      const saveOwned = (approval: PendingApproval) =>
+        backend.savePendingApprovalIfStatusAndWorker(
+          "run-ap-owned-bounded",
+          ["waiting"],
+          "worker-new",
+          approval,
+        );
+
+      assertEquals(await saveOwned(makeApproval("owned-live-oldest")), true);
+      assertEquals(await saveOwned(makeApproval("owned-decided")), true);
+      await backend.updateApproval("run-ap-owned-bounded", "owned-decided", {
+        approved: false,
+        approver: "admin",
+      });
+      for (let index = 2; index < MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES; index++) {
+        assertEquals(await saveOwned(makeApproval(`owned-${index}`)), true);
+      }
+
+      assertEquals(await saveOwned(makeApproval("owned-newest")), true);
+
+      const stored = mockRedis.lists.get("test:schema-v1:approvals:run-ap-owned-bounded")!;
+      assertEquals(stored.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);
+      assertEquals(stored.some((raw) => JSON.parse(raw).id === "owned-decided"), false);
+      assertEquals(JSON.parse(stored[0]!).id, "owned-live-oldest");
+
+      await assertRejects(
+        () => saveOwned(makeApproval("owned-overflow")),
+        Error,
+        "still pending",
+      );
+      assertEquals(stored.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);
+
+      assertEquals(
+        await backend.savePendingApprovalIfStatusAndWorker(
+          "run-ap-owned-bounded",
+          ["waiting"],
+          "worker-stale",
+          makeApproval("owned-must-not-append"),
+        ),
+        false,
+      );
+      assertEquals(stored.length, MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES);
     });
 
     it("should get a specific pending approval", async () => {

--- a/src/workflow/backends/redis/index.ts
+++ b/src/workflow/backends/redis/index.ts
@@ -352,35 +352,32 @@ return 1`;
  * append scripts. The list is append-only (decisions rewrite records in
  * place), so a live pending approval must never be evicted: a run waiting on
  * an evicted ID could never be decided or expired and would wait forever. At
- * the bound this evicts the oldest decided record first, then the oldest
- * expired one (ISO timestamps compare lexicographically), and reports failure
- * when every retained record is still live so the caller can reject the
- * append instead of silently dropping a live approval.
+ * the bound this evicts the oldest decided record. An expired record remains
+ * pending until expiration reconciliation decides it, so it cannot be evicted
+ * safely. The routine reports failure when there are not enough decided
+ * records to make room, so the caller can reject the append without changing
+ * existing history instead of silently dropping a decidable approval.
  */
-const RETAIN_APPROVALS_LUA = `local function retainApprovals(key, maxEntries, now)
-  while redis.call('llen', key) >= maxEntries do
-    local len = redis.call('llen', key)
-    local decidedIndex = -1
-    local expiredIndex = -1
-    for i = 0, len - 1 do
-      local raw = redis.call('lindex', key, i)
-      if raw then
-        local approval = cjson.decode(raw)
-        if approval.status ~= 'pending' then
-          decidedIndex = i
-          break
-        end
-        if expiredIndex == -1 and type(approval.expiresAt) == 'string' and approval.expiresAt <= now then
-          expiredIndex = i
-        end
+const RETAIN_APPROVALS_LUA = `local function retainApprovals(key, maxEntries)
+  local len = redis.call('llen', key)
+  local evictionsRequired = len - maxEntries + 1
+  if evictionsRequired <= 0 then return true end
+  local decidedIndexes = {}
+  for i = 0, len - 1 do
+    local raw = redis.call('lindex', key, i)
+    if raw then
+      local approval = cjson.decode(raw)
+      if approval.status ~= 'pending' then
+        table.insert(decidedIndexes, i)
+        if #decidedIndexes == evictionsRequired then break end
       end
     end
-    local evictIndex = decidedIndex
-    if evictIndex == -1 then evictIndex = expiredIndex end
-    if evictIndex == -1 then return false end
-    redis.call('lset', key, evictIndex, '__vf_evicted__')
-    redis.call('lrem', key, 1, '__vf_evicted__')
   end
+  if #decidedIndexes < evictionsRequired then return false end
+  for _, index in ipairs(decidedIndexes) do
+    redis.call('lset', key, index, '__vf_evicted__')
+  end
+  redis.call('lrem', key, 0, '__vf_evicted__')
   return true
 end`;
 
@@ -390,13 +387,12 @@ end`;
  * KEYS[1] = approvals list key
  * ARGV[1] = serialized approval
  * ARGV[2] = max entries
- * ARGV[3] = now (ISO string)
  *
- * Returns 1 when appended, 0 when every retained record is still live.
+ * Returns 1 when appended, 0 when insufficient decided history can be evicted.
  */
 const APPEND_RETAINED_APPROVAL_SCRIPT = `-- state-aware-approval-append
 ${RETAIN_APPROVALS_LUA}
-if not retainApprovals(KEYS[1], tonumber(ARGV[2]), ARGV[3]) then return 0 end
+if not retainApprovals(KEYS[1], tonumber(ARGV[2])) then return 0 end
 redis.call('rpush', KEYS[1], ARGV[1])
 return 1`;
 
@@ -410,10 +406,9 @@ return 1`;
  * ARGV[n + 3] = approvals list key
  * ARGV[n + 4] = serialized approval
  * ARGV[n + 5] = max entries
- * ARGV[n + 6] = now (ISO string)
  *
- * Returns 1 when appended, 0 when the ownership fence fails, 2 when every
- * retained record is still live.
+ * Returns 1 when appended, 0 when the ownership fence fails, and 2 when
+ * insufficient decided history can be evicted.
  */
 const APPEND_APPROVAL_IF_STATUS_AND_WORKER_SCRIPT = `-- conditional-owned-approval-append
 ${RETAIN_APPROVALS_LUA}
@@ -430,7 +425,7 @@ if not allowed then return 0 end
 local expectedWorkerId = ARGV[expectedCount + 2]
 if redis.call('hget', KEYS[1], 'workerId') ~= expectedWorkerId then return 0 end
 local storageKey = ARGV[expectedCount + 3]
-if not retainApprovals(storageKey, tonumber(ARGV[expectedCount + 5]), ARGV[expectedCount + 6]) then
+if not retainApprovals(storageKey, tonumber(ARGV[expectedCount + 5])) then
   return 2
 end
 redis.call('rpush', storageKey, ARGV[expectedCount + 4])
@@ -1119,7 +1114,6 @@ export class RedisBackend implements WorkflowBackend {
       [
         this.serializeApproval(approval),
         String(MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES),
-        new Date().toISOString(),
       ],
     );
     if (Number(result) !== 1) {
@@ -1130,7 +1124,8 @@ export class RedisBackend implements WorkflowBackend {
   private approvalListFullError(approvalId: string): Error {
     return ORCHESTRATION_ERROR.create({
       detail: `Approval list full (max: ${MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES}) and ` +
-        `every retained approval is still pending. Cannot append approval: ${approvalId}`,
+        `not enough decided records can be evicted without dropping a pending approval. ` +
+        `Cannot append approval: ${approvalId}`,
     });
   }
 
@@ -1151,7 +1146,6 @@ export class RedisBackend implements WorkflowBackend {
         this.approvalsKey(runId),
         this.serializeApproval(approval),
         String(MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES),
-        new Date().toISOString(),
       ],
     );
     if (Number(result) === 2) {

--- a/src/workflow/backends/redis/index.ts
+++ b/src/workflow/backends/redis/index.ts
@@ -26,9 +26,17 @@ import {
 import { agentLogger, safeJsonParse } from "#veryfront/utils";
 import { prepareWorkflowJson, serializeWorkflowContext } from "../../context-serialization.ts";
 import { requeueRun } from "../shared/requeue-run.ts";
-import { INITIALIZATION_ERROR, INVALID_ARGUMENT, RESOURCE_NOT_FOUND } from "#veryfront/errors";
+import {
+  INITIALIZATION_ERROR,
+  INVALID_ARGUMENT,
+  ORCHESTRATION_ERROR,
+  RESOURCE_NOT_FOUND,
+} from "#veryfront/errors";
 import { requireWorkflowSourceIntegrationPolicy } from "../../source-integration-policy.ts";
-import { MAX_WORKFLOW_CHECKPOINT_HISTORY_ENTRIES } from "../../limits.ts";
+import {
+  MAX_WORKFLOW_CHECKPOINT_HISTORY_ENTRIES,
+  MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES,
+} from "../../limits.ts";
 
 import type { RedisAdapter } from "#veryfront/platform/adapters/redis/index.ts";
 import { getRedisModule, NodeRedisAdapter } from "#veryfront/platform/adapters/redis/index.ts";
@@ -337,6 +345,95 @@ local storageKey = ARGV[expectedCount + 3]
 redis.call('rpush', storageKey, ARGV[expectedCount + 4])
 local maxEntries = tonumber(ARGV[expectedCount + 5])
 if maxEntries then redis.call('ltrim', storageKey, -maxEntries, -1) end
+return 1`;
+
+/**
+ * State-aware retention for the per-run approval list, shared by the approval
+ * append scripts. The list is append-only (decisions rewrite records in
+ * place), so a live pending approval must never be evicted: a run waiting on
+ * an evicted ID could never be decided or expired and would wait forever. At
+ * the bound this evicts the oldest decided record first, then the oldest
+ * expired one (ISO timestamps compare lexicographically), and reports failure
+ * when every retained record is still live so the caller can reject the
+ * append instead of silently dropping a live approval.
+ */
+const RETAIN_APPROVALS_LUA = `local function retainApprovals(key, maxEntries, now)
+  while redis.call('llen', key) >= maxEntries do
+    local len = redis.call('llen', key)
+    local decidedIndex = -1
+    local expiredIndex = -1
+    for i = 0, len - 1 do
+      local raw = redis.call('lindex', key, i)
+      if raw then
+        local approval = cjson.decode(raw)
+        if approval.status ~= 'pending' then
+          decidedIndex = i
+          break
+        end
+        if expiredIndex == -1 and type(approval.expiresAt) == 'string' and approval.expiresAt <= now then
+          expiredIndex = i
+        end
+      end
+    end
+    local evictIndex = decidedIndex
+    if evictIndex == -1 then evictIndex = expiredIndex end
+    if evictIndex == -1 then return false end
+    redis.call('lset', key, evictIndex, '__vf_evicted__')
+    redis.call('lrem', key, 1, '__vf_evicted__')
+  end
+  return true
+end`;
+
+/**
+ * Atomically append one approval with state-aware retention.
+ *
+ * KEYS[1] = approvals list key
+ * ARGV[1] = serialized approval
+ * ARGV[2] = max entries
+ * ARGV[3] = now (ISO string)
+ *
+ * Returns 1 when appended, 0 when every retained record is still live.
+ */
+const APPEND_RETAINED_APPROVAL_SCRIPT = `-- state-aware-approval-append
+${RETAIN_APPROVALS_LUA}
+if not retainApprovals(KEYS[1], tonumber(ARGV[2]), ARGV[3]) then return 0 end
+redis.call('rpush', KEYS[1], ARGV[1])
+return 1`;
+
+/**
+ * Atomically verify canonical run ownership, then append one approval with
+ * state-aware retention.
+ *
+ * KEYS[1] = canonical run hash key
+ * ARGV[1] = expected status count, followed by that many statuses
+ * ARGV[n + 2] = expected worker id
+ * ARGV[n + 3] = approvals list key
+ * ARGV[n + 4] = serialized approval
+ * ARGV[n + 5] = max entries
+ * ARGV[n + 6] = now (ISO string)
+ *
+ * Returns 1 when appended, 0 when the ownership fence fails, 2 when every
+ * retained record is still live.
+ */
+const APPEND_APPROVAL_IF_STATUS_AND_WORKER_SCRIPT = `-- conditional-owned-approval-append
+${RETAIN_APPROVALS_LUA}
+local status = redis.call('hget', KEYS[1], 'status')
+local expectedCount = tonumber(ARGV[1])
+local allowed = false
+for i = 2, expectedCount + 1 do
+  if status == ARGV[i] then
+    allowed = true
+    break
+  end
+end
+if not allowed then return 0 end
+local expectedWorkerId = ARGV[expectedCount + 2]
+if redis.call('hget', KEYS[1], 'workerId') ~= expectedWorkerId then return 0 end
+local storageKey = ARGV[expectedCount + 3]
+if not retainApprovals(storageKey, tonumber(ARGV[expectedCount + 5]), ARGV[expectedCount + 6]) then
+  return 2
+end
+redis.call('rpush', storageKey, ARGV[expectedCount + 4])
 return 1`;
 
 /**
@@ -1016,25 +1113,51 @@ export class RedisBackend implements WorkflowBackend {
 
     if (this.config.debug) logger.debug(`[RedisBackend] Saving approval: ${approval.id}`);
 
-    await client.rpush(
-      this.approvalsKey(runId),
-      this.serializeApproval(approval),
+    const result = await client.eval(
+      APPEND_RETAINED_APPROVAL_SCRIPT,
+      [this.approvalsKey(runId)],
+      [
+        this.serializeApproval(approval),
+        String(MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES),
+        new Date().toISOString(),
+      ],
     );
+    if (Number(result) !== 1) {
+      throw this.approvalListFullError(approval.id);
+    }
   }
 
-  savePendingApprovalIfStatusAndWorker(
+  private approvalListFullError(approvalId: string): Error {
+    return ORCHESTRATION_ERROR.create({
+      detail: `Approval list full (max: ${MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES}) and ` +
+        `every retained approval is still pending. Cannot append approval: ${approvalId}`,
+    });
+  }
+
+  async savePendingApprovalIfStatusAndWorker(
     runId: string,
     expectedStatuses: WorkflowStatus[],
     expectedWorkerId: string,
     approval: PendingApproval,
   ): Promise<boolean> {
-    return this.appendIfStatusAndWorker(
-      runId,
-      expectedStatuses,
-      expectedWorkerId,
-      this.approvalsKey(runId),
-      this.serializeApproval(approval),
+    const client = await this.ensureClient();
+    const result = await client.eval(
+      APPEND_APPROVAL_IF_STATUS_AND_WORKER_SCRIPT,
+      [this.runKey(runId)],
+      [
+        String(expectedStatuses.length),
+        ...expectedStatuses,
+        expectedWorkerId,
+        this.approvalsKey(runId),
+        this.serializeApproval(approval),
+        String(MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES),
+        new Date().toISOString(),
+      ],
     );
+    if (Number(result) === 2) {
+      throw this.approvalListFullError(approval.id);
+    }
+    return Number(result) === 1;
   }
 
   private parseApproval(raw: string): PendingApproval {

--- a/src/workflow/limits.ts
+++ b/src/workflow/limits.ts
@@ -38,8 +38,9 @@ export const MAX_WORKFLOW_CHECKPOINT_HISTORY_ENTRIES = 1_000;
  * Maximum per-run approval records retained. The per-run approval list is
  * append-only: decisions rewrite records in place, so decided approvals stay
  * in the list and dominate its growth. Once this bound is reached, built-in
- * backends evict the oldest decided record first, then the oldest expired
- * one, and reject the append when every retained record is still pending, so
- * a live approval a run is waiting on is never silently dropped.
+ * backends evict the oldest decided records and reject the append when there
+ * are not enough to make room. Expired records remain pending until the
+ * expiration reconciler decides them, so a decidable approval a run is waiting
+ * on is never silently dropped.
  */
 export const MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES = 1_000;

--- a/src/workflow/limits.ts
+++ b/src/workflow/limits.ts
@@ -33,3 +33,13 @@ export const MAX_WORKFLOW_DEFINITION_STATIC_BYTES = 16 * 1024 * 1024;
  * backends evict the oldest entries by append order once this bound is reached.
  */
 export const MAX_WORKFLOW_CHECKPOINT_HISTORY_ENTRIES = 1_000;
+
+/**
+ * Maximum per-run approval records retained. The per-run approval list is
+ * append-only: decisions rewrite records in place, so decided approvals stay
+ * in the list and dominate its growth. Once this bound is reached, built-in
+ * backends evict the oldest decided record first, then the oldest expired
+ * one, and reject the append when every retained record is still pending, so
+ * a live approval a run is waiting on is never silently dropped.
+ */
+export const MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES = 1_000;


### PR DESCRIPTION
## Problem

Per-run approval lists were the one unbounded per-run structure in the workflow backends. The Redis append script already supports trimming (`retained-list-append` takes a `maxEntries` argument), but `savePendingApproval` used a bare `rpush` and `savePendingApprovalIfStatusAndWorker` omitted the argument — `tonumber("")` is `nil` in Lua, so the `ltrim` guard never fired. The memory backend had no bound at all. A long-lived run that repeatedly waits accumulates approval records indefinitely (checkpoints, by contrast, are capped at 1,000).

## Fix

- New `MAX_WORKFLOW_PENDING_APPROVAL_ENTRIES` in `src/workflow/limits.ts`, documented in the style of the checkpoint cap. The list holds append-ordered approval records including decided ones, so oldest-first eviction cannot drop a live pending approval under any realistic accumulation.
- Redis: both save paths now pass the bound so the existing Lua trim fires.
- Memory: appends route through a new `approval-retention.ts` helper mirroring `checkpoint-retention.ts`, for backend parity.

## Tests

Red-green: trim tests written first and confirmed failing against the unbounded behavior, then green after the fix. New `approval-retention.test.ts` (5 steps) covers the helper and both memory save paths incl. failed ownership fences; `redis/index.test.ts` gains trim assertions for both Redis save paths (suite: 111 steps green).

Closes veryfront/veryfront-issue-inbox#778

