### PR TITLE
fix: preserve workflow persistence fences after user hooks

### DIFF
--- a/src/workflow/backends/checkpoint-retention.test.ts
+++ b/src/workflow/backends/checkpoint-retention.test.ts
@@ -877,6 +877,35 @@ describe("workflow checkpoint retention", () => {
     assertEquals(JSON.stringify(snapshot.context.input), expected);
   });
 
+  it("does not inspect proxy symbol descriptors while capturing JSON-visible values", () => {
+    const ignored = Symbol("ignored");
+    let symbolDescriptorCalls = 0;
+    const context: WorkflowContext = {
+      input: {},
+      later: { state: "before" },
+    };
+    const source = { visible: "stored", [ignored]: true };
+    const proxied = new Proxy(source, {
+      getOwnPropertyDescriptor(target, key) {
+        if (key === ignored) {
+          symbolDescriptorCalls++;
+          (context.later as { state: string }).state = "after";
+        }
+        return Reflect.getOwnPropertyDescriptor(target, key);
+      },
+    });
+    context.input = { proxied };
+    const expected = JSON.stringify(context);
+
+    const snapshot = cloneCheckpointForPersistence({
+      ...checkpoint("proxy-symbol-descriptor-order"),
+      context,
+    });
+
+    assertEquals(JSON.stringify(snapshot.context), expected);
+    assertEquals(symbolDescriptorCalls, 0);
+  });
+
   it("snapshots a proxy's dynamic toJSON result", () => {
     const source = { value: "original" };
     const proxied = new Proxy(source, {

--- a/src/workflow/backends/checkpoint-retention.test.ts
+++ b/src/workflow/backends/checkpoint-retention.test.ts
@@ -855,6 +855,28 @@ describe("workflow checkpoint retention", () => {
     );
   });
 
+  it("collects proxy descriptors before traversing property values", () => {
+    const source = {
+      first: { state: "before" },
+      later: true,
+    };
+    const proxied = new Proxy(source, {
+      getOwnPropertyDescriptor(target, key) {
+        if (key === "later") target.first.state = "after";
+        return Reflect.getOwnPropertyDescriptor(target, key);
+      },
+    });
+    const expected = JSON.stringify({ proxied });
+    source.first.state = "before";
+
+    const snapshot = cloneCheckpointForPersistence({
+      ...checkpoint("proxy-descriptor-order"),
+      context: { input: { proxied } },
+    });
+
+    assertEquals(JSON.stringify(snapshot.context.input), expected);
+  });
+
   it("snapshots a proxy's dynamic toJSON result", () => {
     const source = { value: "original" };
     const proxied = new Proxy(source, {

--- a/src/workflow/backends/checkpoint-retention.ts
+++ b/src/workflow/backends/checkpoint-retention.ts
@@ -76,6 +76,7 @@ interface CheckpointCloneTraversalFrame {
   keyIndex?: number;
   keys?: Array<string | symbol>;
   readonly objectProxy?: boolean;
+  proxyDescriptors?: Array<PropertyDescriptor | undefined>;
   readonly source: object;
   readonly target: object;
 }
@@ -823,17 +824,29 @@ function cloneCheckpointValueForPersistence<T>(value: T): T {
       frame.keys = reflectOwnKeys(frame.source);
       frame.keyIndex = 0;
       frame.jsonLookupInstalled = false;
+      if (frame.objectProxy === true) {
+        const descriptors: Array<PropertyDescriptor | undefined> = [];
+        for (const key of frame.keys) {
+          reflectApply(arrayPush, descriptors, [
+            objectGetOwnPropertyDescriptor(frame.source, key),
+          ]);
+        }
+        frame.proxyDescriptors = descriptors;
+      }
     }
     if ((frame.keyIndex ?? 0) < frame.keys.length) {
-      const key = frame.keys[frame.keyIndex ?? 0]!;
-      frame.keyIndex = (frame.keyIndex ?? 0) + 1;
+      const keyIndex = frame.keyIndex ?? 0;
+      const key = frame.keys[keyIndex]!;
+      frame.keyIndex = keyIndex + 1;
       if (
         frame.arrayLength !== undefined &&
         isArrayIndexWithinLength(key, frame.arrayLength)
       ) {
         continue;
       }
-      const descriptor = objectGetOwnPropertyDescriptor(frame.source, key);
+      const descriptor = frame.objectProxy === true
+        ? frame.proxyDescriptors?.[keyIndex]
+        : objectGetOwnPropertyDescriptor(frame.source, key);
       if (descriptor === undefined) continue;
       if (
         key !== "toJSON" &&

--- a/src/workflow/backends/checkpoint-retention.ts
+++ b/src/workflow/backends/checkpoint-retention.ts
@@ -821,17 +821,20 @@ function cloneCheckpointValueForPersistence<T>(value: T): T {
       }
     }
     if (frame.keys === undefined) {
-      frame.keys = reflectOwnKeys(frame.source);
       frame.keyIndex = 0;
       frame.jsonLookupInstalled = false;
       if (frame.objectProxy === true) {
+        const stringKeys: string[] = [];
         const descriptors: Array<PropertyDescriptor | undefined> = [];
-        for (const key of frame.keys) {
-          reflectApply(arrayPush, descriptors, [
-            objectGetOwnPropertyDescriptor(frame.source, key),
-          ]);
+        for (const key of reflectOwnKeys(frame.source)) {
+          if (typeof key === "symbol") continue;
+          reflectApply(arrayPush, stringKeys, [key]);
+          reflectApply(arrayPush, descriptors, [objectGetOwnPropertyDescriptor(frame.source, key)]);
         }
+        frame.keys = stringKeys;
         frame.proxyDescriptors = descriptors;
+      } else {
+        frame.keys = reflectOwnKeys(frame.source);
       }
     }
     if ((frame.keyIndex ?? 0) < frame.keys.length) {

--- a/src/workflow/backends/memory.test.ts
+++ b/src/workflow/backends/memory.test.ts
@@ -446,6 +446,55 @@ describe("MemoryBackend", () => {
       assertEquals(updated?.context.dynamic, "stored");
     });
 
+    it("rechecks conditional run preconditions after context hooks", async () => {
+      const statusRunId = "run-context-reentrant-status-fence";
+      await backend.createRun(createTestRun(statusRunId, {
+        status: "running",
+        workerId: "worker-original",
+      }));
+      const statusHook = {
+        toJSON() {
+          void backend.updateRun(statusRunId, { status: "waiting" });
+          return "stale";
+        },
+      };
+
+      assertEquals(
+        await backend.updateRunIfStatus(statusRunId, ["running"], {
+          context: { input: {}, statusHook },
+        }),
+        false,
+      );
+      const statusRun = await backend.getRun(statusRunId);
+      assertEquals(statusRun?.status, "waiting");
+      assertEquals(statusRun?.context.statusHook, undefined);
+
+      const workerRunId = "run-context-reentrant-worker-fence";
+      await backend.createRun(createTestRun(workerRunId, {
+        status: "running",
+        workerId: "worker-original",
+      }));
+      const workerHook = {
+        toJSON() {
+          void backend.updateRun(workerRunId, { workerId: "worker-replaced" });
+          return "stale";
+        },
+      };
+
+      assertEquals(
+        await backend.updateRunIfStatusAndWorker(
+          workerRunId,
+          ["running"],
+          "worker-original",
+          { context: { input: {}, workerHook } },
+        ),
+        false,
+      );
+      const workerRun = await backend.getRun(workerRunId);
+      assertEquals(workerRun?.workerId, "worker-replaced");
+      assertEquals(workerRun?.context.workerHook, undefined);
+    });
+
     it("deletes context keys omitted by JSON through conditional updates", async () => {
       await backend.createRun(createTestRun("run-context-conditional-omitted", {
         status: "running",
@@ -1091,6 +1140,45 @@ describe("MemoryBackend", () => {
         "Looks good!",
         "a losing decision must not overwrite the recorded comment",
       );
+    });
+
+    it("rechecks the winning approval after decision data hooks", async () => {
+      const runId = "run-approval-reentrant-decision";
+      const approvalId = "approval-reentrant-decision";
+      await backend.savePendingApproval(runId, {
+        id: approvalId,
+        nodeId: "review",
+        status: "pending",
+        message: "Review needed",
+        payload: {},
+        requestedAt: new Date(),
+      });
+      const decisionData = {
+        toJSON() {
+          void backend.updateApproval(runId, approvalId, {
+            approved: true,
+            approver: "winner@example.com",
+            comment: "First decision",
+          });
+          return { source: "loser" };
+        },
+      };
+
+      assertEquals(
+        await backend.updateApproval(runId, approvalId, {
+          approved: false,
+          approver: "loser@example.com",
+          comment: "Late decision",
+          data: decisionData,
+        }),
+        false,
+      );
+
+      const approval = await backend.getPendingApproval(runId, approvalId);
+      assertEquals(approval?.status, "approved");
+      assertEquals(approval?.decidedBy, "winner@example.com");
+      assertEquals(approval?.comment, "First decision");
+      assertEquals(approval?.decisionData, undefined);
     });
 
     it("uses the JSON persistence contract for non-strict approval decision data", async () => {

--- a/src/workflow/backends/memory.test.ts
+++ b/src/workflow/backends/memory.test.ts
@@ -495,6 +495,35 @@ describe("MemoryBackend", () => {
       assertEquals(workerRun?.context.workerHook, undefined);
     });
 
+    it("snapshots conditional statuses before context hooks can mutate them", async () => {
+      const runId = "run-context-mutated-status-input";
+      await backend.createRun(createTestRun(runId, { status: "running" }));
+      const expectedStatuses: WorkflowRun["status"][] = ["running"];
+      let mutatedIncludesCalls = 0;
+      const statusHook = {
+        toJSON() {
+          expectedStatuses.includes = () => {
+            mutatedIncludesCalls++;
+            void backend.updateRun(runId, { status: "waiting" });
+            return true;
+          };
+          return "stored";
+        },
+      };
+
+      assertEquals(
+        await backend.updateRunIfStatus(runId, expectedStatuses, {
+          context: { input: {}, statusHook },
+        }),
+        true,
+      );
+
+      assertEquals(mutatedIncludesCalls, 0);
+      const updated = await backend.getRun(runId);
+      assertEquals(updated?.status, "running");
+      assertEquals(updated?.context.statusHook, "stored");
+    });
+
     it("routes conditional run updates through updateRun overrides", async () => {
       class TrackingMemoryBackend extends MemoryBackend {
         updates = 0;
@@ -1200,6 +1229,50 @@ describe("MemoryBackend", () => {
       assertEquals(approval?.decidedBy, "winner@example.com");
       assertEquals(approval?.comment, "First decision");
       assertEquals(approval?.decisionData, undefined);
+    });
+
+    it("does not decide an approval record replaced by a decision data hook", async () => {
+      const runId = "run-approval-replaced-during-decision";
+      const approvalId = "approval-replaced-during-decision";
+      await backend.createRun(createTestRun(runId, { status: "waiting" }));
+      await backend.savePendingApproval(runId, {
+        id: approvalId,
+        nodeId: "original-review",
+        status: "pending",
+        message: "Original approval",
+        payload: {},
+        requestedAt: new Date(),
+      });
+      const decisionData = {
+        toJSON() {
+          void backend.deleteRun(runId);
+          void backend.createRun(createTestRun(runId, { status: "waiting" }));
+          void backend.savePendingApproval(runId, {
+            id: approvalId,
+            nodeId: "replacement-review",
+            status: "pending",
+            message: "Replacement approval",
+            payload: {},
+            requestedAt: new Date(),
+          });
+          return { source: "stale-decision" };
+        },
+      };
+
+      assertEquals(
+        await backend.updateApproval(runId, approvalId, {
+          approved: true,
+          approver: "stale@example.com",
+          data: decisionData,
+        }),
+        false,
+      );
+
+      const replacement = await backend.getPendingApproval(runId, approvalId);
+      assertEquals(replacement?.nodeId, "replacement-review");
+      assertEquals(replacement?.status, "pending");
+      assertEquals(replacement?.decidedBy, undefined);
+      assertEquals(replacement?.decisionData, undefined);
     });
 
     it("uses the JSON persistence contract for non-strict approval decision data", async () => {

--- a/src/workflow/backends/memory.test.ts
+++ b/src/workflow/backends/memory.test.ts
@@ -495,6 +495,27 @@ describe("MemoryBackend", () => {
       assertEquals(workerRun?.context.workerHook, undefined);
     });
 
+    it("routes conditional run updates through updateRun overrides", async () => {
+      class TrackingMemoryBackend extends MemoryBackend {
+        updates = 0;
+
+        override updateRun(runId: string, patch: Partial<WorkflowRun>): Promise<void> {
+          this.updates++;
+          return super.updateRun(runId, patch);
+        }
+      }
+
+      const trackingBackend = new TrackingMemoryBackend();
+      const runId = "run-conditional-update-override";
+      await trackingBackend.createRun(createTestRun(runId, { status: "running" }));
+
+      assertEquals(
+        await trackingBackend.updateRunIfStatus(runId, ["running"], { status: "waiting" }),
+        true,
+      );
+      assertEquals(trackingBackend.updates, 1);
+    });
+
     it("deletes context keys omitted by JSON through conditional updates", async () => {
       await backend.createRun(createTestRun("run-context-conditional-omitted", {
         status: "running",

--- a/src/workflow/backends/memory.ts
+++ b/src/workflow/backends/memory.ts
@@ -330,12 +330,21 @@ export class MemoryBackend implements WorkflowBackend {
   }
 
   updateRun(runId: string, patch: WorkflowRunUpdate): Promise<void> {
+    return this.applyRunUpdate(runId, patch).then(() => undefined);
+  }
+
+  private applyRunUpdate(
+    runId: string,
+    patch: WorkflowRunUpdate,
+    precondition?: (run: WorkflowRun) => boolean,
+  ): Promise<boolean> {
     const run = this.runs.get(runId);
     // Reject rather than throw synchronously so callers see a rejected Promise
     // consistently (matching the Redis backend's async error paths).
     if (!run) {
       return Promise.reject(RESOURCE_NOT_FOUND.create({ detail: `Run not found: ${runId}` }));
     }
+    if (precondition !== undefined && !precondition(run)) return Promise.resolve(false);
 
     try {
       assertWorkflowRunUpdate(patch);
@@ -364,6 +373,7 @@ export class MemoryBackend implements WorkflowBackend {
     if (!currentRun) {
       return Promise.reject(RESOURCE_NOT_FOUND.create({ detail: `Run not found: ${runId}` }));
     }
+    if (precondition !== undefined && !precondition(currentRun)) return Promise.resolve(false);
     const context = { ...currentRun.context, ...contextPatch };
     if (contextPatch !== undefined) {
       for (const key of patchContextKeys) {
@@ -396,7 +406,7 @@ export class MemoryBackend implements WorkflowBackend {
       this.runEventClaims.delete(runId);
     }
 
-    return Promise.resolve();
+    return Promise.resolve(true);
   }
 
   updateRunIfStatus(
@@ -404,15 +414,11 @@ export class MemoryBackend implements WorkflowBackend {
     expectedStatuses: WorkflowRun["status"][],
     patch: Partial<WorkflowRun>,
   ): Promise<boolean> {
-    const run = this.runs.get(runId);
-    if (!run) {
-      return Promise.reject(RESOURCE_NOT_FOUND.create({ detail: `Run not found: ${runId}` }));
-    }
-    if (!expectedStatuses.includes(run.status)) return Promise.resolve(false);
-
-    // updateRun mutates synchronously before returning, so the status check and
-    // patch are one atomic operation for this in-memory backend.
-    return this.updateRun(runId, patch).then(() => true);
+    return this.applyRunUpdate(
+      runId,
+      patch,
+      (run) => expectedStatuses.includes(run.status),
+    );
   }
 
   updateRunIfStatusAndWorker(
@@ -421,15 +427,11 @@ export class MemoryBackend implements WorkflowBackend {
     expectedWorkerId: string,
     patch: Partial<WorkflowRun>,
   ): Promise<boolean> {
-    const run = this.runs.get(runId);
-    if (!run) {
-      return Promise.reject(RESOURCE_NOT_FOUND.create({ detail: `Run not found: ${runId}` }));
-    }
-    if (!expectedStatuses.includes(run.status) || run.workerId !== expectedWorkerId) {
-      return Promise.resolve(false);
-    }
-
-    return this.updateRun(runId, patch).then(() => true);
+    return this.applyRunUpdate(
+      runId,
+      patch,
+      (run) => expectedStatuses.includes(run.status) && run.workerId === expectedWorkerId,
+    );
   }
 
   restoreRunStateIfStatus(
@@ -879,22 +881,27 @@ export class MemoryBackend implements WorkflowBackend {
       return Promise.resolve(false);
     }
 
+    const { approved, approver, comment, data } = decision;
     let decisionData: unknown;
-    if (decision.data !== undefined) {
+    if (data !== undefined) {
       try {
-        decisionData = persistedApprovalDecisionData(decision.data, runId, this.config);
+        decisionData = persistedApprovalDecisionData(data, runId, this.config);
       } catch (error) {
         return Promise.reject(error);
       }
     }
+    const currentApproval = this.approvals.get(runId)?.find((item) => item.id === approvalId);
+    if (!currentApproval || currentApproval.status !== "pending") {
+      return Promise.resolve(false);
+    }
     logger.debug("Updating approval", { approvalId, decision });
-    approval.status = decision.approved ? "approved" : "rejected";
-    approval.decidedBy = decision.approver;
-    approval.decidedAt = new Date();
-    approval.comment = decision.comment;
-    if (decision.data === undefined) delete approval.decisionData;
-    else approval.decisionData = decisionData;
-    approval.reconciliationPending = true;
+    currentApproval.status = approved ? "approved" : "rejected";
+    currentApproval.decidedBy = approver;
+    currentApproval.decidedAt = new Date();
+    currentApproval.comment = comment;
+    if (data === undefined) delete currentApproval.decisionData;
+    else currentApproval.decisionData = decisionData;
+    currentApproval.reconciliationPending = true;
     return Promise.resolve(true);
   }
 

--- a/src/workflow/backends/memory.ts
+++ b/src/workflow/backends/memory.ts
@@ -60,6 +60,7 @@ const objectHasOwn = Object.hasOwn;
 const objectKeys = Object.keys;
 const objectPrototype = Object.prototype;
 const jsonParse = JSON.parse;
+const SetConstructor = Set;
 const structuredCloneValue = structuredClone;
 const conditionalRunUpdateControl = Symbol("conditional-run-update-control");
 
@@ -429,10 +430,11 @@ export class MemoryBackend implements WorkflowBackend {
     expectedStatuses: WorkflowRun["status"][],
     patch: Partial<WorkflowRun>,
   ): Promise<boolean> {
+    const statuses = new SetConstructor(expectedStatuses);
     return this.applyConditionalRunUpdate(
       runId,
       patch,
-      (run) => expectedStatuses.includes(run.status),
+      (run) => statuses.has(run.status),
     );
   }
 
@@ -442,10 +444,11 @@ export class MemoryBackend implements WorkflowBackend {
     expectedWorkerId: string,
     patch: Partial<WorkflowRun>,
   ): Promise<boolean> {
+    const statuses = new SetConstructor(expectedStatuses);
     return this.applyConditionalRunUpdate(
       runId,
       patch,
-      (run) => expectedStatuses.includes(run.status) && run.workerId === expectedWorkerId,
+      (run) => statuses.has(run.status) && run.workerId === expectedWorkerId,
     );
   }
 
@@ -918,8 +921,12 @@ export class MemoryBackend implements WorkflowBackend {
         return Promise.reject(error);
       }
     }
-    const currentApproval = this.approvals.get(runId)?.find((item) => item.id === approvalId);
-    if (!currentApproval || currentApproval.status !== "pending") {
+    const currentApprovals = this.approvals.get(runId);
+    const currentApproval = currentApprovals?.find((item) => item.id === approvalId);
+    if (
+      currentApprovals !== approvals || currentApproval !== approval ||
+      currentApproval.status !== "pending"
+    ) {
       return Promise.resolve(false);
     }
     logger.debug("Updating approval", { approvalId, decision });

--- a/src/workflow/backends/memory.ts
+++ b/src/workflow/backends/memory.ts
@@ -61,6 +61,16 @@ const objectKeys = Object.keys;
 const objectPrototype = Object.prototype;
 const jsonParse = JSON.parse;
 const structuredCloneValue = structuredClone;
+const conditionalRunUpdateControl = Symbol("conditional-run-update-control");
+
+interface ConditionalRunUpdateControl {
+  applied: boolean;
+  readonly precondition: (run: WorkflowRun) => boolean;
+}
+
+type ConditionalWorkflowRunUpdate = WorkflowRunUpdate & {
+  readonly [conditionalRunUpdateControl]?: ConditionalRunUpdateControl;
+};
 
 /**
  * Memory backend configuration
@@ -330,12 +340,16 @@ export class MemoryBackend implements WorkflowBackend {
   }
 
   updateRun(runId: string, patch: WorkflowRunUpdate): Promise<void> {
-    return this.applyRunUpdate(runId, patch).then(() => undefined);
+    const conditionalPatch = patch as ConditionalWorkflowRunUpdate;
+    const control = conditionalPatch[conditionalRunUpdateControl];
+    return this.applyRunUpdate(runId, conditionalPatch, control?.precondition).then((applied) => {
+      if (control !== undefined) control.applied = applied;
+    });
   }
 
   private applyRunUpdate(
     runId: string,
-    patch: WorkflowRunUpdate,
+    patch: ConditionalWorkflowRunUpdate,
     precondition?: (run: WorkflowRun) => boolean,
   ): Promise<boolean> {
     const run = this.runs.get(runId);
@@ -355,6 +369,7 @@ export class MemoryBackend implements WorkflowBackend {
     logger.debug(`Updating run: ${runId}`, patch);
 
     const {
+      [conditionalRunUpdateControl]: _conditionalUpdateControl,
       context: patchContext,
       contextDeletes = [],
       nodeStateDeletes = [],
@@ -414,7 +429,7 @@ export class MemoryBackend implements WorkflowBackend {
     expectedStatuses: WorkflowRun["status"][],
     patch: Partial<WorkflowRun>,
   ): Promise<boolean> {
-    return this.applyRunUpdate(
+    return this.applyConditionalRunUpdate(
       runId,
       patch,
       (run) => expectedStatuses.includes(run.status),
@@ -427,11 +442,24 @@ export class MemoryBackend implements WorkflowBackend {
     expectedWorkerId: string,
     patch: Partial<WorkflowRun>,
   ): Promise<boolean> {
-    return this.applyRunUpdate(
+    return this.applyConditionalRunUpdate(
       runId,
       patch,
       (run) => expectedStatuses.includes(run.status) && run.workerId === expectedWorkerId,
     );
+  }
+
+  private applyConditionalRunUpdate(
+    runId: string,
+    patch: WorkflowRunUpdate,
+    precondition: (run: WorkflowRun) => boolean,
+  ): Promise<boolean> {
+    const control: ConditionalRunUpdateControl = { applied: false, precondition };
+    const conditionalPatch: ConditionalWorkflowRunUpdate = {
+      ...patch,
+      [conditionalRunUpdateControl]: control,
+    };
+    return this.updateRun(runId, conditionalPatch).then(() => control.applied);
   }
 
   restoreRunStateIfStatus(


### PR DESCRIPTION
## Summary

- recheck in-memory run preconditions after context serialization hooks complete
- snapshot conditional status inputs before user hooks can mutate caller methods
- preserve public `updateRun` override interception for conditional updates
- require approval collection and record identity after decision-data hooks complete
- snapshot only JSON-visible proxy descriptors and ignore symbol descriptor traps
- add focused regressions for every late review finding on #4265 and #4273

This is a follow-up to merged PR #4265. It preserves the public API and does not change Veryfront Cloud API routes or schemas.

## Verification

- pinned Deno persistence/executor suite: 5 files, 431 steps passed
- Node persistence/executor suite: 398 tests passed
- Bun persistence/executor suite: 5 files passed
- full pinned-Deno pre-push gate: 4,390 tests passed, 0 failed
- Deno format, lint, and type check passed
- all review threads replied to and resolved

Related: #4265