### PR TITLE
Keep deploy credentials out of readiness probes

### DIFF
--- a/cli/shared/deployment/deploy-project.test.ts
+++ b/cli/shared/deployment/deploy-project.test.ts
@@ -558,7 +558,6 @@ describe("environment URL readiness", () => {
     environmentName: "production",
     url: "https://my-project.production.veryfront.com",
     protected: false,
-    apiToken: "test-token",
   };
 
   it("retries a transient 404 before accepting the environment URL", async () => {
@@ -617,7 +616,7 @@ describe("environment URL readiness", () => {
     assertEquals(requests, 0);
   });
 
-  it("authenticates a protected Veryfront environment with the stored token", async () => {
+  it("checks a protected Veryfront environment without exposing the stored token", async () => {
     let cookie: string | null = null;
 
     await withMockFetch(
@@ -633,10 +632,10 @@ describe("environment URL readiness", () => {
         }),
     );
 
-    assertEquals(cookie, "authToken=test-token");
+    assertEquals(cookie, null);
   });
 
-  it("upgrades authenticated Veryfront environment probes to HTTPS", async () => {
+  it("upgrades protected Veryfront environment probes to HTTPS", async () => {
     let requestedUrl = "";
     let cookie: string | null = null;
 
@@ -656,7 +655,7 @@ describe("environment URL readiness", () => {
     );
 
     assertEquals(requestedUrl, "https://my-project.production.veryfront.com/");
-    assertEquals(cookie, "authToken=test-token");
+    assertEquals(cookie, null);
   });
 
   it("does not send credentials to a mismatched Veryfront project host", async () => {
@@ -693,12 +692,12 @@ describe("environment URL readiness", () => {
       },
       {
         url: "https://my-project.production.veryfront.com/",
-        cookie: "authToken=test-token",
+        cookie: null,
       },
     ]);
   });
 
-  it("authenticates a protected veryfront.org environment directly", async () => {
+  it("checks a protected veryfront.org environment without credentials", async () => {
     const requests: Array<{ url: string; cookie: string | null }> = [];
 
     await withMockFetch(
@@ -720,7 +719,7 @@ describe("environment URL readiness", () => {
 
     assertEquals(requests, [{
       url: "https://my-project.production.veryfront.org/",
-      cookie: "authToken=test-token",
+      cookie: null,
     }]);
   });
 
@@ -755,7 +754,7 @@ describe("environment URL readiness", () => {
       { url: "https://app.example.com/", cookie: null },
       {
         url: "https://my-project.production.veryfront.com/",
-        cookie: "authToken=test-token",
+        cookie: null,
       },
     ]);
   });
@@ -807,7 +806,7 @@ describe("environment URL readiness", () => {
     );
   });
 
-  it("reports an actionable authentication error for sign-in redirects", async () => {
+  it("accepts a protected environment sign-in redirect as ready", async () => {
     await withMockFetch(
       () =>
         Promise.resolve(
@@ -817,15 +816,10 @@ describe("environment URL readiness", () => {
           }),
         ),
       () =>
-        assertRejects(
-          () =>
-            waitForEnvironmentReady({
-              ...hostedTarget,
-              protected: true,
-            }),
-          Error,
-          "veryfront login",
-        ),
+        waitForEnvironmentReady({
+          ...hostedTarget,
+          protected: true,
+        }),
     );
   });
 

--- a/cli/shared/deployment/deploy-project.ts
+++ b/cli/shared/deployment/deploy-project.ts
@@ -698,12 +698,10 @@ interface EnvironmentReadinessTarget {
   url: string;
   route?: string | null;
   protected: boolean;
-  apiToken: string;
 }
 
 interface EnvironmentReadinessProbe {
   url: string;
-  authenticate: boolean;
   acceptAuthenticationChallenge: boolean;
 }
 
@@ -732,7 +730,6 @@ function buildEnvironmentReadinessProbes(
     return [
       {
         url: targetUrl,
-        authenticate: false,
         acceptAuthenticationChallenge: true,
       },
       {
@@ -740,15 +737,13 @@ function buildEnvironmentReadinessProbes(
           buildCanonicalEnvironmentUrl(target.projectSlug, target.environmentName),
           route,
         ),
-        authenticate: true,
-        acceptAuthenticationChallenge: false,
+        acceptAuthenticationChallenge: true,
       },
     ];
   }
   return [{
     url: target.protected ? secureEnvironmentProbeUrl(targetUrl) : targetUrl,
-    authenticate: target.protected,
-    acceptAuthenticationChallenge: false,
+    acceptAuthenticationChallenge: target.protected,
   }];
 }
 
@@ -796,9 +791,6 @@ export async function waitForEnvironmentReady(
   const deadline = Date.now() + timeoutMs;
   for (const probe of buildEnvironmentReadinessProbes(target)) {
     const headers = new Headers({ "Cache-Control": "no-cache" });
-    if (probe.authenticate) {
-      headers.set("Cookie", `authToken=${target.apiToken}`);
-    }
     let lastResponse = "no response";
 
     for (;;) {
@@ -827,10 +819,9 @@ export async function waitForEnvironmentReady(
 
         if (ready) break;
         if (authenticationChallenge) {
-          const message = probe.authenticate
-            ? `Could not authenticate the protected environment URL ${probe.url}. Run veryfront login and deploy again.`
-            : `Environment URL ${probe.url} redirected to sign-in. Check its protection settings and deploy again.`;
-          throw new Error(message);
+          throw new Error(
+            `Environment URL ${probe.url} redirected to sign-in. Check its protection settings and deploy again.`,
+          );
         }
         if (!isTransientEnvironmentStatus(response.status)) {
           throw new Error(
@@ -1120,7 +1111,6 @@ export function createDeployProject(options: {
           url: environmentUrl,
           route: readinessRoute,
           protected: environment.protected,
-          apiToken: config.apiToken,
         }, {
           pollIntervalMs: polling.environmentPollIntervalMs,
           timeoutMs: polling.environmentTimeoutMs,


### PR DESCRIPTION
### Motivation

- Prevent leaking the CLI API token into tenant-controlled application requests during post-deploy readiness probing by removing credentials from data-plane probes. 

### Description

- Stop including `apiToken` on `EnvironmentReadinessTarget` and remove any code path that sets `Cookie: authToken=...` for readiness probes in `waitForEnvironmentReady` and probe construction. (changes in `cli/shared/deployment/deploy-project.ts`).
- Treat expected authentication challenges (sign-in redirects, `401`, `403`) as acceptable evidence of reachability for protected hosts and preserve HTTPS upgrade and canonical-host fallback probing behavior. (changes in `cli/shared/deployment/deploy-project.ts`).
- Update focused readiness tests to assert that no cookie is sent to hosted or custom-domain probes and to accept sign-in redirects as readiness for protected environments. (changes in `cli/shared/deployment/deploy-project.test.ts`).
- Remove the now-unused probe-related fields and simplify probe construction so tests and runtime no longer rely on passing the CLI credential into application-visible requests. (modifications across the two files above).

### Testing

- Ran `git diff --check` to validate patch formatting and whitespace, which passed. 
- Ran targeted static checks via `rg` to ensure no remaining `authToken` cookie construction or `headers.set("Cookie", ...)` remained in the modified readiness code, which passed. 
- Attempted to run the repository's focused Deno tests (`deno test`) but the environment does not have Deno installed, so the automated test suite could not be executed here. 
- Attempted to install Deno in the environment to run tests but the install attempt failed due to network/environment restrictions, so full test verification is pending in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fa697d59c832d932b63a01e1df9c8)