### PR TITLE
Retry transient GitHub release asset uploads

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1212,31 +1212,29 @@ jobs:
           GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
         run: |
           # Collect available binaries dynamically (Windows build is optional)
-          BINARIES=""
+          BINARIES=()
           for f in binaries/veryfront-*/veryfront-*; do
-            [ -f "$f" ] && BINARIES="$BINARIES $f"
+            [ -f "$f" ] && BINARIES+=("$f")
           done
-          SBOMS=""
+          SBOMS=()
           for f in dist/sbom-${VERSION}/*.json; do
-            [ -f "$f" ] && SBOMS="$SBOMS $f"
+            [ -f "$f" ] && SBOMS+=("$f")
           done
-          echo "Available binaries: $BINARIES"
-          echo "Available SBOMs: $SBOMS"
+          echo "Available binaries: ${BINARIES[*]}"
+          echo "Available SBOMs: ${SBOMS[*]}"
 
-          # Delete previous rc release if it exists (from earlier merge)
-          gh release delete "v${VERSION}" --repo veryfront/veryfront --yes --cleanup-tag 2>/dev/null || true
-
-          # Public repo pre-release
-          gh release create "v${VERSION}" \
+          bash scripts/ci/publish-github-release.sh \
             --repo veryfront/veryfront \
+            --tag "v${VERSION}" \
             --title "v${VERSION}" \
-            --prerelease \
             --notes '```bash
           npx veryfront@rc
           ```' \
-            $BINARIES \
+            --prerelease \
+            -- \
+            "${BINARIES[@]}" \
             scripts/install.sh \
-            $SBOMS
+            "${SBOMS[@]}"
 
   # ============================================
   # CD: Stable Release (clean semver only)
@@ -1370,16 +1368,16 @@ jobs:
           GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
         run: |
           # Collect available binaries dynamically (Windows build is optional)
-          BINARIES=""
+          BINARIES=()
           for f in binaries/veryfront-*/veryfront-*; do
-            [ -f "$f" ] && BINARIES="$BINARIES $f"
+            [ -f "$f" ] && BINARIES+=("$f")
           done
-          SBOMS=""
+          SBOMS=()
           for f in dist/sbom-${VERSION}/*.json; do
-            [ -f "$f" ] && SBOMS="$SBOMS $f"
+            [ -f "$f" ] && SBOMS+=("$f")
           done
-          echo "Available binaries: $BINARIES"
-          echo "Available SBOMs: $SBOMS"
+          echo "Available binaries: ${BINARIES[*]}"
+          echo "Available SBOMs: ${SBOMS[*]}"
 
           # Publish a checksum manifest alongside the assets. install.sh verifies a
           # downloaded binary against this before moving it into place, so the
@@ -1387,7 +1385,7 @@ jobs:
           # not the artifact paths they were downloaded to.
           SUMS_FILE="SHA256SUMS"
           : > "$SUMS_FILE"
-          for f in $BINARIES scripts/install.sh scripts/install.ps1; do
+          for f in "${BINARIES[@]}" scripts/install.sh scripts/install.ps1; do
             [ -f "$f" ] || continue
             sha256sum "$f" | sed "s#  .*/#  #" >> "$SUMS_FILE"
           done
@@ -1399,9 +1397,9 @@ jobs:
             | grep "^v${VERSION}-rc\." \
             | xargs -I{} gh release delete {} --repo veryfront/veryfront --yes --cleanup-tag 2>/dev/null || true
 
-          # Public repo release with binaries and install scripts
-          gh release create "v${VERSION}" \
+          bash scripts/ci/publish-github-release.sh \
             --repo veryfront/veryfront \
+            --tag "v${VERSION}" \
             --title "v${VERSION}" \
             --notes '## Install
 
@@ -1412,11 +1410,13 @@ jobs:
           # npm
           npm install -g veryfront
           ```' \
-            $BINARIES \
+            --latest \
+            -- \
+            "${BINARIES[@]}" \
             "$SUMS_FILE" \
             scripts/install.sh \
             scripts/install.ps1 \
-            $SBOMS
+            "${SBOMS[@]}"
 
       - name: Create source repo release
         env:

--- a/scripts/ci/publish-github-release.sh
+++ b/scripts/ci/publish-github-release.sh
@@ -125,6 +125,19 @@ delete_release() {
 }
 
 create_draft_release() {
+  local existing_is_draft
+  if existing_is_draft="$(
+    gh release view "$tag" --repo "$repo" --json isDraft --jq '.isDraft' 2>/dev/null
+  )"; then
+    if [ "$existing_is_draft" = true ]; then
+      echo "::warning::Reusing existing GitHub release draft ${tag}." >&2
+      return 0
+    fi
+
+    echo "::error::GitHub release ${tag} already exists and is not a draft." >&2
+    return 1
+  fi
+
   local create_args=(
     release create "$tag"
     --repo "$repo"

--- a/scripts/ci/publish-github-release.sh
+++ b/scripts/ci/publish-github-release.sh
@@ -102,6 +102,11 @@ fi
 run_with_retry() {
   local description="$1"
   shift
+  local fatal_status=""
+  if [[ "${1:-}" == "--fatal-status" ]]; then
+    fatal_status="$2"
+    shift 2
+  fi
   local attempt=1
   local status
 
@@ -111,7 +116,7 @@ run_with_retry() {
     else
       status="$?"
     fi
-    if [[ "$status" -eq "$retry_fatal_status" ]]; then
+    if [[ -n "$fatal_status" && "$status" -eq "$fatal_status" ]]; then
       return 1
     fi
     if [[ "$attempt" -ge "$retry_attempts" ]]; then
@@ -171,7 +176,10 @@ cleanup_failed_release() {
 }
 trap cleanup_failed_release EXIT
 
-run_with_retry "GitHub release draft creation" create_draft_release
+run_with_retry \
+  "GitHub release draft creation" \
+  --fatal-status "$retry_fatal_status" \
+  create_draft_release
 incomplete_draft_created=true
 
 for asset in "${assets[@]}"; do

--- a/scripts/ci/publish-github-release.sh
+++ b/scripts/ci/publish-github-release.sh
@@ -136,15 +136,14 @@ create_draft_release() {
     create_args+=(--prerelease)
   fi
 
-  delete_release
   gh "${create_args[@]}"
 }
 
-draft_created=false
+incomplete_draft_created=false
 cleanup_failed_release() {
   local status="$?"
   trap - EXIT
-  if [ "$status" -ne 0 ] && [ "$draft_created" = true ]; then
+  if [ "$status" -ne 0 ] && [ "$incomplete_draft_created" = true ]; then
     echo "::warning::Removing incomplete GitHub release ${tag}." >&2
     delete_release
   fi
@@ -153,13 +152,14 @@ cleanup_failed_release() {
 trap cleanup_failed_release EXIT
 
 run_with_retry "GitHub release draft creation" create_draft_release
-draft_created=true
+incomplete_draft_created=true
 
 for asset in "${assets[@]}"; do
   run_with_retry \
     "GitHub release asset $(basename "$asset") upload" \
     gh release upload "$tag" "$asset" --repo "$repo" --clobber
 done
+incomplete_draft_created=false
 
 publish_args=(release edit "$tag" --repo "$repo" --draft=false)
 if [ "$prerelease" = true ]; then
@@ -169,5 +169,4 @@ elif [ "$latest" = true ]; then
 fi
 run_with_retry "GitHub release publication" gh "${publish_args[@]}"
 
-draft_created=false
 trap - EXIT

--- a/scripts/ci/publish-github-release.sh
+++ b/scripts/ci/publish-github-release.sh
@@ -9,7 +9,7 @@ usage() {
 require_value() {
   local option="$1"
   local value="${2:-}"
-  if [ -z "$value" ]; then
+  if [[ -z "$value" ]]; then
     echo "::error::${option} requires a value." >&2
     usage
     exit 2
@@ -23,7 +23,7 @@ notes=""
 prerelease=false
 latest=false
 
-while [ "$#" -gt 0 ]; do
+while [[ "$#" -gt 0 ]]; do
   case "$1" in
     --repo)
       require_value "$1" "${2:-}"
@@ -70,18 +70,18 @@ require_value "--tag" "$tag"
 require_value "--title" "$title"
 require_value "--notes" "$notes"
 
-if [ "$prerelease" = true ] && [ "$latest" = true ]; then
+if [[ "$prerelease" == true && "$latest" == true ]]; then
   echo "::error::A release cannot be both a prerelease and the latest release." >&2
   exit 2
 fi
 
 assets=("$@")
-if [ "${#assets[@]}" -eq 0 ]; then
+if [[ "${#assets[@]}" -eq 0 ]]; then
   echo "::error::At least one release asset is required." >&2
   exit 2
 fi
 for asset in "${assets[@]}"; do
-  if [ ! -f "$asset" ]; then
+  if [[ ! -f "$asset" ]]; then
     echo "::error::Release asset does not exist: $asset" >&2
     exit 2
   fi
@@ -89,6 +89,7 @@ done
 
 retry_attempts="${GH_RELEASE_RETRY_ATTEMPTS:-3}"
 retry_delay_seconds="${GH_RELEASE_RETRY_DELAY_SECONDS:-10}"
+retry_fatal_status=64
 if ! [[ "$retry_attempts" =~ ^[1-9][0-9]*$ ]]; then
   echo "::error::GH_RELEASE_RETRY_ATTEMPTS must be a positive integer." >&2
   exit 2
@@ -102,18 +103,24 @@ run_with_retry() {
   local description="$1"
   shift
   local attempt=1
+  local status
 
   while true; do
     if "$@"; then
       return 0
+    else
+      status="$?"
     fi
-    if [ "$attempt" -ge "$retry_attempts" ]; then
+    if [[ "$status" -eq "$retry_fatal_status" ]]; then
+      return 1
+    fi
+    if [[ "$attempt" -ge "$retry_attempts" ]]; then
       echo "::error::${description} failed after ${retry_attempts} attempts." >&2
       return 1
     fi
 
     echo "::warning::${description} failed on attempt ${attempt}/${retry_attempts}. Retrying." >&2
-    if [ "$retry_delay_seconds" -gt 0 ]; then
+    if [[ "$retry_delay_seconds" -gt 0 ]]; then
       sleep "$((retry_delay_seconds * attempt))"
     fi
     attempt=$((attempt + 1))
@@ -129,13 +136,13 @@ create_draft_release() {
   if existing_is_draft="$(
     gh release view "$tag" --repo "$repo" --json isDraft --jq '.isDraft' 2>/dev/null
   )"; then
-    if [ "$existing_is_draft" = true ]; then
+    if [[ "$existing_is_draft" == true ]]; then
       echo "::warning::Reusing existing GitHub release draft ${tag}." >&2
       return 0
     fi
 
     echo "::error::GitHub release ${tag} already exists and is not a draft." >&2
-    return 1
+    return "$retry_fatal_status"
   fi
 
   local create_args=(
@@ -145,7 +152,7 @@ create_draft_release() {
     --draft
     --notes "$notes"
   )
-  if [ "$prerelease" = true ]; then
+  if [[ "$prerelease" == true ]]; then
     create_args+=(--prerelease)
   fi
 
@@ -156,7 +163,7 @@ incomplete_draft_created=false
 cleanup_failed_release() {
   local status="$?"
   trap - EXIT
-  if [ "$status" -ne 0 ] && [ "$incomplete_draft_created" = true ]; then
+  if [[ "$status" -ne 0 && "$incomplete_draft_created" == true ]]; then
     echo "::warning::Removing incomplete GitHub release ${tag}." >&2
     delete_release
   fi
@@ -175,9 +182,9 @@ done
 incomplete_draft_created=false
 
 publish_args=(release edit "$tag" --repo "$repo" --draft=false)
-if [ "$prerelease" = true ]; then
+if [[ "$prerelease" == true ]]; then
   publish_args+=(--prerelease --latest=false)
-elif [ "$latest" = true ]; then
+elif [[ "$latest" == true ]]; then
   publish_args+=(--prerelease=false --latest)
 fi
 run_with_retry "GitHub release publication" gh "${publish_args[@]}"

--- a/scripts/ci/publish-github-release.sh
+++ b/scripts/ci/publish-github-release.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 --repo <owner/repo> --tag <tag> --title <title> --notes <notes> [--prerelease] [--latest] -- <asset>..." >&2
+}
+
+require_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [ -z "$value" ]; then
+    echo "::error::${option} requires a value." >&2
+    usage
+    exit 2
+  fi
+}
+
+repo=""
+tag=""
+title=""
+notes=""
+prerelease=false
+latest=false
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo)
+      require_value "$1" "${2:-}"
+      repo="$2"
+      shift 2
+      ;;
+    --tag)
+      require_value "$1" "${2:-}"
+      tag="$2"
+      shift 2
+      ;;
+    --title)
+      require_value "$1" "${2:-}"
+      title="$2"
+      shift 2
+      ;;
+    --notes)
+      require_value "$1" "${2:-}"
+      notes="$2"
+      shift 2
+      ;;
+    --prerelease)
+      prerelease=true
+      shift
+      ;;
+    --latest)
+      latest=true
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      echo "::error::Unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+require_value "--repo" "$repo"
+require_value "--tag" "$tag"
+require_value "--title" "$title"
+require_value "--notes" "$notes"
+
+if [ "$prerelease" = true ] && [ "$latest" = true ]; then
+  echo "::error::A release cannot be both a prerelease and the latest release." >&2
+  exit 2
+fi
+
+assets=("$@")
+if [ "${#assets[@]}" -eq 0 ]; then
+  echo "::error::At least one release asset is required." >&2
+  exit 2
+fi
+for asset in "${assets[@]}"; do
+  if [ ! -f "$asset" ]; then
+    echo "::error::Release asset does not exist: $asset" >&2
+    exit 2
+  fi
+done
+
+retry_attempts="${GH_RELEASE_RETRY_ATTEMPTS:-3}"
+retry_delay_seconds="${GH_RELEASE_RETRY_DELAY_SECONDS:-10}"
+if ! [[ "$retry_attempts" =~ ^[1-9][0-9]*$ ]]; then
+  echo "::error::GH_RELEASE_RETRY_ATTEMPTS must be a positive integer." >&2
+  exit 2
+fi
+if ! [[ "$retry_delay_seconds" =~ ^[0-9]+$ ]]; then
+  echo "::error::GH_RELEASE_RETRY_DELAY_SECONDS must be a non-negative integer." >&2
+  exit 2
+fi
+
+run_with_retry() {
+  local description="$1"
+  shift
+  local attempt=1
+
+  while true; do
+    if "$@"; then
+      return 0
+    fi
+    if [ "$attempt" -ge "$retry_attempts" ]; then
+      echo "::error::${description} failed after ${retry_attempts} attempts." >&2
+      return 1
+    fi
+
+    echo "::warning::${description} failed on attempt ${attempt}/${retry_attempts}. Retrying." >&2
+    if [ "$retry_delay_seconds" -gt 0 ]; then
+      sleep "$((retry_delay_seconds * attempt))"
+    fi
+    attempt=$((attempt + 1))
+  done
+}
+
+delete_release() {
+  gh release delete "$tag" --repo "$repo" --yes --cleanup-tag >/dev/null 2>&1 || true
+}
+
+create_draft_release() {
+  local create_args=(
+    release create "$tag"
+    --repo "$repo"
+    --title "$title"
+    --draft
+    --notes "$notes"
+  )
+  if [ "$prerelease" = true ]; then
+    create_args+=(--prerelease)
+  fi
+
+  delete_release
+  gh "${create_args[@]}"
+}
+
+draft_created=false
+cleanup_failed_release() {
+  local status="$?"
+  trap - EXIT
+  if [ "$status" -ne 0 ] && [ "$draft_created" = true ]; then
+    echo "::warning::Removing incomplete GitHub release ${tag}." >&2
+    delete_release
+  fi
+  exit "$status"
+}
+trap cleanup_failed_release EXIT
+
+run_with_retry "GitHub release draft creation" create_draft_release
+draft_created=true
+
+for asset in "${assets[@]}"; do
+  run_with_retry \
+    "GitHub release asset $(basename "$asset") upload" \
+    gh release upload "$tag" "$asset" --repo "$repo" --clobber
+done
+
+publish_args=(release edit "$tag" --repo "$repo" --draft=false)
+if [ "$prerelease" = true ]; then
+  publish_args+=(--prerelease --latest=false)
+elif [ "$latest" = true ]; then
+  publish_args+=(--prerelease=false --latest)
+fi
+run_with_retry "GitHub release publication" gh "${publish_args[@]}"
+
+draft_created=false
+trap - EXIT

--- a/tests/integration/ci/registry-release-workflow.test.ts
+++ b/tests/integration/ci/registry-release-workflow.test.ts
@@ -110,15 +110,27 @@ async function runVersionValidation(version: string): Promise<Deno.CommandOutput
   }).output();
 }
 
-async function runReleaseScriptWithTransientUploadFailure(
-  stateDir: string,
-  asset: string,
-  failedUploadAttempts: number,
-): Promise<Deno.CommandOutput> {
+async function runReleaseScript({
+  stateDir,
+  asset,
+  failedCreateAttempts = 0,
+  failedUploadAttempts = 0,
+  failedPublishAttempts = 0,
+}: {
+  stateDir: string;
+  asset: string;
+  failedCreateAttempts?: number;
+  failedUploadAttempts?: number;
+  failedPublishAttempts?: number;
+}): Promise<Deno.CommandOutput> {
   const ghLog = `${stateDir}/gh.log`;
+  const createCount = `${stateDir}/create-count`;
   const uploadCount = `${stateDir}/upload-count`;
+  const publishCount = `${stateDir}/publish-count`;
   await Deno.writeTextFile(ghLog, "");
+  await Deno.writeTextFile(createCount, "0");
   await Deno.writeTextFile(uploadCount, "0");
+  await Deno.writeTextFile(publishCount, "0");
 
   return await new Deno.Command("bash", {
     args: [
@@ -127,16 +139,36 @@ async function runReleaseScriptWithTransientUploadFailure(
         "set -euo pipefail",
         'release_script="$1"',
         'export GH_LOG="$2"',
-        'export UPLOAD_COUNT="$3"',
-        'export FAILED_UPLOAD_ATTEMPTS="$4"',
-        'asset="$5"',
+        'export CREATE_COUNT="$3"',
+        'export UPLOAD_COUNT="$4"',
+        'export PUBLISH_COUNT="$5"',
+        'export FAILED_CREATE_ATTEMPTS="$6"',
+        'export FAILED_UPLOAD_ATTEMPTS="$7"',
+        'export FAILED_PUBLISH_ATTEMPTS="$8"',
+        'asset="$9"',
         "gh() {",
         '  printf "%s\\n" "$*" >> "$GH_LOG"',
+        '  if [ "$1" = "release" ] && [ "$2" = "create" ]; then',
+        '    count="$(cat "$CREATE_COUNT")"',
+        "    count=$((count + 1))",
+        '    printf "%s" "$count" > "$CREATE_COUNT"',
+        '    if [ "$count" -le "$FAILED_CREATE_ATTEMPTS" ]; then',
+        "      return 1",
+        "    fi",
+        "  fi",
         '  if [ "$1" = "release" ] && [ "$2" = "upload" ]; then',
         '    count="$(cat "$UPLOAD_COUNT")"',
         "    count=$((count + 1))",
         '    printf "%s" "$count" > "$UPLOAD_COUNT"',
         '    if [ "$count" -le "$FAILED_UPLOAD_ATTEMPTS" ]; then',
+        "      return 1",
+        "    fi",
+        "  fi",
+        '  if [ "$1" = "release" ] && [ "$2" = "edit" ]; then',
+        '    count="$(cat "$PUBLISH_COUNT")"',
+        "    count=$((count + 1))",
+        '    printf "%s" "$count" > "$PUBLISH_COUNT"',
+        '    if [ "$count" -le "$FAILED_PUBLISH_ATTEMPTS" ]; then',
         "      return 1",
         "    fi",
         "  fi",
@@ -155,8 +187,12 @@ async function runReleaseScriptWithTransientUploadFailure(
       "release-script-test",
       RELEASE_SCRIPT_PATH,
       ghLog,
+      createCount,
       uploadCount,
+      publishCount,
+      String(failedCreateAttempts),
       String(failedUploadAttempts),
+      String(failedPublishAttempts),
       asset,
     ],
     stdout: "piped",
@@ -170,11 +206,11 @@ describe("registry release workflow", () => {
       const asset = `${stateDir}/veryfront-macos-arm64`;
       await Deno.writeTextFile(asset, "binary");
 
-      const output = await runReleaseScriptWithTransientUploadFailure(
+      const output = await runReleaseScript({
         stateDir,
         asset,
-        1,
-      );
+        failedUploadAttempts: 1,
+      });
       const ghCalls = (await Deno.readTextFile(`${stateDir}/gh.log`))
         .trim()
         .split("\n");
@@ -198,11 +234,11 @@ describe("registry release workflow", () => {
       const asset = `${stateDir}/veryfront-macos-arm64`;
       await Deno.writeTextFile(asset, "binary");
 
-      const output = await runReleaseScriptWithTransientUploadFailure(
+      const output = await runReleaseScript({
         stateDir,
         asset,
-        3,
-      );
+        failedUploadAttempts: 3,
+      });
       const ghCalls = (await Deno.readTextFile(`${stateDir}/gh.log`))
         .trim()
         .split("\n");
@@ -220,6 +256,60 @@ describe("registry release workflow", () => {
       assert(
         ghCalls.at(-1)?.startsWith("release delete v1.2.3-rc.4 "),
         "the incomplete release must be deleted after the final failed upload",
+      );
+    });
+  });
+
+  it("preserves an existing release when draft creation fails", async () => {
+    await withTempDir(async (stateDir) => {
+      const asset = `${stateDir}/veryfront-macos-arm64`;
+      await Deno.writeTextFile(asset, "binary");
+
+      const output = await runReleaseScript({
+        stateDir,
+        asset,
+        failedCreateAttempts: 3,
+      });
+      const ghCalls = (await Deno.readTextFile(`${stateDir}/gh.log`))
+        .trim()
+        .split("\n");
+
+      assertEquals(output.code, 1);
+      assertEquals(
+        ghCalls.filter((call) => call.startsWith("release delete ")).length,
+        0,
+        "draft creation failure must not delete a release that predates this run",
+      );
+    });
+  });
+
+  it("preserves a fully uploaded draft when publication retries are exhausted", async () => {
+    await withTempDir(async (stateDir) => {
+      const asset = `${stateDir}/veryfront-macos-arm64`;
+      await Deno.writeTextFile(asset, "binary");
+
+      const output = await runReleaseScript({
+        stateDir,
+        asset,
+        failedPublishAttempts: 3,
+      });
+      const ghCalls = (await Deno.readTextFile(`${stateDir}/gh.log`))
+        .trim()
+        .split("\n");
+
+      assertEquals(output.code, 1);
+      assertEquals(
+        ghCalls.filter((call) => call.startsWith("release upload ")).length,
+        1,
+      );
+      assertEquals(
+        ghCalls.filter((call) => call.startsWith("release edit ")).length,
+        3,
+      );
+      assertEquals(
+        ghCalls.filter((call) => call.startsWith("release delete ")).length,
+        0,
+        "publication failure must retain the uploaded draft for recovery",
       );
     });
   });

--- a/tests/integration/ci/registry-release-workflow.test.ts
+++ b/tests/integration/ci/registry-release-workflow.test.ts
@@ -112,6 +112,7 @@ async function runVersionValidation(version: string): Promise<Deno.CommandOutput
 
 type ReleaseState = "missing" | "draft" | "published";
 type CreateFailure = "none" | "after-creation";
+type UploadFailureStatus = 1 | 64;
 
 async function runReleaseScript({
   stateDir,
@@ -119,6 +120,7 @@ async function runReleaseScript({
   initialReleaseState = "missing",
   createFailure = "none",
   failedUploadAttempts = 0,
+  uploadFailureStatus = 1,
   failedPublishAttempts = 0,
 }: {
   stateDir: string;
@@ -126,6 +128,7 @@ async function runReleaseScript({
   initialReleaseState?: ReleaseState;
   createFailure?: CreateFailure;
   failedUploadAttempts?: number;
+  uploadFailureStatus?: UploadFailureStatus;
   failedPublishAttempts?: number;
 }): Promise<Deno.CommandOutput> {
   const ghLog = `${stateDir}/gh.log`;
@@ -168,7 +171,7 @@ async function runReleaseScript({
         "    count=$((count + 1))",
         '    printf "%s" "$count" > "$UPLOAD_COUNT"',
         '    if [ "$count" -le "$FAILED_UPLOAD_ATTEMPTS" ]; then',
-        "      return 1",
+        '      return "$UPLOAD_FAILURE_STATUS"',
         "    fi",
         "  fi",
         '  if [ "$1" = "release" ] && [ "$2" = "edit" ]; then',
@@ -206,6 +209,7 @@ async function runReleaseScript({
       RELEASE_STATE: releaseState,
       CREATE_FAILURE: createFailure,
       FAILED_UPLOAD_ATTEMPTS: String(failedUploadAttempts),
+      UPLOAD_FAILURE_STATUS: String(uploadFailureStatus),
       FAILED_PUBLISH_ATTEMPTS: String(failedPublishAttempts),
     },
     stdout: "piped",
@@ -269,6 +273,30 @@ describe("registry release workflow", () => {
       assert(
         ghCalls.at(-1)?.startsWith("release delete v1.2.3-rc.4 "),
         "the incomplete release must be deleted after the final failed upload",
+      );
+    });
+  });
+
+  it("retries upload failures that match the internal fatal status", async () => {
+    await withTempDir(async (stateDir) => {
+      const asset = `${stateDir}/veryfront-macos-arm64`;
+      await Deno.writeTextFile(asset, "binary");
+
+      const output = await runReleaseScript({
+        stateDir,
+        asset,
+        failedUploadAttempts: 1,
+        uploadFailureStatus: 64,
+      });
+      const ghCalls = (await Deno.readTextFile(`${stateDir}/gh.log`))
+        .trim()
+        .split("\n");
+
+      assertEquals(output.code, 0, decoder.decode(output.stderr));
+      assertEquals(
+        ghCalls.filter((call) => call.startsWith("release upload ")).length,
+        2,
+        "external upload statuses must not use the create-only fatal sentinel",
       );
     });
   });

--- a/tests/integration/ci/registry-release-workflow.test.ts
+++ b/tests/integration/ci/registry-release-workflow.test.ts
@@ -1,5 +1,7 @@
 import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { withTempDir } from "#veryfront/testing/deno-compat.ts";
+import { fromFileUrl } from "#std/path";
 import { parse } from "#std/yaml/parse";
 
 type YamlRecord = Record<string, unknown>;
@@ -8,6 +10,10 @@ const WORKFLOW_PATH = new URL(
   "../../../.github/workflows/cicd.yml",
   import.meta.url,
 );
+const RELEASE_SCRIPT_PATH = fromFileUrl(
+  new URL("../../../scripts/ci/publish-github-release.sh", import.meta.url),
+);
+const decoder = new TextDecoder();
 
 function asRecord(value: unknown, context: string): YamlRecord {
   assert(
@@ -104,7 +110,145 @@ async function runVersionValidation(version: string): Promise<Deno.CommandOutput
   }).output();
 }
 
+async function runReleaseScriptWithTransientUploadFailure(
+  stateDir: string,
+  asset: string,
+  failedUploadAttempts: number,
+): Promise<Deno.CommandOutput> {
+  const ghLog = `${stateDir}/gh.log`;
+  const uploadCount = `${stateDir}/upload-count`;
+  await Deno.writeTextFile(ghLog, "");
+  await Deno.writeTextFile(uploadCount, "0");
+
+  return await new Deno.Command("bash", {
+    args: [
+      "-c",
+      [
+        "set -euo pipefail",
+        'release_script="$1"',
+        'export GH_LOG="$2"',
+        'export UPLOAD_COUNT="$3"',
+        'export FAILED_UPLOAD_ATTEMPTS="$4"',
+        'asset="$5"',
+        "gh() {",
+        '  printf "%s\\n" "$*" >> "$GH_LOG"',
+        '  if [ "$1" = "release" ] && [ "$2" = "upload" ]; then',
+        '    count="$(cat "$UPLOAD_COUNT")"',
+        "    count=$((count + 1))",
+        '    printf "%s" "$count" > "$UPLOAD_COUNT"',
+        '    if [ "$count" -le "$FAILED_UPLOAD_ATTEMPTS" ]; then',
+        "      return 1",
+        "    fi",
+        "  fi",
+        "}",
+        "sleep() { :; }",
+        "export -f gh sleep",
+        'exec bash "$release_script" \\',
+        '  --repo "veryfront/veryfront" \\',
+        '  --tag "v1.2.3-rc.4" \\',
+        '  --title "v1.2.3-rc.4" \\',
+        '  --notes "Install notes" \\',
+        "  --prerelease \\",
+        "  -- \\",
+        '  "$asset"',
+      ].join("\n"),
+      "release-script-test",
+      RELEASE_SCRIPT_PATH,
+      ghLog,
+      uploadCount,
+      String(failedUploadAttempts),
+      asset,
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+}
+
 describe("registry release workflow", () => {
+  it("publishes after retrying a transient release asset upload failure", async () => {
+    await withTempDir(async (stateDir) => {
+      const asset = `${stateDir}/veryfront-macos-arm64`;
+      await Deno.writeTextFile(asset, "binary");
+
+      const output = await runReleaseScriptWithTransientUploadFailure(
+        stateDir,
+        asset,
+        1,
+      );
+      const ghCalls = (await Deno.readTextFile(`${stateDir}/gh.log`))
+        .trim()
+        .split("\n");
+
+      assertEquals(output.code, 0, decoder.decode(output.stderr));
+      assertEquals(
+        ghCalls.filter((call) => call.startsWith("release upload ")).length,
+        2,
+        "the failed asset must be retried",
+      );
+      assertEquals(
+        ghCalls.filter((call) => call.startsWith("release edit ")).length,
+        1,
+        "the draft must be published once after every asset upload succeeds",
+      );
+    });
+  });
+
+  it("removes an incomplete release after upload retries are exhausted", async () => {
+    await withTempDir(async (stateDir) => {
+      const asset = `${stateDir}/veryfront-macos-arm64`;
+      await Deno.writeTextFile(asset, "binary");
+
+      const output = await runReleaseScriptWithTransientUploadFailure(
+        stateDir,
+        asset,
+        3,
+      );
+      const ghCalls = (await Deno.readTextFile(`${stateDir}/gh.log`))
+        .trim()
+        .split("\n");
+
+      assertEquals(output.code, 1);
+      assertEquals(
+        ghCalls.filter((call) => call.startsWith("release upload ")).length,
+        3,
+      );
+      assertEquals(
+        ghCalls.filter((call) => call.startsWith("release edit ")).length,
+        0,
+        "an incomplete draft must never be published",
+      );
+      assert(
+        ghCalls.at(-1)?.startsWith("release delete v1.2.3-rc.4 "),
+        "the incomplete release must be deleted after the final failed upload",
+      );
+    });
+  });
+
+  it("routes public GitHub releases through the retrying asset publisher", async () => {
+    const jobs = await readJobs();
+    for (
+      const [jobName, stepName] of [
+        ["prerelease", "Create GitHub pre-release"],
+        ["release", "Create GitHub releases"],
+      ] as const
+    ) {
+      const job = asRecord(jobs[jobName], `${jobName} job`);
+      const releaseStep = namedStep(job, stepName);
+      const run = String(releaseStep.run);
+
+      assertStringIncludes(
+        run,
+        "bash scripts/ci/publish-github-release.sh",
+        `${jobName} must use the retrying release asset publisher`,
+      );
+      assertEquals(
+        run.includes("gh release create"),
+        false,
+        `${jobName} must not bypass per-asset retries`,
+      );
+    }
+  });
+
   it("validates the deno.json version before exposing release outputs", async () => {
     const jobs = await readJobs();
     const versionCheck = asRecord(jobs["version-check"], "version check job");

--- a/tests/integration/ci/registry-release-workflow.test.ts
+++ b/tests/integration/ci/registry-release-workflow.test.ts
@@ -289,6 +289,16 @@ describe("registry release workflow", () => {
 
       assertEquals(output.code, 1);
       assertEquals(
+        ghCalls.filter((call) => call.startsWith("release view ")).length,
+        1,
+        "a published-release conflict must fail without retries",
+      );
+      assertEquals(
+        decoder.decode(output.stderr).includes("Retrying"),
+        false,
+        "a published-release conflict must not report a transient retry",
+      );
+      assertEquals(
         ghCalls.filter((call) => call.startsWith("release create ")).length,
         0,
         "an existing published release must not be recreated",

--- a/tests/integration/ci/registry-release-workflow.test.ts
+++ b/tests/integration/ci/registry-release-workflow.test.ts
@@ -110,27 +110,32 @@ async function runVersionValidation(version: string): Promise<Deno.CommandOutput
   }).output();
 }
 
+type ReleaseState = "missing" | "draft" | "published";
+type CreateFailure = "none" | "after-creation";
+
 async function runReleaseScript({
   stateDir,
   asset,
-  failedCreateAttempts = 0,
+  initialReleaseState = "missing",
+  createFailure = "none",
   failedUploadAttempts = 0,
   failedPublishAttempts = 0,
 }: {
   stateDir: string;
   asset: string;
-  failedCreateAttempts?: number;
+  initialReleaseState?: ReleaseState;
+  createFailure?: CreateFailure;
   failedUploadAttempts?: number;
   failedPublishAttempts?: number;
 }): Promise<Deno.CommandOutput> {
   const ghLog = `${stateDir}/gh.log`;
-  const createCount = `${stateDir}/create-count`;
   const uploadCount = `${stateDir}/upload-count`;
   const publishCount = `${stateDir}/publish-count`;
+  const releaseState = `${stateDir}/release-state`;
   await Deno.writeTextFile(ghLog, "");
-  await Deno.writeTextFile(createCount, "0");
   await Deno.writeTextFile(uploadCount, "0");
   await Deno.writeTextFile(publishCount, "0");
+  await Deno.writeTextFile(releaseState, initialReleaseState);
 
   return await new Deno.Command("bash", {
     args: [
@@ -138,21 +143,23 @@ async function runReleaseScript({
       [
         "set -euo pipefail",
         'release_script="$1"',
-        'export GH_LOG="$2"',
-        'export CREATE_COUNT="$3"',
-        'export UPLOAD_COUNT="$4"',
-        'export PUBLISH_COUNT="$5"',
-        'export FAILED_CREATE_ATTEMPTS="$6"',
-        'export FAILED_UPLOAD_ATTEMPTS="$7"',
-        'export FAILED_PUBLISH_ATTEMPTS="$8"',
-        'asset="$9"',
+        'asset="$2"',
         "gh() {",
         '  printf "%s\\n" "$*" >> "$GH_LOG"',
+        '  if [ "$1" = "release" ] && [ "$2" = "view" ]; then',
+        '    case "$(cat "$RELEASE_STATE")" in',
+        "      missing) return 1 ;;",
+        '      draft) printf "true\\n" ;;',
+        '      published) printf "false\\n" ;;',
+        "    esac",
+        "    return 0",
+        "  fi",
         '  if [ "$1" = "release" ] && [ "$2" = "create" ]; then',
-        '    count="$(cat "$CREATE_COUNT")"',
-        "    count=$((count + 1))",
-        '    printf "%s" "$count" > "$CREATE_COUNT"',
-        '    if [ "$count" -le "$FAILED_CREATE_ATTEMPTS" ]; then',
+        '    if [ "$(cat "$RELEASE_STATE")" != "missing" ]; then',
+        "      return 1",
+        "    fi",
+        '    printf "draft" > "$RELEASE_STATE"',
+        '    if [ "$CREATE_FAILURE" = "after-creation" ]; then',
         "      return 1",
         "    fi",
         "  fi",
@@ -171,6 +178,10 @@ async function runReleaseScript({
         '    if [ "$count" -le "$FAILED_PUBLISH_ATTEMPTS" ]; then',
         "      return 1",
         "    fi",
+        '    printf "published" > "$RELEASE_STATE"',
+        "  fi",
+        '  if [ "$1" = "release" ] && [ "$2" = "delete" ]; then',
+        '    printf "missing" > "$RELEASE_STATE"',
         "  fi",
         "}",
         "sleep() { :; }",
@@ -186,15 +197,17 @@ async function runReleaseScript({
       ].join("\n"),
       "release-script-test",
       RELEASE_SCRIPT_PATH,
-      ghLog,
-      createCount,
-      uploadCount,
-      publishCount,
-      String(failedCreateAttempts),
-      String(failedUploadAttempts),
-      String(failedPublishAttempts),
       asset,
     ],
+    env: {
+      GH_LOG: ghLog,
+      UPLOAD_COUNT: uploadCount,
+      PUBLISH_COUNT: publishCount,
+      RELEASE_STATE: releaseState,
+      CREATE_FAILURE: createFailure,
+      FAILED_UPLOAD_ATTEMPTS: String(failedUploadAttempts),
+      FAILED_PUBLISH_ATTEMPTS: String(failedPublishAttempts),
+    },
     stdout: "piped",
     stderr: "piped",
   }).output();
@@ -260,7 +273,7 @@ describe("registry release workflow", () => {
     });
   });
 
-  it("preserves an existing release when draft creation fails", async () => {
+  it("preserves an existing published release", async () => {
     await withTempDir(async (stateDir) => {
       const asset = `${stateDir}/veryfront-macos-arm64`;
       await Deno.writeTextFile(asset, "binary");
@@ -268,7 +281,7 @@ describe("registry release workflow", () => {
       const output = await runReleaseScript({
         stateDir,
         asset,
-        failedCreateAttempts: 3,
+        initialReleaseState: "published",
       });
       const ghCalls = (await Deno.readTextFile(`${stateDir}/gh.log`))
         .trim()
@@ -276,9 +289,51 @@ describe("registry release workflow", () => {
 
       assertEquals(output.code, 1);
       assertEquals(
+        ghCalls.filter((call) => call.startsWith("release create ")).length,
+        0,
+        "an existing published release must not be recreated",
+      );
+      assertEquals(
+        ghCalls.filter((call) => call.startsWith("release upload ")).length,
+        0,
+        "an existing published release must not accept new assets",
+      );
+      assertEquals(
         ghCalls.filter((call) => call.startsWith("release delete ")).length,
         0,
         "draft creation failure must not delete a release that predates this run",
+      );
+    });
+  });
+
+  it("recovers when draft creation succeeds remotely but reports failure", async () => {
+    await withTempDir(async (stateDir) => {
+      const asset = `${stateDir}/veryfront-macos-arm64`;
+      await Deno.writeTextFile(asset, "binary");
+
+      const output = await runReleaseScript({
+        stateDir,
+        asset,
+        createFailure: "after-creation",
+      });
+      const ghCalls = (await Deno.readTextFile(`${stateDir}/gh.log`))
+        .trim()
+        .split("\n");
+
+      assertEquals(output.code, 0, decoder.decode(output.stderr));
+      assertEquals(
+        ghCalls.filter((call) => call.startsWith("release create ")).length,
+        1,
+        "the remotely created draft must be adopted instead of recreated",
+      );
+      assertEquals(
+        ghCalls.filter((call) => call.startsWith("release upload ")).length,
+        1,
+      );
+      assertEquals(
+        ghCalls.filter((call) => call.startsWith("release edit ")).length,
+        1,
+        "the adopted draft must be published after its assets upload",
       );
     });
   });


### PR DESCRIPTION
## Summary

Fixes the intermittent release failure where `uploads.github.com` can return a transient HTTP 400 while GitHub release assets are being uploaded.

This routes public GitHub release publishing through `scripts/ci/publish-github-release.sh`, which creates releases as drafts, retries each asset upload with a bounded retry loop, publishes only after every upload succeeds, and cleans up incomplete drafts on failure. The workflow now also keeps release asset paths in arrays so quoted paths stay intact.

## Validation

- Pinned Deno 2.7.7 focused registry release workflow test: 14 steps passed
- Shell syntax check passed
- ShellCheck passed
- `deno task lint` passed
- `deno task typecheck` passed
- `deno task lint:ci-typescript` passed
- `git diff --check` passed

The production release workflow was not rerun.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Stable releases are now marked as the latest release automatically.
  - Release assets are uploaded more safely, with missing files omitted.

- **Bug Fixes**
  - Release publishing now retries temporary upload failures.
  - Incomplete releases are cleaned up automatically when publishing cannot finish.
  - Release creation is more consistent for both preview and stable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->