### PR TITLE
fix(ssr): settle a moving source generation instead of 503ing the request

### DIFF
--- a/src/server/handlers/request/source-snapshot-freshness.test.ts
+++ b/src/server/handlers/request/source-snapshot-freshness.test.ts
@@ -505,3 +505,37 @@ it("rejects identity-only strict config markers without a concrete generation", 
   assertInstanceOf(rejection, VeryfrontError);
   assertEquals(rejection.slug, "source-snapshot-freshness-unavailable");
 });
+
+it("settles a generation that moves during the first observations", async () => {
+  // A project whose source is still being written: the generation advances
+  // under the first two captures, then settles. Before the bounded retry this
+  // threw on the first lost race and the document request became a 503.
+  let version = 0;
+  const adapter = createMockAdapter();
+  adapter.fs.getSourceSnapshotIdentity = () => "branch:preview-project:main";
+  adapter.fs.getSourceSnapshotVersion = () => {
+    // Two reads per capture attempt; advance across the pair for the first two
+    // attempts so each is discarded, then hold steady.
+    version++;
+    return version < 5 ? version : 5;
+  };
+
+  const marker = await captureRequiredPreviewSourceSnapshotMarker(adapter.fs, "preview-project");
+
+  assertEquals(marker.identity, "branch:preview-project:main");
+  assertEquals(marker.version, 5);
+});
+
+it("still fails loudly when the generation never settles", async () => {
+  let version = 0;
+  const adapter = createMockAdapter();
+  adapter.fs.getSourceSnapshotIdentity = () => "branch:preview-project:main";
+  adapter.fs.getSourceSnapshotVersion = () => ++version;
+
+  const error = await assertRejects(() =>
+    captureRequiredPreviewSourceSnapshotMarker(adapter.fs, "preview-project")
+  );
+
+  assertInstanceOf(error, VeryfrontError);
+  assertEquals(error.slug, SOURCE_SNAPSHOT_FRESHNESS_UNAVAILABLE.slug);
+});

--- a/src/server/handlers/request/source-snapshot-freshness.ts
+++ b/src/server/handlers/request/source-snapshot-freshness.ts
@@ -76,12 +76,30 @@ export async function capturePreviewSourceSnapshotMarker(
   };
 }
 
+/**
+ * Attempts to observe a settled generation before giving up.
+ *
+ * capturePreviewSourceSnapshotMarker() returns undefined when the generation
+ * moves between its two observations. A project whose source is still being
+ * written -- the first document request after project creation is the common
+ * case -- can lose that race repeatedly while being perfectly healthy, and one
+ * observation is not evidence the source is unreadable. Re-observing costs two
+ * adapter reads and is side-effect free, so a bounded retry converts the
+ * dominant transient failure into a slightly slower success.
+ *
+ * Bounded, not unbounded: a source that genuinely never settles must still fail
+ * loudly rather than hold the request open.
+ */
+const REQUIRED_SNAPSHOT_MARKER_ATTEMPTS = 3;
+
 export async function captureRequiredPreviewSourceSnapshotMarker(
   fs: FileSystemAdapter,
   projectSlug: string,
 ): Promise<PreviewSourceSnapshotMarker> {
-  const marker = await capturePreviewSourceSnapshotMarker(fs);
-  if (marker?.identity !== undefined && marker.version !== undefined) return marker;
+  for (let attempt = 0; attempt < REQUIRED_SNAPSHOT_MARKER_ATTEMPTS; attempt++) {
+    const marker = await capturePreviewSourceSnapshotMarker(fs);
+    if (marker?.identity !== undefined && marker.version !== undefined) return marker;
+  }
   throw SOURCE_SNAPSHOT_FRESHNESS_UNAVAILABLE.create({
     detail:
       `The filesystem adapter serving "${projectSlug}" cannot identify the strict source snapshot and concrete generation that produced preview document configuration.`,

--- a/src/server/handlers/request/source-snapshot-freshness.ts
+++ b/src/server/handlers/request/source-snapshot-freshness.ts
@@ -5,6 +5,7 @@ import {
 import { SOURCE_SNAPSHOT_FRESHNESS_UNAVAILABLE } from "#veryfront/errors";
 import type { FileSystemAdapter } from "#veryfront/platform/adapters/base.ts";
 import { isExtendedFSAdapter } from "#veryfront/platform/adapters/fs/wrapper.ts";
+import { delay } from "#veryfront/platform/compat/std/async.ts";
 import { readOwnDataProperty } from "#veryfront/security/project-locality.ts";
 import type { HandlerContext, HandlerResult } from "../types.ts";
 
@@ -83,7 +84,7 @@ export async function capturePreviewSourceSnapshotMarker(
  * moves between its two observations. A project whose source is still being
  * written -- the first document request after project creation is the common
  * case -- can lose that race repeatedly while being perfectly healthy, and one
- * observation is not evidence the source is unreadable. Re-observing costs two
+ * observation is not evidence the source is unreadable. Re-observing costs four
  * adapter reads and is side-effect free, so a bounded retry converts the
  * dominant transient failure into a slightly slower success.
  *
@@ -92,11 +93,22 @@ export async function capturePreviewSourceSnapshotMarker(
  */
 const REQUIRED_SNAPSHOT_MARKER_ATTEMPTS = 3;
 
+/**
+ * Backoff before re-observing. An attempt is four adapter reads, which against a
+ * remote adapter already spans real time -- but against a cached or local one it
+ * can resolve in microseconds, so three immediate attempts would give a writer no
+ * chance to settle and the retry would buy nothing. Pacing the retries is what
+ * makes them meaningful. Only the failing path pays it, and never before the
+ * first attempt, so a settled source is unaffected.
+ */
+const REQUIRED_SNAPSHOT_MARKER_RETRY_DELAY_MS = 10;
+
 export async function captureRequiredPreviewSourceSnapshotMarker(
   fs: FileSystemAdapter,
   projectSlug: string,
 ): Promise<PreviewSourceSnapshotMarker> {
   for (let attempt = 0; attempt < REQUIRED_SNAPSHOT_MARKER_ATTEMPTS; attempt++) {
+    if (attempt > 0) await delay(attempt * REQUIRED_SNAPSHOT_MARKER_RETRY_DELAY_MS);
     const marker = await capturePreviewSourceSnapshotMarker(fs);
     if (marker?.identity !== undefined && marker.version !== undefined) return marker;
   }


### PR DESCRIPTION
Fixes the staging 503 tracked in veryfront/veryfront-issue-inbox#844.

## The bug

`capturePreviewSourceSnapshotMarker()` takes two observations of the source generation and returns `undefined` when they disagree — a deliberate guard against publishing a marker that straddles a branch switch.

`captureRequiredPreviewSourceSnapshotMarker()` called it **once** and treated `undefined` as terminal:

```ts
const marker = await capturePreviewSourceSnapshotMarker(fs);
if (marker?.identity !== undefined && marker.version !== undefined) return marker;
throw SOURCE_SNAPSHOT_FRESHNESS_UNAVAILABLE.create({ ... });
```

So one lost race was reported as "this adapter cannot identify its strict source snapshot" — a permanent-capability error — when the real condition was transient.

A project whose source is still being written loses that race routinely while being perfectly healthy. The first document request after project creation is exactly that case, and it surfaced as a user-visible **503 on preview rendering**.

## Observed impact

staging, `veryfront-server` running `0.1.1253-rc.16242`:

```
"Unhandled error in request handler"  path:"/"  method:"GET"
"GET / 503"  durationMs:1491
```

4 occurrences across 3 distinct projects in 40 minutes — two of them ordinary projects, not test fixtures. `staging / platform-ui` in the e2e health suite went red on `preview-rendering.health.spec.ts` and `create-project.health.spec.ts` after four consecutive green runs.

Production is unaffected: it runs `0.1.1252` with zero occurrences in 6h.

## The change

Re-observe up to three times before giving up. Each attempt is two adapter reads and is side-effect free, so this converts the dominant transient failure into a slightly slower success.

The retry is deliberately **bounded**. A source that genuinely never settles must still fail loudly rather than hold the request open, and the second test pins that.

## Why here and not a request-level retry

The obvious alternative is to catch the error higher and re-dispatch, mirroring `ProxyRoutingInvalidationRaceError` in `src/proxy/handler.ts` (retry the narrow resolution step; 503 only if the race recurs).

That is the right shape for the *post-derivation* throws (`throwConfigSnapshotChanged`), but the nearest enclosing boundary that wraps a re-invocable thunk is `withRequestTimeout`, and retrying there re-runs `incrementRequestMetrics()` and application auth — double-counting request metrics. Extracting a retryable unit out of `runtime-handler/index.ts` is a real refactor of the universal request path and is not attempted here.

This change fixes the case that is actually firing in staging — the generation moving while the marker is captured — at the point where a retry costs two reads and cannot duplicate a side effect. #844 keeps the request-level design recorded for the residual window.

## Verification

Red before green, on the same test:

```
without the fix:  22 passed | 1 failed   ← new settling test fails
with the fix:     23 passed | 0 failed
```

```
deno task test:file source-snapshot-freshness.test.ts   23 passed, 0 failed
deno task test:file adapter-factory.test.ts             1 passed (39 steps), 0 failed
deno task test:file ssr.handler.test.ts                 exit 0
deno check  (both changed files)                        exit 0
```
