### PR TITLE
Prevent API token disclosure during deploy readiness checks

### DIFF
--- a/cli/shared/deployment/deploy-project.test.ts
+++ b/cli/shared/deployment/deploy-project.test.ts
@@ -558,7 +558,6 @@ describe("environment URL readiness", () => {
     environmentName: "production",
     url: "https://my-project.production.veryfront.com",
     protected: false,
-    apiToken: "test-token",
   };
 
   it("retries a transient 404 before accepting the environment URL", async () => {
@@ -617,7 +616,7 @@ describe("environment URL readiness", () => {
     assertEquals(requests, 0);
   });
 
-  it("authenticates a protected Veryfront environment with the stored token", async () => {
+  it("does not send the API token to a protected Veryfront environment", async () => {
     let cookie: string | null = null;
 
     await withMockFetch(
@@ -633,10 +632,10 @@ describe("environment URL readiness", () => {
         }),
     );
 
-    assertEquals(cookie, "authToken=test-token");
+    assertEquals(cookie, null);
   });
 
-  it("upgrades authenticated Veryfront environment probes to HTTPS", async () => {
+  it("upgrades protected Veryfront environment probes to HTTPS", async () => {
     let requestedUrl = "";
     let cookie: string | null = null;
 
@@ -656,7 +655,7 @@ describe("environment URL readiness", () => {
     );
 
     assertEquals(requestedUrl, "https://my-project.production.veryfront.com/");
-    assertEquals(cookie, "authToken=test-token");
+    assertEquals(cookie, null);
   });
 
   it("does not send credentials to a mismatched Veryfront project host", async () => {
@@ -693,12 +692,12 @@ describe("environment URL readiness", () => {
       },
       {
         url: "https://my-project.production.veryfront.com/",
-        cookie: "authToken=test-token",
+        cookie: null,
       },
     ]);
   });
 
-  it("authenticates a protected veryfront.org environment directly", async () => {
+  it("does not send the API token to a protected veryfront.org environment", async () => {
     const requests: Array<{ url: string; cookie: string | null }> = [];
 
     await withMockFetch(
@@ -720,7 +719,7 @@ describe("environment URL readiness", () => {
 
     assertEquals(requests, [{
       url: "https://my-project.production.veryfront.org/",
-      cookie: "authToken=test-token",
+      cookie: null,
     }]);
   });
 
@@ -755,7 +754,7 @@ describe("environment URL readiness", () => {
       { url: "https://app.example.com/", cookie: null },
       {
         url: "https://my-project.production.veryfront.com/",
-        cookie: "authToken=test-token",
+        cookie: null,
       },
     ]);
   });
@@ -807,7 +806,7 @@ describe("environment URL readiness", () => {
     );
   });
 
-  it("reports an actionable authentication error for sign-in redirects", async () => {
+  it("accepts the sign-in challenge for a protected environment", async () => {
     await withMockFetch(
       () =>
         Promise.resolve(
@@ -817,15 +816,10 @@ describe("environment URL readiness", () => {
           }),
         ),
       () =>
-        assertRejects(
-          () =>
-            waitForEnvironmentReady({
-              ...hostedTarget,
-              protected: true,
-            }),
-          Error,
-          "veryfront login",
-        ),
+        waitForEnvironmentReady({
+          ...hostedTarget,
+          protected: true,
+        }),
     );
   });
 

--- a/cli/shared/deployment/deploy-project.ts
+++ b/cli/shared/deployment/deploy-project.ts
@@ -698,12 +698,10 @@ interface EnvironmentReadinessTarget {
   url: string;
   route?: string | null;
   protected: boolean;
-  apiToken: string;
 }
 
 interface EnvironmentReadinessProbe {
   url: string;
-  authenticate: boolean;
   acceptAuthenticationChallenge: boolean;
 }
 
@@ -732,7 +730,6 @@ function buildEnvironmentReadinessProbes(
     return [
       {
         url: targetUrl,
-        authenticate: false,
         acceptAuthenticationChallenge: true,
       },
       {
@@ -740,15 +737,13 @@ function buildEnvironmentReadinessProbes(
           buildCanonicalEnvironmentUrl(target.projectSlug, target.environmentName),
           route,
         ),
-        authenticate: true,
-        acceptAuthenticationChallenge: false,
+        acceptAuthenticationChallenge: true,
       },
     ];
   }
   return [{
     url: target.protected ? secureEnvironmentProbeUrl(targetUrl) : targetUrl,
-    authenticate: target.protected,
-    acceptAuthenticationChallenge: false,
+    acceptAuthenticationChallenge: target.protected,
   }];
 }
 
@@ -796,9 +791,6 @@ export async function waitForEnvironmentReady(
   const deadline = Date.now() + timeoutMs;
   for (const probe of buildEnvironmentReadinessProbes(target)) {
     const headers = new Headers({ "Cache-Control": "no-cache" });
-    if (probe.authenticate) {
-      headers.set("Cookie", `authToken=${target.apiToken}`);
-    }
     let lastResponse = "no response";
 
     for (;;) {
@@ -827,10 +819,9 @@ export async function waitForEnvironmentReady(
 
         if (ready) break;
         if (authenticationChallenge) {
-          const message = probe.authenticate
-            ? `Could not authenticate the protected environment URL ${probe.url}. Run veryfront login and deploy again.`
-            : `Environment URL ${probe.url} redirected to sign-in. Check its protection settings and deploy again.`;
-          throw new Error(message);
+          throw new Error(
+            `Environment URL ${probe.url} redirected to sign-in. Check its protection settings and deploy again.`,
+          );
         }
         if (!isTransientEnvironmentStatus(response.status)) {
           throw new Error(
@@ -1120,7 +1111,6 @@ export function createDeployProject(options: {
           url: environmentUrl,
           route: readinessRoute,
           protected: environment.protected,
-          apiToken: config.apiToken,
         }, {
           pollIntervalMs: polling.environmentPollIntervalMs,
           timeoutMs: polling.environmentTimeoutMs,


### PR DESCRIPTION
### Motivation

- A deploy path exposed the management API token to deployed tenant code via authenticated readiness probes, which could let malicious app code exfiltrate the token.  
- The MCP `vf_trigger_deploy` change caused `DeployProject.execute` to run these probes on behalf of MCP callers, increasing the attack surface.  
- The intent of the change is to remove any credentials from readiness probes while preserving the ability to verify protected environments are reachable.

### Description

- Removed `apiToken` from `EnvironmentReadinessTarget` and stopped passing `config.apiToken` into readiness calls in `createDeployProject` so readiness checks are credential-free.  
- Reworked probe construction so probes do not set an authentication cookie; probes instead use `acceptAuthenticationChallenge` for protected targets and no longer attempt to authenticate the probe request.  
- Updated `waitForEnvironmentReady` to avoid setting `Cookie: authToken=...` and to treat sign-in redirects / 401 / 403 as acceptable evidence of protected routing when `acceptAuthenticationChallenge` is set.  
- Adjusted test coverage in `cli/shared/deployment/deploy-project.test.ts` to assert that protected Veryfront-hosted and custom-domain probes do not send any authentication cookie and that sign-in redirects satisfy readiness without credentials.

### Testing

- Ran `git diff --check` which passed.  
- Attempted `deno fmt --check` and `deno test --no-check --allow-all cli/shared/deployment/deploy-project.test.ts`, but `deno` is not available in this execution environment so those automated checks could not be executed here.  
- Committed the change locally (`fix(security): keep deploy readiness probes credential-free`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f9f8a6328832d8a2974b0c14cdb2f)