### PR TITLE
test: decouple permission-coupled unit tests from the --allow-all lane (loopback-only prep)

### DIFF
--- a/src/platform/compat/dns.test.ts
+++ b/src/platform/compat/dns.test.ts
@@ -293,10 +293,6 @@ describe("platform/compat/dns loopback names", () => {
       const addresses = await resolveHostAddresses("broadcasthost", { recordTypes: ["A"] });
       assertEquals(addresses, [], `got ${JSON.stringify(addresses)}`);
     } catch (error) {
-      // Only the fail-closed permission outcome is acceptable here. Anything
-      // else — including the AssertionError above when the hosts file did
-      // answer — must surface with its own message, not a misleading
-      // "expected DnsPermissionError".
       if (!(error instanceof DnsPermissionError)) throw error;
     } finally {
       __resetHostAddressCacheForTests();

--- a/src/platform/compat/dns.test.ts
+++ b/src/platform/compat/dns.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   __resetHostAddressCacheForTests,
   createHostAddressResolver,
+  DnsPermissionError,
   HOST_ADDRESS_CACHE_MAX_ENTRIES,
   HOST_ADDRESS_CACHE_TTL_MS,
   resolveHostAddresses,
@@ -281,10 +282,24 @@ describe("platform/compat/dns loopback names", () => {
     // The refuted fix switched Node to dns.lookup, which reads /etc/hosts and
     // would resolve this on macOS while Deno returns nothing — inverting the
     // divergence instead of closing it. Loopback names are special-cased; the
-    // hosts file is not consulted.
+    // hosts file is not consulted. A hosts-file answer needs no network at
+    // all, so an address here would prove the hosts file was consulted under
+    // ANY permission set. The two honest outcomes are an empty answer from a
+    // real nameserver query, or DnsPermissionError when the lane cannot reach
+    // a nameserver (the loopback-only unit lane of veryfront-issue-inbox#714,
+    // where Deno checks --allow-net against the nameserver itself).
     __resetHostAddressCacheForTests();
-    const addresses = await resolveHostAddresses("broadcasthost", { recordTypes: ["A"] });
-    assertEquals(addresses, [], `got ${JSON.stringify(addresses)}`);
-    __resetHostAddressCacheForTests();
+    try {
+      const addresses = await resolveHostAddresses("broadcasthost", { recordTypes: ["A"] });
+      assertEquals(addresses, [], `got ${JSON.stringify(addresses)}`);
+    } catch (error) {
+      assertEquals(
+        error instanceof DnsPermissionError,
+        true,
+        `expected DnsPermissionError, got ${String(error)}`,
+      );
+    } finally {
+      __resetHostAddressCacheForTests();
+    }
   });
 });

--- a/src/platform/compat/dns.test.ts
+++ b/src/platform/compat/dns.test.ts
@@ -293,11 +293,11 @@ describe("platform/compat/dns loopback names", () => {
       const addresses = await resolveHostAddresses("broadcasthost", { recordTypes: ["A"] });
       assertEquals(addresses, [], `got ${JSON.stringify(addresses)}`);
     } catch (error) {
-      assertEquals(
-        error instanceof DnsPermissionError,
-        true,
-        `expected DnsPermissionError, got ${String(error)}`,
-      );
+      // Only the fail-closed permission outcome is acceptable here. Anything
+      // else — including the AssertionError above when the hosts file did
+      // answer — must surface with its own message, not a misleading
+      // "expected DnsPermissionError".
+      if (!(error instanceof DnsPermissionError)) throw error;
     } finally {
       __resetHostAddressCacheForTests();
     }

--- a/src/security/sandbox/permission-system.test.ts
+++ b/src/security/sandbox/permission-system.test.ts
@@ -21,22 +21,13 @@ async function expectGranted(request: PermissionRequest): Promise<void> {
 }
 
 /**
- * What requestPermission must return for a net descriptor in this process:
- * the runtime's own answer, with "prompt" folded to "denied". The fold is a
- * property of the test runner, not an assumption: `deno test` runs with
- * permission prompting disabled even on an interactive TTY (measured on Deno
- * 2.7.7 — the same request under `deno run` blocks on the prompt), so
- * `request()` can never block or interactively grant here, and nothing in the
- * suite calls `Deno.permissions.revoke`, so query and request cannot disagree
- * mid-run. Outside Deno the sandbox is a documented auto-granting no-op.
- * Anchoring the expectation to the runtime instead of hard-coding "granted"
- * keeps these cases honest on any lane: they pass under --allow-all and pin
- * the fail-closed answer once the unit suite runs loopback-only
- * (veryfront-issue-inbox#714).
+ * The runtime's own answer, with "prompt" folded to "denied" because
+ * `deno test` disables permission prompting. Outside Deno the sandbox is a
+ * documented auto-granting no-op.
  */
 async function expectedNetState(host?: string): Promise<PermissionResult["state"]> {
   const permissions = getDenoRuntime()?.permissions;
-  if (!isDeno || !permissions) return "granted";
+  if (!permissions) return "granted";
   const status = await permissions.query(
     host ? { name: "net", host } : { name: "net" },
   );
@@ -182,10 +173,7 @@ describe("Permission System", () => {
 
   describe("Security Edge Cases", () => {
     it("should handle permission request with empty object", async () => {
-      const result = await requestPermission({ name: "net" });
-
-      assertExists(result);
-      assertEquals(result.state, await expectedNetState());
+      await expectNetMirrorsRuntime({ name: "net" });
     });
 
     it("should handle permission request with undefined host", async () => {

--- a/src/security/sandbox/permission-system.test.ts
+++ b/src/security/sandbox/permission-system.test.ts
@@ -22,12 +22,17 @@ async function expectGranted(request: PermissionRequest): Promise<void> {
 
 /**
  * What requestPermission must return for a net descriptor in this process:
- * the runtime's own answer, with "prompt" folded to "denied" because a test
- * process cannot grant interactively. Outside Deno the sandbox is a documented
- * auto-granting no-op. Anchoring the expectation to the runtime instead of
- * hard-coding "granted" keeps these cases honest on any lane: they pass under
- * --allow-all and pin the fail-closed answer once the unit suite runs
- * loopback-only (veryfront-issue-inbox#714).
+ * the runtime's own answer, with "prompt" folded to "denied". The fold is a
+ * property of the test runner, not an assumption: `deno test` runs with
+ * permission prompting disabled even on an interactive TTY (measured on Deno
+ * 2.7.7 — the same request under `deno run` blocks on the prompt), so
+ * `request()` can never block or interactively grant here, and nothing in the
+ * suite calls `Deno.permissions.revoke`, so query and request cannot disagree
+ * mid-run. Outside Deno the sandbox is a documented auto-granting no-op.
+ * Anchoring the expectation to the runtime instead of hard-coding "granted"
+ * keeps these cases honest on any lane: they pass under --allow-all and pin
+ * the fail-closed answer once the unit suite runs loopback-only
+ * (veryfront-issue-inbox#714).
  */
 async function expectedNetState(host?: string): Promise<PermissionResult["state"]> {
   const permissions = getDenoRuntime()?.permissions;

--- a/src/security/sandbox/permission-system.test.ts
+++ b/src/security/sandbox/permission-system.test.ts
@@ -1,7 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { isDeno } from "#veryfront/platform/compat/runtime.ts";
+import { getDenoRuntime, isDeno } from "#veryfront/platform/compat/runtime.ts";
 import {
   type Permission,
   type PermissionRequest,
@@ -18,6 +18,29 @@ function assertValidState(state: string): void {
 async function expectGranted(request: PermissionRequest): Promise<void> {
   const result = await requestPermission(request);
   assertEquals(result.state, "granted");
+}
+
+/**
+ * What requestPermission must return for a net descriptor in this process:
+ * the runtime's own answer, with "prompt" folded to "denied" because a test
+ * process cannot grant interactively. Outside Deno the sandbox is a documented
+ * auto-granting no-op. Anchoring the expectation to the runtime instead of
+ * hard-coding "granted" keeps these cases honest on any lane: they pass under
+ * --allow-all and pin the fail-closed answer once the unit suite runs
+ * loopback-only (veryfront-issue-inbox#714).
+ */
+async function expectedNetState(host?: string): Promise<PermissionResult["state"]> {
+  const permissions = getDenoRuntime()?.permissions;
+  if (!isDeno || !permissions) return "granted";
+  const status = await permissions.query(
+    host ? { name: "net", host } : { name: "net" },
+  );
+  return status.state === "granted" ? "granted" : "denied";
+}
+
+async function expectNetMirrorsRuntime(request: PermissionRequest): Promise<void> {
+  const result = await requestPermission(request);
+  assertEquals(result.state, await expectedNetState(request.host || undefined));
 }
 
 describe("Permission System", () => {
@@ -55,8 +78,8 @@ describe("Permission System", () => {
   });
 
   describe("Permission Requests with Host", () => {
-    it("should handle net permission with host", async () => {
-      await expectGranted({ name: "net", host: "example.com" });
+    it("should mirror the runtime for an external host", async () => {
+      await expectNetMirrorsRuntime({ name: "net", host: "example.com" });
     });
 
     it("should handle net permission with localhost", async () => {
@@ -67,8 +90,8 @@ describe("Permission System", () => {
       await expectGranted({ name: "net", host: "127.0.0.1" });
     });
 
-    it("should handle net permission with port", async () => {
-      await expectGranted({ name: "net", host: "example.com:8080" });
+    it("should mirror the runtime for an external host with port", async () => {
+      await expectNetMirrorsRuntime({ name: "net", host: "example.com:8080" });
     });
 
     // Deno validates wildcard domains and returns "denied"; Node.js just returns "granted"
@@ -116,25 +139,22 @@ describe("Permission System", () => {
       assertEquals(typeof result.state, "string");
     });
 
-    it("should return granted state for all permissions in current implementation", async () => {
-      const permissions: Permission[] = ["net", "fs", "env", "run", "read", "write"];
+    it("should grant non-net permissions and mirror the runtime for blanket net", async () => {
+      const permissions: Permission[] = ["fs", "env", "run", "read", "write"];
 
       for (const permission of permissions) {
         const result = await requestPermission({ name: permission });
         assertEquals(result.state, "granted", `Permission ${permission} should be granted`);
       }
+      // Blanket net includes external destinations, so its answer depends on
+      // the lane's --allow-net and must match the runtime's own decision.
+      await expectNetMirrorsRuntime({ name: "net" });
     });
 
     it("should handle multiple permission requests sequentially", async () => {
-      const requests: PermissionRequest[] = [
-        { name: "net", host: "example.com" },
-        { name: "read", path: "/tmp/file.txt" },
-        { name: "env" },
-      ];
-
-      for (const request of requests) {
-        await expectGranted(request);
-      }
+      await expectNetMirrorsRuntime({ name: "net", host: "example.com" });
+      await expectGranted({ name: "read", path: "/tmp/file.txt" });
+      await expectGranted({ name: "env" });
     });
 
     it("should handle concurrent permission requests", async () => {
@@ -148,7 +168,8 @@ describe("Permission System", () => {
       const results = await Promise.all(requests.map((request) => requestPermission(request)));
 
       assertEquals(results.length, 4);
-      for (const result of results) {
+      assertEquals(results[0]?.state, await expectedNetState());
+      for (const result of results.slice(1)) {
         assertEquals(result.state, "granted");
       }
     });
@@ -159,11 +180,11 @@ describe("Permission System", () => {
       const result = await requestPermission({ name: "net" });
 
       assertExists(result);
-      assertEquals(result.state, "granted");
+      assertEquals(result.state, await expectedNetState());
     });
 
     it("should handle permission request with undefined host", async () => {
-      await expectGranted({ name: "net", host: undefined });
+      await expectNetMirrorsRuntime({ name: "net", host: undefined });
     });
 
     it("should handle permission request with undefined path", async () => {
@@ -171,7 +192,7 @@ describe("Permission System", () => {
     });
 
     it("should handle permission request with both host and path", async () => {
-      await expectGranted({ name: "net", host: "example.com", path: "/some/path" });
+      await expectNetMirrorsRuntime({ name: "net", host: "example.com", path: "/some/path" });
     });
 
     it("should not mutate the input request object", async () => {
@@ -219,7 +240,7 @@ describe("Permission System", () => {
     });
 
     it("should handle IPv6 with brackets", async () => {
-      await expectGranted({ name: "net", host: "[2001:db8::1]" });
+      await expectNetMirrorsRuntime({ name: "net", host: "[2001:db8::1]" });
     });
 
     it("should handle empty string path", async () => {
@@ -227,7 +248,8 @@ describe("Permission System", () => {
     });
 
     it("should handle empty string host", async () => {
-      await expectGranted({ name: "net", host: "" });
+      // An empty host is falsy, so the descriptor degrades to blanket net.
+      await expectNetMirrorsRuntime({ name: "net", host: "" });
     });
   });
 
@@ -245,6 +267,7 @@ describe("Permission System", () => {
     });
 
     it("should handle rapid successive requests", async () => {
+      const expected = await expectedNetState();
       const promises: Promise<PermissionResult>[] = [];
 
       for (let i = 0; i < 100; i++) {
@@ -255,7 +278,7 @@ describe("Permission System", () => {
       assertEquals(results.length, 100);
 
       for (const result of results) {
-        assertEquals(result.state, "granted");
+        assertEquals(result.state, expected);
       }
     });
 
@@ -310,13 +333,13 @@ describe("Permission System", () => {
       };
 
       const result = await requestPermission(request);
-      assertEquals(result.state, "granted");
+      assertEquals(result.state, await expectedNetState("example.com"));
     });
   });
 
   describe("Sandbox Enforcement Documentation", () => {
-    it("should document current permission model as facade", async () => {
-      await expectGranted({ name: "net" });
+    it("should enforce through the runtime under Deno and auto-grant elsewhere", async () => {
+      await expectNetMirrorsRuntime({ name: "net" });
     });
 
     it("should always resolve (never reject)", async () => {

--- a/src/security/sandbox/worker-egress-guard.test.ts
+++ b/src/security/sandbox/worker-egress-guard.test.ts
@@ -762,7 +762,7 @@ describe("worker-egress-guard guardedEgressFetch redirect handling", () => {
           fetchImpl: globalThis.fetch.bind(globalThis),
           runtime: {
             connect: (options) => {
-              pinnedDials.push(`${options.hostname ?? "127.0.0.1"}:${options.port}`);
+              pinnedDials.push(`${options.hostname}:${options.port}`);
               return Deno.connect(options);
             },
           },

--- a/src/security/sandbox/worker-egress-guard.test.ts
+++ b/src/security/sandbox/worker-egress-guard.test.ts
@@ -747,15 +747,25 @@ describe("worker-egress-guard guardedEgressFetch redirect handling", () => {
       // The URL host must be a loopback name: `fetch` checks --allow-net
       // against it even though the connection goes through the pinned SOCKS
       // tunnel on 127.0.0.1, so a non-loopback name cannot run on the
-      // loopback-only unit lane (veryfront-issue-inbox#714). The resolver
-      // call count keeps the pinned path observable: the tunnel must be built
-      // from the injected resolution, not from a direct system lookup.
+      // loopback-only unit lane (veryfront-issue-inbox#714). A loopback name
+      // is also directly fetchable, so the old .invalid-TLD tripwire is
+      // replaced by instrumenting the tunnel's data plane: the upstream dial
+      // to the pinned address goes through runtime.connect, and a guard that
+      // stops attaching the pinned client fetches directly and never dials
+      // through this runtime at all.
       let resolveHostCalls = 0;
+      const pinnedDials: string[] = [];
       const response = await guardedEgressFetch(
         `http://localhost:${address.port}/data`,
         undefined,
         {
           fetchImpl: globalThis.fetch.bind(globalThis),
+          runtime: {
+            connect: (options) => {
+              pinnedDials.push(`${options.hostname ?? "127.0.0.1"}:${options.port}`);
+              return Deno.connect(options);
+            },
+          },
           options: {
             allowInternalEgress: true,
             resolveHost: () => {
@@ -767,6 +777,11 @@ describe("worker-egress-guard guardedEgressFetch redirect handling", () => {
       );
       assertEquals(await response.text(), "ab");
       assertEquals(resolveHostCalls, 1, "the guard must pin through the injected resolver");
+      assertEquals(
+        pinnedDials,
+        [`127.0.0.1:${address.port}`],
+        "the streamed body must travel through the pinned SOCKS tunnel",
+      );
     } finally {
       await server.shutdown();
     }

--- a/src/security/sandbox/worker-egress-guard.test.ts
+++ b/src/security/sandbox/worker-egress-guard.test.ts
@@ -579,13 +579,20 @@ describe("worker-egress-guard admission and shutdown", () => {
 
   it("aborts and drains a broker request stalled during SOCKS resolution", async () => {
     const resolutionStarted = Promise.withResolvers<void>();
+    // The target must be a loopback name: `fetch` checks --allow-net against
+    // the URL host even when the connection only ever reaches the loopback
+    // SOCKS proxy, so a non-loopback name cannot run on the loopback-only
+    // unit lane (veryfront-issue-inbox#714). `localhost` still resolves
+    // through the injected (stalled) resolver; allowInternalEgress lets it
+    // past the internal-host gate so the stall is reached at all.
     const broker = startWorkerEgressBroker({
+      allowInternalEgress: true,
       resolveHost: () => {
         resolutionStarted.resolve();
         return new Promise<string[]>(() => {});
       },
     });
-    const pending = guardedEgressFetch("http://stalled.invalid/", undefined, {
+    const pending = guardedEgressFetch("http://localhost/", undefined, {
       options: { httpBroker: broker.config.httpBroker },
     }).then(
       () => null,
@@ -737,18 +744,29 @@ describe("worker-egress-guard guardedEgressFetch redirect handling", () => {
     if (address.transport !== "tcp") throw new Error("expected TCP test server");
 
     try {
+      // The URL host must be a loopback name: `fetch` checks --allow-net
+      // against it even though the connection goes through the pinned SOCKS
+      // tunnel on 127.0.0.1, so a non-loopback name cannot run on the
+      // loopback-only unit lane (veryfront-issue-inbox#714). The resolver
+      // call count keeps the pinned path observable: the tunnel must be built
+      // from the injected resolution, not from a direct system lookup.
+      let resolveHostCalls = 0;
       const response = await guardedEgressFetch(
-        `http://stream.invalid:${address.port}/data`,
+        `http://localhost:${address.port}/data`,
         undefined,
         {
           fetchImpl: globalThis.fetch.bind(globalThis),
           options: {
             allowInternalEgress: true,
-            resolveHost: () => Promise.resolve(["127.0.0.1"]),
+            resolveHost: () => {
+              resolveHostCalls++;
+              return Promise.resolve(["127.0.0.1"]);
+            },
           },
         },
       );
       assertEquals(await response.text(), "ab");
+      assertEquals(resolveHostCalls, 1, "the guard must pin through the injected resolver");
     } finally {
       await server.shutdown();
     }


### PR DESCRIPTION
## What this is

The measurement-first slice of the loopback-only unit-suite flip. Re-measured at `aa69b39c5` with the four unit lanes on `--allow-read --allow-write --allow-env --allow-run --allow-sys --allow-ffi --allow-import --allow-net=127.0.0.1,localhost,0.0.0.0,[::1],[::]` and a **cold** `VERYFRONT_CACHE_DIR` (all 21 parallel batches forced to run). The flip itself is not in this PR — the measurement shows why — but the three permission-coupled test files it exposes are fixed here so they hold under both permission regimes.

## Measurement (cold cache, loopback-only, Deno 2.7.7)

| Lane | Result |
| --- | --- |
| `test:unit:serial` | green |
| `test:unit:cwd` | green |
| `test:unit:cwd-exclusion` | green |
| `test:unit:parallel` | 14 files failed |

**Group A — permission-coupled tests (fixed here):**

| File | Steps | Cause |
| --- | --- | --- |
| `src/platform/compat/dns.test.ts` | 1 | real nameserver query for `broadcasthost` expecting `[]`; loopback-only raises `DnsPermissionError` (Deno checks `--allow-net` against the nameserver) |
| `src/security/sandbox/permission-system.test.ts` | 12 | external/blanket net requests pinned `"granted"` — pinning the runner's `--allow-all`, not the wrapper |
| `src/security/sandbox/worker-egress-guard.test.ts` | 2 | `fetch` checks `--allow-net` against the URL host even when the bytes only ever flow through a loopback SOCKS proxy/tunnel, so `stream.invalid` / `stalled.invalid` die before the code under test runs |

**Group B — cold-cache esm.sh cohort (11 files, remaining work):** every failure is the `ssr-http-cache` pipeline stage pulling React/React DOM from esm.sh while producing a local bundle for a framework component (222 blocked-egress instances). Full list and the scoping decision are in the issue comment. There is no small per-file fix: the fetch is interceptable via `withMockFetch`, but the tests need real React ESM to compile and render, and `ESM_CDN_BASE` has no offline path — that is the offline-resolution subsystem this slice explicitly excludes.

The previously named `NotFound` temp-path straggler no longer fails any test at HEAD (it is a post-test `[mdx-loader] Failed to save module index` warning only).

## What was fixed, and why it does not weaken the tests

- **dns.test.ts** — the property is "the hosts file has no authority", and a hosts-file answer arrives with *no* network at all. The test now accepts an empty nameserver answer or the fail-closed `DnsPermissionError`; a resolved address still fails in every environment.
- **permission-system.test.ts** — net expectations are anchored to `Deno.permissions.query` (prompt folded to denied, since a test process cannot grant interactively), asserting the wrapper mirrors the runtime instead of hard-coding the lane's grant. Loopback hosts (`localhost`, `127.0.0.1`) remain pinned `granted`, non-net permissions unchanged, the Deno-only `denied` validation pins unchanged. Runtime access goes through `getDenoRuntime()` (the compat seam `platform/compat/std/fs.ts` already uses), keeping the file out of the semantic-disposition ratchet and in the node/bun lanes.
- **worker-egress-guard.test.ts** — both tests move to a loopback URL host (`localhost`), which Deno's fetch-time permission check accepts on any lane. The streaming-tunnel test additionally asserts the injected resolver was consulted exactly once, so the pinned path stays observable now that the `.invalid`-TLD NXDOMAIN tripwire is unavailable; the stalled-broker test adds `allowInternalEgress: true` so the loopback name reaches the (stalled) resolver at all. What each test verifies — tunnel lifetime across a streaming body, abort/drain of a stalled in-flight resolution — is exercised unchanged.

## Verification

- All three files green under the current lanes (`deno task test:file …`) **and** under `--allow-net=127.0.0.1,localhost,0.0.0.0,[::1],[::]` with the granular grant set (red→green shown in the measurement).
- Full unit suite (`test:unit:parallel` + `serial` + `cwd` + `cwd-exclusion`), unpiped, all exit 0.
- `deno fmt` / `deno lint` / `deno check` on the three files; `lint:test-semantic-dispositions`, `lint:cwd-relative-test-reads`, `lint:anti-slop` clean.

Refs https://github.com/veryfront/veryfront-issue-inbox/issues/714
