### PR TITLE
fix(security): contain RSC app directory paths

### DIFF
--- a/src/rendering/rsc/component-analyzer.test.ts
+++ b/src/rendering/rsc/component-analyzer.test.ts
@@ -16,6 +16,7 @@ function createMockFs(files: Map<string, string>): FileSystemAdapter {
   };
 
   return {
+    symlinkSemantics: "none",
     readFile,
     writeFile: () => Promise.resolve(),
     exists: (path: string) => Promise.resolve(files.has(path)),
@@ -246,6 +247,82 @@ describe("rendering/rsc/component-analyzer", () => {
   });
 
   describe("buildClientManifest", () => {
+    it("does not scan a configured app directory outside the project", async () => {
+      let scanned = false;
+      const fs = createMockFs(new Map());
+      fs.readDir = () => {
+        scanned = true;
+        return (async function* () {})();
+      };
+
+      const manifest = await buildClientManifest("/project", "../sibling/app", fs);
+
+      assertEquals(manifest.size, 0);
+      assertEquals(scanned, false);
+    });
+
+    it("does not scan an in-project app symlink whose target escapes the project", async () => {
+      let scanned = false;
+      const fs = createMockFs(new Map());
+      delete (fs as { symlinkSemantics?: "none" }).symlinkSemantics;
+      fs.realPath = (path) =>
+        Promise.resolve(path === "/project" ? "/canonical/project" : "/outside/app");
+      fs.readDir = () => {
+        scanned = true;
+        return (async function* () {})();
+      };
+
+      const manifest = await buildClientManifest("/project", "app", fs);
+
+      assertEquals(manifest.size, 0);
+      assertEquals(scanned, false);
+    });
+
+    it("scans a contained app directory on a virtual adapter without realPath", async () => {
+      const filePath = "/project/app/Button.tsx";
+      const fs = createMockFs(
+        new Map([
+          [filePath, `'use client';\nexport default function Button() {}`],
+        ]),
+      );
+      // Virtual/remote adapters may omit both markers and realPath entirely;
+      // lexical containment must then be sufficient.
+      delete (fs as { symlinkSemantics?: "none" }).symlinkSemantics;
+      fs.readDir = (path) =>
+        (async function* () {
+          if (path === "/project/app") {
+            yield { name: "Button.tsx", isFile: true, isDirectory: false, isSymlink: false };
+          }
+        })();
+
+      const manifest = await buildClientManifest("/project", "app", fs);
+
+      assertEquals(manifest.get("Button")?.rel, "app/Button.tsx");
+    });
+
+    it("keeps lexical manifest paths after canonical containment succeeds", async () => {
+      const filePath = "/project/app/Button.tsx";
+      const fs = createMockFs(
+        new Map([
+          [filePath, `'use client';\nexport default function Button() {}`],
+        ]),
+      );
+      delete (fs as { symlinkSemantics?: "none" }).symlinkSemantics;
+      fs.realPath = (path) =>
+        Promise.resolve(path === "/project" ? "/canonical/project" : "/canonical/project/app");
+      fs.readDir = (path) =>
+        (async function* () {
+          if (path === "/project/app") {
+            yield { name: "Button.tsx", isFile: true, isDirectory: false, isSymlink: false };
+          }
+        })();
+
+      const manifest = await buildClientManifest("/project", "app", fs);
+
+      assertEquals(manifest.get("Button")?.sourcePath, filePath);
+      assertEquals(manifest.get("Button")?.rel, "app/Button.tsx");
+    });
+
     it("fails explicitly when different paths produce the same component ID", async () => {
       const files = new Map([
         [

--- a/src/rendering/rsc/component-analyzer.test.ts
+++ b/src/rendering/rsc/component-analyzer.test.ts
@@ -278,15 +278,13 @@ describe("rendering/rsc/component-analyzer", () => {
       assertEquals(scanned, false);
     });
 
-    it("scans a contained app directory on a virtual adapter without realPath", async () => {
+    it("does not scan with an adapter that lacks containment authority", async () => {
       const filePath = "/project/app/Button.tsx";
       const fs = createMockFs(
         new Map([
           [filePath, `'use client';\nexport default function Button() {}`],
         ]),
       );
-      // Virtual/remote adapters may omit both markers and realPath entirely;
-      // lexical containment must then be sufficient.
       delete (fs as { symlinkSemantics?: "none" }).symlinkSemantics;
       fs.readDir = (path) =>
         (async function* () {
@@ -297,6 +295,29 @@ describe("rendering/rsc/component-analyzer", () => {
 
       const manifest = await buildClientManifest("/project", "app", fs);
 
+      assertEquals(manifest.size, 0);
+    });
+
+    it("keeps relative paths for a symlink-free virtual adapter", async () => {
+      const filePath = "app/Button.tsx";
+      const fs = createMockFs(
+        new Map([
+          [filePath, `'use client';\nexport default function Button() {}`],
+        ]),
+      );
+      const scannedPaths: string[] = [];
+      fs.readDir = (path) =>
+        (async function* () {
+          scannedPaths.push(path);
+          if (path === "app") {
+            yield { name: "Button.tsx", isFile: true, isDirectory: false, isSymlink: false };
+          }
+        })();
+
+      const manifest = await buildClientManifest(".", "app", fs);
+
+      assertEquals(scannedPaths, ["app"]);
+      assertEquals(manifest.get("Button")?.sourcePath, filePath);
       assertEquals(manifest.get("Button")?.rel, "app/Button.tsx");
     });
 

--- a/src/rendering/rsc/component-analyzer.ts
+++ b/src/rendering/rsc/component-analyzer.ts
@@ -62,14 +62,15 @@ export async function buildClientManifest(
   const manifest = new Map<string, ClientComponentMeta>();
   const projectRoot = resolve(projectDir);
   const normalizedAppDir = appDir.replace(/^\/+|\/+$/g, "") || "app";
-  const appPath = resolve(projectRoot, normalizedAppDir);
-  if (!isWithinDirectory(projectRoot, appPath)) return manifest;
+  const appPath = join(projectDir, normalizedAppDir);
+  const absoluteAppPath = resolve(projectRoot, normalizedAppDir);
+  if (!isWithinDirectory(projectRoot, absoluteAppPath)) return manifest;
 
   const fsAdapter = fs ?? (await getFsAdapter());
   if (!fsAdapter) return manifest;
 
   try {
-    if (!await isCanonicallyContainedAppRoot(projectRoot, appPath, fsAdapter)) {
+    if (!await isCanonicallyContainedAppRoot(projectDir, appPath, fsAdapter)) {
       return manifest;
     }
 
@@ -81,7 +82,7 @@ export async function buildClientManifest(
         const analysis = await analyzeComponent(filePath, fsAdapter);
         if (analysis.type !== "client") return;
 
-        const relativePath = relative(projectRoot, filePath);
+        const relativePath = relative(projectDir, filePath);
         const normalizedRelativePath = relativePath.replaceAll("\\", "/");
         const existing = manifest.get(analysis.id);
         if (existing && existing.rel !== normalizedRelativePath) {
@@ -113,10 +114,8 @@ export async function buildClientManifest(
 
 /**
  * Confirm the lexically contained app root stays inside the project once
- * symlinks are resolved. Adapters that declare `symlinkSemantics: "none"` or
- * omit `realPath` are virtual/symlink-free by the FileSystemAdapter contract
- * (native/local adapters must provide `realPath`), so lexical containment —
- * already verified by the caller — is sufficient for them.
+ * symlinks are resolved. An adapter must either declare
+ * `symlinkSemantics: "none"` or provide canonical paths.
  */
 async function isCanonicallyContainedAppRoot(
   projectRoot: string,
@@ -127,7 +126,7 @@ async function isCanonicallyContainedAppRoot(
   if (semantics && "value" in semantics && semantics.value === "none") return true;
 
   const realPath = fsAdapter.realPath?.bind(fsAdapter);
-  if (!realPath) return true;
+  if (!realPath) return false;
 
   try {
     const [canonicalProjectRoot, canonicalAppPath] = await Promise.all([

--- a/src/rendering/rsc/component-analyzer.ts
+++ b/src/rendering/rsc/component-analyzer.ts
@@ -1,4 +1,4 @@
-import { join, relative } from "#veryfront/compat/path/index.ts";
+import { join, relative, resolve } from "#veryfront/compat/path/index.ts";
 import { isNotFoundError } from "#veryfront/platform/compat/fs.ts";
 import { serverLogger } from "#veryfront/utils";
 import { capitalizeSeparatedWords } from "#veryfront/utils/case-utils.ts";
@@ -10,6 +10,7 @@ import { createError, toError } from "#veryfront/errors";
 import { extractExportNames } from "./export-extractor.ts";
 import { shortHash } from "#veryfront/utils/hash-utils.ts";
 import { hasClientFileName, hasUseClientDirective, hasUseServerDirective } from "./page-island.ts";
+import { isWithinDirectory } from "#veryfront/security/path-validation.ts";
 
 class DuplicateClientComponentIdError extends Error {}
 
@@ -59,12 +60,19 @@ export async function buildClientManifest(
   fs?: FileSystemAdapter,
 ): Promise<Map<string, ClientComponentMeta>> {
   const manifest = new Map<string, ClientComponentMeta>();
-  const appPath = join(projectDir, appDir);
+  const projectRoot = resolve(projectDir);
+  const normalizedAppDir = appDir.replace(/^\/+|\/+$/g, "") || "app";
+  const appPath = resolve(projectRoot, normalizedAppDir);
+  if (!isWithinDirectory(projectRoot, appPath)) return manifest;
 
   const fsAdapter = fs ?? (await getFsAdapter());
   if (!fsAdapter) return manifest;
 
   try {
+    if (!await isCanonicallyContainedAppRoot(projectRoot, appPath, fsAdapter)) {
+      return manifest;
+    }
+
     await walkDirectory(
       appPath,
       async (filePath) => {
@@ -73,7 +81,7 @@ export async function buildClientManifest(
         const analysis = await analyzeComponent(filePath, fsAdapter);
         if (analysis.type !== "client") return;
 
-        const relativePath = relative(projectDir, filePath);
+        const relativePath = relative(projectRoot, filePath);
         const normalizedRelativePath = relativePath.replaceAll("\\", "/");
         const existing = manifest.get(analysis.id);
         if (existing && existing.rel !== normalizedRelativePath) {
@@ -101,6 +109,40 @@ export async function buildClientManifest(
   }
 
   return manifest;
+}
+
+/**
+ * Confirm the lexically contained app root stays inside the project once
+ * symlinks are resolved. Adapters that declare `symlinkSemantics: "none"` or
+ * omit `realPath` are virtual/symlink-free by the FileSystemAdapter contract
+ * (native/local adapters must provide `realPath`), so lexical containment —
+ * already verified by the caller — is sufficient for them.
+ */
+async function isCanonicallyContainedAppRoot(
+  projectRoot: string,
+  appPath: string,
+  fsAdapter: FileSystemAdapter,
+): Promise<boolean> {
+  const semantics = Object.getOwnPropertyDescriptor(fsAdapter, "symlinkSemantics");
+  if (semantics && "value" in semantics && semantics.value === "none") return true;
+
+  const realPath = fsAdapter.realPath?.bind(fsAdapter);
+  if (!realPath) return true;
+
+  try {
+    const [canonicalProjectRoot, canonicalAppPath] = await Promise.all([
+      realPath(projectRoot),
+      realPath(appPath),
+    ]);
+    return isWithinDirectory(canonicalProjectRoot, canonicalAppPath);
+  } catch (error) {
+    // A missing app directory yields an empty manifest either way; any other
+    // canonicalization failure fails closed.
+    if (!isNotFoundError(error)) {
+      serverLogger.warn(`Failed to canonicalize app directory:`, error);
+    }
+    return false;
+  }
 }
 
 async function getFsAdapter(): Promise<FileSystemAdapter | undefined> {

--- a/src/server/services/rsc/orchestrators/component-resolver.test.ts
+++ b/src/server/services/rsc/orchestrators/component-resolver.test.ts
@@ -6,6 +6,7 @@ import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
 
 function createMockFs(existingFiles: Set<string>): FileSystemAdapter {
   return {
+    symlinkSemantics: "none",
     stat: async (path: string) => {
       if (existingFiles.has(path)) {
         return { isFile: true, isDirectory: false, size: 100 };
@@ -101,6 +102,34 @@ describe("server/services/rsc/orchestrators/component-resolver", () => {
       const fs = createMockFs(new Set(["/project/frontend/about/page.tsx"]));
       const result = await resolveComponentPath("/about", "/project", fs, "frontend");
       assertEquals(result, "/project/frontend/about/page.tsx");
+    });
+
+    it("does not resolve routes from a configured app directory outside the project", async () => {
+      const fs = createMockFs(new Set(["/sibling/app/page.tsx"]));
+      const result = await resolveComponentPath("/", "/project", fs, "../sibling/app");
+      assertEquals(result, null);
+    });
+
+    it("resolves contained routes on a virtual adapter without realPath", async () => {
+      const fs = createMockFs(new Set(["/project/app/page.tsx"]));
+      // Virtual/remote adapters may omit both markers and realPath entirely;
+      // lexical containment must then be sufficient.
+      delete (fs as { symlinkSemantics?: "none" }).symlinkSemantics;
+
+      const result = await resolveComponentPath("/", "/project", fs);
+
+      assertEquals(result, "/project/app/page.tsx");
+    });
+
+    it("does not resolve a lexical route whose canonical target escapes the project", async () => {
+      const fs = createMockFs(new Set(["/project/app/page.tsx"]));
+      delete (fs as { symlinkSemantics?: "none" }).symlinkSemantics;
+      fs.realPath = (path) =>
+        Promise.resolve(path === "/project" ? "/canonical/project" : "/outside/page.tsx");
+
+      const result = await resolveComponentPath("/", "/project", fs);
+
+      assertEquals(result, null);
     });
   });
 

--- a/src/server/services/rsc/orchestrators/component-resolver.test.ts
+++ b/src/server/services/rsc/orchestrators/component-resolver.test.ts
@@ -110,15 +110,21 @@ describe("server/services/rsc/orchestrators/component-resolver", () => {
       assertEquals(result, null);
     });
 
-    it("resolves contained routes on a virtual adapter without realPath", async () => {
+    it("does not resolve with an adapter that lacks containment authority", async () => {
       const fs = createMockFs(new Set(["/project/app/page.tsx"]));
-      // Virtual/remote adapters may omit both markers and realPath entirely;
-      // lexical containment must then be sufficient.
       delete (fs as { symlinkSemantics?: "none" }).symlinkSemantics;
 
       const result = await resolveComponentPath("/", "/project", fs);
 
-      assertEquals(result, "/project/app/page.tsx");
+      assertEquals(result, null);
+    });
+
+    it("keeps relative paths for a symlink-free virtual adapter", async () => {
+      const fs = createMockFs(new Set(["app/page.tsx"]));
+
+      const result = await resolveComponentPath("/", ".", fs);
+
+      assertEquals(result, "app/page.tsx");
     });
 
     it("does not resolve a lexical route whose canonical target escapes the project", async () => {

--- a/src/server/services/rsc/orchestrators/component-resolver.ts
+++ b/src/server/services/rsc/orchestrators/component-resolver.ts
@@ -41,9 +41,9 @@ async function findFirstExistingPath(
 ): Promise<string | null> {
   const projectRoot = pathHelper.resolve(projectDir);
   for (const pattern of patterns) {
-    const fullPath = pathHelper.resolve(projectDir, pattern);
-    if (!isWithinDirectory(projectRoot, fullPath)) continue;
-    if (!await isCanonicalCandidateContained(projectRoot, fullPath, fsAdapter)) continue;
+    const fullPath = pathHelper.join(projectDir, pattern);
+    if (!isWithinDirectory(projectRoot, pathHelper.resolve(fullPath))) continue;
+    if (!await isCanonicalCandidateContained(projectDir, fullPath, fsAdapter)) continue;
     if (await fileExists(fullPath, fsAdapter)) return fullPath;
   }
   return null;
@@ -51,10 +51,8 @@ async function findFirstExistingPath(
 
 /**
  * Confirm a lexically contained candidate stays inside the project once
- * symlinks are resolved. Adapters that declare `symlinkSemantics: "none"` or
- * omit `realPath` are virtual/symlink-free by the FileSystemAdapter contract
- * (native/local adapters must provide `realPath`), so the caller's lexical
- * containment check is sufficient for them.
+ * symlinks are resolved. An adapter must either declare
+ * `symlinkSemantics: "none"` or provide canonical paths.
  */
 async function isCanonicalCandidateContained(
   projectRoot: string,
@@ -67,7 +65,7 @@ async function isCanonicalCandidateContained(
   if (semantics && "value" in semantics && semantics.value === "none") return true;
 
   const canonicalize = fsAdapter ? fsAdapter.realPath?.bind(fsAdapter) : realPath;
-  if (!canonicalize) return true;
+  if (!canonicalize) return false;
   try {
     const [canonicalRoot, canonicalCandidate] = await Promise.all([
       canonicalize(projectRoot),

--- a/src/server/services/rsc/orchestrators/component-resolver.ts
+++ b/src/server/services/rsc/orchestrators/component-resolver.ts
@@ -1,6 +1,7 @@
-import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
+import { createFileSystem, realPath } from "#veryfront/platform/compat/fs.ts";
 import * as pathHelper from "#veryfront/compat/path";
 import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
+import { isWithinDirectory } from "#veryfront/security/path-validation.ts";
 
 const fs = createFileSystem();
 
@@ -38,11 +39,44 @@ async function findFirstExistingPath(
   patterns: string[],
   fsAdapter?: FileSystemAdapter,
 ): Promise<string | null> {
+  const projectRoot = pathHelper.resolve(projectDir);
   for (const pattern of patterns) {
-    const fullPath = pathHelper.join(projectDir, pattern);
+    const fullPath = pathHelper.resolve(projectDir, pattern);
+    if (!isWithinDirectory(projectRoot, fullPath)) continue;
+    if (!await isCanonicalCandidateContained(projectRoot, fullPath, fsAdapter)) continue;
     if (await fileExists(fullPath, fsAdapter)) return fullPath;
   }
   return null;
+}
+
+/**
+ * Confirm a lexically contained candidate stays inside the project once
+ * symlinks are resolved. Adapters that declare `symlinkSemantics: "none"` or
+ * omit `realPath` are virtual/symlink-free by the FileSystemAdapter contract
+ * (native/local adapters must provide `realPath`), so the caller's lexical
+ * containment check is sufficient for them.
+ */
+async function isCanonicalCandidateContained(
+  projectRoot: string,
+  candidate: string,
+  fsAdapter?: FileSystemAdapter,
+): Promise<boolean> {
+  const semantics = fsAdapter
+    ? Object.getOwnPropertyDescriptor(fsAdapter, "symlinkSemantics")
+    : undefined;
+  if (semantics && "value" in semantics && semantics.value === "none") return true;
+
+  const canonicalize = fsAdapter ? fsAdapter.realPath?.bind(fsAdapter) : realPath;
+  if (!canonicalize) return true;
+  try {
+    const [canonicalRoot, canonicalCandidate] = await Promise.all([
+      canonicalize(projectRoot),
+      canonicalize(candidate),
+    ]);
+    return isWithinDirectory(canonicalRoot, canonicalCandidate);
+  } catch {
+    return false;
+  }
 }
 
 async function fileExists(filePath: string, fsAdapter?: FileSystemAdapter): Promise<boolean> {

--- a/src/server/services/rsc/orchestrators/manifest-handler.test.ts
+++ b/src/server/services/rsc/orchestrators/manifest-handler.test.ts
@@ -67,6 +67,7 @@ describe("server/services/rsc/orchestrators/manifest-handler", () => {
 
     it("builds manifests through the request filesystem adapter", async () => {
       const fs = {
+        symlinkSemantics: "none" as const,
         readDir: async function* (path: string) {
           if (path === "/project/frontend") {
             yield {
@@ -434,6 +435,7 @@ describe("server/services/rsc/orchestrators/manifest-handler", () => {
         markFirstReadStarted = resolve;
       });
       const fs = {
+        symlinkSemantics: "none" as const,
         readDir: async function* (path: string) {
           if (path === "/project/app") {
             yield {


### PR DESCRIPTION
### Motivation
- Tenant-controlled `config.directories.app` was used directly to build RSC component and manifest paths without containment checks, allowing a configured `appDir` like `../other/app` to escape `projectDir` and read sibling or host files.

### Description
- Canonicalize candidate paths and skip any resolved path outside the project root in `resolveComponentPath` by switching from `join` to `resolve` and adding an `isWithinDirectory` check in `src/server/services/rsc/orchestrators/component-resolver.ts`.
- Canonicalize and validate the configured `appDir` in `buildClientManifest`, resolving it against `projectDir` and returning an empty manifest if it lies outside the project, in `src/rendering/rsc/component-analyzer.ts`.
- Add focused regression tests to `src/server/services/rsc/orchestrators/component-resolver.test.ts` and `src/rendering/rsc/component-analyzer.test.ts` that assert escaped app directories do not resolve or get scanned.

### Testing
- Ran `git diff --check` and inspected the working tree, no diff/check failures reported.
- Added unit tests: `component-resolver.test.ts` and `component-analyzer.test.ts` include new cases for external `appDir` values (tests committed but Deno could not be executed in this environment).
- Attempted to run focused Deno test and formatter commands (`npx deno@2.7.7 ...`) and to install Deno, but the environment blocked downloads with HTTP 403 so automated test execution was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fc79a3dd4832db3f2fe77ba81c41b)