### PR TITLE
fix(modules): classify the module error body on the same path as its type

### DIFF
--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -358,10 +358,9 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
   });
 
   it("answers a missing stylesheet module request with 404", async () => {
-    // findSourceFile resolves only the extensions this server compiles to
-    // JavaScript, so a stylesheet never reaches the transform at all. The dev
-    // styles handler serves those. Pinning it keeps the error-body helper from
-    // regrowing a CSS arm that nothing can reach.
+    // An ordinary missing stylesheet stops at the 404 path. Exceptional lookup
+    // failures still reach the CSS-formatted 500 branch covered above, so this
+    // case distinguishes absence from a storage or permission failure.
     const { serveModule } = await import("./module-server.ts");
     const projectDir = "/module-css-unreachable";
     const adapter = createMockAdapter();

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -291,6 +291,56 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     assertEquals(defaultedBody.includes(secret), false);
   });
 
+  it("returns a JSON error body when the rewriter appended .js to a JSON module", async () => {
+    // The import rewriter appends `.js` to any specifier whose extension it
+    // does not recognise, so `@/lib/data.json` arrives as `lib/data.json.js`.
+    // The content type resolved that back to JSON while the error body did not,
+    // so the response carried a JavaScript `throw` under `application/json`.
+    const { serveModule } = await import("./module-server.ts");
+    const projectDir = "/module-error-json-rewritten";
+    const sourcePath = `${projectDir}/lib/data.json`;
+    const adapter = createMockAdapter();
+    adapter.fs.files.set(sourcePath, `{ "value": 1 }`);
+    const originalReadFile = adapter.fs.readFileBytesWithinLimit!.bind(adapter.fs);
+    adapter.fs.readFileBytesWithinLimit = (path, byteLimit) => {
+      if (path === sourcePath) return Promise.reject(new Error("json transform failed"));
+      return originalReadFile(path, byteLimit);
+    };
+
+    const response = await serveModule(
+      new Request("http://localhost:3000/_vf_modules/lib/data.json.js"),
+      { projectId: "module-error-json-rewritten", projectDir, adapter, dev: true },
+    );
+
+    assertEquals(response.status, 500);
+    assertEquals(response.headers.get("content-type"), "application/json; charset=utf-8");
+    assertEquals(
+      JSON.parse(await response.text()),
+      { error: "json transform failed" },
+      "the body must parse as the JSON its content type promises",
+    );
+  });
+
+  it("answers a stylesheet module request with 404 rather than a transform error", async () => {
+    // findSourceFile resolves only the extensions this server compiles to
+    // JavaScript, so a stylesheet never reaches the transform at all. The dev
+    // styles handler serves those. Pinning it keeps the error-body helper from
+    // regrowing a CSS arm that nothing can reach.
+    const { serveModule } = await import("./module-server.ts");
+    const projectDir = "/module-css-unreachable";
+    const adapter = createMockAdapter();
+    adapter.fs.files.set(`${projectDir}/styles/globals.css`, "body { color: red; }");
+
+    for (const requestPath of ["styles/globals.css", "styles/globals.css.js"]) {
+      const response = await serveModule(
+        new Request(`http://localhost:3000/_vf_modules/${requestPath}`),
+        { projectId: "module-css-unreachable", projectDir, adapter, dev: true },
+      );
+
+      assertEquals(response.status, 404, `${requestPath} is not served by the module server`);
+    }
+  });
+
   it("returns a JSON error body when a JSON module fails to transform", async () => {
     const { serveModule } = await import("./module-server.ts");
     const projectDir = "/module-error-json";

--- a/src/modules/server/module-server.test.ts
+++ b/src/modules/server/module-server.test.ts
@@ -321,7 +321,43 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
     );
   });
 
-  it("answers a stylesheet module request with 404 rather than a transform error", async () => {
+  it("returns a CSS error body when a stylesheet lookup fails", async () => {
+    // A missing stylesheet is a 404, but a permission or transient storage
+    // error escapes findSourceFile and surfaces as a 500 that is typed
+    // text/css. The body must be CSS, and the rewriter-appended form must be
+    // classified the same way as the bare one.
+    const { serveModule } = await import("./module-server.ts");
+
+    for (const requestPath of ["styles/globals.css", "styles/globals.css.js"]) {
+      const projectDir = `/module-css-error-${requestPath.replace(/[^a-z]/gi, "")}`;
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(`${projectDir}/styles/globals.css`, "body { color: red; }");
+      adapter.fs.stat = () => Promise.reject(new Error("EACCES: denied */ escape"));
+      adapter.fs.readFileBytesWithinLimit = () =>
+        Promise.reject(new Error("EACCES: denied */ escape"));
+
+      const response = await serveModule(
+        new Request(`http://localhost:3000/_vf_modules/${requestPath}`),
+        { projectId: "module-css-error", projectDir, adapter, dev: true },
+      );
+      const body = await response.text();
+
+      assertEquals(response.status, 500);
+      assertEquals(response.headers.get("content-type"), "text/css; charset=utf-8");
+      assertEquals(
+        body.startsWith("/*") && body.endsWith("*/"),
+        true,
+        `${requestPath} must answer with a CSS comment, not a JavaScript throw`,
+      );
+      assertEquals(
+        body.includes("denied *\\/ escape"),
+        true,
+        "a comment terminator inside the message must be escaped, not end the comment early",
+      );
+    }
+  });
+
+  it("answers a missing stylesheet module request with 404", async () => {
     // findSourceFile resolves only the extensions this server compiles to
     // JavaScript, so a stylesheet never reaches the transform at all. The dev
     // styles handler serves those. Pinning it keeps the error-body helper from
@@ -337,7 +373,7 @@ describe({ name: "serveModule", sanitizeResources: false, sanitizeOps: false }, 
         { projectId: "module-css-unreachable", projectDir, adapter, dev: true },
       );
 
-      assertEquals(response.status, 404, `${requestPath} is not served by the module server`);
+      assertEquals(response.status, 404, `${requestPath} has no source file to serve`);
     }
   });
 

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -1698,14 +1698,19 @@ function getClientModuleError(dev: boolean, errorMessage: string): string {
 /**
  * The body served when a module fails to transform.
  *
- * There is no CSS arm. `findSourceFile` resolves only the extensions it can
- * compile to JavaScript, so a `.css` request never reaches here in either the
- * bare or the rewriter-appended form; both answer 404. Stylesheets are served
- * by the dev styles handler instead. An arm here would be unreachable code
- * implying support this server does not offer.
+ * A stylesheet reaches here only when the lookup itself fails rather than
+ * reporting the file missing: a permission or transient storage error escapes
+ * `findSourceFile` and surfaces as a 500 instead of a 404. The response is
+ * typed `text/css` in that case, so the body has to be CSS.
  */
 function createModuleErrorBody(modulePath: string, errorMessage: string): string {
   const sourcePath = getModuleSourcePath(modulePath);
+
+  if (sourcePath.endsWith(".css")) {
+    // A comment cannot contain its own terminator.
+    const sanitized = errorMessage.replace(/\*\//g, "*\\/");
+    return `/* Transform Error: ${sanitized} */`;
+  }
 
   if (sourcePath.endsWith(".json") || sourcePath.endsWith(".map")) {
     return JSON.stringify({ error: errorMessage });

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -1642,11 +1642,6 @@ function getModuleHeaders(
 const COMPILED_TO_JS_EXTENSIONS = /\.(?:tsx?|jsx|mdx|md)$/;
 
 /**
- * Content type for a dev module response.
- *
- * Exported for testing.
- */
-/**
  * The source path a module request refers to.
  *
  * The import rewriter appends `.js` to any specifier whose extension it does
@@ -1661,6 +1656,11 @@ function getModuleSourcePath(modulePath: string): string {
   return modulePath.toLowerCase().replace(/\.(?:mjs|js)$/, "");
 }
 
+/**
+ * Content type for a dev module response.
+ *
+ * Exported for testing.
+ */
 export function getDevModuleContentType(modulePath: string): string {
   const normalizedPath = modulePath.toLowerCase();
   const sourcePath = getModuleSourcePath(modulePath);

--- a/src/modules/server/module-server.ts
+++ b/src/modules/server/module-server.ts
@@ -1646,13 +1646,24 @@ const COMPILED_TO_JS_EXTENSIONS = /\.(?:tsx?|jsx|mdx|md)$/;
  *
  * Exported for testing.
  */
+/**
+ * The source path a module request refers to.
+ *
+ * The import rewriter appends `.js` to any specifier whose extension it does
+ * not recognise, so `@/lib/data.json` arrives here as `lib/data.json.js` while
+ * the source file, and therefore the body, is still raw JSON.
+ *
+ * The content type and the error body must classify on the same path. They did
+ * not, so a failing `lib/data.json.js` was answered with a JavaScript `throw`
+ * body under `application/json`.
+ */
+function getModuleSourcePath(modulePath: string): string {
+  return modulePath.toLowerCase().replace(/\.(?:mjs|js)$/, "");
+}
+
 export function getDevModuleContentType(modulePath: string): string {
   const normalizedPath = modulePath.toLowerCase();
-  // The import rewriter appends `.js` to any specifier whose extension it does
-  // not recognise, so `@/lib/data.json` arrives here as `lib/data.json.js`
-  // while the source file, and therefore the body, is still raw JSON. Resolve
-  // the source extension the same way the module lookup does before deciding.
-  const sourcePath = normalizedPath.replace(/\.(?:mjs|js)$/, "");
+  const sourcePath = getModuleSourcePath(modulePath);
 
   if (sourcePath.endsWith(".map") || sourcePath.endsWith(".json")) {
     return "application/json; charset=utf-8";
@@ -1684,15 +1695,19 @@ function getClientModuleError(dev: boolean, errorMessage: string): string {
   return dev ? errorMessage : PRODUCTION_MODULE_ERROR;
 }
 
+/**
+ * The body served when a module fails to transform.
+ *
+ * There is no CSS arm. `findSourceFile` resolves only the extensions it can
+ * compile to JavaScript, so a `.css` request never reaches here in either the
+ * bare or the rewriter-appended form; both answer 404. Stylesheets are served
+ * by the dev styles handler instead. An arm here would be unreachable code
+ * implying support this server does not offer.
+ */
 function createModuleErrorBody(modulePath: string, errorMessage: string): string {
-  const normalizedPath = modulePath.toLowerCase();
+  const sourcePath = getModuleSourcePath(modulePath);
 
-  if (normalizedPath.endsWith(".css")) {
-    const sanitized = errorMessage.replace(/\*\//g, "*\\/");
-    return `/* Transform Error: ${sanitized} */`;
-  }
-
-  if (normalizedPath.endsWith(".json") || normalizedPath.endsWith(".map")) {
+  if (sourcePath.endsWith(".json") || sourcePath.endsWith(".map")) {
     return JSON.stringify({ error: errorMessage });
   }
 


### PR DESCRIPTION
## Description

The issue reports two things that "mask each other": the CSS error arm is dead code, and *if it were reached*, a failing CSS module would be served a JavaScript `throw` body under `text/css`.

Probing the running server showed the second one is **not hypothetical**, and that the first one is **wrong**.

### The live defect

`getDevModuleContentType` resolves the rewriter's appended `.js` before classifying; `createModuleErrorBody` classified on the raw path and did not. So the two disagreed about what a request was:

```
JSON bare   status=500 type=application/json  body="{\"error\":\"boom\"}"
JSON .js    status=500 type=application/json  body="// Transform Error\nthrow new Error(\"boom\");"   ← wrong
```

Both now derive the source path through `getModuleSourcePath`, so they cannot disagree again.

### The CSS arm is not dead

My first version of this PR deleted it, on the evidence that a stylesheet 404s in both the bare and rewriter-appended forms. That probe was incomplete: it only covered a **missing file**. A stylesheet whose lookup **fails** — a permission or transient storage error — escapes `findSourceFile` and surfaces as a 500 that is typed `text/css`:

```
CSS  bare    status=500 type=text/css  body="// Transform Error\nthrow new Error(\"EACCES...\")"   ← after my deletion
CSS  .css.js status=500 type=text/css  body="// Transform Error\nthrow new Error(\"EACCES...\")"   ← after my deletion
```

So deleting it *introduced* the exact mis-typing this change exists to remove. Caught in review. The arm is restored and now classified on the shared normalised path, which also means `styles/globals.css.js` gets a CSS body where previously only the bare form did.

## Related Issue(s)

Fixes #4090

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have added tests that prove my fix is effective

## Testing

Three tests, verified against `origin/main`:

- **`.json.js` returns a parseable JSON error body** — fails on `main`. Asserts `JSON.parse` succeeds, so a JavaScript body under a JSON content type cannot pass.
- **a failing stylesheet lookup returns a CSS error body** — fails on `main` (the `.css.js` half) and against my own deleted-arm version. Also asserts the `*/` escaping, so a comment terminator in the message cannot end the comment early.
- **a missing stylesheet answers 404** — passes on `main` too. A **pinning test, not a regression test**: it records that a missing stylesheet is a lookup failure rather than a transform error, which is the distinction that makes the CSS arm reachable only through the error path.

```
deno task test:file src/modules/ src/server/     270 passed (3378 steps) | 0 failed
deno check src/modules/index.ts
deno task lint:test-typecheck / lint:anti-slop / lint:test-semantic-dispositions
deno fmt --check, deno lint
```