### PR TITLE
docs(security): name the surfaces that enforce path containment

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -266,7 +266,7 @@
 **Key Features**:
 
 - Input validation with Zod
-- Path containment helpers (`validateLexicalPath`), plus enforced read scope for sandboxed workers and isolated Pages `ctx.fs`
+- Lexical path checks (`validateLexicalPath`) and filesystem-aware containment (`validatePath`, `SecureFs`), plus enforced read scopes for sandboxed workers and isolated Pages `ctx.fs`
 - CORS configuration
 - CSP (Content Security Policy)
 - Rate limiting

--- a/src/README.md
+++ b/src/README.md
@@ -266,7 +266,7 @@
 **Key Features**:
 
 - Input validation with Zod
-- Path traversal protection
+- Path containment helpers (`validateLexicalPath`), plus enforced read scope for sandboxed workers and isolated Pages `ctx.fs`
 - CORS configuration
 - CSP (Content Security Policy)
 - Rate limiting


### PR DESCRIPTION
## Description

`src/README.md` listed "Path traversal protection" as a flat feature of the `security/` layer. The generated `veryfront/fs` reference explicitly contradicts that for the `veryfront/fs` surface:

> `veryfront/fs` does not add a project-root sandbox, block `.env` or other secret-file names, or validate paths from untrusted input. Relative paths resolve from `cwd()`. Absolute paths and `..` segments can reach any location that the runtime permits.

Confirmed against `src/fs/index.ts:80-92` and `src/platform/compat/fs.ts:502-504`, which re-export and call through to the host runtime with no normalization and no root check.

The bullet now names the surfaces that do enforce containment: the `validateLexicalPath` helper exported at `src/security/index.ts:93`, the sandboxed-worker read scope in `src/security/sandbox/worker-read-scope.ts`, and the project-confined `ctx.fs` given to isolated Pages routes.

This is a documentation accuracy fix only. No behavior changes, and it is correct regardless of how the open trust-model question is decided.

## Type of Change

- [x] Documentation update

## Testing

- [x] No test covers README feature bullets in this repo, so there is no red test to add. Nothing else references the changed line.

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Documentation updated

Context: veryfront/veryfront-issue-inbox#105

https://claude.ai/code/session_01WtJ7sKmLwxBnuqFejdGQqc