### PR TITLE
fix(agent): keep generic child streams private

### DIFF
--- a/src/agent/composition/composition.test.ts
+++ b/src/agent/composition/composition.test.ts
@@ -320,10 +320,10 @@ describe("agentAsTool", () => {
       });
     };
     const published: unknown[] = [];
-    const tool = createInvokeAgentTool({ resolveAgent: () => childAgent });
+    const tool = agentAsTool(childAgent, "Run case ingest", { publishChildStream: true });
 
     await tool.execute(
-      { agent_id: "case-ingest", description: "Run case ingest", prompt: "Fetch", context: {} },
+      { input: "Fetch" },
       {
         toolCallId: "parent-tool-call",
         publishDataEvent: (event) => {
@@ -356,10 +356,10 @@ describe("agentAsTool", () => {
       });
     };
     const published: unknown[] = [];
-    const tool = createInvokeAgentTool({ resolveAgent: () => childAgent });
+    const tool = agentAsTool(childAgent, "Run case ingest", { publishChildStream: true });
 
     await tool.execute(
-      { agent_id: "case-ingest", description: "Run case ingest", prompt: "Fetch", context: {} },
+      { input: "Fetch" },
       {
         toolCallId: "parent-tool-call",
         publishDataEvent: (event) => {

--- a/src/agent/composition/composition.test.ts
+++ b/src/agent/composition/composition.test.ts
@@ -250,7 +250,7 @@ describe("agentAsTool", () => {
     );
   });
 
-  it("publishes child stream events against the parent invoke_agent tool call", async () => {
+  it("does not publish child stream events from generic invoke_agent calls", async () => {
     const childResponse: AgentResponse = {
       text: "streamed child result",
       messages: [],
@@ -291,26 +291,7 @@ describe("agentAsTool", () => {
       },
     );
 
-    assertEquals(events, [
-      {
-        type: "veryfront.invoke_agent.stream",
-        name: "veryfront.invoke_agent.stream",
-        value: {
-          toolCallId: "parent-tool-call",
-          agentId: "case-ingest",
-          event: { type: "message-start", messageId: "child-message" },
-        },
-      },
-      {
-        type: "veryfront.invoke_agent.stream",
-        name: "veryfront.invoke_agent.stream",
-        value: {
-          toolCallId: "parent-tool-call",
-          agentId: "case-ingest",
-          event: { type: "text-delta", id: "child-text", delta: "Fetching cases" },
-        },
-      },
-    ]);
+    assertEquals(events, []);
   });
 
   it("attaches the child agent's name and avatar to every published event", async () => {

--- a/src/agent/runtime/agent-delegation.test.ts
+++ b/src/agent/runtime/agent-delegation.test.ts
@@ -15,7 +15,6 @@ import {
 import { runWithExactSourceIntegrationPolicy } from "#veryfront/integrations/source-policy-context.ts";
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
 import { getAvailableTools } from "./tool-helpers.ts";
-import { parseInvokeAgentStreamValue } from "#veryfront/chat/invoke-agent-stream.ts";
 
 it("buildAgentDelegateTools exposes one tool per delegate, excluding self and dupes", () => {
   const tools = buildAgentDelegateTools({
@@ -152,7 +151,7 @@ describe("invoke_agent", () => {
     assertEquals(result, { text: "drafted copy", toolCalls: 0, status: "completed" });
   });
 
-  it("publishes child stream events to the parent tool call", async () => {
+  it("keeps generic invoke_agent child stream events private", async () => {
     const writer = {
       id: "writer",
       config: {},
@@ -184,23 +183,7 @@ describe("invoke_agent", () => {
       },
     });
 
-    assertEquals(
-      published.length >= 1,
-      true,
-      "invoke_agent must publish child stream events to the parent tool call",
-    );
-    const parsed = parseInvokeAgentStreamValue(published[0]);
-    assertEquals(
-      parsed?.toolCallId,
-      "call-1",
-      "published child events must carry the parent toolCallId",
-    );
-    assertEquals(parsed?.agentId, "writer", "published child events must name the invoked agent");
-    assertEquals(
-      parsed?.event,
-      { type: "text-delta", id: "child-1", delta: "hi" },
-      "published child events must preserve the child stream payload",
-    );
+    assertEquals(published, []);
   });
 
   it("reports an error when the invoked agent id is unknown", async () => {

--- a/src/agent/runtime/agent-delegation.ts
+++ b/src/agent/runtime/agent-delegation.ts
@@ -85,7 +85,7 @@ export function createInvokeAgentTool(input: CreateInvokeAgentToolInput = {}): T
         });
       }
 
-      return agentAsTool(target, toolInput.description, { publishChildStream: true }).execute({
+      return agentAsTool(target, toolInput.description).execute({
         input: buildInvokeAgentPrompt(toolInput.prompt, toolInput.context),
       }, context);
     },


### PR DESCRIPTION
### Motivation

- A change enabled `publishChildStream` by default for generic `invoke_agent` calls, which forwards raw child-agent stream events to the parent chat and can expose nested reasoning and tool input/output data to end users.
- The goal is to restore the previous summary-only default for generic `invoke_agent` usage while preserving explicit opt-in streaming for callers that intentionally request it.

### Description

- Removed the default child-stream publication from the generic invoke tool by deleting `publishChildStream: true` in `createInvokeAgentTool` so `createInvokeAgentTool(...).execute` now calls `agentAsTool(target, ...)` without enabling `publishChildStream` (file: `src/agent/runtime/agent-delegation.ts`).
- Updated the focused regression test to assert that generic `invoke_agent` calls do not publish child stream events by changing the expectation to an empty `events` array (file: `src/agent/composition/composition.test.ts`).
- Preserved the explicit opt-in behavior for callers that call `agentAsTool(..., { publishChildStream: true })` so deliberate streaming use-cases remain supported.
- Committed the change with the message `fix(agent): keep generic child streams private`.

### Testing

- Ran `git diff --check` and basic diff checks locally which reported no whitespace errors and showed the intended changes. (succeeded)
- Attempted to run the focused Deno unit test: `deno test --preload=src/testing/preload.ts --no-check --allow-all src/agent/composition/composition.test.ts`, but `deno` is not available in the execution environment so the test could not be run. (not run)
- Attempted to run the test with `bun test src/agent/composition/composition.test.ts`, but the run failed due to an unavailable runtime dependency (`ajv`) in this environment, causing the test runner to error. (failed in this environment)
- The change is minimal and covered by the modified unit test; please run the repository's normal CI (Deno test suite) in CI or a developer environment with `deno` available to verify all tests pass before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bd5862904832da43742156afbdd0f)