### PR TITLE
test(observability): make memory gauges deterministic under load

### DIFF
--- a/src/observability/instruments/memory-instruments.test.ts
+++ b/src/observability/instruments/memory-instruments.test.ts
@@ -9,7 +9,6 @@ import type {
   ObservableGauge,
   ObservableResult,
 } from "#veryfront/observability/tracing/api-shim.ts";
-import { getMemoryUsage } from "../metrics/config.ts";
 import type { MetricsConfig } from "../metrics/types.ts";
 import {
   createMemoryInstruments,
@@ -22,6 +21,11 @@ const CONFIG: MetricsConfig = { enabled: true, exporter: "console", prefix: "tes
 /** Heap limit pinned through the configured V8 flags so the percentage has a known denominator. */
 const CONFIGURED_HEAP_LIMIT_MIB = 16;
 const CONFIGURED_HEAP_LIMIT_BYTES = CONFIGURED_HEAP_LIMIT_MIB * 1024 * 1024;
+const MEMORY_USAGE_SAMPLE = {
+  rss: 24 * 1024 * 1024,
+  heapUsed: 8 * 1024 * 1024,
+  heapTotal: 12 * 1024 * 1024,
+};
 
 function createRecordingMeter(
   created: Array<{ name: string; unit: string | undefined }>,
@@ -80,7 +84,7 @@ describe("observability/instruments/memory-instruments", () => {
 
   it("observes rss, heap, and heap utilization through their matching gauges", async () => {
     const instruments = createMemoryInstruments(createRecordingMeter([]), CONFIG);
-    const bindings = createMemoryObservableBindings(instruments);
+    const bindings = createMemoryObservableBindings(instruments, () => MEMORY_USAGE_SAMPLE);
 
     assertEquals(bindings.length, 4, "every memory gauge is bound to a callback");
     assertStrictEquals(
@@ -120,24 +124,12 @@ describe("observability/instruments/memory-instruments", () => {
       _resetEnvironmentConfig();
     }
 
-    assert(heapUsed !== undefined && heapUsed > 0, "the heap gauge observes used heap bytes");
-    assert(
-      heapTotal !== undefined && heapTotal >= heapUsed,
-      "the heap_total gauge observes allocated heap, never less than the used heap",
-    );
-    assert(
-      rss !== undefined && rss > heapTotal,
-      "the usage gauge observes resident memory, which exceeds the allocated V8 heap",
-    );
-
-    const usage = getMemoryUsage();
-    assert(usage !== null, "the host runtime reports memory usage");
-    const expectedPercent = (usage.heapUsed / CONFIGURED_HEAP_LIMIT_BYTES) * 100;
+    assertEquals(rss, MEMORY_USAGE_SAMPLE.rss);
+    assertEquals(heapUsed, MEMORY_USAGE_SAMPLE.heapUsed);
+    assertEquals(heapTotal, MEMORY_USAGE_SAMPLE.heapTotal);
     assert(heapPercent !== undefined, "the heap_percent gauge observes a value");
-    assert(
-      Math.abs(heapPercent - expectedPercent) <= expectedPercent * 0.02,
-      `heap_percent must be heapUsed/limit*100, expected about ${expectedPercent}, observed ${heapPercent}`,
-    );
+    const expectedPercent = (MEMORY_USAGE_SAMPLE.heapUsed / CONFIGURED_HEAP_LIMIT_BYTES) * 100;
+    assertEquals(heapPercent, expectedPercent, "heap_percent must be heapUsed/limit*100");
     assertEquals(
       heapPercent,
       Math.round(heapPercent * 100) / 100,

--- a/src/observability/instruments/memory-instruments.ts
+++ b/src/observability/instruments/memory-instruments.ts
@@ -9,6 +9,8 @@ import type { MetricsConfig } from "../metrics/types.ts";
 import type { ObservableCallbackBinding } from "./observable-callbacks.ts";
 
 const BYTES_PER_MEBIBYTE = 1024 * 1024;
+type MemoryUsage = NonNullable<ReturnType<typeof getMemoryUsage>>;
+type MemoryUsageReader = () => MemoryUsage | null;
 
 /** Parse the configured V8 old-space limit, when present. */
 export function parseV8HeapLimitBytes(flags: string): number | undefined {
@@ -66,11 +68,12 @@ export interface MemoryInstruments {
 function createMemoryCallback(
   observe: (
     result: ObservableResult,
-    memoryUsage: NonNullable<ReturnType<typeof getMemoryUsage>>,
+    memoryUsage: MemoryUsage,
   ) => void,
+  readMemoryUsage: MemoryUsageReader,
 ): (result: ObservableResult) => void {
   return (result: ObservableResult) => {
-    const memoryUsage = getMemoryUsage();
+    const memoryUsage = readMemoryUsage();
     if (!memoryUsage) return;
     observe(result, memoryUsage);
   };
@@ -100,25 +103,33 @@ export function createMemoryInstruments(meter: Meter, config: MetricsConfig): Me
 
 export function createMemoryObservableBindings(
   instruments: MemoryInstruments,
+  readMemoryUsage: MemoryUsageReader = getMemoryUsage,
 ): ObservableCallbackBinding[] {
   const bindings: ObservableCallbackBinding[] = [];
   if (instruments.memoryUsageGauge) {
     bindings.push({
       instrument: instruments.memoryUsageGauge,
-      callback: createMemoryCallback((result, memoryUsage) => result.observe(memoryUsage.rss)),
+      callback: createMemoryCallback(
+        (result, memoryUsage) => result.observe(memoryUsage.rss),
+        readMemoryUsage,
+      ),
     });
   }
   if (instruments.heapUsageGauge) {
     bindings.push({
       instrument: instruments.heapUsageGauge,
-      callback: createMemoryCallback((result, memoryUsage) => result.observe(memoryUsage.heapUsed)),
+      callback: createMemoryCallback(
+        (result, memoryUsage) => result.observe(memoryUsage.heapUsed),
+        readMemoryUsage,
+      ),
     });
   }
   if (instruments.heapTotalGauge) {
     bindings.push({
       instrument: instruments.heapTotalGauge,
-      callback: createMemoryCallback((result, memoryUsage) =>
-        result.observe(memoryUsage.heapTotal)
+      callback: createMemoryCallback(
+        (result, memoryUsage) => result.observe(memoryUsage.heapTotal),
+        readMemoryUsage,
       ),
     });
   }
@@ -128,7 +139,7 @@ export function createMemoryObservableBindings(
       callback: async (result) => {
         const heapLimitBytes = await getV8HeapLimitBytes();
         if (heapLimitBytes === undefined) return;
-        const memoryUsage = getMemoryUsage();
+        const memoryUsage = readMemoryUsage();
         if (!memoryUsage) return;
         const percent = (memoryUsage.heapUsed / heapLimitBytes) * 100;
         result.observe(Math.round(percent * 100) / 100);


### PR DESCRIPTION
## Summary

- inject a stable memory-usage reader at the internal observable-binding seam
- keep production behavior unchanged by defaulting to the host memory reader
- replace cross-snapshot tolerance assertions with exact deterministic gauge assertions

## Why main was red

The merge-group run and the post-merge run evaluated the identical `b51acf7e` SHA. The merge-group Node shard passed, but the post-merge Node shard sampled live V8 heap usage at different moments and observed 62.88% after a later read implied about 59.03%. The test treated those separate samples as one snapshot, so normal heap growth under shard load made it flaky.

This is why it was not caught before merge: the exact pre-merge gate passed. The failure was nondeterministic test timing, not a difference between the reviewed PR head and the merged code.

Failed main run: https://github.com/veryfront/veryfront-code/actions/runs/33161180467

## Verification

- focused Deno test: 3/3 steps pass
- focused Node test: 25/25 repeated runs pass
- full Node shard 1/2: all three phases pass (2,622 + 2,481 + 2,516 tests)
- full pre-push gate: format, lint, typecheck, 4,390 Deno unit tests (36,316 steps), cwd suites
- independent code review: no medium-or-higher findings

## Compatibility

No public export, Cloud API route, schema, wire format, or runtime default changes. Production still reads host memory through `getMemoryUsage`.