### PR TITLE
fix(extensions): preserve Deno fallback in packed installs

### DIFF
--- a/scripts/build/npm-package-metadata.test.ts
+++ b/scripts/build/npm-package-metadata.test.ts
@@ -830,6 +830,11 @@ describe("npm supply-chain policy", () => {
     assertStringIncludes(source, "CodeParser was not registered");
     assertStringIncludes(source, "getDeferredExtensionState(resolved)");
     assertStringIncludes(source, "await deferred.load(logger)");
+    assertStringIncludes(source, "deno eval --node-modules-dir=auto");
+    assertStringIncludes(
+      source,
+      "Deno could not load the packed bundler extension",
+    );
     assertStringIncludes(source, "app/page.tsx");
     assertStringIncludes(source, "materializeScaffold");
     assertStringIncludes(source, "template: 'ai-agent'");

--- a/scripts/test/npm-install-smoke.sh
+++ b/scripts/test/npm-install-smoke.sh
@@ -4,7 +4,7 @@
 # Verifies, against the real `deno task build:npm` artifacts installed into a
 # throwaway npm project, that:
 #   1. a `veryfront` install with co-published required packages runs the CLI
-#      and activates the parser extension under Node
+#      and activates first-party extensions under Node and Deno
 #   2. the @huggingface/transformers optional peer is declared
 #   3. loading a missing extension fails naming the installable package
 #   4. installing @veryfront/ext-auth-jwt makes the extension load
@@ -183,6 +183,18 @@ const ast = await codeParser.parse({
 if (ast?.type !== 'File') throw new Error('TSX parse failed');
 await extension.teardown?.();
 " || fail "root deferred builtin did not register a working CodeParser"
+
+echo "== 1b. root install: workspace-source fallback loads under Deno"
+deno eval --node-modules-dir=auto "
+const loader = await import('./node_modules/veryfront/esm/src/extensions/first-party-import.js');
+const extension = await loader.importFirstPartyExtensionModule(
+  'ext-bundler-esbuild',
+  '@veryfront/ext-bundler-esbuild',
+);
+if (typeof extension.EsbuildBundler !== 'function') {
+  throw new Error('Deno could not load the packed bundler extension');
+}
+" || fail "Deno could not load the packed bundler extension"
 
 echo "== 2. root install: transformers optional peer declared"
 node -e "

--- a/src/agent/hosted/cloud-agent-provider-bootstrap.test.ts
+++ b/src/agent/hosted/cloud-agent-provider-bootstrap.test.ts
@@ -1,0 +1,32 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { isMissingOpenTelemetryNodeTelemetryProviderError } from "./cloud-agent-provider-bootstrap.ts";
+
+Deno.test("OpenTelemetry bootstrap distinguishes an absent extension from transitive failures", () => {
+  const expectedSource =
+    "/app/node_modules/veryfront/esm/extensions/ext-observability-opentelemetry/src/index.ts";
+  const missingExtension = Object.assign(
+    new Error(
+      `Unable to load ${expectedSource}\n  Caused by:\n    The system cannot find the path specified. (os error 3)`,
+    ),
+    { code: "ERR_MODULE_NOT_FOUND" },
+  );
+  const missingTransitiveFile = Object.assign(
+    new Error(
+      "Unable to load /app/node_modules/@veryfront/ext-observability-opentelemetry/esm/src/helper.ts\n" +
+        "  Caused by:\n    No such file or directory (os error 2)",
+    ),
+    { code: "ERR_MODULE_NOT_FOUND" },
+  );
+  const missingPackage = Object.assign(
+    new Error(
+      "Cannot find package '@veryfront/ext-observability-opentelemetry' imported from " +
+        "'file:///app/node_modules/veryfront/esm/src/agent/hosted/cloud-agent-provider-bootstrap.js'",
+    ),
+    { code: "ERR_MODULE_NOT_FOUND" },
+  );
+
+  assertEquals(isMissingOpenTelemetryNodeTelemetryProviderError(missingExtension), true);
+  assertEquals(isMissingOpenTelemetryNodeTelemetryProviderError(missingPackage), true);
+  assertEquals(isMissingOpenTelemetryNodeTelemetryProviderError(missingTransitiveFile), false);
+});

--- a/src/agent/hosted/cloud-agent-provider-bootstrap.ts
+++ b/src/agent/hosted/cloud-agent-provider-bootstrap.ts
@@ -158,23 +158,19 @@ async function importOpenTelemetryNodeTelemetryProvider() {
     );
     return OpenTelemetryNodeTelemetryProvider;
   } catch (error) {
-    if (!isMissingOptionalPackageError(error) && !isMissingFirstPartyExtensionModule(error)) {
+    if (!isMissingOpenTelemetryNodeTelemetryProviderError(error)) {
       throw error;
     }
     return null;
   }
 }
 
-// Runtime heuristic: detects a missing optional npm/Deno package by error message text.
-// These strings come from Node, Deno, and bundler runtimes and can vary by version.
-// If the wording changes, a missing optional package will throw instead of returning null,
-// turning an optional dependency into a hard startup failure — the safe fallback.
-function isMissingOptionalPackageError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return message.includes("Cannot find package") ||
-    message.includes("Cannot find module") ||
-    message.includes("ERR_MODULE_NOT_FOUND") ||
-    message.includes("Module not found");
+/** @internal Classify only absence of the optional OpenTelemetry extension itself. */
+export function isMissingOpenTelemetryNodeTelemetryProviderError(error: unknown): boolean {
+  return isMissingFirstPartyExtensionModule(error, [
+    "extensions/ext-observability-opentelemetry/src/index",
+    "@veryfront/ext-observability-opentelemetry",
+  ]);
 }
 
 /** Validates and snapshots an explicit runtime source identity, rejecting branch sources. */

--- a/src/extensions/first-party-import.test.ts
+++ b/src/extensions/first-party-import.test.ts
@@ -230,6 +230,19 @@ describe("first-party extension imports", () => {
         true,
       );
 
+      const missingWorkspacePath = Object.assign(
+        new Error(
+          `Unable to load ${expectedSource}\n  Caused by:\n    The system cannot find the path specified. (os error 3)`,
+        ),
+        { code: "ERR_MODULE_NOT_FOUND" },
+      );
+      assertEquals(
+        isMissingFirstPartyExtensionModule(missingWorkspacePath, [
+          `file://${expectedSource}`,
+        ]),
+        true,
+      );
+
       const quotedImporterSourceMiss = Object.assign(
         new Error(
           `[ERR_MODULE_NOT_FOUND] Cannot find module 'file://${expectedSource}' imported from 'file:///app/node_modules/veryfront/esm/src/extensions/first-party-import.js'`,

--- a/src/extensions/first-party-import.test.ts
+++ b/src/extensions/first-party-import.test.ts
@@ -214,6 +214,62 @@ describe("first-party extension imports", () => {
       );
     });
 
+    it("parses Deno packed source probes without hiding transitive failures", () => {
+      const expectedSource =
+        "/app/node_modules/veryfront/esm/extensions/ext-bundler-esbuild/src/index.ts";
+      const missingWorkspaceSource = Object.assign(
+        new Error(
+          `Unable to load ${expectedSource}\n  Caused by:\n    No such file or directory (os error 2)`,
+        ),
+        { code: "ERR_MODULE_NOT_FOUND" },
+      );
+      assertEquals(
+        isMissingFirstPartyExtensionModule(missingWorkspaceSource, [
+          `file://${expectedSource}`,
+        ]),
+        true,
+      );
+
+      const quotedImporterSourceMiss = Object.assign(
+        new Error(
+          `[ERR_MODULE_NOT_FOUND] Cannot find module 'file://${expectedSource}' imported from 'file:///app/node_modules/veryfront/esm/src/extensions/first-party-import.js'`,
+        ),
+        { code: "ERR_MODULE_NOT_FOUND" },
+      );
+      assertEquals(
+        isMissingFirstPartyExtensionModule(quotedImporterSourceMiss, [
+          `file://${expectedSource}`,
+        ]),
+        true,
+      );
+
+      const missingTransitiveDependency = Object.assign(
+        new Error(
+          "Unable to load /app/node_modules/missing-helper/index.ts\n  Caused by:\n    No such file or directory (os error 2)",
+        ),
+        { code: "ERR_MODULE_NOT_FOUND" },
+      );
+      assertEquals(
+        isMissingFirstPartyExtensionModule(missingTransitiveDependency, [
+          `file://${expectedSource}`,
+        ]),
+        false,
+      );
+
+      const quotedTransitiveDependency = Object.assign(
+        new Error(
+          "[ERR_MODULE_NOT_FOUND] Cannot find package 'missing-helper' imported from 'file:///app/node_modules/@veryfront/ext-bundler-esbuild/esm/src/index.js'",
+        ),
+        { code: "ERR_MODULE_NOT_FOUND" },
+      );
+      assertEquals(
+        isMissingFirstPartyExtensionModule(quotedTransitiveDependency, [
+          "@veryfront/ext-bundler-esbuild",
+        ]),
+        false,
+      );
+    });
+
     it("does not misread a broken transitive dependency as a missing extension", () => {
       const transitiveError = new Error(
         "Cannot find package 'jose' imported from /app/node_modules/@veryfront/ext-auth-jwt/esm/src/index.js",

--- a/src/extensions/first-party-import.ts
+++ b/src/extensions/first-party-import.ts
@@ -398,6 +398,17 @@ function matchReportedMissingSpecifier(message: string): string | undefined {
     if (packageName) return `${packageName}/${packageSubpath[1]!.slice(2)}`;
   }
 
+  // Deno reports an import of an absent absolute file as a filesystem loader
+  // failure instead of its usual `Cannot find module` resolver wording. Keep
+  // the complete error shape anchored so only the requested file can match;
+  // callers still compare the captured path exactly with the expected source.
+  const denoFilesystemLoad = ReflectApply(
+    RegExpPrototypeExec,
+    /^Unable to load ([^\r\n]+)\r?\n {2}Caused by:\r?\n {4}(?:No such file or directory|The system cannot find the file specified\.?) \(os error 2\)$/,
+    [message],
+  ) as RegExpExecArray | null;
+  if (denoFilesystemLoad) return denoFilesystemLoad[1];
+
   const bunResolveMessage = ReflectApply(
     RegExpPrototypeExec,
     /^(?:ResolveMessage:\s+)?Cannot find module\s+["']([^"']+)["']\s+from\s+["']([^"']+)["']$/,
@@ -424,7 +435,7 @@ function matchReportedMissingSpecifier(message: string): string | undefined {
   for (
     const pattern of [
       /^Cannot find module\s+["']([^"']+)["']\nRequire stack:(?:\n- [^\r\n]+)+$/,
-      /^(?:Cannot find package|Cannot find module)\s+["']([^"']+)["']\s+imported from\s+(?:file:|https?:|npm:|jsr:|\/|[A-Za-z]:|\\\\).+$/,
+      /^(?:Cannot find package|Cannot find module)\s+["']([^"']+)["']\s+imported from\s+["']?(?:file:|https?:|npm:|jsr:|\/|[A-Za-z]:|\\\\).+$/,
       /^Module not found\s+["']([^"']+)["']\.$/,
       // Deno, when the importer itself resolves out of the npm cache. The
       // trailing parenthetical names the owning package when the referrer

--- a/src/extensions/first-party-import.ts
+++ b/src/extensions/first-party-import.ts
@@ -404,7 +404,7 @@ function matchReportedMissingSpecifier(message: string): string | undefined {
   // callers still compare the captured path exactly with the expected source.
   const denoFilesystemLoad = ReflectApply(
     RegExpPrototypeExec,
-    /^Unable to load ([^\r\n]+)\r?\n {2}Caused by:\r?\n {4}(?:No such file or directory|The system cannot find the file specified\.?) \(os error 2\)$/,
+    /^Unable to load ([^\r\n]+)\r?\n {2}Caused by:\r?\n {4}(?:(?:No such file or directory|The system cannot find the file specified\.?) \(os error 2\)|The system cannot find the path specified\.? \(os error 3\))$/,
     [message],
   ) as RegExpExecArray | null;
   if (denoFilesystemLoad) return denoFilesystemLoad[1];

--- a/tests/integration/ci/registry-release-smoke.test.ts
+++ b/tests/integration/ci/registry-release-smoke.test.ts
@@ -129,6 +129,7 @@ printf '%s' "\${VF_NPM_REGISTRY_PACKAGES:-}" >>"\$VF_INVOCATION_LOG"
     const npmLog = `${tempDir}/npm.log`;
     const npmCount = `${tempDir}/npm.count`;
     await Deno.mkdir(binDir);
+    await writeExecutable(`${binDir}/deno`, "#!/bin/bash\nexit 0\n");
     await writeExecutable(
       `${binDir}/npm`,
       `#!/usr/bin/env bash


### PR DESCRIPTION
## Summary

- recognize the two exact Deno 2.7 error shapes emitted when a packed install probes an absent workspace source
- preserve exact expected-specifier matching so missing transitive dependencies still fail visibly
- exercise the packed first-party extension fallback under Deno in the existing clean npm-install smoke test

The standalone application-auth example exposed this while importing `veryfront/testing/bdd` from an installed package. The fallback target was present, but Deno reported the absent source probe with quoted-importer and filesystem-loader wording that the classifier did not recognize.

## Security

The parser remains fully anchored and the captured missing path must equal the expected source after canonicalization. Tests cover both real missing-source shapes and negative transitive-dependency cases. A focused security review found no remaining findings.

## Verification

- focused first-party import suite: 38 steps passed
- full unit suite: 4,313 tests and 34,783 steps passed, 1 test ignored
- `deno task lint`
- `deno check` for the touched TypeScript files
- `deno task build:npm`
- packed npm-install smoke, including the new Deno runtime proof
- npm package metadata tests: 19 tests and 27 steps passed
- `bash -n scripts/test/npm-install-smoke.sh`
- `git diff --check`

Local verification used Deno 2.7.12. The repository currently pins Deno 2.7.7.

Related: veryfront/veryfront-issue-inbox#826
Supports: veryfront/veryfront-examples#52