### PR TITLE
fix(sandbox): stop LazySandbox aborting on a malformed NDJSON line

### DIFF
--- a/docs/api-reference/veryfront/sandbox.md
+++ b/docs/api-reference/veryfront/sandbox.md
@@ -182,15 +182,15 @@ Streaming event emitted during command execution.
 | `createSandboxShellTools`              | Create sandbox shell tools.                     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/shell-tools.ts#L242)         |
 | `normalizeBashToolSet`                 | Normalizes bash tool set.                       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/shell-tools.ts#L197)         |
 | `renameSandboxFileTools`               | Rename sandbox file tools.                      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/shell-tools.ts#L206)         |
-| `resolveDefaultSandboxRuntimeEndpoint` | Resolves default sandbox runtime endpoint.      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/lazy-sandbox.ts#L79)         |
+| `resolveDefaultSandboxRuntimeEndpoint` | Resolves default sandbox runtime endpoint.      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/lazy-sandbox.ts#L80)         |
 | `unwrapSandboxWorkingDirectoryCommand` | Unwrap sandbox working directory command.       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L51)  |
 
 ### Classes
 
 | Name          | Description                                                                             | Source                                                                                           |
 | ------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `LazySandbox` | Lazily provisions sandbox sessions and keeps them alive while in use.                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/lazy-sandbox.ts#L105) |
-| `Sandbox`     | Client for isolated ephemeral compute environments with command execution and file I/O. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/sandbox.ts#L44)       |
+| `LazySandbox` | Lazily provisions sandbox sessions and keeps them alive while in use.                   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/lazy-sandbox.ts#L106) |
+| `Sandbox`     | Client for isolated ephemeral compute environments with command execution and file I/O. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/sandbox.ts#L45)       |
 
 ### Types
 
@@ -215,7 +215,7 @@ Streaming event emitted during command execution.
 | `HostedSandboxClientOptions`                 | Options accepted by hosted sandbox client.                                                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L191)   |
 | `HostedSandboxToolsOptions`                  | Options accepted by hosted sandbox tools.                                                                         | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L193)   |
 | `HostedSandboxToolsResult`                   | Result returned from hosted sandbox tools.                                                                        | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/agent-service-tools.ts#L195)   |
-| `LazySandboxOptions`                         | Options accepted by lazy sandbox.                                                                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/lazy-sandbox.ts#L17)           |
+| `LazySandboxOptions`                         | Options accepted by lazy sandbox.                                                                                 | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/lazy-sandbox.ts#L18)           |
 | `SandboxAttachment`                          | Known sandbox session connection details used to attach without a lookup round-trip.                              | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L92)                  |
 | `SandboxListOptions`                         | Options for listing sandbox sessions.                                                                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L75)                  |
 | `SandboxListResult`                          | Paginated result of sandbox sessions.                                                                             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/sandbox/types.ts#L81)                  |

--- a/src/sandbox/exec-stream.test.ts
+++ b/src/sandbox/exec-stream.test.ts
@@ -1,0 +1,94 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ExecStreamEvent } from "./types.ts";
+import { readExecStreamEvents } from "./exec-stream.ts";
+
+/** Streams `chunks` verbatim so chunk boundaries can be placed deliberately. */
+function streamOf(...chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+async function collect(stream: ReadableStream<Uint8Array>): Promise<ExecStreamEvent[]> {
+  const events: ExecStreamEvent[] = [];
+  for await (const event of readExecStreamEvents(stream)) events.push(event);
+  return events;
+}
+
+describe("sandbox/exec-stream", () => {
+  it("yields one event per NDJSON line", async () => {
+    const events = await collect(streamOf(
+      '{"type":"stdout","data":"a"}\n{"type":"stderr","data":"b"}\n{"type":"exit","exitCode":0}\n',
+    ));
+
+    assertEquals(events.map((event) => event.type), ["stdout", "stderr", "exit"]);
+  });
+
+  it("keeps streaming past a malformed line", async () => {
+    const events = await collect(streamOf(
+      '{"type":"stdout","data":"a"}\n',
+      "<<garbage>>\n",
+      '{"type":"exit","exitCode":0}\n',
+    ));
+
+    assertEquals(
+      events.map((event) => event.type),
+      ["stdout", "exit"],
+      "a truncated chunk must not discard the events buffered around it",
+    );
+  });
+
+  it("discards a malformed final chunk rather than throwing", async () => {
+    const events = await collect(streamOf('{"type":"stdout","data":"a"}\n', "{truncated"));
+
+    assertEquals(
+      events.map((event) => event.type),
+      ["stdout"],
+      "an unterminated trailing chunk must not surface as a SyntaxError",
+    );
+  });
+
+  it("yields a final line that arrives without a trailing newline", async () => {
+    const events = await collect(streamOf('{"type":"exit","exitCode":3}'));
+
+    assertEquals(events.length, 1, "the last line need not be newline-terminated");
+    assertEquals(events[0]?.exitCode, 3);
+  });
+
+  it("reassembles an event split across chunk boundaries", async () => {
+    const events = await collect(streamOf('{"type":"std', 'out","data":"split"}\n'));
+
+    assertEquals(events.length, 1, "a JSON object split mid-token must be rejoined, not dropped");
+    assertEquals(events[0]?.data, "split");
+  });
+
+  it("ignores blank lines", async () => {
+    const events = await collect(streamOf('\n\n{"type":"exit","exitCode":0}\n\n'));
+
+    assertEquals(events.length, 1);
+  });
+
+  it("cancels the body when the caller stops iterating early", async () => {
+    let cancelled = false;
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('{"type":"stdout","data":"a"}\n'));
+        controller.enqueue(encoder.encode('{"type":"exit","exitCode":0}\n'));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+
+    for await (const _event of readExecStreamEvents(stream)) break;
+
+    assertEquals(cancelled, true, "abandoning the generator must not leave the body open");
+  });
+});

--- a/src/sandbox/exec-stream.ts
+++ b/src/sandbox/exec-stream.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared NDJSON reader for sandbox exec streams.
+ * @module sandbox/exec-stream
+ */
+
+import type { ExecStreamEvent } from "./types.ts";
+
+/**
+ * Parses one NDJSON line, reporting null for anything unusable.
+ *
+ * A malformed line is skipped rather than thrown. This transport delivers
+ * truncated network chunks, and aborting would discard every event already
+ * buffered ahead of the bad line.
+ */
+function parseExecStreamLine(line: string): ExecStreamEvent | null {
+  if (!line.trim()) return null;
+
+  try {
+    return JSON.parse(line) as ExecStreamEvent;
+  } catch (_) {
+    /* expected: truncated or malformed NDJSON line, skipped to keep streaming */
+    return null;
+  }
+}
+
+/**
+ * Reads an exec response body as NDJSON, yielding one event per line.
+ *
+ * Sandbox and LazySandbox consume the same stream, so the loop lives here.
+ * Keeping a copy in each is what let them disagree about malformed input: the
+ * eager path skipped a bad line while the lazy one threw out of the generator
+ * and dropped the output that had already arrived.
+ */
+export async function* readExecStreamEvents(
+  body: ReadableStream<Uint8Array>,
+): AsyncGenerator<ExecStreamEvent> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let completed = false;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        completed = true;
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        const event = parseExecStreamLine(line);
+        if (event) yield event;
+      }
+    }
+
+    buffer += decoder.decode();
+    const trailing = parseExecStreamLine(buffer);
+    if (trailing) yield trailing;
+  } finally {
+    // An early return from the caller leaves the stream open; cancel it so the
+    // connection is not held until GC.
+    if (!completed) {
+      await reader.cancel().catch(() => {});
+    }
+    reader.releaseLock();
+  }
+}

--- a/src/sandbox/lazy-sandbox.ts
+++ b/src/sandbox/lazy-sandbox.ts
@@ -3,6 +3,7 @@ import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { logger, sleep } from "#veryfront/utils";
 import { resolveSandboxApiUrl, resolveSandboxAuthToken } from "./config.ts";
 import { readSandboxFileContent, sandboxSessionRoute } from "./proxy-routes.ts";
+import { readExecStreamEvents } from "./exec-stream.ts";
 import {
   type BackgroundCommand,
   type BackgroundCommandOutput,
@@ -214,39 +215,7 @@ export class LazySandbox {
       throw new Error("Exec response has no body");
     }
 
-    const reader = res.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
-    let completed = false;
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          completed = true;
-          break;
-        }
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop() ?? "";
-
-        for (const line of lines) {
-          if (!line.trim()) continue;
-          yield JSON.parse(line) as ExecStreamEvent;
-        }
-      }
-
-      buffer += decoder.decode();
-      if (buffer.trim()) {
-        yield JSON.parse(buffer) as ExecStreamEvent;
-      }
-    } finally {
-      if (!completed) {
-        await reader.cancel().catch(() => {});
-      }
-      reader.releaseLock();
-    }
+    yield* readExecStreamEvents(res.body);
   }
 
   async readFile(path: string): Promise<string> {

--- a/src/sandbox/sandbox.ts
+++ b/src/sandbox/sandbox.ts
@@ -11,6 +11,7 @@ import { INITIALIZATION_ERROR, REQUEST_ERROR, TIMEOUT_ERROR } from "#veryfront/e
 import { LazySandbox, type LazySandboxOptions } from "./lazy-sandbox.ts";
 import { resolveSandboxApiUrl, resolveSandboxAuthToken } from "./config.ts";
 import { readSandboxFileContent, sandboxSessionRoute } from "./proxy-routes.ts";
+import { readExecStreamEvents } from "./exec-stream.ts";
 import type {
   BackgroundCommand,
   BackgroundCommandHeartbeatStatus,
@@ -210,49 +211,7 @@ export class Sandbox {
     if (!res.body) {
       throw new Error("Exec response has no body");
     }
-    const reader = res.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
-    let completed = false;
-
-    try {
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          completed = true;
-          break;
-        }
-
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop()!;
-
-        for (const line of lines) {
-          if (line.trim()) {
-            try {
-              yield JSON.parse(line) as ExecStreamEvent;
-            } catch {
-              // Malformed NDJSON line (e.g. truncated network chunk); skip and
-              // continue streaming so already-buffered output is not lost.
-            }
-          }
-        }
-      }
-
-      buffer += decoder.decode();
-      if (buffer.trim()) {
-        try {
-          yield JSON.parse(buffer) as ExecStreamEvent;
-        } catch {
-          // Malformed final chunk; discard rather than surfacing a SyntaxError.
-        }
-      }
-    } finally {
-      if (!completed) {
-        await reader.cancel().catch(() => {});
-      }
-      reader.releaseLock();
-    }
+    yield* readExecStreamEvents(res.body);
   }
 
   /** Read a file from the sandbox workspace. */


### PR DESCRIPTION
## Description

`Sandbox.executeStream` and `LazySandbox.executeStream` ran the same NDJSON read loop, but only the eager one guarded its two `JSON.parse` calls. The eager version even documents the intent:

```ts
} catch {
  // Malformed NDJSON line (e.g. truncated network chunk); skip and
  // continue streaming so already-buffered output is not lost.
}
```

The lazy version performed both parses with no `try`/`catch`. A single malformed line — exactly the truncated network chunk the eager path anticipates — threw a `SyntaxError` out of the generator. The stream aborted and **every already-buffered event was discarded**, so the caller lost output that had arrived successfully.

### Fix

Extract the loop into `readExecStreamEvents` (`src/sandbox/exec-stream.ts`) and have both paths delegate to it.

This is the issue's preferred remedy, and it is the right one: copying the loop is what let the two disagree about the same failure mode in the first place. Applying the missing guards in place would have fixed today's divergence while leaving the next one just as easy. The two loops were byte-identical apart from the guards and a `lines.pop()!` vs `lines.pop() ?? ""`, so nothing was lost in unifying them.

The extracted reader preserves the eager behaviour exactly: a malformed line is skipped, a malformed final chunk is discarded rather than surfacing a `SyntaxError`, and an abandoned generator still cancels the response body.

## Related Issue(s)

Fixes #4080

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have added tests that prove my fix is effective

## Testing

There was **no test file for `lazy-sandbox.ts` at all**, which is why the divergence went unnoticed. Rather than build a control-plane mocking harness to test the lazy path indirectly, the shared reader now has its own hermetic test file covering the behaviour both paths depend on:

- one event per line
- streaming continues past a malformed line
- a malformed final chunk is discarded, not thrown
- a final line with no trailing newline is still yielded
- an event split across chunk boundaries is reassembled
- blank lines are ignored
- an abandoned generator cancels the body

Because both call sites now `yield*` the same function, the lazy path gets this behaviour by construction rather than by a parallel test that could drift again.

The pre-existing eager end-to-end test ("should skip malformed NDJSON lines and keep delivering events") is unchanged and still passes, confirming the extraction preserved observable behaviour.

```
deno task test:file src/sandbox/     5 passed (132 steps) | 0 failed
deno check src/sandbox/index.ts
deno task lint:anti-slop / lint:test-semantic-dispositions / lint:module-boundaries / lint:wildcard-exports
deno fmt --check, deno lint
```