### PR TITLE
fix(integrations): prevent connector credential exfiltration

### DIFF
--- a/src/integrations/_data.test.ts
+++ b/src/integrations/_data.test.ts
@@ -1321,6 +1321,41 @@ describe("integration endpoint specs", () => {
     );
   });
 
+  it("does not allow tool arguments to control endpoint authorities", () => {
+    for (const connectorName of ["algolia", "segment"]) {
+      const connector = getConnector(connectorName);
+      for (const tool of connector.tools) {
+        const url = tool.endpoint?.url;
+        if (!url) continue;
+
+        // Parse the authority scheme-independently so URLs that deviate from
+        // the trusted https:// form (e.g. http://{host}/) fail instead of
+        // silently skipping the placeholder check.
+        const authorityMatch = url.match(/^([a-z][a-z0-9+.-]*):\/\/([^/]+)/i);
+        assertExists(
+          authorityMatch,
+          `${connector.name}:${
+            tool.id ?? tool.name
+          } endpoint URL has no parseable authority: ${url}`,
+        );
+        const [, scheme, authority] = authorityMatch;
+        assertEquals(
+          scheme,
+          "https",
+          `${connector.name}:${tool.id ?? tool.name} endpoint URL must use https: ${url}`,
+        );
+        const callerControlledPlaceholder = authority!.match(/(?<!\{)\{([A-Za-z0-9_$.-]+)\}(?!\})/);
+        assertEquals(
+          callerControlledPlaceholder,
+          null,
+          `${connector.name}:${
+            tool.id ?? tool.name
+          } lets a tool argument control its endpoint authority`,
+        );
+      }
+    }
+  });
+
   it("keeps endpoint path params aligned with URL placeholders", () => {
     const oauthMetadataTemplate =
       /{{\s*(?:oauth\.raw\.[A-Za-z0-9_.-]+|auth\.token|env\.[A-Za-z0-9_]+)\s*}}/g;

--- a/src/integrations/_data.ts
+++ b/src/integrations/_data.ts
@@ -1266,7 +1266,7 @@ export const connectors: IntegrationConfig[] = [
         "step": 2,
         "title": "Copy your credentials",
         "description":
-          "In Settings → API Keys (https://dashboard.algolia.com/account/api-keys/all), copy the Application ID into ALGOLIA_APP_ID and an API key into ALGOLIA_API_KEY. Use the Search API key for read-only use, or create a scoped key with search, browse, and addObject ACLs for writes — avoid the Admin API key.",
+          "In Settings → API Keys (https://dashboard.algolia.com/account/api-keys/all), copy the Application ID into ALGOLIA_APP_ID and an API key into ALGOLIA_API_KEY. Use the Search API key for read-only use, or create a scoped key with search, browse, and addObject ACLs for writes. Avoid the Admin API key.",
       }, {
         "step": 3,
         "title": "Note your host",
@@ -1279,7 +1279,7 @@ export const connectors: IntegrationConfig[] = [
           "Run the List Indices tool. A 403 usually means the API key lacks the required ACL or the host does not match your application ID.",
       }],
       "notes": [
-        "Algolia authenticates with two headers: X-Algolia-API-Key and X-Algolia-Application-Id — both env vars are required",
+        "Algolia authenticates with two required headers: X-Algolia-API-Key and X-Algolia-Application-Id",
         "Browse requires an API key with the 'browse' ACL; Save Objects requires 'addObject'",
         "The Search API key is safe to expose in frontends, but scoped/write keys must stay server-side",
       ],
@@ -48271,7 +48271,7 @@ export const connectors: IntegrationConfig[] = [
         "step": 2,
         "title": "Create a Public API token",
         "description":
-          "Open Workspace Settings > Access Management > Tokens and click Create Token. Choose the Public API token type (not the legacy Config API) and grant Workspace Member or Owner scope as needed. Copy the token — it is shown only once.",
+          "Open Workspace Settings > Access Management > Tokens and select Create Token. Choose the Public API token type (not the legacy Config API) and grant Workspace Member or Owner scope as needed. Copy the token because it is shown only once.",
       }, {
         "step": 3,
         "title": "Set the environment variable",

--- a/src/integrations/_data.ts
+++ b/src/integrations/_data.ts
@@ -1096,15 +1096,8 @@ export const connectors: IntegrationConfig[] = [
       "requiresWrite": false,
       "endpoint": {
         "method": "GET",
-        "url": "https://{host}/1/indexes",
+        "url": "https://{{env.ALGOLIA_APP_ID}}-dsn.algolia.net/1/indexes",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description":
-              'Algolia host built from your application ID: pass "<ALGOLIA_APP_ID>-dsn.algolia.net", e.g. B1G2GM9NG0-dsn.algolia.net',
-            "required": true,
-          },
           "page": {
             "type": "number",
             "in": "query",
@@ -1131,15 +1124,8 @@ export const connectors: IntegrationConfig[] = [
       "requiresWrite": false,
       "endpoint": {
         "method": "POST",
-        "url": "https://{host}/1/indexes/{indexName}/query",
+        "url": "https://{{env.ALGOLIA_APP_ID}}-dsn.algolia.net/1/indexes/{indexName}/query",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description":
-              'Algolia host built from your application ID: pass "<ALGOLIA_APP_ID>-dsn.algolia.net", e.g. B1G2GM9NG0-dsn.algolia.net',
-            "required": true,
-          },
           "indexName": {
             "type": "string",
             "in": "path",
@@ -1176,15 +1162,8 @@ export const connectors: IntegrationConfig[] = [
       "requiresWrite": false,
       "endpoint": {
         "method": "POST",
-        "url": "https://{host}/1/indexes/{indexName}/browse",
+        "url": "https://{{env.ALGOLIA_APP_ID}}-dsn.algolia.net/1/indexes/{indexName}/browse",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description":
-              'Algolia host built from your application ID: pass "<ALGOLIA_APP_ID>-dsn.algolia.net", e.g. B1G2GM9NG0-dsn.algolia.net',
-            "required": true,
-          },
           "indexName": {
             "type": "string",
             "in": "path",
@@ -1215,15 +1194,8 @@ export const connectors: IntegrationConfig[] = [
       "requiresWrite": false,
       "endpoint": {
         "method": "GET",
-        "url": "https://{host}/1/indexes/{indexName}/{objectID}",
+        "url": "https://{{env.ALGOLIA_APP_ID}}-dsn.algolia.net/1/indexes/{indexName}/{objectID}",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description":
-              'Algolia host built from your application ID: pass "<ALGOLIA_APP_ID>-dsn.algolia.net", e.g. B1G2GM9NG0-dsn.algolia.net',
-            "required": true,
-          },
           "indexName": {
             "type": "string",
             "in": "path",
@@ -1250,15 +1222,8 @@ export const connectors: IntegrationConfig[] = [
       "requiresWrite": true,
       "endpoint": {
         "method": "POST",
-        "url": "https://{host}/1/indexes/{indexName}/batch",
+        "url": "https://{{env.ALGOLIA_APP_ID}}.algolia.net/1/indexes/{indexName}/batch",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description":
-              'Algolia host built from your application ID: pass "<ALGOLIA_APP_ID>-dsn.algolia.net", e.g. B1G2GM9NG0-dsn.algolia.net',
-            "required": true,
-          },
           "indexName": {
             "type": "string",
             "in": "path",
@@ -1306,7 +1271,7 @@ export const connectors: IntegrationConfig[] = [
         "step": 3,
         "title": "Note your host",
         "description":
-          "Tools take a 'host' parameter: pass \"<ALGOLIA_APP_ID>-dsn.algolia.net\" (your application ID followed by -dsn.algolia.net).",
+          "Veryfront derives the Algolia API hostname from ALGOLIA_APP_ID. Tool callers cannot override it.",
       }, {
         "step": 4,
         "title": "Verify access",
@@ -48070,6 +48035,12 @@ export const connectors: IntegrationConfig[] = [
       "required": true,
       "sensitive": true,
       "docsUrl": "https://docs.segmentapis.com/tag/Getting-Started",
+    }, {
+      "name": "SEGMENT_API_HOST",
+      "description": "Segment Public API host for your workspace region",
+      "required": false,
+      "sensitive": false,
+      "default": "api.segmentapis.com",
     }],
     "tools": [{
       "id": "segment__list_sources",
@@ -48078,15 +48049,8 @@ export const connectors: IntegrationConfig[] = [
       "requiresWrite": false,
       "endpoint": {
         "method": "GET",
-        "url": "https://{host}/sources",
+        "url": "https://{{env.SEGMENT_API_HOST}}/sources",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description":
-              "Segment Public API host: api.segmentapis.com (US, default) or eu1.api.segmentapis.com (EU workspaces)",
-            "default": "api.segmentapis.com",
-          },
           "count": {
             "type": "number",
             "in": "query",
@@ -48126,15 +48090,8 @@ export const connectors: IntegrationConfig[] = [
       "requiresWrite": false,
       "endpoint": {
         "method": "GET",
-        "url": "https://{host}/sources/{sourceId}",
+        "url": "https://{{env.SEGMENT_API_HOST}}/sources/{sourceId}",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description":
-              "Segment Public API host (api.segmentapis.com or eu1.api.segmentapis.com)",
-            "default": "api.segmentapis.com",
-          },
           "sourceId": {
             "type": "string",
             "in": "path",
@@ -48151,16 +48108,8 @@ export const connectors: IntegrationConfig[] = [
       "requiresWrite": true,
       "endpoint": {
         "method": "POST",
-        "url": "https://{host}/sources",
-        "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description":
-              "Segment Public API host (api.segmentapis.com or eu1.api.segmentapis.com)",
-            "default": "api.segmentapis.com",
-          },
-        },
+        "url": "https://{{env.SEGMENT_API_HOST}}/sources",
+        "params": {},
         "body": {
           "slug": {
             "type": "string",
@@ -48191,15 +48140,8 @@ export const connectors: IntegrationConfig[] = [
       "requiresWrite": true,
       "endpoint": {
         "method": "PATCH",
-        "url": "https://{host}/sources/{sourceId}",
+        "url": "https://{{env.SEGMENT_API_HOST}}/sources/{sourceId}",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description":
-              "Segment Public API host (api.segmentapis.com or eu1.api.segmentapis.com)",
-            "default": "api.segmentapis.com",
-          },
           "sourceId": {
             "type": "string",
             "in": "path",
@@ -48222,15 +48164,8 @@ export const connectors: IntegrationConfig[] = [
       "requiresWrite": false,
       "endpoint": {
         "method": "GET",
-        "url": "https://{host}/destinations",
+        "url": "https://{{env.SEGMENT_API_HOST}}/destinations",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description":
-              "Segment Public API host (api.segmentapis.com or eu1.api.segmentapis.com)",
-            "default": "api.segmentapis.com",
-          },
           "count": {
             "type": "number",
             "in": "query",
@@ -48265,15 +48200,8 @@ export const connectors: IntegrationConfig[] = [
       "requiresWrite": false,
       "endpoint": {
         "method": "GET",
-        "url": "https://{host}/destinations/{destinationId}",
+        "url": "https://{{env.SEGMENT_API_HOST}}/destinations/{destinationId}",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description":
-              "Segment Public API host (api.segmentapis.com or eu1.api.segmentapis.com)",
-            "default": "api.segmentapis.com",
-          },
           "destinationId": {
             "type": "string",
             "in": "path",
@@ -48290,16 +48218,8 @@ export const connectors: IntegrationConfig[] = [
       "requiresWrite": true,
       "endpoint": {
         "method": "POST",
-        "url": "https://{host}/destinations",
-        "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description":
-              "Segment Public API host (api.segmentapis.com or eu1.api.segmentapis.com)",
-            "default": "api.segmentapis.com",
-          },
-        },
+        "url": "https://{{env.SEGMENT_API_HOST}}/destinations",
+        "params": {},
         "body": {
           "sourceId": {
             "type": "string",
@@ -48360,11 +48280,11 @@ export const connectors: IntegrationConfig[] = [
         "step": 4,
         "title": "Verify access",
         "description":
-          "Run List Sources. EU-hosted workspaces must pass host=eu1.api.segmentapis.com on each call.",
+          "Run List Sources. EU-hosted workspaces must set SEGMENT_API_HOST=eu1.api.segmentapis.com in their environment.",
       }],
       "notes": [
         "The Public API authenticates with 'Authorization: Bearer <token>'",
-        "US workspaces use api.segmentapis.com (the default); EU workspaces use eu1.api.segmentapis.com via the host parameter",
+        "US workspaces use api.segmentapis.com (the default); EU workspaces set the SEGMENT_API_HOST environment variable to eu1.api.segmentapis.com",
         "Creating sources/destinations needs a catalog metadataId from the /catalog endpoints",
       ],
       "documentation": "https://docs.segmentapis.com/",

--- a/templates/integrations/algolia/connector.json
+++ b/templates/integrations/algolia/connector.json
@@ -248,7 +248,7 @@
       {
         "step": 2,
         "title": "Copy your credentials",
-        "description": "In Settings \u2192 API Keys (https://dashboard.algolia.com/account/api-keys/all), copy the Application ID into ALGOLIA_APP_ID and an API key into ALGOLIA_API_KEY. Use the Search API key for read-only use, or create a scoped key with search, browse, and addObject ACLs for writes \u2014 avoid the Admin API key."
+        "description": "In Settings \u2192 API Keys (https://dashboard.algolia.com/account/api-keys/all), copy the Application ID into ALGOLIA_APP_ID and an API key into ALGOLIA_API_KEY. Use the Search API key for read-only use, or create a scoped key with search, browse, and addObject ACLs for writes. Avoid the Admin API key."
       },
       {
         "step": 3,
@@ -262,7 +262,7 @@
       }
     ],
     "notes": [
-      "Algolia authenticates with two headers: X-Algolia-API-Key and X-Algolia-Application-Id \u2014 both env vars are required",
+      "Algolia authenticates with two required headers: X-Algolia-API-Key and X-Algolia-Application-Id",
       "Browse requires an API key with the 'browse' ACL; Save Objects requires 'addObject'",
       "The Search API key is safe to expose in frontends, but scoped/write keys must stay server-side"
     ],

--- a/templates/integrations/algolia/connector.json
+++ b/templates/integrations/algolia/connector.json
@@ -42,14 +42,8 @@
       "requiresWrite": false,
       "endpoint": {
         "method": "GET",
-        "url": "https://{host}/1/indexes",
+        "url": "https://{{env.ALGOLIA_APP_ID}}-dsn.algolia.net/1/indexes",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description": "Algolia host built from your application ID: pass \"<ALGOLIA_APP_ID>-dsn.algolia.net\", e.g. B1G2GM9NG0-dsn.algolia.net",
-            "required": true
-          },
           "page": {
             "type": "number",
             "in": "query",
@@ -59,17 +53,34 @@
         "response": {
           "transform": "items",
           "historicalSummary": {
-            "collectionKeys": ["items", "indices"],
+            "collectionKeys": [
+              "items",
+              "indices"
+            ],
             "collectionName": "indices",
             "itemFields": [
-              { "name": "name" },
-              { "name": "entries" },
-              { "name": "dataSize" },
-              { "name": "createdAt" },
-              { "name": "updatedAt" }
+              {
+                "name": "name"
+              },
+              {
+                "name": "entries"
+              },
+              {
+                "name": "dataSize"
+              },
+              {
+                "name": "createdAt"
+              },
+              {
+                "name": "updatedAt"
+              }
             ],
             "omitted": "index settings and provider-specific payload fields",
-            "outputFields": [{ "name": "nbPages" }]
+            "outputFields": [
+              {
+                "name": "nbPages"
+              }
+            ]
           }
         }
       }
@@ -81,14 +92,8 @@
       "requiresWrite": false,
       "endpoint": {
         "method": "POST",
-        "url": "https://{host}/1/indexes/{indexName}/query",
+        "url": "https://{{env.ALGOLIA_APP_ID}}-dsn.algolia.net/1/indexes/{indexName}/query",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description": "Algolia host built from your application ID: pass \"<ALGOLIA_APP_ID>-dsn.algolia.net\", e.g. B1G2GM9NG0-dsn.algolia.net",
-            "required": true
-          },
           "indexName": {
             "type": "string",
             "in": "path",
@@ -130,14 +135,8 @@
       "requiresWrite": false,
       "endpoint": {
         "method": "POST",
-        "url": "https://{host}/1/indexes/{indexName}/browse",
+        "url": "https://{{env.ALGOLIA_APP_ID}}-dsn.algolia.net/1/indexes/{indexName}/browse",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description": "Algolia host built from your application ID: pass \"<ALGOLIA_APP_ID>-dsn.algolia.net\", e.g. B1G2GM9NG0-dsn.algolia.net",
-            "required": true
-          },
           "indexName": {
             "type": "string",
             "in": "path",
@@ -169,14 +168,8 @@
       "requiresWrite": false,
       "endpoint": {
         "method": "GET",
-        "url": "https://{host}/1/indexes/{indexName}/{objectID}",
+        "url": "https://{{env.ALGOLIA_APP_ID}}-dsn.algolia.net/1/indexes/{indexName}/{objectID}",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description": "Algolia host built from your application ID: pass \"<ALGOLIA_APP_ID>-dsn.algolia.net\", e.g. B1G2GM9NG0-dsn.algolia.net",
-            "required": true
-          },
           "indexName": {
             "type": "string",
             "in": "path",
@@ -204,14 +197,8 @@
       "requiresWrite": true,
       "endpoint": {
         "method": "POST",
-        "url": "https://{host}/1/indexes/{indexName}/batch",
+        "url": "https://{{env.ALGOLIA_APP_ID}}.algolia.net/1/indexes/{indexName}/batch",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description": "Algolia host built from your application ID: pass \"<ALGOLIA_APP_ID>-dsn.algolia.net\", e.g. B1G2GM9NG0-dsn.algolia.net",
-            "required": true
-          },
           "indexName": {
             "type": "string",
             "in": "path",
@@ -245,7 +232,11 @@
       "icon": "list"
     }
   ],
-  "suggestedWith": ["shopify", "supabase", "github"],
+  "suggestedWith": [
+    "shopify",
+    "supabase",
+    "github"
+  ],
   "SETUP_GUIDE": {
     "title": "Algolia API Setup",
     "steps": [
@@ -257,12 +248,12 @@
       {
         "step": 2,
         "title": "Copy your credentials",
-        "description": "In Settings → API Keys (https://dashboard.algolia.com/account/api-keys/all), copy the Application ID into ALGOLIA_APP_ID and an API key into ALGOLIA_API_KEY. Use the Search API key for read-only use, or create a scoped key with search, browse, and addObject ACLs for writes — avoid the Admin API key."
+        "description": "In Settings \u2192 API Keys (https://dashboard.algolia.com/account/api-keys/all), copy the Application ID into ALGOLIA_APP_ID and an API key into ALGOLIA_API_KEY. Use the Search API key for read-only use, or create a scoped key with search, browse, and addObject ACLs for writes \u2014 avoid the Admin API key."
       },
       {
         "step": 3,
         "title": "Note your host",
-        "description": "Tools take a 'host' parameter: pass \"<ALGOLIA_APP_ID>-dsn.algolia.net\" (your application ID followed by -dsn.algolia.net)."
+        "description": "Veryfront derives the Algolia API hostname from ALGOLIA_APP_ID. Tool callers cannot override it."
       },
       {
         "step": 4,
@@ -271,7 +262,7 @@
       }
     ],
     "notes": [
-      "Algolia authenticates with two headers: X-Algolia-API-Key and X-Algolia-Application-Id — both env vars are required",
+      "Algolia authenticates with two headers: X-Algolia-API-Key and X-Algolia-Application-Id \u2014 both env vars are required",
       "Browse requires an API key with the 'browse' ACL; Save Objects requires 'addObject'",
       "The Search API key is safe to expose in frontends, but scoped/write keys must stay server-side"
     ],

--- a/templates/integrations/segment/connector.json
+++ b/templates/integrations/segment/connector.json
@@ -343,7 +343,7 @@
       {
         "step": 2,
         "title": "Create a Public API token",
-        "description": "Open Workspace Settings > Access Management > Tokens and click Create Token. Choose the Public API token type (not the legacy Config API) and grant Workspace Member or Owner scope as needed. Copy the token \u2014 it is shown only once."
+        "description": "Open Workspace Settings > Access Management > Tokens and select Create Token. Choose the Public API token type (not the legacy Config API) and grant Workspace Member or Owner scope as needed. Copy the token because it is shown only once."
       },
       {
         "step": 3,

--- a/templates/integrations/segment/connector.json
+++ b/templates/integrations/segment/connector.json
@@ -22,6 +22,13 @@
       "required": true,
       "sensitive": true,
       "docsUrl": "https://docs.segmentapis.com/tag/Getting-Started"
+    },
+    {
+      "name": "SEGMENT_API_HOST",
+      "description": "Segment Public API host for your workspace region",
+      "required": false,
+      "sensitive": false,
+      "default": "api.segmentapis.com"
     }
   ],
   "tools": [
@@ -32,14 +39,8 @@
       "requiresWrite": false,
       "endpoint": {
         "method": "GET",
-        "url": "https://{host}/sources",
+        "url": "https://{{env.SEGMENT_API_HOST}}/sources",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description": "Segment Public API host: api.segmentapis.com (US, default) or eu1.api.segmentapis.com (EU workspaces)",
-            "default": "api.segmentapis.com"
-          },
           "count": {
             "type": "number",
             "in": "query",
@@ -101,14 +102,8 @@
       "requiresWrite": false,
       "endpoint": {
         "method": "GET",
-        "url": "https://{host}/sources/{sourceId}",
+        "url": "https://{{env.SEGMENT_API_HOST}}/sources/{sourceId}",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description": "Segment Public API host (api.segmentapis.com or eu1.api.segmentapis.com)",
-            "default": "api.segmentapis.com"
-          },
           "sourceId": {
             "type": "string",
             "in": "path",
@@ -128,15 +123,8 @@
       "requiresWrite": true,
       "endpoint": {
         "method": "POST",
-        "url": "https://{host}/sources",
-        "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description": "Segment Public API host (api.segmentapis.com or eu1.api.segmentapis.com)",
-            "default": "api.segmentapis.com"
-          }
-        },
+        "url": "https://{{env.SEGMENT_API_HOST}}/sources",
+        "params": {},
         "body": {
           "slug": {
             "type": "string",
@@ -170,14 +158,8 @@
       "requiresWrite": true,
       "endpoint": {
         "method": "PATCH",
-        "url": "https://{host}/sources/{sourceId}",
+        "url": "https://{{env.SEGMENT_API_HOST}}/sources/{sourceId}",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description": "Segment Public API host (api.segmentapis.com or eu1.api.segmentapis.com)",
-            "default": "api.segmentapis.com"
-          },
           "sourceId": {
             "type": "string",
             "in": "path",
@@ -215,14 +197,8 @@
       "requiresWrite": false,
       "endpoint": {
         "method": "GET",
-        "url": "https://{host}/destinations",
+        "url": "https://{{env.SEGMENT_API_HOST}}/destinations",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description": "Segment Public API host (api.segmentapis.com or eu1.api.segmentapis.com)",
-            "default": "api.segmentapis.com"
-          },
           "count": {
             "type": "number",
             "in": "query",
@@ -281,14 +257,8 @@
       "requiresWrite": false,
       "endpoint": {
         "method": "GET",
-        "url": "https://{host}/destinations/{destinationId}",
+        "url": "https://{{env.SEGMENT_API_HOST}}/destinations/{destinationId}",
         "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description": "Segment Public API host (api.segmentapis.com or eu1.api.segmentapis.com)",
-            "default": "api.segmentapis.com"
-          },
           "destinationId": {
             "type": "string",
             "in": "path",
@@ -308,15 +278,8 @@
       "requiresWrite": true,
       "endpoint": {
         "method": "POST",
-        "url": "https://{host}/destinations",
-        "params": {
-          "host": {
-            "type": "string",
-            "in": "path",
-            "description": "Segment Public API host (api.segmentapis.com or eu1.api.segmentapis.com)",
-            "default": "api.segmentapis.com"
-          }
-        },
+        "url": "https://{{env.SEGMENT_API_HOST}}/destinations",
+        "params": {},
         "body": {
           "sourceId": {
             "type": "string",
@@ -380,7 +343,7 @@
       {
         "step": 2,
         "title": "Create a Public API token",
-        "description": "Open Workspace Settings > Access Management > Tokens and click Create Token. Choose the Public API token type (not the legacy Config API) and grant Workspace Member or Owner scope as needed. Copy the token — it is shown only once."
+        "description": "Open Workspace Settings > Access Management > Tokens and click Create Token. Choose the Public API token type (not the legacy Config API) and grant Workspace Member or Owner scope as needed. Copy the token \u2014 it is shown only once."
       },
       {
         "step": 3,
@@ -390,12 +353,12 @@
       {
         "step": 4,
         "title": "Verify access",
-        "description": "Run List Sources. EU-hosted workspaces must pass host=eu1.api.segmentapis.com on each call."
+        "description": "Run List Sources. EU-hosted workspaces must set SEGMENT_API_HOST=eu1.api.segmentapis.com in their environment."
       }
     ],
     "notes": [
       "The Public API authenticates with 'Authorization: Bearer <token>'",
-      "US workspaces use api.segmentapis.com (the default); EU workspaces use eu1.api.segmentapis.com via the host parameter",
+      "US workspaces use api.segmentapis.com (the default); EU workspaces set the SEGMENT_API_HOST environment variable to eu1.api.segmentapis.com",
       "Creating sources/destinations needs a catalog metadataId from the /catalog endpoints"
     ],
     "documentation": "https://docs.segmentapis.com/"


### PR DESCRIPTION
### Motivation
- New connector definitions exposed a caller-controlled `host` path parameter that could be used to place an attacker-controlled authority in credentialed requests. 
- Algolia and Segment endpoints were attaching project-scoped secrets (API keys / bearer tokens) while allowing the URL authority to be supplied by untrusted tool arguments. 
- The intent of this change is to ensure endpoint authorities are derived from trusted project configuration or fixed templates so secrets cannot be exfiltrated to attacker-controlled hosts. 

### Description
- Algolia connector templates and generated metadata were changed to derive the hostname from the trusted project `ALGOLIA_APP_ID` (replacing `https://{host}` with `https://{{env.ALGOLIA_APP_ID}}-dsn.algolia.net`) and the `host` tool parameter was removed. 
- Segment connector templates and generated metadata were changed to use a trusted `SEGMENT_API_HOST` project env var (defaulting to `api.segmentapis.com`) instead of a caller-controlled `host` param, and per-tool `host` params were removed. 
- Added a regression test `it("does not allow tool arguments to control endpoint authorities")` in `src/integrations/_data.test.ts` that asserts Algolia and Segment tool endpoint authorities do not contain caller-controlled placeholders. 
- Updated connector setup guidance and catalog metadata to reflect the trusted-host derivation and the new `SEGMENT_API_HOST` env var; changes touch `cli/templates/integrations/algolia/connector.json`, `cli/templates/integrations/segment/connector.json`, and the generated `src/integrations/_data.ts`. 

### Testing
- Verified JSON validity for modified connector templates with `python3 -m json.tool` and the checks passed. 
- Ran targeted Python validation scripts that confirm the `host` params were removed and no caller-controlled `{...}` placeholders remain in the authority portion for Algolia and Segment, and those checks passed. 
- Ran `git diff --check` and automatic repository text checks with no new issues reported. 
- Attempted to run the integration generation and `deno` unit tests (`scripts/build/generate-integrations-module.ts` and `deno test src/integrations/_data.test.ts`), but `deno` is unavailable in this environment so those commands were not executed here; the changes are prepared to pass the normal `deno` generation and test flow in CI/dev where `deno` is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a701654c3a4832db5f71e8013e1a9ec)