### PR TITLE
test(platform/adapters): make weak assertions bite across the adapter surface

### DIFF
--- a/src/platform/adapters/bounded-file-read.test.ts
+++ b/src/platform/adapters/bounded-file-read.test.ts
@@ -288,6 +288,27 @@ Deno.test("exact bounded reads distinguish an exact-size file from overflow", as
   );
 });
 
+Deno.test("exact bounded reads restore the final byte when a reader clears the probe buffer at EOF", async () => {
+  const source = new Uint8Array([1, 2, 3]);
+  let offset = 0;
+  const reader = {
+    read(buffer: Uint8Array) {
+      buffer.fill(0);
+      if (offset >= source.byteLength) return Promise.resolve(null);
+      const bytesRead = Math.min(buffer.byteLength, source.byteLength - offset);
+      buffer.set(source.subarray(offset, offset + bytesRead));
+      offset += bytesRead;
+      return Promise.resolve(bytesRead);
+    },
+  };
+
+  assertEquals(
+    [...await readFileHandleWithinLimit(reader, 3)],
+    [1, 2, 3],
+    "an exact-size file keeps its final byte after the EOF probe",
+  );
+});
+
 Deno.test("exact bounded reads validate before opening and close after overflow", async () => {
   let opened = false;
   await assertRejects(

--- a/src/platform/adapters/bounded-text-reader.test.ts
+++ b/src/platform/adapters/bounded-text-reader.test.ts
@@ -372,4 +372,83 @@ describe("platform/adapters/bounded-text-reader", () => {
       "fixed ArrayBuffer",
     );
   });
+
+  it("rejects invalid UTF-8 instead of substituting replacement characters", async () => {
+    const exact = captureBoundedTextReader({
+      readFileBytesWithinLimit: () => Promise.resolve(new Uint8Array([0xff, 0xfe, 0xfd])),
+    });
+
+    await assertRejects(
+      () => exact.readUtf8("/binary.css", 4, "Exact stylesheet"),
+      TypeError,
+      "Exact stylesheet must contain valid UTF-8",
+      "invalid UTF-8 must be rejected, not replacement-charactered",
+    );
+
+    const snapshot = captureSnapshotTextReader({
+      readFileSnapshotWithinLimit: () => Promise.resolve(new Uint8Array([0xff, 0xfe, 0xfd])),
+    });
+
+    await assertRejects(
+      () => snapshot.readUtf8("/binary.css", "/root", 4, "Snapshot stylesheet"),
+      TypeError,
+      "Snapshot stylesheet must contain valid UTF-8",
+      "invalid UTF-8 must be rejected on the snapshot path too",
+    );
+
+    const wellFormed = captureBoundedTextReader({
+      readFileBytesWithinLimit: () => Promise.resolve(new TextEncoder().encode("A\u20ACB")),
+    });
+
+    assertEquals(
+      await wellFormed.readUtf8("/valid.css", 8, "Exact stylesheet"),
+      { content: "A\u20ACB", byteLength: 5 },
+      "well-formed multi-byte UTF-8 must still decode",
+    );
+  });
+
+  it("validates path, maximum and containment root before reaching the reader", async () => {
+    let reads = 0;
+    const exact = captureBoundedTextReader({
+      readFileBytesWithinLimit: () => {
+        reads++;
+        return Promise.resolve(new Uint8Array());
+      },
+    });
+
+    await assertRejects(
+      () => exact.readUtf8("", 4, "CSS input"),
+      TypeError,
+      "path must be a non-empty string",
+      "an empty path must be refused",
+    );
+    await assertRejects(
+      () => exact.readUtf8("a.css", 0, "CSS input"),
+      RangeError,
+      "positive safe integer",
+      "a non-positive maximum must be refused",
+    );
+    await assertRejects(
+      () => exact.readUtf8("a.css", 1.5, "CSS input"),
+      RangeError,
+      "positive safe integer",
+      "a fractional maximum must be refused",
+    );
+
+    const snapshot = captureSnapshotTextReader({
+      readFileSnapshotWithinLimit: () => {
+        reads++;
+        return Promise.resolve(new Uint8Array());
+      },
+    });
+
+    await assertRejects(
+      () => snapshot.readUtf8("/project/app.css", "", 4, "Project CSS"),
+      TypeError,
+      "containment root must be a non-empty string",
+      "an empty containment root must be refused",
+    );
+
+    assertEquals(reads, 0, "an unvalidated read must never reach the underlying reader");
+  });
 });

--- a/src/platform/adapters/fallback-wrapper.test.ts
+++ b/src/platform/adapters/fallback-wrapper.test.ts
@@ -15,13 +15,18 @@ describe("fallback-wrapper", () => {
   describe("withFallback", () => {
     it("should return primary result when successful", async () => {
       const primary = () => Promise.resolve("primary-success");
-      const fallback = () => Promise.resolve("fallback-success");
+      let fallbackCalls = 0;
+      const fallback = () => {
+        fallbackCalls++;
+        return Promise.resolve("fallback-success");
+      };
 
       const result = await withFallback(primary, fallback, {
         operationName: "test-operation",
       });
 
       assertEquals(result, "primary-success");
+      assertEquals(fallbackCalls, 0, "the fallback must not run when the primary succeeds");
     });
 
     it("should return fallback result when primary fails", async () => {
@@ -125,13 +130,18 @@ describe("fallback-wrapper", () => {
   describe("withFallbackSync", () => {
     it("should return primary result when successful", () => {
       const primary = () => "primary-success";
-      const fallback = () => "fallback-success";
+      let fallbackCalls = 0;
+      const fallback = () => {
+        fallbackCalls++;
+        return "fallback-success";
+      };
 
       const result = withFallbackSync(primary, fallback, {
         operationName: "test-operation",
       });
 
       assertEquals(result, "primary-success");
+      assertEquals(fallbackCalls, 0, "the fallback must not run when the primary succeeds");
     });
 
     it("should return fallback result when primary fails", () => {
@@ -202,7 +212,11 @@ describe("fallback-wrapper", () => {
   describe("createAdapterFallback", () => {
     it("should create a reusable fallback wrapper", async () => {
       const adapterOperation = () => Promise.resolve("adapter-result");
-      const directOperation = () => Promise.resolve("direct-result");
+      let directCalls = 0;
+      const directOperation = () => {
+        directCalls++;
+        return Promise.resolve("direct-result");
+      };
 
       const wrapper = createAdapterFallback(
         adapterOperation,
@@ -212,6 +226,11 @@ describe("fallback-wrapper", () => {
 
       const result = await wrapper.execute();
       assertEquals(result, "adapter-result");
+      assertEquals(
+        directCalls,
+        0,
+        "the direct operation must not run when the adapter operation succeeds",
+      );
     });
 
     it("should fall back to direct operation when adapter fails", async () => {

--- a/src/platform/adapters/file-system-capabilities.test.ts
+++ b/src/platform/adapters/file-system-capabilities.test.ts
@@ -122,6 +122,49 @@ describe("platform/adapters/file-system-capabilities", () => {
     );
   });
 
+  it("enforces each capture site's declared byte ceiling", async () => {
+    const overByOne = captureByteReadCapabilities({
+      maxWholeFileReadBytes: 2,
+      readFileBytes: () => Promise.resolve(new Uint8Array(3)),
+      readFileBytesBounded: () => Promise.resolve(new Uint8Array(3)),
+      readFileBytesWithinLimit: () => Promise.resolve(new Uint8Array(3)),
+    });
+
+    await assertRejects(
+      () => overByOne.whole!.read("/a"),
+      RangeError,
+      "exceeds 2 bytes",
+      "the whole-file ceiling must be enforced at the capture site",
+    );
+    await assertRejects(
+      () => overByOne.prefix!("/a", 2),
+      RangeError,
+      "exceeds 2 bytes",
+      "the prefix ceiling must be enforced at the capture site",
+    );
+    await assertRejects(
+      () => overByOne.exact!("/a", 2),
+      RangeError,
+      "exceeds 2 bytes",
+      "the exact ceiling must be enforced at the capture site",
+    );
+
+    const staticCaptured = captureStaticReadCapabilities({
+      symlinkSemantics: "none" as const,
+      readFileSnapshotWithinLimit: () => Promise.resolve(new Uint8Array([1])),
+      getSourceSnapshotVersion: () => 7,
+      readFileBytes: () => Promise.resolve(new Uint8Array(5)),
+      maxWholeFileReadBytes: 4,
+    });
+
+    await assertRejects(
+      () => staticCaptured.virtual!.whole!.read("/b"),
+      RangeError,
+      "exceeds 4 bytes",
+      "the virtual whole-file ceiling must be enforced at the capture site",
+    );
+  });
+
   it("captures byte readers without inspecting an unrelated malformed writer", async () => {
     const captured = captureByteReadCapabilities({
       readFileBytesWithinLimit: () => Promise.resolve(new Uint8Array([4])),

--- a/src/platform/adapters/fs/cache/factory.test.ts
+++ b/src/platform/adapters/fs/cache/factory.test.ts
@@ -20,6 +20,22 @@ describe("createFileCache", () => {
     const cache = createFileCache({ maxSize: 1000, ttl: 60000 });
     assertExists(cache);
     assertEquals(cache instanceof FileCache, true);
+
+    const disabled = createFileCache({ enabled: false });
+    disabled.set("k", "v");
+    assertEquals(
+      disabled.get<string>("k"),
+      undefined,
+      "enabled:false must reach the FileCache instance so reads miss",
+    );
+
+    const enabled = createFileCache({ enabled: true });
+    enabled.set("k", "v");
+    assertEquals(
+      enabled.get<string>("k"),
+      "v",
+      "an enabled cache round-trips the value",
+    );
   });
 
   it("should create independent cache instances", () => {

--- a/src/platform/adapters/fs/cache/file-cache.test.ts
+++ b/src/platform/adapters/fs/cache/file-cache.test.ts
@@ -502,6 +502,13 @@ describe("Distributed cache functions", () => {
       const descriptor = Object.getOwnPropertyDescriptor(CacheBackends, "file");
       assertExists(descriptor);
       const patterns: string[] = [];
+      const pendingDeletions: Array<() => void> = [];
+      // While gated, the backend deletion only settles when the test releases it,
+      // so an *Async method that stopped awaiting it would resolve early.
+      let gateDeletions = false;
+      const flushMicrotasks = async (): Promise<void> => {
+        for (let tick = 0; tick < 20; tick++) await Promise.resolve();
+      };
       Object.defineProperty(CacheBackends, "file", {
         ...descriptor,
         value: () =>
@@ -514,7 +521,10 @@ describe("Distributed cache functions", () => {
             clear: () => Promise.resolve(),
             delByPattern: (pattern: string) => {
               patterns.push(pattern);
-              return Promise.resolve(0);
+              if (!gateDeletions) return Promise.resolve(0);
+              return new Promise<number>((resolve) => {
+                pendingDeletions.push(() => resolve(0));
+              });
             },
           } as never),
       });
@@ -536,13 +546,33 @@ describe("Distributed cache functions", () => {
         "deleteByPrefix must forward a wildcard pattern to the distributed backend",
       );
 
-      await distributedCache.deleteByPrefixAsync("file:release:p:r2:");
+      gateDeletions = true;
+      let prefixAsyncSettled = false;
+      const prefixAsync = distributedCache
+        .deleteByPrefixAsync("file:release:p:r2:")
+        .then((count) => {
+          prefixAsyncSettled = true;
+          return count;
+        });
+      await flushMicrotasks();
       assertEquals(
         patterns,
         ["file:release:p:r1:*", "file:release:p:r2:*"],
-        "deleteByPrefixAsync must await the same wildcard pattern on the backend",
+        "deleteByPrefixAsync must forward the same wildcard pattern to the backend",
+      );
+      assertEquals(
+        prefixAsyncSettled,
+        false,
+        "deleteByPrefixAsync must stay pending until the backend deletion settles",
+      );
+      pendingDeletions.shift()?.();
+      assertEquals(
+        await prefixAsync,
+        0,
+        "deleteByPrefixAsync must resolve once the backend deletion settles",
       );
 
+      gateDeletions = false;
       distributedCache.deleteByPrefixAndSuffix("file:release:p:r3:", "s");
       await Promise.resolve();
       assertEquals(
@@ -551,11 +581,35 @@ describe("Distributed cache functions", () => {
         "deleteByPrefixAndSuffix must forward a suffix-qualified pattern",
       );
 
-      await distributedCache.deleteByPrefixAndSuffixAsync("file:release:p:r4:", "s");
+      gateDeletions = true;
+      let suffixAsyncSettled = false;
+      const suffixAsync = distributedCache
+        .deleteByPrefixAndSuffixAsync("file:release:p:r4:", "s")
+        .then((count) => {
+          suffixAsyncSettled = true;
+          return count;
+        });
+      await flushMicrotasks();
       assertEquals(
         patterns[3],
         "file:release:p:r4:*:s",
-        "deleteByPrefixAndSuffixAsync must await a suffix-qualified pattern",
+        "deleteByPrefixAndSuffixAsync must forward a suffix-qualified pattern",
+      );
+      assertEquals(
+        suffixAsyncSettled,
+        false,
+        "deleteByPrefixAndSuffixAsync must stay pending until the backend deletion settles",
+      );
+      pendingDeletions.shift()?.();
+      assertEquals(
+        await suffixAsync,
+        0,
+        "deleteByPrefixAndSuffixAsync must resolve once the backend deletion settles",
+      );
+      assertEquals(
+        pendingDeletions.length,
+        0,
+        "every gated backend deletion must have been released",
       );
     });
 

--- a/src/platform/adapters/fs/cache/file-cache.test.ts
+++ b/src/platform/adapters/fs/cache/file-cache.test.ts
@@ -495,6 +495,70 @@ describe("Distributed cache functions", () => {
       });
     });
 
+    it("forwards prefix invalidation to the distributed backend", async () => {
+      const distributedModule = await import(
+        "./file-cache.ts?distributed-prefix-invalidation-regression"
+      );
+      const descriptor = Object.getOwnPropertyDescriptor(CacheBackends, "file");
+      assertExists(descriptor);
+      const patterns: string[] = [];
+      Object.defineProperty(CacheBackends, "file", {
+        ...descriptor,
+        value: () =>
+          Promise.resolve({
+            type: "redis",
+            size: 0,
+            get: () => Promise.resolve(null),
+            set: () => Promise.resolve(),
+            del: () => Promise.resolve(false),
+            clear: () => Promise.resolve(),
+            delByPattern: (pattern: string) => {
+              patterns.push(pattern);
+              return Promise.resolve(0);
+            },
+          } as never),
+      });
+
+      try {
+        assertEquals(await distributedModule.initializeFileCacheBackend(), true);
+      } finally {
+        Object.defineProperty(CacheBackends, "file", descriptor);
+      }
+
+      const distributedCache = new distributedModule.FileCache();
+
+      distributedCache.deleteByPrefix("file:release:p:r1:");
+      // deleteByPrefix dispatches the backend deletion fire-and-forget.
+      await Promise.resolve();
+      assertEquals(
+        patterns,
+        ["file:release:p:r1:*"],
+        "deleteByPrefix must forward a wildcard pattern to the distributed backend",
+      );
+
+      await distributedCache.deleteByPrefixAsync("file:release:p:r2:");
+      assertEquals(
+        patterns,
+        ["file:release:p:r1:*", "file:release:p:r2:*"],
+        "deleteByPrefixAsync must await the same wildcard pattern on the backend",
+      );
+
+      distributedCache.deleteByPrefixAndSuffix("file:release:p:r3:", "s");
+      await Promise.resolve();
+      assertEquals(
+        patterns[2],
+        "file:release:p:r3:*:s",
+        "deleteByPrefixAndSuffix must forward a suffix-qualified pattern",
+      );
+
+      await distributedCache.deleteByPrefixAndSuffixAsync("file:release:p:r4:", "s");
+      assertEquals(
+        patterns[3],
+        "file:release:p:r4:*:s",
+        "deleteByPrefixAndSuffixAsync must await a suffix-qualified pattern",
+      );
+    });
+
     it("should return boolean", async () => {
       assertEquals(typeof (await initializeFileCacheBackend()), "boolean");
     });

--- a/src/platform/adapters/fs/github/adapter.test.ts
+++ b/src/platform/adapters/fs/github/adapter.test.ts
@@ -1,6 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
-import { observeFetchRequestInit } from "#veryfront/testing/mock-fetch.ts";
+import {
+  installMockFetch,
+  observeFetchRequestInit,
+  restoreMockFetch,
+} from "#veryfront/testing/mock-fetch.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { isNotFoundError } from "#veryfront/platform/compat/fs.ts";
 import { FSAdapterWrapper } from "../wrapper.ts";
@@ -62,14 +66,8 @@ function assertThrowsMessageIncludes(fn: () => void, includes: string): void {
 }
 
 describe("GitHubFSAdapter", () => {
-  let originalFetch: typeof fetch;
-
-  beforeEach(() => {
-    originalFetch = globalThis.fetch;
-  });
-
   afterEach(() => {
-    globalThis.fetch = originalFetch;
+    restoreMockFetch();
   });
 
   describe("createGitHubConfig", () => {
@@ -103,7 +101,7 @@ describe("GitHubFSAdapter", () => {
     it("should fetch tree on initialize", async () => {
       let treeRequested = false;
 
-      globalThis.fetch = (url) => {
+      installMockFetch((url) => {
         if (!String(url).includes("/git/trees/")) {
           return Promise.resolve(new Response("Not found", { status: 404 }));
         }
@@ -112,7 +110,7 @@ describe("GitHubFSAdapter", () => {
         return Promise.resolve(
           new Response(JSON.stringify(mockTreeResponse), { status: 200 }),
         );
-      };
+      });
 
       const adapter = createAdapter();
       await adapter.initialize();
@@ -121,7 +119,7 @@ describe("GitHubFSAdapter", () => {
     });
 
     it("re-initializes against the current tree after dispose", async () => {
-      globalThis.fetch = createTreeFetch(mockTreeResponse);
+      installMockFetch(createTreeFetch(mockTreeResponse));
 
       const adapter = createAdapter();
       await adapter.initialize();
@@ -130,11 +128,11 @@ describe("GitHubFSAdapter", () => {
       adapter.dispose();
       assertEquals(adapter.getCacheStats().cache.size, 0, "dispose clears the blob cache");
 
-      globalThis.fetch = createTreeFetch({
+      installMockFetch(createTreeFetch({
         sha: "def456",
         tree: [{ path: "docs/new.md", type: "blob", sha: "sha9", size: 5 }],
         truncated: false,
-      });
+      }));
 
       assertEquals(
         await adapter.exists("docs/new.md"),
@@ -149,14 +147,14 @@ describe("GitHubFSAdapter", () => {
     });
 
     it("admits ordinary files through the real wrapper while excluding Git symlinks", async () => {
-      globalThis.fetch = createTreeFetch({
+      installMockFetch(createTreeFetch({
         sha: "abc123",
         tree: [
           { path: "README.md", mode: "100644", type: "blob", sha: "sha1", size: 100 },
           { path: "outside.md", mode: "120000", type: "blob", sha: "sha2", size: 9 },
         ],
         truncated: false,
-      });
+      }));
 
       const adapter = createAdapter("/project");
       const wrapped = new FSAdapterWrapper(adapter);
@@ -176,7 +174,7 @@ describe("GitHubFSAdapter", () => {
     let adapter: GitHubFSAdapter;
 
     beforeEach(async () => {
-      globalThis.fetch = (url, init) => {
+      installMockFetch((url, init) => {
         const urlStr = String(url);
 
         if (urlStr.includes("/git/trees/")) {
@@ -202,7 +200,7 @@ describe("GitHubFSAdapter", () => {
         }
 
         return Promise.resolve(new Response("Not found", { status: 404 }));
-      };
+      });
 
       adapter = createAdapter();
       await adapter.initialize();
@@ -249,7 +247,7 @@ describe("GitHubFSAdapter", () => {
 
     it("rejects an indexed oversized file without fetching its content", async () => {
       let contentRequested = false;
-      globalThis.fetch = (url) => {
+      installMockFetch((url) => {
         const urlString = String(url);
         if (urlString.includes("/git/trees/")) {
           return Promise.resolve(
@@ -260,7 +258,7 @@ describe("GitHubFSAdapter", () => {
         return Promise.resolve(
           new Response(JSON.stringify(mockFileContent), { status: 200 }),
         );
-      };
+      });
       const boundedAdapter = createAdapter();
 
       await assertRejects(
@@ -273,7 +271,7 @@ describe("GitHubFSAdapter", () => {
 
     it("fails closed before fetching when the tree omits authoritative size", async () => {
       let blobRequested = false;
-      globalThis.fetch = (url) => {
+      installMockFetch((url) => {
         const urlString = String(url);
         if (urlString.includes("/git/trees/")) {
           return Promise.resolve(
@@ -289,7 +287,7 @@ describe("GitHubFSAdapter", () => {
         }
         blobRequested = true;
         return Promise.resolve(new Response(JSON.stringify(mockFileContent), { status: 200 }));
-      };
+      });
       const boundedAdapter = createAdapter();
 
       await assertRejects(
@@ -301,7 +299,7 @@ describe("GitHubFSAdapter", () => {
     });
 
     it("rejects a raw blob that does not match its admitted immutable tree entry", async () => {
-      globalThis.fetch = (url, init) => {
+      installMockFetch((url, init) => {
         const urlString = String(url);
         if (urlString.includes("/git/trees/")) {
           return Promise.resolve(
@@ -311,7 +309,7 @@ describe("GitHubFSAdapter", () => {
         const accept = new Headers(observeFetchRequestInit(init).headers).get("Accept");
         assertEquals(accept, "application/vnd.github.raw+json");
         return Promise.resolve(new Response("hello worl", { status: 200 }));
-      };
+      });
       const boundedAdapter = createAdapter();
 
       await assertRejects(
@@ -324,7 +322,7 @@ describe("GitHubFSAdapter", () => {
     it("cancels a raw blob stream at the first chunk beyond its admitted size", async () => {
       let cancelled = false;
       let blobRequests = 0;
-      globalThis.fetch = (url) => {
+      installMockFetch((url) => {
         const urlString = String(url);
         if (urlString.includes("/git/trees/")) {
           return Promise.resolve(
@@ -345,7 +343,7 @@ describe("GitHubFSAdapter", () => {
             { status: 200 },
           ),
         );
-      };
+      });
       const boundedAdapter = createAdapter();
 
       await assertRejects(
@@ -372,7 +370,7 @@ describe("GitHubFSAdapter", () => {
     let adapter: GitHubFSAdapter;
 
     beforeEach(async () => {
-      globalThis.fetch = createTreeFetch(mockTreeResponse);
+      installMockFetch(createTreeFetch(mockTreeResponse));
 
       adapter = createAdapter();
       await adapter.initialize();
@@ -410,7 +408,7 @@ describe("GitHubFSAdapter", () => {
         ],
       };
 
-      globalThis.fetch = createTreeFetch(treeWithExtensions);
+      installMockFetch(createTreeFetch(treeWithExtensions));
 
       adapter = createAdapter();
       await adapter.initialize();
@@ -434,7 +432,7 @@ describe("GitHubFSAdapter", () => {
 
   describe("error handling", () => {
     it("should handle 401 authentication error", async () => {
-      globalThis.fetch = () => Promise.resolve(new Response("Unauthorized", { status: 401 }));
+      installMockFetch(() => Promise.resolve(new Response("Unauthorized", { status: 401 })));
 
       const adapter = new GitHubFSAdapter({
         type: "github",
@@ -445,7 +443,7 @@ describe("GitHubFSAdapter", () => {
     });
 
     it("should handle 404 repo not found", async () => {
-      globalThis.fetch = () => Promise.resolve(new Response("Not found", { status: 404 }));
+      installMockFetch(() => Promise.resolve(new Response("Not found", { status: 404 })));
 
       const adapter = new GitHubFSAdapter({
         type: "github",

--- a/src/platform/adapters/fs/github/adapter.test.ts
+++ b/src/platform/adapters/fs/github/adapter.test.ts
@@ -120,6 +120,34 @@ describe("GitHubFSAdapter", () => {
       assertEquals(treeRequested, true);
     });
 
+    it("re-initializes against the current tree after dispose", async () => {
+      globalThis.fetch = createTreeFetch(mockTreeResponse);
+
+      const adapter = createAdapter();
+      await adapter.initialize();
+      assertEquals(await adapter.exists("src/index.ts"), true, "the first tree is indexed");
+
+      adapter.dispose();
+      assertEquals(adapter.getCacheStats().cache.size, 0, "dispose clears the blob cache");
+
+      globalThis.fetch = createTreeFetch({
+        sha: "def456",
+        tree: [{ path: "docs/new.md", type: "blob", sha: "sha9", size: 5 }],
+        truncated: false,
+      });
+
+      assertEquals(
+        await adapter.exists("docs/new.md"),
+        true,
+        "a disposed adapter re-fetches the tree",
+      );
+      assertEquals(
+        await adapter.exists("src/index.ts"),
+        false,
+        "the pre-dispose tree index must not survive dispose",
+      );
+    });
+
     it("admits ordinary files through the real wrapper while excluding Git symlinks", async () => {
       globalThis.fetch = createTreeFetch({
         sha: "abc123",

--- a/src/platform/adapters/fs/github/cache-scope.test.ts
+++ b/src/platform/adapters/fs/github/cache-scope.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { FileCache } from "#veryfront/platform/adapters/fs/cache/file-cache.ts";
+import { FileCache } from "../cache/file-cache.ts";
 import { buildGitHubCacheRef } from "./cache-scope.ts";
 import { GitHubStatOperations } from "./stat-operations.ts";
 

--- a/src/platform/adapters/fs/github/cache-scope.test.ts
+++ b/src/platform/adapters/fs/github/cache-scope.test.ts
@@ -1,7 +1,9 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { FileCache } from "../cache/file-cache.ts";
 import { buildGitHubCacheRef } from "./cache-scope.ts";
+import { GitHubStatOperations } from "./stat-operations.ts";
 
 describe("GitHub cache scope", () => {
   it("isolates repositories that use the same ref", () => {
@@ -27,6 +29,71 @@ describe("GitHub cache scope", () => {
         ref: "feature/cache:key",
       }),
       "owner%3Aname:site%2Fname:feature%2Fcache%3Akey",
+    );
+  });
+
+  it("isolates stat and resolve cache entries by repository", async () => {
+    const baseConfig = {
+      ref: "main",
+      token: "test-token",
+      basePath: "",
+      retry: { maxRetries: 3, initialDelay: 1000, maxDelay: 30000 },
+      cache: { enabled: true, ttl: 60000, maxSize: 1000, maxMemory: 104857600 },
+    };
+
+    function createStatOps(
+      owner: string,
+      entries: Array<{ path: string; sha: string; size: number }>,
+      cache: FileCache,
+    ): GitHubStatOperations {
+      return new GitHubStatOperations(
+        { ...baseConfig, owner, repo: "site" } as never,
+        {
+          getTree: () =>
+            Promise.resolve({
+              tree: entries.map((entry) => ({ ...entry, type: "blob" })),
+              truncated: false,
+            }),
+          repoId: `${owner}/site`,
+        } as never,
+        cache,
+      );
+    }
+
+    // One process-wide cache, as a distributed backend would be.
+    const cache = new FileCache();
+    const first = createStatOps("owner-a", [
+      { path: "pages/shared.tsx", sha: "a-shared", size: 1 },
+      { path: "pages/about.tsx", sha: "a-about", size: 1 },
+    ], cache);
+    const second = createStatOps("owner-b", [
+      { path: "pages/shared.tsx", sha: "b-shared", size: 2 },
+      { path: "pages/about.mdx", sha: "b-about", size: 2 },
+    ], cache);
+
+    await first.buildIndex();
+    await second.buildIndex();
+
+    assertEquals(
+      (await first.stat("pages/shared.tsx")).size,
+      1,
+      "the first repository must stat its own file",
+    );
+    assertEquals(
+      (await second.stat("pages/shared.tsx")).size,
+      2,
+      "a second repository on the same ref must not serve the first repository's stat entry",
+    );
+
+    assertEquals(
+      await first.resolveFile("about"),
+      "pages/about.tsx",
+      "the first repository must resolve its own page",
+    );
+    assertEquals(
+      await second.resolveFile("about"),
+      "pages/about.mdx",
+      "a second repository on the same ref must not serve the first repository's resolved path",
     );
   });
 });

--- a/src/platform/adapters/fs/github/cache-scope.test.ts
+++ b/src/platform/adapters/fs/github/cache-scope.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { FileCache } from "../cache/file-cache.ts";
+import { FileCache } from "#veryfront/platform/adapters/fs/cache/file-cache.ts";
 import { buildGitHubCacheRef } from "./cache-scope.ts";
 import { GitHubStatOperations } from "./stat-operations.ts";
 

--- a/src/platform/adapters/fs/github/directory-operations.test.ts
+++ b/src/platform/adapters/fs/github/directory-operations.test.ts
@@ -57,8 +57,36 @@ describe("GitHubDirectoryOperations", () => {
       assertEquals(typeof ops.readDir, "function");
     });
 
+    function createOpsWithListing(isDirectory: boolean): GitHubDirectoryOperations {
+      return new GitHubDirectoryOperations(
+        mockConfig,
+        new FileCache(),
+        {
+          isDirectory: () => isDirectory,
+          getFilesInDirectory: () => [
+            { path: "src/b.ts", sha: "b", size: 1, type: "blob" },
+            { path: "src/a.ts", sha: "a", size: 1, type: "blob" },
+          ],
+          getSubdirectories: () => ["z", "m"],
+        } as any,
+      );
+    }
+
     it("should return empty array for non-existent directory", () => {
-      assertEquals(createOps().readdir("/non-existent"), []);
+      // The stub would produce entries if the not-a-directory guard were gone.
+      assertEquals(
+        createOpsWithListing(false).readdir("/non-existent"),
+        [],
+        "readdir returns empty when the path is not an indexed directory",
+      );
+    });
+
+    it("should list directories first, then entries name-sorted", () => {
+      assertEquals(
+        createOpsWithListing(true).readdir("src").map((entry) => entry.name),
+        ["m", "z", "a.ts", "b.ts"],
+        "readdir must list directories first, then entries name-sorted",
+      );
     });
 
     it("isolates directory cache entries by repository", () => {

--- a/src/platform/adapters/fs/github/github-api-client.test.ts
+++ b/src/platform/adapters/fs/github/github-api-client.test.ts
@@ -29,6 +29,15 @@ function createClient(): GitHubApiClient {
   return new GitHubApiClient(mockConfig);
 }
 
+// Same retry budget as mockConfig, but with backoff delays small enough that an
+// exhausted retry sequence stays inside a unit test's time budget.
+function createFastRetryClient(): GitHubApiClient {
+  return new GitHubApiClient({
+    ...mockConfig,
+    retry: { maxRetries: mockConfig.retry.maxRetries, initialDelay: 1, maxDelay: 1 },
+  });
+}
+
 function assertMethod(client: GitHubApiClient, name: keyof GitHubApiClient): void {
   const value = client[name];
   assertExists(value);
@@ -102,6 +111,228 @@ describe("GitHubApiClient", () => {
 
     it("should return null for initial rate limit info", () => {
       assertEquals(createClient().getRateLimitInfo(), null);
+    });
+  });
+
+  describe("getBlobBytesWithinLimit", () => {
+    it("rejects an expected size above the byte limit before fetching", async () => {
+      let fetchCalls = 0;
+      await withMockFetch(
+        () => {
+          fetchCalls++;
+          return Promise.resolve(new Response(new Uint8Array()));
+        },
+        async () => {
+          await assertRejects(
+            () => createClient().getBlobBytesWithinLimit("sha-1", 5, 4),
+            RangeError,
+            "GitHub blob exceeds 4 bytes",
+          );
+        },
+      );
+
+      assertEquals(fetchCalls, 0, "expectedSize above byteLimit must reject before any fetch");
+    });
+
+    it("rejects a truncated blob body instead of zero-padding it", async () => {
+      await withMockFetch(
+        () => Promise.resolve(new Response(new Uint8Array([1, 2]))),
+        async () => {
+          await assertRejects(
+            () => createClient().getBlobBytesWithinLimit("sha-1", 4, 4),
+            Error,
+            "does not match its admitted 4-byte tree entry",
+          );
+        },
+      );
+    });
+
+    it("rejects a blob body longer than its admitted tree entry", async () => {
+      await withMockFetch(
+        () => Promise.resolve(new Response(new Uint8Array([1, 2, 3, 4, 5]))),
+        async () => {
+          await assertRejects(
+            () => createClient().getBlobBytesWithinLimit("sha-1", 4, 8),
+            Error,
+            "does not match its admitted 4-byte tree entry",
+          );
+        },
+      );
+    });
+
+    it("rejects a declared Content-Length above the limit before streaming the body", async () => {
+      let bodyCancelled = false;
+      await withMockFetch(
+        () =>
+          Promise.resolve(
+            new Response(
+              new ReadableStream<Uint8Array>({
+                pull(controller) {
+                  controller.enqueue(new Uint8Array([1, 2, 3, 4, 5]));
+                },
+                cancel() {
+                  bodyCancelled = true;
+                },
+              }),
+              { headers: { "Content-Length": "5" } },
+            ),
+          ),
+        async () => {
+          // The pre-stream guard and the over-long-chunk guard report different
+          // messages, so the message pins which branch rejected this response.
+          await assertRejects(
+            () => createClient().getBlobBytesWithinLimit("sha-1", 4, 4),
+            Error,
+            "exceeds 4 bytes before streaming",
+          );
+        },
+      );
+
+      assertEquals(
+        bodyCancelled,
+        true,
+        "a Content-Length above the limit must cancel the body instead of streaming it",
+      );
+    });
+
+    it("returns the exact admitted bytes", async () => {
+      const result = await withMockFetch(
+        () => Promise.resolve(new Response(new Uint8Array([1, 2, 3, 4]))),
+        () => createClient().getBlobBytesWithinLimit("sha-1", 4, 4),
+      );
+
+      assertEquals(
+        [...result],
+        [1, 2, 3, 4],
+        "bounded blob read returns the exact admitted bytes",
+      );
+    });
+  });
+
+  describe("HTTP failure policy", () => {
+    it("attempts a 404 exactly once and classifies it as a file error", async () => {
+      let fetchCalls = 0;
+      const error = await withMockFetch(
+        () => {
+          fetchCalls++;
+          return Promise.resolve(new Response("Not found", { status: 404 }));
+        },
+        () => assertRejects(() => createFastRetryClient().getTree("main"), Error),
+      );
+
+      assertInstanceOf(error, Error);
+      assertEquals(fetchCalls, 1, "a 404 must not be retried");
+      assertEquals(
+        (error as { statusCode?: number }).statusCode,
+        404,
+        "the API error carries its status code",
+      );
+      assertEquals(
+        error.name,
+        "VeryfrontError[file]",
+        "a missing file must not be classified as a transient network fault",
+      );
+    });
+
+    it("attempts a 401 exactly once and classifies it as a config error", async () => {
+      let fetchCalls = 0;
+      const error = await withMockFetch(
+        () => {
+          fetchCalls++;
+          return Promise.resolve(new Response("Bad credentials", { status: 401 }));
+        },
+        () => assertRejects(() => createFastRetryClient().getTree("main"), Error),
+      );
+
+      assertInstanceOf(error, Error);
+      assertEquals(fetchCalls, 1, "an auth failure must not be retried");
+      assertEquals(
+        error.name,
+        "VeryfrontError[config]",
+        "an auth failure must be classified as a configuration fault",
+      );
+    });
+
+    it("retries a 403 once the rate limit is exhausted", async () => {
+      let fetchCalls = 0;
+      const resetSeconds = Math.floor(Date.now() / 1000);
+      const error = await withMockFetch(
+        () => {
+          fetchCalls++;
+          return Promise.resolve(
+            new Response("rate limited", {
+              status: 403,
+              headers: {
+                "X-RateLimit-Limit": "60",
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Used": "60",
+                "X-RateLimit-Reset": String(resetSeconds),
+              },
+            }),
+          );
+        },
+        () => assertRejects(() => createFastRetryClient().getTree("main"), Error),
+      );
+
+      assertInstanceOf(error, Error);
+      assertEquals(
+        fetchCalls,
+        mockConfig.retry.maxRetries,
+        "an exhausted rate limit must consume the whole retry budget",
+      );
+      assertEquals(
+        error.message,
+        `GitHub API rate limit exceeded. Resets at ${new Date(resetSeconds * 1000).toISOString()}`,
+        "the rate limit error names the reset instant",
+      );
+    });
+
+    it("retries a 500 up to the retry budget", async () => {
+      let fetchCalls = 0;
+      await withMockFetch(
+        () => {
+          fetchCalls++;
+          return Promise.resolve(new Response("boom", { status: 500 }));
+        },
+        () => assertRejects(() => createFastRetryClient().getTree("main"), Error),
+      );
+
+      assertEquals(
+        fetchCalls,
+        mockConfig.retry.maxRetries,
+        "server errors exhaust the retry budget",
+      );
+    });
+
+    it("records rate limit headers from a successful response", async () => {
+      const resetSeconds = 1_700_000_000;
+      const client = createClient();
+
+      await withMockFetch(
+        () =>
+          Promise.resolve(
+            Response.json({ sha: "tree", tree: [], truncated: false }, {
+              headers: {
+                "X-RateLimit-Limit": "60",
+                "X-RateLimit-Remaining": "42",
+                "X-RateLimit-Used": "18",
+                "X-RateLimit-Reset": String(resetSeconds),
+              },
+            }),
+          ),
+        () => client.getTree("main"),
+      );
+
+      assertEquals(
+        client.getRateLimitInfo(),
+        {
+          limit: 60,
+          remaining: 42,
+          reset: new Date(resetSeconds * 1000),
+          used: 18,
+        },
+        "a successful response records its rate limit headers",
+      );
     });
   });
 

--- a/src/platform/adapters/fs/github/read-operations.test.ts
+++ b/src/platform/adapters/fs/github/read-operations.test.ts
@@ -1,7 +1,9 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { buildGitHubBytesCacheKey } from "#veryfront/cache";
 import { GitHubReadOperations } from "./read-operations.ts";
+import { buildGitHubCacheRef } from "./cache-scope.ts";
 import { FileCache } from "../cache/file-cache.ts";
 
 describe("GitHubReadOperations", () => {
@@ -232,6 +234,62 @@ describe("GitHubReadOperations", () => {
       assertEquals(result instanceof Uint8Array, true);
       // Should encode "plain text" as UTF-8 bytes
       assertEquals(new TextDecoder().decode(result), "plain text");
+    });
+  });
+
+  describe("readFileBytesWithinLimit", () => {
+    function seedExactCache(cache: FileCache, sha: string, bytes: Uint8Array): void {
+      cache.set(
+        `${buildGitHubBytesCacheKey(buildGitHubCacheRef(mockConfig), "README.md")}:exact:${sha}`,
+        bytes,
+      );
+    }
+
+    it("rejects a cached entry whose length disagrees with the tree entry", async () => {
+      const cache = new FileCache();
+      seedExactCache(cache, "sha-1", new Uint8Array(5));
+      const ops = new GitHubReadOperations(
+        mockConfig,
+        createMockClient() as any,
+        cache as any,
+        createMockStatOps({
+          getFileEntry: () => ({ sha: "sha-1", size: 11, type: "blob" }),
+        }) as any,
+      );
+
+      await assertRejects(
+        () => ops.readFileBytesWithinLimit("README.md", 11),
+        TypeError,
+        "does not match its tree entry",
+      );
+    });
+
+    it("returns a cached entry whose length matches without refetching", async () => {
+      const cache = new FileCache();
+      const content = new TextEncoder().encode("hello world");
+      seedExactCache(cache, "sha-1", content);
+      let blobFetches = 0;
+      const ops = new GitHubReadOperations(
+        mockConfig,
+        createMockClient({
+          getBlobBytesWithinLimit: () => {
+            blobFetches++;
+            throw new Error("the cached entry must answer the read");
+          },
+        }) as any,
+        cache as any,
+        createMockStatOps({
+          getFileEntry: () => ({ sha: "sha-1", size: content.byteLength, type: "blob" }),
+        }) as any,
+      );
+
+      const bytes = await ops.readFileBytesWithinLimit("README.md", content.byteLength);
+      assertEquals(
+        new TextDecoder().decode(bytes),
+        "hello world",
+        "a size-matching cached entry is served verbatim",
+      );
+      assertEquals(blobFetches, 0, "a size-matching cached entry is served without a blob fetch");
     });
   });
 

--- a/src/platform/adapters/fs/github/stat-operations.test.ts
+++ b/src/platform/adapters/fs/github/stat-operations.test.ts
@@ -79,6 +79,54 @@ describe("GitHubStatOperations", () => {
     });
   });
 
+  describe("resolveFile", () => {
+    function createOpsWithTree(): GitHubStatOperations {
+      const client = {
+        getTree: () =>
+          Promise.resolve({
+            tree: [
+              { path: "pages/about.tsx", type: "blob", sha: "a", size: 1 },
+              { path: "lib/utils.ts", type: "blob", sha: "b", size: 1 },
+            ],
+            truncated: false,
+          }),
+        repoId: "test-owner/test-repo",
+      } as any;
+      // A fresh cache per instance keeps one lookup's resolve entry out of the next.
+      return new GitHubStatOperations(mockConfig, client, new FileCache());
+    }
+
+    it("should resolve a bare page name through the pages prefix", async () => {
+      const ops = createOpsWithTree();
+      await ops.buildIndex();
+      assertEquals(
+        await ops.resolveFile("about"),
+        "pages/about.tsx",
+        "resolves a bare page name through the pages prefix",
+      );
+    });
+
+    it("should suppress the pages fallback when allowPagesPrefix is false", async () => {
+      const ops = createOpsWithTree();
+      await ops.buildIndex();
+      assertEquals(
+        await ops.resolveFile("about", { allowPagesPrefix: false }),
+        null,
+        "allowPagesPrefix:false suppresses the pages fallback",
+      );
+    });
+
+    it("should still resolve a direct hit when the pages fallback is disabled", async () => {
+      const ops = createOpsWithTree();
+      await ops.buildIndex();
+      assertEquals(
+        await ops.resolveFile("lib/utils", { allowPagesPrefix: false }),
+        "lib/utils.ts",
+        "the opt-out still resolves a direct hit",
+      );
+    });
+  });
+
   describe("initial state", () => {
     it("should return undefined for getFileEntry before index is built", () => {
       assertEquals(createOps().getFileEntry("test.ts"), undefined);

--- a/src/platform/adapters/fs/github/stat-operations.test.ts
+++ b/src/platform/adapters/fs/github/stat-operations.test.ts
@@ -92,7 +92,6 @@ describe("GitHubStatOperations", () => {
           }),
         repoId: "test-owner/test-repo",
       } as any;
-      // A fresh cache per instance keeps one lookup's resolve entry out of the next.
       return new GitHubStatOperations(mockConfig, client, new FileCache());
     }
 
@@ -123,6 +122,37 @@ describe("GitHubStatOperations", () => {
         await ops.resolveFile("lib/utils", { allowPagesPrefix: false }),
         "lib/utils.ts",
         "the opt-out still resolves a direct hit",
+      );
+    });
+
+    it("should not serve a cached pages-prefix hit to a later opt-out", async () => {
+      // One instance, one cache: the resolve cache must key on the option too.
+      const ops = createOpsWithTree();
+      await ops.buildIndex();
+      assertEquals(
+        await ops.resolveFile("about"),
+        "pages/about.tsx",
+        "the default lookup resolves through the pages prefix and caches it",
+      );
+      assertEquals(
+        await ops.resolveFile("about", { allowPagesPrefix: false }),
+        null,
+        "a cached pages-prefix resolution must not survive the opt-out on the same cache",
+      );
+    });
+
+    it("should not serve a cached opt-out miss to a later default lookup", async () => {
+      const ops = createOpsWithTree();
+      await ops.buildIndex();
+      assertEquals(
+        await ops.resolveFile("about", { allowPagesPrefix: false }),
+        null,
+        "the opt-out lookup misses and caches the miss",
+      );
+      assertEquals(
+        await ops.resolveFile("about"),
+        "pages/about.tsx",
+        "a cached opt-out miss must not suppress the default pages fallback",
       );
     });
   });

--- a/src/platform/adapters/fs/github/stat-operations.ts
+++ b/src/platform/adapters/fs/github/stat-operations.ts
@@ -186,8 +186,11 @@ export class GitHubStatOperations {
     await this.ensureIndex();
 
     const normalizedPath = normalizeGitHubPath(basePath, this.projectDir);
+    // The pages-prefix fallback changes the answer for the same path, so the
+    // opt-out needs its own cache scope; otherwise one variant serves the other.
+    const cacheRef = buildGitHubCacheRef(this.config);
     const cacheKey = buildGitHubResolveCacheKey(
-      buildGitHubCacheRef(this.config),
+      options?.allowPagesPrefix === false ? `${cacheRef}:no-pages-prefix` : cacheRef,
       normalizedPath,
     );
     const cached = this.cache.get<string | null>(cacheKey);

--- a/src/platform/adapters/fs/integration.test.ts
+++ b/src/platform/adapters/fs/integration.test.ts
@@ -378,9 +378,22 @@ describe("integration.ts", () => {
       assertEquals(enhanced.id, denoAdapter.id);
       assertEquals(enhanced.name, denoAdapter.name);
       assertEquals(enhanced.capabilities, denoAdapter.capabilities);
+      for (const key of ["env", "server", "shell", "serve"]) {
+        assertEquals(
+          typeof (enhanced as unknown as Record<string, unknown>)[key],
+          typeof (denoAdapter as unknown as Record<string, unknown>)[key],
+          `${key} must survive materialization`,
+        );
+      }
       // `shutdown` lives on the prototype and closes over instance state, so it
-      // must survive materialization already bound to the source adapter.
-      assertEquals(typeof enhanced.shutdown, "function");
+      // must survive materialization already bound to the source adapter. An
+      // unbound copy called as a bare function throws on `this`.
+      const { shutdown } = enhanced as { shutdown: () => Promise<void> };
+      assertEquals(
+        await shutdown().then(() => "resolved").catch((error) => String(error)),
+        "resolved",
+        "a destructured shutdown must stay bound to the source adapter",
+      );
     });
   });
 });

--- a/src/platform/adapters/fs/veryfront/adapter-content-context.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter-content-context.test.ts
@@ -51,7 +51,11 @@ describe("veryfront/adapter-content-context", () => {
     };
 
     assertEquals(hasContentContextChanged(null, branchContext), true);
-    assertEquals(hasContentContextChanged(branchContext, branchContext), false);
+    assertEquals(
+      hasContentContextChanged({ ...branchContext }, { ...branchContext }),
+      false,
+      "structurally identical contexts must not force a cache clear",
+    );
     assertEquals(
       hasContentContextChanged(branchContext, {
         sourceType: "branch",
@@ -59,6 +63,52 @@ describe("veryfront/adapter-content-context", () => {
         branch: "feature/auth",
       }),
       true,
+    );
+    assertEquals(
+      hasContentContextChanged(branchContext, {
+        sourceType: "branch",
+        projectSlug: "other",
+        branch: "main",
+      }),
+      true,
+      "a projectSlug switch must be treated as a context change",
+    );
+    assertEquals(
+      hasContentContextChanged(branchContext, {
+        sourceType: "environment",
+        projectSlug: "demo",
+        branch: "main",
+      }),
+      true,
+      "a sourceType switch must be treated as a context change",
+    );
+    assertEquals(
+      hasContentContextChanged({
+        sourceType: "environment",
+        projectSlug: "demo",
+        environmentName: "production",
+        releaseId: "rel-1",
+      }, {
+        sourceType: "environment",
+        projectSlug: "demo",
+        environmentName: "preview",
+        releaseId: "rel-1",
+      }),
+      true,
+      "an environmentName switch must be treated as a context change",
+    );
+    assertEquals(
+      hasContentContextChanged({
+        sourceType: "release",
+        projectSlug: "demo",
+        releaseId: "rel-1",
+      }, {
+        sourceType: "release",
+        projectSlug: "demo",
+        releaseId: "rel-2",
+      }),
+      true,
+      "a releaseId switch must be treated as a context change",
     );
   });
 

--- a/src/platform/adapters/fs/veryfront/adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/adapter.test.ts
@@ -1,5 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertNotEquals,
+  assertRejects,
+} from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
 import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import { VeryfrontFSAdapter } from "./adapter.ts";
@@ -649,6 +654,22 @@ describe("VeryfrontFSAdapter", () => {
         projectSlug: "test-project",
         releaseId: "release-old",
       });
+
+      const statOps = (adapter as unknown as { statOps: { clearIndex: () => void } }).statOps;
+      const dirOps = (adapter as unknown as { dirOps: { clearTree: () => void } }).dirOps;
+      const originalClearIndex = statOps.clearIndex;
+      const originalClearTree = dirOps.clearTree;
+      let indexClears = 0;
+      let treeClears = 0;
+      statOps.clearIndex = () => {
+        indexClears++;
+        originalClearIndex.call(statOps);
+      };
+      dirOps.clearTree = () => {
+        treeClears++;
+        originalClearTree.call(dirOps);
+      };
+
       adapter.setContentContext({
         sourceType: "release",
         projectSlug: "test-project",
@@ -656,6 +677,17 @@ describe("VeryfrontFSAdapter", () => {
       });
 
       assertEquals(adapter.getContentContext()?.releaseId, "release-new");
+      assertEquals(indexClears, 1, "a release switch must clear the stat index");
+      assertEquals(treeClears, 1, "a release switch must clear the directory tree");
+
+      adapter.setContentContext({
+        sourceType: "release",
+        projectSlug: "test-project",
+        releaseId: "release-new",
+      });
+
+      assertEquals(indexClears, 1, "an unchanged context must not clear the stat index");
+      assertEquals(treeClears, 1, "an unchanged context must not clear the directory tree");
     });
 
     it("should not clear caches when context is identical", () => {
@@ -754,14 +786,92 @@ describe("VeryfrontFSAdapter", () => {
   });
 
   describe("dispose", () => {
-    it("should dispose without error", () => {
-      createAdapter().dispose();
+    it("should clear the cache, bump the snapshot generation and allow re-initialization", async () => {
+      const adapter = createAdapter({
+        veryfront: {
+          apiBaseUrl: "https://api.example.com",
+          apiToken: "test-token",
+          projectSlug: "test-project",
+          contentSource: { type: "branch", branch: "main" },
+          cache: { enabled: true },
+        },
+      });
+
+      const client = (adapter as unknown as {
+        client: {
+          initialize: () => Promise<void>;
+          getProjectSlug: () => string;
+          getProjectId: () => string;
+          getCachedProject: () => { provider: string; layout: string };
+          listAllFiles: () => Promise<
+            Array<{ path: string; version_id: string; content: string }>
+          >;
+        };
+      }).client;
+
+      client.initialize = () => Promise.resolve();
+      client.getProjectSlug = () => "test-project";
+      client.getProjectId = () => "project-123";
+      client.getCachedProject = () => ({ provider: "veryfront", layout: "default" });
+
+      let listAllFilesCalls = 0;
+      client.listAllFiles = () => {
+        listAllFilesCalls++;
+        return Promise.resolve([{
+          path: "pages/index.tsx",
+          version_id: "v1",
+          content: "hello",
+        }]);
+      };
+
+      (adapter as unknown as { wsManager: { connect: (_projectId: string) => void } }).wsManager
+        .connect = () => {};
+
+      await adapter.initialize();
+      assertEquals(await adapter.readTextFile("pages/index.tsx"), "hello");
+
+      const versionBeforeDispose = adapter.getSourceSnapshotVersion();
+      assertEquals(
+        adapter.getCacheStats().cache.size > 0,
+        true,
+        "an initialized read must leave something in the file cache",
+      );
+      const callsBeforeDispose = listAllFilesCalls;
+
+      adapter.dispose();
+
+      assertEquals(adapter.getCacheStats().cache.size, 0, "dispose clears the file cache");
+      assertNotEquals(
+        adapter.getSourceSnapshotVersion(),
+        versionBeforeDispose,
+        "dispose bumps the source snapshot generation",
+      );
+
+      await adapter.initialize();
+      assertEquals(
+        listAllFilesCalls > callsBeforeDispose,
+        true,
+        "dispose resets initialized so a later initialize re-fetches",
+      );
     });
 
     it("should allow calling dispose multiple times", () => {
       const adapter = createAdapter();
       adapter.dispose();
+      const versionAfterFirst = adapter.getSourceSnapshotVersion();
+
       adapter.dispose();
+
+      assertNotEquals(
+        adapter.getSourceSnapshotVersion(),
+        versionAfterFirst,
+        "every dispose bumps the source snapshot generation",
+      );
+      assertEquals(
+        adapter.getCacheStats().cache.size,
+        0,
+        "the file cache stays cleared after a repeated dispose",
+      );
     });
   });
 

--- a/src/platform/adapters/fs/veryfront/cache-keys.test.ts
+++ b/src/platform/adapters/fs/veryfront/cache-keys.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertNotEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   buildDirCacheKeyPrefix,
@@ -11,9 +11,14 @@ import {
 const branchCtx = {
   sourceType: "branch" as const,
   projectSlug: "my-project",
-  branch: "main",
+  branch: "feature/x",
   releaseId: undefined,
   environmentName: undefined,
+};
+
+const mainBranchCtx = {
+  ...branchCtx,
+  branch: "main",
 };
 
 const releaseCtx = {
@@ -45,7 +50,15 @@ describe("cache-keys", () => {
     it("should build branch-based key", () => {
       assertEquals(
         buildFileCacheKeyPrefix(branchCtx),
-        "file:branch:my-project:main",
+        "file:branch:my-project:feature%2Fx",
+      );
+    });
+
+    it("should give each branch its own namespace", () => {
+      assertNotEquals(
+        buildFileCacheKeyPrefix(branchCtx),
+        buildFileCacheKeyPrefix(mainBranchCtx),
+        "each branch must get its own file cache namespace",
       );
     });
 
@@ -72,7 +85,7 @@ describe("cache-keys", () => {
     it("should build branch-based key", () => {
       assertEquals(
         buildStatCacheKeyPrefix(branchCtx),
-        "stat:branch:my-project:main",
+        "stat:branch:my-project:feature%2Fx",
       );
     });
 
@@ -92,7 +105,7 @@ describe("cache-keys", () => {
     it("should build branch-based key", () => {
       assertEquals(
         buildDirCacheKeyPrefix(branchCtx),
-        "dir:branch:my-project:main",
+        "dir:branch:my-project:feature%2Fx",
       );
     });
   });
@@ -105,7 +118,7 @@ describe("cache-keys", () => {
     it("should build branch-based key", () => {
       assertEquals(
         buildFileListCacheKey(branchCtx),
-        "files:branch:my-project:main",
+        "files:branch:my-project:feature%2Fx",
       );
     });
 

--- a/src/platform/adapters/fs/veryfront/content-metrics.test.ts
+++ b/src/platform/adapters/fs/veryfront/content-metrics.test.ts
@@ -2,6 +2,10 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
+  createSnapshot,
+  resetMetrics,
+} from "#veryfront/observability/simple-metrics/metrics-state.ts";
+import {
   endRequestMetrics,
   getContentMetricsSnapshot,
   logContentMetric,
@@ -43,10 +47,19 @@ describe("platform/adapters/fs/veryfront/content-metrics", () => {
 
     it("should not throw when endRequestMetrics called without context", () => {
       resetContentMetrics();
-      // endRequestMetrics is a no-op when there is no active metrics store
-      // Note: enterWith from previous tests may persist in the same async context,
-      // so we just verify it does not throw
+      // endRequestMetrics is a no-op when there is no active metrics store.
       endRequestMetrics({ requestId: "no-start" });
+      const snapshot = getContentMetricsSnapshot();
+      assertEquals(
+        snapshot.requestsTracked,
+        0,
+        "an endRequestMetrics without a live store must not count a request",
+      );
+      assertEquals(
+        snapshot.avgNetworkMsPerRequest,
+        0,
+        "an orphan end must not skew the network average",
+      );
     });
 
     it("should handle endRequestMetrics with no context", () => {
@@ -121,10 +134,44 @@ describe("platform/adapters/fs/veryfront/content-metrics", () => {
 
     it("should track isPreviewMode", () => {
       resetContentMetrics();
+      resetMetrics();
       startRequestMetrics();
       logContentMetric("REQUEST_SCOPED_HIT", { path: "test.ts", isPreviewMode: true });
       endRequestMetrics();
-      // No assertion on preview mode directly, but it should not throw
+
+      const snapshot = createSnapshot();
+      assertEquals(
+        snapshot.contentPreviewRequests,
+        1,
+        "a request flagged isPreviewMode must be attributed to preview traffic",
+      );
+      assertEquals(
+        snapshot.contentProductionRequests,
+        0,
+        "a preview request must not be counted as production",
+      );
+      resetMetrics();
+    });
+
+    it("should attribute an unflagged request to production traffic", () => {
+      resetContentMetrics();
+      resetMetrics();
+      startRequestMetrics();
+      logContentMetric("REQUEST_SCOPED_HIT", { path: "test.ts" });
+      endRequestMetrics();
+
+      const snapshot = createSnapshot();
+      assertEquals(
+        snapshot.contentProductionRequests,
+        1,
+        "a request without an isPreviewMode flag must be attributed to production traffic",
+      );
+      assertEquals(
+        snapshot.contentPreviewRequests,
+        0,
+        "an unflagged request must not be counted as preview",
+      );
+      resetMetrics();
     });
 
     it("should accumulate multiple events in a single request", () => {

--- a/src/platform/adapters/fs/veryfront/content-metrics.test.ts
+++ b/src/platform/adapters/fs/veryfront/content-metrics.test.ts
@@ -45,11 +45,12 @@ describe("platform/adapters/fs/veryfront/content-metrics", () => {
       assertEquals(snapshot.requestsTracked, 1);
     });
 
-    it("should not throw when endRequestMetrics called without context", () => {
-      resetContentMetrics();
+    it("should not throw when endRequestMetrics called without context", async () => {
+      const isolatedMetrics = await import("./content-metrics.ts?without-context");
+      isolatedMetrics.resetContentMetrics();
       // endRequestMetrics is a no-op when there is no active metrics store.
-      endRequestMetrics({ requestId: "no-start" });
-      const snapshot = getContentMetricsSnapshot();
+      isolatedMetrics.endRequestMetrics({ requestId: "no-start" });
+      const snapshot = isolatedMetrics.getContentMetricsSnapshot();
       assertEquals(
         snapshot.requestsTracked,
         0,

--- a/src/platform/adapters/fs/veryfront/directory-operations.test.ts
+++ b/src/platform/adapters/fs/veryfront/directory-operations.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { FileCache } from "../cache/file-cache.ts";
+import { buildFileListCacheKey } from "./cache-keys.ts";
 import { DirectoryOperations } from "./directory-operations.ts";
 import { PathNormalizer } from "./path-normalizer.ts";
 
@@ -47,9 +48,13 @@ describe("DirectoryOperations", () => {
   });
 
   describe("readdir with mock data", () => {
-    function createDirOpsWithFiles(
+    function createDirOpsHarness(
       files: Array<{ path: string; type?: string }>,
-    ): DirectoryOperations {
+    ): {
+      dirOps: DirectoryOperations;
+      files: Array<{ path: string; type?: string }>;
+      cache: FileCache;
+    } {
       const mockClient = {
         getRequestBranch: () => "main",
         listAllFiles: () => Promise.resolve(files),
@@ -58,7 +63,13 @@ describe("DirectoryOperations", () => {
 
       const cache = new FileCache({ enabled: true, ttl: 60000, maxSize: 100 });
       const normalizer = new PathNormalizer();
-      return new DirectoryOperations(mockClient, cache, normalizer);
+      return { dirOps: new DirectoryOperations(mockClient, cache, normalizer), files, cache };
+    }
+
+    function createDirOpsWithFiles(
+      files: Array<{ path: string; type?: string }>,
+    ): DirectoryOperations {
+      return createDirOpsHarness(files).dirOps;
     }
 
     it("should return empty array for empty project", async () => {
@@ -123,13 +134,35 @@ describe("DirectoryOperations", () => {
     });
 
     it("should cache readdir results", async () => {
-      const dirOps = createDirOpsWithFiles([
+      const { dirOps, files, cache } = createDirOpsHarness([
         { path: "index.tsx" },
       ]);
 
-      const entries1 = await dirOps.readdir("");
-      const entries2 = await dirOps.readdir("");
-      assertEquals(entries1.length, entries2.length);
+      assertEquals(
+        (await dirOps.readdir("")).map((entry) => entry.name),
+        ["index.tsx"],
+        "the first listing is built from the file list",
+      );
+
+      // Drop everything the second listing could rebuild from, so only the
+      // readdir cache can still produce the original answer.
+      files.push({ path: "added.tsx" });
+      dirOps.clearTree();
+      cache.delete(buildFileListCacheKey(undefined));
+
+      assertEquals(
+        (await dirOps.readdir("")).map((entry) => entry.name),
+        ["index.tsx"],
+        "readdir must answer from its cache, not rebuild the tree",
+      );
+
+      cache.clear();
+      dirOps.clearTree();
+      assertEquals(
+        (await dirOps.readdir("")).map((entry) => entry.name).sort(),
+        ["added.tsx", "index.tsx"],
+        "clearing the cache must let the new listing through",
+      );
     });
 
     it("should clear tree on clearTree call", async () => {

--- a/src/platform/adapters/fs/veryfront/extension-priority.test.ts
+++ b/src/platform/adapters/fs/veryfront/extension-priority.test.ts
@@ -29,25 +29,19 @@ describe("platform/adapters/fs/veryfront/extension-priority", () => {
   });
 
   describe("STAT_OPERATION_EXTENSION_PRIORITY", () => {
-    it("should have 6 extensions", () => {
-      assertEquals(STAT_OPERATION_EXTENSION_PRIORITY.length, 6);
-    });
-
-    it("should prioritize mdx first", () => {
-      assertEquals(STAT_OPERATION_EXTENSION_PRIORITY[0], ".mdx");
+    it("should pin the exact stat resolution precedence", () => {
+      const expected = [".mdx", ".md", ".tsx", ".jsx", ".ts", ".js"];
+      assertEquals(
+        [...STAT_OPERATION_EXTENSION_PRIORITY],
+        expected,
+        "stat resolution precedence is a contract",
+      );
     });
 
     it("should contain the same extensions as READ_OPERATION_EXTENSION_PRIORITY", () => {
       const readSorted = [...READ_OPERATION_EXTENSION_PRIORITY].sort();
       const statSorted = [...STAT_OPERATION_EXTENSION_PRIORITY].sort();
       assertEquals(readSorted, statSorted);
-    });
-
-    it("should have a different order from READ_OPERATION_EXTENSION_PRIORITY", () => {
-      const isSameOrder = READ_OPERATION_EXTENSION_PRIORITY.every(
-        (ext, i) => ext === STAT_OPERATION_EXTENSION_PRIORITY[i],
-      );
-      assertEquals(isSameOrder, false);
     });
   });
 });

--- a/src/platform/adapters/fs/veryfront/file-list-access.test.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-access.test.ts
@@ -135,4 +135,89 @@ describe("veryfront/file-list-access", () => {
     assertEquals(apiCalls, 1);
     assertEquals(loaded.map((file) => file.path), ["fresh.tsx"]);
   });
+
+  it("serves a valid persistent cache entry without calling the API", async () => {
+    let apiCalls = 0;
+    const cache = new FileCache({ enabled: true, ttl: 60_000, maxSize: 100 });
+    const contextProvider: ContentContextProvider = {
+      isProductionMode: () => false,
+      getReleaseId: () => null,
+      getContentContext: () => ({
+        sourceType: "branch",
+        projectSlug: "test",
+        branch: "main",
+      }),
+      isPersistentCacheInvalidated: () => false,
+    };
+
+    cache.set("files:branch:test:main", [makeFile("cached.tsx")]);
+
+    const loaded = await loadAllProjectFiles({
+      client: {
+        listAllFiles: () => {
+          apiCalls++;
+          return Promise.resolve([makeFile("fresh.tsx")]);
+        },
+        listPublishedFiles: () => Promise.resolve([]),
+      } as any,
+      cache,
+      contextProvider,
+      logger: createLogger(),
+      operationLabel: "test",
+    });
+
+    assertEquals(
+      loaded.map((file) => file.path),
+      ["cached.tsx"],
+      "a valid persistent cache entry must be served without hitting the API",
+    );
+    assertEquals(apiCalls, 0, "a persistent cache hit must not refetch the file list");
+  });
+
+  it("writes a fetched file list back to the persistent cache", async () => {
+    let apiCalls = 0;
+    const cache = new FileCache({ enabled: true, ttl: 60_000, maxSize: 100 });
+    const contextProvider: ContentContextProvider = {
+      isProductionMode: () => false,
+      getReleaseId: () => null,
+      getContentContext: () => ({
+        sourceType: "branch",
+        projectSlug: "test",
+        branch: "main",
+      }),
+      isPersistentCacheInvalidated: () => false,
+    };
+
+    const client = {
+      listAllFiles: () => {
+        apiCalls++;
+        return Promise.resolve([makeFile("fresh.tsx")]);
+      },
+      listPublishedFiles: () => Promise.resolve([]),
+    } as any;
+
+    await loadAllProjectFiles({
+      client,
+      cache,
+      contextProvider,
+      logger: createLogger(),
+      operationLabel: "test",
+    });
+
+    assertEquals(
+      (await cache.getAsync<ProjectFile[]>("files:branch:test:main"))?.map((file) => file.path),
+      ["fresh.tsx"],
+      "a fetched file list must be written back to the persistent cache",
+    );
+
+    await loadAllProjectFiles({
+      client,
+      cache,
+      contextProvider,
+      logger: createLogger(),
+      operationLabel: "test",
+    });
+
+    assertEquals(apiCalls, 1, "the written-back entry must answer the next load");
+  });
 });

--- a/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-fanout.test.ts
@@ -2,7 +2,8 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { VeryfrontFSAdapter } from "./adapter.ts";
-import { buildFileListCacheKey } from "./cache-keys.ts";
+import { buildFileCacheKeyPrefix, buildFileListCacheKey } from "./cache-keys.ts";
+import { addPendingInvalidation, removePendingInvalidation } from "./invalidation-state.ts";
 import { createAdapter, waitFor } from "./adapter.test-helpers.ts";
 
 interface StubFile {
@@ -814,15 +815,32 @@ describe("file list fan-out (issue inbox#32)", () => {
     // The fan-out gate disables snapshot recovery while the index can answer.
     // Raised in review: nothing pinned that recovery still works when it
     // cannot — i.e. that the gate narrows the path rather than closing it.
+    // The oracle is the recovered file itself: a request counter cannot tell a
+    // snapshot refresh apart from the ordinary listing probe.
     const files: StubFile[] = [{ path: "app/page.tsx", content: "export default () => null;" }];
-    const { adapter, counts } = createDraftAdapter(files, true, true);
+    const { adapter } = createDraftAdapter(files, true, true);
 
-    const before = counts.listFiles;
-    assertEquals(await adapter.resolveFile("app/added-later"), null);
     assertEquals(
-      counts.listFiles > before,
-      true,
-      "a recoverable snapshot must still refresh when the index cannot answer",
+      (await adapter.readdir("app")).map((entry) => entry.path),
+      ["app/page.tsx"],
+      "the pre-edit listing answers from the index",
+    );
+
+    files.push({ path: "lib/util.ts", content: "export const util = 1;" });
+
+    const branchSourcePrefix = buildFileCacheKeyPrefix(adapter.getContentContext());
+    let entries: Array<{ path: string }>;
+    try {
+      addPendingInvalidation(branchSourcePrefix);
+      entries = await adapter.readdir("lib");
+    } finally {
+      removePendingInvalidation(branchSourcePrefix);
+    }
+
+    assertEquals(
+      entries.map((entry) => entry.path),
+      ["lib/util.ts"],
+      "a recoverable snapshot must refresh and list the new file when the index cannot answer",
     );
   });
 

--- a/src/platform/adapters/fs/veryfront/file-list-index.test.ts
+++ b/src/platform/adapters/fs/veryfront/file-list-index.test.ts
@@ -131,16 +131,71 @@ describe("platform/adapters/fs/veryfront/file-list-index", () => {
   describe("index reuse", () => {
     it("should reuse index when cache key is unchanged", async () => {
       let callCount = 0;
-      const fileList = [{ path: "a.ts", content: "content" }];
+      const entry = { path: "a.ts", content: "v1" };
+      const fileList: Array<{ path: string; content: string }> = [entry];
       const index = new FileListIndex(async () => {
         callCount++;
         return fileList;
       });
 
-      await index.lookup("a.ts");
-      await index.lookup("a.ts");
-      // Both lookups call getFileListCache but second should reuse the built index
-      assertEquals(callCount, 2); // getFileListCache is called each time, but index is reused
+      assertEquals(await index.lookup("a.ts"), "v1", "the first lookup builds the index");
+
+      // Mutating content in place leaves the cache key (length, first and last
+      // path) untouched, so a reused index must still answer with the old value.
+      entry.content = "v2";
+      assertEquals(
+        await index.lookup("a.ts"),
+        "v1",
+        "an unchanged cache key must reuse the built index rather than re-walking the file list",
+      );
+
+      // Both lookups call getFileListCache but the second reuses the built index.
+      assertEquals(callCount, 2, "getFileListCache is consulted on every lookup");
+
+      fileList.push({ path: "b.ts", content: "v3" });
+      assertEquals(
+        await index.lookup("b.ts"),
+        "v3",
+        "a changed file-list key must rebuild the index",
+      );
+    });
+  });
+
+  describe("expired cache entry", () => {
+    it("keeps serving a warm index after the cache entry expires", async () => {
+      let calls = 0;
+      const index = new FileListIndex(async () => {
+        calls++;
+        return calls === 1 ? [{ path: "a.ts", content: "content-a" }] : undefined;
+      });
+
+      assertEquals(await index.lookup("a.ts"), "content-a", "the first read builds the index");
+      assertEquals(await index.match("a.ts"), {
+        status: "hit",
+        fresh: false,
+        path: "a.ts",
+        content: "content-a",
+      }, "an expired cache entry must keep serving the warm index, marked stale");
+    });
+
+    it("discards an index older than the staleness limit", async () => {
+      let calls = 0;
+      const index = new FileListIndex(async () => {
+        calls++;
+        return calls === 1 ? [{ path: "a.ts", content: "content-a" }] : undefined;
+      });
+
+      assertEquals(await index.lookup("a.ts"), "content-a", "the first read builds the index");
+
+      // Age the index past the limit rather than sleeping through it.
+      (index as unknown as { indexBuiltAt: number }).indexBuiltAt = Date.now() -
+        (5 * 60 * 1000 + 1);
+
+      assertEquals(
+        await index.match("a.ts"),
+        { status: "unavailable", fresh: false },
+        "a too-stale in-memory index must be discarded rather than served",
+      );
     });
   });
 });

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
@@ -1,6 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
 
-import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertInstanceOf,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   clearRequestScopedFileCache,
@@ -96,11 +102,21 @@ describe("MultiProjectFSAdapter", () => {
 
     it("rejects a context-less read with an actionable initialization error", async () => {
       await withAdapterAsync(async (adapter) => {
-        await assertRejects(
+        const rejection = await assertRejects(
           () => adapter.readTextFile("a.ts"),
           Error,
           "Use runWithContext() to set project context before accessing files",
           "a read with neither a request context nor a default adapter must name runWithContext",
+        );
+        assertInstanceOf(
+          rejection,
+          Error,
+          "the context-less read must reject with an Error carrying a message",
+        );
+        assertStringIncludes(
+          rejection.message,
+          "[MultiProjectFSAdapter] No request context available.",
+          "the remedy must stay attached to the symptom that explains why the read failed",
         );
       });
     });

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
@@ -94,6 +94,17 @@ describe("MultiProjectFSAdapter", () => {
       });
     });
 
+    it("rejects a context-less read with an actionable initialization error", async () => {
+      await withAdapterAsync(async (adapter) => {
+        await assertRejects(
+          () => adapter.readTextFile("a.ts"),
+          Error,
+          "No request context available",
+          "a read with neither a request context nor a default adapter must name runWithContext",
+        );
+      });
+    });
+
     it("forwards exact reads only to the selected captured authority", async () => {
       await withAdapterAsync(async (adapter) => {
         let exactCalls = 0;
@@ -120,6 +131,53 @@ describe("MultiProjectFSAdapter", () => {
         assertEquals([...result], [1, 2, 3]);
         assertEquals(exactCalls, 1);
         assertEquals(unboundedCalls, 0);
+      });
+    });
+
+    it("refuses a whole-file reader whose ceiling exceeds the requested limit", async () => {
+      await withAdapterAsync(async (adapter) => {
+        let reads = 0;
+        adapter.setDefaultAdapter(
+          {
+            maxWholeFileReadBytes: 64,
+            readFileBytes() {
+              reads++;
+              return Promise.resolve(new Uint8Array(3));
+            },
+            dispose() {},
+          } as unknown as Parameters<MultiProjectFSAdapter["setDefaultAdapter"]>[0],
+        );
+
+        await assertRejects(
+          () => adapter.readFileBytesWithinLimit("asset.css", 3),
+          TypeError,
+          "whole-file ceiling no larger than 3 bytes",
+          "a whole-file ceiling above the requested limit must not satisfy a bounded read",
+        );
+        assertEquals(reads, 0, "an over-ceiling whole-file reader must not be read from");
+      });
+    });
+
+    it("uses a whole-file reader whose ceiling fits inside the requested limit", async () => {
+      await withAdapterAsync(async (adapter) => {
+        let reads = 0;
+        adapter.setDefaultAdapter(
+          {
+            maxWholeFileReadBytes: 3,
+            readFileBytes() {
+              reads++;
+              return Promise.resolve(new Uint8Array([1, 2, 3]));
+            },
+            dispose() {},
+          } as unknown as Parameters<MultiProjectFSAdapter["setDefaultAdapter"]>[0],
+        );
+
+        assertEquals(
+          [...await adapter.readFileBytesWithinLimit("asset.css", 3)],
+          [1, 2, 3],
+          "a within-ceiling whole-file reader satisfies the bounded read",
+        );
+        assertEquals(reads, 1, "the whole-file reader is the one consulted");
       });
     });
 
@@ -367,6 +425,7 @@ describe("MultiProjectFSAdapter", () => {
         let capturedProductionMode: boolean | undefined;
         let capturedReleaseId: string | null | undefined;
         let capturedEnvironmentName: string | null | undefined;
+        let capturedBranch: string | null | undefined;
 
         (adapter as any).manager = {
           getAdapter(
@@ -376,6 +435,7 @@ describe("MultiProjectFSAdapter", () => {
             productionMode?: boolean,
             releaseId?: string | null,
             environmentName?: string | null,
+            branch?: string | null,
           ) {
             getAdapterCalled = true;
             capturedProjectSlug = projectSlug;
@@ -383,6 +443,7 @@ describe("MultiProjectFSAdapter", () => {
             capturedProductionMode = productionMode;
             capturedReleaseId = releaseId;
             capturedEnvironmentName = environmentName;
+            capturedBranch = branch;
             return Promise.resolve({});
           },
           getStats: () => ({ adapters: 0, stats: [] }),
@@ -401,6 +462,7 @@ describe("MultiProjectFSAdapter", () => {
               productionMode: true,
               releaseId: "rel-first-hit",
               environmentName: "production",
+              branch: "main",
             },
           );
         } finally {
@@ -413,6 +475,58 @@ describe("MultiProjectFSAdapter", () => {
         assertEquals(capturedProductionMode, true);
         assertEquals(capturedReleaseId, "rel-first-hit");
         assertEquals(capturedEnvironmentName, "production");
+        assertEquals(
+          capturedBranch,
+          null,
+          "a production release request must not forward a branch",
+        );
+      });
+    });
+
+    it("does not forward a releaseId for a preview branch request", async () => {
+      await withAdapterAsync(async (adapter) => {
+        const originalManager = (adapter as any).manager;
+        let capturedReleaseId: string | null | undefined;
+        let capturedBranch: string | null | undefined;
+
+        (adapter as any).manager = {
+          getAdapter(
+            _projectSlug: string,
+            _token: string,
+            _projectId?: string,
+            _productionMode?: boolean,
+            releaseId?: string | null,
+            _environmentName?: string | null,
+            branch?: string | null,
+          ) {
+            capturedReleaseId = releaseId;
+            capturedBranch = branch;
+            return Promise.resolve({
+              readOptionalTextFile: () => Promise.resolve("preview stylesheet"),
+            });
+          },
+          getStats: () => ({ adapters: 0, stats: [] }),
+          dispose: () => {},
+        };
+
+        try {
+          await adapter.runWithContext(
+            "project-preview",
+            "test-token",
+            () => adapter.readOptionalTextFile("app/globals.css"),
+            "project-id-preview",
+            {
+              productionMode: false,
+              releaseId: "rel-x",
+              branch: "feature-x",
+            },
+          );
+        } finally {
+          (adapter as any).manager = originalManager;
+        }
+
+        assertEquals(capturedReleaseId, null, "a preview request must not forward a releaseId");
+        assertEquals(capturedBranch, "feature-x", "a preview request forwards its branch");
       });
     });
   });

--- a/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
+++ b/src/platform/adapters/fs/veryfront/multi-project-adapter.test.ts
@@ -99,7 +99,7 @@ describe("MultiProjectFSAdapter", () => {
         await assertRejects(
           () => adapter.readTextFile("a.ts"),
           Error,
-          "No request context available",
+          "Use runWithContext() to set project context before accessing files",
           "a read with neither a request context nor a default adapter must name runWithContext",
         );
       });

--- a/src/platform/adapters/fs/veryfront/proxy-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/proxy-manager.test.ts
@@ -9,6 +9,7 @@ import {
   assertThrows,
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { waitFor } from "#veryfront/testing/deno-compat.ts";
 import { API_CLIENT_ERROR } from "#veryfront/errors";
 import {
   __registerLogRecordEmitter,
@@ -32,6 +33,24 @@ function createManager(
   options: Partial<ConstructorParameters<typeof ProxyFSAdapterManager>[0]> = {},
 ): ProxyFSAdapterManager {
   return new ProxyFSAdapterManager({ baseConfig, ...options });
+}
+
+/**
+ * Adapter factory whose adapters skip network initialization and record every
+ * dispose() call, so cache lifecycle assertions can observe adapter teardown.
+ */
+function createRecordingAdapterFactory(disposedSlugs: string[]) {
+  return (config: ConstructorParameters<typeof VeryfrontFSAdapter>[0]): VeryfrontFSAdapter => {
+    const projectSlug = config.veryfront?.projectSlug ?? "";
+    const adapter = new VeryfrontFSAdapter(config);
+    adapter.initialize = () => Promise.resolve();
+    const disposeAdapter = adapter.dispose.bind(adapter);
+    adapter.dispose = (): void => {
+      disposedSlugs.push(projectSlug);
+      disposeAdapter();
+    };
+    return adapter;
+  };
 }
 
 async function assertGetAdapterRejects(
@@ -456,6 +475,63 @@ describe("ProxyFSAdapterManager", () => {
     });
   });
 
+  describe("idle cleanup", () => {
+    it("disposes idle adapters and keeps adapters inside their idle window", async () => {
+      const idleDisposedSlugs: string[] = [];
+      const retainedDisposedSlugs: string[] = [];
+      const idleManager = createManager({
+        cleanupIntervalMs: 5,
+        maxIdleMs: 0,
+        adapterFactory: createRecordingAdapterFactory(idleDisposedSlugs),
+      });
+      const retainingManager = createManager({
+        cleanupIntervalMs: 5,
+        maxIdleMs: 60_000,
+        adapterFactory: createRecordingAdapterFactory(retainedDisposedSlugs),
+      });
+
+      try {
+        await idleManager.getAdapter("idle-project", "token", undefined, false, null, null, "main");
+        await retainingManager.getAdapter(
+          "fresh-project",
+          "token",
+          undefined,
+          false,
+          null,
+          null,
+          "main",
+        );
+        assertEquals(idleManager.getStats().adapters, 1, "the idle adapter starts cached");
+        assertEquals(retainingManager.getStats().adapters, 1, "the fresh adapter starts cached");
+
+        await waitFor(() => idleManager.getStats().adapters === 0, {
+          message: "an idle adapter must be removed by the cleanup timer",
+        });
+        assertEquals(
+          idleDisposedSlugs,
+          ["idle-project"],
+          "an idle adapter must be disposed, not just dropped",
+        );
+
+        // Both managers share a cleanup interval, so the eviction above proves
+        // the timer has ticked for the retaining manager too.
+        assertEquals(
+          retainingManager.getStats().adapters,
+          1,
+          "an adapter inside its idle window must survive the same cleanup ticks",
+        );
+        assertEquals(
+          retainedDisposedSlugs,
+          [],
+          "an adapter inside its idle window must not be disposed",
+        );
+      } finally {
+        idleManager.dispose();
+        retainingManager.dispose();
+      }
+    });
+  });
+
   describe("methods", () => {
     it("should have getAdapter method", () => {
       const manager = createManager();
@@ -489,21 +565,67 @@ describe("ProxyFSAdapterManager", () => {
       manager.dispose();
     });
 
-    it("should differentiate adapters by branch in preview mode", () => {
-      const manager = createManager();
-      assertEquals(manager.hasAdapter("project", false, null, "main"), false);
-      assertEquals(manager.hasAdapter("project", false, null, "feature-x"), false);
-      assertEquals(manager.hasAdapter("project", false, null, null), false);
-      manager.dispose();
+    it("should differentiate adapters by branch in preview mode", async () => {
+      const manager = createManager({
+        adapterFactory: createRecordingAdapterFactory([]),
+      });
+      try {
+        await manager.getAdapter("project", "token", undefined, false, null, null, "main");
+        await manager.getAdapter("project", "token", undefined, false, null, null, "feature-x");
+
+        assertEquals(
+          manager.hasAdapter("project", false, null, "main"),
+          true,
+          "the main-branch adapter must be selectable",
+        );
+        assertEquals(
+          manager.hasAdapter("project", false, null, "feature-x"),
+          true,
+          "the feature-branch adapter must be selectable",
+        );
+        assertEquals(
+          manager.hasAdapter("project", false, null, "other"),
+          false,
+          "branch must be part of preview adapter selection",
+        );
+      } finally {
+        manager.dispose();
+      }
     });
 
-    it("should treat null branch as main branch", () => {
-      const manager = createManager();
-      assertEquals(
-        manager.hasAdapter("project", false, null, null),
-        manager.hasAdapter("project", false, null, "main"),
-      );
-      manager.dispose();
+    it("should treat null branch as main branch", async () => {
+      const manager = createManager({
+        adapterFactory: createRecordingAdapterFactory([]),
+      });
+      try {
+        await manager.getAdapter("my-project", "test-token", undefined, false, null, null, "main");
+
+        assertEquals(
+          manager.hasAdapter("my-project", false, null, null),
+          true,
+          "null branch resolves to the cached main-branch adapter",
+        );
+        assertEquals(
+          manager.hasAdapter("my-project", false, null, "main"),
+          true,
+          "the cached adapter is still selectable by its explicit branch",
+        );
+        assertEquals(
+          manager.hasAdapter("my-project", false, null, "feature-x"),
+          false,
+          "another branch must not resolve to the main-branch adapter",
+        );
+
+        manager.evictAdapter("my-project", false, null, null);
+
+        assertEquals(
+          manager.hasAdapter("my-project", false, null, "main"),
+          false,
+          "eviction by null branch must remove the main-branch adapter",
+        );
+      } finally {
+        manager.dispose();
+      }
     });
 
     it("should ignore branch for production mode", () => {
@@ -623,11 +745,23 @@ describe("ProxyFSAdapterManager", () => {
       manager.dispose();
     });
 
-    it("should clear all adapters on dispose", () => {
-      const manager = createManager();
-      assertEquals(manager.getStats().adapters, 0);
+    it("should clear all adapters on dispose", async () => {
+      const disposedSlugs: string[] = [];
+      const manager = createManager({
+        adapterFactory: createRecordingAdapterFactory(disposedSlugs),
+      });
+
+      await manager.getAdapter("test-project", "test-token", undefined, false, null, null, "main");
+      assertEquals(manager.getStats().adapters, 1, "a cached adapter is tracked before dispose");
+
       manager.dispose();
-      assertEquals(manager.getStats().adapters, 0);
+
+      assertEquals(manager.getStats().adapters, 0, "dispose must clear the adapter map");
+      assertEquals(
+        disposedSlugs,
+        ["test-project"],
+        "dispose must dispose each cached adapter's timers and socket",
+      );
     });
   });
 
@@ -672,11 +806,24 @@ describe("ProxyFSAdapterManager", () => {
       manager.dispose();
     });
 
-    it("should remove all adapters on dispose", () => {
-      const manager = createManager();
-      assertEquals(manager.getStats().adapters, 0);
+    it("should remove all adapters on dispose", async () => {
+      const disposedSlugs: string[] = [];
+      const manager = createManager({
+        adapterFactory: createRecordingAdapterFactory(disposedSlugs),
+      });
+
+      await manager.getAdapter("project-one", "test-token", undefined, false, null, null, "main");
+      await manager.getAdapter("project-two", "test-token", undefined, false, null, null, "main");
+      assertEquals(manager.getStats().adapters, 2, "both cached adapters are tracked");
+
       manager.dispose();
-      assertEquals(manager.getStats().adapters, 0);
+
+      assertEquals(manager.getStats().adapters, 0, "dispose must clear every cached adapter");
+      assertEquals(
+        disposedSlugs.slice().sort(),
+        ["project-one", "project-two"],
+        "dispose must dispose every cached adapter, not just the first",
+      );
     });
   });
 
@@ -926,6 +1073,50 @@ describe("ProxyFSAdapterManager", () => {
       } finally {
         initializationGate.resolve();
         await firstRequest?.catch(() => {});
+        manager.dispose();
+      }
+    });
+
+    it("evicts the least recently used adapter, not the most recent", async () => {
+      const disposedSlugs: string[] = [];
+      // ProxyFSAdapterManager stamps lastAccessed with Date.now(), so a pinned
+      // clock is what makes the three admissions strictly ordered instead of
+      // sharing a millisecond.
+      const originalNow = Date.now;
+      let clock = 1_000_000;
+      Date.now = (): number => clock;
+      const manager = createManager({
+        maxAdapters: 2,
+        adapterFactory: createRecordingAdapterFactory(disposedSlugs),
+      });
+
+      try {
+        await manager.getAdapter("tenant-a", "credential", undefined, false, null, null, "main");
+        clock += 1_000;
+        await manager.getAdapter("tenant-b", "credential", undefined, false, null, null, "main");
+        clock += 1_000;
+        // Refreshing A makes B the least recently used entry.
+        await manager.getAdapter("tenant-a", "credential", undefined, false, null, null, "main");
+        clock += 1_000;
+        await manager.getAdapter("tenant-c", "credential", undefined, false, null, null, "main");
+
+        assertEquals(
+          manager.hasAdapter("tenant-a", false, null, "main"),
+          true,
+          "the most recently used adapter must survive admission",
+        );
+        assertEquals(
+          manager.hasAdapter("tenant-b", false, null, "main"),
+          false,
+          "the least recently used adapter must be the one evicted",
+        );
+        assertEquals(
+          disposedSlugs,
+          ["tenant-b"],
+          "eviction must dispose only the least recently used adapter",
+        );
+      } finally {
+        Date.now = originalNow;
         manager.dispose();
       }
     });

--- a/src/platform/adapters/fs/veryfront/read-operations.test.ts
+++ b/src/platform/adapters/fs/veryfront/read-operations.test.ts
@@ -6,6 +6,7 @@ import type { VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
 import { FileCache } from "../cache/file-cache.ts";
 import type { ContentContextProvider } from "./file-list-access.ts";
 import { runWithRequestContext } from "./multi-project-adapter.ts";
+import { buildFileCacheKeyPrefix } from "./cache-keys.ts";
 import { PathNormalizer } from "./path-normalizer.ts";
 import { ReadOperations } from "./read-operations.ts";
 
@@ -973,26 +974,52 @@ describe("ReadOperations", () => {
   });
 
   describe("clearFileListIndex", () => {
-    it("should clear without error when no index exists", () => {
-      const readOps = createReadOps(createMockClient(), true);
+    it("should clear without error when no index exists", async () => {
+      const client = createMockClient({
+        getFileContent: () => Promise.resolve("api content"),
+      });
+      const readOps = createReadOps(client, false, createBranchContext());
+      readOps.setFileListReadyPromise(Promise.resolve());
+
       readOps.clearFileListIndex();
+
+      assertEquals(
+        await readOps.readTextFile("pages/index.tsx"),
+        "api content",
+        "clearing an unbuilt index must leave later reads working",
+      );
     });
 
     it("should clear built index", async () => {
       const client = createMockClient({
         getFileContent: () => Promise.resolve("content"),
       });
+      const files = [{ path: "pages/index.tsx", content: "v1" }];
 
       const readOps = createReadOps(
         client,
         false,
         createReleaseContext(),
         (path: string) => path,
-        () => Promise.resolve([{ path: "pages/index.tsx", content: "test content" }]),
+        () => Promise.resolve(files),
       );
 
-      await readOps.readTextFile("pages/index.tsx");
+      assertEquals(
+        await readOps.readTextFile("pages/index.tsx"),
+        "v1",
+        "first read builds the file-list index",
+      );
+
+      // The list length and its first/last path stay the same, so the index key
+      // memo would keep serving v1 unless the index itself is discarded.
+      files[0]!.content = "v2";
       readOps.clearFileListIndex();
+
+      assertEquals(
+        await readOps.readTextFile("pages/index.tsx"),
+        "v2",
+        "clearFileListIndex must discard the in-memory file-list index, not just the extension cache",
+      );
     });
   });
 
@@ -1020,7 +1047,7 @@ describe("ReadOperations", () => {
   });
 
   describe("cache invalidation", () => {
-    it("should accept isPersistentCacheInvalidated in context provider", () => {
+    it("should honour isPersistentCacheInvalidated from the context provider", async () => {
       const contextProvider: ContentContextProvider = {
         isProductionMode: () => true,
         getReleaseId: () => "release-123",
@@ -1030,11 +1057,22 @@ describe("ReadOperations", () => {
           releaseId: "release-123",
         }),
         isPersistentCacheInvalidated: (prefix: string) => prefix.includes("release-123"),
-        isReleaseBeingInvalidated: (releaseId: string) => releaseId === "release-123",
+        isReleaseBeingInvalidated: () => false,
       };
 
-      const readOps = createReadOps(createMockClient(), true, contextProvider);
-      assertExists(readOps);
+      const client = createMockClient({
+        getPublishedFileContent: () => Promise.resolve("fresh api content"),
+      });
+      const cache = new FileCache({ enabled: true, ttl: 60000, maxSize: 100 });
+      cache.set("file:release:test:release-123:pages/index.tsx", "stale persistent content");
+
+      const readOps = new ReadOperations(client, cache, new PathNormalizer(), contextProvider);
+
+      assertEquals(
+        await readOps.readTextFile("pages/index.tsx"),
+        "fresh api content",
+        "an invalidated prefix reported by the provider must bypass the persistent cache",
+      );
     });
 
     it("should skip persistent cache when release is being invalidated", async () => {
@@ -1310,7 +1348,7 @@ describe("ReadOperations", () => {
       );
     });
 
-    it("should track invalidation state changes", () => {
+    it("should track invalidation state changes", async () => {
       const invalidatedReleases = new Set<string>();
 
       const contextProvider: ContentContextProvider = {
@@ -1325,17 +1363,41 @@ describe("ReadOperations", () => {
         isReleaseBeingInvalidated: (releaseId: string) => invalidatedReleases.has(releaseId),
       };
 
-      assertEquals(contextProvider.isReleaseBeingInvalidated?.("release-456"), false);
+      const client = createMockClient({
+        getPublishedFileContent: () => Promise.resolve("fresh api content"),
+      });
+      const cache = new FileCache({ enabled: true, ttl: 60000, maxSize: 100 });
+      const cacheKey = "file:release:test-project:release-456:pages/index.tsx";
+      cache.set(cacheKey, "stale persistent content");
+
+      assertEquals(
+        await new ReadOperations(client, cache, new PathNormalizer(), contextProvider)
+          .readTextFile("pages/index.tsx"),
+        "stale persistent content",
+        "a release that is not being invalidated must still serve the cached value",
+      );
 
       invalidatedReleases.add("release-456");
-      assertEquals(contextProvider.isReleaseBeingInvalidated?.("release-456"), true);
-      assertEquals(contextProvider.isReleaseBeingInvalidated?.("release-789"), false);
+
+      assertEquals(
+        await new ReadOperations(client, cache, new PathNormalizer(), contextProvider)
+          .readTextFile("pages/index.tsx"),
+        "fresh api content",
+        "a release marked as invalidating must bypass the persistent cache",
+      );
 
       invalidatedReleases.delete("release-456");
-      assertEquals(contextProvider.isReleaseBeingInvalidated?.("release-456"), false);
+      cache.set(cacheKey, "stale persistent content");
+
+      assertEquals(
+        await new ReadOperations(client, cache, new PathNormalizer(), contextProvider)
+          .readTextFile("pages/index.tsx"),
+        "stale persistent content",
+        "clearing the invalidation must return the read to the persistent cache",
+      );
     });
 
-    it("should handle prefix-based invalidation", () => {
+    it("should handle prefix-based invalidation", async () => {
       const invalidatedPrefixes = new Set<string>();
 
       const contextProvider: ContentContextProvider = {
@@ -1355,43 +1417,46 @@ describe("ReadOperations", () => {
         isReleaseBeingInvalidated: () => false,
       };
 
+      const client = createMockClient({
+        getPublishedFileContent: () => Promise.resolve("fresh api content"),
+      });
+      const cache = new FileCache({ enabled: true, ttl: 60000, maxSize: 100 });
+      const cacheKey = "file:release:my-project:release-abc:pages/index.tsx";
+      cache.set(cacheKey, "stale persistent content");
+
+      invalidatedPrefixes.add("file:release:my-project:release-xyz:");
       assertEquals(
-        contextProvider.isPersistentCacheInvalidated?.("file:release:my-project:release-abc:"),
-        false,
+        await new ReadOperations(client, cache, new PathNormalizer(), contextProvider)
+          .readTextFile("pages/index.tsx"),
+        "stale persistent content",
+        "a non-matching prefix must still serve the cached value",
       );
 
+      invalidatedPrefixes.clear();
       invalidatedPrefixes.add("file:release:my-project:release-abc:");
+      cache.set(cacheKey, "stale persistent content");
 
       assertEquals(
-        contextProvider.isPersistentCacheInvalidated?.("file:release:my-project:release-abc:"),
-        true,
-      );
-
-      assertEquals(
-        contextProvider.isPersistentCacheInvalidated?.(
-          "file:release:my-project:release-abc:components/app.tsx",
-        ),
-        true,
-      );
-
-      assertEquals(
-        contextProvider.isPersistentCacheInvalidated?.("file:release:my-project:release-xyz:"),
-        false,
+        await new ReadOperations(client, cache, new PathNormalizer(), contextProvider)
+          .readTextFile("pages/index.tsx"),
+        "fresh api content",
+        "a matching invalidated prefix must bypass the persistent cache",
       );
     });
 
-    it("should handle environment-based invalidation", () => {
+    it("should handle environment-based invalidation", async () => {
       const invalidatedPrefixes = new Set<string>();
 
+      const environmentContext = {
+        sourceType: "environment" as const,
+        projectSlug: "env-project",
+        environmentName: "production",
+        releaseId: "release-env-123",
+      };
       const contextProvider: ContentContextProvider = {
         isProductionMode: () => true,
         getReleaseId: () => "release-env-123",
-        getContentContext: () => ({
-          sourceType: "environment" as const,
-          projectSlug: "env-project",
-          environmentName: "production",
-          releaseId: "release-env-123",
-        }),
+        getContentContext: () => environmentContext,
         isPersistentCacheInvalidated: (prefix: string) => {
           for (const pending of invalidatedPrefixes) {
             if (prefix.startsWith(pending) || pending.startsWith(prefix)) return true;
@@ -1401,20 +1466,30 @@ describe("ReadOperations", () => {
         isReleaseBeingInvalidated: () => false,
       };
 
-      invalidatedPrefixes.add("file:release:env-project:release-env-123:");
-      invalidatedPrefixes.add("file:env:env-project:production:");
+      const client = createMockClient({
+        getPublishedFileContent: () => Promise.resolve("fresh api content"),
+      });
+      const cache = new FileCache({ enabled: true, ttl: 60000, maxSize: 100 });
+      const cacheKey = `${buildFileCacheKeyPrefix(environmentContext)}:pages/index.tsx`;
+      cache.set(cacheKey, "stale persistent content");
+
+      invalidatedPrefixes.add("file:env:env-project:staging:");
+      assertEquals(
+        await new ReadOperations(client, cache, new PathNormalizer(), contextProvider)
+          .readTextFile("pages/index.tsx"),
+        "stale persistent content",
+        "an unrelated environment prefix must still serve the cached value",
+      );
+
+      invalidatedPrefixes.clear();
+      invalidatedPrefixes.add("file:env:env-project:");
+      cache.set(cacheKey, "stale persistent content");
 
       assertEquals(
-        contextProvider.isPersistentCacheInvalidated?.("file:release:env-project:release-env-123:"),
-        true,
-      );
-      assertEquals(
-        contextProvider.isPersistentCacheInvalidated?.("file:env:env-project:production:"),
-        true,
-      );
-      assertEquals(
-        contextProvider.isPersistentCacheInvalidated?.("file:env:env-project:staging:"),
-        false,
+        await new ReadOperations(client, cache, new PathNormalizer(), contextProvider)
+          .readTextFile("pages/index.tsx"),
+        "fresh api content",
+        "an invalidated environment prefix must bypass the persistent cache",
       );
     });
   });
@@ -1513,10 +1588,22 @@ describe("ReadOperations", () => {
         },
       );
 
-      await readOps.readTextFile("pages/index.tsx");
-      await readOps.readTextFile("pages/about.tsx");
+      assertEquals(
+        await readOps.readTextFile("pages/index.tsx"),
+        "index content",
+        "the first read is served from the freshly built index",
+      );
 
-      assertEquals(indexBuildCount >= 1, true);
+      // The list length and its first/last path stay the same, so the index key
+      // is unchanged and the memoized index must answer the second read.
+      fileList[0]!.content = "mutated content";
+
+      assertEquals(
+        await readOps.readTextFile("pages/index.tsx"),
+        "index content",
+        "an unchanged index key must reuse the memoized index instead of rebuilding it",
+      );
+      assertEquals(indexBuildCount, 2, "getFileListCache is consulted once per read");
     });
   });
 });

--- a/src/platform/adapters/fs/veryfront/retry.test.ts
+++ b/src/platform/adapters/fs/veryfront/retry.test.ts
@@ -37,6 +37,20 @@ describe("platform/adapters/fs/veryfront/retry", () => {
       assertEquals(callCount, 2);
     });
 
+    it("should not retry a non-TypeError whose message merely mentions fetch", async () => {
+      let callCount = 0;
+      await assertRejects(
+        () =>
+          withRetryOnTransient(() => {
+            callCount++;
+            throw new Error("fetch failed");
+          }, "test"),
+        Error,
+        "fetch failed",
+      );
+      assertEquals(callCount, 1, "a plain Error mentioning fetch is not treated as transient");
+    });
+
     it("should retry once on 500 status error", async () => {
       let callCount = 0;
       const result = await withRetryOnTransient(() => {

--- a/src/platform/adapters/fs/veryfront/stat-operations-helpers.test.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations-helpers.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { ProjectFile } from "../../veryfront-api-client/index.ts";
+import { STAT_OPERATION_EXTENSION_PRIORITY } from "./extension-priority.ts";
 import {
   collectParentDirectories,
   normalizeIndexedFilePath,
@@ -42,38 +43,76 @@ describe("veryfront/stat-operations-helpers", () => {
   });
 
   it("strips only known extensions", () => {
-    const order = [".mdx", ".md", ".tsx", ".jsx", ".ts", ".js"] as const;
-    assertEquals(stripKnownExtension("pages/index.tsx", order), "pages/index");
-    assertEquals(stripKnownExtension("pages/index.unknown", order), "pages/index.unknown");
+    for (const ext of STAT_OPERATION_EXTENSION_PRIORITY) {
+      assertEquals(
+        stripKnownExtension(`pages/index${ext}`, STAT_OPERATION_EXTENSION_PRIORITY),
+        "pages/index",
+        `stripKnownExtension must strip ${ext}, which is in the priority list`,
+      );
+    }
+    assertEquals(
+      stripKnownExtension("pages/index.unknown", STAT_OPERATION_EXTENSION_PRIORITY),
+      "pages/index.unknown",
+      "an extension outside the priority list must be left untouched",
+    );
   });
 
   it("resolves direct and index matches by extension priority", () => {
     const order = [".mdx", ".md", ".tsx", ".jsx", ".ts", ".js"] as const;
     const idx = new Map<string, ProjectFile>([
       ["pages/home.tsx", makeFile("pages/home.tsx")],
+      ["pages/home.mdx", makeFile("pages/home.mdx", "page")],
       ["docs/index.mdx", makeFile("docs/index.mdx", "page")],
+      ["docs/index.tsx", makeFile("docs/index.tsx")],
+      ["blog/post.js", makeFile("blog/post.js")],
+      ["blog/post.ts", makeFile("blog/post.ts")],
     ]);
 
-    assertEquals(resolveByExtensionPriority(idx, "pages/home", order), "pages/home.tsx");
-    assertEquals(resolveIndexByExtensionPriority(idx, "docs", order), "docs/index.mdx");
-    assertEquals(resolveByExtensionPriority(idx, "missing/path", order), null);
+    assertEquals(
+      resolveByExtensionPriority(idx, "pages/home", order),
+      "pages/home.mdx",
+      "mdx wins over tsx for the same base path",
+    );
+    assertEquals(
+      resolveIndexByExtensionPriority(idx, "docs", order),
+      "docs/index.mdx",
+      "index.mdx wins over index.tsx for the same directory",
+    );
+    assertEquals(
+      resolveByExtensionPriority(idx, "blog/post", order),
+      "blog/post.ts",
+      "ts wins over js for the same base path",
+    );
+    assertEquals(
+      resolveByExtensionPriority(idx, "missing/path", order),
+      null,
+      "an unknown base path resolves to null",
+    );
   });
 
   it("sorts API matches by extension priority", () => {
     const order = [".mdx", ".md", ".tsx", ".jsx", ".ts", ".js"] as const;
     const sorted = sortPathsByExtensionPriority(
       [
+        { path: "pages/a.css" },
         { path: "pages/a.tsx" },
         { path: "pages/a.mdx" },
         { path: "pages/a.js" },
+        { path: "pages/a.json" },
       ],
       order,
     );
 
-    assertEquals(sorted.map((m) => m.path), [
-      "pages/a.mdx",
-      "pages/a.tsx",
-      "pages/a.js",
-    ]);
+    assertEquals(
+      sorted.map((m) => m.path),
+      [
+        "pages/a.mdx",
+        "pages/a.tsx",
+        "pages/a.js",
+        "pages/a.css",
+        "pages/a.json",
+      ],
+      "unknown extensions sort behind every known extension",
+    );
   });
 });

--- a/src/platform/adapters/fs/veryfront/stat-operations.test.ts
+++ b/src/platform/adapters/fs/veryfront/stat-operations.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { isNotFoundError } from "#veryfront/platform/compat/fs.ts";
 import type { ProjectFile, VeryfrontApiClient } from "../../veryfront-api-client/index.ts";
@@ -162,6 +162,45 @@ describe("StatOperations", () => {
       }
     });
 
+    it("should recover a file missing from a stale index via API search", async () => {
+      let searchCalls = 0;
+      const client = createMockClient({
+        searchFiles: (pattern: string) => {
+          searchCalls++;
+          return Promise.resolve(
+            pattern === "components/Late.tsx"
+              ? [{ id: "late-1", path: "components/Late.tsx" }]
+              : [],
+          );
+        },
+      });
+      const statOps = createStatOps(
+        client,
+        new PathNormalizer(),
+        createBranchContextWithFiles([makeFile("pages/index.tsx")]),
+      );
+
+      await statOps.stat("pages/index.tsx");
+      (statOps as unknown as { indexBuiltAt: number }).indexBuiltAt = Date.now() -
+        (5 * 60 * 1000 + 1);
+
+      const info = await statOps.stat("components/Late.tsx");
+      assertEquals(
+        info.isFile,
+        true,
+        "a file missing from a stale index must be recovered via searchFiles",
+      );
+      assertEquals(info.isDirectory, false, "the recovered entry is a file, not a directory");
+      assertEquals(searchCalls, 1, "the stale index must fall back to exactly one API search");
+
+      await statOps.stat("components/Late.tsx");
+      assertEquals(
+        searchCalls,
+        1,
+        "the recovered file must be inserted into the index, not re-searched",
+      );
+    });
+
     it("should normalize paths with project dir", async () => {
       const statOps = createStatOps(
         createMockClient(),
@@ -246,6 +285,28 @@ describe("StatOperations", () => {
       );
 
       assertEquals(await statOps.exists("nonexistent.tsx"), false);
+    });
+
+    it("should propagate non-not-found failures instead of reporting absence", async () => {
+      const statOps = createStatOps(createMockClient(), new PathNormalizer(), {
+        isProductionMode: () => false,
+        getReleaseId: () => null,
+        getContentContext: () => ({
+          sourceType: "branch" as const,
+          projectSlug: "test",
+          branch: "main",
+        }),
+        getFileList: () => Promise.reject(new Error("upstream down")),
+        hasCachedFileList: () => Promise.resolve(false),
+        isPersistentCacheInvalidated: () => false,
+      });
+
+      await assertRejects(
+        () => statOps.exists("pages/index.tsx"),
+        Error,
+        "upstream down",
+        "an upstream listing failure must surface, not be reported as absence",
+      );
     });
 
     it("should not route existence misses through the public stat span", async () => {
@@ -753,6 +814,52 @@ describe("StatOperations", () => {
         // First request exhausts 4 patterns, second request trips the breaker on its first pattern,
         // and the post-cooldown request gets another full 4-pattern attempt.
         assertEquals(searchCallCount, 9);
+      } finally {
+        Date.now = originalNow;
+      }
+    });
+
+    it("should not negatively cache a path it could not search while the breaker was open", async () => {
+      const originalNow = Date.now;
+      let now = originalNow();
+      Date.now = () => now;
+
+      try {
+        let failing = true;
+        const client = createMockClient({
+          searchFiles: (pattern: string) => {
+            if (failing) return Promise.reject(new Error("API error"));
+            return Promise.resolve(
+              pattern === "pages/late.*" ? [{ path: "pages/late.tsx" }] : [],
+            );
+          },
+        });
+
+        const statOps = new StatOperations(
+          client,
+          new FileCache({ enabled: true, ttl: 60_000, maxSize: 100 }),
+          new PathNormalizer(),
+          createBranchContextWithFiles([makeFile("pages/index.tsx")]),
+        );
+
+        for (let i = 0; i < 5; i++) {
+          await statOps.resolveFile(`missing-trip-${i}`);
+        }
+
+        assertEquals(
+          await statOps.resolveFile("pages/late"),
+          null,
+          "a path that could not be searched while the breaker was open resolves to null",
+        );
+
+        failing = false;
+        now += 30_001;
+
+        assertEquals(
+          await statOps.resolveFile("pages/late"),
+          "pages/late.tsx",
+          "a path probed while the breaker was open must not be negatively cached",
+        );
       } finally {
         Date.now = originalNow;
       }

--- a/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
+++ b/src/platform/adapters/fs/veryfront/websocket-manager.test.ts
@@ -59,6 +59,13 @@ class MockWebSocket {
   }
 }
 
+function deliverPoke(socket: MockWebSocket, data: Record<string, unknown>): void {
+  socket.onmessage?.call(
+    socket as unknown as WebSocket,
+    new MessageEvent("message", { data: JSON.stringify({ type: "poke", data }) }),
+  );
+}
+
 function captureConsoleMethod(
   method: "debug" | "log" | "warn",
 ): { getOutput: () => string; reset: () => void; restore: () => void } {
@@ -100,6 +107,8 @@ function withJsonLogFormat<T>(fn: () => T): T {
 
 function createWebSocketManager(options: {
   apiBaseUrl?: string;
+  /** Branch this preview is pinned to; `null` previews the default branch. */
+  branch?: string | null;
   client?: Partial<VeryfrontApiClient>;
   invalidationCallbacks?: InvalidationCallbacks;
   pregenerateStyles?: (
@@ -125,6 +134,7 @@ function createWebSocketManager(options: {
   } as unknown as VeryfrontApiClient;
 
   const invalidationCallbacks: InvalidationCallbacks = options.invalidationCallbacks ?? {};
+  const branch = options.branch === null ? undefined : options.branch ?? "main";
 
   return new WebSocketManager({
     apiBaseUrl: options.apiBaseUrl ?? "https://api.example.com/api",
@@ -136,9 +146,9 @@ function createWebSocketManager(options: {
     getContentContext: () => ({
       sourceType: "branch",
       projectSlug: "test-project",
-      branch: "main",
+      branch,
     }),
-    getContentSource: () => ({ type: "branch", branch: "main" }),
+    getContentSource: () => ({ type: "branch", branch }),
     getProjectDir: () => undefined,
     clearMemoryCaches: options.clearMemoryCaches ?? (() => {}),
     getSourceSnapshotVersion: options.getSourceSnapshotVersion,
@@ -227,6 +237,8 @@ describe("WebSocketManager", () => {
   let originalWebSocket: typeof WebSocket;
   let originalSetTimeout: typeof setTimeout;
   let originalClearTimeout: typeof clearTimeout;
+  let originalSetInterval: typeof setInterval;
+  let heartbeatCallback: (() => void) | undefined;
   let nextTimerId = 1;
   let scheduledTimers = new Map<ReturnType<typeof setTimeout>, TimerEntry>();
 
@@ -250,6 +262,13 @@ describe("WebSocketManager", () => {
     originalWebSocket = globalThis.WebSocket;
     originalSetTimeout = globalThis.setTimeout;
     originalClearTimeout = globalThis.clearTimeout;
+    originalSetInterval = globalThis.setInterval;
+    heartbeatCallback = undefined;
+
+    globalThis.setInterval = ((handler: TimerHandler): ReturnType<typeof setInterval> => {
+      heartbeatCallback = typeof handler === "function" ? handler as () => void : () => {};
+      return 999 as unknown as ReturnType<typeof setInterval>;
+    }) as typeof setInterval;
 
     (globalThis as typeof globalThis & { WebSocket: typeof WebSocket }).WebSocket =
       MockWebSocket as unknown as typeof WebSocket;
@@ -279,6 +298,7 @@ describe("WebSocketManager", () => {
       originalWebSocket;
     globalThis.setTimeout = originalSetTimeout;
     globalThis.clearTimeout = originalClearTimeout;
+    globalThis.setInterval = originalSetInterval;
   });
 
   it("should not add an extra retry delay after reaching reconnect failure cap", () => {
@@ -358,6 +378,35 @@ describe("WebSocketManager", () => {
 
     const metrics = manager.getPokeMetrics();
     assertExists(metrics.connectionId);
+
+    manager.dispose();
+  });
+
+  it("closes and replaces a socket whose pong is older than the heartbeat timeout", () => {
+    const manager = createWebSocketManager();
+    manager.connect("project-1");
+
+    const socket = MockWebSocket.instances[0];
+    assertExists(socket);
+    socket.onopen?.call(socket as unknown as WebSocket, new Event("open"));
+
+    const runHeartbeat = heartbeatCallback;
+    assertExists(runHeartbeat, "connecting must arm the heartbeat interval");
+
+    (manager as unknown as { wsLastPong: number }).wsLastPong = Date.now() - (300_000 + 1);
+    runHeartbeat();
+
+    assertEquals(
+      socket.onclose,
+      null,
+      "onclose is detached before closing so it cannot double-reconnect",
+    );
+    assertEquals(socket.readyState, MockWebSocket.CLOSED, "the dead socket is closed");
+    assertEquals(
+      MockWebSocket.instances.length,
+      2,
+      "exactly one replacement socket is opened",
+    );
 
     manager.dispose();
   });
@@ -862,6 +911,115 @@ describe("WebSocketManager", () => {
 
     // IPv6 loopback should stay as ws://
     assertEquals(socket.url.startsWith("ws://"), true);
+
+    manager.dispose();
+  });
+
+  it("ignores pokes scoped to a different branch", () => {
+    let clearCalls = 0;
+    let reloadCalls = 0;
+    const manager = createWebSocketManager({
+      branch: "feature-x",
+      clearMemoryCaches: () => {
+        clearCalls++;
+      },
+      invalidationCallbacks: {
+        triggerReload: () => {
+          reloadCalls++;
+        },
+      },
+    });
+
+    manager.connect("project-1");
+    const socket = MockWebSocket.instances[0];
+    assertExists(socket);
+
+    deliverPoke(socket, { changedPaths: ["app/page.tsx"], branchName: "main" });
+
+    assertEquals(clearCalls, 0, "a poke for another branch must not flush the preview caches");
+    assertEquals(reloadCalls, 0, "a poke for another branch must not republish a reload");
+
+    manager.dispose();
+  });
+
+  it("ignores branchId-only pokes on the default-branch preview", () => {
+    let clearCalls = 0;
+    let reloadCalls = 0;
+    const manager = createWebSocketManager({
+      branch: null,
+      clearMemoryCaches: () => {
+        clearCalls++;
+      },
+      invalidationCallbacks: {
+        triggerReload: () => {
+          reloadCalls++;
+        },
+      },
+    });
+
+    manager.connect("project-1");
+    const socket = MockWebSocket.instances[0];
+    assertExists(socket);
+
+    deliverPoke(socket, { changedPaths: ["app/page.tsx"], branchId: "br-1" });
+
+    assertEquals(
+      clearCalls,
+      0,
+      "a branchId-only poke must not flush the default-branch preview caches",
+    );
+    assertEquals(reloadCalls, 0, "a branchId-only poke must not republish a reload");
+
+    manager.dispose();
+  });
+
+  it("ignores unscoped pokes while previewing a named branch", () => {
+    let clearCalls = 0;
+    let reloadCalls = 0;
+    const manager = createWebSocketManager({
+      branch: "feature-x",
+      clearMemoryCaches: () => {
+        clearCalls++;
+      },
+      invalidationCallbacks: {
+        triggerReload: () => {
+          reloadCalls++;
+        },
+      },
+    });
+
+    manager.connect("project-1");
+    const socket = MockWebSocket.instances[0];
+    assertExists(socket);
+
+    deliverPoke(socket, { changedPaths: ["app/page.tsx"] });
+
+    assertEquals(
+      clearCalls,
+      0,
+      "an unscoped poke targets the default branch, not a named branch preview",
+    );
+    assertEquals(reloadCalls, 0, "an unscoped poke must not republish a reload on a named branch");
+
+    manager.dispose();
+  });
+
+  it("accepts a poke scoped to the previewed branch", () => {
+    let clearCalls = 0;
+    const manager = createWebSocketManager({
+      branch: "feature-x",
+      clearMemoryCaches: () => {
+        clearCalls++;
+      },
+    });
+
+    manager.connect("project-1");
+    const socket = MockWebSocket.instances[0];
+    assertExists(socket);
+
+    deliverPoke(socket, { changedPaths: ["app/page.tsx"], branchName: "feature-x" });
+
+    assertEquals(clearCalls, 1, "a poke for the previewed branch must flush the preview caches");
 
     manager.dispose();
   });

--- a/src/platform/adapters/fs/wrapper.test.ts
+++ b/src/platform/adapters/fs/wrapper.test.ts
@@ -207,6 +207,26 @@ describe("FSAdapterWrapper", () => {
 
       assertEquals(refreshedReason, "review-comment");
     });
+
+    it("rejects an accessor-valued refreshSourceSnapshot", () => {
+      let getterCalls = 0;
+      const fsAdapter = createMockFSAdapter();
+      Object.defineProperty(fsAdapter, "refreshSourceSnapshot", {
+        configurable: true,
+        get() {
+          getterCalls++;
+          return () => Promise.resolve();
+        },
+      });
+
+      assertThrows(
+        () => new FSAdapterWrapper(fsAdapter),
+        TypeError,
+        "must be a data-property method",
+        "an accessor-valued refreshSourceSnapshot must be rejected",
+      );
+      assertEquals(getterCalls, 0, "the accessor must never be invoked during capture");
+    });
   });
 
   describe("source snapshot freshness", () => {

--- a/src/platform/adapters/mock.test.ts
+++ b/src/platform/adapters/mock.test.ts
@@ -74,6 +74,19 @@ describe("MockAdapter", () => {
 
       assertEquals([...await readFileBytes("/test.bin")], [...bytes]);
       assertEquals(adapter.fs.byteFiles.get("/test.bin") === bytes, false);
+
+      const first = await readFileBytes("/test.bin");
+      first[0] = 99;
+      assertEquals(
+        [...adapter.fs.byteFiles.get("/test.bin")!],
+        [0, 255, 1, 128],
+        "readFileBytes must return a copy, not the live stored buffer",
+      );
+      assertEquals(
+        [...await readFileBytes("/test.bin")],
+        [0, 255, 1, 128],
+        "a later read must still see the unmutated stored bytes",
+      );
     });
 
     it("should throw for non-existent file", async () => {
@@ -117,6 +130,19 @@ describe("MockAdapter", () => {
 
       const read = readSnapshot("/project/asset.bin", "/project", 3);
       adapter.fs.byteFiles.set("/project/asset.bin", new Uint8Array([4, 5, 6]));
+
+      await assertRejects(() => read, FileSnapshotChangedError, "changed");
+    });
+
+    it("rejects in-place mutation during a snapshot read", async () => {
+      const adapter = createMockAdapter();
+      const stored = new Uint8Array([1, 2, 3]);
+      adapter.fs.byteFiles.set("/project/asset.bin", stored);
+      const readSnapshot = adapter.fs.readFileSnapshotWithinLimit;
+      assertExists(readSnapshot);
+
+      const read = readSnapshot("/project/asset.bin", "/project", 3);
+      stored[0] = 9;
 
       await assertRejects(() => read, FileSnapshotChangedError, "changed");
     });
@@ -249,6 +275,48 @@ describe("MockAdapter", () => {
 
       await adapter.fs.writeFile("/test.txt", "new");
       assertEquals(adapter.fs.files.get("/test.txt"), "new");
+    });
+
+    it("drops a stale byte entry when text overwrites it", async () => {
+      const adapter = createMockAdapter();
+      const writeFileBytes = adapter.fs.writeFileBytes;
+      const readFileBytes = adapter.fs.readFileBytes;
+      assertExists(writeFileBytes);
+      assertExists(readFileBytes);
+
+      await writeFileBytes("/x.dat", new TextEncoder().encode("old binary"));
+      await adapter.fs.writeFile("/x.dat", "new text");
+
+      assertEquals(
+        new TextDecoder().decode(await readFileBytes("/x.dat")),
+        "new text",
+        "readFileBytes must not return the pre-overwrite binary content",
+      );
+      assertEquals(
+        adapter.fs.byteFiles.has("/x.dat"),
+        false,
+        "the byte entry is cleared by a text write",
+      );
+    });
+
+    it("drops a stale text entry when bytes overwrite it", async () => {
+      const adapter = createMockAdapter();
+      const writeFileBytes = adapter.fs.writeFileBytes;
+      assertExists(writeFileBytes);
+
+      await adapter.fs.writeFile("/y.dat", "old text");
+      await writeFileBytes("/y.dat", new TextEncoder().encode("new binary"));
+
+      assertEquals(
+        await adapter.fs.readFile("/y.dat"),
+        "new binary",
+        "readFile must not return the pre-overwrite text",
+      );
+      assertEquals(
+        adapter.fs.files.has("/y.dat"),
+        false,
+        "the text entry is cleared by a byte write",
+      );
     });
   });
 
@@ -512,7 +580,8 @@ describe("MockAdapter", () => {
   describe("shutdown", () => {
     it("should resolve without error", async () => {
       const adapter = createMockAdapter();
-      await adapter.shutdown?.();
+      assertExists(adapter.shutdown, "mock adapter exposes shutdown");
+      await adapter.shutdown();
     });
   });
 });

--- a/tests/integration/adapters/fs-factory-routing.test.ts
+++ b/tests/integration/adapters/fs-factory-routing.test.ts
@@ -29,7 +29,7 @@ describe("createFSAdapter adapter routing", () => {
           type: "veryfront-api",
           veryfront: {
             apiBaseUrl: "https://api.example.com",
-            apiToken: "test-token",
+            apiToken: "<TOKEN>",
             projectSlug: "test-project",
             proxyMode: true,
           },
@@ -78,7 +78,7 @@ describe("createFSAdapter adapter routing", () => {
           type: "veryfront-api",
           veryfront: {
             apiBaseUrl: "https://api.example.com",
-            apiToken: "test-token",
+            apiToken: "<TOKEN>",
             projectSlug: "test-project",
             contentSource: { type: "release", releaseId: "release-1" },
           },

--- a/tests/integration/adapters/fs-factory-routing.test.ts
+++ b/tests/integration/adapters/fs-factory-routing.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Adapter routing for createFSAdapter.
+ *
+ * Constructing a veryfront-api adapter initializes it over the outbound fetch
+ * boundary, so these cases replace the process-global fetch and cannot live
+ * beside the colocated unit tests in src/platform/adapters/fs/factory.test.ts.
+ */
+
+import "../../_helpers/contract-init.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
+import { createFSAdapter } from "#veryfront/platform/adapters/fs/factory.ts";
+
+function disposeAdapter(adapter: unknown): void {
+  (adapter as { dispose?: () => void }).dispose?.();
+}
+
+describe("createFSAdapter adapter routing", () => {
+  it("should route a proxy-mode config to the multi-project adapter", async () => {
+    let requests = 0;
+    const adapter = await withMockFetch(
+      () => {
+        requests++;
+        return Promise.reject(new Error("proxy mode must not initialize over the network"));
+      },
+      () =>
+        createFSAdapter({
+          type: "veryfront-api",
+          veryfront: {
+            apiBaseUrl: "https://api.example.com",
+            apiToken: "test-token",
+            projectSlug: "test-project",
+            proxyMode: true,
+          },
+        }),
+    );
+
+    try {
+      assertEquals(
+        adapter.constructor.name,
+        "MultiProjectFSAdapter",
+        "proxyMode must route to the multi-project adapter",
+      );
+      assertEquals(requests, 0, "the multi-project adapter initializes lazily per project");
+    } finally {
+      disposeAdapter(adapter);
+    }
+  });
+
+  it("should route a single-project config to the veryfront adapter", async () => {
+    const adapter = await withMockFetch(
+      (input) => {
+        const url = input instanceof Request ? input.url : String(input);
+        const body = url.includes("/files")
+          ? {
+            data: [],
+            page_info: { self: null, first: null, next: null, prev: null },
+            release_id: "release-1",
+            release_version: null,
+          }
+          : {
+            id: "11111111-1111-4111-8111-111111111111",
+            name: "Test Project",
+            slug: "test-project",
+            provider: "veryfront",
+            layout: "default",
+          };
+        return Promise.resolve(
+          new Response(JSON.stringify(body), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        );
+      },
+      () =>
+        createFSAdapter({
+          type: "veryfront-api",
+          veryfront: {
+            apiBaseUrl: "https://api.example.com",
+            apiToken: "test-token",
+            projectSlug: "test-project",
+            contentSource: { type: "release", releaseId: "release-1" },
+          },
+        }),
+    );
+
+    try {
+      assertEquals(
+        adapter.constructor.name,
+        "VeryfrontFSAdapter",
+        "single-project config must not get the multi-project adapter",
+      );
+    } finally {
+      disposeAdapter(adapter);
+    }
+  });
+});

--- a/tests/integration/adapters/fs-wrapper-prototype-capture.test.ts
+++ b/tests/integration/adapters/fs-wrapper-prototype-capture.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Prototype-pollution safety for FSAdapterWrapper optional-method capture.
+ *
+ * These cases mutate the shared Object.prototype, so they cannot live beside
+ * the colocated unit tests in src/platform/adapters/fs/wrapper.test.ts.
+ */
+
+import "../../_helpers/contract-init.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { FSAdapterWrapper } from "#veryfront/platform/adapters/fs/wrapper.ts";
+import type { FSAdapter } from "#veryfront/platform/adapters/fs/veryfront/types.ts";
+
+function createMockFSAdapter(): FSAdapter {
+  return {
+    readFile: (path: string) => {
+      if (path === "/exists.txt") return Promise.resolve("content");
+      return Promise.reject(new Error(`File not found: ${path}`));
+    },
+    exists: (path: string) => Promise.resolve(path === "/exists.txt"),
+    stat: (path: string) => {
+      if (path === "/exists.txt") {
+        return Promise.resolve({
+          size: 7,
+          isFile: true,
+          isDirectory: false,
+          isSymlink: false,
+          mtime: new Date(0),
+        });
+      }
+      return Promise.reject(new Error(`File not found: ${path}`));
+    },
+  } as FSAdapter;
+}
+
+function withPollutedObjectPrototype<T>(
+  key: string,
+  value: unknown,
+  run: () => T,
+): T {
+  const original = Object.getOwnPropertyDescriptor(Object.prototype, key);
+  Object.defineProperty(Object.prototype, key, { configurable: true, value });
+  try {
+    return run();
+  } finally {
+    if (original === undefined) {
+      Reflect.deleteProperty(Object.prototype, key);
+    } else {
+      Object.defineProperty(Object.prototype, key, original);
+    }
+  }
+}
+
+describe("FSAdapterWrapper optional-method capture under prototype pollution", () => {
+  it("ignores a refreshSourceSnapshot planted on Object.prototype", () => {
+    let planted = false;
+
+    withPollutedObjectPrototype(
+      "refreshSourceSnapshot",
+      () => {
+        planted = true;
+        return Promise.resolve();
+      },
+      () => {
+        const wrapper = new FSAdapterWrapper(createMockFSAdapter());
+
+        assertEquals(
+          wrapper.refreshSourceSnapshot,
+          undefined,
+          "a refreshSourceSnapshot planted on Object.prototype must not be captured",
+        );
+        assertEquals(planted, false, "the planted prototype method must never be invoked");
+      },
+    );
+  });
+
+  it("ignores an ensureSourceSnapshotFresh planted on Object.prototype", () => {
+    let planted = false;
+
+    withPollutedObjectPrototype(
+      "ensureSourceSnapshotFresh",
+      () => {
+        planted = true;
+        return Promise.resolve();
+      },
+      () => {
+        const wrapper = new FSAdapterWrapper(createMockFSAdapter());
+
+        assertEquals(
+          wrapper.ensureSourceSnapshotFresh,
+          undefined,
+          "an ensureSourceSnapshotFresh planted on Object.prototype must not be captured",
+        );
+        assertEquals(planted, false, "the planted prototype method must never be invoked");
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Audit of the first 54 test files under `src/platform/adapters` (filesystem adapters, cache keys, websocket manager, bounded readers, capabilities).

Every change was **mutation checked**: the named source edit was applied, the test confirmed to fail, then reverted. 60 candidate findings, 54 confirmed after adversarial verification, 6 refuted. **Test files only**; no source changes.

## Recurring weaknesses fixed

**Fixtures that matched the code's own fallback.** The branch cache-key test used `branch: "main"`, which is the builder's own default, so dropping `branch` entirely still passed. It now uses `feature/x` with the URI-encoded expectations, plus a sibling asserting two branches never share a namespace.

**Vacuous dispose tests.** Both `dispose` cases asserted nothing observable. They now assert the cache is emptied, the snapshot generation is bumped, and a second `initialize()` genuinely re-fetches.

**Skip logic with no positive control.** The websocket branch-scoping tests now pair three skip cases with a positive control that must deliver, so the trio cannot pass by silently failing to deliver the frame at all.

**Branches no test reached:** the circuit breaker refusing to negatively cache a path it could not search, stale-index recovery via API search, `exists()` propagating non-not-found failures instead of reporting absence, every capture site's declared byte ceiling, invalid UTF-8 rejection (`fatal: true`), and all four argument guards before the reader is reached.

**Heartbeat timeout** is now driven by capturing the interval callback and backdating the last pong, asserting the stale socket is closed and exactly one replacement opens.

## Front door migration

`installMockFetch`/`restoreMockFetch` replace the bare `globalThis.fetch` assignments in three files, each taken to zero bypasses. That rule guards correctness rather than style: code reaching `guardedOutboundFetch` reads the host transport, not the global. The baseline file is untouched.

## Verification

- Semantic unit-boundary audit ok, migration file untouched
- Sanitizer ratchet ok 374/374, `lint:test-typecheck` baseline holds (0 new)
- `lint:testing-front-door`: no key above baseline
- `deno fmt`, `deno lint` clean
- **33/33** changed test files pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file reading at size limits, preserving final bytes and rejecting invalid UTF-8.
  * Added stronger validation for file paths, size limits, and containment settings.
  * Improved cache isolation across repositories, branches, releases, and projects.
  * Fixed stale-cache invalidation and ensured refreshed content is fetched when needed.
  * Improved GitHub API retry and error handling, including rate-limit scenarios.
  * Enhanced directory listing order and file resolution behavior.
  * Improved adapter disposal, context switching, WebSocket heartbeats, and resource cleanup.
* **Tests**
  * Expanded coverage for caching, bounded reads, routing, fallbacks, retries, and adapter lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->