### PR TITLE
ci: align format check with local task

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           case "${{ matrix.check }}" in
             test-layout) deno task test:layout ;;
-            format) deno fmt --check ;;
+            format) deno task fmt:check ;;
             # The chain lives in the lint:ci task so a contributor can run this
             # shard locally instead of learning what it covers from a red CI run.
             lint) deno task lint:ci ;;

--- a/scripts/ci/setup-deno-workflow.test.ts
+++ b/scripts/ci/setup-deno-workflow.test.ts
@@ -850,6 +850,11 @@ jobs:
       /^\s*lint\) deno task lint:ci ;;$/m,
       "the lint shard must delegate to the lint:ci task",
     );
+    assertMatch(
+      String(ciRunStep.run),
+      /^\s*format\) deno task fmt:check ;;$/m,
+      "the format shard must delegate to the fmt:check task",
+    );
 
     const tasks = asRecord(
       asRecord(JSON.parse(await Deno.readTextFile("deno.json")), "deno.json")


### PR DESCRIPTION
## Summary

- make the CI format matrix leg call the repository fmt:check task
- add a workflow contract assertion that prevents command drift

## Red-green TDD

RED:
- the setup-deno workflow contract failed because CI ran bare deno fmt --check

GREEN:
- focused workflow contract: 11 steps passed
- formatter task: all configured source, scripts, build, and codemod paths passed
- CI workflow contracts: 20 steps passed
- deno task lint:ci
- git diff --check

Closes veryfront/veryfront-issue-inbox#884

Parent: veryfront/veryfront-issue-inbox#881 item 1.