### PR TITLE
ci: absorb transient npm 409 conflicts when publishing packages

### DIFF
--- a/scripts/ci/publish-npm-packages.sh
+++ b/scripts/ci/publish-npm-packages.sh
@@ -167,6 +167,7 @@ publish_npm_package_with_retry() {
   PUBLISH_PACKAGE_NAME="$1"
   PUBLISH_SPEC="$2"
   shift 2
+  PUBLISH_SAW_CONFLICT=0
   for PUBLISH_ATTEMPT in $(seq 1 "${NPM_PUBLISH_CONFLICT_ATTEMPTS}"); do
     if [[ "${PUBLISH_ATTEMPT}" -gt 1 ]]; then
       # npm refuses to reuse a published name/version, so a write that landed
@@ -188,8 +189,17 @@ publish_npm_package_with_retry() {
       return 0
     fi
     if ! is_transient_publish_conflict "${PUBLISH_OUTPUT}"; then
+      # A conflicting write can land between the pre-retry registry check and
+      # this publish, which npm then rejects as an ordinary already-published
+      # error rather than a conflict. Only the registry can say whether that
+      # earlier conflict published this commit, so reinspect before failing.
+      if [[ "${PUBLISH_SAW_CONFLICT}" -eq 1 ]] \
+        && inspect_publish_conflict_result "${PUBLISH_PACKAGE_NAME}"; then
+        return 0
+      fi
       return "${PUBLISH_STATUS}"
     fi
+    PUBLISH_SAW_CONFLICT=1
 
     inspect_publish_conflict_result "${PUBLISH_PACKAGE_NAME}" \
       && PUBLISH_CONFLICT_STATE=0 || PUBLISH_CONFLICT_STATE=$?

--- a/scripts/ci/publish-npm-packages.sh
+++ b/scripts/ci/publish-npm-packages.sh
@@ -119,9 +119,6 @@ verify_npm_compatibility_artifact() {
   fi
 }
 
-# Poll the npm registry until PACKAGE_NAME@VERSION reports a gitHead. Succeeds
-# only when that gitHead matches GITHUB_SHA. Leaves the last observed value in
-# the global PUBLISHED_GIT_HEAD for callers' error messages.
 # npm answers a burst of publishes with `409 Conflict - Failed to save
 # packument` when it cannot serialise the writes fast enough. The conflicting
 # write sometimes still lands, so recheck the registry before retrying and give
@@ -134,17 +131,48 @@ is_transient_publish_conflict() {
     | grep -Eq 'npm error code E409|409 Conflict|Failed to save packument'
 }
 
+# Report what the registry holds for PACKAGE_NAME@VERSION after a conflict.
+# Exit status: 0 when the version landed for GITHUB_SHA, 1 when it exists for a
+# different commit, 2 when it is still absent. Leaves the observed value in the
+# global PUBLISHED_GIT_HEAD.
+inspect_publish_conflict_result() {
+  PUBLISHED_GIT_HEAD="$(npm view "$1@${VERSION}" gitHead 2>/dev/null || true)"
+  if [[ "${PUBLISHED_GIT_HEAD}" == "${GITHUB_SHA}" ]]; then
+    echo "::notice::$1@${VERSION} landed despite an npm registry conflict; continuing."
+    return 0
+  fi
+  if [[ -n "${PUBLISHED_GIT_HEAD}" ]]; then
+    echo "::error::$1@${VERSION} exists with a different commit after a registry conflict." >&2
+    return 1
+  fi
+  return 2
+}
+
 # Publish one spec, absorbing transient registry conflicts. Prints sanitized npm
 # output. Returns 0 when the version is published for GITHUB_SHA.
+#
+# Never toggles errexit: `set -e` is process-global rather than function-scoped,
+# so flipping it here would clobber a caller that disabled it to capture this
+# helper's exit status. Statuses are captured with `&& ... || ...` instead,
+# which suppresses errexit without changing the shell option.
 publish_npm_package_with_retry() {
   PUBLISH_PACKAGE_NAME="$1"
   PUBLISH_SPEC="$2"
   shift 2
   for PUBLISH_ATTEMPT in $(seq 1 "${NPM_PUBLISH_CONFLICT_ATTEMPTS}"); do
-    set +e
-    PUBLISH_OUTPUT="$(npm publish "${PUBLISH_SPEC}" "$@" 2>&1)"
-    PUBLISH_STATUS=$?
-    set -e
+    if [[ "${PUBLISH_ATTEMPT}" -gt 1 ]]; then
+      # The conflicting write can surface while the delay elapses. npm refuses
+      # to reuse a published name/version, so republishing without this recheck
+      # would turn a recoverable conflict into a fatal already-published error.
+      inspect_publish_conflict_result "${PUBLISH_PACKAGE_NAME}" \
+        && PUBLISH_CONFLICT_STATE=0 || PUBLISH_CONFLICT_STATE=$?
+      if [[ "${PUBLISH_CONFLICT_STATE}" -ne 2 ]]; then
+        return "${PUBLISH_CONFLICT_STATE}"
+      fi
+    fi
+
+    PUBLISH_OUTPUT="$(npm publish "${PUBLISH_SPEC}" "$@" 2>&1)" \
+      && PUBLISH_STATUS=0 || PUBLISH_STATUS=$?
     SANITIZED_PUBLISH_OUTPUT="$(sanitize_npm_lookup_output "${PUBLISH_OUTPUT}")"
     if [[ -n "${SANITIZED_PUBLISH_OUTPUT}" ]]; then
       printf '%s\n' "${SANITIZED_PUBLISH_OUTPUT}"
@@ -156,14 +184,10 @@ publish_npm_package_with_retry() {
       return "${PUBLISH_STATUS}"
     fi
 
-    PUBLISHED_GIT_HEAD="$(npm view "${PUBLISH_PACKAGE_NAME}@${VERSION}" gitHead 2>/dev/null || true)"
-    if [[ "${PUBLISHED_GIT_HEAD}" == "${GITHUB_SHA}" ]]; then
-      echo "::notice::${PUBLISH_PACKAGE_NAME}@${VERSION} landed despite an npm registry conflict; continuing."
-      return 0
-    fi
-    if [[ -n "${PUBLISHED_GIT_HEAD}" ]]; then
-      echo "::error::${PUBLISH_PACKAGE_NAME}@${VERSION} exists with a different commit after a registry conflict." >&2
-      return 1
+    inspect_publish_conflict_result "${PUBLISH_PACKAGE_NAME}" \
+      && PUBLISH_CONFLICT_STATE=0 || PUBLISH_CONFLICT_STATE=$?
+    if [[ "${PUBLISH_CONFLICT_STATE}" -ne 2 ]]; then
+      return "${PUBLISH_CONFLICT_STATE}"
     fi
     if [[ "${PUBLISH_ATTEMPT}" -lt "${NPM_PUBLISH_CONFLICT_ATTEMPTS}" ]]; then
       echo "npm registry conflict publishing ${PUBLISH_PACKAGE_NAME}@${VERSION}; retrying in ${NPM_PUBLISH_CONFLICT_DELAY_SECONDS}s (attempt ${PUBLISH_ATTEMPT}/${NPM_PUBLISH_CONFLICT_ATTEMPTS})."
@@ -174,6 +198,9 @@ publish_npm_package_with_retry() {
   return 1
 }
 
+# Poll the npm registry until PACKAGE_NAME@VERSION reports a gitHead. Succeeds
+# only when that gitHead matches GITHUB_SHA. Leaves the last observed value in
+# the global PUBLISHED_GIT_HEAD for callers' error messages.
 wait_for_npm_git_head() {
   PACKAGE_NAME="$1"
   # npm can expose a published version before its gitHead metadata converges.
@@ -234,11 +261,9 @@ release_publish_package_dir() {
     echo "${PACKAGE_NAME}@${VERSION} is already published for this commit; skipping npm publish."
   else
     echo "Publishing ${PACKAGE_NAME}@${VERSION}"
-    set +e
     publish_npm_package_with_retry "${PACKAGE_NAME}" "${PUBLISH_SPEC}" \
-      --provenance --access public
-    PUBLISH_STATUS=$?
-    set -e
+      --provenance --access public \
+      && PUBLISH_STATUS=0 || PUBLISH_STATUS=$?
 
     if [ "${PUBLISH_STATUS}" -ne 0 ]; then
       if printf '%s\n' "${PUBLISH_OUTPUT}" | grep -Fq "previously published versions: ${VERSION}" \

--- a/scripts/ci/publish-npm-packages.sh
+++ b/scripts/ci/publish-npm-packages.sh
@@ -120,50 +120,41 @@ verify_npm_compatibility_artifact() {
 }
 
 # npm answers a burst of publishes with `409 Conflict - Failed to save
-# packument` when it cannot serialise the writes fast enough. The conflicting
-# write sometimes still lands, so recheck the registry before retrying and give
-# the packument time to settle between attempts.
+# packument`; the conflicting write sometimes still lands.
 NPM_PUBLISH_CONFLICT_ATTEMPTS="${NPM_PUBLISH_CONFLICT_ATTEMPTS:-5}"
 NPM_PUBLISH_CONFLICT_DELAY_SECONDS="${NPM_PUBLISH_CONFLICT_DELAY_SECONDS:-15}"
 
 is_transient_publish_conflict() {
-  printf '%s\n' "$1" \
+  CONFLICT_OUTPUT_CANDIDATE="$1"
+  printf '%s\n' "${CONFLICT_OUTPUT_CANDIDATE}" \
     | grep -Eq 'npm error code E409|409 Conflict|Failed to save packument'
 }
 
-# Report what the registry holds for PACKAGE_NAME@VERSION after a conflict.
-# Exit status: 0 when the version landed for GITHUB_SHA, 1 when it exists for a
-# different commit, 2 when it is still absent. Leaves the observed value in the
-# global PUBLISHED_GIT_HEAD.
+# 0: landed for GITHUB_SHA. 1: exists for another commit. 2: still absent.
 inspect_publish_conflict_result() {
-  PUBLISHED_GIT_HEAD="$(npm view "$1@${VERSION}" gitHead 2>/dev/null || true)"
+  CONFLICT_PACKAGE_NAME="$1"
+  PUBLISHED_GIT_HEAD="$(npm view "${CONFLICT_PACKAGE_NAME}@${VERSION}" gitHead 2>/dev/null || true)"
   if [[ "${PUBLISHED_GIT_HEAD}" == "${GITHUB_SHA}" ]]; then
-    echo "::notice::$1@${VERSION} landed despite an npm registry conflict; continuing."
+    echo "::notice::${CONFLICT_PACKAGE_NAME}@${VERSION} landed despite an npm registry conflict; continuing."
     return 0
   fi
   if [[ -n "${PUBLISHED_GIT_HEAD}" ]]; then
-    echo "::error::$1@${VERSION} exists with a different commit after a registry conflict." >&2
+    echo "::error::${CONFLICT_PACKAGE_NAME}@${VERSION} exists with a different commit after a registry conflict." >&2
     return 1
   fi
   return 2
 }
 
-# Publish one spec, absorbing transient registry conflicts. Prints sanitized npm
-# output. Returns 0 when the version is published for GITHUB_SHA.
-#
-# Never toggles errexit: `set -e` is process-global rather than function-scoped,
-# so flipping it here would clobber a caller that disabled it to capture this
-# helper's exit status. Statuses are captured with `&& ... || ...` instead,
-# which suppresses errexit without changing the shell option.
+# Never toggles errexit: `set -e` is process-global, so flipping it here would
+# clobber a caller that disabled it to capture this helper's status.
 publish_npm_package_with_retry() {
   PUBLISH_PACKAGE_NAME="$1"
   PUBLISH_SPEC="$2"
   shift 2
   for PUBLISH_ATTEMPT in $(seq 1 "${NPM_PUBLISH_CONFLICT_ATTEMPTS}"); do
     if [[ "${PUBLISH_ATTEMPT}" -gt 1 ]]; then
-      # The conflicting write can surface while the delay elapses. npm refuses
-      # to reuse a published name/version, so republishing without this recheck
-      # would turn a recoverable conflict into a fatal already-published error.
+      # npm refuses to reuse a published name/version, so a write that landed
+      # during the delay must be caught before republishing.
       inspect_publish_conflict_result "${PUBLISH_PACKAGE_NAME}" \
         && PUBLISH_CONFLICT_STATE=0 || PUBLISH_CONFLICT_STATE=$?
       if [[ "${PUBLISH_CONFLICT_STATE}" -ne 2 ]]; then

--- a/scripts/ci/publish-npm-packages.sh
+++ b/scripts/ci/publish-npm-packages.sh
@@ -130,7 +130,7 @@ is_transient_publish_conflict() {
     | grep -Eq 'npm error code E409|409 Conflict|Failed to save packument'
 }
 
-# 0: landed for GITHUB_SHA. 1: exists for another commit. 2: still absent.
+# 0: landed for GITHUB_SHA. 1: exists but cannot match. 2: still absent.
 inspect_publish_conflict_result() {
   CONFLICT_PACKAGE_NAME="$1"
   PUBLISHED_GIT_HEAD="$(npm view "${CONFLICT_PACKAGE_NAME}@${VERSION}" gitHead 2>/dev/null || true)"
@@ -140,6 +140,22 @@ inspect_publish_conflict_result() {
   fi
   if [[ -n "${PUBLISHED_GIT_HEAD}" ]]; then
     echo "::error::${CONFLICT_PACKAGE_NAME}@${VERSION} exists with a different commit after a registry conflict." >&2
+    return 1
+  fi
+
+  # npm can expose the immutable name@version before its gitHead metadata. A
+  # visible version is pending, not absent: wait for its identity instead of
+  # issuing a publish that npm must reject.
+  if npm view "${CONFLICT_PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
+    if wait_for_npm_git_head "${CONFLICT_PACKAGE_NAME}"; then
+      echo "::notice::${CONFLICT_PACKAGE_NAME}@${VERSION} landed despite an npm registry conflict; continuing."
+      return 0
+    fi
+    if [[ -n "${PUBLISHED_GIT_HEAD}" ]]; then
+      echo "::error::${CONFLICT_PACKAGE_NAME}@${VERSION} exists with a different commit after a registry conflict." >&2
+    else
+      echo "::error::${CONFLICT_PACKAGE_NAME}@${VERSION} exists after a registry conflict, but its gitHead metadata did not converge." >&2
+    fi
     return 1
   fi
   return 2
@@ -183,6 +199,12 @@ publish_npm_package_with_retry() {
     if [[ "${PUBLISH_ATTEMPT}" -lt "${NPM_PUBLISH_CONFLICT_ATTEMPTS}" ]]; then
       echo "npm registry conflict publishing ${PUBLISH_PACKAGE_NAME}@${VERSION}; retrying in ${NPM_PUBLISH_CONFLICT_DELAY_SECONDS}s (attempt ${PUBLISH_ATTEMPT}/${NPM_PUBLISH_CONFLICT_ATTEMPTS})."
       sleep "${NPM_PUBLISH_CONFLICT_DELAY_SECONDS}"
+    elif wait_for_npm_git_head "${PUBLISH_PACKAGE_NAME}"; then
+      echo "::notice::${PUBLISH_PACKAGE_NAME}@${VERSION} landed after the final npm registry conflict; continuing."
+      return 0
+    elif [[ -n "${PUBLISHED_GIT_HEAD}" ]]; then
+      echo "::error::${PUBLISH_PACKAGE_NAME}@${VERSION} exists with a different commit after the final registry conflict." >&2
+      return 1
     fi
   done
   echo "::error::npm registry conflict persisted for ${PUBLISH_PACKAGE_NAME}@${VERSION} after ${NPM_PUBLISH_CONFLICT_ATTEMPTS} attempts." >&2
@@ -229,6 +251,14 @@ rc_publish_package_dir() {
         printf '%s\n' "${SANITIZED_NPM_LOOKUP_OUTPUT}" >&2
       fi
       return "${PUBLISHED_GIT_HEAD_STATUS}"
+    fi
+    if [[ -z "${PUBLISHED_GIT_HEAD}" ]] && ! wait_for_npm_git_head "${PACKAGE_NAME}"; then
+      if [[ -n "${PUBLISHED_GIT_HEAD}" ]]; then
+        echo "::error::${PACKAGE_NAME}@${VERSION} already exists, but its gitHead does not match this commit." >&2
+      else
+        echo "::error::${PACKAGE_NAME}@${VERSION} already exists, but its gitHead metadata did not converge." >&2
+      fi
+      return 1
     fi
     if [[ "${PUBLISHED_GIT_HEAD}" == "${GITHUB_SHA}" ]]; then
       echo "::notice::${PACKAGE_NAME}@${VERSION} already published for this commit; skipping npm publish"

--- a/scripts/ci/publish-npm-packages.sh
+++ b/scripts/ci/publish-npm-packages.sh
@@ -122,6 +122,58 @@ verify_npm_compatibility_artifact() {
 # Poll the npm registry until PACKAGE_NAME@VERSION reports a gitHead. Succeeds
 # only when that gitHead matches GITHUB_SHA. Leaves the last observed value in
 # the global PUBLISHED_GIT_HEAD for callers' error messages.
+# npm answers a burst of publishes with `409 Conflict - Failed to save
+# packument` when it cannot serialise the writes fast enough. The conflicting
+# write sometimes still lands, so recheck the registry before retrying and give
+# the packument time to settle between attempts.
+NPM_PUBLISH_CONFLICT_ATTEMPTS="${NPM_PUBLISH_CONFLICT_ATTEMPTS:-5}"
+NPM_PUBLISH_CONFLICT_DELAY_SECONDS="${NPM_PUBLISH_CONFLICT_DELAY_SECONDS:-15}"
+
+is_transient_publish_conflict() {
+  printf '%s\n' "$1" \
+    | grep -Eq 'npm error code E409|409 Conflict|Failed to save packument'
+}
+
+# Publish one spec, absorbing transient registry conflicts. Prints sanitized npm
+# output. Returns 0 when the version is published for GITHUB_SHA.
+publish_npm_package_with_retry() {
+  PUBLISH_PACKAGE_NAME="$1"
+  PUBLISH_SPEC="$2"
+  shift 2
+  for PUBLISH_ATTEMPT in $(seq 1 "${NPM_PUBLISH_CONFLICT_ATTEMPTS}"); do
+    set +e
+    PUBLISH_OUTPUT="$(npm publish "${PUBLISH_SPEC}" "$@" 2>&1)"
+    PUBLISH_STATUS=$?
+    set -e
+    SANITIZED_PUBLISH_OUTPUT="$(sanitize_npm_lookup_output "${PUBLISH_OUTPUT}")"
+    if [[ -n "${SANITIZED_PUBLISH_OUTPUT}" ]]; then
+      printf '%s\n' "${SANITIZED_PUBLISH_OUTPUT}"
+    fi
+    if [[ "${PUBLISH_STATUS}" -eq 0 ]]; then
+      return 0
+    fi
+    if ! is_transient_publish_conflict "${PUBLISH_OUTPUT}"; then
+      return "${PUBLISH_STATUS}"
+    fi
+
+    PUBLISHED_GIT_HEAD="$(npm view "${PUBLISH_PACKAGE_NAME}@${VERSION}" gitHead 2>/dev/null || true)"
+    if [[ "${PUBLISHED_GIT_HEAD}" == "${GITHUB_SHA}" ]]; then
+      echo "::notice::${PUBLISH_PACKAGE_NAME}@${VERSION} landed despite an npm registry conflict; continuing."
+      return 0
+    fi
+    if [[ -n "${PUBLISHED_GIT_HEAD}" ]]; then
+      echo "::error::${PUBLISH_PACKAGE_NAME}@${VERSION} exists with a different commit after a registry conflict." >&2
+      return 1
+    fi
+    if [[ "${PUBLISH_ATTEMPT}" -lt "${NPM_PUBLISH_CONFLICT_ATTEMPTS}" ]]; then
+      echo "npm registry conflict publishing ${PUBLISH_PACKAGE_NAME}@${VERSION}; retrying in ${NPM_PUBLISH_CONFLICT_DELAY_SECONDS}s (attempt ${PUBLISH_ATTEMPT}/${NPM_PUBLISH_CONFLICT_ATTEMPTS})."
+      sleep "${NPM_PUBLISH_CONFLICT_DELAY_SECONDS}"
+    fi
+  done
+  echo "::error::npm registry conflict persisted for ${PUBLISH_PACKAGE_NAME}@${VERSION} after ${NPM_PUBLISH_CONFLICT_ATTEMPTS} attempts." >&2
+  return 1
+}
+
 wait_for_npm_git_head() {
   PACKAGE_NAME="$1"
   # npm can expose a published version before its gitHead metadata converges.
@@ -169,15 +221,8 @@ rc_publish_package_dir() {
   fi
 
   echo "Publishing ${PACKAGE_NAME}@${VERSION} with rc tag"
-  set +e
-  PUBLISH_OUTPUT="$(npm publish "${PUBLISH_SPEC}" --provenance --access public --tag rc 2>&1)"
-  PUBLISH_STATUS=$?
-  set -e
-  SANITIZED_PUBLISH_OUTPUT="$(sanitize_npm_lookup_output "${PUBLISH_OUTPUT}")"
-  if [[ -n "${SANITIZED_PUBLISH_OUTPUT}" ]]; then
-    printf '%s\n' "${SANITIZED_PUBLISH_OUTPUT}"
-  fi
-  return "${PUBLISH_STATUS}"
+  publish_npm_package_with_retry "${PACKAGE_NAME}" "${PUBLISH_SPEC}" \
+    --provenance --access public --tag rc
 }
 
 release_publish_package_dir() {
@@ -190,13 +235,10 @@ release_publish_package_dir() {
   else
     echo "Publishing ${PACKAGE_NAME}@${VERSION}"
     set +e
-    PUBLISH_OUTPUT="$(npm publish "${PUBLISH_SPEC}" --provenance --access public 2>&1)"
+    publish_npm_package_with_retry "${PACKAGE_NAME}" "${PUBLISH_SPEC}" \
+      --provenance --access public
     PUBLISH_STATUS=$?
     set -e
-    SANITIZED_PUBLISH_OUTPUT="$(sanitize_npm_lookup_output "${PUBLISH_OUTPUT}")"
-    if [[ -n "${SANITIZED_PUBLISH_OUTPUT}" ]]; then
-      printf '%s\n' "${SANITIZED_PUBLISH_OUTPUT}"
-    fi
 
     if [ "${PUBLISH_STATUS}" -ne 0 ]; then
       if printf '%s\n' "${PUBLISH_OUTPUT}" | grep -Fq "previously published versions: ${VERSION}" \

--- a/scripts/ci/publish-npm-packages.sh
+++ b/scripts/ci/publish-npm-packages.sh
@@ -130,6 +130,16 @@ is_transient_publish_conflict() {
     | grep -Eq 'npm error code E409|409 Conflict|Failed to save packument'
 }
 
+# npm rejects a reused name/version with "You cannot publish over the
+# previously published versions". That answer comes from the registry's write
+# side, so it is authoritative that the version exists even while the read
+# replica still reports it absent.
+is_npm_version_already_published() {
+  ALREADY_PUBLISHED_OUTPUT_CANDIDATE="$1"
+  printf '%s\n' "${ALREADY_PUBLISHED_OUTPUT_CANDIDATE}" \
+    | grep -Fq "previously published versions: ${VERSION}"
+}
+
 # 0: landed for GITHUB_SHA. 1: exists but cannot match. 2: still absent.
 inspect_publish_conflict_result() {
   CONFLICT_PACKAGE_NAME="$1"
@@ -196,6 +206,18 @@ publish_npm_package_with_retry() {
       if [[ "${PUBLISH_SAW_CONFLICT}" -eq 1 ]] \
         && inspect_publish_conflict_result "${PUBLISH_PACKAGE_NAME}"; then
         return 0
+      fi
+      # The read replica can lag behind that write. When npm itself says the
+      # version already exists, one absent lookup is not evidence of failure,
+      # so fall back to the bounded metadata poll the stable path already uses.
+      if [[ "${PUBLISH_SAW_CONFLICT}" -eq 1 ]] \
+        && is_npm_version_already_published "${PUBLISH_OUTPUT}"; then
+        if wait_for_npm_git_head "${PUBLISH_PACKAGE_NAME}"; then
+          echo "::notice::${PUBLISH_PACKAGE_NAME}@${VERSION} landed despite an npm registry conflict; continuing."
+          return 0
+        fi
+        echo "::error::${PUBLISH_PACKAGE_NAME}@${VERSION} already exists after a registry conflict, but its gitHead is \"${PUBLISHED_GIT_HEAD}\" instead of ${GITHUB_SHA}." >&2
+        return 1
       fi
       return "${PUBLISH_STATUS}"
     fi

--- a/scripts/ci/publish-npm-packages.test.ts
+++ b/scripts/ci/publish-npm-packages.test.ts
@@ -992,4 +992,138 @@ describe("npm package publishing", () => {
       assertEquals(publishes.length, 3);
     });
   });
+
+  // The conflicting write can surface while the retry delay elapses. npm
+  // refuses to reuse a published name/version, so a blind republish would turn
+  // a recoverable conflict into a fatal already-published error.
+  for (
+    const [publishFunction, gitHeadVisibleAfter] of [
+      ["rc_publish_package_dir", "1"],
+      ["release_publish_package_dir", "2"],
+    ]
+  ) {
+    it(`rechecks gitHead after the conflict delay in ${publishFunction}`, async () => {
+      await withTempDir(async (stateDir) => {
+        const packageDir = `${stateDir}/package`;
+        const npmLog = `${stateDir}/npm.log`;
+        await Deno.mkdir(packageDir);
+        await Deno.writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({ name: "@veryfront/ext-llm-google" }),
+        );
+        await Deno.writeTextFile(npmLog, "");
+
+        const output = await runBash(
+          [
+            "set -euo pipefail",
+            'source "$SCRIPT_PATH"',
+            "npm() {",
+            '  printf "%s\\n" "$*" >> "$NPM_LOG"',
+            '  if [ "$1" = "publish" ]; then',
+            '    printf "%s\\n" "$CONFLICT_OUTPUT"',
+            "    return 1",
+            "  fi",
+            // gitHead stays invisible until the conflict delay has elapsed
+            '  if [ "$1" = "view" ] && [ "$3" = "gitHead" ]; then',
+            '    if [ "$(grep -c gitHead "$NPM_LOG")" -le "$GIT_HEAD_VISIBLE_AFTER" ]; then',
+            "      return 1",
+            "    fi",
+            '    printf "%s\\n" "$GITHUB_SHA"',
+            "    return 0",
+            "  fi",
+            "  return 1",
+            "}",
+            `${publishFunction} "$PACKAGE_DIR"`,
+          ].join("\n"),
+          {
+            CONFLICT_OUTPUT,
+            GITHUB_SHA: "0".repeat(40),
+            GIT_HEAD_VISIBLE_AFTER: gitHeadVisibleAfter,
+            NPM_LOG: npmLog,
+            NPM_PUBLISH_CONFLICT_DELAY_SECONDS: "0",
+            PACKAGE_DIR: packageDir,
+            VERSION: "0.1.0",
+          },
+        );
+
+        assertEquals(
+          output.code,
+          0,
+          `${publishFunction} must accept the conflicted publish once gitHead converges: ${
+            decoder.decode(output.stderr)
+          }`,
+        );
+        assertStringIncludes(
+          decoder.decode(output.stdout),
+          "landed despite an npm registry conflict",
+        );
+        const publishes = (await Deno.readTextFile(npmLog)).trim().split("\n")
+          .filter((line) => line.startsWith("publish"));
+        assertEquals(
+          publishes.length,
+          1,
+          `${publishFunction} must not republish an immutable name@version after the conflict delay, but issued: ${
+            publishes.join(", ")
+          }`,
+        );
+      });
+    });
+  }
+
+  it("keeps the caller's errexit state so the release rerun recovery still runs", async () => {
+    await withTempDir(async (stateDir) => {
+      const packageDir = `${stateDir}/package`;
+      const npmLog = `${stateDir}/npm.log`;
+      await Deno.mkdir(packageDir);
+      await Deno.writeTextFile(
+        `${packageDir}/package.json`,
+        JSON.stringify({ name: "@veryfront/ext-llm-google" }),
+      );
+      await Deno.writeTextFile(npmLog, "");
+
+      const output = await runBash(
+        [
+          "set -euo pipefail",
+          'source "$SCRIPT_PATH"',
+          "npm() {",
+          '  printf "%s\\n" "$*" >> "$NPM_LOG"',
+          '  if [ "$1" = "publish" ]; then',
+          '    printf "%s\\n" "npm error code E403"',
+          '    printf "%s\\n" "npm error 403 You cannot publish over the previously published versions: 0.1.0"',
+          "    return 1",
+          "  fi",
+          '  if [ "$1" = "view" ] && [ "$3" = "gitHead" ]; then',
+          '    if [ "$(grep -c gitHead "$NPM_LOG")" -le 1 ]; then return 1; fi',
+          '    printf "%s\\n" "$GITHUB_SHA"',
+          "    return 0",
+          "  fi",
+          "  return 1",
+          "}",
+          'release_publish_package_dir "$PACKAGE_DIR"',
+          'echo "RECOVERY_REACHED"',
+        ].join("\n"),
+        {
+          GITHUB_SHA: "0".repeat(40),
+          NPM_LOG: npmLog,
+          NPM_PUBLISH_CONFLICT_DELAY_SECONDS: "0",
+          PACKAGE_DIR: packageDir,
+          VERSION: "0.1.0",
+        },
+      );
+
+      const stdout = decoder.decode(output.stdout);
+      assertEquals(
+        output.code,
+        0,
+        `the publish retry helper must not enable errexit under a caller that disabled it: ${
+          decoder.decode(output.stderr)
+        }`,
+      );
+      assertStringIncludes(
+        stdout,
+        "already exists, and gitHead matches this commit; continuing.",
+      );
+      assertStringIncludes(stdout, "RECOVERY_REACHED");
+    });
+  });
 });

--- a/scripts/ci/publish-npm-packages.test.ts
+++ b/scripts/ci/publish-npm-packages.test.ts
@@ -798,4 +798,198 @@ describe("npm package publishing", () => {
       await Deno.remove(stateDir, { recursive: true });
     }
   });
+  // npm answers a burst of publishes with `409 Conflict - Failed to save
+  // packument`. The write sometimes still lands, so the publish path has to
+  // recheck the registry and retry rather than failing the whole release.
+  const CONFLICT_OUTPUT =
+    "npm error code E409\nnpm error 409 Conflict - PUT https://registry.npmjs.org/@veryfront%2fext-llm-google - Failed to save packument.";
+
+  for (
+    const publishFunction of [
+      "rc_publish_package_dir",
+      "release_publish_package_dir",
+    ]
+  ) {
+    it(`retries a transient npm 409 conflict in ${publishFunction}`, async () => {
+      await withTempDir(async (stateDir) => {
+        const packageDir = `${stateDir}/package`;
+        const npmLog = `${stateDir}/npm.log`;
+        await Deno.mkdir(packageDir);
+        await Deno.writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({ name: "@veryfront/ext-llm-google" }),
+        );
+        await Deno.writeTextFile(npmLog, "");
+
+        const output = await runBash(
+          [
+            "set -euo pipefail",
+            'source "$SCRIPT_PATH"',
+            "npm() {",
+            '  printf "%s\\n" "$*" >> "$NPM_LOG"',
+            '  if [ "$1" = "publish" ]; then',
+            '    if [ "$(grep -c "^publish" "$NPM_LOG")" -eq 1 ]; then',
+            '      printf "%s\\n" "$CONFLICT_OUTPUT"',
+            "      return 1",
+            "    fi",
+            "    return 0",
+            "  fi",
+            '  if [ "$1" = "view" ]; then',
+            // no published version yet, so the conflict was a genuine failure
+            '    if [ "$(grep -c "^publish" "$NPM_LOG")" -le 1 ]; then return 1; fi',
+            '    printf "%s\\n" "$GITHUB_SHA"',
+            "    return 0",
+            "  fi",
+            "}",
+            `${publishFunction} "$PACKAGE_DIR"`,
+          ].join("\n"),
+          {
+            CONFLICT_OUTPUT,
+            GITHUB_SHA: "0".repeat(40),
+            NPM_LOG: npmLog,
+            NPM_PUBLISH_CONFLICT_DELAY_SECONDS: "0",
+            PACKAGE_DIR: packageDir,
+            VERSION: "0.1.0",
+          },
+        );
+
+        assertEquals(output.code, 0, decoder.decode(output.stderr));
+        const publishes = (await Deno.readTextFile(npmLog)).trim().split("\n")
+          .filter((line) => line.startsWith("publish"));
+        assertEquals(publishes.length, 2);
+      });
+    });
+
+    it(`accepts a 409 whose publish already landed in ${publishFunction}`, async () => {
+      await withTempDir(async (stateDir) => {
+        const packageDir = `${stateDir}/package`;
+        const npmLog = `${stateDir}/npm.log`;
+        await Deno.mkdir(packageDir);
+        await Deno.writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({ name: "@veryfront/ext-llm-google" }),
+        );
+        await Deno.writeTextFile(npmLog, "");
+
+        const output = await runBash(
+          [
+            "set -euo pipefail",
+            'source "$SCRIPT_PATH"',
+            "npm() {",
+            '  printf "%s\\n" "$*" >> "$NPM_LOG"',
+            '  if [ "$1" = "publish" ]; then',
+            '    printf "%s\\n" "$CONFLICT_OUTPUT"',
+            "    return 1",
+            "  fi",
+            // not published before the attempt; the conflicting write did land
+            '  if [ "$1" = "view" ] && [ "$3" = "version" ]; then return 1; fi',
+            '  if [ "$1" = "view" ]; then',
+            '    if [ "$(grep -c "^publish" "$NPM_LOG")" -eq 0 ]; then return 1; fi',
+            '    printf "%s\\n" "$GITHUB_SHA"',
+            "    return 0",
+            "  fi",
+            "}",
+            `${publishFunction} "$PACKAGE_DIR"`,
+          ].join("\n"),
+          {
+            CONFLICT_OUTPUT,
+            GITHUB_SHA: "0".repeat(40),
+            NPM_LOG: npmLog,
+            NPM_PUBLISH_CONFLICT_DELAY_SECONDS: "0",
+            PACKAGE_DIR: packageDir,
+            VERSION: "0.1.0",
+          },
+        );
+
+        assertEquals(output.code, 0, decoder.decode(output.stderr));
+        const publishes = (await Deno.readTextFile(npmLog)).trim().split("\n")
+          .filter((line) => line.startsWith("publish"));
+        assertEquals(publishes.length, 1);
+      });
+    });
+  }
+
+  it("does not retry a non-conflict npm publish failure", async () => {
+    await withTempDir(async (stateDir) => {
+      const packageDir = `${stateDir}/package`;
+      const npmLog = `${stateDir}/npm.log`;
+      await Deno.mkdir(packageDir);
+      await Deno.writeTextFile(
+        `${packageDir}/package.json`,
+        JSON.stringify({ name: "@veryfront/ext-llm-google" }),
+      );
+      await Deno.writeTextFile(npmLog, "");
+
+      const output = await runBash(
+        [
+          "set -euo pipefail",
+          'source "$SCRIPT_PATH"',
+          "npm() {",
+          '  printf "%s\\n" "$*" >> "$NPM_LOG"',
+          '  if [ "$1" = "publish" ]; then',
+          '    printf "%s\\n" "npm error code E403"',
+          "    return 1",
+          "  fi",
+          '  if [ "$1" = "view" ]; then return 1; fi',
+          "}",
+          'rc_publish_package_dir "$PACKAGE_DIR" || echo "EXIT=$?"',
+        ].join("\n"),
+        {
+          GITHUB_SHA: "0".repeat(40),
+          NPM_LOG: npmLog,
+          NPM_PUBLISH_CONFLICT_DELAY_SECONDS: "0",
+          PACKAGE_DIR: packageDir,
+          VERSION: "0.1.0",
+        },
+      );
+
+      assertStringIncludes(decoder.decode(output.stdout), "EXIT=1");
+      const publishes = (await Deno.readTextFile(npmLog)).trim().split("\n")
+        .filter((line) => line.startsWith("publish"));
+      assertEquals(publishes.length, 1);
+    });
+  });
+
+  it("gives up after the bounded number of conflict retries", async () => {
+    await withTempDir(async (stateDir) => {
+      const packageDir = `${stateDir}/package`;
+      const npmLog = `${stateDir}/npm.log`;
+      await Deno.mkdir(packageDir);
+      await Deno.writeTextFile(
+        `${packageDir}/package.json`,
+        JSON.stringify({ name: "@veryfront/ext-llm-google" }),
+      );
+      await Deno.writeTextFile(npmLog, "");
+
+      const output = await runBash(
+        [
+          "set -euo pipefail",
+          'source "$SCRIPT_PATH"',
+          "npm() {",
+          '  printf "%s\\n" "$*" >> "$NPM_LOG"',
+          '  if [ "$1" = "publish" ]; then',
+          '    printf "%s\\n" "$CONFLICT_OUTPUT"',
+          "    return 1",
+          "  fi",
+          '  if [ "$1" = "view" ]; then return 1; fi',
+          "}",
+          'rc_publish_package_dir "$PACKAGE_DIR" || echo "EXIT=$?"',
+        ].join("\n"),
+        {
+          CONFLICT_OUTPUT,
+          GITHUB_SHA: "0".repeat(40),
+          NPM_LOG: npmLog,
+          NPM_PUBLISH_CONFLICT_ATTEMPTS: "3",
+          NPM_PUBLISH_CONFLICT_DELAY_SECONDS: "0",
+          PACKAGE_DIR: packageDir,
+          VERSION: "0.1.0",
+        },
+      );
+
+      assertStringIncludes(decoder.decode(output.stdout), "EXIT=1");
+      const publishes = (await Deno.readTextFile(npmLog)).trim().split("\n")
+        .filter((line) => line.startsWith("publish"));
+      assertEquals(publishes.length, 3);
+    });
+  });
 });

--- a/scripts/ci/publish-npm-packages.test.ts
+++ b/scripts/ci/publish-npm-packages.test.ts
@@ -1188,6 +1188,70 @@ describe("npm package publishing", () => {
     });
   });
 
+  // The conflicting write can land while its gitHead never converges. The
+  // version is immutable either way, so the helper must report the unresolved
+  // identity instead of republishing over it.
+  it("fails without republishing when a conflicted RC version never reports a gitHead", async () => {
+    await withTempDir(async (stateDir) => {
+      const packageDir = `${stateDir}/package`;
+      const npmLog = `${stateDir}/npm.log`;
+      await Deno.mkdir(packageDir);
+      await Deno.writeTextFile(
+        `${packageDir}/package.json`,
+        JSON.stringify({ name: "@veryfront/ext-llm-google" }),
+      );
+      await Deno.writeTextFile(npmLog, "");
+
+      const output = await runBash(
+        [
+          "set -euo pipefail",
+          'source "$SCRIPT_PATH"',
+          "npm() {",
+          '  printf "%s\\n" "$*" >> "$NPM_LOG"',
+          '  if [ "$1" = "publish" ]; then',
+          '    printf "%s\\n" "$CONFLICT_OUTPUT"',
+          "    return 1",
+          "  fi",
+          // the conflicting write lands, but its gitHead stays empty forever
+          '  if [ "$1" = "view" ] && [ "$3" = "version" ]; then',
+          '    if [ "$(grep -c "^publish" "$NPM_LOG")" -eq 0 ]; then return 1; fi',
+          '    printf "%s\\n" "$VERSION"',
+          "    return 0",
+          "  fi",
+          "  return 1",
+          "}",
+          "sleep() { :; }",
+          'rc_publish_package_dir "$PACKAGE_DIR"',
+        ].join("\n"),
+        {
+          CONFLICT_OUTPUT,
+          GITHUB_SHA: "0".repeat(40),
+          NPM_LOG: npmLog,
+          NPM_PUBLISH_CONFLICT_DELAY_SECONDS: "0",
+          PACKAGE_DIR: packageDir,
+          VERSION: "0.1.0",
+        },
+      );
+
+      const stderr = decoder.decode(output.stderr);
+      assertEquals(
+        output.code,
+        1,
+        `a published version without a readable gitHead must fail the RC publish: ${stderr}`,
+      );
+      assertStringIncludes(stderr, "gitHead metadata did not converge");
+      const publishes = (await Deno.readTextFile(npmLog)).trim().split("\n")
+        .filter((line) => line.startsWith("publish"));
+      assertEquals(
+        publishes.length,
+        1,
+        `the retry must stop once the version exists, but issued: ${
+          publishes.join(", ")
+        }`,
+      );
+    });
+  });
+
   for (
     const publishFunction of [
       "rc_publish_package_dir",

--- a/scripts/ci/publish-npm-packages.test.ts
+++ b/scripts/ci/publish-npm-packages.test.ts
@@ -1,4 +1,7 @@
-import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { withTempDir } from "#veryfront/testing/deno-compat.ts";
 
@@ -234,7 +237,9 @@ describe("npm package publishing", () => {
 
   for (const publishFunction of ["run_rc_publish", "run_release_publish"]) {
     for (const artifactGitHead of [undefined, "f".repeat(40)]) {
-      const identityCase = artifactGitHead === undefined ? "missing" : "mismatched";
+      const identityCase = artifactGitHead === undefined
+        ? "missing"
+        : "mismatched";
       it(`blocks ${publishFunction} before publish when canonical tarball gitHead is ${identityCase}`, async () => {
         await withTempDir(async (stateDir) => {
           const packageDir = `${stateDir}/npm`;
@@ -410,61 +415,110 @@ describe("npm package publishing", () => {
     }
   });
 
-  for (const publishedGitHead of ["", "wrong-commit"]) {
-    const identityCase = publishedGitHead === "" ? "missing" : "mismatched";
-    it(`rejects an RC rerun when the existing version has ${identityCase} gitHead`, async () => {
-      await withTempDir(async (stateDir) => {
-        const packageDir = `${stateDir}/package`;
-        const npmLog = `${stateDir}/npm.log`;
-        await Deno.mkdir(packageDir);
-        await Deno.writeTextFile(
-          `${packageDir}/package.json`,
-          JSON.stringify({ name: "@veryfront/ext-auth-jwt" }),
-        );
-        await Deno.writeTextFile(npmLog, "");
+  it("rejects an RC rerun when the existing version has a mismatched gitHead", async () => {
+    await withTempDir(async (stateDir) => {
+      const packageDir = `${stateDir}/package`;
+      const npmLog = `${stateDir}/npm.log`;
+      await Deno.mkdir(packageDir);
+      await Deno.writeTextFile(
+        `${packageDir}/package.json`,
+        JSON.stringify({ name: "@veryfront/ext-auth-jwt" }),
+      );
+      await Deno.writeTextFile(npmLog, "");
 
-        const output = await runBash(
-          [
-            "set -euo pipefail",
-            'source "$SCRIPT_PATH"',
-            "npm() {",
-            '  printf "%s\\n" "$*" >> "$NPM_LOG"',
-            '  if [ "$1" = "view" ] && [ "$3" = "version" ]; then',
-            '    printf "%s\\n" "$VERSION"',
-            "    return 0",
-            "  fi",
-            '  if [ "$1" = "view" ] && [ "$3" = "gitHead" ]; then',
-            '    printf "%s\\n" "$PUBLISHED_GIT_HEAD_FIXTURE"',
-            "    return 0",
-            "  fi",
-            "  return 92",
-            "}",
-            'rc_publish_package_dir "$PACKAGE_DIR"',
-          ].join("\n"),
-          {
-            GITHUB_SHA: "expected-commit",
-            NPM_LOG: npmLog,
-            PACKAGE_DIR: packageDir,
-            PUBLISHED_GIT_HEAD_FIXTURE: publishedGitHead,
-            VERSION: "0.1.1069",
-          },
-        );
+      const output = await runBash(
+        [
+          "set -euo pipefail",
+          'source "$SCRIPT_PATH"',
+          "npm() {",
+          '  printf "%s\\n" "$*" >> "$NPM_LOG"',
+          '  if [ "$1" = "view" ] && [ "$3" = "version" ]; then',
+          '    printf "%s\\n" "$VERSION"',
+          "    return 0",
+          "  fi",
+          '  if [ "$1" = "view" ] && [ "$3" = "gitHead" ]; then',
+          '    printf "%s\\n" "wrong-commit"',
+          "    return 0",
+          "  fi",
+          "  return 92",
+          "}",
+          'rc_publish_package_dir "$PACKAGE_DIR"',
+        ].join("\n"),
+        {
+          GITHUB_SHA: "expected-commit",
+          NPM_LOG: npmLog,
+          PACKAGE_DIR: packageDir,
+          VERSION: "0.1.1069",
+        },
+      );
 
-        assertEquals(output.code, 1, decoder.decode(output.stderr));
-        assertStringIncludes(
-          decoder.decode(output.stderr),
-          "gitHead does not match this commit",
-        );
-        assertEquals(
-          (await Deno.readTextFile(npmLog)).trim().split("\n"),
-          [
-            "view @veryfront/ext-auth-jwt@0.1.1069 version",
-            "view @veryfront/ext-auth-jwt@0.1.1069 gitHead",
-          ],
-        );
-      });
+      assertEquals(output.code, 1, decoder.decode(output.stderr));
+      assertStringIncludes(
+        decoder.decode(output.stderr),
+        "gitHead does not match this commit",
+      );
+      assertEquals(
+        (await Deno.readTextFile(npmLog)).trim().split("\n"),
+        [
+          "view @veryfront/ext-auth-jwt@0.1.1069 version",
+          "view @veryfront/ext-auth-jwt@0.1.1069 gitHead",
+        ],
+      );
     });
-  }
+  });
+
+  it("waits for an existing RC version's missing gitHead metadata", async () => {
+    await withTempDir(async (stateDir) => {
+      const packageDir = `${stateDir}/package`;
+      const npmLog = `${stateDir}/npm.log`;
+      await Deno.mkdir(packageDir);
+      await Deno.writeTextFile(
+        `${packageDir}/package.json`,
+        JSON.stringify({ name: "@veryfront/ext-auth-jwt" }),
+      );
+      await Deno.writeTextFile(npmLog, "");
+
+      const output = await runBash(
+        [
+          "set -euo pipefail",
+          'source "$SCRIPT_PATH"',
+          "npm() {",
+          '  printf "%s\\n" "$*" >> "$NPM_LOG"',
+          '  if [ "$1" = "view" ] && [ "$3" = "version" ]; then',
+          '    printf "%s\\n" "$VERSION"',
+          "    return 0",
+          "  fi",
+          '  if [ "$1" = "view" ] && [ "$3" = "gitHead" ]; then',
+          '    if [ "$(grep -c gitHead "$NPM_LOG")" -lt 4 ]; then return 0; fi',
+          '    printf "%s\\n" "$GITHUB_SHA"',
+          "    return 0",
+          "  fi",
+          "  return 92",
+          "}",
+          "sleep() { :; }",
+          'rc_publish_package_dir "$PACKAGE_DIR"',
+        ].join("\n"),
+        {
+          GITHUB_SHA: "expected-commit",
+          NPM_LOG: npmLog,
+          PACKAGE_DIR: packageDir,
+          VERSION: "0.1.1069",
+        },
+      );
+
+      assertEquals(output.code, 0, decoder.decode(output.stderr));
+      assertStringIncludes(
+        decoder.decode(output.stdout),
+        "already published for this commit; skipping npm publish",
+      );
+      const calls = (await Deno.readTextFile(npmLog)).trim().split("\n");
+      assertEquals(
+        calls.filter((line) => line.startsWith("publish")).length,
+        0,
+      );
+      assertEquals(calls.filter((line) => line.endsWith("gitHead")).length, 4);
+    });
+  });
 
   it("reports a sanitized npm lookup failure when an existing RC version gitHead cannot be read", async () => {
     await withTempDir(async (stateDir) => {
@@ -973,6 +1027,7 @@ describe("npm package publishing", () => {
           "  fi",
           '  if [ "$1" = "view" ]; then return 1; fi',
           "}",
+          "sleep() { :; }",
           'rc_publish_package_dir "$PACKAGE_DIR" || echo "EXIT=$?"',
         ].join("\n"),
         {
@@ -1066,6 +1121,125 @@ describe("npm package publishing", () => {
             publishes.join(", ")
           }`,
         );
+      });
+    });
+  }
+
+  it("waits instead of republishing when an RC conflict version lacks gitHead", async () => {
+    await withTempDir(async (stateDir) => {
+      const packageDir = `${stateDir}/package`;
+      const npmLog = `${stateDir}/npm.log`;
+      const delayMarker = `${stateDir}/delay-elapsed`;
+      await Deno.mkdir(packageDir);
+      await Deno.writeTextFile(
+        `${packageDir}/package.json`,
+        JSON.stringify({ name: "@veryfront/ext-llm-google" }),
+      );
+      await Deno.writeTextFile(npmLog, "");
+
+      const output = await runBash(
+        [
+          "set -euo pipefail",
+          'source "$SCRIPT_PATH"',
+          "npm() {",
+          '  printf "%s\\n" "$*" >> "$NPM_LOG"',
+          '  if [ "$1" = "publish" ]; then',
+          '    if [ "$(grep -c "^publish" "$NPM_LOG")" -gt 1 ]; then',
+          '      printf "%s\\n" "npm error code E403"',
+          "      return 1",
+          "    fi",
+          '    printf "%s\\n" "$CONFLICT_OUTPUT"',
+          "    return 1",
+          "  fi",
+          '  if [ "$1" = "view" ] && [ "$3" = "version" ]; then',
+          '    if [ ! -f "$DELAY_MARKER" ]; then return 1; fi',
+          '    printf "%s\\n" "$VERSION"',
+          "    return 0",
+          "  fi",
+          '  if [ "$1" = "view" ] && [ "$3" = "gitHead" ]; then',
+          '    if [ "$(grep -c gitHead "$NPM_LOG")" -lt 4 ]; then return 0; fi',
+          '    printf "%s\\n" "$GITHUB_SHA"',
+          "    return 0",
+          "  fi",
+          "  return 1",
+          "}",
+          'sleep() { : > "$DELAY_MARKER"; }',
+          'rc_publish_package_dir "$PACKAGE_DIR"',
+        ].join("\n"),
+        {
+          CONFLICT_OUTPUT,
+          DELAY_MARKER: delayMarker,
+          GITHUB_SHA: "0".repeat(40),
+          NPM_LOG: npmLog,
+          NPM_PUBLISH_CONFLICT_DELAY_SECONDS: "0",
+          PACKAGE_DIR: packageDir,
+          VERSION: "0.1.0",
+        },
+      );
+
+      assertEquals(output.code, 0, decoder.decode(output.stderr));
+      const publishes = (await Deno.readTextFile(npmLog)).trim().split("\n")
+        .filter((line) => line.startsWith("publish"));
+      assertEquals(
+        publishes.length,
+        1,
+        "an immutable name@version must not be republished while gitHead converges",
+      );
+    });
+  });
+
+  for (
+    const publishFunction of [
+      "rc_publish_package_dir",
+      "release_publish_package_dir",
+    ]
+  ) {
+    it(`rechecks after the final conflict in ${publishFunction}`, async () => {
+      await withTempDir(async (stateDir) => {
+        const packageDir = `${stateDir}/package`;
+        const npmLog = `${stateDir}/npm.log`;
+        await Deno.mkdir(packageDir);
+        await Deno.writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({ name: "@veryfront/ext-llm-google" }),
+        );
+        await Deno.writeTextFile(npmLog, "");
+
+        const output = await runBash(
+          [
+            "set -euo pipefail",
+            'source "$SCRIPT_PATH"',
+            "npm() {",
+            '  printf "%s\\n" "$*" >> "$NPM_LOG"',
+            '  if [ "$1" = "publish" ]; then',
+            '    printf "%s\\n" "$CONFLICT_OUTPUT"',
+            "    return 1",
+            "  fi",
+            '  if [ "$1" = "view" ] && [ "$3" = "gitHead" ]; then',
+            '    if [ "$(grep -c gitHead "$NPM_LOG")" -le 2 ]; then return 1; fi',
+            '    printf "%s\\n" "$GITHUB_SHA"',
+            "    return 0",
+            "  fi",
+            '  if [ "$1" = "view" ]; then return 1; fi',
+            "}",
+            "sleep() { :; }",
+            `${publishFunction} "$PACKAGE_DIR"`,
+          ].join("\n"),
+          {
+            CONFLICT_OUTPUT,
+            GITHUB_SHA: "0".repeat(40),
+            NPM_LOG: npmLog,
+            NPM_PUBLISH_CONFLICT_ATTEMPTS: "1",
+            NPM_PUBLISH_CONFLICT_DELAY_SECONDS: "0",
+            PACKAGE_DIR: packageDir,
+            VERSION: "0.1.0",
+          },
+        );
+
+        assertEquals(output.code, 0, decoder.decode(output.stderr));
+        const publishes = (await Deno.readTextFile(npmLog)).trim().split("\n")
+          .filter((line) => line.startsWith("publish"));
+        assertEquals(publishes.length, 1);
       });
     });
   }

--- a/scripts/ci/publish-npm-packages.test.ts
+++ b/scripts/ci/publish-npm-packages.test.ts
@@ -1308,6 +1308,85 @@ describe("npm package publishing", () => {
     });
   }
 
+  // The conflicting write can also land between the pre-retry registry check
+  // and the retry publish. npm rejects that publish as an ordinary
+  // already-published error rather than a conflict, so the registry has to
+  // settle whether the earlier conflict published this commit.
+  const ALREADY_PUBLISHED_OUTPUT =
+    "npm error code E403\nnpm error 403 403 Forbidden - PUT https://registry.npmjs.org/@veryfront%2fext-llm-google - You cannot publish over the previously published versions: 0.1.0.";
+
+  for (
+    const publishFunction of [
+      "rc_publish_package_dir",
+      "release_publish_package_dir",
+    ]
+  ) {
+    it(`accepts an already-published retry rejection in ${publishFunction}`, async () => {
+      await withTempDir(async (stateDir) => {
+        const packageDir = `${stateDir}/package`;
+        const npmLog = `${stateDir}/npm.log`;
+        await Deno.mkdir(packageDir);
+        await Deno.writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({ name: "@veryfront/ext-llm-google" }),
+        );
+        await Deno.writeTextFile(npmLog, "");
+
+        const output = await runBash(
+          [
+            "set -euo pipefail",
+            'source "$SCRIPT_PATH"',
+            "npm() {",
+            '  printf "%s\\n" "$*" >> "$NPM_LOG"',
+            '  if [ "$1" = "publish" ]; then',
+            '    if [ "$(grep -c "^publish" "$NPM_LOG")" -eq 1 ]; then',
+            '      printf "%s\\n" "$CONFLICT_OUTPUT"',
+            "    else",
+            '      printf "%s\\n" "$ALREADY_PUBLISHED_OUTPUT"',
+            "    fi",
+            "    return 1",
+            "  fi",
+            // the conflicting write stays invisible until the retry races it
+            '  if [ "$1" = "view" ]; then',
+            '    if [ "$(grep -c "^publish" "$NPM_LOG")" -le 1 ]; then return 1; fi',
+            '    printf "%s\\n" "$GITHUB_SHA"',
+            "    return 0",
+            "  fi",
+            "  return 1",
+            "}",
+            `${publishFunction} "$PACKAGE_DIR"`,
+          ].join("\n"),
+          {
+            ALREADY_PUBLISHED_OUTPUT,
+            CONFLICT_OUTPUT,
+            GITHUB_SHA: "0".repeat(40),
+            NPM_LOG: npmLog,
+            NPM_PUBLISH_CONFLICT_DELAY_SECONDS: "0",
+            PACKAGE_DIR: packageDir,
+            VERSION: "0.1.0",
+          },
+        );
+
+        assertEquals(
+          output.code,
+          0,
+          `${publishFunction} must accept a raced already-published rejection whose gitHead matches this commit: ${
+            decoder.decode(output.stderr)
+          }`,
+        );
+        const publishes = (await Deno.readTextFile(npmLog)).trim().split("\n")
+          .filter((line) => line.startsWith("publish"));
+        assertEquals(
+          publishes.length,
+          2,
+          `${publishFunction} must stop publishing once the registry shows this commit, but issued: ${
+            publishes.join(", ")
+          }`,
+        );
+      });
+    });
+  }
+
   it("keeps the caller's errexit state so the release rerun recovery still runs", async () => {
     await withTempDir(async (stateDir) => {
       const packageDir = `${stateDir}/package`;

--- a/scripts/ci/publish-npm-packages.test.ts
+++ b/scripts/ci/publish-npm-packages.test.ts
@@ -1,7 +1,4 @@
-import {
-  assertEquals,
-  assertStringIncludes,
-} from "#veryfront/testing/assert.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { withTempDir } from "#veryfront/testing/deno-compat.ts";
 
@@ -237,9 +234,7 @@ describe("npm package publishing", () => {
 
   for (const publishFunction of ["run_rc_publish", "run_release_publish"]) {
     for (const artifactGitHead of [undefined, "f".repeat(40)]) {
-      const identityCase = artifactGitHead === undefined
-        ? "missing"
-        : "mismatched";
+      const identityCase = artifactGitHead === undefined ? "missing" : "mismatched";
       it(`blocks ${publishFunction} before publish when canonical tarball gitHead is ${identityCase}`, async () => {
         await withTempDir(async (stateDir) => {
           const packageDir = `${stateDir}/npm`;
@@ -1245,9 +1240,7 @@ describe("npm package publishing", () => {
       assertEquals(
         publishes.length,
         1,
-        `the retry must stop once the version exists, but issued: ${
-          publishes.join(", ")
-        }`,
+        `the retry must stop once the version exists, but issued: ${publishes.join(", ")}`,
       );
     });
   });
@@ -1441,6 +1434,83 @@ describe("npm package publishing", () => {
         "already exists, and gitHead matches this commit; continuing.",
       );
       assertStringIncludes(stdout, "RECOVERY_REACHED");
+    });
+  });
+
+  // npm's write side can reject a reused name/version while its read replica
+  // still reports the package absent. The RC path has no stable-release
+  // fallback, so it has to poll instead of trusting one absent lookup.
+  it("polls for metadata when a raced retry is rejected as already published", async () => {
+    await withTempDir(async (stateDir) => {
+      const packageDir = `${stateDir}/package`;
+      const npmLog = `${stateDir}/npm.log`;
+      await Deno.mkdir(packageDir);
+      await Deno.writeTextFile(
+        `${packageDir}/package.json`,
+        JSON.stringify({ name: "@veryfront/ext-llm-google" }),
+      );
+      await Deno.writeTextFile(npmLog, "");
+
+      const output = await runBash(
+        [
+          "set -euo pipefail",
+          'source "$SCRIPT_PATH"',
+          // wait_for_npm_git_head sleeps between polls; keep the test bounded
+          "sleep() { :; }",
+          "npm() {",
+          '  printf "%s\\n" "$*" >> "$NPM_LOG"',
+          '  if [ "$1" = "publish" ]; then',
+          '    if [ "$(grep -c "^publish" "$NPM_LOG")" -eq 1 ]; then',
+          '      printf "%s\\n" "$CONFLICT_OUTPUT"',
+          "      return 1",
+          "    fi",
+          // the conflicted write landed, so npm refuses the immutable version
+          '    printf "%s\\n" "npm error code E403"',
+          '    printf "%s\\n" "npm error 403 You cannot publish over the previously published versions: 0.1.0"',
+          "    return 1",
+          "  fi",
+          // the read replica never exposes the version itself
+          '  if [ "$1" = "view" ] && [ "$3" = "version" ]; then return 1; fi',
+          '  if [ "$1" = "view" ] && [ "$3" = "gitHead" ]; then',
+          '    if [ "$(grep -c gitHead "$NPM_LOG")" -le 3 ]; then return 1; fi',
+          '    printf "%s\\n" "$GITHUB_SHA"',
+          "    return 0",
+          "  fi",
+          "  return 1",
+          "}",
+          'rc_publish_package_dir "$PACKAGE_DIR"',
+        ].join("\n"),
+        {
+          CONFLICT_OUTPUT,
+          GITHUB_SHA: "0".repeat(40),
+          NPM_LOG: npmLog,
+          NPM_PUBLISH_CONFLICT_ATTEMPTS: "3",
+          NPM_PUBLISH_CONFLICT_DELAY_SECONDS: "0",
+          PACKAGE_DIR: packageDir,
+          VERSION: "0.1.0",
+        },
+      );
+
+      assertEquals(
+        output.code,
+        0,
+        `an already-published rejection after a handled conflict must poll for gitHead instead of failing the RC publish: ${
+          decoder.decode(output.stderr)
+        }`,
+      );
+      assertStringIncludes(
+        decoder.decode(output.stdout),
+        "landed despite an npm registry conflict",
+      );
+      const publishes = (await Deno.readTextFile(npmLog)).trim().split("\n")
+        .filter((line) => line.startsWith("publish"));
+      assertEquals(
+        publishes.length,
+        2,
+        `the RC publish must stop republishing once npm reports the version already exists, but issued: ${
+          publishes.join(", ")
+        }`,
+      );
     });
   });
 });

--- a/src/security/repository-hardening.test.ts
+++ b/src/security/repository-hardening.test.ts
@@ -46,9 +46,7 @@ function workflowStepBlock(workflow: string, stepName: string): string {
   assert(start >= 0, `expected ${stepName} step to exist`);
 
   const nextStep = workflow.indexOf("\n      - ", start + marker.length);
-  return nextStep === -1
-    ? workflow.slice(start)
-    : workflow.slice(start, nextStep);
+  return nextStep === -1 ? workflow.slice(start) : workflow.slice(start, nextStep);
 }
 
 describe("repository hardening", () => {
@@ -148,8 +146,7 @@ describe("repository hardening", () => {
     // access cannot be dropped at an individual call site. Collapse the
     // `\`-continuations first so each call site reads as one line.
     const flattenedPublishScript = publishScript.replace(/\\\n\s*/g, " ");
-    const publishInvocations =
-      flattenedPublishScript.match(/npm publish "[^\n]*/g) ?? [];
+    const publishInvocations = flattenedPublishScript.match(/npm publish "[^\n]*/g) ?? [];
     assertEquals(publishInvocations.length, 1);
     assert(
       publishInvocations[0].includes('npm publish "${PUBLISH_SPEC}" "$@"'),

--- a/src/security/repository-hardening.test.ts
+++ b/src/security/repository-hardening.test.ts
@@ -149,7 +149,7 @@ describe("repository hardening", () => {
     const publishInvocations = flattenedPublishScript.match(/npm publish "[^\n]*/g) ?? [];
     assertEquals(publishInvocations.length, 1);
     assert(
-      publishInvocations[0].includes('npm publish "${PUBLISH_SPEC}" "$@"'),
+      publishInvocations[0]?.includes('npm publish "${PUBLISH_SPEC}" "$@"'),
     );
 
     const retryCallSites = flattenedPublishScript.match(

--- a/src/security/repository-hardening.test.ts
+++ b/src/security/repository-hardening.test.ts
@@ -46,7 +46,9 @@ function workflowStepBlock(workflow: string, stepName: string): string {
   assert(start >= 0, `expected ${stepName} step to exist`);
 
   const nextStep = workflow.indexOf("\n      - ", start + marker.length);
-  return nextStep === -1 ? workflow.slice(start) : workflow.slice(start, nextStep);
+  return nextStep === -1
+    ? workflow.slice(start)
+    : workflow.slice(start, nextStep);
 }
 
 describe("repository hardening", () => {
@@ -142,15 +144,30 @@ describe("repository hardening", () => {
 
     assertEquals(publishScript.includes("NPM_TOKEN"), false);
     assertEquals(publishScript.includes("NODE_AUTH_TOKEN"), false);
+    // Every publish flows through one retry helper, so provenance and public
+    // access cannot be dropped at an individual call site. Collapse the
+    // `\`-continuations first so each call site reads as one line.
+    const flattenedPublishScript = publishScript.replace(/\\\n\s*/g, " ");
+    const publishInvocations =
+      flattenedPublishScript.match(/npm publish "[^\n]*/g) ?? [];
+    assertEquals(publishInvocations.length, 1);
     assert(
-      publishScript.includes(
-        'npm publish "${PUBLISH_SPEC}" --provenance --access public --tag rc',
+      publishInvocations[0].includes('npm publish "${PUBLISH_SPEC}" "$@"'),
+    );
+
+    const retryCallSites = flattenedPublishScript.match(
+      /publish_npm_package_with_retry "\$\{PACKAGE_NAME\}".*/g,
+    ) ?? [];
+    assertEquals(retryCallSites.length, 2);
+    assert(
+      retryCallSites.every((callSite) =>
+        callSite.includes("--provenance") &&
+        callSite.includes("--access public")
       ),
     );
-    assert(
-      publishScript.includes(
-        'npm publish "${PUBLISH_SPEC}" --provenance --access public 2>&1',
-      ),
+    assertEquals(
+      retryCallSites.filter((callSite) => callSite.includes("--tag rc")).length,
+      1,
     );
   });
 


### PR DESCRIPTION
## Problem

`prerelease` failed on `main` and took `quality gate (registry)` with it — [run 32840051063](https://github.com/veryfront/veryfront-code/actions/runs/32840051063).

```
npm error code E409
npm error 409 Conflict - PUT https://registry.npmjs.org/@veryfront%2fext-llm-google
  - Failed to save packument. A common cause is if you try to publish a new
    package before the previous package has been fully processed.
```

Publishing 31 packages back to back outruns npm's packument writes. Neither publish path retried, so one transient conflict aborted the job and left RC `0.1.1253-rc.15082` half-published.

## Fix

`publish_npm_package_with_retry` wraps both the RC and stable publish paths:

- Retries a conflicting publish — bounded attempts with a settle delay between them.
- **Rechecks the registry before retrying.** A 409 can still have landed; if `gitHead` already matches the release commit the package is accepted rather than republished.
- A version that exists for a *different* commit still fails immediately.
- Non-conflict failures are not retried at all.

Attempts and delay are overridable via `NPM_PUBLISH_CONFLICT_ATTEMPTS` / `NPM_PUBLISH_CONFLICT_DELAY_SECONDS` so the tests run instantly.

## Verification

Written test-first — the five new cases were confirmed red against the current publish path before the fix, and the negative control (`does not retry a non-conflict npm publish failure`) passed both before and after, so the suite is not vacuously failing.

- `scripts/ci/publish-npm-packages.test.ts`: 26 steps, 0 failures.
- CI contract suites (`registry-release-*`, `npm-compatibility-artifact`, `merge-quality-gate-workflow`): 6 passed, 76 steps, 0 failures.
- `deno task lint:ci-typescript`: exit 0.

## Note

The gates behaved correctly during the failure: `quality gate (registry)` still ran and reported, and all three downstream deploy dispatches stayed blocked. RC `0.1.1253-rc.15082` is permanently partial — npm versions are immutable, so the next run number supersedes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved npm package publishing reliability by retrying transient registry conflicts.
  - Confirms whether a conflicting version was successfully published before retrying, preventing unnecessary duplicate publishes.
  - Stops retrying after a configurable number of attempts and delay.
  - Preserves recovery behavior for release reruns while avoiding retries for unrelated publishing errors.

- **Tests**
  - Added comprehensive coverage for conflict handling, retry limits, provenance checks, and failure scenarios.
  - Strengthened validation of secure publishing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->