### PR TITLE
fix(integrations): remove injectable Outlook group lookup

### DIFF
--- a/docs/api-reference/veryfront/oauth.md
+++ b/docs/api-reference/veryfront/oauth.md
@@ -121,16 +121,16 @@ export const GET = createOAuthCallbackHandler(gmailConfig, { tokenStore });
 | `mailchimpConfig`                  | Configuration used by mailchimp.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/common.ts#L264)     |
 | `mondayConfig`                     | Configuration used by monday.      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/common.ts#L200)     |
 | `notionConfig`                     | Configuration used by notion.      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/common.ts#L46)      |
-| `oneDriveConfig`                   | Configuration used by one drive.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/microsoft.ts#L73)   |
+| `oneDriveConfig`                   | Configuration used by one drive.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/microsoft.ts#L72)   |
 | `outlookConfig`                    | Configuration used by outlook.     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/microsoft.ts#L20)   |
 | `pipedriveConfig`                  | Configuration used by pipedrive.   | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/common.ts#L394)     |
 | `quickbooksConfig`                 | Configuration used by quickbooks.  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/common.ts#L292)     |
 | `salesforceConfig`                 | Configuration used by salesforce.  | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/common.ts#L157)     |
-| `sharePointConfig`                 | Configuration used by share point. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/microsoft.ts#L57)   |
+| `sharePointConfig`                 | Configuration used by share point. | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/microsoft.ts#L56)   |
 | `sheetsConfig`                     | Configuration used by sheets.      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/google.ts#L50)      |
 | `shopifyConfig`                    | Configuration used by shopify.     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/common.ts#L278)     |
 | `slackConfig`                      | Configuration used by slack.       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/common.ts#L19)      |
-| `teamsConfig`                      | Configuration used by teams.       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/microsoft.ts#L40)   |
+| `teamsConfig`                      | Configuration used by teams.       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/microsoft.ts#L39)   |
 | `trelloConfig`                     | Configuration used by trello.      | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/common.ts#L362)     |
 | `twitterConfig`                    | Configuration used by twitter.     | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/common.ts#L171)     |
 | `webexConfig`                      | Configuration used by webex.       | [source](https://github.com/veryfront/veryfront-code/blob/main/src/oauth/providers/common.ts#L343)     |

--- a/src/integrations/_data.test.ts
+++ b/src/integrations/_data.test.ts
@@ -787,7 +787,7 @@ describe("integration endpoint specs", () => {
       ["gitlab", 10],
       ["jira", 12],
       ["confluence", 7],
-      ["outlook", 63],
+      ["outlook", 62],
       ["teams", 7],
     ]);
 
@@ -1823,7 +1823,6 @@ describe("integration endpoint specs", () => {
       "Mail.Read.Shared",
       "Calendars.Read",
       "Calendars.ReadWrite",
-      "Group.Read.All",
       "Group-Conversation.Read.All",
       "offline_access",
     ]);
@@ -1870,7 +1869,6 @@ describe("integration endpoint specs", () => {
       "get_thread",
       "list_shared_mailbox_emails",
       "search_shared_mailbox_emails",
-      "find_group_by_mail",
       "list_group_threads",
       "list_group_thread_posts",
       "list_calendars",
@@ -1953,8 +1951,10 @@ describe("integration endpoint specs", () => {
       "microsoft-graph-search",
     );
     assertEquals(
-      getTool("outlook", "find_group_by_mail").endpoint?.url,
-      "https://graph.microsoft.com/v1.0/groups?$filter=mail eq '{mailAddress}'",
+      connectors.find((connector) => connector.name === "outlook")?.tools.some(
+        (tool) => tool.id === "outlook__find_group_by_mail",
+      ),
+      false,
     );
     assertEquals(
       getTool("outlook", "list_group_threads").endpoint?.url,

--- a/src/integrations/_data.ts
+++ b/src/integrations/_data.ts
@@ -37904,7 +37904,6 @@ export const connectors: IntegrationConfig[] = [
         "Mail.Read.Shared",
         "Calendars.Read",
         "Calendars.ReadWrite",
-        "Group.Read.All",
         "Group-Conversation.Read.All",
         "offline_access",
       ],
@@ -39156,37 +39155,6 @@ export const connectors: IntegrationConfig[] = [
             "omitted": "large email bodies and provider-specific message fields",
           },
         },
-      },
-    }, {
-      "id": "outlook__find_group_by_mail",
-      "name": "Find Group By Mail",
-      "description":
-        "Find a Microsoft 365 group by primary email address before reading its group inbox threads",
-      "requiresWrite": false,
-      "endpoint": {
-        "method": "GET",
-        "url": "https://graph.microsoft.com/v1.0/groups?$filter=mail eq '{mailAddress}'",
-        "params": {
-          "mailAddress": {
-            "type": "string",
-            "in": "path",
-            "description": "Microsoft 365 group primary email address",
-            "required": true,
-          },
-          "$select": {
-            "type": "string",
-            "in": "query",
-            "description": "Comma-separated group fields to return",
-            "default": "id,displayName,mail,mailNickname,groupTypes,securityEnabled,mailEnabled",
-          },
-          "$top": {
-            "type": "number",
-            "in": "query",
-            "description": "Maximum groups to return",
-            "default": 5,
-          },
-        },
-        "response": { "transform": "value" },
       },
     }, {
       "id": "outlook__list_group_threads",

--- a/src/oauth/providers/microsoft.ts
+++ b/src/oauth/providers/microsoft.ts
@@ -30,7 +30,6 @@ export const outlookConfig: OAuthServiceConfig = {
     "Mail.Read.Shared",
     "Calendars.Read",
     "Calendars.ReadWrite",
-    "Group.Read.All",
     "Group-Conversation.Read.All",
     "offline_access",
   ],

--- a/templates/integrations/outlook/connector.json
+++ b/templates/integrations/outlook/connector.json
@@ -15,7 +15,6 @@
       "Mail.Read.Shared",
       "Calendars.Read",
       "Calendars.ReadWrite",
-      "Group.Read.All",
       "Group-Conversation.Read.All",
       "offline_access"
     ],
@@ -1804,39 +1803,6 @@
             ],
             "omitted": "large email bodies and provider-specific message fields"
           }
-        }
-      }
-    },
-    {
-      "id": "outlook__find_group_by_mail",
-      "name": "Find Group By Mail",
-      "description": "Find a Microsoft 365 group by primary email address before reading its group inbox threads",
-      "requiresWrite": false,
-      "endpoint": {
-        "method": "GET",
-        "url": "https://graph.microsoft.com/v1.0/groups?$filter=mail eq '{mailAddress}'",
-        "params": {
-          "mailAddress": {
-            "type": "string",
-            "in": "path",
-            "description": "Microsoft 365 group primary email address",
-            "required": true
-          },
-          "$select": {
-            "type": "string",
-            "in": "query",
-            "description": "Comma-separated group fields to return",
-            "default": "id,displayName,mail,mailNickname,groupTypes,securityEnabled,mailEnabled"
-          },
-          "$top": {
-            "type": "number",
-            "in": "query",
-            "description": "Maximum groups to return",
-            "default": 5
-          }
-        },
-        "response": {
-          "transform": "value"
         }
       }
     },


### PR DESCRIPTION
### Motivation
- The Outlook `find_group_by_mail` tool inlined an untrusted `mailAddress` into a Microsoft Graph OData `$filter`, creating an OData injection primitive that could enumerate group IDs when combined with newly added group read scopes and group-thread tools.

### Description
- Removed the `outlook__find_group_by_mail` tool entry and its vulnerable `https://graph.microsoft.com/v1.0/groups?$filter=mail eq '{mailAddress}'` endpoint from the connector template `cli/templates/integrations/outlook/connector.json` and the generated data `src/integrations/_data.ts`.
- Updated `src/integrations/_data.test.ts` to remove references to the unsafe tool and to add a regression assertion that the Outlook connector does not expose a `outlook__find_group_by_mail` tool.
- Committed the changes as a focused fix that preserves existing group-thread/post tools which still require an explicit `groupId`.

### Testing
- Ran `python3 -m json.tool cli/templates/integrations/outlook/connector.json` to validate the JSON template and it succeeded.
- Ran `git diff --check` and a Python presence scan to confirm the vulnerable `find_group_by_mail` identifier and the `mail eq '{mailAddress}'` template are absent from both the template and generated data, and those checks succeeded.
- Attempted to run `deno test --no-check --allow-all src/integrations/_data.test.ts` but Deno is not available in the environment, so the repository unit tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a70329ede90832d89517c797bd51cd6)