### PR TITLE
test(errors): stop pinning registry counts that every new error must bump

### DIFF
--- a/src/errors/error-registry.test.ts
+++ b/src/errors/error-registry.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertExists, assertNotEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   API_CLIENT_ERROR,
@@ -22,17 +22,17 @@ import {
 import type { ErrorCategory } from "./types.ts";
 
 /**
- * Every error slug published as of this list being written.
+ * Every error slug the registry publishes.
  *
- * Slugs are part of the public surface: callers match on them, so removing one
- * is a breaking change while adding one is routine. This guards the breaking
- * direction only, which is also why it is a list rather than a count. An exact
- * count made every error-adding pull request edit the same line, so two of them
- * were each green alone and the second died in the merge queue -- that happened
- * at 120, 121 and again at 122. Adding a slug now touches nothing here.
+ * Slugs are public surface: callers match on them, so retiring one is a
+ * breaking change that should be deliberate and visible in review.
  *
- * Removing a slug is meant to fail. Delete the entry deliberately, in the same
- * change that retires the error.
+ * This is an exhaustive list rather than a count on purpose. A count put every
+ * error-adding pull request on one shared line, each changing it to a different
+ * value, so two of them were green alone and the second died in the merge queue
+ * -- that happened at 120, 121 and again at 122. Adding a slug here appends its
+ * own line instead, which merges cleanly alongside an unrelated addition. Keep
+ * the list sorted so appends stay spread out.
  */
 const PUBLISHED_ERROR_SLUGS: readonly string[] = Object.freeze([
   "agent-error",
@@ -190,13 +190,13 @@ describe("error-registry", () => {
       assertEquals(slugs.length, uniqueSlugs.size, "Duplicate slugs detected");
     });
 
-    it("keeps every published error slug registered", () => {
-      const slugs = new Set<string>(getAllSlugs());
-      const missing = PUBLISHED_ERROR_SLUGS.filter((slug) => !slugs.has(slug));
+    it("publishes exactly the recorded slugs", () => {
+      // Exhaustive, not a subset: a subset would stop covering every slug added
+      // after the list was written, so a later removal would go unnoticed.
       assertEquals(
-        missing,
-        [],
-        `Published error slug(s) no longer registered: ${missing.join(", ")}`,
+        [...getAllSlugs()].sort(),
+        [...PUBLISHED_ERROR_SLUGS],
+        "Update PUBLISHED_ERROR_SLUGS: add a line for a new error, delete one only when retiring it",
       );
     });
 
@@ -340,7 +340,7 @@ describe("error-registry", () => {
   describe("getErrorsByCategory", () => {
     it("should return CONFIG errors", () => {
       const errors = getErrorsByCategory("CONFIG");
-      assertEquals(errors.length, 14);
+      assertNotEquals(errors.length, 0);
       for (const error of errors) {
         assertEquals(error.category, "CONFIG");
       }
@@ -348,7 +348,7 @@ describe("error-registry", () => {
 
     it("should return BUILD errors", () => {
       const errors = getErrorsByCategory("BUILD");
-      assertEquals(errors.length, 9);
+      assertNotEquals(errors.length, 0);
       for (const error of errors) {
         assertEquals(error.category, "BUILD");
       }
@@ -495,14 +495,21 @@ describe("error-registry", () => {
       assertEquals(empty, [], `Categories with no registered errors: ${empty.join(", ")}`);
     });
 
-    it("partitions the registry across categories", () => {
-      // Catches an error that is registered but unreachable by category, which
-      // a per-category count cannot see once the expected number is also wrong.
-      const categorized = ERROR_CATEGORIES.reduce(
-        (total, category) => total + getErrorsByCategory(category).length,
-        0,
-      );
-      assertEquals(categorized, getAllSlugs().length);
+    it("routes every registered error to exactly one category", () => {
+      // Cardinality alone would miss two lookups swapping contents, so check
+      // which slugs come back and that each declares the category it came from.
+      const routed: string[] = [];
+      const misrouted: string[] = [];
+      for (const category of ERROR_CATEGORIES) {
+        for (const error of getErrorsByCategory(category)) {
+          routed.push(error.slug);
+          if (error.category !== category) {
+            misrouted.push(`${error.slug} returned for ${category} but declares ${error.category}`);
+          }
+        }
+      }
+      assertEquals(misrouted, [], `Misrouted errors: ${misrouted.join("; ")}`);
+      assertEquals(routed.sort(), [...getAllSlugs()].sort());
     });
   });
 

--- a/src/errors/error-registry.test.ts
+++ b/src/errors/error-registry.test.ts
@@ -168,7 +168,7 @@ const PUBLISHED_ERROR_SLUGS: readonly string[] = Object.freeze([
  * alone. Adding a category is a deliberate, rare change and belongs here;
  * adding an error does not.
  */
-const ERROR_CATEGORIES: readonly ErrorCategory[] = Object.freeze([
+const ERROR_CATEGORIES = [
   "CONFIG",
   "BUILD",
   "RUNTIME",
@@ -180,7 +180,24 @@ const ERROR_CATEGORIES: readonly ErrorCategory[] = Object.freeze([
   "DEPLOY",
   "AGENT",
   "GENERAL",
-]);
+] as const satisfies readonly ErrorCategory[];
+
+/**
+ * Fails to compile when `ErrorCategory` gains a member this list omits.
+ *
+ * `as const` above is what makes this work: typed as `readonly ErrorCategory[]`
+ * the element type would widen back to the whole union and the check would
+ * always be `never`, so a missing category would go unasserted. The constraint
+ * has to be `extends never` too -- assigning to an array of the leftover union
+ * compiles fine for an empty array, which makes that form vacuous.
+ */
+/** Widened for membership checks; the tuple above stays narrow for the type assertion. */
+const KNOWN_ERROR_CATEGORIES: ReadonlySet<string> = new Set(ERROR_CATEGORIES);
+
+type AssertNever<T extends never> = T;
+type _EveryErrorCategoryListed = AssertNever<
+  Exclude<ErrorCategory, typeof ERROR_CATEGORIES[number]>
+>;
 
 describe("error-registry", () => {
   describe("slug uniqueness", () => {
@@ -195,7 +212,7 @@ describe("error-registry", () => {
       // after the list was written, so a later removal would go unnoticed.
       assertEquals(
         [...getAllSlugs()].sort(),
-        [...PUBLISHED_ERROR_SLUGS],
+        [...PUBLISHED_ERROR_SLUGS].sort(),
         "Update PUBLISHED_ERROR_SLUGS: add a line for a new error, delete one only when retiring it",
       );
     });
@@ -261,7 +278,7 @@ describe("error-registry", () => {
       const errors = Object.values(ERROR_REGISTRY);
       for (const error of errors) {
         assertEquals(
-          ERROR_CATEGORIES.includes(error.category),
+          KNOWN_ERROR_CATEGORIES.has(error.category),
           true,
           `Error "${error.slug}" has invalid category "${error.category}"`,
         );

--- a/src/errors/error-registry.test.ts
+++ b/src/errors/error-registry.test.ts
@@ -21,6 +21,167 @@ import {
 } from "./error-registry.ts";
 import type { ErrorCategory } from "./types.ts";
 
+/**
+ * Every error slug published as of this list being written.
+ *
+ * Slugs are part of the public surface: callers match on them, so removing one
+ * is a breaking change while adding one is routine. This guards the breaking
+ * direction only, which is also why it is a list rather than a count. An exact
+ * count made every error-adding pull request edit the same line, so two of them
+ * were each green alone and the second died in the merge queue -- that happened
+ * at 120, 121 and again at 122. Adding a slug now touches nothing here.
+ *
+ * Removing a slug is meant to fail. Delete the entry deliberately, in the same
+ * change that retires the error.
+ */
+const PUBLISHED_ERROR_SLUGS: readonly string[] = Object.freeze([
+  "agent-error",
+  "agent-intent-error",
+  "agent-not-found",
+  "agent-timeout",
+  "already-exists",
+  "api-client-error",
+  "api-error",
+  "api-route-error",
+  "asset-optimization-error",
+  "authentication-required",
+  "branch-not-found",
+  "build-failed",
+  "bundle-error",
+  "cache-error",
+  "cache-invariant-violation",
+  "cache-path-mismatch",
+  "circuit-breaker-open",
+  "circular-dependency",
+  "client-boundary-violation",
+  "client-only-in-server",
+  "compilation-error",
+  "component-error",
+  "config-invalid",
+  "config-not-deployable",
+  "config-not-found",
+  "config-parse-error",
+  "config-type-error",
+  "config-validation-error",
+  "config-validation-failed",
+  "cors-config-invalid",
+  "cost-limit-exceeded",
+  "default-model-credential-mismatch",
+  "dependency-missing",
+  "deployment-error",
+  "deployment-verification-timeout",
+  "dev-server-error",
+  "durable-run-event-persistence-failed",
+  "dynamic-route-error",
+  "env-var-missing",
+  "environment-not-found",
+  "environment-not-routable",
+  "error-overlay-error",
+  "fallback-exhausted",
+  "fast-refresh-error",
+  "file-not-found",
+  "file-watch-error",
+  "hmr-error",
+  "hydration-mismatch",
+  "import-map-invalid",
+  "import-resolution-error",
+  "initialization-error",
+  "input-validation-failed",
+  "invalid-argument",
+  "invalid-import",
+  "invalid-route-file",
+  "invalid-use-client",
+  "invalid-use-server",
+  "layout-not-found",
+  "local-integration-config-invalid",
+  "local-integration-credential-unavailable",
+  "local-integration-credentials-missing",
+  "local-integration-request-failed",
+  "local-integration-request-invalid",
+  "local-integration-response-invalid",
+  "lockfile-format-mismatch",
+  "lockfile-read-error",
+  "markdown-compile-error",
+  "mdx-compile-error",
+  "middleware-error",
+  "module-not-found",
+  "nested-cwd-scope",
+  "network-error",
+  "not-supported",
+  "orchestration-error",
+  "page-not-found",
+  "permission-denied",
+  "platform-error",
+  "port-in-use",
+  "preview-hostname-too-long",
+  "production-build-required",
+  "project-execution-unavailable",
+  "project-source-empty",
+  "push-conflict",
+  "push-receipt-missing",
+  "rag-store-corrupt",
+  "rag-store-unavailable",
+  "redirect-destination-not-allowed",
+  "release-build-timeout",
+  "release-missing-version",
+  "release-not-found",
+  "render-error",
+  "request-error",
+  "resource-not-found",
+  "route-conflict",
+  "route-handler-invalid",
+  "route-params-error",
+  "rsc-payload-error",
+  "schedule-config-invalid",
+  "security-violation",
+  "semaphore-timeout",
+  "server-only-in-client",
+  "server-start-error",
+  "service-overloaded",
+  "source-digest-mismatch",
+  "source-map-error",
+  "source-snapshot-freshness-unavailable",
+  "sourcemap-error",
+  "ssg-generation-error",
+  "ssr-output-limit-exceeded",
+  "sync-state-invalid",
+  "template-not-found",
+  "timeout-error",
+  "token-storage-error",
+  "tool-id-conflict",
+  "trigger-config-invalid",
+  "trigger-execution-failed",
+  "trigger-not-supported",
+  "trigger-target-not-found",
+  "typescript-error",
+  "unknown-error",
+  "version-mismatch",
+  "webhook-config-invalid",
+]);
+
+/**
+ * Every category an error may declare.
+ *
+ * Category names are pinned here; per-category totals are not. Those totals
+ * used to be, which put every error-adding pull request on the same line and
+ * made two of them collide in the merge queue even though each was green
+ * alone. Adding a category is a deliberate, rare change and belongs here;
+ * adding an error does not.
+ */
+const ERROR_CATEGORIES: readonly ErrorCategory[] = Object.freeze([
+  "CONFIG",
+  "BUILD",
+  "RUNTIME",
+  "ROUTE",
+  "MODULE",
+  "SERVER",
+  "BOUNDARY",
+  "DEV",
+  "DEPLOY",
+  "AGENT",
+  "GENERAL",
+]);
+
 describe("error-registry", () => {
   describe("slug uniqueness", () => {
     it("should have unique slugs across all errors", () => {
@@ -29,9 +190,14 @@ describe("error-registry", () => {
       assertEquals(slugs.length, uniqueSlugs.size, "Duplicate slugs detected");
     });
 
-    it("should have 122 registered errors", () => {
-      const slugs = getAllSlugs();
-      assertEquals(slugs.length, 122);
+    it("keeps every published error slug registered", () => {
+      const slugs = new Set<string>(getAllSlugs());
+      const missing = PUBLISHED_ERROR_SLUGS.filter((slug) => !slugs.has(slug));
+      assertEquals(
+        missing,
+        [],
+        `Published error slug(s) no longer registered: ${missing.join(", ")}`,
+      );
     });
 
     it("registers every local integration boundary error", () => {
@@ -91,25 +257,11 @@ describe("error-registry", () => {
   });
 
   describe("error definitions", () => {
-    const validCategories: ErrorCategory[] = [
-      "CONFIG",
-      "BUILD",
-      "RUNTIME",
-      "ROUTE",
-      "MODULE",
-      "SERVER",
-      "BOUNDARY",
-      "DEV",
-      "DEPLOY",
-      "AGENT",
-      "GENERAL",
-    ];
-
     it("should have valid category for all errors", () => {
       const errors = Object.values(ERROR_REGISTRY);
       for (const error of errors) {
         assertEquals(
-          validCategories.includes(error.category),
+          ERROR_CATEGORIES.includes(error.category),
           true,
           `Error "${error.slug}" has invalid category "${error.category}"`,
         );
@@ -336,34 +488,22 @@ describe("error-registry", () => {
   });
 
   describe("error categories coverage", () => {
-    const expectedCategoryCounts: Record<string, number> = {
-      CONFIG: 14,
-      BUILD: 9,
-      RUNTIME: 14,
-      ROUTE: 6,
-      MODULE: 8,
-      SERVER: 19,
-      BOUNDARY: 8,
-      DEV: 5,
-      DEPLOY: 16,
-      AGENT: 9,
-      GENERAL: 14,
-    };
+    it("keeps every category populated", () => {
+      const empty = ERROR_CATEGORIES.filter(
+        (category) => getErrorsByCategory(category).length === 0,
+      );
+      assertEquals(empty, [], `Categories with no registered errors: ${empty.join(", ")}`);
+    });
 
-    for (
-      const [category, count] of Object.entries(
-        expectedCategoryCounts,
-      ) as Array<[ErrorCategory, number]>
-    ) {
-      it(`should have ${count} errors in ${category} category`, () => {
-        const errors = getErrorsByCategory(category);
-        assertEquals(
-          errors.length,
-          count,
-          `Expected ${count} ${category} errors, got ${errors.length}`,
-        );
-      });
-    }
+    it("partitions the registry across categories", () => {
+      // Catches an error that is registered but unreachable by category, which
+      // a per-category count cannot see once the expected number is also wrong.
+      const categorized = ERROR_CATEGORIES.reduce(
+        (total, category) => total + getErrorsByCategory(category).length,
+        0,
+      );
+      assertEquals(categorized, getAllSlugs().length);
+    });
   });
 
   // =========================================================================


### PR DESCRIPTION
## Why

`src/errors/error-registry.test.ts` pinned **fourteen exact totals** — one registry-wide count, eleven per-category counts, and two more inside the `getErrorsByCategory` tests. Every PR that registers an error had to edit them, so two such PRs were each green alone and the second died in the merge queue.

The registry-wide number churned across four changes:

```
113  →  119  →  120  →  121  →  122
     #3843   #3874   #4001   #4010
```

veryfront-issue-inbox#769 records this test rejecting a change **twice at 122**, and names the shape: *"green alone, fatal in the merge queue. Neither author did anything wrong."*

## The specific failure a count produces

This is the part worth being precise about, because it is not an ordinary merge conflict. Two branches each bumping the shared count to the same value:

```
merge exit 0, no conflict  →  count says 123, registry has 124
```

Git merges two identical edits silently. The branch is green, the merge is clean, and the wrong number only surfaces later in the queue. Two branches each **appending a slug** instead:

```
merge exit 0, both slugs present
```

Both verified by merging simulated branches, not assumed.

## What replaces the counts

| Assertion | Guards |
|---|---|
| Exhaustive list of published slugs | Any slug removed, including ones added after this PR |
| Every category is populated | A category losing all its errors |
| Every error routed to exactly one category | A lookup returning entries that declare a different category |

Slugs are public surface — callers match on them — so retiring one should be deliberate and visible in review.

**Adding an error still appends one sorted line to the slug list.** That is a deliberate trade: an earlier draft used a subset check so additions touched nothing, but a subset only ever protects the slugs present when it is written, so later additions silently stop being covered. Exhaustive is the correct guard, and an append does not carry the shared-line failure above.

## Every assertion was checked against a deliberate break

A guard that cannot fail is worse than none:

```
retire a published slug              → FAILS, names the slug
empty a category                     → FAILS, names the category
swap the AGENT and GENERAL lookups   → FAILS "routes every registered error to
                                       exactly one category"
break getErrorsByCategory            → FAILS the same assertion
add a CONFIG error                   → "should return CONFIG errors" stays green;
                                       only the slug list asks for the new line
```

**One assertion was written and then deleted.** It asserted every registered error has a known category — but `error-registry-helpers.ts` already throws `TypeError: Registered error has unknown category` first, so it could never fail. Only the control revealed that; it would otherwise have shipped vacuous.

## Review

Codex raised three findings and all three were correct — two exact counts I had missed, the decaying subset guard, and the cardinality-only partition check. All are fixed in `ff923a99f7` and answered inline.

## Verification

| Gate | Result |
|---|---|
| Suite | ✅ 2 passed, **60 steps**, 0 failed |
| `deno fmt --check` / `lint` / `check` | ✅ exit 0 |
| `lint:test-semantic-dispositions` | ✅ exit 0 (no new effects, backlog untouched) |
| `lint:anti-slop`, `ban-test-only`, `skipped-tests`, `testing-front-door` | ✅ exit 0 |

## Scope

One test file. No production code changes.

This is the last unfixed instance of the class #769 describes. The issue's own subject — the semantic audit's two arms reading different trees — was already fixed by #4156, which normalizes the baseline ref through `git merge-base`. #4156 merged with an empty body and never linked #769, which is why the issue is still open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded validation of published error categories and identifiers.
  * Added checks to ensure error entries route to the correct categories.
  * Updated tests to verify categories and results remain populated without relying on fixed counts.
  * Added consistency checks using the shared category definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->