### PR TITLE
fix(security): match OIDC cache poison keys exactly

### DIFF
--- a/tests/integration/security/application-auth/oidc-metadata.test.ts
+++ b/tests/integration/security/application-auth/oidc-metadata.test.ts
@@ -924,7 +924,7 @@ describe("security/application-auth OIDC metadata", () => {
             Map.prototype,
             "has",
             function (this: Map<unknown, unknown>, key: unknown): boolean {
-              if (typeof key === "string" && key.includes(issuerB)) return true;
+              if (typeof key === "string" && key === issuerB) return true;
               return TestReflectApply(TestMapPrototypeHas, this, [key]) as boolean;
             },
           ),

--- a/tests/integration/security/application-auth/oidc-metadata.test.ts
+++ b/tests/integration/security/application-auth/oidc-metadata.test.ts
@@ -902,9 +902,19 @@ describe("security/application-auth OIDC metadata", () => {
   });
 
   it("does not let poisoned Map.has or size bypass pending metadata capacity", async () => {
-    const cache = createOidcMetadataCache({ maxEntries: 1 });
+    const cacheTtlSeconds = 60;
+    const requestTimeoutMs = 5_000;
+    const cache = createOidcMetadataCache({ ttlSeconds: cacheTtlSeconds, maxEntries: 1 });
     const issuerA = "https://pending-primordial-a.example.com";
     const issuerB = "https://pending-primordial-b.example.com";
+    const issuerBCacheKey = [
+      "oidc-metadata-cache-v1",
+      issuerB,
+      "https-only",
+      `${requestTimeoutMs}`,
+      `${cacheTtlSeconds * 1_000}`,
+      "0",
+    ].reduce((key, field) => `${key}${field.length}:${field}`, "");
     let releaseFirst: ((response: Response) => void) | undefined;
     const firstResponse = new Promise<Response>((resolve) => {
       releaseFirst = resolve;
@@ -924,7 +934,7 @@ describe("security/application-auth OIDC metadata", () => {
             Map.prototype,
             "has",
             function (this: Map<unknown, unknown>, key: unknown): boolean {
-              if (typeof key === "string" && key === issuerB) return true;
+              if (key === issuerBCacheKey) return true;
               return TestReflectApply(TestMapPrototypeHas, this, [key]) as boolean;
             },
           ),
@@ -932,7 +942,7 @@ describe("security/application-auth OIDC metadata", () => {
         ];
         try {
           await assertRejects(
-            () => cache.get({ issuer: issuerB }),
+            () => cache.get({ issuer: issuerB, timeoutMs: requestTimeoutMs }),
             TypeError,
             "capacity",
           );


### PR DESCRIPTION
## Summary

- replace substring issuer matching in the OIDC metadata cache poison helper with exact key matching
- preserve the pending-capacity primordial regression while removing the ambiguous URL-host pattern
- keep the change test-only, with no production runtime behavior change

## Security

This addresses [code-scanning alert 319](https://github.com/veryfront/veryfront-code/security/code-scanning/319), CodeQL `js/incomplete-url-substring-sanitization`. The helper now targets only the intended canonical issuer key and cannot match a different URL that merely contains the issuer text.

## Verification

- `deno fmt --check tests/integration/security/application-auth/oidc-metadata.test.ts`
- `deno lint tests/integration/security/application-auth/oidc-metadata.test.ts`
- `deno task test:file tests/integration/security/application-auth/oidc-metadata.test.ts` (1 test, 23 steps)
- `deno task audit` (80 npm dependencies and Storybook, 0 vulnerabilities)
- full repository pre-push format, lint, typecheck, unit, cwd, and cwd-exclusion gates passed

Exact head: `81ca1ec325dd0130291cd5392f974dd2d28738a6` based on `origin/main` at `fddb2c312817bfac5bf148d8cce2aadd461c534c`.