### PR TITLE
fix(rendering): isolate layout discovery cache

### DIFF
--- a/src/rendering/factories/service-factories.ts
+++ b/src/rendering/factories/service-factories.ts
@@ -24,6 +24,7 @@ export function createLayoutCollector(
   return new LayoutCollector({
     projectDir: ctx.projectDir,
     projectId: ctx.projectId,
+    contentSourceId: ctx.contentSourceId,
     adapter: ctx.adapter,
     config: ctx.config,
     compileMDX,

--- a/src/rendering/layouts/layout-collector.test.ts
+++ b/src/rendering/layouts/layout-collector.test.ts
@@ -8,6 +8,7 @@ import {
   LayoutCollector,
   resolveLayoutRouterRootDir,
 } from "./layout-collector.ts";
+import { clearLayoutDiscoveryCache } from "./utils/discovery.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { EntityInfo, MdxBundle } from "#veryfront/types";
@@ -59,6 +60,69 @@ function createPageInfo(path: string, frontmatter: Record<string, unknown> = {})
 }
 
 describe("LayoutCollector", () => {
+  it("does not reuse layout discovery across projects that share virtual paths", async () => {
+    clearLayoutDiscoveryCache();
+    const sharedOptions = {
+      projectDir: "/",
+      contentSourceId: "preview-main",
+      config: {} as VeryfrontConfig,
+      compileMDX: () => Promise.resolve(LAYOUT_BUNDLE),
+    };
+    const projectA = new LayoutCollector({
+      ...sharedOptions,
+      projectId: "project-a",
+      adapter: createCollectorAdapter({
+        "/app/layout.tsx": "export default function Layout({ children }) { return children; }",
+      }),
+    });
+    const projectB = new LayoutCollector({
+      ...sharedOptions,
+      projectId: "project-b",
+      adapter: createCollectorAdapter({}),
+    });
+
+    const projectAResult = await projectA.collectLayouts(createPageInfo("/app/page.tsx"));
+    const projectBResult = await projectB.collectLayouts(createPageInfo("/app/page.tsx"));
+
+    assertEquals(projectAResult.nestedLayouts.map((layout) => layout.path), ["/app/layout.tsx"]);
+    assertEquals(
+      projectBResult.nestedLayouts,
+      [],
+      "a project without app/layout.tsx must not receive another project's cached layout",
+    );
+  });
+
+  it("does not reuse layout discovery across content source snapshots", async () => {
+    clearLayoutDiscoveryCache();
+    const sharedOptions = {
+      projectDir: "/",
+      projectId: "project-a",
+      config: {} as VeryfrontConfig,
+      compileMDX: () => Promise.resolve(LAYOUT_BUNDLE),
+    };
+    const releaseA = new LayoutCollector({
+      ...sharedOptions,
+      contentSourceId: "release-a",
+      adapter: createCollectorAdapter({
+        "/app/layout.tsx": "export default function Layout({ children }) { return children; }",
+      }),
+    });
+    const releaseB = new LayoutCollector({
+      ...sharedOptions,
+      contentSourceId: "release-b",
+      adapter: createCollectorAdapter({}),
+    });
+
+    await releaseA.collectLayouts(createPageInfo("/app/page.tsx"));
+    const releaseBResult = await releaseB.collectLayouts(createPageInfo("/app/page.tsx"));
+
+    assertEquals(
+      releaseBResult.nestedLayouts,
+      [],
+      "a source snapshot without app/layout.tsx must not receive a cached layout from another release",
+    );
+  });
+
   it("resolves configured App Router and Pages Router roots", () => {
     const config = {
       directories: { app: "src/site", pages: "src/content" },

--- a/src/rendering/layouts/layout-collector.test.ts
+++ b/src/rendering/layouts/layout-collector.test.ts
@@ -23,6 +23,7 @@ const LAYOUT_BUNDLE = { compiledCode: "LAYOUT_CODE" } as unknown as MdxBundle;
 function createCollectorAdapter(
   files: Record<string, string>,
   statPaths: string[] = [],
+  snapshotVersion?: { value: number },
 ): RuntimeAdapter {
   return {
     fs: {
@@ -41,6 +42,9 @@ function createCollectorAdapter(
       writeFile: () => Promise.resolve(),
       mkdir: () => Promise.resolve(),
       remove: () => Promise.resolve(),
+      getSourceSnapshotVersion: snapshotVersion
+        ? () => Promise.resolve(snapshotVersion.value)
+        : undefined,
     },
     env: { get: () => undefined },
   } as unknown as RuntimeAdapter;
@@ -120,6 +124,34 @@ describe("LayoutCollector", () => {
       releaseBResult.nestedLayouts,
       [],
       "a source snapshot without app/layout.tsx must not receive a cached layout from another release",
+    );
+  });
+
+  it("invalidates mutable preview discovery when the source snapshot changes", async () => {
+    clearLayoutDiscoveryCache();
+    const files: Record<string, string> = {
+      "/app/layout.tsx": "export default function Layout({ children }) { return children; }",
+    };
+    const snapshot = { value: 1 };
+    const collector = new LayoutCollector({
+      projectDir: "/",
+      projectId: "project-a",
+      contentSourceId: "preview-main",
+      adapter: createCollectorAdapter(files, [], snapshot),
+      config: {} as VeryfrontConfig,
+      compileMDX: () => Promise.resolve(LAYOUT_BUNDLE),
+    });
+
+    const initial = await collector.collectLayouts(createPageInfo("/app/page.tsx"));
+    delete files["/app/layout.tsx"];
+    snapshot.value = 2;
+    const afterEdit = await collector.collectLayouts(createPageInfo("/app/page.tsx"));
+
+    assertEquals(initial.nestedLayouts.map((layout) => layout.path), ["/app/layout.tsx"]);
+    assertEquals(
+      afterEdit.nestedLayouts,
+      [],
+      "a new mutable source snapshot must not reuse the previous layout discovery",
     );
   });
 

--- a/src/rendering/layouts/layout-collector.ts
+++ b/src/rendering/layouts/layout-collector.ts
@@ -1,5 +1,5 @@
 import { isAbsolute, join, normalize } from "#veryfront/compat/path";
-import { memoizeHash, rendererLogger } from "#veryfront/utils";
+import { rendererLogger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { EntityInfo, LayoutItem, MdxBundle } from "#veryfront/types";
 import type { VeryfrontConfig } from "#veryfront/config";
@@ -563,8 +563,12 @@ export class LayoutCollector {
       this.config,
     );
 
-    const contentSourceId = this.contentSourceId ?? pageInfo.bundle?.hash ??
-      memoizeHash(pageInfo.entity.content);
+    const snapshotVersion = await this.adapter.fs.getSourceSnapshotVersion?.();
+    const contentSourceId = this.contentSourceId === undefined
+      ? snapshotVersion === undefined ? undefined : `snapshot-${snapshotVersion}`
+      : snapshotVersion === undefined
+      ? this.contentSourceId
+      : `${this.contentSourceId}:snapshot-${snapshotVersion}`;
 
     return this.collectLayoutsUnified(pageFilePath, rootDir, contentSourceId);
   }
@@ -572,7 +576,7 @@ export class LayoutCollector {
   private async collectLayoutsUnified(
     pageFilePath: string,
     rootDir: string,
-    contentSourceId: string,
+    contentSourceId: string | undefined,
   ): Promise<LayoutItem[]> {
     logger.debug("collectLayoutsUnified", {
       pageFilePath,
@@ -586,7 +590,7 @@ export class LayoutCollector {
       this.projectDir,
       this.adapter,
       {
-        projectId: this.projectId ?? this.projectDir,
+        projectId: this.projectId,
         contentSourceId,
       },
     );

--- a/src/rendering/layouts/layout-collector.ts
+++ b/src/rendering/layouts/layout-collector.ts
@@ -592,6 +592,7 @@ export class LayoutCollector {
       {
         projectId: this.projectId,
         contentSourceId,
+        cache: this.projectId !== undefined && contentSourceId !== undefined,
       },
     );
 

--- a/src/rendering/layouts/layout-collector.ts
+++ b/src/rendering/layouts/layout-collector.ts
@@ -1,5 +1,5 @@
 import { isAbsolute, join, normalize } from "#veryfront/compat/path";
-import { rendererLogger } from "#veryfront/utils";
+import { memoizeHash, rendererLogger } from "#veryfront/utils";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { EntityInfo, LayoutItem, MdxBundle } from "#veryfront/types";
 import type { VeryfrontConfig } from "#veryfront/config";
@@ -318,6 +318,7 @@ export interface LayoutCollectionResult {
 export interface LayoutCollectorOptions {
   projectDir: string;
   projectId?: string;
+  contentSourceId?: string;
   adapter: RuntimeAdapter;
   config: VeryfrontConfig;
   compileMDX: (
@@ -330,6 +331,7 @@ export interface LayoutCollectorOptions {
 export class LayoutCollector {
   private projectDir: string;
   private projectId?: string;
+  private contentSourceId?: string;
   private adapter: RuntimeAdapter;
   private config: VeryfrontConfig;
   private compileMDX: (
@@ -341,6 +343,7 @@ export class LayoutCollector {
   constructor(options: LayoutCollectorOptions) {
     this.projectDir = options.projectDir;
     this.projectId = options.projectId;
+    this.contentSourceId = options.contentSourceId;
     this.adapter = options.adapter;
     this.config = options.config;
     this.compileMDX = options.compileMDX;
@@ -560,12 +563,16 @@ export class LayoutCollector {
       this.config,
     );
 
-    return this.collectLayoutsUnified(pageFilePath, rootDir);
+    const contentSourceId = this.contentSourceId ?? pageInfo.bundle?.hash ??
+      memoizeHash(pageInfo.entity.content);
+
+    return this.collectLayoutsUnified(pageFilePath, rootDir, contentSourceId);
   }
 
   private async collectLayoutsUnified(
     pageFilePath: string,
     rootDir: string,
+    contentSourceId: string,
   ): Promise<LayoutItem[]> {
     logger.debug("collectLayoutsUnified", {
       pageFilePath,
@@ -578,6 +585,10 @@ export class LayoutCollector {
       rootDir,
       this.projectDir,
       this.adapter,
+      {
+        projectId: this.projectId ?? this.projectDir,
+        contentSourceId,
+      },
     );
 
     if (nestedLayouts.length > 0) {

--- a/src/rendering/layouts/utils/discovery.test.ts
+++ b/src/rendering/layouts/utils/discovery.test.ts
@@ -61,12 +61,14 @@ describe("rendering/layouts/utils/discovery", () => {
         "/project-a",
         "/project-a",
         adapterA,
+        { projectId: "project-a", contentSourceId: "snapshot-a" },
       );
       await discoverNestedLayouts(
         "/project-b/pages/index.mdx",
         "/project-b",
         "/project-b",
         adapterB,
+        { projectId: "project-b", contentSourceId: "snapshot-b" },
       );
       assertEquals(
         getLayoutDiscoveryCacheStats().size,
@@ -89,6 +91,7 @@ describe("rendering/layouts/utils/discovery", () => {
         "/project-a",
         "/project-a",
         adapterA,
+        { projectId: "project-a", contentSourceId: "snapshot-a" },
       );
       assertEquals(
         counterA.statCalls > statCallsA,
@@ -101,6 +104,7 @@ describe("rendering/layouts/utils/discovery", () => {
         "/project-b",
         "/project-b",
         adapterB,
+        { projectId: "project-b", contentSourceId: "snapshot-b" },
       );
       assertEquals(
         counterB.statCalls,
@@ -128,6 +132,7 @@ describe("rendering/layouts/utils/discovery", () => {
         "/project",
         "/project",
         adapter,
+        { projectId: "project", contentSourceId: "snapshot-empty" },
       );
       assertEquals(layouts.length, 0);
     });
@@ -141,6 +146,7 @@ describe("rendering/layouts/utils/discovery", () => {
         "/project",
         "/project",
         adapter,
+        { projectId: "project", contentSourceId: "snapshot-mdx" },
       );
       assertEquals(layouts.length, 1);
       assertEquals(layouts[0].kind, "mdx");
@@ -156,6 +162,7 @@ describe("rendering/layouts/utils/discovery", () => {
         "/project",
         "/project",
         adapter,
+        { projectId: "project", contentSourceId: "snapshot-tsx" },
       );
       assertEquals(layouts.length, 1);
       assertEquals(layouts[0].kind, "tsx");
@@ -180,6 +187,7 @@ describe("rendering/layouts/utils/discovery", () => {
         "/project",
         "/project",
         adapter,
+        { projectId: "project", contentSourceId: "snapshot-root" },
       );
       assertEquals(layouts.length, 1);
       assertEquals(layouts[0].path, "/project/layout.mdx");
@@ -197,6 +205,7 @@ describe("rendering/layouts/utils/discovery", () => {
         "/project",
         "/project",
         adapter,
+        { projectId: "project", contentSourceId: "snapshot-ancestors" },
       );
       assertEquals(
         layouts.map((l) => l.path),
@@ -221,6 +230,7 @@ describe("rendering/layouts/utils/discovery", () => {
         "/project",
         "/project",
         adapter,
+        { projectId: "project", contentSourceId: "snapshot-cache" },
       );
       const statCallsAfterFirst = counter.statCalls;
       const layouts2 = await discoverNestedLayouts(
@@ -228,6 +238,7 @@ describe("rendering/layouts/utils/discovery", () => {
         "/project",
         "/project",
         adapter,
+        { projectId: "project", contentSourceId: "snapshot-cache" },
       );
       assertEquals(layouts1.length, layouts2.length);
       assertEquals(
@@ -252,6 +263,7 @@ describe("rendering/layouts/utils/discovery", () => {
         "/project",
         "/project",
         adapter,
+        { projectId: "project", contentSourceId: "snapshot-nested" },
       );
       assertEquals(Array.isArray(layouts), true);
     });

--- a/src/rendering/layouts/utils/discovery.ts
+++ b/src/rendering/layouts/utils/discovery.ts
@@ -15,6 +15,11 @@ interface CacheEntry {
   projectDir: string;
 }
 
+export interface LayoutDiscoveryIdentity {
+  projectId: string;
+  contentSourceId: string;
+}
+
 const MAX_CACHE_SIZE = 500;
 const layoutDiscoveryCache = new LRUCache<string, CacheEntry>({
   maxEntries: MAX_CACHE_SIZE,
@@ -57,14 +62,26 @@ export async function discoverNestedLayouts(
   rootDir: string,
   projectDir: string,
   adapter: RuntimeAdapter,
+  identity: LayoutDiscoveryIdentity = {
+    projectId: projectDir,
+    contentSourceId: "mutable",
+  },
 ): Promise<LayoutItem[]> {
-  const key = simpleHash(projectDir, pageFilePath, rootDir);
+  const key = simpleHash(
+    identity.projectId,
+    identity.contentSourceId,
+    projectDir,
+    pageFilePath,
+    rootDir,
+  );
   const cached = layoutDiscoveryCache.get(key);
   if (cached) {
     cached.accessedAt = Date.now();
     discoveryLog.debug("Layout cache HIT", {
       pageFilePath,
       rootDir,
+      projectId: identity.projectId,
+      contentSourceId: identity.contentSourceId,
       layoutCount: cached.layouts.length,
       layoutPaths: cached.layouts.map((l) => l.path),
     });
@@ -75,6 +92,8 @@ export async function discoverNestedLayouts(
     pageFilePath,
     rootDir,
     projectDir,
+    projectId: identity.projectId,
+    contentSourceId: identity.contentSourceId,
   });
 
   const layouts = await discoverNestedLayoutsImpl(pageFilePath, rootDir, adapter);

--- a/src/rendering/layouts/utils/discovery.ts
+++ b/src/rendering/layouts/utils/discovery.ts
@@ -18,9 +18,13 @@ interface CacheEntry {
 export interface LayoutDiscoveryIdentity {
   projectId?: string;
   contentSourceId?: string;
+  /** Explicitly disable the legacy adapter-scoped cache for mutable callers. */
+  cache?: boolean;
 }
 
 const MAX_CACHE_SIZE = 500;
+const legacyAdapterIds = new WeakMap<object, number>();
+let nextLegacyAdapterId = 1;
 const layoutDiscoveryCache = new LRUCache<string, CacheEntry>({
   maxEntries: MAX_CACHE_SIZE,
 });
@@ -64,10 +68,21 @@ export async function discoverNestedLayouts(
   adapter: RuntimeAdapter,
   identity?: LayoutDiscoveryIdentity,
 ): Promise<LayoutItem[]> {
-  // Discovery depends on the complete source snapshot, not just the page.
-  // Callers without both identities must bypass the process-global cache rather
-  // than risk serving an ancestor layout from another mutable source.
-  const key = identity?.projectId && identity.contentSourceId
+  // Production collectors pass project and source identities. Legacy direct
+  // callers retain adapter-scoped caching for compatibility; mutable collectors
+  // pass cache:false when no trustworthy snapshot identity is available.
+  let legacyAdapterId: number | undefined;
+  if (identity === undefined) {
+    legacyAdapterId = legacyAdapterIds.get(adapter);
+    if (legacyAdapterId === undefined) {
+      legacyAdapterId = nextLegacyAdapterId++;
+      legacyAdapterIds.set(adapter, legacyAdapterId);
+    }
+  }
+
+  const key = identity?.cache === false
+    ? null
+    : identity?.projectId && identity.contentSourceId
     ? simpleHash(
       identity.projectId,
       identity.contentSourceId,
@@ -75,6 +90,8 @@ export async function discoverNestedLayouts(
       pageFilePath,
       rootDir,
     )
+    : identity === undefined
+    ? simpleHash(`legacy-adapter-${legacyAdapterId}`, projectDir, pageFilePath, rootDir)
     : null;
   const cached = key ? layoutDiscoveryCache.get(key) : undefined;
   if (cached) {

--- a/src/rendering/layouts/utils/discovery.ts
+++ b/src/rendering/layouts/utils/discovery.ts
@@ -16,8 +16,8 @@ interface CacheEntry {
 }
 
 export interface LayoutDiscoveryIdentity {
-  projectId: string;
-  contentSourceId: string;
+  projectId?: string;
+  contentSourceId?: string;
 }
 
 const MAX_CACHE_SIZE = 500;
@@ -62,26 +62,28 @@ export async function discoverNestedLayouts(
   rootDir: string,
   projectDir: string,
   adapter: RuntimeAdapter,
-  identity: LayoutDiscoveryIdentity = {
-    projectId: projectDir,
-    contentSourceId: "mutable",
-  },
+  identity?: LayoutDiscoveryIdentity,
 ): Promise<LayoutItem[]> {
-  const key = simpleHash(
-    identity.projectId,
-    identity.contentSourceId,
-    projectDir,
-    pageFilePath,
-    rootDir,
-  );
-  const cached = layoutDiscoveryCache.get(key);
+  // Discovery depends on the complete source snapshot, not just the page.
+  // Callers without both identities must bypass the process-global cache rather
+  // than risk serving an ancestor layout from another mutable source.
+  const key = identity?.projectId && identity.contentSourceId
+    ? simpleHash(
+      identity.projectId,
+      identity.contentSourceId,
+      projectDir,
+      pageFilePath,
+      rootDir,
+    )
+    : null;
+  const cached = key ? layoutDiscoveryCache.get(key) : undefined;
   if (cached) {
     cached.accessedAt = Date.now();
     discoveryLog.debug("Layout cache HIT", {
       pageFilePath,
       rootDir,
-      projectId: identity.projectId,
-      contentSourceId: identity.contentSourceId,
+      projectId: identity?.projectId,
+      contentSourceId: identity?.contentSourceId,
       layoutCount: cached.layouts.length,
       layoutPaths: cached.layouts.map((l) => l.path),
     });
@@ -92,8 +94,8 @@ export async function discoverNestedLayouts(
     pageFilePath,
     rootDir,
     projectDir,
-    projectId: identity.projectId,
-    contentSourceId: identity.contentSourceId,
+    projectId: identity?.projectId,
+    contentSourceId: identity?.contentSourceId,
   });
 
   const layouts = await discoverNestedLayoutsImpl(pageFilePath, rootDir, adapter);
@@ -104,7 +106,9 @@ export async function discoverNestedLayouts(
     layoutPaths: layouts.map((l) => l.path),
   });
 
-  layoutDiscoveryCache.set(key, { layouts, accessedAt: Date.now(), projectDir });
+  if (key) {
+    layoutDiscoveryCache.set(key, { layouts, accessedAt: Date.now(), projectDir });
+  }
 
   return layouts;
 }

--- a/src/rendering/orchestrator/lifecycle.ts
+++ b/src/rendering/orchestrator/lifecycle.ts
@@ -171,6 +171,7 @@ export class RendererLifecycle {
     const layoutCollector = new LayoutCollector({
       projectDir,
       projectId: this.projectId,
+      contentSourceId: this.contentSourceId,
       adapter: this.adapter,
       config,
       compileMDX: compileMDXProxy,


### PR DESCRIPTION
## Summary

Hosted projects share a virtual `/app` directory, but layout discovery used a process-global cache keyed only by virtual paths. A project with `app/layout.tsx` could therefore make another project without that file render with a stale layout and return intermittent 500s.

This change namespaces discovery by project identity and content-source identity, includes the remote filesystem snapshot generation for mutable previews, threads those values through the renderer lifecycle and layout collector, and bypasses the global cache when a direct collector cannot provide a trustworthy identity.

## Verification

- Regression coverage for cross-project, cross-release, and same-preview-generation isolation
- Focused layout collector suites: 88 steps, 0 failed on the pinned verification environment
- `deno task typecheck` in the pinned verification environment
- format and diff checks clean

The local pre-push hook reports eight unrelated baseline Deno type errors under the installed toolchain; the focused suites and pinned typecheck are green.
