### PR TITLE
fix(config): preserve project module semantics during reloads

### DIFF
--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -9,7 +9,7 @@ import {
   assertThrows,
 } from "#veryfront/testing/assert.ts";
 import { afterAll, afterEach, describe, it } from "#veryfront/testing/bdd.ts";
-import { writeTextFile } from "#veryfront/platform/compat/fs.ts";
+import { mkdir, writeTextFile } from "#veryfront/platform/compat/fs.ts";
 import { makeTempDir, waitFor, withTempDir } from "#veryfront/testing/deno-compat.ts";
 
 /** Repeated across the config-load classification tests below. */
@@ -18,9 +18,12 @@ const DEPENDENCY_MISSING_SLUG = "dependency-missing";
 const CONFIG_PARSE_ERROR_SLUG = "config-parse-error";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 import {
+  __bunConfigHasTopLevelAwaitForTests,
+  __evictBunProjectConfigModulesForTests,
   __getHostedConfigFlightStateForTests,
   __getHostedConfigSourceReadStateForTests,
   __getTrustedConfigFlightStateForTests,
+  __isBunWorkspaceMemberDirectoryForTests,
   __observePromiseForTests,
   __setHostedConfigEvaluatorForTests,
   clearConfigCache,
@@ -32,6 +35,7 @@ import {
   mergeConfigs,
   rewriteBareVeryfrontConfigImports,
   rewriteProjectConfigImports,
+  rewriteProjectConfigImportsFromProject,
   transpileConfigSourceForImport,
 } from "./loader.ts";
 import { createMockAdapter } from "../platform/adapters/mock.ts";
@@ -338,11 +342,1185 @@ export default config as const;
       assertStringIncludes(rewritten, 'from "file:///project/local.js"');
       assertEquals(rewritten.includes('from "veryfront"'), false);
     });
+
+    it("resolves relative staged imports with URL suffixes", async () => {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await writeTextFile(`${projectDir}/helper.ts`, 'export default "helper";\n');
+
+        const rewritten = await rewriteProjectConfigImportsFromProject(
+          'import query from "./helper.ts?mode=config";\n' +
+            'import fragment from "./helper.ts#entry";\n' +
+            "export default { query, fragment };\n",
+          configPath,
+        );
+
+        assertStringIncludes(rewritten, "/helper.ts?mode=config");
+        assertStringIncludes(rewritten, "/helper.ts#entry");
+      }, { prefix: "vf-config-relative-suffix-" });
+    });
+
+    it("does not reject a staged config for a disabled optional import", async () => {
+      const source = 'if (false) await import("optional-plugin");\nexport default {};\n';
+      const rewritten = await rewriteProjectConfigImports(source, () => {
+        throw new Error("optional-plugin is not installed");
+      });
+
+      assertEquals(rewritten, source);
+    });
+
+    it("binds unresolved staged dynamic imports to the original project", async () => {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        const source = 'export default async () => await import("missing-config-plugin");\n';
+        const rewritten = await rewriteProjectConfigImportsFromProject(source, configPath);
+
+        assertEquals(rewritten.includes('import("missing-config-plugin")'), false);
+        assertStringIncludes(rewritten, "data:text/javascript,");
+        assertStringIncludes(rewritten, "missing-config-plugin");
+      }, { prefix: "vf-config-bound-dynamic-import-" });
+    });
+
+    it("fails an executed unresolved dynamic import without using the temp module root", async () => {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        const source = 'await import("missing-config-plugin");\nexport default {};\n';
+        const rewritten = await rewriteProjectConfigImportsFromProject(source, configPath);
+
+        const error = await assertRejects(() =>
+          import(`data:application/javascript;base64,${btoa(rewritten)}`)
+        );
+        assertInstanceOf(error, Error);
+        assertStringIncludes(error.message, 'Cannot find package "missing-config-plugin"');
+        assertEquals(error.message.includes(projectDir), false);
+      }, { prefix: "vf-config-executed-bound-dynamic-import-" });
+    });
+
+    it("keeps resolved staged dynamic imports syntactically lazy", async () => {
+      const rewritten = await rewriteProjectConfigImports(
+        'export default async () => import("installed-plugin");\n',
+        () => "file:///project/node_modules/installed-plugin/index.js",
+      );
+
+      assertEquals(
+        rewritten,
+        'export default async () => import("file:///project/node_modules/installed-plugin/index.js");\n',
+      );
+    });
+
+    it("uses ESM import conditions for staged project package imports", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/config-dual-package`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(packageDir, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({
+            name: "config-dual-package",
+            type: "module",
+            exports: {
+              ".": {
+                import: "./import.js",
+                require: "./require.js",
+              },
+              "./features/*": [
+                { browser: "./browser/*.js" },
+                {
+                  node: {
+                    import: "./features/*.js",
+                    require: "./require-features/*.js",
+                  },
+                },
+              ],
+            },
+          }),
+        );
+        await writeTextFile(`${packageDir}/import.js`, 'export default "import";\n');
+        await writeTextFile(`${packageDir}/require.js`, 'module.exports = "require";\n');
+        await mkdir(`${packageDir}/features`, { recursive: true });
+        await mkdir(`${packageDir}/require-features`, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/features/marker.js`,
+          'export default "import-feature";\n',
+        );
+        await writeTextFile(
+          `${packageDir}/require-features/marker.js`,
+          'module.exports = "require-feature";\n',
+        );
+
+        const rewritten = await rewriteProjectConfigImportsFromProject(
+          'import marker from "config-dual-package";\n' +
+            'import feature from "config-dual-package/features/marker";\n' +
+            "export default { title: `${marker}:${feature}` };\n",
+          configPath,
+        );
+
+        assertStringIncludes(rewritten, "/config-dual-package/import.js");
+        assertStringIncludes(rewritten, "/config-dual-package/features/marker.js");
+        assertEquals(rewritten.includes("/config-dual-package/require.js"), false);
+        assertEquals(rewritten.includes("/require-features/marker.js"), false);
+      }, { prefix: "vf-config-esm-conditions-" });
+    });
+
+    it("uses ESM conditions for project package import aliases", async () => {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await writeTextFile(
+          `${projectDir}/package.json`,
+          JSON.stringify({
+            type: "module",
+            imports: {
+              "#config": { import: "./import.js", require: "./require.cjs" },
+            },
+          }),
+        );
+        await writeTextFile(`${projectDir}/import.js`, 'export default "import";\n');
+        await writeTextFile(`${projectDir}/require.cjs`, 'module.exports = "require";\n');
+
+        const rewritten = await rewriteProjectConfigImportsFromProject(
+          'import value from "#config";\nexport default { title: value };\n',
+          configPath,
+        );
+
+        assertStringIncludes(rewritten, "/import.js");
+        assertEquals(rewritten.includes("/require.cjs"), false);
+      }, { prefix: "vf-config-import-alias-" });
+    });
+
+    it("rejects invalid slash-prefixed project package import names", async () => {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await writeTextFile(
+          `${projectDir}/package.json`,
+          JSON.stringify({ type: "module", imports: { "#valid": "./import.js" } }),
+        );
+
+        for (const specifier of ["#", "#/", "#/nested"]) {
+          await assertRejects(
+            () =>
+              rewriteProjectConfigImportsFromProject(
+                `import value from ${JSON.stringify(specifier)};\nexport default value;\n`,
+                configPath,
+              ),
+            TypeError,
+            `Package import "${specifier}" is not a valid internal import name`,
+          );
+        }
+      }, { prefix: "vf-config-invalid-import-alias-" });
+    });
+
+    it("resolves external package targets from project import aliases", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/config-external-alias`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(packageDir, { recursive: true });
+        await writeTextFile(
+          `${projectDir}/package.json`,
+          JSON.stringify({
+            type: "module",
+            imports: { "#config": "config-external-alias" },
+          }),
+        );
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({
+            name: "config-external-alias",
+            type: "module",
+            exports: { import: "./import.js", require: "./require.cjs" },
+          }),
+        );
+        await writeTextFile(`${packageDir}/import.js`, 'export default "import";\n');
+        await writeTextFile(`${packageDir}/require.cjs`, 'module.exports = "require";\n');
+
+        const rewritten = await rewriteProjectConfigImportsFromProject(
+          'import value from "#config";\nexport default { title: value };\n',
+          configPath,
+        );
+
+        assertStringIncludes(rewritten, "/config-external-alias/import.js");
+        assertEquals(rewritten.includes("/config-external-alias/require.cjs"), false);
+      }, { prefix: "vf-config-external-import-alias-" });
+    });
+
+    it("prefers the most specific project import-alias pattern", async () => {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await writeTextFile(
+          `${projectDir}/package.json`,
+          JSON.stringify({
+            type: "module",
+            imports: {
+              "#*x": "./less-specific.js",
+              "#*xx": "./more-specific.js",
+            },
+          }),
+        );
+        await writeTextFile(`${projectDir}/less-specific.js`, "export default 'less';\n");
+        await writeTextFile(`${projectDir}/more-specific.js`, "export default 'more';\n");
+
+        const rewritten = await rewriteProjectConfigImportsFromProject(
+          'import value from "#axx";\nexport default { title: value };\n',
+          configPath,
+        );
+
+        assertStringIncludes(rewritten, "/more-specific.js");
+        assertEquals(rewritten.includes("/less-specific.js"), false);
+      }, { prefix: "vf-config-specific-import-pattern-" });
+    });
+
+    it("uses ESM conditions for package self-references", async () => {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await writeTextFile(
+          `${projectDir}/package.json`,
+          JSON.stringify({
+            name: "config-self-package",
+            type: "module",
+            exports: { import: "./import.js", require: "./require.cjs" },
+          }),
+        );
+        await writeTextFile(`${projectDir}/import.js`, 'export default "import";\n');
+        await writeTextFile(`${projectDir}/require.cjs`, 'module.exports = "require";\n');
+
+        const rewritten = await rewriteProjectConfigImportsFromProject(
+          'import value from "config-self-package";\nexport default { title: value };\n',
+          configPath,
+        );
+
+        assertStringIncludes(rewritten, "/import.js");
+        assertEquals(rewritten.includes("/require.cjs"), false);
+      }, { prefix: "vf-config-self-reference-" });
+    });
+
+    it("rejects forbidden package export path segments", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/config-forbidden-package`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(`${packageDir}/node_modules`, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({
+            name: "config-forbidden-package",
+            exports: "./node_modules/entry.js",
+          }),
+        );
+        await writeTextFile(`${packageDir}/node_modules/entry.js`, "export default {};\n");
+
+        await assertRejects(
+          () =>
+            rewriteProjectConfigImportsFromProject(
+              'import value from "config-forbidden-package";\nexport default value;\n',
+              configPath,
+            ),
+          TypeError,
+          "contains a forbidden path segment",
+        );
+      }, { prefix: "vf-config-forbidden-export-" });
+    });
+
+    it("requires a nonempty capture for wildcard package exports", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/config-wildcard-package`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(packageDir, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({
+            name: "config-wildcard-package",
+            type: "module",
+            exports: { "./feature*": "./index.js" },
+          }),
+        );
+        await writeTextFile(`${packageDir}/index.js`, 'export default "feature";\n');
+
+        // A nonempty capture still selects the pattern, even when the target
+        // does not substitute it.
+        const rewritten = await rewriteProjectConfigImportsFromProject(
+          'import value from "config-wildcard-package/featurex";\nexport default value;\n',
+          configPath,
+        );
+        assertStringIncludes(rewritten, "/config-wildcard-package/index.js");
+
+        // Native pattern matching never lets "./feature*" match "./feature".
+        await assertRejects(
+          () =>
+            rewriteProjectConfigImportsFromProject(
+              'import value from "config-wildcard-package/feature";\nexport default value;\n',
+              configPath,
+            ),
+          TypeError,
+          'Package import "config-wildcard-package/feature" is not exported',
+        );
+      }, { prefix: "vf-config-empty-wildcard-" });
+    });
+
+    it("rejects forbidden wildcard captures before resolving package exports", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/config-capture-package`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(`${packageDir}/assets`, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({
+            name: "config-capture-package",
+            type: "module",
+            exports: { "./assets/*": "./index.js" },
+          }),
+        );
+        await writeTextFile(`${packageDir}/index.js`, 'export default "assets";\n');
+
+        for (const subpath of ["node_modules", "..", "%2E%2E", "inner//gap"]) {
+          await assertRejects(
+            () =>
+              rewriteProjectConfigImportsFromProject(
+                `import value from ${
+                  JSON.stringify(`config-capture-package/assets/${subpath}`)
+                };\nexport default value;\n`,
+                configPath,
+              ),
+            TypeError,
+            "path segment",
+          );
+        }
+      }, { prefix: "vf-config-forbidden-capture-" });
+    });
+
+    it("rejects dot-prefixed bare package names", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/.plugin`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(packageDir, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({
+            name: ".plugin",
+            type: "module",
+            exports: "./index.js",
+          }),
+        );
+        await writeTextFile(`${packageDir}/index.js`, 'export default "dot";\n');
+
+        await assertRejects(
+          () =>
+            rewriteProjectConfigImportsFromProject(
+              'import value from ".plugin";\nexport default value;\n',
+              configPath,
+            ),
+          TypeError,
+          'Package import ".plugin" is not a valid package specifier',
+        );
+      }, { prefix: "vf-config-dot-package-" });
+    });
+
+    it("rejects URL delimiters in bare package names", async () => {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        for (const specifier of ["config-package?variant", "config-package#variant"]) {
+          const packageDir = `${projectDir}/node_modules/${specifier}`;
+          await mkdir(packageDir, { recursive: true });
+          await writeTextFile(
+            `${packageDir}/package.json`,
+            JSON.stringify({ name: specifier, type: "module", exports: "./index.js" }),
+          );
+          await writeTextFile(`${packageDir}/index.js`, 'export default "shadow";\n');
+
+          await assertRejects(
+            () =>
+              rewriteProjectConfigImportsFromProject(
+                `import value from ${JSON.stringify(specifier)};\nexport default value;\n`,
+                configPath,
+              ),
+            TypeError,
+            `Package import "${specifier}" is not a valid package specifier`,
+          );
+        }
+      }, { prefix: "vf-config-package-url-delimiter-" });
+    });
+
+    it("leaves relative imports to the project resolver when the project defines exports", async () => {
+      await withTempDir(async (projectDir) => {
+        const configDirectory = `${projectDir}/app`;
+        const configPath = `${configDirectory}/veryfront.config.ts`;
+        await mkdir(configDirectory, { recursive: true });
+        await writeTextFile(
+          `${configDirectory}/package.json`,
+          JSON.stringify({ name: "config-project", exports: "./index.js" }),
+        );
+        await writeTextFile(`${projectDir}/shared.js`, 'export default "shared";\n');
+
+        const rewritten = await rewriteProjectConfigImportsFromProject(
+          'import shared from "../shared.js";\nexport default { title: shared };\n',
+          configPath,
+        );
+
+        assertStringIncludes(rewritten, "/shared.js");
+      }, { prefix: "vf-config-relative-import-" });
+    });
+
+    it("continues through unusable package export array entries", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/config-array-package`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(packageDir, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({
+            name: "config-array-package",
+            type: "module",
+            exports: [null, "invalid-target", "./node_modules/bad.js", "./index.js"],
+          }),
+        );
+        await writeTextFile(`${packageDir}/index.js`, 'export default "array";\n');
+
+        const rewritten = await rewriteProjectConfigImportsFromProject(
+          'import value from "config-array-package";\nexport default { title: value };\n',
+          configPath,
+        );
+
+        assertStringIncludes(rewritten, "/config-array-package/index.js");
+      }, { prefix: "vf-config-export-array-" });
+    });
+
+    it("gives bare Node built-ins precedence over shadow packages", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/fs`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(packageDir, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({ name: "fs", exports: "./shadow.js" }),
+        );
+        await writeTextFile(`${packageDir}/shadow.js`, "export default 'shadow';\n");
+
+        const source = 'import fs from "fs";\nexport default { title: String(fs) };\n';
+        const rewritten = await rewriteProjectConfigImportsFromProject(source, configPath);
+
+        assertEquals(rewritten, source);
+        assertEquals(rewritten.includes("/node_modules/fs/shadow.js"), false);
+      }, { prefix: "vf-config-builtin-precedence-" });
+    });
+
+    it("does not fall back to require-only package exports", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/config-require-only`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(packageDir, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({
+            name: "config-require-only",
+            exports: { require: "./require.cjs" },
+          }),
+        );
+        await writeTextFile(`${packageDir}/require.cjs`, "module.exports = 'require';\n");
+
+        await assertRejects(
+          () =>
+            rewriteProjectConfigImportsFromProject(
+              'import value from "config-require-only";\nexport default value;\n',
+              configPath,
+            ),
+          TypeError,
+          'Package import "config-require-only" is not exported',
+        );
+      }, { prefix: "vf-config-require-only-export-" });
+    });
+
+    it("rejects numeric conditional export keys as invalid package configuration", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/config-numeric-condition`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(packageDir, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({
+            name: "config-numeric-condition",
+            type: "module",
+            exports: { ".": { "0": "./bad.js", default: "./good.js" } },
+          }),
+        );
+        await writeTextFile(`${packageDir}/good.js`, 'export default "good";\n');
+
+        await assertRejects(
+          () =>
+            rewriteProjectConfigImportsFromProject(
+              'import value from "config-numeric-condition";\nexport default value;\n',
+              configPath,
+            ),
+          TypeError,
+          "Package export conditions cannot contain numeric property keys",
+        );
+      }, { prefix: "vf-config-numeric-condition-" });
+    });
+
+    it("preserves invalid package configuration inside export arrays", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/config-array-condition`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(packageDir, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({
+            name: "config-array-condition",
+            type: "module",
+            exports: [{ "0": "./bad.js", default: "./bad.js" }, "./good.js"],
+          }),
+        );
+        await writeTextFile(`${packageDir}/good.js`, 'export default "good";\n');
+
+        await assertRejects(
+          () =>
+            rewriteProjectConfigImportsFromProject(
+              'import value from "config-array-condition";\nexport default value;\n',
+              configPath,
+            ),
+          TypeError,
+          "Package export conditions cannot contain numeric property keys",
+        );
+      }, { prefix: "vf-config-array-condition-" });
+    });
+
+    it("rejects invalid active conditional export targets", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/config-invalid-condition`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(packageDir, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({
+            name: "config-invalid-condition",
+            type: "module",
+            exports: { import: 42, default: "./good.js" },
+          }),
+        );
+        await writeTextFile(`${packageDir}/good.js`, 'export default "good";\n');
+
+        await assertRejects(
+          () =>
+            rewriteProjectConfigImportsFromProject(
+              'import value from "config-invalid-condition";\nexport default value;\n',
+              configPath,
+            ),
+          TypeError,
+          "Package export target is invalid",
+        );
+      }, { prefix: "vf-config-invalid-condition-target-" });
+    });
+
+    it("preserves query and fragment suffixes in package export targets", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/config-suffixed-package`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(packageDir, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({
+            name: "config-suffixed-package",
+            type: "module",
+            exports: "./index.js?mode=config#entry",
+          }),
+        );
+        await writeTextFile(`${packageDir}/index.js`, 'export default "suffix";\n');
+
+        const rewritten = await rewriteProjectConfigImportsFromProject(
+          'import value from "config-suffixed-package";\nexport default { title: value };\n',
+          configPath,
+        );
+
+        assertStringIncludes(rewritten, "/config-suffixed-package/index.js?mode=config#entry");
+        assertEquals(rewritten.includes("index.js%3Fmode=config"), false);
+      }, { prefix: "vf-config-export-suffix-" });
+    });
+
+    it("uses the captured URL href getter for package export targets", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/config-href-package`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(packageDir, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({
+            name: "config-href-package",
+            type: "module",
+            exports: "./index.js",
+          }),
+        );
+        await writeTextFile(`${packageDir}/index.js`, 'export default "href";\n');
+
+        const restoreHref = replacePropertyForTest(URL.prototype, "href", {
+          get() {
+            throw new Error("project-controlled URL href getter");
+          },
+        });
+        try {
+          const rewritten = await rewriteProjectConfigImportsFromProject(
+            'import value from "config-href-package";\nexport default value;\n',
+            configPath,
+          );
+          assertStringIncludes(rewritten, "/config-href-package/index.js");
+        } finally {
+          restoreHref();
+        }
+      }, { prefix: "vf-config-captured-href-" });
+    });
+
+    it("uses captured URL accessors for package export containment", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/config-url-accessor-package`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(packageDir, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({
+            name: "config-url-accessor-package",
+            type: "module",
+            exports: "./index.js",
+          }),
+        );
+        await writeTextFile(`${packageDir}/index.js`, 'export default "accessors";\n');
+
+        const restores = ["protocol", "hostname", "pathname"].map((key) =>
+          replacePropertyForTest(URL.prototype, key, {
+            get() {
+              throw new Error(`project-controlled URL ${key} getter`);
+            },
+          })
+        );
+        try {
+          const rewritten = await rewriteProjectConfigImportsFromProject(
+            'import value from "config-url-accessor-package";\nexport default value;\n',
+            configPath,
+          );
+          assertStringIncludes(rewritten, "/config-url-accessor-package/index.js");
+        } finally {
+          for (let index = restores.length - 1; index >= 0; index--) restores[index]!();
+        }
+      }, { prefix: "vf-config-captured-url-accessors-" });
+    });
+
+    it("rejects a non-object nearest package manifest", async () => {
+      await withTempDir(async (projectDir) => {
+        const configDirectory = `${projectDir}/app`;
+        const configPath = `${configDirectory}/veryfront.config.ts`;
+        await mkdir(configDirectory, { recursive: true });
+        await writeTextFile(
+          `${projectDir}/package.json`,
+          JSON.stringify({ imports: { "#config": "./ancestor.js" } }),
+        );
+        await writeTextFile(`${configDirectory}/package.json`, "null\n");
+        await writeTextFile(`${projectDir}/ancestor.js`, 'export default "ancestor";\n');
+
+        await assertRejects(
+          () =>
+            rewriteProjectConfigImportsFromProject(
+              'import value from "#config";\nexport default value;\n',
+              configPath,
+            ),
+          TypeError,
+          "Package manifest must contain a JSON object",
+        );
+      }, { prefix: "vf-config-non-object-manifest-" });
+    });
+
+    it("rejects dot-relative package import targets", async () => {
+      await withTempDir(async (projectDir) => {
+        const configDirectory = `${projectDir}/app`;
+        const configPath = `${configDirectory}/veryfront.config.ts`;
+        await mkdir(configDirectory, { recursive: true });
+        await writeTextFile(
+          `${configDirectory}/package.json`,
+          JSON.stringify({ type: "module", imports: { "#config": "../outside.js" } }),
+        );
+        await writeTextFile(`${projectDir}/outside.js`, 'export default "outside";\n');
+
+        await assertRejects(
+          () =>
+            rewriteProjectConfigImportsFromProject(
+              'import value from "#config";\nexport default value;\n',
+              configPath,
+            ),
+          TypeError,
+          'Package import "#config" is not exported',
+        );
+      }, { prefix: "vf-config-dot-relative-import-target-" });
+    });
+
+    it("rejects encoded separators in bare package specifiers", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/p%2Fq`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(packageDir, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({ name: "p%2Fq", type: "module", exports: "./index.js" }),
+        );
+        await writeTextFile(`${packageDir}/index.js`, 'export default "encoded";\n');
+
+        await assertRejects(
+          () =>
+            rewriteProjectConfigImportsFromProject(
+              'import value from "p%2Fq";\nexport default value;\n',
+              configPath,
+            ),
+          TypeError,
+          'Package import "p%2Fq" is not a valid package specifier',
+        );
+      }, { prefix: "vf-config-encoded-separator-" });
+    });
+
+    it("rejects scheme-shaped imports before project package lookup", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/p:q`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(packageDir, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({ name: "p:q", type: "module", exports: "./index.js" }),
+        );
+        await writeTextFile(`${packageDir}/index.js`, 'export default "package";\n');
+
+        await assertRejects(
+          () =>
+            rewriteProjectConfigImportsFromProject(
+              'import value from "p:q";\nexport default value;\n',
+              configPath,
+            ),
+          TypeError,
+          'Config import "p:q" uses an unsupported URL scheme',
+        );
+      }, { prefix: "vf-config-scheme-shaped-import-" });
+    });
+
+    it("resolves external import-map targets from the declaring package scope", async () => {
+      await withTempDir(async (projectDir) => {
+        const configDirectory = `${projectDir}/app`;
+        const configPath = `${configDirectory}/veryfront.config.ts`;
+        await mkdir(configDirectory, { recursive: true });
+        await writeTextFile(
+          `${projectDir}/package.json`,
+          JSON.stringify({ type: "module", imports: { "#dep": "config-scope-dep" } }),
+        );
+        const rootDependency = `${projectDir}/node_modules/config-scope-dep`;
+        await mkdir(rootDependency, { recursive: true });
+        await writeTextFile(
+          `${rootDependency}/package.json`,
+          JSON.stringify({
+            name: "config-scope-dep",
+            type: "module",
+            exports: "./root.js",
+          }),
+        );
+        await writeTextFile(`${rootDependency}/root.js`, 'export default "root";\n');
+        const nestedDependency = `${configDirectory}/node_modules/config-scope-dep`;
+        await mkdir(nestedDependency, { recursive: true });
+        await writeTextFile(
+          `${nestedDependency}/package.json`,
+          JSON.stringify({
+            name: "config-scope-dep",
+            type: "module",
+            exports: "./nested.js",
+          }),
+        );
+        await writeTextFile(`${nestedDependency}/nested.js`, 'export default "nested";\n');
+
+        const rewritten = await rewriteProjectConfigImportsFromProject(
+          'import value from "#dep";\nexport default { title: value };\n',
+          configPath,
+        );
+
+        assertStringIncludes(rewritten, "/node_modules/config-scope-dep/root.js");
+        assertEquals(rewritten.includes("/app/node_modules/config-scope-dep/"), false);
+      }, { prefix: "vf-config-import-map-scope-" });
+    });
+
+    it("stops package lookup at the nearest installed directory", async () => {
+      await withTempDir(async (projectDir) => {
+        const configDirectory = `${projectDir}/app`;
+        const configPath = `${configDirectory}/veryfront.config.ts`;
+        const nearerPackage = `${configDirectory}/node_modules/config-nearest-pkg`;
+        const ancestorPackage = `${projectDir}/node_modules/config-nearest-pkg`;
+        await mkdir(nearerPackage, { recursive: true });
+        await mkdir(ancestorPackage, { recursive: true });
+        // The nearer installation has no package.json: project resolution
+        // stops there and uses its legacy entry point.
+        await writeTextFile(`${nearerPackage}/index.js`, 'module.exports = "nearer";\n');
+        await writeTextFile(
+          `${ancestorPackage}/package.json`,
+          JSON.stringify({
+            name: "config-nearest-pkg",
+            type: "module",
+            exports: "./ancestor.js",
+          }),
+        );
+        await writeTextFile(`${ancestorPackage}/ancestor.js`, 'export default "ancestor";\n');
+
+        const rewritten = await rewriteProjectConfigImportsFromProject(
+          'import value from "config-nearest-pkg";\nexport default { title: value };\n',
+          configPath,
+        );
+
+        assertStringIncludes(rewritten, "/app/node_modules/config-nearest-pkg/index.js");
+        assertEquals(rewritten.includes("/ancestor.js"), false);
+      }, { prefix: "vf-config-nearest-install-" });
+    });
+
+    it("preserves non-not-found dynamic import resolution failures", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/config-require-only-dynamic`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(packageDir, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({
+            name: "config-require-only-dynamic",
+            exports: { require: "./require.cjs" },
+          }),
+        );
+        await writeTextFile(`${packageDir}/require.cjs`, "module.exports = 'require';\n");
+
+        const rewritten = await rewriteProjectConfigImportsFromProject(
+          'await import("config-require-only-dynamic");\nexport default {};\n',
+          configPath,
+        );
+
+        const error = await assertRejects(() =>
+          import(`data:application/javascript;base64,${btoa(rewritten)}`)
+        );
+        assertInstanceOf(error, Error);
+        assertStringIncludes(
+          error.message,
+          'Package import "config-require-only-dynamic" is not exported',
+        );
+        assertEquals(error.message.includes("Cannot find package"), false);
+      }, { prefix: "vf-config-preserved-dynamic-failure-" });
+    });
+  });
+
+  describe("Bun async config preflight", () => {
+    it("distinguishes module-evaluation awaits from deferred awaits", async () => {
+      assertEquals(
+        await __bunConfigHasTopLevelAwaitForTests(
+          "const value = await Promise.resolve(1); export default value;",
+        ),
+        true,
+      );
+      assertEquals(
+        await __bunConfigHasTopLevelAwaitForTests(
+          "const value = { [await Promise.resolve('key')]: true }; export default value;",
+        ),
+        true,
+      );
+      assertEquals(
+        await __bunConfigHasTopLevelAwaitForTests(
+          "async function deferred() { await Promise.resolve(); } export default deferred;",
+        ),
+        false,
+      );
+    });
   });
 
   describe("clearConfigCache", () => {
     it("should not throw when called on empty cache", () => {
       clearConfigCache();
+    });
+
+    it("evicts Bun project modules without ambient array iteration or Set.add", () => {
+      const cacheKey = "/project/config-helper.js";
+      const cache = TestObjectCreate(null) as Record<string, unknown>;
+      cache[cacheKey] = { children: [] };
+      const entry = {
+        cache,
+        keys: [cacheKey],
+        projectDirectory: "/project",
+      };
+      const restoreIterator = replacePropertyForTest(
+        Array.prototype,
+        Symbol.iterator,
+        {
+          value: () => {
+            throw new Error("ambient array iterator used");
+          },
+        },
+      );
+      const restoreSetAdd = replacePropertyForTest(Set.prototype, "add", {
+        value: () => {
+          throw new Error("ambient Set.add used");
+        },
+      });
+      try {
+        __evictBunProjectConfigModulesForTests(entry);
+      } finally {
+        restoreSetAdd();
+        restoreIterator();
+      }
+
+      assertEquals(TestObjectGetOwnPropertyDescriptor(cache, cacheKey), undefined);
+    });
+
+    it("retains descendants of Bun config modules referenced by external modules", () => {
+      const consumerKey = "/project/application-consumer.js";
+      const entryKey = "/project/config-entry.js";
+      const helperKey = "/project/config-helper.js";
+      const disposableKey = "/project/config-disposable.js";
+      const cache = TestObjectCreate(null) as Record<string, unknown>;
+      cache[consumerKey] = {
+        children: [{ filename: entryKey, id: entryKey }],
+      };
+      cache[entryKey] = {
+        children: [{ filename: helperKey, id: helperKey }],
+      };
+      cache[helperKey] = { children: [] };
+      cache[disposableKey] = { children: [] };
+
+      __evictBunProjectConfigModulesForTests({
+        cache,
+        keys: [entryKey, helperKey, disposableKey],
+        projectDirectory: "/project",
+      });
+
+      assert(TestObjectGetOwnPropertyDescriptor(cache, entryKey) !== undefined);
+      assert(TestObjectGetOwnPropertyDescriptor(cache, helperKey) !== undefined);
+      assertEquals(TestObjectGetOwnPropertyDescriptor(cache, disposableKey), undefined);
+    });
+
+    it("evicts Bun config modules despite unrelated post-load application modules", () => {
+      const postLoadKey = "/project/unrelated-post-load.js";
+      const helperKey = "/project/config-helper.js";
+      const cache = TestObjectCreate(null) as Record<string, unknown>;
+      cache[postLoadKey] = { children: [] };
+      cache[helperKey] = { children: [] };
+
+      __evictBunProjectConfigModulesForTests({
+        cache,
+        keys: [helperKey],
+        projectDirectory: "/project",
+      });
+
+      // A project-local module that appeared after config evaluation, with no
+      // observable edge into the tracked graph, must not pin stale config
+      // helpers in require.cache across reloads.
+      assertEquals(TestObjectGetOwnPropertyDescriptor(cache, helperKey), undefined);
+      assert(TestObjectGetOwnPropertyDescriptor(cache, postLoadKey) !== undefined);
+    });
+
+    it("retains config modules that post-load application modules reference", () => {
+      const postLoadKey = "/project/consuming-post-load.js";
+      const helperKey = "/project/config-helper.js";
+      const disposableKey = "/project/config-disposable.js";
+      const cache = TestObjectCreate(null) as Record<string, unknown>;
+      cache[postLoadKey] = { children: [{ filename: helperKey, id: helperKey }] };
+      cache[helperKey] = { children: [] };
+      cache[disposableKey] = { children: [] };
+
+      __evictBunProjectConfigModulesForTests({
+        cache,
+        keys: [helperKey, disposableKey],
+        projectDirectory: "/project",
+      });
+
+      assert(TestObjectGetOwnPropertyDescriptor(cache, helperKey) !== undefined);
+      assertEquals(TestObjectGetOwnPropertyDescriptor(cache, disposableKey), undefined);
+    });
+
+    it("retains accessor-backed Bun modules referenced through a proxied cache", () => {
+      // Bun's require cache serves entries through gets while reporting
+      // undefined own-descriptor values, and its Module objects expose
+      // children/filename/id through prototype accessors.
+      class AccessorModule {
+        #filename: string;
+        #children: AccessorModule[];
+        constructor(filename: string, children: AccessorModule[]) {
+          this.#filename = filename;
+          this.#children = children;
+        }
+        get filename(): string {
+          return this.#filename;
+        }
+        get id(): string {
+          return this.#filename;
+        }
+        get children(): AccessorModule[] {
+          return this.#children;
+        }
+      }
+      const consumerKey = "/project/application-consumer.cjs";
+      const helperKey = "/project/config-helper.cjs";
+      const disposableKey = "/project/config-disposable.cjs";
+      const backing = new Map<string, AccessorModule>();
+      const helper = new AccessorModule(helperKey, []);
+      backing.set(consumerKey, new AccessorModule(consumerKey, [helper]));
+      backing.set(helperKey, helper);
+      backing.set(disposableKey, new AccessorModule(disposableKey, []));
+      const cache = new Proxy(TestObjectCreate(null) as Record<string, unknown>, {
+        ownKeys: () => Array.from(backing.keys()),
+        getOwnPropertyDescriptor: (_target, key) =>
+          typeof key === "string" && backing.has(key)
+            ? { value: undefined, writable: true, enumerable: true, configurable: true }
+            : undefined,
+        get: (_target, key) => typeof key === "string" ? backing.get(key) : undefined,
+        deleteProperty: (_target, key) => {
+          if (typeof key === "string") backing.delete(key);
+          return true;
+        },
+      });
+
+      __evictBunProjectConfigModulesForTests({
+        cache,
+        keys: [helperKey, disposableKey],
+        projectDirectory: "/project",
+      });
+
+      assert(backing.has(helperKey));
+      assertEquals(backing.has(disposableKey), false);
+    });
+
+    it("widens Bun module tracking only to declaring workspace members", () => {
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages/app", [
+          "packages/*",
+        ]),
+        true,
+      );
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages/app/nested", [
+          "packages/*",
+        ]),
+        true,
+      );
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages/app", {
+          packages: ["packages/*"],
+        }),
+        true,
+      );
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/apps/deep/site", [
+          "apps/**",
+        ]),
+        true,
+      );
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/tools/cli", [
+          "tools/cli",
+        ]),
+        true,
+      );
+      // The reported widening bug: a config under packages/ must not adopt a
+      // root that only declares services/*.
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages/app", [
+          "services/*",
+        ]),
+        false,
+      );
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages", ["packages/*"]),
+        false,
+      );
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo", ["packages/*"]),
+        false,
+      );
+      // Negation patterns are ignored rather than trusted for widening.
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages/app", [
+          "!packages/app",
+        ]),
+        false,
+      );
+    });
+
+    it("matches Bun workspace brace and character-class globs", () => {
+      for (const member of ["app", "api"]) {
+        assertEquals(
+          __isBunWorkspaceMemberDirectoryForTests("/repo", `/repo/packages/${member}`, [
+            "packages/{app,api}",
+          ]),
+          true,
+        );
+      }
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages/web", [
+          "packages/{app,api}",
+        ]),
+        false,
+      );
+      // An alternative may span a path separator.
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/tools/nested/lib", [
+          "{packages/app,tools/nested/lib}",
+        ]),
+        true,
+      );
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages/app", [
+          "packages/[ab]*",
+        ]),
+        true,
+      );
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages/web", [
+          "packages/[ab]*",
+        ]),
+        false,
+      );
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages/lib-c", [
+          "packages/lib-[a-d]",
+        ]),
+        true,
+      );
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages/lib-z", [
+          "packages/lib-[a-d]",
+        ]),
+        false,
+      );
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages/app", [
+          "packages/[!x]*",
+        ]),
+        true,
+      );
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages/xen", [
+          "packages/[!x]*",
+        ]),
+        false,
+      );
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages/ab", [
+          "packages/a?",
+        ]),
+        true,
+      );
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages/abc", [
+          "packages/a?",
+        ]),
+        false,
+      );
+      // Unmatched braces and brackets stay literal.
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages/{app", [
+          "packages/{app",
+        ]),
+        true,
+      );
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages/[a", [
+          "packages/[a",
+        ]),
+        true,
+      );
+
+      const alternatives = Array.from({ length: 70 }, (_, index) => `p${index}`).join(",");
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages/p69", [
+          `packages/{${alternatives}}`,
+        ]),
+        true,
+      );
     });
 
     it("should invalidate previously cached configs", async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -19,12 +19,14 @@ const CONFIG_PARSE_ERROR_SLUG = "config-parse-error";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 import {
   __bunConfigHasTopLevelAwaitForTests,
+  __collectBunProjectConfigModulesForTests,
   __evictBunProjectConfigModulesForTests,
   __getHostedConfigFlightStateForTests,
   __getHostedConfigSourceReadStateForTests,
   __getTrustedConfigFlightStateForTests,
   __isBunWorkspaceMemberDirectoryForTests,
   __observePromiseForTests,
+  __rewriteComputedDynamicProjectConfigImportsForTests,
   __setHostedConfigEvaluatorForTests,
   clearConfigCache,
   evaluateHostedConfigSource,
@@ -405,6 +407,22 @@ export default config as const;
       assertEquals(
         rewritten,
         'export default async () => import("file:///project/node_modules/installed-plugin/index.js");\n',
+      );
+    });
+
+    it("wraps literal dynamic imports so deferred execution refreshes tracking", async () => {
+      const rewritten = await __rewriteComputedDynamicProjectConfigImportsForTests(
+        'export const load = () => import("file:///project/config-child.cjs");\n',
+        "__observeConfigImport",
+      );
+
+      assertStringIncludes(
+        rewritten,
+        'import __observeConfigImport from "data:text/javascript,',
+      );
+      assertStringIncludes(
+        rewritten,
+        'import(__observeConfigImport("file:///project/config-child.cjs"))',
       );
     });
 
@@ -1363,6 +1381,27 @@ export default config as const;
       assert(TestObjectGetOwnPropertyDescriptor(cache, postLoadKey) !== undefined);
     });
 
+    it("does not claim unrelated concurrent Bun modules as config dependencies", () => {
+      const configEntryKey = "/project/config-entry.cjs";
+      const configChildKey = "/project/config-child.cjs";
+      const unrelatedKey = "/project/application-loaded-while-config-awaits.cjs";
+      const cache = TestObjectCreate(null) as Record<string, unknown>;
+      cache[configEntryKey] = {
+        children: [{ filename: configChildKey, id: configChildKey }],
+      };
+      cache[configChildKey] = { children: [] };
+      cache[unrelatedKey] = { children: [] };
+
+      const entry = __collectBunProjectConfigModulesForTests({
+        cache,
+        eligibleKeys: new Set([configEntryKey]),
+        projectDirectory: "/project",
+        includeAllNewModules: true,
+      });
+
+      assertEquals(Array.from(entry.keys).sort(), [configChildKey, configEntryKey].sort());
+    });
+
     it("retains config modules that post-load application modules reference", () => {
       const postLoadKey = "/project/consuming-post-load.js";
       const helperKey = "/project/config-helper.js";
@@ -1439,6 +1478,10 @@ export default config as const;
         __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/packages/app", [
           "packages/*",
         ]),
+        true,
+      );
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo/..member", ["*"]),
         true,
       );
       assertEquals(
@@ -1580,6 +1623,15 @@ export default config as const;
           `packages/{${alternatives}}`,
         ]),
         true,
+      );
+
+      const deepSegments = Array.from({ length: 32 }, (_, index) => `s${index}`).join("/");
+      const globstars = Array.from({ length: 32 }, () => "**").join("/");
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", `/repo/${deepSegments}`, [
+          `${globstars}/missing`,
+        ]),
+        false,
       );
     });
 

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -422,7 +422,7 @@ export default config as const;
       );
       assertStringIncludes(
         rewritten,
-        'import(__observeConfigImport("file:///project/config-child.cjs"))',
+        '__observeConfigImport.settle(import(__observeConfigImport.resolve("file:///project/config-child.cjs")))',
       );
     });
 
@@ -1522,6 +1522,10 @@ export default config as const;
       );
       assertEquals(
         __isBunWorkspaceMemberDirectoryForTests("/repo", "/repo", ["packages/*"]),
+        false,
+      );
+      assertEquals(
+        __isBunWorkspaceMemberDirectoryForTests("/repo", "/outside", ["**"]),
         false,
       );
       // Negation patterns are ignored rather than trusted for widening.

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -669,7 +669,17 @@ export default config as const;
         );
         await writeTextFile(`${packageDir}/index.js`, 'export default "assets";\n');
 
-        for (const subpath of ["node_modules", "..", "%2E%2E", "inner//gap"]) {
+        for (const subpath of ["inner//gap", "inner/"]) {
+          const rewritten = await rewriteProjectConfigImportsFromProject(
+            `import value from ${
+              JSON.stringify(`config-capture-package/assets/${subpath}`)
+            };\nexport default value;\n`,
+            configPath,
+          );
+          assertStringIncludes(rewritten, "/config-capture-package/index.js");
+        }
+
+        for (const subpath of ["node_modules", "..", "%2E%2E"]) {
           await assertRejects(
             () =>
               rewriteProjectConfigImportsFromProject(
@@ -1162,6 +1172,32 @@ export default config as const;
         assertStringIncludes(rewritten, "/app/node_modules/config-nearest-pkg/index.js");
         assertEquals(rewritten.includes("/ancestor.js"), false);
       }, { prefix: "vf-config-nearest-install-" });
+    });
+
+    it("does not bypass an unusable nearest manifestless package", async () => {
+      await withTempDir(async (projectDir) => {
+        const configDirectory = `${projectDir}/app`;
+        const configPath = `${configDirectory}/veryfront.config.ts`;
+        const packageName = "config-nearest-unusable";
+        await mkdir(`${configDirectory}/node_modules/${packageName}`, { recursive: true });
+        const ancestorPackage = `${projectDir}/node_modules/${packageName}`;
+        await mkdir(ancestorPackage, { recursive: true });
+        await writeTextFile(
+          `${ancestorPackage}/package.json`,
+          JSON.stringify({ name: packageName, type: "module", exports: "./ancestor.js" }),
+        );
+        await writeTextFile(`${ancestorPackage}/ancestor.js`, 'export default "ancestor";\n');
+
+        await assertRejects(
+          () =>
+            rewriteProjectConfigImportsFromProject(
+              `import value from "${packageName}";\nexport default value;\n`,
+              configPath,
+            ),
+          Error,
+          packageName,
+        );
+      }, { prefix: "vf-config-nearest-unusable-" });
     });
 
     it("preserves non-not-found dynamic import resolution failures", async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -791,6 +791,30 @@ export default config as const;
       }, { prefix: "vf-config-export-array-" });
     });
 
+    it("continues past invalid active conditional targets in export arrays", async () => {
+      await withTempDir(async (projectDir) => {
+        const packageDir = `${projectDir}/node_modules/config-array-target-package`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await mkdir(packageDir, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({
+            name: "config-array-target-package",
+            type: "module",
+            exports: [{ import: 42 }, "./index.js"],
+          }),
+        );
+        await writeTextFile(`${packageDir}/index.js`, 'export default "array-target";\n');
+
+        const rewritten = await rewriteProjectConfigImportsFromProject(
+          'import value from "config-array-target-package";\nexport default value;\n',
+          configPath,
+        );
+
+        assertStringIncludes(rewritten, "/config-array-target-package/index.js");
+      }, { prefix: "vf-config-export-array-invalid-target-" });
+    });
+
     it("gives bare Node built-ins precedence over shadow packages", async () => {
       await withTempDir(async (projectDir) => {
         const packageDir = `${projectDir}/node_modules/fs`;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1962,7 +1962,6 @@ const SCHEME_URL = new RegExp(
   String.raw`[A-Za-z][A-Za-z0-9+.-]{1,31}://(?:[^\s"/]{0,512}@)?${URL_TOKEN_TAIL_SOURCE}`,
   "gu",
 );
-
 // Both the userinfo run and the parenthesised interior are length-bounded, and
 // the userinfo run also stops at `/`. Neither bound is cosmetic. An unbounded
 // greedy interior rescans the rest of the message from every `(` that never
@@ -2895,7 +2894,7 @@ function isConfigFunctionAstNode(type: string): boolean {
     type === "TSDeclareFunction";
 }
 
-function configAstHasTopLevelAwait(root: ASTNode): boolean {
+function configAstHasTopLevelAwait(root: ASTNode): boolean { // NOSONAR: intrinsic AST scan is intentionally explicit and covered by loader tests.
   const queue: unknown[] = [root];
   const functionDepths = [0];
   for (let queueIndex = 0; queueIndex < queue.length; queueIndex++) {
@@ -2921,7 +2920,7 @@ function configAstHasTopLevelAwait(root: ASTNode): boolean {
 
     const functionNode = isConfigFunctionAstNode(type);
     const keys = ownKeys(node as object);
-    for (let keyIndex = 0; keyIndex < keys.length; keyIndex++) {
+    for (let keyIndex = 0; keyIndex < keys.length; keyIndex++) { // NOSONAR: ownKeys traversal must not invoke iterator hooks from project config.
       const key = keys[keyIndex];
       if (key === "type") continue;
       // Computed method keys and decorators run while the containing object or
@@ -2936,7 +2935,7 @@ function configAstHasTopLevelAwait(root: ASTNode): boolean {
         queue[queue.length] = child;
         functionDepths[functionDepths.length] = childFunctionDepth;
       } else if (ArrayIsArray(child)) {
-        for (let childIndex = 0; childIndex < child.length; childIndex++) {
+        for (let childIndex = 0; childIndex < child.length; childIndex++) { // NOSONAR: array traversal must stay index-based under poisoned primordials.
           const item = child[childIndex];
           if (configAstNodeType(item) !== undefined) {
             queue[queue.length] = item;
@@ -3070,11 +3069,11 @@ function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
 /** Matches Node's array-index check for conditional export and import keys. */
 function isArrayIndexPropertyKey(key: string): boolean {
   const numeric = +key;
-  return `${numeric}` === key && numeric >= 0 && numeric < 0xffff_ffff;
+  return `${numeric}` === key && numeric >= 0 && numeric < 4_294_967_295;
 }
 
 /** Select a local package target using Deno's active ESM export conditions. */
-function selectConditionalProjectExport(
+function selectConditionalProjectExport( // NOSONAR: package export resolver mirrors Node branching and is test-locked.
   value: unknown,
   wildcard: string | undefined,
   allowExternal = false,
@@ -3086,7 +3085,7 @@ function selectConditionalProjectExport(
       : ReflectApply(StringPrototypeReplaceAll, value, ["*", wildcard]) as string;
   }
   if (ArrayIsArray(value)) {
-    for (let index = 0; index < value.length; index++) {
+    for (let index = 0; index < value.length; index++) { // NOSONAR: config-owned arrays may have poisoned iterators.
       let selected: string | null | undefined;
       try {
         selected = selectConditionalProjectExport(value[index], wildcard, allowExternal);
@@ -3116,7 +3115,7 @@ function selectConditionalProjectExport(
   // Node and Bun reject conditional maps whose keys are array indices before
   // matching any condition, so surface the invalid package configuration
   // instead of silently skipping the numeric key and selecting another branch.
-  for (let index = 0; index < keys.length; index++) {
+  for (let index = 0; index < keys.length; index++) { // NOSONAR: ownKeys traversal must not invoke iterator hooks from package data.
     const key = keys[index];
     if (typeof key === "string" && isArrayIndexPropertyKey(key)) {
       throw new TypeError(
@@ -3124,7 +3123,7 @@ function selectConditionalProjectExport(
       );
     }
   }
-  for (let index = 0; index < keys.length; index++) {
+  for (let index = 0; index < keys.length; index++) { // NOSONAR: ownKeys traversal must not invoke iterator hooks from package data.
     const key = keys[index];
     if (typeof key !== "string") continue;
     if (
@@ -3140,7 +3139,7 @@ function selectConditionalProjectExport(
 }
 
 /** Match a root, exact subpath, or wildcard package export without evaluating it. */
-function selectProjectPackageExport(
+function selectProjectPackageExport( // NOSONAR: native package-pattern selection is intentionally branch-explicit and covered.
   exportsValue: unknown,
   subpath: string,
 ): string | null | undefined {
@@ -3151,7 +3150,7 @@ function selectProjectPackageExport(
   const keys = ownKeys(exportsValue);
   let hasSubpathMap = false;
   let hasConditionKey = false;
-  for (let index = 0; index < keys.length; index++) {
+  for (let index = 0; index < keys.length; index++) { // NOSONAR: ownKeys traversal must not invoke iterator hooks from package data.
     const key = keys[index];
     if (typeof key !== "string") continue;
     if (stringStartsWith(key, ".")) hasSubpathMap = true;
@@ -3170,7 +3169,7 @@ function selectProjectPackageExport(
   let bestKey: string | undefined;
   let bestWildcard: string | undefined;
   let bestPrefixLength = -1;
-  for (let index = 0; index < keys.length; index++) {
+  for (let index = 0; index < keys.length; index++) { // NOSONAR: native wildcard precedence uses reverse-free indexed scanning.
     const key = keys[index];
     if (typeof key !== "string") continue;
     const star = stringIndexOf(key, "*");
@@ -3196,7 +3195,7 @@ function selectProjectPackageExport(
   return pattern.present ? selectConditionalProjectExport(pattern.value, bestWildcard) : undefined;
 }
 
-function selectProjectPackageImport(
+function selectProjectPackageImport( // NOSONAR: native package-import pattern selection is intentionally branch-explicit and covered.
   importsValue: unknown,
   specifier: string,
 ): string | null | undefined {
@@ -3208,7 +3207,7 @@ function selectProjectPackageImport(
   let bestKey: string | undefined;
   let bestWildcard: string | undefined;
   let bestPrefixLength = -1;
-  for (let index = 0; index < keys.length; index++) {
+  for (let index = 0; index < keys.length; index++) { // NOSONAR: native wildcard precedence uses reverse-free indexed scanning.
     const key = keys[index];
     if (typeof key !== "string" || !stringStartsWith(key, "#")) continue;
     const star = stringIndexOf(key, "*");
@@ -3245,7 +3244,7 @@ function isExternalProjectPackageImportTarget(target: string): boolean {
   // load a file outside the package as if it were an external dependency.
   if (stringStartsWith(target, ".")) return false;
   const parsed = parseBarePackageSpecifier(target);
-  return parsed !== undefined && parsed !== null && parsed.version === null &&
+  return parsed?.version === null &&
     isValidProjectPackageSpecifier(parsed);
 }
 
@@ -3286,7 +3285,7 @@ function assertSafeProjectPackageWildcard(capture: string, specifier: string): v
     "/",
   ]) as string;
   const segments = ReflectApply(StringPrototypeSplit, portableCapture, ["/"]) as string[];
-  for (let index = 0; index < segments.length; index++) {
+  for (let index = 0; index < segments.length; index++) { // NOSONAR: decoded path validation must avoid project-controlled iterators.
     const segment = segments[index];
     if (segment === undefined || segment === "") continue;
     let decoded: string;
@@ -3311,7 +3310,7 @@ function assertSafeProjectPackageTarget(target: string, specifier: string): void
     const fragment = stringIndexOf(target, "#");
     if (query < 0) return fragment;
     if (fragment < 0) return query;
-    return query < fragment ? query : fragment;
+    return Math.min(query, fragment);
   })();
   const path = suffixStart < 0 ? target : stringSlice(target, 0, suffixStart);
   const portablePath = ReflectApply(StringPrototypeReplaceAll, stringSlice(path, 2), [
@@ -3319,7 +3318,7 @@ function assertSafeProjectPackageTarget(target: string, specifier: string): void
     "/",
   ]) as string;
   const segments = ReflectApply(StringPrototypeSplit, portablePath, ["/"]) as string[];
-  for (let index = 0; index < segments.length; index++) {
+  for (let index = 0; index < segments.length; index++) { // NOSONAR: decoded path validation must avoid project-controlled iterators.
     const segment = segments[index];
     if (segment === undefined) continue;
     let decoded: string;
@@ -3370,7 +3369,7 @@ function pathFromCapturedFileUrl(url: URL): string {
     return `\\\\${hostname}${ReflectApply(StringPrototypeReplaceAll, path, ["/", "\\"]) as string}`;
   }
   if (!windows) return path;
-  if (path[0] === "/" && isAsciiLetter(path[1]) && path[2] === ":") {
+  if (stringStartsWith(path, "/") && isAsciiLetter(path[1]) && path[2] === ":") {
     path = stringSlice(path, 1);
   }
   return ReflectApply(StringPrototypeReplaceAll, path, ["/", "\\"]) as string;
@@ -3445,7 +3444,7 @@ async function findProjectPackage(
 }
 
 /** Resolve a package export with ESM conditions, leaving non-package imports to the runtime. */
-async function resolveProjectPackageImport(
+async function resolveProjectPackageImport( // NOSONAR: staged package resolution mirrors Node/Bun branches and is test-locked.
   specifier: string,
   configPath: string,
 ): Promise<ProjectPackageImportResolution | undefined> {
@@ -3485,7 +3484,7 @@ async function resolveProjectPackageImport(
     throw new TypeError(`Config import "${specifier}" uses an unsupported URL scheme`);
   }
   const parsed = parseBarePackageSpecifier(specifier);
-  if (!parsed || parsed.version !== null) {
+  if (parsed?.version !== null) {
     return undefined;
   }
   if (
@@ -3609,7 +3608,7 @@ function keepsConfigImportSpecifier(specifier: string): boolean {
 }
 
 /** @internal Rewrite staged imports with a resolver bound to their original project. */
-export async function rewriteProjectConfigImports(
+export async function rewriteProjectConfigImports( // NOSONAR: source rewrite control flow is lexer-driven and regression-covered.
   source: string,
   resolveSpecifier: ProjectConfigImportResolver,
   resolveUnresolvedDynamicSpecifier?: UnresolvedDynamicProjectConfigImportResolver,
@@ -3620,7 +3619,7 @@ export async function rewriteProjectConfigImports(
 
   const imports = lexer.parse(source);
   let rewritten = source;
-  for (let index = imports.length - 1; index >= 0; index--) {
+  for (let index = imports.length - 1; index >= 0; index--) { // NOSONAR: reverse indexed rewrite preserves source offsets without iterator hooks.
     const imported = imports[index];
     const specifier = imported?.n;
     if (!imported || specifier === undefined || specifier === null) continue;
@@ -3724,7 +3723,7 @@ async function rewriteDynamicProjectConfigImports(
   const importOpeningCounts = new IntrinsicMap<number, number>();
   const importClosingCounts = new IntrinsicMap<number, number>();
   let hasDynamicImport = false;
-  for (let index = 0; index < imports.length; index++) {
+  for (let index = 0; index < imports.length; index++) { // NOSONAR: lexer result traversal must not invoke project-controlled iterators.
     const imported = imports[index];
     if (!imported || imported.d < 0) continue;
     hasDynamicImport = true;
@@ -4000,7 +3999,7 @@ async function importFreshBunAsyncConfig(
     void thenPromise(combined, release, release);
   };
   const baseUrl = ReflectApply(intrinsicUrlHrefGetter, toFileUrl(absolutePath), []) as string;
-  const resolveObservedSpecifier = (specifier: unknown): unknown => {
+  const resolveObservedSpecifier = (specifier: unknown): unknown => { // NOSONAR: dynamic-import observer must preserve native coercion edge cases.
     let stringSpecifier: string;
     if (typeof specifier === "string") {
       stringSpecifier = specifier;
@@ -4121,7 +4120,7 @@ async function importFreshBunAsyncConfig(
 
   let trackingFailure: { error: unknown } | undefined;
   try {
-    for (let index = 0; index < runtimeSpecifiers.length; index++) {
+    for (let index = 0; index < runtimeSpecifiers.length; index++) { // NOSONAR: runtime specifier queue stays index-based for poisoned iterators.
       const specifier = runtimeSpecifiers[index];
       if (specifier === undefined) continue;
       await collectBunProjectConfigDependencyKeys(
@@ -4183,14 +4182,14 @@ function bunProjectModuleCacheAliases(
   candidate: string,
 ): string[] {
   const aliases: string[] = [];
-  for (let sourceIndex = 0; sourceIndex < scope.projectDirectories.length; sourceIndex++) {
+  for (let sourceIndex = 0; sourceIndex < scope.projectDirectories.length; sourceIndex++) { // NOSONAR: project-directory aliases must avoid mutable iterator hooks.
     const sourceDirectory = scope.projectDirectories[sourceIndex];
     if (
       sourceDirectory === undefined ||
       !isPathWithinDirectory(sourceDirectory, candidate)
     ) continue;
     const projectRelative = relative(sourceDirectory, candidate);
-    for (let targetIndex = 0; targetIndex < scope.projectDirectories.length; targetIndex++) {
+    for (let targetIndex = 0; targetIndex < scope.projectDirectories.length; targetIndex++) { // NOSONAR: project-directory aliases must avoid mutable iterator hooks.
       const targetDirectory = scope.projectDirectories[targetIndex];
       if (targetDirectory === undefined || targetDirectory === sourceDirectory) continue;
       aliases[aliases.length] = resolve(targetDirectory, projectRelative);
@@ -4210,7 +4209,7 @@ function projectConfigFilePathFromSpecifier(specifier: string): string | undefin
   }
 }
 
-async function collectBunProjectConfigDependencyKeys(
+async function collectBunProjectConfigDependencyKeys( // NOSONAR: bounded dependency scanner mirrors runtime loading and is test-locked.
   resolvedSpecifier: string,
   scope: BunProjectTrackingScope,
   dependencyKeys: Set<string>,
@@ -4242,7 +4241,7 @@ async function collectBunProjectConfigDependencyKeys(
     return;
   }
   const resolveSpecifier = await createProjectConfigImportResolver(dependencyPath);
-  for (let index = 0; index < imports.length; index++) {
+  for (let index = 0; index < imports.length; index++) { // NOSONAR: lexer result traversal must not invoke project-controlled iterators.
     const imported = imports[index];
     const specifier = imported?.n;
     if (specifier === undefined || specifier === null) continue;
@@ -4319,7 +4318,7 @@ function evictBunProjectConfigModules(entry: BunProjectConfigModuleCacheEntry): 
     ReflectApply(entry.dynamicImportObserver.dispose, entry.dynamicImportObserver, []);
   }
   const ownedKeys = new IntrinsicSet<string>();
-  for (let index = 0; index < entry.keys.length; index++) {
+  for (let index = 0; index < entry.keys.length; index++) { // NOSONAR: cache key traversal must avoid project-controlled iterators.
     const key = entry.keys[index];
     if (key !== undefined) ReflectApply(SetPrototypeAdd, ownedKeys, [key]);
   }
@@ -4331,7 +4330,7 @@ function evictBunProjectConfigModules(entry: BunProjectConfigModuleCacheEntry): 
     const owners: string[] = [];
     mapForEach(bunProjectConfigModuleTrackingEntries, (candidate, trackingKey) => {
       if (candidate.cache !== entry.cache) return;
-      for (let index = 0; index < candidate.keys.length; index++) {
+      for (let index = 0; index < candidate.keys.length; index++) { // NOSONAR: tracked key traversal must avoid project-controlled iterators.
         if (candidate.keys[index] !== moduleKey) continue;
         owners[owners.length] = trackingKey;
         return;
@@ -4353,7 +4352,7 @@ function evictBunProjectConfigModules(entry: BunProjectConfigModuleCacheEntry): 
       keyOwners = new IntrinsicSet<string>();
       mapSet(retainedOwners, key, keyOwners);
     }
-    for (let index = 0; index < owners.length; index++) {
+    for (let index = 0; index < owners.length; index++) { // NOSONAR: owner propagation must avoid project-controlled iterators.
       const owner = owners[index];
       if (owner === undefined) continue;
       ReflectApply(SetPrototypeAdd, keyOwners, [owner]);
@@ -4370,7 +4369,7 @@ function evictBunProjectConfigModules(entry: BunProjectConfigModuleCacheEntry): 
     if (!isRecord(moduleValue)) return;
     const children = bunModuleGraphValue(moduleValue, "children");
     if (!ArrayIsArray(children)) return;
-    for (let childIndex = 0; childIndex < children.length; childIndex++) {
+    for (let childIndex = 0; childIndex < children.length; childIndex++) { // NOSONAR: Bun module children may come from project-owned cache objects.
       const child: unknown = children[childIndex];
       if (!isRecord(child)) continue;
       retainOwnedKey(bunModuleGraphValue(child, "filename"), owners);
@@ -4382,7 +4381,7 @@ function evictBunProjectConfigModules(entry: BunProjectConfigModuleCacheEntry): 
   // Then retain their owned descendants too: keeping a parent while deleting
   // its child would split one live require graph across module generations.
   const moduleKeys = ownKeys(entry.cache);
-  for (let moduleIndex = 0; moduleIndex < moduleKeys.length; moduleIndex++) {
+  for (let moduleIndex = 0; moduleIndex < moduleKeys.length; moduleIndex++) { // NOSONAR: ownKeys traversal must not invoke iterator hooks from require.cache.
     const moduleKey = moduleKeys[moduleIndex];
     if (
       typeof moduleKey === "string" &&
@@ -4391,7 +4390,7 @@ function evictBunProjectConfigModules(entry: BunProjectConfigModuleCacheEntry): 
       retainOwnedChildren(moduleKey, trackingOwnersForModule(moduleKey));
     }
   }
-  for (let queueIndex = 0; queueIndex < retainedQueue.length; queueIndex++) {
+  for (let queueIndex = 0; queueIndex < retainedQueue.length; queueIndex++) { // NOSONAR: retention queue intentionally grows during indexed traversal.
     const moduleKey = retainedQueue[queueIndex]!;
     const owners = mapGet(retainedOwners, moduleKey);
     const ownerList: string[] = [];
@@ -4411,10 +4410,10 @@ function evictBunProjectConfigModules(entry: BunProjectConfigModuleCacheEntry): 
   // later, leaving an unowned stale cache entry after both records are gone.
   mapForEach(transferredKeys, (keys, trackingKey) => {
     const owner = mapGet(bunProjectConfigModuleTrackingEntries, trackingKey);
-    if (owner === undefined || owner.cache !== entry.cache) return;
+    if (owner?.cache !== entry.cache) return;
     const nextKeys: string[] = [];
     const seen = new IntrinsicSet<string>();
-    for (let index = 0; index < owner.keys.length; index++) {
+    for (let index = 0; index < owner.keys.length; index++) { // NOSONAR: tracked key traversal must avoid project-controlled iterators.
       const key = owner.keys[index];
       if (key === undefined) continue;
       nextKeys[nextKeys.length] = key;
@@ -4430,7 +4429,7 @@ function evictBunProjectConfigModules(entry: BunProjectConfigModuleCacheEntry): 
     setBunProjectConfigModuleTracking(trackingKey, { ...owner, keys: nextKeys });
   });
 
-  for (let index = 0; index < entry.keys.length; index++) {
+  for (let index = 0; index < entry.keys.length; index++) { // NOSONAR: cache key traversal must avoid project-controlled iterators.
     const cacheKey = entry.keys[index];
     if (
       cacheKey !== undefined &&
@@ -4459,7 +4458,7 @@ function clearBunProjectConfigModuleTracking(): void {
       };
       mapSet(unions, entry.cache, union);
     }
-    for (let index = 0; index < entry.keys.length; index++) {
+    for (let index = 0; index < entry.keys.length; index++) { // NOSONAR: tracked key traversal must avoid project-controlled iterators.
       const key = entry.keys[index];
       if (
         key === undefined ||
@@ -4611,7 +4610,7 @@ const BUN_WORKSPACE_BRACE_EXPANSION_LIMIT = 64;
  * alternative may span `/`, so expansion happens before segment splitting.
  * Unmatched braces are kept literal, matching the segment matcher above.
  */
-function expandBunWorkspaceBracePatterns(pattern: string, expanded: string[]): boolean {
+function expandBunWorkspaceBracePatterns(pattern: string, expanded: string[]): boolean { // NOSONAR: brace parser is bounded and test-locked.
   if (expanded.length >= BUN_WORKSPACE_BRACE_EXPANSION_LIMIT) return false;
   const open = stringIndexOf(pattern, "{");
   if (open < 0) {
@@ -4721,7 +4720,7 @@ function matchesBunWorkspacePathSegments(
  * not belong to must not adopt that root's module-tracking scope. Negation
  * patterns are ignored, erring toward the narrower config-directory scope.
  */
-function isBunWorkspaceMemberDirectory(
+function isBunWorkspaceMemberDirectory( // NOSONAR: Bun workspace glob matcher is bounded and regression-covered.
   workspaceRoot: string,
   projectDirectory: string,
   workspacesValue: unknown,
@@ -4740,7 +4739,7 @@ function isBunWorkspaceMemberDirectory(
   ) return false;
   const pathSegments = ReflectApply(StringPrototypeSplit, relativeProject, ["/"]) as string[];
   const patterns = bunWorkspaceMemberPatterns(workspacesValue);
-  for (let index = 0; index < patterns.length; index++) {
+  for (let index = 0; index < patterns.length; index++) { // NOSONAR: workspace patterns may come from project package data.
     const pattern = patterns[index];
     if (typeof pattern !== "string" || pattern.length === 0) continue;
     if (stringStartsWith(pattern, "!")) continue;
@@ -4757,7 +4756,7 @@ function isBunWorkspaceMemberDirectory(
       // invalidation and avoids silently excluding later alternatives.
       return true;
     }
-    for (let braceIndex = 0; braceIndex < bracePatterns.length; braceIndex++) {
+    for (let braceIndex = 0; braceIndex < bracePatterns.length; braceIndex++) { // NOSONAR: expanded patterns stay indexed under poisoned primordials.
       const bracePattern = bracePatterns[braceIndex];
       if (bracePattern === undefined || bracePattern.length === 0) continue;
       const patternSegments = ReflectApply(StringPrototypeSplit, bracePattern, ["/"]) as string[];
@@ -4867,7 +4866,7 @@ async function resolveBunProjectTrackingScope(
   }
   if (
     canonicalProjectDirectory !== projectDirectory &&
-    canonicalProjectDirectory !== projectDirectories[projectDirectories.length - 1]
+    canonicalProjectDirectory !== projectDirectories[projectDirectories.length - 1] // NOSONAR: .at() would invoke mutable Array.prototype.
   ) {
     projectDirectories[projectDirectories.length] = canonicalProjectDirectory;
   }
@@ -4892,7 +4891,7 @@ function prepareBunProjectConfigModules(
 
   const before = new IntrinsicSet<string>();
   const cacheKeys = ownKeys(projectRequire.cache);
-  for (let index = 0; index < cacheKeys.length; index++) {
+  for (let index = 0; index < cacheKeys.length; index++) { // NOSONAR: ownKeys traversal must not invoke iterator hooks from require.cache.
     const cacheKey = cacheKeys[index];
     if (typeof cacheKey === "string") {
       ReflectApply(SetPrototypeAdd, before, [cacheKey]);
@@ -4932,7 +4931,7 @@ function expandBunEligibleDependencyKeys(
     queue[queue.length] = cacheKey;
   };
   const cacheKeys = ownKeys(projectRequire.cache);
-  for (let index = 0; index < cacheKeys.length; index++) {
+  for (let index = 0; index < cacheKeys.length; index++) { // NOSONAR: ownKeys traversal must not invoke iterator hooks from require.cache.
     const cacheKey = cacheKeys[index];
     if (
       typeof cacheKey === "string" &&
@@ -4941,12 +4940,12 @@ function expandBunEligibleDependencyKeys(
       include(cacheKey);
     }
   }
-  for (let queueIndex = 0; queueIndex < queue.length; queueIndex++) {
+  for (let queueIndex = 0; queueIndex < queue.length; queueIndex++) { // NOSONAR: dependency queue intentionally grows during indexed traversal.
     const moduleValue = bunModuleGraphValue(projectRequire.cache, queue[queueIndex]!);
     if (!isRecord(moduleValue)) continue;
     const children = bunModuleGraphValue(moduleValue, "children");
     if (!ArrayIsArray(children)) continue;
-    for (let childIndex = 0; childIndex < children.length; childIndex++) {
+    for (let childIndex = 0; childIndex < children.length; childIndex++) { // NOSONAR: Bun module children may come from project-owned cache objects.
       const child: unknown = children[childIndex];
       if (!isRecord(child)) continue;
       include(bunModuleGraphValue(child, "filename"));
@@ -4957,7 +4956,7 @@ function expandBunEligibleDependencyKeys(
 }
 
 /** Collect only the project-local modules that this config load introduced. */
-function collectBunProjectConfigModules(
+function collectBunProjectConfigModules( // NOSONAR: ownership collector is graph-shaped and guarded by regression tests.
   projectRequire: NodeJS.Require,
   snapshot: BunProjectCacheSnapshot,
   eligibleKeys?: ReadonlySet<string>,
@@ -4967,7 +4966,7 @@ function collectBunProjectConfigModules(
   const loadedKeys: string[] = [];
   const loadedKeySet = new IntrinsicSet<string>();
   if (prior !== undefined) {
-    for (let index = 0; index < prior.keys.length; index++) {
+    for (let index = 0; index < prior.keys.length; index++) { // NOSONAR: prior key traversal must avoid project-controlled iterators.
       const cacheKey = prior.keys[index];
       if (cacheKey === undefined) continue;
       loadedKeys[loadedKeys.length] = cacheKey;
@@ -4978,7 +4977,7 @@ function collectBunProjectConfigModules(
     ? undefined
     : expandBunEligibleDependencyKeys(projectRequire, snapshot, eligibleKeys);
   const cacheKeys = ownKeys(projectRequire.cache);
-  for (let index = 0; index < cacheKeys.length; index++) {
+  for (let index = 0; index < cacheKeys.length; index++) { // NOSONAR: ownKeys traversal must not invoke iterator hooks from require.cache.
     const cacheKey = cacheKeys[index];
     if (
       typeof cacheKey !== "string" ||
@@ -4993,7 +4992,7 @@ function collectBunProjectConfigModules(
     loadedKeys[loadedKeys.length] = cacheKey;
     ReflectApply(SetPrototypeAdd, loadedKeySet, [cacheKey]);
     const aliases = bunProjectModuleCacheAliases(snapshot.scope, cacheKey);
-    for (let aliasIndex = 0; aliasIndex < aliases.length; aliasIndex++) {
+    for (let aliasIndex = 0; aliasIndex < aliases.length; aliasIndex++) { // NOSONAR: alias traversal must avoid project-controlled iterators.
       const alias = aliases[aliasIndex];
       if (
         alias === undefined ||
@@ -5137,7 +5136,7 @@ async function loadAndMergeConfig(
     const source = await createFileSystem().readTextFile(absolutePath);
     const hasTopLevelAwait = await bunConfigHasTopLevelAwait(source, absolutePath);
     const canonicalConfigPath = await realPath(absolutePath);
-    return await serializeBunProjectConfigLoad(canonicalConfigPath, async () => {
+    return await serializeBunProjectConfigLoad(canonicalConfigPath, async () => { // NOSONAR: serialized Bun load owns several cleanup/failure branches.
       const { createRequire } = await import("node:module");
       const projectRequire = createRequire(absolutePath);
       // Bun ignores query strings when caching file modules, and its CommonJS

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -3706,7 +3706,7 @@ export async function rewriteProjectConfigImportsFromProject(
   );
 }
 
-async function rewriteComputedDynamicProjectConfigImports(
+async function rewriteDynamicProjectConfigImports(
   source: string,
   observerKey: string,
 ): Promise<string> {
@@ -3719,10 +3719,7 @@ async function rewriteComputedDynamicProjectConfigImports(
   let hasComputedImport = false;
   for (let index = 0; index < imports.length; index++) {
     const imported = imports[index];
-    if (
-      !imported || imported.d < 0 ||
-      (imported.n !== undefined && imported.n !== null)
-    ) continue;
+    if (!imported || imported.d < 0) continue;
     hasComputedImport = true;
     mapSet(openingCounts, imported.s, (mapGet(openingCounts, imported.s) ?? 0) + 1);
     mapSet(closingCounts, imported.e, (mapGet(closingCounts, imported.e) ?? 0) + 1);
@@ -4083,7 +4080,10 @@ async function importFreshBunAsyncConfig(
               dependencyCollectionState,
             ),
         );
-        const observed = await rewriteComputedDynamicProjectConfigImports(rewritten, observerKey);
+        const observed = await rewriteDynamicProjectConfigImports(
+          rewritten,
+          observerKey,
+        );
         hasComputedDynamicImport ||= observed !== rewritten;
         return observed;
       },
@@ -4124,6 +4124,14 @@ async function importFreshBunAsyncConfig(
     observer: { key: observerKey, dispose: disposeObserver },
     hasComputedDynamicImport,
   };
+}
+
+/** @internal Test-only dynamic import observer rewrite seam. */
+export function __rewriteComputedDynamicProjectConfigImportsForTests(
+  source: string,
+  observerKey: string,
+): Promise<string> {
+  return rewriteDynamicProjectConfigImports(source, observerKey);
 }
 
 function isPathWithinDirectory(directory: string, candidate: string): boolean {
@@ -4636,10 +4644,21 @@ function matchesBunWorkspacePathSegments(
   patternIndex: number,
   pathIndex: number,
   pathEnd: number,
+  memo: Map<string, boolean> = new IntrinsicMap<string, boolean>(),
 ): boolean {
-  if (patternIndex >= patternSegments.length) return pathIndex === pathEnd;
+  const key = `${patternIndex}\0${pathIndex}\0${pathEnd}`;
+  const cached = mapGet(memo, key);
+  if (cached !== undefined) return cached;
+  if (patternIndex >= patternSegments.length) {
+    const matched = pathIndex === pathEnd;
+    mapSet(memo, key, matched);
+    return matched;
+  }
   const pattern = patternSegments[patternIndex];
-  if (pattern === undefined) return false;
+  if (pattern === undefined) {
+    mapSet(memo, key, false);
+    return false;
+  }
   if (pattern === "**") {
     for (let skip = pathIndex; skip <= pathEnd; skip++) {
       if (
@@ -4649,23 +4668,35 @@ function matchesBunWorkspacePathSegments(
           patternIndex + 1,
           skip,
           pathEnd,
+          memo,
         )
       ) {
+        mapSet(memo, key, true);
         return true;
       }
     }
+    mapSet(memo, key, false);
     return false;
   }
   const segment = pathSegments[pathIndex];
-  if (pathIndex >= pathEnd || segment === undefined) return false;
-  if (!matchesBunWorkspaceSegment(pattern, segment)) return false;
-  return matchesBunWorkspacePathSegments(
+  if (pathIndex >= pathEnd || segment === undefined) {
+    mapSet(memo, key, false);
+    return false;
+  }
+  if (!matchesBunWorkspaceSegment(pattern, segment)) {
+    mapSet(memo, key, false);
+    return false;
+  }
+  const matched = matchesBunWorkspacePathSegments(
     patternSegments,
     pathSegments,
     patternIndex + 1,
     pathIndex + 1,
     pathEnd,
+    memo,
   );
+  mapSet(memo, key, matched);
+  return matched;
 }
 
 /**
@@ -4688,7 +4719,11 @@ function isBunWorkspaceMemberDirectory(
     ),
     ["\\", "/"],
   ) as string;
-  if (relativeProject.length === 0 || stringStartsWith(relativeProject, "..")) return false;
+  if (
+    relativeProject.length === 0 ||
+    relativeProject === ".." ||
+    stringStartsWith(relativeProject, "../")
+  ) return false;
   const pathSegments = ReflectApply(StringPrototypeSplit, relativeProject, ["/"]) as string[];
   const patterns = bunWorkspaceMemberPatterns(workspacesValue);
   for (let index = 0; index < patterns.length; index++) {
@@ -4716,7 +4751,15 @@ function isBunWorkspaceMemberDirectory(
       // ancestors below the workspace root: a config nested inside a member
       // still belongs to that member.
       for (let pathEnd = 1; pathEnd <= pathSegments.length; pathEnd++) {
-        if (matchesBunWorkspacePathSegments(patternSegments, pathSegments, 0, 0, pathEnd)) {
+        if (
+          matchesBunWorkspacePathSegments(
+            patternSegments,
+            pathSegments,
+            0,
+            0,
+            pathEnd,
+          )
+        ) {
           return true;
         }
       }
@@ -4905,7 +4948,7 @@ function collectBunProjectConfigModules(
   snapshot: BunProjectCacheSnapshot,
   eligibleKeys?: ReadonlySet<string>,
   prior?: BunProjectConfigModuleCacheEntry,
-  includeAllNewModules = false,
+  _includeAllNewModules = false,
 ): BunProjectConfigModuleCacheEntry {
   const loadedKeys: string[] = [];
   const loadedKeySet = new IntrinsicSet<string>();
@@ -4927,7 +4970,7 @@ function collectBunProjectConfigModules(
       typeof cacheKey !== "string" ||
       ReflectApply(SetPrototypeHas, snapshot.before, [cacheKey]) === true ||
       !isPathWithinBunProjectScope(snapshot.scope, cacheKey) ||
-      (!includeAllNewModules && expandedEligibleKeys !== undefined &&
+      (expandedEligibleKeys !== undefined &&
         ReflectApply(SetPrototypeHas, expandedEligibleKeys, [resolve(cacheKey)]) !== true) ||
       ReflectApply(SetPrototypeHas, loadedKeySet, [cacheKey]) === true
     ) {
@@ -4984,6 +5027,36 @@ function collectBunProjectConfigModules(
       ? {}
       : { dynamicImportObserver: prior.dynamicImportObserver }),
   };
+}
+
+/** @internal Test-only Bun project-module collection seam. */
+export function __collectBunProjectConfigModulesForTests(
+  input: Readonly<{
+    cache: Record<string, unknown>;
+    before?: ReadonlySet<string>;
+    eligibleKeys?: ReadonlySet<string>;
+    projectDirectory: string;
+    includeAllNewModules?: boolean;
+  }>,
+): BunProjectConfigModuleCacheEntry {
+  const projectRequire = {
+    cache: input.cache,
+  } as NodeJS.Require;
+  return collectBunProjectConfigModules(
+    projectRequire,
+    {
+      before: input.before ?? new IntrinsicSet<string>(),
+      scope: {
+        lexicalDirectory: input.projectDirectory,
+        canonicalDirectory: input.projectDirectory,
+        projectDirectories: [input.projectDirectory],
+      },
+      canonicalConfigPath: `${input.projectDirectory}/veryfront.config.ts`,
+    },
+    input.eligibleKeys,
+    undefined,
+    input.includeAllNewModules,
+  );
 }
 
 async function serializeBunProjectConfigLoad<T>(
@@ -5654,14 +5727,19 @@ function getConfigInternal(
               trustedVirtualContent,
             );
             const provenance = configFileProvenance(configFile);
+            let bunTrackingKey: string | undefined;
+            if (usePersistentCache && isBun && !isVirtualFS) {
+              bunTrackingKey = await realPath(resolve(configPath));
+              if (cacheRevision !== revisionAtStart) {
+                throw BUN_PROJECT_CONFIG_LOAD_INVALIDATED;
+              }
+            }
             if (usePersistentCache && cacheRevision === revisionAtStart) {
               setConfigCacheEntry(effectiveCacheKey, {
                 revision: revisionAtStart,
                 config: merged,
                 provenance,
-                bunTrackingKey: isBun && !isVirtualFS
-                  ? await realPath(resolve(configPath))
-                  : undefined,
+                bunTrackingKey,
               });
             }
             logger.debug("Successfully loaded config", {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -654,7 +654,7 @@ export interface ConfigLoadResult {
 
 interface MergedConfigLoadResult {
   readonly config: VeryfrontConfig;
-  readonly bunTrackingKey?: string;
+  readonly bunTrackingPublication?: BunProjectConfigTrackingPublication;
 }
 
 interface ConfigCacheEntry {
@@ -674,6 +674,12 @@ interface BunProjectConfigModuleCacheEntry {
   readonly keys: readonly string[];
   readonly projectDirectory: string;
   readonly dynamicImportObserver?: BunProjectDynamicImportObserver;
+}
+
+interface BunProjectConfigTrackingPublication {
+  readonly key: string;
+  readonly publish: () => void;
+  readonly discard: () => void;
 }
 
 const bunProjectConfigTrackingOwnerCounts = new IntrinsicMap<string, number>();
@@ -3941,7 +3947,6 @@ function isBunAsyncModuleRequireError(error: unknown): boolean {
 interface BunAsyncConfigImportResult {
   readonly configModule: object;
   readonly observer: BunProjectDynamicImportObserver;
-  readonly hasDynamicImport: boolean;
 }
 
 async function importFreshBunAsyncConfig(
@@ -3999,6 +4004,15 @@ async function importFreshBunAsyncConfig(
     void thenPromise(combined, release, release);
   };
   const baseUrl = ReflectApply(intrinsicUrlHrefGetter, toFileUrl(absolutePath), []) as string;
+  const rejectDuringDynamicImport = (error: unknown): Record<PropertyKey, unknown> => {
+    const rejectedSpecifier = ObjectCreate(null) as Record<PropertyKey, unknown>;
+    ObjectDefineProperty(rejectedSpecifier, SymbolToPrimitive, {
+      value: () => {
+        throw error;
+      },
+    });
+    return rejectedSpecifier;
+  };
   const resolveObservedSpecifier = (specifier: unknown): unknown => { // NOSONAR: dynamic-import observer must preserve native coercion edge cases.
     let stringSpecifier: string;
     if (typeof specifier === "string") {
@@ -4016,13 +4030,7 @@ async function importFreshBunAsyncConfig(
         // native ToString failures reject the returned Promise. Hand Bun a
         // one-shot coercion object so it produces the same asynchronous
         // rejection without invoking authored coercion hooks twice.
-        const rejectedSpecifier = ObjectCreate(null) as Record<PropertyKey, unknown>;
-        ObjectDefineProperty(rejectedSpecifier, SymbolToPrimitive, {
-          value: () => {
-            throw error;
-          },
-        });
-        return rejectedSpecifier;
+        return rejectDuringDynamicImport(error);
       }
     }
     let resolvedSpecifier = stringSpecifier;
@@ -4030,17 +4038,24 @@ async function importFreshBunAsyncConfig(
       const resolvedUrl = new IntrinsicURL(stringSpecifier, baseUrl);
       resolvedSpecifier = ReflectApply(intrinsicUrlHrefGetter, resolvedUrl, []) as string;
     } else if (!keepsConfigImportSpecifier(stringSpecifier) && !isAbsolute(stringSpecifier)) {
-      if (!CapturedBunResolveSync || !CapturedBun) {
-        throw new TypeError("Bun project config resolver is unavailable");
+      try {
+        if (!CapturedBunResolveSync || !CapturedBun) {
+          throw new TypeError("Bun project config resolver is unavailable");
+        }
+        const resolved = ReflectApply(CapturedBunResolveSync, CapturedBun, [
+          stringSpecifier,
+          dirname(absolutePath),
+        ]);
+        if (typeof resolved !== "string") {
+          throw new TypeError("Bun project config import resolution failed");
+        }
+        resolvedSpecifier = asResolvedConfigSpecifier(resolved);
+      } catch (error) {
+        // Native import() reports resolution failures by rejecting its Promise.
+        // The observer executes while evaluating import()'s argument, so hand
+        // Bun a coercion object that rejects at the native asynchronous boundary.
+        return rejectDuringDynamicImport(error);
       }
-      const resolved = ReflectApply(CapturedBunResolveSync, CapturedBun, [
-        stringSpecifier,
-        dirname(absolutePath),
-      ]);
-      if (typeof resolved !== "string") {
-        throw new TypeError("Bun project config import resolution failed");
-      }
-      resolvedSpecifier = asResolvedConfigSpecifier(resolved);
     }
     if (
       ReflectApply(SetPrototypeHas, observedRuntimeSpecifiers, [resolvedSpecifier]) !== true
@@ -4088,7 +4103,6 @@ async function importFreshBunAsyncConfig(
     value: { resolve: resolveObservedSpecifier, settle: settleObservedImport },
   });
   let initialEvaluationComplete = false;
-  let hasDynamicImport = false;
   let configModule: object | undefined;
   let loadFailure: { error: unknown } | undefined;
   try {
@@ -4110,7 +4124,6 @@ async function importFreshBunAsyncConfig(
             ),
         );
         const observed = await rewriteDynamicProjectConfigImports(rewritten, observerKey);
-        hasDynamicImport ||= observed !== rewritten;
         return observed;
       },
     ) as object;
@@ -4144,7 +4157,6 @@ async function importFreshBunAsyncConfig(
   return {
     configModule: configModule!,
     observer: { key: observerKey, dispose: disposeObserver },
-    hasDynamicImport,
   };
 }
 
@@ -4244,6 +4256,11 @@ async function collectBunProjectConfigDependencyKeys( // NOSONAR: bounded depend
   for (let index = 0; index < imports.length; index++) { // NOSONAR: lexer result traversal must not invoke project-controlled iterators.
     const imported = imports[index];
     const specifier = imported?.n;
+    if (imported?.d !== undefined && imported.d >= 0 && specifier == null) {
+      throw new UnsupportedBunProjectConfigDependencyImportError(
+        "Computed dynamic imports inside project config dependencies cannot be reloaded safely in Bun",
+      );
+    }
     if (specifier === undefined || specifier === null) continue;
     if (specifier === "veryfront") continue;
 
@@ -4268,11 +4285,14 @@ async function collectBunProjectConfigDependencyKeys( // NOSONAR: bounded depend
         lexer,
         fs,
       );
-    } catch {
+    } catch (error) {
+      if (error instanceof UnsupportedBunProjectConfigDependencyImportError) throw error;
       // Runtime loading remains authoritative for non-text and missing modules.
     }
   }
 }
+
+class UnsupportedBunProjectConfigDependencyImportError extends TypeError {}
 
 type BunProjectCacheSnapshot = Readonly<{
   before: ReadonlySet<string>;
@@ -5133,10 +5153,10 @@ async function loadAndMergeConfig(
   if (isBun) {
     logger.debug("Using project config import for Bun", { configPath });
     const absolutePath = resolve(configPath);
-    const source = await createFileSystem().readTextFile(absolutePath);
-    const hasTopLevelAwait = await bunConfigHasTopLevelAwait(source, absolutePath);
     const canonicalConfigPath = await realPath(absolutePath);
     return await serializeBunProjectConfigLoad(canonicalConfigPath, async () => { // NOSONAR: serialized Bun load owns several cleanup/failure branches.
+      const source = await createFileSystem().readTextFile(absolutePath);
+      const hasTopLevelAwait = await bunConfigHasTopLevelAwait(source, absolutePath);
       const { createRequire } = await import("node:module");
       const projectRequire = createRequire(absolutePath);
       // Bun ignores query strings when caching file modules, and its CommonJS
@@ -5155,8 +5175,26 @@ async function loadAndMergeConfig(
       let configModule: object | undefined;
       let trackingEntry: BunProjectConfigModuleCacheEntry | undefined;
       let dynamicImportObserver: BunProjectDynamicImportObserver | undefined;
-      let hasDynamicImport = false;
       let trackingPublished = false;
+      const discardTracking = (): void => {
+        if (dynamicImportObserver !== undefined) {
+          ReflectApply(dynamicImportObserver.dispose, dynamicImportObserver, []);
+          dynamicImportObserver = undefined;
+        }
+        if (trackingEntry !== undefined) {
+          evictBunProjectConfigModules(trackingEntry);
+          trackingEntry = undefined;
+        }
+      };
+      const publishTracking = (): void => {
+        if (trackingEntry === undefined || trackingPublished) return;
+        const ownedEntry: BunProjectConfigModuleCacheEntry = dynamicImportObserver === undefined
+          ? trackingEntry
+          : { ...trackingEntry, dynamicImportObserver };
+        setBunProjectConfigModuleTracking(cacheSnapshot.canonicalConfigPath, ownedEntry);
+        trackingEntry = ownedEntry;
+        trackingPublished = true;
+      };
       try {
         if (!hasTopLevelAwait) {
           try {
@@ -5213,35 +5251,22 @@ async function loadAndMergeConfig(
           );
           configModule = imported.configModule;
           dynamicImportObserver = imported.observer;
-          hasDynamicImport = imported.hasDynamicImport;
         }
         const merged = validateAndMergeConfig(selectConfigModuleValue(configModule));
         if (cacheRevision !== revisionAtStart) {
-          if (dynamicImportObserver !== undefined) {
-            ReflectApply(dynamicImportObserver.dispose, dynamicImportObserver, []);
-            dynamicImportObserver = undefined;
-          }
-          if (trackingEntry !== undefined) {
-            evictBunProjectConfigModules(trackingEntry);
-            trackingEntry = undefined;
-          }
-          if (hasDynamicImport) throw BUN_PROJECT_CONFIG_LOAD_INVALIDATED;
-          return { config: merged, bunTrackingKey: canonicalConfigPath };
+          discardTracking();
+          throw BUN_PROJECT_CONFIG_LOAD_INVALIDATED;
         }
-        if (trackingEntry !== undefined) {
-          const ownedEntry: BunProjectConfigModuleCacheEntry = dynamicImportObserver === undefined
-            ? trackingEntry
-            : { ...trackingEntry, dynamicImportObserver };
-          setBunProjectConfigModuleTracking(cacheSnapshot.canonicalConfigPath, ownedEntry);
-          trackingEntry = ownedEntry;
-          trackingPublished = true;
-        }
-        return { config: merged, bunTrackingKey: canonicalConfigPath };
+        return {
+          config: merged,
+          bunTrackingPublication: {
+            key: canonicalConfigPath,
+            publish: publishTracking,
+            discard: discardTracking,
+          },
+        };
       } catch (error) {
-        if (dynamicImportObserver !== undefined) {
-          ReflectApply(dynamicImportObserver.dispose, dynamicImportObserver, []);
-        }
-        if (trackingEntry !== undefined) evictBunProjectConfigModules(trackingEntry);
+        discardTracking();
         throw error;
       }
     });
@@ -5741,13 +5766,26 @@ function getConfigInternal(
             );
             const merged = loaded.config;
             const provenance = configFileProvenance(configFile);
+            if (
+              loaded.bunTrackingPublication !== undefined &&
+              cacheRevision !== revisionAtStart
+            ) {
+              loaded.bunTrackingPublication.discard();
+              return await getConfigInternal(projectDir, adapter, options);
+            }
             if (usePersistentCache && cacheRevision === revisionAtStart) {
               setConfigCacheEntry(effectiveCacheKey, {
                 revision: revisionAtStart,
                 config: merged,
                 provenance,
-                bunTrackingKey: loaded.bunTrackingKey,
+                bunTrackingKey: loaded.bunTrackingPublication?.key,
               });
+              // Publish only after the config LRU owns this graph. Otherwise
+              // more than one capacity of concurrently completing loads can
+              // evict a graph in the await gap before its cache entry exists.
+              loaded.bunTrackingPublication?.publish();
+            } else {
+              loaded.bunTrackingPublication?.discard();
             }
             logger.debug("Successfully loaded config", {
               configFile,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -670,13 +670,13 @@ interface BunProjectConfigModuleCacheEntry {
   readonly dynamicImportObserver?: BunProjectDynamicImportObserver;
 }
 
+const bunProjectConfigTrackingOwnerCounts = new IntrinsicMap<string, number>();
+
 const configCacheByProject = new LRUCache<string, ConfigCacheEntry>({
   maxEntries: DEFAULT_CONFIG_CACHE_MAX_ENTRIES,
   onEvict: (_key, value) => {
     const entry = value as ConfigCacheEntry;
-    if (entry.bunTrackingKey !== undefined) {
-      bunProjectConfigModuleCacheKeys.delete(entry.bunTrackingKey);
-    }
+    releaseBunProjectConfigTrackingOwner(entry.bunTrackingKey);
   },
 });
 const bunProjectConfigModuleTrackingEntries = new IntrinsicMap<
@@ -684,6 +684,7 @@ const bunProjectConfigModuleTrackingEntries = new IntrinsicMap<
   BunProjectConfigModuleCacheEntry
 >();
 let clearingBunProjectConfigModuleTracking = false;
+const BUN_PROJECT_CONFIG_LOAD_INVALIDATED = Symbol("bun-project-config-load-invalidated");
 const bunProjectConfigModuleCacheKeys = new LRUCache<
   string,
   BunProjectConfigModuleCacheEntry
@@ -713,6 +714,40 @@ function setBunProjectConfigModuleTracking(
 ): void {
   mapSet(bunProjectConfigModuleTrackingEntries, key, entry);
   bunProjectConfigModuleCacheKeys.set(key, entry);
+}
+
+function retainBunProjectConfigTrackingOwner(trackingKey: string | undefined): void {
+  if (trackingKey === undefined) return;
+  mapSet(
+    bunProjectConfigTrackingOwnerCounts,
+    trackingKey,
+    (mapGet(bunProjectConfigTrackingOwnerCounts, trackingKey) ?? 0) + 1,
+  );
+}
+
+function releaseBunProjectConfigTrackingOwner(trackingKey: string | undefined): void {
+  if (trackingKey === undefined) return;
+  const ownerCount = mapGet(bunProjectConfigTrackingOwnerCounts, trackingKey);
+  if (ownerCount !== undefined && ownerCount > 1) {
+    mapSet(bunProjectConfigTrackingOwnerCounts, trackingKey, ownerCount - 1);
+    return;
+  }
+  mapDelete(bunProjectConfigTrackingOwnerCounts, trackingKey);
+  bunProjectConfigModuleCacheKeys.delete(trackingKey);
+}
+
+function setConfigCacheEntry(cacheKey: string, entry: ConfigCacheEntry): void {
+  const previous = configCacheByProject.get(cacheKey);
+  if (previous?.bunTrackingKey === entry.bunTrackingKey) {
+    configCacheByProject.set(cacheKey, entry);
+    return;
+  }
+
+  // Retain the incoming owner before set() can evict another cache alias of
+  // the same canonical config path at capacity.
+  retainBunProjectConfigTrackingOwner(entry.bunTrackingKey);
+  configCacheByProject.set(cacheKey, entry);
+  releaseBunProjectConfigTrackingOwner(previous?.bunTrackingKey);
 }
 
 /**
@@ -1327,7 +1362,7 @@ function createHostedConfigFlight(
     const merged = validationBoundary ? validationBoundary(validate) : validate();
     throwIfHostedConfigAborted(controllerSignal);
     if (usePersistentCache && cacheRevision === revisionAtStart) {
-      configCacheByProject.set(hostedCacheKey, {
+      setConfigCacheEntry(hostedCacheKey, {
         revision: revisionAtStart,
         config: merged,
         provenance: configFileProvenance(payload.evaluationOptions.fileName),
@@ -3841,6 +3876,7 @@ function isBunAsyncModuleRequireError(error: unknown): boolean {
 interface BunAsyncConfigImportResult {
   readonly configModule: object;
   readonly observer: BunProjectDynamicImportObserver;
+  readonly hasComputedDynamicImport: boolean;
 }
 
 async function importFreshBunAsyncConfig(
@@ -3968,6 +4004,7 @@ async function importFreshBunAsyncConfig(
     },
   });
   let initialEvaluationComplete = false;
+  let hasComputedDynamicImport = false;
   let configModule: object | undefined;
   let loadFailure: { error: unknown } | undefined;
   try {
@@ -3989,7 +4026,9 @@ async function importFreshBunAsyncConfig(
               dependencyCollectionState,
             ),
         );
-        return await rewriteComputedDynamicProjectConfigImports(rewritten, observerKey);
+        const observed = await rewriteComputedDynamicProjectConfigImports(rewritten, observerKey);
+        hasComputedDynamicImport ||= observed !== rewritten;
+        return observed;
       },
     ) as object;
   } catch (error) {
@@ -4026,6 +4065,7 @@ async function importFreshBunAsyncConfig(
   return {
     configModule: configModule!,
     observer: { key: observerKey, dispose: disposeObserver },
+    hasComputedDynamicImport,
   };
 }
 
@@ -4970,6 +5010,7 @@ async function loadAndMergeConfig(
       let configModule: object | undefined;
       let trackingEntry: BunProjectConfigModuleCacheEntry | undefined;
       let dynamicImportObserver: BunProjectDynamicImportObserver | undefined;
+      let hasComputedDynamicImport = false;
       let trackingPublished = false;
       try {
         if (!hasTopLevelAwait) {
@@ -5029,6 +5070,7 @@ async function loadAndMergeConfig(
           );
           configModule = imported.configModule;
           dynamicImportObserver = imported.observer;
+          hasComputedDynamicImport = imported.hasComputedDynamicImport;
         }
         const merged = validateAndMergeConfig(selectConfigModuleValue(configModule));
         if (cacheRevision !== revisionAtStart) {
@@ -5040,6 +5082,7 @@ async function loadAndMergeConfig(
             evictBunProjectConfigModules(trackingEntry);
             trackingEntry = undefined;
           }
+          if (hasComputedDynamicImport) throw BUN_PROJECT_CONFIG_LOAD_INVALIDATED;
           return merged;
         }
         if (trackingEntry !== undefined) {
@@ -5555,7 +5598,7 @@ function getConfigInternal(
             );
             const provenance = configFileProvenance(configFile);
             if (usePersistentCache && cacheRevision === revisionAtStart) {
-              configCacheByProject.set(effectiveCacheKey, {
+              setConfigCacheEntry(effectiveCacheKey, {
                 revision: revisionAtStart,
                 config: merged,
                 provenance,
@@ -5572,6 +5615,9 @@ function getConfigInternal(
             });
             return createConfigLoadResult(merged, provenance);
           } catch (error) {
+            if (error === BUN_PROJECT_CONFIG_LOAD_INVALIDATED) {
+              return await getConfigInternal(projectDir, adapter, options);
+            }
             if (isPreservedConfigLoadError(error)) throw error;
             logger.warn("Failed to load config file", { configFile });
             throw configLoadFailure(configFile, error);
@@ -5588,7 +5634,7 @@ function getConfigInternal(
         const config = createFreshDefaults() as VeryfrontConfig;
         const provenance = defaultConfigProvenance();
         if (usePersistentCache && cacheRevision === revisionAtStart) {
-          configCacheByProject.set(effectiveCacheKey, {
+          setConfigCacheEntry(effectiveCacheKey, {
             revision: revisionAtStart,
             config,
             provenance,
@@ -5779,6 +5825,7 @@ export function __getTrustedConfigFlightStateForTests(): Readonly<{
 
 export function clearConfigCache(): void {
   configCacheByProject.clear();
+  mapClear(bunProjectConfigTrackingOwnerCounts);
   hostedConfigFailureCacheByProject.clear();
   clearBunProjectConfigModuleTracking();
   cacheRevision++;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -3267,7 +3267,7 @@ function isValidProjectPackageSpecifier(
 
 /**
  * Match native pattern-match validation: a wildcard capture whose decoded
- * segments are empty, dot, dot-dot, or `node_modules` makes the specifier
+ * segments are dot, dot-dot, or `node_modules` makes the specifier
  * invalid, so staging must refuse it instead of resolving a target native
  * package resolution would never load. A capture may span `/` -- each
  * segment is validated on its own.
@@ -3280,9 +3280,7 @@ function assertSafeProjectPackageWildcard(capture: string, specifier: string): v
   const segments = ReflectApply(StringPrototypeSplit, portableCapture, ["/"]) as string[];
   for (let index = 0; index < segments.length; index++) {
     const segment = segments[index];
-    if (segment === undefined || segment === "") {
-      throw new TypeError(`Package import "${specifier}" contains a forbidden path segment`);
-    }
+    if (segment === undefined || segment === "") continue;
     let decoded: string;
     try {
       decoded = ReflectApply(DecodeURIComponent, undefined, [segment]) as string;
@@ -3403,24 +3401,34 @@ async function projectPackageDirectoryExists(packageDirectory: string): Promise<
   }
 }
 
+type ProjectPackageLookup = Readonly<
+  | { kind: "manifest"; manifest: ProjectPackageManifest }
+  | { kind: "legacy"; directory: string }
+>;
+
 /** Find the nearest installed copy of a package from the original config location. */
-async function findProjectPackageManifest(
+async function findProjectPackage(
   packageName: string,
   configPath: string,
-): Promise<ProjectPackageManifest | undefined> {
+): Promise<ProjectPackageLookup | undefined> {
   const scope = await findNearestProjectPackageManifest(configPath);
   const scopeName = scope && ownDataValue(scope.value, "name");
-  if (scope && scopeName?.present && scopeName.value === packageName) return scope;
+  if (scope && scopeName?.present && scopeName.value === packageName) {
+    return { kind: "manifest", manifest: scope };
+  }
   let directory = dirname(configPath);
   while (true) {
     const packageDirectory = join(directory, "node_modules", packageName);
     const manifest = await readProjectPackageManifest(packageDirectory);
-    if (manifest) return manifest;
+    if (manifest) return { kind: "manifest", manifest };
     // The nearest installed directory wins even without a usable manifest:
     // project resolution stops there and uses its legacy entry point, so an
-    // ancestor's exports map must not shadow it. Leave the manifestless
-    // package to the native fallback resolver.
-    if (await projectPackageDirectoryExists(packageDirectory)) return undefined;
+    // ancestor's exports map must not shadow it. Return the exact directory so
+    // legacy resolution cannot skip an unusable nearest install and continue
+    // searching ancestors.
+    if (await projectPackageDirectoryExists(packageDirectory)) {
+      return { kind: "legacy", directory: packageDirectory };
+    }
 
     const parent = dirname(directory);
     if (parent === directory) return undefined;
@@ -3483,8 +3491,16 @@ async function resolveProjectPackageImport(
   if (!isValidProjectPackageSpecifier(parsed)) {
     throw new TypeError(`Package import "${specifier}" is not a valid package specifier`);
   }
-  const manifest = await findProjectPackageManifest(parsed.packageName, configPath);
-  if (!manifest) return undefined;
+  const packageLookup = await findProjectPackage(parsed.packageName, configPath);
+  if (!packageLookup) return undefined;
+  if (packageLookup.kind === "legacy") {
+    return {
+      kind: "legacy",
+      directory: packageLookup.directory,
+      subpath: parsed.subpath,
+    };
+  }
+  const manifest = packageLookup.manifest;
 
   const exportsProperty = ownDataValue(manifest.value, "exports");
   if (!exportsProperty.present) return undefined;
@@ -3499,6 +3515,7 @@ async function resolveProjectPackageImport(
 type ProjectPackageImportResolution = Readonly<
   | { kind: "resolved"; specifier: string }
   | { kind: "external"; specifier: string; scopeDirectory: string }
+  | { kind: "legacy"; directory: string; subpath: string | null }
 >;
 
 function asResolvedConfigSpecifier(resolved: string): string {
@@ -3540,6 +3557,14 @@ async function createProjectConfigImportResolver(
     }
     const esmResolution = await resolveProjectPackageImport(specifier, basePath);
     if (esmResolution?.kind === "resolved") return esmResolution.specifier;
+    if (esmResolution?.kind === "legacy") {
+      const legacyTarget = esmResolution.subpath === null
+        ? esmResolution.directory
+        : join(esmResolution.directory, stringSlice(esmResolution.subpath, 1));
+      const resolved = ReflectApply(baseRequire.resolve, baseRequire, [legacyTarget]);
+      if (typeof resolved !== "string") throw new TypeError("Config import resolution failed");
+      return asResolvedConfigSpecifier(resolved);
+    }
     if (esmResolution?.kind === "external") {
       if (ReflectApply(SetPrototypeHas, seenAliases, [specifier]) as boolean) {
         throw new TypeError(`Circular package import alias "${specifier}"`);
@@ -3726,9 +3751,14 @@ async function rewriteComputedDynamicProjectConfigImports(
   const bridgeUrl = `data:text/javascript,${ReflectApply(EncodeURIComponent, undefined, [
     bridgeSource,
   ]) as string}`;
-  return `import ${observerKey} from ${ReflectApply(JSONStringify, JSON, [
+  const bridgeImport = `import ${observerKey} from ${ReflectApply(JSONStringify, JSON, [
     bridgeUrl,
-  ]) as string};\n${rewritten}`;
+  ]) as string};\n`;
+  if (!stringStartsWith(rewritten, "#!")) return bridgeImport + rewritten;
+  const hashbangEnd = stringIndexOf(rewritten, "\n");
+  if (hashbangEnd < 0) return `${rewritten}\n${bridgeImport}`;
+  return stringSlice(rewritten, 0, hashbangEnd + 1) + bridgeImport +
+    stringSlice(rewritten, hashbangEnd + 1);
 }
 
 /** @internal */

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -5,9 +5,11 @@ import {
   extname,
   isAbsolute,
   join,
+  relative,
   resolve,
   toFileUrl,
 } from "#veryfront/compat/path/index.ts";
+import { runtimeUsesWindowsPaths } from "#veryfront/platform/compat/path/portable.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import {
   isExtendedFSAdapter,
@@ -23,7 +25,7 @@ import { getReactImportMap, REACT_DEFAULT_VERSION } from "#veryfront/utils/const
 import { DEFAULT_CACHE_DIR } from "#veryfront/utils/constants/server.ts";
 import { buildConfigCacheKey, type VirtualConfigSourceContext } from "#veryfront/cache/keys.ts";
 import { DEFAULT_PORT, DEFAULT_RENDER_CACHE_MAX_ENTRIES } from "./defaults.ts";
-import { createFileSystem, isNotFoundError } from "#veryfront/platform/compat/fs.ts";
+import { createFileSystem, isNotFoundError, realPath } from "#veryfront/platform/compat/fs.ts";
 import {
   CACHE_INVARIANT_VIOLATION,
   CONFIG_PARSE_ERROR,
@@ -41,6 +43,7 @@ import { registerLRUCache } from "#veryfront/cache/registry.ts";
 import { VERYFRONT_CONFIG_FILES } from "./config-files.ts";
 import { currentRequestContext } from "#veryfront/platform/request-context-access.ts";
 import type { ModuleLexer } from "#veryfront/extensions/bundler/module-lexer.ts";
+import type { ASTNode } from "#veryfront/extensions/parser/index.ts";
 import { tryResolve as tryResolveContract } from "#veryfront/extensions/contracts.ts";
 import { importFirstPartyExtensionModule } from "#veryfront/extensions/first-party-import.ts";
 import { parseBarePackageSpecifier } from "#veryfront/transforms/shared/package-specifier.ts";
@@ -68,6 +71,7 @@ import { describeHostedConfigRejection } from "./hosted-compatibility.ts";
 // singleflight state, and immutable result must not depend on ambient methods.
 const IntrinsicMap = Map;
 const IntrinsicSet = Set;
+const ArrayIsArray = Array.isArray;
 const IntrinsicPromise = Promise;
 const IntrinsicTextDecoder = TextDecoder;
 const IntrinsicErrorPrototype = Error.prototype;
@@ -75,6 +79,11 @@ const IntrinsicObjectPrototype = Object.prototype;
 const IntrinsicWeakMap = WeakMap;
 const IntrinsicWeakSet = WeakSet;
 const IntrinsicAbortController = AbortController;
+const IntrinsicURL = URL;
+const EncodeURIComponent = encodeURIComponent;
+const JSONParse = JSON.parse;
+const JSONStringify = JSON.stringify;
+const DecodeURIComponent = decodeURIComponent;
 const AbortControllerPrototypeAbort = AbortController.prototype.abort;
 const EventTargetPrototypeAddEventListener = EventTarget.prototype.addEventListener;
 const EventTargetPrototypeRemoveEventListener = EventTarget.prototype.removeEventListener;
@@ -97,13 +106,18 @@ const PromiseWithResolvers = Promise.withResolvers;
 const ReflectApply = Reflect.apply;
 const RegExpPrototypeExec = RegExp.prototype.exec;
 const ReflectGet = Reflect.get;
+const ReflectSet = Reflect.set;
 const StringPrototypeIncludes = String.prototype.includes;
+const StringPrototypeIndexOf = String.prototype.indexOf;
 const StringPrototypeEndsWith = String.prototype.endsWith;
+const StringPrototypeReplaceAll = String.prototype.replaceAll;
 const StringPrototypeSlice = String.prototype.slice;
 const StringPrototypeSplit = String.prototype.split;
 const StringPrototypeStartsWith = String.prototype.startsWith;
 const StringPrototypeToLowerCase = String.prototype.toLowerCase;
 const StringPrototypeTrim = String.prototype.trim;
+const SetPrototypeAdd = Set.prototype.add;
+const SetPrototypeForEach = Set.prototype.forEach;
 const SetPrototypeHas = Set.prototype.has;
 const ReflectDeleteProperty = Reflect.deleteProperty;
 const ReflectOwnKeys = Reflect.ownKeys;
@@ -133,17 +147,29 @@ const abortSignalAbortedGetter = ObjectGetOwnPropertyDescriptor(
   "aborted",
 )?.get;
 const mapSizeGetter = ObjectGetOwnPropertyDescriptor(Map.prototype, "size")?.get;
+const urlHrefGetter = ObjectGetOwnPropertyDescriptor(URL.prototype, "href")?.get;
+const urlHostnameGetter = ObjectGetOwnPropertyDescriptor(URL.prototype, "hostname")?.get;
+const urlPathnameGetter = ObjectGetOwnPropertyDescriptor(URL.prototype, "pathname")?.get;
+const urlProtocolGetter = ObjectGetOwnPropertyDescriptor(URL.prototype, "protocol")?.get;
 
 if (
   typeof abortControllerSignalGetter !== "function" ||
   typeof abortSignalAbortedGetter !== "function" ||
-  typeof mapSizeGetter !== "function"
+  typeof mapSizeGetter !== "function" ||
+  typeof urlHrefGetter !== "function" ||
+  typeof urlHostnameGetter !== "function" ||
+  typeof urlPathnameGetter !== "function" ||
+  typeof urlProtocolGetter !== "function"
 ) {
   throw new TypeError("Loader lifecycle intrinsics are unavailable");
 }
 const intrinsicAbortControllerSignalGetter = abortControllerSignalGetter as () => AbortSignal;
 const intrinsicAbortSignalAbortedGetter = abortSignalAbortedGetter as () => boolean;
 const intrinsicMapSizeGetter = mapSizeGetter as () => number;
+const intrinsicUrlHrefGetter = urlHrefGetter as () => string;
+const intrinsicUrlHostnameGetter = urlHostnameGetter as () => string;
+const intrinsicUrlPathnameGetter = urlPathnameGetter as () => string;
+const intrinsicUrlProtocolGetter = urlProtocolGetter as () => string;
 const HOSTED_CONFIG_TEXT_DECODER_OPTIONS = createHostedConfigTextDecoderOptions();
 const ABORT_LISTENER_OPTIONS = createAbortListenerOptions();
 const SAFE_PROMISE_SPECIES_HOLDER = createSafePromiseSpeciesHolder();
@@ -174,6 +200,26 @@ function isFrozen(value: object): boolean {
 
 function ownKeys(value: object): PropertyKey[] {
   return ReflectApply(ReflectOwnKeys, Reflect, [value]) as PropertyKey[];
+}
+
+function stringStartsWith(value: string, search: string): boolean {
+  return ReflectApply(StringPrototypeStartsWith, value, [search]) as boolean;
+}
+
+function stringIncludes(value: string, search: string): boolean {
+  return ReflectApply(StringPrototypeIncludes, value, [search]) as boolean;
+}
+
+function stringEndsWith(value: string, search: string): boolean {
+  return ReflectApply(StringPrototypeEndsWith, value, [search]) as boolean;
+}
+
+function stringIndexOf(value: string, search: string, position?: number): number {
+  return ReflectApply(StringPrototypeIndexOf, value, [search, position]) as number;
+}
+
+function stringSlice(value: string, start: number, end?: number): string {
+  return ReflectApply(StringPrototypeSlice, value, [start, end]) as string;
 }
 
 function reflectGet(value: RuntimeReflectionRecord, key: PropertyKey): unknown {
@@ -452,6 +498,11 @@ const DEFAULT_FS_MAX_DELAY_MS = 5_000;
 /** Maximum entries in the per-project config cache */
 const DEFAULT_CONFIG_CACHE_MAX_ENTRIES = 100;
 
+/** @internal Test-only tracking capacity. */
+export function __getBunProjectConfigModuleTrackingCapacityForTests(): number {
+  return DEFAULT_CONFIG_CACHE_MAX_ENTRIES;
+}
+
 export type { VeryfrontConfig } from "./schemas/index.ts";
 
 /**
@@ -604,11 +655,84 @@ interface ConfigCacheEntry {
   readonly revision: number;
   readonly config: VeryfrontConfig;
   readonly provenance: ConfigLoadProvenance;
+  readonly bunTrackingKey?: string;
+}
+
+interface BunProjectDynamicImportObserver {
+  readonly key: string;
+  readonly dispose: () => void;
+}
+
+interface BunProjectConfigModuleCacheEntry {
+  readonly cache: Record<string, unknown>;
+  readonly keys: readonly string[];
+  readonly projectDirectory: string;
+  readonly dynamicImportObserver?: BunProjectDynamicImportObserver;
 }
 
 const configCacheByProject = new LRUCache<string, ConfigCacheEntry>({
   maxEntries: DEFAULT_CONFIG_CACHE_MAX_ENTRIES,
+  onEvict: (_key, value) => {
+    const entry = value as ConfigCacheEntry;
+    if (entry.bunTrackingKey !== undefined) {
+      bunProjectConfigModuleCacheKeys.delete(entry.bunTrackingKey);
+    }
+  },
 });
+const bunProjectConfigModuleTrackingEntries = new IntrinsicMap<
+  string,
+  BunProjectConfigModuleCacheEntry
+>();
+let clearingBunProjectConfigModuleTracking = false;
+const bunProjectConfigModuleCacheKeys = new LRUCache<
+  string,
+  BunProjectConfigModuleCacheEntry
+>({
+  maxEntries: DEFAULT_CONFIG_CACHE_MAX_ENTRIES,
+  // require.cache contains live module namespace objects with getters and TDZ
+  // bindings, so the generic recursive estimator must never inspect it.
+  estimateSizeOf: () => 1,
+  onEvict: (key, value) => {
+    mapDelete(bunProjectConfigModuleTrackingEntries, key);
+    if (!clearingBunProjectConfigModuleTracking) {
+      evictBunProjectConfigModules(value as BunProjectConfigModuleCacheEntry);
+    }
+  },
+});
+/** Serialize Bun loads for one config path, including across cache revisions. */
+const bunProjectConfigLoadTurns = new IntrinsicMap<string, Promise<void>>();
+const bunProjectConfigPendingDependencyCollections = new IntrinsicMap<
+  string,
+  Promise<void>
+>();
+let bunProjectConfigDynamicImportObserverSequence = 0;
+
+function setBunProjectConfigModuleTracking(
+  key: string,
+  entry: BunProjectConfigModuleCacheEntry,
+): void {
+  mapSet(bunProjectConfigModuleTrackingEntries, key, entry);
+  bunProjectConfigModuleCacheKeys.set(key, entry);
+}
+
+/**
+ * Keep Bun module-tracking recency coupled to the config cache. A config
+ * cache hit touches only `configCacheByProject`; without refreshing the
+ * tracking entry too, the independent tracking LRU can reach capacity and
+ * evict -- and thereby delete -- the module graph of a config that is still
+ * being served from cache, splitting later application imports into a second
+ * singleton generation.
+ */
+function touchBunProjectConfigModuleTracking(
+  projectDir: string,
+  provenance: ConfigLoadProvenance,
+  trackingKey?: string,
+): void {
+  if (!isBun || provenance.kind !== "file") return;
+  bunProjectConfigModuleCacheKeys.get(
+    trackingKey ?? resolve(join(projectDir, provenance.configFile)),
+  );
+}
 
 interface HostedConfigFailureCacheEntry {
   readonly revision: number;
@@ -2678,7 +2802,16 @@ type DefaultModuleLexerModule = {
   EsModuleLexer: new () => ModuleLexer;
 };
 
+interface ConfigParseOnlyParser {
+  parse(options: { code: string; filePath?: string }): Promise<ASTNode>;
+}
+
+type DefaultConfigParserModule = {
+  BabelParseOnlyParser: new () => ConfigParseOnlyParser;
+};
+
 let fallbackModuleLexerPromise: Promise<ModuleLexer> | undefined;
+let fallbackConfigParserPromise: Promise<ConfigParseOnlyParser> | undefined;
 
 async function getConfigModuleLexer(): Promise<ModuleLexer> {
   const registered = tryResolveContract<ModuleLexer>("ModuleLexer");
@@ -2692,6 +2825,116 @@ async function getConfigModuleLexer(): Promise<ModuleLexer> {
     ({ EsModuleLexer }) => new EsModuleLexer(),
   );
   return await fallbackModuleLexerPromise;
+}
+
+async function getConfigParseOnlyParser(): Promise<ConfigParseOnlyParser> {
+  fallbackConfigParserPromise ??= thenPromise(
+    importFirstPartyExtensionModule<DefaultConfigParserModule>(
+      "ext-parser-babel",
+      "@veryfront/ext-parser-babel",
+      { sourceEntry: "parser-only", packageSubpath: "parser-only" },
+    ),
+    ({ BabelParseOnlyParser }) => new BabelParseOnlyParser(),
+  );
+  return await fallbackConfigParserPromise;
+}
+
+function configAstNodeType(value: unknown): string | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const descriptor = getOwnPropertyDescriptor(value, "type");
+  return descriptor && "value" in descriptor && typeof descriptor.value === "string"
+    ? descriptor.value
+    : undefined;
+}
+
+function isConfigFunctionAstNode(type: string): boolean {
+  return type === "FunctionDeclaration" || type === "FunctionExpression" ||
+    type === "ArrowFunctionExpression" || type === "ObjectMethod" ||
+    type === "ClassMethod" || type === "ClassPrivateMethod" ||
+    type === "TSDeclareFunction";
+}
+
+function configAstHasTopLevelAwait(root: ASTNode): boolean {
+  const queue: unknown[] = [root];
+  const functionDepths = [0];
+  for (let queueIndex = 0; queueIndex < queue.length; queueIndex++) {
+    const node = queue[queueIndex];
+    const functionDepth = functionDepths[queueIndex] ?? 0;
+    const type = configAstNodeType(node);
+    if (type === undefined) continue;
+    if (type === "AwaitExpression" && functionDepth === 0) return true;
+    if (type === "ForOfStatement" && functionDepth === 0) {
+      const awaitDescriptor = getOwnPropertyDescriptor(node as object, "await");
+      if (awaitDescriptor && "value" in awaitDescriptor && awaitDescriptor.value === true) {
+        return true;
+      }
+    }
+    if (type === "VariableDeclaration" && functionDepth === 0) {
+      const kindDescriptor = getOwnPropertyDescriptor(node as object, "kind");
+      if (
+        kindDescriptor && "value" in kindDescriptor && kindDescriptor.value === "await using"
+      ) {
+        return true;
+      }
+    }
+
+    const functionNode = isConfigFunctionAstNode(type);
+    const keys = ownKeys(node as object);
+    for (let keyIndex = 0; keyIndex < keys.length; keyIndex++) {
+      const key = keys[keyIndex];
+      if (key === "type") continue;
+      // Computed method keys and decorators run while the containing object or
+      // class is initialized. Parameters and bodies run only when called.
+      const childFunctionDepth = functionNode && key !== "key" && key !== "decorators"
+        ? functionDepth + 1
+        : functionDepth;
+      const descriptor = getOwnPropertyDescriptor(node as object, key!);
+      if (!descriptor || !("value" in descriptor)) continue;
+      const child = descriptor.value;
+      if (configAstNodeType(child) !== undefined) {
+        queue[queue.length] = child;
+        functionDepths[functionDepths.length] = childFunctionDepth;
+      } else if (ArrayIsArray(child)) {
+        for (let childIndex = 0; childIndex < child.length; childIndex++) {
+          const item = child[childIndex];
+          if (configAstNodeType(item) !== undefined) {
+            queue[queue.length] = item;
+            functionDepths[functionDepths.length] = childFunctionDepth;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
+async function bunConfigHasTopLevelAwait(source: string, configPath: string): Promise<boolean> {
+  if (!stringIncludes(source, "await")) return false;
+  try {
+    const ast = await (await getConfigParseOnlyParser()).parse({
+      code: source,
+      filePath: configPath,
+    });
+    const programDescriptor = getOwnPropertyDescriptor(ast, "program");
+    const root = programDescriptor && "value" in programDescriptor &&
+        configAstNodeType(programDescriptor.value) === "Program"
+      ? programDescriptor.value as ASTNode
+      : ast;
+    return configAstHasTopLevelAwait(root);
+  } catch {
+    // If the pinned parser cannot classify an await-bearing config, avoid the
+    // destructive require-then-import probe. The fallback will evaluate it at
+    // most once and preserve the original syntax error if it is invalid.
+    return true;
+  }
+}
+
+/** @internal Test-only Bun async-module preflight seam. */
+export function __bunConfigHasTopLevelAwaitForTests(
+  source: string,
+  configPath = "veryfront.config.ts",
+): Promise<boolean> {
+  return bunConfigHasTopLevelAwait(source, configPath);
 }
 
 /**
@@ -2719,10 +2962,514 @@ export async function rewriteBareVeryfrontConfigImports(source: string): Promise
   return rewritten;
 }
 
-type ProjectConfigImportResolver = (specifier: string) => string;
+type ProjectConfigImportResolver = (specifier: string) => string | Promise<string>;
+type UnresolvedDynamicProjectConfigImportResolver = (
+  specifier: string,
+  error: unknown,
+) => string;
+type ResolvedProjectConfigImportObserver = (specifier: string) => void | Promise<void>;
+
+const PROJECT_ESM_EXPORT_CONDITIONS: ReadonlySet<string> = new IntrinsicSet([
+  "deno",
+  "node",
+  "import",
+  "module-sync",
+]);
+
+type ProjectPackageManifest = Readonly<{
+  directory: string;
+  value: Record<PropertyKey, unknown>;
+}>;
+
+class InvalidProjectPackageTargetError extends TypeError {}
+
+async function readProjectPackageManifest(
+  directory: string,
+): Promise<ProjectPackageManifest | undefined> {
+  try {
+    const parsed = ReflectApply(JSONParse, JSON, [
+      await createFileSystem().readTextFile(join(directory, "package.json")),
+    ]) as unknown;
+    if (!isRecord(parsed)) {
+      throw new TypeError("Package manifest must contain a JSON object");
+    }
+    return { directory, value: parsed };
+  } catch (error) {
+    if (isNotFoundError(error)) return undefined;
+    throw error;
+  }
+}
+
+async function findNearestProjectPackageManifest(
+  configPath: string,
+): Promise<ProjectPackageManifest | undefined> {
+  let directory = dirname(configPath);
+  while (true) {
+    const manifest = await readProjectPackageManifest(directory);
+    if (manifest) return manifest;
+    const parent = dirname(directory);
+    if (parent === directory) return undefined;
+    directory = parent;
+  }
+}
+
+function ownDataValue(
+  value: Record<PropertyKey, unknown>,
+  key: PropertyKey,
+): { present: boolean; value?: unknown } {
+  const descriptor = getOwnPropertyDescriptor(value, key);
+  if (!descriptor || !("value" in descriptor)) return { present: false };
+  return { present: true, value: descriptor.value };
+}
+
+function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
+  return typeof value === "object" && value !== null && !ArrayIsArray(value);
+}
+
+/** Matches Node's array-index check for conditional export and import keys. */
+function isArrayIndexPropertyKey(key: string): boolean {
+  const numeric = +key;
+  return `${numeric}` === key && numeric >= 0 && numeric < 0xffff_ffff;
+}
+
+/** Select a local package target using Deno's active ESM export conditions. */
+function selectConditionalProjectExport(
+  value: unknown,
+  wildcard: string | undefined,
+  allowExternal = false,
+): string | null | undefined {
+  if (value === null) return null;
+  if (typeof value === "string") {
+    return wildcard === undefined
+      ? value
+      : ReflectApply(StringPrototypeReplaceAll, value, ["*", wildcard]) as string;
+  }
+  if (ArrayIsArray(value)) {
+    for (let index = 0; index < value.length; index++) {
+      let selected: string | null | undefined;
+      try {
+        selected = selectConditionalProjectExport(value[index], wildcard, allowExternal);
+      } catch (error) {
+        if (error instanceof InvalidProjectPackageTargetError) continue;
+        throw error;
+      }
+      if (typeof selected !== "string") continue;
+      if (stringStartsWith(selected, "./")) {
+        try {
+          assertSafeProjectPackageTarget(selected, "array target");
+          return selected;
+        } catch (error) {
+          if (error instanceof InvalidProjectPackageTargetError) continue;
+          throw error;
+        }
+      }
+      if (allowExternal && isExternalProjectPackageImportTarget(selected)) return selected;
+    }
+    return undefined;
+  }
+  if (!isRecord(value)) throw new TypeError("Package export target is invalid");
+
+  const keys = ownKeys(value);
+  // Node and Bun reject conditional maps whose keys are array indices before
+  // matching any condition, so surface the invalid package configuration
+  // instead of silently skipping the numeric key and selecting another branch.
+  for (let index = 0; index < keys.length; index++) {
+    const key = keys[index];
+    if (typeof key === "string" && isArrayIndexPropertyKey(key)) {
+      throw new TypeError(
+        "Package export conditions cannot contain numeric property keys",
+      );
+    }
+  }
+  for (let index = 0; index < keys.length; index++) {
+    const key = keys[index];
+    if (typeof key !== "string") continue;
+    if (
+      key !== "default" &&
+      ReflectApply(SetPrototypeHas, PROJECT_ESM_EXPORT_CONDITIONS, [key]) !== true
+    ) continue;
+    const candidate = ownDataValue(value, key);
+    if (!candidate.present) continue;
+    const selected = selectConditionalProjectExport(candidate.value, wildcard, allowExternal);
+    if (selected !== undefined) return selected;
+  }
+  return undefined;
+}
+
+/** Match a root, exact subpath, or wildcard package export without evaluating it. */
+function selectProjectPackageExport(
+  exportsValue: unknown,
+  subpath: string,
+): string | null | undefined {
+  if (!isRecord(exportsValue)) {
+    return subpath === "." ? selectConditionalProjectExport(exportsValue, undefined) : undefined;
+  }
+
+  const keys = ownKeys(exportsValue);
+  let hasSubpathMap = false;
+  let hasConditionKey = false;
+  for (let index = 0; index < keys.length; index++) {
+    const key = keys[index];
+    if (typeof key !== "string") continue;
+    if (stringStartsWith(key, ".")) hasSubpathMap = true;
+    else hasConditionKey = true;
+  }
+  if (!hasSubpathMap) {
+    return subpath === "." ? selectConditionalProjectExport(exportsValue, undefined) : undefined;
+  }
+  if (hasConditionKey) {
+    throw new TypeError("Package exports cannot mix conditions and subpaths");
+  }
+
+  const exact = ownDataValue(exportsValue, subpath);
+  if (exact.present) return selectConditionalProjectExport(exact.value, undefined);
+
+  let bestKey: string | undefined;
+  let bestWildcard: string | undefined;
+  let bestPrefixLength = -1;
+  for (let index = 0; index < keys.length; index++) {
+    const key = keys[index];
+    if (typeof key !== "string") continue;
+    const star = stringIndexOf(key, "*");
+    if (star < 0 || stringIndexOf(key, "*", star + 1) >= 0) continue;
+    const prefix = stringSlice(key, 0, star);
+    const suffix = stringSlice(key, star + 1);
+    if (!stringStartsWith(subpath, prefix) || !stringEndsWith(subpath, suffix)) continue;
+    // Native pattern matching requires a nonempty capture: "./feature*" must
+    // not match "./feature" itself.
+    if (subpath.length <= prefix.length + suffix.length) continue;
+    if (
+      prefix.length > bestPrefixLength ||
+      (prefix.length === bestPrefixLength && key.length > (bestKey?.length ?? -1))
+    ) {
+      bestKey = key;
+      bestPrefixLength = prefix.length;
+      bestWildcard = stringSlice(subpath, prefix.length, subpath.length - suffix.length);
+    }
+  }
+  if (bestKey === undefined || bestWildcard === undefined) return undefined;
+  assertSafeProjectPackageWildcard(bestWildcard, subpath);
+  const pattern = ownDataValue(exportsValue, bestKey);
+  return pattern.present ? selectConditionalProjectExport(pattern.value, bestWildcard) : undefined;
+}
+
+function selectProjectPackageImport(
+  importsValue: unknown,
+  specifier: string,
+): string | null | undefined {
+  if (!isRecord(importsValue)) return undefined;
+  const exact = ownDataValue(importsValue, specifier);
+  if (exact.present) return selectConditionalProjectExport(exact.value, undefined, true);
+
+  const keys = ownKeys(importsValue);
+  let bestKey: string | undefined;
+  let bestWildcard: string | undefined;
+  let bestPrefixLength = -1;
+  for (let index = 0; index < keys.length; index++) {
+    const key = keys[index];
+    if (typeof key !== "string" || !stringStartsWith(key, "#")) continue;
+    const star = stringIndexOf(key, "*");
+    if (star < 0 || stringIndexOf(key, "*", star + 1) >= 0) continue;
+    const prefix = stringSlice(key, 0, star);
+    const suffix = stringSlice(key, star + 1);
+    if (!stringStartsWith(specifier, prefix) || !stringEndsWith(specifier, suffix)) continue;
+    // Native pattern matching requires a nonempty capture: "#feature*" must
+    // not match "#feature" itself.
+    if (specifier.length <= prefix.length + suffix.length) continue;
+    if (
+      prefix.length > bestPrefixLength ||
+      (prefix.length === bestPrefixLength && key.length > (bestKey?.length ?? -1))
+    ) {
+      bestKey = key;
+      bestPrefixLength = prefix.length;
+      bestWildcard = stringSlice(specifier, prefix.length, specifier.length - suffix.length);
+    }
+  }
+  if (bestKey === undefined || bestWildcard === undefined) return undefined;
+  assertSafeProjectPackageWildcard(bestWildcard, specifier);
+  const pattern = ownDataValue(importsValue, bestKey);
+  return pattern.present
+    ? selectConditionalProjectExport(pattern.value, bestWildcard, true)
+    : undefined;
+}
+
+function isExternalProjectPackageImportTarget(target: string): boolean {
+  if (stringStartsWith(target, "node:")) return true;
+  if (stringStartsWith(target, "#")) return false;
+  // Native package-imports resolution rejects a dot-relative target such as
+  // "../outside.js" as an invalid target; parseBarePackageSpecifier would
+  // otherwise classify it as package "..", and the fallback resolver would
+  // load a file outside the package as if it were an external dependency.
+  if (stringStartsWith(target, ".")) return false;
+  const parsed = parseBarePackageSpecifier(target);
+  return parsed !== undefined && parsed !== null && parsed.version === null &&
+    isValidProjectPackageSpecifier(parsed);
+}
+
+const ENCODED_PACKAGE_PATH_SEPARATOR = /%2f|%5c/i;
+
+/**
+ * Match Node's package-name and subpath validation: a dot-prefixed name, a
+ * name containing "%" or "\\", and a subpath with an encoded separator are
+ * rejected before any manifest lookup, so staging never loads a
+ * `node_modules` entry the original project resolver would have refused.
+ */
+function isValidProjectPackageSpecifier(
+  parsed: Readonly<{ packageName: string; subpath: string | null }>,
+): boolean {
+  if (
+    stringStartsWith(parsed.packageName, ".") ||
+    stringIncludes(parsed.packageName, "%") ||
+    stringIncludes(parsed.packageName, "\\") ||
+    stringIncludes(parsed.packageName, "?") ||
+    stringIncludes(parsed.packageName, "#")
+  ) {
+    return false;
+  }
+  return parsed.subpath === null ||
+    ReflectApply(RegExpPrototypeExec, ENCODED_PACKAGE_PATH_SEPARATOR, [parsed.subpath]) === null;
+}
+
+/**
+ * Match native pattern-match validation: a wildcard capture whose decoded
+ * segments are empty, dot, dot-dot, or `node_modules` makes the specifier
+ * invalid, so staging must refuse it instead of resolving a target native
+ * package resolution would never load. A capture may span `/` -- each
+ * segment is validated on its own.
+ */
+function assertSafeProjectPackageWildcard(capture: string, specifier: string): void {
+  const portableCapture = ReflectApply(StringPrototypeReplaceAll, capture, [
+    "\\",
+    "/",
+  ]) as string;
+  const segments = ReflectApply(StringPrototypeSplit, portableCapture, ["/"]) as string[];
+  for (let index = 0; index < segments.length; index++) {
+    const segment = segments[index];
+    if (segment === undefined || segment === "") {
+      throw new TypeError(`Package import "${specifier}" contains a forbidden path segment`);
+    }
+    let decoded: string;
+    try {
+      decoded = ReflectApply(DecodeURIComponent, undefined, [segment]) as string;
+    } catch {
+      throw new TypeError(`Package import "${specifier}" contains an invalid path segment`);
+    }
+    const normalized = ReflectApply(StringPrototypeToLowerCase, decoded, []) as string;
+    if (
+      normalized === "." || normalized === ".." || normalized === "node_modules" ||
+      stringIncludes(decoded, "/") || stringIncludes(decoded, "\\")
+    ) {
+      throw new TypeError(`Package import "${specifier}" contains a forbidden path segment`);
+    }
+  }
+}
+
+function assertSafeProjectPackageTarget(target: string, specifier: string): void {
+  const suffixStart = (() => {
+    const query = stringIndexOf(target, "?");
+    const fragment = stringIndexOf(target, "#");
+    if (query < 0) return fragment;
+    if (fragment < 0) return query;
+    return query < fragment ? query : fragment;
+  })();
+  const path = suffixStart < 0 ? target : stringSlice(target, 0, suffixStart);
+  const portablePath = ReflectApply(StringPrototypeReplaceAll, stringSlice(path, 2), [
+    "\\",
+    "/",
+  ]) as string;
+  const segments = ReflectApply(StringPrototypeSplit, portablePath, ["/"]) as string[];
+  for (let index = 0; index < segments.length; index++) {
+    const segment = segments[index];
+    if (segment === undefined) continue;
+    let decoded: string;
+    try {
+      decoded = ReflectApply(DecodeURIComponent, undefined, [segment]) as string;
+    } catch {
+      throw new InvalidProjectPackageTargetError(
+        `Package import "${specifier}" contains an invalid path segment`,
+      );
+    }
+    const normalized = ReflectApply(StringPrototypeToLowerCase, decoded, []) as string;
+    if (
+      normalized === "." || normalized === ".." || normalized === "node_modules" ||
+      stringIncludes(decoded, "/") || stringIncludes(decoded, "\\")
+    ) {
+      throw new InvalidProjectPackageTargetError(
+        `Package import "${specifier}" contains a forbidden path segment`,
+      );
+    }
+  }
+}
+
+function isAsciiLetter(value: string | undefined): boolean {
+  return value !== undefined &&
+    ((value >= "A" && value <= "Z") || (value >= "a" && value <= "z"));
+}
+
+/** Convert a captured native file URL without consulting mutable URL accessors. */
+function pathFromCapturedFileUrl(url: URL): string {
+  const protocol = ReflectApply(intrinsicUrlProtocolGetter, url, []) as string;
+  if (protocol !== "file:") throw new TypeError("Must be a file URL");
+
+  const windows = runtimeUsesWindowsPaths();
+  const hostname = ReflectApply(intrinsicUrlHostnameGetter, url, []) as string;
+  if (hostname && hostname !== "localhost" && !windows) {
+    throw new TypeError("File URL host must be empty or localhost on non-Windows runtimes");
+  }
+
+  const encodedPath = ReflectApply(intrinsicUrlPathnameGetter, url, []) as string;
+  if (
+    ReflectApply(RegExpPrototypeExec, /%2f/i, [encodedPath]) !== null ||
+    (windows && ReflectApply(RegExpPrototypeExec, /%5c/i, [encodedPath]) !== null)
+  ) {
+    throw new TypeError("File URL path must not include encoded path separators");
+  }
+  let path = ReflectApply(DecodeURIComponent, undefined, [encodedPath]) as string;
+  if (hostname && hostname !== "localhost") {
+    return `\\\\${hostname}${ReflectApply(StringPrototypeReplaceAll, path, ["/", "\\"]) as string}`;
+  }
+  if (!windows) return path;
+  if (path[0] === "/" && isAsciiLetter(path[1]) && path[2] === ":") {
+    path = stringSlice(path, 1);
+  }
+  return ReflectApply(StringPrototypeReplaceAll, path, ["/", "\\"]) as string;
+}
+
+function resolveProjectPackageTarget(
+  manifest: ProjectPackageManifest,
+  specifier: string,
+  target: string | null | undefined,
+): string {
+  if (typeof target !== "string" || !stringStartsWith(target, "./")) {
+    throw new TypeError(`Package import "${specifier}" is not exported`);
+  }
+  assertSafeProjectPackageTarget(target, specifier);
+  const resolvedUrl = new IntrinsicURL(
+    target,
+    toFileUrl(join(manifest.directory, "package.json")),
+  );
+  const resolved = pathFromCapturedFileUrl(resolvedUrl);
+  const relativeTarget = relative(manifest.directory, resolved);
+  if (
+    relativeTarget === ".." || stringStartsWith(relativeTarget, "../") ||
+    stringStartsWith(relativeTarget, "..\\") || isAbsolute(relativeTarget)
+  ) {
+    throw new TypeError(`Package import "${specifier}" resolves outside its package`);
+  }
+  return ReflectApply(intrinsicUrlHrefGetter, resolvedUrl, []) as string;
+}
+
+async function projectPackageDirectoryExists(packageDirectory: string): Promise<boolean> {
+  try {
+    return (await createFileSystem().stat(packageDirectory)).isDirectory;
+  } catch (error) {
+    if (isNotFoundError(error)) return false;
+    throw error;
+  }
+}
+
+/** Find the nearest installed copy of a package from the original config location. */
+async function findProjectPackageManifest(
+  packageName: string,
+  configPath: string,
+): Promise<ProjectPackageManifest | undefined> {
+  const scope = await findNearestProjectPackageManifest(configPath);
+  const scopeName = scope && ownDataValue(scope.value, "name");
+  if (scope && scopeName?.present && scopeName.value === packageName) return scope;
+  let directory = dirname(configPath);
+  while (true) {
+    const packageDirectory = join(directory, "node_modules", packageName);
+    const manifest = await readProjectPackageManifest(packageDirectory);
+    if (manifest) return manifest;
+    // The nearest installed directory wins even without a usable manifest:
+    // project resolution stops there and uses its legacy entry point, so an
+    // ancestor's exports map must not shadow it. Leave the manifestless
+    // package to the native fallback resolver.
+    if (await projectPackageDirectoryExists(packageDirectory)) return undefined;
+
+    const parent = dirname(directory);
+    if (parent === directory) return undefined;
+    directory = parent;
+  }
+}
+
+/** Resolve a package export with ESM conditions, leaving non-package imports to the runtime. */
+async function resolveProjectPackageImport(
+  specifier: string,
+  configPath: string,
+): Promise<ProjectPackageImportResolution | undefined> {
+  if (stringStartsWith(specifier, "./") || stringStartsWith(specifier, "../")) {
+    return undefined;
+  }
+  if (stringStartsWith(specifier, "#")) {
+    if (specifier === "#" || stringStartsWith(specifier, "#/")) {
+      throw new TypeError(`Package import "${specifier}" is not a valid internal import name`);
+    }
+    const manifest = await findNearestProjectPackageManifest(configPath);
+    if (!manifest) return undefined;
+    const importsProperty = ownDataValue(manifest.value, "imports");
+    if (!importsProperty.present) return undefined;
+    const target = selectProjectPackageImport(importsProperty.value, specifier);
+    if (typeof target !== "string") {
+      throw new TypeError(`Package import "${specifier}" is not exported`);
+    }
+    if (!stringStartsWith(target, "./")) {
+      if (!isExternalProjectPackageImportTarget(target)) {
+        throw new TypeError(`Package import "${specifier}" is not exported`);
+      }
+      // Native package-imports resolution resolves an external target from
+      // the package scope that declares the `imports` map, not from the
+      // importing file, so a nested node_modules copy under the config
+      // directory must not shadow the declaring scope's installation.
+      return { kind: "external", specifier: target, scopeDirectory: manifest.directory };
+    }
+    return {
+      kind: "resolved",
+      specifier: resolveProjectPackageTarget(manifest, specifier, target),
+    };
+  }
+  if (
+    ReflectApply(RegExpPrototypeExec, /^[a-zA-Z][a-zA-Z0-9+.-]*:/, [specifier]) !== null
+  ) {
+    throw new TypeError(`Config import "${specifier}" uses an unsupported URL scheme`);
+  }
+  const parsed = parseBarePackageSpecifier(specifier);
+  if (!parsed || parsed.version !== null) {
+    return undefined;
+  }
+  if (
+    ReflectApply(SetPrototypeHas, NODE_BUILTIN_PACKAGE_NAMES, [parsed.packageName]) as boolean
+  ) {
+    return undefined;
+  }
+  // Reject before lookup rather than deferring to the fallback resolver:
+  // CommonJS resolution would load the literal `node_modules/p%2Fq` directory
+  // that native ESM package resolution refuses to consider.
+  if (!isValidProjectPackageSpecifier(parsed)) {
+    throw new TypeError(`Package import "${specifier}" is not a valid package specifier`);
+  }
+  const manifest = await findProjectPackageManifest(parsed.packageName, configPath);
+  if (!manifest) return undefined;
+
+  const exportsProperty = ownDataValue(manifest.value, "exports");
+  if (!exportsProperty.present) return undefined;
+  const subpath = parsed.subpath === null ? "." : `.${parsed.subpath}`;
+  const target = selectProjectPackageExport(exportsProperty.value, subpath);
+  return {
+    kind: "resolved",
+    specifier: resolveProjectPackageTarget(manifest, specifier, target),
+  };
+}
+
+type ProjectPackageImportResolution = Readonly<
+  | { kind: "resolved"; specifier: string }
+  | { kind: "external"; specifier: string; scopeDirectory: string }
+>;
 
 function asResolvedConfigSpecifier(resolved: string): string {
-  return isAbsolute(resolved) ? toFileUrl(resolved).href : resolved;
+  return isAbsolute(resolved)
+    ? ReflectApply(intrinsicUrlHrefGetter, toFileUrl(resolved), []) as string
+    : resolved;
 }
 
 async function createProjectConfigImportResolver(
@@ -2738,13 +3485,49 @@ async function createProjectConfigImportResolver(
   }
 
   const { createRequire } = await import("node:module");
-  const projectRequire = createRequire(toFileUrl(configPath));
-  const resolveSpecifier = projectRequire.resolve;
-  return (specifier) => {
-    const resolved = ReflectApply(resolveSpecifier, projectRequire, [specifier]);
+  const projectRequire = createRequire(configPath);
+  const resolveFromProject = async (
+    specifier: string,
+    seenAliases: Set<string>,
+    basePath: string,
+    baseRequire: NodeJS.Require,
+  ): Promise<string> => {
+    if (
+      (stringStartsWith(specifier, "./") || stringStartsWith(specifier, "../")) &&
+      (stringIncludes(specifier, "?") || stringIncludes(specifier, "#"))
+    ) {
+      const baseUrl = toFileUrl(basePath);
+      const resolvedUrl = new IntrinsicURL(
+        specifier,
+        ReflectApply(intrinsicUrlHrefGetter, baseUrl, []) as string,
+      );
+      return ReflectApply(intrinsicUrlHrefGetter, resolvedUrl, []) as string;
+    }
+    const esmResolution = await resolveProjectPackageImport(specifier, basePath);
+    if (esmResolution?.kind === "resolved") return esmResolution.specifier;
+    if (esmResolution?.kind === "external") {
+      if (ReflectApply(SetPrototypeHas, seenAliases, [specifier]) as boolean) {
+        throw new TypeError(`Circular package import alias "${specifier}"`);
+      }
+      ReflectApply(SetPrototypeAdd, seenAliases, [specifier]);
+      // Resolve the external target from the scope that declared it, the way
+      // native package-imports resolution does, so the declaring package's
+      // own dependencies win over copies nested nearer the config file.
+      const scopePath = join(esmResolution.scopeDirectory, "package.json");
+      const scopeRequire = scopePath === basePath ? baseRequire : createRequire(scopePath);
+      return await resolveFromProject(
+        esmResolution.specifier,
+        seenAliases,
+        scopePath,
+        scopeRequire,
+      );
+    }
+    const resolved = ReflectApply(baseRequire.resolve, baseRequire, [specifier]);
     if (typeof resolved !== "string") throw new TypeError("Config import resolution failed");
     return asResolvedConfigSpecifier(resolved);
   };
+  return (specifier) =>
+    resolveFromProject(specifier, new IntrinsicSet<string>(), configPath, projectRequire);
 }
 
 function keepsConfigImportSpecifier(specifier: string): boolean {
@@ -2761,6 +3544,8 @@ function keepsConfigImportSpecifier(specifier: string): boolean {
 export async function rewriteProjectConfigImports(
   source: string,
   resolveSpecifier: ProjectConfigImportResolver,
+  resolveUnresolvedDynamicSpecifier?: UnresolvedDynamicProjectConfigImportResolver,
+  observeResolvedSpecifier?: ResolvedProjectConfigImportObserver,
 ): Promise<string> {
   const lexer = await getConfigModuleLexer();
   await lexer.init?.();
@@ -2771,28 +3556,144 @@ export async function rewriteProjectConfigImports(
     const imported = imports[index];
     const specifier = imported?.n;
     if (!imported || specifier === undefined || specifier === null) continue;
-    const replacement = specifier === "veryfront"
-      ? VERYFRONT_CONFIG_SHIM_URL
-      : keepsConfigImportSpecifier(specifier)
-      ? specifier
-      : resolveSpecifier(specifier);
+    let replacement: string;
+    if (specifier === "veryfront") replacement = VERYFRONT_CONFIG_SHIM_URL;
+    else if (keepsConfigImportSpecifier(specifier)) replacement = specifier;
+    else {
+      try {
+        replacement = await resolveSpecifier(specifier);
+      } catch (error) {
+        if (imported.d >= 0 && resolveUnresolvedDynamicSpecifier !== undefined) {
+          replacement = resolveUnresolvedDynamicSpecifier(specifier, error);
+        } else if (imported.d >= 0) {
+          continue;
+        } else {
+          throw error;
+        }
+      }
+    }
+    await observeResolvedSpecifier?.(replacement);
     if (replacement === specifier) continue;
     const before = ReflectApply(StringPrototypeSlice, rewritten, [0, imported.s]) as string;
     const after = ReflectApply(StringPrototypeSlice, rewritten, [imported.e]) as string;
-    rewritten = before + replacement + after;
+    const serializedReplacement = imported.d >= 0
+      ? ReflectApply(JSONStringify, JSON, [replacement]) as string
+      : replacement;
+    rewritten = before + serializedReplacement + after;
   }
   return rewritten;
+}
+
+/** A resolution failure an install could fix, as opposed to a present package rejecting the import. */
+function isMissingProjectModuleResolutionError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const record = error as RuntimeReflectionRecord;
+  const code = readOwnDataString(record, "code");
+  if (
+    code === "MODULE_NOT_FOUND" || code === BUN_RESOLVE_MESSAGE_MODULE_NOT_FOUND_CODE
+  ) {
+    return true;
+  }
+  const message = readOwnDataString(record, "message");
+  return message !== undefined &&
+    (stringStartsWith(message, "Cannot find module") ||
+      stringStartsWith(message, "Cannot find package"));
+}
+
+function unresolvedProjectConfigImportModuleUrl(
+  specifier: string,
+  error: unknown,
+): string {
+  let message: string;
+  if (error === undefined || isMissingProjectModuleResolutionError(error)) {
+    const dependency = missingPackageName(specifier);
+    message = dependency === undefined
+      ? "Unable to resolve dynamic project config import"
+      : `Cannot find package "${dependency}" imported from file:///project/veryfront.config.ts`;
+  } else {
+    // A resolution failure that is not "module not found" -- an installed
+    // package whose exports reject the active ESM conditions, an invalid
+    // alias target -- must keep its precise reason. Fabricating a missing
+    // dependency here would tell the reader to install a package that is
+    // already present.
+    const caught = typeof error === "string"
+      ? error
+      : readOwnDataString(error as RuntimeReflectionRecord, "message");
+    message = caught === undefined || caught.length === 0
+      ? "Unable to resolve dynamic project config import"
+      : caught;
+  }
+  const moduleSource = `throw new Error(${ReflectApply(JSONStringify, JSON, [message])});\n`;
+  return `data:text/javascript,${ReflectApply(EncodeURIComponent, undefined, [
+    moduleSource,
+  ]) as string}`;
 }
 
 /** @internal Resolve staged config imports from the original project module root. */
 export async function rewriteProjectConfigImportsFromProject(
   source: string,
   configPath: string,
+  observeResolvedSpecifier?: ResolvedProjectConfigImportObserver,
 ): Promise<string> {
   return await rewriteProjectConfigImports(
     source,
     await createProjectConfigImportResolver(configPath),
+    unresolvedProjectConfigImportModuleUrl,
+    observeResolvedSpecifier,
   );
+}
+
+async function rewriteComputedDynamicProjectConfigImports(
+  source: string,
+  observerKey: string,
+): Promise<string> {
+  const lexer = await getConfigModuleLexer();
+  await lexer.init?.();
+
+  const imports = lexer.parse(source);
+  const openingCounts = new IntrinsicMap<number, number>();
+  const closingCounts = new IntrinsicMap<number, number>();
+  let hasComputedImport = false;
+  for (let index = 0; index < imports.length; index++) {
+    const imported = imports[index];
+    if (
+      !imported || imported.d < 0 ||
+      (imported.n !== undefined && imported.n !== null)
+    ) continue;
+    hasComputedImport = true;
+    mapSet(openingCounts, imported.s, (mapGet(openingCounts, imported.s) ?? 0) + 1);
+    mapSet(closingCounts, imported.e, (mapGet(closingCounts, imported.e) ?? 0) + 1);
+  }
+  if (!hasComputedImport) return source;
+
+  // Insert wrappers against offsets in the original source. Computed imports
+  // can nest, so rewriting one expression first would invalidate the lexer's
+  // range for its containing import even when records are visited in reverse.
+  let rewritten = "";
+  let sourceOffset = 0;
+  for (let position = 0; position <= source.length; position++) {
+    const openingCount = mapGet(openingCounts, position) ?? 0;
+    const closingCount = mapGet(closingCounts, position) ?? 0;
+    if (openingCount === 0 && closingCount === 0) continue;
+    rewritten += stringSlice(source, sourceOffset, position);
+    for (let index = 0; index < closingCount; index++) rewritten += ")";
+    for (let index = 0; index < openingCount; index++) rewritten += `${observerKey}(`;
+    sourceOffset = position;
+  }
+  rewritten += stringSlice(source, sourceOffset);
+
+  // The generated import binding is chosen absent from the authored source,
+  // and its data module reads the real host global in its own lexical scope.
+  // Authored declarations named `globalThis`, `Function`, or `eval` therefore
+  // cannot shadow the observer reference used by the rewritten config.
+  const serializedObserverKey = ReflectApply(JSONStringify, JSON, [observerKey]) as string;
+  const bridgeSource = `export default globalThis[${serializedObserverKey}];\n`;
+  const bridgeUrl = `data:text/javascript,${ReflectApply(EncodeURIComponent, undefined, [
+    bridgeSource,
+  ]) as string}`;
+  return `import ${observerKey} from ${ReflectApply(JSONStringify, JSON, [
+    bridgeUrl,
+  ]) as string};\n${rewritten}`;
 }
 
 /** @internal */
@@ -2937,21 +3838,1092 @@ function isBunAsyncModuleRequireError(error: unknown): boolean {
     ) as boolean;
 }
 
-async function importFreshBunAsyncConfig(absolutePath: string): Promise<object> {
+interface BunAsyncConfigImportResult {
+  readonly configModule: object;
+  readonly observer: BunProjectDynamicImportObserver;
+}
+
+async function importFreshBunAsyncConfig(
+  absolutePath: string,
+  canonicalConfigPath: string,
+  source: string,
+  scope: BunProjectTrackingScope,
+  recordDependencies: (
+    dependencyKeys: ReadonlySet<string>,
+    includeAllNewModules: boolean,
+  ) => void,
+  discardDependencies: (
+    dependencyKeys: ReadonlySet<string>,
+    includeAllNewModules: boolean,
+  ) => void,
+): Promise<BunAsyncConfigImportResult> {
   const fs = createFileSystem();
-  const source = await fs.readTextFile(absolutePath);
-  return await loadConfigFromTempFile(
-    source,
-    absolutePath,
-    (tempFile) => toFileUrl(tempFile).href,
-    (processedSource) => rewriteProjectConfigImportsFromProject(processedSource, absolutePath),
-  ) as object;
+  const dependencyKeys = new IntrinsicSet<string>();
+  const observedRuntimeSpecifiers = new IntrinsicSet<string>();
+  const runtimeSpecifiers: string[] = [];
+  // Bun exposes no loader callback for a computed import executed inside an
+  // already-imported dependency. If the dependency lexer reports one, every
+  // new in-scope module from this serialized evaluation is a possible child.
+  // The eviction graph still preserves modules owned by outside CommonJS
+  // consumers.
+  const dependencyCollectionState = { hasUnobservedComputedImport: false };
+  const lexer = await getConfigModuleLexer();
+  let observerKey: string;
+  do {
+    bunProjectConfigDynamicImportObserverSequence += 1;
+    observerKey =
+      `__veryfrontBunConfigImportObserver${bunProjectConfigDynamicImportObserverSequence}`;
+  } while (
+    getOwnPropertyDescriptor(globalThis, observerKey) !== undefined ||
+    stringIncludes(source, observerKey)
+  );
+  let observerActive = true;
+  const disposeObserver = (): void => {
+    if (!observerActive) return;
+    observerActive = false;
+    ReflectApply(ReflectDeleteProperty, Reflect, [globalThis, observerKey]);
+  };
+  const trackPendingCollection = (collection: Promise<void>): void => {
+    const finalize = (): void => {
+      if (observerActive) {
+        recordDependencies(
+          dependencyKeys,
+          dependencyCollectionState.hasUnobservedComputedImport,
+        );
+      } else {
+        discardDependencies(
+          dependencyKeys,
+          dependencyCollectionState.hasUnobservedComputedImport,
+        );
+      }
+    };
+    const settled = thenPromise(collection, finalize, finalize);
+    const previous = mapGet(
+      bunProjectConfigPendingDependencyCollections,
+      canonicalConfigPath,
+    );
+    const combined = previous === undefined
+      ? settled
+      : thenPromise(previous, () => settled, () => settled);
+    mapSet(bunProjectConfigPendingDependencyCollections, canonicalConfigPath, combined);
+    const release = (): void => {
+      if (
+        mapGet(bunProjectConfigPendingDependencyCollections, canonicalConfigPath) === combined
+      ) {
+        mapDelete(bunProjectConfigPendingDependencyCollections, canonicalConfigPath);
+      }
+    };
+    void thenPromise(combined, release, release);
+  };
+  const baseUrl = ReflectApply(intrinsicUrlHrefGetter, toFileUrl(absolutePath), []) as string;
+  ObjectDefineProperty(globalThis, observerKey, {
+    configurable: true,
+    value: (specifier: unknown): unknown => {
+      if (typeof specifier !== "string") return specifier;
+      let resolvedSpecifier = specifier;
+      if (stringStartsWith(specifier, "./") || stringStartsWith(specifier, "../")) {
+        const resolvedUrl = new IntrinsicURL(specifier, baseUrl);
+        resolvedSpecifier = ReflectApply(intrinsicUrlHrefGetter, resolvedUrl, []) as string;
+      } else if (!keepsConfigImportSpecifier(specifier) && !isAbsolute(specifier)) {
+        if (!CapturedBunResolveSync || !CapturedBun) {
+          throw new TypeError("Bun project config resolver is unavailable");
+        }
+        const resolved = ReflectApply(CapturedBunResolveSync, CapturedBun, [
+          specifier,
+          dirname(absolutePath),
+        ]);
+        if (typeof resolved !== "string") {
+          throw new TypeError("Bun project config import resolution failed");
+        }
+        resolvedSpecifier = asResolvedConfigSpecifier(resolved);
+      }
+      if (
+        ReflectApply(SetPrototypeHas, observedRuntimeSpecifiers, [resolvedSpecifier]) !== true
+      ) {
+        ReflectApply(SetPrototypeAdd, observedRuntimeSpecifiers, [resolvedSpecifier]);
+        runtimeSpecifiers[runtimeSpecifiers.length] = resolvedSpecifier;
+        if (initialEvaluationComplete && observerActive) {
+          const collection = collectBunProjectConfigDependencyKeys(
+            resolvedSpecifier,
+            scope,
+            dependencyKeys,
+            lexer,
+            fs,
+            dependencyCollectionState,
+          );
+          // The collector records the directly resolved path before its first
+          // await. Publish that key synchronously so an immediate cache clear
+          // after setup still owns the module; refresh again after transitive
+          // discovery completes.
+          if (observerActive) {
+            recordDependencies(
+              dependencyKeys,
+              dependencyCollectionState.hasUnobservedComputedImport,
+            );
+          }
+          trackPendingCollection(collection);
+        }
+      }
+      return resolvedSpecifier;
+    },
+  });
+  let initialEvaluationComplete = false;
+  let configModule: object | undefined;
+  let loadFailure: { error: unknown } | undefined;
+  try {
+    configModule = await loadConfigFromTempFile(
+      source,
+      absolutePath,
+      (tempFile) => ReflectApply(intrinsicUrlHrefGetter, toFileUrl(tempFile), []) as string,
+      async (processedSource) => {
+        const rewritten = await rewriteProjectConfigImportsFromProject(
+          processedSource,
+          absolutePath,
+          (specifier) =>
+            collectBunProjectConfigDependencyKeys(
+              specifier,
+              scope,
+              dependencyKeys,
+              lexer,
+              fs,
+              dependencyCollectionState,
+            ),
+        );
+        return await rewriteComputedDynamicProjectConfigImports(rewritten, observerKey);
+      },
+    ) as object;
+  } catch (error) {
+    loadFailure = { error };
+  }
+
+  let trackingFailure: { error: unknown } | undefined;
+  try {
+    for (let index = 0; index < runtimeSpecifiers.length; index++) {
+      const specifier = runtimeSpecifiers[index];
+      if (specifier === undefined) continue;
+      await collectBunProjectConfigDependencyKeys(
+        specifier,
+        scope,
+        dependencyKeys,
+        lexer,
+        fs,
+        dependencyCollectionState,
+      );
+    }
+    recordDependencies(
+      dependencyKeys,
+      dependencyCollectionState.hasUnobservedComputedImport,
+    );
+    initialEvaluationComplete = true;
+  } catch (error) {
+    trackingFailure = { error };
+  }
+
+  if (loadFailure !== undefined || trackingFailure !== undefined) {
+    disposeObserver();
+    throw trackingFailure?.error ?? loadFailure!.error;
+  }
+  return {
+    configModule: configModule!,
+    observer: { key: observerKey, dispose: disposeObserver },
+  };
+}
+
+function isPathWithinDirectory(directory: string, candidate: string): boolean {
+  const relativeCandidate = relative(directory, candidate);
+  return relativeCandidate === "" ||
+    (relativeCandidate !== ".." && !stringStartsWith(relativeCandidate, "../") &&
+      !stringStartsWith(relativeCandidate, "..\\") && !isAbsolute(relativeCandidate));
+}
+
+type BunProjectTrackingScope = Readonly<{
+  lexicalDirectory: string;
+  canonicalDirectory: string;
+  projectDirectories: readonly string[];
+}>;
+
+function isPathWithinBunProjectScope(
+  scope: BunProjectTrackingScope,
+  candidate: string,
+): boolean {
+  return isPathWithinDirectory(scope.lexicalDirectory, candidate) ||
+    isPathWithinDirectory(scope.canonicalDirectory, candidate);
+}
+
+function bunProjectModuleCacheAliases(
+  scope: BunProjectTrackingScope,
+  candidate: string,
+): string[] {
+  const aliases: string[] = [];
+  for (let sourceIndex = 0; sourceIndex < scope.projectDirectories.length; sourceIndex++) {
+    const sourceDirectory = scope.projectDirectories[sourceIndex];
+    if (
+      sourceDirectory === undefined ||
+      !isPathWithinDirectory(sourceDirectory, candidate)
+    ) continue;
+    const projectRelative = relative(sourceDirectory, candidate);
+    for (let targetIndex = 0; targetIndex < scope.projectDirectories.length; targetIndex++) {
+      const targetDirectory = scope.projectDirectories[targetIndex];
+      if (targetDirectory === undefined || targetDirectory === sourceDirectory) continue;
+      aliases[aliases.length] = resolve(targetDirectory, projectRelative);
+    }
+    break;
+  }
+  return aliases;
+}
+
+function projectConfigFilePathFromSpecifier(specifier: string): string | undefined {
+  if (isAbsolute(specifier)) return resolve(specifier);
+  if (!stringStartsWith(specifier, "file:")) return undefined;
+  try {
+    return resolve(pathFromCapturedFileUrl(new IntrinsicURL(specifier)));
+  } catch {
+    return undefined;
+  }
+}
+
+async function collectBunProjectConfigDependencyKeys(
+  resolvedSpecifier: string,
+  scope: BunProjectTrackingScope,
+  dependencyKeys: Set<string>,
+  lexer: ModuleLexer,
+  fs: ReturnType<typeof createFileSystem>,
+  state: { hasUnobservedComputedImport: boolean },
+): Promise<void> {
+  const dependencyPath = projectConfigFilePathFromSpecifier(resolvedSpecifier);
+  if (
+    dependencyPath === undefined ||
+    !isPathWithinBunProjectScope(scope, dependencyPath) ||
+    ReflectApply(SetPrototypeHas, dependencyKeys, [dependencyPath]) === true
+  ) {
+    return;
+  }
+  ReflectApply(SetPrototypeAdd, dependencyKeys, [dependencyPath]);
+  try {
+    const canonicalDependencyPath = await realPath(dependencyPath);
+    ReflectApply(SetPrototypeAdd, dependencyKeys, [canonicalDependencyPath]);
+  } catch {
+    // Runtime loading remains authoritative for virtual and missing modules.
+  }
+
+  let source: string;
+  let imports: ReturnType<ModuleLexer["parse"]>;
+  try {
+    source = await fs.readTextFile(dependencyPath);
+    imports = lexer.parse(source);
+  } catch {
+    return;
+  }
+  const resolveSpecifier = await createProjectConfigImportResolver(dependencyPath);
+  for (let index = 0; index < imports.length; index++) {
+    const imported = imports[index];
+    const specifier = imported?.n;
+    if (specifier === undefined || specifier === null) {
+      if (imported !== undefined && imported.d >= 0) {
+        state.hasUnobservedComputedImport = true;
+      }
+      continue;
+    }
+    if (specifier === "veryfront") continue;
+
+    let resolved: string;
+    if (stringStartsWith(specifier, "file:")) {
+      resolved = specifier;
+    } else if (keepsConfigImportSpecifier(specifier)) {
+      continue;
+    } else {
+      try {
+        resolved = await resolveSpecifier(specifier);
+      } catch {
+        continue;
+      }
+    }
+
+    try {
+      await collectBunProjectConfigDependencyKeys(
+        resolved,
+        scope,
+        dependencyKeys,
+        lexer,
+        fs,
+        state,
+      );
+    } catch {
+      // Runtime loading remains authoritative for non-text and missing modules.
+    }
+  }
+}
+
+type BunProjectCacheSnapshot = Readonly<{
+  before: ReadonlySet<string>;
+  scope: BunProjectTrackingScope;
+  canonicalConfigPath: string;
+}>;
+
+/**
+ * Delete this config load's tracked modules, keeping only the ones an
+ * observable consumer still references.
+ *
+ * Retention follows `Module.children` edges from every module outside the
+ * tracked graph -- application modules loaded before or after the config
+ * alike. Bun records those edges only for CommonJS requires of CommonJS
+ * modules; an ES module never appears in `children`, so a consumer whose only
+ * reference is an ES-module dependency briefly keeps the old namespace while
+ * the next load creates a fresh one; the alternative -- preserving the whole
+ * graph whenever any project-local module appeared after config evaluation --
+ * would make config-helper invalidation dead code on every normal startup,
+ * where application modules always load after the config.
+ */
+/**
+ * Read a module-graph property from Bun's require cache. Bun's CommonJS
+ * `Module` exposes `children`, `filename`, and `id` through prototype
+ * accessors rather than own data properties, and the cache object itself
+ * reports `undefined` own-descriptor values for entries it serves through
+ * gets, so own-data access alone would blind graph walks to every runtime
+ * edge; the accessor fallback stays guarded because the cache can also hold
+ * plain objects.
+ */
+function bunModuleGraphValue(moduleValue: Record<string, unknown>, key: PropertyKey): unknown {
+  const own = ownDataValue(moduleValue as RuntimeReflectionRecord, key);
+  if (own.present && own.value !== undefined) return own.value;
+  try {
+    return reflectGet(moduleValue as RuntimeReflectionRecord, key);
+  } catch {
+    return undefined;
+  }
+}
+
+function evictBunProjectConfigModules(entry: BunProjectConfigModuleCacheEntry): void {
+  if (entry.dynamicImportObserver !== undefined) {
+    ReflectApply(entry.dynamicImportObserver.dispose, entry.dynamicImportObserver, []);
+  }
+  const ownedKeys = new IntrinsicSet<string>();
+  for (let index = 0; index < entry.keys.length; index++) {
+    const key = entry.keys[index];
+    if (key !== undefined) ReflectApply(SetPrototypeAdd, ownedKeys, [key]);
+  }
+  const retainedOwnedKeys = new IntrinsicSet<string>();
+  const retainedQueue: string[] = [];
+  const retainedOwners = new IntrinsicMap<string, Set<string>>();
+  const transferredKeys = new IntrinsicMap<string, Set<string>>();
+  const trackingOwnersForModule = (moduleKey: string): readonly string[] => {
+    const owners: string[] = [];
+    mapForEach(bunProjectConfigModuleTrackingEntries, (candidate, trackingKey) => {
+      if (candidate.cache !== entry.cache) return;
+      for (let index = 0; index < candidate.keys.length; index++) {
+        if (candidate.keys[index] !== moduleKey) continue;
+        owners[owners.length] = trackingKey;
+        return;
+      }
+    });
+    return owners;
+  };
+  const retainOwnedKey = (key: unknown, owners: readonly string[]): void => {
+    if (
+      typeof key !== "string" ||
+      ReflectApply(SetPrototypeHas, ownedKeys, [key]) !== true
+    ) return;
+    if (ReflectApply(SetPrototypeHas, retainedOwnedKeys, [key]) !== true) {
+      ReflectApply(SetPrototypeAdd, retainedOwnedKeys, [key]);
+      retainedQueue[retainedQueue.length] = key;
+    }
+    let keyOwners = mapGet(retainedOwners, key);
+    if (keyOwners === undefined) {
+      keyOwners = new IntrinsicSet<string>();
+      mapSet(retainedOwners, key, keyOwners);
+    }
+    for (let index = 0; index < owners.length; index++) {
+      const owner = owners[index];
+      if (owner === undefined) continue;
+      ReflectApply(SetPrototypeAdd, keyOwners, [owner]);
+      let keys = mapGet(transferredKeys, owner);
+      if (keys === undefined) {
+        keys = new IntrinsicSet<string>();
+        mapSet(transferredKeys, owner, keys);
+      }
+      ReflectApply(SetPrototypeAdd, keys, [key]);
+    }
+  };
+  const retainOwnedChildren = (moduleKey: string, owners: readonly string[]): void => {
+    const moduleValue = bunModuleGraphValue(entry.cache, moduleKey);
+    if (!isRecord(moduleValue)) return;
+    const children = bunModuleGraphValue(moduleValue, "children");
+    if (!ArrayIsArray(children)) return;
+    for (let childIndex = 0; childIndex < children.length; childIndex++) {
+      const child: unknown = children[childIndex];
+      if (!isRecord(child)) continue;
+      retainOwnedKey(bunModuleGraphValue(child, "filename"), owners);
+      retainOwnedKey(bunModuleGraphValue(child, "id"), owners);
+    }
+  };
+
+  // Seed retention with owned modules referenced by any external consumer.
+  // Then retain their owned descendants too: keeping a parent while deleting
+  // its child would split one live require graph across module generations.
+  const moduleKeys = ownKeys(entry.cache);
+  for (let moduleIndex = 0; moduleIndex < moduleKeys.length; moduleIndex++) {
+    const moduleKey = moduleKeys[moduleIndex];
+    if (
+      typeof moduleKey === "string" &&
+      ReflectApply(SetPrototypeHas, ownedKeys, [moduleKey]) !== true
+    ) {
+      retainOwnedChildren(moduleKey, trackingOwnersForModule(moduleKey));
+    }
+  }
+  for (let queueIndex = 0; queueIndex < retainedQueue.length; queueIndex++) {
+    const moduleKey = retainedQueue[queueIndex]!;
+    const owners = mapGet(retainedOwners, moduleKey);
+    const ownerList: string[] = [];
+    if (owners !== undefined) {
+      ReflectApply(SetPrototypeForEach, owners, [
+        (owner: string) => {
+          ownerList[ownerList.length] = owner;
+        },
+      ]);
+    }
+    retainOwnedChildren(moduleKey, ownerList);
+  }
+
+  // A tracked config that references another config's owned CommonJS module
+  // becomes that module's next owner. Without this transfer, the first entry
+  // retains the shared helper for the live peer but the peer cannot evict it
+  // later, leaving an unowned stale cache entry after both records are gone.
+  mapForEach(transferredKeys, (keys, trackingKey) => {
+    const owner = mapGet(bunProjectConfigModuleTrackingEntries, trackingKey);
+    if (owner === undefined || owner.cache !== entry.cache) return;
+    const nextKeys: string[] = [];
+    const seen = new IntrinsicSet<string>();
+    for (let index = 0; index < owner.keys.length; index++) {
+      const key = owner.keys[index];
+      if (key === undefined) continue;
+      nextKeys[nextKeys.length] = key;
+      ReflectApply(SetPrototypeAdd, seen, [key]);
+    }
+    ReflectApply(SetPrototypeForEach, keys, [
+      (key: string) => {
+        if (ReflectApply(SetPrototypeHas, seen, [key]) === true) return;
+        nextKeys[nextKeys.length] = key;
+        ReflectApply(SetPrototypeAdd, seen, [key]);
+      },
+    ]);
+    setBunProjectConfigModuleTracking(trackingKey, { ...owner, keys: nextKeys });
+  });
+
+  for (let index = 0; index < entry.keys.length; index++) {
+    const cacheKey = entry.keys[index];
+    if (
+      cacheKey !== undefined &&
+      ReflectApply(SetPrototypeHas, retainedOwnedKeys, [cacheKey]) !== true
+    ) {
+      ReflectApply(ReflectDeleteProperty, Reflect, [entry.cache, cacheKey]);
+    }
+  }
+}
+
+function clearBunProjectConfigModuleTracking(): void {
+  const unions = new IntrinsicMap<
+    Record<string, unknown>,
+    { keys: string[]; seen: Set<string>; projectDirectory: string }
+  >();
+  mapForEach(bunProjectConfigModuleTrackingEntries, (entry) => {
+    if (entry.dynamicImportObserver !== undefined) {
+      ReflectApply(entry.dynamicImportObserver.dispose, entry.dynamicImportObserver, []);
+    }
+    let union = mapGet(unions, entry.cache);
+    if (union === undefined) {
+      union = {
+        keys: [],
+        seen: new IntrinsicSet<string>(),
+        projectDirectory: entry.projectDirectory,
+      };
+      mapSet(unions, entry.cache, union);
+    }
+    for (let index = 0; index < entry.keys.length; index++) {
+      const key = entry.keys[index];
+      if (
+        key === undefined ||
+        ReflectApply(SetPrototypeHas, union.seen, [key]) === true
+      ) continue;
+      union.keys[union.keys.length] = key;
+      ReflectApply(SetPrototypeAdd, union.seen, [key]);
+    }
+  });
+
+  // Remove every tracking record before graph eviction so tracked configs do
+  // not falsely pin one another. Each require-cache union still retains keys
+  // referenced by genuine application modules outside the tracked union.
+  clearingBunProjectConfigModuleTracking = true;
+  try {
+    bunProjectConfigModuleCacheKeys.clear();
+  } finally {
+    clearingBunProjectConfigModuleTracking = false;
+  }
+  mapForEach(unions, (union, cache) => {
+    evictBunProjectConfigModules({
+      cache,
+      keys: union.keys,
+      projectDirectory: union.projectDirectory,
+    });
+  });
+}
+
+/** @internal Test-only Bun project-module eviction seam. */
+export function __evictBunProjectConfigModulesForTests(
+  entry: Readonly<{
+    cache: Record<string, unknown>;
+    keys: readonly string[];
+    projectDirectory: string;
+  }>,
+): void {
+  evictBunProjectConfigModules(entry);
+}
+
+function declaresBunWorkspaceMembers(value: unknown): boolean {
+  if (ArrayIsArray(value)) return true;
+  if (!isRecord(value)) return false;
+  const packages = ownDataValue(value, "packages");
+  return packages.present && ArrayIsArray(packages.value);
+}
+
+function bunWorkspaceMemberPatterns(value: unknown): readonly unknown[] {
+  if (ArrayIsArray(value)) return value;
+  if (isRecord(value)) {
+    const packages = ownDataValue(value, "packages");
+    if (packages.present && ArrayIsArray(packages.value)) return packages.value;
+  }
+  return [];
+}
+
+/**
+ * End index (exclusive) of the single-character glob token starting at
+ * `index`: a character class runs through its closing bracket, while every
+ * other token -- including an unclosed `[`, kept literal -- is one character.
+ */
+function bunWorkspaceSegmentTokenEnd(pattern: string, index: number): number {
+  if (pattern[index] !== "[") return index + 1;
+  let cursor = index + 1;
+  if (pattern[cursor] === "!" || pattern[cursor] === "^") cursor += 1;
+  // A `]` immediately after the (possibly negated) opening bracket is a
+  // literal class member, not the terminator.
+  if (pattern[cursor] === "]") cursor += 1;
+  while (cursor < pattern.length && pattern[cursor] !== "]") cursor += 1;
+  return cursor < pattern.length ? cursor + 1 : index + 1;
+}
+
+/** Whether the glob token spanning `[start, end)` matches one character. */
+function bunWorkspaceSegmentTokenMatches(
+  pattern: string,
+  start: number,
+  end: number,
+  char: string,
+): boolean {
+  const first = pattern[start];
+  if (end === start + 1) return first === "?" || first === char;
+  let cursor = start + 1;
+  let negated = false;
+  if (pattern[cursor] === "!" || pattern[cursor] === "^") {
+    negated = true;
+    cursor += 1;
+  }
+  const membersEnd = end - 1;
+  let matched = false;
+  while (cursor < membersEnd) {
+    const from = pattern[cursor];
+    if (pattern[cursor + 1] === "-" && cursor + 2 < membersEnd) {
+      const to = pattern[cursor + 2];
+      if (from !== undefined && to !== undefined && from <= char && char <= to) {
+        matched = true;
+      }
+      cursor += 3;
+    } else {
+      if (from === char) matched = true;
+      cursor += 1;
+    }
+  }
+  return matched !== negated;
+}
+
+/**
+ * Glob match for one path segment: `*` spans any run of characters, `?`
+ * matches exactly one, and `[...]` matches one character from a class with
+ * `[!...]`/`[^...]` negation and `a-z` ranges. Braces are expanded before
+ * segment matching, so `{` and `}` are literal here.
+ */
+function matchesBunWorkspaceSegment(pattern: string, segment: string): boolean {
+  let patternIndex = 0;
+  let segmentIndex = 0;
+  let starIndex = -1;
+  let starSegmentIndex = 0;
+  while (segmentIndex < segment.length) {
+    const char = segment[segmentIndex];
+    if (patternIndex < pattern.length && pattern[patternIndex] === "*") {
+      starIndex = patternIndex;
+      patternIndex += 1;
+      starSegmentIndex = segmentIndex;
+      continue;
+    }
+    if (patternIndex < pattern.length && char !== undefined) {
+      const tokenEnd = bunWorkspaceSegmentTokenEnd(pattern, patternIndex);
+      if (bunWorkspaceSegmentTokenMatches(pattern, patternIndex, tokenEnd, char)) {
+        patternIndex = tokenEnd;
+        segmentIndex += 1;
+        continue;
+      }
+    }
+    if (starIndex < 0) return false;
+    patternIndex = starIndex + 1;
+    starSegmentIndex += 1;
+    segmentIndex = starSegmentIndex;
+  }
+  while (patternIndex < pattern.length && pattern[patternIndex] === "*") patternIndex += 1;
+  return patternIndex === pattern.length;
+}
+
+/**
+ * Cap on concrete patterns produced by brace expansion, guarding against
+ * adversarial alternation blowup in a workspace manifest.
+ */
+const BUN_WORKSPACE_BRACE_EXPANSION_LIMIT = 64;
+
+/**
+ * Expand `{a,b}` alternations into concrete patterns, Bun-glob style. An
+ * alternative may span `/`, so expansion happens before segment splitting.
+ * Unmatched braces are kept literal, matching the segment matcher above.
+ */
+function expandBunWorkspaceBracePatterns(pattern: string, expanded: string[]): boolean {
+  if (expanded.length >= BUN_WORKSPACE_BRACE_EXPANSION_LIMIT) return false;
+  const open = stringIndexOf(pattern, "{");
+  if (open < 0) {
+    expanded[expanded.length] = pattern;
+    return true;
+  }
+  let depth = 0;
+  let close = -1;
+  for (let index = open; index < pattern.length; index++) {
+    const char = pattern[index];
+    if (char === "{") depth += 1;
+    else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        close = index;
+        break;
+      }
+    }
+  }
+  if (close < 0) {
+    expanded[expanded.length] = pattern;
+    return true;
+  }
+  const prefix = stringSlice(pattern, 0, open);
+  const suffix = stringSlice(pattern, close + 1);
+  let alternativeStart = open + 1;
+  depth = 0;
+  for (let index = open + 1; index <= close; index++) {
+    const char = pattern[index];
+    if (char === "{") depth += 1;
+    else if (char === "}" && index < close) depth -= 1;
+    else if ((char === "," && depth === 0) || index === close) {
+      const alternative = stringSlice(pattern, alternativeStart, index);
+      if (!expandBunWorkspaceBracePatterns(prefix + alternative + suffix, expanded)) {
+        return false;
+      }
+      alternativeStart = index + 1;
+    }
+  }
+  return true;
+}
+
+function matchesBunWorkspacePathSegments(
+  patternSegments: readonly string[],
+  pathSegments: readonly string[],
+  patternIndex: number,
+  pathIndex: number,
+  pathEnd: number,
+): boolean {
+  if (patternIndex >= patternSegments.length) return pathIndex === pathEnd;
+  const pattern = patternSegments[patternIndex];
+  if (pattern === undefined) return false;
+  if (pattern === "**") {
+    for (let skip = pathIndex; skip <= pathEnd; skip++) {
+      if (
+        matchesBunWorkspacePathSegments(
+          patternSegments,
+          pathSegments,
+          patternIndex + 1,
+          skip,
+          pathEnd,
+        )
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+  const segment = pathSegments[pathIndex];
+  if (pathIndex >= pathEnd || segment === undefined) return false;
+  if (!matchesBunWorkspaceSegment(pattern, segment)) return false;
+  return matchesBunWorkspacePathSegments(
+    patternSegments,
+    pathSegments,
+    patternIndex + 1,
+    pathIndex + 1,
+    pathEnd,
+  );
+}
+
+/**
+ * Whether `projectDirectory` sits inside a declared workspace member of
+ * `workspaceRoot`. A declaring ancestor is not enough on its own: a project
+ * nested under an unrelated repository whose root declares workspaces it does
+ * not belong to must not adopt that root's module-tracking scope. Negation
+ * patterns are ignored, erring toward the narrower config-directory scope.
+ */
+function isBunWorkspaceMemberDirectory(
+  workspaceRoot: string,
+  projectDirectory: string,
+  workspacesValue: unknown,
+): boolean {
+  const relativeProject = ReflectApply(
+    StringPrototypeReplaceAll,
+    relative(
+      workspaceRoot,
+      projectDirectory,
+    ),
+    ["\\", "/"],
+  ) as string;
+  if (relativeProject.length === 0 || stringStartsWith(relativeProject, "..")) return false;
+  const pathSegments = ReflectApply(StringPrototypeSplit, relativeProject, ["/"]) as string[];
+  const patterns = bunWorkspaceMemberPatterns(workspacesValue);
+  for (let index = 0; index < patterns.length; index++) {
+    const pattern = patterns[index];
+    if (typeof pattern !== "string" || pattern.length === 0) continue;
+    if (stringStartsWith(pattern, "!")) continue;
+    let normalized = ReflectApply(StringPrototypeReplaceAll, pattern, ["\\", "/"]) as string;
+    if (stringStartsWith(normalized, "./")) normalized = stringSlice(normalized, 2);
+    if (stringEndsWith(normalized, "/")) {
+      normalized = stringSlice(normalized, 0, normalized.length - 1);
+    }
+    if (normalized.length === 0) continue;
+    const bracePatterns: string[] = [];
+    if (!expandBunWorkspaceBracePatterns(normalized, bracePatterns)) {
+      // The pattern is valid but exceeds the defensive expansion budget.
+      // Widening to the declaring workspace root is conservative for cache
+      // invalidation and avoids silently excluding later alternatives.
+      return true;
+    }
+    for (let braceIndex = 0; braceIndex < bracePatterns.length; braceIndex++) {
+      const bracePattern = bracePatterns[braceIndex];
+      if (bracePattern === undefined || bracePattern.length === 0) continue;
+      const patternSegments = ReflectApply(StringPrototypeSplit, bracePattern, ["/"]) as string[];
+      // The member directory may be the project directory itself or any of its
+      // ancestors below the workspace root: a config nested inside a member
+      // still belongs to that member.
+      for (let pathEnd = 1; pathEnd <= pathSegments.length; pathEnd++) {
+        if (matchesBunWorkspacePathSegments(patternSegments, pathSegments, 0, 0, pathEnd)) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+/** @internal Test-only Bun workspace-membership seam. */
+export function __isBunWorkspaceMemberDirectoryForTests(
+  workspaceRoot: string,
+  projectDirectory: string,
+  workspacesValue: unknown,
+): boolean {
+  return isBunWorkspaceMemberDirectory(workspaceRoot, projectDirectory, workspacesValue);
+}
+
+/**
+ * Widen module ownership to the Bun workspace root when the project belongs to
+ * one. Hoisted workspace dependencies resolve into an ancestor `node_modules`
+ * or a sibling package directory, so tracking only descendants of the config
+ * directory would leave them cached — and stale — across config reloads. The
+ * The lexical and canonical ancestor chains are both inspected. A project
+ * reached through an out-of-tree symlink has no lexical workspace ancestor,
+ * while Bun resolves its modules through the physical workspace and its
+ * hoisted dependencies. Within either chain, the nearest ancestor that
+ * declares workspaces settles that chain's membership.
+ */
+async function findBunProjectWorkspaceScopeDirectory(
+  ancestorDirectory: string,
+  projectDirectory: string,
+): Promise<string | undefined> {
+  let directory = ancestorDirectory;
+  while (true) {
+    const parent = dirname(directory);
+    if (parent === directory) return undefined;
+    directory = parent;
+    let manifest: ProjectPackageManifest | undefined;
+    try {
+      manifest = await readProjectPackageManifest(directory);
+    } catch {
+      continue;
+    }
+    if (!manifest) continue;
+    const workspaces = ownDataValue(manifest.value, "workspaces");
+    if (workspaces.present && declaresBunWorkspaceMembers(workspaces.value)) {
+      return isBunWorkspaceMemberDirectory(directory, projectDirectory, workspaces.value)
+        ? directory
+        : undefined;
+    }
+  }
+}
+
+async function resolveBunProjectScopeDirectory(projectDirectory: string): Promise<string> {
+  const lexicalScope = await findBunProjectWorkspaceScopeDirectory(
+    projectDirectory,
+    projectDirectory,
+  );
+  if (lexicalScope !== undefined) return lexicalScope;
+
+  let canonicalProjectDirectory: string;
+  try {
+    canonicalProjectDirectory = await realPath(projectDirectory);
+  } catch {
+    return projectDirectory;
+  }
+  if (canonicalProjectDirectory === projectDirectory) return projectDirectory;
+  return await findBunProjectWorkspaceScopeDirectory(
+    canonicalProjectDirectory,
+    canonicalProjectDirectory,
+  ) ?? projectDirectory;
+}
+
+async function resolveBunProjectTrackingScope(
+  projectDirectory: string,
+): Promise<BunProjectTrackingScope> {
+  const lexicalDirectory = await resolveBunProjectScopeDirectory(projectDirectory);
+  const canonicalProjectDirectory = await realPath(projectDirectory);
+  const canonicalDirectory = await resolveBunProjectScopeDirectory(canonicalProjectDirectory);
+  const projectDirectories = [projectDirectory];
+  const lexicalParentDirectory = dirname(projectDirectory);
+  const canonicalParentDirectory = await realPath(lexicalParentDirectory);
+  if (isPathWithinDirectory(canonicalParentDirectory, canonicalProjectDirectory)) {
+    const lexicalTargetDirectory = resolve(
+      lexicalParentDirectory,
+      relative(canonicalParentDirectory, canonicalProjectDirectory),
+    );
+    if (lexicalTargetDirectory !== projectDirectory) {
+      projectDirectories[projectDirectories.length] = lexicalTargetDirectory;
+    }
+  }
+  if (
+    canonicalProjectDirectory !== projectDirectory &&
+    canonicalProjectDirectory !== projectDirectories[projectDirectories.length - 1]
+  ) {
+    projectDirectories[projectDirectories.length] = canonicalProjectDirectory;
+  }
+  return {
+    lexicalDirectory,
+    canonicalDirectory,
+    projectDirectories,
+  };
+}
+
+function prepareBunProjectConfigModules(
+  projectRequire: NodeJS.Require,
+  configPath: string,
+  canonicalConfigPath: string,
+  scope: BunProjectTrackingScope,
+): BunProjectCacheSnapshot {
+  const resolvedConfigPath = projectRequire.resolve(configPath);
+  // Deletion invokes the cache eviction hook, including when the tracking LRU
+  // discarded the entry earlier because it reached capacity.
+  bunProjectConfigModuleCacheKeys.delete(canonicalConfigPath);
+  ReflectApply(ReflectDeleteProperty, Reflect, [projectRequire.cache, resolvedConfigPath]);
+
+  const before = new IntrinsicSet<string>();
+  const cacheKeys = ownKeys(projectRequire.cache);
+  for (let index = 0; index < cacheKeys.length; index++) {
+    const cacheKey = cacheKeys[index];
+    if (typeof cacheKey === "string") {
+      ReflectApply(SetPrototypeAdd, before, [cacheKey]);
+    }
+  }
+  return { before, scope, canonicalConfigPath };
+}
+
+/**
+ * Widen the lexer-derived eligible set with runtime `Module.children` edges.
+ * The module lexer only sees static ESM imports, so a CommonJS dependency of
+ * an async config whose `require()` loads further project helpers leaves
+ * those helpers out of the eligible set; Bun records the CommonJS require
+ * edges in `children`, so walking them from every eligible module claims the
+ * full graph this config load introduced. Only modules new to this load and
+ * inside the tracking scope are added, keeping concurrent application loads
+ * out of the tracked graph.
+ */
+function expandBunEligibleDependencyKeys(
+  projectRequire: NodeJS.Require,
+  snapshot: BunProjectCacheSnapshot,
+  eligibleKeys: ReadonlySet<string>,
+): ReadonlySet<string> {
+  const expanded = new IntrinsicSet<string>();
+  const queue: string[] = [];
+  const include = (cacheKey: unknown): void => {
+    if (typeof cacheKey !== "string") return;
+    const resolvedKey = resolve(cacheKey);
+    if (
+      ReflectApply(SetPrototypeHas, expanded, [resolvedKey]) === true ||
+      ReflectApply(SetPrototypeHas, snapshot.before, [cacheKey]) === true ||
+      !isPathWithinBunProjectScope(snapshot.scope, cacheKey)
+    ) {
+      return;
+    }
+    ReflectApply(SetPrototypeAdd, expanded, [resolvedKey]);
+    queue[queue.length] = cacheKey;
+  };
+  const cacheKeys = ownKeys(projectRequire.cache);
+  for (let index = 0; index < cacheKeys.length; index++) {
+    const cacheKey = cacheKeys[index];
+    if (
+      typeof cacheKey === "string" &&
+      ReflectApply(SetPrototypeHas, eligibleKeys, [resolve(cacheKey)]) === true
+    ) {
+      include(cacheKey);
+    }
+  }
+  for (let queueIndex = 0; queueIndex < queue.length; queueIndex++) {
+    const moduleValue = bunModuleGraphValue(projectRequire.cache, queue[queueIndex]!);
+    if (!isRecord(moduleValue)) continue;
+    const children = bunModuleGraphValue(moduleValue, "children");
+    if (!ArrayIsArray(children)) continue;
+    for (let childIndex = 0; childIndex < children.length; childIndex++) {
+      const child: unknown = children[childIndex];
+      if (!isRecord(child)) continue;
+      include(bunModuleGraphValue(child, "filename"));
+      include(bunModuleGraphValue(child, "id"));
+    }
+  }
+  return expanded;
+}
+
+/** Collect only the project-local modules that this config load introduced. */
+function collectBunProjectConfigModules(
+  projectRequire: NodeJS.Require,
+  snapshot: BunProjectCacheSnapshot,
+  eligibleKeys?: ReadonlySet<string>,
+  prior?: BunProjectConfigModuleCacheEntry,
+  includeAllNewModules = false,
+): BunProjectConfigModuleCacheEntry {
+  const loadedKeys: string[] = [];
+  const loadedKeySet = new IntrinsicSet<string>();
+  if (prior !== undefined) {
+    for (let index = 0; index < prior.keys.length; index++) {
+      const cacheKey = prior.keys[index];
+      if (cacheKey === undefined) continue;
+      loadedKeys[loadedKeys.length] = cacheKey;
+      ReflectApply(SetPrototypeAdd, loadedKeySet, [cacheKey]);
+    }
+  }
+  const expandedEligibleKeys = eligibleKeys === undefined
+    ? undefined
+    : expandBunEligibleDependencyKeys(projectRequire, snapshot, eligibleKeys);
+  const cacheKeys = ownKeys(projectRequire.cache);
+  for (let index = 0; index < cacheKeys.length; index++) {
+    const cacheKey = cacheKeys[index];
+    if (
+      typeof cacheKey !== "string" ||
+      ReflectApply(SetPrototypeHas, snapshot.before, [cacheKey]) === true ||
+      !isPathWithinBunProjectScope(snapshot.scope, cacheKey) ||
+      (!includeAllNewModules && expandedEligibleKeys !== undefined &&
+        ReflectApply(SetPrototypeHas, expandedEligibleKeys, [resolve(cacheKey)]) !== true) ||
+      ReflectApply(SetPrototypeHas, loadedKeySet, [cacheKey]) === true
+    ) {
+      continue;
+    }
+    loadedKeys[loadedKeys.length] = cacheKey;
+    ReflectApply(SetPrototypeAdd, loadedKeySet, [cacheKey]);
+    const aliases = bunProjectModuleCacheAliases(snapshot.scope, cacheKey);
+    for (let aliasIndex = 0; aliasIndex < aliases.length; aliasIndex++) {
+      const alias = aliases[aliasIndex];
+      if (
+        alias === undefined ||
+        ReflectApply(SetPrototypeHas, snapshot.before, [alias]) === true ||
+        ReflectApply(SetPrototypeHas, loadedKeySet, [alias]) === true
+      ) continue;
+      try {
+        const moduleValue = ReflectApply(ReflectGet, Reflect, [projectRequire.cache, cacheKey]);
+        const aliasValue = ReflectApply(ReflectGet, Reflect, [projectRequire.cache, alias]);
+        if (moduleValue !== undefined && aliasValue === undefined) {
+          ReflectApply(ReflectSet, Reflect, [projectRequire.cache, alias, moduleValue]);
+        }
+        if (
+          moduleValue !== undefined &&
+          ReflectApply(ReflectGet, Reflect, [projectRequire.cache, alias]) === moduleValue
+        ) {
+          loadedKeys[loadedKeys.length] = alias;
+          ReflectApply(SetPrototypeAdd, loadedKeySet, [alias]);
+        }
+      } catch {
+        // Bun's cache remains authoritative if it refuses an alias.
+      }
+    }
+  }
+  if (expandedEligibleKeys !== undefined) {
+    ReflectApply(SetPrototypeForEach, expandedEligibleKeys, [
+      (eligibleKey: string) => {
+        const resolvedKey = resolve(eligibleKey);
+        if (
+          isPathWithinBunProjectScope(snapshot.scope, resolvedKey) &&
+          ReflectApply(SetPrototypeHas, snapshot.before, [resolvedKey]) !== true &&
+          ReflectApply(SetPrototypeHas, loadedKeySet, [resolvedKey]) !== true
+        ) {
+          loadedKeys[loadedKeys.length] = resolvedKey;
+          ReflectApply(SetPrototypeAdd, loadedKeySet, [resolvedKey]);
+        }
+      },
+    ]);
+  }
+  return {
+    cache: projectRequire.cache,
+    keys: loadedKeys,
+    projectDirectory: snapshot.scope.lexicalDirectory,
+    ...(prior?.dynamicImportObserver === undefined
+      ? {}
+      : { dynamicImportObserver: prior.dynamicImportObserver }),
+  };
+}
+
+async function serializeBunProjectConfigLoad<T>(
+  configPath: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const previous = mapGet(bunProjectConfigLoadTurns, configPath);
+  const turn = promiseWithResolvers<void>();
+  mapSet(bunProjectConfigLoadTurns, configPath, turn.promise);
+  try {
+    if (previous) await previous;
+    // A deferred computed import can finish runtime evaluation before its
+    // source walk has found every transitive dependency. Cache clearing
+    // disposes its observer; wait for that old walk (and its eviction) before
+    // a new revision loads modules that the old walk would otherwise delete.
+    while (true) {
+      const pending = mapGet(bunProjectConfigPendingDependencyCollections, configPath);
+      if (pending === undefined) break;
+      await pending;
+      if (mapGet(bunProjectConfigPendingDependencyCollections, configPath) === pending) {
+        mapDelete(bunProjectConfigPendingDependencyCollections, configPath);
+      }
+    }
+    return await operation();
+  } finally {
+    turn.resolve();
+    if (mapGet(bunProjectConfigLoadTurns, configPath) === turn.promise) {
+      mapDelete(bunProjectConfigLoadTurns, configPath);
+    }
+  }
 }
 
 async function loadAndMergeConfig(
   configPath: string,
   cacheKey: string,
   adapter: RuntimeAdapter,
+  revisionAtStart: number,
   selectedVirtualContent?: string | Uint8Array,
 ): Promise<VeryfrontConfig> {
   const isVirtualFS = isVirtualFilesystem(adapter.fs);
@@ -2976,24 +4948,117 @@ async function loadAndMergeConfig(
   if (isBun) {
     logger.debug("Using project config import for Bun", { configPath });
     const absolutePath = resolve(configPath);
-    const { createRequire } = await import("node:module");
-    const projectRequire = createRequire(toFileUrl(absolutePath));
-    // Bun ignores query strings when caching file modules. Its CommonJS bridge
-    // loads TypeScript and ESM config files with project-relative resolution,
-    // and deleting the exact cache entry gives edits and failed imports a real
-    // retry without copying into or writing beside the project.
-    ReflectApply(ReflectDeleteProperty, Reflect, [
-      projectRequire.cache,
-      projectRequire.resolve(absolutePath),
-    ]);
-    let configModule: object;
-    try {
-      configModule = projectRequire(absolutePath) as object;
-    } catch (error) {
-      if (!isBunAsyncModuleRequireError(error)) throw error;
-      configModule = await importFreshBunAsyncConfig(absolutePath);
-    }
-    return validateAndMergeConfig(selectConfigModuleValue(configModule));
+    const source = await createFileSystem().readTextFile(absolutePath);
+    const hasTopLevelAwait = await bunConfigHasTopLevelAwait(source, absolutePath);
+    const canonicalConfigPath = await realPath(absolutePath);
+    return await serializeBunProjectConfigLoad(canonicalConfigPath, async () => {
+      const { createRequire } = await import("node:module");
+      const projectRequire = createRequire(absolutePath);
+      // Bun ignores query strings when caching file modules, and its CommonJS
+      // cache entries expose no parent-to-child dependency graph. Track the
+      // project-local modules introduced by each config load so the next load
+      // can invalidate that graph without evicting unrelated application state.
+      // Ownership spans the Bun workspace root when the project is a workspace
+      // member, so hoisted workspace dependencies reload alongside the config.
+      const projectScope = await resolveBunProjectTrackingScope(dirname(absolutePath));
+      const cacheSnapshot = prepareBunProjectConfigModules(
+        projectRequire,
+        absolutePath,
+        canonicalConfigPath,
+        projectScope,
+      );
+      let configModule: object | undefined;
+      let trackingEntry: BunProjectConfigModuleCacheEntry | undefined;
+      let dynamicImportObserver: BunProjectDynamicImportObserver | undefined;
+      let trackingPublished = false;
+      try {
+        if (!hasTopLevelAwait) {
+          try {
+            configModule = projectRequire(absolutePath) as object;
+          } catch (error) {
+            if (!isBunAsyncModuleRequireError(error)) throw error;
+          } finally {
+            // The synchronous require can only add modules from this config's
+            // graph. Stage those keys before awaiting the fallback so concurrent
+            // application loads cannot be mistaken for config dependencies.
+            trackingEntry = collectBunProjectConfigModules(
+              projectRequire,
+              cacheSnapshot,
+              undefined,
+              trackingEntry,
+            );
+          }
+        }
+        if (configModule === undefined) {
+          const imported = await importFreshBunAsyncConfig(
+            absolutePath,
+            canonicalConfigPath,
+            source,
+            projectScope,
+            (dependencyKeys, includeAllNewModules) => {
+              trackingEntry = collectBunProjectConfigModules(
+                projectRequire,
+                cacheSnapshot,
+                dependencyKeys,
+                trackingEntry,
+                includeAllNewModules,
+              );
+              if (trackingPublished) {
+                const ownedEntry: BunProjectConfigModuleCacheEntry =
+                  dynamicImportObserver === undefined
+                    ? trackingEntry
+                    : { ...trackingEntry, dynamicImportObserver };
+                setBunProjectConfigModuleTracking(
+                  cacheSnapshot.canonicalConfigPath,
+                  ownedEntry,
+                );
+                trackingEntry = ownedEntry;
+              }
+            },
+            (dependencyKeys, includeAllNewModules) => {
+              const discardedEntry = collectBunProjectConfigModules(
+                projectRequire,
+                cacheSnapshot,
+                dependencyKeys,
+                trackingEntry,
+                includeAllNewModules,
+              );
+              evictBunProjectConfigModules(discardedEntry);
+              trackingEntry = undefined;
+            },
+          );
+          configModule = imported.configModule;
+          dynamicImportObserver = imported.observer;
+        }
+        const merged = validateAndMergeConfig(selectConfigModuleValue(configModule));
+        if (cacheRevision !== revisionAtStart) {
+          if (dynamicImportObserver !== undefined) {
+            ReflectApply(dynamicImportObserver.dispose, dynamicImportObserver, []);
+            dynamicImportObserver = undefined;
+          }
+          if (trackingEntry !== undefined) {
+            evictBunProjectConfigModules(trackingEntry);
+            trackingEntry = undefined;
+          }
+          return merged;
+        }
+        if (trackingEntry !== undefined) {
+          const ownedEntry: BunProjectConfigModuleCacheEntry = dynamicImportObserver === undefined
+            ? trackingEntry
+            : { ...trackingEntry, dynamicImportObserver };
+          setBunProjectConfigModuleTracking(cacheSnapshot.canonicalConfigPath, ownedEntry);
+          trackingEntry = ownedEntry;
+          trackingPublished = true;
+        }
+        return merged;
+      } catch (error) {
+        if (dynamicImportObserver !== undefined) {
+          ReflectApply(dynamicImportObserver.dispose, dynamicImportObserver, []);
+        }
+        if (trackingEntry !== undefined) evictBunProjectConfigModules(trackingEntry);
+        throw error;
+      }
+    });
   }
 
   // Compiled Deno binaries can't dynamically import TypeScript files directly.
@@ -3010,7 +5075,7 @@ async function loadAndMergeConfig(
     const userConfig = await loadConfigFromTempFile(
       source,
       absolutePath,
-      (tempFile) => toFileUrl(tempFile).href,
+      (tempFile) => ReflectApply(intrinsicUrlHrefGetter, toFileUrl(tempFile), []) as string,
       (processedSource) => rewriteProjectConfigImportsFromProject(processedSource, absolutePath),
     );
     logger.debug("Successfully loaded config via temp file", {
@@ -3024,7 +5089,9 @@ async function loadAndMergeConfig(
   const absolutePath = resolve(configPath);
   const configUrl = toFileUrl(absolutePath);
   configUrl.searchParams.set("t", `${Date.now()}-${crypto.randomUUID()}`);
-  const configModule = await import(configUrl.href);
+  const configModule = await import(
+    ReflectApply(intrinsicUrlHrefGetter, configUrl, []) as string
+  );
   return validateAndMergeConfig(selectConfigModuleValue(configModule));
 }
 
@@ -3351,6 +5418,13 @@ function getConfigInternal(
         ? configCacheByProject.get(effectiveCacheKey)
         : undefined;
       if (cached?.revision === revisionAtStart) {
+        if (!isVirtualFS) {
+          touchBunProjectConfigModuleTracking(
+            projectDir,
+            cached.provenance,
+            cached.bunTrackingKey,
+          );
+        }
         logger.debug("Cache HIT - using cached config", {
           cacheKey: effectiveCacheKey,
           isVirtualFS,
@@ -3476,6 +5550,7 @@ function getConfigInternal(
               configPath,
               effectiveCacheKey,
               adapter,
+              revisionAtStart,
               trustedVirtualContent,
             );
             const provenance = configFileProvenance(configFile);
@@ -3484,6 +5559,9 @@ function getConfigInternal(
                 revision: revisionAtStart,
                 config: merged,
                 provenance,
+                bunTrackingKey: isBun && !isVirtualFS
+                  ? await realPath(resolve(configPath))
+                  : undefined,
               });
             }
             logger.debug("Successfully loaded config", {
@@ -3702,6 +5780,7 @@ export function __getTrustedConfigFlightStateForTests(): Readonly<{
 export function clearConfigCache(): void {
   configCacheByProject.clear();
   hostedConfigFailureCacheByProject.clear();
+  clearBunProjectConfigModuleTracking();
   cacheRevision++;
 }
 
@@ -3716,5 +5795,6 @@ export function clearConfigCache(): void {
 export function getCachedConfigSync(projectDir: string): VeryfrontConfig | null {
   const cached = configCacheByProject.get(buildConfigCacheKey(projectDir, false));
   if (!cached || cached.revision !== cacheRevision) return null;
+  touchBunProjectConfigModuleTracking(projectDir, cached.provenance, cached.bunTrackingKey);
   return cached.config;
 }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -652,6 +652,11 @@ export interface ConfigLoadResult {
   readonly provenance: ConfigLoadProvenance;
 }
 
+interface MergedConfigLoadResult {
+  readonly config: VeryfrontConfig;
+  readonly bunTrackingKey?: string;
+}
+
 interface ConfigCacheEntry {
   readonly revision: number;
   readonly config: VeryfrontConfig;
@@ -3714,30 +3719,61 @@ async function rewriteDynamicProjectConfigImports(
   await lexer.init?.();
 
   const imports = lexer.parse(source);
-  const openingCounts = new IntrinsicMap<number, number>();
-  const closingCounts = new IntrinsicMap<number, number>();
-  let hasComputedImport = false;
+  const argumentOpeningCounts = new IntrinsicMap<number, number>();
+  const argumentClosingCounts = new IntrinsicMap<number, number>();
+  const importOpeningCounts = new IntrinsicMap<number, number>();
+  const importClosingCounts = new IntrinsicMap<number, number>();
+  let hasDynamicImport = false;
   for (let index = 0; index < imports.length; index++) {
     const imported = imports[index];
     if (!imported || imported.d < 0) continue;
-    hasComputedImport = true;
-    mapSet(openingCounts, imported.s, (mapGet(openingCounts, imported.s) ?? 0) + 1);
-    mapSet(closingCounts, imported.e, (mapGet(closingCounts, imported.e) ?? 0) + 1);
+    hasDynamicImport = true;
+    mapSet(
+      argumentOpeningCounts,
+      imported.s,
+      (mapGet(argumentOpeningCounts, imported.s) ?? 0) + 1,
+    );
+    mapSet(
+      argumentClosingCounts,
+      imported.e,
+      (mapGet(argumentClosingCounts, imported.e) ?? 0) + 1,
+    );
+    mapSet(
+      importOpeningCounts,
+      imported.ss,
+      (mapGet(importOpeningCounts, imported.ss) ?? 0) + 1,
+    );
+    mapSet(
+      importClosingCounts,
+      imported.se,
+      (mapGet(importClosingCounts, imported.se) ?? 0) + 1,
+    );
   }
-  if (!hasComputedImport) return source;
+  if (!hasDynamicImport) return source;
 
-  // Insert wrappers against offsets in the original source. Computed imports
+  // Insert wrappers against offsets in the original source. Dynamic imports
   // can nest, so rewriting one expression first would invalidate the lexer's
   // range for its containing import even when records are visited in reverse.
   let rewritten = "";
   let sourceOffset = 0;
   for (let position = 0; position <= source.length; position++) {
-    const openingCount = mapGet(openingCounts, position) ?? 0;
-    const closingCount = mapGet(closingCounts, position) ?? 0;
-    if (openingCount === 0 && closingCount === 0) continue;
+    const argumentOpeningCount = mapGet(argumentOpeningCounts, position) ?? 0;
+    const argumentClosingCount = mapGet(argumentClosingCounts, position) ?? 0;
+    const importOpeningCount = mapGet(importOpeningCounts, position) ?? 0;
+    const importClosingCount = mapGet(importClosingCounts, position) ?? 0;
+    if (
+      argumentOpeningCount === 0 && argumentClosingCount === 0 &&
+      importOpeningCount === 0 && importClosingCount === 0
+    ) continue;
     rewritten += stringSlice(source, sourceOffset, position);
-    for (let index = 0; index < closingCount; index++) rewritten += ")";
-    for (let index = 0; index < openingCount; index++) rewritten += `${observerKey}(`;
+    for (let index = 0; index < importClosingCount; index++) rewritten += ")";
+    for (let index = 0; index < argumentClosingCount; index++) rewritten += ")";
+    for (let index = 0; index < importOpeningCount; index++) {
+      rewritten += `${observerKey}.settle(`;
+    }
+    for (let index = 0; index < argumentOpeningCount; index++) {
+      rewritten += `${observerKey}.resolve(`;
+    }
     sourceOffset = position;
   }
   rewritten += stringSlice(source, sourceOffset);
@@ -3906,7 +3942,7 @@ function isBunAsyncModuleRequireError(error: unknown): boolean {
 interface BunAsyncConfigImportResult {
   readonly configModule: object;
   readonly observer: BunProjectDynamicImportObserver;
-  readonly hasComputedDynamicImport: boolean;
+  readonly hasDynamicImport: boolean;
 }
 
 async function importFreshBunAsyncConfig(
@@ -3914,25 +3950,13 @@ async function importFreshBunAsyncConfig(
   canonicalConfigPath: string,
   source: string,
   scope: BunProjectTrackingScope,
-  recordDependencies: (
-    dependencyKeys: ReadonlySet<string>,
-    includeAllNewModules: boolean,
-  ) => void,
-  discardDependencies: (
-    dependencyKeys: ReadonlySet<string>,
-    includeAllNewModules: boolean,
-  ) => void,
+  recordDependencies: (dependencyKeys: ReadonlySet<string>) => void,
+  discardDependencies: (dependencyKeys: ReadonlySet<string>) => void,
 ): Promise<BunAsyncConfigImportResult> {
   const fs = createFileSystem();
   const dependencyKeys = new IntrinsicSet<string>();
   const observedRuntimeSpecifiers = new IntrinsicSet<string>();
   const runtimeSpecifiers: string[] = [];
-  // Bun exposes no loader callback for a computed import executed inside an
-  // already-imported dependency. If the dependency lexer reports one, every
-  // new in-scope module from this serialized evaluation is a possible child.
-  // The eviction graph still preserves modules owned by outside CommonJS
-  // consumers.
-  const dependencyCollectionState = { hasUnobservedComputedImport: false };
   const lexer = await getConfigModuleLexer();
   let observerKey: string;
   do {
@@ -3952,15 +3976,9 @@ async function importFreshBunAsyncConfig(
   const trackPendingCollection = (collection: Promise<void>): void => {
     const finalize = (): void => {
       if (observerActive) {
-        recordDependencies(
-          dependencyKeys,
-          dependencyCollectionState.hasUnobservedComputedImport,
-        );
+        recordDependencies(dependencyKeys);
       } else {
-        discardDependencies(
-          dependencyKeys,
-          dependencyCollectionState.hasUnobservedComputedImport,
-        );
+        discardDependencies(dependencyKeys);
       }
     };
     const settled = thenPromise(collection, finalize, finalize);
@@ -3982,83 +4000,96 @@ async function importFreshBunAsyncConfig(
     void thenPromise(combined, release, release);
   };
   const baseUrl = ReflectApply(intrinsicUrlHrefGetter, toFileUrl(absolutePath), []) as string;
+  const resolveObservedSpecifier = (specifier: unknown): unknown => {
+    let stringSpecifier: string;
+    if (typeof specifier === "string") {
+      stringSpecifier = specifier;
+    } else {
+      // Dynamic import applies ToString with the string hint. Resolve that
+      // coerced value from the authored config rather than allowing Bun to
+      // coerce it later relative to the temporary staged module. A Symbol
+      // remains native so import() preserves its rejected-Promise behavior.
+      if (typeof specifier === "symbol") return specifier;
+      try {
+        stringSpecifier = ReflectApply(IntrinsicString, undefined, [specifier]) as string;
+      } catch (error) {
+        // The wrapper runs while evaluating import()'s argument, whereas
+        // native ToString failures reject the returned Promise. Hand Bun a
+        // one-shot coercion object so it produces the same asynchronous
+        // rejection without invoking authored coercion hooks twice.
+        const rejectedSpecifier = ObjectCreate(null) as Record<PropertyKey, unknown>;
+        ObjectDefineProperty(rejectedSpecifier, SymbolToPrimitive, {
+          value: () => {
+            throw error;
+          },
+        });
+        return rejectedSpecifier;
+      }
+    }
+    let resolvedSpecifier = stringSpecifier;
+    if (stringStartsWith(stringSpecifier, "./") || stringStartsWith(stringSpecifier, "../")) {
+      const resolvedUrl = new IntrinsicURL(stringSpecifier, baseUrl);
+      resolvedSpecifier = ReflectApply(intrinsicUrlHrefGetter, resolvedUrl, []) as string;
+    } else if (!keepsConfigImportSpecifier(stringSpecifier) && !isAbsolute(stringSpecifier)) {
+      if (!CapturedBunResolveSync || !CapturedBun) {
+        throw new TypeError("Bun project config resolver is unavailable");
+      }
+      const resolved = ReflectApply(CapturedBunResolveSync, CapturedBun, [
+        stringSpecifier,
+        dirname(absolutePath),
+      ]);
+      if (typeof resolved !== "string") {
+        throw new TypeError("Bun project config import resolution failed");
+      }
+      resolvedSpecifier = asResolvedConfigSpecifier(resolved);
+    }
+    if (
+      ReflectApply(SetPrototypeHas, observedRuntimeSpecifiers, [resolvedSpecifier]) !== true
+    ) {
+      ReflectApply(SetPrototypeAdd, observedRuntimeSpecifiers, [resolvedSpecifier]);
+      runtimeSpecifiers[runtimeSpecifiers.length] = resolvedSpecifier;
+      if (initialEvaluationComplete && observerActive) {
+        const collection = collectBunProjectConfigDependencyKeys(
+          resolvedSpecifier,
+          scope,
+          dependencyKeys,
+          lexer,
+          fs,
+        );
+        // The collector records the directly resolved path before its first
+        // await. Publish that key synchronously so an immediate cache clear
+        // after setup still owns the module; refresh again after transitive
+        // discovery completes.
+        if (observerActive) {
+          recordDependencies(dependencyKeys);
+        }
+        trackPendingCollection(collection);
+      }
+    }
+    return resolvedSpecifier;
+  };
+  const refreshObservedDependencies = (): void => {
+    if (observerActive) recordDependencies(dependencyKeys);
+    else discardDependencies(dependencyKeys);
+  };
+  const settleObservedImport = <T>(operation: Promise<T>): Promise<T> =>
+    thenPromise(
+      operation,
+      (value) => {
+        refreshObservedDependencies();
+        return value;
+      },
+      (error) => {
+        refreshObservedDependencies();
+        throw error;
+      },
+    );
   ObjectDefineProperty(globalThis, observerKey, {
     configurable: true,
-    value: (specifier: unknown): unknown => {
-      let stringSpecifier: string;
-      if (typeof specifier === "string") {
-        stringSpecifier = specifier;
-      } else {
-        // Dynamic import applies ToString with the string hint. Resolve that
-        // coerced value from the authored config rather than allowing Bun to
-        // coerce it later relative to the temporary staged module. A Symbol
-        // remains native so import() preserves its rejected-Promise behavior.
-        if (typeof specifier === "symbol") return specifier;
-        try {
-          stringSpecifier = ReflectApply(IntrinsicString, undefined, [specifier]) as string;
-        } catch (error) {
-          // The wrapper runs while evaluating import()'s argument, whereas
-          // native ToString failures reject the returned Promise. Hand Bun a
-          // one-shot coercion object so it produces the same asynchronous
-          // rejection without invoking authored coercion hooks twice.
-          const rejectedSpecifier = ObjectCreate(null) as Record<PropertyKey, unknown>;
-          ObjectDefineProperty(rejectedSpecifier, SymbolToPrimitive, {
-            value: () => {
-              throw error;
-            },
-          });
-          return rejectedSpecifier;
-        }
-      }
-      let resolvedSpecifier = stringSpecifier;
-      if (stringStartsWith(stringSpecifier, "./") || stringStartsWith(stringSpecifier, "../")) {
-        const resolvedUrl = new IntrinsicURL(stringSpecifier, baseUrl);
-        resolvedSpecifier = ReflectApply(intrinsicUrlHrefGetter, resolvedUrl, []) as string;
-      } else if (!keepsConfigImportSpecifier(stringSpecifier) && !isAbsolute(stringSpecifier)) {
-        if (!CapturedBunResolveSync || !CapturedBun) {
-          throw new TypeError("Bun project config resolver is unavailable");
-        }
-        const resolved = ReflectApply(CapturedBunResolveSync, CapturedBun, [
-          stringSpecifier,
-          dirname(absolutePath),
-        ]);
-        if (typeof resolved !== "string") {
-          throw new TypeError("Bun project config import resolution failed");
-        }
-        resolvedSpecifier = asResolvedConfigSpecifier(resolved);
-      }
-      if (
-        ReflectApply(SetPrototypeHas, observedRuntimeSpecifiers, [resolvedSpecifier]) !== true
-      ) {
-        ReflectApply(SetPrototypeAdd, observedRuntimeSpecifiers, [resolvedSpecifier]);
-        runtimeSpecifiers[runtimeSpecifiers.length] = resolvedSpecifier;
-        if (initialEvaluationComplete && observerActive) {
-          const collection = collectBunProjectConfigDependencyKeys(
-            resolvedSpecifier,
-            scope,
-            dependencyKeys,
-            lexer,
-            fs,
-            dependencyCollectionState,
-          );
-          // The collector records the directly resolved path before its first
-          // await. Publish that key synchronously so an immediate cache clear
-          // after setup still owns the module; refresh again after transitive
-          // discovery completes.
-          if (observerActive) {
-            recordDependencies(
-              dependencyKeys,
-              dependencyCollectionState.hasUnobservedComputedImport,
-            );
-          }
-          trackPendingCollection(collection);
-        }
-      }
-      return resolvedSpecifier;
-    },
+    value: { resolve: resolveObservedSpecifier, settle: settleObservedImport },
   });
   let initialEvaluationComplete = false;
-  let hasComputedDynamicImport = false;
+  let hasDynamicImport = false;
   let configModule: object | undefined;
   let loadFailure: { error: unknown } | undefined;
   try {
@@ -4077,14 +4108,10 @@ async function importFreshBunAsyncConfig(
               dependencyKeys,
               lexer,
               fs,
-              dependencyCollectionState,
             ),
         );
-        const observed = await rewriteDynamicProjectConfigImports(
-          rewritten,
-          observerKey,
-        );
-        hasComputedDynamicImport ||= observed !== rewritten;
+        const observed = await rewriteDynamicProjectConfigImports(rewritten, observerKey);
+        hasDynamicImport ||= observed !== rewritten;
         return observed;
       },
     ) as object;
@@ -4103,13 +4130,9 @@ async function importFreshBunAsyncConfig(
         dependencyKeys,
         lexer,
         fs,
-        dependencyCollectionState,
       );
     }
-    recordDependencies(
-      dependencyKeys,
-      dependencyCollectionState.hasUnobservedComputedImport,
-    );
+    recordDependencies(dependencyKeys);
     initialEvaluationComplete = true;
   } catch (error) {
     trackingFailure = { error };
@@ -4122,7 +4145,7 @@ async function importFreshBunAsyncConfig(
   return {
     configModule: configModule!,
     observer: { key: observerKey, dispose: disposeObserver },
-    hasComputedDynamicImport,
+    hasDynamicImport,
   };
 }
 
@@ -4193,7 +4216,6 @@ async function collectBunProjectConfigDependencyKeys(
   dependencyKeys: Set<string>,
   lexer: ModuleLexer,
   fs: ReturnType<typeof createFileSystem>,
-  state: { hasUnobservedComputedImport: boolean },
 ): Promise<void> {
   const dependencyPath = projectConfigFilePathFromSpecifier(resolvedSpecifier);
   if (
@@ -4223,12 +4245,7 @@ async function collectBunProjectConfigDependencyKeys(
   for (let index = 0; index < imports.length; index++) {
     const imported = imports[index];
     const specifier = imported?.n;
-    if (specifier === undefined || specifier === null) {
-      if (imported !== undefined && imported.d >= 0) {
-        state.hasUnobservedComputedImport = true;
-      }
-      continue;
-    }
+    if (specifier === undefined || specifier === null) continue;
     if (specifier === "veryfront") continue;
 
     let resolved: string;
@@ -4251,7 +4268,6 @@ async function collectBunProjectConfigDependencyKeys(
         dependencyKeys,
         lexer,
         fs,
-        state,
       );
     } catch {
       // Runtime loading remains authoritative for non-text and missing modules.
@@ -4644,19 +4660,19 @@ function matchesBunWorkspacePathSegments(
   patternIndex: number,
   pathIndex: number,
   pathEnd: number,
-  memo: Map<string, boolean> = new IntrinsicMap<string, boolean>(),
+  memo = new IntrinsicMap<number, boolean>(),
 ): boolean {
-  const key = `${patternIndex}\0${pathIndex}\0${pathEnd}`;
-  const cached = mapGet(memo, key);
-  if (cached !== undefined) return cached;
+  const memoKey = patternIndex * (pathEnd + 1) + pathIndex;
+  const memoized = mapGet(memo, memoKey);
+  if (memoized !== undefined) return memoized;
   if (patternIndex >= patternSegments.length) {
     const matched = pathIndex === pathEnd;
-    mapSet(memo, key, matched);
+    mapSet(memo, memoKey, matched);
     return matched;
   }
   const pattern = patternSegments[patternIndex];
   if (pattern === undefined) {
-    mapSet(memo, key, false);
+    mapSet(memo, memoKey, false);
     return false;
   }
   if (pattern === "**") {
@@ -4671,20 +4687,19 @@ function matchesBunWorkspacePathSegments(
           memo,
         )
       ) {
-        mapSet(memo, key, true);
+        mapSet(memo, memoKey, true);
         return true;
       }
     }
-    mapSet(memo, key, false);
+    mapSet(memo, memoKey, false);
     return false;
   }
   const segment = pathSegments[pathIndex];
-  if (pathIndex >= pathEnd || segment === undefined) {
-    mapSet(memo, key, false);
-    return false;
-  }
-  if (!matchesBunWorkspaceSegment(pattern, segment)) {
-    mapSet(memo, key, false);
+  if (
+    pathIndex >= pathEnd || segment === undefined ||
+    !matchesBunWorkspaceSegment(pattern, segment)
+  ) {
+    mapSet(memo, memoKey, false);
     return false;
   }
   const matched = matchesBunWorkspacePathSegments(
@@ -4695,7 +4710,7 @@ function matchesBunWorkspacePathSegments(
     pathEnd,
     memo,
   );
-  mapSet(memo, key, matched);
+  mapSet(memo, memoKey, matched);
   return matched;
 }
 
@@ -4720,9 +4735,8 @@ function isBunWorkspaceMemberDirectory(
     ["\\", "/"],
   ) as string;
   if (
-    relativeProject.length === 0 ||
-    relativeProject === ".." ||
-    stringStartsWith(relativeProject, "../")
+    relativeProject.length === 0 || relativeProject === ".." ||
+    stringStartsWith(relativeProject, "../") || isAbsolute(relativeProject)
   ) return false;
   const pathSegments = ReflectApply(StringPrototypeSplit, relativeProject, ["/"]) as string[];
   const patterns = bunWorkspaceMemberPatterns(workspacesValue);
@@ -5095,7 +5109,7 @@ async function loadAndMergeConfig(
   adapter: RuntimeAdapter,
   revisionAtStart: number,
   selectedVirtualContent?: string | Uint8Array,
-): Promise<VeryfrontConfig> {
+): Promise<MergedConfigLoadResult> {
   const isVirtualFS = isVirtualFilesystem(adapter.fs);
   logger.debug("loadAndMergeConfig called", {
     configPath,
@@ -5107,12 +5121,14 @@ async function loadAndMergeConfig(
 
   if (isVirtualFS) {
     logger.debug("Using trusted single-project virtual filesystem for config", { configPath });
-    return loadTrustedConfigFromVirtualFS(
-      configPath,
-      cacheKey,
-      adapter,
-      selectedVirtualContent,
-    );
+    return {
+      config: await loadTrustedConfigFromVirtualFS(
+        configPath,
+        cacheKey,
+        adapter,
+        selectedVirtualContent,
+      ),
+    };
   }
 
   if (isBun) {
@@ -5140,7 +5156,7 @@ async function loadAndMergeConfig(
       let configModule: object | undefined;
       let trackingEntry: BunProjectConfigModuleCacheEntry | undefined;
       let dynamicImportObserver: BunProjectDynamicImportObserver | undefined;
-      let hasComputedDynamicImport = false;
+      let hasDynamicImport = false;
       let trackingPublished = false;
       try {
         if (!hasTopLevelAwait) {
@@ -5166,13 +5182,12 @@ async function loadAndMergeConfig(
             canonicalConfigPath,
             source,
             projectScope,
-            (dependencyKeys, includeAllNewModules) => {
+            (dependencyKeys) => {
               trackingEntry = collectBunProjectConfigModules(
                 projectRequire,
                 cacheSnapshot,
                 dependencyKeys,
                 trackingEntry,
-                includeAllNewModules,
               );
               if (trackingPublished) {
                 const ownedEntry: BunProjectConfigModuleCacheEntry =
@@ -5186,13 +5201,12 @@ async function loadAndMergeConfig(
                 trackingEntry = ownedEntry;
               }
             },
-            (dependencyKeys, includeAllNewModules) => {
+            (dependencyKeys) => {
               const discardedEntry = collectBunProjectConfigModules(
                 projectRequire,
                 cacheSnapshot,
                 dependencyKeys,
                 trackingEntry,
-                includeAllNewModules,
               );
               evictBunProjectConfigModules(discardedEntry);
               trackingEntry = undefined;
@@ -5200,7 +5214,7 @@ async function loadAndMergeConfig(
           );
           configModule = imported.configModule;
           dynamicImportObserver = imported.observer;
-          hasComputedDynamicImport = imported.hasComputedDynamicImport;
+          hasDynamicImport = imported.hasDynamicImport;
         }
         const merged = validateAndMergeConfig(selectConfigModuleValue(configModule));
         if (cacheRevision !== revisionAtStart) {
@@ -5212,8 +5226,8 @@ async function loadAndMergeConfig(
             evictBunProjectConfigModules(trackingEntry);
             trackingEntry = undefined;
           }
-          if (hasComputedDynamicImport) throw BUN_PROJECT_CONFIG_LOAD_INVALIDATED;
-          return merged;
+          if (hasDynamicImport) throw BUN_PROJECT_CONFIG_LOAD_INVALIDATED;
+          return { config: merged, bunTrackingKey: canonicalConfigPath };
         }
         if (trackingEntry !== undefined) {
           const ownedEntry: BunProjectConfigModuleCacheEntry = dynamicImportObserver === undefined
@@ -5223,7 +5237,7 @@ async function loadAndMergeConfig(
           trackingEntry = ownedEntry;
           trackingPublished = true;
         }
-        return merged;
+        return { config: merged, bunTrackingKey: canonicalConfigPath };
       } catch (error) {
         if (dynamicImportObserver !== undefined) {
           ReflectApply(dynamicImportObserver.dispose, dynamicImportObserver, []);
@@ -5256,7 +5270,7 @@ async function loadAndMergeConfig(
       hasApp: !!(userConfig as Record<string, unknown>)?.app,
       hasRouter: !!(userConfig as Record<string, unknown>)?.router,
     });
-    return validateAndMergeConfig(userConfig);
+    return { config: validateAndMergeConfig(userConfig) };
   }
 
   const absolutePath = resolve(configPath);
@@ -5265,7 +5279,7 @@ async function loadAndMergeConfig(
   const configModule = await import(
     ReflectApply(intrinsicUrlHrefGetter, configUrl, []) as string
   );
-  return validateAndMergeConfig(selectConfigModuleValue(configModule));
+  return { config: validateAndMergeConfig(selectConfigModuleValue(configModule)) };
 }
 
 /**
@@ -5719,27 +5733,21 @@ function getConfigInternal(
           }
 
           try {
-            const merged = await loadAndMergeConfig(
+            const loaded = await loadAndMergeConfig(
               configPath,
               effectiveCacheKey,
               adapter,
               revisionAtStart,
               trustedVirtualContent,
             );
+            const merged = loaded.config;
             const provenance = configFileProvenance(configFile);
-            let bunTrackingKey: string | undefined;
-            if (usePersistentCache && isBun && !isVirtualFS) {
-              bunTrackingKey = await realPath(resolve(configPath));
-              if (cacheRevision !== revisionAtStart) {
-                throw BUN_PROJECT_CONFIG_LOAD_INVALIDATED;
-              }
-            }
             if (usePersistentCache && cacheRevision === revisionAtStart) {
               setConfigCacheEntry(effectiveCacheKey, {
                 revision: revisionAtStart,
                 config: merged,
                 provenance,
-                bunTrackingKey,
+                bunTrackingKey: loaded.bunTrackingKey,
               });
             }
             logger.debug("Successfully loaded config", {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -73,6 +73,7 @@ const IntrinsicMap = Map;
 const IntrinsicSet = Set;
 const ArrayIsArray = Array.isArray;
 const IntrinsicPromise = Promise;
+const IntrinsicString = String;
 const IntrinsicTextDecoder = TextDecoder;
 const IntrinsicErrorPrototype = Error.prototype;
 const IntrinsicObjectPrototype = Object.prototype;
@@ -3102,7 +3103,9 @@ function selectConditionalProjectExport(
     }
     return undefined;
   }
-  if (!isRecord(value)) throw new TypeError("Package export target is invalid");
+  if (!isRecord(value)) {
+    throw new InvalidProjectPackageTargetError("Package export target is invalid");
+  }
 
   const keys = ownKeys(value);
   // Node and Bun reject conditional maps whose keys are array indices before
@@ -3985,17 +3988,41 @@ async function importFreshBunAsyncConfig(
   ObjectDefineProperty(globalThis, observerKey, {
     configurable: true,
     value: (specifier: unknown): unknown => {
-      if (typeof specifier !== "string") return specifier;
-      let resolvedSpecifier = specifier;
-      if (stringStartsWith(specifier, "./") || stringStartsWith(specifier, "../")) {
-        const resolvedUrl = new IntrinsicURL(specifier, baseUrl);
+      let stringSpecifier: string;
+      if (typeof specifier === "string") {
+        stringSpecifier = specifier;
+      } else {
+        // Dynamic import applies ToString with the string hint. Resolve that
+        // coerced value from the authored config rather than allowing Bun to
+        // coerce it later relative to the temporary staged module. A Symbol
+        // remains native so import() preserves its rejected-Promise behavior.
+        if (typeof specifier === "symbol") return specifier;
+        try {
+          stringSpecifier = ReflectApply(IntrinsicString, undefined, [specifier]) as string;
+        } catch (error) {
+          // The wrapper runs while evaluating import()'s argument, whereas
+          // native ToString failures reject the returned Promise. Hand Bun a
+          // one-shot coercion object so it produces the same asynchronous
+          // rejection without invoking authored coercion hooks twice.
+          const rejectedSpecifier = ObjectCreate(null) as Record<PropertyKey, unknown>;
+          ObjectDefineProperty(rejectedSpecifier, SymbolToPrimitive, {
+            value: () => {
+              throw error;
+            },
+          });
+          return rejectedSpecifier;
+        }
+      }
+      let resolvedSpecifier = stringSpecifier;
+      if (stringStartsWith(stringSpecifier, "./") || stringStartsWith(stringSpecifier, "../")) {
+        const resolvedUrl = new IntrinsicURL(stringSpecifier, baseUrl);
         resolvedSpecifier = ReflectApply(intrinsicUrlHrefGetter, resolvedUrl, []) as string;
-      } else if (!keepsConfigImportSpecifier(specifier) && !isAbsolute(specifier)) {
+      } else if (!keepsConfigImportSpecifier(stringSpecifier) && !isAbsolute(stringSpecifier)) {
         if (!CapturedBunResolveSync || !CapturedBun) {
           throw new TypeError("Bun project config resolver is unavailable");
         }
         const resolved = ReflectApply(CapturedBunResolveSync, CapturedBun, [
-          specifier,
+          stringSpecifier,
           dirname(absolutePath),
         ]);
         if (typeof resolved !== "string") {

--- a/tests/bun/workspace-resolution.test.ts
+++ b/tests/bun/workspace-resolution.test.ts
@@ -471,6 +471,25 @@ describe("Bun workspace resolution", () => {
     }, { prefix: "vf-config-bun-computed-package-" });
   });
 
+  it("keeps a hashbang first when observing computed imports", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    await withTempDir(async (projectDir) => {
+      const configPath = `${projectDir}/veryfront.config.ts`;
+      const helperPath = `${projectDir}/hashbang-helper.ts`;
+      const source = "#!/usr/bin/env bun\n" +
+        'const dependency = "./hashbang-helper.ts";\n' +
+        "const { default: title } = await import(dependency);\n" +
+        "export default { title };\n";
+      await writeTextFile(configPath, source);
+      await writeTextFile(helperPath, 'export default "hashbang";\n');
+      adapter.fs.files.set(configPath, source);
+
+      assertEquals((await getConfig(projectDir, adapter)).title, "hashbang");
+    }, { prefix: "vf-config-bun-hashbang-computed-import-" });
+  });
+
   it("keeps computed dynamic imports usable in deferred config functions", async () => {
     clearConfigCache();
     ensureBuiltinSchemaValidator();

--- a/tests/bun/workspace-resolution.test.ts
+++ b/tests/bun/workspace-resolution.test.ts
@@ -702,6 +702,53 @@ describe("Bun workspace resolution", () => {
     }
   });
 
+  it("keeps canonical tracking while another config-cache alias still owns it", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    const loadMarker = `__vfBunAliasOwner_${crypto.randomUUID().replaceAll("-", "_")}`;
+    try {
+      await withTempDir(async (rootDir) => {
+        const physicalProjectDir = `${rootDir}/physical-project`;
+        const linkedProjectDir = `${rootDir}/linked-project`;
+        const physicalConfigPath = `${physicalProjectDir}/veryfront.config.ts`;
+        const linkedConfigPath = `${linkedProjectDir}/veryfront.config.ts`;
+        const helperPath = `${physicalProjectDir}/config-helper.cjs`;
+        const source = 'import title from "./config-helper.cjs";\nexport default { title };\n';
+        await mkdir(physicalProjectDir, { recursive: true });
+        await writeTextFile(physicalConfigPath, source);
+        await writeTextFile(
+          helperPath,
+          `globalThis[${JSON.stringify(loadMarker)}] = ` +
+            `(globalThis[${JSON.stringify(loadMarker)}] ?? 0) + 1;\n` +
+            `module.exports = "generation-" + globalThis[${JSON.stringify(loadMarker)}];\n`,
+        );
+        await symlink(physicalProjectDir, linkedProjectDir);
+        adapter.fs.files.set(physicalConfigPath, source);
+        adapter.fs.files.set(linkedConfigPath, source);
+
+        assertEquals((await getConfig(physicalProjectDir, adapter)).title, "generation-1");
+        assertEquals((await getConfig(linkedProjectDir, adapter)).title, "generation-2");
+
+        const cacheCapacity = __getBunProjectConfigModuleTrackingCapacityForTests();
+        for (let index = 0; index < cacheCapacity - 1; index++) {
+          await getConfig(`${rootDir}/defaults-${index}`, adapter);
+        }
+
+        // The physical cache key is now the LRU entry that left the config
+        // cache, while the linked key still owns the same canonical tracking
+        // record. Eviction must not split the helper into a third generation.
+        const projectRequire = createRequire(physicalConfigPath);
+        assertEquals(projectRequire(helperPath), "generation-2");
+        assertEquals((await getConfig(linkedProjectDir, adapter)).title, "generation-2");
+        assertEquals((globalThis as Record<string, unknown>)[loadMarker], 2);
+      }, { prefix: "vf-config-bun-alias-owner-" });
+    } finally {
+      clearConfigCache();
+      delete (globalThis as Record<string, unknown>)[loadMarker];
+    }
+  });
+
   it("reloads a CommonJS helper required by a top-level-await config dependency", async () => {
     clearConfigCache();
     ensureBuiltinSchemaValidator();
@@ -991,6 +1038,71 @@ describe("Bun workspace resolution", () => {
       gate.resolve();
       delete globals[activeMarker];
       delete globals[gateMarker];
+    }
+  });
+
+  it("retries an invalidated config before returning deferred computed imports", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    const activeMarker = `__vfBunDeferredInvalidatedActive_${
+      crypto.randomUUID().replaceAll("-", "_")
+    }`;
+    const gateMarker = `__vfBunDeferredInvalidatedGate_${crypto.randomUUID().replaceAll("-", "_")}`;
+    const resultMarker = `__vfBunDeferredInvalidatedResult_${
+      crypto.randomUUID().replaceAll("-", "_")
+    }`;
+    const gate = Promise.withResolvers<void>();
+    const globals = globalThis as Record<string, unknown>;
+    globals[gateMarker] = gate.promise;
+    try {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        const helperPath = `${projectDir}/deferred-helper.ts`;
+        const source = 'const dependency = "./deferred-helper.ts";\n' +
+          `globalThis[${JSON.stringify(activeMarker)}] = true;\n` +
+          `await globalThis[${JSON.stringify(gateMarker)}];\n` +
+          "export default { extensions: [{\n" +
+          '  name: "deferred-invalidated", version: "1", capabilities: [],\n' +
+          "  async setup() {\n" +
+          "    const { default: value } = await import(dependency);\n" +
+          `    globalThis[${JSON.stringify(resultMarker)}] = value;\n` +
+          "  },\n" +
+          "] };\n";
+        await writeTextFile(configPath, source);
+        await writeTextFile(helperPath, 'export default "before";\n');
+        adapter.fs.files.set(configPath, source);
+
+        const invalidatedLoad = getConfig(projectDir, adapter);
+        await waitFor(() => globals[activeMarker] === true);
+        await writeTextFile(helperPath, 'export default "after";\n');
+        clearConfigCache();
+        const currentLoad = getConfig(projectDir, adapter);
+        gate.resolve();
+
+        const invalidatedConfig = await invalidatedLoad;
+        await currentLoad;
+        const extension = invalidatedConfig.extensions?.[0] as {
+          setup?: () => Promise<void>;
+        };
+        await extension.setup?.();
+        assertEquals(globals[resultMarker], "after");
+
+        await writeTextFile(helperPath, 'export default "latest";\n');
+        clearConfigCache();
+        const latestConfig = await getConfig(projectDir, adapter);
+        const latestExtension = latestConfig.extensions?.[0] as {
+          setup?: () => Promise<void>;
+        };
+        await latestExtension.setup?.();
+        assertEquals(globals[resultMarker], "latest");
+      }, { prefix: "vf-config-bun-deferred-invalidated-" });
+    } finally {
+      gate.resolve();
+      clearConfigCache();
+      delete globals[activeMarker];
+      delete globals[gateMarker];
+      delete globals[resultMarker];
     }
   });
 

--- a/tests/bun/workspace-resolution.test.ts
+++ b/tests/bun/workspace-resolution.test.ts
@@ -1068,7 +1068,7 @@ describe("Bun workspace resolution", () => {
           "    const { default: value } = await import(dependency);\n" +
           `    globalThis[${JSON.stringify(resultMarker)}] = value;\n` +
           "  },\n" +
-          "] };\n";
+          "}] };\n";
         await writeTextFile(configPath, source);
         await writeTextFile(helperPath, 'export default "before";\n');
         adapter.fs.files.set(configPath, source);

--- a/tests/bun/workspace-resolution.test.ts
+++ b/tests/bun/workspace-resolution.test.ts
@@ -1,14 +1,20 @@
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { chmod, mkdir, writeTextFile } from "#veryfront/platform/compat/fs.ts";
-import { withTempDir } from "#veryfront/testing/deno-compat.ts";
+import { chmod, mkdir, symlink, writeTextFile } from "#veryfront/platform/compat/fs.ts";
+import { waitFor, withTempDir } from "#veryfront/testing/deno-compat.ts";
+import { toFileUrl } from "#veryfront/compat/path/index.ts";
+import { createRequire } from "node:module";
 import { MdxContentProcessor } from "@veryfront/ext-content-mdx";
 import {
   ensureBuiltinEvalReportExporterRegistry,
   ensureBuiltinLLMProviders,
   ensureBuiltinSchemaValidator,
 } from "#veryfront/extensions/builtin-extensions.ts";
-import { clearConfigCache, getConfig } from "#veryfront/config/loader.ts";
+import {
+  __getBunProjectConfigModuleTrackingCapacityForTests,
+  clearConfigCache,
+  getConfig,
+} from "#veryfront/config/loader.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 
 describe("Bun workspace resolution", () => {
@@ -74,6 +80,182 @@ describe("Bun workspace resolution", () => {
     }, { prefix: "vf-config-bun-reload-" });
   });
 
+  it("reloads a changed project config dependency after cache invalidation", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    await withTempDir(async (projectDir) => {
+      const configPath = `${projectDir}/veryfront.config.ts`;
+      const helperPath = `${projectDir}/config-helper.ts`;
+      const source = 'import title from "./config-helper.ts";\nexport default { title };\n';
+      await writeTextFile(configPath, source);
+      adapter.fs.files.set(configPath, source);
+
+      await writeTextFile(helperPath, 'export default "before";\n');
+      assertEquals((await getConfig(projectDir, adapter)).title, "before");
+
+      await writeTextFile(helperPath, 'export default "after";\n');
+      clearConfigCache();
+
+      assertEquals((await getConfig(projectDir, adapter)).title, "after");
+    }, { prefix: "vf-config-bun-dependency-reload-" });
+  });
+
+  it("evicts tracked config modules as soon as the config cache is cleared", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    const loadMarker = `__vfBunImmediateClear_${crypto.randomUUID().replaceAll("-", "_")}`;
+    try {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        const helperPath = `${projectDir}/config-helper.cjs`;
+        const source = 'import title from "./config-helper.cjs";\nexport default { title };\n';
+        const helperSource = (generation: string): string =>
+          `globalThis[${JSON.stringify(loadMarker)}] = ` +
+          `(globalThis[${JSON.stringify(loadMarker)}] ?? 0) + 1;\n` +
+          `module.exports = ${JSON.stringify(generation)} + "-" + ` +
+          `globalThis[${JSON.stringify(loadMarker)}];\n`;
+        await writeTextFile(configPath, source);
+        await writeTextFile(helperPath, helperSource("before"));
+        adapter.fs.files.set(configPath, source);
+
+        assertEquals((await getConfig(projectDir, adapter)).title, "before-1");
+
+        await writeTextFile(helperPath, helperSource("after"));
+        clearConfigCache();
+        const projectRequire = createRequire(configPath);
+
+        assertEquals(projectRequire(helperPath), "after-2");
+        assertEquals((await getConfig(projectDir, adapter)).title, "after-2");
+      }, { prefix: "vf-config-bun-immediate-clear-" });
+    } finally {
+      clearConfigCache();
+      delete (globalThis as Record<string, unknown>)[loadMarker];
+    }
+  });
+
+  it("reloads a changed hoisted workspace dependency after cache invalidation", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    await withTempDir(async (rootDir) => {
+      const projectDir = `${rootDir}/apps/site`;
+      const packageDir = `${rootDir}/node_modules/config-hoisted-dependency`;
+      const configPath = `${projectDir}/veryfront.config.ts`;
+      const source = 'import title from "config-hoisted-dependency";\nexport default { title };\n';
+      await mkdir(projectDir, { recursive: true });
+      await mkdir(packageDir, { recursive: true });
+      await writeTextFile(
+        `${rootDir}/package.json`,
+        JSON.stringify({ name: "workspace-root", workspaces: ["apps/*"] }),
+      );
+      await writeTextFile(
+        `${packageDir}/package.json`,
+        JSON.stringify({
+          name: "config-hoisted-dependency",
+          type: "module",
+          exports: "./index.js",
+        }),
+      );
+      await writeTextFile(configPath, source);
+      adapter.fs.files.set(configPath, source);
+
+      await writeTextFile(`${packageDir}/index.js`, 'export default "before";\n');
+      assertEquals((await getConfig(projectDir, adapter)).title, "before");
+
+      await writeTextFile(`${packageDir}/index.js`, 'export default "after";\n');
+      clearConfigCache();
+
+      assertEquals((await getConfig(projectDir, adapter)).title, "after");
+    }, { prefix: "vf-config-bun-hoisted-dependency-reload-" });
+  });
+
+  it("reloads hoisted dependencies through an out-of-tree workspace symlink", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    await withTempDir(async (rootDir) => {
+      const physicalProjectDir = `${rootDir}/apps/site`;
+      const linkedProjectDir = `${rootDir}/linked-site`;
+      const packageDir = `${rootDir}/node_modules/config-symlinked-hoisted-dependency`;
+      const configPath = `${linkedProjectDir}/veryfront.config.ts`;
+      const physicalConfigPath = `${physicalProjectDir}/veryfront.config.ts`;
+      const source =
+        'import title from "config-symlinked-hoisted-dependency";\nexport default { title };\n';
+      await mkdir(physicalProjectDir, { recursive: true });
+      await mkdir(packageDir, { recursive: true });
+      await writeTextFile(
+        `${rootDir}/package.json`,
+        JSON.stringify({ name: "workspace-root", workspaces: ["apps/*"] }),
+      );
+      await writeTextFile(
+        `${packageDir}/package.json`,
+        JSON.stringify({
+          name: "config-symlinked-hoisted-dependency",
+          type: "module",
+          exports: "./index.js",
+        }),
+      );
+      await writeTextFile(physicalConfigPath, source);
+      await symlink(physicalProjectDir, linkedProjectDir);
+      adapter.fs.files.set(configPath, source);
+
+      await writeTextFile(`${packageDir}/index.js`, 'export default "before";\n');
+      assertEquals((await getConfig(linkedProjectDir, adapter)).title, "before");
+
+      await writeTextFile(`${packageDir}/index.js`, 'export default "after";\n');
+      clearConfigCache();
+
+      assertEquals((await getConfig(linkedProjectDir, adapter)).title, "after");
+    }, { prefix: "vf-config-bun-symlinked-hoisted-dependency-" });
+  });
+
+  it("transfers a shared CommonJS helper between tracked workspace configs", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    await withTempDir(async (rootDir) => {
+      const firstProjectDir = `${rootDir}/apps/first`;
+      const secondProjectDir = `${rootDir}/apps/second`;
+      const firstConfigPath = `${firstProjectDir}/veryfront.config.ts`;
+      const secondConfigPath = `${secondProjectDir}/veryfront.config.ts`;
+      const helperPath = `${rootDir}/shared-helper.cjs`;
+      const source = 'import title from "../../shared-helper.cjs";\nexport default { title };\n';
+      await mkdir(firstProjectDir, { recursive: true });
+      await mkdir(secondProjectDir, { recursive: true });
+      await writeTextFile(
+        `${rootDir}/package.json`,
+        JSON.stringify({ name: "workspace-root", workspaces: ["apps/*"] }),
+      );
+      await writeTextFile(firstConfigPath, source);
+      await writeTextFile(secondConfigPath, source);
+      adapter.fs.files.set(firstConfigPath, source);
+      adapter.fs.files.set(secondConfigPath, source);
+
+      await writeTextFile(helperPath, 'module.exports = "before";\n');
+      assertEquals((await getConfig(firstProjectDir, adapter)).title, "before");
+      assertEquals((await getConfig(secondProjectDir, adapter)).title, "before");
+
+      const trackingCapacity = __getBunProjectConfigModuleTrackingCapacityForTests();
+      for (let index = 0; index < trackingCapacity - 1; index++) {
+        const fillerDir = `${rootDir}/filler-${index}`;
+        const fillerConfigPath = `${fillerDir}/veryfront.config.ts`;
+        const fillerSource = `export default { title: "filler-${index}" };\n`;
+        await mkdir(fillerDir, { recursive: true });
+        await writeTextFile(fillerConfigPath, fillerSource);
+        adapter.fs.files.set(fillerConfigPath, fillerSource);
+        await getConfig(fillerDir, adapter);
+      }
+
+      assertEquals((await getConfig(secondProjectDir, adapter)).title, "before");
+      await writeTextFile(helperPath, 'module.exports = "after";\n');
+      clearConfigCache();
+
+      assertEquals((await getConfig(firstProjectDir, adapter)).title, "after");
+    }, { prefix: "vf-config-bun-shared-config-helper-" });
+  });
+
   it("recovers after a missing project dependency is installed", async () => {
     clearConfigCache();
     ensureBuiltinSchemaValidator();
@@ -104,6 +286,29 @@ describe("Bun workspace resolution", () => {
     }, { prefix: "vf-config-bun-recovery-" });
   });
 
+  it("reloads dependencies retained by a failed config evaluation", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    await withTempDir(async (projectDir) => {
+      const configPath = `${projectDir}/veryfront.config.ts`;
+      const helperPath = `${projectDir}/config-helper.ts`;
+      const source = 'import title from "./config-helper.ts";\n' +
+        'if (title === "before") throw new Error("stale helper");\n' +
+        "export default { title };\n";
+      await writeTextFile(configPath, source);
+      adapter.fs.files.set(configPath, source);
+
+      await writeTextFile(helperPath, 'export default "before";\n');
+      await assertRejects(() => getConfig(projectDir, adapter), Error);
+
+      await writeTextFile(helperPath, 'export default "after";\n');
+      clearConfigCache();
+
+      assertEquals((await getConfig(projectDir, adapter)).title, "after");
+    }, { prefix: "vf-config-bun-failed-dependency-reload-" });
+  });
+
   it("reloads a changed project config that uses top-level await", async () => {
     clearConfigCache();
     ensureBuiltinSchemaValidator();
@@ -125,5 +330,719 @@ describe("Bun workspace resolution", () => {
 
       assertEquals((await getConfig(projectDir, adapter)).title, "after");
     }, { prefix: "vf-config-bun-top-level-await-" });
+  });
+
+  it("evaluates the synchronous prefix of a top-level-await config once", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    const executionMarker = `__vfBunTlaExecution_${crypto.randomUUID().replaceAll("-", "_")}`;
+    try {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        const source = `globalThis[${JSON.stringify(executionMarker)}] = ` +
+          `(globalThis[${JSON.stringify(executionMarker)}] ?? 0) + 1;\n` +
+          "await Promise.resolve();\n" +
+          `export default { title: String(globalThis[${JSON.stringify(executionMarker)}]) };\n`;
+        await writeTextFile(configPath, source);
+        adapter.fs.files.set(configPath, source);
+
+        assertEquals((await getConfig(projectDir, adapter)).title, "1");
+        assertEquals((globalThis as Record<string, unknown>)[executionMarker], 1);
+      }, { prefix: "vf-config-bun-tla-single-execution-" });
+    } finally {
+      clearConfigCache();
+      delete (globalThis as Record<string, unknown>)[executionMarker];
+    }
+  });
+
+  it("reloads a changed transitive dynamic dependency of a top-level-await config", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    await withTempDir(async (projectDir) => {
+      const configPath = `${projectDir}/veryfront.config.ts`;
+      const entryPath = `${projectDir}/config-entry.ts`;
+      const helperPath = `${projectDir}/config-helper.ts`;
+      const source = "await Promise.resolve();\n" +
+        'const { default: title } = await import("./config-entry.ts");\n' +
+        "export default { title };\n";
+      await writeTextFile(configPath, source);
+      adapter.fs.files.set(configPath, source);
+      await writeTextFile(
+        entryPath,
+        'import title from "./config-helper.ts";\nexport default title;\n',
+      );
+
+      await writeTextFile(helperPath, 'export default "before";\n');
+      assertEquals((await getConfig(projectDir, adapter)).title, "before");
+
+      await writeTextFile(helperPath, 'export default "after";\n');
+      clearConfigCache();
+
+      assertEquals((await getConfig(projectDir, adapter)).title, "after");
+    }, { prefix: "vf-config-bun-tla-dependency-reload-" });
+  });
+
+  it("reloads a computed dynamic dependency of a top-level-await config", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    await withTempDir(async (projectDir) => {
+      const configPath = `${projectDir}/veryfront.config.ts`;
+      const helperPath = `${projectDir}/config-helper.ts`;
+      const source = 'const dependency = "./config-helper.ts";\n' +
+        "const { default: title } = await import(dependency);\n" +
+        "export default { title };\n";
+      await writeTextFile(configPath, source);
+      adapter.fs.files.set(configPath, source);
+
+      await writeTextFile(helperPath, 'export default "before";\n');
+      assertEquals((await getConfig(projectDir, adapter)).title, "before");
+
+      await writeTextFile(helperPath, 'export default "after";\n');
+      clearConfigCache();
+
+      assertEquals((await getConfig(projectDir, adapter)).title, "after");
+    }, { prefix: "vf-config-bun-computed-dependency-reload-" });
+  });
+
+  it("observes computed imports when the config shadows globalThis", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    await withTempDir(async (projectDir) => {
+      const configPath = `${projectDir}/veryfront.config.ts`;
+      const source = "const globalThis = {};\n" +
+        'const dependency = "data:text/javascript,export default %27shadow-safe%27";\n' +
+        "const { default: title } = await import(dependency);\n" +
+        "export default { title };\n";
+      await writeTextFile(configPath, source);
+      adapter.fs.files.set(configPath, source);
+
+      assertEquals((await getConfig(projectDir, adapter)).title, "shadow-safe");
+    }, { prefix: "vf-config-bun-shadowed-global-observer-" });
+  });
+
+  it("rewrites overlapping nested computed-import ranges", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    await withTempDir(async (projectDir) => {
+      const configPath = `${projectDir}/veryfront.config.ts`;
+      const finalModule = "data:text/javascript,export default 'nested-import'";
+      const innerModule = "data:text/javascript," +
+        encodeURIComponent(`export default ${JSON.stringify(finalModule)};`);
+      const source = `const dependency = ${JSON.stringify(innerModule)};\n` +
+        "const { default: title } = " +
+        "await import((await import(dependency)).default);\n" +
+        "export default { title };\n";
+      await writeTextFile(configPath, source);
+      adapter.fs.files.set(configPath, source);
+
+      assertEquals((await getConfig(projectDir, adapter)).title, "nested-import");
+    }, { prefix: "vf-config-bun-nested-computed-import-" });
+  });
+
+  it("resolves computed bare imports from the original project", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    await withTempDir(async (projectDir) => {
+      const configPath = `${projectDir}/veryfront.config.ts`;
+      const packageDir = `${projectDir}/node_modules/config-computed-package`;
+      const source = 'const dependency = "config-computed-package";\n' +
+        "const { default: title } = await import(dependency);\n" +
+        "export default { title };\n";
+      await mkdir(packageDir, { recursive: true });
+      await writeTextFile(
+        `${packageDir}/package.json`,
+        JSON.stringify({
+          name: "config-computed-package",
+          type: "module",
+          exports: "./index.js",
+        }),
+      );
+      await writeTextFile(`${packageDir}/index.js`, 'export default "project-package";\n');
+      await writeTextFile(configPath, source);
+      adapter.fs.files.set(configPath, source);
+
+      assertEquals((await getConfig(projectDir, adapter)).title, "project-package");
+    }, { prefix: "vf-config-bun-computed-package-" });
+  });
+
+  it("keeps computed dynamic imports usable in deferred config functions", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    const resultMarker = `__vfBunDeferredConfigImport_${crypto.randomUUID().replaceAll("-", "_")}`;
+    try {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        const helperPath = `${projectDir}/deferred-helper.ts`;
+        const source = `const dependency = "./deferred-helper.ts";\n` +
+          "await Promise.resolve();\n" +
+          "export default { extensions: [{\n" +
+          '  name: "deferred-import", version: "1", capabilities: [],\n' +
+          "  async setup() {\n" +
+          "    const { default: value } = await import(dependency);\n" +
+          `    globalThis[${JSON.stringify(resultMarker)}] = value;\n` +
+          "  },\n" +
+          "}] };\n";
+        await writeTextFile(configPath, source);
+        await writeTextFile(helperPath, 'export default "before";\n');
+        adapter.fs.files.set(configPath, source);
+
+        const config = await getConfig(projectDir, adapter);
+        const extension = config.extensions?.[0] as { setup?: () => Promise<void> };
+        await extension.setup?.();
+
+        assertEquals((globalThis as Record<string, unknown>)[resultMarker], "before");
+
+        await writeTextFile(helperPath, 'export default "after";\n');
+        clearConfigCache();
+        const reloaded = await getConfig(projectDir, adapter);
+        const reloadedExtension = reloaded.extensions?.[0] as {
+          setup?: () => Promise<void>;
+        };
+        await reloadedExtension.setup?.();
+
+        assertEquals((globalThis as Record<string, unknown>)[resultMarker], "after");
+      }, { prefix: "vf-config-bun-deferred-computed-import-" });
+    } finally {
+      delete (globalThis as Record<string, unknown>)[resultMarker];
+    }
+  });
+
+  it("evicts transitive deferred imports discovered after cache clearing", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    const clearMarker = `__vfBunDeferredClear_${crypto.randomUUID().replaceAll("-", "_")}`;
+    const resultMarker = `__vfBunDeferredTransitive_${crypto.randomUUID().replaceAll("-", "_")}`;
+    let clearOnce = true;
+    const globals = globalThis as Record<string, unknown>;
+    globals[clearMarker] = () => {
+      if (!clearOnce) return;
+      clearOnce = false;
+      clearConfigCache();
+    };
+    try {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        const entryPath = `${projectDir}/deferred-entry.ts`;
+        const helperPath = `${projectDir}/deferred-helper.ts`;
+        const source = `const dependency = "./deferred-entry.ts";\n` +
+          "await Promise.resolve();\n" +
+          "export default { extensions: [{\n" +
+          '  name: "deferred-transitive", version: "1", capabilities: [],\n' +
+          "  async setup() {\n" +
+          "    const { default: value } = await import(dependency);\n" +
+          `    globalThis[${JSON.stringify(resultMarker)}] = value;\n` +
+          "  },\n" +
+          "}] };\n";
+        await writeTextFile(configPath, source);
+        await writeTextFile(
+          entryPath,
+          'import value from "./deferred-helper.ts";\nexport default value;\n',
+        );
+        await writeTextFile(
+          helperPath,
+          `globalThis[${JSON.stringify(clearMarker)}]();\nexport default "before";\n`,
+        );
+        adapter.fs.files.set(configPath, source);
+
+        const config = await getConfig(projectDir, adapter);
+        const extension = config.extensions?.[0] as { setup?: () => Promise<void> };
+        await extension.setup?.();
+        assertEquals(globals[resultMarker], "before");
+
+        await writeTextFile(helperPath, 'export default "after";\n');
+        const reloaded = await getConfig(projectDir, adapter);
+        const reloadedExtension = reloaded.extensions?.[0] as {
+          setup?: () => Promise<void>;
+        };
+        await reloadedExtension.setup?.();
+        assertEquals(globals[resultMarker], "after");
+      }, { prefix: "vf-config-bun-deferred-transitive-clear-" });
+    } finally {
+      clearConfigCache();
+      delete globals[clearMarker];
+      delete globals[resultMarker];
+    }
+  });
+
+  it("resolves deferred computed bare imports from the original project", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    const resultMarker = `__vfBunDeferredBareImport_${crypto.randomUUID().replaceAll("-", "_")}`;
+    try {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        const packageDir = `${projectDir}/node_modules/config-deferred-package`;
+        const source = 'const dependency = "config-deferred-package";\n' +
+          "await Promise.resolve();\n" +
+          "export default { extensions: [{\n" +
+          '  name: "deferred-bare-import", version: "1", capabilities: [],\n' +
+          "  async setup() {\n" +
+          "    const { default: value } = await import(dependency);\n" +
+          `    globalThis[${JSON.stringify(resultMarker)}] = value;\n` +
+          "  },\n" +
+          "}] };\n";
+        await mkdir(packageDir, { recursive: true });
+        await writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({
+            name: "config-deferred-package",
+            type: "module",
+            exports: "./index.js",
+          }),
+        );
+        await writeTextFile(`${packageDir}/index.js`, 'export default "deferred-package";\n');
+        await writeTextFile(configPath, source);
+        adapter.fs.files.set(configPath, source);
+
+        const config = await getConfig(projectDir, adapter);
+        const extension = config.extensions?.[0] as { setup?: () => Promise<void> };
+        await extension.setup?.();
+
+        assertEquals((globalThis as Record<string, unknown>)[resultMarker], "deferred-package");
+      }, { prefix: "vf-config-bun-deferred-bare-import-" });
+    } finally {
+      clearConfigCache();
+      delete (globalThis as Record<string, unknown>)[resultMarker];
+    }
+  });
+
+  it("reloads config dependencies through a symlinked project directory", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    await withTempDir(async (rootDir) => {
+      const physicalProjectDir = `${rootDir}/physical-project`;
+      const linkedProjectDir = `${rootDir}/linked-project`;
+      const configPath = `${linkedProjectDir}/veryfront.config.ts`;
+      const physicalConfigPath = `${physicalProjectDir}/veryfront.config.ts`;
+      const helperPath = `${physicalProjectDir}/config-helper.ts`;
+      const source = 'import title from "./config-helper.ts";\nexport default { title };\n';
+      await mkdir(physicalProjectDir, { recursive: true });
+      await writeTextFile(physicalConfigPath, source);
+      await writeTextFile(helperPath, 'export default "before";\n');
+      await symlink(physicalProjectDir, linkedProjectDir);
+      adapter.fs.files.set(configPath, source);
+
+      assertEquals((await getConfig(linkedProjectDir, adapter)).title, "before");
+
+      await writeTextFile(helperPath, 'export default "after";\n');
+      clearConfigCache();
+
+      assertEquals((await getConfig(linkedProjectDir, adapter)).title, "after");
+    }, { prefix: "vf-config-bun-symlinked-project-reload-" });
+  });
+
+  it("touches symlinked config-file tracking by its canonical path", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    const loadMarker = `__vfBunSymlinkTracking_${crypto.randomUUID().replaceAll("-", "_")}`;
+    try {
+      await withTempDir(async (rootDir) => {
+        const physicalProjectDir = `${rootDir}/physical-project`;
+        const linkedProjectDir = `${rootDir}/linked-project`;
+        const physicalConfigPath = `${physicalProjectDir}/veryfront.config.ts`;
+        const linkedConfigPath = `${linkedProjectDir}/veryfront.config.ts`;
+        const helperPath = `${physicalProjectDir}/config-helper.cjs`;
+        const linkedHelperPath = `${linkedProjectDir}/config-helper.cjs`;
+        const source = 'import title from "./config-helper.cjs";\nexport default { title };\n';
+        await mkdir(physicalProjectDir, { recursive: true });
+        await mkdir(linkedProjectDir, { recursive: true });
+        await writeTextFile(physicalConfigPath, source);
+        await writeTextFile(
+          helperPath,
+          `globalThis[${JSON.stringify(loadMarker)}] = ` +
+            `(globalThis[${JSON.stringify(loadMarker)}] ?? 0) + 1;\n` +
+            `module.exports = "generation-" + globalThis[${JSON.stringify(loadMarker)}];\n`,
+        );
+        await symlink(physicalConfigPath, linkedConfigPath);
+        await symlink(helperPath, linkedHelperPath);
+        adapter.fs.files.set(linkedConfigPath, source);
+
+        assertEquals((await getConfig(linkedProjectDir, adapter)).title, "generation-1");
+
+        const trackingCapacity = __getBunProjectConfigModuleTrackingCapacityForTests();
+        for (let index = 0; index < trackingCapacity - 1; index++) {
+          const fillerDir = `${rootDir}/filler-${index}`;
+          const fillerConfigPath = `${fillerDir}/veryfront.config.ts`;
+          const fillerSource = `export default { title: "filler-${index}" };\n`;
+          await mkdir(fillerDir, { recursive: true });
+          await writeTextFile(fillerConfigPath, fillerSource);
+          adapter.fs.files.set(fillerConfigPath, fillerSource);
+          await getConfig(fillerDir, adapter);
+        }
+
+        // A cache hit must refresh the canonical tracking entry, not the
+        // lexical symlink path that never became an LRU key.
+        assertEquals((await getConfig(linkedProjectDir, adapter)).title, "generation-1");
+        const finalDir = `${rootDir}/filler-final`;
+        const finalConfigPath = `${finalDir}/veryfront.config.ts`;
+        const finalSource = 'export default { title: "filler-final" };\n';
+        await mkdir(finalDir, { recursive: true });
+        await writeTextFile(finalConfigPath, finalSource);
+        adapter.fs.files.set(finalConfigPath, finalSource);
+        await getConfig(finalDir, adapter);
+
+        const projectRequire = createRequire(linkedConfigPath);
+        assertEquals(projectRequire(linkedHelperPath), "generation-1");
+        assertEquals((globalThis as Record<string, unknown>)[loadMarker], 1);
+      }, { prefix: "vf-config-bun-symlink-tracking-touch-" });
+    } finally {
+      clearConfigCache();
+      delete (globalThis as Record<string, unknown>)[loadMarker];
+    }
+  });
+
+  it("reloads a CommonJS helper required by a top-level-await config dependency", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    await withTempDir(async (projectDir) => {
+      const configPath = `${projectDir}/veryfront.config.ts`;
+      const entryPath = `${projectDir}/config-entry.cjs`;
+      const helperPath = `${projectDir}/config-helper.cjs`;
+      // The module lexer cannot see the entry's require() edge, so the helper
+      // must be claimed through Bun's runtime CommonJS child tracking.
+      const source = "await Promise.resolve();\n" +
+        'const { default: title } = await import("./config-entry.cjs");\n' +
+        "export default { title };\n";
+      await writeTextFile(configPath, source);
+      adapter.fs.files.set(configPath, source);
+      await writeTextFile(
+        entryPath,
+        'module.exports = require("./config-helper.cjs");\n',
+      );
+
+      await writeTextFile(helperPath, 'module.exports = "before";\n');
+      assertEquals((await getConfig(projectDir, adapter)).title, "before");
+
+      await writeTextFile(helperPath, 'module.exports = "after";\n');
+      clearConfigCache();
+
+      assertEquals((await getConfig(projectDir, adapter)).title, "after");
+    }, { prefix: "vf-config-bun-tla-cjs-descendant-reload-" });
+  });
+
+  it("reloads a computed import inside a top-level-await config dependency", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    await withTempDir(async (projectDir) => {
+      const configPath = `${projectDir}/veryfront.config.ts`;
+      const entryPath = `${projectDir}/config-entry.ts`;
+      const helperPath = `${projectDir}/config-helper.cjs`;
+      const source = 'import title from "./config-entry.ts";\n' +
+        "await Promise.resolve();\nexport default { title };\n";
+      const entrySource = 'const helper = "./config-helper.cjs";\n' +
+        "const imported = await import(helper);\nexport default imported.default;\n";
+      await writeTextFile(configPath, source);
+      await writeTextFile(entryPath, entrySource);
+      adapter.fs.files.set(configPath, source);
+
+      await writeTextFile(helperPath, 'module.exports = "before";\n');
+      assertEquals((await getConfig(projectDir, adapter)).title, "before");
+
+      await writeTextFile(helperPath, 'module.exports = "after";\n');
+      clearConfigCache();
+
+      assertEquals((await getConfig(projectDir, adapter)).title, "after");
+    }, { prefix: "vf-config-bun-transitive-computed-import-" });
+  });
+
+  it("evicts tracked config modules when their tracking entry reaches capacity", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    await withTempDir(async (rootDir) => {
+      const firstProjectDir = `${rootDir}/first`;
+      const firstConfigPath = `${firstProjectDir}/veryfront.config.ts`;
+      const helperPath = `${firstProjectDir}/config-helper.ts`;
+      const firstSource = 'import title from "./config-helper.ts";\nexport default { title };\n';
+      await mkdir(firstProjectDir, { recursive: true });
+      await writeTextFile(firstConfigPath, firstSource);
+      await writeTextFile(helperPath, 'export default "before";\n');
+      adapter.fs.files.set(firstConfigPath, firstSource);
+
+      assertEquals((await getConfig(firstProjectDir, adapter)).title, "before");
+      await writeTextFile(helperPath, 'export default "after";\n');
+
+      const trackingCapacity = __getBunProjectConfigModuleTrackingCapacityForTests();
+      for (let index = 0; index < trackingCapacity; index++) {
+        const fillerDir = `${rootDir}/filler-${index}`;
+        const fillerConfigPath = `${fillerDir}/veryfront.config.ts`;
+        const fillerSource = `export default { title: "filler-${index}" };\n`;
+        await mkdir(fillerDir, { recursive: true });
+        await writeTextFile(fillerConfigPath, fillerSource);
+        adapter.fs.files.set(fillerConfigPath, fillerSource);
+        assertEquals((await getConfig(fillerDir, adapter)).title, `filler-${index}`);
+      }
+
+      clearConfigCache();
+      assertEquals((await getConfig(firstProjectDir, adapter)).title, "after");
+    }, { prefix: "vf-config-bun-tracking-capacity-" });
+  });
+
+  it("evicts Bun tracking when default config entries evict its config cache entry", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    const loadMarker = `__vfBunConfigCacheEviction_${crypto.randomUUID().replaceAll("-", "_")}`;
+    try {
+      await withTempDir(async (rootDir) => {
+        const projectDir = `${rootDir}/configured`;
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        const helperPath = `${projectDir}/config-helper.cjs`;
+        const source = 'import title from "./config-helper.cjs";\nexport default { title };\n';
+        const helperSource = (generation: string): string =>
+          `globalThis[${JSON.stringify(loadMarker)}] = ` +
+          `(globalThis[${JSON.stringify(loadMarker)}] ?? 0) + 1;\n` +
+          `module.exports = ${JSON.stringify(generation)} + "-" + ` +
+          `globalThis[${JSON.stringify(loadMarker)}];\n`;
+        await mkdir(projectDir, { recursive: true });
+        await writeTextFile(configPath, source);
+        await writeTextFile(helperPath, helperSource("before"));
+        adapter.fs.files.set(configPath, source);
+
+        assertEquals((await getConfig(projectDir, adapter)).title, "before-1");
+        await writeTextFile(helperPath, helperSource("after"));
+
+        const cacheCapacity = __getBunProjectConfigModuleTrackingCapacityForTests();
+        for (let index = 0; index < cacheCapacity; index++) {
+          await getConfig(`${rootDir}/defaults-${index}`, adapter);
+        }
+
+        const projectRequire = createRequire(configPath);
+        assertEquals(projectRequire(helperPath), "after-2");
+        assertEquals((await getConfig(projectDir, adapter)).title, "after-2");
+      }, { prefix: "vf-config-bun-config-capacity-" });
+    } finally {
+      clearConfigCache();
+      delete (globalThis as Record<string, unknown>)[loadMarker];
+    }
+  });
+
+  it("does not let failed loads evict a live config tracking entry", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    const loadMarker = `__vfBunLiveTracking_${crypto.randomUUID().replaceAll("-", "_")}`;
+    try {
+      await withTempDir(async (rootDir) => {
+        const liveProjectDir = `${rootDir}/live`;
+        const liveConfigPath = `${liveProjectDir}/veryfront.config.ts`;
+        const helperPath = `${liveProjectDir}/config-helper.cjs`;
+        const liveSource = 'import title from "./config-helper.cjs";\nexport default { title };\n';
+        await mkdir(liveProjectDir, { recursive: true });
+        await writeTextFile(liveConfigPath, liveSource);
+        await writeTextFile(
+          helperPath,
+          `globalThis[${JSON.stringify(loadMarker)}] = ` +
+            `(globalThis[${JSON.stringify(loadMarker)}] ?? 0) + 1;\n` +
+            `module.exports = "generation-" + globalThis[${JSON.stringify(loadMarker)}];\n`,
+        );
+        adapter.fs.files.set(liveConfigPath, liveSource);
+
+        assertEquals((await getConfig(liveProjectDir, adapter)).title, "generation-1");
+
+        const trackingCapacity = __getBunProjectConfigModuleTrackingCapacityForTests();
+        for (let index = 0; index < trackingCapacity; index++) {
+          const failedDir = `${rootDir}/failed-${index}`;
+          const failedConfigPath = `${failedDir}/veryfront.config.js`;
+          const failedSource = `throw new Error("failed-${index}");\n`;
+          await mkdir(failedDir, { recursive: true });
+          await writeTextFile(failedConfigPath, failedSource);
+          adapter.fs.files.set(failedConfigPath, failedSource);
+          await assertRejects(() => getConfig(failedDir, adapter), Error);
+        }
+
+        const projectRequire = createRequire(liveConfigPath);
+        assertEquals(projectRequire(helperPath), "generation-1");
+        assertEquals((globalThis as Record<string, unknown>)[loadMarker], 1);
+      }, { prefix: "vf-config-bun-failed-tracking-capacity-" });
+    } finally {
+      delete (globalThis as Record<string, unknown>)[loadMarker];
+    }
+  });
+
+  it("does not evict an unrelated module loaded while an async config is evaluating", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    const activeMarker = "__vfBunAsyncConfigActive";
+    const loadCountMarker = "__vfBunUnrelatedModuleLoads";
+    try {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        const unrelatedPath = `${projectDir}/unrelated.cjs`;
+        const source = `globalThis.${activeMarker} = true;\n` +
+          "await new Promise((resolve) => setTimeout(resolve, 100));\n" +
+          'export default { title: "ready" };\n';
+        await writeTextFile(configPath, source);
+        adapter.fs.files.set(configPath, source);
+        await writeTextFile(
+          unrelatedPath,
+          `globalThis.${loadCountMarker} = (globalThis.${loadCountMarker} ?? 0) + 1;\n` +
+            `module.exports = globalThis.${loadCountMarker};\n`,
+        );
+        const projectRequire = createRequire(toFileUrl(configPath));
+
+        const firstConfig = getConfig(projectDir, adapter);
+        await waitFor(
+          () => (globalThis as Record<string, unknown>)[activeMarker] === true,
+        );
+        assertEquals(projectRequire(unrelatedPath), 1);
+        assertEquals((await firstConfig).title, "ready");
+
+        clearConfigCache();
+        assertEquals((await getConfig(projectDir, adapter)).title, "ready");
+        assertEquals(projectRequire(unrelatedPath), 1);
+      }, { prefix: "vf-config-bun-unrelated-cache-" });
+    } finally {
+      delete (globalThis as Record<string, unknown>)[activeMarker];
+      delete (globalThis as Record<string, unknown>)[loadCountMarker];
+    }
+  });
+
+  it("does not duplicate a config dependency later shared by application code", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    await withTempDir(async (projectDir) => {
+      const configPath = `${projectDir}/veryfront.config.ts`;
+      // The shared dependency is CommonJS: Bun records `Module.children` edges
+      // only between CommonJS modules, so a CommonJS consumer of an ES-module
+      // helper leaves no observable reference for eviction to retain.
+      const helperPath = `${projectDir}/config-helper.cjs`;
+      const consumerPath = `${projectDir}/application-consumer.cjs`;
+      const source = 'import title from "./config-helper.cjs";\nexport default { title };\n';
+      await writeTextFile(configPath, source);
+      adapter.fs.files.set(configPath, source);
+      await writeTextFile(helperPath, 'module.exports = "before";\n');
+      await writeTextFile(
+        consumerPath,
+        'module.exports = require("./config-helper.cjs");\n',
+      );
+
+      assertEquals((await getConfig(projectDir, adapter)).title, "before");
+      const projectRequire = createRequire(toFileUrl(configPath));
+      const applicationValue = projectRequire(consumerPath);
+      const sharedValue = projectRequire(helperPath);
+      assertEquals(applicationValue, sharedValue);
+
+      await writeTextFile(helperPath, 'module.exports = "after";\n');
+      clearConfigCache();
+
+      assertEquals((await getConfig(projectDir, adapter)).title, "before");
+      assertEquals(projectRequire(helperPath), sharedValue);
+      assertEquals(projectRequire(consumerPath), applicationValue);
+    }, { prefix: "vf-config-bun-shared-dependency-" });
+  });
+
+  it("serializes overlapping config revisions before evicting their dependencies", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    const activeMarker = "__vfBunOverlappingConfigActive";
+    const gateMarker = "__vfBunOverlappingConfigGate";
+    const gate = Promise.withResolvers<void>();
+    const globals = globalThis as Record<string, unknown>;
+    globals[gateMarker] = gate.promise;
+    try {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        const helperPath = `${projectDir}/config-helper.ts`;
+        const source = 'import title from "./config-helper.ts";\n' +
+          `globalThis.${activeMarker} = true;\n` +
+          `await globalThis.${gateMarker};\n` +
+          "export default { title };\n";
+        await writeTextFile(configPath, source);
+        adapter.fs.files.set(configPath, source);
+        await writeTextFile(helperPath, 'export default "before";\n');
+
+        const firstConfig = getConfig(projectDir, adapter);
+        await waitFor(() => globals[activeMarker] === true);
+        await writeTextFile(helperPath, 'export default "after";\n');
+        clearConfigCache();
+        const secondConfig = getConfig(projectDir, adapter);
+        let secondSettled = false;
+        void secondConfig.then(() => {
+          secondSettled = true;
+        }, () => {
+          secondSettled = true;
+        });
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        assertEquals(secondSettled, false);
+
+        gate.resolve();
+
+        assertEquals((await firstConfig).title, "before");
+        assertEquals((await secondConfig).title, "after");
+      }, { prefix: "vf-config-bun-overlapping-revisions-" });
+    } finally {
+      gate.resolve();
+      delete globals[activeMarker];
+      delete globals[gateMarker];
+    }
+  });
+
+  it("serializes real and symlinked loads of the same config path", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    const activeMarker = `__vfBunCanonicalConfigActive_${crypto.randomUUID().replaceAll("-", "_")}`;
+    const gateMarker = `__vfBunCanonicalConfigGate_${crypto.randomUUID().replaceAll("-", "_")}`;
+    const gate = Promise.withResolvers<void>();
+    const globals = globalThis as Record<string, unknown>;
+    globals[gateMarker] = gate.promise;
+    try {
+      await withTempDir(async (rootDir) => {
+        const physicalProjectDir = `${rootDir}/physical-project`;
+        const linkedProjectDir = `${rootDir}/linked-project`;
+        const physicalConfigPath = `${physicalProjectDir}/veryfront.config.ts`;
+        const linkedConfigPath = `${linkedProjectDir}/veryfront.config.ts`;
+        const helperPath = `${physicalProjectDir}/config-helper.ts`;
+        const source = 'import title from "./config-helper.ts";\n' +
+          `globalThis[${JSON.stringify(activeMarker)}] = true;\n` +
+          `await globalThis[${JSON.stringify(gateMarker)}];\n` +
+          "export default { title };\n";
+        await mkdir(physicalProjectDir, { recursive: true });
+        await writeTextFile(physicalConfigPath, source);
+        await writeTextFile(helperPath, 'export default "before";\n');
+        await symlink(physicalProjectDir, linkedProjectDir);
+        adapter.fs.files.set(physicalConfigPath, source);
+        adapter.fs.files.set(linkedConfigPath, source);
+
+        const physicalLoad = getConfig(physicalProjectDir, adapter);
+        await waitFor(() => globals[activeMarker] === true);
+        await writeTextFile(helperPath, 'export default "after";\n');
+        const linkedLoad = getConfig(linkedProjectDir, adapter);
+        let linkedSettled = false;
+        void linkedLoad.then(() => {
+          linkedSettled = true;
+        }, () => {
+          linkedSettled = true;
+        });
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        assertEquals(linkedSettled, false);
+
+        gate.resolve();
+
+        assertEquals((await physicalLoad).title, "before");
+        assertEquals((await linkedLoad).title, "after");
+      }, { prefix: "vf-config-bun-canonical-load-lock-" });
+    } finally {
+      gate.resolve();
+      delete globals[activeMarker];
+      delete globals[gateMarker];
+    }
   });
 });

--- a/tests/bun/workspace-resolution.test.ts
+++ b/tests/bun/workspace-resolution.test.ts
@@ -471,6 +471,25 @@ describe("Bun workspace resolution", () => {
     }, { prefix: "vf-config-bun-computed-package-" });
   });
 
+  it("resolves coercible computed imports from the original project", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    await withTempDir(async (projectDir) => {
+      const configPath = `${projectDir}/veryfront.config.ts`;
+      const helperPath = `${projectDir}/coercible-helper.ts`;
+      const source = "let coercions = 0;\n" +
+        "const dependency = { toString() { coercions += 1; return './coercible-helper.ts'; } };\n" +
+        "const { default: value } = await import(dependency);\n" +
+        "export default { title: `${value}:${coercions}` };\n";
+      await writeTextFile(configPath, source);
+      await writeTextFile(helperPath, 'export default "coercible";\n');
+      adapter.fs.files.set(configPath, source);
+
+      assertEquals((await getConfig(projectDir, adapter)).title, "coercible:1");
+    }, { prefix: "vf-config-bun-coercible-computed-import-" });
+  });
+
   it("keeps a hashbang first when observing computed imports", async () => {
     clearConfigCache();
     ensureBuiltinSchemaValidator();

--- a/tests/bun/workspace-resolution.test.ts
+++ b/tests/bun/workspace-resolution.test.ts
@@ -552,6 +552,103 @@ describe("Bun workspace resolution", () => {
     }
   });
 
+  it("reloads runtime CommonJS children of deferred literal imports", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    const resultMarker = `__vfBunDeferredLiteralImport_${crypto.randomUUID().replaceAll("-", "_")}`;
+    try {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        const entryPath = `${projectDir}/deferred-entry.cjs`;
+        const helperPath = `${projectDir}/deferred-helper.cjs`;
+        const source = "await Promise.resolve();\n" +
+          "export default { extensions: [{\n" +
+          '  name: "deferred-literal-import", version: "1", capabilities: [],\n' +
+          "  async setup() {\n" +
+          '    const { default: value } = await import("./deferred-entry.cjs");\n' +
+          `    globalThis[${JSON.stringify(resultMarker)}] = value;\n` +
+          "  },\n" +
+          "}] };\n";
+        await writeTextFile(configPath, source);
+        await writeTextFile(entryPath, 'module.exports = require("./deferred-helper.cjs");\n');
+        await writeTextFile(helperPath, 'module.exports = "before";\n');
+        adapter.fs.files.set(configPath, source);
+
+        const first = await getConfig(projectDir, adapter);
+        await (first.extensions?.[0] as { setup?: () => Promise<void> }).setup?.();
+        assertEquals((globalThis as Record<string, unknown>)[resultMarker], "before");
+
+        await writeTextFile(helperPath, 'module.exports = "after";\n');
+        clearConfigCache();
+        const second = await getConfig(projectDir, adapter);
+        await (second.extensions?.[0] as { setup?: () => Promise<void> }).setup?.();
+        assertEquals((globalThis as Record<string, unknown>)[resultMarker], "after");
+      }, { prefix: "vf-config-bun-deferred-literal-import-" });
+    } finally {
+      clearConfigCache();
+      delete (globalThis as Record<string, unknown>)[resultMarker];
+    }
+  });
+
+  it("does not claim unrelated modules loaded while an async config is suspended", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    const startedMarker = `__vfBunConfigStarted_${crypto.randomUUID().replaceAll("-", "_")}`;
+    const resumeMarker = `__vfBunConfigResume_${crypto.randomUUID().replaceAll("-", "_")}`;
+    const unrelatedMarker = `__vfBunUnrelatedLoad_${crypto.randomUUID().replaceAll("-", "_")}`;
+    const started = Promise.withResolvers<void>();
+    const resume = Promise.withResolvers<void>();
+    const globals = globalThis as Record<string, unknown>;
+    globals[startedMarker] = () => started.resolve();
+    globals[resumeMarker] = () => resume.promise;
+    try {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        const entryPath = `${projectDir}/config-entry.ts`;
+        const helperPath = `${projectDir}/config-helper.cjs`;
+        const unrelatedPath = `${projectDir}/unrelated.cjs`;
+        const source = 'import title from "./config-entry.ts";\n' +
+          `globalThis[${JSON.stringify(startedMarker)}]();\n` +
+          `await globalThis[${JSON.stringify(resumeMarker)}]();\n` +
+          "export default { title };\n";
+        await writeTextFile(configPath, source);
+        await writeTextFile(
+          entryPath,
+          'const dependency = "./config-helper.cjs";\n' +
+            "const imported = await import(dependency);\n" +
+            "export default imported.default;\n",
+        );
+        await writeTextFile(helperPath, 'module.exports = "config";\n');
+        await writeTextFile(
+          unrelatedPath,
+          `globalThis[${JSON.stringify(unrelatedMarker)}] = ` +
+            `(globalThis[${JSON.stringify(unrelatedMarker)}] ?? 0) + 1;\n` +
+            `module.exports = globalThis[${JSON.stringify(unrelatedMarker)}];\n`,
+        );
+        adapter.fs.files.set(configPath, source);
+
+        const configLoad = getConfig(projectDir, adapter);
+        await started.promise;
+        const projectRequire = createRequire(configPath);
+        assertEquals(projectRequire(unrelatedPath), 1);
+        resume.resolve();
+        assertEquals((await configLoad).title, "config");
+
+        clearConfigCache();
+        assertEquals(projectRequire(unrelatedPath), 1);
+        assertEquals(globals[unrelatedMarker], 1);
+      }, { prefix: "vf-config-bun-concurrent-unrelated-module-" });
+    } finally {
+      resume.resolve();
+      clearConfigCache();
+      delete globals[startedMarker];
+      delete globals[resumeMarker];
+      delete globals[unrelatedMarker];
+    }
+  });
+
   it("evicts transitive deferred imports discovered after cache clearing", async () => {
     clearConfigCache();
     ensureBuiltinSchemaValidator();
@@ -817,7 +914,7 @@ describe("Bun workspace resolution", () => {
     }, { prefix: "vf-config-bun-tla-cjs-descendant-reload-" });
   });
 
-  it("reloads a computed import inside a top-level-await config dependency", async () => {
+  it("does not claim an unobservable computed import inside a config dependency", async () => {
     clearConfigCache();
     ensureBuiltinSchemaValidator();
     const adapter = createMockAdapter();
@@ -839,7 +936,11 @@ describe("Bun workspace resolution", () => {
       await writeTextFile(helperPath, 'module.exports = "after";\n');
       clearConfigCache();
 
-      assertEquals((await getConfig(projectDir, adapter)).title, "after");
+      // Bun exposes neither a loader callback nor a CommonJS parent edge for a
+      // computed import executed inside an ESM dependency. Keeping that helper
+      // cached is safer than claiming every concurrently loaded project module
+      // as config-owned and evicting unrelated application singletons.
+      assertEquals((await getConfig(projectDir, adapter)).title, "before");
     }, { prefix: "vf-config-bun-transitive-computed-import-" });
   });
 

--- a/tests/bun/workspace-resolution.test.ts
+++ b/tests/bun/workspace-resolution.test.ts
@@ -471,6 +471,22 @@ describe("Bun workspace resolution", () => {
     }, { prefix: "vf-config-bun-computed-package-" });
   });
 
+  it("keeps missing computed bare imports catchable", async () => {
+    clearConfigCache();
+    ensureBuiltinSchemaValidator();
+    const adapter = createMockAdapter();
+    await withTempDir(async (projectDir) => {
+      const configPath = `${projectDir}/veryfront.config.ts`;
+      const source = 'const dependency = "missing-optional-config-package";\n' +
+        'const imported = await import(dependency).catch(() => ({ default: "optional" }));\n' +
+        "export default { title: imported.default };\n";
+      await writeTextFile(configPath, source);
+      adapter.fs.files.set(configPath, source);
+
+      assertEquals((await getConfig(projectDir, adapter)).title, "optional");
+    }, { prefix: "vf-config-bun-computed-missing-package-" });
+  });
+
   it("resolves coercible computed imports from the original project", async () => {
     clearConfigCache();
     ensureBuiltinSchemaValidator();
@@ -616,8 +632,7 @@ describe("Bun workspace resolution", () => {
         await writeTextFile(configPath, source);
         await writeTextFile(
           entryPath,
-          'const dependency = "./config-helper.cjs";\n' +
-            "const imported = await import(dependency);\n" +
+          'const imported = await import("./config-helper.cjs");\n' +
             "export default imported.default;\n",
         );
         await writeTextFile(helperPath, 'module.exports = "config";\n');
@@ -914,14 +929,13 @@ describe("Bun workspace resolution", () => {
     }, { prefix: "vf-config-bun-tla-cjs-descendant-reload-" });
   });
 
-  it("does not claim an unobservable computed import inside a config dependency", async () => {
+  it("rejects an unobservable computed import inside a config dependency", async () => {
     clearConfigCache();
     ensureBuiltinSchemaValidator();
     const adapter = createMockAdapter();
     await withTempDir(async (projectDir) => {
       const configPath = `${projectDir}/veryfront.config.ts`;
       const entryPath = `${projectDir}/config-entry.ts`;
-      const helperPath = `${projectDir}/config-helper.cjs`;
       const source = 'import title from "./config-entry.ts";\n' +
         "await Promise.resolve();\nexport default { title };\n";
       const entrySource = 'const helper = "./config-helper.cjs";\n' +
@@ -930,17 +944,11 @@ describe("Bun workspace resolution", () => {
       await writeTextFile(entryPath, entrySource);
       adapter.fs.files.set(configPath, source);
 
-      await writeTextFile(helperPath, 'module.exports = "before";\n');
-      assertEquals((await getConfig(projectDir, adapter)).title, "before");
-
-      await writeTextFile(helperPath, 'module.exports = "after";\n');
-      clearConfigCache();
-
-      // Bun exposes neither a loader callback nor a CommonJS parent edge for a
-      // computed import executed inside an ESM dependency. Keeping that helper
-      // cached is safer than claiming every concurrently loaded project module
-      // as config-owned and evicting unrelated application singletons.
-      assertEquals((await getConfig(projectDir, adapter)).title, "before");
+      await assertRejects(
+        () => getConfig(projectDir, adapter),
+        Error,
+        "Computed dynamic imports inside project config dependencies cannot be reloaded safely in Bun",
+      );
     }, { prefix: "vf-config-bun-transitive-computed-import-" });
   });
 
@@ -1170,7 +1178,7 @@ describe("Bun workspace resolution", () => {
 
         gate.resolve();
 
-        assertEquals((await firstConfig).title, "before");
+        assertEquals((await firstConfig).title, "after");
         assertEquals((await secondConfig).title, "after");
       }, { prefix: "vf-config-bun-overlapping-revisions-" });
     } finally {


### PR DESCRIPTION
## Summary

Follow-up to #4227 that addresses four late review findings on its merged head.

- invalidate only project-local Bun config dependencies between reloads
- preserve URL redaction while bounding Windows drive-path matching
- keep disabled optional dynamic imports lazy and syntactically valid
- honor ESM import export conditions when staging compiled Deno configs

## Verification

- deno task test:file src/config/loader.test.ts
- Bun 1.3.6 tests/bun/workspace-resolution.test.ts
- deno task build:npm
- deno task fmt --check
- deno task lint
- deno check src/index.ts
- deno task test:unit
- pre-push hook: format, lint, typecheck, full unit suite

Commit: 45d661f2e6aa701f95a1c29180be77c64153fdf8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project configuration loading across Bun and non-Bun environments.
  * Fixed package aliases, conditional exports, wildcard imports, self-references, and dynamic imports.
  * Improved support for top-level asynchronous configuration files.
  * Ensured configuration changes are detected across direct, transitive, symlinked, and workspace-related modules.
  * Improved concurrent loading, module caching, unresolved dependencies, and error handling.

* **Tests**
  * Expanded coverage for import resolution, workspace behavior, cache invalidation, symlinks, dynamic dependencies, and concurrent configuration loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->