### PR TITLE
fix(config): redact config-load URLs whole, and strip SGR before matching paths

### DIFF
--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1028,6 +1028,30 @@ export default config as const;
         assertEquals(error.message.includes("((x))"), false);
       });
 
+      it("redacts a URL whose path nests parentheses", async () => {
+        const error = await loadFailure(
+          "vf-config-nested-paren-path-",
+          `throw new Error("Fetch https://registry.internal/a((TOKENVALUE1234)) failed");\n`,
+        );
+
+        // The residue here is a URL path fragment, not decoration: whatever sat
+        // inside the parentheses survived into the caller-visible detail.
+        assertStringIncludes(error.message, "[url]");
+        assertEquals(error.message.includes("TOKENVALUE1234"), false);
+        assertEquals(error.message.includes("registry.internal"), false);
+      });
+
+      it("redacts a file URL whose path nests parentheses", async () => {
+        const error = await loadFailure(
+          "vf-config-nested-paren-file-url-",
+          `throw new Error("Fetch file:///home/alice/a((TOKENVALUE1234)) failed");\n`,
+        );
+
+        assertStringIncludes(error.message, "[path]");
+        assertEquals(error.message.includes("TOKENVALUE1234"), false);
+        assertEquals(error.message.includes("/home/alice"), false);
+      });
+
       it("redacts a single-slash URL-like token without misclassifying Windows paths", async () => {
         const error = await loadFailure(
           "vf-config-single-slash-url-",

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1014,6 +1014,20 @@ export default config as const;
         assertEquals(error.message.includes("registry.internal"), false);
       });
 
+      it("redacts a URL whose userinfo nests parentheses", async () => {
+        const error = await loadFailure(
+          "vf-config-nested-paren-userinfo-",
+          `throw new Error("Fetch https://u((x))y@registry.internal/config.ts failed");\n`,
+        );
+
+        // The balanced-pair alternative matches one flat `(...)`, so a nested
+        // userinfo ended the token at the first `(` and left the hostname behind.
+        // RFC 3986 sub-delims include `(` and `)`, so this is a legal authority.
+        assertStringIncludes(error.message, "[url]");
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertEquals(error.message.includes("((x))"), false);
+      });
+
       it("redacts a single-slash URL-like token without misclassifying Windows paths", async () => {
         const error = await loadFailure(
           "vf-config-single-slash-url-",

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -971,6 +971,22 @@ export default config as const;
         assertEquals(error.message.includes("C:\\Users\\example"), false);
       });
 
+      it("keeps a hosted config URL intact while still redacting machine paths", async () => {
+        const error = await loadFailure(
+          "vf-config-url-not-a-path-",
+          `throw new Error("Failed to fetch https://cdn.example.test/hosted/config.ts from /home/example/project/veryfront.config.ts");\n`,
+        );
+
+        // The drive-letter alternative used to match the `s:/` inside `https:/`
+        // and eat the rest of the URL, so this line arrived as `http[path]` --
+        // losing the only token the reader can act on (veryfront-issue-inbox#836).
+        assertStringIncludes(error.message, "https://cdn.example.test/hosted/config.ts");
+        assertEquals(error.message.includes("http[path]"), false);
+        // The real machine path on the same line is still redacted.
+        assertStringIncludes(error.message, "[path]");
+        assertEquals(error.message.includes("/home/example"), false);
+      });
+
       it("classifies Bun resolver objects that do not inherit from Error", async () => {
         const error = await loadFailure(
           "vf-config-bun-resolve-object-",

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1376,6 +1376,66 @@ export default config as const;
         assertEquals(prose.message.includes("mError"), false);
       });
 
+      it("keeps a boundary when a completed CSI sequence sits before a path", async () => {
+        const posix = await loadFailure(
+          "vf-config-csi-final-byte-posix-",
+          `throw new Error("Failed at" + String.fromCharCode(27) + "[3~/home/alice/veryfront.config.ts");\n`,
+        );
+
+        // `ESC[3~` is a complete, legal CSI whose final byte is `~`. Removing it
+        // during de-colorization joined `at` to the path, and POSIX_ABSOLUTE_PATH's
+        // lookbehind refuses a slash after an alphanumeric -- so the whole local
+        // path reached the caller-visible error.
+        assertEquals(posix.message.includes("alice"), false);
+        assertEquals(posix.message.includes("at/home"), false);
+        assertStringIncludes(posix.message, "[path]");
+
+        const drive = await loadFailure(
+          "vf-config-csi-final-byte-drive-",
+          `throw new Error("Failed at" + String.fromCharCode(27) + "[3~C:\\\\Users\\\\alice\\\\veryfront.config.ts");\n`,
+        );
+
+        assertEquals(drive.message.includes("alice"), false);
+        assertEquals(drive.message.includes("Users"), false);
+        assertStringIncludes(drive.message, "[path]");
+
+        const url = await loadFailure(
+          "vf-config-csi-final-byte-url-",
+          `throw new Error("Failed at" + String.fromCharCode(27) + "[3~https:registry.internal/veryfront.config.ts");\n`,
+        );
+
+        assertEquals(url.message.includes("registry.internal"), false);
+        assertStringIncludes(url.message, "[url]");
+
+        const credential = await loadFailure(
+          "vf-config-csi-final-byte-credential-",
+          `throw new Error("Using token sk-" + String.fromCharCode(27) + "[0mABCD1234EFGH5678");\n`,
+        );
+
+        // The counterpart that pins why this is a pre-pass and not a change to
+        // de-colorization itself. That pass must keep replacing with nothing: a
+        // sequence inside a credential only rejoins into a contiguous secret if
+        // removal leaves no gap, and the sanitiser after it matches nothing
+        // otherwise. Emitting a space there would fix the path boundary above and
+        // reopen this.
+        assertEquals(credential.message.includes("ABCD1234EFGH5678"), false);
+      });
+
+      it("reports a CSI-glued file URL as a path, not a remote URL", async () => {
+        const error = await loadFailure(
+          "vf-config-csi-glued-file-url-",
+          `throw new Error(String.fromCharCode(27) + "[file:///home/alice/veryfront.config.ts");\n`,
+        );
+
+        // `f` is a legal CSI final byte, so the pass consumed `ESC[f` and SCHEME_URL
+        // read the remaining `ile:///home/alice/...` as a remote URL. Nothing leaked,
+        // but a local path was reported as `[url]` -- the path-as-URL mislabel this
+        // change exists to remove, arrived at from the other direction.
+        assertEquals(error.message.includes("alice"), false);
+        assertEquals(error.message.includes("[url]"), false);
+        assertStringIncludes(error.message, "[path]");
+      });
+
       it("classifies a drive path glued to diagnostic text as a path, not a URL", async () => {
         const drive = await loadFailure(
           "vf-config-glued-fwd-drive-",

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -996,9 +996,9 @@ export default config as const;
           `throw new Error("Attempt 3https://registry.internal/config.ts failed");\n`,
         );
 
-        // REMOTE_URL is unanchored on the left for this: with a left boundary the
-        // glued scheme is not recognised as a URL, and the hostname survives into
-        // a caller-visible detail.
+        // SCHEME_URL is unanchored on the left for this: with a left boundary
+        // the glued scheme is not recognised as a URL, and the hostname survives
+        // into a caller-visible detail.
         assertStringIncludes(error.message, "[url]");
         assertEquals(error.message.includes("registry.internal"), false);
       });
@@ -1021,8 +1021,9 @@ export default config as const;
           `throw new Error("Failed at" + String.fromCharCode(67) + ":\\\\Users\\\\alice\\\\veryfront.config.ts");\n`,
         );
 
-        // A left boundary on WINDOWS_ABSOLUTE_PATH refuses this, and REMOTE_URL
-        // cannot claim a backslash form, so the path would reach the caller.
+        // A left boundary on WINDOWS_ABSOLUTE_PATH refuses this, and neither
+        // SCHEME_URL nor MALFORMED_SCHEME_URL can claim a backslash form, so the
+        // path would reach the caller.
         assertStringIncludes(error.message, "[path]");
         assertEquals(error.message.includes("Users"), false);
         assertEquals(error.message.includes("alice"), false);

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1272,6 +1272,56 @@ export default config as const;
         assertStringIncludes(drive.message, "[path]");
       });
 
+      it("keeps a path intact when CSI parameter or intermediate bytes precede it", async () => {
+        const drive = await loadFailure(
+          "vf-config-csi-param-drive-",
+          `throw new Error(String.fromCharCode(27) + "[31" + String.fromCharCode(67) + ":\\\\Users\\\\alice\\\\veryfront.config.ts");\n`,
+        );
+
+        // `ESC[31C` is a legal cursor-forward sequence whose final byte is the
+        // drive letter itself. Removing only the bare introducer left `:\Users`
+        // behind, which WINDOWS_ABSOLUTE_PATH does not match -- so the parameter
+        // run has to be part of what the pre-pass removes.
+        assertEquals(drive.message.includes("alice"), false);
+        assertEquals(drive.message.includes("Users"), false);
+        assertStringIncludes(drive.message, "[path]");
+
+        const posix = await loadFailure(
+          "vf-config-csi-param-posix-",
+          `throw new Error(String.fromCharCode(27) + "[31/home/alice/veryfront.config.ts");\n`,
+        );
+
+        // Same sequence shape, POSIX side: `31` are parameter bytes, `/` an
+        // intermediate and `h` the final, so the CSI pass ate `ESC[31/h` and
+        // emitted `ome/alice/...`.
+        assertEquals(posix.message.includes("alice"), false);
+        assertEquals(posix.message.includes("ome/alice"), false);
+        assertStringIncludes(posix.message, "[path]");
+
+        const intermediate = await loadFailure(
+          "vf-config-csi-intermediate-posix-",
+          `throw new Error(String.fromCharCode(27) + "['/home/alice/veryfront.config.ts");\n`,
+        );
+
+        // An intermediate byte can precede the path with no parameters at all
+        // (`'` is 0x27), which is why the pre-pass carries both runs.
+        assertEquals(intermediate.message.includes("alice"), false);
+        assertEquals(intermediate.message.includes("ome/alice"), false);
+        assertStringIncludes(intermediate.message, "[path]");
+
+        const colorized = await loadFailure(
+          "vf-config-csi-param-sgr-",
+          `throw new Error(String.fromCharCode(27) + "[38:2:255:0:0m/home/alice/veryfront.config.ts");\n`,
+        );
+
+        // The widened pre-pass must not claim an ordinary colour sequence: its
+        // final byte `m` is not a path start, so the sequence still falls through
+        // to the full CSI pass and the path is redacted after de-colorization.
+        assertEquals(colorized.message.includes("alice"), false);
+        assertEquals(colorized.message.includes("38:2"), false);
+        assertStringIncludes(colorized.message, "[path]");
+      });
+
       it("classifies a drive path glued to diagnostic text as a path, not a URL", async () => {
         const drive = await loadFailure(
           "vf-config-glued-fwd-drive-",

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1015,6 +1015,34 @@ export default config as const;
         assertEquals(error.message.includes("http[path]"), false);
       });
 
+      it("redacts a machine path glued to the preceding diagnostic text", async () => {
+        const error = await loadFailure(
+          "vf-config-glued-path-",
+          `throw new Error("Failed at" + String.fromCharCode(67) + ":\\\\Users\\\\alice\\\\veryfront.config.ts");\n`,
+        );
+
+        // A left boundary on WINDOWS_ABSOLUTE_PATH refuses this, and REMOTE_URL
+        // cannot claim a backslash form, so the path would reach the caller.
+        assertStringIncludes(error.message, "[path]");
+        assertEquals(error.message.includes("Users"), false);
+        assertEquals(error.message.includes("alice"), false);
+      });
+
+      it("strips a colon-parameter CSI sequence, not only the digit-and-semicolon form", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-truecolor-sgr-",
+          `throw new Error("Failed to load ${escape}[38:2:255:0:0m/home/example/project/veryfront.config.ts");\n`,
+        );
+
+        // A true-colour sequence separates its parameters with colons. Matching
+        // only [0-9;] left "[38:2:255:0:0m" in front of the path, which defeats
+        // POSIX_ABSOLUTE_PATH's boundary exactly as an unstripped "[31m" would.
+        assertStringIncludes(error.message, "[path]");
+        assertEquals(error.message.includes("/home/example"), false);
+        assertEquals(error.message.includes("38:2"), false);
+      });
+
       it("redacts a colorized machine path instead of leaving SGR residue in front of it", async () => {
         const escape = String.fromCharCode(27);
         const error = await loadFailure(

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1003,6 +1003,17 @@ export default config as const;
         assertEquals(error.message.includes("registry.internal"), false);
       });
 
+      it("redacts a URL with parenthesized userinfo without consuming trailing prose", async () => {
+        const error = await loadFailure(
+          "vf-config-parenthesized-userinfo-",
+          `throw new Error("Fetch https://user(name):<TOKEN>@registry.internal/config.ts) failed");\n`,
+        );
+
+        assertStringIncludes(error.message, "Fetch [url]) failed");
+        assertEquals(error.message.includes("user(name)"), false);
+        assertEquals(error.message.includes("registry.internal"), false);
+      });
+
       it("redacts a single-slash URL-like token without misclassifying Windows paths", async () => {
         const error = await loadFailure(
           "vf-config-single-slash-url-",
@@ -1075,6 +1086,29 @@ export default config as const;
         assertStringIncludes(error.message, "[path]");
         assertEquals(error.message.includes("/home/example"), false);
         assertEquals(error.message.includes("38:2"), false);
+      });
+
+      it("strips an eight-bit CSI sequence before redacting a machine path", async () => {
+        const csi = String.fromCharCode(0x9b);
+        const error = await loadFailure(
+          "vf-config-eight-bit-csi-path-",
+          `throw new Error("Failed to load ${csi}31m/home/example/project/veryfront.config.ts");\n`,
+        );
+
+        assertStringIncludes(error.message, "[path]");
+        assertEquals(error.message.includes("/home/example"), false);
+        assertEquals(error.message.includes("31m"), false);
+      });
+
+      it("redacts credentials both before and after stripping CSI sequences", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-ansi-credential-",
+          `throw new Error("${escape}[API_KEY=<TOKEN>");\n`,
+        );
+
+        assertEquals(error.message.includes("<TOKEN>"), false);
+        assertStringIncludes(error.message, "[REDACTED]");
       });
 
       it("redacts a colorized machine path instead of leaving SGR residue in front of it", async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -990,6 +990,19 @@ export default config as const;
         assertEquals(error.message.includes("/home/example"), false);
       });
 
+      it("redacts a URL whose scheme is glued to preceding text", async () => {
+        const error = await loadFailure(
+          "vf-config-glued-url-",
+          `throw new Error("Attempt 3https://registry.internal/config.ts failed");\n`,
+        );
+
+        // REMOTE_URL is unanchored on the left for this: with a left boundary the
+        // glued scheme is not recognised as a URL, and the hostname survives into
+        // a caller-visible detail.
+        assertStringIncludes(error.message, "[url]");
+        assertEquals(error.message.includes("registry.internal"), false);
+      });
+
       it("redacts a colorized machine path instead of leaving SGR residue in front of it", async () => {
         const escape = String.fromCharCode(27);
         const error = await loadFailure(

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1028,20 +1028,36 @@ export default config as const;
         assertEquals(error.message.includes("alice"), false);
       });
 
-      it("summarizes a very long cause without quadratic rescanning", async () => {
-        const start = Date.now();
-        const error = await loadFailure(
-          "vf-config-long-cause-",
-          `throw new Error("a".repeat(100000));\n`,
-        );
-        const elapsed = Date.now() - start;
+      it("summarizes a very long cause in time proportional to its length", async () => {
+        // A wall-clock bound would couple this to runner speed, and a partial
+        // reintroduction of backtracking that stayed under it would pass
+        // silently. Instead time two inputs of the SAME length on the SAME
+        // machine, differing only in whether the pathological retry can start:
+        // digits cannot begin a scheme, letters can. Both measurements pay the
+        // same fixed overhead, so the ratio isolates the backtracking cost.
+        const size = 100000;
 
-        // REMOTE_URL is unanchored and runs over the whole message before the
-        // 200-character cap applies. With an unbounded scheme prefix it rescans
-        // to the end of the input at every letter, which measured ~17.9s for
-        // this input; bounding the scheme brings it to ~35ms. The threshold is
-        // deliberately loose -- it only has to separate those two orders.
-        assertEquals(elapsed < 5000, true, `summarize took ${elapsed}ms`);
+        const controlStart = Date.now();
+        await loadFailure(
+          "vf-config-long-control-",
+          `throw new Error("1".repeat(${size}));\n`,
+        );
+        const controlMs = Math.max(1, Date.now() - controlStart);
+
+        const probeStart = Date.now();
+        const error = await loadFailure(
+          "vf-config-long-probe-",
+          `throw new Error("a".repeat(${size}));\n`,
+        );
+        const probeMs = Date.now() - probeStart;
+
+        // Bounded, the two are within noise of each other. Unbounded, the probe
+        // measured ~17.9s against an unchanged control.
+        assertEquals(
+          probeMs < controlMs * 20,
+          true,
+          `probe ${probeMs}ms vs control ${controlMs}ms`,
+        );
         assertEquals(error.slug, CONFIG_PARSE_ERROR_SLUG);
       });
 

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1125,6 +1125,37 @@ export default config as const;
         assertEquals(error.slug, CONFIG_PARSE_ERROR_SLUG);
       });
 
+      it("summarizes many failed URL starts in time proportional to length", async () => {
+        // A different pathological shape from the long-alphabetic case above: here
+        // every `a://` starts a URL match that then fails on `(`, and an unbounded
+        // parenthesised interior rescans the rest of the message from each one.
+        // Measured unbounded: 2.6s for 20k repeats, growing 4x per doubling.
+        // Bounded: 53ms, growing 2x. Same control/probe ratio method -- a digit
+        // cannot begin a scheme, so the control never starts a match at all.
+        const repeats = 20000;
+
+        const controlStart = Date.now();
+        await loadFailure(
+          "vf-config-starts-control-",
+          `throw new Error("1://(".repeat(${repeats}));\n`,
+        );
+        const controlMs = Math.max(1, Date.now() - controlStart);
+
+        const probeStart = Date.now();
+        const error = await loadFailure(
+          "vf-config-starts-probe-",
+          `throw new Error("a://(".repeat(${repeats}));\n`,
+        );
+        const probeMs = Date.now() - probeStart;
+
+        assertEquals(
+          probeMs < controlMs * 20,
+          true,
+          `probe ${probeMs}ms vs control ${controlMs}ms`,
+        );
+        assertEquals(error.slug, CONFIG_PARSE_ERROR_SLUG);
+      });
+
       it("strips a colon-parameter CSI sequence, not only the digit-and-semicolon form", async () => {
         const escape = String.fromCharCode(27);
         const error = await loadFailure(

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1210,6 +1210,30 @@ export default config as const;
         assertEquals(error.slug, CONFIG_PARSE_ERROR_SLUG);
       });
 
+      it("redacts a path with a CSI introducer glued to its first character", async () => {
+        const posix = await loadFailure(
+          "vf-config-csi-glued-posix-",
+          `throw new Error(String.fromCharCode(27) + "[/home/alice/veryfront.config.ts");\n`,
+        );
+
+        // `/` is a valid CSI intermediate byte and `h` a valid final, so the CSI
+        // pass consumes `ESC[/h` and leaves `ome/alice/...`, which no later path
+        // pattern recognises. Both are legal CSI sequences, so the grammar cannot
+        // tell them from a path -- the path has to be matched while still intact.
+        assertEquals(posix.message.includes("alice"), false);
+        assertEquals(posix.message.includes("ome/alice"), false);
+
+        const drive = await loadFailure(
+          "vf-config-csi-glued-drive-",
+          `throw new Error(String.fromCharCode(27) + "[" + String.fromCharCode(67) + ":\\\\Users\\\\alice\\\\veryfront.config.ts");\n`,
+        );
+
+        // Same shape: `C` is a valid final byte, so the drive letter is consumed
+        // and `:\Users\alice` no longer matches WINDOWS_ABSOLUTE_PATH.
+        assertEquals(drive.message.includes("alice"), false);
+        assertEquals(drive.message.includes("Users"), false);
+      });
+
       it("strips a colon-parameter CSI sequence, not only the digit-and-semicolon form", async () => {
         const escape = String.fromCharCode(27);
         const error = await loadFailure(

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1421,6 +1421,42 @@ export default config as const;
         assertEquals(credential.message.includes("ABCD1234EFGH5678"), false);
       });
 
+      it("keeps both UNC separators when a CSI introducer precedes them", async () => {
+        const unc = await loadFailure(
+          "vf-config-csi-unc-",
+          `throw new Error(String.fromCharCode(27) + "[\\\\\\\\server\\\\share\\\\veryfront.config.ts");\n`,
+        );
+
+        // A backslash is 0x5C, inside the CSI final-byte range, so the optional
+        // final byte consumed the first of the two separators while the lookahead
+        // was satisfied by the second. The pre-pass emitted a single-separator
+        // path, WINDOWS_ABSOLUTE_PATH requires a doubled one, and the whole UNC
+        // path reached the caller. `origin/main` redacts this input, so the
+        // pre-pass introduced the leak rather than inheriting it.
+        assertEquals(unc.message.includes("server"), false);
+        assertEquals(unc.message.includes("share"), false);
+        assertStringIncludes(unc.message, "[path]");
+
+        const eightBit = await loadFailure(
+          "vf-config-csi-unc-eight-bit-",
+          `throw new Error(String.fromCharCode(155) + "\\\\\\\\server\\\\share\\\\veryfront.config.ts");\n`,
+        );
+
+        assertEquals(eightBit.message.includes("server"), false);
+        assertStringIncludes(eightBit.message, "[path]");
+
+        // The completed form already worked: `m` is consumed as the final byte, so
+        // both separators survived. Pinned so a later change cannot regress the
+        // half that was never broken while fixing the half that was.
+        const completed = await loadFailure(
+          "vf-config-csi-unc-completed-",
+          `throw new Error(String.fromCharCode(27) + "[31m\\\\\\\\server\\\\share\\\\veryfront.config.ts");\n`,
+        );
+
+        assertEquals(completed.message.includes("server"), false);
+        assertStringIncludes(completed.message, "[path]");
+      });
+
       it("reports a CSI-glued file URL as a path, not a remote URL", async () => {
         const error = await loadFailure(
           "vf-config-csi-glued-file-url-",

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1174,28 +1174,64 @@ export default config as const;
         assertEquals(error.message.includes("alice"), false);
       });
 
+      /**
+       * Fastest of `runs` timed `loadFailure` calls, with the error it raised.
+       *
+       * A single timing is the wrong instrument here. `loadFailure` writes a temp
+       * file and loads a module, which costs tens of milliseconds before any
+       * redaction runs, while the backtracking these two tests exist to catch
+       * costs about 16ms at 100k characters when it is bounded. The signal is
+       * therefore smaller than the harness noise, and one scheduler hiccup on a
+       * shared runner is enough to fail the ratio: this went red at
+       * `probe 5450ms vs control 39ms` on a change measured to leave every
+       * pattern's cost byte-identical.
+       *
+       * Noise only ever adds time, so the minimum of several runs is the closest
+       * available estimate of the true cost. Unbounded backtracking is not
+       * intermittent -- it is paid on every run -- so taking the minimum cannot
+       * hide the thing being guarded against, which is what makes this safe
+       * rather than a way of making a red test green.
+       */
+      async function fastestLoad(
+        prefix: string,
+        source: string,
+        runs = 3,
+      ): Promise<{ ms: number; error: VeryfrontError }> {
+        const start = Date.now();
+        let error = await loadFailure(prefix, source);
+        let ms = Date.now() - start;
+        for (let run = 1; run < runs; run += 1) {
+          const runStart = Date.now();
+          error = await loadFailure(prefix, source);
+          ms = Math.min(ms, Date.now() - runStart);
+        }
+
+        return { ms, error };
+      }
+
       it("summarizes a very long cause in time proportional to its length", async () => {
         // A wall-clock bound would couple this to runner speed, and a partial
         // reintroduction of backtracking that stayed under it would pass
         // silently. Instead time two inputs of the SAME length on the SAME
         // machine, differing only in whether the pathological retry can start:
-        // digits cannot begin a scheme, letters can. Both measurements pay the
-        // same fixed overhead, so the ratio isolates the backtracking cost.
+        // digits cannot begin a scheme, letters can, so the ratio isolates the
+        // backtracking cost from the harness overhead both inputs pay.
+        //
+        // That overhead is the same in expectation but NOT run to run, which is
+        // why each side is the fastest of several runs -- see `fastestLoad`. A
+        // single pair of timings failed here once at 5450ms vs 39ms on a change
+        // measured to leave every pattern's cost unchanged.
         const size = 100000;
 
-        const controlStart = Date.now();
-        await loadFailure(
+        const control = await fastestLoad(
           "vf-config-long-control-",
           `throw new Error("1".repeat(${size}));\n`,
         );
-        const controlMs = Math.max(1, Date.now() - controlStart);
-
-        const probeStart = Date.now();
-        const error = await loadFailure(
+        const controlMs = Math.max(1, control.ms);
+        const { ms: probeMs, error } = await fastestLoad(
           "vf-config-long-probe-",
           `throw new Error("a".repeat(${size}));\n`,
         );
-        const probeMs = Date.now() - probeStart;
 
         // Bounded, the two are within noise of each other. Unbounded, the probe
         // measured ~17.9s against an unchanged control.
@@ -1220,19 +1256,15 @@ export default config as const;
         // is how this guard silently went vacuous once, and why it is `ab://`.
         const repeats = 20000;
 
-        const controlStart = Date.now();
-        await loadFailure(
+        const control = await fastestLoad(
           "vf-config-starts-control-",
           `throw new Error("1b://(".repeat(${repeats}));\n`,
         );
-        const controlMs = Math.max(1, Date.now() - controlStart);
-
-        const probeStart = Date.now();
-        const error = await loadFailure(
+        const controlMs = Math.max(1, control.ms);
+        const { ms: probeMs, error } = await fastestLoad(
           "vf-config-starts-probe-",
           `throw new Error("ab://(".repeat(${repeats}));\n`,
         );
-        const probeMs = Date.now() - probeStart;
 
         assertEquals(
           probeMs < controlMs * 20,

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1028,6 +1028,38 @@ export default config as const;
         assertEquals(error.message.includes("((x))"), false);
       });
 
+      it("redacts a zero-slash special-scheme URL", async () => {
+        const error = await loadFailure(
+          "vf-config-zero-slash-scheme-",
+          `throw new Error("Fetch https:registry.internal/config.ts failed");\n`,
+        );
+
+        // `https:host/x` parses to `https://host/x`, so the hostname is as real
+        // as in the two-slash form. Both URL patterns above require a slash, and
+        // POSIX_ABSOLUTE_PATH refuses `/config.ts` after an alphanumeric.
+        assertStringIncludes(error.message, "[url]");
+        assertEquals(error.message.includes("registry.internal"), false);
+      });
+
+      it("does not treat a drive letter or ordinary prose as a zero-slash URL", async () => {
+        const drive = await loadFailure(
+          "vf-config-zero-slash-drive-",
+          `throw new Error("Load " + String.fromCharCode(67) + ":/Users/alice/veryfront.config.ts");\n`,
+        );
+
+        assertStringIncludes(drive.message, "[path]");
+        assertEquals(drive.message.includes("alice"), false);
+
+        // The scheme list is closed for exactly this reason: a generic
+        // `scheme:` shape would claim prose, and at one character, drive letters.
+        const prose = await loadFailure(
+          "vf-config-zero-slash-prose-",
+          `throw new Error("warning:something happened");\n`,
+        );
+
+        assertStringIncludes(prose.message, "warning:something happened");
+      });
+
       it("redacts a URL whose userinfo contains an apostrophe", async () => {
         const error = await loadFailure(
           "vf-config-apostrophe-userinfo-",

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1322,6 +1322,60 @@ export default config as const;
         assertStringIncludes(colorized.message, "[path]");
       });
 
+      it("keeps a special-scheme URL intact when a CSI introducer precedes it", async () => {
+        const zeroSlash = await loadFailure(
+          "vf-config-csi-zero-slash-url-",
+          `throw new Error(String.fromCharCode(27) + "[https:registry.internal/veryfront.config.ts");\n`,
+        );
+
+        // `h` is a legal CSI final byte, so the CSI pass consumed `ESC[h` and left
+        // `ttps:registry.internal/...`. ZERO_SLASH_SCHEME_URL no longer recognises
+        // the damaged scheme, and POSIX_ABSOLUTE_PATH refuses a `/` that follows a
+        // hostname, so the private host reached the caller-visible error.
+        assertEquals(zeroSlash.message.includes("registry.internal"), false);
+        assertStringIncludes(zeroSlash.message, "[url]");
+
+        const upper = await loadFailure(
+          "vf-config-csi-zero-slash-upper-",
+          `throw new Error(String.fromCharCode(27) + "[WSS:registry.internal/veryfront.config.ts");\n`,
+        );
+
+        // Every special scheme leaks the same way, and schemes are case-insensitive.
+        assertEquals(upper.message.includes("registry.internal"), false);
+        assertStringIncludes(upper.message, "[url]");
+
+        const eightBit = await loadFailure(
+          "vf-config-csi-zero-slash-8bit-",
+          `throw new Error(String.fromCharCode(155) + "ftp:registry.internal/veryfront.config.ts");\n`,
+        );
+
+        assertEquals(eightBit.message.includes("registry.internal"), false);
+        assertStringIncludes(eightBit.message, "[url]");
+
+        const singleSlash = await loadFailure(
+          "vf-config-csi-single-slash-url-",
+          `throw new Error(String.fromCharCode(27) + "[https:/registry.internal/veryfront.config.ts");\n`,
+        );
+
+        // This form did not leak -- the damaged `ttp` still hit the drive-letter
+        // alternative -- but it emitted `ttp[path]`, the path-as-URL mislabel this
+        // change exists to remove.
+        assertEquals(singleSlash.message.includes("registry.internal"), false);
+        assertEquals(singleSlash.message.includes("[path]"), false);
+        assertStringIncludes(singleSlash.message, "[url]");
+
+        const prose = await loadFailure(
+          "vf-config-csi-reset-prose-",
+          `throw new Error(String.fromCharCode(27) + "[0mError: cannot find module");\n`,
+        );
+
+        // The scheme lookahead is restricted to the special schemes for this case:
+        // a generic `[A-Za-z][A-Za-z0-9+.-]*:` would match the `mError:` prose here,
+        // strip `ESC[0`, and leave a stray `m` in an ordinary diagnostic.
+        assertStringIncludes(prose.message, "Error: cannot find module");
+        assertEquals(prose.message.includes("mError"), false);
+      });
+
       it("classifies a drive path glued to diagnostic text as a path, not a URL", async () => {
         const drive = await loadFailure(
           "vf-config-glued-fwd-drive-",

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1041,6 +1041,28 @@ export default config as const;
         assertEquals(error.message.includes("registry.internal"), false);
       });
 
+      it("redacts a zero-slash URL and a file URL whatever the scheme's case", async () => {
+        const upper = await loadFailure(
+          "vf-config-uppercase-zero-slash-",
+          `throw new Error("Fetch HTTPS:registry.internal/config.ts failed");\n`,
+        );
+
+        // A URL scheme is case-insensitive. The sibling patterns get that free
+        // from `[A-Za-z]`; a literal scheme list does not.
+        assertStringIncludes(upper.message, "[url]");
+        assertEquals(upper.message.includes("registry.internal"), false);
+
+        const fileUrl = await loadFailure(
+          "vf-config-uppercase-file-url-",
+          `throw new Error("Load FILE:///home/alice/veryfront.config.ts");\n`,
+        );
+
+        // Reported as a path, not a URL: an uppercase scheme previously fell
+        // past FILE_URL_ABSOLUTE_PATH to SCHEME_URL and came back as `[url]`.
+        assertStringIncludes(fileUrl.message, "[path]");
+        assertEquals(fileUrl.message.includes("alice"), false);
+      });
+
       it("does not treat a drive letter or ordinary prose as a zero-slash URL", async () => {
         const drive = await loadFailure(
           "vf-config-zero-slash-drive-",

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -971,20 +971,38 @@ export default config as const;
         assertEquals(error.message.includes("C:\\Users\\example"), false);
       });
 
-      it("keeps a hosted config URL intact while still redacting machine paths", async () => {
+      it("redacts a hosted config URL cleanly instead of mangling it into a path", async () => {
         const error = await loadFailure(
-          "vf-config-url-not-a-path-",
+          "vf-config-url-redaction-",
           `throw new Error("Failed to fetch https://cdn.example.test/hosted/config.ts from /home/example/project/veryfront.config.ts");\n`,
         );
 
-        // The drive-letter alternative used to match the `s:/` inside `https:/`
-        // and eat the rest of the URL, so this line arrived as `http[path]` --
-        // losing the only token the reader can act on (veryfront-issue-inbox#836).
-        assertStringIncludes(error.message, "https://cdn.example.test/hosted/config.ts");
+        // The drive-letter alternative matches the `s:/` inside `https:/`, so an
+        // unguarded pass reported `http[path]` -- neither the URL nor an honest
+        // redaction marker. AGENTS.md counts private hostnames among the values
+        // user-facing output must not carry, so the URL is redacted whole rather
+        // than preserved (veryfront-issue-inbox#836).
+        assertStringIncludes(error.message, "[url]");
         assertEquals(error.message.includes("http[path]"), false);
-        // The real machine path on the same line is still redacted.
+        assertEquals(error.message.includes("cdn.example.test"), false);
+        // The machine path on the same line is still redacted separately.
         assertStringIncludes(error.message, "[path]");
         assertEquals(error.message.includes("/home/example"), false);
+      });
+
+      it("redacts a colorized machine path instead of leaving SGR residue in front of it", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-ansi-path-",
+          `throw new Error("Failed to load ${escape}[31m/home/example/project/veryfront.config.ts");\n`,
+        );
+
+        // Dropping only the ESC as a control character leaves `[31m` sitting
+        // between the boundary and the path, which defeats any pattern anchored
+        // on what precedes it. The whole SGR sequence is removed first.
+        assertStringIncludes(error.message, "[path]");
+        assertEquals(error.message.includes("/home/example"), false);
+        assertEquals(error.message.includes("31m"), false);
       });
 
       it("classifies Bun resolver objects that do not inherit from Error", async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1003,6 +1003,18 @@ export default config as const;
         assertEquals(error.message.includes("registry.internal"), false);
       });
 
+      it("redacts a single-slash URL-like token without misclassifying Windows paths", async () => {
+        const error = await loadFailure(
+          "vf-config-single-slash-url-",
+          `throw new Error("Fetch https:/registry.internal/config.ts beside C:/Users/alice/config.ts");\n`,
+        );
+
+        assertStringIncludes(error.message, "Fetch [url] beside [path]");
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertEquals(error.message.includes("C:/Users"), false);
+        assertEquals(error.message.includes("http[path]"), false);
+      });
+
       it("redacts a colorized machine path instead of leaving SGR residue in front of it", async () => {
         const escape = String.fromCharCode(27);
         const error = await loadFailure(

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1028,6 +1028,23 @@ export default config as const;
         assertEquals(error.message.includes("alice"), false);
       });
 
+      it("summarizes a very long cause without quadratic rescanning", async () => {
+        const start = Date.now();
+        const error = await loadFailure(
+          "vf-config-long-cause-",
+          `throw new Error("a".repeat(100000));\n`,
+        );
+        const elapsed = Date.now() - start;
+
+        // REMOTE_URL is unanchored and runs over the whole message before the
+        // 200-character cap applies. With an unbounded scheme prefix it rescans
+        // to the end of the input at every letter, which measured ~17.9s for
+        // this input; bounding the scheme brings it to ~35ms. The threshold is
+        // deliberately loose -- it only has to separate those two orders.
+        assertEquals(elapsed < 5000, true, `summarize took ${elapsed}ms`);
+        assertEquals(error.slug, CONFIG_PARSE_ERROR_SLUG);
+      });
+
       it("strips a colon-parameter CSI sequence, not only the digit-and-semicolon form", async () => {
         const escape = String.fromCharCode(27);
         const error = await loadFailure(

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1222,6 +1222,11 @@ export default config as const;
         // tell them from a path -- the path has to be matched while still intact.
         assertEquals(posix.message.includes("alice"), false);
         assertEquals(posix.message.includes("ome/alice"), false);
+        // Assert the marker, not only the absence of the secret. Redacting the
+        // path before the CSI pass instead of removing just the introducer
+        // produced `ESC[[path]`, and `[` is a valid CSI final byte, so the pass
+        // ate the marker's own bracket and emitted `path]`.
+        assertStringIncludes(posix.message, "[path]");
 
         const drive = await loadFailure(
           "vf-config-csi-glued-drive-",
@@ -1232,6 +1237,30 @@ export default config as const;
         // and `:\Users\alice` no longer matches WINDOWS_ABSOLUTE_PATH.
         assertEquals(drive.message.includes("alice"), false);
         assertEquals(drive.message.includes("Users"), false);
+        assertStringIncludes(drive.message, "[path]");
+      });
+
+      it("classifies a drive path glued to diagnostic text as a path, not a URL", async () => {
+        const drive = await loadFailure(
+          "vf-config-glued-fwd-drive-",
+          `throw new Error("Failed at" + String.fromCharCode(67) + ":/Users/alice/veryfront.config.ts");\n`,
+        );
+
+        // A generic scheme shape claimed `atC` here, reporting `Failed [url]` --
+        // mislabelling a local path and eating the word `at`. The single-slash
+        // form is restricted to the special schemes for exactly this reason.
+        assertStringIncludes(drive.message, "Failed at[path]");
+        assertEquals(drive.message.includes("alice"), false);
+
+        const url = await loadFailure(
+          "vf-config-glued-single-slash-url-",
+          `throw new Error("Failed athttps:/registry.internal/veryfront.config.ts");\n`,
+        );
+
+        // The glued URL still redacts; the match just starts later in the token,
+        // so the diagnostic keeps `at` instead of losing it.
+        assertStringIncludes(url.message, "Failed at[url]");
+        assertEquals(url.message.includes("registry.internal"), false);
       });
 
       it("strips a colon-parameter CSI sequence, not only the digit-and-semicolon form", async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1028,6 +1028,20 @@ export default config as const;
         assertEquals(error.message.includes("((x))"), false);
       });
 
+      it("redacts a URL whose userinfo contains an apostrophe", async () => {
+        const error = await loadFailure(
+          "vf-config-apostrophe-userinfo-",
+          `throw new Error("Fetch https://user'name:<TOKEN>@registry.internal/config.ts failed");\n`,
+        );
+
+        // `'` is an RFC 3986 sub-delim, so this is a legal authority. The tail of
+        // the token still stops at an apostrophe, which is what keeps quoted
+        // config messages intact.
+        assertStringIncludes(error.message, "[url]");
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertEquals(error.message.includes("user'name"), false);
+      });
+
       it("redacts a URL whose path nests parentheses", async () => {
         const error = await loadFailure(
           "vf-config-nested-paren-path-",

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -1028,6 +1028,34 @@ export default config as const;
         assertEquals(error.message.includes("((x))"), false);
       });
 
+      it("keeps a left boundary when a CSI introducer is glued to preceding text", async () => {
+        const error = await loadFailure(
+          "vf-config-csi-between-text-and-path-",
+          `throw new Error("Failed at" + String.fromCharCode(27) + "[/home/alice/veryfront.config.ts");\n`,
+        );
+
+        // The introducer is replaced with a space, not removed. Removing it would
+        // join `at` to `/home/alice`, and POSIX_ABSOLUTE_PATH's lookbehind refuses
+        // a slash following an alphanumeric -- manufacturing the exact adjacency
+        // that defeats the pass meant to catch it.
+        assertStringIncludes(error.message, "[path]");
+        assertEquals(error.message.includes("alice"), false);
+        assertEquals(error.message.includes("at/home"), false);
+      });
+
+      it("treats a drive letter with a doubled separator as a path, not a URL", async () => {
+        const error = await loadFailure(
+          "vf-config-drive-double-slash-",
+          `throw new Error("Load " + String.fromCharCode(67) + "://Users/alice/veryfront.config.ts");\n`,
+        );
+
+        // Node normalises `C://Users/...` as an absolute drive path. A one-letter
+        // scheme would claim it as a URL, which is the path-as-URL mislabel this
+        // PR exists to remove; no registered scheme is a single character.
+        assertStringIncludes(error.message, "[path]");
+        assertEquals(error.message.includes("alice"), false);
+      });
+
       it("redacts a zero-slash special-scheme URL", async () => {
         const error = await loadFailure(
           "vf-config-zero-slash-scheme-",
@@ -1184,21 +1212,25 @@ export default config as const;
         // every `a://` starts a URL match that then fails on `(`, and an unbounded
         // parenthesised interior rescans the rest of the message from each one.
         // Measured unbounded: 2.6s for 20k repeats, growing 4x per doubling.
-        // Bounded: 53ms, growing 2x. Same control/probe ratio method -- a digit
+        // Bounded: 47ms, growing 2x. Same control/probe ratio method -- a digit
         // cannot begin a scheme, so the control never starts a match at all.
+        //
+        // Two characters, not one: SCHEME_URL requires a scheme of at least two,
+        // so `a://` stops matching entirely and the probe measures nothing. That
+        // is how this guard silently went vacuous once, and why it is `ab://`.
         const repeats = 20000;
 
         const controlStart = Date.now();
         await loadFailure(
           "vf-config-starts-control-",
-          `throw new Error("1://(".repeat(${repeats}));\n`,
+          `throw new Error("1b://(".repeat(${repeats}));\n`,
         );
         const controlMs = Math.max(1, Date.now() - controlStart);
 
         const probeStart = Date.now();
         const error = await loadFailure(
           "vf-config-starts-probe-",
-          `throw new Error("a://(".repeat(${repeats}));\n`,
+          `throw new Error("ab://(".repeat(${repeats}));\n`,
         );
         const probeMs = Date.now() - probeStart;
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1655,7 +1655,18 @@ const ANSI_CSI_SEQUENCE = /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\
 // end of the input at every position starting with a letter, so a long
 // alphabetic message with no colon costs O(n^2) -- 100k characters measured at
 // ~17.9s, versus ~34ms bounded. Every registered scheme is far shorter than 31.
-const SCHEME_URL = /[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\/(?:[^\s"]*@)?(?:[^\s"'()]|\([^\s"']*\))+/g;
+const SCHEME_URL =
+  /[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\/(?:[^\s"\/]{0,512}@)?(?:[^\s"'()]|\([^\s"']{0,512}\))+/g;
+// Both the userinfo run and the parenthesised interior are length-bounded, and
+// the userinfo run also stops at `/`. Neither bound is cosmetic. An unbounded
+// greedy interior rescans the rest of the message from every `(` that never
+// finds a `)`, so `"a://(".repeat(20_000)` cost 2.6s and grew 4x per doubling --
+// quadratic, and reachable from a project-authored error because
+// summarizeConfigLoadCause runs this before the 200-character cap. Bounded, the
+// same input is 42ms and grows 2x per doubling. `/` cannot appear unencoded in
+// userinfo (it terminates the authority), so excluding it costs nothing and
+// keeps that run inside the authority rather than the whole message.
+//
 // The interior of a parenthesised segment is `[^\s"']*`, not `[^\s"'()]*`: a
 // flat interior matches one nesting level, so `/a((TOKEN))` ended the token at
 // the first `(` and left `((TOKEN))` in the caller-visible detail -- a URL path
@@ -1684,10 +1695,10 @@ const SCHEME_URL = /[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\/(?:[^\s"]*@)?(?:[^\s"'()]|\
 // The scheme needs at least two characters here, which is what keeps a genuine
 // `C:/Users/...` out -- a drive letter is always exactly one.
 const MALFORMED_SCHEME_URL =
-  /[A-Za-z][A-Za-z0-9+.-]{1,31}:\/(?!\/)(?:[^\s"]*@)?(?:[^\s"'()]|\([^\s"']*\))+/g;
+  /[A-Za-z][A-Za-z0-9+.-]{1,31}:\/(?!\/)(?:[^\s"\/]{0,512}@)?(?:[^\s"'()]|\([^\s"']{0,512}\))+/g;
 const QUOTED_WINDOWS_ABSOLUTE_PATH = /(?<=["'])(?:[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+(?=["'])/g;
 const QUOTED_POSIX_ABSOLUTE_PATH = /(?<=["'])\/[^"'\r\n]+(?=["'])/g;
-const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/(?:[^\s"'()]|\([^\s"']*\))+/g;
+const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/(?:[^\s"'()]|\([^\s"']{0,512}\))+/g;
 // Unanchored on the left. A boundary here refuses a path glued to preceding
 // text (`Failed atC:\\Users\\alice\\...`), and neither URL pattern can claim a
 // backslash form, so the path would reach the caller intact. The scheme match in

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1655,9 +1655,22 @@ const ANSI_CSI_SEQUENCE = /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\
 //
 // The intermediate run stops at 0x2E rather than the grammar's 0x2F, because
 // 0x2F is `/` -- the first character of the path this pass exists to preserve.
+//
+// The final byte is optional so a *completed* sequence is covered too, not only
+// an introducer. `Failed at` + `ESC[3~` + `/home/alice/x` is a legal CSI whose
+// final byte is `~`; removing it during de-colorization joined `at` to the path,
+// POSIX_ABSOLUTE_PATH's lookbehind then refused the slash, and the path reached
+// the caller. Optional rather than required, because `ESC[/home` has no final
+// byte before the path at all.
+//
+// The sequence is taken here rather than by making de-colorization emit a space
+// instead of nothing. That pass must keep emitting nothing: `sk-` + `ESC[0m` +
+// `ABCD1234EFGH5678` only rejoins into a contiguous credential if the removal
+// leaves no gap, and the sanitiser that runs after it matches nothing otherwise.
+// Fixing a path boundary must not reopen that.
 const CSI_GLUED_PATH =
   // deno-lint-ignore no-control-regex
-  /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002E]*(?=[\\/]|[A-Za-z]:[\\/])/g;
+  /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002E]*[\u0040-\u007E]?(?=[\\/]|[A-Za-z]:[\\/])/g;
 // The same pre-pass for a special-scheme URL start, which the CSI grammar eats
 // exactly as it eats a path. In `ESC[https:registry.internal/x`, `h` is a legal
 // final byte, so the CSI pass left `ttps:registry.internal/x`:
@@ -1675,8 +1688,12 @@ const CSI_GLUED_PATH =
 // earlier in this PR, when `REMOTE_URL` became SCHEME_URL and
 // MALFORMED_SCHEME_URL. Each pass reads as one rule.
 //
-// Only the special schemes are listed, matching MALFORMED_SCHEME_URL and
-// ZERO_SLASH_SCHEME_URL -- keep the three in sync. A generic
+// The list is every scheme the redactor itself recognises: the special schemes
+// of MALFORMED_SCHEME_URL and ZERO_SLASH_SCHEME_URL, plus `file`, which
+// FILE_URL_ABSOLUTE_PATH claims. `file` is here because `f` is a legal final
+// byte, so `ESC[file:///home/alice/x` lost `ESC[f` and SCHEME_URL read the
+// remaining `ile:///home/alice/x` as a remote URL -- reporting `[url]` for a
+// local path. Keep this list in sync with those three. A generic
 // `[A-Za-z][A-Za-z0-9+.-]*:` lookahead cannot be used: it matches the prose in
 // `ESC[0mError: cannot find module`, which would strip `ESC[0` and leave a
 // stray `m` in an ordinary diagnostic. A generic `scheme://` needs no help
@@ -1686,7 +1703,7 @@ const CSI_GLUED_PATH =
 // both cases (`[A-Za-z]`) or contains no letters at all.
 const CSI_GLUED_URL =
   // deno-lint-ignore no-control-regex
-  /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002E]*(?=(?:https?|wss?|ftp):)/gi;
+  /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002E]*[\u0040-\u007E]?(?=(?:https?|wss?|ftp|file):)/gi;
 // The scheme needs at least two characters: `C://Users/alice` is a drive path
 // that Node normalises, not a URL with the one-letter scheme `C`, and matching it
 // here reintroduced the path-as-URL mislabel this PR exists to remove. No

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1655,7 +1655,14 @@ const ANSI_CSI_SEQUENCE = /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\
 // end of the input at every position starting with a letter, so a long
 // alphabetic message with no colon costs O(n^2) -- 100k characters measured at
 // ~17.9s, versus ~34ms bounded. Every registered scheme is far shorter than 31.
-const SCHEME_URL = /[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\/(?:[^\s"']*@)?(?:[^\s"'()]|\([^\s"'()]*\))+/g;
+const SCHEME_URL = /[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\/(?:[^\s"']*@)?(?:[^\s"'()]|\([^\s"']*\))+/g;
+// The interior of a parenthesised segment is `[^\s"']*`, not `[^\s"'()]*`: a
+// flat interior matches one nesting level, so `/a((TOKEN))` ended the token at
+// the first `(` and left `((TOKEN))` in the caller-visible detail -- a URL path
+// or query fragment, which can carry the value it was redacting. A greedy
+// interior backtracks to the last `)` in the run, so any nesting depth is
+// consumed in one pass. A token with no `(` at all is unaffected, which is what
+// still leaves a trailing prose `)` outside the match.
 // Userinfo gets its own permissive run up to `@`, rather than relying on the
 // balanced-parentheses alternative that covers the rest of the token. That
 // alternative matches one flat `(...)` pair, so a legal nested userinfo such as
@@ -1671,10 +1678,10 @@ const SCHEME_URL = /[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\/(?:[^\s"']*@)?(?:[^\s"'()]|
 // The scheme needs at least two characters here, which is what keeps a genuine
 // `C:/Users/...` out -- a drive letter is always exactly one.
 const MALFORMED_SCHEME_URL =
-  /[A-Za-z][A-Za-z0-9+.-]{1,31}:\/(?!\/)(?:[^\s"']*@)?(?:[^\s"'()]|\([^\s"'()]*\))+/g;
+  /[A-Za-z][A-Za-z0-9+.-]{1,31}:\/(?!\/)(?:[^\s"']*@)?(?:[^\s"'()]|\([^\s"']*\))+/g;
 const QUOTED_WINDOWS_ABSOLUTE_PATH = /(?<=["'])(?:[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+(?=["'])/g;
 const QUOTED_POSIX_ABSOLUTE_PATH = /(?<=["'])\/[^"'\r\n]+(?=["'])/g;
-const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/(?:[^\s"'()]|\([^\s"'()]*\))+/g;
+const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/(?:[^\s"'()]|\([^\s"']*\))+/g;
 // Unanchored on the left. A boundary here refuses a path glued to preceding
 // text (`Failed atC:\\Users\\alice\\...`), and neither URL pattern can claim a
 // backslash form, so the path would reach the caller intact. The scheme match in

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1653,14 +1653,23 @@ const ANSI_CSI_SEQUENCE = /\u001B\[[\u0030-\u003F]*[\u0020-\u002F]*[\u0040-\u007
 // to the Windows pattern. A single-slash form requires a scheme of at least two
 // characters, which catches malformed `https:/host/x` without misclassifying
 // the genuine Windows path `C:/Users/...` as a URL.
-// The scheme length is bounded because this pattern is unanchored and runs
-// over the whole message before the 200-character cap applies. Unbounded, the
-// greedy scheme prefix rescans to the end of the input at every position that
-// starts with a letter, so an ordinary long alphabetic message with no colon
-// costs O(n^2): 100k characters measured at ~17.9s, versus ~32ms bounded.
-// Real schemes are short -- 31 characters is well past every registered one.
-const REMOTE_URL =
-  /(?:[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\/|[A-Za-z][A-Za-z0-9+.-]{1,31}:\/(?!\/))[^\s"'()]+/g;
+// The ordinary form. Unanchored on the left so a scheme glued to preceding
+// text (`3https://host/x`) is still recognised rather than falling through to
+// the Windows pattern.
+//
+// The scheme length is bounded because this runs over the whole message before
+// the 200-character cap applies. Unbounded, the greedy prefix rescans to the
+// end of the input at every position starting with a letter, so a long
+// alphabetic message with no colon costs O(n^2) -- 100k characters measured at
+// ~17.9s, versus ~34ms bounded. Every registered scheme is far shorter than 31.
+const SCHEME_URL = /[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\/[^\s"'()]+/g;
+// The malformed single-slash form, kept separate from SCHEME_URL rather than
+// folded in as an alternation: two plain patterns read more clearly than one
+// branching expression, and each stays independently checkable.
+//
+// The scheme needs at least two characters here, which is what keeps a genuine
+// `C:/Users/...` out -- a drive letter is always exactly one.
+const MALFORMED_SCHEME_URL = /[A-Za-z][A-Za-z0-9+.-]{1,31}:\/(?!\/)[^\s"'()]+/g;
 const QUOTED_WINDOWS_ABSOLUTE_PATH = /(?<=["'])(?:[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+(?=["'])/g;
 const QUOTED_POSIX_ABSOLUTE_PATH = /(?<=["'])\/[^"'\r\n]+(?=["'])/g;
 const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/[^\s"'()]+/g;
@@ -1722,7 +1731,8 @@ function redactMachinePaths(value: string): string {
   let redacted = replaceMatchesWithCapturedExec(value, QUOTED_WINDOWS_ABSOLUTE_PATH, "[path]");
   redacted = replaceMatchesWithCapturedExec(redacted, QUOTED_POSIX_ABSOLUTE_PATH, "[path]");
   redacted = replaceMatchesWithCapturedExec(redacted, FILE_URL_ABSOLUTE_PATH, "[path]");
-  redacted = replaceMatchesWithCapturedExec(redacted, REMOTE_URL, "[url]");
+  redacted = replaceMatchesWithCapturedExec(redacted, SCHEME_URL, "[url]");
+  redacted = replaceMatchesWithCapturedExec(redacted, MALFORMED_SCHEME_URL, "[url]");
   redacted = replaceMatchesWithCapturedExec(redacted, WINDOWS_ABSOLUTE_PATH, "[path]");
   return replaceMatchesWithCapturedExec(redacted, POSIX_ABSOLUTE_PATH, "[path]");
 }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1641,6 +1641,11 @@ const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F-\u009F]/g;
 // defeated POSIX_ABSOLUTE_PATH exactly as an unstripped `[31m` would.
 // deno-lint-ignore no-control-regex
 const ANSI_CSI_SEQUENCE = /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\u0040-\u007E]/g;
+// A CSI introducer immediately followed by a path start. Removed before the
+// full CSI pass so that pass cannot consume the path's first characters; see
+// summarizeConfigLoadCause for why the path itself is not redacted here.
+// deno-lint-ignore no-control-regex
+const CSI_GLUED_PATH = /(?:\u001B\[|\u009B)(?=[\\/]|[A-Za-z]:[\\/])/g;
 // A remote config URL is redacted whole rather than picked apart: AGENTS.md
 // counts private hostnames among the values user-facing output must not carry,
 // and the caller cannot tell an internal registry from a public CDN by looking
@@ -1692,10 +1697,15 @@ const SCHEME_URL =
 // folded in as an alternation: two plain patterns read more clearly than one
 // branching expression, and each stays independently checkable.
 //
-// The scheme needs at least two characters here, which is what keeps a genuine
-// `C:/Users/...` out -- a drive letter is always exactly one.
+// Restricted to the WHATWG special schemes, like the zero-slash form below and
+// for a sharper version of the same reason. A generic `[A-Za-z][...]{1,31}:`
+// shape claimed `atC` in `Failed atC:/Users/alice/x` -- reporting `Failed [url]`,
+// which both mislabels a local path and eats the word `at`. A two-character
+// minimum is not enough to separate a scheme from prose glued to a drive letter.
+// A glued *URL* still redacts: the match simply starts later in the token, so
+// `Failed athttps:/registry.internal/x` gives `Failed at[url]` and keeps `at`.
 const MALFORMED_SCHEME_URL =
-  /[A-Za-z][A-Za-z0-9+.-]{1,31}:\/(?!\/)(?:[^\s"\/]{0,512}@)?(?:[^\s"'()]|\([^\s"']{0,512}\))+/g;
+  /(?:https?|wss?|ftp):\/(?!\/)(?:[^\s"\/]{0,512}@)?(?:[^\s"'()]|\([^\s"']{0,512}\))+/gi;
 // The zero-slash form of a WHATWG special scheme. `https:registry.internal/x`
 // parses to `https://registry.internal/x`, so the hostname is just as real as in
 // the two-slash form, but neither pattern above matches it -- both require at
@@ -1772,6 +1782,11 @@ function replaceMatchesWithCapturedExec(
  * before it sanitises credentials. Colorized text leaves `[31m` style residue
  * directly in front of a path once the escape itself is gone, which defeats the
  * boundary lookbehind step 5 relies on.
+ *
+ * That caller also removes a CSI introducer glued to a path start beforehand
+ * (`CSI_GLUED_PATH`), because the CSI grammar would otherwise consume the path's
+ * own first characters. It removes only the introducer, so this function still
+ * runs exactly once and still runs after de-colorization.
  */
 function redactMachinePaths(value: string): string {
   let redacted = replaceMatchesWithCapturedExec(value, QUOTED_WINDOWS_ABSOLUTE_PATH, "[path]");
@@ -1805,17 +1820,22 @@ function summarizeConfigLoadCause(error: unknown): string | undefined {
   // consume the first character of a key such as API_KEY. Either ordering alone
   // can therefore expose a usable value after the transformation.
   const initiallyRedacted = sanitizeUrlCredentials(message);
-  // Redact paths on both sides of de-colorization too, and for the same reason.
-  // A CSI introducer sitting directly against an absolute path consumes the
-  // start of it: `/` is a valid intermediate byte and `h` a valid final, so
-  // `ESC[/home/alice/x` loses `ESC[/h` and leaves `ome/alice/x`, which no later
-  // path pattern recognises. `ESC[C:\\Users\\alice` loses the drive letter the
-  // same way. Both are legal CSI sequences, so no tightening of the grammar can
-  // tell them apart from a path -- the only fix is to match the path while it is
-  // still intact.
-  const pathsPreRedacted = redactMachinePaths(initiallyRedacted);
+  // Drop a CSI introducer that is glued to the start of a path, before the CSI
+  // pass can eat into the path itself. `/` is a valid intermediate byte and `h`
+  // a valid final, so `ESC[/home/alice/x` would lose `ESC[/h` and leave
+  // `ome/alice/x`, which no later path pattern recognises; `ESC[C:\\Users` would
+  // lose the drive letter the same way. Both are legal CSI sequences, so no
+  // tightening of the grammar separates them from a path.
+  //
+  // Only the introducer is removed, not the path: redacting here instead would
+  // produce `ESC[[path]`, and `[` is itself a valid CSI final byte, so the pass
+  // below would eat the marker's opening bracket and emit `path]`. Removing just
+  // the introducer leaves the path intact for the single redaction pass at the
+  // end, which keeps `redactMachinePaths` running exactly once and after
+  // de-colorization -- the precondition its own docstring states.
+  const unglued = replaceMatchesWithCapturedExec(initiallyRedacted, CSI_GLUED_PATH, "");
   const deColorized = replaceMatchesWithCapturedExec(
-    pathsPreRedacted,
+    unglued,
     ANSI_CSI_SEQUENCE,
     "",
   );

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1703,11 +1703,20 @@ const MALFORMED_SCHEME_URL =
 // alphanumeric. Restricted to the special schemes rather than the generic
 // `[A-Za-z][A-Za-z0-9+.-]+:` shape, because that would claim ordinary prose
 // (`warning:something`) and, at one character, drive letters.
+//
+// The `i` flag is load-bearing rather than tidy. A URL scheme is
+// case-insensitive, and the two patterns above get that free from `[A-Za-z]`; a
+// literal list does not, so `HTTPS:registry.internal/x` matched nothing at all
+// and the hostname survived into the caller-visible detail.
 const ZERO_SLASH_SCHEME_URL =
-  /(?:https?|wss?|ftp):(?![\/\s])(?:[^\s"\/]{0,512}@)?(?:[^\s"'()]|\([^\s"']{0,512}\))+/g;
+  /(?:https?|wss?|ftp):(?![\/\s])(?:[^\s"\/]{0,512}@)?(?:[^\s"'()]|\([^\s"']{0,512}\))+/gi;
 const QUOTED_WINDOWS_ABSOLUTE_PATH = /(?<=["'])(?:[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+(?=["'])/g;
 const QUOTED_POSIX_ABSOLUTE_PATH = /(?<=["'])\/[^"'\r\n]+(?=["'])/g;
-const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/(?:[^\s"'()]|\([^\s"']{0,512}\))+/g;
+// Case-insensitive for the same reason. `FILE:///home/alice` otherwise fell
+// past this pattern to SCHEME_URL and came back as `[url]`. Not a leak -- the
+// home directory was redacted either way -- but it reported a local path as a
+// remote URL, which is this PR's original misclassification running backwards.
+const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/(?:[^\s"'()]|\([^\s"']{0,512}\))+/gi;
 // Unanchored on the left. A boundary here refuses a path glued to preceding
 // text (`Failed atC:\\Users\\alice\\...`), and neither URL pattern can claim a
 // backslash form, so the path would reach the caller intact. The scheme match in

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1644,14 +1644,14 @@ const ANSI_SGR_SEQUENCE = /\u001B\[[0-9;]*[A-Za-z]/g;
 //
 // Deliberately unanchored on the left, so a scheme glued to preceding text
 // (`3https://host/x`) is still recognised as a URL rather than falling through
-// to the Windows pattern. Requiring both slashes is what keeps a genuine
-// `C:/Users/...` out: with one slash allowed, that path would match here and be
-// reported as `[url]` instead of `[path]`.
-const REMOTE_URL = /[A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s"'()]+/g;
+// to the Windows pattern. A single-slash form requires a scheme of at least two
+// characters, which catches malformed `https:/host/x` without misclassifying
+// the genuine Windows path `C:/Users/...` as a URL.
+const REMOTE_URL = /(?:[A-Za-z][A-Za-z0-9+.-]*:\/\/|[A-Za-z][A-Za-z0-9+.-]+:\/(?!\/))[^\s"'()]+/g;
 const QUOTED_WINDOWS_ABSOLUTE_PATH = /(?<=["'])(?:[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+(?=["'])/g;
 const QUOTED_POSIX_ABSOLUTE_PATH = /(?<=["'])\/[^"'\r\n]+(?=["'])/g;
 const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/[^\s"'()]+/g;
-const WINDOWS_ABSOLUTE_PATH = /(?:[A-Za-z]:[\\/]|\\\\)[^\s"'()]+/g;
+const WINDOWS_ABSOLUTE_PATH = /(?<![A-Za-z0-9])(?:[A-Za-z]:[\\/]|\\\\)[^\s"'()]+/g;
 const POSIX_ABSOLUTE_PATH = /(?<![A-Za-z0-9:/.\\])\/[^\s"'()]+/g;
 
 function replaceMatchesWithCapturedExec(

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1641,11 +1641,23 @@ const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F-\u009F]/g;
 // defeated POSIX_ABSOLUTE_PATH exactly as an unstripped `[31m` would.
 // deno-lint-ignore no-control-regex
 const ANSI_CSI_SEQUENCE = /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\u0040-\u007E]/g;
-// A CSI introducer immediately followed by a path start. Removed before the
-// full CSI pass so that pass cannot consume the path's first characters; see
+// A CSI introducer, with any parameter and intermediate bytes it carries,
+// immediately followed by a path start. Removed before the full CSI pass so
+// that pass cannot consume the path's first characters; see
 // summarizeConfigLoadCause for why the path itself is not redacted here.
-// deno-lint-ignore no-control-regex
-const CSI_GLUED_PATH = /(?:\u001B\[|\u009B)(?=[\\/]|[A-Za-z]:[\\/])/g;
+//
+// The parameter and intermediate runs are part of the match, not just the bare
+// introducer: `ESC[31C:\\Users\\alice` is a legal CUF sequence whose final byte
+// is the drive letter, and `ESC[31/home/alice` is a legal sequence whose
+// intermediate is the leading `/` and whose final byte is the `h`. Matching only
+// the introducer left `:\\Users\\alice` and `ome/alice` behind, which no later
+// path pattern recognises.
+//
+// The intermediate run stops at 0x2E rather than the grammar's 0x2F, because
+// 0x2F is `/` -- the first character of the path this pass exists to preserve.
+const CSI_GLUED_PATH =
+  // deno-lint-ignore no-control-regex
+  /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002E]*(?=[\\/]|[A-Za-z]:[\\/])/g;
 // The scheme needs at least two characters: `C://Users/alice` is a drive path
 // that Node normalises, not a URL with the one-letter scheme `C`, and matching it
 // here reintroduced the path-as-URL mislabel this PR exists to remove. No

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1653,7 +1653,14 @@ const ANSI_CSI_SEQUENCE = /\u001B\[[\u0030-\u003F]*[\u0020-\u002F]*[\u0040-\u007
 // to the Windows pattern. A single-slash form requires a scheme of at least two
 // characters, which catches malformed `https:/host/x` without misclassifying
 // the genuine Windows path `C:/Users/...` as a URL.
-const REMOTE_URL = /(?:[A-Za-z][A-Za-z0-9+.-]*:\/\/|[A-Za-z][A-Za-z0-9+.-]+:\/(?!\/))[^\s"'()]+/g;
+// The scheme length is bounded because this pattern is unanchored and runs
+// over the whole message before the 200-character cap applies. Unbounded, the
+// greedy scheme prefix rescans to the end of the input at every position that
+// starts with a letter, so an ordinary long alphabetic message with no colon
+// costs O(n^2): 100k characters measured at ~17.9s, versus ~32ms bounded.
+// Real schemes are short -- 31 characters is well past every registered one.
+const REMOTE_URL =
+  /(?:[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\/|[A-Za-z][A-Za-z0-9+.-]{1,31}:\/(?!\/))[^\s"'()]+/g;
 const QUOTED_WINDOWS_ABSOLUTE_PATH = /(?<=["'])(?:[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+(?=["'])/g;
 const QUOTED_POSIX_ABSOLUTE_PATH = /(?<=["'])\/[^"'\r\n]+(?=["'])/g;
 const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/[^\s"'()]+/g;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1675,6 +1675,25 @@ function replaceMatchesWithCapturedExec(
   }
 }
 
+/**
+ * Replace machine-identifying locations in a diagnostic with stable markers.
+ *
+ * The order is load-bearing, narrowest first. Each pass consumes its matches
+ * before the next runs, so an earlier pattern is what keeps a later, greedier
+ * one away from text it would mis-read:
+ *
+ * 1. the quoted forms, whose surrounding quotes bound the match precisely;
+ * 2. `file:///`, which is a path wearing a URL and is reported as `[path]`;
+ * 3. any other `scheme://` URL, reported as `[url]` -- this is also what keeps
+ *    `https:/` away from step 4, whose drive-letter alternative would otherwise
+ *    match the `s:/` inside it and emit `http[path]`;
+ * 4. unquoted Windows drive and UNC paths;
+ * 5. unquoted POSIX paths.
+ *
+ * Callers must strip ANSI sequences first. Colorized text leaves `[31m` style
+ * residue directly in front of a path once the escape itself is gone, which
+ * defeats the boundary lookbehinds steps 3 and 5 rely on.
+ */
 function redactMachinePaths(value: string): string {
   let redacted = replaceMatchesWithCapturedExec(value, QUOTED_WINDOWS_ABSOLUTE_PATH, "[path]");
   redacted = replaceMatchesWithCapturedExec(redacted, QUOTED_POSIX_ABSOLUTE_PATH, "[path]");

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1641,18 +1641,11 @@ const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F-\u009F]/g;
 // defeated POSIX_ABSOLUTE_PATH exactly as an unstripped `[31m` would.
 // deno-lint-ignore no-control-regex
 const ANSI_CSI_SEQUENCE = /\u001B\[[\u0030-\u003F]*[\u0020-\u002F]*[\u0040-\u007E]/g;
-// A remote config URL is redacted whole rather than picked apart. AGENTS.md
+// A remote config URL is redacted whole rather than picked apart: AGENTS.md
 // counts private hostnames among the values user-facing output must not carry,
 // and the caller cannot tell an internal registry from a public CDN by looking
-// at it. Matching the scheme here also keeps `https:/` away from
-// WINDOWS_ABSOLUTE_PATH, whose drive-letter alternative would otherwise match
-// the `s:/` inside it and report `http[path]` (veryfront-issue-inbox#836).
+// at it (veryfront-issue-inbox#836).
 //
-// Deliberately unanchored on the left, so a scheme glued to preceding text
-// (`3https://host/x`) is still recognised as a URL rather than falling through
-// to the Windows pattern. A single-slash form requires a scheme of at least two
-// characters, which catches malformed `https:/host/x` without misclassifying
-// the genuine Windows path `C:/Users/...` as a URL.
 // The ordinary form. Unanchored on the left so a scheme glued to preceding
 // text (`3https://host/x`) is still recognised rather than falling through to
 // the Windows pattern.
@@ -1674,10 +1667,10 @@ const QUOTED_WINDOWS_ABSOLUTE_PATH = /(?<=["'])(?:[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+
 const QUOTED_POSIX_ABSOLUTE_PATH = /(?<=["'])\/[^"'\r\n]+(?=["'])/g;
 const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/[^\s"'()]+/g;
 // Unanchored on the left. A boundary here refuses a path glued to preceding
-// text (`Failed atC:\\Users\\alice\\...`), and REMOTE_URL cannot claim a
-// backslash form, so the path would reach the caller intact. The scheme match
-// in REMOTE_URL is what keeps `https:/` away from the drive-letter alternative,
-// so the boundary is not needed for that either.
+// text (`Failed atC:\\Users\\alice\\...`), and neither URL pattern can claim a
+// backslash form, so the path would reach the caller intact. The scheme match in
+// SCHEME_URL and MALFORMED_SCHEME_URL is what keeps `https:/` away from the
+// drive-letter alternative, so the boundary is not needed for that either.
 const WINDOWS_ABSOLUTE_PATH = /(?:[A-Za-z]:[\\/]|\\\\)[^\s"'()]+/g;
 const POSIX_ABSOLUTE_PATH = /(?<![A-Za-z0-9:/.\\])\/[^\s"'()]+/g;
 
@@ -1717,15 +1710,17 @@ function replaceMatchesWithCapturedExec(
  *
  * 1. the quoted forms, whose surrounding quotes bound the match precisely;
  * 2. `file:///`, which is a path wearing a URL and is reported as `[path]`;
- * 3. any other `scheme://` URL, reported as `[url]` -- this is also what keeps
- *    `https:/` away from step 4, whose drive-letter alternative would otherwise
- *    match the `s:/` inside it and emit `http[path]`;
+ * 3. `SCHEME_URL`, then `MALFORMED_SCHEME_URL`, each reported as `[url]` --
+ *    together these are also what keep `https:/` away from step 4, whose
+ *    drive-letter alternative would otherwise match the `s:/` inside it and
+ *    emit `http[path]`;
  * 4. unquoted Windows drive and UNC paths;
  * 5. unquoted POSIX paths.
  *
- * Callers must strip ANSI sequences first. Colorized text leaves `[31m` style
- * residue directly in front of a path once the escape itself is gone, which
- * defeats the boundary lookbehinds steps 3 and 5 rely on.
+ * Callers must strip ANSI sequences first -- `summarizeConfigLoadCause` does,
+ * before it sanitises credentials. Colorized text leaves `[31m` style residue
+ * directly in front of a path once the escape itself is gone, which defeats the
+ * boundary lookbehind step 5 relies on.
  */
 function redactMachinePaths(value: string): string {
   let redacted = replaceMatchesWithCapturedExec(value, QUOTED_WINDOWS_ABSOLUTE_PATH, "[path]");

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1655,9 +1655,28 @@ const ANSI_CSI_SEQUENCE = /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\
 //
 // The intermediate run stops at 0x2E rather than the grammar's 0x2F, because
 // 0x2F is `/` -- the first character of the path this pass exists to preserve.
+//
+// A special-scheme URL start is preserved for the same reason a path is. In
+// `ESC[https:registry.internal/x`, `h` is a legal final byte, so the CSI pass
+// left `ttps:registry.internal/x`: ZERO_SLASH_SCHEME_URL no longer recognises
+// the damaged scheme, and POSIX_ABSOLUTE_PATH refuses the `/x` that follows a
+// hostname, so the private host reached the caller. `wss`, `ftp`, the 8-bit
+// introducer, a parameterized introducer and an uppercase scheme all leaked the
+// same way; the single-slash form survived but emitted `ttp[path]`, the
+// path-as-URL mislabel this PR exists to remove.
+//
+// Only the special schemes are listed, matching MALFORMED_SCHEME_URL and
+// ZERO_SLASH_SCHEME_URL -- keep the three in sync. A generic
+// `[A-Za-z][A-Za-z0-9+.-]*:` lookahead cannot be used: it matches the prose in
+// `ESC[0mError: cannot find module`, which would strip `ESC[0` and leave a
+// stray `m` in an ordinary diagnostic. A generic `scheme://` needs no help
+// here, because SCHEME_URL still matches the damaged `ttps://host/x`.
+//
+// `i` is safe on the whole pattern: every other class is either explicitly
+// both cases (`[A-Za-z]`) or contains no letters at all.
 const CSI_GLUED_PATH =
   // deno-lint-ignore no-control-regex
-  /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002E]*(?=[\\/]|[A-Za-z]:[\\/])/g;
+  /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002E]*(?=[\\/]|[A-Za-z]:[\\/]|(?:https?|wss?|ftp):)/gi;
 // The scheme needs at least two characters: `C://Users/alice` is a drive path
 // that Node normalises, not a URL with the one-letter scheme `C`, and matching it
 // here reintroduced the path-as-URL mislabel this PR exists to remove. No

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1628,15 +1628,24 @@ const MAX_CONFIG_LOAD_CAUSE_CHARACTERS = 200;
 
 // deno-lint-ignore no-control-regex
 const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F-\u009F]/g;
+// A colorized cause arrives as ESC + "[31m" + text. Dropping only the ESC as a
+// control character leaves the "[31m" behind, and that residue sits between the
+// start of the token and the path -- which defeats any pattern anchored on what
+// precedes a path. Remove the whole SGR sequence so the path patterns see the
+// text a plain terminal would.
+// deno-lint-ignore no-control-regex
+const ANSI_SGR_SEQUENCE = /\u001B\[[0-9;]*[A-Za-z]/g;
+// A remote config URL is redacted whole rather than picked apart. AGENTS.md
+// counts private hostnames among the values user-facing output must not carry,
+// and the caller cannot tell an internal registry from a public CDN by looking
+// at it. Matching the scheme here also keeps `https:/` away from
+// WINDOWS_ABSOLUTE_PATH, whose drive-letter alternative would otherwise match
+// the `s:/` inside it and report `http[path]` (veryfront-issue-inbox#836).
+const REMOTE_URL = /(?<![A-Za-z0-9])[A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s"'()]+/g;
 const QUOTED_WINDOWS_ABSOLUTE_PATH = /(?<=["'])(?:[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+(?=["'])/g;
 const QUOTED_POSIX_ABSOLUTE_PATH = /(?<=["'])\/[^"'\r\n]+(?=["'])/g;
 const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/[^\s"'()]+/g;
-// The drive-letter alternative needs the same token boundary its quoted and
-// POSIX siblings already carry: without it, `[A-Za-z]:[\\/]` matches the `s:/`
-// inside `https:/`, and the rest of the URL is eaten as a Windows path. A
-// hosted-config failure then reports `http[path]` and loses the one token the
-// reader can act on (veryfront-issue-inbox#836).
-const WINDOWS_ABSOLUTE_PATH = /(?<![A-Za-z0-9])(?:[A-Za-z]:[\\/]|\\\\)[^\s"'()]+/g;
+const WINDOWS_ABSOLUTE_PATH = /(?:[A-Za-z]:[\\/]|\\\\)[^\s"'()]+/g;
 const POSIX_ABSOLUTE_PATH = /(?<![A-Za-z0-9:/.\\])\/[^\s"'()]+/g;
 
 function replaceMatchesWithCapturedExec(
@@ -1670,6 +1679,7 @@ function redactMachinePaths(value: string): string {
   let redacted = replaceMatchesWithCapturedExec(value, QUOTED_WINDOWS_ABSOLUTE_PATH, "[path]");
   redacted = replaceMatchesWithCapturedExec(redacted, QUOTED_POSIX_ABSOLUTE_PATH, "[path]");
   redacted = replaceMatchesWithCapturedExec(redacted, FILE_URL_ABSOLUTE_PATH, "[path]");
+  redacted = replaceMatchesWithCapturedExec(redacted, REMOTE_URL, "[url]");
   redacted = replaceMatchesWithCapturedExec(redacted, WINDOWS_ABSOLUTE_PATH, "[path]");
   return replaceMatchesWithCapturedExec(redacted, POSIX_ABSOLUTE_PATH, "[path]");
 }
@@ -1693,7 +1703,8 @@ function summarizeConfigLoadCause(error: unknown): string | undefined {
   const redacted = sanitizeUrlCredentials(message);
   const firstLine = (ReflectApply(StringPrototypeSplit, redacted, ["\n", 1]) as string[])[0] ??
     "";
-  const replaced = replaceMatchesWithCapturedExec(firstLine, CONTROL_CHARACTERS, " ");
+  const deColorized = replaceMatchesWithCapturedExec(firstLine, ANSI_SGR_SEQUENCE, "");
+  const replaced = replaceMatchesWithCapturedExec(deColorized, CONTROL_CHARACTERS, " ");
   const clean = ReflectApply(StringPrototypeTrim, redactMachinePaths(replaced), []) as string;
   if (clean.length === 0) return undefined;
   return clean.length > MAX_CONFIG_LOAD_CAUSE_CHARACTERS

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1805,8 +1805,17 @@ function summarizeConfigLoadCause(error: unknown): string | undefined {
   // consume the first character of a key such as API_KEY. Either ordering alone
   // can therefore expose a usable value after the transformation.
   const initiallyRedacted = sanitizeUrlCredentials(message);
+  // Redact paths on both sides of de-colorization too, and for the same reason.
+  // A CSI introducer sitting directly against an absolute path consumes the
+  // start of it: `/` is a valid intermediate byte and `h` a valid final, so
+  // `ESC[/home/alice/x` loses `ESC[/h` and leaves `ome/alice/x`, which no later
+  // path pattern recognises. `ESC[C:\\Users\\alice` loses the drive letter the
+  // same way. Both are legal CSI sequences, so no tightening of the grammar can
+  // tell them apart from a path -- the only fix is to match the path while it is
+  // still intact.
+  const pathsPreRedacted = redactMachinePaths(initiallyRedacted);
   const deColorized = replaceMatchesWithCapturedExec(
-    initiallyRedacted,
+    pathsPreRedacted,
     ANSI_CSI_SEQUENCE,
     "",
   );

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1631,7 +1631,12 @@ const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F-\u009F]/g;
 const QUOTED_WINDOWS_ABSOLUTE_PATH = /(?<=["'])(?:[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+(?=["'])/g;
 const QUOTED_POSIX_ABSOLUTE_PATH = /(?<=["'])\/[^"'\r\n]+(?=["'])/g;
 const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/[^\s"'()]+/g;
-const WINDOWS_ABSOLUTE_PATH = /(?:[A-Za-z]:[\\/]|\\\\)[^\s"'()]+/g;
+// The drive-letter alternative needs the same token boundary its quoted and
+// POSIX siblings already carry: without it, `[A-Za-z]:[\\/]` matches the `s:/`
+// inside `https:/`, and the rest of the URL is eaten as a Windows path. A
+// hosted-config failure then reports `http[path]` and loses the one token the
+// reader can act on (veryfront-issue-inbox#836).
+const WINDOWS_ABSOLUTE_PATH = /(?<![A-Za-z0-9])(?:[A-Za-z]:[\\/]|\\\\)[^\s"'()]+/g;
 const POSIX_ABSOLUTE_PATH = /(?<![A-Za-z0-9:/.\\])\/[^\s"'()]+/g;
 
 function replaceMatchesWithCapturedExec(

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1663,6 +1663,17 @@ const ANSI_CSI_SEQUENCE = /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\
 // the caller. Optional rather than required, because `ESC[/home` has no final
 // byte before the path at all.
 //
+// The backslash branch of the lookahead requires *both* UNC separators, not one.
+// A backslash is 0x5C, inside the final-byte range, so in an introducer followed by
+// a UNC path the optional final byte ate the first separator while the lookahead was
+// satisfied by the second. The pass then emitted a single-separator path, which
+// WINDOWS_ABSOLUTE_PATH does not recognise -- it requires a doubled separator or a
+// drive letter -- so the UNC path reached the caller. `origin/main` redacts that same
+// input, so this pre-pass introduced the leak rather than inheriting it. Demanding
+// both separators makes the engine backtrack the optional final byte to zero width
+// and leave the prefix whole. A forward slash needs no such care: 0x2F sits below the
+// final-byte range, and the intermediate run already stops at 0x2E to protect it.
+//
 // The sequence is taken here rather than by making de-colorization emit a space
 // instead of nothing. That pass must keep emitting nothing: `sk-` + `ESC[0m` +
 // `ABCD1234EFGH5678` only rejoins into a contiguous credential if the removal
@@ -1670,7 +1681,7 @@ const ANSI_CSI_SEQUENCE = /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\
 // Fixing a path boundary must not reopen that.
 const CSI_GLUED_PATH =
   // deno-lint-ignore no-control-regex
-  /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002E]*[\u0040-\u007E]?(?=[\\/]|[A-Za-z]:[\\/])/g;
+  /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002E]*[\u0040-\u007E]?(?=\\\\|\/|[A-Za-z]:[\\/])/g;
 // The same pre-pass for a special-scheme URL start, which the CSI grammar eats
 // exactly as it eats a path. In `ESC[https:registry.internal/x`, `h` is a legal
 // final byte, so the CSI pass left `ttps:registry.internal/x`:

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1646,6 +1646,10 @@ const ANSI_CSI_SEQUENCE = /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\
 // summarizeConfigLoadCause for why the path itself is not redacted here.
 // deno-lint-ignore no-control-regex
 const CSI_GLUED_PATH = /(?:\u001B\[|\u009B)(?=[\\/]|[A-Za-z]:[\\/])/g;
+// The scheme needs at least two characters: `C://Users/alice` is a drive path
+// that Node normalises, not a URL with the one-letter scheme `C`, and matching it
+// here reintroduced the path-as-URL mislabel this PR exists to remove. No
+// registered scheme is a single character.
 // A remote config URL is redacted whole rather than picked apart: AGENTS.md
 // counts private hostnames among the values user-facing output must not carry,
 // and the caller cannot tell an internal registry from a public CDN by looking
@@ -1661,7 +1665,7 @@ const CSI_GLUED_PATH = /(?:\u001B\[|\u009B)(?=[\\/]|[A-Za-z]:[\\/])/g;
 // alphabetic message with no colon costs O(n^2) -- 100k characters measured at
 // ~17.9s, versus ~34ms bounded. Every registered scheme is far shorter than 31.
 const SCHEME_URL =
-  /[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\/(?:[^\s"\/]{0,512}@)?(?:[^\s"'()]|\([^\s"']{0,512}\))+/g;
+  /[A-Za-z][A-Za-z0-9+.-]{1,31}:\/\/(?:[^\s"\/]{0,512}@)?(?:[^\s"'()]|\([^\s"']{0,512}\))+/g;
 // Both the userinfo run and the parenthesised interior are length-bounded, and
 // the userinfo run also stops at `/`. Neither bound is cosmetic. An unbounded
 // greedy interior rescans the rest of the message from every `(` that never
@@ -1827,13 +1831,20 @@ function summarizeConfigLoadCause(error: unknown): string | undefined {
   // lose the drive letter the same way. Both are legal CSI sequences, so no
   // tightening of the grammar separates them from a path.
   //
+  // Replaced with a space, not with nothing. `Failed at` + `ESC[` + `/home/alice`
+  // would otherwise become `Failed at/home/alice`, and POSIX_ABSOLUTE_PATH's
+  // lookbehind refuses a slash that follows an alphanumeric -- so removing the
+  // introducer cleanly would manufacture the one adjacency that defeats the very
+  // pass meant to catch it. A doubled space when the text already ended in one is
+  // the whole cost.
+  //
   // Only the introducer is removed, not the path: redacting here instead would
   // produce `ESC[[path]`, and `[` is itself a valid CSI final byte, so the pass
   // below would eat the marker's opening bracket and emit `path]`. Removing just
   // the introducer leaves the path intact for the single redaction pass at the
   // end, which keeps `redactMachinePaths` running exactly once and after
   // de-colorization -- the precondition its own docstring states.
-  const unglued = replaceMatchesWithCapturedExec(initiallyRedacted, CSI_GLUED_PATH, "");
+  const unglued = replaceMatchesWithCapturedExec(initiallyRedacted, CSI_GLUED_PATH, " ");
   const deColorized = replaceMatchesWithCapturedExec(
     unglued,
     ANSI_CSI_SEQUENCE,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1631,10 +1631,16 @@ const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F-\u009F]/g;
 // A colorized cause arrives as ESC + "[31m" + text. Dropping only the ESC as a
 // control character leaves the "[31m" behind, and that residue sits between the
 // start of the token and the path -- which defeats any pattern anchored on what
-// precedes a path. Remove the whole SGR sequence so the path patterns see the
-// text a plain terminal would.
+// precedes a path. Remove the whole sequence so the path patterns see the text
+// a plain terminal would.
+//
+// Matches the full CSI grammar rather than the colour sequences alone:
+// parameter bytes 0x30-0x3F, intermediate bytes 0x20-0x2F, one final byte
+// 0x40-0x7E. Accepting only digits and semicolons missed the colon-separated
+// form a true-colour sequence uses (`ESC[38:2:255:0:0m`), whose residue then
+// defeated POSIX_ABSOLUTE_PATH exactly as an unstripped `[31m` would.
 // deno-lint-ignore no-control-regex
-const ANSI_SGR_SEQUENCE = /\u001B\[[0-9;]*[A-Za-z]/g;
+const ANSI_CSI_SEQUENCE = /\u001B\[[\u0030-\u003F]*[\u0020-\u002F]*[\u0040-\u007E]/g;
 // A remote config URL is redacted whole rather than picked apart. AGENTS.md
 // counts private hostnames among the values user-facing output must not carry,
 // and the caller cannot tell an internal registry from a public CDN by looking
@@ -1651,7 +1657,12 @@ const REMOTE_URL = /(?:[A-Za-z][A-Za-z0-9+.-]*:\/\/|[A-Za-z][A-Za-z0-9+.-]+:\/(?
 const QUOTED_WINDOWS_ABSOLUTE_PATH = /(?<=["'])(?:[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+(?=["'])/g;
 const QUOTED_POSIX_ABSOLUTE_PATH = /(?<=["'])\/[^"'\r\n]+(?=["'])/g;
 const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/[^\s"'()]+/g;
-const WINDOWS_ABSOLUTE_PATH = /(?<![A-Za-z0-9])(?:[A-Za-z]:[\\/]|\\\\)[^\s"'()]+/g;
+// Unanchored on the left. A boundary here refuses a path glued to preceding
+// text (`Failed atC:\\Users\\alice\\...`), and REMOTE_URL cannot claim a
+// backslash form, so the path would reach the caller intact. The scheme match
+// in REMOTE_URL is what keeps `https:/` away from the drive-letter alternative,
+// so the boundary is not needed for that either.
+const WINDOWS_ABSOLUTE_PATH = /(?:[A-Za-z]:[\\/]|\\\\)[^\s"'()]+/g;
 const POSIX_ABSOLUTE_PATH = /(?<![A-Za-z0-9:/.\\])\/[^\s"'()]+/g;
 
 function replaceMatchesWithCapturedExec(
@@ -1725,11 +1736,15 @@ function summarizeConfigLoadCause(error: unknown): string | undefined {
     ? readOwnDataString(error, "message")
     : undefined;
   if (message === undefined) return undefined;
-  const redacted = sanitizeUrlCredentials(message);
+  // De-colorize first. An escape sequence sitting inside a credential leaves it
+  // noncontiguous, so sanitizeUrlCredentials would not match it -- and stripping
+  // the sequence afterwards would rejoin the halves into a usable secret with no
+  // sanitiser left to run.
+  const deColorized = replaceMatchesWithCapturedExec(message, ANSI_CSI_SEQUENCE, "");
+  const redacted = sanitizeUrlCredentials(deColorized);
   const firstLine = (ReflectApply(StringPrototypeSplit, redacted, ["\n", 1]) as string[])[0] ??
     "";
-  const deColorized = replaceMatchesWithCapturedExec(firstLine, ANSI_SGR_SEQUENCE, "");
-  const replaced = replaceMatchesWithCapturedExec(deColorized, CONTROL_CHARACTERS, " ");
+  const replaced = replaceMatchesWithCapturedExec(firstLine, CONTROL_CHARACTERS, " ");
   const clean = ReflectApply(StringPrototypeTrim, redactMachinePaths(replaced), []) as string;
   if (clean.length === 0) return undefined;
   return clean.length > MAX_CONFIG_LOAD_CAUSE_CHARACTERS

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1655,7 +1655,7 @@ const ANSI_CSI_SEQUENCE = /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\
 // end of the input at every position starting with a letter, so a long
 // alphabetic message with no colon costs O(n^2) -- 100k characters measured at
 // ~17.9s, versus ~34ms bounded. Every registered scheme is far shorter than 31.
-const SCHEME_URL = /[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\/(?:[^\s"']*@)?(?:[^\s"'()]|\([^\s"']*\))+/g;
+const SCHEME_URL = /[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\/(?:[^\s"]*@)?(?:[^\s"'()]|\([^\s"']*\))+/g;
 // The interior of a parenthesised segment is `[^\s"']*`, not `[^\s"'()]*`: a
 // flat interior matches one nesting level, so `/a((TOKEN))` ended the token at
 // the first `(` and left `((TOKEN))` in the caller-visible detail -- a URL path
@@ -1663,6 +1663,12 @@ const SCHEME_URL = /[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\/(?:[^\s"']*@)?(?:[^\s"'()]|
 // interior backtracks to the last `)` in the run, so any nesting depth is
 // consumed in one pass. A token with no `(` at all is unaffected, which is what
 // still leaves a trailing prose `)` outside the match.
+// The userinfo run excludes only whitespace and a double quote, not an
+// apostrophe: RFC 3986 puts `'` in sub-delims, so `user'name@registry.internal`
+// is a legal authority, and stopping at the apostrophe left the hostname in the
+// caller-visible detail. The tail still excludes `'`, so a quoted config
+// message such as `Cannot find module 'some-pkg'` is unaffected and the quoted
+// path and quoted URL regressions keep their delimiters.
 // Userinfo gets its own permissive run up to `@`, rather than relying on the
 // balanced-parentheses alternative that covers the rest of the token. That
 // alternative matches one flat `(...)` pair, so a legal nested userinfo such as
@@ -1678,7 +1684,7 @@ const SCHEME_URL = /[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\/(?:[^\s"']*@)?(?:[^\s"'()]|
 // The scheme needs at least two characters here, which is what keeps a genuine
 // `C:/Users/...` out -- a drive letter is always exactly one.
 const MALFORMED_SCHEME_URL =
-  /[A-Za-z][A-Za-z0-9+.-]{1,31}:\/(?!\/)(?:[^\s"']*@)?(?:[^\s"'()]|\([^\s"']*\))+/g;
+  /[A-Za-z][A-Za-z0-9+.-]{1,31}:\/(?!\/)(?:[^\s"]*@)?(?:[^\s"'()]|\([^\s"']*\))+/g;
 const QUOTED_WINDOWS_ABSOLUTE_PATH = /(?<=["'])(?:[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+(?=["'])/g;
 const QUOTED_POSIX_ABSOLUTE_PATH = /(?<=["'])\/[^"'\r\n]+(?=["'])/g;
 const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/(?:[^\s"'()]|\([^\s"']*\))+/g;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1655,14 +1655,23 @@ const ANSI_CSI_SEQUENCE = /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\
 // end of the input at every position starting with a letter, so a long
 // alphabetic message with no colon costs O(n^2) -- 100k characters measured at
 // ~17.9s, versus ~34ms bounded. Every registered scheme is far shorter than 31.
-const SCHEME_URL = /[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\/(?:[^\s"'()]|\([^\s"'()]*\))+/g;
+const SCHEME_URL = /[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\/(?:[^\s"']*@)?(?:[^\s"'()]|\([^\s"'()]*\))+/g;
+// Userinfo gets its own permissive run up to `@`, rather than relying on the
+// balanced-parentheses alternative that covers the rest of the token. That
+// alternative matches one flat `(...)` pair, so a legal nested userinfo such as
+// `u((x))y@registry.internal` ended the match at the first `(` and left the
+// hostname in the caller-visible detail. RFC 3986 puts `(` and `)` in
+// sub-delims, so nesting there is valid rather than exotic. `[^\s"']*` cannot
+// cross whitespace or a quote, so the run stays inside one URL token and a
+// trailing prose `)` is still left behind.
 // The malformed single-slash form, kept separate from SCHEME_URL rather than
 // folded in as an alternation: two plain patterns read more clearly than one
 // branching expression, and each stays independently checkable.
 //
 // The scheme needs at least two characters here, which is what keeps a genuine
 // `C:/Users/...` out -- a drive letter is always exactly one.
-const MALFORMED_SCHEME_URL = /[A-Za-z][A-Za-z0-9+.-]{1,31}:\/(?!\/)(?:[^\s"'()]|\([^\s"'()]*\))+/g;
+const MALFORMED_SCHEME_URL =
+  /[A-Za-z][A-Za-z0-9+.-]{1,31}:\/(?!\/)(?:[^\s"']*@)?(?:[^\s"'()]|\([^\s"'()]*\))+/g;
 const QUOTED_WINDOWS_ABSOLUTE_PATH = /(?<=["'])(?:[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+(?=["'])/g;
 const QUOTED_POSIX_ABSOLUTE_PATH = /(?<=["'])\/[^"'\r\n]+(?=["'])/g;
 const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/(?:[^\s"'()]|\([^\s"'()]*\))+/g;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1655,15 +1655,25 @@ const ANSI_CSI_SEQUENCE = /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\
 //
 // The intermediate run stops at 0x2E rather than the grammar's 0x2F, because
 // 0x2F is `/` -- the first character of the path this pass exists to preserve.
+const CSI_GLUED_PATH =
+  // deno-lint-ignore no-control-regex
+  /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002E]*(?=[\\/]|[A-Za-z]:[\\/])/g;
+// The same pre-pass for a special-scheme URL start, which the CSI grammar eats
+// exactly as it eats a path. In `ESC[https:registry.internal/x`, `h` is a legal
+// final byte, so the CSI pass left `ttps:registry.internal/x`:
+// ZERO_SLASH_SCHEME_URL no longer recognises the damaged scheme, and
+// POSIX_ABSOLUTE_PATH refuses the `/x` that follows a hostname, so the private
+// host reached the caller. `wss`, `ftp`, the 8-bit introducer, a parameterized
+// introducer and an uppercase scheme all leaked the same way; the single-slash
+// form survived but emitted `ttp[path]`, the path-as-URL mislabel this PR
+// exists to remove.
 //
-// A special-scheme URL start is preserved for the same reason a path is. In
-// `ESC[https:registry.internal/x`, `h` is a legal final byte, so the CSI pass
-// left `ttps:registry.internal/x`: ZERO_SLASH_SCHEME_URL no longer recognises
-// the damaged scheme, and POSIX_ABSOLUTE_PATH refuses the `/x` that follows a
-// hostname, so the private host reached the caller. `wss`, `ftp`, the 8-bit
-// introducer, a parameterized introducer and an uppercase scheme all leaked the
-// same way; the single-slash form survived but emitted `ttp[path]`, the
-// path-as-URL mislabel this PR exists to remove.
+// A separate constant rather than a third alternative in the one above. The two
+// share a prefix, so folding them together is the obvious move -- and it is what
+// took SonarCloud's maintainability rating on new code to B. Splitting a dense
+// alternation into plain per-shape constants is what cleared the same gate
+// earlier in this PR, when `REMOTE_URL` became SCHEME_URL and
+// MALFORMED_SCHEME_URL. Each pass reads as one rule.
 //
 // Only the special schemes are listed, matching MALFORMED_SCHEME_URL and
 // ZERO_SLASH_SCHEME_URL -- keep the three in sync. A generic
@@ -1674,9 +1684,9 @@ const ANSI_CSI_SEQUENCE = /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\
 //
 // `i` is safe on the whole pattern: every other class is either explicitly
 // both cases (`[A-Za-z]`) or contains no letters at all.
-const CSI_GLUED_PATH =
+const CSI_GLUED_URL =
   // deno-lint-ignore no-control-regex
-  /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002E]*(?=[\\/]|[A-Za-z]:[\\/]|(?:https?|wss?|ftp):)/gi;
+  /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002E]*(?=(?:https?|wss?|ftp):)/gi;
 // The scheme needs at least two characters: `C://Users/alice` is a drive path
 // that Node normalises, not a URL with the one-letter scheme `C`, and matching it
 // here reintroduced the path-as-URL mislabel this PR exists to remove. No
@@ -1876,8 +1886,9 @@ function summarizeConfigLoadCause(error: unknown): string | undefined {
   // end, which keeps `redactMachinePaths` running exactly once and after
   // de-colorization -- the precondition its own docstring states.
   const unglued = replaceMatchesWithCapturedExec(initiallyRedacted, CSI_GLUED_PATH, " ");
+  const ungluedUrl = replaceMatchesWithCapturedExec(unglued, CSI_GLUED_URL, " ");
   const deColorized = replaceMatchesWithCapturedExec(
-    unglued,
+    ungluedUrl,
     ANSI_CSI_SEQUENCE,
     "",
   );

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1640,7 +1640,7 @@ const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F-\u009F]/g;
 // form a true-colour sequence uses (`ESC[38:2:255:0:0m`), whose residue then
 // defeated POSIX_ABSOLUTE_PATH exactly as an unstripped `[31m` would.
 // deno-lint-ignore no-control-regex
-const ANSI_CSI_SEQUENCE = /\u001B\[[\u0030-\u003F]*[\u0020-\u002F]*[\u0040-\u007E]/g;
+const ANSI_CSI_SEQUENCE = /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\u0040-\u007E]/g;
 // A remote config URL is redacted whole rather than picked apart: AGENTS.md
 // counts private hostnames among the values user-facing output must not carry,
 // and the caller cannot tell an internal registry from a public CDN by looking
@@ -1655,17 +1655,17 @@ const ANSI_CSI_SEQUENCE = /\u001B\[[\u0030-\u003F]*[\u0020-\u002F]*[\u0040-\u007
 // end of the input at every position starting with a letter, so a long
 // alphabetic message with no colon costs O(n^2) -- 100k characters measured at
 // ~17.9s, versus ~34ms bounded. Every registered scheme is far shorter than 31.
-const SCHEME_URL = /[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\/[^\s"'()]+/g;
+const SCHEME_URL = /[A-Za-z][A-Za-z0-9+.-]{0,31}:\/\/(?:[^\s"'()]|\([^\s"'()]*\))+/g;
 // The malformed single-slash form, kept separate from SCHEME_URL rather than
 // folded in as an alternation: two plain patterns read more clearly than one
 // branching expression, and each stays independently checkable.
 //
 // The scheme needs at least two characters here, which is what keeps a genuine
 // `C:/Users/...` out -- a drive letter is always exactly one.
-const MALFORMED_SCHEME_URL = /[A-Za-z][A-Za-z0-9+.-]{1,31}:\/(?!\/)[^\s"'()]+/g;
+const MALFORMED_SCHEME_URL = /[A-Za-z][A-Za-z0-9+.-]{1,31}:\/(?!\/)(?:[^\s"'()]|\([^\s"'()]*\))+/g;
 const QUOTED_WINDOWS_ABSOLUTE_PATH = /(?<=["'])(?:[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+(?=["'])/g;
 const QUOTED_POSIX_ABSOLUTE_PATH = /(?<=["'])\/[^"'\r\n]+(?=["'])/g;
-const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/[^\s"'()]+/g;
+const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/(?:[^\s"'()]|\([^\s"'()]*\))+/g;
 // Unanchored on the left. A boundary here refuses a path glued to preceding
 // text (`Failed atC:\\Users\\alice\\...`), and neither URL pattern can claim a
 // backslash form, so the path would reach the caller intact. The scheme match in
@@ -1748,11 +1748,16 @@ function summarizeConfigLoadCause(error: unknown): string | undefined {
     ? readOwnDataString(error, "message")
     : undefined;
   if (message === undefined) return undefined;
-  // De-colorize first. An escape sequence sitting inside a credential leaves it
-  // noncontiguous, so sanitizeUrlCredentials would not match it -- and stripping
-  // the sequence afterwards would rejoin the halves into a usable secret with no
-  // sanitiser left to run.
-  const deColorized = replaceMatchesWithCapturedExec(message, ANSI_CSI_SEQUENCE, "");
+  // Sanitize on both sides of de-colorization. A sequence inside a credential
+  // can make it noncontiguous before removal, while a CSI final byte can also
+  // consume the first character of a key such as API_KEY. Either ordering alone
+  // can therefore expose a usable value after the transformation.
+  const initiallyRedacted = sanitizeUrlCredentials(message);
+  const deColorized = replaceMatchesWithCapturedExec(
+    initiallyRedacted,
+    ANSI_CSI_SEQUENCE,
+    "",
+  );
   const redacted = sanitizeUrlCredentials(deColorized);
   const firstLine = (ReflectApply(StringPrototypeSplit, redacted, ["\n", 1]) as string[])[0] ??
     "";

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1696,6 +1696,15 @@ const SCHEME_URL =
 // `C:/Users/...` out -- a drive letter is always exactly one.
 const MALFORMED_SCHEME_URL =
   /[A-Za-z][A-Za-z0-9+.-]{1,31}:\/(?!\/)(?:[^\s"\/]{0,512}@)?(?:[^\s"'()]|\([^\s"']{0,512}\))+/g;
+// The zero-slash form of a WHATWG special scheme. `https:registry.internal/x`
+// parses to `https://registry.internal/x`, so the hostname is just as real as in
+// the two-slash form, but neither pattern above matches it -- both require at
+// least one slash -- and POSIX_ABSOLUTE_PATH refuses `/x` because it follows an
+// alphanumeric. Restricted to the special schemes rather than the generic
+// `[A-Za-z][A-Za-z0-9+.-]+:` shape, because that would claim ordinary prose
+// (`warning:something`) and, at one character, drive letters.
+const ZERO_SLASH_SCHEME_URL =
+  /(?:https?|wss?|ftp):(?![\/\s])(?:[^\s"\/]{0,512}@)?(?:[^\s"'()]|\([^\s"']{0,512}\))+/g;
 const QUOTED_WINDOWS_ABSOLUTE_PATH = /(?<=["'])(?:[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+(?=["'])/g;
 const QUOTED_POSIX_ABSOLUTE_PATH = /(?<=["'])\/[^"'\r\n]+(?=["'])/g;
 const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/(?:[^\s"'()]|\([^\s"']{0,512}\))+/g;
@@ -1761,6 +1770,7 @@ function redactMachinePaths(value: string): string {
   redacted = replaceMatchesWithCapturedExec(redacted, FILE_URL_ABSOLUTE_PATH, "[path]");
   redacted = replaceMatchesWithCapturedExec(redacted, SCHEME_URL, "[url]");
   redacted = replaceMatchesWithCapturedExec(redacted, MALFORMED_SCHEME_URL, "[url]");
+  redacted = replaceMatchesWithCapturedExec(redacted, ZERO_SLASH_SCHEME_URL, "[url]");
   redacted = replaceMatchesWithCapturedExec(redacted, WINDOWS_ABSOLUTE_PATH, "[path]");
   return replaceMatchesWithCapturedExec(redacted, POSIX_ABSOLUTE_PATH, "[path]");
 }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1641,7 +1641,13 @@ const ANSI_SGR_SEQUENCE = /\u001B\[[0-9;]*[A-Za-z]/g;
 // at it. Matching the scheme here also keeps `https:/` away from
 // WINDOWS_ABSOLUTE_PATH, whose drive-letter alternative would otherwise match
 // the `s:/` inside it and report `http[path]` (veryfront-issue-inbox#836).
-const REMOTE_URL = /(?<![A-Za-z0-9])[A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s"'()]+/g;
+//
+// Deliberately unanchored on the left, so a scheme glued to preceding text
+// (`3https://host/x`) is still recognised as a URL rather than falling through
+// to the Windows pattern. Requiring both slashes is what keeps a genuine
+// `C:/Users/...` out: with one slash allowed, that path would match here and be
+// reported as `[url]` instead of `[path]`.
+const REMOTE_URL = /[A-Za-z][A-Za-z0-9+.-]*:\/\/[^\s"'()]+/g;
 const QUOTED_WINDOWS_ABSOLUTE_PATH = /(?<=["'])(?:[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+(?=["'])/g;
 const QUOTED_POSIX_ABSOLUTE_PATH = /(?<=["'])\/[^"'\r\n]+(?=["'])/g;
 const FILE_URL_ABSOLUTE_PATH = /file:\/\/\/[^\s"'()]+/g;


### PR DESCRIPTION
> **⚠️ Read [Correction](#correction) and [Second correction](#correction2) at the end before the body below.**
>
> The original description proposed *preserving* hosted URLs. Two P1 findings showed that was wrong — one of them a regression the first commit introduced. The URL is now redacted **whole** as `[url]`. A later section arguing a trade-off was unavoidable has also been superseded by @kojiwakayama's `4d55774`. The original text is kept below unedited; the title was widened to match the change.

## Description

`WINDOWS_ABSOLUTE_PATH` (`src/config/loader.ts:1634`) had no token boundary, so its drive-letter alternative `[A-Za-z]:[\\/]` matched the **`s:/` inside `https:/`** and `[^\s"'()]+` consumed the rest of the URL. Every hosted-config failure summary therefore reported:

```
Failed to load http[path]
```

losing the one token in the line the reader can act on. `http://host:3000/x` came out as `htt[path]`.

Shipped with #4227 as part of the new failure-summary redaction pass, so it currently degrades exactly the error messages that PR set out to make actionable.

### The fix is one boundary, and its siblings already have it

```diff
-const WINDOWS_ABSOLUTE_PATH = /(?:[A-Za-z]:[\\/]|\\\\)[^\s"'()]+/g;
+const WINDOWS_ABSOLUTE_PATH = /(?<[A-Za-z0-9])(?:[A-Za-z]:[\\/]|\\\\)[^\s"'()]+/g;
```

Both neighbours in the same five-constant block were never affected, because each already carries the guard this one lacked:

| constant | boundary it has |
|---|---|
| `QUOTED_WINDOWS_ABSOLUTE_PATH` (`:1631`) | `(?<=["'])` |
| `POSIX_ABSOLUTE_PATH` (`:1635`) | `(?<[A-Za-z0-9:/.\\])` — added for exactly this hazard |
| `WINDOWS_ABSOLUTE_PATH` (`:1634`) | **none** ← |

### Credentials are unaffected

`summarizeConfigLoadCause` runs `sanitizeUrlCredentials` **first** (`:1688`), masking userinfo, sensitive query params and provider tokens before `redactMachinePaths` sees the string.

## Related Issue(s)

Refs veryfront/veryfront-issue-inbox#836 (item 1 of four; the other three are in the staging/caching path and are deliberately not in this PR)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

---

<a name="correction"></a>

# Correction — `4702a2e` supersedes the approach above

Two P1 findings from `@chatgpt-codex-connector`, both verified rather than taken on trust, both grounded in AGENTS.md's list of values user-facing output must not carry.

## The premise above was wrong

`http[path]` **is** garbled output — but the URL redaction it accidentally performed is what policy requires:

> AGENTS.md:124 — *Internal infrastructure names, **private hostnames**, cluster names, deployment contexts, and account identifiers*

and `summarizeConfigLoadCause`'s own docstring (`loader.ts:1750`) states this string *"reaches `VeryfrontError.message` and its context, which callers log."* `sanitizeUrlCredentials` masks userinfo but leaves the hostname intact, so `https://registry.internal/config.ts` would have survived. Preserving the URL removed a protection policy demands.

## And the first commit introduced a leak

A colorized cause arrives as `ESC` + `[31m` + text. `CONTROL_CHARACTERS` drops only the ESC, leaving `[31m` in front of the path — so the new lookbehind saw the alphanumeric `m` and refused to match:

| input | before `1feaaf0` | after `1feaaf0` |
|---|---|---|
| `ESC[31mC:\Users\alice\veryfront.config.ts` | `[31m[path]` | **leaked intact** |
| `ESC[31m\\server\share\config.ts` | `[31m[path]` | **leaked intact** |

Found while checking: **`POSIX_ABSOLUTE_PATH` has the same hole and always has** — `ESC[31m/home/alice/…` was never redacted, before or after. The SGR fix closes that too.

## What `4702a2e` did

1. **Strip the whole SGR sequence** before path matching.
2. **Redact remote URLs whole**, as `[url]` — fixing the garbled output without un-redacting a hostname.
3. **`WINDOWS_ABSOLUTE_PATH` reverted** to its original form, since matching the scheme explicitly kept `https:/` away from it.

---

<a name="correction2"></a>

# Second correction — `4d55774` (@kojiwakayama) solves a trade-off I called unavoidable

An earlier revision of this description argued that a single-slash `https:/host/x` had to stay mangled, because allowing one slash would make `C:/Users/alice` match as scheme `C` and report `[url]` instead of `[path]`. **That framing was wrong** — it treated slash count as the only axis and ignored scheme *length*.

```js
const REMOTE_URL =
  /(?:[A-Za-z][A-Za-z0-9+.-]*:\/\/|[A-Za-z][A-Za-z0-9+.-]+:\/(?!\/))[^\s"'()]+/g;
```

The single-slash alternative uses `+` rather than `*`, so it requires a scheme of **at least two characters**. A drive letter is always exactly one. `https:/host` matches; `C:/Users` cannot.

`4d55774` also **restores the `(?<[A-Za-z0-9])` boundary** on `WINDOWS_ABSOLUTE_PATH` as defence in depth. That is safe now and was not when it was first proposed: the boundary leaked because SGR residue sat in front of the path, and `4702a2e` strips the escape sequence first — so the fix for one finding is what made the other finding's remedy viable.

## Final behaviour on `4d55774`

| input | output |
|---|---|
| `https://cdn.example.test/c.ts` | `[url]` |
| `https://registry.internal/c.ts` | `[url]` |
| `3https://registry.internal/c.ts` | `3[url]` |
| `https:/registry.internal/c.ts` | `[url]` — was `http[path]` |
| `C:/Users/alice/c.ts` | `[path]` |
| `C:\Users\alice\c.ts` | `[path]` |
| `\\server\share\c.ts` | `[path]` |
| `/home/alice/c.ts` | `[path]` |
| `file:///home/alice/c.ts` | `[path]` |
| `ESC[31m` + any of the above paths | `[path]` |
| `Cannot find package "some-pkg"` | unchanged |

Nothing leaks under any shipped pattern; every machine-path form reports `[path]`; no cosmetic gap remains.

## Validation

- **@kojiwakayama executed the Deno suite** — the 168-step config suite, typecheck, and full `lint:ci` all pass on `4d55774`.
- On my side: `deno check`, `deno fmt --check` and `deno lint` clean, plus the leak matrix above run by extracting every pattern from `loader.ts` itself and replaying `redactMachinePaths`' exact order. **The Deno suite cannot execute in my sandbox** — `jsr.io` returns 403 for `@std/assert`, which `src/testing/assert.ts` reaches through a runtime dynamic import — so his run is the first real execution of the added regressions.
- Codecov: all modified and coverable lines covered.
- Both review bots approved on the current approach.

## Review history worth keeping

Two bot findings on this PR identified real defects but proposed remedies that would have made things worse — Gitar's suggested guard would have reintroduced the exact hostname leak Codex found. Each was verified by running the actual patterns against the actual pipeline before acting, and the reasoning is preserved in the PR comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration error messages by safely redacting URLs, machine paths, credentials, and terminal formatting sequences.
  * Prevented hostnames, sensitive path details, and credentials from appearing in displayed errors.
  * Added reliable handling for malformed, parenthesized, nested, and credential-containing URLs, as well as Windows and file paths.
  * Improved redaction for long error messages and complex control-sequence formats without damaging surrounding diagnostic text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->