### PR TITLE
fix(embedding): retry disappearing local-index leases

### DIFF
--- a/src/embedding/local-json-store-lock.ts
+++ b/src/embedding/local-json-store-lock.ts
@@ -199,10 +199,11 @@ async function readObservation(
         leaseInfo = await lstat(join(lockDirectory, entryName));
       } catch (error) {
         if (isCanonicalNotFoundError(error)) {
-          throw new LocalJsonStoreLockError(
-            "RAG store lock lease changed while ownership was being inspected",
-            { cause: error },
-          );
+          // The directory listing and lease metadata are one observation. If a
+          // listed lease disappears between them, discard the snapshot. Lock
+          // acquisition retries, while ownership checks still fail closed on
+          // the null observation.
+          return null;
         }
         throw error;
       }

--- a/src/embedding/rag-store.test.ts
+++ b/src/embedding/rag-store.test.ts
@@ -182,6 +182,41 @@ describe("ragStore", () => {
     });
   }
 
+  it("retries when a listed lock lease disappears before lstat", async () => {
+    await withTempDir(async (tempDir) => {
+      const storagePath = join(tempDir, "data", "index.json");
+      const lockDirectory = `${storagePath}.veryfront-rag.lock`;
+      const leasePath = join(lockDirectory, `${crypto.randomUUID()}.lease`);
+      await Deno.mkdir(lockDirectory, { recursive: true });
+      await Deno.writeTextFile(join(lockDirectory, "owner.json"), "{");
+      await Deno.writeTextFile(leasePath, "live\n");
+
+      const lstatDescriptor = Object.getOwnPropertyDescriptor(Deno, "lstat");
+      assert(lstatDescriptor !== undefined);
+      const originalLstat = Deno.lstat.bind(Deno);
+      let changed = false;
+      Object.defineProperty(Deno, "lstat", {
+        ...lstatDescriptor,
+        value: async (path: string | URL) => {
+          if (!changed && String(path) === leasePath) {
+            changed = true;
+            await Deno.remove(lockDirectory, { recursive: true });
+            throw new Deno.errors.NotFound("lock lease disappeared");
+          }
+          return await originalLstat(path);
+        },
+      });
+
+      try {
+        await withLocalJsonStoreLock(storagePath, async () => undefined);
+        assertEquals(changed, true);
+        assertEquals(await exists(lockDirectory), false);
+      } finally {
+        Object.defineProperty(Deno, "lstat", lstatDescriptor);
+      }
+    });
+  });
+
   it("removes an owner-only lock when the lease write fails", async () => {
     await withTempDir(async (tempDir) => {
       const storagePath = join(tempDir, "data", "index.json");


### PR DESCRIPTION
## Root cause

The failed coverage log for inbox issue #880 shows `readObservation` listing a lease and then receiving `NotFound` when it calls `lstat` on that lease. This is an expected snapshot race when the current writer releases its lock directory, but the acquisition path converted it into a fatal `LocalJsonStoreLockError`.

## Change

- Treat a lease that disappears between `readDir` and `lstat` as an invalid observation.
- Let lock acquisition retry that observation.
- Keep ownership checks fail-closed because a null observation still fails the current-owner comparison.
- Add a deterministic regression that removes the lock directory at the observed `lstat` boundary.

## Verification

- `deno task test:file src/embedding/rag-store.test.ts`
- The same focused command repeated 10 times
- `deno fmt --check src/embedding/local-json-store-lock.ts src/embedding/rag-store.test.ts`
- `deno lint src/embedding/local-json-store-lock.ts src/embedding/rag-store.test.ts`
- `deno check src/embedding/local-json-store-lock.ts src/embedding/rag-store.test.ts`
- `git diff --check`

Refs https://github.com/veryfront/veryfront-issue-inbox/issues/880

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved lock handling when a lease disappears during verification.
  - Lock acquisition now retries instead of failing due to a transient, inconsistent lock state.
  - Ownership checks continue to fail safely when lock information cannot be verified.

- **Tests**
  - Added coverage for retry behavior when a lease disappears during lock inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->