### PR TITLE
fix(ssr): load preview config under the request environment name

### DIFF
--- a/src/server/runtime-handler/adapter-factory.test.ts
+++ b/src/server/runtime-handler/adapter-factory.test.ts
@@ -804,6 +804,59 @@ describe("adapter-factory", () => {
       ]);
     });
 
+    it("loads preview config under the request environment name", async () => {
+      // The proxy adapter cache key is environment-qualified in preview mode, and every
+      // later request phase re-enters through runInProjectFilesystemContext with
+      // ctx.environmentName. Loading config without it selects a SECOND concrete adapter
+      // whose per-instance snapshot generation can never match the config-bound marker,
+      // so every preview document request fails with
+      // "the mutable source snapshot ... changed after request configuration was derived"
+      // (veryfront-issue-inbox#861). The preview source context carries no environment
+      // name, so it must come from the resolution options.
+      const { adapter, calls } = createExtendedMockAdapter();
+      // A snapshot-capable adapter, so the strict preview config path runs to completion
+      // rather than stopping earlier on a missing marker.
+      const fs = (adapter as unknown as { fs: Record<string, unknown> }).fs;
+      fs.getSourceSnapshotIdentity = () => "branch:preview-slug:main";
+      fs.getSourceSnapshotVersion = () => 7;
+      fs.ensureSourceSnapshotFresh = () => Promise.resolve();
+      fs.refreshSourceSnapshot = () => Promise.resolve();
+      fs.sourceSnapshotFreshnessOptionsVersion = 1;
+
+      await resolveAdapter({
+        projectDir: "/base/project",
+        adapter,
+        config: undefined,
+        projectSlug: "preview-slug",
+        projectId: "proj_preview",
+        proxyToken: "tok-123",
+        releaseId: undefined,
+        proxyEnv: "preview",
+        branch: "main",
+        environmentName: "preview",
+        parsedDomain: {
+          slug: null,
+          branch: null,
+          environment: null,
+          isVeryfrontDomain: false,
+          isDraft: false,
+          allowIframeEmbed: false,
+        },
+        req: await makeReq(),
+        isProxyMode: true,
+        prepareHostedConfigContext: preparePreviewHostedConfigContext,
+      });
+
+      const opts = (calls.runWithContext ?? [])[3] as
+        | { environmentName?: string | null }
+        | undefined;
+      assertEquals(
+        opts?.environmentName,
+        "preview",
+        "config must load under the same environment every later phase uses, or the request resolves two adapters",
+      );
+    });
+
     it("refreshes mutable source before config for document and HEAD Markdown routes", async () => {
       let sourceFresh = false;
       const freshnessCalls: Array<{ reason?: string; maxAgeMs?: number }> = [];

--- a/src/server/runtime-handler/adapter-factory.ts
+++ b/src/server/runtime-handler/adapter-factory.ts
@@ -573,7 +573,14 @@ export async function resolveAdapter(
               productionMode: hosted.sourceContext.productionMode,
               releaseId: hosted.sourceContext.releaseId,
               branch: hosted.sourceContext.branch,
-              environmentName: hosted.sourceContext.environmentName,
+              // The proxy adapter cache key is environment-qualified in preview mode,
+              // so this must be the same value every later request phase passes through
+              // runInProjectFilesystemContext. The preview source context carries no
+              // environment name, and reading only it selected a second concrete adapter
+              // whose per-instance snapshot generation could never match the
+              // config-bound marker (veryfront-issue-inbox#861).
+              environmentName: hosted.sourceContext.environmentName ??
+                opts.environmentName ?? null,
             },
           );
         }


### PR DESCRIPTION
Fixes veryfront/veryfront-issue-inbox#861 — every preview document request on staging returns 503.

## Root cause

One preview request resolves **two different `VeryfrontFSAdapter` instances**. The source-snapshot generation is per-instance, so the config-bound marker can never match.

| step | |
|---|---|
| 1 | `project-runtime-context.ts:239-243` — the **preview** branch of `sourceContext` is `{ productionMode: false, branch }`, with **no `environmentName`**. The production branch sets it. |
| 2 | `adapter-factory.ts:576` read only that when loading config → `undefined` for preview. |
| 3 | Every later phase re-enters via `project-middleware.ts:87` with `ctx.environmentName ?? null` — the real value, `"preview"`. |
| 4 | `buildProxyManagerCacheKey` appends `:env:<name>` in preview mode **only when truthy** → two manager entries, two adapter objects. |
| 5 | `sourceSnapshotVersion` is a per-instance draw from a global counter → the version seeded from A can never equal the version read from B. |

**Deterministic, not a race.** Which is why #4240's bounded retry did not help — it retried a comparison that cannot succeed.

## Evidence (Grafana Loki, staging `rc.16613`)

```
throwConfigSnapshotChanged            source-snapshot-freshness.ts:302:47
  ← runWithRetainedPreviewDocumentSourceSnapshot   :157:7
  ← multi-project-adapter.ts:280
  ← runInProjectFilesystemContext     project-middleware.ts:78

"The mutable source snapshot serving "test-d60d8eb5" changed after request
 configuration was derived, so this document request must be retried against
 one generation."
```

Three occurrences in 8 minutes. **Identity matched on both sides; only the version differed** — which rules out the undefined-identity hypotheses and points squarely at two instances.

## The change

One line. **The guard is not touched.**

```ts
environmentName: hosted.sourceContext.environmentName ?? opts.environmentName ?? null,
```

`opts.environmentName` is already an `AdapterResolutionOptions` field carrying the same value that becomes `ctx.environmentName`. In production the source context already sets the field, so the fallback is inert and the existing production test passes unchanged.

**Why this direction rather than stripping the environment in the middleware:** the environment-qualified adapter is the one that actually renders the document, so config must be read from *it*, not the reverse.

The guard is correct: it refuses to render a document whose config came from a different generation. The bug was that it was handed two adapters, not that its rule was wrong.

## Verification

Red before green, on the same test:

```
without the fallback:  AssertionError — "config must load under the same environment
                       every later phase uses, or the request resolves two adapters"
with the fallback:     pass
```

It fails on the environment assertion specifically, not incidentally on something else.

Full affected set, all passing:

```
adapter-factory · source-snapshot-freshness · ssr.handler · api-handler-wrapper
markdown-preview.handler · veryfront/adapter · multi-project-adapter · cache-key-builder
deno fmt --check / deno lint / deno check          8/8 pass, gates 0
```

## Expected secondary win

The trace shows the duplicate adapter also re-runs `listAllBranchFiles`, roughly **1.6 s per request**. Collapsing to one adapter should remove that.

## Latent bugs found while investigating, not fixed here

- `adapter.ts:1553` does not `await #ensureInitialized()` the way read methods do, so `getSourceSnapshotIdentity()` can return `undefined` while `contentContext` is null.
- Adapter instance churn under LRU eviction reaches the same mismatch by another route.

Both are reachable and recorded in #861. Neither is what fires here — identity matched on both sides.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed preview configuration loading in proxy mode so requests consistently use the correct environment.
  * Added a fallback for requests where hosted environment information is unavailable, preventing undefined environment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->