### PR TITLE
fix(proxy): settle the pending read when an upstream socket closes

### DIFF
--- a/src/proxy/websocket-client.test.ts
+++ b/src/proxy/websocket-client.test.ts
@@ -80,7 +80,73 @@ function identityHeaders(): Headers {
   });
 }
 
+/**
+ * A stream whose readable never produces a frame, so the client's read stays
+ * pending until something settles it. `close()` resolves `closed`, which is all
+ * a real `WebSocketStream` does: it does not settle a read already awaiting the
+ * next frame.
+ */
+function silentStream(): {
+  stream: UpstreamWebSocketStream;
+  readCancelled: () => boolean;
+} {
+  let cancelled = false;
+  let resolveClosed: (info: { closeCode?: number; reason?: string }) => void = () => {};
+  const closed = new Promise<{ closeCode?: number; reason?: string }>((resolve) => {
+    resolveClosed = resolve;
+  });
+
+  const readable = new ReadableStream<string | Uint8Array>({
+    cancel() {
+      cancelled = true;
+    },
+  });
+
+  return {
+    stream: {
+      opened: Promise.resolve({
+        readable,
+        writable: new WritableStream<string | Uint8Array>(),
+      }),
+      closed,
+      close(closeInfo) {
+        resolveClosed(closeInfo ?? {});
+      },
+    },
+    readCancelled: () => cancelled,
+  };
+}
+
 describe("upstream WebSocket client", () => {
+  it("settles a pending read when the socket closes", async () => {
+    // Regression guard for a leak that surfaced as an intermittent CI failure on
+    // unrelated pull requests: closing left `read()` awaiting the next frame, so
+    // `--trace-leaks` reported an async operation outliving the test.
+    const { stream, readCancelled } = silentStream();
+    const socket = new UpstreamWebSocket(
+      "ws://upstream.test/_ws",
+      identityHeaders(),
+      () => stream,
+    );
+
+    await new Promise<void>((resolve) => {
+      socket.onopen = () => resolve();
+    });
+    assertEquals(readCancelled(), false, "the read is pending while the socket is open");
+
+    const closed = new Promise<void>((resolve) => {
+      socket.onclose = () => resolve();
+    });
+    socket.close(1000, "done");
+    await closed;
+
+    assertEquals(
+      readCancelled(),
+      true,
+      "closing must settle the read, or the operation outlives the connection",
+    );
+  });
+
   it("presents the proxy identity headers on the handshake", async () => {
     const server = startUpstreamServer();
     try {

--- a/src/proxy/websocket-client.ts
+++ b/src/proxy/websocket-client.ts
@@ -71,6 +71,7 @@ async function toChunk(
 export class UpstreamWebSocket {
   #stream: UpstreamWebSocketStream;
   #writer: WritableStreamDefaultWriter<string | Uint8Array> | null = null;
+  #reader: ReadableStreamDefaultReader<string | Uint8Array> | null = null;
   #readyState: number = WebSocket.CONNECTING;
   #writes: Promise<void> = Promise.resolve();
   #settled = false;
@@ -137,6 +138,7 @@ export class UpstreamWebSocket {
 
   async #pump(readable: ReadableStream<string | Uint8Array>): Promise<void> {
     const reader = readable.getReader();
+    this.#reader = reader;
     try {
       while (true) {
         const { done, value } = await reader.read();
@@ -146,6 +148,7 @@ export class UpstreamWebSocket {
     } catch (error) {
       this.#fail(error);
     } finally {
+      this.#reader = null;
       reader.releaseLock();
     }
   }
@@ -161,6 +164,11 @@ export class UpstreamWebSocket {
     if (this.#settled) return;
     this.#settled = true;
     this.#readyState = WebSocket.CLOSED;
+    // Settle the read still pending on the socket. Closing the stream resolves
+    // `closed` and fires this handler, but it does not settle a `read()` that is
+    // already awaiting the next frame, so the operation would outlive the
+    // connection it belongs to.
+    this.#reader?.cancel().catch(() => {});
     this.onclose?.(new CloseEvent("close", { code, reason, wasClean }));
   }
 }


### PR DESCRIPTION
## Description

`UpstreamWebSocket#pump` awaits `reader.read()` for the next frame:

```ts
while (true) {
  const { done, value } = await reader.read();   // <- stays pending
  if (done) return;
  this.onmessage?.(new MessageEvent("message", { data: value }));
}
```

Closing the stream resolves `closed` and fires `onclose`, but it does **not** settle a `read()` that is already awaiting. The read outlives the connection it belongs to.

In the proxy that leaks one pending read per closed socket. In CI it surfaces as an intermittent failure from `src/proxy/websocket-client.test.ts` under `--trace-leaks --parallel`:

```
upstream WebSocket client => ./src/testing/bdd.ts:631:11
error: Leaks detected:
  - An async operation to receive the next message on a WebSocket was started
    in this test, but never completed.
    at op_ws_next_event (ext:core/00_infra.js:256:13)
    at pull (ext:deno_websocket/02_websocketstream.js:253:34)
```

### Why this is worth fixing now rather than filing

It is not confined to the proxy. This exact failure took out `coverage shard 8/8` on **two separate pull requests that touch neither the proxy nor WebSockets** — one changing only `src/transforms/import-rewriter/`, one changing only `src/modules/server/`. Every occurrence costs a shard re-run and, worse, invites the reading that the shard is "just flaky" when a real regression eventually lands there.

### Fix

Hold the reader and cancel it in `#close`. Cancelling settles the pending read, `#pump` unwinds, and `releaseLock` runs. The `#settled` guard already prevents re-entry from the `#fail` path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have added tests that prove my fix is effective

## Testing

Chasing the flake by re-running was not going to prove anything, so the regression guard is deterministic instead. It uses the client's existing `UpstreamWebSocketStreamFactory` seam with a stream whose readable never produces a frame and whose `close()` only resolves `closed`, which is precisely what a real `WebSocketStream` does. The test then asserts the read was settled.

Verified to fail without the fix:

```
AssertionError: Values are not equal:
  closing must settle the read, or the operation outlives the connection
```

```
deno task test:file src/proxy/     51 passed (533 steps) | 0 failed
deno check src/proxy/main.ts
deno task lint:anti-slop / lint:test-semantic-dispositions / lint:sanitizer-baseline
deno fmt --check, deno lint
```

Found while shepherding the issue-triage PRs (#4147, #4148, #4149, #4150, #4152, #4154), where it twice failed a shard on unrelated changes.