### PR TITLE
Keep App Router module CSS in production builds

### DIFF
--- a/src/build/production-build/static-generation.test.ts
+++ b/src/build/production-build/static-generation.test.ts
@@ -263,6 +263,46 @@ describe(
         assertStringIncludes(adapter.fs.files.get(cssPath!) ?? "", ".h-screen");
       });
 
+      it("includes CSS imported by App Router modules in production output", async () => {
+        const adapter = createMemoryAdapter();
+        adapter.fs.files.set("/tmp/project/globals.css", '@import "tailwindcss";');
+        adapter.fs.files.set(
+          "/tmp/project/app/foo/page.tsx",
+          `import "./foo.css";
+          export default function Page() {
+            return <main className="foo">Hello</main>;
+          }`,
+        );
+        adapter.fs.files.set(
+          "/tmp/project/app/foo/foo.css",
+          ".foo { color: red; }",
+        );
+
+        await buildAppRoutes(
+          [{
+            path: "/foo",
+            pageFile: "/tmp/project/app/foo/page.tsx",
+            segments: ["foo"],
+            segmentDirs: ["/tmp/project/app/foo"],
+          }],
+          {
+            adapter,
+            projectDir: "/tmp/project",
+            outputDir: "/tmp/output",
+            renderer: createMockRenderer(),
+            config: createMockConfig(),
+            enablePrefetch: false,
+            chunkManifest: null,
+          },
+        );
+
+        const cssPath = [...adapter.fs.files.keys()].find((path) =>
+          path.startsWith("/tmp/output/_vf/css/") && path.endsWith(".css")
+        );
+        assertEquals(typeof cssPath, "string");
+        assertStringIncludes(adapter.fs.files.get(cssPath!) ?? "", ".foo");
+      });
+
       it("caches generated App Router CSS by hash for runtime CSS handler lookups", async () => {
         clearCSSCache();
         const adapter = createMemoryAdapter();

--- a/src/build/production-build/static-generation.test.ts
+++ b/src/build/production-build/static-generation.test.ts
@@ -303,6 +303,47 @@ describe(
         assertStringIncludes(adapter.fs.files.get(cssPath!) ?? "", ".foo");
       });
 
+      it("merges App Router CSS imports onto the default stylesheet when no global stylesheet exists", async () => {
+        const adapter = createMemoryAdapter();
+        adapter.fs.files.set(
+          "/tmp/project/app/foo/page.tsx",
+          `import "./foo.css";
+          export default function Page() {
+            return <main className="foo px-4">Hello</main>;
+          }`,
+        );
+        adapter.fs.files.set(
+          "/tmp/project/app/foo/foo.css",
+          ".foo { color: red; }",
+        );
+
+        await buildAppRoutes(
+          [{
+            path: "/foo",
+            pageFile: "/tmp/project/app/foo/page.tsx",
+            segments: ["foo"],
+            segmentDirs: ["/tmp/project/app/foo"],
+          }],
+          {
+            adapter,
+            projectDir: "/tmp/project",
+            outputDir: "/tmp/output",
+            renderer: createMockRenderer(),
+            config: createMockConfig(),
+            enablePrefetch: false,
+            chunkManifest: null,
+          },
+        );
+
+        const cssPath = [...adapter.fs.files.keys()].find((path) =>
+          path.startsWith("/tmp/output/_vf/css/") && path.endsWith(".css")
+        );
+        assertEquals(typeof cssPath, "string");
+        const css = adapter.fs.files.get(cssPath!) ?? "";
+        assertStringIncludes(css, ".foo");
+        assertStringIncludes(css, ".px-4");
+      });
+
       it("caches generated App Router CSS by hash for runtime CSS handler lookups", async () => {
         clearCSSCache();
         const adapter = createMemoryAdapter();

--- a/src/build/production-build/static-generation.ts
+++ b/src/build/production-build/static-generation.ts
@@ -21,9 +21,14 @@ import {
   generateTailwindCSS,
   hashCSS,
 } from "#veryfront/html/styles-builder/index.ts";
+import {
+  collectCssImportPaths,
+  CSS_IMPORTING_SOURCE_EXTENSIONS,
+} from "#veryfront/html/styles-builder/css-import-extraction.ts";
 import { FRAMEWORK_CANDIDATES } from "#veryfront/server/handlers/dev/framework-candidates.generated.ts";
 import { jsonForInlineScript } from "#veryfront/security/client/html-sanitizer.ts";
 import { SSG_GENERATION_ERROR } from "#veryfront/errors";
+import { mergeImportedCSS } from "#veryfront/rendering/orchestrator/html-imported-css.ts";
 
 export interface PageRenderResult {
   html: string;
@@ -145,8 +150,8 @@ async function readOptionalFile(
 async function collectAppRouteStyleSources(
   adapter: RuntimeAdapter,
   dir: string,
-): Promise<Array<{ path: string; content?: string }>> {
-  const files: Array<{ path: string; content?: string }> = [];
+): Promise<Array<{ path: string; content: string }>> {
+  const files: Array<{ path: string; content: string }> = [];
 
   async function walk(currentDir: string): Promise<void> {
     let entries: AsyncIterable<{ name: string; isFile: boolean; isDirectory: boolean }>;
@@ -186,13 +191,26 @@ async function prepareAppRouteStylesheet(
     join(options.projectDir, stylesheetPath),
   );
   const sourceFiles = await collectAppRouteStyleSources(options.adapter, options.projectDir);
+  const cssImportSources = sourceFiles.filter((file) =>
+    CSS_IMPORTING_SOURCE_EXTENSIONS.some((ext) => file.path.endsWith(ext))
+  );
+  const cssImports = collectCssImportPaths(cssImportSources, options.projectDir);
+  const mergedStylesheet = await mergeImportedCSS({
+    fs: options.adapter.fs,
+    logger,
+    projectDir: options.projectDir,
+    globalCSS: stylesheet,
+    cssImports,
+    stylesheetPath,
+  });
   const candidates = extractCandidatesFromFiles(sourceFiles, {
     projectDir: options.projectDir,
   });
   for (const candidate of FRAMEWORK_CANDIDATES) candidates.add(candidate);
 
   const generationSession = acquireCSSGenerationSession(true);
-  const resolvedStylesheet = stylesheet ?? generationSession.compilationSession.defaultStylesheet;
+  const resolvedStylesheet = mergedStylesheet ??
+    generationSession.compilationSession.defaultStylesheet;
   const generated = await generateTailwindCSS(resolvedStylesheet, candidates, {
     minify: true,
     environment: "production",

--- a/src/build/production-build/static-generation.ts
+++ b/src/build/production-build/static-generation.ts
@@ -190,6 +190,8 @@ async function prepareAppRouteStylesheet(
     options.adapter,
     join(options.projectDir, stylesheetPath),
   );
+  const generationSession = acquireCSSGenerationSession(true);
+  const baseStylesheet = stylesheet ?? generationSession.compilationSession.defaultStylesheet;
   const sourceFiles = await collectAppRouteStyleSources(options.adapter, options.projectDir);
   const cssImportSources = sourceFiles.filter((file) =>
     CSS_IMPORTING_SOURCE_EXTENSIONS.some((ext) => file.path.endsWith(ext))
@@ -199,7 +201,7 @@ async function prepareAppRouteStylesheet(
     fs: options.adapter.fs,
     logger,
     projectDir: options.projectDir,
-    globalCSS: stylesheet,
+    globalCSS: baseStylesheet,
     cssImports,
     stylesheetPath,
   });
@@ -208,9 +210,8 @@ async function prepareAppRouteStylesheet(
   });
   for (const candidate of FRAMEWORK_CANDIDATES) candidates.add(candidate);
 
-  const generationSession = acquireCSSGenerationSession(true);
   const resolvedStylesheet = mergedStylesheet ??
-    generationSession.compilationSession.defaultStylesheet;
+    baseStylesheet;
   const generated = await generateTailwindCSS(resolvedStylesheet, candidates, {
     minify: true,
     environment: "production",


### PR DESCRIPTION
## Description

Production App Router static generation now merges CSS imported by route modules before compiling the output stylesheet. This brings `veryfront build` in line with dev, SSR, and release asset behavior for route-local CSS imports.

A focused production-build regression covers a page module importing `./foo.css`.

## Related Issue(s)

Fixes #4137

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

## Verification

- Focused static generation suite: 22 steps passed
- Production build directory: 195 steps passed
- Integration server/build suite: 111 steps passed
- CSS extraction and SSR merger suites: 77 steps passed
- Pre-push formatting, 5,113-file lint, typecheck, and unit gate: 33,655 steps passed
- Full repository suite: 4,689 tests passed; four unrelated parallel race failures passed when both affected files were rerun in isolation
