### PR TITLE
Filter irrelevant automated review events before runner allocation

### DIFF
--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -35,10 +35,7 @@ jobs:
          github.event.comment.user.type == 'Bot')) &&
        (github.event_name != 'workflow_run' ||
         (github.event.workflow_run.event == 'pull_request_review' &&
-         (github.event.workflow_run.actor.type == 'User' ||
-          (github.event.workflow_run.actor.login == 'chatgpt-codex-connector[bot]' &&
-           github.event.workflow_run.actor.id == 199175422 &&
-           github.event.workflow_run.actor.type == 'Bot')))))
+         github.event.workflow_run.conclusion != 'skipped')))
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -28,9 +28,17 @@ jobs:
     # concurrency key while keeping the immutable source SHA separate.
     if: >-
       github.event_name == 'merge_group' ||
-      ((github.event_name != 'issue_comment' || github.event.issue.pull_request) &&
+      ((github.event_name != 'issue_comment' ||
+        (github.event.issue.pull_request &&
+         github.event.comment.user.login == 'chatgpt-codex-connector[bot]' &&
+         github.event.comment.user.id == 199175422 &&
+         github.event.comment.user.type == 'Bot')) &&
        (github.event_name != 'workflow_run' ||
-        github.event.workflow_run.event == 'pull_request_review'))
+        (github.event.workflow_run.event == 'pull_request_review' &&
+         (github.event.workflow_run.actor.type == 'User' ||
+          (github.event.workflow_run.actor.login == 'chatgpt-codex-connector[bot]' &&
+           github.event.workflow_run.actor.id == 199175422 &&
+           github.event.workflow_run.actor.type == 'Bot')))))
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -35,7 +35,7 @@ jobs:
          github.event.comment.user.type == 'Bot')) &&
        (github.event_name != 'workflow_run' ||
         (github.event.workflow_run.event == 'pull_request_review' &&
-         github.event.workflow_run.conclusion != 'skipped')))
+         endsWith(github.event.workflow_run.display_title, '-eligible'))))
     permissions:
       contents: read
       pull-requests: read
@@ -72,7 +72,7 @@ jobs:
               const title = typeof run?.display_title === "string"
                 ? run.display_title
                 : "";
-              const match = /^automated-review-wakeup-pr-([1-9]\d*)$/.exec(title);
+              const match = /^automated-review-wakeup-pr-([1-9]\d*)-eligible$/.exec(title);
               const pullNumber = match ? Number(match[1]) : undefined;
               const headRepositoryId = run?.head_repository?.id;
               if (

--- a/.github/workflows/automated-review-wakeup.yml
+++ b/.github/workflows/automated-review-wakeup.yml
@@ -1,5 +1,5 @@
 name: Automated review wakeup
-run-name: automated-review-wakeup-pr-${{ github.event.pull_request.number }}
+run-name: automated-review-wakeup-pr-${{ github.event.pull_request.number }}-${{ (github.event.review.user.type == 'User' || (github.event.review.user.login == 'chatgpt-codex-connector[bot]' && github.event.review.user.id == 199175422 && github.event.review.user.type == 'Bot')) && 'eligible' || 'ignored' }}
 
 on:
   pull_request_review:

--- a/.github/workflows/automated-review-wakeup.yml
+++ b/.github/workflows/automated-review-wakeup.yml
@@ -10,6 +10,11 @@ permissions: {}
 jobs:
   review_event:
     name: signal review reconciliation
+    if: >-
+      github.event.review.user.type == 'User' ||
+      (github.event.review.user.login == 'chatgpt-codex-connector[bot]' &&
+       github.event.review.user.id == 199175422 &&
+       github.event.review.user.type == 'Bot')
     permissions: {}
     runs-on: ubuntu-latest
     timeout-minutes: 2

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -58,7 +58,7 @@ export function parseReviewWakeupRun(run) {
   const displayTitle = typeof run?.display_title === "string"
     ? run.display_title
     : "";
-  const titleMatch = /^automated-review-wakeup-pr-([1-9]\d*)$/.exec(
+  const titleMatch = /^automated-review-wakeup-pr-([1-9]\d*)-eligible$/.exec(
     displayTitle,
   );
   const pullNumber = titleMatch ? Number(titleMatch[1]) : undefined;
@@ -66,7 +66,6 @@ export function parseReviewWakeupRun(run) {
   if (
     !trustedPath ||
     run?.event !== "pull_request_review" ||
-    run?.conclusion !== "success" ||
     !Number.isSafeInteger(run?.id) ||
     run.id < 1 ||
     !Number.isSafeInteger(pullNumber) ||

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -3283,10 +3283,7 @@ describe("automated review workflow", () => {
         "github.event.comment.user.id == 199175422",
         "github.event.comment.user.type == 'Bot'",
         "github.event.workflow_run.event == 'pull_request_review'",
-        "github.event.workflow_run.actor.type == 'User'",
-        "github.event.workflow_run.actor.login == 'chatgpt-codex-connector[bot]'",
-        "github.event.workflow_run.actor.id == 199175422",
-        "github.event.workflow_run.actor.type == 'Bot'",
+        "github.event.workflow_run.conclusion != 'skipped'",
       ]
     ) {
       assert(
@@ -3297,6 +3294,10 @@ describe("automated review workflow", () => {
     assert(
       !targetIf.includes("github.event.workflow_run.conclusion == 'success'"),
       "failed or cancelled review wakeups must reach trusted invalidation",
+    );
+    assert(
+      !targetIf.includes("github.event.workflow_run.actor"),
+      "downstream reconciliation must trust the classified wakeup result, not the dismissal actor",
     );
     assertEquals(record(targetJob.permissions, "target permissions"), {
       contents: "read",
@@ -3435,8 +3436,7 @@ describe("automated review workflow", () => {
     );
     assertEquals(record(mergeGroupFailureJob.env, "merge group failure env"), {
       TARGET_RESULT: "${{ needs.target.result }}",
-      TARGET_STATUS_ID:
-        "${{ needs.target.outputs.merge_group_status_id }}",
+      TARGET_STATUS_ID: "${{ needs.target.outputs.merge_group_status_id }}",
       PUBLISHER_STATUS_ID: "${{ needs.merge_group.outputs.status_id }}",
     });
     assertEquals(

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -3112,7 +3112,7 @@ describe("review wakeup identity", () => {
     path: ".github/workflows/automated-review-wakeup.yml@main",
     event: "pull_request_review",
     conclusion: "success",
-    display_title: "automated-review-wakeup-pr-123",
+    display_title: "automated-review-wakeup-pr-123-eligible",
     head_branch: "contributor-branch",
     head_sha: HEAD,
     head_repository: { id: 77 },
@@ -3131,22 +3131,33 @@ describe("review wakeup identity", () => {
   });
   const repository = { id: 88, default_branch: "main" };
 
-  it("parses only a trusted completed wakeup run", () => {
+  it("parses only trusted eligible wakeup metadata", () => {
     assertEquals(parseReviewWakeupRun(wakeupRun()), {
       pullNumber: 123,
       headBranch: "contributor-branch",
       headSha: HEAD,
       headRepositoryId: 77,
     });
+    for (const conclusion of ["failure", "cancelled"]) {
+      assertEquals(parseReviewWakeupRun(wakeupRun({ conclusion })), {
+        pullNumber: 123,
+        headBranch: "contributor-branch",
+        headSha: HEAD,
+        headRepositoryId: 77,
+      });
+    }
     for (
       const candidate of [
         wakeupRun({ path: ".github/workflows/untrusted.yml@main" }),
         wakeupRun({ path: 42 }),
         wakeupRun({ event: "pull_request" }),
-        wakeupRun({ conclusion: "failure" }),
         wakeupRun({ id: 0 }),
-        wakeupRun({ display_title: "automated-review-wakeup-pr-0" }),
-        wakeupRun({ display_title: "automated-review-wakeup-pr-123-extra" }),
+        wakeupRun({ display_title: "automated-review-wakeup-pr-0-eligible" }),
+        wakeupRun({ display_title: "automated-review-wakeup-pr-123" }),
+        wakeupRun({ display_title: "automated-review-wakeup-pr-123-ignored" }),
+        wakeupRun({
+          display_title: "automated-review-wakeup-pr-123-eligible-extra",
+        }),
         wakeupRun({ display_title: 123 }),
         wakeupRun({ head_repository: undefined }),
         wakeupRun({ head_branch: "" }),

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -3279,7 +3279,14 @@ describe("automated review workflow", () => {
       const condition of [
         "github.event_name == 'merge_group'",
         "github.event.issue.pull_request",
+        "github.event.comment.user.login == 'chatgpt-codex-connector[bot]'",
+        "github.event.comment.user.id == 199175422",
+        "github.event.comment.user.type == 'Bot'",
         "github.event.workflow_run.event == 'pull_request_review'",
+        "github.event.workflow_run.actor.type == 'User'",
+        "github.event.workflow_run.actor.login == 'chatgpt-codex-connector[bot]'",
+        "github.event.workflow_run.actor.id == 199175422",
+        "github.event.workflow_run.actor.type == 'Bot'",
       ]
     ) {
       assert(
@@ -3819,6 +3826,20 @@ describe("automated review workflow", () => {
     const jobs = record(workflow.jobs, "wakeup jobs");
     const job = record(jobs.review_event, "review event job");
     assertEquals(record(job.permissions, "review event permissions"), {});
+    const jobIf = String(job.if);
+    for (
+      const condition of [
+        "github.event.review.user.type == 'User'",
+        "github.event.review.user.login == 'chatgpt-codex-connector[bot]'",
+        "github.event.review.user.id == 199175422",
+        "github.event.review.user.type == 'Bot'",
+      ]
+    ) {
+      assert(
+        jobIf.includes(condition),
+        "the wakeup must reject review actors that cannot affect the gate",
+      );
+    }
     assertEquals("uses" in job, false);
     const steps = job.steps;
     assert(Array.isArray(steps));

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -3283,7 +3283,7 @@ describe("automated review workflow", () => {
         "github.event.comment.user.id == 199175422",
         "github.event.comment.user.type == 'Bot'",
         "github.event.workflow_run.event == 'pull_request_review'",
-        "github.event.workflow_run.conclusion != 'skipped'",
+        "endsWith(github.event.workflow_run.display_title, '-eligible')",
       ]
     ) {
       assert(
@@ -3291,6 +3291,10 @@ describe("automated review workflow", () => {
         "target resolution must skip events that no publisher job can use",
       );
     }
+    assert(
+      !targetIf.includes("github.event.workflow_run.conclusion"),
+      "review wakeup eligibility must come from the classified wakeup run-name",
+    );
     assert(
       !targetIf.includes("github.event.workflow_run.conclusion == 'success'"),
       "failed or cancelled review wakeups must reach trusted invalidation",
@@ -3813,7 +3817,7 @@ describe("automated review workflow", () => {
     assertEquals(workflow.name, "Automated review wakeup");
     assertEquals(
       workflow["run-name"],
-      "automated-review-wakeup-pr-${{ github.event.pull_request.number }}",
+      "automated-review-wakeup-pr-${{ github.event.pull_request.number }}-${{ (github.event.review.user.type == 'User' || (github.event.review.user.login == 'chatgpt-codex-connector[bot]' && github.event.review.user.id == 199175422 && github.event.review.user.type == 'Bot')) && 'eligible' || 'ignored' }}",
     );
     assertEquals(record(workflow.permissions, "wakeup permissions"), {});
     assertEquals(


### PR DESCRIPTION
## Why

The review gate currently allocates a trusted resolver and a FIFO reconciliation slot for every third-party PR comment/review, even though only the pinned Codex identity or a trusted human can change gate evidence. At the observed event rate this amplified hundreds of Sonar, Codecov, CodeRabbit, and Greptile events into a repository-local queue.

## What changes

- Admit issue-comment reconciliation only for the pinned Codex bot identity.
- Admit review wakeups only for GitHub users or the same pinned Codex bot.
- Keep failed/cancelled trusted wakeups eligible for fail-closed invalidation.
- Leave current-head and merge-group FIFO behavior unchanged.

## Verification

- Automated review gate test: 7 suites, 93 steps passed.
- Deno lint and type check passed.
- Git diff check passed.
- Independent exact-diff review found no issues.

## Risk

Narrow. The allowlist mirrors identities the tested gate helper already accepts; rejected third-party actors could not satisfy or revoke the gate.
