### PR TITLE
fix(security): fail closed for requested API isolation

### DIFF
--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -425,7 +425,7 @@ describe("APIRouteHandler", () => {
         Deno.env.delete(HOST_PROJECT_EXECUTION_OVERRIDE_ENV);
       });
 
-      it("serves through the host realm when the operator has granted host execution", async () => {
+      it("fails closed when API isolation conflicts with a host execution grant", async () => {
         const adapter = createMockAdapter();
         adapter.fs.files.set(
           "/test/project/pages/api/hosted.ts",
@@ -463,10 +463,13 @@ describe("APIRouteHandler", () => {
           },
         );
 
-        assertEquals(response?.status, 200);
-        assertEquals(await response?.text(), "hosted");
-        // Must reach route execution too, not just the handler.
-        assertEquals(hostLoads, 1);
+        assertEquals(response?.status, 503);
+        assert(
+          response?.headers.get("content-type")?.includes("application/problem+json"),
+        );
+        const body = await response?.json();
+        assert(String(body.detail).includes("WORKER_ISOLATION_API"));
+        assertEquals(hostLoads, 0);
         assertEquals(preparations, 0);
       });
 

--- a/src/security/README.md
+++ b/src/security/README.md
@@ -363,21 +363,15 @@ replaced with defaults.
 (`routing/api/handler.ts` and `routing/api/route-executor.ts`), which resolve it
 through the single `isHostRealmApiExecution` accessor. Data fetchers and SSR
 have their own flags. Agent streams are gated by `allowHostProjectCodeExecution`
-alone, so on a shared runtime granted host project execution, API routes execute
-in the same host realm as streams.
+alone.
 
 A runtime that cannot honour a configured isolation flag never fakes it. A
 compiled binary cannot prepare isolated API route source
 (`security/sandbox/isolation-capability.ts`), so `WORKER_ISOLATION_API=1` in a
-compiled deployment resolves one of two ways, both logged once at startup: where
-the operator has explicitly granted host project code execution through
-`VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION`, the flag is downgraded and execution
-uses the host realm the operator already opted into; where that grant is absent,
-the flag stands and API ownership returns the typed
-`project-execution-unavailable` 503 naming it. The downgrade cannot grant
-execution on its own. Every execution gate is a conjunction with
-`allowHostProjectCodeExecution`, so the downgrade only ever lands API routes in
-the realm that grant already licenses for every other surface.
+compiled deployment keeps the requested isolation posture and API ownership
+returns the typed `project-execution-unavailable` 503 naming it. The broad
+`VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION` grant does not override the
+API-specific isolation flag.
 
 OpenAPI metadata is currently attached to handler functions. Because reading
 it requires route evaluation, runtime OpenAPI generation is available only for

--- a/src/security/sandbox/isolation-posture.test.ts
+++ b/src/security/sandbox/isolation-posture.test.ts
@@ -132,7 +132,7 @@ describe("security/sandbox isolation posture reporting", () => {
     assertEquals(posture.inForce, true);
   });
 
-  it("reports API isolation as requested but not in force when it is downgraded under a grant", async () => {
+  it("keeps API isolation in force when preparation is unsupported under a grant", async () => {
     setEnv("WORKER_ISOLATION_ENABLED", "1");
     setEnv("WORKER_ISOLATION_API", "1");
     setEnv(HOST_PROJECT_EXECUTION_OVERRIDE_ENV, "1");
@@ -142,10 +142,10 @@ describe("security/sandbox isolation posture reporting", () => {
     const posture = getIsolationPosture();
 
     assertEquals(posture.api.requested, true);
-    assertEquals(posture.api.effective, false);
+    assertEquals(posture.api.effective, true);
     assertEquals(posture.apiPreparationSupported, false);
     assertEquals(posture.hostExecutionGranted, true);
-    assertEquals(posture.inForce, false);
+    assertEquals(posture.inForce, true);
   });
 
   it("keeps the default posture off the default-verbosity dev log", async () => {

--- a/src/security/sandbox/worker-pool.test.ts
+++ b/src/security/sandbox/worker-pool.test.ts
@@ -1627,14 +1627,14 @@ describe("Feature flag caching", () => {
   });
 
   describe("when the runtime cannot prepare an isolated API module", () => {
-    it("downgrades WORKER_ISOLATION_API under an explicit host-execution grant", async () => {
+    it("keeps WORKER_ISOLATION_API set under a broad host-execution grant", async () => {
       Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
       Deno.env.set("WORKER_ISOLATION_API", "1");
       Deno.env.set(HOST_PROJECT_EXECUTION_OVERRIDE_ENV, "1");
       __setCompiledBinaryForTests(true);
       await __resetPoolForTests();
 
-      assertEquals(isWorkerIsolationEnabled(), false);
+      assertEquals(isWorkerIsolationEnabled(), true);
     });
 
     it("keeps WORKER_ISOLATION_API set when host execution is not granted", async () => {
@@ -1657,7 +1657,7 @@ describe("Feature flag caching", () => {
       assertEquals(isWorkerIsolationEnabled(), true);
     });
 
-    it("never downgrades data isolation, which uses a different transport", async () => {
+    it("keeps API and data isolation, which use different transports", async () => {
       Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
       Deno.env.set("WORKER_ISOLATION_API", "1");
       Deno.env.set("WORKER_ISOLATION_DATA", "1");
@@ -1665,7 +1665,7 @@ describe("Feature flag caching", () => {
       __setCompiledBinaryForTests(true);
       await __resetPoolForTests();
 
-      assertEquals(isWorkerIsolationEnabled(), false);
+      assertEquals(isWorkerIsolationEnabled(), true);
       assertEquals(isDataIsolationEnabled(), true);
     });
 

--- a/src/security/sandbox/worker-pool.ts
+++ b/src/security/sandbox/worker-pool.ts
@@ -1255,11 +1255,10 @@ export interface IsolationSurfacePosture {
 /**
  * The resolved isolation configuration, as an operator would need to read it.
  *
- * `requested` and `effective` are separate fields because they diverge: API
- * isolation is requested and not effective when it is downgraded under an
- * explicit host-execution grant. `inForce` is the field that answers the
- * question the per-surface booleans cannot: whether the configuration as a
- * whole isolates anything at all.
+ * `requested` and `effective` are separate fields so posture remains explicit
+ * if a runtime capability changes. A host-execution grant never makes requested
+ * API isolation ineffective: unsupported runtimes keep the gate enabled and
+ * fail closed. `inForce` answers whether any surface is isolated at all.
  */
 export interface IsolationPosture {
   /** WORKER_ISOLATION_ENABLED. On its own it enables no surface. */

--- a/src/security/sandbox/worker-pool.ts
+++ b/src/security/sandbox/worker-pool.ts
@@ -23,6 +23,7 @@ import { SECURITY_VIOLATION, SERVICE_OVERLOADED } from "#veryfront/errors";
 import { basename, dirname, resolve as resolvePath } from "#veryfront/compat/path";
 import { fromFileUrl, toFileUrl } from "#veryfront/compat/path";
 import { isWithinDirectory } from "#veryfront/security/path-validation.ts";
+import { isHostProjectExecutionOverrideEnabled } from "#veryfront/security/host-execution-policy.ts";
 import { resolve as resolveExtensionContract } from "#veryfront/extensions/contracts.ts";
 import {
   IsolatedSsrRendererProviderName,
@@ -36,7 +37,6 @@ import {
 } from "./worker-egress-guard.ts";
 import { isWorkerGenerationInScope } from "./worker-generation.ts";
 import { buildWorkerPermissions } from "./worker-permissions.ts";
-import { isHostProjectExecutionOverrideEnabled } from "#veryfront/security/host-execution-policy.ts";
 import {
   isIsolatedApiPreparationSupported,
   ISOLATED_API_PREPARATION_UNSUPPORTED_REASON,
@@ -1282,13 +1282,8 @@ export interface IsolationPosture {
 /**
  * Resolve the host-owned isolation flags once per process.
  *
- * A build that cannot honour `WORKER_ISOLATION_API` has no configuration that
- * serves traffic: every API route dead-ends in `prepareHandlerModule`. The flag
- * is downgraded in exactly one case — the operator already granted host-realm
- * execution via VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION. The downgrade cannot
- * grant more than that, since every execution gate is a conjunction with
- * `allowHostProjectCodeExecution`. Without the grant the flag stands and API
- * ownership fails closed with a typed 503.
+ * A build that cannot honour `WORKER_ISOLATION_API` must fail closed. A broad
+ * host-execution grant does not override an API-specific isolation posture.
  */
 function resolveFlags(): void {
   if (_flagsResolved) return;
@@ -1304,9 +1299,7 @@ function resolveFlags(): void {
 
   const preparationSupported = isIsolatedApiPreparationSupported();
   const hostExecutionGranted = isHostProjectExecutionOverrideEnabled();
-  const downgraded = apiRequested && !preparationSupported && hostExecutionGranted;
-
-  _apiIsolation = apiRequested && !downgraded;
+  _apiIsolation = apiRequested;
   _flagsResolved = true;
 
   const effectiveSurfaces = [_apiIsolation, _dataIsolation, _ssrIsolation]
@@ -1362,20 +1355,9 @@ function resolveFlags(): void {
     });
   }
 
-  if (downgraded) {
-    logger.warn(
-      "WORKER_ISOLATION_API downgraded to host-realm execution under an explicit operator grant",
-      {
-        flag: "WORKER_ISOLATION_API",
-        requested: true,
-        effective: false,
-        reason: ISOLATED_API_PREPARATION_UNSUPPORTED_REASON,
-        grantedBy: "VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION",
-      },
-    );
-  } else if (apiRequested && !preparationSupported) {
+  if (apiRequested && !preparationSupported) {
     logger.error(
-      "WORKER_ISOLATION_API cannot be honoured by this runtime and host project execution is not granted; project API routes will fail closed",
+      "WORKER_ISOLATION_API cannot be honoured by this runtime; project API routes will fail closed",
       {
         flag: "WORKER_ISOLATION_API",
         requested: true,

--- a/tests/integration/compiled-binary-e2e.test.ts
+++ b/tests/integration/compiled-binary-e2e.test.ts
@@ -751,9 +751,7 @@ export function GET() {
     });
   });
 
-  // Production ran exactly this flag combination and every project API route
-  // returned a masked 500.
-  it("serves API routes when a compiled binary cannot honour WORKER_ISOLATION_API but host execution is granted", async () => {
+  it("fails closed when API isolation conflicts with a broad host execution grant", async () => {
     const projectDir = await createTestProject(
       "isolation-downgrade-test",
       `
@@ -770,26 +768,32 @@ export function GET() {
       },
     );
 
-    await withServer(projectDir, async (server) => {
-      const response = await fetch(`http://127.0.0.1:${server.port}/api/hello`);
-      const body = await response.text();
+    await withServer(
+      projectDir,
+      async (server) => {
+        const response = await fetch(`http://127.0.0.1:${server.port}/api/hello`);
+        const body = await response.text();
 
-      assertEquals(
-        response.status,
-        200,
-        `Should return 200\nResponse body: ${body}\n${server.logs.join("").slice(-16000)}`,
-      );
-      assertEquals(JSON.parse(body).message, "Hello from API");
-      assertStringIncludes(
-        server.logs.join(""),
-        "WORKER_ISOLATION_API downgraded",
-        "the downgrade must be logged",
-      );
-    }, "production", {
-      WORKER_ISOLATION_ENABLED: "1",
-      WORKER_ISOLATION_API: "1",
-      VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION: "1",
-    });
+        assertEquals(
+          response.status,
+          503,
+          `Should fail closed as 503, not execute in the host realm\nResponse body: ${body}\n${
+            server.logs.join("").slice(-16000)
+          }`,
+        );
+        assertStringIncludes(
+          body,
+          "WORKER_ISOLATION_API",
+          "the response must name the flag",
+        );
+      },
+      "production",
+      {
+        WORKER_ISOLATION_ENABLED: "1",
+        WORKER_ISOLATION_API: "1",
+        VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION: "1",
+      },
+    );
   });
 
   it("returns a typed 503 for API routes when WORKER_ISOLATION_API is unserviceable and ungranted", async () => {
@@ -809,22 +813,27 @@ export function GET() {
       },
     );
 
-    await withServer(projectDir, async (server) => {
-      const response = await fetch(`http://127.0.0.1:${server.port}/api/hello`);
-      const body = await response.text();
+    await withServer(
+      projectDir,
+      async (server) => {
+        const response = await fetch(`http://127.0.0.1:${server.port}/api/hello`);
+        const body = await response.text();
 
-      assertEquals(
-        response.status,
-        503,
-        `Should fail closed as 503, not a masked 500\nResponse body: ${body}\n${
-          server.logs.join("").slice(-16000)
-        }`,
-      );
-      assertStringIncludes(body, "WORKER_ISOLATION_API", "the response must name the flag");
-    }, "production", {
-      WORKER_ISOLATION_ENABLED: "1",
-      WORKER_ISOLATION_API: "1",
-    });
+        assertEquals(
+          response.status,
+          503,
+          `Should fail closed as 503, not a masked 500\nResponse body: ${body}\n${
+            server.logs.join("").slice(-16000)
+          }`,
+        );
+        assertStringIncludes(body, "WORKER_ISOLATION_API", "the response must name the flag");
+      },
+      "production",
+      {
+        WORKER_ISOLATION_ENABLED: "1",
+        WORKER_ISOLATION_API: "1",
+      },
+    );
   });
 
   it("should drain an active SSE response before production serve exits on SIGTERM", async () => {

--- a/tests/integration/compiled-binary-e2e.test.ts
+++ b/tests/integration/compiled-binary-e2e.test.ts
@@ -753,7 +753,7 @@ export function GET() {
 
   it("fails closed when API isolation conflicts with a broad host execution grant", async () => {
     const projectDir = await createTestProject(
-      "isolation-downgrade-test",
+      "isolation-fail-closed-test",
       `
 export default function Home() {
   return <div>Home Page</div>;


### PR DESCRIPTION
### Motivation

- Prevent a security regression where `WORKER_ISOLATION_API=1` could be silently downgraded to host-realm execution when `VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION=1`, which allowed tenant API code to be imported and executed in the shared host process.
- Ensure compiled runtimes that cannot prepare isolated API modules fail closed rather than executing untrusted tenant code in the host realm.

### Description

- Remove the downgrade path in `src/security/sandbox/worker-pool.ts` so the effective API isolation remains `apiRequested` (i.e. `_apiIsolation = apiRequested`) and a runtime that cannot prepare isolated modules will fail closed and log the condition. 
- Remove the host-execution override dependency from the API isolation resolution and keep `isHostRealmApiExecution()` semantics unchanged (host realm is only used when `allowHostProjectCodeExecution` is granted and API isolation is not requested). 
- Update tests to assert the fail-closed behavior and to preserve `WORKER_ISOLATION_API` when `VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION` is set (`src/security/sandbox/worker-pool.test.ts`, `src/routing/api/handler.test.ts`, `tests/integration/compiled-binary-e2e.test.ts`).
- Update security docs to state that a broad host-execution grant does not override the API-specific isolation flag (`src/security/README.md`).

### Testing

- Ran `git diff --check` which passed. 
- Ran repository grep and Python assertions to validate the source edits (checked `_apiIsolation = apiRequested;` is present and downgrade predicate removed), which passed. 
- Updated and committed the tests and assertions; `git commit` succeeded. 
- Attempted `deno fmt --check` / `deno test` but the environment does not have Deno installed (`deno: command not found`), so the Deno-based automated test and formatting checks were not runnable in this environment; these must be executed in CI or a developer machine to fully validate. 

Please run the repository's Deno test matrix (`deno test` per project instructions) in CI or locally to verify all tests and formatting succeed before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7495defa60832d81c33ba3d905cd73)