### PR TITLE
fix(docs): close late parser review gaps

### DIFF
--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -514,6 +514,9 @@ describe("public docs validation", () => {
           '<a data-ok={(() => { class Sample {} /[}>]/.test(value); return true })()} href="../architecture/class-block-regex.md">ok</a>\n' +
           '<a data-ok={(() => { {} /[}>]/.test(value); return true })()} href="../architecture/bare-block-regex.md">ok</a>\n' +
           '<a data-ok={(function () { class Sample {} /[}>]/.test(value); return true })()} href="../architecture/function-body-regex.md">ok</a>\n' +
+          '<a data-ok={({ method() { {} /[}>]/.test(value) } })} href="../architecture/method-body-regex.md">ok</a>\n' +
+          '<a data-ok={(class { method() { {} /[}>]/.test(value) } })} href="../architecture/class-method-body-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { return\n{} /[}>]/.test(value) })()} href="../architecture/return-asi-regex.md">ok</a>\n' +
           '<a data-ok={<Foo></Foo>} href="../architecture/paired-jsx.md">ok</a>\n' +
           '<a data-ok={<Foo>child</Foo>} href="../architecture/jsx-child-text.md">ok</a>\n' +
           '<a data-ok={value </foo>/.source} href="../architecture/less-than-regex.md">ok</a>\n' +
@@ -598,6 +601,9 @@ describe("public docs validation", () => {
         "../architecture/class-block-regex.md",
         "../architecture/bare-block-regex.md",
         "../architecture/function-body-regex.md",
+        "../architecture/method-body-regex.md",
+        "../architecture/class-method-body-regex.md",
+        "../architecture/return-asi-regex.md",
         "../architecture/paired-jsx.md",
         "../architecture/jsx-child-text.md",
         "../architecture/less-than-regex.md",
@@ -1856,6 +1862,24 @@ describe("public docs validation", () => {
   });
 
   it("ignores Markdown syntax inside MDX ESM blocks", () => {
+    assertEquals(
+      destinations(
+        'import value from "example"\n' +
+          "/[}]/.test(value)\n" +
+          'export const hidden = "[old](../architecture/import-regex.md)"\n\n' +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        'export { value } from "example"\n' +
+          "/[}]/.test(value)\n" +
+          'export const hidden = "[old](../architecture/export-regex.md)"\n\n' +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
     assertEquals(
       destinations(
         "export function sample() {}\n" +

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -1761,6 +1761,23 @@ describe("public docs validation", () => {
     );
   });
 
+  it("scans multiline MDX ESM block comments in linear time", () => {
+    const comment = Array.from(
+      { length: 80_001 },
+      (_, index) => `line ${index} [old](../architecture/private.md)`,
+    ).join("\n");
+    const source = `export const sample = /*\n${comment}\n*/ "done"\n\n` +
+      "[real](../architecture/real.md)";
+    const startedAt = performance.now();
+
+    assertEquals(destinations(source), ["../architecture/real.md"]);
+    assertLess(
+      performance.now() - startedAt,
+      2_000,
+      "multiline block comment scanning must stay linear",
+    );
+  });
+
   it("ignores destinations inside initial YAML frontmatter", () => {
     const source = '---\ntitle: "[sample](./does-not-exist.md)"\n' +
       "canonical: https://veryfront.com/docs/code/architecture/private\n---\n" +

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -511,6 +511,7 @@ describe("public docs validation", () => {
           '<a data-ok={--/}/.lastIndex} href="../architecture/prefix-decrement.md">ok</a>\n' +
           '<a data-ok={value++ / count > 1} href="../architecture/postfix-update.md">ok</a>\n' +
           '<a data-ok={value-- / count > 1} href="../architecture/postfix-decrement.md">ok</a>\n' +
+          '<a data-ok={[...++/{/.lastIndex]} href="../architecture/spread-update.md">ok</a>\n' +
           '<a data-ok={this.#instanceof / ({ marker: "}>/" }).length} href="../architecture/private-member.md">ok</a>\n' +
           '<a data-ok={πinstanceof / ({ marker: "}>/" }).length} href="../architecture/unicode-identifier.md">ok</a>\n' +
           '<a data-ok={𐐀instanceof / ({ marker: "}>/" }).length} href="../architecture/astral-identifier.md">ok</a>\n' +
@@ -545,6 +546,7 @@ describe("public docs validation", () => {
         "../architecture/prefix-decrement.md",
         "../architecture/postfix-update.md",
         "../architecture/postfix-decrement.md",
+        "../architecture/spread-update.md",
         "../architecture/private-member.md",
         "../architecture/unicode-identifier.md",
         "../architecture/astral-identifier.md",

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -510,8 +510,13 @@ describe("public docs validation", () => {
           '<a data-ok={class extends /[}>]/.constructor {}} href="../architecture/extends-regex.md">ok</a>\n' +
           '<a data-ok={(() => { class Sample {} /[}>]/.test(value) })()} href="../architecture/class-block-regex.md">ok</a>\n' +
           '<a data-ok={(() => { if (x) {} else /[}>]/.test(x); do /[}>]/.test(x); while (false); })()} href="../architecture/statement-regex.md">ok</a>\n' +
-          '<a data-ok={(() => { try {} catch {} /[}>]/.test(value) })()} href="../architecture/catch-block-regex.md">ok</a>\n' +
-          '<a data-ok={(() => { {}\n/[}>]/.test(value) })()} href="../architecture/standalone-block-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { class Sample {} /[}>]/.test(value); return true })()} href="../architecture/class-block-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { {} /[}>]/.test(value); return true })()} href="../architecture/bare-block-regex.md">ok</a>\n' +
+          '<a data-ok={(function () { class Sample {} /[}>]/.test(value); return true })()} href="../architecture/function-body-regex.md">ok</a>\n' +
+          '<a data-ok={<Foo></Foo>} href="../architecture/paired-jsx.md">ok</a>\n' +
+          '<a data-ok={<Foo>child</Foo>} href="../architecture/jsx-child-text.md">ok</a>\n' +
+          '<a data-ok={value </foo>/.source} href="../architecture/less-than-regex.md">ok</a>\n' +
+          '<a data-ok={<Foo>{value </foo>/.source}</Foo>} href="../architecture/jsx-child-less-than-regex.md">ok</a>\n' +
           '<a data-ok={(() => { for (const x of /[}>]/.source) {} return true })()} href="../architecture/for-of-regex.md">ok</a>\n' +
           '<a data-ok={(() => { for (using of /[}>]/.source) {} return true })()} href="../architecture/for-using-of-regex.md">ok</a>\n' +
           '<a data-ok={(async () => { for await (const x of /[}>]/.source) {} return true })()} href="../architecture/for-await-of-regex.md">ok</a>\n' +
@@ -535,6 +540,12 @@ describe("public docs validation", () => {
           '<a data-ok={(() => { let value\n/[}>]/.test(input); var other\n/[}>]/.test(input) })()} href="../architecture/declaration-asi-regex.md">ok</a>\n' +
           '<a data-ok={(() => { breakfast\n/ ({ marker: ">/" }).length; continueValue\n/ ({ marker: ">/" }).length; debuggerValue\n/ ({ marker: ">/" }).length; return true })()} href="../architecture/asi-prefix-division.md">ok</a>\n' +
           '<a data-ok={(() => { while (value) { break\n/[}>]/.test(value) } while (value) { continue\n/[}>]/.test(value) } debugger\n/[}>]/.test(value); return true })()} href="../architecture/asi-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { let value\n/[}>]/.test(input); return true })()} href="../architecture/uninitialized-let-asi-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { var value\n/[}>]/.test(input); return true })()} href="../architecture/uninitialized-var-asi-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { let value, other\n/[}>]/.test(input); return true })()} href="../architecture/uninitialized-let-list-asi-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { var value, other\n/[}>]/.test(input); return true })()} href="../architecture/uninitialized-var-list-asi-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { let value = input\n/ ({ marker: ">/" }).length; return true })()} href="../architecture/initialized-let-division.md">ok</a>\n' +
+          '<a data-ok={(() => { let value, other = input\n/ ({ marker: ">/" }).length; return true })()} href="../architecture/initialized-let-list-division.md">ok</a>\n' +
           '<a data-ok={(async () => await (x) / ({ marker: "}>/" }).length)()} href="../architecture/await-group-division.md">ok</a>\n' +
           '<a data-ok={`x ${"`"} >`} href="../architecture/template.md">ok</a>\n' +
           '<a data-ok={value / count > 1} href="../architecture/division.md">ok</a>\n' +
@@ -576,8 +587,13 @@ describe("public docs validation", () => {
         "../architecture/extends-regex.md",
         "../architecture/class-block-regex.md",
         "../architecture/statement-regex.md",
-        "../architecture/catch-block-regex.md",
-        "../architecture/standalone-block-regex.md",
+        "../architecture/class-block-regex.md",
+        "../architecture/bare-block-regex.md",
+        "../architecture/function-body-regex.md",
+        "../architecture/paired-jsx.md",
+        "../architecture/jsx-child-text.md",
+        "../architecture/less-than-regex.md",
+        "../architecture/jsx-child-less-than-regex.md",
         "../architecture/for-of-regex.md",
         "../architecture/for-using-of-regex.md",
         "../architecture/for-await-of-regex.md",
@@ -597,6 +613,12 @@ describe("public docs validation", () => {
         "../architecture/declaration-asi-regex.md",
         "../architecture/asi-prefix-division.md",
         "../architecture/asi-regex.md",
+        "../architecture/uninitialized-let-asi-regex.md",
+        "../architecture/uninitialized-var-asi-regex.md",
+        "../architecture/uninitialized-let-list-asi-regex.md",
+        "../architecture/uninitialized-var-list-asi-regex.md",
+        "../architecture/initialized-let-division.md",
+        "../architecture/initialized-let-list-division.md",
         "../architecture/await-group-division.md",
         "../architecture/template.md",
         "../architecture/division.md",
@@ -1801,12 +1823,104 @@ describe("public docs validation", () => {
     );
     assertEquals(
       destinations(
+        "export class Sample {}\n" +
+          "/[}]/.test(value);\n" +
+          'export const hidden = "[old](../architecture/class-block-regex.md)";\n\n' +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        "export default class Sample extends Base {}\n" +
+          "/[}]/.test(value);\n" +
+          'export const hidden = "[old](../architecture/default-class-block-regex.md)";\n\n' +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        'export class Sample extends mixin({ marker: "ok" }) {}\n' +
+          "/[}]/.test(value);\n" +
+          'export const hidden = "[old](../architecture/class-extends-string-regex.md)";\n\n' +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        "export class Sample extends mixin({ test: /[}]/ }) {}\n" +
+          "/[}]/.test(value);\n" +
+          'export const hidden = "[old](../architecture/class-extends-regex.md)";\n\n' +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        "export function sample(value) {\n" +
+          "  try {} catch {}\n" +
+          "  /[}]/.test(value);\n" +
+          '  return "[old](../architecture/catch-block-regex.md)";\n' +
+          "}\n\n" +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        "export function sample(input) {\n" +
+          "  let first, second\n" +
+          "  /[}]/.test(input);\n" +
+          "  var third, fourth\n" +
+          "  /[}]/.test(input);\n" +
+          '  return "[old](../architecture/declaration-list-asi.md)";\n' +
+          "}\n\n" +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        "export function sample(value) {\n" +
+          "  {}\n" +
+          "  /[}]/.test(value);\n" +
+          '  return "[old](../architecture/statement-block-regex.md)";\n' +
+          "}\n\n" +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
         "export const sample = function () {}\n" +
           '/ ({ marker: "}/" }).length;\n' +
           'export const hidden = "[old](../architecture/function-division.md)";\n\n' +
           "[real](../architecture/real.md)",
       ),
       ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        "export const Sample = class {}\n" +
+          '/ ({ marker: "}/" }).length;\n' +
+          "export const arrow = () => {}\n" +
+          '/ ({ marker: "}/" }).length;\n' +
+          "export const object = {}\n" +
+          '/ ({ marker: "}/" }).length;\n' +
+          'export const hidden = "[old](../architecture/expression-division.md)";\n\n' +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        "export const sample = <Foo>" +
+          "[old](../architecture/mismatched-jsx.md)</Bar>\n\n" +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/mismatched-jsx.md", "../architecture/real.md"],
     );
     assertEquals(
       destinations(
@@ -1990,7 +2104,7 @@ describe("public docs validation", () => {
     );
   });
 
-  it("scans long JavaScript identifiers in linear time", () => {
+  it("scans long MDX ESM identifiers in linear time", () => {
     const identifier = `value${"x".repeat(32_000)}`;
     const source = `export const ${identifier} = 1\n\n` +
       "[real](../architecture/real.md)";
@@ -2000,7 +2114,22 @@ describe("public docs validation", () => {
     assertLess(
       performance.now() - startedAt,
       2_000,
-      "identifier scanning must stay linear",
+      "long identifier scanning must stay linear",
+    );
+  });
+
+  it("rejects malformed nested JSX without rescanning suffixes", () => {
+    const depth = 2_000;
+    const source = "<a data-ok={" +
+      "<A value={".repeat(depth) +
+      "null}".repeat(depth) + ">";
+    const startedAt = performance.now();
+
+    assertEquals(destinations(source), []);
+    assertLess(
+      performance.now() - startedAt,
+      2_000,
+      "malformed nested JSX scanning must stay linear",
     );
   });
 

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -766,6 +766,16 @@ describe("public docs validation", () => {
       ).length,
       1,
     );
+    assertEquals(
+      collectIssues(
+        "docs/guides/example.md",
+        `https://github.com/example-org/private%2Dexamples/${
+          "%FF".repeat(512)
+        }`,
+        BLOCKED_REPOSITORY,
+      ).length,
+      1,
+    );
   });
 
   it("finds destinations that wrap across lines", () => {
@@ -1653,6 +1663,13 @@ describe("public docs validation", () => {
       collectUnpublishedLinkIssues(
         "docs/guides/example.mdx",
         'export const sample = `x ${"`"} [old](../architecture/private.md)`',
+      ),
+      [],
+    );
+    assertEquals(
+      collectUnpublishedLinkIssues(
+        "docs/guides/example.mdx",
+        'export const sample = `${foo / /}`/.test(x) ? "[old](../architecture/private.md)" : ""}`',
       ),
       [],
     );

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -82,6 +82,20 @@ describe("public docs validation", () => {
     );
     assertEquals(
       destinations(
+        '![outer ![one](./one.png) ![two](./two.png) ![three](./three.png) <a href="../architecture/private.md">old</a>][ref]\n' +
+          "![later](./later.png)\n\n" +
+          "[ref]: ./image.png",
+      ),
+      [
+        "./one.png",
+        "./two.png",
+        "./three.png",
+        "./later.png",
+        "./image.png",
+      ],
+    );
+    assertEquals(
+      destinations(
         "[outer ![alt <https://veryfront.com/docs/code/architecture/private>]" +
           "(./diagram.png)](./deploying.md)",
       ),

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -519,6 +519,8 @@ describe("public docs validation", () => {
           '<a data-ok={value </foo>/.source} href="../architecture/less-than-regex.md">ok</a>\n' +
           '<a data-ok={<Foo>{value </foo>/.source}</Foo>} href="../architecture/jsx-child-less-than-regex.md">ok</a>\n' +
           '<a data-ok={(() => { for (const x of /[}>]/.source) {} return true })()} href="../architecture/for-of-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { for (let x of values\n/ ({ marker: ">/" }).length) {} return true })()} href="../architecture/for-of-rhs-division.md">ok</a>\n' +
+          '<a data-ok={(() => { for (var x in values\n/ ({ marker: ">/" }).length) {} return true })()} href="../architecture/for-in-rhs-division.md">ok</a>\n' +
           '<a data-ok={(() => { for (using of /[}>]/.source) {} return true })()} href="../architecture/for-using-of-regex.md">ok</a>\n' +
           '<a data-ok={(async () => { for await (const x of /[}>]/.source) {} return true })()} href="../architecture/for-await-of-regex.md">ok</a>\n' +
           '<a data-ok={(() => { for (item1 of /[}>]/.source) {} return true })()} href="../architecture/for-digit-identifier-of-regex.md">ok</a>\n' +
@@ -540,6 +542,7 @@ describe("public docs validation", () => {
           '<a data-ok={<Foo>child</Foo>} href="../architecture/paired-jsx-text.md">ok</a>\n' +
           '<a data-ok={<Foo/> / ({ marker: ">/" }).length} href="../architecture/jsx-division.md">ok</a>\n' +
           '<Comp value={<a href="../architecture/nested-jsx-link.md">x</a>} />\n' +
+          "<Comp title=\"<a href='../architecture/quoted-jsx-link.md'>\" value={true} />\n" +
           '<a data-ok={(() => { let value\n/[}>]/.test(input); var other\n/[}>]/.test(input) })()} href="../architecture/declaration-asi-regex.md">ok</a>\n' +
           '<a data-ok={(() => { let first, second\n/[}>]/.test(input); var third, fourth\n/[}>]/.test(input) })()} href="../architecture/declaration-list-asi-regex.md">ok</a>\n' +
           '<a data-ok={(() => { breakfast\n/ ({ marker: ">/" }).length; continueValue\n/ ({ marker: ">/" }).length; debuggerValue\n/ ({ marker: ">/" }).length; return true })()} href="../architecture/asi-prefix-division.md">ok</a>\n' +
@@ -600,6 +603,8 @@ describe("public docs validation", () => {
         "../architecture/less-than-regex.md",
         "../architecture/jsx-child-less-than-regex.md",
         "../architecture/for-of-regex.md",
+        "../architecture/for-of-rhs-division.md",
+        "../architecture/for-in-rhs-division.md",
         "../architecture/for-using-of-regex.md",
         "../architecture/for-await-of-regex.md",
         "../architecture/for-digit-identifier-of-regex.md",
@@ -2160,6 +2165,23 @@ describe("public docs validation", () => {
       performance.now() - startedAt,
       2_000,
       "malformed nested JSX scanning must stay linear",
+    );
+  });
+
+  it("scans deeply nested valid JSX without overflowing the call stack", () => {
+    const depth = 4_000;
+    const source = "<a data-ok={" +
+      "<A>{".repeat(depth) +
+      "value" +
+      "}</A>".repeat(depth) +
+      '} href="../architecture/deep-jsx.md">ok</a>';
+    const startedAt = performance.now();
+
+    assertEquals(destinations(source), ["../architecture/deep-jsx.md"]);
+    assertLess(
+      performance.now() - startedAt,
+      2_000,
+      "deep valid JSX scanning must stay iterative",
     );
   });
 

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -514,6 +514,9 @@ describe("public docs validation", () => {
           '<a data-ok={this.#instanceof / ({ marker: "}>/" }).length} href="../architecture/private-member.md">ok</a>\n' +
           '<a data-ok={πinstanceof / ({ marker: "}>/" }).length} href="../architecture/unicode-identifier.md">ok</a>\n' +
           '<a data-ok={𐐀instanceof / ({ marker: "}>/" }).length} href="../architecture/astral-identifier.md">ok</a>\n' +
+          String
+            .raw`<a data-ok={\u{10400}instanceof / ({ marker: ">/" }).length} href="../architecture/escaped-astral-identifier.md">ok</a>` +
+          "\n" +
           '<div title="[old](../architecture/title-link.md)"></div>\n' +
           '<div title={"[old](../architecture/expression.md)"}></div>\n' +
           "<Code value={'Configure href=\"../architecture/string.md\"'} />\n" +
@@ -545,6 +548,7 @@ describe("public docs validation", () => {
         "../architecture/private-member.md",
         "../architecture/unicode-identifier.md",
         "../architecture/astral-identifier.md",
+        "../architecture/escaped-astral-identifier.md",
         "../architecture/real.md",
       ],
     );

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -579,7 +579,7 @@ describe("public docs validation", () => {
       [],
     );
     assertEquals(
-      destinations('[label]( "tooltip") and [label]( \'tooltip\')'),
+      destinations("[label]( \"tooltip\") and [label]( 'tooltip')"),
       [],
     );
     assertEquals(
@@ -1658,7 +1658,7 @@ describe("public docs validation", () => {
     );
     assertEquals(
       destinations(
-        'export const sample = `${x++ / value} / ` +\n' +
+        "export const sample = `${x++ / value} / ` +\n" +
           "[old](../architecture/postfix.md)",
       ),
       [],

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -656,6 +656,46 @@ describe("public docs validation", () => {
     );
   });
 
+  it("does not rescan quoted JSX attributes as nested tags", () => {
+    assertEquals(
+      destinations(
+        "<Comp title=\"<a href='./literal.md'>\" value={true} />",
+      ),
+      [],
+    );
+    assertEquals(
+      destinations(
+        "<Comp title=\"<a href='./literal.md'>\" " +
+          'value={<a href="../architecture/real.md">x</a>} />',
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        "{<Comp title=\"<a href='./literal.md'>\" " +
+          'value={<a href="../architecture/nested.md">x</a>} />}',
+      ),
+      ["../architecture/nested.md"],
+    );
+  });
+
+  it("keeps for-in and for-of right-hand division inside JSX attributes", () => {
+    assertEquals(
+      destinations(
+        "<a data-ok={(() => { for (let value of values\n" +
+          '/ ({ marker: ">/" }).length) {} return true })()} ' +
+          'href="../architecture/for-of-rhs-division.md">ok</a>\n' +
+          "<a data-ok={(() => { for (var key in object\n" +
+          '/ ({ marker: ">/" }).length) {} return true })()} ' +
+          'href="../architecture/for-in-rhs-division.md">ok</a>',
+      ),
+      [
+        "../architecture/for-of-rhs-division.md",
+        "../architecture/for-in-rhs-division.md",
+      ],
+    );
+  });
+
   it("ignores escaped Markdown link openers", () => {
     assertEquals(
       destinations(String.raw`\[example](../architecture/private.md)`),

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -74,6 +74,14 @@ describe("public docs validation", () => {
     );
     assertEquals(
       destinations(
+        '![alt <a href="../architecture/private.md">old</a>][ref]\n' +
+          "![later](./later.png)\n\n" +
+          "[ref]: ./image.png",
+      ),
+      ["./later.png", "./image.png"],
+    );
+    assertEquals(
+      destinations(
         "[outer ![alt <https://veryfront.com/docs/code/architecture/private>]" +
           "(./diagram.png)](./deploying.md)",
       ),
@@ -1673,6 +1681,13 @@ describe("public docs validation", () => {
       collectUnpublishedLinkIssues(
         "docs/guides/example.mdx",
         'export const sample = `${foo / /}`/.test(x) ? "[old](../architecture/private.md)" : ""}`',
+      ),
+      [],
+    );
+    assertEquals(
+      collectUnpublishedLinkIssues(
+        "docs/guides/example.mdx",
+        "export const sample = `${/a/ / value} / \\` [old](../architecture/private.md)`",
       ),
       [],
     );

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -579,6 +579,10 @@ describe("public docs validation", () => {
       [],
     );
     assertEquals(
+      destinations('[label]( "tooltip") and [label]( \'tooltip\')'),
+      [],
+    );
+    assertEquals(
       destinations(
         '[sample](../architecture/private.md "title"\n\n)',
       ),
@@ -1609,6 +1613,7 @@ describe("public docs validation", () => {
       ).map((destination) => destination.href),
       ["../architecture/escaped.md", "../architecture/real.md"],
     );
+    assertEquals(destinations("<!--".repeat(1_000)), []);
   });
 
   it("ignores Markdown syntax inside complete MDX expressions", () => {
@@ -1650,6 +1655,13 @@ describe("public docs validation", () => {
           "[real](../architecture/real.md)",
       ),
       ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        'export const sample = `${x++ / value} / ` +\n' +
+          "[old](../architecture/postfix.md)",
+      ),
+      [],
     );
   });
 

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -747,6 +747,16 @@ describe("public docs validation", () => {
           "https://github.com/example-org/private%2Dexamples%23-fork/%ZZ\n" +
           "https://github.com/example-org/private%2Dexamples%2Ffork/%ZZ\n" +
           "https://github.com/example-org/private%2Dexamples%3Ffork/%ZZ\n" +
+          "https://github.com/example-org/private%2Dexamples%20-fork/%ZZ\n" +
+          "https://github.com/example-org/private%2Dexamples%29-fork/%ZZ\n" +
+          "https://github.com/example-org/private%2Dexamples%3E-fork/%ZZ\n" +
+          "https://github.com/example-org/private%2Dexamples%5D-fork/%ZZ\n" +
+          "https://github.com/example-org/private%2Dexamples%2C-fork/%ZZ\n" +
+          "https://github.com/example-org/private%2Dexamples%3B-fork/%ZZ\n" +
+          "https://github.com/example-org/private%2Dexamples%3A-fork/%ZZ\n" +
+          "https://github.com/example-org/private%2Dexamples%27-fork/%ZZ\n" +
+          "https://github.com/example-org/private%2Dexamples%22-fork/%ZZ\n" +
+          "https://github.com/example-org/private%2Dexamples%21-fork/%ZZ\n" +
           `_https://github.com/${BLOCKED_REPOSITORY}_public_`,
         BLOCKED_REPOSITORY,
       ),

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -587,9 +587,13 @@ describe("public docs validation", () => {
       [],
     );
     assertEquals(
-      destinations("[label]( \"tooltip\") and [label]( 'tooltip')"),
-      [],
+      destinations(
+        "[label]( \"tooltip\") and [label]( 'tooltip') and " +
+          "[label]( (tooltip))",
+      ),
+      ['"tooltip"', "'tooltip'", "(tooltip)"],
     );
+    assertEquals(destinations('[label](<> "tooltip")'), []);
     assertEquals(
       destinations(
         '[sample](../architecture/private.md "title"\n\n)',

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -512,6 +512,8 @@ describe("public docs validation", () => {
           '<a data-ok={value++ / count > 1} href="../architecture/postfix-update.md">ok</a>\n' +
           '<a data-ok={value-- / count > 1} href="../architecture/postfix-decrement.md">ok</a>\n' +
           '<a data-ok={this.#instanceof / ({ marker: "}>/" }).length} href="../architecture/private-member.md">ok</a>\n' +
+          '<a data-ok={πinstanceof / ({ marker: "}>/" }).length} href="../architecture/unicode-identifier.md">ok</a>\n' +
+          '<a data-ok={𐐀instanceof / ({ marker: "}>/" }).length} href="../architecture/astral-identifier.md">ok</a>\n' +
           '<div title="[old](../architecture/title-link.md)"></div>\n' +
           '<div title={"[old](../architecture/expression.md)"}></div>\n' +
           "<Code value={'Configure href=\"../architecture/string.md\"'} />\n" +
@@ -541,6 +543,8 @@ describe("public docs validation", () => {
         "../architecture/postfix-update.md",
         "../architecture/postfix-decrement.md",
         "../architecture/private-member.md",
+        "../architecture/unicode-identifier.md",
+        "../architecture/astral-identifier.md",
         "../architecture/real.md",
       ],
     );

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -507,6 +507,7 @@ describe("public docs validation", () => {
           '<a data-ok={value instanceof /}>/} href="../architecture/instanceof-regex.md">ok</a>\n' +
           '<a data-ok={(async () => await /}>/.test(x))()} href="../architecture/await-regex.md">ok</a>\n' +
           '<a data-ok={(function* () { yield /}>/.test(x) })()} href="../architecture/yield-regex.md">ok</a>\n' +
+          '<a data-ok={(async () => await (x) / ({ marker: "}>/" }).length)()} href="../architecture/await-group-division.md">ok</a>\n' +
           '<a data-ok={`x ${"`"} >`} href="../architecture/template.md">ok</a>\n' +
           '<a data-ok={value / count > 1} href="../architecture/division.md">ok</a>\n' +
           '<a data-ok={++/{/.lastIndex} href="../architecture/prefix-update.md">ok</a>\n' +
@@ -544,6 +545,7 @@ describe("public docs validation", () => {
         "../architecture/instanceof-regex.md",
         "../architecture/await-regex.md",
         "../architecture/yield-regex.md",
+        "../architecture/await-group-division.md",
         "../architecture/template.md",
         "../architecture/division.md",
         "../architecture/prefix-update.md",
@@ -1750,6 +1752,18 @@ describe("public docs validation", () => {
     assertEquals(
       destinations(
         'export function sample(value) { if (value) /[}]/.test(value); return "[old](../architecture/control-header.md)"; }\n\n' +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        "export async function sample(items, value) {\n" +
+          "  for await (const item of items) /[}]/.test(item);\n" +
+          "  if (value) {} else /[}]/.test(value);\n" +
+          "  do /[}]/.test(value); while (false);\n" +
+          '  return "[old](../architecture/statement-context.md)";\n' +
+          "}\n\n" +
           "[real](../architecture/real.md)",
       ),
       ["../architecture/real.md"],

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -510,9 +510,13 @@ describe("public docs validation", () => {
           '<a data-ok={class extends /[}>]/.constructor {}} href="../architecture/extends-regex.md">ok</a>\n' +
           '<a data-ok={(() => { if (x) {} else /[}>]/.test(x); do /[}>]/.test(x); while (false); })()} href="../architecture/statement-regex.md">ok</a>\n' +
           '<a data-ok={(() => { for (const x of /[}>]/.source) {} return true })()} href="../architecture/for-of-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { for (using of /[}>]/.source) {} return true })()} href="../architecture/for-using-of-regex.md">ok</a>\n' +
+          '<a data-ok={(async () => { for await (const x of /[}>]/.source) {} return true })()} href="../architecture/for-await-of-regex.md">ok</a>\n' +
           '<a data-ok={(() => { for (of / ({ marker: ">/" }).length; false;) {} return true })()} href="../architecture/for-of-division.md">ok</a>\n' +
-          '<a data-ok={of / ({ marker: "}>/" }).length} href="../architecture/of-division.md">ok</a>\n' +
+          '<a data-ok={(() => { for (const x = { value: of / ({ marker: ">/" }).length }; false;) {} return true })()} href="../architecture/for-header-nested-of-division.md">ok</a>\n' +
+          '<a data-ok={of / ({ marker: ">/" }).length} href="../architecture/of-division.md">ok</a>\n' +
           '<a data-ok={(() => { breakfast\n/ ({ marker: ">/" }).length; continueValue\n/ ({ marker: ">/" }).length; debuggerValue\n/ ({ marker: ">/" }).length; return true })()} href="../architecture/asi-prefix-division.md">ok</a>\n' +
+          '<a data-ok={(() => { while (value) { break\n/[}>]/.test(value) } while (value) { continue\n/[}>]/.test(value) } debugger\n/[}>]/.test(value); return true })()} href="../architecture/asi-regex.md">ok</a>\n' +
           '<a data-ok={(async () => await (x) / ({ marker: "}>/" }).length)()} href="../architecture/await-group-division.md">ok</a>\n' +
           '<a data-ok={`x ${"`"} >`} href="../architecture/template.md">ok</a>\n' +
           '<a data-ok={value / count > 1} href="../architecture/division.md">ok</a>\n' +
@@ -554,9 +558,13 @@ describe("public docs validation", () => {
         "../architecture/extends-regex.md",
         "../architecture/statement-regex.md",
         "../architecture/for-of-regex.md",
+        "../architecture/for-using-of-regex.md",
+        "../architecture/for-await-of-regex.md",
         "../architecture/for-of-division.md",
+        "../architecture/for-header-nested-of-division.md",
         "../architecture/of-division.md",
         "../architecture/asi-prefix-division.md",
+        "../architecture/asi-regex.md",
         "../architecture/await-group-division.md",
         "../architecture/template.md",
         "../architecture/division.md",
@@ -1783,9 +1791,24 @@ describe("public docs validation", () => {
     assertEquals(
       destinations(
         "export function sample(value) {\n" +
-          "  for (;;) { break\n/[}]/.test(value) }\n" +
-          "  for (;;) { continue\n/[}]/.test(value) }\n" +
-          "  debugger\n/[}]/.test(value)\n" +
+          "  outer1: while (value) {\n" +
+          "    break outer1\n" +
+          "    /[}]/.test(value);\n" +
+          "  }\n" +
+          "  while (value) {\n" +
+          "    break\n" +
+          "    /[}]/.test(value);\n" +
+          "  }\n" +
+          "  \\u03c0: while (value) {\n" +
+          "    continue \\u03c0\n" +
+          "    /[}]/.test(value);\n" +
+          "  }\n" +
+          "  while (value) {\n" +
+          "    continue\n" +
+          "    /[}]/.test(value);\n" +
+          "  }\n" +
+          "  debugger\n" +
+          "  /[}]/.test(value);\n" +
           '  return "[old](../architecture/asi-statement.md)";\n' +
           "}\n\n" +
           "[real](../architecture/real.md)",

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -525,6 +525,7 @@ describe("public docs validation", () => {
           '<a data-ok={(() => { for (of / ({ marker: ">/" }).length; false;) {} return true })()} href="../architecture/for-of-division.md">ok</a>\n' +
           '<a data-ok={(() => { for (const x = { value: of / ({ marker: ">/" }).length }; false;) {} return true })()} href="../architecture/for-header-nested-of-division.md">ok</a>\n' +
           '<a data-ok={of / ({ marker: ">/" }).length} href="../architecture/of-division.md">ok</a>\n' +
+          '<a data-ok={function () {} / ({ marker: ">/" }).length} href="../architecture/function-expression-division.md">ok</a>\n' +
           '<a data-ok={(() => { breakfast\n/ ({ marker: ">/" }).length; continueValue\n/ ({ marker: ">/" }).length; debuggerValue\n/ ({ marker: ">/" }).length; return true })()} href="../architecture/asi-prefix-division.md">ok</a>\n' +
           '<a data-ok={(() => { while (value) { break\n/[}>]/.test(value) } while (value) { continue\n/[}>]/.test(value) } debugger\n/[}>]/.test(value); return true })()} href="../architecture/asi-regex.md">ok</a>\n' +
           '<a data-ok={(async () => await (x) / ({ marker: "}>/" }).length)()} href="../architecture/await-group-division.md">ok</a>\n' +
@@ -579,6 +580,7 @@ describe("public docs validation", () => {
         "../architecture/for-of-division.md",
         "../architecture/for-header-nested-of-division.md",
         "../architecture/of-division.md",
+        "../architecture/function-expression-division.md",
         "../architecture/asi-prefix-division.md",
         "../architecture/asi-regex.md",
         "../architecture/await-group-division.md",
@@ -1765,6 +1767,33 @@ describe("public docs validation", () => {
   });
 
   it("ignores Markdown syntax inside MDX ESM blocks", () => {
+    assertEquals(
+      destinations(
+        "export function sample() {}\n" +
+          "/[}]/.test(value);\n" +
+          'export const hidden = "[old](../architecture/block-regex.md)";\n\n' +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        "export default async function* sample() {}\n" +
+          "/[}]/.test(value);\n" +
+          'export const hidden = "[old](../architecture/async-block-regex.md)";\n\n' +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        "export const sample = function () {}\n" +
+          '/ ({ marker: "}/" }).length;\n' +
+          'export const hidden = "[old](../architecture/function-division.md)";\n\n' +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
     assertEquals(
       destinations(
         'import sample from "[old](../architecture/import.md)"\n' +

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -196,6 +196,20 @@ describe("public docs validation", () => {
       ),
       ["./deploying.md", "../architecture/private.png"],
     );
+    assertEquals(
+      destinations(
+        "![alt <https://veryfront.com/docs/code/architecture/private>][img]\n\n" +
+          "[img]: ./diagram.png",
+      ),
+      ["./diagram.png"],
+    );
+    assertEquals(
+      destinations(
+        '![alt <a href="../architecture/private.md">old</a>][img]\n\n' +
+          "[img]: ./diagram.png",
+      ),
+      ["./diagram.png"],
+    );
   });
 
   it("parses quoted HTML anchors and angle-bracket destinations", () => {
@@ -466,6 +480,8 @@ describe("public docs validation", () => {
           '<a data-ok={typeof /}>/} href="../architecture/typeof-regex.md">ok</a>\n' +
           '<a data-ok={void /}>/} href="../architecture/void-regex.md">ok</a>\n' +
           '<a data-ok={delete /}>/} href="../architecture/delete-regex.md">ok</a>\n' +
+          '<a data-ok={"x" in /}>/} href="../architecture/in-regex.md">ok</a>\n' +
+          '<a data-ok={value instanceof /}>/} href="../architecture/instanceof-regex.md">ok</a>\n' +
           '<a data-ok={`x ${"`"} >`} href="../architecture/template.md">ok</a>\n' +
           '<a data-ok={value / count > 1} href="../architecture/division.md">ok</a>\n' +
           '<div title="[old](../architecture/title-link.md)"></div>\n' +
@@ -487,6 +503,8 @@ describe("public docs validation", () => {
         "../architecture/typeof-regex.md",
         "../architecture/void-regex.md",
         "../architecture/delete-regex.md",
+        "../architecture/in-regex.md",
+        "../architecture/instanceof-regex.md",
         "../architecture/template.md",
         "../architecture/division.md",
         "../architecture/real.md",
@@ -719,6 +737,7 @@ describe("public docs validation", () => {
             .raw`[escaped](https://github.com/example-org/private\-examples)` +
           `\n_https://github.com/${BLOCKED_REPOSITORY}_\n` +
           `**https://%67ithub.com/example-org/private%2dexamples**\n` +
+          `https://github.com/example-org/private%2Dexamples/%ZZ\n` +
           `***https://github.com/${BLOCKED_REPOSITORY}***\n` +
           `___https://github.com/${BLOCKED_REPOSITORY}___\n` +
           `****https://github.com/${BLOCKED_REPOSITORY}****\n` +
@@ -726,7 +745,7 @@ describe("public docs validation", () => {
           `~https://github.com/${BLOCKED_REPOSITORY}~`,
         BLOCKED_REPOSITORY,
       ).length,
-      15,
+      16,
     );
     assertEquals(
       collectIssues(
@@ -853,6 +872,13 @@ describe("public docs validation", () => {
           "[public]",
       ),
       ["./deploying.md"],
+    );
+    assertEquals(
+      scanDestinations(
+        '[unused]: ./deploying.md\r  "https://veryfront.com/docs/code/guides/does-not-exist"',
+        "markdown",
+      ),
+      [],
     );
   });
 
@@ -1210,11 +1236,12 @@ describe("public docs validation", () => {
     const issues = collectUnpublishedLinkIssues(
       "docs/guides/example.md",
       '<a href="./does-not-exist.md">missing</a>\n' +
+        "<a href=\"'./quote-does-not-exist.md'\">quoted</a>\n" +
         "[missing]\n\n" +
         "[missing]: ./also-does-not-exist.md",
     );
 
-    assertEquals(issues.length, 2);
+    assertEquals(issues.length, 3);
   });
 
   it("finds reference definitions inside block quotes", () => {
@@ -1518,6 +1545,14 @@ describe("public docs validation", () => {
     );
     assertEquals(
       scanDestinations(
+        "before <!-- unfinished\n" +
+          "[gate](../architecture/private.md)",
+        "markdown",
+      ).map((destination) => destination.href),
+      ["../architecture/private.md"],
+    );
+    assertEquals(
+      scanDestinations(
         String.raw`\<!-- [visible](../architecture/escaped.md) -->` +
           '\ntext <div title="<!--"></div>\n' +
           "[real](../architecture/real.md)",
@@ -1611,6 +1646,13 @@ describe("public docs validation", () => {
           '  : ""\n\n[real](../architecture/real.md)',
       ).map((issue) => issue.line),
       [5],
+    );
+    assertEquals(
+      collectUnpublishedLinkIssues(
+        "docs/guides/example.mdx",
+        'export const sample = `x ${"`"} [old](../architecture/private.md)`',
+      ),
+      [],
     );
     assertEquals(
       collectUnpublishedLinkIssues(

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -511,6 +511,7 @@ describe("public docs validation", () => {
           '<a data-ok={(() => { class Sample {} /[}>]/.test(value) })()} href="../architecture/class-block-regex.md">ok</a>\n' +
           '<a data-ok={(() => { if (x) {} else /[}>]/.test(x); do /[}>]/.test(x); while (false); })()} href="../architecture/statement-regex.md">ok</a>\n' +
           '<a data-ok={(() => { try {} catch {} /[}>]/.test(value) })()} href="../architecture/catch-block-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { {}\n/[}>]/.test(value) })()} href="../architecture/standalone-block-regex.md">ok</a>\n' +
           '<a data-ok={(() => { for (const x of /[}>]/.source) {} return true })()} href="../architecture/for-of-regex.md">ok</a>\n' +
           '<a data-ok={(() => { for (using of /[}>]/.source) {} return true })()} href="../architecture/for-using-of-regex.md">ok</a>\n' +
           '<a data-ok={(async () => { for await (const x of /[}>]/.source) {} return true })()} href="../architecture/for-await-of-regex.md">ok</a>\n' +
@@ -530,6 +531,8 @@ describe("public docs validation", () => {
           '<a data-ok={function () {} / ({ marker: ">/" }).length} href="../architecture/function-expression-division.md">ok</a>\n' +
           '<a data-ok={class Sample {} / ({ marker: ">/" }).length} href="../architecture/class-expression-division.md">ok</a>\n' +
           '<a data-ok={<Foo></Foo>} href="../architecture/paired-jsx.md">ok</a>\n' +
+          '<a data-ok={<Foo>child</Foo>} href="../architecture/paired-jsx-text.md">ok</a>\n' +
+          '<a data-ok={(() => { let value\n/[}>]/.test(input); var other\n/[}>]/.test(input) })()} href="../architecture/declaration-asi-regex.md">ok</a>\n' +
           '<a data-ok={(() => { breakfast\n/ ({ marker: ">/" }).length; continueValue\n/ ({ marker: ">/" }).length; debuggerValue\n/ ({ marker: ">/" }).length; return true })()} href="../architecture/asi-prefix-division.md">ok</a>\n' +
           '<a data-ok={(() => { while (value) { break\n/[}>]/.test(value) } while (value) { continue\n/[}>]/.test(value) } debugger\n/[}>]/.test(value); return true })()} href="../architecture/asi-regex.md">ok</a>\n' +
           '<a data-ok={(async () => await (x) / ({ marker: "}>/" }).length)()} href="../architecture/await-group-division.md">ok</a>\n' +
@@ -574,6 +577,7 @@ describe("public docs validation", () => {
         "../architecture/class-block-regex.md",
         "../architecture/statement-regex.md",
         "../architecture/catch-block-regex.md",
+        "../architecture/standalone-block-regex.md",
         "../architecture/for-of-regex.md",
         "../architecture/for-using-of-regex.md",
         "../architecture/for-await-of-regex.md",
@@ -589,6 +593,8 @@ describe("public docs validation", () => {
         "../architecture/function-expression-division.md",
         "../architecture/class-expression-division.md",
         "../architecture/paired-jsx.md",
+        "../architecture/paired-jsx-text.md",
+        "../architecture/declaration-asi-regex.md",
         "../architecture/asi-prefix-division.md",
         "../architecture/asi-regex.md",
         "../architecture/await-group-division.md",

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -507,6 +507,10 @@ describe("public docs validation", () => {
           '<a data-ok={value instanceof /}>/} href="../architecture/instanceof-regex.md">ok</a>\n' +
           '<a data-ok={`x ${"`"} >`} href="../architecture/template.md">ok</a>\n' +
           '<a data-ok={value / count > 1} href="../architecture/division.md">ok</a>\n' +
+          '<a data-ok={++/{/.lastIndex} href="../architecture/prefix-update.md">ok</a>\n' +
+          '<a data-ok={--/}/.lastIndex} href="../architecture/prefix-decrement.md">ok</a>\n' +
+          '<a data-ok={value++ / count > 1} href="../architecture/postfix-update.md">ok</a>\n' +
+          '<a data-ok={value-- / count > 1} href="../architecture/postfix-decrement.md">ok</a>\n' +
           '<a data-ok={this.#instanceof / ({ marker: "}>/" }).length} href="../architecture/private-member.md">ok</a>\n' +
           '<div title="[old](../architecture/title-link.md)"></div>\n' +
           '<div title={"[old](../architecture/expression.md)"}></div>\n' +
@@ -532,6 +536,10 @@ describe("public docs validation", () => {
         "../architecture/instanceof-regex.md",
         "../architecture/template.md",
         "../architecture/division.md",
+        "../architecture/prefix-update.md",
+        "../architecture/prefix-decrement.md",
+        "../architecture/postfix-update.md",
+        "../architecture/postfix-decrement.md",
         "../architecture/private-member.md",
         "../architecture/real.md",
       ],
@@ -1670,6 +1678,13 @@ describe("public docs validation", () => {
       ),
       [],
     );
+    assertEquals(
+      destinations(
+        "export const sample = `${--/}/.lastIndex} / \\` " +
+          "[old](../architecture/prefix-decrement.md)`",
+      ),
+      [],
+    );
   });
 
   it("ignores Markdown syntax inside MDX ESM blocks", () => {
@@ -1679,6 +1694,30 @@ describe("public docs validation", () => {
           "export const metadata = {\n" +
           '  sample: "[old](../architecture/export.md)",\n' +
           "}\n\n" +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        'export const increment = ++/{/.lastIndex ? "[old](../architecture/prefix.md)" : ""\n' +
+          'export const decrement = --/}/.lastIndex ? "[old](../architecture/prefix-decrement.md)" : ""\n\n' +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        'export const increment = value++ / total ? "[old](../architecture/postfix.md)" : ""\n' +
+          'export const decrement = value-- / total ? "[old](../architecture/postfix-decrement.md)" : ""\n\n' +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        "export const value = sample\n++/{/.lastIndex\n" +
+          'export const hidden = "[old](../architecture/line-break.md)"\n\n' +
           "[real](../architecture/real.md)",
       ),
       ["../architecture/real.md"],

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -494,6 +494,7 @@ describe("public docs validation", () => {
           'Configure href="../architecture/prose.md" for the sample.\n' +
           "<a title=\"sample href='../architecture/title.md' text\">safe</a>\n" +
           '<a data-ok={true /* } > */} href="../architecture/commented-tag.md">ok</a>\n' +
+          '<a data-ok={value /* c */ / divisor} href="../architecture/comment-division.md">ok</a>\n' +
           '<a data-ok={{ value: /* } > */ true }} href="../architecture/nested-comment.md">ok</a>\n' +
           '<a data-ok={true // } >\n} href="../architecture/line-comment.md">ok</a>\n' +
           '<a data-ok={/<}>/.test(value)} href="../architecture/regex.md">ok</a>\n' +
@@ -518,6 +519,7 @@ describe("public docs validation", () => {
       [
         "../architecture/image.png",
         "../architecture/commented-tag.md",
+        "../architecture/comment-division.md",
         "../architecture/nested-comment.md",
         "../architecture/line-comment.md",
         "../architecture/regex.md",
@@ -1628,6 +1630,13 @@ describe("public docs validation", () => {
     assertEquals(
       destinations(
         '{/<}>/.test(value) ? "[old](../architecture/regex.md)" : ""}\n' +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        '{new /[}]/ ? "[old](../architecture/new-regex.md)" : ""}\n' +
           "[real](../architecture/real.md)",
       ),
       ["../architecture/real.md"],

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -507,6 +507,7 @@ describe("public docs validation", () => {
           '<a data-ok={value instanceof /}>/} href="../architecture/instanceof-regex.md">ok</a>\n' +
           '<a data-ok={(async () => await /}>/.test(x))()} href="../architecture/await-regex.md">ok</a>\n' +
           '<a data-ok={(function* () { yield /}>/.test(x) })()} href="../architecture/yield-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { if (x) {} else /[}>]/.test(x); do /[}>]/.test(x); while (false); })()} href="../architecture/statement-regex.md">ok</a>\n' +
           '<a data-ok={(async () => await (x) / ({ marker: "}>/" }).length)()} href="../architecture/await-group-division.md">ok</a>\n' +
           '<a data-ok={`x ${"`"} >`} href="../architecture/template.md">ok</a>\n' +
           '<a data-ok={value / count > 1} href="../architecture/division.md">ok</a>\n' +
@@ -545,6 +546,7 @@ describe("public docs validation", () => {
         "../architecture/instanceof-regex.md",
         "../architecture/await-regex.md",
         "../architecture/yield-regex.md",
+        "../architecture/statement-regex.md",
         "../architecture/await-group-division.md",
         "../architecture/template.md",
         "../architecture/division.md",

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -484,6 +484,7 @@ describe("public docs validation", () => {
           '<a data-ok={value instanceof /}>/} href="../architecture/instanceof-regex.md">ok</a>\n' +
           '<a data-ok={`x ${"`"} >`} href="../architecture/template.md">ok</a>\n' +
           '<a data-ok={value / count > 1} href="../architecture/division.md">ok</a>\n' +
+          '<a data-ok={this.#instanceof / ({ marker: "}>/" }).length} href="../architecture/private-member.md">ok</a>\n' +
           '<div title="[old](../architecture/title-link.md)"></div>\n' +
           '<div title={"[old](../architecture/expression.md)"}></div>\n' +
           "<Code value={'Configure href=\"../architecture/string.md\"'} />\n" +
@@ -507,6 +508,7 @@ describe("public docs validation", () => {
         "../architecture/instanceof-regex.md",
         "../architecture/template.md",
         "../architecture/division.md",
+        "../architecture/private-member.md",
         "../architecture/real.md",
       ],
     );

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -505,6 +505,8 @@ describe("public docs validation", () => {
           '<a data-ok={delete /}>/} href="../architecture/delete-regex.md">ok</a>\n' +
           '<a data-ok={"x" in /}>/} href="../architecture/in-regex.md">ok</a>\n' +
           '<a data-ok={value instanceof /}>/} href="../architecture/instanceof-regex.md">ok</a>\n' +
+          '<a data-ok={(async () => await /}>/.test(x))()} href="../architecture/await-regex.md">ok</a>\n' +
+          '<a data-ok={(function* () { yield /}>/.test(x) })()} href="../architecture/yield-regex.md">ok</a>\n' +
           '<a data-ok={`x ${"`"} >`} href="../architecture/template.md">ok</a>\n' +
           '<a data-ok={value / count > 1} href="../architecture/division.md">ok</a>\n' +
           '<a data-ok={++/{/.lastIndex} href="../architecture/prefix-update.md">ok</a>\n' +
@@ -540,6 +542,8 @@ describe("public docs validation", () => {
         "../architecture/delete-regex.md",
         "../architecture/in-regex.md",
         "../architecture/instanceof-regex.md",
+        "../architecture/await-regex.md",
+        "../architecture/yield-regex.md",
         "../architecture/template.md",
         "../architecture/division.md",
         "../architecture/prefix-update.md",
@@ -1694,6 +1698,13 @@ describe("public docs validation", () => {
     );
     assertEquals(
       destinations(
+        '{(() => { if (value) /[}]/.test(value); return "[old](../architecture/expression-control.md)"; })()}\n' +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
         "export const sample = `${--/}/.lastIndex} / \\` " +
           "[old](../architecture/prefix-decrement.md)`",
       ),
@@ -1732,6 +1743,20 @@ describe("public docs validation", () => {
       destinations(
         "export const value = sample\n++/{/.lastIndex\n" +
           'export const hidden = "[old](../architecture/line-break.md)"\n\n' +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        'export function sample(value) { if (value) /[}]/.test(value); return "[old](../architecture/control-header.md)"; }\n\n' +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        'export const sample = `${(() => { if (value) /[}]/.test(value); return "[old](../architecture/template-control.md)"; })()}`\n\n' +
           "[real](../architecture/real.md)",
       ),
       ["../architecture/real.md"],

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -507,9 +507,12 @@ describe("public docs validation", () => {
           '<a data-ok={value instanceof /}>/} href="../architecture/instanceof-regex.md">ok</a>\n' +
           '<a data-ok={(async () => await /}>/.test(x))()} href="../architecture/await-regex.md">ok</a>\n' +
           '<a data-ok={(function* () { yield /}>/.test(x) })()} href="../architecture/yield-regex.md">ok</a>\n' +
+          '<a data-ok={class extends /[}>]/.constructor {}} href="../architecture/extends-regex.md">ok</a>\n' +
           '<a data-ok={(() => { if (x) {} else /[}>]/.test(x); do /[}>]/.test(x); while (false); })()} href="../architecture/statement-regex.md">ok</a>\n' +
           '<a data-ok={(() => { for (const x of /[}>]/.source) {} return true })()} href="../architecture/for-of-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { for (of / ({ marker: ">/" }).length; false;) {} return true })()} href="../architecture/for-of-division.md">ok</a>\n' +
           '<a data-ok={of / ({ marker: "}>/" }).length} href="../architecture/of-division.md">ok</a>\n' +
+          '<a data-ok={(() => { breakfast\n/ ({ marker: ">/" }).length; continueValue\n/ ({ marker: ">/" }).length; debuggerValue\n/ ({ marker: ">/" }).length; return true })()} href="../architecture/asi-prefix-division.md">ok</a>\n' +
           '<a data-ok={(async () => await (x) / ({ marker: "}>/" }).length)()} href="../architecture/await-group-division.md">ok</a>\n' +
           '<a data-ok={`x ${"`"} >`} href="../architecture/template.md">ok</a>\n' +
           '<a data-ok={value / count > 1} href="../architecture/division.md">ok</a>\n' +
@@ -548,9 +551,12 @@ describe("public docs validation", () => {
         "../architecture/instanceof-regex.md",
         "../architecture/await-regex.md",
         "../architecture/yield-regex.md",
+        "../architecture/extends-regex.md",
         "../architecture/statement-regex.md",
         "../architecture/for-of-regex.md",
+        "../architecture/for-of-division.md",
         "../architecture/of-division.md",
+        "../architecture/asi-prefix-division.md",
         "../architecture/await-group-division.md",
         "../architecture/template.md",
         "../architecture/division.md",

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -512,6 +512,16 @@ describe("public docs validation", () => {
           '<a data-ok={(() => { for (const x of /[}>]/.source) {} return true })()} href="../architecture/for-of-regex.md">ok</a>\n' +
           '<a data-ok={(() => { for (using of /[}>]/.source) {} return true })()} href="../architecture/for-using-of-regex.md">ok</a>\n' +
           '<a data-ok={(async () => { for await (const x of /[}>]/.source) {} return true })()} href="../architecture/for-await-of-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { for (item1 of /[}>]/.source) {} return true })()} href="../architecture/for-digit-identifier-of-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { for (item_ of /[}>]/.source) {} return true })()} href="../architecture/for-underscore-identifier-of-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { for (item$ of /[}>]/.source) {} return true })()} href="../architecture/for-dollar-identifier-of-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { for (π of /[}>]/.source) {} return true })()} href="../architecture/for-unicode-identifier-of-regex.md">ok</a>\n' +
+          String
+            .raw`<a data-ok={(() => { for (\u{10400}item of /[}>]/.source) {} return true })()} href="../architecture/for-escaped-start-identifier-of-regex.md">ok</a>` +
+          "\n" +
+          String
+            .raw`<a data-ok={(() => { for (item\u0031 of /[}>]/.source) {} return true })()} href="../architecture/for-escaped-end-identifier-of-regex.md">ok</a>` +
+          "\n" +
           '<a data-ok={(() => { for (of / ({ marker: ">/" }).length; false;) {} return true })()} href="../architecture/for-of-division.md">ok</a>\n' +
           '<a data-ok={(() => { for (const x = { value: of / ({ marker: ">/" }).length }; false;) {} return true })()} href="../architecture/for-header-nested-of-division.md">ok</a>\n' +
           '<a data-ok={of / ({ marker: ">/" }).length} href="../architecture/of-division.md">ok</a>\n' +
@@ -560,6 +570,12 @@ describe("public docs validation", () => {
         "../architecture/for-of-regex.md",
         "../architecture/for-using-of-regex.md",
         "../architecture/for-await-of-regex.md",
+        "../architecture/for-digit-identifier-of-regex.md",
+        "../architecture/for-underscore-identifier-of-regex.md",
+        "../architecture/for-dollar-identifier-of-regex.md",
+        "../architecture/for-unicode-identifier-of-regex.md",
+        "../architecture/for-escaped-start-identifier-of-regex.md",
+        "../architecture/for-escaped-end-identifier-of-regex.md",
         "../architecture/for-of-division.md",
         "../architecture/for-header-nested-of-division.md",
         "../architecture/of-division.md",
@@ -1727,6 +1743,20 @@ describe("public docs validation", () => {
     );
     assertEquals(
       destinations(
+        '{(() => { for (item1 of /[}]/.source) {} return "[old](../architecture/expression-for-of.md)"; })()}\n' +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        "export const sample = `${(() => { for (item_ of /[}]/.source) {} return '[old](../architecture/template-for-of.md)'; })()}`\n\n" +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
         "export const sample = `${--/}/.lastIndex} / \\` " +
           "[old](../architecture/prefix-decrement.md)`",
       ),
@@ -1783,6 +1813,16 @@ describe("public docs validation", () => {
           "  if (value) {} else /[}]/.test(value);\n" +
           "  do /[}]/.test(value); while (false);\n" +
           '  return "[old](../architecture/statement-context.md)";\n' +
+          "}\n\n" +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        "export function sample() {\n" +
+          "  for (π of /[}]/.source) {}\n" +
+          '  return "[old](../architecture/esm-for-of.md)";\n' +
           "}\n\n" +
           "[real](../architecture/real.md)",
       ),

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertLess } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   collectIssues,
@@ -720,6 +720,9 @@ describe("public docs validation", () => {
           `https://%67ithub.com.example/${BLOCKED_REPOSITORY}\n` +
           `https://github.com@example.com/${BLOCKED_REPOSITORY}\n` +
           `https://github.com/${BLOCKED_REPOSITORY}_public\n` +
+          "https://github.com/example-org/private%2Dexamples%23-fork/%ZZ\n" +
+          "https://github.com/example-org/private%2Dexamples%2Ffork/%ZZ\n" +
+          "https://github.com/example-org/private%2Dexamples%3Ffork/%ZZ\n" +
           `_https://github.com/${BLOCKED_REPOSITORY}_public_`,
         BLOCKED_REPOSITORY,
       ),
@@ -1679,6 +1682,22 @@ describe("public docs validation", () => {
         'export const sample = "[old](../architecture/markdown.md)"',
       ).length,
       1,
+    );
+  });
+
+  it("scans division-heavy MDX ESM template interpolations in linear time", () => {
+    const interpolation = Array.from({ length: 32_001 }, () => "value").join(
+      "/",
+    );
+    const source = "export const sample = `value ${" + interpolation +
+      "}`\n\n[real](../architecture/real.md)";
+    const startedAt = performance.now();
+
+    assertEquals(destinations(source), ["../architecture/real.md"]);
+    assertLess(
+      performance.now() - startedAt,
+      2_000,
+      "division-heavy template interpolation scanning must stay linear",
     );
   });
 

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -1663,6 +1663,13 @@ describe("public docs validation", () => {
       ),
       [],
     );
+    assertEquals(
+      destinations(
+        "export const sample = `${++/{/.lastIndex} / \\` " +
+          "[old](../architecture/prefix-update.md)`",
+      ),
+      [],
+    );
   });
 
   it("ignores Markdown syntax inside MDX ESM blocks", () => {

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -516,7 +516,9 @@ describe("public docs validation", () => {
           '<a data-ok={(function () { class Sample {} /[}>]/.test(value); return true })()} href="../architecture/function-body-regex.md">ok</a>\n' +
           '<a data-ok={({ method() { {} /[}>]/.test(value) } })} href="../architecture/method-body-regex.md">ok</a>\n' +
           '<a data-ok={(class { method() { {} /[}>]/.test(value) } })} href="../architecture/class-method-body-regex.md">ok</a>\n' +
+          '<a data-ok={class Sample { static { {} /[}>]/.test(value) } }} href="../architecture/class-static-block-regex.md">ok</a>\n' +
           '<a data-ok={(() => { return\n{} /[}>]/.test(value) })()} href="../architecture/return-asi-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { label: {} /[}>]/.test(value) })()} href="../architecture/labeled-block-regex.md">ok</a>\n' +
           '<a data-ok={<Foo></Foo>} href="../architecture/paired-jsx.md">ok</a>\n' +
           '<a data-ok={<Foo>child</Foo>} href="../architecture/jsx-child-text.md">ok</a>\n' +
           '<a data-ok={value </foo>/.source} href="../architecture/less-than-regex.md">ok</a>\n' +
@@ -603,7 +605,9 @@ describe("public docs validation", () => {
         "../architecture/function-body-regex.md",
         "../architecture/method-body-regex.md",
         "../architecture/class-method-body-regex.md",
+        "../architecture/class-static-block-regex.md",
         "../architecture/return-asi-regex.md",
+        "../architecture/labeled-block-regex.md",
         "../architecture/paired-jsx.md",
         "../architecture/jsx-child-text.md",
         "../architecture/less-than-regex.md",

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -508,6 +508,8 @@ describe("public docs validation", () => {
           '<a data-ok={(async () => await /}>/.test(x))()} href="../architecture/await-regex.md">ok</a>\n' +
           '<a data-ok={(function* () { yield /}>/.test(x) })()} href="../architecture/yield-regex.md">ok</a>\n' +
           '<a data-ok={(() => { if (x) {} else /[}>]/.test(x); do /[}>]/.test(x); while (false); })()} href="../architecture/statement-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { for (const x of /[}>]/.source) {} return true })()} href="../architecture/for-of-regex.md">ok</a>\n' +
+          '<a data-ok={of / ({ marker: "}>/" }).length} href="../architecture/of-division.md">ok</a>\n' +
           '<a data-ok={(async () => await (x) / ({ marker: "}>/" }).length)()} href="../architecture/await-group-division.md">ok</a>\n' +
           '<a data-ok={`x ${"`"} >`} href="../architecture/template.md">ok</a>\n' +
           '<a data-ok={value / count > 1} href="../architecture/division.md">ok</a>\n' +
@@ -547,6 +549,8 @@ describe("public docs validation", () => {
         "../architecture/await-regex.md",
         "../architecture/yield-regex.md",
         "../architecture/statement-regex.md",
+        "../architecture/for-of-regex.md",
+        "../architecture/of-division.md",
         "../architecture/await-group-division.md",
         "../architecture/template.md",
         "../architecture/division.md",
@@ -1765,6 +1769,18 @@ describe("public docs validation", () => {
           "  if (value) {} else /[}]/.test(value);\n" +
           "  do /[}]/.test(value); while (false);\n" +
           '  return "[old](../architecture/statement-context.md)";\n' +
+          "}\n\n" +
+          "[real](../architecture/real.md)",
+      ),
+      ["../architecture/real.md"],
+    );
+    assertEquals(
+      destinations(
+        "export function sample(value) {\n" +
+          "  for (;;) { break\n/[}]/.test(value) }\n" +
+          "  for (;;) { continue\n/[}]/.test(value) }\n" +
+          "  debugger\n/[}]/.test(value)\n" +
+          '  return "[old](../architecture/asi-statement.md)";\n' +
           "}\n\n" +
           "[real](../architecture/real.md)",
       ),

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -509,6 +509,7 @@ describe("public docs validation", () => {
           '<a data-ok={(function* () { yield /}>/.test(x) })()} href="../architecture/yield-regex.md">ok</a>\n' +
           '<a data-ok={class extends /[}>]/.constructor {}} href="../architecture/extends-regex.md">ok</a>\n' +
           '<a data-ok={(() => { class Sample {} /[}>]/.test(value) })()} href="../architecture/class-block-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { class Sample extends factory(Base) {} /[}>]/.test(value) })()} href="../architecture/class-heritage-regex.md">ok</a>\n' +
           '<a data-ok={(() => { if (x) {} else /[}>]/.test(x); do /[}>]/.test(x); while (false); })()} href="../architecture/statement-regex.md">ok</a>\n' +
           '<a data-ok={(() => { try {} catch {} /[}>]/.test(value) })()} href="../architecture/catch-block-regex.md">ok</a>\n' +
           '<a data-ok={(() => { {}\n/[}>]/.test(value) })()} href="../architecture/standalone-block-regex.md">ok</a>\n' +
@@ -532,7 +533,10 @@ describe("public docs validation", () => {
           '<a data-ok={class Sample {} / ({ marker: ">/" }).length} href="../architecture/class-expression-division.md">ok</a>\n' +
           '<a data-ok={<Foo></Foo>} href="../architecture/paired-jsx.md">ok</a>\n' +
           '<a data-ok={<Foo>child</Foo>} href="../architecture/paired-jsx-text.md">ok</a>\n' +
+          '<a data-ok={<Foo/> / ({ marker: ">/" }).length} href="../architecture/jsx-division.md">ok</a>\n' +
+          '<Comp value={<a href="../architecture/nested-jsx-link.md">x</a>} />\n' +
           '<a data-ok={(() => { let value\n/[}>]/.test(input); var other\n/[}>]/.test(input) })()} href="../architecture/declaration-asi-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { let first, second\n/[}>]/.test(input); var third, fourth\n/[}>]/.test(input) })()} href="../architecture/declaration-list-asi-regex.md">ok</a>\n' +
           '<a data-ok={(() => { breakfast\n/ ({ marker: ">/" }).length; continueValue\n/ ({ marker: ">/" }).length; debuggerValue\n/ ({ marker: ">/" }).length; return true })()} href="../architecture/asi-prefix-division.md">ok</a>\n' +
           '<a data-ok={(() => { while (value) { break\n/[}>]/.test(value) } while (value) { continue\n/[}>]/.test(value) } debugger\n/[}>]/.test(value); return true })()} href="../architecture/asi-regex.md">ok</a>\n' +
           '<a data-ok={(async () => await (x) / ({ marker: "}>/" }).length)()} href="../architecture/await-group-division.md">ok</a>\n' +
@@ -575,6 +579,7 @@ describe("public docs validation", () => {
         "../architecture/yield-regex.md",
         "../architecture/extends-regex.md",
         "../architecture/class-block-regex.md",
+        "../architecture/class-heritage-regex.md",
         "../architecture/statement-regex.md",
         "../architecture/catch-block-regex.md",
         "../architecture/standalone-block-regex.md",
@@ -594,7 +599,10 @@ describe("public docs validation", () => {
         "../architecture/class-expression-division.md",
         "../architecture/paired-jsx.md",
         "../architecture/paired-jsx-text.md",
+        "../architecture/jsx-division.md",
+        "../architecture/nested-jsx-link.md",
         "../architecture/declaration-asi-regex.md",
+        "../architecture/declaration-list-asi-regex.md",
         "../architecture/asi-prefix-division.md",
         "../architecture/asi-regex.md",
         "../architecture/await-group-division.md",

--- a/scripts/docs/validate-public-docs.test.ts
+++ b/scripts/docs/validate-public-docs.test.ts
@@ -508,7 +508,9 @@ describe("public docs validation", () => {
           '<a data-ok={(async () => await /}>/.test(x))()} href="../architecture/await-regex.md">ok</a>\n' +
           '<a data-ok={(function* () { yield /}>/.test(x) })()} href="../architecture/yield-regex.md">ok</a>\n' +
           '<a data-ok={class extends /[}>]/.constructor {}} href="../architecture/extends-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { class Sample {} /[}>]/.test(value) })()} href="../architecture/class-block-regex.md">ok</a>\n' +
           '<a data-ok={(() => { if (x) {} else /[}>]/.test(x); do /[}>]/.test(x); while (false); })()} href="../architecture/statement-regex.md">ok</a>\n' +
+          '<a data-ok={(() => { try {} catch {} /[}>]/.test(value) })()} href="../architecture/catch-block-regex.md">ok</a>\n' +
           '<a data-ok={(() => { for (const x of /[}>]/.source) {} return true })()} href="../architecture/for-of-regex.md">ok</a>\n' +
           '<a data-ok={(() => { for (using of /[}>]/.source) {} return true })()} href="../architecture/for-using-of-regex.md">ok</a>\n' +
           '<a data-ok={(async () => { for await (const x of /[}>]/.source) {} return true })()} href="../architecture/for-await-of-regex.md">ok</a>\n' +
@@ -526,6 +528,8 @@ describe("public docs validation", () => {
           '<a data-ok={(() => { for (const x = { value: of / ({ marker: ">/" }).length }; false;) {} return true })()} href="../architecture/for-header-nested-of-division.md">ok</a>\n' +
           '<a data-ok={of / ({ marker: ">/" }).length} href="../architecture/of-division.md">ok</a>\n' +
           '<a data-ok={function () {} / ({ marker: ">/" }).length} href="../architecture/function-expression-division.md">ok</a>\n' +
+          '<a data-ok={class Sample {} / ({ marker: ">/" }).length} href="../architecture/class-expression-division.md">ok</a>\n' +
+          '<a data-ok={<Foo></Foo>} href="../architecture/paired-jsx.md">ok</a>\n' +
           '<a data-ok={(() => { breakfast\n/ ({ marker: ">/" }).length; continueValue\n/ ({ marker: ">/" }).length; debuggerValue\n/ ({ marker: ">/" }).length; return true })()} href="../architecture/asi-prefix-division.md">ok</a>\n' +
           '<a data-ok={(() => { while (value) { break\n/[}>]/.test(value) } while (value) { continue\n/[}>]/.test(value) } debugger\n/[}>]/.test(value); return true })()} href="../architecture/asi-regex.md">ok</a>\n' +
           '<a data-ok={(async () => await (x) / ({ marker: "}>/" }).length)()} href="../architecture/await-group-division.md">ok</a>\n' +
@@ -567,7 +571,9 @@ describe("public docs validation", () => {
         "../architecture/await-regex.md",
         "../architecture/yield-regex.md",
         "../architecture/extends-regex.md",
+        "../architecture/class-block-regex.md",
         "../architecture/statement-regex.md",
+        "../architecture/catch-block-regex.md",
         "../architecture/for-of-regex.md",
         "../architecture/for-using-of-regex.md",
         "../architecture/for-await-of-regex.md",
@@ -581,6 +587,8 @@ describe("public docs validation", () => {
         "../architecture/for-header-nested-of-division.md",
         "../architecture/of-division.md",
         "../architecture/function-expression-division.md",
+        "../architecture/class-expression-division.md",
+        "../architecture/paired-jsx.md",
         "../architecture/asi-prefix-division.md",
         "../architecture/asi-regex.md",
         "../architecture/await-group-division.md",
@@ -1973,6 +1981,20 @@ describe("public docs validation", () => {
       performance.now() - startedAt,
       2_000,
       "division-heavy template interpolation scanning must stay linear",
+    );
+  });
+
+  it("scans long JavaScript identifiers in linear time", () => {
+    const identifier = `value${"x".repeat(32_000)}`;
+    const source = `export const ${identifier} = 1\n\n` +
+      "[real](../architecture/real.md)";
+    const startedAt = performance.now();
+
+    assertEquals(destinations(source), ["../architecture/real.md"]);
+    assertLess(
+      performance.now() - startedAt,
+      2_000,
+      "identifier scanning must stay linear",
     );
   });
 

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -776,6 +776,12 @@ interface JavaScriptSignificantToken {
   readonly kind: "other" | "regex";
 }
 
+interface JavaScriptScannedToken {
+  readonly end: number;
+  readonly kind: "literal" | "other" | "regex" | "trivia";
+  readonly string?: Range;
+}
+
 function quotedRangeEnd(
   text: string,
   start: number,
@@ -819,45 +825,28 @@ function javaScriptTemplateInterpolationEnd(
   let cursor = start + 2;
   let previousSignificantToken: JavaScriptSignificantToken | undefined;
   while (cursor < text.length) {
-    const commentEnd = javaScriptCommentEnd(text, cursor);
-    if (commentEnd !== undefined) {
-      cursor = commentEnd;
+    const token = javaScriptTokenAt(
+      text,
+      cursor,
+      previousSignificantToken,
+    );
+    if (token === undefined) return undefined;
+    if (token.kind === "trivia") {
+      cursor = token.end;
+      continue;
+    }
+    previousSignificantToken = {
+      end: token.end,
+      kind: token.kind === "regex" ? "regex" : "other",
+    };
+    if (token.kind !== "other") {
+      cursor = token.end;
       continue;
     }
     const character = text[cursor]!;
-    if (character === '"' || character === "'") {
-      const end = quotedRangeEnd(text, cursor, character);
-      if (end === undefined) return undefined;
-      previousSignificantToken = { end, kind: "other" };
-      cursor = end;
-      continue;
-    }
-    if (character === "`") {
-      const end = javaScriptTemplateEnd(text, cursor);
-      if (end === undefined) return undefined;
-      previousSignificantToken = { end, kind: "other" };
-      cursor = end;
-      continue;
-    }
-    if (
-      character === "/" &&
-      javaScriptRegexMayStart(text, previousSignificantToken)
-    ) {
-      const regexEnd = javaScriptRegexEnd(text, cursor);
-      if (regexEnd !== undefined) {
-        previousSignificantToken = { end: regexEnd, kind: "regex" };
-        cursor = regexEnd;
-        continue;
-      }
-    }
-    if (/\s/.test(character)) {
-      cursor++;
-      continue;
-    }
-    previousSignificantToken = { end: cursor + 1, kind: "other" };
     if (character === "{") depth++;
     else if (character === "}" && --depth === 0) return cursor + 1;
-    cursor++;
+    cursor = token.end;
   }
   return undefined;
 }
@@ -934,49 +923,31 @@ function mdxExpressionAt(
   let cursor = start + 1;
   let previousSignificantToken: JavaScriptSignificantToken | undefined;
   while (cursor < text.length) {
-    const commentEnd = javaScriptCommentEnd(text, cursor);
-    if (commentEnd !== undefined) {
-      cursor = commentEnd;
+    const token = javaScriptTokenAt(
+      text,
+      cursor,
+      previousSignificantToken,
+    );
+    if (token === undefined) return undefined;
+    if (token.string !== undefined) strings.push(token.string);
+    if (token.kind === "trivia") {
+      cursor = token.end;
+      continue;
+    }
+    previousSignificantToken = {
+      end: token.end,
+      kind: token.kind === "regex" ? "regex" : "other",
+    };
+    if (token.kind !== "other") {
+      cursor = token.end;
       continue;
     }
     const character = text[cursor]!;
-    if (character === "`") {
-      const end = javaScriptTemplateEnd(text, cursor);
-      if (end === undefined) return undefined;
-      strings.push({ start: cursor, end });
-      previousSignificantToken = { end, kind: "other" };
-      cursor = end;
-      continue;
-    }
-    if (character === '"' || character === "'") {
-      const end = quotedRangeEnd(text, cursor, character);
-      if (end === undefined) return undefined;
-      strings.push({ start: cursor, end });
-      previousSignificantToken = { end, kind: "other" };
-      cursor = end;
-      continue;
-    }
-    if (
-      character === "/" &&
-      javaScriptRegexMayStart(text, previousSignificantToken)
-    ) {
-      const regexEnd = javaScriptRegexEnd(text, cursor);
-      if (regexEnd !== undefined) {
-        previousSignificantToken = { end: regexEnd, kind: "regex" };
-        cursor = regexEnd;
-        continue;
-      }
-    }
-    if (/\s/.test(character)) {
-      cursor++;
-      continue;
-    }
-    previousSignificantToken = { end: cursor + 1, kind: "other" };
     if (character === "{") depth++;
     else if (character === "}" && --depth === 0) {
       return { expression: { start, end: cursor + 1 }, strings };
     }
-    cursor++;
+    cursor = token.end;
   }
   return undefined;
 }
@@ -1116,6 +1087,37 @@ function javaScriptRegexMayStart(
 
   return wordStart === 0 ||
     !/[A-Za-z0-9_$.#]/.test(text[wordStart - 1]!);
+}
+
+function javaScriptTokenAt(
+  text: string,
+  start: number,
+  previousSignificantToken: JavaScriptSignificantToken | undefined,
+): JavaScriptScannedToken | undefined {
+  const commentEnd = javaScriptCommentEnd(text, start);
+  if (commentEnd !== undefined) {
+    return { end: commentEnd, kind: "trivia" };
+  }
+
+  const character = text[start]!;
+  if (/\s/.test(character)) return { end: start + 1, kind: "trivia" };
+
+  if (character === '"' || character === "'" || character === "`") {
+    const end = quotedRangeEnd(text, start, character);
+    return end === undefined
+      ? undefined
+      : { end, kind: "literal", string: { start, end } };
+  }
+
+  if (
+    character === "/" &&
+    javaScriptRegexMayStart(text, previousSignificantToken)
+  ) {
+    const end = javaScriptRegexEnd(text, start);
+    if (end !== undefined) return { end, kind: "regex" };
+  }
+
+  return { end: start + 1, kind: "other" };
 }
 
 function scanJavaScriptLine(

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -771,6 +771,11 @@ interface MdxSyntaxRanges {
   readonly strings: Range[];
 }
 
+// This is a bounded lexical scanner, not a JavaScript parser. It tracks only
+// the token and delimiter context needed to distinguish regex literals from
+// division while balancing JSX, MDX expressions, templates, and ESM blocks.
+// Keep those scanner surfaces on this shared state model, and regression-test
+// both the regex and division forms when adding a new grammar context.
 type JavaScriptSignificantTokenKind =
   | "control-header"
   | "other"

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -216,16 +216,33 @@ function decodeJavaScriptStringLiteral(value: string): string | undefined {
   return decoded;
 }
 
+function decodeUrlComponentTolerantly(value: string): string {
+  return value.replace(/(?:%[0-9a-fA-F]{2})+/g, (encoded) => {
+    let decoded = "";
+    for (let start = 0; start < encoded.length;) {
+      let end = encoded.length;
+      let consumed = false;
+      for (; end > start; end -= 3) {
+        try {
+          decoded += decodeURIComponent(encoded.slice(start, end));
+          start = end;
+          consumed = true;
+          break;
+        } catch {
+          // Try a shorter complete UTF-8 sequence.
+        }
+      }
+      if (!consumed) {
+        decoded += encoded.slice(start, start + 3);
+        start += 3;
+      }
+    }
+    return decoded;
+  });
+}
+
 function normalizeRepositoryPath(pathname: string): string {
-  let decoded: string;
-  try {
-    decoded = decodeURIComponent(pathname);
-  } catch {
-    decoded = pathname
-      .replace(/%2e/gi, ".")
-      .replace(/%2f/gi, "/")
-      .replace(/%5c/gi, "\\");
-  }
+  const decoded = decodeUrlComponentTolerantly(pathname);
   const slashPath = decoded.replaceAll("\\", "/");
   const segments: string[] = [];
   for (const segment of slashPath.split("/")) {
@@ -263,7 +280,7 @@ function resolveDocumentationTarget(
   const href = syntax === "markdown"
     ? decodeMarkdownBackslashEscapes(withCharacterReferences)
     : withCharacterReferences;
-  if (/^(?:#|["'])/.test(href)) return undefined;
+  if (href.startsWith("#")) return undefined;
   let resolved: URL;
   try {
     resolved = new URL(href, `${RESOLUTION_ORIGIN}/${fromPath}`);
@@ -1002,8 +1019,9 @@ function mdxEsmMayStart(text: string, lineStart: number): boolean {
 
 interface JavaScriptBalance {
   readonly delimiters: string[];
-  quote: '"' | "'" | "`" | undefined;
+  quote: '"' | "'" | undefined;
   blockComment: boolean;
+  templateEnd: number;
   valid: boolean;
 }
 
@@ -1032,22 +1050,32 @@ function javaScriptRegexEnd(line: string, start: number): number | undefined {
 function javaScriptRegexMayStart(line: string, start: number): boolean {
   const prefix = line.slice(0, start).trimEnd();
   return prefix === "" ||
-    /(?:[=(:,!\[{;?&|+*%^~<>-]|=>|(?:^|[^A-Za-z0-9_$.])(?:return|case|throw|default|typeof|void|delete))$/
+    /(?:[=(:,!\[{;?&|+*%^~<>-]|=>|(?:^|[^A-Za-z0-9_$.])(?:return|case|throw|default|typeof|void|delete|in|instanceof))$/
       .test(
         prefix,
       );
 }
 
-function scanJavaScriptLine(line: string, state: JavaScriptBalance): void {
+function scanJavaScriptLine(
+  text: string,
+  lineStart: number,
+  lineEnd: number,
+  state: JavaScriptBalance,
+): void {
   const closers: Readonly<Record<string, string>> = {
     ")": "(",
     "]": "[",
     "}": "{",
   };
-  for (let cursor = 0; cursor < line.length; cursor++) {
-    const character = line[cursor]!;
+  const line = text.slice(lineStart, lineEnd);
+  for (
+    let cursor = Math.max(lineStart, state.templateEnd);
+    cursor < lineEnd;
+    cursor++
+  ) {
+    const character = text[cursor]!;
     if (state.blockComment) {
-      if (line.startsWith("*/", cursor)) {
+      if (text.startsWith("*/", cursor)) {
         state.blockComment = false;
         cursor++;
       }
@@ -1058,20 +1086,31 @@ function scanJavaScriptLine(line: string, state: JavaScriptBalance): void {
       else if (character === state.quote) state.quote = undefined;
       continue;
     }
-    if (line.startsWith("//", cursor)) break;
-    if (line.startsWith("/*", cursor)) {
+    if (text.startsWith("//", cursor)) break;
+    if (text.startsWith("/*", cursor)) {
       state.blockComment = true;
       cursor++;
       continue;
     }
-    if (character === '"' || character === "'" || character === "`") {
+    if (character === "`") {
+      const templateEnd = javaScriptTemplateEnd(text, cursor);
+      if (templateEnd === undefined) {
+        state.valid = false;
+        return;
+      }
+      state.templateEnd = templateEnd;
+      cursor = templateEnd - 1;
+      continue;
+    }
+    if (character === '"' || character === "'") {
       state.quote = character;
       continue;
     }
-    if (character === "/" && javaScriptRegexMayStart(line, cursor)) {
-      const regexEnd = javaScriptRegexEnd(line, cursor);
+    const lineCursor = cursor - lineStart;
+    if (character === "/" && javaScriptRegexMayStart(line, lineCursor)) {
+      const regexEnd = javaScriptRegexEnd(line, lineCursor);
       if (regexEnd !== undefined) {
-        cursor = regexEnd - 1;
+        cursor = lineStart + regexEnd - 1;
         continue;
       }
     }
@@ -1094,6 +1133,7 @@ function mdxEsmRangeEnd(text: string, start: number): number | undefined {
     delimiters: [],
     quote: undefined,
     blockComment: false,
+    templateEnd: start,
     valid: true,
   };
   for (let lineStart = start; lineStart <= text.length;) {
@@ -1103,10 +1143,10 @@ function mdxEsmRangeEnd(text: string, start: number): number | undefined {
     if (
       lineStart > start && line.trim() === "" &&
       state.delimiters.length === 0 && state.quote === undefined &&
-      !state.blockComment
+      !state.blockComment && state.templateEnd <= lineStart
     ) return lineStart;
 
-    scanJavaScriptLine(line, state);
+    scanJavaScriptLine(text, lineStart, lineEnd, state);
     if (!state.valid) return undefined;
     if (next === -1) {
       return state.delimiters.length === 0 && state.quote === undefined &&
@@ -1175,6 +1215,14 @@ function yamlFrontmatterRanges(text: string): Range[] {
   return [];
 }
 
+function htmlCommentBlockMayStart(text: string, start: number): boolean {
+  const lineStart = Math.max(
+    text.lastIndexOf("\n", start - 1),
+    text.lastIndexOf("\r", start - 1),
+  ) + 1;
+  return blockContentStart(text, lineStart) === start;
+}
+
 function htmlCommentRanges(
   text: string,
   ignoredRanges: readonly Range[],
@@ -1191,6 +1239,10 @@ function htmlCommentRanges(
       continue;
     }
     const closing = text.indexOf("-->", start + 4);
+    if (closing === -1 && !htmlCommentBlockMayStart(text, start)) {
+      start += 4;
+      continue;
+    }
     const end = closing === -1 ? text.length : closing + 3;
     ranges.push({ start, end });
     start = end;
@@ -1590,6 +1642,11 @@ function topLevelTagOffsets(tag: string): ReadonlySet<number> {
   return scanTagSyntax(tag, 0).topLevelOffsets;
 }
 
+function nextLineEndingStart(text: string, start: number): number | undefined {
+  const match = /[\r\n]/.exec(text.slice(start));
+  return match === null ? undefined : start + match.index;
+}
+
 function referenceTitleEnd(
   text: string,
   start: number,
@@ -1618,11 +1675,9 @@ function referenceTitleEnd(
         : undefined;
     }
     if (text[cursor] === "\n" || text[cursor] === "\r") {
-      if (text[cursor] === "\r") cursor++;
-      if (text[cursor] !== "\n") return undefined;
-      const lineStart = cursor + 1;
-      const next = text.indexOf("\n", lineStart);
-      const lineEnd = next === -1 ? text.length : next;
+      const lineStart = lineEndingEnd(text, cursor);
+      if (lineStart === undefined) return undefined;
+      const lineEnd = nextLineEndingStart(text, lineStart) ?? text.length;
       const contentStart = blockContainerContentStart(
         text,
         lineStart,
@@ -1634,8 +1689,7 @@ function referenceTitleEnd(
       while (text[significant] === " " || text[significant] === "\t") {
         significant++;
       }
-      const contentEnd = text[lineEnd - 1] === "\r" ? lineEnd - 1 : lineEnd;
-      if (significant >= contentEnd) return undefined;
+      if (significant >= lineEnd) return undefined;
       cursor = contentStart;
       continue;
     }
@@ -1663,11 +1717,9 @@ function referenceDefinitionTailEnd(
   }
 
   const destinationLineEnd = cursor;
-  if (text[cursor] === "\r") cursor++;
-  if (text[cursor] !== "\n") return destinationLineEnd;
-  const titleLineStart = cursor + 1;
-  const next = text.indexOf("\n", titleLineStart);
-  const titleLineEnd = next === -1 ? text.length : next;
+  const titleLineStart = lineEndingEnd(text, cursor);
+  if (titleLineStart === undefined) return destinationLineEnd;
+  const titleLineEnd = nextLineEndingStart(text, titleLineStart) ?? text.length;
   const contentStart = blockContainerContentStart(
     text,
     titleLineStart,
@@ -1881,6 +1933,8 @@ function afterInlineLink(text: string, start: number): number | undefined {
 interface ReferenceUsage {
   readonly label: string;
   readonly range: Range;
+  readonly image: boolean;
+  readonly description: Range;
 }
 
 function usedReferences(
@@ -1897,6 +1951,7 @@ function usedReferences(
       text[start + 1] === "^"
     ) continue;
     const linkStart = start;
+    const image = isImageLabel(text, start);
     const afterText = afterMarkdownLabel(text, start);
     if (afterText === undefined) continue;
     if (
@@ -1923,6 +1978,8 @@ function usedReferences(
     usages.push({
       label: normalized,
       range: { start: linkStart, end: start + 1 },
+      image,
+      description: { start: linkStart + 1, end: afterText - 1 },
     });
   }
   return { labels, usages };
@@ -2323,9 +2380,25 @@ export function scanDestinations(
     }
   }
 
+  const referenceUse = usedReferences(
+    text,
+    mergeRanges([
+      ...markdownIgnoredRanges,
+      ...markdownImageLabelRanges,
+      ...markdownLinkTailRanges,
+    ]),
+    new Set(references.map((reference) => reference.labelStart)),
+  );
+  markdownImageLabelRanges.push(
+    ...referenceUse.usages
+      .filter((usage) => usage.image && definedLabels.has(usage.label))
+      .map((usage) => usage.description),
+  );
+
   for (const tagRange of tagRanges) {
     if (
       isInsideRange(referenceDefinitionRanges, tagRange.start) ||
+      isInsideRange(markdownImageLabelRanges, tagRange.start) ||
       isInsideRange(rawHtmlBlocks.rawText, tagRange.start)
     ) continue;
     const tag = text.slice(tagRange.start, tagRange.end);
@@ -2377,15 +2450,6 @@ export function scanDestinations(
     }
   }
 
-  const referenceUse = usedReferences(
-    text,
-    mergeRanges([
-      ...markdownIgnoredRanges,
-      ...markdownImageLabelRanges,
-      ...markdownLinkTailRanges,
-    ]),
-    new Set(references.map((reference) => reference.labelStart)),
-  );
   const recordedReferenceLabels = new Set<string>();
   for (const reference of references) {
     destinationOffsets.add(reference.offset);
@@ -2567,7 +2631,7 @@ function canonicalizeHttpUrls(text: string): string {
     const candidate = rawUrl.slice(0, rawUrl.length - suffix.length);
     try {
       const url = new URL(candidate);
-      const pathname = decodeURIComponent(url.pathname);
+      const pathname = decodeUrlComponentTolerantly(url.pathname);
       return `${url.protocol}//${url.host}${pathname}${url.search}${url.hash}${suffix}`;
     } catch {
       return rawUrl;

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -2670,18 +2670,24 @@ function htmlTagRanges(
 ): Range[] {
   const ranges: Range[] = [];
   const jsxScanCache: JavaScriptJsxScanCache = new Map();
+  const containingTagEnds: number[] = [];
   let expressionIndex = 0;
   for (let start = 0; start < text.length;) {
     start = text.indexOf("<", start);
     if (start === -1) break;
     while (
+      containingTagEnds.length > 0 && containingTagEnds.at(-1)! <= start
+    ) containingTagEnds.pop();
+    while (
       expressionIndex < expressionRanges.length &&
       expressionRanges[expressionIndex]!.start <= start
     ) expressionIndex++;
+    const insideExpression = isInsideRange(expressionRanges, start);
     if (
+      (containingTagEnds.length > 0 && !insideExpression) ||
       isInsideRange(stringRanges, start) ||
       (isInsideRange(ignoredRanges, start) &&
-        !isInsideRange(expressionRanges, start)) ||
+        !insideExpression) ||
       isBackslashEscaped(text, start) ||
       !/[A-Za-z]/.test(text[start + 1] ?? "") ||
       /^[A-Za-z][A-Za-z0-9+.-]{1,31}:/.test(text.slice(start + 1))
@@ -2701,7 +2707,10 @@ function htmlTagRanges(
       ranges.push({ start, end: tagEnd });
       const containsExpression =
         (expressionRanges[expressionIndex]?.start ?? tagEnd) < tagEnd;
-      start = containsExpression ? start + 1 : tagEnd;
+      if (containsExpression) {
+        containingTagEnds.push(tagEnd);
+        start = expressionRanges[expressionIndex]!.start;
+      } else start = tagEnd;
     } else start++;
   }
   return ranges;

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -1128,6 +1128,7 @@ function javaScriptRegexMayStart(
   ) return false;
   const end = previousSignificantToken.end;
 
+  if (text.slice(end - 3, end) === "...") return true;
   if ("=(:,![{;?&|+*%/^~<>-".includes(text[end - 1]!)) return true;
 
   let wordStart = end;

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -771,9 +771,15 @@ interface MdxSyntaxRanges {
   readonly strings: Range[];
 }
 
+type JavaScriptSignificantTokenKind =
+  | "other"
+  | "postfix-update"
+  | "prefix-update"
+  | "regex";
+
 interface JavaScriptSignificantToken {
   readonly end: number;
-  readonly kind: "other" | "regex";
+  readonly kind: JavaScriptSignificantTokenKind;
 }
 
 type JavaScriptQuote = '"' | "'";
@@ -781,7 +787,7 @@ type JavaScriptStringDelimiter = JavaScriptQuote | "`";
 
 interface JavaScriptScannedToken {
   readonly end: number;
-  readonly kind: "literal" | "other" | "regex" | "trivia";
+  readonly kind: JavaScriptSignificantTokenKind | "literal" | "trivia";
   readonly string?: Range;
 }
 
@@ -840,7 +846,7 @@ function javaScriptTemplateInterpolationEnd(
     }
     previousSignificantToken = {
       end: token.end,
-      kind: token.kind === "regex" ? "regex" : "other",
+      kind: token.kind === "literal" ? "other" : token.kind,
     };
     if (token.kind !== "other") {
       cursor = token.end;
@@ -939,7 +945,7 @@ function mdxExpressionAt(
     }
     previousSignificantToken = {
       end: token.end,
-      kind: token.kind === "regex" ? "regex" : "other",
+      kind: token.kind === "literal" ? "other" : token.kind,
     };
     if (token.kind !== "other") {
       cursor = token.end;
@@ -1078,12 +1084,13 @@ function javaScriptRegexMayStart(
   previousSignificantToken: JavaScriptSignificantToken | undefined,
 ): boolean {
   if (previousSignificantToken === undefined) return true;
-  if (previousSignificantToken.kind === "regex") return false;
+  if (previousSignificantToken.kind === "prefix-update") return true;
+  if (
+    previousSignificantToken.kind === "postfix-update" ||
+    previousSignificantToken.kind === "regex"
+  ) return false;
   const end = previousSignificantToken.end;
 
-  if (text.slice(end - 2, end) === "++" || text.slice(end - 2, end) === "--") {
-    return false;
-  }
   if ("=(:,![{;?&|+*%/^~<>-".includes(text[end - 1]!)) return true;
 
   let wordStart = end;
@@ -1093,6 +1100,25 @@ function javaScriptRegexMayStart(
 
   return wordStart === 0 ||
     !/[A-Za-z0-9_$.#]/.test(text[wordStart - 1]!);
+}
+
+function javaScriptUpdateKind(
+  text: string,
+  start: number,
+  previousSignificantToken: JavaScriptSignificantToken | undefined,
+): "postfix-update" | "prefix-update" | undefined {
+  const operator = text[start];
+  if ((operator !== "+" && operator !== "-") || text[start + 1] !== operator) {
+    return undefined;
+  }
+  if (
+    previousSignificantToken === undefined ||
+    /[\n\r\u2028\u2029]/.test(
+      text.slice(previousSignificantToken.end, start),
+    ) ||
+    javaScriptRegexMayStart(text, previousSignificantToken)
+  ) return "prefix-update";
+  return "postfix-update";
 }
 
 function javaScriptTokenAt(
@@ -1122,6 +1148,13 @@ function javaScriptTokenAt(
     const end = javaScriptRegexEnd(text, start);
     if (end !== undefined) return { end, kind: "regex" };
   }
+
+  const updateKind = javaScriptUpdateKind(
+    text,
+    start,
+    previousSignificantToken,
+  );
+  if (updateKind !== undefined) return { end: start + 2, kind: updateKind };
 
   return { end: start + 1, kind: "other" };
 }
@@ -1185,6 +1218,16 @@ function javaScriptLineTokenEnd(
   if (character === '"' || character === "'") {
     state.quote = character;
     return start + 1;
+  }
+  const updateKind = javaScriptUpdateKind(
+    text,
+    start,
+    state.previousSignificantToken,
+  );
+  if (updateKind !== undefined) {
+    const end = start + 2;
+    state.previousSignificantToken = { end, kind: updateKind };
+    return end;
   }
   if (
     character !== "/" ||
@@ -1513,6 +1556,14 @@ function scanTagSyntax(
       : undefined;
     if (commentEnd !== undefined) {
       cursor = commentEnd;
+      continue;
+    }
+    const updateKind = expressionDepth > 0
+      ? javaScriptUpdateKind(text, cursor, previousSignificantToken)
+      : undefined;
+    if (updateKind !== undefined) {
+      cursor += 2;
+      previousSignificantToken = { end: cursor, kind: updateKind };
       continue;
     }
     if (

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -778,16 +778,31 @@ interface MdxSyntaxRanges {
 // both the regex and division forms when adding a new grammar context.
 type JavaScriptSignificantTokenKind =
   | "control-header"
+  | "declaration-header"
   | "other"
   | "postfix-update"
   | "prefix-update"
-  | "regex";
+  | "regex"
+  | "statement-block";
 
-type JavaScriptPrecedingIdentifierKeyword = "break" | "continue" | "for";
-type JavaScriptDelimiterContext = "control" | "for" | "nested" | undefined;
+type JavaScriptPrecedingIdentifierKeyword =
+  | "break"
+  | "continue"
+  | "export"
+  | "for";
+type JavaScriptDelimiterContext =
+  | "block"
+  | "control"
+  | "for"
+  | "function-declaration"
+  | "nested"
+  | undefined;
 
 interface JavaScriptSignificantToken {
   readonly end: number;
+  readonly functionDeclaration?: true;
+  readonly functionDeclarationCandidate?: true;
+  readonly functionDeclarationPrefix?: true;
   readonly identifier?: true;
   readonly kind: JavaScriptSignificantTokenKind;
   readonly followsForOfLeftOperand?: true;
@@ -811,7 +826,16 @@ function javaScriptTokenWithIdentifierContext(
   previousSignificantToken: JavaScriptSignificantToken | undefined,
   delimiterContexts: readonly JavaScriptDelimiterContext[],
 ): JavaScriptSignificantToken {
-  if (!javaScriptIdentifierCodeUnitAt(text, start)) return { end, kind };
+  if (!javaScriptIdentifierCodeUnitAt(text, start)) {
+    return {
+      end,
+      ...(text[start] === "*" &&
+          previousSignificantToken?.functionDeclaration === true
+        ? { functionDeclaration: true }
+        : {}),
+      kind,
+    };
+  }
 
   const escapeRange = javaScriptIdentifierEscapeRangeAt(text, start);
   const codePoint = text.codePointAt(start);
@@ -823,6 +847,25 @@ function javaScriptTokenWithIdentifierContext(
   const identifier = continuesIdentifierWord
     ? previousSignificantToken?.identifier === true
     : javaScriptIdentifierStartsAt(text, start);
+  const functionDeclarationCandidate = continuesIdentifierWord
+    ? previousSignificantToken?.functionDeclarationCandidate === true
+    : javaScriptMayStartFunctionDeclaration(
+      text,
+      previousSignificantToken,
+      delimiterContexts,
+    );
+  const word = javaScriptIdentifierWordAtEnd(text, end);
+  const completeIdentifier = word !== undefined &&
+    !javaScriptIdentifierCodeUnitAt(text, end);
+  const functionDeclarationPrefix = completeIdentifier &&
+    ((word === "export" || word === "async") &&
+        functionDeclarationCandidate ||
+      word === "default" &&
+        previousSignificantToken?.functionDeclarationPrefix === true);
+  const functionDeclaration =
+    previousSignificantToken?.functionDeclaration === true ||
+    (completeIdentifier && word === "function" &&
+      functionDeclarationCandidate);
   let precedingIdentifierKeyword:
     | JavaScriptPrecedingIdentifierKeyword
     | undefined;
@@ -839,7 +882,7 @@ function javaScriptTokenWithIdentifierContext(
     );
     if (
       previousWord === "break" || previousWord === "continue" ||
-      previousWord === "for"
+      previousWord === "export" || previousWord === "for"
     ) precedingIdentifierKeyword = previousWord;
     followsForOfLeftOperand = delimiterContexts.at(-1) === "for" &&
       javaScriptTokenMayEndForOfLeftOperand(text, previousSignificantToken);
@@ -847,6 +890,11 @@ function javaScriptTokenWithIdentifierContext(
 
   return {
     end,
+    ...(functionDeclaration ? { functionDeclaration: true } : {}),
+    ...(functionDeclarationCandidate && !completeIdentifier
+      ? { functionDeclarationCandidate: true }
+      : {}),
+    ...(functionDeclarationPrefix ? { functionDeclarationPrefix: true } : {}),
     ...(identifier ? { identifier: true } : {}),
     kind,
     ...(followsForOfLeftOperand ? { followsForOfLeftOperand: true } : {}),
@@ -927,7 +975,7 @@ function javaScriptTemplateInterpolationEnd(
 ): number | undefined {
   let depth = 1;
   let cursor = start + 2;
-  const delimiterContexts: JavaScriptDelimiterContext[] = [];
+  const delimiterContexts: JavaScriptDelimiterContext[] = ["nested"];
   let previousSignificantToken: JavaScriptSignificantToken | undefined;
   while (cursor < text.length) {
     const token = javaScriptTokenAt(
@@ -1036,7 +1084,7 @@ function mdxExpressionAt(
   const strings: Range[] = [];
   let depth = 1;
   let cursor = start + 1;
-  const delimiterContexts: JavaScriptDelimiterContext[] = [];
+  const delimiterContexts: JavaScriptDelimiterContext[] = ["nested"];
   let previousSignificantToken: JavaScriptSignificantToken | undefined;
   while (cursor < text.length) {
     const token = javaScriptTokenAt(
@@ -1203,10 +1251,19 @@ const JAVASCRIPT_REGEX_PREFIX_KEYWORDS: ReadonlySet<string> = new Set([
 ]);
 
 const JAVASCRIPT_CONTROL_HEADER_KEYWORDS: ReadonlySet<string> = new Set([
+  "catch",
   "for",
   "if",
+  "switch",
   "while",
   "with",
+]);
+
+const JAVASCRIPT_BLOCK_PREFIX_KEYWORDS: ReadonlySet<string> = new Set([
+  "do",
+  "else",
+  "finally",
+  "try",
 ]);
 
 const JAVASCRIPT_IDENTIFIER_START = /[$_\p{ID_Start}]/u;
@@ -1322,6 +1379,25 @@ function javaScriptIdentifierWordAtEnd(
   return text.slice(start, end);
 }
 
+function javaScriptMayStartFunctionDeclaration(
+  text: string,
+  token: JavaScriptSignificantToken | undefined,
+  delimiterContexts: readonly JavaScriptDelimiterContext[],
+): boolean {
+  if (
+    delimiterContexts.length > 0 && delimiterContexts.at(-1) !== "block"
+  ) return false;
+  if (token === undefined) return true;
+  if (token.functionDeclarationPrefix === true) return true;
+  const word = javaScriptIdentifierWordAtEnd(text, token.end);
+  if (word === "export") return true;
+  if (
+    (word === "default" || word === "async") &&
+    token.precedingIdentifierKeyword === "export"
+  ) return true;
+  return ";{}".includes(text[token.end - 1]!);
+}
+
 function javaScriptLineTerminatesRestrictedStatement(
   text: string,
   token: JavaScriptSignificantToken | undefined,
@@ -1375,7 +1451,9 @@ function javaScriptDelimiterTokenKind(
       ? undefined
       : javaScriptIdentifierWordAtEnd(text, previousSignificantToken.end);
     let context: JavaScriptDelimiterContext;
-    if (
+    if (previousSignificantToken?.functionDeclaration === true) {
+      context = "function-declaration";
+    } else if (
       keyword === "for" ||
       (keyword === "await" &&
         previousSignificantToken?.precedingIdentifierKeyword === "for")
@@ -1387,11 +1465,23 @@ function javaScriptDelimiterTokenKind(
       context = "control";
     }
     delimiterContexts.push(context);
-  } else if (character === "[" || character === "{") {
+  } else if (character === "[") {
     delimiterContexts.push("nested");
+  } else if (character === "{") {
+    const keyword = previousSignificantToken === undefined
+      ? undefined
+      : javaScriptIdentifierWordAtEnd(text, previousSignificantToken.end);
+    const statementBlock =
+      previousSignificantToken?.kind === "control-header" ||
+      previousSignificantToken?.kind === "declaration-header" ||
+      (keyword !== undefined &&
+        JAVASCRIPT_BLOCK_PREFIX_KEYWORDS.has(keyword));
+    delimiterContexts.push(statementBlock ? "block" : "nested");
   } else if (character === ")" || character === "]" || character === "}") {
     const context = delimiterContexts.pop();
     if (context === "control" || context === "for") return "control-header";
+    if (context === "function-declaration") return "declaration-header";
+    if (context === "block") return "statement-block";
   }
   return "other";
 }
@@ -1404,6 +1494,7 @@ function javaScriptRegexMayStart(
   if (previousSignificantToken === undefined) return true;
   if (
     previousSignificantToken.kind === "control-header" ||
+    previousSignificantToken.kind === "statement-block" ||
     previousSignificantToken.kind === "prefix-update"
   ) return true;
   if (
@@ -2003,6 +2094,7 @@ function scanTagSyntax(
       );
     } else if (character === "{") {
       previousSignificantToken = { end: cursor + 1, kind: "other" };
+      delimiterContexts.push("nested");
     }
     if (character === '"' || character === "'") {
       quote = character;

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -2183,6 +2183,7 @@ function followsCompletedHtmlBlock(
 
 interface TagSyntaxScan {
   readonly end: number | undefined;
+  readonly expressionRanges: Range[];
   readonly topLevelOffsets: ReadonlySet<number>;
 }
 
@@ -2428,7 +2429,9 @@ function scanTagSyntax(
   text: string,
   start: number,
 ): TagSyntaxScan {
+  const expressionRanges: Range[] = [];
   const topLevelOffsets = new Set<number>();
+  let expressionStart: number | undefined;
   let quote: JavaScriptQuote | undefined;
   let quoteUsesJavaScriptEscapes = false;
   let expressionDepth = 0;
@@ -2479,7 +2482,7 @@ function scanTagSyntax(
     ) {
       const jsxElementEnd = javaScriptJsxElementEnd(text, cursor);
       if (jsxElementEnd === undefined) {
-        return { end: undefined, topLevelOffsets };
+        return { end: undefined, expressionRanges, topLevelOffsets };
       }
       previousSignificantToken = javaScriptTokenWithPersistentContext(
         jsxElementEnd,
@@ -2528,7 +2531,7 @@ function scanTagSyntax(
     if (expressionDepth === 0) {
       topLevelOffsets.add(cursor);
       if (character === ">") {
-        return { end: cursor + 1, topLevelOffsets };
+        return { end: cursor + 1, expressionRanges, topLevelOffsets };
       }
     }
     if (character === "`" && expressionDepth > 0) {
@@ -2569,6 +2572,7 @@ function scanTagSyntax(
         delimiterContexts,
       );
     } else if (character === "{") {
+      expressionStart = cursor;
       previousSignificantToken = { end: cursor + 1, kind: "other" };
       delimiterContexts.push("nested");
     }
@@ -2576,10 +2580,16 @@ function scanTagSyntax(
       quote = character;
       quoteUsesJavaScriptEscapes = expressionDepth > 0;
     } else if (character === "{") expressionDepth++;
-    else if (character === "}" && expressionDepth > 0) expressionDepth--;
+    else if (character === "}" && expressionDepth > 0) {
+      expressionDepth--;
+      if (expressionDepth === 0 && expressionStart !== undefined) {
+        expressionRanges.push({ start: expressionStart, end: cursor + 1 });
+        expressionStart = undefined;
+      }
+    }
     cursor++;
   }
-  return { end: undefined, topLevelOffsets };
+  return { end: undefined, expressionRanges, topLevelOffsets };
 }
 
 function commonMarkHtmlTagEnd(text: string, start: number): number | undefined {
@@ -2670,21 +2680,28 @@ function htmlTagRanges(
 ): Range[] {
   const ranges: Range[] = [];
   const jsxScanCache: JavaScriptJsxScanCache = new Map();
-  const containingTagEnds: number[] = [];
+  const containingTags: Array<{
+    readonly end: number;
+    readonly expressionRanges: Range[];
+  }> = [];
   let expressionIndex = 0;
   for (let start = 0; start < text.length;) {
     start = text.indexOf("<", start);
     if (start === -1) break;
     while (
-      containingTagEnds.length > 0 && containingTagEnds.at(-1)! <= start
-    ) containingTagEnds.pop();
+      containingTags.length > 0 && containingTags.at(-1)!.end <= start
+    ) containingTags.pop();
     while (
       expressionIndex < expressionRanges.length &&
       expressionRanges[expressionIndex]!.start <= start
     ) expressionIndex++;
     const insideExpression = isInsideRange(expressionRanges, start);
+    const insideContainingTagExpression = containingTags.some((tag) =>
+      isInsideRange(tag.expressionRanges, start)
+    );
     if (
-      (containingTagEnds.length > 0 && !insideExpression) ||
+      (containingTags.length > 0 && !insideExpression &&
+        !insideContainingTagExpression) ||
       isInsideRange(stringRanges, start) ||
       (isInsideRange(ignoredRanges, start) &&
         !insideExpression) ||
@@ -2697,6 +2714,7 @@ function htmlTagRanges(
     }
 
     const commonMarkEnd = commonMarkHtmlTagEnd(text, start);
+    const tagSyntax = scanTagSyntax(text, start);
     const mdxJsxEnd = mdxJsxTagEnd(text, start, jsxScanCache);
     const tagEnd = commonMarkEnd === undefined
       ? mdxJsxEnd
@@ -2705,11 +2723,15 @@ function htmlTagRanges(
       : Math.max(commonMarkEnd, mdxJsxEnd);
     if (tagEnd !== undefined) {
       ranges.push({ start, end: tagEnd });
-      const containsExpression =
-        (expressionRanges[expressionIndex]?.start ?? tagEnd) < tagEnd;
-      if (containsExpression) {
-        containingTagEnds.push(tagEnd);
-        start = expressionRanges[expressionIndex]!.start;
+      const rescanExpression = tagSyntax.end === tagEnd
+        ? tagSyntax.expressionRanges[0]
+        : undefined;
+      if (rescanExpression !== undefined) {
+        containingTags.push({
+          end: tagEnd,
+          expressionRanges: tagSyntax.expressionRanges,
+        });
+        start = rescanExpression.start;
       } else start = tagEnd;
     } else start++;
   }

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -788,6 +788,7 @@ type JavaScriptDelimiterContext = "control" | "for" | "nested" | undefined;
 
 interface JavaScriptSignificantToken {
   readonly end: number;
+  readonly identifier?: true;
   readonly kind: JavaScriptSignificantTokenKind;
   readonly followsForOfLeftOperand?: true;
   readonly precedingIdentifierKeyword?: JavaScriptPrecedingIdentifierKeyword;
@@ -819,6 +820,9 @@ function javaScriptTokenWithIdentifierContext(
       (escapeRange !== undefined && escapeRange.start < start) ||
       (codeUnit >= 0xdc00 && codeUnit <= 0xdfff &&
         javaScriptIdentifierContinueBefore(text, start + 1)));
+  const identifier = continuesIdentifierWord
+    ? previousSignificantToken?.identifier === true
+    : javaScriptIdentifierStartsAt(text, start);
   let precedingIdentifierKeyword:
     | JavaScriptPrecedingIdentifierKeyword
     | undefined;
@@ -843,6 +847,7 @@ function javaScriptTokenWithIdentifierContext(
 
   return {
     end,
+    ...(identifier ? { identifier: true } : {}),
     kind,
     ...(followsForOfLeftOperand ? { followsForOfLeftOperand: true } : {}),
     ...(precedingIdentifierKeyword === undefined
@@ -1204,6 +1209,7 @@ const JAVASCRIPT_CONTROL_HEADER_KEYWORDS: ReadonlySet<string> = new Set([
   "with",
 ]);
 
+const JAVASCRIPT_IDENTIFIER_START = /[$_\p{ID_Start}]/u;
 const JAVASCRIPT_IDENTIFIER_CONTINUE = /[$_\u200C\u200D\p{ID_Continue}]/u;
 const JAVASCRIPT_IDENTIFIER_ESCAPE =
   /\\u(?:([0-9A-Fa-f]{4})|\{([0-9A-Fa-f]{1,6})\})$/;
@@ -1243,6 +1249,28 @@ function javaScriptIdentifierCodeUnitAt(
   return (codeUnit >= 0xdc00 && codeUnit <= 0xdfff &&
     javaScriptIdentifierContinueBefore(text, offset + 1)) ||
     javaScriptIdentifierEscapeRangeAt(text, offset) !== undefined;
+}
+
+function javaScriptIdentifierStartsAt(
+  text: string,
+  offset: number,
+): boolean {
+  const codePoint = text.codePointAt(offset);
+  if (
+    codePoint !== undefined &&
+    JAVASCRIPT_IDENTIFIER_START.test(String.fromCodePoint(codePoint))
+  ) return true;
+
+  const escapeRange = javaScriptIdentifierEscapeRangeAt(text, offset);
+  if (escapeRange?.start !== offset) return false;
+  const match = JAVASCRIPT_IDENTIFIER_ESCAPE_PREFIX.exec(
+    text.slice(offset, escapeRange.end),
+  );
+  if (match === null) return false;
+  const escapedCodePoint = Number.parseInt(match[1] ?? match[2] ?? "", 16);
+  return JAVASCRIPT_IDENTIFIER_START.test(
+    String.fromCodePoint(escapedCodePoint),
+  );
 }
 
 function javaScriptCodePointBefore(
@@ -1326,7 +1354,8 @@ function javaScriptTokenMayEndForOfLeftOperand(
   token: JavaScriptSignificantToken,
 ): boolean {
   const word = javaScriptIdentifierWordAtEnd(text, token.end);
-  if (word !== undefined) {
+  if (token.identifier === true) {
+    if (word === undefined) return true;
     return !JAVASCRIPT_REGEX_PREFIX_KEYWORDS.has(word) &&
       !JAVASCRIPT_CONTROL_HEADER_KEYWORDS.has(word) &&
       word !== "break" && word !== "continue" && word !== "debugger" &&

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -776,6 +776,9 @@ interface JavaScriptSignificantToken {
   readonly kind: "other" | "regex";
 }
 
+type JavaScriptQuote = '"' | "'";
+type JavaScriptStringDelimiter = JavaScriptQuote | "`";
+
 interface JavaScriptScannedToken {
   readonly end: number;
   readonly kind: "literal" | "other" | "regex" | "trivia";
@@ -785,7 +788,7 @@ interface JavaScriptScannedToken {
 function quotedRangeEnd(
   text: string,
   start: number,
-  quote: '"' | "'" | "`",
+  quote: JavaScriptStringDelimiter,
 ): number | undefined {
   if (quote === "`") return javaScriptTemplateEnd(text, start);
   for (let cursor = start + 1; cursor < text.length; cursor++) {
@@ -1028,7 +1031,7 @@ function mdxEsmMayStart(text: string, lineStart: number): boolean {
 
 interface JavaScriptBalance {
   readonly delimiters: string[];
-  quote: '"' | "'" | undefined;
+  quote: JavaScriptQuote | undefined;
   blockComment: boolean;
   templateEnd: number;
   previousSignificantToken: JavaScriptSignificantToken | undefined;
@@ -1123,83 +1126,130 @@ function javaScriptTokenAt(
   return { end: start + 1, kind: "other" };
 }
 
+function javaScriptLineCommentEnd(
+  text: string,
+  start: number,
+  lineEnd: number,
+  state: JavaScriptBalance,
+): number | undefined {
+  if (state.blockComment) {
+    let closing: number | undefined;
+    for (let cursor = start; cursor + 1 < lineEnd; cursor++) {
+      if (text.startsWith("*/", cursor)) {
+        closing = cursor + 2;
+        break;
+      }
+    }
+    if (closing === undefined) return lineEnd;
+    state.blockComment = false;
+    return closing;
+  }
+  if (state.quote !== undefined) return undefined;
+  if (text.startsWith("//", start)) return lineEnd;
+  if (!text.startsWith("/*", start)) return undefined;
+  state.blockComment = true;
+  return start + 2;
+}
+
+function javaScriptLineQuoteEnd(
+  text: string,
+  start: number,
+  state: JavaScriptBalance,
+): number | undefined {
+  if (state.quote === undefined) return undefined;
+  const character = text[start]!;
+  if (character === "\\") return start + 2;
+  if (character === state.quote) {
+    state.quote = undefined;
+    state.previousSignificantToken = { end: start + 1, kind: "other" };
+  }
+  return start + 1;
+}
+
+function javaScriptLineTokenEnd(
+  text: string,
+  start: number,
+  lineEnd: number,
+  state: JavaScriptBalance,
+): number | undefined {
+  const character = text[start]!;
+  if (character === "`") {
+    const end = javaScriptTemplateEnd(text, start);
+    if (end === undefined) state.valid = false;
+    else {
+      state.previousSignificantToken = { end, kind: "other" };
+      state.templateEnd = end;
+    }
+    return end ?? lineEnd;
+  }
+  if (character === '"' || character === "'") {
+    state.quote = character;
+    return start + 1;
+  }
+  if (
+    character !== "/" ||
+    !javaScriptRegexMayStart(text, state.previousSignificantToken)
+  ) return undefined;
+
+  const end = javaScriptRegexEnd(text, start);
+  if (end === undefined) return undefined;
+  state.previousSignificantToken = { end, kind: "regex" };
+  return end;
+}
+
+const JAVASCRIPT_DELIMITER_CLOSERS: Readonly<Record<string, string>> = {
+  ")": "(",
+  "]": "[",
+  "}": "{",
+};
+
+function recordJavaScriptDelimiter(
+  character: string,
+  state: JavaScriptBalance,
+): void {
+  if (character === "(" || character === "[" || character === "{") {
+    state.delimiters.push(character);
+    return;
+  }
+  const opener = JAVASCRIPT_DELIMITER_CLOSERS[character];
+  if (opener === undefined) return;
+  if (state.delimiters.at(-1) !== opener) {
+    state.valid = false;
+    return;
+  }
+  state.delimiters.pop();
+}
+
 function scanJavaScriptLine(
   text: string,
   lineStart: number,
   lineEnd: number,
   state: JavaScriptBalance,
 ): void {
-  const closers: Readonly<Record<string, string>> = {
-    ")": "(",
-    "]": "[",
-    "}": "{",
-  };
-  for (
-    let cursor = Math.max(lineStart, state.templateEnd);
-    cursor < lineEnd;
-    cursor++
-  ) {
+  let cursor = Math.max(lineStart, state.templateEnd);
+  while (cursor < lineEnd) {
+    const commentEnd = javaScriptLineCommentEnd(text, cursor, lineEnd, state);
+    if (commentEnd !== undefined) {
+      cursor = commentEnd;
+      continue;
+    }
+    const quoteEnd = javaScriptLineQuoteEnd(text, cursor, state);
+    if (quoteEnd !== undefined) {
+      cursor = quoteEnd;
+      continue;
+    }
+    const tokenEnd = javaScriptLineTokenEnd(text, cursor, lineEnd, state);
+    if (tokenEnd !== undefined) {
+      cursor = tokenEnd;
+      continue;
+    }
     const character = text[cursor]!;
-    if (state.blockComment) {
-      if (text.startsWith("*/", cursor)) {
-        state.blockComment = false;
-        cursor++;
-      }
-      continue;
+    if (!/\s/.test(character)) {
+      state.previousSignificantToken = { end: cursor + 1, kind: "other" };
+      recordJavaScriptDelimiter(character, state);
+      if (!state.valid) return;
     }
-    if (state.quote !== undefined) {
-      if (character === "\\") cursor++;
-      else if (character === state.quote) {
-        state.quote = undefined;
-        state.previousSignificantToken = { end: cursor + 1, kind: "other" };
-      }
-      continue;
-    }
-    if (text.startsWith("//", cursor)) break;
-    if (text.startsWith("/*", cursor)) {
-      state.blockComment = true;
-      cursor++;
-      continue;
-    }
-    if (character === "`") {
-      const templateEnd = javaScriptTemplateEnd(text, cursor);
-      if (templateEnd === undefined) {
-        state.valid = false;
-        return;
-      }
-      state.previousSignificantToken = { end: templateEnd, kind: "other" };
-      state.templateEnd = templateEnd;
-      cursor = templateEnd - 1;
-      continue;
-    }
-    if (character === '"' || character === "'") {
-      state.quote = character;
-      continue;
-    }
-    if (
-      character === "/" &&
-      javaScriptRegexMayStart(text, state.previousSignificantToken)
-    ) {
-      const regexEnd = javaScriptRegexEnd(text, cursor);
-      if (regexEnd !== undefined) {
-        state.previousSignificantToken = { end: regexEnd, kind: "regex" };
-        cursor = regexEnd - 1;
-        continue;
-      }
-    }
-    if (/\s/.test(character)) continue;
-    state.previousSignificantToken = { end: cursor + 1, kind: "other" };
-    if (character === "(" || character === "[" || character === "{") {
-      state.delimiters.push(character);
-      continue;
-    }
-    const opener = closers[character];
-    if (opener === undefined) continue;
-    if (state.delimiters.at(-1) !== opener) {
-      state.valid = false;
-      return;
-    }
-    state.delimiters.pop();
+    cursor++;
   }
 }
 
@@ -1437,20 +1487,24 @@ function scanTagSyntax(
   start: number,
 ): TagSyntaxScan {
   const topLevelOffsets = new Set<number>();
-  let quote: '"' | "'" | undefined;
+  let quote: JavaScriptQuote | undefined;
   let quoteUsesJavaScriptEscapes = false;
   let expressionDepth = 0;
   let previousSignificantToken: JavaScriptSignificantToken | undefined;
-  for (let cursor = start; cursor < text.length; cursor++) {
+  let cursor = start;
+  while (cursor < text.length) {
     const character = text[cursor]!;
     if (quote !== undefined) {
-      if (quoteUsesJavaScriptEscapes && character === "\\") cursor++;
+      if (quoteUsesJavaScriptEscapes && character === "\\") cursor += 2;
       else if (character === quote) {
         quote = undefined;
         if (expressionDepth > 0) {
           previousSignificantToken = { end: cursor + 1, kind: "other" };
         }
         quoteUsesJavaScriptEscapes = false;
+        cursor++;
+      } else {
+        cursor++;
       }
       continue;
     }
@@ -1458,7 +1512,7 @@ function scanTagSyntax(
       ? javaScriptCommentEnd(text, cursor)
       : undefined;
     if (commentEnd !== undefined) {
-      cursor = commentEnd - 1;
+      cursor = commentEnd;
       continue;
     }
     if (
@@ -1468,7 +1522,7 @@ function scanTagSyntax(
       const regexEnd = javaScriptRegexEnd(text, cursor);
       if (regexEnd !== undefined) {
         previousSignificantToken = { end: regexEnd, kind: "regex" };
-        cursor = regexEnd - 1;
+        cursor = regexEnd;
         continue;
       }
     }
@@ -1482,11 +1536,14 @@ function scanTagSyntax(
       const templateEnd = javaScriptTemplateEnd(text, cursor);
       if (templateEnd !== undefined) {
         previousSignificantToken = { end: templateEnd, kind: "other" };
-        cursor = templateEnd - 1;
+        cursor = templateEnd;
         continue;
       }
     }
-    if (expressionDepth > 0 && /\s/.test(character)) continue;
+    if (expressionDepth > 0 && /\s/.test(character)) {
+      cursor++;
+      continue;
+    }
     if (expressionDepth > 0 || character === "{") {
       previousSignificantToken = { end: cursor + 1, kind: "other" };
     }
@@ -1495,6 +1552,7 @@ function scanTagSyntax(
       quoteUsesJavaScriptEscapes = expressionDepth > 0;
     } else if (character === "{") expressionDepth++;
     else if (character === "}" && expressionDepth > 0) expressionDepth--;
+    cursor++;
   }
   return { end: undefined, topLevelOffsets };
 }

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -782,6 +782,7 @@ type JavaScriptSignificantTokenKind =
   | "declaration-header"
   | "expression-header"
   | "other"
+  | "operand"
   | "postfix-update"
   | "prefix-update"
   | "regex"
@@ -817,6 +818,7 @@ interface JavaScriptSignificantToken {
   readonly kind: JavaScriptSignificantTokenKind;
   readonly followsForOfLeftOperand?: true;
   readonly precedingIdentifierKeyword?: JavaScriptPrecedingIdentifierKeyword;
+  readonly uninitializedDeclaration?: "let" | "var";
 }
 
 type JavaScriptQuote = '"' | "'";
@@ -838,6 +840,10 @@ function javaScriptTokenWithIdentifierContext(
 ): JavaScriptSignificantToken {
   if (!javaScriptIdentifierCodeUnitAt(text, start)) {
     return {
+      ...(text[start] !== "{" &&
+          previousSignificantToken?.classDeclaration === true
+        ? { classDeclaration: true }
+        : {}),
       end,
       ...(text[start] === "*" &&
           previousSignificantToken?.functionDeclaration === true
@@ -848,6 +854,13 @@ function javaScriptTokenWithIdentifierContext(
         ? { functionHeader: true }
         : {}),
       kind,
+      ...(text[start] === "," &&
+          previousSignificantToken?.uninitializedDeclaration !== undefined
+        ? {
+          uninitializedDeclaration:
+            previousSignificantToken.uninitializedDeclaration,
+        }
+        : {}),
     };
   }
 
@@ -894,6 +907,13 @@ function javaScriptTokenWithIdentifierContext(
   const classDeclaration =
     previousSignificantToken?.classDeclaration === true ||
     (identifierKeyword === "class" && declarationCandidate);
+  const uninitializedDeclaration =
+    previousSignificantToken?.uninitializedDeclaration ??
+      (previousSignificantToken?.identifierKeyword === "let"
+        ? "let"
+        : previousSignificantToken?.identifierKeyword === "var"
+        ? "var"
+        : undefined);
   let precedingIdentifierKeyword:
     | JavaScriptPrecedingIdentifierKeyword
     | undefined;
@@ -933,6 +953,9 @@ function javaScriptTokenWithIdentifierContext(
     ...(precedingIdentifierKeyword === undefined
       ? {}
       : { precedingIdentifierKeyword }),
+    ...(uninitializedDeclaration === undefined
+      ? {}
+      : { uninitializedDeclaration }),
   };
 }
 
@@ -1018,7 +1041,7 @@ function javaScriptTemplateInterpolationEnd(
       ? javaScriptJsxElementEnd(text, cursor)
       : undefined;
     if (jsxTagEnd !== undefined) {
-      previousSignificantToken = { end: jsxTagEnd, kind: "other" };
+      previousSignificantToken = { end: jsxTagEnd, kind: "operand" };
       cursor = jsxTagEnd;
       continue;
     }
@@ -1139,7 +1162,7 @@ function mdxExpressionAt(
       ? javaScriptJsxElementEnd(text, cursor)
       : undefined;
     if (jsxTagEnd !== undefined) {
-      previousSignificantToken = { end: jsxTagEnd, kind: "other" };
+      previousSignificantToken = { end: jsxTagEnd, kind: "operand" };
       cursor = jsxTagEnd;
       continue;
     }
@@ -1504,7 +1527,8 @@ function javaScriptLineTerminatesRestrictedStatement(
   return token.precedingIdentifierKeyword === "break" ||
     token.precedingIdentifierKeyword === "continue" ||
     token.precedingIdentifierKeyword === "let" ||
-    token.precedingIdentifierKeyword === "var";
+    token.precedingIdentifierKeyword === "var" ||
+    token.uninitializedDeclaration !== undefined;
 }
 
 function javaScriptPreviousSignificantTokenAfterTrivia(
@@ -1612,6 +1636,7 @@ function javaScriptRegexMayStart(
     previousSignificantToken.kind === "prefix-update"
   ) return true;
   if (
+    previousSignificantToken.kind === "operand" ||
     previousSignificantToken.kind === "postfix-update" ||
     previousSignificantToken.kind === "regex"
   ) return false;
@@ -2226,7 +2251,7 @@ function scanTagSyntax(
       ? javaScriptJsxElementEnd(text, cursor)
       : undefined;
     if (jsxTagEnd !== undefined) {
-      previousSignificantToken = { end: jsxTagEnd, kind: "other" };
+      previousSignificantToken = { end: jsxTagEnd, kind: "operand" };
       cursor = jsxTagEnd;
       continue;
     }
@@ -2394,9 +2419,14 @@ function htmlTagRanges(
   stringRanges: readonly Range[] = [],
 ): Range[] {
   const ranges: Range[] = [];
+  let expressionIndex = 0;
   for (let start = 0; start < text.length;) {
     start = text.indexOf("<", start);
     if (start === -1) break;
+    while (
+      expressionIndex < expressionRanges.length &&
+      expressionRanges[expressionIndex]!.start <= start
+    ) expressionIndex++;
     if (
       isInsideRange(stringRanges, start) ||
       (isInsideRange(ignoredRanges, start) &&
@@ -2418,7 +2448,9 @@ function htmlTagRanges(
       : Math.max(commonMarkEnd, mdxJsxEnd);
     if (tagEnd !== undefined) {
       ranges.push({ start, end: tagEnd });
-      start = tagEnd;
+      const containsExpression =
+        (expressionRanges[expressionIndex]?.start ?? tagEnd) < tagEnd;
+      start = containsExpression ? start + 1 : tagEnd;
     } else start++;
   }
   return ranges;

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -814,11 +814,11 @@ function javaScriptTokenWithIdentifierContext(
   if (!javaScriptIdentifierCodeUnitAt(text, start)) return { end, kind };
 
   const escapeRange = javaScriptIdentifierEscapeRangeAt(text, start);
-  const codeUnit = text.charCodeAt(start);
+  const codePoint = text.codePointAt(start);
   const continuesIdentifierWord = start > 0 &&
     (javaScriptIdentifierContinueBefore(text, start) ||
       (escapeRange !== undefined && escapeRange.start < start) ||
-      (codeUnit >= 0xdc00 && codeUnit <= 0xdfff &&
+      (codePoint !== undefined && codePoint >= 0xdc00 && codePoint <= 0xdfff &&
         javaScriptIdentifierContinueBefore(text, start + 1)));
   const identifier = continuesIdentifierWord
     ? previousSignificantToken?.identifier === true
@@ -1245,8 +1245,8 @@ function javaScriptIdentifierCodeUnitAt(
     codePoint !== undefined &&
     JAVASCRIPT_IDENTIFIER_CONTINUE.test(String.fromCodePoint(codePoint))
   ) return true;
-  const codeUnit = text.charCodeAt(offset);
-  return (codeUnit >= 0xdc00 && codeUnit <= 0xdfff &&
+  return (codePoint !== undefined && codePoint >= 0xdc00 &&
+    codePoint <= 0xdfff &&
     javaScriptIdentifierContinueBefore(text, offset + 1)) ||
     javaScriptIdentifierEscapeRangeAt(text, offset) !== undefined;
 }

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -1050,7 +1050,7 @@ function javaScriptRegexEnd(line: string, start: number): number | undefined {
 function javaScriptRegexMayStart(line: string, start: number): boolean {
   const prefix = line.slice(0, start).trimEnd();
   return prefix === "" ||
-    /(?:[=(:,!\[{;?&|+*%^~<>-]|=>|(?:^|[^A-Za-z0-9_$.])(?:return|case|throw|default|typeof|void|delete|in|instanceof))$/
+    /(?:[=(:,!\[{;?&|+*%^~<>-]|=>|(?:^|[^A-Za-z0-9_$.#])(?:return|case|throw|default|typeof|void|delete|in|instanceof))$/
       .test(
         prefix,
       );

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -244,12 +244,10 @@ function decodeUrlComponentTolerantly(value: string): string {
 }
 
 function decodeUrlPathForRepositoryMatch(value: string): string {
-  return value
-    .split(/(%(?:2[fF]|3[fF]|23))/)
-    .map((part, index) =>
-      index % 2 === 0 ? decodeUrlComponentTolerantly(part) : part
-    )
-    .join("");
+  return value.replace(/(?:%[0-9a-fA-F]{2})+/g, (encoded) => {
+    const decoded = decodeUrlComponentTolerantly(encoded);
+    return /^[A-Za-z0-9._~-]+$/.test(decoded) ? decoded : encoded;
+  });
 }
 
 function normalizeRepositoryPath(pathname: string): string {

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -220,7 +220,9 @@ function decodeUrlComponentTolerantly(value: string): string {
   return value.replace(/(?:%[0-9a-fA-F]{2})+/g, (encoded) => {
     let decoded = "";
     for (let start = 0; start < encoded.length;) {
-      let end = encoded.length;
+      // A UTF-8 code point occupies at most four bytes, so no successful
+      // decoding boundary requires retrying the full remaining suffix.
+      let end = Math.min(encoded.length, start + 4 * 3);
       let consumed = false;
       for (; end > start; end -= 3) {
         try {
@@ -1050,7 +1052,7 @@ function javaScriptRegexEnd(line: string, start: number): number | undefined {
 function javaScriptRegexMayStart(line: string, start: number): boolean {
   const prefix = line.slice(0, start).trimEnd();
   return prefix === "" ||
-    /(?:[=(:,!\[{;?&|+*%^~<>-]|=>|(?:^|[^A-Za-z0-9_$.#])(?:return|case|throw|default|typeof|void|delete|in|instanceof))$/
+    /(?:[=(:,!\[{;?&|+*%/^~<>-]|=>|(?:^|[^A-Za-z0-9_$.#])(?:return|case|throw|default|typeof|void|delete|in|instanceof))$/
       .test(
         prefix,
       );

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -1078,6 +1078,9 @@ function javaScriptRegexMayStart(
   if (previousSignificantToken.kind === "regex") return false;
   const end = previousSignificantToken.end;
 
+  if (text.slice(end - 2, end) === "++" || text.slice(end - 2, end) === "--") {
+    return false;
+  }
   if ("=(:,![{;?&|+*%/^~<>-".includes(text[end - 1]!)) return true;
 
   let wordStart = end;
@@ -1301,6 +1304,9 @@ function htmlCommentRanges(
   ignoredRanges: readonly Range[],
 ): Range[] {
   const ranges: Range[] = [];
+  let hasCachedSearch = false;
+  let cachedSearchStart = -1;
+  let cachedClosing = -1;
   for (let start = 0; start < text.length;) {
     start = text.indexOf("<!--", start);
     if (start === -1) break;
@@ -1311,7 +1317,19 @@ function htmlCommentRanges(
       start += 4;
       continue;
     }
-    const closing = text.indexOf("-->", start + 4);
+    const searchStart = start + 4;
+    let closing: number;
+    if (
+      hasCachedSearch && searchStart >= cachedSearchStart &&
+      (cachedClosing === -1 || cachedClosing >= searchStart)
+    ) {
+      closing = cachedClosing;
+    } else {
+      closing = text.indexOf("-->", searchStart);
+      hasCachedSearch = true;
+      cachedSearchStart = searchStart;
+      cachedClosing = closing;
+    }
     if (closing === -1 && !htmlCommentBlockMayStart(text, start)) {
       start += 4;
       continue;
@@ -2232,8 +2250,26 @@ function markdownInlineDestinationAt(
   const afterLabel = afterMarkdownLabel(text, start);
   if (afterLabel === undefined || text[afterLabel] !== "(") return undefined;
 
-  let cursor = markdownDestinationStart(text, afterLabel + 1);
+  const destinationInput = afterLabel + 1;
+  let cursor = markdownDestinationStart(text, destinationInput);
   if (cursor === undefined || cursor >= text.length) return undefined;
+
+  if (
+    cursor > destinationInput &&
+    (text[cursor] === '"' || text[cursor] === "'" || text[cursor] === "(") &&
+    markdownDestinationCloses(text, cursor)
+  ) {
+    const linkEnd = afterInlineLink(text, afterLabel);
+    if (linkEnd === undefined) return undefined;
+    return {
+      href: "",
+      offset: cursor,
+      labelStart: start + 1,
+      labelEnd: afterLabel - 1,
+      linkEnd,
+      tail: { start: afterLabel, end: linkEnd },
+    };
+  }
 
   let href: string;
   let offset: number;

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -2718,7 +2718,6 @@ function htmlTagRanges(
     }
 
     const commonMarkEnd = commonMarkHtmlTagEnd(text, start);
-    const tagSyntax = scanTagSyntax(text, start);
     const mdxJsxEnd = mdxJsxTagEnd(text, start, jsxScanCache);
     const tagEnd = commonMarkEnd === undefined
       ? mdxJsxEnd
@@ -2727,6 +2726,7 @@ function htmlTagRanges(
       : Math.max(commonMarkEnd, mdxJsxEnd);
     if (tagEnd !== undefined) {
       ranges.push({ start, end: tagEnd });
+      const tagSyntax = scanTagSyntax(text, start);
       const rescanExpression = tagSyntax.end === tagEnd
         ? tagSyntax.expressionRanges[0]
         : undefined;

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -814,6 +814,7 @@ function javaScriptTemplateInterpolationEnd(
 ): number | undefined {
   let depth = 1;
   let cursor = start + 2;
+  let previousSignificantEnd: number | undefined;
   let previousTokenWasRegex = false;
   while (cursor < text.length) {
     const commentEnd = javaScriptCommentEnd(text, cursor);
@@ -825,6 +826,7 @@ function javaScriptTemplateInterpolationEnd(
     if (character === '"' || character === "'") {
       const end = quotedRangeEnd(text, cursor, character);
       if (end === undefined) return undefined;
+      previousSignificantEnd = end;
       previousTokenWasRegex = false;
       cursor = end;
       continue;
@@ -832,16 +834,22 @@ function javaScriptTemplateInterpolationEnd(
     if (character === "`") {
       const end = javaScriptTemplateEnd(text, cursor);
       if (end === undefined) return undefined;
+      previousSignificantEnd = end;
       previousTokenWasRegex = false;
       cursor = end;
       continue;
     }
     if (
       character === "/" &&
-      javaScriptRegexMayStart(text, cursor, previousTokenWasRegex)
+      javaScriptRegexMayStart(
+        text,
+        previousSignificantEnd,
+        previousTokenWasRegex,
+      )
     ) {
       const regexEnd = javaScriptRegexEnd(text, cursor);
       if (regexEnd !== undefined) {
+        previousSignificantEnd = regexEnd;
         previousTokenWasRegex = true;
         cursor = regexEnd;
         continue;
@@ -854,6 +862,7 @@ function javaScriptTemplateInterpolationEnd(
     previousTokenWasRegex = false;
     if (character === "{") depth++;
     else if (character === "}" && --depth === 0) return cursor + 1;
+    previousSignificantEnd = cursor + 1;
     cursor++;
   }
   return undefined;
@@ -929,6 +938,7 @@ function mdxExpressionAt(
   const strings: Range[] = [];
   let depth = 1;
   let cursor = start + 1;
+  let previousSignificantEnd: number | undefined;
   let previousTokenWasRegex = false;
   while (cursor < text.length) {
     const commentEnd = javaScriptCommentEnd(text, cursor);
@@ -941,6 +951,7 @@ function mdxExpressionAt(
       const end = javaScriptTemplateEnd(text, cursor);
       if (end === undefined) return undefined;
       strings.push({ start: cursor, end });
+      previousSignificantEnd = end;
       previousTokenWasRegex = false;
       cursor = end;
       continue;
@@ -949,16 +960,22 @@ function mdxExpressionAt(
       const end = quotedRangeEnd(text, cursor, character);
       if (end === undefined) return undefined;
       strings.push({ start: cursor, end });
+      previousSignificantEnd = end;
       previousTokenWasRegex = false;
       cursor = end;
       continue;
     }
     if (
       character === "/" &&
-      javaScriptRegexMayStart(text, cursor, previousTokenWasRegex)
+      javaScriptRegexMayStart(
+        text,
+        previousSignificantEnd,
+        previousTokenWasRegex,
+      )
     ) {
       const regexEnd = javaScriptRegexEnd(text, cursor);
       if (regexEnd !== undefined) {
+        previousSignificantEnd = regexEnd;
         previousTokenWasRegex = true;
         cursor = regexEnd;
         continue;
@@ -973,6 +990,7 @@ function mdxExpressionAt(
     else if (character === "}" && --depth === 0) {
       return { expression: { start, end: cursor + 1 }, strings };
     }
+    previousSignificantEnd = cursor + 1;
     cursor++;
   }
   return undefined;
@@ -1057,6 +1075,7 @@ interface JavaScriptBalance {
   quote: '"' | "'" | undefined;
   blockComment: boolean;
   templateEnd: number;
+  previousSignificantEnd: number | undefined;
   previousTokenWasRegex: boolean;
   valid: boolean;
 }
@@ -1093,27 +1112,28 @@ const JAVASCRIPT_REGEX_PREFIX_KEYWORDS: ReadonlySet<string> = new Set([
   "delete",
   "in",
   "instanceof",
+  "new",
 ]);
 
 function javaScriptRegexMayStart(
-  line: string,
-  start: number,
+  text: string,
+  previousSignificantEnd: number | undefined,
   previousTokenWasRegex: boolean,
 ): boolean {
   if (previousTokenWasRegex) return false;
-  let end = start;
-  while (end > 0 && /\s/.test(line[end - 1]!)) end--;
-  if (end === 0) return true;
+  if (previousSignificantEnd === undefined) return true;
 
-  if ("=(:,![{;?&|+*%/^~<>-".includes(line[end - 1]!)) return true;
+  if (
+    "=(:,![{;?&|+*%/^~<>-".includes(text[previousSignificantEnd - 1]!)
+  ) return true;
 
-  let wordStart = end;
-  while (wordStart > 0 && /[A-Za-z]/.test(line[wordStart - 1]!)) wordStart--;
-  const keyword = line.slice(wordStart, end);
+  let wordStart = previousSignificantEnd;
+  while (wordStart > 0 && /[A-Za-z]/.test(text[wordStart - 1]!)) wordStart--;
+  const keyword = text.slice(wordStart, previousSignificantEnd);
   if (!JAVASCRIPT_REGEX_PREFIX_KEYWORDS.has(keyword)) return false;
 
   return wordStart === 0 ||
-    !/[A-Za-z0-9_$.#]/.test(line[wordStart - 1]!);
+    !/[A-Za-z0-9_$.#]/.test(text[wordStart - 1]!);
 }
 
 function scanJavaScriptLine(
@@ -1143,7 +1163,11 @@ function scanJavaScriptLine(
     }
     if (state.quote !== undefined) {
       if (character === "\\") cursor++;
-      else if (character === state.quote) state.quote = undefined;
+      else if (character === state.quote) {
+        state.quote = undefined;
+        state.previousSignificantEnd = cursor + 1;
+        state.previousTokenWasRegex = false;
+      }
       continue;
     }
     if (text.startsWith("//", cursor)) break;
@@ -1158,6 +1182,7 @@ function scanJavaScriptLine(
         state.valid = false;
         return;
       }
+      state.previousSignificantEnd = templateEnd;
       state.previousTokenWasRegex = false;
       state.templateEnd = templateEnd;
       cursor = templateEnd - 1;
@@ -1172,13 +1197,14 @@ function scanJavaScriptLine(
     if (
       character === "/" &&
       javaScriptRegexMayStart(
-        line,
-        lineCursor,
+        text,
+        state.previousSignificantEnd,
         state.previousTokenWasRegex,
       )
     ) {
       const regexEnd = javaScriptRegexEnd(line, lineCursor);
       if (regexEnd !== undefined) {
+        state.previousSignificantEnd = lineStart + regexEnd;
         state.previousTokenWasRegex = true;
         cursor = lineStart + regexEnd - 1;
         continue;
@@ -1186,6 +1212,7 @@ function scanJavaScriptLine(
     }
     if (/\s/.test(character)) continue;
     state.previousTokenWasRegex = false;
+    state.previousSignificantEnd = cursor + 1;
     if (character === "(" || character === "[" || character === "{") {
       state.delimiters.push(character);
       continue;
@@ -1206,6 +1233,7 @@ function mdxEsmRangeEnd(text: string, start: number): number | undefined {
     quote: undefined,
     blockComment: false,
     templateEnd: start,
+    previousSignificantEnd: undefined,
     previousTokenWasRegex: false,
     valid: true,
   };
@@ -1422,12 +1450,20 @@ function scanTagSyntax(
   let quote: '"' | "'" | undefined;
   let quoteUsesJavaScriptEscapes = false;
   let expressionDepth = 0;
+  let previousSignificantEnd: number | undefined;
   let previousTokenWasRegex = false;
   for (let cursor = start; cursor < text.length; cursor++) {
     const character = text[cursor]!;
     if (quote !== undefined) {
       if (quoteUsesJavaScriptEscapes && character === "\\") cursor++;
-      else if (character === quote) quote = undefined;
+      else if (character === quote) {
+        quote = undefined;
+        if (quoteUsesJavaScriptEscapes) {
+          previousSignificantEnd = cursor + 1;
+          previousTokenWasRegex = false;
+        }
+        quoteUsesJavaScriptEscapes = false;
+      }
       continue;
     }
     const commentEnd = expressionDepth > 0
@@ -1439,10 +1475,15 @@ function scanTagSyntax(
     }
     if (
       expressionDepth > 0 && character === "/" &&
-      javaScriptRegexMayStart(text, cursor, previousTokenWasRegex)
+      javaScriptRegexMayStart(
+        text,
+        previousSignificantEnd,
+        previousTokenWasRegex,
+      )
     ) {
       const regexEnd = javaScriptRegexEnd(text, cursor);
       if (regexEnd !== undefined) {
+        previousSignificantEnd = regexEnd;
         previousTokenWasRegex = true;
         cursor = regexEnd - 1;
         continue;
@@ -1457,6 +1498,7 @@ function scanTagSyntax(
     if (character === "`" && expressionDepth > 0) {
       const templateEnd = javaScriptTemplateEnd(text, cursor);
       if (templateEnd !== undefined) {
+        previousSignificantEnd = templateEnd;
         previousTokenWasRegex = false;
         cursor = templateEnd - 1;
         continue;
@@ -1464,6 +1506,9 @@ function scanTagSyntax(
     }
     if (expressionDepth > 0 && /\s/.test(character)) continue;
     previousTokenWasRegex = false;
+    if (expressionDepth > 0 || character === "{") {
+      previousSignificantEnd = cursor + 1;
+    }
     if (character === '"' || character === "'") {
       quote = character;
       quoteUsesJavaScriptEscapes = expressionDepth > 0;

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -1003,6 +1003,10 @@ function javaScriptTokenWithIdentifierContext(
     followsForOfLeftOperand = delimiterContexts.at(-1) === "for" &&
       javaScriptTokenMayEndForOfLeftOperand(text, previousSignificantToken);
   }
+  const endsForIterationBinding = completeIdentifier &&
+    (identifierWord === "in" || identifierWord === "of") &&
+    delimiterContexts.at(-1) === "for" && followsForOfLeftOperand;
+  if (endsForIterationBinding) variableDeclaration = undefined;
   const uninitializedDeclaration = completeIdentifier &&
     !startsVariableDeclaration && variableDeclaration?.phase === "binding" &&
     delimiterContexts.length === variableDeclaration.depth;

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -2472,12 +2472,14 @@ export function scanDestinations(
       .filter((usage) => usage.image && definedLabels.has(usage.label))
       .map((usage) => usage.description),
   );
-  markdownImageLabelRanges.sort((left, right) => left.start - right.start);
+  const markdownImageLabelLookupRanges = mergeRanges(
+    markdownImageLabelRanges,
+  );
 
   for (const tagRange of tagRanges) {
     if (
       isInsideRange(referenceDefinitionRanges, tagRange.start) ||
-      isInsideRange(markdownImageLabelRanges, tagRange.start) ||
+      isInsideRange(markdownImageLabelLookupRanges, tagRange.start) ||
       isInsideRange(rawHtmlBlocks.rawText, tagRange.start)
     ) continue;
     const tag = text.slice(tagRange.start, tagRange.end);
@@ -2548,7 +2550,7 @@ export function scanDestinations(
   ]);
   const uriAutolinkIgnoredRanges = mergeRanges([
     ...markdownIgnoredRanges,
-    ...markdownImageLabelRanges,
+    ...markdownImageLabelLookupRanges,
     ...markdownLinkTailRanges,
     ...referenceDefinitionRanges,
     ...markdownAngleDestinationRanges,
@@ -2567,7 +2569,7 @@ export function scanDestinations(
   }
   const bareAutolinkIgnoredRanges = mergeRanges([
     ...markdownIgnoredRanges,
-    ...markdownImageLabelRanges,
+    ...markdownImageLabelLookupRanges,
     ...renderedLinkRanges,
     ...referenceDefinitionRanges,
   ]);

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -777,7 +777,6 @@ interface MdxSyntaxRanges {
 // Keep those scanner surfaces on this shared state model, and regression-test
 // both the regex and division forms when adding a new grammar context.
 type JavaScriptSignificantTokenKind =
-  | "arrow"
   | "control-header"
   | "declaration-header"
   | "expression-header"
@@ -791,32 +790,34 @@ type JavaScriptPrecedingIdentifierKeyword =
   | "break"
   | "continue"
   | "export"
-  | "for"
-  | "let"
-  | "var";
+  | "for";
+type JavaScriptVariableDeclarationPhase = "binding" | "initializer";
 type JavaScriptDelimiterContext =
   | "block"
   | "control"
+  | "expression-block"
   | "for"
   | "function-declaration"
   | "function-expression"
-  | "function-body"
   | "nested"
   | undefined;
 
 interface JavaScriptSignificantToken {
-  readonly classDeclaration?: true;
+  readonly classDeclarationDepth?: number;
   readonly declarationCandidate?: true;
+  readonly declarationPrefix?: true;
   readonly end: number;
   readonly functionDeclaration?: true;
-  readonly functionDeclarationPrefix?: true;
-  readonly functionHeader?: true;
+  readonly functionExpression?: true;
   readonly identifier?: true;
-  readonly identifierKeyword?: string;
-  readonly identifierKeywordCandidate?: string;
+  readonly identifierStart?: number;
+  readonly identifierWord?: string;
   readonly kind: JavaScriptSignificantTokenKind;
   readonly followsForOfLeftOperand?: true;
   readonly precedingIdentifierKeyword?: JavaScriptPrecedingIdentifierKeyword;
+  readonly uninitializedDeclaration?: true;
+  readonly variableDeclarationDepth?: number;
+  readonly variableDeclarationPhase?: JavaScriptVariableDeclarationPhase;
 }
 
 type JavaScriptQuote = '"' | "'";
@@ -828,6 +829,53 @@ interface JavaScriptScannedToken {
   readonly string?: Range;
 }
 
+type JavaScriptJsxScanCache = Map<number, number | undefined>;
+
+interface JavaScriptVariableDeclarationContext {
+  readonly depth: number;
+  readonly phase: JavaScriptVariableDeclarationPhase;
+}
+
+function javaScriptVariableDeclarationContext(
+  text: string,
+  start: number,
+  previousSignificantToken: JavaScriptSignificantToken | undefined,
+  delimiterContexts: readonly JavaScriptDelimiterContext[],
+): JavaScriptVariableDeclarationContext | undefined {
+  const depth = previousSignificantToken?.variableDeclarationDepth;
+  let phase = previousSignificantToken?.variableDeclarationPhase;
+  if (depth === undefined || phase === undefined) return undefined;
+  if (delimiterContexts.length < depth) return undefined;
+  if (delimiterContexts.length === depth) {
+    if (text[start] === ";") return undefined;
+    if (text[start] === "=") phase = "initializer";
+    else if (text[start] === ",") phase = "binding";
+  }
+  return { depth, phase };
+}
+
+function javaScriptTokenWithPersistentContext(
+  end: number,
+  kind: JavaScriptSignificantTokenKind,
+  previousSignificantToken: JavaScriptSignificantToken | undefined,
+): JavaScriptSignificantToken {
+  const classDeclarationDepth = previousSignificantToken
+    ?.classDeclarationDepth;
+  const variableDeclarationDepth = previousSignificantToken
+    ?.variableDeclarationDepth;
+  const variableDeclarationPhase = previousSignificantToken
+    ?.variableDeclarationPhase;
+  return {
+    end,
+    ...(classDeclarationDepth === undefined ? {} : { classDeclarationDepth }),
+    kind,
+    ...(variableDeclarationDepth === undefined ||
+        variableDeclarationPhase === undefined
+      ? {}
+      : { variableDeclarationDepth, variableDeclarationPhase }),
+  };
+}
+
 function javaScriptTokenWithIdentifierContext(
   text: string,
   start: number,
@@ -837,17 +885,41 @@ function javaScriptTokenWithIdentifierContext(
   delimiterContexts: readonly JavaScriptDelimiterContext[],
 ): JavaScriptSignificantToken {
   if (!javaScriptIdentifierCodeUnitAt(text, start)) {
+    const classDeclarationDepth = previousSignificantToken
+      ?.classDeclarationDepth;
+    const variableDeclaration = javaScriptVariableDeclarationContext(
+      text,
+      start,
+      previousSignificantToken,
+      delimiterContexts,
+    );
+    const startsClassDeclarationBody = text[start] === "{" &&
+      classDeclarationDepth !== undefined &&
+      delimiterContexts.length === classDeclarationDepth + 1 &&
+      delimiterContexts.at(-1) === "block";
+    const uninitializedDeclaration = variableDeclaration?.phase ===
+        "binding" &&
+      delimiterContexts.length === variableDeclaration.depth &&
+      "]}".includes(text[start]!);
     return {
       end,
+      ...(classDeclarationDepth !== undefined && !startsClassDeclarationBody
+        ? { classDeclarationDepth }
+        : {}),
       ...(text[start] === "*" &&
           previousSignificantToken?.functionDeclaration === true
         ? { functionDeclaration: true }
         : {}),
       ...(text[start] === "*" &&
-          previousSignificantToken?.functionHeader === true
-        ? { functionHeader: true }
+          previousSignificantToken?.functionExpression === true
+        ? { functionExpression: true }
         : {}),
       kind,
+      ...(uninitializedDeclaration ? { uninitializedDeclaration: true } : {}),
+      ...(variableDeclaration === undefined ? {} : {
+        variableDeclarationDepth: variableDeclaration.depth,
+        variableDeclarationPhase: variableDeclaration.phase,
+      }),
     };
   }
 
@@ -861,39 +933,57 @@ function javaScriptTokenWithIdentifierContext(
   const identifier = continuesIdentifierWord
     ? previousSignificantToken?.identifier === true
     : javaScriptIdentifierStartsAt(text, start);
-  const identifierKeywordCandidate = javaScriptIdentifierKeywordCandidate(
-    text,
-    start,
-    continuesIdentifierWord,
-    previousSignificantToken,
-  );
+  const precedingCodePoint = javaScriptCodePointBefore(text, start);
+  const identifierStart = continuesIdentifierWord
+    ? previousSignificantToken?.identifierStart
+    : identifier && precedingCodePoint !== "." && precedingCodePoint !== "#"
+    ? start
+    : undefined;
   const declarationCandidate = continuesIdentifierWord
     ? previousSignificantToken?.declarationCandidate === true
-    : javaScriptMayStartStatement(
+    : javaScriptMayStartDeclaration(
       text,
       previousSignificantToken,
       delimiterContexts,
     );
-  const completeIdentifier = !javaScriptIdentifierCodeUnitAt(text, end);
-  const identifierKeyword = completeIdentifier &&
-      identifierKeywordCandidate !== undefined &&
-      JAVASCRIPT_IDENTIFIER_KEYWORDS.has(identifierKeywordCandidate)
-    ? identifierKeywordCandidate
+  const completeIdentifier = identifier &&
+    !javaScriptIdentifierCodeUnitAt(text, end);
+  const identifierWord = completeIdentifier && identifierStart !== undefined
+    ? text.slice(identifierStart, end)
     : undefined;
-  const functionDeclarationPrefix = completeIdentifier &&
-    ((identifierKeyword === "export" || identifierKeyword === "async") &&
+  const declarationPrefix = completeIdentifier &&
+    ((identifierWord === "export" || identifierWord === "async") &&
         declarationCandidate ||
-      identifierKeyword === "default" &&
-        previousSignificantToken?.functionDeclarationPrefix === true);
+      identifierWord === "default" &&
+        previousSignificantToken?.declarationPrefix === true);
   const functionDeclaration =
     previousSignificantToken?.functionDeclaration === true ||
-    (identifierKeyword === "function" &&
+    (completeIdentifier && identifierWord === "function" &&
       declarationCandidate);
-  const functionHeader = previousSignificantToken?.functionHeader === true ||
-    identifierKeyword === "function";
-  const classDeclaration =
-    previousSignificantToken?.classDeclaration === true ||
-    (identifierKeyword === "class" && declarationCandidate);
+  const functionExpression =
+    previousSignificantToken?.functionExpression === true ||
+    (completeIdentifier && identifierWord === "function" &&
+      !declarationCandidate);
+  const classDeclarationDepth = previousSignificantToken
+    ?.classDeclarationDepth ??
+    (completeIdentifier && identifierWord === "class" && declarationCandidate
+      ? delimiterContexts.length
+      : undefined);
+  let variableDeclaration = javaScriptVariableDeclarationContext(
+    text,
+    start,
+    previousSignificantToken,
+    delimiterContexts,
+  );
+  const startsVariableDeclaration = completeIdentifier &&
+    (identifierWord === "let" || identifierWord === "var") &&
+    declarationCandidate;
+  if (startsVariableDeclaration) {
+    variableDeclaration = {
+      depth: delimiterContexts.length,
+      phase: "binding",
+    };
+  }
   let precedingIdentifierKeyword:
     | JavaScriptPrecedingIdentifierKeyword
     | undefined;
@@ -904,35 +994,39 @@ function javaScriptTokenWithIdentifierContext(
     followsForOfLeftOperand =
       previousSignificantToken?.followsForOfLeftOperand === true;
   } else if (previousSignificantToken !== undefined) {
-    const previousWord = previousSignificantToken.identifierKeyword;
+    const previousWord = previousSignificantToken.identifierWord;
     if (
       previousWord === "break" || previousWord === "continue" ||
-      previousWord === "export" || previousWord === "for" ||
-      previousWord === "let" || previousWord === "var"
+      previousWord === "export" || previousWord === "for"
     ) precedingIdentifierKeyword = previousWord;
     followsForOfLeftOperand = delimiterContexts.at(-1) === "for" &&
       javaScriptTokenMayEndForOfLeftOperand(text, previousSignificantToken);
   }
-
+  const uninitializedDeclaration = completeIdentifier &&
+    !startsVariableDeclaration && variableDeclaration?.phase === "binding" &&
+    delimiterContexts.length === variableDeclaration.depth;
   return {
-    ...(classDeclaration ? { classDeclaration: true } : {}),
+    ...(classDeclarationDepth === undefined ? {} : { classDeclarationDepth }),
     ...(declarationCandidate && !completeIdentifier
       ? { declarationCandidate: true }
       : {}),
+    ...(declarationPrefix ? { declarationPrefix: true } : {}),
     end,
     ...(functionDeclaration ? { functionDeclaration: true } : {}),
-    ...(functionDeclarationPrefix ? { functionDeclarationPrefix: true } : {}),
-    ...(functionHeader ? { functionHeader: true } : {}),
+    ...(functionExpression ? { functionExpression: true } : {}),
     ...(identifier ? { identifier: true } : {}),
-    ...(identifierKeyword === undefined ? {} : { identifierKeyword }),
-    ...(identifierKeywordCandidate === undefined || completeIdentifier
-      ? {}
-      : { identifierKeywordCandidate }),
+    ...(identifierStart === undefined ? {} : { identifierStart }),
+    ...(identifierWord === undefined ? {} : { identifierWord }),
     kind,
     ...(followsForOfLeftOperand ? { followsForOfLeftOperand: true } : {}),
     ...(precedingIdentifierKeyword === undefined
       ? {}
       : { precedingIdentifierKeyword }),
+    ...(uninitializedDeclaration ? { uninitializedDeclaration: true } : {}),
+    ...(variableDeclaration === undefined ? {} : {
+      variableDeclarationDepth: variableDeclaration.depth,
+      variableDeclarationPhase: variableDeclaration.phase,
+    }),
   };
 }
 
@@ -970,8 +1064,9 @@ function quotedRangeEnd(
   text: string,
   start: number,
   quote: JavaScriptStringDelimiter,
+  jsxScanCache?: JavaScriptJsxScanCache,
 ): number | undefined {
-  if (quote === "`") return javaScriptTemplateEnd(text, start);
+  if (quote === "`") return javaScriptTemplateEnd(text, start, jsxScanCache);
   for (let cursor = start + 1; cursor < text.length; cursor++) {
     if (text[cursor] === "\\") cursor++;
     else if (text[cursor] === quote) return cursor + 1;
@@ -982,6 +1077,7 @@ function quotedRangeEnd(
 function javaScriptTemplateEnd(
   text: string,
   start: number,
+  jsxScanCache?: JavaScriptJsxScanCache,
 ): number | undefined {
   let cursor = start + 1;
   while (cursor < text.length) {
@@ -991,7 +1087,11 @@ function javaScriptTemplateEnd(
     }
     if (text[cursor] === "`") return cursor + 1;
     if (text.startsWith("${", cursor)) {
-      const interpolationEnd = javaScriptTemplateInterpolationEnd(text, cursor);
+      const interpolationEnd = javaScriptTemplateInterpolationEnd(
+        text,
+        cursor,
+        jsxScanCache,
+      );
       if (interpolationEnd === undefined) return undefined;
       cursor = interpolationEnd;
       continue;
@@ -1004,29 +1104,20 @@ function javaScriptTemplateEnd(
 function javaScriptTemplateInterpolationEnd(
   text: string,
   start: number,
+  jsxScanCache?: JavaScriptJsxScanCache,
 ): number | undefined {
   let depth = 1;
   let cursor = start + 2;
   const delimiterContexts: JavaScriptDelimiterContext[] = ["nested"];
   let previousSignificantToken: JavaScriptSignificantToken | undefined;
   while (cursor < text.length) {
-    const jsxTagEnd = text[cursor] === "<" && javaScriptRegexMayStart(
-        text,
-        previousSignificantToken,
-        delimiterContexts,
-      )
-      ? javaScriptJsxElementEnd(text, cursor)
-      : undefined;
-    if (jsxTagEnd !== undefined) {
-      previousSignificantToken = { end: jsxTagEnd, kind: "other" };
-      cursor = jsxTagEnd;
-      continue;
-    }
     const token = javaScriptTokenAt(
       text,
       cursor,
       previousSignificantToken,
       delimiterContexts,
+      true,
+      jsxScanCache,
     );
     if (token === undefined) return undefined;
     if (token.kind === "trivia") {
@@ -1124,6 +1215,7 @@ function staticJsxStringExpression(
 function mdxExpressionAt(
   text: string,
   start: number,
+  jsxScanCache?: JavaScriptJsxScanCache,
 ): { readonly expression: Range; readonly strings: Range[] } | undefined {
   const strings: Range[] = [];
   let depth = 1;
@@ -1131,23 +1223,13 @@ function mdxExpressionAt(
   const delimiterContexts: JavaScriptDelimiterContext[] = ["nested"];
   let previousSignificantToken: JavaScriptSignificantToken | undefined;
   while (cursor < text.length) {
-    const jsxTagEnd = text[cursor] === "<" && javaScriptRegexMayStart(
-        text,
-        previousSignificantToken,
-        delimiterContexts,
-      )
-      ? javaScriptJsxElementEnd(text, cursor)
-      : undefined;
-    if (jsxTagEnd !== undefined) {
-      previousSignificantToken = { end: jsxTagEnd, kind: "other" };
-      cursor = jsxTagEnd;
-      continue;
-    }
     const token = javaScriptTokenAt(
       text,
       cursor,
       previousSignificantToken,
       delimiterContexts,
+      true,
+      jsxScanCache,
     );
     if (token === undefined) return undefined;
     if (token.string !== undefined) strings.push(token.string);
@@ -1189,6 +1271,7 @@ function mdxSyntaxRanges(
   const comments: Range[] = [];
   const expressions: Range[] = [];
   const strings: Range[] = [];
+  const jsxScanCache: JavaScriptJsxScanCache = new Map();
   let codeIndex = 0;
   let cursor = 0;
   while (cursor < text.length) {
@@ -1221,7 +1304,7 @@ function mdxSyntaxRanges(
       continue;
     }
 
-    const expression = mdxExpressionAt(text, cursor);
+    const expression = mdxExpressionAt(text, cursor, jsxScanCache);
     if (expression === undefined) {
       cursor++;
       continue;
@@ -1323,33 +1406,6 @@ const JAVASCRIPT_BLOCK_PREFIX_KEYWORDS: ReadonlySet<string> = new Set([
   "try",
 ]);
 
-const JAVASCRIPT_IDENTIFIER_KEYWORDS: ReadonlySet<string> = new Set([
-  ...JAVASCRIPT_REGEX_PREFIX_KEYWORDS,
-  ...JAVASCRIPT_CONTROL_HEADER_KEYWORDS,
-  ...JAVASCRIPT_BLOCK_PREFIX_KEYWORDS,
-  "async",
-  "break",
-  "class",
-  "const",
-  "continue",
-  "debugger",
-  "export",
-  "function",
-  "let",
-  "of",
-  "using",
-  "var",
-]);
-
-const JAVASCRIPT_IDENTIFIER_KEYWORD_PREFIXES: ReadonlySet<string> = new Set(
-  [...JAVASCRIPT_IDENTIFIER_KEYWORDS].flatMap((keyword) =>
-    Array.from(
-      { length: keyword.length },
-      (_, index) => keyword.slice(0, index + 1),
-    )
-  ),
-);
-
 const JAVASCRIPT_IDENTIFIER_START = /[$_\p{ID_Start}]/u;
 const JAVASCRIPT_IDENTIFIER_CONTINUE = /[$_\u200C\u200D\p{ID_Continue}]/u;
 const JAVASCRIPT_IDENTIFIER_ESCAPE =
@@ -1414,32 +1470,6 @@ function javaScriptIdentifierStartsAt(
   );
 }
 
-function javaScriptIdentifierKeywordCandidate(
-  text: string,
-  start: number,
-  continuesIdentifier: boolean,
-  previousSignificantToken: JavaScriptSignificantToken | undefined,
-): string | undefined {
-  const character = text[start]!;
-  if (!/[A-Za-z]/.test(character)) return undefined;
-  if (!continuesIdentifier) {
-    if (
-      previousSignificantToken !== undefined &&
-      ".#".includes(text[previousSignificantToken.end - 1]!)
-    ) return undefined;
-    return JAVASCRIPT_IDENTIFIER_KEYWORD_PREFIXES.has(character)
-      ? character
-      : undefined;
-  }
-
-  const previous = previousSignificantToken?.identifierKeywordCandidate;
-  if (previous === undefined) return undefined;
-  const candidate = previous + character;
-  return JAVASCRIPT_IDENTIFIER_KEYWORD_PREFIXES.has(candidate)
-    ? candidate
-    : undefined;
-}
-
 function javaScriptCodePointBefore(
   text: string,
   end: number,
@@ -1472,18 +1502,19 @@ function javaScriptIdentifierContinueBefore(
     JAVASCRIPT_IDENTIFIER_CONTINUE.test(codePoint);
 }
 
-function javaScriptMayStartStatement(
+function javaScriptMayStartDeclaration(
   text: string,
   token: JavaScriptSignificantToken | undefined,
   delimiterContexts: readonly JavaScriptDelimiterContext[],
 ): boolean {
   if (
-    delimiterContexts.length > 0 && delimiterContexts.at(-1) !== "block" &&
-    delimiterContexts.at(-1) !== "function-body"
+    delimiterContexts.length > 0 &&
+    delimiterContexts.at(-1) !== "block" &&
+    delimiterContexts.at(-1) !== "expression-block"
   ) return false;
   if (token === undefined) return true;
-  if (token.functionDeclarationPrefix === true) return true;
-  const word = token.identifierKeyword;
+  if (token.declarationPrefix === true) return true;
+  const word = token.identifierWord;
   if (word === "export") return true;
   if (
     (word === "default" || word === "async") &&
@@ -1492,19 +1523,18 @@ function javaScriptMayStartStatement(
   return ";{}".includes(text[token.end - 1]!);
 }
 
-function javaScriptLineTerminatesRestrictedStatement(
+function javaScriptLineTerminatesStatement(
   token: JavaScriptSignificantToken | undefined,
 ): boolean {
   if (token === undefined) return false;
-  const finalWord = token.identifierKeyword;
+  if (token.uninitializedDeclaration === true) return true;
+  const finalWord = token.identifierWord;
   if (
     finalWord === "break" || finalWord === "continue" ||
     finalWord === "debugger"
   ) return true;
   return token.precedingIdentifierKeyword === "break" ||
-    token.precedingIdentifierKeyword === "continue" ||
-    token.precedingIdentifierKeyword === "let" ||
-    token.precedingIdentifierKeyword === "var";
+    token.precedingIdentifierKeyword === "continue";
 }
 
 function javaScriptPreviousSignificantTokenAfterTrivia(
@@ -1515,7 +1545,7 @@ function javaScriptPreviousSignificantTokenAfterTrivia(
 ): JavaScriptSignificantToken | undefined {
   if (
     /[\n\r\u2028\u2029]/.test(text.slice(start, end)) &&
-    javaScriptLineTerminatesRestrictedStatement(token)
+    javaScriptLineTerminatesStatement(token)
   ) return undefined;
   return token;
 }
@@ -1524,7 +1554,7 @@ function javaScriptTokenMayEndForOfLeftOperand(
   text: string,
   token: JavaScriptSignificantToken,
 ): boolean {
-  const word = token.identifierKeyword;
+  const word = token.identifierWord;
   if (token.identifier === true) {
     if (word === undefined) return true;
     return !JAVASCRIPT_REGEX_PREFIX_KEYWORDS.has(word) &&
@@ -1541,17 +1571,13 @@ function javaScriptDelimiterTokenKind(
   previousSignificantToken: JavaScriptSignificantToken | undefined,
   delimiterContexts: JavaScriptDelimiterContext[],
 ): JavaScriptSignificantTokenKind {
-  if (
-    character === ">" && previousSignificantToken !== undefined &&
-    text[previousSignificantToken.end - 1] === "="
-  ) return "arrow";
   if (character === "(") {
-    const keyword = previousSignificantToken?.identifierKeyword;
+    const keyword = previousSignificantToken?.identifierWord;
     let context: JavaScriptDelimiterContext;
-    if (previousSignificantToken?.functionHeader === true) {
-      context = previousSignificantToken.functionDeclaration === true
-        ? "function-declaration"
-        : "function-expression";
+    if (previousSignificantToken?.functionDeclaration === true) {
+      context = "function-declaration";
+    } else if (previousSignificantToken?.functionExpression === true) {
+      context = "function-expression";
     } else if (
       keyword === "for" ||
       (keyword === "await" &&
@@ -1567,29 +1593,39 @@ function javaScriptDelimiterTokenKind(
   } else if (character === "[") {
     delimiterContexts.push("nested");
   } else if (character === "{") {
-    const keyword = previousSignificantToken?.identifierKeyword;
-    if (previousSignificantToken?.classDeclaration === true) {
-      delimiterContexts.push("block");
-      return "other";
-    }
-    if (
-      previousSignificantToken?.kind === "arrow" ||
-      previousSignificantToken?.kind === "expression-header"
-    ) {
-      delimiterContexts.push("function-body");
-      return "other";
-    }
-    const statementBlock =
+    const keyword = previousSignificantToken?.identifierWord;
+    const statementPosition = delimiterContexts.length === 0 ||
+      delimiterContexts.at(-1) === "block" ||
+      delimiterContexts.at(-1) === "expression-block";
+    const previousCharacter = previousSignificantToken === undefined
+      ? undefined
+      : text[previousSignificantToken.end - 1];
+    const classDeclarationBody =
+      previousSignificantToken?.classDeclarationDepth ===
+        delimiterContexts.length;
+    const expressionBlock = previousSignificantToken?.kind ===
+        "expression-header" ||
+      (previousSignificantToken !== undefined &&
+        text.slice(
+            previousSignificantToken.end - 2,
+            previousSignificantToken.end,
+          ) === "=>");
+    const statementBlock = !expressionBlock && (classDeclarationBody ||
       previousSignificantToken?.kind === "control-header" ||
       previousSignificantToken?.kind === "declaration-header" ||
       (keyword !== undefined &&
         JAVASCRIPT_BLOCK_PREFIX_KEYWORDS.has(keyword)) ||
-      javaScriptMayStartStatement(
-        text,
-        previousSignificantToken,
-        delimiterContexts,
-      );
-    delimiterContexts.push(statementBlock ? "block" : "nested");
+      (statementPosition &&
+        (previousSignificantToken === undefined ||
+          previousCharacter !== undefined &&
+            ";{}".includes(previousCharacter))));
+    delimiterContexts.push(
+      expressionBlock
+        ? "expression-block"
+        : statementBlock
+        ? "block"
+        : "nested",
+    );
   } else if (character === ")" || character === "]" || character === "}") {
     const context = delimiterContexts.pop();
     if (context === "control" || context === "for") return "control-header";
@@ -1620,7 +1656,7 @@ function javaScriptRegexMayStart(
   if (text.slice(end - 3, end) === "...") return true;
   if ("=(:,![{;?&|+*%/^~<>-".includes(text[end - 1]!)) return true;
 
-  const keyword = previousSignificantToken.identifierKeyword;
+  const keyword = previousSignificantToken.identifierWord;
   if (
     keyword === "of" && delimiterContexts.at(-1) === "for" &&
     previousSignificantToken.followsForOfLeftOperand === true
@@ -1657,6 +1693,8 @@ function javaScriptTokenAt(
   start: number,
   previousSignificantToken: JavaScriptSignificantToken | undefined,
   delimiterContexts: readonly JavaScriptDelimiterContext[] = [],
+  scanJsx = true,
+  jsxScanCache?: JavaScriptJsxScanCache,
 ): JavaScriptScannedToken | undefined {
   const commentEnd = javaScriptCommentEnd(text, start);
   if (commentEnd !== undefined) {
@@ -1667,10 +1705,23 @@ function javaScriptTokenAt(
   if (/\s/.test(character)) return { end: start + 1, kind: "trivia" };
 
   if (character === '"' || character === "'" || character === "`") {
-    const end = quotedRangeEnd(text, start, character);
+    const end = quotedRangeEnd(text, start, character, jsxScanCache);
     return end === undefined
       ? undefined
       : { end, kind: "literal", string: { start, end } };
+  }
+
+  if (
+    scanJsx && character === "<" &&
+    javaScriptJsxElementMayStart(
+      text,
+      start,
+      previousSignificantToken,
+      delimiterContexts,
+    )
+  ) {
+    const end = javaScriptJsxElementEnd(text, start, jsxScanCache);
+    return end === undefined ? undefined : { end, kind: "other" };
   }
 
   if (
@@ -1731,7 +1782,11 @@ function javaScriptLineQuoteEnd(
   if (character === "\\") return start + 2;
   if (character === state.quote) {
     state.quote = undefined;
-    state.previousSignificantToken = { end: start + 1, kind: "other" };
+    state.previousSignificantToken = javaScriptTokenWithPersistentContext(
+      start + 1,
+      "other",
+      state.previousSignificantToken,
+    );
   }
   return start + 1;
 }
@@ -1743,11 +1798,36 @@ function javaScriptLineTokenEnd(
   state: JavaScriptBalance,
 ): number | undefined {
   const character = text[start]!;
+  if (
+    character === "<" &&
+    javaScriptJsxElementMayStart(
+      text,
+      start,
+      state.previousSignificantToken,
+      state.delimiterContexts,
+    )
+  ) {
+    const end = javaScriptJsxElementEnd(text, start);
+    if (end === undefined) state.valid = false;
+    else {
+      state.previousSignificantToken = javaScriptTokenWithPersistentContext(
+        end,
+        "other",
+        state.previousSignificantToken,
+      );
+      state.templateEnd = end;
+    }
+    return end ?? lineEnd;
+  }
   if (character === "`") {
     const end = javaScriptTemplateEnd(text, start);
     if (end === undefined) state.valid = false;
     else {
-      state.previousSignificantToken = { end, kind: "other" };
+      state.previousSignificantToken = javaScriptTokenWithPersistentContext(
+        end,
+        "other",
+        state.previousSignificantToken,
+      );
       state.templateEnd = end;
     }
     return end ?? lineEnd;
@@ -1764,7 +1844,11 @@ function javaScriptLineTokenEnd(
   );
   if (updateKind !== undefined) {
     const end = start + 2;
-    state.previousSignificantToken = { end, kind: updateKind };
+    state.previousSignificantToken = javaScriptTokenWithPersistentContext(
+      end,
+      updateKind,
+      state.previousSignificantToken,
+    );
     return end;
   }
   if (
@@ -1778,7 +1862,11 @@ function javaScriptLineTokenEnd(
 
   const end = javaScriptRegexEnd(text, start);
   if (end === undefined) return undefined;
-  state.previousSignificantToken = { end, kind: "regex" };
+  state.previousSignificantToken = javaScriptTokenWithPersistentContext(
+    end,
+    "regex",
+    state.previousSignificantToken,
+  );
   return end;
 }
 
@@ -1862,9 +1950,7 @@ function scanJavaScriptLine(
     cursor++;
   }
   if (
-    javaScriptLineTerminatesRestrictedStatement(
-      state.previousSignificantToken,
-    )
+    javaScriptLineTerminatesStatement(state.previousSignificantToken)
   ) state.previousSignificantToken = undefined;
 }
 
@@ -2098,83 +2184,242 @@ interface TagSyntaxScan {
   readonly topLevelOffsets: ReadonlySet<number>;
 }
 
-interface JavaScriptJsxTag {
-  readonly closing: boolean;
-  readonly end: number;
-  readonly name: string;
-  readonly selfClosing: boolean;
+function javaScriptJsxTagStartsAt(text: string, start: number): boolean {
+  const next = text[start + 1];
+  if (next === "/") {
+    return text[start + 2] === ">" ||
+      /[A-Za-z_$]/.test(text[start + 2] ?? "");
+  }
+  return next === ">" || /[A-Za-z_$]/.test(next ?? "");
 }
 
-function javaScriptJsxTagAt(
+function javaScriptJsxElementMayStart(
   text: string,
   start: number,
-): JavaScriptJsxTag | undefined {
-  if (text.startsWith("<>", start)) {
-    return { closing: false, end: start + 2, name: "", selfClosing: false };
-  }
-  if (text.startsWith("</>", start)) {
-    return { closing: true, end: start + 3, name: "", selfClosing: false };
-  }
+  previousSignificantToken: JavaScriptSignificantToken | undefined,
+  delimiterContexts: readonly JavaScriptDelimiterContext[],
+): boolean {
+  return text[start + 1] !== "/" && javaScriptJsxTagStartsAt(text, start) &&
+    javaScriptRegexMayStart(
+      text,
+      previousSignificantToken,
+      delimiterContexts,
+    );
+}
 
-  const closing = text.startsWith("</", start);
+interface JavaScriptJsxTagFrame {
+  readonly closing: boolean;
+  readonly kind: "tag";
+  readonly name: string;
+  readonly start: number;
+  lastNonWhitespace?: string;
+  quote?: JavaScriptQuote;
+}
+
+interface JavaScriptJsxChildrenFrame {
+  readonly kind: "children";
+  readonly name: string;
+  readonly start: number;
+}
+
+interface JavaScriptJsxExpressionFrame {
+  readonly delimiterContexts: JavaScriptDelimiterContext[];
+  depth: number;
+  readonly kind: "expression";
+  previousSignificantToken: JavaScriptSignificantToken | undefined;
+}
+
+type JavaScriptJsxFrame =
+  | JavaScriptJsxChildrenFrame
+  | JavaScriptJsxExpressionFrame
+  | JavaScriptJsxTagFrame;
+
+function javaScriptJsxTagFrameAt(
+  text: string,
+  start: number,
+): { readonly frame: JavaScriptJsxTagFrame; readonly end: number } | undefined {
+  if (!javaScriptJsxTagStartsAt(text, start)) return undefined;
+  const closing = text[start + 1] === "/";
   const nameStart = start + (closing ? 2 : 1);
   const nameEnd = mdxJsxNameEnd(text, nameStart);
-  if (nameEnd === undefined) return undefined;
-  const name = text.slice(nameStart, nameEnd);
-  if (!closing) {
-    const end = mdxJsxTagEnd(text, start);
-    if (end === undefined) return undefined;
-    return {
-      closing: false,
-      end,
-      name,
-      selfClosing: text[end - 2] === "/",
-    };
-  }
-  const end = skipJavaScriptTrivia(text, nameEnd);
-  return text[end] === ">"
-    ? { closing: true, end: end + 1, name, selfClosing: false }
-    : undefined;
+  const fragment = text[nameStart] === ">";
+  if (nameEnd === undefined && !fragment) return undefined;
+  return {
+    end: nameEnd ?? nameStart,
+    frame: {
+      closing,
+      kind: "tag",
+      name: fragment ? "" : text.slice(nameStart, nameEnd),
+      start,
+    },
+  };
 }
 
 function javaScriptJsxElementEnd(
   text: string,
   start: number,
+  jsxScanCache?: JavaScriptJsxScanCache,
 ): number | undefined {
-  const opening = javaScriptJsxTagAt(text, start);
-  if (opening === undefined) return undefined;
-  if (opening.closing || opening.selfClosing) return opening.end;
+  if (jsxScanCache?.has(start)) return jsxScanCache.get(start);
+  const root = javaScriptJsxTagFrameAt(text, start);
+  if (root === undefined || root.frame.closing) {
+    jsxScanCache?.set(start, undefined);
+    return undefined;
+  }
 
-  const elementNames = [opening.name];
-  let cursor = opening.end;
-  while (cursor < text.length) {
-    if (text[cursor] === "{") {
-      const expression = mdxExpressionAt(text, cursor);
-      if (expression !== undefined) {
-        cursor = expression.expression.end;
-        continue;
+  const frames: JavaScriptJsxFrame[] = [root.frame];
+  const fail = (): undefined => {
+    jsxScanCache?.set(start, undefined);
+    for (const frame of frames) {
+      if (frame.kind !== "expression" && !jsxScanCache?.has(frame.start)) {
+        jsxScanCache?.set(frame.start, undefined);
       }
     }
-    if (text[cursor] !== "<") {
+    return undefined;
+  };
+  let cursor = root.end;
+  while (cursor < text.length) {
+    const frame = frames.at(-1)!;
+    const character = text[cursor]!;
+
+    if (frame.kind === "tag") {
+      if (frame.quote !== undefined) {
+        if (character === frame.quote) frame.quote = undefined;
+        cursor++;
+        continue;
+      }
+      if (character === '"' || character === "'") {
+        if (frame.closing) return fail();
+        frame.lastNonWhitespace = character;
+        frame.quote = character;
+        cursor++;
+        continue;
+      }
+      if (/\s/.test(character)) {
+        cursor++;
+        continue;
+      }
+      if (character === "{") {
+        if (frame.closing) return fail();
+        frame.lastNonWhitespace = character;
+        frames.push({
+          delimiterContexts: ["nested"],
+          depth: 1,
+          kind: "expression",
+          previousSignificantToken: undefined,
+        });
+        cursor++;
+        continue;
+      }
+      if (character !== ">") {
+        if (frame.closing) return fail();
+        frame.lastNonWhitespace = character;
+        cursor++;
+        continue;
+      }
+
+      frames.pop();
       cursor++;
+      if (frame.closing) {
+        if (frame.lastNonWhitespace !== undefined) return fail();
+        const children = frames.at(-1);
+        if (children?.kind !== "children" || children.name !== frame.name) {
+          return fail();
+        }
+        frames.pop();
+        jsxScanCache?.set(children.start, cursor);
+      } else if (frame.lastNonWhitespace !== "/") {
+        frames.push({ kind: "children", name: frame.name, start: frame.start });
+        continue;
+      } else {
+        jsxScanCache?.set(frame.start, cursor);
+      }
+
+      if (frames.length === 0) {
+        jsxScanCache?.set(start, cursor);
+        return cursor;
+      }
+      const parent = frames.at(-1)!;
+      if (parent.kind === "expression") {
+        parent.previousSignificantToken = javaScriptTokenWithPersistentContext(
+          cursor,
+          "other",
+          parent.previousSignificantToken,
+        );
+      }
       continue;
     }
 
-    const tag = javaScriptJsxTagAt(text, cursor);
-    if (tag === undefined) {
-      cursor++;
+    if (frame.kind === "children") {
+      if (character === "<") {
+        const tag = javaScriptJsxTagFrameAt(text, cursor);
+        if (tag === undefined) return fail();
+        frames.push(tag.frame);
+        cursor = tag.end;
+      } else if (character === "{") {
+        frames.push({
+          delimiterContexts: ["nested"],
+          depth: 1,
+          kind: "expression",
+          previousSignificantToken: undefined,
+        });
+        cursor++;
+      } else {
+        cursor++;
+      }
       continue;
     }
-    if (tag.closing) {
-      if (elementNames.at(-1) !== tag.name) return undefined;
-      elementNames.pop();
-      if (elementNames.length === 0) return tag.end;
-    } else if (!tag.selfClosing) {
-      elementNames.push(tag.name);
+
+    if (
+      character === "<" &&
+      javaScriptJsxElementMayStart(
+        text,
+        cursor,
+        frame.previousSignificantToken,
+        frame.delimiterContexts,
+      )
+    ) {
+      const tag = javaScriptJsxTagFrameAt(text, cursor);
+      if (tag === undefined || tag.frame.closing) return fail();
+      frames.push(tag.frame);
+      cursor = tag.end;
+      continue;
     }
-    cursor = tag.end;
+
+    const token = javaScriptTokenAt(
+      text,
+      cursor,
+      frame.previousSignificantToken,
+      frame.delimiterContexts,
+      false,
+      jsxScanCache,
+    );
+    if (token === undefined) return fail();
+    if (token.kind === "trivia") {
+      frame.previousSignificantToken =
+        javaScriptPreviousSignificantTokenAfterTrivia(
+          text,
+          cursor,
+          token.end,
+          frame.previousSignificantToken,
+        );
+      cursor = token.end;
+      continue;
+    }
+    frame.previousSignificantToken = significantJavaScriptToken(
+      text,
+      cursor,
+      token,
+      frame.previousSignificantToken,
+      frame.delimiterContexts,
+    );
+    if (token.kind === "other") {
+      if (character === "{") frame.depth++;
+      else if (character === "}" && --frame.depth === 0) frames.pop();
+    }
+    cursor = token.end;
   }
-  return undefined;
+  return fail();
 }
 
 function scanTagSyntax(
@@ -2195,7 +2440,11 @@ function scanTagSyntax(
       else if (character === quote) {
         quote = undefined;
         if (expressionDepth > 0) {
-          previousSignificantToken = { end: cursor + 1, kind: "other" };
+          previousSignificantToken = javaScriptTokenWithPersistentContext(
+            cursor + 1,
+            "other",
+            previousSignificantToken,
+          );
         }
         quoteUsesJavaScriptEscapes = false;
         cursor++;
@@ -2217,17 +2466,25 @@ function scanTagSyntax(
       cursor = commentEnd;
       continue;
     }
-    const jsxTagEnd = expressionDepth > 0 && character === "<" &&
-        javaScriptRegexMayStart(
-          text,
-          previousSignificantToken,
-          delimiterContexts,
-        )
-      ? javaScriptJsxElementEnd(text, cursor)
-      : undefined;
-    if (jsxTagEnd !== undefined) {
-      previousSignificantToken = { end: jsxTagEnd, kind: "other" };
-      cursor = jsxTagEnd;
+    if (
+      expressionDepth > 0 && character === "<" &&
+      javaScriptJsxElementMayStart(
+        text,
+        cursor,
+        previousSignificantToken,
+        delimiterContexts,
+      )
+    ) {
+      const jsxElementEnd = javaScriptJsxElementEnd(text, cursor);
+      if (jsxElementEnd === undefined) {
+        return { end: undefined, topLevelOffsets };
+      }
+      previousSignificantToken = javaScriptTokenWithPersistentContext(
+        jsxElementEnd,
+        "other",
+        previousSignificantToken,
+      );
+      cursor = jsxElementEnd;
       continue;
     }
     const updateKind = expressionDepth > 0
@@ -2240,7 +2497,11 @@ function scanTagSyntax(
       : undefined;
     if (updateKind !== undefined) {
       cursor += 2;
-      previousSignificantToken = { end: cursor, kind: updateKind };
+      previousSignificantToken = javaScriptTokenWithPersistentContext(
+        cursor,
+        updateKind,
+        previousSignificantToken,
+      );
       continue;
     }
     if (
@@ -2253,7 +2514,11 @@ function scanTagSyntax(
     ) {
       const regexEnd = javaScriptRegexEnd(text, cursor);
       if (regexEnd !== undefined) {
-        previousSignificantToken = { end: regexEnd, kind: "regex" };
+        previousSignificantToken = javaScriptTokenWithPersistentContext(
+          regexEnd,
+          "regex",
+          previousSignificantToken,
+        );
         cursor = regexEnd;
         continue;
       }
@@ -2267,7 +2532,11 @@ function scanTagSyntax(
     if (character === "`" && expressionDepth > 0) {
       const templateEnd = javaScriptTemplateEnd(text, cursor);
       if (templateEnd !== undefined) {
-        previousSignificantToken = { end: templateEnd, kind: "other" };
+        previousSignificantToken = javaScriptTokenWithPersistentContext(
+          templateEnd,
+          "other",
+          previousSignificantToken,
+        );
         cursor = templateEnd;
         continue;
       }
@@ -2345,7 +2614,11 @@ function mdxJsxNameEnd(text: string, start: number): number | undefined {
   return cursor;
 }
 
-function mdxJsxTagEnd(text: string, start: number): number | undefined {
+function mdxJsxTagEnd(
+  text: string,
+  start: number,
+  jsxScanCache?: JavaScriptJsxScanCache,
+): number | undefined {
   if (text[start] !== "<") return undefined;
   let cursor = mdxJsxNameEnd(text, start + 1);
   if (cursor === undefined) return undefined;
@@ -2357,7 +2630,7 @@ function mdxJsxTagEnd(text: string, start: number): number | undefined {
     if (text[cursor] === ">") return cursor + 1;
     if (cursor === attributeSeparatorStart) return undefined;
     if (text[cursor] === "{") {
-      const expression = mdxExpressionAt(text, cursor);
+      const expression = mdxExpressionAt(text, cursor, jsxScanCache);
       if (expression === undefined) return undefined;
       const spreadStart = skipJavaScriptTrivia(text, cursor + 1);
       if (!text.startsWith("...", spreadStart)) return undefined;
@@ -2380,7 +2653,7 @@ function mdxJsxTagEnd(text: string, start: number): number | undefined {
       continue;
     }
     if (text[cursor] !== "{") return undefined;
-    const expression = mdxExpressionAt(text, cursor);
+    const expression = mdxExpressionAt(text, cursor, jsxScanCache);
     if (expression === undefined) return undefined;
     cursor = expression.expression.end;
   }
@@ -2394,6 +2667,7 @@ function htmlTagRanges(
   stringRanges: readonly Range[] = [],
 ): Range[] {
   const ranges: Range[] = [];
+  const jsxScanCache: JavaScriptJsxScanCache = new Map();
   for (let start = 0; start < text.length;) {
     start = text.indexOf("<", start);
     if (start === -1) break;
@@ -2410,7 +2684,7 @@ function htmlTagRanges(
     }
 
     const commonMarkEnd = commonMarkHtmlTagEnd(text, start);
-    const mdxJsxEnd = mdxJsxTagEnd(text, start);
+    const mdxJsxEnd = mdxJsxTagEnd(text, start, jsxScanCache);
     const tagEnd = commonMarkEnd === undefined
       ? mdxJsxEnd
       : mdxJsxEnd === undefined

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -1046,6 +1046,7 @@ function significantJavaScriptToken(
   if (token.kind === "other") {
     kind = javaScriptDelimiterTokenKind(
       text,
+      start,
       text[start]!,
       previousSignificantToken,
       delimiterContexts,
@@ -1349,6 +1350,7 @@ interface JavaScriptBalance {
   readonly delimiterContexts: JavaScriptDelimiterContext[];
   quote: JavaScriptQuote | undefined;
   blockComment: boolean;
+  moduleDeclaration: boolean;
   templateEnd: number;
   previousSignificantToken: JavaScriptSignificantToken | undefined;
   valid: boolean;
@@ -1536,7 +1538,7 @@ function javaScriptLineTerminatesStatement(
   const finalWord = token.identifierWord;
   if (
     finalWord === "break" || finalWord === "continue" ||
-    finalWord === "debugger"
+    finalWord === "debugger" || finalWord === "return"
   ) return true;
   return token.precedingIdentifierKeyword === "break" ||
     token.precedingIdentifierKeyword === "continue";
@@ -1572,6 +1574,7 @@ function javaScriptTokenMayEndForOfLeftOperand(
 
 function javaScriptDelimiterTokenKind(
   text: string,
+  start: number,
   character: string,
   previousSignificantToken: JavaScriptSignificantToken | undefined,
   delimiterContexts: JavaScriptDelimiterContext[],
@@ -1636,6 +1639,11 @@ function javaScriptDelimiterTokenKind(
     if (context === "control" || context === "for") return "control-header";
     if (context === "function-declaration") return "declaration-header";
     if (context === "function-expression") return "expression-header";
+    if (
+      character === ")" && context === undefined &&
+      previousSignificantToken?.classDeclarationDepth === undefined &&
+      text[skipJavaScriptTrivia(text, start + 1)] === "{"
+    ) return "expression-header";
     if (context === "block") return "statement-block";
   }
   return "other";
@@ -1884,6 +1892,7 @@ const JAVASCRIPT_DELIMITER_CLOSERS: Readonly<Record<string, string>> = {
 
 function recordJavaScriptDelimiter(
   text: string,
+  start: number,
   character: string,
   previousSignificantToken: JavaScriptSignificantToken | undefined,
   state: JavaScriptBalance,
@@ -1892,6 +1901,7 @@ function recordJavaScriptDelimiter(
     state.delimiters.push(character);
     return javaScriptDelimiterTokenKind(
       text,
+      start,
       character,
       previousSignificantToken,
       state.delimiterContexts,
@@ -1906,6 +1916,7 @@ function recordJavaScriptDelimiter(
   state.delimiters.pop();
   return javaScriptDelimiterTokenKind(
     text,
+    start,
     character,
     previousSignificantToken,
     state.delimiterContexts,
@@ -1918,6 +1929,13 @@ function scanJavaScriptLine(
   lineEnd: number,
   state: JavaScriptBalance,
 ): void {
+  if (
+    state.delimiters.length === 0 && state.quote === undefined &&
+    !state.blockComment &&
+    /^(?:import\b(?!\s*[.(])|export\b\s*(?:\{|\*))/.test(
+      text.slice(lineStart, lineEnd),
+    )
+  ) state.moduleDeclaration = true;
   let cursor = Math.max(lineStart, state.templateEnd);
   while (cursor < lineEnd) {
     const commentEnd = javaScriptLineCommentEnd(text, cursor, lineEnd, state);
@@ -1939,6 +1957,7 @@ function scanJavaScriptLine(
     if (!/\s/.test(character)) {
       const kind = recordJavaScriptDelimiter(
         text,
+        cursor,
         character,
         state.previousSignificantToken,
         state,
@@ -1955,9 +1974,14 @@ function scanJavaScriptLine(
     }
     cursor++;
   }
+  const moduleDeclarationEnded = state.moduleDeclaration &&
+    state.delimiters.length === 0 && state.quote === undefined &&
+    !state.blockComment && state.templateEnd <= lineEnd;
   if (
+    moduleDeclarationEnded ||
     javaScriptLineTerminatesStatement(state.previousSignificantToken)
   ) state.previousSignificantToken = undefined;
+  if (moduleDeclarationEnded) state.moduleDeclaration = false;
 }
 
 function mdxEsmRangeEnd(text: string, start: number): number | undefined {
@@ -1966,6 +1990,7 @@ function mdxEsmRangeEnd(text: string, start: number): number | undefined {
     delimiterContexts: [],
     quote: undefined,
     blockComment: false,
+    moduleDeclaration: false,
     templateEnd: start,
     previousSignificantToken: undefined,
     valid: true,
@@ -2563,6 +2588,7 @@ function scanTagSyntax(
     if (expressionDepth > 0) {
       const kind = javaScriptDelimiterTokenKind(
         text,
+        cursor,
         character,
         previousSignificantToken,
         delimiterContexts,

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -1080,6 +1080,8 @@ const JAVASCRIPT_REGEX_PREFIX_KEYWORDS: ReadonlySet<string> = new Set([
 ]);
 
 const JAVASCRIPT_IDENTIFIER_CONTINUE = /[$\u200C\u200D\p{ID_Continue}]/u;
+const JAVASCRIPT_IDENTIFIER_ESCAPE =
+  /\\u(?:([0-9A-Fa-f]{4})|\{([0-9A-Fa-f]{1,6})\})$/;
 
 function javaScriptCodePointBefore(
   text: string,
@@ -1091,6 +1093,27 @@ function javaScriptCodePointBefore(
     trailing <= 0xDFFF && text.charCodeAt(end - 2) >= 0xD800 &&
     text.charCodeAt(end - 2) <= 0xDBFF;
   return text.slice(end - (startsWithSurrogatePair ? 2 : 1), end);
+}
+
+function javaScriptIdentifierContinueBefore(
+  text: string,
+  end: number,
+): boolean {
+  const escapeMatch = JAVASCRIPT_IDENTIFIER_ESCAPE.exec(
+    text.slice(Math.max(0, end - 10), end),
+  );
+  if (escapeMatch !== null) {
+    const codePoint = Number.parseInt(
+      escapeMatch[1] ?? escapeMatch[2] ?? "",
+      16,
+    );
+    return codePoint <= 0x10ffff &&
+      JAVASCRIPT_IDENTIFIER_CONTINUE.test(String.fromCodePoint(codePoint));
+  }
+
+  const codePoint = javaScriptCodePointBefore(text, end);
+  return codePoint !== undefined &&
+    JAVASCRIPT_IDENTIFIER_CONTINUE.test(codePoint);
 }
 
 function javaScriptRegexMayStart(
@@ -1115,7 +1138,7 @@ function javaScriptRegexMayStart(
   const preceding = javaScriptCodePointBefore(text, wordStart);
   return preceding === undefined ||
     (preceding !== "." && preceding !== "#" &&
-      !JAVASCRIPT_IDENTIFIER_CONTINUE.test(preceding));
+      !javaScriptIdentifierContinueBefore(text, wordStart));
 }
 
 function javaScriptUpdateKind(

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -782,7 +782,8 @@ interface JavaScriptSignificantToken {
   readonly end: number;
   readonly kind: JavaScriptSignificantTokenKind;
   readonly followsForKeyword?: true;
-  readonly insideForHeader?: true;
+  readonly forOfSeparator?: true;
+  readonly forOfSeparatorCandidate?: true;
   readonly lineTerminatedStatement?: true;
 }
 
@@ -819,18 +820,38 @@ function javaScriptTokenWithIdentifierContext(
   }
 
   const word = javaScriptIdentifierWordAtEnd(text, end);
-  const lineTerminatedStatement = (word !== undefined &&
-    JAVASCRIPT_LINE_TERMINATED_STATEMENT_KEYWORDS.has(word)) ||
-    previousSignificantToken?.lineTerminatedStatement === true;
+  const completeIdentifier = word !== undefined &&
+    !javaScriptIdentifierContinueAt(text, end);
+  let forOfSeparatorCandidate = false;
+  if (continuesIdentifierWord) {
+    forOfSeparatorCandidate =
+      previousSignificantToken?.forOfSeparatorCandidate === true;
+  } else if (insideForHeader && previousSignificantToken !== undefined) {
+    const precedingWord = javaScriptIdentifierWordAtEnd(
+      text,
+      previousSignificantToken.end,
+    );
+    forOfSeparatorCandidate =
+      !JAVASCRIPT_FOR_DECLARATION_KEYWORDS.has(precedingWord ?? "") &&
+      !javaScriptRegexMayStart(text, start, previousSignificantToken);
+  }
+  const forOfSeparator = completeIdentifier && word === "of" &&
+    forOfSeparatorCandidate;
+  const lineTerminatedStatement = completeIdentifier &&
+    JAVASCRIPT_LINE_TERMINATED_STATEMENT_KEYWORDS.has(word);
   const contextualToken: {
     end: number;
     kind: JavaScriptSignificantTokenKind;
     followsForKeyword?: true;
-    insideForHeader?: true;
+    forOfSeparator?: true;
+    forOfSeparatorCandidate?: true;
     lineTerminatedStatement?: true;
   } = { end, kind };
   if (followsForKeyword) contextualToken.followsForKeyword = true;
-  if (insideForHeader) contextualToken.insideForHeader = true;
+  if (forOfSeparator) contextualToken.forOfSeparator = true;
+  if (forOfSeparatorCandidate && !completeIdentifier) {
+    contextualToken.forOfSeparatorCandidate = true;
+  }
   if (lineTerminatedStatement) {
     contextualToken.lineTerminatedStatement = true;
   }
@@ -1163,6 +1184,7 @@ const JAVASCRIPT_REGEX_PREFIX_KEYWORDS: ReadonlySet<string> = new Set([
   "yield",
   "else",
   "do",
+  "extends",
 ]);
 
 const JAVASCRIPT_CONTROL_HEADER_KEYWORDS: ReadonlySet<string> = new Set([
@@ -1179,9 +1201,18 @@ const JAVASCRIPT_LINE_TERMINATED_STATEMENT_KEYWORDS: ReadonlySet<string> =
     "debugger",
   ]);
 
+const JAVASCRIPT_FOR_DECLARATION_KEYWORDS: ReadonlySet<string> = new Set([
+  "const",
+  "let",
+  "using",
+  "var",
+]);
+
 const JAVASCRIPT_IDENTIFIER_CONTINUE = /[$\u200C\u200D\p{ID_Continue}]/u;
 const JAVASCRIPT_IDENTIFIER_ESCAPE =
   /\\u(?:([0-9A-Fa-f]{4})|\{([0-9A-Fa-f]{1,6})\})$/;
+const JAVASCRIPT_IDENTIFIER_ESCAPE_AT =
+  /^\\u(?:([0-9A-Fa-f]{4})|\{([0-9A-Fa-f]{1,6})\})/;
 
 function javaScriptCodePointBefore(
   text: string,
@@ -1213,6 +1244,27 @@ function javaScriptIdentifierContinueBefore(
   const codePoint = javaScriptCodePointBefore(text, end);
   return codePoint !== undefined &&
     JAVASCRIPT_IDENTIFIER_CONTINUE.test(codePoint);
+}
+
+function javaScriptIdentifierContinueAt(
+  text: string,
+  start: number,
+): boolean {
+  const escapeMatch = JAVASCRIPT_IDENTIFIER_ESCAPE_AT.exec(
+    text.slice(start, start + 10),
+  );
+  if (escapeMatch !== null) {
+    const codePoint = Number.parseInt(
+      escapeMatch[1] ?? escapeMatch[2] ?? "",
+      16,
+    );
+    return codePoint <= 0x10ffff &&
+      JAVASCRIPT_IDENTIFIER_CONTINUE.test(String.fromCodePoint(codePoint));
+  }
+
+  const codePoint = text.codePointAt(start);
+  return codePoint !== undefined &&
+    JAVASCRIPT_IDENTIFIER_CONTINUE.test(String.fromCodePoint(codePoint));
 }
 
 function javaScriptIdentifierWordAtEnd(
@@ -1289,7 +1341,7 @@ function javaScriptRegexMayStart(
   const keyword = javaScriptIdentifierWordAtEnd(text, end);
   return keyword !== undefined &&
     (JAVASCRIPT_REGEX_PREFIX_KEYWORDS.has(keyword) ||
-      (keyword === "of" && previousSignificantToken.insideForHeader === true));
+      (keyword === "of" && previousSignificantToken.forOfSeparator === true));
 }
 
 function javaScriptUpdateKind(

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -785,6 +785,7 @@ type JavaScriptSignificantTokenKind =
   | "postfix-update"
   | "prefix-update"
   | "regex"
+  | "statement-label"
   | "statement-block";
 
 type JavaScriptPrecedingIdentifierKeyword =
@@ -814,6 +815,7 @@ interface JavaScriptSignificantToken {
   readonly identifierStart?: number;
   readonly identifierWord?: string;
   readonly kind: JavaScriptSignificantTokenKind;
+  readonly labelCandidate?: true;
   readonly followsForOfLeftOperand?: true;
   readonly precedingIdentifierKeyword?: JavaScriptPrecedingIdentifierKeyword;
   readonly uninitializedDeclaration?: true;
@@ -957,6 +959,7 @@ function javaScriptTokenWithIdentifierContext(
         declarationCandidate ||
       identifierWord === "default" &&
         previousSignificantToken?.declarationPrefix === true);
+  const labelCandidate = completeIdentifier && declarationCandidate;
   const functionDeclaration =
     previousSignificantToken?.functionDeclaration === true ||
     (completeIdentifier && identifierWord === "function" &&
@@ -1023,6 +1026,7 @@ function javaScriptTokenWithIdentifierContext(
     ...(identifierStart === undefined ? {} : { identifierStart }),
     ...(identifierWord === undefined ? {} : { identifierWord }),
     kind,
+    ...(labelCandidate ? { labelCandidate: true } : {}),
     ...(followsForOfLeftOperand ? { followsForOfLeftOperand: true } : {}),
     ...(precedingIdentifierKeyword === undefined
       ? {}
@@ -1520,6 +1524,7 @@ function javaScriptMayStartDeclaration(
     delimiterContexts.at(-1) !== "expression-block"
   ) return false;
   if (token === undefined) return true;
+  if (token.kind === "statement-label") return true;
   if (token.declarationPrefix === true) return true;
   const word = token.identifierWord;
   if (word === "export") return true;
@@ -1621,6 +1626,8 @@ function javaScriptDelimiterTokenKind(
     const statementBlock = !expressionBlock && (classDeclarationBody ||
       previousSignificantToken?.kind === "control-header" ||
       previousSignificantToken?.kind === "declaration-header" ||
+      previousSignificantToken?.kind === "statement-label" ||
+      keyword === "static" ||
       (keyword !== undefined &&
         JAVASCRIPT_BLOCK_PREFIX_KEYWORDS.has(keyword)) ||
       (statementPosition &&
@@ -1634,6 +1641,10 @@ function javaScriptDelimiterTokenKind(
         ? "block"
         : "nested",
     );
+  } else if (
+    character === ":" && previousSignificantToken?.labelCandidate === true
+  ) {
+    return "statement-label";
   } else if (character === ")" || character === "]" || character === "}") {
     const context = delimiterContexts.pop();
     if (context === "control" || context === "for") return "control-header";

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -1088,11 +1088,10 @@ function javaScriptCodePointBefore(
   end: number,
 ): string | undefined {
   if (end <= 0) return undefined;
-  const trailing = text.charCodeAt(end - 1);
-  const startsWithSurrogatePair = end > 1 && trailing >= 0xDC00 &&
-    trailing <= 0xDFFF && text.charCodeAt(end - 2) >= 0xD800 &&
-    text.charCodeAt(end - 2) <= 0xDBFF;
-  return text.slice(end - (startsWithSurrogatePair ? 2 : 1), end);
+  const precedingCodePoint = text.codePointAt(end - 2);
+  const usesSurrogatePair = precedingCodePoint !== undefined &&
+    precedingCodePoint > 0xffff;
+  return text.slice(end - (usesSurrogatePair ? 2 : 1), end);
 }
 
 function javaScriptIdentifierContinueBefore(

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -773,6 +773,11 @@ interface MdxSyntaxRanges {
   readonly strings: Range[];
 }
 
+interface JavaScriptSignificantToken {
+  readonly end: number;
+  readonly kind: "other" | "regex";
+}
+
 function quotedRangeEnd(
   text: string,
   start: number,
@@ -814,8 +819,7 @@ function javaScriptTemplateInterpolationEnd(
 ): number | undefined {
   let depth = 1;
   let cursor = start + 2;
-  let previousSignificantEnd: number | undefined;
-  let previousTokenWasRegex = false;
+  let previousSignificantToken: JavaScriptSignificantToken | undefined;
   while (cursor < text.length) {
     const commentEnd = javaScriptCommentEnd(text, cursor);
     if (commentEnd !== undefined) {
@@ -826,31 +830,24 @@ function javaScriptTemplateInterpolationEnd(
     if (character === '"' || character === "'") {
       const end = quotedRangeEnd(text, cursor, character);
       if (end === undefined) return undefined;
-      previousSignificantEnd = end;
-      previousTokenWasRegex = false;
+      previousSignificantToken = { end, kind: "other" };
       cursor = end;
       continue;
     }
     if (character === "`") {
       const end = javaScriptTemplateEnd(text, cursor);
       if (end === undefined) return undefined;
-      previousSignificantEnd = end;
-      previousTokenWasRegex = false;
+      previousSignificantToken = { end, kind: "other" };
       cursor = end;
       continue;
     }
     if (
       character === "/" &&
-      javaScriptRegexMayStart(
-        text,
-        previousSignificantEnd,
-        previousTokenWasRegex,
-      )
+      javaScriptRegexMayStart(text, previousSignificantToken)
     ) {
       const regexEnd = javaScriptRegexEnd(text, cursor);
       if (regexEnd !== undefined) {
-        previousSignificantEnd = regexEnd;
-        previousTokenWasRegex = true;
+        previousSignificantToken = { end: regexEnd, kind: "regex" };
         cursor = regexEnd;
         continue;
       }
@@ -859,10 +856,9 @@ function javaScriptTemplateInterpolationEnd(
       cursor++;
       continue;
     }
-    previousTokenWasRegex = false;
+    previousSignificantToken = { end: cursor + 1, kind: "other" };
     if (character === "{") depth++;
     else if (character === "}" && --depth === 0) return cursor + 1;
-    previousSignificantEnd = cursor + 1;
     cursor++;
   }
   return undefined;
@@ -938,8 +934,7 @@ function mdxExpressionAt(
   const strings: Range[] = [];
   let depth = 1;
   let cursor = start + 1;
-  let previousSignificantEnd: number | undefined;
-  let previousTokenWasRegex = false;
+  let previousSignificantToken: JavaScriptSignificantToken | undefined;
   while (cursor < text.length) {
     const commentEnd = javaScriptCommentEnd(text, cursor);
     if (commentEnd !== undefined) {
@@ -951,8 +946,7 @@ function mdxExpressionAt(
       const end = javaScriptTemplateEnd(text, cursor);
       if (end === undefined) return undefined;
       strings.push({ start: cursor, end });
-      previousSignificantEnd = end;
-      previousTokenWasRegex = false;
+      previousSignificantToken = { end, kind: "other" };
       cursor = end;
       continue;
     }
@@ -960,23 +954,17 @@ function mdxExpressionAt(
       const end = quotedRangeEnd(text, cursor, character);
       if (end === undefined) return undefined;
       strings.push({ start: cursor, end });
-      previousSignificantEnd = end;
-      previousTokenWasRegex = false;
+      previousSignificantToken = { end, kind: "other" };
       cursor = end;
       continue;
     }
     if (
       character === "/" &&
-      javaScriptRegexMayStart(
-        text,
-        previousSignificantEnd,
-        previousTokenWasRegex,
-      )
+      javaScriptRegexMayStart(text, previousSignificantToken)
     ) {
       const regexEnd = javaScriptRegexEnd(text, cursor);
       if (regexEnd !== undefined) {
-        previousSignificantEnd = regexEnd;
-        previousTokenWasRegex = true;
+        previousSignificantToken = { end: regexEnd, kind: "regex" };
         cursor = regexEnd;
         continue;
       }
@@ -985,12 +973,11 @@ function mdxExpressionAt(
       cursor++;
       continue;
     }
-    previousTokenWasRegex = false;
+    previousSignificantToken = { end: cursor + 1, kind: "other" };
     if (character === "{") depth++;
     else if (character === "}" && --depth === 0) {
       return { expression: { start, end: cursor + 1 }, strings };
     }
-    previousSignificantEnd = cursor + 1;
     cursor++;
   }
   return undefined;
@@ -1075,8 +1062,7 @@ interface JavaScriptBalance {
   quote: '"' | "'" | undefined;
   blockComment: boolean;
   templateEnd: number;
-  previousSignificantEnd: number | undefined;
-  previousTokenWasRegex: boolean;
+  previousSignificantToken: JavaScriptSignificantToken | undefined;
   valid: boolean;
 }
 
@@ -1117,19 +1103,17 @@ const JAVASCRIPT_REGEX_PREFIX_KEYWORDS: ReadonlySet<string> = new Set([
 
 function javaScriptRegexMayStart(
   text: string,
-  previousSignificantEnd: number | undefined,
-  previousTokenWasRegex: boolean,
+  previousSignificantToken: JavaScriptSignificantToken | undefined,
 ): boolean {
-  if (previousTokenWasRegex) return false;
-  if (previousSignificantEnd === undefined) return true;
+  if (previousSignificantToken === undefined) return true;
+  if (previousSignificantToken.kind === "regex") return false;
+  const end = previousSignificantToken.end;
 
-  if (
-    "=(:,![{;?&|+*%/^~<>-".includes(text[previousSignificantEnd - 1]!)
-  ) return true;
+  if ("=(:,![{;?&|+*%/^~<>-".includes(text[end - 1]!)) return true;
 
-  let wordStart = previousSignificantEnd;
+  let wordStart = end;
   while (wordStart > 0 && /[A-Za-z]/.test(text[wordStart - 1]!)) wordStart--;
-  const keyword = text.slice(wordStart, previousSignificantEnd);
+  const keyword = text.slice(wordStart, end);
   if (!JAVASCRIPT_REGEX_PREFIX_KEYWORDS.has(keyword)) return false;
 
   return wordStart === 0 ||
@@ -1147,7 +1131,6 @@ function scanJavaScriptLine(
     "]": "[",
     "}": "{",
   };
-  const line = text.slice(lineStart, lineEnd);
   for (
     let cursor = Math.max(lineStart, state.templateEnd);
     cursor < lineEnd;
@@ -1165,8 +1148,7 @@ function scanJavaScriptLine(
       if (character === "\\") cursor++;
       else if (character === state.quote) {
         state.quote = undefined;
-        state.previousSignificantEnd = cursor + 1;
-        state.previousTokenWasRegex = false;
+        state.previousSignificantToken = { end: cursor + 1, kind: "other" };
       }
       continue;
     }
@@ -1182,37 +1164,28 @@ function scanJavaScriptLine(
         state.valid = false;
         return;
       }
-      state.previousSignificantEnd = templateEnd;
-      state.previousTokenWasRegex = false;
+      state.previousSignificantToken = { end: templateEnd, kind: "other" };
       state.templateEnd = templateEnd;
       cursor = templateEnd - 1;
       continue;
     }
     if (character === '"' || character === "'") {
-      state.previousTokenWasRegex = false;
       state.quote = character;
       continue;
     }
-    const lineCursor = cursor - lineStart;
     if (
       character === "/" &&
-      javaScriptRegexMayStart(
-        text,
-        state.previousSignificantEnd,
-        state.previousTokenWasRegex,
-      )
+      javaScriptRegexMayStart(text, state.previousSignificantToken)
     ) {
-      const regexEnd = javaScriptRegexEnd(line, lineCursor);
+      const regexEnd = javaScriptRegexEnd(text, cursor);
       if (regexEnd !== undefined) {
-        state.previousSignificantEnd = lineStart + regexEnd;
-        state.previousTokenWasRegex = true;
-        cursor = lineStart + regexEnd - 1;
+        state.previousSignificantToken = { end: regexEnd, kind: "regex" };
+        cursor = regexEnd - 1;
         continue;
       }
     }
     if (/\s/.test(character)) continue;
-    state.previousTokenWasRegex = false;
-    state.previousSignificantEnd = cursor + 1;
+    state.previousSignificantToken = { end: cursor + 1, kind: "other" };
     if (character === "(" || character === "[" || character === "{") {
       state.delimiters.push(character);
       continue;
@@ -1233,8 +1206,7 @@ function mdxEsmRangeEnd(text: string, start: number): number | undefined {
     quote: undefined,
     blockComment: false,
     templateEnd: start,
-    previousSignificantEnd: undefined,
-    previousTokenWasRegex: false,
+    previousSignificantToken: undefined,
     valid: true,
   };
   for (let lineStart = start; lineStart <= text.length;) {
@@ -1450,17 +1422,15 @@ function scanTagSyntax(
   let quote: '"' | "'" | undefined;
   let quoteUsesJavaScriptEscapes = false;
   let expressionDepth = 0;
-  let previousSignificantEnd: number | undefined;
-  let previousTokenWasRegex = false;
+  let previousSignificantToken: JavaScriptSignificantToken | undefined;
   for (let cursor = start; cursor < text.length; cursor++) {
     const character = text[cursor]!;
     if (quote !== undefined) {
       if (quoteUsesJavaScriptEscapes && character === "\\") cursor++;
       else if (character === quote) {
         quote = undefined;
-        if (quoteUsesJavaScriptEscapes) {
-          previousSignificantEnd = cursor + 1;
-          previousTokenWasRegex = false;
+        if (expressionDepth > 0) {
+          previousSignificantToken = { end: cursor + 1, kind: "other" };
         }
         quoteUsesJavaScriptEscapes = false;
       }
@@ -1475,16 +1445,11 @@ function scanTagSyntax(
     }
     if (
       expressionDepth > 0 && character === "/" &&
-      javaScriptRegexMayStart(
-        text,
-        previousSignificantEnd,
-        previousTokenWasRegex,
-      )
+      javaScriptRegexMayStart(text, previousSignificantToken)
     ) {
       const regexEnd = javaScriptRegexEnd(text, cursor);
       if (regexEnd !== undefined) {
-        previousSignificantEnd = regexEnd;
-        previousTokenWasRegex = true;
+        previousSignificantToken = { end: regexEnd, kind: "regex" };
         cursor = regexEnd - 1;
         continue;
       }
@@ -1498,16 +1463,14 @@ function scanTagSyntax(
     if (character === "`" && expressionDepth > 0) {
       const templateEnd = javaScriptTemplateEnd(text, cursor);
       if (templateEnd !== undefined) {
-        previousSignificantEnd = templateEnd;
-        previousTokenWasRegex = false;
+        previousSignificantToken = { end: templateEnd, kind: "other" };
         cursor = templateEnd - 1;
         continue;
       }
     }
     if (expressionDepth > 0 && /\s/.test(character)) continue;
-    previousTokenWasRegex = false;
     if (expressionDepth > 0 || character === "{") {
-      previousSignificantEnd = cursor + 1;
+      previousSignificantToken = { end: cursor + 1, kind: "other" };
     }
     if (character === '"' || character === "'") {
       quote = character;

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -772,6 +772,7 @@ interface MdxSyntaxRanges {
 }
 
 type JavaScriptSignificantTokenKind =
+  | "control-header"
   | "other"
   | "postfix-update"
   | "prefix-update"
@@ -789,6 +790,26 @@ interface JavaScriptScannedToken {
   readonly end: number;
   readonly kind: JavaScriptSignificantTokenKind | "literal" | "trivia";
   readonly string?: Range;
+}
+
+function significantJavaScriptToken(
+  text: string,
+  start: number,
+  token: JavaScriptScannedToken,
+  previousSignificantToken: JavaScriptSignificantToken | undefined,
+  controlParentheses: boolean[],
+): JavaScriptSignificantToken {
+  const kind = token.kind === "other"
+    ? javaScriptParenthesisTokenKind(
+      text,
+      text[start]!,
+      previousSignificantToken,
+      controlParentheses,
+    )
+    : token.kind === "literal" || token.kind === "trivia"
+    ? "other"
+    : token.kind;
+  return { end: token.end, kind };
 }
 
 function quotedRangeEnd(
@@ -832,6 +853,7 @@ function javaScriptTemplateInterpolationEnd(
 ): number | undefined {
   let depth = 1;
   let cursor = start + 2;
+  const controlParentheses: boolean[] = [];
   let previousSignificantToken: JavaScriptSignificantToken | undefined;
   while (cursor < text.length) {
     const token = javaScriptTokenAt(
@@ -844,10 +866,13 @@ function javaScriptTemplateInterpolationEnd(
       cursor = token.end;
       continue;
     }
-    previousSignificantToken = {
-      end: token.end,
-      kind: token.kind === "literal" ? "other" : token.kind,
-    };
+    previousSignificantToken = significantJavaScriptToken(
+      text,
+      cursor,
+      token,
+      previousSignificantToken,
+      controlParentheses,
+    );
     if (token.kind !== "other") {
       cursor = token.end;
       continue;
@@ -930,6 +955,7 @@ function mdxExpressionAt(
   const strings: Range[] = [];
   let depth = 1;
   let cursor = start + 1;
+  const controlParentheses: boolean[] = [];
   let previousSignificantToken: JavaScriptSignificantToken | undefined;
   while (cursor < text.length) {
     const token = javaScriptTokenAt(
@@ -943,10 +969,13 @@ function mdxExpressionAt(
       cursor = token.end;
       continue;
     }
-    previousSignificantToken = {
-      end: token.end,
-      kind: token.kind === "literal" ? "other" : token.kind,
-    };
+    previousSignificantToken = significantJavaScriptToken(
+      text,
+      cursor,
+      token,
+      previousSignificantToken,
+      controlParentheses,
+    );
     if (token.kind !== "other") {
       cursor = token.end;
       continue;
@@ -1037,6 +1066,7 @@ function mdxEsmMayStart(text: string, lineStart: number): boolean {
 
 interface JavaScriptBalance {
   readonly delimiters: string[];
+  readonly controlParentheses: boolean[];
   quote: JavaScriptQuote | undefined;
   blockComment: boolean;
   templateEnd: number;
@@ -1077,6 +1107,15 @@ const JAVASCRIPT_REGEX_PREFIX_KEYWORDS: ReadonlySet<string> = new Set([
   "in",
   "instanceof",
   "new",
+  "await",
+  "yield",
+]);
+
+const JAVASCRIPT_CONTROL_HEADER_KEYWORDS: ReadonlySet<string> = new Set([
+  "for",
+  "if",
+  "while",
+  "with",
 ]);
 
 const JAVASCRIPT_IDENTIFIER_CONTINUE = /[$\u200C\u200D\p{ID_Continue}]/u;
@@ -1115,12 +1154,51 @@ function javaScriptIdentifierContinueBefore(
     JAVASCRIPT_IDENTIFIER_CONTINUE.test(codePoint);
 }
 
+function javaScriptIdentifierWordAtEnd(
+  text: string,
+  end: number,
+): string | undefined {
+  let start = end;
+  while (start > 0 && /[A-Za-z]/.test(text[start - 1]!)) start--;
+  if (start === end) return undefined;
+
+  const preceding = javaScriptCodePointBefore(text, start);
+  if (
+    preceding !== undefined &&
+    (preceding === "." || preceding === "#" ||
+      javaScriptIdentifierContinueBefore(text, start))
+  ) return undefined;
+  return text.slice(start, end);
+}
+
+function javaScriptParenthesisTokenKind(
+  text: string,
+  character: string,
+  previousSignificantToken: JavaScriptSignificantToken | undefined,
+  controlParentheses: boolean[],
+): JavaScriptSignificantTokenKind {
+  if (character === "(") {
+    const keyword = previousSignificantToken === undefined
+      ? undefined
+      : javaScriptIdentifierWordAtEnd(text, previousSignificantToken.end);
+    controlParentheses.push(
+      keyword !== undefined && JAVASCRIPT_CONTROL_HEADER_KEYWORDS.has(keyword),
+    );
+  } else if (character === ")" && controlParentheses.pop()) {
+    return "control-header";
+  }
+  return "other";
+}
+
 function javaScriptRegexMayStart(
   text: string,
   previousSignificantToken: JavaScriptSignificantToken | undefined,
 ): boolean {
   if (previousSignificantToken === undefined) return true;
-  if (previousSignificantToken.kind === "prefix-update") return true;
+  if (
+    previousSignificantToken.kind === "control-header" ||
+    previousSignificantToken.kind === "prefix-update"
+  ) return true;
   if (
     previousSignificantToken.kind === "postfix-update" ||
     previousSignificantToken.kind === "regex"
@@ -1130,15 +1208,8 @@ function javaScriptRegexMayStart(
   if (text.slice(end - 3, end) === "...") return true;
   if ("=(:,![{;?&|+*%/^~<>-".includes(text[end - 1]!)) return true;
 
-  let wordStart = end;
-  while (wordStart > 0 && /[A-Za-z]/.test(text[wordStart - 1]!)) wordStart--;
-  const keyword = text.slice(wordStart, end);
-  if (!JAVASCRIPT_REGEX_PREFIX_KEYWORDS.has(keyword)) return false;
-
-  const preceding = javaScriptCodePointBefore(text, wordStart);
-  return preceding === undefined ||
-    (preceding !== "." && preceding !== "#" &&
-      !javaScriptIdentifierContinueBefore(text, wordStart));
+  const keyword = javaScriptIdentifierWordAtEnd(text, end);
+  return keyword !== undefined && JAVASCRIPT_REGEX_PREFIX_KEYWORDS.has(keyword);
 }
 
 function javaScriptUpdateKind(
@@ -1286,20 +1357,33 @@ const JAVASCRIPT_DELIMITER_CLOSERS: Readonly<Record<string, string>> = {
 };
 
 function recordJavaScriptDelimiter(
+  text: string,
   character: string,
+  previousSignificantToken: JavaScriptSignificantToken | undefined,
   state: JavaScriptBalance,
-): void {
+): JavaScriptSignificantTokenKind {
   if (character === "(" || character === "[" || character === "{") {
     state.delimiters.push(character);
-    return;
+    return javaScriptParenthesisTokenKind(
+      text,
+      character,
+      previousSignificantToken,
+      state.controlParentheses,
+    );
   }
   const opener = JAVASCRIPT_DELIMITER_CLOSERS[character];
-  if (opener === undefined) return;
+  if (opener === undefined) return "other";
   if (state.delimiters.at(-1) !== opener) {
     state.valid = false;
-    return;
+    return "other";
   }
   state.delimiters.pop();
+  return javaScriptParenthesisTokenKind(
+    text,
+    character,
+    previousSignificantToken,
+    state.controlParentheses,
+  );
 }
 
 function scanJavaScriptLine(
@@ -1327,8 +1411,13 @@ function scanJavaScriptLine(
     }
     const character = text[cursor]!;
     if (!/\s/.test(character)) {
-      state.previousSignificantToken = { end: cursor + 1, kind: "other" };
-      recordJavaScriptDelimiter(character, state);
+      const kind = recordJavaScriptDelimiter(
+        text,
+        character,
+        state.previousSignificantToken,
+        state,
+      );
+      state.previousSignificantToken = { end: cursor + 1, kind };
       if (!state.valid) return;
     }
     cursor++;
@@ -1338,6 +1427,7 @@ function scanJavaScriptLine(
 function mdxEsmRangeEnd(text: string, start: number): number | undefined {
   const state: JavaScriptBalance = {
     delimiters: [],
+    controlParentheses: [],
     quote: undefined,
     blockComment: false,
     templateEnd: start,
@@ -1572,6 +1662,7 @@ function scanTagSyntax(
   let quote: JavaScriptQuote | undefined;
   let quoteUsesJavaScriptEscapes = false;
   let expressionDepth = 0;
+  const controlParentheses: boolean[] = [];
   let previousSignificantToken: JavaScriptSignificantToken | undefined;
   let cursor = start;
   while (cursor < text.length) {
@@ -1634,7 +1725,15 @@ function scanTagSyntax(
       cursor++;
       continue;
     }
-    if (expressionDepth > 0 || character === "{") {
+    if (expressionDepth > 0) {
+      const kind = javaScriptParenthesisTokenKind(
+        text,
+        character,
+        previousSignificantToken,
+        controlParentheses,
+      );
+      previousSignificantToken = { end: cursor + 1, kind };
+    } else if (character === "{") {
       previousSignificantToken = { end: cursor + 1, kind: "other" };
     }
     if (character === '"' || character === "'") {

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -243,6 +243,15 @@ function decodeUrlComponentTolerantly(value: string): string {
   });
 }
 
+function decodeUrlPathForRepositoryMatch(value: string): string {
+  return value
+    .split(/(%(?:2[fF]|3[fF]|23))/)
+    .map((part, index) =>
+      index % 2 === 0 ? decodeUrlComponentTolerantly(part) : part
+    )
+    .join("");
+}
+
 function normalizeRepositoryPath(pathname: string): string {
   const decoded = decodeUrlComponentTolerantly(pathname);
   const slashPath = decoded.replaceAll("\\", "/");
@@ -1049,13 +1058,32 @@ function javaScriptRegexEnd(line: string, start: number): number | undefined {
   return undefined;
 }
 
+const JAVASCRIPT_REGEX_PREFIX_KEYWORDS: ReadonlySet<string> = new Set([
+  "return",
+  "case",
+  "throw",
+  "default",
+  "typeof",
+  "void",
+  "delete",
+  "in",
+  "instanceof",
+]);
+
 function javaScriptRegexMayStart(line: string, start: number): boolean {
-  const prefix = line.slice(0, start).trimEnd();
-  return prefix === "" ||
-    /(?:[=(:,!\[{;?&|+*%/^~<>-]|=>|(?:^|[^A-Za-z0-9_$.#])(?:return|case|throw|default|typeof|void|delete|in|instanceof))$/
-      .test(
-        prefix,
-      );
+  let end = start;
+  while (end > 0 && /\s/.test(line[end - 1]!)) end--;
+  if (end === 0) return true;
+
+  if ("=(:,![{;?&|+*%/^~<>-".includes(line[end - 1]!)) return true;
+
+  let wordStart = end;
+  while (wordStart > 0 && /[A-Za-z]/.test(line[wordStart - 1]!)) wordStart--;
+  const keyword = line.slice(wordStart, end);
+  if (!JAVASCRIPT_REGEX_PREFIX_KEYWORDS.has(keyword)) return false;
+
+  return wordStart === 0 ||
+    !/[A-Za-z0-9_$.#]/.test(line[wordStart - 1]!);
 }
 
 function scanJavaScriptLine(
@@ -2633,7 +2661,7 @@ function canonicalizeHttpUrls(text: string): string {
     const candidate = rawUrl.slice(0, rawUrl.length - suffix.length);
     try {
       const url = new URL(candidate);
-      const pathname = decodeUrlComponentTolerantly(url.pathname);
+      const pathname = decodeUrlPathForRepositoryMatch(url.pathname);
       return `${url.protocol}//${url.host}${pathname}${url.search}${url.hash}${suffix}`;
     } catch {
       return rawUrl;

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -2359,26 +2359,8 @@ function markdownInlineDestinationAt(
   const afterLabel = afterMarkdownLabel(text, start);
   if (afterLabel === undefined || text[afterLabel] !== "(") return undefined;
 
-  const destinationInput = afterLabel + 1;
-  let cursor = markdownDestinationStart(text, destinationInput);
+  let cursor = markdownDestinationStart(text, afterLabel + 1);
   if (cursor === undefined || cursor >= text.length) return undefined;
-
-  if (
-    cursor > destinationInput &&
-    (text[cursor] === '"' || text[cursor] === "'" || text[cursor] === "(") &&
-    markdownDestinationCloses(text, cursor)
-  ) {
-    const linkEnd = afterInlineLink(text, afterLabel);
-    if (linkEnd === undefined) return undefined;
-    return {
-      href: "",
-      offset: cursor,
-      labelStart: start + 1,
-      labelEnd: afterLabel - 1,
-      linkEnd,
-      tail: { start: afterLabel, end: linkEnd },
-    };
-  }
 
   let href: string;
   let offset: number;

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -814,6 +814,7 @@ function javaScriptTemplateInterpolationEnd(
 ): number | undefined {
   let depth = 1;
   let cursor = start + 2;
+  let previousTokenWasRegex = false;
   while (cursor < text.length) {
     const commentEnd = javaScriptCommentEnd(text, cursor);
     if (commentEnd !== undefined) {
@@ -824,22 +825,33 @@ function javaScriptTemplateInterpolationEnd(
     if (character === '"' || character === "'") {
       const end = quotedRangeEnd(text, cursor, character);
       if (end === undefined) return undefined;
+      previousTokenWasRegex = false;
       cursor = end;
       continue;
     }
     if (character === "`") {
       const end = javaScriptTemplateEnd(text, cursor);
       if (end === undefined) return undefined;
+      previousTokenWasRegex = false;
       cursor = end;
       continue;
     }
-    if (character === "/" && javaScriptRegexMayStart(text, cursor)) {
+    if (
+      character === "/" &&
+      javaScriptRegexMayStart(text, cursor, previousTokenWasRegex)
+    ) {
       const regexEnd = javaScriptRegexEnd(text, cursor);
       if (regexEnd !== undefined) {
+        previousTokenWasRegex = true;
         cursor = regexEnd;
         continue;
       }
     }
+    if (/\s/.test(character)) {
+      cursor++;
+      continue;
+    }
+    previousTokenWasRegex = false;
     if (character === "{") depth++;
     else if (character === "}" && --depth === 0) return cursor + 1;
     cursor++;
@@ -917,6 +929,7 @@ function mdxExpressionAt(
   const strings: Range[] = [];
   let depth = 1;
   let cursor = start + 1;
+  let previousTokenWasRegex = false;
   while (cursor < text.length) {
     const commentEnd = javaScriptCommentEnd(text, cursor);
     if (commentEnd !== undefined) {
@@ -928,6 +941,7 @@ function mdxExpressionAt(
       const end = javaScriptTemplateEnd(text, cursor);
       if (end === undefined) return undefined;
       strings.push({ start: cursor, end });
+      previousTokenWasRegex = false;
       cursor = end;
       continue;
     }
@@ -935,16 +949,26 @@ function mdxExpressionAt(
       const end = quotedRangeEnd(text, cursor, character);
       if (end === undefined) return undefined;
       strings.push({ start: cursor, end });
+      previousTokenWasRegex = false;
       cursor = end;
       continue;
     }
-    if (character === "/" && javaScriptRegexMayStart(text, cursor)) {
+    if (
+      character === "/" &&
+      javaScriptRegexMayStart(text, cursor, previousTokenWasRegex)
+    ) {
       const regexEnd = javaScriptRegexEnd(text, cursor);
       if (regexEnd !== undefined) {
+        previousTokenWasRegex = true;
         cursor = regexEnd;
         continue;
       }
     }
+    if (/\s/.test(character)) {
+      cursor++;
+      continue;
+    }
+    previousTokenWasRegex = false;
     if (character === "{") depth++;
     else if (character === "}" && --depth === 0) {
       return { expression: { start, end: cursor + 1 }, strings };
@@ -1033,6 +1057,7 @@ interface JavaScriptBalance {
   quote: '"' | "'" | undefined;
   blockComment: boolean;
   templateEnd: number;
+  previousTokenWasRegex: boolean;
   valid: boolean;
 }
 
@@ -1070,7 +1095,12 @@ const JAVASCRIPT_REGEX_PREFIX_KEYWORDS: ReadonlySet<string> = new Set([
   "instanceof",
 ]);
 
-function javaScriptRegexMayStart(line: string, start: number): boolean {
+function javaScriptRegexMayStart(
+  line: string,
+  start: number,
+  previousTokenWasRegex: boolean,
+): boolean {
+  if (previousTokenWasRegex) return false;
   let end = start;
   while (end > 0 && /\s/.test(line[end - 1]!)) end--;
   if (end === 0) return true;
@@ -1128,22 +1158,34 @@ function scanJavaScriptLine(
         state.valid = false;
         return;
       }
+      state.previousTokenWasRegex = false;
       state.templateEnd = templateEnd;
       cursor = templateEnd - 1;
       continue;
     }
     if (character === '"' || character === "'") {
+      state.previousTokenWasRegex = false;
       state.quote = character;
       continue;
     }
     const lineCursor = cursor - lineStart;
-    if (character === "/" && javaScriptRegexMayStart(line, lineCursor)) {
+    if (
+      character === "/" &&
+      javaScriptRegexMayStart(
+        line,
+        lineCursor,
+        state.previousTokenWasRegex,
+      )
+    ) {
       const regexEnd = javaScriptRegexEnd(line, lineCursor);
       if (regexEnd !== undefined) {
+        state.previousTokenWasRegex = true;
         cursor = lineStart + regexEnd - 1;
         continue;
       }
     }
+    if (/\s/.test(character)) continue;
+    state.previousTokenWasRegex = false;
     if (character === "(" || character === "[" || character === "{") {
       state.delimiters.push(character);
       continue;
@@ -1164,6 +1206,7 @@ function mdxEsmRangeEnd(text: string, start: number): number | undefined {
     quote: undefined,
     blockComment: false,
     templateEnd: start,
+    previousTokenWasRegex: false,
     valid: true,
   };
   for (let lineStart = start; lineStart <= text.length;) {
@@ -1379,6 +1422,7 @@ function scanTagSyntax(
   let quote: '"' | "'" | undefined;
   let quoteUsesJavaScriptEscapes = false;
   let expressionDepth = 0;
+  let previousTokenWasRegex = false;
   for (let cursor = start; cursor < text.length; cursor++) {
     const character = text[cursor]!;
     if (quote !== undefined) {
@@ -1395,10 +1439,11 @@ function scanTagSyntax(
     }
     if (
       expressionDepth > 0 && character === "/" &&
-      javaScriptRegexMayStart(text, cursor)
+      javaScriptRegexMayStart(text, cursor, previousTokenWasRegex)
     ) {
       const regexEnd = javaScriptRegexEnd(text, cursor);
       if (regexEnd !== undefined) {
+        previousTokenWasRegex = true;
         cursor = regexEnd - 1;
         continue;
       }
@@ -1412,10 +1457,13 @@ function scanTagSyntax(
     if (character === "`" && expressionDepth > 0) {
       const templateEnd = javaScriptTemplateEnd(text, cursor);
       if (templateEnd !== undefined) {
+        previousTokenWasRegex = false;
         cursor = templateEnd - 1;
         continue;
       }
     }
+    if (expressionDepth > 0 && /\s/.test(character)) continue;
+    previousTokenWasRegex = false;
     if (character === '"' || character === "'") {
       quote = character;
       quoteUsesJavaScriptEscapes = expressionDepth > 0;
@@ -2424,6 +2472,7 @@ export function scanDestinations(
       .filter((usage) => usage.image && definedLabels.has(usage.label))
       .map((usage) => usage.description),
   );
+  markdownImageLabelRanges.sort((left, right) => left.start - right.start);
 
   for (const tagRange of tagRanges) {
     if (

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -778,16 +778,15 @@ type JavaScriptSignificantTokenKind =
   | "prefix-update"
   | "regex";
 
+type JavaScriptPrecedingIdentifierKeyword = "break" | "continue" | "for";
+type JavaScriptDelimiterContext = "control" | "for" | "nested" | undefined;
+
 interface JavaScriptSignificantToken {
   readonly end: number;
   readonly kind: JavaScriptSignificantTokenKind;
-  readonly followsForKeyword?: true;
-  readonly forOfSeparator?: true;
-  readonly forOfSeparatorCandidate?: true;
-  readonly lineTerminatedStatement?: true;
+  readonly followsForOfLeftOperand?: true;
+  readonly precedingIdentifierKeyword?: JavaScriptPrecedingIdentifierKeyword;
 }
-
-type JavaScriptControlParenthesis = "for" | "other" | "statement";
 
 type JavaScriptQuote = '"' | "'";
 type JavaScriptStringDelimiter = JavaScriptQuote | "`";
@@ -804,58 +803,47 @@ function javaScriptTokenWithIdentifierContext(
   end: number,
   kind: JavaScriptSignificantTokenKind,
   previousSignificantToken: JavaScriptSignificantToken | undefined,
-  insideForHeader: boolean,
+  delimiterContexts: readonly JavaScriptDelimiterContext[],
 ): JavaScriptSignificantToken {
-  if (!/[A-Za-z]/.test(text[start]!)) return { end, kind };
+  if (!javaScriptIdentifierCodeUnitAt(text, start)) return { end, kind };
 
+  const escapeRange = javaScriptIdentifierEscapeRangeAt(text, start);
+  const codeUnit = text.charCodeAt(start);
   const continuesIdentifierWord = start > 0 &&
-    /[A-Za-z]/.test(text[start - 1]!);
-  let followsForKeyword = false;
+    (javaScriptIdentifierContinueBefore(text, start) ||
+      (escapeRange !== undefined && escapeRange.start < start) ||
+      (codeUnit >= 0xdc00 && codeUnit <= 0xdfff &&
+        javaScriptIdentifierContinueBefore(text, start + 1)));
+  let precedingIdentifierKeyword:
+    | JavaScriptPrecedingIdentifierKeyword
+    | undefined;
+  let followsForOfLeftOperand = false;
   if (continuesIdentifierWord) {
-    followsForKeyword = previousSignificantToken?.followsForKeyword === true;
+    precedingIdentifierKeyword = previousSignificantToken
+      ?.precedingIdentifierKeyword;
+    followsForOfLeftOperand =
+      previousSignificantToken?.followsForOfLeftOperand === true;
   } else if (previousSignificantToken !== undefined) {
-    followsForKeyword =
-      javaScriptIdentifierWordAtEnd(text, previousSignificantToken.end) ===
-        "for";
-  }
-
-  const word = javaScriptIdentifierWordAtEnd(text, end);
-  const completeIdentifier = word !== undefined &&
-    !javaScriptIdentifierContinueAt(text, end);
-  let forOfSeparatorCandidate = false;
-  if (continuesIdentifierWord) {
-    forOfSeparatorCandidate =
-      previousSignificantToken?.forOfSeparatorCandidate === true;
-  } else if (insideForHeader && previousSignificantToken !== undefined) {
-    const precedingWord = javaScriptIdentifierWordAtEnd(
+    const previousWord = javaScriptIdentifierWordAtEnd(
       text,
       previousSignificantToken.end,
     );
-    forOfSeparatorCandidate =
-      !JAVASCRIPT_FOR_DECLARATION_KEYWORDS.has(precedingWord ?? "") &&
-      !javaScriptRegexMayStart(text, start, previousSignificantToken);
+    if (
+      previousWord === "break" || previousWord === "continue" ||
+      previousWord === "for"
+    ) precedingIdentifierKeyword = previousWord;
+    followsForOfLeftOperand = delimiterContexts.at(-1) === "for" &&
+      javaScriptTokenMayEndForOfLeftOperand(text, previousSignificantToken);
   }
-  const forOfSeparator = completeIdentifier && word === "of" &&
-    forOfSeparatorCandidate;
-  const lineTerminatedStatement = completeIdentifier &&
-    JAVASCRIPT_LINE_TERMINATED_STATEMENT_KEYWORDS.has(word);
-  const contextualToken: {
-    end: number;
-    kind: JavaScriptSignificantTokenKind;
-    followsForKeyword?: true;
-    forOfSeparator?: true;
-    forOfSeparatorCandidate?: true;
-    lineTerminatedStatement?: true;
-  } = { end, kind };
-  if (followsForKeyword) contextualToken.followsForKeyword = true;
-  if (forOfSeparator) contextualToken.forOfSeparator = true;
-  if (forOfSeparatorCandidate && !completeIdentifier) {
-    contextualToken.forOfSeparatorCandidate = true;
-  }
-  if (lineTerminatedStatement) {
-    contextualToken.lineTerminatedStatement = true;
-  }
-  return contextualToken;
+
+  return {
+    end,
+    kind,
+    ...(followsForOfLeftOperand ? { followsForOfLeftOperand: true } : {}),
+    ...(precedingIdentifierKeyword === undefined
+      ? {}
+      : { precedingIdentifierKeyword }),
+  };
 }
 
 function significantJavaScriptToken(
@@ -863,25 +851,28 @@ function significantJavaScriptToken(
   start: number,
   token: JavaScriptScannedToken,
   previousSignificantToken: JavaScriptSignificantToken | undefined,
-  controlParentheses: JavaScriptControlParenthesis[],
+  delimiterContexts: JavaScriptDelimiterContext[],
 ): JavaScriptSignificantToken {
-  const kind = token.kind === "other"
-    ? javaScriptParenthesisTokenKind(
+  let kind: JavaScriptSignificantTokenKind;
+  if (token.kind === "other") {
+    kind = javaScriptDelimiterTokenKind(
       text,
       text[start]!,
       previousSignificantToken,
-      controlParentheses,
-    )
-    : token.kind === "literal" || token.kind === "trivia"
-    ? "other"
-    : token.kind;
+      delimiterContexts,
+    );
+  } else if (token.kind === "literal" || token.kind === "trivia") {
+    kind = "other";
+  } else {
+    kind = token.kind;
+  }
   return javaScriptTokenWithIdentifierContext(
     text,
     start,
     token.end,
     kind,
     previousSignificantToken,
-    controlParentheses.at(-1) === "for",
+    delimiterContexts,
   );
 }
 
@@ -926,16 +917,23 @@ function javaScriptTemplateInterpolationEnd(
 ): number | undefined {
   let depth = 1;
   let cursor = start + 2;
-  const controlParentheses: JavaScriptControlParenthesis[] = [];
+  const delimiterContexts: JavaScriptDelimiterContext[] = [];
   let previousSignificantToken: JavaScriptSignificantToken | undefined;
   while (cursor < text.length) {
     const token = javaScriptTokenAt(
       text,
       cursor,
       previousSignificantToken,
+      delimiterContexts,
     );
     if (token === undefined) return undefined;
     if (token.kind === "trivia") {
+      previousSignificantToken = javaScriptPreviousSignificantTokenAfterTrivia(
+        text,
+        cursor,
+        token.end,
+        previousSignificantToken,
+      );
       cursor = token.end;
       continue;
     }
@@ -944,7 +942,7 @@ function javaScriptTemplateInterpolationEnd(
       cursor,
       token,
       previousSignificantToken,
-      controlParentheses,
+      delimiterContexts,
     );
     if (token.kind !== "other") {
       cursor = token.end;
@@ -1028,17 +1026,24 @@ function mdxExpressionAt(
   const strings: Range[] = [];
   let depth = 1;
   let cursor = start + 1;
-  const controlParentheses: JavaScriptControlParenthesis[] = [];
+  const delimiterContexts: JavaScriptDelimiterContext[] = [];
   let previousSignificantToken: JavaScriptSignificantToken | undefined;
   while (cursor < text.length) {
     const token = javaScriptTokenAt(
       text,
       cursor,
       previousSignificantToken,
+      delimiterContexts,
     );
     if (token === undefined) return undefined;
     if (token.string !== undefined) strings.push(token.string);
     if (token.kind === "trivia") {
+      previousSignificantToken = javaScriptPreviousSignificantTokenAfterTrivia(
+        text,
+        cursor,
+        token.end,
+        previousSignificantToken,
+      );
       cursor = token.end;
       continue;
     }
@@ -1047,7 +1052,7 @@ function mdxExpressionAt(
       cursor,
       token,
       previousSignificantToken,
-      controlParentheses,
+      delimiterContexts,
     );
     if (token.kind !== "other") {
       cursor = token.end;
@@ -1139,7 +1144,7 @@ function mdxEsmMayStart(text: string, lineStart: number): boolean {
 
 interface JavaScriptBalance {
   readonly delimiters: string[];
-  readonly controlParentheses: JavaScriptControlParenthesis[];
+  readonly delimiterContexts: JavaScriptDelimiterContext[];
   quote: JavaScriptQuote | undefined;
   blockComment: boolean;
   templateEnd: number;
@@ -1194,25 +1199,46 @@ const JAVASCRIPT_CONTROL_HEADER_KEYWORDS: ReadonlySet<string> = new Set([
   "with",
 ]);
 
-const JAVASCRIPT_LINE_TERMINATED_STATEMENT_KEYWORDS: ReadonlySet<string> =
-  new Set([
-    "break",
-    "continue",
-    "debugger",
-  ]);
-
-const JAVASCRIPT_FOR_DECLARATION_KEYWORDS: ReadonlySet<string> = new Set([
-  "const",
-  "let",
-  "using",
-  "var",
-]);
-
-const JAVASCRIPT_IDENTIFIER_CONTINUE = /[$\u200C\u200D\p{ID_Continue}]/u;
+const JAVASCRIPT_IDENTIFIER_CONTINUE = /[$_\u200C\u200D\p{ID_Continue}]/u;
 const JAVASCRIPT_IDENTIFIER_ESCAPE =
   /\\u(?:([0-9A-Fa-f]{4})|\{([0-9A-Fa-f]{1,6})\})$/;
-const JAVASCRIPT_IDENTIFIER_ESCAPE_AT =
+const JAVASCRIPT_IDENTIFIER_ESCAPE_PREFIX =
   /^\\u(?:([0-9A-Fa-f]{4})|\{([0-9A-Fa-f]{1,6})\})/;
+
+function javaScriptIdentifierEscapeRangeAt(
+  text: string,
+  offset: number,
+): Range | undefined {
+  let start = offset;
+  const earliest = Math.max(0, offset - 9);
+  while (start >= earliest && text[start] !== "\\") start--;
+  if (start < earliest) return undefined;
+  const match = JAVASCRIPT_IDENTIFIER_ESCAPE_PREFIX.exec(text.slice(start));
+  if (match === null) return undefined;
+  const end = start + match[0].length;
+  if (offset >= end) return undefined;
+  const codePoint = Number.parseInt(match[1] ?? match[2] ?? "", 16);
+  if (
+    codePoint > 0x10ffff ||
+    !JAVASCRIPT_IDENTIFIER_CONTINUE.test(String.fromCodePoint(codePoint))
+  ) return undefined;
+  return { start, end };
+}
+
+function javaScriptIdentifierCodeUnitAt(
+  text: string,
+  offset: number,
+): boolean {
+  const codePoint = text.codePointAt(offset);
+  if (
+    codePoint !== undefined &&
+    JAVASCRIPT_IDENTIFIER_CONTINUE.test(String.fromCodePoint(codePoint))
+  ) return true;
+  const codeUnit = text.charCodeAt(offset);
+  return (codeUnit >= 0xdc00 && codeUnit <= 0xdfff &&
+    javaScriptIdentifierContinueBefore(text, offset + 1)) ||
+    javaScriptIdentifierEscapeRangeAt(text, offset) !== undefined;
+}
 
 function javaScriptCodePointBefore(
   text: string,
@@ -1246,27 +1272,6 @@ function javaScriptIdentifierContinueBefore(
     JAVASCRIPT_IDENTIFIER_CONTINUE.test(codePoint);
 }
 
-function javaScriptIdentifierContinueAt(
-  text: string,
-  start: number,
-): boolean {
-  const escapeMatch = JAVASCRIPT_IDENTIFIER_ESCAPE_AT.exec(
-    text.slice(start, start + 10),
-  );
-  if (escapeMatch !== null) {
-    const codePoint = Number.parseInt(
-      escapeMatch[1] ?? escapeMatch[2] ?? "",
-      16,
-    );
-    return codePoint <= 0x10ffff &&
-      JAVASCRIPT_IDENTIFIER_CONTINUE.test(String.fromCodePoint(codePoint));
-  }
-
-  const codePoint = text.codePointAt(start);
-  return codePoint !== undefined &&
-    JAVASCRIPT_IDENTIFIER_CONTINUE.test(String.fromCodePoint(codePoint));
-}
-
 function javaScriptIdentifierWordAtEnd(
   text: string,
   end: number,
@@ -1284,47 +1289,85 @@ function javaScriptIdentifierWordAtEnd(
   return text.slice(start, end);
 }
 
-function javaScriptParenthesisTokenKind(
+function javaScriptLineTerminatesRestrictedStatement(
+  text: string,
+  token: JavaScriptSignificantToken | undefined,
+): boolean {
+  if (token === undefined) return false;
+  const finalWord = javaScriptIdentifierWordAtEnd(text, token.end);
+  if (
+    finalWord === "break" || finalWord === "continue" ||
+    finalWord === "debugger"
+  ) return true;
+  return token.precedingIdentifierKeyword === "break" ||
+    token.precedingIdentifierKeyword === "continue";
+}
+
+function javaScriptPreviousSignificantTokenAfterTrivia(
+  text: string,
+  start: number,
+  end: number,
+  token: JavaScriptSignificantToken | undefined,
+): JavaScriptSignificantToken | undefined {
+  if (
+    /[\n\r\u2028\u2029]/.test(text.slice(start, end)) &&
+    javaScriptLineTerminatesRestrictedStatement(text, token)
+  ) return undefined;
+  return token;
+}
+
+function javaScriptTokenMayEndForOfLeftOperand(
+  text: string,
+  token: JavaScriptSignificantToken,
+): boolean {
+  const word = javaScriptIdentifierWordAtEnd(text, token.end);
+  if (word !== undefined) {
+    return !JAVASCRIPT_REGEX_PREFIX_KEYWORDS.has(word) &&
+      !JAVASCRIPT_CONTROL_HEADER_KEYWORDS.has(word) &&
+      word !== "break" && word !== "continue" && word !== "debugger" &&
+      word !== "const" && word !== "let" && word !== "var";
+  }
+  return ")]}".includes(text[token.end - 1]!);
+}
+
+function javaScriptDelimiterTokenKind(
   text: string,
   character: string,
   previousSignificantToken: JavaScriptSignificantToken | undefined,
-  controlParentheses: JavaScriptControlParenthesis[],
+  delimiterContexts: JavaScriptDelimiterContext[],
 ): JavaScriptSignificantTokenKind {
   if (character === "(") {
     const keyword = previousSignificantToken === undefined
       ? undefined
       : javaScriptIdentifierWordAtEnd(text, previousSignificantToken.end);
+    let context: JavaScriptDelimiterContext;
     if (
       keyword === "for" ||
       (keyword === "await" &&
-        previousSignificantToken?.followsForKeyword === true)
-    ) controlParentheses.push("for");
-    else if (
-      keyword !== undefined &&
-      JAVASCRIPT_CONTROL_HEADER_KEYWORDS.has(keyword)
-    ) controlParentheses.push("statement");
-    else controlParentheses.push("other");
-  } else if (character === ")") {
-    const context = controlParentheses.pop();
-    if (context === "for" || context === "statement") {
-      return "control-header";
+        previousSignificantToken?.precedingIdentifierKeyword === "for")
+    ) {
+      context = "for";
+    } else if (
+      keyword !== undefined && JAVASCRIPT_CONTROL_HEADER_KEYWORDS.has(keyword)
+    ) {
+      context = "control";
     }
+    delimiterContexts.push(context);
+  } else if (character === "[" || character === "{") {
+    delimiterContexts.push("nested");
+  } else if (character === ")" || character === "]" || character === "}") {
+    const context = delimiterContexts.pop();
+    if (context === "control" || context === "for") return "control-header";
   }
   return "other";
 }
 
 function javaScriptRegexMayStart(
   text: string,
-  start: number,
   previousSignificantToken: JavaScriptSignificantToken | undefined,
+  delimiterContexts: readonly JavaScriptDelimiterContext[] = [],
 ): boolean {
   if (previousSignificantToken === undefined) return true;
-  if (
-    previousSignificantToken.lineTerminatedStatement === true &&
-    /[\n\r\u2028\u2029]/.test(
-      text.slice(previousSignificantToken.end, start),
-    )
-  ) return true;
   if (
     previousSignificantToken.kind === "control-header" ||
     previousSignificantToken.kind === "prefix-update"
@@ -1339,15 +1382,18 @@ function javaScriptRegexMayStart(
   if ("=(:,![{;?&|+*%/^~<>-".includes(text[end - 1]!)) return true;
 
   const keyword = javaScriptIdentifierWordAtEnd(text, end);
-  return keyword !== undefined &&
-    (JAVASCRIPT_REGEX_PREFIX_KEYWORDS.has(keyword) ||
-      (keyword === "of" && previousSignificantToken.forOfSeparator === true));
+  if (
+    keyword === "of" && delimiterContexts.at(-1) === "for" &&
+    previousSignificantToken.followsForOfLeftOperand === true
+  ) return true;
+  return keyword !== undefined && JAVASCRIPT_REGEX_PREFIX_KEYWORDS.has(keyword);
 }
 
 function javaScriptUpdateKind(
   text: string,
   start: number,
   previousSignificantToken: JavaScriptSignificantToken | undefined,
+  delimiterContexts: readonly JavaScriptDelimiterContext[] = [],
 ): "postfix-update" | "prefix-update" | undefined {
   const operator = text[start];
   if ((operator !== "+" && operator !== "-") || text[start + 1] !== operator) {
@@ -1358,7 +1404,11 @@ function javaScriptUpdateKind(
     /[\n\r\u2028\u2029]/.test(
       text.slice(previousSignificantToken.end, start),
     ) ||
-    javaScriptRegexMayStart(text, start, previousSignificantToken)
+    javaScriptRegexMayStart(
+      text,
+      previousSignificantToken,
+      delimiterContexts,
+    )
   ) return "prefix-update";
   return "postfix-update";
 }
@@ -1367,6 +1417,7 @@ function javaScriptTokenAt(
   text: string,
   start: number,
   previousSignificantToken: JavaScriptSignificantToken | undefined,
+  delimiterContexts: readonly JavaScriptDelimiterContext[] = [],
 ): JavaScriptScannedToken | undefined {
   const commentEnd = javaScriptCommentEnd(text, start);
   if (commentEnd !== undefined) {
@@ -1385,7 +1436,11 @@ function javaScriptTokenAt(
 
   if (
     character === "/" &&
-    javaScriptRegexMayStart(text, start, previousSignificantToken)
+    javaScriptRegexMayStart(
+      text,
+      previousSignificantToken,
+      delimiterContexts,
+    )
   ) {
     const end = javaScriptRegexEnd(text, start);
     if (end !== undefined) return { end, kind: "regex" };
@@ -1395,6 +1450,7 @@ function javaScriptTokenAt(
     text,
     start,
     previousSignificantToken,
+    delimiterContexts,
   );
   if (updateKind !== undefined) return { end: start + 2, kind: updateKind };
 
@@ -1465,6 +1521,7 @@ function javaScriptLineTokenEnd(
     text,
     start,
     state.previousSignificantToken,
+    state.delimiterContexts,
   );
   if (updateKind !== undefined) {
     const end = start + 2;
@@ -1473,7 +1530,11 @@ function javaScriptLineTokenEnd(
   }
   if (
     character !== "/" ||
-    !javaScriptRegexMayStart(text, start, state.previousSignificantToken)
+    !javaScriptRegexMayStart(
+      text,
+      state.previousSignificantToken,
+      state.delimiterContexts,
+    )
   ) return undefined;
 
   const end = javaScriptRegexEnd(text, start);
@@ -1496,11 +1557,11 @@ function recordJavaScriptDelimiter(
 ): JavaScriptSignificantTokenKind {
   if (character === "(" || character === "[" || character === "{") {
     state.delimiters.push(character);
-    return javaScriptParenthesisTokenKind(
+    return javaScriptDelimiterTokenKind(
       text,
       character,
       previousSignificantToken,
-      state.controlParentheses,
+      state.delimiterContexts,
     );
   }
   const opener = JAVASCRIPT_DELIMITER_CLOSERS[character];
@@ -1510,11 +1571,11 @@ function recordJavaScriptDelimiter(
     return "other";
   }
   state.delimiters.pop();
-  return javaScriptParenthesisTokenKind(
+  return javaScriptDelimiterTokenKind(
     text,
     character,
     previousSignificantToken,
-    state.controlParentheses,
+    state.delimiterContexts,
   );
 }
 
@@ -1555,18 +1616,24 @@ function scanJavaScriptLine(
         cursor + 1,
         kind,
         state.previousSignificantToken,
-        state.controlParentheses.at(-1) === "for",
+        state.delimiterContexts,
       );
       if (!state.valid) return;
     }
     cursor++;
   }
+  if (
+    javaScriptLineTerminatesRestrictedStatement(
+      text,
+      state.previousSignificantToken,
+    )
+  ) state.previousSignificantToken = undefined;
 }
 
 function mdxEsmRangeEnd(text: string, start: number): number | undefined {
   const state: JavaScriptBalance = {
     delimiters: [],
-    controlParentheses: [],
+    delimiterContexts: [],
     quote: undefined,
     blockComment: false,
     templateEnd: start,
@@ -1801,7 +1868,7 @@ function scanTagSyntax(
   let quote: JavaScriptQuote | undefined;
   let quoteUsesJavaScriptEscapes = false;
   let expressionDepth = 0;
-  const controlParentheses: JavaScriptControlParenthesis[] = [];
+  const delimiterContexts: JavaScriptDelimiterContext[] = [];
   let previousSignificantToken: JavaScriptSignificantToken | undefined;
   let cursor = start;
   while (cursor < text.length) {
@@ -1824,11 +1891,22 @@ function scanTagSyntax(
       ? javaScriptCommentEnd(text, cursor)
       : undefined;
     if (commentEnd !== undefined) {
+      previousSignificantToken = javaScriptPreviousSignificantTokenAfterTrivia(
+        text,
+        cursor,
+        commentEnd,
+        previousSignificantToken,
+      );
       cursor = commentEnd;
       continue;
     }
     const updateKind = expressionDepth > 0
-      ? javaScriptUpdateKind(text, cursor, previousSignificantToken)
+      ? javaScriptUpdateKind(
+        text,
+        cursor,
+        previousSignificantToken,
+        delimiterContexts,
+      )
       : undefined;
     if (updateKind !== undefined) {
       cursor += 2;
@@ -1837,7 +1915,11 @@ function scanTagSyntax(
     }
     if (
       expressionDepth > 0 && character === "/" &&
-      javaScriptRegexMayStart(text, cursor, previousSignificantToken)
+      javaScriptRegexMayStart(
+        text,
+        previousSignificantToken,
+        delimiterContexts,
+      )
     ) {
       const regexEnd = javaScriptRegexEnd(text, cursor);
       if (regexEnd !== undefined) {
@@ -1861,15 +1943,21 @@ function scanTagSyntax(
       }
     }
     if (expressionDepth > 0 && /\s/.test(character)) {
+      previousSignificantToken = javaScriptPreviousSignificantTokenAfterTrivia(
+        text,
+        cursor,
+        cursor + 1,
+        previousSignificantToken,
+      );
       cursor++;
       continue;
     }
     if (expressionDepth > 0) {
-      const kind = javaScriptParenthesisTokenKind(
+      const kind = javaScriptDelimiterTokenKind(
         text,
         character,
         previousSignificantToken,
-        controlParentheses,
+        delimiterContexts,
       );
       previousSignificantToken = javaScriptTokenWithIdentifierContext(
         text,
@@ -1877,7 +1965,7 @@ function scanTagSyntax(
         cursor + 1,
         kind,
         previousSignificantToken,
-        controlParentheses.at(-1) === "for",
+        delimiterContexts,
       );
     } else if (character === "{") {
       previousSignificantToken = { end: cursor + 1, kind: "other" };

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -791,7 +791,9 @@ type JavaScriptPrecedingIdentifierKeyword =
   | "break"
   | "continue"
   | "export"
-  | "for";
+  | "for"
+  | "let"
+  | "var";
 type JavaScriptDelimiterContext =
   | "block"
   | "control"
@@ -867,7 +869,7 @@ function javaScriptTokenWithIdentifierContext(
   );
   const declarationCandidate = continuesIdentifierWord
     ? previousSignificantToken?.declarationCandidate === true
-    : javaScriptMayStartDeclaration(
+    : javaScriptMayStartStatement(
       text,
       previousSignificantToken,
       delimiterContexts,
@@ -905,7 +907,8 @@ function javaScriptTokenWithIdentifierContext(
     const previousWord = previousSignificantToken.identifierKeyword;
     if (
       previousWord === "break" || previousWord === "continue" ||
-      previousWord === "export" || previousWord === "for"
+      previousWord === "export" || previousWord === "for" ||
+      previousWord === "let" || previousWord === "var"
     ) precedingIdentifierKeyword = previousWord;
     followsForOfLeftOperand = delimiterContexts.at(-1) === "for" &&
       javaScriptTokenMayEndForOfLeftOperand(text, previousSignificantToken);
@@ -1012,7 +1015,7 @@ function javaScriptTemplateInterpolationEnd(
         previousSignificantToken,
         delimiterContexts,
       )
-      ? javaScriptJsxTagEnd(text, cursor)
+      ? javaScriptJsxElementEnd(text, cursor)
       : undefined;
     if (jsxTagEnd !== undefined) {
       previousSignificantToken = { end: jsxTagEnd, kind: "other" };
@@ -1133,7 +1136,7 @@ function mdxExpressionAt(
         previousSignificantToken,
         delimiterContexts,
       )
-      ? javaScriptJsxTagEnd(text, cursor)
+      ? javaScriptJsxElementEnd(text, cursor)
       : undefined;
     if (jsxTagEnd !== undefined) {
       previousSignificantToken = { end: jsxTagEnd, kind: "other" };
@@ -1469,7 +1472,7 @@ function javaScriptIdentifierContinueBefore(
     JAVASCRIPT_IDENTIFIER_CONTINUE.test(codePoint);
 }
 
-function javaScriptMayStartDeclaration(
+function javaScriptMayStartStatement(
   text: string,
   token: JavaScriptSignificantToken | undefined,
   delimiterContexts: readonly JavaScriptDelimiterContext[],
@@ -1499,7 +1502,9 @@ function javaScriptLineTerminatesRestrictedStatement(
     finalWord === "debugger"
   ) return true;
   return token.precedingIdentifierKeyword === "break" ||
-    token.precedingIdentifierKeyword === "continue";
+    token.precedingIdentifierKeyword === "continue" ||
+    token.precedingIdentifierKeyword === "let" ||
+    token.precedingIdentifierKeyword === "var";
 }
 
 function javaScriptPreviousSignificantTokenAfterTrivia(
@@ -1578,7 +1583,12 @@ function javaScriptDelimiterTokenKind(
       previousSignificantToken?.kind === "control-header" ||
       previousSignificantToken?.kind === "declaration-header" ||
       (keyword !== undefined &&
-        JAVASCRIPT_BLOCK_PREFIX_KEYWORDS.has(keyword));
+        JAVASCRIPT_BLOCK_PREFIX_KEYWORDS.has(keyword)) ||
+      javaScriptMayStartStatement(
+        text,
+        previousSignificantToken,
+        delimiterContexts,
+      );
     delimiterContexts.push(statementBlock ? "block" : "nested");
   } else if (character === ")" || character === "]" || character === "}") {
     const context = delimiterContexts.pop();
@@ -2088,18 +2098,83 @@ interface TagSyntaxScan {
   readonly topLevelOffsets: ReadonlySet<number>;
 }
 
-function javaScriptJsxTagEnd(
+interface JavaScriptJsxTag {
+  readonly closing: boolean;
+  readonly end: number;
+  readonly name: string;
+  readonly selfClosing: boolean;
+}
+
+function javaScriptJsxTagAt(
+  text: string,
+  start: number,
+): JavaScriptJsxTag | undefined {
+  if (text.startsWith("<>", start)) {
+    return { closing: false, end: start + 2, name: "", selfClosing: false };
+  }
+  if (text.startsWith("</>", start)) {
+    return { closing: true, end: start + 3, name: "", selfClosing: false };
+  }
+
+  const closing = text.startsWith("</", start);
+  const nameStart = start + (closing ? 2 : 1);
+  const nameEnd = mdxJsxNameEnd(text, nameStart);
+  if (nameEnd === undefined) return undefined;
+  const name = text.slice(nameStart, nameEnd);
+  if (!closing) {
+    const end = mdxJsxTagEnd(text, start);
+    if (end === undefined) return undefined;
+    return {
+      closing: false,
+      end,
+      name,
+      selfClosing: text[end - 2] === "/",
+    };
+  }
+  const end = skipJavaScriptTrivia(text, nameEnd);
+  return text[end] === ">"
+    ? { closing: true, end: end + 1, name, selfClosing: false }
+    : undefined;
+}
+
+function javaScriptJsxElementEnd(
   text: string,
   start: number,
 ): number | undefined {
-  if (text.startsWith("<>", start)) return start + 2;
-  if (text.startsWith("</>", start)) return start + 3;
-  if (!text.startsWith("</", start)) return mdxJsxTagEnd(text, start);
+  const opening = javaScriptJsxTagAt(text, start);
+  if (opening === undefined) return undefined;
+  if (opening.closing || opening.selfClosing) return opening.end;
 
-  const nameEnd = mdxJsxNameEnd(text, start + 2);
-  if (nameEnd === undefined) return undefined;
-  const end = skipJavaScriptTrivia(text, nameEnd);
-  return text[end] === ">" ? end + 1 : undefined;
+  const elementNames = [opening.name];
+  let cursor = opening.end;
+  while (cursor < text.length) {
+    if (text[cursor] === "{") {
+      const expression = mdxExpressionAt(text, cursor);
+      if (expression !== undefined) {
+        cursor = expression.expression.end;
+        continue;
+      }
+    }
+    if (text[cursor] !== "<") {
+      cursor++;
+      continue;
+    }
+
+    const tag = javaScriptJsxTagAt(text, cursor);
+    if (tag === undefined) {
+      cursor++;
+      continue;
+    }
+    if (tag.closing) {
+      if (elementNames.at(-1) !== tag.name) return undefined;
+      elementNames.pop();
+      if (elementNames.length === 0) return tag.end;
+    } else if (!tag.selfClosing) {
+      elementNames.push(tag.name);
+    }
+    cursor = tag.end;
+  }
+  return undefined;
 }
 
 function scanTagSyntax(
@@ -2148,7 +2223,7 @@ function scanTagSyntax(
           previousSignificantToken,
           delimiterContexts,
         )
-      ? javaScriptJsxTagEnd(text, cursor)
+      ? javaScriptJsxElementEnd(text, cursor)
       : undefined;
     if (jsxTagEnd !== undefined) {
       previousSignificantToken = { end: jsxTagEnd, kind: "other" };

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -1079,6 +1079,20 @@ const JAVASCRIPT_REGEX_PREFIX_KEYWORDS: ReadonlySet<string> = new Set([
   "new",
 ]);
 
+const JAVASCRIPT_IDENTIFIER_CONTINUE = /[$\u200C\u200D\p{ID_Continue}]/u;
+
+function javaScriptCodePointBefore(
+  text: string,
+  end: number,
+): string | undefined {
+  if (end <= 0) return undefined;
+  const trailing = text.charCodeAt(end - 1);
+  const startsWithSurrogatePair = end > 1 && trailing >= 0xDC00 &&
+    trailing <= 0xDFFF && text.charCodeAt(end - 2) >= 0xD800 &&
+    text.charCodeAt(end - 2) <= 0xDBFF;
+  return text.slice(end - (startsWithSurrogatePair ? 2 : 1), end);
+}
+
 function javaScriptRegexMayStart(
   text: string,
   previousSignificantToken: JavaScriptSignificantToken | undefined,
@@ -1098,8 +1112,10 @@ function javaScriptRegexMayStart(
   const keyword = text.slice(wordStart, end);
   if (!JAVASCRIPT_REGEX_PREFIX_KEYWORDS.has(keyword)) return false;
 
-  return wordStart === 0 ||
-    !/[A-Za-z0-9_$.#]/.test(text[wordStart - 1]!);
+  const preceding = javaScriptCodePointBefore(text, wordStart);
+  return preceding === undefined ||
+    (preceding !== "." && preceding !== "#" &&
+      !JAVASCRIPT_IDENTIFIER_CONTINUE.test(preceding));
 }
 
 function javaScriptUpdateKind(

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -777,8 +777,10 @@ interface MdxSyntaxRanges {
 // Keep those scanner surfaces on this shared state model, and regression-test
 // both the regex and division forms when adding a new grammar context.
 type JavaScriptSignificantTokenKind =
+  | "arrow"
   | "control-header"
   | "declaration-header"
+  | "expression-header"
   | "other"
   | "postfix-update"
   | "prefix-update"
@@ -795,15 +797,21 @@ type JavaScriptDelimiterContext =
   | "control"
   | "for"
   | "function-declaration"
+  | "function-expression"
+  | "function-body"
   | "nested"
   | undefined;
 
 interface JavaScriptSignificantToken {
+  readonly classDeclaration?: true;
+  readonly declarationCandidate?: true;
   readonly end: number;
   readonly functionDeclaration?: true;
-  readonly functionDeclarationCandidate?: true;
   readonly functionDeclarationPrefix?: true;
+  readonly functionHeader?: true;
   readonly identifier?: true;
+  readonly identifierKeyword?: string;
+  readonly identifierKeywordCandidate?: string;
   readonly kind: JavaScriptSignificantTokenKind;
   readonly followsForOfLeftOperand?: true;
   readonly precedingIdentifierKeyword?: JavaScriptPrecedingIdentifierKeyword;
@@ -833,6 +841,10 @@ function javaScriptTokenWithIdentifierContext(
           previousSignificantToken?.functionDeclaration === true
         ? { functionDeclaration: true }
         : {}),
+      ...(text[start] === "*" &&
+          previousSignificantToken?.functionHeader === true
+        ? { functionHeader: true }
+        : {}),
       kind,
     };
   }
@@ -847,25 +859,39 @@ function javaScriptTokenWithIdentifierContext(
   const identifier = continuesIdentifierWord
     ? previousSignificantToken?.identifier === true
     : javaScriptIdentifierStartsAt(text, start);
-  const functionDeclarationCandidate = continuesIdentifierWord
-    ? previousSignificantToken?.functionDeclarationCandidate === true
-    : javaScriptMayStartFunctionDeclaration(
+  const identifierKeywordCandidate = javaScriptIdentifierKeywordCandidate(
+    text,
+    start,
+    continuesIdentifierWord,
+    previousSignificantToken,
+  );
+  const declarationCandidate = continuesIdentifierWord
+    ? previousSignificantToken?.declarationCandidate === true
+    : javaScriptMayStartDeclaration(
       text,
       previousSignificantToken,
       delimiterContexts,
     );
-  const word = javaScriptIdentifierWordAtEnd(text, end);
-  const completeIdentifier = word !== undefined &&
-    !javaScriptIdentifierCodeUnitAt(text, end);
+  const completeIdentifier = !javaScriptIdentifierCodeUnitAt(text, end);
+  const identifierKeyword = completeIdentifier &&
+      identifierKeywordCandidate !== undefined &&
+      JAVASCRIPT_IDENTIFIER_KEYWORDS.has(identifierKeywordCandidate)
+    ? identifierKeywordCandidate
+    : undefined;
   const functionDeclarationPrefix = completeIdentifier &&
-    ((word === "export" || word === "async") &&
-        functionDeclarationCandidate ||
-      word === "default" &&
+    ((identifierKeyword === "export" || identifierKeyword === "async") &&
+        declarationCandidate ||
+      identifierKeyword === "default" &&
         previousSignificantToken?.functionDeclarationPrefix === true);
   const functionDeclaration =
     previousSignificantToken?.functionDeclaration === true ||
-    (completeIdentifier && word === "function" &&
-      functionDeclarationCandidate);
+    (identifierKeyword === "function" &&
+      declarationCandidate);
+  const functionHeader = previousSignificantToken?.functionHeader === true ||
+    identifierKeyword === "function";
+  const classDeclaration =
+    previousSignificantToken?.classDeclaration === true ||
+    (identifierKeyword === "class" && declarationCandidate);
   let precedingIdentifierKeyword:
     | JavaScriptPrecedingIdentifierKeyword
     | undefined;
@@ -876,10 +902,7 @@ function javaScriptTokenWithIdentifierContext(
     followsForOfLeftOperand =
       previousSignificantToken?.followsForOfLeftOperand === true;
   } else if (previousSignificantToken !== undefined) {
-    const previousWord = javaScriptIdentifierWordAtEnd(
-      text,
-      previousSignificantToken.end,
-    );
+    const previousWord = previousSignificantToken.identifierKeyword;
     if (
       previousWord === "break" || previousWord === "continue" ||
       previousWord === "export" || previousWord === "for"
@@ -889,13 +912,19 @@ function javaScriptTokenWithIdentifierContext(
   }
 
   return {
+    ...(classDeclaration ? { classDeclaration: true } : {}),
+    ...(declarationCandidate && !completeIdentifier
+      ? { declarationCandidate: true }
+      : {}),
     end,
     ...(functionDeclaration ? { functionDeclaration: true } : {}),
-    ...(functionDeclarationCandidate && !completeIdentifier
-      ? { functionDeclarationCandidate: true }
-      : {}),
     ...(functionDeclarationPrefix ? { functionDeclarationPrefix: true } : {}),
+    ...(functionHeader ? { functionHeader: true } : {}),
     ...(identifier ? { identifier: true } : {}),
+    ...(identifierKeyword === undefined ? {} : { identifierKeyword }),
+    ...(identifierKeywordCandidate === undefined || completeIdentifier
+      ? {}
+      : { identifierKeywordCandidate }),
     kind,
     ...(followsForOfLeftOperand ? { followsForOfLeftOperand: true } : {}),
     ...(precedingIdentifierKeyword === undefined
@@ -978,6 +1007,18 @@ function javaScriptTemplateInterpolationEnd(
   const delimiterContexts: JavaScriptDelimiterContext[] = ["nested"];
   let previousSignificantToken: JavaScriptSignificantToken | undefined;
   while (cursor < text.length) {
+    const jsxTagEnd = text[cursor] === "<" && javaScriptRegexMayStart(
+        text,
+        previousSignificantToken,
+        delimiterContexts,
+      )
+      ? javaScriptJsxTagEnd(text, cursor)
+      : undefined;
+    if (jsxTagEnd !== undefined) {
+      previousSignificantToken = { end: jsxTagEnd, kind: "other" };
+      cursor = jsxTagEnd;
+      continue;
+    }
     const token = javaScriptTokenAt(
       text,
       cursor,
@@ -1087,6 +1128,18 @@ function mdxExpressionAt(
   const delimiterContexts: JavaScriptDelimiterContext[] = ["nested"];
   let previousSignificantToken: JavaScriptSignificantToken | undefined;
   while (cursor < text.length) {
+    const jsxTagEnd = text[cursor] === "<" && javaScriptRegexMayStart(
+        text,
+        previousSignificantToken,
+        delimiterContexts,
+      )
+      ? javaScriptJsxTagEnd(text, cursor)
+      : undefined;
+    if (jsxTagEnd !== undefined) {
+      previousSignificantToken = { end: jsxTagEnd, kind: "other" };
+      cursor = jsxTagEnd;
+      continue;
+    }
     const token = javaScriptTokenAt(
       text,
       cursor,
@@ -1260,11 +1313,39 @@ const JAVASCRIPT_CONTROL_HEADER_KEYWORDS: ReadonlySet<string> = new Set([
 ]);
 
 const JAVASCRIPT_BLOCK_PREFIX_KEYWORDS: ReadonlySet<string> = new Set([
+  "catch",
   "do",
   "else",
   "finally",
   "try",
 ]);
+
+const JAVASCRIPT_IDENTIFIER_KEYWORDS: ReadonlySet<string> = new Set([
+  ...JAVASCRIPT_REGEX_PREFIX_KEYWORDS,
+  ...JAVASCRIPT_CONTROL_HEADER_KEYWORDS,
+  ...JAVASCRIPT_BLOCK_PREFIX_KEYWORDS,
+  "async",
+  "break",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "export",
+  "function",
+  "let",
+  "of",
+  "using",
+  "var",
+]);
+
+const JAVASCRIPT_IDENTIFIER_KEYWORD_PREFIXES: ReadonlySet<string> = new Set(
+  [...JAVASCRIPT_IDENTIFIER_KEYWORDS].flatMap((keyword) =>
+    Array.from(
+      { length: keyword.length },
+      (_, index) => keyword.slice(0, index + 1),
+    )
+  ),
+);
 
 const JAVASCRIPT_IDENTIFIER_START = /[$_\p{ID_Start}]/u;
 const JAVASCRIPT_IDENTIFIER_CONTINUE = /[$_\u200C\u200D\p{ID_Continue}]/u;
@@ -1330,6 +1411,32 @@ function javaScriptIdentifierStartsAt(
   );
 }
 
+function javaScriptIdentifierKeywordCandidate(
+  text: string,
+  start: number,
+  continuesIdentifier: boolean,
+  previousSignificantToken: JavaScriptSignificantToken | undefined,
+): string | undefined {
+  const character = text[start]!;
+  if (!/[A-Za-z]/.test(character)) return undefined;
+  if (!continuesIdentifier) {
+    if (
+      previousSignificantToken !== undefined &&
+      ".#".includes(text[previousSignificantToken.end - 1]!)
+    ) return undefined;
+    return JAVASCRIPT_IDENTIFIER_KEYWORD_PREFIXES.has(character)
+      ? character
+      : undefined;
+  }
+
+  const previous = previousSignificantToken?.identifierKeywordCandidate;
+  if (previous === undefined) return undefined;
+  const candidate = previous + character;
+  return JAVASCRIPT_IDENTIFIER_KEYWORD_PREFIXES.has(candidate)
+    ? candidate
+    : undefined;
+}
+
 function javaScriptCodePointBefore(
   text: string,
   end: number,
@@ -1362,34 +1469,18 @@ function javaScriptIdentifierContinueBefore(
     JAVASCRIPT_IDENTIFIER_CONTINUE.test(codePoint);
 }
 
-function javaScriptIdentifierWordAtEnd(
-  text: string,
-  end: number,
-): string | undefined {
-  let start = end;
-  while (start > 0 && /[A-Za-z]/.test(text[start - 1]!)) start--;
-  if (start === end) return undefined;
-
-  const preceding = javaScriptCodePointBefore(text, start);
-  if (
-    preceding !== undefined &&
-    (preceding === "." || preceding === "#" ||
-      javaScriptIdentifierContinueBefore(text, start))
-  ) return undefined;
-  return text.slice(start, end);
-}
-
-function javaScriptMayStartFunctionDeclaration(
+function javaScriptMayStartDeclaration(
   text: string,
   token: JavaScriptSignificantToken | undefined,
   delimiterContexts: readonly JavaScriptDelimiterContext[],
 ): boolean {
   if (
-    delimiterContexts.length > 0 && delimiterContexts.at(-1) !== "block"
+    delimiterContexts.length > 0 && delimiterContexts.at(-1) !== "block" &&
+    delimiterContexts.at(-1) !== "function-body"
   ) return false;
   if (token === undefined) return true;
   if (token.functionDeclarationPrefix === true) return true;
-  const word = javaScriptIdentifierWordAtEnd(text, token.end);
+  const word = token.identifierKeyword;
   if (word === "export") return true;
   if (
     (word === "default" || word === "async") &&
@@ -1399,11 +1490,10 @@ function javaScriptMayStartFunctionDeclaration(
 }
 
 function javaScriptLineTerminatesRestrictedStatement(
-  text: string,
   token: JavaScriptSignificantToken | undefined,
 ): boolean {
   if (token === undefined) return false;
-  const finalWord = javaScriptIdentifierWordAtEnd(text, token.end);
+  const finalWord = token.identifierKeyword;
   if (
     finalWord === "break" || finalWord === "continue" ||
     finalWord === "debugger"
@@ -1420,7 +1510,7 @@ function javaScriptPreviousSignificantTokenAfterTrivia(
 ): JavaScriptSignificantToken | undefined {
   if (
     /[\n\r\u2028\u2029]/.test(text.slice(start, end)) &&
-    javaScriptLineTerminatesRestrictedStatement(text, token)
+    javaScriptLineTerminatesRestrictedStatement(token)
   ) return undefined;
   return token;
 }
@@ -1429,7 +1519,7 @@ function javaScriptTokenMayEndForOfLeftOperand(
   text: string,
   token: JavaScriptSignificantToken,
 ): boolean {
-  const word = javaScriptIdentifierWordAtEnd(text, token.end);
+  const word = token.identifierKeyword;
   if (token.identifier === true) {
     if (word === undefined) return true;
     return !JAVASCRIPT_REGEX_PREFIX_KEYWORDS.has(word) &&
@@ -1446,13 +1536,17 @@ function javaScriptDelimiterTokenKind(
   previousSignificantToken: JavaScriptSignificantToken | undefined,
   delimiterContexts: JavaScriptDelimiterContext[],
 ): JavaScriptSignificantTokenKind {
+  if (
+    character === ">" && previousSignificantToken !== undefined &&
+    text[previousSignificantToken.end - 1] === "="
+  ) return "arrow";
   if (character === "(") {
-    const keyword = previousSignificantToken === undefined
-      ? undefined
-      : javaScriptIdentifierWordAtEnd(text, previousSignificantToken.end);
+    const keyword = previousSignificantToken?.identifierKeyword;
     let context: JavaScriptDelimiterContext;
-    if (previousSignificantToken?.functionDeclaration === true) {
-      context = "function-declaration";
+    if (previousSignificantToken?.functionHeader === true) {
+      context = previousSignificantToken.functionDeclaration === true
+        ? "function-declaration"
+        : "function-expression";
     } else if (
       keyword === "for" ||
       (keyword === "await" &&
@@ -1468,9 +1562,18 @@ function javaScriptDelimiterTokenKind(
   } else if (character === "[") {
     delimiterContexts.push("nested");
   } else if (character === "{") {
-    const keyword = previousSignificantToken === undefined
-      ? undefined
-      : javaScriptIdentifierWordAtEnd(text, previousSignificantToken.end);
+    const keyword = previousSignificantToken?.identifierKeyword;
+    if (previousSignificantToken?.classDeclaration === true) {
+      delimiterContexts.push("block");
+      return "other";
+    }
+    if (
+      previousSignificantToken?.kind === "arrow" ||
+      previousSignificantToken?.kind === "expression-header"
+    ) {
+      delimiterContexts.push("function-body");
+      return "other";
+    }
     const statementBlock =
       previousSignificantToken?.kind === "control-header" ||
       previousSignificantToken?.kind === "declaration-header" ||
@@ -1481,6 +1584,7 @@ function javaScriptDelimiterTokenKind(
     const context = delimiterContexts.pop();
     if (context === "control" || context === "for") return "control-header";
     if (context === "function-declaration") return "declaration-header";
+    if (context === "function-expression") return "expression-header";
     if (context === "block") return "statement-block";
   }
   return "other";
@@ -1506,7 +1610,7 @@ function javaScriptRegexMayStart(
   if (text.slice(end - 3, end) === "...") return true;
   if ("=(:,![{;?&|+*%/^~<>-".includes(text[end - 1]!)) return true;
 
-  const keyword = javaScriptIdentifierWordAtEnd(text, end);
+  const keyword = previousSignificantToken.identifierKeyword;
   if (
     keyword === "of" && delimiterContexts.at(-1) === "for" &&
     previousSignificantToken.followsForOfLeftOperand === true
@@ -1749,7 +1853,6 @@ function scanJavaScriptLine(
   }
   if (
     javaScriptLineTerminatesRestrictedStatement(
-      text,
       state.previousSignificantToken,
     )
   ) state.previousSignificantToken = undefined;
@@ -1985,6 +2088,20 @@ interface TagSyntaxScan {
   readonly topLevelOffsets: ReadonlySet<number>;
 }
 
+function javaScriptJsxTagEnd(
+  text: string,
+  start: number,
+): number | undefined {
+  if (text.startsWith("<>", start)) return start + 2;
+  if (text.startsWith("</>", start)) return start + 3;
+  if (!text.startsWith("</", start)) return mdxJsxTagEnd(text, start);
+
+  const nameEnd = mdxJsxNameEnd(text, start + 2);
+  if (nameEnd === undefined) return undefined;
+  const end = skipJavaScriptTrivia(text, nameEnd);
+  return text[end] === ">" ? end + 1 : undefined;
+}
+
 function scanTagSyntax(
   text: string,
   start: number,
@@ -2023,6 +2140,19 @@ function scanTagSyntax(
         previousSignificantToken,
       );
       cursor = commentEnd;
+      continue;
+    }
+    const jsxTagEnd = expressionDepth > 0 && character === "<" &&
+        javaScriptRegexMayStart(
+          text,
+          previousSignificantToken,
+          delimiterContexts,
+        )
+      ? javaScriptJsxTagEnd(text, cursor)
+      : undefined;
+    if (jsxTagEnd !== undefined) {
+      previousSignificantToken = { end: jsxTagEnd, kind: "other" };
+      cursor = jsxTagEnd;
       continue;
     }
     const updateKind = expressionDepth > 0

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -782,7 +782,11 @@ interface JavaScriptSignificantToken {
   readonly end: number;
   readonly kind: JavaScriptSignificantTokenKind;
   readonly followsForKeyword?: true;
+  readonly insideForHeader?: true;
+  readonly lineTerminatedStatement?: true;
 }
+
+type JavaScriptControlParenthesis = "for" | "other" | "statement";
 
 type JavaScriptQuote = '"' | "'";
 type JavaScriptStringDelimiter = JavaScriptQuote | "`";
@@ -799,6 +803,7 @@ function javaScriptTokenWithIdentifierContext(
   end: number,
   kind: JavaScriptSignificantTokenKind,
   previousSignificantToken: JavaScriptSignificantToken | undefined,
+  insideForHeader: boolean,
 ): JavaScriptSignificantToken {
   if (!/[A-Za-z]/.test(text[start]!)) return { end, kind };
 
@@ -813,8 +818,23 @@ function javaScriptTokenWithIdentifierContext(
         "for";
   }
 
-  if (!followsForKeyword) return { end, kind };
-  return { end, kind, followsForKeyword: true };
+  const word = javaScriptIdentifierWordAtEnd(text, end);
+  const lineTerminatedStatement = (word !== undefined &&
+    JAVASCRIPT_LINE_TERMINATED_STATEMENT_KEYWORDS.has(word)) ||
+    previousSignificantToken?.lineTerminatedStatement === true;
+  const contextualToken: {
+    end: number;
+    kind: JavaScriptSignificantTokenKind;
+    followsForKeyword?: true;
+    insideForHeader?: true;
+    lineTerminatedStatement?: true;
+  } = { end, kind };
+  if (followsForKeyword) contextualToken.followsForKeyword = true;
+  if (insideForHeader) contextualToken.insideForHeader = true;
+  if (lineTerminatedStatement) {
+    contextualToken.lineTerminatedStatement = true;
+  }
+  return contextualToken;
 }
 
 function significantJavaScriptToken(
@@ -822,7 +842,7 @@ function significantJavaScriptToken(
   start: number,
   token: JavaScriptScannedToken,
   previousSignificantToken: JavaScriptSignificantToken | undefined,
-  controlParentheses: boolean[],
+  controlParentheses: JavaScriptControlParenthesis[],
 ): JavaScriptSignificantToken {
   const kind = token.kind === "other"
     ? javaScriptParenthesisTokenKind(
@@ -840,6 +860,7 @@ function significantJavaScriptToken(
     token.end,
     kind,
     previousSignificantToken,
+    controlParentheses.at(-1) === "for",
   );
 }
 
@@ -884,7 +905,7 @@ function javaScriptTemplateInterpolationEnd(
 ): number | undefined {
   let depth = 1;
   let cursor = start + 2;
-  const controlParentheses: boolean[] = [];
+  const controlParentheses: JavaScriptControlParenthesis[] = [];
   let previousSignificantToken: JavaScriptSignificantToken | undefined;
   while (cursor < text.length) {
     const token = javaScriptTokenAt(
@@ -986,7 +1007,7 @@ function mdxExpressionAt(
   const strings: Range[] = [];
   let depth = 1;
   let cursor = start + 1;
-  const controlParentheses: boolean[] = [];
+  const controlParentheses: JavaScriptControlParenthesis[] = [];
   let previousSignificantToken: JavaScriptSignificantToken | undefined;
   while (cursor < text.length) {
     const token = javaScriptTokenAt(
@@ -1097,7 +1118,7 @@ function mdxEsmMayStart(text: string, lineStart: number): boolean {
 
 interface JavaScriptBalance {
   readonly delimiters: string[];
-  readonly controlParentheses: boolean[];
+  readonly controlParentheses: JavaScriptControlParenthesis[];
   quote: JavaScriptQuote | undefined;
   blockComment: boolean;
   templateEnd: number;
@@ -1150,6 +1171,13 @@ const JAVASCRIPT_CONTROL_HEADER_KEYWORDS: ReadonlySet<string> = new Set([
   "while",
   "with",
 ]);
+
+const JAVASCRIPT_LINE_TERMINATED_STATEMENT_KEYWORDS: ReadonlySet<string> =
+  new Set([
+    "break",
+    "continue",
+    "debugger",
+  ]);
 
 const JAVASCRIPT_IDENTIFIER_CONTINUE = /[$\u200C\u200D\p{ID_Continue}]/u;
 const JAVASCRIPT_IDENTIFIER_ESCAPE =
@@ -1208,29 +1236,43 @@ function javaScriptParenthesisTokenKind(
   text: string,
   character: string,
   previousSignificantToken: JavaScriptSignificantToken | undefined,
-  controlParentheses: boolean[],
+  controlParentheses: JavaScriptControlParenthesis[],
 ): JavaScriptSignificantTokenKind {
   if (character === "(") {
     const keyword = previousSignificantToken === undefined
       ? undefined
       : javaScriptIdentifierWordAtEnd(text, previousSignificantToken.end);
-    controlParentheses.push(
-      (keyword !== undefined &&
-        JAVASCRIPT_CONTROL_HEADER_KEYWORDS.has(keyword)) ||
-        (keyword === "await" &&
-          previousSignificantToken?.followsForKeyword === true),
-    );
-  } else if (character === ")" && controlParentheses.pop()) {
-    return "control-header";
+    if (
+      keyword === "for" ||
+      (keyword === "await" &&
+        previousSignificantToken?.followsForKeyword === true)
+    ) controlParentheses.push("for");
+    else if (
+      keyword !== undefined &&
+      JAVASCRIPT_CONTROL_HEADER_KEYWORDS.has(keyword)
+    ) controlParentheses.push("statement");
+    else controlParentheses.push("other");
+  } else if (character === ")") {
+    const context = controlParentheses.pop();
+    if (context === "for" || context === "statement") {
+      return "control-header";
+    }
   }
   return "other";
 }
 
 function javaScriptRegexMayStart(
   text: string,
+  start: number,
   previousSignificantToken: JavaScriptSignificantToken | undefined,
 ): boolean {
   if (previousSignificantToken === undefined) return true;
+  if (
+    previousSignificantToken.lineTerminatedStatement === true &&
+    /[\n\r\u2028\u2029]/.test(
+      text.slice(previousSignificantToken.end, start),
+    )
+  ) return true;
   if (
     previousSignificantToken.kind === "control-header" ||
     previousSignificantToken.kind === "prefix-update"
@@ -1245,7 +1287,9 @@ function javaScriptRegexMayStart(
   if ("=(:,![{;?&|+*%/^~<>-".includes(text[end - 1]!)) return true;
 
   const keyword = javaScriptIdentifierWordAtEnd(text, end);
-  return keyword !== undefined && JAVASCRIPT_REGEX_PREFIX_KEYWORDS.has(keyword);
+  return keyword !== undefined &&
+    (JAVASCRIPT_REGEX_PREFIX_KEYWORDS.has(keyword) ||
+      (keyword === "of" && previousSignificantToken.insideForHeader === true));
 }
 
 function javaScriptUpdateKind(
@@ -1262,7 +1306,7 @@ function javaScriptUpdateKind(
     /[\n\r\u2028\u2029]/.test(
       text.slice(previousSignificantToken.end, start),
     ) ||
-    javaScriptRegexMayStart(text, previousSignificantToken)
+    javaScriptRegexMayStart(text, start, previousSignificantToken)
   ) return "prefix-update";
   return "postfix-update";
 }
@@ -1289,7 +1333,7 @@ function javaScriptTokenAt(
 
   if (
     character === "/" &&
-    javaScriptRegexMayStart(text, previousSignificantToken)
+    javaScriptRegexMayStart(text, start, previousSignificantToken)
   ) {
     const end = javaScriptRegexEnd(text, start);
     if (end !== undefined) return { end, kind: "regex" };
@@ -1377,7 +1421,7 @@ function javaScriptLineTokenEnd(
   }
   if (
     character !== "/" ||
-    !javaScriptRegexMayStart(text, state.previousSignificantToken)
+    !javaScriptRegexMayStart(text, start, state.previousSignificantToken)
   ) return undefined;
 
   const end = javaScriptRegexEnd(text, start);
@@ -1459,6 +1503,7 @@ function scanJavaScriptLine(
         cursor + 1,
         kind,
         state.previousSignificantToken,
+        state.controlParentheses.at(-1) === "for",
       );
       if (!state.valid) return;
     }
@@ -1704,7 +1749,7 @@ function scanTagSyntax(
   let quote: JavaScriptQuote | undefined;
   let quoteUsesJavaScriptEscapes = false;
   let expressionDepth = 0;
-  const controlParentheses: boolean[] = [];
+  const controlParentheses: JavaScriptControlParenthesis[] = [];
   let previousSignificantToken: JavaScriptSignificantToken | undefined;
   let cursor = start;
   while (cursor < text.length) {
@@ -1740,7 +1785,7 @@ function scanTagSyntax(
     }
     if (
       expressionDepth > 0 && character === "/" &&
-      javaScriptRegexMayStart(text, previousSignificantToken)
+      javaScriptRegexMayStart(text, cursor, previousSignificantToken)
     ) {
       const regexEnd = javaScriptRegexEnd(text, cursor);
       if (regexEnd !== undefined) {
@@ -1780,6 +1825,7 @@ function scanTagSyntax(
         cursor + 1,
         kind,
         previousSignificantToken,
+        controlParentheses.at(-1) === "for",
       );
     } else if (character === "{") {
       previousSignificantToken = { end: cursor + 1, kind: "other" };

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -781,6 +781,7 @@ type JavaScriptSignificantTokenKind =
 interface JavaScriptSignificantToken {
   readonly end: number;
   readonly kind: JavaScriptSignificantTokenKind;
+  readonly followsForKeyword?: true;
 }
 
 type JavaScriptQuote = '"' | "'";
@@ -790,6 +791,29 @@ interface JavaScriptScannedToken {
   readonly end: number;
   readonly kind: JavaScriptSignificantTokenKind | "literal" | "trivia";
   readonly string?: Range;
+}
+
+function javaScriptTokenWithIdentifierContext(
+  text: string,
+  start: number,
+  end: number,
+  kind: JavaScriptSignificantTokenKind,
+  previousSignificantToken: JavaScriptSignificantToken | undefined,
+): JavaScriptSignificantToken {
+  if (!/[A-Za-z]/.test(text[start]!)) return { end, kind };
+
+  const continuesIdentifierWord = start > 0 &&
+    /[A-Za-z]/.test(text[start - 1]!);
+  const followsForKeyword = continuesIdentifierWord
+    ? previousSignificantToken?.followsForKeyword === true
+    : previousSignificantToken === undefined
+    ? false
+    : javaScriptIdentifierWordAtEnd(text, previousSignificantToken.end) ===
+      "for";
+  return followsForKeyword ? { end, kind, followsForKeyword: true } : {
+    end,
+    kind,
+  };
 }
 
 function significantJavaScriptToken(
@@ -809,7 +833,13 @@ function significantJavaScriptToken(
     : token.kind === "literal" || token.kind === "trivia"
     ? "other"
     : token.kind;
-  return { end: token.end, kind };
+  return javaScriptTokenWithIdentifierContext(
+    text,
+    start,
+    token.end,
+    kind,
+    previousSignificantToken,
+  );
 }
 
 function quotedRangeEnd(
@@ -1109,6 +1139,8 @@ const JAVASCRIPT_REGEX_PREFIX_KEYWORDS: ReadonlySet<string> = new Set([
   "new",
   "await",
   "yield",
+  "else",
+  "do",
 ]);
 
 const JAVASCRIPT_CONTROL_HEADER_KEYWORDS: ReadonlySet<string> = new Set([
@@ -1182,7 +1214,10 @@ function javaScriptParenthesisTokenKind(
       ? undefined
       : javaScriptIdentifierWordAtEnd(text, previousSignificantToken.end);
     controlParentheses.push(
-      keyword !== undefined && JAVASCRIPT_CONTROL_HEADER_KEYWORDS.has(keyword),
+      (keyword !== undefined &&
+        JAVASCRIPT_CONTROL_HEADER_KEYWORDS.has(keyword)) ||
+        (keyword === "await" &&
+          previousSignificantToken?.followsForKeyword === true),
     );
   } else if (character === ")" && controlParentheses.pop()) {
     return "control-header";
@@ -1417,7 +1452,13 @@ function scanJavaScriptLine(
         state.previousSignificantToken,
         state,
       );
-      state.previousSignificantToken = { end: cursor + 1, kind };
+      state.previousSignificantToken = javaScriptTokenWithIdentifierContext(
+        text,
+        cursor,
+        cursor + 1,
+        kind,
+        state.previousSignificantToken,
+      );
       if (!state.valid) return;
     }
     cursor++;
@@ -1732,7 +1773,13 @@ function scanTagSyntax(
         previousSignificantToken,
         controlParentheses,
       );
-      previousSignificantToken = { end: cursor + 1, kind };
+      previousSignificantToken = javaScriptTokenWithIdentifierContext(
+        text,
+        cursor,
+        cursor + 1,
+        kind,
+        previousSignificantToken,
+      );
     } else if (character === "{") {
       previousSignificantToken = { end: cursor + 1, kind: "other" };
     }

--- a/scripts/docs/validate-public-docs.ts
+++ b/scripts/docs/validate-public-docs.ts
@@ -804,16 +804,17 @@ function javaScriptTokenWithIdentifierContext(
 
   const continuesIdentifierWord = start > 0 &&
     /[A-Za-z]/.test(text[start - 1]!);
-  const followsForKeyword = continuesIdentifierWord
-    ? previousSignificantToken?.followsForKeyword === true
-    : previousSignificantToken === undefined
-    ? false
-    : javaScriptIdentifierWordAtEnd(text, previousSignificantToken.end) ===
-      "for";
-  return followsForKeyword ? { end, kind, followsForKeyword: true } : {
-    end,
-    kind,
-  };
+  let followsForKeyword = false;
+  if (continuesIdentifierWord) {
+    followsForKeyword = previousSignificantToken?.followsForKeyword === true;
+  } else if (previousSignificantToken !== undefined) {
+    followsForKeyword =
+      javaScriptIdentifierWordAtEnd(text, previousSignificantToken.end) ===
+        "for";
+  }
+
+  if (!followsForKeyword) return { end, kind };
+  return { end, kind, followsForKeyword: true };
 }
 
 function significantJavaScriptToken(


### PR DESCRIPTION
Follow-up to #4275 for review findings that arrived after its merge-queue admission.

## Summary

- preserve JavaScript regex and recursive template boundaries across JSX, MDX expressions, template interpolation, and ESM scanning
- distinguish contextual for-of separators from ordinary division, including nested for headers and for-await
- track IdentifierStart and IdentifierContinue explicitly so digit, punctuation, Unicode, and escaped for-of identifiers preserve regex context
- apply line-terminator handling only to complete break, continue, and debugger statements
- match CommonMark comment, reference-title, reference-image, and quote-prefixed destination semantics
- tolerantly decode valid URL escapes beside malformed sequences

## Review disposition

- All concrete inline review findings are fixed and their threads are resolved.
- An independent exact-head review found the remaining non-ASCII and escaped for-of identifier gap. Commit d119f62ff9 fixes it with explicit token identity and regressions across every shared scanner surface.
- Sonar identified two duplicated code-unit checks after that fix. Commit 06ac054ace keeps both checks on the existing code-point API; surrogate-equivalence probes and focused tests confirm no behavior change.
- The CodeRabbit risk summary at 490fff mapped to its concrete quoted and parenthesized destination finding. That finding was fixed in ffc94a8 with regressions, so the review did not leave an unidentified missing-target form to track.
- The JavaScript scan is intentionally a bounded lexical scanner, not a full parser. Commit c9486e3632 documents the shared-state contract and requires paired regex and division regressions for new grammar contexts. No dependency was added.

## Test plan

- focused public-doc validator suite: 53 steps passed
- forced per-file format, lint, and typecheck passed
- public-doc validation: 128 files passed
- required pre-push hook at 06ac054ace:
  - format: 5,248 files
  - lint: 5,171 files
  - typecheck: passed
  - unit tests: 4,390 tests and 36,337 steps passed, 0 failed
  - cwd suites: 5 tests and 117 steps passed, 0 failed
- two independent exact-diff reviews approved the identifier fix; an additional exact-diff review approved the Sonar cleanup

Exact-head GitHub checks and automated review remain authoritative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation link validation across complex JavaScript, JSX, MDX, and template syntax.
  * Corrected handling of URLs, inline-link tooltips, HTML tags, comments, and encoded paths.
  * Prevented quoted JSX attributes from being incorrectly interpreted as nested tags.

* **Performance**
  * Improved validation performance for long identifiers and deeply nested or malformed JSX content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->