### PR TITLE
fix(platform): classify bind hostname resolution failures at serve startup

### DIFF
--- a/src/platform/adapters/runtime/deno/http-server.test.ts
+++ b/src/platform/adapters/runtime/deno/http-server.test.ts
@@ -344,6 +344,69 @@ describe("Deno HTTP server lifecycle", () => {
     assertEquals(error.message.toLowerCase().includes("already in use"), false);
   });
 
+  it("classifies a bind hostname that fails DNS resolution", async () => {
+    // A deployment bound through a DNS name that does not resolve made
+    // Deno.serve() throw the raw getaddrinfo error, which reached Sentry as an
+    // unhandled `Error: failed to lookup address information: Name or service
+    // not known` with no port and no classification
+    // (veryfront-issue-inbox#810, Sentry VERYFRONT-STUDIO-5J).
+    const lookupFailure = new Error(
+      "failed to lookup address information: Name or service not known",
+    );
+
+    const error = await assertRejects(
+      () =>
+        createDenoServerWithRuntime(
+          {
+            serve() {
+              throw lookupFailure;
+            },
+          },
+          () => new Response("ok"),
+          { hostname: "registry.internal", port: 4321 },
+        ),
+      Error,
+      "4321",
+    ) as Error & { slug?: string; cause?: unknown };
+
+    assertEquals(error.slug, "initialization-error");
+    // The bind host can be an internal DNS name, which must never reach an
+    // error message (AGENTS.md); the port is the reportable half.
+    assertEquals(error.message.includes("registry.internal"), false);
+    assertStringIncludes(error.message.toLowerCase(), "could not be resolved");
+    // The raw OS-level signature is preserved for Sentry correlation rather
+    // than swallowed.
+    assertStrictEquals(error.cause, lookupFailure);
+  });
+
+  it("names a loopback bind host that fails DNS resolution", async () => {
+    // `localhost` itself can fail to resolve on a broken NSS setup. It is on
+    // the loopback allowlist, so unlike an infrastructure hostname it is safe
+    // to name -- and naming it is what makes the fault actionable.
+    const lookupFailure = new Error(
+      "failed to lookup address information: nodename nor servname provided, or not known",
+    );
+
+    const error = await assertRejects(
+      () =>
+        createDenoServerWithRuntime(
+          {
+            serve() {
+              throw lookupFailure;
+            },
+          },
+          () => new Response("ok"),
+          { hostname: "localhost", port: 4321 },
+        ),
+      Error,
+      "localhost:4321",
+    ) as Error & { slug?: string; cause?: unknown };
+
+    assertEquals(error.slug, "initialization-error");
+    assertStringIncludes(error.message.toLowerCase(), "could not be resolved");
+    assertStrictEquals(error.cause, lookupFailure);
+  });
+
   it("treats a DNS name that merely starts with 127. as private", async () => {
     // `127.api.prod.internal` is a hostname, not a loopback literal. A `127.`
     // prefix check exposed it -- the same leak the redaction exists to prevent,

--- a/src/platform/adapters/runtime/deno/http-server.ts
+++ b/src/platform/adapters/runtime/deno/http-server.ts
@@ -40,6 +40,21 @@ function isAddressInUseError(error: unknown): boolean {
 }
 
 /**
+ * Whether `error` is a failure to resolve the bind hostname.
+ *
+ * Matched on the getaddrinfo message prefix that Deno surfaces on every
+ * platform ("Name or service not known" on Linux, "nodename nor servname
+ * provided, or not known" on macOS) because the error arrives as a plain
+ * `Error` with no name or code to key on. Deliberately narrow, like
+ * `isAddressInUseError` above: only the lookup signature is claimed, so an
+ * unrelated startup fault keeps its own identity.
+ */
+function isAddressResolutionError(error: unknown): boolean {
+  if (!isErrorAcrossRealms(error)) return false;
+  return error.message.toLowerCase().includes("failed to lookup address");
+}
+
+/**
  * The bind host rendered for an error message, or `undefined` to omit it.
  *
  * A deployment can bind through an internal DNS name, and AGENTS.md:124 lists
@@ -256,6 +271,27 @@ export async function createDenoServerWithRuntime(
     // hostname or port -- so an operator saw which process died but not which
     // address collided (veryfront-issue-inbox#806).
     //
+    // A bind hostname that fails DNS resolution throws the same way, and the
+    // raw `failed to lookup address information: ...` reached Sentry as an
+    // unhandled error with no port and no classification
+    // (veryfront-issue-inbox#810). The message deliberately does not contain
+    // the canonical in-use phrase: retrying other ports cannot fix a
+    // resolution fault, so the dev server's port fallback must not trigger.
+    if (isAddressResolutionError(error)) {
+      const safeHost = describeBindHost(hostname);
+      throw INITIALIZATION_ERROR.create({
+        detail: safeHost === undefined
+          ? `Bind hostname could not be resolved: port ${port}`
+          : `Bind hostname could not be resolved: ${safeHost}:${port}`,
+        context: {
+          platform: "deno",
+          operation: "serve",
+          port,
+          ...(safeHost === undefined ? {} : { hostname: safeHost }),
+        },
+        cause: error,
+      });
+    }
     // Only a bind failure is relabelled. Catching everything here would report
     // an unrelated startup fault as an address collision, which is worse than
     // the raw error it replaces, so anything else is rethrown untouched.


### PR DESCRIPTION
Refs https://github.com/veryfront/veryfront-issue-inbox/issues/810 (Sentry VERYFRONT-STUDIO-5J)

## Root cause

`createDenoServerWithRuntime` classifies only `AddrInUse` bind failures; every other synchronous `Deno.serve()` startup fault is rethrown raw (`src/platform/adapters/runtime/deno/http-server.ts`). A bind hostname that fails DNS resolution therefore surfaced as an unhandled `Error: failed to lookup address information: Name or service not known` — the exact Sentry signature — with no port, no classification, and no suggestion.

## Fix

- `isAddressResolutionError`: a deliberately narrow classifier keyed on the cross-platform getaddrinfo message prefix (`failed to lookup address`), matched via `isErrorAcrossRealms` like its `isAddressInUseError` sibling.
- The catch relabels the fault as `initialization-error` through the error registry, mirroring the #806 AddrInUse precedent:
  - the raw OS error is preserved as `cause` (Sentry is not suppressed; correlation with platform logs still works),
  - a private bind hostname never reaches the message — only loopback/wildcard literals are named (`describeBindHost`), the port is always reported,
  - the message deliberately avoids the canonical "address already in use" phrase, so the dev server's port fallback does not retry ports for a fault that retrying cannot fix.
- Successful startup, cancellation, address-in-use, address-family-unavailable, and unrelated-failure rethrow behavior are all unchanged (existing tests cover each).

## Red → green

Red first: both new tests failed on the unclassified rethrow before the fix —

```
deno task test:file src/platform/adapters/runtime/deno/http-server.test.ts
  classifies a bind hostname that fails DNS resolution ... FAILED
  names a loopback bind host that fails DNS resolution ... FAILED
```

Green after: `ok | 1 passed (18 steps) | 0 failed`, plus `deno task test:file src/platform/adapters/runtime/deno/adapter.test.ts src/platform/adapters/runtime/deno/index.test.ts` → `4 passed (73 steps)`, `deno fmt`/`lint`/`check` clean on both files.

Synthetic fixtures only — no Sentry payload values are copied into tests (both getaddrinfo message variants are the documented OS strings, which carry no hostname).