### PR TITLE
Keep merge-group validation anchored to the queue base

### DIFF
--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -1138,10 +1138,7 @@ jobs:
             const pullNumber = Number(process.env.PULL_NUMBER);
             const sourceHeadSha = process.env.SOURCE_HEAD_SHA;
             const baseSha = context.payload.merge_group.base_sha;
-            // The trusted default-branch helper returns sourceHeadSha until
-            // this compatibility fix itself has passed the merge queue.
-            const serializedBaseSha = queueEntry.baseHeadSha ??
-              queueEntry.sourceHeadSha;
+            const serializedBaseSha = queueEntry.baseHeadSha;
             if (
               !Number.isSafeInteger(pullNumber) ||
               pullNumber !== queueEntry.pullNumber ||

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -3797,8 +3797,8 @@ describe("automated review workflow", () => {
       "the publisher must capture its status boundary immediately after acquiring the lock",
     );
     assert(
-      mergeGroupScript.includes("queueEntry.sourceHeadSha"),
-      "the merge-group job must remain compatible with the trusted pre-fix parser until this PR merges",
+      !mergeGroupScript.includes("queueEntry.sourceHeadSha"),
+      "the merge-group job must serialize the queue base from queueEntry.baseHeadSha only",
     );
     for (
       const required of [


### PR DESCRIPTION
Summary
- Require merge-group validation to use queueEntry.baseHeadSha as the serialized queue base.
- Update the workflow regression check so the source-head compatibility fallback cannot return.

Verification
- deno task test:file scripts/ci/automated-review-gate.test.ts

Closes veryfront/veryfront-issue-inbox#834