### PR TITLE
Bind merge-queue review to the queued source

### DIFF
--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -55,7 +55,7 @@ jobs:
               const match = /^(?:refs\/heads\/)?gh-readonly-queue\/.+\/pr-([1-9]\d*)-([0-9a-f]{40})$/i.exec(headRef);
               const pullNumber = match ? Number(match[1]) : undefined;
               return Number.isSafeInteger(pullNumber)
-                ? { pullNumber, sourceHeadSha: match[2].toLowerCase() }
+                ? { pullNumber, baseSha: match[2].toLowerCase() }
                 : undefined;
             };
             const parseReviewWakeupIdentity = (run) => {
@@ -102,6 +102,13 @@ jobs:
                 core.setOutput("key", `run-${context.runId}`);
                 return;
               }
+              const mergeGroupBaseSha =
+                context.payload.merge_group?.base_sha?.toLowerCase();
+              if (queueEntry.baseSha !== mergeGroupBaseSha) {
+                core.setFailed("Merge queue ref does not match its base commit");
+                core.setOutput("key", `run-${context.runId}`);
+                return;
+              }
             }
             const pullNumber = queueEntry?.pullNumber ??
               context.payload.pull_request?.number ??
@@ -113,8 +120,8 @@ jobs:
               core.setOutput("key", `run-${context.runId}`);
               return;
             }
-            let headSha = queueEntry?.sourceHeadSha;
-            if (!headSha) {
+            let headSha;
+            {
               try {
                 const response = await github.rest.git.getRef({
                   owner: context.repo.owner,
@@ -611,15 +618,22 @@ jobs:
                 {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  ref: `heads/gh-readonly-queue/${baseRef}/pr-${pullNumber}-${headSha}`,
+                  ref: `heads/gh-readonly-queue/${baseRef}/pr-${pullNumber}-`,
                 },
                 "merge queue refs",
               );
               const seen = new Set();
-              const expectedQueueRef =
-                `refs/heads/gh-readonly-queue/${baseRef}/pr-${pullNumber}-${headSha}`;
+              const queueRefPrefix =
+                `refs/heads/gh-readonly-queue/${baseRef}/pr-${pullNumber}-`;
               for (const queueRef of refs) {
-                if (queueRef?.ref !== expectedQueueRef) continue;
+                if (
+                  typeof queueRef?.ref !== "string" ||
+                  !queueRef.ref.startsWith(queueRefPrefix)
+                ) continue;
+                const queueBaseSha = queueRef.ref.slice(queueRefPrefix.length);
+                if (!fullSha.test(queueBaseSha)) {
+                  throw new Error("Merge queue ref has a malformed base commit");
+                }
                 const mergeGroupSha = queueRef?.object?.sha;
                 if (!fullSha.test(mergeGroupSha ?? "")) {
                   throw new Error("Merge queue ref has a malformed commit");
@@ -742,7 +756,8 @@ jobs:
             if (
               !Number.isSafeInteger(pullNumber) ||
               pullNumber !== queueEntry.pullNumber ||
-              sourceHeadSha !== queueEntry.sourceHeadSha
+              queueEntry.baseSha !==
+                context.payload.merge_group.base_sha?.toLowerCase()
             ) {
               core.setFailed("Merge queue source does not match its serialized lock");
               return;
@@ -753,6 +768,7 @@ jobs:
               repo: context.repo.repo,
               pullNumber,
               sourceHeadSha,
+              baseSha: queueEntry.baseSha,
               mergeGroupSha: context.payload.merge_group.head_sha,
             });
             if (result.state === "success") {

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -622,6 +622,50 @@ jobs:
                 },
                 "merge queue refs",
               );
+              let queueEntryIdentity;
+              if (refs.length > 0) {
+                const queueResponse = await github.graphql(
+                  `query ResolveIndependentQueueSource(
+                    $owner: String!
+                    $repo: String!
+                    $pullNumber: Int!
+                  ) {
+                    repository(owner: $owner, name: $repo) {
+                      pullRequest(number: $pullNumber) {
+                        number
+                        headRefOid
+                        mergeQueueEntry {
+                          baseCommit { oid }
+                          headCommit { oid }
+                          pullRequest { number headRefOid }
+                        }
+                      }
+                    }
+                  }`,
+                  { owner: context.repo.owner, repo: context.repo.repo, pullNumber },
+                );
+                const queuePull = queueResponse?.repository?.pullRequest;
+                const queueEntry = queuePull?.mergeQueueEntry;
+                const queueSourceHead = queueEntry?.pullRequest?.headRefOid;
+                const queueBaseSha = queueEntry?.baseCommit?.oid;
+                const queueMergeGroupSha = queueEntry?.headCommit?.oid;
+                if (
+                  queuePull?.number !== pullNumber ||
+                  queueEntry?.pullRequest?.number !== pullNumber ||
+                  !fullSha.test(queueSourceHead ?? "") ||
+                  !fullSha.test(queueBaseSha ?? "") ||
+                  !fullSha.test(queueMergeGroupSha ?? "") ||
+                  queuePull?.headRefOid?.toLowerCase() !==
+                    queueSourceHead.toLowerCase()
+                ) throw new Error("Merge queue entry is malformed");
+                if (queueSourceHead.toLowerCase() !== headSha.toLowerCase()) {
+                  return { headSha, queueFailures: 0, skipped: false };
+                }
+                queueEntryIdentity = {
+                  baseSha: queueBaseSha.toLowerCase(),
+                  mergeGroupSha: queueMergeGroupSha.toLowerCase(),
+                };
+              }
               const seen = new Set();
               const queueRefPrefix =
                 `refs/heads/gh-readonly-queue/${baseRef}/pr-${pullNumber}-`;
@@ -638,6 +682,11 @@ jobs:
                 if (!fullSha.test(mergeGroupSha ?? "")) {
                   throw new Error("Merge queue ref has a malformed commit");
                 }
+                if (
+                  queueBaseSha.toLowerCase() !== queueEntryIdentity?.baseSha ||
+                  mergeGroupSha.toLowerCase() !==
+                    queueEntryIdentity?.mergeGroupSha
+                ) continue;
                 if (seen.has(mergeGroupSha.toLowerCase())) continue;
                 seen.add(mergeGroupSha.toLowerCase());
                 await github.rest.repos.createCommitStatus({

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -20,6 +20,19 @@ on:
 
 permissions: {}
 
+# Coalesce replaceable state reconciliations before they allocate a runner.
+# Source updates and merge-group checks keep unique run IDs so none are lost.
+concurrency:
+  group: >-
+    ${{
+      github.event_name == 'workflow_run' &&
+        format('{0}-wakeup-{1}', github.workflow, github.event.workflow_run.display_title) ||
+      github.event_name == 'issue_comment' && github.event.issue.pull_request &&
+        format('{0}-comment-pr-{1}', github.workflow, github.event.issue.number) ||
+      format('{0}-run-{1}', github.workflow, github.run_id)
+    }}
+  cancel-in-progress: false
+
 jobs:
   target:
     name: resolve automated review target

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -548,6 +548,14 @@ jobs:
               core.setFailed("The review status boundary is invalid");
               return;
             }
+            const parseMergeQueuePullNumber = (headRef) => {
+              if (typeof headRef !== "string") return undefined;
+              const match = /^(?:refs\/heads\/)?gh-readonly-queue\/.+\/pr-([1-9]\d*)-([0-9a-f]{40})$/i.exec(headRef);
+              const number = match ? Number(match[1]) : undefined;
+              return Number.isSafeInteger(number)
+                ? { pullNumber: number, baseSha: match[2].toLowerCase() }
+                : undefined;
+            };
             const collectAll = async (endpoint, parameters, source) => {
               const items = [];
               for await (
@@ -566,13 +574,35 @@ jobs:
               }
               return items;
             };
+            const resolveQueueRefTarget = async (ref) => {
+              let response;
+              try {
+                response = await github.rest.git.getRef({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref,
+                });
+              } catch (error) {
+                if (error?.status === 404) return undefined;
+                throw error;
+              }
+              const sha = response?.data?.object?.sha;
+              if (!fullSha.test(sha ?? "")) {
+                throw new Error("Merge queue ref response has a malformed commit");
+              }
+              return sha;
+            };
             const publishIndependentFailure = async () => {
               const pull = await github.rest.pulls.get({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: pullNumber,
               });
-              if (pull.data?.head?.sha?.toLowerCase() !== headSha.toLowerCase()) {
+              const pullHeadSha = pull.data?.head?.sha;
+              if (!fullSha.test(pullHeadSha ?? "")) {
+                throw new Error("Pull request head response has a malformed commit");
+              }
+              if (pullHeadSha.toLowerCase() !== headSha.toLowerCase()) {
                 return { headSha, queueFailures: 0, skipped: true };
               }
               const baseRepositoryId = pull.data?.base?.repo?.id;
@@ -631,77 +661,98 @@ jobs:
                 {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  ref: `heads/gh-readonly-queue/${baseRef}/pr-${pullNumber}-`,
+                  ref: "heads/gh-readonly-queue/",
                 },
                 "merge queue refs",
               );
-              let queueEntryIdentity;
-              if (refs.length > 0) {
-                const queueResponse = await github.graphql(
-                  `query ResolveIndependentQueueSource(
-                    $owner: String!
-                    $repo: String!
-                    $pullNumber: Int!
-                  ) {
-                    repository(owner: $owner, name: $repo) {
-                      pullRequest(number: $pullNumber) {
-                        number
-                        headRefOid
-                        mergeQueueEntry {
-                          baseCommit { oid }
-                          headCommit { oid }
-                          pullRequest { number headRefOid }
-                        }
-                      }
-                    }
-                  }`,
-                  { owner: context.repo.owner, repo: context.repo.repo, pullNumber },
-                );
-                const queuePull = queueResponse?.repository?.pullRequest;
-                const queueEntry = queuePull?.mergeQueueEntry;
-                const queueSourceHead = queueEntry?.pullRequest?.headRefOid;
-                const queueBaseSha = queueEntry?.baseCommit?.oid;
-                const queueMergeGroupSha = queueEntry?.headCommit?.oid;
-                if (
-                  queuePull?.number !== pullNumber ||
-                  queueEntry?.pullRequest?.number !== pullNumber ||
-                  !fullSha.test(queueSourceHead ?? "") ||
-                  !fullSha.test(queueBaseSha ?? "") ||
-                  !fullSha.test(queueMergeGroupSha ?? "") ||
-                  queuePull?.headRefOid?.toLowerCase() !==
-                    queueSourceHead.toLowerCase()
-                ) throw new Error("Merge queue entry is malformed");
-                if (queueSourceHead.toLowerCase() !== headSha.toLowerCase()) {
-                  return { headSha, queueFailures: 0, skipped: false };
-                }
-                queueEntryIdentity = {
-                  baseSha: queueBaseSha.toLowerCase(),
-                  mergeGroupSha: queueMergeGroupSha.toLowerCase(),
-                };
-              }
               const seen = new Set();
-              const queueRefPrefix =
-                `refs/heads/gh-readonly-queue/${baseRef}/pr-${pullNumber}-`;
               for (const queueRef of refs) {
-                if (
-                  typeof queueRef?.ref !== "string" ||
-                  !queueRef.ref.startsWith(queueRefPrefix)
-                ) continue;
-                const queueBaseSha = queueRef.ref.slice(queueRefPrefix.length);
-                if (!fullSha.test(queueBaseSha)) {
-                  throw new Error("Merge queue ref has a malformed base commit");
-                }
+                const parsed = parseMergeQueuePullNumber(queueRef?.ref);
+                if (parsed?.pullNumber !== pullNumber) continue;
                 const mergeGroupSha = queueRef?.object?.sha;
                 if (!fullSha.test(mergeGroupSha ?? "")) {
                   throw new Error("Merge queue ref has a malformed commit");
                 }
-                if (
-                  queueBaseSha.toLowerCase() !== queueEntryIdentity?.baseSha ||
-                  mergeGroupSha.toLowerCase() !==
-                    queueEntryIdentity?.mergeGroupSha
-                ) continue;
                 if (seen.has(mergeGroupSha.toLowerCase())) continue;
-                seen.add(mergeGroupSha.toLowerCase());
+                const latestPull = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pullNumber,
+                });
+                const latestHeadSha = latestPull.data?.head?.sha;
+                if (!fullSha.test(latestHeadSha ?? "")) {
+                  throw new Error("Pull request head response has a malformed commit");
+                }
+                if (latestHeadSha.toLowerCase() !== headSha.toLowerCase()) {
+                  continue;
+                }
+                let targetVerified = false;
+                try {
+                  const bindingResponse = await github.graphql(
+                    `query ActiveMergeQueueBinding($owner: String!, $repo: String!, $number: Int!) {
+                      repository(owner: $owner, name: $repo) {
+                        pullRequest(number: $number) {
+                          number
+                          state
+                          headRefOid
+                          baseRefName
+                          mergeQueueEntry {
+                            baseCommit { oid }
+                            headCommit { oid }
+                          }
+                        }
+                      }
+                    }`,
+                    {
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      number: pullNumber,
+                    },
+                  );
+                  const boundPull = bindingResponse?.repository?.pullRequest;
+                  const boundEntry = boundPull?.mergeQueueEntry;
+                  const activeBindingMismatch =
+                    boundPull?.number !== pullNumber ||
+                    boundPull?.state !== "OPEN" ||
+                    boundPull?.headRefOid?.toLowerCase() !== headSha.toLowerCase() ||
+                    boundPull?.baseRefName !== baseRef ||
+                    boundEntry?.baseCommit?.oid?.toLowerCase() !==
+                      parsed.baseSha ||
+                    boundEntry?.headCommit?.oid?.toLowerCase() !==
+                      mergeGroupSha.toLowerCase();
+                  if (!activeBindingMismatch) {
+                    const liveRef = await github.rest.git.getRef({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      ref: queueRef.ref.slice("refs/".length),
+                    });
+                    targetVerified =
+                      liveRef?.data?.object?.sha?.toLowerCase() ===
+                        mergeGroupSha.toLowerCase();
+                  }
+                } catch {
+                  targetVerified = false;
+                }
+                if (!targetVerified) {
+                  const liveTarget = await resolveQueueRefTarget(
+                    queueRef.ref.slice("refs/".length),
+                  );
+                  targetVerified =
+                    liveTarget?.toLowerCase() === mergeGroupSha.toLowerCase();
+                }
+                if (!targetVerified) continue;
+                const finalPull = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pullNumber,
+                });
+                const finalHeadSha = finalPull.data?.head?.sha;
+                if (!fullSha.test(finalHeadSha ?? "")) {
+                  throw new Error("Pull request head response has a malformed commit");
+                }
+                if (finalHeadSha.toLowerCase() !== headSha.toLowerCase()) {
+                  continue;
+                }
                 await github.rest.repos.createCommitStatus({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -711,6 +762,7 @@ jobs:
                   description: `Could not revalidate review for PR #${pullNumber}`,
                   target_url: pullUrl,
                 });
+                seen.add(mergeGroupSha.toLowerCase());
               }
               return {
                 headSha,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -503,13 +503,34 @@ async function collectAll(github, endpoint, parameters, source) {
 async function resolveCommitRef(github, common, ref) {
   try {
     const response = await github.rest.repos.getCommit({ ...common, ref });
-    return response?.data?.sha;
+    const sha = response?.data?.sha;
+    if (!FULL_SHA.test(sha ?? "")) {
+      throw new Error("Commit ref response has a malformed commit");
+    }
+    return sha;
   } catch (error) {
     if (
       typeof error === "object" && error !== null && error.status === 404
     ) return undefined;
     throw error;
   }
+}
+
+async function resolveQueueRefTarget(github, common, ref) {
+  let response;
+  try {
+    response = await github.rest.git.getRef({ ...common, ref });
+  } catch (error) {
+    if (
+      typeof error === "object" && error !== null && error.status === 404
+    ) return undefined;
+    throw error;
+  }
+  const sha = response?.data?.object?.sha;
+  if (!FULL_SHA.test(sha ?? "")) {
+    throw new Error("Merge queue ref response has a malformed commit");
+  }
+  return sha;
 }
 
 /** Fail one source head and every active queue commit derived from it. */
@@ -527,6 +548,14 @@ export async function publishReviewResolutionFailure({
   if (!FULL_SHA.test(sourceHeadSha)) {
     throw new Error("Pull request source commit is malformed");
   }
+  const currentHeadSha = await resolveCommitRef(
+    github,
+    { owner, repo },
+    `refs/pull/${pullNumber}/head`,
+  );
+  if (currentHeadSha?.toLowerCase() !== sourceHeadSha.toLowerCase()) {
+    return { queueFailures: 0, skipped: true };
+  }
   await github.rest.repos.createCommitStatus({
     owner,
     repo,
@@ -542,32 +571,56 @@ export async function publishReviewResolutionFailure({
     { owner, repo, ref: "heads/gh-readonly-queue/" },
     "merge queue refs",
   );
-  const pullQueueRefs = refs.filter((queueRef) =>
-    parseMergeQueuePullNumber(queueRef?.ref)?.pullNumber === pullNumber
-  );
-  if (pullQueueRefs.length === 0) return { queueFailures: 0 };
-  const queueEntry = await resolveCurrentMergeQueueEntry({
-    github,
-    owner,
-    repo,
-    pullNumber,
-  });
-  if (queueEntry.sourceHeadSha !== sourceHeadSha.toLowerCase()) {
-    return { queueFailures: 0 };
-  }
   const seen = new Set();
-  for (const queueRef of pullQueueRefs) {
+  for (const queueRef of refs) {
     const parsed = parseMergeQueuePullNumber(queueRef?.ref);
     const mergeGroupSha = queueRef?.object?.sha;
+    if (parsed?.pullNumber !== pullNumber) continue;
     if (!FULL_SHA.test(mergeGroupSha ?? "")) {
       throw new Error("Merge queue ref has a malformed commit");
     }
-    if (
-      parsed?.baseSha !== queueEntry.baseSha ||
-      mergeGroupSha.toLowerCase() !== queueEntry.mergeGroupSha
-    ) continue;
     if (seen.has(mergeGroupSha.toLowerCase())) continue;
-    seen.add(mergeGroupSha.toLowerCase());
+    const latestSourceHeadSha = await resolveCommitRef(
+      github,
+      { owner, repo },
+      `refs/pull/${pullNumber}/head`,
+    );
+    if (latestSourceHeadSha?.toLowerCase() !== sourceHeadSha.toLowerCase()) {
+      continue;
+    }
+    let targetVerified = false;
+    try {
+      await requireActiveMergeQueueBinding({
+        github,
+        owner,
+        repo,
+        pullNumber,
+        sourceHeadSha,
+        baseSha: parsed.baseSha,
+        mergeGroupSha,
+      });
+      targetVerified = true;
+    } catch {
+      const ref = queueRef.ref.startsWith("refs/")
+        ? queueRef.ref.slice("refs/".length)
+        : queueRef.ref;
+      const liveTarget = await resolveQueueRefTarget(
+        github,
+        { owner, repo },
+        ref,
+      );
+      targetVerified =
+        liveTarget?.toLowerCase() === mergeGroupSha.toLowerCase();
+    }
+    if (!targetVerified) continue;
+    const finalSourceHeadSha = await resolveCommitRef(
+      github,
+      { owner, repo },
+      `refs/pull/${pullNumber}/head`,
+    );
+    if (
+      finalSourceHeadSha?.toLowerCase() !== sourceHeadSha.toLowerCase()
+    ) continue;
     await github.rest.repos.createCommitStatus({
       owner,
       repo,
@@ -577,8 +630,9 @@ export async function publishReviewResolutionFailure({
       description: `Could not revalidate review for PR #${pullNumber}`,
       target_url: pullUrl,
     });
+    seen.add(mergeGroupSha.toLowerCase());
   }
-  return { queueFailures: seen.size };
+  return { queueFailures: seen.size, skipped: false };
 }
 
 async function isCurrentlyTrustedHuman(
@@ -861,7 +915,7 @@ export async function invalidateReviewProof({
       ? response.data.html_url
       : undefined,
   });
-  return { headSha, description, ...result, skipped: false };
+  return { headSha, description, skipped: false, ...result };
 }
 
 /** Extract the pull request represented by a merge queue head ref. */
@@ -1005,6 +1059,70 @@ function latestReviewGateStatusForPull(statuses, pullNumber) {
   );
 }
 
+const ACTIVE_MERGE_QUEUE_BINDING_QUERY = `
+  query ActiveMergeQueueBinding($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        number
+        state
+        headRefOid
+        baseRefName
+        mergeQueueEntry {
+          baseCommit { oid }
+          headCommit { oid }
+        }
+      }
+    }
+  }
+`;
+
+async function requireActiveMergeQueueBinding({
+  github,
+  owner,
+  repo,
+  pullNumber,
+  sourceHeadSha,
+  baseSha,
+  mergeGroupSha,
+}) {
+  const response = await github.graphql(ACTIVE_MERGE_QUEUE_BINDING_QUERY, {
+    owner,
+    repo,
+    number: pullNumber,
+  });
+  const pull = response?.repository?.pullRequest;
+  const entry = pull?.mergeQueueEntry;
+  const liveBaseSha = entry?.baseCommit?.oid;
+  const queueHeadSha = entry?.headCommit?.oid;
+  const baseRef = pull?.baseRefName;
+  const normalizedBaseSha = baseSha.toLowerCase();
+  if (
+    pull?.number !== pullNumber || pull?.state !== "OPEN" ||
+    pull?.headRefOid?.toLowerCase() !== sourceHeadSha.toLowerCase() ||
+    liveBaseSha?.toLowerCase() !== normalizedBaseSha ||
+    queueHeadSha?.toLowerCase() !== mergeGroupSha.toLowerCase() ||
+    typeof baseRef !== "string" || baseRef.length === 0 ||
+    baseRef.length > 1024 || baseRef.includes("\0")
+  ) {
+    throw new Error(
+      "Merge group is not bound to the current pull request head",
+    );
+  }
+  const ref =
+    `heads/gh-readonly-queue/${baseRef}/pr-${pullNumber}-${normalizedBaseSha}`;
+  const parsed = parseMergeQueuePullNumber(`refs/${ref}`);
+  if (
+    parsed?.pullNumber !== pullNumber ||
+    parsed?.baseSha !== normalizedBaseSha
+  ) {
+    throw new Error("Merge queue ref identity is malformed");
+  }
+  const liveTarget = await resolveQueueRefTarget(github, { owner, repo }, ref);
+  if (liveTarget?.toLowerCase() !== mergeGroupSha.toLowerCase()) {
+    throw new Error("Merge queue ref no longer targets this merge group");
+  }
+}
+
 /** Reuse a successful exact-head review for a synthetic merge queue commit. */
 export async function publishMergeGroupReviewStatus({
   github,
@@ -1016,6 +1134,7 @@ export async function publishMergeGroupReviewStatus({
   mergeGroupSha,
 }) {
   let failure;
+  let bindingVerified = false;
   let pullUrl = `https://github.com/${owner}/${repo}/pull/${pullNumber}`;
   try {
     assertMergeGroupInputs({
@@ -1024,17 +1143,16 @@ export async function publishMergeGroupReviewStatus({
       baseSha,
       mergeGroupSha,
     });
-    const queuedSourceHeadSha = await resolveMergeQueueSource({
+    await requireActiveMergeQueueBinding({
       github,
       owner,
       repo,
       pullNumber,
+      sourceHeadSha,
       baseSha,
       mergeGroupSha,
     });
-    if (queuedSourceHeadSha !== sourceHeadSha.toLowerCase()) {
-      throw new Error("Merge queue source does not match its queued entry");
-    }
+    bindingVerified = true;
     const pull = await github.rest.pulls.get({
       owner,
       repo,
@@ -1162,6 +1280,17 @@ export async function publishMergeGroupReviewStatus({
         "Human reviewer is no longer trusted for merge queue reuse",
       );
     }
+    bindingVerified = false;
+    await requireActiveMergeQueueBinding({
+      github,
+      owner,
+      repo,
+      pullNumber,
+      sourceHeadSha,
+      baseSha,
+      mergeGroupSha,
+    });
+    bindingVerified = true;
     currentReviewStatus = latestReviewStatus;
     const description = `Reused exact-head review for PR #${pullNumber}`;
     await github.rest.repos.createCommitStatus({
@@ -1175,11 +1304,16 @@ export async function publishMergeGroupReviewStatus({
         ? currentReviewStatus.target_url
         : pullUrl,
     });
-    return { state: "success", description, failure: undefined };
+    return {
+      state: "success",
+      description,
+      failure: undefined,
+      published: true,
+    };
   } catch (error) {
     failure = error instanceof Error ? error : new Error(String(error));
   }
-  if (FULL_SHA.test(mergeGroupSha)) {
+  if (bindingVerified && FULL_SHA.test(mergeGroupSha)) {
     await github.rest.repos.createCommitStatus({
       owner,
       repo,
@@ -1190,7 +1324,12 @@ export async function publishMergeGroupReviewStatus({
       target_url: pullUrl,
     });
   }
-  return { state: "failure", description: undefined, failure };
+  return {
+    state: "failure",
+    description: undefined,
+    failure,
+    published: bindingVerified,
+  };
 }
 
 /** Reconcile copied review proof on every active queue ref for one source. */
@@ -1235,17 +1374,20 @@ export async function reconcileActiveMergeGroupReviewStatuses({
     }
     if (seen.has(mergeGroupSha.toLowerCase())) continue;
     seen.add(mergeGroupSha.toLowerCase());
-    results.push(
-      await publishMergeGroupReviewStatus({
-        github,
-        owner,
-        repo,
-        pullNumber,
-        sourceHeadSha,
-        baseSha: parsed.baseSha,
-        mergeGroupSha,
-      }),
-    );
+    const result = await publishMergeGroupReviewStatus({
+      github,
+      owner,
+      repo,
+      pullNumber,
+      sourceHeadSha,
+      baseSha: parsed.baseSha,
+      mergeGroupSha,
+    });
+    if (result.state === "failure" && !result.published) {
+      throw result.failure ??
+        new Error("Could not publish the merge queue review failure");
+    }
+    results.push(result);
   }
   return results;
 }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -224,14 +224,10 @@ function evidenceFreshness(
   timeline,
 ) {
   if (boundary === undefined) return "newer";
-  const evidenceTime = Date.parse(
-    timelineEvent === "reviewed"
-      ? evidence?.submitted_at ?? ""
-      : evidence?.created_at ?? "",
-  );
-  if (!Number.isFinite(evidenceTime)) return "ambiguous";
-  if (evidenceTime < boundary.time) return "older";
-  if (evidenceTime > boundary.time) return "newer";
+  const time = evidenceTime(evidence, timelineEvent);
+  if (!Number.isFinite(time)) return "ambiguous";
+  if (time < boundary.time) return "older";
+  if (time > boundary.time) return "newer";
   if (boundary.timelineEvent === undefined) return "ambiguous";
   const boundaryPosition = timelinePosition(
     timeline,
@@ -250,11 +246,13 @@ function evidenceFreshness(
 }
 
 function evidenceTime(evidence, timelineEvent) {
-  return Date.parse(
-    timelineEvent === "reviewed"
-      ? evidence?.submitted_at ?? ""
-      : evidence?.created_at ?? "",
-  );
+  if (timelineEvent === "reviewed") {
+    return Date.parse(evidence?.submitted_at ?? "");
+  }
+  const updatedAt = Date.parse(evidence?.updated_at ?? "");
+  return Number.isFinite(updatedAt)
+    ? updatedAt
+    : Date.parse(evidence?.created_at ?? "");
 }
 
 function isEvidenceProvablyLater(candidate, current, timeline) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -249,6 +249,38 @@ function evidenceFreshness(
   return evidencePosition > boundaryPosition ? "newer" : "older";
 }
 
+function evidenceTime(evidence, timelineEvent) {
+  return Date.parse(
+    timelineEvent === "reviewed"
+      ? evidence?.submitted_at ?? ""
+      : evidence?.created_at ?? "",
+  );
+}
+
+function isEvidenceProvablyLater(candidate, current, timeline) {
+  const candidateTime = evidenceTime(
+    candidate.evidence,
+    candidate.timelineEvent,
+  );
+  const currentTime = evidenceTime(current.evidence, current.timelineEvent);
+  if (!Number.isFinite(candidateTime) || !Number.isFinite(currentTime)) {
+    return false;
+  }
+  if (candidateTime !== currentTime) return candidateTime > currentTime;
+  const candidatePosition = timelinePosition(
+    timeline,
+    candidate.timelineEvent,
+    candidate.evidence?.id,
+  );
+  const currentPosition = timelinePosition(
+    timeline,
+    current.timelineEvent,
+    current.evidence?.id,
+  );
+  return candidatePosition !== undefined && currentPosition !== undefined &&
+    candidatePosition > currentPosition;
+}
+
 function reviewResetDescription(pullNumber, baseBinding, requestKey) {
   const prefix = `PR#${pullNumber} reset base:${baseBinding}`;
   return requestKey === undefined
@@ -315,8 +347,8 @@ export async function findAutomatedReview(
     validReviewNotBefore,
     latestBaseRefChange(events),
   );
-  let codexApproval;
-  let codexReviewFinding = false;
+  const codexSuccesses = [];
+  const codexFindings = [];
   {
     const latestHumanReviews = new Map();
     for (const [index, review] of reviews.entries()) {
@@ -336,21 +368,29 @@ export async function findAutomatedReview(
         freshness === "newer" && state === "APPROVED" &&
         isPinnedBot(review?.user, CODEX_LOGIN)
       ) {
-        codexApproval = {
-          reviewer: CODEX_LOGIN,
-          source: "pull-request-review",
-          state,
-          url: typeof review.html_url === "string"
-            ? review.html_url
-            : undefined,
-        };
+        codexSuccesses.push({
+          evidence: review,
+          timelineEvent: "reviewed",
+          proof: {
+            reviewer: CODEX_LOGIN,
+            source: "pull-request-review",
+            state,
+            url: typeof review.html_url === "string"
+              ? review.html_url
+              : undefined,
+          },
+        });
         continue;
       }
       if (
         freshness !== "older" && isPinnedBot(review?.user, CODEX_LOGIN) &&
         (state === "COMMENTED" || state === "CHANGES_REQUESTED")
       ) {
-        codexReviewFinding = true;
+        codexFindings.push({
+          evidence: review,
+          freshness,
+          timelineEvent: "reviewed",
+        });
         continue;
       }
       if (
@@ -381,8 +421,6 @@ export async function findAutomatedReview(
     }
   }
 
-  let codexNoFindings;
-  let codexFinding = false;
   for (const comment of comments) {
     if (
       !isPinnedBot(comment?.user, CODEX_LOGIN) ||
@@ -413,22 +451,34 @@ export async function findAutomatedReview(
       if (
         freshness === "newer" && comment.body.startsWith(CODEX_NO_FINDINGS)
       ) {
-        codexNoFindings = {
-          reviewer: CODEX_LOGIN,
-          source: "codex-comment",
-          state: "COMMENTED",
-          url: typeof comment.html_url === "string"
-            ? comment.html_url
-            : undefined,
-        };
+        codexSuccesses.push({
+          evidence: comment,
+          timelineEvent: "commented",
+          proof: {
+            reviewer: CODEX_LOGIN,
+            source: "codex-comment",
+            state: "COMMENTED",
+            url: typeof comment.html_url === "string"
+              ? comment.html_url
+              : undefined,
+          },
+        });
       } else {
-        codexFinding = true;
+        codexFindings.push({
+          evidence: comment,
+          freshness,
+          timelineEvent: "commented",
+        });
       }
     }
   }
-  return codexReviewFinding || codexFinding
-    ? undefined
-    : codexApproval ?? codexNoFindings;
+  if (codexFindings.length === 0) return codexSuccesses[0]?.proof;
+  return codexSuccesses.find((success) =>
+    codexFindings.every((finding) =>
+      finding.freshness === "newer" &&
+      isEvidenceProvablyLater(success, finding, timeline)
+    )
+  )?.proof;
 }
 
 async function collectAll(github, endpoint, parameters, source) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -820,12 +820,16 @@ export async function resolveMergeQueueSource({
   repo,
   pullNumber,
   baseSha,
+  mergeGroupSha,
 }) {
   if (!Number.isSafeInteger(pullNumber) || pullNumber < 1) {
     throw new Error("Merge queue pull request number is invalid");
   }
   if (!FULL_SHA.test(baseSha)) {
     throw new Error("Merge queue base commit is malformed");
+  }
+  if (!FULL_SHA.test(mergeGroupSha)) {
+    throw new Error("Merge group commit is malformed");
   }
   const response = await github.graphql(
     `query ResolveMergeQueueSource(
@@ -849,15 +853,14 @@ export async function resolveMergeQueueSource({
   );
   const pullRequest = response?.repository?.pullRequest;
   const entry = pullRequest?.mergeQueueEntry;
-  const sourceHeadSha = entry?.headCommit?.oid;
+  const sourceHeadSha = entry?.pullRequest?.headRefOid;
   if (
     pullRequest?.number !== pullNumber ||
     entry?.pullRequest?.number !== pullNumber ||
     entry?.baseCommit?.oid?.toLowerCase() !== baseSha.toLowerCase() ||
+    entry?.headCommit?.oid?.toLowerCase() !== mergeGroupSha.toLowerCase() ||
     !FULL_SHA.test(sourceHeadSha ?? "") ||
-    pullRequest?.headRefOid?.toLowerCase() !== sourceHeadSha.toLowerCase() ||
-    entry?.pullRequest?.headRefOid?.toLowerCase() !==
-      sourceHeadSha.toLowerCase()
+    pullRequest?.headRefOid?.toLowerCase() !== sourceHeadSha.toLowerCase()
   ) {
     throw new Error("Merge queue entry does not match its queued pull request");
   }
@@ -934,6 +937,7 @@ export async function publishMergeGroupReviewStatus({
       repo,
       pullNumber,
       baseSha,
+      mergeGroupSha,
     });
     if (queuedSourceHeadSha !== sourceHeadSha.toLowerCase()) {
       throw new Error("Merge queue source does not match its queued entry");

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -492,14 +492,30 @@ export async function publishReviewResolutionFailure({
     { owner, repo, ref: "heads/gh-readonly-queue/" },
     "merge queue refs",
   );
+  const pullQueueRefs = refs.filter((queueRef) =>
+    parseMergeQueuePullNumber(queueRef?.ref)?.pullNumber === pullNumber
+  );
+  if (pullQueueRefs.length === 0) return { queueFailures: 0 };
+  const queueEntry = await resolveCurrentMergeQueueEntry({
+    github,
+    owner,
+    repo,
+    pullNumber,
+  });
+  if (queueEntry.sourceHeadSha !== sourceHeadSha.toLowerCase()) {
+    return { queueFailures: 0 };
+  }
   const seen = new Set();
-  for (const queueRef of refs) {
+  for (const queueRef of pullQueueRefs) {
     const parsed = parseMergeQueuePullNumber(queueRef?.ref);
     const mergeGroupSha = queueRef?.object?.sha;
-    if (parsed?.pullNumber !== pullNumber) continue;
     if (!FULL_SHA.test(mergeGroupSha ?? "")) {
       throw new Error("Merge queue ref has a malformed commit");
     }
+    if (
+      parsed?.baseSha !== queueEntry.baseSha ||
+      mergeGroupSha.toLowerCase() !== queueEntry.mergeGroupSha
+    ) continue;
     if (seen.has(mergeGroupSha.toLowerCase())) continue;
     seen.add(mergeGroupSha.toLowerCase());
     await github.rest.repos.createCommitStatus({
@@ -813,23 +829,14 @@ export function parseMergeQueuePullNumber(headRef) {
     : undefined;
 }
 
-/** Resolve the immutable source commit stored in GitHub's merge-queue entry. */
-export async function resolveMergeQueueSource({
+async function resolveCurrentMergeQueueEntry({
   github,
   owner,
   repo,
   pullNumber,
-  baseSha,
-  mergeGroupSha,
 }) {
   if (!Number.isSafeInteger(pullNumber) || pullNumber < 1) {
     throw new Error("Merge queue pull request number is invalid");
-  }
-  if (!FULL_SHA.test(baseSha)) {
-    throw new Error("Merge queue base commit is malformed");
-  }
-  if (!FULL_SHA.test(mergeGroupSha)) {
-    throw new Error("Merge group commit is malformed");
   }
   const response = await github.graphql(
     `query ResolveMergeQueueSource(
@@ -854,17 +861,53 @@ export async function resolveMergeQueueSource({
   const pullRequest = response?.repository?.pullRequest;
   const entry = pullRequest?.mergeQueueEntry;
   const sourceHeadSha = entry?.pullRequest?.headRefOid;
+  const baseSha = entry?.baseCommit?.oid;
+  const mergeGroupSha = entry?.headCommit?.oid;
   if (
     pullRequest?.number !== pullNumber ||
     entry?.pullRequest?.number !== pullNumber ||
-    entry?.baseCommit?.oid?.toLowerCase() !== baseSha.toLowerCase() ||
-    entry?.headCommit?.oid?.toLowerCase() !== mergeGroupSha.toLowerCase() ||
+    !FULL_SHA.test(baseSha ?? "") ||
+    !FULL_SHA.test(mergeGroupSha ?? "") ||
     !FULL_SHA.test(sourceHeadSha ?? "") ||
     pullRequest?.headRefOid?.toLowerCase() !== sourceHeadSha.toLowerCase()
   ) {
     throw new Error("Merge queue entry does not match its queued pull request");
   }
-  return sourceHeadSha.toLowerCase();
+  return {
+    baseSha: baseSha.toLowerCase(),
+    mergeGroupSha: mergeGroupSha.toLowerCase(),
+    sourceHeadSha: sourceHeadSha.toLowerCase(),
+  };
+}
+
+/** Resolve the immutable source commit stored in GitHub's merge-queue entry. */
+export async function resolveMergeQueueSource({
+  github,
+  owner,
+  repo,
+  pullNumber,
+  baseSha,
+  mergeGroupSha,
+}) {
+  if (!FULL_SHA.test(baseSha)) {
+    throw new Error("Merge queue base commit is malformed");
+  }
+  if (!FULL_SHA.test(mergeGroupSha)) {
+    throw new Error("Merge group commit is malformed");
+  }
+  const entry = await resolveCurrentMergeQueueEntry({
+    github,
+    owner,
+    repo,
+    pullNumber,
+  });
+  if (
+    entry.baseSha !== baseSha.toLowerCase() ||
+    entry.mergeGroupSha !== mergeGroupSha.toLowerCase()
+  ) {
+    throw new Error("Merge queue entry does not match its queued pull request");
+  }
+  return entry.sourceHeadSha;
 }
 
 function assertMergeGroupInputs({

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -496,10 +496,7 @@ export async function publishReviewResolutionFailure({
   for (const queueRef of refs) {
     const parsed = parseMergeQueuePullNumber(queueRef?.ref);
     const mergeGroupSha = queueRef?.object?.sha;
-    if (
-      parsed?.pullNumber !== pullNumber ||
-      parsed?.sourceHeadSha !== sourceHeadSha.toLowerCase()
-    ) continue;
+    if (parsed?.pullNumber !== pullNumber) continue;
     if (!FULL_SHA.test(mergeGroupSha ?? "")) {
       throw new Error("Merge queue ref has a malformed commit");
     }
@@ -805,17 +802,74 @@ export async function invalidateReviewProof({
 export function parseMergeQueuePullNumber(headRef) {
   if (typeof headRef !== "string") return undefined;
   const match =
-    /^(?:refs\/heads\/)?gh-readonly-queue\/.+\/pr-([1-9]\d*)-([0-9a-f]{40})$/i.exec(
-      headRef,
-    );
+    /^(?:refs\/heads\/)?gh-readonly-queue\/.+\/pr-([1-9]\d*)-([0-9a-f]{40})$/i
+      .exec(
+        headRef,
+      );
   if (!match) return undefined;
   const pullNumber = Number(match[1]);
   return Number.isSafeInteger(pullNumber)
-    ? { pullNumber, sourceHeadSha: match[2].toLowerCase() }
+    ? { pullNumber, baseSha: match[2].toLowerCase() }
     : undefined;
 }
 
-function assertMergeGroupInputs({ pullNumber, sourceHeadSha, mergeGroupSha }) {
+/** Resolve the immutable source commit stored in GitHub's merge-queue entry. */
+export async function resolveMergeQueueSource({
+  github,
+  owner,
+  repo,
+  pullNumber,
+  baseSha,
+}) {
+  if (!Number.isSafeInteger(pullNumber) || pullNumber < 1) {
+    throw new Error("Merge queue pull request number is invalid");
+  }
+  if (!FULL_SHA.test(baseSha)) {
+    throw new Error("Merge queue base commit is malformed");
+  }
+  const response = await github.graphql(
+    `query ResolveMergeQueueSource(
+      $owner: String!
+      $repo: String!
+      $pullNumber: Int!
+    ) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $pullNumber) {
+          number
+          headRefOid
+          mergeQueueEntry {
+            baseCommit { oid }
+            headCommit { oid }
+            pullRequest { number headRefOid }
+          }
+        }
+      }
+    }`,
+    { owner, repo, pullNumber },
+  );
+  const pullRequest = response?.repository?.pullRequest;
+  const entry = pullRequest?.mergeQueueEntry;
+  const sourceHeadSha = entry?.headCommit?.oid;
+  if (
+    pullRequest?.number !== pullNumber ||
+    entry?.pullRequest?.number !== pullNumber ||
+    entry?.baseCommit?.oid?.toLowerCase() !== baseSha.toLowerCase() ||
+    !FULL_SHA.test(sourceHeadSha ?? "") ||
+    pullRequest?.headRefOid?.toLowerCase() !== sourceHeadSha.toLowerCase() ||
+    entry?.pullRequest?.headRefOid?.toLowerCase() !==
+      sourceHeadSha.toLowerCase()
+  ) {
+    throw new Error("Merge queue entry does not match its queued pull request");
+  }
+  return sourceHeadSha.toLowerCase();
+}
+
+function assertMergeGroupInputs({
+  pullNumber,
+  sourceHeadSha,
+  baseSha,
+  mergeGroupSha,
+}) {
   if (!Number.isSafeInteger(pullNumber) || pullNumber < 1) {
     throw new Error("Merge queue pull request number is invalid");
   }
@@ -824,6 +878,9 @@ function assertMergeGroupInputs({ pullNumber, sourceHeadSha, mergeGroupSha }) {
   }
   if (!FULL_SHA.test(sourceHeadSha)) {
     throw new Error("Merge queue source commit is malformed");
+  }
+  if (!FULL_SHA.test(baseSha)) {
+    throw new Error("Merge queue base commit is malformed");
   }
 }
 
@@ -859,12 +916,28 @@ export async function publishMergeGroupReviewStatus({
   repo,
   pullNumber,
   sourceHeadSha,
+  baseSha,
   mergeGroupSha,
 }) {
   let failure;
   let pullUrl = `https://github.com/${owner}/${repo}/pull/${pullNumber}`;
   try {
-    assertMergeGroupInputs({ pullNumber, sourceHeadSha, mergeGroupSha });
+    assertMergeGroupInputs({
+      pullNumber,
+      sourceHeadSha,
+      baseSha,
+      mergeGroupSha,
+    });
+    const queuedSourceHeadSha = await resolveMergeQueueSource({
+      github,
+      owner,
+      repo,
+      pullNumber,
+      baseSha,
+    });
+    if (queuedSourceHeadSha !== sourceHeadSha.toLowerCase()) {
+      throw new Error("Merge queue source does not match its queued entry");
+    }
     const pull = await github.rest.pulls.get({
       owner,
       repo,
@@ -1050,8 +1123,7 @@ export async function reconcileActiveMergeGroupReviewStatuses({
     {
       owner,
       repo,
-      ref:
-        `heads/gh-readonly-queue/${baseRef}/pr-${pullNumber}-${sourceHeadSha}`,
+      ref: `heads/gh-readonly-queue/${baseRef}/pr-${pullNumber}-`,
     },
     "merge queue refs",
   );
@@ -1060,10 +1132,7 @@ export async function reconcileActiveMergeGroupReviewStatuses({
   for (const queueRef of refs) {
     const parsed = parseMergeQueuePullNumber(queueRef?.ref);
     const mergeGroupSha = queueRef?.object?.sha;
-    if (
-      parsed?.pullNumber !== pullNumber ||
-      parsed?.sourceHeadSha !== sourceHeadSha.toLowerCase()
-    ) continue;
+    if (parsed?.pullNumber !== pullNumber) continue;
     if (!FULL_SHA.test(mergeGroupSha ?? "")) {
       throw new Error("Merge queue ref has a malformed commit");
     }
@@ -1076,6 +1145,7 @@ export async function reconcileActiveMergeGroupReviewStatuses({
         repo,
         pullNumber,
         sourceHeadSha,
+        baseSha: parsed.baseSha,
         mergeGroupSha,
       }),
     );

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -1384,6 +1384,19 @@ export async function reconcileActiveMergeGroupReviewStatuses({
       mergeGroupSha,
     });
     if (result.state === "failure" && !result.published) {
+      // A failed binding check could not safely replace any prior success on
+      // the synthetic commit. Skip only when the exact queue ref has
+      // demonstrably moved or disappeared. A still-live entry, malformed
+      // response, or operational lookup failure must keep reconciliation red.
+      const ref = queueRef.ref.startsWith("refs/")
+        ? queueRef.ref.slice("refs/".length)
+        : queueRef.ref;
+      const liveTarget = await resolveQueueRefTarget(
+        github,
+        { owner, repo },
+        ref,
+      );
+      if (liveTarget?.toLowerCase() !== mergeGroupSha.toLowerCase()) continue;
       throw result.failure ??
         new Error("Could not publish the merge queue review failure");
     }

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -222,6 +222,51 @@ describe("automated review evidence", () => {
     );
   });
 
+  it("lets a later exact-head no-findings comment supersede a Codex finding", async () => {
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [review({
+            state: "COMMENTED",
+            body: "P1: An earlier exact-head review reported a false positive.",
+            submitted_at: "2026-08-25T08:00:00Z",
+          })],
+          comments: [codexComment(HEAD.slice(0, 10), {
+            created_at: "2026-08-25T08:00:01Z",
+          })],
+        },
+        HEAD,
+        () => Promise.resolve(HEAD),
+      ))?.source,
+      "codex-comment",
+    );
+
+    const submittedAt = "2026-08-25T08:00:00Z";
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [review({
+            id: 100,
+            state: "COMMENTED",
+            body: "P1: An earlier exact-head review reported a false positive.",
+            submitted_at: submittedAt,
+          })],
+          comments: [codexComment(HEAD.slice(0, 10), {
+            id: 101,
+            created_at: submittedAt,
+          })],
+          timeline: [
+            { event: "reviewed", id: 100 },
+            { event: "commented", id: 101 },
+          ],
+        },
+        HEAD,
+        () => Promise.resolve(HEAD),
+      ))?.source,
+      "codex-comment",
+    );
+  });
+
   it("lets an exact-head Codex finding comment supersede an earlier no-findings comment", async () => {
     assertEquals(
       await findAutomatedReview(
@@ -2447,7 +2492,28 @@ describe("automated review workflow", () => {
     };
     assertEquals(record(workflow.permissions, "permissions"), {});
 
-    assertEquals(workflow.concurrency, undefined);
+    const workflowConcurrency = record(
+      workflow.concurrency,
+      "workflow concurrency",
+    );
+    const workflowConcurrencyGroup = String(workflowConcurrency.group);
+    for (
+      const identity of [
+        "github.event_name == 'workflow_run'",
+        "github.event.workflow_run.display_title",
+        "github.event_name == 'issue_comment'",
+        "github.event.issue.pull_request",
+        "github.event.issue.number",
+        "github.run_id",
+      ]
+    ) {
+      assert(
+        workflowConcurrencyGroup.includes(identity),
+        "workflow concurrency must coalesce only replaceable reconciliation events",
+      );
+    }
+    assertEquals(workflowConcurrency["cancel-in-progress"], false);
+    assertEquals("queue" in workflowConcurrency, false);
 
     const triggers = record(workflow.on, "triggers");
     assertEquals(
@@ -2864,6 +2930,11 @@ describe("automated review workflow", () => {
       "automated-review-wakeup-pr-${{ github.event.pull_request.number }}",
     );
     assertEquals(record(workflow.permissions, "wakeup permissions"), {});
+    assertEquals(
+      workflow.concurrency,
+      undefined,
+      "cancelled wakeups are fail-closed signals and must not be coalesced",
+    );
     assertEquals(
       record(
         record(workflow.on, "wakeup triggers").pull_request_review,

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -23,6 +23,7 @@ import {
 const HEAD = "a4804e5b9a0c9c45da7c4866d9eb317c878b029c";
 const OTHER_HEAD = "d258d506fede01c84b61bc40488059447d755a5a";
 const QUEUE_BASE = "4e85ab7773ea2341a4d2cc75a81001df3f084fcc";
+const NEW_HEAD = "b8459394dd5bac3a6736ee4c7723d7f291abb382";
 const BASE_REPOSITORY_ID = 1_101_259_327;
 const BASE_REF = "main";
 const OTHER_BASE_REF = "release";
@@ -38,9 +39,14 @@ const WAKEUP_WORKFLOW_PATH = new URL(
   import.meta.url,
 );
 
-function publishMergeGroupReviewStatus(
-  options: Record<string, unknown>,
-) {
+function publishMergeGroupReviewStatus(options: {
+  github: ReturnType<typeof githubFixture>["github"];
+  owner: string;
+  repo: string;
+  pullNumber: number;
+  sourceHeadSha: string;
+  mergeGroupSha: string;
+}) {
   return publishMergeGroupReviewStatusImpl({
     baseSha: QUEUE_BASE,
     ...options,
@@ -136,6 +142,31 @@ function associatedPull(overrides: Record<string, unknown> = {}) {
     head: { sha: HEAD },
     base: { ref: BASE_REF, repo: { id: BASE_REPOSITORY_ID } },
     ...overrides,
+  };
+}
+
+function activeQueueBinding(overrides: Record<string, unknown> = {}) {
+  const number = Number.isSafeInteger(overrides.number) ? overrides.number : 1;
+  const headRefOid = typeof overrides.headRefOid === "string"
+    ? overrides.headRefOid
+    : HEAD;
+  const mergeQueueEntry = "mergeQueueEntry" in overrides
+    ? overrides.mergeQueueEntry
+    : {
+      baseCommit: { oid: QUEUE_BASE },
+      headCommit: { oid: OTHER_HEAD },
+      pullRequest: { number, headRefOid },
+    };
+  return {
+    repository: {
+      pullRequest: {
+        number,
+        state: overrides.state ?? "OPEN",
+        headRefOid,
+        baseRefName: overrides.baseRefName ?? BASE_REF,
+        mergeQueueEntry,
+      },
+    },
   };
 }
 
@@ -806,6 +837,7 @@ function githubFixture(options: {
   headResponses?: string[];
   pullResponses?: Record<string, unknown>[];
   commit?: string | undefined;
+  commitResponses?: (string | undefined)[];
   commitError?: Error;
   failAfterFirstPage?: string;
   pullError?: Error;
@@ -815,6 +847,10 @@ function githubFixture(options: {
   draft?: boolean;
   queueEntry?: Record<string, unknown> | null;
   queueSourceHead?: string;
+  queueBindings?: Record<string, unknown>[];
+  queueBindingError?: Error;
+  queueRefHeads?: (string | undefined)[];
+  queueRefError?: Error;
 } = {}) {
   const endpoints = {
     reviews: () => undefined,
@@ -825,26 +861,33 @@ function githubFixture(options: {
     timeline: () => undefined,
   };
   const published: Record<string, unknown>[] = [];
+  const refReads: Record<string, unknown>[] = [];
   const pageReads = new Map<string, number>();
   let pullRead = 0;
+  let commitRead = 0;
+  let queueBindingRead = 0;
+  let queueRefRead = 0;
   const queueSourceHead = options.queueSourceHead ?? HEAD;
   const github = {
-    graphql: () =>
-      Promise.resolve({
-        repository: {
-          pullRequest: {
-            number: 1,
+    graphql: () => {
+      if (options.queueBindingError) {
+        return Promise.reject(options.queueBindingError);
+      }
+      if (options.queueBindings) {
+        const data = options.queueBindings[
+          Math.min(queueBindingRead++, options.queueBindings.length - 1)
+        ];
+        return Promise.resolve(data);
+      }
+      return Promise.resolve(
+        options.queueEntry === undefined
+          ? activeQueueBinding({ headRefOid: queueSourceHead })
+          : activeQueueBinding({
             headRefOid: queueSourceHead,
-            mergeQueueEntry: options.queueEntry === undefined
-              ? {
-                baseCommit: { oid: QUEUE_BASE },
-                headCommit: { oid: OTHER_HEAD },
-                pullRequest: { number: 1, headRefOid: queueSourceHead },
-              }
-              : options.queueEntry,
-          },
-        },
-      }),
+            mergeQueueEntry: options.queueEntry,
+          }),
+      );
+    },
     paginate: {
       async *iterator(endpoint: unknown) {
         const name = Object.entries(endpoints).find(([, value]) =>
@@ -890,13 +933,26 @@ function githubFixture(options: {
         listEvents: endpoints.events,
         listEventsForTimeline: endpoints.timeline,
       },
-      git: { listMatchingRefs: endpoints.refs },
+      git: {
+        listMatchingRefs: endpoints.refs,
+        getRef: (parameters: Record<string, unknown>) => {
+          refReads.push(parameters);
+          if (options.queueRefError) {
+            return Promise.reject(options.queueRefError);
+          }
+          const heads = options.queueRefHeads ?? [OTHER_HEAD];
+          const sha = heads[Math.min(queueRefRead++, heads.length - 1)];
+          return Promise.resolve({ data: { object: { sha } } });
+        },
+      },
       repos: {
         listCommitStatusesForRef: endpoints.statuses,
-        getCommit: () =>
-          options.commitError
-            ? Promise.reject(options.commitError)
-            : Promise.resolve({ data: { sha: options.commit } }),
+        getCommit: () => {
+          if (options.commitError) return Promise.reject(options.commitError);
+          const commits = options.commitResponses ?? [options.commit];
+          const sha = commits[Math.min(commitRead++, commits.length - 1)];
+          return Promise.resolve({ data: { sha } });
+        },
         getCollaboratorPermissionLevel: () =>
           options.permissionError
             ? Promise.reject(options.permissionError)
@@ -913,7 +969,7 @@ function githubFixture(options: {
       },
     },
   };
-  return { github, published };
+  return { github, published, refReads };
 }
 
 describe("automated review publication", () => {
@@ -1075,6 +1131,24 @@ describe("automated review publication", () => {
     assertEquals(result.state, "pending");
     assertEquals(result.failure, undefined);
     assertEquals(fixture.published[0]?.state, "pending");
+  });
+
+  it("fails when an exact-ref lookup returns a malformed commit", async () => {
+    const fixture = githubFixture({
+      pages: { comments: [[codexComment()]] },
+      commit: undefined,
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+    assertEquals(result.state, "failure");
+    assert(result.failure instanceof Error);
+    assertEquals(fixture.published[0]?.state, "failure");
   });
 
   it("fails closed on partial pagination and the 500-item cap", async () => {
@@ -1507,9 +1581,10 @@ describe("merge queue review propagation", () => {
     }
   });
 
-  it("fails the source and only its identity-bound queue ref", async () => {
+  it("fails every exact queue ref still owned by the current source", async () => {
     const secondQueueHead = "e724246c0e05c8dcf0db41f024f4592128222937";
     const fixture = githubFixture({
+      commit: HEAD,
       pages: {
         refs: [[
           {
@@ -1527,6 +1602,7 @@ describe("merge queue review propagation", () => {
         ]],
       },
       pullError: new Error("pull lookup unavailable"),
+      queueRefHeads: [OTHER_HEAD, secondQueueHead],
     });
     const result = await publishReviewResolutionFailure({
       github: fixture.github,
@@ -1535,29 +1611,24 @@ describe("merge queue review propagation", () => {
       pullNumber: 1,
       sourceHeadSha: HEAD,
     });
-    assertEquals(result.queueFailures, 1);
+    assertEquals(result.queueFailures, 2);
     assertEquals(
       fixture.published.map((status) => [status.sha, status.state]),
       [
         [HEAD, "failure"],
         [OTHER_HEAD, "failure"],
+        [secondQueueHead, "failure"],
       ],
     );
   });
 
   it("does not let an old-head failure close a newer queue entry", async () => {
-    const newerQueueHead = "e724246c0e05c8dcf0db41f024f4592128222937";
     const fixture = githubFixture({
-      queueSourceHead: OTHER_HEAD,
-      queueEntry: {
-        baseCommit: { oid: QUEUE_BASE },
-        headCommit: { oid: newerQueueHead },
-        pullRequest: { number: 1, headRefOid: OTHER_HEAD },
-      },
+      commit: OTHER_HEAD,
       pages: {
         refs: [[{
           ref: `refs/heads/gh-readonly-queue/main/pr-1-${QUEUE_BASE}`,
-          object: { sha: newerQueueHead },
+          object: { sha: OTHER_HEAD },
         }]],
       },
     });
@@ -1570,16 +1641,136 @@ describe("merge queue review propagation", () => {
       sourceHeadSha: HEAD,
     });
 
-    assertEquals(result.queueFailures, 0);
+    assertEquals(result, { queueFailures: 0, skipped: true });
+    assertEquals(fixture.published, []);
+  });
+
+  it("does not cross queue ownership when the head changes after failure begins", async () => {
+    const fixture = githubFixture({
+      commitResponses: [HEAD, HEAD, NEW_HEAD],
+      pages: {
+        refs: [[{
+          ref: `refs/heads/gh-readonly-queue/main/pr-1-${QUEUE_BASE}`,
+          object: { sha: OTHER_HEAD },
+        }]],
+      },
+      queueBindings: [activeQueueBinding({ headRefOid: NEW_HEAD })],
+    });
+
+    const result = await publishReviewResolutionFailure({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      sourceHeadSha: HEAD,
+    });
+    assertEquals(result, { queueFailures: 0, skipped: false });
     assertEquals(
       fixture.published.map((status) => [status.sha, status.state]),
       [[HEAD, "failure"]],
     );
   });
 
-  it("does not guess a queue failure target when entry identity is unavailable", async () => {
+  it("propagates operational queue ownership lookup failures", async () => {
     const fixture = githubFixture({
-      queueEntry: null,
+      commit: HEAD,
+      pages: {
+        refs: [[{
+          ref: `refs/heads/gh-readonly-queue/main/pr-1-${QUEUE_BASE}`,
+          object: { sha: OTHER_HEAD },
+        }]],
+      },
+      queueBindingError: Object.assign(
+        new Error("queue binding unavailable"),
+        { status: 503 },
+      ),
+      queueRefError: Object.assign(new Error("queue ref unavailable"), {
+        status: 503,
+      }),
+    });
+
+    await assertRejects(
+      () =>
+        publishReviewResolutionFailure({
+          github: fixture.github,
+          owner: "veryfront",
+          repo: "veryfront-code",
+          pullNumber: 1,
+          sourceHeadSha: HEAD,
+        }),
+      Error,
+      "queue ref unavailable",
+    );
+    assertEquals(
+      fixture.published.map((status) => [status.sha, status.state]),
+      [[HEAD, "failure"]],
+      "an ownership outage must fail the job instead of reporting queue invalidation complete",
+    );
+  });
+
+  it("skips only a confirmed missing queue ref", async () => {
+    const fixture = githubFixture({
+      commit: HEAD,
+      pages: {
+        refs: [[{
+          ref: `refs/heads/gh-readonly-queue/main/pr-1-${QUEUE_BASE}`,
+          object: { sha: OTHER_HEAD },
+        }]],
+      },
+      queueBindingError: Object.assign(
+        new Error("queue binding unavailable"),
+        { status: 503 },
+      ),
+      queueRefError: Object.assign(new Error("queue ref not found"), {
+        status: 404,
+      }),
+    });
+
+    assertEquals(
+      await publishReviewResolutionFailure({
+        github: fixture.github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        pullNumber: 1,
+        sourceHeadSha: HEAD,
+      }),
+      { queueFailures: 0, skipped: false },
+    );
+  });
+
+  it("rejects a malformed successful queue ref lookup", async () => {
+    const fixture = githubFixture({
+      commit: HEAD,
+      pages: {
+        refs: [[{
+          ref: `refs/heads/gh-readonly-queue/main/pr-1-${QUEUE_BASE}`,
+          object: { sha: OTHER_HEAD },
+        }]],
+      },
+      queueBindingError: Object.assign(
+        new Error("queue binding unavailable"),
+        { status: 503 },
+      ),
+      queueRefHeads: [undefined],
+    });
+
+    await assertRejects(
+      () =>
+        publishReviewResolutionFailure({
+          github: fixture.github,
+          owner: "veryfront",
+          repo: "veryfront-code",
+          pullNumber: 1,
+          sourceHeadSha: HEAD,
+        }),
+      Error,
+      "Merge queue ref response has a malformed commit",
+    );
+  });
+
+  it("rejects a malformed final source ownership lookup", async () => {
+    const fixture = githubFixture({
+      commitResponses: [HEAD, HEAD, undefined],
       pages: {
         refs: [[{
           ref: `refs/heads/gh-readonly-queue/main/pr-1-${QUEUE_BASE}`,
@@ -1598,11 +1789,12 @@ describe("merge queue review propagation", () => {
           sourceHeadSha: HEAD,
         }),
       Error,
-      "does not match its queued pull request",
+      "Commit ref response has a malformed commit",
     );
     assertEquals(
       fixture.published.map((status) => [status.sha, status.state]),
       [[HEAD, "failure"]],
+      "a malformed final source response must not leave queue invalidation looking complete",
     );
   });
 
@@ -1632,6 +1824,109 @@ describe("merge queue review propagation", () => {
       description: "Reused exact-head review for PR #1",
       target_url: "https://example.test/review-proof",
     }]);
+    assertEquals(fixture.refReads, [
+      {
+        owner: "veryfront",
+        repo: "veryfront-code",
+        ref: `heads/gh-readonly-queue/${BASE_REF}/pr-1-${QUEUE_BASE}`,
+      },
+      {
+        owner: "veryfront",
+        repo: "veryfront-code",
+        ref: `heads/gh-readonly-queue/${BASE_REF}/pr-1-${QUEUE_BASE}`,
+      },
+    ]);
+  });
+
+  it("fails closed when the live merge-queue binding does not match", async () => {
+    const staleBindings = [
+      ["source", activeQueueBinding({ headRefOid: OTHER_HEAD })],
+      [
+        "base",
+        activeQueueBinding({
+          mergeQueueEntry: {
+            baseCommit: { oid: HEAD },
+            headCommit: { oid: OTHER_HEAD },
+            pullRequest: { number: 1, headRefOid: HEAD },
+          },
+        }),
+      ],
+      [
+        "synthetic head",
+        activeQueueBinding({
+          mergeQueueEntry: {
+            baseCommit: { oid: QUEUE_BASE },
+            headCommit: { oid: HEAD },
+            pullRequest: { number: 1, headRefOid: HEAD },
+          },
+        }),
+      ],
+      ["missing entry", activeQueueBinding({ mergeQueueEntry: null })],
+    ] as const;
+    for (const [label, binding] of staleBindings) {
+      const fixture = githubFixture({
+        pages: {
+          reviews: [[review({ state: "APPROVED" })]],
+          statuses: [[automatedReviewStatus()]],
+        },
+        queueBindings: [binding],
+      });
+      const result = await publishMergeGroupReviewStatus({
+        github: fixture.github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        pullNumber: 1,
+        sourceHeadSha: HEAD,
+        mergeGroupSha: OTHER_HEAD,
+      });
+      assertEquals(result.state, "failure", label);
+      assertEquals(
+        fixture.published,
+        [],
+        `${label}: an unbound synthetic commit must not receive a status`,
+      );
+    }
+
+    const replacedRef = githubFixture({
+      pages: {
+        reviews: [[review({ state: "APPROVED" })]],
+        statuses: [[automatedReviewStatus()]],
+      },
+      queueRefHeads: [HEAD],
+    });
+    const result = await publishMergeGroupReviewStatus({
+      github: replacedRef.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      sourceHeadSha: HEAD,
+      mergeGroupSha: OTHER_HEAD,
+    });
+    assertEquals(result.state, "failure");
+    assertEquals(replacedRef.published, []);
+  });
+
+  it("rechecks the live merge-queue binding before publishing success", async () => {
+    const fixture = githubFixture({
+      pages: {
+        reviews: [[review({ state: "APPROVED" })]],
+        statuses: [[automatedReviewStatus()]],
+      },
+      queueBindings: [
+        activeQueueBinding(),
+        activeQueueBinding({ headRefOid: OTHER_HEAD }),
+      ],
+    });
+    const result = await publishMergeGroupReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      sourceHeadSha: HEAD,
+      mergeGroupSha: OTHER_HEAD,
+    });
+    assertEquals(result.state, "failure");
+    assertEquals(fixture.published, []);
   });
 
   it("does not reuse proof that predates a base-ref issue event", async () => {
@@ -1722,7 +2017,7 @@ describe("merge queue review propagation", () => {
       mergeGroupSha: OTHER_HEAD,
     });
     assertEquals(result.state, "failure");
-    assertEquals(fixture.published[0]?.state, "failure");
+    assertEquals(fixture.published, []);
   });
 
   it("selects the latest source status owned by the queued pull request", async () => {
@@ -1862,6 +2157,40 @@ describe("merge queue review propagation", () => {
     assertEquals(results[0]?.state, "failure");
     assertEquals(fixture.published[0]?.sha, OTHER_HEAD);
     assertEquals(fixture.published[0]?.state, "failure");
+  });
+
+  it("surfaces an unpublished queue failure to the workflow", async () => {
+    const fixture = githubFixture({
+      pages: {
+        refs: [[{
+          ref: `refs/heads/gh-readonly-queue/${BASE_REF}/pr-1-${QUEUE_BASE}`,
+          object: { sha: OTHER_HEAD },
+        }]],
+      },
+      queueBindingError: Object.assign(
+        new Error("queue binding unavailable"),
+        { status: 503 },
+      ),
+    });
+
+    await assertRejects(
+      () =>
+        reconcileActiveMergeGroupReviewStatuses({
+          github: fixture.github,
+          owner: "veryfront",
+          repo: "veryfront-code",
+          pullNumber: 1,
+          sourceHeadSha: HEAD,
+          baseRef: BASE_REF,
+        }),
+      Error,
+      "queue binding unavailable",
+    );
+    assertEquals(
+      fixture.published,
+      [],
+      "the workflow fallback must handle a failure that could not be published safely",
+    );
   });
 
   it("rechecks source proof immediately before publishing queue success", async () => {
@@ -2170,6 +2499,7 @@ describe("review proof invalidation", () => {
 
   it("invalidates a same-second success that existed when reconciliation began", async () => {
     const fixture = githubFixture({
+      commit: HEAD,
       headResponses: [HEAD],
       pages: {
         statuses: [[automatedReviewStatus({
@@ -2193,6 +2523,7 @@ describe("review proof invalidation", () => {
 
   it("closes source and queued gates a dropped reconciliation left behind", async () => {
     const fixture = githubFixture({
+      commit: HEAD,
       headResponses: [HEAD],
       pages: {
         refs: [[{
@@ -2255,6 +2586,28 @@ describe("review proof invalidation", () => {
       fixture.published,
       [],
       "an old reconciliation must not write a failure onto the new head",
+    );
+  });
+
+  it("reports a skipped invalidation when the head changes before publication", async () => {
+    const fixture = githubFixture({
+      headResponses: [HEAD],
+      commitResponses: [OTHER_HEAD],
+    });
+    const result = await invalidateReviewProof({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+    });
+
+    assertEquals(result.skipped, true);
+    assertEquals(result.headSha, HEAD);
+    assertEquals(result.queueFailures, 0);
+    assertEquals(
+      fixture.published,
+      [],
+      "a head change after target resolution must remain visibly skipped",
     );
   });
 
@@ -2852,9 +3205,18 @@ describe("automated review workflow", () => {
         "reconciliationStatusId",
         "publishIndependentFailure",
         "listMatchingRefs",
+        "parseMergeQueuePullNumber",
         "github.graphql",
         "mergeQueueEntry",
+        "baseCommit",
         "headCommit",
+        "github.rest.git.getRef",
+        "resolveQueueRefTarget",
+        "error?.status === 404",
+        "Merge queue ref response has a malformed commit",
+        "Pull request head response has a malformed commit",
+        "finalPull",
+        'ref: "heads/gh-readonly-queue/"',
         "createCommitStatus",
         "process.env.TARGET_SHA",
         "process.env.PULL_NUMBER",
@@ -2868,16 +3230,8 @@ describe("automated review workflow", () => {
       );
     }
     assert(
-      invalidateScript.includes(
-        "`heads/gh-readonly-queue/${baseRef}/pr-${pullNumber}-`",
-      ),
-      "the independent fallback must list every queue ref for the pull request",
-    );
-    assert(
-      !invalidateScript.includes(
-        "`heads/gh-readonly-queue/${baseRef}/pr-${pullNumber}-${headSha}`",
-      ),
-      "the queue ref suffix is the base commit, not the source head",
+      !invalidateScript.includes("pr-${pullNumber}-${headSha}"),
+      "the independent fallback must not treat the queue-ref base suffix as a source head",
     );
 
     const mergeGroupJob = record(jobs.merge_group, "merge group job");

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -312,6 +312,60 @@ describe("automated review evidence", () => {
     );
   });
 
+  it("treats an edited Codex finding comment as newer than a later-created clean verdict", async () => {
+    assertEquals(
+      await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [
+            codexFindingComment(HEAD.slice(0, 10), {
+              id: 100,
+              created_at: "2026-08-25T08:00:00Z",
+              updated_at: "2026-08-25T08:00:02Z",
+            }),
+            codexComment(HEAD.slice(0, 10), {
+              id: 101,
+              created_at: "2026-08-25T08:00:01Z",
+              updated_at: "2026-08-25T08:00:01Z",
+            }),
+          ],
+        },
+        HEAD,
+        () => Promise.resolve(HEAD),
+      ),
+      undefined,
+    );
+  });
+
+  it("lets an edited old clean verdict supersede a finding after a base boundary", async () => {
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          reviews: [],
+          comments: [
+            codexComment(HEAD.slice(0, 10), {
+              id: 100,
+              created_at: "2026-08-25T08:00:00Z",
+              updated_at: "2026-08-25T08:00:03Z",
+            }),
+            codexFindingComment(HEAD.slice(0, 10), {
+              id: 101,
+              created_at: "2026-08-25T08:00:02Z",
+              updated_at: "2026-08-25T08:00:02Z",
+            }),
+          ],
+          events: [{
+            event: "base_ref_changed",
+            created_at: "2026-08-25T08:00:01Z",
+          }],
+        },
+        HEAD,
+        () => Promise.resolve(HEAD),
+      ))?.source,
+      "codex-comment",
+    );
+  });
+
   it("lets an exact-head Codex finding comment override a Codex approval", async () => {
     assertEquals(
       await findAutomatedReview(

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2191,6 +2191,73 @@ describe("merge queue review propagation", () => {
       [],
       "the workflow fallback must handle a failure that could not be published safely",
     );
+    assertEquals(fixture.refReads, [{
+      owner: "veryfront",
+      repo: "veryfront-code",
+      ref: `heads/gh-readonly-queue/${BASE_REF}/pr-1-${QUEUE_BASE}`,
+    }]);
+  });
+
+  it("skips an unpublished failure after its queue ref moves", async () => {
+    const fixture = githubFixture({
+      pages: {
+        refs: [[{
+          ref: `refs/heads/gh-readonly-queue/${BASE_REF}/pr-1-${QUEUE_BASE}`,
+          object: { sha: OTHER_HEAD },
+        }]],
+      },
+      queueBindingError: Object.assign(
+        new Error("queue binding unavailable"),
+        { status: 503 },
+      ),
+      queueRefHeads: [NEW_HEAD],
+    });
+
+    assertEquals(
+      await reconcileActiveMergeGroupReviewStatuses({
+        github: fixture.github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        pullNumber: 1,
+        sourceHeadSha: HEAD,
+        baseRef: BASE_REF,
+      }),
+      [],
+    );
+    assertEquals(fixture.published, []);
+  });
+
+  it("propagates a queue ref outage while rechecking an unpublished failure", async () => {
+    const fixture = githubFixture({
+      pages: {
+        refs: [[{
+          ref: `refs/heads/gh-readonly-queue/${BASE_REF}/pr-1-${QUEUE_BASE}`,
+          object: { sha: OTHER_HEAD },
+        }]],
+      },
+      queueBindingError: Object.assign(
+        new Error("queue binding unavailable"),
+        { status: 503 },
+      ),
+      queueRefError: Object.assign(new Error("queue ref unavailable"), {
+        status: 503,
+      }),
+    });
+
+    await assertRejects(
+      () =>
+        reconcileActiveMergeGroupReviewStatuses({
+          github: fixture.github,
+          owner: "veryfront",
+          repo: "veryfront-code",
+          pullNumber: 1,
+          sourceHeadSha: HEAD,
+          baseRef: BASE_REF,
+        }),
+      Error,
+      "queue ref unavailable",
+    );
+    assertEquals(fixture.published, []);
   });
 
   it("rechecks source proof immediately before publishing queue success", async () => {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -791,7 +791,7 @@ function githubFixture(options: {
             mergeQueueEntry: options.queueEntry === undefined
               ? {
                 baseCommit: { oid: QUEUE_BASE },
-                headCommit: { oid: HEAD },
+                headCommit: { oid: OTHER_HEAD },
                 pullRequest: { number: 1, headRefOid: HEAD },
               }
               : options.queueEntry,
@@ -1404,7 +1404,7 @@ describe("merge queue review propagation", () => {
     ) assertEquals(parseMergeQueuePullNumber(ref), undefined);
   });
 
-  it("binds a queue base to GitHub's immutable entry source", async () => {
+  it("binds a queue base and synthetic commit to its immutable source", async () => {
     const fixture = githubFixture();
     assertEquals(
       await resolveMergeQueueSource({
@@ -1413,6 +1413,7 @@ describe("merge queue review propagation", () => {
         repo: "veryfront-code",
         pullNumber: 1,
         baseSha: QUEUE_BASE,
+        mergeGroupSha: OTHER_HEAD,
       }),
       HEAD,
     );
@@ -1422,18 +1423,23 @@ describe("merge queue review propagation", () => {
         null,
         {
           baseCommit: { oid: OTHER_HEAD },
-          headCommit: { oid: HEAD },
-          pullRequest: { number: 1, headRefOid: HEAD },
-        },
-        {
-          baseCommit: { oid: QUEUE_BASE },
           headCommit: { oid: OTHER_HEAD },
           pullRequest: { number: 1, headRefOid: HEAD },
         },
         {
           baseCommit: { oid: QUEUE_BASE },
           headCommit: { oid: HEAD },
+          pullRequest: { number: 1, headRefOid: HEAD },
+        },
+        {
+          baseCommit: { oid: QUEUE_BASE },
+          headCommit: { oid: OTHER_HEAD },
           pullRequest: { number: 2, headRefOid: HEAD },
+        },
+        {
+          baseCommit: { oid: QUEUE_BASE },
+          headCommit: { oid: OTHER_HEAD },
+          pullRequest: { number: 1, headRefOid: QUEUE_BASE },
         },
       ]
     ) {
@@ -1446,6 +1452,7 @@ describe("merge queue review propagation", () => {
             repo: "veryfront-code",
             pullNumber: 1,
             baseSha: QUEUE_BASE,
+            mergeGroupSha: OTHER_HEAD,
           }),
         Error,
         "does not match its queued pull request",

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -769,6 +769,7 @@ function githubFixture(options: {
   pullAuthor?: string;
   draft?: boolean;
   queueEntry?: Record<string, unknown> | null;
+  queueSourceHead?: string;
 } = {}) {
   const endpoints = {
     reviews: () => undefined,
@@ -781,18 +782,19 @@ function githubFixture(options: {
   const published: Record<string, unknown>[] = [];
   const pageReads = new Map<string, number>();
   let pullRead = 0;
+  const queueSourceHead = options.queueSourceHead ?? HEAD;
   const github = {
     graphql: () =>
       Promise.resolve({
         repository: {
           pullRequest: {
             number: 1,
-            headRefOid: HEAD,
+            headRefOid: queueSourceHead,
             mergeQueueEntry: options.queueEntry === undefined
               ? {
                 baseCommit: { oid: QUEUE_BASE },
                 headCommit: { oid: OTHER_HEAD },
-                pullRequest: { number: 1, headRefOid: HEAD },
+                pullRequest: { number: 1, headRefOid: queueSourceHead },
               }
               : options.queueEntry,
           },
@@ -1460,7 +1462,7 @@ describe("merge queue review propagation", () => {
     }
   });
 
-  it("fails the source and active queue refs without a pull lookup", async () => {
+  it("fails the source and only its identity-bound queue ref", async () => {
     const secondQueueHead = "e724246c0e05c8dcf0db41f024f4592128222937";
     const fixture = githubFixture({
       pages: {
@@ -1488,14 +1490,74 @@ describe("merge queue review propagation", () => {
       pullNumber: 1,
       sourceHeadSha: HEAD,
     });
-    assertEquals(result.queueFailures, 2);
+    assertEquals(result.queueFailures, 1);
     assertEquals(
       fixture.published.map((status) => [status.sha, status.state]),
       [
         [HEAD, "failure"],
         [OTHER_HEAD, "failure"],
-        [secondQueueHead, "failure"],
       ],
+    );
+  });
+
+  it("does not let an old-head failure close a newer queue entry", async () => {
+    const newerQueueHead = "e724246c0e05c8dcf0db41f024f4592128222937";
+    const fixture = githubFixture({
+      queueSourceHead: OTHER_HEAD,
+      queueEntry: {
+        baseCommit: { oid: QUEUE_BASE },
+        headCommit: { oid: newerQueueHead },
+        pullRequest: { number: 1, headRefOid: OTHER_HEAD },
+      },
+      pages: {
+        refs: [[{
+          ref: `refs/heads/gh-readonly-queue/main/pr-1-${QUEUE_BASE}`,
+          object: { sha: newerQueueHead },
+        }]],
+      },
+    });
+
+    const result = await publishReviewResolutionFailure({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      sourceHeadSha: HEAD,
+    });
+
+    assertEquals(result.queueFailures, 0);
+    assertEquals(
+      fixture.published.map((status) => [status.sha, status.state]),
+      [[HEAD, "failure"]],
+    );
+  });
+
+  it("does not guess a queue failure target when entry identity is unavailable", async () => {
+    const fixture = githubFixture({
+      queueEntry: null,
+      pages: {
+        refs: [[{
+          ref: `refs/heads/gh-readonly-queue/main/pr-1-${QUEUE_BASE}`,
+          object: { sha: OTHER_HEAD },
+        }]],
+      },
+    });
+
+    await assertRejects(
+      () =>
+        publishReviewResolutionFailure({
+          github: fixture.github,
+          owner: "veryfront",
+          repo: "veryfront-code",
+          pullNumber: 1,
+          sourceHeadSha: HEAD,
+        }),
+      Error,
+      "does not match its queued pull request",
+    );
+    assertEquals(
+      fixture.published.map((status) => [status.sha, status.state]),
+      [[HEAD, "failure"]],
     );
   });
 
@@ -2724,6 +2786,9 @@ describe("automated review workflow", () => {
         "reconciliationStatusId",
         "publishIndependentFailure",
         "listMatchingRefs",
+        "github.graphql",
+        "mergeQueueEntry",
+        "headCommit",
         "createCommitStatus",
         "process.env.TARGET_SHA",
         "process.env.PULL_NUMBER",

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -12,15 +12,17 @@ import {
   parseMergeQueuePullNumber,
   parseReviewWakeupRun,
   publishAutomatedReviewStatus,
-  publishMergeGroupReviewStatus,
+  publishMergeGroupReviewStatus as publishMergeGroupReviewStatusImpl,
   publishReviewResolutionFailure,
   reconcileActiveMergeGroupReviewStatuses,
   requestAutomatedReview,
+  resolveMergeQueueSource,
   reviewBaseBinding,
 } from "./automated-review-gate.mjs";
 
 const HEAD = "a4804e5b9a0c9c45da7c4866d9eb317c878b029c";
 const OTHER_HEAD = "d258d506fede01c84b61bc40488059447d755a5a";
+const QUEUE_BASE = "4e85ab7773ea2341a4d2cc75a81001df3f084fcc";
 const BASE_REPOSITORY_ID = 1_101_259_327;
 const BASE_REF = "main";
 const OTHER_BASE_REF = "release";
@@ -35,6 +37,15 @@ const WAKEUP_WORKFLOW_PATH = new URL(
   "../../.github/workflows/automated-review-wakeup.yml",
   import.meta.url,
 );
+
+function publishMergeGroupReviewStatus(
+  options: Record<string, unknown>,
+) {
+  return publishMergeGroupReviewStatusImpl({
+    baseSha: QUEUE_BASE,
+    ...options,
+  });
+}
 
 const bot = (login: string, id: number) => ({ login, id, type: "Bot" });
 
@@ -757,6 +768,7 @@ function githubFixture(options: {
   permissionError?: Error;
   pullAuthor?: string;
   draft?: boolean;
+  queueEntry?: Record<string, unknown> | null;
 } = {}) {
   const endpoints = {
     reviews: () => undefined,
@@ -770,6 +782,22 @@ function githubFixture(options: {
   const pageReads = new Map<string, number>();
   let pullRead = 0;
   const github = {
+    graphql: () =>
+      Promise.resolve({
+        repository: {
+          pullRequest: {
+            number: 1,
+            headRefOid: HEAD,
+            mergeQueueEntry: options.queueEntry === undefined
+              ? {
+                baseCommit: { oid: QUEUE_BASE },
+                headCommit: { oid: HEAD },
+                pullRequest: { number: 1, headRefOid: HEAD },
+              }
+              : options.queueEntry,
+          },
+        },
+      }),
     paginate: {
       async *iterator(endpoint: unknown) {
         const name = Object.entries(endpoints).find(([, value]) =>
@@ -1358,12 +1386,12 @@ describe("automated review publication", () => {
 });
 
 describe("merge queue review propagation", () => {
-  it("extracts only a fully qualified merge-queue pull request ref", () => {
+  it("extracts the pull request and base commit from a merge-queue ref", () => {
     assertEquals(
       parseMergeQueuePullNumber(
         `refs/heads/gh-readonly-queue/main/pr-4135-${OTHER_HEAD}`,
       ),
-      { pullNumber: 4135, sourceHeadSha: OTHER_HEAD },
+      { pullNumber: 4135, baseSha: OTHER_HEAD },
     );
     for (
       const ref of [
@@ -1376,21 +1404,70 @@ describe("merge queue review propagation", () => {
     ) assertEquals(parseMergeQueuePullNumber(ref), undefined);
   });
 
+  it("binds a queue base to GitHub's immutable entry source", async () => {
+    const fixture = githubFixture();
+    assertEquals(
+      await resolveMergeQueueSource({
+        github: fixture.github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        pullNumber: 1,
+        baseSha: QUEUE_BASE,
+      }),
+      HEAD,
+    );
+
+    for (
+      const queueEntry of [
+        null,
+        {
+          baseCommit: { oid: OTHER_HEAD },
+          headCommit: { oid: HEAD },
+          pullRequest: { number: 1, headRefOid: HEAD },
+        },
+        {
+          baseCommit: { oid: QUEUE_BASE },
+          headCommit: { oid: OTHER_HEAD },
+          pullRequest: { number: 1, headRefOid: HEAD },
+        },
+        {
+          baseCommit: { oid: QUEUE_BASE },
+          headCommit: { oid: HEAD },
+          pullRequest: { number: 2, headRefOid: HEAD },
+        },
+      ]
+    ) {
+      const invalid = githubFixture({ queueEntry });
+      await assertRejects(
+        () =>
+          resolveMergeQueueSource({
+            github: invalid.github,
+            owner: "veryfront",
+            repo: "veryfront-code",
+            pullNumber: 1,
+            baseSha: QUEUE_BASE,
+          }),
+        Error,
+        "does not match its queued pull request",
+      );
+    }
+  });
+
   it("fails the source and active queue refs without a pull lookup", async () => {
     const secondQueueHead = "e724246c0e05c8dcf0db41f024f4592128222937";
     const fixture = githubFixture({
       pages: {
         refs: [[
           {
-            ref: `refs/heads/gh-readonly-queue/main/pr-1-${HEAD}`,
+            ref: `refs/heads/gh-readonly-queue/main/pr-1-${QUEUE_BASE}`,
             object: { sha: OTHER_HEAD },
           },
           {
-            ref: `refs/heads/gh-readonly-queue/release/pr-1-${HEAD}`,
+            ref: `refs/heads/gh-readonly-queue/release/pr-1-${QUEUE_BASE}`,
             object: { sha: secondQueueHead },
           },
           {
-            ref: `refs/heads/gh-readonly-queue/main/pr-2-${HEAD}`,
+            ref: `refs/heads/gh-readonly-queue/main/pr-2-${QUEUE_BASE}`,
             object: { sha: secondQueueHead },
           },
         ]],
@@ -1652,7 +1729,7 @@ describe("merge queue review propagation", () => {
       pages: {
         reviews: [[review({ state: "APPROVED" })]],
         refs: [[{
-          ref: `refs/heads/gh-readonly-queue/${BASE_REF}/pr-1-${HEAD}`,
+          ref: `refs/heads/gh-readonly-queue/${BASE_REF}/pr-1-${QUEUE_BASE}`,
           object: { sha: OTHER_HEAD },
         }]],
         statuses: [[automatedReviewStatus({ state: "pending" })]],
@@ -1955,7 +2032,7 @@ describe("review proof invalidation", () => {
           created_at: "2026-08-25T08:00:00Z",
         })]],
         refs: [[{
-          ref: `refs/heads/gh-readonly-queue/${BASE_REF}/pr-1-${HEAD}`,
+          ref: `refs/heads/gh-readonly-queue/${BASE_REF}/pr-1-${QUEUE_BASE}`,
           object: { sha: OTHER_HEAD },
         }]],
       },
@@ -2005,7 +2082,7 @@ describe("review proof invalidation", () => {
       headResponses: [HEAD],
       pages: {
         refs: [[{
-          ref: `refs/heads/gh-readonly-queue/${BASE_REF}/pr-1-${HEAD}`,
+          ref: `refs/heads/gh-readonly-queue/${BASE_REF}/pr-1-${QUEUE_BASE}`,
           object: { sha: OTHER_HEAD },
         }]],
       },
@@ -2395,6 +2472,8 @@ describe("automated review workflow", () => {
         "github.rest.git.getRef",
         "fallbackResponse = await github.rest.pulls.get",
         "context.payload.pull_request?.head?.sha",
+        "context.payload.merge_group?.base_sha",
+        "queueEntry.baseSha",
         "Could not resolve a valid review target commit",
       ]
     ) assert(targetScript.includes(required));
@@ -2423,6 +2502,10 @@ describe("automated review workflow", () => {
     assert(
       !targetScript.includes("workflowRun?.name"),
       "a dynamic run-name must not be mistaken for the stable workflow identity",
+    );
+    assert(
+      !targetScript.includes("sourceHeadSha: match[2]"),
+      "the queue ref suffix is the base commit, not the pull request head",
     );
 
     const mergeGroupFailureJob = record(
@@ -2625,8 +2708,7 @@ describe("automated review workflow", () => {
       {
         TARGET_SHA: "${{ needs.target.outputs.key }}",
         PULL_NUMBER: "${{ needs.target.outputs.pull_number }}",
-        RECONCILIATION_STATUS_ID:
-          "${{ needs.target.outputs.status_id }}",
+        RECONCILIATION_STATUS_ID: "${{ needs.target.outputs.status_id }}",
       },
     );
     for (
@@ -2647,6 +2729,18 @@ describe("automated review workflow", () => {
         "the invalidator must resolve its pull request the way the resolver does",
       );
     }
+    assert(
+      invalidateScript.includes(
+        "`heads/gh-readonly-queue/${baseRef}/pr-${pullNumber}-`",
+      ),
+      "the independent fallback must list every queue ref for the pull request",
+    );
+    assert(
+      !invalidateScript.includes(
+        "`heads/gh-readonly-queue/${baseRef}/pr-${pullNumber}-${headSha}`",
+      ),
+      "the queue ref suffix is the base commit, not the source head",
+    );
 
     const mergeGroupJob = record(jobs.merge_group, "merge group job");
     assertEquals(mergeGroupJob.if, "github.event_name == 'merge_group'");
@@ -2677,6 +2771,8 @@ describe("automated review workflow", () => {
     assert(mergeGroupScript.includes("process.env.SOURCE_HEAD_SHA"));
     assert(mergeGroupScript.includes("process.env.PULL_NUMBER"));
     assert(mergeGroupScript.includes("sourceHeadSha"));
+    assert(mergeGroupScript.includes("queueEntry.baseSha"));
+    assert(mergeGroupScript.includes("context.payload.merge_group.base_sha"));
     assert(mergeGroupScript.includes("context.payload.merge_group.head_ref"));
     assert(mergeGroupScript.includes("context.payload.merge_group.head_sha"));
     assert(


### PR DESCRIPTION
## Why

The #4161 live merge-group run proved that GitHub serializes the merge queue base commit in the queue-ref suffix. The gate treated that suffix as the pull request head, so it failed every synthetic queue commit.

## What changed

- Parse the queue-ref suffix as the base SHA and validate it against the merge-group payload.
- Resolve the immutable queued source through GitHub GraphQL merge queue metadata.
- Require the queue entry, base commit, source head, nested pull request, and live pull request to agree before reusing review proof.
- Make both tested and independent failure paths close every matching synthetic queue gate without assuming the suffix is a source SHA.
- Add focused regressions with distinct source, base, and synthetic commits.

The privileged workflow still executes only default-branch code loaded through the GitHub API. It does not check out fork contents.

## Verification

- Deno 2.7.7 focused automated-review gate: 68 steps passed
- Repository formatting and lint: passed
- Generated artifacts and full project typecheck: passed
- Unit suite: 4,277 tests, 34,124 steps, zero failures
- Cwd isolation suites: passed
- Independent code review: approved, zero findings, 94% confidence
- Sonar API for #4161: zero unresolved issues

## Rollout guard

Keep the current human approval requirement and keep Automated review non-required until this change passes a live source-head plus merge-group canary. The canary is the evidence needed before removing the permanent human bottleneck.