### PR TITLE
fix(cli): render invalid-argument for user-input mistakes instead of unknown-error

### DIFF
--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -6,6 +6,7 @@ import {
   assertStringIncludes,
 } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { withTempDir } from "#veryfront/testing/deno-compat.ts";
 import { VeryfrontError } from "veryfront/errors";
 import { type Agent, agent as createAgent, type AgentResponse } from "veryfront/agent";
 import { defineSchema } from "veryfront/schemas";
@@ -2183,8 +2184,7 @@ describe("eval CLI command helpers", () => {
       ],
     ];
 
-    const projectDir = await Deno.makeTempDir();
-    try {
+    await withTempDir(async (projectDir) => {
       for (const [payload, expectedDetail] of cases) {
         await Deno.writeTextFile(`${projectDir}/policy.json`, payload);
         const error = await assertRejects(
@@ -2196,9 +2196,7 @@ describe("eval CLI command helpers", () => {
         assertEquals(error.slug, "invalid-argument");
         assertEquals(error.message, expectedDetail);
       }
-    } finally {
-      await Deno.remove(projectDir, { recursive: true });
-    }
+    }, { prefix: "vf-eval-policy-shapes-" });
   });
 
   it("reports malformed model comparison policy JSON as a usage error", async () => {

--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -2122,13 +2122,80 @@ describe("eval CLI command helpers", () => {
   it("reports missing model comparison policy files as usage errors", async () => {
     const projectDir = await Deno.makeTempDir();
     try {
-      const error = await assertRejects(() =>
-        loadEvalModelComparisonPolicy(projectDir, "missing-policy.json")
-      );
-      assertEquals(
-        error instanceof Error ? error.message : String(error),
+      const error = await assertRejects(
+        () => loadEvalModelComparisonPolicy(projectDir, "missing-policy.json"),
+        VeryfrontError,
         "Invalid --comparison-policy: file not found.",
       );
+      assertInstanceOf(error, VeryfrontError);
+      assertEquals(error.slug, "invalid-argument");
+    } finally {
+      await Deno.remove(projectDir, { recursive: true });
+    }
+  });
+
+  it("rejects every malformed comparison policy shape as an invalid-argument usage error", async () => {
+    const cases: Array<[string, string]> = [
+      ["[]", "Invalid --comparison-policy: root value must be an object."],
+      [
+        JSON.stringify({ minGroundedness: "high" }),
+        "Invalid --comparison-policy: root.minGroundedness must be a finite number.",
+      ],
+      [
+        JSON.stringify({ constraints: "latency" }),
+        "Invalid --comparison-policy: constraints must be an object.",
+      ],
+      [
+        JSON.stringify({ constraints: { bogus: {} } }),
+        'Invalid --comparison-policy: constraints.bogus uses unknown metric "bogus".',
+      ],
+      [
+        JSON.stringify({ constraints: { p95Ms: 5 } }),
+        "Invalid --comparison-policy: constraints.p95Ms must be an object.",
+      ],
+      [
+        JSON.stringify({ constraints: { p95Ms: { min: "fast" } } }),
+        "Invalid --comparison-policy: constraints.p95Ms.min must be a finite number.",
+      ],
+      [
+        JSON.stringify({ constraints: { p95Ms: { maxRegressionPct: -1 } } }),
+        "Invalid --comparison-policy: constraints.p95Ms.maxRegressionPct must be at least 0.",
+      ],
+      [
+        JSON.stringify({ objectives: "latency" }),
+        "Invalid --comparison-policy: objectives must be an object.",
+      ],
+      [
+        JSON.stringify({ objectives: { p95Ms: 5 } }),
+        "Invalid --comparison-policy: objectives.p95Ms must be an object.",
+      ],
+      [
+        JSON.stringify({ objectives: { p95Ms: { direction: "minimize" } } }),
+        "Invalid --comparison-policy: objectives.p95Ms.weight is required.",
+      ],
+      [
+        JSON.stringify({ objectives: { p95Ms: { weight: 0, direction: "minimize" } } }),
+        "Invalid --comparison-policy: objectives.p95Ms.weight must be greater than 0.",
+      ],
+      [
+        JSON.stringify({ objectives: { p95Ms: { weight: 1, direction: "sideways" } } }),
+        'Invalid --comparison-policy: objectives.p95Ms.direction must be "minimize" or "maximize".',
+      ],
+    ];
+
+    const projectDir = await Deno.makeTempDir();
+    try {
+      for (const [payload, expectedDetail] of cases) {
+        await Deno.writeTextFile(`${projectDir}/policy.json`, payload);
+        const error = await assertRejects(
+          () => loadEvalModelComparisonPolicy(projectDir, "policy.json"),
+          VeryfrontError,
+          expectedDetail,
+        );
+        assertInstanceOf(error, VeryfrontError);
+        assertEquals(error.slug, "invalid-argument");
+        assertEquals(error.message, expectedDetail);
+      }
     } finally {
       await Deno.remove(projectDir, { recursive: true });
     }

--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -1,6 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { VeryfrontError } from "veryfront/errors";
 import { type Agent, agent as createAgent, type AgentResponse } from "veryfront/agent";
 import { defineSchema } from "veryfront/schemas";
 import {
@@ -2133,11 +2139,15 @@ describe("eval CLI command helpers", () => {
     try {
       await Deno.writeTextFile(`${projectDir}/policy.json`, "{not-json");
 
-      const error = await assertRejects(() =>
-        loadEvalModelComparisonPolicy(projectDir, "policy.json")
+      const error = await assertRejects(
+        () => loadEvalModelComparisonPolicy(projectDir, "policy.json"),
+        VeryfrontError,
+        "Invalid --comparison-policy: file must contain valid JSON.",
       );
+      assertInstanceOf(error, VeryfrontError);
+      assertEquals(error.slug, "invalid-argument");
       assertEquals(
-        error instanceof Error ? error.message : String(error),
+        error.message,
         "Invalid --comparison-policy: file must contain valid JSON.",
       );
     } finally {

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -3,6 +3,7 @@
  */
 
 import { dirname, isAbsolute, relative, resolve } from "veryfront/platform/path";
+import { INVALID_ARGUMENT } from "veryfront/errors";
 import type { Agent, AgentResponse } from "veryfront/agent";
 import type { VeryfrontConfig } from "veryfront/config";
 import {
@@ -400,14 +401,18 @@ function readNumberField(
   const value = record[field];
   if (value === undefined) return undefined;
   if (typeof value !== "number" || !Number.isFinite(value)) {
-    throw new Error(`Invalid --comparison-policy: ${path}.${field} must be a finite number.`);
+    throw INVALID_ARGUMENT.create({
+      detail: `Invalid --comparison-policy: ${path}.${field} must be a finite number.`,
+    });
   }
   return value;
 }
 
 function assertKnownComparisonMetric(metric: string, path: string): EvalModelComparisonMetricName {
   if (MODEL_COMPARISON_METRIC_SET.has(metric)) return metric as EvalModelComparisonMetricName;
-  throw new Error(`Invalid --comparison-policy: ${path} uses unknown metric "${metric}".`);
+  throw INVALID_ARGUMENT.create({
+    detail: `Invalid --comparison-policy: ${path} uses unknown metric "${metric}".`,
+  });
 }
 
 function parseComparisonConstraints(
@@ -415,14 +420,18 @@ function parseComparisonConstraints(
 ): EvalModelComparisonPolicy["constraints"] {
   if (value === undefined) return undefined;
   if (!isRecord(value)) {
-    throw new Error("Invalid --comparison-policy: constraints must be an object.");
+    throw INVALID_ARGUMENT.create({
+      detail: "Invalid --comparison-policy: constraints must be an object.",
+    });
   }
 
   const constraints: NonNullable<EvalModelComparisonPolicy["constraints"]> = {};
   for (const [metricName, rawConstraint] of Object.entries(value)) {
     const metric = assertKnownComparisonMetric(metricName, `constraints.${metricName}`);
     if (!isRecord(rawConstraint)) {
-      throw new Error(`Invalid --comparison-policy: constraints.${metricName} must be an object.`);
+      throw INVALID_ARGUMENT.create({
+        detail: `Invalid --comparison-policy: constraints.${metricName} must be an object.`,
+      });
     }
     const maxRegressionPct = readNumberField(
       rawConstraint,
@@ -430,9 +439,10 @@ function parseComparisonConstraints(
       `constraints.${metricName}`,
     );
     if (maxRegressionPct !== undefined && maxRegressionPct < 0) {
-      throw new Error(
-        `Invalid --comparison-policy: constraints.${metricName}.maxRegressionPct must be at least 0.`,
-      );
+      throw INVALID_ARGUMENT.create({
+        detail:
+          `Invalid --comparison-policy: constraints.${metricName}.maxRegressionPct must be at least 0.`,
+      });
     }
     constraints[metric] = {
       ...(rawConstraint.min !== undefined
@@ -450,31 +460,39 @@ function parseComparisonConstraints(
 function parseComparisonObjectives(value: unknown): EvalModelComparisonPolicy["objectives"] {
   if (value === undefined) return undefined;
   if (!isRecord(value)) {
-    throw new Error("Invalid --comparison-policy: objectives must be an object.");
+    throw INVALID_ARGUMENT.create({
+      detail: "Invalid --comparison-policy: objectives must be an object.",
+    });
   }
 
   const objectives: NonNullable<EvalModelComparisonPolicy["objectives"]> = {};
   for (const [metricName, rawObjective] of Object.entries(value)) {
     const metric = assertKnownComparisonMetric(metricName, `objectives.${metricName}`);
     if (!isRecord(rawObjective)) {
-      throw new Error(`Invalid --comparison-policy: objectives.${metricName} must be an object.`);
+      throw INVALID_ARGUMENT.create({
+        detail: `Invalid --comparison-policy: objectives.${metricName} must be an object.`,
+      });
     }
     const weight = readNumberField(rawObjective, "weight", `objectives.${metricName}`);
     if (weight === undefined) {
-      throw new Error(`Invalid --comparison-policy: objectives.${metricName}.weight is required.`);
+      throw INVALID_ARGUMENT.create({
+        detail: `Invalid --comparison-policy: objectives.${metricName}.weight is required.`,
+      });
     }
     if (weight <= 0) {
-      throw new Error(
-        `Invalid --comparison-policy: objectives.${metricName}.weight must be greater than 0.`,
-      );
+      throw INVALID_ARGUMENT.create({
+        detail:
+          `Invalid --comparison-policy: objectives.${metricName}.weight must be greater than 0.`,
+      });
     }
     const direction = rawObjective.direction;
     if (
       typeof direction !== "string" || !MODEL_COMPARISON_OBJECTIVE_DIRECTIONS.has(direction)
     ) {
-      throw new Error(
-        `Invalid --comparison-policy: objectives.${metricName}.direction must be "minimize" or "maximize".`,
-      );
+      throw INVALID_ARGUMENT.create({
+        detail:
+          `Invalid --comparison-policy: objectives.${metricName}.direction must be "minimize" or "maximize".`,
+      });
     }
     objectives[metric] = {
       weight,
@@ -495,7 +513,7 @@ export async function loadEvalModelComparisonPolicy(
     rawPolicy = await Deno.readTextFile(resolvedPath);
   } catch (error) {
     if (error instanceof Deno.errors.NotFound) {
-      throw new Error("Invalid --comparison-policy: file not found.");
+      throw INVALID_ARGUMENT.create({ detail: "Invalid --comparison-policy: file not found." });
     }
     throw error;
   }
@@ -504,10 +522,14 @@ export async function loadEvalModelComparisonPolicy(
   try {
     policy = JSON.parse(rawPolicy) as unknown;
   } catch {
-    throw new Error("Invalid --comparison-policy: file must contain valid JSON.");
+    throw INVALID_ARGUMENT.create({
+      detail: "Invalid --comparison-policy: file must contain valid JSON.",
+    });
   }
   if (!isRecord(policy)) {
-    throw new Error("Invalid --comparison-policy: root value must be an object.");
+    throw INVALID_ARGUMENT.create({
+      detail: "Invalid --comparison-policy: root value must be an object.",
+    });
   }
   return {
     ...("minGroundedness" in policy

--- a/cli/commands/files/command.test.ts
+++ b/cli/commands/files/command.test.ts
@@ -1,15 +1,22 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertInstanceOf, assertThrows } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertRejects,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { VeryfrontError } from "veryfront/errors";
 import {
   buildRemoteFileUrl,
   deleteRemoteFile,
+  filesCommand,
   getRemoteFile,
   listRemoteFiles,
   putRemoteFileFromLocal,
 } from "./command.ts";
 import type { ApiClient } from "#cli/shared/config";
+import type { ParsedArgs } from "#cli/shared/types";
 
 function createMockClient(overrides: {
   get?: (path: string, params?: Record<string, string>) => Promise<unknown>;
@@ -136,5 +143,24 @@ describe("deleteRemoteFile", () => {
     await deleteRemoteFile(client, "my-project", "knowledge/q1-report.md");
 
     assertEquals(capturedPath, "/projects/my-project/files/knowledge%2Fq1-report.md");
+  });
+});
+
+describe("filesCommand", () => {
+  it("rejects unusable subcommand arguments as invalid-argument usage errors", async () => {
+    const cases: Array<[ParsedArgs, string]> = [
+      [{ _: ["files", "get"] }, "Invalid files get arguments:"],
+      [{ _: ["files", "put"] }, "Invalid files put arguments:"],
+      [{ _: ["files", "delete"] }, "Invalid files delete arguments:"],
+    ];
+    for (const [args, expectedDetail] of cases) {
+      const error = await assertRejects(
+        () => filesCommand(args),
+        VeryfrontError,
+        expectedDetail,
+      );
+      assertInstanceOf(error, VeryfrontError);
+      assertEquals(error.slug, "invalid-argument");
+    }
   });
 });

--- a/cli/commands/files/command.test.ts
+++ b/cli/commands/files/command.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertInstanceOf, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { VeryfrontError } from "veryfront/errors";
 import {
   buildRemoteFileUrl,
   deleteRemoteFile,
@@ -39,6 +40,16 @@ describe("buildRemoteFileUrl", () => {
       buildRemoteFileUrl("my-project", "knowledge/contracts/q1-report.md"),
       "/projects/my-project/files/knowledge%2Fcontracts%2Fq1-report.md",
     );
+  });
+
+  it("rejects traversal attempts as invalid-argument usage errors", () => {
+    const error = assertThrows(
+      () => buildRemoteFileUrl("my-project", "../secrets.txt"),
+      VeryfrontError,
+      "Invalid remote file path",
+    );
+    assertInstanceOf(error, VeryfrontError);
+    assertEquals(error.slug, "invalid-argument");
   });
 });
 

--- a/cli/commands/files/command.ts
+++ b/cli/commands/files/command.ts
@@ -7,7 +7,9 @@ type SafeParseResult<T> = { success: true; data: T } | {
 import { createFileSystem } from "veryfront/platform";
 import { dirname, normalize } from "veryfront/platform/path";
 import { withSpan } from "veryfront/observability/otlp-setup";
+import { INVALID_ARGUMENT } from "veryfront/errors";
 import { cliLogger } from "#cli/utils";
+import { parseArgsOrThrow } from "#cli/shared/args";
 import { type ApiClient, createApiClient, resolveConfigWithAuth } from "#cli/shared/config";
 import type { ParsedArgs } from "#cli/shared/types";
 import { printJson } from "../../shared/json-output.ts";
@@ -94,7 +96,7 @@ Subcommands:
 function normalizeProjectFilePath(remotePath: string): string {
   const normalizedPath = normalize(remotePath).replace(/^\/+/, "");
   if (!normalizedPath || normalizedPath.startsWith("..") || normalizedPath.startsWith("/")) {
-    throw new Error(`Invalid remote file path: ${remotePath}`);
+    throw INVALID_ARGUMENT.create({ detail: `Invalid remote file path: ${remotePath}` });
   }
   return normalizedPath;
 }
@@ -205,12 +207,7 @@ export async function filesCommand(args: ParsedArgs): Promise<void> {
   await withSpan("cli.command.files", async () => {
     switch (subcommand) {
       case "list": {
-        const parsed = parseFilesListArgs(args);
-        if (!parsed.success) {
-          throw new Error(`Invalid files list arguments: ${parsed.error.message}`);
-        }
-
-        const options = parsed.data;
+        const options = parseArgsOrThrow(parseFilesListArgs, "files list", args);
         let config = await resolveConfigWithAuth(options.projectDir);
         if (options.projectSlug) config = { ...config, projectSlug: options.projectSlug };
 
@@ -235,12 +232,7 @@ export async function filesCommand(args: ParsedArgs): Promise<void> {
       }
 
       case "get": {
-        const parsed = parseFilesGetArgs(args);
-        if (!parsed.success) {
-          throw new Error(`Invalid files get arguments: ${parsed.error.message}`);
-        }
-
-        const options = parsed.data;
+        const options = parseArgsOrThrow(parseFilesGetArgs, "files get", args);
         let config = await resolveConfigWithAuth(options.projectDir);
         if (options.projectSlug) config = { ...config, projectSlug: options.projectSlug };
 
@@ -276,12 +268,7 @@ export async function filesCommand(args: ParsedArgs): Promise<void> {
       }
 
       case "put": {
-        const parsed = parseFilesPutArgs(args);
-        if (!parsed.success) {
-          throw new Error(`Invalid files put arguments: ${parsed.error.message}`);
-        }
-
-        const options = parsed.data;
+        const options = parseArgsOrThrow(parseFilesPutArgs, "files put", args);
         let config = await resolveConfigWithAuth(options.projectDir);
         if (options.projectSlug) config = { ...config, projectSlug: options.projectSlug };
 
@@ -306,12 +293,7 @@ export async function filesCommand(args: ParsedArgs): Promise<void> {
 
       case "delete":
       case "rm": {
-        const parsed = parseFilesDeleteArgs(args);
-        if (!parsed.success) {
-          throw new Error(`Invalid files delete arguments: ${parsed.error.message}`);
-        }
-
-        const options = parsed.data;
+        const options = parseArgsOrThrow(parseFilesDeleteArgs, "files delete", args);
         let config = await resolveConfigWithAuth(options.projectDir);
         if (options.projectSlug) config = { ...config, projectSlug: options.projectSlug };
 

--- a/cli/commands/knowledge/command-helpers.ts
+++ b/cli/commands/knowledge/command-helpers.ts
@@ -1,3 +1,4 @@
+import { INVALID_ARGUMENT } from "veryfront/errors";
 import { createFileSystem } from "veryfront/platform";
 import { basename, extname, join, normalize, relative } from "veryfront/platform/path";
 import { classifyKnowledgeDirectoryPath, classifyKnowledgeSourcePath } from "./source-policy.ts";
@@ -26,7 +27,7 @@ const CHAT_UPLOAD_PREFIX_RE =
 export function normalizeKnowledgeInputPath(inputPath: string): string {
   const normalizedPath = normalize(inputPath).replace(/^\/+/, "").replace(/\\/g, "/");
   if (!normalizedPath || normalizedPath.startsWith("..") || normalizedPath.startsWith("/")) {
-    throw new Error(`Invalid knowledge input path: ${inputPath}`);
+    throw INVALID_ARGUMENT.create({ detail: `Invalid knowledge input path: ${inputPath}` });
   }
   return normalizedPath;
 }

--- a/cli/commands/knowledge/command.test.ts
+++ b/cli/commands/knowledge/command.test.ts
@@ -2,12 +2,15 @@ import "#veryfront/schemas/_test-setup.ts";
 import {
   assert,
   assertEquals,
+  assertInstanceOf,
   assertRejects,
   assertStringIncludes,
   assertThrows,
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { basename, join } from "veryfront/platform/path";
+import { VeryfrontError } from "veryfront/errors";
+import type { ParsedArgs } from "#cli/shared/types";
 import {
   buildSuggestedSlug,
   collectKnowledgeSources,
@@ -17,6 +20,7 @@ import {
   formatKnowledgeUploadSource,
   ingestResolvedSources,
   isLikelyLocalPath,
+  knowledgeCommand,
   normalizeKnowledgeInputPath,
   normalizeProjectUploadPath,
   resolveKnowledgeDownloadOutputDir,
@@ -61,8 +65,26 @@ describe("normalizeKnowledgeInputPath", () => {
     );
   });
 
-  it("rejects traversal", () => {
-    assertThrows(() => normalizeKnowledgeInputPath("../secret.txt"));
+  it("rejects traversal as an invalid-argument usage error", () => {
+    const error = assertThrows(
+      () => normalizeKnowledgeInputPath("../secret.txt"),
+      VeryfrontError,
+      "Invalid knowledge input path",
+    );
+    assertInstanceOf(error, VeryfrontError);
+    assertEquals(error.slug, "invalid-argument");
+  });
+});
+
+describe("knowledgeCommand", () => {
+  it("rejects unusable ingest arguments as invalid-argument usage errors", async () => {
+    const error = await assertRejects(
+      () => knowledgeCommand({ _: ["knowledge", "ingest"] } as unknown as ParsedArgs),
+      VeryfrontError,
+      "Invalid knowledge ingest arguments",
+    );
+    assertInstanceOf(error, VeryfrontError);
+    assertEquals(error.slug, "invalid-argument");
   });
 });
 

--- a/cli/commands/knowledge/command.ts
+++ b/cli/commands/knowledge/command.ts
@@ -8,6 +8,7 @@ import { createFileSystem, getEnv } from "veryfront/platform";
 import { basename } from "veryfront/platform/path";
 import { withSpan } from "veryfront/observability/otlp-setup";
 import { cliLogger } from "#cli/utils";
+import { parseArgsOrThrow } from "#cli/shared/args";
 import { type ApiClient, createApiClient, resolveConfigWithAuth } from "#cli/shared/config";
 import type { ParsedArgs } from "#cli/shared/types";
 import { printJson } from "../../shared/json-output.ts";
@@ -547,12 +548,7 @@ export async function knowledgeCommand(args: ParsedArgs): Promise<void> {
   await withSpan("cli.command.knowledge", async () => {
     switch (subcommand) {
       case "ingest": {
-        const parsed = parseKnowledgeIngestArgs(args);
-        if (!parsed.success) {
-          throw new Error(`Invalid knowledge ingest arguments: ${parsed.error.message}`);
-        }
-
-        const options = parsed.data;
+        const options = parseArgsOrThrow(parseKnowledgeIngestArgs, "knowledge ingest", args);
         let config = await resolveConfigWithAuth(options.projectDir);
         if (options.projectSlug) config = { ...config, projectSlug: options.projectSlug };
 

--- a/cli/commands/project/command.test.ts
+++ b/cli/commands/project/command.test.ts
@@ -1,6 +1,13 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertRejects,
+  assertStringIncludes,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { VeryfrontError } from "veryfront/errors";
 import type { ApiClient } from "#cli/shared/config";
 import type { ParsedArgs } from "#cli/shared/types";
 import {
@@ -57,6 +64,16 @@ describe("cli/commands/project", () => {
 
     it("encodes the project reference", () => {
       assertEquals(buildProjectDeleteUrl("my app/2"), "/projects/my%20app%2F2");
+    });
+
+    it("rejects an empty reference as an invalid-argument usage error", () => {
+      const error = assertThrows(
+        () => buildProjectDeleteUrl("  "),
+        VeryfrontError,
+        "Invalid project reference: a project slug or id is required",
+      );
+      assertInstanceOf(error, VeryfrontError);
+      assertEquals(error.slug, "invalid-argument");
     });
   });
 

--- a/cli/commands/project/command.ts
+++ b/cli/commands/project/command.ts
@@ -9,6 +9,7 @@ type SafeParseResult<T> = { success: true; data: T } | {
 import { withSpan } from "veryfront/observability/otlp-setup";
 import { INVALID_ARGUMENT } from "veryfront/errors";
 import { cliLogger, confirmPrompt } from "#cli/utils";
+import { parseArgsOrThrow } from "#cli/shared/args";
 import { type ApiClient, createApiClient, resolveConfigWithAuth } from "#cli/shared/config";
 import type { ParsedArgs } from "#cli/shared/types";
 import { createSuccessEnvelope, outputJson } from "../../shared/json-output.ts";
@@ -56,7 +57,9 @@ export function parseProjectDeleteArgs(
 export function buildProjectDeleteUrl(projectReference: string): string {
   const reference = projectReference.trim();
   if (!reference) {
-    throw new Error("Invalid project reference: a project slug or id is required");
+    throw INVALID_ARGUMENT.create({
+      detail: "Invalid project reference: a project slug or id is required",
+    });
   }
   return `/projects/${encodeURIComponent(reference)}`;
 }
@@ -80,12 +83,7 @@ export async function projectCommand(args: ParsedArgs): Promise<void> {
     switch (subcommand) {
       case "delete":
       case "rm": {
-        const parsed = parseProjectDeleteArgs(args);
-        if (!parsed.success) {
-          throw new Error(`Invalid project delete arguments: ${parsed.error.message}`);
-        }
-
-        const options = parsed.data;
+        const options = parseArgsOrThrow(parseProjectDeleteArgs, "project delete", args);
         const config = await resolveConfigWithAuth(options.projectDir);
         const projectSlug = options.projectSlug ?? config.projectSlug;
 

--- a/cli/commands/styles/command.test.ts
+++ b/cli/commands/styles/command.test.ts
@@ -1,7 +1,13 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertInstanceOf, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { getUnderlyingVeryfrontClient, normalizeStyleArtifactBuildConfigInput } from "./command.ts";
+import { VeryfrontError } from "veryfront/errors";
+import type { StylesArgs } from "./handler.ts";
+import {
+  getUnderlyingVeryfrontClient,
+  normalizeStyleArtifactBuildConfigInput,
+  stylesCommand,
+} from "./command.ts";
 
 describe("getUnderlyingVeryfrontClient", () => {
   it("binds getAllSourceFiles to the underlying adapter", async () => {
@@ -57,5 +63,18 @@ describe("normalizeStyleArtifactBuildConfigInput", () => {
       normalizeStyleArtifactBuildConfigInput({ branch: "main", style_profile_hash: "profile-1" }),
       { branch: "main", style_profile_hash: "profile-1" },
     );
+  });
+});
+
+describe("stylesCommand", () => {
+  it("rejects malformed --config JSON as an invalid-argument usage error", async () => {
+    const args: StylesArgs = { subcommand: "build-artifact", config: "{not-json", debug: false };
+    const error = await assertRejects(
+      () => stylesCommand(args),
+      VeryfrontError,
+      "Invalid --config JSON",
+    );
+    assertInstanceOf(error, VeryfrontError);
+    assertEquals(error.slug, "invalid-argument");
   });
 });

--- a/cli/commands/styles/command.ts
+++ b/cli/commands/styles/command.ts
@@ -1,5 +1,6 @@
 import { defineSchema, lazySchema } from "veryfront/schemas";
 import type { InferSchema } from "veryfront/extensions/schema";
+import { INVALID_ARGUMENT } from "veryfront/errors";
 import { getConfig } from "veryfront/config";
 import {
   enhanceAdapterWithFS,
@@ -95,7 +96,7 @@ function parseStyleArtifactBuildConfig(rawConfig: string | undefined): StyleArti
   try {
     parsed = JSON.parse(rawConfig);
   } catch {
-    throw new Error("Invalid --config JSON");
+    throw INVALID_ARGUMENT.create({ detail: "Invalid --config JSON" });
   }
 
   return StyleArtifactBuildConfigSchema.parse(normalizeStyleArtifactBuildConfigInput(parsed));

--- a/cli/commands/trigger-utils.ts
+++ b/cli/commands/trigger-utils.ts
@@ -1,3 +1,4 @@
+import { INVALID_ARGUMENT } from "veryfront/errors";
 import { cliLogger, exitProcess } from "#cli/utils";
 import { createSuccessEnvelope, isJsonMode, outputJson } from "../shared/json-output.ts";
 import type { SourceTriggerDiscoveryError } from "veryfront/trigger";
@@ -8,7 +9,7 @@ export async function readJsonFile(path: string, label: string): Promise<unknown
     return JSON.parse(content);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Invalid ${label}: ${message}`);
+    throw INVALID_ARGUMENT.create({ detail: `Invalid ${label}: ${message}`, cause: error });
   }
 }
 

--- a/cli/commands/trigger-utils.ts
+++ b/cli/commands/trigger-utils.ts
@@ -4,8 +4,16 @@ import { createSuccessEnvelope, isJsonMode, outputJson } from "../shared/json-ou
 import type { SourceTriggerDiscoveryError } from "veryfront/trigger";
 
 export async function readJsonFile(path: string, label: string): Promise<unknown> {
+  let content: string;
   try {
-    const content = await Deno.readTextFile(path);
+    content = await Deno.readTextFile(path);
+  } catch (error) {
+    // Only a missing file is a usage mistake; permission or I/O failures on an
+    // existing file are runtime errors and must keep exit code 1.
+    if (!(error instanceof Deno.errors.NotFound)) throw error;
+    throw INVALID_ARGUMENT.create({ detail: `Invalid ${label}: ${error.message}`, cause: error });
+  }
+  try {
     return JSON.parse(content);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/cli/commands/uploads/command.test.ts
+++ b/cli/commands/uploads/command.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import {
   assertEquals,
   assertInstanceOf,
+  assertRejects,
   assertStringIncludes,
   assertThrows,
 } from "#veryfront/testing/assert.ts";
@@ -16,8 +17,10 @@ import {
   listAllUploads,
   resolveUploadOutputPath,
   uploadLocalFileToUploads,
+  uploadsCommand,
 } from "./command.ts";
 import type { ApiClient } from "#cli/shared/config";
+import type { ParsedArgs } from "#cli/shared/types";
 
 function createMockClient(overrides: {
   get?: (path: string, params?: Record<string, string>) => Promise<unknown>;
@@ -124,6 +127,25 @@ describe("resolveUploadOutputPath", () => {
     );
     assertInstanceOf(error, VeryfrontError);
     assertEquals(error.slug, "invalid-argument");
+  });
+});
+
+describe("uploadsCommand", () => {
+  it("rejects unusable subcommand arguments as invalid-argument usage errors", async () => {
+    const cases: Array<[ParsedArgs, string]> = [
+      [{ _: ["uploads", "list"], limit: "many" }, "Invalid uploads list arguments:"],
+      [{ _: ["uploads", "put"] }, "Invalid uploads put arguments:"],
+      [{ _: ["uploads", "delete"] }, "Invalid uploads delete arguments:"],
+    ];
+    for (const [args, expectedDetail] of cases) {
+      const error = await assertRejects(
+        () => uploadsCommand(args),
+        VeryfrontError,
+        expectedDetail,
+      );
+      assertInstanceOf(error, VeryfrontError);
+      assertEquals(error.slug, "invalid-argument");
+    }
   });
 });
 

--- a/cli/commands/uploads/command.test.ts
+++ b/cli/commands/uploads/command.test.ts
@@ -1,6 +1,12 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertStringIncludes, assertThrows } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertStringIncludes,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { VeryfrontError } from "veryfront/errors";
 import {
   buildUploadCreateUrl,
   buildUploadSignedUrlPath,
@@ -110,12 +116,14 @@ describe("resolveUploadOutputPath", () => {
     );
   });
 
-  it("rejects traversal attempts", () => {
-    assertThrows(
+  it("rejects traversal attempts as invalid-argument usage errors", () => {
+    const error = assertThrows(
       () => resolveUploadOutputPath("../secrets.txt", "/workspace/uploads"),
-      Error,
+      VeryfrontError,
       "Invalid upload path",
     );
+    assertInstanceOf(error, VeryfrontError);
+    assertEquals(error.slug, "invalid-argument");
   });
 });
 

--- a/cli/commands/uploads/command.ts
+++ b/cli/commands/uploads/command.ts
@@ -8,7 +8,9 @@ type SafeParseResult<T> = { success: true; data: T } | {
 import { createFileSystem, cwd, lookupMimeType } from "veryfront/platform";
 import { dirname, join, normalize, resolve } from "veryfront/platform/path";
 import { withSpan } from "veryfront/observability/otlp-setup";
+import { INVALID_ARGUMENT } from "veryfront/errors";
 import { cliLogger } from "#cli/utils";
+import { parseArgsOrThrow } from "#cli/shared/args";
 import { type ApiClient, createApiClient, resolveConfigWithAuth } from "#cli/shared/config";
 import type { ParsedArgs } from "#cli/shared/types";
 import { printJson } from "../../shared/json-output.ts";
@@ -137,7 +139,7 @@ Subcommands:
 function normalizeUploadPath(uploadPath: string): string {
   const normalizedPath = normalize(uploadPath).replace(/^\/+/, "");
   if (!normalizedPath || normalizedPath.startsWith("..") || normalizedPath.startsWith("/")) {
-    throw new Error(`Invalid upload path: ${uploadPath}`);
+    throw INVALID_ARGUMENT.create({ detail: `Invalid upload path: ${uploadPath}` });
   }
   return normalizedPath;
 }
@@ -248,7 +250,7 @@ export function resolveUploadOutputPath(uploadPath: string, outputDir: string): 
   const resolvedOutputDir = resolve(outputDir);
 
   if (!fullPath.startsWith(`${resolvedOutputDir}/`) && fullPath !== resolvedOutputDir) {
-    throw new Error(`Invalid upload path: ${uploadPath}`);
+    throw INVALID_ARGUMENT.create({ detail: `Invalid upload path: ${uploadPath}` });
   }
 
   return fullPath;
@@ -331,12 +333,7 @@ export async function uploadsCommand(args: ParsedArgs): Promise<void> {
   await withSpan("cli.command.uploads", async () => {
     switch (subcommand) {
       case "list": {
-        const parsed = parseUploadsListArgs(args);
-        if (!parsed.success) {
-          throw new Error(`Invalid uploads list arguments: ${parsed.error.message}`);
-        }
-
-        const options = parsed.data;
+        const options = parseArgsOrThrow(parseUploadsListArgs, "uploads list", args);
         let config = await resolveConfigWithAuth(options.projectDir);
         if (options.projectSlug) config = { ...config, projectSlug: options.projectSlug };
 
@@ -363,12 +360,7 @@ export async function uploadsCommand(args: ParsedArgs): Promise<void> {
       }
 
       case "pull": {
-        const parsed = parseUploadsPullArgs(args);
-        if (!parsed.success) {
-          throw new Error(`Invalid uploads pull arguments: ${parsed.error.message}`);
-        }
-
-        const options = parsed.data;
+        const options = parseArgsOrThrow(parseUploadsPullArgs, "uploads pull", args);
         let config = await resolveConfigWithAuth(options.projectDir);
         if (options.projectSlug) config = { ...config, projectSlug: options.projectSlug };
 
@@ -414,12 +406,7 @@ export async function uploadsCommand(args: ParsedArgs): Promise<void> {
       }
 
       case "put": {
-        const parsed = parseUploadsPutArgs(args);
-        if (!parsed.success) {
-          throw new Error(`Invalid uploads put arguments: ${parsed.error.message}`);
-        }
-
-        const options = parsed.data;
+        const options = parseArgsOrThrow(parseUploadsPutArgs, "uploads put", args);
         let config = await resolveConfigWithAuth(options.projectDir);
         if (options.projectSlug) config = { ...config, projectSlug: options.projectSlug };
 
@@ -445,12 +432,7 @@ export async function uploadsCommand(args: ParsedArgs): Promise<void> {
 
       case "delete":
       case "rm": {
-        const parsed = parseUploadsDeleteArgs(args);
-        if (!parsed.success) {
-          throw new Error(`Invalid uploads delete arguments: ${parsed.error.message}`);
-        }
-
-        const options = parsed.data;
+        const options = parseArgsOrThrow(parseUploadsDeleteArgs, "uploads delete", args);
         let config = await resolveConfigWithAuth(options.projectDir);
         if (options.projectSlug) config = { ...config, projectSlug: options.projectSlug };
 

--- a/cli/commands/webhook/handler.test.ts
+++ b/cli/commands/webhook/handler.test.ts
@@ -13,6 +13,7 @@ import { VeryfrontError } from "veryfront/errors";
 import { setJsonMode } from "../../shared/json-output.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
 import { handleWebhookCommand, toWebhookAgentOptions } from "./handler.ts";
+import { readJsonFile } from "../trigger-utils.ts";
 
 const originalExit = Deno.exit;
 const originalConsoleLog = console.log;
@@ -283,6 +284,18 @@ describe("webhook command", () => {
         ),
       VeryfrontError,
       "Local agent webhook runs cannot attach to an existing cloud conversation.",
+    );
+    assertInstanceOf(error, VeryfrontError);
+    assertEquals(error.slug, "invalid-argument");
+  });
+});
+
+describe("readJsonFile", () => {
+  it("rejects an unreadable payload file as an invalid-argument usage error", async () => {
+    const error = await assertRejects(
+      () => readJsonFile("/nonexistent/veryfront-payload.json", "--payload JSON file"),
+      VeryfrontError,
+      "Invalid --payload JSON file:",
     );
     assertInstanceOf(error, VeryfrontError);
     assertEquals(error.slug, "invalid-argument");

--- a/cli/commands/webhook/handler.test.ts
+++ b/cli/commands/webhook/handler.test.ts
@@ -10,6 +10,8 @@ import { clearProjectAgentRuntimeRegistries } from "#veryfront/agent/project/age
 import { clearTranspileCache } from "#veryfront/discovery/transpiler.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
 import { VeryfrontError } from "veryfront/errors";
+import { join } from "veryfront/platform/path";
+import { withTempDir } from "#veryfront/testing/deno-compat.ts";
 import { setJsonMode } from "../../shared/json-output.ts";
 import type { ParsedArgs } from "../../shared/types.ts";
 import { handleWebhookCommand, toWebhookAgentOptions } from "./handler.ts";
@@ -292,12 +294,15 @@ describe("webhook command", () => {
 
 describe("readJsonFile", () => {
   it("rejects an unreadable payload file as an invalid-argument usage error", async () => {
-    const error = await assertRejects(
-      () => readJsonFile("/nonexistent/veryfront-payload.json", "--payload JSON file"),
-      VeryfrontError,
-      "Invalid --payload JSON file:",
-    );
-    assertInstanceOf(error, VeryfrontError);
-    assertEquals(error.slug, "invalid-argument");
+    await withTempDir(async (tempDir) => {
+      const missingPath = join(tempDir, "veryfront-payload.json");
+      const error = await assertRejects(
+        () => readJsonFile(missingPath, "--payload JSON file"),
+        VeryfrontError,
+        "Invalid --payload JSON file:",
+      );
+      assertInstanceOf(error, VeryfrontError);
+      assertEquals(error.slug, "invalid-argument");
+    }, { prefix: "vf-webhook-payload-" });
   });
 });

--- a/cli/commands/webhook/handler.test.ts
+++ b/cli/commands/webhook/handler.test.ts
@@ -305,4 +305,25 @@ describe("readJsonFile", () => {
       assertEquals(error.slug, "invalid-argument");
     }, { prefix: "vf-webhook-payload-" });
   });
+
+  it("rejects malformed payload JSON as an invalid-argument usage error", async () => {
+    await withTempDir(async (tempDir) => {
+      const payloadPath = join(tempDir, "veryfront-payload.json");
+      await Deno.writeTextFile(payloadPath, "{not-json");
+      const error = await assertRejects(
+        () => readJsonFile(payloadPath, "--payload JSON file"),
+        VeryfrontError,
+        "Invalid --payload JSON file:",
+      );
+      assertInstanceOf(error, VeryfrontError);
+      assertEquals(error.slug, "invalid-argument");
+    }, { prefix: "vf-webhook-payload-" });
+  });
+
+  it("propagates operational read failures without the usage-error envelope", async () => {
+    await withTempDir(async (tempDir) => {
+      const error = await assertRejects(() => readJsonFile(tempDir, "--payload JSON file"));
+      assertEquals(error instanceof VeryfrontError, false);
+    }, { prefix: "vf-webhook-payload-" });
+  });
 });


### PR DESCRIPTION
## Root cause

CLI commands still threw plain `Error("Invalid ...")` for user-input mistakes. The error boundary classifies plain errors as `[unknown-error] Unknown/unclassified error` with the suggestion "Check logs for more details", and exit code 2 was only reached via the string-prefix heuristic in `cli/router.ts` (`message.startsWith("Invalid ")`). This PR converts the user-input sites to the registered `INVALID_ARGUMENT` error (slug `invalid-argument`, `exitCode: 2`, `src/errors/error-registry/general.ts`), so the envelope and exit code are a declared contract instead of a string accident.

**Message-preserving by design:** every `detail` string is byte-identical to the previous `Error` message, and `VeryfrontError.message` equals the detail, so all existing message assertions stay green. The only observable change is the slug (`unknown-error` → `invalid-argument`) and its suggestion/docs link. Exit codes do not move (the heuristic already matched the `"Invalid "` prefix).

## Per-file conversions

| File | Sites | Conversion |
| --- | --- | --- |
| `cli/commands/uploads/command.ts` | 2 | `Invalid upload path: ...` → `INVALID_ARGUMENT.create` |
| `cli/commands/uploads/command.ts` | 4 | hand-rolled parse+throw → `parseArgsOrThrow` (`uploads list/pull/put/delete`) |
| `cli/commands/files/command.ts` | 1 | `Invalid remote file path: ...` → `INVALID_ARGUMENT.create` |
| `cli/commands/files/command.ts` | 4 | hand-rolled parse+throw → `parseArgsOrThrow` (`files list/get/put/delete`) |
| `cli/commands/project/command.ts` | 1 | `Invalid project reference: ...` → `INVALID_ARGUMENT.create` |
| `cli/commands/project/command.ts` | 1 | hand-rolled parse+throw → `parseArgsOrThrow` (`project delete`) |
| `cli/commands/knowledge/command.ts` | 1 | hand-rolled parse+throw → `parseArgsOrThrow` (`knowledge ingest`) |
| `cli/commands/knowledge/command-helpers.ts` | 1 | `Invalid knowledge input path: ...` → `INVALID_ARGUMENT.create` |
| `cli/commands/trigger-utils.ts` | 1 | `readJsonFile` (`--payload`/`--input` JSON files) → `INVALID_ARGUMENT.create` with `cause` |
| `cli/commands/styles/command.ts` | 1 | `Invalid --config JSON` → `INVALID_ARGUMENT.create` |
| `cli/commands/eval/command.ts` | 13 | all `Invalid --comparison-policy: ...` validations → `INVALID_ARGUMENT.create` |

The `parseArgsOrThrow` replacements are message-identical by construction: the hand-rolled sites interpolated the same `parsed.error.message` from the same parser function into the same `Invalid <cmd> arguments: ...` template that `parseArgsOrThrow` (`cli/shared/args.ts`) emits.

## Red → green evidence (TDD)

One representative test per converted file was added/extended first and confirmed failing, then the conversion made it pass.

Red (before conversion):

```
resolveUploadOutputPath ... rejects traversal attempts as invalid-argument usage errors ... FAILED
error: AssertionError: Expected error to be instance of "VeryfrontError", but was "Error".
FAILED | 7 passed (8 steps) | 1 failed (1 step)            # uploads/command.test.ts
FAILED | 4 passed (5 steps) | 1 failed (1 step)            # files/command.test.ts
FAILED | 0 passed (10 steps) | 1 failed (2 steps)          # project/command.test.ts
FAILED | 2 passed (3 steps) | 1 failed (1 step)            # styles/command.test.ts
FAILED | 13 passed (40 steps) | 2 failed (2 steps)         # knowledge/command.test.ts
FAILED | 1 passed (5 steps) | 1 failed (1 step)            # webhook/handler.test.ts (readJsonFile)
FAILED | 0 passed (43 steps) | 1 failed (1 step)           # eval/command.test.ts
```

Green (after conversion), each run via `deno task test:file` without piping, exit 0:

```
ok | 8 passed (9 steps) | 0 failed     uploads/command.test.ts    uploads-exit:0
ok | 5 passed (6 steps) | 0 failed     files/command.test.ts      files-exit:0
ok | 1 passed (12 steps) | 0 failed    project/command.test.ts    project-exit:0
ok | 3 passed (4 steps) | 0 failed     styles/command.test.ts     styles-exit:0
ok | 15 passed (42 steps) | 0 failed   knowledge/command.test.ts  knowledge-exit:0
ok | 2 passed (6 steps) | 0 failed     webhook/handler.test.ts    webhook-exit:0
ok | 1 passed (44 steps) | 0 failed    eval/command.test.ts       eval-exit:0
```

Also run green (exit 0): `uploads/handler.test.ts`, `files/handler.test.ts`, `knowledge/handler.test.ts`, `schedule/handler.test.ts` (second consumer of `readJsonFile`). `deno fmt`, `deno lint`, and `deno check` pass on all changed files, with one caveat: `cli/commands/knowledge/command.test.ts` has 5 pre-existing `deno check` errors that reproduce identically at `origin/main` (Logger `metadata: unknown` assignments and a `DocumentExtractionProgressEvent` push, all in untouched code); this PR adds no new check errors to that file.

## Deliberately out of scope

- **`cli/commands/pull/command.ts` (untouched):** its `Invalid file path` throws validate paths coming from a *remote listing*, not user input. `invalid-argument` (usage error, exit 2) is likely the wrong slug there; per the issue triage it needs a separate decision (runtime slug, exit 1).
- **`cli/utils/package-manager.ts:191` (`Invalid command`):** internal invariant on a hardcoded install-command string, caught in the same function and turned into a logged `false` return; never rendered through the error boundary. Not a user-input mistake, left alone.
- **Non-`Invalid `-prefixed user-input throws** (e.g. `eval/command.ts:1144/1149` `--model`/`--baseline` comparison-mode conflicts, `knowledge/command-helpers.ts` directory-reference message, `styles` `Missing --config JSON`, `generate`/`issues` helpers): outside this PR's message-preserving inventory of `throw new Error("Invalid ...")` sites.
- **Router exit-code heuristic (`cli/router.ts:290-292`), unchanged:** still load-bearing for the unconverted sites above. It can only be deleted once every site carries a real `exitCode`; removing it now would flip exit codes across many commands (including the misfiring auth-token case the issue documents).
- **No copy changes and no Zod-issue-array rendering fix:** the issue also asks for details that name the offending flag; that is a wording change existing tests assert against, sequenced after this conversion.

Refs https://github.com/veryfront/veryfront-issue-inbox/issues/767
