### PR TITLE
fix(sonar): exclude tests from duplication metrics

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,7 +8,7 @@ sonar.exclusions=coverage-profiles/**
 # Test fixtures and assertions are intentionally repetitive. Keep test files
 # in the analysis so their issues remain visible, but exclude them from CPD so
 # the duplication gate measures production implementation duplication.
-sonar.cpd.exclusions=**/*.test.*,**/*.spec.*,tests/**
+sonar.cpd.exclusions=**/*.test.*,**/*.spec.*,**/*test-helpers.*,**/*.fixture.*,**/*.mock.*,**/__fixtures__/**,**/fixtures/**,**/testing/**,tests/**
 
 sonar.javascript.lcov.reportPaths=coverage-profiles/coverage-shard-*/lcov.info
 sonar.javascript.node.maxspace=8192

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,11 @@ sonar.sourceEncoding=UTF-8
 sonar.sources=.
 sonar.exclusions=coverage-profiles/**
 
+# Test fixtures and assertions are intentionally repetitive. Keep test files
+# in the analysis so their issues remain visible, but exclude them from CPD so
+# the duplication gate measures production implementation duplication.
+sonar.cpd.exclusions=**/*.test.*,**/*.spec.*,tests/**
+
 sonar.javascript.lcov.reportPaths=coverage-profiles/coverage-shard-*/lcov.info
 sonar.javascript.node.maxspace=8192
 


### PR DESCRIPTION
## Summary

- Exclude test/spec files and the `tests/` tree from Sonar CPD duplication metrics.
- Keep those files in `sonar.sources` so Sonar issues remain visible and coverage configuration is unchanged.
- Restore the New Code duplication gate after the current main analysis counted repetitive test fixtures and assertions as production duplication.

## Evidence

SonarCloud main currently reports:

- New Code duplication: 8.716% (threshold: 3%)
- New Code coverage: 85.95% (threshold: 80%)
- Reliability, security, maintainability, and hotspot conditions: passing

The current analysis attributes 17,938 of 18,526 duplicated New Code lines to test files. Non-test code accounts for 588 duplicated lines across 64,651 New Code lines (0.909%).

## Verification

- `deno fmt --check`
- `deno task lint`
- `git diff --check`
- Sonar properties CPD exclusion contract

The local pre-push typecheck was blocked by pre-existing Deno/Node compatibility errors in the baseline checkout; the required CI typecheck remains authoritative.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code-quality analysis settings to exclude test files from copy-paste detection while continuing to include them in overall source analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->