### PR TITLE
feat(semantic-audit): prune logical receivers with a truthiness lattice

### DIFF
--- a/scripts/test/test-semantic-audit.test.ts
+++ b/scripts/test/test-semantic-audit.test.ts
@@ -5305,6 +5305,20 @@ EvalFallback.write("eval.txt", "x");
     assertEquals(
       collectSemanticMarkers(
         `
+class CastEvalFallback {}
+class CastEvalReceiver {}
+(eval as unknown as (source: string) => void)("CastEvalReceiver = null");
+const CastEvalAlias = CastEvalReceiver || CastEvalFallback;
+CastEvalAlias.write = Deno.writeTextFile;
+CastEvalFallback.write("cast-eval.txt", "x");
+`,
+        "src/logical-receiver-cast-direct-eval.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "CastEvalFallback.write"]],
+    );
+    assertEquals(
+      collectSemanticMarkers(
+        `
 class ArgumentsFallback {}
 function outer(ArgumentsReceiver) {
   function ArgumentsReceiver() {}

--- a/scripts/test/test-semantic-audit.test.ts
+++ b/scripts/test/test-semantic-audit.test.ts
@@ -4840,6 +4840,130 @@ conjoinedResult();
     );
   });
 
+  it("prunes unreachable logical receivers with truthiness proof", () => {
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class OrLeft {}
+class OrRight {}
+const OrAlias = OrLeft || OrRight;
+OrAlias.write = Deno.writeTextFile;
+OrLeft.write("or-left.txt", "x");
+OrRight.write("or-right.txt", "x");
+
+class AndLeft {}
+class AndRight {}
+const AndAlias = AndLeft && AndRight;
+AndAlias.write = Deno.writeTextFile;
+AndLeft.write("and-left.txt", "x");
+AndRight.write("and-right.txt", "x");
+
+class NullishLeft {}
+class NullishRight {}
+const NullishAlias = NullishLeft ?? NullishRight;
+NullishAlias.write = Deno.writeTextFile;
+NullishLeft.write("nullish-left.txt", "x");
+NullishRight.write("nullish-right.txt", "x");
+
+class GateSource {}
+class GateFallback {}
+const Gate = GateSource;
+const GateAlias = Gate || GateFallback;
+GateAlias.write = Deno.writeTextFile;
+GateSource.write("gate-source.txt", "x");
+GateFallback.write("gate-fallback.txt", "x");
+
+class NestedInner {}
+class NestedFallback {}
+const nestedMaybe = Math.random() > 0.5 ? NestedInner : undefined;
+const NestedAlias = (nestedMaybe || NestedInner) || NestedFallback;
+NestedAlias.write = Deno.writeTextFile;
+NestedInner.write("nested-inner.txt", "x");
+NestedFallback.write("nested-fallback.txt", "x");
+
+class FalsyGateClass {}
+class FalsyGateFallback {}
+const falsyGate = Math.random() > 0.5 ? FalsyGateClass : false;
+const FalsyGateAlias = falsyGate ?? FalsyGateFallback;
+FalsyGateAlias.write = Deno.writeTextFile;
+FalsyGateClass.write("falsy-gate.txt", "x");
+FalsyGateFallback.write("falsy-gate-fallback.txt", "x");
+`,
+        "src/logical-receiver-truthiness-pruning.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [
+        ["filesystem-write", "OrLeft.write"],
+        ["filesystem-write", "AndRight.write"],
+        ["filesystem-write", "NullishLeft.write"],
+        ["filesystem-write", "GateSource.write"],
+        ["filesystem-write", "NestedInner.write"],
+        ["filesystem-write", "FalsyGateClass.write"],
+      ],
+    );
+  });
+
+  it("retains logical receivers without operator-specific truthiness proof", () => {
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class NullGateClass {}
+class NullGateOrFallback {}
+class NullGateNullishFallback {}
+const nullGate = Math.random() > 0.5 ? NullGateClass : null;
+const NullGateOrAlias = nullGate || NullGateOrFallback;
+NullGateOrAlias.write = Deno.writeTextFile;
+NullGateOrFallback.write("null-gate-or.txt", "x");
+const NullGateNullishAlias = nullGate ?? NullGateNullishFallback;
+NullGateNullishAlias.write = Deno.writeTextFile;
+NullGateNullishFallback.write("null-gate-nullish.txt", "x");
+
+class FalseGateClass {}
+class FalseGateOrFallback {}
+const falseGate = Math.random() > 0.5 ? FalseGateClass : false;
+const FalseGateOrAlias = falseGate || FalseGateOrFallback;
+FalseGateOrAlias.write = Deno.writeTextFile;
+FalseGateOrFallback.write("false-gate-or.txt", "x");
+
+class UncertainClass {}
+class UncertainFallback {}
+const uncertain = Math.random() > 0.5 ? UncertainClass : undefined;
+const UncertainAlias = uncertain || UncertainFallback;
+UncertainAlias.write = Deno.writeTextFile;
+UncertainFallback.write("uncertain-or.txt", "x");
+
+class MemberFallback {}
+const memberHolder = { Receiver: class {} };
+const MemberAlias = memberHolder.Receiver || MemberFallback;
+MemberAlias.write = Deno.writeTextFile;
+MemberFallback.write("member-or.txt", "x");
+
+class OptionalFallback {}
+const optionalHolder = { Receiver: class {} };
+const OptionalAlias = optionalHolder?.Receiver || OptionalFallback;
+OptionalAlias.write = Deno.writeTextFile;
+OptionalFallback.write("optional-or.txt", "x");
+
+class AndKeepLeft {}
+class AndKeepRight {}
+const andUncertain = Math.random() > 0.5 ? AndKeepLeft : undefined;
+const AndKeepAlias = andUncertain && AndKeepRight;
+AndKeepAlias.write = Deno.writeTextFile;
+AndKeepLeft.write("and-keep-left.txt", "x");
+`,
+        "src/logical-receiver-fail-closed.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [
+        ["filesystem-write", "NullGateOrFallback.write"],
+        ["filesystem-write", "NullGateNullishFallback.write"],
+        ["filesystem-write", "FalseGateOrFallback.write"],
+        ["filesystem-write", "UncertainFallback.write"],
+        ["filesystem-write", "MemberFallback.write"],
+        ["filesystem-write", "OptionalFallback.write"],
+        ["filesystem-write", "AndKeepLeft.write"],
+      ],
+    );
+  });
+
   it("uses JavaScript array-index bounds for sparse writes", () => {
     assertEquals(
       collectSemanticMarkers(

--- a/scripts/test/test-semantic-audit.test.ts
+++ b/scripts/test/test-semantic-audit.test.ts
@@ -5288,6 +5288,64 @@ VarOfFallback.write("var-of.txt", "x");
       ).map((marker) => [marker.effect, marker.symbol]),
       [["filesystem-write", "VarOfFallback.write"]],
     );
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class EvalFallback {}
+class EvalReceiver {}
+eval("EvalReceiver = null");
+const EvalAlias = EvalReceiver || EvalFallback;
+EvalAlias.write = Deno.writeTextFile;
+EvalFallback.write("eval.txt", "x");
+`,
+        "src/logical-receiver-direct-eval.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "EvalFallback.write"]],
+    );
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class ArgumentsFallback {}
+function outer(ArgumentsReceiver) {
+  function ArgumentsReceiver() {}
+  arguments[0] = null;
+  const ArgumentsAlias = ArgumentsReceiver || ArgumentsFallback;
+  ArgumentsAlias.write = Deno.writeTextFile;
+}
+void outer;
+ArgumentsFallback.write("arguments.txt", "x");
+`,
+        "src/logical-receiver-mapped-arguments.test.cjs",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "ArgumentsFallback.write"]],
+    );
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class TsCastFallback {}
+class TsCastReceiver {}
+(TsCastReceiver as unknown as null) = null;
+const TsCastAlias = TsCastReceiver || TsCastFallback;
+TsCastAlias.write = Deno.writeTextFile;
+TsCastFallback.write("ts-cast.txt", "x");
+`,
+        "src/logical-receiver-ts-cast-target.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "TsCastFallback.write"]],
+    );
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class NewFallback {}
+class NewExotic {}
+const NewAlias = new NewExotic() || NewFallback;
+NewAlias.write = Deno.writeTextFile;
+NewFallback.write("new.txt", "x");
+`,
+        "src/logical-receiver-new-expression.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "NewFallback.write"]],
+    );
   });
 
   it("uses JavaScript array-index bounds for sparse writes", () => {

--- a/scripts/test/test-semantic-audit.test.ts
+++ b/scripts/test/test-semantic-audit.test.ts
@@ -4964,6 +4964,107 @@ AndKeepLeft.write("and-keep-left.txt", "x");
     );
   });
 
+  it("retains logical receivers when truthiness evidence is invalidated", () => {
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class BoundaryOriginal {}
+class BoundaryFallback {}
+let boundaryReceiver = BoundaryOriginal;
+const useBoundary = () => {
+  const BoundaryAlias = boundaryReceiver || BoundaryFallback;
+  BoundaryAlias.write = Deno.writeTextFile;
+};
+boundaryReceiver = null;
+useBoundary();
+BoundaryFallback.write("boundary.txt", "x");
+`,
+        "src/logical-receiver-function-boundary.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "BoundaryFallback.write"]],
+    );
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class JsxFallback {}
+const Component = () => null;
+const JsxAlias = (<Component />) || JsxFallback;
+JsxAlias.write = Deno.writeTextFile;
+JsxFallback.write("jsx.txt", "x");
+`,
+        "src/logical-receiver-jsx-factory.test.tsx",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "JsxFallback.write"]],
+    );
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class DecrementFallback {}
+let counter = 1;
+counter--;
+const CounterAlias = counter || DecrementFallback;
+CounterAlias.write = Deno.writeTextFile;
+DecrementFallback.write("decrement.txt", "x");
+
+class CompoundFallback {}
+let compound = 1;
+compound *= 0;
+const CompoundAlias = compound || CompoundFallback;
+CompoundAlias.write = Deno.writeTextFile;
+CompoundFallback.write("compound.txt", "x");
+
+class LoopOriginal {}
+class LoopFallback {}
+let looped = LoopOriginal;
+for (looped of [null]) {}
+const LoopAlias = looped || LoopFallback;
+LoopAlias.write = Deno.writeTextFile;
+LoopFallback.write("loop.txt", "x");
+`,
+        "src/logical-receiver-unmodeled-mutations.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [
+        ["filesystem-write", "DecrementFallback.write"],
+        ["filesystem-write", "CompoundFallback.write"],
+        ["filesystem-write", "LoopFallback.write"],
+      ],
+    );
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class SwitchOriginal {}
+class SwitchFallback {}
+let switched = null;
+switch (Math.random()) {
+  case 0.1:
+    break;
+  case (switched = SwitchOriginal, 0.2):
+    break;
+}
+const SwitchAlias = switched || SwitchFallback;
+SwitchAlias.write = Deno.writeTextFile;
+SwitchFallback.write("switch.txt", "x");
+`,
+        "src/logical-receiver-switch-case-test.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "SwitchFallback.write"]],
+    );
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class SequenceOriginal {}
+class SequenceFallback {}
+let sequenced = SequenceOriginal;
+const SequenceAlias = (sequenced = null, sequenced) || SequenceFallback;
+SequenceAlias.write = Deno.writeTextFile;
+SequenceFallback.write("sequence.txt", "x");
+`,
+        "src/logical-receiver-intra-expression-write.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "SequenceFallback.write"]],
+    );
+  });
+
   it("uses JavaScript array-index bounds for sparse writes", () => {
     assertEquals(
       collectSemanticMarkers(

--- a/scripts/test/test-semantic-audit.test.ts
+++ b/scripts/test/test-semantic-audit.test.ts
@@ -4991,6 +4991,26 @@ AndKeepLeft.write("and-keep-left.txt", "x");
     );
   });
 
+  it("does not leak positive truthiness facts out of uncalled nested functions", () => {
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class ClosureFallback {}
+let closureReceiver;
+function assignClosureReceiver() {
+  closureReceiver = class {};
+}
+void assignClosureReceiver;
+const ClosureAlias = closureReceiver || ClosureFallback;
+ClosureAlias.write = Deno.writeTextFile;
+ClosureFallback.write("closure-fallback.txt", "x");
+`,
+        "src/logical-receiver-uncalled-closure.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "ClosureFallback.write"]],
+    );
+  });
+
   it("retains logical receivers when truthiness evidence is invalidated", () => {
     assertEquals(
       collectSemanticMarkers(

--- a/scripts/test/test-semantic-audit.test.ts
+++ b/scripts/test/test-semantic-audit.test.ts
@@ -4902,6 +4902,33 @@ FalsyGateFallback.write("falsy-gate-fallback.txt", "x");
     );
   });
 
+  it("retains logical receivers for awaited thenables resolving null or falsy", () => {
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class AwaitedTruthyOperand {}
+class AwaitedTruthyFallback {}
+const awaitedTruthy = await { then(resolve) { resolve(false); }, value: AwaitedTruthyOperand };
+const AwaitedTruthyAlias = awaitedTruthy || AwaitedTruthyFallback;
+AwaitedTruthyAlias.write = Deno.writeTextFile;
+AwaitedTruthyFallback.write("awaited-truthy.txt", "x");
+
+class AwaitedNonNullishOperand {}
+class AwaitedNonNullishFallback {}
+const awaitedNonNullish = await { then(resolve) { resolve(null); }, value: AwaitedNonNullishOperand };
+const AwaitedNonNullishAlias = awaitedNonNullish ?? AwaitedNonNullishFallback;
+AwaitedNonNullishAlias.write = Deno.writeTextFile;
+AwaitedNonNullishFallback.write("awaited-non-nullish.txt", "x");
+`,
+        "src/logical-receiver-awaited-thenable.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [
+        ["filesystem-write", "AwaitedTruthyFallback.write"],
+        ["filesystem-write", "AwaitedNonNullishFallback.write"],
+      ],
+    );
+  });
+
   it("retains logical receivers without operator-specific truthiness proof", () => {
     assertEquals(
       collectSemanticMarkers(

--- a/scripts/test/test-semantic-audit.test.ts
+++ b/scripts/test/test-semantic-audit.test.ts
@@ -5260,6 +5260,20 @@ DefaultFallback.write("default.txt", "x");
       ).map((marker) => [marker.effect, marker.symbol]),
       [["filesystem-write", "DefaultFallback.write"]],
     );
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class VarFnFallback {}
+function VarFnReceiver() {}
+var VarFnReceiver = null;
+const VarFnAlias = VarFnReceiver || VarFnFallback;
+VarFnAlias.write = Deno.writeTextFile;
+VarFnFallback.write("var-fn.txt", "x");
+`,
+        "src/logical-receiver-var-redeclared-function.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "VarFnFallback.write"]],
+    );
   });
 
   it("uses JavaScript array-index bounds for sparse writes", () => {

--- a/scripts/test/test-semantic-audit.test.ts
+++ b/scripts/test/test-semantic-audit.test.ts
@@ -5112,6 +5112,156 @@ SequenceFallback.write("sequence.txt", "x");
     );
   });
 
+  it("grants truthiness evidence only from immutable declaration forms", () => {
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class MutatorOriginal {}
+class MutatorFallback {}
+let mutatorReceiver = MutatorOriginal;
+mutate();
+const MutatorAlias = mutatorReceiver || MutatorFallback;
+MutatorAlias.write = Deno.writeTextFile;
+MutatorFallback.write("mutator.txt", "x");
+function mutate() {
+  mutatorReceiver = null;
+}
+`,
+        "src/logical-receiver-hoisted-mutator.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "MutatorFallback.write"]],
+    );
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class AmbientFallback {}
+(globalThis as { AmbientReceiver: null }).AmbientReceiver = null;
+declare class AmbientReceiver {}
+const AmbientAlias = AmbientReceiver || AmbientFallback;
+AmbientAlias.write = Deno.writeTextFile;
+AmbientFallback.write("ambient.txt", "x");
+`,
+        "src/logical-receiver-declare-class.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [
+        ["process", "globalThis.AmbientReceiver"],
+        ["filesystem-write", "AmbientFallback.write"],
+      ],
+    );
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class DoWhileOriginal {}
+class DoWhileFallback {}
+let doWhileReceiver = null;
+do {
+  if (Math.random() > 0.5) break;
+} while (doWhileReceiver = DoWhileOriginal);
+const DoWhileAlias = doWhileReceiver || DoWhileFallback;
+DoWhileAlias.write = Deno.writeTextFile;
+DoWhileFallback.write("do-while.txt", "x");
+`,
+        "src/logical-receiver-do-while-test.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "DoWhileFallback.write"]],
+    );
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class VarOriginal {}
+class VarFallback {}
+const VarAlias = varReceiver || VarFallback;
+VarAlias.write = Deno.writeTextFile;
+VarFallback.write("var.txt", "x");
+var varReceiver = VarOriginal;
+`,
+        "src/logical-receiver-hoisted-var.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "VarFallback.write"]],
+    );
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class LabelOriginal {}
+class LabelFallback {}
+let labelReceiver = null;
+outer: {
+  if (Math.random() > 0.5) break outer;
+  labelReceiver = LabelOriginal;
+}
+const LabelAlias = labelReceiver || LabelFallback;
+LabelAlias.write = Deno.writeTextFile;
+LabelFallback.write("label.txt", "x");
+`,
+        "src/logical-receiver-labeled-break.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "LabelFallback.write"]],
+    );
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class UncalledFallback {}
+let uncalledReceiver = null;
+const mutateUncalled = () => {
+  uncalledReceiver = {};
+};
+const UncalledAlias = uncalledReceiver || UncalledFallback;
+UncalledAlias.write = Deno.writeTextFile;
+UncalledFallback.write("uncalled.txt", "x");
+`,
+        "src/logical-receiver-uncalled-function.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "UncalledFallback.write"]],
+    );
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class FieldFallback {}
+let fieldReceiver = null;
+class FieldHolder {
+  value = (fieldReceiver = {});
+}
+const FieldAlias = fieldReceiver || FieldFallback;
+FieldAlias.write = Deno.writeTextFile;
+FieldFallback.write("field.txt", "x");
+`,
+        "src/logical-receiver-instance-field.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "FieldFallback.write"]],
+    );
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class NestedWriteOriginal {}
+class NestedWriteFallback {}
+let nestedWriteReceiver = null;
+nestedWriteReceiver = (nestedWriteReceiver = NestedWriteOriginal, null);
+const NestedWriteAlias = nestedWriteReceiver || NestedWriteFallback;
+NestedWriteAlias.write = Deno.writeTextFile;
+NestedWriteFallback.write("nested-write.txt", "x");
+`,
+        "src/logical-receiver-nested-write.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "NestedWriteFallback.write"]],
+    );
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class DefaultOriginal {}
+class DefaultFallback {}
+let defaultReceiver = null;
+const { gate = (defaultReceiver = DefaultOriginal) } = { gate: true };
+void gate;
+const DefaultAlias = defaultReceiver || DefaultFallback;
+DefaultAlias.write = Deno.writeTextFile;
+DefaultFallback.write("default.txt", "x");
+`,
+        "src/logical-receiver-skipped-default.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "DefaultFallback.write"]],
+    );
+  });
+
   it("uses JavaScript array-index bounds for sparse writes", () => {
     assertEquals(
       collectSemanticMarkers(

--- a/scripts/test/test-semantic-audit.test.ts
+++ b/scripts/test/test-semantic-audit.test.ts
@@ -5274,6 +5274,20 @@ VarFnFallback.write("var-fn.txt", "x");
       ).map((marker) => [marker.effect, marker.symbol]),
       [["filesystem-write", "VarFnFallback.write"]],
     );
+    assertEquals(
+      collectSemanticMarkers(
+        `
+class VarOfFallback {}
+function VarOfReceiver() {}
+for (var VarOfReceiver of [null]) {}
+const VarOfAlias = VarOfReceiver || VarOfFallback;
+VarOfAlias.write = Deno.writeTextFile;
+VarOfFallback.write("var-of.txt", "x");
+`,
+        "src/logical-receiver-var-of-loop-target.test.ts",
+      ).map((marker) => [marker.effect, marker.symbol]),
+      [["filesystem-write", "VarOfFallback.write"]],
+    );
   });
 
   it("uses JavaScript array-index bounds for sparse writes", () => {

--- a/scripts/test/test-semantic-audit.ts
+++ b/scripts/test/test-semantic-audit.ts
@@ -887,6 +887,7 @@ export function collectSemanticMarkers(
       nextScopes,
       allowAssignmentClearing,
     );
+    clearTruthinessForUnmodeledMutation(node, nextScopes);
     bindRuntimeDeleteMutation(
       node,
       bindings,
@@ -4143,6 +4144,7 @@ function visitRuntimeBindingSummary(
   }
   bindRuntimeClassDeclaration(node, nextScopes);
   bindRuntimeAssignment(node, imports, nextScopes, allowClearing);
+  clearTruthinessForUnmodeledMutation(node, nextScopes);
   bindRuntimeDeleteMutation(node, imports, nextScopes, allowClearing);
   for (const key of Object.keys(node)) {
     if (
@@ -7421,6 +7423,38 @@ function assignmentTargetScope(
   return undefined;
 }
 
+// Writes that bindRuntimeAssignment does not model (update expressions,
+// arithmetic compound assignments, bare loop targets) can make a previously
+// truthy binding falsy, so they must drop both truthiness facts.
+function clearTruthinessForUnmodeledMutation(
+  node: Node,
+  scopes: readonly Scope[],
+): void {
+  let target: Node | undefined;
+  if (
+    node.type === "AssignmentExpression" && isNode(node.left) &&
+    !["=", "&&=", "||=", "??="].includes(String(node.operator))
+  ) {
+    target = node.left;
+  } else if (node.type === "UpdateExpression" && isNode(node.argument)) {
+    target = node.argument;
+  } else if (
+    (node.type === "ForOfStatement" || node.type === "ForInStatement") &&
+    isNode(node.left) && node.left.type !== "VariableDeclaration"
+  ) {
+    target = node.left;
+  }
+  if (!target) return;
+  const names = new Set<string>();
+  collectPatternNames(target, names);
+  for (const name of names) {
+    const scope = declaringScopeForName(name, scopes);
+    if (!scope) continue;
+    scope.definitelyTruthyNames.delete(name);
+    scope.definitelyNonNullishNames.delete(name);
+  }
+}
+
 function bindDefinitelyNonUndefinedPattern(
   pattern: Node,
   binding: RuntimeBinding | undefined,
@@ -8154,7 +8188,12 @@ function isConditionalBranch(parent: Node, key: string): boolean {
     return true;
   }
   if (parent.type === "LogicalExpression" && key === "right") return true;
-  if (parent.type === "SwitchCase" && key === "consequent") return true;
+  // A case test only runs when no earlier case matched.
+  if (
+    parent.type === "SwitchCase" && (key === "consequent" || key === "test")
+  ) {
+    return true;
+  }
   if (
     (parent.type === "WhileStatement" ||
       parent.type === "DoWhileStatement" ||
@@ -8926,21 +8965,65 @@ function expressionMayBeUndefined(
   );
 }
 
+// Syntactic writes inside the expression being proven run after the proof is
+// computed, so identifier evidence read alongside them may be stale.
+function expressionSubtreeContainsWrite(node: unknown): boolean {
+  if (!isNode(node)) return false;
+  if (
+    node.type === "AssignmentExpression" || node.type === "UpdateExpression"
+  ) {
+    return true;
+  }
+  for (const key of Object.keys(node)) {
+    if (key === "loc" || COMMENT_KEYS.has(key)) continue;
+    const value = node[key];
+    if (Array.isArray(value)) {
+      if (value.some((item) => expressionSubtreeContainsWrite(item))) {
+        return true;
+      }
+    } else if (expressionSubtreeContainsWrite(value)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Recorded evidence is unusable across function boundaries (interleaved calls
+// can reassign the outer binding before the function body runs).
+function identifierTruthinessEvidence(
+  name: string,
+  scopes: readonly Scope[],
+): {
+  readonly definitelyTruthy: boolean;
+  readonly definitelyNonNullish: boolean;
+} {
+  const resolved = resolveLocalBinding(name, scopes);
+  if (!resolved.declared || resolved.crossesFunctionBoundary === true) {
+    return { definitelyTruthy: false, definitelyNonNullish: false };
+  }
+  return {
+    definitelyTruthy: resolved.definitelyTruthy === true,
+    definitelyNonNullish: resolved.definitelyNonNullish === true,
+  };
+}
+
 // Intentionally separate from expressionMayBeUndefined: definitely-non-undefined
 // is not truthiness proof (`maybe ? ClassA : null` is non-undefined but nullish).
 function expressionIsDefinitelyTruthy(
   expression: unknown,
   scopes: readonly Scope[],
+  identifierEvidenceUsable?: boolean,
 ): boolean {
   const value = unwrapExpression(expression);
   if (!value) return false;
+  const identifierEvidence = identifierEvidenceUsable ??
+    !expressionSubtreeContainsWrite(value);
   switch (value.type) {
+    // JSX is absent: a custom jsxFactory may legally return null or false.
     case "ArrayExpression":
     case "ArrowFunctionExpression":
     case "ClassExpression":
     case "FunctionExpression":
-    case "JSXElement":
-    case "JSXFragment":
     case "NewExpression":
     case "ObjectExpression":
     case "RegExpLiteral":
@@ -8952,15 +9035,29 @@ function expressionIsDefinitelyTruthy(
     case "StringLiteral":
       return value.value !== "";
     case "ConditionalExpression":
-      return expressionIsDefinitelyTruthy(value.consequent, scopes) &&
-        expressionIsDefinitelyTruthy(value.alternate, scopes);
+      return expressionIsDefinitelyTruthy(
+        value.consequent,
+        scopes,
+        identifierEvidence,
+      ) &&
+        expressionIsDefinitelyTruthy(
+          value.alternate,
+          scopes,
+          identifierEvidence,
+        );
     case "LogicalExpression": {
-      const left = expressionIsDefinitelyTruthy(value.left, scopes);
+      const left = expressionIsDefinitelyTruthy(
+        value.left,
+        scopes,
+        identifierEvidence,
+      );
       if (value.operator === "&&") {
-        return left && expressionIsDefinitelyTruthy(value.right, scopes);
+        return left &&
+          expressionIsDefinitelyTruthy(value.right, scopes, identifierEvidence);
       }
       if (value.operator === "||") {
-        return left || expressionIsDefinitelyTruthy(value.right, scopes);
+        return left ||
+          expressionIsDefinitelyTruthy(value.right, scopes, identifierEvidence);
       }
       return left;
     }
@@ -8968,14 +9065,19 @@ function expressionIsDefinitelyTruthy(
       const expressions = Array.isArray(value.expressions)
         ? value.expressions
         : [];
-      return expressionIsDefinitelyTruthy(expressions.at(-1), scopes);
+      return expressionIsDefinitelyTruthy(
+        expressions.at(-1),
+        scopes,
+        identifierEvidence,
+      );
     }
     case "AssignmentExpression":
       return value.operator === "=" &&
-        expressionIsDefinitelyTruthy(value.right, scopes);
+        expressionIsDefinitelyTruthy(value.right, scopes, identifierEvidence);
     case "Identifier":
-      return resolveLocalBinding(value.name as string, scopes)
-        .definitelyTruthy === true;
+      return identifierEvidence &&
+        identifierTruthinessEvidence(value.name as string, scopes)
+          .definitelyTruthy;
     default:
       return false;
   }
@@ -8984,9 +9086,12 @@ function expressionIsDefinitelyTruthy(
 function expressionIsDefinitelyNonNullish(
   expression: unknown,
   scopes: readonly Scope[],
+  identifierEvidenceUsable?: boolean,
 ): boolean {
   const value = unwrapExpression(expression);
   if (!value) return false;
+  const identifierEvidence = identifierEvidenceUsable ??
+    !expressionSubtreeContainsWrite(value);
   switch (value.type) {
     case "ArrayExpression":
     case "ArrowFunctionExpression":
@@ -8994,8 +9099,6 @@ function expressionIsDefinitelyNonNullish(
     case "BooleanLiteral":
     case "ClassExpression":
     case "FunctionExpression":
-    case "JSXElement":
-    case "JSXFragment":
     case "NewExpression":
     case "NumericLiteral":
     case "ObjectExpression":
@@ -9004,32 +9107,73 @@ function expressionIsDefinitelyNonNullish(
     case "TemplateLiteral":
       return true;
     case "ConditionalExpression":
-      return expressionIsDefinitelyNonNullish(value.consequent, scopes) &&
-        expressionIsDefinitelyNonNullish(value.alternate, scopes);
+      return expressionIsDefinitelyNonNullish(
+        value.consequent,
+        scopes,
+        identifierEvidence,
+      ) &&
+        expressionIsDefinitelyNonNullish(
+          value.alternate,
+          scopes,
+          identifierEvidence,
+        );
     case "LogicalExpression": {
       if (value.operator === "&&") {
-        return expressionIsDefinitelyNonNullish(value.left, scopes) &&
-          expressionIsDefinitelyNonNullish(value.right, scopes);
+        return expressionIsDefinitelyNonNullish(
+          value.left,
+          scopes,
+          identifierEvidence,
+        ) &&
+          expressionIsDefinitelyNonNullish(
+            value.right,
+            scopes,
+            identifierEvidence,
+          );
       }
       if (value.operator === "||") {
-        return expressionIsDefinitelyTruthy(value.left, scopes) ||
-          expressionIsDefinitelyNonNullish(value.right, scopes);
+        return expressionIsDefinitelyTruthy(
+          value.left,
+          scopes,
+          identifierEvidence,
+        ) ||
+          expressionIsDefinitelyNonNullish(
+            value.right,
+            scopes,
+            identifierEvidence,
+          );
       }
-      return expressionIsDefinitelyNonNullish(value.left, scopes) ||
-        expressionIsDefinitelyNonNullish(value.right, scopes);
+      return expressionIsDefinitelyNonNullish(
+        value.left,
+        scopes,
+        identifierEvidence,
+      ) ||
+        expressionIsDefinitelyNonNullish(
+          value.right,
+          scopes,
+          identifierEvidence,
+        );
     }
     case "SequenceExpression": {
       const expressions = Array.isArray(value.expressions)
         ? value.expressions
         : [];
-      return expressionIsDefinitelyNonNullish(expressions.at(-1), scopes);
+      return expressionIsDefinitelyNonNullish(
+        expressions.at(-1),
+        scopes,
+        identifierEvidence,
+      );
     }
     case "AssignmentExpression":
       return value.operator === "=" &&
-        expressionIsDefinitelyNonNullish(value.right, scopes);
+        expressionIsDefinitelyNonNullish(
+          value.right,
+          scopes,
+          identifierEvidence,
+        );
     case "Identifier":
-      return resolveLocalBinding(value.name as string, scopes)
-        .definitelyNonNullish === true;
+      return identifierEvidence &&
+        identifierTruthinessEvidence(value.name as string, scopes)
+          .definitelyNonNullish;
     default:
       return false;
   }

--- a/scripts/test/test-semantic-audit.ts
+++ b/scripts/test/test-semantic-audit.ts
@@ -3557,6 +3557,16 @@ function collectAssignedIdentifierNames(
     collectPatternNames(node.left, names);
   } else if (node.type === "UpdateExpression") {
     collectPatternNames(node.argument, names);
+  } else if (node.type === "VariableDeclaration" && node.kind === "var") {
+    for (
+      const declarator of Array.isArray(node.declarations)
+        ? node.declarations
+        : []
+    ) {
+      if (isNode(declarator) && declarator.init) {
+        collectPatternNames(declarator.id, names);
+      }
+    }
   } else if (
     (node.type === "ForOfStatement" || node.type === "ForInStatement") &&
     isNode(node.left) && node.left.type !== "VariableDeclaration"
@@ -8199,12 +8209,7 @@ function isConditionalBranch(parent: Node, key: string): boolean {
     return true;
   }
   if (parent.type === "LogicalExpression" && key === "right") return true;
-  // A case test only runs when no earlier case matched.
-  if (
-    parent.type === "SwitchCase" && (key === "consequent" || key === "test")
-  ) {
-    return true;
-  }
+  if (parent.type === "SwitchCase" && key === "consequent") return true;
   if (
     (parent.type === "WhileStatement" ||
       parent.type === "DoWhileStatement" ||
@@ -8969,29 +8974,6 @@ function expressionMayBeUndefined(
   );
 }
 
-// Syntactic writes inside the expression being proven run after the proof is
-// computed, so identifier evidence read alongside them may be stale.
-function expressionSubtreeContainsWrite(node: unknown): boolean {
-  if (!isNode(node)) return false;
-  if (
-    node.type === "AssignmentExpression" || node.type === "UpdateExpression"
-  ) {
-    return true;
-  }
-  for (const key of Object.keys(node)) {
-    if (key === "loc" || COMMENT_KEYS.has(key)) continue;
-    const value = node[key];
-    if (Array.isArray(value)) {
-      if (value.some((item) => expressionSubtreeContainsWrite(item))) {
-        return true;
-      }
-    } else if (expressionSubtreeContainsWrite(value)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 // Recorded evidence is unusable across function boundaries (interleaved calls
 // can reassign the outer binding before the function body runs).
 function identifierTruthinessEvidence(
@@ -9016,12 +8998,9 @@ function identifierTruthinessEvidence(
 function expressionIsDefinitelyTruthy(
   expression: unknown,
   scopes: readonly Scope[],
-  identifierEvidenceUsable?: boolean,
 ): boolean {
   const value = unwrapTruthinessProofExpression(expression);
   if (!value) return false;
-  const identifierEvidence = identifierEvidenceUsable ??
-    !expressionSubtreeContainsWrite(value);
   switch (value.type) {
     // JSX is absent: a custom jsxFactory may legally return null or false.
     case "ArrayExpression":
@@ -9039,29 +9018,17 @@ function expressionIsDefinitelyTruthy(
     case "StringLiteral":
       return value.value !== "";
     case "ConditionalExpression":
-      return expressionIsDefinitelyTruthy(
-        value.consequent,
-        scopes,
-        identifierEvidence,
-      ) &&
-        expressionIsDefinitelyTruthy(
-          value.alternate,
-          scopes,
-          identifierEvidence,
-        );
+      return expressionIsDefinitelyTruthy(value.consequent, scopes) &&
+        expressionIsDefinitelyTruthy(value.alternate, scopes);
     case "LogicalExpression": {
-      const left = expressionIsDefinitelyTruthy(
-        value.left,
-        scopes,
-        identifierEvidence,
-      );
+      const left = expressionIsDefinitelyTruthy(value.left, scopes);
       if (value.operator === "&&") {
         return left &&
-          expressionIsDefinitelyTruthy(value.right, scopes, identifierEvidence);
+          expressionIsDefinitelyTruthy(value.right, scopes);
       }
       if (value.operator === "||") {
         return left ||
-          expressionIsDefinitelyTruthy(value.right, scopes, identifierEvidence);
+          expressionIsDefinitelyTruthy(value.right, scopes);
       }
       return left;
     }
@@ -9069,19 +9036,14 @@ function expressionIsDefinitelyTruthy(
       const expressions = Array.isArray(value.expressions)
         ? value.expressions
         : [];
-      return expressionIsDefinitelyTruthy(
-        expressions.at(-1),
-        scopes,
-        identifierEvidence,
-      );
+      return expressionIsDefinitelyTruthy(expressions.at(-1), scopes);
     }
     case "AssignmentExpression":
       return value.operator === "=" &&
-        expressionIsDefinitelyTruthy(value.right, scopes, identifierEvidence);
+        expressionIsDefinitelyTruthy(value.right, scopes);
     case "Identifier":
-      return identifierEvidence &&
-        identifierTruthinessEvidence(value.name as string, scopes)
-          .definitelyTruthy;
+      return identifierTruthinessEvidence(value.name as string, scopes)
+        .definitelyTruthy;
     default:
       return false;
   }
@@ -9090,12 +9052,9 @@ function expressionIsDefinitelyTruthy(
 function expressionIsDefinitelyNonNullish(
   expression: unknown,
   scopes: readonly Scope[],
-  identifierEvidenceUsable?: boolean,
 ): boolean {
   const value = unwrapTruthinessProofExpression(expression);
   if (!value) return false;
-  const identifierEvidence = identifierEvidenceUsable ??
-    !expressionSubtreeContainsWrite(value);
   switch (value.type) {
     case "ArrayExpression":
     case "ArrowFunctionExpression":
@@ -9111,73 +9070,32 @@ function expressionIsDefinitelyNonNullish(
     case "TemplateLiteral":
       return true;
     case "ConditionalExpression":
-      return expressionIsDefinitelyNonNullish(
-        value.consequent,
-        scopes,
-        identifierEvidence,
-      ) &&
-        expressionIsDefinitelyNonNullish(
-          value.alternate,
-          scopes,
-          identifierEvidence,
-        );
+      return expressionIsDefinitelyNonNullish(value.consequent, scopes) &&
+        expressionIsDefinitelyNonNullish(value.alternate, scopes);
     case "LogicalExpression": {
       if (value.operator === "&&") {
-        return expressionIsDefinitelyNonNullish(
-          value.left,
-          scopes,
-          identifierEvidence,
-        ) &&
-          expressionIsDefinitelyNonNullish(
-            value.right,
-            scopes,
-            identifierEvidence,
-          );
+        return expressionIsDefinitelyNonNullish(value.left, scopes) &&
+          expressionIsDefinitelyNonNullish(value.right, scopes);
       }
       if (value.operator === "||") {
-        return expressionIsDefinitelyTruthy(
-          value.left,
-          scopes,
-          identifierEvidence,
-        ) ||
-          expressionIsDefinitelyNonNullish(
-            value.right,
-            scopes,
-            identifierEvidence,
-          );
+        return expressionIsDefinitelyTruthy(value.left, scopes) ||
+          expressionIsDefinitelyNonNullish(value.right, scopes);
       }
-      return expressionIsDefinitelyNonNullish(
-        value.left,
-        scopes,
-        identifierEvidence,
-      ) ||
-        expressionIsDefinitelyNonNullish(
-          value.right,
-          scopes,
-          identifierEvidence,
-        );
+      return expressionIsDefinitelyNonNullish(value.left, scopes) ||
+        expressionIsDefinitelyNonNullish(value.right, scopes);
     }
     case "SequenceExpression": {
       const expressions = Array.isArray(value.expressions)
         ? value.expressions
         : [];
-      return expressionIsDefinitelyNonNullish(
-        expressions.at(-1),
-        scopes,
-        identifierEvidence,
-      );
+      return expressionIsDefinitelyNonNullish(expressions.at(-1), scopes);
     }
     case "AssignmentExpression":
       return value.operator === "=" &&
-        expressionIsDefinitelyNonNullish(
-          value.right,
-          scopes,
-          identifierEvidence,
-        );
+        expressionIsDefinitelyNonNullish(value.right, scopes);
     case "Identifier":
-      return identifierEvidence &&
-        identifierTruthinessEvidence(value.name as string, scopes)
-          .definitelyNonNullish;
+      return identifierTruthinessEvidence(value.name as string, scopes)
+        .definitelyNonNullish;
     default:
       return false;
   }

--- a/scripts/test/test-semantic-audit.ts
+++ b/scripts/test/test-semantic-audit.ts
@@ -3552,8 +3552,8 @@ const OPAQUE_BINDING_WRITE = "\u0000opaque-binding-write";
 
 function isOpaqueBindingWrite(node: Node): boolean {
   if (node.type === "CallExpression") {
-    return isNode(node.callee) && node.callee.type === "Identifier" &&
-      node.callee.name === "eval";
+    const callee = unwrapExpression(node.callee);
+    return callee?.type === "Identifier" && callee.name === "eval";
   }
   const target = node.type === "AssignmentExpression"
     ? node.left

--- a/scripts/test/test-semantic-audit.ts
+++ b/scripts/test/test-semantic-audit.ts
@@ -753,6 +753,7 @@ interface Scope {
   readonly definitelyNonUndefinedNames: Set<string>;
   readonly definitelyTruthyNames: Set<string>;
   readonly definitelyNonNullishNames: Set<string>;
+  readonly assignedNames: Set<string>;
   readonly functionBoundary: boolean;
   readonly playwrightFixtures: Set<string>;
   readonly runtimeBindings: Map<string, RuntimeBinding>;
@@ -3569,9 +3570,19 @@ function collectAssignedIdentifierNames(
     }
   } else if (
     (node.type === "ForOfStatement" || node.type === "ForInStatement") &&
-    isNode(node.left) && node.left.type !== "VariableDeclaration"
+    isNode(node.left)
   ) {
-    collectPatternNames(node.left, names);
+    if (node.left.type !== "VariableDeclaration") {
+      collectPatternNames(node.left, names);
+    } else if (node.left.kind === "var") {
+      for (
+        const declarator of Array.isArray(node.left.declarations)
+          ? node.left.declarations
+          : []
+      ) {
+        if (isNode(declarator)) collectPatternNames(declarator.id, names);
+      }
+    }
   }
   for (const key of Object.keys(node)) {
     if (key === "loc" || COMMENT_KEYS.has(key)) continue;
@@ -3595,8 +3606,11 @@ function createScope(
   const definitelyTruthyNames = new Set<string>();
   const definitelyNonNullishNames = new Set<string>();
   const playwrightFixtures = new Set<string>();
-  const locallyAssignedNames = new Set<string>();
-  collectAssignedIdentifierNames(node, locallyAssignedNames);
+  const locallyAssignedNames = outerScopes[0]?.assignedNames ??
+    new Set<string>();
+  if (!outerScopes[0]) {
+    collectAssignedIdentifierNames(node, locallyAssignedNames);
+  }
   collectLocalDeclaredNames(
     node,
     names,
@@ -3620,6 +3634,7 @@ function createScope(
     definitelyNonUndefinedNames,
     definitelyTruthyNames,
     definitelyNonNullishNames,
+    assignedNames: locallyAssignedNames,
     functionBoundary: isFunctionScopeNode(node),
     playwrightFixtures,
     runtimeBindings: new Map(),
@@ -3899,6 +3914,7 @@ function runtimeReceiverScope(
     definitelyNonUndefinedNames: new Set([THIS_RUNTIME_ROOT]),
     definitelyTruthyNames: new Set(),
     definitelyNonNullishNames: new Set(),
+    assignedNames: new Set(),
     functionBoundary: false,
     playwrightFixtures: new Set(),
     runtimeBindings: new Map([

--- a/scripts/test/test-semantic-audit.ts
+++ b/scripts/test/test-semantic-audit.ts
@@ -4682,6 +4682,8 @@ function bindRuntimeAssignment(
     assignedDefinitelyTruthy,
     assignedDefinitelyTruthy ||
       expressionIsDefinitelyNonNullish(node.right, scopes),
+    (name) =>
+      assignmentTargetScope(name, scopes)?.crossesFunctionBoundary !== true,
   );
   if (
     bindRuntimeMemberAssignment(
@@ -7465,6 +7467,7 @@ function bindDefinitelyNonUndefinedPattern(
   scopeForName: (name: string) => Scope | undefined,
   definitelyTruthy = false,
   definitelyNonNullish = false,
+  canAddPositiveTruthinessFact: (name: string) => boolean = () => true,
 ): void {
   if (pattern.type === "Identifier") {
     const name = pattern.name as string;
@@ -7477,12 +7480,12 @@ function bindDefinitelyNonUndefinedPattern(
     }
     if (!definitelyTruthy) {
       scope.definitelyTruthyNames.delete(name);
-    } else if (unconditional) {
+    } else if (unconditional && canAddPositiveTruthinessFact(name)) {
       scope.definitelyTruthyNames.add(name);
     }
     if (!definitelyNonNullish) {
       scope.definitelyNonNullishNames.delete(name);
-    } else if (unconditional) {
+    } else if (unconditional && canAddPositiveTruthinessFact(name)) {
       scope.definitelyNonNullishNames.add(name);
     }
     return;
@@ -7514,6 +7517,9 @@ function bindDefinitelyNonUndefinedPattern(
       scopes,
       unconditional,
       scopeForName,
+      false,
+      false,
+      canAddPositiveTruthinessFact,
     );
     return;
   }
@@ -7526,6 +7532,9 @@ function bindDefinitelyNonUndefinedPattern(
       scopes,
       unconditional,
       scopeForName,
+      false,
+      false,
+      canAddPositiveTruthinessFact,
     );
     return;
   }
@@ -7545,6 +7554,9 @@ function bindDefinitelyNonUndefinedPattern(
           scopes,
           unconditional,
           scopeForName,
+          false,
+          false,
+          canAddPositiveTruthinessFact,
         );
         continue;
       }
@@ -7562,6 +7574,9 @@ function bindDefinitelyNonUndefinedPattern(
         scopes,
         unconditional,
         scopeForName,
+        false,
+        false,
+        canAddPositiveTruthinessFact,
       );
     }
     return;
@@ -7576,6 +7591,9 @@ function bindDefinitelyNonUndefinedPattern(
       scopes,
       unconditional,
       scopeForName,
+      false,
+      false,
+      canAddPositiveTruthinessFact,
     );
   }
 }

--- a/scripts/test/test-semantic-audit.ts
+++ b/scripts/test/test-semantic-audit.ts
@@ -887,7 +887,6 @@ export function collectSemanticMarkers(
       nextScopes,
       allowAssignmentClearing,
     );
-    clearTruthinessForUnmodeledMutation(node, nextScopes);
     bindRuntimeDeleteMutation(
       node,
       bindings,
@@ -3545,6 +3544,36 @@ function canonicalCompatSource(source: string): string {
   return normalized;
 }
 
+// Names any syntactic write in the subtree can rebind. Truthiness facts are
+// granted only to bindings with no such writer, which keeps them valid
+// regardless of traversal order (hoisted calls, deferred function bodies,
+// skipped branches, and abrupt completions cannot invalidate them later).
+function collectAssignedIdentifierNames(
+  node: unknown,
+  names: Set<string>,
+): void {
+  if (!isNode(node)) return;
+  if (node.type === "AssignmentExpression") {
+    collectPatternNames(node.left, names);
+  } else if (node.type === "UpdateExpression") {
+    collectPatternNames(node.argument, names);
+  } else if (
+    (node.type === "ForOfStatement" || node.type === "ForInStatement") &&
+    isNode(node.left) && node.left.type !== "VariableDeclaration"
+  ) {
+    collectPatternNames(node.left, names);
+  }
+  for (const key of Object.keys(node)) {
+    if (key === "loc" || COMMENT_KEYS.has(key)) continue;
+    const value = node[key];
+    if (Array.isArray(value)) {
+      for (const item of value) collectAssignedIdentifierNames(item, names);
+    } else {
+      collectAssignedIdentifierNames(value, names);
+    }
+  }
+}
+
 function createScope(
   node: Node,
   imports: ImportBindings,
@@ -3556,6 +3585,8 @@ function createScope(
   const definitelyTruthyNames = new Set<string>();
   const definitelyNonNullishNames = new Set<string>();
   const playwrightFixtures = new Set<string>();
+  const locallyAssignedNames = new Set<string>();
+  collectAssignedIdentifierNames(node, locallyAssignedNames);
   collectLocalDeclaredNames(
     node,
     names,
@@ -3563,6 +3594,7 @@ function createScope(
     definitelyNonUndefinedNames,
     definitelyTruthyNames,
     definitelyNonNullishNames,
+    locallyAssignedNames,
     playwrightFixtures,
   );
   if (hasOwnThisRuntimeBinding(node)) {
@@ -3602,7 +3634,12 @@ function createScope(
         emptyRuntimeNamespaceBinding(),
     );
   }
-  collectLocalRuntimeBindings(node, imports, [...outerScopes, scope]);
+  collectLocalRuntimeBindings(
+    node,
+    imports,
+    [...outerScopes, scope],
+    locallyAssignedNames,
+  );
   if (isVarHoistScope(node)) {
     collectHoistedVarRuntimeBindings(
       node,
@@ -3633,6 +3670,7 @@ function collectLocalDeclaredNames(
   definitelyNonUndefinedNames: Set<string>,
   definitelyTruthyNames: Set<string>,
   definitelyNonNullishNames: Set<string>,
+  assignedNames: Set<string>,
   playwrightFixtures: Set<string>,
 ): void {
   const statements = lexicalScopeStatements(node);
@@ -3647,8 +3685,12 @@ function collectLocalDeclaredNames(
         const name = statement.id.name as string;
         names.add(name);
         definitelyNonUndefinedNames.add(name);
-        definitelyTruthyNames.add(name);
-        definitelyNonNullishNames.add(name);
+        // `declare` bindings are erased at runtime; reassigned names lose
+        // their declaration-form truthiness.
+        if (statement.declare !== true && !assignedNames.has(name)) {
+          definitelyTruthyNames.add(name);
+          definitelyNonNullishNames.add(name);
+        }
         if (statement.type === "FunctionDeclaration") {
           definitelyInitializedNames.add(name);
         }
@@ -3692,8 +3734,10 @@ function collectLocalDeclaredNames(
       names.add(name);
       definitelyInitializedNames.add(name);
       definitelyNonUndefinedNames.add(name);
-      definitelyTruthyNames.add(name);
-      definitelyNonNullishNames.add(name);
+      if (!assignedNames.has(name)) {
+        definitelyTruthyNames.add(name);
+        definitelyNonNullishNames.add(name);
+      }
     }
     for (const param of Array.isArray(node.params) ? node.params : []) {
       collectPatternNames(param, names);
@@ -3709,8 +3753,10 @@ function collectLocalDeclaredNames(
     names.add(name);
     definitelyInitializedNames.add(name);
     definitelyNonUndefinedNames.add(name);
-    definitelyTruthyNames.add(name);
-    definitelyNonNullishNames.add(name);
+    if (node.declare !== true && !assignedNames.has(name)) {
+      definitelyTruthyNames.add(name);
+      definitelyNonNullishNames.add(name);
+    }
     return;
   }
   if (
@@ -3740,6 +3786,7 @@ function collectLocalRuntimeBindings(
   node: Node,
   imports: ImportBindings,
   scopes: readonly Scope[],
+  assignedNames: Set<string>,
 ): void {
   const statements = lexicalScopeStatements(node);
   if (!statements) return;
@@ -3767,6 +3814,22 @@ function collectLocalRuntimeBindings(
         : []
     ) {
       if (!isNode(declarator)) continue;
+      // Truthiness evidence comes only from immutable declaration forms:
+      // a never-reassigned const whose initializer carries the proof.
+      if (
+        declaration.kind === "const" && isNode(declarator.id) &&
+        declarator.id.type === "Identifier" &&
+        !assignedNames.has(declarator.id.name as string)
+      ) {
+        const name = declarator.id.name as string;
+        const truthy = expressionIsDefinitelyTruthy(declarator.init, scopes);
+        if (truthy) scope.definitelyTruthyNames.add(name);
+        if (
+          truthy || expressionIsDefinitelyNonNullish(declarator.init, scopes)
+        ) {
+          scope.definitelyNonNullishNames.add(name);
+        }
+      }
       bindRuntimeDeclaration(declarator, imports, scopes, scope);
     }
   }
@@ -4144,7 +4207,6 @@ function visitRuntimeBindingSummary(
   }
   bindRuntimeClassDeclaration(node, nextScopes);
   bindRuntimeAssignment(node, imports, nextScopes, allowClearing);
-  clearTruthinessForUnmodeledMutation(node, nextScopes);
   bindRuntimeDeleteMutation(node, imports, nextScopes, allowClearing);
   for (const key of Object.keys(node)) {
     if (
@@ -4667,10 +4729,6 @@ function bindRuntimeAssignment(
     canClearPrevious,
     (name) => declaringScopeForName(name, scopes),
   );
-  const assignedDefinitelyTruthy = expressionIsDefinitelyTruthy(
-    node.right,
-    scopes,
-  );
   bindDefinitelyNonUndefinedPattern(
     node.left,
     binding,
@@ -4679,11 +4737,6 @@ function bindRuntimeAssignment(
     scopes,
     canClearPrevious,
     (name) => declaringScopeForName(name, scopes),
-    assignedDefinitelyTruthy,
-    assignedDefinitelyTruthy ||
-      expressionIsDefinitelyNonNullish(node.right, scopes),
-    (name) =>
-      assignmentTargetScope(name, scopes)?.crossesFunctionBoundary !== true,
   );
   if (
     bindRuntimeMemberAssignment(
@@ -7425,38 +7478,6 @@ function assignmentTargetScope(
   return undefined;
 }
 
-// Writes that bindRuntimeAssignment does not model (update expressions,
-// arithmetic compound assignments, bare loop targets) can make a previously
-// truthy binding falsy, so they must drop both truthiness facts.
-function clearTruthinessForUnmodeledMutation(
-  node: Node,
-  scopes: readonly Scope[],
-): void {
-  let target: Node | undefined;
-  if (
-    node.type === "AssignmentExpression" && isNode(node.left) &&
-    !["=", "&&=", "||=", "??="].includes(String(node.operator))
-  ) {
-    target = node.left;
-  } else if (node.type === "UpdateExpression" && isNode(node.argument)) {
-    target = node.argument;
-  } else if (
-    (node.type === "ForOfStatement" || node.type === "ForInStatement") &&
-    isNode(node.left) && node.left.type !== "VariableDeclaration"
-  ) {
-    target = node.left;
-  }
-  if (!target) return;
-  const names = new Set<string>();
-  collectPatternNames(target, names);
-  for (const name of names) {
-    const scope = declaringScopeForName(name, scopes);
-    if (!scope) continue;
-    scope.definitelyTruthyNames.delete(name);
-    scope.definitelyNonNullishNames.delete(name);
-  }
-}
-
 function bindDefinitelyNonUndefinedPattern(
   pattern: Node,
   binding: RuntimeBinding | undefined,
@@ -7465,9 +7486,6 @@ function bindDefinitelyNonUndefinedPattern(
   scopes: readonly Scope[],
   unconditional: boolean,
   scopeForName: (name: string) => Scope | undefined,
-  definitelyTruthy = false,
-  definitelyNonNullish = false,
-  canAddPositiveTruthinessFact: (name: string) => boolean = () => true,
 ): void {
   if (pattern.type === "Identifier") {
     const name = pattern.name as string;
@@ -7477,16 +7495,6 @@ function bindDefinitelyNonUndefinedPattern(
       scope.definitelyNonUndefinedNames.delete(name);
     } else if (unconditional) {
       scope.definitelyNonUndefinedNames.add(name);
-    }
-    if (!definitelyTruthy) {
-      scope.definitelyTruthyNames.delete(name);
-    } else if (unconditional && canAddPositiveTruthinessFact(name)) {
-      scope.definitelyTruthyNames.add(name);
-    }
-    if (!definitelyNonNullish) {
-      scope.definitelyNonNullishNames.delete(name);
-    } else if (unconditional && canAddPositiveTruthinessFact(name)) {
-      scope.definitelyNonNullishNames.add(name);
     }
     return;
   }
@@ -7517,9 +7525,6 @@ function bindDefinitelyNonUndefinedPattern(
       scopes,
       unconditional,
       scopeForName,
-      false,
-      false,
-      canAddPositiveTruthinessFact,
     );
     return;
   }
@@ -7532,9 +7537,6 @@ function bindDefinitelyNonUndefinedPattern(
       scopes,
       unconditional,
       scopeForName,
-      false,
-      false,
-      canAddPositiveTruthinessFact,
     );
     return;
   }
@@ -7554,9 +7556,6 @@ function bindDefinitelyNonUndefinedPattern(
           scopes,
           unconditional,
           scopeForName,
-          false,
-          false,
-          canAddPositiveTruthinessFact,
         );
         continue;
       }
@@ -7574,9 +7573,6 @@ function bindDefinitelyNonUndefinedPattern(
         scopes,
         unconditional,
         scopeForName,
-        false,
-        false,
-        canAddPositiveTruthinessFact,
       );
     }
     return;
@@ -7591,9 +7587,6 @@ function bindDefinitelyNonUndefinedPattern(
       scopes,
       unconditional,
       scopeForName,
-      false,
-      false,
-      canAddPositiveTruthinessFact,
     );
   }
 }
@@ -8265,10 +8258,6 @@ function bindRuntimeDeclaration(
     imports,
     scopes,
   );
-  const initDefinitelyTruthy = expressionIsDefinitelyTruthy(
-    declaration.init,
-    scopes,
-  );
   bindDefinitelyNonUndefinedPattern(
     declaration.id,
     binding,
@@ -8277,9 +8266,6 @@ function bindRuntimeDeclaration(
     scopes,
     !merge,
     (name) => scope.names.has(name) ? scope : undefined,
-    initDefinitelyTruthy,
-    initDefinitelyTruthy ||
-      expressionIsDefinitelyNonNullish(declaration.init, scopes),
   );
   bindRuntimeAlias(
     declaration.id,

--- a/scripts/test/test-semantic-audit.ts
+++ b/scripts/test/test-semantic-audit.ts
@@ -9014,7 +9014,7 @@ function expressionIsDefinitelyTruthy(
   scopes: readonly Scope[],
   identifierEvidenceUsable?: boolean,
 ): boolean {
-  const value = unwrapExpression(expression);
+  const value = unwrapTruthinessProofExpression(expression);
   if (!value) return false;
   const identifierEvidence = identifierEvidenceUsable ??
     !expressionSubtreeContainsWrite(value);
@@ -9088,7 +9088,7 @@ function expressionIsDefinitelyNonNullish(
   scopes: readonly Scope[],
   identifierEvidenceUsable?: boolean,
 ): boolean {
-  const value = unwrapExpression(expression);
+  const value = unwrapTruthinessProofExpression(expression);
   if (!value) return false;
   const identifierEvidence = identifierEvidenceUsable ??
     !expressionSubtreeContainsWrite(value);
@@ -10747,6 +10747,25 @@ function unwrapExpression(value: unknown): Node | undefined {
     current &&
     (current.type === "AwaitExpression" || current.type === "TSAsExpression" ||
       current.type === "TSTypeAssertion" ||
+      current.type === "TSSatisfiesExpression" ||
+      current.type === "TSInstantiationExpression" ||
+      current.type === "TSNonNullExpression" ||
+      current.type === "ParenthesizedExpression")
+  ) {
+    current = isNode(current.argument)
+      ? current.argument
+      : isNode(current.expression)
+      ? current.expression
+      : undefined;
+  }
+  return current;
+}
+
+function unwrapTruthinessProofExpression(value: unknown): Node | undefined {
+  let current = isNode(value) ? value : undefined;
+  while (
+    current &&
+    (current.type === "TSAsExpression" || current.type === "TSTypeAssertion" ||
       current.type === "TSSatisfiesExpression" ||
       current.type === "TSInstantiationExpression" ||
       current.type === "TSNonNullExpression" ||

--- a/scripts/test/test-semantic-audit.ts
+++ b/scripts/test/test-semantic-audit.ts
@@ -3545,6 +3545,26 @@ function canonicalCompatSource(source: string): string {
   return normalized;
 }
 
+// Direct `eval` can rebind any binding visible to it, and a write through a
+// mapped `arguments` rebinds the matching parameter. Neither names its target
+// syntactically, so both retract every mutable declaration fact in the file.
+const OPAQUE_BINDING_WRITE = "\u0000opaque-binding-write";
+
+function isOpaqueBindingWrite(node: Node): boolean {
+  if (node.type === "CallExpression") {
+    return isNode(node.callee) && node.callee.type === "Identifier" &&
+      node.callee.name === "eval";
+  }
+  const target = node.type === "AssignmentExpression"
+    ? node.left
+    : node.type === "UpdateExpression"
+    ? node.argument
+    : undefined;
+  return isNode(target) && target.type === "MemberExpression" &&
+    isNode(target.object) && target.object.type === "Identifier" &&
+    target.object.name === "arguments";
+}
+
 // Names any syntactic write in the subtree can rebind. Truthiness facts are
 // granted only to bindings with no such writer, which keeps them valid
 // regardless of traversal order (hoisted calls, deferred function bodies,
@@ -3554,6 +3574,7 @@ function collectAssignedIdentifierNames(
   names: Set<string>,
 ): void {
   if (!isNode(node)) return;
+  if (isOpaqueBindingWrite(node)) names.add(OPAQUE_BINDING_WRITE);
   if (node.type === "AssignmentExpression") {
     collectPatternNames(node.left, names);
   } else if (node.type === "UpdateExpression") {
@@ -3712,7 +3733,10 @@ function collectLocalDeclaredNames(
         definitelyNonUndefinedNames.add(name);
         // `declare` bindings are erased at runtime; reassigned names lose
         // their declaration-form truthiness.
-        if (statement.declare !== true && !assignedNames.has(name)) {
+        if (
+          statement.declare !== true && !assignedNames.has(name) &&
+          !assignedNames.has(OPAQUE_BINDING_WRITE)
+        ) {
           definitelyTruthyNames.add(name);
           definitelyNonNullishNames.add(name);
         }
@@ -9019,11 +9043,11 @@ function expressionIsDefinitelyTruthy(
   if (!value) return false;
   switch (value.type) {
     // JSX is absent: a custom jsxFactory may legally return null or false.
+    // `new` is absent: a constructor may return the falsy host `document.all`.
     case "ArrayExpression":
     case "ArrowFunctionExpression":
     case "ClassExpression":
     case "FunctionExpression":
-    case "NewExpression":
     case "ObjectExpression":
     case "RegExpLiteral":
       return true;
@@ -10718,8 +10742,10 @@ function unwrapTruthinessProofExpression(value: unknown): Node | undefined {
   return current;
 }
 
-function collectPatternNames(value: unknown, names: Set<string>): void {
-  if (!isNode(value)) return;
+function collectPatternNames(target: unknown, names: Set<string>): void {
+  // `(X as any) = null` and `X! = null` keep X as the runtime write target.
+  const value = unwrapTruthinessProofExpression(target);
+  if (!value) return;
   if (value.type === "TSParameterProperty") {
     collectPatternNames(value.parameter, names);
     return;

--- a/scripts/test/test-semantic-audit.ts
+++ b/scripts/test/test-semantic-audit.ts
@@ -751,6 +751,8 @@ interface Scope {
   readonly names: Set<string>;
   readonly definitelyInitializedNames: Set<string>;
   readonly definitelyNonUndefinedNames: Set<string>;
+  readonly definitelyTruthyNames: Set<string>;
+  readonly definitelyNonNullishNames: Set<string>;
   readonly functionBoundary: boolean;
   readonly playwrightFixtures: Set<string>;
   readonly runtimeBindings: Map<string, RuntimeBinding>;
@@ -3550,12 +3552,16 @@ function createScope(
   const names = new Set<string>();
   const definitelyInitializedNames = new Set<string>();
   const definitelyNonUndefinedNames = new Set<string>();
+  const definitelyTruthyNames = new Set<string>();
+  const definitelyNonNullishNames = new Set<string>();
   const playwrightFixtures = new Set<string>();
   collectLocalDeclaredNames(
     node,
     names,
     definitelyInitializedNames,
     definitelyNonUndefinedNames,
+    definitelyTruthyNames,
+    definitelyNonNullishNames,
     playwrightFixtures,
   );
   if (hasOwnThisRuntimeBinding(node)) {
@@ -3569,6 +3575,8 @@ function createScope(
     names,
     definitelyInitializedNames,
     definitelyNonUndefinedNames,
+    definitelyTruthyNames,
+    definitelyNonNullishNames,
     functionBoundary: isFunctionScopeNode(node),
     playwrightFixtures,
     runtimeBindings: new Map(),
@@ -3622,6 +3630,8 @@ function collectLocalDeclaredNames(
   names: Set<string>,
   definitelyInitializedNames: Set<string>,
   definitelyNonUndefinedNames: Set<string>,
+  definitelyTruthyNames: Set<string>,
+  definitelyNonNullishNames: Set<string>,
   playwrightFixtures: Set<string>,
 ): void {
   const statements = lexicalScopeStatements(node);
@@ -3636,6 +3646,8 @@ function collectLocalDeclaredNames(
         const name = statement.id.name as string;
         names.add(name);
         definitelyNonUndefinedNames.add(name);
+        definitelyTruthyNames.add(name);
+        definitelyNonNullishNames.add(name);
         if (statement.type === "FunctionDeclaration") {
           definitelyInitializedNames.add(name);
         }
@@ -3679,6 +3691,8 @@ function collectLocalDeclaredNames(
       names.add(name);
       definitelyInitializedNames.add(name);
       definitelyNonUndefinedNames.add(name);
+      definitelyTruthyNames.add(name);
+      definitelyNonNullishNames.add(name);
     }
     for (const param of Array.isArray(node.params) ? node.params : []) {
       collectPatternNames(param, names);
@@ -3694,6 +3708,8 @@ function collectLocalDeclaredNames(
     names.add(name);
     definitelyInitializedNames.add(name);
     definitelyNonUndefinedNames.add(name);
+    definitelyTruthyNames.add(name);
+    definitelyNonNullishNames.add(name);
     return;
   }
   if (
@@ -3807,6 +3823,8 @@ function runtimeReceiverScope(
     names: new Set([THIS_RUNTIME_ROOT]),
     definitelyInitializedNames: new Set([THIS_RUNTIME_ROOT]),
     definitelyNonUndefinedNames: new Set([THIS_RUNTIME_ROOT]),
+    definitelyTruthyNames: new Set(),
+    definitelyNonNullishNames: new Set(),
     functionBoundary: false,
     playwrightFixtures: new Set(),
     runtimeBindings: new Map([
@@ -4647,6 +4665,10 @@ function bindRuntimeAssignment(
     canClearPrevious,
     (name) => declaringScopeForName(name, scopes),
   );
+  const assignedDefinitelyTruthy = expressionIsDefinitelyTruthy(
+    node.right,
+    scopes,
+  );
   bindDefinitelyNonUndefinedPattern(
     node.left,
     binding,
@@ -4655,6 +4677,9 @@ function bindRuntimeAssignment(
     scopes,
     canClearPrevious,
     (name) => declaringScopeForName(name, scopes),
+    assignedDefinitelyTruthy,
+    assignedDefinitelyTruthy ||
+      expressionIsDefinitelyNonNullish(node.right, scopes),
   );
   if (
     bindRuntimeMemberAssignment(
@@ -7218,14 +7243,36 @@ function runtimeNamespaceAliasTargetsForExpression(
       ),
     ]);
   } else if (value.type === "LogicalExpression") {
-    targets = uniqueRuntimeAliasTargets([
-      ...runtimeNamespaceAliasTargetsForExpression(value.left, imports, scopes),
-      ...runtimeNamespaceAliasTargetsForExpression(
-        value.right,
-        imports,
-        scopes,
-      ),
-    ]);
+    const leftTargets = runtimeNamespaceAliasTargetsForExpression(
+      value.left,
+      imports,
+      scopes,
+    );
+    const rightTargets = runtimeNamespaceAliasTargetsForExpression(
+      value.right,
+      imports,
+      scopes,
+    );
+    // Prune an operand only with operator-specific proof; otherwise fail
+    // closed to the union of both receivers.
+    if (
+      value.operator === "||" &&
+      expressionIsDefinitelyTruthy(value.left, scopes)
+    ) {
+      targets = leftTargets;
+    } else if (
+      value.operator === "&&" &&
+      expressionIsDefinitelyTruthy(value.left, scopes)
+    ) {
+      targets = rightTargets;
+    } else if (
+      value.operator === "??" &&
+      expressionIsDefinitelyNonNullish(value.left, scopes)
+    ) {
+      targets = leftTargets;
+    } else {
+      targets = uniqueRuntimeAliasTargets([...leftTargets, ...rightTargets]);
+    }
   } else if (value.type === "SequenceExpression") {
     const expressions = Array.isArray(value.expressions)
       ? value.expressions
@@ -7382,6 +7429,8 @@ function bindDefinitelyNonUndefinedPattern(
   scopes: readonly Scope[],
   unconditional: boolean,
   scopeForName: (name: string) => Scope | undefined,
+  definitelyTruthy = false,
+  definitelyNonNullish = false,
 ): void {
   if (pattern.type === "Identifier") {
     const name = pattern.name as string;
@@ -7391,6 +7440,16 @@ function bindDefinitelyNonUndefinedPattern(
       scope.definitelyNonUndefinedNames.delete(name);
     } else if (unconditional) {
       scope.definitelyNonUndefinedNames.add(name);
+    }
+    if (!definitelyTruthy) {
+      scope.definitelyTruthyNames.delete(name);
+    } else if (unconditional) {
+      scope.definitelyTruthyNames.add(name);
+    }
+    if (!definitelyNonNullish) {
+      scope.definitelyNonNullishNames.delete(name);
+    } else if (unconditional) {
+      scope.definitelyNonNullishNames.add(name);
     }
     return;
   }
@@ -8149,6 +8208,10 @@ function bindRuntimeDeclaration(
     imports,
     scopes,
   );
+  const initDefinitelyTruthy = expressionIsDefinitelyTruthy(
+    declaration.init,
+    scopes,
+  );
   bindDefinitelyNonUndefinedPattern(
     declaration.id,
     binding,
@@ -8157,6 +8220,9 @@ function bindRuntimeDeclaration(
     scopes,
     !merge,
     (name) => scope.names.has(name) ? scope : undefined,
+    initDefinitelyTruthy,
+    initDefinitelyTruthy ||
+      expressionIsDefinitelyNonNullish(declaration.init, scopes),
   );
   bindRuntimeAlias(
     declaration.id,
@@ -8858,6 +8924,115 @@ function expressionMayBeUndefined(
     value.type === "StringLiteral" ||
     value.type === "TemplateLiteral"
   );
+}
+
+// Intentionally separate from expressionMayBeUndefined: definitely-non-undefined
+// is not truthiness proof (`maybe ? ClassA : null` is non-undefined but nullish).
+function expressionIsDefinitelyTruthy(
+  expression: unknown,
+  scopes: readonly Scope[],
+): boolean {
+  const value = unwrapExpression(expression);
+  if (!value) return false;
+  switch (value.type) {
+    case "ArrayExpression":
+    case "ArrowFunctionExpression":
+    case "ClassExpression":
+    case "FunctionExpression":
+    case "JSXElement":
+    case "JSXFragment":
+    case "NewExpression":
+    case "ObjectExpression":
+    case "RegExpLiteral":
+      return true;
+    case "BooleanLiteral":
+      return value.value === true;
+    case "NumericLiteral":
+      return value.value !== 0;
+    case "StringLiteral":
+      return value.value !== "";
+    case "ConditionalExpression":
+      return expressionIsDefinitelyTruthy(value.consequent, scopes) &&
+        expressionIsDefinitelyTruthy(value.alternate, scopes);
+    case "LogicalExpression": {
+      const left = expressionIsDefinitelyTruthy(value.left, scopes);
+      if (value.operator === "&&") {
+        return left && expressionIsDefinitelyTruthy(value.right, scopes);
+      }
+      if (value.operator === "||") {
+        return left || expressionIsDefinitelyTruthy(value.right, scopes);
+      }
+      return left;
+    }
+    case "SequenceExpression": {
+      const expressions = Array.isArray(value.expressions)
+        ? value.expressions
+        : [];
+      return expressionIsDefinitelyTruthy(expressions.at(-1), scopes);
+    }
+    case "AssignmentExpression":
+      return value.operator === "=" &&
+        expressionIsDefinitelyTruthy(value.right, scopes);
+    case "Identifier":
+      return resolveLocalBinding(value.name as string, scopes)
+        .definitelyTruthy === true;
+    default:
+      return false;
+  }
+}
+
+function expressionIsDefinitelyNonNullish(
+  expression: unknown,
+  scopes: readonly Scope[],
+): boolean {
+  const value = unwrapExpression(expression);
+  if (!value) return false;
+  switch (value.type) {
+    case "ArrayExpression":
+    case "ArrowFunctionExpression":
+    case "BigIntLiteral":
+    case "BooleanLiteral":
+    case "ClassExpression":
+    case "FunctionExpression":
+    case "JSXElement":
+    case "JSXFragment":
+    case "NewExpression":
+    case "NumericLiteral":
+    case "ObjectExpression":
+    case "RegExpLiteral":
+    case "StringLiteral":
+    case "TemplateLiteral":
+      return true;
+    case "ConditionalExpression":
+      return expressionIsDefinitelyNonNullish(value.consequent, scopes) &&
+        expressionIsDefinitelyNonNullish(value.alternate, scopes);
+    case "LogicalExpression": {
+      if (value.operator === "&&") {
+        return expressionIsDefinitelyNonNullish(value.left, scopes) &&
+          expressionIsDefinitelyNonNullish(value.right, scopes);
+      }
+      if (value.operator === "||") {
+        return expressionIsDefinitelyTruthy(value.left, scopes) ||
+          expressionIsDefinitelyNonNullish(value.right, scopes);
+      }
+      return expressionIsDefinitelyNonNullish(value.left, scopes) ||
+        expressionIsDefinitelyNonNullish(value.right, scopes);
+    }
+    case "SequenceExpression": {
+      const expressions = Array.isArray(value.expressions)
+        ? value.expressions
+        : [];
+      return expressionIsDefinitelyNonNullish(expressions.at(-1), scopes);
+    }
+    case "AssignmentExpression":
+      return value.operator === "=" &&
+        expressionIsDefinitelyNonNullish(value.right, scopes);
+    case "Identifier":
+      return resolveLocalBinding(value.name as string, scopes)
+        .definitelyNonNullish === true;
+    default:
+      return false;
+  }
 }
 
 function constructedRuntimeBinding(
@@ -10524,6 +10699,8 @@ function resolveLocalBinding(
   readonly declared: boolean;
   readonly definitelyInitialized?: boolean;
   readonly definitelyNonUndefined?: boolean;
+  readonly definitelyTruthy?: boolean;
+  readonly definitelyNonNullish?: boolean;
   readonly crossesFunctionBoundary?: boolean;
   readonly binding?: RuntimeBinding;
 } {
@@ -10535,6 +10712,8 @@ function resolveLocalBinding(
         declared: true,
         definitelyInitialized: scope.definitelyInitializedNames.has(name),
         definitelyNonUndefined: scope.definitelyNonUndefinedNames.has(name),
+        definitelyTruthy: scope.definitelyTruthyNames.has(name),
+        definitelyNonNullish: scope.definitelyNonNullishNames.has(name),
         crossesFunctionBoundary,
         binding: scope.runtimeBindings.get(name),
       };


### PR DESCRIPTION
## Root cause

PR #4019 made logical receiver selection fail-closed: `runtimeNamespaceAliasTargetsForExpression` unions both operands of every `LogicalExpression`, so an unreachable receiver (e.g. the right side of `ClassA || Fallback` where the left is always a class) still collects runtime provenance and gets flagged for effects it can never carry. The analyzer tracks undefined-reachability (`definitelyNonUndefinedNames`) but has no falsy/nullish lattice, and using not-undefined as truthiness proof was tested and rejected in the issue (`maybe ? ClassA : null` is definitely-non-undefined but nullish).

## Design

Two fail-closed structural predicates in `scripts/test/test-semantic-audit.ts`, mirroring `expressionMayBeUndefined`'s style:

- `expressionIsDefinitelyTruthy`: object/array/class/function/arrow/new/regexp/JSX expressions, `true`, non-zero numbers, non-empty strings; `ConditionalExpression` only when **both** branches carry the proof; nested logicals with operator-specific rules (`a && b` truthy iff both, `a || b` truthy iff either, `a ?? b` truthy iff left); `(x = e)` follows `e`; identifiers only via recorded per-scope evidence. Everything else (members, calls, unknown nodes) → no proof.
- `expressionIsDefinitelyNonNullish`: everything definitely truthy plus `false`, `0`, `""`, bigint and template literals; `null`/`undefined`/`void` are **not** non-nullish; `a && b` iff both non-nullish, `a || b` iff left truthy or right non-nullish, `a ?? b` iff either side non-nullish.

**Identifier evidence** piggybacks the existing lattice exactly: new `definitelyTruthyNames` / `definitelyNonNullishNames` sets on `Scope`, populated and cleared at the same sites as `definitelyNonUndefinedNames` — `collectLocalDeclaredNames` (class/function declarations), `bindRuntimeDeclaration`, and `bindRuntimeAssignment` via two new optional parameters on `bindDefinitelyNonUndefinedPattern` (recursive destructuring paths pass no proof, so destructured names stay fail-closed while reassignment clearing is inherited). Truthy proof always implies non-nullish at the population sites, keeping the sets consistent.

**Pruning** in the `LogicalExpression` branch of `runtimeNamespaceAliasTargetsForExpression`:

- `left || right`: left definitely truthy → left targets only.
- `left && right`: left definitely truthy → right targets only (left is never the result value).
- `left ?? right`: left definitely non-nullish → left targets only.
- Otherwise: the existing union, unchanged.

**Member expressions**: no per-property truthiness evidence — the analyzer's `RuntimeBinding` property maps carry provenance, not abstract values, so extending them would mean a new per-property lattice. Members stay fail-closed; the negative regressions pin this.

**Logical-assignment result path** (`x = (h.R ||= C)`): left untouched. `runtimeAssignmentExpressionResolution` still unions left+right for compound operators — its left operand is a member expression (no proof possible) or an identifier whose assignment wouldn't even execute when the proof holds, and no acceptance criterion needs it. The existing `preserves both branches of logical property assignments` regression stays green byte-for-byte.

## Red → green evidence

Red (tests written first, on unmodified analyzer): the pruning positives failed with exactly the unreachable receivers retained; the fail-closed negatives already passed.

```
  prunes unreachable logical receivers with truthiness proof ... FAILED (2ms)
  retains logical receivers without operator-specific truthiness proof ... ok (2ms)

    [Diff] Actual / Expected
      ["filesystem-write", "OrLeft.write"],
-     ["filesystem-write", "OrRight.write"],
-     ["filesystem-write", "AndLeft.write"],
      ["filesystem-write", "AndRight.write"],
      ["filesystem-write", "NullishLeft.write"],
-     ["filesystem-write", "NullishRight.write"],
      ["filesystem-write", "GateSource.write"],
-     ["filesystem-write", "GateFallback.write"],
      ["filesystem-write", "NestedInner.write"],
-     ["filesystem-write", "NestedFallback.write"],
      ...
```

Green (after implementation, full file via `deno test --config=scripts/test.deno.json ... scripts/test/test-semantic-audit.test.ts`):

```
  prunes unreachable logical receivers with truthiness proof ... ok (1ms)
  retains logical receivers without operator-specific truthiness proof ... ok (1ms)
ok | 4 passed (149 steps) | 0 failed (7s)
```

`deno fmt --check`, `deno lint`, and `deno check` (scripts/test.deno.json config) all pass on both changed files.

## Acceptance criteria

- [x] `||` prunes its right receiver only when the left is proven definitely truthy (`OrLeft || OrRight`, plus `nullGate || Fallback`, `falseGate || Fallback`, `uncertain || Fallback` negatives).
- [x] `&&` prunes its left receiver mutation target only when the left is proven definitely truthy (`AndLeft && AndRight` positive; `andUncertain && AndKeepRight` negative keeps `AndKeepLeft`).
- [x] `??` prunes its right receiver only when the left is proven definitely non-nullish (`NullishLeft ?? NullishRight` positive; `nullGate ?? Fallback` negative; `maybe ? ClassA : false` gate prunes under `??`).
- [x] `maybe ? ClassA : null` retains the right receiver for both `||` and `??`.
- [x] `maybe ? ClassA : false` retains the right receiver for `||`.
- [x] Uncertain identifiers and optional members remain fail-closed (`uncertain ||`, `memberHolder.Receiver ||`, `optionalHolder?.Receiver ||` negatives).
- [x] Positive and negative regressions cover direct members, variables (`const Gate = GateSource; Gate || Fallback`), and nested logical expressions (`(nestedMaybe || NestedInner) || NestedFallback`).
- [x] Ratchets do not grow:
  - Semantic disposition ratchet — before: `2185 unit executable(s) considered; 736 effect-bearing file(s) disposed` / after: identical, exit 0.
  - Layout ratchet — before: `2518 executable tests; 2467 canonical; 51 migration` / after: identical, exit 0.

Refs https://github.com/veryfront/veryfront-issue-inbox/issues/770


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved semantic analysis of `||`, `&&`, and `??` expressions.
  * Unreachable branches are now excluded when truthiness or non-nullish values can be reliably established.
  * Fallback branches are preserved when values may be falsy, nullish, reassigned, mutated, or otherwise uncertain.
  * Analysis now handles conditional, sequence, assignment, literal, and identifier expressions more accurately.
  * Evidence is no longer incorrectly carried across function boundaries or unmodeled control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->