### PR TITLE
Shorten CI feedback without weakening release gates

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -130,9 +130,14 @@ jobs:
 
   tests-node:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    needs: [npm-compatibility-artifact]
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    name: tests (node)
+    name: "tests (node shard ${{ matrix.shard }}/2)"
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -145,11 +150,40 @@ jobs:
         with:
           node-version: "24"
           package-manager-cache: false
-      - name: Run Node runtime suite
-        run: deno task test:node
+      - name: Download npm runtime workspace
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: npm-runtime-workspace-${{ github.sha }}
+          path: dist/npm-runtime-workspace
+      - name: Restore npm runtime workspace
+        run: |
+          tar -xzf dist/npm-runtime-workspace/npm-runtime-workspace.tar.gz
+          mkdir -p node_modules
+      - name: Start Node shard timer
+        id: timer
+        run: echo "started_at=$(date +%s)" >> "$GITHUB_OUTPUT"
+      - name: Run Node runtime shard
+        env:
+          VF_TEST_SHARD: ${{ matrix.shard }}/2
+        run: node ./tests/node/run-tests.mjs --suite=runtime:node
+      - name: Report Node shard duration
+        if: ${{ always() }}
+        env:
+          SHARD: ${{ matrix.shard }}/2
+          STARTED_AT: ${{ steps.timer.outputs.started_at }}
+        run: |
+          case "$STARTED_AT" in
+            ''|*[!0-9]*)
+              echo "Node shard ${SHARD} did not start" >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+              ;;
+          esac
+          duration_seconds=$(($(date +%s) - STARTED_AT))
+          echo "Node shard ${SHARD}: ${duration_seconds}s" >> "$GITHUB_STEP_SUMMARY"
 
   tests-bun:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    needs: [npm-compatibility-artifact]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     name: tests (bun)
@@ -168,8 +202,17 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.6"
+      - name: Download npm runtime workspace
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: npm-runtime-workspace-${{ github.sha }}
+          path: dist/npm-runtime-workspace
+      - name: Restore npm runtime workspace
+        run: |
+          tar -xzf dist/npm-runtime-workspace/npm-runtime-workspace.tar.gz
+          mkdir -p node_modules
       - name: Run Bun runtime suite
-        run: deno task test:bun
+        run: node --test tests/bun/runner-args.test.mjs tests/bun/workspace-packages.test.mjs && node ./tests/bun/run-tests.mjs --suite=runtime:bun
 
   npm-compatibility-artifact:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
@@ -178,6 +221,8 @@ jobs:
     name: npm compatibility artifact
     outputs:
       build_duration_seconds: ${{ steps.build.outputs.build_duration_seconds }}
+      runtime_workspace_archive_bytes: ${{ steps.runtime-workspace.outputs.archive_bytes }}
+      runtime_workspace_archive_duration_seconds: ${{ steps.runtime-workspace.outputs.archive_duration_seconds }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -203,12 +248,27 @@ jobs:
           deno run --config=scripts/test.deno.json --frozen --allow-read --allow-write --allow-run=npm,tar \
             scripts/ci/npm-compatibility-artifact.ts pack npm dist/npm-compatibility "${GITHUB_SHA}"
           echo "build_duration_seconds=$(($(date +%s) - started_at))" >> "$GITHUB_OUTPUT"
+      - name: Archive npm runtime workspace
+        id: runtime-workspace
+        run: |
+          started_at=$(date +%s)
+          tar -cf - npm | gzip -1 > dist/npm-runtime-workspace.tar.gz
+          echo "archive_bytes=$(wc -c < dist/npm-runtime-workspace.tar.gz | tr -d ' ')" >> "$GITHUB_OUTPUT"
+          echo "archive_duration_seconds=$(($(date +%s) - started_at))" >> "$GITHUB_OUTPUT"
       - name: Upload tested npm compatibility artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: npm-compatibility-${{ github.sha }}
           path: dist/npm-compatibility
           retention-days: 30
+          overwrite: true
+      - name: Upload npm runtime workspace
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-runtime-workspace-${{ github.sha }}
+          path: dist/npm-runtime-workspace.tar.gz
+          retention-days: 1
+          compression-level: 0
           overwrite: true
 
   tests-runtime-critical-flow:
@@ -650,7 +710,7 @@ jobs:
       - tests-bun
       - tests-binary-e2e
       - tests-e2e-rsc-browser
-    if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
+    if: ${{ always() }}
     steps:
       - name: Require merge correctness dependencies
         env:
@@ -787,7 +847,10 @@ jobs:
         if: ${{ success() }}
         env:
           BUILD_DURATION_SECONDS: ${{ needs.npm-compatibility-artifact.outputs.build_duration_seconds }}
-          LEGACY_BUILD_COUNT: "5"
+          RUNTIME_WORKSPACE_ARCHIVE_BYTES: ${{ needs.npm-compatibility-artifact.outputs.runtime_workspace_archive_bytes }}
+          RUNTIME_WORKSPACE_ARCHIVE_DURATION_SECONDS: ${{ needs.npm-compatibility-artifact.outputs.runtime_workspace_archive_duration_seconds }}
+          LEGACY_BUILD_COUNT: "7"
+          PREVIOUS_BUILD_COUNT: "3"
           CANONICAL_BUILD_COUNT: "1"
         run: |
           case "$BUILD_DURATION_SECONDS" in
@@ -796,20 +859,34 @@ jobs:
               exit 1
               ;;
           esac
+          for metric_name in RUNTIME_WORKSPACE_ARCHIVE_BYTES RUNTIME_WORKSPACE_ARCHIVE_DURATION_SECONDS; do
+            case "${!metric_name}" in
+              ''|*[!0-9]*)
+                echo "::error::Missing numeric ${metric_name}"
+                exit 1
+                ;;
+            esac
+          done
           before=$(awk -v seconds="$BUILD_DURATION_SECONDS" -v count="$LEGACY_BUILD_COUNT" \
+            'BEGIN { printf "%.2f", seconds * count / 60 }')
+          previous=$(awk -v seconds="$BUILD_DURATION_SECONDS" -v count="$PREVIOUS_BUILD_COUNT" \
             'BEGIN { printf "%.2f", seconds * count / 60 }')
           after=$(awk -v seconds="$BUILD_DURATION_SECONDS" -v count="$CANONICAL_BUILD_COUNT" \
             'BEGIN { printf "%.2f", seconds * count / 60 }')
-          saved=$(awk -v before="$before" -v after="$after" \
-            'BEGIN { printf "%.2f", before - after }')
+          incremental_saved=$(awk -v previous="$previous" -v after="$after" \
+            'BEGIN { printf "%.2f", previous - after }')
+          runtime_workspace_mib=$(awk -v bytes="$RUNTIME_WORKSPACE_ARCHIVE_BYTES" \
+            'BEGIN { printf "%.2f", bytes / 1024 / 1024 }')
           {
             echo "### Canonical npm build reuse"
             echo
             echo "Measured producer duration: ${BUILD_DURATION_SECONDS}s"
-            echo "Estimate basis: five current npm build consumers (three runtime critical-flow jobs and two npm install-smoke jobs)"
-            echo "Estimated before: ${before} npm build runner-minutes"
-            echo "Estimated after: ${after} npm build runner-minutes"
-            echo "Estimated savings: ${saved} npm build runner-minutes"
+            echo "Estimate basis: seven legacy npm build sites (three runtime critical-flow jobs, two npm install-smoke jobs, Node tests, and Bun tests)"
+            echo "Legacy independent builds: ${before} npm build runner-minutes"
+            echo "Previous partial reuse: ${previous} npm build runner-minutes"
+            echo "Canonical build: ${after} npm build runner-minutes"
+            echo "Incremental savings: ${incremental_saved} npm build runner-minutes"
+            echo "Measured runtime workspace archive: ${runtime_workspace_mib} MiB in ${RUNTIME_WORKSPACE_ARCHIVE_DURATION_SECONDS}s"
           } >> "$GITHUB_STEP_SUMMARY"
 
   tests-sentry-runtime-packages:
@@ -1115,11 +1192,8 @@ jobs:
   prerelease:
     if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && needs.version-check.outputs.is_stable == 'false' }}
     needs: [
-      ci,
-      tests,
+      quality-gate-merge,
       quality-gate-artifact,
-      tests-binary-e2e,
-      tests-npm-install-smoke,
       tests-sentry-runtime-packages,
       tests-windows-localhost,
       build-binaries,
@@ -1245,12 +1319,8 @@ jobs:
   release:
     if: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && needs.version-check.outputs.is_stable == 'true' && needs.version-check.outputs.stable_release_requested == 'true' }}
     needs: [
-      ci,
-      tests,
-      coverage,
+      quality-gate-merge,
       quality-gate-artifact,
-      tests-binary-e2e,
-      tests-npm-install-smoke,
       tests-sentry-runtime-packages,
       tests-windows-localhost,
       build-binaries,

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -156,9 +156,9 @@ jobs:
           name: npm-runtime-workspace-${{ github.sha }}
           path: dist/npm-runtime-workspace
       - name: Restore npm runtime workspace
-        run: |
-          tar -xzf dist/npm-runtime-workspace/npm-runtime-workspace.tar.gz
-          mkdir -p node_modules
+        run: tar -xzf dist/npm-runtime-workspace/npm-runtime-workspace.tar.gz
+      - name: Materialize locked test dependencies
+        run: deno install --frozen
       - name: Start Node shard timer
         id: timer
         run: echo "started_at=$(date +%s)" >> "$GITHUB_OUTPUT"
@@ -208,9 +208,9 @@ jobs:
           name: npm-runtime-workspace-${{ github.sha }}
           path: dist/npm-runtime-workspace
       - name: Restore npm runtime workspace
-        run: |
-          tar -xzf dist/npm-runtime-workspace/npm-runtime-workspace.tar.gz
-          mkdir -p node_modules
+        run: tar -xzf dist/npm-runtime-workspace/npm-runtime-workspace.tar.gz
+      - name: Materialize locked test dependencies
+        run: deno install --frozen
       - name: Run Bun runtime suite
         run: node --test tests/bun/runner-args.test.mjs tests/bun/workspace-packages.test.mjs && node ./tests/bun/run-tests.mjs --suite=runtime:bun
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Veryfront Code
 
-[![CI/CD](https://github.com/veryfront/veryfront-code/actions/workflows/cicd.yml/badge.svg?branch=main)](https://github.com/veryfront/veryfront-code/actions/workflows/cicd.yml)
+[![CI](https://github.com/veryfront/veryfront-code/actions/workflows/cicd.yml/badge.svg?event=merge_group)](https://github.com/veryfront/veryfront-code/actions/workflows/cicd.yml?query=event%3Amerge_group)
 [![npm version](https://badge.fury.io/js/veryfront.svg)](https://www.npmjs.com/package/veryfront)
 [![codecov](https://codecov.io/gh/veryfront/veryfront-code/branch/main/graph/badge.svg)](https://codecov.io/gh/veryfront/veryfront-code)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](./LICENSE)

--- a/scripts/build/runtime-support.test.ts
+++ b/scripts/build/runtime-support.test.ts
@@ -104,8 +104,8 @@ describe("npm smoke Node support contract", () => {
       const releaseJob = record(jobs[jobName], `${jobName} job`);
       assert(
         Array.isArray(releaseJob.needs) &&
-          releaseJob.needs.includes("tests-npm-install-smoke"),
-        `${jobName} must wait for every npm install smoke matrix leg`,
+          releaseJob.needs.includes("quality-gate-artifact"),
+        `${jobName} must wait for the npm artifact quality gate`,
       );
     }
 

--- a/src/security/repository-hardening.test.ts
+++ b/src/security/repository-hardening.test.ts
@@ -380,12 +380,9 @@ describe("repository hardening", () => {
           path === ".github/workflows/cicd.yml" &&
           TRUSTED_AGGREGATE_JOBS.has(jobName)
         ) {
-          const expectedCondition = jobName === "quality-gate-merge"
-            ? "if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}"
-            : "if: ${{ always() }}";
           assertEquals(
             jobIf.trim(),
-            expectedCondition,
+            "if: ${{ always() }}",
             `expected trusted aggregate ${jobName} to run and inspect skipped dependencies`,
           );
           assertEquals(

--- a/tests/integration/ci/merge-quality-gate-workflow.test.ts
+++ b/tests/integration/ci/merge-quality-gate-workflow.test.ts
@@ -101,19 +101,43 @@ describe("merge quality gate workflow", () => {
     );
   });
 
+  it("shows merge-queue CI status without including release failures in the README badge", async () => {
+    const readme = await readRepoFile("README.md");
+
+    assertStringIncludes(
+      readme,
+      "actions/workflows/cicd.yml/badge.svg?event=merge_group",
+    );
+    assertEquals(
+      readme.includes("actions/workflows/cicd.yml/badge.svg?branch=main"),
+      false,
+    );
+  });
+
   it("always reads every required dependency result", async () => {
     const gate = await readMergeGate();
     const step = gateStep(gate);
 
     assertEquals(gate.needs, REQUIRED_DEPENDENCIES);
-    assertEquals(
-      gate.if,
-      "${{ always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}",
-    );
+    assertEquals(gate.if, "${{ always() }}");
     assertEquals(
       asRecord(step.env, "merge quality gate result env"),
       RESULT_ENV,
     );
+  });
+
+  it("blocks every release path on the complete merge correctness gate", async () => {
+    const workflow = await readWorkflow();
+    const jobs = asRecord(workflow.jobs, "cicd workflow jobs");
+
+    for (const jobName of ["prerelease", "release"] as const) {
+      const job = asRecord(jobs[jobName], `${jobName} job`);
+      assert(Array.isArray(job.needs), `${jobName} needs must be an array`);
+      assert(
+        job.needs.includes("quality-gate-merge"),
+        `${jobName} must wait for the complete merge correctness gate`,
+      );
+    }
   });
 
   it("preserves all required coverage shards, the unit sentinel, and the floor", async () => {

--- a/tests/integration/ci/npm-compatibility-artifact-workflow.test.ts
+++ b/tests/integration/ci/npm-compatibility-artifact-workflow.test.ts
@@ -237,7 +237,7 @@ describe("canonical npm artifact workflow", () => {
     }
   });
 
-  it("feeds the built runtime workspace to Node and Bun without rebuilding or reinstalling", async () => {
+  it("feeds the built runtime workspace to Node and Bun without rebuilding it", async () => {
     const jobs = await readJobs();
 
     for (
@@ -270,16 +270,18 @@ describe("canonical npm artifact workflow", () => {
       );
       const steps = jobSteps(job, `${jobName} job`);
       const restore = namedStep(job, "Restore npm runtime workspace");
+      const install = namedStep(job, "Materialize locked test dependencies");
       const run = namedStep(job, stepName);
       assertStringIncludes(
         String(restore.run),
         "tar -xzf dist/npm-runtime-workspace/npm-runtime-workspace.tar.gz",
       );
-      assertStringIncludes(String(restore.run), "mkdir -p node_modules");
+      assertEquals(install.run, "deno install --frozen");
       assert(
         steps.indexOf(download) < steps.indexOf(restore) &&
-          steps.indexOf(restore) < steps.indexOf(run),
-        `${jobName} must restore the runtime workspace before tests`,
+          steps.indexOf(restore) < steps.indexOf(install) &&
+          steps.indexOf(install) < steps.indexOf(run),
+        `${jobName} must restore the runtime workspace and materialize cached dependencies before tests`,
       );
       assertEquals(run.run, directCommand);
       assertEquals(

--- a/tests/integration/ci/npm-compatibility-artifact-workflow.test.ts
+++ b/tests/integration/ci/npm-compatibility-artifact-workflow.test.ts
@@ -57,7 +57,7 @@ async function runArtifactGate(
 }
 
 describe("canonical npm artifact workflow", () => {
-  it("builds and uploads one SHA-addressed package artifact", async () => {
+  it("builds once and uploads SHA-addressed package and runtime artifacts", async () => {
     const jobs = await readJobs();
     const producer = asRecord(
       jobs["npm-compatibility-artifact"],
@@ -80,7 +80,11 @@ describe("canonical npm artifact workflow", () => {
       ),
       "The producer must create the package-version and SHA-256 manifest",
     );
-    const upload = steps.find((step) => String(step.uses).startsWith("actions/upload-artifact@"));
+    const upload = steps.find((step) =>
+      String(step.uses).startsWith("actions/upload-artifact@") &&
+      asRecord(step.with, "artifact upload inputs").name ===
+        "npm-compatibility-${{ github.sha }}"
+    );
     assert(upload, "The producer must upload the canonical package set");
     assertEquals(
       asRecord(upload.with, "artifact upload inputs").name,
@@ -100,9 +104,55 @@ describe("canonical npm artifact workflow", () => {
       30,
       "The tested npm artifact must remain available through production approval",
     );
+    const archive = namedStep(producer, "Archive npm runtime workspace");
+    assertEquals(archive.id, "runtime-workspace");
+    assertStringIncludes(
+      String(archive.run),
+      "tar -cf - npm | gzip -1 > dist/npm-runtime-workspace.tar.gz",
+    );
+    assertStringIncludes(
+      String(archive.run),
+      'echo "archive_bytes=$(wc -c < dist/npm-runtime-workspace.tar.gz | tr -d \' \')" >> "$GITHUB_OUTPUT"',
+    );
+    assertStringIncludes(
+      String(archive.run),
+      'echo "archive_duration_seconds=$(($(date +%s) - started_at))" >> "$GITHUB_OUTPUT"',
+    );
+    const runtimeUpload = steps.find((step) =>
+      String(step.uses).startsWith("actions/upload-artifact@") &&
+      asRecord(step.with, "runtime artifact upload inputs").name ===
+        "npm-runtime-workspace-${{ github.sha }}"
+    );
+    assert(runtimeUpload, "The producer must upload the built runtime workspace");
+    assertEquals(
+      asRecord(runtimeUpload.with, "runtime artifact upload inputs"),
+      {
+        name: "npm-runtime-workspace-${{ github.sha }}",
+        path: "dist/npm-runtime-workspace.tar.gz",
+        "retention-days": 1,
+        "compression-level": 0,
+        overwrite: true,
+      },
+    );
+    assert(
+      steps.indexOf(namedStep(producer, "Build and pack tested npm output")) <
+          steps.indexOf(archive) &&
+        steps.indexOf(archive) < steps.indexOf(runtimeUpload),
+      "The producer must archive and upload the already-built runtime workspace",
+    );
     assertEquals(
       asRecord(producer.outputs, "producer outputs").build_duration_seconds,
       "${{ steps.build.outputs.build_duration_seconds }}",
+    );
+    assertEquals(
+      asRecord(producer.outputs, "producer outputs")
+        .runtime_workspace_archive_bytes,
+      "${{ steps.runtime-workspace.outputs.archive_bytes }}",
+    );
+    assertEquals(
+      asRecord(producer.outputs, "producer outputs")
+        .runtime_workspace_archive_duration_seconds,
+      "${{ steps.runtime-workspace.outputs.archive_duration_seconds }}",
     );
     const buildStep = namedStep(producer, "Build and pack tested npm output");
     const buildScript = String(buildStep.run);
@@ -185,6 +235,92 @@ describe("canonical npm artifact workflow", () => {
         `${label} must not rebuild the canonical npm output`,
       );
     }
+  });
+
+  it("feeds the built runtime workspace to Node and Bun without rebuilding or reinstalling", async () => {
+    const jobs = await readJobs();
+
+    for (
+      const [jobName, stepName, directCommand] of [
+        [
+          "tests-node",
+          "Run Node runtime shard",
+          "node ./tests/node/run-tests.mjs --suite=runtime:node",
+        ],
+        [
+          "tests-bun",
+          "Run Bun runtime suite",
+          "node --test tests/bun/runner-args.test.mjs tests/bun/workspace-packages.test.mjs && node ./tests/bun/run-tests.mjs --suite=runtime:bun",
+        ],
+      ] as const
+    ) {
+      const job = asRecord(jobs[jobName], `${jobName} job`);
+      assertEquals(job.needs, ["npm-compatibility-artifact"]);
+      const download = jobSteps(job, `${jobName} job`).find((step) =>
+        String(step.uses).startsWith("actions/download-artifact@")
+      );
+      assert(download, `${jobName} must download the built runtime workspace`);
+      assertEquals(
+        asRecord(download.with, `${jobName} artifact download`).name,
+        "npm-runtime-workspace-${{ github.sha }}",
+      );
+      assertEquals(
+        asRecord(download.with, `${jobName} artifact download`).path,
+        "dist/npm-runtime-workspace",
+      );
+      const steps = jobSteps(job, `${jobName} job`);
+      const restore = namedStep(job, "Restore npm runtime workspace");
+      const run = namedStep(job, stepName);
+      assertStringIncludes(
+        String(restore.run),
+        "tar -xzf dist/npm-runtime-workspace/npm-runtime-workspace.tar.gz",
+      );
+      assertStringIncludes(String(restore.run), "mkdir -p node_modules");
+      assert(
+        steps.indexOf(download) < steps.indexOf(restore) &&
+          steps.indexOf(restore) < steps.indexOf(run),
+        `${jobName} must restore the runtime workspace before tests`,
+      );
+      assertEquals(run.run, directCommand);
+      assertEquals(
+        steps.filter((step) =>
+          String(step.run).includes("deno task build:npm") ||
+          String(step.run).includes("npm --prefix npm install")
+        ).length,
+        0,
+        `${jobName} must not rebuild or reinstall the runtime workspace`,
+      );
+    }
+  });
+
+  it("runs two required Node shards without duplicating test files", async () => {
+    const jobs = await readJobs();
+    const node = asRecord(jobs["tests-node"], "Node sharding job");
+    const strategy = asRecord(node.strategy, "Node sharding strategy");
+    const matrix = asRecord(strategy.matrix, "Node sharding matrix");
+
+    assertEquals(jobs["tests-node-sharded-shadow"], undefined);
+    assertEquals(node["continue-on-error"], undefined);
+    assertEquals(node.needs, ["npm-compatibility-artifact"]);
+    assertEquals(node.name, "tests (node shard ${{ matrix.shard }}/2)");
+    assertEquals(strategy["fail-fast"], false);
+    assertEquals(matrix.shard, [1, 2]);
+    assertStringIncludes(
+      String(namedStep(node, "Restore npm runtime workspace").run),
+      "tar -xzf dist/npm-runtime-workspace/npm-runtime-workspace.tar.gz",
+    );
+    const run = namedStep(node, "Run Node runtime shard");
+    assertEquals(
+      asRecord(run.env, "Node sharding environment").VF_TEST_SHARD,
+      "${{ matrix.shard }}/2",
+    );
+    assertEquals(
+      run.run,
+      "node ./tests/node/run-tests.mjs --suite=runtime:node",
+    );
+    const report = namedStep(node, "Report Node shard duration");
+    assertEquals(report.if, "${{ always() }}");
+    assertStringIncludes(String(report.run), "Node shard ${SHARD}: ${duration_seconds}s");
   });
 
   it("publishes the tested artifact for both prerelease and stable releases", async () => {
@@ -275,7 +411,7 @@ describe("canonical npm artifact workflow", () => {
     }
   });
 
-  it("reports a reproducible five-to-one estimated build runner-minute comparison", async () => {
+  it("reports the measured seven-to-one build reuse and incremental savings", async () => {
     const jobs = await readJobs();
     const runtime = asRecord(
       jobs["tests-runtime-critical-flow"],
@@ -291,8 +427,8 @@ describe("canonical npm artifact workflow", () => {
       2,
       "The npm install smoke must have two Node consumers",
     );
-    const estimatedConsumerCount = runtimes.length + NPM_SMOKE_NODE_VERSIONS.length;
-    assertEquals(estimatedConsumerCount, 5);
+    const legacyBuildSiteCount = runtimes.length + NPM_SMOKE_NODE_VERSIONS.length + 2;
+    assertEquals(legacyBuildSiteCount, 7);
     const gate = asRecord(jobs["quality-gate-artifact"], "artifact gate");
     const step = namedStep(gate, "Report npm build reuse");
     assertEquals(
@@ -305,7 +441,12 @@ describe("canonical npm artifact workflow", () => {
       {
         BUILD_DURATION_SECONDS:
           "${{ needs.npm-compatibility-artifact.outputs.build_duration_seconds }}",
-        LEGACY_BUILD_COUNT: String(estimatedConsumerCount),
+        RUNTIME_WORKSPACE_ARCHIVE_BYTES:
+          "${{ needs.npm-compatibility-artifact.outputs.runtime_workspace_archive_bytes }}",
+        RUNTIME_WORKSPACE_ARCHIVE_DURATION_SECONDS:
+          "${{ needs.npm-compatibility-artifact.outputs.runtime_workspace_archive_duration_seconds }}",
+        LEGACY_BUILD_COUNT: String(legacyBuildSiteCount),
+        PREVIOUS_BUILD_COUNT: "3",
         CANONICAL_BUILD_COUNT: "1",
       },
     );
@@ -316,7 +457,10 @@ describe("canonical npm artifact workflow", () => {
         env: {
           GITHUB_STEP_SUMMARY: summary,
           BUILD_DURATION_SECONDS: "120",
-          LEGACY_BUILD_COUNT: String(estimatedConsumerCount),
+          RUNTIME_WORKSPACE_ARCHIVE_BYTES: "26214400",
+          RUNTIME_WORKSPACE_ARCHIVE_DURATION_SECONDS: "1",
+          LEGACY_BUILD_COUNT: String(legacyBuildSiteCount),
+          PREVIOUS_BUILD_COUNT: "3",
           CANONICAL_BUILD_COUNT: "1",
         },
       }).output();
@@ -324,19 +468,27 @@ describe("canonical npm artifact workflow", () => {
       const report = await Deno.readTextFile(summary);
       assertStringIncludes(
         report,
-        "Estimate basis: five current npm build consumers (three runtime critical-flow jobs and two npm install-smoke jobs)",
+        "Estimate basis: seven legacy npm build sites (three runtime critical-flow jobs, two npm install-smoke jobs, Node tests, and Bun tests)",
       );
       assertStringIncludes(
         report,
-        "Estimated before: 10.00 npm build runner-minutes",
+        "Legacy independent builds: 14.00 npm build runner-minutes",
       );
       assertStringIncludes(
         report,
-        "Estimated after: 2.00 npm build runner-minutes",
+        "Previous partial reuse: 6.00 npm build runner-minutes",
       );
       assertStringIncludes(
         report,
-        "Estimated savings: 8.00 npm build runner-minutes",
+        "Canonical build: 2.00 npm build runner-minutes",
+      );
+      assertStringIncludes(
+        report,
+        "Incremental savings: 4.00 npm build runner-minutes",
+      );
+      assertStringIncludes(
+        report,
+        "Measured runtime workspace archive: 25.00 MiB in 1s",
       );
     } finally {
       await Deno.remove(summary);

--- a/tests/integration/ci/registry-release-workflow.test.ts
+++ b/tests/integration/ci/registry-release-workflow.test.ts
@@ -5,6 +5,16 @@ import { fromFileUrl } from "#std/path";
 import { parse } from "#std/yaml/parse";
 
 type YamlRecord = Record<string, unknown>;
+const MERGE_CORRECTNESS_DEPENDENCIES = [
+  "ci",
+  "unit-tests",
+  "coverage",
+  "tests",
+  "tests-node",
+  "tests-bun",
+  "tests-binary-e2e",
+  "tests-e2e-rsc-browser",
+] as const;
 
 const WORKFLOW_PATH = new URL(
   "../../../.github/workflows/cicd.yml",
@@ -574,10 +584,15 @@ describe("registry release workflow", () => {
           job.needs.includes("quality-gate-artifact"),
         `${jobName} must require the canonical artifact quality gate`,
       );
-      if (jobName === "release") {
-        assert(
-          job.needs.includes("coverage"),
-          "stable release must retain the coverage dependency",
+      assert(
+        job.needs.includes("quality-gate-merge"),
+        `${jobName} must require the complete merge correctness gate`,
+      );
+      for (const dependency of MERGE_CORRECTNESS_DEPENDENCIES) {
+        assertEquals(
+          job.needs.includes(dependency),
+          false,
+          `${jobName} must inherit ${dependency} through quality-gate-merge`,
         );
       }
     });
@@ -848,21 +863,6 @@ describe("registry release workflow", () => {
         "Selected published version is empty",
       );
     }
-  });
-
-  it("documents the five-build estimate against the current npm build consumers", async () => {
-    const jobs = await readJobs();
-    const gate = asRecord(jobs["quality-gate-artifact"], "artifact gate");
-    const report = namedStep(gate, "Report npm build reuse");
-
-    assertEquals(
-      asRecord(report.env, "npm build reuse environment").LEGACY_BUILD_COUNT,
-      "5",
-    );
-    assertStringIncludes(
-      String(report.run),
-      "Estimate basis: five current npm build consumers (three runtime critical-flow jobs and two npm install-smoke jobs)",
-    );
   });
 
   it("keeps stable production approval and publishing in the release job", async () => {

--- a/tests/load-suite-plan.mjs
+++ b/tests/load-suite-plan.mjs
@@ -14,6 +14,7 @@ const PLANNER_CONFIG_PATH = fileURLToPath(
  * Runtime adapters retain process ownership; this helper only crosses the
  * TypeScript/JavaScript module boundary with a versioned JSON value.
  */
+/** Loads the ordered test paths for a suite, including any external shard selection. */
 export function loadSuitePlan({
   suite,
   patterns = [],

--- a/tests/load-suite-plan.mjs
+++ b/tests/load-suite-plan.mjs
@@ -19,6 +19,7 @@ export function loadSuitePlan({
   patterns = [],
   include = [],
   exclude = [],
+  shard,
   cwd = process.cwd(),
 }) {
   const args = [
@@ -31,6 +32,7 @@ export function loadSuitePlan({
     `--root=${cwd}`,
     ...include.map((pattern) => `--include=${pattern}`),
     ...exclude.map((pattern) => `--exclude=${pattern}`),
+    ...(shard ? [`--shard=${shard}`] : []),
     ...(patterns.length > 0 ? ["--", ...patterns] : []),
   ];
   const result = spawnSync("deno", args, {

--- a/tests/node/run-tests.mjs
+++ b/tests/node/run-tests.mjs
@@ -57,6 +57,7 @@ const envExcludePatterns = (process.env.NODE_TEST_EXCLUDE || process.env.VF_TEST
   .split(",")
   .map((value) => value.trim())
   .filter(Boolean);
+const externalShard = process.env.NODE_TEST_SHARD || process.env.VF_TEST_SHARD || undefined;
 
 function selectedTestFiles() {
   const files = loadSuitePlan({
@@ -64,6 +65,7 @@ function selectedTestFiles() {
     patterns,
     include: includePatterns,
     exclude: envExcludePatterns,
+    shard: externalShard,
   });
   if (files.length === 0) {
     console.error(

--- a/tests/node/run-tests.mjs
+++ b/tests/node/run-tests.mjs
@@ -59,6 +59,7 @@ const envExcludePatterns = (process.env.NODE_TEST_EXCLUDE || process.env.VF_TEST
   .filter(Boolean);
 const externalShard = process.env.NODE_TEST_SHARD || process.env.VF_TEST_SHARD || undefined;
 
+/** Returns the ordered files for this Node shard and rejects an empty selection. */
 function selectedTestFiles() {
   const files = loadSuitePlan({
     suite: suite ?? "runtime:node",

--- a/tests/runtime-test-filters.test.ts
+++ b/tests/runtime-test-filters.test.ts
@@ -44,14 +44,17 @@ const ELIGIBLE_FILES = [
 
 describe("runtime test filters", () => {
   it("keeps external runtime shards complete and disjoint", () => {
-    const full = loadSuitePlan({ suite: "runtime:node" });
+    const cwd = fromFileUrl(new URL("../", import.meta.url));
+    const full = loadSuitePlan({ suite: "runtime:node", cwd });
     const first = loadSuitePlan({
       suite: "runtime:node",
       shard: "1/2",
+      cwd,
     });
     const second = loadSuitePlan({
       suite: "runtime:node",
       shard: "2/2",
+      cwd,
     });
 
     assert(first.length > 0 && second.length > 0);

--- a/tests/runtime-test-filters.test.ts
+++ b/tests/runtime-test-filters.test.ts
@@ -25,7 +25,7 @@ import {
   hasRuntimeGuardedDenoHeader,
   isDenoDependentTestSource,
 } from "./test-file-utils.mjs";
-import { validateSuitePlan } from "./load-suite-plan.mjs";
+import { loadSuitePlan, validateSuitePlan } from "./load-suite-plan.mjs";
 
 /** The files the shared list exists to exclude. */
 const DENO_ONLY_FILES = [
@@ -43,6 +43,23 @@ const ELIGIBLE_FILES = [
 ];
 
 describe("runtime test filters", () => {
+  it("keeps external runtime shards complete and disjoint", () => {
+    const full = loadSuitePlan({ suite: "runtime:node" });
+    const first = loadSuitePlan({
+      suite: "runtime:node",
+      shard: "1/2",
+    });
+    const second = loadSuitePlan({
+      suite: "runtime:node",
+      shard: "2/2",
+    });
+
+    assert(first.length > 0 && second.length > 0);
+    assertEquals(new Set([...first, ...second]).size, full.length);
+    assertEquals([...new Set([...first, ...second])].sort(), [...full].sort());
+    assertEquals(first.some((file) => second.includes(file)), false);
+  });
+
   it("fails loudly when Node filters select no files", async () => {
     const output = await new Deno.Command("node", {
       args: [


### PR DESCRIPTION
## Summary

- make the README badge report merge-queue CI instead of release outcomes
- reuse one SHA-addressed npm workspace across Node and Bun jobs
- split the measured Node critical path into two complete required shards
- make release paths inherit the complete merge and artifact quality gates
- report build reuse, archive cost, and shard timing for follow-up tuning

## Why

Main run 33060202121 attempt 1 had green merge correctness but a failed prerelease job, so the workflow-level badge reported failure. Recent runs also spent 153 to 183 seconds rebuilding npm output in Node and Bun jobs, and Node remained the critical path.

## Validation

- [x] pinned Deno 2.7.7 npm build
- [x] canonical artifact contract suite
- [x] full unsharded Node suite
- [x] both complete and disjoint Node shards
- [x] Bun restored-workspace smoke
- [x] CI, release, and security workflow contract suites
- [x] CI TypeScript lint, format, YAML parse, and diff check
- [x] repository pre-push gate: 4,390 unit tests and 36,175 steps

## Measured impact

- npm workspace: 134 MB, 25 MB fast-gzip archive in 0.88 seconds locally
- Node plan: 1,337 files split 669 and 668
- local Node: 136 seconds unsharded, 99 seconds for the heavier shard alone
- prior GitHub run: npm producer 155 seconds, Node step 746 seconds

## Follow-up

Exact-SHA reuse between merge queue and main remains intentionally deferred. It needs a separate CI/CD workflow split and fail-closed attestation fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/CD Improvements**
  - Streamlined Node and Bun runtime testing by sharing a prepared runtime workspace.
  - Added sharded Node test execution for more efficient validation.
  - Consolidated release readiness checks behind quality gates.
  - Expanded workflow reporting with archive size, duration, and build-reuse metrics.
  - Quality checks now run consistently across workflow events.

- **Documentation**
  - Updated the README CI badge to reflect merge-group validation.

- **Tests**
  - Added coverage for runtime workspace reuse, test sharding, release dependencies, and quality-gate behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->