### PR TITLE
feat(eval): expose target kind in structured output

### DIFF
--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -551,6 +551,82 @@ describe("eval CLI command helpers", () => {
     }
   });
 
+  it("includes target kinds in structured eval list output", async () => {
+    const projectDir = await makeTempDir({ prefix: "vf-eval-list-json-" });
+    const configHome = await makeTempDir({ prefix: "vf-eval-list-json-auth-" });
+    const agentDefinition = evalAgent({
+      id: "eval:agent-target",
+      name: "Agent target",
+      target: "agent:fixture",
+      dataset: [{ id: "agent-case", input: "agent" }],
+    });
+    const datasetDefinition = evalDataset({
+      id: "eval:dataset-target",
+      name: "Dataset target",
+      dataset: [{ id: "dataset-case", input: "dataset" }],
+    });
+    agentDefinition.source = {
+      filePath: `${projectDir}/evals/agent-target.eval.ts`,
+      exportName: "default",
+    };
+    datasetDefinition.source = {
+      filePath: `${projectDir}/evals/dataset-target.eval.ts`,
+      exportName: "default",
+    };
+    const runtime = createProjectRuntimeDiscovery(normalizeSourceIntegrationPolicy({ allow: {} }));
+    runtime.evals.set(agentDefinition.id, agentDefinition);
+    runtime.evals.set(datasetDefinition.id, datasetDefinition);
+
+    try {
+      Deno.env.delete("VERYFRONT_API_TOKEN");
+      Deno.env.delete("VERYFRONT_PROJECT_SLUG");
+      Deno.env.delete("VERYFRONT_EVAL_EXPORT");
+      Deno.env.delete("VERYFRONT_EVAL_EXPORTERS");
+      Deno.env.set("XDG_CONFIG_HOME", configHome);
+      setJsonMode(true);
+
+      const output = await captureConsoleOutput(async () => {
+        await runEvalCommand(
+          {
+            list: true,
+            exporters: [],
+            debug: false,
+            candidateModels: [],
+            projectDir,
+          },
+          { discoverProjectAgentRuntime: () => Promise.resolve(runtime) },
+        );
+      });
+
+      assertEquals(parseLastJsonEnvelope(output).data.evals, [
+        {
+          id: "eval:agent-target",
+          name: "Agent target",
+          targetKind: "agent",
+          target: "agent:fixture",
+          source: {
+            filePath: "evals/agent-target.eval.ts",
+            exportName: "default",
+          },
+        },
+        {
+          id: "eval:dataset-target",
+          name: "Dataset target",
+          targetKind: "dataset",
+          target: "eval:dataset-target",
+          source: {
+            filePath: "evals/dataset-target.eval.ts",
+            exportName: "default",
+          },
+        },
+      ]);
+    } finally {
+      setJsonMode(false);
+      await Deno.remove(projectDir, { recursive: true });
+      await Deno.remove(configHome, { recursive: true });
+    }
+  });
+
   it("resolves eval export redaction from exact global env toggles", () => {
     Deno.env.set("VERYFRONT_EVAL_EXPORT_INCLUDE_INPUTS", "true");
     Deno.env.set("VERYFRONT_EVAL_EXPORT_INCLUDE_OUTPUTS", "1");

--- a/cli/commands/eval/command.test.ts
+++ b/cli/commands/eval/command.test.ts
@@ -6,7 +6,7 @@ import {
   assertStringIncludes,
 } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
-import { withTempDir } from "#veryfront/testing/deno-compat.ts";
+import { deleteEnv, makeTempDir, setEnv, withTempDir } from "#veryfront/testing/deno-compat.ts";
 import { VeryfrontError } from "veryfront/errors";
 import { type Agent, agent as createAgent, type AgentResponse } from "veryfront/agent";
 import { defineSchema } from "veryfront/schemas";
@@ -33,7 +33,6 @@ import {
   normalizeSourceIntegrationPolicy,
   type SourceIntegrationPolicyManifest,
 } from "../../../src/integrations/source-policy.ts";
-import { makeTempDir } from "#veryfront/testing/deno-compat.ts";
 import { saveToken } from "../../auth/token-store.ts";
 import { setJsonMode } from "../../shared/json-output.ts";
 import { setQuietMode } from "../../utils/index.ts";
@@ -552,79 +551,81 @@ describe("eval CLI command helpers", () => {
   });
 
   it("includes target kinds in structured eval list output", async () => {
-    const projectDir = await makeTempDir({ prefix: "vf-eval-list-json-" });
-    const configHome = await makeTempDir({ prefix: "vf-eval-list-json-auth-" });
-    const agentDefinition = evalAgent({
-      id: "eval:agent-target",
-      name: "Agent target",
-      target: "agent:fixture",
-      dataset: [{ id: "agent-case", input: "agent" }],
-    });
-    const datasetDefinition = evalDataset({
-      id: "eval:dataset-target",
-      name: "Dataset target",
-      dataset: [{ id: "dataset-case", input: "dataset" }],
-    });
-    agentDefinition.source = {
-      filePath: `${projectDir}/evals/agent-target.eval.ts`,
-      exportName: "default",
-    };
-    datasetDefinition.source = {
-      filePath: `${projectDir}/evals/dataset-target.eval.ts`,
-      exportName: "default",
-    };
-    const runtime = createProjectRuntimeDiscovery(normalizeSourceIntegrationPolicy({ allow: {} }));
-    runtime.evals.set(agentDefinition.id, agentDefinition);
-    runtime.evals.set(datasetDefinition.id, datasetDefinition);
-
-    try {
-      Deno.env.delete("VERYFRONT_API_TOKEN");
-      Deno.env.delete("VERYFRONT_PROJECT_SLUG");
-      Deno.env.delete("VERYFRONT_EVAL_EXPORT");
-      Deno.env.delete("VERYFRONT_EVAL_EXPORTERS");
-      Deno.env.set("XDG_CONFIG_HOME", configHome);
-      setJsonMode(true);
-
-      const output = await captureConsoleOutput(async () => {
-        await runEvalCommand(
-          {
-            list: true,
-            exporters: [],
-            debug: false,
-            candidateModels: [],
-            projectDir,
-          },
-          { discoverProjectAgentRuntime: () => Promise.resolve(runtime) },
-        );
-      });
-
-      assertEquals(parseLastJsonEnvelope(output).data.evals, [
-        {
+    await withTempDir(async (projectDir) => {
+      await withTempDir(async (configHome) => {
+        const agentDefinition = evalAgent({
           id: "eval:agent-target",
           name: "Agent target",
-          targetKind: "agent",
           target: "agent:fixture",
-          source: {
-            filePath: "evals/agent-target.eval.ts",
-            exportName: "default",
-          },
-        },
-        {
+          dataset: [{ id: "agent-case", input: "agent" }],
+        });
+        const datasetDefinition = evalDataset({
           id: "eval:dataset-target",
           name: "Dataset target",
-          targetKind: "dataset",
-          target: "eval:dataset-target",
-          source: {
-            filePath: "evals/dataset-target.eval.ts",
-            exportName: "default",
-          },
-        },
-      ]);
-    } finally {
-      setJsonMode(false);
-      await Deno.remove(projectDir, { recursive: true });
-      await Deno.remove(configHome, { recursive: true });
-    }
+          dataset: [{ id: "dataset-case", input: "dataset" }],
+        });
+        agentDefinition.source = {
+          filePath: `${projectDir}/evals/agent-target.eval.ts`,
+          exportName: "default",
+        };
+        datasetDefinition.source = {
+          filePath: `${projectDir}/evals/dataset-target.eval.ts`,
+          exportName: "default",
+        };
+        const runtime = createProjectRuntimeDiscovery(
+          normalizeSourceIntegrationPolicy({ allow: {} }),
+        );
+        runtime.evals.set(agentDefinition.id, agentDefinition);
+        runtime.evals.set(datasetDefinition.id, datasetDefinition);
+
+        deleteEnv("VERYFRONT_API_TOKEN");
+        deleteEnv("VERYFRONT_PROJECT_SLUG");
+        deleteEnv("VERYFRONT_EVAL_EXPORT");
+        deleteEnv("VERYFRONT_EVAL_EXPORTERS");
+        setEnv("XDG_CONFIG_HOME", configHome);
+        setJsonMode(true);
+
+        try {
+          const output = await captureConsoleOutput(async () => {
+            await runEvalCommand(
+              {
+                list: true,
+                exporters: [],
+                debug: false,
+                candidateModels: [],
+                projectDir,
+              },
+              { discoverProjectAgentRuntime: () => Promise.resolve(runtime) },
+            );
+          });
+
+          assertEquals(parseLastJsonEnvelope(output).data.evals, [
+            {
+              id: "eval:agent-target",
+              name: "Agent target",
+              targetKind: "agent",
+              target: "agent:fixture",
+              source: {
+                filePath: "evals/agent-target.eval.ts",
+                exportName: "default",
+              },
+            },
+            {
+              id: "eval:dataset-target",
+              name: "Dataset target",
+              targetKind: "dataset",
+              target: "eval:dataset-target",
+              source: {
+                filePath: "evals/dataset-target.eval.ts",
+                exportName: "default",
+              },
+            },
+          ]);
+        } finally {
+          setJsonMode(false);
+        }
+      }, { prefix: "vf-eval-list-json-auth-" });
+    }, { prefix: "vf-eval-list-json-" });
   });
 
   it("resolves eval export redaction from exact global env toggles", () => {

--- a/cli/commands/eval/command.ts
+++ b/cli/commands/eval/command.ts
@@ -769,6 +769,7 @@ function listEvals(evals: DiscoveredEval[], projectDir: string) {
   return sortEvals(evals).map((item) => ({
     id: item.id,
     name: item.name,
+    targetKind: item.definition.targetKind,
     target: item.definition.target,
     source: {
       filePath: displaySourcePath(item.filePath, projectDir),

--- a/src/eval/run-report.test.ts
+++ b/src/eval/run-report.test.ts
@@ -77,6 +77,7 @@ function createSuiteEval(
   filePath: string,
   target: string,
   name = id,
+  targetKind: EvalReport["targetKind"] = "agent",
 ): DiscoveredEval {
   return {
     ...createDiscoveredEval(),
@@ -88,6 +89,7 @@ function createSuiteEval(
       ...createDiscoveredEval().definition,
       id,
       name,
+      targetKind,
       target,
     },
   };
@@ -768,7 +770,13 @@ describe("runEvalReport single mode", () => {
 
 describe("runEvalReport suite mode", () => {
   it("runs evals sorted by id and file path with sequential child ids, artifacts, and output events", async () => {
-    const beta = createSuiteEval("eval:beta", "/repo/evals/beta.eval.ts", "agent:beta", "Beta");
+    const beta = createSuiteEval(
+      "eval:beta",
+      "/repo/evals/beta.eval.ts",
+      "eval:beta",
+      "Beta",
+      "dataset",
+    );
     const alphaB = createSuiteEval(
       "eval:alpha",
       "/repo/evals/z-alpha.eval.ts",
@@ -793,7 +801,15 @@ describe("runEvalReport suite mode", () => {
     const betaFailure = createFailingReport();
     const reportById = new Map([
       ["eval:alpha", createReport({ definitionId: "eval:alpha", target: "agent:alpha" })],
-      ["eval:beta", { ...betaFailure, definitionId: "eval:beta", target: "agent:beta" }],
+      [
+        "eval:beta",
+        {
+          ...betaFailure,
+          definitionId: "eval:beta",
+          targetKind: "dataset" as const,
+          target: "eval:beta",
+        },
+      ],
       [
         "eval:gamma",
         createReport({
@@ -946,8 +962,8 @@ describe("runEvalReport suite mode", () => {
         report: {
           ...reportById.get("eval:beta")!,
           runId: "evalrun_20260621_010203004_abcdef12_003",
-          targetKind: "agent",
-          target: "agent:beta",
+          targetKind: "dataset",
+          target: "eval:beta",
           records: reportById.get("eval:beta")!.records.map((record) => ({
             ...record,
             evalId: "eval:beta",
@@ -982,6 +998,7 @@ describe("runEvalReport suite mode", () => {
         {
           id: "eval:alpha",
           name: "Alpha",
+          targetKind: "agent",
           target: "agent:alpha",
           status: "passed",
           artifacts: {
@@ -1004,6 +1021,7 @@ describe("runEvalReport suite mode", () => {
         {
           id: "eval:alpha",
           name: "Alpha missing",
+          targetKind: "agent",
           target: "agent:missing",
           status: "error",
           artifacts: {
@@ -1017,7 +1035,8 @@ describe("runEvalReport suite mode", () => {
         {
           id: "eval:beta",
           name: "Beta",
-          target: "agent:beta",
+          targetKind: "dataset",
+          target: "eval:beta",
           status: "failed",
           artifacts: {
             directory: "suite/003-beta",
@@ -1028,7 +1047,7 @@ describe("runEvalReport suite mode", () => {
           summary: {
             runId: "evalrun_20260621_010203004_abcdef12_003",
             evalId: "eval:beta",
-            target: "agent:beta",
+            target: "eval:beta",
             records: 1,
             passed: 0,
             failed: 1,
@@ -1039,6 +1058,7 @@ describe("runEvalReport suite mode", () => {
         {
           id: "eval:gamma",
           name: "Gamma",
+          targetKind: "agent",
           target: "agent:gamma",
           status: "failed",
           artifacts: {
@@ -1060,6 +1080,38 @@ describe("runEvalReport suite mode", () => {
         },
       ],
     });
+    const persistedSummary = JSON.parse(
+      writes.find((write) => write.path === "suite/summary.json")?.content ?? "null",
+    );
+    const persistedResults = (writes.find((write) => write.path === "suite/results.jsonl")
+      ?.content ?? "")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    const expectedStructuredTargets = [
+      { id: "eval:alpha", targetKind: "agent", status: "passed" },
+      { id: "eval:alpha", targetKind: "agent", status: "error" },
+      { id: "eval:beta", targetKind: "dataset", status: "failed" },
+      { id: "eval:gamma", targetKind: "agent", status: "failed" },
+    ];
+    assertEquals(
+      persistedSummary.results.map(
+        (result: { id: string; targetKind: string; status: string }) => ({
+          id: result.id,
+          targetKind: result.targetKind,
+          status: result.status,
+        }),
+      ),
+      expectedStructuredTargets,
+    );
+    assertEquals(
+      persistedResults.map((result: { id: string; targetKind: string; status: string }) => ({
+        id: result.id,
+        targetKind: result.targetKind,
+        status: result.status,
+      })),
+      expectedStructuredTargets,
+    );
     assertEquals(targetRuns.map((run) => run.runId), [
       "evalrun_20260621_010203004_abcdef12_001",
       "evalrun_20260621_010203004_abcdef12_003",

--- a/src/eval/run-report.ts
+++ b/src/eval/run-report.ts
@@ -237,6 +237,7 @@ type EvalSuiteArtifactPaths = {
 type EvalSuiteResult = {
   id: string;
   name: string;
+  targetKind: EvalReport["targetKind"];
   target: string;
   status: "passed" | "failed" | "error";
   artifacts?: EvalArtifactPaths;
@@ -921,6 +922,7 @@ async function runEvalReportSuite(
       results.push({
         id: evalItem.id,
         name: evalItem.name,
+        targetKind: evalItem.definition.targetKind,
         target: evalItem.definition.target,
         status,
         artifacts: childArtifacts,
@@ -938,6 +940,7 @@ async function runEvalReportSuite(
       results.push({
         id: evalItem.id,
         name: evalItem.name,
+        targetKind: evalItem.definition.targetKind,
         target: evalItem.definition.target,
         status: "error",
         artifacts: childArtifacts,


### PR DESCRIPTION
## Summary

- add targetKind to structured eval list entries
- add targetKind to suite summary and results JSONL rows, including errors
- source every value directly from EvalDefinition.targetKind

## Red-green TDD

RED:
- the focused list test failed for both agent and dataset entries because targetKind was absent
- the focused suite test failed for passed, failed, and error rows because targetKind was absent

GREEN:
- deno task test:file cli/commands/eval/command.test.ts src/eval/run-report.test.ts
- deno task test:file cli/commands/eval src/eval
- deno task typecheck
- deno task lint:ci
- deno task test:unit
- git diff --check

Closes veryfront/veryfront-issue-inbox#882

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Eval listings now identify each evaluation’s target type, including agents, tools, and datasets.
  - Evaluation suite results now include the target type for both successful and failed evaluations.
  - Suite summary and results output provide clearer target details for each evaluation.

- **Bug Fixes**
  - Improved consistency of target information across evaluation listing and suite result outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->