### PR TITLE
fix(routing): canonicalise before the CJS shim's containment check

### DIFF
--- a/src/routing/api/module-loader/external-import-rewriter.ts
+++ b/src/routing/api/module-loader/external-import-rewriter.ts
@@ -77,6 +77,20 @@ var __vf_projectRoot = ${safeProjectRoot};
 // legitimate dependencies would be rejected.
 try { __vf_projectRoot = Deno.realPathSync(__vf_projectRoot); } catch (_) { /* expected: projectRoot may not exist at shim init in some environments */ }
 var __vf_cache = Object.create(null);
+// Resolve symlinks so containment compares canonical paths. A module that does
+// not exist yet cannot be canonicalized, so fall back to its parent directory,
+// which is what carries a symlinked project root; only if that fails too is the
+// plain resolved path used.
+function __vf_canonicalize(candidate) {
+  try {
+    return Deno.realPathSync(candidate);
+  } catch (_) { /* expected: candidate may not exist */ }
+  try {
+    var parent = __vf_dirname(candidate);
+    return Deno.realPathSync(parent) + candidate.slice(parent.length);
+  } catch (_) { /* expected: parent may not exist either */ }
+  return __vf_resolve(candidate);
+}
 function __vf_assertContained(resolved) {
   var norm = __vf_resolve(resolved).replace(/\\\\/g, "/");
   var root = __vf_projectRoot.replace(/\\\\/g, "/");
@@ -101,20 +115,15 @@ function __vf_loadCjs(id, parentDir) {
   } else {
     resolved = __vf_builtinRequire.resolve(id);
   }
-  // VULN-FS-5: Always assert containment after resolution (both branches),
-  // then re-canonicalize via realPathSync to resist symlinked node_modules
-  // entries that could point outside the project root.
+  // VULN-FS-5: Canonicalize before asserting containment, so the candidate and
+  // the already-canonical project root are compared like with like, then assert
+  // once. Checking the non-canonical path first rejected dependencies genuinely
+  // inside a project whose root is reached through a symlink, which is the
+  // ordinary case for package managers, CI checkouts and macOS /tmp.
+  // Canonicalizing first also keeps the guard against symlinked node_modules
+  // entries pointing outside the root: the escape is only visible once resolved.
+  resolved = __vf_canonicalize(resolved);
   __vf_assertContained(resolved);
-  var real;
-  try {
-    real = Deno.realPathSync(resolved);
-  } catch (_) {
-    /* expected: realPathSync fails for non-existent paths — assertContained above already held */
-  }
-  if (real !== undefined) {
-    __vf_assertContained(real);
-    resolved = real;
-  }
   if (resolved in __vf_cache) return __vf_cache[resolved];
   var code = Deno.readTextFileSync(resolved);
   if (resolved.endsWith(".json")) {

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -1819,16 +1819,19 @@ describe("generateCompiledBinaryRequireShim - static checks (VULN-FS-5)", () => 
     );
   });
 
-  it("emits a Deno.realPathSync re-canonicalisation on the resolved path", () => {
+  it("canonicalises the resolved path before checking containment", () => {
     const shim = generateCompiledBinaryRequireShim("/fake/project");
     assertEquals(shim.includes("Deno.realPathSync"), true);
-    // And the real path must itself be checked for containment.
-    const realIdx = shim.indexOf("Deno.realPathSync");
-    const realAssertIdx = shim.indexOf("__vf_assertContained(real)", realIdx);
+    // The containment check must run on the canonical path. Asserting on the
+    // pre-canonical one instead compares a non-canonical candidate against an
+    // already-canonical root, which rejects legitimate dependencies whenever
+    // the project root is itself a symlink.
+    const canonIdx = shim.indexOf("resolved = __vf_canonicalize(resolved)");
+    const assertIdx = shim.indexOf("__vf_assertContained(resolved)", canonIdx);
     assertEquals(
-      realAssertIdx > realIdx,
+      canonIdx !== -1 && assertIdx > canonIdx,
       true,
-      "realPathSync result must be containment-checked",
+      "the resolved path must be canonicalised before it is containment-checked",
     );
   });
 
@@ -1943,13 +1946,13 @@ describe("generateCompiledBinaryRequireShim - symlink resistance (VULN-FS-5)", {
   });
 
   denoIt("accepts dependencies through a symlinked project root", async () => {
-    // Regression for Codex review on #1120: if __vf_projectRoot is not
-    // canonicalised at shim init, a legitimate dep inside a symlinked project
-    // fails the post-realPathSync containment check (because realPathSync on
-    // the resolved module returns the canonical prefix while projectRoot is
-    // still the symlinked one).
-    const realProject = await makeTempDir();
-    const symlinkedProject = (await makeTempDir()) + "-link";
+    // Regression for #4091. The previous version of this test re-implemented
+    // __vf_assertContained locally and only ever called it with the already
+    // canonicalised path, so it passed without ever exercising the check that
+    // actually rejected these dependencies. The emitted shim is executed here
+    // so the containment check itself is the thing under test.
+    const realProject = Deno.realPathSync(await makeTempDir());
+    const symlinkedProject = `${realProject}-link`;
     try {
       await Deno.symlink(realProject, symlinkedProject);
     } catch (e) {
@@ -1960,28 +1963,18 @@ describe("generateCompiledBinaryRequireShim - symlink resistance (VULN-FS-5)", {
 
     const depDir = join(realProject, "node_modules", "ok");
     await fs.mkdir(depDir, { recursive: true });
-    const depEntry = join(depDir, "index.js");
-    await fs.writeTextFile(depEntry, "module.exports = 1;");
+    await fs.writeTextFile(join(depDir, "index.js"), "module.exports = { ok: true };");
 
-    // Simulate shim init: projectRoot supplied as the symlinked path, then
-    // canonicalised via realPathSync (the fix).
-    let projectRoot = symlinkedProject;
-    projectRoot = Deno.realPathSync(projectRoot);
+    // The project root is handed to the shim as the symlinked path, which is
+    // what happens with package managers, CI checkouts, and macOS /tmp.
+    const vfRequire = await importCompiledBinaryRequireShim(symlinkedProject);
 
-    const assertContained = (resolved: string): void => {
-      const norm = resolved.replace(/\\/g, "/");
-      const root = projectRoot.replace(/\\/g, "/");
-      if (!norm.startsWith(root + "/") && norm !== root) {
-        throw new Error("CJS loader blocked path outside project: " + resolved);
-      }
-    };
-
-    // Resolve through the symlinked project root (as createRequire would),
-    // then realPathSync (as the shim does). With the fix, projectRoot is
-    // canonical so this passes. Without the fix, it would throw.
-    const resolvedThroughSymlink = join(symlinkedProject, "node_modules/ok/index.js");
-    const real = Deno.realPathSync(resolvedThroughSymlink);
-    assertContained(real);
+    assertEquals(
+      (vfRequire(join(symlinkedProject, "node_modules", "ok", "index.js")) as { ok: boolean })
+        .ok,
+      true,
+      "a dependency genuinely inside the project must load when the root is a symlink",
+    );
 
     try {
       await fs.remove(symlinkedProject);


### PR DESCRIPTION
## Description

The emitted CJS shim asserted containment **before** canonicalising:

```js
__vf_assertContained(resolved);
try { real = Deno.realPathSync(resolved); } catch (_) { /* non-existent path */ }
if (real !== undefined) { __vf_assertContained(real); resolved = real; }
```

`__vf_projectRoot` has already been through `realPathSync` at shim init, so that first assertion compares a **non-canonical** candidate against a **canonical** root. When the project root is itself reached through a symlink the two disagree, and a dependency genuinely inside the project is rejected with `CJS loader blocked path outside project`.

This fails closed rather than open, so it is a correctness and usability problem rather than a security one. It affects any layout where the project root is a symlink: package managers, CI checkouts, and macOS `/tmp`, which is a symlink to `/private/tmp`.

### Fix

Canonicalise first, then assert once. `__vf_canonicalize` falls back to the **parent directory** when the module does not exist yet, since the parent is what carries a symlinked root, and to the plain resolved path when that fails too. The assertion therefore always runs, on the most canonical form available.

The symlink-escape guard is unaffected. That escape is only visible *after* canonicalisation, which is precisely what the single remaining assertion runs on. Dropping the pre-canonicalisation assertion loses nothing: any path it would have rejected is still rejected by the canonical check, whereas the reverse — canonical-contained but non-canonical-looking — is exactly the false rejection being fixed.

## Related Issue(s)

Fixes #4091

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have added tests that prove my fix is effective

## Testing

### Why the existing test did not catch this

`loader.test.ts` already had a test named **"accepts dependencies through a symlinked project root"**. It passed on `main` while the bug was live, because it re-implemented `__vf_assertContained` inline:

```ts
const assertContained = (resolved: string): void => { /* local copy */ };
const real = Deno.realPathSync(resolvedThroughSymlink);
assertContained(real);          // only ever called with the canonical path
```

It never ran the emitted shim and never called the check with the pre-canonical path, so the assertion that actually rejected these dependencies was never exercised. The test was vacuous with respect to the behaviour it claimed to cover.

It now uses the file's existing `importCompiledBinaryRequireShim` helper to execute the real emitted shim against a symlinked root. Verified to fail without the fix:

```
CJS loader blocked path outside project:
  /private/var/folders/.../tmp-9827889dd203c9dd-link/node_modules/ok/index.js
```

The neighbouring escape test — "re-canonicalisation via realPathSync catches a node_modules symlink escape" — passes both before and after, confirming the security property is intact.

One static test was also retargeted. It asserted the literal string `__vf_assertContained(real)`, pinning a variable name rather than a property; it now asserts that canonicalisation precedes the containment check.

```
deno task test:file src/routing/     45 passed (1161 steps) | 0 failed
deno check src/routing/api/index.ts
deno task lint:anti-slop / lint:test-semantic-dispositions / lint:skipped-tests / lint:sanitizer-baseline
deno fmt --check, deno lint
```