### PR TITLE
fix(ci): move the publisher concurrency queue to the workflow level

### DIFF
--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -21,6 +21,13 @@ permissions:
   pull-requests: write
   statuses: write
 
+# One publisher at a time repo-wide, processing every event in order. `queue`
+# is a workflow-level key; placing this block on the jobs made them fail before
+# any step ran, which took the gate down for every pull request.
+concurrency:
+  group: automated-review-status-publishers
+  queue: max
+
 jobs:
   review:
     name: publish automated review status
@@ -33,9 +40,6 @@ jobs:
       (github.event_name != 'issue_comment' || github.event.issue.pull_request) &&
       (github.event_name != 'pull_request_review' ||
        github.event.pull_request.head.repo.full_name == github.repository)
-    concurrency:
-      group: automated-review-status-publishers
-      queue: max
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -167,9 +171,6 @@ jobs:
       github.event.sender.login == 'coderabbitai[bot]' &&
       github.event.sender.id == 136622811 &&
       github.event.sender.type == 'Bot'
-    concurrency:
-      group: automated-review-status-publishers
-      queue: max
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1001,8 +1001,6 @@ describe("automated review workflow", () => {
     assertEquals(permissions["pull-requests"], "write");
     assertEquals(permissions.statuses, "write");
 
-    assertEquals(workflow.concurrency, undefined);
-
     const triggers = record(workflow.on, "triggers");
     assertEquals(
       record(triggers.pull_request_target, "pull request trigger").types,
@@ -1021,13 +1019,17 @@ describe("automated review workflow", () => {
     assert("status" in triggers, "completion status must have a wakeup path");
     const jobs = record(workflow.jobs, "jobs");
     const job = record(jobs.review, "review job");
-    const publisherConcurrency = {
+    // `queue` is only valid in workflow-level concurrency; placing this block
+    // on the jobs made them fail before any step ran and took the gate down.
+    assertEquals(record(workflow.concurrency, "workflow concurrency"), {
       group: "automated-review-status-publishers",
       queue: "max",
-    };
-    assertEquals(record(job.concurrency, "review concurrency"), {
-      ...publisherConcurrency,
     });
+    assertEquals(
+      job.concurrency,
+      undefined,
+      "review job must not redeclare concurrency",
+    );
     assert(
       String(job.if).includes("github.event_name != 'status'"),
       "raw status events must never enter general PR reconciliation",
@@ -1119,9 +1121,11 @@ describe("automated review workflow", () => {
       !statusIf.includes("github.event.creator"),
       "the status payload has no creator field, so that condition never matches",
     );
-    assertEquals(record(statusJob.concurrency, "status concurrency"), {
-      ...publisherConcurrency,
-    });
+    assertEquals(
+      statusJob.concurrency,
+      undefined,
+      "status job must not redeclare concurrency",
+    );
     const statusSteps = statusJob.steps;
     assert(Array.isArray(statusSteps));
     const statusScript = String(


### PR DESCRIPTION
GitHub only supports `group`/`cancel-in-progress` in job-level `concurrency`; the `queue: max` key placed there by #4041 made both publisher jobs fail before any step ran — every "publish automated review status" run since #4041 merged (all event types) fails with zero steps executed, so no PR can get its required Automated review status.

This moves the shared publisher group back to the workflow level, where `queue` is valid (the pre-#4041 gate already used it there) and where one group serializes the publishers exactly as the job-level blocks intended. The workflow-shape test now locks the corrected placement and asserts neither job redeclares concurrency.

Verification: gate suite 5 passed (32 steps) 0 failed; YAML parses; fmt/typecheck clean.

https://claude.ai/code/session_016wezkD1Xnjjk5gQiCDHGGZ