### PR TITLE
test(config): pin the glued C:// [url] label as a documented limit

### DIFF
--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -5727,6 +5727,24 @@ export default config as const;
         assertEquals(error.message.includes("alice"), false);
       });
 
+      it("labels a glued double-separator drive path [url] -- a documented limit", async () => {
+        const error = await loadFailure(
+          "vf-config-glued-drive-scheme-",
+          `throw new Error("Failed atC://Users/alice/veryfront.config.ts");\n`,
+        );
+
+        // Documented limit, decided on inbox#852. Glued prose turns the drive
+        // letter into the legal three-character scheme `atC`, and that token is
+        // structurally identical to `...s://host`: a drive-letter rescue rule
+        // that relabels this [path] re-opens the http[path] regression #4236
+        // fixed, and narrowing SCHEME_URL to known schemes would under-redact
+        // real URLs. The label is cosmetic; the redaction is what matters, and
+        // it holds -- nothing from the path survives.
+        assertStringIncludes(error.message, "Failed [url]");
+        assertEquals(error.message.includes("Users"), false);
+        assertEquals(error.message.includes("alice"), false);
+      });
+
       /**
        * Fastest of `runs` timed `loadFailure` calls, with the error it raised.
        *

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2084,6 +2084,13 @@ const URI_PAREN_INTERIOR_SOURCE = String.raw`[A-Za-z0-9\-._~:/?#\[\]@!$&()*+,;=%
 const URL_BALANCED_PAREN_SEGMENT_SOURCE = String.raw`\([^\s"']{0,512}\)`;
 const URL_TOKEN_TAIL_SOURCE = String
   .raw`(?:${URI_TOKEN_CHARACTER_SOURCE}|${URL_BALANCED_PAREN_SEGMENT_SOURCE}|\((?=(?:${URI_PAREN_INTERIOR_SOURCE}|\P{ASCII}))|\)(?=${URI_PAREN_INTERIOR_SOURCE})(?![\p{P}\p{S}\p{M}\p{Cf}]{0,16}(?:[\s"']|$)))+`;
+// Documented limit (inbox#852): prose glued to a drive path that also has a
+// redundant double separator -- `Failed atC://Users` -- lengthens the apparent
+// scheme to the RFC-legal `atC` and is labeled [url]. That token is
+// structurally identical to `...s://host`, so a drive-letter rescue here
+// re-opens the http[path] regression #4236 fixed, and a known-scheme whitelist
+// would under-redact real URLs. Redaction stays complete either way; only the
+// label is off. Pinned in loader.test.ts.
 const SCHEME_URL = new RegExp(
   String.raw`[A-Za-z][A-Za-z0-9+.-]{1,31}://(?:[^\s"/]{0,512}@)?${URL_TOKEN_TAIL_SOURCE}`,
   "gu",


### PR DESCRIPTION
## Summary

Follow-through from the decision recorded on veryfront/veryfront-issue-inbox#852 (closed as working-as-intended):

- a loader test asserting `Failed atC://Users/alice/veryfront.config.ts` redacts to `Failed [url]` with nothing from the path surviving, labeled as a documented limit
- a comment at `SCHEME_URL` explaining why this must not be "fixed": the token is structurally identical to `...s://host`, so a drive-letter rescue re-opens the `http[path]` regression #4236 fixed, and a known-scheme whitelist would under-redact real URLs

No behavior change — 25 added lines, all test + comments.

## Testing

- `deno task test:file src/config/loader.test.ts` — 346 steps, 0 failed (new test: "labels a glued double-separator drive path [url] -- a documented limit")
- `deno task fmt:check` clean on the touched files