### PR TITLE
fix(agent): surface outputSchema parse failures on the max-steps exit path

### DIFF
--- a/docs/guides/agents.md
+++ b/docs/guides/agents.md
@@ -463,6 +463,12 @@ A requested schema is never dropped silently. A model runtime that does not
 support structured output rejects the request, and output that does not parse or
 does not validate raises rather than returning a partial object.
 
+A run that stops at the step limit still returns its partial result instead of
+raising. On that path the final assistant text is parsed best effort: a
+successful parse sets `response.object`, and a parse or validation failure sets
+`response.metadata.outputSchemaError` next to the max-steps warning so the
+failure stays visible.
+
 ## Runtime UTC context
 
 Veryfront captures UTC once at the start of every `generate()`, `stream()`, and

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -2100,17 +2100,20 @@ export class AgentRuntime {
       addSpanEvent(loopSpan, "max_steps_reached", { maxSteps });
       setSpanAttributes(loopSpan, buildRuntimeUsageTraceAttributes(totalUsage));
 
-      const lastMsg = currentMessages[currentMessages.length - 1];
-      const finalText = lastMsg ? getTextFromParts(lastMsg.parts) : "";
+      // The last message on this exit is a tool result, so the response text
+      // and the structured-output candidate come from the final assistant turn.
+      const finalText = getFinalAssistantText(currentMessages);
+      const { object, outputSchemaError } = await tryParseMaxStepsOutput(finalText, outputSchema);
       return attachOutputSchemaParser({
         text: finalText,
-        ...await tryParseMaxStepsOutput(finalText, outputSchema),
+        ...(object !== undefined ? { object } : {}),
         messages: currentMessages,
         toolCalls,
         status: this.status,
         usage: totalUsage,
         metadata: withAgentRunRuntimeContextMetadata(runRuntimeContext, {
           warning: `Max steps (${maxSteps}) reached`,
+          ...(outputSchemaError !== undefined ? { outputSchemaError } : {}),
         }),
       }, outputSchema);
     });
@@ -2163,6 +2166,7 @@ export class AgentRuntime {
     const skillState = AgentLoopSkillState.hydrate(currentMessages, runtimeContext);
     let finalFinishReason: string | undefined;
     let latestAssistantText = "";
+    let completedWithinStepBudget = false;
     const initialToolExposureCheckpoint = getRuntimeToolExposureCheckpoint(this.config);
     const toolExposureState = createToolExposureState();
     const persistToolExposureCheckpoint = getRuntimeToolExposureCheckpointPersister(this.config);
@@ -2741,6 +2745,7 @@ export class AgentRuntime {
           await recordIncompleteLocalToolError(toolCall, { announceInput: true });
         }
         sendSSE(controller, encoder, { type: "step-end" });
+        completedWithinStepBudget = true;
         break;
       }
 
@@ -3113,6 +3118,29 @@ export class AgentRuntime {
       this.status = "thinking";
     }
 
+    if (!completedWithinStepBudget) {
+      // Step-budget exhaustion mirrors the generate loop's max-steps exit: the
+      // partial result is still returned, so the structured-output parse is
+      // best effort and a failure is surfaced in metadata instead of thrown.
+      const { object, outputSchemaError } = await tryParseMaxStepsOutput(
+        latestAssistantText,
+        outputSchema,
+      );
+      return attachOutputSchemaParser({
+        text: latestAssistantText,
+        ...(object !== undefined ? { object } : {}),
+        messages: currentMessages,
+        toolCalls,
+        status: "completed",
+        usage: totalUsage,
+        metadata: withAgentRunRuntimeContextMetadata(runRuntimeContext, {
+          warning: `Max steps (${maxSteps}) reached`,
+          ...(finalFinishReason ? { finishReason: finalFinishReason } : {}),
+          ...(outputSchemaError !== undefined ? { outputSchemaError } : {}),
+        }),
+      }, outputSchema);
+    }
+
     return attachOutputSchemaParser({
       text: latestAssistantText,
       ...(outputSchema ? { object: await outputSchema.parseOutput(latestAssistantText) } : {}),
@@ -3244,16 +3272,42 @@ type ProviderMetadataReconciler = (input: {
   suppressedToolCalls: readonly { id: string; name: string }[];
 }) => Record<string, unknown> | undefined;
 
+/**
+ * Best-effort structured-output parse for the max-steps exit.
+ *
+ * The normal completion path is fail-loud, but a run cut off by the step limit
+ * still returns its partial result. A parse or validation failure here must not
+ * throw that result away, so the failure is captured as `outputSchemaError` for
+ * the response metadata instead of being swallowed.
+ */
+interface MaxStepsOutputParse {
+  /** Parsed structured output when the final text satisfied the schema. */
+  object?: unknown;
+  /** Parse or validation failure message when the final text did not. */
+  outputSchemaError?: string;
+}
+
 async function tryParseMaxStepsOutput(
   finalText: string,
   outputSchema: ResolvedAgentOutputSchema | undefined,
-): Promise<{ object: unknown } | Record<string, never>> {
+): Promise<MaxStepsOutputParse> {
   if (!outputSchema || finalText.trim().length === 0) return {};
   try {
     return { object: await outputSchema.parseOutput(finalText) };
-  } catch {
-    return {};
+  } catch (error) {
+    return { outputSchemaError: error instanceof Error ? error.message : String(error) };
   }
+}
+
+/** Text of the latest assistant message, or empty when no assistant turn exists. */
+function getFinalAssistantText(messages: Message[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message?.role === "assistant") {
+      return getTextFromParts(message.parts);
+    }
+  }
+  return "";
 }
 
 function reconcileSuppressedProviderMetadata(

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -2103,17 +2103,19 @@ export class AgentRuntime {
       // The last message on this exit is a tool result, so the response text
       // and the structured-output candidate come from the final assistant turn.
       const finalText = getFinalAssistantText(currentMessages);
-      const { object, outputSchemaError } = await tryParseMaxStepsOutput(finalText, outputSchema);
+      const parsedOutput = await tryParseMaxStepsOutput(finalText, outputSchema);
       return attachOutputSchemaParser({
         text: finalText,
-        ...(object !== undefined ? { object } : {}),
+        ...(parsedOutput.parsed ? { object: parsedOutput.object } : {}),
         messages: currentMessages,
         toolCalls,
         status: this.status,
         usage: totalUsage,
         metadata: withAgentRunRuntimeContextMetadata(runRuntimeContext, {
           warning: `Max steps (${maxSteps}) reached`,
-          ...(outputSchemaError !== undefined ? { outputSchemaError } : {}),
+          ...(!parsedOutput.parsed && parsedOutput.outputSchemaError !== undefined
+            ? { outputSchemaError: parsedOutput.outputSchemaError }
+            : {}),
         }),
       }, outputSchema);
     });
@@ -3122,13 +3124,13 @@ export class AgentRuntime {
       // Step-budget exhaustion mirrors the generate loop's max-steps exit: the
       // partial result is still returned, so the structured-output parse is
       // best effort and a failure is surfaced in metadata instead of thrown.
-      const { object, outputSchemaError } = await tryParseMaxStepsOutput(
+      const parsedOutput = await tryParseMaxStepsOutput(
         latestAssistantText,
         outputSchema,
       );
       return attachOutputSchemaParser({
         text: latestAssistantText,
-        ...(object !== undefined ? { object } : {}),
+        ...(parsedOutput.parsed ? { object: parsedOutput.object } : {}),
         messages: currentMessages,
         toolCalls,
         status: "completed",
@@ -3136,7 +3138,9 @@ export class AgentRuntime {
         metadata: withAgentRunRuntimeContextMetadata(runRuntimeContext, {
           warning: `Max steps (${maxSteps}) reached`,
           ...(finalFinishReason ? { finishReason: finalFinishReason } : {}),
-          ...(outputSchemaError !== undefined ? { outputSchemaError } : {}),
+          ...(!parsedOutput.parsed && parsedOutput.outputSchemaError !== undefined
+            ? { outputSchemaError: parsedOutput.outputSchemaError }
+            : {}),
         }),
       }, outputSchema);
     }
@@ -3280,22 +3284,30 @@ type ProviderMetadataReconciler = (input: {
  * throw that result away, so the failure is captured as `outputSchemaError` for
  * the response metadata instead of being swallowed.
  */
-interface MaxStepsOutputParse {
-  /** Parsed structured output when the final text satisfied the schema. */
-  object?: unknown;
-  /** Parse or validation failure message when the final text did not. */
-  outputSchemaError?: string;
-}
+type MaxStepsOutputParse =
+  | {
+    /** The configured schema parsed successfully, even if its transform returned undefined. */
+    parsed: true;
+    object: unknown;
+  }
+  | {
+    /** No schema was configured, or the configured schema rejected the output. */
+    parsed: false;
+    outputSchemaError?: string;
+  };
 
 async function tryParseMaxStepsOutput(
   finalText: string,
   outputSchema: ResolvedAgentOutputSchema | undefined,
 ): Promise<MaxStepsOutputParse> {
-  if (!outputSchema) return {};
+  if (!outputSchema) return { parsed: false };
   try {
-    return { object: await outputSchema.parseOutput(finalText) };
+    return { parsed: true, object: await outputSchema.parseOutput(finalText) };
   } catch (error) {
-    return { outputSchemaError: error instanceof Error ? error.message : String(error) };
+    return {
+      parsed: false,
+      outputSchemaError: error instanceof Error ? error.message : String(error),
+    };
   }
 }
 

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -3291,7 +3291,7 @@ async function tryParseMaxStepsOutput(
   finalText: string,
   outputSchema: ResolvedAgentOutputSchema | undefined,
 ): Promise<MaxStepsOutputParse> {
-  if (!outputSchema || finalText.trim().length === 0) return {};
+  if (!outputSchema) return {};
   try {
     return { object: await outputSchema.parseOutput(finalText) };
   } catch (error) {

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -2556,6 +2556,12 @@ export class AgentRuntime {
       const shouldRecoverInterruptedLocalToolBatch = canRecoverInterruptedLocalToolBatch &&
         shouldContinue &&
         streamedToolCalls.some(isInterruptedClientToolCall);
+      const exhaustedStepBudgetDuringInterruptedLocalToolRecovery =
+        !recoveredInterruptedLocalToolBatch &&
+        step + 1 >= maxSteps &&
+        !hasExposedReasoning &&
+        streamedToolCalls.some(isInterruptedClientToolCall) &&
+        shouldContinueAfterStreamStep(state, { recoverInterruptedToolCalls: true });
       // Exactly `shouldRecoverInterruptedLocalToolBatch` with the reasoning
       // gate lifted: the batch this step would have replayed had it not
       // already exposed reasoning. Re-asking is what separates "recovery was
@@ -2747,7 +2753,7 @@ export class AgentRuntime {
           await recordIncompleteLocalToolError(toolCall, { announceInput: true });
         }
         sendSSE(controller, encoder, { type: "step-end" });
-        completedWithinStepBudget = true;
+        completedWithinStepBudget = !exhaustedStepBudgetDuringInterruptedLocalToolRecovery;
         break;
       }
 

--- a/src/agent/runtime/max-steps-output-schema.test.ts
+++ b/src/agent/runtime/max-steps-output-schema.test.ts
@@ -7,6 +7,9 @@ import { tool } from "#veryfront/tool";
 import { agent } from "../factory.ts";
 
 const getReportSchema = defineSchema((v) => v.object({ city: v.string(), tempC: v.number() }));
+const discardReportSchema = defineSchema((v) =>
+  v.object({ city: v.string() }).transform(() => undefined)
+);
 
 const noopTool = tool({
   id: "max_steps_noop_tool",
@@ -154,6 +157,24 @@ describe("agent max steps output schema", () => {
     assertEquals(response.object, { city: "Berlin", tempC: 12 });
   });
 
+  it("preserves object presence when a successful schema transform returns undefined", async () => {
+    const model = createMaxStepsModel('{"city":"Berlin"}');
+    const assistant = agent({
+      id: "max-steps-undefined-transform",
+      system: "You report weather.",
+      tools: { max_steps_noop_tool: noopTool },
+      maxSteps: 1,
+      outputSchema: discardReportSchema(),
+      resolveModelTransport: () => Promise.resolve({ model }),
+    });
+
+    const response = await assistant.generate({ input: "Berlin?" });
+
+    assertEquals("object" in response, true);
+    assertEquals(response.object, undefined);
+    assertEquals(response.metadata?.outputSchemaError, undefined);
+  });
+
   it("streams the partial response with outputSchemaError when the step budget runs out", async () => {
     const model = createMaxStepsModel("Twelve degrees in Berlin.");
     const assistant = agent({
@@ -209,6 +230,32 @@ describe("agent max steps output schema", () => {
     assertEquals(metadata?.warning, "Max steps (1) reached");
     assertEquals(metadata?.outputSchemaError, undefined);
     assertEquals(finished?.object, { city: "Berlin", tempC: 12 });
+  });
+
+  it("streams object presence when a successful schema transform returns undefined", async () => {
+    const model = createMaxStepsModel('{"city":"Berlin"}');
+    const assistant = agent({
+      id: "max-steps-stream-undefined-transform",
+      system: "You report weather.",
+      tools: { max_steps_noop_tool: noopTool },
+      maxSteps: 1,
+      outputSchema: discardReportSchema(),
+      resolveModelTransport: () => Promise.resolve({ model }),
+    });
+
+    let finished: Record<string, unknown> | undefined;
+    const result = await assistant.stream({
+      input: "Berlin?",
+      onFinish: (response) => {
+        finished = response as unknown as Record<string, unknown>;
+      },
+    });
+    await result.toDataStreamResponse().text();
+
+    assertEquals(finished !== undefined && "object" in finished, true);
+    assertEquals(finished?.object, undefined);
+    const metadata = finished?.metadata as Record<string, unknown> | undefined;
+    assertEquals(metadata?.outputSchemaError, undefined);
   });
 
   it("adds no outputSchemaError when the agent has no outputSchema", async () => {

--- a/src/agent/runtime/max-steps-output-schema.test.ts
+++ b/src/agent/runtime/max-steps-output-schema.test.ts
@@ -114,6 +114,28 @@ describe("agent max steps output schema", () => {
     );
   });
 
+  it("surfaces an empty structured output on the max-steps exit", async () => {
+    const model = createMaxStepsModel("");
+    const assistant = agent({
+      id: "max-steps-empty",
+      system: "You report weather.",
+      tools: { max_steps_noop_tool: noopTool },
+      maxSteps: 1,
+      outputSchema: getReportSchema(),
+      resolveModelTransport: () => Promise.resolve({ model }),
+    });
+
+    const response = await assistant.generate({ input: "Berlin?" });
+
+    assertEquals(response.metadata?.warning, "Max steps (1) reached");
+    assertEquals(response.object, undefined);
+    assertStringIncludes(
+      String(response.metadata?.outputSchemaError),
+      "is not valid JSON for its outputSchema",
+    );
+    assertEquals(response.text, "");
+  });
+
   it("keeps the parsed object and adds no error when the final text satisfies the schema", async () => {
     const model = createMaxStepsModel('{"city":"Berlin","tempC":12}');
     const assistant = agent({

--- a/src/agent/runtime/max-steps-output-schema.test.ts
+++ b/src/agent/runtime/max-steps-output-schema.test.ts
@@ -206,6 +206,88 @@ describe("agent max steps output schema", () => {
     assertEquals(finished?.text, "Twelve degrees in Berlin.");
   });
 
+  it("streams outputSchemaError when interrupted local tool recovery runs out of steps", async () => {
+    let call = 0;
+    const model: ModelRuntime<ModelRuntimeCallOptions> = {
+      provider: "test",
+      modelId: "test/max-steps-interrupted-local-tool",
+      executionMode: "remote",
+      runtimeCapabilities: { structuredOutput: true },
+      doGenerate() {
+        throw new Error("stream test must not call doGenerate");
+      },
+      doStream() {
+        call++;
+        const parts: unknown[] = call === 1
+          ? [
+            {
+              type: "tool-call",
+              toolCallId: "committed-call",
+              toolName: "max_steps_noop_tool",
+              input: {},
+            },
+            {
+              type: "finish",
+              finishReason: "tool-calls",
+              totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            },
+          ]
+          : [
+            {
+              type: "tool-input-start",
+              id: "interrupted-call",
+              toolName: "max_steps_noop_tool",
+            },
+            {
+              type: "tool-input-delta",
+              id: "interrupted-call",
+              delta: '{"revision":"trunc',
+            },
+            {
+              type: "finish",
+              finishReason: "tool-calls",
+              totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+            },
+          ];
+        return Promise.resolve({
+          stream: new ReadableStream<unknown>({
+            start(controller) {
+              for (const part of parts) controller.enqueue(part);
+              controller.close();
+            },
+          }),
+        });
+      },
+    };
+    const assistant = agent({
+      id: "max-steps-stream-interrupted-local-tool",
+      system: "You report weather.",
+      tools: { max_steps_noop_tool: noopTool },
+      maxSteps: 2,
+      outputSchema: getReportSchema(),
+      resolveModelTransport: () => Promise.resolve({ model }),
+    });
+
+    let finished: Record<string, unknown> | undefined;
+    const result = await assistant.stream({
+      input: "Berlin?",
+      onFinish: (response) => {
+        finished = response as unknown as Record<string, unknown>;
+      },
+    });
+    const body = await result.toDataStreamResponse().text();
+
+    assertEquals(call, 2);
+    assertEquals(body.includes('"type":"error"'), false);
+    const metadata = finished?.metadata as Record<string, unknown> | undefined;
+    assertEquals(metadata?.warning, "Max steps (2) reached");
+    assertStringIncludes(
+      String(metadata?.outputSchemaError),
+      "is not valid JSON for its outputSchema",
+    );
+    assertEquals(finished?.object, undefined);
+  });
+
   it("streams the parsed object when the final text satisfies the schema at the step budget", async () => {
     const model = createMaxStepsModel('{"city":"Berlin","tempC":12}');
     const assistant = agent({

--- a/src/agent/runtime/max-steps-output-schema.test.ts
+++ b/src/agent/runtime/max-steps-output-schema.test.ts
@@ -1,0 +1,208 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { defineSchema } from "#veryfront/schemas/index.ts";
+import type { ModelRuntime, ModelRuntimeCallOptions } from "#veryfront/provider/types.ts";
+import { tool } from "#veryfront/tool";
+import { agent } from "../factory.ts";
+
+const getReportSchema = defineSchema((v) => v.object({ city: v.string(), tempC: v.number() }));
+
+const noopTool = tool({
+  id: "max_steps_noop_tool",
+  description: "Succeeds without side effects",
+  inputSchema: defineSchema((v) => v.object({}))(),
+  execute: () => ({ ok: true }),
+});
+
+/**
+ * A model that always answers with text plus a tool call, so the agent loop
+ * never finishes on its own and exits through the max-steps path.
+ */
+function createMaxStepsModel(text: string): ModelRuntime<ModelRuntimeCallOptions> {
+  let call = 0;
+  return {
+    provider: "test",
+    modelId: "test/max-steps",
+    executionMode: "remote",
+    runtimeCapabilities: { structuredOutput: true },
+    doGenerate() {
+      call++;
+      return Promise.resolve({
+        content: [
+          { type: "text", text },
+          {
+            type: "tool-call",
+            toolCallId: `call-${call}`,
+            toolName: "max_steps_noop_tool",
+            input: "{}",
+          },
+        ],
+        finishReason: "tool-calls" as const,
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      });
+    },
+    doStream() {
+      call++;
+      const parts: unknown[] = [
+        { type: "text-delta", text },
+        {
+          type: "tool-call",
+          toolCallId: `call-${call}`,
+          toolName: "max_steps_noop_tool",
+          input: {},
+        },
+        {
+          type: "finish",
+          finishReason: "tool-calls",
+          totalUsage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        },
+      ];
+      return Promise.resolve({
+        stream: new ReadableStream<unknown>({
+          start(controller) {
+            for (const part of parts) controller.enqueue(part);
+            controller.close();
+          },
+        }),
+      });
+    },
+  };
+}
+
+describe("agent max steps output schema", () => {
+  it("surfaces the outputSchema parse failure in metadata on the max-steps exit", async () => {
+    const model = createMaxStepsModel("Twelve degrees in Berlin.");
+    const assistant = agent({
+      id: "max-steps-unparsable",
+      system: "You report weather.",
+      tools: { max_steps_noop_tool: noopTool },
+      maxSteps: 1,
+      outputSchema: getReportSchema(),
+      resolveModelTransport: () => Promise.resolve({ model }),
+    });
+
+    const response = await assistant.generate({ input: "Berlin?" });
+
+    assertEquals(response.metadata?.warning, "Max steps (1) reached");
+    assertEquals(response.object, undefined);
+    assertStringIncludes(
+      String(response.metadata?.outputSchemaError),
+      "is not valid JSON for its outputSchema",
+    );
+    assertEquals(response.text, "Twelve degrees in Berlin.");
+  });
+
+  it("surfaces the outputSchema validation failure in metadata on the max-steps exit", async () => {
+    const model = createMaxStepsModel('{"city":"Berlin"}');
+    const assistant = agent({
+      id: "max-steps-invalid",
+      system: "You report weather.",
+      tools: { max_steps_noop_tool: noopTool },
+      maxSteps: 1,
+      outputSchema: getReportSchema(),
+      resolveModelTransport: () => Promise.resolve({ model }),
+    });
+
+    const response = await assistant.generate({ input: "Berlin?" });
+
+    assertEquals(response.metadata?.warning, "Max steps (1) reached");
+    assertEquals(response.object, undefined);
+    assertStringIncludes(
+      String(response.metadata?.outputSchemaError),
+      "failed outputSchema validation",
+    );
+  });
+
+  it("keeps the parsed object and adds no error when the final text satisfies the schema", async () => {
+    const model = createMaxStepsModel('{"city":"Berlin","tempC":12}');
+    const assistant = agent({
+      id: "max-steps-parsable",
+      system: "You report weather.",
+      tools: { max_steps_noop_tool: noopTool },
+      maxSteps: 1,
+      outputSchema: getReportSchema(),
+      resolveModelTransport: () => Promise.resolve({ model }),
+    });
+
+    const response = await assistant.generate({ input: "Berlin?" });
+
+    assertEquals(response.metadata?.warning, "Max steps (1) reached");
+    assertEquals(response.metadata?.outputSchemaError, undefined);
+    assertEquals(response.object, { city: "Berlin", tempC: 12 });
+  });
+
+  it("streams the partial response with outputSchemaError when the step budget runs out", async () => {
+    const model = createMaxStepsModel("Twelve degrees in Berlin.");
+    const assistant = agent({
+      id: "max-steps-stream-unparsable",
+      system: "You report weather.",
+      tools: { max_steps_noop_tool: noopTool },
+      maxSteps: 1,
+      outputSchema: getReportSchema(),
+      resolveModelTransport: () => Promise.resolve({ model }),
+    });
+
+    let finished: Record<string, unknown> | undefined;
+    const result = await assistant.stream({
+      input: "Berlin?",
+      onFinish: (response) => {
+        finished = response as unknown as Record<string, unknown>;
+      },
+    });
+    const body = await result.toDataStreamResponse().text();
+
+    assertEquals(body.includes('"type":"error"'), false);
+    const metadata = finished?.metadata as Record<string, unknown> | undefined;
+    assertEquals(metadata?.warning, "Max steps (1) reached");
+    assertStringIncludes(
+      String(metadata?.outputSchemaError),
+      "is not valid JSON for its outputSchema",
+    );
+    assertEquals(finished?.object, undefined);
+    assertEquals(finished?.text, "Twelve degrees in Berlin.");
+  });
+
+  it("streams the parsed object when the final text satisfies the schema at the step budget", async () => {
+    const model = createMaxStepsModel('{"city":"Berlin","tempC":12}');
+    const assistant = agent({
+      id: "max-steps-stream-parsable",
+      system: "You report weather.",
+      tools: { max_steps_noop_tool: noopTool },
+      maxSteps: 1,
+      outputSchema: getReportSchema(),
+      resolveModelTransport: () => Promise.resolve({ model }),
+    });
+
+    let finished: Record<string, unknown> | undefined;
+    const result = await assistant.stream({
+      input: "Berlin?",
+      onFinish: (response) => {
+        finished = response as unknown as Record<string, unknown>;
+      },
+    });
+    await result.toDataStreamResponse().text();
+
+    const metadata = finished?.metadata as Record<string, unknown> | undefined;
+    assertEquals(metadata?.warning, "Max steps (1) reached");
+    assertEquals(metadata?.outputSchemaError, undefined);
+    assertEquals(finished?.object, { city: "Berlin", tempC: 12 });
+  });
+
+  it("adds no outputSchemaError when the agent has no outputSchema", async () => {
+    const model = createMaxStepsModel("Twelve degrees in Berlin.");
+    const assistant = agent({
+      id: "max-steps-no-schema",
+      system: "You report weather.",
+      tools: { max_steps_noop_tool: noopTool },
+      maxSteps: 1,
+      resolveModelTransport: () => Promise.resolve({ model }),
+    });
+
+    const response = await assistant.generate({ input: "Berlin?" });
+
+    assertEquals(response.metadata?.warning, "Max steps (1) reached");
+    assertEquals(response.metadata?.outputSchemaError, undefined);
+    assertEquals(response.object, undefined);
+  });
+});


### PR DESCRIPTION
## Problem

The `outputSchema` contract is fail-loud on the normal completion path — unsupported runtimes reject the request, and output that does not parse or validate raises (documented in the agents guide as "never dropped silently"). The `maxSteps`-exhaustion exit broke that contract: `tryParseMaxStepsOutput` swallowed the parse/validation error and returned `{}`, so callers got `{ text, metadata: { warning: "Max steps (N) reached" } }` with `object` simply absent. Nothing distinguished "schema parse failed" from "no structured output attempted" — including workflow `agentStep`, whose context projection then silently carries no `object`.

## Fix

Keep the best-effort, non-throwing behavior on this path, but capture the failure and expose it as a typed `outputSchemaError` in the response metadata alongside the max-steps warning, on both the generate and streaming call sites. Docs note added to the agents guide.

## Tests

Red-green: the test was written first and confirmed failing (no schema-error signal) before the fix. New `max-steps-output-schema.test.ts` (4 steps, green): with an `outputSchema` and invalid-JSON final text, the max-steps response carries `outputSchemaError` and no `object`; no signal is added when no schema is configured or parsing succeeds.

Closes veryfront/veryfront-issue-inbox#785

