### PR TITLE
test(platform/adapters): make weak assertions bite across the client and runtime adapters

### DIFF
--- a/scripts/lint/test-typecheck-baseline.json
+++ b/scripts/lint/test-typecheck-baseline.json
@@ -31,7 +31,6 @@
   "src/middleware/core/pipeline/composer.test.ts",
   "src/modules/react-loader/ssr-module-loader.stress.test.ts",
   "src/platform/adapters/fs/veryfront/directory-operations.test.ts",
-  "src/platform/adapters/redis/node.test.ts",
   "src/rendering/client/browser-logger.test.ts",
   "src/rendering/element-validator/validator-core.test.ts",
   "src/rendering/layouts/utils/compiler.test.ts",

--- a/src/platform/adapters/redis/modules.test.ts
+++ b/src/platform/adapters/redis/modules.test.ts
@@ -11,7 +11,9 @@ import {
   assertExists,
   assertNotEquals,
   assertRejects,
+  assertStringIncludes,
 } from "#veryfront/testing/assert.ts";
+import { VeryfrontError } from "#veryfront/errors/types.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { isDeno } from "#veryfront/platform/compat/runtime.ts";
 import { clearModuleCache, getRedisModule } from "./modules.ts";
@@ -56,10 +58,20 @@ describe("platform/adapters/redis/modules", () => {
       await getRedisModule();
       unregister(RedisRuntimeProviderName);
 
-      await assertRejects(
+      const error = await assertRejects(
         () => getRedisModule(),
-        Error,
+        VeryfrontError,
         "Missing extension",
+      ) as VeryfrontError;
+      assertEquals(
+        error.slug,
+        "initialization-error",
+        "a failed Redis runtime load must be classified as INITIALIZATION_ERROR",
+      );
+      assertStringIncludes(
+        error.message,
+        "Install @veryfront/ext-redis alongside veryfront",
+        "the failure must carry the extension install guidance",
       );
     });
 
@@ -168,6 +180,48 @@ describe("platform/adapters/redis/modules", () => {
   describe("clearModuleCache", () => {
     it("should not throw", () => {
       clearModuleCache();
+    });
+
+    it("rejects an in-flight module load that was invalidated by clearModuleCache", async () => {
+      const deferredBase = createRedisRuntimeProvider();
+      const deferredModule = await deferredBase.loadModule();
+      let markLoadStarted: (() => void) | undefined;
+      const loadStarted = new Promise<void>((resolve) => {
+        markLoadStarted = resolve;
+      });
+      let releaseModule: ((module: NodeRedisModule) => void) | undefined;
+      const moduleGate = new Promise<NodeRedisModule>((resolve) => {
+        releaseModule = resolve;
+      });
+      const deferredProvider: RedisRuntimeProvider = {
+        ...deferredBase,
+        loadModule() {
+          markLoadStarted?.();
+          return moduleGate;
+        },
+      };
+      register(RedisRuntimeProviderName, deferredProvider);
+
+      try {
+        const staleLoad = getRedisModule();
+        await loadStarted;
+        clearModuleCache();
+        releaseModule?.(deferredModule);
+
+        await assertRejects(
+          () => staleLoad,
+          Error,
+          "provider changed while its module was loading",
+          "clearModuleCache must invalidate an in-flight provider module resolution",
+        );
+        assertExists(
+          (await getRedisModule()).NodeRedis,
+          "a load started after the clear must still resolve",
+        );
+      } finally {
+        unregister(RedisRuntimeProviderName);
+        await deferredBase.close();
+      }
     });
 
     it("should allow reloading after clear", async () => {

--- a/src/platform/adapters/redis/node.test.ts
+++ b/src/platform/adapters/redis/node.test.ts
@@ -1,10 +1,15 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { NodeRedisAdapter } from "./node.ts";
 
+interface ClientCall {
+  readonly method: string;
+  readonly args: unknown[];
+}
+
 function createMockClient() {
-  const calls: Array<{ method: string; args: unknown[] }> = [];
+  const calls: ClientCall[] = [];
 
   const client = {
     calls,
@@ -73,7 +78,10 @@ function createMockClient() {
       consumer: string,
       streams: Array<{ key: string; id: string }>,
       options?: { BLOCK?: number; COUNT?: number },
-    ) {
+    ): Promise<
+      | Array<{ name: string; messages: Array<{ id: string; message: Record<string, string> }> }>
+      | null
+    > {
       calls.push({ method: "xReadGroup", args: [group, consumer, streams, options] });
       return Promise.resolve([
         {
@@ -134,14 +142,21 @@ function createMockClient() {
   return { client, calls };
 }
 
+function firstCall(calls: readonly ClientCall[]): ClientCall {
+  const call = calls[0];
+  assertExists(call, "expected the Redis client mock to capture a call");
+  return call;
+}
+
 describe("platform/adapters/redis/node", () => {
   describe("NodeRedisAdapter", () => {
     it("should proxy hset to the camelCase client method (hSet)", async () => {
       const { client, calls } = createMockClient();
       const adapter = new NodeRedisAdapter(client as never);
       await adapter.hset("key", { f: "v" });
-      assertEquals(calls[0].method, "hSet");
-      assertEquals(calls[0].args, ["key", { f: "v" }]);
+      const call = firstCall(calls);
+      assertEquals(call.method, "hSet");
+      assertEquals(call.args, ["key", { f: "v" }]);
     });
 
     it("should return the hgetall object as-is", async () => {
@@ -156,14 +171,14 @@ describe("platform/adapters/redis/node", () => {
       const adapter = new NodeRedisAdapter(client as never);
       const result = await adapter.del("k1", "k2");
       assertEquals(result, 2);
-      assertEquals(calls[0].args, [["k1", "k2"]]);
+      assertEquals(firstCall(calls).args, [["k1", "k2"]]);
     });
 
     it("should map mkstream to the MKSTREAM option on xgroupCreate", async () => {
       const { client, calls } = createMockClient();
       const adapter = new NodeRedisAdapter(client as never);
       await adapter.xgroupCreate("stream", "group", "0", true);
-      assertEquals(calls[0].args[3], { MKSTREAM: true });
+      assertEquals(firstCall(calls).args[3], { MKSTREAM: true });
     });
 
     it("should reshape xreadgroup streams and responses (name->key, message->data)", async () => {
@@ -174,14 +189,19 @@ describe("platform/adapters/redis/node", () => {
         { group: "g", consumer: "c", block: 100, count: 5 },
       );
       // request shape: xid -> id, group/consumer/BLOCK/COUNT forwarded
-      assertEquals(calls[0].args[0], "g");
-      assertEquals(calls[0].args[1], "c");
-      assertEquals(calls[0].args[2], [{ key: "stream1", id: ">" }]);
-      assertEquals(calls[0].args[3], { BLOCK: 100, COUNT: 5 });
+      const call = firstCall(calls);
+      assertEquals(call.args[0], "g");
+      assertEquals(call.args[1], "c");
+      assertEquals(call.args[2], [{ key: "stream1", id: ">" }]);
+      assertEquals(call.args[3], { BLOCK: 100, COUNT: 5 });
       // response shape: name -> key, message -> data
       assertEquals(result.length, 1);
-      assertEquals(result[0].key, "stream1");
-      assertEquals(result[0].messages[0].data, { f1: "v1", f2: "v2" });
+      const stream = result[0];
+      assertExists(stream);
+      const message = stream.messages[0];
+      assertExists(message);
+      assertEquals(stream.key, "stream1");
+      assertEquals(message.data, { f1: "v1", f2: "v2" });
     });
 
     it("should return an empty array when xreadgroup yields null", async () => {
@@ -203,8 +223,9 @@ describe("platform/adapters/redis/node", () => {
         { block: 25, count: 8 },
       );
 
-      assertEquals(calls[0].method, "xRead");
-      assertEquals(calls[0].args, [
+      const call = firstCall(calls);
+      assertEquals(call.method, "xRead");
+      assertEquals(call.args, [
         [{ key: "stream1", id: "1-0" }],
         { BLOCK: 25, COUNT: 8 },
       ]);
@@ -225,14 +246,14 @@ describe("platform/adapters/redis/node", () => {
       const { client, calls } = createMockClient();
       const adapter = new NodeRedisAdapter(client as never);
       await adapter.set("key", "val", { nx: true, px: 1000, ex: 60 });
-      assertEquals(calls[0].args[2], { NX: true, PX: 1000, EX: 60 });
+      assertEquals(firstCall(calls).args[2], { NX: true, PX: 1000, EX: 60 });
     });
 
     it("should leave NX undefined when nx is falsy", async () => {
       const { client, calls } = createMockClient();
       const adapter = new NodeRedisAdapter(client as never);
       await adapter.set("key", "val");
-      assertEquals(calls[0].args[2], { NX: undefined, PX: undefined, EX: undefined });
+      assertEquals(firstCall(calls).args[2], { NX: undefined, PX: undefined, EX: undefined });
     });
 
     it("should call client.close on quit (v5 rename)", async () => {
@@ -265,7 +286,7 @@ describe("platform/adapters/redis/node", () => {
       const adapter = new NodeRedisAdapter(client as never);
       const result = await adapter.hdel("key", "f1", "f2");
       assertEquals(result, 2);
-      assertEquals(calls[0].args, ["key", ["f1", "f2"]]);
+      assertEquals(firstCall(calls).args, ["key", ["f1", "f2"]]);
     });
 
     it("should forward sadd members as an array (sAdd)", async () => {
@@ -273,7 +294,7 @@ describe("platform/adapters/redis/node", () => {
       const adapter = new NodeRedisAdapter(client as never);
       const result = await adapter.sadd("set", "m1", "m2");
       assertEquals(result, 2);
-      assertEquals(calls[0].args, ["set", ["m1", "m2"]]);
+      assertEquals(firstCall(calls).args, ["set", ["m1", "m2"]]);
     });
 
     it("should forward srem members as an array (sRem)", async () => {
@@ -281,7 +302,7 @@ describe("platform/adapters/redis/node", () => {
       const adapter = new NodeRedisAdapter(client as never);
       const result = await adapter.srem("set", "m1");
       assertEquals(result, 1);
-      assertEquals(calls[0].args, ["set", ["m1"]]);
+      assertEquals(firstCall(calls).args, ["set", ["m1"]]);
     });
 
     it("should proxy smembers (sMembers)", async () => {
@@ -295,21 +316,25 @@ describe("platform/adapters/redis/node", () => {
       const adapter = new NodeRedisAdapter(client as never);
       const result = await adapter.rpush("list", "a", "b");
       assertEquals(result, 2);
-      assertEquals(calls[0].args, ["list", ["a", "b"]]);
+      assertEquals(firstCall(calls).args, ["list", ["a", "b"]]);
     });
 
     it("should proxy lrange (lRange)", async () => {
       const { client, calls } = createMockClient();
       const adapter = new NodeRedisAdapter(client as never);
       assertEquals(await adapter.lrange("list", 2, 5), ["a", "b"]);
-      assertEquals(calls[0].args, ["list", 2, 5], "lrange must forward start/stop to lRange");
+      assertEquals(
+        firstCall(calls).args,
+        ["list", 2, 5],
+        "lrange must forward start/stop to lRange",
+      );
     });
 
     it("should proxy lindex (lIndex)", async () => {
       const { client, calls } = createMockClient();
       const adapter = new NodeRedisAdapter(client as never);
       assertEquals(await adapter.lindex("list", 3), "item");
-      assertEquals(calls[0].args, ["list", 3], "lindex must forward the index to lIndex");
+      assertEquals(firstCall(calls).args, ["list", 3], "lindex must forward the index to lIndex");
     });
 
     it("should proxy lset (lSet)", async () => {
@@ -317,7 +342,7 @@ describe("platform/adapters/redis/node", () => {
       const adapter = new NodeRedisAdapter(client as never);
       assertEquals(await adapter.lset("list", 4, "v"), "OK");
       assertEquals(
-        calls[0].args,
+        firstCall(calls).args,
         ["list", 4, "v"],
         "lset must forward the index and value to lSet",
       );
@@ -327,7 +352,7 @@ describe("platform/adapters/redis/node", () => {
       const { client, calls } = createMockClient();
       const adapter = new NodeRedisAdapter(client as never);
       assertEquals(await adapter.llen("list"), 5);
-      assertEquals(calls[0].args, ["list"], "llen must forward the key to lLen");
+      assertEquals(firstCall(calls).args, ["list"], "llen must forward the key to lLen");
     });
 
     it("should proxy xadd (xAdd)", async () => {
@@ -335,7 +360,7 @@ describe("platform/adapters/redis/node", () => {
       const adapter = new NodeRedisAdapter(client as never);
       assertEquals(await adapter.xadd("stream", "*", { k: "v" }), "1-0");
       assertEquals(
-        calls[0].args,
+        firstCall(calls).args,
         ["stream", "*", { k: "v" }],
         "xadd must forward the entry id and fields to xAdd",
       );
@@ -346,7 +371,7 @@ describe("platform/adapters/redis/node", () => {
       const adapter = new NodeRedisAdapter(client as never);
       const result = await adapter.xack("stream", "group", "1-0", "1-1");
       assertEquals(result, 2);
-      assertEquals(calls[0].args, ["stream", "group", ["1-0", "1-1"]]);
+      assertEquals(firstCall(calls).args, ["stream", "group", ["1-0", "1-1"]]);
     });
 
     it("should proxy keys", async () => {
@@ -360,14 +385,14 @@ describe("platform/adapters/redis/node", () => {
       const adapter = new NodeRedisAdapter(client as never);
       const result = await adapter.exists("k1", "k2");
       assertEquals(result, 1);
-      assertEquals(calls[0].args, [["k1", "k2"]]);
+      assertEquals(firstCall(calls).args, [["k1", "k2"]]);
     });
 
     it("should proxy expire", async () => {
       const { client, calls } = createMockClient();
       const adapter = new NodeRedisAdapter(client as never);
       assertEquals(await adapter.expire("key", 60), 1);
-      assertEquals(calls[0].args, ["key", 60], "expire must forward the ttl in seconds");
+      assertEquals(firstCall(calls).args, ["key", 60], "expire must forward the ttl in seconds");
     });
 
     it("should proxy get", async () => {
@@ -380,7 +405,7 @@ describe("platform/adapters/redis/node", () => {
       const { client, calls } = createMockClient();
       const adapter = new NodeRedisAdapter(client as never);
       await adapter.eval("return 1", ["k1"], ["a1"]);
-      assertEquals(calls[0].args, ["return 1", { keys: ["k1"], arguments: ["a1"] }]);
+      assertEquals(firstCall(calls).args, ["return 1", { keys: ["k1"], arguments: ["a1"] }]);
     });
   });
 });

--- a/src/platform/adapters/redis/node.test.ts
+++ b/src/platform/adapters/redis/node.test.ts
@@ -299,33 +299,46 @@ describe("platform/adapters/redis/node", () => {
     });
 
     it("should proxy lrange (lRange)", async () => {
-      const { client } = createMockClient();
+      const { client, calls } = createMockClient();
       const adapter = new NodeRedisAdapter(client as never);
-      assertEquals(await adapter.lrange("list", 0, -1), ["a", "b"]);
+      assertEquals(await adapter.lrange("list", 2, 5), ["a", "b"]);
+      assertEquals(calls[0].args, ["list", 2, 5], "lrange must forward start/stop to lRange");
     });
 
     it("should proxy lindex (lIndex)", async () => {
-      const { client } = createMockClient();
+      const { client, calls } = createMockClient();
       const adapter = new NodeRedisAdapter(client as never);
-      assertEquals(await adapter.lindex("list", 0), "item");
+      assertEquals(await adapter.lindex("list", 3), "item");
+      assertEquals(calls[0].args, ["list", 3], "lindex must forward the index to lIndex");
     });
 
     it("should proxy lset (lSet)", async () => {
-      const { client } = createMockClient();
+      const { client, calls } = createMockClient();
       const adapter = new NodeRedisAdapter(client as never);
-      assertEquals(await adapter.lset("list", 0, "v"), "OK");
+      assertEquals(await adapter.lset("list", 4, "v"), "OK");
+      assertEquals(
+        calls[0].args,
+        ["list", 4, "v"],
+        "lset must forward the index and value to lSet",
+      );
     });
 
     it("should proxy llen (lLen)", async () => {
-      const { client } = createMockClient();
+      const { client, calls } = createMockClient();
       const adapter = new NodeRedisAdapter(client as never);
       assertEquals(await adapter.llen("list"), 5);
+      assertEquals(calls[0].args, ["list"], "llen must forward the key to lLen");
     });
 
     it("should proxy xadd (xAdd)", async () => {
-      const { client } = createMockClient();
+      const { client, calls } = createMockClient();
       const adapter = new NodeRedisAdapter(client as never);
       assertEquals(await adapter.xadd("stream", "*", { k: "v" }), "1-0");
+      assertEquals(
+        calls[0].args,
+        ["stream", "*", { k: "v" }],
+        "xadd must forward the entry id and fields to xAdd",
+      );
     });
 
     it("should forward xack ids as an array (xAck)", async () => {
@@ -351,9 +364,10 @@ describe("platform/adapters/redis/node", () => {
     });
 
     it("should proxy expire", async () => {
-      const { client } = createMockClient();
+      const { client, calls } = createMockClient();
       const adapter = new NodeRedisAdapter(client as never);
       assertEquals(await adapter.expire("key", 60), 1);
+      assertEquals(calls[0].args, ["key", 60], "expire must forward the ttl in seconds");
     });
 
     it("should proxy get", async () => {

--- a/src/platform/adapters/registry.test.ts
+++ b/src/platform/adapters/registry.test.ts
@@ -91,6 +91,17 @@ describe("registry.ts", () => {
     it("should throw on invalid adapter", async () => {
       await assertRejects(() => runtime.set({} as any), Error, "Invalid adapter");
       await assertRejects(() => runtime.set(null as never), Error, "Invalid adapter");
+
+      for (const missing of ["id", "name", "fs", "env", "server"] as const) {
+        const adapter = createMockAdapter();
+        delete (adapter as unknown as Record<string, unknown>)[missing];
+        await assertRejects(
+          () => runtime.set(adapter),
+          Error,
+          "Invalid adapter",
+          `an adapter missing ${missing} must be rejected at set() time`,
+        );
+      }
     });
 
     it("should replace existing adapter", async () => {
@@ -319,6 +330,49 @@ describe("registry.ts", () => {
 
       assertEquals(a, b);
       assertEquals(b, c);
+    });
+
+    it("refuses getSync and reports uninitialized while a replacement is in flight", async () => {
+      const registry = new AdapterRegistry();
+      const initializationStarted = createDeferred();
+      const release = createDeferred();
+      const installed = createMockAdapter();
+      const replacement = createMockAdapter();
+      replacement.initialize = async () => {
+        initializationStarted.resolve();
+        await release.promise;
+      };
+
+      await registry.set(installed);
+      const pending = registry.set(replacement);
+      await initializationStarted.promise;
+
+      assertEquals(
+        registry.isInitialized(),
+        false,
+        "isInitialized must report false while an operation is in flight",
+      );
+      assertThrows(
+        () => registry.getSync(),
+        Error,
+        "transitioning",
+        "getSync must refuse to hand back an adapter that is being replaced",
+      );
+
+      release.resolve();
+      await pending;
+
+      assertEquals(
+        registry.isInitialized(),
+        true,
+        "the registry must report initialized once the operation settles",
+      );
+      assertEquals(
+        registry.getSync(),
+        replacement,
+        "getSync must return the replacement after the transition completes",
+      );
+      await registry.reset();
     });
 
     it("serializes an explicit set after an in-flight automatic initialization", async () => {

--- a/src/platform/adapters/runtime/bun/filesystem-adapter.bun.test.ts
+++ b/src/platform/adapters/runtime/bun/filesystem-adapter.bun.test.ts
@@ -11,6 +11,17 @@ import { getBunRuntime } from "./types.ts";
 
 describe("BunFileSystemAdapter native integration", () => {
   it("reads, writes, and watches through the real Bun runtime", async () => {
+    // Only the real Bun runtime sets process.versions.bun, and it is independent
+    // of the global getBunRuntime() reads, so a detection regression fails here
+    // instead of silently turning this file into a no-op.
+    const bunVersion = (globalThis as { process?: { versions?: { bun?: string } } })
+      .process?.versions?.bun;
+    if (bunVersion !== undefined) {
+      assertExists(
+        getBunRuntime(),
+        "getBunRuntime() must detect the Bun namespace when the process reports a Bun version",
+      );
+    }
     if (!getBunRuntime()) return;
     const root = await mkdtemp(join(tmpdir(), "veryfront-bun-fs-"));
     const adapter = new BunFileSystemAdapter();

--- a/src/platform/adapters/runtime/bun/http-server.test.ts
+++ b/src/platform/adapters/runtime/bun/http-server.test.ts
@@ -132,6 +132,26 @@ describe("Bun HTTP server lifecycle", () => {
     assertEquals(observedPeer, undefined);
   });
 
+  it("contains handler exceptions as a 500 instead of leaking them to Bun", async () => {
+    const native = new FakeNativeServer();
+    const fake = createRuntime(native);
+    await createBunServerWithRuntime(fake.runtime, () => {
+      throw new Error("handler exploded");
+    });
+
+    const response = await fake.getOptions().fetch(
+      new Request("http://localhost/"),
+      native,
+    );
+
+    assertEquals(response?.status, 500, "handler exceptions must be contained");
+    assertEquals(
+      await response?.text(),
+      "Internal Server Error",
+      "the contained response must not leak the error",
+    );
+  });
+
   it("reports the actual bound address and installs the native WebSocket handler", async () => {
     const native = new FakeNativeServer("::1", 45_678);
     const fake = createRuntime(native);

--- a/src/platform/adapters/runtime/bun/index.test.ts
+++ b/src/platform/adapters/runtime/bun/index.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   BunAdapter,
@@ -11,15 +11,25 @@ import {
   BunWebSocket,
   createBunServer,
 } from "./index.ts";
-
-function assertExportedFunction(value: unknown): void {
-  assertExists(value);
-  assertEquals(typeof value, "function");
-}
+import { BunAdapter as ConcreteBunAdapter } from "./adapter.ts";
+import { BunEnvironmentAdapter as ConcreteBunEnvironmentAdapter } from "./environment-adapter.ts";
+import { BunFileSystemAdapter as ConcreteBunFileSystemAdapter } from "./filesystem-adapter.ts";
+import {
+  BunServer as ConcreteBunServer,
+  createBunServer as concreteCreateBunServer,
+} from "./http-server.ts";
+import {
+  BunServerAdapter as ConcreteBunServerAdapter,
+  BunWebSocket as ConcreteBunWebSocket,
+} from "./websocket-adapter.ts";
 
 describe("runtime/bun/index.ts exports", () => {
   it("should export BunAdapter class", () => {
-    assertExportedFunction(BunAdapter);
+    assertStrictEquals(
+      BunAdapter,
+      ConcreteBunAdapter,
+      "the barrel must re-export the Bun platform adapter class itself",
+    );
   });
 
   it("should export bunAdapter singleton", () => {
@@ -29,26 +39,50 @@ describe("runtime/bun/index.ts exports", () => {
   });
 
   it("should export BunFileSystemAdapter class", () => {
-    assertExportedFunction(BunFileSystemAdapter);
+    assertStrictEquals(
+      BunFileSystemAdapter,
+      ConcreteBunFileSystemAdapter,
+      "the barrel must re-export the file system adapter class itself",
+    );
   });
 
   it("should export BunEnvironmentAdapter class", () => {
-    assertExportedFunction(BunEnvironmentAdapter);
+    assertStrictEquals(
+      BunEnvironmentAdapter,
+      ConcreteBunEnvironmentAdapter,
+      "the barrel must re-export the environment adapter class itself",
+    );
   });
 
   it("should export BunServerAdapter class", () => {
-    assertExportedFunction(BunServerAdapter);
+    assertStrictEquals(
+      BunServerAdapter,
+      ConcreteBunServerAdapter,
+      "the barrel must re-export the server adapter class itself",
+    );
   });
 
   it("should export BunWebSocket class", () => {
-    assertExportedFunction(BunWebSocket);
+    assertStrictEquals(
+      BunWebSocket,
+      ConcreteBunWebSocket,
+      "the barrel must re-export the WebSocket class itself",
+    );
   });
 
   it("should export BunServer class", () => {
-    assertExportedFunction(BunServer);
+    assertStrictEquals(
+      BunServer,
+      ConcreteBunServer,
+      "the barrel must re-export the HTTP server class itself",
+    );
   });
 
   it("should export createBunServer function", () => {
-    assertExportedFunction(createBunServer);
+    assertStrictEquals(
+      createBunServer,
+      concreteCreateBunServer,
+      "the barrel must re-export the server factory itself",
+    );
   });
 });

--- a/src/platform/adapters/runtime/bun/websocket-adapter.test.ts
+++ b/src/platform/adapters/runtime/bun/websocket-adapter.test.ts
@@ -211,9 +211,26 @@ describe("Bun WebSocket transport bridge", () => {
     assertEquals(nativeSocket.sent, ["hello"]);
 
     bunWebSocketHandler.message(nativeSocket, "world");
-    bunWebSocketHandler.message(nativeSocket, new Uint8Array([1, 2, 3]));
+    const pool = new Uint8Array([9, 9, 1, 2, 3, 9]);
+    bunWebSocketHandler.message(nativeSocket, pool.subarray(2, 5));
     assertEquals(messages[0], "world");
-    assertEquals([...new Uint8Array(messages[1] as ArrayBuffer)], [1, 2, 3]);
+    const delivered = messages[1] as ArrayBuffer;
+    assertEquals(
+      delivered.byteLength,
+      3,
+      "only the framed bytes may be delivered, not the whole receive pool",
+    );
+    assertEquals(
+      [...new Uint8Array(delivered)],
+      [1, 2, 3],
+      "binary frames must arrive with their exact bytes",
+    );
+    pool.set([7, 7, 7], 2);
+    assertEquals(
+      [...new Uint8Array(delivered)],
+      [1, 2, 3],
+      "the delivered buffer must be a copy, not a live view into Bun's pool",
+    );
 
     bunWebSocketHandler.close?.(nativeSocket, 1000, "done");
     assertEquals(socket.readyState, BunWebSocket.CLOSED);
@@ -259,6 +276,60 @@ describe("Bun WebSocket transport bridge", () => {
       Error,
       "original Request",
     );
+  });
+
+  it("rejects a second upgrade of the same Request", async () => {
+    const server = new FakeBunServer();
+    const adapter = new BunServerAdapter();
+
+    await dispatchBunRequest(websocketRequest(), server, (request) => {
+      const first = adapter.upgradeWebSocket(request);
+      assertThrows(
+        () => adapter.upgradeWebSocket(request),
+        Error,
+        "already been upgraded",
+        "a Bun Request must not be upgraded twice",
+      );
+      return first.response;
+    });
+
+    assertEquals(
+      server.upgradeCalls.length,
+      1,
+      "the rejected second upgrade must not reach server.upgrade()",
+    );
+  });
+
+  it("fails a committed socket when the handler throws after upgrading", async () => {
+    const failure = new Error("handler exploded");
+    let socket: BunWebSocket | undefined;
+    let errorCalls = 0;
+    let closeCalls = 0;
+
+    const result = await dispatchBunRequest(
+      websocketRequest(),
+      new FakeBunServer(),
+      (request) => {
+        socket = new BunServerAdapter().upgradeWebSocket(request).socket as BunWebSocket;
+        socket.addEventListener("error", () => errorCalls++);
+        socket.addEventListener("close", () => closeCalls++);
+        throw failure;
+      },
+    );
+
+    assertEquals(
+      result.upgradeError,
+      failure,
+      "a handler that throws after upgrading must surface the error as upgradeError instead of rethrowing",
+    );
+    assertExists(socket);
+    assertEquals(
+      socket.readyState,
+      BunWebSocket.CLOSED,
+      "the committed socket must be closed when the handler throws",
+    );
+    assertEquals(errorCalls, 1, "the committed socket must emit exactly one error event");
+    assertEquals(closeCalls, 1, "the committed socket must emit exactly one close event");
   });
 
   it("closes a committed upgrade if the handler returns an HTTP response", async () => {
@@ -358,5 +429,39 @@ describe("Bun WebSocket transport bridge", () => {
     bunWebSocketHandler.close?.(nativeSocket, 1000, "done");
     bunWebSocketHandler.message(nativeSocket, "late");
     assertEquals(messages, []);
+  });
+
+  it("terminates a native socket that carries no WebSocket bridge", () => {
+    const openedSocket = new FakeNativeSocket({} as unknown as BunWebSocketData);
+    bunWebSocketHandler.open?.(openedSocket);
+    assertEquals(
+      openedSocket.terminated,
+      true,
+      "a socket without a BunWebSocket bridge must be terminated",
+    );
+
+    const messagedSocket = new FakeNativeSocket({} as unknown as BunWebSocketData);
+    bunWebSocketHandler.message(messagedSocket, "forged");
+    assertEquals(
+      messagedSocket.terminated,
+      true,
+      "a message from a socket without a bridge must tear the connection down",
+    );
+
+    const closes: Array<[number | undefined, string | undefined]> = [];
+    const withoutTerminate: BunServerWebSocket<BunWebSocketData> = {
+      data: {} as unknown as BunWebSocketData,
+      readyState: BunWebSocket.OPEN,
+      send: () => 1,
+      close(code?: number, reason?: string) {
+        closes.push([code, reason]);
+      },
+    };
+    bunWebSocketHandler.open?.(withoutTerminate);
+    assertEquals(
+      closes,
+      [[1011, "Invalid WebSocket context"]],
+      "a runtime without terminate() must close the bridge-less socket with a protocol error",
+    );
   });
 });

--- a/src/platform/adapters/runtime/cloudflare/adapter.test.ts
+++ b/src/platform/adapters/runtime/cloudflare/adapter.test.ts
@@ -1,6 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertInstanceOf,
+  assertRejects,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { VeryfrontError } from "#veryfront/errors/types.ts";
 import { CloudflareAdapter, createCloudflareAdapter } from "./adapter.ts";
 import type { KVNamespace } from "./types.ts";
 
@@ -72,11 +78,23 @@ describe("CloudflareAdapter", () => {
 
     it("fails closed instead of pretending to open a listener", async () => {
       const adapter = new CloudflareAdapter(mockEnv);
-      await assertRejects(
+      const error = await assertRejects(
         () => adapter.serve(() => new Response("test")),
-        Error,
+        VeryfrontError,
         "fetch handler",
       );
+
+      assertInstanceOf(
+        error,
+        VeryfrontError,
+        "serve() must reject with a VeryfrontError",
+      );
+      assertEquals(
+        error.slug,
+        "not-supported",
+        "serve() must raise the NOT_SUPPORTED registry error",
+      );
+      assertEquals(error.status, 501, "NOT_SUPPORTED must map to HTTP 501");
     });
 
     it("shutdown should complete without error", async () => {

--- a/src/platform/adapters/runtime/cloudflare/environment.test.ts
+++ b/src/platform/adapters/runtime/cloudflare/environment.test.ts
@@ -20,6 +20,17 @@ describe("CloudflareEnvironmentAdapter", () => {
     };
     const environment = new CloudflareEnvironmentAdapter(bindings);
 
+    assertEquals(
+      environment.get("FILES"),
+      undefined,
+      "object bindings must not enter the string environment",
+    );
+    assertEquals(
+      Object.hasOwn(environment.toObject(), "FILES"),
+      false,
+      "toObject must expose only string bindings",
+    );
+
     environment.set("API_URL", "https://override.example.com");
     environment.set("FILES", "request-local-shadow");
 

--- a/src/platform/adapters/runtime/deno/adapter.test.ts
+++ b/src/platform/adapters/runtime/deno/adapter.test.ts
@@ -380,11 +380,40 @@ if (isDeno) {
 
   describe("denoAdapter singleton", () => {
     it("should be an instance of DenoAdapter", () => {
-      assertEquals(denoAdapter instanceof DenoAdapter, true);
+      assertEquals(
+        denoAdapter instanceof DenoAdapter,
+        true,
+        "the exported singleton must be a DenoAdapter",
+      );
     });
 
-    it("should return consistent instance", () => {
-      assertEquals(denoAdapter, denoAdapter);
+    it("shuts down the servers started through the same singleton", async () => {
+      const server = await denoAdapter.serve(
+        () => new Response("singleton"),
+        { hostname: "127.0.0.1", port: 0 },
+      );
+      const url = `http://127.0.0.1:${server.addr.port}/`;
+
+      try {
+        const response = await fetch(url);
+        assertEquals(
+          await response.text(),
+          "singleton",
+          "the singleton must serve the registered handler",
+        );
+
+        await denoAdapter.shutdown();
+
+        await assertRejects(
+          () => fetch(url),
+          TypeError,
+          undefined,
+          "denoAdapter.shutdown() must stop servers started through the same singleton",
+        );
+      } finally {
+        await server.stop();
+        await denoAdapter.shutdown();
+      }
     });
   });
 

--- a/src/platform/adapters/runtime/deno/filesystem-adapter.test.ts
+++ b/src/platform/adapters/runtime/deno/filesystem-adapter.test.ts
@@ -101,34 +101,42 @@ if (isDeno) {
       const failure = new Error("injected Deno write failure");
       let writes = 0;
       let closes = 0;
-      let removes = 0;
+      const root = await Deno.makeTempDir({ prefix: "vf-deno-reserved-" });
+      const reserved = join(root, "reserved.bin");
       const TestableAdapter = DenoFileSystemAdapter as unknown as new (
         options: Record<string, unknown>,
       ) => DenoFileSystemAdapter;
       const adapter = new TestableAdapter({
         denoCreateRuntime: {
-          open: () =>
-            Promise.resolve({
+          open: async (path: string, options: { write: true; createNew: true }) => {
+            const file = await Deno.open(path, options);
+            return {
               write: () => writes++ === 0 ? Promise.resolve(1) : Promise.reject(failure),
               close: () => {
                 closes++;
+                file.close();
               },
-            }),
-          remove: () => {
-            removes++;
-            return Promise.resolve();
+            };
           },
         },
       });
 
-      const error = await assertRejects(
-        () => adapter.createFileBytesExclusive!("/reserved.bin", new Uint8Array([1, 2])),
-        Error,
-      );
-      assertEquals(error, failure);
-      assertEquals(writes, 2);
-      assertEquals(closes, 1);
-      assertEquals(removes, 0);
+      try {
+        const error = await assertRejects(
+          () => adapter.createFileBytesExclusive!(reserved, new Uint8Array([1, 2])),
+          Error,
+        );
+        assertEquals(error, failure);
+        assertEquals(writes, 2);
+        assertEquals(closes, 1);
+        assertEquals(
+          (await Deno.lstat(reserved)).isFile,
+          true,
+          "a partial write failure must leave the createNew reservation on disk",
+        );
+      } finally {
+        await Deno.remove(root, { recursive: true });
+      }
     });
 
     it("preserves createNew write and handle cleanup failures", async () => {

--- a/src/platform/adapters/runtime/deno/filesystem-adapter.test.ts
+++ b/src/platform/adapters/runtime/deno/filesystem-adapter.test.ts
@@ -11,11 +11,12 @@ import { isDeno } from "#veryfront/platform/compat/runtime.ts";
 import { join } from "#veryfront/compat/path";
 import { isNativeFileSystemAdapter } from "../../native-file-system-provenance.ts";
 import { DenoFileSystemAdapter } from "./filesystem-adapter.ts";
+import { makeTempDir } from "#veryfront/testing/deno-compat.ts";
 
 if (isDeno) {
   describe("Deno filesystem adapter", () => {
     it("constructs exact snapshot and exclusive-create capabilities independently", async () => {
-      const root = await Deno.makeTempDir({ prefix: "vf-deno-snapshot-factory-" });
+      const root = await makeTempDir({ prefix: "vf-deno-snapshot-factory-" });
       try {
         const empty = join(root, "empty.bin");
         const exact = join(root, "exact.bin");
@@ -101,7 +102,7 @@ if (isDeno) {
       const failure = new Error("injected Deno write failure");
       let writes = 0;
       let closes = 0;
-      const root = await Deno.makeTempDir({ prefix: "vf-deno-reserved-" });
+      const root = await makeTempDir({ prefix: "vf-deno-reserved-" });
       const reserved = join(root, "reserved.bin");
       const TestableAdapter = DenoFileSystemAdapter as unknown as new (
         options: Record<string, unknown>,
@@ -198,7 +199,7 @@ if (isDeno) {
     });
 
     it("reads a genuinely bounded byte prefix", async () => {
-      const root = await Deno.makeTempDir({ prefix: "vf-deno-bounded-read-" });
+      const root = await makeTempDir({ prefix: "vf-deno-bounded-read-" });
       const path = join(root, "file.txt");
       try {
         await Deno.writeTextFile(path, "hello");
@@ -237,7 +238,7 @@ if (isDeno) {
     });
 
     it("round-trips binary files without text decoding", async () => {
-      const root = await Deno.makeTempDir({ prefix: "vf-deno-binary-write-" });
+      const root = await makeTempDir({ prefix: "vf-deno-binary-write-" });
       const path = join(root, "file.bin");
       const bytes = new Uint8Array([0, 255, 1, 128]);
       try {
@@ -250,7 +251,7 @@ if (isDeno) {
     });
 
     it("uses the native watcher and surfaces observed paths", async () => {
-      const root = await Deno.makeTempDir({ prefix: "vf-deno-watch-" });
+      const root = await makeTempDir({ prefix: "vf-deno-watch-" });
       const path = join(root, "created.txt");
       const watcher = new DenoFileSystemAdapter().watch(root, {
         recursive: false,
@@ -291,7 +292,7 @@ if (isDeno) {
     });
 
     it("rejects a second concurrent iterator read", async () => {
-      const root = await Deno.makeTempDir({ prefix: "vf-deno-watch-next-" });
+      const root = await makeTempDir({ prefix: "vf-deno-watch-next-" });
       const watcher = new DenoFileSystemAdapter().watch(root);
       const iterator = watcher[Symbol.asyncIterator]();
 

--- a/src/platform/adapters/runtime/deno/http-server.test.ts
+++ b/src/platform/adapters/runtime/deno/http-server.test.ts
@@ -156,6 +156,34 @@ describe("Deno HTTP server lifecycle", () => {
     await server.stop();
   });
 
+  it("contains a throwing application handler in a 500 response", async () => {
+    const native = new FakeNativeServer();
+    const fake = createRuntime(native);
+    const server = await createDenoServerWithRuntime(
+      fake.runtime,
+      () => {
+        throw new Error("boom");
+      },
+      { hostname: "localhost", port: 0 },
+    );
+
+    try {
+      const response = await fake.getOptions().handler(new Request("http://localhost/boom"));
+      assertEquals(
+        response.status,
+        500,
+        "a throwing handler must be contained in a 500 response",
+      );
+      assertEquals(
+        await response.text(),
+        "Internal Server Error",
+        "the contained failure must not leak handler detail",
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+
   it("shares concurrent stop calls, remains idempotent, and aborts owned work", async () => {
     const native = new FakeNativeServer();
     let release!: () => void;

--- a/src/platform/adapters/runtime/node/filesystem-adapter.test.ts
+++ b/src/platform/adapters/runtime/node/filesystem-adapter.test.ts
@@ -61,30 +61,67 @@ describe("NodeFileSystemAdapter", () => {
       await Deno.symlink(exact, link);
       const adapter = new NodeFileSystemAdapter();
 
-      assertEquals(Object.hasOwn(adapter, "createFileBytesExclusive"), true);
-      const readSnapshot = adapter.readFileSnapshotWithinLimit;
-      if (readSnapshot === undefined) return;
-      assertExists(readSnapshot);
-      assertEquals([...await readSnapshot(empty, root, 1)], []);
-      assertEquals([...await readSnapshot(exact, root, 3)], [1, 2, 3]);
-      await assertRejects(
-        () => readSnapshot(oversized, root, 3),
-        RangeError,
+      assertEquals(
+        Object.hasOwn(adapter, "createFileBytesExclusive"),
+        true,
+        "the exclusive-create capability must be constructed on every platform",
       );
-      for (const limit of [0, Number.MAX_SAFE_INTEGER + 1]) {
+      if (Deno.build.os === "windows") {
+        assertEquals(
+          Object.hasOwn(adapter, "readFileSnapshotWithinLimit"),
+          false,
+          "Deno-hosted Windows has no usable Node snapshot identity",
+        );
+        assertEquals(
+          adapter.readFileSnapshotWithinLimit,
+          undefined,
+          "the absent capability must not be inherited",
+        );
+      } else {
+        assertEquals(
+          Object.hasOwn(adapter, "readFileSnapshotWithinLimit"),
+          true,
+          "POSIX Node adapters must construct a bounded snapshot reader",
+        );
+        assertExists(adapter.readFileSnapshotWithinLimit);
+        const readSnapshot = adapter.readFileSnapshotWithinLimit;
+        assertEquals(
+          [...await readSnapshot(empty, root, 1)],
+          [],
+          "an empty file must snapshot to zero bytes",
+        );
+        assertEquals(
+          [...await readSnapshot(exact, root, 3)],
+          [1, 2, 3],
+          "a file at the byte limit must snapshot exactly",
+        );
         await assertRejects(
-          () => readSnapshot(exact, root, limit),
+          () => readSnapshot(oversized, root, 3),
           RangeError,
+          undefined,
+          "a file over the byte limit must be refused",
+        );
+        for (const limit of [0, Number.MAX_SAFE_INTEGER + 1]) {
+          await assertRejects(
+            () => readSnapshot(exact, root, limit),
+            RangeError,
+            undefined,
+            `an out-of-range byte limit (${limit}) must be refused`,
+          );
+        }
+        await assertRejects(
+          () => readSnapshot(directory, root, 3),
+          TypeError,
+          undefined,
+          "a directory must not be snapshot as a file",
+        );
+        await assertRejects(
+          () => readSnapshot(link, root, 3),
+          TypeError,
+          undefined,
+          "a symlink must be refused instead of followed",
         );
       }
-      await assertRejects(
-        () => readSnapshot(directory, root, 3),
-        TypeError,
-      );
-      await assertRejects(
-        () => readSnapshot(link, root, 3),
-        TypeError,
-      );
     } finally {
       await Deno.remove(root, { recursive: true });
     }

--- a/src/platform/adapters/runtime/node/http-server.test.ts
+++ b/src/platform/adapters/runtime/node/http-server.test.ts
@@ -15,6 +15,8 @@ import { createWebSocketUpgradeResponse } from "../../base.ts";
 import { createNodeServer, createNodeServerWithStartupOwner, NodeServer } from "./http-server.ts";
 import type { NodeHttpServer } from "./types.ts";
 import { NodeServerAdapter } from "./websocket-adapter.ts";
+import { getRequestPeerProvenance } from "../shared/request-peer.ts";
+import { isTrustedLocalControlRequest } from "#veryfront/security/http/local-control-request.ts";
 import { WsNodeWebSocketServerProvider } from "../../../../../extensions/ext-node-websocket-ws/src/index.ts";
 import { NODE_WEBSOCKET_SERVER_PROVIDER_PACKAGE } from "#veryfront/extensions/websocket";
 
@@ -1298,6 +1300,91 @@ describe("NodeServer lifecycle", () => {
       await bodyCancelled.promise;
     } finally {
       client.destroy();
+      await server.stop();
+    }
+  });
+
+  it("records the native TCP peer of a request instead of a caller-supplied header", async () => {
+    if (!isNode) return;
+    const observed: Array<{
+      path: string;
+      provenance: ReturnType<typeof getRequestPeerProvenance>;
+      trusted: boolean;
+    }> = [];
+    const server = await createNodeServer((request) => {
+      observed.push({
+        path: new URL(request.url).pathname,
+        provenance: getRequestPeerProvenance(request),
+        trusted: isTrustedLocalControlRequest(request, { proxyTopologyTrusted: false }),
+      });
+      return new Response(null, { status: 204 });
+    }, {
+      hostname: "127.0.0.1",
+      port: 0,
+    });
+
+    try {
+      const forwarded = await fetch(`http://127.0.0.1:${server.addr.port}/_dev-forwarded`, {
+        headers: { "x-forwarded-for": "10.0.0.9" },
+      });
+      assertEquals(forwarded.status, 204, "the listener must serve the forwarded-header request");
+      const direct = await fetch(`http://127.0.0.1:${server.addr.port}/_dev-direct`);
+      assertEquals(direct.status, 204, "the listener must serve the direct loopback request");
+
+      assertEquals(
+        observed,
+        [
+          {
+            path: "/_dev-forwarded",
+            provenance: { runtime: "node", transport: "tcp", hostname: "127.0.0.1" },
+            trusted: false,
+          },
+          {
+            path: "/_dev-direct",
+            provenance: { runtime: "node", transport: "tcp", hostname: "127.0.0.1" },
+            trusted: true,
+          },
+        ],
+        "the Node listener must record the native TCP peer, not a caller-supplied header",
+      );
+    } finally {
+      await server.stop();
+    }
+  });
+
+  it("records the native TCP peer on the synthesized WebSocket upgrade request", async () => {
+    if (!isNode) return;
+    const adapter = new NodeServerAdapter();
+    let observed: ReturnType<typeof getRequestPeerProvenance>;
+    let observedCalls = 0;
+    const server = await createNodeServer((request) => {
+      observedCalls++;
+      observed = getRequestPeerProvenance(request);
+      return adapter.upgradeWebSocket(request).response;
+    }, {
+      hostname: "127.0.0.1",
+      port: 0,
+      nodeWebSocketServerProvider: WsNodeWebSocketServerProvider,
+    });
+    const { WebSocket } = await import("ws");
+    const client = new WebSocket(`ws://127.0.0.1:${server.addr.port}/_ws`, {
+      headers: { "x-forwarded-for": "10.0.0.9" },
+    });
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        client.once("open", resolve);
+        client.once("error", reject);
+      });
+
+      assertEquals(observedCalls, 1, "the upgrade must run through the request handler once");
+      assertEquals(
+        observed,
+        { runtime: "node", transport: "tcp", hostname: "127.0.0.1" },
+        "the Node upgrade path must record the native TCP peer, not a caller-supplied header",
+      );
+    } finally {
+      if (client.readyState !== WebSocket.CLOSED) client.terminate();
       await server.stop();
     }
   });

--- a/src/platform/adapters/runtime/node/websocket-adapter.test.ts
+++ b/src/platform/adapters/runtime/node/websocket-adapter.test.ts
@@ -3,6 +3,7 @@ import {
   assertEquals,
   assertExists,
   assertRejects,
+  assertStrictEquals,
   assertThrows,
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
@@ -160,6 +161,31 @@ describe("NodeServerAdapter WebSocket upgrade", () => {
     );
   });
 
+  it("rejects a second upgrade of the same Request", () => {
+    const requestId = "QUJDREVGR0hJSktMTU5PUA==";
+    const adapter = new NodeServerAdapter();
+    const request = websocketRequest(requestId);
+
+    adapter.upgradeWebSocket(request);
+
+    assertThrows(
+      () => adapter.upgradeWebSocket(request),
+      Error,
+      "already been upgraded",
+      "a Node Request must not be upgraded twice",
+    );
+    assertEquals(
+      resolveWebSocketUpgrade(requestId, createMockWs()),
+      true,
+      "only the first upgrade may register pending transport state",
+    );
+    assertEquals(
+      resolveWebSocketUpgrade(requestId, createMockWs()),
+      false,
+      "the rejected second upgrade must not leave a second pending registration",
+    );
+  });
+
   it("rejects requests that are not valid RFC 6455 handshakes", () => {
     const adapter = new NodeServerAdapter();
 
@@ -198,6 +224,37 @@ describe("NodeServerAdapter WebSocket upgrade", () => {
         ),
       Error,
       "Sec-WebSocket-Version",
+    );
+    assertThrows(
+      () =>
+        adapter.upgradeWebSocket(
+          new Request("http://localhost/_ws", {
+            headers: {
+              upgrade: "websocket",
+              "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+              "sec-websocket-version": "13",
+            },
+          }),
+        ),
+      Error,
+      "Connection: Upgrade",
+      "a handshake without a Connection: Upgrade token must be rejected",
+    );
+    assertThrows(
+      () =>
+        adapter.upgradeWebSocket(
+          new Request("http://localhost/_ws", {
+            headers: {
+              connection: "keep-alive",
+              upgrade: "websocket",
+              "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+              "sec-websocket-version": "13",
+            },
+          }),
+        ),
+      Error,
+      "Connection: Upgrade",
+      "a Connection header without an upgrade token must be rejected",
     );
   });
 
@@ -329,13 +386,22 @@ describe("NodeWebSocket close handling", () => {
     // Regression test: Node <23 does not expose `CloseEvent` as a global. The
     // previous implementation used `new CloseEvent("close")`, which crashed
     // the dev server with an unhandled `ReferenceError` on every socket
-    // teardown. The handler must complete without throwing regardless of the
-    // runtime's `CloseEvent` support.
+    // teardown. The handler must build and deliver the close event itself.
+    // The companion case in tests/integration/adapters covers the same path
+    // with the global constructor removed.
     const { socket, ws } = attach();
-    socket.onclose = () => {};
+    let received: CloseEvent | null = null;
+    socket.onclose = (event) => {
+      received = event;
+    };
 
     ws.emit("close", 1000, Buffer.from("ok"));
-    // Reaching this line without throwing proves the regression is fixed.
+
+    const event = received as unknown as CloseEvent;
+    assertExists(event, "the close handler must run without throwing a ReferenceError");
+    assertEquals(event.code, 1000, "the close code must reach the handler");
+    assertEquals(event.reason, "ok", "the close reason must reach the handler");
+    assertEquals(event.wasClean, true, "a 1000 close must be reported as clean");
   });
 
   it("transitions readyState to CLOSED after close", () => {
@@ -370,6 +436,11 @@ describe("NodeWebSocket error handling", () => {
     assertEquals(event.message, "transport failed");
     assertEquals(event.error instanceof Error, true);
     assertEquals(socket.readyState, NodeWebSocket.CLOSED);
+    assertStrictEquals(
+      Object.getPrototypeOf(event),
+      Event.prototype,
+      "the error event must be a plain Event so runtimes without a global ErrorEvent do not throw",
+    );
   });
 });
 

--- a/src/platform/adapters/runtime/shared/node-based-shell-adapter.test.ts
+++ b/src/platform/adapters/runtime/shared/node-based-shell-adapter.test.ts
@@ -64,8 +64,13 @@ describe("NodeBasedShellAdapter", () => {
 
     it("should read existing file", () => {
       const content = createAdapter().readFileSync("./deno.json");
-      assertEquals(typeof content, "string");
-      assertEquals(content.length > 0, true);
+
+      assertEquals(typeof content, "string", "readFileSync must return decoded text");
+      assertEquals(
+        JSON.parse(content).name,
+        "veryfront",
+        "readFileSync must decode the file as UTF-8 JSON text, not bytes",
+      );
     });
 
     it("should throw for non-existent file", () => {

--- a/src/platform/adapters/runtime/shared/node-filesystem-adapter.test.ts
+++ b/src/platform/adapters/runtime/shared/node-filesystem-adapter.test.ts
@@ -6,6 +6,7 @@ import {
   assertStrictEquals,
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { constants as nodeFsConstants } from "node:fs";
 import { FileSnapshotChangedError } from "../../file-snapshot-error.ts";
 import { isNativeFileSystemAdapter } from "../../native-file-system-provenance.ts";
 import {
@@ -175,6 +176,55 @@ describe("NodeCompatibleFileSystemAdapter", () => {
       [4, 5, 6],
     );
     assertEquals(openedWith, ["r"]);
+  });
+
+  it("opens a POSIX snapshot with the runtime no-follow flag", async () => {
+    const source = new Uint8Array([7, 8, 9]);
+    const stat = {
+      dev: 1n,
+      ino: 2n,
+      size: BigInt(source.byteLength),
+      mtimeNs: 4n,
+      ctimeNs: 5n,
+      isFile: () => true,
+      isSymbolicLink: () => false,
+    };
+    const openedWith: Array<number | string> = [];
+    const operations = {
+      realpath: (path: string) => Promise.resolve(path),
+      lstat: () => Promise.resolve(stat),
+      open: (_path: string, flags: number | string) => {
+        openedWith.push(flags);
+        return Promise.resolve({
+          stat: () => Promise.resolve(stat),
+          read: (buffer: Uint8Array, offset: number, length: number, position: number) => {
+            buffer.set(source.subarray(position, position + length), offset);
+            return Promise.resolve({ bytesRead: length });
+          },
+          writeFile: () => Promise.resolve(),
+          close: () => Promise.resolve(),
+        });
+      },
+    };
+    assertEquals(
+      [
+        ...await readNodeFileSnapshotWithinLimit(
+          operations,
+          "posix",
+          0x20000,
+          "/root/file.bin",
+          "/root",
+          3,
+        ),
+      ],
+      [7, 8, 9],
+      "a POSIX snapshot must read the exact admitted bytes",
+    );
+    assertEquals(
+      openedWith,
+      [nodeFsConstants.O_RDONLY | 0x20000],
+      "POSIX snapshot opens must carry O_NOFOLLOW",
+    );
   });
 
   it("rejects a Windows lexical containment escape before candidate filesystem access", async () => {
@@ -929,32 +979,43 @@ describe("NodeCompatibleFileSystemAdapter", () => {
   });
 
   it("does not guess ownership by deleting a reserved path after write failure", async () => {
-    let closeCalls = 0;
-    let removeCalls = 0;
-    const failure = new Error("injected write failure");
-    const operations = {
-      open: () =>
-        Promise.resolve({
-          writeFile: () => Promise.reject(failure),
-          close: () => {
-            closeCalls++;
-            return Promise.resolve();
-          },
-        }),
-      remove: () => {
-        removeCalls++;
-        return Promise.resolve();
-      },
-    };
-    const adapter = new TestableNodeCompatibleFileSystemAdapter(undefined, { operations });
+    const root = await Deno.makeTempDir({ prefix: "veryfront-node-reserved-" });
+    try {
+      const target = `${root}/reserved.bin`;
+      await Deno.writeFile(target, new Uint8Array([9, 8, 7]));
+      let closeCalls = 0;
+      const failure = new Error("injected write failure");
+      const operations = {
+        open: () =>
+          Promise.resolve({
+            writeFile: () => Promise.reject(failure),
+            close: () => {
+              closeCalls++;
+              return Promise.resolve();
+            },
+          }),
+      };
+      const adapter = new TestableNodeCompatibleFileSystemAdapter(undefined, { operations });
 
-    const error = await assertRejects(
-      () => requireExclusiveCreator(adapter)("/reserved.bin", new Uint8Array([1])),
-      Error,
-    );
-    assertEquals(error, failure);
-    assertEquals(closeCalls, 1);
-    assertEquals(removeCalls, 0);
+      const error = await assertRejects(
+        () => requireExclusiveCreator(adapter)(target, new Uint8Array([1])),
+        Error,
+      );
+      assertEquals(error, failure);
+      assertEquals(closeCalls, 1);
+      assertEquals(
+        (await Deno.lstat(target)).isFile,
+        true,
+        "a failed exclusive write must not delete a path the adapter does not own",
+      );
+      assertEquals(
+        [...await Deno.readFile(target)],
+        [9, 8, 7],
+        "the pre-existing bytes must survive the failed write",
+      );
+    } finally {
+      await Deno.remove(root, { recursive: true });
+    }
   });
 
   it("preserves exclusive-create write and handle cleanup failures", async () => {

--- a/src/platform/adapters/runtime/shared/node-filesystem-adapter.test.ts
+++ b/src/platform/adapters/runtime/shared/node-filesystem-adapter.test.ts
@@ -16,6 +16,7 @@ import {
   resolveNoFollowFlag,
 } from "./node-filesystem-adapter.ts";
 import { setupNodeFsWatcher } from "./shared-watcher.ts";
+import { makeTempDir } from "#veryfront/testing/deno-compat.ts";
 
 type AdapterOptions = {
   noFollow?: number;
@@ -76,7 +77,7 @@ describe("NodeCompatibleFileSystemAdapter", () => {
   });
 
   it("reads empty and exact-limit snapshots and rejects invalid or oversized inputs", async () => {
-    const root = await Deno.makeTempDir({ prefix: "veryfront-node-snapshot-" });
+    const root = await makeTempDir({ prefix: "veryfront-node-snapshot-" });
     try {
       const empty = `${root}/empty.bin`;
       const exact = `${root}/exact.bin`;
@@ -106,7 +107,7 @@ describe("NodeCompatibleFileSystemAdapter", () => {
 
   it("accepts a canonical candidate beneath a symlinked containment root", async () => {
     if (Deno.build.os === "windows") return;
-    const workspace = await Deno.makeTempDir({ prefix: "veryfront-node-snapshot-root-" });
+    const workspace = await makeTempDir({ prefix: "veryfront-node-snapshot-root-" });
     const physicalRoot = `${workspace}/physical`;
     const linkedRoot = `${workspace}/linked`;
     try {
@@ -958,7 +959,7 @@ describe("NodeCompatibleFileSystemAdapter", () => {
   });
 
   it("creates byte files exclusively and never truncates colliding entries", async () => {
-    const root = await Deno.makeTempDir({ prefix: "veryfront-node-exclusive-" });
+    const root = await makeTempDir({ prefix: "veryfront-node-exclusive-" });
     try {
       const absent = `${root}/created.bin`;
       const existing = `${root}/existing.bin`;
@@ -979,7 +980,7 @@ describe("NodeCompatibleFileSystemAdapter", () => {
   });
 
   it("does not guess ownership by deleting a reserved path after write failure", async () => {
-    const root = await Deno.makeTempDir({ prefix: "veryfront-node-reserved-" });
+    const root = await makeTempDir({ prefix: "veryfront-node-reserved-" });
     try {
       const target = `${root}/reserved.bin`;
       await Deno.writeFile(target, new Uint8Array([9, 8, 7]));
@@ -1108,7 +1109,7 @@ describe("NodeCompatibleFileSystemAdapter", () => {
   });
 
   it("provides consistent text, byte, metadata, and symlink operations", async () => {
-    const root = await Deno.makeTempDir({ prefix: "veryfront-node-fs-" });
+    const root = await makeTempDir({ prefix: "veryfront-node-fs-" });
     try {
       const adapter = new NodeCompatibleFileSystemAdapter();
       assertEquals(isNativeFileSystemAdapter(adapter), true);
@@ -1171,7 +1172,7 @@ describe("NodeCompatibleFileSystemAdapter", () => {
   });
 
   it("closes watcher resources when iteration returns", async () => {
-    const root = await Deno.makeTempDir({ prefix: "veryfront-node-watch-" });
+    const root = await makeTempDir({ prefix: "veryfront-node-watch-" });
     try {
       const watcher = new NodeCompatibleFileSystemAdapter().watch(root, {
         recursive: false,
@@ -1196,7 +1197,7 @@ describe("NodeCompatibleFileSystemAdapter", () => {
   });
 
   it("settles watcher shutdown when the caller aborts", async () => {
-    const root = await Deno.makeTempDir({ prefix: "veryfront-node-watch-abort-" });
+    const root = await makeTempDir({ prefix: "veryfront-node-watch-abort-" });
     try {
       const controller = new AbortController();
       const watcher = new NodeCompatibleFileSystemAdapter().watch(root, {
@@ -1216,7 +1217,7 @@ describe("NodeCompatibleFileSystemAdapter", () => {
   });
 
   it("rejects watcher readiness when the requested root cannot be acquired", async () => {
-    const root = await Deno.makeTempDir({ prefix: "veryfront-node-watch-missing-" });
+    const root = await makeTempDir({ prefix: "veryfront-node-watch-missing-" });
     const missingRoot = `${root}/missing`;
     const watcher = new NodeCompatibleFileSystemAdapter().watch(missingRoot, {
       recursive: true,

--- a/src/platform/adapters/runtime/shared/server-lifecycle.test.ts
+++ b/src/platform/adapters/runtime/shared/server-lifecycle.test.ts
@@ -68,10 +68,15 @@ describe("platform/adapters/runtime/shared/server-lifecycle", () => {
       const first = await serve(() => new Response("first"));
       await serve(() => new Response("second"));
       await first.stop();
+      await first.stop();
       await registry.shutdown();
       await registry.shutdown();
 
-      assertEquals(stopCalls, [1, 1]);
+      assertEquals(
+        stopCalls,
+        [1, 1],
+        "a directly stopped server must delegate stop() exactly once, even across repeat stop and shutdown calls",
+      );
     });
 
     it("shares concurrent shutdown and retries only servers that failed to stop", async () => {

--- a/src/platform/adapters/token/factory.test.ts
+++ b/src/platform/adapters/token/factory.test.ts
@@ -42,6 +42,38 @@ describe("createTokenStorageAdapter", () => {
     );
   });
 
+  it("validates the retry config captured at call time, not a later mutation", async () => {
+    const options = {
+      apiToken: "original-token",
+      projectSlug: "test-project",
+      retry: { maxRetries: 10 },
+    };
+
+    const pending = createTokenStorageAdapter({ type: "veryfront-api", veryfront: options });
+    options.retry = { maxRetries: 0 };
+
+    await assertRejects(
+      () => pending,
+      RangeError,
+      "maxRetries",
+      "the factory must reject the retry config it captured before its async body ran",
+    );
+  });
+
+  it("reads credentials from the call-time options, not a later mutation", async () => {
+    const options = { apiToken: "   ", projectSlug: "test-project" };
+
+    const pending = createTokenStorageAdapter({ type: "veryfront-api", veryfront: options });
+    options.apiToken = "repaired-token";
+
+    await assertRejects(
+      () => pending,
+      Error,
+      "requires apiToken",
+      "a blank call-time apiToken must not be repaired by mutating the caller's object",
+    );
+  });
+
   it("should default to memory type when type not specified", async () => {
     const adapter = await createTokenStorageAdapter({} as TokenStorageAdapterConfig);
     assertExists(adapter);

--- a/src/platform/adapters/token/index.test.ts
+++ b/src/platform/adapters/token/index.test.ts
@@ -1,36 +1,91 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import {
+  MemoryTokenAdapter,
+  TOKEN_STORAGE_ERROR,
+  TokenStorageApiClient,
+  VeryfrontTokenAdapter,
+} from "./veryfront/index.ts";
+import { createTokenStorageAdapter } from "./factory.ts";
+import {
+  getTokenStorageAdapter,
+  getTokenStorageType,
+  isTokenStorageConfigured,
+  resetTokenStorageAdapter,
+} from "./integration.ts";
 
 describe("token/index.ts exports", () => {
   async function getModule(): Promise<typeof import("./index.ts")> {
     return await import("./index.ts");
   }
 
-  async function assertExportedFunction(name: string): Promise<void> {
+  it("should export MemoryTokenAdapter", async () => {
     const mod = await getModule();
-    const value = mod[name as keyof typeof mod];
-    assertExists(value);
-    assertEquals(typeof value, "function");
-  }
+    assertStrictEquals(
+      mod.MemoryTokenAdapter,
+      MemoryTokenAdapter,
+      "the barrel must re-export the same MemoryTokenAdapter binding",
+    );
+  });
 
-  it("should export MemoryTokenAdapter", () => assertExportedFunction("MemoryTokenAdapter"));
-  it("should export VeryfrontTokenAdapter", () => assertExportedFunction("VeryfrontTokenAdapter"));
-  it("should export TokenStorageApiClient", () => assertExportedFunction("TokenStorageApiClient"));
+  it("should export VeryfrontTokenAdapter", async () => {
+    const mod = await getModule();
+    assertStrictEquals(
+      mod.VeryfrontTokenAdapter,
+      VeryfrontTokenAdapter,
+      "the barrel must re-export the same VeryfrontTokenAdapter binding",
+    );
+  });
+
+  it("should export TokenStorageApiClient", async () => {
+    const mod = await getModule();
+    assertStrictEquals(
+      mod.TokenStorageApiClient,
+      TokenStorageApiClient,
+      "the barrel must re-export the same TokenStorageApiClient binding",
+    );
+  });
+
   it("should export TOKEN_STORAGE_ERROR", async () => {
     const mod = await getModule();
-    const value = mod["TOKEN_STORAGE_ERROR" as keyof typeof mod];
-    assertExists(value);
-    assertEquals(typeof value, "object");
+    assertStrictEquals(
+      mod.TOKEN_STORAGE_ERROR,
+      TOKEN_STORAGE_ERROR,
+      "the barrel must re-export the same TOKEN_STORAGE_ERROR registry entry",
+    );
   });
-  it("should export createTokenStorageAdapter", () =>
-    assertExportedFunction("createTokenStorageAdapter"));
+
+  it("should export createTokenStorageAdapter", async () => {
+    const mod = await getModule();
+    assertStrictEquals(
+      mod.createTokenStorageAdapter,
+      createTokenStorageAdapter,
+      "the barrel must re-export the same createTokenStorageAdapter binding",
+    );
+  });
 
   it("should export integration functions", async () => {
     const mod = await getModule();
-    assertExists(mod.getTokenStorageAdapter);
-    assertExists(mod.getTokenStorageType);
-    assertExists(mod.isTokenStorageConfigured);
-    assertExists(mod.resetTokenStorageAdapter);
+    assertStrictEquals(
+      mod.getTokenStorageAdapter,
+      getTokenStorageAdapter,
+      "the barrel must re-export the same getTokenStorageAdapter binding",
+    );
+    assertStrictEquals(
+      mod.getTokenStorageType,
+      getTokenStorageType,
+      "the barrel must re-export the same getTokenStorageType binding",
+    );
+    assertStrictEquals(
+      mod.isTokenStorageConfigured,
+      isTokenStorageConfigured,
+      "the barrel must re-export the same isTokenStorageConfigured binding",
+    );
+    assertStrictEquals(
+      mod.resetTokenStorageAdapter,
+      resetTokenStorageAdapter,
+      "the barrel must re-export the same resetTokenStorageAdapter binding",
+    );
   });
 });

--- a/src/platform/adapters/token/integration.test.ts
+++ b/src/platform/adapters/token/integration.test.ts
@@ -1,5 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertNotStrictEquals,
+  assertRejects,
+  assertStrictEquals,
+} from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   getTokenStorageAdapter,
@@ -105,7 +111,11 @@ describe("platform/adapters/token/integration", () => {
     it("should return same instance on multiple calls (singleton)", async () => {
       const adapter1 = await getTokenStorageAdapter();
       const adapter2 = await getTokenStorageAdapter();
-      assertEquals(adapter1, adapter2);
+      assertStrictEquals(
+        adapter1,
+        adapter2,
+        "getTokenStorageAdapter must return the same adapter instance",
+      );
     });
 
     it("coalesces concurrent singleton creation", async () => {
@@ -114,8 +124,16 @@ describe("platform/adapters/token/integration", () => {
         getTokenStorageAdapter(),
         getTokenStorageAdapter(),
       ]);
-      assertEquals(adapter1, adapter2);
-      assertEquals(adapter2, adapter3);
+      assertStrictEquals(
+        adapter1,
+        adapter2,
+        "concurrent callers must share one adapter instance",
+      );
+      assertStrictEquals(
+        adapter2,
+        adapter3,
+        "concurrent callers must share one adapter instance",
+      );
     });
 
     it("prevents pending creation from republishing an adapter after reset", async () => {
@@ -129,7 +147,11 @@ describe("platform/adapters/token/integration", () => {
       );
 
       const replacement = await getTokenStorageAdapter();
-      assertEquals(await getTokenStorageAdapter(), replacement);
+      assertStrictEquals(
+        await getTokenStorageAdapter(),
+        replacement,
+        "the replacement adapter must be published as the singleton",
+      );
     });
 
     it("should create new instance after reset", async () => {
@@ -138,6 +160,11 @@ describe("platform/adapters/token/integration", () => {
       const adapter2 = await getTokenStorageAdapter();
       assertExists(adapter1);
       assertExists(adapter2);
+      assertNotStrictEquals(
+        adapter1,
+        adapter2,
+        "resetTokenStorageAdapter must publish a new adapter instance",
+      );
     });
 
     it("should return a working memory adapter", async () => {

--- a/src/platform/adapters/token/veryfront/adapter.test.ts
+++ b/src/platform/adapters/token/veryfront/adapter.test.ts
@@ -132,5 +132,32 @@ describe("platform/adapters/token/veryfront/adapter", () => {
       // Should attempt to re-init (will fail since API is unreachable)
       await assertRejects(() => adapter.initialize(), VeryfrontError);
     });
+
+    it("clears the initialized flag so a disposed adapter re-pings the API", async () => {
+      const originalFetch = globalThis.fetch;
+      let requests = 0;
+      globalThis.fetch = () => {
+        requests++;
+        return Promise.resolve(Response.json({ keys: [] }));
+      };
+
+      try {
+        const adapter = new VeryfrontTokenAdapter(createConfig({
+          apiBaseUrl: "https://api.example.com",
+        }));
+        await adapter.initialize();
+        assertEquals(requests, 1, "the first initialize must ping the API");
+
+        adapter.dispose();
+        await adapter.initialize();
+        assertEquals(
+          requests,
+          2,
+          "dispose must clear the initialized flag so the next initialize re-pings the API",
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
   });
 });

--- a/src/platform/adapters/token/veryfront/adapter.test.ts
+++ b/src/platform/adapters/token/veryfront/adapter.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { MAX_VERYFRONT_API_RETRIES } from "#veryfront/utils/config-resource-limits.ts";
 import { VeryfrontTokenAdapter } from "./adapter.ts";
 import { VeryfrontError } from "#veryfront/errors/types.ts";
+import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 
 describe("platform/adapters/token/veryfront/adapter", () => {
   function createConfig(overrides: Record<string, unknown> = {}) {
@@ -62,12 +63,11 @@ describe("platform/adapters/token/veryfront/adapter", () => {
     });
 
     it("coalesces concurrent connection checks", async () => {
-      const originalFetch = globalThis.fetch;
       let requests = 0;
-      globalThis.fetch = () => {
+      installMockFetch(() => {
         requests++;
         return Promise.resolve(Response.json({ keys: [] }));
-      };
+      });
 
       try {
         const adapter = new VeryfrontTokenAdapter(createConfig({
@@ -80,17 +80,17 @@ describe("platform/adapters/token/veryfront/adapter", () => {
         ]);
         assertEquals(requests, 1);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
 
     it("does not let a late connection check resurrect a disposed adapter", async () => {
-      const originalFetch = globalThis.fetch;
       let resolveResponse: ((response: Response) => void) | undefined;
-      globalThis.fetch = () =>
+      installMockFetch(() =>
         new Promise<Response>((resolve) => {
           resolveResponse = resolve;
-        });
+        })
+      );
 
       try {
         const adapter = new VeryfrontTokenAdapter(createConfig({
@@ -108,14 +108,14 @@ describe("platform/adapters/token/veryfront/adapter", () => {
         );
 
         let retries = 0;
-        globalThis.fetch = () => {
+        installMockFetch(() => {
           retries++;
           return Promise.resolve(Response.json({ keys: [] }));
-        };
+        });
         await adapter.initialize();
         assertEquals(retries, 1);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
   });
@@ -134,12 +134,11 @@ describe("platform/adapters/token/veryfront/adapter", () => {
     });
 
     it("clears the initialized flag so a disposed adapter re-pings the API", async () => {
-      const originalFetch = globalThis.fetch;
       let requests = 0;
-      globalThis.fetch = () => {
+      installMockFetch(() => {
         requests++;
         return Promise.resolve(Response.json({ keys: [] }));
-      };
+      });
 
       try {
         const adapter = new VeryfrontTokenAdapter(createConfig({
@@ -156,7 +155,7 @@ describe("platform/adapters/token/veryfront/adapter", () => {
           "dispose must clear the initialized flag so the next initialize re-pings the API",
         );
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
   });

--- a/src/platform/adapters/token/veryfront/api-client.test.ts
+++ b/src/platform/adapters/token/veryfront/api-client.test.ts
@@ -10,6 +10,7 @@ import { MAX_VERYFRONT_API_RETRIES } from "#veryfront/utils/config-resource-limi
 import { TokenStorageApiClient } from "./api-client.ts";
 import { VeryfrontError } from "#veryfront/errors/types.ts";
 import type { VeryfrontTokenConfig } from "./types.ts";
+import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 
 function createConfig(overrides: Partial<VeryfrontTokenConfig> = {}): VeryfrontTokenConfig {
   return {
@@ -83,8 +84,7 @@ describe("platform/adapters/token/veryfront/api-client", () => {
     });
 
     it("validates successful response payloads", async () => {
-      const originalFetch = globalThis.fetch;
-      globalThis.fetch = () => Promise.resolve(Response.json({ value: 42 }));
+      installMockFetch(() => Promise.resolve(Response.json({ value: 42 })));
 
       try {
         const client = new TokenStorageApiClient(createConfig());
@@ -94,7 +94,7 @@ describe("platform/adapters/token/veryfront/api-client", () => {
           "Malformed get response",
         );
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
   });
@@ -137,8 +137,7 @@ describe("platform/adapters/token/veryfront/api-client", () => {
     });
 
     it("validates the returned key array", async () => {
-      const originalFetch = globalThis.fetch;
-      globalThis.fetch = () => Promise.resolve(Response.json({ keys: ["valid", 42] }));
+      installMockFetch(() => Promise.resolve(Response.json({ keys: ["valid", 42] })));
 
       try {
         const client = new TokenStorageApiClient(createConfig());
@@ -148,7 +147,7 @@ describe("platform/adapters/token/veryfront/api-client", () => {
           "Malformed list response",
         );
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
   });
@@ -163,18 +162,19 @@ describe("platform/adapters/token/veryfront/api-client", () => {
 
   describe("request and response lifecycle", () => {
     it("preserves configured base paths for every endpoint", async () => {
-      const originalFetch = globalThis.fetch;
       const requests: string[] = [];
-      globalThis.fetch = ((url: RequestInfo | URL, init?: RequestInit) => {
-        requests.push(String(url));
-        if (init?.method === "PUT" || init?.method === "DELETE") {
-          return Promise.resolve(new Response(null, { status: 204 }));
-        }
-        if (String(url).endsWith("/tokens")) {
-          return Promise.resolve(Response.json({ keys: [] }));
-        }
-        return Promise.resolve(Response.json({ value: "encrypted" }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((url: RequestInfo | URL, init?: RequestInit) => {
+          requests.push(String(url));
+          if (init?.method === "PUT" || init?.method === "DELETE") {
+            return Promise.resolve(new Response(null, { status: 204 }));
+          }
+          if (String(url).endsWith("/tokens")) {
+            return Promise.resolve(Response.json({ keys: [] }));
+          }
+          return Promise.resolve(Response.json({ value: "encrypted" }));
+        }) as typeof fetch,
+      );
 
       try {
         const client = new TokenStorageApiClient(createConfig({
@@ -192,19 +192,18 @@ describe("platform/adapters/token/veryfront/api-client", () => {
           "https://api.example.com/control/v1/projects/test-project/tokens",
         ]);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
 
     it("consumes successful and not-found response bodies before returning", async () => {
-      const originalFetch = globalThis.fetch;
       const createdResponses = [
         new Response("missing", { status: 404 }),
         new Response("stored", { status: 200 }),
         new Response("already absent", { status: 404 }),
       ];
       const responses = [...createdResponses];
-      globalThis.fetch = () => Promise.resolve(responses.shift()!);
+      installMockFetch(() => Promise.resolve(responses.shift()!));
 
       try {
         const client = new TokenStorageApiClient(createConfig());
@@ -215,29 +214,29 @@ describe("platform/adapters/token/veryfront/api-client", () => {
         assertEquals(responses.length, 0);
         assertEquals(createdResponses.every((response) => response.bodyUsed), true);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
 
     it("rejects empty keys at the client boundary before fetching", async () => {
-      const originalFetch = globalThis.fetch;
       let fetchCalls = 0;
-      globalThis.fetch = (() => {
-        fetchCalls++;
-        return Promise.resolve(Response.json({ value: "unexpected" }));
-      }) as typeof fetch;
+      installMockFetch(
+        (() => {
+          fetchCalls++;
+          return Promise.resolve(Response.json({ value: "unexpected" }));
+        }) as typeof fetch,
+      );
 
       try {
         const client = new TokenStorageApiClient(createConfig());
         await assertRejects(() => client.get(""), TypeError, "non-empty");
         assertEquals(fetchCalls, 0);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
 
     it("bounds and cancels oversized successful response bodies", async () => {
-      const originalFetch = globalThis.fetch;
       let cancelled = false;
       const body = new ReadableStream<Uint8Array>({
         start(controller) {
@@ -247,7 +246,7 @@ describe("platform/adapters/token/veryfront/api-client", () => {
           cancelled = true;
         },
       });
-      globalThis.fetch = () => Promise.resolve(new Response(body));
+      installMockFetch(() => Promise.resolve(new Response(body)));
 
       try {
         const client = new TokenStorageApiClient(createConfig());
@@ -258,20 +257,21 @@ describe("platform/adapters/token/veryfront/api-client", () => {
         );
         assertEquals(cancelled, true);
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
 
     it("retries rate-limited reads instead of failing the caller", async () => {
-      const originalFetch = globalThis.fetch;
       let fetchCalls = 0;
-      globalThis.fetch = (() => {
-        fetchCalls++;
-        if (fetchCalls === 1) {
-          return Promise.resolve(new Response("slow down", { status: 429 }));
-        }
-        return Promise.resolve(Response.json({ value: "secret" }));
-      }) as typeof fetch;
+      installMockFetch(
+        (() => {
+          fetchCalls++;
+          if (fetchCalls === 1) {
+            return Promise.resolve(new Response("slow down", { status: 429 }));
+          }
+          return Promise.resolve(Response.json({ value: "secret" }));
+        }) as typeof fetch,
+      );
 
       try {
         const client = new TokenStorageApiClient(createConfig({
@@ -284,29 +284,30 @@ describe("platform/adapters/token/veryfront/api-client", () => {
         );
         assertEquals(fetchCalls, 2, "the rate-limited attempt must be retried exactly once");
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
 
     it("cancels the unread body of a retried server error", async () => {
-      const originalFetch = globalThis.fetch;
       let cancelled = false;
       let fetchCalls = 0;
-      globalThis.fetch = (() => {
-        fetchCalls++;
-        if (fetchCalls === 1) {
-          const body = new ReadableStream<Uint8Array>({
-            start(controller) {
-              controller.enqueue(new Uint8Array(16));
-            },
-            cancel() {
-              cancelled = true;
-            },
-          });
-          return Promise.resolve(new Response(body, { status: 500 }));
-        }
-        return Promise.resolve(Response.json({ value: "ok" }));
-      }) as typeof fetch;
+      installMockFetch(
+        (() => {
+          fetchCalls++;
+          if (fetchCalls === 1) {
+            const body = new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(new Uint8Array(16));
+              },
+              cancel() {
+                cancelled = true;
+              },
+            });
+            return Promise.resolve(new Response(body, { status: 500 }));
+          }
+          return Promise.resolve(Response.json({ value: "ok" }));
+        }) as typeof fetch,
+      );
 
       try {
         const client = new TokenStorageApiClient(createConfig({
@@ -323,7 +324,7 @@ describe("platform/adapters/token/veryfront/api-client", () => {
           "a retried 5xx body must be cancelled so the connection is not held open",
         );
       } finally {
-        globalThis.fetch = originalFetch;
+        restoreMockFetch();
       }
     });
   });

--- a/src/platform/adapters/token/veryfront/api-client.test.ts
+++ b/src/platform/adapters/token/veryfront/api-client.test.ts
@@ -261,5 +261,70 @@ describe("platform/adapters/token/veryfront/api-client", () => {
         globalThis.fetch = originalFetch;
       }
     });
+
+    it("retries rate-limited reads instead of failing the caller", async () => {
+      const originalFetch = globalThis.fetch;
+      let fetchCalls = 0;
+      globalThis.fetch = (() => {
+        fetchCalls++;
+        if (fetchCalls === 1) {
+          return Promise.resolve(new Response("slow down", { status: 429 }));
+        }
+        return Promise.resolve(Response.json({ value: "secret" }));
+      }) as typeof fetch;
+
+      try {
+        const client = new TokenStorageApiClient(createConfig({
+          retry: { maxRetries: 1, initialDelay: 0, maxDelay: 0 },
+        }));
+        assertEquals(
+          await client.get("key"),
+          "secret",
+          "a 429 must be retried, not surfaced as a failed token read",
+        );
+        assertEquals(fetchCalls, 2, "the rate-limited attempt must be retried exactly once");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("cancels the unread body of a retried server error", async () => {
+      const originalFetch = globalThis.fetch;
+      let cancelled = false;
+      let fetchCalls = 0;
+      globalThis.fetch = (() => {
+        fetchCalls++;
+        if (fetchCalls === 1) {
+          const body = new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new Uint8Array(16));
+            },
+            cancel() {
+              cancelled = true;
+            },
+          });
+          return Promise.resolve(new Response(body, { status: 500 }));
+        }
+        return Promise.resolve(Response.json({ value: "ok" }));
+      }) as typeof fetch;
+
+      try {
+        const client = new TokenStorageApiClient(createConfig({
+          retry: { maxRetries: 1, initialDelay: 0, maxDelay: 0 },
+        }));
+        assertEquals(
+          await client.get("key"),
+          "ok",
+          "the retried attempt must serve the caller",
+        );
+        assertEquals(
+          cancelled,
+          true,
+          "a retried 5xx body must be cancelled so the connection is not held open",
+        );
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
   });
 });

--- a/src/platform/adapters/token/veryfront/memory-adapter.test.ts
+++ b/src/platform/adapters/token/veryfront/memory-adapter.test.ts
@@ -55,6 +55,40 @@ describe("platform/adapters/token/veryfront/memory-adapter", () => {
       assertThrows(() => adapter.set("", "value"), TypeError, "non-empty");
       assertThrows(() => adapter.delete(""), TypeError, "non-empty");
     });
+
+    it("rejects control characters, oversized identifiers, and non-string values", () => {
+      const adapter = createAdapter();
+      assertThrows(
+        () => adapter.get("user\u0000:gmail"),
+        TypeError,
+        "control characters",
+        "NUL in a key must be rejected",
+      );
+      assertThrows(
+        () => adapter.set("a\nb", "v"),
+        TypeError,
+        "control characters",
+        "CR/LF in a key must be rejected",
+      );
+      assertThrows(
+        () => adapter.get("a".repeat(4097)),
+        RangeError,
+        "code units",
+        "keys past 4096 code units must be rejected",
+      );
+      assertThrows(
+        () => adapter.list("user\u0007"),
+        TypeError,
+        "control characters",
+        "list prefixes are validated too",
+      );
+      assertThrows(
+        () => adapter.set("k", 42 as unknown as string),
+        TypeError,
+        "must be a string",
+        "non-string values must be rejected",
+      );
+    });
   });
 
   describe("delete", () => {

--- a/src/platform/adapters/veryfront-api-client.test.ts
+++ b/src/platform/adapters/veryfront-api-client.test.ts
@@ -158,7 +158,8 @@ describe("VeryfrontApiClient", () => {
 
   describe("file operations", () => {
     it("should handle pagination in listAllFiles", async () => {
-      let page = 0;
+      const fileListUrls: string[] = [];
+      const unexpectedCursors: string[] = [];
 
       await withMockFetch(
         (url) => {
@@ -182,9 +183,11 @@ describe("VeryfrontApiClient", () => {
           }
 
           if (urlStr.includes("/projects/test-project/files?") && urlStr.includes("branch=main")) {
-            page++;
+            fileListUrls.push(urlStr);
+            const cursor = new URL(urlStr).searchParams.get("cursor");
+            if (cursor !== null && cursor !== "page2") unexpectedCursors.push(cursor);
 
-            if (page === 1) {
+            if (cursor === null && fileListUrls.length === 1) {
               return Promise.resolve(
                 new Response(
                   JSON.stringify({
@@ -216,24 +219,39 @@ describe("VeryfrontApiClient", () => {
               );
             }
 
+            if (cursor === "page2") {
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    data: [
+                      {
+                        path: "file3.ts",
+                        content: "// file3",
+                        size: 300,
+                        type: "file",
+                        updated_at: "2024-01-01",
+                      },
+                    ],
+                    page_info: {
+                      self: "page2",
+                      first: null,
+                      next: null,
+                      prev: "page1",
+                    },
+                  }),
+                  { status: 200, headers: { "Content-Type": "application/json" } },
+                ),
+              );
+            }
+
+            // Terminate any request that repeats an already-served cursor so a
+            // client that never forwards page_info.next fails an assertion
+            // instead of looping forever.
             return Promise.resolve(
               new Response(
                 JSON.stringify({
-                  data: [
-                    {
-                      path: "file3.ts",
-                      content: "// file3",
-                      size: 300,
-                      type: "file",
-                      updated_at: "2024-01-01",
-                    },
-                  ],
-                  page_info: {
-                    self: "page2",
-                    first: null,
-                    next: null,
-                    prev: "page1",
-                  },
+                  data: [],
+                  page_info: { self: null, first: null, next: null, prev: null },
                 }),
                 { status: 200, headers: { "Content-Type": "application/json" } },
               ),
@@ -261,6 +279,26 @@ describe("VeryfrontApiClient", () => {
           assertEquals(files[0]?.path, "file1.ts");
           assertEquals(files[1]?.path, "file2.ts");
           assertEquals(files[2]?.path, "file3.ts");
+          assertEquals(
+            unexpectedCursors,
+            [],
+            "listAllFiles must only send cursors the API handed back",
+          );
+          assertEquals(
+            fileListUrls.length,
+            2,
+            "listAllFiles must issue exactly one request per page",
+          );
+          assertEquals(
+            new URL(fileListUrls[0]!).searchParams.get("cursor"),
+            null,
+            "the first page request must not carry a cursor",
+          );
+          assertEquals(
+            new URL(fileListUrls[1]!).searchParams.get("cursor"),
+            "page2",
+            "the follow-up request must carry the cursor returned in page_info.next",
+          );
         },
       );
     });

--- a/src/platform/adapters/veryfront-api-client/client.test.ts
+++ b/src/platform/adapters/veryfront-api-client/client.test.ts
@@ -16,6 +16,10 @@ function createClient(config: VeryfrontAPIConfig = baseConfig): VeryfrontApiClie
   return new VeryfrontApiClient(config);
 }
 
+type ResolvedRetryConfig = {
+  config: { retry: { maxRetries: number; initialDelay: number; maxDelay: number } };
+};
+
 describe("VeryfrontApiClient", () => {
   describe("token priority", () => {
     it("uses config token when no request token set", () => {
@@ -59,6 +63,27 @@ describe("VeryfrontApiClient", () => {
       client.setProjectSlug("request-slug");
       client.clearProjectSlug();
       assertEquals(client.getProjectSlug(), "config-slug");
+    });
+
+    it("project-scoped calls fail fast without a slug", () => {
+      const client = createClient({ apiBaseUrl: "http://test.api", apiToken: "token" });
+      const listError = assertThrows(
+        () => client.listFiles(),
+        VeryfrontError,
+        "No project slug configured",
+        "listFiles must refuse to build a request without a project slug",
+      );
+      assertEquals(
+        (listError as VeryfrontError).status,
+        400,
+        "a missing project slug must be reported as a 400, not a downstream failure",
+      );
+      assertThrows(
+        () => client.getFile("index.tsx"),
+        VeryfrontError,
+        "No project slug configured",
+        "getFile must refuse to build a request without a project slug",
+      );
     });
   });
 
@@ -113,6 +138,31 @@ describe("VeryfrontApiClient", () => {
       assertEquals(client.isInitialized(), false);
     });
 
+    it("coalesces concurrent initialize() calls into one getProject round trip", async () => {
+      const client = createClient();
+      let getProjectCalls = 0;
+      const mutable = client as unknown as {
+        operations: { getProject: (projectRef: string) => Promise<{ id: string }> };
+      };
+      mutable.operations.getProject = () => {
+        getProjectCalls++;
+        return Promise.resolve({ id: "11111111-2222-3333-4444-555555555555" });
+      };
+
+      await Promise.all([client.initialize(), client.initialize()]);
+
+      assertEquals(
+        getProjectCalls,
+        1,
+        "concurrent initialize() calls must share one getProject round trip",
+      );
+      assertEquals(
+        client.isInitialized(),
+        true,
+        "the coalesced initialization must still mark the client initialized",
+      );
+    });
+
     it("initialize throws when no slug available", async () => {
       const client = createClient({ apiBaseUrl: "http://test.api", apiToken: "token" });
       await assertRejects(
@@ -126,7 +176,11 @@ describe("VeryfrontApiClient", () => {
   describe("retry config", () => {
     it("uses default retry config", () => {
       const client = createClient({ apiBaseUrl: "http://test.api" });
-      assertEquals(client.isProxyMode(), false);
+      assertEquals(
+        (client as unknown as ResolvedRetryConfig).config.retry,
+        { maxRetries: 3, initialDelay: 1000, maxDelay: 10000 },
+        "the client must apply the documented default retry policy",
+      );
     });
 
     it("accepts custom retry config", () => {
@@ -134,17 +188,63 @@ describe("VeryfrontApiClient", () => {
         apiBaseUrl: "http://test.api",
         retry: { maxRetries: 5, initialDelay: 100, maxDelay: 1000 },
       });
-      assertEquals(client.isProxyMode(), false);
+      assertEquals(
+        (client as unknown as ResolvedRetryConfig).config.retry,
+        { maxRetries: 5, initialDelay: 100, maxDelay: 1000 },
+        "a caller-supplied retry policy must reach the transport unchanged",
+      );
     });
   });
 
   describe("searchFilesWithContent", () => {
-    it("should expose searchFilesWithContent method for pattern-based file search", () => {
+    it("should expose searchFilesWithContent method for pattern-based file search", async () => {
       const client = createClient();
+      const listed: Array<{ limit?: number; pattern?: string }> = [];
+      let perFileReads = 0;
+      const mutable = client as unknown as {
+        operations: {
+          listBranchFiles: (
+            projectRef: string,
+            branchRef: string,
+            options: { limit?: number; pattern?: string },
+          ) => Promise<{ files: Array<{ path: string; content?: string }> }>;
+          getBranchFile: () => Promise<never>;
+        };
+      };
+      mutable.operations.listBranchFiles = (_projectRef, _branchRef, options) => {
+        listed.push(options);
+        return Promise.resolve({
+          files: [{ path: "components/Button.tsx", content: "export default Button;" }],
+        });
+      };
+      mutable.operations.getBranchFile = () => {
+        perFileReads++;
+        return Promise.reject(new Error("unexpected per-file read"));
+      };
+
+      assertEquals(
+        await client.searchFilesWithContent("components/Button.*"),
+        [{ path: "components/Button.tsx", content: "export default Button;" }],
+        "searchFilesWithContent must return the matched files with their content",
+      );
+      assertEquals(
+        listed[0]?.pattern,
+        "components/Button.*",
+        "searchFilesWithContent must forward the caller pattern",
+      );
       // searchFilesWithContent uses limit: 100 (up from 20) to support projects
       // with many files (e.g., 138 XML files) that would otherwise cause
       // excessive cache misses and individual API round-trips.
-      assertEquals(typeof client.searchFilesWithContent, "function");
+      assertEquals(
+        listed[0]?.limit,
+        100,
+        "searchFilesWithContent must request 100 files per page to avoid per-file round trips",
+      );
+      assertEquals(
+        perFileReads,
+        0,
+        "files returned with content must not be re-fetched individually",
+      );
     });
   });
 
@@ -241,6 +341,12 @@ describe("VeryfrontApiClient", () => {
       assertEquals(client.isInitialized(), true);
       client.reset();
       assertEquals(client.isInitialized(), false);
+      assertThrows(
+        () => client.getProjectId(),
+        VeryfrontError,
+        "not initialized",
+        "reset must clear the cached project id so later calls cannot target the previous project",
+      );
     });
   });
 
@@ -289,7 +395,7 @@ describe("VeryfrontApiClient", () => {
   describe("bounded content probes", () => {
     it("forwards expected-missing options for branch and published exact reads", async () => {
       const client = createClient();
-      const calls: Array<[string, boolean | undefined]> = [];
+      const calls: Array<[string, string, string, number, boolean | undefined]> = [];
       const mutable = client as unknown as {
         operations: {
           getBranchFileContentBytesWithinLimit: (
@@ -309,23 +415,23 @@ describe("VeryfrontApiClient", () => {
         };
       };
       mutable.operations.getBranchFileContentBytesWithinLimit = (
-        _projectRef,
-        _branchRef,
+        projectRef,
+        branchRef,
         path,
-        _maximumBytes,
+        maximumBytes,
         options,
       ) => {
-        calls.push([path, options?.expectedMissing]);
+        calls.push([projectRef, branchRef, path, maximumBytes, options?.expectedMissing]);
         return Promise.resolve(new Uint8Array([1]));
       };
       mutable.operations.getReleaseFileContentBytesWithinLimit = (
-        _projectRef,
-        _releaseId,
+        projectRef,
+        releaseId,
         path,
-        _maximumBytes,
+        maximumBytes,
         options,
       ) => {
-        calls.push([path, options?.expectedMissing]);
+        calls.push([projectRef, releaseId, path, maximumBytes, options?.expectedMissing]);
         return Promise.resolve(new Uint8Array([2]));
       };
 
@@ -351,10 +457,14 @@ describe("VeryfrontApiClient", () => {
         ],
         [2],
       );
-      assertEquals(calls, [
-        ["pages/home.tsx", true],
-        ["pages/home.tsx", true],
-      ]);
+      assertEquals(
+        calls,
+        [
+          ["config-slug", "main", "pages/home.tsx", 1, true],
+          ["config-slug", "release-id", "pages/home.tsx", 1, true],
+        ],
+        "bounded reads must forward the project ref, the context ref, the byte cap, and expectedMissing unchanged",
+      );
     });
   });
 });

--- a/src/platform/adapters/veryfront-api-client/operations.test.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.test.ts
@@ -248,9 +248,80 @@ describe("VeryfrontAPIOperations", () => {
         };
       });
 
-      await createOps().getBranchFile("project-slug", "main", "app/api/ag-ui/route.ts");
+      const detail = await createOps().getBranchFile(
+        "project-slug",
+        "main",
+        "app/api/ag-ui/route.ts",
+      );
 
       assertStringIncludes(requestedUrl, "include_server_functions=true");
+      assertEquals(detail, {
+        path: "app/api/ag-ui/route.ts",
+        content: "export const POST = () => new Response();",
+        id: "file-id",
+        type: "function",
+        size: 40,
+      }, "branch file detail must map every payload field");
+    });
+
+    it("maps every environment file detail field returned by the API", async () => {
+      stubJsonFetch(() => ({
+        id: "file-id",
+        version_id: "version-id",
+        path: "app/api/agents/route.ts",
+        content: "export const GET = () => new Response();",
+        size: 39,
+        type: "function",
+        updated_at: "2026-04-23T00:00:00.000Z",
+        environment_id: "environment-id",
+        environment_name: "production",
+        release_id: "release-id",
+        release_version: "v1",
+      }));
+
+      const detail = await createOps().getEnvironmentFile(
+        "project-slug",
+        "production",
+        "app/api/agents/route.ts",
+      );
+
+      assertEquals(detail, {
+        path: "app/api/agents/route.ts",
+        content: "export const GET = () => new Response();",
+        id: "file-id",
+        version_id: "version-id",
+        release_id: "release-id",
+        release_version: "v1",
+      }, "environment file detail must map every payload field");
+    });
+
+    it("maps every release file detail field returned by the API", async () => {
+      stubJsonFetch(() => ({
+        id: "file-id",
+        version_id: "version-id",
+        path: "pages/api/articles-2.ts",
+        content: "export default () => {}",
+        size: 23,
+        type: "function",
+        updated_at: "2026-04-23T00:00:00.000Z",
+        release_id: "release-id",
+        release_version: "v1",
+      }));
+
+      const detail = await createOps().getReleaseFile(
+        "project-slug",
+        "release-id",
+        "pages/api/articles-2.ts",
+      );
+
+      assertEquals(detail, {
+        path: "pages/api/articles-2.ts",
+        content: "export default () => {}",
+        id: "file-id",
+        version_id: "version-id",
+        release_id: "release-id",
+        release_version: "v1",
+      }, "release file detail must map every payload field");
     });
 
     it("warn-logs normal 404s for branch file content reads", async () => {
@@ -469,6 +540,96 @@ describe("VeryfrontAPIOperations", () => {
       await createOps().getReleaseFile("project-slug", "release-id", "pages/api/articles-2.ts");
 
       assertStringIncludes(requestedUrl, "include_server_functions=true");
+    });
+  });
+
+  describe("lookupProjectByDomain", () => {
+    it("strips the port and matches environment domains case-insensitively", async () => {
+      let requestedUrl = "";
+      stubJsonFetch((url) => {
+        requestedUrl = url;
+        return {
+          id: "550e8400-e29b-41d4-a716-446655440000",
+          name: "P",
+          slug: "p",
+          environments: [{
+            id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+            name: "production",
+            domains: ["APP.EXAMPLE.COM"],
+            active_release_id: "6ba7b811-9dad-11d1-80b4-00c04fd430c8",
+          }],
+        };
+      });
+
+      const result = await createOps().lookupProjectByDomain("app.example.com:8443");
+
+      assertEquals(
+        new URL(requestedUrl).pathname,
+        "/projects/app.example.com",
+        "the lookup path must drop the :port suffix",
+      );
+      assertEquals(
+        result?.environment?.name,
+        "production",
+        "domain matching must be case-insensitive",
+      );
+      assertEquals(
+        result?.release_id,
+        "6ba7b811-9dad-11d1-80b4-00c04fd430c8",
+        "the matching environment's active release must be returned",
+      );
+    });
+
+    it("resolves to null when the domain has no project", async () => {
+      const originalWarn = console.warn;
+      console.warn = () => {};
+      globalThis.fetch = (() =>
+        Promise.resolve(
+          new Response("{}", {
+            status: 404,
+            statusText: "Not Found",
+            headers: { "Content-Type": "application/json" },
+          }),
+        )) as typeof fetch;
+
+      try {
+        assertEquals(
+          await createOps().lookupProjectByDomain("missing.example.com"),
+          null,
+          "a 404 lookup must resolve to null, not throw",
+        );
+      } finally {
+        console.warn = originalWarn;
+      }
+    });
+
+    it("rethrows non-404 upstream failures", async () => {
+      const originalWarn = console.warn;
+      console.warn = () => {};
+      globalThis.fetch = (() =>
+        Promise.resolve(
+          new Response("{}", {
+            status: 500,
+            statusText: "Internal Server Error",
+            headers: { "Content-Type": "application/json" },
+          }),
+        )) as typeof fetch;
+      const ops = new VeryfrontAPIOperations(
+        "https://api.example.com",
+        "token",
+        { maxRetries: 0, initialDelay: 0, maxDelay: 0 },
+      );
+
+      try {
+        await assertRejects(
+          () => ops.lookupProjectByDomain("app.example.com"),
+          VeryfrontError,
+          undefined,
+          "a 500 must surface as an error instead of a null lookup",
+        );
+      } finally {
+        console.warn = originalWarn;
+      }
     });
   });
 

--- a/src/platform/adapters/veryfront-api-client/operations.test.ts
+++ b/src/platform/adapters/veryfront-api-client/operations.test.ts
@@ -21,6 +21,7 @@ import {
   type TransportRequestInit,
 } from "#veryfront/platform/adapters/veryfront-api-transport.ts";
 import { VeryfrontAPIOperations } from "./operations.ts";
+import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 
 function createOps(
   token: string | (() => string) = "token",
@@ -90,22 +91,22 @@ function observeAbortListenerBalance(signal: AbortSignal): {
 }
 
 describe("VeryfrontAPIOperations", () => {
-  const originalFetch = globalThis.fetch;
-
   function stubJsonFetch(handler: (url: string, init?: RequestInit) => unknown): void {
-    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
-      const body = handler(String(input), init);
-      return Promise.resolve(
-        new Response(JSON.stringify(body), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
-      );
-    }) as typeof fetch;
+    installMockFetch(
+      ((input: RequestInfo | URL, init?: RequestInit) => {
+        const body = handler(String(input), init);
+        return Promise.resolve(
+          new Response(JSON.stringify(body), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+      }) as typeof fetch,
+    );
   }
 
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
     __resetLogRecordEmitterForTests();
   });
 
@@ -329,14 +330,16 @@ describe("VeryfrontAPIOperations", () => {
       const originalWarn = console.warn;
       console.warn = () => {};
       __registerLogRecordEmitter((entry) => entries.push(entry));
-      globalThis.fetch = (() =>
-        Promise.resolve(
-          new Response(JSON.stringify({ error: "Not found" }), {
-            status: 404,
-            statusText: "Not Found",
-            headers: { "Content-Type": "application/json" },
-          }),
-        )) as typeof fetch;
+      installMockFetch(
+        (() =>
+          Promise.resolve(
+            new Response(JSON.stringify({ error: "Not found" }), {
+              status: 404,
+              statusText: "Not Found",
+              headers: { "Content-Type": "application/json" },
+            }),
+          )) as typeof fetch,
+      );
 
       try {
         await assertRejects(
@@ -363,14 +366,16 @@ describe("VeryfrontAPIOperations", () => {
       const originalWarn = console.warn;
       console.warn = () => {};
       __registerLogRecordEmitter((entry) => entries.push(entry));
-      globalThis.fetch = (() =>
-        Promise.resolve(
-          new Response(JSON.stringify({ error: "Not found" }), {
-            status: 404,
-            statusText: "Not Found",
-            headers: { "Content-Type": "application/json" },
-          }),
-        )) as typeof fetch;
+      installMockFetch(
+        (() =>
+          Promise.resolve(
+            new Response(JSON.stringify({ error: "Not found" }), {
+              status: 404,
+              statusText: "Not Found",
+              headers: { "Content-Type": "application/json" },
+            }),
+          )) as typeof fetch,
+      );
 
       try {
         await assertRejects(
@@ -400,14 +405,16 @@ describe("VeryfrontAPIOperations", () => {
       const originalWarn = console.warn;
       console.warn = () => {};
       __registerLogRecordEmitter((entry) => entries.push(entry));
-      globalThis.fetch = (() =>
-        Promise.resolve(
-          new Response(JSON.stringify({ error: "Not found" }), {
-            status: 404,
-            statusText: "Not Found",
-            headers: { "Content-Type": "application/json" },
-          }),
-        )) as typeof fetch;
+      installMockFetch(
+        (() =>
+          Promise.resolve(
+            new Response(JSON.stringify({ error: "Not found" }), {
+              status: 404,
+              statusText: "Not Found",
+              headers: { "Content-Type": "application/json" },
+            }),
+          )) as typeof fetch,
+      );
 
       try {
         await assertRejects(
@@ -437,14 +444,16 @@ describe("VeryfrontAPIOperations", () => {
       const originalWarn = console.warn;
       console.warn = () => {};
       __registerLogRecordEmitter((entry) => entries.push(entry));
-      globalThis.fetch = (() =>
-        Promise.resolve(
-          new Response(JSON.stringify({ error: "Not found" }), {
-            status: 404,
-            statusText: "Not Found",
-            headers: { "Content-Type": "application/json" },
-          }),
-        )) as typeof fetch;
+      installMockFetch(
+        (() =>
+          Promise.resolve(
+            new Response(JSON.stringify({ error: "Not found" }), {
+              status: 404,
+              statusText: "Not Found",
+              headers: { "Content-Type": "application/json" },
+            }),
+          )) as typeof fetch,
+      );
 
       try {
         await assertRejects(
@@ -474,14 +483,16 @@ describe("VeryfrontAPIOperations", () => {
       const originalWarn = console.warn;
       console.warn = () => {};
       __registerLogRecordEmitter((entry) => entries.push(entry));
-      globalThis.fetch = (() =>
-        Promise.resolve(
-          new Response(JSON.stringify({ error: "Invalid authentication token" }), {
-            status: 401,
-            statusText: "Unauthorized",
-            headers: { "Content-Type": "application/json" },
-          }),
-        )) as typeof fetch;
+      installMockFetch(
+        (() =>
+          Promise.resolve(
+            new Response(JSON.stringify({ error: "Invalid authentication token" }), {
+              status: 401,
+              statusText: "Unauthorized",
+              headers: { "Content-Type": "application/json" },
+            }),
+          )) as typeof fetch,
+      );
 
       try {
         await assertRejects(
@@ -583,14 +594,16 @@ describe("VeryfrontAPIOperations", () => {
     it("resolves to null when the domain has no project", async () => {
       const originalWarn = console.warn;
       console.warn = () => {};
-      globalThis.fetch = (() =>
-        Promise.resolve(
-          new Response("{}", {
-            status: 404,
-            statusText: "Not Found",
-            headers: { "Content-Type": "application/json" },
-          }),
-        )) as typeof fetch;
+      installMockFetch(
+        (() =>
+          Promise.resolve(
+            new Response("{}", {
+              status: 404,
+              statusText: "Not Found",
+              headers: { "Content-Type": "application/json" },
+            }),
+          )) as typeof fetch,
+      );
 
       try {
         assertEquals(
@@ -606,14 +619,16 @@ describe("VeryfrontAPIOperations", () => {
     it("rethrows non-404 upstream failures", async () => {
       const originalWarn = console.warn;
       console.warn = () => {};
-      globalThis.fetch = (() =>
-        Promise.resolve(
-          new Response("{}", {
-            status: 500,
-            statusText: "Internal Server Error",
-            headers: { "Content-Type": "application/json" },
-          }),
-        )) as typeof fetch;
+      installMockFetch(
+        (() =>
+          Promise.resolve(
+            new Response("{}", {
+              status: 500,
+              statusText: "Internal Server Error",
+              headers: { "Content-Type": "application/json" },
+            }),
+          )) as typeof fetch,
+      );
       const ops = new VeryfrontAPIOperations(
         "https://api.example.com",
         "token",
@@ -636,14 +651,16 @@ describe("VeryfrontAPIOperations", () => {
   describe("bounded file content", () => {
     it("returns exact UTF-8 bytes through the normal branch file endpoint", async () => {
       let requestedUrl = "";
-      globalThis.fetch = ((input: RequestInfo | URL) => {
-        requestedUrl = String(input);
-        return Promise.resolve(
-          new Response(JSON.stringify({ ignored: [1, 2, 3], content: "é" }), {
-            headers: { "Content-Type": "application/json" },
-          }),
-        );
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL) => {
+          requestedUrl = String(input);
+          return Promise.resolve(
+            new Response(JSON.stringify({ ignored: [1, 2, 3], content: "é" }), {
+              headers: { "Content-Type": "application/json" },
+            }),
+          );
+        }) as typeof fetch,
+      );
 
       const bytes = await createOps().getBranchFileContentBytesWithinLimit(
         "project-slug",
@@ -662,10 +679,12 @@ describe("VeryfrontAPIOperations", () => {
       let fetchCalls = 0;
       let parseCalls = 0;
       const originalJsonParse = JSON.parse;
-      globalThis.fetch = (() => {
-        fetchCalls++;
-        return Promise.resolve(new Response(JSON.stringify({ content: "xx" })));
-      }) as typeof fetch;
+      installMockFetch(
+        (() => {
+          fetchCalls++;
+          return Promise.resolve(new Response(JSON.stringify({ content: "xx" })));
+        }) as typeof fetch,
+      );
       JSON.parse = ((...args: Parameters<typeof JSON.parse>) => {
         parseCalls++;
         return Reflect.apply(originalJsonParse, JSON, args);
@@ -730,17 +749,19 @@ describe("VeryfrontAPIOperations", () => {
       const started = new Promise<void>((resolve) => {
         requestStarted = resolve;
       });
-      globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) => {
-        fetchCalls++;
-        const signal = init?.signal;
-        requestStarted();
-        return new Promise<Response>((_resolve, reject) => {
-          if (!signal) return;
-          const rejectAbort = () => reject(signal.reason);
-          if (signal.aborted) rejectAbort();
-          else signal.addEventListener("abort", rejectAbort, { once: true });
-        });
-      }) as typeof fetch;
+      installMockFetch(
+        ((_input: RequestInfo | URL, init?: RequestInit) => {
+          fetchCalls++;
+          const signal = init?.signal;
+          requestStarted();
+          return new Promise<Response>((_resolve, reject) => {
+            if (!signal) return;
+            const rejectAbort = () => reject(signal.reason);
+            if (signal.aborted) rejectAbort();
+            else signal.addEventListener("abort", rejectAbort, { once: true });
+          });
+        }) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport<unknown>({
         baseUrl: "https://api.example.com",
         getToken: () => "token",
@@ -763,17 +784,19 @@ describe("VeryfrontAPIOperations", () => {
         const started = new Promise<void>((resolve) => {
           markStarted = resolve;
         });
-        globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) => {
-          observedSignal = init?.signal ?? undefined;
-          markStarted();
-          return new Promise<Response>((_resolve, reject) => {
-            observedSignal?.addEventListener(
-              "abort",
-              () => reject(observedSignal?.reason),
-              { once: true },
-            );
-          });
-        }) as typeof fetch;
+        installMockFetch(
+          ((_input: RequestInfo | URL, init?: RequestInit) => {
+            observedSignal = init?.signal ?? undefined;
+            markStarted();
+            return new Promise<Response>((_resolve, reject) => {
+              observedSignal?.addEventListener(
+                "abort",
+                () => reject(observedSignal?.reason),
+                { once: true },
+              );
+            });
+          }) as typeof fetch,
+        );
         const transport = createVeryfrontApiTransport<unknown>({
           baseUrl: "https://api.example.com",
           getToken: () => "token",
@@ -799,7 +822,7 @@ describe("VeryfrontAPIOperations", () => {
 
     it("detaches compatibility listeners after a successful request", async () => {
       await withoutAbortSignalAny(async () => {
-        globalThis.fetch = (() => Promise.resolve(new Response("{}"))) as typeof fetch;
+        installMockFetch((() => Promise.resolve(new Response("{}"))) as typeof fetch);
         const caller = new AbortController();
         const observation = observeAbortListenerBalance(caller.signal);
         try {
@@ -821,7 +844,7 @@ describe("VeryfrontAPIOperations", () => {
 
     it("detaches compatibility listeners after a non-abort failure", async () => {
       await withoutAbortSignalAny(async () => {
-        globalThis.fetch = (() => Promise.reject(new Error("network failed"))) as typeof fetch;
+        installMockFetch((() => Promise.reject(new Error("network failed"))) as typeof fetch);
         const caller = new AbortController();
         const observation = observeAbortListenerBalance(caller.signal);
         try {
@@ -848,12 +871,14 @@ describe("VeryfrontAPIOperations", () => {
     it("balances compatibility listeners across retry attempts", async () => {
       await withoutAbortSignalAny(async () => {
         let fetchCalls = 0;
-        globalThis.fetch = (() => {
-          fetchCalls++;
-          return fetchCalls === 1
-            ? Promise.reject(new Error("retryable failure"))
-            : Promise.resolve(new Response("{}"));
-        }) as typeof fetch;
+        installMockFetch(
+          (() => {
+            fetchCalls++;
+            return fetchCalls === 1
+              ? Promise.reject(new Error("retryable failure"))
+              : Promise.resolve(new Response("{}"));
+          }) as typeof fetch,
+        );
         const caller = new AbortController();
         const observation = observeAbortListenerBalance(caller.signal);
         try {
@@ -878,7 +903,7 @@ describe("VeryfrontAPIOperations", () => {
     it("reserves worst-case JSON escape bytes outside the non-value response budget", async () => {
       const body = '{"content":"\\u0000\\u0000"}';
       assertEquals(new TextEncoder().encode(body).byteLength, 26);
-      globalThis.fetch = (() => Promise.resolve(new Response(body))) as typeof fetch;
+      installMockFetch((() => Promise.resolve(new Response(body))) as typeof fetch);
       const transport = createVeryfrontApiTransport<unknown>({
         baseUrl: "https://api.example.com",
         getToken: () => "token",
@@ -899,10 +924,12 @@ describe("VeryfrontAPIOperations", () => {
       const body = '{"content":"","x":0}';
       assertEquals(new TextEncoder().encode(body).byteLength, 20);
       let fetchCalls = 0;
-      globalThis.fetch = (() => {
-        fetchCalls++;
-        return Promise.resolve(new Response(body));
-      }) as typeof fetch;
+      installMockFetch(
+        (() => {
+          fetchCalls++;
+          return Promise.resolve(new Response(body));
+        }) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport<unknown>({
         baseUrl: "https://api.example.com",
         getToken: () => "token",
@@ -931,21 +958,23 @@ describe("VeryfrontAPIOperations", () => {
     it("retries a body read aborted by the per-attempt timeout", async () => {
       let fetchCalls = 0;
       let cancellations = 0;
-      globalThis.fetch = (() => {
-        fetchCalls++;
-        return Promise.resolve(
-          new Response(
-            new ReadableStream<Uint8Array>({
-              pull() {
-                return new Promise<void>(() => {});
-              },
-              cancel() {
-                cancellations++;
-              },
-            }),
-          ),
-        );
-      }) as typeof fetch;
+      installMockFetch(
+        (() => {
+          fetchCalls++;
+          return Promise.resolve(
+            new Response(
+              new ReadableStream<Uint8Array>({
+                pull() {
+                  return new Promise<void>(() => {});
+                },
+                cancel() {
+                  cancellations++;
+                },
+              }),
+            ),
+          );
+        }) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport<unknown>({
         baseUrl: "https://api.example.com",
         getToken: () => "token",
@@ -968,15 +997,17 @@ describe("VeryfrontAPIOperations", () => {
 
     it("preserves a 400 status when its diagnostic body is malformed UTF-8", async () => {
       let fetchCalls = 0;
-      globalThis.fetch = (() => {
-        fetchCalls++;
-        return Promise.resolve(
-          new Response(new Uint8Array([0xc3, 0x28]), {
-            status: 400,
-            statusText: "Bad Request",
-          }),
-        );
-      }) as typeof fetch;
+      installMockFetch(
+        (() => {
+          fetchCalls++;
+          return Promise.resolve(
+            new Response(new Uint8Array([0xc3, 0x28]), {
+              status: 400,
+              statusText: "Bad Request",
+            }),
+          );
+        }) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport<unknown>({
         baseUrl: "https://api.example.com",
         getToken: () => "token",
@@ -995,15 +1026,17 @@ describe("VeryfrontAPIOperations", () => {
 
     it("retries a 500 even when its diagnostic body is malformed UTF-8", async () => {
       let fetchCalls = 0;
-      globalThis.fetch = (() => {
-        fetchCalls++;
-        return Promise.resolve(
-          new Response(new Uint8Array([0xc3, 0x28]), {
-            status: 500,
-            statusText: "Internal Server Error",
-          }),
-        );
-      }) as typeof fetch;
+      installMockFetch(
+        (() => {
+          fetchCalls++;
+          return Promise.resolve(
+            new Response(new Uint8Array([0xc3, 0x28]), {
+              status: 500,
+              statusText: "Internal Server Error",
+            }),
+          );
+        }) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport<unknown>({
         baseUrl: "https://api.example.com",
         getToken: () => "token",
@@ -1021,10 +1054,12 @@ describe("VeryfrontAPIOperations", () => {
 
     it("rejects invalid bounded options before fetching", async () => {
       let fetchCalls = 0;
-      globalThis.fetch = (() => {
-        fetchCalls++;
-        return Promise.resolve(new Response("{}"));
-      }) as typeof fetch;
+      installMockFetch(
+        (() => {
+          fetchCalls++;
+          return Promise.resolve(new Response("{}"));
+        }) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport<unknown>({
         baseUrl: "https://api.example.com",
         getToken: () => "token",
@@ -1072,18 +1107,20 @@ describe("VeryfrontAPIOperations", () => {
       let contentHashHeader: string | null = null;
       let contentTypeHeader: string | null = null;
       let requestedUrl = "";
-      globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
-        requestedUrl = String(input);
-        const headers = new Headers(init?.headers);
-        contentHashHeader = headers.get("x-vf-content-hash");
-        contentTypeHeader = headers.get("Content-Type");
-        return Promise.resolve(
-          new Response(JSON.stringify({ stored: true, existed: false }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          }),
-        );
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL, init?: RequestInit) => {
+          requestedUrl = String(input);
+          const headers = new Headers(init?.headers);
+          contentHashHeader = headers.get("x-vf-content-hash");
+          contentTypeHeader = headers.get("Content-Type");
+          return Promise.resolve(
+            new Response(JSON.stringify({ stored: true, existed: false }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }),
+          );
+        }) as typeof fetch,
+      );
 
       const bytes = new TextEncoder().encode("export const x = 1;");
       const res = await createOps().uploadReleaseAsset(
@@ -1156,18 +1193,20 @@ describe("VeryfrontAPIOperations", () => {
       let method = "";
       let contentType = "";
       let body: BodyInit | null | undefined;
-      globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
-        requestedUrl = String(input);
-        method = init?.method ?? "GET";
-        contentType = new Headers(init?.headers).get("content-type") ?? "";
-        body = init?.body;
-        return Promise.resolve(
-          new Response(JSON.stringify({ stored: true, existed: false }), {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          }),
-        );
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL, init?: RequestInit) => {
+          requestedUrl = String(input);
+          method = init?.method ?? "GET";
+          contentType = new Headers(init?.headers).get("content-type") ?? "";
+          body = init?.body;
+          return Promise.resolve(
+            new Response(JSON.stringify({ stored: true, existed: false }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+          );
+        }) as typeof fetch,
+      );
       const bytes = new TextEncoder().encode("export const value = 42;");
       const contentHash = await crypto.subtle.digest("SHA-256", bytes).then((digest) =>
         [...new Uint8Array(digest)].map((value) => value.toString(16).padStart(2, "0")).join("")
@@ -1193,10 +1232,12 @@ describe("VeryfrontAPIOperations", () => {
 
     it("rejects a local content hash mismatch before transport", async () => {
       let fetchCalls = 0;
-      globalThis.fetch = ((_input: RequestInfo | URL, _init?: RequestInit) => {
-        fetchCalls++;
-        return Promise.resolve(new Response("{}"));
-      }) as typeof fetch;
+      installMockFetch(
+        ((_input: RequestInfo | URL, _init?: RequestInit) => {
+          fetchCalls++;
+          return Promise.resolve(new Response("{}"));
+        }) as typeof fetch,
+      );
 
       await assertRejects(
         () =>

--- a/src/platform/adapters/veryfront-api-client/retry-handler.test.ts
+++ b/src/platform/adapters/veryfront-api-client/retry-handler.test.ts
@@ -3,6 +3,26 @@ import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { requestWithRetry } from "./retry-handler.ts";
 import { VeryfrontError } from "#veryfront/errors/types.ts";
+import {
+  type Context,
+  installGlobalTelemetryAPI,
+  type TextMapPropagator,
+  type TextMapSetter,
+} from "#veryfront/observability/tracing/api-shim.ts";
+
+const TEST_TRACEPARENT = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+
+const traceparentPropagator: TextMapPropagator = {
+  inject(_ctx: Context, carrier: unknown, setter?: TextMapSetter<unknown>): void {
+    setter?.set(carrier, "traceparent", TEST_TRACEPARENT);
+  },
+  extract(ctx: Context): Context {
+    return ctx;
+  },
+  fields(): string[] {
+    return ["traceparent"];
+  },
+};
 
 const originalFetch = globalThis.fetch;
 
@@ -63,6 +83,27 @@ describe("retry-handler", () => {
         assertExists(capturedHeaders, "Headers should be passed to fetch");
         assertEquals(capturedHeaders.get("Authorization"), "Bearer test-token");
         assertEquals(capturedHeaders.get("Content-Type"), "application/json");
+      });
+
+      it("injects the active trace context into outbound request headers", async () => {
+        const installation = installGlobalTelemetryAPI({ propagator: traceparentPropagator });
+
+        try {
+          await requestWithRetry(
+            "https://api.test.com/endpoint",
+            "test-token",
+            { maxRetries: 0, initialDelay: 100, maxDelay: 1000 },
+          );
+        } finally {
+          installation.dispose();
+        }
+
+        assertExists(capturedHeaders, "Headers should be passed to fetch");
+        assertEquals(
+          capturedHeaders.get("traceparent"),
+          TEST_TRACEPARENT,
+          "requestWithRetry must inject the active trace context into the outbound headers",
+        );
       });
 
       it("should forward custom method, body, and headers", async () => {

--- a/src/platform/adapters/veryfront-api-client/schemas/api.schema.test.ts
+++ b/src/platform/adapters/veryfront-api-client/schemas/api.schema.test.ts
@@ -45,8 +45,23 @@ describe("schemas", () => {
     });
 
     it("should reject missing required fields", () => {
-      const result = getProjectSchema().safeParse({ id: "not-a-uuid" });
-      assertEquals(result.success, false);
+      const id = "550e8400-e29b-41d4-a716-446655440000";
+
+      assertEquals(
+        getProjectSchema().safeParse({ id }).success,
+        false,
+        "a project payload without name and slug must be rejected",
+      );
+      assertEquals(
+        getProjectSchema().safeParse({ id, slug: "test" }).success,
+        false,
+        "name must stay required on a project payload",
+      );
+      assertEquals(
+        getProjectSchema().safeParse({ id, name: "Test" }).success,
+        false,
+        "slug must stay required on a project payload",
+      );
     });
 
     it("should reject invalid UUID", () => {

--- a/src/platform/adapters/veryfront-api-transport.test.ts
+++ b/src/platform/adapters/veryfront-api-transport.test.ts
@@ -5,6 +5,7 @@ import {
   assertThrows,
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { MAX_VERYFRONT_API_RETRIES } from "#veryfront/utils/config-resource-limits.ts";
 import {
   createCanonicalVeryfrontApiTransport,
@@ -165,6 +166,46 @@ describe("Veryfront API transport retry boundaries", () => {
       assertEquals(error.name, "AbortError");
       assertEquals(tokenReads, 0);
       assertEquals(fetchCalls, 0);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("captures the request token once so retries cannot observe a mid-flight token change", async () => {
+    const originalFetch = globalThis.fetch;
+    let tokenReads = 0;
+    const authorizations: Array<string | null> = [];
+
+    try {
+      globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) => {
+        authorizations.push(new Headers(init?.headers).get("authorization"));
+        return Promise.resolve(
+          authorizations.length === 1
+            ? new Response(null, { status: 500, statusText: "Upstream failure" })
+            : Response.json({ ok: true }),
+        );
+      }) as typeof fetch;
+      const transport = createVeryfrontApiTransport({
+        baseUrl: baseConfig.baseUrl,
+        getToken: () => `token-${++tokenReads}`,
+        retry: { maxRetries: 2, initialDelay: 0, maxDelay: 0 },
+      });
+
+      assertEquals(
+        await transport.request("/files"),
+        { ok: true },
+        "the retried request must resolve with the successful attempt",
+      );
+      assertEquals(
+        tokenReads,
+        1,
+        "the token provider must be read exactly once per request, not once per attempt",
+      );
+      assertEquals(
+        authorizations,
+        ["Bearer token-1", "Bearer token-1"],
+        "every retry attempt must reuse the token captured for the request",
+      );
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -578,5 +619,166 @@ describe("Veryfront API transport authority and response boundaries", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  it("omits the upstream error body when diagnostics opt out", async () => {
+    const originalFetch = globalThis.fetch;
+    let cancelled = false;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("x".repeat(16 * 1024)));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+
+    try {
+      globalThis.fetch = (() =>
+        Promise.resolve(
+          new Response(body, {
+            status: 500,
+            statusText: "Upstream failure",
+          }),
+        )) as typeof fetch;
+      const transport = createVeryfrontApiTransport({
+        ...baseConfig,
+        retry: { maxRetries: 0, initialDelay: 0, maxDelay: 0 },
+        shouldRetry: () => false,
+        wrapFinalError: (error) => error,
+      });
+
+      const error = await assertRejects(() =>
+        transport.request(
+          "https://api.example.com/files?access_token=secret&cursor=public",
+          { includeErrorBodyInDiagnostics: false },
+        )
+      );
+      assertInstanceOf(error, Error);
+      const context = (error as {
+        context?: {
+          details?: {
+            url?: string;
+            responseText?: string;
+            responseTruncated?: boolean;
+          };
+        };
+      }).context;
+      assertEquals(
+        context?.details?.responseText,
+        undefined,
+        "opting out must keep the upstream body out of the error context",
+      );
+      assertEquals(
+        context?.details?.url,
+        "https://api.example.com/files?access_token=[REDACTED]&cursor=public",
+        "the redacted URL must still be reported",
+      );
+      assertEquals(
+        context?.details?.responseTruncated,
+        true,
+        "truncation must still be reported when the body is withheld",
+      );
+      assertEquals(cancelled, true, "the upstream body stream must still be cancelled");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("authorizes every egress hop when an outbound policy is configured", async () => {
+    const authorizedOrigin = "https://93.184.216.34";
+    const retry = { maxRetries: 0, initialDelay: 0, maxDelay: 0 };
+    const outboundPolicy = {
+      authorizeUrl(url: URL) {
+        if (url.origin !== authorizedOrigin) {
+          throw new Error(`blocked: ${url.origin}`);
+        }
+      },
+    };
+
+    const authorized: Request[] = [];
+    await withMockFetch(
+      (input: URL | Request | string, init?: RequestInit) => {
+        authorized.push(new Request(input, init));
+        return Promise.resolve(Response.json({ ok: true }));
+      },
+      async () => {
+        const transport = createVeryfrontApiTransport({
+          baseUrl: authorizedOrigin,
+          getToken: () => "secret",
+          retry,
+          outboundPolicy,
+          wrapFinalError: (error) => error,
+        });
+        assertEquals(
+          await transport.request("/files"),
+          { ok: true },
+          "an authorized origin must complete through the guarded transport",
+        );
+      },
+    );
+    assertEquals(
+      authorized.length,
+      1,
+      "the authorized request must reach the outbound transport exactly once",
+    );
+    assertEquals(
+      authorized[0]?.headers.get("authorization"),
+      "Bearer secret",
+      "the guarded path must forward the bearer credential",
+    );
+
+    await withMockFetch(
+      () =>
+        Promise.resolve(
+          new Response(null, {
+            status: 302,
+            headers: { location: `${authorizedOrigin}/elsewhere` },
+          }),
+        ),
+      async () => {
+        const transport = createVeryfrontApiTransport({
+          baseUrl: authorizedOrigin,
+          getToken: () => "secret",
+          retry,
+          outboundPolicy,
+          wrapFinalError: (error) => error,
+        });
+        await assertRejects(
+          () => transport.request("/files"),
+          Error,
+          "redirect",
+          "the guarded path must refuse redirects for credentialed requests",
+        );
+      },
+    );
+
+    const blocked: Request[] = [];
+    await withMockFetch(
+      (input: URL | Request | string, init?: RequestInit) => {
+        blocked.push(new Request(input, init));
+        return Promise.resolve(Response.json({ ok: true }));
+      },
+      async () => {
+        const transport = createVeryfrontApiTransport({
+          baseUrl: "https://93.184.216.35",
+          getToken: () => "secret",
+          retry,
+          outboundPolicy,
+          wrapFinalError: (error) => error,
+        });
+        await assertRejects(
+          () => transport.request("/files"),
+          Error,
+          "blocked",
+          "an unauthorized origin must be refused by the outbound policy",
+        );
+      },
+    );
+    assertEquals(
+      blocked.length,
+      0,
+      "the bearer credential must never leave the process for an unauthorized origin",
+    );
   });
 });

--- a/src/platform/adapters/veryfront-api-transport.test.ts
+++ b/src/platform/adapters/veryfront-api-transport.test.ts
@@ -13,6 +13,7 @@ import {
   MAX_VERYFRONT_API_SUCCESS_BODY_BYTES,
   type TransportRetryConfig,
 } from "./veryfront-api-transport.ts";
+import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 
 const baseConfig = {
   baseUrl: "https://api.example.com",
@@ -91,7 +92,6 @@ describe("Veryfront API transport retry boundaries", () => {
   });
 
   it("composes caller cancellation with request timeout without retrying", async () => {
-    const originalFetch = globalThis.fetch;
     const controller = new AbortController();
     let attempts = 0;
     let requestStarted: (() => void) | undefined;
@@ -100,24 +100,26 @@ describe("Veryfront API transport retry boundaries", () => {
     });
 
     try {
-      globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) => {
-        attempts += 1;
-        const signal = init?.signal;
-        requestStarted?.();
-        return new Promise<Response>((_resolve, reject) => {
-          if (!signal) {
-            reject(new Error("request did not receive an AbortSignal"));
-            return;
-          }
-          if (signal.aborted) {
-            reject(signal.reason);
-            return;
-          }
-          signal.addEventListener("abort", () => reject(signal.reason), {
-            once: true,
+      installMockFetch(
+        ((_input: RequestInfo | URL, init?: RequestInit) => {
+          attempts += 1;
+          const signal = init?.signal;
+          requestStarted?.();
+          return new Promise<Response>((_resolve, reject) => {
+            if (!signal) {
+              reject(new Error("request did not receive an AbortSignal"));
+              return;
+            }
+            if (signal.aborted) {
+              reject(signal.reason);
+              return;
+            }
+            signal.addEventListener("abort", () => reject(signal.reason), {
+              once: true,
+            });
           });
-        });
-      }) as typeof fetch;
+        }) as typeof fetch,
+      );
 
       const transport = createVeryfrontApiTransport({
         ...baseConfig,
@@ -134,22 +136,23 @@ describe("Veryfront API transport retry boundaries", () => {
       assertEquals(error.name, "AbortError");
       assertEquals(attempts, 1);
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 
   it("rejects pre-cancelled requests before reading credentials or fetching", async () => {
-    const originalFetch = globalThis.fetch;
     const controller = new AbortController();
     controller.abort(new DOMException("cancelled", "AbortError"));
     let tokenReads = 0;
     let fetchCalls = 0;
 
     try {
-      globalThis.fetch = (() => {
-        fetchCalls += 1;
-        return Promise.resolve(new Response("{}"));
-      }) as typeof fetch;
+      installMockFetch(
+        (() => {
+          fetchCalls += 1;
+          return Promise.resolve(new Response("{}"));
+        }) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport({
         baseUrl: baseConfig.baseUrl,
         getToken: () => {
@@ -167,24 +170,25 @@ describe("Veryfront API transport retry boundaries", () => {
       assertEquals(tokenReads, 0);
       assertEquals(fetchCalls, 0);
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 
   it("captures the request token once so retries cannot observe a mid-flight token change", async () => {
-    const originalFetch = globalThis.fetch;
     let tokenReads = 0;
     const authorizations: Array<string | null> = [];
 
     try {
-      globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) => {
-        authorizations.push(new Headers(init?.headers).get("authorization"));
-        return Promise.resolve(
-          authorizations.length === 1
-            ? new Response(null, { status: 500, statusText: "Upstream failure" })
-            : Response.json({ ok: true }),
-        );
-      }) as typeof fetch;
+      installMockFetch(
+        ((_input: RequestInfo | URL, init?: RequestInit) => {
+          authorizations.push(new Headers(init?.headers).get("authorization"));
+          return Promise.resolve(
+            authorizations.length === 1
+              ? new Response(null, { status: 500, statusText: "Upstream failure" })
+              : Response.json({ ok: true }),
+          );
+        }) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport({
         baseUrl: baseConfig.baseUrl,
         getToken: () => `token-${++tokenReads}`,
@@ -207,22 +211,23 @@ describe("Veryfront API transport retry boundaries", () => {
         "every retry attempt must reuse the token captured for the request",
       );
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 });
 
 describe("Veryfront API transport authority and response boundaries", () => {
   it("rejects invalid success-body limits before reading credentials or fetching", async () => {
-    const originalFetch = globalThis.fetch;
     let tokenReads = 0;
     let fetchCalls = 0;
 
     try {
-      globalThis.fetch = (() => {
-        fetchCalls += 1;
-        return Promise.resolve(Response.json({ ok: true }));
-      }) as typeof fetch;
+      installMockFetch(
+        (() => {
+          fetchCalls += 1;
+          return Promise.resolve(Response.json({ ok: true }));
+        }) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport({
         baseUrl: baseConfig.baseUrl,
         getToken: () => {
@@ -250,28 +255,29 @@ describe("Veryfront API transport authority and response boundaries", () => {
       assertEquals(tokenReads, 0);
       assertEquals(fetchCalls, 0);
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 
   it("bounds and cancels successful response bodies before parsing", async () => {
-    const originalFetch = globalThis.fetch;
     let cancellations = 0;
     let fetchCalls = 0;
 
     try {
-      globalThis.fetch = (() => {
-        fetchCalls += 1;
-        const body = new ReadableStream<Uint8Array>({
-          start(controller) {
-            controller.enqueue(new TextEncoder().encode('{"ok":true}'));
-          },
-          cancel() {
-            cancellations += 1;
-          },
-        });
-        return Promise.resolve(new Response(body));
-      }) as typeof fetch;
+      installMockFetch(
+        (() => {
+          fetchCalls += 1;
+          const body = new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('{"ok":true}'));
+            },
+            cancel() {
+              cancellations += 1;
+            },
+          });
+          return Promise.resolve(new Response(body));
+        }) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport({
         ...baseConfig,
         retry: { maxRetries: 3, initialDelay: 0, maxDelay: 0 },
@@ -286,14 +292,13 @@ describe("Veryfront API transport authority and response boundaries", () => {
       assertEquals(fetchCalls, 1);
       assertEquals(cancellations, 1);
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 
   it("accepts a successful JSON body exactly at the configured byte limit", async () => {
-    const originalFetch = globalThis.fetch;
     try {
-      globalThis.fetch = (() => Promise.resolve(new Response("null"))) as typeof fetch;
+      installMockFetch((() => Promise.resolve(new Response("null"))) as typeof fetch);
       const transport = createVeryfrontApiTransport({
         ...baseConfig,
         retry: { maxRetries: 0, initialDelay: 0, maxDelay: 0 },
@@ -304,21 +309,22 @@ describe("Veryfront API transport authority and response boundaries", () => {
         null,
       );
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 
   it("snapshots the success-body limit before asynchronous fetch work", async () => {
-    const originalFetch = globalThis.fetch;
     let releaseFetch!: () => void;
     const fetchGate = new Promise<void>((resolve) => {
       releaseFetch = resolve;
     });
     try {
-      globalThis.fetch = (async () => {
-        await fetchGate;
-        return new Response('{"ok":true}');
-      }) as typeof fetch;
+      installMockFetch(
+        (async () => {
+          await fetchGate;
+          return new Response('{"ok":true}');
+        }) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport({
         ...baseConfig,
         retry: { maxRetries: 0, initialDelay: 0, maxDelay: 0 },
@@ -336,21 +342,22 @@ describe("Veryfront API transport authority and response boundaries", () => {
         "successful response exceeded 4 bytes",
       );
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 
   it("snapshots nested bounded-field options before asynchronous fetch work", async () => {
-    const originalFetch = globalThis.fetch;
     let releaseFetch!: () => void;
     const fetchGate = new Promise<void>((resolve) => {
       releaseFetch = resolve;
     });
     try {
-      globalThis.fetch = (async () => {
-        await fetchGate;
-        return new Response('{"content":"abcdef"}');
-      }) as typeof fetch;
+      installMockFetch(
+        (async () => {
+          await fetchGate;
+          return new Response('{"content":"abcdef"}');
+        }) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport({
         ...baseConfig,
         retry: { maxRetries: 0, initialDelay: 0, maxDelay: 0 },
@@ -369,18 +376,19 @@ describe("Veryfront API transport authority and response boundaries", () => {
 
       await assertRejects(() => pending, RangeError, "exceeds 5 UTF-8 bytes");
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 
   it("rejects invalid UTF-8 success bodies without retrying", async () => {
-    const originalFetch = globalThis.fetch;
     let fetchCalls = 0;
     try {
-      globalThis.fetch = (() => {
-        fetchCalls += 1;
-        return Promise.resolve(new Response(new Uint8Array([0xff])));
-      }) as typeof fetch;
+      installMockFetch(
+        (() => {
+          fetchCalls += 1;
+          return Promise.resolve(new Response(new Uint8Array([0xff])));
+        }) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport({
         ...baseConfig,
         retry: { maxRetries: 3, initialDelay: 0, maxDelay: 0 },
@@ -394,12 +402,11 @@ describe("Veryfront API transport authority and response boundaries", () => {
       );
       assertEquals(fetchCalls, 1);
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 
   it("rejects and cancels oversized declared success bodies", async () => {
-    const originalFetch = globalThis.fetch;
     let cancelled = false;
     const body = new ReadableStream<Uint8Array>({
       start(controller) {
@@ -411,10 +418,12 @@ describe("Veryfront API transport authority and response boundaries", () => {
     });
 
     try {
-      globalThis.fetch = (() =>
-        Promise.resolve(
-          new Response(body, { headers: { "content-length": "100" } }),
-        )) as typeof fetch;
+      installMockFetch(
+        (() =>
+          Promise.resolve(
+            new Response(body, { headers: { "content-length": "100" } }),
+          )) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport({
         ...baseConfig,
         retry: { maxRetries: 0, initialDelay: 0, maxDelay: 0 },
@@ -429,7 +438,7 @@ describe("Veryfront API transport authority and response boundaries", () => {
       );
       assertEquals(cancelled, true);
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 
@@ -456,15 +465,16 @@ describe("Veryfront API transport authority and response boundaries", () => {
   });
 
   it("rejects cross-origin absolute requests before reading credentials or fetching", async () => {
-    const originalFetch = globalThis.fetch;
     let tokenReads = 0;
     let fetchCalls = 0;
 
     try {
-      globalThis.fetch = (() => {
-        fetchCalls += 1;
-        return Promise.resolve(new Response("{}"));
-      }) as typeof fetch;
+      installMockFetch(
+        (() => {
+          fetchCalls += 1;
+          return Promise.resolve(new Response("{}"));
+        }) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport({
         baseUrl: baseConfig.baseUrl,
         getToken: () => {
@@ -482,22 +492,23 @@ describe("Veryfront API transport authority and response boundaries", () => {
       assertEquals(tokenReads, 0);
       assertEquals(fetchCalls, 0);
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 
   it("allows same-origin absolute requests and normalizes relative base paths", async () => {
-    const originalFetch = globalThis.fetch;
     const requests: Array<{ url: string; authorization: string | null }> = [];
 
     try {
-      globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
-        requests.push({
-          url: String(input),
-          authorization: new Headers(init?.headers).get("authorization"),
-        });
-        return Promise.resolve(Response.json({ ok: true }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((input: RequestInfo | URL, init?: RequestInit) => {
+          requests.push({
+            url: String(input),
+            authorization: new Headers(init?.headers).get("authorization"),
+          });
+          return Promise.resolve(Response.json({ ok: true }));
+        }) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport({
         baseUrl: "https://api.example.com/root/",
         getToken: () => "secret",
@@ -518,19 +529,20 @@ describe("Veryfront API transport authority and response boundaries", () => {
         },
       ]);
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 
   it("rejects redirects by default for credentialed API requests", async () => {
-    const originalFetch = globalThis.fetch;
     const redirectPolicies: Array<RequestRedirect | undefined> = [];
 
     try {
-      globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) => {
-        redirectPolicies.push(init?.redirect);
-        return Promise.resolve(Response.json({ ok: true }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((_input: RequestInfo | URL, init?: RequestInit) => {
+          redirectPolicies.push(init?.redirect);
+          return Promise.resolve(Response.json({ ok: true }));
+        }) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport({
         ...baseConfig,
         retry: { maxRetries: 0, initialDelay: 0, maxDelay: 0 },
@@ -540,19 +552,20 @@ describe("Veryfront API transport authority and response boundaries", () => {
 
       assertEquals(redirectPolicies, ["error"]);
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 
   it("uses explicit redirect policies when callers opt in", async () => {
-    const originalFetch = globalThis.fetch;
     const redirectPolicies: Array<RequestRedirect | undefined> = [];
 
     try {
-      globalThis.fetch = ((_input: RequestInfo | URL, init?: RequestInit) => {
-        redirectPolicies.push(init?.redirect);
-        return Promise.resolve(Response.json({ ok: true }));
-      }) as typeof fetch;
+      installMockFetch(
+        ((_input: RequestInfo | URL, init?: RequestInit) => {
+          redirectPolicies.push(init?.redirect);
+          return Promise.resolve(Response.json({ ok: true }));
+        }) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport({
         ...baseConfig,
         retry: { maxRetries: 0, initialDelay: 0, maxDelay: 0 },
@@ -563,12 +576,11 @@ describe("Veryfront API transport authority and response boundaries", () => {
 
       assertEquals(redirectPolicies, ["follow", "manual"]);
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 
   it("bounds and cancels upstream error bodies while redacting diagnostic URLs", async () => {
-    const originalFetch = globalThis.fetch;
     let cancelled = false;
     const body = new ReadableStream<Uint8Array>({
       start(controller) {
@@ -580,13 +592,15 @@ describe("Veryfront API transport authority and response boundaries", () => {
     });
 
     try {
-      globalThis.fetch = (() =>
-        Promise.resolve(
-          new Response(body, {
-            status: 500,
-            statusText: "Upstream failure",
-          }),
-        )) as typeof fetch;
+      installMockFetch(
+        (() =>
+          Promise.resolve(
+            new Response(body, {
+              status: 500,
+              statusText: "Upstream failure",
+            }),
+          )) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport({
         ...baseConfig,
         retry: { maxRetries: 0, initialDelay: 0, maxDelay: 0 },
@@ -617,12 +631,11 @@ describe("Veryfront API transport authority and response boundaries", () => {
       assertEquals(context?.details?.responseTruncated, true);
       assertEquals(cancelled, true);
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 
   it("omits the upstream error body when diagnostics opt out", async () => {
-    const originalFetch = globalThis.fetch;
     let cancelled = false;
     const body = new ReadableStream<Uint8Array>({
       start(controller) {
@@ -634,13 +647,15 @@ describe("Veryfront API transport authority and response boundaries", () => {
     });
 
     try {
-      globalThis.fetch = (() =>
-        Promise.resolve(
-          new Response(body, {
-            status: 500,
-            statusText: "Upstream failure",
-          }),
-        )) as typeof fetch;
+      installMockFetch(
+        (() =>
+          Promise.resolve(
+            new Response(body, {
+              status: 500,
+              statusText: "Upstream failure",
+            }),
+          )) as typeof fetch,
+      );
       const transport = createVeryfrontApiTransport({
         ...baseConfig,
         retry: { maxRetries: 0, initialDelay: 0, maxDelay: 0 },
@@ -681,7 +696,7 @@ describe("Veryfront API transport authority and response boundaries", () => {
       );
       assertEquals(cancelled, true, "the upstream body stream must still be cancelled");
     } finally {
-      globalThis.fetch = originalFetch;
+      restoreMockFetch();
     }
   });
 

--- a/src/platform/adapters/veryfront-api-url.test.ts
+++ b/src/platform/adapters/veryfront-api-url.test.ts
@@ -59,3 +59,38 @@ Deno.test("Veryfront API URL resolver permits the configured base path and desce
     "https://api.example.test/admin/health",
   );
 });
+
+Deno.test("Veryfront API URL resolver rejects credentials and malformed base URLs", () => {
+  const resolveUrl = createVeryfrontApiRequestUrlResolver("https://api.example.test/v1");
+
+  assertThrows(
+    () => resolveUrl("https://user:pass@api.example.test/v1/runs/run_1"),
+    TypeError,
+    "credentials",
+    "a same-origin request URL carrying userinfo must be rejected",
+  );
+  assertThrows(
+    () => resolveUrl("ftp://api.example.test/v1/runs"),
+    TypeError,
+    "http or https",
+    "non-http request URLs must be rejected",
+  );
+
+  for (
+    const [baseUrl, message] of [
+      ["https://user:pass@api.example.test", "credentials"],
+      ["ftp://api.example.test", "http or https"],
+      [" https://api.example.test ", "non-empty absolute URL"],
+      ["", "non-empty absolute URL"],
+      ["https://api.example.test/v1?x=1", "query or fragment"],
+      ["https://api.example.test/v1#f", "query or fragment"],
+    ] as const
+  ) {
+    assertThrows(
+      () => createVeryfrontApiRequestUrlResolver(baseUrl),
+      TypeError,
+      message,
+      baseUrl,
+    );
+  }
+});

--- a/tests/integration/adapters/node-shell-file-decoding.test.ts
+++ b/tests/integration/adapters/node-shell-file-decoding.test.ts
@@ -1,0 +1,31 @@
+/**
+ * NodeBasedShellAdapter file decoding integration test.
+ *
+ * Writing a fixture file to the host filesystem is a filesystem effect, so the
+ * exact-content decoding check lives here rather than beside the adapter.
+ */
+
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { NodeBasedShellAdapter } from "#veryfront/platform/adapters/runtime/shared/node-based-shell-adapter.ts";
+
+describe("NodeBasedShellAdapter.readFileSync against the host filesystem", () => {
+  it("returns the file decoded as UTF-8 text", async () => {
+    const directory = await Deno.makeTempDir({ prefix: "vf-node-shell-read-" });
+
+    try {
+      const path = `${directory}/sample.txt`;
+      const expected = 'héllo 世界\n{"name":"veryfront"}\n';
+      await Deno.writeTextFile(path, expected);
+
+      assertEquals(
+        new NodeBasedShellAdapter().readFileSync(path),
+        expected,
+        "readFileSync must return the file decoded as UTF-8 text",
+      );
+    } finally {
+      await Deno.remove(directory, { recursive: true });
+    }
+  });
+});

--- a/tests/integration/adapters/node-shell-file-decoding.test.ts
+++ b/tests/integration/adapters/node-shell-file-decoding.test.ts
@@ -9,10 +9,11 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { NodeBasedShellAdapter } from "#veryfront/platform/adapters/runtime/shared/node-based-shell-adapter.ts";
+import { makeTempDir } from "#veryfront/testing/deno-compat.ts";
 
 describe("NodeBasedShellAdapter.readFileSync against the host filesystem", () => {
   it("returns the file decoded as UTF-8 text", async () => {
-    const directory = await Deno.makeTempDir({ prefix: "vf-node-shell-read-" });
+    const directory = await makeTempDir({ prefix: "vf-node-shell-read-" });
 
     try {
       const path = `${directory}/sample.txt`;

--- a/tests/integration/adapters/shared-watcher-filesystem.test.ts
+++ b/tests/integration/adapters/shared-watcher-filesystem.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared watcher filesystem integration test.
+ *
+ * Exercises `setupNodeFsWatcher` against a real directory. Creating and
+ * watching files on the host is a filesystem effect, so the case lives here
+ * rather than beside the shared watcher module.
+ */
+
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { resolve } from "node:path";
+import type { FileChangeEvent } from "#veryfront/platform/adapters/base.ts";
+import { setupNodeFsWatcher } from "#veryfront/platform/adapters/runtime/shared/shared-watcher.ts";
+import { waitFor } from "#veryfront/testing/deno-compat.ts";
+
+describe("setupNodeFsWatcher on a real directory", () => {
+  it("emits the resolved path of a file changed inside the watched root", async () => {
+    const root = await Deno.realPath(
+      await Deno.makeTempDir({ prefix: "veryfront-shared-watcher-" }),
+    );
+    const changedFile = resolve(root, "file.ts");
+    const eventQueue: FileChangeEvent[] = [];
+    const watchers: Array<import("node:fs").FSWatcher> = [];
+    const failures: Error[] = [];
+    let closed = false;
+
+    try {
+      await setupNodeFsWatcher(root, {
+        recursive: true,
+        closed: () => closed,
+        signal: undefined,
+        eventQueue,
+        getResolver: () => null,
+        setResolver: () => {},
+        watchers,
+        onError: (error) => {
+          failures.push(error);
+        },
+      });
+
+      // Host watchers arm asynchronously, so keep rewriting the file until the
+      // first event lands instead of racing a single write against setup.
+      await waitFor(
+        async () => {
+          await Deno.writeTextFile(changedFile, "export const value = 1;\n");
+          return eventQueue.some((event) => event.paths.includes(changedFile));
+        },
+        { message: "the watcher never reported the file created inside the root" },
+      );
+
+      const event = eventQueue.find((candidate) => candidate.paths.includes(changedFile));
+      assertExists(event, "the watcher must report the file created inside the root");
+      assertEquals(
+        event.paths,
+        [changedFile],
+        "the watcher must emit the resolved path of the changed file inside the watched root",
+      );
+      assertEquals(
+        event.kind === "modify" || event.kind === "any",
+        true,
+        "a created file must be reported as a modify or any change",
+      );
+      assertEquals(failures, [], "watching a plain temp directory must not raise errors");
+    } finally {
+      closed = true;
+      for (const watcher of watchers) watcher.close();
+      await Deno.remove(root, { recursive: true });
+    }
+  });
+});

--- a/tests/integration/adapters/shared-watcher-filesystem.test.ts
+++ b/tests/integration/adapters/shared-watcher-filesystem.test.ts
@@ -12,12 +12,12 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { resolve } from "node:path";
 import type { FileChangeEvent } from "#veryfront/platform/adapters/base.ts";
 import { setupNodeFsWatcher } from "#veryfront/platform/adapters/runtime/shared/shared-watcher.ts";
-import { waitFor } from "#veryfront/testing/deno-compat.ts";
+import { makeTempDir, waitFor } from "#veryfront/testing/deno-compat.ts";
 
 describe("setupNodeFsWatcher on a real directory", () => {
   it("emits the resolved path of a file changed inside the watched root", async () => {
     const root = await Deno.realPath(
-      await Deno.makeTempDir({ prefix: "veryfront-shared-watcher-" }),
+      await makeTempDir({ prefix: "veryfront-shared-watcher-" }),
     );
     const changedFile = resolve(root, "file.ts");
     const eventQueue: FileChangeEvent[] = [];

--- a/tests/integration/adapters/token-storage-cloud-wiring.test.ts
+++ b/tests/integration/adapters/token-storage-cloud-wiring.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Token storage cloud wiring integration tests.
+ *
+ * These cases read process environment variables and observe the outbound
+ * request the cloud adapter issues during initialization. Both are host
+ * effects, so they live here rather than beside the token adapter modules.
+ */
+
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { createTokenStorageAdapter } from "#veryfront/platform/adapters/token/factory.ts";
+import {
+  getTokenStorageAdapter,
+  resetTokenStorageAdapter,
+} from "#veryfront/platform/adapters/token/integration.ts";
+
+interface CapturedRequest {
+  readonly urls: string[];
+  readonly authorizations: (string | null)[];
+}
+
+async function withCapturedFetch(
+  action: (captured: CapturedRequest) => Promise<void>,
+): Promise<void> {
+  const originalFetch = globalThis.fetch;
+  const captured: CapturedRequest = { urls: [], authorizations: [] };
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    captured.urls.push(String(input));
+    captured.authorizations.push(new Headers(init?.headers).get("authorization"));
+    return Promise.resolve(Response.json({ keys: [] }));
+  }) as typeof fetch;
+
+  try {
+    await action(captured);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+function deleteEnv(name: string): void {
+  try {
+    Deno.env.delete(name);
+  } catch { /* the host may not allow deleting this variable */ }
+}
+
+describe("token storage cloud wiring", () => {
+  afterEach(() => {
+    deleteEnv("VERYFRONT_API_TOKEN");
+    deleteEnv("VERYFRONT_PROJECT_SLUG");
+    deleteEnv("VERYFRONT_API_URL");
+    resetTokenStorageAdapter();
+  });
+
+  it("snapshots veryfront options before the async factory body runs", async () => {
+    await withCapturedFetch(async (captured) => {
+      const options = {
+        apiToken: "original-token",
+        projectSlug: "test-project",
+        apiBaseUrl: "https://original.example.com",
+        retry: { maxRetries: 0, initialDelay: 0, maxDelay: 0 },
+      };
+
+      const pending = createTokenStorageAdapter({ type: "veryfront-api", veryfront: options });
+      options.apiToken = "mutated-token";
+      options.apiBaseUrl = "https://mutated.example.com";
+      const adapter = await pending;
+      adapter.dispose?.();
+
+      assertEquals(captured.urls.length, 1, "initialization must issue exactly one ping request");
+      assertEquals(
+        captured.urls[0]?.startsWith("https://original.example.com") ?? false,
+        true,
+        "the adapter must use the base URL captured at call time",
+      );
+      assertEquals(
+        captured.authorizations[0],
+        "Bearer original-token",
+        "the adapter must use the token captured at call time",
+      );
+    });
+  });
+
+  it("wires the cloud adapter to the environment credentials and API base URL", async () => {
+    await withCapturedFetch(async (captured) => {
+      Deno.env.set("VERYFRONT_API_TOKEN", "env-token");
+      Deno.env.set("VERYFRONT_PROJECT_SLUG", "env-project");
+      Deno.env.set("VERYFRONT_API_URL", "https://tokens.example.test");
+
+      await getTokenStorageAdapter();
+
+      assertEquals(
+        captured.urls[0],
+        "https://tokens.example.test/v1/projects/env-project/tokens",
+        "the project slug and API base URL must come from the environment",
+      );
+      assertEquals(
+        captured.authorizations[0],
+        "Bearer env-token",
+        "the API token must come from VERYFRONT_API_TOKEN",
+      );
+    });
+  });
+});

--- a/tests/integration/adapters/token-storage-cloud-wiring.test.ts
+++ b/tests/integration/adapters/token-storage-cloud-wiring.test.ts
@@ -71,8 +71,8 @@ describe("token storage cloud wiring", () => {
 
       assertEquals(captured.urls.length, 1, "initialization must issue exactly one ping request");
       assertEquals(
-        captured.urls[0]?.startsWith("https://original.example.com") ?? false,
-        true,
+        captured.urls[0],
+        "https://original.example.com/v1/projects/test-project/tokens",
         "the adapter must use the base URL captured at call time",
       );
       assertEquals(

--- a/tests/integration/adapters/token-storage-cloud-wiring.test.ts
+++ b/tests/integration/adapters/token-storage-cloud-wiring.test.ts
@@ -14,6 +14,7 @@ import {
   getTokenStorageAdapter,
   resetTokenStorageAdapter,
 } from "#veryfront/platform/adapters/token/integration.ts";
+import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 
 interface CapturedRequest {
   readonly urls: string[];
@@ -23,18 +24,19 @@ interface CapturedRequest {
 async function withCapturedFetch(
   action: (captured: CapturedRequest) => Promise<void>,
 ): Promise<void> {
-  const originalFetch = globalThis.fetch;
   const captured: CapturedRequest = { urls: [], authorizations: [] };
-  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
-    captured.urls.push(String(input));
-    captured.authorizations.push(new Headers(init?.headers).get("authorization"));
-    return Promise.resolve(Response.json({ keys: [] }));
-  }) as typeof fetch;
+  installMockFetch(
+    ((input: RequestInfo | URL, init?: RequestInit) => {
+      captured.urls.push(String(input));
+      captured.authorizations.push(new Headers(init?.headers).get("authorization"));
+      return Promise.resolve(Response.json({ keys: [] }));
+    }) as typeof fetch,
+  );
 
   try {
     await action(captured);
   } finally {
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
   }
 }
 

--- a/tests/integration/adapters/websocket-runtime-globals.test.ts
+++ b/tests/integration/adapters/websocket-runtime-globals.test.ts
@@ -1,0 +1,116 @@
+/**
+ * WebSocket runtime-global integration tests.
+ *
+ * These cases replace runtime globals (`WebSocketPair`, `CloseEvent`) to prove
+ * the adapters behave correctly on hosts that do or do not provide them. The
+ * global mutation is a host effect, so the cases live here instead of beside
+ * the adapters they cover.
+ */
+
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertExists, assertStrictEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { EventEmitter } from "node:events";
+import { Buffer } from "node:buffer";
+import { CloudflareServerAdapter } from "#veryfront/platform/adapters/runtime/cloudflare/server.ts";
+import type { CloudflareWebSocket } from "#veryfront/platform/adapters/runtime/cloudflare/types.ts";
+import { NodeWebSocket } from "#veryfront/platform/adapters/runtime/node/websocket-adapter.ts";
+import type { WSWebSocket } from "#veryfront/platform/adapters/runtime/node/types.ts";
+
+function cloudflareWebSocketRequest(protocols?: string): Request {
+  return new Request("https://example.com/socket", {
+    headers: {
+      connection: "Upgrade",
+      upgrade: "websocket",
+      "sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+      "sec-websocket-version": "13",
+      ...(protocols ? { "sec-websocket-protocol": protocols } : {}),
+    },
+  });
+}
+
+function createMockWs(): WSWebSocket & EventEmitter {
+  const emitter = new EventEmitter() as EventEmitter & {
+    send: (data: string | ArrayBuffer) => void;
+    close: (code?: number, reason?: string) => void;
+  };
+  emitter.send = () => {};
+  emitter.close = () => {};
+  return emitter as unknown as WSWebSocket & EventEmitter;
+}
+
+describe("CloudflareServerAdapter with a host-provided WebSocketPair", () => {
+  it("hands the application the accepted server half with a 101 handshake response", () => {
+    let acceptCalls = 0;
+    const clientHalf = { half: "client" } as unknown as CloudflareWebSocket;
+    const serverHalf = {
+      half: "server",
+      accept() {
+        acceptCalls++;
+      },
+    } as unknown as CloudflareWebSocket;
+    const globalRecord = globalThis as Record<string, unknown>;
+    const previous = Object.getOwnPropertyDescriptor(globalThis, "WebSocketPair");
+    globalRecord.WebSocketPair = class {
+      0 = clientHalf;
+      1 = serverHalf;
+    };
+
+    try {
+      const upgrade = new CloudflareServerAdapter().upgradeWebSocket(
+        cloudflareWebSocketRequest("chat"),
+        { protocol: "chat" },
+      );
+
+      assertStrictEquals(
+        upgrade.socket,
+        serverHalf,
+        "the application must receive the server half of the pair",
+      );
+      assertEquals(acceptCalls, 1, "the server half must be accepted exactly once");
+      assertEquals(
+        upgrade.response.status,
+        101,
+        "the handshake must be reported as 101 Switching Protocols",
+      );
+      assertEquals(
+        upgrade.response.headers.get("sec-websocket-protocol"),
+        "chat",
+        "the negotiated subprotocol must travel on the handshake response",
+      );
+    } finally {
+      if (previous) Object.defineProperty(globalThis, "WebSocketPair", previous);
+      else delete globalRecord.WebSocketPair;
+    }
+  });
+});
+
+describe("NodeWebSocket on a host without a global CloseEvent", () => {
+  it("delivers a close event instead of throwing a ReferenceError", () => {
+    // Regression test: Node <23 does not expose `CloseEvent` as a global. An
+    // implementation that calls `new CloseEvent("close")` crashes the dev
+    // server with an unhandled `ReferenceError` on every socket teardown.
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, "CloseEvent");
+    Reflect.deleteProperty(globalThis, "CloseEvent");
+
+    try {
+      const socket = new NodeWebSocket();
+      const ws = createMockWs();
+      socket._attachRealSocket(ws);
+      let received: CloseEvent | null = null;
+      socket.onclose = (event) => {
+        received = event;
+      };
+
+      ws.emit("close", 1000, Buffer.from("ok"));
+
+      const event = received as unknown as CloseEvent;
+      assertExists(event, "close must be delivered without a global CloseEvent constructor");
+      assertEquals(event.code, 1000, "the close code must survive without a global CloseEvent");
+      assertEquals(event.reason, "ok", "the close reason must survive without a global CloseEvent");
+      assertEquals(event.wasClean, true, "a 1000 close must be reported as clean");
+    } finally {
+      if (descriptor) Object.defineProperty(globalThis, "CloseEvent", descriptor);
+    }
+  });
+});

--- a/tests/integration/adapters/websocket-runtime-globals.test.ts
+++ b/tests/integration/adapters/websocket-runtime-globals.test.ts
@@ -50,10 +50,27 @@ describe("CloudflareServerAdapter with a host-provided WebSocketPair", () => {
       },
     } as unknown as CloudflareWebSocket;
     const globalRecord = globalThis as Record<string, unknown>;
-    const previous = Object.getOwnPropertyDescriptor(globalThis, "WebSocketPair");
+    const previousPair = Object.getOwnPropertyDescriptor(globalThis, "WebSocketPair");
+    const previousResponse = Object.getOwnPropertyDescriptor(globalThis, "Response");
     globalRecord.WebSocketPair = class {
       0 = clientHalf;
       1 = serverHalf;
+    };
+    globalRecord.Response = class {
+      readonly status: number;
+      readonly statusText: string;
+      readonly headers: Headers;
+      readonly webSocket: CloudflareWebSocket | undefined;
+
+      constructor(
+        _body: BodyInit | null,
+        init: ResponseInit & { webSocket?: CloudflareWebSocket },
+      ) {
+        this.status = init.status ?? 200;
+        this.statusText = init.statusText ?? "";
+        this.headers = new Headers(init.headers);
+        this.webSocket = init.webSocket;
+      }
     };
 
     try {
@@ -78,9 +95,16 @@ describe("CloudflareServerAdapter with a host-provided WebSocketPair", () => {
         "chat",
         "the negotiated subprotocol must travel on the handshake response",
       );
+      assertStrictEquals(
+        (upgrade.response as Response & { webSocket: CloudflareWebSocket }).webSocket,
+        clientHalf,
+        "the Cloudflare response extension must receive the client half of the pair",
+      );
     } finally {
-      if (previous) Object.defineProperty(globalThis, "WebSocketPair", previous);
+      if (previousPair) Object.defineProperty(globalThis, "WebSocketPair", previousPair);
       else delete globalRecord.WebSocketPair;
+      if (previousResponse) Object.defineProperty(globalThis, "Response", previousResponse);
+      else delete globalRecord.Response;
     }
   });
 });


### PR DESCRIPTION
## Summary

Audit of the second 53 test files under `src/platform/adapters` (API client, token storage, and the Deno/Node/Cloudflare runtime adapters).

Every change was **mutation checked**: the named source edit was applied, the test confirmed to fail, then reverted. 60 candidate findings, 51 confirmed after adversarial verification, 9 refuted.

## Recurring weaknesses fixed

**Field-by-field mappings asserted on one field.** `getBranchFile`, `getEnvironmentFile` and `getReleaseFile` now assert the complete `FileDetail` literal, so swapping `content` for `path` in the mapper fails.

**Logic with no test at all.** `lookupProjectByDomain` gained a suite covering port stripping, case-insensitive environment matching, a 404 resolving to `null`, and a 500 rethrowing as `VeryfrontError`.

**A pagination mock that drove itself.** The `listAllFiles` mock incremented its own page counter, so a client ignoring `page_info.next` still passed. It now keys off the observed cursor and asserts exactly two requests with the expected cursor on each.

**Tautologies and vacuous guards.** `assertEquals(denoAdapter, denoAdapter)` became a real state round trip through `serve` and `shutdown`; a `if (readSnapshot === undefined) return;` early exit was deleted and replaced with an explicit platform branch.

**Two mutation notes recorded honestly.** For the Node filesystem adapter, the finding's literal edit is a silent no-op because the property is non-configurable, so an equivalent regression was used and the trail says so. The same is done for the singleton Proxy case.

## Front door migration

The `fetch-assignment` rule guards correctness, not duplication: code reaching `guardedOutboundFetch` reads the host transport rather than the global, so a bare `globalThis.fetch =` can leave that path talking to the real network. All touched files now use `installMockFetch`/`restoreMockFetch`, and raw `Deno.makeTempDir` calls use `makeTempDir`. Seven files went to zero bypasses; the baseline file is untouched.

## Verification

- Semantic unit-boundary audit ok (2160 units, 743 disposed), migration file untouched
- Sanitizer ratchet ok 374/374, `lint:test-typecheck` baseline holds (0 new)
- `lint:testing-front-door`: no key above baseline
- `deno fmt`, `deno lint` clean
- All changed test files pass
