### PR TITLE
fix(security): isolate authenticated metrics transport

### DIFF
--- a/docs/api-reference/veryfront/metrics.md
+++ b/docs/api-reference/veryfront/metrics.md
@@ -26,20 +26,20 @@ metrics.gauge("vf_eval_queue_depth", 3);
 
 | Name        | Description | Source                                                                                    |
 | ----------- | ----------- | ----------------------------------------------------------------------------------------- |
-| `counter`   |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L450) |
-| `gauge`     |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L478) |
-| `histogram` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L464) |
+| `counter`   |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L466) |
+| `gauge`     |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L494) |
+| `histogram` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L480) |
 
 ### Types
 
 | Name                      | Description | Source                                                                                   |
 | ------------------------- | ----------- | ---------------------------------------------------------------------------------------- |
-| `MetricAttributes`        |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L30) |
-| `MetricAttributeValue`    |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L29) |
-| `MetricInstrumentOptions` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L32) |
+| `MetricAttributes`        |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L31) |
+| `MetricAttributeValue`    |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L30) |
+| `MetricInstrumentOptions` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L33) |
 
 ### Constants
 
 | Name      | Description | Source                                                                                    |
 | --------- | ----------- | ----------------------------------------------------------------------------------------- |
-| `metrics` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L498) |
+| `metrics` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L514) |

--- a/docs/api-reference/veryfront/metrics.md
+++ b/docs/api-reference/veryfront/metrics.md
@@ -26,20 +26,20 @@ metrics.gauge("vf_eval_queue_depth", 3);
 
 | Name        | Description | Source                                                                                    |
 | ----------- | ----------- | ----------------------------------------------------------------------------------------- |
-| `counter`   |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L466) |
-| `gauge`     |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L494) |
-| `histogram` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L480) |
+| `counter`   |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L501) |
+| `gauge`     |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L529) |
+| `histogram` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L515) |
 
 ### Types
 
 | Name                      | Description | Source                                                                                   |
 | ------------------------- | ----------- | ---------------------------------------------------------------------------------------- |
-| `MetricAttributes`        |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L31) |
-| `MetricAttributeValue`    |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L30) |
-| `MetricInstrumentOptions` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L33) |
+| `MetricAttributes`        |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L30) |
+| `MetricAttributeValue`    |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L29) |
+| `MetricInstrumentOptions` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L32) |
 
 ### Constants
 
 | Name      | Description | Source                                                                                    |
 | --------- | ----------- | ----------------------------------------------------------------------------------------- |
-| `metrics` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L514) |
+| `metrics` |             | [source](https://github.com/veryfront/veryfront-code/blob/main/src/metrics/index.ts#L549) |

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -10,6 +10,7 @@ import {
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
 import { runWithProjectEnv } from "#veryfront/server/project-env/storage.ts";
 import { withEnv } from "#veryfront/testing/deno-compat.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { metrics } from "./index.ts";
 
 describe("metrics public SDK", () => {
@@ -422,6 +423,49 @@ describe("metrics public SDK", () => {
     );
     assertEquals(
       (requests[0]?.init?.headers as Record<string, string>).Authorization,
+      "Basic aW50ZXJuYWwtdXNlcjppbnRlcm5hbC1wYXNz",
+    );
+  });
+
+  it("does not expose internal metrics credentials to a replaced Base64 encoder", async () => {
+    const originalBtoa = Object.getOwnPropertyDescriptor(globalThis, "btoa");
+    const observedValues: string[] = [];
+    const requests: RequestInit[] = [];
+
+    await withEnv({
+      OTEL_METRICS_ENABLED: "true",
+      VERYFRONT_API_BASE_URL: "http://veryfront-api:80",
+      VERYFRONT_API_INTERNAL_USER: "internal-user",
+      VERYFRONT_API_INTERNAL_PASS: "internal-pass",
+    }, async () => {
+      await withMockFetch(
+        ((_url: string | URL | Request, init?: RequestInit) => {
+          requests.push(init ?? {});
+          return Promise.resolve(new Response("{}", { status: 200 }));
+        }) as typeof fetch,
+        async () => {
+          Object.defineProperty(globalThis, "btoa", {
+            configurable: true,
+            writable: true,
+            value: (value: string) => {
+              observedValues.push(value);
+              return "forged-authorization";
+            },
+          });
+          try {
+            metrics.counter("vf_internal_metric_total", 1);
+            await (metrics as unknown as { __flushForTests(): Promise<void> }).__flushForTests();
+          } finally {
+            if (originalBtoa) Object.defineProperty(globalThis, "btoa", originalBtoa);
+            else Reflect.deleteProperty(globalThis, "btoa");
+          }
+        },
+      );
+    });
+
+    assertEquals(observedValues, []);
+    assertEquals(
+      (requests[0]?.headers as Record<string, string>).Authorization,
       "Basic aW50ZXJuYWwtdXNlcjppbnRlcm5hbC1wYXNz",
     );
   });

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -22,6 +22,7 @@ import {
 } from "#veryfront/observability";
 import { getCurrentRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
 import { getEnv, getHostEnv } from "#veryfront/platform/compat/process.ts";
+import { getDenoRuntime } from "#veryfront/platform/compat/runtime.ts";
 import { encodeBase64 } from "#veryfront/utils";
 import { isProjectEnvActive } from "#veryfront/server/project-env/storage.ts";
 import { serverLogger } from "#veryfront/utils/logger/logger.ts";
@@ -76,6 +77,18 @@ let directFlushTimer: ReturnType<typeof setTimeout> | null = null;
 const DIRECT_FLUSH_DELAY_MS = 1_000;
 const DIRECT_MAX_BATCH_SIZE = 100;
 const HISTOGRAM_BOUNDS = [0, 10, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000];
+// Capture the runtime transport before project code can replace the ambient fetch.
+// Host-authenticated telemetry must never cross a project-controlled function.
+const hostFetch = globalThis.fetch.bind(globalThis);
+const useAmbientFetchForTests = (() => {
+  const deno = getDenoRuntime();
+  if (!deno) return false;
+  try {
+    return deno.env.get("DENO_TESTING") === "1";
+  } catch {
+    return false;
+  }
+})();
 
 function getMeter() {
   return getGlobalMetricsAPI()?.getMeter("veryfront.project.metrics");
@@ -390,14 +403,17 @@ async function flushDirectMetrics(): Promise<void> {
 
   const batch = directQueue.splice(0, DIRECT_MAX_BATCH_SIZE);
   try {
-    const response = await fetch(target.url, {
-      method: "POST",
-      headers: {
-        ...target.headers,
-        "Content-Type": "application/json",
+    const response = await (useAmbientFetchForTests ? globalThis.fetch : hostFetch)(
+      target.url,
+      {
+        method: "POST",
+        headers: {
+          ...target.headers,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(buildDirectOtlpBody(batch)),
       },
-      body: JSON.stringify(buildDirectOtlpBody(batch)),
-    });
+    );
     if (!response.ok) {
       logDirectExportFailure(`HTTP ${response.status}`);
     }

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -23,7 +23,6 @@ import {
 import { getCurrentRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
 import { getEnv, getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { getDenoRuntime } from "#veryfront/platform/compat/runtime.ts";
-import { encodeBase64 } from "#veryfront/utils";
 import { isProjectEnvActive } from "#veryfront/server/project-env/storage.ts";
 import { serverLogger } from "#veryfront/utils/logger/logger.ts";
 
@@ -77,6 +76,18 @@ let directFlushTimer: ReturnType<typeof setTimeout> | null = null;
 const DIRECT_FLUSH_DELAY_MS = 1_000;
 const DIRECT_MAX_BATCH_SIZE = 100;
 const HISTOGRAM_BOUNDS = [0, 10, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000];
+const apply = Reflect.apply;
+const hostBtoa = typeof globalThis.btoa === "function" ? globalThis.btoa : undefined;
+const mathMin = Math.min;
+const NativeTextEncoder = TextEncoder;
+const textEncoderEncode = NativeTextEncoder.prototype.encode;
+const stringFromCharCode = String.fromCharCode;
+const typedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
+const typedArrayByteLength = Object.getOwnPropertyDescriptor(
+  typedArrayPrototype,
+  "byteLength",
+)?.get;
+const utf8Encoder = new NativeTextEncoder();
 // Capture the runtime transport before project code can replace the ambient fetch.
 // Host-authenticated telemetry must never cross a project-controlled function.
 const hostFetch = globalThis.fetch.bind(globalThis);
@@ -89,6 +100,30 @@ const useAmbientFetchForTests = (() => {
     return false;
   }
 })();
+
+function encodeHostBase64(value: string): string {
+  if (!hostBtoa || !typedArrayByteLength) {
+    throw new Error("Base64 encoding is not supported in this runtime");
+  }
+  try {
+    return apply(hostBtoa, globalThis, [value]) as string;
+  } catch {
+    // Preserve the existing UTF-8 fallback without consulting mutable globals.
+    const bytes = apply(textEncoderEncode, utf8Encoder, [value]) as Uint8Array;
+    const byteLength = apply(typedArrayByteLength, bytes, []) as number;
+    const chunkSize = 24 * 1_024;
+    let encoded = "";
+    for (let offset = 0; offset < byteLength; offset += chunkSize) {
+      const end = apply(mathMin, undefined, [offset + chunkSize, byteLength]) as number;
+      let binary = "";
+      for (let index = offset; index < end; index++) {
+        binary += apply(stringFromCharCode, undefined, [bytes[index]]) as string;
+      }
+      encoded += apply(hostBtoa, globalThis, [binary]) as string;
+    }
+    return encoded;
+  }
+}
 
 function getMeter() {
   return getGlobalMetricsAPI()?.getMeter("veryfront.project.metrics");
@@ -211,7 +246,7 @@ function resolveInternalMetricsUrl(): string | null {
 
 function buildBasicAuth(username: string, password: string): string {
   const credentials = `${username}:${password}`;
-  return `Basic ${encodeBase64(credentials)}`;
+  return `Basic ${encodeHostBase64(credentials)}`;
 }
 
 function parseHeaders(headerInput: string | undefined): Record<string, string> {


### PR DESCRIPTION
### Motivation

- Prevent tenant code from capturing or forging host-authenticated OTLP metric exports by removing use of the ambient, monkey-patchable `fetch` for host-authenticated telemetry and by hiding test-only helpers from production.

### Description

- Capture the runtime transport at module initialization with `hostFetch = globalThis.fetch.bind(globalThis)` and use it for host-authenticated direct OTLP exports. (changed `src/metrics/index.ts`).
- Use the captured transport in production flushes and only allow the ambient `globalThis.fetch` when the host test environment is explicitly enabled. (changed `src/metrics/index.ts`).
- Move `__flushForTests` and `__resetForTests` behind a `testHelpers` branch so these helpers are only exported when the host enables the test environment, preventing immediate tenant-triggered credential-bearing exports in production. (changed `src/metrics/index.ts`).

### Testing

- ✅ `git diff --check` passed locally. 
- ⚠️ `DENO_TESTING=1 deno test --no-check --allow-all src/metrics/index.test.ts` was attempted but could not be run because `deno` is not available in the current environment; run this in CI or a Deno-enabled host to verify the focused tests. 
- ✅ Confirmed working-tree updated with the modified file `src/metrics/index.ts` and the change is ready for CI validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6feeac1ed0832d80e57492a4307b5a)