### PR TITLE
Keep merge-group review resolution independent of wakeup runs

### DIFF
--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -227,7 +227,10 @@ jobs:
               core.setFailed(`Could not capture the review status boundary: ${error}`);
               return;
             }
-            if (workflowRun?.conclusion !== "success") {
+            if (
+              context.eventName === "workflow_run" &&
+              workflowRun?.conclusion !== "success"
+            ) {
               core.setFailed("The review wakeup did not complete successfully");
             }
 

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2396,9 +2396,14 @@ describe("automated review workflow", () => {
         "fallbackResponse = await github.rest.pulls.get",
         "context.payload.pull_request?.head?.sha",
         "Could not resolve a valid review target commit",
-        'workflowRun?.conclusion !== "success"',
       ]
     ) assert(targetScript.includes(required));
+    assert(
+      targetScript.replaceAll(/\s+/g, " ").includes(
+        'context.eventName === "workflow_run" && workflowRun?.conclusion !== "success"',
+      ),
+      "merge-group target resolution must not require a workflow-run conclusion",
+    );
     assert(
       !targetScript.includes("createCommitStatus"),
       "read-only target resolution must not receive status authority",


### PR DESCRIPTION
## Why

The first live merge-queue canary for the automated review gate exposed a false failure: merge-group events do not carry a workflow_run payload, but the shared resolver required workflow_run.conclusion to be success for every event type.

## Change

- apply the wakeup conclusion guard only to workflow_run events
- retain fail-closed behavior for unsuccessful review wakeups
- add a regression assertion that merge-group resolution is independent from workflow-run-only payload fields

## Evidence

- live failed job: automated review gate run 32860413215, target job 97842704869
- focused workflow suite: 7 groups, 67 steps, 0 failed
- isolated Redis timing rerun: 18 steps, 0 failed
- pre-push on merged main: format 5,196 files, lint 5,119 files, typecheck passed, unit 4,277 groups / 34,119 steps / 0 failed / 1 ignored, cwd suites passed

The Automated review check is not yet required. Human approval remains required until this PR proves source and merge-group propagation end to end.