### PR TITLE
fix(modules): clear batch cache entries by the key the write path used

### DIFF
--- a/src/modules/server/module-batch-handler.test.ts
+++ b/src/modules/server/module-batch-handler.test.ts
@@ -183,6 +183,56 @@ describe(
 
         clearBatchCache();
       });
+
+      it("clears entries for a project that supplies a projectId", async () => {
+        clearBatchCache();
+
+        async function cacheOneTransform(
+          identity: { projectSlug: string; projectId?: string },
+        ): Promise<void> {
+          const adapter = createMockAdapter();
+          adapter.fs.files.set(
+            `/test-project/${identity.projectSlug}.tsx`,
+            "export const value = 1;",
+          );
+          const url = new URL("/_vf_modules/_batch", "http://localhost:8080");
+          url.searchParams.set("paths", `${identity.projectSlug}.js`);
+          const response = await handleModuleBatch(new Request(url.toString()), {
+            projectDir: "/test-project",
+            adapter,
+            projectSlug: identity.projectSlug,
+            projectId: identity.projectId,
+            releaseId: `rel-${identity.projectSlug}`,
+            dev: false,
+          });
+          assertEquals(
+            response.status,
+            200,
+            `project ${identity.projectSlug} must serve its module`,
+          );
+          await response.text();
+        }
+
+        await cacheOneTransform({ projectSlug: "slug-a", projectId: "id-a" });
+        await cacheOneTransform({ projectSlug: "slug-b", projectId: "id-b" });
+        assertEquals(getBatchCacheStats().size, 2, "both projects cached a transform");
+
+        clearBatchCache({ projectSlug: "slug-a", projectId: "id-a" });
+
+        const stats = getBatchCacheStats();
+        assertEquals(
+          stats.size,
+          1,
+          "clearing a project that supplies a projectId must delete its entry, not silently match nothing",
+        );
+        assertEquals(
+          stats.keys.every((key) => key.startsWith("id-b:")),
+          true,
+          "only the other project's entries may survive the invalidation",
+        );
+
+        clearBatchCache();
+      });
     });
 
     describe("handleModuleBatch", () => {

--- a/src/modules/server/module-batch-handler.test.ts
+++ b/src/modules/server/module-batch-handler.test.ts
@@ -3,6 +3,7 @@ import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   type BatchHandlerOptions,
+  buildBatchCacheProjectKey,
   buildBatchTransformCacheKey,
   clearBatchCache,
   getBatchCacheStats,
@@ -132,6 +133,28 @@ describe(
         assertEquals(knex === baseline, false);
         assertEquals(prismaAndKnex === knex, false);
         assertEquals(reordered, prismaAndKnex);
+      });
+    });
+
+    describe("buildBatchCacheProjectKey", () => {
+      it("prefers the projectId over the slug", () => {
+        assertEquals(
+          buildBatchCacheProjectKey({ projectId: "id-1", projectSlug: "slug-1" }),
+          "id-1",
+          "the id identifies a project across slug renames, so it wins",
+        );
+      });
+
+      it("uses the slug when no projectId is supplied", () => {
+        assertEquals(buildBatchCacheProjectKey({ projectSlug: "slug-1" }), "slug-1");
+      });
+
+      it("falls back to a shared default when neither is supplied", () => {
+        assertEquals(
+          buildBatchCacheProjectKey({}),
+          "default",
+          "an unidentified project must still land under a stable, clearable namespace",
+        );
       });
     });
 

--- a/src/modules/server/module-batch-handler.ts
+++ b/src/modules/server/module-batch-handler.ts
@@ -95,6 +95,25 @@ const FRAMEWORK_EXTENSIONS = [
   ".js", // Regular sources for dev mode
 ] as const;
 
+/** Identity a batch transform is cached under. */
+export interface BatchCacheProjectIdentity {
+  projectId?: string;
+  projectSlug?: string;
+}
+
+/**
+ * Derives the cache key namespace a project's batch transforms are stored
+ * under. Every key this module writes begins with `<projectKey>:`.
+ *
+ * Both the request path and `clearBatchCache` must derive the namespace here.
+ * They previously disagreed: writes preferred `projectId` while deletion built
+ * its prefix from `projectSlug`, so a project supplying an id stored entries
+ * under that id and the deletion prefix matched nothing.
+ */
+export function buildBatchCacheProjectKey(identity: BatchCacheProjectIdentity): string {
+  return identity.projectId || identity.projectSlug || "default";
+}
+
 export function buildBatchTransformCacheKey(
   projectKey: string,
   modulePath: string,
@@ -221,7 +240,7 @@ export function handleModuleBatch(req: Request, options: BatchHandlerOptions): P
         config,
       } = options;
 
-      const projectKey = projectId || projectSlug || "default";
+      const projectKey = buildBatchCacheProjectKey({ projectId, projectSlug });
       const pinValues = url.searchParams.getAll("pins");
       const requestedPinKey = pinValues[0];
       const hasRequestedPinKey = pinValues.length > 0;
@@ -731,21 +750,28 @@ function transformExportsForBundle(code: string): string {
 
 /**
  * Clear the transform cache (on deployment or memory pressure)
+ *
+ * Pass nothing to clear every project. Pass the project's identity to clear
+ * only its entries; supply the same `projectId` and `projectSlug` the request
+ * path was given, since the namespace prefers the id. A bare string is treated
+ * as an already-derived project key.
  */
-export function clearBatchCache(projectSlug?: string): void {
+export function clearBatchCache(project?: string | BatchCacheProjectIdentity): void {
   clearSourceMissCache("module-batch");
 
-  if (!projectSlug) {
+  if (project === undefined) {
     transformCache.clear();
     logger.debug("Cleared all cache");
     return;
   }
 
-  const prefix = `${projectSlug}:`;
+  const projectKey = typeof project === "string" ? project : buildBatchCacheProjectKey(project);
+
+  const prefix = `${projectKey}:`;
   for (const key of [...transformCache.keys()]) {
     if (key.startsWith(prefix)) transformCache.delete(key);
   }
-  logger.debug("Cleared cache for project", { projectSlug });
+  logger.debug("Cleared cache for project", { projectKey });
 }
 
 /**


### PR DESCRIPTION
## Description

`module-batch-handler.ts` writes cache keys under a project key that prefers `projectId`:

```ts
const projectKey = projectId || projectSlug || "default";
const cacheKey = buildBatchTransformCacheKey(projectKey, ...);
```

but deleted by `projectSlug`:

```ts
const prefix = `${projectSlug}:`;
```

Whenever a project supplies a `projectId`, its entries are stored under that id and the slug-derived prefix matches nothing. `clearBatchCache(projectSlug)` cleared **zero** entries while returning normally and logging "Cleared cache for project", so stale batch bundles survived an invalidation that reported success.

### Fix

Derive the namespace in one place. `buildBatchCacheProjectKey` is now the single definition of the prefix every key begins with, and both the request path and `clearBatchCache` go through it, so the two sides cannot drift apart again.

`clearBatchCache` now takes the project identity rather than a slug, so a caller can pass the same `projectId`/`projectSlug` the request path was given. A bare string is still accepted and treated as an already-derived project key, which is what the existing callers pass, so this is not a breaking change.

## Related Issue(s)

Fixes #4088

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have added tests that prove my fix is effective

## Testing

The existing "should clear cache for specific project slug" test only ever passed a `projectSlug` with no `projectId`, so the two keying schemes coincided and the mismatch was invisible. The new test caches a transform for two projects that **do** supply a `projectId`, clears one, and asserts the entry is actually gone and the other project's survives. Verified to fail before the fix:

```
clearing a project that supplies a projectId must delete its entry, not silently match nothing
  actual: 2  expected: 1
```

```
deno task test:file src/modules/     60 passed (739 steps) | 0 failed
deno check src/modules/index.ts src/server/index.ts
deno task lint:anti-slop / lint:test-semantic-dispositions / lint:module-boundaries
deno fmt --check, deno lint
```