### PR TITLE
ci: raise the SonarJS bridge heap

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,6 +7,11 @@ sonar.exclusions=coverage-profiles/**
 
 sonar.javascript.lcov.reportPaths=coverage-profiles/coverage-shard-*/lcov.info
 
+# The SonarJS bridge runs in Node and defaults to a 4288 MB heap, which this
+# project exhausts: the first main analysis died with "the bridge server is
+# unresponsive". Runners have ~16 GB, so raise it.
+sonar.javascript.node.maxspace=8192
+
 # Excluded from the coverage ratio only; these files are still analysed.
 #
 # scripts/test/coverage-ci.ts builds the lcov with --include=src/ and


### PR DESCRIPTION
## Description

The first analysis of `main` under the new CI scanner **failed**, so `main` currently has no Sonar analysis at all — Automatic Analysis is off and the CI scan is the only path.

```
ERROR The analysis will stop due to the Node.js process running out of memory (heap size limit 4288 MB)
      Memory configuration: OS (15988 MB), Node.js (4288 MB)
Caused by: java.lang.IllegalStateException: The bridge server is unresponsive.
      It might be because you don't have enough memory
```

SonarJS runs its analysis bridge as a Node process with a **4288 MB** default heap, which a 643k-line TypeScript project exhausts. The runner has ~16 GB, so `sonar.javascript.node.maxspace=8192` leaves ample headroom for the JVM alongside it.

## Why #4268 didn't catch this

The pull request analysis stayed under the limit — it completed and reported 85.0% coverage over 419,799 lines. The ceiling was only reached analysing the full `main` branch. A PR-green scan is not proof the branch scan fits in memory, which is worth knowing for the next config change of this kind.

## Type of Change

- [x] Bug fix — restores analysis on `main`

## Checklist

- [x] Root cause read from the failing job log, not inferred
- [x] Heap sized against the runner's actual 15,988 MB, not guessed

## Note for the reviewer

If 8192 still proves tight as the codebase grows, the next lever is excluding the committed generated bundles from analysis — `dev-ui-bundle.generated.ts` alone is ~305 KB of minified JS. I deliberately did not do that here: it would change the analysed file set and therefore the issue counts, which is a separate decision from fixing a crash.