### PR TITLE
fix(ci): run required checks on pull requests off any base branch

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -3,7 +3,6 @@ name: CI/CD
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
   # Required for merge-queue entries: queued runs report checks via merge_group.
   merge_group:
     types: [checks_requested]

--- a/.github/workflows/client-bundle-report.yml
+++ b/.github/workflows/client-bundle-report.yml
@@ -6,7 +6,6 @@ name: Client bundle report
 # fail-fast check runs in the `ci (lint)` job via `deno task lint:client-bundle`.
 on:
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   # Required for merge-queue entries: queued runs report checks via merge_group.
   merge_group:
     types: [checks_requested]

--- a/src/security/repository-hardening.test.ts
+++ b/src/security/repository-hardening.test.ts
@@ -1,5 +1,6 @@
 import { assert, assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { parse } from "#std/yaml/parse";
 
 const WORKFLOW_PR_GUARD =
   "github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository";
@@ -40,35 +41,61 @@ function jobBlock(workflow: string, jobName: string): string {
   return nextJob === -1 ? rest : rest.slice(0, nextJob);
 }
 
-/** Slices the body of the top-level `on:` mapping, excluding the `on:` line. */
-function onBlock(workflow: string, path: string): string {
-  const marker = "\non:\n";
-  const start = workflow.indexOf(marker);
-  assert(start >= 0, `expected ${path} to define a top-level on: block`);
+/**
+ * Reads the top-level `on:` mapping of a workflow as parsed YAML.
+ *
+ * The trigger assertions below used to slice this block with string offsets.
+ * That made every answer depend on where a sibling trigger happened to sit:
+ * a trigger written with no body left the slice starting at the NEXT sibling,
+ * so the helper silently returned that sibling's entry, and a guard could pass
+ * while reporting on a trigger nobody asked about. Parsing the document takes
+ * trigger order, body emptiness and comment placement out of the question.
+ *
+ * GitHub's `on` key comes back as the string key "on" rather than YAML 1.1's
+ * boolean `true`, so it is read by name.
+ */
+async function workflowTriggers(
+  path: string,
+): Promise<Record<string, unknown>> {
+  const document = parse(await readText(path));
+  assert(
+    document !== null && typeof document === "object" &&
+      !Array.isArray(document),
+    `expected ${path} to parse as a YAML mapping`,
+  );
 
-  const rest = workflow.slice(start + marker.length);
-  const nextTopLevelKey = rest.search(/\n[A-Za-z0-9_-]+:/);
-  return nextTopLevelKey === -1 ? rest : rest.slice(0, nextTopLevelKey);
+  const triggers = (document as Record<string, unknown>).on;
+  assert(
+    triggers !== null && typeof triggers === "object" &&
+      !Array.isArray(triggers),
+    `expected ${path} to define a top-level on: mapping of triggers`,
+  );
+  return triggers as Record<string, unknown>;
 }
 
 /**
- * Slices a single trigger entry out of the `on:` block. Scoped to that one
- * entry so a sibling trigger keeping its own `branches:` filter (`push:`
- * legitimately stays pinned to main) cannot be mistaken for it.
+ * Reads one trigger entry out of a parsed `on:` mapping. A trigger written
+ * with no body (`pull_request:`) parses as null, which is its unfiltered form,
+ * and is returned as null rather than being confused with a sibling entry.
  */
 function triggerEntry(
-  workflow: string,
+  triggers: Record<string, unknown>,
   path: string,
   trigger: string,
-): string {
-  const block = onBlock(workflow, path);
-  const marker = `  ${trigger}:\n`;
-  const start = block.indexOf(marker);
-  assert(start >= 0, `expected ${path} to define an ${trigger}: trigger`);
+): Record<string, unknown> | null {
+  assert(
+    Object.hasOwn(triggers, trigger),
+    `expected ${path} to define an ${trigger}: trigger`,
+  );
 
-  const rest = block.slice(start + marker.length);
-  const nextTrigger = rest.search(/\n {2}[A-Za-z0-9_-]+:/);
-  return nextTrigger === -1 ? rest : rest.slice(0, nextTrigger);
+  const entry = triggers[trigger];
+  if (entry === null || entry === undefined) return null;
+  assert(
+    typeof entry === "object" && !Array.isArray(entry),
+    `expected ${path} ${trigger}: trigger to be empty or a mapping of ` +
+      `filters, found ${JSON.stringify(entry)}`,
+  );
+  return entry as Record<string, unknown>;
 }
 
 function workflowStepBlock(workflow: string, stepName: string): string {
@@ -385,18 +412,25 @@ describe("repository hardening", () => {
         ".github/workflows/client-bundle-report.yml",
       ]
     ) {
-      const workflow = stripComments(await readText(path));
-      const pullRequest = triggerEntry(workflow, path, "pull_request");
+      const pullRequest = triggerEntry(
+        await workflowTriggers(path),
+        path,
+        "pull_request",
+      );
+      const branchFilters = Object.keys(pullRequest ?? {}).filter((key) =>
+        key === "branches" || key === "branches-ignore"
+      );
 
       assertEquals(
-        /^\s+branches(?:-ignore)?:/m.test(pullRequest),
-        false,
+        branchFilters,
+        [],
         `${path} filters its pull_request: trigger by branch, and GitHub ` +
           `matches that filter against the pull request BASE branch. A pull ` +
           `request stacked on any other branch would skip this workflow ` +
           `entirely, its required checks would report as absent rather than ` +
           `failing, and branch protection would let it merge green without ` +
-          `ever running the gates. Found: ${JSON.stringify(pullRequest)}`,
+          `ever running the gates. Found pull_request: ` +
+          `${JSON.stringify(pullRequest)}`,
       );
     }
   });
@@ -408,15 +442,16 @@ describe("repository hardening", () => {
         ".github/workflows/codeql.yml",
       ]
     ) {
-      const workflow = stripComments(await readText(path));
-      const push = triggerEntry(workflow, path, "push");
+      const push = triggerEntry(await workflowTriggers(path), path, "push");
 
-      assert(
-        /^\s+branches: \[main\]$/m.test(push),
+      assertEquals(
+        push?.branches,
+        ["main"],
         `${path} must keep its push: trigger pinned to branches: [main]. ` +
           `Release-capable jobs key off refs/heads/main on push, so widening ` +
           `this trigger would expose the publish path to feature branches. ` +
-          `Found: ${JSON.stringify(push)}`,
+          `An empty push: entry is the widest form of all and must fail here ` +
+          `too. Found push: ${JSON.stringify(push)}`,
       );
     }
   });

--- a/src/security/repository-hardening.test.ts
+++ b/src/security/repository-hardening.test.ts
@@ -40,6 +40,37 @@ function jobBlock(workflow: string, jobName: string): string {
   return nextJob === -1 ? rest : rest.slice(0, nextJob);
 }
 
+/** Slices the body of the top-level `on:` mapping, excluding the `on:` line. */
+function onBlock(workflow: string, path: string): string {
+  const marker = "\non:\n";
+  const start = workflow.indexOf(marker);
+  assert(start >= 0, `expected ${path} to define a top-level on: block`);
+
+  const rest = workflow.slice(start + marker.length);
+  const nextTopLevelKey = rest.search(/\n[A-Za-z0-9_-]+:/);
+  return nextTopLevelKey === -1 ? rest : rest.slice(0, nextTopLevelKey);
+}
+
+/**
+ * Slices a single trigger entry out of the `on:` block. Scoped to that one
+ * entry so a sibling trigger keeping its own `branches:` filter (`push:`
+ * legitimately stays pinned to main) cannot be mistaken for it.
+ */
+function triggerEntry(
+  workflow: string,
+  path: string,
+  trigger: string,
+): string {
+  const block = onBlock(workflow, path);
+  const marker = `  ${trigger}:\n`;
+  const start = block.indexOf(marker);
+  assert(start >= 0, `expected ${path} to define an ${trigger}: trigger`);
+
+  const rest = block.slice(start + marker.length);
+  const nextTrigger = rest.search(/\n {2}[A-Za-z0-9_-]+:/);
+  return nextTrigger === -1 ? rest : rest.slice(0, nextTrigger);
+}
+
 function workflowStepBlock(workflow: string, stepName: string): string {
   const marker = `      - name: ${stepName}\n`;
   const start = workflow.indexOf(marker);
@@ -331,6 +362,62 @@ describe("repository hardening", () => {
           `expected ${path} job ${jobName} to carry the fork guard on its own job-level if:, not on a step`,
         );
       }
+    }
+  });
+
+  it("runs the required checks on a pull request whatever its base branch", async () => {
+    // GitHub matches `branches:` on a `pull_request:` trigger against the pull
+    // request's BASE branch, not its head. While these workflows carried
+    // `branches: [main]`, a pull request stacked on any other branch ran none
+    // of them, and a required status context that never runs is ABSENT rather
+    // than failing, so branch protection had nothing to block on: the pull
+    // request rendered fully green having run zero gates.
+    //
+    // cicd.yml owns `ci (format)`, `ci (lint)`, `ci (typecheck)`,
+    // `tests (unit)`, `tests (integration)`, `coverage gate`,
+    // `tests (rsc browser e2e)` and `tests (binary e2e)`; codeql.yml owns
+    // `Analyze`. client-bundle-report.yml is informational but shares the
+    // failure mode, so it is held to the same rule.
+    for (
+      const path of [
+        ".github/workflows/cicd.yml",
+        ".github/workflows/codeql.yml",
+        ".github/workflows/client-bundle-report.yml",
+      ]
+    ) {
+      const workflow = stripComments(await readText(path));
+      const pullRequest = triggerEntry(workflow, path, "pull_request");
+
+      assertEquals(
+        /^\s+branches(?:-ignore)?:/m.test(pullRequest),
+        false,
+        `${path} filters its pull_request: trigger by branch, and GitHub ` +
+          `matches that filter against the pull request BASE branch. A pull ` +
+          `request stacked on any other branch would skip this workflow ` +
+          `entirely, its required checks would report as absent rather than ` +
+          `failing, and branch protection would let it merge green without ` +
+          `ever running the gates. Found: ${JSON.stringify(pullRequest)}`,
+      );
+    }
+  });
+
+  it("keeps push builds pinned to main so widening pull requests cannot publish", async () => {
+    for (
+      const path of [
+        ".github/workflows/cicd.yml",
+        ".github/workflows/codeql.yml",
+      ]
+    ) {
+      const workflow = stripComments(await readText(path));
+      const push = triggerEntry(workflow, path, "push");
+
+      assert(
+        /^\s+branches: \[main\]$/m.test(push),
+        `${path} must keep its push: trigger pinned to branches: [main]. ` +
+          `Release-capable jobs key off refs/heads/main on push, so widening ` +
+          `this trigger would expose the publish path to feature branches. ` +
+          `Found: ${JSON.stringify(push)}`,
+      );
     }
   });
 


### PR DESCRIPTION
## Description

A pull request based on a branch other than `main` ran **none** of the nine required checks, and still rendered fully green.

GitHub matches the `branches:` filter on a `pull_request:` trigger against the pull request's **base** branch, not its head. Three workflows pinned that filter to main:

- `.github/workflows/cicd.yml` owned 8 of the 9 required contexts: the `ci` matrix (`ci (format)`, `ci (lint)`, `ci (typecheck)`), `tests (unit)`, `tests (integration)`, `coverage gate`, `tests (rsc browser e2e)`, `tests (binary e2e)`.
- `.github/workflows/codeql.yml` owned the 9th, `Analyze`.
- `.github/workflows/client-bundle-report.yml` owned the informational bundle-report comment.

A required status context that never runs is **absent**, not failing, so branch protection had nothing to block on. A stacked pull request merged green having run zero gates. Live proof at the time of filing: PR #4146 (base = a feature branch) showed 0 of 9 required contexts, PR #4142 (base = main) showed all 9.

The fix removes the `branches:` restriction from the `pull_request:` trigger in all three workflows. `push: branches: [main]` and `merge_group:` are untouched.

### Publish safety

No publish path can fire from the widened `pull_request` trigger:

- `version-check` and `build-binaries` are gated on `github.ref == 'refs/heads/main'`, which a `pull_request` run never satisfies.
- `prerelease` and `release` both list `version-check` in `needs`, so a skipped `version-check` skips them too.
- The "Configure test migration baselines" step already resolves from `github.event.pull_request.base.sha` rather than `origin/main`, so a feature-branch base works unchanged.
- Concurrency already keys `pull_request` runs by `github.ref` with `cancel-in-progress`, so stacked-PR pushes still supersede their own earlier runs.

### Note on runner cost

This runs the full matrix on stacked pull requests, which costs more runner minutes than before. The cheaper alternative, keeping the trigger narrow and adding job-level `if:` conditions, was deliberately not taken: it reintroduces the visible/invisible split between "check exists but was skipped" and "check never existed" that is the whole complaint here.

## What this pull request cannot show, and what it does not cover

Three limits, stated up front because none of them are visible from the diff or from this pull request's own check run.

**1. This pull request cannot demonstrate its own fix.** Its base is `main`, so all nine required checks run on it either way, before and after the change. A green run here is evidence that the widened triggers still work on a main-based pull request, and nothing more. Proving the stacked case needs a throwaway pull request based on a feature branch, opened after this merges; that is the only place the before/after difference is observable.

**2. The regression assertions run on the Deno unit runner only.** `src/security/repository-hardening.test.ts` reads workflow files through `Deno.readTextFile`, and both the Node and the Bun runners drop any test file whose source mentions `Deno.` (`tests/test-file-utils.mjs`, `isDenoDependentTestSource`). So the whole file, not just the new assertions, is excluded from `tests (node)` and `tests (bun)`. That is fine for a repository-configuration assertion, which has no runtime-portability dimension, but it does mean `tests (unit)` is the single lane holding this guard.

**3. Branch protection itself is unchanged by this pull request.** The nine required contexts are configured on the repository, not in this repository's source, and nothing here asserts anything about them. The hole closed here is "the workflow did not run"; the identical symptom is reachable through "the required context name drifted from the job name that produces it", and neither this change nor its test would catch that. A required context whose name no longer matches any job is absent for exactly the same reason and merges green in exactly the same way.

## Scope decision: `security-audit.yml` is knowingly left alone

`.github/workflows/security-audit.yml:19-20` carries the same `pull_request: branches: [main]` pin, and it is deliberately not changed here.

It is not a required context. Verified directly against branch protection:

```
$ gh api repos/veryfront/veryfront-code/branches/main/protection \
    --jq '.required_status_checks.contexts'
["ci (format)","ci (lint)","ci (typecheck)","tests (unit)","tests (integration)",
 "coverage gate","tests (rsc browser e2e)","tests (binary e2e)","Analyze"]
```

Its two jobs, `NPM Dependency Audit` and `Submit Dependency Snapshot`, appear nowhere in that list, so merging is never gated on them from any base branch. The reported bug is specifically "a required context that never ran is absent rather than failing, and branch protection lets the merge through", and `security-audit.yml` cannot participate in that failure mode. Widening it would be a separate behavioural change to advisory coverage, landing in the same diff as a fix whose workflow half has already been reviewed on its own terms.

The gap it leaves is real and worth stating plainly: **a pull request stacked on a feature branch that edits `deno.json`, `cli/deno.json`, `react/deno.json`, an extension manifest, or anything else under that trigger's `paths:` filter gets zero dependency-audit coverage.** The audit runs later, on the push to main, so nothing reaches a release unaudited, but the stacked pull request itself is reviewed without it.

Follow-up, not carried by this pull request: remove `branches: [main]` from `security-audit.yml`'s `pull_request:` trigger and extend `runs the required checks on a pull request whatever its base branch` to cover that fourth file. The trigger's `paths:` filter keeps the added runner cost near zero, so the follow-up is small; it is separated for reviewability, not because it is hard.

## Related Issue(s)

Context: veryfront/veryfront-issue-inbox#766

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Testing

Regression coverage lands in the existing workflow-assertion lane, `src/security/repository-hardening.test.ts`, which already asserts against these same three workflow files:

- `runs the required checks on a pull request whatever its base branch` asserts the `pull_request:` entry inside the top-level `on:` block of all three workflows carries no `branches:` or `branches-ignore:` key. The assertion is scoped to that one trigger entry, so `push: branches: [main]` cannot trip it.
- `keeps push builds pinned to main so widening pull requests cannot publish` is the paired guard: it asserts `push:` keeps `branches: [main]`, so a future "fix" cannot widen the publish path while satisfying the first test.

### Trigger lookup is parsed, not sliced

Both assertions locate their trigger by parsing the workflow with `#std/yaml/parse` and reading `on.pull_request` / `on.push` off the resulting mapping. The first version of these helpers sliced the `on:` block with string offsets, and that approach was wrong in a way that made both guards report on the wrong trigger:

- `block.slice(start + marker.length)` started **past** the marker's trailing newline. For an empty-bodied trigger the remainder therefore began at the next sibling key with no preceding newline, the `/\n {2}[A-Za-z0-9_-]+:/` scan skipped that sibling, and the helper returned the trigger **after** the one it was asked for.
- Because the applied fix makes `pull_request:` empty-bodied, this meant the headline assertion was inspecting `merge_group` on both `cicd.yml` and `codeql.yml` and passing for the wrong reason. The original red run was real, but only because a *filtered* `pull_request:` has a non-empty body and slices correctly.
- The same defect inverted the push guard: an empty `push:` entry sitting above a still-pinned `pull_request:` resolved to the pull_request entry, so the guard passed while the publish trigger was completely unfiltered.
- It was also order-dependent. Reordering `codeql.yml`'s `on:` block to put `pull_request:` above `push:`, a no-op for GitHub, made the slice resolve to `"  push:\n    branches: [main]"` and failed the test spuriously.

Parsing removes all four failure modes at once: an empty trigger body parses as `null` (its unfiltered form), sibling order is irrelevant, comments never need stripping, and `on` comes back as the string key `"on"` rather than YAML 1.1's boolean `true`. Slicing helpers elsewhere in the file are unchanged; this is the one place where a wrong answer is silent rather than loud.

### Mutation evidence

Each mutation below was applied to the workflow file, run against both the sliced helper and the parsed helper, and then reverted. Outputs are verbatim.

**(a) The headline assertion now inspects `pull_request`, not `merge_group`.**

Mutation: add `branches: [main]` under `cicd.yml`'s `merge_group:` entry, leaving `pull_request:` empty and correct. If the assertion is really reading `pull_request`, this must not affect it.

Sliced helper, `runs the required checks on a pull request whatever its base branch` FAILS, and its own message names the entry it read:

```
error: AssertionError: Values are not equal: .github/workflows/cicd.yml filters its
pull_request: trigger by branch, [...] Found: "  merge_group:\n    types:
[checks_requested]\n    branches: [main]"
```

Parsed helper, same mutation:

```
  runs the required checks on a pull request whatever its base branch ... ok (25ms)
  keeps push builds pinned to main so widening pull requests cannot publish ... ok (16ms)
ok | 1 passed (13 steps) | 0 failed (51ms)
```

And the parsed helper still bites on the real target. Mutation: restore `merge_group:`, re-pin `pull_request: branches: [main]`:

```
  runs the required checks on a pull request whatever its base branch ... FAILED (20ms)

error: AssertionError: Values are not equal: .github/workflows/cicd.yml filters its
pull_request: trigger by branch, and GitHub matches that filter against the pull
request BASE branch. [...] Found pull_request: {"branches":["main"]}

    [Diff] Actual / Expected

-   [
-     "branches",
-   ]
+   []
```

**(b) Trigger order no longer matters.**

Mutation: reorder `codeql.yml`'s `on:` block to put `pull_request:` above `push:`. This is a no-op for GitHub.

Sliced helper fails spuriously, on a workflow that is entirely correct:

```
  runs the required checks on a pull request whatever its base branch ... FAILED (1ms)

error: AssertionError: Values are not equal: .github/workflows/codeql.yml filters its
pull_request: trigger by branch, [...] Found: "  push:\n    branches: [main]"
```

Parsed helper, same reordering:

```
  keeps push builds pinned to main so widening pull requests cannot publish ... ok (12ms)
  leaves the CLA workflow non-executing for contributor code ... ok (0ms)
repository hardening ... ok (40ms)

ok | 1 passed (13 steps) | 0 failed (41ms)
```

**(c) The push guard now fails when the publish trigger is widened.**

Mutation: in `cicd.yml`, empty the `push:` entry and move it above a `pull_request:` that keeps `branches: [main]`. The publish trigger is now wide open on every branch.

Sliced helper: the guard reports **ok** while `push:` is completely unfiltered, which is the exact inverse of what it exists to prevent:

```
  runs the required checks on a pull request whatever its base branch ... FAILED (1ms)
  keeps push builds pinned to main so widening pull requests cannot publish ... ok (1ms)
```

Parsed helper, same mutation:

```
  runs the required checks on a pull request whatever its base branch ... FAILED (19ms)
  keeps push builds pinned to main so widening pull requests cannot publish ... FAILED (13ms)

error: AssertionError: Values are not equal: .github/workflows/cicd.yml must keep its
push: trigger pinned to branches: [main]. Release-capable jobs key off refs/heads/main
on push, so widening this trigger would expose the publish path to feature branches. An
empty push: entry is the widest form of all and must fail here too. Found push: null
```

All three workflow files were restored after each mutation; `git status` confirms the only tracked change in this pull request beyond the three trigger removals is `src/security/repository-hardening.test.ts`.

### TDD evidence

Red, with the workflow fix reverted and the new test in place:

```
  runs only trusted non-code aggregates for fork pull requests ... ok (1ms)
  runs the required checks on a pull request whatever its base branch ... FAILED (1ms)
  keeps push builds pinned to main so widening pull requests cannot publish ... ok (1ms)

error: AssertionError: Values are not equal: .github/workflows/cicd.yml filters its
pull_request: trigger by branch, and GitHub matches that filter against the pull
request BASE branch. A pull request stacked on any other branch would skip this
workflow entirely, its required checks would report as absent rather than failing,
and branch protection would let it merge green without ever running the gates.

FAILED | 0 passed (12 steps) | 1 failed (1 step) (8ms)
```

Green, with the workflow fix applied and the parsed helper in place:

```
  runs only trusted non-code aggregates for fork pull requests ... ok (1ms)
  runs the required checks on a pull request whatever its base branch ... ok (22ms)
  keeps push builds pinned to main so widening pull requests cannot publish ... ok (11ms)
  leaves the CLA workflow non-executing for contributor code ... ok (0ms)
repository hardening ... ok (39ms)

ok | 1 passed (13 steps) | 0 failed (40ms)
```

### Regression runs

- `deno task test:unit:parallel`: `ok | 4276 passed (34110 steps) | 0 failed | 1 ignored (5 steps) (2m41s)`
- `deno task test:file src/security/repository-hardening.test.ts`: `ok | 1 passed (13 steps) | 0 failed (40ms)`
- `deno task test:file tests/integration/ci/merge-quality-gate-workflow.test.ts`: `ok | 1 passed (7 steps) | 0 failed`
- Lint gates for the test lane all pass: `lint:test-semantic-dispositions`, `lint:cwd-relative-test-reads`, `lint:anti-slop`, `lint:skipped-tests`, `lint:testing-front-door`, `lint:module-boundaries`, `lint:cross-runtime-jsr`, `test:layout`, plus `deno fmt --check`, `deno lint` and `deno check` on the changed file.
- All three widened workflow files were re-parsed as YAML to confirm `pull_request` now resolves to an unfiltered trigger while `push` keeps `branches: [main]`.

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

https://claude.ai/code/session_01WtJ7sKmLwxBnuqFejdGQqc
