### PR TITLE
docs: document private CA trust and identity projection for application auth

### DIFF
--- a/docs/guides/application-auth.md
+++ b/docs/guides/application-auth.md
@@ -131,6 +131,13 @@ This is an operator-owned host setting, not application configuration. List
 comma-separated exact origins when the provider uses more than one internal
 origin. Do not use the broad internal-egress override for application auth.
 
+If the provider uses a private CA, add its PEM certificate bundle to the host
+runtime trust settings. Use `NODE_EXTRA_CA_CERTS` for Node.js and Bun. Use
+`DENO_CERT` or `deno --cert` for Deno. Veryfront keeps certificate and hostname
+verification enabled and adds the private CA to the runtime's normal trust
+roots. On Veryfront Cloud, expose the provider through a certificate chain the
+Cloud runtime already trusts.
+
 Changing `clientId`, claim mappings, scopes, signing algorithms, issuer,
 callback origin, or `trustedEndpointOrigins` invalidates existing sessions.
 
@@ -148,6 +155,10 @@ Logout requires `POST` and a same-origin `Origin` header.
 After a request is admitted, middleware and routes receive the same identity.
 The stable user key is `(issuer, subject)`. Map that pair to your own user
 record before applying application authorization.
+
+When an API route sends identity data to a browser, return only the normalized
+fields that the UI needs. Do not return the raw provider claims object by
+default. Keep authorization decisions in server-side middleware or route code.
 
 Microsoft group overage does not become an empty group list. When a token says
 groups must be fetched elsewhere, Veryfront sets `groupsComplete: false`.


### PR DESCRIPTION
## Description

Two gaps in `docs/guides/application-auth.md`, both carried over from the draft [veryfront-docs#401](https://github.com/veryfront/veryfront-docs/pull/401) and moved here because that guide is synced from this repository.

**Private CA trust.** The guide explains `trustedEndpointOrigins` but never says how to trust a provider that terminates TLS with a private CA, which is the common shape for self-hosted Authelia and AD FS. The new paragraph documents the per-runtime setting that `src/security/http/outbound-fetch.ts` already honors, and states that certificate and hostname verification stay enabled.

**Identity projection.** `ApplicationIdentity` (`src/security/application-auth/types.ts`) carries the normalized fields alongside a raw `claims` object. The guide did not say which of the two a browser-facing route should return, so the new paragraph says to project the normalized fields and keep authorization server-side.

## Type of Change

- [x] Documentation update

## Testing

Both claims were checked against the implementation rather than restated from the draft:

- `src/security/http/outbound-fetch.ts:79-82` documents the same split the guide now states: Node consumes `NODE_EXTRA_CA_CERTS` at process start, Bun is handed the same bundle explicitly, and Deno consumes `--cert` or `DENO_CERT`.
- `loadTrustedCaCertificates` returns `[...defaultRoots, extraCa]`, so the private CA is added to the normal trust roots and nothing disables verification. That is what "keeps certificate and hostname verification enabled" refers to.
- `ApplicationIdentity` in `src/security/application-auth/types.ts` exposes `issuer`, `subject`, `email`, `name`, `groups`, `roles`, `groupsComplete`, and `claims`, which is the distinction the second paragraph draws.

`validate-public-docs`, `validate-guides`, `check-doc-links`, `tests/docs/guide-contracts.test.ts`, and `tests/docs/guide-content.test.ts` all pass.

## Notes

Stacked behind [#4275](https://github.com/veryfront/veryfront-code/pull/4275), which touches the intro of the same file. The hunks do not overlap.

The draft carried a third paragraph describing the cross-runtime setup in `veryfront-examples`. That one is deliberately left out: #4275 removes the link to that repository because it is private and the path does not exist on its `main` yet.