### PR TITLE
fix(security): let an operator grant host execution to a shared runtime

### DIFF
--- a/src/security/README.md
+++ b/src/security/README.md
@@ -419,8 +419,8 @@ A runtime that cannot honour a configured isolation flag never fakes it. A
 compiled binary cannot prepare isolated API route source
 (`security/sandbox/isolation-capability.ts`), so `WORKER_ISOLATION_API=1` in a
 compiled deployment keeps the requested isolation posture and API ownership
-returns the typed `project-execution-unavailable` 503 naming it. The deprecated
-`VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION` setting does not override the
+returns the typed `project-execution-unavailable` 503 naming it. The
+`VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION` grant does not override the
 API-specific isolation flag.
 
 OpenAPI metadata is currently attached to handler functions. Because reading
@@ -438,10 +438,20 @@ evaluating tenant modules.
 ## Shared execution grant
 
 `VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION` grants host execution to a shared
-runtime. Without it a shared runtime rejects same-process tenant execution and
-routes to a dedicated isolated project runtime. A dedicated single-project
-runtime already has the capability, so there the setting changes no supported
-topology and is reported as ignored.
+runtime. Without it a shared runtime rejects same-process tenant execution:
+preview rendering and tenant `/api/*` return the typed
+`project-execution-unavailable` 503 response until routing to a genuinely
+external or dedicated isolated project runtime exists. A dedicated
+single-project runtime already has the capability, so there the setting changes
+no supported topology and is reported as ignored.
+
+Only the affirmative values `1`, `true`, `yes`, and `on` (trimmed,
+case-insensitive) enable the grant; every other value is treated as
+unconfigured and fails closed. The grant does not override requested worker
+isolation: with `WORKER_ISOLATION_API=1`, API execution keeps the isolation
+posture — in a compiled deployment, which cannot prepare isolated API route
+source, API ownership still returns the documented
+`project-execution-unavailable` 503 despite the grant.
 
 **Granting it is a deliberate reduction in isolation.** Tenant code then runs in
 the shared process, where per-request separation is source scoping and not a
@@ -467,7 +477,9 @@ is no host-rendering or remote-import fallback. The current HTTP renderer does
 not yet produce a generation-owned isolated page and layout graph, so remote
 SSR and server-executing RSC endpoints return `503 Service Unavailable` before
 resolving a renderer. API and data workers do not resolve or receive the
-renderer contract.
+renderer contract. On a shared runtime, requested SSR isolation also outranks
+the shared execution grant: the SSR handler fails closed with the typed 503
+rather than silently downgrading an isolation request into host rendering.
 
 Deno Workers share the host process. Worker retirement is lifecycle hygiene,
 not a hard per-worker memory or CPU boundary. They are therefore limited to

--- a/src/security/README.md
+++ b/src/security/README.md
@@ -397,10 +397,10 @@ it would tell an anonymous caller which realm tenant code runs in.
 
 A dedicated single-project runtime may execute
 prepared API source in its local worker pool. A shared multi-project/proxy
-runtime never executes tenant API source in the host process or a same-process
-Worker: API ownership returns the typed
-`project-execution-unavailable` 503 response until the request is routed to a
-genuinely external or dedicated isolated project runtime. Raw-path server-data
+runtime does so only where an operator has granted host execution at the
+host-owned entrypoint (see below); without that grant, API ownership returns
+the typed `project-execution-unavailable` 503 response until the request is
+routed to a genuinely external or dedicated isolated project runtime. Raw-path server-data
 modules are local-only; remote data and renderer-backed module endpoints return
 503 before resolving project modules. Shared-runtime CORS preflights never
 import route modules to discover methods, and component-snippet requests fail
@@ -435,21 +435,30 @@ dedicated single-project runtimes grant the capability at their host-owned
 entrypoints. Shared proxy runtimes reject these operations before reading or
 evaluating tenant modules.
 
-## Deprecated shared execution override
+## Shared execution grant
 
-`VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION` no longer grants host execution. A
-shared runtime always rejects same-process tenant execution and routes it to a
-dedicated isolated project runtime. A dedicated single-project runtime already
-has the required capability, so the setting changes no supported topology.
+`VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION` grants host execution to a shared
+runtime. Without it a shared runtime rejects same-process tenant execution and
+routes to a dedicated isolated project runtime. A dedicated single-project
+runtime already has the capability, so there the setting changes no supported
+topology and is reported as ignored.
 
-Veryfront still reads an affirmative value at server startup so it can report
-stale deployment configuration. The startup warning states that the setting is
-ignored and explains whether the runtime is shared or already dedicated. The
-read uses `getHostEnv`, so a project environment variable cannot manufacture
-the operator diagnostic.
+**Granting it is a deliberate reduction in isolation.** Tenant code then runs in
+the shared process, where per-request separation is source scoping and not a
+tenant boundary, and ambient runtime channels can expose host state outside the
+scoped environment facade. Do not set it on a runtime that serves tenants which
+must not observe one another.
 
-Remove the deprecated setting. Shared multi-project execution must use a
-separately limited external process or container.
+It exists because this platform's own shared rendering and executor runtime has
+no dedicated isolated runtime to route to: without the grant, preview rendering
+and tenant `/api/*` return 503 and agent chat fails
+(veryfront-issue-inbox#848, #356). The grant is retired by routing hosted
+project execution to a dedicated runtime, not by dropping it while that routing
+does not exist.
+
+Startup warns in both directions: that the grant is active on a shared runtime,
+or that it is present but ignored on a dedicated one. The read uses
+`getHostEnv`, so a project environment variable cannot manufacture the grant.
 
 `WORKER_ISOLATION_SSR=1` additionally requires explicit registration of an
 `IsolatedSsrRendererProvider`. The provider supplies a local, offline renderer

--- a/src/security/host-execution-policy.test.ts
+++ b/src/security/host-execution-policy.test.ts
@@ -10,11 +10,33 @@ import {
 } from "./host-execution-policy.ts";
 
 describe("security/host-execution-policy operator override", () => {
-  it("treats the deprecated override as ignored in every runtime topology", () => {
+  it("lets an operator grant host execution to a shared runtime", () => {
+    // The platform's own rendering and executor runtime is shared, and no dedicated
+    // isolated runtime is provisioned for hosted project previews or agents. Without
+    // an honoured grant, tenant /api/* returns 503 PROJECT_EXECUTION_UNAVAILABLE and
+    // the Studio preview pane fails to load (veryfront-issue-inbox#848, #356).
+    //
+    // This re-accepts a known posture: tenant code runs in the shared process, where
+    // per-request separation is source scoping rather than a tenant boundary. It is
+    // the posture production already runs. Withdrawing it belongs with routing
+    // execution to a dedicated runtime, not ahead of it.
     assertEquals(
       resolveHostProjectExecutionPosture({ sharedRuntime: true, overrideConfigured: true }),
-      { allowHostProjectCodeExecution: false, overrideIgnored: true },
+      { allowHostProjectCodeExecution: true, overrideIgnored: false },
     );
+  });
+
+  it("keeps a shared runtime fail-closed when no grant is configured", () => {
+    assertEquals(
+      resolveHostProjectExecutionPosture({ sharedRuntime: true, overrideConfigured: false }),
+      { allowHostProjectCodeExecution: false, overrideIgnored: false },
+    );
+  });
+
+  it("reports the grant as ignored where it changes nothing", () => {
+    // A dedicated runtime already carries the capability, so the grant is redundant
+    // there. Reporting it lets startup surface stale operator configuration without
+    // implying it did any work.
     assertEquals(
       resolveHostProjectExecutionPosture({ sharedRuntime: false, overrideConfigured: true }),
       { allowHostProjectCodeExecution: true, overrideIgnored: true },

--- a/src/security/host-execution-policy.ts
+++ b/src/security/host-execution-policy.ts
@@ -1,14 +1,18 @@
 /**
- * Deprecated operator-owned host execution override.
+ * Operator-owned host execution grant.
  *
- * A shared multi-project runtime denies tenant code execution by default, and
- * routes the request to a dedicated isolated project runtime instead. Dedicated
- * single-project runtimes already carry the host execution capability. The
- * former override therefore grants no additional topology and is retained only
- * so startup can identify and report stale operator configuration.
+ * A shared multi-project runtime denies tenant code execution by default and
+ * fails closed with the typed `project-execution-unavailable` 503 response. An
+ * operator can grant host execution to a shared runtime with
+ * `VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION`; granting it is a deliberate
+ * reduction in isolation, because tenant code then runs in the shared process
+ * where per-request separation is source scoping and not a tenant boundary
+ * (see security/README.md, "Shared execution grant"). Dedicated single-project
+ * runtimes already carry the capability, so there the setting changes nothing
+ * and is reported as ignored so startup can surface stale configuration.
  *
  * `getHostEnv` bypasses the project env overlay, so a project variable of the
- * same name cannot manufacture the diagnostic.
+ * same name cannot manufacture the grant.
  */
 
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
@@ -16,8 +20,9 @@ import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 export const HOST_PROJECT_EXECUTION_OVERRIDE_ENV = "VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION";
 
 /**
- * Detect the deprecated operator override. Absent and unrecognized values are
- * treated as unconfigured.
+ * Detect the operator grant. Only `1`, `true`, `yes`, and `on` (after trimming
+ * and case folding) configure it; absent and unrecognized values are treated
+ * as unconfigured and fail closed.
  */
 export function isHostProjectExecutionOverrideConfigured(
   value: string | undefined = getHostEnv(HOST_PROJECT_EXECUTION_OVERRIDE_ENV),

--- a/src/security/host-execution-policy.ts
+++ b/src/security/host-execution-policy.ts
@@ -34,7 +34,7 @@ export function isHostProjectExecutionOverrideConfigured(
   }
 }
 
-/** @deprecated The override no longer enables host execution. */
+/** @deprecated Prefer isHostProjectExecutionOverrideConfigured. */
 export const isHostProjectExecutionOverrideEnabled = isHostProjectExecutionOverrideConfigured;
 
 /** Resolve the only two supported production execution topologies. */
@@ -43,7 +43,11 @@ export function resolveHostProjectExecutionPosture(options: {
   overrideConfigured: boolean;
 }): { allowHostProjectCodeExecution: boolean; overrideIgnored: boolean } {
   return {
-    allowHostProjectCodeExecution: !options.sharedRuntime,
-    overrideIgnored: options.overrideConfigured,
+    // A dedicated runtime always carries the capability. A shared runtime carries it
+    // only where an operator has granted it at the host-owned entrypoint.
+    allowHostProjectCodeExecution: !options.sharedRuntime || options.overrideConfigured,
+    // Configured but redundant: a dedicated runtime already had the capability, so the
+    // grant did no work and startup can report it as stale operator configuration.
+    overrideIgnored: options.overrideConfigured && !options.sharedRuntime,
   };
 }

--- a/src/security/project-locality.test.ts
+++ b/src/security/project-locality.test.ts
@@ -145,8 +145,8 @@ describe("security/project-locality isolated runtime requirement", () => {
         ...sharedRuntime,
         allowHostProjectCodeExecution: true,
       }),
-      false,
-      "the topology-aware boundary must still deny shared Bun execution",
+      true,
+      "an explicit operator grant reaches shared Bun execution too",
     );
   });
 

--- a/src/security/project-locality.test.ts
+++ b/src/security/project-locality.test.ts
@@ -101,11 +101,18 @@ describe("security/project-locality isolated runtime requirement", () => {
     );
   });
 
-  it("denies shared host execution even when the entrypoint grants the capability", () => {
+  it("honours an operator grant of host execution on a shared runtime", () => {
+    // The platform's shared rendering and executor runtime has no dedicated isolated
+    // runtime to route to, so denying the grant here returns 503
+    // PROJECT_EXECUTION_UNAVAILABLE on preview and tenant /api/*
+    // (veryfront-issue-inbox#848). Granting re-accepts the posture production already
+    // runs: tenant code executes in the shared process, where per-request separation
+    // is source scoping and not a tenant boundary. Retiring it belongs with routing
+    // execution to a dedicated runtime (#356).
     assertEquals(
       requiresIsolatedProjectRuntime({ ...sharedRuntime, allowHostProjectCodeExecution: true }),
-      true,
-      "ambient runtime channels keep shared host execution unsafe",
+      false,
+      "an explicit operator grant must reach the execution surfaces",
     );
   });
 
@@ -165,9 +172,11 @@ describe("security/project-locality isolated runtime requirement", () => {
   });
 
   it("uses one topology snapshot for the host-execution decision", () => {
+    // No grant, so the decision turns on topology alone -- which is what this
+    // invariant guards. The provider disagrees with itself after the first call, so a
+    // second read would flip the answer to "not shared" and wrongly skip isolation.
     let calls = 0;
     const runtime = {
-      allowHostProjectCodeExecution: true,
       adapter: {
         fs: {
           isMultiProjectMode: () => calls++ === 0,

--- a/src/security/project-locality.ts
+++ b/src/security/project-locality.ts
@@ -100,20 +100,25 @@ export function isExplicitlyLocalProject(value: unknown): boolean {
  * An explicitly local development project retains the historical capability.
  * A standalone production runtime can grant the narrower capability without
  * enabling development-only rendering, caching, diagnostics, or HTTP policy.
- * A shared runtime cannot grant it because ambient runtime channels can expose
- * host state outside the scoped environment facade. Every ambiguous value
- * fails closed.
+ * A shared runtime honours an explicit operator grant from its host-owned
+ * entrypoint; ambient runtime channels can then expose host state outside the
+ * scoped environment facade, which is the accepted cost of this deployment.
+ * Without a grant a shared runtime still fails closed, as does every ambiguous
+ * value.
  */
 export function isHostProjectCodeExecutionAllowed(value: unknown): boolean {
-  return isHostProjectCodeExecutionAllowedForTopology(value, isSharedProjectRuntime(value));
+  return isHostProjectCodeExecutionAllowedForTopology(value);
 }
 
-function isHostProjectCodeExecutionAllowedForTopology(
-  value: unknown,
-  sharedRuntime: boolean,
-): boolean {
-  return isExplicitlyLocalProject(value) ||
-    (!sharedRuntime && isExplicitHostProjectCodeExecutionAllowed(value));
+function isHostProjectCodeExecutionAllowedForTopology(value: unknown): boolean {
+  // The grant is topology-independent: a shared runtime honours it too. Denying it here
+  // discarded the capability the host-owned entrypoint had already granted, so preview
+  // and tenant /api/* returned 503 with no isolated runtime to route to
+  // (veryfront-issue-inbox#848). Ambient runtime channels can still expose host state
+  // outside the scoped environment facade -- that is the accepted cost of running this
+  // platform's shared executor, and it is retired by routing execution to a dedicated
+  // runtime (#356), not by dropping the capability here.
+  return isExplicitlyLocalProject(value) || isExplicitHostProjectCodeExecutionAllowed(value);
 }
 
 /**
@@ -138,8 +143,10 @@ export function isExplicitHostProjectCodeExecutionAllowed(
  * cannot drift apart.
  */
 export function requiresIsolatedProjectRuntime(value: unknown): boolean {
+  // Sample the topology once: a re-read can disagree with itself, and the first
+  // observation must stay authoritative for the whole decision.
   const sharedRuntime = isSharedProjectRuntime(value);
-  return !isHostProjectCodeExecutionAllowedForTopology(value, sharedRuntime) && sharedRuntime;
+  return !isHostProjectCodeExecutionAllowedForTopology(value) && sharedRuntime;
 }
 
 /**

--- a/src/security/sandbox/worker-pool.ts
+++ b/src/security/sandbox/worker-pool.ts
@@ -1272,9 +1272,16 @@ export interface IsolationPosture {
    * `api.effective` true, API routes fail closed rather than execute.
    */
   apiPreparationSupported: boolean;
-  /** @deprecated Always false. The former override no longer grants execution. */
+  /**
+   * Always false here: this posture reports the sandbox worker isolation surfaces and
+   * does not resolve the host-execution grant, which is decided per request from
+   * host-owned context in security/project-locality.ts. A shared runtime CAN execute
+   * tenant code when an operator grants it (veryfront-issue-inbox#848), so do not read
+   * this field as evidence that it does not. `hostExecutionOverrideConfigured` below
+   * reports whether the grant is present.
+   */
   hostExecutionGranted: false;
-  /** Whether the deprecated VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION setting is present. */
+  /** Whether the VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION grant is present. */
   hostExecutionOverrideConfigured: boolean;
   /** True when at least one surface actually resolved to isolated execution. */
   inForce: boolean;

--- a/src/security/sandbox/worker-pool.ts
+++ b/src/security/sandbox/worker-pool.ts
@@ -1256,8 +1256,8 @@ export interface IsolationSurfacePosture {
  * The resolved isolation configuration, as an operator would need to read it.
  *
  * `requested` and `effective` are separate fields so posture remains explicit
- * if a runtime capability changes. The deprecated host-execution override never
- * makes requested API isolation ineffective: unsupported runtimes keep the gate
+ * if a runtime capability changes. The host-execution grant never makes
+ * requested API isolation ineffective: unsupported runtimes keep the gate
  * enabled and fail closed. `inForce` answers whether any surface is isolated.
  */
 export interface IsolationPosture {
@@ -1291,7 +1291,8 @@ export interface IsolationPosture {
  * Resolve the host-owned isolation flags once per process.
  *
  * A build that cannot honour `WORKER_ISOLATION_API` must fail closed. The
- * deprecated host-execution override does not alter an API-specific posture.
+ * host-execution grant does not alter an API-specific posture: requested
+ * worker isolation takes precedence over host-realm execution.
  */
 function resolveFlags(): void {
   if (_flagsResolved) return;

--- a/src/server/handlers/execution-surface-policy.test.ts
+++ b/src/server/handlers/execution-surface-policy.test.ts
@@ -47,6 +47,8 @@ const CAPABILITY_GATED_SURFACES = [
 const NON_GATE_USES: Record<string, string> = {
   "response/cors.ts":
     "Chooses which CORS methods to advertise. Degrades to defaults on a shared runtime rather than denying, so the capability does not apply.",
+  "request/ssr/ssr.handler.ts":
+    "Fails closed when the operator explicitly requested SSR isolation: that request outranks the host-execution capability, so the gate checks topology directly instead of requiresIsolatedProjectRuntime(), which would honor the grant and downgrade the render into the host realm.",
 };
 
 async function readHandlerSources(): Promise<Map<string, string>> {

--- a/src/server/handlers/preview/markdown-preview.handler.test.ts
+++ b/src/server/handlers/preview/markdown-preview.handler.test.ts
@@ -102,7 +102,10 @@ it("MarkdownPreviewHandler fails closed before shared source reads", async () =>
 });
 
 describe("MarkdownPreviewHandler host-execution capability", () => {
-  it("keeps shared preview execution denied despite a host grant", async () => {
+  it("honours a host grant for shared preview execution", async () => {
+    // An explicit operator grant from the host-owned entrypoint reaches this
+    // surface (veryfront-issue-inbox#848): the markdown source is read and the
+    // preview renders instead of failing closed with the ungranted 503 above.
     let reads = 0;
     const ctx = {
       projectDir: "/remote/project",
@@ -144,8 +147,12 @@ describe("MarkdownPreviewHandler host-execution capability", () => {
       ctx,
     );
 
-    assertEquals(result.response?.status, 503);
-    assertEquals(reads, 0);
+    assertEquals(result.response?.status, 200);
+    assertEquals(
+      reads > 0,
+      true,
+      "the grant must reach the markdown source read",
+    );
   });
 });
 

--- a/src/server/handlers/request/api/api-handler-wrapper.test.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.test.ts
@@ -664,7 +664,12 @@ describe("ApiHandlerWrapper", () => {
     );
   });
 
-  it("keeps shared-runtime API discovery denied despite a host grant", async () => {
+  it("honours a host grant for shared-runtime API execution", async () => {
+    // An explicit operator grant from the host-owned entrypoint reaches this
+    // surface (veryfront-issue-inbox#848): the request enters the project
+    // context, discovery reads project source, and the route resolves against
+    // it (404 here, since the fixture has no routes) instead of failing closed
+    // with the 503 the ungranted shared runtime returns above.
     let projectContextEntries = 0;
     let filesystemReads = 0;
     const ctx = createCtx({});
@@ -697,9 +702,13 @@ describe("ApiHandlerWrapper", () => {
       ctx,
     );
 
-    assertEquals(result.response?.status, 503);
+    assertEquals(result.response?.status, 404);
     assertEquals(projectContextEntries, 1);
-    assertEquals(filesystemReads, 0);
+    assertEquals(
+      filesystemReads > 0,
+      true,
+      "the grant must reach project source discovery",
+    );
   });
 
   it("rejects a shared contextual adapter before mutating or reading it", async () => {

--- a/src/server/handlers/request/api/app-router-handler.test.ts
+++ b/src/server/handlers/request/api/app-router-handler.test.ts
@@ -33,7 +33,11 @@ describe("server API app-router compatibility handler", () => {
     assertEquals(filesystemCalls, 0);
   });
 
-  it("keeps shared route discovery denied despite a host grant", async () => {
+  it("honours a host grant for shared route discovery", async () => {
+    // An explicit operator grant from the host-owned entrypoint reaches this
+    // surface (veryfront-issue-inbox#848): route discovery runs against project
+    // source instead of failing closed with the ungranted 503 above. No route
+    // exists in the fixture, so the handler yields to the next one.
     let filesystemCalls = 0;
     const ctx = {
       projectDir: "/remote/project",
@@ -56,7 +60,11 @@ describe("server API app-router compatibility handler", () => {
       ctx,
     );
 
-    assertEquals(response?.status, 503);
-    assertEquals(filesystemCalls, 0);
+    assertEquals(response, null);
+    assertEquals(
+      filesystemCalls > 0,
+      true,
+      "the grant must reach route discovery",
+    );
   });
 });

--- a/src/server/handlers/request/api/project-discovery.test.ts
+++ b/src/server/handlers/request/api/project-discovery.test.ts
@@ -151,7 +151,13 @@ describe(
       assertEquals((globalThis as Record<string, unknown>)[marker], undefined);
     });
 
-    it("keeps shared primitive discovery denied despite a host grant", async () => {
+    it("honours a host grant for shared primitive discovery", async () => {
+      // An explicit operator grant from the host-owned entrypoint reaches this
+      // surface (veryfront-issue-inbox#848): discovery reads project source and
+      // registers its primitives instead of failing closed like the ungranted
+      // shared runtime above.
+      agentRegistry.clearAll();
+      toolRegistryInternal.clearAll();
       const ctx = createHandlerContext("/granted-project", "granted", "preview");
       ctx.isLocalProject = false;
       // Present marks a shared multi-project runtime, as veryfront-server is.
@@ -181,12 +187,19 @@ describe(
         return readFile(path);
       };
 
-      await assertRejects(
-        () => ensureProjectDiscovery(ctx),
-        Error,
-        "isolated project runtime",
+      const result = await ensureProjectDiscovery(ctx);
+
+      assertEquals(
+        reads > 0,
+        true,
+        "the grant must reach project source reads",
       );
-      assertEquals(reads, 0);
+      assertEquals(result.errors.length, 0, "granted discovery must complete cleanly");
+      assertEquals(
+        toolRegistry.has("granted_tool"),
+        true,
+        "granted discovery must register the project tool",
+      );
     });
 
     afterAll(async () => {

--- a/src/server/handlers/request/snippet.handler.test.ts
+++ b/src/server/handlers/request/snippet.handler.test.ts
@@ -114,9 +114,10 @@ Deno.test("SnippetHandler rejects shared rendering before proxy context or sourc
 });
 
 describe("SnippetHandler host-execution capability", () => {
-  it("keeps shared snippet execution denied despite a host grant", async () => {
-    // An entrypoint grant cannot override shared-runtime topology. Pin the
-    // source-read boundary so this does not regress to capability-only checks.
+  it("honours a host grant for shared snippet execution", async () => {
+    // An explicit operator grant from the host-owned entrypoint reaches this
+    // surface (veryfront-issue-inbox#848): the component source is read and the
+    // snippet renders instead of failing closed with the ungranted 503 above.
     let readPath: string | undefined;
     const fs = {
       symlinkSemantics: "none" as const,
@@ -155,8 +156,12 @@ describe("SnippetHandler host-execution capability", () => {
       ctx,
     );
 
-    assertEquals(result.response?.status, 503);
-    assertEquals(readPath, undefined);
+    assertEquals(result.response?.status, 200);
+    assertEquals(
+      readPath !== undefined,
+      true,
+      "the grant must reach the component source read",
+    );
   });
 
   it("passes the canonical enriched release identity to snippet rendering", async () => {

--- a/src/server/handlers/request/ssr/ssr.handler.test.ts
+++ b/src/server/handlers/request/ssr/ssr.handler.test.ts
@@ -8,7 +8,7 @@ import {
   assertStringIncludes,
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { SSRHandler } from "./ssr.handler.ts";
+import { __setSSRIsolationProbeForTests, SSRHandler } from "./ssr.handler.ts";
 import { __setComponentSourceLoaderForTests } from "./error-page-fallback.ts";
 import {
   __injectProjectReactForTests,
@@ -843,7 +843,10 @@ describe("server/handlers/request/ssr/ssr.handler", () => {
       assertEquals(renderCalls, 0);
     });
 
-    it("keeps shared rendering denied despite a host grant", async () => {
+    it("honours a host grant for shared rendering", async () => {
+      // An explicit operator grant from the host-owned entrypoint reaches this
+      // surface (veryfront-issue-inbox#848): the shared runtime renders instead
+      // of failing closed with the ungranted 503 above.
       let renderCalls = 0;
       const handler = new SSRHandler(createMockSSRService({
         renderPage: () => {
@@ -866,8 +869,78 @@ describe("server/handlers/request/ssr/ssr.handler", () => {
         } as Partial<HandlerContext>),
       );
 
-      assertEquals(result.response?.status, 503);
-      assertEquals(renderCalls, 0);
+      assertEquals(result.response?.status, 200);
+      assertEquals(renderCalls, 1, "the grant must reach the renderer");
+    });
+
+    it("preserves an explicit SSR isolation request over the shared execution grant", async () => {
+      // WORKER_ISOLATION_SSR asks renders to leave the host realm. The broad
+      // host-execution grant must not silently downgrade that request into
+      // host rendering; with no isolated renderer path wired to this surface,
+      // the request fails closed instead.
+      __setSSRIsolationProbeForTests(() => true);
+      try {
+        let renderCalls = 0;
+        const handler = new SSRHandler(createMockSSRService({
+          renderPage: () => {
+            renderCalls++;
+            return Promise.resolve({
+              status: 200,
+              html: "<html>must not host-render</html>",
+              isStreaming: false,
+              cacheStrategy: "short" as const,
+              slug: "private-page",
+            });
+          },
+        }));
+        const result = await handler.handle(
+          new Request("https://tenant.example/private-page"),
+          makeCtx({
+            isLocalProject: false,
+            allowHostProjectCodeExecution: true,
+            prepareHostedConfigContext: (() => {}) as HandlerContext["prepareHostedConfigContext"],
+          } as Partial<HandlerContext>),
+        );
+
+        assertEquals(result.response?.status, 503);
+        assertEquals(
+          (await result.response?.json() as { type?: string }).type,
+          "https://veryfront.com/docs/code/guides/errors#project-execution-unavailable",
+        );
+        assertEquals(
+          renderCalls,
+          0,
+          "requested SSR isolation must not downgrade to host rendering",
+        );
+      } finally {
+        __setSSRIsolationProbeForTests(undefined);
+      }
+    });
+
+    it("keeps dedicated-runtime rendering unaffected by the SSR isolation gate", async () => {
+      // The gate is scoped to shared runtimes, where the grant is what lets
+      // the request through; a dedicated runtime keeps its existing behaviour.
+      __setSSRIsolationProbeForTests(() => true);
+      try {
+        const handler = new SSRHandler(createMockSSRService({
+          renderPage: () =>
+            Promise.resolve({
+              status: 200,
+              html: "<html>dedicated</html>",
+              isStreaming: false,
+              cacheStrategy: "short" as const,
+              slug: "about",
+            }),
+        }));
+        const result = await handler.handle(
+          new Request("http://localhost/about"),
+          makeCtx(),
+        );
+
+        assertEquals(result.response?.status, 200);
+      } finally {
+        __setSSRIsolationProbeForTests(undefined);
+      }
     });
 
     it("returns response from renderPage result", async () => {

--- a/src/server/handlers/request/ssr/ssr.handler.ts
+++ b/src/server/handlers/request/ssr/ssr.handler.ts
@@ -51,7 +51,11 @@ import {
   PROJECT_EXECUTION_UNAVAILABLE,
   SOURCE_SNAPSHOT_FRESHNESS_UNAVAILABLE,
 } from "#veryfront/errors";
-import { requiresIsolatedProjectRuntime } from "#veryfront/security/project-locality.ts";
+import {
+  isSharedProjectRuntime,
+  requiresIsolatedProjectRuntime,
+} from "#veryfront/security/project-locality.ts";
+import { isSSRIsolationEnabled } from "#veryfront/security/sandbox/worker-pool.ts";
 import { appendDataResponseMetadata } from "#veryfront/data/response-metadata.ts";
 import {
   ensurePreviewDocumentSourceSnapshot,
@@ -62,6 +66,15 @@ import {
 import { ssrOwnsDocumentPathname } from "./document-ownership.ts";
 
 const logger = serverLogger.component("ssr");
+
+// The worker-pool probe resolves host-owned env flags once per process, which
+// tests cannot toggle portably across Deno, Node, and Bun. Test-only seam.
+let ssrIsolationRequested: () => boolean = isSSRIsolationEnabled;
+
+/** Test-only: replace the SSR isolation probe. Pass undefined to restore. */
+export function __setSSRIsolationProbeForTests(probe?: () => boolean): void {
+  ssrIsolationRequested = probe ?? isSSRIsolationEnabled;
+}
 const MAX_DOCUMENT_OWNERSHIP_RECLASSIFICATIONS = 3;
 
 /**
@@ -110,21 +123,31 @@ export class SSRHandler extends BaseHandler {
     }
 
     if (requiresIsolatedProjectRuntime(ctx)) {
-      const problem = createErrorResponseFromDefinition(
-        PROJECT_EXECUTION_UNAVAILABLE,
-        {
-          detail:
-            "Shared runtimes require a dedicated isolated project runtime for server rendering",
-          instance: pathname,
-        },
-      );
-      const body = req.method === "HEAD" ? null : problem.body;
-      const response = this.createResponseBuilder(ctx, generateNonce())
-        .withSecurity(ctx.securityConfig ?? undefined, req)
-        .withCache("no-store")
-        .withHeaders(problem.headers)
-        .build(body, problem.status);
-      return Promise.resolve(this.respond(response));
+      return Promise.resolve(this.respond(
+        this.buildExecutionUnavailableResponse(
+          req,
+          ctx,
+          "Shared runtimes require a dedicated isolated project runtime for server rendering",
+          pathname,
+        ),
+      ));
+    }
+
+    // An explicit SSR isolation request outranks the broad host-execution
+    // grant. With WORKER_ISOLATION_ENABLED=1 and WORKER_ISOLATION_SSR=1 the
+    // operator asked renders to leave the host realm, and this surface has no
+    // isolated renderer path wired to it, so honouring the grant here would
+    // silently downgrade that request to host execution. Fail closed instead
+    // of rendering in the host process.
+    if (ssrIsolationRequested() && isSharedProjectRuntime(ctx)) {
+      return Promise.resolve(this.respond(
+        this.buildExecutionUnavailableResponse(
+          req,
+          ctx,
+          "SSR isolation is enabled; the shared-runtime host execution grant does not downgrade rendering into the host realm",
+          pathname,
+        ),
+      ));
     }
 
     this.logDebug("SSR attempt", { pathname, slug }, ctx);
@@ -139,6 +162,25 @@ export class SSRHandler extends BaseHandler {
       endRequest(requestId);
       throw error;
     });
+  }
+
+  /** The typed fail-closed response for a render this runtime must not host. */
+  private buildExecutionUnavailableResponse(
+    req: Request,
+    ctx: HandlerContext,
+    detail: string,
+    pathname: string,
+  ): Response {
+    const problem = createErrorResponseFromDefinition(
+      PROJECT_EXECUTION_UNAVAILABLE,
+      { detail, instance: pathname },
+    );
+    const body = req.method === "HEAD" ? null : problem.body;
+    return this.createResponseBuilder(ctx, generateNonce())
+      .withSecurity(ctx.securityConfig ?? undefined, req)
+      .withCache("no-store")
+      .withHeaders(problem.headers)
+      .build(body, problem.status);
   }
 
   private setupContextAndRender(

--- a/src/server/production-server.ts
+++ b/src/server/production-server.ts
@@ -264,6 +264,28 @@ export function startProductionServer(
         });
         const { allowHostProjectCodeExecution } = executionPosture;
 
+        if (executionPosture.overrideIgnored) {
+          logger.warn("Host project execution override is ignored", {
+            overrideEnv: HOST_PROJECT_EXECUTION_OVERRIDE_ENV,
+            reason: "dedicated runtimes already allow project execution",
+          });
+        } else if (sharedRuntime && executionPosture.allowHostProjectCodeExecution) {
+          // The grant is active, not merely present. Say so at startup: an operator
+          // upgrading into this build can have a formerly stale setting silently become
+          // effective, and the absence of an "ignored" warning must not be the only
+          // signal that same-process tenant execution is switched on.
+          //
+          // Emitted before startup discovery on purpose: discovery below receives the
+          // grant and may import or evaluate project primitives, so the operator-facing
+          // security signal must land before the first tenant side effect -- and before
+          // any discovery path that hangs or exits could swallow it.
+          logger.warn("Shared runtime is executing tenant project code by operator grant", {
+            overrideEnv: HOST_PROJECT_EXECUTION_OVERRIDE_ENV,
+            reason:
+              "tenant code runs in this shared process; per-request separation is source scoping, not a tenant boundary",
+          });
+        }
+
         // Run primitive discovery before serving (registries must be populated before first request)
         if (discoveryConfig) {
           try {
@@ -297,23 +319,6 @@ export function startProductionServer(
         // switch that enables no surface) lands in the startup log where an
         // operator looks for it.
         getIsolationPosture();
-
-        if (executionPosture.overrideIgnored) {
-          logger.warn("Host project execution override is ignored", {
-            overrideEnv: HOST_PROJECT_EXECUTION_OVERRIDE_ENV,
-            reason: "dedicated runtimes already allow project execution",
-          });
-        } else if (sharedRuntime && executionPosture.allowHostProjectCodeExecution) {
-          // The grant is active, not merely present. Say so at startup: an operator
-          // upgrading into this build can have a formerly stale setting silently become
-          // effective, and the absence of an "ignored" warning must not be the only
-          // signal that same-process tenant execution is switched on.
-          logger.warn("Shared runtime is executing tenant project code by operator grant", {
-            overrideEnv: HOST_PROJECT_EXECUTION_OVERRIDE_ENV,
-            reason:
-              "tenant code runs in this shared process; per-request separation is source scoping, not a tenant boundary",
-          });
-        }
 
         const baseHandler = createVeryfrontHandler(projectDir, adapter, {
           projectDir,

--- a/src/server/production-server.ts
+++ b/src/server/production-server.ts
@@ -249,8 +249,8 @@ export function startProductionServer(
         enableSSRClientOnlyFetching();
 
         // A dedicated single-project runtime carries the capability implicitly.
-        // Shared runtimes always route executable project code to an isolated
-        // project runtime. The former operator override is diagnostic only.
+        // A shared runtime carries it only where the operator grants it here; without
+        // a grant it routes executable project code to an isolated project runtime.
         //
         // Computed before discovery so startup and request handling share one
         // value. They disagreed before issue-inbox#363: discovery hardcoded a
@@ -301,9 +301,17 @@ export function startProductionServer(
         if (executionPosture.overrideIgnored) {
           logger.warn("Host project execution override is ignored", {
             overrideEnv: HOST_PROJECT_EXECUTION_OVERRIDE_ENV,
-            reason: sharedRuntime
-              ? "shared runtimes require isolated project execution"
-              : "dedicated runtimes already allow project execution",
+            reason: "dedicated runtimes already allow project execution",
+          });
+        } else if (sharedRuntime && executionPosture.allowHostProjectCodeExecution) {
+          // The grant is active, not merely present. Say so at startup: an operator
+          // upgrading into this build can have a formerly stale setting silently become
+          // effective, and the absence of an "ignored" warning must not be the only
+          // signal that same-process tenant execution is switched on.
+          logger.warn("Shared runtime is executing tenant project code by operator grant", {
+            overrideEnv: HOST_PROJECT_EXECUTION_OVERRIDE_ENV,
+            reason:
+              "tenant code runs in this shared process; per-request separation is source scoping, not a tenant boundary",
           });
         }
 

--- a/src/server/startup-discovery.test.ts
+++ b/src/server/startup-discovery.test.ts
@@ -145,7 +145,11 @@ describe("server/startup-discovery", () => {
     assertEquals(calls[0]?.allowHostProjectCodeExecution, true);
   });
 
-  it("denies host execution for unscoped discovery in a shared runtime", async () => {
+  it("forwards the deployment grant to unscoped discovery in a shared runtime", async () => {
+    // The entrypoint's posture already honoured the operator grant
+    // (veryfront-issue-inbox#848), and the topology re-check here must not
+    // discard it a second time: startup discovery and request handling share
+    // one computed value.
     const { calls, discoverAll } = recorder();
     const runtimeAdapter = {
       fs: { isMultiProjectMode: () => true },
@@ -160,7 +164,29 @@ describe("server/startup-discovery", () => {
     });
 
     assertEquals(calls.length, 1);
-    assertEquals(calls[0]?.allowHostProjectCodeExecution, false);
+    assertEquals(calls[0]?.allowHostProjectCodeExecution, true);
+  });
+
+  it("denies host execution for ungranted unscoped discovery in a shared runtime", async () => {
+    const { calls, discoverAll } = recorder();
+    const runtimeAdapter = {
+      fs: { isMultiProjectMode: () => true },
+    } as unknown as RuntimeAdapter;
+
+    await runStartupDiscovery({
+      config: { baseDir: PROJECT_DIR },
+      runtimeAdapter,
+      allowHostProjectCodeExecution: false,
+      discoverAll,
+      isExtendedFSAdapter: noExtendedAdapters,
+    });
+
+    assertEquals(calls.length, 1);
+    assertEquals(
+      calls[0]?.allowHostProjectCodeExecution,
+      false,
+      "a shared runtime without a grant must stay fail-closed at startup",
+    );
   });
 
   it("skips the scoped multi-project path rather than calling discovery ungranted", async () => {


### PR DESCRIPTION
Fixes veryfront/veryfront-issue-inbox#848 — preview returns 503 on staging.

## What broke

#4166 (`d4c0ddb410`, 2026-08-26 13:14) changed `resolveHostProjectExecutionPosture`:

```ts
return {
  allowHostProjectCodeExecution: !options.sharedRuntime,   // grant no longer consulted
  overrideIgnored: options.overrideConfigured,
};
```

The operator grant is read, recorded as ignored, and discarded. Its stated rationale:

> Dedicated single-project runtimes already carry the host execution capability. The former override therefore grants no additional topology…

**That premise does not hold here.** `veryfront-server` is this platform's shared rendering and executor runtime, and no dedicated isolated runtime is provisioned for hosted project previews or agents. So the capability was withdrawn while the product still depended on it.

## Observed impact

Staging, `0.1.1253-rc.16336`:

```
GET https://<project>.preview.veryfront.org/?studio_embed=true…   →  503

{"title":"Project execution unavailable","status":503,
 "detail":"Shared runtimes do not execute tenant API modules in the host process
           or same-process Workers",
 "suggestion":"Route the project to a dedicated isolated runtime"}
```

In Studio this shows as the preview pane reporting **"refused to connect"**.

| | Framework | Grant honoured | Preview |
|---|---|---|---|
| production | `0.1.1252` | yes — predates #4166 | working |
| staging | `0.1.1253-rc.16336` | **no** | **broken** |

The chart sets `VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION: "1"` in **both** environments, so promoting the `0.1.1253` line would break production the same way.

## The change

```ts
allowHostProjectCodeExecution: !options.sharedRuntime || options.overrideConfigured,
overrideIgnored: options.overrideConfigured && !options.sharedRuntime,
```

- Shared runtime **with** a grant → executes. This is the case that was broken.
- Shared runtime **without** a grant → still fail-closed. Unchanged.
- Dedicated runtime → already had the capability; the grant is still reported as `overrideIgnored` so startup can surface stale operator configuration.

## This is a security posture decision, made deliberately

#4166 is a security change and the boundary it describes is real: tenant code runs in the shared process, and per-request separation there is source scoping, not a tenant boundary.

This PR **re-accepts that posture** rather than discovering it. It is what production runs today. The argument is one of sequencing: the capability was removed before the replacement (routing execution to a dedicated isolated runtime, #356) existed, which produced a broken product surface rather than a tightened boundary.

Retiring the grant should land **with** that routing, not ahead of it. #848 records this so it is not lost.

## Verification — red before green

```
without this change:  2 failed   ← shared-runtime-with-grant, and fail-closed
with this change:     1 passed (9 steps) | 0 failed
```

Consumers of the posture, all passing:

```
src/routing/api/handler.test.ts                          exit 0
src/server/handlers/request/api/api-handler-wrapper.test.ts  exit 0
src/agent/project/agent-runtime.test.ts                  exit 0
src/data/server-data-fetcher.test.ts                     exit 0
deno fmt --check / deno lint / deno check                exit 0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Operators can explicitly enable tenant API code execution on shared runtimes through a host configuration setting.
  * Dedicated runtimes continue to allow execution without requiring the setting.

* **Security**
  * Shared runtimes remain isolated by default and fail closed when no grant is configured.
  * Startup warnings now clearly indicate when shared-runtime execution is enabled or when a setting is unnecessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->