### PR TITLE
fix(ssr): prevent caching sensitive response metadata

### DIFF
--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -378,6 +378,51 @@ describe("Renderer response metadata", () => {
     assertEquals(store.data.size, 0);
   });
 
+  it("evicts a legacy cache entry that contains response headers", async () => {
+    const store = createInMemoryStore();
+    const ctx = makeRenderContext();
+    const cacheKey = `${ctx.cachePrefix}:page:/legacy-header`;
+    store.data.set(cacheKey, {
+      result: {
+        html: "<html>legacy private response</html>",
+        frontmatter: {},
+        stream: null,
+        headers: { "x-page-state": "request-derived" },
+      },
+      storedAt: Date.now(),
+    });
+    const renderer = new Renderer({ cache: { store } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    let renderCalls = 0;
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: { renderPage: () => Promise<RenderResult> };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: () => {
+          renderCalls++;
+          return Promise.resolve({
+            html: "<html>fresh public response</html>",
+            frontmatter: {},
+            stream: null,
+          });
+        },
+      },
+    });
+
+    const result = await renderer.renderPage("/legacy-header", ctx, {
+      environment: "production",
+      releaseId: "rel-1",
+      releaseAssetManifest: null,
+    });
+
+    assertEquals(result.html, "<html>fresh public response</html>");
+    assertEquals(result.headers, undefined);
+    assertEquals(renderCalls, 1);
+    assertEquals(store.data.get(cacheKey)?.result.html, "<html>fresh public response</html>");
+  });
+
   it("rerenders singleflight followers when the leader returns headers", async () => {
     const store = createInMemoryStore();
     const renderer = new Renderer({ cache: { store } });
@@ -536,6 +581,60 @@ describe("Renderer response metadata", () => {
     assertEquals(observedDelivery, "stream");
     assertEquals(result.stream, stream);
     assertEquals(result.html, "");
+  });
+
+  it("holds render admission until an uncached stream is ready", async () => {
+    const projectId = `stream-project-${crypto.randomUUID()}`;
+    const ctx = {
+      ...makeRenderContext(),
+      projectId,
+      projectSlug: projectId,
+      cachePrefix: buildRenderCachePrefix(projectId, "production", "rel-1", "production"),
+    };
+    const renderer = new Renderer({ cache: { store: createInMemoryStore() } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    const shellReady = Promise.withResolvers<void>();
+    const allReady = Promise.withResolvers<void>();
+    const stream = new ReadableStream<Uint8Array>();
+    Object.defineProperty(stream, "allReady", { value: allReady.promise });
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: { renderPage: () => Promise<RenderResult> };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: () => {
+          shellReady.resolve();
+          return Promise.resolve({ html: "", frontmatter: {}, stream });
+        },
+      },
+    });
+
+    const render = renderer.renderPage("/private-stream", ctx, {
+      environment: "production",
+      releaseId: "rel-1",
+      releaseAssetManifest: null,
+      delivery: "stream",
+      request: new Request("https://example.test/private-stream", {
+        headers: { authorization: "Bearer secret" },
+      }),
+    });
+
+    try {
+      await shellReady.promise;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      assertEquals(projectRenderCounts.get(projectId), 1);
+
+      allReady.resolve();
+      assertEquals((await render).stream, stream);
+      assertEquals(projectRenderCounts.has(projectId), false);
+    } finally {
+      allReady.resolve();
+      await render.catch(() => {});
+      while ((projectRenderCounts.get(projectId) ?? 0) > 0) {
+        await releaseProjectSlot(projectId);
+      }
+    }
   });
 
   it("rerenders singleflight followers when the leader returns cookies", async () => {

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -437,6 +437,104 @@ describe("Renderer response metadata", () => {
     assertEquals(store.data.size, 0);
   });
 
+  it("rerenders singleflight followers when the leader throws with headers", async () => {
+    const renderer = new Renderer({ cache: { store: createInMemoryStore() } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    const firstStarted = Promise.withResolvers<void>();
+    const releaseFirst = Promise.withResolvers<void>();
+    let renderCalls = 0;
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: (_slug: string, options?: RenderOptions) => Promise<RenderResult>;
+        };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: async (_slug, options) => {
+          renderCalls++;
+          if (renderCalls === 1) {
+            firstStarted.resolve();
+            await releaseFirst.promise;
+          }
+          const user = options?.request?.headers.get("x-test-user") ?? "missing";
+          throw attachDataResponseMetadata(new Error(user), {
+            headers: { "x-page-state": user },
+          });
+        },
+      },
+    });
+    const baseOptions = {
+      environment: "production" as const,
+      releaseId: "rel-1",
+      releaseAssetManifest: null,
+    };
+    const captureFailure = async (promise: Promise<RenderResult>): Promise<Error> => {
+      try {
+        await promise;
+      } catch (error) {
+        if (error instanceof Error) return error;
+      }
+      throw new Error("Expected render to fail");
+    };
+
+    const leader = captureFailure(renderer.renderPage("/header-error", makeRenderContext(), {
+      ...baseOptions,
+      request: new Request("https://example.test/header-error", {
+        headers: { "x-test-user": "leader" },
+      }),
+    }));
+    await firstStarted.promise;
+    const follower = captureFailure(renderer.renderPage("/header-error", makeRenderContext(), {
+      ...baseOptions,
+      request: new Request("https://example.test/header-error", {
+        headers: { "x-test-user": "follower" },
+      }),
+    }));
+    releaseFirst.resolve();
+
+    const [leaderError, followerError] = await Promise.all([leader, follower]);
+    assertEquals(getAttachedDataResponseMetadata(leaderError).headers, {
+      "x-page-state": "leader",
+    });
+    assertEquals(getAttachedDataResponseMetadata(followerError).headers, {
+      "x-page-state": "follower",
+    });
+    assertEquals(renderCalls, 2);
+  });
+
+  it("preserves streaming delivery for cache-sensitive requests", async () => {
+    const renderer = new Renderer({ cache: { store: createInMemoryStore() } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    let observedDelivery: RenderOptions["delivery"];
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: (_slug: string, options?: RenderOptions) => Promise<RenderResult>;
+        };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: (_slug, options) => {
+          observedDelivery = options?.delivery;
+          return Promise.resolve({ html: "<html>private</html>", frontmatter: {}, stream: null });
+        },
+      },
+    });
+
+    await renderer.renderPage("/private", makeRenderContext(), {
+      environment: "production",
+      releaseId: "rel-1",
+      releaseAssetManifest: null,
+      delivery: "stream",
+      request: new Request("https://example.test/private", {
+        headers: { authorization: "Bearer secret" },
+      }),
+    });
+
+    assertEquals(observedDelivery, "stream");
+  });
+
   it("rerenders singleflight followers when the leader returns cookies", async () => {
     const store = createInMemoryStore();
     const renderer = new Renderer({ cache: { store } });

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -339,7 +339,7 @@ describe("Renderer response metadata", () => {
     assertEquals(store.data.size, 0);
   });
 
-  it("preserves response headers through render cache hits", async () => {
+  it("does not persist response headers through render cache hits", async () => {
     const store = createInMemoryStore();
     const renderer = new Renderer({ cache: { store } });
     (renderer as unknown as { initialized: boolean }).initialized = true;
@@ -374,7 +374,67 @@ describe("Renderer response metadata", () => {
 
     assertEquals(first.headers, { "x-page-state": "cacheable" });
     assertEquals(second.headers, { "x-page-state": "cacheable" });
-    assertEquals(renderCalls, 1);
+    assertEquals(renderCalls, 2);
+    assertEquals(store.data.size, 0);
+  });
+
+  it("rerenders singleflight followers when the leader returns headers", async () => {
+    const store = createInMemoryStore();
+    const renderer = new Renderer({ cache: { store } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    const firstStarted = Promise.withResolvers<void>();
+    const releaseFirst = Promise.withResolvers<void>();
+    let renderCalls = 0;
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: (_slug: string, options?: RenderOptions) => Promise<RenderResult>;
+        };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: async (_slug, options) => {
+          renderCalls++;
+          if (renderCalls === 1) {
+            firstStarted.resolve();
+            await releaseFirst.promise;
+          }
+          const user = options?.request?.headers.get("x-test-user") ?? "missing";
+          return {
+            html: `<html>${user}</html>`,
+            frontmatter: {},
+            stream: null,
+            headers: { "x-page-state": user },
+          };
+        },
+      },
+    });
+    const baseOptions = {
+      environment: "production" as const,
+      releaseId: "rel-1",
+      releaseAssetManifest: null,
+    };
+
+    const leader = renderer.renderPage("/concurrent-header", makeRenderContext(), {
+      ...baseOptions,
+      request: new Request("https://example.test/concurrent-header", {
+        headers: { "x-test-user": "leader" },
+      }),
+    });
+    await firstStarted.promise;
+    const follower = renderer.renderPage("/concurrent-header", makeRenderContext(), {
+      ...baseOptions,
+      request: new Request("https://example.test/concurrent-header", {
+        headers: { "x-test-user": "follower" },
+      }),
+    });
+    releaseFirst.resolve();
+
+    const [leaderResult, followerResult] = await Promise.all([leader, follower]);
+    assertEquals(leaderResult.headers, { "x-page-state": "leader" });
+    assertEquals(followerResult.headers, { "x-page-state": "follower" });
+    assertEquals(renderCalls, 2);
+    assertEquals(store.data.size, 0);
   });
 
   it("rerenders singleflight followers when the leader returns cookies", async () => {

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import {
   assertEquals,
   assertRejects,
+  assertStrictEquals,
   assertStringIncludes,
   assertThrows,
 } from "#veryfront/testing/assert.ts";
@@ -630,6 +631,85 @@ describe("Renderer response metadata", () => {
       assertEquals(projectRenderCounts.has(projectId), false);
     } finally {
       allReady.resolve();
+      await render.catch(() => {});
+      while ((projectRenderCounts.get(projectId) ?? 0) > 0) {
+        await releaseProjectSlot(projectId);
+      }
+    }
+  });
+
+  it("cancels a failed uncached stream before releasing render admission", async () => {
+    const projectId = `failed-stream-project-${crypto.randomUUID()}`;
+    const ctx = {
+      ...makeRenderContext(),
+      projectId,
+      projectSlug: projectId,
+      cachePrefix: buildRenderCachePrefix(projectId, "production", "rel-1", "production"),
+    };
+    const renderer = new Renderer({ cache: { store: createInMemoryStore() } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    const shellReady = Promise.withResolvers<void>();
+    const allReady = Promise.withResolvers<void>();
+    allReady.promise.catch(() => {});
+    const finishCancellation = Promise.withResolvers<void>();
+    let cancellationStarted = false;
+    let cancellationReason: unknown;
+    let renderSignal: AbortSignal | undefined;
+    const stream = new ReadableStream<Uint8Array>({
+      async cancel(reason) {
+        cancellationStarted = true;
+        cancellationReason = reason;
+        await finishCancellation.promise;
+      },
+    });
+    Object.defineProperty(stream, "allReady", { value: allReady.promise });
+    (renderer as unknown as {
+      createServicesForContext: () => {
+        pipeline: {
+          renderPage: (
+            _slug: string,
+            options?: { abortSignal?: AbortSignal },
+          ) => Promise<RenderResult>;
+        };
+      };
+    }).createServicesForContext = () => ({
+      pipeline: {
+        renderPage: (_slug, options) => {
+          renderSignal = options?.abortSignal;
+          shellReady.resolve();
+          return Promise.resolve({ html: "", frontmatter: {}, stream });
+        },
+      },
+    });
+
+    const render = renderer.renderPage("/failed-private-stream", ctx, {
+      environment: "production",
+      releaseId: "rel-1",
+      releaseAssetManifest: null,
+      delivery: "stream",
+      request: new Request("https://example.test/failed-private-stream", {
+        headers: { authorization: "Bearer secret" },
+      }),
+    });
+    const readinessError = new Error("late suspense branch failed");
+
+    try {
+      await shellReady.promise;
+      allReady.reject(readinessError);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      assertEquals(cancellationStarted, true);
+      assertStrictEquals(cancellationReason, readinessError);
+      assertEquals(renderSignal?.aborted, true);
+      assertStrictEquals(renderSignal?.reason, readinessError);
+      assertEquals(projectRenderCounts.get(projectId), 1);
+
+      finishCancellation.resolve();
+      assertEquals((await render).stream, stream);
+      assertEquals(projectRenderCounts.has(projectId), false);
+    } finally {
+      allReady.reject(readinessError);
+      finishCancellation.resolve();
       await render.catch(() => {});
       while ((projectRenderCounts.get(projectId) ?? 0) > 0) {
         await releaseProjectSlot(projectId);

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -507,6 +507,7 @@ describe("Renderer response metadata", () => {
     const renderer = new Renderer({ cache: { store: createInMemoryStore() } });
     (renderer as unknown as { initialized: boolean }).initialized = true;
     let observedDelivery: RenderOptions["delivery"];
+    const stream = new ReadableStream<Uint8Array>();
     (renderer as unknown as {
       createServicesForContext: () => {
         pipeline: {
@@ -517,12 +518,12 @@ describe("Renderer response metadata", () => {
       pipeline: {
         renderPage: (_slug, options) => {
           observedDelivery = options?.delivery;
-          return Promise.resolve({ html: "<html>private</html>", frontmatter: {}, stream: null });
+          return Promise.resolve({ html: "", frontmatter: {}, stream });
         },
       },
     });
 
-    await renderer.renderPage("/private", makeRenderContext(), {
+    const result = await renderer.renderPage("/private", makeRenderContext(), {
       environment: "production",
       releaseId: "rel-1",
       releaseAssetManifest: null,
@@ -533,6 +534,8 @@ describe("Renderer response metadata", () => {
     });
 
     assertEquals(observedDelivery, "stream");
+    assertEquals(result.stream, stream);
+    assertEquals(result.html, "");
   });
 
   it("rerenders singleflight followers when the leader returns cookies", async () => {

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -705,7 +705,8 @@ describe("Renderer response metadata", () => {
       assertEquals(projectRenderCounts.get(projectId), 1);
 
       finishCancellation.resolve();
-      assertEquals((await render).stream, stream);
+      const rejected = await assertRejects(() => render, Error, readinessError.message);
+      assertStrictEquals(rejected, readinessError);
       assertEquals(projectRenderCounts.has(projectId), false);
     } finally {
       allReady.reject(readinessError);

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -1047,6 +1047,7 @@ export class Renderer {
                   error: cancelError instanceof Error ? cancelError.message : cancelError,
                 });
               }
+              throw error;
             }
           }
         }

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -148,8 +148,8 @@ export interface RendererOptions {
 
 /**
  * Cached render result for Singleflight deduplication.
- * Contains only the serializable parts of RenderResult (no stream).
- * Each caller gets a fresh RenderResult from this cached data.
+ * Contains serializable cache data plus an uncached leader's stream.
+ * Singleflight entries never carry streams because cache-sensitive renders bypass it.
  */
 interface CachedRenderData {
   html: string;
@@ -160,6 +160,7 @@ interface CachedRenderData {
   pageModule?: RenderResult["pageModule"];
   headers?: RenderResult["headers"];
   cookies?: RenderResult["cookies"];
+  stream?: RenderResult["stream"];
 }
 
 function createCacheRenderNonce(): string {
@@ -929,7 +930,7 @@ export class Renderer {
       pageModule: cachedData.pageModule,
       ...(cachedData.headers ? { headers: cachedData.headers } : {}),
       ...(cachedData.cookies ? { cookies: cachedData.cookies } : {}),
-      stream: null,
+      stream: cachedData.stream ?? null,
     };
   }
 
@@ -1066,6 +1067,7 @@ export class Renderer {
         pageModule: result.pageModule,
         ...(result.headers ? { headers: result.headers } : {}),
         ...(result.cookies ? { cookies: result.cookies } : {}),
+        ...(cacheKey === null && result.stream ? { stream: result.stream } : {}),
       };
     } finally {
       if (globalAcquired) renderSemaphore.release();

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -882,8 +882,11 @@ export class Renderer {
       throw error;
     }
 
-    if (isFollower && cachedData.cookies?.length) {
-      logger.debug("Rerendering follower after cookie-bearing render", {
+    if (
+      isFollower &&
+      (cachedData.cookies?.length || Object.keys(cachedData.headers ?? {}).length > 0)
+    ) {
+      logger.debug("Rerendering follower after response-metadata-bearing render", {
         slug,
         projectId: ctx.projectId,
       });
@@ -1021,7 +1024,11 @@ export class Renderer {
         },
       );
 
-      if (cacheKey !== null && !result.cookies?.length) {
+      if (
+        cacheKey !== null &&
+        !result.cookies?.length &&
+        Object.keys(result.headers ?? {}).length === 0
+      ) {
         await this.cache.persistResult(
           result,
           slug,

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -831,19 +831,25 @@ export class Renderer {
         )
         : await runRender();
     } catch (error) {
-      const attachedCookies = error instanceof Error
-        ? getAttachedDataResponseMetadata(error).cookies
-        : undefined;
+      const attachedMetadata = error instanceof Error ? getAttachedDataResponseMetadata(error) : {};
+      const attachedCookies = attachedMetadata.cookies;
       const unwrappedError = error instanceof Error
         ? unwrapDataResponseMetadataError(error)
         : error;
-      const controlCookies = resolveSSRControlOutcome(unwrappedError)?.cookies ??
-        resolveSSRControlOutcome(error)?.cookies;
+      const controlOutcome = resolveSSRControlOutcome(unwrappedError) ??
+        resolveSSRControlOutcome(error);
+      const controlCookies = controlOutcome?.cookies;
+      const attachedHeaders = attachedMetadata.headers;
+      const controlHeaders = controlOutcome?.headers;
       if (
         isFollower &&
-        ((attachedCookies?.length ?? 0) > 0 || (controlCookies?.length ?? 0) > 0)
+        ((attachedCookies?.length ?? 0) > 0 ||
+          (controlCookies?.length ?? 0) > 0 ||
+          Object.keys(attachedHeaders ?? {}).length > 0 ||
+          (typeof controlHeaders === "object" && controlHeaders !== null &&
+            Object.keys(controlHeaders).length > 0))
       ) {
-        logger.debug("Rerendering follower after cookie-bearing render failure", {
+        logger.debug("Rerendering follower after response-metadata-bearing render failure", {
           slug,
           projectId: ctx.projectId,
         });
@@ -1006,7 +1012,7 @@ export class Renderer {
           ...options,
           request,
           abortSignal: renderAbortController.signal,
-          delivery: "string",
+          delivery: cacheKey === null ? options?.delivery : "string",
           projectId: ctx.projectId,
           projectSlug: ctx.projectSlug,
           environment: ctx.environment,

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -1032,9 +1032,22 @@ export class Renderer {
           const allReady = getStreamAllReady(result.stream);
           if (allReady) {
             // Keep admission and the render deadline active through streamed
-            // work. The SSR boundary classifies the original promise's
-            // rejection after this method returns.
-            await allReady.catch(() => {});
+            // work. A readiness rejection reports an error, not producer
+            // completion, so cancel the stream before releasing either slot.
+            try {
+              await allReady;
+            } catch (error) {
+              renderAbortController.abort(error);
+              try {
+                await result.stream?.cancel(error);
+              } catch (cancelError) {
+                logger.warn("Failed to cancel streamed render after readiness failure", {
+                  slug,
+                  projectId: ctx.projectId,
+                  error: cancelError instanceof Error ? cancelError.message : cancelError,
+                });
+              }
+            }
           }
         }
         return result;

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -163,6 +163,12 @@ interface CachedRenderData {
   stream?: RenderResult["stream"];
 }
 
+function getStreamAllReady(stream: RenderResult["stream"]): Promise<unknown> | null {
+  const allReady = (stream as { allReady?: unknown } | null | undefined)?.allReady;
+  if (!allReady || typeof (allReady as { then?: unknown }).then !== "function") return null;
+  return allReady as Promise<unknown>;
+}
+
 function createCacheRenderNonce(): string {
   const bytes = crypto.getRandomValues(new Uint8Array(16));
   return Array.from(bytes, (value) => value.toString(16).padStart(2, "0")).join("");
@@ -1008,8 +1014,8 @@ export class Renderer {
       const request = cacheKey !== null && options?.request
         ? new Request(options.request, { signal: renderAbortController.signal })
         : options?.request;
-      const result = await withTimeoutThrow(
-        services.pipeline.renderPage(slug, {
+      const renderToReady = async (): Promise<RenderResult> => {
+        const result = await services.pipeline.renderPage(slug, {
           ...options,
           request,
           abortSignal: renderAbortController.signal,
@@ -1021,7 +1027,20 @@ export class Renderer {
           releaseId: ctx.releaseId,
           skipCacheCheck: true,
           skipCachePersist: true,
-        }),
+        });
+        if (cacheKey === null) {
+          const allReady = getStreamAllReady(result.stream);
+          if (allReady) {
+            // Keep admission and the render deadline active through streamed
+            // work. The SSR boundary classifies the original promise's
+            // rejection after this method returns.
+            await allReady.catch(() => {});
+          }
+        }
+        return result;
+      };
+      const result = await withTimeoutThrow(
+        renderToReady(),
         RENDER_PIPELINE_TIMEOUT_MS,
         `Render pipeline for ${ctx.projectId}:${slug}`,
         {

--- a/src/rendering/shared/context-aware-cache.ts
+++ b/src/rendering/shared/context-aware-cache.ts
@@ -37,6 +37,10 @@ export interface ContextAwareCacheLookupResult {
   lookupDurationMs: number;
 }
 
+function hasResponseMetadata(result: RenderResult): boolean {
+  return Object.keys(result.headers ?? {}).length > 0 || (result.cookies?.length ?? 0) > 0;
+}
+
 export class ContextAwareCacheCoordinator {
   private store: CacheStore;
   private ttlMs: number | undefined;
@@ -73,6 +77,24 @@ export class ContextAwareCacheCoordinator {
           const lookupDurationMs = roundDurationMs(performance.now() - lookupStart);
           recordCacheLookup("miss", lookupDurationMs);
           logger.debug("Cache miss", {
+            slug,
+            cacheKey,
+            projectId: ctx.projectId,
+            environment: ctx.environment,
+            lookupDurationMs,
+          });
+          return { cacheKey, hit: false, status: "miss", lookupDurationMs };
+        }
+
+        if (hasResponseMetadata(cached.result)) {
+          if (this.store.deleteIfUnchanged) {
+            await this.store.deleteIfUnchanged(cacheKey, cached);
+          } else {
+            await this.store.delete(cacheKey);
+          }
+          const lookupDurationMs = roundDurationMs(performance.now() - lookupStart);
+          recordCacheLookup("miss", lookupDurationMs);
+          logger.debug("Rejected response-metadata-bearing cache entry", {
             slug,
             cacheKey,
             projectId: ctx.projectId,

--- a/src/server/services/rendering/ssr.service.test.ts
+++ b/src/server/services/rendering/ssr.service.test.ts
@@ -470,7 +470,7 @@ describe("server/services/rendering/ssr.service", () => {
         assertEquals(result.etag, undefined);
       });
 
-      for (const sensitiveHeader of ["cookie", "authorization"] as const) {
+      for (const sensitiveHeader of ["cookie", "authorization", "x-api-key"] as const) {
         it(
           `forces no-cache and suppresses etags for requests with ${sensitiveHeader}`,
           async () => {
@@ -491,6 +491,23 @@ describe("server/services/rendering/ssr.service", () => {
           },
         );
       }
+
+      it("keeps the load-balancer cookie cache neutral", async () => {
+        const service = new SSRService({
+          rendererProvider: createMockRendererProvider(),
+        });
+        const request = new Request("http://localhost/test-page", {
+          headers: { cookie: "lb=sticky-route" },
+        });
+
+        const result = await service.renderPage(
+          makeCtx(),
+          makeRenderOptions({ request, useNoCache: false }),
+        );
+
+        assertEquals(result.cacheStrategy, "short");
+        assertEquals(typeof result.etag, "string");
+      });
 
       it("requests buffered delivery when the response is cacheable", async () => {
         let delivery: unknown;

--- a/src/server/services/rendering/ssr.service.test.ts
+++ b/src/server/services/rendering/ssr.service.test.ts
@@ -445,6 +445,53 @@ describe("server/services/rendering/ssr.service", () => {
         assertEquals(result.etag, undefined);
       });
 
+      it("forces no-cache and suppresses etags when a render sets custom headers", async () => {
+        const adapter = createMockRendererAdapter({
+          renderPage: () =>
+            Promise.resolve({
+              html: "<html>rendered</html>",
+              stream: undefined,
+              ssrHash: "hash123",
+              frontmatter: {},
+              headers: { "x-page-state": "request-derived" },
+            } as any),
+        });
+        const service = new SSRService({
+          rendererProvider: createMockRendererProvider(adapter),
+        });
+
+        const result = await service.renderPage(
+          makeCtx(),
+          makeRenderOptions({ useNoCache: false }),
+        );
+
+        assertEquals(result.headers, { "x-page-state": "request-derived" });
+        assertEquals(result.cacheStrategy, "no-cache");
+        assertEquals(result.etag, undefined);
+      });
+
+      for (const sensitiveHeader of ["cookie", "authorization"] as const) {
+        it(
+          `forces no-cache and suppresses etags for requests with ${sensitiveHeader}`,
+          async () => {
+            const service = new SSRService({
+              rendererProvider: createMockRendererProvider(),
+            });
+            const request = new Request("http://localhost/test-page", {
+              headers: { [sensitiveHeader]: "sensitive-value" },
+            });
+
+            const result = await service.renderPage(
+              makeCtx(),
+              makeRenderOptions({ request, useNoCache: false }),
+            );
+
+            assertEquals(result.cacheStrategy, "no-cache");
+            assertEquals(result.etag, undefined);
+          },
+        );
+      }
+
       it("requests buffered delivery when the response is cacheable", async () => {
         let delivery: unknown;
         const adapter = createMockRendererAdapter({

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -234,6 +234,9 @@ export class SSRService implements SSRServiceLike {
   async renderPage(ctx: HandlerContext, options: SSRRenderOptions): Promise<SSRRenderResult> {
     const { request, url, slug, nonce, studioEmbed, projectId, pageId, noHmr, useNoCache } =
       options;
+    const requestHasSensitiveState = request.headers.has("cookie") ||
+      request.headers.has("authorization");
+    const mustNotCache = useNoCache || requestHasSensitiveState;
 
     // Project source without an explicit host capability is not trusted to
     // execute in the server process. Dedicated single-project runtimes may
@@ -285,7 +288,7 @@ export class SSRService implements SSRServiceLike {
       // Bind the render session to this async context so modules fetched
       // during the render are attributed to THIS render, not whichever
       // concurrent session started first.
-      const delivery = useNoCache ? "stream" : "string";
+      const delivery = mustNotCache ? "stream" : "string";
       const result = await runInRenderSession(renderSessionId, () =>
         profilePhase(
           "ssr.render_page",
@@ -345,8 +348,10 @@ export class SSRService implements SSRServiceLike {
         ...(result.cookies ? { cookies: result.cookies } : {}),
       };
       const setsCookies = (responseMetadata.cookies?.length ?? 0) > 0;
-      const cacheStrategy = useNoCache || setsCookies ? "no-cache" : "short";
-      const etag = isStreaming || setsCookies
+      const setsCustomHeaders = Object.keys(responseMetadata.headers ?? {}).length > 0;
+      const responseMustNotCache = mustNotCache || setsCookies || setsCustomHeaders;
+      const cacheStrategy = responseMustNotCache ? "no-cache" : "short";
+      const etag = isStreaming || responseMustNotCache
         ? undefined
         : computeSSRETag(result.ssrHash, result.html);
 

--- a/src/server/services/rendering/ssr.service.ts
+++ b/src/server/services/rendering/ssr.service.ts
@@ -43,6 +43,7 @@ import type { CacheRepository } from "#veryfront/repositories/types.ts";
 import type { DependencyPinningSourceInput } from "#veryfront/transforms/esm/package-registry.ts";
 import { isHostProjectCodeExecutionAllowed } from "#veryfront/security/project-locality.ts";
 import type { DataResponseMetadata, ResponseCookie } from "#veryfront/data/types.ts";
+import { requestHasCacheSensitiveState } from "#veryfront/cache/request-cacheability.ts";
 import {
   getAttachedDataResponseMetadata,
   mergeDataResponseMetadata,
@@ -234,8 +235,7 @@ export class SSRService implements SSRServiceLike {
   async renderPage(ctx: HandlerContext, options: SSRRenderOptions): Promise<SSRRenderResult> {
     const { request, url, slug, nonce, studioEmbed, projectId, pageId, noHmr, useNoCache } =
       options;
-    const requestHasSensitiveState = request.headers.has("cookie") ||
-      request.headers.has("authorization");
+    const requestHasSensitiveState = requestHasCacheSensitiveState(request);
     const mustNotCache = useNoCache || requestHasSensitiveState;
 
     // Project source without an explicit host capability is not trusted to


### PR DESCRIPTION
### Motivation
- Prevent production SSR responses that include request-derived headers or cookies from being served with the public short cache, which allows shared caches to replay sensitive headers.
- Ensure ETag generation and buffered (cacheable) delivery are suppressed whenever the request or the application response makes the result sensitive.

### Description
- Treat requests that include `Cookie` or `Authorization` as sensitive and mark them `mustNotCache`, causing non-cacheable delivery selection. (changed `renderPage` request handling and delivery selection in `src/server/services/rendering/ssr.service.ts`).
- Treat responses that emit cookies or application-provided headers as non-cacheable and suppress ETag generation by introducing `setsCustomHeaders` and `responseMustNotCache` in the response decision logic. (updated cache decision and ETag logic in `src/server/services/rendering/ssr.service.ts`).
- Switch rendering delivery to streaming when the request is sensitive to avoid sending a cached string body for request-derived responses. (adjusted `delivery` selection passed to `renderer.renderPage`).
- Add focused unit tests that verify header-bearing renders and requests carrying `Cookie`/`Authorization` result in `no-cache` and no ETag. (tests added to `src/server/services/rendering/ssr.service.test.ts`).

### Testing
- ✅ `git diff --check` (no whitespace or diff errors).
- ⚠️ `deno fmt --check src/server/services/rendering/ssr.service.ts src/server/services/rendering/ssr.service.test.ts` (formatting check; skipped because `deno` is not available in the environment).
- ⚠️ `deno test --preload=src/testing/preload.ts --no-check --allow-all src/server/services/rendering/ssr.service.test.ts` (unit tests; could not run because `deno` is not available in the environment).
- ✅ Committed the change locally as `fix(ssr): prevent caching sensitive response metadata`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8268d309ec832d8b28f2341d8c86d4)