### PR TITLE
fix(proxy): cancel the in-flight upstream read when closing a socket

### DIFF
--- a/src/proxy/websocket-client.test.ts
+++ b/src/proxy/websocket-client.test.ts
@@ -343,6 +343,41 @@ describe("upstream WebSocket client", () => {
     assertEquals(socket.readyState, WebSocket.CLOSING);
   });
 
+  it("cancels the in-flight upstream read when an open socket is closed", async () => {
+    let admit: (connection: UpstreamWebSocketConnection) => void = () => {};
+    const opened = new Promise<UpstreamWebSocketConnection>((resolve) => {
+      admit = resolve;
+    });
+    const stream: UpstreamWebSocketStream = {
+      opened,
+      closed: new Promise(() => {}),
+      close() {},
+    };
+    let cancels = 0;
+
+    const socket = new UpstreamWebSocket("ws://renderer/_ws", new Headers(), () => stream);
+    admit({
+      readable: new ReadableStream<string | Uint8Array>({
+        cancel() {
+          cancels++;
+        },
+      }),
+      writable: new WritableStream<string | Uint8Array>(),
+    });
+    await opened;
+    for (let turn = 0; turn < 5; turn++) await Promise.resolve();
+    assertEquals(socket.readyState, WebSocket.OPEN, "the socket must be open before closing");
+
+    socket.close(1000, "done");
+    for (let turn = 0; turn < 5; turn++) await Promise.resolve();
+
+    assertEquals(
+      cancels,
+      1,
+      "close() must cancel the in-flight read so no receive op outlives the socket",
+    );
+  });
+
   it("discards an upstream connection that arrives after close", async () => {
     let admit: (connection: UpstreamWebSocketConnection) => void = () => {};
     const opened = new Promise<UpstreamWebSocketConnection>((resolve) => {

--- a/src/proxy/websocket-client.ts
+++ b/src/proxy/websocket-client.ts
@@ -71,6 +71,7 @@ async function toChunk(
 export class UpstreamWebSocket {
   #stream: UpstreamWebSocketStream;
   #writer: WritableStreamDefaultWriter<string | Uint8Array> | null = null;
+  #reader: ReadableStreamDefaultReader<string | Uint8Array> | null = null;
   #readyState: number = WebSocket.CONNECTING;
   #writes: Promise<void> = Promise.resolve();
   #settled = false;
@@ -110,6 +111,10 @@ export class UpstreamWebSocket {
   close(code?: number, reason?: string): void {
     if (this.#readyState === WebSocket.CLOSING || this.#readyState === WebSocket.CLOSED) return;
     this.#readyState = WebSocket.CLOSING;
+    // Cancel the in-flight read first. Closing the stream alone leaves the
+    // pending receive op outstanding until the close propagates, which can
+    // outlive the caller and trips Deno's leak detector under --trace-leaks.
+    this.#reader?.cancel().catch(() => {});
     try {
       this.#stream.close(code === undefined ? undefined : { closeCode: code, reason });
     } catch {
@@ -137,6 +142,7 @@ export class UpstreamWebSocket {
 
   async #pump(readable: ReadableStream<string | Uint8Array>): Promise<void> {
     const reader = readable.getReader();
+    this.#reader = reader;
     try {
       while (true) {
         const { done, value } = await reader.read();
@@ -146,6 +152,7 @@ export class UpstreamWebSocket {
     } catch (error) {
       this.#fail(error);
     } finally {
+      this.#reader = null;
       reader.releaseLock();
     }
   }


### PR DESCRIPTION
## Problem

`coverage shard 8/8` failed on an unrelated PR with every assertion passing:

```
upstream WebSocket client
error: Leaks detected:
  - An async operation to receive the next message on a WebSocket was started
    in this test, but never completed.
    at op_ws_next_event → pull (ext:deno_websocket/02_websocketstream.js)
```

`421 passed | 1 failed` — the failure is Deno's leak detector, not a test.

## Cause

`UpstreamWebSocket#pump` keeps an outstanding `reader.read()`:

```ts
async #pump(readable) {
  const reader = readable.getReader();
  while (true) {
    const { done, value } = await reader.read();   // outstanding receive op
    ...
  }
}
```

`close()` closed the stream but never cancelled that reader, so teardown raced the close propagating through the stream. Usually the close wins; when it doesn't, a receive op outlives the caller and `--trace-leaks` fails the entire shard.

The tests were never at fault — they use `try/finally`, close explicitly, and await `onclose`.

## Fix

Hold the reader on the instance and cancel it in `close()`, so the pending read is aborted deterministically rather than racing.

## Verification

- New regression test `cancels the in-flight upstream read when an open socket is closed`, verified **red** before the fix.
- Removing the `cancel()` turns it red again (mutation-checked).
- Full `websocket-client.test.ts`: 10 steps, 0 failures, run 12× consecutively under `--trace-leaks` with 0 failures.
- `deno task fmt:check`, `deno lint`, `deno check`: all exit 0.
- Ran the whole `src/proxy/*.test.ts` group with and without the change and diffed the failing test **names**: identical sets, so no regressions. (That group has pre-existing environment-dependent failures locally — control-plane signature and domain-auth tests — unchanged by this PR.)
