### PR TITLE
fix(build): key the chunk manifest by route path, not source filename

### DIFF
--- a/src/build/bundler/code-splitter/manifest-builder.ts
+++ b/src/build/bundler/code-splitter/manifest-builder.ts
@@ -79,6 +79,22 @@ export async function getChunkInfo(
   };
 }
 
+/**
+ * Recovers the esbuild entry name from an entry output path relative to `outDir`.
+ *
+ * `createBuildContext` sets `entryNames: "[name]"`, so an entry declared as
+ * `name` is written to `<outDir>/<name>.js`. That makes the output path the
+ * reliable link back to the name a route was registered under in `routeMap`.
+ *
+ * The metafile's `entryPoint` cannot serve this purpose. esbuild reports it
+ * relative to the process working directory rather than as the absolute path
+ * the route declared, and its basename discards the entry name outright, so
+ * `app/page.tsx` reduces to `page` for every App Router route.
+ */
+function entryNameFromOutputPath(relativeOutputPath: string): string {
+  return relativeOutputPath.replace(/\.js$/, "");
+}
+
 /** Adds a route entry to the manifest */
 function addRouteToManifest(
   manifest: ChunkManifest,
@@ -89,7 +105,7 @@ function addRouteToManifest(
 ): void {
   if (!output.entryPoint) return;
 
-  const entryName = extractEntryName(output.entryPoint);
+  const entryName = entryNameFromOutputPath(relativePath);
   const routePath = routeMap.get(entryName) ?? `/${entryName}`;
 
   manifest.routes[routePath] = {

--- a/src/build/bundler/code-splitter/splitter.test.ts
+++ b/src/build/bundler/code-splitter/splitter.test.ts
@@ -13,6 +13,7 @@ import {
 } from "#veryfront/testing/deno-compat.ts";
 import { type BuildContext, stop } from "veryfront/extensions/bundler";
 import { CodeSplitter, rebuildAndDispose } from "./splitter.ts";
+import { generatePreloadLinks } from "./index.ts";
 
 async function readJsOutputs(dir: string): Promise<string> {
   let contents = "";
@@ -183,9 +184,9 @@ describe("build/bundler/code-splitter/splitter", () => {
 
         const routeEntries = Object.entries(result.manifest.routes);
         assertEquals(
-          routeEntries.length,
-          1,
-          "the split must map the built route in its chunk manifest",
+          routeEntries.map(([routePath]) => routePath),
+          ["/"],
+          "the split must map the built route under its route path, not its source filename",
         );
         const route = routeEntries[0]?.[1];
         assertExists(route, "the mapped route must carry chunk metadata");
@@ -213,6 +214,82 @@ describe("build/bundler/code-splitter/splitter", () => {
         assertEquals(browserOutputs.includes("createHash"), false);
         assertEquals(browserOutputs.includes("hashSecret"), false);
         assertEquals(browserOutputs.includes("notFound"), false);
+      } finally {
+        await stop();
+        if (previousCodeParser) register("CodeParser", previousCodeParser);
+        else unregister("CodeParser");
+        await remove(projectDir, { recursive: true });
+        await remove(outDir, { recursive: true });
+      }
+    });
+
+    it("keys App Router and nested routes by route path so preload hints resolve", async () => {
+      const projectDir = await makeTempDir({ prefix: "vf-splitter-routes-" });
+      const outDir = await makeTempDir({ prefix: "vf-splitter-routes-out-" });
+      const previousCodeParser = tryResolve<unknown>("CodeParser");
+      unregister("CodeParser");
+
+      try {
+        await mkdir(join(projectDir, "app/blog"), { recursive: true });
+        await mkdir(join(projectDir, "app/docs"), { recursive: true });
+        await writeTextFile(
+          join(projectDir, "app/page.tsx"),
+          `export default function Page() { return "home"; }`,
+        );
+        await writeTextFile(
+          join(projectDir, "app/blog/page.tsx"),
+          `export default function BlogPage() { return "blog"; }`,
+        );
+        await writeTextFile(
+          join(projectDir, "app/docs/page.tsx"),
+          `export default function DocsPage() { return "docs"; }`,
+        );
+        await writeTextFile(
+          join(projectDir, "app/blog/post.tsx"),
+          `export default function Post() { return "post"; }`,
+        );
+
+        const splitter = new CodeSplitter({
+          projectDir,
+          outDir,
+          mode: "production",
+          moduleResolution: "bundled",
+          routes: [
+            // Three App Router pages whose source basenames all reduce to "page",
+            // plus a nested route whose entry name is dashed rather than nested.
+            { path: "/", file: join(projectDir, "app/page.tsx"), name: "index" },
+            { path: "/blog", file: join(projectDir, "app/blog/page.tsx"), name: "blog" },
+            { path: "/docs", file: join(projectDir, "app/docs/page.tsx"), name: "docs" },
+            { path: "/blog/post", file: join(projectDir, "app/blog/post.tsx"), name: "blog-post" },
+          ],
+        });
+
+        const { manifest } = await splitter.split();
+
+        assertEquals(
+          Object.keys(manifest.routes).sort(),
+          ["/", "/blog", "/blog/post", "/docs"],
+          "each route must be keyed by its own path; App Router pages must not collapse onto a single /page key",
+        );
+        assertEquals(
+          manifest.routes["/blog"]?.entry,
+          "blog.js",
+          "a route must point at the chunk built from its own entry",
+        );
+        assertEquals(
+          manifest.routes["/blog/post"]?.entry,
+          "blog-post.js",
+          "a nested route must point at the chunk built from its own entry",
+        );
+
+        for (const routePath of ["/", "/blog", "/blog/post", "/docs"]) {
+          const links = generatePreloadLinks(manifest, routePath, "/_veryfront/chunks");
+          assertEquals(
+            links.includes("modulepreload"),
+            true,
+            `route ${routePath} must ship a modulepreload hint rather than resolving to an empty string`,
+          );
+        }
       } finally {
         await stop();
         if (previousCodeParser) register("CodeParser", previousCodeParser);


### PR DESCRIPTION
## Description

`buildManifest` published every route under a key derived from the entry point's **source basename**, while the `routeMap` it consults is keyed by **entry name**. `extractEntryName` is `entryPoint.split("/").pop()`, so it discards the directory:

- `{ path: "/", file: "app/page.tsx", name: "index" }` → `routeMap` holds `"index" -> "/"`, but the lookup used `"page"`. Manifest key became `/page`.
- `{ path: "/blog/post", slug: "blog/post" }` → entry name `blog-post`, lookup used `"post"`. Manifest key became `/post`.

At runtime `generatePreloadLinks(manifest, "/blog/post")` found no matching key and returned `""`, so these routes shipped with **no modulepreload and no stylesheet preload hints**. The chunk artifacts were written correctly, so nothing errored and the performance loss was silent.

### Worse than a wrong key

Basename collisions also **drop routes**. Three App Router pages under `app/`, `app/blog/` and `app/docs/` all reduce to `page` and overwrite each other, leaving one `/page` entry and no trace of the other two. Reproduced against a real esbuild split before the fix:

```
each route must be keyed by its own path ...
  actual:   ["/page"]
  expected: ["/", "/blog", "/blog/post", "/docs"]
```

### Fix

Derive the entry name from the entry's **output path relative to `outDir`**. `createBuildContext` sets `entryNames: "[name]"`, so an entry declared as `name` is written to `<outDir>/<name>.js` — that makes the output path the reliable link back to `routeMap`, and `addRouteToManifest` already receives it as `relativePath`.

The issue suggested threading the entry name through from `createEntryPoints` and matching on the source file. That route was explored and rejected: the metafile's `entryPoint` is reported **relative to the process working directory** (`../../var/folders/.../app/page.tsx`), so it never compares equal to the absolute path the route declared, and on macOS the `/var` → `/private/var` symlink defeats even a `resolve()`-normalised comparison. The output path has no such ambiguity.

## Related Issue(s)

Fixes #4052

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have added tests that prove my fix is effective

## Testing

The new test in `splitter.test.ts` runs a **real esbuild split** (no stub) over three colliding `page.tsx` sources plus a nested route, and asserts both the manifest keys and that `generatePreloadLinks` actually emits a `modulepreload` for each. It was verified to fail before the fix and pass after.

The pre-existing assertion in that file was also strengthened: it asserted only `routeEntries.length === 1`, which passed while the sole key was the wrong `/page`. It now asserts the key itself.

Route-keying assertions were deliberately kept in `splitter.test.ts` rather than added to `manifest-builder.test.ts`: exercising `buildManifest` requires real chunk files on disk (`getChunkInfo` reads them), which would have made a hermetic unit file effect-bearing and grown the `lint:test-semantic-dispositions` baseline. `splitter.test.ts` is already dispositioned for filesystem effects.

```
deno task test:file src/build/            67 passed (891 steps) | 0 failed
deno check src/build/index.ts src/build/production-build/index.ts
deno task lint:test-semantic-dispositions / lint:anti-slop / lint:module-boundaries / lint:dependency-boundaries
deno fmt --check, deno lint
```

## Note for reviewers

`extractEntryName` is now unused by the route-keying path. It is left exported and tested since it is a correct utility for its stated name and removing a barrel export is outside this fix's scope, but it is worth deciding whether it should survive.