### PR TITLE
ci(e2e): run the Playwright suite in CI as a report-only gate

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -1,0 +1,49 @@
+# Playwright browser e2e suite. Report-only: the job is not a required check,
+# so failures inform rather than block. Promote it to required once it has a
+# clean run history (veryfront-issue-inbox#749).
+name: e2e-playwright
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - "tests/e2e/**"
+      - "deno.json"
+      - "deno.lock"
+      - ".github/workflows/e2e-playwright.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    name: e2e (playwright)
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-deno
+        timeout-minutes: 5
+        with:
+          warm-cache: "true"
+      - name: Materialize locked test dependencies
+        run: deno install --frozen
+      - name: Install Playwright Chromium
+        run: deno task test:e2e:playwright:install
+      - name: Run Playwright e2e suite
+        run: deno task test:e2e:playwright
+      - name: Upload traces and screenshots
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report-${{ github.run_id }}
+          path: tests/e2e/test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   playwright:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     name: e2e (playwright)

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -12,12 +12,16 @@ on:
       - "deno.json"
       - "deno.lock"
       - ".github/workflows/e2e-playwright.yml"
+      - ".github/actions/setup-deno/**"
 
 permissions:
   contents: read
 
+# GitHub keeps at most one pending run per concurrency group, so main pushes
+# need SHA-qualified groups or a later push silently replaces an earlier queued
+# datapoint in the clean-run history this workflow exists to build.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -36,15 +40,62 @@ jobs:
           warm-cache: "true"
       - name: Materialize locked test dependencies
         run: deno install --frozen
+      # Same hardened installer as the browser jobs in cicd.yml: a runner's
+      # own apt activity or an orphaned attempt can hold the dpkg locks, and a
+      # report-only history poisoned by provisioning failures is worthless.
       - name: Install Playwright Chromium
-        run: deno task test:e2e:playwright:install
+        timeout-minutes: 16
+        run: |
+          readonly install_attempts=2
+          readonly install_timeout_minutes=7
+          readonly install_kill_grace_seconds=15
+          readonly apt_lock_attempts=12
+          readonly apt_lock_sleep_seconds=5
+          readonly retry_backoff_seconds=20
+          readonly apt_lock_files="/var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock /var/lib/apt/lists/lock"
+
+          echo 'DPkg::Lock::Timeout "300";' | sudo tee /etc/apt/apt.conf.d/99vf-lock-timeout >/dev/null
+
+          wait_for_apt_locks() {
+            for _ in $(seq 1 "${apt_lock_attempts}"); do
+              if ! sudo fuser ${apt_lock_files} >/dev/null 2>&1; then
+                return 0
+              fi
+              sleep "${apt_lock_sleep_seconds}"
+            done
+            return 1
+          }
+
+          reap_apt_lock_holders() {
+            sudo fuser -k -TERM ${apt_lock_files} >/dev/null 2>&1 || true
+            sleep 5
+            sudo fuser -k -KILL ${apt_lock_files} >/dev/null 2>&1 || true
+            sudo dpkg --configure -a >/dev/null 2>&1 || true
+          }
+
+          for attempt in $(seq 1 "${install_attempts}"); do
+            if ! wait_for_apt_locks; then
+              echo "::warning::apt/dpkg locks still held; reaping the holders"
+              reap_apt_lock_holders
+            fi
+            timeout --signal=TERM --kill-after="${install_kill_grace_seconds}s" "${install_timeout_minutes}m" \
+              deno task test:e2e:playwright:install && exit 0
+            status=$?
+
+            if [ "$attempt" -eq "${install_attempts}" ]; then
+              exit "$status"
+            fi
+
+            reap_apt_lock_holders
+            sleep "${retry_backoff_seconds}"
+          done
       - name: Run Playwright e2e suite
         run: deno task test:e2e:playwright
       - name: Upload traces and screenshots
         if: ${{ failure() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: playwright-report-${{ github.run_id }}
+          name: playwright-report-${{ github.run_id }}-${{ github.run_attempt }}
           path: tests/e2e/test-results/
           retention-days: 7
           if-no-files-found: ignore

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -28,7 +28,7 @@ jobs:
   playwright:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     name: e2e (playwright)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -40,11 +40,42 @@ jobs:
           warm-cache: "true"
       - name: Materialize locked test dependencies
         run: deno install --frozen
-      # Same hardened installer as the browser jobs in cicd.yml: a runner's
-      # own apt activity or an orphaned attempt can hold the dpkg locks, and a
-      # report-only history poisoned by provisioning failures is worthless.
+      # Same hardening as the browser jobs in cicd.yml, both halves: park the
+      # third-party apt sources whose persistent outages fail `apt-get update`
+      # inside `playwright install --with-deps`, then run the bounded, retried
+      # installer. A report-only history poisoned by provisioning failures is
+      # worthless.
+      - name: Configure apt sources, retries, and mirrors
+        run: |
+          sudo sed -i \
+            -e 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
+            -e 's|http://security.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
+            /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+          {
+            echo 'Acquire::ForceIPv4 "true";'
+            echo 'Acquire::Retries "5";'
+            echo 'Acquire::http::Timeout "30";'
+            echo 'Acquire::https::Timeout "30";'
+          } | sudo tee /etc/apt/apt.conf.d/99veryfront-ci-retries
+
+          if grep -rqE '\.ubuntu\.com' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then
+            sudo mkdir -p /etc/apt/sources.list.d.disabled
+            for source_file in /etc/apt/sources.list.d/*; do
+              [ -f "${source_file}" ] || continue
+              if grep -qE '\.ubuntu\.com' "${source_file}"; then
+                continue
+              fi
+              sudo mv "${source_file}" /etc/apt/sources.list.d.disabled/
+              echo "Disabled apt source unrelated to Chromium deps: ${source_file}"
+            done
+          else
+            echo "::warning::No Ubuntu archive apt source detected; leaving apt sources untouched"
+          fi
+      # Worst case of the retry loop is ~17 minutes (two full attempts plus
+      # lock waits and backoff), matching the 20-minute step deadline the
+      # cicd.yml browser jobs use.
       - name: Install Playwright Chromium
-        timeout-minutes: 16
+        timeout-minutes: 20
         run: |
           readonly install_attempts=2
           readonly install_timeout_minutes=7

--- a/deno.json
+++ b/deno.json
@@ -598,6 +598,7 @@
     "test:all-runtimes": "deno task test:unit && deno task test:node && deno task test:bun",
     "test:e2e": "deno task test:e2e:playwright",
     "test:e2e:playwright": "deno run -A npm:playwright@1.60.0 test --config=tests/e2e/playwright.config.cjs",
+    "test:e2e:playwright:install": "deno run -A npm:playwright@1.60.0 install --with-deps chromium",
     "test:e2e:rsc-browser": "deno task generate && deno run --config=scripts/test.deno.json --allow-read --allow-run=deno --allow-env scripts/test/run-deno-suite.ts --suite=e2e:rsc-browser",
     "test:e2e:binary": "deno task generate && deno run --config=scripts/test.deno.json --allow-read --allow-run=deno --allow-env scripts/test/run-deno-suite.ts --suite=e2e:binary",
     "test:e2e:binary:fresh": "deno task generate && VERYFRONT_BINARY_FRESH=1 deno run --config=scripts/test.deno.json --allow-read --allow-run=deno --allow-env scripts/test/run-deno-suite.ts --suite=e2e:binary",


### PR DESCRIPTION
Refs https://github.com/veryfront/veryfront-issue-inbox/issues/749

## Problem

`git grep` confirms no CI workflow invokes `deno task test:e2e:playwright`, so every change to the shared e2e harness (the `/_vf_debug/context` readiness probe, the `type: module` ESM setup from #3995) reaches developers' local runs with no gate in front of it.

## Change

- New workflow `e2e-playwright.yml`: one Linux job running `deno task test:e2e:playwright` on pushes to main (builds the clean-run history needed to later promote it) and on PRs touching `tests/e2e/**`, `deno.json`/`deno.lock`, or the workflow itself. Playwright traces/screenshots are uploaded on failure.
- New task `test:e2e:playwright:install` so the browser-install pin lives in `deno.json` next to the test task instead of drifting in the workflow.

## Report-only, deliberately

Per the issue's own sequencing: an e2e suite that has never run in CI may be flaky on contact, and a newly-required job that fails on unrelated PRs gets disabled rather than fixed. The job is not in the required-check set — it reports honestly (no `continue-on-error`) without blocking the merge queue. Promote to required once it has a clean run history.

## Verification

- Full suite run locally on this machine before writing the workflow: **30 passed, 4 skipped, 22.6s**, exit 0 — the suite is green on contact, exercising the readiness change and the ESM repair for real (`production-host` and `preview-host` projects).
- `deno task test:e2e:playwright:install` verified to resolve.
- Workflow YAML validated; action SHAs match the pins used elsewhere in this repo.

This PR itself touches the workflow + `deno.json`, so the new job runs on this PR — its result is visible below as the first CI datapoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated browser end-to-end testing with Playwright.
  - Added setup support for installing Chromium and required system dependencies.
  - Test failures now provide trace and screenshot artifacts for troubleshooting.

- **Chores**
  - Configured automated test runs for relevant code changes and main branch updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->