### PR TITLE
fix(config): continue hosted config discovery after candidate 404

### DIFF
--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1378,6 +1378,167 @@ export default config as const;
       assertEquals(existsCalls, 0);
     });
 
+    it("continues hosted config discovery after an API 404", async () => {
+      const adapter = setup();
+      const reads: string[] = [];
+      Object.assign(adapter.fs, {
+        getUnderlyingAdapter: () => adapter.fs,
+        isMultiProjectMode: () => true,
+        isVeryfrontAdapter: () => true,
+        readFile: async (path: string) => {
+          reads.push(path);
+          if (path === "/veryfront.config.js") {
+            throw Object.assign(new Error("Config candidate not found"), {
+              status: 404,
+            });
+          }
+          if (path === "/veryfront.config.ts") {
+            return 'export default { title: "later-candidate" };';
+          }
+          throw configCandidateNotFound(path);
+        },
+      });
+      __setHostedConfigEvaluatorForTests(async () => ({
+        title: "later-candidate",
+      }));
+      const sourceContext = {
+        productionMode: false,
+        branch: "feature/api-not-found",
+      } as const;
+      const preparedContext = await prepareDeclarativeConfigContext({
+        environmentName: "preview",
+        environment: {},
+      });
+
+      const config = await runWithRequestContext(
+        {
+          projectSlug: "demo",
+          projectId: "project-api-not-found",
+          token: "token",
+          branch: sourceContext.branch,
+        },
+        () =>
+          getHostedConfig("/hosted-api-not-found", adapter, {
+            cacheKey: "project-api-not-found",
+            sourceContext,
+            preparedContext,
+          }),
+      );
+
+      assertEquals(reads, ["/veryfront.config.js", "/veryfront.config.ts"]);
+      assertEquals(config.title, "later-candidate");
+    });
+
+    it("surfaces the 404 when every hosted candidate is missing at the API layer", async () => {
+      // A release that publishes no config at all must keep 404ing out of
+      // getHostedConfig: adapter-factory reads that 404 as "hosted-absent" and
+      // substitutes process-wide defaults. Continuing discovery past a
+      // candidate 404 must not convert total absence into a synthesized
+      // default config.
+      const adapter = setup();
+      const reads: string[] = [];
+      Object.assign(adapter.fs, {
+        getUnderlyingAdapter: () => adapter.fs,
+        isMultiProjectMode: () => true,
+        isVeryfrontAdapter: () => true,
+        readFile: (path: string) => {
+          reads.push(path);
+          return Promise.reject(
+            Object.assign(new Error("API request failed: 404 Not Found"), {
+              status: 404,
+            }),
+          );
+        },
+      });
+      const sourceContext = {
+        productionMode: false,
+        branch: "feature/api-all-not-found",
+      } as const;
+      const preparedContext = await prepareDeclarativeConfigContext({
+        environmentName: "preview",
+        environment: {},
+      });
+
+      const error = await assertRejects(
+        () =>
+          runWithRequestContext(
+            {
+              projectSlug: "demo",
+              projectId: "project-api-all-not-found",
+              token: "token",
+              branch: sourceContext.branch,
+            },
+            () =>
+              getHostedConfig("/hosted-api-all-not-found", adapter, {
+                cacheKey: "project-api-all-not-found",
+                sourceContext,
+                preparedContext,
+              }),
+          ),
+        VeryfrontError,
+      ) as VeryfrontError;
+
+      // Every candidate was tried before giving up.
+      assertEquals(reads, [
+        "/veryfront.config.js",
+        "/veryfront.config.ts",
+        "/veryfront.config.mjs",
+      ]);
+      // The 404 survives on the cause chain, where adapter-factory's
+      // hasNotFoundStatus finds it and reports the config as hosted-absent.
+      assertEquals(error.slug, "config-parse-error");
+      assertEquals((error.cause as { status?: number }).status, 404);
+    });
+
+    it("normalizes a proxy-backed hosted config read failure without invoking traps", async () => {
+      const adapter = setup();
+      let descriptorTrapCalls = 0;
+      const hostileError = new Proxy(new Error("backend details"), {
+        getOwnPropertyDescriptor() {
+          descriptorTrapCalls += 1;
+          throw new Error("descriptor trap must not run");
+        },
+      });
+      Object.assign(adapter.fs, {
+        getUnderlyingAdapter: () => adapter.fs,
+        isMultiProjectMode: () => true,
+        isVeryfrontAdapter: () => true,
+        readFile: async () => {
+          throw hostileError;
+        },
+      });
+      const sourceContext = {
+        productionMode: false,
+        branch: "feature/proxy-backend-failure",
+      } as const;
+      const preparedContext = await prepareDeclarativeConfigContext({
+        environmentName: "preview",
+        environment: {},
+      });
+
+      const error = await assertRejects(
+        () =>
+          runWithRequestContext(
+            {
+              projectSlug: "demo",
+              projectId: "project-proxy-failure",
+              token: "token",
+              branch: sourceContext.branch,
+            },
+            () =>
+              getHostedConfig("/hosted-proxy-failure", adapter, {
+                cacheKey: "project-proxy-failure",
+                sourceContext,
+                preparedContext,
+              }),
+          ),
+        VeryfrontError,
+      ) as VeryfrontError;
+
+      assertEquals(error.slug, "config-parse-error");
+      assertEquals(descriptorTrapCalls, 0);
+    });
+
     it("propagates hosted config backend failures without trying another candidate", async () => {
       const adapter = setup();
       let reads = 0;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -7,6 +7,7 @@ import {
   isVirtualFilesystem,
 } from "#veryfront/platform/adapters/fs/wrapper.ts";
 import { isBun, isDenoCompiled } from "#veryfront/platform/compat/runtime.ts";
+import { isProxyWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
 import { ESBUILD_WASM_URL } from "#veryfront/platform/compat/esbuild-shared.ts";
 import { serverLogger } from "#veryfront/utils/logger/logger.ts";
 import { sanitizeUrlCredentials } from "#veryfront/utils/logger/redact.ts";
@@ -771,6 +772,7 @@ async function readHostedConfigSource(
   adapter: RuntimeAdapter,
   configBaseDir: string,
 ): Promise<HostedConfigSourceSelection | null> {
+  let apiNotFound: { error: unknown } | undefined;
   for (const configFile of VERYFRONT_CONFIG_FILES) {
     const configPath = join(configBaseDir, configFile);
     try {
@@ -783,6 +785,14 @@ async function readHostedConfigSource(
     } catch (error) {
       if (isNotFoundError(error)) {
         logger.debug("Hosted config candidate not found", { configPath });
+        continue;
+      }
+      if (hasNotFoundStatus(error)) {
+        // A candidate-scoped API 404 must not abort discovery: a later
+        // candidate may still exist. Remember the first one instead -- if no
+        // candidate is found at all, the 404 has to surface (see below).
+        logger.debug("Hosted config candidate not found", { configPath });
+        if (apiNotFound === undefined) apiNotFound = { error };
         continue;
       }
       if (error instanceof DeclarativeConfigEvaluationError) {
@@ -804,7 +814,30 @@ async function readHostedConfigSource(
       });
     }
   }
+  if (apiNotFound !== undefined) {
+    // Every candidate is missing and at least one miss was an API-layer 404:
+    // the release publishes no config. Rethrow it so the caller reports the
+    // project as "hosted-absent" (adapter-factory then substitutes the
+    // process-wide defaults) instead of synthesizing a default config that
+    // downstream would treat as the project's own.
+    throw apiNotFound.error;
+  }
   return null;
+}
+
+function hasNotFoundStatus(error: unknown): boolean {
+  let current = error;
+  for (let depth = 0; depth < 8; depth++) {
+    if (
+      typeof current !== "object" || current === null || isProxyWithoutHooks(current)
+    ) return false;
+    const status = ObjectGetOwnPropertyDescriptor(current, "status");
+    if (status?.value === 404) return true;
+    const cause = ObjectGetOwnPropertyDescriptor(current, "cause");
+    if (cause === undefined) return false;
+    current = cause.value;
+  }
+  return false;
 }
 
 function removeQueuedHostedConfigSourceRead(


### PR DESCRIPTION
### Motivation

- A wrapped HTTP 404 returned by the hosted filesystem could be mistaken for "no config published" and cause the proxy path to proceed with no project config, disabling per-project security (auth/CORS/CSRF/CSP). 
- The existing discovery loop only treated filesystem-style ENOENT/ENOTDIR as absent, so a 404 from an earlier candidate (for example `veryfront.config.js`) could escape before later candidates (for example `veryfront.config.ts`) were tried.

### Description

- Treat bounded HTTP 404 status values in the error/cause chain as a candidate-level absence inside `readHostedConfigSource` by checking `hasNotFoundStatus(error)` in addition to `isNotFoundError(error)`.
- Add a safe, depth-bounded `hasNotFoundStatus` helper that inspects own `status` descriptors and follows `cause` without invoking getters.
- Add a regression test `continues hosted config discovery after an API 404` to `src/config/loader.test.ts` that simulates a 404 for `veryfront.config.js` and verifies `veryfront.config.ts` is read and evaluated.
- Preserve existing failure behavior so non-404 backend failures still surface and fail closed through the existing error path.

### Testing

- Ran `git diff --check`, which completed with no whitespace/formatting diffs reported.
- Attempted `deno fmt --check src/config/loader.ts src/config/loader.test.ts`, but `deno` is not available in this environment so the check was not executed.
- Attempted `deno test --no-check --allow-all src/config/loader.test.ts`, but `deno` is not available in this environment so the unit test run was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a73fd487288832d90dc1c59a0108e4e)