### PR TITLE
fix(cli): classify usage errors by typed exit code

### DIFF
--- a/cli/commands/build/embedded-preset-flags.test.ts
+++ b/cli/commands/build/embedded-preset-flags.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { join } from "#veryfront/compat/path/index.ts";
 import { withCwd } from "#veryfront/testing/cwd.ts";
 import { parseCliArgs } from "#cli/shared/args";
+import { VeryfrontError } from "veryfront/errors";
 import { setJsonMode } from "../../shared/json-output.ts";
 import {
   assertEmbeddedPresetFlags,
@@ -185,13 +186,11 @@ describe("commands/build/handler embedded preset flags", () => {
           thrown = error;
         }
 
-        assertEquals(thrown instanceof Error, true, `${flag} must be rejected`);
-        const message = (thrown as Error).message;
-        assertEquals(
-          message.startsWith("Invalid "),
-          true,
-          `usage errors must start with "Invalid " so the router exits 2: ${message}`,
-        );
+        assertEquals(thrown instanceof VeryfrontError, true, `${flag} must be a typed error`);
+        const usageError = thrown as VeryfrontError;
+        assertEquals(usageError.slug, "invalid-argument", `${flag} must be a usage error`);
+        assertEquals(usageError.exitCode, 2, `${flag} must exit with the usage code`);
+        const message = usageError.message;
         assertEquals(
           message.includes(flag),
           true,

--- a/cli/commands/build/handler.ts
+++ b/cli/commands/build/handler.ts
@@ -10,6 +10,7 @@ import { showHeader } from "#cli/utils";
 import type { ParsedArgs } from "#cli/shared/types";
 import { ensureBuiltinContentProcessor } from "../../shared/ensure-content-processor.ts";
 import { isJsonMode, streamJsonLine } from "../../shared/json-output.ts";
+import { INVALID_ARGUMENT } from "veryfront/errors";
 
 /**
  * Schema factory for build command arguments
@@ -92,8 +93,8 @@ const UNSUPPORTED_EMBEDDED_FLAGS = [
  * object cannot tell a typed flag from a default — keying off it would reject
  * every embedded build, including a bare one.
  *
- * The message starts with `Invalid ` so the router maps it to exit code 2 as a
- * usage error, matching `parseArgsOrThrow`.
+ * Uses the registered invalid-argument contract so the router returns usage
+ * exit code 2 without depending on message wording.
  *
  * @param args raw parsed argv, carrying `__explicit`
  * @param preset the lowercased `--preset` value, if any
@@ -111,9 +112,11 @@ export function assertEmbeddedPresetFlags(
     .map((flag) => `--${flag}`);
   if (unsupported.length === 0) return;
 
-  throw new Error(
-    `Invalid build arguments: the embedded preset does not support ${unsupported.join(", ")}`,
-  );
+  throw INVALID_ARGUMENT.create({
+    detail: `Invalid build arguments: the embedded preset does not support ${
+      unsupported.join(", ")
+    }`,
+  });
 }
 
 export async function handleBuildCommand(args: ParsedArgs): Promise<void> {

--- a/cli/router.test.ts
+++ b/cli/router.test.ts
@@ -4,7 +4,8 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { COMMANDS } from "./help/command-definitions.ts";
 import { parseLoginMethod } from "./auth/utils.ts";
-import { routeCommand } from "./router.ts";
+import { classifyCliError, routeCommand } from "./router.ts";
+import { INVALID_ARGUMENT, UNKNOWN_ERROR } from "veryfront/errors";
 import { cliLogger, VERSION } from "./utils/index.ts";
 import { setJsonMode } from "./shared/json-output.ts";
 import { isInteractive, resetInteractiveMode } from "./shared/interactive.ts";
@@ -136,6 +137,27 @@ describe("cli/command-definitions integrity", () => {
 });
 
 describe("cli/router helpers", () => {
+  describe("classifyCliError", () => {
+    it("uses typed exit metadata instead of message prefixes", () => {
+      assertEquals(
+        classifyCliError(UNKNOWN_ERROR.create({ detail: "Invalid runtime response" })),
+        {
+          code: "RUNTIME_ERROR",
+          slug: "command-failed",
+          exitCode: 1,
+        },
+      );
+      assertEquals(
+        classifyCliError(INVALID_ARGUMENT.create({ detail: "Check the supplied value" })),
+        {
+          code: "USAGE_ERROR",
+          slug: "invalid-arguments",
+          exitCode: 2,
+        },
+      );
+    });
+  });
+
   describe("resolveProjectDir pattern", () => {
     it("should return cwd when no matching key found", () => {
       assertEquals(resolveProjectDir({}, ["dir", "d"], "/home/user"), "/home/user");

--- a/cli/router.ts
+++ b/cli/router.ts
@@ -4,7 +4,7 @@
  * @module cli/router
  */
 
-import { cliErrorBoundary } from "veryfront/errors";
+import { cliErrorBoundary, type VeryfrontError } from "veryfront/errors";
 import { cliLogger, isVerbose, VERSION } from "#cli/utils";
 import { showCommandHelp, showMainHelp } from "./help/index.ts";
 import { setColorOverride, shouldUseColor } from "./ui/colors.ts";
@@ -140,6 +140,22 @@ async function outputCliJsonError(
   error: ErrorEnvelope["error"],
 ): Promise<void> {
   await outputJson(createErrorEnvelope(command, error));
+}
+
+/** Classify a CLI failure from its registered exit-code contract. */
+export function classifyCliError(
+  error: Pick<VeryfrontError, "exitCode">,
+): {
+  code: "USAGE_ERROR" | "RUNTIME_ERROR";
+  slug: "invalid-arguments" | "command-failed";
+  exitCode: number;
+} {
+  const usageError = error.exitCode === 2;
+  return {
+    code: usageError ? "USAGE_ERROR" : "RUNTIME_ERROR",
+    slug: usageError ? "invalid-arguments" : "command-failed",
+    exitCode: error.exitCode ?? 1,
+  };
 }
 
 /**
@@ -279,16 +295,15 @@ export async function routeCommand(args: ParsedArgs): Promise<void> {
       }
 
       const message = vfError.detail ?? vfError.message;
-      const isUsageError = vfError.exitCode === 2 || message.startsWith("Invalid ");
+      const classification = classifyCliError(vfError);
       await outputCliJsonError(commandNameForJson(args), {
-        code: isUsageError ? "USAGE_ERROR" : "RUNTIME_ERROR",
-        slug: isUsageError ? "invalid-arguments" : "command-failed",
+        code: classification.code,
+        slug: classification.slug,
         registrySlug: vfError.slug,
         message: vfError.detail ?? message,
       });
     },
-    getExitCode: (_error, vfError) =>
-      vfError.exitCode ?? ((vfError.detail ?? vfError.message).startsWith("Invalid ") ? 2 : 1),
+    getExitCode: (_error, vfError) => classifyCliError(vfError).exitCode,
   });
 
   // Wait for update check to finish (with timeout to avoid hanging)


### PR DESCRIPTION
## Summary

- classify CLI JSON and process failures from VeryfrontError exit metadata only
- remove both Invalid message-prefix fallbacks from the router
- convert embedded-build unsupported flags to the registered invalid-argument error

## Red-green TDD

RED:
- 11 embedded-build flag cases failed because they threw plain Error values
- router classification regression failed because typed-only classification was absent

GREEN:
- focused router and embedded-build tests: 88 steps
- CLI-wide suite: 354 test files, 3617 steps
- deno task typecheck
- deno task lint:ci
- git diff --check

Closes veryfront/veryfront-issue-inbox#885

Parent: veryfront/veryfront-issue-inbox#881 item 7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CLI error handling for invalid build options.
  - Invalid embedded-preset flags now consistently return a usage error with exit code 2.
  - Error responses now provide reliable classifications and exit codes, including for JSON output.
  - Prevented error message wording from affecting how command failures are reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->