### PR TITLE
Prevent App Router server modules from becoming release assets

### DIFF
--- a/src/html/styles-builder/css-import-extraction.test.ts
+++ b/src/html/styles-builder/css-import-extraction.test.ts
@@ -88,6 +88,15 @@ describe("html/styles-builder/css-import-extraction", () => {
       assertEquals(extractCssImportSpecifiers('import.meta.resolve("./a.css");'), []);
     });
 
+    it("retains query and fragment suffixes for filesystem normalization", () => {
+      assertEquals(
+        extractCssImportSpecifiers(
+          'import "./theme.css?inline"; import styles from "./card.module.css#release";',
+        ),
+        ["./theme.css?inline", "./card.module.css#release"],
+      );
+    });
+
     it("finds every real import in a mixed file", () => {
       const source = [
         '// import "./commented.css";',
@@ -137,6 +146,17 @@ describe("html/styles-builder/css-import-extraction", () => {
       assertEquals(
         resolveCssImportPath("@/theme/tokens.css", "/project/app/layout.tsx", "/project"),
         "/project/theme/tokens.css",
+      );
+    });
+
+    it("strips query and fragment suffixes before resolving", () => {
+      assertEquals(
+        resolveCssImportPath("./styles.css#release", "/project/app/layout.tsx", "/project"),
+        "/project/app/styles.css",
+      );
+      assertEquals(
+        resolveCssImportPath("@/theme.css?inline", "/project/app/layout.tsx", "/project"),
+        "/project/theme.css",
       );
     });
 

--- a/src/html/styles-builder/css-import-extraction.ts
+++ b/src/html/styles-builder/css-import-extraction.ts
@@ -21,15 +21,27 @@
 
 import { isWithinDirectory, normalizePath } from "#veryfront/utils/path-utils.ts";
 import { compareStrings } from "#veryfront/utils/compare.ts";
+import { splitSpecifierSuffix } from "#veryfront/transforms/shared/specifier-suffix.ts";
 
 /** Module extensions whose sources can carry CSS imports. */
-export const CSS_IMPORTING_SOURCE_EXTENSIONS = [".tsx", ".jsx", ".mdx", ".ts", ".js"];
+export const CSS_IMPORTING_SOURCE_EXTENSIONS = [
+  ".tsx",
+  ".jsx",
+  ".mdx",
+  ".ts",
+  ".js",
+  ".mjs",
+  ".cjs",
+  ".mts",
+  ".cts",
+];
 
 /**
- * ESM imports whose specifier ends in `.css`:
+ * ESM imports whose specifier path ends in `.css`, with an optional suffix:
  *   import "./styles.css";
  *   import styles from "./button.module.css";
  *   import("./theme.css")
+ *   import "./theme.css#release";
  *
  * Dynamic imports are matched on purpose, despite this once being described as
  * static-only. `import("./theme.css")` loads that stylesheet at runtime, so
@@ -42,7 +54,7 @@ export const CSS_IMPORTING_SOURCE_EXTENSIONS = [".tsx", ".jsx", ".mdx", ".ts", "
  * than it looks: release-asset builds turn a bogus specifier into a fatal
  * coverage gap, so a false positive fails the release.
  */
-const CSS_IMPORT_RE = /\bimport\b(?!\s*\.)[^'";]*['"]([^'"]+\.css)['"]/g;
+const CSS_IMPORT_RE = /\bimport\b(?!\s*\.)[^'";]*['"]([^'"]+\.css(?:[?#][^'"]*)?)['"]/g;
 
 /**
  * Extract the raw specifiers of all CSS imports in a source file.
@@ -94,16 +106,17 @@ export function resolveCssImportPath(
   importerPath: string,
   projectDir: string,
 ): string | null {
+  const specifierPath = splitSpecifierSuffix(specifier).path;
   const normalizedImporter = normalizePath(importerPath);
   const normalizedProjectDir = normalizePath(projectDir);
 
   let candidate: string;
-  if (specifier.startsWith("./") || specifier.startsWith("../")) {
+  if (specifierPath.startsWith("./") || specifierPath.startsWith("../")) {
     const dirEnd = normalizedImporter.lastIndexOf("/");
     if (dirEnd <= 0) return null;
-    candidate = `${normalizedImporter.slice(0, dirEnd)}/${specifier}`;
-  } else if (specifier.startsWith("@/")) {
-    candidate = `${normalizedProjectDir}/${specifier.slice(2)}`;
+    candidate = `${normalizedImporter.slice(0, dirEnd)}/${specifierPath}`;
+  } else if (specifierPath.startsWith("@/")) {
+    candidate = `${normalizedProjectDir}/${specifierPath.slice(2)}`;
   } else {
     return null;
   }

--- a/src/modules/import-map/loader.ts
+++ b/src/modules/import-map/loader.ts
@@ -46,7 +46,8 @@ function hasOwn(descriptor: PropertyDescriptor, key: PropertyKey): boolean {
   return ReflectApply(ObjectPrototypeHasOwnProperty, descriptor, [key]) as boolean;
 }
 
-function isFrameworkOwnedSpecifier(specifier: string): boolean {
+/** @internal Whether a project mapping targets a framework-owned specifier. */
+export function isFrameworkOwnedImportMapSpecifier(specifier: string): boolean {
   return specifier === "react" || specifier === "react-dom" ||
     stringStartsWith(specifier, "react/") ||
     stringStartsWith(specifier, "react-dom/") ||
@@ -57,7 +58,7 @@ function removeFrameworkOwnedMappings(record: Record<string, string>): void {
   const keys = ReflectOwnKeys(record);
   for (let index = 0; index < keys.length; index++) {
     const key = keys[index];
-    if (typeof key === "string" && isFrameworkOwnedSpecifier(key)) {
+    if (typeof key === "string" && isFrameworkOwnedImportMapSpecifier(key)) {
       delete record[key];
     }
   }
@@ -152,7 +153,8 @@ function normalizeImportValue(value: string): string {
   return query ? `${url}?${query}` : `${url}?target=es2022`;
 }
 
-function normalizeImportMapForRuntime(importMap: ImportMapConfig): ImportMapConfig {
+/** @internal Apply the authoritative runtime import-map policy to a merged map. */
+export function normalizeImportMapForRuntime(importMap: ImportMapConfig): ImportMapConfig {
   const exact = snapshotImportMap(importMap);
   const imports = copyFilteredRecord(exact.imports ?? ObjectCreate(null), true);
   const scopes = ObjectCreate(null) as Record<string, Record<string, string>>;

--- a/src/modules/import-map/resolver.test.ts
+++ b/src/modules/import-map/resolver.test.ts
@@ -118,6 +118,16 @@ describe("modules/import-map/resolver", () => {
       assertEquals(resolveImport("@lib/utils.ts", map), "/src/lib/utils.ts");
     });
 
+    it("uses the longest matching prefix regardless of insertion order", () => {
+      const map = {
+        imports: {
+          "#/": "/short/",
+          "#/nested/": "/long/",
+        },
+      };
+      assertEquals(resolveImport("#/nested/client.ts", map), "/long/client.ts");
+    });
+
     it("should try stripping .js extension for fallback", () => {
       const map = { imports: { lodash: "https://esm.sh/lodash@4" } };
       assertEquals(resolveImport("lodash.js", map), "https://esm.sh/lodash@4");

--- a/src/modules/import-map/resolver.ts
+++ b/src/modules/import-map/resolver.ts
@@ -34,10 +34,17 @@ export function resolveImport(
     if (mapped) return mapped;
   }
 
+  let prefixMatch: { key: string; value: string } | undefined;
   for (const [key, value] of Object.entries(importMap.imports ?? {})) {
-    if (key.endsWith("/") && specifier.startsWith(key)) {
-      return value + specifier.slice(key.length);
+    if (
+      key.endsWith("/") && specifier.startsWith(key) &&
+      (prefixMatch === undefined || key.length > prefixMatch.key.length)
+    ) {
+      prefixMatch = { key, value };
     }
+  }
+  if (prefixMatch !== undefined) {
+    return prefixMatch.value + specifier.slice(prefixMatch.key.length);
   }
 
   return specifier;

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -1,5 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
 import "../transforms/plugins/__tests__/code-parser-setup.ts";
+// Server MDX pages are compiled before their imports are collected, which
+// resolves the ContentProcessor contract provided by @veryfront/ext-content-mdx.
+import "../transforms/mdx/compiler/__tests__/content-processor-setup.ts";
 
 import type { VeryfrontConfig } from "#veryfront/config";
 import {
@@ -24,6 +27,7 @@ import {
 import {
   type ReleaseAssetBuildClient,
   type ReleaseAssetBuildInput,
+  releaseAssetBuildInternals,
   type ReleaseAssetBuildResult,
   type ReleaseAssetHttpDependencyVendor,
   type ReleaseAssetVendorResult,
@@ -39,6 +43,9 @@ import {
   type DependencyPinningSourceInput,
   resolveDependencyPinningSnapshot,
 } from "#veryfront/transforms/esm/package-registry.ts";
+import { register, tryResolve, unregister } from "#veryfront/extensions/contracts.ts";
+import type { CodeParser } from "#veryfront/extensions/parser/code-parser.ts";
+import { __subscribeLogRecordEmitter } from "#veryfront/utils/logger/logger.ts";
 
 const STYLE_PROFILE_HASH = "d".repeat(64);
 const CSS_PIPELINE_IDENTITY = "test-css-pipeline@1";
@@ -107,7 +114,14 @@ function assertCoverageFailure(
 function releaseConfigLoader(
   config: Partial<VeryfrontConfig> = {},
 ): ReleaseAssetBuildInput["loadConfig"] {
-  return () => Promise.resolve(config as VeryfrontConfig);
+  return () =>
+    Promise.resolve({
+      ...config,
+      experimental: {
+        ...config.experimental,
+        rsc: config.experimental?.rsc ?? true,
+      },
+    } as VeryfrontConfig);
 }
 
 function baseInput(
@@ -273,9 +287,12 @@ describe("release asset build executor", () => {
   it("assembles App Router page routes from app/page modules", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
-      { path: "app/page.tsx", content: "export default () => null;" },
-      { path: "app/about/page.tsx", content: "export default () => null;" },
-      { path: "app/layout.tsx", content: "export default ({ children }) => children;" },
+      { path: "app/page.tsx", content: '"use client"; export default () => null;' },
+      { path: "app/about/page.tsx", content: '"use client"; export default () => null;' },
+      {
+        path: "app/layout.tsx",
+        content: '"use client"; export default ({ children }) => children;',
+      },
       { path: "app/api/ag-ui/route.ts", content: "export async function POST() {}" },
     ];
     const client = makeClient(files, rec);
@@ -293,6 +310,3015 @@ describe("release asset build executor", () => {
     assertEquals(manifest.routes["/"]?.modules, ["app/page.tsx", "app/layout.tsx"]);
     assertEquals(manifest.routes["/about"]?.modules, ["app/about/page.tsx", "app/layout.tsx"]);
     assertEquals(routeForPage("app/layout.tsx"), null);
+  });
+
+  it("publishes App Router pages when RSC is explicitly disabled", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      { path: "app/page.tsx", content: "export default function Page() { return null; }" },
+      {
+        path: "app/layout.tsx",
+        content: "export default function Layout({ children }) { return children; }",
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild({
+      ...baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      loadConfig: releaseConfigLoader({ experimental: { rsc: false } }),
+    }, await tmp());
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertExists(manifest.modules["app/page.tsx"]);
+    assertExists(manifest.modules["app/layout.tsx"]);
+    assertEquals(manifest.routes["/"]?.modules, ["app/page.tsx", "app/layout.tsx"]);
+  });
+
+  it("rejects function-local server actions in non-RSC App Router entries", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'export async function save() { "use server"; return "<SECRET>"; } ' +
+          "export default function Page() { return save; }",
+      },
+      {
+        path: "app/layout.tsx",
+        content: "export default function Layout({ children }) { return children; }",
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild({
+      ...baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      loadConfig: releaseConfigLoader({ experimental: { rsc: false } }),
+    }, await tmp());
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assert(rec.uploads.every((upload) => !upload.text.includes("<SECRET>")));
+  });
+
+  it("rejects module-level use server in non-RSC App Router entries", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: '"use server"; export default function Page() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild({
+      ...baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      loadConfig: releaseConfigLoader({ experimental: { rsc: false } }),
+    }, await tmp());
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assertEquals(manifest.modules["app/page.tsx"], undefined);
+  });
+
+  it("does not publish App Router server modules or their server-only imports", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content:
+          'import "./private.ts"; import Client from "./client.tsx"; export default () => <Client />;',
+      },
+      { path: "app/private.ts", content: 'export const value = "<REDACTED>";' },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+    const client = makeClient(files, rec);
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.modules["app/page.tsx"], undefined);
+    assertEquals(manifest.modules["app/private.ts"], undefined);
+    assertExists(manifest.modules["app/client.tsx"]);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("does not let a client component promote a directive-less App Router entry", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "./client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; import OtherPage from "./other/page.tsx"; ' +
+          "export default () => <OtherPage />;",
+      },
+      {
+        path: "app/other/page.tsx",
+        content: 'export default () => "<REDACTED>";',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/other"]?.modules, []);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assertEquals(manifest.modules["app/other/page.tsx"], undefined);
+    assert(rec.uploads.every((upload) => !upload.text.includes("<REDACTED>")));
+  });
+
+  it("does not let a client component promote a directive-less App Router layout", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "./client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; import OtherLayout from "./other/layout.tsx"; ' +
+          "export default () => <OtherLayout />;",
+      },
+      {
+        path: "app/other/layout.tsx",
+        content: 'export default () => "<REDACTED>";',
+      },
+      { path: "app/other/page.tsx", content: "export default function Page() { return null; }" },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/other"]?.modules, []);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assertEquals(manifest.modules["app/other/layout.tsx"], undefined);
+    assert(rec.uploads.every((upload) => !upload.text.includes("<REDACTED>")));
+  });
+
+  it("drops an App Router route whose entry has conflicting directives", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: '"use client"; "use server"; export default () => "<REDACTED>";',
+      },
+      { path: "pages/ok.tsx", content: "export default () => null;" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assert(rec.uploads.every((upload) => !upload.text.includes("<REDACTED>")));
+  });
+
+  it("drops an App Router route whose outside dependency has conflicting directives", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import Conflict from "../shared/conflict.tsx"; ' +
+          "export default () => <Conflict />;",
+      },
+      {
+        path: "shared/conflict.tsx",
+        content: '"use client"; "use server"; export default () => "<REDACTED>";',
+      },
+      { path: "pages/ok.tsx", content: "export default () => null;" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assert(rec.uploads.every((upload) => !upload.text.includes("<REDACTED>")));
+  });
+
+  it("allows supported JSON imports in App Router server modules", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import data from "./data.json" with { type: "json" }; ' +
+          'import Client from "./client.tsx"; export default () => <Client data={data} />;',
+      },
+      { path: "app/data.json", content: '{"label":"server only"}' },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+    assertEquals(manifest.modules["app/data.json"], undefined);
+  });
+
+  it("drops an App Router route whose JSON import omits its type attribute", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import data from "./data.json"; import Client from "./client.tsx"; ' +
+          "export default () => <Client data={data} />;",
+      },
+      { path: "app/data.json", content: '{"label":"server only"}' },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+  });
+
+  it("drops an App Router route whose direct remote JSON import omits its type attribute", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import data from "https://cdn.example/config.json"; ' +
+          'import Client from "./client.tsx"; export default () => <Client data={data} />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+  });
+
+  it("treats bare package aliases ending in .json as packages", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      { path: "deno.json", content: '{"imports":{"#config":"pkg.json"}}' },
+      {
+        path: "app/page.tsx",
+        content: 'import config from "#config"; import Client from "./client.tsx"; ' +
+          "export default () => <Client config={config} />;",
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("drops an App Router route whose JSON alias omits its type attribute", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#data":"/_vf_modules/app/data.json"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import data from "#data"; import Client from "./client.tsx"; ' +
+          "export default () => <Client data={data} />;",
+      },
+      { path: "app/data.json", content: '{"label":"server only"}' },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+  });
+
+  it("allows a JSON alias with its type attribute in an App Router server module", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#data":"/_vf_modules/app/data.json"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import data from "#data" with { type: "json" }; ' +
+          'import Client from "./client.tsx"; export default () => <Client data={data} />;',
+      },
+      { path: "app/data.json", content: '{"label":"server only"}' },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+    assertEquals(manifest.modules["app/data.json"], undefined);
+  });
+
+  it("drops an App Router route whose JSON data URL omits its type attribute", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import data from "data:application/json,%7B%22label%22%3A%22inline%22%7D"; ' +
+          'import Client from "./client.tsx"; export default () => <Client data={data} />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+  });
+
+  it("drops an App Router route that directly imports a CSS data URL", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import "data:text/css,body%7Bcolor%3Ared%7D"; ' +
+          'import Client from "./client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+  });
+
+  it("allows a JSON data URL with its type attribute in an App Router server module", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content:
+          'import data from "data:application/problem+json,%7B%22label%22%3A%22inline%22%7D" with { type: "json" }; ' +
+          'import Client from "./client.tsx"; export default () => <Client data={data} />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("resolves project import-map aliases while traversing server modules", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#client":"/_vf_modules/app/client.tsx"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "#client"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("keeps relative server imports ahead of import-map entries", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"./client.tsx":"https://cdn.example/client.js"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "./client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("resolves project import-map aliases throughout the browser closure", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#helper":"/_vf_modules/app/helper.ts"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "./client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; import { helper } from "#helper"; ' +
+          "export default function Client() { return helper; }",
+      },
+      { path: "app/helper.ts", content: "export const helper = null;" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx", "app/helper.ts"]);
+    const clientHash = manifest.modules["app/client.tsx"]?.contentHash;
+    const helperHash = manifest.modules["app/helper.ts"]?.contentHash;
+    assertExists(clientHash);
+    assertExists(helperHash);
+    const clientUpload = rec.uploads.find((upload) => upload.hash === clientHash);
+    assertExists(clientUpload);
+    assertStringIncludes(clientUpload.text, `"/_vf/assets/${helperHash}.js"`);
+  });
+
+  it("keeps relative browser imports ahead of import-map entries", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"./client.tsx":"https://cdn.example/client.js"}}',
+      },
+      {
+        path: "pages/index.tsx",
+        content: 'import Client from "./client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "pages/client.tsx",
+        content: "export default function Client() { return null; }",
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["pages/index.tsx", "pages/client.tsx"]);
+    const entryHash = manifest.modules["pages/index.tsx"]?.contentHash;
+    const clientHash = manifest.modules["pages/client.tsx"]?.contentHash;
+    assertExists(entryHash);
+    assertExists(clientHash);
+    const entryUpload = rec.uploads.find((upload) => upload.hash === entryHash);
+    assertExists(entryUpload);
+    assertStringIncludes(entryUpload.text, `"/_vf/assets/${clientHash}.js"`);
+    assert(!entryUpload.text.includes("https://cdn.example/client.js"));
+  });
+
+  it("canonicalizes bare package import-map targets in source dependency mode", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#ui":"browser-ui-package"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "./client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; import ui from "#ui"; export default () => ui;',
+      },
+    ];
+    const input = baseInput(makeClient(files, rec), (source) => Promise.resolve(source));
+
+    const result = await runReleaseAssetBuild(
+      { ...input, dependencyMode: "source", vendorHttpImports: undefined },
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    const clientHash = manifest.modules["app/client.tsx"]?.contentHash;
+    assertExists(clientHash);
+    const clientUpload = rec.uploads.find((upload) => upload.hash === clientHash);
+    assertExists(clientUpload);
+    assertStringIncludes(clientUpload.text, "https://esm.sh/browser-ui-package?target=node");
+  });
+
+  it("uses the longest project import-map prefix during server traversal", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: JSON.stringify({
+          imports: {
+            "#/": "/_vf_modules/short/",
+            "#/nested/": "/_vf_modules/long/",
+          },
+        }),
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "#/nested/client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "short/nested/client.tsx",
+        content: '"use client"; export default function Short() { return null; }',
+      },
+      {
+        path: "long/client.tsx",
+        content: '"use client"; export default function Long() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["long/client.tsx"]);
+    assertEquals(manifest.modules["short/nested/client.tsx"], undefined);
+  });
+
+  it("applies package mappings to esm.sh server imports", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"widget":"/_vf_modules/app/client.tsx"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "https://esm.sh/widget@1"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("keeps esm.sh package mappings to remote targets external", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"widget":"https://esm.sh/widget@2"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import "https://esm.sh/widget@1"; ' +
+          'import Client from "./client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("drops a server route whose alias maps to an external stylesheet", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#theme":"https://cdn.example/theme.css?release"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import "#theme"; export default function Page() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+  });
+
+  it("validates JSON data URLs after resolving server aliases", async () => {
+    for (
+      const [attribute, publishesRoute] of [
+        ["", false],
+        [' with { type: "json" }', true],
+      ] as const
+    ) {
+      const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+      const files = [
+        {
+          path: "deno.json",
+          content:
+            '{"imports":{"#data":"data:application/problem+json,%7B%22label%22%3A%22inline%22%7D"}}',
+        },
+        {
+          path: "app/page.tsx",
+          content: `import data from "#data"${attribute}; export default () => data;`,
+        },
+        { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+      ];
+
+      const result = await runReleaseAssetBuild(
+        baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+        await tmp(),
+      );
+
+      assertEquals(result.success, true, result.error);
+      const manifest = parseReleaseAssetManifest(rec.manifest);
+      assertExists(manifest);
+      assertEquals(manifest.routes["/"] !== undefined, publishesRoute);
+      assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    }
+  });
+
+  it("resolves chained project import-map aliases while traversing server modules", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: JSON.stringify({
+          imports: {
+            "#entry": "#client",
+            "#client": "/_vf_modules/app/client.tsx",
+          },
+        }),
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "#entry"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("drops an App Router route whose project import-map aliases form a cycle", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: JSON.stringify({ imports: { "#first": "#second", "#second": "#first" } }),
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import "#first"; export default function Page() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+  });
+
+  it("treats native and bare import-map alias targets as external server imports", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: JSON.stringify({
+          imports: {
+            "#native": "node:fs",
+            "#package": "installed-server-package",
+          },
+        }),
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import "#native"; import "#package"; ' +
+          'import Client from "./client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("keeps protocol-relative server imports outside the project graph", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import "//cdn.example/sdk.js"; import Client from "./client.tsx"; ' +
+          "export default () => <Client />;",
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      {
+        path: "cdn.example/sdk.js",
+        content: '"use client"; export const sdk = "must stay external";',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+    assertEquals(manifest.modules["cdn.example/sdk.js"], undefined);
+  });
+
+  it("drops an App Router route that imports an existing file outside the release root", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const outerDir = await tmp();
+    const releaseDir = join(outerDir, "release");
+    await Deno.mkdir(releaseDir);
+    await Deno.writeTextFile(join(outerDir, "outside.ts"), "export const secret = true;");
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import { secret } from "../../outside.ts"; export default () => secret;',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      releaseDir,
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertExists(manifest.routes["/ok"]);
+  });
+
+  it("traverses mjs server helpers to find nested client boundaries", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import { renderClient } from "./server-helper.mjs"; ' +
+          "export default () => renderClient();",
+      },
+      {
+        path: "app/server-helper.mjs",
+        content: 'import Client from "./client.tsx"; ' +
+          "export const renderClient = () => Client();",
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.modules["app/server-helper.mjs"], undefined);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("prefers an mjs server helper over an mdx fallback", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import { renderClient } from "app/helper"; export default () => renderClient();',
+      },
+      {
+        path: "app/helper.mjs",
+        content:
+          'import Client from "./mjs-client.tsx"; export const renderClient = () => Client();',
+      },
+      {
+        path: "app/helper.mdx",
+        content: 'import Client from "./mdx-client.tsx"\n\n<Client />',
+      },
+      {
+        path: "app/mjs-client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      {
+        path: "app/mdx-client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/mjs-client.tsx"]);
+    assertEquals(manifest.modules["app/mdx-client.tsx"], undefined);
+  });
+
+  it("uses hosted extension priority for relative server imports", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import { renderClient } from "./helper"; export default () => renderClient();',
+      },
+      {
+        path: "app/helper.mdx",
+        content: 'import Client from "./mdx-client.tsx"\n\n<Client />',
+      },
+      {
+        path: "app/helper.tsx",
+        content:
+          'import Client from "./tsx-client.tsx"; export const renderClient = () => Client();',
+      },
+      {
+        path: "app/mdx-client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      {
+        path: "app/tsx-client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/mdx-client.tsx"]);
+    assertEquals(manifest.modules["app/tsx-client.tsx"], undefined);
+  });
+
+  it("strips a Windows materialization root before hosted extension lookup", () => {
+    assertEquals(
+      releaseAssetBuildInternals.releaseLogicalPathFromMaterializedPath(
+        "C:\\release\\app\\helper",
+        "C:\\release",
+        "windows",
+      ),
+      "app/helper",
+    );
+  });
+
+  it("drops routes that import unsupported server script extensions", async () => {
+    for (const extension of [".cjs", ".mts", ".cts"]) {
+      const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+      const files = [
+        {
+          path: "app/page.tsx",
+          content: `import { renderClient } from "./helper${extension}"; ` +
+            "export default () => renderClient();",
+        },
+        {
+          path: `app/helper${extension}`,
+          content: 'import Client from "./client.tsx"; export const renderClient = () => Client();',
+        },
+        {
+          path: "app/client.tsx",
+          content: '"use client"; export default function Client() { return null; }',
+        },
+        { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+      ];
+
+      const result = await runReleaseAssetBuild(
+        baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+        await tmp(),
+      );
+
+      assertEquals(result.success, true, `${extension}: ${result.error}`);
+      const manifest = parseReleaseAssetManifest(rec.manifest);
+      assertExists(manifest);
+      assertEquals(manifest.routes["/"], undefined, extension);
+      assertExists(manifest.routes["/ok"]);
+    }
+  });
+
+  it("does not source-fallback an absent CommonJS server import", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import { renderClient } from "./helper.cjs"; ' +
+          "export default () => renderClient();",
+      },
+      {
+        path: "app/helper.tsx",
+        content: 'import Client from "./client.tsx"; export const renderClient = () => Client();',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertExists(manifest.routes["/ok"]);
+  });
+
+  it("drops a server route with an unresolved cross-project import", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const result = await runReleaseAssetBuild(
+      baseInput(
+        makeClient([
+          {
+            path: "app/page.tsx",
+            content: 'import "demo/@/components/Card"; export default () => null;',
+          },
+          { path: "pages/ok.tsx", content: "export default () => null;" },
+        ], rec),
+        (source) => Promise.resolve(source),
+      ),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertExists(manifest.routes["/ok"]);
+  });
+
+  it("resolves Markdown imports from App Router server modules", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import "./content.md"; import Client from "./client.tsx"; ' +
+          "export default () => <Client />;",
+      },
+      { path: "app/content.md", content: "# Content" },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("classifies the complete server closure before generic browser seeds", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import { mid } from "../lib/mid.ts"; ' +
+          'import Client from "./client.tsx"; export default () => <Client value={mid} />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      {
+        path: "lib/mid.ts",
+        content: 'import { leaf } from "./a-leaf.ts"; export const mid = leaf;',
+      },
+      {
+        path: "lib/a-leaf.ts",
+        content: 'import { secret } from "./z-secret.ts"; export const leaf = secret;',
+      },
+      { path: "lib/z-secret.ts", content: 'export const secret = "<SECRET>";' },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+    for (const serverPath of ["lib/mid.ts", "lib/a-leaf.ts", "lib/z-secret.ts"]) {
+      assertEquals(manifest.modules[serverPath], undefined);
+    }
+    assert(rec.uploads.every((upload) => !upload.text.includes("<SECRET>")));
+  });
+
+  it("initializes the default parser before inspecting browser boundaries", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const previousParser = tryResolve<CodeParser>("CodeParser");
+    unregister("CodeParser");
+    try {
+      const result = await runReleaseAssetBuild(
+        baseInput(
+          makeClient([
+            {
+              path: "pages/index.tsx",
+              content: "export default function Page() { return null; }",
+            },
+          ], rec),
+          (source) => Promise.resolve(source),
+        ),
+        await tmp(),
+      );
+
+      assertEquals(result.success, true, result.error);
+      assertExists(parseReleaseAssetManifest(rec.manifest)?.routes["/"]);
+    } finally {
+      unregister("CodeParser");
+      if (previousParser) register("CodeParser", previousParser);
+    }
+  });
+
+  it("resolves extension-fallback import-map aliases while traversing server modules", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#client":"/_vf_modules/app/client.tsx"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "#client.js"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("excludes JSON when JavaScript-suffixed server imports use source fallbacks", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#alias":"/_vf_modules/app/alias-helper.js"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Direct from "app/direct-helper.js"; ' +
+          'import Alias from "#alias"; export default () => <><Direct /><Alias /></>;',
+      },
+      { path: "app/direct-helper.json", content: "{}" },
+      {
+        path: "app/direct-helper.tsx",
+        content: '"use client"; export default function Direct() { return null; }',
+      },
+      { path: "app/alias-helper.json", content: "{}" },
+      {
+        path: "app/alias-helper.tsx",
+        content: '"use client"; export default function Alias() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, [
+      "app/direct-helper.tsx",
+      "app/alias-helper.tsx",
+    ]);
+  });
+
+  it("applies a configured @/ mapping before the default project-root alias", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"@/":"/_vf_modules/src/"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "@/Client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "src/Client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["src/Client.tsx"]);
+  });
+
+  it("resolves import-map aliases targeting a relative _vf_modules path", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#client":"_vf_modules/app/client.tsx"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "#client"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("resolves import-map aliases targeting the project @/ alias", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#client":"@/components/Client.tsx"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "#client"; export default () => <Client />;',
+      },
+      {
+        path: "components/Client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["components/Client.tsx"]);
+  });
+
+  it("preserves the local @/ module when its import-map target is external", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"@/Widget":"https://example.com/external-widget.js"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Widget from "@/Widget"; export default () => <Widget />;',
+      },
+      {
+        path: "Widget.tsx",
+        content: '"use client"; export default function Widget() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["Widget.tsx"]);
+  });
+
+  it("filters project-relative aliases to match the runtime import map", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#client":"./app/client.tsx"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "#client"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertExists(manifest.routes["/ok"]);
+  });
+
+  it("ignores deno.jsonc import aliases like the runtime loader", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.jsonc",
+        content: '{"imports":{"#client":"/_vf_modules/app/client.tsx"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "#client"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertExists(manifest.routes["/ok"]);
+  });
+
+  it("rejects JSONC syntax in deno.json like the runtime loader", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{\n// comment\n"imports":{"#client":"/_vf_modules/app/client.tsx"}\n}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "#client"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertExists(manifest.routes["/ok"]);
+  });
+
+  it("ignores the complete Deno import map when an entry is invalid", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#client":"/_vf_modules/app/client.tsx","#invalid":42}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "#client"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertExists(manifest.routes["/ok"]);
+  });
+
+  it("rejects noncanonical local import-map targets", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#bare":"app/client.tsx","#root":"/app/client.tsx"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Bare from "#bare"; import Root from "#root"; ' +
+          "export default () => <><Bare /><Root /></>;",
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertExists(manifest.routes["/ok"]);
+  });
+
+  it("does not publish an unvendored browser alias outside the script CSP", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#sdk":"https://example.com/sdk.js"}}',
+      },
+      {
+        path: "pages/index.tsx",
+        content: 'import { sdk } from "#sdk"; export default function Page() { return sdk; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assert(rec.uploads.every((upload) => !upload.text.includes("https://example.com/sdk.js")));
+  });
+
+  it("does not publish browser routes whose aliases target server-only packages", async () => {
+    for (
+      const [target, serverExternalPackages] of [
+        ["pg", undefined],
+        ["npm:redis@5", undefined],
+        ["knex", ["knex"]],
+      ] as const
+    ) {
+      const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+      const files = [
+        {
+          path: "deno.json",
+          content: JSON.stringify({ imports: { "#database": target } }),
+        },
+        {
+          path: "pages/index.tsx",
+          content:
+            'import database from "#database"; export default function Page() { return database; }',
+        },
+        { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+      ];
+      const input = baseInput(makeClient(files, rec), (source) => Promise.resolve(source));
+
+      const result = await runReleaseAssetBuild(
+        {
+          ...input,
+          loadConfig: releaseConfigLoader({
+            build: serverExternalPackages
+              ? { serverExternalPackages: [...serverExternalPackages] }
+              : {},
+          }),
+        },
+        await tmp(),
+      );
+
+      assertEquals(result.success, true, result.error);
+      const manifest = parseReleaseAssetManifest(rec.manifest);
+      assertExists(manifest);
+      assertEquals(manifest.routes["/"], undefined, `server-only alias was published: ${target}`);
+      assertExists(manifest.routes["/ok"]);
+    }
+  });
+
+  it("does not publish browser routes whose aliases target external stylesheets", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#theme":"https://example.com/theme.css"}}',
+      },
+      {
+        path: "pages/index.tsx",
+        content: '"use client"; import "#theme"; export default function Page() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assert(rec.uploads.every((upload) => !upload.text.includes("theme.css")));
+  });
+
+  it("vendors an external browser alias in immutable dependency mode", async () => {
+    enableDependencyImportMap();
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#sdk":"https://example.com/sdk.js"}}',
+      },
+      {
+        path: "pages/index.tsx",
+        content: 'import { sdk } from "#sdk"; export default function Page() { return sdk; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    const hash = manifest.modules["pages/index.tsx"]?.contentHash;
+    assertExists(hash);
+    const upload = rec.uploads.find((candidate) => candidate.hash === hash);
+    assertExists(upload);
+    assert(!upload.text.includes("#sdk"));
+    assert(!upload.text.includes("https://example.com/sdk.js"));
+    assertStringIncludes(upload.text, "/_vf/assets/");
+  });
+
+  it("does not publish a protocol-relative browser alias outside the script CSP", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#sdk":"//cdn.example.com/sdk.js"}}',
+      },
+      {
+        path: "pages/index.tsx",
+        content: 'import { sdk } from "#sdk"; export default function Page() { return sdk; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assert(rec.uploads.every((upload) => !upload.text.includes("cdn.example.com/sdk.js")));
+  });
+
+  it("vendors a protocol-relative external browser alias in immutable dependency mode", async () => {
+    enableDependencyImportMap();
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#sdk":"//cdn.example.com/sdk.js"}}',
+      },
+      {
+        path: "pages/index.tsx",
+        content: 'import { sdk } from "#sdk"; export default function Page() { return sdk; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    const hash = manifest.modules["pages/index.tsx"]?.contentHash;
+    assertExists(hash);
+    const upload = rec.uploads.find((candidate) => candidate.hash === hash);
+    assertExists(upload);
+    assert(!upload.text.includes("#sdk"));
+    assert(!upload.text.includes("cdn.example.com/sdk.js"));
+    assertStringIncludes(upload.text, "/_vf/assets/");
+  });
+
+  it("resolves veryfront.config import-map aliases while traversing server modules", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    // No deno.json at all: the alias exists only in veryfront.config.ts under
+    // resolve.importMap.imports, the second supported alias source.
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "#client"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild({
+      ...baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      loadConfig: releaseConfigLoader({
+        resolve: { importMap: { imports: { "#client": "/_vf_modules/app/client.tsx" } } },
+      }),
+    }, await tmp());
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("ignores a malformed optional Deno map while retaining config aliases", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      { path: "deno.json", content: "not valid json{" },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "#client"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild({
+      ...baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      loadConfig: releaseConfigLoader({
+        resolve: { importMap: { imports: { "#client": "/_vf_modules/app/client.tsx" } } },
+      }),
+    }, await tmp());
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("ignores project overrides for framework-owned import-map aliases", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content: JSON.stringify({
+          imports: {
+            react: "./app/missing-react.ts",
+            "veryfront/router": "./app/missing-router.ts",
+          },
+        }),
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import React from "react"; import "veryfront/router"; ' +
+          'import Client from "./client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("lets a veryfront.config alias override the deno.json mapping", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    // Same key in both sources: the config mapping must win, mirroring
+    // loadImportMap's serve-time merge order (deno.json first, config last).
+    const files = [
+      {
+        path: "deno.json",
+        content: '{"imports":{"#client":"/_vf_modules/app/decoy.tsx"}}',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "#client"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      {
+        path: "app/decoy.tsx",
+        content: '"use client"; export default function Decoy() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild({
+      ...baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      loadConfig: releaseConfigLoader({
+        resolve: { importMap: { imports: { "#client": "/_vf_modules/app/client.tsx" } } },
+      }),
+    }, await tmp());
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("resolves directory-index imports from App Router server modules", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "app/client"; export default () => <Client />;',
+      },
+      {
+        path: "app/client/index.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client/index.tsx"]);
+  });
+
+  it("resolves suffixed server imports instead of dropping the route", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    // A query or fragment on a supported specifier is not part of the file
+    // path; before suffix splitting both imports were reported missing and the
+    // only route was dropped, failing the release.
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "./client.tsx#island"; ' +
+          'import { copy } from "@/lib/copy.ts?raw"; ' +
+          "export default () => <Client label={copy} />;",
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      { path: "lib/copy.ts", content: 'export const copy = "text";' },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertExists(manifest.modules["app/client.tsx"]);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("publishes app/ helpers that inherit the client boundary from their importer", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    // The server page reaches shared.ts first, parking it as a server module;
+    // the client component then imports the same helper, which must promote it
+    // back into the browser closure or Counter's import cannot be rewritten.
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import { shared } from "./shared.ts"; import Counter from "./counter.tsx"; ' +
+          "export default () => <Counter label={shared} />;",
+      },
+      { path: "app/shared.ts", content: 'export const shared = "label";' },
+      {
+        path: "app/counter.tsx",
+        content: '"use client"; import { shared } from "./shared.ts"; ' +
+          "export default function Counter() { return shared; }",
+      },
+    ];
+    const client = makeClient(files, rec);
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.modules["app/page.tsx"], undefined);
+    assertExists(manifest.modules["app/counter.tsx"]);
+    assertExists(manifest.modules["app/shared.ts"]);
+    assertEquals(
+      [...(manifest.routes["/"]?.modules ?? [])].sort(),
+      ["app/counter.tsx", "app/shared.ts"],
+    );
+  });
+
+  it("preserves server reachability when a shared module fails client promotion", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import { value } from "../server/shared.ts"; export default () => value;',
+      },
+      {
+        path: "pages/broken.tsx",
+        content: 'import { value } from "../server/shared.ts"; export default () => value;',
+      },
+      {
+        path: "server/shared.ts",
+        content: 'export async function action() { "use server"; return "ok"; } ' +
+          'export const value = "ok";',
+      },
+      { path: "pages/ok.tsx", content: "export default () => null;" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, []);
+    assertEquals(manifest.routes["/broken"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assertEquals(manifest.modules["server/shared.ts"], undefined);
+  });
+
+  it("preserves each server edge when a shared browser module fails finalization", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import { value } from "../server/shared.ts"; export default () => value;',
+      },
+      {
+        path: "pages/broken.tsx",
+        content: 'import { value } from "../server/shared.ts"; export default () => value;',
+      },
+      { path: "server/shared.ts", content: 'export const value = "ok";' },
+      { path: "pages/ok.tsx", content: "export default () => null;" },
+    ];
+    const transform = (source: string, filePath: string) =>
+      Promise.resolve(
+        filePath.endsWith("server/shared.ts")
+          ? 'import "./missing.ts"; export const value = "ok";'
+          : source,
+      );
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), transform),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, []);
+    assertEquals(manifest.routes["/broken"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assertEquals(manifest.modules["server/shared.ts"], undefined);
+  });
+
+  it("drops a Pages Router entry with a module-level use server directive", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "pages/index.tsx",
+        content: '"use server"; export default function Page() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default () => null;" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assertEquals(manifest.modules["pages/index.tsx"], undefined);
+  });
+
+  it("never grants client trust to a use server module imported by a client boundary", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "./client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; import { act } from "./actions.ts"; ' +
+          "export default function Client() { return act; }",
+      },
+      { path: "app/actions.ts", content: '"use server"; export const act = "<SECRET>";' },
+      { path: "pages/ok.tsx", content: "export default () => null;" },
+    ];
+    const client = makeClient(files, rec);
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    // The client boundary cannot resolve its server-action import in the
+    // browser, so its route fails closed instead of publishing the action.
+    assertEquals(result.success, true);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.modules["app/actions.ts"], undefined);
+    assertEquals(manifest.routes["/"], undefined, "route with a server-action import is dropped");
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assert(
+      rec.uploads.every((upload) => !upload.text.includes("<SECRET>")),
+      "use server module content must never be uploaded",
+    );
+  });
+
+  it("never publishes a client module containing a function-local server action", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "./client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; async function save() { "use server"; return "<SECRET>"; } ' +
+          "export default function Client() { return save; }",
+      },
+      { path: "pages/ok.tsx", content: "export default () => null;" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assert(rec.uploads.every((upload) => !upload.text.includes("<SECRET>")));
+  });
+
+  it("never publishes an outside-app client module containing a server action", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "../components/Client.tsx"; ' +
+          "export default () => <Client />;",
+      },
+      {
+        path: "components/Client.tsx",
+        content: '"use client"; async function save() { "use server"; return "<SECRET>"; } ' +
+          "export default function Client() { return save; }",
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.modules["components/Client.tsx"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assert(rec.uploads.every((upload) => !upload.text.includes("<SECRET>")));
+  });
+
+  it("inspects directive-less dependencies inherited by an outside-app client", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "./client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; import { save } from "../components/actions.ts"; ' +
+          "export default function Client() { return save; }",
+      },
+      {
+        path: "components/actions.ts",
+        content: 'export async function save() { "use server"; return "<SECRET>"; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.modules["components/actions.ts"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assert(rec.uploads.every((upload) => !upload.text.includes("<SECRET>")));
+  });
+
+  for (const protectedPath of ["app/api/users/route.ts", "tools/private.ts"] as const) {
+    it(`never publishes protected client dependency ${protectedPath}`, async () => {
+      const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+      const relativeImport = protectedPath.startsWith("app/")
+        ? `./${protectedPath.slice("app/".length)}`
+        : `../${protectedPath}`;
+      const files = [
+        {
+          path: "app/page.tsx",
+          content: 'import Client from "./client.tsx"; export default () => <Client />;',
+        },
+        {
+          path: "app/client.tsx",
+          content: `"use client"; import { secret } from ${JSON.stringify(relativeImport)}; ` +
+            "export default function Client() { return secret; }",
+        },
+        { path: protectedPath, content: 'export const secret = "<SECRET>";' },
+        { path: "pages/ok.tsx", content: "export default () => null;" },
+      ];
+
+      const result = await runReleaseAssetBuild(
+        baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+        await tmp(),
+      );
+
+      assertEquals(result.success, true, result.error);
+      const manifest = parseReleaseAssetManifest(rec.manifest);
+      assertExists(manifest);
+      assertEquals(manifest.routes["/"], undefined);
+      assertEquals(manifest.modules[protectedPath], undefined);
+      assert(rec.uploads.every((upload) => !upload.text.includes("<SECRET>")));
+    });
+  }
+
+  it("drops a server route that imports a protected explicit client boundary", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import { secret } from "./api/users/route.ts"; export default () => secret;',
+      },
+      {
+        path: "app/api/users/route.ts",
+        content: '"use client"; export const secret = "<SECRET>";',
+      },
+      { path: "pages/ok.tsx", content: "export default () => null;" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assertEquals(manifest.modules["app/api/users/route.ts"], undefined);
+    assert(rec.uploads.every((upload) => !upload.text.includes("<SECRET>")));
+  });
+
+  it("queues client boundaries imported through project-root specifiers", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    // Server pages can import client boundaries with the same project-root
+    // specifier forms the browser collector supports; dropping any of them
+    // would publish the route without its hydration JavaScript.
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import A from "app/client-a.tsx"; ' +
+          'import B from "/app/client-b.tsx"; ' +
+          'import C from "/_vf_modules/app/client-c.tsx"; ' +
+          "export default () => <><A /><B /><C /></>;",
+      },
+      {
+        path: "app/client-a.tsx",
+        content: '"use client"; export default function A() { return null; }',
+      },
+      {
+        path: "app/client-b.tsx",
+        content: '"use client"; export default function B() { return null; }',
+      },
+      {
+        path: "app/client-c.tsx",
+        content: '"use client"; export default function C() { return null; }',
+      },
+    ];
+    const client = makeClient(files, rec);
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, `root-form imports must resolve: ${result.error}`);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.modules["app/page.tsx"], undefined);
+    assertExists(manifest.modules["app/client-a.tsx"]);
+    assertExists(manifest.modules["app/client-b.tsx"]);
+    assertExists(manifest.modules["app/client-c.tsx"]);
+    assertEquals(
+      [...(manifest.routes["/"]?.modules ?? [])].sort(),
+      ["app/client-a.tsx", "app/client-b.tsx", "app/client-c.tsx"],
+    );
+  });
+
+  for (const extension of ["js", "ts"] as const) {
+    it(`queues client boundaries required through a .${extension} server helper`, async () => {
+      const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+      const files = [
+        {
+          path: "app/page.tsx",
+          content: `import helper from "./helper.${extension}"; export default () => helper;`,
+        },
+        {
+          path: `app/helper.${extension}`,
+          content: 'module.exports = require("./client.tsx");',
+        },
+        {
+          path: "app/client.tsx",
+          content: '"use client"; export default function Client() { return null; }',
+        },
+      ];
+
+      const result = await runReleaseAssetBuild(
+        baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+        await tmp(),
+      );
+
+      assertEquals(result.success, true, result.error);
+      const manifest = parseReleaseAssetManifest(rec.manifest);
+      assertExists(manifest);
+      assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+      assertEquals(manifest.modules[`app/helper.${extension}`], undefined);
+    });
+  }
+
+  for (
+    const missingSpecifier of [
+      "app/missing.tsx",
+      "/app/missing.tsx",
+      "/_vf_modules/app/missing.tsx",
+    ]
+  ) {
+    it(`drops a server route with missing project-root import ${missingSpecifier}`, async () => {
+      const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+      const client = makeClient([
+        {
+          path: "app/page.tsx",
+          content: `import Missing from ${JSON.stringify(missingSpecifier)}; ` +
+            "export default () => <Missing />;",
+        },
+        { path: "pages/ok.tsx", content: "export default () => null;" },
+      ], rec);
+
+      const result = await runReleaseAssetBuild(
+        baseInput(client, (source) => Promise.resolve(source)),
+        await tmp(),
+      );
+
+      assertEquals(result.success, true);
+      const manifest = parseReleaseAssetManifest(rec.manifest);
+      assertExists(manifest);
+      assertEquals(manifest.routes["/"], undefined);
+      assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    });
+  }
+
+  it("counts a missing ESM and CommonJS server specifier once", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import "app/missing.ts"; require("app/missing.ts"); ' +
+          "export default () => null;",
+      },
+      { path: "pages/ok.tsx", content: "export default () => null;" },
+    ];
+    const records: Array<{ message: string; context?: Record<string, unknown> }> = [];
+    const unsubscribe = __subscribeLogRecordEmitter((entry) => {
+      if (entry.component === "release-asset-build") records.push(entry);
+    });
+    let result: ReleaseAssetBuildResult;
+    try {
+      result = await runReleaseAssetBuild(
+        baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+        await tmp(),
+      );
+    } finally {
+      unsubscribe();
+    }
+
+    assertEquals(result.success, true, result.error);
+    const failure = records.find((entry) =>
+      entry.message === "Server module import parse failed during release asset build" &&
+      entry.context?.path === "app/page.tsx"
+    );
+    assertStringIncludes(String(failure?.context?.error), "1 unresolved project import(s)");
+  });
+
+  it("drops a server route with a computed dynamic import", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const client = makeClient([
+      {
+        path: "app/page.tsx",
+        content: 'const target = "./client.tsx"; ' +
+          "export default async function Page() { await import(target); return null; }",
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default () => null;" },
+    ], rec);
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+  });
+
+  it("applies the server boundary to modules outside the app directory", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    // Modules reached through a server-module edge are server code wherever
+    // they live: an explicit "use server" action and a plain helper outside
+    // the app root must both stay off the release.
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import { act } from "../server/actions.ts"; ' +
+          'import { data } from "../server/data.ts"; ' +
+          'import Client from "./client.tsx"; ' +
+          "export default () => <Client act={act} data={data} />;",
+      },
+      { path: "server/actions.ts", content: '"use server"; export const act = "<SECRET>";' },
+      { path: "server/data.ts", content: 'export const data = "<REDACTED>";' },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+    const client = makeClient(files, rec);
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, `server imports must stay server-side: ${result.error}`);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.modules["server/actions.ts"], undefined);
+    assertEquals(manifest.modules["server/data.ts"], undefined);
+    assertExists(manifest.modules["app/client.tsx"]);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+    assert(
+      rec.uploads.every(
+        (upload) => !upload.text.includes("<SECRET>") && !upload.text.includes("<REDACTED>"),
+      ),
+      "server module content must never be uploaded",
+    );
+  });
+
+  it("preserves the server boundary inside configured browser seed directories", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      { path: "src/server/data.ts", content: 'export const data = "<REDACTED>";' },
+      {
+        path: "src/app/page.tsx",
+        content: 'import { data } from "../server/data.ts"; ' +
+          'import Client from "./client.tsx"; ' +
+          "export default () => <Client data={data} />;",
+      },
+      {
+        path: "src/app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+    const client = makeClient(files, rec);
+
+    const result = await runReleaseAssetBuild({
+      ...baseInput(client, (source) => Promise.resolve(source)),
+      loadConfig: releaseConfigLoader({
+        directories: { app: "src/app", pages: "src/pages" },
+      }),
+    }, await tmp());
+
+    assertEquals(result.success, true);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.modules["src/server/data.ts"], undefined);
+    assertExists(manifest.modules["src/app/client.tsx"]);
+    assertEquals(manifest.routes["/"]?.modules, ["src/app/client.tsx"]);
+    assert(
+      rec.uploads.every((upload) => !upload.text.includes("<REDACTED>")),
+      "a server-only src dependency must never be uploaded",
+    );
+  });
+
+  it("never publishes an outside-app use server module imported by a client boundary", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "./client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; import { act } from "../server/actions.ts"; ' +
+          "export default function Client() { return act; }",
+      },
+      { path: "server/actions.ts", content: '"use server"; export const act = "<SECRET>";' },
+      { path: "pages/ok.tsx", content: "export default () => null;" },
+    ];
+    const client = makeClient(files, rec);
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    // Same fail-closed behavior as an in-app server action: the route that
+    // needs the action in the browser is dropped rather than published with
+    // server source.
+    assertEquals(result.success, true);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.modules["server/actions.ts"], undefined);
+    assertEquals(manifest.routes["/"], undefined, "route with a server-action import is dropped");
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assert(
+      rec.uploads.every((upload) => !upload.text.includes("<SECRET>")),
+      "use server module content must never be uploaded",
+    );
+  });
+
+  it("does not publish targets of type-only imports from server pages", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import type { Model } from "../server/models.ts"; ' +
+          'import Client from "./client.tsx"; ' +
+          "export default () => <Client model={null as unknown as Model} />;",
+      },
+      { path: "server/models.ts", content: "export type Model = { secret: string };" },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+    const client = makeClient(files, rec);
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertEquals(rec.uploads.length > 0, true);
+    assertExists(manifest);
+    assertEquals(manifest.modules["server/models.ts"], undefined);
+    assertExists(manifest.modules["app/client.tsx"]);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+  });
+
+  it("keeps CSS imports out of the server module closure", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      { path: "app/globals.css", content: "body { margin: 0; }" },
+      {
+        path: "app/layout.tsx",
+        content: 'import "./globals.css"; export default ({ children }) => children;',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "./client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+    let seenStylesheet: string | undefined;
+    const client = makeClient(files, rec, {
+      compileProjectCss: (_candidates, stylesheet) => {
+        seenStylesheet = stylesheet;
+        return Promise.resolve(compiledCss("body{margin:0}"));
+      },
+    });
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    // The stylesheet edge must not become a closure gap for the route; it is
+    // merged into the release CSS instead.
+    assertEquals(result.success, true);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"]?.modules, ["app/client.tsx"]);
+    assertExists(seenStylesheet);
+    assert(seenStylesheet!.includes("margin: 0"), "layout CSS merged into release stylesheet");
+  });
+
+  it("merges CSS re-exported by a server module", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      { path: "app/globals.css", content: "body { margin: 0; }" },
+      { path: "app/Button.module.css", content: ".button { color: red; }" },
+      {
+        path: "app/layout.tsx",
+        content: 'export * from "./globals.css";\n' +
+          'export { default as styles } from "./Button.module.css";\n' +
+          "export default ({ children }) => children;",
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "./client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+    ];
+    let seenStylesheet: string | undefined;
+    const client = makeClient(files, rec, {
+      compileProjectCss: (_candidates, stylesheet) => {
+        seenStylesheet = stylesheet;
+        return Promise.resolve(compiledCss("body{margin:0}"));
+      },
+    });
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    assertExists(seenStylesheet);
+    assertStringIncludes(seenStylesheet, "margin: 0");
+    assertStringIncludes(seenStylesheet, "color: red");
+  });
+
+  it("ignores CSS import and re-export text in comments and strings", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      { path: "globals.css", content: ":root { --brand: blue; }" },
+      { path: "app/legacy.css", content: ".legacy { color: red; }" },
+      { path: "app/quoted.css", content: ".quoted { color: purple; }" },
+      {
+        path: "app/layout.tsx",
+        content: '// import "./legacy.css";\n' +
+          '// export * from "./legacy.css";\n' +
+          "const imported = 'import \"./quoted.css\"';\n" +
+          "const exported = 'export * from \"./quoted.css\"';\n" +
+          "export default ({ children }) => <main>{children}</main>;",
+      },
+      { path: "pages/index.tsx", content: "export default () => null;" },
+    ];
+    let seenStylesheet: string | undefined;
+    const client = makeClient(files, rec, {
+      compileProjectCss: (_candidates, stylesheet) => {
+        seenStylesheet = stylesheet;
+        return Promise.resolve(compiledCss(":root{--brand:blue}"));
+      },
+    });
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    assertExists(seenStylesheet);
+    assertStringIncludes(seenStylesheet, "--brand: blue");
+    assertEquals(seenStylesheet.includes(".legacy"), false);
+    assertEquals(seenStylesheet.includes(".quoted"), false);
+  });
+
+  it("ignores CSS referenced only by type-only declarations", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      { path: "globals.css", content: ":root { --brand: blue; }" },
+      { path: "app/import-type.css", content: ".import-type { color: red; }" },
+      { path: "app/export-type.css", content: ".export-type { color: purple; }" },
+      { path: "app/inline-type.css", content: ".inline-type { color: orange; }" },
+      {
+        path: "app/layout.tsx",
+        content: 'import type Styles from "./import-type.css";\n' +
+          'export type { Classes } from "./export-type.css";\n' +
+          'import { type Tokens } from "./inline-type.css";\n' +
+          "export default ({ children }) => <main>{children}</main>;",
+      },
+      { path: "pages/index.tsx", content: "export default () => null;" },
+    ];
+    let seenStylesheet: string | undefined;
+    const client = makeClient(files, rec, {
+      compileProjectCss: (_candidates, stylesheet) => {
+        seenStylesheet = stylesheet;
+        return Promise.resolve(compiledCss(":root{--brand:blue}"));
+      },
+    });
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    assertExists(seenStylesheet);
+    assertStringIncludes(seenStylesheet, "--brand: blue");
+    assertEquals(seenStylesheet.includes(".import-type"), false);
+    assertEquals(seenStylesheet.includes(".export-type"), false);
+    assertEquals(seenStylesheet.includes(".inline-type"), false);
+  });
+
+  it("merges a CSS import whose default binding is named type", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      { path: "app/theme.css", content: ".theme { color: green; }" },
+      {
+        path: "app/layout.tsx",
+        content: 'import type from "./theme.css"; export default () => type;',
+      },
+      { path: "pages/index.tsx", content: "export default () => null;" },
+    ];
+    let seenStylesheet: string | undefined;
+    const client = makeClient(files, rec, {
+      compileProjectCss: (_candidates, stylesheet) => {
+        seenStylesheet = stylesheet;
+        return Promise.resolve(compiledCss(".theme{color:green}"));
+      },
+    });
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    assertExists(seenStylesheet);
+    assertStringIncludes(seenStylesheet, ".theme { color: green; }");
+  });
+
+  it("finds CSS after the static import match budget in generated source", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const ordinaryImports = Array.from(
+      // Match the build executor's release-file/scanner bound. Before the
+      // matcher became CSS-specific, these unrelated edges consumed it all.
+      { length: 50_000 },
+      () => 'import"pkg";',
+    ).join("");
+    const files = [
+      { path: "styles/late.css", content: ".late { color: blue; }" },
+      {
+        path: "tools/generated.ts",
+        content: `${ordinaryImports}import styles from "../styles/late.css";`,
+      },
+      { path: "pages/index.tsx", content: "export default () => null;" },
+    ];
+    let seenStylesheet: string | undefined;
+    const client = makeClient(files, rec, {
+      compileProjectCss: (_candidates, stylesheet) => {
+        seenStylesheet = stylesheet;
+        return Promise.resolve(compiledCss(".late{color:blue}"));
+      },
+    });
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    assertExists(seenStylesheet);
+    assertStringIncludes(seenStylesheet, ".late { color: blue; }");
+  });
+
+  it("merges a CSS alias but drops the server route that still executes it", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "deno.json",
+        content:
+          '{"imports":{"#theme":"/_vf_modules/styles/theme.css","theme":"/_vf_modules/styles/bare.css","theme/":"/_vf_modules/styles/"}}',
+      },
+      { path: "styles/theme.css", content: ":root { --theme-color: blue; }" },
+      { path: "styles/bare.css", content: ".bare { color: green; }" },
+      { path: "styles/prefix.css", content: ".prefix { color: purple; }" },
+      {
+        path: "app/layout.tsx",
+        content:
+          'import "#theme"; import "theme"; import "theme/prefix.css"; export default ({ children }) => children;',
+      },
+      {
+        path: "app/page.tsx",
+        content: 'import Client from "./client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+    let seenStylesheet: string | undefined;
+    const client = makeClient(files, rec, {
+      compileProjectCss: (_candidates, stylesheet) => {
+        seenStylesheet = stylesheet;
+        return Promise.resolve(compiledCss(":root{--theme-color:blue}"));
+      },
+    });
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assertExists(seenStylesheet);
+    assertStringIncludes(seenStylesheet, "--theme-color: blue");
+    assertStringIncludes(seenStylesheet, ".bare { color: green; }");
+    assertStringIncludes(seenStylesheet, ".prefix { color: purple; }");
+  });
+
+  it("merges CSS imported by an mjs server helper", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const extensions = ["mjs"];
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: extensions.map((ext) => `import "./helper.${ext}";`).join("\n") +
+          '\nimport Client from "./client.tsx"; export default () => <Client />;',
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      ...extensions.flatMap((ext) => [
+        {
+          path: `app/helper.${ext}`,
+          content: `import "./helper-${ext}.css"; export const value = "${ext}";`,
+        },
+        { path: `app/helper-${ext}.css`, content: `.${ext} { --format: ${ext}; }` },
+      ]),
+    ];
+    let seenStylesheet: string | undefined;
+    const client = makeClient(files, rec, {
+      compileProjectCss: (_candidates, stylesheet) => {
+        seenStylesheet = stylesheet;
+        return Promise.resolve(compiledCss("/* server formats */"));
+      },
+    });
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    assertExists(seenStylesheet);
+    for (const ext of extensions) {
+      assert(
+        seenStylesheet!.includes(`.${ext} { --format: ${ext}; }`),
+        `CSS imported by .${ext} must be merged`,
+      );
+    }
+  });
+
+  it("collects imports from server MDX pages by compiling the MDX first", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.mdx",
+        content: "import Widget from './widget.tsx'\n\n# Hello\n\n" +
+          "It's prose, not JavaScript, and the lexer must never see it raw.\n\n<Widget />\n",
+      },
+      {
+        path: "app/widget.tsx",
+        content: '"use client"; export default function Widget() { return null; }',
+      },
+    ];
+    const client = makeClient(files, rec);
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.modules["app/page.mdx"], undefined);
+    assertExists(manifest.modules["app/widget.tsx"]);
+    assertEquals(manifest.routes["/"]?.modules, ["app/widget.tsx"]);
+  });
+
+  it("drops only the affected route when a server page cannot be analyzed", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      // Unclosed JSX makes the MDX compile throw, so this server page's
+      // imports cannot be discovered. That must cost this page its route, not
+      // the release.
+      { path: "app/broken/page.mdx", content: "# Broken\n\n<Unclosed\n" },
+      { path: "pages/ok.tsx", content: "export default () => null;" },
+    ];
+    const client = makeClient(files, rec);
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, `healthy routes must publish: ${result.error}`);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/broken"], undefined, "unanalyzable route is dropped");
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+  });
+
+  it("drops a server route with an unresolved local import", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/broken/page.tsx",
+        content: 'import "./missing.ts"; export default function Page() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default () => null;" },
+    ];
+    const client = makeClient(files, rec);
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/broken"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+  });
+
+  it("drops a server route with a case-insensitive local file URL", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      {
+        path: "app/page.tsx",
+        content: 'import "FILE:///tmp/secret.mjs"; export default function Page() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertExists(manifest.routes["/ok"]);
+  });
+
+  it("drops App Router routes that import static assets as modules", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      { path: "app/logo.png", content: "png-bytes" },
+      { path: "app/icon.svg", content: "<svg></svg>" },
+      { path: "app/fonts/brand.woff2", content: "font-bytes" },
+      {
+        path: "app/page.tsx",
+        content: 'import logo from "./logo.png";\n' +
+          'import "./icon.svg";\n' +
+          'import "./fonts/brand.woff2";\n' +
+          'import Client from "./client.tsx";\n' +
+          "export default () => <Client src={logo} />;",
+      },
+      {
+        path: "app/client.tsx",
+        content: '"use client"; export default function Client() { return null; }',
+      },
+      {
+        path: "app/commonjs/page.tsx",
+        content: 'require("../logo.png"); export default function Page() { return null; }',
+      },
+      { path: "pages/ok.tsx", content: "export default function Ok() { return null; }" },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(manifest.routes["/"], undefined);
+    assertEquals(manifest.routes["/commonjs"], undefined);
+    assertEquals(manifest.routes["/ok"]?.modules, ["pages/ok.tsx"]);
+    assertEquals(manifest.modules["app/logo.png"], undefined);
+    assertEquals(manifest.modules["app/icon.svg"], undefined);
+    assertEquals(manifest.modules["app/fonts/brand.woff2"], undefined);
   });
 
   it("rejects release file paths outside the materialization directory", async () => {
@@ -640,10 +3666,10 @@ describe("release asset build executor", () => {
     // module the admission boundary refuses.
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const client = makeClient([
-      { path: "app/page.tsx", content: "export default () => null;" },
+      { path: "app/page.tsx", content: '"use client"; export default () => null;' },
       {
         path: "app/layout.tsx",
-        content: "export default function Layout({ children }) { return children; }",
+        content: '"use client"; export default function Layout({ children }) { return children; }',
       },
       { path: "pages/ok.tsx", content: "export default () => null;" },
     ], rec);
@@ -2097,7 +5123,7 @@ export default { tailwind: { stylesheet: "src/styles/imported.css" } };`,
       },
       {
         path: "pages/index.tsx",
-        content: 'export default () => "<div class="p-4"/>";',
+        content: 'export default () => "<div class=\\"p-4\\"/>";',
       },
     ];
     let seenStylesheet: string | undefined;
@@ -2357,7 +5383,7 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
     const files = [
       { path: "globals.css", content: ":root { --brand: blue; } /* fallback */" },
-      { path: "pages/index.tsx", content: 'export default () => "<div class="p-4"/>";' },
+      { path: "pages/index.tsx", content: 'export default () => "<div class=\\"p-4\\"/>";' },
     ];
     let seenStylesheet: string | undefined;
     const seenReactVersions: Array<string | undefined> = [];
@@ -2419,6 +5445,61 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
       seenStylesheet!.includes(".calc"),
       "CSS imported from app/layout.tsx must be merged into the stylesheet",
     );
+  });
+
+  it("rejects a CSS import scan that would omit a later live stylesheet", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const externalImports = Array.from(
+      { length: 50_000 },
+      () => 'import {} from "x.css";',
+    ).join("\n");
+    const files = [
+      { path: "app/live.css", content: ".live { color: green; }" },
+      {
+        path: "app/layout.tsx",
+        content:
+          `${externalImports}\nimport {} from "./live.css";\nexport default ({ children }) => children;`,
+      },
+    ];
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), () => Promise.resolve("export default null;")),
+      await tmp(),
+    );
+
+    assertEquals(result.success, false);
+    assertStringIncludes(
+      result.error ?? "",
+      "Release CSS import scan exceeds 50000 matches",
+    );
+  });
+
+  it("merges module CSS imported with a query or fragment suffix", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [
+      { path: "app/styles.css", content: ".suffixed { color: rebeccapurple; }" },
+      {
+        path: "app/layout.tsx",
+        content: 'import "./styles.css#release"; export default ({ children }) => children;',
+      },
+      { path: "pages/index.tsx", content: "export default () => null;" },
+    ];
+    let seenStylesheet: string | undefined;
+    const client = makeClient(files, rec, {
+      compileProjectCss: (_candidates, stylesheet) => {
+        seenStylesheet = stylesheet;
+        return Promise.resolve(compiledCss(".suffixed{color:rebeccapurple}"));
+      },
+    });
+
+    const result = await runReleaseAssetBuild(
+      baseInput(client, (source) => Promise.resolve(source)),
+      await tmp(),
+    );
+
+    assertEquals(result.success, true, result.error);
+    assertExists(seenStylesheet);
+    assertStringIncludes(seenStylesheet, ".suffixed { color: rebeccapurple; }");
   });
 
   it("merges module CSS from sources containing real JSX", async () => {
@@ -2722,11 +5803,11 @@ export default defineConfig({ react: { version: "19.2.1" } });`,
       },
       {
         path: "src\\site\\layout.tsx",
-        content: "export default function Layout({ children }) { return children; }",
+        content: '"use client"; export default function Layout({ children }) { return children; }',
       },
       {
         path: "src\\site\\page.tsx",
-        content: "export default function Home() { return null; }",
+        content: '"use client"; export default function Home() { return null; }',
       },
       {
         path: "src\\pages\\about.tsx",

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -24,13 +24,16 @@ import {
 } from "#veryfront/utils/css-artifact-identity.ts";
 import { VERSION } from "#veryfront/utils/version.ts";
 import { createFileSystem, isNotFoundError, realPath } from "#veryfront/platform/compat/fs.ts";
+import { getOsType } from "#veryfront/platform/compat/process.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { STAT_OPERATION_EXTENSION_PRIORITY } from "#veryfront/platform/adapters/fs/veryfront/extension-priority.ts";
 import {
   dirname,
   fromFileUrl,
   isAbsolute,
   join,
   normalize,
+  relative,
   toFileUrl,
 } from "#veryfront/compat/path/index.ts";
 import {
@@ -41,9 +44,27 @@ import {
 } from "#veryfront/platform/compat/framework-source-resolver.ts";
 import { PUBLISHED_RUNTIME_HELPERS } from "#veryfront/platform/compat/published-runtime-helpers.ts";
 import { getFrameworkRoot } from "#veryfront/platform/compat/vfs-paths.ts";
-import { normalizeHttpUrl } from "#veryfront/transforms/esm/http-cache-helpers.ts";
+import {
+  normalizeHttpUrl,
+  resolveBareSpecifier,
+} from "#veryfront/transforms/esm/http-cache-helpers.ts";
 import { extractSourceUrl } from "#veryfront/transforms/esm/source-url-embed.ts";
 import { parseImports, replaceSpecifiers } from "#veryfront/transforms/esm/lexer.ts";
+import { parseLocalImports } from "#veryfront/transforms/esm/import-parser.ts";
+import {
+  findDynamicImportSpans,
+  findStaticImportFromSpans,
+  findStaticSideEffectImportSpans,
+} from "#veryfront/transforms/mdx/esm-module-loader/utils/source-spans.ts";
+import {
+  parseEsmShSpecifier,
+  resolveEsmShThroughImportMap,
+} from "#veryfront/transforms/shared/esm-sh-import-map.ts";
+import { isRuntimeImportMapSpecifier } from "#veryfront/transforms/import-rewriter/strategies/import-map-strategy.ts";
+import { isEsmShUrl } from "#veryfront/transforms/import-rewriter/url-builder.ts";
+import { tryResolve } from "#veryfront/extensions/contracts.ts";
+import type { CodeParser } from "#veryfront/extensions/parser/code-parser.ts";
+import { ensureDefaultParserContracts } from "#veryfront/extensions/parser/defaults.ts";
 import {
   createDependencyPinningSource,
   type DependencyPinningSnapshot,
@@ -54,11 +75,14 @@ import {
 import { getReactUrls } from "#veryfront/transforms/esm/react-cdn.ts";
 import { PLATFORM_UTILITIES } from "#veryfront/html/utils.ts";
 import { extractCandidatesFromFiles } from "#veryfront/html/styles-builder/candidate-extractor.ts";
+import {
+  hasUseClientDirective,
+  hasUseServerDirective,
+} from "#veryfront/rendering/rsc/page-island.ts";
 import { FRAMEWORK_CANDIDATES } from "#veryfront/server/handlers/dev/framework-candidates.generated.ts";
 import { validateLexicalPath } from "#veryfront/security/path-validation.ts";
 import {
   CSS_IMPORTING_SOURCE_EXTENSIONS,
-  extractCssImportSpecifiers,
   resolveCssImportPath,
 } from "#veryfront/html/styles-builder/css-import-extraction.ts";
 import { rewriteCssModuleContent } from "#veryfront/transforms/css-modules/naming.ts";
@@ -92,11 +116,38 @@ import {
 import type { CompileProjectCssResult } from "./css-compile.ts";
 import { materializeReleaseDependencyGraph } from "./dependency-artifact-graph.ts";
 import { compareStrings } from "#veryfront/utils/compare.ts";
+import { mergeImportMaps } from "#veryfront/modules/import-map/index.ts";
+import {
+  isFrameworkOwnedImportMapSpecifier,
+  normalizeImportMapForRuntime,
+} from "#veryfront/modules/import-map/loader.ts";
+import { classifyBrowserModuleSourcePath } from "#veryfront/modules/server/browser-module-admission.ts";
+import {
+  describeBrowserModuleBoundaryViolation,
+  inspectBrowserModuleBoundary,
+} from "#veryfront/server/shared/browser-module-boundary.ts";
+import { isRSCEnabled } from "#veryfront/utils/feature-flags.ts";
+import { splitSpecifierSuffix } from "#veryfront/transforms/shared/specifier-suffix.ts";
+import { snapshotImportMap } from "#veryfront/transforms/pipeline/cache-identity.ts";
+import { parseBarePackageSpecifier } from "#veryfront/transforms/shared/package-specifier.ts";
+import { isServerOnlyPackage } from "#veryfront/transforms/shared/server-only-packages.ts";
+import { PLATFORM_SCRIPT_ORIGINS } from "#veryfront/security/http/platform-asset-origins.ts";
 
 const logger = serverLogger.component("release-asset-build");
 
 /** Browser module source extensions eligible for transform. */
 const BROWSER_MODULE_EXTENSIONS = [".tsx", ".ts", ".jsx", ".js", ".mdx"];
+/** Runtime-loadable extensions eligible for server-only import traversal. */
+const SERVER_MODULE_EXTENSIONS = [
+  ".json",
+  ".tsx",
+  ".ts",
+  ".jsx",
+  ".js",
+  ".mjs",
+  ".mdx",
+  ".md",
+];
 /** Directories used as browser graph entry seeds. Imports may reach any project directory. */
 const BROWSER_MODULE_DIRS = ["components/", "layouts/", "lib/", "src/"];
 const PROJECT_IMPORT_ROOTS = ["app/", "pages/", ...BROWSER_MODULE_DIRS];
@@ -499,6 +550,12 @@ function isTransformableBrowserModule(path: string): boolean {
   return true;
 }
 
+/** True when authored source can be traversed without publishing it to the browser. */
+function isTraversableServerModule(path: string): boolean {
+  if (!SERVER_MODULE_EXTENSIONS.some((ext) => path.endsWith(ext))) return false;
+  return !/\.d\.(?:ts|mts|cts)$/.test(path);
+}
+
 /** True when a logical path should seed the browser module graph. */
 function isBrowserModule(path: string, directories: ReleaseRouterDirectories): boolean {
   if (!isTransformableBrowserModule(path)) return false;
@@ -515,6 +572,31 @@ function isConfiguredAppRouterLayout(path: string, directories: ReleaseRouterDir
   const fileName = segments.pop();
   if (!fileName || !/^layout\.(tsx|ts|jsx|mdx|js)$/.test(fileName)) return false;
   return !segments.some((segment) => segment.startsWith("@") || segment.startsWith("_"));
+}
+
+function isConfiguredAppRouterModule(
+  path: string,
+  directories: ReleaseRouterDirectories,
+): boolean {
+  return configuredRoutePath(path, directories, "app")?.startsWith("app/") ?? false;
+}
+
+function isConfiguredAppRouterBrowserEntry(
+  path: string,
+  directories: ReleaseRouterDirectories,
+): boolean {
+  return isConfiguredAppRouterLayout(path, directories) ||
+    (routeForConfiguredPage(path, directories) !== null &&
+      isConfiguredAppRouterModule(path, directories));
+}
+
+function isTrustedAppRouterBrowserModule(source: string, path: string): boolean {
+  return hasUseClientDirective(source, path) && !hasUseServerDirective(source);
+}
+
+async function inspectReleaseBrowserModuleBoundary(source: string, sourceFile: string) {
+  await ensureDefaultParserContracts();
+  return await inspectBrowserModuleBoundary(source, sourceFile);
 }
 
 function collectConfiguredAppRouterLayoutsForPage(
@@ -550,7 +632,11 @@ function releaseRouterDirectories(config: VeryfrontConfig): ReleaseRouterDirecto
   };
 }
 
-function resolveKnownModulePath(path: string, knownPaths: Set<string>): string | null {
+function resolveKnownModulePathWithExtensions(
+  path: string,
+  knownPaths: Set<string>,
+  extensions: readonly string[],
+): string | null {
   const normalized = normalizeLogicalPath(
     path
       .replace(/^\/?_vf_modules\//, "")
@@ -562,13 +648,42 @@ function resolveKnownModulePath(path: string, knownPaths: Set<string>): string |
   if (normalized.startsWith("_veryfront/")) return null;
   if (knownPaths.has(normalized)) return normalized;
 
-  const withoutExt = normalized.replace(/\.(tsx|ts|jsx|mdx|js)$/, "");
-  for (const ext of BROWSER_MODULE_EXTENSIONS) {
+  const existingExtension = extensions.find((ext) => normalized.endsWith(ext));
+  const withoutExt = existingExtension
+    ? normalized.slice(0, -existingExtension.length)
+    : normalized;
+  const fallbackExtensions = existingExtension !== undefined && existingExtension !== ".json"
+    ? extensions.filter((ext) => ext !== ".json")
+    : extensions;
+  for (const ext of fallbackExtensions) {
     const candidate = `${withoutExt}${ext}`;
+    if (knownPaths.has(candidate)) return candidate;
+  }
+  for (const ext of fallbackExtensions) {
+    const candidate = `${withoutExt}/index${ext}`;
     if (knownPaths.has(candidate)) return candidate;
   }
 
   return null;
+}
+
+function resolveKnownModulePath(path: string, knownPaths: Set<string>): string | null {
+  return resolveKnownModulePathWithExtensions(path, knownPaths, BROWSER_MODULE_EXTENSIONS);
+}
+
+function resolveKnownServerModulePath(path: string, knownPaths: Set<string>): string | null {
+  const resolved = resolveKnownModulePathWithExtensions(path, knownPaths, SERVER_MODULE_EXTENSIONS);
+  return resolved && isTraversableServerModule(resolved) ? resolved : null;
+}
+
+function resolveKnownStylesheetPath(path: string, knownPaths: Set<string>): string | null {
+  const resolved = resolveKnownModulePathWithExtensions(path, knownPaths, [".css"]);
+  return resolved?.endsWith(".css") ? resolved : null;
+}
+
+function resolveKnownServerDependencyPath(path: string, knownPaths: Set<string>): string | null {
+  return resolveKnownServerModulePath(path, knownPaths) ??
+    resolveKnownStylesheetPath(path, knownPaths);
 }
 
 function normalizeLogicalPath(path: string): string | null {
@@ -588,10 +703,8 @@ function normalizeLogicalPath(path: string): string | null {
 
 function normalizeProjectSpecifier(specifier: string, logicalPath: string): string | null {
   if (
-    specifier.startsWith("http://") ||
-    specifier.startsWith("https://") ||
-    specifier.startsWith("data:") ||
-    specifier.startsWith("blob:") ||
+    specifier.startsWith("//") ||
+    /^[A-Za-z][A-Za-z0-9+.-]*:/.test(specifier) ||
     specifier.startsWith("#")
   ) {
     return null;
@@ -616,6 +729,61 @@ function normalizeProjectSpecifier(specifier: string, logicalPath: string): stri
   return null;
 }
 
+function isJsonDataUrlSpecifier(specifier: string): boolean {
+  if (!specifier.toLowerCase().startsWith("data:")) return false;
+  const metadataEnd = specifier.indexOf(",");
+  if (metadataEnd < 0) return false;
+  const mediaType = specifier.slice("data:".length, metadataEnd)
+    .split(";", 1)[0]
+    ?.trim()
+    .toLowerCase();
+  return mediaType === "application/json" || mediaType === "text/json" ||
+    mediaType?.endsWith("+json") === true;
+}
+
+function isExternalCssSpecifier(specifier: string): boolean {
+  const dataMetadataEnd = specifier.indexOf(",");
+  if (specifier.toLowerCase().startsWith("data:") && dataMetadataEnd >= 0) {
+    const mediaType = specifier.slice("data:".length, dataMetadataEnd)
+      .split(";", 1)[0]
+      ?.trim()
+      .toLowerCase();
+    if (mediaType === "text/css") return true;
+  }
+  return splitSpecifierSuffix(specifier).path.toLowerCase().endsWith(".css");
+}
+
+function mayResolveProjectStylesheetSpecifier(
+  specifier: string,
+  aliases: ReadonlyMap<string, string>,
+): boolean {
+  if (isEsmShUrl(specifier) || aliases.has(specifier)) return true;
+  if (
+    (specifier.endsWith(".js") || specifier.endsWith(".mjs") || specifier.endsWith(".cjs")) &&
+    aliases.has(specifier.replace(/\.(m|c)?js$/, ""))
+  ) return true;
+  for (
+    let separator = specifier.indexOf("/");
+    separator >= 0;
+    separator = specifier.indexOf("/", separator + 1)
+  ) {
+    if (aliases.has(specifier.slice(0, separator + 1))) return true;
+  }
+  return false;
+}
+
+function isExternalJsonSpecifier(specifier: string): boolean {
+  const bareCandidate = specifier.startsWith("npm:") ? specifier.slice(4) : specifier;
+  if (
+    !bareCandidate.startsWith(".") && !bareCandidate.startsWith("/") &&
+    !bareCandidate.startsWith("#") &&
+    !/^[A-Za-z][A-Za-z0-9+.-]*:/.test(bareCandidate) &&
+    parseBarePackageSpecifier(bareCandidate) !== null
+  ) return false;
+  return isJsonDataUrlSpecifier(specifier) ||
+    splitSpecifierSuffix(specifier).path.toLowerCase().endsWith(".json");
+}
+
 function resolveProjectModuleSpecifier(
   specifier: string,
   logicalPath: string,
@@ -630,6 +798,7 @@ async function collectProjectModuleImports(
   code: string,
   logicalPath: string,
   knownPaths: Set<string>,
+  projectImportAliases: ReadonlyMap<string, string>,
 ): Promise<Map<string, string>> {
   const imports = new Map<string, string>();
 
@@ -637,6 +806,16 @@ async function collectProjectModuleImports(
     if (!imp.n) continue;
 
     const specifier = imp.n;
+    const aliasResolution = resolveProjectImportAlias(
+      specifier,
+      projectImportAliases,
+      knownPaths,
+      resolveKnownModulePath,
+    );
+    if (aliasResolution.matched) {
+      if (aliasResolution.path) imports.set(specifier, aliasResolution.path);
+      continue;
+    }
     const importedPath = resolveProjectModuleSpecifier(specifier, logicalPath, knownPaths);
     if (importedPath) imports.set(specifier, importedPath);
   }
@@ -644,14 +823,541 @@ async function collectProjectModuleImports(
   return imports;
 }
 
+async function importsExternalStylesheetAlias(
+  code: string,
+  projectImportAliases: ReadonlyMap<string, string>,
+  knownPaths: Set<string>,
+): Promise<boolean> {
+  for (const imp of await parseImports(code)) {
+    if (!imp.n) continue;
+    const resolution = resolveProjectImportAlias(
+      imp.n,
+      projectImportAliases,
+      knownPaths,
+      resolveKnownModulePath,
+    );
+    if (
+      resolution.external !== undefined && isExternalCssSpecifier(resolution.external)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function releaseLogicalPathFromMaterializedPath(
+  basePath: string,
+  tempDir: string,
+  hostOs = getOsType(),
+): string {
+  const normalizeHostPath = hostOs === "windows"
+    ? (path: string) => path.replaceAll("\\", "/")
+    : (path: string) => path;
+  const materializedRoot = normalizeHostPath(tempDir).replace(/^\/+|\/+$/g, "");
+  const normalizedPath = normalizeHostPath(basePath).replace(/^\/+/, "");
+  return normalizedPath.startsWith(`${materializedRoot}/`)
+    ? normalizedPath.slice(materializedRoot.length + 1)
+    : normalizedPath;
+}
+
+/** @internal Test seams for portable release materialization rules. */
+export const releaseAssetBuildInternals = Object.freeze({
+  releaseLogicalPathFromMaterializedPath,
+});
+
+/**
+ * Import edges of an App Router server module, read from its authored source.
+ *
+ * Server modules are never transformed for the browser, so their imports
+ * cannot be read from transformed output the way the rest of the closure is.
+ * Raw source needs the preprocessing the dev-time dependency parser applies
+ * (parseLocalImports): MDX is compiled to JavaScript first, because prose is
+ * not lexable ESM, and the TypeScript pass drops type-only edges so an
+ * `import type` target never gains browser reachability it would not have had
+ * after a real transform. CSS and other non-JavaScript resources are excluded
+ * as well -- they are not transformable modules, and route closures must only
+ * traverse module edges (stylesheets are merged by mergeModuleCssImports).
+ *
+ * parseLocalImports resolves relative and `@/` specifiers only, so the
+ * project-root forms the rest of this executor supports (`app/x.tsx`,
+ * `/app/x.tsx`, `/_vf_modules/app/x.tsx` -- see normalizeProjectSpecifier)
+ * come back in `unresolvedSpecifiers` and are resolved here with the same
+ * project-specifier semantics. Dropping them would silently leave a client
+ * boundary imported through a root form out of the closure, publishing the
+ * route without the JavaScript needed to hydrate it.
+ *
+ * CommonJS server helpers use the parser contract to add statically named
+ * require edges that the ESM lexer does not report.
+ */
+async function collectServerModuleImports(
+  source: string,
+  logicalPath: string,
+  tempDir: string,
+  knownPaths: Set<string>,
+  projectImportAliases: ReadonlyMap<string, string>,
+  adapter: RuntimeAdapter,
+): Promise<string[]> {
+  const materializedFs = createFileSystem();
+  const resolutionAdapter: RuntimeAdapter = {
+    ...adapter,
+    fs: {
+      ...adapter.fs,
+      // Release sources were just materialized as regular files beneath a
+      // fresh build-owned directory. The parser may therefore use its
+      // symlink-free containment path even when the transform adapter itself
+      // does not expose a host realPath capability.
+      symlinkSemantics: "none",
+      stat: (path: string) => materializedFs.stat(path),
+      resolveFile: (basePath: string) => {
+        const logicalPath = releaseLogicalPathFromMaterializedPath(basePath, tempDir);
+        const resolved = resolveKnownModulePathWithExtensions(
+          logicalPath,
+          knownPaths,
+          STAT_OPERATION_EXTENSION_PRIORITY,
+        );
+        return Promise.resolve(
+          resolved === null ? null : resolveMaterializedReleasePath(tempDir, resolved),
+        );
+      },
+    },
+  };
+  const parsed = await parseLocalImports(
+    source,
+    resolveMaterializedReleasePath(tempDir, logicalPath),
+    tempDir,
+    resolutionAdapter,
+  );
+  if (parsed.nonLiteralDynamicImports > 0) {
+    throw new Error(
+      `Server module has ${parsed.nonLiteralDynamicImports} non-literal dynamic import(s)`,
+    );
+  }
+  if (logicalPath.endsWith(".json") || logicalPath.endsWith(".md")) return [];
+
+  const imports = new Set<string>();
+  const addResolved = (importedPath: string | null, allowCss = true): boolean => {
+    if (importedPath?.endsWith(".css")) return allowCss;
+    if (importedPath && isTraversableServerModule(importedPath)) {
+      imports.add(importedPath);
+      return true;
+    }
+    return false;
+  };
+  const resolveRuntimeImportAlias = (specifier: string) =>
+    isRuntimeImportMapSpecifier(specifier)
+      ? resolveProjectImportAlias(
+        specifier,
+        projectImportAliases,
+        knownPaths,
+        resolveKnownServerDependencyPath,
+      )
+      : { matched: false };
+  let missingProjectImports = 0;
+  for (const { specifier, absolutePath } of parsed.imports) {
+    const aliasResolution = resolveRuntimeImportAlias(specifier);
+    if (aliasResolution.matched) {
+      if (aliasResolution.path === null) missingProjectImports++;
+      else if (
+        aliasResolution.path !== undefined && !addResolved(aliasResolution.path, false)
+      ) missingProjectImports++;
+      continue;
+    }
+    const relativePath = relative(tempDir, absolutePath).replaceAll("\\", "/");
+    if (!addResolved(resolveKnownServerModulePath(relativePath, knownPaths))) {
+      missingProjectImports++;
+    }
+  }
+  for (const { specifier } of parsed.missing) {
+    const aliasResolution = resolveRuntimeImportAlias(specifier);
+    if (!aliasResolution.matched || aliasResolution.path === null) {
+      missingProjectImports++;
+    } else if (aliasResolution.path !== undefined) {
+      if (!addResolved(aliasResolution.path, false)) missingProjectImports++;
+    }
+  }
+  // Cross-project imports are resolved by the runtime's project boundary, not
+  // by a single release asset. They cannot be represented in this closure, so
+  // fail the route closed instead of publishing an incomplete server module.
+  missingProjectImports += parsed.crossProjectImports.length;
+  const resolveUnresolvedImport = (
+    specifier: string,
+    hasJsonTypeAttribute?: boolean,
+    fromCommonJs = false,
+  ) => {
+    if (/^file:/i.test(specifier)) {
+      missingProjectImports++;
+      return;
+    }
+    if (/^data:/i.test(specifier) && isExternalCssSpecifier(specifier)) {
+      missingProjectImports++;
+      return;
+    }
+    if (isJsonDataUrlSpecifier(specifier) && hasJsonTypeAttribute !== true) {
+      missingProjectImports++;
+      return;
+    }
+    if (
+      (specifier.startsWith("//") || /^https?:/i.test(specifier)) &&
+      isExternalJsonSpecifier(specifier) && hasJsonTypeAttribute !== true
+    ) {
+      missingProjectImports++;
+      return;
+    }
+    const aliasResolution = resolveRuntimeImportAlias(specifier);
+    if (aliasResolution.matched) {
+      if (aliasResolution.path === null) {
+        missingProjectImports++;
+      } else if (aliasResolution.path !== undefined) {
+        if (aliasResolution.path.endsWith(".json") && hasJsonTypeAttribute === false) {
+          missingProjectImports++;
+        } else if (!addResolved(aliasResolution.path, false)) {
+          missingProjectImports++;
+        }
+      } else if (
+        aliasResolution.external !== undefined &&
+        (isExternalCssSpecifier(aliasResolution.external) ||
+          (isExternalJsonSpecifier(aliasResolution.external) && hasJsonTypeAttribute !== true))
+      ) {
+        missingProjectImports++;
+      }
+      return;
+    }
+    if (specifier.startsWith("#")) {
+      missingProjectImports++;
+      return;
+    }
+    const normalized = normalizeProjectSpecifier(specifier, logicalPath);
+    if (normalized === null) return;
+    const importedPath = resolveKnownServerModulePath(normalized, knownPaths);
+    if (importedPath === null) {
+      missingProjectImports++;
+      return;
+    }
+    if (importedPath.endsWith(".json") && hasJsonTypeAttribute === false) {
+      missingProjectImports++;
+      return;
+    }
+    if (!addResolved(importedPath, !fromCommonJs)) missingProjectImports++;
+  };
+
+  const unresolvedImports = new Map<string, boolean | undefined>();
+  for (const unresolved of parsed.unresolvedImports) {
+    const current = unresolvedImports.get(unresolved.specifier);
+    unresolvedImports.set(
+      unresolved.specifier,
+      current === false ? false : unresolved.hasJsonTypeAttribute,
+    );
+  }
+
+  const commonJsSpecifiers = new Set<string>();
+  // MDX is traversable only after parseLocalImports compiles it above. Its raw
+  // prose is not a JavaScript program and must not reach the CommonJS parser.
+  if (!logicalPath.endsWith(".mdx")) {
+    await ensureDefaultParserContracts();
+    const parser = tryResolve<CodeParser>("CodeParser");
+    if (typeof parser?.findStaticCommonJsImports !== "function") {
+      throw new Error('Missing CodeParser capability "findStaticCommonJsImports"');
+    }
+    for (
+      const specifier of await parser.findStaticCommonJsImports({
+        code: source,
+        filePath: resolveMaterializedReleasePath(tempDir, logicalPath),
+      })
+    ) {
+      commonJsSpecifiers.add(specifier);
+    }
+  }
+  for (const specifier of commonJsSpecifiers) {
+    if (!unresolvedImports.has(specifier)) unresolvedImports.set(specifier, undefined);
+  }
+  for (const [specifier, hasJsonTypeAttribute] of unresolvedImports) {
+    resolveUnresolvedImport(specifier, hasJsonTypeAttribute, commonJsSpecifiers.has(specifier));
+  }
+  if (missingProjectImports > 0) {
+    throw new Error(
+      `Server module has ${missingProjectImports} unresolved project import(s)`,
+    );
+  }
+  return [...imports];
+}
+
+interface ProjectImportAliasResolution {
+  readonly matched: boolean;
+  readonly path?: string | null;
+  readonly external?: string;
+}
+
+/**
+ * External alias targets reach browser finalization verbatim, and
+ * assertFinalModuleImports accepts only parseable absolute URLs. A
+ * protocol-relative target such as `//cdn.example/sdk.js` is valid at
+ * runtime because the canonical resolver upgrades it to an absolute URL
+ * (canonicalizeHttpSpecifier in src/transforms/esm/specifier-resolver.ts).
+ * A release asset has no plaintext dev module-server base to inherit a
+ * scheme from, so remote executable code always canonicalizes to https --
+ * the same scheme the runtime enforces for any host other than a local dev
+ * origin.
+ */
+function canonicalizeExternalProjectImportAliasTarget(mapped: string): string {
+  return mapped.startsWith("//") ? `https:${mapped}` : mapped;
+}
+
+function serverOnlyBrowserProjectImportAliasTarget(
+  mapped: string,
+  serverExternalPackages?: readonly string[],
+): string | null {
+  const canonical = canonicalizeExternalProjectImportAliasTarget(mapped);
+  const npmCandidate = canonical.startsWith("npm:") ? canonical.slice("npm:".length) : canonical;
+  const bare = parseBarePackageSpecifier(npmCandidate);
+  const esmSh = parseEsmShSpecifier(canonical);
+  const packageName = esmSh?.packageName ?? bare?.packageName;
+  if (!packageName || !isServerOnlyPackage(packageName, serverExternalPackages)) return null;
+  return esmSh ? `${esmSh.packageName}${esmSh.subpath}` : canonical;
+}
+
+function canonicalizeBrowserProjectImportAliasTarget(
+  mapped: string,
+  reactVersion: string,
+  serverExternalPackages?: readonly string[],
+  requireCspCompatible = false,
+): string {
+  const canonical = canonicalizeExternalProjectImportAliasTarget(mapped);
+  const serverOnly = serverOnlyBrowserProjectImportAliasTarget(
+    canonical,
+    serverExternalPackages,
+  );
+  if (serverOnly !== null) {
+    // Match BareStrategy: a server-only package must remain native so final
+    // browser-import validation rejects the route instead of publishing an
+    // esm.sh bundle containing unusable Node stubs.
+    return serverOnly;
+  }
+  const resolved = canonical.startsWith("npm:")
+    ? resolveBareSpecifier(canonical.slice(4), {}, reactVersion)
+    : /^[A-Za-z][A-Za-z0-9+.-]*:/.test(canonical)
+    ? canonical
+    : resolveBareSpecifier(canonical, {}, reactVersion);
+  if (requireCspCompatible && /^https?:/i.test(resolved)) {
+    const origin = new URL(resolved).origin;
+    if (!PLATFORM_SCRIPT_ORIGINS.some((allowed) => allowed === origin)) {
+      throw new Error("Browser import-map alias target is outside the enforced script CSP");
+    }
+  }
+  return resolved;
+}
+
+function isExternalProjectImportAliasTarget(mapped: string): boolean {
+  if (mapped.startsWith("//") || /^[A-Za-z][A-Za-z0-9+.-]*:/.test(mapped)) return true;
+  if (
+    mapped.startsWith("./") || mapped.startsWith("../") ||
+    mapped.startsWith("/") || mapped.startsWith("@/") ||
+    PROJECT_IMPORT_ROOTS.some((directory) => mapped.startsWith(directory))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function resolveProjectImportAlias(
+  specifier: string,
+  aliases: ReadonlyMap<string, string>,
+  knownPaths: Set<string>,
+  resolveKnownPath: (path: string, knownPaths: Set<string>) => string | null =
+    resolveKnownServerModulePath,
+  seenKeys: Set<string> = new Set(),
+): ProjectImportAliasResolution {
+  if (!isRuntimeImportMapSpecifier(specifier)) {
+    return { matched: false, path: null };
+  }
+  let key = aliases.has(specifier) ? specifier : undefined;
+  let suffix = "";
+  if (key === undefined && isEsmShUrl(specifier)) {
+    const esmShMapping = resolveEsmShThroughImportMap(
+      specifier,
+      undefined,
+      Object.fromEntries(aliases),
+    );
+    if (esmShMapping !== null) {
+      if (
+        !aliases.has(esmShMapping) && !esmShMapping.startsWith("#") &&
+        !/^file:/i.test(esmShMapping) &&
+        isExternalProjectImportAliasTarget(esmShMapping)
+      ) {
+        return {
+          matched: true,
+          external: canonicalizeExternalProjectImportAliasTarget(esmShMapping),
+        };
+      }
+      return resolveProjectImportAliasTarget(
+        specifier,
+        esmShMapping,
+        aliases,
+        knownPaths,
+        resolveKnownPath,
+        seenKeys,
+      );
+    }
+  }
+  if (
+    key === undefined &&
+    (specifier.endsWith(".js") || specifier.endsWith(".mjs") || specifier.endsWith(".cjs"))
+  ) {
+    const base = specifier.replace(/\.(m|c)?js$/, "");
+    if (aliases.has(base)) key = base;
+  }
+  if (key === undefined) {
+    for (
+      let separator = specifier.indexOf("/");
+      separator >= 0;
+      separator = specifier.indexOf("/", separator + 1)
+    ) {
+      const candidate = specifier.slice(0, separator + 1);
+      if (aliases.has(candidate)) key = candidate;
+    }
+    if (key !== undefined) suffix = specifier.slice(key.length);
+  }
+  if (key === undefined) return { matched: false, path: null };
+  if (seenKeys.has(key)) return { matched: true, path: null };
+  seenKeys.add(key);
+
+  const mapped = aliases.get(key)! + suffix;
+  return resolveProjectImportAliasTarget(
+    specifier,
+    mapped,
+    aliases,
+    knownPaths,
+    resolveKnownPath,
+    seenKeys,
+  );
+}
+
+function resolveProjectImportAliasTarget(
+  specifier: string,
+  mapped: string,
+  aliases: ReadonlyMap<string, string>,
+  knownPaths: Set<string>,
+  resolveKnownPath: (path: string, knownPaths: Set<string>) => string | null,
+  seenKeys: Set<string>,
+): ProjectImportAliasResolution {
+  const nested = resolveProjectImportAlias(
+    mapped,
+    aliases,
+    knownPaths,
+    resolveKnownPath,
+    seenKeys,
+  );
+  if (nested.matched) {
+    return specifier.startsWith("@/") && nested.external !== undefined
+      ? { matched: false, path: null }
+      : nested;
+  }
+  if (mapped.startsWith("#")) return { matched: true, path: null };
+  if (/^file:/i.test(mapped)) return { matched: true, path: null };
+  if (mapped.startsWith("/_vf_modules/") || mapped.startsWith("_vf_modules/")) {
+    return { matched: true, path: resolveKnownPath(mapped, knownPaths) };
+  }
+  if (mapped.startsWith("@/")) {
+    return { matched: true, path: resolveKnownPath(mapped.slice(2), knownPaths) };
+  }
+  if (isExternalProjectImportAliasTarget(mapped)) {
+    if (specifier.startsWith("@/")) return { matched: false, path: null };
+    return { matched: true, external: canonicalizeExternalProjectImportAliasTarget(mapped) };
+  }
+  return { matched: true, path: null };
+}
+
+function readReleaseProjectImportAliases(
+  sourceByPath: ReadonlyMap<string, string>,
+  config: VeryfrontConfig,
+): ReadonlyMap<string, string> {
+  const source = sourceByPath.get("deno.json");
+  const denoImports: Record<string, string> = {};
+  if (source !== undefined) {
+    try {
+      const parsed = JSON.parse(source) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        const imports = (parsed as { imports?: unknown }).imports;
+        const scopes = (parsed as { scopes?: unknown }).scopes;
+        if (imports !== undefined || scopes !== undefined) {
+          const snapshot = snapshotImportMap({
+            imports: imports ?? {},
+            scopes: scopes ?? {},
+          });
+          Object.assign(denoImports, snapshot.imports ?? {});
+        }
+      }
+    } catch {
+      // Optional malformed Deno maps do not override validated config aliases.
+    }
+  }
+  // A project can also declare aliases in veryfront.config.ts under
+  // resolve.importMap.imports. loadImportMap merges deno.json first and the
+  // config map last at serve time, so the release traversal mirrors that
+  // order: a config mapping overrides the deno.json one for the same key.
+  const merged = mergeImportMaps(
+    { imports: denoImports },
+    config.resolve?.importMap ?? {},
+  );
+  const normalized = normalizeImportMapForRuntime(merged);
+  const aliases = new Map<string, string>();
+  for (const [key, value] of Object.entries(normalized.imports ?? {})) {
+    if (typeof value === "string" && !isFrameworkOwnedImportMapSpecifier(key)) {
+      aliases.set(key, value);
+    }
+  }
+  return aliases;
+}
+
+async function rewriteExternalProjectImportAliases(
+  code: string,
+  projectImportAliases: ReadonlyMap<string, string>,
+  knownPaths: Set<string>,
+  reactVersion: string,
+  serverExternalPackages?: readonly string[],
+): Promise<string> {
+  return await replaceSpecifiers(code, (specifier) => {
+    const resolution = resolveProjectImportAlias(
+      specifier,
+      projectImportAliases,
+      knownPaths,
+      resolveKnownModulePath,
+    );
+    return resolution.external === undefined ? null : canonicalizeBrowserProjectImportAliasTarget(
+      resolution.external,
+      reactVersion,
+      serverExternalPackages,
+    );
+  });
+}
+
 async function rewriteProjectModuleImports(
   code: string,
   logicalPath: string,
   moduleAssets: Map<string, PreparedAsset>,
   knownPaths: Set<string>,
+  projectImportAliases: ReadonlyMap<string, string>,
   dependencyUrls: Map<string, string>,
+  reactVersion: string,
+  serverExternalPackages?: readonly string[],
 ): Promise<string> {
   function rewriteSpecifier(specifier: string): string | null {
+    const aliasResolution = resolveProjectImportAlias(
+      specifier,
+      projectImportAliases,
+      knownPaths,
+      resolveKnownModulePath,
+    );
+    if (aliasResolution.external !== undefined) {
+      if (isExternalCssSpecifier(aliasResolution.external)) {
+        throw new Error("Browser import-map alias cannot target an external stylesheet");
+      }
+      const serverOnly = serverOnlyBrowserProjectImportAliasTarget(
+        aliasResolution.external,
+        serverExternalPackages,
+      );
+      if (serverOnly !== null) return serverOnly;
+    }
+
     const dependencyUrl = dependencyUrlForSpecifier(dependencyUrls, specifier);
     if (dependencyUrl) return dependencyUrl;
 
@@ -660,7 +1366,18 @@ async function rewriteProjectModuleImports(
       if (dependencyUrl) return dependencyUrl;
     }
 
-    const importedPath = resolveProjectModuleSpecifier(specifier, logicalPath, knownPaths);
+    if (aliasResolution.external !== undefined) {
+      return dependencyUrlForSpecifier(dependencyUrls, aliasResolution.external) ??
+        canonicalizeBrowserProjectImportAliasTarget(
+          aliasResolution.external,
+          reactVersion,
+          serverExternalPackages,
+          true,
+        );
+    }
+    const importedPath = aliasResolution.matched
+      ? aliasResolution.path ?? null
+      : resolveProjectModuleSpecifier(specifier, logicalPath, knownPaths);
     const asset = importedPath ? moduleAssets.get(importedPath) : undefined;
     return asset ? releaseAssetUrl(asset.contentHash, "js") : null;
   }
@@ -1727,16 +2444,24 @@ async function finalizeDependencyModules(
 async function finalizeProjectModules(
   transformedModules: Map<string, TransformedProjectModule>,
   knownPaths: Set<string>,
+  projectImportAliases: ReadonlyMap<string, string>,
   dependencyUrls: Map<string, string>,
   uploadQueue: PreparedAsset[],
   pendingBytes: PendingAssetStore,
   gaps: string[],
   allowHttp: boolean,
+  reactVersion: string,
+  serverExternalPackages?: readonly string[],
 ): Promise<{ modules: Record<string, PreparedAsset>; skippedModules: Set<string> }> {
   const finalized = new Map<string, PreparedAsset>();
   const unresolvedCycles = new Set<string>();
   const nonSizeFailures = new Set<string>();
-  const cyclicModules = await collectCyclicProjectModules(transformedModules, knownPaths, gaps);
+  const cyclicModules = await collectCyclicProjectModules(
+    transformedModules,
+    knownPaths,
+    projectImportAliases,
+    gaps,
+  );
   const skippedModules = new Set(cyclicModules);
 
   async function finalize(logicalPath: string, stack: string[]): Promise<PreparedAsset | null> {
@@ -1761,7 +2486,12 @@ async function finalizeProjectModules(
     const nextStack = [...stack, logicalPath];
     let imports: Map<string, string>;
     try {
-      imports = await collectProjectModuleImports(transformed.code, logicalPath, knownPaths);
+      imports = await collectProjectModuleImports(
+        transformed.code,
+        logicalPath,
+        knownPaths,
+        projectImportAliases,
+      );
     } catch (error) {
       pushGap(gaps, `module-import-parse-failed:${logicalPath}`);
       logger.warn("Module import parse failed during release asset finalization", {
@@ -1782,7 +2512,10 @@ async function finalizeProjectModules(
         logicalPath,
         finalized,
         knownPaths,
+        projectImportAliases,
         dependencyUrls,
+        reactVersion,
+        serverExternalPackages,
       );
       await assertFinalModuleImports(rewritten, { allowHttp });
     } catch (error) {
@@ -1824,6 +2557,7 @@ async function finalizeProjectModules(
 async function collectCyclicProjectModules(
   transformedModules: Map<string, TransformedProjectModule>,
   knownPaths: Set<string>,
+  projectImportAliases: ReadonlyMap<string, string>,
   gaps: string[],
 ): Promise<Set<string>> {
   const cyclic = new Set<string>();
@@ -1858,7 +2592,12 @@ async function collectCyclicProjectModules(
 
     let imports: Map<string, string>;
     try {
-      imports = await collectProjectModuleImports(transformed.code, logicalPath, knownPaths);
+      imports = await collectProjectModuleImports(
+        transformed.code,
+        logicalPath,
+        knownPaths,
+        projectImportAliases,
+      );
     } catch (error) {
       cyclic.add(logicalPath);
       pushGap(gaps, `module-import-parse-failed:${logicalPath}`);
@@ -2163,27 +2902,54 @@ function addFrameworkDependencyUrlAliases(
 async function collectRouteClosure(
   entrypoints: string[],
   transformedModules: Map<string, TransformedProjectModule>,
+  finalizedModules: ReadonlySet<string>,
   knownPaths: Set<string>,
+  projectImportAliases: ReadonlyMap<string, string>,
+  serverModuleImports: ReadonlyMap<string, readonly string[]> = new Map(),
 ): Promise<{ modules: string[]; gaps: string[] }> {
+  type ClosureMode = "browser" | "server";
   const visited = new Set<string>();
-  const queue = [...entrypoints];
+  const browserModules = new Set<string>();
+  const queue: Array<{ path: string; mode: ClosureMode }> = entrypoints.map((path) => ({
+    path,
+    mode: serverModuleImports.has(path) ? "server" as const : "browser" as const,
+  }));
   const gaps: string[] = [];
 
   for (let queueIndex = 0; queueIndex < queue.length; queueIndex++) {
-    const current = queue[queueIndex]!;
-    if (visited.has(current)) continue;
-    visited.add(current);
+    const { path: current, mode } = queue[queueIndex]!;
+    const visitKey = `${mode}:${current}`;
+    if (visited.has(visitKey)) continue;
+    visited.add(visitKey);
+
+    if (mode === "server") {
+      const serverImports = serverModuleImports.get(current);
+      if (serverImports) {
+        for (const importedPath of serverImports) {
+          queue.push({ path: importedPath, mode: "server" });
+        }
+        continue;
+      }
+      // A client boundary reached by a server edge has no server graph. Its
+      // finalized browser graph is the route's hydration dependency.
+    }
 
     const transformed = transformedModules.get(current);
-    if (!transformed) {
+    if (!transformed || !finalizedModules.has(current)) {
       // Module referenced but not transformable or not successfully transformed.
       pushGap(gaps, `closure-missing:${current}`);
       continue;
     }
+    browserModules.add(current);
 
     let imports: Map<string, string>;
     try {
-      imports = await collectProjectModuleImports(transformed.code, current, knownPaths);
+      imports = await collectProjectModuleImports(
+        transformed.code,
+        current,
+        knownPaths,
+        projectImportAliases,
+      );
     } catch (error) {
       pushGap(gaps, `closure-import-parse-failed:${current}`);
       logger.warn("Route closure import parse failed during release asset build", {
@@ -2193,11 +2959,11 @@ async function collectRouteClosure(
       continue;
     }
     for (const importedPath of imports.values()) {
-      if (!visited.has(importedPath)) queue.push(importedPath);
+      queue.push({ path: importedPath, mode: "browser" });
     }
   }
 
-  return { modules: [...visited], gaps };
+  return { modules: [...browserModules], gaps };
 }
 
 function validateReleaseAssetBuildInput(
@@ -2449,7 +3215,9 @@ async function runBuildInner(
   if (!releaseConfig || typeof releaseConfig !== "object" || Array.isArray(releaseConfig)) {
     throw new Error("Release asset config loader returned an invalid config");
   }
+  const projectImportAliases = readReleaseProjectImportAliases(sourceByPath, releaseConfig);
   const routeDirectories = releaseRouterDirectories(releaseConfig);
+  const releaseRscEnabled = isRSCEnabled(releaseConfig);
   const dependencyPinningSource = createDependencyPinningSource({
     projectDir: tempDir,
     projectId: input.projectId,
@@ -2471,14 +3239,134 @@ async function runBuildInner(
   async function transformProjectModule(
     logicalPath: string,
   ): Promise<string[]> {
-    if (transformedModules.has(logicalPath) || !isTransformableBrowserModule(logicalPath)) {
+    if (transformedModules.has(logicalPath)) {
+      return [];
+    }
+    const browserTransformable = isTransformableBrowserModule(logicalPath);
+    if (
+      !browserTransformable &&
+      !(serverReachedPaths.has(logicalPath) && isTraversableServerModule(logicalPath))
+    ) {
       return [];
     }
 
     const source = sourceByPath.get(logicalPath);
     if (typeof source !== "string") return [];
-
     const sourceFile = join(tempDir, logicalPath);
+    const sourcePolicy = classifyBrowserModuleSourcePath(logicalPath, {
+      config: releaseConfig,
+      rscEnabled: releaseRscEnabled,
+      isLocalProject: false,
+    });
+    const protectedSource = sourcePolicy.protectionReason !== null;
+    const hasClientDirective = hasUseClientDirective(source, logicalPath);
+    const hasServerDirective = hasUseServerDirective(source);
+    if (hasClientDirective && hasServerDirective) {
+      pushGap(moduleGaps, `module-boundary-failed:${logicalPath}`);
+      logger.warn("Browser module boundary rejected during release asset build", {
+        path: logicalPath,
+        error: "Module cannot contain both use client and use server directives",
+      });
+      return [];
+    }
+    if (protectedSource && hasClientDirective) {
+      pushGap(moduleGaps, `module-boundary-failed:${logicalPath}`);
+      logger.warn("Browser module boundary rejected during release asset build", {
+        path: logicalPath,
+        error: "Protected module cannot declare a client boundary",
+      });
+      return [];
+    }
+    if (
+      releaseRscEnabled &&
+      clientTrustedPaths.has(logicalPath) &&
+      isConfiguredAppRouterBrowserEntry(logicalPath, routeDirectories) &&
+      !hasClientDirective
+    ) {
+      pushGap(moduleGaps, `module-boundary-failed:${logicalPath}`);
+      logger.warn("Browser module boundary rejected during release asset build", {
+        path: logicalPath,
+        error: "App Router page or layout cannot inherit a client boundary",
+      });
+      return [];
+    }
+    const pagesRouterEntry = routeForConfiguredPage(logicalPath, routeDirectories) !== null &&
+      !isConfiguredAppRouterModule(logicalPath, routeDirectories);
+    const nonRscAppRouterEntry = !releaseRscEnabled &&
+      isConfiguredAppRouterBrowserEntry(logicalPath, routeDirectories);
+    if ((pagesRouterEntry || nonRscAppRouterEntry) && hasServerDirective) {
+      pushGap(moduleGaps, `module-boundary-failed:${logicalPath}`);
+      logger.warn("Browser module boundary rejected during release asset build", {
+        path: logicalPath,
+        error: "Browser route entry cannot contain a module-level use server directive",
+      });
+      return [];
+    }
+    const appRouterBrowserCandidate = (hasClientDirective && !hasServerDirective) ||
+      clientTrustedPaths.has(logicalPath) || nonRscAppRouterEntry;
+
+    // An App Router module is a server module unless it opts into the client
+    // boundary itself or inherits the boundary from a published browser module
+    // that imports it (a "use client" component's dependency closure is client
+    // code even when the helper files carry no directive of their own). An
+    // explicit "use server" module never inherits that trust: whoever imports
+    // it, wherever it lives, its source stays on the server. The same server
+    // boundary follows every module reached through a server-module edge, not
+    // only files beneath the app directory -- a server page importing
+    // ../server/actions.ts keeps that module server-side too.
+    if (
+      protectedSource ||
+      (!(hasClientDirective && !hasServerDirective) &&
+        (hasServerDirective ||
+          (((releaseRscEnabled && isConfiguredAppRouterModule(logicalPath, routeDirectories)) ||
+            serverReachedPaths.has(logicalPath)) &&
+            !clientTrustedPaths.has(logicalPath))))
+    ) {
+      try {
+        const imports = await collectServerModuleImports(
+          source,
+          logicalPath,
+          tempDir,
+          knownPaths,
+          projectImportAliases,
+          input.adapter,
+        );
+        serverModuleImports.set(logicalPath, imports);
+        // Everything a server module reaches is server code by default. A
+        // client entry or boundary that also imports the module reclassifies
+        // it below.
+        for (const importedPath of imports) {
+          serverReachedPaths.add(importedPath);
+        }
+        return imports;
+      } catch (error) {
+        // Route-local like every other per-module parse failure: the routes
+        // this module serves lose coverage and are dropped, and the failure
+        // only becomes fatal when it leaves the release with nothing to serve.
+        pushGap(moduleGaps, `module-import-parse-failed:${logicalPath}`);
+        logger.warn("Server module import parse failed during release asset build", {
+          path: logicalPath,
+          error: sanitizeError(error),
+        });
+        return [];
+      }
+    }
+
+    // Server-only script formats participate in route reachability but never
+    // enter the browser transform or release manifest.
+    if (!browserTransformable) return [];
+
+    const sourceBoundaryViolation = appRouterBrowserCandidate && !logicalPath.endsWith(".mdx")
+      ? await inspectReleaseBrowserModuleBoundary(source, sourceFile)
+      : null;
+    if (sourceBoundaryViolation) {
+      pushGap(moduleGaps, `module-boundary-failed:${logicalPath}`);
+      logger.warn("Browser module boundary rejected during release asset build", {
+        path: logicalPath,
+        error: describeBrowserModuleBoundaryViolation(sourceBoundaryViolation),
+      });
+      return [];
+    }
     let code: string;
     try {
       code = await transform(source, sourceFile, tempDir, input.adapter, {
@@ -2505,6 +3393,17 @@ async function runBuildInner(
       });
       return [];
     }
+    const transformedBoundaryViolation = appRouterBrowserCandidate && logicalPath.endsWith(".mdx")
+      ? await inspectReleaseBrowserModuleBoundary(code, sourceFile)
+      : null;
+    if (transformedBoundaryViolation) {
+      pushGap(moduleGaps, `module-boundary-failed:${logicalPath}`);
+      logger.warn("Browser module boundary rejected during release asset build", {
+        path: logicalPath,
+        error: describeBrowserModuleBoundaryViolation(transformedBoundaryViolation),
+      });
+      return [];
+    }
     const transformedSize = textEncoder.encode(code).byteLength;
     if (transformedSize > RELEASE_ASSET_MAX_SIZE_BYTES) {
       pushGap(moduleGaps, `oversized:${logicalPath}`);
@@ -2516,12 +3415,37 @@ async function runBuildInner(
       return [];
     }
 
+    try {
+      if (await importsExternalStylesheetAlias(code, projectImportAliases, knownPaths)) {
+        pushGap(moduleGaps, `module-boundary-failed:${logicalPath}`);
+        logger.warn("Browser module boundary rejected during release asset build", {
+          path: logicalPath,
+          error: "Browser import-map alias cannot target an external stylesheet",
+        });
+        return [];
+      }
+    } catch (error) {
+      pushGap(moduleGaps, `module-import-parse-failed:${logicalPath}`);
+      logger.warn("Module import parse failed during release asset build", {
+        path: logicalPath,
+        error: sanitizeError(error),
+      });
+      return [];
+    }
+
     const unvendoredCode = code;
     let imports: Map<string, string> | undefined;
     if (typeof vendorHttpImports === "function") {
       try {
+        const vendorSource = await rewriteExternalProjectImportAliases(
+          code,
+          projectImportAliases,
+          knownPaths,
+          releaseReactVersion,
+          releaseConfig.build?.serverExternalPackages,
+        );
         const vendored = validateVendorResult(
-          await vendorHttpImports(code, {
+          await vendorHttpImports(vendorSource, {
             tempDir,
             reactVersion: releaseReactVersion,
           }),
@@ -2531,6 +3455,7 @@ async function runBuildInner(
           vendored.code,
           logicalPath,
           knownPaths,
+          projectImportAliases,
         );
         commitDependencyModules(dependencyModules, stagedDependencies);
         code = vendored.code;
@@ -2553,7 +3478,12 @@ async function runBuildInner(
 
     if (!imports) {
       try {
-        imports = await collectProjectModuleImports(code, logicalPath, knownPaths);
+        imports = await collectProjectModuleImports(
+          code,
+          logicalPath,
+          knownPaths,
+          projectImportAliases,
+        );
       } catch (error) {
         const sanitized = sanitizeError(error);
         pushGap(moduleGaps, `module-import-parse-failed:${logicalPath}`);
@@ -2565,25 +3495,97 @@ async function runBuildInner(
       }
     }
 
+    // This module ships to the browser, so everything it imports is client
+    // code too. Propagate that trust before the imports are dequeued, and
+    // reclassify any import that an earlier server-module traversal parked as
+    // a server module: it must be transformed and published after all, or the
+    // importing module's finalize step has nothing to rewrite the edge to.
+    for (const importedPath of imports.values()) {
+      if (clientTrustedPaths.has(importedPath)) continue;
+      clientTrustedPaths.add(importedPath);
+      if (serverModuleImports.has(importedPath)) {
+        moduleQueue.push(importedPath);
+      } else if (transformedModules.delete(importedPath)) {
+        // A broad browser seed can be transformed before its client importer.
+        // Re-run it now that inherited client trust requires boundary checks.
+        moduleQueue.push(importedPath);
+      }
+    }
+
+    // Keep the server traversal for server edges even after browser promotion.
+    // Route assembly selects the graph per edge after finalization, so a failed
+    // browser publication cannot break an otherwise valid server-only path.
     transformedModules.set(logicalPath, { logicalPath, code, unvendoredCode });
     return [...imports.values()];
   }
 
+  const serverModuleImports = new Map<string, readonly string[]>();
+  // Logical paths outside the seeded browser locations that a server-module
+  // edge reached. They default to server modules wherever they live on disk,
+  // unless a client boundary also imports them.
+  const serverReachedPaths = new Set<string>();
+  // Logical paths that inherit the client boundary from an importing browser
+  // module, so App Router files without their own "use client" directive are
+  // still transformed when a client component pulls them in.
+  const clientTrustedPaths = new Set<string>();
   const moduleQueue: string[] = [];
   const queuedModules = new Set<string>();
-  for (const logicalPath of sourceByPath.keys()) {
-    if (!isBrowserModule(logicalPath, routeDirectories)) continue;
-    moduleQueue.push(logicalPath);
-    queuedModules.add(logicalPath);
-  }
-  for (let index = 0; index < moduleQueue.length; index++) {
-    const logicalPath = moduleQueue[index]!;
-    for (const importedPath of await transformProjectModule(logicalPath)) {
-      if (queuedModules.has(importedPath)) continue;
-      queuedModules.add(importedPath);
-      moduleQueue.push(importedPath);
+  const browserSeeds = [...sourceByPath.keys()].filter((logicalPath) =>
+    isBrowserModule(logicalPath, routeDirectories)
+  );
+  const seedRank = (logicalPath: string): number => {
+    const source = sourceByPath.get(logicalPath) ?? "";
+    const sourcePolicy = classifyBrowserModuleSourcePath(logicalPath, {
+      config: releaseConfig,
+      rscEnabled: releaseRscEnabled,
+      isLocalProject: false,
+    });
+    if (sourcePolicy.protectionReason !== null || hasUseServerDirective(source)) return 0;
+    if (isConfiguredAppRouterModule(logicalPath, routeDirectories)) {
+      return isTrustedAppRouterBrowserModule(source, logicalPath) ? 1 : 0;
+    }
+    return routeForConfiguredPage(logicalPath, routeDirectories) !== null ? 1 : 2;
+  };
+  browserSeeds.sort((left, right) => {
+    const rankDifference = seedRank(left) - seedRank(right);
+    if (rankDifference !== 0) return rankDifference;
+    return left < right ? -1 : left > right ? 1 : 0;
+  });
+  for (const logicalPath of browserSeeds) {
+    const pagesRouterEntry = routeForConfiguredPage(logicalPath, routeDirectories) !== null &&
+      !isConfiguredAppRouterModule(logicalPath, routeDirectories);
+    const nonRscAppRouterEntry = !releaseRscEnabled &&
+      isConfiguredAppRouterBrowserEntry(logicalPath, routeDirectories);
+    if (pagesRouterEntry || nonRscAppRouterEntry) {
+      clientTrustedPaths.add(logicalPath);
     }
   }
+
+  const enqueueModule = (logicalPath: string) => {
+    if (queuedModules.has(logicalPath)) return;
+    queuedModules.add(logicalPath);
+    moduleQueue.push(logicalPath);
+  };
+  let moduleQueueIndex = 0;
+  const drainModuleQueue = async () => {
+    while (moduleQueueIndex < moduleQueue.length) {
+      const logicalPath = moduleQueue[moduleQueueIndex++]!;
+      for (const importedPath of await transformProjectModule(logicalPath)) {
+        enqueueModule(importedPath);
+      }
+    }
+  };
+
+  // Build the complete server closure before broad directory seeds can be
+  // transformed. Otherwise a generic seed that sorts before its server
+  // importer can publish itself and propagate false client trust to its own
+  // dependencies before the server edge reaches it.
+  for (const logicalPath of browserSeeds) {
+    if (seedRank(logicalPath) === 0) enqueueModule(logicalPath);
+  }
+  await drainModuleQueue();
+  for (const logicalPath of browserSeeds) enqueueModule(logicalPath);
+  await drainModuleQueue();
 
   if (typeof vendorHttpImports === "function") {
     try {
@@ -2673,11 +3675,14 @@ async function runBuildInner(
   const { modules, skippedModules } = await finalizeProjectModules(
     transformedModules,
     knownPaths,
+    projectImportAliases,
     dependencyUrls,
     uploadQueue,
     pendingBytes,
     moduleGaps,
     !vendorDependencies,
+    releaseReactVersion,
+    releaseConfig.build?.serverExternalPackages,
   );
 
   for (const logicalPath of transformedModules.keys()) {
@@ -2706,7 +3711,11 @@ async function runBuildInner(
     pushGap(gaps, `stylesheet-missing:${stylesheetPath}`);
     assertCompleteReleaseAssetCoverage(gaps, moduleGaps);
   }
-  const stylesheet = await mergeModuleCssImports(sourceByPath, resolvedStylesheet);
+  const stylesheet = await mergeModuleCssImports(
+    sourceByPath,
+    resolvedStylesheet,
+    projectImportAliases,
+  );
   assertCompleteReleaseAssetCoverage(gaps, moduleGaps);
   const cssRequested = candidates.size > 0 || stylesheet !== undefined;
   if (cssRequested) {
@@ -2755,7 +3764,8 @@ async function runBuildInner(
   // Modules missing from transformedModules are recorded as closure gaps.
   const routes: Record<string, ReleaseAssetRouteEntry> = {};
   const droppedRoutes = new Map<string, string[]>();
-  const pageModules = Object.keys(modules).filter((p) =>
+  const finalizedModulePaths = new Set(Object.keys(modules));
+  const pageModules = [...sourceByPath.keys()].filter((p) =>
     routeForConfiguredPage(p, routeDirectories) !== null
   );
 
@@ -2774,7 +3784,10 @@ async function runBuildInner(
     const { modules: closureModules, gaps: closureGaps } = await collectRouteClosure(
       entryModules,
       transformedModules,
+      finalizedModulePaths,
       knownPaths,
+      projectImportAliases,
+      serverModuleImports,
     );
 
     // Include only modules we actually have in the manifest (transformed +
@@ -2959,22 +3972,79 @@ function resolveProjectStylesheet(
 async function mergeModuleCssImports(
   sourceByPath: Map<string, string>,
   stylesheet: { content: string; path: string } | undefined,
+  projectImportAliases: ReadonlyMap<string, string>,
 ): Promise<string | undefined> {
   const importedPaths = new Set<string>();
+  const knownPaths = new Set(sourceByPath.keys());
   for (const [path, content] of sourceByPath) {
     if (!CSS_IMPORTING_SOURCE_EXTENSIONS.some((ext) => path.endsWith(ext))) continue;
-    // Regex extraction, not the ESM lexer. This runs over project source --
-    // .tsx/.jsx/.mdx/.ts by definition, see CSS_IMPORTING_SOURCE_EXTENSIONS --
-    // and es-module-lexer parses none of those. Every file containing JSX threw
-    // here, each throw recorded a gap, and gaps are fatal since #3244, so no
-    // project with a JSX component could publish a release at all.
-    //
-    // This is the same extractor the dev CSS scanner has always used, so the
-    // two paths now agree. It also removes the failure mode rather than
-    // handling it: a scanner that cannot throw cannot fail a release for a
-    // reason that has nothing to do with the release.
-    for (const specifier of extractCssImportSpecifiers(content)) {
-      const cssPath = specifier.split(/[?#]/, 1)[0] ?? "";
+    // The source-span scanners understand comments, strings, JSX, and
+    // TypeScript without requiring the raw source to be valid plain
+    // JavaScript. That keeps the JSX-safe behavior this release path needs,
+    // while ensuring quoted or commented import/export examples cannot merge
+    // a real but unreachable stylesheet into production CSS.
+    // Matcher rejections do not count against the scanner bound. Restricting
+    // the scan here keeps a generated file's ordinary imports from exhausting
+    // the budget before a later live stylesheet edge.
+    const keepCssSpecifier = (specifier: string) => {
+      if (isExternalCssSpecifier(specifier)) return specifier;
+      if (
+        !mayResolveProjectStylesheetSpecifier(
+          specifier,
+          projectImportAliases,
+        )
+      ) return null;
+      const aliasResolution = resolveProjectImportAlias(
+        specifier,
+        projectImportAliases,
+        knownPaths,
+        resolveKnownStylesheetPath,
+      );
+      return aliasResolution.matched && aliasResolution.path ? specifier : null;
+    };
+    const specifiers = new Set<string>();
+    const findCompleteCssSpans = (
+      scan: (maxMatches: number) => ReturnType<typeof findStaticImportFromSpans>,
+    ) => {
+      const spans = scan(MAX_RELEASE_FILES + 1);
+      if (spans.length > MAX_RELEASE_FILES) {
+        throw new Error(
+          `Release CSS import scan exceeds ${MAX_RELEASE_FILES} matches in ${path}`,
+        );
+      }
+      return spans;
+    };
+    for (
+      const spans of [
+        findCompleteCssSpans((maxMatches) =>
+          findStaticImportFromSpans(content, keepCssSpecifier, maxMatches)
+        ),
+        findCompleteCssSpans((maxMatches) =>
+          findStaticSideEffectImportSpans(content, keepCssSpecifier, maxMatches)
+        ),
+        findCompleteCssSpans((maxMatches) =>
+          findDynamicImportSpans(content, keepCssSpecifier, maxMatches)
+        ),
+      ]
+    ) {
+      for (const span of spans) {
+        if (span.typeOnly !== true) specifiers.add(span.path);
+      }
+    }
+    for (const specifier of specifiers) {
+      const cssPath = specifier.startsWith("#") ? specifier : splitSpecifierSuffix(specifier).path;
+      const aliasResolution = resolveProjectImportAlias(
+        cssPath,
+        projectImportAliases,
+        knownPaths,
+        resolveKnownStylesheetPath,
+      );
+      if (aliasResolution.matched) {
+        if (aliasResolution.path !== undefined && aliasResolution.path !== null) {
+          importedPaths.add(aliasResolution.path);
+        }
+        continue;
+      }
       if (!cssPath.endsWith(".css")) continue;
       // Nothing this scan fails to resolve is fatal, because a regex match is
       // not knowledge that the build needs the file. extractCssImportSpecifiers
@@ -2989,11 +4059,7 @@ async function mergeModuleCssImports(
       // missing-CSS detection belongs on the resolved module graph
       // (collectProjectModuleImports, over transformed code where the lexer is
       // trustworthy), not on this text scan.
-      if (cssPath !== specifier) {
-        logger.debug("Skipping CSS import with an unsupported specifier", { path, specifier });
-        continue;
-      }
-      const importedPath = resolveCssImportPath(specifier, `/${path}`, "/");
+      const importedPath = resolveCssImportPath(cssPath, `/${path}`, "/");
       if (!importedPath) {
         logger.debug("Skipping CSS import that does not resolve", { path, specifier });
         continue;

--- a/src/release-assets/scaffolded-project-build.test.ts
+++ b/src/release-assets/scaffolded-project-build.test.ts
@@ -41,6 +41,7 @@ import {
 import { CSSOptimizationEngineName } from "#veryfront/extensions/css/index.ts";
 import { FIRST_PARTY_EXTENSION_POLICIES } from "#veryfront/extensions/first-party-defaults.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { hasUseClientDirective } from "#veryfront/rendering/rsc/page-island.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { readTextFile } from "#veryfront/testing/deno-compat.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
@@ -236,7 +237,9 @@ describe("release assets: scaffolded project build", () => {
         releaseVersionRef: "rel-uuid",
         adapter: fsAdapter,
         dependencyMode: "source",
-        loadConfig: () => Promise.resolve({} as VeryfrontConfig),
+        // Exercise App Router's server/client release boundary independently
+        // of the host process's experimental feature environment.
+        loadConfig: () => Promise.resolve({ experimental: { rsc: true } } as VeryfrontConfig),
         client: makeClient(sources, rec, `scaffold-${templateName}`),
         // The real browser transform the hosted runtime injects. A passthrough
         // stub would leave TSX unparseable and turn every module into an
@@ -269,11 +272,27 @@ describe("release assets: scaffolded project build", () => {
       // build succeeds either way: before the fix these scaffolds published
       // platform/compat/dynamic-import.ts as its own chunk and every test here
       // still passed.
-      const jsUploads = rec.uploads.filter((upload) => upload.contentType.includes("javascript"));
-      assert(
-        jsUploads.length > 0,
-        `${templateName} published no JS assets, so the new Function guard would pass vacuously`,
+      //
+      // Browser JS only exists where the scaffold crosses the client boundary.
+      // A fully server-rendered template (`minimal`) must publish zero JS
+      // assets now that App Router server modules stay out of release assets;
+      // publishing any would regress that confidentiality boundary.
+      const declaresClientBoundary = sources.some(({ path, content }) =>
+        hasUseClientDirective(content, path)
       );
+      const jsUploads = rec.uploads.filter((upload) => upload.contentType.includes("javascript"));
+      if (declaresClientBoundary) {
+        assert(
+          jsUploads.length > 0,
+          `${templateName} published no JS assets, so the new Function guard would pass vacuously`,
+        );
+      } else {
+        assertEquals(
+          jsUploads.map((upload) => upload.hash),
+          [],
+          `${templateName} is fully server-rendered and must not publish JS release assets`,
+        );
+      }
       const evalOffenders = jsUploads
         .filter((upload) => /\bnew Function\s*\(/.test(new TextDecoder().decode(upload.bytes)));
       assertEquals(
@@ -289,10 +308,18 @@ describe("release assets: scaffolded project build", () => {
 
       const manifest = parseReleaseAssetManifest(rec.manifest);
       assertExists(manifest);
-      assert(
-        Object.keys(manifest.modules).length > 0,
-        `${templateName} manifest must list browser modules`,
-      );
+      if (declaresClientBoundary) {
+        assert(
+          Object.keys(manifest.modules).length > 0,
+          `${templateName} manifest must list browser modules`,
+        );
+      } else {
+        assertEquals(
+          Object.keys(manifest.modules),
+          [],
+          `${templateName} has no client modules, so its manifest must list none`,
+        );
+      }
       assertEquals(
         manifest.css.length,
         1,

--- a/src/transforms/esm/import-attributes.ts
+++ b/src/transforms/esm/import-attributes.ts
@@ -49,6 +49,12 @@ function declaresJsonTypeOnly(clause: string, isDynamic: boolean): boolean {
   return attributes !== undefined && JSON_TYPE_ATTRIBUTE.test(attributes);
 }
 
+/** Whether one lexer-bounded import declares exactly the required JSON type attribute. */
+export function hasJsonTypeImportAttribute(code: string, imp: ImportSpecifier): boolean {
+  const { start, end } = attributeRange(imp);
+  return start < end && declaresJsonTypeOnly(code.slice(start, end), imp.d > -1);
+}
+
 /** Position of the legacy `assert` keyword this import uses, or `null`. */
 function findAssertKeyword(masked: string, imp: ImportSpecifier): number | null {
   if (imp.d === -1) {

--- a/src/transforms/esm/import-parser.test.ts
+++ b/src/transforms/esm/import-parser.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
-import { dirname, join } from "#veryfront/compat/path/index.ts";
+import { dirname, join, relative } from "#veryfront/compat/path/index.ts";
 import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { register, unregister } from "#veryfront/extensions/contracts.ts";
@@ -129,6 +129,218 @@ describe("transforms/esm/import-parser", () => {
           result.imports.map(({ specifier }) => specifier).sort(),
           ["../package.json", "@/data/site.json"],
         );
+      },
+    );
+  });
+
+  it("resolves explicit .mts and .cts imports", async () => {
+    await withProject(
+      {
+        "app/page.ts": [
+          'import { esmValue } from "./helper.mts";',
+          'import { cjsValue } from "./helper.cts";',
+          "export default esmValue + cjsValue;",
+        ].join("\n"),
+        "app/helper.mts": "export const esmValue = 1;",
+        "app/helper.cts": "export const cjsValue = 2;",
+      },
+      async (projectDir) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.ts");
+        const result = await parseLocalImports(
+          await Deno.readTextFile(filePath),
+          filePath,
+          projectDir,
+          adapter,
+        );
+
+        assertEquals(result.missing, []);
+        assertEquals(
+          result.imports.map((entry) => entry.specifier),
+          ["./helper.mts", "./helper.cts"],
+        );
+      },
+    );
+  });
+
+  it("resolves explicit Markdown imports", async () => {
+    await withProject(
+      {
+        "app/page.ts": 'import content from "./content.md"; export default content;',
+        "app/content.md": "# Content",
+      },
+      async (projectDir) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.ts");
+        const result = await parseLocalImports(
+          await Deno.readTextFile(filePath),
+          filePath,
+          projectDir,
+          adapter,
+        );
+
+        assertEquals(result.missing, []);
+        assertEquals(
+          result.imports.map(({ absolutePath }) => relative(projectDir, absolutePath)),
+          ["app/content.md"],
+        );
+      },
+    );
+  });
+
+  it("accepts legacy static and dynamic JSON assertions", async () => {
+    await withProject(
+      {
+        "app/page.ts": [
+          'import staticData from "./static.json" assert { type: "json" };',
+          'const dynamicData = import("./dynamic.json", { assert: { type: "json" } });',
+          "export default [staticData, dynamicData];",
+        ].join("\n"),
+        "app/static.json": '{"kind":"static"}',
+        "app/dynamic.json": '{"kind":"dynamic"}',
+      },
+      async (projectDir) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.ts");
+        const result = await parseLocalImports(
+          await Deno.readTextFile(filePath),
+          filePath,
+          projectDir,
+          adapter,
+        );
+
+        assertEquals(result.missing, []);
+        assertEquals(
+          result.imports.map((entry) => entry.specifier),
+          ["./static.json", "./dynamic.json"],
+        );
+      },
+    );
+  });
+
+  it("surfaces specifiers outside its resolution shapes as unresolved", async () => {
+    await withProject(
+      {
+        "app/page.tsx": [
+          `import A from "app/client-a.tsx";`,
+          `import B from "/app/client-b.tsx";`,
+          `import C from "/_vf_modules/app/client-c.tsx";`,
+          `import { useState } from "react";`,
+          `import type { Model } from "app/models.ts";`,
+          `export default () => [A, B, C, useState, null as unknown as Model];`,
+        ].join("\n"),
+      },
+      async (projectDir) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.tsx");
+        const result = await parseLocalImports(
+          await Deno.readTextFile(filePath),
+          filePath,
+          projectDir,
+          adapter,
+        );
+
+        // Project-root forms and bare packages are surfaced for callers with
+        // their own resolution semantics; the type-only edge is erased by the
+        // TypeScript pass and must not appear at all.
+        assertEquals(result.imports.length, 0);
+        assertEquals(result.missing.length, 0);
+        assertEquals(
+          [...result.unresolvedSpecifiers].sort(),
+          [
+            "/_vf_modules/app/client-c.tsx",
+            "/app/client-b.tsx",
+            "app/client-a.tsx",
+            "react",
+          ],
+        );
+      },
+    );
+  });
+
+  it("defers JSON classification for unresolved import-map alias keys", async () => {
+    await withProject(
+      {
+        "app/page.ts": 'import config from "config.json"; export default config;',
+      },
+      async (projectDir) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.ts");
+        const result = await parseLocalImports(
+          await Deno.readTextFile(filePath),
+          filePath,
+          projectDir,
+          adapter,
+        );
+
+        assertEquals(result.missing, []);
+        assertEquals(result.unresolvedImports, [{
+          specifier: "config.json",
+          hasJsonTypeAttribute: false,
+        }]);
+      },
+    );
+  });
+
+  it("resolves relative and @/ imports carrying query or fragment suffixes", async () => {
+    await withProject(
+      {
+        "app/page.tsx": [
+          `import Raw from "./client.tsx?raw";`,
+          `import Variant from "@/components/card.tsx#variant";`,
+          `export default () => [Raw, Variant];`,
+        ].join("\n"),
+        "app/client.tsx": `export default () => null;`,
+        "components/card.tsx": `export default () => null;`,
+      },
+      async (projectDir) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.tsx");
+        const result = await parseLocalImports(
+          await Deno.readTextFile(filePath),
+          filePath,
+          projectDir,
+          adapter,
+        );
+
+        // The suffix is not part of the file path (the canonical resolvers
+        // split it before touching the filesystem), so both files resolve;
+        // the authored specifier keeps its suffix in the record.
+        assertEquals(result.missing.length, 0);
+        assertEquals(
+          result.imports.map(({ specifier }) => specifier).sort(),
+          ["./client.tsx?raw", "@/components/card.tsx#variant"],
+        );
+        assertEquals(
+          result.imports.some((imp) => imp.absolutePath.endsWith("app/client.tsx")),
+          true,
+          "the query-suffixed relative import must resolve to the file",
+        );
+        assertEquals(
+          result.imports.some((imp) => imp.absolutePath.endsWith("components/card.tsx")),
+          true,
+          "the fragment-suffixed alias import must resolve to the file",
+        );
+      },
+    );
+  });
+
+  it("reports non-literal dynamic imports", async () => {
+    await withProject(
+      {
+        "app/page.tsx": 'const target = "./client.tsx"; export const load = () => import(target);',
+      },
+      async (projectDir) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.tsx");
+        const result = await parseLocalImports(
+          await Deno.readTextFile(filePath),
+          filePath,
+          projectDir,
+          adapter,
+        );
+
+        assertEquals(result.nonLiteralDynamicImports, 1);
       },
     );
   });
@@ -459,6 +671,7 @@ describe("transforms/esm/import-parser", () => {
     });
 
     assertEquals(importParserInternals.isFileUrlSpecifier(shadowed), true);
+    assertEquals(importParserInternals.isFileUrlSpecifier("FILE:///project/Child.tsx"), true);
   });
 
   it("preserves backslashes in POSIX file URL paths", () => {
@@ -877,6 +1090,192 @@ describe("transforms/esm/import-parser", () => {
             true,
             "the index ladder must find the directory entry point",
           );
+        },
+      );
+    } finally {
+      stub.restore();
+    }
+  });
+
+  it("resolves extensionless ESM and CommonJS server scripts", async () => {
+    await withProject(
+      {
+        "app/page.ts": [
+          `import "./helper";`,
+          `import "./legacy";`,
+          `import "./feature";`,
+        ].join("\n"),
+        "app/helper.mjs": `export const helper = true;`,
+        "app/legacy.cjs": `exports.legacy = true;`,
+        "app/feature/index.mjs": `export const feature = true;`,
+      },
+      async (projectDir) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.ts");
+        const result = await parseLocalImports(
+          await Deno.readTextFile(filePath),
+          filePath,
+          projectDir,
+          adapter,
+        );
+
+        assertEquals(result.missing, []);
+        assertEquals(
+          result.imports.map(({ absolutePath }) => relative(projectDir, absolutePath)),
+          ["app/helper.mjs", "app/legacy.cjs", "app/feature/index.mjs"],
+        );
+      },
+    );
+  });
+
+  it("uses runtime extension precedence for extensionless project imports", async () => {
+    await withProject(
+      {
+        "app/page.ts": `import "./helper";\nimport "@/lib/helper";`,
+        "app/helper.json": `{}`,
+        "app/helper.tsx": `export const helper = true;`,
+        "lib/helper.json": `{}`,
+        "lib/helper.tsx": `export const helper = true;`,
+      },
+      async (projectDir) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.ts");
+        const result = await parseLocalImports(
+          await Deno.readTextFile(filePath),
+          filePath,
+          projectDir,
+          adapter,
+        );
+
+        assertEquals(result.missing, []);
+        assertEquals(
+          result.imports.map(({ absolutePath, resolvedPath }) =>
+            relative(projectDir, resolvedPath ?? absolutePath)
+          ),
+          ["app/helper.tsx", "lib/helper.tsx"],
+        );
+      },
+    );
+  });
+
+  it("resolves JavaScript specifiers to TypeScript source files", async () => {
+    await withProject(
+      {
+        "app/page.ts": `import "./helper.js";\nimport "./view.js";`,
+        "app/helper.ts": `export const helper = true;`,
+        "app/view.tsx": `export const View = () => null;`,
+      },
+      async (projectDir) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.ts");
+        const result = await parseLocalImports(
+          await Deno.readTextFile(filePath),
+          filePath,
+          projectDir,
+          adapter,
+        );
+
+        assertEquals(result.missing, []);
+        assertEquals(
+          result.imports.map(({ absolutePath }) => relative(projectDir, absolutePath)),
+          ["app/helper.ts", "app/view.tsx"],
+        );
+      },
+    );
+  });
+
+  it("does not apply source fallback to an absent CommonJS specifier", async () => {
+    await withProject(
+      {
+        "app/page.ts": 'import "./helper.cjs";',
+        "app/helper.tsx": "export const helper = true;",
+      },
+      async (projectDir) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.ts");
+        const result = await parseLocalImports(
+          await Deno.readTextFile(filePath),
+          filePath,
+          projectDir,
+          adapter,
+        );
+
+        assertEquals(result.imports, []);
+        assertEquals(result.missing.map(({ specifier }) => specifier), ["./helper.cjs"]);
+      },
+    );
+  });
+
+  it("falls back across supported source suffixes", async () => {
+    await withProject(
+      {
+        "app/page.ts": 'import "./helper.jsx";',
+        "app/helper.tsx": "export const helper = true;",
+      },
+      async (projectDir) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.ts");
+        const result = await parseLocalImports(
+          await Deno.readTextFile(filePath),
+          filePath,
+          projectDir,
+          adapter,
+        );
+
+        assertEquals(result.missing, []);
+        assertEquals(result.imports.map(({ absolutePath }) => relative(projectDir, absolutePath)), [
+          "app/helper.tsx",
+        ]);
+      },
+    );
+  });
+
+  it("does not resolve JavaScript specifiers to JSON or MDX assets", async () => {
+    await withProject(
+      {
+        "app/page.ts": `import "./config.js";\nimport "@/content.js";`,
+        "app/config.json": `{ "enabled": true }`,
+        "content.mdx": `# Content`,
+      },
+      async (projectDir) => {
+        const adapter = await getLocalAdapter();
+        const filePath = join(projectDir, "app/page.ts");
+        const result = await parseLocalImports(
+          await Deno.readTextFile(filePath),
+          filePath,
+          projectDir,
+          adapter,
+        );
+
+        assertEquals(result.imports, []);
+        assertEquals(
+          result.missing.map(({ specifier }) => specifier),
+          ["./config.js", "@/content.js"],
+        );
+      },
+    );
+  });
+
+  it("does not resolve compiled MDX JavaScript specifiers to JSON assets", async () => {
+    const stub = withStubContentProcessor();
+    try {
+      await withProject(
+        {
+          "components/snippet.mdx": `import config from "./config.js";\n\n{config.enabled}`,
+          "components/config.json": `{ "enabled": true }`,
+        },
+        async (projectDir) => {
+          const adapter = await getLocalAdapter();
+          const filePath = join(projectDir, "components/snippet.mdx");
+          const result = await parseLocalImports(
+            await Deno.readTextFile(filePath),
+            filePath,
+            projectDir,
+            adapter,
+          );
+
+          assertEquals(result.imports, []);
+          assertEquals(result.missing.map(({ specifier }) => specifier), ["./config.js"]);
         },
       );
     } finally {

--- a/src/transforms/esm/import-parser.ts
+++ b/src/transforms/esm/import-parser.ts
@@ -17,9 +17,11 @@ import {
   resolveRelativeFrameworkSourceImport,
 } from "#veryfront/platform/compat/framework-source-resolver.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { splitSpecifierSuffix } from "#veryfront/transforms/shared/specifier-suffix.ts";
 import { isCrossProjectImport, parseCrossProjectImport } from "./path-resolver.ts";
-import { parseImports } from "./lexer.ts";
+import { parseMaskedImports } from "./lexer.ts";
 import { getLoaderFromPath } from "./transform-utils.ts";
+import { hasJsonTypeImportAttribute, upgradeImportAssertions } from "./import-attributes.ts";
 import { isCanonicalNotFoundError } from "#veryfront/platform/compat/not-found-error.ts";
 import { isNativeErrorWithoutHooks } from "#veryfront/platform/compat/error-introspection.ts";
 import { isWindowsPlatform } from "#veryfront/platform/compat/process/runtime-process.ts";
@@ -55,10 +57,69 @@ interface ParseLocalImportsResult {
   cssImports: LocalImport[];
   crossProjectImports: CrossProjectImport[];
   missing: MissingImport[];
+  /**
+   * Specifiers outside this parser's resolution shapes: bare package names,
+   * framework specifiers, and project-root forms such as `app/x.tsx`,
+   * `/app/x.tsx`, or `/_vf_modules/app/x.tsx`. They are surfaced, not
+   * resolved, so a caller with its own project-specifier semantics (the
+   * release asset build) can resolve them against its file set after the
+   * MDX compile and TypeScript pass have already removed type-only edges.
+   */
+  unresolvedSpecifiers: string[];
+  /** Attribute state retained for callers that resolve bare aliases later. */
+  unresolvedImports: Array<{ specifier: string; hasJsonTypeAttribute: boolean }>;
+  /** Dynamic import expressions whose target is not a string literal. */
+  nonLiteralDynamicImports: number;
 }
 
-const EXTENSIONS = [".tsx", ".ts", ".jsx", ".js", ".mdx"];
-const HAS_EXTENSION_RE = /\.(tsx?|jsx?|mjs|cjs|mdx|css|json)$/;
+const EXTENSIONS = [
+  ".tsx",
+  ".ts",
+  ".mts",
+  ".cts",
+  ".jsx",
+  ".js",
+  ".mjs",
+  ".cjs",
+  ".mdx",
+  ".md",
+];
+const JAVASCRIPT_SPECIFIER_FALLBACK_EXTENSIONS = [
+  ".tsx",
+  ".ts",
+  ".mts",
+  ".cts",
+  ".jsx",
+  ".js",
+  ".mjs",
+  ".cjs",
+] as const;
+const HAS_EXTENSION_RE = /\.(tsx?|jsx?|mjs|cjs|mts|cts|mdx?|css|json)$/;
+const JAVASCRIPT_SPECIFIER_EXTENSION_RE = /\.(?:mjs|js)$/;
+const SOURCE_SPECIFIER_EXTENSION_RE = /\.(?:tsx?|jsx?|mjs)$/;
+const JAVASCRIPT_SOURCE_EXTENSION_RE = /\.(?:tsx?|mts|cts|jsx?|mjs|cjs)$/;
+
+function fallbackExtensions(path: string): readonly string[] {
+  return regExpTest(JAVASCRIPT_SPECIFIER_EXTENSION_RE, path)
+    ? JAVASCRIPT_SPECIFIER_FALLBACK_EXTENSIONS
+    : EXTENSIONS;
+}
+
+function rejectJsonImportWithoutType(
+  candidatePath: string,
+  specifier: string,
+  fromFile: string,
+  hasJsonTypeAttribute: boolean,
+  missingImports: MissingImport[],
+): boolean {
+  if (!stringEndsWith(candidatePath, ".json") || hasJsonTypeAttribute) return false;
+  arrayPush(missingImports, {
+    specifier,
+    fromFile,
+    reason: 'JSON imports require with { type: "json" }',
+  });
+  return true;
+}
 
 // Tenant SSR code executes in this realm before later parses run, so the
 // containment decision must not dispatch through mutable prototype methods or
@@ -143,7 +204,7 @@ function joinProjectPath(root: string, path: string): string {
 }
 
 function isFileUrlSpecifier(value: string): boolean {
-  return stringStartsWith(value, "file://");
+  return regExpTest(/^file:\/\//i, value);
 }
 
 function indexedIterable<T>(values: readonly T[]): Iterable<T> {
@@ -215,7 +276,15 @@ export async function parseLocalImports(
     stringEndsWith(filePath, ".css") || stringEndsWith(filePath, ".json") ||
     regExpTest(/\.md$/i, filePath)
   ) {
-    return { imports: [], cssImports: [], crossProjectImports: [], missing: [] };
+    return {
+      imports: [],
+      cssImports: [],
+      crossProjectImports: [],
+      missing: [],
+      unresolvedSpecifiers: [],
+      unresolvedImports: [],
+      nonLiteralDynamicImports: 0,
+    };
   }
 
   // MDX is not JSX, so handing the raw source to esbuild under the `jsx` loader
@@ -227,6 +296,7 @@ export async function parseLocalImports(
   if (regExpTest(/\.mdx$/i, filePath)) {
     parseSource = await compileMdxForParsing(code, filePath, projectDir);
   }
+  parseSource = await upgradeImportAssertions(parseSource);
 
   const esbuild = await getEsbuild();
   const result = await esbuild.transform(parseSource, {
@@ -241,18 +311,25 @@ export async function parseLocalImports(
     keepNames: true,
   });
 
-  const imports = await parseImports(result.code);
+  const { masked, imports, unmask } = await parseMaskedImports(result.code);
   const localImports: LocalImport[] = [];
   const cssImports: LocalImport[] = [];
   const crossProjectImports: CrossProjectImport[] = [];
   const missingImports: MissingImport[] = [];
+  const unresolvedSpecifiers: string[] = [];
+  const unresolvedImports: Array<{ specifier: string; hasJsonTypeAttribute: boolean }> = [];
+  let nonLiteralDynamicImports = 0;
   const containment = createContainmentContext(projectDir, adapter);
 
   for (let importIndex = 0; importIndex < imports.length; importIndex++) {
     const imp = imports[importIndex]!;
-    const specifier = imp.n;
-    if (!specifier) continue;
+    const specifier = imp.n === undefined ? undefined : unmask(imp.n);
+    if (!specifier) {
+      if (imp.d >= 0) nonLiteralDynamicImports++;
+      continue;
+    }
 
+    const hasJsonTypeAttribute = hasJsonTypeImportAttribute(masked, imp);
     // The content compile above runs with the "server" target, which rewrites a
     // relative specifier to an absolute `file://` URL before the lexer ever
     // sees it. Without this branch those dependencies match none of the shapes
@@ -267,6 +344,17 @@ export async function parseLocalImports(
       const resolved = targetPath ? await resolveContainedFilePath(targetPath, containment) : null;
 
       if (resolved) {
+        if (
+          rejectJsonImportWithoutType(
+            resolved.requestedPath,
+            authoredSpecifier,
+            filePath,
+            hasJsonTypeAttribute,
+            missingImports,
+          )
+        ) {
+          continue;
+        }
         const entry = {
           specifier: authoredSpecifier,
           rewriteSpecifier: specifier,
@@ -286,14 +374,35 @@ export async function parseLocalImports(
       arrayPush(missingImports, {
         specifier: authoredSpecifier,
         fromFile: filePath,
-        reason: `File not found: tried extensions ${arrayJoin(EXTENSIONS, ", ")}`,
+        reason: `File not found: tried extensions ${
+          arrayJoin(fallbackExtensions(targetPath ?? authoredSpecifier), ", ")
+        }`,
       });
       continue;
     }
 
     if (stringStartsWith(specifier, "./") || stringStartsWith(specifier, "../")) {
-      const resolved = await resolveLocalImportPath(filePath, specifier, adapter);
+      // A query or fragment (`./Client.tsx?raw`, `./Icon.svg#glyph`) is not
+      // part of the file path. The canonical resolvers split it off before
+      // touching the filesystem (see splitSpecifierSuffix), so probing with it
+      // attached would report an existing file as missing.
+      const resolved = await resolveLocalImportPath(
+        filePath,
+        splitSpecifierSuffix(specifier).path,
+        adapter,
+      );
       if (resolved) {
+        if (
+          rejectJsonImportWithoutType(
+            resolved,
+            specifier,
+            filePath,
+            hasJsonTypeAttribute,
+            missingImports,
+          )
+        ) {
+          continue;
+        }
         if (stringEndsWith(resolved, ".css")) {
           arrayPush(cssImports, { specifier, absolutePath: resolved });
         } else {
@@ -305,15 +414,30 @@ export async function parseLocalImports(
       arrayPush(missingImports, {
         specifier,
         fromFile: filePath,
-        reason: `File not found: tried extensions ${arrayJoin(EXTENSIONS, ", ")}`,
+        reason: `File not found: tried extensions ${
+          arrayJoin(fallbackExtensions(splitSpecifierSuffix(specifier).path), ", ")
+        }`,
       });
       continue;
     }
 
     if (stringStartsWith(specifier, "@/")) {
-      const aliasPath = stringSlice(specifier, 2);
+      // Same suffix rule as the relative branch: resolve the path, keep the
+      // authored specifier (suffix included) in the reported records.
+      const aliasPath = splitSpecifierSuffix(stringSlice(specifier, 2)).path;
       const resolved = await resolveAliasImportPath(aliasPath, containment);
       if (resolved) {
+        if (
+          rejectJsonImportWithoutType(
+            resolved.requestedPath,
+            specifier,
+            filePath,
+            hasJsonTypeAttribute,
+            missingImports,
+          )
+        ) {
+          continue;
+        }
         const entry = {
           specifier,
           absolutePath: resolved.absolutePath,
@@ -334,20 +458,43 @@ export async function parseLocalImports(
       continue;
     }
 
-    if (!isCrossProjectImport(specifier)) continue;
+    if (isCrossProjectImport(specifier)) {
+      const parsed = parseCrossProjectImport(specifier);
+      if (!parsed) continue;
+      if (
+        rejectJsonImportWithoutType(
+          splitSpecifierSuffix(parsed.path).path,
+          specifier,
+          filePath,
+          hasJsonTypeAttribute,
+          missingImports,
+        )
+      ) {
+        continue;
+      }
 
-    const parsed = parseCrossProjectImport(specifier);
-    if (!parsed) continue;
+      arrayPush(crossProjectImports, {
+        specifier,
+        projectSlug: parsed.projectSlug,
+        version: parsed.version,
+        path: parsed.path,
+      });
+      continue;
+    }
 
-    arrayPush(crossProjectImports, {
-      specifier,
-      projectSlug: parsed.projectSlug,
-      version: parsed.version,
-      path: parsed.path,
-    });
+    arrayPush(unresolvedSpecifiers, specifier);
+    arrayPush(unresolvedImports, { specifier, hasJsonTypeAttribute });
   }
 
-  return { imports: localImports, cssImports, crossProjectImports, missing: missingImports };
+  return {
+    imports: localImports,
+    cssImports,
+    crossProjectImports,
+    missing: missingImports,
+    unresolvedSpecifiers,
+    unresolvedImports,
+    nonLiteralDynamicImports,
+  };
 }
 
 function isPathWithinProject(path: string, projectDir: string): boolean {
@@ -610,17 +757,25 @@ async function resolveExistingFilePath(
     }
   }
 
-  if (regExpTest(HAS_EXTENSION_RE, basePath)) {
-    return (await checkFileExists(basePath, adapter)) ? basePath : null;
-  }
+  const hasExtension = regExpTest(HAS_EXTENSION_RE, basePath);
+  if (hasExtension && await checkFileExists(basePath, adapter)) return basePath;
+  if (hasExtension && !regExpTest(SOURCE_SPECIFIER_EXTENSION_RE, basePath)) return null;
 
-  for (let extensionIndex = 0; extensionIndex < EXTENSIONS.length; extensionIndex++) {
-    const candidate = basePath + EXTENSIONS[extensionIndex]!;
+  const sourceSpecifier = regExpTest(SOURCE_SPECIFIER_EXTENSION_RE, basePath);
+  const probeBasePath = sourceSpecifier
+    ? stringReplace(basePath, SOURCE_SPECIFIER_EXTENSION_RE, "")
+    : basePath;
+  const extensions = sourceSpecifier
+    ? JAVASCRIPT_SPECIFIER_FALLBACK_EXTENSIONS
+    : fallbackExtensions(basePath);
+
+  for (let extensionIndex = 0; extensionIndex < extensions.length; extensionIndex++) {
+    const candidate = probeBasePath + extensions[extensionIndex]!;
     if (await checkFileExists(candidate, adapter)) return candidate;
   }
 
-  for (let extensionIndex = 0; extensionIndex < EXTENSIONS.length; extensionIndex++) {
-    const candidate = `${basePath}/index${EXTENSIONS[extensionIndex]!}`;
+  for (let extensionIndex = 0; extensionIndex < extensions.length; extensionIndex++) {
+    const candidate = `${probeBasePath}/index${extensions[extensionIndex]!}`;
     if (await checkFileExists(candidate, adapter)) return candidate;
   }
 
@@ -634,12 +789,16 @@ async function resolveAliasImportPath(
   const normalizedPath = stringReplace(basePath, /^\/+/, "");
   const lexicalPath = joinProjectPath(containment.projectDir, normalizedPath);
   if (!isPathWithinProject(lexicalPath, containment.projectDir)) return null;
+  const javascriptSpecifier = regExpTest(JAVASCRIPT_SPECIFIER_EXTENSION_RE, normalizedPath);
 
   const adapter = containment.adapter;
   if (adapter?.fs.resolveFile) {
     try {
       const resolved = await adapter.fs.resolveFile(normalizedPath);
-      if (resolved) {
+      if (
+        resolved &&
+        (!javascriptSpecifier || regExpTest(JAVASCRIPT_SOURCE_EXTENSION_RE, resolved))
+      ) {
         return await toContainedImportPath(
           resolved,
           containment,
@@ -652,23 +811,30 @@ async function resolveAliasImportPath(
     }
   }
 
-  if (regExpTest(HAS_EXTENSION_RE, normalizedPath)) {
-    return await resolveContainedFilePath(lexicalPath, containment);
+  const hasExtension = regExpTest(HAS_EXTENSION_RE, normalizedPath);
+  if (hasExtension) {
+    const exact = await resolveContainedFilePath(lexicalPath, containment);
+    if (exact !== null) return exact;
+    if (!javascriptSpecifier) return null;
   }
 
+  const probePath = javascriptSpecifier
+    ? stringReplace(normalizedPath, JAVASCRIPT_SPECIFIER_EXTENSION_RE, "")
+    : normalizedPath;
+  const extensions = fallbackExtensions(normalizedPath);
   const candidates: string[] = [];
-  for (let extensionIndex = 0; extensionIndex < EXTENSIONS.length; extensionIndex++) {
+  for (let extensionIndex = 0; extensionIndex < extensions.length; extensionIndex++) {
     arrayPush(
       candidates,
-      joinProjectPath(containment.projectDir, normalizedPath + EXTENSIONS[extensionIndex]!),
+      joinProjectPath(containment.projectDir, probePath + extensions[extensionIndex]!),
     );
   }
-  for (let extensionIndex = 0; extensionIndex < EXTENSIONS.length; extensionIndex++) {
+  for (let extensionIndex = 0; extensionIndex < extensions.length; extensionIndex++) {
     arrayPush(
       candidates,
       joinProjectPath(
-        joinProjectPath(containment.projectDir, normalizedPath),
-        "index" + EXTENSIONS[extensionIndex]!,
+        joinProjectPath(containment.projectDir, probePath),
+        "index" + extensions[extensionIndex]!,
       ),
     );
   }

--- a/src/transforms/esm/transform-utils.test.ts
+++ b/src/transforms/esm/transform-utils.test.ts
@@ -8,6 +8,8 @@ describe("transforms/esm/transform-utils", () => {
     const cases: Array<[string, string]> = [
       ["pages/index.tsx", "tsx"],
       ["utils/helper.ts", "ts"],
+      ["utils/helper.mts", "ts"],
+      ["utils/helper.cts", "ts"],
       ["schemas/lazy.ts.src", "ts"],
       ["components/Button.jsx", "jsx"],
       ["lib/main.js", "js"],

--- a/src/transforms/esm/transform-utils.ts
+++ b/src/transforms/esm/transform-utils.ts
@@ -33,6 +33,8 @@ export const ESBUILD_SUPPORTED_FEATURES = {
 const EXTENSION_LOADERS: Record<string, Loader> = {
   ".tsx": "tsx",
   ".ts": "ts",
+  ".mts": "ts",
+  ".cts": "ts",
   ".jsx": "jsx",
   ".js": "js",
   ".mdx": "jsx",

--- a/src/transforms/import-rewriter/strategies/import-map-strategy.test.ts
+++ b/src/transforms/import-rewriter/strategies/import-map-strategy.test.ts
@@ -90,6 +90,16 @@ describe("transforms/import-rewriter/strategies/import-map-strategy", () => {
       assertEquals(resolveImportWithMap("lodash/fp", map), "/_vf_modules/lodash/fp");
     });
 
+    it("uses the longest overlapping prefix regardless of insertion order", () => {
+      const map: ImportMapConfig = {
+        imports: {
+          "#/": "/short/",
+          "#/nested/": "/long/",
+        },
+      };
+      assertEquals(resolveImportWithMap("#/nested/client.ts", map), "/long/client.ts");
+    });
+
     it("resolves scoped exact match", () => {
       const map: ImportMapConfig = {
         imports: {},

--- a/src/transforms/import-rewriter/strategies/import-map-strategy.ts
+++ b/src/transforms/import-rewriter/strategies/import-map-strategy.ts
@@ -44,13 +44,28 @@ export function resolveImportWithMap(
   const imports = importMap.imports;
   if (!imports) return null;
 
+  let prefixMatch: { key: string; value: string } | undefined;
   for (const [key, value] of Object.entries(imports)) {
-    if (key.endsWith("/") && specifier.startsWith(key)) {
-      return value + specifier.slice(key.length);
+    if (
+      key.endsWith("/") && specifier.startsWith(key) &&
+      (prefixMatch === undefined || key.length > prefixMatch.key.length)
+    ) {
+      prefixMatch = { key, value };
     }
+  }
+  if (prefixMatch !== undefined) {
+    return prefixMatch.value + specifier.slice(prefixMatch.key.length);
   }
 
   return null;
+}
+
+export function isRuntimeImportMapSpecifier(specifier: string): boolean {
+  const isBare = !specifier.startsWith("http") &&
+    !specifier.startsWith("/") &&
+    !specifier.startsWith(".");
+
+  return isBare || isEsmShUrl(specifier);
 }
 
 export class ImportMapStrategy implements ImportRewriteStrategy {
@@ -59,12 +74,7 @@ export class ImportMapStrategy implements ImportRewriteStrategy {
 
   matches(specifier: string, ctx: RewriteContext): boolean {
     if (ctx.target !== "ssr" || !ctx.importMap) return false;
-
-    const isBare = !specifier.startsWith("http") &&
-      !specifier.startsWith("/") &&
-      !specifier.startsWith(".");
-
-    return isBare || isEsmShUrl(specifier);
+    return isRuntimeImportMapSpecifier(specifier);
   }
 
   rewrite(info: ImportSpecifierInfo, ctx: RewriteContext): RewriteResult {

--- a/src/transforms/mdx/esm-module-loader/utils/source-spans.test.ts
+++ b/src/transforms/mdx/esm-module-loader/utils/source-spans.test.ts
@@ -305,6 +305,33 @@ describe("transforms/mdx/esm-module-loader/utils/source-spans", () => {
       );
     });
 
+    it("classifies declarations that contain only type edges", () => {
+      const spans = findStaticImportFromSpans(
+        'import type Styles from "./import-type.css"; ' +
+          'export type { Classes } from "./export-type.css"; ' +
+          'import { type Tokens } from "./inline-type.css"; ' +
+          'import { type Tokens as Types, value } from "./mixed.css"; ' +
+          'import { type as value } from "./type-binding.css"; ' +
+          'import type, { value as other } from "./type-default.css"; ' +
+          'import type from "./type-named-default.css";',
+        matchRelative,
+        UNBOUNDED,
+      );
+
+      assertEquals(
+        spans.map(({ path, typeOnly }) => ({ path, typeOnly })),
+        [
+          { path: "./import-type.css", typeOnly: true },
+          { path: "./export-type.css", typeOnly: true },
+          { path: "./inline-type.css", typeOnly: true },
+          { path: "./mixed.css", typeOnly: false },
+          { path: "./type-binding.css", typeOnly: false },
+          { path: "./type-default.css", typeOnly: false },
+          { path: "./type-named-default.css", typeOnly: false },
+        ],
+      );
+    });
+
     it("finds static imports after top-level block declarations", () => {
       assertEquals(
         findStaticImportFromSpans(

--- a/src/transforms/mdx/esm-module-loader/utils/source-spans.ts
+++ b/src/transforms/mdx/esm-module-loader/utils/source-spans.ts
@@ -18,6 +18,8 @@ export interface StaticImportSpan {
   path: string;
   start: number;
   end: number;
+  /** Whether TypeScript erases the complete static import or export edge. */
+  typeOnly?: boolean;
 }
 
 type SpecifierMatcher = (specifier: string) => string | null | undefined;
@@ -2340,6 +2342,54 @@ function canExportHaveFromClause(source: string, statementStart: number): boolea
   return source[cursor] === "*" || source[cursor] === "{";
 }
 
+function tokenAt(source: string, index: number, token: string): boolean {
+  return source.startsWith(token, index) &&
+    !isIdentifierPartAt(source, index - 1) &&
+    !isIdentifierPartAt(source, index + token.length);
+}
+
+/** Whether a static module clause contains no runtime binding or side effect. */
+function isTypeOnlyModuleClause(source: string, start: number, end: number): boolean {
+  let cursor = skipWhitespaceAndComments(source, start);
+  if (tokenAt(source, cursor, "type")) {
+    cursor = skipWhitespaceAndComments(source, cursor + "type".length);
+    return cursor < end && source[cursor] !== "," && !tokenAt(source, cursor, "as") &&
+      !tokenAt(source, cursor, "from");
+  }
+  if (source[cursor] !== "{") return false;
+  cursor++;
+
+  let foundTypeSpecifier = false;
+  while (cursor < end) {
+    cursor = skipWhitespaceAndComments(source, cursor);
+    if (source[cursor] === "}") return foundTypeSpecifier;
+    if (!tokenAt(source, cursor, "type")) return false;
+    cursor = skipWhitespaceAndComments(source, cursor + "type".length);
+    if (
+      cursor >= end || source[cursor] === "," || source[cursor] === "}" ||
+      tokenAt(source, cursor, "as")
+    ) {
+      return false;
+    }
+    foundTypeSpecifier = true;
+
+    while (cursor < end) {
+      const skipped = skipIgnored(source, cursor);
+      if (skipped !== cursor) {
+        cursor = skipped;
+        continue;
+      }
+      if (source[cursor] === ",") {
+        cursor++;
+        break;
+      }
+      if (source[cursor] === "}") return true;
+      cursor++;
+    }
+  }
+  return false;
+}
+
 /**
  * Validate the match bound every scanner requires.
  *
@@ -2532,7 +2582,10 @@ export function findStaticImportFromSpans(
 
     const span = findFromSpan(source, afterKeyword, matcher, isExport);
     if (span) {
-      spans.push(span);
+      spans.push({
+        ...span,
+        typeOnly: isTypeOnlyModuleClause(source, afterKeyword, span.start),
+      });
       if (spans.length >= maxMatches) return spans;
       atStatementStart = false;
       previousTokenIndex = span.end - 1;

--- a/src/transforms/pipeline/stages/ssr-css-strip.test.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.test.ts
@@ -162,6 +162,23 @@ describe("css-strip plugin", () => {
     }
   });
 
+  it("strips CSS imports carrying query and fragment suffixes", async () => {
+    const ctx = createContext(
+      'import "./theme.css?inline"; import styles from "./Button.module.css#release"; ' +
+        "export const cls = styles.container;",
+    );
+
+    const result = await cssStripPlugin.transform(ctx);
+    const namespace = await evaluateModule(result);
+
+    assertEquals(result.includes("import "), false);
+    assertEquals(namespace.cls, toScopedCssModuleClass(MODULE_KEY, "container"));
+    assertEquals(ctx.metadata.get("cssImports"), [
+      "./Button.module.css#release",
+      "./theme.css?inline",
+    ]);
+  });
+
   it("keeps a css re-export exporting the bindings it re-exported", async () => {
     const ctx = createContext(
       `export { default as styles, container as root } from "./Button.module.css";`,

--- a/src/transforms/pipeline/stages/ssr-css-strip.ts
+++ b/src/transforms/pipeline/stages/ssr-css-strip.ts
@@ -17,6 +17,7 @@
 import type { TransformPlugin } from "../types.ts";
 import { TransformStage } from "../types.ts";
 import { parseImports, rewriteImports } from "../../esm/lexer.ts";
+import { splitSpecifierSuffix } from "#veryfront/transforms/shared/specifier-suffix.ts";
 import { defineError } from "#veryfront/errors";
 import {
   getCssModuleScope,
@@ -33,11 +34,11 @@ const CSS_COMMENT_MASK_SENTINEL_EXHAUSTED = defineError({
 });
 
 function isCSSImport(specifier: string | undefined): boolean {
-  return specifier?.endsWith(".css") || false;
+  return specifier !== undefined && splitSpecifierSuffix(specifier).path.endsWith(".css");
 }
 
 function isCssModuleImport(specifier: string | undefined): boolean {
-  return specifier?.endsWith(".module.css") || false;
+  return specifier !== undefined && splitSpecifierSuffix(specifier).path.endsWith(".module.css");
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Close a confidentiality gap where App Router `app/**/page.*` and `app/**/layout.*` server components could be transformed and published as browser release assets without requiring `"use client"`.

### Description
- Require App Router modules to opt into the client boundary by checking `hasUseClientDirective` and rejecting `hasUseServerDirective` before transforming for browser release assets in `src/release-assets/build-executor.ts`.
- For server-only App Router modules, parse and record their imports but do not transform or publish those server modules, preserving discovery of reachable client components via a `serverModuleImports` map used during closure collection. 
- Filter route closures so published manifest route module lists contain only successfully transformed client modules and not server modules. 
- Update `src/release-assets/build-executor.test.ts` to mark App Router pages/layouts as client when intended and add a regression test that verifies a server page and its private server import are excluded from the manifest while a reachable `use client` component is published.

### Testing
- Ran `git diff --check` which passed without issues. 
- Updated and added tests in `src/release-assets/build-executor.test.ts` to cover the new trust boundary and regression scenario, but could not execute `deno` tests in this environment because `deno` is not installed and `npx -y deno@2.5.6` failed with an HTTP 403 from the package registry; local/CI execution of `deno test --no-check --allow-all src/release-assets/build-executor.test.ts` is recommended to validate.
- Committed changes and created the PR titled as above; please run the repository's usual Deno test matrix in CI to confirm all suites pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fa898b5d0832db42ac47230470daa)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved release builds for App Router projects using server and client components.
  - Added support for import-map aliases, recursive mappings, and more accurate alias resolution.
  - Expanded support for JavaScript, TypeScript, JSX, MDX, Markdown, JSON, and CommonJS modules.
  - Added support for modern TypeScript extensions and enhanced CSS import detection.
- **Bug Fixes**
  - Isolated failures to affected routes during builds.
  - Improved browser-boundary and JSON import validation.
  - Preserved query strings and fragments when resolving imports.
  - Ensured the most specific import-map mapping takes precedence.
  - Corrected handling of type-only imports and file URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->