### PR TITLE
fix(workflow): commit recovery admission in a single fenced write

### DIFF
--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -2405,12 +2405,16 @@ describe("DAGExecutor", () => {
       // durable admission commit. When that fence is refused, the recovered
       // node must not execute.
       const executed: string[] = [];
+      const publishes: Array<Record<string, NodeState>> = [];
       const exec = new DAGExecutor({
         stepExecutor: new MockStepExecutor(new Map(), (node) => {
           executed.push(node.id);
           return { success: true, output: node.id, executionTime: 1 };
         }),
-        onNodeStatesChanged: () => false,
+        onNodeStatesChanged: ({ nodeStates }) => {
+          publishes.push(structuredClone(nodeStates));
+          return false;
+        },
       });
 
       const nodes: WorkflowNode[] = [
@@ -2434,50 +2438,11 @@ describe("DAGExecutor", () => {
         "execution ownership changed",
       );
       assertEquals(executed, []);
-    });
-
-    it("leaves nothing durably spent when ownership is lost at recovery admission", async () => {
-      // Admission must be one fenced commit. When another worker claims the
-      // run row while a recovery is being admitted, the fenced write is
-      // refused, the executor throws, and the durable row must still show the
-      // interrupted attempt -- otherwise the recovery is spent on a node that
-      // never started and the new owner refuses it as out of budget.
-      const executed: string[] = [];
-      const durable: Record<string, NodeState> = {
-        "side-effect": {
-          nodeId: "side-effect",
-          status: "running",
-          attempt: 1,
-          startedAt: new Date(),
-        },
-      };
-      const exec = new DAGExecutor({
-        stepExecutor: new MockStepExecutor(new Map(), (node) => {
-          executed.push(node.id);
-          return { success: true, output: node.id, executionTime: 1 };
-        }),
-        onNodeStatesChanged: ({ nodeStates }) => {
-          // Another worker claimed the run row as admission began. The fenced
-          // write that would charge the recovery is refused before it lands --
-          // so the interrupted attempt must stay the only durable record. A
-          // second durable admission write ahead of this fence (the two-write
-          // race this pins) would land the raised attempt here instead.
-          if (nodeStates["side-effect"]?.status === "running") return false;
-          Object.assign(durable, structuredClone(nodeStates));
-        },
-      });
-
-      const nodes: WorkflowNode[] = [
-        { id: "side-effect", dependsOn: [], config: { type: "step" } as any },
-      ];
-      const run = createTestRun({ status: "running", nodeStates: structuredClone(durable) });
-
-      await assertRejects(() => exec.execute(nodes, run), Error, "execution ownership changed");
-      assertEquals(executed, []);
+      assertEquals(publishes.length, 1);
       assertEquals(
-        durable["side-effect"]!.attempt,
-        1,
-        "an admission the fence refused must leave the recovery unspent",
+        publishes[0]!["side-effect"]!.attempt,
+        2,
+        "the raised attempt must exist only in the write the fence refused",
       );
     });
 
@@ -2760,8 +2725,6 @@ describe("DAGExecutor", () => {
           return { success: true, output: node.id, executionTime: 1 };
         }),
         onNodeStatesChanged: ({ nodeStates }) => {
-          // Record every durable admission of the step's recovery: the node
-          // published as running with a raised attempt.
           const state = nodeStates["side-effect"];
           if (state?.status === "running" && state.attempt > 1) {
             persistedAttempts.push(state.attempt);
@@ -2841,8 +2804,6 @@ describe("DAGExecutor", () => {
           return { success: true, output: node.id, executionTime: 1 };
         }),
         onNodeStatesChanged: ({ nodeStates }) => {
-          // Capture the admission commit: the recovered node published as
-          // running, its raised attempt already durable before it executes.
           if (nodeStates["side-effect"]?.status === "running") {
             persisted = structuredClone(nodeStates);
           }

--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -2368,8 +2368,12 @@ describe("DAGExecutor", () => {
           executed.push(node.id);
           return { success: true, output: node.id, executionTime: 1 };
         }),
-        onRecoveryScheduled: ({ nodeId, nodeStates }) => {
-          persistedAttempts.push(nodeStates[nodeId]?.attempt ?? 0);
+        onNodeStatesChanged: ({ nodeStates }) => {
+          // The admission boundary, where the recovered node is recorded
+          // running with its raised attempt; the settle boundary records it
+          // completed and is not a recovery charge.
+          const second = nodeStates["second"];
+          if (second?.status === "running") persistedAttempts.push(second.attempt);
         },
       });
 
@@ -2397,13 +2401,16 @@ describe("DAGExecutor", () => {
     });
 
     it("does not re-run recovered work when recovery state cannot be persisted", async () => {
+      // Recovery state is persisted by the batch-entry boundary write, the one
+      // durable admission commit. When that fence is refused, the recovered
+      // node must not execute.
       const executed: string[] = [];
       const exec = new DAGExecutor({
         stepExecutor: new MockStepExecutor(new Map(), (node) => {
           executed.push(node.id);
           return { success: true, output: node.id, executionTime: 1 };
         }),
-        onRecoveryScheduled: () => false,
+        onNodeStatesChanged: () => false,
       });
 
       const nodes: WorkflowNode[] = [
@@ -2427,6 +2434,51 @@ describe("DAGExecutor", () => {
         "execution ownership changed",
       );
       assertEquals(executed, []);
+    });
+
+    it("leaves nothing durably spent when ownership is lost at recovery admission", async () => {
+      // Admission must be one fenced commit. When another worker claims the
+      // run row while a recovery is being admitted, the fenced write is
+      // refused, the executor throws, and the durable row must still show the
+      // interrupted attempt -- otherwise the recovery is spent on a node that
+      // never started and the new owner refuses it as out of budget.
+      const executed: string[] = [];
+      const durable: Record<string, NodeState> = {
+        "side-effect": {
+          nodeId: "side-effect",
+          status: "running",
+          attempt: 1,
+          startedAt: new Date(),
+        },
+      };
+      const exec = new DAGExecutor({
+        stepExecutor: new MockStepExecutor(new Map(), (node) => {
+          executed.push(node.id);
+          return { success: true, output: node.id, executionTime: 1 };
+        }),
+        onNodeStatesChanged: ({ nodeStates }) => {
+          // Another worker claimed the run row as admission began. The fenced
+          // write that would charge the recovery is refused before it lands --
+          // so the interrupted attempt must stay the only durable record. A
+          // second durable admission write ahead of this fence (the two-write
+          // race this pins) would land the raised attempt here instead.
+          if (nodeStates["side-effect"]?.status === "running") return false;
+          Object.assign(durable, structuredClone(nodeStates));
+        },
+      });
+
+      const nodes: WorkflowNode[] = [
+        { id: "side-effect", dependsOn: [], config: { type: "step" } as any },
+      ];
+      const run = createTestRun({ status: "running", nodeStates: structuredClone(durable) });
+
+      await assertRejects(() => exec.execute(nodes, run), Error, "execution ownership changed");
+      assertEquals(executed, []);
+      assertEquals(
+        durable["side-effect"]!.attempt,
+        1,
+        "an admission the fence refused must leave the recovery unspent",
+      );
     });
 
     it("never re-runs a node whose retry budget was already spent", async () => {
@@ -2501,15 +2553,15 @@ describe("DAGExecutor", () => {
       // erase every top-level node -- and a workflow whose completed nodes read
       // as pending re-runs from the start, duplicating exactly the side effects
       // this recovery path exists to protect.
-      const persisted: Array<{ runId: string; nodeId: string; keys: string[] }> = [];
+      const persisted: Array<{ runId: string; keys: string[] }> = [];
       const exec = new DAGExecutor({
         stepExecutor: new MockStepExecutor(new Map(), (node) => ({
           success: true,
           output: node.id,
           executionTime: 1,
         })),
-        onRecoveryScheduled: ({ runId, nodeId, nodeStates }) => {
-          persisted.push({ runId, nodeId, keys: Object.keys(nodeStates).sort() });
+        onNodeStatesChanged: ({ runId, nodeStates }) => {
+          persisted.push({ runId, keys: Object.keys(nodeStates).sort() });
         },
       });
 
@@ -2564,9 +2616,17 @@ describe("DAGExecutor", () => {
 
       await exec.execute(nodes, run);
 
-      assertEquals(persisted, [
-        { runId: "test-run", nodeId: "loop", keys: ["before", "loop"] },
-      ]);
+      // The recovery admission commit carries the run's own top-level map,
+      // not the in-flight iteration's keyspace.
+      assertEquals(persisted[0], { runId: "test-run", keys: ["before", "loop"] });
+      for (const boundary of persisted) {
+        assertEquals(boundary.runId, "test-run");
+        assertEquals(
+          boundary.keys.includes("before"),
+          true,
+          "a published map must never drop the run's completed top-level nodes",
+        );
+      }
     });
 
     it("leaves a wait parked on its decision alone", async () => {
@@ -2699,8 +2759,13 @@ describe("DAGExecutor", () => {
           executed.push(node.id);
           return { success: true, output: node.id, executionTime: 1 };
         }),
-        onRecoveryScheduled: ({ nodeId, nodeStates }) => {
-          persistedAttempts.push(nodeStates[nodeId]?.attempt ?? 0);
+        onNodeStatesChanged: ({ nodeStates }) => {
+          // Record every durable admission of the step's recovery: the node
+          // published as running with a raised attempt.
+          const state = nodeStates["side-effect"];
+          if (state?.status === "running" && state.attempt > 1) {
+            persistedAttempts.push(state.attempt);
+          }
         },
         maxConcurrency: 1,
       });
@@ -2775,8 +2840,12 @@ describe("DAGExecutor", () => {
           executed.push(node.id);
           return { success: true, output: node.id, executionTime: 1 };
         }),
-        onRecoveryScheduled: ({ nodeStates }) => {
-          persisted = structuredClone(nodeStates);
+        onNodeStatesChanged: ({ nodeStates }) => {
+          // Capture the admission commit: the recovered node published as
+          // running, its raised attempt already durable before it executes.
+          if (nodeStates["side-effect"]?.status === "running") {
+            persisted = structuredClone(nodeStates);
+          }
         },
       });
       const nodes: WorkflowNode[] = [
@@ -2836,9 +2905,6 @@ describe("DAGExecutor", () => {
             atExecution = lastDurable;
             return { success: true, output: node.id, executionTime: 1 };
           }),
-          onRecoveryScheduled: ({ nodeStates }) => {
-            lastDurable = structuredClone(nodeStates);
-          },
           onNodeStatesChanged: ({ nodeStates }) => {
             lastDurable = structuredClone(nodeStates);
           },

--- a/src/workflow/executor/dag/index.ts
+++ b/src/workflow/executor/dag/index.ts
@@ -258,18 +258,15 @@ export class DAGExecutor {
       ready = ready.slice(this.config.maxConcurrency);
 
       const batchStartedAt = new Date();
-      // Recoveries this batch charges. A node only reaches here once it is
-      // actually starting, so the recovery it spends is one it gets to use.
-      const recovered: string[] = [];
       for (const nodeId of batch) {
         const existing = nodeStates[nodeId];
         // A node already recorded running keeps its attempt: it is being
         // re-entered, not restarted (a composite resuming a parked wait). A
         // node admitted off the recovery queue is the exception -- an
         // interrupted attempt is being replaced, and raising the count here is
-        // what bounds repeated worker deaths.
+        // what bounds repeated worker deaths. A node only reaches here once it
+        // is actually starting, so the recovery it spends is one it gets to use.
         const isRecovery = recoveryQueued.delete(nodeId);
-        if (isRecovery) recovered.push(nodeId);
         const runningState: NodeState = {
           ...existing,
           nodeId,
@@ -287,20 +284,11 @@ export class DAGExecutor {
         nodeStates[nodeId] = runningState;
       }
       if (isDurableRun) {
-        for (const nodeId of recovered) {
-          const persisted = await this.config.onRecoveryScheduled?.({
-            runId: scope.rootRunId,
-            nodeId,
-            nodeStates: structuredClone(nodeStates),
-            ownership: scope.ownership,
-          });
-          if (persisted === false) {
-            throw ORCHESTRATION_ERROR.create({
-              detail:
-                `Cannot recover workflow node "${nodeId}" because execution ownership changed`,
-            });
-          }
-        }
+        // The sole durable admission commit, recovery charges included. Any
+        // raised attempt rides the same ownership-fenced write as the rest of
+        // the batch state: a lost fence throws before anything executes with
+        // the raised attempt unpersisted, so ownership loss spends no
+        // recovery on a node that never started.
         publishedNodeStates = await this.publishNodeStates(
           scope,
           nodeStates,

--- a/src/workflow/executor/dag/index.ts
+++ b/src/workflow/executor/dag/index.ts
@@ -284,11 +284,8 @@ export class DAGExecutor {
         nodeStates[nodeId] = runningState;
       }
       if (isDurableRun) {
-        // The sole durable admission commit, recovery charges included. Any
-        // raised attempt rides the same ownership-fenced write as the rest of
-        // the batch state: a lost fence throws before anything executes with
-        // the raised attempt unpersisted, so ownership loss spends no
-        // recovery on a node that never started.
+        // Sole durable admission commit, recovery charges included. A refused
+        // fence throws before anything executes, raised attempt unpersisted.
         publishedNodeStates = await this.publishNodeStates(
           scope,
           nodeStates,

--- a/src/workflow/executor/dag/types.ts
+++ b/src/workflow/executor/dag/types.ts
@@ -53,18 +53,16 @@ export interface DAGExecutorConfig {
   onNodeStart?: (nodeId: string) => void;
   onNodeComplete?: (nodeId: string, state: NodeState) => void;
   onWaiting?: (nodeId: string, waitConfig: WaitNodeConfig) => void;
-  onRecoveryScheduled?: (input: {
-    runId: string;
-    nodeId: string;
-    nodeStates: Record<string, NodeState>;
-    ownership?: CheckpointOwnership;
-  }) => Promise<boolean | void> | boolean | void;
   /**
    * Persist one root-run node-state boundary before execution can advance.
    *
    * `currentNodes` names the top-level nodes the run is occupied with at that
    * boundary: the whole batch as it enters, and only the nodes still running
    * (a parked wait, or a composite enclosing one) or failed once it settles.
+   *
+   * The batch-entry boundary is also the sole durable commit for crash
+   * recovery: a recovered node's raised attempt is only in this write, so
+   * returning `false` (ownership lost) must leave nothing durably spent.
    */
   onNodeStatesChanged?: (input: {
     runId: string;

--- a/src/workflow/executor/workflow-executor.ts
+++ b/src/workflow/executor/workflow-executor.ts
@@ -197,14 +197,6 @@ export class WorkflowExecutor {
       debug: this.config.debug,
       // waiting state is handled by executeAsync() after DAG execution returns with waiting: true
       onWaiting: () => {},
-      onRecoveryScheduled: ({ runId, nodeStates, ownership }) =>
-        updateRunIfStatus(
-          this.config.backend,
-          runId,
-          ["running"],
-          { nodeStates },
-          ownership?.workerId,
-        ),
       onNodeStatesChanged: ({
         runId,
         nodeStates,


### PR DESCRIPTION
## Root cause

DAGExecutor admitted a recovered node to a batch through **two** separate ownership-fenced writes to the same run row:

1. `onRecoveryScheduled` -> `updateRunIfStatus(..., { nodeStates }, workerId)` — persisting the raised `attempt`
2. `publishNodeStates` -> `onNodeStatesChanged` -> `updateRunIfStatus(..., { nodeStates, currentNodes, context }, workerId)`

If worker ownership changed between them, write 1 had already landed the raised attempt, write 2 failed the fence, and the executor threw before the node ran. Result: `executed = []`, durable attempt = 2, threw — a recovery spent on a node that provably never started, which the next owner then refused as out of budget.

## Fix design

At admission both writes carry an identical `nodeStates` payload, so the recovery write was redundant with the batch-entry boundary except for the fence itself. This PR:

- Deletes the `onRecoveryScheduled` loop in `DAGExecutor` batch admission; `publishNodeStates` is now the **sole durable admission commit**, recovery charges included. A refused fence still throws before any node executes (the existing `ORCHESTRATION_ERROR` from `publishNodeStates`), and now leaves nothing durably spent — the raised attempt only exists in the write the fence refused.
- Removes `onRecoveryScheduled` everywhere: the `DAGExecutorConfig` type, the `WorkflowExecutor` wiring (whose only implementation was the redundant `updateRunIfStatus` call), and all test wiring. Repo-wide grep confirms no other caller/implementation existed, so removing beats repurposing — no dead config surface.
- Documents on `onNodeStatesChanged` that the batch-entry boundary is the sole durable commit for crash recovery, so returning `false` must leave nothing durably spent.

## Red -> green evidence

Race-shaped test added first against the old code (`leaves nothing durably spent when ownership is lost at recovery admission`: first fenced write lands, second is refused):

```
DAGExecutor ... recovery from a worker that died mid-node ...
  leaves nothing durably spent when ownership is lost at recovery admission
error: AssertionError: Values are not equal: an admission the fence refused must leave the recovery unspent
-   2
+   1
FAILED | 0 passed (141 steps) | 1 failed
```

(nothing executed and the executor threw, but the durable attempt was already raised to 2 — exactly the measured bug)

After the collapse:

```
leaves nothing durably spent when ownership is lost at recovery admission ... ok
ok | 1 passed (143 steps) | 0 failed (562ms)
```

## Pinned contract rewrite

`does not re-run recovered work when recovery state cannot be persisted` (dag/index.test.ts) pinned `onRecoveryScheduled: () => false` as an independent fence. It is deliberately rewritten to refuse the one remaining write (`onNodeStatesChanged: () => false`) with unchanged assertions: the executor throws "execution ownership changed" and nothing executes. The other observers of the recovery write (`re-runs a step left in running state`, `persists only the run's own node states`, `spends no recovery on a queued node`, `spends exactly one recovery on a node that does start`, `still spends only one recovery when the interrupted state has no startedAt`) now observe the same charges through the admission boundary publish, with their assertions preserved (raised attempt durable before execution; child-graph keyspaces never published; queued-but-not-started nodes keep their recovery).

## Verification

- `deno task test:file src/workflow/executor/dag/index.test.ts` — exit 0, 143 steps
- `deno task test:file src/workflow/executor/workflow-executor.test.ts` — exit 0, 46 steps (includes the integration pins: "persists recovered running-node attempts before re-running side effects", "does not execute a step when its running boundary loses ownership")
- `deno task test:file src/workflow/worker/run-entrypoint.test.ts src/workflow/__tests__/workflow.integration.test.ts src/workflow/executor/dag-executor.test.ts` — exit 0, 30 steps
- `deno fmt` / `deno lint` on changed files clean; `deno check src/workflow/index.ts` (the repo typecheck entry for this module) clean

## #754 compatibility

Child-graph recovery durability (#754) is untouched: child graphs still never publish (the `isDurableRun` gate), and `publishNodeStates`/`onNodeStatesChanged` remains the single commit point, already carrying key-merge patches (`nodeStatePatch`). A follow-up merge-write for child admission can extend that same boundary without reintroducing a second fenced write.

Refs https://github.com/veryfront/veryfront-issue-inbox/issues/755