### PR TITLE
fix(server): contain unhandled rejections on Node

### DIFF
--- a/src/server/unhandled-rejection-guard.test.ts
+++ b/src/server/unhandled-rejection-guard.test.ts
@@ -1,6 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { runtimeProcess } from "#veryfront/platform/compat/process/runtime-process.ts";
+import { isNode } from "#veryfront/platform/compat/runtime.ts";
 import { installUnhandledRejectionGuard } from "#veryfront/server/unhandled-rejection-guard.ts";
 
 interface RecordedLog {
@@ -53,6 +55,44 @@ function rejectionEvent(reason: unknown) {
 }
 
 describe("server/unhandled-rejection-guard", () => {
+  it({
+    name: "installs one lease-shared listener on the real Node process",
+    skip: !isNode,
+  }, () => {
+    assertExists(runtimeProcess);
+    const logger = createFakeLogger();
+    const eventType = "unhandledRejection";
+    const originalListeners = runtimeProcess.listeners(eventType);
+    const originalListenerSet = new Set(originalListeners);
+    const first = installUnhandledRejectionGuard({ logger });
+    const second = installUnhandledRejectionGuard({ logger });
+
+    try {
+      assertEquals(first.installed, true);
+      assertEquals(second.installed, true);
+      assertEquals(runtimeProcess.listenerCount(eventType), originalListeners.length + 1);
+
+      const listener = runtimeProcess.listeners(eventType).find((candidate) =>
+        !originalListenerSet.has(candidate)
+      );
+      assertExists(listener);
+      listener(new Error("HTTP client disconnected"), Promise.resolve());
+
+      assertEquals(first.getRejectionCount(), 1);
+      assertEquals(second.getRejectionCount(), 1);
+      assertEquals(logger.errors.length, 1);
+      assertStringIncludes(String(logger.errors[0]?.context.error), "HTTP client disconnected");
+
+      first.dispose();
+      assertEquals(runtimeProcess.listenerCount(eventType), originalListeners.length + 1);
+      second.dispose();
+      assertEquals(runtimeProcess.listenerCount(eventType), originalListeners.length);
+    } finally {
+      first.dispose();
+      second.dispose();
+    }
+  });
+
   it("subscribes to unhandled rejections on the process", () => {
     const target = createFakeTarget();
     const guard = installUnhandledRejectionGuard({ target, logger: createFakeLogger() });

--- a/src/server/unhandled-rejection-guard.ts
+++ b/src/server/unhandled-rejection-guard.ts
@@ -26,6 +26,7 @@
  * @module server/unhandled-rejection-guard
  */
 
+import { runtimeProcess } from "#veryfront/platform/compat/process/runtime-process.ts";
 import { serverLogger } from "#veryfront/utils";
 
 /** Minimal view of the rejection event both Deno and browsers dispatch. */
@@ -38,6 +39,13 @@ interface GuardEventTarget {
   addEventListener(type: string, listener: (event: unknown) => void): void;
   removeEventListener(type: string, listener: (event: unknown) => void): void;
 }
+
+interface GuardProcessTarget {
+  on(type: "unhandledRejection", listener: (reason: unknown) => void): void;
+  off(type: "unhandledRejection", listener: (reason: unknown) => void): void;
+}
+
+type GuardTarget = GuardEventTarget | GuardProcessTarget;
 
 interface GuardLogger {
   error(message: string, context?: Record<string, unknown>): void;
@@ -68,7 +76,8 @@ export interface UnhandledRejectionGuardHandle {
   dispose(): void;
 }
 
-const EVENT_TYPE = "unhandledrejection";
+const EVENT_TARGET_TYPE = "unhandledrejection";
+const PROCESS_EVENT_TYPE = "unhandledRejection";
 
 /**
  * One listener per target, shared by every holder.
@@ -83,7 +92,7 @@ interface GuardLease {
   rejectionCount: number;
 }
 
-const guardedTargets = new WeakMap<GuardEventTarget, GuardLease>();
+const guardedTargets = new WeakMap<GuardTarget, GuardLease>();
 
 function describeReason(reason: unknown): { error: string; stack?: string } {
   if (reason instanceof Error) {
@@ -95,12 +104,40 @@ function describeReason(reason: unknown): { error: string; stack?: string } {
   return { error: String(reason) };
 }
 
-function resolveDefaultTarget(): GuardEventTarget | undefined {
-  const candidate = globalThis as Partial<GuardEventTarget>;
+function isEventTarget(target: GuardTarget): target is GuardEventTarget {
+  const candidate = target as Partial<GuardEventTarget>;
   return typeof candidate.addEventListener === "function" &&
-      typeof candidate.removeEventListener === "function"
-    ? candidate as GuardEventTarget
-    : undefined;
+    typeof candidate.removeEventListener === "function";
+}
+
+function resolveDefaultTarget(): GuardTarget | undefined {
+  const globalTarget = globalThis as Partial<GuardEventTarget>;
+  if (
+    typeof globalTarget.addEventListener === "function" &&
+    typeof globalTarget.removeEventListener === "function"
+  ) {
+    return globalTarget as GuardEventTarget;
+  }
+
+  // Node and Bun expose the fatal rejection hook through process events, not
+  // global EventTarget methods.
+  if (runtimeProcess) return runtimeProcess;
+}
+
+function subscribe(target: GuardTarget, listener: (event: unknown) => void): void {
+  if (isEventTarget(target)) {
+    target.addEventListener(EVENT_TARGET_TYPE, listener);
+    return;
+  }
+  target.on(PROCESS_EVENT_TYPE, listener);
+}
+
+function unsubscribe(target: GuardTarget, listener: (event: unknown) => void): void {
+  if (isEventTarget(target)) {
+    target.removeEventListener(EVENT_TARGET_TYPE, listener);
+    return;
+  }
+  target.off(PROCESS_EVENT_TYPE, listener);
 }
 
 const disposedHandle: UnhandledRejectionGuardHandle = Object.freeze({
@@ -118,7 +155,7 @@ const disposedHandle: UnhandledRejectionGuardHandle = Object.freeze({
 export function installUnhandledRejectionGuard(
   options: UnhandledRejectionGuardOptions = {},
 ): UnhandledRejectionGuardHandle {
-  const target = options.target ?? resolveDefaultTarget();
+  const target: GuardTarget | undefined = options.target ?? resolveDefaultTarget();
   if (!target) return disposedHandle;
 
   const logger = options.logger ?? guardLog;
@@ -131,7 +168,7 @@ export function installUnhandledRejectionGuard(
       holders: 1,
       rejectionCount: 0,
       listener: (event: unknown): void => {
-        const rejection = event as UnhandledRejectionEventLike;
+        const rejection = isEventTarget(target) ? event as UnhandledRejectionEventLike : undefined;
         // Suppress first. Deno terminates the process unless the default is
         // prevented, and a reason with a throwing toString, or a logger that
         // fails, must not be able to cost the process its containment.
@@ -144,7 +181,7 @@ export function installUnhandledRejectionGuard(
         created.rejectionCount++;
         try {
           logger.error("Contained an unhandled promise rejection", {
-            ...describeReason(rejection?.reason),
+            ...describeReason(rejection ? rejection.reason : event),
             rejectionCount: created.rejectionCount,
           });
         } catch {
@@ -153,7 +190,7 @@ export function installUnhandledRejectionGuard(
         }
       },
     };
-    target.addEventListener(EVENT_TYPE, created.listener);
+    subscribe(target, created.listener);
     guardedTargets.set(target, created);
     lease = created;
   }
@@ -169,7 +206,7 @@ export function installUnhandledRejectionGuard(
       released = true;
       held.holders--;
       if (held.holders > 0) return;
-      target.removeEventListener(EVENT_TYPE, held.listener);
+      unsubscribe(target, held.listener);
       if (guardedTargets.get(target) === held) guardedTargets.delete(target);
     },
   };

--- a/src/server/unhandled-rejection-guard.ts
+++ b/src/server/unhandled-rejection-guard.ts
@@ -53,7 +53,7 @@ interface GuardLogger {
 
 export interface UnhandledRejectionGuardOptions {
   /** Defaults to the global process event target. */
-  target?: GuardEventTarget;
+  target?: GuardTarget;
   /** Defaults to the server logger. */
   logger?: GuardLogger;
 }

--- a/src/server/unhandled-rejection-guard.ts
+++ b/src/server/unhandled-rejection-guard.ts
@@ -52,7 +52,7 @@ interface GuardLogger {
 }
 
 export interface UnhandledRejectionGuardOptions {
-  /** Defaults to the global process event target. */
+  /** Defaults to the global EventTarget, with a runtime process fallback. */
   target?: GuardTarget;
   /** Defaults to the server logger. */
   logger?: GuardLogger;


### PR DESCRIPTION
## Summary

Fixes #4257.

### Root cause

Node does not expose unhandled promise rejections through global `addEventListener`. The default guard only checked the EventTarget API, so in Node it silently returned `installed=false` and left shared servers without rejection containment.

### Minimal fix

- keep the EventTarget path first for Deno and browser-like runtimes
- fall back to `runtimeProcess` for Node/Bun process `unhandledRejection`
- preserve the existing lease semantics and public guard API

### Verification

RED:
- filtered Node runtime test before the fix: 13 passed / 1 failed, Expected true got false

GREEN:
- focused Deno suite: 13 existing steps pass, Node real-process case skipped under Deno
- Node 22.23.2 filtered runtime suite: 14/14 pass
- real Node 22.23.2 unhandled `AbortError` child process exited 0 with `installed=true`, `count=1`, `logs=1`
- typecheck passed
- touched-file fmt/lint/check passed
- git diff check passed

### Notes

Local full `lint:ci` reaches the docs link stage after preceding lint stages pass, then reproduces the same pinned Deno 2.7.7 source-link one-line-low failure on both this branch and `origin/main`; that baseline issue is separate from this change.

Locating the second page-data promise is out of scope for this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved unhandled-rejection handling across browser, Deno, Node.js, and Bun environments.
  - Ensured multiple guards coordinate correctly, preventing duplicate logging and maintaining accurate rejection counts.
  - Improved listener cleanup so monitoring remains active until all configured guards are released.

- **Tests**
  - Added coverage validating shared monitoring behavior and cleanup in Node.js environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->