### PR TITLE
fix(server): bound knowledge-ingest progress logs to prevent OOM

### DIFF
--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -15,6 +15,7 @@ import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
 import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import {
+  createKnowledgeEventLogger,
   ProjectRunExecuteHandler,
   type ProjectRunExecuteHandlerDeps,
 } from "./project-run-execute.handler.ts";
@@ -22,6 +23,32 @@ import { createControlPlaneSignature, createCtx } from "./internal-agent-run.tes
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 
 const encoder = new TextEncoder();
+
+describe("createKnowledgeEventLogger", () => {
+  it("caps the number of accumulated knowledge ingest events", () => {
+    const lines: string[] = [];
+    const logger = createKnowledgeEventLogger(lines);
+
+    for (let index = 0; index < 2_000; index += 1) {
+      logger.info("Knowledge source extraction progress", { slide_current: index + 1 });
+    }
+
+    assertEquals(lines.length, 1_001);
+    assertStringIncludes(lines.at(-1) ?? "", "Knowledge ingest logs were truncated");
+  });
+
+  it("caps the accumulated knowledge ingest log size", () => {
+    const lines: string[] = [];
+    const logger = createKnowledgeEventLogger(lines);
+
+    for (let index = 0; index < 100; index += 1) {
+      logger.info("x".repeat(10_000));
+    }
+
+    assertEquals(encoder.encode(lines.join("\n")).byteLength <= 256 * 1_024, true);
+    assertStringIncludes(lines.at(-1) ?? "", "Knowledge ingest logs were truncated");
+  });
+});
 
 function encodeDataStreamEvent(payload: Record<string, unknown>): Uint8Array {
   return encoder.encode(`data: ${JSON.stringify(payload)}\n\n`);

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -59,6 +59,12 @@ const DEFAULT_WORKFLOW_STATUS_TIMEOUT_MS = 15 * 60 * 1_000;
 const DEFAULT_LOCAL_AG_UI_PORT = 3001;
 const WORKFLOW_PERSISTENCE_REQUIRED_ERROR =
   "Workflow paused but runtime workflow persistence is not configured";
+const KNOWLEDGE_LOG_MAX_EVENTS = 1_000;
+const KNOWLEDGE_LOG_MAX_BYTES = 256 * 1_024;
+const KNOWLEDGE_LOG_TRUNCATED_LINE = JSON.stringify({
+  level: "warn",
+  message: "Knowledge ingest logs were truncated",
+});
 
 export interface ProjectRunExecuteRequest {
   runId: string;
@@ -752,9 +758,41 @@ async function resolveUploadIdsToPaths(
   return paths;
 }
 
-function createKnowledgeEventLogger(lines: string[]): Logger {
+export function createKnowledgeEventLogger(lines: string[]): Logger {
+  const encoder = new TextEncoder();
+  const truncatedLineBytes = encoder.encode(KNOWLEDGE_LOG_TRUNCATED_LINE).byteLength;
+  let eventCount = 0;
+  let byteCount = 0;
+  let truncated = false;
+
+  const truncate = () => {
+    if (truncated) return;
+    truncated = true;
+    const separatorBytes = lines.length > 0 ? 1 : 0;
+    if (byteCount + separatorBytes + truncatedLineBytes <= KNOWLEDGE_LOG_MAX_BYTES) {
+      lines.push(KNOWLEDGE_LOG_TRUNCATED_LINE);
+    }
+  };
   const append = (level: string, message: string, metadata?: Record<string, unknown>) => {
-    lines.push(JSON.stringify({ level, message, ...(metadata ?? {}) }));
+    if (truncated || eventCount >= KNOWLEDGE_LOG_MAX_EVENTS) {
+      truncate();
+      return;
+    }
+
+    const line = JSON.stringify({ level, message, ...(metadata ?? {}) });
+    const lineBytes = encoder.encode(line).byteLength;
+    const separatorBytes = lines.length > 0 ? 1 : 0;
+    if (
+      byteCount + separatorBytes + lineBytes + truncatedLineBytes + 1 >
+        KNOWLEDGE_LOG_MAX_BYTES
+    ) {
+      truncate();
+      return;
+    }
+
+    lines.push(line);
+    eventCount += 1;
+    byteCount += separatorBytes + lineBytes;
   };
   const logger: Logger = {
     info: (message: string, metadata?: Record<string, unknown>) =>


### PR DESCRIPTION
### Motivation

- Prevent unbounded, attacker-controlled progress events from exhausting process memory or producing extremely large responses when knowledge-ingest runs log per-page/per-slide progress.
- Ensure server-side logging for knowledge-ingest remains useful while limiting worst-case event and response size amplification.

### Description

- Add bounded in-memory logger for knowledge-ingest by introducing `createKnowledgeEventLogger(lines)` that enforces a maximum of `1_000` events and `256 KiB` total accumulated bytes, and emits a single truncation warning line when limits are hit.
- Stop serializing further progress events after the cap is reached instead of continually appending, and reserve space to append a truncation notice without exceeding the byte cap.
- Export `createKnowledgeEventLogger` and wire it into the existing knowledge-ingest run path (the same in-memory `logLines` array is still used but now bounded and guarded against excessive growth).
- Add focused unit tests that validate both the event-count cap and the accumulated-bytes cap in `src/server/handlers/request/project-run-execute.handler.test.ts`.

### Testing

- Added unit test coverage: `createKnowledgeEventLogger` tests that exercise the event-count cap and the response-size cap (new tests in `src/server/handlers/request/project-run-execute.handler.test.ts`).
- Ran repository checks in this environment: `git diff --check` succeeded and repository changes were staged locally in the working tree; code formatting was verified where possible but `deno` tooling is not available here.
- Attempted automated test run: `deno test --no-check --allow-all src/server/handlers/request/project-run-execute.handler.test.ts` but it could not be executed because `deno` is not installed in this environment; `npx --no-install deno --version` was blocked by registry policy (403).
- Safest next step: run the new tests and format checks in a CI environment or a developer machine with Deno installed using `deno test --no-check --allow-all src/server/handlers/request/project-run-execute.handler.test.ts` and `deno fmt --check` to confirm passing tests and formatting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6fe348d6a8832d80f26effb4b4d214)