### PR TITLE
fix(config): preserve prose after redacted URLs

### DIFF
--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -3038,6 +3038,45 @@ export default config as const;
         assertEquals(acceptedRawPath.message.includes("registry.internal"), false);
         assertStringIncludes(acceptedRawPath.message, "Failed [url]");
 
+        for (const rawCharacter of ["<", ">", "`", "^", "|"]) {
+          const rawValue = `${rawCharacter}PRIVATE${rawCharacter}`;
+          const acceptedRawUrlPath = await loadFailure(
+            "vf-config-raw-accepted-url-path-",
+            `throw new Error("Failed https://registry.internal/${rawValue}/config.ts");\n`,
+          );
+
+          assertEquals(acceptedRawUrlPath.message.includes("PRIVATE"), false);
+          assertEquals(acceptedRawUrlPath.message.includes("registry.internal"), false);
+          assertStringIncludes(acceptedRawUrlPath.message, "Failed [url]");
+
+          const acceptedRawFilePath = await loadFailure(
+            "vf-config-raw-accepted-file-path-",
+            `throw new Error("Failed file:///home/alice/${rawValue}/config.ts");\n`,
+          );
+
+          assertEquals(acceptedRawFilePath.message.includes("PRIVATE"), false);
+          assertEquals(acceptedRawFilePath.message.includes("/home/alice"), false);
+          assertStringIncludes(acceptedRawFilePath.message, "Failed [path]");
+        }
+
+        const longIriPrefix = "a".repeat(2049);
+        const longIriPath = await loadFailure(
+          "vf-config-long-iri-prefix-",
+          `throw new Error("Failed https://registry.internal/${longIriPrefix}/秘密/config.ts");\n`,
+        );
+
+        assertEquals(longIriPath.message.includes("秘密"), false);
+        assertEquals(longIriPath.message.includes("registry.internal"), false);
+        assertStringIncludes(longIriPath.message, "Failed [url]");
+
+        const closingAngleProse = await loadFailure(
+          "vf-config-closing-angle-prose-",
+          `throw new Error("Failed (see https://registry.internal/x)> Retry");\n`,
+        );
+
+        assertEquals(closingAngleProse.message.includes("registry.internal"), false);
+        assertStringIncludes(closingAngleProse.message, "Failed (see [url])> Retry");
+
         const bareAuthorityProse = await loadFailure(
           "vf-config-iri-authority-prose-",
           `throw new Error("Failed (see https://registry.internal)。次を試してください");\n`,

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -2907,36 +2907,58 @@ export default config as const;
         }
       });
 
-      it("cannot keep prose that follows a redacted URL without a space", async () => {
-        // The trailing-punctuation rule needs a boundary -- whitespace, a quote,
-        // or end of line. A script that does not put spaces between sentences
-        // gives it none, so the punctuation run never terminates, the `)` is
-        // taken as URL, and the rest of the line goes with it.
-        //
-        // Asserted rather than left implicit, because the Unicode class above
-        // makes this look handled. `Failed (see .../x)。 Retry` passes, and it is
-        // the space doing that work, not the class. Remove the space and the
-        // whole remainder is redacted.
+      it("keeps prose that follows a redacted URL without a space", async () => {
+        // Keep the space-separated control next to the glued case. Both must
+        // preserve the sentence mark and following prose; the no-space input
+        // proves the URL token ends at characters that cannot appear unencoded
+        // in an RFC 3986 URI, not only at whitespace.
+        const spaced = await loadFailure(
+          "vf-config-paren-cjk-spaced-",
+          `throw new Error("Failed (see https://registry.internal/x)。 Retry");\n`,
+        );
+
+        assertStringIncludes(spaced.message, "Failed (see [url])。 Retry");
+
         const glued = await loadFailure(
           "vf-config-paren-cjk-glued-",
           `throw new Error("Failed (see https://registry.internal/x)。次を試してください");\n`,
         );
 
-        assertStringIncludes(glued.message, "Failed (see [url]");
-        assertEquals(glued.message.includes("次を試してください"), false);
+        assertStringIncludes(glued.message, "Failed (see [url])。次を試してください");
+        assertEquals(glued.message.includes("registry.internal"), false);
 
-        // Pre-existing, and not something the parenthesis branches introduced:
-        // origin/main redacts this identically, because the ordinary tail branch
-        // already eats CJK glued to a URL. The whole tail assumes an ASCII token
-        // delimited by whitespace. Closing it means redefining the boundary
-        // across every pattern here, which is a separate change.
+        // Cover the ordinary tail independently of the parenthesis branches.
+        // It must stop before the first non-ASCII prose character while still
+        // redacting the complete host and ASCII path.
         const noParen = await loadFailure(
           "vf-config-cjk-glued-",
           `throw new Error("Failed https://registry.internal/x次を試してください");\n`,
         );
 
         assertEquals(noParen.message.includes("registry.internal"), false);
-        assertEquals(noParen.message.includes("次を試してください"), false);
+        assertStringIncludes(noParen.message, "Failed [url]次を試してください");
+
+        // Percent-encoding keeps the complete URI in ASCII, so an encoded path
+        // and query remain inside the redacted token.
+        const encoded = await loadFailure(
+          "vf-config-cjk-percent-encoded-",
+          `throw new Error("Failed https://registry.internal/x%E6%AC%A1?t=SUPERSECRET");\n`,
+        );
+
+        assertEquals(encoded.message.includes("registry.internal"), false);
+        assertEquals(encoded.message.includes("SUPERSECRET"), false);
+        assertStringIncludes(encoded.message, "Failed [url]");
+
+        // A non-ASCII authority has no completed ASCII host prefix to redact.
+        // Treat it as an IRI and fail closed on the whole token rather than
+        // exposing the hostname while trying to preserve following prose.
+        const iriHost = await loadFailure(
+          "vf-config-iri-host-",
+          `throw new Error("Failed https://例え.internal/config.ts");\n`,
+        );
+
+        assertEquals(iriHost.message.includes("例え.internal"), false);
+        assertStringIncludes(iriHost.message, "Failed [url]");
       });
 
       it("redacts a URL tail that begins after a lone `)` and punctuation", async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -2967,6 +2967,38 @@ export default config as const;
 
         assertEquals(mixedIriHost.message.includes("例.internal"), false);
         assertStringIncludes(mixedIriHost.message, "Failed [url]");
+
+        const iriUrlPath = await loadFailure(
+          "vf-config-iri-url-path-",
+          `throw new Error("Failed https://registry.internal/秘密/config.ts");\n`,
+        );
+
+        assertEquals(iriUrlPath.message.includes("秘密"), false);
+        assertStringIncludes(iriUrlPath.message, "Failed [url]");
+
+        const iriFilePath = await loadFailure(
+          "vf-config-iri-file-path-",
+          `throw new Error("Failed file:///home/alice/秘密/config.ts");\n`,
+        );
+
+        assertEquals(iriFilePath.message.includes("秘密"), false);
+        assertStringIncludes(iriFilePath.message, "Failed [path]");
+
+        const zeroSlashIri = await loadFailure(
+          "vf-config-zero-slash-iri-host-",
+          `throw new Error("Failed https:例え.internal/config.ts");\n`,
+        );
+
+        assertEquals(zeroSlashIri.message.includes("例え.internal"), false);
+        assertStringIncludes(zeroSlashIri.message, "Failed [url]");
+
+        const zeroSlashIriPath = await loadFailure(
+          "vf-config-zero-slash-iri-path-",
+          `throw new Error("Failed https:registry.internal/秘密/config.ts");\n`,
+        );
+
+        assertEquals(zeroSlashIriPath.message.includes("秘密"), false);
+        assertStringIncludes(zeroSlashIriPath.message, "Failed [url]");
       });
 
       it("redacts a URL tail that begins after a lone `)` and punctuation", async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -3164,6 +3164,28 @@ export default config as const;
         assertStringIncludes(singleSlashIriPath.message, "Failed [url]");
       });
 
+      it("redacts raw IRI remainders after Unicode authorities", async () => {
+        const cases = [
+          ["two-slash-path", "https://例え.internal/秘密"],
+          ["two-slash-query", "https://例え.internal?q=秘密"],
+          ["single-slash-path", "https:/例え.internal/秘密"],
+          ["single-slash-query", "https:/例え.internal?q=秘密"],
+          ["zero-slash-path", "https:例え.internal/秘密"],
+          ["zero-slash-query", "https:例え.internal?q=秘密"],
+        ] as const;
+
+        for (const [label, url] of cases) {
+          const error = await loadFailure(
+            `vf-config-iri-authority-${label}-`,
+            `throw new Error(${JSON.stringify(`Failed ${url}`)});\n`,
+          );
+
+          assertEquals(error.message.includes("例え.internal"), false, label);
+          assertEquals(error.message.includes("秘密"), false, label);
+          assertStringIncludes(error.message, "Failed [url]", label);
+        }
+      });
+
       it("redacts a URL tail that begins after a lone `)` and punctuation", async () => {
         // The other half of the structural rule, and the reason it is not a list
         // of characters prose may end with. Punctuation after a `)` does not make

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -2974,6 +2974,7 @@ export default config as const;
         );
 
         assertEquals(iriUrlPath.message.includes("秘密"), false);
+        assertEquals(iriUrlPath.message.includes("registry.internal"), false);
         assertStringIncludes(iriUrlPath.message, "Failed [url]");
 
         const iriFilePath = await loadFailure(
@@ -2982,6 +2983,7 @@ export default config as const;
         );
 
         assertEquals(iriFilePath.message.includes("秘密"), false);
+        assertEquals(iriFilePath.message.includes("/home/alice"), false);
         assertStringIncludes(iriFilePath.message, "Failed [path]");
 
         const iriTerminalPath = await loadFailure(

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -2959,6 +2959,14 @@ export default config as const;
 
         assertEquals(iriHost.message.includes("例え.internal"), false);
         assertStringIncludes(iriHost.message, "Failed [url]");
+
+        const mixedIriHost = await loadFailure(
+          "vf-config-mixed-iri-host-",
+          `throw new Error("Failed https://a例.internal/config.ts");\n`,
+        );
+
+        assertEquals(mixedIriHost.message.includes("例.internal"), false);
+        assertStringIncludes(mixedIriHost.message, "Failed [url]");
       });
 
       it("redacts a URL tail that begins after a lone `)` and punctuation", async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -2984,6 +2984,30 @@ export default config as const;
         assertEquals(iriFilePath.message.includes("秘密"), false);
         assertStringIncludes(iriFilePath.message, "Failed [path]");
 
+        const iriTerminalPath = await loadFailure(
+          "vf-config-iri-terminal-path-",
+          `throw new Error("Failed https://registry.internal/秘密");\n`,
+        );
+
+        assertEquals(iriTerminalPath.message.includes("秘密"), false);
+        assertStringIncludes(iriTerminalPath.message, "Failed [url]");
+
+        const iriQuery = await loadFailure(
+          "vf-config-iri-query-",
+          `throw new Error("Failed https://registry.internal/x?q=秘密");\n`,
+        );
+
+        assertEquals(iriQuery.message.includes("秘密"), false);
+        assertStringIncludes(iriQuery.message, "Failed [url]");
+
+        const iriTerminalFilePath = await loadFailure(
+          "vf-config-iri-terminal-file-path-",
+          `throw new Error("Failed file:///home/alice/秘密");\n`,
+        );
+
+        assertEquals(iriTerminalFilePath.message.includes("秘密"), false);
+        assertStringIncludes(iriTerminalFilePath.message, "Failed [path]");
+
         const zeroSlashIri = await loadFailure(
           "vf-config-zero-slash-iri-host-",
           `throw new Error("Failed https:例え.internal/config.ts");\n`,

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -3002,6 +3002,50 @@ export default config as const;
         assertEquals(iriQuery.message.includes("秘密"), false);
         assertStringIncludes(iriQuery.message, "Failed [url]");
 
+        const iriPrefixedQuery = await loadFailure(
+          "vf-config-iri-prefixed-query-",
+          `throw new Error("Failed https://registry.internal/x?q=abc秘密");\n`,
+        );
+
+        assertEquals(iriPrefixedQuery.message.includes("秘密"), false);
+        assertEquals(iriPrefixedQuery.message.includes("abc"), false);
+        assertStringIncludes(iriPrefixedQuery.message, "Failed [url]");
+
+        const iriParenthesizedPath = await loadFailure(
+          "vf-config-iri-parenthesized-path-",
+          `throw new Error("Failed https://registry.internal/x(秘密)/config.ts");\n`,
+        );
+
+        assertEquals(iriParenthesizedPath.message.includes("秘密"), false);
+        assertEquals(iriParenthesizedPath.message.includes("registry.internal"), false);
+        assertStringIncludes(iriParenthesizedPath.message, "Failed [url]");
+
+        const fileIriParenthesizedPath = await loadFailure(
+          "vf-config-file-iri-parenthesized-path-",
+          `throw new Error("Failed file:///home/alice/x(秘密)/config.ts");\n`,
+        );
+
+        assertEquals(fileIriParenthesizedPath.message.includes("秘密"), false);
+        assertEquals(fileIriParenthesizedPath.message.includes("/home/alice"), false);
+        assertStringIncludes(fileIriParenthesizedPath.message, "Failed [path]");
+
+        const acceptedRawPath = await loadFailure(
+          "vf-config-raw-accepted-url-path-",
+          `throw new Error("Failed https://registry.internal/{PRIVATE}/config.ts");\n`,
+        );
+
+        assertEquals(acceptedRawPath.message.includes("{PRIVATE}"), false);
+        assertEquals(acceptedRawPath.message.includes("registry.internal"), false);
+        assertStringIncludes(acceptedRawPath.message, "Failed [url]");
+
+        const bareAuthorityProse = await loadFailure(
+          "vf-config-iri-authority-prose-",
+          `throw new Error("Failed (see https://registry.internal)。次を試してください");\n`,
+        );
+
+        assertStringIncludes(bareAuthorityProse.message, "Failed (see [url])。次を試してください");
+        assertEquals(bareAuthorityProse.message.includes("registry.internal"), false);
+
         const iriTerminalFilePath = await loadFailure(
           "vf-config-iri-terminal-file-path-",
           `throw new Error("Failed file:///home/alice/秘密");\n`,

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -3020,6 +3020,18 @@ export default config as const;
         assertEquals(iriParenthesizedPath.message.includes("registry.internal"), false);
         assertStringIncludes(iriParenthesizedPath.message, "Failed [url]");
 
+        const iriUnbalancedParenthesizedPath = await loadFailure(
+          "vf-config-iri-unbalanced-parenthesized-path-",
+          `throw new Error("Failed https://registry.internal/x(秘密/config.ts");\n`,
+        );
+
+        assertEquals(iriUnbalancedParenthesizedPath.message.includes("秘密"), false);
+        assertEquals(
+          iriUnbalancedParenthesizedPath.message.includes("registry.internal"),
+          false,
+        );
+        assertStringIncludes(iriUnbalancedParenthesizedPath.message, "Failed [url]");
+
         const fileIriParenthesizedPath = await loadFailure(
           "vf-config-file-iri-parenthesized-path-",
           `throw new Error("Failed file:///home/alice/x(秘密)/config.ts");\n`,
@@ -3037,6 +3049,24 @@ export default config as const;
         assertEquals(acceptedRawPath.message.includes("{PRIVATE}"), false);
         assertEquals(acceptedRawPath.message.includes("registry.internal"), false);
         assertStringIncludes(acceptedRawPath.message, "Failed [url]");
+
+        const acceptedRawTerminalPath = await loadFailure(
+          "vf-config-raw-accepted-terminal-path-",
+          `throw new Error("Failed https://registry.internal/account{PRIVATE}");\n`,
+        );
+
+        assertEquals(acceptedRawTerminalPath.message.includes("PRIVATE"), false);
+        assertEquals(acceptedRawTerminalPath.message.includes("registry.internal"), false);
+        assertStringIncludes(acceptedRawTerminalPath.message, "Failed [url]");
+
+        const backslashUrlPath = await loadFailure(
+          "vf-config-backslash-url-path-",
+          `throw new Error("Failed https://registry.internal\\\\PRIVATE\\\\config.ts");\n`,
+        );
+
+        assertEquals(backslashUrlPath.message.includes("PRIVATE"), false);
+        assertEquals(backslashUrlPath.message.includes("registry.internal"), false);
+        assertStringIncludes(backslashUrlPath.message, "Failed [url]");
 
         for (const rawCharacter of ["<", ">", "`", "^", "|"]) {
           const rawValue = `${rawCharacter}PRIVATE${rawCharacter}`;
@@ -3100,6 +3130,14 @@ export default config as const;
 
         assertEquals(zeroSlashIri.message.includes("例え.internal"), false);
         assertStringIncludes(zeroSlashIri.message, "Failed [url]");
+
+        const zeroSlashSymbolIri = await loadFailure(
+          "vf-config-zero-slash-symbol-iri-host-",
+          `throw new Error("Failed https:🙂.internal/config.ts");\n`,
+        );
+
+        assertEquals(zeroSlashSymbolIri.message.includes("🙂.internal"), false);
+        assertStringIncludes(zeroSlashSymbolIri.message, "Failed [url]");
 
         const zeroSlashIriPath = await loadFailure(
           "vf-config-zero-slash-iri-path-",

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -2999,6 +2999,22 @@ export default config as const;
 
         assertEquals(zeroSlashIriPath.message.includes("秘密"), false);
         assertStringIncludes(zeroSlashIriPath.message, "Failed [url]");
+
+        const singleSlashIri = await loadFailure(
+          "vf-config-single-slash-iri-host-",
+          `throw new Error("Failed https:/例え.internal/config.ts");\n`,
+        );
+
+        assertEquals(singleSlashIri.message.includes("例え.internal"), false);
+        assertStringIncludes(singleSlashIri.message, "Failed [url]");
+
+        const singleSlashIriPath = await loadFailure(
+          "vf-config-single-slash-iri-path-",
+          `throw new Error("Failed https:/registry.internal/秘密/config.ts");\n`,
+        );
+
+        assertEquals(singleSlashIriPath.message.includes("秘密"), false);
+        assertStringIncludes(singleSlashIriPath.message, "Failed [url]");
       });
 
       it("redacts a URL tail that begins after a lone `)` and punctuation", async () => {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1988,14 +1988,14 @@ const SCHEME_URL = new RegExp(
 // the diagnostic. This runs after the file-URL pass, which keeps local file
 // URLs classified as paths.
 //
-// Unicode after the first slash does not match this fallback. The normal rule
-// handles that shape and preserves the following prose, which is the no-space
-// boundary this fallback must not undo.
+// Group the optional ASCII tail. Writing `${URL_TOKEN_TAIL_SOURCE}?` directly
+// would turn the tail's final `+` lazy, stop after one delimiter, and strand an
+// ASCII query prefix before a later raw-IRI remainder.
 const NON_ASCII_HOST_SOURCE = String
   .raw`[\p{L}\p{N}\p{M}.-]{0,512}[\u0080-\u{10FFFF}][\p{L}\p{N}\p{M}.-]{0,512}`;
 const NON_ASCII_AUTHORITY_URL = new RegExp(
   String
-    .raw`[A-Za-z][A-Za-z0-9+.-]{1,31}://(?:[^\s"/]{0,512}@)?${NON_ASCII_HOST_SOURCE}${URL_TOKEN_TAIL_SOURCE}?`,
+    .raw`[A-Za-z][A-Za-z0-9+.-]{1,31}://(?:[^\s"/]{0,512}@)?${NON_ASCII_HOST_SOURCE}(?:${URL_TOKEN_TAIL_SOURCE})?`,
   "gu",
 );
 // Raw Unicode at the start of a slash-delimited path segment is part of an IRI,
@@ -2093,7 +2093,7 @@ const ZERO_SLASH_SCHEME_URL = new RegExp(
 // remain linear-time.
 const NON_ASCII_MALFORMED_AUTHORITY_URL = new RegExp(
   String
-    .raw`${ASCII_SPECIAL_SCHEME_SOURCE}:/(?!/)(?:[^\s"/]{0,512}@)?${NON_ASCII_HOST_SOURCE}${URL_TOKEN_TAIL_SOURCE}?`,
+    .raw`${ASCII_SPECIAL_SCHEME_SOURCE}:/(?!/)(?:[^\s"/]{0,512}@)?${NON_ASCII_HOST_SOURCE}(?:${URL_TOKEN_TAIL_SOURCE})?`,
   "gu",
 );
 const NON_ASCII_MALFORMED_URL_PATH = new RegExp(
@@ -2103,7 +2103,7 @@ const NON_ASCII_MALFORMED_URL_PATH = new RegExp(
 );
 const NON_ASCII_ZERO_SLASH_AUTHORITY_URL = new RegExp(
   String
-    .raw`${ASCII_SPECIAL_SCHEME_SOURCE}:(?![/\s])(?:[^\s"/]{0,512}@)?${NON_ASCII_HOST_SOURCE}${URL_TOKEN_TAIL_SOURCE}?`,
+    .raw`${ASCII_SPECIAL_SCHEME_SOURCE}:(?![/\s])(?:[^\s"/]{0,512}@)?${NON_ASCII_HOST_SOURCE}(?:${URL_TOKEN_TAIL_SOURCE})?`,
   "gu",
 );
 const NON_ASCII_ZERO_SLASH_URL_PATH = new RegExp(
@@ -2248,18 +2248,25 @@ function redactMachinePaths(value: string): string {
   }
   redacted = replaceMatchesWithCapturedExec(redacted, FILE_URL_ABSOLUTE_PATH, "[path]", true);
   if (containsNonAscii(redacted)) {
-    redacted = replaceMatchesWithCapturedExec(redacted, NON_ASCII_AUTHORITY_URL, "[url]");
+    redacted = replaceMatchesWithCapturedExec(
+      redacted,
+      NON_ASCII_AUTHORITY_URL,
+      "[url]",
+      true,
+    );
     redacted = replaceMatchesWithCapturedExec(redacted, NON_ASCII_URL_PATH, "[url]");
     redacted = replaceMatchesWithCapturedExec(
       redacted,
       NON_ASCII_MALFORMED_AUTHORITY_URL,
       "[url]",
+      true,
     );
     redacted = replaceMatchesWithCapturedExec(redacted, NON_ASCII_MALFORMED_URL_PATH, "[url]");
     redacted = replaceMatchesWithCapturedExec(
       redacted,
       NON_ASCII_ZERO_SLASH_AUTHORITY_URL,
       "[url]",
+      true,
     );
     redacted = replaceMatchesWithCapturedExec(redacted, NON_ASCII_ZERO_SLASH_URL_PATH, "[url]");
   }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1976,7 +1976,7 @@ const URI_TOKEN_CHARACTER_SOURCE = String.raw`[A-Za-z0-9\-._~:/?#\[\]@!$&*+,;=%]
 const URI_PAREN_INTERIOR_SOURCE = String.raw`[A-Za-z0-9\-._~:/?#\[\]@!$&()*+,;=%]`;
 const URL_BALANCED_PAREN_SEGMENT_SOURCE = String.raw`\([^\s"']{0,512}\)`;
 const URL_TOKEN_TAIL_SOURCE = String
-  .raw`(?:${URI_TOKEN_CHARACTER_SOURCE}|${URL_BALANCED_PAREN_SEGMENT_SOURCE}|\((?=${URI_PAREN_INTERIOR_SOURCE})|\)(?=${URI_PAREN_INTERIOR_SOURCE})(?![\p{P}\p{S}\p{M}\p{Cf}]{0,16}(?:[\s"']|$)))+`;
+  .raw`(?:${URI_TOKEN_CHARACTER_SOURCE}|${URL_BALANCED_PAREN_SEGMENT_SOURCE}|\((?=(?:${URI_PAREN_INTERIOR_SOURCE}|\P{ASCII}))|\)(?=${URI_PAREN_INTERIOR_SOURCE})(?![\p{P}\p{S}\p{M}\p{Cf}]{0,16}(?:[\s"']|$)))+`;
 const SCHEME_URL = new RegExp(
   String.raw`[A-Za-z][A-Za-z0-9+.-]{1,31}://(?:[^\s"/]{0,512}@)?${URL_TOKEN_TAIL_SOURCE}`,
   "gu",
@@ -2016,10 +2016,13 @@ const NON_ASCII_CHARACTER = /[\u0080-\u{10FFFF}]/u;
 // raw IRI path, query, or fragment rather than prose glued after a completed
 // path segment. The continuation consumes the rest of that token fail-closed.
 const RAW_IRI_REMAINDER = /\P{ASCII}[^\s"']*/uy;
-// WHATWG URL parsing accepts these raw path characters and percent-encodes
-// them. Extend only from a component boundary or through a later slash, so a
-// prose delimiter such as the closing `>` in `<https://host/x>` stays visible.
-const RAW_ACCEPTED_URL_REMAINDER = /[<>{}\x60^|][^\s"']*/uy;
+// WHATWG URL parsing accepts these raw path characters and backslash separators,
+// percent-encoding or normalizing them. Extend from a component boundary,
+// through a later slash, or when the accepted delimiter introduces an actual
+// letter/number payload. A delimiter-only closing `>` in `<https://host/x>`
+// therefore stays visible while `{PRIVATE}` and `\\PRIVATE` remain redacted.
+const RAW_ACCEPTED_URL_REMAINDER = /[\\<>{}\x60^|][^\s"']*/uy;
+const RAW_ACCEPTED_URL_PAYLOAD = /[\p{L}\p{N}\p{M}]/u;
 
 // Both the userinfo run and the parenthesised interior are length-bounded, and
 // the userinfo run also stops at `/`. Neither bound is cosmetic. An unbounded
@@ -2151,11 +2154,15 @@ function rawUrlMatchEnd(value: string, matched: string, offset: number): number 
     (ReflectApply(StringPrototypeIncludes, matched, ["?"]) as boolean) ||
     (ReflectApply(StringPrototypeIncludes, matched, ["#"]) as boolean);
   const lastCharacter = ReflectApply(StringPrototypeSlice, matched, [-1]) as string;
+  // A lone opening parenthesis admitted by URL_TOKEN_TAIL_SOURCE is a
+  // structural path delimiter. Treat it like `/` when raw IRI data follows so
+  // an accepted `x(秘密` path cannot strand the Unicode segment.
   const atComponentBoundary = lastCharacter === "/" ||
     lastCharacter === "?" ||
     lastCharacter === "#" ||
     lastCharacter === "&" ||
-    lastCharacter === "=";
+    lastCharacter === "=" ||
+    lastCharacter === "(";
   if (insideQueryOrFragment || atComponentBoundary) {
     const iriEnd = stickyMatchEnd(RAW_IRI_REMAINDER, value, offset);
     if (iriEnd !== offset) return iriEnd;
@@ -2168,7 +2175,8 @@ function rawUrlMatchEnd(value: string, matched: string, offset: number): number 
     acceptedEnd,
   ]) as string;
   const structurallyDelimited = atComponentBoundary || insideQueryOrFragment ||
-    (ReflectApply(StringPrototypeIncludes, acceptedRemainder, ["/"]) as boolean);
+    (ReflectApply(StringPrototypeIncludes, acceptedRemainder, ["/"]) as boolean) ||
+    ReflectApply(RegExpPrototypeExec, RAW_ACCEPTED_URL_PAYLOAD, [acceptedRemainder]) !== null;
   return structurallyDelimited ? acceptedEnd : offset;
 }
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1972,10 +1972,11 @@ const CSI_GLUED_URL =
 // Apostrophes are intentionally absent even though RFC 3986 lists them as a
 // sub-delimiter. The userinfo prefix handles them before `@`, while the tail
 // must leave the closing quote in `Cannot find module 'https://host/x'` intact.
-const URI_TOKEN_CHARACTER_SOURCE = String.raw`[A-Za-z0-9\-._~:/?#\[\]@!$&*+,;=%]`;
-const URI_PAREN_INTERIOR_SOURCE = String.raw`[A-Za-z0-9\-._~:/?#\[\]@!$&()*+,;=%]`;
+const URI_TOKEN_CHARACTER_SOURCE = String.raw`[A-Za-z0-9\-._~:/?#\[\]@!$&*+,;=%{}]`;
+const URI_PAREN_INTERIOR_SOURCE = String.raw`[A-Za-z0-9\-._~:/?#\[\]@!$&()*+,;=%{}]`;
+const URL_BALANCED_PAREN_SEGMENT_SOURCE = String.raw`\([^\s"']{0,512}\)`;
 const URL_TOKEN_TAIL_SOURCE = String
-  .raw`(?:${URI_TOKEN_CHARACTER_SOURCE}|\(${URI_PAREN_INTERIOR_SOURCE}{0,512}\)|\((?=${URI_PAREN_INTERIOR_SOURCE})|\)(?=${URI_PAREN_INTERIOR_SOURCE})(?![\p{P}\p{S}\p{M}\p{Cf}]{0,16}(?:[\s"']|$)))+`;
+  .raw`(?:${URI_TOKEN_CHARACTER_SOURCE}|${URL_BALANCED_PAREN_SEGMENT_SOURCE}|\((?=${URI_PAREN_INTERIOR_SOURCE})|\)(?=${URI_PAREN_INTERIOR_SOURCE})(?![\p{P}\p{S}\p{M}\p{Cf}]{0,16}(?:[\s"']|$)))+`;
 const SCHEME_URL = new RegExp(
   String.raw`[A-Za-z][A-Za-z0-9+.-]{1,31}://(?:[^\s"/]{0,512}@)?${URL_TOKEN_TAIL_SOURCE}`,
   "gu",
@@ -1990,8 +1991,13 @@ const SCHEME_URL = new RegExp(
 // Unicode after the first slash does not match this fallback. The normal rule
 // handles that shape and preserves the following prose, which is the no-space
 // boundary this fallback must not undo.
-const NON_ASCII_AUTHORITY_URL =
-  /[A-Za-z][A-Za-z0-9+.-]{1,31}:\/\/(?:[^\s"/]{0,512}@)?(?=[^\s"/]{0,512}[\u0080-\u{10FFFF}])[^\s"']*/gu;
+const NON_ASCII_HOST_SOURCE = String
+  .raw`[\p{L}\p{N}\p{M}.-]{0,512}[\u0080-\u{10FFFF}][\p{L}\p{N}\p{M}.-]{0,512}`;
+const NON_ASCII_AUTHORITY_URL = new RegExp(
+  String
+    .raw`[A-Za-z][A-Za-z0-9+.-]{1,31}://(?:[^\s"/]{0,512}@)?${NON_ASCII_HOST_SOURCE}${URL_TOKEN_TAIL_SOURCE}?`,
+  "gu",
+);
 // Raw Unicode at the start of a slash-delimited path segment is part of an IRI,
 // rather than prose glued to the preceding ASCII segment. Match the complete
 // whitespace-delimited token in that unambiguous case. Requiring the segment
@@ -2080,7 +2086,7 @@ const ZERO_SLASH_SCHEME_URL = new RegExp(
 // remain linear-time.
 const NON_ASCII_MALFORMED_AUTHORITY_URL = new RegExp(
   String
-    .raw`${ASCII_SPECIAL_SCHEME_SOURCE}:/(?!/)(?:[^\s"/]{0,512}@)?(?=[^\s"/]{0,512}[^\x00-\x7F])[^\s"']*`,
+    .raw`${ASCII_SPECIAL_SCHEME_SOURCE}:/(?!/)(?:[^\s"/]{0,512}@)?${NON_ASCII_HOST_SOURCE}${URL_TOKEN_TAIL_SOURCE}?`,
   "gu",
 );
 const NON_ASCII_MALFORMED_URL_PATH = new RegExp(
@@ -2090,7 +2096,7 @@ const NON_ASCII_MALFORMED_URL_PATH = new RegExp(
 );
 const NON_ASCII_ZERO_SLASH_AUTHORITY_URL = new RegExp(
   String
-    .raw`${ASCII_SPECIAL_SCHEME_SOURCE}:(?![/\s])(?:[^\s"/]{0,512}@)?(?=[^\s"/]{0,512}[^\x00-\x7F])[^\s"']*`,
+    .raw`${ASCII_SPECIAL_SCHEME_SOURCE}:(?![/\s])(?:[^\s"/]{0,512}@)?${NON_ASCII_HOST_SOURCE}${URL_TOKEN_TAIL_SOURCE}?`,
   "gu",
 );
 const NON_ASCII_ZERO_SLASH_URL_PATH = new RegExp(
@@ -2126,7 +2132,11 @@ const POSIX_ABSOLUTE_PATH = /(?<![A-Za-z0-9:/.\\])\/[^\s"'()]+/g;
 
 function rawIriMatchEnd(value: string, matched: string, offset: number): number {
   const lastCharacter = ReflectApply(StringPrototypeSlice, matched, [-1]) as string;
+  const insideQueryOrFragment =
+    (ReflectApply(StringPrototypeIncludes, matched, ["?"]) as boolean) ||
+    (ReflectApply(StringPrototypeIncludes, matched, ["#"]) as boolean);
   if (
+    !insideQueryOrFragment &&
     lastCharacter !== "/" &&
     lastCharacter !== "?" &&
     lastCharacter !== "#" &&

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2009,6 +2009,11 @@ const NON_ASCII_URL_PATH = new RegExp(
 // limit even though the fallback could not match.
 // deno-lint-ignore no-control-regex
 const NON_ASCII_CHARACTER = /[^\x00-\x7F]/u;
+// A sticky continuation used only when an ASCII URL match ends on a structural
+// component delimiter. In that position a following non-ASCII character is a
+// raw IRI path, query, or fragment rather than prose glued after a completed
+// path segment. The continuation consumes the rest of that token fail-closed.
+const RAW_IRI_REMAINDER = /\P{ASCII}[^\s"']*/uy;
 
 // Both the userinfo run and the parenthesised interior are length-bounded, and
 // the userinfo run also stops at `/`. Neither bound is cosmetic. An unbounded
@@ -2123,10 +2128,34 @@ const NON_ASCII_FILE_URL_PATH = new RegExp(
 const WINDOWS_ABSOLUTE_PATH = /(?:[A-Za-z]:[\\/]|\\\\)[^\s"'()]+/g;
 const POSIX_ABSOLUTE_PATH = /(?<![A-Za-z0-9:/.\\])\/[^\s"'()]+/g;
 
+function rawIriMatchEnd(value: string, matched: string, offset: number): number {
+  const lastCharacter = ReflectApply(StringPrototypeSlice, matched, [-1]) as string;
+  if (
+    lastCharacter !== "/" &&
+    lastCharacter !== "?" &&
+    lastCharacter !== "#" &&
+    lastCharacter !== "&" &&
+    lastCharacter !== "="
+  ) {
+    return offset;
+  }
+
+  RAW_IRI_REMAINDER.lastIndex = offset;
+  try {
+    const remainder = ReflectApply(RegExpPrototypeExec, RAW_IRI_REMAINDER, [value]) as
+      | RegExpExecArray
+      | null;
+    return remainder === null ? offset : RAW_IRI_REMAINDER.lastIndex;
+  } finally {
+    RAW_IRI_REMAINDER.lastIndex = 0;
+  }
+}
+
 function replaceMatchesWithCapturedExec(
   value: string,
   pattern: RegExp,
   replacement: string,
+  extendRawIri = false,
 ): string {
   pattern.lastIndex = 0;
   let output = "";
@@ -2139,6 +2168,7 @@ function replaceMatchesWithCapturedExec(
       if (match === null) break;
       const matched = match[0];
       if (matched.length === 0) throw new TypeError("Diagnostic pattern must make progress");
+      if (extendRawIri) pattern.lastIndex = rawIriMatchEnd(value, matched, pattern.lastIndex);
       output += ReflectApply(StringPrototypeSlice, value, [offset, match.index]) as string;
       output += replacement;
       offset = pattern.lastIndex;
@@ -2187,7 +2217,7 @@ function redactMachinePaths(value: string): string {
   if (containsNonAscii(redacted)) {
     redacted = replaceMatchesWithCapturedExec(redacted, NON_ASCII_FILE_URL_PATH, "[path]");
   }
-  redacted = replaceMatchesWithCapturedExec(redacted, FILE_URL_ABSOLUTE_PATH, "[path]");
+  redacted = replaceMatchesWithCapturedExec(redacted, FILE_URL_ABSOLUTE_PATH, "[path]", true);
   if (containsNonAscii(redacted)) {
     redacted = replaceMatchesWithCapturedExec(redacted, NON_ASCII_AUTHORITY_URL, "[url]");
     redacted = replaceMatchesWithCapturedExec(redacted, NON_ASCII_URL_PATH, "[url]");
@@ -2204,9 +2234,9 @@ function redactMachinePaths(value: string): string {
     );
     redacted = replaceMatchesWithCapturedExec(redacted, NON_ASCII_ZERO_SLASH_URL_PATH, "[url]");
   }
-  redacted = replaceMatchesWithCapturedExec(redacted, SCHEME_URL, "[url]");
-  redacted = replaceMatchesWithCapturedExec(redacted, MALFORMED_SCHEME_URL, "[url]");
-  redacted = replaceMatchesWithCapturedExec(redacted, ZERO_SLASH_SCHEME_URL, "[url]");
+  redacted = replaceMatchesWithCapturedExec(redacted, SCHEME_URL, "[url]", true);
+  redacted = replaceMatchesWithCapturedExec(redacted, MALFORMED_SCHEME_URL, "[url]", true);
+  redacted = replaceMatchesWithCapturedExec(redacted, ZERO_SLASH_SCHEME_URL, "[url]", true);
   redacted = replaceMatchesWithCapturedExec(redacted, WINDOWS_ABSOLUTE_PATH, "[path]");
   return replaceMatchesWithCapturedExec(redacted, POSIX_ABSOLUTE_PATH, "[path]");
 }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1972,8 +1972,8 @@ const CSI_GLUED_URL =
 // Apostrophes are intentionally absent even though RFC 3986 lists them as a
 // sub-delimiter. The userinfo prefix handles them before `@`, while the tail
 // must leave the closing quote in `Cannot find module 'https://host/x'` intact.
-const URI_TOKEN_CHARACTER_SOURCE = String.raw`[A-Za-z0-9\-._~:/?#\[\]@!$&*+,;=%{}]`;
-const URI_PAREN_INTERIOR_SOURCE = String.raw`[A-Za-z0-9\-._~:/?#\[\]@!$&()*+,;=%{}]`;
+const URI_TOKEN_CHARACTER_SOURCE = String.raw`[A-Za-z0-9\-._~:/?#\[\]@!$&*+,;=%]`;
+const URI_PAREN_INTERIOR_SOURCE = String.raw`[A-Za-z0-9\-._~:/?#\[\]@!$&()*+,;=%]`;
 const URL_BALANCED_PAREN_SEGMENT_SOURCE = String.raw`\([^\s"']{0,512}\)`;
 const URL_TOKEN_TAIL_SOURCE = String
   .raw`(?:${URI_TOKEN_CHARACTER_SOURCE}|${URL_BALANCED_PAREN_SEGMENT_SOURCE}|\((?=${URI_PAREN_INTERIOR_SOURCE})|\)(?=${URI_PAREN_INTERIOR_SOURCE})(?![\p{P}\p{S}\p{M}\p{Cf}]{0,16}(?:[\s"']|$)))+`;
@@ -2016,6 +2016,10 @@ const NON_ASCII_CHARACTER = /[\u0080-\u{10FFFF}]/u;
 // raw IRI path, query, or fragment rather than prose glued after a completed
 // path segment. The continuation consumes the rest of that token fail-closed.
 const RAW_IRI_REMAINDER = /\P{ASCII}[^\s"']*/uy;
+// WHATWG URL parsing accepts these raw path characters and percent-encodes
+// them. Extend only from a component boundary or through a later slash, so a
+// prose delimiter such as the closing `>` in `<https://host/x>` stays visible.
+const RAW_ACCEPTED_URL_REMAINDER = /[<>{}\x60^|][^\s"']*/uy;
 
 // Both the userinfo run and the parenthesised interior are length-bounded, and
 // the userinfo run also stops at `/`. Neither bound is cosmetic. An unbounded
@@ -2130,38 +2134,49 @@ const NON_ASCII_FILE_URL_PATH = new RegExp(
 const WINDOWS_ABSOLUTE_PATH = /(?:[A-Za-z]:[\\/]|\\\\)[^\s"'()]+/g;
 const POSIX_ABSOLUTE_PATH = /(?<![A-Za-z0-9:/.\\])\/[^\s"'()]+/g;
 
-function rawIriMatchEnd(value: string, matched: string, offset: number): number {
-  const lastCharacter = ReflectApply(StringPrototypeSlice, matched, [-1]) as string;
+function stickyMatchEnd(pattern: RegExp, value: string, offset: number): number {
+  pattern.lastIndex = offset;
+  try {
+    const remainder = ReflectApply(RegExpPrototypeExec, pattern, [value]) as
+      | RegExpExecArray
+      | null;
+    return remainder === null ? offset : pattern.lastIndex;
+  } finally {
+    pattern.lastIndex = 0;
+  }
+}
+
+function rawUrlMatchEnd(value: string, matched: string, offset: number): number {
   const insideQueryOrFragment =
     (ReflectApply(StringPrototypeIncludes, matched, ["?"]) as boolean) ||
     (ReflectApply(StringPrototypeIncludes, matched, ["#"]) as boolean);
-  if (
-    !insideQueryOrFragment &&
-    lastCharacter !== "/" &&
-    lastCharacter !== "?" &&
-    lastCharacter !== "#" &&
-    lastCharacter !== "&" &&
-    lastCharacter !== "="
-  ) {
-    return offset;
+  const lastCharacter = ReflectApply(StringPrototypeSlice, matched, [-1]) as string;
+  const atComponentBoundary = lastCharacter === "/" ||
+    lastCharacter === "?" ||
+    lastCharacter === "#" ||
+    lastCharacter === "&" ||
+    lastCharacter === "=";
+  if (insideQueryOrFragment || atComponentBoundary) {
+    const iriEnd = stickyMatchEnd(RAW_IRI_REMAINDER, value, offset);
+    if (iriEnd !== offset) return iriEnd;
   }
 
-  RAW_IRI_REMAINDER.lastIndex = offset;
-  try {
-    const remainder = ReflectApply(RegExpPrototypeExec, RAW_IRI_REMAINDER, [value]) as
-      | RegExpExecArray
-      | null;
-    return remainder === null ? offset : RAW_IRI_REMAINDER.lastIndex;
-  } finally {
-    RAW_IRI_REMAINDER.lastIndex = 0;
-  }
+  const acceptedEnd = stickyMatchEnd(RAW_ACCEPTED_URL_REMAINDER, value, offset);
+  if (acceptedEnd === offset) return offset;
+  const acceptedRemainder = ReflectApply(StringPrototypeSlice, value, [
+    offset,
+    acceptedEnd,
+  ]) as string;
+  const structurallyDelimited = atComponentBoundary || insideQueryOrFragment ||
+    (ReflectApply(StringPrototypeIncludes, acceptedRemainder, ["/"]) as boolean);
+  return structurallyDelimited ? acceptedEnd : offset;
 }
 
 function replaceMatchesWithCapturedExec(
   value: string,
   pattern: RegExp,
   replacement: string,
-  extendRawIri = false,
+  extendRawUrl = false,
 ): string {
   pattern.lastIndex = 0;
   let output = "";
@@ -2174,7 +2189,7 @@ function replaceMatchesWithCapturedExec(
       if (match === null) break;
       const matched = match[0];
       if (matched.length === 0) throw new TypeError("Diagnostic pattern must make progress");
-      if (extendRawIri) pattern.lastIndex = rawIriMatchEnd(value, matched, pattern.lastIndex);
+      if (extendRawUrl) pattern.lastIndex = rawUrlMatchEnd(value, matched, pattern.lastIndex);
       output += ReflectApply(StringPrototypeSlice, value, [offset, match.index]) as string;
       output += replacement;
       offset = pattern.lastIndex;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1990,11 +1990,8 @@ const SCHEME_URL = new RegExp(
 // Unicode after the first slash does not match this fallback. The normal rule
 // handles that shape and preserves the following prose, which is the no-space
 // boundary this fallback must not undo.
-const NON_ASCII_AUTHORITY_URL = new RegExp(
-  String
-    .raw`[A-Za-z][A-Za-z0-9+.-]{1,31}://(?:[^\s"/]{0,512}@)?(?=[^\s"/]{0,512}[^\x00-\x7F])[^\s"']*`,
-  "gu",
-);
+const NON_ASCII_AUTHORITY_URL =
+  /[A-Za-z][A-Za-z0-9+.-]{1,31}:\/\/(?:[^\s"/]{0,512}@)?(?=[^\s"/]{0,512}[\u0080-\u{10FFFF}])[^\s"']*/gu;
 // Raw Unicode at the start of a slash-delimited path segment is part of an IRI,
 // rather than prose glued to the preceding ASCII segment. Match the complete
 // whitespace-delimited token in that unambiguous case. Requiring the segment
@@ -2007,8 +2004,7 @@ const NON_ASCII_URL_PATH = new RegExp(
 // Avoid a second generic scheme scan for ordinary ASCII diagnostics. Without
 // this gate, the long-alphabetic quadratic guard reached its unchanged 20x
 // limit even though the fallback could not match.
-// deno-lint-ignore no-control-regex
-const NON_ASCII_CHARACTER = /[^\x00-\x7F]/u;
+const NON_ASCII_CHARACTER = /[\u0080-\u{10FFFF}]/u;
 // A sticky continuation used only when an ASCII URL match ends on a structural
 // component delimiter. In that position a following non-ASCII character is a
 // raw IRI path, query, or fragment rather than prose glued after a completed

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1962,12 +1962,44 @@ const CSI_GLUED_URL =
 // Keep this source shared by every URL shape. Apart from preventing the four
 // redactors from drifting, the extraction keeps each complete expression below
 // the static-analysis complexity threshold.
+//
+// An RFC 3986 URI is ASCII before percent-encoding. Defining the token from
+// that legal set makes any non-ASCII character after a completed ASCII prefix
+// a boundary, including scripts that do not put spaces between a URL and the
+// following sentence. A percent-encoded equivalent stays entirely inside the
+// token.
+//
+// Apostrophes are intentionally absent even though RFC 3986 lists them as a
+// sub-delimiter. The userinfo prefix handles them before `@`, while the tail
+// must leave the closing quote in `Cannot find module 'https://host/x'` intact.
+const URI_TOKEN_CHARACTER_SOURCE = String.raw`[A-Za-z0-9\-._~:/?#\[\]@!$&*+,;=%]`;
+const URI_PAREN_INTERIOR_SOURCE = String.raw`[A-Za-z0-9\-._~:/?#\[\]@!$&()*+,;=%]`;
 const URL_TOKEN_TAIL_SOURCE = String
-  .raw`(?:[^\s"'()]|\([^\s"']{0,512}\)|\((?=[^\s"'])|\)(?![\p{P}\p{S}\p{M}\p{Cf}]{0,16}(?:[\s"']|$)))+`;
+  .raw`(?:${URI_TOKEN_CHARACTER_SOURCE}|\(${URI_PAREN_INTERIOR_SOURCE}{0,512}\)|\((?=${URI_PAREN_INTERIOR_SOURCE})|\)(?=${URI_PAREN_INTERIOR_SOURCE})(?![\p{P}\p{S}\p{M}\p{Cf}]{0,16}(?:[\s"']|$)))+`;
 const SCHEME_URL = new RegExp(
   String.raw`[A-Za-z][A-Za-z0-9+.-]{1,31}://(?:[^\s"/]{0,512}@)?${URL_TOKEN_TAIL_SOURCE}`,
   "gu",
 );
+// The ASCII-tail rule above deliberately ends before raw IRI characters. If
+// the authority itself starts with one, however, there is no completed ASCII
+// host prefix for that rule to redact. Fail closed on the whitespace-delimited
+// token so an internationalized hostname cannot fall through to the path
+// passes and reach the diagnostic. This runs after the file-URL pass, which
+// keeps local file URLs classified as paths.
+//
+// An ASCII authority followed by Unicode does not match this fallback. The
+// normal rule handles that shape and preserves the following prose, which is
+// the no-space boundary this fallback must not undo.
+const NON_ASCII_AUTHORITY_URL = new RegExp(
+  String.raw`[A-Za-z][A-Za-z0-9+.-]{1,31}://(?:[^\s"/]{0,512}@)?[^\x00-\x7F][^\s"']*`,
+  "gu",
+);
+// Avoid a second generic scheme scan for ordinary ASCII diagnostics. Without
+// this gate, the long-alphabetic quadratic guard reached its unchanged 20x
+// limit even though the fallback could not match.
+// deno-lint-ignore no-control-regex
+const NON_ASCII_CHARACTER = /[^\x00-\x7F]/u;
+
 // Both the userinfo run and the parenthesised interior are length-bounded, and
 // the userinfo run also stops at `/`. Neither bound is cosmetic. An unbounded
 // greedy interior rescans the rest of the message from every `(` that never
@@ -2075,6 +2107,10 @@ function replaceMatchesWithCapturedExec(
   }
 }
 
+function containsNonAscii(value: string): boolean {
+  return ReflectApply(RegExpPrototypeExec, NON_ASCII_CHARACTER, [value]) !== null;
+}
+
 /**
  * Replace machine-identifying locations in a diagnostic with stable markers.
  *
@@ -2084,10 +2120,10 @@ function replaceMatchesWithCapturedExec(
  *
  * 1. the quoted forms, whose surrounding quotes bound the match precisely;
  * 2. `file:///`, which is a path wearing a URL and is reported as `[path]`;
- * 3. `SCHEME_URL`, then `MALFORMED_SCHEME_URL`, each reported as `[url]` --
- *    together these are also what keep `https:/` away from step 4, whose
- *    drive-letter alternative would otherwise match the `s:/` inside it and
- *    emit `http[path]`;
+ * 3. the non-ASCII-authority fallback, then `SCHEME_URL` and
+ *    `MALFORMED_SCHEME_URL`, each reported as `[url]` -- together these are
+ *    also what keep `https:/` away from step 4, whose drive-letter alternative
+ *    would otherwise match the `s:/` inside it and emit `http[path]`;
  * 4. unquoted Windows drive and UNC paths;
  * 5. unquoted POSIX paths.
  *
@@ -2105,6 +2141,9 @@ function redactMachinePaths(value: string): string {
   let redacted = replaceMatchesWithCapturedExec(value, QUOTED_WINDOWS_ABSOLUTE_PATH, "[path]");
   redacted = replaceMatchesWithCapturedExec(redacted, QUOTED_POSIX_ABSOLUTE_PATH, "[path]");
   redacted = replaceMatchesWithCapturedExec(redacted, FILE_URL_ABSOLUTE_PATH, "[path]");
+  if (containsNonAscii(redacted)) {
+    redacted = replaceMatchesWithCapturedExec(redacted, NON_ASCII_AUTHORITY_URL, "[url]");
+  }
   redacted = replaceMatchesWithCapturedExec(redacted, SCHEME_URL, "[url]");
   redacted = replaceMatchesWithCapturedExec(redacted, MALFORMED_SCHEME_URL, "[url]");
   redacted = replaceMatchesWithCapturedExec(redacted, ZERO_SLASH_SCHEME_URL, "[url]");

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1981,17 +1981,18 @@ const SCHEME_URL = new RegExp(
   "gu",
 );
 // The ASCII-tail rule above deliberately ends before raw IRI characters. If
-// the authority itself starts with one, however, there is no completed ASCII
-// host prefix for that rule to redact. Fail closed on the whitespace-delimited
-// token so an internationalized hostname cannot fall through to the path
-// passes and reach the diagnostic. This runs after the file-URL pass, which
-// keeps local file URLs classified as paths.
+// the authority itself contains one, however, the completed ASCII prefix is
+// not the complete host. Fail closed on the whitespace-delimited token so an
+// internationalized hostname cannot fall through to the path passes and reach
+// the diagnostic. This runs after the file-URL pass, which keeps local file
+// URLs classified as paths.
 //
-// An ASCII authority followed by Unicode does not match this fallback. The
-// normal rule handles that shape and preserves the following prose, which is
-// the no-space boundary this fallback must not undo.
+// Unicode after the first slash does not match this fallback. The normal rule
+// handles that shape and preserves the following prose, which is the no-space
+// boundary this fallback must not undo.
 const NON_ASCII_AUTHORITY_URL = new RegExp(
-  String.raw`[A-Za-z][A-Za-z0-9+.-]{1,31}://(?:[^\s"/]{0,512}@)?[^\x00-\x7F][^\s"']*`,
+  String
+    .raw`[A-Za-z][A-Za-z0-9+.-]{1,31}://(?:[^\s"/]{0,512}@)?(?=[^\s"/]{0,512}[^\x00-\x7F])[^\s"']*`,
   "gu",
 );
 // Avoid a second generic scheme scan for ordinary ASCII diagnostics. Without

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2072,10 +2072,21 @@ const ZERO_SLASH_SCHEME_URL = new RegExp(
   String.raw`${ASCII_SPECIAL_SCHEME_SOURCE}:(?![/\s])(?:[^\s"/]{0,512}@)?${URL_TOKEN_TAIL_SOURCE}`,
   "gu",
 );
-// The IRI fallbacks mirror the two-slash forms above. The authority matcher
-// catches a raw Unicode hostname, while the path matcher catches a raw Unicode
-// segment after a complete ASCII authority. Both are bounded before the first
-// non-ASCII character so hostile diagnostics remain linear-time.
+// The IRI fallbacks mirror the malformed single-slash and zero-slash forms
+// above. Each authority matcher catches a raw Unicode hostname, while each path
+// matcher catches a raw Unicode segment after a complete ASCII authority. All
+// are bounded before the first non-ASCII character so hostile diagnostics
+// remain linear-time.
+const NON_ASCII_MALFORMED_AUTHORITY_URL = new RegExp(
+  String
+    .raw`${ASCII_SPECIAL_SCHEME_SOURCE}:/(?!/)(?:[^\s"/]{0,512}@)?(?=[^\s"/]{0,512}[^\x00-\x7F])[^\s"']*`,
+  "gu",
+);
+const NON_ASCII_MALFORMED_URL_PATH = new RegExp(
+  String
+    .raw`${ASCII_SPECIAL_SCHEME_SOURCE}:/(?!/)(?:[^\s"/]{0,512}@)?[^\s"/]{1,512}(?:/${URI_TOKEN_CHARACTER_SOURCE}{0,2048})?/(?=[^\x00-\x7F])[^\s"']*`,
+  "gu",
+);
 const NON_ASCII_ZERO_SLASH_AUTHORITY_URL = new RegExp(
   String
     .raw`${ASCII_SPECIAL_SCHEME_SOURCE}:(?![/\s])(?:[^\s"/]{0,512}@)?(?=[^\s"/]{0,512}[^\x00-\x7F])[^\s"']*`,
@@ -2180,6 +2191,12 @@ function redactMachinePaths(value: string): string {
   if (containsNonAscii(redacted)) {
     redacted = replaceMatchesWithCapturedExec(redacted, NON_ASCII_AUTHORITY_URL, "[url]");
     redacted = replaceMatchesWithCapturedExec(redacted, NON_ASCII_URL_PATH, "[url]");
+    redacted = replaceMatchesWithCapturedExec(
+      redacted,
+      NON_ASCII_MALFORMED_AUTHORITY_URL,
+      "[url]",
+    );
+    redacted = replaceMatchesWithCapturedExec(redacted, NON_ASCII_MALFORMED_URL_PATH, "[url]");
     redacted = replaceMatchesWithCapturedExec(
       redacted,
       NON_ASCII_ZERO_SLASH_AUTHORITY_URL,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1995,6 +1995,15 @@ const NON_ASCII_AUTHORITY_URL = new RegExp(
     .raw`[A-Za-z][A-Za-z0-9+.-]{1,31}://(?:[^\s"/]{0,512}@)?(?=[^\s"/]{0,512}[^\x00-\x7F])[^\s"']*`,
   "gu",
 );
+// Raw Unicode at the start of a slash-delimited path segment is part of an IRI,
+// rather than prose glued to the preceding ASCII segment. Match the complete
+// whitespace-delimited token in that unambiguous case. Requiring the segment
+// boundary preserves `https://host/x次を試す` as `[url]次を試す`.
+const NON_ASCII_URL_PATH = new RegExp(
+  String
+    .raw`[A-Za-z][A-Za-z0-9+.-]{1,31}://(?:[^\s"/]{0,512}@)?[^\s"/]{1,512}(?:/${URI_TOKEN_CHARACTER_SOURCE}{0,2048})?/(?=[^\x00-\x7F])[^\s"']*`,
+  "gu",
+);
 // Avoid a second generic scheme scan for ordinary ASCII diagnostics. Without
 // this gate, the long-alphabetic quadratic guard reached its unchanged 20x
 // limit even though the fallback could not match.
@@ -2063,6 +2072,20 @@ const ZERO_SLASH_SCHEME_URL = new RegExp(
   String.raw`${ASCII_SPECIAL_SCHEME_SOURCE}:(?![/\s])(?:[^\s"/]{0,512}@)?${URL_TOKEN_TAIL_SOURCE}`,
   "gu",
 );
+// The IRI fallbacks mirror the two-slash forms above. The authority matcher
+// catches a raw Unicode hostname, while the path matcher catches a raw Unicode
+// segment after a complete ASCII authority. Both are bounded before the first
+// non-ASCII character so hostile diagnostics remain linear-time.
+const NON_ASCII_ZERO_SLASH_AUTHORITY_URL = new RegExp(
+  String
+    .raw`${ASCII_SPECIAL_SCHEME_SOURCE}:(?![/\s])(?:[^\s"/]{0,512}@)?(?=[^\s"/]{0,512}[^\x00-\x7F])[^\s"']*`,
+  "gu",
+);
+const NON_ASCII_ZERO_SLASH_URL_PATH = new RegExp(
+  String
+    .raw`${ASCII_SPECIAL_SCHEME_SOURCE}:(?![/\s])(?:[^\s"/]{0,512}@)?[^\s"/]{1,512}(?:/${URI_TOKEN_CHARACTER_SOURCE}{0,2048})?/(?=[^\x00-\x7F])[^\s"']*`,
+  "gu",
+);
 const QUOTED_WINDOWS_ABSOLUTE_PATH = /(?<=["'])(?:[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+(?=["'])/g;
 const QUOTED_POSIX_ABSOLUTE_PATH = /(?<=["'])\/[^"'\r\n]+(?=["'])/g;
 // Case-insensitive for the same reason. `FILE:///home/alice` otherwise fell
@@ -2071,6 +2094,14 @@ const QUOTED_POSIX_ABSOLUTE_PATH = /(?<=["'])\/[^"'\r\n]+(?=["'])/g;
 // remote URL, which is this PR's original misclassification running backwards.
 const FILE_URL_ABSOLUTE_PATH = new RegExp(
   `file:///${URL_TOKEN_TAIL_SOURCE}`,
+  "giu",
+);
+// Run before FILE_URL_ABSOLUTE_PATH. That ASCII matcher intentionally stops at
+// raw Unicode, but replacing only its prefix would expose a later IRI segment.
+// As with NON_ASCII_URL_PATH, the segment boundary distinguishes path data from
+// prose glued directly to an ASCII filename.
+const NON_ASCII_FILE_URL_PATH = new RegExp(
+  String.raw`file:///(?:${URI_TOKEN_CHARACTER_SOURCE}{0,2048}/)?(?=[^\x00-\x7F])[^\s"']*`,
   "giu",
 );
 // Unanchored on the left. A boundary here refuses a path glued to preceding
@@ -2120,8 +2151,9 @@ function containsNonAscii(value: string): boolean {
  * one away from text it would mis-read:
  *
  * 1. the quoted forms, whose surrounding quotes bound the match precisely;
- * 2. `file:///`, which is a path wearing a URL and is reported as `[path]`;
- * 3. the non-ASCII-authority fallback, then `SCHEME_URL` and
+ * 2. `file:///`, including its unambiguous raw-IRI path form, which is a path
+ *    wearing a URL and is reported as `[path]`;
+ * 3. the non-ASCII authority and path fallbacks, then `SCHEME_URL` and
  *    `MALFORMED_SCHEME_URL`, each reported as `[url]` -- together these are
  *    also what keep `https:/` away from step 4, whose drive-letter alternative
  *    would otherwise match the `s:/` inside it and emit `http[path]`;
@@ -2141,9 +2173,19 @@ function containsNonAscii(value: string): boolean {
 function redactMachinePaths(value: string): string {
   let redacted = replaceMatchesWithCapturedExec(value, QUOTED_WINDOWS_ABSOLUTE_PATH, "[path]");
   redacted = replaceMatchesWithCapturedExec(redacted, QUOTED_POSIX_ABSOLUTE_PATH, "[path]");
+  if (containsNonAscii(redacted)) {
+    redacted = replaceMatchesWithCapturedExec(redacted, NON_ASCII_FILE_URL_PATH, "[path]");
+  }
   redacted = replaceMatchesWithCapturedExec(redacted, FILE_URL_ABSOLUTE_PATH, "[path]");
   if (containsNonAscii(redacted)) {
     redacted = replaceMatchesWithCapturedExec(redacted, NON_ASCII_AUTHORITY_URL, "[url]");
+    redacted = replaceMatchesWithCapturedExec(redacted, NON_ASCII_URL_PATH, "[url]");
+    redacted = replaceMatchesWithCapturedExec(
+      redacted,
+      NON_ASCII_ZERO_SLASH_AUTHORITY_URL,
+      "[url]",
+    );
+    redacted = replaceMatchesWithCapturedExec(redacted, NON_ASCII_ZERO_SLASH_URL_PATH, "[url]");
   }
   redacted = replaceMatchesWithCapturedExec(redacted, SCHEME_URL, "[url]");
   redacted = replaceMatchesWithCapturedExec(redacted, MALFORMED_SCHEME_URL, "[url]");


### PR DESCRIPTION
## Description

Define config-loader URL tails from the RFC 3986 unencoded ASCII character set so non-ASCII prose can follow a redacted URL without whitespace. Keep the existing bounded parenthesis handling and require a URI-legal next character before a lone closing parenthesis continues the token.

Keep percent-encoded URLs inside the token. Add a bounded fail-closed fallback for non-ASCII authorities so internationalized hostnames do not leak when no ASCII host prefix can be redacted. Skip that fallback for ASCII-only diagnostics so both existing quadratic guards retain their unchanged ratio.

## Related issue(s)

Fixes veryfront/veryfront-issue-inbox#860

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Red-green verification

- Red: the updated no-space CJK fixture failed because the sentence was absent.
- Green: both parenthesized and ordinary URL forms retain the glued sentence while redacting the host.
- Red: the raw IRI-host regression failed as http[path], exposing the hostname.
- Green: the bounded non-ASCII-authority fallback emits [url].
- Red during repetition: the extra generic scheme scan hit the existing quadratic limit at 20 ms versus 1 ms.
- Green: the non-ASCII gate preserved the existing 20x threshold across 5 consecutive full loader runs.

## Verification

- deno task test:file src/config/loader.test.ts, 194 steps, 5 consecutive final runs
- deno task test:unit, 4,385 parallel tests plus cwd suites, 0 failures
- deno fmt --check src/config/loader.ts src/config/loader.test.ts
- deno lint src/config/loader.ts src/config/loader.test.ts
- deno check src/config/loader.ts src/config/loader.test.ts
- TEST_SEMANTIC_AUDIT_BASE_REF=origin/main deno task lint:test-semantic-dispositions
- git diff --check

## Checklist

- [x] Documentation is unchanged because this corrects an internal diagnostic redactor.
- [x] Tests cover the behavior, percent-encoding, raw IRI authorities, existing leak shapes, and performance guards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic redaction for URLs and file paths containing Unicode characters.
  * Prevented trailing non-ASCII prose from being incorrectly included in redacted URLs.
  * Added safer handling for internationalized hosts, encoded and raw paths, backslashes, malformed URL formats, and unusually long prefixes.
  * Preserved redaction behavior for the host and ASCII path portions of affected URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->