### PR TITLE
docs: stop publishing links readers cannot open

### DIFF
--- a/docs/guides/application-auth.md
+++ b/docs/guides/application-auth.md
@@ -14,10 +14,6 @@ Veryfront speaks OpenID Connect to the provider, verifies the ID token, creates
 an encrypted application session, and exposes one normalized identity to
 middleware and routes.
 
-See the complete
-[application auth example](https://github.com/veryfront/veryfront-examples/tree/main/application-auth)
-for a local Authelia deployment and protected routes.
-
 ## Choose a mode
 
 Use OIDC for user login in Veryfront Cloud and self-hosted deployments. Use

--- a/docs/guides/cloud-environment-access.md
+++ b/docs/guides/cloud-environment-access.md
@@ -93,6 +93,4 @@ curl -s -o /dev/null -w '%{http_code} %{redirect_url}\n' \
 Validate the status that route normally returns. Do not require a `200` from
 the environment root when the project has no static page at `/`.
 
-See [Deployment behavior](./deploying.md) for readiness and URL semantics, and
-[Environment access gate](../architecture/29-environment-access-gate.md) for how
-the gate decides.
+See [Deployment behavior](./deploying.md) for readiness and URL semantics.


### PR DESCRIPTION
## Description

Two links in the published docs tree resolve in this repository and 404 for readers of the site. Both block the pending veryfront-docs sync ([veryfront-docs#400](https://github.com/veryfront/veryfront-docs/pull/400)).

**`docs/guides/cloud-environment-access.md`** linked `docs/architecture/29-environment-access-gate.md`. The sync copies only `docs/getting-started`, `docs/guides`, `docs/concepts`, and `docs/api-reference`, so the target is never published, and `docs/architecture/` is private implementation notes, so the link also crossed the public boundary:

```
found 1 broken links in 1 files

code/guides/cloud-environment-access.md
 ⎿  /code/architecture/29-environment-access-gate
```

**`docs/guides/application-auth.md`** linked `github.com/veryfront/veryfront-examples`. That repository is private and the `application-auth` path does not exist on its `main` yet. It was the only veryfront-examples link in the published tree, and external links are outside what `mintlify broken-links` checks, so nothing would have caught it.

Neither guide loses information. `cloud-environment-access.md` keeps its public `Deployment behavior` reference, and `application-auth.md` already carries complete inline configuration.

## Why this is separate from #4275

#4275 carries both the same two link fixes and a `validate-public-docs` rule preventing the class from recurring. The rule is the right thing to build and @kojiwakayama is actively iterating on it, but it has drawn five rounds of review so far and is holding up a docs sync that is only waiting on four lines of Markdown.

This PR is those four lines against `main`, nothing else, so the sync can proceed. #4275 keeps the guard and its tests and can take as many rounds as it needs. Once this lands, #4275 rebases and its Markdown hunks drop out.

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Testing

- `validate-public-docs`, `validate-guides`, and `check-doc-links` pass.
- Re-ran the veryfront-docs sync pipeline with these two files: `mintlify@4.2.754 broken-links` reports no broken links and `mintlify@4.2.754 validate` passes, where `broken-links` fails on `main` today.