### PR TITLE
test: use a reserved mock resolver address

### DIFF
--- a/src/security/http/outbound-fetch.ts
+++ b/src/security/http/outbound-fetch.ts
@@ -11,7 +11,6 @@ import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { fetchWithPinnedAddresses } from "#veryfront/platform/compat/http/pinned-fetch.ts";
 import { isBun } from "#veryfront/platform/compat/runtime.ts";
 import {
-  __guardedEgressFetchWithAllowedResolvedAddressesForTests,
   guardedEgressFetch,
   isInternalEgressOverrideEnabled,
   type ResolveWorkerHost,
@@ -142,10 +141,10 @@ async function fetchWithHostTransport(
   transport: TrustedHostTransport,
   allowInternalEgress: boolean,
 ): Promise<Response> {
-  const deps = {
+  return await guardedEgressFetch(input, init, {
     fetchImpl: transport.fetch,
     pinnedFetch: transport.pinnedFetch,
-    authorizeUrl: async (url: URL) => {
+    authorizeUrl: async (url) => {
       if (url.protocol !== "http:" && url.protocol !== "https:") {
         throw new OutboundRequestBlockedError(
           `Outbound request blocked: unsupported URL scheme ${url.protocol}`,
@@ -159,16 +158,13 @@ async function fetchWithHostTransport(
       await options.authorizeUrl?.(url);
     },
     onRedirect: options.onRedirect,
+    allowedResolvedAddressesForTests: transport.allowedResolvedAddressesForTests,
     options: {
       allowInternalEgress: allowInternalEgress ||
         isInternalEgressOverrideEnabled(getHostEnv(HOST_INTERNAL_EGRESS_OVERRIDE_ENV)),
       resolveHost: transport.resolveHost,
     },
-  };
-  const allowed = transport.allowedResolvedAddressesForTests;
-  return await (allowed
-    ? __guardedEgressFetchWithAllowedResolvedAddressesForTests(input, init, deps, allowed)
-    : guardedEgressFetch(input, init, deps));
+  });
 }
 
 function parseAllowedInternalProviderOrigins(value: string | undefined): ReadonlySet<string> {

--- a/src/security/http/outbound-fetch.ts
+++ b/src/security/http/outbound-fetch.ts
@@ -11,6 +11,7 @@ import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { fetchWithPinnedAddresses } from "#veryfront/platform/compat/http/pinned-fetch.ts";
 import { isBun } from "#veryfront/platform/compat/runtime.ts";
 import {
+  __guardedEgressFetchWithAllowedResolvedAddressesForTests,
   guardedEgressFetch,
   isInternalEgressOverrideEnabled,
   type ResolveWorkerHost,
@@ -57,6 +58,10 @@ export interface OutboundFetchTransport {
   resolveHost?: ResolveWorkerHost;
 }
 
+type TrustedHostTransport = OutboundFetchTransport & {
+  allowedResolvedAddressesForTests?: readonly string[];
+};
+
 /** Explicit host transport boundary used by runtime composition and tests. */
 export interface OutboundFetchBoundary {
   guardedFetch(
@@ -69,9 +74,9 @@ export interface OutboundFetchBoundary {
 
 // Capture the host transport before tenant code can replace globalThis.fetch.
 const capturedHostFetch = globalThis.fetch.bind(globalThis);
-let outboundFetchTransportForTests: Readonly<OutboundFetchTransport> | undefined;
+let outboundFetchTransportForTests: Readonly<TrustedHostTransport> | undefined;
 
-function getTrustedHostTransport(): OutboundFetchTransport {
+function getTrustedHostTransport(): TrustedHostTransport {
   if (outboundFetchTransportForTests !== undefined) {
     return outboundFetchTransportForTests;
   }
@@ -134,13 +139,13 @@ async function fetchWithHostTransport(
   input: RequestInfo | URL,
   init: RequestInit | undefined,
   options: GuardedOutboundFetchOptions,
-  transport: OutboundFetchTransport,
+  transport: TrustedHostTransport,
   allowInternalEgress: boolean,
 ): Promise<Response> {
-  return await guardedEgressFetch(input, init, {
+  const deps = {
     fetchImpl: transport.fetch,
     pinnedFetch: transport.pinnedFetch,
-    authorizeUrl: async (url) => {
+    authorizeUrl: async (url: URL) => {
       if (url.protocol !== "http:" && url.protocol !== "https:") {
         throw new OutboundRequestBlockedError(
           `Outbound request blocked: unsupported URL scheme ${url.protocol}`,
@@ -159,7 +164,11 @@ async function fetchWithHostTransport(
         isInternalEgressOverrideEnabled(getHostEnv(HOST_INTERNAL_EGRESS_OVERRIDE_ENV)),
       resolveHost: transport.resolveHost,
     },
-  });
+  };
+  const allowed = transport.allowedResolvedAddressesForTests;
+  return await (allowed
+    ? __guardedEgressFetchWithAllowedResolvedAddressesForTests(input, init, deps, allowed)
+    : guardedEgressFetch(input, init, deps));
 }
 
 function parseAllowedInternalProviderOrigins(value: string | undefined): ReadonlySet<string> {
@@ -335,9 +344,15 @@ export function __installUnpinnedHostTransportForTests(): () => void {
 
 export function __installOutboundFetchTransportForTests(
   transport: OutboundFetchTransport,
+  options: { allowedResolvedAddresses?: readonly string[] } = {},
 ): () => void {
   const previous = outboundFetchTransportForTests;
-  outboundFetchTransportForTests = snapshotOutboundFetchTransport(transport);
+  outboundFetchTransportForTests = Object.freeze({
+    ...snapshotOutboundFetchTransport(transport),
+    allowedResolvedAddressesForTests: options.allowedResolvedAddresses === undefined
+      ? undefined
+      : Object.freeze([...options.allowedResolvedAddresses]),
+  });
   return () => {
     outboundFetchTransportForTests = previous;
   };
@@ -346,8 +361,9 @@ export function __installOutboundFetchTransportForTests(
 export async function __runWithOutboundFetchTransportForTests<T>(
   transport: OutboundFetchTransport,
   fn: () => Promise<T>,
+  options: { allowedResolvedAddresses?: readonly string[] } = {},
 ): Promise<T> {
-  const restore = __installOutboundFetchTransportForTests(transport);
+  const restore = __installOutboundFetchTransportForTests(transport, options);
   try {
     return await fn();
   } finally {

--- a/src/security/sandbox/worker-egress-guard.ts
+++ b/src/security/sandbox/worker-egress-guard.ts
@@ -315,6 +315,7 @@ async function resolveWorkerHostEgressAddresses(
   hostname: string,
   options: WorkerEgressGuardOptions,
   signal?: AbortSignal,
+  allowedResolvedAddresses: readonly string[] = [],
 ): Promise<string[]> {
   const allowInternalEgress = options.allowInternalEgress === true;
 
@@ -363,7 +364,11 @@ async function resolveWorkerHostEgressAddresses(
         `Worker network egress blocked: resolver returned an invalid address for host ${hostname}`,
       );
     }
-    if (!allowInternalEgress && !allowedInternalHost && isInternalEgressIp(normalizedAddress)) {
+    if (
+      !allowInternalEgress && !allowedInternalHost &&
+      isInternalEgressIp(normalizedAddress) &&
+      !allowedResolvedAddresses.includes(normalizedAddress)
+    ) {
       throw new WorkerEgressBlockedError(
         `Worker network egress blocked for host: ${hostname}`,
       );
@@ -1179,10 +1184,28 @@ function isReplayableBody(body: BodyInit | null | undefined): boolean {
  * follows manually after re-checking. Credential headers are stripped on a
  * cross-origin hop, matching the platform fetch the guard wraps.
  */
-export async function guardedEgressFetch(
+export function guardedEgressFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
   deps: GuardedEgressFetchDeps = {},
+): Promise<Response> {
+  return guardedEgressFetchImpl(input, init, deps);
+}
+
+export function __guardedEgressFetchWithAllowedResolvedAddressesForTests(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  deps: GuardedEgressFetchDeps,
+  allowedResolvedAddresses: readonly string[],
+): Promise<Response> {
+  return guardedEgressFetchImpl(input, init, deps, allowedResolvedAddresses);
+}
+
+async function guardedEgressFetchImpl(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  deps: GuardedEgressFetchDeps,
+  allowedResolvedAddresses: readonly string[] = [],
 ): Promise<Response> {
   const doFetch = deps.fetchImpl ?? fetch;
   const options = deps.options ?? {};
@@ -1266,6 +1289,7 @@ export async function guardedEgressFetch(
             hostname,
             options,
             requestInit.signal ?? undefined,
+            allowedResolvedAddresses,
           );
           const port = parsedUrl.port
             ? Number.parseInt(parsedUrl.port, 10)

--- a/src/security/sandbox/worker-egress-guard.ts
+++ b/src/security/sandbox/worker-egress-guard.ts
@@ -1163,6 +1163,8 @@ export interface GuardedEgressFetchDeps {
   onRedirect?: (redirect: WorkerEgressRedirect) => void | Promise<void>;
   /** Captured runtime primitives used to establish the DNS-pinned tunnel. */
   runtime?: Partial<PinnedEgressRuntime>;
+  /** Resolved addresses admitted by an installed test transport. */
+  allowedResolvedAddressesForTests?: readonly string[];
 }
 
 /** A request body that can be safely replayed across a body-preserving redirect. */
@@ -1184,28 +1186,10 @@ function isReplayableBody(body: BodyInit | null | undefined): boolean {
  * follows manually after re-checking. Credential headers are stripped on a
  * cross-origin hop, matching the platform fetch the guard wraps.
  */
-export function guardedEgressFetch(
+export async function guardedEgressFetch(
   input: RequestInfo | URL,
   init?: RequestInit,
   deps: GuardedEgressFetchDeps = {},
-): Promise<Response> {
-  return guardedEgressFetchImpl(input, init, deps);
-}
-
-export function __guardedEgressFetchWithAllowedResolvedAddressesForTests(
-  input: RequestInfo | URL,
-  init: RequestInit | undefined,
-  deps: GuardedEgressFetchDeps,
-  allowedResolvedAddresses: readonly string[],
-): Promise<Response> {
-  return guardedEgressFetchImpl(input, init, deps, allowedResolvedAddresses);
-}
-
-async function guardedEgressFetchImpl(
-  input: RequestInfo | URL,
-  init: RequestInit | undefined,
-  deps: GuardedEgressFetchDeps,
-  allowedResolvedAddresses: readonly string[] = [],
 ): Promise<Response> {
   const doFetch = deps.fetchImpl ?? fetch;
   const options = deps.options ?? {};
@@ -1289,7 +1273,7 @@ async function guardedEgressFetchImpl(
             hostname,
             options,
             requestInit.signal ?? undefined,
-            allowedResolvedAddresses,
+            deps.allowedResolvedAddressesForTests,
           );
           const port = parsedUrl.port
             ? Number.parseInt(parsedUrl.port, 10)

--- a/src/testing/mock-fetch.test.ts
+++ b/src/testing/mock-fetch.test.ts
@@ -1,7 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { guardedOutboundFetch } from "#veryfront/security/http/outbound-fetch.ts";
+import {
+  guardedOutboundFetch,
+  OutboundRequestBlockedError,
+} from "#veryfront/security/http/outbound-fetch.ts";
 import {
   installMockFetch,
   observeFetchRequestInit,
@@ -69,6 +72,24 @@ describe("mock fetch host resolution", () => {
       realFetch,
       "withMockFetch puts the ambient fetch back once the callback settles",
     );
+  });
+
+  it("does not allow the resolver sentinel as a request destination", async () => {
+    let calls = 0;
+    await withMockFetch(
+      () => {
+        calls++;
+        return Promise.resolve(new Response("unexpected"));
+      },
+      async () => {
+        await assertRejects(
+          () => guardedOutboundFetch("https://192.0.2.1/private"),
+          OutboundRequestBlockedError,
+          "internal host",
+        );
+      },
+    );
+    assertEquals(calls, 0);
   });
 
   it("serializes overlapping callers so each sees only its own stub", async () => {

--- a/src/testing/mock-fetch.ts
+++ b/src/testing/mock-fetch.ts
@@ -5,16 +5,10 @@ import {
 
 type FetchMock = typeof globalThis.fetch | undefined;
 
-/**
- * Address a stubbed request is pinned to instead of asking a real resolver.
- *
- * The egress guard resolves the destination host before it reaches the stub,
- * so without this a fully stubbed test still performs live DNS and dies
- * upstream of its own transport. The literal is public, which keeps the
- * guard's internal-destination checks running exactly as they do in
- * production; the stub transport ignores addresses, so nothing connects to it.
- */
-const STUB_PINNED_ADDRESS = "93.184.216.34";
+const STUB_PINNED_ADDRESS = "192.0.2.1";
+const STUB_TRANSPORT_OPTIONS = {
+  allowedResolvedAddresses: [STUB_PINNED_ADDRESS],
+} as const;
 
 function stubTransport(mockFetch: typeof globalThis.fetch) {
   return {
@@ -94,7 +88,11 @@ export async function withMockFetch<T>(
     if (typeof mockFetch !== "function") {
       return await fn();
     }
-    return await __runWithOutboundFetchTransportForTests(stubTransport(mockFetch), fn);
+    return await __runWithOutboundFetchTransportForTests(
+      stubTransport(mockFetch),
+      fn,
+      STUB_TRANSPORT_OPTIONS,
+    );
   } finally {
     Object.defineProperty(globalThis, "fetch", {
       value: originalFetch,
@@ -122,7 +120,10 @@ export async function withMockFetch<T>(
  * where there is no callback to wrap.
  */
 export function installMockFetch(mockFetch: typeof globalThis.fetch): void {
-  const restoreTransport = __installOutboundFetchTransportForTests(stubTransport(mockFetch));
+  const restoreTransport = __installOutboundFetchTransportForTests(
+    stubTransport(mockFetch),
+    STUB_TRANSPORT_OPTIONS,
+  );
   // Only the first install records the pristine state, so a test that swaps its
   // stub mid-way still restores to the real transport rather than to its own
   // earlier stub.


### PR DESCRIPTION
## Summary

- replace the public mock resolver sentinel with RFC 5737 TEST-NET-1
- allow that exact resolved address only for installed test transports
- keep direct and production internal-address validation unchanged

## Validation

- deno task lint
- deno task typecheck
- deno task test:file src/testing/mock-fetch.test.ts
- deno task test:file src/security/http/outbound-fetch.test.ts
- deno task test:file src/security/sandbox/worker-egress-guard.test.ts
- deno task test:unit: 4,389 passed; one unrelated CLI project-creation test failed because npm is unavailable in the local environment and reproduced in isolation