### PR TITLE
fix(workflow): use an https sentinel base for path canonicalization

### DIFF
--- a/src/workflow/http/handler.ts
+++ b/src/workflow/http/handler.ts
@@ -94,7 +94,7 @@ function routeSegments(pathname: string, basePath: string): string[] | null {
 }
 
 function canonicalWorkflowPath(basePath: string, segments: readonly string[]): string {
-  const baseUrl = new URL("http://workflow.invalid");
+  const baseUrl = new URL("https://workflow.invalid");
   baseUrl.pathname = `/${basePath.split("/").filter(Boolean).join("/")}`;
   const normalizedBase = baseUrl.pathname;
   const encodedSuffix = segments.map((segment) => encodeURIComponent(segment)).join("/");


### PR DESCRIPTION
## Why

`main` is red. Every CI job passes — the only failing check is **SonarQubeCloud / SonarCloud Code Analysis**, whose quality gate fails two conditions:

| Condition | Actual | Required |
|---|---|---|
| `new_security_rating` | **B (2)** | A (1) |
| `new_reliability_rating` | **C (3)** | A (1) |

Sonar's own gate metrics report `new_bugs=1` and `new_vulnerabilities=1` — the gate is held red by exactly two findings, not by a large backlog. This PR clears the security one.

## The finding

`typescript:S5332` — *"Using http protocol is insecure. Use https instead."* at `src/workflow/http/handler.ts:97`, introduced by #4168.

```ts
function canonicalWorkflowPath(basePath: string, segments: readonly string[]): string {
  const baseUrl = new URL("http://workflow.invalid");
  baseUrl.pathname = `/${basePath.split("/").filter(Boolean).join("/")}`;
  const normalizedBase = baseUrl.pathname;
```

The `URL` is a throwaway used only to normalize a pathname. `baseUrl` is written and read exactly once each, both times as `.pathname`; nothing is ever fetched. The scheme carried no meaning, so there was no reason for it to be `http`.

## The change

One line — the sentinel becomes `https://workflow.invalid`. This matches the convention already established for parse-only base URLs in this repo:

- `src/chat/conversation.ts:207` — `new URL(url, "https://veryfront.invalid")`
- `src/config/schemas/config.schema.ts:84` — `"https://csrf-policy.invalid"`

`.invalid` is an RFC 2606 reserved TLD, so the host is guaranteed non-resolvable either way.

## Verification

Run in a clean worktree branched from `origin/main` (`bc00a5a3`):

| Gate | Command | Result |
|---|---|---|
| Tests | `deno test --allow-all src/workflow/http/handler.test.ts` | ✅ 1 passed, **45 steps**, 0 failed |
| Format | `deno fmt --check src/workflow/http/handler.ts` | ✅ exit 0 |
| Lint | `deno lint src/workflow/http/handler.ts` | ✅ exit 0 |
| Typecheck | `deno check src/workflow/http/handler.ts` | ✅ exit 0 |

No new test is added: the change swaps an unobservable constant, and asserting "the internal base URL is https" would test an implementation detail rather than behavior. The existing handler suite already covers `canonicalWorkflowPath`.

## Not in scope

Two follow-ups, deliberately left out:

1. **The reliability finding.** `typescript:S7739` ("Do not add `then` to an object") at `src/workflow/api/workflow-client.ts:262` is a **false positive** — `then` is the public workflow DSL's branch field (`branch → then` / `else`), typed `WorkflowNode[]` in `src/workflow/types.ts:210` and documented in `src/workflow/index.ts:33`. An array is not callable, so the object is not a thenable. Renaming it would be a breaking DSL change. It is being marked *False Positive* in SonarCloud instead. **`main` stays red until that is done — both findings must clear.**

2. **The new-code window.** The new-code period is `previous_version`, but no `sonar.projectVersion` is ever supplied, so the baseline has been pinned at `2026-08-24T22:25:51Z` and has now accumulated **110,711 new lines across 93 commits**. It will keep growing. `sonarcloud-quality-gate-prd.md` already proposes the fix (CI-based analysis with a real version); this PR does not address it.