### PR TITLE
Document SHA-bound merge queue review policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,8 +228,9 @@ validates that reviewed head against the latest `main` and the pull requests ahe
 the required checks on the generated `merge_group` commit.
 
 - Do not update, rebase, or re-review a clean pull request only because `main` advanced.
-- Do not rerun pull request checks manually when the reviewed head SHA is unchanged. Let the merge
-  queue validate the current integration commit.
+- Do not rerun successful pull request checks manually only because `main` advanced. If a pull
+  request check fails, diagnose it and rerun the unchanged head after an infrastructure flake;
+  change the head and re-review when the failure exposes a real defect.
 - Re-review when the pull request head SHA changes, including after a conflict resolution or fix.
 - If a merge-group check fails without a code change, diagnose the failure. Requeue the same reviewed
   head after an infrastructure flake. Change the head and re-review it when the failure exposes a real

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,24 @@ Build and release loop:
 4. Run a dry build when build output changes: `vf_build({ dryRun: true })`.
 5. Run the production build when release behavior changes: `vf_build()`.
 
+### Pull request merge queue policy
+
+Treat a completed review as an attestation for the exact pull request head SHA. The merge queue
+validates that reviewed head against the latest `main` and the pull requests ahead of it by running
+the required checks on the generated `merge_group` commit.
+
+- Do not update, rebase, or re-review a clean pull request only because `main` advanced.
+- Do not rerun pull request checks manually when the reviewed head SHA is unchanged. Let the merge
+  queue validate the current integration commit.
+- Re-review when the pull request head SHA changes, including after a conflict resolution or fix.
+- If a merge-group check fails without a code change, diagnose the failure. Requeue the same reviewed
+  head after an infrastructure flake. Change the head and re-review it when the failure exposes a real
+  incompatibility.
+- Do not jump a pull request ahead of other queued entries. Reordering invalidates generated queue
+  prefixes and forces GitHub to rebuild them.
+- Before queueing, ensure the exact head has the required review, all review threads are resolved, and
+  pull request checks pass. Do not mutate the pull request branch while it is queued.
+
 ## Architecture map
 
 ```text


### PR DESCRIPTION
## Summary

- bind completed reviews to the exact pull request head SHA
- let merge-group checks validate unchanged heads against current main
- require re-review only after head changes or genuine integration defects
- forbid queue jumping and branch mutation while queued

## Live repository settings applied

- disabled stale-review dismissal on base movement
- require one formal approval without dismissing it for base-only movement
- required review-thread resolution
- removed the personal review bypass
- increased merge-queue build concurrency from 1 to 3
- retained ALLGREEN, squash, and one-at-a-time merges

## Verification

- git diff --check
- AGENTS.md forbidden-path scan
- AGENTS.md secret-pattern scan
- pinned Deno fmt check