### PR TITLE
fix(ci): isolate automated review concurrency per change

### DIFF
--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -9,21 +9,13 @@ on:
     types: [created, edited, deleted]
   status:
 
-permissions:
-  contents: read
-  issues: read
-  # pull-requests: write lets the gate post the "@codex review" comment when a
-  # push leaves the head commit without a review. This workflow runs with
-  # pull_request_target authority, so the write scope stays safe only because
-  # the workflow checks out the trusted default branch, never executes files
-  # from the pull request head, and the posted comment body is a fixed string
-  # plus the verified head commit SHA with no pull request controlled content.
-  pull-requests: write
-  statuses: write
+permissions: {}
 
 jobs:
   target:
     name: resolve automated review target
+    permissions:
+      pull-requests: read
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
@@ -62,6 +54,14 @@ jobs:
 
   review:
     name: publish automated review status
+    # pull-requests and issues write let this job post the fixed "@codex
+    # review" request after verifying the current head. This job checks out
+    # only the trusted default branch and never executes pull request files.
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      statuses: write
     # issue_comment fires for issues too, so keep only pull request comments.
     # pull_request_review hands fork pull requests a read-only token that cannot
     # write a commit status, so skip it there and let the trusted
@@ -206,6 +206,10 @@ jobs:
 
   status_review:
     name: publish completed CodeRabbit review status
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
     # This SHA-scoped path publishes only durable completion success. It shares
     # the status publisher queue so it cannot race general PR reconciliation.
     # The status payload carries no creator field, so pin the sender instead:

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -21,13 +21,45 @@ permissions:
   pull-requests: write
   statuses: write
 
-concurrency:
-  group: automated-review-${{ github.event.pull_request.number || github.event.issue.number || github.event.sha || github.run_id }}
-  # Preserve event order for one pull request without allowing unrelated pull
-  # requests and commit-status events to fill the same repository-wide queue.
-  queue: max
-
 jobs:
+  target:
+    name: resolve automated review target
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      key: ${{ steps.resolve.outputs.result }}
+    steps:
+      - name: Resolve the current head commit
+        id: resolve
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          retries: 3
+          result-encoding: string
+          script: |
+            let headSha = context.payload.sha;
+            const pullNumber = context.payload.pull_request?.number ??
+              (context.payload.issue?.pull_request
+                ? context.payload.issue.number
+                : undefined);
+            if (!headSha && pullNumber) {
+              const response = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pullNumber,
+              });
+              headSha = response.data.head.sha;
+            }
+            // Non-PR issue comments never reach a publisher job, but still
+            // need a harmless key so this resolver succeeds for the trigger.
+            if (!headSha && context.eventName === "issue_comment") {
+              return `issue-${context.payload.issue.number}`;
+            }
+            if (!/^[0-9a-f]{40}$/i.test(headSha ?? "")) {
+              core.setFailed("Could not resolve a valid review target commit");
+              return `run-${context.runId}`;
+            }
+            return headSha;
+
   review:
     name: publish automated review status
     # issue_comment fires for issues too, so keep only pull request comments.
@@ -39,6 +71,12 @@ jobs:
       (github.event_name != 'issue_comment' || github.event.issue.pull_request) &&
       (github.event_name != 'pull_request_review' ||
        github.event.pull_request.head.repo.full_name == github.repository)
+    needs: target
+    concurrency:
+      # Every event for one head, including issue comments and status events,
+      # must serialize on the same key so an older pending write cannot win.
+      group: automated-review-${{ needs.target.outputs.key }}
+      queue: max
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -170,6 +208,10 @@ jobs:
       github.event.sender.login == 'coderabbitai[bot]' &&
       github.event.sender.id == 136622811 &&
       github.event.sender.type == 'Bot'
+    needs: target
+    concurrency:
+      group: automated-review-${{ needs.target.outputs.key }}
+      queue: max
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -24,10 +24,7 @@ jobs:
       (github.event_name == 'status' &&
        github.event.context == 'CodeRabbit' &&
        github.event.state == 'success' &&
-       github.event.description == 'Review completed' &&
-       github.event.sender.login == 'coderabbitai[bot]' &&
-       github.event.sender.id == 136622811 &&
-       github.event.sender.type == 'Bot')
+       github.event.description == 'Review completed')
     permissions:
       pull-requests: read
     runs-on: ubuntu-latest
@@ -226,18 +223,14 @@ jobs:
       statuses: write
     # This SHA-scoped path publishes only durable completion success. It shares
     # the status publisher queue so it cannot race general PR reconciliation.
-    # The status payload carries no creator field, so pin the sender instead:
-    # for a bot-created commit status the sender is the bot itself. The gate
-    # helper then re-verifies the creator over the REST status history, where
-    # creator does exist, before treating the wakeup as completion proof.
+    # The webhook payload carries no creator field. Treat it only as a wakeup;
+    # the helper re-reads status history and requires the pinned CodeRabbit
+    # creator before publishing completion.
     if: >-
       github.event_name == 'status' &&
       github.event.context == 'CodeRabbit' &&
       github.event.state == 'success' &&
-      github.event.description == 'Review completed' &&
-      github.event.sender.login == 'coderabbitai[bot]' &&
-      github.event.sender.id == 136622811 &&
-      github.event.sender.type == 'Bot'
+      github.event.description == 'Review completed'
     needs: target
     concurrency:
       group: automated-review-${{ needs.target.outputs.key }}

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -91,6 +91,8 @@ jobs:
       - name: Require an automated review for the current commit
         id: publish
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          TARGET_SHA: ${{ needs.target.outputs.key }}
         with:
           retries: 3
           result-encoding: string
@@ -109,7 +111,15 @@ jobs:
             const pullRequest = response.data;
             const sameRepository =
               `${context.repo.owner}/${context.repo.repo}`;
-            const headSha = pullRequest.head.sha;
+            const headSha = process.env.TARGET_SHA;
+            if (!/^[0-9a-f]{40}$/i.test(headSha ?? "")) {
+              core.setFailed("The resolved review target commit is invalid");
+              return "failure";
+            }
+            if (pullRequest.head.sha !== headSha) {
+              core.notice("Skipped automated review publication after the pull request head changed.");
+              return "stale";
+            }
             let publishAutomatedReviewStatus;
             try {
               ({ publishAutomatedReviewStatus } = await import(gateUrl));
@@ -168,6 +178,8 @@ jobs:
           github.event.action == 'synchronize' &&
           steps.publish.outputs.result == 'pending'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          TARGET_SHA: ${{ needs.target.outputs.key }}
         with:
           retries: 3
           script: |
@@ -182,11 +194,11 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               pullNumber: pullRequest.number,
-              headSha: pullRequest.head.sha,
+              headSha: process.env.TARGET_SHA,
             });
             core.notice(
               result.requested
-                ? `Requested an automated review of ${pullRequest.head.sha.slice(0, 12)}.`
+                ? `Requested an automated review of ${process.env.TARGET_SHA.slice(0, 12)}.`
                 : result.reason === "stale-head"
                 ? "Skipped an automated review request from a stale synchronize event."
                 : "An automated review request for this head commit already exists.",
@@ -221,6 +233,8 @@ jobs:
           persist-credentials: false
       - name: Publish authenticated CodeRabbit completion
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          TARGET_SHA: ${{ needs.target.outputs.key }}
         with:
           retries: 3
           script: |
@@ -239,7 +253,7 @@ jobs:
               github,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              headSha: context.payload.sha,
+              headSha: process.env.TARGET_SHA,
               // The payload claim carries no creator; the helper authenticates
               // the completion against the REST status history for the head.
               status: {
@@ -250,7 +264,7 @@ jobs:
             });
             if (result.state === "success") {
               core.notice(
-                `Authenticated CodeRabbit completion for ${context.payload.sha.slice(0, 12)}.`,
+                `Authenticated CodeRabbit completion for ${process.env.TARGET_SHA.slice(0, 12)}.`,
               );
             } else if (result.failure) {
               core.warning(result.failure.message);

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -14,6 +14,20 @@ permissions: {}
 jobs:
   target:
     name: resolve automated review target
+    # Apply publisher eligibility before allocating a resolver runner. The
+    # resolver exists only to feed the two publisher jobs below.
+    if: >-
+      (github.event_name != 'status' &&
+       (github.event_name != 'issue_comment' || github.event.issue.pull_request) &&
+       (github.event_name != 'pull_request_review' ||
+        github.event.pull_request.head.repo.full_name == github.repository)) ||
+      (github.event_name == 'status' &&
+       github.event.context == 'CodeRabbit' &&
+       github.event.state == 'success' &&
+       github.event.description == 'Review completed' &&
+       github.event.sender.login == 'coderabbitai[bot]' &&
+       github.event.sender.id == 136622811 &&
+       github.event.sender.type == 'Bot')
     permissions:
       pull-requests: read
     runs-on: ubuntu-latest

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -21,6 +21,12 @@ permissions:
   pull-requests: write
   statuses: write
 
+concurrency:
+  group: automated-review-${{ github.event.pull_request.number || github.event.issue.number || github.event.sha || github.run_id }}
+  # Preserve event order for one pull request without allowing unrelated pull
+  # requests and commit-status events to fill the same repository-wide queue.
+  queue: max
+
 jobs:
   review:
     name: publish automated review status
@@ -33,9 +39,6 @@ jobs:
       (github.event_name != 'issue_comment' || github.event.issue.pull_request) &&
       (github.event_name != 'pull_request_review' ||
        github.event.pull_request.head.repo.full_name == github.repository)
-    concurrency:
-      group: automated-review-status-publishers
-      queue: max
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -167,9 +170,6 @@ jobs:
       github.event.sender.login == 'coderabbitai[bot]' &&
       github.event.sender.id == 136622811 &&
       github.event.sender.type == 'Bot'
-    concurrency:
-      group: automated-review-status-publishers
-      queue: max
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1027,9 +1027,6 @@ describe("automated review workflow", () => {
         "github.event.context == 'CodeRabbit'",
         "github.event.state == 'success'",
         "github.event.description == 'Review completed'",
-        "github.event.sender.login == 'coderabbitai[bot]'",
-        "github.event.sender.id == 136622811",
-        "github.event.sender.type == 'Bot'",
       ]
     ) {
       assert(
@@ -1180,14 +1177,12 @@ describe("automated review workflow", () => {
         "github.event.context == 'CodeRabbit'",
         "github.event.state == 'success'",
         "github.event.description == 'Review completed'",
-        "github.event.sender.login == 'coderabbitai[bot]'",
-        "github.event.sender.id == 136622811",
-        "github.event.sender.type == 'Bot'",
       ]
     ) assert(statusIf.includes(condition));
     assert(
-      !statusIf.includes("github.event.creator"),
-      "the status payload has no creator field, so that condition never matches",
+      !statusIf.includes("github.event.sender") &&
+        !statusIf.includes("github.event.creator"),
+      "the webhook is only a wakeup; creator trust comes from REST status history",
     );
     assertEquals(record(statusJob.concurrency, "status concurrency"), {
       ...publisherConcurrency,

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -995,11 +995,7 @@ describe("automated review workflow", () => {
       parse(await Deno.readTextFile(WORKFLOW_PATH)),
       "workflow",
     );
-    const permissions = record(workflow.permissions, "permissions");
-    assertEquals(permissions.contents, "read");
-    assertEquals(permissions.issues, "read");
-    assertEquals(permissions["pull-requests"], "write");
-    assertEquals(permissions.statuses, "write");
+    assertEquals(record(workflow.permissions, "permissions"), {});
 
     assertEquals(workflow.concurrency, undefined);
 
@@ -1021,6 +1017,9 @@ describe("automated review workflow", () => {
     assert("status" in triggers, "completion status must have a wakeup path");
     const jobs = record(workflow.jobs, "jobs");
     const targetJob = record(jobs.target, "target job");
+    assertEquals(record(targetJob.permissions, "target permissions"), {
+      "pull-requests": "read",
+    });
     assertEquals(
       record(targetJob.outputs, "target outputs").key,
       "${{ steps.resolve.outputs.result }}",
@@ -1049,6 +1048,12 @@ describe("automated review workflow", () => {
     );
 
     const job = record(jobs.review, "review job");
+    assertEquals(record(job.permissions, "review permissions"), {
+      contents: "read",
+      issues: "write",
+      "pull-requests": "write",
+      statuses: "write",
+    });
     const publisherConcurrency = {
       group: "automated-review-${{ needs.target.outputs.key }}",
       queue: "max",
@@ -1143,6 +1148,11 @@ describe("automated review workflow", () => {
     );
 
     const statusJob = record(jobs.status_review, "status review job");
+    assertEquals(record(statusJob.permissions, "status review permissions"), {
+      contents: "read",
+      "pull-requests": "read",
+      statuses: "write",
+    });
     assertEquals(statusJob.needs, "target");
     const statusIf = String(statusJob.if);
     for (

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1080,8 +1080,18 @@ describe("automated review workflow", () => {
     );
     const gate = record(steps[1], "gate");
     const script = String(record(gate.with, "gate inputs").script);
+    assertEquals(
+      record(gate.env, "gate environment").TARGET_SHA,
+      "${{ needs.target.outputs.key }}",
+    );
     assert(script.includes("publishAutomatedReviewStatus"));
     assert(script.includes("github.rest.pulls.get"));
+    assert(script.includes("process.env.TARGET_SHA"));
+    assert(script.includes("pullRequest.head.sha !== headSha"));
+    assert(
+      !script.includes("const headSha = pullRequest.head.sha"),
+      "the publisher must use the same immutable SHA as its concurrency key",
+    );
     assert(!script.includes("listPullRequestsAssociatedWithCommit"));
     assert(
       script.includes("allowPullRequestReviews") &&

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1020,11 +1020,40 @@ describe("automated review workflow", () => {
     );
     assert("status" in triggers, "completion status must have a wakeup path");
     const jobs = record(workflow.jobs, "jobs");
+    const targetJob = record(jobs.target, "target job");
+    assertEquals(
+      record(targetJob.outputs, "target outputs").key,
+      "${{ steps.resolve.outputs.result }}",
+    );
+    const targetSteps = targetJob.steps;
+    assert(Array.isArray(targetSteps));
+    const targetScript = String(
+      record(
+        record(targetSteps[0], "target resolver").with,
+        "target resolver inputs",
+      )
+        .script,
+    );
+    for (
+      const required of [
+        "context.payload.sha",
+        "context.payload.pull_request?.number",
+        "context.payload.issue?.pull_request",
+        "github.rest.pulls.get",
+        "Could not resolve a valid review target commit",
+      ]
+    ) assert(targetScript.includes(required));
+    assert(
+      !targetScript.includes("pull_request?.head.sha"),
+      "queued pull request events must resolve the current head before choosing a lock",
+    );
+
     const job = record(jobs.review, "review job");
     const publisherConcurrency = {
-      group: "automated-review-status-publishers",
+      group: "automated-review-${{ needs.target.outputs.key }}",
       queue: "max",
     };
+    assertEquals(job.needs, "target");
     assertEquals(record(job.concurrency, "review concurrency"), {
       ...publisherConcurrency,
     });
@@ -1104,6 +1133,7 @@ describe("automated review workflow", () => {
     );
 
     const statusJob = record(jobs.status_review, "status review job");
+    assertEquals(statusJob.needs, "target");
     const statusIf = String(statusJob.if);
     for (
       const condition of [

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1017,6 +1017,26 @@ describe("automated review workflow", () => {
     assert("status" in triggers, "completion status must have a wakeup path");
     const jobs = record(workflow.jobs, "jobs");
     const targetJob = record(jobs.target, "target job");
+    const targetIf = String(targetJob.if);
+    for (
+      const condition of [
+        "github.event_name != 'status'",
+        "github.event.issue.pull_request",
+        "github.event.pull_request.head.repo.full_name == github.repository",
+        "github.event_name == 'status'",
+        "github.event.context == 'CodeRabbit'",
+        "github.event.state == 'success'",
+        "github.event.description == 'Review completed'",
+        "github.event.sender.login == 'coderabbitai[bot]'",
+        "github.event.sender.id == 136622811",
+        "github.event.sender.type == 'Bot'",
+      ]
+    ) {
+      assert(
+        targetIf.includes(condition),
+        "target resolution must skip events that no publisher job can use",
+      );
+    }
     assertEquals(record(targetJob.permissions, "target permissions"), {
       "pull-requests": "read",
     });


### PR DESCRIPTION
## Summary
- isolate Automated review gate concurrency by pull request, issue, or status SHA
- keep ordered processing for each change while preventing a repository-wide queue
- share one workflow-level group across both publisher jobs

## Verification
- git diff --check
- formatting and lint pre-push checks passed
- local typecheck is blocked by eight unrelated existing baseline errors
- GitHub Actions will validate the workflow syntax and required checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated review processing by coordinating runs independently for each pull request, issue, or commit.
  - Reduced unnecessary delays caused by unrelated review status updates running at the same time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->