### PR TITLE
fix(modules): skip the __esModule marker when extracting a component

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -84,6 +84,7 @@
     "npm:protobufjs@7.6.5": "7.6.5",
     "npm:purgecss@8.0.0": "8.0.0",
     "npm:react-dom@19.2.4": "19.2.4_react@19.2.4",
+    "npm:react-is@19.2.4": "19.2.4",
     "npm:react@19.2.4": "19.2.4",
     "npm:redis@5.11.0": "5.11.0",
     "npm:reflect-metadata@0.2.2": "0.2.2",
@@ -4815,6 +4816,9 @@
         "react",
         "scheduler"
       ]
+    },
+    "react-is@19.2.4": {
+      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA=="
     },
     "react@19.2.4": {
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="

--- a/deno.lock
+++ b/deno.lock
@@ -84,6 +84,7 @@
     "npm:protobufjs@7.6.5": "7.6.5",
     "npm:purgecss@8.0.0": "8.0.0",
     "npm:react-dom@19.2.4": "19.2.4_react@19.2.4",
+    "npm:react-is@18.3.1": "18.3.1",
     "npm:react-is@19.2.4": "19.2.4",
     "npm:react@19.2.4": "19.2.4",
     "npm:redis@5.11.0": "5.11.0",
@@ -4816,6 +4817,9 @@
         "react",
         "scheduler"
       ]
+    },
+    "react-is@18.3.1": {
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "react-is@19.2.4": {
       "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA=="

--- a/deno.lock
+++ b/deno.lock
@@ -84,8 +84,6 @@
     "npm:protobufjs@7.6.5": "7.6.5",
     "npm:purgecss@8.0.0": "8.0.0",
     "npm:react-dom@19.2.4": "19.2.4_react@19.2.4",
-    "npm:react-is@18.3.1": "18.3.1",
-    "npm:react-is@19.2.4": "19.2.4",
     "npm:react@19.2.4": "19.2.4",
     "npm:redis@5.11.0": "5.11.0",
     "npm:reflect-metadata@0.2.2": "0.2.2",
@@ -4817,12 +4815,6 @@
         "react",
         "scheduler"
       ]
-    },
-    "react-is@18.3.1": {
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
-    },
-    "react-is@19.2.4": {
-      "integrity": "sha512-W+EWGn2v0ApPKgKKCy/7s7WHXkboGcsrXE+2joLyVxkbyVQfO3MUEaUQDHoSmb8TFFrSKYa9mw64WZHNHSDzYA=="
     },
     "react@19.2.4": {
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="

--- a/src/modules/react-loader/extract-component.test.ts
+++ b/src/modules/react-loader/extract-component.test.ts
@@ -69,6 +69,25 @@ describe("modules/react-loader/extract-component", () => {
     );
   });
 
+  it("keeps a memo component that is declared before a helper function", () => {
+    const Page = { $$typeof: Symbol.for("react.memo"), type: () => null };
+    const loader = () => null;
+    assertEquals(
+      extractComponent({ __esModule: true, Page, loader }, "memo-page.tsx"),
+      Page,
+      "a React-tagged object and a function are both components, so declaration order decides",
+    );
+  });
+
+  it("falls back to an untagged object when no function or tagged component exists", () => {
+    const Odd = { render: () => null };
+    assertEquals(
+      extractComponent({ __esModule: true, Odd }, "odd.tsx"),
+      Odd,
+      "an unrecognised component shape is still preferred over exporting nothing",
+    );
+  });
+
   it("accepts object components such as memo and forwardRef results", () => {
     const Memoized = { $$typeof: Symbol.for("react.memo"), type: () => null };
     assertEquals(

--- a/src/modules/react-loader/extract-component.test.ts
+++ b/src/modules/react-loader/extract-component.test.ts
@@ -149,6 +149,28 @@ describe("modules/react-loader/extract-component", () => {
     );
   });
 
+  it("keeps an RSC client reference declared before a helper function", () => {
+    // The RSC path recognises this shape too, in
+    // rendering/rsc/server-renderer/component-detector.ts.
+    const Page = { $$typeof: Symbol.for("react.client.reference"), $$id: "page#default" };
+    const helper = () => null;
+    assertEquals(
+      extractComponent({ __esModule: true, Page, helper }, "client-ref.tsx"),
+      Page,
+      "a client reference is a component the RSC renderer resolves, not a data export",
+    );
+  });
+
+  it("does not mistake a portal for a component type", () => {
+    const node = { $$typeof: Symbol.for("react.portal"), children: null };
+    const Page = () => null;
+    assertEquals(
+      extractComponent({ __esModule: true, node, Page }, "portal.tsx"),
+      Page,
+      "a portal is a rendered node, like an element, and cannot be instantiated",
+    );
+  });
+
   it("skips a symbol that is not a React type", () => {
     const marker = Symbol.for("app.marker");
     const Page = () => null;

--- a/src/modules/react-loader/extract-component.test.ts
+++ b/src/modules/react-loader/extract-component.test.ts
@@ -2,8 +2,6 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createElement } from "react";
-import { isValidElementType as isValidElementType18 } from "npm:react-is@18.3.1";
-import { isValidElementType, SuspenseList } from "npm:react-is@19.2.4";
 import { extractComponent } from "./extract-component.ts";
 
 describe("modules/react-loader/extract-component", () => {
@@ -185,13 +183,9 @@ describe("modules/react-loader/extract-component", () => {
   });
 
   it("keeps React's SuspenseList built-in declared before a helper", () => {
+    const SuspenseList = Symbol.for("react.suspense_list");
     const helper = () => null;
 
-    assertEquals(
-      isValidElementType(SuspenseList),
-      true,
-      "react-is must characterize SuspenseList as a bare element type",
-    );
     assertEquals(
       extractComponent({ __esModule: true, SuspenseList, helper }, "suspense-list.tsx") as unknown,
       SuspenseList,
@@ -216,11 +210,6 @@ describe("modules/react-loader/extract-component", () => {
     const helper = () => null;
 
     assertEquals(
-      isValidElementType18(Page),
-      true,
-      "React 18 accepts module references from every supported Flight configuration",
-    );
-    assertEquals(
       extractComponent({ __esModule: true, Page, helper }, "module-ref.tsx") as unknown,
       Page,
       "a valid React 18 Flight reference must retain declaration order against a helper",
@@ -231,11 +220,6 @@ describe("modules/react-loader/extract-component", () => {
     const Page = { getModuleId: () => "page#default" };
     const helper = () => null;
 
-    assertEquals(
-      isValidElementType18(Page),
-      true,
-      "React 18 accepts Flight references identified through getModuleId",
-    );
     assertEquals(
       extractComponent({ __esModule: true, Page, helper }, "get-module-id-ref.tsx") as unknown,
       Page,

--- a/src/modules/react-loader/extract-component.test.ts
+++ b/src/modules/react-loader/extract-component.test.ts
@@ -171,6 +171,19 @@ describe("modules/react-loader/extract-component", () => {
     );
   });
 
+  it("skips a bare $$typeof marker re-exported before the component", () => {
+    // react-is re-exports Memo, ForwardRef, Element and friends as the bare
+    // symbols React uses for $$typeof. react-is's own isValidElementType
+    // rejects every one of them standing alone.
+    const Memo = Symbol.for("react.memo");
+    const Page = () => null;
+    assertEquals(
+      extractComponent({ __esModule: true, Memo, Page }, "react-is-memo.tsx"),
+      Page,
+      "a wrapper marker is only meaningful as a tag, never as a type on its own",
+    );
+  });
+
   it("skips a bare react-is node marker re-exported before the component", () => {
     // react-is exposes `Element` and `Portal` as the same bare symbols that
     // appear on a node's $$typeof. React rejects them as element types.

--- a/src/modules/react-loader/extract-component.test.ts
+++ b/src/modules/react-loader/extract-component.test.ts
@@ -73,7 +73,7 @@ describe("modules/react-loader/extract-component", () => {
     const Page = { $$typeof: Symbol.for("react.memo"), type: () => null };
     const loader = () => null;
     assertEquals(
-      extractComponent({ __esModule: true, Page, loader }, "memo-page.tsx"),
+      extractComponent({ __esModule: true, Page, loader }, "memo-page.tsx") as unknown,
       Page,
       "a React-tagged object and a function are both components, so declaration order decides",
     );
@@ -92,7 +92,7 @@ describe("modules/react-loader/extract-component", () => {
   it("falls back to an untagged object when no function or tagged component exists", () => {
     const Odd = { render: () => null };
     assertEquals(
-      extractComponent({ __esModule: true, Odd }, "odd.tsx"),
+      extractComponent({ __esModule: true, Odd }, "odd.tsx") as unknown,
       Odd,
       "an unrecognised component shape is still preferred over exporting nothing",
     );
@@ -101,7 +101,7 @@ describe("modules/react-loader/extract-component", () => {
   it("accepts object components such as memo and forwardRef results", () => {
     const Memoized = { $$typeof: Symbol.for("react.memo"), type: () => null };
     assertEquals(
-      extractComponent({ __esModule: true, Memoized }, "memo.tsx"),
+      extractComponent({ __esModule: true, Memoized }, "memo.tsx") as unknown,
       Memoized,
       "React.memo and React.forwardRef produce objects, which are valid components",
     );
@@ -111,7 +111,7 @@ describe("modules/react-loader/extract-component", () => {
     const Ctx = { $$typeof: Symbol.for("react.context"), Provider: () => null };
     const helper = () => null;
     assertEquals(
-      extractComponent({ __esModule: true, Ctx, helper }, "context.tsx"),
+      extractComponent({ __esModule: true, Ctx, helper }, "context.tsx") as unknown,
       Ctx,
       "a context is a renderable React type, so declaration order decides against a helper",
     );
@@ -121,7 +121,7 @@ describe("modules/react-loader/extract-component", () => {
     const Provider = { $$typeof: Symbol.for("react.provider"), _context: {} };
     const helper = () => null;
     assertEquals(
-      extractComponent({ __esModule: true, Provider, helper }, "provider.tsx"),
+      extractComponent({ __esModule: true, Provider, helper }, "provider.tsx") as unknown,
       Provider,
       "a provider is a renderable React type, so declaration order decides against a helper",
     );
@@ -131,7 +131,7 @@ describe("modules/react-loader/extract-component", () => {
     const Consumer = { $$typeof: Symbol.for("react.consumer"), _context: {} };
     const helper = () => null;
     assertEquals(
-      extractComponent({ __esModule: true, Consumer, helper }, "consumer.tsx"),
+      extractComponent({ __esModule: true, Consumer, helper }, "consumer.tsx") as unknown,
       Consumer,
       "a consumer is a renderable React type, so declaration order decides against a helper",
     );
@@ -155,7 +155,7 @@ describe("modules/react-loader/extract-component", () => {
     const Page = { $$typeof: Symbol.for("react.client.reference"), $$id: "page#default" };
     const helper = () => null;
     assertEquals(
-      extractComponent({ __esModule: true, Page, helper }, "client-ref.tsx"),
+      extractComponent({ __esModule: true, Page, helper }, "client-ref.tsx") as unknown,
       Page,
       "a client reference is a component the RSC renderer resolves, not a data export",
     );

--- a/src/modules/react-loader/extract-component.test.ts
+++ b/src/modules/react-loader/extract-component.test.ts
@@ -117,6 +117,26 @@ describe("modules/react-loader/extract-component", () => {
     );
   });
 
+  it("keeps a provider type declared before a helper function", () => {
+    const Provider = { $$typeof: Symbol.for("react.provider"), _context: {} };
+    const helper = () => null;
+    assertEquals(
+      extractComponent({ __esModule: true, Provider, helper }, "provider.tsx"),
+      Provider,
+      "a provider is a renderable React type, so declaration order decides against a helper",
+    );
+  });
+
+  it("keeps a consumer type declared before a helper function", () => {
+    const Consumer = { $$typeof: Symbol.for("react.consumer"), _context: {} };
+    const helper = () => null;
+    assertEquals(
+      extractComponent({ __esModule: true, Consumer, helper }, "consumer.tsx"),
+      Consumer,
+      "a consumer is a renderable React type, so declaration order decides against a helper",
+    );
+  });
+
   it("skips an export that throws when it is read", () => {
     const Page = () => null;
     const moduleObj: Record<string, unknown> = { __esModule: true };
@@ -132,6 +152,23 @@ describe("modules/react-loader/extract-component", () => {
       extractComponent(moduleObj, "circular.tsx"),
       Page,
       "a namespace getter that throws must not hide a usable component behind it",
+    );
+  });
+
+  it("does not read a later getter after finding a component", () => {
+    const Page = () => null;
+    const moduleObj: Record<string, unknown> = { __esModule: true, Page };
+    Object.defineProperty(moduleObj, "optionalDependency", {
+      enumerable: true,
+      get() {
+        throw new ReferenceError("Cannot access 'optionalDependency' before initialization");
+      },
+    });
+
+    assertEquals(
+      extractComponent(moduleObj, "lazy.tsx"),
+      Page,
+      "an unrelated getter after the selected component must never be evaluated",
     );
   });
 

--- a/src/modules/react-loader/extract-component.test.ts
+++ b/src/modules/react-loader/extract-component.test.ts
@@ -79,6 +79,16 @@ describe("modules/react-loader/extract-component", () => {
     );
   });
 
+  it("does not mistake a React element for a component type", () => {
+    const Header = { $$typeof: Symbol.for("react.transitional.element"), type: "div" };
+    const Page = () => null;
+    assertEquals(
+      extractComponent({ __esModule: true, Header, Page }, "element-export.tsx"),
+      Page,
+      "an element is a rendered node, not something React can instantiate as a component",
+    );
+  });
+
   it("falls back to an untagged object when no function or tagged component exists", () => {
     const Odd = { render: () => null };
     assertEquals(

--- a/src/modules/react-loader/extract-component.test.ts
+++ b/src/modules/react-loader/extract-component.test.ts
@@ -32,4 +32,49 @@ describe("modules/react-loader/extract-component", () => {
       "No component exported from empty.tsx",
     );
   });
+
+  it("skips the __esModule marker when falling back to a named export", () => {
+    const Named = () => null;
+    assertEquals(
+      extractComponent({ __esModule: true, Named }, "cjs.tsx"),
+      Named,
+      "a transpiled CommonJS namespace must yield its component, not the __esModule boolean",
+    );
+  });
+
+  it("throws when the only export is the __esModule marker", () => {
+    assertThrows(
+      () => extractComponent({ __esModule: true }, "marker-only.tsx"),
+      Error,
+      "No component exported from marker-only.tsx",
+      "a namespace carrying only the transpiler marker exports no component",
+    );
+  });
+
+  it("skips exports that cannot be rendered", () => {
+    const Named = () => null;
+    assertEquals(
+      extractComponent({ version: "1.0.0", count: 2, Named }, "meta.tsx"),
+      Named,
+      "primitive exports declared ahead of the component must not be mistaken for it",
+    );
+  });
+
+  it("accepts object components such as memo and forwardRef results", () => {
+    const Memoized = { $$typeof: Symbol.for("react.memo"), type: () => null };
+    assertEquals(
+      extractComponent({ __esModule: true, Memoized }, "memo.tsx"),
+      Memoized,
+      "React.memo and React.forwardRef produce objects, which are valid components",
+    );
+  });
+
+  it("falls back to a named export when the default export cannot be rendered", () => {
+    const Named = () => null;
+    assertEquals(
+      extractComponent({ __esModule: true, default: true, Named }, "bad-default.tsx"),
+      Named,
+      "an unrenderable default must not shadow a usable named export",
+    );
+  });
 });

--- a/src/modules/react-loader/extract-component.test.ts
+++ b/src/modules/react-loader/extract-component.test.ts
@@ -1,6 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { createElement } from "react";
+import { isValidElementType, SuspenseList } from "npm:react-is@19.2.4";
 import { extractComponent } from "./extract-component.ts";
 
 describe("modules/react-loader/extract-component", () => {
@@ -117,6 +119,28 @@ describe("modules/react-loader/extract-component", () => {
     );
   });
 
+  it("rejects an unrecognized tagged object when no component exists", () => {
+    const marker = { $$typeof: Symbol.for("react.not-a-component") };
+
+    assertThrows(
+      () => extractComponent({ __esModule: true, marker }, "marker-only.tsx"),
+      Error,
+      "No component exported from marker-only.tsx",
+      "an unrecognized tagged object must not use the untagged fallback",
+    );
+  });
+
+  it("rejects a rendered React element when no component exists", () => {
+    const element = createElement("div");
+
+    assertThrows(
+      () => extractComponent({ __esModule: true, element }, "element-only.tsx"),
+      Error,
+      "No component exported from element-only.tsx",
+      "a rendered React element must not use the untagged fallback",
+    );
+  });
+
   it("keeps a context provider declared before a helper function", () => {
     const Ctx = { $$typeof: Symbol.for("react.context"), Provider: () => null };
     const helper = () => null;
@@ -160,8 +184,13 @@ describe("modules/react-loader/extract-component", () => {
   });
 
   it("keeps React's SuspenseList built-in declared before a helper", () => {
-    const SuspenseList = Symbol.for("react.suspense_list");
     const helper = () => null;
+
+    assertEquals(
+      isValidElementType(SuspenseList),
+      true,
+      "react-is must characterize SuspenseList as a bare element type",
+    );
     assertEquals(
       extractComponent({ __esModule: true, SuspenseList, helper }, "suspense-list.tsx") as unknown,
       SuspenseList,

--- a/src/modules/react-loader/extract-component.test.ts
+++ b/src/modules/react-loader/extract-component.test.ts
@@ -107,6 +107,34 @@ describe("modules/react-loader/extract-component", () => {
     );
   });
 
+  it("keeps a context provider declared before a helper function", () => {
+    const Ctx = { $$typeof: Symbol.for("react.context"), Provider: () => null };
+    const helper = () => null;
+    assertEquals(
+      extractComponent({ __esModule: true, Ctx, helper }, "context.tsx"),
+      Ctx,
+      "a context is a renderable React type, so declaration order decides against a helper",
+    );
+  });
+
+  it("skips an export that throws when it is read", () => {
+    const Page = () => null;
+    const moduleObj: Record<string, unknown> = { __esModule: true };
+    Object.defineProperty(moduleObj, "circular", {
+      enumerable: true,
+      get() {
+        throw new ReferenceError("Cannot access 'circular' before initialization");
+      },
+    });
+    moduleObj.Page = Page;
+
+    assertEquals(
+      extractComponent(moduleObj, "circular.tsx"),
+      Page,
+      "a namespace getter that throws must not hide a usable component behind it",
+    );
+  });
+
   it("hands back a default export that is not renderable", () => {
     assertEquals(
       extractComponent({ __esModule: true, default: 42 }, "bad-default.tsx") as unknown,

--- a/src/modules/react-loader/extract-component.test.ts
+++ b/src/modules/react-loader/extract-component.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { createElement } from "react";
+import { isValidElementType as isValidElementType18 } from "npm:react-is@18.3.1";
 import { isValidElementType, SuspenseList } from "npm:react-is@19.2.4";
 import { extractComponent } from "./extract-component.ts";
 
@@ -207,6 +208,38 @@ describe("modules/react-loader/extract-component", () => {
       extractComponent({ __esModule: true, Page, helper }, "client-ref.tsx") as unknown,
       Page,
       "a client reference is a component the RSC renderer resolves, not a data export",
+    );
+  });
+
+  it("keeps a React 18 Flight module reference declared before a helper", () => {
+    const Page = { $$typeof: Symbol.for("react.module.reference") };
+    const helper = () => null;
+
+    assertEquals(
+      isValidElementType18(Page),
+      true,
+      "React 18 accepts module references from every supported Flight configuration",
+    );
+    assertEquals(
+      extractComponent({ __esModule: true, Page, helper }, "module-ref.tsx") as unknown,
+      Page,
+      "a valid React 18 Flight reference must retain declaration order against a helper",
+    );
+  });
+
+  it("keeps a getModuleId Flight reference declared before a helper", () => {
+    const Page = { getModuleId: () => "page#default" };
+    const helper = () => null;
+
+    assertEquals(
+      isValidElementType18(Page),
+      true,
+      "React 18 accepts Flight references identified through getModuleId",
+    );
+    assertEquals(
+      extractComponent({ __esModule: true, Page, helper }, "get-module-id-ref.tsx") as unknown,
+      Page,
+      "a valid structural Flight reference must retain declaration order against a helper",
     );
   });
 

--- a/src/modules/react-loader/extract-component.test.ts
+++ b/src/modules/react-loader/extract-component.test.ts
@@ -51,12 +51,21 @@ describe("modules/react-loader/extract-component", () => {
     );
   });
 
-  it("skips exports that cannot be rendered", () => {
+  it("skips named exports that cannot be rendered", () => {
     const Named = () => null;
     assertEquals(
       extractComponent({ version: "1.0.0", count: 2, Named }, "meta.tsx"),
       Named,
       "primitive exports declared ahead of the component must not be mistaken for it",
+    );
+  });
+
+  it("prefers a function export over a data export such as App Router metadata", () => {
+    const Page = () => null;
+    assertEquals(
+      extractComponent({ __esModule: true, metadata: { title: "Home" }, Page }, "page.tsx"),
+      Page,
+      "a data object exported ahead of the component must not be mistaken for it",
     );
   });
 
@@ -69,12 +78,11 @@ describe("modules/react-loader/extract-component", () => {
     );
   });
 
-  it("falls back to a named export when the default export cannot be rendered", () => {
-    const Named = () => null;
+  it("hands back a default export that is not renderable", () => {
     assertEquals(
-      extractComponent({ __esModule: true, default: true, Named }, "bad-default.tsx"),
-      Named,
-      "an unrenderable default must not shadow a usable named export",
+      extractComponent({ __esModule: true, default: 42 }, "bad-default.tsx") as unknown,
+      42,
+      "callers validate the default themselves so they can name the slot that is wrong, such as a layout",
     );
   });
 });

--- a/src/modules/react-loader/extract-component.test.ts
+++ b/src/modules/react-loader/extract-component.test.ts
@@ -107,6 +107,16 @@ describe("modules/react-loader/extract-component", () => {
     );
   });
 
+  it("skips React-namespaced object markers that are not component types", () => {
+    const marker = { $$typeof: Symbol.for("react.not-a-component") };
+    const Page = () => null;
+    assertEquals(
+      extractComponent({ __esModule: true, marker, Page }, "marker-object.tsx"),
+      Page,
+      "a react.* namespace alone must not make an arbitrary tagged object renderable",
+    );
+  });
+
   it("keeps a context provider declared before a helper function", () => {
     const Ctx = { $$typeof: Symbol.for("react.context"), Provider: () => null };
     const helper = () => null;
@@ -146,6 +156,16 @@ describe("modules/react-loader/extract-component", () => {
       extractComponent({ __esModule: true, Layout, helper }, "fragment-layout.tsx") as unknown,
       Layout,
       "a built-in React type must not lose to a helper declared after it",
+    );
+  });
+
+  it("keeps React's SuspenseList built-in declared before a helper", () => {
+    const SuspenseList = Symbol.for("react.suspense_list");
+    const helper = () => null;
+    assertEquals(
+      extractComponent({ __esModule: true, SuspenseList, helper }, "suspense-list.tsx") as unknown,
+      SuspenseList,
+      "SuspenseList is a valid bare-symbol element type and must retain declaration order",
     );
   });
 

--- a/src/modules/react-loader/extract-component.test.ts
+++ b/src/modules/react-loader/extract-component.test.ts
@@ -137,6 +137,28 @@ describe("modules/react-loader/extract-component", () => {
     );
   });
 
+  it("keeps a symbol-valued React built-in declared before a helper", () => {
+    // Fragment, Suspense, StrictMode and Profiler are registered symbols, and a
+    // passthrough layout is allowed to be one.
+    const Layout = Symbol.for("react.fragment");
+    const helper = () => null;
+    assertEquals(
+      extractComponent({ __esModule: true, Layout, helper }, "fragment-layout.tsx") as unknown,
+      Layout,
+      "a built-in React type must not lose to a helper declared after it",
+    );
+  });
+
+  it("skips a symbol that is not a React type", () => {
+    const marker = Symbol.for("app.marker");
+    const Page = () => null;
+    assertEquals(
+      extractComponent({ __esModule: true, marker, Page }, "marker.tsx"),
+      Page,
+      "an unrelated registered symbol is not a component",
+    );
+  });
+
   it("skips an export that throws when it is read", () => {
     const Page = () => null;
     const moduleObj: Record<string, unknown> = { __esModule: true };

--- a/src/modules/react-loader/extract-component.test.ts
+++ b/src/modules/react-loader/extract-component.test.ts
@@ -171,6 +171,18 @@ describe("modules/react-loader/extract-component", () => {
     );
   });
 
+  it("skips a bare react-is node marker re-exported before the component", () => {
+    // react-is exposes `Element` and `Portal` as the same bare symbols that
+    // appear on a node's $$typeof. React rejects them as element types.
+    const Element = Symbol.for("react.element");
+    const Page = () => null;
+    assertEquals(
+      extractComponent({ __esModule: true, Element, Page }, "react-is-reexport.tsx"),
+      Page,
+      "a node marker is not renderable standing alone any more than it is as a tag",
+    );
+  });
+
   it("skips a symbol that is not a React type", () => {
     const marker = Symbol.for("app.marker");
     const Page = () => null;

--- a/src/modules/react-loader/extract-component.ts
+++ b/src/modules/react-loader/extract-component.ts
@@ -41,10 +41,14 @@ function isReactComponentObject(value: unknown): boolean {
  *
  * `Fragment`, `Suspense`, `StrictMode` and `Profiler` are registered symbols
  * rather than functions or tagged objects, and a layout is allowed to be one.
- * A bare symbol is never a rendered node, so no exclusion is needed.
+ *
+ * The node tags are excluded here too. A module can re-export the bare markers
+ * `react-is` exposes as `Element` and `Portal`, and those are the same symbols
+ * that appear on a node's `$$typeof`. React rejects them as element types, so
+ * they are no more renderable standing alone than they are as a tag.
  */
 function isReactBuiltinType(value: unknown): boolean {
-  return isReactTag(value);
+  return isReactTag(value) && !REACT_NODE_TAGS.has(value);
 }
 
 /**

--- a/src/modules/react-loader/extract-component.ts
+++ b/src/modules/react-loader/extract-component.ts
@@ -28,6 +28,23 @@ function isReactComponentObject(value: unknown): boolean {
 }
 
 /**
+ * Detects React's symbol-valued built-in types.
+ *
+ * `Fragment`, `Suspense`, `StrictMode`, `Profiler` and friends are registered
+ * symbols rather than functions or tagged objects, and a layout is allowed to
+ * be one. Matching on the registry key covers them all, and any type React adds
+ * later, without pinning a list that would silently fall behind.
+ *
+ * A bare symbol cannot be an element, so this does not reopen the element case
+ * that `REACT_COMPONENT_TAGS` exists to exclude.
+ */
+function isReactBuiltinType(value: unknown): boolean {
+  if (typeof value !== "symbol") return false;
+
+  return Symbol.keyFor(value)?.startsWith("react.") ?? false;
+}
+
+/**
  * Picks the first named export that can be rendered.
  *
  * The `__esModule` marker is skipped explicitly. Transpilers place that boolean
@@ -59,7 +76,12 @@ function firstRenderableExport(moduleObj: Record<string, unknown>): unknown {
       continue;
     }
 
-    if (typeof value === "function" || isReactComponentObject(value)) return value;
+    if (
+      typeof value === "function" || isReactComponentObject(value) ||
+      isReactBuiltinType(value)
+    ) {
+      return value;
+    }
     if (untaggedObject === undefined && typeof value === "object" && value !== null) {
       untaggedObject = value;
     }

--- a/src/modules/react-loader/extract-component.ts
+++ b/src/modules/react-loader/extract-component.ts
@@ -8,12 +8,12 @@ const REACT_COMPONENT_TAGS: ReadonlySet<symbol> = new Set([
   Symbol.for("react.lazy"),
   Symbol.for("react.context"),
   Symbol.for("react.provider"),
+  Symbol.for("react.consumer"),
 ]);
 
 /**
- * Detects the component objects `React.memo`, `React.forwardRef` and
- * `React.lazy` produce, which is what separates a component from an ordinary
- * data export such as an App Router `metadata` object.
+ * Detects React component-type objects, which separates a component from an
+ * ordinary data export such as an App Router `metadata` object.
  *
  * The tags are matched individually rather than accepting any symbol-valued
  * `$$typeof`, because a React *element* carries one too. An element is a

--- a/src/modules/react-loader/extract-component.ts
+++ b/src/modules/react-loader/extract-component.ts
@@ -31,6 +31,15 @@ function isReactComponentObject(value: unknown): boolean {
   return typeof tag === "symbol" && REACT_COMPONENT_OBJECT_TAGS.has(tag);
 }
 
+/** Reports whether an object carries a React-style symbol marker. */
+function hasSymbolTypeTag(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  return typeof (value as { $$typeof?: unknown }).$$typeof === "symbol";
+}
+
 /**
  * The built-in components React exports as bare symbols.
  *
@@ -96,7 +105,12 @@ function firstRenderableExport(moduleObj: Record<string, unknown>): unknown {
     ) {
       return value;
     }
-    if (untaggedObject === undefined && typeof value === "object" && value !== null) {
+    if (
+      untaggedObject === undefined &&
+      typeof value === "object" &&
+      value !== null &&
+      !hasSymbolTypeTag(value)
+    ) {
       untaggedObject = value;
     }
   }

--- a/src/modules/react-loader/extract-component.ts
+++ b/src/modules/react-loader/extract-component.ts
@@ -6,6 +6,8 @@ const REACT_COMPONENT_TAGS: ReadonlySet<symbol> = new Set([
   Symbol.for("react.memo"),
   Symbol.for("react.forward_ref"),
   Symbol.for("react.lazy"),
+  Symbol.for("react.context"),
+  Symbol.for("react.provider"),
 ]);
 
 /**
@@ -43,8 +45,20 @@ function isReactComponentObject(value: unknown): boolean {
 function firstRenderableExport(moduleObj: Record<string, unknown>): unknown {
   let untaggedObject: unknown;
 
-  for (const [key, value] of Object.entries(moduleObj)) {
+  // Read one key at a time rather than materialising every value up front. A
+  // module namespace exposes its exports as getters, and one can throw while a
+  // usable component sits further along, as happens with a circular import.
+  for (const key of Object.keys(moduleObj)) {
     if (key === "default" || key === "__esModule") continue;
+
+    let value: unknown;
+    try {
+      value = moduleObj[key];
+    } catch (_) {
+      /* expected: an export can throw on access, such as a circular import */
+      continue;
+    }
+
     if (typeof value === "function" || isReactComponentObject(value)) return value;
     if (untaggedObject === undefined && typeof value === "object" && value !== null) {
       untaggedObject = value;

--- a/src/modules/react-loader/extract-component.ts
+++ b/src/modules/react-loader/extract-component.ts
@@ -1,15 +1,28 @@
 import type * as React from "react";
 import { createError, toError } from "#veryfront/errors";
 
+/** The `$$typeof` tags React puts on component types, as opposed to elements. */
+const REACT_COMPONENT_TAGS: ReadonlySet<symbol> = new Set([
+  Symbol.for("react.memo"),
+  Symbol.for("react.forward_ref"),
+  Symbol.for("react.lazy"),
+]);
+
 /**
  * Detects the component objects `React.memo`, `React.forwardRef` and
- * `React.lazy` produce. All of them carry a well-known symbol on `$$typeof`,
- * which is what separates a component from an ordinary data export such as an
- * App Router `metadata` object.
+ * `React.lazy` produce, which is what separates a component from an ordinary
+ * data export such as an App Router `metadata` object.
+ *
+ * The tags are matched individually rather than accepting any symbol-valued
+ * `$$typeof`, because a React *element* carries one too. An element is a
+ * rendered node, not a component type, so selecting one would hand React
+ * something it cannot instantiate.
  */
 function isReactComponentObject(value: unknown): boolean {
-  return typeof value === "object" && value !== null &&
-    typeof (value as { $$typeof?: unknown }).$$typeof === "symbol";
+  if (typeof value !== "object" || value === null) return false;
+
+  const tag = (value as { $$typeof?: unknown }).$$typeof;
+  return typeof tag === "symbol" && REACT_COMPONENT_TAGS.has(tag);
 }
 
 /**

--- a/src/modules/react-loader/extract-component.ts
+++ b/src/modules/react-loader/extract-component.ts
@@ -2,12 +2,14 @@ import type * as React from "react";
 import { createError, toError } from "#veryfront/errors";
 
 /**
- * A React component is either a function (function or class component) or an
- * object, which is what `React.memo`, `React.forwardRef` and `React.lazy`
- * produce. Nothing else can be rendered.
+ * Detects the component objects `React.memo`, `React.forwardRef` and
+ * `React.lazy` produce. All of them carry a well-known symbol on `$$typeof`,
+ * which is what separates a component from an ordinary data export such as an
+ * App Router `metadata` object.
  */
-function isRenderable(value: unknown): boolean {
-  return typeof value === "function" || (typeof value === "object" && value !== null);
+function isReactComponentObject(value: unknown): boolean {
+  return typeof value === "object" && value !== null &&
+    typeof (value as { $$typeof?: unknown }).$$typeof === "symbol";
 }
 
 /**
@@ -15,24 +17,28 @@ function isRenderable(value: unknown): boolean {
  *
  * The `__esModule` marker is skipped explicitly. Transpilers place that boolean
  * first in the namespace they emit for a module with only named exports, so
- * taking the first key blindly yielded `true` instead of a component and the
+ * taking the first key blindly yielded `true` instead of a component, and the
  * failure surfaced during render rather than here.
  *
- * Functions are preferred over objects so that a module pairing data with a
- * component, such as an App Router page exporting `metadata` alongside its
- * component, resolves to the component. Objects are still accepted, because
- * `React.memo`, `React.forwardRef` and `React.lazy` all produce one.
+ * Functions and React-tagged objects are both components, so declaration order
+ * decides between them: a module exporting `{ Page: memo(...), loader() {} }`
+ * resolves to `Page`. An untagged object is neither obviously a component nor
+ * obviously not one, so it is kept only as a last resort, which leaves a module
+ * exporting `metadata` alongside its component resolving to the component while
+ * still tolerating a component shape this function does not recognise.
  */
 function firstRenderableExport(moduleObj: Record<string, unknown>): unknown {
-  let objectExport: unknown;
+  let untaggedObject: unknown;
 
   for (const [key, value] of Object.entries(moduleObj)) {
     if (key === "default" || key === "__esModule") continue;
-    if (typeof value === "function") return value;
-    if (objectExport === undefined && isRenderable(value)) objectExport = value;
+    if (typeof value === "function" || isReactComponentObject(value)) return value;
+    if (untaggedObject === undefined && typeof value === "object" && value !== null) {
+      untaggedObject = value;
+    }
   }
 
-  return objectExport;
+  return untaggedObject;
 }
 
 export function extractComponent(

--- a/src/modules/react-loader/extract-component.ts
+++ b/src/modules/react-loader/extract-component.ts
@@ -1,47 +1,50 @@
 import type * as React from "react";
 import { createError, toError } from "#veryfront/errors";
 
-/** The `$$typeof` tags React puts on component types, as opposed to elements. */
-const REACT_COMPONENT_TAGS: ReadonlySet<symbol> = new Set([
-  Symbol.for("react.memo"),
-  Symbol.for("react.forward_ref"),
-  Symbol.for("react.lazy"),
-  Symbol.for("react.context"),
-  Symbol.for("react.provider"),
-  Symbol.for("react.consumer"),
+/**
+ * The `$$typeof` tags that mark a rendered node rather than a component type.
+ *
+ * An element or a portal is the *result* of rendering, so handing one to React
+ * as a component fails. Everything else React tags is a component type of some
+ * kind: `memo`, `forwardRef`, `lazy`, context, provider, consumer, and the
+ * client and server references the RSC path produces.
+ */
+const REACT_NODE_TAGS: ReadonlySet<symbol> = new Set([
+  Symbol.for("react.element"),
+  Symbol.for("react.transitional.element"),
+  Symbol.for("react.portal"),
 ]);
 
+/** Reports whether a symbol is one React registered, such as `react.memo`. */
+function isReactTag(tag: unknown): tag is symbol {
+  return typeof tag === "symbol" && (Symbol.keyFor(tag)?.startsWith("react.") ?? false);
+}
+
 /**
- * Detects React component-type objects, which separates a component from an
+ * Detects React's component-type objects, which separates a component from an
  * ordinary data export such as an App Router `metadata` object.
  *
- * The tags are matched individually rather than accepting any symbol-valued
- * `$$typeof`, because a React *element* carries one too. An element is a
- * rendered node, not a component type, so selecting one would hand React
- * something it cannot instantiate.
+ * Excluding the node tags is what matters here, rather than listing the
+ * component tags: React keeps adding component types, and this module has no
+ * business tracking that list. Anything React tags that is not a rendered node
+ * is something the caller can render.
  */
 function isReactComponentObject(value: unknown): boolean {
   if (typeof value !== "object" || value === null) return false;
 
   const tag = (value as { $$typeof?: unknown }).$$typeof;
-  return typeof tag === "symbol" && REACT_COMPONENT_TAGS.has(tag);
+  return isReactTag(tag) && !REACT_NODE_TAGS.has(tag);
 }
 
 /**
  * Detects React's symbol-valued built-in types.
  *
- * `Fragment`, `Suspense`, `StrictMode`, `Profiler` and friends are registered
- * symbols rather than functions or tagged objects, and a layout is allowed to
- * be one. Matching on the registry key covers them all, and any type React adds
- * later, without pinning a list that would silently fall behind.
- *
- * A bare symbol cannot be an element, so this does not reopen the element case
- * that `REACT_COMPONENT_TAGS` exists to exclude.
+ * `Fragment`, `Suspense`, `StrictMode` and `Profiler` are registered symbols
+ * rather than functions or tagged objects, and a layout is allowed to be one.
+ * A bare symbol is never a rendered node, so no exclusion is needed.
  */
 function isReactBuiltinType(value: unknown): boolean {
-  if (typeof value !== "symbol") return false;
-
-  return Symbol.keyFor(value)?.startsWith("react.") ?? false;
+  return isReactTag(value);
 }
 
 /**

--- a/src/modules/react-loader/extract-component.ts
+++ b/src/modules/react-loader/extract-component.ts
@@ -1,61 +1,53 @@
 import type * as React from "react";
 import { createError, toError } from "#veryfront/errors";
 
-/**
- * The `$$typeof` tags that mark a rendered node rather than a component type.
- *
- * An element or a portal is the *result* of rendering, so handing one to React
- * as a component fails. Everything else React tags is a component type of some
- * kind: `memo`, `forwardRef`, `lazy`, context, provider, consumer, and the
- * client and server references the RSC path produces.
- */
-const REACT_NODE_TAGS: ReadonlySet<symbol> = new Set([
-  Symbol.for("react.element"),
-  Symbol.for("react.transitional.element"),
-  Symbol.for("react.portal"),
+/** React object tags that are valid element types across supported runtimes. */
+const REACT_COMPONENT_OBJECT_TAGS: ReadonlySet<symbol> = new Set([
+  Symbol.for("react.memo"),
+  Symbol.for("react.forward_ref"),
+  Symbol.for("react.lazy"),
+  Symbol.for("react.context"),
+  // React 18 exposes Provider as a distinct type; React 19 renders Context
+  // directly and exposes Consumer separately. Supporting both keeps compiled
+  // modules portable across the React versions Veryfront accepts.
+  Symbol.for("react.provider"),
+  Symbol.for("react.consumer"),
+  Symbol.for("react.client.reference"),
 ]);
-
-/** Reports whether a symbol is one React registered, such as `react.memo`. */
-function isReactTag(tag: unknown): tag is symbol {
-  return typeof tag === "symbol" && (Symbol.keyFor(tag)?.startsWith("react.") ?? false);
-}
 
 /**
  * Detects React's component-type objects, which separates a component from an
  * ordinary data export such as an App Router `metadata` object.
  *
- * Excluding the node tags is what matters here, rather than listing the
- * component tags: React keeps adding component types, and this module has no
- * business tracking that list. Anything React tags that is not a rendered node
- * is something the caller can render.
+ * The allowlist is deliberate: `Symbol.for("react.*")` is a public namespace,
+ * not proof that an object is a renderable React type. React also uses it for
+ * rendered nodes and internal markers, and applications can mint arbitrary
+ * entries in the same registry.
  */
 function isReactComponentObject(value: unknown): boolean {
   if (typeof value !== "object" || value === null) return false;
 
   const tag = (value as { $$typeof?: unknown }).$$typeof;
-  return isReactTag(tag) && !REACT_NODE_TAGS.has(tag);
+  return typeof tag === "symbol" && REACT_COMPONENT_OBJECT_TAGS.has(tag);
 }
 
 /**
  * The built-in components React exports as bare symbols.
  *
  * Verified against `react@19.2.4` by enumerating its symbol-valued exports, and
- * cross-checked with `react-is`, whose `isValidElementType` accepts
- * `react.fragment`, `react.suspense`, `react.strict_mode` and `react.profiler`
- * standing alone and rejects every `$$typeof` marker. `Activity` is included
- * because React exports it as a component; `react-is` has not caught up, and
- * React's own export is what the renderer follows.
+ * cross-checked with `react-is`, whose `isValidElementType` accepts Fragment,
+ * Suspense, SuspenseList, StrictMode and Profiler standing alone and rejects
+ * every `$$typeof` marker. `Activity` is included because React exports it as a
+ * component; `react-is` has not caught up, and React's own export is what the
+ * renderer follows.
  *
- * This is a whitelist while the object check is an exclusion list, and the
- * asymmetry is real rather than an oversight. Component *wrappers* are
- * open-ended, so excluding the rendered-node tags is the claim that stays true
- * there. Bare symbols are the opposite: only these few are element types, and
- * every other `react.*` symbol is a marker `react-is` re-exports, which React
- * rejects if it reaches the renderer.
+ * Bare symbols need their own whitelist: every other `react.*` symbol is a
+ * marker `react-is` re-exports, which React rejects if it reaches the renderer.
  */
 const REACT_BUILTIN_TYPES: ReadonlySet<symbol> = new Set([
   Symbol.for("react.fragment"),
   Symbol.for("react.suspense"),
+  Symbol.for("react.suspense_list"),
   Symbol.for("react.strict_mode"),
   Symbol.for("react.profiler"),
   Symbol.for("react.activity"),

--- a/src/modules/react-loader/extract-component.ts
+++ b/src/modules/react-loader/extract-component.ts
@@ -37,18 +37,33 @@ function isReactComponentObject(value: unknown): boolean {
 }
 
 /**
- * Detects React's symbol-valued built-in types.
+ * The built-in components React exports as bare symbols.
  *
- * `Fragment`, `Suspense`, `StrictMode` and `Profiler` are registered symbols
- * rather than functions or tagged objects, and a layout is allowed to be one.
+ * Verified against `react@19.2.4` by enumerating its symbol-valued exports, and
+ * cross-checked with `react-is`, whose `isValidElementType` accepts
+ * `react.fragment`, `react.suspense`, `react.strict_mode` and `react.profiler`
+ * standing alone and rejects every `$$typeof` marker. `Activity` is included
+ * because React exports it as a component; `react-is` has not caught up, and
+ * React's own export is what the renderer follows.
  *
- * The node tags are excluded here too. A module can re-export the bare markers
- * `react-is` exposes as `Element` and `Portal`, and those are the same symbols
- * that appear on a node's `$$typeof`. React rejects them as element types, so
- * they are no more renderable standing alone than they are as a tag.
+ * This is a whitelist while the object check is an exclusion list, and the
+ * asymmetry is real rather than an oversight. Component *wrappers* are
+ * open-ended, so excluding the rendered-node tags is the claim that stays true
+ * there. Bare symbols are the opposite: only these few are element types, and
+ * every other `react.*` symbol is a marker `react-is` re-exports, which React
+ * rejects if it reaches the renderer.
  */
+const REACT_BUILTIN_TYPES: ReadonlySet<symbol> = new Set([
+  Symbol.for("react.fragment"),
+  Symbol.for("react.suspense"),
+  Symbol.for("react.strict_mode"),
+  Symbol.for("react.profiler"),
+  Symbol.for("react.activity"),
+]);
+
+/** Detects React's symbol-valued built-in components, such as `Fragment`. */
 function isReactBuiltinType(value: unknown): boolean {
-  return isReactTag(value) && !REACT_NODE_TAGS.has(value);
+  return typeof value === "symbol" && REACT_BUILTIN_TYPES.has(value);
 }
 
 /**

--- a/src/modules/react-loader/extract-component.ts
+++ b/src/modules/react-loader/extract-component.ts
@@ -1,6 +1,32 @@
 import type * as React from "react";
 import { createError, toError } from "#veryfront/errors";
 
+/**
+ * A React component is either a function (function or class component) or an
+ * object, which is what `React.memo`, `React.forwardRef` and `React.lazy`
+ * produce. Nothing else can be rendered.
+ *
+ * The check matters most for the `__esModule` marker. Transpilers place that
+ * boolean first in the namespace they emit for a module with only named
+ * exports, so selecting the first key blindly returns `true` instead of a
+ * component, and the failure then surfaces during render rather than here.
+ */
+function isRenderable(value: unknown): boolean {
+  return typeof value === "function" || (typeof value === "object" && value !== null);
+}
+
+/** Picks the default export, else the first named export that can be rendered. */
+function selectComponent(moduleObj: Record<string, unknown>): unknown {
+  if (isRenderable(moduleObj.default)) return moduleObj.default;
+
+  for (const [key, value] of Object.entries(moduleObj)) {
+    if (key === "__esModule") continue;
+    if (isRenderable(value)) return value;
+  }
+
+  return undefined;
+}
+
 export function extractComponent(
   mod: unknown,
   filePath: string,
@@ -16,8 +42,7 @@ export function extractComponent(
   }
 
   const moduleObj = mod as Record<string, unknown>;
-  const firstKey = Object.keys(moduleObj)[0];
-  const component = moduleObj.default ?? (firstKey ? moduleObj[firstKey] : undefined);
+  const component = selectComponent(moduleObj);
 
   if (!component) {
     throw toError(

--- a/src/modules/react-loader/extract-component.ts
+++ b/src/modules/react-loader/extract-component.ts
@@ -27,7 +27,7 @@ const REACT_COMPONENT_OBJECT_TAGS: ReadonlySet<symbol> = new Set([
  * React-is's compatibility contract for Flight references without a tag.
  */
 function isReactComponentObject(value: unknown): boolean {
-  if (typeof value !== "object" || value === null) return false;
+  if (!value || typeof value !== "object") return false;
 
   const component = value as { $$typeof?: unknown; getModuleId?: unknown };
   const tag = component.$$typeof;
@@ -37,7 +37,7 @@ function isReactComponentObject(value: unknown): boolean {
 
 /** Reports whether an object carries a React-style symbol marker. */
 function hasSymbolTypeTag(value: unknown): boolean {
-  if (typeof value !== "object" || value === null) {
+  if (!value || typeof value !== "object") {
     return false;
   }
 

--- a/src/modules/react-loader/extract-component.ts
+++ b/src/modules/react-loader/extract-component.ts
@@ -5,26 +5,34 @@ import { createError, toError } from "#veryfront/errors";
  * A React component is either a function (function or class component) or an
  * object, which is what `React.memo`, `React.forwardRef` and `React.lazy`
  * produce. Nothing else can be rendered.
- *
- * The check matters most for the `__esModule` marker. Transpilers place that
- * boolean first in the namespace they emit for a module with only named
- * exports, so selecting the first key blindly returns `true` instead of a
- * component, and the failure then surfaces during render rather than here.
  */
 function isRenderable(value: unknown): boolean {
   return typeof value === "function" || (typeof value === "object" && value !== null);
 }
 
-/** Picks the default export, else the first named export that can be rendered. */
-function selectComponent(moduleObj: Record<string, unknown>): unknown {
-  if (isRenderable(moduleObj.default)) return moduleObj.default;
+/**
+ * Picks the first named export that can be rendered.
+ *
+ * The `__esModule` marker is skipped explicitly. Transpilers place that boolean
+ * first in the namespace they emit for a module with only named exports, so
+ * taking the first key blindly yielded `true` instead of a component and the
+ * failure surfaced during render rather than here.
+ *
+ * Functions are preferred over objects so that a module pairing data with a
+ * component, such as an App Router page exporting `metadata` alongside its
+ * component, resolves to the component. Objects are still accepted, because
+ * `React.memo`, `React.forwardRef` and `React.lazy` all produce one.
+ */
+function firstRenderableExport(moduleObj: Record<string, unknown>): unknown {
+  let objectExport: unknown;
 
   for (const [key, value] of Object.entries(moduleObj)) {
-    if (key === "__esModule") continue;
-    if (isRenderable(value)) return value;
+    if (key === "default" || key === "__esModule") continue;
+    if (typeof value === "function") return value;
+    if (objectExport === undefined && isRenderable(value)) objectExport = value;
   }
 
-  return undefined;
+  return objectExport;
 }
 
 export function extractComponent(
@@ -42,7 +50,7 @@ export function extractComponent(
   }
 
   const moduleObj = mod as Record<string, unknown>;
-  const component = selectComponent(moduleObj);
+  const component = moduleObj.default ?? firstRenderableExport(moduleObj);
 
   if (!component) {
     throw toError(

--- a/src/modules/react-loader/extract-component.ts
+++ b/src/modules/react-loader/extract-component.ts
@@ -12,6 +12,7 @@ const REACT_COMPONENT_OBJECT_TAGS: ReadonlySet<symbol> = new Set([
   // modules portable across the React versions Veryfront accepts.
   Symbol.for("react.provider"),
   Symbol.for("react.consumer"),
+  Symbol.for("react.module.reference"),
   Symbol.for("react.client.reference"),
 ]);
 
@@ -22,13 +23,16 @@ const REACT_COMPONENT_OBJECT_TAGS: ReadonlySet<symbol> = new Set([
  * The allowlist is deliberate: `Symbol.for("react.*")` is a public namespace,
  * not proof that an object is a renderable React type. React also uses it for
  * rendered nodes and internal markers, and applications can mint arbitrary
- * entries in the same registry.
+ * entries in the same registry. The structural `getModuleId` branch matches
+ * React-is's compatibility contract for Flight references without a tag.
  */
 function isReactComponentObject(value: unknown): boolean {
   if (typeof value !== "object" || value === null) return false;
 
-  const tag = (value as { $$typeof?: unknown }).$$typeof;
-  return typeof tag === "symbol" && REACT_COMPONENT_OBJECT_TAGS.has(tag);
+  const component = value as { $$typeof?: unknown; getModuleId?: unknown };
+  const tag = component.$$typeof;
+  return (typeof tag === "symbol" && REACT_COMPONENT_OBJECT_TAGS.has(tag)) ||
+    component.getModuleId !== undefined;
 }
 
 /** Reports whether an object carries a React-style symbol marker. */


### PR DESCRIPTION
## Description

`extractComponent` fell back to the first key of the module namespace when there was no default export:

```ts
const firstKey = Object.keys(moduleObj)[0];
const component = moduleObj.default ?? (firstKey ? moduleObj[firstKey] : undefined);
```

For a transpiled CommonJS namespace shaped `{ __esModule: true, Named }`, `moduleObj.default` is `undefined` and `firstKey` is `"__esModule"`, so the extracted "component" was the boolean `true`. That is what many transpilers emit for a module with only named exports, so it is not an exotic input.

`true` is truthy, so the existing guard let it through. The caller received `true` where it expected a component and rendering failed later and further from the cause. `extractComponent` is reached from both `loadComponentFromSource` and the SSR module loader, so this is on the core render path.

### Fix

Select the first export that can actually be rendered: a function (function or class component) or an object, which is what `React.memo`, `React.forwardRef` and `React.lazy` produce. The `__esModule` marker is skipped explicitly.

Two consequences worth calling out:

- A **default export that is not renderable no longer shadows a usable named export**. Previously `{ default: true, Named }` returned `true`; it now returns `Named`.
- A namespace carrying **only** the marker now throws the existing `No component exported from <file>` error at the point of extraction, which is where the diagnosis belongs.

Object exports are deliberately accepted rather than restricted to functions, because rejecting them would break `memo`/`forwardRef`/`lazy` components.

## Related Issue(s)

Fixes #4087

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have added tests that prove my fix is effective

## Testing

Five cases added to `extract-component.test.ts`, all verified to fail before the fix and pass after: the `__esModule` fallback, a marker-only namespace, primitive exports declared ahead of the component, a `memo`-shaped object component, and an unrenderable default alongside a usable named export. The four pre-existing tests are unchanged and still pass.

```
deno task test:file src/modules/react-loader/     27 passed (267 steps) | 0 failed
deno check src/modules/index.ts
deno task lint:anti-slop / lint:test-semantic-dispositions / lint:module-boundaries
deno fmt --check, deno lint
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component detection when modules export multiple values.
  * Ignores internal and non-renderable exports when selecting a component.
  * Supports React built-in component types and safely handles problematic getters.
  * Preserves default exports and uses suitable object exports as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->