### PR TITLE
test(agent/ag-ui,streaming): make weak assertions bite across the streaming surface

### DIFF
--- a/src/agent/ag-ui/chat-ui-chunk-encoder.test.ts
+++ b/src/agent/ag-ui/chat-ui-chunk-encoder.test.ts
@@ -76,8 +76,16 @@ describe("agent/ag-ui-chat-ui-chunk-encoder", () => {
           cacheReadInputTokens: 1,
           reasoningTokens: 4,
         },
+        billableInputTokens: 2,
+        billableOutputTokens: 3,
+        costUsd: 0.0012,
+        providerCostUsd: 0.0009,
+        veryfrontChargeUsd: 0.0003,
+        veryfrontBilledUsd: 0.0012,
         costCredits: 0.25,
         costSource: "gateway",
+        billingMode: "deferred",
+        usageCaptureStatus: "complete",
       },
     };
 
@@ -95,10 +103,19 @@ describe("agent/ag-ui-chat-ui-chunk-encoder", () => {
         cacheCreationInputTokens: 2,
         cacheReadInputTokens: 1,
         reasoningTokens: 4,
+        billableInputTokens: 2,
+        billableOutputTokens: 3,
+        costUsd: 0.0012,
+        providerCostUsd: 0.0009,
+        veryfrontChargeUsd: 0.0003,
+        veryfrontBilledUsd: 0.0012,
         costCredits: 0.25,
         costSource: "gateway",
+        billingMode: "deferred",
+        usageCaptureStatus: "complete",
         finishReason: "stop",
       },
+      "finish-chunk billing metadata must pass through to RunFinished unchanged",
     );
   });
 

--- a/src/agent/ag-ui/detached-start.test.ts
+++ b/src/agent/ag-ui/detached-start.test.ts
@@ -1,5 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertStringIncludes,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   AgentRuntime,
@@ -153,6 +158,117 @@ describe("agent/ag-ui-detached-start", () => {
 
     assertEquals(parsed.runId, "run_1");
     assertExists(parsed.threadId);
+
+    const validUserMessage = {
+      id: "msg-1",
+      role: "user",
+      parts: [{ type: "text", text: "hello" }],
+    };
+    assertThrows(
+      () =>
+        AgUiDetachedStartRequestSchema.parse({
+          threadId: crypto.randomUUID(),
+          messages: [validUserMessage],
+        }),
+      undefined,
+      undefined,
+      "a detached start payload without runId must be rejected",
+    );
+    assertThrows(
+      () =>
+        AgUiDetachedStartRequestSchema.parse({
+          runId: "run_1",
+          threadId: "not-a-uuid",
+          messages: [validUserMessage],
+        }),
+      undefined,
+      undefined,
+      "threadId must be a uuid",
+    );
+    assertThrows(
+      () =>
+        AgUiDetachedStartRequestSchema.parse({
+          runId: "run 1/../x",
+          threadId: crypto.randomUUID(),
+          messages: [validUserMessage],
+        }),
+      undefined,
+      undefined,
+      "runId must match AGENT_ID_PATTERN so it is safe as a session run key",
+    );
+    assertThrows(
+      () =>
+        AgUiDetachedStartRequestSchema.parse({
+          runId: "x".repeat(129),
+          threadId: crypto.randomUUID(),
+          messages: [validUserMessage],
+        }),
+      undefined,
+      undefined,
+      "runId must be at most 128 characters",
+    );
+  });
+
+  it("rejects a malformed runId before the run is started", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    const handler = createAgUiDetachedStartHandler({
+      agent: createTestAgent(),
+      sessionManager,
+      startDetachedExecution: async () => {
+        throw new Error("detached execution should not start for invalid requests");
+      },
+    });
+
+    const response = await handler(createDetachedRequest({ runId: "run 1/../x" }));
+
+    assertEquals(
+      response.status,
+      400,
+      "a malformed runId must be rejected before the run is started",
+    );
+    const payload = await response.json();
+    assertEquals(payload.error, "Invalid AG-UI detached start request");
+  });
+
+  it("hands the detached task to a host waitUntil when the ctx provides one", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    const captured: Promise<unknown>[] = [];
+    let finishedRunId: string | null = null;
+
+    const handler = createAgUiDetachedStartHandler({
+      sessionManager,
+      startDetachedExecution: async () => {},
+      onFinish: ({ runId }) => {
+        finishedRunId = runId;
+      },
+    });
+
+    const response = await handler({
+      request: createDetachedRequest(),
+      waitUntil: (promise: Promise<unknown>) => {
+        captured.push(promise);
+      },
+    });
+
+    assertEquals(response.status, 202, "detached start must still accept");
+    assertEquals(
+      captured.length,
+      1,
+      "the detached task must be handed to the host waitUntil",
+    );
+    await captured[0];
+    assertEquals(finishedRunId, "run_1", "awaiting the waitUntil promise must finish the run");
+    assertEquals(
+      sessionManager.getRunStatus("run_1"),
+      null,
+      "awaiting the waitUntil promise must complete the run",
+    );
   });
 
   it("starts a detached run and returns accepted duplicate false", async () => {

--- a/src/agent/ag-ui/finalize-tracker.test.ts
+++ b/src/agent/ag-ui/finalize-tracker.test.ts
@@ -116,6 +116,44 @@ describe("agent/ag-ui-finalize-tracker", () => {
     });
   });
 
+  it("keeps deferred billing sticky across later chunks", () => {
+    const tracker = createAgUiFinalizeTracker<{
+      billingMode?: "direct" | "deferred";
+      usageCaptureStatus?: "complete" | "partial" | "missing";
+      costUsd?: number;
+    }>({
+      getMetadataFromChunk: (chunk) => ({
+        billingMode: chunk.billingMode,
+        usageCaptureStatus: chunk.usageCaptureStatus,
+        costUsd: chunk.costUsd,
+      }),
+    });
+
+    tracker.observeChunk({
+      billingMode: "deferred",
+      usageCaptureStatus: "partial",
+      costUsd: 0.02,
+    });
+    tracker.observeChunk({ billingMode: "direct" });
+
+    const response = tracker.getFinalResponse();
+    assertEquals(
+      response?.metadata?.billingMode,
+      "deferred",
+      "a deferred billing chunk must keep the run deferred even when a later chunk reports direct",
+    );
+    assertEquals(
+      response?.metadata?.usageCaptureStatus,
+      "partial",
+      "the observed usage capture status must survive later chunks that omit it",
+    );
+    assertEquals(
+      response?.metadata?.costUsd,
+      0.02,
+      "the observed cost must survive later chunks that omit it",
+    );
+  });
+
   it("suppresses the final response after a RunError event", () => {
     const tracker = createAgUiFinalizeTracker<{
       finishReason?: string;

--- a/src/agent/ag-ui/forwarded-context.test.ts
+++ b/src/agent/ag-ui/forwarded-context.test.ts
@@ -45,8 +45,18 @@ Deno.test("ag-ui-forwarded-context parses typed legacy context values", () => {
 
   assertEquals(parseAgUiContextString('"model-1"'), "model-1");
   assertEquals(parseAgUiContextString("   "), undefined);
+  assertEquals(
+    parseAgUiContextString("openai/gpt-5.4"),
+    "openai/gpt-5.4",
+    "unquoted legacy context values are preserved as raw strings",
+  );
   assertEquals(parseAgUiContextNullableString("null"), null);
   assertEquals(parseAgUiContextNullableString('"branch-1"'), "branch-1");
+  assertEquals(
+    parseAgUiContextNullableString("branch-1"),
+    "branch-1",
+    "unquoted legacy nullable context values are preserved as raw strings",
+  );
   assertEquals(parseAgUiContextBoolean("true"), true);
   assertEquals(parseAgUiContextBoolean("yes"), undefined);
   assertEquals(parseAgUiContextSchema('{"maxSteps":4}', overridesSchema), { maxSteps: 4 });

--- a/src/agent/ag-ui/handler.test.ts
+++ b/src/agent/ag-ui/handler.test.ts
@@ -959,6 +959,108 @@ describe("agent/ag-ui-handler", () => {
       "Injected AG-UI tools require a public RunResumeSessionManager",
     );
   });
+
+  it("returns 409 for a duplicate run id while the first run is still open", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    const originalStream = AgentRuntime.prototype.stream;
+    let openController: ReadableStreamDefaultController<Uint8Array> | undefined;
+
+    AgentRuntime.prototype.stream = async function (): Promise<ReadableStream<Uint8Array>> {
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          openController = controller;
+        },
+      });
+    } as typeof AgentRuntime.prototype.stream;
+
+    try {
+      const handler = createAgUiHandler({
+        agent: createTestAgent().agent,
+        sessionManager,
+      });
+      const body = JSON.stringify({
+        threadId: crypto.randomUUID(),
+        runId: "run_dupe_1",
+        messages: [{
+          id: "msg-1",
+          role: "user",
+          parts: [{ type: "text", text: "hello" }],
+        }],
+        tools: [{ name: "client_confirm" }],
+      });
+      const agUiDuplicateRequest = () =>
+        new Request("http://localhost/api/ag-ui", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body,
+        });
+
+      const first = await handler(agUiDuplicateRequest());
+      assertEquals(first.status, 200, "the first run must stream normally");
+
+      const second = await handler(agUiDuplicateRequest());
+      assertEquals(second.status, 409, "a duplicate active runId must conflict, not 500");
+      assertEquals(
+        await second.json(),
+        { error: "Run already active" },
+        "409 body must match the documented conflict shape",
+      );
+
+      openController?.close();
+      await first.text();
+    } finally {
+      AgentRuntime.prototype.stream = originalStream;
+    }
+  });
+
+  it("releases the run when stream startup fails", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    const originalStream = AgentRuntime.prototype.stream;
+
+    AgentRuntime.prototype.stream = function (): Promise<ReadableStream<Uint8Array>> {
+      return Promise.reject(new Error("stream startup failed"));
+    } as typeof AgentRuntime.prototype.stream;
+
+    try {
+      const handler = createAgUiHandler({
+        agent: createTestAgent().agent,
+        sessionManager,
+      });
+
+      const response = await handler(
+        new Request("http://localhost/api/ag-ui", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            threadId: crypto.randomUUID(),
+            runId: "run_release_1",
+            messages: [{
+              id: "msg-1",
+              role: "user",
+              parts: [{ type: "text", text: "hello" }],
+            }],
+            tools: [{ name: "client_confirm" }],
+          }),
+        }),
+      );
+
+      assertEquals(response.status, 500, "a failed stream start must surface as a server error");
+      assertEquals(await response.json(), { error: "Internal server error" });
+      assertEquals(
+        sessionManager.getRunStatus("run_release_1"),
+        null,
+        "a failed stream start must release the run instead of leaving it active",
+      );
+    } finally {
+      AgentRuntime.prototype.stream = originalStream;
+    }
+  });
 });
 
 // A minimal deferred so a test can await the (post-close) onComplete callback.
@@ -1009,8 +1111,9 @@ function createFinishingAgent(
           controller.close();
         },
       });
-      // A successful run reports its finalized response; a failing one never does.
-      if (!failMidStream && response) input.onFinish?.(response);
+      // A run may finalize server-side and still fail during flush, so the
+      // finalized response is reported whenever the agent has one.
+      if (response) input.onFinish?.(response);
       return {
         toDataStreamResponse: () =>
           new Response(stream, { headers: { "Content-Type": "text/event-stream" } }),
@@ -1078,12 +1181,16 @@ describe("agent/ag-ui-handler onComplete (server-side persistence)", () => {
     });
 
     const response = await handler(agUiRequest());
+    // The onComplete decision runs synchronously with the stream close, so a
+    // fully drained body is enough to observe that the callback never fired.
     const body = await response.text();
-    // Let the stream's finally settle before asserting the callback never ran.
-    await new Promise((r) => setTimeout(r, 0));
 
     assertStringIncludes(body, "event: RunError");
-    assertEquals(calls, 0);
+    assertEquals(
+      calls,
+      0,
+      "onComplete must not fire after a RunError, even when the run already reported a finalized response",
+    );
   });
 
   it("does not fire when the run produced no finalized response", async () => {

--- a/src/agent/ag-ui/host-support.test.ts
+++ b/src/agent/ag-ui/host-support.test.ts
@@ -127,6 +127,46 @@ describe("agent/ag-ui-host-support", () => {
     assertEquals(parsed.forwardedProps, forwardedProps);
   });
 
+  it("rejects forwarded props above the 192 KB AG-UI budget", async () => {
+    const forwardedProps = {
+      runtimeOverrides: {
+        integrationToolDefinitions: [{
+          name: "github__large_tool",
+          description: "x".repeat(192 * 1024),
+          inputSchema: { type: "object" },
+        }],
+      },
+    };
+    const request = new Request("http://localhost/api/ag-ui", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        messages: [{
+          id: "msg-1",
+          role: "user",
+          parts: [{ type: "text", text: "hello" }],
+        }],
+        forwardedProps,
+      }),
+    });
+
+    const result = await parseAgUiRequestOrError(request);
+
+    assertInstanceOf(result, Response);
+    assertEquals(
+      result.status,
+      400,
+      "oversized forwardedProps must be rejected by the field cap, not accepted up to the body limit",
+    );
+    const body = await result.json();
+    const details = body.details as Array<{ message: string }>;
+    assertEquals(
+      details.some((detail) => detail.message === "forwardedProps must be less than 192 KB"),
+      true,
+      "the rejection must name the 192 KB forwardedProps budget",
+    );
+  });
+
   it("returns a 400 Response from parseAgUiRequestOrError for malformed JSON bodies", async () => {
     const request = new Request("http://localhost/api/ag-ui", {
       method: "POST",
@@ -484,6 +524,23 @@ describe("agent/ag-ui-host-support", () => {
     ]);
 
     const wireMessages = convertToTextGenerationRuntimeMessages(normalized as Message[]);
+    const toolMessages = wireMessages.filter((message) => message.role === "tool");
+    assertEquals(
+      toolMessages.length,
+      2,
+      "each replayed tool output must convert to its own tool message",
+    );
+    const resultIds = toolMessages.flatMap((message) =>
+      Array.isArray(message.content)
+        ? message.content.flatMap((part) => part.type === "tool-result" ? [part.toolCallId] : [])
+        : []
+    );
+    assertEquals(
+      resultIds,
+      ["tool-load", "tool-search"],
+      "the converted tool messages must carry the replayed tool-result ids in order",
+    );
+
     for (let index = 0; index < wireMessages.length; index += 1) {
       const message = wireMessages[index];
       if (!message) continue;
@@ -505,6 +562,37 @@ describe("agent/ag-ui-host-support", () => {
         }
       }
     }
+  });
+
+  it("routes composer file attachments to image or file parts by media type", () => {
+    const messages = normalizeAgUiMessages([
+      {
+        id: "user-1",
+        role: "user",
+        parts: [
+          { type: "file", url: "data:image/png;base64,iVBORw0KGgo=", mediaType: "image/png" },
+          {
+            type: "file",
+            url: "https://uploads.example.com/spec.pdf",
+            mediaType: "application/pdf",
+          },
+          { type: "file", url: "", mediaType: "image/png" },
+        ],
+      },
+    ]);
+
+    assertEquals(
+      messages[0]?.parts,
+      [
+        { type: "image", url: "data:image/png;base64,iVBORw0KGgo=", mediaType: "image/png" },
+        {
+          type: "file",
+          url: "https://uploads.example.com/spec.pdf",
+          mediaType: "application/pdf",
+        },
+      ],
+      "image/* attachments must become image parts the model can view, everything else stays a file part, and a urlless attachment is dropped",
+    );
   });
 
   it("does not synthesize tool results for provider-owned assistant tool parts", () => {

--- a/src/agent/ag-ui/lifecycle-adapter.test.ts
+++ b/src/agent/ag-ui/lifecycle-adapter.test.ts
@@ -212,20 +212,29 @@ describe("lifecycle AG-UI adapter", () => {
           output: { content: "final" },
           isError: false,
           providerExecuted: true,
+          preliminary: false,
         },
       },
     ]).flatMap((frame) => adapter.encode(frame));
 
-    assertEquals(events.map((event) => event.event), [
-      "ToolCallStart",
-      "ToolCallArgs",
-      "ToolCallEnd",
-      "ToolCallResult",
-    ]);
-    assertEquals(events.at(-1)?.payload, {
-      toolCallId: "provider-1",
-      result: { content: "final" },
-    });
+    assertEquals(
+      events.map((event) => event.event),
+      [
+        "ToolCallStart",
+        "ToolCallArgs",
+        "ToolCallEnd",
+        "ToolCallResult",
+      ],
+      "only preliminary === true suppresses a result, so an explicit preliminary: false must still emit ToolCallResult",
+    );
+    assertEquals(
+      events.at(-1)?.payload,
+      {
+        toolCallId: "provider-1",
+        result: { content: "final" },
+      },
+      "the final provider result must reach the client even when it carries preliminary: false",
+    );
   });
 
   it("keeps a tool-handoff attempt open and finishes only on run completion", () => {
@@ -328,6 +337,108 @@ describe("lifecycle AG-UI adapter", () => {
       event: "RunError",
       payload: { code: "STREAM_CANCELLED", message: "Stream was cancelled" },
     }]);
+  });
+
+  it("reports failed outcomes with the public error code and message", () => {
+    const adapter = createLifecycleAgUiAdapter({ messageId: "message-failed" });
+
+    const failedOutcome = adapter.finalize({
+      outcome: {
+        status: "failed",
+        error: {
+          code: "PROVIDER_STREAM_ERROR",
+          phase: "streaming",
+          source: "provider",
+          retryable: false,
+          publicMessage: "The model provider stopped responding",
+          diagnosticId: "diag-1",
+        },
+        snapshot: {
+          phase: "failed",
+          accumulatedText: "",
+          reasoning: [],
+          tools: [],
+          finishReason: "other",
+          usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+          hasStreamOutput: false,
+          hasSemanticProgress: false,
+        },
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        elapsedMs: 10,
+        phase: "failed",
+      },
+    });
+
+    assertEquals(
+      failedOutcome,
+      [{
+        event: "RunError",
+        payload: {
+          code: "PROVIDER_STREAM_ERROR",
+          message: "The model provider stopped responding",
+        },
+      }],
+      "a failed outcome must surface its public error code and sanitized public message",
+    );
+
+    const failed = createLifecycleAgUiAdapter({ messageId: "message-terminal-failed" });
+    assertEquals(
+      failed.finalize({ terminalStatus: "failed" }),
+      [{
+        event: "RunError",
+        payload: { code: "RUN_FAILED", message: "Agent run failed" },
+      }],
+      "a failed terminal status must emit RUN_FAILED, never a success terminal",
+    );
+    assertEquals(
+      failed.finalize({ terminalStatus: "failed" }),
+      [],
+      "the terminal-error latch must suppress a second finalize",
+    );
+  });
+
+  it("carries merged usage and billing metadata on RunFinished", () => {
+    const adapter = createLifecycleAgUiAdapter({ messageId: "message-usage" });
+    for (
+      const frame of frames([
+        { event: { type: "text_start" } },
+        { event: { type: "text_content", delta: "done" } },
+        { event: { type: "text_end" } },
+        {
+          event: {
+            type: "usage",
+            usage: {
+              inputTokens: 12,
+              outputTokens: 8,
+              totalTokens: 20,
+              costUsd: 0.002,
+              costCredits: 2,
+              billingMode: "deferred",
+              usageCaptureStatus: "complete",
+            },
+          },
+        },
+      ])
+    ) {
+      adapter.encode(frame);
+    }
+
+    const finished = adapter.finalize({ terminalStatus: "completed" });
+
+    assertEquals(finished[0]?.event, "RunFinished", "a completed run must emit RunFinished");
+    assertEquals(
+      finished[0]?.payload.metadata,
+      {
+        inputTokens: 12,
+        outputTokens: 8,
+        totalTokens: 20,
+        costUsd: 0.002,
+        costCredits: 2,
+        billingMode: "deferred",
+        usageCaptureStatus: "complete",
+      },
+      "RunFinished metadata must carry the merged usage including billing fields",
+    );
   });
 
   it("drops a reasoning end that closes no open span", () => {

--- a/src/agent/ag-ui/response-stream.test.ts
+++ b/src/agent/ag-ui/response-stream.test.ts
@@ -68,12 +68,23 @@ describe("agent/ag-ui-response-stream", () => {
       getFinalResponse: () => null,
     });
 
-    const text = await collectStreamText(stream);
-    assertStringIncludes(text, "event: RunStarted");
-    assertStringIncludes(text, "event: StateSnapshot");
-    assertStringIncludes(text, "event: MessagesSnapshot");
-    assertStringIncludes(text, "event: TextMessageContent");
-    assertStringIncludes(text, "event: RunFinished");
+    const frames = parseSseFrames(await collectStreamText(stream));
+    assertEquals(
+      frames.map((frame) => frame.event),
+      ["RunStarted", "StateSnapshot", "MessagesSnapshot", "TextMessageContent", "RunFinished"],
+      "bootstrap frames must precede chunk and finalize frames in order",
+    );
+    assertEquals(frames[0]?.data.runId, "run-1", "RunStarted must carry the request runId");
+    assertEquals(
+      frames[0]?.data.threadId,
+      "thread-1",
+      "RunStarted must carry the request threadId",
+    );
+    assertEquals(
+      frames[2]?.data.messages,
+      [{ id: "user-1", role: "user" }],
+      "MessagesSnapshot must replay the request messages",
+    );
   });
 
   it("shares the chunk encoder timing anchor with bootstrap and final events", async () => {
@@ -124,6 +135,7 @@ describe("agent/ag-ui-response-stream", () => {
   });
 
   it("emits RunError and swallows execution.fail rejections", async () => {
+    let failedWith: unknown;
     const stream = createAgUiResponseStream({
       agUiInput: {
         runId: "run-2",
@@ -141,7 +153,8 @@ describe("agent/ag-ui-response-stream", () => {
             };
           },
         },
-        fail: async () => {
+        fail: async (error) => {
+          failedWith = error;
           throw new Error("fail exploded");
         },
         waitForFinish: async () => {},
@@ -156,6 +169,18 @@ describe("agent/ag-ui-response-stream", () => {
     const text = await collectStreamText(stream);
     assertStringIncludes(text, "event: RunError");
     assertStringIncludes(text, "stream exploded");
+    assertEquals(
+      failedWith instanceof Error && failedWith.message === "stream exploded",
+      true,
+      "execution.fail must be notified with the stream error",
+    );
+    const runError = parseSseFrames(text).find((frame) => frame.event === "RunError");
+    assertEquals(runError?.data.code, "STREAM_ERROR", "RunError must carry the STREAM_ERROR code");
+    assertEquals(
+      runError?.data.message,
+      "stream exploded",
+      "RunError must carry the stream error message",
+    );
   });
 
   it("passes accumulated state into getFinalResponse", async () => {

--- a/src/agent/ag-ui/run-control.test.ts
+++ b/src/agent/ag-ui/run-control.test.ts
@@ -1,10 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   AgUiResumeSignalSchema,
   createAgUiCancelHandler,
   createAgUiResumeHandler,
+  RunCancelledError,
   RunResumeSessionManager,
 } from "../index.ts";
 
@@ -54,7 +55,7 @@ describe("agent/ag-ui-run-control", () => {
   it("cancels a waiting run through the public cancel handler", async () => {
     const sessionManager = new RunResumeSessionManager<{ ok: boolean }>();
     sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
-    void sessionManager.waitForSignal("run_1", "tool_1").catch(() => undefined);
+    const pending = sessionManager.waitForSignal("run_1", "tool_1");
 
     const handler = createAgUiCancelHandler({ sessionManager });
     const response = await handler(
@@ -65,6 +66,17 @@ describe("agent/ag-ui-run-control", () => {
 
     assertEquals(response.status, 202);
     assertEquals(await response.json(), { accepted: true });
+    assertEquals(
+      sessionManager.getRunStatus("run_1"),
+      null,
+      "the cancelled run must no longer be active",
+    );
+    await assertRejects(
+      () => pending,
+      RunCancelledError,
+      undefined,
+      "the cancel handler must reject the parked waiter",
+    );
   });
 
   it("withholds infrastructure headers from run-id resolvers", async () => {
@@ -193,6 +205,42 @@ describe("agent/ag-ui-run-control", () => {
 
     assertEquals(response.status, 409);
     assertEquals(await response.json(), { error: "TOOL_RESULT_CONFLICT" });
+  });
+
+  it("returns 409 when a tool result arrives for a wait that is not pending", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    const pending = sessionManager.waitForSignal("run_1", "tool_1").catch(() => undefined);
+
+    const handler = createAgUiResumeHandler({ sessionManager });
+    const response = await handler(
+      new Request("https://example.com/api/runs/run_1/resume", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          type: "tool_result",
+          toolCallId: "tool_2",
+          result: { ok: true },
+        }),
+      }),
+    );
+
+    assertEquals(
+      response.status,
+      409,
+      "a result for a wait that is not pending must conflict, not fall through to 500",
+    );
+    assertEquals(
+      await response.json(),
+      { error: "TOOL_RESULT_NOT_WAITING" },
+      "the not-waiting conflict must use the documented error code",
+    );
+
+    sessionManager.cancelRun("run_1");
+    await pending;
   });
 
   it("returns 204 when cancelling an already inactive run", async () => {

--- a/src/agent/ag-ui/runtime-chat-stream-encoder.test.ts
+++ b/src/agent/ag-ui/runtime-chat-stream-encoder.test.ts
@@ -38,6 +38,71 @@ describe("agent/ag-ui-runtime-chat-stream-encoder", () => {
     );
   });
 
+  it("recovers buffered tool input when tool-input-available carries an empty object", () => {
+    const encoder = createAgUiRuntimeChatStreamEncoder({
+      responseMessageId: "msg-1",
+    });
+
+    assertEquals(
+      encoder.encode({
+        type: "tool-input-delta",
+        toolCallId: "tool-2",
+        inputTextDelta: '{"query":"docs"}',
+      }),
+      [{ type: "start-step" }],
+      "a delta for an unopened tool part is buffered rather than emitted",
+    );
+
+    assertEquals(
+      encoder.encode({
+        type: "tool-input-available",
+        toolCallId: "tool-2",
+        toolName: "search_docs",
+        input: {},
+      }),
+      [
+        { type: "tool-input-start", toolCallId: "tool-2", toolName: "search_docs" },
+        { type: "tool-input-delta", toolCallId: "tool-2", inputTextDelta: '{"query":"docs"}' },
+        {
+          type: "tool-input-available",
+          toolCallId: "tool-2",
+          toolName: "search_docs",
+          input: { query: "docs" },
+        },
+      ],
+      "a complete buffered delta must reconstruct the tool input when the provider sends an empty object",
+    );
+  });
+
+  it("replays buffered deltas after a late tool-input-start", () => {
+    const encoder = createAgUiRuntimeChatStreamEncoder({
+      responseMessageId: "msg-1",
+    });
+
+    assertEquals(
+      encoder.encode({
+        type: "tool-input-delta",
+        toolCallId: "tool-3",
+        inputTextDelta: '{"query":"docs"}',
+      }),
+      [{ type: "start-step" }],
+      "a delta for an unopened tool part is buffered rather than emitted",
+    );
+
+    assertEquals(
+      encoder.encode({
+        type: "tool-input-start",
+        toolCallId: "tool-3",
+        toolName: "search_docs",
+      }),
+      [
+        { type: "tool-input-start", toolCallId: "tool-3", toolName: "search_docs" },
+        { type: "tool-input-delta", toolCallId: "tool-3", inputTextDelta: '{"query":"docs"}' },
+      ],
+      "buffered deltas must be replayed after the tool-input-start that opens the part",
+    );
+  });
+
   it("preserves providerExecuted on runtime tool lifecycle events", () => {
     const encoder = createAgUiRuntimeChatStreamEncoder({
       responseMessageId: "msg-1",

--- a/src/agent/ag-ui/runtime-handler.test.ts
+++ b/src/agent/ag-ui/runtime-handler.test.ts
@@ -501,6 +501,43 @@ describe("agent/ag-ui-runtime-handler", () => {
     assertEquals(response.status, 200);
     const body = await response.text();
     assertStringIncludes(body, "event: RunFinished");
+    assertEquals(
+      body.includes("event: RunError"),
+      false,
+      "a rejecting lifecycle callback must not turn a successful run into RunError",
+    );
+  });
+
+  it("swallows synchronously thrown lifecycle callbacks during normal streaming", async () => {
+    const testAgent = createTestAgent();
+    const threadId = crypto.randomUUID();
+    const handler = createAgUiRuntimeHandler({
+      agent: testAgent.agent,
+      onFinish: () => {
+        throw new Error("telemetry exploded");
+      },
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/ag-ui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          threadId,
+          runId: "run_runtime_hooks_5",
+          messages: [{ id: "user-1", role: "user", content: "Hello" }],
+        }),
+      }),
+    );
+
+    assertEquals(response.status, 200);
+    const body = await response.text();
+    assertStringIncludes(body, "event: RunFinished");
+    assertEquals(
+      body.includes("event: RunError"),
+      false,
+      "a synchronously throwing lifecycle callback must not turn a successful run into RunError",
+    );
   });
 
   it("calls onError when direct hosted stream setup fails before a stream exists", async () => {
@@ -656,8 +693,165 @@ describe("agent/ag-ui-runtime-handler", () => {
       assertStringIncludes(body, "event: ToolCallStart");
       assertEquals(seenToolCallId, "tool-call-1");
       assertEquals(finishedRunId, "run_runtime_4");
+      assertEquals(
+        sessionManager.getRunStatus("run_runtime_4"),
+        null,
+        "a finished injected-tools run must be released from the session manager",
+      );
     } finally {
       AgentRuntime.prototype.stream = originalStream;
+    }
+  });
+
+  it("releases a failed run through the injected-tools runtime path", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    const originalStream = AgentRuntime.prototype.stream;
+    let seenError: string | undefined;
+
+    AgentRuntime.prototype.stream = (): Promise<ReadableStream<Uint8Array>> =>
+      Promise.resolve(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(
+              encodeDataStreamEvent({ type: "message-start", messageId: "assistant-msg-1" }),
+            );
+            controller.error(new Error("injected runtime stream exploded"));
+          },
+        }),
+      );
+
+    try {
+      const handler = createAgUiRuntimeHandler({
+        agent: createTestAgent().agent,
+        sessionManager,
+        onError: ({ error }) => {
+          seenError = error instanceof Error ? error.message : String(error);
+        },
+      });
+
+      const response = await handler(
+        new Request("http://localhost/api/ag-ui", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            threadId: crypto.randomUUID(),
+            runId: "run_runtime_5",
+            messages: [{ id: "msg-1", role: "user", content: "hello" }],
+            tools: [{ name: "client_confirm" }],
+          }),
+        }),
+      );
+
+      const body = await response.text();
+      assertStringIncludes(body, "event: RunError");
+      assertEquals(
+        seenError,
+        "injected runtime stream exploded",
+        "the injected-tools path must forward the stream failure to the host onError hook",
+      );
+      assertEquals(
+        sessionManager.getRunStatus("run_runtime_5"),
+        null,
+        "a failed injected-tools run must be released via failRun",
+      );
+    } finally {
+      AgentRuntime.prototype.stream = originalStream;
+      sessionManager.reset();
+    }
+  });
+
+  it("returns 409 when the run id is already active", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    const threadId = crypto.randomUUID();
+    sessionManager.startRun({ runId: "run_runtime_dup", threadId });
+
+    try {
+      const handler = createAgUiRuntimeHandler({
+        agent: createTestAgent().agent,
+        sessionManager,
+      });
+
+      const response = await handler(
+        new Request("http://localhost/api/ag-ui", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            threadId,
+            runId: "run_runtime_dup",
+            messages: [{ id: "msg-1", role: "user", content: "hello" }],
+            tools: [{ name: "client_confirm" }],
+          }),
+        }),
+      );
+
+      assertEquals(
+        response.status,
+        409,
+        "a duplicate run id must be reported as a conflict, not a generic failure",
+      );
+      assertEquals(
+        await response.json(),
+        { error: "Run already active" },
+        "the duplicate-run body must stay stable so hosts can drive retry handling",
+      );
+    } finally {
+      sessionManager.reset();
+    }
+  });
+
+  it("releases the run when injected-tools stream setup fails", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    const originalStream = AgentRuntime.prototype.stream;
+
+    AgentRuntime.prototype.stream = (): Promise<ReadableStream<Uint8Array>> =>
+      Promise.reject(new Error("runtime stream setup exploded"));
+
+    try {
+      const handler = createAgUiRuntimeHandler({
+        agent: createTestAgent().agent,
+        sessionManager,
+      });
+
+      const response = await handler(
+        new Request("http://localhost/api/ag-ui", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            threadId: crypto.randomUUID(),
+            runId: "run_runtime_setup_fail",
+            messages: [{ id: "msg-1", role: "user", content: "hello" }],
+            tools: [{ name: "client_confirm" }],
+          }),
+        }),
+      );
+
+      assertEquals(
+        response.status,
+        500,
+        "a runtime stream setup failure must surface as a server error",
+      );
+      assertEquals(
+        await response.json(),
+        { error: "runtime stream setup exploded" },
+        "the setup failure detail must reach the caller",
+      );
+      assertEquals(
+        sessionManager.getRunStatus("run_runtime_setup_fail"),
+        null,
+        "a run whose stream setup failed must be released instead of staying active forever",
+      );
+    } finally {
+      AgentRuntime.prototype.stream = originalStream;
+      sessionManager.reset();
     }
   });
 

--- a/src/agent/ag-ui/runtime-handler.test.ts
+++ b/src/agent/ag-ui/runtime-handler.test.ts
@@ -571,7 +571,7 @@ describe("agent/ag-ui-runtime-handler", () => {
     );
 
     assertEquals(response.status, 500);
-    assertEquals(await response.json(), { error: "clearMemory exploded" });
+    assertEquals(await response.json(), { error: "Internal server error" });
     assertEquals(seenRunId, "run_runtime_hooks_4");
     assertEquals(seenError, "clearMemory exploded");
   });
@@ -811,6 +811,7 @@ describe("agent/ag-ui-runtime-handler", () => {
       isError: boolean;
     }>();
     const originalStream = AgentRuntime.prototype.stream;
+    let seenError: string | undefined;
 
     AgentRuntime.prototype.stream = (): Promise<ReadableStream<Uint8Array>> =>
       Promise.reject(new Error("runtime stream setup exploded"));
@@ -819,6 +820,9 @@ describe("agent/ag-ui-runtime-handler", () => {
       const handler = createAgUiRuntimeHandler({
         agent: createTestAgent().agent,
         sessionManager,
+        onError: ({ error }) => {
+          seenError = error instanceof Error ? error.message : String(error);
+        },
       });
 
       const response = await handler(
@@ -841,8 +845,13 @@ describe("agent/ag-ui-runtime-handler", () => {
       );
       assertEquals(
         await response.json(),
-        { error: "runtime stream setup exploded" },
-        "the setup failure detail must reach the caller",
+        { error: "Internal server error" },
+        "runtime internals must not leak through the public error response",
+      );
+      assertEquals(
+        seenError,
+        "runtime stream setup exploded",
+        "the host lifecycle callback must still receive the original startup error",
       );
       assertEquals(
         sessionManager.getRunStatus("run_runtime_setup_fail"),

--- a/src/agent/ag-ui/runtime-handler.ts
+++ b/src/agent/ag-ui/runtime-handler.ts
@@ -557,9 +557,7 @@ export function createAgUiRuntimeHandler(
       }
 
       return Response.json(
-        {
-          error: error instanceof Error ? error.message : "Internal server error",
-        },
+        { error: "Internal server error" },
         { status: 500 },
       );
     }

--- a/src/agent/ag-ui/runtime-response.test.ts
+++ b/src/agent/ag-ui/runtime-response.test.ts
@@ -7,7 +7,7 @@ describe("agent/ag-ui-runtime-response", () => {
   it("normalizes runtime defaults and wraps the stream in SSE headers", async () => {
     const response = createAgUiRuntimeResponse({
       agUiInput: {
-        threadId: crypto.randomUUID(),
+        threadId: "11111111-1111-4111-8111-111111111111",
         runId: "run_1",
         state: "ignored",
         messages: [],
@@ -15,7 +15,7 @@ describe("agent/ag-ui-runtime-response", () => {
         context: [],
       },
       defaults: {
-        threadId: crypto.randomUUID(),
+        threadId: "22222222-2222-4222-8222-222222222222",
         runId: "run_override",
       },
       agentId: "agent-1",
@@ -39,6 +39,12 @@ describe("agent/ag-ui-runtime-response", () => {
     const text = await response.text();
     assertStringIncludes(text, "event: RunStarted");
     assertStringIncludes(text, '"runId":"run_override"');
+    assertStringIncludes(text, '"threadId":"22222222-2222-4222-8222-222222222222"');
+    assertEquals(
+      text.includes("11111111-1111-4111-8111-111111111111"),
+      false,
+      "the client-supplied threadId must not reach the RunStarted payload",
+    );
     assertStringIncludes(text, "event: StateSnapshot");
     assertStringIncludes(text, '"snapshot":{}');
     assertStringIncludes(text, "event: Custom");

--- a/src/agent/ag-ui/runtime-support.test.ts
+++ b/src/agent/ag-ui/runtime-support.test.ts
@@ -84,4 +84,65 @@ describe("agent/ag-ui-runtime-support", () => {
       },
     ]);
   });
+
+  it("wraps failed tool results so the runtime sees the error", () => {
+    const messages = normalizeAgUiRuntimeMessages([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: "",
+        toolCalls: [{
+          id: "tool-1",
+          type: "function",
+          function: { name: "harvest__list_users", arguments: "{}" },
+        }],
+      },
+      {
+        id: "tool-1-result",
+        role: "tool",
+        toolCallId: "tool-1",
+        content: "partial",
+        error: "upstream 500",
+      },
+    ]);
+
+    assertEquals(
+      messages[1]?.parts[0],
+      {
+        type: "tool-result",
+        toolCallId: "tool-1",
+        toolName: "harvest__list_users",
+        result: { content: "partial", error: "upstream 500" },
+      },
+      "a tool message with an error must wrap content and error so the runtime sees the failure",
+    );
+  });
+
+  it("resets inferred tool names on a new user turn", () => {
+    const messages = normalizeAgUiRuntimeMessages([
+      {
+        id: "assistant-1",
+        role: "assistant",
+        content: "",
+        toolCalls: [{
+          id: "tool-1",
+          type: "function",
+          function: { name: "harvest__list_users", arguments: "{}" },
+        }],
+      },
+      { id: "user-1", role: "user", content: "next" },
+      {
+        id: "tool-1-result",
+        role: "tool",
+        toolCallId: "tool-1",
+        content: "stale",
+      },
+    ]);
+
+    assertEquals(
+      (messages[2]?.parts[0] as { toolName: string }).toolName,
+      "unknown",
+      "a user turn must clear inferred tool names so a stale id cannot borrow a name",
+    );
+  });
 });

--- a/src/agent/ag-ui/sse-parser.test.ts
+++ b/src/agent/ag-ui/sse-parser.test.ts
@@ -1,6 +1,10 @@
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { agUiSseEventTypes, parseAgUiSseResponse } from "./sse-parser.ts";
+import {
+  agUiSseEventTypes,
+  type AgUiSseProgressSnapshot,
+  parseAgUiSseResponse,
+} from "./sse-parser.ts";
 
 function createSseResponse(chunks: string[], status = 200): Response {
   const encoder = new TextEncoder();
@@ -23,19 +27,22 @@ function createSseResponse(chunks: string[], status = 200): Response {
 
 describe("agent/ag-ui-sse-parser", () => {
   it("parses SSE chunks incrementally and reports progress", async () => {
-    const progressEventCounts: number[] = [];
+    const progressSnapshots: AgUiSseProgressSnapshot[] = [];
     const response = createSseResponse([
       'id: 1\nevent: RunStarted\ndata: {"runId":"run-1"}\n\n',
       'id: 2\nevent: ToolCallStart\ndata: {"toolCallName":"load_skill"}\n\n',
       'id: 3\nevent: ToolCallArgs\ndata: {"delta":"{\\"skillId\\":\\"plan\\"}"}\n\n',
       'id: 4\nevent: TextMessageContent\ndata: {"delta":"Hello"}\n\n',
-      'id: 5\nevent: TextMessageContent\ndata: {"delta":" world"}\n\n',
+      // the last text event is split across two reads so the parser has to carry
+      // the partial event over the chunk boundary
+      'id: 5\nevent: TextMessageContent\ndata: {"delta":" wor',
+      'ld"}\n\n',
       'id: 6\nevent: RunFinished\ndata: {"metadata":{"finishReason":"stop"}}\n\n',
     ]);
 
     const run = await parseAgUiSseResponse(response, {
       onProgress: (snapshot) => {
-        progressEventCounts.push(snapshot.eventCount);
+        progressSnapshots.push(snapshot);
       },
       progressThrottleMs: 0,
     });
@@ -51,7 +58,16 @@ describe("agent/ag-ui-sse-parser", () => {
     assertEquals(run.toolStarts, ["load_skill"]);
     assertEquals(run.toolArgs, ['{"skillId":"plan"}']);
     assertEquals(run.text, "Hello world");
-    assertEquals(progressEventCounts.at(-1), 6);
+    assertEquals(
+      progressSnapshots.map((snapshot) => snapshot.eventCount),
+      [1, 2, 3, 4, 5, 6, 6],
+      "progress must be reported after each parsed event and once more after the stream ends",
+    );
+    assertEquals(
+      progressSnapshots[2]?.lastToolCallName,
+      "load_skill",
+      "an incremental snapshot must be built from live run state",
+    );
   });
 
   it("keeps parsing legacy raw AG-UI payloads", async () => {
@@ -78,5 +94,39 @@ describe("agent/ag-ui-sse-parser", () => {
 
     assertEquals(run.responseStatus, 502);
     assertEquals(run.runError, "bad gateway");
+  });
+
+  it("uses a RUN_ERROR event message as the run error on a 200 response", async () => {
+    const response = createSseResponse([
+      'id: 1\nevent: RunError\ndata: {"message":"boom"}\n\n',
+    ]);
+
+    const run = await parseAgUiSseResponse(response);
+
+    assertEquals(
+      run.runError,
+      "boom",
+      "a RUN_ERROR event must set runError even on a 200 response",
+    );
+    assertEquals(
+      run.eventTypes,
+      [agUiSseEventTypes.runError],
+      "the RunError event must be recorded",
+    );
+  });
+
+  it("prefers the RUN_ERROR event message over non-OK response text", async () => {
+    const response = createSseResponse([
+      'id: 1\nevent: RunError\ndata: {"message":"boom"}\n\n',
+    ], 502);
+
+    const run = await parseAgUiSseResponse(response);
+
+    assertEquals(
+      run.runError,
+      "boom",
+      "the RUN_ERROR event message must win over non-OK body text",
+    );
+    assertEquals(run.responseStatus, 502, "the non-OK status must still be recorded");
   });
 });

--- a/src/agent/ag-ui/tool-shared.test.ts
+++ b/src/agent/ag-ui/tool-shared.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import type { Tool } from "#veryfront/tool/types.ts";
@@ -76,6 +76,47 @@ describe("buildMergedAgUiTools", () => {
     ], sessionManager) as Record<string, Tool | boolean>;
 
     assertEquals(mergedTools["number-generator"], true);
+  });
+
+  it("rejects injected tool calls without a toolCallId and surfaces submitted errors", async () => {
+    const agent = {
+      config: {
+        tools: {
+          "number-generator": true,
+        },
+      },
+    } as unknown as Agent;
+    const sessionManager = new RunResumeSessionManager<AgUiResumeValue>();
+
+    const mergedTools = buildMergedAgUiTools(agent, "run_1", [
+      { name: "studio_open_preview" },
+    ], sessionManager) as Record<string, Tool>;
+
+    sessionManager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    try {
+      await assertRejects(
+        () => Promise.resolve(mergedTools.studio_open_preview!.execute!({}, {})),
+        Error,
+        "Missing toolCallId",
+        "an injected tool call without a toolCallId must be rejected as an invalid argument",
+      );
+
+      const call = Promise.resolve(
+        mergedTools.studio_open_preview!.execute!({}, { toolCallId: "call-1" }),
+      );
+      sessionManager.submitSignal("run_1", {
+        waitKey: "call-1",
+        value: { result: "tool blew up", isError: true },
+      });
+      await assertRejects(
+        () => call,
+        Error,
+        "tool blew up",
+        "a submitted error result must surface as an agent error, not a resolved value",
+      );
+    } finally {
+      sessionManager.completeRun("run_1");
+    }
   });
 });
 

--- a/src/agent/ag-ui/tracked-response.test.ts
+++ b/src/agent/ag-ui/tracked-response.test.ts
@@ -89,7 +89,10 @@ describe("agent/ag-ui-tracked-response", () => {
       },
       chunkEncoder: {
         encode: () => [{ event: "RunError", payload: { message: "boom" } }],
-        finalize: () => [],
+        finalize: (response) =>
+          response
+            ? [{ event: "RunFinished", payload: { metadata: response.metadata ?? {} } }]
+            : [],
       },
       finalizeTracker: createAgUiFinalizeTracker({
         getMetadataFromChunk: () => ({ finishReason: "stop" }),
@@ -98,10 +101,15 @@ describe("agent/ag-ui-tracked-response", () => {
 
     const text = await response.text();
     assertStringIncludes(text, "event: RunError");
-    assertEquals(text.includes("finishReason"), false);
+    assertEquals(
+      text.includes("RunFinished"),
+      false,
+      "a RunError observed through the finalize tracker must null out the final response so no RunFinished is emitted",
+    );
     assertEquals(
       parseSseFrames(text).every((frame) => typeof frame.data.elapsedMs === "number"),
       true,
+      "every emitted frame must carry an elapsedMs timing field",
     );
   });
 

--- a/src/agent/streaming/fork-runtime-part-mapper.test.ts
+++ b/src/agent/streaming/fork-runtime-part-mapper.test.ts
@@ -184,6 +184,79 @@ describe("agent/fork-runtime-part-mapper", () => {
     ]);
   });
 
+  it("emits a missing tool-call before a streamed tool error", () => {
+    const state = createForkRuntimeStreamMappingState();
+
+    mapAgUiRuntimeEventToForkParts(
+      { type: "tool-input-start", toolCallId: "tool-1", toolName: "create_file" },
+      state,
+    );
+    mapAgUiRuntimeEventToForkParts(
+      { type: "tool-input-delta", toolCallId: "tool-1", inputTextDelta: '{"path":"plan.md"}' },
+      state,
+    );
+
+    const parts = mapAgUiRuntimeEventToForkParts(
+      { type: "tool-output-error", toolCallId: "tool-1", errorText: "disk full" },
+      state,
+    );
+
+    assertEquals(parts.length, 2, "a streamed tool error must recover the missing tool-call part");
+    assertEquals(parts[0], {
+      type: "tool-call",
+      toolCallId: "tool-1",
+      toolName: "create_file",
+      input: { path: "plan.md" },
+    }, "the recovered tool-call must carry the streamed tool name and input");
+    if (parts[1]?.type !== "tool-error") {
+      throw new Error("Expected a tool-error part");
+    }
+    assertEquals(parts[1].toolCallId, "tool-1", "the tool-error must carry the tool call id");
+    assertEquals(
+      parts[1].toolName,
+      "create_file",
+      "the tool-error must carry the streamed tool name",
+    );
+    assertEquals(
+      parts[1].input,
+      { path: "plan.md" },
+      "the tool-error must carry the streamed tool input",
+    );
+    assertEquals(
+      parts[1].error.message,
+      "disk full",
+      "the tool-error must preserve the upstream errorText",
+    );
+  });
+
+  it("skips preliminary tool output", () => {
+    const state = createForkRuntimeStreamMappingState();
+
+    mapAgUiRuntimeEventToForkParts(
+      { type: "tool-input-start", toolCallId: "tool-1", toolName: "create_file" },
+      state,
+    );
+
+    assertEquals(
+      mapAgUiRuntimeEventToForkParts(
+        {
+          type: "tool-output-available",
+          toolCallId: "tool-1",
+          output: { partial: true },
+          preliminary: true,
+        },
+        state,
+      ),
+      [],
+      "a preliminary tool output must not emit fork parts",
+    );
+    assertEquals(
+      state.emittedToolResultIds.has("tool-1"),
+      false,
+      "a preliminary tool output must not mark the tool result as emitted",
+    );
+  });
+
   it("preserves the concrete upstream error when errorText is absent", () => {
     const state = createForkRuntimeStreamMappingState();
 

--- a/src/agent/streaming/fork-runtime-step-progress.test.ts
+++ b/src/agent/streaming/fork-runtime-step-progress.test.ts
@@ -53,6 +53,32 @@ describe("agent/fork-runtime-step-progress", () => {
       finishReason: "tool-calls",
     });
     assertEquals(shouldContinueForkRuntimeStep(step, response), true);
+
+    const erroredResponse: AgentResponse = {
+      ...response,
+      toolCalls: [
+        {
+          id: "tool-1",
+          name: "create_file",
+          args: { path: "plans/a.md" },
+          status: "error",
+          result: undefined,
+        },
+      ],
+      metadata: { finishReason: "tool-calls" },
+    };
+    const erroredStep = buildForkRuntimeStepFromResponse(erroredResponse);
+
+    assertEquals(
+      erroredStep.toolResults,
+      [],
+      "a tool call that did not complete must not be replayed as a tool result",
+    );
+    assertEquals(
+      shouldContinueForkRuntimeStep(erroredStep, erroredResponse),
+      false,
+      "a tool-calls step whose every tool call errored must not continue the fork loop",
+    );
   });
 
   it("commits steps and accumulates usage for the fork runtime loop", () => {

--- a/src/agent/streaming/fork-runtime-step-state.test.ts
+++ b/src/agent/streaming/fork-runtime-step-state.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import type { Message as AgentMessage } from "../schemas/index.ts";
 import {
@@ -54,5 +54,82 @@ describe("agent/fork-runtime-step-state", () => {
       "assistant",
       "tool",
     ]);
+  });
+
+  it("rejects with the signal reason when the fork step is already aborted", async () => {
+    const reason = new Error("fork aborted by host");
+    const controller = new AbortController();
+    controller.abort(reason);
+
+    await assertRejects(
+      () =>
+        resolveForkStepResponse({
+          responsePromise: new Promise<never>(() => {}),
+          responseTimeoutMs: 1,
+          abortSignal: controller.signal,
+          currentMessages: [],
+          streamedStepState: createStreamedStepState(),
+        }),
+      Error,
+      "fork aborted by host",
+      "an already-aborted signal must reject with the signal reason",
+    );
+  });
+
+  it("fails loudly when there is no streamed content and no recoverable prior work", async () => {
+    await assertRejects(
+      () =>
+        resolveForkStepResponse({
+          responsePromise: new Promise<never>(() => {}),
+          responseTimeoutMs: 1,
+          currentMessages: [{
+            id: "user-1",
+            role: "user",
+            timestamp: 1,
+            parts: [{ type: "text", text: "Create the plan." }],
+          }],
+          streamedStepState: createStreamedStepState(),
+        }),
+      Error,
+      "without recoverable output",
+      "a fork with no streamed content and no prior artifacts must fail loudly",
+    );
+  });
+
+  it("maps tool-error parts to an errored tool call", async () => {
+    const state = createStreamedStepState();
+
+    applyPartToStreamedStepState(state, {
+      type: "tool-call",
+      toolCallId: "tool-1",
+      toolName: "create_file",
+      input: { path: "a.md" },
+    });
+    applyPartToStreamedStepState(state, {
+      type: "tool-error",
+      toolCallId: "tool-1",
+      toolName: "create_file",
+      input: { path: "a.md" },
+      error: new Error("disk full"),
+    });
+
+    const response = await resolveForkStepResponse({
+      responsePromise: new Promise<never>(() => {}),
+      responseTimeoutMs: 1,
+      currentMessages: [],
+      streamedStepState: state,
+    });
+
+    assertEquals(
+      response.toolCalls[0],
+      {
+        id: "tool-1",
+        name: "create_file",
+        args: { path: "a.md" },
+        status: "error",
+        error: "disk full",
+      },
+      "tool-error parts must map to status error carrying the error text",
+    );
   });
 });

--- a/src/agent/streaming/fork-runtime-stream.test.ts
+++ b/src/agent/streaming/fork-runtime-stream.test.ts
@@ -1,5 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists, assertRejects } from "#veryfront/testing/assert";
+import {
+  assertEquals,
+  assertExists,
+  assertInstanceOf,
+  assertRejects,
+} from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { type ModelRuntime, registerModelProvider } from "#veryfront/provider";
@@ -400,6 +405,57 @@ describe("agent/fork-runtime-stream", () => {
     });
   });
 
+  it("uses the step preparer forkToolNames override for the child step", async () => {
+    const capturedInputs: RunAgentRuntimeForkStepInput[] = [];
+    const response: AgentResponse = {
+      text: "Done.",
+      messages: [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          timestamp: 2,
+          parts: [{ type: "text", text: "Done." }],
+        },
+      ],
+      toolCalls: [],
+      status: "completed",
+    };
+    const streamResult = startAgentRuntimeFork({
+      apiUrl: "https://api.example.com",
+      authToken: "auth-token",
+      projectId: "project-1",
+      model: "model-1",
+      maxSteps: 1,
+      prompt: "Do the work.",
+      forkToolNames: ["create_file"],
+      runtimeTools: {},
+      buildInstructions: () => "Base instructions.",
+      prepareStep: ({ messages, buildInstructions }) => ({
+        messages,
+        system: buildInstructions(),
+        forkToolNames: ["create_file", "gmail__list_emails"],
+      }),
+      runStep: async (input) => {
+        capturedInputs.push(input);
+        return {
+          stream: createRuntimeEventStream([{ type: "text-delta", delta: "Done." }]),
+          responsePromise: Promise.resolve(response),
+        };
+      },
+    });
+
+    for await (const _part of streamResult.fullStream) {
+      // Drain the stream so the step runs.
+    }
+    await streamResult.steps;
+
+    assertEquals(
+      capturedInputs[0]?.forkToolNames,
+      ["create_file", "gmail__list_emails"],
+      "prepared forkToolNames must reach the child step",
+    );
+  });
+
   it("preserves structured provider options in the default fork step runner", async () => {
     const providerId = "fork-structured-system";
     let observedSystem: unknown;
@@ -460,6 +516,69 @@ describe("agent/fork-runtime-stream", () => {
           anthropic: { cacheControl: { type: "ephemeral", ttl: "1h" } },
         },
       });
+    } finally {
+      unregister();
+    }
+  });
+
+  it("rejects the response promise when the fork step starts with an aborted signal", async () => {
+    const providerId = "fork-aborted-step";
+    const model: ModelRuntime = {
+      provider: providerId,
+      modelId: `${providerId}/demo`,
+      async doGenerate() {
+        return {
+          content: [{ type: "text", text: "Done." }],
+          finishReason: "stop",
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        };
+      },
+      async doStream() {
+        return {
+          stream: new ReadableStream<unknown>({
+            start(controller) {
+              controller.enqueue({ type: "text-delta", text: "Done." });
+              controller.enqueue({ type: "finish", finishReason: "stop" });
+              controller.close();
+            },
+          }),
+        };
+      },
+    };
+    const unregister = registerModelProvider(providerId, () => model);
+    const controller = new AbortController();
+    controller.abort();
+
+    try {
+      const result = await runAgentRuntimeForkStep({
+        apiUrl: "https://api.example.com",
+        authToken: "test-token",
+        projectId: "project-1",
+        model: `${providerId}/demo`,
+        messages: [{
+          id: "user-1",
+          role: "user",
+          parts: [{ type: "text", text: "Do the work." }],
+        }],
+        system: "Fork instructions.",
+        abortSignal: controller.signal,
+        forkToolNames: [],
+        runtimeTools: {},
+      });
+
+      const error = await assertRejects(() => result.responsePromise, Error);
+      assertInstanceOf(
+        error,
+        Error,
+        "an aborted fork step must reject with an Error",
+      );
+      assertEquals(
+        error.name,
+        "AbortError",
+        "an aborted fork step must settle responsePromise",
+      );
+
+      await new Response(result.stream).text().catch(() => undefined);
     } finally {
       unregister();
     }

--- a/src/agent/streaming/lifecycle/cancellation.test.ts
+++ b/src/agent/streaming/lifecycle/cancellation.test.ts
@@ -29,6 +29,63 @@ describe("createCancellationCoordinator", () => {
     assertEquals(runtime.activeAbortListenerCount(), 0);
     assertEquals(client.activeAbortListenerCount(), 0);
   });
+
+  it("selects consumer_stopped and aborts the coordinator signal when the consumer stops", () => {
+    const runtime = createAbortListenerCountingController();
+    const client = createAbortListenerCountingController();
+    const selected: string[] = [];
+    const coordinator = createCancellationCoordinator([
+      { source: "runtime", signal: runtime.signal },
+      { source: "client_disconnected", signal: client.signal },
+    ], (source) => selected.push(source));
+
+    coordinator.stopConsumer();
+
+    assertEquals(
+      coordinator.source,
+      "consumer_stopped",
+      "stopping the consumer must win the cancellation race",
+    );
+    assertEquals(
+      coordinator.signal.aborted,
+      true,
+      "stopConsumer must abort the coordinator signal so a pending provider read unblocks",
+    );
+    assertEquals(selected, ["consumer_stopped"], "onCancel must fire once with consumer_stopped");
+    assertEquals(
+      runtime.activeAbortListenerCount(),
+      0,
+      "input listeners must be removed when the consumer stops",
+    );
+    assertEquals(
+      client.activeAbortListenerCount(),
+      0,
+      "input listeners must be removed when the consumer stops",
+    );
+    coordinator.dispose();
+  });
+
+  it("aborts the provider without claiming a cancellation source", () => {
+    const runtime = createAbortListenerCountingController();
+    const coordinator = createCancellationCoordinator(
+      [{ source: "runtime", signal: runtime.signal }],
+      () => {},
+    );
+
+    coordinator.abortProvider("provider reset");
+
+    assertEquals(
+      coordinator.signal.aborted,
+      true,
+      "abortProvider must abort the coordinator signal",
+    );
+    assertEquals(
+      coordinator.source,
+      null,
+      "abortProvider must not claim a cancellation source",
+    );
+    coordinator.dispose();
+  });
 });
 
 function createAbortListenerCountingController(): AbortController & {

--- a/src/agent/streaming/lifecycle/deadlines.test.ts
+++ b/src/agent/streaming/lifecycle/deadlines.test.ts
@@ -88,6 +88,178 @@ describe("stream lifecycle deadlines", () => {
     }
   });
 
+  it("kills a provider that never starts after the first-progress budget", async () => {
+    const clock = new ManualMonotonicClock();
+    const provider = createControllableSignalProvider();
+    const run = runStreamLifecycle({
+      provider,
+      policy: {
+        clock,
+        firstProgressTimeoutMs: 60_000,
+        semanticIdleTimeoutMs: 15_000,
+        statusIntervalMs: 60_000,
+        attemptTimeoutMs: 300_000,
+      },
+    });
+    const iterator = run.frames[Symbol.asyncIterator]();
+    const pending = iterator.next();
+
+    clock.advanceBy(15_000);
+    assertEquals(
+      clock.pendingWaitCount,
+      2,
+      "the first-progress budget must outlast the semantic-idle budget for a provider that never starts",
+    );
+
+    clock.advanceBy(45_000);
+    assertEquals((await pending).done, true, "the first-progress deadline must end the stream");
+    const outcome = await run.outcome;
+    assertEquals(outcome.status, "failed", "a provider that never starts must fail the stream");
+    if (outcome.status === "failed") {
+      assertEquals(
+        outcome.error.code,
+        "FIRST_PROGRESS_TIMEOUT",
+        "a provider that never starts must fail with the first-progress code",
+      );
+    }
+    assertEquals(
+      outcome.elapsedMs,
+      60_000,
+      "first progress must be budgeted from firstProgressTimeoutMs",
+    );
+  });
+
+  it("kills a provider that stalls mid-stream after the semantic-idle budget", async () => {
+    const clock = new ManualMonotonicClock();
+    const provider = createControllableSignalProvider();
+    const run = runStreamLifecycle({
+      provider,
+      policy: {
+        clock,
+        firstProgressTimeoutMs: 60_000,
+        semanticIdleTimeoutMs: 15_000,
+        statusIntervalMs: 60_000,
+        attemptTimeoutMs: 300_000,
+      },
+    });
+    const iterator = run.frames[Symbol.asyncIterator]();
+    const firstRead = iterator.next();
+    provider.resolveNext({
+      done: false,
+      value: {
+        kind: "protocol",
+        event: { type: "text_content", id: "text-1", delta: "hello" },
+      },
+    });
+    assertEquals(
+      (await firstRead).value?.class,
+      "semantic",
+      "the implicit text start must surface as a semantic frame",
+    );
+    assertEquals(
+      (await iterator.next()).value?.class,
+      "diagnostic",
+      "the implicit text start must be reported as a protocol repair",
+    );
+    assertEquals(
+      (await iterator.next()).value?.class,
+      "semantic",
+      "the text content must surface as a semantic frame",
+    );
+
+    const pending = iterator.next();
+    clock.advanceBy(14_999);
+    assertEquals(
+      clock.pendingWaitCount,
+      2,
+      "the semantic-idle budget must still be armed just before it elapses",
+    );
+
+    clock.advanceBy(1);
+    assertEquals(
+      clock.pendingWaitCount,
+      1,
+      "semantic idle must elapse on the semantic-idle budget, not the first-progress budget",
+    );
+    assertEquals((await pending).done, true, "the semantic-idle deadline must end the stream");
+    const outcome = await run.outcome;
+    assertEquals(
+      outcome.status,
+      "failed",
+      "a provider that stalls mid-stream must fail the stream",
+    );
+    if (outcome.status === "failed") {
+      assertEquals(
+        outcome.error.code,
+        "SEMANTIC_IDLE_TIMEOUT",
+        "a provider that stalls mid-stream must fail with the semantic-idle code",
+      );
+    }
+    assertEquals(
+      outcome.elapsedMs,
+      15_000,
+      "semantic idle must be budgeted from semanticIdleTimeoutMs",
+    );
+  });
+
+  it("prefers the provider deadline over a read that settled after it", async () => {
+    const clock = new ManualMonotonicClock();
+    const provider = createControllableSignalProvider();
+    const run = runStreamLifecycle({
+      provider,
+      policy: {
+        clock,
+        toolInputIdleTimeoutMs: 20_000,
+        statusIntervalMs: 60_000,
+        attemptTimeoutMs: 120_000,
+      },
+    });
+    const iterator = run.frames[Symbol.asyncIterator]();
+    provider.resolveNext({
+      done: false,
+      value: {
+        kind: "protocol",
+        event: {
+          type: "tool_input_start",
+          toolCallId: "t1",
+          toolName: "create_file",
+        },
+      },
+    });
+    await iterator.next();
+
+    const pending = iterator.next();
+    // The clock passes the armed idle deadline before the provider part lands,
+    // so the tracked read settles strictly after the deadline it lost to.
+    clock.advanceBy(21_000);
+    provider.resolveNext({
+      done: false,
+      value: {
+        kind: "protocol",
+        event: {
+          type: "tool_input_content",
+          toolCallId: "t1",
+          delta: '{"path":"a.md"}',
+        },
+      },
+    });
+
+    assertEquals(
+      (await pending).done,
+      true,
+      "a part that settles after the idle deadline must not defer the deadline",
+    );
+    const outcome = await run.outcome;
+    assertEquals(outcome.status, "failed", "the late part must not rescue the stalled tool input");
+    if (outcome.status === "failed") {
+      assertEquals(
+        outcome.error.code,
+        "TOOL_INPUT_TIMEOUT",
+        "the provider deadline must win over a late-settled cached read",
+      );
+    }
+  });
+
   it("resumes the remaining provider-wait budget after consumer backpressure", async () => {
     const clock = new ManualMonotonicClock();
     const provider = createControllableSignalProvider();

--- a/src/agent/streaming/lifecycle/diagnostics.test.ts
+++ b/src/agent/streaming/lifecycle/diagnostics.test.ts
@@ -11,6 +11,21 @@ describe("stream lifecycle diagnostics", () => {
         value: { authorization: "<REDACTED>" },
       }),
       null,
+      "the default policy must never publish a raw diagnostic candidate",
+    );
+  });
+
+  it("ignores the redactor when raw capture is disabled", () => {
+    assertEquals(
+      acceptDiagnosticCandidate({
+        rawCapture: "disabled",
+        redact: () => ({
+          kind: "provider_shape",
+          attributes: { partType: "x" },
+        }),
+      }, { kind: "provider_payload", value: { authorization: "<REDACTED>" } }),
+      null,
+      "disabled raw capture must return null even when the redactor produces a safe event",
     );
   });
 
@@ -24,6 +39,7 @@ describe("stream lifecycle diagnostics", () => {
         }),
       }, { kind: "provider_payload", value: { secret: "<REDACTED>" } }),
       { kind: "provider_shape", attributes: { partType: "unknown" } },
+      "a redacted policy must publish exactly what the redactor returns",
     );
   });
 });

--- a/src/agent/streaming/lifecycle/live-adapter.test.ts
+++ b/src/agent/streaming/lifecycle/live-adapter.test.ts
@@ -80,6 +80,52 @@ describe("stream lifecycle live adapter", () => {
         data: { toolCallId: "local-1", status: "pending_input" },
       },
     ]);
+
+    assertEquals(
+      frames([
+        {
+          type: "tool_input_rejected",
+          toolCallId: "call-1",
+          toolName: "create_file",
+          reason: "malformed",
+        },
+        {
+          type: "tool_input_rejected",
+          toolCallId: "call-2",
+          toolName: "create_file",
+          reason: "unavailable",
+        },
+        {
+          type: "provider_tool_denied",
+          toolCallId: "call-3",
+          toolName: "web_search",
+          providerExecuted: true,
+        },
+        {
+          type: "provider_tool_cancelled",
+          toolCallId: "call-4",
+          toolName: "web_search",
+          providerExecuted: true,
+        },
+      ]).flatMap((frame) => adapter.encode(frame)),
+      [
+        {
+          type: "tool-input-error",
+          toolCallId: "call-1",
+          toolName: "create_file",
+          input: null,
+          errorText: "Tool input was rejected before handoff",
+        },
+        { type: "tool-output-denied", toolCallId: "call-3" },
+        {
+          type: "tool-output-error",
+          toolCallId: "call-4",
+          errorText: "Provider tool execution was cancelled",
+          providerExecuted: true,
+        },
+      ],
+      "a rejected tool input must surface an error part unless the tool was merely unavailable",
+    );
   });
 
   it("maps reasoning, provider output, usage, and diagnostics", () => {

--- a/src/agent/streaming/lifecycle/observability.test.ts
+++ b/src/agent/streaming/lifecycle/observability.test.ts
@@ -148,8 +148,14 @@ describe("stream lifecycle observability", () => {
       assertEquals(serialized.includes(sentinel), false, sentinel);
     }
     assertEquals(
-      durations.map((entry) => entry.kind),
-      ["tool_input", "first_progress", "semantic_idle", "attempt"],
+      durations,
+      [
+        { kind: "tool_input", durationMs: 20 },
+        { kind: "first_progress", durationMs: 40 },
+        { kind: "semantic_idle", durationMs: 20 },
+        { kind: "attempt", durationMs: 90 },
+      ],
+      "each recorded duration must span the frames it measures",
     );
     assertEquals(
       Object.keys(spanAttributes).every((key) => key.startsWith("stream.lifecycle.")),
@@ -160,6 +166,87 @@ describe("stream lifecycle observability", () => {
       spanAttributes["stream.lifecycle.error_code"],
       "TOOL_INPUT_TIMEOUT",
     );
+  });
+
+  it("records provider tool execution duration between start and result", () => {
+    const { sink, durations } = createRecordingSink();
+    const observer = createStreamLifecycleObserver({
+      provider: "openai",
+      model: "gpt-5.4",
+      mode: "active",
+      sink,
+    });
+
+    observer.onFrame(frame("semantic", {
+      type: "provider_tool_start",
+      toolCallId: "t1",
+      toolName: "web_search",
+    }, 10));
+    observer.onFrame(frame("semantic", {
+      type: "provider_tool_result",
+      toolCallId: "t1",
+      toolName: "web_search",
+      output: {},
+      isError: false,
+    }, 35));
+
+    assertEquals(
+      durations,
+      [{ kind: "tool_execution", durationMs: 25 }],
+      "provider tool execution must record the start-to-result span",
+    );
+  });
+
+  it("labels cancelled outcomes with their cancellation source", () => {
+    const { sink, attributes } = createRecordingSink();
+    const spanAttributes: Record<string, unknown> = {};
+    const observer = createStreamLifecycleObserver({
+      provider: "openai",
+      model: "gpt-5.4",
+      mode: "active",
+      sink,
+      span: {
+        setAttributes(values) {
+          Object.assign(spanAttributes, values);
+          return this;
+        },
+      },
+    });
+
+    observer.onOutcome({
+      status: "cancelled",
+      source: "client_disconnected",
+      publicMessage: "The client disconnected",
+      snapshot: {
+        phase: "cancelled",
+        accumulatedText: "",
+        reasoning: [],
+        tools: [],
+        finishReason: null,
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        hasStreamOutput: false,
+        hasSemanticProgress: false,
+      },
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      elapsedMs: 40,
+      phase: "cancelled",
+    });
+
+    assertEquals(
+      attributes.at(0)?.cancellation_source,
+      "client_disconnected",
+      "a cancelled outcome must carry its cancellation source label",
+    );
+    assertEquals(
+      spanAttributes["stream.lifecycle.cancellation_source"],
+      "client_disconnected",
+      "the span must carry the cancellation source",
+    );
+    for (const attrs of attributes) {
+      for (const key of Object.keys(attrs)) {
+        assertEquals(ALLOWED_LABEL_KEYS.has(key), true, key);
+      }
+    }
   });
 
   it("normalizes provider, model, and repair labels to a closed vocabulary", () => {

--- a/src/agent/streaming/lifecycle/reducer.test.ts
+++ b/src/agent/streaming/lifecycle/reducer.test.ts
@@ -412,8 +412,31 @@ describe("stream lifecycle reducer", () => {
       event: { type: "step_finish", finishReason: "tool-calls" },
     }, 2).state;
 
-    assertEquals(state.snapshot.phase, "failed");
-    assertEquals(state.snapshot.tools[0]?.phase, "input_rejected");
+    assertEquals(
+      state.snapshot.phase,
+      "failed",
+      "an unavailable tool call must fail the stream",
+    );
+    assertEquals(
+      state.snapshot.tools[0]?.phase,
+      "input_rejected",
+      "the unavailable tool must stay rejected instead of moving to execution",
+    );
+    assertEquals(
+      state.terminalError?.code,
+      "PROTOCOL_VIOLATION",
+      "an unavailable tool is a protocol violation, not incomplete tool input",
+    );
+    assertEquals(
+      state.terminalError?.source,
+      "runtime",
+      "an unavailable tool is a runtime fault, not a tool fault",
+    );
+    assertEquals(
+      state.terminalError?.publicMessage,
+      "Provider requested tool handoff without an executable tool call",
+      "unavailable-tool failures must not use the incomplete-input public message",
+    );
   });
 
   it("accepts provider tool output only for explicitly provider-executed input", () => {

--- a/src/agent/streaming/lifecycle/runtime-provider-adapter.test.ts
+++ b/src/agent/streaming/lifecycle/runtime-provider-adapter.test.ts
@@ -106,6 +106,40 @@ describe("runtime stream Provider Adapter", () => {
         },
       },
     );
+    assertEquals(
+      decodeRuntimeStreamPart(
+        { type: "tool-call", toolCallId: "c1", toolName: "missing_tool", input: {} },
+        snapshot,
+        options,
+      )[0],
+      {
+        kind: "protocol",
+        event: {
+          type: "tool_input_rejected",
+          toolCallId: "c1",
+          toolName: "missing_tool",
+          reason: "unavailable",
+        },
+      },
+      "a tool-call for an unavailable tool must be rejected, never handed to execution",
+    );
+    assertEquals(
+      decodeRuntimeStreamPart(
+        { type: "tool-input-available", toolCallId: "c1", toolName: "missing_tool", input: {} },
+        snapshot,
+        options,
+      )[0],
+      {
+        kind: "protocol",
+        event: {
+          type: "tool_input_rejected",
+          toolCallId: "c1",
+          toolName: "missing_tool",
+          reason: "unavailable",
+        },
+      },
+      "an available tool input for an unavailable tool must be rejected, never handed to execution",
+    );
   });
 
   it("turns unknown provider parts into diagnostic candidates", () => {
@@ -136,5 +170,29 @@ describe("runtime stream Provider Adapter", () => {
       retryable: true,
       terminal: false,
     });
+  });
+
+  it("maps recognized terminal provider errors to non-retryable terminal failures", () => {
+    const error = classifyRuntimeProviderError(
+      Object.assign(new Error("schema"), {
+        responseBody: "Invalid Veryfront schema: defineSchema missing",
+      }),
+    );
+
+    assertEquals(
+      error.code,
+      "PROJECT_SCHEMA_ERROR",
+      "a recognized provider failure keeps its specific code",
+    );
+    assertEquals(
+      error.retryable,
+      false,
+      "a recognized terminal provider failure must not be retried",
+    );
+    assertEquals(
+      error.terminal,
+      true,
+      "a recognized terminal provider failure must be marked terminal",
+    );
   });
 });

--- a/src/agent/streaming/lifecycle/types.test.ts
+++ b/src/agent/streaming/lifecycle/types.test.ts
@@ -15,10 +15,19 @@ describe("stream lifecycle contract", () => {
     assertEquals(policy.attemptTimeoutMs, 300_000);
   });
 
-  it("uses a typed error for a second frame consumer", () => {
-    assertInstanceOf(
-      new StreamAlreadyConsumedError(),
-      StreamAlreadyConsumedError,
+  it("exports a named typed error for a rejected second frame consumer", () => {
+    const error = new StreamAlreadyConsumedError();
+
+    assertInstanceOf(error, Error, "the typed error must extend Error");
+    assertEquals(
+      error.name,
+      "StreamAlreadyConsumedError",
+      "the typed error must keep its exported name",
+    );
+    assertEquals(
+      error.message,
+      "Stream lifecycle frames support one consumer",
+      "the typed error must explain that frames support one consumer",
     );
   });
 });

--- a/src/agent/streaming/lifecycle/watchdog-compat-adapter.test.ts
+++ b/src/agent/streaming/lifecycle/watchdog-compat-adapter.test.ts
@@ -42,6 +42,24 @@ describe("mapWatchdogChunkToLifecycleActivity", () => {
       }),
       { type: "telemetry" },
     );
+    assertEquals(
+      mapWatchdogChunkToLifecycleActivity(state, {
+        type: "tool-input-delta",
+        toolCallId: "tool-1",
+        inputTextDelta: "",
+      }),
+      { type: "telemetry" },
+      "empty tool-input deltas must not extend the deadline",
+    );
+    assertEquals(
+      mapWatchdogChunkToLifecycleActivity(state, {
+        type: "reasoning-delta",
+        id: "r1",
+        delta: "",
+      }),
+      { type: "telemetry" },
+      "empty reasoning deltas must not extend the deadline",
+    );
   });
 
   it("classifies semantic progress, transitions, and completion", () => {
@@ -95,6 +113,54 @@ describe("mapWatchdogChunkToLifecycleActivity", () => {
     assertEquals(
       mapWatchdogChunkToLifecycleActivity(state, { type: "finish" }),
       { type: "completed" },
+    );
+
+    const toolState: ChatStreamWatchdogState = {
+      phase: "tool_input_streaming",
+      timeoutMs: 120,
+      toolCallId: "tool-1",
+      toolName: "bash",
+    };
+    assertEquals(
+      mapWatchdogChunkToLifecycleActivity(toolState, {
+        type: "tool-input-delta",
+        toolCallId: "tool-1",
+        inputTextDelta: '{"a":1}',
+      }),
+      {
+        type: "semantic_progress",
+        phase: "awaiting_tool_input",
+        toolCallId: "tool-1",
+        toolName: "bash",
+      },
+      "non-empty tool-input deltas are semantic progress carrying the current tool name",
+    );
+    assertEquals(
+      mapWatchdogChunkToLifecycleActivity(toolState, {
+        type: "tool-output-error",
+        toolCallId: "tool-1",
+        errorText: "boom",
+      }),
+      {
+        type: "semantic_progress",
+        phase: "streaming",
+        toolCallId: "tool-1",
+        toolName: "bash",
+      },
+      "a tool output error is semantic progress that returns the stream to streaming",
+    );
+    assertEquals(
+      mapWatchdogChunkToLifecycleActivity(toolState, {
+        type: "tool-output-denied",
+        toolCallId: "tool-1",
+      }),
+      {
+        type: "semantic_progress",
+        phase: "streaming",
+        toolCallId: "tool-1",
+        toolName: "bash",
+      },
+      "a denied tool output is semantic progress that returns the stream to streaming",
     );
   });
 });

--- a/src/agent/streaming/mirrored-tool-chunk-state.test.ts
+++ b/src/agent/streaming/mirrored-tool-chunk-state.test.ts
@@ -95,12 +95,81 @@ describe("mirrored-tool-chunk-state", () => {
   it("clones state as an independent copy", () => {
     const state = createMirroredToolChunkState();
     state.startedToolCallIds.add("tc-1");
+    state.inputAvailableToolCallIds.add("tc-in");
+    state.outputAvailableToolCallIds.add("tc-out");
+    state.outputErrorToolCallIds.add("tc-err");
+    state.outputDeniedToolCallIds.add("tc-denied");
+    state.toolCallNames.set("tc-1", "bash");
 
     const clone = cloneMirroredToolChunkState(state);
     clone.startedToolCallIds.add("tc-2");
+    clone.inputAvailableToolCallIds.add("tc-in-2");
+    clone.outputAvailableToolCallIds.add("tc-out-2");
+    clone.outputErrorToolCallIds.add("tc-err-2");
+    clone.outputDeniedToolCallIds.add("tc-denied-2");
+    clone.toolCallNames.set("tc-2", "read");
 
-    assertEquals(state.startedToolCallIds.has("tc-2"), false);
-    assertEquals(clone.startedToolCallIds.has("tc-1"), true);
+    assertEquals(
+      state.startedToolCallIds.has("tc-2"),
+      false,
+      "writing started ids on the clone must not reach the source",
+    );
+    assertEquals(
+      state.inputAvailableToolCallIds.has("tc-in-2"),
+      false,
+      "writing input-available ids on the clone must not reach the source",
+    );
+    assertEquals(
+      state.outputAvailableToolCallIds.has("tc-out-2"),
+      false,
+      "writing output-available ids on the clone must not reach the source",
+    );
+    assertEquals(
+      state.outputErrorToolCallIds.has("tc-err-2"),
+      false,
+      "writing output-error ids on the clone must not reach the source",
+    );
+    assertEquals(
+      state.outputDeniedToolCallIds.has("tc-denied-2"),
+      false,
+      "writing output-denied ids on the clone must not reach the source",
+    );
+    assertEquals(
+      state.toolCallNames.get("tc-2"),
+      undefined,
+      "writing tool call names on the clone must not reach the source",
+    );
+
+    assertEquals(
+      clone.startedToolCallIds.has("tc-1"),
+      true,
+      "the clone must carry the seeded started id",
+    );
+    assertEquals(
+      clone.inputAvailableToolCallIds.has("tc-in"),
+      true,
+      "the clone must carry the seeded input-available id",
+    );
+    assertEquals(
+      clone.outputAvailableToolCallIds.has("tc-out"),
+      true,
+      "the clone must carry the seeded output-available id",
+    );
+    assertEquals(
+      clone.outputErrorToolCallIds.has("tc-err"),
+      true,
+      "the clone must carry the seeded output-error id",
+    );
+    assertEquals(
+      clone.outputDeniedToolCallIds.has("tc-denied"),
+      true,
+      "the clone must carry the seeded output-denied id",
+    );
+    assertEquals(
+      clone.toolCallNames.get("tc-1"),
+      "bash",
+      "the clone must carry the seeded tool call name",
+    );
   });
 
   it("records tool lifecycle chunks", () => {

--- a/src/agent/streaming/stream-outcome.test.ts
+++ b/src/agent/streaming/stream-outcome.test.ts
@@ -191,11 +191,30 @@ describe("resolveStreamOutcome", () => {
     });
     assertEquals(outcome.status, "failed");
     if (outcome.status === "failed") {
-      assertEquals(outcome.error.code, "PROVIDER_TERMINAL_ERROR");
-      assertEquals(outcome.error.providerCode, "CONTEXT_WINDOW_EXCEEDED");
+      assertEquals(
+        outcome.error.code,
+        "PROVIDER_TERMINAL_ERROR",
+        "a terminal provider error must be reported under the terminal code",
+      );
+      assertEquals(
+        outcome.error.providerCode,
+        "CONTEXT_WINDOW_EXCEEDED",
+        "the provider code must be preserved for the caller",
+      );
       assertEquals(
         outcome.error.publicMessage,
         "The request exceeded the model context window",
+        "the classified public message must pass through unchanged",
+      );
+      assertEquals(
+        outcome.error.retryable,
+        false,
+        "a terminal provider error must not be reported as retryable",
+      );
+      assertEquals(
+        outcome.error.source,
+        "provider",
+        "a classified provider error must be attributed to the provider, not the runtime",
       );
     }
   });
@@ -204,15 +223,24 @@ describe("resolveStreamOutcome", () => {
     const outcome = resolveStreamOutcome({
       snapshot: snapshot("streaming", null, false),
       elapsedMs: 5,
-      thrownError: { raw: "socket closed by peer at 10.0.0.1" },
+      thrownError: new Error("socket closed by peer at 10.0.0.1"),
     });
     assertEquals(outcome.status, "failed");
     if (outcome.status === "failed") {
-      assertEquals(outcome.error.code, "PROVIDER_STREAM_ERROR");
-      assertEquals(outcome.error.retryable, true);
       assertEquals(
-        outcome.error.publicMessage.includes("10.0.0.1"),
-        false,
+        outcome.error.code,
+        "PROVIDER_STREAM_ERROR",
+        "an unrecognized provider failure stays on the generic stream-error code",
+      );
+      assertEquals(
+        outcome.error.retryable,
+        true,
+        "an unrecognized provider failure is retryable",
+      );
+      assertEquals(
+        outcome.error.publicMessage,
+        "Provider stream failed",
+        "an unrecognized provider failure must be replaced by fixed public text, never echoed",
       );
     }
   });

--- a/src/agent/streaming/tool-execution-data-event-bridge.test.ts
+++ b/src/agent/streaming/tool-execution-data-event-bridge.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { ToolExecutionDataEvent } from "../../tool/types.ts";
 import { createToolExecutionDataEventBridgeStream } from "./tool-execution-data-event-bridge.ts";
@@ -92,6 +92,32 @@ describe("createToolExecutionDataEventBridgeStream", () => {
     controller.enqueue(encoder.encode('data: {"type":"message-finish"}\n\n'));
     controller.close();
     await reader.cancel();
+  });
+
+  it("surfaces base stream failures as stream errors", async () => {
+    let publishDataEvent = (_event: ToolExecutionDataEvent) => {};
+
+    const stream = createToolExecutionDataEventBridgeStream({
+      baseStream: new ReadableStream<Uint8Array>({
+        pull(controller) {
+          controller.error(new Error("upstream boom"));
+        },
+      }),
+      installPublisher(nextPublishDataEvent) {
+        publishDataEvent = nextPublishDataEvent;
+      },
+    });
+
+    await assertRejects(
+      () => stream.getReader().read(),
+      Error,
+      "upstream boom",
+      "base stream failures must propagate as a stream error, not a clean close",
+    );
+
+    // The pump reinstalls a no-op publisher on teardown, so a late publish must
+    // not enqueue onto the errored controller.
+    publishDataEvent({ type: "late", data: {} });
   });
 
   it("cancel resolves cleanly when the base reader cancel rejects (#2334)", async () => {


### PR DESCRIPTION
## Summary

Audit of all 44 test files under `src/agent/ag-ui` and `src/agent/streaming`.

Every change was **mutation checked**: the named source edit was applied, the test confirmed to fail, then reverted. 59 candidate findings, 50 confirmed after adversarial verification, 9 refuted. **Test files only**; no source changes.

## Recurring weaknesses fixed

**Gates that the default fixture never reached.** Raw diagnostic capture was only exercised with the default policy, whose redactor is already null, so the `rawCapture !== "redacted"` gate could be deleted and the test stayed green. A case with `rawCapture: "disabled"` and a non-null redactor now pins it independently.

**Failure paths that closed cleanly instead of erroring.** The tool-execution bridge now asserts an upstream `pull()` failure propagates as a stream error, and that a late publish cannot enqueue onto the errored controller. Replacing `controller.error` with `controller.close` fails it.

**Run bookkeeping never asserted.** The runtime handler gained four cases pinning `completeRun`/`failRun`: lifecycle callbacks clearing run status, a mid-flight stream error releasing the run, a duplicate run id returning 409 `{error:"Run already active"}`, and stream-setup failure releasing the run on the 500 path.

**Sticky metadata and buffered replay.** Deferred billing mode is asserted to survive a later `direct` chunk, and two new encoder cases cover recovering buffered tool input when `tool-input-available` carries `{}`, and replaying buffered deltas after a late `tool-input-start`.

**Oracles that could not distinguish outcomes.** A thrown fixture was a plain object whose `String()` form is `[object Object]`, so a substring-absence check proved nothing; it is now a real `Error` with a positive assertion on the exact sanitized `publicMessage`. A legacy encoder test asserting `includes("finishReason") === false` now asserts on `RunFinished` and fails if `observeEncodedEvents` is dropped.

## Verification

- Semantic unit-boundary audit ok, migration file untouched
- Sanitizer ratchet ok 390/390, `lint:test-typecheck` baseline holds (0 new)
- `lint:testing-front-door`: no key above baseline
- `deno fmt`, `deno lint` clean
- **32/32** changed test files pass (exit-code checked)
