### PR TITLE
fix(transforms): bound fallback cache memory

### DIFF
--- a/src/transforms/esm/transform-cache.test.ts
+++ b/src/transforms/esm/transform-cache.test.ts
@@ -152,7 +152,7 @@ describe("transforms/esm/transform-cache", () => {
       }
     });
 
-    it("retains fallback entries larger than the default LRU byte limit", () => {
+    it("does not retain fallback entries larger than the byte limit", () => {
       __injectCachesForTests(null);
       __injectCachesForTests({ cacheBackend: null });
       destroyTransformCache();
@@ -161,9 +161,63 @@ describe("transforms/esm/transform-cache", () => {
         const largeTransform = "x".repeat(26 * 1024 * 1024);
         setCachedTransform("large-key", largeTransform, "large-hash");
 
-        const result = getCachedTransform("large-key");
-        assertEquals(result?.code.length, largeTransform.length);
-        assertEquals(result?.hash, "large-hash");
+        assertEquals(getCachedTransform("large-key"), undefined);
+      } finally {
+        destroyTransformCache();
+      }
+    });
+
+    it("rejects an oversized entry without flushing existing entries", () => {
+      __injectCachesForTests(null);
+      __injectCachesForTests({ cacheBackend: null });
+      destroyTransformCache();
+
+      try {
+        setCachedTransform("small-key-1", "small-code-1", "small-hash-1");
+        setCachedTransform("small-key-2", "small-code-2", "small-hash-2");
+
+        const oversizedTransform = "x".repeat(26 * 1024 * 1024);
+        setCachedTransform("oversized-key", oversizedTransform, "oversized-hash");
+
+        assertEquals(getCachedTransform("oversized-key"), undefined);
+        assertEquals(getCachedTransform("small-key-1")?.hash, "small-hash-1");
+        assertEquals(getCachedTransform("small-key-2")?.hash, "small-hash-2");
+      } finally {
+        destroyTransformCache();
+      }
+    });
+
+    it("evicts least recently used entries to stay within the byte limit", () => {
+      __injectCachesForTests(null);
+      __injectCachesForTests({ cacheBackend: null });
+      destroyTransformCache();
+
+      try {
+        const largeTransform = "x".repeat(20 * 1024 * 1024);
+        setCachedTransform("large-key-1", largeTransform, "large-hash-1");
+        setCachedTransform("large-key-2", largeTransform, "large-hash-2");
+
+        assertEquals(getCachedTransform("large-key-1"), undefined);
+        assertEquals(getCachedTransform("large-key-2")?.hash, "large-hash-2");
+      } finally {
+        destroyTransformCache();
+      }
+    });
+
+    it("counts the retained key string against the byte limit", () => {
+      __injectCachesForTests(null);
+      __injectCachesForTests({ cacheBackend: null });
+      destroyTransformCache();
+
+      try {
+        const hugeKey = "k".repeat(26 * 1024 * 1024);
+        setCachedTransform(hugeKey, "tiny-code", "tiny-hash");
+
+        assertEquals(
+          getCachedTransform(hugeKey),
+          undefined,
+          "an entry with a huge key must not be retained even when its code is tiny",
+        );
       } finally {
         destroyTransformCache();
       }
@@ -241,6 +295,100 @@ describe("transforms/esm/transform-cache", () => {
       assertEquals(result?.dependencyResolutionObservations, [
         { packageName: "zod", declaration: "^4" },
       ]);
+    });
+
+    it("counts dependency observation declarations against the byte limit", async () => {
+      __injectCachesForTests(null);
+      __injectCachesForTests({ cacheBackend: null });
+      destroyTransformCache();
+
+      try {
+        await setCachedTransformAsync("small-meta-key", "small-code", "small-hash");
+
+        // Tiny code, but ~52MB of retained dependency declarations.
+        const hugeDeclaration = "d".repeat(13 * 1024 * 1024);
+        await setCachedTransformAsync(
+          "huge-observations-key",
+          "tiny-code",
+          "tiny-hash",
+          300,
+          undefined,
+          [
+            { packageName: "pkg-a", declaration: hugeDeclaration },
+            { packageName: "pkg-b", declaration: hugeDeclaration },
+          ],
+        );
+
+        assertEquals(
+          await getCachedTransformAsync("huge-observations-key"),
+          undefined,
+          "an entry with oversized observation metadata must not be retained",
+        );
+        assertEquals(
+          (await getCachedTransformAsync("small-meta-key"))?.hash,
+          "small-hash",
+          "rejecting an oversized entry must not flush existing entries",
+        );
+      } finally {
+        destroyTransformCache();
+      }
+    });
+
+    it("counts the bundle manifest id against the byte limit", async () => {
+      __injectCachesForTests(null);
+      __injectCachesForTests({ cacheBackend: null });
+      destroyTransformCache();
+
+      try {
+        // Tiny code, but a ~52MB retained bundle manifest id.
+        const hugeManifestId = "m".repeat(26 * 1024 * 1024);
+        await setCachedTransformAsync(
+          "huge-manifest-key",
+          "tiny-code",
+          "tiny-hash",
+          300,
+          hugeManifestId,
+        );
+
+        assertEquals(
+          await getCachedTransformAsync("huge-manifest-key"),
+          undefined,
+          "an entry with an oversized bundle manifest id must not be retained",
+        );
+      } finally {
+        destroyTransformCache();
+      }
+    });
+
+    it("evicts least recently used entries when metadata exceeds the byte limit", async () => {
+      __injectCachesForTests(null);
+      __injectCachesForTests({ cacheBackend: null });
+      destroyTransformCache();
+
+      try {
+        // Tiny code, but each entry retains ~20MB of observation metadata.
+        const declaration = "d".repeat(10 * 1024 * 1024);
+        for (let index = 1; index <= 3; index++) {
+          await setCachedTransformAsync(
+            `meta-key-${index}`,
+            "tiny-code",
+            `meta-hash-${index}`,
+            300,
+            undefined,
+            [{ packageName: "pkg", declaration }],
+          );
+        }
+
+        assertEquals(
+          await getCachedTransformAsync("meta-key-1"),
+          undefined,
+          "metadata-heavy entries must evict the least recently used entry",
+        );
+        assertEquals((await getCachedTransformAsync("meta-key-2"))?.hash, "meta-hash-2");
+        assertEquals((await getCachedTransformAsync("meta-key-3"))?.hash, "meta-hash-3");
+      } finally {
+        destroyTransformCache();
+      }
     });
 
     it("discards a backend entry whose code is empty", async () => {

--- a/src/transforms/esm/transform-cache.test.ts
+++ b/src/transforms/esm/transform-cache.test.ts
@@ -187,6 +187,23 @@ describe("transforms/esm/transform-cache", () => {
       }
     });
 
+    it("preserves an existing entry when its replacement is oversized", () => {
+      __injectCachesForTests(null);
+      __injectCachesForTests({ cacheBackend: null });
+      destroyTransformCache();
+
+      try {
+        setCachedTransform("same-key", "small-code", "small-hash");
+
+        const oversizedTransform = "x".repeat(26 * 1024 * 1024);
+        setCachedTransform("same-key", oversizedTransform, "oversized-hash");
+
+        assertEquals(getCachedTransform("same-key")?.hash, "small-hash");
+      } finally {
+        destroyTransformCache();
+      }
+    });
+
     it("evicts least recently used entries to stay within the byte limit", () => {
       __injectCachesForTests(null);
       __injectCachesForTests({ cacheBackend: null });

--- a/src/transforms/esm/transform-cache.ts
+++ b/src/transforms/esm/transform-cache.ts
@@ -20,6 +20,7 @@ const logger = baseLogger.component("transform-cache");
 
 const DEFAULT_TTL_SECONDS = 300; // 5 minutes
 const FALLBACK_MAX_ENTRIES = 500;
+const FALLBACK_MAX_SIZE_BYTES = 50 * 1024 * 1024;
 export const TRANSFORM_FLIGHT_STALE_EVICTION_MS = 5 * 60_000;
 
 /**
@@ -153,10 +154,16 @@ interface LocalFallbackLike<K, V> {
   entries(): IterableIterator<[K, V]>;
 }
 
-class EntryBoundedFallback<K, V> implements LocalFallbackLike<K, V> {
+class BoundedFallback<K, V> implements LocalFallbackLike<K, V> {
   private readonly store = new Map<K, V>();
+  private readonly entrySizes = new Map<K, number>();
+  private currentSizeBytes = 0;
 
-  constructor(private readonly maxEntries: number) {}
+  constructor(
+    private readonly maxEntries: number,
+    private readonly maxSizeBytes: number,
+    private readonly estimateSizeOf: (key: K, value: V) => number,
+  ) {}
 
   get(key: K): V | undefined {
     const value = this.store.get(key);
@@ -167,18 +174,35 @@ class EntryBoundedFallback<K, V> implements LocalFallbackLike<K, V> {
   }
 
   set(key: K, value: V): void {
-    this.store.delete(key);
+    const entrySize = this.estimateSizeOf(key, value);
+    // Reject individually oversized entries up front: admitting one would make
+    // the eviction loop below flush every cached entry (including this one).
+    if (entrySize > this.maxSizeBytes) {
+      this.delete(key);
+      return;
+    }
+    this.delete(key);
     this.store.set(key, value);
+    this.entrySizes.set(key, entrySize);
+    this.currentSizeBytes += entrySize;
 
-    while (this.store.size > this.maxEntries) {
-      const oldestKey = this.store.keys().next();
-      if (oldestKey.done) break;
-      this.store.delete(oldestKey.value);
+    // The just-admitted entry fits within maxSizeBytes, so evicting oldest
+    // entries always terminates before the store can run empty.
+    while (
+      this.store.size > 0 &&
+      (this.store.size > this.maxEntries || this.currentSizeBytes > this.maxSizeBytes)
+    ) {
+      this.delete(this.store.keys().next().value as K);
     }
   }
 
   delete(key: K): boolean {
-    return this.store.delete(key);
+    const deleted = this.store.delete(key);
+    if (deleted) {
+      this.currentSizeBytes -= this.entrySizes.get(key) ?? 0;
+      this.entrySizes.delete(key);
+    }
+    return deleted;
   }
 
   has(key: K): boolean {
@@ -187,6 +211,8 @@ class EntryBoundedFallback<K, V> implements LocalFallbackLike<K, V> {
 
   clear(): void {
     this.store.clear();
+    this.entrySizes.clear();
+    this.currentSizeBytes = 0;
   }
 
   get size(): number {
@@ -198,8 +224,42 @@ class EntryBoundedFallback<K, V> implements LocalFallbackLike<K, V> {
   }
 }
 
-const defaultLocalFallback = new EntryBoundedFallback<string, TransformCacheEntry>(
+/** Rough per-entry object/bookkeeping overhead beyond the string payloads. */
+const FALLBACK_ENTRY_OVERHEAD_BYTES = 64;
+/** Rough per-observation object overhead beyond its string payloads. */
+const FALLBACK_OBSERVATION_OVERHEAD_BYTES = 32;
+
+function estimateUtf16Bytes(value: string): number {
+  return value.length * 2;
+}
+
+/**
+ * Estimate the retained size of one fallback cache entry, counting every
+ * field the cache keeps alive: the key string, the transformed code, the
+ * hash, the bundle manifest id, and the dependency-resolution observations.
+ * Leaving any retained field out of this estimate would reopen the memory
+ * exhaustion path the byte budget exists to close.
+ */
+function estimateFallbackEntrySize(key: string, entry: TransformCacheEntry): number {
+  let size = FALLBACK_ENTRY_OVERHEAD_BYTES +
+    estimateUtf16Bytes(key) +
+    estimateUtf16Bytes(entry.code) +
+    estimateUtf16Bytes(entry.hash);
+  if (entry.bundleManifestId !== undefined) {
+    size += estimateUtf16Bytes(entry.bundleManifestId);
+  }
+  for (const observation of entry.dependencyResolutionObservations ?? []) {
+    size += FALLBACK_OBSERVATION_OVERHEAD_BYTES +
+      estimateUtf16Bytes(observation.packageName) +
+      (observation.declaration === null ? 0 : estimateUtf16Bytes(observation.declaration));
+  }
+  return size;
+}
+
+const defaultLocalFallback = new BoundedFallback<string, TransformCacheEntry>(
   FALLBACK_MAX_ENTRIES,
+  FALLBACK_MAX_SIZE_BYTES,
+  estimateFallbackEntrySize,
 );
 
 /** Injected caches for testing */

--- a/src/transforms/esm/transform-cache.ts
+++ b/src/transforms/esm/transform-cache.ts
@@ -178,7 +178,6 @@ class BoundedFallback<K, V> implements LocalFallbackLike<K, V> {
     // Reject individually oversized entries up front: admitting one would make
     // the eviction loop below flush every cached entry (including this one).
     if (entrySize > this.maxSizeBytes) {
-      this.delete(key);
       return;
     }
     this.delete(key);


### PR DESCRIPTION
### Motivation

- A recent change replaced the byte-bounded LRU fallback with an entry-count-only Map, which can retain many arbitrarily large transform outputs and enable memory exhaustion under attacker-controlled inputs. 
- The goal is to restore an aggregate memory bound for the local fallback while preserving the 500-entry insertion-order LRU semantics and the Map-like test surface.

### Description

- Add an aggregate fallback size limit `FALLBACK_MAX_SIZE_BYTES = 50 MiB` and replace the entry-only fallback with a `BoundedFallback` that tracks per-entry sizes and the current total bytes. 
- Account for entry sizes on insert, overwrite, eviction, deletion, and clear by maintaining an `entrySizes` map and `currentSizeBytes` counter. 
- Change eviction to run while either the entry count exceeds `FALLBACK_MAX_ENTRIES` or the total size exceeds `FALLBACK_MAX_SIZE_BYTES`, evicting least-recently-used entries in insertion-order without global sorting. 
- Update the default local fallback to use a simple estimator based on the transform `code` and `hash` lengths and extend tests to reject oversized retention and to assert aggregate-size eviction behavior.

### Testing

- Ran repository verifications: `git diff --check` returned clean and working-tree status was inspected successfully. 
- Attempted the project checks and unit tests via `deno fmt --check`, `deno test --no-check --allow-all src/transforms/esm/transform-cache.test.ts`, `deno lint`, and `deno check`, but `deno` is not installed in the execution environment so these commands could not be executed. 
- Attempted to obtain a local `deno` via `npx --yes deno --version`, but the package registry returned HTTP 403 and the installation failed, so automated Deno test runs were not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7021d144a4832d90d48a80787fc2cb)