### PR TITLE
ci: make Sonar failures block unsafe merges

### DIFF
--- a/.github/QUALITY_GATES.md
+++ b/.github/QUALITY_GATES.md
@@ -10,13 +10,13 @@ protects a distinct delivery boundary.
 eight-shard coverage dependency with its 80 percent floor, integration tests,
 the full Node and Bun runtime suites, binary end-to-end tests, and RSC browser
 end-to-end tests to succeed for pull requests, merge queue runs, and main
-pushes. Sonar analysis is also mandatory for merge queue runs, main pushes, and
-trusted pull requests. A failed, skipped, or cancelled dependency fails the
-aggregate check, except that Sonar is intentionally skipped and ignored for
-fork and Dependabot pull requests because those runs cannot receive
-`SONAR_TOKEN`. Fork pull requests still skip other protected dependency jobs
-and therefore fail this aggregate gate closed. Codecov reporting remains
-advisory.
+pushes. Sonar analysis is also mandatory for merge queue runs, main pushes,
+manually dispatched runs, and trusted pull requests. A failed, skipped, or
+cancelled dependency fails the aggregate check, except that Sonar is
+intentionally skipped and ignored for fork and Dependabot pull requests because
+those runs cannot receive `SONAR_TOKEN`. Fork pull requests still skip other
+protected dependency jobs and therefore fail this aggregate gate closed.
+Codecov reporting remains advisory.
 
 Evidence: [CI workflow](workflows/cicd.yml) and
 [merge gate contract](../tests/integration/ci/merge-quality-gate-workflow.test.ts).

--- a/.github/QUALITY_GATES.md
+++ b/.github/QUALITY_GATES.md
@@ -9,11 +9,14 @@ protects a distinct delivery boundary.
 `quality gate (merge)` requires source checks, unit tests, the existing
 eight-shard coverage dependency with its 80 percent floor, integration tests,
 the full Node and Bun runtime suites, binary end-to-end tests, and RSC browser
-end-to-end tests to succeed for pull requests and merge queue runs. A failed,
-skipped, or cancelled dependency fails the aggregate check. The job is scoped
-to those two event types; it does not run on ordinary pushes. Fork pull
-requests skip protected dependency jobs and therefore fail this aggregate gate
-closed. Codecov reporting remains advisory.
+end-to-end tests to succeed for pull requests, merge queue runs, and main
+pushes. Sonar analysis is also mandatory for merge queue runs, main pushes, and
+trusted pull requests. A failed, skipped, or cancelled dependency fails the
+aggregate check, except that Sonar is intentionally skipped and ignored for
+fork and Dependabot pull requests because those runs cannot receive
+`SONAR_TOKEN`. Fork pull requests still skip other protected dependency jobs
+and therefore fail this aggregate gate closed. Codecov reporting remains
+advisory.
 
 Evidence: [CI workflow](workflows/cicd.yml) and
 [merge gate contract](../tests/integration/ci/merge-quality-gate-workflow.test.ts).

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -488,7 +488,7 @@ jobs:
     timeout-minutes: 15
     name: sonar
     needs: [coverage-shards]
-    if: ${{ needs.coverage-shards.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event.pull_request.user.login != 'dependabot[bot]' }}
+    if: ${{ needs.coverage-shards.result == 'success' && ((github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]')) }}
     permissions:
       contents: read
     steps:
@@ -753,7 +753,7 @@ jobs:
         env:
           # Sonar needs SONAR_TOKEN, so fork and Dependabot PRs intentionally
           # skip it. Pushes, merge-group runs, and trusted PRs must block on it.
-          SONAR_REQUIRED: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
+          SONAR_REQUIRED: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') }}
           SOURCE_CHECKS_RESULT: ${{ needs.ci.result }}
           UNIT_TESTS_RESULT: ${{ needs.unit-tests.result }}
           COVERAGE_RESULT: ${{ needs.coverage.result }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -746,13 +746,18 @@ jobs:
       - tests-bun
       - tests-binary-e2e
       - tests-e2e-rsc-browser
+      - sonar
     if: ${{ always() }}
     steps:
       - name: Require merge correctness dependencies
         env:
+          # Sonar needs SONAR_TOKEN, so fork and Dependabot PRs intentionally
+          # skip it. Pushes, merge-group runs, and trusted PRs must block on it.
+          SONAR_REQUIRED: ${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}
           SOURCE_CHECKS_RESULT: ${{ needs.ci.result }}
           UNIT_TESTS_RESULT: ${{ needs.unit-tests.result }}
           COVERAGE_RESULT: ${{ needs.coverage.result }}
+          SONAR_RESULT: ${{ needs.sonar.result }}
           INTEGRATION_TESTS_RESULT: ${{ needs.tests.result }}
           NODE_RUNTIME_TESTS_RESULT: ${{ needs.tests-node.result }}
           BUN_RUNTIME_TESTS_RESULT: ${{ needs.tests-bun.result }}
@@ -764,6 +769,7 @@ jobs:
             SOURCE_CHECKS_RESULT \
             UNIT_TESTS_RESULT \
             COVERAGE_RESULT \
+            SONAR_RESULT \
             INTEGRATION_TESTS_RESULT \
             NODE_RUNTIME_TESTS_RESULT \
             BUN_RUNTIME_TESTS_RESULT \
@@ -771,6 +777,9 @@ jobs:
             RSC_BROWSER_E2E_RESULT
           do
             result="${!result_name}"
+            if [ "$result_name" = "SONAR_RESULT" ] && [ "$SONAR_REQUIRED" != "true" ]; then
+              continue
+            fi
             if [ "$result" != "success" ]; then
               echo "::error::$result_name finished with $result"
               failed=1

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,6 +6,7 @@ sonar.sources=.
 sonar.exclusions=coverage-profiles/**
 
 sonar.javascript.lcov.reportPaths=coverage-profiles/coverage-shard-*/lcov.info
+sonar.javascript.node.maxspace=8192
 
 # Excluded from the coverage ratio only; these files are still analysed.
 #

--- a/src/config/cicd-coverage-workflow.test.ts
+++ b/src/config/cicd-coverage-workflow.test.ts
@@ -150,6 +150,12 @@ describe("cicd coverage workflow", () => {
     assertStringIncludes(workflow, "actions/download-artifact");
     assertStringIncludes(workflow, "Download unit coverage lcov files");
     assertStringIncludes(workflow, "pattern: coverage-shard-*");
+    assertStringIncludes(workflow, "sonar:");
+    assertStringIncludes(workflow, "name: sonar");
+    assertStringIncludes(
+      await readRepoFile("sonar-project.properties"),
+      "sonar.javascript.node.maxspace=8192",
+    );
     assertStringIncludes(
       workflow,
       "deno task coverage:ci:merge coverage-profiles/coverage-shard-*",

--- a/tests/integration/ci/merge-quality-gate-workflow.test.ts
+++ b/tests/integration/ci/merge-quality-gate-workflow.test.ts
@@ -152,6 +152,12 @@ describe("merge quality gate workflow", () => {
     assertEquals(gateEnv.SONAR_REQUIRED, SONAR_REQUIRED_EXPRESSION);
   });
 
+  it("documents Sonar enforcement for manually dispatched runs", async () => {
+    const qualityGates = await readRepoFile(".github/QUALITY_GATES.md");
+
+    assertStringIncludes(qualityGates, "manually dispatched runs");
+  });
+
   it("blocks every release path on the complete merge correctness gate", async () => {
     const workflow = await readWorkflow();
     const jobs = asRecord(workflow.jobs, "cicd workflow jobs");

--- a/tests/integration/ci/merge-quality-gate-workflow.test.ts
+++ b/tests/integration/ci/merge-quality-gate-workflow.test.ts
@@ -17,11 +17,13 @@ const REQUIRED_DEPENDENCIES = [
   "tests-bun",
   "tests-binary-e2e",
   "tests-e2e-rsc-browser",
+  "sonar",
 ] as const;
 const RESULT_ENV = {
   SOURCE_CHECKS_RESULT: "${{ needs.ci.result }}",
   UNIT_TESTS_RESULT: "${{ needs.unit-tests.result }}",
   COVERAGE_RESULT: "${{ needs.coverage.result }}",
+  SONAR_RESULT: "${{ needs.sonar.result }}",
   INTEGRATION_TESTS_RESULT: "${{ needs.tests.result }}",
   NODE_RUNTIME_TESTS_RESULT: "${{ needs.tests-node.result }}",
   BUN_RUNTIME_TESTS_RESULT: "${{ needs.tests-bun.result }}",
@@ -66,6 +68,7 @@ function gateStep(job: YamlRecord): YamlRecord {
 
 async function runGate(
   overrides: Partial<Record<keyof typeof RESULT_ENV, string>> = {},
+  options: { sonarRequired?: boolean } = {},
 ): Promise<Deno.CommandOutput> {
   const job = await readMergeGate();
   const step = gateStep(job);
@@ -77,7 +80,10 @@ async function runGate(
   );
   return await new Deno.Command("bash", {
     args: ["-c", String(step.run)],
-    env,
+    env: {
+      ...env,
+      SONAR_REQUIRED: String(options.sonarRequired ?? true),
+    },
     stdout: "piped",
     stderr: "piped",
   }).output();
@@ -122,7 +128,11 @@ describe("merge quality gate workflow", () => {
     assertEquals(gate.if, "${{ always() }}");
     assertEquals(
       asRecord(step.env, "merge quality gate result env"),
-      RESULT_ENV,
+      {
+        SONAR_REQUIRED:
+          "${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}",
+        ...RESULT_ENV,
+      },
     );
   });
 
@@ -230,6 +240,21 @@ describe("merge quality gate workflow", () => {
           `${resultName} finished with ${dependencyResult}`,
         );
       }
+    }
+  });
+
+  it("allows intentional Sonar skips when pull requests cannot receive secrets", async () => {
+    for (const dependencyResult of ["skipped", "success"]) {
+      const result = await runGate(
+        { SONAR_RESULT: dependencyResult },
+        { sonarRequired: false },
+      );
+
+      assertEquals(
+        result.code,
+        0,
+        `SONAR_RESULT=${dependencyResult} must not fail the merge gate when Sonar is intentionally skipped`,
+      );
     }
   });
 });

--- a/tests/integration/ci/merge-quality-gate-workflow.test.ts
+++ b/tests/integration/ci/merge-quality-gate-workflow.test.ts
@@ -30,6 +30,11 @@ const RESULT_ENV = {
   BINARY_E2E_RESULT: "${{ needs.tests-binary-e2e.result }}",
   RSC_BROWSER_E2E_RESULT: "${{ needs.tests-e2e-rsc-browser.result }}",
 } as const;
+const SONAR_REQUIRED_CONDITION =
+  "github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')";
+const SONAR_REQUIRED_EXPRESSION = `\${{ ${SONAR_REQUIRED_CONDITION} }}`;
+const SONAR_JOB_EXPRESSION =
+  "${{ needs.coverage-shards.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event.pull_request.user.login != 'dependabot[bot]' }}";
 
 function asRecord(value: unknown, context: string): YamlRecord {
   assert(
@@ -129,11 +134,22 @@ describe("merge quality gate workflow", () => {
     assertEquals(
       asRecord(step.env, "merge quality gate result env"),
       {
-        SONAR_REQUIRED:
-          "${{ github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]') }}",
+        SONAR_REQUIRED: SONAR_REQUIRED_EXPRESSION,
         ...RESULT_ENV,
       },
     );
+  });
+
+  it("keeps Sonar execution and merge-gate enforcement on the same trust condition", async () => {
+    const workflow = await readWorkflow();
+    const jobs = asRecord(workflow.jobs, "cicd workflow jobs");
+    const sonar = asRecord(jobs.sonar, "sonar job");
+    const gate = asRecord(jobs["quality-gate-merge"], "merge quality gate job");
+    const step = gateStep(gate);
+    const gateEnv = asRecord(step.env, "merge quality gate result env");
+
+    assertEquals(sonar.if, SONAR_JOB_EXPRESSION);
+    assertEquals(gateEnv.SONAR_REQUIRED, SONAR_REQUIRED_EXPRESSION);
   });
 
   it("blocks every release path on the complete merge correctness gate", async () => {

--- a/tests/integration/ci/merge-quality-gate-workflow.test.ts
+++ b/tests/integration/ci/merge-quality-gate-workflow.test.ts
@@ -31,10 +31,10 @@ const RESULT_ENV = {
   RSC_BROWSER_E2E_RESULT: "${{ needs.tests-e2e-rsc-browser.result }}",
 } as const;
 const SONAR_REQUIRED_CONDITION =
-  "github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.login != 'dependabot[bot]')";
+  "(github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]')";
 const SONAR_REQUIRED_EXPRESSION = `\${{ ${SONAR_REQUIRED_CONDITION} }}`;
 const SONAR_JOB_EXPRESSION =
-  "${{ needs.coverage-shards.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.event.pull_request.user.login != 'dependabot[bot]' }}";
+  `\${{ needs.coverage-shards.result == 'success' && (${SONAR_REQUIRED_CONDITION}) }}`;
 
 function asRecord(value: unknown, context: string): YamlRecord {
   assert(
@@ -224,8 +224,10 @@ describe("merge quality gate workflow", () => {
       );
     }
     for (const entrypoint of ["lint:ci", "verify", "verify:quick"]) {
+      const entrypointTask = denoConfig.tasks[entrypoint];
+      assert(entrypointTask, `deno.json must define ${entrypoint}`);
       assertStringIncludes(
-        denoConfig.tasks[entrypoint],
+        entrypointTask,
         "deno task lint:ci-typescript",
         `${entrypoint} must run the CI TypeScript static gate`,
       );


### PR DESCRIPTION
## Why

The first merge-group Sonar scan after #4268 had no analyzer cache and exhausted the 4288 MB Node heap. The Sonar job failed before merge, but the required aggregate merge gate did not depend on it, so the queue still admitted the commit.

## What changed

- Make `quality gate (merge)` depend on and require the Sonar result for push, merge-group, and trusted pull-request runs.
- Preserve intentional Sonar skips for forks and Dependabot, where `SONAR_TOKEN` is unavailable.
- Set `sonar.javascript.node.maxspace=8192` for the documented large-project analyzer heap.
- Lock the dependency, failure, skip, and heap behavior with workflow tests.

## Verification

- Full pre-push gate: formatting, lint, typecheck, generated artifacts, and 4,390 unit tests passed.
- `deno task test:file src/config/cicd-coverage-workflow.test.ts tests/integration/ci/merge-quality-gate-workflow.test.ts`
- `deno task test:file src/security/repository-hardening.test.ts`
- `deno task lint:ci-typescript`
- `git diff --check`

## Risk

Narrow CI-only change. The hosted Sonar job on this PR is the final proof that the larger heap resolves the merge-group failure mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Quality Improvements**
  - Strengthened automated merge checks by incorporating Sonar analysis results where required.
  - Preserved streamlined validation for external contributions that cannot access Sonar credentials.
  - Increased the available memory for JavaScript code analysis to improve reliability on larger projects.

- **Tests**
  - Added coverage to verify Sonar integration, conditional enforcement, and successful handling of optional analysis results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->