### PR TITLE
fix(workflow): charge recovered composite children durably before they run

### DIFF
--- a/src/workflow/executor/dag/composite-node-execution.ts
+++ b/src/workflow/executor/dag/composite-node-execution.ts
@@ -1,4 +1,4 @@
-import { TIMEOUT_ERROR, VeryfrontError } from "#veryfront/errors";
+import { TIMEOUT_ERROR } from "#veryfront/errors";
 import { ensureError } from "#veryfront/errors/veryfront-error.ts";
 import { sleep } from "#veryfront/utils";
 import {
@@ -19,27 +19,15 @@ import type { NodeExecutionResult } from "./types.ts";
  * An ownership-fenced write was refused: another worker owns the run row, so
  * this execution must stop writing instead of retrying or recording failure.
  */
-function getOwnDataProperty(value: unknown, key: PropertyKey): unknown {
-  if ((typeof value !== "object" && typeof value !== "function") || value === null) {
-    return undefined;
-  }
-  try {
-    const descriptor = Object.getOwnPropertyDescriptor(value, key);
-    return descriptor && "value" in descriptor ? descriptor.value : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 export function isOwnershipLossError(error: unknown): boolean {
-  const isVeryfrontError = error instanceof VeryfrontError ||
-    (error instanceof Error && getOwnDataProperty(error, "name") === "VeryfrontError");
-  if (!isVeryfrontError) return false;
-
-  const context = getOwnDataProperty(error, "context");
-  return getOwnDataProperty(error, "slug") === "orchestration-error" &&
-    getOwnDataProperty(context, "ownershipLost") === true;
+  if (!(error instanceof Error)) return false;
+  const { slug, context } = error as Error & {
+    slug?: unknown;
+    context?: { ownershipLost?: unknown };
+  };
+  return slug === "orchestration-error" && context?.ownershipLost === true;
 }
+
 const DEFAULT_CANCELLATION_GRACE_PERIOD_MS = 1_000;
 
 interface CompositeNodeExecutionInput {

--- a/src/workflow/executor/dag/composite-node-execution.ts
+++ b/src/workflow/executor/dag/composite-node-execution.ts
@@ -5,9 +5,26 @@ import { ensureError } from "#veryfront/errors/veryfront-error.ts";
  * An ownership-fenced write was refused: another worker owns the run row, so
  * this execution must stop writing instead of retrying or recording failure.
  */
+function getOwnDataProperty(value: unknown, key: PropertyKey): unknown {
+  if ((typeof value !== "object" && typeof value !== "function") || value === null) {
+    return undefined;
+  }
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor && "value" in descriptor ? descriptor.value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function isOwnershipLossError(error: unknown): boolean {
-  return error instanceof VeryfrontError && error.slug === "orchestration-error" &&
-    (error.context as Record<string, unknown> | undefined)?.ownershipLost === true;
+  const isVeryfrontError = error instanceof VeryfrontError ||
+    (error instanceof Error && getOwnDataProperty(error, "name") === "VeryfrontError");
+  if (!isVeryfrontError) return false;
+
+  const context = getOwnDataProperty(error, "context");
+  return getOwnDataProperty(error, "slug") === "orchestration-error" &&
+    getOwnDataProperty(context, "ownershipLost") === true;
 }
 import type { RetryConfig, WorkflowNode } from "../../types.ts";
 import { parseDuration, validateRetryConfig } from "../../types.ts";

--- a/src/workflow/executor/dag/composite-node-execution.ts
+++ b/src/workflow/executor/dag/composite-node-execution.ts
@@ -1,5 +1,19 @@
 import { TIMEOUT_ERROR, VeryfrontError } from "#veryfront/errors";
 import { ensureError } from "#veryfront/errors/veryfront-error.ts";
+import { sleep } from "#veryfront/utils";
+import {
+  addActiveSpanEvent,
+  setActiveSpanAttributes,
+} from "#veryfront/observability/tracing/otlp-setup.ts";
+import type { RetryConfig, WorkflowNode } from "../../types.ts";
+import { parseDuration, validateRetryConfig } from "../../types.ts";
+import {
+  calculateRetryDelay,
+  isRetryableWorkflowError,
+  retryTelemetryErrorType,
+} from "../retry-policy.ts";
+import { createSetContextPatch } from "./context-patch.ts";
+import type { NodeExecutionResult } from "./types.ts";
 
 /**
  * An ownership-fenced write was refused: another worker owns the run row, so
@@ -26,21 +40,6 @@ export function isOwnershipLossError(error: unknown): boolean {
   return getOwnDataProperty(error, "slug") === "orchestration-error" &&
     getOwnDataProperty(context, "ownershipLost") === true;
 }
-import type { RetryConfig, WorkflowNode } from "../../types.ts";
-import { parseDuration, validateRetryConfig } from "../../types.ts";
-import type { NodeExecutionResult } from "./types.ts";
-import { sleep } from "#veryfront/utils";
-import { createSetContextPatch } from "./context-patch.ts";
-import {
-  calculateRetryDelay,
-  isRetryableWorkflowError,
-  retryTelemetryErrorType,
-} from "../retry-policy.ts";
-import {
-  addActiveSpanEvent,
-  setActiveSpanAttributes,
-} from "#veryfront/observability/tracing/otlp-setup.ts";
-
 const DEFAULT_CANCELLATION_GRACE_PERIOD_MS = 1_000;
 
 interface CompositeNodeExecutionInput {

--- a/src/workflow/executor/dag/composite-node-execution.ts
+++ b/src/workflow/executor/dag/composite-node-execution.ts
@@ -1,5 +1,14 @@
-import { TIMEOUT_ERROR } from "#veryfront/errors";
+import { TIMEOUT_ERROR, VeryfrontError } from "#veryfront/errors";
 import { ensureError } from "#veryfront/errors/veryfront-error.ts";
+
+/**
+ * An ownership-fenced write was refused: another worker owns the run row, so
+ * this execution must stop writing instead of retrying or recording failure.
+ */
+export function isOwnershipLossError(error: unknown): boolean {
+  return error instanceof VeryfrontError && error.slug === "orchestration-error" &&
+    (error.context as Record<string, unknown> | undefined)?.ownershipLost === true;
+}
 import type { RetryConfig, WorkflowNode } from "../../types.ts";
 import { parseDuration, validateRetryConfig } from "../../types.ts";
 import type { NodeExecutionResult } from "./types.ts";
@@ -87,6 +96,9 @@ export async function executeCompositeNodeWithPolicy(
       await sleep(delay, parentSignal);
     } catch (caught) {
       parentSignal?.throwIfAborted();
+      // Ownership loss is not a composite failure: this worker must stop,
+      // not retry children it no longer owns or record a failed state.
+      if (isOwnershipLossError(caught)) throw caught;
       const error = ensureError(caught);
 
       if (attempt < maxAttempts && isRetryableError(error, retry)) {

--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -2590,6 +2590,34 @@ describe("DAGExecutor", () => {
       );
     });
 
+    it("stops when a composite child throws an ownership-loss error from another module copy", async () => {
+      const { VeryfrontError: DuplicateVeryfrontError } = await import(
+        "../../../errors/types.ts?ownership-loss-regression"
+      );
+      const ownershipLost = new DuplicateVeryfrontError("ownership changed", {
+        slug: "orchestration-error",
+        category: "AGENT",
+        status: 500,
+        title: "Multi-agent orchestration error",
+        context: { ownershipLost: true },
+      });
+      const exec = new DAGExecutor({
+        stepExecutor: new MockStepExecutor(new Map(), (node) => {
+          if (node.id === "outer/inner") throw ownershipLost;
+          return { success: true, output: node.id, executionTime: 1 };
+        }),
+      });
+      const nodes = [parallel("outer", [step("inner", { tool: "noop" })])];
+
+      const error = await assertRejects(
+        () => exec.execute(nodes, createTestRun()),
+        Error,
+        "ownership changed",
+      );
+
+      assertEquals(error, ownershipLost);
+    });
+
     it("does not merge-write recovery for loop iteration children", async () => {
       // A loop iteration's children live in the loop node's private iteration
       // snapshot, not the root node-state map. Merge-writing their keys into

--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -2446,6 +2446,123 @@ describe("DAGExecutor", () => {
       );
     });
 
+    it("charges a recovered composite child durably before it executes", async () => {
+      // A recovered child of a parallel composite runs against a synthetic run
+      // that persists nothing, so its raised attempt reached the backend only
+      // after the child side effect had already run -- repeated worker deaths
+      // re-ran the child past its retry budget (veryfront-issue-inbox#754).
+      const order: string[] = [];
+      const exec = new DAGExecutor({
+        stepExecutor: new MockStepExecutor(new Map(), (node) => {
+          order.push(`exec:${node.id}`);
+          return { success: true, output: node.id, executionTime: 1 };
+        }),
+        onChildRecoveryAdmitted: ({ runId, nodeStatePatch }) => {
+          const keys = Object.keys(nodeStatePatch.set).sort();
+          const attempt = nodeStatePatch.set["outer/inner"]?.attempt;
+          order.push(`admit:${keys.join(",")}@${attempt}:${runId}`);
+        },
+      });
+      const nodes = [
+        parallel("outer", [step("inner", { tool: "noop" })]),
+      ];
+      const run = createTestRun({
+        nodeStates: {
+          outer: { nodeId: "outer", status: "running", attempt: 1, startedAt: new Date() },
+          "outer/inner": {
+            nodeId: "outer/inner",
+            status: "running",
+            attempt: 1,
+            startedAt: new Date(),
+          },
+        },
+      });
+
+      const result = await exec.execute(nodes, run);
+
+      assertEquals(result.completed, true);
+      // The merge patch carries only the recovered child, charged to the root
+      // run id, and lands before the child executes.
+      assertEquals(order, ["admit:outer/inner@2:test-run", "exec:outer/inner"]);
+    });
+
+    it("does not execute a recovered child the merge fence refused", async () => {
+      const executed: string[] = [];
+      const exec = new DAGExecutor({
+        stepExecutor: new MockStepExecutor(new Map(), (node) => {
+          executed.push(node.id);
+          return { success: true, output: node.id, executionTime: 1 };
+        }),
+        onChildRecoveryAdmitted: () => false,
+      });
+      const nodes = [
+        parallel("outer", [step("inner", { tool: "noop" })]),
+      ];
+      const run = createTestRun({
+        nodeStates: {
+          outer: { nodeId: "outer", status: "running", attempt: 1, startedAt: new Date() },
+          "outer/inner": {
+            nodeId: "outer/inner",
+            status: "running",
+            attempt: 1,
+            startedAt: new Date(),
+          },
+        },
+      });
+
+      await assertRejects(() => exec.execute(nodes, run), Error, "ownership changed");
+      assertEquals(executed, []);
+    });
+
+    it("does not merge-write recovery for loop iteration children", async () => {
+      // A loop iteration's children live in the loop node's private iteration
+      // snapshot, not the root node-state map. Merge-writing their keys into
+      // the root map would strand stale entries no later publish deletes.
+      const admitted: string[] = [];
+      const exec = new DAGExecutor({
+        stepExecutor: new MockStepExecutor(new Map(), (node) => ({
+          success: true,
+          output: node.id,
+          executionTime: 1,
+        })),
+        onChildRecoveryAdmitted: ({ nodeStatePatch }) => {
+          admitted.push(...Object.keys(nodeStatePatch.set));
+        },
+      });
+      const nodes = [
+        loop("the-loop", {
+          maxIterations: 1,
+          while: (_context, iteration) => iteration.iteration < 1,
+          steps: [step("inner", { tool: "noop" })],
+        }),
+      ];
+      const run = createTestRun({
+        nodeStates: {
+          "the-loop": { nodeId: "the-loop", status: "running", attempt: 1, startedAt: new Date() },
+        },
+        context: {
+          input: { topic: "test" },
+          "the-loop_loop_state": {
+            iteration: 0,
+            previousResults: [],
+            iterationNodeStates: {
+              inner: {
+                nodeId: "inner",
+                status: "running",
+                attempt: 1,
+                startedAt: new Date().toISOString(),
+              },
+            },
+          },
+        },
+      });
+
+      const result = await exec.execute(nodes, run);
+
+      assertEquals(result.completed, true);
+      assertEquals(admitted, []);
+    });
+
     it("never re-runs a node whose retry budget was already spent", async () => {
       const executed: string[] = [];
       const exec = new DAGExecutor({

--- a/src/workflow/executor/dag/index.test.ts
+++ b/src/workflow/executor/dag/index.test.ts
@@ -2514,6 +2514,82 @@ describe("DAGExecutor", () => {
       assertEquals(executed, []);
     });
 
+    it("charges a recovered map child durably before it executes", async () => {
+      // Map children live in the root node-state map like parallel children
+      // (the strategy passes the parent map through and merges back), so a
+      // recovered map child must be durably charged at admission too.
+      const order: string[] = [];
+      const exec = new DAGExecutor({
+        stepExecutor: new MockStepExecutor(new Map(), (node) => {
+          order.push(`exec:${node.id}`);
+          return { success: true, output: node.id, executionTime: 1 };
+        }),
+        onChildRecoveryAdmitted: ({ nodeStatePatch }) => {
+          order.push(`admit:${Object.keys(nodeStatePatch.set).sort().join(",")}`);
+        },
+      });
+      const nodes = [
+        map("mapper", {
+          items: [{ id: 1 }],
+          processor: step("inner", { tool: "noop" }),
+        }),
+      ];
+      const run = createTestRun({
+        nodeStates: {
+          mapper: { nodeId: "mapper", status: "running", attempt: 1, startedAt: new Date() },
+          mapper_0: { nodeId: "mapper_0", status: "running", attempt: 1, startedAt: new Date() },
+        },
+      });
+
+      const result = await exec.execute(nodes, run);
+
+      assertEquals(result.completed, true);
+      assertEquals(order, ["admit:mapper_0", "exec:mapper_0"]);
+    });
+
+    it("stops instead of failing the composite when a child checkpoint is fenced out", async () => {
+      // A fenced-out checkpoint append means another worker owns the run row.
+      // Inside a composite that must abort the execution, not fall through to
+      // composite retry or record a failed state the new owner would read.
+      const executedNodes: string[] = [];
+      const backend = {
+        saveCheckpoint: () => Promise.resolve(),
+        getLatestCheckpoint: () => Promise.resolve(null),
+      } as unknown as WorkflowBackend;
+      const fencedOut = new (class extends CheckpointManager {
+        override save(): Promise<boolean> {
+          return Promise.resolve(false);
+        }
+      })({ backend });
+      const exec = new DAGExecutor({
+        stepExecutor: new MockStepExecutor(new Map(), (node) => {
+          executedNodes.push(node.id);
+          return { success: true, output: node.id, executionTime: 1 };
+        }),
+        checkpointManager: fencedOut,
+      });
+      const inner = step("inner", { tool: "noop" });
+      (inner.config as { checkpoint?: boolean }).checkpoint = true;
+      const nodes = [parallel("outer", [inner])];
+      const run = createTestRun();
+
+      const error = await assertRejects(
+        () =>
+          exec.execute(nodes, run, undefined, undefined, {
+            runId: "test-run",
+            workerId: "run-execution:worker-a",
+          }),
+        Error,
+        "ownership changed",
+      );
+
+      assertEquals(executedNodes, ["outer/inner"]);
+      assertEquals(
+        (error as { context?: { ownershipLost?: boolean } }).context?.ownershipLost,
+        true,
+      );
+    });
+
     it("does not merge-write recovery for loop iteration children", async () => {
       // A loop iteration's children live in the loop node's private iteration
       // snapshot, not the root node-state map. Merge-writing their keys into

--- a/src/workflow/executor/dag/index.ts
+++ b/src/workflow/executor/dag/index.ts
@@ -50,7 +50,10 @@ import {
 } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { executeMapNodeStrategy } from "./map-node-strategy.ts";
 import type { ChildGraphExecutionOptions } from "./node-strategy-types.ts";
-import { executeCompositeNodeWithPolicy } from "./composite-node-execution.ts";
+import {
+  executeCompositeNodeWithPolicy,
+  isOwnershipLossError,
+} from "./composite-node-execution.ts";
 import {
   applyContextPatch,
   applyRecordPatch,
@@ -100,6 +103,7 @@ export class DAGExecutor {
       // whose status is always "running" and would otherwise read a crash.
       resumingWait: run.status === "waiting",
       declaredNodeIds: new Set(),
+      rootKeyspace: true,
       ownership,
     };
     const { contextPatch: _contextPatch, ...result } = await runWithWorkflowSourceIntegrationPolicy(
@@ -258,6 +262,7 @@ export class DAGExecutor {
       ready = ready.slice(this.config.maxConcurrency);
 
       const batchStartedAt = new Date();
+      const recoveredInBatch: string[] = [];
       for (const nodeId of batch) {
         const existing = nodeStates[nodeId];
         // A node already recorded running keeps its attempt: it is being
@@ -267,6 +272,7 @@ export class DAGExecutor {
         // what bounds repeated worker deaths. A node only reaches here once it
         // is actually starting, so the recovery it spends is one it gets to use.
         const isRecovery = recoveryQueued.delete(nodeId);
+        if (isRecovery) recoveredInBatch.push(nodeId);
         const runningState: NodeState = {
           ...existing,
           nodeId,
@@ -294,6 +300,27 @@ export class DAGExecutor {
           contextPatch,
           batch,
         );
+        abortSignal?.throwIfAborted();
+      } else if (scope.rootKeyspace && recoveredInBatch.length > 0) {
+        // A recovered child of a shared-keyspace composite: its raised attempt
+        // must be durable before it executes, or repeated worker deaths re-run
+        // it past its budget. The patch carries only the admitted recoveries,
+        // merged by key into the root map -- never replacing it.
+        const patchSet: Record<string, NodeState> = {};
+        for (const nodeId of recoveredInBatch) {
+          patchSet[nodeId] = structuredClone(nodeStates[nodeId]!);
+        }
+        const persisted = await this.config.onChildRecoveryAdmitted?.({
+          runId: scope.rootRunId,
+          nodeStatePatch: { set: patchSet, delete: [] },
+          ownership: scope.ownership,
+        });
+        if (persisted === false) {
+          throw ORCHESTRATION_ERROR.create({
+            detail: "Workflow execution ownership changed before child recovery persistence",
+            context: { ownershipLost: true },
+          });
+        }
         abortSignal?.throwIfAborted();
       }
 
@@ -351,6 +378,10 @@ export class DAGExecutor {
         const result = results[i]!;
 
         if (result.status !== "fulfilled") {
+          // Ownership loss inside a composite is not a node failure: this
+          // worker no longer owns the run row and must stop writing, not
+          // record a failed state another worker's recovery would then read.
+          if (isOwnershipLossError(result.reason)) throw result.reason;
           const error = result.reason instanceof Error
             ? result.reason.message
             : String(result.reason);
@@ -677,7 +708,13 @@ export class DAGExecutor {
               parentNodeIds: scope.declaredNodeIds,
               runtime: {
                 executeChildGraph: (nodes, run, options) =>
-                  this.executeChildGraph(nodes, run, scope, options, attemptSignal),
+                  this.executeChildGraph(
+                    nodes,
+                    run,
+                    { ...scope, rootKeyspace: false },
+                    options,
+                    attemptSignal,
+                  ),
                 onNodeComplete: this.config.onNodeComplete,
                 abortSignal: attemptSignal,
               },
@@ -735,7 +772,13 @@ export class DAGExecutor {
               parentNodeIds: scope.declaredNodeIds,
               runtime: {
                 executeChildGraph: (nodes, run) =>
-                  this.executeChildGraph(nodes, run, scope, undefined, attemptSignal),
+                  this.executeChildGraph(
+                    nodes,
+                    run,
+                    { ...scope, rootKeyspace: false },
+                    undefined,
+                    attemptSignal,
+                  ),
                 onNodeComplete: this.config.onNodeComplete,
                 abortSignal: attemptSignal,
               },

--- a/src/workflow/executor/dag/index.ts
+++ b/src/workflow/executor/dag/index.ts
@@ -604,6 +604,7 @@ export class DAGExecutor {
     if (published === false) {
       throw ORCHESTRATION_ERROR.create({
         detail: "Workflow execution ownership changed before node-state persistence",
+        context: { ownershipLost: true },
       });
     }
     return cloneExecutionState(nodeStates, "Workflow node states");
@@ -707,14 +708,10 @@ export class DAGExecutor {
               nodeStates,
               parentNodeIds: scope.declaredNodeIds,
               runtime: {
+                // Map children ride the parent node-state map like parallel
+                // children, so the root-keyspace flag is inherited unchanged.
                 executeChildGraph: (nodes, run, options) =>
-                  this.executeChildGraph(
-                    nodes,
-                    run,
-                    { ...scope, rootKeyspace: false },
-                    options,
-                    attemptSignal,
-                  ),
+                  this.executeChildGraph(nodes, run, scope, options, attemptSignal),
                 onNodeComplete: this.config.onNodeComplete,
                 abortSignal: attemptSignal,
               },
@@ -1152,6 +1149,7 @@ export class DAGExecutor {
     if (saved === false) {
       throw ORCHESTRATION_ERROR.create({
         detail: "Workflow execution ownership changed before checkpoint persistence",
+        context: { ownershipLost: true },
       });
     }
   }

--- a/src/workflow/executor/dag/types.ts
+++ b/src/workflow/executor/dag/types.ts
@@ -45,8 +45,8 @@ export interface ExecutionScope {
   declaredNodeIds: ReadonlySet<string>;
   /**
    * True while every enclosing composite carries its child states back into
-   * the root run's node-state map (parallel, branch, subWorkflow). Loop and
-   * map iterations keep children in a private iteration snapshot instead, so
+   * the root run's node-state map (parallel, branch, subWorkflow, map). Loop
+   * iterations keep children in a private iteration snapshot instead, so
    * their keys must never be merge-written into the root map -- no later
    * publish would delete them.
    */

--- a/src/workflow/executor/dag/types.ts
+++ b/src/workflow/executor/dag/types.ts
@@ -43,6 +43,14 @@ export interface ExecutionScope {
   resumingWait: boolean;
   /** Declared node ids in this graph and every graph that contains it. */
   declaredNodeIds: ReadonlySet<string>;
+  /**
+   * True while every enclosing composite carries its child states back into
+   * the root run's node-state map (parallel, branch, subWorkflow). Loop and
+   * map iterations keep children in a private iteration snapshot instead, so
+   * their keys must never be merge-written into the root map -- no later
+   * publish would delete them.
+   */
+  rootKeyspace: boolean;
   ownership?: CheckpointOwnership;
 }
 
@@ -71,6 +79,22 @@ export interface DAGExecutorConfig {
     currentNodes: string[];
     context: WorkflowContext;
     contextPatch: ContextPatch;
+    ownership?: CheckpointOwnership;
+  }) => Promise<boolean | void> | boolean | void;
+  /**
+   * Durably charge a recovered child-graph node before it executes.
+   *
+   * A composite's children run against a synthetic run with no backend row,
+   * so their raised attempts would otherwise reach the backend only after the
+   * child side effect ran. The patch carries only the admitted recovered
+   * nodes and must be applied as a key merge into the root run's node-state
+   * map -- never as a replacement. Returning `false` (ownership lost) aborts
+   * before the child executes; returning nothing skips durability on
+   * backends without key-merge support.
+   */
+  onChildRecoveryAdmitted?: (input: {
+    runId: string;
+    nodeStatePatch: RecordPatch<NodeState>;
     ownership?: CheckpointOwnership;
   }) => Promise<boolean | void> | boolean | void;
   /** Max milliseconds to wait for an aborted composite attempt to settle (default: 1000) */

--- a/src/workflow/executor/workflow-executor.test.ts
+++ b/src/workflow/executor/workflow-executor.test.ts
@@ -11,7 +11,15 @@ import { VeryfrontError } from "#veryfront/errors";
 import type { Tool } from "#veryfront/tool";
 import { defineSchema } from "#veryfront/schemas/index.ts";
 import { MemoryBackend } from "../backends/memory.ts";
-import { branch, dependsOn, step, waitForApproval, waitForEvent, workflow } from "../dsl/index.ts";
+import {
+  branch,
+  dependsOn,
+  parallel,
+  step,
+  waitForApproval,
+  waitForEvent,
+  workflow,
+} from "../dsl/index.ts";
 import { ApprovalManager } from "../runtime/approval-manager.ts";
 import type { WorkflowRun } from "../types.ts";
 import { WorkflowExecutor } from "./workflow-executor.ts";
@@ -807,6 +815,120 @@ describe("workflow/executor/workflow-executor", () => {
 
     release.resolve();
     await execution;
+  });
+
+  it("persists a recovered parallel child's attempt before its side effect re-runs", async () => {
+    const backend = new MemoryBackend();
+    const executor = new WorkflowExecutor({ backend, enableLocking: false });
+    const started = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    executor.register(
+      workflow({
+        id: "child-recovery-attempt",
+        steps: [
+          parallel("outer", [
+            step("inner", {
+              tool: createTool("inner", async () => {
+                started.resolve();
+                await release.promise;
+                return { ok: true };
+              }),
+            }),
+          ]),
+        ],
+      }).definition,
+    );
+    const run = {
+      ...createRun("child-recovery-attempt"),
+      status: "running" as const,
+      workerId: "run-execution:old-owner",
+      nodeStates: {
+        outer: {
+          nodeId: "outer",
+          status: "running" as const,
+          attempt: 1,
+          startedAt: new Date(),
+        },
+        "outer/inner": {
+          nodeId: "outer/inner",
+          status: "running" as const,
+          attempt: 1,
+          startedAt: new Date(),
+        },
+      },
+    };
+    await backend.createRun(run);
+
+    const execution = executor.resume(run.id, undefined, run.workerId);
+    await started.promise;
+
+    const persistedWhileRunning = await backend.getRun(run.id);
+    assertExists(persistedWhileRunning);
+    assertEquals(persistedWhileRunning.nodeStates["outer/inner"]?.attempt, 2);
+    assertEquals(persistedWhileRunning.nodeStates["outer/inner"]?.status, "running");
+    // A key merge, not a replacement: the composite's own state survives.
+    assertEquals(persistedWhileRunning.nodeStates["outer"]?.status, "running");
+
+    release.resolve();
+    await execution;
+  });
+
+  it("keeps legacy child recovery semantics on a backend without key merge", async () => {
+    const backend = new ReplacementPatchRecordingBackend();
+    const executor = new WorkflowExecutor({ backend, enableLocking: false });
+    const started = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    executor.register(
+      workflow({
+        id: "child-recovery-replacement-backend",
+        steps: [
+          parallel("outer", [
+            step("inner", {
+              tool: createTool("inner", async () => {
+                started.resolve();
+                await release.promise;
+                return { ok: true };
+              }),
+            }),
+          ]),
+        ],
+      }).definition,
+    );
+    const run = {
+      ...createRun("child-recovery-replacement-backend"),
+      status: "running" as const,
+      workerId: "run-execution:old-owner",
+      nodeStates: {
+        outer: {
+          nodeId: "outer",
+          status: "running" as const,
+          attempt: 1,
+          startedAt: new Date(),
+        },
+        "outer/inner": {
+          nodeId: "outer/inner",
+          status: "running" as const,
+          attempt: 1,
+          startedAt: new Date(),
+        },
+      },
+    };
+    await backend.createRun(run);
+
+    const execution = executor.resume(run.id, undefined, run.workerId);
+    await started.promise;
+
+    // No key merge available: the child fragment must not replace the run's
+    // node-state map, so the raised attempt is not yet durable here.
+    const persistedWhileRunning = await backend.getRun(run.id);
+    assertExists(persistedWhileRunning);
+    assertEquals(persistedWhileRunning.nodeStates["outer/inner"]?.attempt, 1);
+
+    release.resolve();
+    await execution;
+
+    const settled = await backend.getRun(run.id);
+    assertEquals(settled?.nodeStates["outer/inner"]?.status, "completed");
   });
 
   it("releases a waiting run lock after wait persistence and before batch completion", async () => {

--- a/src/workflow/executor/workflow-executor.ts
+++ b/src/workflow/executor/workflow-executor.ts
@@ -197,6 +197,22 @@ export class WorkflowExecutor {
       debug: this.config.debug,
       // waiting state is handled by executeAsync() after DAG execution returns with waiting: true
       onWaiting: () => {},
+      onChildRecoveryAdmitted: ({ runId, nodeStatePatch, ownership }) => {
+        // Only a key-merge backend can commit a child fragment without
+        // replacing the run's whole node-state map; others keep the legacy
+        // charge-on-parent-return semantics.
+        if (!hasRunPatchKeyMergeSupport(this.config.backend)) return undefined;
+        return updateRunIfStatus(
+          this.config.backend,
+          runId,
+          ["running"],
+          {
+            nodeStates: nodeStatePatch.set,
+            nodeStateDeletes: nodeStatePatch.delete,
+          },
+          ownership?.workerId,
+        );
+      },
       onNodeStatesChanged: ({
         runId,
         nodeStates,


### PR DESCRIPTION
Refs https://github.com/veryfront/veryfront-issue-inbox/issues/754

> **Stacked on #4291** (issue #755's single-write admission): this branch is based on `fix/755-single-write-recovery-admission` and its diff includes that PR until it merges. Do not merge this before #4291; I will not enable auto-merge until it lands and this shows only its own commit.

## Root cause

`DAGExecutor` gates every durable write on `isDurableRun`, so a composite's children — running against a synthetic run — persist nothing while they run. A recovered child raised its `attempt` in memory only; the raised value reached the backend when the parent returned, after the child's side effect had run. A worker dying mid-child left the durable attempt unchanged, so the next worker charged the same recovery again — the child was not bounded by its retry budget, and the ownership fence never ran for it (the issue's traced ordering: `STATE-WRITE inner.attempt=1 → EXEC:inner → STATE-WRITE inner.attempt=2`).

## Fix design (the triage comment's merge-write, keyed by existing composite paths)

Two existing facts make this small:
1. The DSL already namespaces composite children into the **root run's node-state map** under stable composite-scoped ids (`outer/inner`) for parallel/branch/subWorkflow — the "stable composite paths into the root map" the triage suggested already exist.
2. The backend layer already supports **ownership-fenced key-merge patches** (`hasRunPatchKeyMergeSupport` → `updateRunIfStatus` with `nodeStates: patch.set, nodeStateDeletes`), which is exactly the fenced merge op the triage asked for — a child fragment can be committed without ever replacing the root map.

So: admission of a recovered child in a shared-keyspace composite commits one fenced merge patch carrying **only the admitted recoveries** to the root run id, before the child executes (`onChildRecoveryAdmitted`, wired in `WorkflowExecutor`). A refused fence throws before anything runs, and the error tunnels through composite retry policy and batch settlement (`isOwnershipLossError`) — a fenced-out worker must stop writing, not retry children it no longer owns or record a failed state the new owner would then read.

**Deliberate scoping** (`ExecutionScope.rootKeyspace`): loop and map iterations keep children in a private iteration snapshot, not the root map — merge-writing their keys would strand stale entries no later publish deletes, so their recoveries deliberately keep the legacy semantics, as do backends without key-merge support. `onRecoveryScheduled` is not reintroduced: each admission is one fenced write, preserving #755's single-write contract.

## Red → green

Red first, against the #4291 head:
```
charges a recovered composite child durably before it executes ... FAILED
  Actual: ["exec:outer/inner"]   Expected: ["admit:outer/inner@2:test-run", "exec:outer/inner"]
does not execute a recovered child the merge fence refused ... FAILED (Expected function to reject)
```
Green after: `dag/index.test.ts` 146 steps / `workflow-executor.test.ts` 48 steps — **194 steps, 0 failed** — including the pre-existing invariants this must not break ("persists only the run's own node states, never a child graph's", "bounds a child graph's recovery too", the #755 admission race test, and all composite retry-policy tests). Plus `dag-executor.test.ts`, `workflow-tracing.test.ts`, `workflow-run-control.test.ts` (66 steps) green; `deno fmt`/`lint`/`check` clean.

New coverage: durable charge lands before child exec with only the child key in the patch (order-asserted); fence refusal executes nothing; loop-iteration recovery never merge-writes; end-to-end `WorkflowExecutor` tests on a key-merge backend (fenced patch visible mid-flight, composite sibling state preserved — merge, not replacement) and on a non-key-merge backend (no premature durable write, run still completes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of interrupted workflow nodes by durably recording retry attempts before execution resumes.
  * Prevented workers from retrying or marking nodes as failed when ownership has moved to another worker.
  * Improved handling of recovered parallel, map, and nested workflow executions.
  * Preserved compatibility with backends that do not support incremental state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->