### PR TITLE
fix(server): retry cold preview snapshot races

### DIFF
--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -434,11 +434,12 @@ describe("server/runtime-handler/index", () => {
     assertEquals(denied.headers.get("Access-Control-Allow-Credentials"), null);
   });
 
-  it("rejects terminal hosted auth when the config snapshot changes during admission", async () => {
+  it("retries hosted admission when the config snapshot changes", async () => {
     const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
     const originalTrustedProxy = Deno.env.get("VERYFRONT_TRUST_FORWARDED_HEADERS");
     Deno.env.set("VERYFRONT_API_BASE_URL", "https://api.example.test/api");
     Deno.env.set("VERYFRONT_TRUST_FORWARDED_HEADERS", "1");
+    const otelRequests = captureOtelHttpRequestCount();
     let sourceVersion = 1;
     const baseAdapter = createHostedOidcAdapter();
     Object.assign(baseAdapter.fs, {
@@ -513,12 +514,11 @@ describe("server/runtime-handler/index", () => {
           ),
       );
 
-      assertEquals(response.status, 503);
+      assertEquals(response.status, 401);
+      assertEquals(await response.text(), "Unauthorized");
       assertEquals(sourceVersion, 2);
-      assertEquals(
-        (await response.json()).type,
-        "https://veryfront.com/docs/code/guides/errors#source-snapshot-freshness-unavailable",
-      );
+      assertEquals(createSnapshot().requests, 1);
+      assertEquals(otelRequests.count(), 1);
     } finally {
       if (originalApiBaseUrl === undefined) Deno.env.delete("VERYFRONT_API_BASE_URL");
       else Deno.env.set("VERYFRONT_API_BASE_URL", originalApiBaseUrl);

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -434,7 +434,18 @@ describe("server/runtime-handler/index", () => {
     assertEquals(denied.headers.get("Access-Control-Allow-Credentials"), null);
   });
 
-  it("retries hosted admission when the config snapshot changes", async () => {
+  /**
+   * Drive a hosted preview document request whose source generation advances
+   * while the request derives its configuration.
+   *
+   * `advanceSource` decides how the mutable source behaves. A project that was
+   * just created settles once its writes land, while one being rewritten
+   * continuously never does -- and the handler owes those two cases opposite
+   * answers.
+   */
+  async function runHostedAdmissionWithMovingSnapshot(
+    advanceSource: (currentVersion: number) => number,
+  ): Promise<{ response: Response; sourceVersion: number; otelRequestCount: number }> {
     const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
     const originalTrustedProxy = Deno.env.get("VERYFRONT_TRUST_FORWARDED_HEADERS");
     Deno.env.set("VERYFRONT_API_BASE_URL", "https://api.example.test/api");
@@ -471,7 +482,7 @@ describe("server/runtime-handler/index", () => {
       env: {
         ...baseAdapter.env,
         get(key: string) {
-          if (key === "OIDC_ISSUER" && sourceVersion === 1) sourceVersion++;
+          if (key === "OIDC_ISSUER") sourceVersion = advanceSource(sourceVersion);
           return baseAdapter.env.get(key);
         },
       },
@@ -513,12 +524,7 @@ describe("server/runtime-handler/index", () => {
             }),
           ),
       );
-
-      assertEquals(response.status, 401);
-      assertEquals(await response.text(), "Unauthorized");
-      assertEquals(sourceVersion, 2);
-      assertEquals(createSnapshot().requests, 1);
-      assertEquals(otelRequests.count(), 1);
+      return { response, sourceVersion, otelRequestCount: otelRequests.count() };
     } finally {
       if (originalApiBaseUrl === undefined) Deno.env.delete("VERYFRONT_API_BASE_URL");
       else Deno.env.set("VERYFRONT_API_BASE_URL", originalApiBaseUrl);
@@ -528,6 +534,32 @@ describe("server/runtime-handler/index", () => {
         Deno.env.set("VERYFRONT_TRUST_FORWARDED_HEADERS", originalTrustedProxy);
       }
     }
+  }
+
+  it("retries hosted admission when the config snapshot changes", async () => {
+    const { response, sourceVersion, otelRequestCount } =
+      await runHostedAdmissionWithMovingSnapshot((current) => current === 1 ? 2 : current);
+
+    assertEquals(response.status, 401);
+    assertEquals(await response.text(), "Unauthorized");
+    assertEquals(sourceVersion, 2);
+    // One client request counts once, however many generations it straddles.
+    assertEquals(createSnapshot().requests, 1);
+    assertEquals(otelRequestCount, 1);
+  });
+
+  it("rejects terminal hosted auth when the config snapshot never settles", async () => {
+    // The retry exists for a source that settles. One that advances on every
+    // re-derivation is being rewritten continuously, and rendering it would
+    // serve configuration from a generation the markup does not come from --
+    // so the guard must still fail the request closed rather than loop.
+    const { response } = await runHostedAdmissionWithMovingSnapshot((current) => current + 1);
+
+    assertEquals(response.status, 503);
+    assertEquals(
+      (await response.json()).type,
+      "https://veryfront.com/docs/code/guides/errors#source-snapshot-freshness-unavailable",
+    );
   });
 
   it("keeps CORS preflight ahead of application auth admission", async () => {

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -447,6 +447,7 @@ describe("server/runtime-handler/index", () => {
    */
   async function runHostedAdmissionWithMovingSnapshot(
     advanceSource: (currentVersion: number) => number,
+    method: "GET" | "HEAD" = "GET",
   ): Promise<{ response: Response; sourceVersion: number; otelRequestCount: number }> {
     const originalApiBaseUrl = Deno.env.get("VERYFRONT_API_BASE_URL");
     const originalTrustedProxy = Deno.env.get("VERYFRONT_TRUST_FORWARDED_HEADERS");
@@ -515,6 +516,7 @@ describe("server/runtime-handler/index", () => {
         () =>
           handler(
             new Request("https://snapshot-app.example.test/dashboard", {
+              method,
               headers: {
                 "x-project-slug": "snapshot-project",
                 "x-project-id": "project-snapshot",
@@ -562,6 +564,20 @@ describe("server/runtime-handler/index", () => {
       (await response.json()).type,
       "https://veryfront.com/docs/code/guides/errors#source-snapshot-freshness-unavailable",
     );
+  });
+
+  it("retries HEAD admission without adding a response body", async () => {
+    const { response, sourceVersion, otelRequestCount } =
+      await runHostedAdmissionWithMovingSnapshot(
+        (current) => current === 1 ? 2 : current,
+        "HEAD",
+      );
+
+    assertEquals(response.status, 401);
+    assertEquals(await response.text(), "");
+    assertEquals(sourceVersion, 2);
+    assertEquals(createSnapshot().requests, 1);
+    assertEquals(otelRequestCount, 1);
   });
 
   it("does not replay project middleware after a downstream snapshot failure", async () => {

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -5,6 +5,7 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeAdapter, RuntimeId } from "#veryfront/platform/adapters/base.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
+import { SOURCE_SNAPSHOT_FRESHNESS_UNAVAILABLE } from "#veryfront/errors";
 import { DenoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
 import {
   __registerLogRecordEmitter,
@@ -21,6 +22,7 @@ import { recordRequestPeerFromTransport } from "#veryfront/platform/adapters/run
 import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { createMockOidcProvider } from "#veryfront/security/application-auth/mock-oidc-provider.ts";
 import { createSessionCookie } from "#veryfront/security/application-auth/cookies.ts";
+import type { MiddlewareFunction } from "#veryfront/server/dev-server/middleware.ts";
 import {
   createSnapshot,
   resetMetrics,
@@ -560,6 +562,34 @@ describe("server/runtime-handler/index", () => {
       (await response.json()).type,
       "https://veryfront.com/docs/code/guides/errors#source-snapshot-freshness-unavailable",
     );
+  });
+
+  it("does not replay project middleware after a downstream snapshot failure", async () => {
+    const otelRequests = captureOtelHttpRequestCount();
+    let middlewareCalls = 0;
+    const middleware: MiddlewareFunction = async (_context, next) => {
+      middlewareCalls++;
+      await next();
+      throw SOURCE_SNAPSHOT_FRESHNESS_UNAVAILABLE.create({
+        detail: "The source changed after project middleware dispatched the route.",
+      });
+    };
+    const handler = createVeryfrontHandler("/tmp/test-project", createMockAdapter(), {
+      projectDir: "/tmp/test-project",
+      config: {
+        middleware: {
+          custom: [middleware],
+        },
+      } satisfies VeryfrontConfig,
+      allowHostProjectCodeExecution: true,
+    });
+
+    const response = await handler(new Request("http://localhost/dashboard"));
+
+    assertEquals(response.status, 503);
+    assertEquals(middlewareCalls, 1);
+    assertEquals(createSnapshot().requests, 1);
+    assertEquals(otelRequests.count(), 1);
   });
 
   it("keeps CORS preflight ahead of application auth admission", async () => {

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -12,7 +12,13 @@ import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { inheritRequestPeerProvenance } from "#veryfront/platform/adapters/runtime/shared/request-peer.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { getConfig } from "#veryfront/config/loader.ts";
-import { errorToRFC9457Response, getErrorMessage, UNKNOWN_ERROR } from "#veryfront/errors";
+import {
+  errorToRFC9457Response,
+  getErrorMessage,
+  isVeryfrontError,
+  SOURCE_SNAPSHOT_FRESHNESS_UNAVAILABLE,
+  UNKNOWN_ERROR,
+} from "#veryfront/errors";
 import { RouteRegistry } from "#veryfront/routing/registry/index.ts";
 import type { Handler } from "#veryfront/types";
 import { SecurityConfigLoader } from "#veryfront/security/http/config.ts";
@@ -145,6 +151,19 @@ export { parseProxyEnvironment, type ProxyEnvironment } from "./proxy-environmen
 const baseLogger = getBaseLogger("SERVER");
 
 const logger = baseLogger.component("runtime-handler");
+
+const SOURCE_SNAPSHOT_FRESHNESS_RETRY_LIMIT = 1;
+
+function shouldRetrySourceSnapshotFreshness(
+  request: Request,
+  error: unknown,
+  retries: number,
+): boolean {
+  return retries < SOURCE_SNAPSHOT_FRESHNESS_RETRY_LIMIT &&
+    (request.method === "GET" || request.method === "HEAD") &&
+    isVeryfrontError(error) &&
+    error.slug === SOURCE_SNAPSHOT_FRESHNESS_UNAVAILABLE.slug;
+}
 
 function skipsApplicationAuth(request: Request, pathname: string): boolean {
   return request.method === "OPTIONS" ||
@@ -554,7 +573,8 @@ export function createVeryfrontHandler(
           : "html";
         let requestProfileRecord: ReturnType<typeof finalizeRequestProfiling> = null;
 
-        const executeHandler = async (request: Request): Promise<Response> => {
+        let requestMetricsIncremented = false;
+        const executeHandlerAttempt = async (request: Request): Promise<Response> => {
           // Fast rejection of vulnerability scanner probes before any async work
           if (SCANNER_PATH_PATTERN.test(url.pathname)) {
             return new Response("Not Found", { status: 404 });
@@ -668,7 +688,10 @@ export function createVeryfrontHandler(
               ? operation()
               : runWithProjectEnv(isolatedEnvForRequest, operation);
 
-          await incrementRequestMetrics();
+          if (!requestMetricsIncremented) {
+            await incrementRequestMetrics();
+            requestMetricsIncremented = true;
+          }
 
           if (!skipsApplicationAuth(request, url.pathname)) {
             const runInFilesystemContext = <T>(operation: () => Promise<T>) =>
@@ -743,6 +766,26 @@ export function createVeryfrontHandler(
             instance: url.pathname,
           });
           return errorToRFC9457Response(noHandlerError, ctx, request);
+        };
+
+        const executeHandler = async (request: Request): Promise<Response> => {
+          let retries = 0;
+          while (true) {
+            try {
+              return await executeHandlerAttempt(request);
+            } catch (error) {
+              if (!shouldRetrySourceSnapshotFreshness(request, error, retries)) throw error;
+              retries++;
+              logDebug(
+                "[runtime-handler] Retrying request after source snapshot freshness failure",
+                {
+                  path: url.pathname,
+                  method: request.method,
+                  retry: retries,
+                },
+              );
+            }
+          }
         };
 
         const { response, error, settled } = await withRequestTimeout(

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -158,8 +158,10 @@ function shouldRetrySourceSnapshotFreshness(
   request: Request,
   error: unknown,
   retries: number,
+  projectMiddlewareStarted: boolean,
 ): boolean {
   return retries < SOURCE_SNAPSHOT_FRESHNESS_RETRY_LIMIT &&
+    !projectMiddlewareStarted &&
     (request.method === "GET" || request.method === "HEAD") &&
     isVeryfrontError(error) &&
     error.slug === SOURCE_SNAPSHOT_FRESHNESS_UNAVAILABLE.slug;
@@ -574,6 +576,7 @@ export function createVeryfrontHandler(
         let requestProfileRecord: ReturnType<typeof finalizeRequestProfiling> = null;
 
         let requestMetricsIncremented = false;
+        let projectMiddlewareStarted = false;
         const executeHandlerAttempt = async (request: Request): Promise<Response> => {
           // Fast rejection of vulnerability scanner probes before any async work
           if (SCANNER_PATH_PATTERN.test(url.pathname)) {
@@ -736,6 +739,9 @@ export function createVeryfrontHandler(
               handlerContext: ctx,
               isSharedProxy: isProxyMode,
               next: async () => (await registry.execute(request, ctx)) ?? undefined,
+              onMiddlewareStart: () => {
+                projectMiddlewareStarted = true;
+              },
             });
           const executeRoute = () =>
             runWithExactSourceIntegrationPolicy(
@@ -774,7 +780,14 @@ export function createVeryfrontHandler(
             try {
               return await executeHandlerAttempt(request);
             } catch (error) {
-              if (!shouldRetrySourceSnapshotFreshness(request, error, retries)) throw error;
+              if (
+                !shouldRetrySourceSnapshotFreshness(
+                  request,
+                  error,
+                  retries,
+                  projectMiddlewareStarted,
+                )
+              ) throw error;
               retries++;
               // Info, not debug: a retried request is indistinguishable from a
               // first-attempt success in the response, so this line is the only

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -577,6 +577,9 @@ export function createVeryfrontHandler(
 
         let requestMetricsIncremented = false;
         let projectMiddlewareStarted = false;
+        const markProjectMiddlewareStarted = () => {
+          projectMiddlewareStarted = true;
+        };
         const executeHandlerAttempt = async (request: Request): Promise<Response> => {
           // Fast rejection of vulnerability scanner probes before any async work
           if (SCANNER_PATH_PATTERN.test(url.pathname)) {
@@ -739,9 +742,7 @@ export function createVeryfrontHandler(
               handlerContext: ctx,
               isSharedProxy: isProxyMode,
               next: async () => (await registry.execute(request, ctx)) ?? undefined,
-              onMiddlewareStart: () => {
-                projectMiddlewareStarted = true;
-              },
+              onMiddlewareStart: markProjectMiddlewareStarted,
             });
           const executeRoute = () =>
             runWithExactSourceIntegrationPolicy(

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -776,14 +776,14 @@ export function createVeryfrontHandler(
             } catch (error) {
               if (!shouldRetrySourceSnapshotFreshness(request, error, retries)) throw error;
               retries++;
-              logDebug(
-                "[runtime-handler] Retrying request after source snapshot freshness failure",
-                {
-                  path: url.pathname,
-                  method: request.method,
-                  retry: retries,
-                },
-              );
+              // Info, not debug: a retried request is indistinguishable from a
+              // first-attempt success in the response, so this line is the only
+              // way to confirm in staging that the retry is carrying the load.
+              logger.info("Retrying request after source snapshot freshness failure", {
+                pathname: url.pathname,
+                method: request.method,
+                retry: retries,
+              });
             }
           }
         };

--- a/src/server/runtime-handler/project-middleware.ts
+++ b/src/server/runtime-handler/project-middleware.ts
@@ -46,6 +46,8 @@ export interface ProjectMiddlewareRuntimeContext {
   handlerContext: HandlerContext;
   isSharedProxy: boolean;
   next: () => Promise<Response | undefined>;
+  /** Signals before project middleware can perform request-scoped side effects. */
+  onMiddlewareStart?: () => void;
 }
 
 function cacheSegment(value: string): string {
@@ -131,7 +133,7 @@ export class ProjectMiddlewareRuntime {
   }
 
   async execute(input: ProjectMiddlewareRuntimeContext): Promise<Response | undefined> {
-    const { handlerContext: ctx, isSharedProxy, next, request } = input;
+    const { handlerContext: ctx, isSharedProxy, next, onMiddlewareStart, request } = input;
     const pathname = new URL(request.url).pathname;
 
     if (isWebSocketPath(pathname)) {
@@ -232,6 +234,7 @@ export class ProjectMiddlewareRuntime {
         });
       }
       if (middleware.length === 0) return next();
+      onMiddlewareStart?.();
 
       const pipeline = new MiddlewarePipeline();
       for (const handler of middleware) pipeline.use(handler);


### PR DESCRIPTION
## Description

Cold preview GET/HEAD requests can advance mutable source from the generation used to derive request configuration before application admission or document dispatch. The strict snapshot guard correctly rejects that mixed-generation render, but the request handler previously surfaced the retryable condition as a 503.

Retry the complete project-resolution attempt once for `source-snapshot-freshness-unavailable`, re-deriving config and handler context against the new generation. The retry is limited to idempotent GET/HEAD requests. Request metrics are guarded so the logical request is counted once across both attempts.

The regression test advances the source generation during hosted admission and verifies the request continues normally after re-resolution while both internal and OTel request counters remain one.

## Related Issue(s)

Closes veryfront/veryfront-issue-inbox#863

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Verification

- `deno task test:file src/server/runtime-handler/index.test.ts`
- `deno task test:file src/server/handlers/request/source-snapshot-freshness.test.ts`
- `deno check src/server/runtime-handler/index.ts src/server/runtime-handler/index.test.ts`
- `deno lint src/server/runtime-handler/index.ts src/server/runtime-handler/index.test.ts`
- `deno fmt --check src/server/runtime-handler/index.ts src/server/runtime-handler/index.test.ts`
- `deno task lint:style`
- `deno task lint:test-semantic-dispositions`
- `deno task lint:anti-slop`

Pre-fix staging reproduction: veryfront/veryfront-e2e Actions run 33053634708 reproduced the same cold-preview 503.

## Checklist

- [x] I have made corresponding changes to the documentation (not applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests now retry once when a source snapshot becomes outdated before project middleware starts.
  * Requests return a service-unavailable response when snapshot freshness cannot be established.
  * Prevented retries after middleware execution begins, avoiding duplicate side effects.
  * Improved request and telemetry metric accuracy during retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->