### PR TITLE
fix(proxy): bound release asset cold-load waiters

### DIFF
--- a/src/proxy/asset-handler.test.ts
+++ b/src/proxy/asset-handler.test.ts
@@ -752,7 +752,9 @@ describe("proxy release asset handler", () => {
   it("bounds callers waiting for cold asset loads", async () => {
     const source = "export const boundedWaiters = true;";
     const gate = Promise.withResolvers<void>();
+    let calls = 0;
     const fetchImpl = makeFetch(async () => {
+      calls++;
       await gate.promise;
       return new Response(source, {
         headers: { "Content-Type": "text/javascript" },
@@ -776,6 +778,14 @@ describe("proxy release asset handler", () => {
         .length,
       256,
     );
+    assertEquals(calls, 1);
+
+    clearReleaseAssetProxyCache();
+    assertEquals(
+      (await handle(url, { apiBaseUrl: API_BASE, fetchImpl }))?.status,
+      200,
+    );
+    assertEquals(calls, 2);
   });
 
   it("allows only GET and HEAD on the immutable asset endpoint", async () => {

--- a/src/proxy/asset-handler.test.ts
+++ b/src/proxy/asset-handler.test.ts
@@ -749,6 +749,35 @@ describe("proxy release asset handler", () => {
     assertEquals(calls, 1);
   });
 
+  it("bounds callers waiting for cold asset loads", async () => {
+    const source = "export const boundedWaiters = true;";
+    const gate = Promise.withResolvers<void>();
+    const fetchImpl = makeFetch(async () => {
+      await gate.promise;
+      return new Response(source, {
+        headers: { "Content-Type": "text/javascript" },
+      });
+    });
+    const url = await assetUrl(source, "js");
+    const pending = Array.from(
+      { length: 256 },
+      () => handle(url, { apiBaseUrl: API_BASE, fetchImpl }),
+    );
+    await flushAsyncWork();
+
+    assertEquals(
+      (await handle(url, { apiBaseUrl: API_BASE, fetchImpl }))?.status,
+      503,
+    );
+
+    gate.resolve();
+    assertEquals(
+      (await Promise.all(pending)).filter((response) => response?.status === 200)
+        .length,
+      256,
+    );
+  });
+
   it("allows only GET and HEAD on the immutable asset endpoint", async () => {
     let calls = 0;
     const fetchImpl = makeFetch(() => {

--- a/src/proxy/asset-handler.ts
+++ b/src/proxy/asset-handler.ts
@@ -45,21 +45,11 @@ const MAX_CACHED_ASSET_BYTES = 32 * 1024 * 1024;
  * load buffers a whole asset in memory, so peak bytes is this count times
  * RELEASE_ASSET_MAX_SIZE_BYTES.
  *
- * Excess demand queues rather than failing. A page's module graph is a fan-out
- * this proxy itself produced by serving the HTML, so shedding it would reject
- * the predictable consequence of our own response — and browser `import()`
- * never retries, which turns one shed asset into a dead page. Callers are
- * already bounded by their own deadline (`timeoutMs`) and the producer ceiling
- * (`MAX_UPSTREAM_TIMEOUT_MS`); a saturated proxy therefore shows up as latency
- * and finally an honest 504.
- *
- * A 503 is still reachable, but only from the semaphore's own
- * `DEFAULT_PERMIT_SEMAPHORE_MAX_QUEUE_SIZE` backstop. That threshold is two
- * orders of magnitude above one page's module graph, so reaching it means a
- * genuine flood rather than a project being shed for the size of the document
- * this proxy just served.
+ * Normal page demand queues rather than failing. A process-wide caller limit
+ * prevents unauthenticated requests from growing the queue without bound.
  */
 const MAX_CONCURRENT_COLD_LOADS = 4;
+const MAX_COLD_LOAD_WAITERS = 256;
 
 interface CachedAsset {
   bytes: Uint8Array<ArrayBuffer>;
@@ -115,8 +105,11 @@ const assetCache = new LRUCache<string, CachedAsset>({
   maxSizeBytes: MAX_CACHED_ASSET_BYTES,
   estimateSizeOf: (asset) => asset.bytes.byteLength + asset.contentType.length * 2 + 64,
 });
-const coldLoadAdmission = new PermitSemaphore(MAX_CONCURRENT_COLD_LOADS);
+const coldLoadAdmission = new PermitSemaphore(MAX_CONCURRENT_COLD_LOADS, {
+  maxQueueSize: MAX_COLD_LOAD_WAITERS,
+});
 const inflightAssetLoads = new Map<string, InflightAssetLoad>();
+let coldLoadWaiters = 0;
 
 /** True when the path is owned by the release asset prefix. */
 export function isReleaseAssetPath(pathname: string): boolean {
@@ -428,6 +421,8 @@ export async function handleReleaseAssetRequest(
   }
 
   if (req.signal.aborted) return clientClosedRequest();
+  if (coldLoadWaiters >= MAX_COLD_LOAD_WAITERS) return serviceUnavailable();
+  coldLoadWaiters++;
   try {
     const task = getOrCreateInflightAssetLoad(
       hash,
@@ -444,6 +439,8 @@ export async function handleReleaseAssetRequest(
     if (error instanceof ReleaseAssetTimeoutError) return gatewayTimeout();
     if (error instanceof ReleaseAssetOverloadedError) return serviceUnavailable();
     return badGateway();
+  } finally {
+    coldLoadWaiters--;
   }
 }
 

--- a/src/proxy/asset-handler.ts
+++ b/src/proxy/asset-handler.ts
@@ -357,12 +357,14 @@ async function waitForInflightAssetLoad(
     timeoutMs,
   );
 
+  coldLoadWaiters++;
   task.consumers++;
   try {
     return await waitForSharedPromise(task.promise, waiterController.signal);
   } finally {
     clearTimeout(timeoutId);
     requestSignal.removeEventListener("abort", abortFromRequest);
+    coldLoadWaiters--;
     task.consumers--;
     if (task.consumers === 0 && !task.settled) {
       if (inflightAssetLoads.get(task.hash) === task) {
@@ -422,7 +424,6 @@ export async function handleReleaseAssetRequest(
 
   if (req.signal.aborted) return clientClosedRequest();
   if (coldLoadWaiters >= MAX_COLD_LOAD_WAITERS) return serviceUnavailable();
-  coldLoadWaiters++;
   try {
     const task = getOrCreateInflightAssetLoad(
       hash,
@@ -439,8 +440,6 @@ export async function handleReleaseAssetRequest(
     if (error instanceof ReleaseAssetTimeoutError) return gatewayTimeout();
     if (error instanceof ReleaseAssetOverloadedError) return serviceUnavailable();
     return badGateway();
-  } finally {
-    coldLoadWaiters--;
   }
 }
 


### PR DESCRIPTION
### Motivation
- A recent change removed the small process-wide caps on release-asset cold-load waiters and the small semaphore queue, allowing unauthenticated requests to accumulate many pending waiters and causing memory/event-loop exhaustion and availability failures.
- Same-hash followers had no aggregate cap and could allocate timers/AbortControllers for each waiting caller, enabling an unauthenticated DoS against the public `/_vf/assets/...` endpoint.

### Description
- Add a process-wide caller cap `MAX_COLD_LOAD_WAITERS = 256` to limit the number of requests that may await cold-load work at once. 
- Configure the `PermitSemaphore` with an explicit `maxQueueSize` and keep `MAX_CONCURRENT_COLD_LOADS = 4` as the real upstream fetch bound. 
- Introduce `coldLoadWaiters` accounting and return `503 Service Unavailable` immediately when the cap is reached, while always decrementing the counter in a `finally` block so capacity is released after completion, timeout, abort, or failure. 
- Add a regression test `bounds callers waiting for cold asset loads` that asserts excess callers receive a `503` and admitted callers complete once the upstream load resolves. 

### Testing
- Ran `git diff --check` which passed. 
- Attempted to run the relevant unit tests with `deno test --no-check --allow-all src/proxy/asset-handler.test.ts` but the environment lacks Deno, so the automated test run could not be executed here. 
- Attempted a fallback via `npx deno` but the runtime fetch failed (npm registry 403), so no test execution completed in this environment; CI should run `deno test --no-check --allow-all src/proxy/asset-handler.test.ts` to validate the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a744aa19b70832da5fee2c9cc8b6c6c)