### PR TITLE
fix(module-loader): drop redundant promise-identity guard on inFlight cleanup

### DIFF
--- a/src/rendering/orchestrator/module-loader/esm-rewriter.ts
+++ b/src/rendering/orchestrator/module-loader/esm-rewriter.ts
@@ -316,7 +316,9 @@ async function fetchEsmModuleWithin(
     try {
       return await materialization;
     } finally {
-      if (graph.inFlight.get(url) === materialization) graph.inFlight.delete(url);
+      // This frame is the entry's sole owner: another frame only sets `url`
+      // after observing it absent, which cannot happen before this delete.
+      graph.inFlight.delete(url);
     }
   } finally {
     releaseWait();


### PR DESCRIPTION
Fixes CodeQL alert [#304](https://github.com/veryfront/veryfront-code/security/code-scanning/304) (`js/missing-await`, warning).

## Problem

`fetchEsmModuleWithin` guarded its `finally` cleanup with a promise-identity comparison:

```ts
if (graph.inFlight.get(url) === materialization) graph.inFlight.delete(url);
```

CodeQL flags any `===` against a value that is always a promise, since promise comparisons are usually a missing `await`.

## Fix

The guard is provably redundant, so the entry is deleted unconditionally. `graph.inFlight` has exactly one set site and one delete site: a frame only sets the entry for `url` after observing it absent, and only the frame that set an entry deletes it. So when the `finally` runs, the map entry is always this frame's own `materialization` — no other frame can have replaced it before the delete. A comment now records that ownership invariant in place of the guard.

## Verification

- `deno check` / `deno lint` / `deno fmt --check` on the file: clean
- `esm-rewriter.test.ts`: 44/44 steps pass, including the sibling-cycle and concurrent-graph cleanup cases
- Pre-push hook (fmt + lint + typecheck + full unit suite): passed

https://claude.ai/code/session_01LSRT6E7fobuoSFFJdTfL6V

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup after ECMAScript module loading completes.
  * Prevented stale in-flight module references from affecting subsequent loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->