### PR TITLE
fix(transforms): close late CSS strip review findings

### DIFF
--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -1,10 +1,15 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { stop as stopEsbuild } from "#veryfront/platform/compat/esbuild.ts";
 import { compilePlugin } from "./compile.ts";
 import type { TransformContext } from "../types.ts";
-import { cssStripPlugin } from "./ssr-css-strip.ts";
+import { __maskCommentQuotesForModuleLexer, cssStripPlugin } from "./ssr-css-strip.ts";
 import {
   getCssModuleScope,
   resolveCssModuleKey,
@@ -40,6 +45,22 @@ function createContext(code: string, dev = true): TransformContext {
     metadata: new Map(),
     reactVersion: "19.1.1",
   } as TransformContext;
+}
+
+function allPrivateUseSentinelCandidates(): string {
+  let candidates = "";
+  for (
+    const [first, last] of [
+      [0xe000, 0xf8ff],
+      [0xf0000, 0xffffd],
+      [0x100000, 0x10fffd],
+    ] as const
+  ) {
+    for (let codePoint = first; codePoint <= last; codePoint++) {
+      candidates += String.fromCodePoint(codePoint);
+    }
+  }
+  return candidates;
 }
 
 /**
@@ -118,6 +139,27 @@ describe("css-strip plugin", () => {
       "the emitted class must match the class the aggregated css is rewritten to",
     );
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("rewrites css imports whose suffix contains string escapes", async () => {
+    for (
+      const specifier of [
+        String.raw`./Button.module\x2ecss`,
+        String.raw`./Button.module.\x63ss`,
+        String.raw`./Button.module.c\u0073s`,
+        String.raw`./Button.module.cs\u{73}`,
+      ] as const
+    ) {
+      const ctx = createContext(
+        `import styles from "${specifier}"; export const cls = styles.container;`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+      const namespace = await evaluateModule(result);
+
+      assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
   });
 
   it("keeps a css re-export exporting the bindings it re-exported", async () => {
@@ -311,6 +353,1279 @@ describe("css-strip plugin", () => {
       "a quoted specifier containing `from` must keep the default css module binding",
     );
     assertEquals(ctx.metadata.get("cssImports"), ["./from'button.module.css"]);
+  });
+
+  it("does not treat `from` inside a css import comment as the keyword", async () => {
+    const ctx = createContext(
+      `const quotePattern = /'/; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export const matched = quotePattern.test("'");`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a comment containing a decoy `from` must not hide the real css import clause",
+    );
+    assertEquals(namespace.matched, true, "masking comments must not alter regex literals");
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("treats division after postfix operators as division while masking comments", async () => {
+    const ctx = createContext(
+      `let x = 2; const incremented = x++ / 2; const decremented = x-- / 2; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export const value = incremented + decremented;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a division slash after postfix increment must not hide a later css import comment",
+    );
+    assertEquals(namespace.value, 2.5, "the surrounding division expressions must stay intact");
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("keeps regex backticks inside template interpolations while masking comments", async () => {
+    const ctx = createContext(
+      'const value = `${/`/.test("`")}`; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { value };',
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a regex backtick inside a template interpolation must not hide a later css import comment",
+    );
+    assertEquals(namespace.value, "true", "the surrounding template expression must stay intact");
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("treats division after a Unicode identifier as division while masking comments", async () => {
+    const ctx = createContext(
+      `const π = 3; const value = π / 2; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { value };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(namespace.value, 1.5);
+  });
+
+  it("treats division after a standalone `of` binding as division", async () => {
+    const ctx = createContext(
+      `const of = 4; const value = of / 2; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { value };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "`of` used as a binding must not open regex context for the following slash",
+    );
+    assertEquals(namespace.value, 2);
+  });
+
+  it("still opens regex context for `of` in a for-of head", async () => {
+    const ctx = createContext(
+      `const matches = []; for (const match of /["]/g[Symbol.matchAll]('"x"')) matches.push(match[0]); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export const count = matches.length;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(namespace.count, 2, "a regex literal after for-of `of` must stay a regex");
+  });
+
+  it("does not treat a for-of binding named `of` as the separator", async () => {
+    const ctx = createContext(
+      `const matches = []; for (let of of /[\"]/g[Symbol.matchAll]('\"x\"')) matches.push(of[0]); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export const count = matches.length;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(namespace.count, 2, "only the second `of` must open operand context");
+  });
+
+  it("treats `of` as a binding inside a non-`for` control-flow head", async () => {
+    const ctx = createContext(
+      `const of = 4; let flag = false; if (of / 2) flag = true; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { flag };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "`of` inside an `if` head is a binding, not the for-of operator",
+    );
+    assertEquals(
+      namespace.flag,
+      true,
+      "the division inside the `if` head must stay executable",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("keeps a comment between `from` and the css specifier linkable", async () => {
+    const ctx = createContext(
+      `import styles from /* "./decoy.module.css" */ "./Button.module.css"; export const cls = styles.container;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a comment between `from` and the specifier must not drop the default binding",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("allows a regex literal after a `catch` block", async () => {
+    const ctx = createContext(
+      `const value = "'"; let ok = false; try {} catch (e) {} /[']/u.test(value); ok = true; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { ok };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(namespace.ok, true);
+  });
+
+  it("allows a regex literal after an `else` block", async () => {
+    const ctx = createContext(
+      `const value = "'"; let ok = false; if (!value) {} else {} /[']/u.test(value); ok = true; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { ok };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a regex after an `else` block must not hide the later css import comment",
+    );
+    assertEquals(namespace.ok, true, "the regex after the `else` block must stay executable");
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("allows a regex literal after a `try`/`finally` block", async () => {
+    const ctx = createContext(
+      `const value = "'"; let ok = false; try {} finally {} /[']/u.test(value); ok = true; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { ok };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a regex after a `finally` block must not hide the later css import comment",
+    );
+    assertEquals(namespace.ok, true, "the regex after the `finally` block must stay executable");
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("allows a regex literal after a statement block", async () => {
+    const ctx = createContext(
+      `const value = "'"; let ok = false; if (value) {} /[']/u.test(value); ok = true; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { ok };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a regex after a statement block must not trap the scanner in string mode",
+    );
+    assertEquals(namespace.ok, true, "the regex after the statement block must stay executable");
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("allows a regex literal after an optional-binding `catch` block", async () => {
+    const ctx = createContext(
+      `const value = "'"; let ok = false; try {} catch {} /[']/u.test(value); ok = true; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { ok };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a regex after a binding-less `catch` block must not hide the later css import comment",
+    );
+    assertEquals(
+      namespace.ok,
+      true,
+      "the regex after the binding-less `catch` block must stay executable",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("allows a regex literal after a `switch` block", async () => {
+    const ctx = createContext(
+      `const value = "'"; let ok = false; switch (value) { case "'": ok = true; break; } /[']/u.test(value); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { ok };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a regex after a `switch` block must not hide the later css import comment",
+    );
+    assertEquals(namespace.ok, true, "the `switch` body must stay executable");
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("allows a regex literal after `export default`", async () => {
+    const ctx = createContext(
+      `const value = "'"; export default /[']/u.test(value); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a regex after `export default` must not hide the later css import comment",
+    );
+    assertEquals(
+      namespace.default,
+      true,
+      "the regex exported as the default binding must stay a regex literal",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("treats an export-default object as an operand before division", async () => {
+    const ctx = createContext(
+      `export default {} / 2; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assert(Number.isNaN(namespace.default as number));
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "an export-default object must leave the following slash in division context",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("treats division after a reserved-word private name as division", async () => {
+    const ctx = createContext(
+      `const value = "'"; class Ratio { #return = 4; half() { return this.#return / 2; } } const half = new Ratio().half(); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { half, value };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a private name spelled as a keyword must not open regex context for the following slash",
+    );
+    assertEquals(namespace.half, 2, "`this.#return / 2` must stay a division");
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("allows a regex literal after an ASI-terminated `debugger` statement", async () => {
+    const ctx = createContext(
+      `const value = "'"; let ok = false; debugger\n/[']/u.test(value); ok = true; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { ok };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a regex on the line after `debugger` must not hide the later css import comment",
+    );
+    assertEquals(
+      namespace.ok,
+      true,
+      "the regex after the ASI-terminated statement must stay executable",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("recognizes return ASI before standalone and labelled blocks", async () => {
+    for (const separator of ["\n", " /* line terminator\n*/ "] as const) {
+      for (const block of ["{}", "outer: {}"] as const) {
+        const ctx = createContext(
+          `const value = '"'; function run() { return${separator}${block} /["]/u.test(value); } run(); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container;`,
+        );
+
+        const result = await cssStripPlugin.transform(ctx);
+        const namespace = await evaluateModule(result);
+
+        assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+        assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+      }
+    }
+  });
+
+  it("retains ASI-terminated break and continue context through labels", async () => {
+    for (
+      const statement of [
+        'outer: { break outer\n/["]/u.test(value); }',
+        'outer: for (let i = 0; i < 1; i++) { continue outer\n/["]/u.test(value); }',
+      ]
+    ) {
+      const ctx = createContext(
+        `const value = '"'; ${statement} import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container;`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+      const namespace = await evaluateModule(result);
+
+      assertEquals(
+        namespace.cls,
+        toScopedCssModuleClass(MODULE_KEY, "container"),
+        `${statement} must leave the next line in regex context`,
+      );
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
+  });
+
+  it("finishes restricted ASI statements at line terminators inside block comments", async () => {
+    for (
+      const statement of [
+        'debugger /*\n*/ /["]/u.test(value);',
+        'outer: { break outer /*\n*/ /["]/u.test(value); }',
+        'outer: for (let i = 0; i < 1; i++) { continue outer /*\n*/ /["]/u.test(value); }',
+      ]
+    ) {
+      const ctx = createContext(
+        `const value = '\"'; ${statement} import styles /* from \"./decoy.module.css\" */ from \"./Button.module.css\"; export const cls = styles.container;`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+      const namespace = await evaluateModule(result);
+
+      assertEquals(
+        namespace.cls,
+        toScopedCssModuleClass(MODULE_KEY, "container"),
+        `${statement} must leave the next token in regex context`,
+      );
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
+  });
+
+  it("keeps an optional break label through its ASI line terminator", async () => {
+    const ctx = createContext(
+      `const value = '"'; outer: { break outer\n/[\"]/u.test(value); } import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a break label must not hide the later css import comment after ASI",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("masks comments after a line comment terminates a labelled break", () => {
+    const { masked } = __maskCommentQuotesForModuleLexer(
+      `const value = '\"'; outer: { break outer // the label ends on this line
+/[\"]/u.test(value); } import styles /* from \"./decoy.module.css\" */ from \"./Button.module.css\";`,
+    );
+
+    assertEquals(masked.includes('/* from "./decoy.module.css" */'), false);
+    assertEquals(masked.includes('from "./Button.module.css";'), true);
+  });
+
+  it("masks comments after a block comment terminates a labelled continue", () => {
+    const { masked } = __maskCommentQuotesForModuleLexer(
+      `const value = '\"'; outer: for (;;) { continue outer /* the label ends here
+*/ /[\"]/u.test(value); } import styles /* from \"./decoy.module.css\" */ from \"./Button.module.css\";`,
+    );
+
+    assertEquals(masked.includes('/* from "./decoy.module.css" */'), false);
+    assertEquals(masked.includes('from "./Button.module.css";'), true);
+  });
+
+  it("keeps a line comment between `from` and the css specifier linkable", async () => {
+    const ctx = createContext(
+      `import styles from // "./decoy.module.css"\n"./Button.module.css"; export const cls = styles.container;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a line comment between `from` and the specifier must not drop the default binding",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("keeps a comment between a css re-export `from` and its specifier linkable", async () => {
+    const ctx = createContext(
+      `export { default as styles } from /* "./decoy.module.css" */ "./Button.module.css";`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      (namespace.styles as Record<string, string>).container,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a comment before a re-exported css specifier must not drop the re-exported binding",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("treats division after an object literal as division while masking comments", async () => {
+    const ctx = createContext(
+      `const value = { valueOf: () => 8 } / 2; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { value };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "an object literal closing brace must keep the following slash a division operator",
+    );
+    assertEquals(namespace.value, 4, "the division after the object literal must stay executable");
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("allows a regex literal after a declaration body", async () => {
+    const ctx = createContext(
+      `const value = '"'; function f() {} /["]/u.test(value); const ok = true; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { ok };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(namespace.ok, true);
+  });
+
+  it("keeps declaration body tracking through nested header braces", async () => {
+    for (
+      const declaration of [
+        "function f(options = {}) {}",
+        "function f(options = { function: true, class: true }) {}",
+        "class Declared extends (class { static options = { function: true, class: true }; }) {}",
+      ]
+    ) {
+      const ctx = createContext(
+        `const value = '"'; ${declaration} /["]/u.test(value); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container;`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+      const namespace = await evaluateModule(result);
+
+      assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
+  });
+
+  it("does not treat keyword-named class fields as nested bodies", async () => {
+    const ctx = createContext(
+      `class FieldNames { function; class; } const ratio = {} / 2; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { ratio };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assert(Number.isNaN(namespace.ratio as number));
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("does not treat an import-named class field as a static import", async () => {
+    const ctx = createContext(
+      `class Fields { import = {} / 2; } const ratio = new Fields().import; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { ratio };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assert(Number.isNaN(namespace.ratio as number));
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("drops semicolonless keyword-field body trackers with their class", async () => {
+    const ctx = createContext(
+      `class Fields { function\nclass\n} const value = '"'; if (true) {} /["]/u.test(value); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { Fields };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(typeof namespace.Fields, "function");
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("does not treat a semicolonless class-named field as a class head", () => {
+    const { masked } = __maskCommentQuotesForModuleLexer(
+      `class Fields { class\nvalue = {} / 2 } import styles /* from "./decoy.module.css" */ from "./Button.module.css";`,
+    );
+
+    assertStringIncludes(
+      masked,
+      "value = {} / 2",
+      "a class-named field must leave the next field's initializer division unmasked",
+    );
+    assertEquals(
+      masked.includes('"./decoy.module.css"'),
+      false,
+      "a class-named field must not leave css comment quotes unmasked",
+    );
+  });
+
+  it("does not treat a semicolonless function-named field as a function head", () => {
+    const { masked } = __maskCommentQuotesForModuleLexer(
+      `class Fields { function\nvalue = foo()\nother = {} / 2 } import styles /* from "./decoy.module.css" */ from "./Button.module.css";`,
+    );
+
+    assertStringIncludes(
+      masked,
+      "other = {} / 2",
+      "a function-named field must not turn a later field initializer into a declaration body",
+    );
+    assertEquals(
+      masked.includes('"./decoy.module.css"'),
+      false,
+      "a stale function body tracker must not leave CSS comment quotes unmasked",
+    );
+  });
+
+  it("does not consume an object initializer as a semicolonless class field body", async () => {
+    const ctx = createContext(
+      `class Fields { class\nvalue = {} / 2 } const ratio = new Fields().value; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { ratio };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assert(Number.isNaN(namespace.ratio as number));
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("keeps class-field initializer expressions out of class-element tracking", async () => {
+    const ctx = createContext(
+      `const foo = { bar: 4 }; class Fields { property = foo.bar / 2; sync = function() {} / 2; } const fields = new Fields(); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export const property = fields.property; export const sync = fields.sync;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.property, 2);
+    assert(Number.isNaN(namespace.sync as number));
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("does not track keyword names inside module specifier lists as bodies", async () => {
+    const ctx = createContext(
+      `export { class as x } from "./dep.js"; const ratio = {} / 2; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { ratio };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+
+    assertStringIncludes(result, `export { class as x } from "./dep.js"`);
+    assertStringIncludes(result, `const ratio = {} / 2`);
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("tracks a mixed import's named bindings as module specifiers", async () => {
+    for (const defaultBinding of ["d", "from"] as const) {
+      const ctx = createContext(
+        `import ${defaultBinding}, { class as x } from "./dep.js"; const value = '"'; if (true) {} /["]/u.test(value); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { ${defaultBinding}, x };`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+
+      assertStringIncludes(
+        result,
+        `import ${defaultBinding}, { class as x } from "./dep.js"`,
+      );
+      assertStringIncludes(result, `if (true) {} /["]/u.test(value)`);
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
+  });
+
+  it("reopens statement context after semicolonless module sources", async () => {
+    for (
+      const { declaration, localExport, exportName } of [
+        {
+          declaration: `import dep from "data:text/javascript,export default 1"`,
+          localExport: "export { dep };",
+          exportName: "dep",
+        },
+        {
+          declaration: `import "data:text/javascript,"`,
+          localExport: "",
+          exportName: undefined,
+        },
+        {
+          declaration: `export { default as dep } from "data:text/javascript,export default 1"`,
+          localExport: "",
+          exportName: "dep",
+        },
+        {
+          declaration: `export * from "data:text/javascript,export const helper=1"`,
+          localExport: "",
+          exportName: "helper",
+        },
+      ] as const
+    ) {
+      const ctx = createContext(
+        `const value = '"'; ${declaration}\n/["]/u.test(value); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; ${localExport}`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+      const namespace = await evaluateModule(result);
+
+      if (exportName !== undefined) assertEquals(namespace[exportName], 1);
+      assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
+  });
+
+  it("does not treat an ordinary top-level `from` as a module source", async () => {
+    const ctx = createContext(
+      `const from = 1; from\n"x" / 2; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { from };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.from, 1);
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("reopens statement context after import attribute objects", async () => {
+    for (
+      const declaration of [
+        `import dep from "data:application/json,1" with { type: "json" }`,
+        `export { default as dep } from "data:application/json,1" with { type: "json" }`,
+        `import dep from "data:application/json,1" assert { type: "json" }`,
+        `export { default as dep } from "data:application/json,1" assert { type: "json" }`,
+      ] as const
+    ) {
+      const ctx = createContext(
+        `const value = '"'; ${declaration}\n/["]/u.test(value); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container;`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+
+      assertStringIncludes(result, declaration);
+      assertStringIncludes(result, `/["]/u.test(value)`);
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
+  });
+
+  it("treats function and class expressions as operands before division", async () => {
+    for (
+      const { expression, expectedRatio } of [
+        { expression: "function named() {}", expectedRatio: Number.NaN },
+        { expression: "function named()\n{}", expectedRatio: Number.NaN },
+        { expression: "function named(options = {}) {}", expectedRatio: Number.NaN },
+        {
+          expression: "function named(options = { function: true, class: true }) {}",
+          expectedRatio: Number.NaN,
+        },
+        {
+          expression: "class Named { static [Symbol.toPrimitive]() { return 9; } }",
+          expectedRatio: 4.5,
+        },
+        {
+          expression: "class Named\n{ static [Symbol.toPrimitive]() { return 9; } }",
+          expectedRatio: 4.5,
+        },
+        {
+          expression:
+            "class Named extends (class { static options = { function: true, class: true }; }) { static [Symbol.toPrimitive]() { return 9; } }",
+          expectedRatio: 4.5,
+        },
+      ]
+    ) {
+      const ctx = createContext(
+        `const ratio = ${expression} / 2; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { ratio };`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+      const namespace = await evaluateModule(result);
+
+      assertEquals(
+        namespace.cls,
+        toScopedCssModuleClass(MODULE_KEY, "container"),
+        `${expression} must leave the following slash in division context`,
+      );
+      if (Number.isNaN(expectedRatio)) {
+        assert(Number.isNaN(namespace.ratio as number));
+      } else {
+        assertEquals(namespace.ratio, expectedRatio);
+      }
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
+  });
+
+  it("treats standalone and labelled blocks as statement context before regex", async () => {
+    for (const block of ["{}", "outer: {}"] as const) {
+      const ctx = createContext(
+        `const value = '\"'; ${block} /[\"]/u.test(value); import styles /* from \"./decoy.module.css\" */ from \"./Button.module.css\"; export const cls = styles.container;`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+      const namespace = await evaluateModule(result);
+
+      assertEquals(
+        namespace.cls,
+        toScopedCssModuleClass(MODULE_KEY, "container"),
+        `${block} must leave the following slash in regex context`,
+      );
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
+  });
+
+  it("treats standalone blocks inside concise methods as statement context", async () => {
+    for (
+      const declaration of [
+        `class Container { method() { {} /["]/u.test(value); } }`,
+        `const Container = { method() { {} /["]/u.test(value); } };`,
+      ] as const
+    ) {
+      const ctx = createContext(
+        `const value = '"'; ${declaration} import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { Container };`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+      const namespace = await evaluateModule(result);
+
+      assertEquals(
+        typeof namespace.Container,
+        declaration.startsWith("class") ? "function" : "object",
+      );
+      assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
+  });
+
+  it("treats standalone blocks inside arrow bodies as statement context", async () => {
+    for (const block of ["{}", "labelled: {}"] as const) {
+      const ctx = createContext(
+        `const value = '"'; const matches = () => { ${block} /["]/u.test(value); }; matches(); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container;`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+      const namespace = await evaluateModule(result);
+
+      assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
+  });
+
+  it("keeps parenthesized arrow expression bodies in operand context", async () => {
+    const ctx = createContext(
+      `const createValue = () => ({ value: 1 }); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const value = createValue().value; export const cls = styles.container;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.value, 1);
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("closes a block-bodied arrow as an operand before division", async () => {
+    const ctx = createContext(
+      `const ratio = (() => {}) / 2; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { ratio };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assert(Number.isNaN(namespace.ratio as number));
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("treats class static initialization blocks as statement blocks", async () => {
+    for (const block of ["{}", "labelled: {}"] as const) {
+      const ctx = createContext(
+        `const value = '"'; class WithStatic { static { ${block} /["]/u.test(value); } } import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { WithStatic };`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+      const namespace = await evaluateModule(result);
+
+      assertEquals(
+        namespace.cls,
+        toScopedCssModuleClass(MODULE_KEY, "container"),
+        `a static block containing ${block} must leave the following slash in regex context`,
+      );
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
+  });
+
+  it("recognizes ASI before standalone and labelled blocks", async () => {
+    for (const block of ["{}", "outer: {}"] as const) {
+      const ctx = createContext(
+        `const value = '"'; const foo = () => 0; foo()\n${block} /["]/u.test(value); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container;`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+      const namespace = await evaluateModule(result);
+
+      assertEquals(
+        namespace.cls,
+        toScopedCssModuleClass(MODULE_KEY, "container"),
+        `ASI before ${block} must leave the following slash in regex context`,
+      );
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
+  });
+
+  it("recognizes ASI before function and class declarations", async () => {
+    for (
+      const declaration of [
+        "function declared() {}",
+        "class Declared {}",
+      ] as const
+    ) {
+      const ctx = createContext(
+        `const value = '"'; const foo = () => 0; foo()\n${declaration} /["]/u.test(value); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container;`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+      const namespace = await evaluateModule(result);
+
+      assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
+  });
+
+  it("treats blocks after switch clause colons as statement context", async () => {
+    for (
+      const clause of [
+        'case "value"',
+        "case value?.length",
+        'case value ?? "fallback"',
+        'case true ? value : "fallback"',
+        "case true ? { value: 1 } : 42",
+        "default",
+      ] as const
+    ) {
+      const ctx = createContext(
+        `const value = \"value\"; switch (value) { ${clause}: {} /[\"]/u.test(value); break; } import styles /* from \"./decoy.module.css\" */ from \"./Button.module.css\"; export const cls = styles.container;`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+      const namespace = await evaluateModule(result);
+
+      assertEquals(
+        namespace.cls,
+        toScopedCssModuleClass(MODULE_KEY, "container"),
+        `${clause}: must leave the following block in statement context`,
+      );
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
+  });
+
+  it("preserves an outer switch clause while scanning a nested switch", async () => {
+    const ctx = createContext(
+      `const value = '"'; switch (1) { case (() => { switch (1) { case 1: return 1; } return 2; })(): {} /["]/u.test(value); break; } import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("ignores property names inside switch clause expressions", async () => {
+    for (const property of ["case", "default"] as const) {
+      const ctx = createContext(
+        `const value = '"'; const f = (x) => x; const obj = { case: 1, default: 2 }; switch (f(obj.${property})) { case f(obj.${property}): {} /["]/u.test(value); break; } import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container;`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+      const namespace = await evaluateModule(result);
+
+      assertEquals(
+        namespace.cls,
+        toScopedCssModuleClass(MODULE_KEY, "container"),
+        `a property named ${property} must not move the real clause colon out of statement context`,
+      );
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
+  });
+
+  it("keeps labelled else bodies in statement context", async () => {
+    const ctx = createContext(
+      `const value = '"'; if (true) {} else label: {} /["]/u.test(value); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("keeps escaped break labels through their ASI terminator", async () => {
+    for (const escapedLabel of ["out\\u0065r", "\\u006futer"]) {
+      const ctx = createContext(
+        `const value = '"'; outer: { break ${escapedLabel}\n /["]/u.test(value); } import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container;`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+      const namespace = await evaluateModule(result);
+
+      assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
+  });
+
+  it("retains a class body through tagged-template heritage expressions", async () => {
+    const ctx = createContext(
+      'const value = "\\""; const tag = () => class {}; class C extends tag`${{}}` {} /["]/u.test(value); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { C };',
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(typeof namespace.C, "function");
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("masks comment quotes after division following a function expression", () => {
+    const { masked } = __maskCommentQuotesForModuleLexer(
+      `const ratio = function() {} / 2; import styles /* from "./decoy.module.css" */ from "./Button.module.css";`,
+    );
+
+    assertEquals(
+      masked.includes('/* from "./decoy.module.css" */'),
+      false,
+      "division after a function expression must not leave css comment quotes unmasked",
+    );
+  });
+
+  it("masks comment quotes after division following a class expression", () => {
+    const { masked } = __maskCommentQuotesForModuleLexer(
+      `const ratio = class {} / 2; import styles /* from "./decoy.module.css" */ from "./Button.module.css";`,
+    );
+
+    assertEquals(
+      masked.includes('/* from "./decoy.module.css" */'),
+      false,
+      "division after a class expression must not leave css comment quotes unmasked",
+    );
+  });
+
+  it("reopens regex context after standalone and labelled statement blocks", () => {
+    for (
+      const prefix of [
+        `{} /[\"]/u.test(value);`,
+        `outer: {} /[\"]/u.test(value);`,
+      ]
+    ) {
+      const { masked } = __maskCommentQuotesForModuleLexer(
+        `${prefix} import styles /* from "./decoy.module.css" */ from "./Button.module.css";`,
+      );
+
+      assertEquals(
+        masked.includes('/* from "./decoy.module.css" */'),
+        false,
+        "a statement block closing brace must leave a following slash in regex context",
+      );
+    }
+  });
+
+  it("keeps `of` as an operand in a classic for initializer", () => {
+    const { masked } = __maskCommentQuotesForModuleLexer(
+      `const of = 4; for (let i = of / 2; i < 3; i++) {} import styles /* from "./decoy.module.css" */ from "./Button.module.css";`,
+    );
+
+    assertEquals(
+      masked.includes('/* from "./decoy.module.css" */'),
+      false,
+      "an ordinary binding named of inside a classic for head must keep division semantics",
+    );
+  });
+
+  it("decodes escaped await before classifying a for-await head", () => {
+    const source = String
+      .raw`async function consume() { for aw\u0061it (const value of /["]/u) { break; } } import styles /* from "./decoy.module.css" */ from "./Button.module.css";`;
+
+    const { masked } = __maskCommentQuotesForModuleLexer(source);
+
+    assertStringIncludes(
+      masked,
+      String.raw`for aw\u0061it (const value of /["]/u)`,
+      "the regex slash in a for-await head must not be rewritten as division",
+    );
+    assertEquals(
+      masked.includes(`/* from "./decoy.module.css" */`),
+      false,
+      "the scanner must still reach and mask quotes in the later import comment",
+    );
+  });
+
+  it("retains declaration-body state through parameter object braces", () => {
+    const { masked } = __maskCommentQuotesForModuleLexer(
+      `function f(options = {}) {} /[\"]/u.test(value); import styles /* from "./decoy.module.css" */ from "./Button.module.css";`,
+    );
+
+    assertEquals(
+      masked.includes('/* from "./decoy.module.css" */'),
+      false,
+      "an object in a parameter initializer must not consume the function declaration body",
+    );
+  });
+
+  it("treats `...` as one operator so a spread operand may be a regex", async () => {
+    const ctx = createContext(
+      `const copy = { .../["]/u }; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export const k = Object.keys(copy).length;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(typeof namespace.k, "number");
+  });
+
+  it("keeps statement-block context inside a template interpolation", async () => {
+    const ctx = createContext(
+      'const value = \'"\'; const t = `${(() => { if (value) {} /["]/u.test(value); return 1; })()}`; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { t };',
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(namespace.t, "1");
+  });
+
+  it("allows a regex literal as an unbraced `else` body", async () => {
+    const ctx = createContext(
+      `const value = '"'; let matched = false; if (!value) matched = true; else /["]/u.test(value); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { matched };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a regex after `else` must not trap the scanner in string mode",
+    );
+    assertEquals(namespace.matched, false);
+  });
+
+  it("allows a regex literal as an unbraced `do` body", async () => {
+    const ctx = createContext(
+      `const value = '"'; let seen = 0; do /["]/u.test(value), seen++; while (seen < 1); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { seen };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a regex after `do` must not trap the scanner in string mode",
+    );
+    assertEquals(namespace.seen, 1);
+  });
+
+  it("keeps member context for keyword-named properties before division", async () => {
+    const ctx = createContext(
+      `const stats = { return: 4 }; const value = stats.return / 2; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { value };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(namespace.value, 2);
+  });
+
+  it("starts a regex after a control-flow condition while masking comments", async () => {
+    const ctx = createContext(
+      `const enabled = true; let observed = ""; const record = (value) => { observed = value; return value; }; if (enabled) /["]/u.test(record('"')); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { observed };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a regex literal used as an unbraced if body must not hide a later css import comment",
+    );
+    assertEquals(
+      namespace.observed,
+      '"',
+      "the regex literal after the control-flow condition must stay executable",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("treats division after a call expression as division while masking comments", async () => {
+    const ctx = createContext(
+      `const size = (n) => n; const value = size(5) / 2; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { value };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a division slash after a call expression must not hide a later css import comment",
+    );
+    assertEquals(
+      namespace.value,
+      2.5,
+      "a closing parenthesis that is not a control-flow head must keep division semantics",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("does not borrow a sentinel encoded by a Unicode escape", async () => {
+    const ctx = createContext(
+      `export { "\\uE000" } /* from "./decoy.module.css" */ from "./Button.module.css";`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace["\uE000"],
+      toScopedCssModuleClass(MODULE_KEY, "\uE000"),
+      "restoring comment quotes must not rewrite decoded export-name data",
+    );
+  });
+
+  it("does not restore scanner markers inside generated export names", async () => {
+    for (
+      const { prefix, encodedName, decodedName } of [
+        {
+          prefix: "const ratio = function() {} / 2;",
+          encodedName: "%\\u002f*__VF_CSS_DIVISION_0__*/",
+          decodedName: "%/*__VF_CSS_DIVISION_0__*/",
+        },
+        {
+          prefix: '{} /["]/u.test("\\"");',
+          encodedName: "\\u003b__VF_CSS_REGEX_0__",
+          decodedName: ";__VF_CSS_REGEX_0__",
+        },
+      ] as const
+    ) {
+      const ctx = createContext(
+        `${prefix} export { "${encodedName}" } /* from "./decoy.module.css" */ from "./Button.module.css";`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+      const namespace = await evaluateModule(result);
+
+      assertEquals(
+        namespace[decodedName],
+        toScopedCssModuleClass(MODULE_KEY, decodedName),
+        "restoring scanner masks must not rewrite decoded generated names",
+      );
+    }
+  });
+
+  it("reserves a surrogate pair split by a string line continuation", async () => {
+    // Exhaust the BMP private-use sentinels so selection reaches U+F0000, then
+    // spell that code point as a continuation-split surrogate pair. The pair
+    // decodes to one character at runtime, so it must be reserved.
+    //
+    // The emitted source is asserted directly rather than evaluated: the filler
+    // makes the module too large for a `data:` URL under Bun.
+    const bmpPrivateUse = Array.from(
+      { length: 0xf8ff - 0xe000 + 1 },
+      (_, offset) => String.fromCodePoint(0xe000 + offset),
+    ).join("");
+    const ctx = createContext(
+      `const filler = ${
+        JSON.stringify(bmpPrivateUse)
+      }; export { "\\uDB80\\\n\\uDC00" } /* from "./decoy.module.css" */ from "./Button.module.css"; export { filler };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+
+    assertStringIncludes(
+      result,
+      `as "\u{F0000}"`,
+      "a continuation-split surrogate pair must not be borrowed as a quote sentinel",
+    );
+  });
+
+  it("reserves a surrogate pair written with braced escapes", async () => {
+    const bmpPrivateUse = Array.from(
+      { length: 0xf8ff - 0xe000 + 1 },
+      (_, offset) => String.fromCodePoint(0xe000 + offset),
+    ).join("");
+    const ctx = createContext(
+      `const filler = ${
+        JSON.stringify(bmpPrivateUse)
+      }; export { "\\u{DB80}\\u{DC00}" } /* from "./decoy.module.css" */ from "./Button.module.css"; export { filler };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+
+    assertStringIncludes(
+      result,
+      `as "\u{F0000}"`,
+      "adjacent braced surrogate escapes must reserve their combined code point",
+    );
+  });
+
+  it("treats a leading hashbang as a line comment while masking comments", async () => {
+    const ctx = createContext(
+      `#!/usr/bin/env user's-runner\nimport styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
   });
 
   it("preserves quoted css export names", async () => {
@@ -554,6 +1869,149 @@ describe("css-strip plugin", () => {
       "the css re-export must still resolve through a collision-free local",
     );
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("allocates a css export local without rescanning a long prefix-like string", async () => {
+    const decoy = `__vfCssExport_${"$".repeat(10_000)}`;
+    const ctx = createContext(
+      `export const decoy = ${
+        JSON.stringify(decoy)
+      }; export { default as styles } from "./Button.module.css";`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+
+    assertStringIncludes(
+      result,
+      "const __vfCssExport_0 =",
+      "a long prefix-like string must not force repeated source scans or alter allocation",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("strips comments from a css re-export binding clause", async () => {
+    const ctx = createContext(
+      `export { default /* from "./decoy.module.css" */ as styles } from "./Button.module.css";`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      (namespace.styles as Record<string, string>).container,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "a comment inside a re-export clause must not drop the re-exported binding",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("ends a css import line comment at every ECMAScript line terminator", async () => {
+    for (
+      const [name, terminator] of [
+        ["CR", "\r"],
+        ["LS", "\u2028"],
+        ["PS", "\u2029"],
+        ["LF", "\n"],
+      ] as const
+    ) {
+      const ctx = createContext(
+        `import styles // decoy${terminator} from "./Button.module.css";\nexport const cls = styles.container;`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+      const namespace = await evaluateModule(result);
+
+      assertEquals(
+        namespace.cls,
+        toScopedCssModuleClass(MODULE_KEY, "container"),
+        `a line comment closed by ${name} must not swallow the css import clause`,
+      );
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
+  });
+
+  it("treats an escaped identifier as occupying the generated css export local", async () => {
+    const ctx = createContext(
+      `const __vfCssExport_\\u0030 = "own"; export { default as styles } from "./Button.module.css"; export const own = __vfCssExport_\\u0030;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(
+      namespace.own,
+      "own",
+      "an escaped spelling of the generated local must not be redeclared by the stub",
+    );
+    assertEquals(
+      (namespace.styles as Record<string, string>).container,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "the re-export stub must still carry the css binding",
+    );
+  });
+
+  it("masks comment quotes even when the bmp private use area is exhausted", async () => {
+    let pua = "";
+    for (let codePoint = 0xe000; codePoint <= 0xf8ff; codePoint++) {
+      pua += String.fromCodePoint(codePoint);
+    }
+    const puaLiteral = JSON.stringify(pua);
+    const ctx = createContext(
+      `const icons = ${puaLiteral}; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export const iconCount = [...icons].length;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    assertStringIncludes(
+      result,
+      puaLiteral,
+      "restoring the mask must leave every private use character intact",
+    );
+    // Bun rejects data-URL module specifiers of this size. Shrink only the
+    // already-verified fixture literal so every runtime can still link and
+    // evaluate the generated CSS stub.
+    const namespace = await evaluateModule(result.replace(puaLiteral, '"x"'));
+
+    assertEquals(
+      namespace.cls,
+      toScopedCssModuleClass(MODULE_KEY, "container"),
+      "masking must survive a module occupying every bmp private use code point",
+    );
+    assertEquals(
+      namespace.iconCount,
+      1,
+      "the compacted module must remain executable after masking",
+    );
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("fails closed when every comment mask sentinel is occupied", () => {
+    const occupiedSentinels = allPrivateUseSentinelCandidates();
+
+    const error = assertThrows(
+      () =>
+        __maskCommentQuotesForModuleLexer(
+          `const occupied = ${
+            JSON.stringify(occupiedSentinels)
+          }; import styles /* from "./decoy.module.css" */ from "./Button.module.css";`,
+        ),
+      Error,
+      "CSS import comment masking could not allocate sentinels",
+    );
+
+    const errorSlug = error && typeof error === "object" && "slug" in error
+      ? error.slug
+      : undefined;
+    assertEquals(errorSlug, "css-comment-mask-sentinel-exhausted");
+  });
+
+  it("does not allocate comment-mask sentinels for a module without css", async () => {
+    const code = `const occupied = ${JSON.stringify(allPrivateUseSentinelCandidates())};`;
+    const ctx = createContext(code);
+
+    const result = await cssStripPlugin.transform(ctx);
+
+    assertEquals(result, code);
+    assertEquals(ctx.metadata.has("cssImports"), false);
   });
 
   it("strips a star css re-export, which carries no static names", async () => {

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -1364,6 +1364,32 @@ describe("css-strip plugin", () => {
     );
   });
 
+  it("retains semicolonless class fields after direct object-literal heritage", async () => {
+    const ctx = createContext(
+      `const unused = () => { class C extends {} { class\nextends = {} / 2 } return C; }; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { unused };`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(typeof namespace.unused, "function");
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
+  it("retains direct object-literal heritage inside a template expression", async () => {
+    const ctx = createContext(
+      'const unused = () => `${class extends {} { class\nextends = {} / 2 }}`; import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container; export { unused };',
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(typeof namespace.unused, "function");
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
   it("masks comment quotes after division following a function expression", () => {
     const { masked } = __maskCommentQuotesForModuleLexer(
       `const ratio = function() {} / 2; import styles /* from "./decoy.module.css" */ from "./Button.module.css";`,

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -1221,6 +1221,10 @@ describe("css-strip plugin", () => {
       const declaration of [
         "function declared() {}",
         "class Declared {}",
+        "async function declaredAsync() {}",
+        "export function exported() {}",
+        "export class Exported {}",
+        "export default async function declaredDefaultAsync() {}",
       ] as const
     ) {
       const ctx = createContext(
@@ -1233,6 +1237,18 @@ describe("css-strip plugin", () => {
       assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
       assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
     }
+  });
+
+  it("treats a bare yield line terminator as statement context", async () => {
+    const ctx = createContext(
+      `const value = '"'; function* generate() { yield\n{} /["]/u.test(value); } generate().next(); import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
   });
 
   it("treats blocks after switch clause colons as statement context", async () => {
@@ -1569,6 +1585,21 @@ describe("css-strip plugin", () => {
         "restoring scanner masks must not rewrite decoded generated names",
       );
     }
+  });
+
+  it("restores many scanner markers in one transform pass", async () => {
+    const regexStatements = Array.from(
+      { length: 1_024 },
+      (_, index) => `function declared${index}() {} /["]/u.test(value);`,
+    ).join(" ");
+    const ctx = createContext(
+      `const value = '"'; ${regexStatements} import styles /* from "./decoy.module.css" */ from "./Button.module.css"; export const cls = styles.container;`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+
+    assertEquals(result.includes("./decoy.module.css"), false);
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
   });
 
   it("reserves a surrogate pair split by a string line continuation", async () => {
@@ -2005,7 +2036,9 @@ describe("css-strip plugin", () => {
   });
 
   it("does not allocate comment-mask sentinels for a module without css", async () => {
-    const code = `const occupied = ${JSON.stringify(allPrivateUseSentinelCandidates())};`;
+    const code = `const suffix = ".css"; const occupied = ${
+      JSON.stringify(allPrivateUseSentinelCandidates())
+    };`;
     const ctx = createContext(code);
 
     const result = await cssStripPlugin.transform(ctx);

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -1347,6 +1347,23 @@ describe("css-strip plugin", () => {
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
   });
 
+  it("does not consume object-literal heritage as a class body", () => {
+    const { masked } = __maskCommentQuotesForModuleLexer(
+      `const value = '"'; class C extends { constructor: Object }.constructor { method() {} } /["]/u.test(value); import styles /* from "./decoy.module.css" */ from "./Button.module.css";`,
+    );
+
+    assertStringIncludes(
+      masked,
+      `class C extends { constructor: Object }.constructor { method() {} }`,
+      "object-literal heritage must not consume the pending class body",
+    );
+    assertEquals(
+      masked.includes('/* from "./decoy.module.css" */'),
+      false,
+      "the scanner must still mask comment quotes after the real class body",
+    );
+  });
+
   it("masks comment quotes after division following a function expression", () => {
     const { masked } = __maskCommentQuotesForModuleLexer(
       `const ratio = function() {} / 2; import styles /* from "./decoy.module.css" */ from "./Button.module.css";`,
@@ -1646,6 +1663,43 @@ describe("css-strip plugin", () => {
       `as "\u{F0000}"`,
       "adjacent braced surrogate escapes must reserve their combined code point",
     );
+  });
+
+  it("reserves surrogate pairs split between source text and escapes", async () => {
+    const bmpPrivateUse = Array.from(
+      { length: 0xf8ff - 0xe000 + 1 },
+      (_, offset) => String.fromCodePoint(0xe000 + offset),
+    ).join("");
+    const high = String.fromCharCode(0xdb80);
+    const low = String.fromCharCode(0xdc00);
+
+    for (
+      const { exportName, label } of [
+        {
+          exportName: `${high}\\uDC00`,
+          label: "literal high surrogate plus escaped low surrogate",
+        },
+        {
+          exportName: `\\uDB80${low}`,
+          label: "escaped high surrogate plus literal low surrogate",
+        },
+      ] as const
+    ) {
+      const ctx = createContext(
+        `const filler = ${
+          JSON.stringify(bmpPrivateUse)
+        }; export { "${exportName}" } /* from "./decoy.module.css" */ from "./Button.module.css"; export { filler };`,
+      );
+
+      const result = await cssStripPlugin.transform(ctx);
+
+      assertStringIncludes(
+        result,
+        `as "\u{F0000}"`,
+        `${label} must not be borrowed as a quote sentinel`,
+      );
+      assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+    }
   });
 
   it("treats a leading hashbang as a line comment while masking comments", async () => {

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -1032,6 +1032,25 @@ describe("css-strip plugin", () => {
     assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
   });
 
+  it("clears the source possibility after a semicolonless local named export", async () => {
+    const ctx = createContext(
+      `const x = 1
+export { x }
+const from = 1
+from
+"foo" / 2
+import styles /* from "./decoy.module.css" */ from "./Button.module.css"
+export const cls = styles.container`,
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(namespace.x, 1);
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(ctx.metadata.get("cssImports"), ["./Button.module.css"]);
+  });
+
   it("reopens statement context after import attribute objects", async () => {
     for (
       const declaration of [

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -853,6 +853,8 @@ class CommentQuoteMasker {
   private pendingArrowBody = false;
   private pendingImportSpecifiers = false;
   private pendingModuleSource = false;
+  private pendingNamedExportSpecifiers = false;
+  private pendingLocalExportSource = false;
   private pendingModuleAttributes = false;
   private afterModuleSource = false;
   private nextStringIsModuleSource = false;
@@ -1109,6 +1111,7 @@ class CommentQuoteMasker {
   private scanCodeToken(): void {
     const char = this.currentChar();
     const context = this.takeTokenContext();
+    this.finishLocalExportBeforeToken(context);
     if (this.scanQuoteStart(char)) return;
     if (this.scanNestedTemplateBrace(char, context)) return;
     if (this.scanSpread(char)) return;
@@ -1121,6 +1124,28 @@ class CommentQuoteMasker {
     if (this.scanParenthesis(char, context)) return;
     if (this.scanClosingOperand(char)) return;
     this.scanPunctuator(char, context);
+  }
+
+  private finishLocalExportBeforeToken(context: TokenContext): void {
+    if (!this.pendingLocalExportSource) return;
+    if (context.isIdentifierStart) {
+      const end = findIdentifierEndIndex(this.code, this.index);
+      const token = decodeUnicodeEscapes(this.code.slice(this.index, end));
+      const nextCodeIndex = skipTriviaIndex(this.code, end);
+      const nextCodeChar = nextCodeIndex === -1 ? undefined : this.code[nextCodeIndex];
+      if (
+        token === "from" && this.isTopLevel() &&
+        (nextCodeChar === "'" || nextCodeChar === '"')
+      ) {
+        return;
+      }
+    }
+
+    // A named export may be followed by `from "source"`; any other next token
+    // proves the closed list was local. Do not let a later ordinary identifier
+    // named `from` turn an unrelated string into a module source.
+    this.pendingLocalExportSource = false;
+    this.pendingModuleSource = false;
   }
 
   private takeTokenContext(): TokenContext {
@@ -1288,6 +1313,7 @@ class CommentQuoteMasker {
       (nextCodeChar === "{" || nextCodeChar === "*")
     ) {
       this.pendingModuleSource = true;
+      this.pendingNamedExportSpecifiers = nextCodeChar === "{";
     } else if (
       token === "from" && this.pendingModuleSource && this.isTopLevel() &&
       (nextCodeChar === "'" || nextCodeChar === '"')
@@ -1297,6 +1323,7 @@ class CommentQuoteMasker {
       // re-export, so the string that follows is a module source whose closing
       // quote ends the declaration and restores statement context.
       this.nextStringIsModuleSource = true;
+      this.pendingLocalExportSource = false;
     }
   }
 
@@ -1485,6 +1512,10 @@ class CommentQuoteMasker {
 
   private recordClosedBrace(): void {
     const closedBraceKind = this.braceKinds.pop() ?? "operand";
+    if (closedBraceKind === "module-specifiers" && this.pendingNamedExportSpecifiers) {
+      this.pendingNamedExportSpecifiers = false;
+      this.pendingLocalExportSource = true;
+    }
     this.canStartRegex = closedBraceKind === "statement-block" ||
       closedBraceKind === "switch-block" || closedBraceKind === "module-attributes" ||
       closedBraceKind === "module-specifiers";
@@ -1539,7 +1570,11 @@ class CommentQuoteMasker {
     this.append(char);
     this.updatePunctuatorDeclarationState(char, context, optionalChainQuestion);
     if (char === ";" || char === ".") this.pendingImportSpecifiers = false;
-    if (char === ";") this.pendingModuleSource = false;
+    if (char === ";") {
+      this.pendingModuleSource = false;
+      this.pendingNamedExportSpecifiers = false;
+      this.pendingLocalExportSource = false;
+    }
     this.canStartRegex = char !== ".";
     this.afterPropertyAccess = char === ".";
   }

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -17,11 +17,20 @@
 import type { TransformPlugin } from "../types.ts";
 import { TransformStage } from "../types.ts";
 import { parseImports, rewriteImports } from "../../esm/lexer.ts";
+import { defineError } from "#veryfront/errors";
 import {
   getCssModuleScope,
   resolveCssModuleKey,
   toScopedCssModuleClass,
 } from "#veryfront/transforms/css-modules/naming.ts";
+
+const CSS_COMMENT_MASK_SENTINEL_EXHAUSTED = defineError({
+  slug: "css-comment-mask-sentinel-exhausted",
+  category: "BUILD",
+  status: 500,
+  title: "CSS import comment masking failed",
+  suggestion: "Reduce private-use characters in the transformed module.",
+});
 
 function isCSSImport(specifier: string | undefined): boolean {
   return specifier?.endsWith(".css") || false;
@@ -29,6 +38,39 @@ function isCSSImport(specifier: string | undefined): boolean {
 
 function isCssModuleImport(specifier: string | undefined): boolean {
   return specifier?.endsWith(".module.css") || false;
+}
+
+/**
+ * Whether source text can decode to the suffix of a CSS module specifier.
+ *
+ * Module specifiers are string literals, so the raw source does not have to
+ * contain `.css`: `"./theme\\x2ecss"` names the same module. Decode only the
+ * escape forms that can contribute to this suffix (plus line continuations)
+ * before taking the expensive masking path. False positives outside strings
+ * are harmless; avoiding false negatives here is what keeps escaped CSS
+ * imports from bypassing the transform.
+ */
+function mayContainCSSSpecifier(code: string): boolean {
+  if (code.includes(".css")) return true;
+  if (!code.includes("\\")) return false;
+  const decoded = code.replace(
+    /\\(?:x([\da-fA-F]{2})|u\{([\da-fA-F]{1,6})\}|u([\da-fA-F]{4})|(\r\n|[\n\r\u2028\u2029])|([.cs]))/g,
+    (
+      match,
+      hex: string | undefined,
+      braced: string | undefined,
+      unicode: string | undefined,
+      continuation: string | undefined,
+      identity: string | undefined,
+    ) => {
+      if (continuation !== undefined) return "";
+      if (identity !== undefined) return identity;
+      const codePoint = Number.parseInt(hex ?? braced ?? unicode ?? "", 16);
+      if (!Number.isInteger(codePoint) || codePoint > 0x10ffff) return match;
+      return String.fromCodePoint(codePoint);
+    },
+  );
+  return decoded.includes(".css");
 }
 
 function cssModuleProxyExpression(): string {
@@ -55,6 +97,8 @@ function scopedCssModuleProxyExpression(moduleKey: string): string {
 }
 
 type NamedImportBinding = { imported: string; local: string };
+type StringQuote = '"' | "'";
+type JavaScriptQuote = StringQuote | "`";
 
 function parseNamedImportBindings(
   namedClause: string,
@@ -95,7 +139,7 @@ function parseNamedImportBindings(
 function splitNamedImportBindings(namedClause: string): string[] {
   const bindings: string[] = [];
   let start = 0;
-  let quote: '"' | "'" | undefined;
+  let quote: StringQuote | undefined;
   let escaped = false;
 
   for (let index = 0; index < namedClause.length; index++) {
@@ -127,7 +171,7 @@ function extractNamedImportClause(clause: string): string | undefined {
   const trimmed = clause.trim();
   if (!trimmed.startsWith("{")) return undefined;
 
-  let quote: '"' | "'" | undefined;
+  let quote: StringQuote | undefined;
   let escaped = false;
   for (let index = 1; index < trimmed.length; index++) {
     const char = trimmed[index];
@@ -150,6 +194,82 @@ function extractNamedImportClause(clause: string): string | undefined {
   }
 
   return undefined;
+}
+
+/**
+ * ECMAScript ends a line comment at any of four line terminators, not just LF:
+ * CR (U+000D), LS (U+2028) and PS (U+2029) close one as well. Scanning for
+ * `\n` alone makes `import styles // decoy\r from "./x.module.css"` look like a
+ * comment that runs to end of input, which drops the binding the statement
+ * introduces and leaves its uses undefined.
+ */
+function isLineTerminator(char: string | undefined): boolean {
+  return char === "\n" || char === "\r" || char === "\u2028" || char === "\u2029";
+}
+
+function findLineTerminatorIndex(value: string, from: number): number {
+  for (let index = from; index < value.length; index++) {
+    if (isLineTerminator(value[index])) return index;
+  }
+  return -1;
+}
+
+function findCommentEndIndex(value: string, index: number): number | undefined {
+  if (value[index] !== "/") return undefined;
+  if (value[index + 1] === "/") {
+    const lineEnd = findLineTerminatorIndex(value, index + 2);
+    return lineEnd === -1 ? -1 : lineEnd + 1;
+  }
+  if (value[index + 1] === "*") {
+    const blockEnd = value.indexOf("*/", index + 2);
+    return blockEnd === -1 ? -1 : blockEnd + 2;
+  }
+  return undefined;
+}
+
+function scanQuotedImportClauseCharacter(
+  char: string,
+  quote: StringQuote,
+  escaped: boolean,
+): { quote: StringQuote | undefined; escaped: boolean } {
+  if (escaped) return { quote, escaped: false };
+  if (char === "\\") return { quote, escaped: true };
+  return { quote: char === quote ? undefined : quote, escaped: false };
+}
+
+function stripImportClauseComments(clause: string): string {
+  let stripped = "";
+  let quote: StringQuote | undefined;
+  let escaped = false;
+  let index = 0;
+
+  while (index < clause.length) {
+    const char = clause[index]!;
+    if (quote) {
+      stripped += char;
+      ({ quote, escaped } = scanQuotedImportClauseCharacter(char, quote, escaped));
+      index++;
+      continue;
+    }
+
+    const commentEnd = findCommentEndIndex(clause, index);
+    if (commentEnd !== undefined) {
+      if (commentEnd === -1) return stripped;
+      stripped += " ";
+      index = commentEnd;
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char;
+      stripped += char;
+    } else {
+      stripped += char;
+    }
+    index++;
+  }
+
+  return stripped;
 }
 
 function parseQuotedExportName(token: string | undefined): string | undefined {
@@ -251,19 +371,42 @@ const CSS_EXPORT_LOCAL_PREFIX = "__vfCssExport_";
 type AllocateCssExportLocal = () => string;
 
 /**
- * A `__vfCssExport_` prefix that no text in `code` already contains.
+ * An identifier may spell any of its characters as a Unicode escape, so
+ * `__vfCssExport_\\u0030` and `__vfCssExport_0` name the same binding. A textual
+ * identifier scan sees only the second form, so the allocator would hand out a
+ * local the module already declares and the stub would fail to parse with a
+ * duplicate declaration. Decoding first makes both spellings collide in the set.
  *
+ * Decoding is deliberately unconditional rather than restricted to identifier
+ * positions: a decoded escape inside a string or comment can only *add* an
+ * occupied name, which makes allocation more conservative, never less.
+ */
+function decodeUnicodeEscapes(code: string): string {
+  return code.replace(
+    /\\u\{([0-9a-fA-F]{1,6})\}|\\u([0-9a-fA-F]{4})/g,
+    (match, braced: string | undefined, plain: string | undefined) => {
+      const codePoint = Number.parseInt(braced ?? plain ?? "", 16);
+      if (!Number.isInteger(codePoint) || codePoint > 0x10ffff) return match;
+      return String.fromCodePoint(codePoint);
+    },
+  );
+}
+
+/**
  * The generated locals share the module scope with the module's own bindings,
- * so a source that already declares `__vfCssExport_0` would be redeclared
- * by a fixed prefix and stop parsing. `$` is a valid identifier character, so
- * lengthening the prefix until it appears nowhere in the source makes every
- * counter-derived name unique against the module and its generated siblings.
+ * so a source that already declares `__vfCssExport_0` must be skipped. Collect
+ * identifiers once, then allocate against the set so attacker-controlled source
+ * length cannot turn collision avoidance into repeated full-source scans.
  */
 function createCssExportLocalAllocator(code: string): AllocateCssExportLocal {
-  let prefix = CSS_EXPORT_LOCAL_PREFIX;
-  while (code.includes(prefix)) prefix += "$";
+  const occupied = new Set(decodeUnicodeEscapes(code).match(/[_$a-zA-Z][\w$]*/g) ?? []);
   let nextLocal = 0;
-  return () => `${prefix}${nextLocal++}`;
+  return () => {
+    let candidate: string;
+    do candidate = `${CSS_EXPORT_LOCAL_PREFIX}${nextLocal++}`; while (occupied.has(candidate));
+    occupied.add(candidate);
+    return candidate;
+  };
 }
 
 /**
@@ -301,39 +444,1176 @@ function exportBindingStatement(
  * identifier boundary while quoted regions are skipped. This excludes `from`
  * text inside either an arbitrary export name or the CSS specifier.
  */
-function findFromKeywordIndex(statement: string): number {
-  let quote: '"' | "'" | "`" | undefined;
-  let escaped = false;
+/**
+ * Index of the first character at or after `index` that is neither whitespace
+ * nor a comment, or -1 when the trivia is unterminated or runs to the end.
+ */
+function skipTriviaIndex(statement: string, index: number): number {
+  let cursor = index;
+  while (cursor < statement.length) {
+    const char = statement[cursor];
+    if (char !== undefined && /\s/.test(char)) {
+      cursor++;
+      continue;
+    }
+    const commentEnd = findCommentEndIndex(statement, cursor);
+    if (commentEnd === undefined) return cursor;
+    if (commentEnd === -1) return -1;
+    cursor = commentEnd;
+  }
+  return -1;
+}
 
-  for (let index = 0; index < statement.length; index++) {
+function findQuotedRegionEndIndex(
+  value: string,
+  index: number,
+  quote: JavaScriptQuote,
+): number {
+  let cursor = index + 1;
+  let escaped = false;
+  while (cursor < value.length) {
+    const char = value[cursor++];
+    if (escaped) escaped = false;
+    else if (char === "\\") escaped = true;
+    else if (char === quote) return cursor;
+  }
+  return cursor;
+}
+
+function findFromKeywordIndex(statement: string): number {
+  let index = 0;
+  while (index < statement.length) {
     const char = statement[index];
-    if (quote) {
-      if (escaped) {
-        escaped = false;
-      } else if (char === "\\") {
-        escaped = true;
-      } else if (char === quote) {
-        quote = undefined;
-      }
+    const commentEnd = findCommentEndIndex(statement, index);
+    if (commentEnd !== undefined) {
+      if (commentEnd === -1) return -1;
+      index = commentEnd;
       continue;
     }
 
     if (char === '"' || char === "'" || char === "`") {
-      quote = char;
+      index = findQuotedRegionEndIndex(statement, index, char);
       continue;
     }
 
     if (
       statement.startsWith("from", index) &&
-      !/[\w$]/.test(statement[index - 1] ?? "") &&
-      /^from\s*['"`]/.test(statement.slice(index))
+      !/[\w$]/.test(statement[index - 1] ?? "")
     ) {
-      return index;
+      // A comment may sit between `from` and the specifier, so skip trivia
+      // rather than requiring the quote to follow immediately.
+      const specifierIndex = skipTriviaIndex(statement, index + "from".length);
+      if (specifierIndex !== -1 && /['"`]/.test(statement[specifierIndex] ?? "")) {
+        return index;
+      }
     }
+    index++;
   }
 
   return -1;
 }
+
+/**
+ * Code points the comment mask may borrow as stand-ins for quotes.
+ *
+ * Only a character absent from the module can serve, so a module that occupies
+ * the whole BMP private use area — a generated icon-font table does exactly
+ * that — would otherwise leave masking disabled and hand the decoy-comment
+ * pattern straight back to the module lexer. The supplementary private use
+ * planes add 131,068 further candidates, so exhausting the pool now requires a
+ * module containing essentially every private-use code point. The BMP range is
+ * listed first so ordinary modules keep picking the same single-UTF-16-unit
+ * sentinels they always have.
+ */
+const SENTINEL_CODE_POINT_RANGES: ReadonlyArray<readonly [number, number]> = [
+  [0xe000, 0xf8ff],
+  [0xf0000, 0xffffd],
+  [0x100000, 0x10fffd],
+];
+
+const IDENTIFIER_START = /[$_\p{ID_Start}]/u;
+const IDENTIFIER_CONTINUE = /[$\u200c\u200d\p{ID_Continue}]/u;
+
+/**
+ * Keywords whose parenthesised head is followed by a *statement* or a statement
+ * block, not an operand. The `/` after such a closing parenthesis therefore
+ * opens a regex literal (`if (enabled) /re/.test(value);`) rather than a
+ * division operator, so the closing parenthesis must leave regex context open,
+ * and the `{` it introduces opens a statement block whose `}` does the same
+ * (`switch (value) {} /re/.test(value);`).
+ */
+const CONTROL_FLOW_HEAD_KEYWORD = /^(?:catch|for|if|switch|while|with)$/;
+
+/**
+ * Keywords whose brace body is a statement block, so the `}` closing it sits in
+ * statement position and a following `/` opens a regex literal. `catch` is
+ * listed because its binding is optional, so `catch {}` reaches the `{` with no
+ * head parenthesis to have flagged the block. `static` is listed because a `{`
+ * directly after it is a class static initialization block; modules are strict
+ * code, where `static` cannot be a plain identifier, so no operand brace can
+ * follow the bare token.
+ */
+const STATEMENT_BLOCK_KEYWORD = /^(?:catch|do|else|finally|static|try)$/;
+const STATEMENT_BODY_KEYWORD = /^(?:do|else)$/;
+
+/** What an open parenthesis introduced, for `)` and contextual-`of` handling. */
+type ParenthesisKind = "for-head" | "switch-head" | "control-flow-head" | "operand";
+type BraceKind =
+  | "switch-block"
+  | "statement-block"
+  | "module-attributes"
+  | "module-specifiers"
+  | "expression-body"
+  | "operand";
+
+function classifyParenthesisKind(
+  precedingToken: string | undefined,
+  tokenBeforePreceding: string | undefined,
+): ParenthesisKind {
+  if (
+    precedingToken === "for" ||
+    (precedingToken === "await" && tokenBeforePreceding === "for")
+  ) {
+    return "for-head";
+  }
+  if (precedingToken === "switch") return "switch-head";
+  if (CONTROL_FLOW_HEAD_KEYWORD.test(precedingToken ?? "")) return "control-flow-head";
+  return "operand";
+}
+
+/**
+ * Keywords that can only be followed by an operand, so a `/` after them opens a
+ * regex literal. `do` and `else` lead an unbraced statement body
+ * (`else /re/.test(value);`), and `default` covers `export default /re/`; the
+ * `default` of a switch clause is followed by `:`, which opens regex context
+ * anyway. `of` is deliberately absent: it is contextual, and
+ * `const of = 4; of / 2` is division, so it is only an operator in a for-of head.
+ */
+// `extends` is included for correctness but is not reachable end-to-end: the
+// module lexer rejects a regex literal in a heritage clause on its own, with or
+// without this scanner.
+const REGEX_PRECEDING_KEYWORD =
+  /^(?:await|case|default|delete|do|else|extends|in|instanceof|new|return|throw|typeof|void|yield)$/;
+const FOR_HEAD_DECLARATION_KEYWORD = /^(?:const|let|using|var)$/;
+
+/**
+ * Keywords that end their statement at a line terminator through automatic
+ * semicolon insertion, leaving the next line in statement position where a `/`
+ * opens a regex literal (`debugger\n/re/.test(value);`). `break` and
+ * `continue` carry an optional label, but the label is a restricted production
+ * that must sit on the same line, so a line terminator ends them too.
+ */
+const ASI_TERMINATED_KEYWORD = /^(?:break|continue|debugger|return)$/;
+
+/**
+ * A string line continuation produces no characters, so escapes separated only
+ * by continuations still combine into one code point at runtime.
+ */
+const STRING_LINE_CONTINUATIONS = /^(?:\\(?:\r\n|[\n\r\u2028\u2029]))*$/;
+
+function occupiedCodePoints(code: string): Set<number> {
+  const occupied = new Set(Array.from(code, (char) => char.codePointAt(0)!));
+  const unicodeEscape = /\\u\{([\da-f]{1,6})\}|\\u([\da-f]{4})/gi;
+  let previousHighSurrogate: { codeUnit: number; end: number } | undefined;
+
+  for (const match of code.matchAll(unicodeEscape)) {
+    const escapedValue = Number.parseInt(match[1] ?? match[2]!, 16);
+    if (escapedValue > 0x10ffff) {
+      previousHighSurrogate = undefined;
+      continue;
+    }
+
+    occupied.add(escapedValue);
+    // Braced escapes normally spell a full code point, but JavaScript also
+    // permits a surrogate code unit in braces. Treat those exactly like the
+    // four-digit form so mixed/braced adjacent pairs reserve their combined
+    // supplementary character before sentinel allocation.
+    if (escapedValue > 0xffff) {
+      previousHighSurrogate = undefined;
+      continue;
+    }
+
+    const codeUnit = escapedValue;
+    if (
+      codeUnit >= 0xdc00 && codeUnit <= 0xdfff && previousHighSurrogate &&
+      STRING_LINE_CONTINUATIONS.test(
+        code.slice(previousHighSurrogate.end, match.index),
+      )
+    ) {
+      occupied.add(
+        0x10000 + ((previousHighSurrogate.codeUnit - 0xd800) << 10) +
+          (codeUnit - 0xdc00),
+      );
+    }
+    previousHighSurrogate = codeUnit >= 0xd800 && codeUnit <= 0xdbff
+      ? { codeUnit, end: match.index + match[0].length }
+      : undefined;
+  }
+
+  return occupied;
+}
+
+type MaskMode =
+  | "code"
+  | "single"
+  | "double"
+  | "template"
+  | "regex"
+  | "line-comment"
+  | "block-comment";
+type PendingBodyKind = "declaration" | "expression";
+type PendingBody = {
+  syntax: "function" | "class";
+  kind: PendingBodyKind;
+  parenthesisDepth: number;
+  bracketDepth: number;
+  braceDepth: number;
+  templateExpressionDepth: number;
+  parametersClosed: boolean;
+};
+type ScannerDepth = {
+  parenthesisDepth: number;
+  bracketDepth: number;
+  braceDepth: number;
+};
+type PendingSwitchClause = ScannerDepth & { conditionalDepths: ScannerDepth[] };
+type TokenContext = {
+  followsPropertyAccess: boolean;
+  followsModuleSource: boolean;
+  precedingToken: string | undefined;
+  tokenBeforePreceding: string | undefined;
+  precedingLabelCandidate: boolean;
+  closedHeadParenthesis: boolean;
+  closedSwitchHead: boolean;
+  isIdentifierStart: boolean;
+  startsModuleAttributes: boolean;
+  startsModuleSpecifiers: boolean;
+  startsStatement: boolean;
+};
+
+function selectMaskSentinels(code: string): [string, string, string, string] | undefined {
+  const occupied = occupiedCodePoints(code);
+  const sentinels: string[] = [];
+  for (const [first, last] of SENTINEL_CODE_POINT_RANGES) {
+    let codePoint = first;
+    while (codePoint <= last && sentinels.length < 4) {
+      if (!occupied.has(codePoint)) sentinels.push(String.fromCodePoint(codePoint));
+      codePoint++;
+    }
+    if (sentinels.length === 4) {
+      return sentinels as [string, string, string, string];
+    }
+  }
+  return undefined;
+}
+
+function identifierUnitAt(
+  value: string,
+  index: number,
+): { decoded: string; width: number } | undefined {
+  const unicodeEscape = /^\\u(?:\{([\da-fA-F]{1,6})\}|([\da-fA-F]{4}))/.exec(
+    value.slice(index),
+  );
+  if (unicodeEscape) {
+    const codePoint = Number.parseInt(unicodeEscape[1] ?? unicodeEscape[2]!, 16);
+    if (codePoint > 0x10ffff) return undefined;
+    return { decoded: String.fromCodePoint(codePoint), width: unicodeEscape[0].length };
+  }
+  const codePoint = value.codePointAt(index);
+  if (codePoint === undefined) return undefined;
+  const decoded = String.fromCodePoint(codePoint);
+  return { decoded, width: decoded.length };
+}
+
+function findIdentifierEndIndex(value: string, start: number): number {
+  let end = start;
+  while (end < value.length) {
+    const unit = identifierUnitAt(value, end);
+    if (!unit) break;
+    const valid = end === start
+      ? IDENTIFIER_START.test(unit.decoded)
+      : IDENTIFIER_CONTINUE.test(unit.decoded);
+    if (!valid) break;
+    end += unit.width;
+  }
+  return end;
+}
+
+function findRegexLiteralEndIndex(code: string, start: number): number | undefined {
+  let escaped = false;
+  let inCharacterClass = false;
+  let index = start + 1;
+  while (index < code.length) {
+    const char = code[index++];
+    if (escaped) {
+      escaped = false;
+    } else if (char === "\\") {
+      escaped = true;
+    } else if (char === "[") {
+      inCharacterClass = true;
+    } else if (char === "]") {
+      inCharacterClass = false;
+    } else if (char === "/" && !inCharacterClass) {
+      while (index < code.length && IDENTIFIER_CONTINUE.test(code[index]!)) index++;
+      return index;
+    } else if (isLineTerminator(char)) {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function classifyBraceKind(
+  context: TokenContext,
+  pendingBodyKind: PendingBodyKind | undefined,
+): BraceKind {
+  if (context.closedSwitchHead) return "switch-block";
+  if (context.startsModuleAttributes) return "module-attributes";
+  if (
+    context.precedingToken === "default" &&
+    context.tokenBeforePreceding === "export"
+  ) {
+    return "operand";
+  }
+  if (context.startsModuleSpecifiers) return "module-specifiers";
+  if (pendingBodyKind === "expression") return "expression-body";
+  if (
+    context.startsStatement || context.closedHeadParenthesis ||
+    pendingBodyKind === "declaration" ||
+    STATEMENT_BLOCK_KEYWORD.test(context.precedingToken ?? "")
+  ) {
+    return "statement-block";
+  }
+  return "operand";
+}
+
+/**
+ * Track just enough JavaScript lexical state to hide quotes inside comments
+ * from es-module-lexer without changing import-statement offsets.
+ *
+ * es-module-lexer also treats a slash after an unparenthesized function or
+ * class expression body as a regex opener. In that one context the scanner
+ * emits a modulus operator plus a collision-free marker comment. Both parses
+ * then see an ordinary binary expression, and restoreCommentMask changes the
+ * marker back to the source slash after CSS imports have been rewritten.
+ */
+class CommentQuoteMasker {
+  private index = 0;
+  private mode: MaskMode = "code";
+  private escaped = false;
+  private regexClass = false;
+  private canStartRegex = true;
+  private canStartDeclaration = true;
+  private afterPropertyAccess = false;
+  private precedingLabelCandidate = false;
+  private precedingIdentifier: string | undefined;
+  private identifierBeforePreceding: string | undefined;
+  private readonly parenthesisKinds: ParenthesisKind[] = [];
+  private readonly braceKinds: BraceKind[] = [];
+  private readonly classBodyDepths: number[] = [];
+  private readonly pendingBodies: PendingBody[] = [];
+  private readonly pendingSwitchClauses: PendingSwitchClause[] = [];
+  private bracketDepth = 0;
+  private lastClosedHeadParenthesis = false;
+  private lastClosedSwitchHead = false;
+  private lastClosedExpressionBody = false;
+  private lastClosedStatementBlock = false;
+  private lineTerminatorAfterOperand = false;
+  private pendingArrowBody = false;
+  private pendingImportSpecifiers = false;
+  private pendingModuleSource = false;
+  private pendingModuleAttributes = false;
+  private afterModuleSource = false;
+  private nextStringIsModuleSource = false;
+  private currentStringIsModuleSource = false;
+  private pendingAsiStatement: { labelAllowed: boolean } | undefined;
+  private readonly templateExpressionDepths: number[] = [];
+  private readonly regexMasks = new Map<string, string>();
+  private masked = "";
+
+  constructor(
+    private readonly code: string,
+    private readonly quoteToSentinel: ReadonlyMap<string, string>,
+    private readonly divisionMask: string,
+    private readonly markerSentinel: string,
+  ) {}
+
+  mask(): string {
+    while (this.index < this.code.length) {
+      switch (this.mode) {
+        case "line-comment":
+          this.scanLineComment();
+          break;
+        case "block-comment":
+          this.scanBlockComment();
+          break;
+        case "regex":
+          this.scanRegex();
+          break;
+        case "template":
+          this.scanTemplate();
+          break;
+        case "single":
+        case "double":
+          this.scanString();
+          break;
+        default:
+          this.scanCode();
+      }
+    }
+    return this.masked;
+  }
+
+  getRegexMasks(): ReadonlyMap<string, string> {
+    return this.regexMasks;
+  }
+
+  private currentChar(): string {
+    return this.code[this.index]!;
+  }
+
+  private nextChar(): string | undefined {
+    return this.code[this.index + 1];
+  }
+
+  private append(value: string, width = 1): void {
+    this.masked += value;
+    this.index += width;
+  }
+
+  private scanLineComment(): void {
+    const char = this.currentChar();
+    if (isLineTerminator(char)) {
+      this.mode = "code";
+      this.recordLineTerminator();
+    }
+    this.append(this.quoteToSentinel.get(char) ?? char);
+  }
+
+  private scanBlockComment(): void {
+    const char = this.currentChar();
+    if (char === "*" && this.nextChar() === "/") {
+      this.append("*/", 2);
+      this.mode = "code";
+      return;
+    }
+    if (isLineTerminator(char)) this.recordLineTerminator();
+    this.append(this.quoteToSentinel.get(char) ?? char);
+  }
+
+  private scanRegex(): void {
+    const char = this.currentChar();
+    this.append(char);
+    if (this.escaped) {
+      this.escaped = false;
+      return;
+    }
+    if (char === "\\") {
+      this.escaped = true;
+      return;
+    }
+    if (char === "[") this.regexClass = true;
+    else if (char === "]") this.regexClass = false;
+    else if (char === "/" && !this.regexClass) {
+      this.mode = "code";
+      this.canStartRegex = false;
+      this.canStartDeclaration = false;
+    }
+  }
+
+  private scanTemplate(): void {
+    const char = this.currentChar();
+    if (this.escaped) {
+      this.append(char);
+      this.escaped = false;
+      return;
+    }
+    if (char === "\\") {
+      this.append(char);
+      this.escaped = true;
+      return;
+    }
+    if (char === "$" && this.nextChar() === "{") {
+      this.append("${", 2);
+      this.templateExpressionDepths.push(0);
+      this.mode = "code";
+      this.canStartRegex = true;
+      this.canStartDeclaration = false;
+      return;
+    }
+    this.append(char);
+    if (char === "`") {
+      this.mode = "code";
+      this.canStartRegex = false;
+      this.canStartDeclaration = false;
+    }
+  }
+
+  private scanString(): void {
+    const char = this.currentChar();
+    this.append(char);
+    if (this.escaped) {
+      this.escaped = false;
+      return;
+    }
+    if (char === "\\") {
+      this.escaped = true;
+      return;
+    }
+    if (
+      (this.mode === "single" && char === "'") ||
+      (this.mode === "double" && char === '"')
+    ) {
+      this.mode = "code";
+      // A static import or re-export necessarily ends at its source string, so
+      // the closing quote leaves the scanner in statement position where a
+      // following `/` opens a regex literal even without a semicolon
+      // (`import dep from "./dep.js"\n/re/.test(dep)`). es-module-lexer scans
+      // that slash as division after the quote, so the regex is masked through
+      // the same marker path a closed statement block uses. Every other string
+      // is an ordinary operand.
+      this.canStartRegex = this.currentStringIsModuleSource;
+      this.canStartDeclaration = this.currentStringIsModuleSource;
+      this.lastClosedStatementBlock = this.currentStringIsModuleSource;
+      this.afterModuleSource = this.currentStringIsModuleSource;
+      this.currentStringIsModuleSource = false;
+    }
+  }
+
+  private scanCode(): void {
+    const char = this.currentChar();
+    if (/\s/.test(char)) {
+      this.scanWhitespace(char);
+      return;
+    }
+    if (char === "}" && this.templateExpressionDepths.length > 0) {
+      this.scanTemplateExpressionClose();
+      return;
+    }
+    if (this.isHashbang()) {
+      this.append("#!", 2);
+      this.mode = "line-comment";
+      return;
+    }
+    if (char === "/" && this.nextChar() === "/") {
+      this.append("//", 2);
+      this.mode = "line-comment";
+      return;
+    }
+    if (char === "/" && this.nextChar() === "*") {
+      this.append("/*", 2);
+      this.mode = "block-comment";
+      return;
+    }
+    if (char === "/" && this.lastClosedStatementBlock && this.maskRegexLiteral()) return;
+    if (char === "/" && this.lastClosedExpressionBody) {
+      this.append(this.divisionMask);
+      this.lastClosedExpressionBody = false;
+      this.canStartRegex = true;
+      this.canStartDeclaration = false;
+      return;
+    }
+    if (char === "/" && this.canStartRegex) {
+      this.append(char);
+      this.mode = "regex";
+      this.regexClass = false;
+      this.escaped = false;
+      return;
+    }
+    this.scanCodeToken();
+  }
+
+  private maskRegexLiteral(): boolean {
+    const end = findRegexLiteralEndIndex(this.code, this.index);
+    if (end === undefined) return false;
+    const marker = `;/*${this.markerSentinel}${this.regexMasks.size}*/0`;
+    const literal = this.code.slice(this.index, end);
+    this.regexMasks.set(marker, literal);
+    this.append(marker, literal.length);
+    this.lastClosedStatementBlock = false;
+    this.canStartRegex = false;
+    this.canStartDeclaration = false;
+    return true;
+  }
+
+  private scanWhitespace(char: string): void {
+    this.append(char);
+    if (isLineTerminator(char)) this.recordLineTerminator();
+  }
+
+  private recordLineTerminator(): void {
+    this.lineTerminatorAfterOperand ||= !this.canStartRegex;
+    this.finishAsiStatement();
+  }
+
+  private finishAsiStatement(): void {
+    if (!this.pendingAsiStatement) return;
+    this.canStartRegex = true;
+    this.canStartDeclaration = true;
+    this.pendingAsiStatement = undefined;
+    this.precedingIdentifier = undefined;
+    this.identifierBeforePreceding = undefined;
+  }
+
+  private scanTemplateExpressionClose(): void {
+    const depthIndex = this.templateExpressionDepths.length - 1;
+    this.append("}");
+    if (this.templateExpressionDepths[depthIndex] === 0) {
+      this.templateExpressionDepths.pop();
+      this.mode = "template";
+      this.canStartRegex = false;
+      this.canStartDeclaration = false;
+      this.lastClosedExpressionBody = false;
+      return;
+    }
+    this.templateExpressionDepths[depthIndex] = this.templateExpressionDepths[depthIndex]! - 1;
+    this.recordClosedBrace();
+  }
+
+  private isHashbang(): boolean {
+    return this.currentChar() === "#" && this.nextChar() === "!" &&
+      (this.index === 0 || (this.index === 1 && this.code.startsWith("\ufeff")));
+  }
+
+  private scanCodeToken(): void {
+    const char = this.currentChar();
+    const context = this.takeTokenContext();
+    if (this.scanQuoteStart(char)) return;
+    if (this.scanNestedTemplateBrace(char, context)) return;
+    if (this.scanSpread(char)) return;
+    if (this.scanUpdateOperator(char)) return;
+    if (this.scanPrivateName(char)) return;
+    if (context.isIdentifierStart) {
+      this.scanIdentifier(context);
+      return;
+    }
+    if (this.scanParenthesis(char, context)) return;
+    if (this.scanClosingOperand(char)) return;
+    this.scanPunctuator(char, context);
+  }
+
+  private takeTokenContext(): TokenContext {
+    const char = this.currentChar();
+    const startsArrowBody = char === "{" && this.pendingArrowBody;
+    const context: TokenContext = {
+      followsPropertyAccess: this.afterPropertyAccess,
+      followsModuleSource: this.afterModuleSource,
+      precedingToken: this.precedingIdentifier,
+      tokenBeforePreceding: this.identifierBeforePreceding,
+      precedingLabelCandidate: this.precedingLabelCandidate,
+      closedHeadParenthesis: this.lastClosedHeadParenthesis,
+      closedSwitchHead: this.lastClosedSwitchHead,
+      isIdentifierStart: this.isIdentifierStartAt(this.index),
+      startsModuleAttributes: this.pendingModuleAttributes,
+      startsModuleSpecifiers: this.pendingImportSpecifiers ||
+        this.precedingIdentifier === "export",
+      startsStatement: this.canStartDeclaration || this.startsAsiBlock(char) ||
+        startsArrowBody,
+    };
+    this.pendingArrowBody = false;
+    this.lastClosedExpressionBody = false;
+    this.lastClosedStatementBlock = false;
+    this.lastClosedHeadParenthesis = false;
+    this.lastClosedSwitchHead = false;
+    if (char !== ".") this.afterPropertyAccess = false;
+    this.precedingIdentifier = undefined;
+    this.identifierBeforePreceding = undefined;
+    this.precedingLabelCandidate = false;
+    this.lineTerminatorAfterOperand = false;
+    this.afterModuleSource = false;
+    if (!context.isIdentifierStart) this.pendingAsiStatement = undefined;
+    return context;
+  }
+
+  private startsAsiBlock(char: string): boolean {
+    if (!this.lineTerminatorAfterOperand) return false;
+    if (char === "{") return true;
+    const identifierEnd = findIdentifierEndIndex(this.code, this.index);
+    const token = this.code.slice(this.index, identifierEnd);
+    if (token === "function" || token === "class") return true;
+    return identifierEnd > this.index &&
+      this.code[skipTriviaIndex(this.code, identifierEnd)] === ":";
+  }
+
+  private scanQuoteStart(char: string): boolean {
+    if (char !== "'" && char !== '"' && char !== "`") return false;
+    this.currentStringIsModuleSource = char !== "`" && this.nextStringIsModuleSource;
+    this.append(char);
+    this.pendingImportSpecifiers = false;
+    this.nextStringIsModuleSource = false;
+    if (this.currentStringIsModuleSource) this.pendingModuleSource = false;
+    if (char === "'") this.mode = "single";
+    else if (char === '"') this.mode = "double";
+    else this.mode = "template";
+    this.canStartDeclaration = false;
+    return true;
+  }
+
+  private scanNestedTemplateBrace(char: string, context: TokenContext): boolean {
+    if (char !== "{" || this.templateExpressionDepths.length === 0) return false;
+    const depthIndex = this.templateExpressionDepths.length - 1;
+    const pendingBody = this.takePendingBody();
+    const braceKind = classifyBraceKind(context, pendingBody?.kind);
+    this.append(char);
+    this.templateExpressionDepths[depthIndex] = this.templateExpressionDepths[depthIndex]! + 1;
+    this.braceKinds.push(braceKind);
+    if (pendingBody?.syntax === "class") {
+      this.classBodyDepths.push(this.braceKinds.length);
+    }
+    this.canStartRegex = true;
+    this.canStartDeclaration = braceKind !== "operand" && braceKind !== "module-specifiers";
+    return true;
+  }
+
+  private scanSpread(char: string): boolean {
+    if (char !== "." || !this.code.startsWith("...", this.index)) return false;
+    this.append("...", 3);
+    this.canStartRegex = true;
+    this.canStartDeclaration = false;
+    return true;
+  }
+
+  private scanUpdateOperator(char: string): boolean {
+    if ((char !== "+" && char !== "-") || this.nextChar() !== char) return false;
+    this.append(char.repeat(2), 2);
+    this.canStartDeclaration = false;
+    return true;
+  }
+
+  private scanPrivateName(char: string): boolean {
+    if (char !== "#" || !this.isIdentifierStartAt(this.index + 1)) return false;
+    const end = findIdentifierEndIndex(this.code, this.index + 1);
+    this.append(this.code.slice(this.index, end), end - this.index);
+    this.canStartRegex = false;
+    this.canStartDeclaration = false;
+    return true;
+  }
+
+  private isIdentifierStartAt(index: number): boolean {
+    return findIdentifierEndIndex(this.code, index) > index;
+  }
+
+  private scanIdentifier(context: TokenContext): void {
+    const end = findIdentifierEndIndex(this.code, this.index);
+    const sourceToken = this.code.slice(this.index, end);
+    const token = decodeUnicodeEscapes(sourceToken);
+    this.append(sourceToken, end - this.index);
+    const operandMayStart = this.canStartRegex;
+    this.canStartRegex = !context.followsPropertyAccess &&
+      (REGEX_PRECEDING_KEYWORD.test(token) ||
+        this.isForOfSeparator(token, context, operandMayStart));
+    const nextCodeIndex = skipTriviaIndex(this.code, end);
+    const nextCodeChar = nextCodeIndex === -1 ? undefined : this.code[nextCodeIndex];
+    this.trackImportSpecifiers(token, context, nextCodeChar);
+    this.trackModuleAttributes(token, context, nextCodeChar);
+    this.trackPendingBody(token, context, nextCodeChar, nextCodeIndex, operandMayStart);
+    this.trackPendingSwitchClause(token, context.followsPropertyAccess);
+    this.updateAsiStatement(token, context.followsPropertyAccess);
+    this.precedingIdentifier = context.followsPropertyAccess ? undefined : token;
+    this.identifierBeforePreceding = context.followsPropertyAccess
+      ? undefined
+      : context.precedingToken;
+    this.precedingLabelCandidate = !context.followsPropertyAccess && context.startsStatement;
+    this.canStartDeclaration =
+      (!context.followsPropertyAccess && STATEMENT_BODY_KEYWORD.test(token)) ||
+      (this.canStartDeclaration && /^(?:async|default|export)$/.test(token));
+  }
+
+  private trackImportSpecifiers(
+    token: string,
+    context: TokenContext,
+    nextCodeChar: string | undefined,
+  ): void {
+    if (
+      token === "import" && context.startsStatement && this.isTopLevel() &&
+      nextCodeChar !== "(" && nextCodeChar !== "."
+    ) {
+      this.pendingImportSpecifiers = true;
+      this.pendingModuleSource = true;
+      this.nextStringIsModuleSource = nextCodeChar === "'" || nextCodeChar === '"';
+    } else if (
+      token === "export" && context.startsStatement && this.isTopLevel() &&
+      (nextCodeChar === "{" || nextCodeChar === "*")
+    ) {
+      this.pendingModuleSource = true;
+    } else if (
+      token === "from" && this.pendingModuleSource && this.isTopLevel() &&
+      (nextCodeChar === "'" || nextCodeChar === '"')
+    ) {
+      this.pendingImportSpecifiers = false;
+      // `from` directly before a string only occurs in a static import or
+      // re-export, so the string that follows is a module source whose closing
+      // quote ends the declaration and restores statement context.
+      this.nextStringIsModuleSource = true;
+    }
+  }
+
+  private isForOfSeparator(
+    token: string,
+    context: TokenContext,
+    operandMayStart: boolean,
+  ): boolean {
+    return token === "of" && this.parenthesisKinds.at(-1) === "for-head" &&
+      !operandMayStart &&
+      !FOR_HEAD_DECLARATION_KEYWORD.test(context.precedingToken ?? "");
+  }
+
+  private isTopLevel(): boolean {
+    return this.parenthesisKinds.length === 0 && this.bracketDepth === 0 &&
+      this.braceKinds.length === 0 && this.templateExpressionDepths.length === 0;
+  }
+
+  private trackModuleAttributes(
+    token: string,
+    context: TokenContext,
+    nextCodeChar: string | undefined,
+  ): void {
+    this.pendingModuleAttributes = context.followsModuleSource &&
+      (token === "with" || token === "assert") && nextCodeChar === "{" &&
+      this.isTopLevel();
+  }
+
+  private trackPendingBody(
+    token: string,
+    context: TokenContext,
+    nextCodeChar: string | undefined,
+    nextCodeIndex: number,
+    operandMayStart: boolean,
+  ): void {
+    const isPropertyName = nextCodeChar === ":" || nextCodeChar === "=" ||
+      nextCodeChar === ";";
+    const isBodyKeyword = token === "function" || token === "class";
+    const isDirectClassElement = this.classBodyDepths.at(-1) === this.braceKinds.length;
+    const isClassElementName = isBodyKeyword && isDirectClassElement &&
+      !context.followsPropertyAccess &&
+      (context.startsStatement || !operandMayStart) &&
+      !(token === "function" && context.precedingToken === "async");
+    if (isClassElementName) {
+      if (!isPropertyName && nextCodeChar !== "(") {
+        this.maskSemicolonlessClassElement();
+      }
+      return;
+    }
+    if (
+      !context.followsPropertyAccess && !isPropertyName &&
+      this.braceKinds.at(-1) !== "module-specifiers" &&
+      ((token === "function" && this.continuesFunctionHeadAt(nextCodeIndex)) ||
+        (token === "class" && this.continuesClassHeadAt(nextCodeIndex)))
+    ) {
+      this.pendingBodies.push({
+        syntax: token,
+        kind: context.startsStatement ? "declaration" : "expression",
+        parenthesisDepth: this.parenthesisKinds.length,
+        bracketDepth: this.bracketDepth,
+        braceDepth: this.braceKinds.length,
+        templateExpressionDepth: this.templateExpressionDepths.length,
+        parametersClosed: token === "class",
+      });
+    }
+  }
+
+  /** Whether a `function` token continues with an optional star/name and a parameter list. */
+  private continuesFunctionHeadAt(index: number): boolean {
+    if (index === -1) return false;
+    let cursor = index;
+    if (this.code[cursor] === "*") {
+      cursor = skipTriviaIndex(this.code, cursor + 1);
+      if (cursor === -1) return false;
+    }
+    if (this.code[cursor] === "(") return true;
+    const nameEnd = findIdentifierEndIndex(this.code, cursor);
+    if (nameEnd === cursor) return false;
+    const afterName = skipTriviaIndex(this.code, nameEnd);
+    return afterName !== -1 && this.code[afterName] === "(";
+  }
+
+  /**
+   * Whether the code at `index` continues a `class` token as a class head: an
+   * optional binding identifier and an optional `extends` heritage clause lead
+   * to the `{` body. Any other shape means the token was a class-element or
+   * property name (`class C { class\nvalue = {} }` declares two fields), and a
+   * pending body for it would make the next initializer brace scan as a
+   * statement block. A keyword spelled with Unicode escapes never opens a
+   * heritage clause, so the raw-text `extends` comparison matches exactly the
+   * occurrences the grammar accepts.
+   */
+  private continuesClassHeadAt(index: number): boolean {
+    if (index === -1) return false;
+    if (this.code[index] === "{") return true;
+    const nameEnd = findIdentifierEndIndex(this.code, index);
+    if (nameEnd === index) return false;
+    if (this.code.slice(index, nameEnd) === "extends") return true;
+    const afterName = skipTriviaIndex(this.code, nameEnd);
+    if (afterName === -1) return false;
+    if (this.code[afterName] === "{") return true;
+    const keywordEnd = findIdentifierEndIndex(this.code, afterName);
+    return this.code.slice(afterName, keywordEnd) === "extends";
+  }
+
+  private maskSemicolonlessClassElement(): void {
+    const marker = `;/*${this.markerSentinel}f${this.regexMasks.size}*/`;
+    this.regexMasks.set(marker, "");
+    this.masked += marker;
+  }
+
+  private trackPendingSwitchClause(token: string, followsPropertyAccess: boolean): void {
+    if (
+      !followsPropertyAccess &&
+      (token === "case" || token === "default") &&
+      this.braceKinds.at(-1) === "switch-block"
+    ) {
+      this.pendingSwitchClauses.push({
+        parenthesisDepth: this.parenthesisKinds.length,
+        bracketDepth: this.bracketDepth,
+        braceDepth: this.braceKinds.length,
+        conditionalDepths: [],
+      });
+    }
+  }
+
+  private updateAsiStatement(token: string, followsPropertyAccess: boolean): void {
+    if (!followsPropertyAccess && ASI_TERMINATED_KEYWORD.test(token)) {
+      this.pendingAsiStatement = { labelAllowed: /^(?:break|continue)$/.test(token) };
+      return;
+    }
+    if (this.pendingAsiStatement?.labelAllowed) {
+      this.pendingAsiStatement.labelAllowed = false;
+      return;
+    }
+    this.pendingAsiStatement = undefined;
+  }
+
+  private scanParenthesis(char: string, context: TokenContext): boolean {
+    if (char === "(") {
+      this.append(char);
+      this.pendingImportSpecifiers = false;
+      this.parenthesisKinds.push(
+        classifyParenthesisKind(context.precedingToken, context.tokenBeforePreceding),
+      );
+      this.canStartRegex = true;
+      this.canStartDeclaration = false;
+      return true;
+    }
+    if (char !== ")") return false;
+    this.append(char);
+    const closedKind = this.parenthesisKinds.pop() ?? "operand";
+    const nextCodeIndex = skipTriviaIndex(this.code, this.index);
+    const closedConciseMethodHead = closedKind === "operand" && nextCodeIndex !== -1 &&
+      this.code[nextCodeIndex] === "{";
+    this.lastClosedHeadParenthesis = closedKind !== "operand" || closedConciseMethodHead;
+    this.lastClosedSwitchHead = closedKind === "switch-head";
+    const pendingBody = this.pendingBodies.at(-1);
+    if (
+      pendingBody?.syntax === "function" &&
+      this.parenthesisKinds.length === pendingBody.parenthesisDepth &&
+      this.bracketDepth === pendingBody.bracketDepth &&
+      this.braceKinds.length === pendingBody.braceDepth &&
+      this.templateExpressionDepths.length === pendingBody.templateExpressionDepth
+    ) {
+      pendingBody.parametersClosed = true;
+    }
+    this.canStartRegex = this.lastClosedHeadParenthesis;
+    this.canStartDeclaration = this.lastClosedHeadParenthesis;
+    return true;
+  }
+
+  private scanClosingOperand(char: string): boolean {
+    if (char === "}") {
+      this.append(char);
+      this.recordClosedBrace();
+      return true;
+    }
+    if (!/\d/.test(char) && char !== "]") return false;
+    this.append(char);
+    if (char === "]") this.bracketDepth = Math.max(0, this.bracketDepth - 1);
+    this.canStartRegex = false;
+    this.canStartDeclaration = false;
+    return true;
+  }
+
+  private recordClosedBrace(): void {
+    const closedBraceKind = this.braceKinds.pop() ?? "operand";
+    this.canStartRegex = closedBraceKind === "statement-block" ||
+      closedBraceKind === "switch-block" || closedBraceKind === "module-attributes" ||
+      closedBraceKind === "module-specifiers";
+    this.canStartDeclaration = this.canStartRegex;
+    this.lastClosedExpressionBody = closedBraceKind === "expression-body";
+    this.lastClosedStatementBlock = this.canStartRegex;
+    while ((this.classBodyDepths.at(-1) ?? 0) > this.braceKinds.length) {
+      this.classBodyDepths.pop();
+    }
+    while ((this.pendingBodies.at(-1)?.braceDepth ?? 0) > this.braceKinds.length) {
+      this.pendingBodies.pop();
+    }
+    let pendingClause = this.pendingSwitchClauses.at(-1);
+    while (pendingClause && pendingClause.braceDepth > this.braceKinds.length) {
+      this.pendingSwitchClauses.pop();
+      pendingClause = this.pendingSwitchClauses.at(-1);
+    }
+  }
+
+  private takePendingBody(): PendingBody | undefined {
+    const pendingBody = this.pendingBodies.at(-1);
+    if (
+      !pendingBody?.parametersClosed ||
+      this.parenthesisKinds.length !== pendingBody.parenthesisDepth ||
+      this.bracketDepth !== pendingBody.bracketDepth ||
+      this.braceKinds.length !== pendingBody.braceDepth ||
+      this.templateExpressionDepths.length !== pendingBody.templateExpressionDepth
+    ) {
+      return undefined;
+    }
+    return this.pendingBodies.pop();
+  }
+
+  private scanPunctuator(char: string, context: TokenContext): void {
+    if (char === "=" && this.nextChar() === ">") {
+      this.append("=>", 2);
+      this.pendingArrowBody = true;
+      this.canStartDeclaration = false;
+      this.canStartRegex = true;
+      this.afterPropertyAccess = false;
+      return;
+    }
+    if (char === "?" && this.nextChar() === "?") {
+      this.append("??", 2);
+      this.canStartDeclaration = false;
+      this.canStartRegex = true;
+      this.afterPropertyAccess = false;
+      return;
+    }
+    const optionalChainQuestion = char === "?" && this.nextChar() === "." &&
+      !/\d/.test(this.code[this.index + 2] ?? "");
+    this.append(char);
+    this.updatePunctuatorDeclarationState(char, context, optionalChainQuestion);
+    if (char === ";" || char === ".") this.pendingImportSpecifiers = false;
+    if (char === ";") this.pendingModuleSource = false;
+    this.canStartRegex = char !== ".";
+    this.afterPropertyAccess = char === ".";
+  }
+
+  private updatePunctuatorDeclarationState(
+    char: string,
+    context: TokenContext,
+    optionalChainQuestion: boolean,
+  ): void {
+    switch (char) {
+      case "{":
+        this.recordOpeningBrace(context);
+        return;
+      case "[":
+        this.bracketDepth++;
+        this.canStartDeclaration = false;
+        return;
+      case "?":
+        if (this.recordSwitchConditional(optionalChainQuestion)) return;
+        break;
+      case ":":
+        this.recordColon(context);
+        return;
+    }
+    this.canStartDeclaration = char === ";" && this.parenthesisKinds.length === 0;
+  }
+
+  private recordOpeningBrace(context: TokenContext): void {
+    const pendingBody = this.takePendingBody();
+    const braceKind = classifyBraceKind(context, pendingBody?.kind);
+    this.braceKinds.push(braceKind);
+    if (pendingBody?.syntax === "class") {
+      this.classBodyDepths.push(this.braceKinds.length);
+    }
+    if (braceKind === "module-attributes") this.pendingModuleAttributes = false;
+    if (braceKind === "module-specifiers") this.pendingImportSpecifiers = false;
+    this.canStartDeclaration = braceKind !== "operand" && braceKind !== "module-specifiers";
+  }
+
+  private recordSwitchConditional(optionalChainQuestion: boolean): boolean {
+    if (optionalChainQuestion || this.pendingSwitchClauses.length === 0) return false;
+    this.pendingSwitchClauses.at(-1)!.conditionalDepths.push({
+      parenthesisDepth: this.parenthesisKinds.length,
+      bracketDepth: this.bracketDepth,
+      braceDepth: this.braceKinds.length,
+    });
+    this.canStartDeclaration = false;
+    return true;
+  }
+
+  private recordColon(context: TokenContext): void {
+    if (this.finishesSwitchClause()) {
+      this.pendingSwitchClauses.pop();
+      this.canStartDeclaration = true;
+      return;
+    }
+    this.canStartDeclaration = context.precedingLabelCandidate;
+  }
+
+  private finishesSwitchClause(): boolean {
+    const clause = this.pendingSwitchClauses.at(-1);
+    if (!clause) return false;
+    const conditional = clause.conditionalDepths.at(-1);
+    if (conditional) {
+      if (
+        this.parenthesisKinds.length === conditional.parenthesisDepth &&
+        this.bracketDepth === conditional.bracketDepth &&
+        this.braceKinds.length === conditional.braceDepth
+      ) {
+        clause.conditionalDepths.pop();
+      }
+      return false;
+    }
+    return this.parenthesisKinds.length === clause.parenthesisDepth &&
+      this.bracketDepth === clause.bracketDepth &&
+      this.braceKinds.length === clause.braceDepth;
+  }
+}
+
+function restoreCommentMask(
+  value: string,
+  divisionMask: string,
+  quoteToSentinel: ReadonlyMap<string, string>,
+  regexMasks: ReadonlyMap<string, string>,
+): string {
+  let restored = value.replaceAll(divisionMask, "/");
+  for (const [marker, literal] of regexMasks) restored = restored.replaceAll(marker, literal);
+  for (const [quote, sentinel] of quoteToSentinel) {
+    restored = restored.replaceAll(sentinel, quote);
+  }
+  return restored;
+}
+
+function maskCommentQuotesForModuleLexer(code: string): {
+  masked: string;
+  restore: (value: string) => string;
+} {
+  const sentinels = selectMaskSentinels(code);
+  if (!sentinels) {
+    throw CSS_COMMENT_MASK_SENTINEL_EXHAUSTED.create({
+      message: "CSS import comment masking could not allocate sentinels.",
+    });
+  }
+  const quoteToSentinel = new Map<string, string>([
+    ['"', sentinels[0]],
+    ["'", sentinels[1]],
+    ["`", sentinels[2]],
+  ]);
+  const markerSentinel = sentinels[3];
+  const divisionMask = `%/*${markerSentinel}*/`;
+  const masker = new CommentQuoteMasker(
+    code,
+    quoteToSentinel,
+    divisionMask,
+    markerSentinel,
+  );
+  const masked = masker.mask();
+  return {
+    masked,
+    restore: (value) =>
+      restoreCommentMask(value, divisionMask, quoteToSentinel, masker.getRegexMasks()),
+  };
+}
+
+/** @internal Test-only scanner boundary; this module is not a public package entry point. */
+export const __maskCommentQuotesForModuleLexer = maskCommentQuotesForModuleLexer;
 
 /**
  * Generate a replacement for a CSS re-export statement.
@@ -354,7 +1634,7 @@ function generateCSSReExportStub(
   if (fromIndex === -1) return stripped;
 
   const cssModuleKey = isCssModuleImport(specifier) ? specifier : undefined;
-  const clause = trimmed.slice("export".length, fromIndex).trim();
+  const clause = stripImportClauseComments(trimmed.slice("export".length, fromIndex)).trim();
 
   // Namespace re-export: export * as styles from "./X.module.css"
   const nsMatch = clause.match(/^\*\s*as\s+(.+)$/);
@@ -420,7 +1700,7 @@ function generateCSSStub(
   }
 
   const cssModuleKey = isCssModuleImport(specifier) ? specifier : undefined;
-  const importClause = trimmed.slice(6, fromIndex).trim(); // Skip "import "
+  const importClause = stripImportClauseComments(trimmed.slice(6, fromIndex)).trim();
 
   // Default import: import styles from "./Button.module.css"
   // → const styles = new Proxy({}, { get: (_, p) => String(p) })
@@ -498,7 +1778,12 @@ export const cssStripPlugin: TransformPlugin = {
   stage: TransformStage.COMPILE + 0.5, // Run after esbuild compile, before import resolution
 
   async transform(ctx) {
-    const imports = await parseImports(ctx.code);
+    // Skip sentinel allocation entirely for modules that cannot contain a CSS
+    // suffix, including one encoded with JavaScript string escapes.
+    if (!mayContainCSSSpecifier(ctx.code)) return ctx.code;
+
+    const commentMask = maskCommentQuotesForModuleLexer(ctx.code);
+    const imports = await parseImports(commentMask.masked);
 
     const hasCssImports = imports.some((imp) => isCSSImport(imp.n));
     if (!hasCssImports) return ctx.code;
@@ -506,7 +1791,7 @@ export const cssStripPlugin: TransformPlugin = {
     const cssSpecifiers: string[] = [];
     const allocateExportLocal = createCssExportLocalAllocator(ctx.code);
 
-    const result = await rewriteImports(ctx.code, (imp, statement) => {
+    const result = await rewriteImports(commentMask.masked, (imp, statement) => {
       if (!isCSSImport(imp.n)) return null;
       cssSpecifiers.push(imp.n!);
       const moduleKey = isCssModuleImport(imp.n)
@@ -521,6 +1806,6 @@ export const cssStripPlugin: TransformPlugin = {
       ctx.metadata.set("cssImports", cssSpecifiers);
     }
 
-    return result;
+    return commentMask.restore(result);
   },
 };

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -1596,7 +1596,7 @@ function restoreCommentMask(
 ): string {
   let restored = value.replaceAll(divisionMask, "/");
   const regexMaskPattern = new RegExp(
-    `;/\\*${markerSentinel}(?:f\\d+\\*/|\\d+\\*/0)`,
+    String.raw`;/\*${markerSentinel}(?:f\d+\*/|\d+\*/0)`,
     "g",
   );
   restored = restored.replace(

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -601,9 +601,10 @@ const FOR_HEAD_DECLARATION_KEYWORD = /^(?:const|let|using|var)$/;
  * semicolon insertion, leaving the next line in statement position where a `/`
  * opens a regex literal (`debugger\n/re/.test(value);`). `break` and
  * `continue` carry an optional label, but the label is a restricted production
- * that must sit on the same line, so a line terminator ends them too.
+ * that must sit on the same line, so a line terminator ends them too. A bare
+ * `yield` likewise finishes before the next line starts a statement.
  */
-const ASI_TERMINATED_KEYWORD = /^(?:break|continue|debugger|return)$/;
+const ASI_TERMINATED_KEYWORD = /^(?:break|continue|debugger|return|yield)$/;
 
 /**
  * A string line continuation produces no characters, so escapes separated only
@@ -1128,11 +1129,29 @@ class CommentQuoteMasker {
   private startsAsiBlock(char: string): boolean {
     if (!this.lineTerminatorAfterOperand) return false;
     if (char === "{") return true;
+    if (this.startsAsiDeclaration()) return true;
     const identifierEnd = findIdentifierEndIndex(this.code, this.index);
-    const token = this.code.slice(this.index, identifierEnd);
-    if (token === "function" || token === "class") return true;
     return identifierEnd > this.index &&
       this.code[skipTriviaIndex(this.code, identifierEnd)] === ":";
+  }
+
+  private startsAsiDeclaration(): boolean {
+    const tokens: string[] = [];
+    let cursor = this.index;
+    while (cursor !== -1 && tokens.length < 4) {
+      const end = findIdentifierEndIndex(this.code, cursor);
+      if (end === cursor) break;
+      tokens.push(decodeUnicodeEscapes(this.code.slice(cursor, end)));
+      cursor = skipTriviaIndex(this.code, end);
+    }
+    if (tokens[0] === "function" || tokens[0] === "class") return true;
+    if (tokens[0] === "async") return tokens[1] === "function";
+    if (tokens[0] !== "export") return false;
+    if (tokens[1] === "function" || tokens[1] === "class") return true;
+    if (tokens[1] === "async") return tokens[2] === "function";
+    if (tokens[1] !== "default") return false;
+    return tokens[2] === "function" || tokens[2] === "class" ||
+      (tokens[2] === "async" && tokens[3] === "function");
   }
 
   private scanQuoteStart(char: string): boolean {
@@ -1216,7 +1235,8 @@ class CommentQuoteMasker {
     this.precedingLabelCandidate = !context.followsPropertyAccess && context.startsStatement;
     this.canStartDeclaration =
       (!context.followsPropertyAccess && STATEMENT_BODY_KEYWORD.test(token)) ||
-      (this.canStartDeclaration && /^(?:async|default|export)$/.test(token));
+      ((this.canStartDeclaration || context.startsStatement) &&
+        /^(?:async|default|export)$/.test(token));
   }
 
   private trackImportSpecifiers(
@@ -1570,15 +1590,38 @@ class CommentQuoteMasker {
 function restoreCommentMask(
   value: string,
   divisionMask: string,
+  markerSentinel: string,
   quoteToSentinel: ReadonlyMap<string, string>,
   regexMasks: ReadonlyMap<string, string>,
 ): string {
   let restored = value.replaceAll(divisionMask, "/");
-  for (const [marker, literal] of regexMasks) restored = restored.replaceAll(marker, literal);
+  const regexMaskPattern = new RegExp(
+    `;/\\*${markerSentinel}(?:f\\d+\\*/|\\d+\\*/0)`,
+    "g",
+  );
+  restored = restored.replace(
+    regexMaskPattern,
+    (marker) => regexMasks.get(marker) ?? marker,
+  );
   for (const [quote, sentinel] of quoteToSentinel) {
     restored = restored.replaceAll(sentinel, quote);
   }
   return restored;
+}
+
+const IMPORT_DETECTION_QUOTE_MASKS = new Map<string, string>([
+  ['"', " "],
+  ["'", " "],
+  ["`", " "],
+]);
+
+function maskCommentQuotesForImportDetection(code: string): string {
+  return new CommentQuoteMasker(
+    code,
+    IMPORT_DETECTION_QUOTE_MASKS,
+    "%/**/",
+    "_",
+  ).mask();
 }
 
 function maskCommentQuotesForModuleLexer(code: string): {
@@ -1608,7 +1651,13 @@ function maskCommentQuotesForModuleLexer(code: string): {
   return {
     masked,
     restore: (value) =>
-      restoreCommentMask(value, divisionMask, quoteToSentinel, masker.getRegexMasks()),
+      restoreCommentMask(
+        value,
+        divisionMask,
+        markerSentinel,
+        quoteToSentinel,
+        masker.getRegexMasks(),
+      ),
   };
 }
 
@@ -1781,6 +1830,9 @@ export const cssStripPlugin: TransformPlugin = {
     // Skip sentinel allocation entirely for modules that cannot contain a CSS
     // suffix, including one encoded with JavaScript string escapes.
     if (!mayContainCSSSpecifier(ctx.code)) return ctx.code;
+
+    const detectedImports = await parseImports(maskCommentQuotesForImportDetection(ctx.code));
+    if (!detectedImports.some((imp) => isCSSImport(imp.n))) return ctx.code;
 
     const commentMask = maskCommentQuotesForModuleLexer(ctx.code);
     const imports = await parseImports(commentMask.masked);

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -616,11 +616,48 @@ function occupiedCodePoints(code: string): Set<number> {
   const occupied = new Set(Array.from(code, (char) => char.codePointAt(0)!));
   const unicodeEscape = /\\u\{([\da-f]{1,6})\}|\\u([\da-f]{4})/gi;
   let previousHighSurrogate: { codeUnit: number; end: number } | undefined;
+  let cursor = 0;
+
+  const recordSurrogateCodeUnit = (codeUnit: number, start: number, end: number): void => {
+    if (
+      codeUnit >= 0xdc00 && codeUnit <= 0xdfff && previousHighSurrogate &&
+      STRING_LINE_CONTINUATIONS.test(
+        code.slice(previousHighSurrogate.end, start),
+      )
+    ) {
+      occupied.add(
+        0x10000 + ((previousHighSurrogate.codeUnit - 0xd800) << 10) +
+          (codeUnit - 0xdc00),
+      );
+    }
+    previousHighSurrogate = codeUnit >= 0xd800 && codeUnit <= 0xdbff
+      ? { codeUnit, end }
+      : undefined;
+  };
+
+  const recordLiteralSurrogates = (end: number): void => {
+    while (cursor < end) {
+      if (code[cursor] === "\\") {
+        const continuation = /^(?:\\(?:\r\n|[\n\r\u2028\u2029]))/.exec(
+          code.slice(cursor, end),
+        );
+        if (continuation) {
+          cursor += continuation[0].length;
+          continue;
+        }
+      }
+      const codeUnit = code.charCodeAt(cursor);
+      recordSurrogateCodeUnit(codeUnit, cursor, cursor + 1);
+      cursor++;
+    }
+  };
 
   for (const match of code.matchAll(unicodeEscape)) {
+    recordLiteralSurrogates(match.index);
     const escapedValue = Number.parseInt(match[1] ?? match[2]!, 16);
     if (escapedValue > 0x10ffff) {
       previousHighSurrogate = undefined;
+      cursor = match.index + match[0].length;
       continue;
     }
 
@@ -631,25 +668,18 @@ function occupiedCodePoints(code: string): Set<number> {
     // supplementary character before sentinel allocation.
     if (escapedValue > 0xffff) {
       previousHighSurrogate = undefined;
+      cursor = match.index + match[0].length;
       continue;
     }
 
-    const codeUnit = escapedValue;
-    if (
-      codeUnit >= 0xdc00 && codeUnit <= 0xdfff && previousHighSurrogate &&
-      STRING_LINE_CONTINUATIONS.test(
-        code.slice(previousHighSurrogate.end, match.index),
-      )
-    ) {
-      occupied.add(
-        0x10000 + ((previousHighSurrogate.codeUnit - 0xd800) << 10) +
-          (codeUnit - 0xdc00),
-      );
-    }
-    previousHighSurrogate = codeUnit >= 0xd800 && codeUnit <= 0xdbff
-      ? { codeUnit, end: match.index + match[0].length }
-      : undefined;
+    recordSurrogateCodeUnit(
+      escapedValue,
+      match.index,
+      match.index + match[0].length,
+    );
+    cursor = match.index + match[0].length;
   }
+  recordLiteralSurrogates(code.length);
 
   return occupied;
 }
@@ -1171,7 +1201,9 @@ class CommentQuoteMasker {
   private scanNestedTemplateBrace(char: string, context: TokenContext): boolean {
     if (char !== "{" || this.templateExpressionDepths.length === 0) return false;
     const depthIndex = this.templateExpressionDepths.length - 1;
-    const pendingBody = this.takePendingBody();
+    const pendingBody = this.startsClassHeritageObject(context)
+      ? undefined
+      : this.takePendingBody();
     const braceKind = classifyBraceKind(context, pendingBody?.kind);
     this.append(char);
     this.templateExpressionDepths[depthIndex] = this.templateExpressionDepths[depthIndex]! + 1;
@@ -1536,7 +1568,9 @@ class CommentQuoteMasker {
   }
 
   private recordOpeningBrace(context: TokenContext): void {
-    const pendingBody = this.takePendingBody();
+    const pendingBody = this.startsClassHeritageObject(context)
+      ? undefined
+      : this.takePendingBody();
     const braceKind = classifyBraceKind(context, pendingBody?.kind);
     this.braceKinds.push(braceKind);
     if (pendingBody?.syntax === "class") {
@@ -1545,6 +1579,16 @@ class CommentQuoteMasker {
     if (braceKind === "module-attributes") this.pendingModuleAttributes = false;
     if (braceKind === "module-specifiers") this.pendingImportSpecifiers = false;
     this.canStartDeclaration = braceKind !== "operand" && braceKind !== "module-specifiers";
+  }
+
+  private startsClassHeritageObject(context: TokenContext): boolean {
+    const pendingBody = this.pendingBodies.at(-1);
+    return pendingBody?.syntax === "class" && context.precedingToken === "extends" &&
+      pendingBody.parametersClosed &&
+      this.parenthesisKinds.length === pendingBody.parenthesisDepth &&
+      this.bracketDepth === pendingBody.bracketDepth &&
+      this.braceKinds.length === pendingBody.braceDepth &&
+      this.templateExpressionDepths.length === pendingBody.templateExpressionDepth;
   }
 
   private recordSwitchConditional(optionalChainQuestion: boolean): boolean {

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -646,7 +646,7 @@ function occupiedCodePoints(code: string): Set<number> {
           continue;
         }
       }
-      const codeUnit = code.charCodeAt(cursor);
+      const codeUnit = code.codePointAt(cursor)!;
       recordSurrogateCodeUnit(codeUnit, cursor, cursor + 1);
       cursor++;
     }


### PR DESCRIPTION
Follow-up to #4099 for two valid review findings that arrived as the protected merge queue completed.

- skips lexical comments when locating the real CSS `from` token and masks comment quotes around the module lexer limitation without altering strings or regex literals
- replaces repeated full-source prefix scans with a one-pass occupied-identifier set
- adds regressions for a decoy `from` inside a block comment, regex preservation, and a 10,000-character prefix-like string

Verification:
- pinned Deno 2.7.7 CSS-strip suite: 28/28 steps passed
- changed-file format, lint, typecheck, and `git diff --check`: passed

Original threads:
- https://github.com/veryfront/veryfront-code/pull/4099#discussion_r3851659074
- https://github.com/veryfront/veryfront-code/pull/4099#discussion_r3851659085

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS stripping for imports and exports containing comments, escaped identifiers, Unicode names, and complex syntax.
  * Correctly handles ECMAScript line endings, hashbangs, regular expressions, templates, class fields, import attributes, and spread syntax.
  * Prevents parsing issues caused by comments, quotes, and ambiguous syntax.
  * Avoids collisions in generated export names and reports an error when safe processing is unavailable.

* **Tests**
  * Added comprehensive coverage for advanced module syntax, masking behavior, edge cases, and name allocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->