### PR TITLE
fix(ssr): bound transform waiter queues

### DIFF
--- a/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.test.ts
@@ -205,6 +205,33 @@ describe("modules/react-loader/ssr-module-loader/cache/memory", () => {
         resetState();
       }
     });
+
+    it("should bound queued acquisitions for one project", async () => {
+      const previousLimit = Deno.env.get("SSR_TRANSFORM_PER_PROJECT_LIMIT");
+      Deno.env.set("SSR_TRANSFORM_PER_PROJECT_LIMIT", "1");
+      resetState();
+
+      const projectId = "bounded-waiter-project";
+      try {
+        assertEquals(acquireTransformSlot(projectId), true);
+
+        const waiters = Array.from(
+          { length: 1_024 },
+          () => tryAcquireTransformSlot(projectId, 10_000),
+        );
+        assertEquals(await tryAcquireTransformSlot(projectId, 10_000), false);
+
+        clearSSRModuleCacheForProject(projectId);
+        assertEquals(await Promise.all(waiters), Array(1_024).fill(false));
+      } finally {
+        if (previousLimit === undefined) {
+          Deno.env.delete("SSR_TRANSFORM_PER_PROJECT_LIMIT");
+        } else {
+          Deno.env.set("SSR_TRANSFORM_PER_PROJECT_LIMIT", previousLimit);
+        }
+        resetState();
+      }
+    });
   });
 
   describe("getTransformStats", () => {

--- a/src/modules/react-loader/ssr-module-loader/cache/memory.ts
+++ b/src/modules/react-loader/ssr-module-loader/cache/memory.ts
@@ -84,9 +84,20 @@ type ProjectTransformWaiter = {
   timeoutId: ReturnType<typeof setTimeout>;
   signal?: AbortSignal;
   onAbort?: () => void;
+  previous?: ProjectTransformWaiter;
+  next?: ProjectTransformWaiter;
 };
 
-const projectTransformWaiters = new Map<string, ProjectTransformWaiter[]>();
+type ProjectTransformWaiterQueue = {
+  head?: ProjectTransformWaiter;
+  tail?: ProjectTransformWaiter;
+  size: number;
+};
+
+// Bound pending work per tenant so transform contention cannot consume
+// unbounded memory before the acquisition timeout applies backpressure.
+const MAX_PROJECT_TRANSFORM_WAITERS = 1_024;
+const projectTransformWaiters = new Map<string, ProjectTransformWaiterQueue>();
 
 /**
  * Projects that bypass per-project rate limiting.
@@ -135,9 +146,14 @@ function removeProjectTransformWaiter(
   const queue = projectTransformWaiters.get(projectId);
   if (!queue) return;
 
-  const index = queue.indexOf(waiter);
-  if (index !== -1) queue.splice(index, 1);
-  if (queue.length === 0) projectTransformWaiters.delete(projectId);
+  if (waiter.previous) waiter.previous.next = waiter.next;
+  else queue.head = waiter.next;
+  if (waiter.next) waiter.next.previous = waiter.previous;
+  else queue.tail = waiter.previous;
+  queue.size--;
+  waiter.previous = undefined;
+  waiter.next = undefined;
+  if (queue.size === 0) projectTransformWaiters.delete(projectId);
 }
 
 function settleProjectTransformWaiter(
@@ -172,26 +188,26 @@ function wakeNextProjectTransformWaiter(projectId: string): void {
   if (limit <= 0) return;
 
   const queue = projectTransformWaiters.get(projectId);
-  if (!queue?.length) return;
+  if (!queue?.head) return;
 
   const current = projectTransformCounts.get(projectId) ?? 0;
   if (current >= limit) return;
 
-  const waiter = queue.shift();
-  if (queue.length === 0) projectTransformWaiters.delete(projectId);
-  if (!waiter) return;
-
+  const waiter = queue.head;
   projectTransformCounts.set(projectId, current + 1);
   settleProjectTransformWaiter(projectId, waiter, true);
 }
 
 function rejectProjectTransformWaiters(projectId: string): void {
   const queue = projectTransformWaiters.get(projectId);
-  if (!queue?.length) return;
+  if (!queue?.head) return;
 
   projectTransformWaiters.delete(projectId);
-  for (const waiter of queue) {
+  let waiter: ProjectTransformWaiter | undefined = queue.head;
+  while (waiter) {
+    const next: ProjectTransformWaiter | undefined = waiter.next;
     settleProjectTransformWaiter(projectId, waiter, false);
+    waiter = next;
   }
 }
 
@@ -217,6 +233,12 @@ export async function tryAcquireTransformSlot(
   if (timeoutMs <= 0) return false;
 
   return new Promise<boolean>((resolve, reject) => {
+    let queue = projectTransformWaiters.get(projectId);
+    if (queue && queue.size >= MAX_PROJECT_TRANSFORM_WAITERS) {
+      resolve(false);
+      return;
+    }
+
     const waiter: ProjectTransformWaiter = {
       resolve,
       reject,
@@ -226,12 +248,16 @@ export async function tryAcquireTransformSlot(
       signal,
     };
 
-    const queue = projectTransformWaiters.get(projectId);
-    if (queue) {
-      queue.push(waiter);
-    } else {
-      projectTransformWaiters.set(projectId, [waiter]);
+    if (!queue) {
+      queue = { size: 0 };
+      projectTransformWaiters.set(projectId, queue);
     }
+
+    waiter.previous = queue.tail;
+    if (queue.tail) queue.tail.next = waiter;
+    else queue.head = waiter;
+    queue.tail = waiter;
+    queue.size++;
 
     if (signal) {
       waiter.onAbort = () => abortProjectTransformWaiter(projectId, waiter);


### PR DESCRIPTION
### Motivation

- A per-project unbounded array of transform waiters used `indexOf`/`splice` and `shift`, producing O(n) removals and O(n²) behavior under mass timeouts or drains and enabling CPU DoS for noisy tenants.

### Description

- Replace the array-backed per-project waiter list with a doubly-linked FIFO queue so removal and wake-up are O(1).
- Add a per-project cap `MAX_PROJECT_TRANSFORM_WAITERS = 1024` and immediately reject acquisitions beyond that bound to provide tenant-level backpressure.
- Update `removeProjectTransformWaiter`, `wakeNextProjectTransformWaiter`, `rejectProjectTransformWaiters`, and `tryAcquireTransformSlot` to use the linked queue and handle cleanup correctly while preserving the existing boolean acquisition API and timeout semantics.
- Add a focused test `should bound queued acquisitions for one project` to validate the queue cap and cleanup behavior during `clearSSRModuleCacheForProject`.

### Testing

- `git diff --check` was run and passed.
- `npx -y deno@latest fmt --check src/modules/react-loader/ssr-module-loader/cache/memory.ts src/modules/react-loader/ssr-module-loader/cache/memory.test.ts` was attempted but could not run because the environment could not fetch the `deno` package (npm registry 403), so formatting checks were blocked.
- `npx -y deno@latest test --no-check --allow-all src/modules/react-loader/ssr-module-loader/cache/memory.test.ts` was attempted but similarly blocked by the same registry restriction, so unit tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7021c39fa4832d81354e22a59946ce)