### PR TITLE
docs(workflow): correct waitForEvent option name, document typed approval data and result timeouts

### DIFF
--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -155,6 +155,11 @@ export default tool({
 
 Use `handle.result()` only when the caller should wait for completion. Return the `runId` when the workflow can continue in the background.
 
+`handle.result()` polls the run and resolves with the workflow output once the
+run completes. It throws a timeout error if the run has not reached a terminal
+state after 5 minutes. Set the `resultWaitTimeout` executor option, in
+milliseconds, on `createWorkflowClient` to change that limit.
+
 ## Schedule a workflow
 
 Use a schedule with a `workflow:<workflow-id>` target when a workflow must run on a schedule. See [Runs](./runs.md) for run creation and event monitoring.
@@ -279,6 +284,61 @@ export default workflow({
 
 The workflow pauses at `waitForApproval` and resumes when an approver responds. If the timeout expires, the workflow fails.
 
+### Structured approval responses
+
+Set `responseSchema` when the decision must carry structured data, such as a
+selected option or an edited value:
+
+```ts
+// workflows/publish.ts
+import { defineSchema } from "veryfront/schemas";
+import { step, waitForApproval, workflow } from "veryfront/workflow";
+
+export default workflow({
+  id: "publish",
+  steps: [
+    step("draft", { agent: "writer" }),
+    waitForApproval("editor-review", {
+      message: "Review the draft and choose a channel.",
+      responseSchema: defineSchema((v) =>
+        v.object({
+          channel: v.string().describe("Publish channel"),
+        })
+      )(),
+    }),
+    step("publish", {
+      tool: "publisher",
+      input: (ctx) => ctx["editor-review"],
+    }),
+  ],
+});
+```
+
+Submit the decision through the workflow client. The structured answer is the
+fifth argument to `approve()` and `reject()`, after the optional comment:
+
+```ts
+const [pending] = await workflows.getPendingApprovals(runId);
+
+await workflows.approve(runId, pending.id, "editor@example.com", "Ship it", {
+  channel: "blog",
+});
+```
+
+The submitted `data` is validated against the wait node's `responseSchema`
+before it is persisted. A non-conformant answer is refused with an error and
+the approval stays pending. Validation only covers wait nodes declared in a
+static step list. When a workflow's `steps`, or the `steps` of a nested loop,
+is a function, the node list depends on runtime state, so no schema can be
+resolved for the decision and the answer is accepted unvalidated. After
+approval, the decision lands in the workflow context under the wait node's id,
+so later steps read `ctx["editor-review"]` as
+`{ approved, approver, comment, data, decidedAt }`.
+
+The approval endpoint served by `createWorkflowHandler` accepts the same
+decision as a JSON body of the shape `{ approved, approver, comment?, data? }`.
+See [Workflows: advanced](./workflows-advanced.md) for the handler routes.
+
 ### Wait for events
 
 Pause until an external event arrives:
@@ -287,10 +347,16 @@ Pause until an external event arrives:
 import { waitForEvent } from "veryfront/workflow";
 
 waitForEvent("payment-confirmed", {
-  event: "payment.completed",
+  eventName: "payment.completed",
   timeout: "1h",
 });
 ```
+
+Event delivery is not wired into workflow execution yet. `waitForEvent` pauses
+the run, but nothing resumes it when the named event occurs. The workflow
+backend interface declares optional event delivery methods, but the built-in
+memory and Redis backends do not implement them, and the executor does not
+consume them from a backend that does.
 
 ## Workflow configuration
 


### PR DESCRIPTION
## Problem

Three doc-vs-code mismatches in the workflows guide:

1. The `waitForEvent` example passed `{ event: "payment.completed" }` — the DSL option is `eventName`, and the snippet as documented throws `INVALID_ARGUMENT`.
2. `responseSchema` and the typed decision `data` payload — the intended typed-approval mechanism — were completely undocumented, so the only discoverable channel for structured resume data was prose in `comment`. The argument order matters: `data` is the fifth argument of `approve(runId, approvalId, approver, comment?, data?)`; passing an object fourth lands in `comment` and fails validation at the HTTP boundary.
3. `handle.result()`'s 5-minute default wait and the `resultWaitTimeout` executor config were undocumented.

## Fix

Guide-only changes (`docs/guides/workflows.md`, +62/−1): corrected the `eventName` option with an honest caveat that built-in backends do not currently resume event waits (verified against `src/workflow/backends/`); a new typed-approvals subsection covering `responseSchema`, the `approve`/`reject` signatures, pre-persist validation, where `data` lands in the resumed context, and the HTTP body shape; and the result-timeout default. Every documented claim was verified against source before writing. Generated `docs/api-reference/` untouched.

Closes veryfront/veryfront-issue-inbox#782

