### PR TITLE
test(cli): release dev poll response bodies

### DIFF
--- a/cli/commands/dev/dev-output.integration.test.ts
+++ b/cli/commands/dev/dev-output.integration.test.ts
@@ -1,16 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
 
-import {
-  assert,
-  assertEquals,
-  assertRejects,
-  assertStringIncludes,
-} from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#veryfront/compat/path";
 import { mkdir, writeTextFile } from "#veryfront/testing/deno-compat";
 import { TEST_TIMEOUTS } from "../../../tests/_helpers/constants.ts";
 import { withTestContext } from "../../../tests/_helpers/context.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import {
   fetchWithTimeout,
   pollUrlReady,
@@ -246,7 +242,7 @@ async function waitForPageContent(
   while (Date.now() < deadline) {
     try {
       const response = await fetchWithTimeout(`http://127.0.0.1:${port}/`, 1_000);
-      const content = await readPageResponseText(response);
+      const content = await readResponseTextAndRelease(response);
       if (content.includes(expected)) return;
     } catch {
       // The server may be between reloads.
@@ -256,11 +252,22 @@ async function waitForPageContent(
   throw new Error(`Timed out waiting for page content "${expected}"`);
 }
 
-async function readPageResponseText(response: Response): Promise<string> {
+async function readResponseTextAndRelease(response: Response): Promise<string> {
+  const body = response.body;
+  if (body === null) return "";
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let content = "";
   try {
-    return await response.text();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) return content + decoder.decode();
+      content += decoder.decode(value, { stream: true });
+    }
   } finally {
-    await response.body?.cancel().catch(() => {});
+    await reader.cancel().catch(() => {});
+    reader.releaseLock();
   }
 }
 
@@ -285,33 +292,31 @@ async function requestPageAndApi(port: number): Promise<void> {
 describe(
   "veryfront dev output",
   () => {
-    it("releases page responses after successful and failed reads", async () => {
-      let cancellations = 0;
-      const response = (text: () => Promise<string>): Response =>
-        ({
-          text,
-          body: {
-            cancel: () => {
-              cancellations++;
-              return Promise.resolve();
-            },
-          },
-        }) as unknown as Response;
+    it("releases page responses when reading fails and retries", async () => {
+      let attempts = 0;
+      const bodies: ReadableStream<Uint8Array>[] = [];
 
-      await assertRejects(
-        () =>
-          readPageResponseText(
-            response(() => Promise.reject(new DOMException("Body read aborted", "AbortError"))),
-          ),
-        DOMException,
-        "Body read aborted",
-      );
-      assertEquals(
-        await readPageResponseText(response(() => Promise.resolve("updated dev logs page"))),
-        "updated dev logs page",
+      await withMockFetch(
+        () => {
+          attempts++;
+          const response = attempts === 1
+            ? new Response(
+              new ReadableStream<Uint8Array>({
+                pull(controller) {
+                  controller.error(new DOMException("Body read aborted", "AbortError"));
+                },
+              }),
+            )
+            : new Response("updated dev logs page");
+          if (response.body !== null) bodies.push(response.body);
+          return Promise.resolve(response);
+        },
+        () => waitForPageContent(30_010, "updated dev logs page", 250),
       );
 
-      assertEquals(cancellations, 2);
+      assertEquals(attempts, 2);
+      assertEquals(bodies.length, 2);
+      assert(bodies.every((body) => !body.locked));
     });
 
     it(

--- a/cli/commands/dev/dev-output.integration.test.ts
+++ b/cli/commands/dev/dev-output.integration.test.ts
@@ -237,15 +237,28 @@ function startVeryfrontDev(
   };
 }
 
+interface PageReader {
+  read(): Promise<ReadableStreamReadResult<Uint8Array>>;
+  cancel(): Promise<void>;
+  releaseLock(): void;
+}
+
+interface PageResponse {
+  readonly body: { getReader(): PageReader } | null;
+}
+
+type PageRequest = (url: string, timeoutMs: number) => Promise<PageResponse>;
+
 async function waitForPageContent(
   port: number,
   expected: string,
   timeoutMs: number = TEST_TIMEOUTS.SERVER_STARTUP,
+  requestPage: PageRequest = fetchWithTimeout,
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
-      const response = await fetchWithTimeout(`http://127.0.0.1:${port}/`, 1_000);
+      const response = await requestPage(`http://127.0.0.1:${port}/`, 1_000);
       const content = await readResponseTextAndRelease(response);
       if (content.includes(expected)) return;
     } catch {
@@ -256,7 +269,7 @@ async function waitForPageContent(
   throw new Error(`Timed out waiting for page content "${expected}"`);
 }
 
-async function readResponseTextAndRelease(response: Response): Promise<string> {
+async function readResponseTextAndRelease(response: PageResponse): Promise<string> {
   const body = response.body;
   if (body === null) return "";
 
@@ -321,6 +334,57 @@ describe(
       );
       assert(!failedBody.locked);
       assert(!successfulBody.locked);
+    });
+
+    it("cancels page readers while polling after successful and failed reads", async () => {
+      const cancelled: string[] = [];
+      const released: string[] = [];
+      const failedResponse: PageResponse = {
+        body: {
+          getReader: () => ({
+            read: () => Promise.reject(new DOMException("Body read aborted", "AbortError")),
+            cancel: () => {
+              cancelled.push("failed");
+              return Promise.resolve();
+            },
+            releaseLock: () => released.push("failed"),
+          }),
+        },
+      };
+      let successfulRead = false;
+      const successfulResponse: PageResponse = {
+        body: {
+          getReader: () => ({
+            read: (): Promise<ReadableStreamReadResult<Uint8Array>> => {
+              if (successfulRead) return Promise.resolve({ done: true, value: undefined });
+              successfulRead = true;
+              return Promise.resolve({
+                done: false,
+                value: new TextEncoder().encode("updated dev logs page"),
+              });
+            },
+            cancel: () => {
+              cancelled.push("successful");
+              return Promise.resolve();
+            },
+            releaseLock: () => released.push("successful"),
+          }),
+        },
+      };
+      const responses = [failedResponse, successfulResponse];
+      const requests: Array<{ url: string; timeoutMs: number }> = [];
+
+      await waitForPageContent(4_246, "updated dev logs page", 1_000, (url, timeoutMs) => {
+        requests.push({ url, timeoutMs });
+        return Promise.resolve(responses.shift()!);
+      });
+
+      assertEquals(cancelled, ["failed", "successful"]);
+      assertEquals(released, ["failed", "successful"]);
+      assertEquals(requests, [
+        { url: "http://127.0.0.1:4246/", timeoutMs: 1_000 },
+        { url: "http://127.0.0.1:4246/", timeoutMs: 1_000 },
+      ]);
     });
 
     it(

--- a/cli/commands/dev/dev-output.integration.test.ts
+++ b/cli/commands/dev/dev-output.integration.test.ts
@@ -1,12 +1,16 @@
 import "#veryfront/schemas/_test-setup.ts";
 
-import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#veryfront/compat/path";
 import { mkdir, writeTextFile } from "#veryfront/testing/deno-compat";
 import { TEST_TIMEOUTS } from "../../../tests/_helpers/constants.ts";
 import { withTestContext } from "../../../tests/_helpers/context.ts";
-import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import {
   fetchWithTimeout,
   pollUrlReady,
@@ -292,31 +296,31 @@ async function requestPageAndApi(port: number): Promise<void> {
 describe(
   "veryfront dev output",
   () => {
-    it("releases page responses when reading fails and retries", async () => {
-      let attempts = 0;
-      const bodies: ReadableStream<Uint8Array>[] = [];
-
-      await withMockFetch(
-        () => {
-          attempts++;
-          const response = attempts === 1
-            ? new Response(
-              new ReadableStream<Uint8Array>({
-                pull(controller) {
-                  controller.error(new DOMException("Body read aborted", "AbortError"));
-                },
-              }),
-            )
-            : new Response("updated dev logs page");
-          if (response.body !== null) bodies.push(response.body);
-          return Promise.resolve(response);
-        },
-        () => waitForPageContent(30_010, "updated dev logs page", 250),
+    it("releases page response readers after successful and failed reads", async () => {
+      const failedResponse = new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            controller.error(new DOMException("Body read aborted", "AbortError"));
+          },
+        }),
       );
+      const successfulResponse = new Response("updated dev logs page");
+      const failedBody = failedResponse.body;
+      const successfulBody = successfulResponse.body;
+      assert(failedBody !== null);
+      assert(successfulBody !== null);
 
-      assertEquals(attempts, 2);
-      assertEquals(bodies.length, 2);
-      assert(bodies.every((body) => !body.locked));
+      await assertRejects(
+        () => readResponseTextAndRelease(failedResponse),
+        DOMException,
+        "Body read aborted",
+      );
+      assertEquals(
+        await readResponseTextAndRelease(successfulResponse),
+        "updated dev logs page",
+      );
+      assert(!failedBody.locked);
+      assert(!successfulBody.locked);
     });
 
     it(

--- a/cli/commands/dev/dev-output.integration.test.ts
+++ b/cli/commands/dev/dev-output.integration.test.ts
@@ -1,12 +1,16 @@
 import "#veryfront/schemas/_test-setup.ts";
 
-import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#veryfront/compat/path";
 import { mkdir, writeTextFile } from "#veryfront/testing/deno-compat";
 import { TEST_TIMEOUTS } from "../../../tests/_helpers/constants.ts";
 import { withTestContext } from "../../../tests/_helpers/context.ts";
-import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import {
   fetchWithTimeout,
   pollUrlReady,
@@ -242,18 +246,22 @@ async function waitForPageContent(
   while (Date.now() < deadline) {
     try {
       const response = await fetchWithTimeout(`http://127.0.0.1:${port}/`, 1_000);
-      try {
-        const content = await response.text();
-        if (content.includes(expected)) return;
-      } finally {
-        await response.body?.cancel().catch(() => {});
-      }
+      const content = await readPageResponseText(response);
+      if (content.includes(expected)) return;
     } catch {
       // The server may be between reloads.
     }
     await new Promise((resolve) => setTimeout(resolve, 50));
   }
   throw new Error(`Timed out waiting for page content "${expected}"`);
+}
+
+async function readPageResponseText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } finally {
+    await response.body?.cancel().catch(() => {});
+  }
 }
 
 async function requestPageAndApi(port: number): Promise<void> {
@@ -277,8 +285,7 @@ async function requestPageAndApi(port: number): Promise<void> {
 describe(
   "veryfront dev output",
   () => {
-    it("releases page responses when reading fails and retries", async () => {
-      let attempts = 0;
+    it("releases page responses after successful and failed reads", async () => {
       let cancellations = 0;
       const response = (text: () => Promise<string>): Response =>
         ({
@@ -291,19 +298,19 @@ describe(
           },
         }) as unknown as Response;
 
-      await withMockFetch(
-        () => {
-          attempts++;
-          return Promise.resolve(
-            attempts === 1
-              ? response(() => Promise.reject(new DOMException("Body read aborted", "AbortError")))
-              : response(() => Promise.resolve("updated dev logs page")),
-          );
-        },
-        () => waitForPageContent(30_010, "updated dev logs page", 250),
+      await assertRejects(
+        () =>
+          readPageResponseText(
+            response(() => Promise.reject(new DOMException("Body read aborted", "AbortError"))),
+          ),
+        DOMException,
+        "Body read aborted",
+      );
+      assertEquals(
+        await readPageResponseText(response(() => Promise.resolve("updated dev logs page"))),
+        "updated dev logs page",
       );
 
-      assertEquals(attempts, 2);
       assertEquals(cancellations, 2);
     });
 

--- a/cli/commands/dev/dev-output.integration.test.ts
+++ b/cli/commands/dev/dev-output.integration.test.ts
@@ -236,7 +236,7 @@ function startVeryfrontDev(
 async function waitForPageContent(
   port: number,
   expected: string,
-  timeoutMs = TEST_TIMEOUTS.SERVER_STARTUP,
+  timeoutMs: number = TEST_TIMEOUTS.SERVER_STARTUP,
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {

--- a/cli/commands/dev/dev-output.integration.test.ts
+++ b/cli/commands/dev/dev-output.integration.test.ts
@@ -6,6 +6,7 @@ import { join } from "#veryfront/compat/path";
 import { mkdir, writeTextFile } from "#veryfront/testing/deno-compat";
 import { TEST_TIMEOUTS } from "../../../tests/_helpers/constants.ts";
 import { withTestContext } from "../../../tests/_helpers/context.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import {
   fetchWithTimeout,
   pollUrlReady,
@@ -241,8 +242,12 @@ async function waitForPageContent(
   while (Date.now() < deadline) {
     try {
       const response = await fetchWithTimeout(`http://127.0.0.1:${port}/`, 1_000);
-      const content = await response.text();
-      if (content.includes(expected)) return;
+      try {
+        const content = await response.text();
+        if (content.includes(expected)) return;
+      } finally {
+        await response.body?.cancel().catch(() => {});
+      }
     } catch {
       // The server may be between reloads.
     }
@@ -272,6 +277,36 @@ async function requestPageAndApi(port: number): Promise<void> {
 describe(
   "veryfront dev output",
   () => {
+    it("releases page responses when reading fails and retries", async () => {
+      let attempts = 0;
+      let cancellations = 0;
+      const response = (text: () => Promise<string>): Response =>
+        ({
+          text,
+          body: {
+            cancel: () => {
+              cancellations++;
+              return Promise.resolve();
+            },
+          },
+        }) as unknown as Response;
+
+      await withMockFetch(
+        () => {
+          attempts++;
+          return Promise.resolve(
+            attempts === 1
+              ? response(() => Promise.reject(new DOMException("Body read aborted", "AbortError")))
+              : response(() => Promise.resolve("updated dev logs page")),
+          );
+        },
+        () => waitForPageContent(30_010, "updated dev logs page", 250),
+      );
+
+      assertEquals(attempts, 2);
+      assertEquals(cancellations, 2);
+    });
+
     it(
       "keeps default dev output focused on readiness and hides routine diagnostics",
       { timeout: TEST_TIMEOUTS.INTEGRATION },


### PR DESCRIPTION
## Description

Release every response body used by the dev-output HMR polling loop, including when a timed body read aborts. Keep the existing retry behavior unchanged.

Add a deterministic regression that fails when the aborted response and the successful retry are not both cancelled.

## Related issue(s)

Fixes veryfront/veryfront-issue-inbox#847

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Verification

- Red: deno task test:file cli/commands/dev/dev-output.integration.test.ts failed with 0 cancellations instead of 2.
- Green: the same focused suite passed after the fix.
- Green repeated: the final focused suite passed 3 consecutive runs.
- deno fmt --check cli/commands/dev/dev-output.integration.test.ts
- deno lint cli/commands/dev/dev-output.integration.test.ts
- git diff --check

## Checklist

- [x] Documentation is unchanged because this only corrects test cleanup.
- [x] I added a regression test that proves the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for safely reading response content from streams.
  * Verified response bodies are released after both successful and failed reads.
  * Added validation for aborted body reads and empty response bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->