### PR TITLE
fix(cache): preserve framed ownership in registry invalidation

### DIFF
--- a/src/cache/registry.ts
+++ b/src/cache/registry.ts
@@ -14,6 +14,7 @@ export interface CacheStore {
   keys(): Iterable<string>;
   size(): number;
   deleteWhere?(predicate: (key: string) => boolean): number;
+  keyBelongsToProject?(key: string, projectId: string): boolean;
 }
 
 function deleteWhereFromKeys(
@@ -36,6 +37,7 @@ export class MapCacheStore implements CacheStore {
   constructor(
     name: string,
     private readonly map: CacheStatsSource,
+    readonly keyBelongsToProject?: (key: string, projectId: string) => boolean,
   ) {
     this.name = name;
   }
@@ -138,7 +140,9 @@ class CacheRegistry {
     const result = new Map<string, string[]>();
 
     for (const [name, store] of this.stores) {
-      const matchingKeys = [...store.keys()].filter((key) => isKeyForProject(key, projectId));
+      const matchingKeys = [...store.keys()].filter((key) =>
+        keyBelongsToProject(store, key, projectId)
+      );
       if (matchingKeys.length) result.set(name, matchingKeys);
     }
 
@@ -149,7 +153,7 @@ class CacheRegistry {
     let count = 0;
     for (const store of this.stores.values()) {
       for (const key of store.keys()) {
-        if (isKeyForProject(key, projectId)) count++;
+        if (keyBelongsToProject(store, key, projectId)) count++;
       }
     }
     return count;
@@ -159,7 +163,7 @@ class CacheRegistry {
     let totalDeleted = 0;
 
     for (const store of this.stores.values()) {
-      totalDeleted += store.deleteWhere?.((key) => isKeyForProject(key, projectId)) ?? 0;
+      totalDeleted += store.deleteWhere?.((key) => keyBelongsToProject(store, key, projectId)) ?? 0;
     }
 
     return totalDeleted;
@@ -193,7 +197,8 @@ class CacheRegistry {
 
     for (const store of this.stores.values()) {
       totalDeleted += store.deleteWhere?.((key) =>
-        isKeyForProject(key, projectId) && isKeyForContentSource(key, projectId, contentSourceId)
+        keyBelongsToProject(store, key, projectId) &&
+        isKeyForContentSource(key, projectId, contentSourceId)
       ) ?? 0;
     }
 
@@ -417,6 +422,10 @@ class CacheRegistry {
   }
 }
 
+function keyBelongsToProject(store: CacheStore, key: string, projectId: string): boolean {
+  return store.keyBelongsToProject?.(key, projectId) ?? isKeyForProject(key, projectId);
+}
+
 export function isKeyForProject(key: string, projectId: string): boolean {
   const normalizedKey = stripRedisPrefix(key);
   const parts = normalizedKey.split(":");
@@ -589,8 +598,12 @@ function isKeyForContentSource(
 
 export const cacheRegistry = new CacheRegistry();
 
-export function registerMapCache(name: string, map: CacheStatsSource): void {
-  cacheRegistry.register(new MapCacheStore(name, map));
+export function registerMapCache(
+  name: string,
+  map: CacheStatsSource,
+  keyBelongsToProject?: (key: string, projectId: string) => boolean,
+): void {
+  cacheRegistry.register(new MapCacheStore(name, map, keyBelongsToProject));
 }
 
 export function registerLRUCache(name: string, cache: LRULike): void {

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
@@ -285,7 +285,7 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
         reactVersion: "1.0.0",
         registryBaseUrl: "https://registry.example.com",
       });
-      const entry = { tempPath: "/tmp/cross-project.mjs", contentHash: "hash" };
+      const entry = { tempPath: "cross-project.mjs", contentHash: "hash" };
       globalCrossProjectCache.set(ownedKey, entry);
       globalCrossProjectCache.set(foreignKey, entry);
 

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
@@ -20,6 +20,7 @@ import { getTransformPerProjectLimit } from "../constants.ts";
 import { getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { hashCodeHex } from "#veryfront/utils/hash-utils.ts";
 import { getTmpDirCacheKey } from "../tmp-paths.ts";
+import { cacheRegistry } from "#veryfront/cache/registry.ts";
 
 describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
   function resetState(): void {
@@ -268,6 +269,43 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
   });
 
   describe("clearSSRModuleCacheForProject", () => {
+    it("should expose and delete framed cross-project entries through generic registry APIs", async () => {
+      resetState();
+
+      const projectId = "project:01J2XYZ";
+      const ownedKey = buildCrossProjectImportCacheKey({
+        projectId,
+        specifier: "@acme/component:variant",
+        reactVersion: "1.0.0",
+        registryBaseUrl: "https://registry.example.com",
+      });
+      const foreignKey = buildCrossProjectImportCacheKey({
+        projectId: `tenant:${projectId}`,
+        specifier: `prefix:${projectId}:component`,
+        reactVersion: "1.0.0",
+        registryBaseUrl: "https://registry.example.com",
+      });
+      const entry = { tempPath: "/tmp/cross-project.mjs", contentHash: "hash" };
+      globalCrossProjectCache.set(ownedKey, entry);
+      globalCrossProjectCache.set(foreignKey, entry);
+
+      assertEquals(
+        cacheRegistry.getKeysForProject(projectId).get("ssr-cross-project-cache"),
+        [ownedKey],
+      );
+      assertEquals(cacheRegistry.deleteKeysForProject(projectId), 1);
+      assertEquals(globalCrossProjectCache.has(ownedKey), false);
+      assertEquals(globalCrossProjectCache.has(foreignKey), true);
+
+      globalCrossProjectCache.set(ownedKey, entry);
+      assertEquals(
+        await cacheRegistry.deleteAllKeysForProjectAsync(projectId),
+        { memoryDeleted: 1, redisDeleted: 0 },
+      );
+      assertEquals(globalCrossProjectCache.has(ownedKey), false);
+      assertEquals(globalCrossProjectCache.has(foreignKey), true);
+    });
+
     it("should clear module cache entries for a specific project", () => {
       resetState();
 

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.ts
@@ -320,6 +320,7 @@ registerMapCache("ssr-module-cache", createCacheRegistryWrapper(globalModuleCach
 registerMapCache(
   "ssr-cross-project-cache",
   createCacheRegistryWrapper(globalCrossProjectCache),
+  isCrossProjectCacheKeyForProject,
 );
 registerMapCache("ssr-tmp-dirs", createCacheRegistryWrapper(globalTmpDirs));
 registerMapCache("ssr-in-progress", globalInProgress);
@@ -386,6 +387,11 @@ function parseCrossProjectCacheKeyOwner(
   };
 }
 
+function isCrossProjectCacheKeyForProject(key: string, projectId: string): boolean {
+  const owner = parseCrossProjectCacheKeyOwner(key);
+  return owner.isCrossProjectKey ? owner.projectId === projectId : isKeyForProject(key, projectId);
+}
+
 export function clearSSRModuleCacheForProject(
   projectId: string,
   options: ClearSSRModuleCacheForProjectOptions = {},
@@ -401,11 +407,7 @@ export function clearSSRModuleCacheForProject(
   }
 
   for (const key of globalCrossProjectCache.keys()) {
-    const crossProjectOwner = parseCrossProjectCacheKeyOwner(key);
-    const belongsToProject = crossProjectOwner.isCrossProjectKey
-      ? crossProjectOwner.projectId === projectId
-      : isKeyForProject(key, projectId);
-    if (!belongsToProject) continue;
+    if (!isCrossProjectCacheKeyForProject(key, projectId)) continue;
     globalCrossProjectCache.delete(key);
   }
 


### PR DESCRIPTION
Follow-up to #4058.

The cross-project cache now frames and encodes project ownership, but generic cache-registry operations still used legacy delimiter positions. This adds a store-specific project ownership matcher and registers the cross-project cache with its existing framed-owner decoder.

Regression coverage proves getKeysForProject, deleteKeysForProject, and deleteAllKeysForProjectAsync identify only the exact decoded owner, including opaque project IDs and adversarial specifier text.

Verification (pinned CI Deno 2.7.7):
- deno task test:file src/modules/react-loader/ssr-module-loader/cache/memory.test.ts — 31 steps passed
- deno task test:file src/cache/registry.test.ts — 60 steps passed
- deno fmt --check (3 changed files)
- deno lint (3 changed files)
- deno check (3 changed files)