### PR TITLE
test(agent/runtime,cli/dev,eval): stop three deadline and port races reddening main

### DIFF
--- a/cli/commands/dev/dev.test.ts
+++ b/cli/commands/dev/dev.test.ts
@@ -216,14 +216,19 @@ describe("cli/commands/dev", () => {
         return Promise.resolve(null);
       });
 
-      assertEquals(started.port, port);
-      assertEquals(startedOn, [port]);
+      assert(
+        started.port >= port,
+        `expected the scan to start at ${port}, got ${started.port}`,
+      );
+      assertEquals(startedOn, [started.port]);
     });
 
     it("names the port in a PORT_IN_USE error when binding loses the race", async () => {
       const port = freePort();
+      let boundPort: number | undefined;
 
-      const error = await startDevServerOnFreePort(port, () => {
+      const error = await startDevServerOnFreePort(port, (selected) => {
+        boundPort = selected;
         // What the runtime throws when something grabs the port after the probe.
         return Promise.reject(
           Object.assign(new Error("listen EADDRINUSE: address already in use"), {
@@ -235,7 +240,11 @@ describe("cli/commands/dev", () => {
       assert(error instanceof Error, "expected the lost bind race to reject");
       const veryfrontError = error as Error & { slug?: string };
       assertEquals(veryfrontError.slug, "port-in-use");
-      assertStringIncludes(veryfrontError.message, String(port));
+      assertStringIncludes(
+        veryfrontError.message,
+        String(boundPort),
+        "the error names the port that lost the race, not the one asked for",
+      );
     });
 
     it("lets an unrelated startup failure through untouched", async () => {

--- a/src/agent/runtime/project-files-client.test.ts
+++ b/src/agent/runtime/project-files-client.test.ts
@@ -40,6 +40,7 @@ const TEST_MAX_PATH_CHARACTERS = 4_096;
 const TEST_MAX_ERROR_BODY_BYTES = 64 * 1_024;
 const TEST_MAX_ERROR_MESSAGE_CHARACTERS = 4_096;
 const TEST_PUBLIC_LISTING_MAX_PAGES = 50;
+const TEST_IN_FLIGHT_DEADLINE_MS = 250;
 
 function createUnboundedTestListingBudget() {
   return {
@@ -1189,7 +1190,7 @@ Deno.test("getStrictRuntimeProjectFiles cancels a late terminal response after i
   const error = await assertRejects(() =>
     getStrictRuntimeProjectFiles({
       ...baseOptions,
-      operationTimeoutMs: 1,
+      operationTimeoutMs: TEST_IN_FLIGHT_DEADLINE_MS,
       fetch: () => {
         fetchCalls += 1;
         return lateFetch.promise;
@@ -1199,7 +1200,7 @@ Deno.test("getStrictRuntimeProjectFiles cancels a late terminal response after i
 
   assertEquals((error as Error).name, "TimeoutError");
   assertStringIncludes(getErrorMessage(error), "aggregate deadline");
-  assertEquals(fetchCalls, 1);
+  assertEquals(fetchCalls, 1, "the deadline must end a request that started, not replace it");
 
   lateFetch.resolve(
     streamResponse(
@@ -1213,6 +1214,7 @@ Deno.test("getStrictRuntimeProjectFiles cancels a late terminal response after i
 
 Deno.test("getStrictRuntimeProjectFiles bounds a stalled terminal response body", async () => {
   const responseCancelled = createDeferred<void>();
+  let fetchCalls = 0;
   const body = new ReadableStream<Uint8Array>({
     cancel() {
       responseCancelled.resolve();
@@ -1222,13 +1224,17 @@ Deno.test("getStrictRuntimeProjectFiles bounds a stalled terminal response body"
   const error = await assertRejects(() =>
     getStrictRuntimeProjectFiles({
       ...baseOptions,
-      operationTimeoutMs: 1,
-      fetch: () => Promise.resolve(new Response(body)),
+      operationTimeoutMs: TEST_IN_FLIGHT_DEADLINE_MS,
+      fetch: () => {
+        fetchCalls += 1;
+        return Promise.resolve(new Response(body));
+      },
     })
   );
 
   assertEquals((error as Error).name, "TimeoutError");
   assertStringIncludes(getErrorMessage(error), "aggregate deadline");
+  assertEquals(fetchCalls, 1, "a body that never opened is never cancelled below");
   await responseCancelled.promise;
   assertEquals(body.locked, false);
 });

--- a/src/eval/agent-service-hardening.test.ts
+++ b/src/eval/agent-service-hardening.test.ts
@@ -121,6 +121,8 @@ function createCompletedDurableRunCanaryApiClient(
   };
 }
 
+const NODE_TIMER_EARLY_FIRE_MS = 1;
+
 describe("eval/agent-service hardening", () => {
   it("does not let explicit case ids bypass write authorization", () => {
     const readCase = createLiveCase("read");
@@ -1106,9 +1108,9 @@ describe("eval/agent-service hardening", () => {
       "the canary polls once for running state and once for the deadline-bounded pending request",
     );
     assertEquals(
-      result.durationMs >= requestTimeoutMs,
+      result.durationMs >= requestTimeoutMs - NODE_TIMER_EARLY_FIRE_MS,
       true,
-      "the canary waits out the configured terminal-poll deadline",
+      `the canary waits out the configured terminal-poll deadline, took ${result.durationMs}ms`,
     );
   });
 


### PR DESCRIPTION
## Why

The README CI/CD badge kept showing **failing** while any re-run of main was green. It is not a stale badge: **14 of the last 100 `main` pushes failed CI**, so the badge reports whichever the last push happened to be.

| Failures | Job | Test |
|---|---|---|
| 3 | `coverage shard 7/8` | `src/agent/runtime/project-files-client.test.ts` |
| 2 | `coverage shard 6/8` | `cli/commands/dev/dev.test.ts` |
| 1 | `tests (node)` | `src/eval/agent-service-hardening.test.ts` |
| 1 | `tests (bun)` | `src/utils/singleflight.test.ts` — tracked, untouched |

## What was wrong

**`project-files-client.test.ts`** — two cases asked for a **1 ms** aggregate deadline, then asserted the request had started. `getStrictRuntimeProjectFiles` re-checks the deadline immediately before launching each request, so on a loaded runner the budget was gone before `fetch` was called. Reproduced deterministically by advancing `performance.now()` 5 ms:

```
threw: TimeoutError - Project files listing exceeded its aggregate deadline
fetchCalls = 0 (test asserts 1)
```

The knock-on is worse than the assertion: `await responseCancelled.promise` then hangs on a body nothing will cancel — the `Promise resolution is still pending but the event loop has already resolved` leak that took shard 7/8 down the other two times. Both cases hand back a response that never settles on its own, so the deadline stays the only thing that can end the operation however large the budget is.

**`dev.test.ts`** — `freePort()` reports a port that was free a moment ago, not one it holds. When something took it first the scan moved on, and production correctly named the port it actually tried while the test asserted the one it asked for:

```
AssertionError: Expected actual: "Port 35494 is already in use" to contain: "35493".
```

**`agent-service-hardening.test.ts`** — the deadline is enforced by `setTimeout` but measured with `Date.now()`. On Node the timer can fire a millisecond early; measured at **4 in 300**, and the failing job was `tests (node)`.

## Scope

**No production code changes.** All three implementations were correct; the tests asserted something they never promised.

## Verification

- Deadline race reproduced deterministically, not inferred from a re-run.
- Node's early-timer delivery measured directly rather than assumed.
- Each fixed test re-run against a **mutated implementation** to confirm it still fails when the behaviour breaks: dropping the port from the `PORT_IN_USE` message, disabling late-response consumption, and collapsing the canary's poll budget to 1 ms. All three mutations turned the fixed tests red.
- `fmt:check`, `lint`, `lint:anti-slop`, `lint:test-semantic-dispositions`, `lint:testing-front-door`, `lint:skipped-tests` — all exit 0.
- All three files under `--parallel --trace-leaks`: `78 passed | 0 failed`.

## Left open

`singleflight.test.ts` taking the `DOMException` fallback under Bun matches veryfront/veryfront-issue-inbox#492, which explicitly says not to relax the assertion. Not reproducible in 30 local runs on Bun 1.3.6, so it is untouched — I left a comment there with a data point that narrows its stated hypothesis.

The `react-query (npm packages)` fixture failure in shard 6/8 is a separate cache issue, not addressed here.

https://claude.ai/code/session_01XCPxSvgYJihXd22J5BNABk