### PR TITLE
Close reflective loader capability gaps

### DIFF
--- a/src/routing/api/module-loader/http-validator.test.ts
+++ b/src/routing/api/module-loader/http-validator.test.ts
@@ -2017,6 +2017,25 @@ describe("routing/api/module-loader/http-validator", () => {
         [],
       );
       await validateHTTPImports(
+        `const Command = Deno.Command;` +
+          ` Command && registerSupport();` +
+          ` function registerSupport() {}`,
+        [],
+      );
+      for (
+        const source of [
+          `const Command = Deno.Command; Command || registerSupport();`,
+          `const Command = Deno.Command; registerSupport() && Command;`,
+        ]
+      ) {
+        await assertRejects(
+          async () => await validateHTTPImports(source, []),
+          Error,
+          "dynamic code generation",
+          "logical expressions must not expose a subprocess constructor alias",
+        );
+      }
+      await validateHTTPImports(
         `let Command = Deno.Command; const Safe = class {};` +
           ` export const instance = new (Command &&= Safe)();`,
         [],

--- a/src/routing/api/module-loader/http-validator.test.ts
+++ b/src/routing/api/module-loader/http-validator.test.ts
@@ -1209,6 +1209,11 @@ describe("routing/api/module-loader/http-validator", () => {
           ` objectSupport, reflectSupport, sameImplementation });`,
         [],
       );
+      await validateHTTPImports(
+        `const setProto = Object.setPrototypeOf;` +
+          ` export const support = { setProto: typeof setProto === "function" };`,
+        [],
+      );
       for (
         const inspection of [
           `Object.setPrototypeOf == Reflect.setPrototypeOf`,
@@ -1901,6 +1906,16 @@ describe("routing/api/module-loader/http-validator", () => {
           `Bun.${method} can execute an unchecked module loader`,
         );
       }
+      await validateHTTPImports(
+        `const Command = Deno.Command;` +
+          ` export const support = { Command: typeof Command === "function" };`,
+        [],
+      );
+      await validateHTTPImports(
+        `const Command = Deno.Command;` +
+          ` export const supported = typeof Command === "function";`,
+        [],
+      );
       for (
         const source of [
           `const getCommand = () => Deno.Command;` +

--- a/src/routing/api/module-loader/http-validator.test.ts
+++ b/src/routing/api/module-loader/http-validator.test.ts
@@ -1214,6 +1214,13 @@ describe("routing/api/module-loader/http-validator", () => {
           ` export const support = { setProto: typeof setProto === "function" };`,
         [],
       );
+      await validateHTTPImports(
+        `const flag = true;` +
+          ` const objectSupport = typeof (Object.setPrototypeOf ?? undefined) === "function";` +
+          ` const reflectSupport = (flag ? Reflect.setPrototypeOf : undefined) !== undefined;` +
+          ` export const GET = () => Response.json({ objectSupport, reflectSupport });`,
+        [],
+      );
       for (
         const inspection of [
           `Object.setPrototypeOf == Reflect.setPrototypeOf`,
@@ -1227,6 +1234,43 @@ describe("routing/api/module-loader/http-validator", () => {
           "coercing comparisons can invoke hooks on a prototype mutator",
         );
       }
+    });
+
+    it("should allow a tracked prototype-mutator alias assigned as a statement", async () => {
+      await validateHTTPImports(
+        `let mutate; mutate = Object.setPrototypeOf;` +
+          ` const holder = {}; mutate(holder, null);` +
+          ` export const GET = () => new Response(String(Object.getPrototypeOf(holder)));`,
+        [],
+      );
+      await assertRejects(
+        async () =>
+          await validateHTTPImports(
+            `let mutate; mutate = Object.setPrototypeOf; const holder = {};` +
+              ` mutate(holder, () => {}); const make = holder.constructor;` +
+              ` make('return import("https://blocked.example/mod.js")')();`,
+            [],
+          ),
+        Error,
+        "dynamic code generation",
+        "the standalone alias assignment must remain tracked at its later call",
+      );
+    });
+
+    it("should retain prototype-mutator capability through logical assignments", async () => {
+      await assertRejects(
+        async () =>
+          await validateHTTPImports(
+            `let mutate = Object.setPrototypeOf; const holder = {};` +
+              ` (mutate ||= (_target, _prototype) => false)(holder, () => {});` +
+              ` const make = holder.constructor;` +
+              ` make('return import("https://blocked.example/mod.js")')();`,
+            [],
+          ),
+        Error,
+        "dynamic code generation",
+        "logical assignment can preserve an existing prototype-mutator alias",
+      );
     });
 
     it("should reject unresolved constructor keys after prototype mutation", async () => {
@@ -1915,6 +1959,22 @@ describe("routing/api/module-loader/http-validator", () => {
         `const Command = Deno.Command;` +
           ` export const supported = typeof Command === "function";`,
         [],
+      );
+      await validateHTTPImports(
+        `const flag = true;` +
+          ` export const supported = typeof (flag ? Deno.Command : undefined) === "function";`,
+        [],
+      );
+      await assertRejects(
+        async () =>
+          await validateHTTPImports(
+            `let Command = Deno.Command;` +
+              ` new (Command ||= class {})("deno", { args: ["run", "./unchecked.ts"] });`,
+            [],
+          ),
+        Error,
+        "dynamic code generation",
+        "logical assignment can preserve an existing subprocess constructor alias",
       );
       for (
         const source of [

--- a/src/routing/api/module-loader/http-validator.test.ts
+++ b/src/routing/api/module-loader/http-validator.test.ts
@@ -1224,6 +1224,13 @@ describe("routing/api/module-loader/http-validator", () => {
         [],
       );
       await validateHTTPImports(
+        `const setProto = Object.setPrototypeOf;` +
+          ` let supported = true;` +
+          ` switch (setProto) { case undefined: supported = false; break; }` +
+          ` export { supported };`,
+        [],
+      );
+      await validateHTTPImports(
         `const flag = true;` +
           ` const objectSupport = typeof (Object.setPrototypeOf ?? undefined) === "function";` +
           ` const reflectSupport = (flag ? Reflect.setPrototypeOf : undefined) !== undefined;` +
@@ -2019,6 +2026,12 @@ describe("routing/api/module-loader/http-validator", () => {
       await validateHTTPImports(
         `const Command = Deno.Command;` +
           ` Command && registerSupport();` +
+          ` function registerSupport() {}`,
+        [],
+      );
+      await validateHTTPImports(
+        `const Command = Deno.Command;` +
+          ` switch (Command) { case undefined: break; default: registerSupport(); }` +
           ` function registerSupport() {}`,
         [],
       );

--- a/src/routing/api/module-loader/http-validator.test.ts
+++ b/src/routing/api/module-loader/http-validator.test.ts
@@ -973,6 +973,33 @@ describe("routing/api/module-loader/http-validator", () => {
           `Reflect.apply(Object.setPrototypeOf, null, [holder, () => {}]);`,
           `const setProto = Reflect.setPrototypeOf;` +
           ` let args = [{}, null]; args = [holder, () => {}]; setProto.apply(null, args);`,
+          `Object.setPrototypeOf.bind(Object, holder, () => {})();`,
+          `Reflect.setPrototypeOf.bind(Reflect, holder, () => {})();`,
+          `const setProto = Object.setPrototypeOf.bind(Object, holder, () => {}); setProto();`,
+          `const setProto = Reflect.setPrototypeOf.bind(Reflect, holder, () => {}); setProto();`,
+          `Object.setPrototypeOf.bind.call(Object.setPrototypeOf, Object, holder, () => {})();`,
+          `Reflect.setPrototypeOf.bind.call(Reflect.setPrototypeOf, Reflect, holder, () => {})();`,
+          `Object.setPrototypeOf.bind.apply(Object.setPrototypeOf, [Object, holder, () => {}])();`,
+          `Reflect.setPrototypeOf.bind.apply(Reflect.setPrototypeOf, [Reflect, holder, () => {}])();`,
+          `const bind = Object.setPrototypeOf.bind;` +
+          ` bind.call(Object.setPrototypeOf, Object, holder, () => {})();`,
+          `const bind = Reflect.setPrototypeOf.bind;` +
+          ` bind.apply(Reflect.setPrototypeOf, [Reflect, holder, () => {}])();`,
+          `Function.prototype.bind.call(Object.setPrototypeOf, Object, holder, () => {})();`,
+          `Function.prototype.bind.apply(Reflect.setPrototypeOf, [Reflect, holder, () => {}])();`,
+          `Reflect.apply(Function.prototype.bind, Object.setPrototypeOf,` +
+          ` [Object, holder, () => {}])();`,
+          `const setProto = Object.setPrototypeOf.bind.call(Object.setPrototypeOf, Object);` +
+          ` setProto(holder, () => {});`,
+          `const setProto = Reflect.setPrototypeOf.bind.apply(Reflect.setPrototypeOf, [Reflect]);` +
+          ` setProto(holder, () => {});`,
+          `const bind = Object.setPrototypeOf.bind;` +
+          ` const setProto = bind.call(Object.setPrototypeOf, Object);` +
+          ` setProto(holder, () => {});`,
+          `const setProto = Function.prototype.bind.call(Object.setPrototypeOf, Object);` +
+          ` setProto(holder, () => {});`,
+          `const setProto = Reflect.apply(Function.prototype.bind,` +
+          ` Reflect.setPrototypeOf, [Reflect]); setProto(holder, () => {});`,
         ]
       ) {
         await assertRejects(
@@ -988,6 +1015,15 @@ describe("routing/api/module-loader/http-validator", () => {
           "calling a borrowed setPrototypeOf mutator must invalidate the target object",
         );
       }
+      await validateHTTPImports(
+        `const first = {}; Object.setPrototypeOf(first, null);` +
+          ` const mutate = Reflect.setPrototypeOf; const second = {};` +
+          ` mutate(second, null);` +
+          ` const third = {};` +
+          ` (Object.setPrototypeOf as typeof Object.setPrototypeOf)(third, null);` +
+          ` const fourth = {}; Object.setPrototypeOf!(fourth, null);`,
+        [],
+      );
       await assertRejects(
         async () =>
           await validateHTTPImports(
@@ -1785,6 +1821,21 @@ describe("routing/api/module-loader/http-validator", () => {
           ` const Command = commands.get("run");` +
           ` new Command(Deno.execPath(), { args: ["run", "-A",` +
           ` "https://blocked.example/mod.ts"] }).output();`,
+          `Reflect.apply(Reflect.construct, Reflect, [Deno.Command,` +
+          ` ["deno", { args: ["run", "./x.ts"] }]]);`,
+          `Reflect.construct.bind(Reflect)(Deno.Command,` +
+          ` ["deno", { args: ["run", "./x.ts"] }]);`,
+          `const args = [Deno.Command, ["deno", { args: ["run", "./x.ts"] }]];` +
+          ` Reflect.apply(Reflect.construct, Reflect, args);`,
+          `Reflect.construct.bind(Reflect, Deno.Command,` +
+          ` ["deno", { args: ["run", "./x.ts"] }])();`,
+          `const construct = Reflect.construct.bind(Reflect);` +
+          ` construct(Deno.Command, ["deno", { args: ["run", "./x.ts"] }]);`,
+          `const construct = Reflect.construct.bind(Reflect, Deno.Command,` +
+          ` ["deno", { args: ["run", "./x.ts"] }]); construct();`,
+          `const { bind } = Reflect.construct;` +
+          ` const construct = bind.call(Reflect.construct, Reflect);` +
+          ` construct(Deno.Command, ["deno", { args: ["run", "./x.ts"] }]);`,
         ]
       ) {
         await assertRejects(
@@ -1794,6 +1845,26 @@ describe("routing/api/module-loader/http-validator", () => {
           "reflective construction and opaque storage must retain subprocess capability checks",
         );
       }
+      await validateHTTPImports(
+        `class Safe {} Reflect.construct(Safe, []);`,
+        [],
+      );
+      await validateHTTPImports(
+        `class Command {}` +
+          `const Deno = { Command };` +
+          `const Reflect = { construct: { bind: () => () => undefined } };` +
+          `Reflect.construct.bind(Reflect, Deno.Command,` +
+          ` ["deno", { args: ["run", "./x.ts"] }])();`,
+        [],
+      );
+      await validateHTTPImports(
+        `class Command {}` +
+          `const Deno = { Command };` +
+          `const { bind } = Reflect.construct;` +
+          `const construct = bind.call(Reflect.construct, Reflect);` +
+          `construct(Deno.Command, []);`,
+        [],
+      );
       for (const method of ["spawn", "spawnSync"]) {
         await assertRejects(
           async () =>

--- a/src/routing/api/module-loader/http-validator.test.ts
+++ b/src/routing/api/module-loader/http-validator.test.ts
@@ -1200,6 +1200,30 @@ describe("routing/api/module-loader/http-validator", () => {
       );
     });
 
+    it("should allow inert feature detection of prototype mutators", async () => {
+      await validateHTTPImports(
+        `const objectSupport = typeof Object.setPrototypeOf === "function";` +
+          ` const reflectSupport = Reflect.setPrototypeOf !== undefined;` +
+          ` const sameImplementation = Object.setPrototypeOf === Reflect.setPrototypeOf;` +
+          ` export const GET = () => Response.json({` +
+          ` objectSupport, reflectSupport, sameImplementation });`,
+        [],
+      );
+      for (
+        const inspection of [
+          `Object.setPrototypeOf == Reflect.setPrototypeOf`,
+          `Object.setPrototypeOf < Reflect.setPrototypeOf`,
+        ]
+      ) {
+        await assertRejects(
+          async () => await validateHTTPImports(`export const result = ${inspection};`, []),
+          Error,
+          "dynamic code generation",
+          "coercing comparisons can invoke hooks on a prototype mutator",
+        );
+      }
+    });
+
     it("should reject unresolved constructor keys after prototype mutation", async () => {
       const mutations = [
         `const holder = {}; Object.setPrototypeOf(holder, () => {});`,

--- a/src/routing/api/module-loader/http-validator.test.ts
+++ b/src/routing/api/module-loader/http-validator.test.ts
@@ -1215,10 +1215,33 @@ describe("routing/api/module-loader/http-validator", () => {
         [],
       );
       await validateHTTPImports(
+        `const setProto = Object.setPrototypeOf;` +
+          ` const supported = !!setProto;` +
+          ` const status = setProto ? "supported" : "unsupported";` +
+          ` if (setProto) { exportSupport(supported); }` +
+          ` function exportSupport(_supported: boolean) {}` +
+          ` export { status, supported };`,
+        [],
+      );
+      await validateHTTPImports(
         `const flag = true;` +
           ` const objectSupport = typeof (Object.setPrototypeOf ?? undefined) === "function";` +
           ` const reflectSupport = (flag ? Reflect.setPrototypeOf : undefined) !== undefined;` +
           ` export const GET = () => Response.json({ objectSupport, reflectSupport });`,
+        [],
+      );
+      await validateHTTPImports(
+        `const flag = true; const safeMutate = (_target: object, _prototype: object | null) => true;` +
+          ` const mutate = flag ? Object.setPrototypeOf : safeMutate;` +
+          ` const holder = {}; mutate(holder, null);` +
+          ` export const GET = () => new Response(String(Object.getPrototypeOf(holder)));`,
+        [],
+      );
+      await validateHTTPImports(
+        `const safeMutate = (_target: object, _prototype: object | null) => true;` +
+          ` const mutate = Object.setPrototypeOf ?? safeMutate;` +
+          ` const holder = {}; mutate(holder, null);` +
+          ` export const GET = () => new Response(String(Object.getPrototypeOf(holder)));`,
         [],
       );
       for (
@@ -1237,6 +1260,18 @@ describe("routing/api/module-loader/http-validator", () => {
     });
 
     it("should allow a tracked prototype-mutator alias assigned as a statement", async () => {
+      await validateHTTPImports(
+        `const holder = {}; Object.setPrototypeOf.call(null, holder, null);` +
+          ` export const GET = () => new Response(String(Object.getPrototypeOf(holder)));`,
+        [],
+      );
+      await validateHTTPImports(
+        `const first = {}; Reflect.setPrototypeOf.apply(null, [first, null]);` +
+          ` const second = {}; Reflect.apply(Object.setPrototypeOf, null, [second, null]);` +
+          ` export const GET = () => new Response(String(` +
+          ` Object.getPrototypeOf(first) === Object.getPrototypeOf(second)));`,
+        [],
+      );
       await validateHTTPImports(
         `let mutate; mutate = Object.setPrototypeOf;` +
           ` const holder = {}; mutate(holder, null);` +
@@ -1258,6 +1293,14 @@ describe("routing/api/module-loader/http-validator", () => {
     });
 
     it("should retain prototype-mutator capability through logical assignments", async () => {
+      await validateHTTPImports(
+        `let mutate = Object.setPrototypeOf;` +
+          ` const safeMutate = (_target: object, _prototype: object | null) => true;` +
+          ` const holder = {}; (mutate &&= safeMutate)(holder, null);` +
+          ` const make = holder.constructor;` +
+          ` export const GET = () => new Response(String(make));`,
+        [],
+      );
       await assertRejects(
         async () =>
           await validateHTTPImports(
@@ -1963,6 +2006,19 @@ describe("routing/api/module-loader/http-validator", () => {
       await validateHTTPImports(
         `const flag = true;` +
           ` export const supported = typeof (flag ? Deno.Command : undefined) === "function";`,
+        [],
+      );
+      await validateHTTPImports(
+        `const Command = Deno.Command;` +
+          ` const supported = !!Command;` +
+          ` if (Command) { exportSupport(supported); }` +
+          ` function exportSupport(_supported: boolean) {}` +
+          ` export { supported };`,
+        [],
+      );
+      await validateHTTPImports(
+        `let Command = Deno.Command; const Safe = class {};` +
+          ` export const instance = new (Command &&= Safe)();`,
         [],
       );
       await assertRejects(

--- a/src/routing/api/module-loader/source-capability-analyzer.ts
+++ b/src/routing/api/module-loader/source-capability-analyzer.ts
@@ -1672,6 +1672,19 @@ function resolvesToGlobalIntrinsicMember(
       new Set(seen),
     );
   }
+  if (
+    expression.type === "LogicalExpression" && expression.operator === "&&" &&
+    isNode(expression.right)
+  ) {
+    return resolvesToGlobalIntrinsicMember(
+      expression.right,
+      objectName,
+      propertyName,
+      scope,
+      nodeScopes,
+      new Set(seen),
+    );
+  }
   const branches = expressionBranches(expression);
   if (branches !== null) {
     return resolvesToGlobalIntrinsicMember(
@@ -3277,6 +3290,7 @@ function isInertCapabilityInspection(
   let current = node;
   let link = parents.get(current);
   while (link && isInertInspectionValueFlow(link)) {
+    if (isTruthyLogicalAndLeftGuard(link)) return true;
     current = link.parent;
     link = parents.get(current);
   }
@@ -3290,6 +3304,12 @@ function isInertCapabilityInspection(
   return link.parent.type === "BinaryExpression" &&
     (link.parent.operator === "===" || link.parent.operator === "!==") &&
     (link.key === "left" || link.key === "right");
+}
+
+function isTruthyLogicalAndLeftGuard(link: ParentLink): boolean {
+  return link.parent.type === "LogicalExpression" &&
+    link.parent.operator === "&&" &&
+    link.key === "left";
 }
 
 function isInertInspectionValueFlow(link: ParentLink): boolean {

--- a/src/routing/api/module-loader/source-capability-analyzer.ts
+++ b/src/routing/api/module-loader/source-capability-analyzer.ts
@@ -3247,6 +3247,29 @@ function isCallExpressionCallee(
   return link !== undefined && isCallExpression(link.parent) && link.key === "callee";
 }
 
+function isInertCapabilityInspection(
+  node: ASTNode,
+  parents: WeakMap<ASTNode, ParentLink>,
+): boolean {
+  let current = node;
+  let link = parents.get(current);
+  while (
+    link && TS_EXPRESSION_WRAPPER_TYPES.has(link.parent.type) &&
+    link.key === "expression"
+  ) {
+    current = link.parent;
+    link = parents.get(current);
+  }
+  if (!link) return false;
+  if (
+    link.parent.type === "UnaryExpression" && link.parent.operator === "typeof" &&
+    link.key === "argument"
+  ) return true;
+  return link.parent.type === "BinaryExpression" &&
+    (link.parent.operator === "===" || link.parent.operator === "!==") &&
+    (link.key === "left" || link.key === "right");
+}
+
 function isMemberObjectUse(node: ASTNode, parents: WeakMap<ASTNode, ParentLink>): boolean {
   const link = parents.get(node);
   return (link?.parent.type === "MemberExpression" ||
@@ -4152,6 +4175,7 @@ function applyPrototypeMutatorReferenceCapability(
   if (
     resolvesToPrototypeMutator(node, scope, nodeScopes) &&
     !isCallExpressionCallee(node, parents) &&
+    !isInertCapabilityInspection(node, parents) &&
     !isAliasInitializerUse(node, parents) &&
     !isBindingIdentifier(node, parents) &&
     !isMutationTarget(node, parents)

--- a/src/routing/api/module-loader/source-capability-analyzer.ts
+++ b/src/routing/api/module-loader/source-capability-analyzer.ts
@@ -1120,7 +1120,8 @@ function resolvesToPrototypeMutator(
       resolvesToGlobalIntrinsic(expression.object, "Reflect", scope, nodeScopes);
   }
   if (isAliasAssignmentExpression(expression)) {
-    const leftMayRemain = expression.operator !== "=" && isNode(expression.left) &&
+    const leftMayRemain = logicalAssignmentMayRetainTruthyLeft(expression) &&
+      isNode(expression.left) &&
       resolvesToPrototypeMutator(expression.left, scope, nodeScopes, new Set(seen));
     return leftMayRemain ||
       resolvesToPrototypeMutator(expression.right, scope, nodeScopes, new Set(seen));
@@ -1652,7 +1653,8 @@ function resolvesToGlobalIntrinsicMember(
     )
   ) return true;
   if (isAliasAssignmentExpression(expression)) {
-    const leftMayRemain = expression.operator !== "=" && isNode(expression.left) &&
+    const leftMayRemain = logicalAssignmentMayRetainTruthyLeft(expression) &&
+      isNode(expression.left) &&
       resolvesToGlobalIntrinsicMember(
         expression.left,
         objectName,
@@ -2899,6 +2901,10 @@ function isAliasAssignmentExpression(
     ALIAS_ASSIGNMENT_OPERATORS.has(String(expression.operator)) && isNode(expression.right);
 }
 
+function logicalAssignmentMayRetainTruthyLeft(expression: ASTNode): boolean {
+  return expression.operator === "||=" || expression.operator === "??=";
+}
+
 function isReflectGetGlobalWorker(
   expression: ASTNode,
   scope: Scope,
@@ -3202,10 +3208,7 @@ function isAliasInitializerUse(
 ): boolean {
   let current = node;
   let link = parents.get(current);
-  while (
-    link && TS_EXPRESSION_WRAPPER_TYPES.has(link.parent.type) &&
-    link.key === "expression"
-  ) {
+  while (link && isInertInspectionValueFlow(link)) {
     current = link.parent;
     link = parents.get(current);
   }
@@ -3279,9 +3282,11 @@ function isInertCapabilityInspection(
   }
   if (!link) return false;
   if (
-    link.parent.type === "UnaryExpression" && link.parent.operator === "typeof" &&
+    link.parent.type === "UnaryExpression" &&
+    (link.parent.operator === "typeof" || link.parent.operator === "!") &&
     link.key === "argument"
   ) return true;
+  if (isBooleanTestUse(link)) return true;
   return link.parent.type === "BinaryExpression" &&
     (link.parent.operator === "===" || link.parent.operator === "!==") &&
     (link.key === "left" || link.key === "right");
@@ -3295,6 +3300,52 @@ function isInertInspectionValueFlow(link: ParentLink): boolean {
   ) return true;
   return link.parent.type === "LogicalExpression" &&
     (link.key === "left" || link.key === "right");
+}
+
+function isBooleanTestUse(link: ParentLink): boolean {
+  return link.key === "test" &&
+    (link.parent.type === "IfStatement" ||
+      link.parent.type === "ConditionalExpression" ||
+      link.parent.type === "WhileStatement" ||
+      link.parent.type === "DoWhileStatement" ||
+      link.parent.type === "ForStatement");
+}
+
+function isTrackedPrototypeMutatorInvocationUse(
+  node: ASTNode,
+  scope: Scope,
+  nodeScopes: WeakMap<ASTNode, Scope>,
+  parents: WeakMap<ASTNode, ParentLink>,
+): boolean {
+  let current = node;
+  let link = parents.get(current);
+  while (
+    link && TS_EXPRESSION_WRAPPER_TYPES.has(link.parent.type) &&
+    link.key === "expression"
+  ) {
+    current = link.parent;
+    link = parents.get(current);
+  }
+  if (!link) return false;
+  if (
+    isCallExpression(link.parent) && link.key === "arguments" &&
+    borrowedPrototypeMutatorCallTargets(link.parent, scope, nodeScopes).length > 0
+  ) return true;
+  if (
+    !isMemberExpressionWithObject(link.parent) || link.key !== "object" ||
+    (memberPropertyName(link.parent) !== "call" && memberPropertyName(link.parent) !== "apply")
+  ) return false;
+  current = link.parent;
+  link = parents.get(current);
+  while (
+    link && TS_EXPRESSION_WRAPPER_TYPES.has(link.parent.type) &&
+    link.key === "expression"
+  ) {
+    current = link.parent;
+    link = parents.get(current);
+  }
+  return link !== undefined && isCallExpression(link.parent) && link.key === "callee" &&
+    borrowedPrototypeMutatorCallTargets(link.parent, scope, nodeScopes).length > 0;
 }
 
 function isMemberObjectUse(node: ASTNode, parents: WeakMap<ASTNode, ParentLink>): boolean {
@@ -4207,6 +4258,7 @@ function applyPrototypeMutatorReferenceCapability(
   if (
     resolvesToPrototypeMutator(node, scope, nodeScopes) &&
     !isCallExpressionCallee(node, parents) &&
+    !isTrackedPrototypeMutatorInvocationUse(node, scope, nodeScopes, parents) &&
     !isInertCapabilityInspection(node, parents) &&
     !isAliasInitializerUse(node, parents) &&
     !isBindingIdentifier(node, parents) &&

--- a/src/routing/api/module-loader/source-capability-analyzer.ts
+++ b/src/routing/api/module-loader/source-capability-analyzer.ts
@@ -3231,6 +3231,22 @@ function isNewExpressionCallee(node: ASTNode, parents: WeakMap<ASTNode, ParentLi
   return link?.parent.type === "NewExpression" && link.key === "callee";
 }
 
+function isCallExpressionCallee(
+  node: ASTNode,
+  parents: WeakMap<ASTNode, ParentLink>,
+): boolean {
+  let current = node;
+  let link = parents.get(current);
+  while (
+    link && TS_EXPRESSION_WRAPPER_TYPES.has(link.parent.type) &&
+    link.key === "expression"
+  ) {
+    current = link.parent;
+    link = parents.get(current);
+  }
+  return link !== undefined && isCallExpression(link.parent) && link.key === "callee";
+}
+
 function isMemberObjectUse(node: ASTNode, parents: WeakMap<ASTNode, ParentLink>): boolean {
   const link = parents.get(node);
   return (link?.parent.type === "MemberExpression" ||
@@ -4108,6 +4124,42 @@ function applySubprocessConstructionCapability(
   }
 }
 
+function applySubprocessReferenceCapability(
+  node: ASTNode,
+  scope: Scope,
+  nodeScopes: WeakMap<ASTNode, Scope>,
+  parents: WeakMap<ASTNode, ParentLink>,
+  analysis: MutableSourceCapabilityAnalysis,
+): void {
+  if (
+    resolvesToDenoCommand(node, scope, nodeScopes) &&
+    !isNewExpressionCallee(node, parents) &&
+    !isAliasInitializerUse(node, parents) &&
+    !isBindingIdentifier(node, parents) &&
+    !isMutationTarget(node, parents)
+  ) {
+    analysis.hasDynamicCodeGeneration = true;
+  }
+}
+
+function applyPrototypeMutatorReferenceCapability(
+  node: ASTNode,
+  scope: Scope,
+  nodeScopes: WeakMap<ASTNode, Scope>,
+  parents: WeakMap<ASTNode, ParentLink>,
+  analysis: MutableSourceCapabilityAnalysis,
+): void {
+  if (
+    resolvesToPrototypeMutator(node, scope, nodeScopes) &&
+    !isCallExpressionCallee(node, parents) &&
+    !isAliasInitializerUse(node, parents) &&
+    !isBindingIdentifier(node, parents) &&
+    !isMutationTarget(node, parents)
+  ) {
+    analysis.hasDynamicCodeGeneration = true;
+  }
+}
+
 function applyInheritedClassCapability(
   node: ASTNode,
   scope: Scope,
@@ -4337,6 +4389,14 @@ export async function analyzeSourceCapabilities(
     applyObjectPatternCapability(node, scope, nodeScopes, parents, analysis);
     applyWorkerConstructionCapability(node, scope, nodeScopes, analysis);
     applySubprocessConstructionCapability(node, scope, nodeScopes, analysis);
+    applySubprocessReferenceCapability(node, scope, nodeScopes, parents, analysis);
+    applyPrototypeMutatorReferenceCapability(
+      node,
+      scope,
+      nodeScopes,
+      parents,
+      analysis,
+    );
     applyInheritedClassCapability(node, scope, nodeScopes, analysis);
     applyExportedCapabilityAlias(node, scope, nodeScopes, analysis);
 

--- a/src/routing/api/module-loader/source-capability-analyzer.ts
+++ b/src/routing/api/module-loader/source-capability-analyzer.ts
@@ -4154,9 +4154,11 @@ function applySubprocessReferenceCapability(
   parents: WeakMap<ASTNode, ParentLink>,
   analysis: MutableSourceCapabilityAnalysis,
 ): void {
+  if (node.type === "Identifier" && !isIdentifierReference(node, parents)) return;
   if (
     resolvesToDenoCommand(node, scope, nodeScopes) &&
     !isNewExpressionCallee(node, parents) &&
+    !isInertCapabilityInspection(node, parents) &&
     !isAliasInitializerUse(node, parents) &&
     !isBindingIdentifier(node, parents) &&
     !isMutationTarget(node, parents)
@@ -4172,6 +4174,7 @@ function applyPrototypeMutatorReferenceCapability(
   parents: WeakMap<ASTNode, ParentLink>,
   analysis: MutableSourceCapabilityAnalysis,
 ): void {
+  if (node.type === "Identifier" && !isIdentifierReference(node, parents)) return;
   if (
     resolvesToPrototypeMutator(node, scope, nodeScopes) &&
     !isCallExpressionCallee(node, parents) &&

--- a/src/routing/api/module-loader/source-capability-analyzer.ts
+++ b/src/routing/api/module-loader/source-capability-analyzer.ts
@@ -1120,7 +1120,10 @@ function resolvesToPrototypeMutator(
       resolvesToGlobalIntrinsic(expression.object, "Reflect", scope, nodeScopes);
   }
   if (isAliasAssignmentExpression(expression)) {
-    return resolvesToPrototypeMutator(expression.right, scope, nodeScopes, seen);
+    const leftMayRemain = expression.operator !== "=" && isNode(expression.left) &&
+      resolvesToPrototypeMutator(expression.left, scope, nodeScopes, new Set(seen));
+    return leftMayRemain ||
+      resolvesToPrototypeMutator(expression.right, scope, nodeScopes, new Set(seen));
   }
   const branches = expressionBranches(expression);
   if (branches !== null) {
@@ -1649,13 +1652,22 @@ function resolvesToGlobalIntrinsicMember(
     )
   ) return true;
   if (isAliasAssignmentExpression(expression)) {
-    return resolvesToGlobalIntrinsicMember(
+    const leftMayRemain = expression.operator !== "=" && isNode(expression.left) &&
+      resolvesToGlobalIntrinsicMember(
+        expression.left,
+        objectName,
+        propertyName,
+        scope,
+        nodeScopes,
+        new Set(seen),
+      );
+    return leftMayRemain || resolvesToGlobalIntrinsicMember(
       expression.right,
       objectName,
       propertyName,
       scope,
       nodeScopes,
-      seen,
+      new Set(seen),
     );
   }
   const branches = expressionBranches(expression);
@@ -3198,6 +3210,14 @@ function isAliasInitializerUse(
     link = parents.get(current);
   }
   if (!link) return false;
+  if (
+    current.type === "AssignmentExpression" &&
+    ALIAS_ASSIGNMENT_OPERATORS.has(String(current.operator)) &&
+    isNode(current.left) &&
+    (current.left.type === "Identifier" ||
+      isSafeGlobalObjectDestructuring(current.left)) &&
+    link.parent.type === "ExpressionStatement" && link.key === "expression"
+  ) return true;
   return (link.parent.type === "VariableDeclarator" && link.key === "init" &&
     isNode(link.parent.id) &&
     (link.parent.id.type === "Identifier" ||
@@ -3253,10 +3273,7 @@ function isInertCapabilityInspection(
 ): boolean {
   let current = node;
   let link = parents.get(current);
-  while (
-    link && TS_EXPRESSION_WRAPPER_TYPES.has(link.parent.type) &&
-    link.key === "expression"
-  ) {
+  while (link && isInertInspectionValueFlow(link)) {
     current = link.parent;
     link = parents.get(current);
   }
@@ -3267,6 +3284,16 @@ function isInertCapabilityInspection(
   ) return true;
   return link.parent.type === "BinaryExpression" &&
     (link.parent.operator === "===" || link.parent.operator === "!==") &&
+    (link.key === "left" || link.key === "right");
+}
+
+function isInertInspectionValueFlow(link: ParentLink): boolean {
+  if (TS_EXPRESSION_WRAPPER_TYPES.has(link.parent.type) && link.key === "expression") return true;
+  if (
+    link.parent.type === "ConditionalExpression" &&
+    (link.key === "consequent" || link.key === "alternate")
+  ) return true;
+  return link.parent.type === "LogicalExpression" &&
     (link.key === "left" || link.key === "right");
 }
 
@@ -3432,7 +3459,9 @@ function applyMemberCapability(
   }
   if (
     resolvesToDenoCommand(node, scope, nodeScopes) &&
-    !isNewExpressionCallee(node, parents) && !isAliasInitializerUse(node, parents)
+    !isNewExpressionCallee(node, parents) &&
+    !isInertCapabilityInspection(node, parents) &&
+    !isAliasInitializerUse(node, parents)
   ) {
     analysis.hasDynamicCodeGeneration = true;
   }

--- a/src/routing/api/module-loader/source-capability-analyzer.ts
+++ b/src/routing/api/module-loader/source-capability-analyzer.ts
@@ -3300,7 +3300,7 @@ function isInertCapabilityInspection(
     (link.parent.operator === "typeof" || link.parent.operator === "!") &&
     link.key === "argument"
   ) return true;
-  if (isBooleanTestUse(link)) return true;
+  if (isInertControlFlowUse(link)) return true;
   return link.parent.type === "BinaryExpression" &&
     (link.parent.operator === "===" || link.parent.operator === "!==") &&
     (link.key === "left" || link.key === "right");
@@ -3322,13 +3322,14 @@ function isInertInspectionValueFlow(link: ParentLink): boolean {
     (link.key === "left" || link.key === "right");
 }
 
-function isBooleanTestUse(link: ParentLink): boolean {
-  return link.key === "test" &&
+function isInertControlFlowUse(link: ParentLink): boolean {
+  return (link.key === "test" &&
     (link.parent.type === "IfStatement" ||
       link.parent.type === "ConditionalExpression" ||
       link.parent.type === "WhileStatement" ||
       link.parent.type === "DoWhileStatement" ||
-      link.parent.type === "ForStatement");
+      link.parent.type === "ForStatement")) ||
+    (link.key === "discriminant" && link.parent.type === "SwitchStatement");
 }
 
 function isTrackedPrototypeMutatorInvocationUse(


### PR DESCRIPTION
Follow-up to #4104. The merge queue completed while its final exact-head review fixes were still running, so this PR carries only the two changes not present in the squash merge.

## Summary

- Fail closed when a real `Deno.Command` reference escapes direct construction or a tracked alias.
- Fail closed when real `Object.setPrototypeOf` or `Reflect.setPrototypeOf` references are laundered through bind, call, apply, storage, or forwarding.
- Preserve direct calls, TypeScript-wrapped direct calls, and safe local shadows.

## Validation

- `http-validator.test.ts`: 2 tests, 107 steps passed.
- Full module-loader suite: 15 tests, 364 steps passed.
- Formatting, lint, typecheck, and diff checks passed.
- Representative filesystem tests from a disk-starved broad run: 4 tests, 49 steps passed after reclaiming temp space.
- Independent code, security, and verification reviews are bound to the exact head before queueing.

The first broad pre-push attempt passed repository formatting, lint, typecheck, generation, and 4,300 unit tests before the local volume reached 146 MiB free and 47 filesystem-heavy tests failed. Remote CI remains authoritative for the exact commit.