### PR TITLE
ci: fail closed on review limits and timeouts

### DIFF
--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -688,6 +688,13 @@ jobs:
                 context.payload.pull_request?.updated_at,
               reviewEpochRunKey: String(context.runId),
             });
+            if (
+              context.eventName === "pull_request_target" &&
+              context.payload.action === "ready_for_review" &&
+              /^ready-run-/.test(result.reviewRequestKey ?? "")
+            ) {
+              core.setOutput("explicit-ready-request", "true");
+            }
             if (Number.isSafeInteger(result.statusId)) {
               core.setOutput("source-status-id", String(result.statusId));
             }
@@ -800,7 +807,9 @@ jobs:
       # this head yet, and nothing would request one: the Codex connector
       # handles open and ready-for-review events, but not a push to an open
       # pull request. Post the "@codex review" request for synchronize and
-      # reopened events.
+      # reopened events. Request explicitly after ready-for-review only when
+      # an ambiguous run-bound reset invalidated the connector's automatic
+      # proof and requires replacement evidence.
       # The helper re-fetches the PR immediately before posting so a queued
       # stale event cannot bind its marker to a request for a newer head. A
       # base edit gets a marker scoped to the run, which invalidates
@@ -814,7 +823,8 @@ jobs:
           github.event.pull_request.draft == false &&
           (github.event.action == 'synchronize' ||
            github.event.action == 'reopened' ||
-           github.event.action == 'ready_for_review' ||
+           (github.event.action == 'ready_for_review' &&
+            steps.publish.outputs.explicit-ready-request == 'true') ||
            (github.event.action == 'edited' && github.event.changes.base)) &&
           steps.publish.outputs.result == 'pending'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -884,7 +894,8 @@ jobs:
       (github.event_name == 'issue_comment' ||
        github.event_name == 'workflow_run' ||
        (github.event_name == 'pull_request_target' &&
-        (github.event.action == 'reopened' ||
+        (github.event.action == 'synchronize' ||
+         github.event.action == 'reopened' ||
          github.event.action == 'ready_for_review' ||
          (github.event.action == 'edited' &&
           github.event.changes.base))))

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -691,7 +691,7 @@ jobs:
             if (
               context.eventName === "pull_request_target" &&
               context.payload.action === "ready_for_review" &&
-              /^ready-run-/.test(result.reviewRequestKey ?? "")
+              /^ready-(?:r|run)-/.test(result.reviewRequestKey ?? "")
             ) {
               core.setOutput("explicit-ready-request", "true");
             }

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -682,6 +682,8 @@ jobs:
                   ? context.payload.comment?.id
                   : undefined,
               queuePropagationPending: true,
+              reviewEpochNotBefore:
+                context.payload.pull_request?.updated_at,
             });
             if (Number.isSafeInteger(result.statusId)) {
               core.setOutput("source-status-id", String(result.statusId));
@@ -845,6 +847,8 @@ jobs:
                 : context.payload.action === "reopened"
                 ? "reopen"
                 : undefined,
+              reviewEpochNotBefore:
+                context.payload.pull_request?.updated_at,
             });
             core.notice(
               result.requested

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -674,6 +674,8 @@ jobs:
                     ? "base"
                     : context.payload.action === "reopened"
                     ? "reopen"
+                    : context.payload.action === "ready_for_review"
+                    ? "ready"
                     : undefined
                   : undefined,
               reviewFailureCommentId:

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -618,6 +618,7 @@ jobs:
             let publishAutomatedReviewStatus;
             let publishReviewResolutionFailure;
             let completeReviewFailurePropagation;
+            let publishReviewPropagationRetryStatus;
             let reconcileActiveMergeGroupReviewStatuses;
             try {
               const response = await github.rest.repos.getContent({
@@ -639,6 +640,7 @@ jobs:
                 publishAutomatedReviewStatus,
                 publishReviewResolutionFailure,
                 completeReviewFailurePropagation,
+                publishReviewPropagationRetryStatus,
                 reconcileActiveMergeGroupReviewStatuses,
               } = await import(gateUrl));
             } catch (error) {
@@ -749,18 +751,26 @@ jobs:
                 if (!forceInvalidateCurrentSource()) return "failure";
                 throw error;
               }
-              // A failure that never reached its synthetic commit leaves the
-              // queue's prior success as live review proof. The trusted gate
-              // throws on that, but the loaded module comes from the default
-              // branch, so verify the collected results here as well and fail
-              // the run: the fallback invalidation job keys on this failure.
-              const unreplaced = queueResults.filter((entry) =>
-                entry?.state === "failure" && entry?.published !== true
+              const failedQueueResults = queueResults.filter((entry) =>
+                entry?.state === "failure"
               ).length;
-              if (unreplaced > 0) {
+              if (result.state === "success" && failedQueueResults > 0) {
                 if (!forceInvalidateCurrentSource()) return "failure";
+                const retryStatus = await publishReviewPropagationRetryStatus({
+                  github,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pullNumber,
+                  headSha,
+                  failureKind: "unavailable",
+                  targetUrl: result.targetUrl,
+                });
+                core.setOutput(
+                  "source-status-id",
+                  String(retryStatus.statusId),
+                );
                 core.setFailed(
-                  `Review proof was not replaced on ${unreplaced} active merge queue commit(s).`,
+                  `${failedQueueResults} active merge queue review failed.`,
                 );
                 return "failure";
               }

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -776,6 +776,7 @@ jobs:
                   headSha,
                   failureKind: "unavailable",
                   targetUrl: result.targetUrl,
+                  reviewRequestKey: result.reviewRequestKey,
                 });
                 core.setOutput(
                   "source-status-id",

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -667,9 +667,9 @@ jobs:
               pullUrl: `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${pullNumber}`,
               reviewResetKey:
                 context.eventName === "pull_request_target"
-                  ? context.payload.action === "edited" &&
+                    ? context.payload.action === "edited" &&
                       context.payload.changes?.base !== undefined
-                    ? `base-${context.runId}`
+                    ? "base"
                     : context.payload.action === "reopened"
                     ? "reopen"
                     : undefined
@@ -831,7 +831,7 @@ jobs:
               pullNumber: pullRequest.number,
               headSha: process.env.TARGET_SHA,
               requestKey: context.payload.action === "edited"
-                ? `base-${context.runId}`
+                ? "base"
                 : context.payload.action === "reopened"
                 ? "reopen"
                 : undefined,
@@ -844,7 +844,7 @@ jobs:
                 : result.reason === "ineligible-pull"
                 ? "Skipped an automated review request because the pull request is no longer open and ready for review."
                 : result.reason === "stale-epoch"
-                ? "Skipped an automated review request from a superseded reopen event."
+                ? "Skipped an automated review request from a superseded review epoch."
                 : "An automated review request for this head commit already exists.",
             );
 

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -617,6 +617,7 @@ jobs:
             }
             let publishAutomatedReviewStatus;
             let publishReviewResolutionFailure;
+            let completeReviewFailurePropagation;
             let reconcileActiveMergeGroupReviewStatuses;
             try {
               const response = await github.rest.repos.getContent({
@@ -637,6 +638,7 @@ jobs:
               ({
                 publishAutomatedReviewStatus,
                 publishReviewResolutionFailure,
+                completeReviewFailurePropagation,
                 reconcileActiveMergeGroupReviewStatuses,
               } = await import(gateUrl));
             } catch (error) {
@@ -669,7 +671,7 @@ jobs:
                       context.payload.changes?.base !== undefined
                     ? `base-${context.runId}`
                     : context.payload.action === "reopened"
-                    ? `reopen-${context.runId}`
+                    ? "reopen"
                     : undefined
                   : undefined,
               reviewFailureCommentId:
@@ -677,6 +679,7 @@ jobs:
                   context.payload.action !== "deleted"
                   ? context.payload.comment?.id
                   : undefined,
+              queuePropagationPending: true,
             });
             if (Number.isSafeInteger(result.statusId)) {
               core.setOutput("source-status-id", String(result.statusId));
@@ -701,10 +704,25 @@ jobs:
               return true;
             };
             let queueResultCount;
-            if (
-              result.state === "failure" ||
-              typeof result.baseRef !== "string"
-            ) {
+            if (result.state === "failure") {
+              let completed;
+              try {
+                completed = await completeReviewFailurePropagation({
+                  github,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pullNumber,
+                  headSha,
+                  sourceStatusId: result.statusId,
+                  description: result.description,
+                  targetUrl: result.targetUrl,
+                });
+              } catch (error) {
+                if (!forceInvalidateCurrentSource()) return "failure";
+                throw error;
+              }
+              queueResultCount = completed.resolution.queueFailures;
+            } else if (typeof result.baseRef !== "string") {
               const { queueFailures } = await publishReviewResolutionFailure({
                 github,
                 owner: context.repo.owner,
@@ -815,7 +833,7 @@ jobs:
               requestKey: context.payload.action === "edited"
                 ? `base-${context.runId}`
                 : context.payload.action === "reopened"
-                ? `reopen-${context.runId}`
+                ? "reopen"
                 : undefined,
             });
             core.notice(

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -82,7 +82,7 @@ jobs:
         target: ${{ fromJSON(needs.timeout_targets.outputs.targets) }}
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       statuses: write
     concurrency:
       group: automated-review-pr-${{ matrix.target.pullNumber }}
@@ -684,6 +684,7 @@ jobs:
               queuePropagationPending: true,
               reviewEpochNotBefore:
                 context.payload.pull_request?.updated_at,
+              reviewEpochRunAttempt: context.runAttempt,
             });
             if (Number.isSafeInteger(result.statusId)) {
               core.setOutput("source-status-id", String(result.statusId));

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -843,6 +843,8 @@ jobs:
                 ? "Skipped an automated review request from a stale synchronize event."
                 : result.reason === "ineligible-pull"
                 ? "Skipped an automated review request because the pull request is no longer open and ready for review."
+                : result.reason === "stale-epoch"
+                ? "Skipped an automated review request from a superseded reopen event."
                 : "An automated review request for this head commit already exists.",
             );
 

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -814,6 +814,7 @@ jobs:
           github.event.pull_request.draft == false &&
           (github.event.action == 'synchronize' ||
            github.event.action == 'reopened' ||
+           github.event.action == 'ready_for_review' ||
            (github.event.action == 'edited' && github.event.changes.base)) &&
           steps.publish.outputs.result == 'pending'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -849,10 +850,13 @@ jobs:
                 ? "base"
                 : context.payload.action === "reopened"
                 ? "reopen"
+                : context.payload.action === "ready_for_review"
+                ? "ready"
                 : undefined,
               reviewEpochNotBefore:
                 context.payload.pull_request?.updated_at,
               reviewEpochRunKey: String(context.runId),
+              revalidateReviewEvidence: true,
             });
             core.notice(
               result.requested

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -684,7 +684,7 @@ jobs:
               queuePropagationPending: true,
               reviewEpochNotBefore:
                 context.payload.pull_request?.updated_at,
-              reviewEpochRunAttempt: context.runAttempt,
+              reviewEpochRunKey: String(context.runId),
             });
             if (Number.isSafeInteger(result.statusId)) {
               core.setOutput("source-status-id", String(result.statusId));
@@ -850,6 +850,7 @@ jobs:
                 : undefined,
               reviewEpochNotBefore:
                 context.payload.pull_request?.updated_at,
+              reviewEpochRunKey: String(context.runId),
             });
             core.notice(
               result.requested

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -669,6 +669,11 @@ jobs:
                 context.payload.changes?.base !== undefined
                   ? `base-${context.runId}`
                   : undefined,
+              reviewFailureCommentId:
+                context.eventName === "issue_comment" &&
+                  context.payload.action !== "deleted"
+                  ? context.payload.comment?.id
+                  : undefined,
             });
             if (Number.isSafeInteger(result.statusId)) {
               core.setOutput("source-status-id", String(result.statusId));
@@ -703,6 +708,7 @@ jobs:
                 repo: context.repo.repo,
                 pullNumber,
                 sourceHeadSha: headSha,
+                sourceStatusId: result.statusId,
               });
               queueResultCount = queueFailures;
             } else {

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -18,7 +18,7 @@ on:
   merge_group:
     types: [checks_requested]
   schedule:
-    - cron: "*/5 * * * *"
+    - cron: "*/10 * * * *"
 
 permissions: {}
 
@@ -95,7 +95,6 @@ jobs:
         env:
           PULL_NUMBER: ${{ matrix.target.pullNumber }}
           HEAD_SHA: ${{ matrix.target.headSha }}
-          PENDING_STATUS_ID: ${{ matrix.target.pendingStatusId }}
         with:
           retries: 3
           script: |
@@ -124,7 +123,6 @@ jobs:
               repo: context.repo.repo,
               pullNumber: Number(process.env.PULL_NUMBER),
               headSha: process.env.HEAD_SHA,
-              pendingStatusId: Number(process.env.PENDING_STATUS_ID),
               now: Date.now(),
               reviewTimeoutMs: AUTOMATED_REVIEW_TIMEOUT_MS,
             });

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -664,10 +664,13 @@ jobs:
               headSha,
               pullUrl: `https://github.com/${context.repo.owner}/${context.repo.repo}/pull/${pullNumber}`,
               reviewResetKey:
-                context.eventName === "pull_request_target" &&
-                context.payload.action === "edited" &&
-                context.payload.changes?.base !== undefined
-                  ? `base-${context.runId}`
+                context.eventName === "pull_request_target"
+                  ? context.payload.action === "edited" &&
+                      context.payload.changes?.base !== undefined
+                    ? `base-${context.runId}`
+                    : context.payload.action === "reopened"
+                    ? `reopen-${context.runId}`
+                    : undefined
                   : undefined,
               reviewFailureCommentId:
                 context.eventName === "issue_comment" &&

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -17,25 +17,139 @@ on:
     types: [completed]
   merge_group:
     types: [checks_requested]
+  schedule:
+    - cron: "*/5 * * * *"
 
 permissions: {}
 
 jobs:
+  timeout_targets:
+    name: find timed-out automated reviews
+    if: github.event_name == 'schedule'
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      targets: ${{ steps.discover.outputs.result }}
+    steps:
+      - name: Discover expired review statuses
+        id: discover
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          retries: 3
+          result-encoding: string
+          script: |
+            const response = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: "scripts/ci/automated-review-gate.mjs",
+              ref: context.payload.repository.default_branch,
+            });
+            const file = response.data;
+            if (
+              Array.isArray(file) || file?.type !== "file" ||
+              file?.encoding !== "base64" ||
+              typeof file?.content !== "string"
+            ) throw new Error("Trusted review gate content is malformed");
+            const gateUrl = `data:text/javascript;base64,${
+              Buffer.from(file.content, "base64").toString("base64")
+            }`;
+            const {
+              AUTOMATED_REVIEW_TIMEOUT_MS,
+              findTimedOutAutomatedReviews,
+            } = await import(gateUrl);
+            const targets = await findTimedOutAutomatedReviews({
+              github,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              now: Date.now(),
+              reviewTimeoutMs: AUTOMATED_REVIEW_TIMEOUT_MS,
+            });
+            core.notice(`Found ${targets.length} timed-out automated review(s).`);
+            return JSON.stringify(targets);
+
+  timeout:
+    name: fail timed-out automated review
+    needs: timeout_targets
+    if: needs.timeout_targets.outputs.targets != '[]'
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        target: ${{ fromJSON(needs.timeout_targets.outputs.targets) }}
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
+    concurrency:
+      group: automated-review-pr-${{ matrix.target.pullNumber }}
+      queue: max
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Publish the expired review status
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PULL_NUMBER: ${{ matrix.target.pullNumber }}
+          HEAD_SHA: ${{ matrix.target.headSha }}
+          PENDING_STATUS_ID: ${{ matrix.target.pendingStatusId }}
+        with:
+          retries: 3
+          script: |
+            const response = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: "scripts/ci/automated-review-gate.mjs",
+              ref: context.payload.repository.default_branch,
+            });
+            const file = response.data;
+            if (
+              Array.isArray(file) || file?.type !== "file" ||
+              file?.encoding !== "base64" ||
+              typeof file?.content !== "string"
+            ) throw new Error("Trusted review gate content is malformed");
+            const gateUrl = `data:text/javascript;base64,${
+              Buffer.from(file.content, "base64").toString("base64")
+            }`;
+            const {
+              AUTOMATED_REVIEW_TIMEOUT_MS,
+              expireTimedOutAutomatedReview,
+            } = await import(gateUrl);
+            const result = await expireTimedOutAutomatedReview({
+              github,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pullNumber: Number(process.env.PULL_NUMBER),
+              headSha: process.env.HEAD_SHA,
+              pendingStatusId: Number(process.env.PENDING_STATUS_ID),
+              now: Date.now(),
+              reviewTimeoutMs: AUTOMATED_REVIEW_TIMEOUT_MS,
+            });
+            core.notice(
+              result.expired
+                ? `Failed timed-out review for PR #${process.env.PULL_NUMBER}.`
+                : `Skipped PR #${process.env.PULL_NUMBER}: ${result.reason}.`,
+            );
+
   target:
     name: resolve automated review target
     # Apply publisher eligibility before allocating a resolver runner. The
     # resolver also gives source and merge-group publishers the same per-pull
     # concurrency key while keeping the immutable source SHA separate.
     if: >-
-      github.event_name == 'merge_group' ||
-      ((github.event_name != 'issue_comment' ||
-        (github.event.issue.pull_request &&
-         github.event.comment.user.login == 'chatgpt-codex-connector[bot]' &&
-         github.event.comment.user.id == 199175422 &&
-         github.event.comment.user.type == 'Bot')) &&
-       (github.event_name != 'workflow_run' ||
-        (github.event.workflow_run.event == 'pull_request_review' &&
-         endsWith(github.event.workflow_run.display_title, '-eligible'))))
+      github.event_name != 'schedule' &&
+      (github.event_name == 'merge_group' ||
+       ((github.event_name != 'issue_comment' ||
+         (github.event.issue.pull_request &&
+          github.event.comment.user.login == 'chatgpt-codex-connector[bot]' &&
+          github.event.comment.user.id == 199175422 &&
+          github.event.comment.user.type == 'Bot')) &&
+        (github.event_name != 'workflow_run' ||
+         (github.event.workflow_run.event == 'pull_request_review' &&
+          endsWith(github.event.workflow_run.display_title, '-eligible')))))
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -834,16 +834,18 @@ jobs:
     # resolver or the publisher cannot complete, the previous success stays on
     # the head and a later merge group reuses it, so a finding, a deleted
     # verdict, or a dismissed approval is silently lost. A new head has no
-    # status of its own. A base edit does need this fallback because the source
-    # SHA is unchanged and its prior success can otherwise remain current.
+    # status of its own. Lifecycle resets need this fallback because the source
+    # SHA is unchanged and prior success can otherwise remain current.
     needs: [target, review]
     if: >-
       failure() &&
       (github.event_name == 'issue_comment' ||
        github.event_name == 'workflow_run' ||
        (github.event_name == 'pull_request_target' &&
-        github.event.action == 'edited' &&
-        github.event.changes.base))
+        (github.event.action == 'reopened' ||
+         github.event.action == 'ready_for_review' ||
+         (github.event.action == 'edited' &&
+          github.event.changes.base))))
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -766,7 +766,8 @@ jobs:
       # A pending status on a trusted push event means no review exists for
       # this head yet, and nothing would request one: the Codex connector
       # handles open and ready-for-review events, but not a push to an open
-      # pull request. Post the "@codex review" request only for synchronize.
+      # pull request. Post the "@codex review" request for synchronize and
+      # reopened events.
       # The helper re-fetches the PR immediately before posting so a queued
       # stale event cannot bind its marker to a request for a newer head. A
       # base edit gets a marker scoped to the run, which invalidates
@@ -779,6 +780,7 @@ jobs:
           github.event_name == 'pull_request_target' &&
           github.event.pull_request.draft == false &&
           (github.event.action == 'synchronize' ||
+           github.event.action == 'reopened' ||
            (github.event.action == 'edited' && github.event.changes.base)) &&
           steps.publish.outputs.result == 'pending'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -812,6 +814,8 @@ jobs:
               headSha: process.env.TARGET_SHA,
               requestKey: context.payload.action === "edited"
                 ? `base-${context.runId}`
+                : context.payload.action === "reopened"
+                ? `reopen-${context.runId}`
                 : undefined,
             });
             core.notice(

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -823,6 +823,8 @@ jobs:
                 ? `Requested an automated review of ${process.env.TARGET_SHA.slice(0, 12)}.`
                 : result.reason === "stale-head"
                 ? "Skipped an automated review request from a stale synchronize event."
+                : result.reason === "ineligible-pull"
+                ? "Skipped an automated review request because the pull request is no longer open and ready for review."
                 : "An automated review request for this head commit already exists.",
             );
 

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -222,8 +222,63 @@ function parseReviewEpochNotBefore(value) {
 
 function reviewEpochEventIdentity(epoch) {
   return Number.isSafeInteger(epoch?.id) && epoch.id > 0
-    ? `-event-${epoch.id}`
+    ? `-e-${epoch.id.toString(36)}`
     : "";
+}
+
+function parseBase36Identity(value) {
+  if (typeof value !== "string" || !/^[0-9a-z]+$/i.test(value)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(value, 36);
+  return Number.isSafeInteger(parsed) && parsed > 0 &&
+      parsed.toString(36) === value.toLowerCase()
+    ? parsed
+    : undefined;
+}
+
+function parseCompactRunBoundReviewRequestKey(requestKey) {
+  if (typeof requestKey !== "string") return undefined;
+  const match = /^(base|ready|reopen)-r-([0-9a-z]+)-t-([0-9a-z]+)(?:-e-([0-9a-z]+))?$/i
+    .exec(requestKey);
+  if (!match) return undefined;
+  const epochTime = parseBase36Identity(match[3]);
+  const eventId = match[4] === undefined
+    ? undefined
+    : parseBase36Identity(match[4]);
+  if (epochTime === undefined || (match[4] !== undefined && !eventId)) {
+    return undefined;
+  }
+  return {
+    requestKind: match[1].toLowerCase(),
+    eventKind: REVIEW_REQUEST_EVENT_KINDS.get(match[1].toLowerCase()),
+    epochTime,
+    eventId,
+  };
+}
+
+function parseLegacyRunBoundReviewRequestKey(requestKey) {
+  if (typeof requestKey !== "string") return undefined;
+  const match = /^(base|ready|reopen)-run-([1-9]\d*)-at-(\d{13})(?:-event-([1-9]\d*))?$/
+    .exec(requestKey);
+  if (!match) return undefined;
+  const epochTime = Number(match[3]);
+  const eventId = match[4] === undefined ? undefined : Number(match[4]);
+  if (
+    !Number.isSafeInteger(epochTime) || epochTime < 1 ||
+    (match[4] !== undefined && !isPositiveStatusId(eventId))
+  ) return undefined;
+  return {
+    requestKind: match[1],
+    eventKind: REVIEW_REQUEST_EVENT_KINDS.get(match[1]),
+    epochTime,
+    eventId,
+  };
+}
+
+function parseRunBoundReviewRequestKey(requestKey) {
+  return parseCompactRunBoundReviewRequestKey(requestKey) ??
+    parseLegacyRunBoundReviewRequestKey(requestKey);
 }
 
 function durableReviewRequestKey(
@@ -254,7 +309,8 @@ function durableReviewRequestKey(
       !/^[1-9]\d*$/.test(reviewEpochRunKey)
     ) throw new Error("Review epoch run key is malformed");
     const eventIdentity = reviewEpochEventIdentity(latestEpoch);
-    return `${requestKey}-run-${reviewEpochRunKey}-at-${notBefore}${eventIdentity}`;
+    const compactRunKey = BigInt(reviewEpochRunKey).toString(36);
+    return `${requestKey}-r-${compactRunKey}-t-${notBefore.toString(36)}${eventIdentity}`;
   }
   if (!Number.isSafeInteger(latestEpoch.id) || latestEpoch.id < 1) {
     throw new Error("Review epoch event identity is malformed");
@@ -419,9 +475,7 @@ function isEvidenceProvablyLater(candidate, current, timeline) {
 function reviewResetDescription(pullNumber, baseBinding, requestKey) {
   const prefix = `PR#${pullNumber} reset base:${baseBinding}`;
   if (requestKey === undefined) return prefix;
-  const encodedKey = /^(?:base|ready|reopen)-run-[1-9]\d*-at-\d{13}(?:-event-[1-9]\d*)?$/.test(
-      requestKey,
-    )
+  const encodedKey = parseRunBoundReviewRequestKey(requestKey) !== undefined
     ? requestKey
     : createHash("sha256").update(requestKey).digest("hex").slice(0, 12);
   return `${prefix} key:${encodedKey}`;
@@ -477,10 +531,8 @@ function latestRunBoundReviewRequestKey(
       !isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN)
     ) continue;
     const requestKey = status.description.slice(prefix.length);
-    const runBound = /^(?:base|ready|reopen)-run-[1-9]\d*-at-(\d{13})(?:-event-([1-9]\d*))?$/
-      .exec(requestKey);
+    const runBound = parseRunBoundReviewRequestKey(requestKey);
     if (!runBound) continue;
-    const epochTime = Number(runBound[1]);
     const createdAt = Date.parse(status?.created_at ?? "");
     if (!Number.isFinite(createdAt)) continue;
     if (boundary !== undefined && createdAt < boundary.time) continue;
@@ -488,12 +540,25 @@ function latestRunBoundReviewRequestKey(
       latest = {
         requestKey,
         createdAt,
-        epochTime,
-        eventId: runBound[2] === undefined ? undefined : Number(runBound[2]),
+        epochTime: runBound.epochTime,
+        eventId: runBound.eventId,
+        eventKind: runBound.eventKind,
       };
     }
   }
   return latest;
+}
+
+function runBoundRequestBelongsToBoundary(request, boundary) {
+  if (request === undefined) return false;
+  if (boundary === undefined || !REVIEW_EPOCH_EVENTS.has(boundary.kind)) {
+    return true;
+  }
+  if (boundary.time !== request.epochTime) {
+    return boundary.time < request.epochTime;
+  }
+  return boundary.kind === request.eventKind &&
+    boundary.id === request.eventId;
 }
 
 function latestPendingReviewStatus(statuses, pullNumber) {
@@ -1282,12 +1347,18 @@ export async function publishAutomatedReviewStatus({
         reviewNotBefore,
         latestReviewEpochChange(events),
       );
-      const runBoundRequest = latestRunBoundReviewRequestKey(
+      const recoveredRunBoundRequest = latestRunBoundReviewRequestKey(
         statuses,
         pullNumber,
         baseBinding,
         reviewBoundary,
       );
+      const runBoundRequest = runBoundRequestBelongsToBoundary(
+          recoveredRunBoundRequest,
+          reviewBoundary,
+        )
+        ? recoveredRunBoundRequest
+        : undefined;
       reviewRequestKey = effectiveReviewResetKey ??
         runBoundRequest?.requestKey ??
         reviewRequestKeyFromBoundary(reviewBoundary);
@@ -1323,9 +1394,7 @@ export async function publishAutomatedReviewStatus({
       existingPropagationRetryIsLatest = propagationRetry?.status?.id ===
         latestReviewGateStatusForPull(statuses, pullNumber)?.id;
       const runBoundResetPending = resetPending &&
-        /^(?:base|ready|reopen)-run-/.test(
-          effectiveReviewResetKey ?? "",
-        );
+        parseRunBoundReviewRequestKey(effectiveReviewResetKey) !== undefined;
       if (
         !isDraft &&
         (!resetPending ||
@@ -1730,14 +1799,7 @@ export async function findTimedOutAutomatedReviews({
   throw new Error("Timeout discovery exceeded 1,000 open pull requests");
 }
 
-function latestReviewPropagationRetryStatus(
-  statuses,
-  pullNumber,
-  boundary,
-  comments = [],
-  timeline = [],
-  headSha = "",
-) {
+function storedReviewPropagationRetry(statuses, pullNumber) {
   const latestStatus = latestReviewGateStatusForPull(statuses, pullNumber);
   let status = latestStatus;
   let failureKind = reviewFailureKindFromDescription(
@@ -1771,32 +1833,61 @@ function latestReviewPropagationRetryStatus(
     !isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN)
   ) return undefined;
   if (failureKind === undefined) return undefined;
-  if (boundary !== undefined) {
-    if (failureKind === "rate-limited") {
-      if (!terminalStatusHasBoundaryProof(
-        status,
-        comments,
-        boundary,
-        timeline,
-        headSha,
-      )) return undefined;
-    } else if (failureKind === "timed-out") {
-      if (!pendingHistoryHasBoundaryProof(
+  return { status, failureKind };
+}
+
+function reviewPropagationRetryHasBoundaryProof(
+  retry,
+  statuses,
+  pullNumber,
+  boundary,
+  comments,
+  timeline,
+  headSha,
+) {
+  if (boundary === undefined) return true;
+  if (retry.failureKind === "rate-limited") {
+    return terminalStatusHasBoundaryProof(
+      retry.status,
+      comments,
+      boundary,
+      timeline,
+      headSha,
+    );
+  }
+  if (retry.failureKind === "timed-out") {
+    return pendingHistoryHasBoundaryProof(
+      statuses,
+      pullNumber,
+      boundary,
+      retry.status,
+    );
+  }
+  const createdAt = Date.parse(retry.status?.created_at ?? "");
+  return Number.isFinite(createdAt) && createdAt >= boundary.time;
+}
+
+function latestReviewPropagationRetryStatus(
+  statuses,
+  pullNumber,
+  boundary,
+  comments = [],
+  timeline = [],
+  headSha = "",
+) {
+  const retry = storedReviewPropagationRetry(statuses, pullNumber);
+  return retry &&
+      reviewPropagationRetryHasBoundaryProof(
+        retry,
         statuses,
         pullNumber,
         boundary,
-        status,
-      )) {
-        return undefined;
-      }
-    } else {
-      const createdAt = Date.parse(status?.created_at ?? "");
-      if (!Number.isFinite(createdAt) || createdAt < boundary.time) {
-        return undefined;
-      }
-    }
-  }
-  return { status, failureKind };
+        comments,
+        timeline,
+        headSha,
+      )
+    ? retry
+    : undefined;
 }
 
 async function finalizeReviewFailureStatus({
@@ -2946,23 +3037,16 @@ function resolveAutomatedReviewRequestEpochKey(
       reviewEpochRunKey,
     );
   }
-  const runBoundEpoch = typeof requestKey === "string"
-    ? /^(base|ready|reopen)-run-([1-9]\d*)-at-(\d{13})(?:-event-([1-9]\d*))?$/
-      .exec(requestKey)
-    : null;
+  const runBoundEpoch = parseRunBoundReviewRequestKey(requestKey);
   if (runBoundEpoch) {
     const notAfter = Date.parse(reviewEpochNotAfter ?? "");
-    if (!Number.isFinite(notAfter) || notAfter !== Number(runBoundEpoch[3])) {
+    if (!Number.isFinite(notAfter) || notAfter !== runBoundEpoch.epochTime) {
       throw new TypeError("Run-bound review epoch timestamp is malformed");
     }
     const latestEpoch = latestReviewEpochChange(events);
-    const pinnedEventId = runBoundEpoch[4] === undefined
-      ? undefined
-      : Number(runBoundEpoch[4]);
-    const expectedKind = REVIEW_REQUEST_EVENT_KINDS.get(runBoundEpoch[1]);
     return latestEpoch?.time === notAfter &&
-        latestEpoch.kind === expectedKind &&
-        latestEpoch.id === pinnedEventId
+        latestEpoch.kind === runBoundEpoch.eventKind &&
+        latestEpoch.id === runBoundEpoch.eventId
       ? requestKey
       : undefined;
   }
@@ -3073,8 +3157,9 @@ async function revalidateAutomatedReviewRequest({
         ...common,
         login,
         pullAuthor: refreshed?.data?.user?.login,
-      }),
+    }),
     latestReviewResetTime(statuses, pullNumber, baseBinding),
+    parseRunBoundReviewRequestKey(effectiveRequestKey) !== undefined,
   );
   return review
     ? { requested: false, marker, reason: "reviewed" }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -32,10 +32,12 @@ const REVIEW_EPOCH_EVENTS = new Set([
 const REVIEW_REQUEST_EVENT_KINDS = new Map([
   ["reopen", "reopened"],
   ["base", "base_ref_changed"],
+  ["ready", "ready_for_review"],
 ]);
 const REVIEW_BOUNDARY_REQUEST_KEYS = new Map([
   ["reopened", "reopen"],
   ["base_ref_changed", "base"],
+  ["ready_for_review", "ready"],
 ]);
 /** @type {(ref: string) => Promise<string | undefined>} */
 const NO_COMMIT = () => Promise.resolve(undefined);
@@ -1247,7 +1249,9 @@ export async function publishAutomatedReviewStatus({
       existingPropagationRetryIsLatest = propagationRetry?.status?.id ===
         latestReviewGateStatusForPull(statuses, pullNumber)?.id;
       const runBoundResetPending = resetPending &&
-        /^(?:base|reopen)-run-/.test(effectiveReviewResetKey ?? "");
+        /^(?:base|ready|reopen)-run-/.test(
+          effectiveReviewResetKey ?? "",
+        );
       if (
         !isDraft &&
         (!resetPending ||
@@ -2015,17 +2019,31 @@ export async function expireTimedOutAutomatedReview({
         `${queueFailures} active merge queue review failed`,
       );
     }
-    const reviewRequest = result.state === "pending"
-      ? await requestAutomatedReview({
-        github,
-        owner,
-        repo,
-        pullNumber,
-        headSha,
-        requestKey: result.reviewRequestKey,
-        validateRequestEpoch: result.reviewRequestKey !== undefined,
-      })
-      : undefined;
+    let reviewRequest;
+    if (result.state === "pending") {
+      try {
+        reviewRequest = await requestAutomatedReview({
+          github,
+          owner,
+          repo,
+          pullNumber,
+          headSha,
+          requestKey: result.reviewRequestKey,
+          validateRequestEpoch: result.reviewRequestKey !== undefined,
+        });
+      } catch (error) {
+        await publishReviewPropagationRetryStatus({
+          github,
+          owner,
+          repo,
+          pullNumber,
+          headSha,
+          failureKind: "unavailable",
+          targetUrl: result.targetUrl ?? pullUrl,
+        });
+        throw error;
+      }
+    }
     return {
       ...result,
       expired: false,
@@ -2766,19 +2784,17 @@ export async function requestAutomatedReview({
   }
   let effectiveRequestKey = requestKey;
   const concreteEpoch = typeof requestKey === "string"
-    ? /^(base|reopen)-([1-9]\d*)$/.exec(requestKey)
+    ? /^(base|ready|reopen)-([1-9]\d*)$/.exec(requestKey)
     : null;
-  if (
-    requestKey === "reopen" || requestKey === "base" ||
-    validateRequestEpoch
-  ) {
+  const sentinelEpoch = REVIEW_REQUEST_EVENT_KINDS.has(requestKey);
+  if (sentinelEpoch || validateRequestEpoch) {
     const events = await collectAll(
       github,
       github.rest.issues.listEvents,
       { owner, repo, issue_number: pullNumber },
       "review epoch events",
     );
-    if (requestKey === "reopen" || requestKey === "base") {
+    if (sentinelEpoch) {
       effectiveRequestKey = durableReviewRequestKey(
         events,
         requestKey,
@@ -2834,8 +2850,7 @@ export async function requestAutomatedReview({
     return { requested: false, marker, reason: "ineligible-pull" };
   }
   if (
-    requestKey === "reopen" || requestKey === "base" ||
-    validateRequestEpoch
+    sentinelEpoch || validateRequestEpoch
   ) {
     const events = await collectAll(
       github,
@@ -2843,7 +2858,7 @@ export async function requestAutomatedReview({
       { owner, repo, issue_number: pullNumber },
       "final review epoch events",
     );
-    const currentKey = requestKey === "reopen" || requestKey === "base"
+    const currentKey = sentinelEpoch
       ? durableReviewRequestKey(
         events,
         requestKey,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -619,18 +619,19 @@ function latestTerminalReviewStatus(
         status?.description !== timedOut)
     ) continue;
     if (boundary !== undefined) {
-      const createdAt = Date.parse(status?.created_at ?? "");
-      if (!Number.isFinite(createdAt) || createdAt < boundary.time) continue;
-      if (
-        createdAt === boundary.time &&
-        !terminalStatusHasBoundaryProof(
+      if (status.description === rateLimited) {
+        if (!terminalStatusHasBoundaryProof(
           status,
           comments,
           boundary,
           timeline,
           headSha,
-        )
-      ) continue;
+        )) continue;
+      } else if (!pendingHistoryHasBoundaryProof(
+        statuses,
+        pullNumber,
+        boundary,
+      )) continue;
     }
     return status;
   }
@@ -2013,6 +2014,7 @@ export async function expireTimedOutAutomatedReview({
         pullNumber,
         headSha,
         requestKey: result.reviewRequestKey,
+        validateRequestEpoch: result.reviewRequestKey !== undefined,
       })
       : undefined;
     return {
@@ -2736,6 +2738,7 @@ export async function requestAutomatedReview({
   headSha,
   requestKey = /** @type {string | undefined} */ (undefined),
   reviewEpochNotBefore = /** @type {string | undefined} */ (undefined),
+  validateRequestEpoch = false,
 }) {
   // The comment body must stay a fixed instruction plus a verified commit
   // SHA. Never interpolate pull request controlled content here: this runs
@@ -2752,18 +2755,34 @@ export async function requestAutomatedReview({
     throw new Error("Refusing to use a malformed review request key");
   }
   let effectiveRequestKey = requestKey;
-  if (requestKey === "reopen" || requestKey === "base") {
+  const concreteEpoch = typeof requestKey === "string"
+    ? /^(base|reopen)-([1-9]\d*)$/.exec(requestKey)
+    : null;
+  if (
+    requestKey === "reopen" || requestKey === "base" ||
+    validateRequestEpoch
+  ) {
     const events = await collectAll(
       github,
       github.rest.issues.listEvents,
       { owner, repo, issue_number: pullNumber },
       "review epoch events",
     );
-    effectiveRequestKey = durableReviewRequestKey(
-      events,
-      requestKey,
-      reviewEpochNotBefore,
-    );
+    if (requestKey === "reopen" || requestKey === "base") {
+      effectiveRequestKey = durableReviewRequestKey(
+        events,
+        requestKey,
+        reviewEpochNotBefore,
+      );
+    } else {
+      if (!concreteEpoch) {
+        throw new Error("Concrete review epoch key is malformed");
+      }
+      const currentKey = durableReviewRequestKey(events, concreteEpoch[1]);
+      if (currentKey !== requestKey) {
+        return { requested: false, reason: "stale-epoch" };
+      }
+    }
     if (effectiveRequestKey === undefined) {
       return { requested: false, reason: "stale-epoch" };
     }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -1639,7 +1639,7 @@ async function finalizeReviewFailureStatus({
   return { description, statusId };
 }
 
-async function publishReviewPropagationRetryStatus({
+export async function publishReviewPropagationRetryStatus({
   github,
   owner,
   repo,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -205,12 +205,21 @@ function hasReviewRequest(comments, headSha, requestKey) {
   });
 }
 
-function durableReviewRequestKey(events, requestKey) {
+function durableReviewRequestKey(events, requestKey, reviewEpochNotBefore) {
   const eventKind = REVIEW_REQUEST_EVENT_KINDS.get(requestKey);
   if (eventKind === undefined) return requestKey;
+  const notBefore = reviewEpochNotBefore === undefined
+    ? undefined
+    : Date.parse(reviewEpochNotBefore);
+  if (notBefore !== undefined && !Number.isFinite(notBefore)) {
+    throw new Error("Review epoch timestamp is malformed");
+  }
   const latestEpoch = latestReviewEpochChange(events);
   if (latestEpoch === undefined) {
     throw new Error("Could not resolve the current review epoch event");
+  }
+  if (notBefore !== undefined && latestEpoch.time < notBefore) {
+    throw new Error("The current review epoch event is not visible");
   }
   if (latestEpoch.kind !== eventKind) return undefined;
   if (!Number.isSafeInteger(latestEpoch.id) || latestEpoch.id < 1) {
@@ -1021,6 +1030,7 @@ export async function publishAutomatedReviewStatus({
   now = Date.now(),
   reviewTimeoutMs = /** @type {number | undefined} */ (undefined),
   queuePropagationPending = false,
+  reviewEpochNotBefore = /** @type {string | undefined} */ (undefined),
 }) {
   let review;
   let failure;
@@ -1119,6 +1129,7 @@ export async function publishAutomatedReviewStatus({
       effectiveReviewResetKey = durableReviewRequestKey(
         events,
         reviewResetKey,
+        reviewEpochNotBefore,
       );
       resetPending = effectiveReviewResetKey !== undefined &&
         !hasReviewRequest(comments, headSha, effectiveReviewResetKey) &&
@@ -1640,6 +1651,50 @@ async function finalizeReviewFailureStatus({
   return { description, statusId };
 }
 
+async function currentReviewPropagationRetry({
+  github,
+  owner,
+  repo,
+  pullNumber,
+  headSha,
+}) {
+  const common = { owner, repo };
+  const [statuses, comments, events, timeline] = await Promise.all([
+    collectAll(
+      github,
+      github.rest.repos.listCommitStatusesForRef,
+      { ...common, ref: headSha },
+      "final review statuses",
+    ),
+    collectAll(
+      github,
+      github.rest.issues.listComments,
+      { ...common, issue_number: pullNumber },
+      "final review comments",
+    ),
+    collectAll(
+      github,
+      github.rest.issues.listEvents,
+      { ...common, issue_number: pullNumber },
+      "final review events",
+    ),
+    collectAll(
+      github,
+      github.rest.issues.listEventsForTimeline,
+      { ...common, issue_number: pullNumber },
+      "final review timeline",
+    ),
+  ]);
+  return latestReviewPropagationRetryStatus(
+    statuses,
+    pullNumber,
+    latestReviewEpochChange(events),
+    comments,
+    timeline,
+    headSha,
+  );
+}
+
 export async function publishReviewPropagationRetryStatus({
   github,
   owner,
@@ -1688,6 +1743,21 @@ async function propagateAndFinalizeReviewFailure({
     sourceHeadSha: headSha,
     sourceStatusId,
   });
+  const currentRetry = await currentReviewPropagationRetry({
+    github,
+    owner,
+    repo,
+    pullNumber,
+    headSha,
+  });
+  if (currentRetry?.status?.id !== sourceStatusId) {
+    return {
+      resolution,
+      description: reviewFailureDescription(pullNumber, failureKind, true),
+      statusId: sourceStatusId,
+      finalized: false,
+    };
+  }
   const finalStatus = await finalizeReviewFailureStatus({
     github,
     owner,
@@ -1697,7 +1767,7 @@ async function propagateAndFinalizeReviewFailure({
     failureKind,
     targetUrl,
   });
-  return { resolution, ...finalStatus };
+  return { resolution, ...finalStatus, finalized: true };
 }
 
 /** Propagate one published retry marker, then restore its terminal diagnosis. */
@@ -2585,6 +2655,7 @@ export async function requestAutomatedReview({
   pullNumber,
   headSha,
   requestKey = /** @type {string | undefined} */ (undefined),
+  reviewEpochNotBefore = /** @type {string | undefined} */ (undefined),
 }) {
   // The comment body must stay a fixed instruction plus a verified commit
   // SHA. Never interpolate pull request controlled content here: this runs
@@ -2608,7 +2679,11 @@ export async function requestAutomatedReview({
       { owner, repo, issue_number: pullNumber },
       "review epoch events",
     );
-    effectiveRequestKey = durableReviewRequestKey(events, requestKey);
+    effectiveRequestKey = durableReviewRequestKey(
+      events,
+      requestKey,
+      reviewEpochNotBefore,
+    );
     if (effectiveRequestKey === undefined) {
       return { requested: false, reason: "stale-epoch" };
     }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -33,6 +33,10 @@ const REVIEW_REQUEST_EVENT_KINDS = new Map([
   ["reopen", "reopened"],
   ["base", "base_ref_changed"],
 ]);
+const REVIEW_BOUNDARY_REQUEST_KEYS = new Map([
+  ["reopened", "reopen"],
+  ["base_ref_changed", "base"],
+]);
 /** @type {(ref: string) => Promise<string | undefined>} */
 const NO_COMMIT = () => Promise.resolve(undefined);
 /** @type {(login: string) => Promise<boolean>} */
@@ -286,6 +290,14 @@ function activeReviewBoundary(request, reviewNotBefore, epochChange) {
   ) return { ...request, timelineEvent: "commented" };
   if (boundary !== undefined || request === undefined) return boundary;
   return { ...request, timelineEvent: "commented" };
+}
+
+function reviewRequestKeyFromBoundary(boundary) {
+  const requestKey = REVIEW_BOUNDARY_REQUEST_KEYS.get(boundary?.kind);
+  return requestKey !== undefined && Number.isSafeInteger(boundary?.id) &&
+      boundary.id > 0
+    ? `${requestKey}-${boundary.id}`
+    : undefined;
 }
 
 function evidenceFreshness(
@@ -1076,6 +1088,7 @@ export async function publishAutomatedReviewStatus({
   let existingPropagationRetryStatus;
   let existingPropagationRetryKind;
   let existingPropagationRetryIsLatest = false;
+  let reviewRequestKey;
   let reviewBoundary;
   let failureKind;
   let failureUrl;
@@ -1202,6 +1215,8 @@ export async function publishAutomatedReviewStatus({
         reviewNotBefore,
         latestReviewEpochChange(events),
       );
+      reviewRequestKey = effectiveReviewResetKey ??
+        reviewRequestKeyFromBoundary(reviewBoundary);
       if (
         !pendingStatusBelongsToReviewEpoch(
           existingPendingStatus,
@@ -1406,6 +1421,7 @@ export async function publishAutomatedReviewStatus({
       description: existingPendingStatus.description,
       baseRef,
       statusId: existingPendingStatus.id,
+      reviewRequestKey,
     };
   }
   let targetUrl = failureUrl ?? review?.url ?? pullUrl;
@@ -1454,6 +1470,7 @@ export async function publishAutomatedReviewStatus({
     baseRef,
     statusId,
     targetUrl,
+    reviewRequestKey,
   };
 }
 
@@ -1995,6 +2012,7 @@ export async function expireTimedOutAutomatedReview({
         repo,
         pullNumber,
         headSha,
+        requestKey: result.reviewRequestKey,
       })
       : undefined;
     return {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -228,6 +228,16 @@ function durableReviewRequestKey(events, requestKey, reviewEpochNotBefore) {
   return `${requestKey}-${latestEpoch.id}`;
 }
 
+function reviewEpochTiesTrigger(events, requestKey, reviewEpochNotBefore) {
+  const eventKind = REVIEW_REQUEST_EVENT_KINDS.get(requestKey);
+  if (eventKind === undefined || reviewEpochNotBefore === undefined) {
+    return false;
+  }
+  const latestEpoch = latestReviewEpochChange(events);
+  return latestEpoch?.kind === eventKind &&
+    latestEpoch.time === Date.parse(reviewEpochNotBefore);
+}
+
 function timelinePosition(timeline, event, id) {
   if (!Number.isSafeInteger(id) || id < 1) return undefined;
   let position;
@@ -450,6 +460,25 @@ function pendingStatusBelongsToReviewEpoch(
     description.startsWith(`${resetPrefix} key:`) ||
     (boundary.kind === "ready_for_review" &&
       description.startsWith(`PR#${pullNumber} waits for review `));
+}
+
+function pendingHistoryHasBoundaryProof(statuses, pullNumber, boundary) {
+  const descriptionPrefix = `PR#${pullNumber} `;
+  return statuses.some((status) => {
+    if (
+      status?.context !== AUTOMATED_REVIEW_STATUS_CONTEXT ||
+      status?.state !== "pending" ||
+      typeof status?.description !== "string" ||
+      !status.description.startsWith(descriptionPrefix) ||
+      !isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN)
+    ) return false;
+    const createdAt = Date.parse(status?.created_at ?? "");
+    if (!Number.isFinite(createdAt) || createdAt < boundary.time) return false;
+    if (createdAt > boundary.time) return true;
+    return status.description.startsWith(`PR#${pullNumber} reset base:`) ||
+      (boundary.kind === "ready_for_review" &&
+        status.description.startsWith(`PR#${pullNumber} waits for review `));
+  });
 }
 
 function latestCodexUsageLimit(
@@ -1031,6 +1060,7 @@ export async function publishAutomatedReviewStatus({
   reviewTimeoutMs = /** @type {number | undefined} */ (undefined),
   queuePropagationPending = false,
   reviewEpochNotBefore = /** @type {string | undefined} */ (undefined),
+  reviewEpochRunAttempt = /** @type {number | undefined} */ (undefined),
 }) {
   let review;
   let failure;
@@ -1069,6 +1099,11 @@ export async function publishAutomatedReviewStatus({
     failure = new Error("Review timeout is invalid");
   } else if (!FULL_SHA.test(headSha)) {
     failure = new Error("Captured head is malformed");
+  } else if (
+    reviewEpochRunAttempt !== undefined &&
+    (!Number.isSafeInteger(reviewEpochRunAttempt) || reviewEpochRunAttempt < 1)
+  ) {
+    failure = new Error("Review epoch run attempt is invalid");
   } else {
     try {
       const current = await github.rest.pulls.get({
@@ -1131,14 +1166,28 @@ export async function publishAutomatedReviewStatus({
         reviewResetKey,
         reviewEpochNotBefore,
       );
-      resetPending = effectiveReviewResetKey !== undefined &&
-        !hasReviewRequest(comments, headSha, effectiveReviewResetKey) &&
-        !hasReviewReset(
+      const resetRequested = effectiveReviewResetKey !== undefined &&
+        hasReviewRequest(comments, headSha, effectiveReviewResetKey);
+      const resetPublished = effectiveReviewResetKey !== undefined &&
+        hasReviewReset(
           statuses,
           pullNumber,
           baseBinding,
           effectiveReviewResetKey,
         );
+      if (
+        reviewEpochRunAttempt === 1 &&
+        (resetRequested || resetPublished) &&
+        reviewEpochTiesTrigger(
+          events,
+          reviewResetKey,
+          reviewEpochNotBefore,
+        )
+      ) {
+        throw new Error("The triggering review epoch event is not visible");
+      }
+      resetPending = effectiveReviewResetKey !== undefined &&
+        !resetRequested && !resetPublished;
       existingPendingStatus = latestPendingReviewStatus(
         statuses,
         pullNumber,
@@ -1606,21 +1655,24 @@ function latestReviewPropagationRetryStatus(
   ) return undefined;
   if (failureKind === undefined) return undefined;
   if (boundary !== undefined) {
-    const createdAt = Date.parse(status?.created_at ?? "");
-    if (!Number.isFinite(createdAt) || createdAt < boundary.time) {
-      return undefined;
-    }
-    if (
-      createdAt === boundary.time &&
-      failureKind !== "unavailable" &&
-      !terminalStatusHasBoundaryProof(
+    if (failureKind === "rate-limited") {
+      if (!terminalStatusHasBoundaryProof(
         status,
         comments,
         boundary,
         timeline,
         headSha,
-      )
-    ) return undefined;
+      )) return undefined;
+    } else if (failureKind === "timed-out") {
+      if (!pendingHistoryHasBoundaryProof(statuses, pullNumber, boundary)) {
+        return undefined;
+      }
+    } else {
+      const createdAt = Date.parse(status?.created_at ?? "");
+      if (!Number.isFinite(createdAt) || createdAt < boundary.time) {
+        return undefined;
+      }
+    }
   }
   return { status, failureKind };
 }
@@ -1936,11 +1988,21 @@ export async function expireTimedOutAutomatedReview({
         `${queueFailures} active merge queue review failed`,
       );
     }
+    const reviewRequest = result.state === "pending"
+      ? await requestAutomatedReview({
+        github,
+        owner,
+        repo,
+        pullNumber,
+        headSha,
+      })
+      : undefined;
     return {
       ...result,
       expired: false,
       reason: result.state === "success" ? "reviewed" : "revalidated",
       queueResults,
+      reviewRequest,
     };
   }
   return { ...result, expired: false, reason: "revalidated" };

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -700,6 +700,44 @@ function reviewFailureDescription(pullNumber, kind, retryPending = false) {
   }`;
 }
 
+function reviewEpochIdentity(requestKey) {
+  const runBound = parseRunBoundReviewRequestKey(requestKey);
+  return runBound?.eventId === undefined
+    ? requestKey ?? "head"
+    : `${runBound.requestKind}-${runBound.eventId}`;
+}
+
+function reviewEpochToken(requestKey) {
+  return createHash("sha256")
+    .update(reviewEpochIdentity(requestKey))
+    .digest("hex")
+    .slice(0, 12);
+}
+
+function reviewPropagationRetryDescription(
+  pullNumber,
+  kind,
+  requestKey,
+) {
+  const epoch = kind === "unavailable"
+    ? `; epoch:${reviewEpochToken(requestKey)}`
+    : "";
+  return `${reviewFailureDescription(pullNumber, kind)}${epoch}${REVIEW_PROPAGATION_RETRY_SUFFIX}`;
+}
+
+function reviewPropagationRetryEpochToken(description, pullNumber) {
+  const prefix = `${reviewFailureDescription(pullNumber, "unavailable")}; epoch:`;
+  if (
+    typeof description !== "string" || !description.startsWith(prefix) ||
+    !description.endsWith(REVIEW_PROPAGATION_RETRY_SUFFIX)
+  ) return undefined;
+  const token = description.slice(
+    prefix.length,
+    -REVIEW_PROPAGATION_RETRY_SUFFIX.length,
+  );
+  return /^[0-9a-f]{12}$/.test(token) ? token : undefined;
+}
+
 function reviewFailureKindFromDescription(
   description,
   pullNumber,
@@ -710,6 +748,10 @@ function reviewFailureKindFromDescription(
       description === reviewFailureDescription(pullNumber, kind, retryPending)
     ) return kind;
   }
+  if (
+    retryPending &&
+    reviewPropagationRetryEpochToken(description, pullNumber) !== undefined
+  ) return "unavailable";
   return undefined;
 }
 
@@ -1388,6 +1430,7 @@ export async function publishAutomatedReviewStatus({
         comments,
         timeline,
         headSha,
+        reviewRequestKey,
       );
       existingPropagationRetryStatus = propagationRetry?.status;
       existingPropagationRetryKind = propagationRetry?.failureKind;
@@ -1508,11 +1551,16 @@ export async function publishAutomatedReviewStatus({
   if (failure && existingPropagationRetryStatus) {
     description = existingPropagationRetryStatus.description;
   } else if (failure) {
-    description = reviewFailureDescription(
-      pullNumber,
-      failureKind ?? "unavailable",
-      queuePropagationPending,
-    );
+    description = queuePropagationPending
+      ? reviewPropagationRetryDescription(
+        pullNumber,
+        failureKind ?? "unavailable",
+        reviewRequestKey,
+      )
+      : reviewFailureDescription(
+        pullNumber,
+        failureKind ?? "unavailable",
+      );
   } else if (review) {
     description = `PR#${pullNumber} base:${baseBinding} by:${review.reviewer}`;
   } else if (resetPending) {
@@ -1591,11 +1639,13 @@ export async function publishAutomatedReviewStatus({
     failure = new TypeError("Published review status identity is malformed");
     state = "failure";
     review = undefined;
-    description = reviewFailureDescription(
-      pullNumber,
-      "unavailable",
-      queuePropagationPending,
-    );
+    description = queuePropagationPending
+      ? reviewPropagationRetryDescription(
+        pullNumber,
+        "unavailable",
+        reviewRequestKey,
+      )
+      : reviewFailureDescription(pullNumber, "unavailable");
     targetUrl = pullUrl;
     const failureResponse = await github.rest.repos.createCommitStatus({
       owner,
@@ -1844,6 +1894,7 @@ function reviewPropagationRetryHasBoundaryProof(
   comments,
   timeline,
   headSha,
+  reviewRequestKey,
 ) {
   if (boundary === undefined) return true;
   if (retry.failureKind === "rate-limited") {
@@ -1863,6 +1914,13 @@ function reviewPropagationRetryHasBoundaryProof(
       retry.status,
     );
   }
+  const retryEpoch = reviewPropagationRetryEpochToken(
+    retry.status?.description,
+    pullNumber,
+  );
+  if (retryEpoch !== undefined) {
+    return retryEpoch === reviewEpochToken(reviewRequestKey);
+  }
   const createdAt = Date.parse(retry.status?.created_at ?? "");
   return Number.isFinite(createdAt) && createdAt >= boundary.time;
 }
@@ -1874,6 +1932,7 @@ function latestReviewPropagationRetryStatus(
   comments = [],
   timeline = [],
   headSha = "",
+  reviewRequestKey = /** @type {string | undefined} */ (undefined),
 ) {
   const retry = storedReviewPropagationRetry(statuses, pullNumber);
   return retry &&
@@ -1885,6 +1944,7 @@ function latestReviewPropagationRetryStatus(
         comments,
         timeline,
         headSha,
+        reviewRequestKey,
       )
     ? retry
     : undefined;
@@ -1950,13 +2010,15 @@ async function currentReviewPropagationRetry({
       "final review timeline",
     ),
   ]);
+  const boundary = latestReviewEpochChange(events);
   return latestReviewPropagationRetryStatus(
     statuses,
     pullNumber,
-    latestReviewEpochChange(events),
+    boundary,
     comments,
     timeline,
     headSha,
+    reviewRequestKeyFromBoundary(boundary),
   );
 }
 
@@ -1968,11 +2030,12 @@ export async function publishReviewPropagationRetryStatus({
   headSha,
   failureKind,
   targetUrl,
+  reviewRequestKey = /** @type {string | undefined} */ (undefined),
 }) {
-  const description = reviewFailureDescription(
+  const description = reviewPropagationRetryDescription(
     pullNumber,
     failureKind,
-    true,
+    reviewRequestKey,
   );
   const response = await github.rest.repos.createCommitStatus({
     owner,
@@ -2127,6 +2190,7 @@ async function preserveTimedOutQueueRetry({
     targetUrl: typeof retryStatus?.status?.target_url === "string"
       ? retryStatus.status.target_url
       : result.targetUrl ?? pullUrl,
+    reviewRequestKey: result.reviewRequestKey,
   });
 }
 
@@ -2163,6 +2227,7 @@ async function requestTimedOutAutomatedReview({
       headSha,
       failureKind: "unavailable",
       targetUrl: result.targetUrl ?? pullUrl,
+      reviewRequestKey: result.reviewRequestKey,
     });
     throw error;
   }
@@ -3076,6 +3141,16 @@ function automatedReviewRequestIneligibility(response, headSha) {
   return undefined;
 }
 
+function pullSnapshotAdvanced(snapshotUpdatedAt, response) {
+  if (typeof snapshotUpdatedAt !== "string") return false;
+  const snapshot = Date.parse(snapshotUpdatedAt);
+  const current = Date.parse(response?.data?.updated_at ?? "");
+  if (!Number.isFinite(snapshot) || !Number.isFinite(current)) {
+    throw new Error("Could not verify the pull request lifecycle snapshot");
+  }
+  return current > snapshot;
+}
+
 async function revalidateAutomatedReviewRequest({
   github,
   owner,
@@ -3088,6 +3163,7 @@ async function revalidateAutomatedReviewRequest({
   reviewEpochNotAfter,
   reviewEpochRunKey,
   validateRequestEpoch,
+  pullSnapshotUpdatedAt,
   marker,
 }) {
   const common = { owner, repo };
@@ -3144,6 +3220,10 @@ async function revalidateAutomatedReviewRequest({
   if (ineligibility) {
     return { requested: false, marker, reason: ineligibility };
   }
+  if (
+    validateRequestEpoch &&
+    pullSnapshotAdvanced(pullSnapshotUpdatedAt, refreshed)
+  ) return { requested: false, marker, reason: "stale-epoch" };
   if (hasReviewRequest(comments, headSha, effectiveRequestKey)) {
     return { requested: false, marker };
   }
@@ -3282,6 +3362,7 @@ export async function requestAutomatedReview({
       reviewEpochNotAfter,
       reviewEpochRunKey,
       validateRequestEpoch: shouldValidateRequestEpoch,
+      pullSnapshotUpdatedAt: response?.data?.updated_at,
       marker,
     });
     if (result) return result;

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -1601,6 +1601,7 @@ function latestReviewPropagationRetryStatus(
     }
     if (
       createdAt === boundary.time &&
+      failureKind !== "unavailable" &&
       !terminalStatusHasBoundaryProof(
         status,
         comments,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -211,6 +211,21 @@ function hasReviewRequest(comments, headSha, requestKey) {
   });
 }
 
+function parseReviewEpochNotBefore(value) {
+  if (value === undefined) return undefined;
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) {
+    throw new TypeError("Review epoch timestamp is malformed");
+  }
+  return parsed;
+}
+
+function reviewEpochEventIdentity(epoch) {
+  return Number.isSafeInteger(epoch?.id) && epoch.id > 0
+    ? `-event-${epoch.id}`
+    : "";
+}
+
 function durableReviewRequestKey(
   events,
   requestKey,
@@ -219,12 +234,7 @@ function durableReviewRequestKey(
 ) {
   const eventKind = REVIEW_REQUEST_EVENT_KINDS.get(requestKey);
   if (eventKind === undefined) return requestKey;
-  const notBefore = reviewEpochNotBefore === undefined
-    ? undefined
-    : Date.parse(reviewEpochNotBefore);
-  if (notBefore !== undefined && !Number.isFinite(notBefore)) {
-    throw new Error("Review epoch timestamp is malformed");
-  }
+  const notBefore = parseReviewEpochNotBefore(reviewEpochNotBefore);
   const latestEpoch = latestReviewEpochChange(events);
   if (latestEpoch === undefined) {
     throw new Error("Could not resolve the current review epoch event");
@@ -243,7 +253,8 @@ function durableReviewRequestKey(
       typeof reviewEpochRunKey !== "string" ||
       !/^[1-9]\d*$/.test(reviewEpochRunKey)
     ) throw new Error("Review epoch run key is malformed");
-    return `${requestKey}-run-${reviewEpochRunKey}-at-${notBefore}`;
+    const eventIdentity = reviewEpochEventIdentity(latestEpoch);
+    return `${requestKey}-run-${reviewEpochRunKey}-at-${notBefore}${eventIdentity}`;
   }
   if (!Number.isSafeInteger(latestEpoch.id) || latestEpoch.id < 1) {
     throw new Error("Review epoch event identity is malformed");
@@ -285,14 +296,23 @@ function latestReviewEpochChange(events) {
   return latest;
 }
 
-function activeReviewBoundary(request, reviewNotBefore, epochChange) {
+function activeReviewBoundary(
+  request,
+  reviewNotBefore,
+  epochChange,
+  preferReviewNotBefore = false,
+) {
   // The issue event is GitHub's durable record of the review-epoch change. The
   // workflow writes its reset status later, so letting that timestamp replace
   // the event would reject valid evidence submitted between the two writes.
-  if (epochChange !== undefined) return epochChange;
   const boundary = reviewNotBefore === undefined
     ? undefined
     : { time: reviewNotBefore, kind: "status" };
+  // A run-bound reset exists only when the triggering event cannot be ordered
+  // safely. Keep its published status as the boundary until a later lifecycle
+  // event supersedes the run-bound status.
+  if (preferReviewNotBefore && boundary !== undefined) return boundary;
+  if (epochChange !== undefined) return epochChange;
   if (
     boundary?.kind === "status" &&
     request?.time === boundary.time
@@ -399,7 +419,7 @@ function isEvidenceProvablyLater(candidate, current, timeline) {
 function reviewResetDescription(pullNumber, baseBinding, requestKey) {
   const prefix = `PR#${pullNumber} reset base:${baseBinding}`;
   if (requestKey === undefined) return prefix;
-  const encodedKey = /^(?:base|ready|reopen)-run-[1-9]\d*-at-\d{13}$/.test(
+  const encodedKey = /^(?:base|ready|reopen)-run-[1-9]\d*-at-\d{13}(?:-event-[1-9]\d*)?$/.test(
       requestKey,
     )
     ? requestKey
@@ -457,7 +477,7 @@ function latestRunBoundReviewRequestKey(
       !isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN)
     ) continue;
     const requestKey = status.description.slice(prefix.length);
-    const runBound = /^(?:base|ready|reopen)-run-[1-9]\d*-at-(\d{13})$/
+    const runBound = /^(?:base|ready|reopen)-run-[1-9]\d*-at-(\d{13})(?:-event-([1-9]\d*))?$/
       .exec(requestKey);
     if (!runBound) continue;
     const epochTime = Number(runBound[1]);
@@ -465,7 +485,12 @@ function latestRunBoundReviewRequestKey(
     if (!Number.isFinite(createdAt)) continue;
     if (boundary !== undefined && createdAt < boundary.time) continue;
     if (latest === undefined || createdAt > latest.createdAt) {
-      latest = { requestKey, createdAt, epochTime };
+      latest = {
+        requestKey,
+        createdAt,
+        epochTime,
+        eventId: runBound[2] === undefined ? undefined : Number(runBound[2]),
+      };
     }
   }
   return latest;
@@ -718,6 +743,7 @@ export async function findAutomatedReview(
   resolveCommit = NO_COMMIT,
   isTrustedHuman = NO_TRUSTED_HUMAN,
   reviewNotBefore = /** @type {number | undefined} */ (undefined),
+  preferReviewNotBefore = false,
 ) {
   if (!FULL_SHA.test(headSha)) return undefined;
   const request = latestReviewRequest(comments, headSha);
@@ -729,6 +755,7 @@ export async function findAutomatedReview(
     request,
     validReviewNotBefore,
     latestReviewEpochChange(events),
+    preferReviewNotBefore,
   );
   const codexSuccesses = [];
   const codexFindings = [];
@@ -1316,6 +1343,7 @@ export async function publishAutomatedReviewStatus({
               pullAuthor,
             }),
           reviewNotBefore,
+          runBoundRequest !== undefined,
         );
         if (!review) {
           if (existingPropagationRetryStatus) {
@@ -1657,6 +1685,20 @@ function timedOutReviewTarget(pull, now, reviewTimeoutMs) {
   return { pullNumber, headSha: headSha.toLowerCase() };
 }
 
+function appendTimedOutReviewTargets(
+  targets,
+  pulls,
+  now,
+  reviewTimeoutMs,
+) {
+  for (const pull of pulls) {
+    const target = timedOutReviewTarget(pull, now, reviewTimeoutMs);
+    if (target) targets.push(target);
+    if (targets.length >= MAX_TIMEOUT_TARGETS_PER_RUN) return true;
+  }
+  return false;
+}
+
 export async function findTimedOutAutomatedReviews({
   github,
   owner,
@@ -1674,12 +1716,14 @@ export async function findTimedOutAutomatedReviews({
       cursor,
     });
     const pageResult = timeoutDiscoveryPage(response);
-    for (const pull of pageResult.nodes) {
-      const target = timedOutReviewTarget(pull, now, reviewTimeoutMs);
-      if (!target) continue;
-      targets.push(target);
-      if (targets.length >= MAX_TIMEOUT_TARGETS_PER_RUN) return targets;
-    }
+    if (
+      appendTimedOutReviewTargets(
+        targets,
+        pageResult.nodes,
+        now,
+        reviewTimeoutMs,
+      )
+    ) return targets;
     if (pageResult.cursor === undefined) return targets;
     cursor = pageResult.cursor;
   }
@@ -1934,6 +1978,167 @@ export async function completeReviewFailurePropagation({
   });
 }
 
+async function completeExpiredReviewFailure({
+  github,
+  owner,
+  repo,
+  pullNumber,
+  headSha,
+  pullUrl,
+  result,
+  retrying,
+}) {
+  const failureKind = reviewFailureKindFromDescription(
+    result.description,
+    pullNumber,
+    true,
+  );
+  if (failureKind === undefined || !isPositiveStatusId(result.statusId)) {
+    throw new Error("Review failure retry status is malformed");
+  }
+  const propagated = await propagateAndFinalizeReviewFailure({
+    github,
+    owner,
+    repo,
+    pullNumber,
+    headSha,
+    sourceStatusId: result.statusId,
+    failureKind,
+    targetUrl: result.targetUrl ?? pullUrl,
+  });
+  return {
+    ...result,
+    ...propagated,
+    expired: true,
+    retried: retrying,
+  };
+}
+
+async function preserveTimedOutQueueRetry({
+  github,
+  owner,
+  repo,
+  pullNumber,
+  headSha,
+  pullUrl,
+  result,
+  retryStatus,
+}) {
+  return publishReviewPropagationRetryStatus({
+    github,
+    owner,
+    repo,
+    pullNumber,
+    headSha,
+    failureKind: result.state === "success"
+      ? retryStatus?.failureKind ?? "unavailable"
+      : "unavailable",
+    targetUrl: typeof retryStatus?.status?.target_url === "string"
+      ? retryStatus.status.target_url
+      : result.targetUrl ?? pullUrl,
+  });
+}
+
+async function requestTimedOutAutomatedReview({
+  github,
+  owner,
+  repo,
+  pullNumber,
+  headSha,
+  pullUrl,
+  result,
+}) {
+  if (result.state !== "pending") return undefined;
+  try {
+    return await requestAutomatedReview({
+      github,
+      owner,
+      repo,
+      pullNumber,
+      headSha,
+      requestKey: result.reviewRequestKey,
+      reviewEpochNotAfter: Number.isFinite(result.reviewRequestEpochTime)
+        ? new Date(result.reviewRequestEpochTime).toISOString()
+        : undefined,
+      validateRequestEpoch: result.reviewRequestKey !== undefined,
+      revalidateReviewEvidence: true,
+    });
+  } catch (error) {
+    await publishReviewPropagationRetryStatus({
+      github,
+      owner,
+      repo,
+      pullNumber,
+      headSha,
+      failureKind: "unavailable",
+      targetUrl: result.targetUrl ?? pullUrl,
+    });
+    throw error;
+  }
+}
+
+async function reconcileTimedOutReviewQueue({
+  github,
+  owner,
+  repo,
+  pullNumber,
+  headSha,
+  pullUrl,
+  result,
+  retryStatus,
+}) {
+  const preserveQueueRetry = () =>
+    preserveTimedOutQueueRetry({
+      github,
+      owner,
+      repo,
+      pullNumber,
+      headSha,
+      pullUrl,
+      result,
+      retryStatus,
+    });
+  let queueResults;
+  try {
+    queueResults = await reconcileActiveMergeGroupReviewStatuses({
+      github,
+      owner,
+      repo,
+      pullNumber,
+      sourceHeadSha: headSha,
+      baseRef: result.baseRef,
+    });
+  } catch (error) {
+    await preserveQueueRetry();
+    throw error;
+  }
+  const queueFailures = queueResults.filter((entry) =>
+    entry?.state === "failure"
+  ).length;
+  if (result.state === "success" && queueFailures > 0) {
+    await preserveQueueRetry();
+    throw new Error(
+      `${queueFailures} active merge queue review failed`,
+    );
+  }
+  const reviewRequest = await requestTimedOutAutomatedReview({
+    github,
+    owner,
+    repo,
+    pullNumber,
+    headSha,
+    pullUrl,
+    result,
+  });
+  return {
+    ...result,
+    expired: false,
+    reason: result.state === "success" ? "reviewed" : "revalidated",
+    queueResults,
+    reviewRequest,
+  };
+}
+
 /** Revalidate one discovered timeout and publish under the per-pull lock. */
 export async function expireTimedOutAutomatedReview({
   github,
@@ -2005,105 +2210,28 @@ export async function expireTimedOutAutomatedReview({
     queuePropagationPending: true,
   });
   if (result.state === "failure") {
-    const failureKind = reviewFailureKindFromDescription(
-      result.description,
-      pullNumber,
-      true,
-    );
-    if (failureKind === undefined || !isPositiveStatusId(result.statusId)) {
-      throw new Error("Review failure retry status is malformed");
-    }
-    const propagated = await propagateAndFinalizeReviewFailure({
+    return completeExpiredReviewFailure({
       github,
       owner,
       repo,
       pullNumber,
       headSha,
-      sourceStatusId: result.statusId,
-      failureKind,
-      targetUrl: result.targetUrl ?? pullUrl,
+      pullUrl,
+      result,
+      retrying,
     });
-    return {
-      ...result,
-      ...propagated,
-      expired: true,
-      retried: retrying,
-    };
   }
   if (typeof result.baseRef === "string") {
-    const preserveQueueRetry = () =>
-      publishReviewPropagationRetryStatus({
-        github,
-        owner,
-        repo,
-        pullNumber,
-        headSha,
-        failureKind: result.state === "success"
-          ? retryStatus?.failureKind ?? "unavailable"
-          : "unavailable",
-        targetUrl: typeof retryStatus?.status?.target_url === "string"
-          ? retryStatus.status.target_url
-          : result.targetUrl ?? pullUrl,
-      });
-    let queueResults;
-    try {
-      queueResults = await reconcileActiveMergeGroupReviewStatuses({
-        github,
-        owner,
-        repo,
-        pullNumber,
-        sourceHeadSha: headSha,
-        baseRef: result.baseRef,
-      });
-    } catch (error) {
-      await preserveQueueRetry();
-      throw error;
-    }
-    const queueFailures = queueResults.filter((entry) =>
-      entry?.state === "failure"
-    ).length;
-    if (result.state === "success" && queueFailures > 0) {
-      await preserveQueueRetry();
-      throw new Error(
-        `${queueFailures} active merge queue review failed`,
-      );
-    }
-    let reviewRequest;
-    if (result.state === "pending") {
-      try {
-        reviewRequest = await requestAutomatedReview({
-          github,
-          owner,
-          repo,
-          pullNumber,
-          headSha,
-          requestKey: result.reviewRequestKey,
-          reviewEpochNotAfter: Number.isFinite(result.reviewRequestEpochTime)
-            ? new Date(result.reviewRequestEpochTime).toISOString()
-            : undefined,
-          validateRequestEpoch: result.reviewRequestKey !== undefined,
-          revalidateReviewEvidence: true,
-        });
-      } catch (error) {
-        await publishReviewPropagationRetryStatus({
-          github,
-          owner,
-          repo,
-          pullNumber,
-          headSha,
-          failureKind: "unavailable",
-          targetUrl: result.targetUrl ?? pullUrl,
-        });
-        throw error;
-      }
-    }
-    return {
-      ...result,
-      expired: false,
-      reason: result.state === "success" ? "reviewed" : "revalidated",
-      queueResults,
-      reviewRequest,
-    };
+    return reconcileTimedOutReviewQueue({
+      github,
+      owner,
+      repo,
+      pullNumber,
+      headSha,
+      pullUrl,
+      result,
+      retryStatus,
+    });
   }
   return { ...result, expired: false, reason: "revalidated" };
 }
@@ -2789,6 +2917,170 @@ export async function reconcileActiveMergeGroupReviewStatuses({
   return results;
 }
 
+function requireAutomatedReviewRequestInputs(headSha, requestKey) {
+  if (typeof headSha !== "string" || !FULL_SHA.test(headSha)) {
+    throw new TypeError(
+      "Refusing to request an automated review of a malformed head commit",
+    );
+  }
+  if (
+    requestKey !== undefined &&
+    (typeof requestKey !== "string" || !REQUEST_KEY.test(requestKey))
+  ) {
+    throw new TypeError("Refusing to use a malformed review request key");
+  }
+}
+
+function resolveAutomatedReviewRequestEpochKey(
+  events,
+  requestKey,
+  reviewEpochNotBefore,
+  reviewEpochNotAfter,
+  reviewEpochRunKey,
+) {
+  if (REVIEW_REQUEST_EVENT_KINDS.has(requestKey)) {
+    return durableReviewRequestKey(
+      events,
+      requestKey,
+      reviewEpochNotBefore,
+      reviewEpochRunKey,
+    );
+  }
+  const runBoundEpoch = typeof requestKey === "string"
+    ? /^(base|ready|reopen)-run-([1-9]\d*)-at-(\d{13})(?:-event-([1-9]\d*))?$/
+      .exec(requestKey)
+    : null;
+  if (runBoundEpoch) {
+    const notAfter = Date.parse(reviewEpochNotAfter ?? "");
+    if (!Number.isFinite(notAfter) || notAfter !== Number(runBoundEpoch[3])) {
+      throw new TypeError("Run-bound review epoch timestamp is malformed");
+    }
+    const latestEpoch = latestReviewEpochChange(events);
+    const pinnedEventId = runBoundEpoch[4] === undefined
+      ? undefined
+      : Number(runBoundEpoch[4]);
+    const expectedKind = REVIEW_REQUEST_EVENT_KINDS.get(runBoundEpoch[1]);
+    return latestEpoch?.time === notAfter &&
+        latestEpoch.kind === expectedKind &&
+        latestEpoch.id === pinnedEventId
+      ? requestKey
+      : undefined;
+  }
+  const concreteEpoch = typeof requestKey === "string"
+    ? /^(base|ready|reopen)-([1-9]\d*)$/.exec(requestKey)
+    : null;
+  if (!concreteEpoch) {
+    throw new TypeError("Concrete review epoch key is malformed");
+  }
+  return durableReviewRequestKey(events, concreteEpoch[1]);
+}
+
+function automatedReviewRequestIneligibility(response, headSha) {
+  const currentHeadSha = response?.data?.head?.sha;
+  if (
+    typeof currentHeadSha !== "string" ||
+    !FULL_SHA.test(currentHeadSha)
+  ) {
+    throw new Error("Could not verify the current pull request head commit");
+  }
+  if (currentHeadSha.toLowerCase() !== headSha.toLowerCase()) {
+    return "stale-head";
+  }
+  if (response?.data?.state !== "open" || response?.data?.draft !== false) {
+    return "ineligible-pull";
+  }
+  return undefined;
+}
+
+async function revalidateAutomatedReviewRequest({
+  github,
+  owner,
+  repo,
+  pullNumber,
+  headSha,
+  requestKey,
+  effectiveRequestKey,
+  reviewEpochNotBefore,
+  reviewEpochNotAfter,
+  reviewEpochRunKey,
+  validateRequestEpoch,
+  marker,
+}) {
+  const common = { owner, repo };
+  const [reviews, comments, events, statuses, timeline] = await Promise.all([
+    collectAll(
+      github,
+      github.rest.pulls.listReviews,
+      { ...common, pull_number: pullNumber },
+      "final request reviews",
+    ),
+    collectAll(
+      github,
+      github.rest.issues.listComments,
+      { ...common, issue_number: pullNumber },
+      "final request comments",
+    ),
+    collectAll(
+      github,
+      github.rest.issues.listEvents,
+      { ...common, issue_number: pullNumber },
+      "final request events",
+    ),
+    collectAll(
+      github,
+      github.rest.repos.listCommitStatusesForRef,
+      { ...common, ref: headSha },
+      "final request statuses",
+    ),
+    collectAll(
+      github,
+      github.rest.issues.listEventsForTimeline,
+      { ...common, issue_number: pullNumber },
+      "final request timeline",
+    ),
+  ]);
+  if (validateRequestEpoch) {
+    const currentKey = resolveAutomatedReviewRequestEpochKey(
+      events,
+      requestKey,
+      reviewEpochNotBefore,
+      reviewEpochNotAfter,
+      reviewEpochRunKey,
+    );
+    if (currentKey !== effectiveRequestKey) {
+      return { requested: false, marker, reason: "stale-epoch" };
+    }
+  }
+  const refreshed = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: pullNumber,
+  });
+  const ineligibility = automatedReviewRequestIneligibility(refreshed, headSha);
+  if (ineligibility) {
+    return { requested: false, marker, reason: ineligibility };
+  }
+  if (hasReviewRequest(comments, headSha, effectiveRequestKey)) {
+    return { requested: false, marker };
+  }
+  const baseBinding = pullRequestBaseBinding(refreshed?.data);
+  const review = await findAutomatedReview(
+    { reviews, comments, events, timeline },
+    headSha,
+    (ref) => resolveCommitRef(github, common, ref),
+    (login) =>
+      isCurrentlyTrustedHuman(github, {
+        ...common,
+        login,
+        pullAuthor: refreshed?.data?.user?.login,
+      }),
+    latestReviewResetTime(statuses, pullNumber, baseBinding),
+  );
+  return review
+    ? { requested: false, marker, reason: "reviewed" }
+    : undefined;
+}
+
 /**
  * Ask Codex to review the current head commit, at most once per commit.
  *
@@ -2826,61 +3118,24 @@ export async function requestAutomatedReview({
   // The comment body must stay a fixed instruction plus a verified commit
   // SHA. Never interpolate pull request controlled content here: this runs
   // with pull_request_target authority.
-  if (typeof headSha !== "string" || !FULL_SHA.test(headSha)) {
-    throw new Error(
-      "Refusing to request an automated review of a malformed head commit",
-    );
-  }
-  if (
-    requestKey !== undefined &&
-    (typeof requestKey !== "string" || !REQUEST_KEY.test(requestKey))
-  ) {
-    throw new Error("Refusing to use a malformed review request key");
-  }
+  requireAutomatedReviewRequestInputs(headSha, requestKey);
   let effectiveRequestKey = requestKey;
-  const concreteEpoch = typeof requestKey === "string"
-    ? /^(base|ready|reopen)-([1-9]\d*)$/.exec(requestKey)
-    : null;
-  const runBoundEpoch = typeof requestKey === "string"
-    ? /^(base|ready|reopen)-run-([1-9]\d*)-at-(\d{13})$/.exec(
-      requestKey,
-    )
-    : null;
   const sentinelEpoch = REVIEW_REQUEST_EVENT_KINDS.has(requestKey);
-  const resolveEpochKey = (events) => {
-    if (sentinelEpoch) {
-      return durableReviewRequestKey(
-        events,
-        requestKey,
-        reviewEpochNotBefore,
-        reviewEpochRunKey,
-      );
-    }
-    if (runBoundEpoch) {
-      const notAfter = Date.parse(reviewEpochNotAfter ?? "");
-      if (
-        !Number.isFinite(notAfter) || notAfter !== Number(runBoundEpoch[3])
-      ) {
-        throw new Error("Run-bound review epoch timestamp is malformed");
-      }
-      const latestEpoch = latestReviewEpochChange(events);
-      return latestEpoch === undefined || latestEpoch.time <= notAfter
-        ? requestKey
-        : undefined;
-    }
-    if (!concreteEpoch) {
-      throw new Error("Concrete review epoch key is malformed");
-    }
-    return durableReviewRequestKey(events, concreteEpoch[1]);
-  };
-  if (sentinelEpoch || validateRequestEpoch) {
+  const shouldValidateRequestEpoch = sentinelEpoch || validateRequestEpoch;
+  if (shouldValidateRequestEpoch) {
     const events = await collectAll(
       github,
       github.rest.issues.listEvents,
       { owner, repo, issue_number: pullNumber },
       "review epoch events",
     );
-    effectiveRequestKey = resolveEpochKey(events);
+    effectiveRequestKey = resolveAutomatedReviewRequestEpochKey(
+      events,
+      requestKey,
+      reviewEpochNotBefore,
+      reviewEpochNotAfter,
+      reviewEpochRunKey,
+    );
     if (effectiveRequestKey === undefined) {
       return { requested: false, reason: "stale-epoch" };
     }
@@ -2907,103 +3162,44 @@ export async function requestAutomatedReview({
     repo,
     pull_number: pullNumber,
   });
-  const currentHeadSha = response?.data?.head?.sha;
-  if (
-    typeof currentHeadSha !== "string" ||
-    !FULL_SHA.test(currentHeadSha)
-  ) {
-    throw new Error("Could not verify the current pull request head commit");
+  const ineligibility = automatedReviewRequestIneligibility(response, headSha);
+  if (ineligibility) {
+    return { requested: false, marker, reason: ineligibility };
   }
-  if (currentHeadSha.toLowerCase() !== headSha.toLowerCase()) {
-    return { requested: false, marker, reason: "stale-head" };
-  }
-  if (response?.data?.state !== "open" || response?.data?.draft !== false) {
-    return { requested: false, marker, reason: "ineligible-pull" };
-  }
-  if (
-    sentinelEpoch || validateRequestEpoch
-  ) {
+  if (shouldValidateRequestEpoch) {
     const events = await collectAll(
       github,
       github.rest.issues.listEvents,
       { owner, repo, issue_number: pullNumber },
       "final review epoch events",
     );
-    const currentKey = resolveEpochKey(events);
+    const currentKey = resolveAutomatedReviewRequestEpochKey(
+      events,
+      requestKey,
+      reviewEpochNotBefore,
+      reviewEpochNotAfter,
+      reviewEpochRunKey,
+    );
     if (currentKey !== effectiveRequestKey) {
       return { requested: false, marker, reason: "stale-epoch" };
     }
   }
   if (revalidateReviewEvidence) {
-    const common = { owner, repo };
-    const [reviews, comments, events, statuses, timeline] = await Promise.all([
-      collectAll(
-        github,
-        github.rest.pulls.listReviews,
-        { ...common, pull_number: pullNumber },
-        "final request reviews",
-      ),
-      collectAll(
-        github,
-        github.rest.issues.listComments,
-        { ...common, issue_number: pullNumber },
-        "final request comments",
-      ),
-      collectAll(
-        github,
-        github.rest.issues.listEvents,
-        { ...common, issue_number: pullNumber },
-        "final request events",
-      ),
-      collectAll(
-        github,
-        github.rest.repos.listCommitStatusesForRef,
-        { ...common, ref: headSha },
-        "final request statuses",
-      ),
-      collectAll(
-        github,
-        github.rest.issues.listEventsForTimeline,
-        { ...common, issue_number: pullNumber },
-        "final request timeline",
-      ),
-    ]);
-    if (sentinelEpoch || validateRequestEpoch) {
-      const currentKey = resolveEpochKey(events);
-      if (currentKey !== effectiveRequestKey) {
-        return { requested: false, marker, reason: "stale-epoch" };
-      }
-    }
-    const refreshed = await github.rest.pulls.get({
+    const result = await revalidateAutomatedReviewRequest({
+      github,
       owner,
       repo,
-      pull_number: pullNumber,
-    });
-    const refreshedHead = refreshed?.data?.head?.sha;
-    if (
-      typeof refreshedHead !== "string" || !FULL_SHA.test(refreshedHead) ||
-      refreshedHead.toLowerCase() !== headSha.toLowerCase()
-    ) return { requested: false, marker, reason: "stale-head" };
-    if (refreshed?.data?.state !== "open" || refreshed?.data?.draft !== false) {
-      return { requested: false, marker, reason: "ineligible-pull" };
-    }
-    if (hasReviewRequest(comments, headSha, effectiveRequestKey)) {
-      return { requested: false, marker };
-    }
-    const baseBinding = pullRequestBaseBinding(refreshed?.data);
-    const review = await findAutomatedReview(
-      { reviews, comments, events, timeline },
+      pullNumber,
       headSha,
-      (ref) => resolveCommitRef(github, common, ref),
-      (login) =>
-        isCurrentlyTrustedHuman(github, {
-          ...common,
-          login,
-          pullAuthor: refreshed?.data?.user?.login,
-        }),
-      latestReviewResetTime(statuses, pullNumber, baseBinding),
-    );
-    if (review) return { requested: false, marker, reason: "reviewed" };
+      requestKey,
+      effectiveRequestKey,
+      reviewEpochNotBefore,
+      reviewEpochNotAfter,
+      reviewEpochRunKey,
+      validateRequestEpoch: shouldValidateRequestEpoch,
+      marker,
+    });
+    if (result) return result;
   }
   await github.rest.issues.createComment({
     owner,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -2968,10 +2968,29 @@ export async function requestAutomatedReview({
         "final request timeline",
       ),
     ]);
+    if (sentinelEpoch || validateRequestEpoch) {
+      const currentKey = resolveEpochKey(events);
+      if (currentKey !== effectiveRequestKey) {
+        return { requested: false, marker, reason: "stale-epoch" };
+      }
+    }
+    const refreshed = await github.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: pullNumber,
+    });
+    const refreshedHead = refreshed?.data?.head?.sha;
+    if (
+      typeof refreshedHead !== "string" || !FULL_SHA.test(refreshedHead) ||
+      refreshedHead.toLowerCase() !== headSha.toLowerCase()
+    ) return { requested: false, marker, reason: "stale-head" };
+    if (refreshed?.data?.state !== "open" || refreshed?.data?.draft !== false) {
+      return { requested: false, marker, reason: "ineligible-pull" };
+    }
     if (hasReviewRequest(comments, headSha, effectiveRequestKey)) {
       return { requested: false, marker };
     }
-    const baseBinding = pullRequestBaseBinding(response?.data);
+    const baseBinding = pullRequestBaseBinding(refreshed?.data);
     const review = await findAutomatedReview(
       { reviews, comments, events, timeline },
       headSha,
@@ -2980,7 +2999,7 @@ export async function requestAutomatedReview({
         isCurrentlyTrustedHuman(github, {
           ...common,
           login,
-          pullAuthor: response?.data?.user?.login,
+          pullAuthor: refreshed?.data?.user?.login,
         }),
       latestReviewResetTime(statuses, pullNumber, baseBinding),
     );

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -232,6 +232,12 @@ function durableReviewRequestKey(
   if (notBefore !== undefined && latestEpoch.time < notBefore) {
     throw new Error("The current review epoch event is not visible");
   }
+  if (latestEpoch.kind !== eventKind) {
+    if (notBefore !== undefined && latestEpoch.time === notBefore) {
+      throw new Error("The current review epoch event is not visible");
+    }
+    return undefined;
+  }
   if (notBefore !== undefined && latestEpoch.time === notBefore) {
     if (
       typeof reviewEpochRunKey !== "string" ||
@@ -239,7 +245,6 @@ function durableReviewRequestKey(
     ) throw new Error("Review epoch run key is malformed");
     return `${requestKey}-run-${reviewEpochRunKey}`;
   }
-  if (latestEpoch.kind !== eventKind) return undefined;
   if (!Number.isSafeInteger(latestEpoch.id) || latestEpoch.id < 1) {
     throw new Error("Review epoch event identity is malformed");
   }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -243,7 +243,7 @@ function durableReviewRequestKey(
       typeof reviewEpochRunKey !== "string" ||
       !/^[1-9]\d*$/.test(reviewEpochRunKey)
     ) throw new Error("Review epoch run key is malformed");
-    return `${requestKey}-run-${reviewEpochRunKey}`;
+    return `${requestKey}-run-${reviewEpochRunKey}-at-${notBefore}`;
   }
   if (!Number.isSafeInteger(latestEpoch.id) || latestEpoch.id < 1) {
     throw new Error("Review epoch event identity is malformed");
@@ -399,7 +399,9 @@ function isEvidenceProvablyLater(candidate, current, timeline) {
 function reviewResetDescription(pullNumber, baseBinding, requestKey) {
   const prefix = `PR#${pullNumber} reset base:${baseBinding}`;
   if (requestKey === undefined) return prefix;
-  const encodedKey = /^(?:base|ready|reopen)-run-[1-9]\d*$/.test(requestKey)
+  const encodedKey = /^(?:base|ready|reopen)-run-[1-9]\d*-at-\d{13}$/.test(
+      requestKey,
+    )
     ? requestKey
     : createHash("sha256").update(requestKey).digest("hex").slice(0, 12);
   return `${prefix} key:${encodedKey}`;
@@ -455,12 +457,15 @@ function latestRunBoundReviewRequestKey(
       !isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN)
     ) continue;
     const requestKey = status.description.slice(prefix.length);
-    if (!/^(?:base|ready|reopen)-run-[1-9]\d*$/.test(requestKey)) continue;
+    const runBound = /^(?:base|ready|reopen)-run-[1-9]\d*-at-(\d{13})$/
+      .exec(requestKey);
+    if (!runBound) continue;
+    const epochTime = Number(runBound[1]);
     const createdAt = Date.parse(status?.created_at ?? "");
     if (!Number.isFinite(createdAt)) continue;
     if (boundary !== undefined && createdAt < boundary.time) continue;
     if (latest === undefined || createdAt > latest.createdAt) {
-      latest = { requestKey, createdAt };
+      latest = { requestKey, createdAt, epochTime };
     }
   }
   return latest;
@@ -1259,7 +1264,7 @@ export async function publishAutomatedReviewStatus({
       reviewRequestKey = effectiveReviewResetKey ??
         runBoundRequest?.requestKey ??
         reviewRequestKeyFromBoundary(reviewBoundary);
-      reviewRequestEpochTime = runBoundRequest?.createdAt;
+      reviewRequestEpochTime = runBoundRequest?.epochTime;
       if (
         !pendingStatusBelongsToReviewEpoch(
           existingPendingStatus,
@@ -2077,6 +2082,7 @@ export async function expireTimedOutAutomatedReview({
             ? new Date(result.reviewRequestEpochTime).toISOString()
             : undefined,
           validateRequestEpoch: result.reviewRequestKey !== undefined,
+          revalidateReviewEvidence: true,
         });
       } catch (error) {
         await publishReviewPropagationRetryStatus({
@@ -2815,6 +2821,7 @@ export async function requestAutomatedReview({
   reviewEpochNotAfter = /** @type {string | undefined} */ (undefined),
   reviewEpochRunKey = /** @type {string | undefined} */ (undefined),
   validateRequestEpoch = false,
+  revalidateReviewEvidence = false,
 }) {
   // The comment body must stay a fixed instruction plus a verified commit
   // SHA. Never interpolate pull request controlled content here: this runs
@@ -2835,7 +2842,9 @@ export async function requestAutomatedReview({
     ? /^(base|ready|reopen)-([1-9]\d*)$/.exec(requestKey)
     : null;
   const runBoundEpoch = typeof requestKey === "string"
-    ? /^(base|ready|reopen)-run-([1-9]\d*)$/.exec(requestKey)
+    ? /^(base|ready|reopen)-run-([1-9]\d*)-at-(\d{13})$/.exec(
+      requestKey,
+    )
     : null;
   const sentinelEpoch = REVIEW_REQUEST_EVENT_KINDS.has(requestKey);
   const resolveEpochKey = (events) => {
@@ -2849,7 +2858,9 @@ export async function requestAutomatedReview({
     }
     if (runBoundEpoch) {
       const notAfter = Date.parse(reviewEpochNotAfter ?? "");
-      if (!Number.isFinite(notAfter)) {
+      if (
+        !Number.isFinite(notAfter) || notAfter !== Number(runBoundEpoch[3])
+      ) {
         throw new Error("Run-bound review epoch timestamp is malformed");
       }
       const latestEpoch = latestReviewEpochChange(events);
@@ -2922,6 +2933,58 @@ export async function requestAutomatedReview({
     if (currentKey !== effectiveRequestKey) {
       return { requested: false, marker, reason: "stale-epoch" };
     }
+  }
+  if (revalidateReviewEvidence) {
+    const common = { owner, repo };
+    const [reviews, comments, events, statuses, timeline] = await Promise.all([
+      collectAll(
+        github,
+        github.rest.pulls.listReviews,
+        { ...common, pull_number: pullNumber },
+        "final request reviews",
+      ),
+      collectAll(
+        github,
+        github.rest.issues.listComments,
+        { ...common, issue_number: pullNumber },
+        "final request comments",
+      ),
+      collectAll(
+        github,
+        github.rest.issues.listEvents,
+        { ...common, issue_number: pullNumber },
+        "final request events",
+      ),
+      collectAll(
+        github,
+        github.rest.repos.listCommitStatusesForRef,
+        { ...common, ref: headSha },
+        "final request statuses",
+      ),
+      collectAll(
+        github,
+        github.rest.issues.listEventsForTimeline,
+        { ...common, issue_number: pullNumber },
+        "final request timeline",
+      ),
+    ]);
+    if (hasReviewRequest(comments, headSha, effectiveRequestKey)) {
+      return { requested: false, marker };
+    }
+    const baseBinding = pullRequestBaseBinding(response?.data);
+    const review = await findAutomatedReview(
+      { reviews, comments, events, timeline },
+      headSha,
+      (ref) => resolveCommitRef(github, common, ref),
+      (login) =>
+        isCurrentlyTrustedHuman(github, {
+          ...common,
+          login,
+          pullAuthor: response?.data?.user?.login,
+        }),
+      latestReviewResetTime(statuses, pullNumber, baseBinding),
+    );
+    if (review) return { requested: false, marker, reason: "reviewed" };
   }
   await github.rest.issues.createComment({
     owner,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -209,7 +209,12 @@ function hasReviewRequest(comments, headSha, requestKey) {
   });
 }
 
-function durableReviewRequestKey(events, requestKey, reviewEpochNotBefore) {
+function durableReviewRequestKey(
+  events,
+  requestKey,
+  reviewEpochNotBefore,
+  reviewEpochRunKey,
+) {
   const eventKind = REVIEW_REQUEST_EVENT_KINDS.get(requestKey);
   if (eventKind === undefined) return requestKey;
   const notBefore = reviewEpochNotBefore === undefined
@@ -225,21 +230,18 @@ function durableReviewRequestKey(events, requestKey, reviewEpochNotBefore) {
   if (notBefore !== undefined && latestEpoch.time < notBefore) {
     throw new Error("The current review epoch event is not visible");
   }
+  if (notBefore !== undefined && latestEpoch.time === notBefore) {
+    if (
+      typeof reviewEpochRunKey !== "string" ||
+      !/^[1-9]\d*$/.test(reviewEpochRunKey)
+    ) throw new Error("Review epoch run key is malformed");
+    return `${requestKey}-run-${reviewEpochRunKey}`;
+  }
   if (latestEpoch.kind !== eventKind) return undefined;
   if (!Number.isSafeInteger(latestEpoch.id) || latestEpoch.id < 1) {
     throw new Error("Review epoch event identity is malformed");
   }
   return `${requestKey}-${latestEpoch.id}`;
-}
-
-function reviewEpochTiesTrigger(events, requestKey, reviewEpochNotBefore) {
-  const eventKind = REVIEW_REQUEST_EVENT_KINDS.get(requestKey);
-  if (eventKind === undefined || reviewEpochNotBefore === undefined) {
-    return false;
-  }
-  const latestEpoch = latestReviewEpochChange(events);
-  return latestEpoch?.kind === eventKind &&
-    latestEpoch.time === Date.parse(reviewEpochNotBefore);
 }
 
 function timelinePosition(timeline, event, id) {
@@ -1073,7 +1075,7 @@ export async function publishAutomatedReviewStatus({
   reviewTimeoutMs = /** @type {number | undefined} */ (undefined),
   queuePropagationPending = false,
   reviewEpochNotBefore = /** @type {string | undefined} */ (undefined),
-  reviewEpochRunAttempt = /** @type {number | undefined} */ (undefined),
+  reviewEpochRunKey = /** @type {string | undefined} */ (undefined),
 }) {
   let review;
   let failure;
@@ -1113,11 +1115,6 @@ export async function publishAutomatedReviewStatus({
     failure = new Error("Review timeout is invalid");
   } else if (!FULL_SHA.test(headSha)) {
     failure = new Error("Captured head is malformed");
-  } else if (
-    reviewEpochRunAttempt !== undefined &&
-    (!Number.isSafeInteger(reviewEpochRunAttempt) || reviewEpochRunAttempt < 1)
-  ) {
-    failure = new Error("Review epoch run attempt is invalid");
   } else {
     try {
       const current = await github.rest.pulls.get({
@@ -1179,6 +1176,7 @@ export async function publishAutomatedReviewStatus({
         events,
         reviewResetKey,
         reviewEpochNotBefore,
+        reviewEpochRunKey,
       );
       const resetRequested = effectiveReviewResetKey !== undefined &&
         hasReviewRequest(comments, headSha, effectiveReviewResetKey);
@@ -1189,17 +1187,6 @@ export async function publishAutomatedReviewStatus({
           baseBinding,
           effectiveReviewResetKey,
         );
-      if (
-        reviewEpochRunAttempt === 1 &&
-        (resetRequested || resetPublished) &&
-        reviewEpochTiesTrigger(
-          events,
-          reviewResetKey,
-          reviewEpochNotBefore,
-        )
-      ) {
-        throw new Error("The triggering review epoch event is not visible");
-      }
       resetPending = effectiveReviewResetKey !== undefined &&
         !resetRequested && !resetPublished;
       existingPendingStatus = latestPendingReviewStatus(
@@ -2738,6 +2725,7 @@ export async function requestAutomatedReview({
   headSha,
   requestKey = /** @type {string | undefined} */ (undefined),
   reviewEpochNotBefore = /** @type {string | undefined} */ (undefined),
+  reviewEpochRunKey = /** @type {string | undefined} */ (undefined),
   validateRequestEpoch = false,
 }) {
   // The comment body must stay a fixed instruction plus a verified commit
@@ -2773,6 +2761,7 @@ export async function requestAutomatedReview({
         events,
         requestKey,
         reviewEpochNotBefore,
+        reviewEpochRunKey,
       );
     } else {
       if (!concreteEpoch) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -393,11 +393,11 @@ function isEvidenceProvablyLater(candidate, current, timeline) {
 
 function reviewResetDescription(pullNumber, baseBinding, requestKey) {
   const prefix = `PR#${pullNumber} reset base:${baseBinding}`;
-  return requestKey === undefined
-    ? prefix
-    : `${prefix} key:${
-      createHash("sha256").update(requestKey).digest("hex").slice(0, 12)
-    }`;
+  if (requestKey === undefined) return prefix;
+  const encodedKey = /^(?:base|ready|reopen)-run-[1-9]\d*$/.test(requestKey)
+    ? requestKey
+    : createHash("sha256").update(requestKey).digest("hex").slice(0, 12);
+  return `${prefix} key:${encodedKey}`;
 }
 
 function hasReviewReset(statuses, pullNumber, baseBinding, requestKey) {
@@ -431,6 +431,34 @@ function latestReviewResetTime(statuses, pullNumber, baseBinding) {
     if (latest === undefined || createdAt > latest) latest = createdAt;
   }
   return latest;
+}
+
+function latestRunBoundReviewRequestKey(
+  statuses,
+  pullNumber,
+  baseBinding,
+  boundary,
+) {
+  const prefix = `${reviewResetDescription(pullNumber, baseBinding)} key:`;
+  let latest;
+  for (const status of statuses) {
+    if (
+      status?.context !== AUTOMATED_REVIEW_STATUS_CONTEXT ||
+      status?.state !== "pending" ||
+      typeof status?.description !== "string" ||
+      !status.description.startsWith(prefix) ||
+      !isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN)
+    ) continue;
+    const requestKey = status.description.slice(prefix.length);
+    if (!/^(?:base|ready|reopen)-run-[1-9]\d*$/.test(requestKey)) continue;
+    const createdAt = Date.parse(status?.created_at ?? "");
+    if (!Number.isFinite(createdAt)) continue;
+    if (boundary !== undefined && createdAt < boundary.time) continue;
+    if (latest === undefined || createdAt > latest.createdAt) {
+      latest = { requestKey, createdAt };
+    }
+  }
+  return latest?.requestKey;
 }
 
 function latestPendingReviewStatus(statuses, pullNumber) {
@@ -1217,7 +1245,12 @@ export async function publishAutomatedReviewStatus({
         latestReviewEpochChange(events),
       );
       reviewRequestKey = effectiveReviewResetKey ??
-        reviewRequestKeyFromBoundary(reviewBoundary);
+        latestRunBoundReviewRequestKey(
+          statuses,
+          pullNumber,
+          baseBinding,
+          reviewBoundary,
+        ) ?? reviewRequestKeyFromBoundary(reviewBoundary);
       if (
         !pendingStatusBelongsToReviewEpoch(
           existingPendingStatus,
@@ -2027,9 +2060,10 @@ export async function expireTimedOutAutomatedReview({
           owner,
           repo,
           pullNumber,
-          headSha,
-          requestKey: result.reviewRequestKey,
-          validateRequestEpoch: result.reviewRequestKey !== undefined,
+        headSha,
+        requestKey: result.reviewRequestKey,
+        validateRequestEpoch: result.reviewRequestKey !== undefined &&
+          !/-run-/.test(result.reviewRequestKey),
         });
       } catch (error) {
         await publishReviewPropagationRetryStatus({

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -312,7 +312,10 @@ function durableReviewRequestKey(
       !/^[1-9]\d*$/.test(reviewEpochRunKey)
     ) throw new Error("Review epoch run key is malformed");
     const eventIdentity = reviewEpochEventIdentity(latestEpoch);
-    const compactRunKey = BigInt(reviewEpochRunKey).toString(36);
+    const compactRunKey = Number.isSafeInteger(latestEpoch.id) &&
+        latestEpoch.id > 0
+      ? latestEpoch.id.toString(36)
+      : BigInt(reviewEpochRunKey).toString(36);
     return `${requestKey}-r-${compactRunKey}-t-${notBefore.toString(36)}${eventIdentity}`;
   }
   if (!Number.isSafeInteger(latestEpoch.id) || latestEpoch.id < 1) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -1235,9 +1235,13 @@ export async function publishAutomatedReviewStatus({
       existingPropagationRetryKind = propagationRetry?.failureKind;
       existingPropagationRetryIsLatest = propagationRetry?.status?.id ===
         latestReviewGateStatusForPull(statuses, pullNumber)?.id;
+      const runBoundResetPending = resetPending &&
+        /^(?:base|reopen)-run-/.test(effectiveReviewResetKey ?? "");
       if (
         !isDraft &&
-        (!resetPending || REVIEW_EPOCH_EVENTS.has(reviewBoundary?.kind))
+        (!resetPending ||
+          (!runBoundResetPending &&
+            REVIEW_EPOCH_EVENTS.has(reviewBoundary?.kind)))
       ) {
         review = await findAutomatedReview(
           { reviews, comments, events, timeline },

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -24,6 +24,7 @@ const REVIEW_FAILURE_DETAILS = new Map([
   ["rate-limited", "automated review rate limited"],
   ["timed-out", "automated review timed out"],
   ["unavailable", "review status unavailable"],
+  ["request-unavailable", "review request unavailable"],
 ]);
 const TRUSTED_PERMISSIONS = new Set(["admin", "maintain", "write"]);
 const REVIEW_EPOCH_EVENTS = new Set([
@@ -352,6 +353,12 @@ function latestReviewEpochChange(events) {
     }
   }
   return latest;
+}
+
+function sameReviewEpoch(left, right) {
+  if (left === undefined || right === undefined) return left === right;
+  return left.time === right.time && left.kind === right.kind &&
+    left.id === right.id;
 }
 
 function activeReviewBoundary(
@@ -721,23 +728,27 @@ function reviewPropagationRetryDescription(
   kind,
   requestKey,
 ) {
-  const epoch = kind === "unavailable"
+  const epoch = kind === "unavailable" || kind === "request-unavailable"
     ? `; epoch:${reviewEpochToken(requestKey)}`
     : "";
   return `${reviewFailureDescription(pullNumber, kind)}${epoch}${REVIEW_PROPAGATION_RETRY_SUFFIX}`;
 }
 
-function reviewPropagationRetryEpochToken(description, pullNumber) {
-  const prefix = `${reviewFailureDescription(pullNumber, "unavailable")}; epoch:`;
+function reviewPropagationRetryEpoch(description, pullNumber) {
   if (
-    typeof description !== "string" || !description.startsWith(prefix) ||
+    typeof description !== "string" ||
     !description.endsWith(REVIEW_PROPAGATION_RETRY_SUFFIX)
   ) return undefined;
-  const token = description.slice(
-    prefix.length,
-    -REVIEW_PROPAGATION_RETRY_SUFFIX.length,
-  );
-  return /^[0-9a-f]{12}$/.test(token) ? token : undefined;
+  for (const kind of ["unavailable", "request-unavailable"]) {
+    const prefix = `${reviewFailureDescription(pullNumber, kind)}; epoch:`;
+    if (!description.startsWith(prefix)) continue;
+    const token = description.slice(
+      prefix.length,
+      -REVIEW_PROPAGATION_RETRY_SUFFIX.length,
+    );
+    if (/^[0-9a-f]{12}$/.test(token)) return { kind, token };
+  }
+  return undefined;
 }
 
 function reviewFailureKindFromDescription(
@@ -750,10 +761,8 @@ function reviewFailureKindFromDescription(
       description === reviewFailureDescription(pullNumber, kind, retryPending)
     ) return kind;
   }
-  if (
-    retryPending &&
-    reviewPropagationRetryEpochToken(description, pullNumber) !== undefined
-  ) return "unavailable";
+  const retryEpoch = reviewPropagationRetryEpoch(description, pullNumber);
+  if (retryPending && retryEpoch !== undefined) return retryEpoch.kind;
   return undefined;
 }
 
@@ -1281,6 +1290,7 @@ export async function publishAutomatedReviewStatus({
   let reviewRequestKey;
   let reviewRequestEpochTime;
   let reviewBoundary;
+  let reviewEpochAtEvaluation;
   let failureKind;
   let failureUrl;
   if (
@@ -1386,10 +1396,11 @@ export async function publishAutomatedReviewStatus({
         pullNumber,
         baseBinding,
       );
+      reviewEpochAtEvaluation = latestReviewEpochChange(events);
       reviewBoundary = activeReviewBoundary(
         latestReviewRequest(comments, headSha),
         reviewNotBefore,
-        latestReviewEpochChange(events),
+        reviewEpochAtEvaluation,
       );
       const recoveredRunBoundRequest = latestRunBoundReviewRequestKey(
         statuses,
@@ -1439,6 +1450,9 @@ export async function publishAutomatedReviewStatus({
       );
       existingPropagationRetryStatus = propagationRetry?.status;
       existingPropagationRetryKind = propagationRetry?.failureKind;
+      if (existingPropagationRetryKind === "request-unavailable") {
+        existingPendingStatus = undefined;
+      }
       existingPropagationRetryIsLatest = propagationRetry?.status?.id ===
         latestReviewGateStatusForPull(statuses, pullNumber)?.id;
       const runBoundResetPending = resetPending &&
@@ -1463,7 +1477,10 @@ export async function publishAutomatedReviewStatus({
           runBoundRequest !== undefined,
         );
         if (!review) {
-          if (existingPropagationRetryStatus) {
+          if (
+            existingPropagationRetryStatus &&
+            existingPropagationRetryKind !== "request-unavailable"
+          ) {
             failure = new Error("Automated review queue propagation is pending");
             failureKind = existingPropagationRetryKind;
             failureUrl = typeof existingPropagationRetryStatus.target_url ===
@@ -1534,6 +1551,25 @@ export async function publishAutomatedReviewStatus({
       throw new Error(
         "Pull request base changed while checking review evidence",
       );
+    }
+    if (review) {
+      const finalEvents = await collectAll(
+        github,
+        github.rest.issues.listEvents,
+        { owner, repo, issue_number: pullNumber },
+        "final pull request events",
+      );
+      if (
+        !sameReviewEpoch(
+          reviewEpochAtEvaluation,
+          latestReviewEpochChange(finalEvents),
+        )
+      ) {
+        review = undefined;
+        throw new Error(
+          "Pull request lifecycle changed while checking review evidence",
+        );
+      }
     }
   } catch (error) {
     review = undefined;
@@ -1932,12 +1968,12 @@ function reviewPropagationRetryHasBoundaryProof(
       retry.status,
     );
   }
-  const retryEpoch = reviewPropagationRetryEpochToken(
+  const retryEpoch = reviewPropagationRetryEpoch(
     retry.status?.description,
     pullNumber,
   );
   if (retryEpoch !== undefined) {
-    return retryEpoch === reviewEpochToken(reviewRequestKey);
+    return retryEpoch.token === reviewEpochToken(reviewRequestKey);
   }
   const createdAt = Date.parse(retry.status?.created_at ?? "");
   return Number.isFinite(createdAt) && createdAt >= boundary.time;
@@ -2247,7 +2283,7 @@ async function requestTimedOutAutomatedReview({
       repo,
       pullNumber,
       headSha,
-      failureKind: "unavailable",
+      failureKind: "request-unavailable",
       targetUrl: result.targetUrl ?? pullUrl,
       reviewRequestKey: result.reviewRequestKey,
     });
@@ -2721,6 +2757,28 @@ async function requireCurrentAutomatedReview({
   pullNumber,
   baseBinding,
 }) {
+  const reviewNotBefore = latestReviewResetTime(
+    evidence.statuses,
+    pullNumber,
+    baseBinding,
+  );
+  const boundary = activeReviewBoundary(
+    latestReviewRequest(evidence.comments, sourceHeadSha),
+    reviewNotBefore,
+    latestReviewEpochChange(evidence.events),
+  );
+  const recoveredRunBoundRequest = latestRunBoundReviewRequestKey(
+    evidence.statuses,
+    pullNumber,
+    baseBinding,
+    boundary,
+  );
+  const runBoundRequest = runBoundRequestBelongsToBoundary(
+      recoveredRunBoundRequest,
+      boundary,
+    )
+    ? recoveredRunBoundRequest
+    : undefined;
   const liveReview = await findAutomatedReview(
     evidence,
     sourceHeadSha,
@@ -2731,7 +2789,8 @@ async function requireCurrentAutomatedReview({
         login,
         pullAuthor: pull?.data?.user?.login,
       }),
-    latestReviewResetTime(evidence.statuses, pullNumber, baseBinding),
+    reviewNotBefore,
+    runBoundRequest !== undefined,
   );
   if (!liveReview) {
     throw new Error("Pull request does not have current review evidence");
@@ -3173,6 +3232,28 @@ function pullSnapshotAdvanced(snapshotUpdatedAt, response) {
   return current > snapshot;
 }
 
+async function pullSnapshotHasNewLifecycle({
+  github,
+  owner,
+  repo,
+  pullNumber,
+  snapshotUpdatedAt,
+  refreshed,
+  events,
+}) {
+  if (!pullSnapshotAdvanced(snapshotUpdatedAt, refreshed)) return false;
+  const finalEvents = await collectAll(
+    github,
+    github.rest.issues.listEvents,
+    { owner, repo, issue_number: pullNumber },
+    "final snapshot review events",
+  );
+  return !sameReviewEpoch(
+    latestReviewEpochChange(events),
+    latestReviewEpochChange(finalEvents),
+  );
+}
+
 async function revalidateAutomatedReviewRequest({
   github,
   owner,
@@ -3243,8 +3324,15 @@ async function revalidateAutomatedReviewRequest({
     return { requested: false, marker, reason: ineligibility };
   }
   if (
-    validateRequestEpoch &&
-    pullSnapshotAdvanced(pullSnapshotUpdatedAt, refreshed)
+    await pullSnapshotHasNewLifecycle({
+      github,
+      owner,
+      repo,
+      pullNumber,
+      snapshotUpdatedAt: pullSnapshotUpdatedAt,
+      refreshed,
+      events,
+    })
   ) return { requested: false, marker, reason: "stale-epoch" };
   if (hasReviewRequest(comments, headSha, effectiveRequestKey)) {
     return { requested: false, marker };

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -404,12 +404,7 @@ function latestPendingReviewStatus(statuses, pullNumber) {
     status?.state === "pending" &&
       isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN)
   ) return status;
-  if (
-    status?.state !== "failure" ||
-    status?.description !==
-      reviewFailureDescription(pullNumber, "unavailable") ||
-    !isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN)
-  ) return undefined;
+  if (!isTrustedOperationalReviewFailure(status, pullNumber)) return undefined;
   const descriptionPrefix = `PR#${pullNumber} `;
   return statuses.find((candidate) =>
     candidate?.context === AUTOMATED_REVIEW_STATUS_CONTEXT &&
@@ -524,6 +519,14 @@ function reviewFailureKindFromDescription(
     ) return kind;
   }
   return undefined;
+}
+
+function isTrustedOperationalReviewFailure(status, pullNumber) {
+  return status?.context === AUTOMATED_REVIEW_STATUS_CONTEXT &&
+    status?.state === "failure" &&
+    status?.description ===
+      reviewFailureDescription(pullNumber, "unavailable") &&
+    isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN);
 }
 
 function terminalStatusHasBoundaryProof(
@@ -1032,6 +1035,7 @@ export async function publishAutomatedReviewStatus({
   let existingTerminalStatusIsLatest = false;
   let existingPropagationRetryStatus;
   let existingPropagationRetryKind;
+  let existingPropagationRetryIsLatest = false;
   let reviewBoundary;
   let failureKind;
   let failureUrl;
@@ -1166,6 +1170,8 @@ export async function publishAutomatedReviewStatus({
       );
       existingPropagationRetryStatus = propagationRetry?.status;
       existingPropagationRetryKind = propagationRetry?.failureKind;
+      existingPropagationRetryIsLatest = propagationRetry?.status?.id ===
+        latestReviewGateStatusForPull(statuses, pullNumber)?.id;
       if (
         !isDraft &&
         (!resetPending || REVIEW_EPOCH_EVENTS.has(reviewBoundary?.kind))
@@ -1295,6 +1301,7 @@ export async function publishAutomatedReviewStatus({
   }
   if (
     state === "failure" &&
+    existingPropagationRetryIsLatest &&
     existingPropagationRetryStatus?.description === description &&
     isPositiveStatusId(existingPropagationRetryStatus.id)
   ) {
@@ -1554,17 +1561,38 @@ function latestReviewPropagationRetryStatus(
   timeline = [],
   headSha = "",
 ) {
-  const status = latestReviewGateStatusForPull(statuses, pullNumber);
+  const latestStatus = latestReviewGateStatusForPull(statuses, pullNumber);
+  let status = latestStatus;
+  let failureKind = reviewFailureKindFromDescription(
+    status?.description,
+    pullNumber,
+    true,
+  );
+  if (
+    failureKind === undefined &&
+    isTrustedOperationalReviewFailure(latestStatus, pullNumber)
+  ) {
+    status = statuses.find((candidate) =>
+      candidate?.context === AUTOMATED_REVIEW_STATUS_CONTEXT &&
+      candidate?.state === "failure" &&
+      isPinnedBot(candidate?.creator, GITHUB_ACTIONS_LOGIN) &&
+      reviewFailureKindFromDescription(
+          candidate?.description,
+          pullNumber,
+          true,
+        ) !== undefined
+    );
+    failureKind = reviewFailureKindFromDescription(
+      status?.description,
+      pullNumber,
+      true,
+    );
+  }
   if (
     status?.state !== "failure" ||
     !isPositiveStatusId(status?.id) ||
     !isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN)
   ) return undefined;
-  const failureKind = reviewFailureKindFromDescription(
-    status.description,
-    pullNumber,
-    true,
-  );
   if (failureKind === undefined) return undefined;
   if (boundary !== undefined) {
     const createdAt = Date.parse(status?.created_at ?? "");
@@ -1749,12 +1777,17 @@ export async function expireTimedOutAutomatedReview({
     pullNumber,
   );
   const retrying = retryStatus !== undefined;
+  const operationalFailure = isTrustedOperationalReviewFailure(
+    latestReviewGateStatusForPull(statuses, pullNumber),
+    pullNumber,
+  );
+  const recovering = retrying || operationalFailure;
   const pendingStatus = latestPendingReviewStatus(statuses, pullNumber);
-  if (!retrying && !pendingStatus) {
+  if (!recovering && !pendingStatus) {
     return { expired: false, reason: "status-changed" };
   }
   if (
-    !retrying && pendingReviewAge(pendingStatus, now) < reviewTimeoutMs
+    !recovering && pendingReviewAge(pendingStatus, now) < reviewTimeoutMs
   ) {
     return { expired: false, reason: "not-expired" };
   }
@@ -1797,6 +1830,18 @@ export async function expireTimedOutAutomatedReview({
     };
   }
   if (typeof result.baseRef === "string") {
+    const preserveQueueRetry = () =>
+      publishReviewPropagationRetryStatus({
+        github,
+        owner,
+        repo,
+        pullNumber,
+        headSha,
+        failureKind: retryStatus?.failureKind ?? "unavailable",
+        targetUrl: typeof retryStatus?.status?.target_url === "string"
+          ? retryStatus.status.target_url
+          : result.targetUrl ?? pullUrl,
+      });
     let queueResults;
     try {
       queueResults = await reconcileActiveMergeGroupReviewStatuses({
@@ -1808,20 +1853,17 @@ export async function expireTimedOutAutomatedReview({
         baseRef: result.baseRef,
       });
     } catch (error) {
-      if (result.state === "success") {
-        await publishReviewPropagationRetryStatus({
-          github,
-          owner,
-          repo,
-          pullNumber,
-          headSha,
-          failureKind: retryStatus?.failureKind ?? "unavailable",
-          targetUrl: typeof retryStatus?.status?.target_url === "string"
-            ? retryStatus.status.target_url
-            : result.targetUrl ?? pullUrl,
-        });
-      }
+      if (result.state === "success") await preserveQueueRetry();
       throw error;
+    }
+    const queueFailures = queueResults.filter((entry) =>
+      entry?.state === "failure"
+    ).length;
+    if (result.state === "success" && queueFailures > 0) {
+      await preserveQueueRetry();
+      throw new Error(
+        `${queueFailures} active merge queue review failed`,
+      );
     }
     return {
       ...result,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -201,6 +201,22 @@ function hasReviewRequest(comments, headSha, requestKey) {
   });
 }
 
+function durableReviewRequestKey(events, requestKey) {
+  if (requestKey !== "reopen") return requestKey;
+  let latestId;
+  for (const event of events) {
+    if (event?.event !== "reopened") continue;
+    if (!Number.isSafeInteger(event?.id) || event.id < 1) {
+      throw new Error("Reopen event identity is malformed");
+    }
+    if (latestId === undefined || event.id > latestId) latestId = event.id;
+  }
+  if (latestId === undefined) {
+    throw new Error("Could not resolve the current reopen event");
+  }
+  return `reopen-${latestId}`;
+}
+
 function timelinePosition(timeline, event, id) {
   if (!Number.isSafeInteger(id) || id < 1) return undefined;
   let position;
@@ -992,6 +1008,7 @@ export async function publishAutomatedReviewStatus({
   let baseRef;
   let isDraft = false;
   let resetPending = false;
+  let effectiveReviewResetKey = reviewResetKey;
   let existingPendingStatus;
   let existingTerminalStatus;
   let existingTerminalStatusIsLatest = false;
@@ -1077,13 +1094,17 @@ export async function publishAutomatedReviewStatus({
           ),
         ],
       );
-      resetPending = reviewResetKey !== undefined &&
-        !hasReviewRequest(comments, headSha, reviewResetKey) &&
+      effectiveReviewResetKey = durableReviewRequestKey(
+        events,
+        reviewResetKey,
+      );
+      resetPending = effectiveReviewResetKey !== undefined &&
+        !hasReviewRequest(comments, headSha, effectiveReviewResetKey) &&
         !hasReviewReset(
           statuses,
           pullNumber,
           baseBinding,
-          reviewResetKey,
+          effectiveReviewResetKey,
         );
       existingPendingStatus = latestPendingReviewStatus(
         statuses,
@@ -1248,7 +1269,7 @@ export async function publishAutomatedReviewStatus({
     description = reviewResetDescription(
       pullNumber,
       baseBinding,
-      reviewResetKey,
+      effectiveReviewResetKey,
     );
   } else if (isDraft) description = `PR#${pullNumber} draft waits for review`;
   else {
@@ -1600,6 +1621,40 @@ async function propagateAndFinalizeReviewFailure({
   return { resolution, ...finalStatus };
 }
 
+/** Propagate one published retry marker, then restore its terminal diagnosis. */
+export async function completeReviewFailurePropagation({
+  github,
+  owner,
+  repo,
+  pullNumber,
+  headSha,
+  sourceStatusId,
+  description,
+  targetUrl,
+}) {
+  if (!isPositiveStatusId(sourceStatusId)) {
+    throw new Error("Review failure retry status identity is malformed");
+  }
+  const failureKind = reviewFailureKindFromDescription(
+    description,
+    pullNumber,
+    true,
+  );
+  if (failureKind === undefined) {
+    throw new Error("Review failure retry description is malformed");
+  }
+  return propagateAndFinalizeReviewFailure({
+    github,
+    owner,
+    repo,
+    pullNumber,
+    headSha,
+    sourceStatusId,
+    failureKind,
+    targetUrl,
+  });
+}
+
 /** Revalidate one discovered timeout and publish under the per-pull lock. */
 export async function expireTimedOutAutomatedReview({
   github,
@@ -1753,6 +1808,7 @@ export async function invalidateReviewProof({
   }
   const headSha = resolvedHeadSha.toLowerCase();
   const description = `PR#${pullNumber} review status unavailable`;
+  let sourceStatusId;
   if (
     expectedHeadSha !== undefined &&
     headSha !== expectedHeadSha.toLowerCase()
@@ -1772,6 +1828,10 @@ export async function invalidateReviewProof({
       "review statuses",
     );
     const latestStatus = latestReviewGateStatusForPull(statuses, pullNumber);
+    sourceStatusId = latestReviewPropagationRetryStatus(
+      statuses,
+      pullNumber,
+    )?.status?.id;
     if (
       Number.isSafeInteger(latestStatus?.id) &&
       latestStatus.id !== reconciliationStatusId &&
@@ -1795,6 +1855,7 @@ export async function invalidateReviewProof({
     repo,
     pullNumber,
     sourceHeadSha: headSha,
+    sourceStatusId,
     pullUrl: typeof response?.data?.html_url === "string"
       ? response.data.html_url
       : undefined,
@@ -2428,8 +2489,18 @@ export async function requestAutomatedReview({
   ) {
     throw new Error("Refusing to use a malformed review request key");
   }
+  let effectiveRequestKey = requestKey;
+  if (requestKey === "reopen") {
+    const events = await collectAll(
+      github,
+      github.rest.issues.listEvents,
+      { owner, repo, issue_number: pullNumber },
+      "review epoch events",
+    );
+    effectiveRequestKey = durableReviewRequestKey(events, requestKey);
+  }
   const marker = `<!-- automated-review-request: ${headSha.toLowerCase()}${
-    requestKey === undefined ? "" : ` ${requestKey}`
+    effectiveRequestKey === undefined ? "" : ` ${effectiveRequestKey}`
   } -->`;
   const comments = await collectAll(
     github,
@@ -2437,7 +2508,11 @@ export async function requestAutomatedReview({
     { owner, repo, issue_number: pullNumber },
     "request comments",
   );
-  const alreadyRequested = hasReviewRequest(comments, headSha, requestKey);
+  const alreadyRequested = hasReviewRequest(
+    comments,
+    headSha,
+    effectiveRequestKey,
+  );
   if (alreadyRequested) {
     return { requested: false, marker };
   }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -29,6 +29,10 @@ const REVIEW_EPOCH_EVENTS = new Set([
   "reopened",
   "ready_for_review",
 ]);
+const REVIEW_REQUEST_EVENT_KINDS = new Map([
+  ["reopen", "reopened"],
+  ["base", "base_ref_changed"],
+]);
 /** @type {(ref: string) => Promise<string | undefined>} */
 const NO_COMMIT = () => Promise.resolve(undefined);
 /** @type {(login: string) => Promise<boolean>} */
@@ -202,16 +206,17 @@ function hasReviewRequest(comments, headSha, requestKey) {
 }
 
 function durableReviewRequestKey(events, requestKey) {
-  if (requestKey !== "reopen") return requestKey;
+  const eventKind = REVIEW_REQUEST_EVENT_KINDS.get(requestKey);
+  if (eventKind === undefined) return requestKey;
   const latestEpoch = latestReviewEpochChange(events);
   if (latestEpoch === undefined) {
-    throw new Error("Could not resolve the current reopen event");
+    throw new Error("Could not resolve the current review epoch event");
   }
-  if (latestEpoch.kind !== "reopened") return undefined;
+  if (latestEpoch.kind !== eventKind) return undefined;
   if (!Number.isSafeInteger(latestEpoch.id) || latestEpoch.id < 1) {
-    throw new Error("Reopen event identity is malformed");
+    throw new Error("Review epoch event identity is malformed");
   }
-  return `reopen-${latestEpoch.id}`;
+  return `${requestKey}-${latestEpoch.id}`;
 }
 
 function timelinePosition(timeline, event, id) {
@@ -2553,7 +2558,7 @@ export async function requestAutomatedReview({
     throw new Error("Refusing to use a malformed review request key");
   }
   let effectiveRequestKey = requestKey;
-  if (requestKey === "reopen") {
+  if (requestKey === "reopen" || requestKey === "base") {
     const events = await collectAll(
       github,
       github.rest.issues.listEvents,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -463,7 +463,7 @@ function latestRunBoundReviewRequestKey(
       latest = { requestKey, createdAt };
     }
   }
-  return latest?.requestKey;
+  return latest;
 }
 
 function latestPendingReviewStatus(statuses, pullNumber) {
@@ -1138,6 +1138,7 @@ export async function publishAutomatedReviewStatus({
   let existingPropagationRetryKind;
   let existingPropagationRetryIsLatest = false;
   let reviewRequestKey;
+  let reviewRequestEpochTime;
   let reviewBoundary;
   let failureKind;
   let failureUrl;
@@ -1249,13 +1250,16 @@ export async function publishAutomatedReviewStatus({
         reviewNotBefore,
         latestReviewEpochChange(events),
       );
+      const runBoundRequest = latestRunBoundReviewRequestKey(
+        statuses,
+        pullNumber,
+        baseBinding,
+        reviewBoundary,
+      );
       reviewRequestKey = effectiveReviewResetKey ??
-        latestRunBoundReviewRequestKey(
-          statuses,
-          pullNumber,
-          baseBinding,
-          reviewBoundary,
-        ) ?? reviewRequestKeyFromBoundary(reviewBoundary);
+        runBoundRequest?.requestKey ??
+        reviewRequestKeyFromBoundary(reviewBoundary);
+      reviewRequestEpochTime = runBoundRequest?.createdAt;
       if (
         !pendingStatusBelongsToReviewEpoch(
           existingPendingStatus,
@@ -1467,6 +1471,7 @@ export async function publishAutomatedReviewStatus({
       baseRef,
       statusId: existingPendingStatus.id,
       reviewRequestKey,
+      reviewRequestEpochTime,
     };
   }
   let targetUrl = failureUrl ?? review?.url ?? pullUrl;
@@ -1516,6 +1521,7 @@ export async function publishAutomatedReviewStatus({
     statusId,
     targetUrl,
     reviewRequestKey,
+    reviewRequestEpochTime,
   };
 }
 
@@ -2065,10 +2071,12 @@ export async function expireTimedOutAutomatedReview({
           owner,
           repo,
           pullNumber,
-        headSha,
-        requestKey: result.reviewRequestKey,
-        validateRequestEpoch: result.reviewRequestKey !== undefined &&
-          !/-run-/.test(result.reviewRequestKey),
+          headSha,
+          requestKey: result.reviewRequestKey,
+          reviewEpochNotAfter: Number.isFinite(result.reviewRequestEpochTime)
+            ? new Date(result.reviewRequestEpochTime).toISOString()
+            : undefined,
+          validateRequestEpoch: result.reviewRequestKey !== undefined,
         });
       } catch (error) {
         await publishReviewPropagationRetryStatus({
@@ -2804,6 +2812,7 @@ export async function requestAutomatedReview({
   headSha,
   requestKey = /** @type {string | undefined} */ (undefined),
   reviewEpochNotBefore = /** @type {string | undefined} */ (undefined),
+  reviewEpochNotAfter = /** @type {string | undefined} */ (undefined),
   reviewEpochRunKey = /** @type {string | undefined} */ (undefined),
   validateRequestEpoch = false,
 }) {
@@ -2825,7 +2834,34 @@ export async function requestAutomatedReview({
   const concreteEpoch = typeof requestKey === "string"
     ? /^(base|ready|reopen)-([1-9]\d*)$/.exec(requestKey)
     : null;
+  const runBoundEpoch = typeof requestKey === "string"
+    ? /^(base|ready|reopen)-run-([1-9]\d*)$/.exec(requestKey)
+    : null;
   const sentinelEpoch = REVIEW_REQUEST_EVENT_KINDS.has(requestKey);
+  const resolveEpochKey = (events) => {
+    if (sentinelEpoch) {
+      return durableReviewRequestKey(
+        events,
+        requestKey,
+        reviewEpochNotBefore,
+        reviewEpochRunKey,
+      );
+    }
+    if (runBoundEpoch) {
+      const notAfter = Date.parse(reviewEpochNotAfter ?? "");
+      if (!Number.isFinite(notAfter)) {
+        throw new Error("Run-bound review epoch timestamp is malformed");
+      }
+      const latestEpoch = latestReviewEpochChange(events);
+      return latestEpoch === undefined || latestEpoch.time <= notAfter
+        ? requestKey
+        : undefined;
+    }
+    if (!concreteEpoch) {
+      throw new Error("Concrete review epoch key is malformed");
+    }
+    return durableReviewRequestKey(events, concreteEpoch[1]);
+  };
   if (sentinelEpoch || validateRequestEpoch) {
     const events = await collectAll(
       github,
@@ -2833,22 +2869,7 @@ export async function requestAutomatedReview({
       { owner, repo, issue_number: pullNumber },
       "review epoch events",
     );
-    if (sentinelEpoch) {
-      effectiveRequestKey = durableReviewRequestKey(
-        events,
-        requestKey,
-        reviewEpochNotBefore,
-        reviewEpochRunKey,
-      );
-    } else {
-      if (!concreteEpoch) {
-        throw new Error("Concrete review epoch key is malformed");
-      }
-      const currentKey = durableReviewRequestKey(events, concreteEpoch[1]);
-      if (currentKey !== requestKey) {
-        return { requested: false, reason: "stale-epoch" };
-      }
-    }
+    effectiveRequestKey = resolveEpochKey(events);
     if (effectiveRequestKey === undefined) {
       return { requested: false, reason: "stale-epoch" };
     }
@@ -2897,14 +2918,7 @@ export async function requestAutomatedReview({
       { owner, repo, issue_number: pullNumber },
       "final review epoch events",
     );
-    const currentKey = sentinelEpoch
-      ? durableReviewRequestKey(
-        events,
-        requestKey,
-        reviewEpochNotBefore,
-        reviewEpochRunKey,
-      )
-      : durableReviewRequestKey(events, concreteEpoch?.[1]);
+    const currentKey = resolveEpochKey(events);
     if (currentKey !== effectiveRequestKey) {
       return { requested: false, marker, reason: "stale-epoch" };
     }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -1643,33 +1643,14 @@ export async function expireTimedOutAutomatedReview({
     statuses,
     pullNumber,
   );
-  if (retryStatus) {
-    const propagated = await propagateAndFinalizeReviewFailure({
-      github,
-      owner,
-      repo,
-      pullNumber,
-      headSha,
-      sourceStatusId: retryStatus.status.id,
-      failureKind: retryStatus.failureKind,
-      targetUrl: typeof retryStatus.status.target_url === "string"
-        ? retryStatus.status.target_url
-        : pullUrl,
-    });
-    return {
-      state: "failure",
-      failure: new Error("Automated review queue propagation was retried"),
-      baseRef: pull?.base?.ref,
-      expired: true,
-      retried: true,
-      ...propagated,
-    };
-  }
+  const retrying = retryStatus !== undefined;
   const pendingStatus = latestPendingReviewStatus(statuses, pullNumber);
-  if (!pendingStatus) {
+  if (!retrying && !pendingStatus) {
     return { expired: false, reason: "status-changed" };
   }
-  if (pendingReviewAge(pendingStatus, now) < reviewTimeoutMs) {
+  if (
+    !retrying && pendingReviewAge(pendingStatus, now) < reviewTimeoutMs
+  ) {
     return { expired: false, reason: "not-expired" };
   }
 
@@ -1682,7 +1663,7 @@ export async function expireTimedOutAutomatedReview({
     pullUrl,
     now,
     reviewTimeoutMs,
-    queuePropagationPending: true,
+    queuePropagationPending: !retrying,
   });
   if (result.state === "failure") {
     const failureKind = reviewFailureKindFromDescription(
@@ -1707,9 +1688,10 @@ export async function expireTimedOutAutomatedReview({
       ...result,
       ...propagated,
       expired: true,
+      retried: retrying,
     };
   }
-  if (result.state === "success" && typeof result.baseRef === "string") {
+  if (typeof result.baseRef === "string") {
     const queueResults = await reconcileActiveMergeGroupReviewStatuses({
       github,
       owner,
@@ -1721,7 +1703,7 @@ export async function expireTimedOutAutomatedReview({
     return {
       ...result,
       expired: false,
-      reason: "reviewed",
+      reason: result.state === "success" ? "reviewed" : "revalidated",
       queueResults,
     };
   }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -476,8 +476,15 @@ function pendingStatusBelongsToReviewEpoch(
       description.startsWith(`PR#${pullNumber} waits for review `));
 }
 
-function pendingHistoryHasBoundaryProof(statuses, pullNumber, boundary) {
+function pendingHistoryHasBoundaryProof(
+  statuses,
+  pullNumber,
+  boundary,
+  failureStatus,
+) {
   const descriptionPrefix = `PR#${pullNumber} `;
+  const failureAt = Date.parse(failureStatus?.created_at ?? "");
+  if (!Number.isFinite(failureAt)) return false;
   return statuses.some((status) => {
     if (
       status?.context !== AUTOMATED_REVIEW_STATUS_CONTEXT ||
@@ -487,7 +494,10 @@ function pendingHistoryHasBoundaryProof(statuses, pullNumber, boundary) {
       !isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN)
     ) return false;
     const createdAt = Date.parse(status?.created_at ?? "");
-    if (!Number.isFinite(createdAt) || createdAt < boundary.time) return false;
+    if (
+      !Number.isFinite(createdAt) || createdAt < boundary.time ||
+      createdAt >= failureAt
+    ) return false;
     if (createdAt > boundary.time) return true;
     return status.description.startsWith(`PR#${pullNumber} reset base:`) ||
       (boundary.kind === "ready_for_review" &&
@@ -633,6 +643,7 @@ function latestTerminalReviewStatus(
         statuses,
         pullNumber,
         boundary,
+        status,
       )) continue;
     }
     return status;
@@ -1673,7 +1684,12 @@ function latestReviewPropagationRetryStatus(
         headSha,
       )) return undefined;
     } else if (failureKind === "timed-out") {
-      if (!pendingHistoryHasBoundaryProof(statuses, pullNumber, boundary)) {
+      if (!pendingHistoryHasBoundaryProof(
+        statuses,
+        pullNumber,
+        boundary,
+        status,
+      )) {
         return undefined;
       }
     } else {
@@ -1969,7 +1985,9 @@ export async function expireTimedOutAutomatedReview({
         repo,
         pullNumber,
         headSha,
-        failureKind: retryStatus?.failureKind ?? "unavailable",
+        failureKind: result.state === "success"
+          ? retryStatus?.failureKind ?? "unavailable"
+          : "unavailable",
         targetUrl: typeof retryStatus?.status?.target_url === "string"
           ? retryStatus.status.target_url
           : result.targetUrl ?? pullUrl,
@@ -1985,7 +2003,7 @@ export async function expireTimedOutAutomatedReview({
         baseRef: result.baseRef,
       });
     } catch (error) {
-      if (result.state === "success") await preserveQueueRetry();
+      await preserveQueueRetry();
       throw error;
     }
     const queueFailures = queueResults.filter((entry) =>
@@ -2814,6 +2832,28 @@ export async function requestAutomatedReview({
   }
   if (response?.data?.state !== "open" || response?.data?.draft !== false) {
     return { requested: false, marker, reason: "ineligible-pull" };
+  }
+  if (
+    requestKey === "reopen" || requestKey === "base" ||
+    validateRequestEpoch
+  ) {
+    const events = await collectAll(
+      github,
+      github.rest.issues.listEvents,
+      { owner, repo, issue_number: pullNumber },
+      "final review epoch events",
+    );
+    const currentKey = requestKey === "reopen" || requestKey === "base"
+      ? durableReviewRequestKey(
+        events,
+        requestKey,
+        reviewEpochNotBefore,
+        reviewEpochRunKey,
+      )
+      : durableReviewRequestKey(events, concreteEpoch?.[1]);
+    if (currentKey !== effectiveRequestKey) {
+      return { requested: false, marker, reason: "stale-epoch" };
+    }
   }
   await github.rest.issues.createComment({
     owner,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -17,7 +17,9 @@ const REQUEST_KEY = /^[a-z0-9-]{1,64}$/i;
 const MAX_ITEMS_PER_SOURCE = 500;
 const MAX_TIMEOUT_TARGETS_PER_RUN = 25;
 const MAX_TIMEOUT_DISCOVERY_PAGES = 20;
+const TIMEOUT_DISCOVERY_ROTATION_MS = 10 * 60 * 1000;
 const REVIEW_PROPAGATION_RETRY_SUFFIX = "; queue retry pending";
+const REVIEW_RETRY_FINALIZED_SUFFIX = "; retry finalized";
 const REVIEW_FAILURE_DETAILS = new Map([
   ["rate-limited", "automated review rate limited"],
   ["timed-out", "automated review timed out"],
@@ -1405,10 +1407,13 @@ export async function publishAutomatedReviewStatus({
         runBoundRequest?.requestKey ??
         reviewRequestKeyFromBoundary(reviewBoundary);
       reviewRequestEpochTime = runBoundRequest?.epochTime;
+      const evidenceBoundary = runBoundRequest === undefined
+        ? reviewBoundary
+        : { time: runBoundRequest.createdAt, kind: "status" };
       if (
         !pendingStatusBelongsToReviewEpoch(
           existingPendingStatus,
-          reviewBoundary,
+          evidenceBoundary,
           pullNumber,
           baseBinding,
         )
@@ -1416,7 +1421,7 @@ export async function publishAutomatedReviewStatus({
       existingTerminalStatus = latestTerminalReviewStatus(
         statuses,
         pullNumber,
-        reviewBoundary,
+        evidenceBoundary,
         comments,
         timeline,
         headSha,
@@ -1426,7 +1431,7 @@ export async function publishAutomatedReviewStatus({
       const propagationRetry = latestReviewPropagationRetryStatus(
         statuses,
         pullNumber,
-        reviewBoundary,
+        evidenceBoundary,
         comments,
         timeline,
         headSha,
@@ -1468,7 +1473,7 @@ export async function publishAutomatedReviewStatus({
           } else {
             const usageLimit = latestCodexUsageLimit(
               comments,
-              reviewBoundary,
+              evidenceBoundary,
               reviewFailureCommentId,
               timeline,
               headSha,
@@ -1813,9 +1818,20 @@ function appendTimedOutReviewTargets(
   for (const pull of pulls) {
     const target = timedOutReviewTarget(pull, now, reviewTimeoutMs);
     if (target) targets.push(target);
-    if (targets.length >= MAX_TIMEOUT_TARGETS_PER_RUN) return true;
   }
-  return false;
+}
+
+function boundedRotatingTimeoutTargets(targets, now) {
+  if (targets.length <= MAX_TIMEOUT_TARGETS_PER_RUN) return targets;
+  const batchCount = Math.ceil(
+    targets.length / MAX_TIMEOUT_TARGETS_PER_RUN,
+  );
+  const batch = Math.floor(now / TIMEOUT_DISCOVERY_ROTATION_MS) % batchCount;
+  const start = batch * MAX_TIMEOUT_TARGETS_PER_RUN;
+  return Array.from(
+    { length: MAX_TIMEOUT_TARGETS_PER_RUN },
+    (_, index) => targets[(start + index) % targets.length],
+  );
 }
 
 export async function findTimedOutAutomatedReviews({
@@ -1835,15 +1851,15 @@ export async function findTimedOutAutomatedReviews({
       cursor,
     });
     const pageResult = timeoutDiscoveryPage(response);
-    if (
-      appendTimedOutReviewTargets(
-        targets,
-        pageResult.nodes,
-        now,
-        reviewTimeoutMs,
-      )
-    ) return targets;
-    if (pageResult.cursor === undefined) return targets;
+    appendTimedOutReviewTargets(
+      targets,
+      pageResult.nodes,
+      now,
+      reviewTimeoutMs,
+    );
+    if (pageResult.cursor === undefined) {
+      return boundedRotatingTimeoutTargets(targets, now);
+    }
     cursor = pageResult.cursor;
   }
   throw new Error("Timeout discovery exceeded 1,000 open pull requests");
@@ -1888,13 +1904,15 @@ function storedReviewPropagationRetry(statuses, pullNumber) {
 
 function reviewPropagationRetryHasBoundaryProof(
   retry,
-  statuses,
-  pullNumber,
-  boundary,
-  comments,
-  timeline,
-  headSha,
-  reviewRequestKey,
+  {
+    statuses,
+    pullNumber,
+    boundary,
+    comments,
+    timeline,
+    headSha,
+    reviewRequestKey,
+  },
 ) {
   if (boundary === undefined) return true;
   if (retry.failureKind === "rate-limited") {
@@ -1938,13 +1956,15 @@ function latestReviewPropagationRetryStatus(
   return retry &&
       reviewPropagationRetryHasBoundaryProof(
         retry,
-        statuses,
-        pullNumber,
-        boundary,
-        comments,
-        timeline,
-        headSha,
-        reviewRequestKey,
+        {
+          statuses,
+          pullNumber,
+          boundary,
+          comments,
+          timeline,
+          headSha,
+          reviewRequestKey,
+        },
       )
     ? retry
     : undefined;
@@ -1959,7 +1979,9 @@ async function finalizeReviewFailureStatus({
   failureKind,
   targetUrl,
 }) {
-  const description = reviewFailureDescription(pullNumber, failureKind);
+  const description = failureKind === "unavailable"
+    ? `${reviewFailureDescription(pullNumber, failureKind)}${REVIEW_RETRY_FINALIZED_SUFFIX}`
+    : reviewFailureDescription(pullNumber, failureKind);
   const response = await github.rest.repos.createCommitStatus({
     owner,
     repo,
@@ -3146,7 +3168,7 @@ function pullSnapshotAdvanced(snapshotUpdatedAt, response) {
   const snapshot = Date.parse(snapshotUpdatedAt);
   const current = Date.parse(response?.data?.updated_at ?? "");
   if (!Number.isFinite(snapshot) || !Number.isFinite(current)) {
-    throw new Error("Could not verify the pull request lifecycle snapshot");
+    throw new TypeError("Could not verify the pull request lifecycle snapshot");
   }
   return current > snapshot;
 }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -1276,6 +1276,7 @@ export async function publishAutomatedReviewStatus({
   let review;
   let failure;
   let pullAuthor;
+  let pullSnapshotUpdatedAt;
   let baseBinding;
   let baseRef;
   let isDraft = false;
@@ -1326,6 +1327,7 @@ export async function publishAutomatedReviewStatus({
         );
       }
       pullAuthor = current?.data?.user?.login;
+      pullSnapshotUpdatedAt = current?.data?.updated_at;
       baseBinding = pullRequestBaseBinding(current?.data);
       baseRef = current?.data?.base?.ref;
       isDraft = current?.data?.draft === true;
@@ -1550,6 +1552,12 @@ export async function publishAutomatedReviewStatus({
       review = undefined;
       throw new Error(
         "Pull request base changed while checking review evidence",
+      );
+    }
+    if (review && pullSnapshotAdvanced(pullSnapshotUpdatedAt, current)) {
+      review = undefined;
+      throw new Error(
+        "Pull request changed while checking review evidence",
       );
     }
     if (review) {
@@ -2140,6 +2148,14 @@ async function propagateAndFinalizeReviewFailure({
     return {
       resolution,
       description: reviewFailureDescription(pullNumber, failureKind, true),
+      statusId: sourceStatusId,
+      finalized: false,
+    };
+  }
+  if (failureKind === "request-unavailable") {
+    return {
+      resolution,
+      description: currentRetry.status.description,
       statusId: sourceStatusId,
       finalized: false,
     };

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -203,18 +203,15 @@ function hasReviewRequest(comments, headSha, requestKey) {
 
 function durableReviewRequestKey(events, requestKey) {
   if (requestKey !== "reopen") return requestKey;
-  let latestId;
-  for (const event of events) {
-    if (event?.event !== "reopened") continue;
-    if (!Number.isSafeInteger(event?.id) || event.id < 1) {
-      throw new Error("Reopen event identity is malformed");
-    }
-    if (latestId === undefined || event.id > latestId) latestId = event.id;
-  }
-  if (latestId === undefined) {
+  const latestEpoch = latestReviewEpochChange(events);
+  if (latestEpoch === undefined) {
     throw new Error("Could not resolve the current reopen event");
   }
-  return `reopen-${latestId}`;
+  if (latestEpoch.kind !== "reopened") return undefined;
+  if (!Number.isSafeInteger(latestEpoch.id) || latestEpoch.id < 1) {
+    throw new Error("Reopen event identity is malformed");
+  }
+  return `reopen-${latestEpoch.id}`;
 }
 
 function timelinePosition(timeline, event, id) {
@@ -398,10 +395,24 @@ function latestReviewResetTime(statuses, pullNumber, baseBinding) {
 
 function latestPendingReviewStatus(statuses, pullNumber) {
   const status = latestReviewGateStatusForPull(statuses, pullNumber);
-  return status?.state === "pending" &&
+  if (
+    status?.state === "pending" &&
       isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN)
-    ? status
-    : undefined;
+  ) return status;
+  if (
+    status?.state !== "failure" ||
+    status?.description !==
+      reviewFailureDescription(pullNumber, "unavailable") ||
+    !isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN)
+  ) return undefined;
+  const descriptionPrefix = `PR#${pullNumber} `;
+  return statuses.find((candidate) =>
+    candidate?.context === AUTOMATED_REVIEW_STATUS_CONTEXT &&
+    candidate?.state === "pending" &&
+    typeof candidate?.description === "string" &&
+    candidate.description.startsWith(descriptionPrefix) &&
+    isPinnedBot(candidate?.creator, GITHUB_ACTIONS_LOGIN)
+  );
 }
 
 function pendingReviewAge(status, now) {
@@ -427,7 +438,9 @@ function pendingStatusBelongsToReviewEpoch(
     ? status.description
     : "";
   return description === resetPrefix ||
-    description.startsWith(`${resetPrefix} key:`);
+    description.startsWith(`${resetPrefix} key:`) ||
+    (boundary.kind === "ready_for_review" &&
+      description.startsWith(`PR#${pullNumber} waits for review `));
 }
 
 function latestCodexUsageLimit(
@@ -1452,11 +1465,13 @@ function reviewTimeoutContext(pull, pullNumber) {
       return context.description.startsWith(descriptionPrefix);
     }
     return context.state === "FAILURE" &&
-      reviewFailureKindFromDescription(
-          context.description,
-          pullNumber,
-          true,
-        ) !== undefined;
+      (context.description ===
+          reviewFailureDescription(pullNumber, "unavailable") ||
+        reviewFailureKindFromDescription(
+            context.description,
+            pullNumber,
+            true,
+          ) !== undefined);
   });
 }
 
@@ -1591,6 +1606,36 @@ async function finalizeReviewFailureStatus({
   return { description, statusId };
 }
 
+async function publishReviewPropagationRetryStatus({
+  github,
+  owner,
+  repo,
+  pullNumber,
+  headSha,
+  failureKind,
+  targetUrl,
+}) {
+  const description = reviewFailureDescription(
+    pullNumber,
+    failureKind,
+    true,
+  );
+  const response = await github.rest.repos.createCommitStatus({
+    owner,
+    repo,
+    sha: headSha,
+    state: "failure",
+    context: AUTOMATED_REVIEW_STATUS_CONTEXT,
+    description,
+    target_url: targetUrl,
+  });
+  const statusId = response?.data?.id;
+  if (!isPositiveStatusId(statusId)) {
+    throw new TypeError("Review propagation retry status identity is malformed");
+  }
+  return { description, statusId };
+}
+
 async function propagateAndFinalizeReviewFailure({
   github,
   owner,
@@ -1718,7 +1763,7 @@ export async function expireTimedOutAutomatedReview({
     pullUrl,
     now,
     reviewTimeoutMs,
-    queuePropagationPending: !retrying,
+    queuePropagationPending: true,
   });
   if (result.state === "failure") {
     const failureKind = reviewFailureKindFromDescription(
@@ -1747,14 +1792,32 @@ export async function expireTimedOutAutomatedReview({
     };
   }
   if (typeof result.baseRef === "string") {
-    const queueResults = await reconcileActiveMergeGroupReviewStatuses({
-      github,
-      owner,
-      repo,
-      pullNumber,
-      sourceHeadSha: headSha,
-      baseRef: result.baseRef,
-    });
+    let queueResults;
+    try {
+      queueResults = await reconcileActiveMergeGroupReviewStatuses({
+        github,
+        owner,
+        repo,
+        pullNumber,
+        sourceHeadSha: headSha,
+        baseRef: result.baseRef,
+      });
+    } catch (error) {
+      if (result.state === "success") {
+        await publishReviewPropagationRetryStatus({
+          github,
+          owner,
+          repo,
+          pullNumber,
+          headSha,
+          failureKind: retryStatus?.failureKind ?? "unavailable",
+          targetUrl: typeof retryStatus?.status?.target_url === "string"
+            ? retryStatus.status.target_url
+            : result.targetUrl ?? pullUrl,
+        });
+      }
+      throw error;
+    }
     return {
       ...result,
       expired: false,
@@ -2498,6 +2561,9 @@ export async function requestAutomatedReview({
       "review epoch events",
     );
     effectiveRequestKey = durableReviewRequestKey(events, requestKey);
+    if (effectiveRequestKey === undefined) {
+      return { requested: false, reason: "stale-epoch" };
+    }
   }
   const marker = `<!-- automated-review-request: ${headSha.toLowerCase()}${
     effectiveRequestKey === undefined ? "" : ` ${effectiveRequestKey}`

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -1111,17 +1111,12 @@ const TIMED_OUT_AUTOMATED_REVIEWS_QUERY = `
           commits(last: 1) {
             nodes {
               commit {
-                statusCheckRollup {
-                  contexts(first: 100) {
-                    nodes {
-                      __typename
-                      ... on StatusContext {
-                        context
-                        state
-                        description
-                        createdAt
-                      }
-                    }
+                status {
+                  contexts {
+                    context
+                    state
+                    description
+                    createdAt
                   }
                 }
               }
@@ -1142,15 +1137,14 @@ function pendingReviewContext(pull, pullNumber) {
   if (!Array.isArray(commitNodes)) {
     throw new Error(`PR #${pullNumber} commit rollup is malformed`);
   }
-  const rollup = commitNodes[0]?.commit?.statusCheckRollup;
-  if (rollup == null) return undefined;
-  const contexts = rollup?.contexts?.nodes;
+  const status = commitNodes[0]?.commit?.status;
+  if (status == null) return undefined;
+  const contexts = status?.contexts;
   if (!Array.isArray(contexts)) {
     throw new Error(`PR #${pullNumber} status rollup is malformed`);
   }
   const descriptionPrefix = `PR#${pullNumber} `;
   return contexts.find((context) =>
-    context?.__typename === "StatusContext" &&
     context?.context === AUTOMATED_REVIEW_STATUS_CONTEXT &&
     context?.state === "PENDING" &&
     typeof context?.description === "string" &&

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -16,6 +16,7 @@ const FULL_SHA = /^[0-9a-f]{40}$/i;
 const REQUEST_KEY = /^[a-z0-9-]{1,64}$/i;
 const MAX_ITEMS_PER_SOURCE = 500;
 const MAX_TIMEOUT_TARGETS_PER_RUN = 25;
+const MAX_TIMEOUT_DISCOVERY_PAGES = 20;
 const TRUSTED_PERMISSIONS = new Set(["admin", "maintain", "write"]);
 /** @type {(ref: string) => Promise<string | undefined>} */
 const NO_COMMIT = () => Promise.resolve(undefined);
@@ -1016,6 +1017,73 @@ function requireReviewTimeoutInputs(now, reviewTimeoutMs) {
 }
 
 /** Discover current non-draft pull request heads whose review status expired. */
+const TIMED_OUT_AUTOMATED_REVIEWS_QUERY = `
+  query TimedOutAutomatedReviews(
+    $owner: String!
+    $repo: String!
+    $cursor: String
+  ) {
+    repository(owner: $owner, name: $repo) {
+      pullRequests(
+        first: 50
+        after: $cursor
+        states: OPEN
+        orderBy: { field: UPDATED_AT, direction: DESC }
+      ) {
+        nodes {
+          number
+          isDraft
+          headRefOid
+          commits(last: 1) {
+            nodes {
+              commit {
+                statusCheckRollup {
+                  contexts(first: 100) {
+                    nodes {
+                      __typename
+                      ... on StatusContext {
+                        context
+                        state
+                        description
+                        createdAt
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+`;
+
+function pendingReviewContext(pull, pullNumber) {
+  const commitNodes = pull?.commits?.nodes;
+  if (!Array.isArray(commitNodes)) {
+    throw new Error(`PR #${pullNumber} commit rollup is malformed`);
+  }
+  const rollup = commitNodes[0]?.commit?.statusCheckRollup;
+  if (rollup == null) return undefined;
+  const contexts = rollup?.contexts?.nodes;
+  if (!Array.isArray(contexts)) {
+    throw new Error(`PR #${pullNumber} status rollup is malformed`);
+  }
+  const descriptionPrefix = `PR#${pullNumber} `;
+  return contexts.find((context) =>
+    context?.__typename === "StatusContext" &&
+    context?.context === AUTOMATED_REVIEW_STATUS_CONTEXT &&
+    context?.state === "PENDING" &&
+    typeof context?.description === "string" &&
+    context.description.startsWith(descriptionPrefix)
+  );
+}
+
 export async function findTimedOutAutomatedReviews({
   github,
   owner,
@@ -1024,41 +1092,43 @@ export async function findTimedOutAutomatedReviews({
   reviewTimeoutMs = AUTOMATED_REVIEW_TIMEOUT_MS,
 }) {
   requireReviewTimeoutInputs(now, reviewTimeoutMs);
-  const pulls = await collectAll(
-    github,
-    github.rest.pulls.list,
-    { owner, repo, state: "open", sort: "created", direction: "asc" },
-    "open pull requests",
-  );
   const targets = [];
-  for (const pull of pulls) {
-    if (pull?.state !== "open" || pull?.draft === true) continue;
-    const pullNumber = pull?.number;
-    const headSha = pull?.head?.sha;
-    if (!Number.isSafeInteger(pullNumber) || pullNumber < 1) {
-      throw new Error("Open pull request number is invalid");
-    }
-    if (typeof headSha !== "string" || !FULL_SHA.test(headSha)) {
-      throw new Error(`PR #${pullNumber} head commit is invalid`);
-    }
-    const statuses = await collectAll(
-      github,
-      github.rest.repos.listCommitStatusesForRef,
-      { owner, repo, ref: headSha },
-      `PR #${pullNumber} review statuses`,
-    );
-    const pendingStatus = latestPendingReviewStatus(statuses, pullNumber);
-    if (
-      !pendingStatus ||
-      !isPositiveStatusId(pendingStatus.id) ||
-      pendingReviewAge(pendingStatus, now) < reviewTimeoutMs
-    ) continue;
-    targets.push({
-      pullNumber,
-      headSha: headSha.toLowerCase(),
-      pendingStatusId: pendingStatus.id,
+  let cursor;
+  for (let page = 0; page < MAX_TIMEOUT_DISCOVERY_PAGES; page += 1) {
+    const response = await github.graphql(TIMED_OUT_AUTOMATED_REVIEWS_QUERY, {
+      owner,
+      repo,
+      cursor,
     });
-    if (targets.length >= MAX_TIMEOUT_TARGETS_PER_RUN) break;
+    const pullRequests = response?.repository?.pullRequests;
+    if (!Array.isArray(pullRequests?.nodes)) {
+      throw new Error("Open pull request rollup is malformed");
+    }
+    for (const pull of pullRequests.nodes) {
+      if (pull?.isDraft === true) continue;
+      const pullNumber = pull?.number;
+      const headSha = pull?.headRefOid;
+      if (!Number.isSafeInteger(pullNumber) || pullNumber < 1) {
+        throw new Error("Open pull request number is invalid");
+      }
+      if (typeof headSha !== "string" || !FULL_SHA.test(headSha)) {
+        throw new Error(`PR #${pullNumber} head commit is invalid`);
+      }
+      const pendingStatus = pendingReviewContext(pull, pullNumber);
+      if (!pendingStatus) continue;
+      const createdAt = Date.parse(pendingStatus?.createdAt ?? "");
+      if (Number.isFinite(createdAt) && now - createdAt < reviewTimeoutMs) {
+        continue;
+      }
+      targets.push({ pullNumber, headSha: headSha.toLowerCase() });
+      if (targets.length >= MAX_TIMEOUT_TARGETS_PER_RUN) return targets;
+    }
+    const pageInfo = pullRequests?.pageInfo;
+    if (pageInfo?.hasNextPage !== true) return targets;
+    if (typeof pageInfo?.endCursor !== "string" || !pageInfo.endCursor) {
+      throw new Error("Open pull request cursor is malformed");
+    }
+    cursor = pageInfo.endCursor;
   }
   return targets;
 }
@@ -1070,7 +1140,6 @@ export async function expireTimedOutAutomatedReview({
   repo,
   pullNumber,
   headSha,
-  pendingStatusId,
   now = Date.now(),
   reviewTimeoutMs = AUTOMATED_REVIEW_TIMEOUT_MS,
 }) {
@@ -1081,10 +1150,6 @@ export async function expireTimedOutAutomatedReview({
   if (typeof headSha !== "string" || !FULL_SHA.test(headSha)) {
     throw new Error("Timed-out pull request head is invalid");
   }
-  if (!isPositiveStatusId(pendingStatusId)) {
-    throw new Error("Timed-out review status identity is invalid");
-  }
-
   const response = await github.rest.pulls.get({
     owner,
     repo,
@@ -1105,7 +1170,7 @@ export async function expireTimedOutAutomatedReview({
     "timeout review statuses",
   );
   const pendingStatus = latestPendingReviewStatus(statuses, pullNumber);
-  if (pendingStatus?.id !== pendingStatusId) {
+  if (!pendingStatus) {
     return { expired: false, reason: "status-changed" };
   }
   if (pendingReviewAge(pendingStatus, now) < reviewTimeoutMs) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -17,6 +17,12 @@ const REQUEST_KEY = /^[a-z0-9-]{1,64}$/i;
 const MAX_ITEMS_PER_SOURCE = 500;
 const MAX_TIMEOUT_TARGETS_PER_RUN = 25;
 const MAX_TIMEOUT_DISCOVERY_PAGES = 20;
+const REVIEW_PROPAGATION_RETRY_SUFFIX = "; queue retry pending";
+const REVIEW_FAILURE_DETAILS = new Map([
+  ["rate-limited", "automated review rate limited"],
+  ["timed-out", "automated review timed out"],
+  ["unavailable", "review status unavailable"],
+]);
 const TRUSTED_PERMISSIONS = new Set(["admin", "maintain", "write"]);
 const REVIEW_EPOCH_EVENTS = new Set([
   "base_ref_changed",
@@ -465,9 +471,58 @@ function commentFollowsHeadCommit(timeline, commentId, headSha) {
   return headIndex >= 0 && commentIndex > headIndex;
 }
 
-function latestTerminalReviewStatus(statuses, pullNumber, boundary) {
-  const rateLimited = `PR#${pullNumber} automated review rate limited`;
-  const timedOut = `PR#${pullNumber} automated review timed out`;
+function reviewFailureDescription(pullNumber, kind, retryPending = false) {
+  const detail = REVIEW_FAILURE_DETAILS.get(kind) ??
+    "review status unavailable";
+  return `PR#${pullNumber} ${detail}${
+    retryPending ? REVIEW_PROPAGATION_RETRY_SUFFIX : ""
+  }`;
+}
+
+function reviewFailureKindFromDescription(
+  description,
+  pullNumber,
+  retryPending = false,
+) {
+  for (const kind of REVIEW_FAILURE_DETAILS.keys()) {
+    if (
+      description === reviewFailureDescription(pullNumber, kind, retryPending)
+    ) return kind;
+  }
+  return undefined;
+}
+
+function terminalStatusHasBoundaryProof(
+  status,
+  comments,
+  boundary,
+  timeline,
+  headSha,
+) {
+  if (typeof status?.target_url !== "string") return false;
+  const comment = comments.find((candidate) =>
+    candidate?.html_url === status.target_url
+  );
+  return comment !== undefined &&
+    latestCodexUsageLimit(
+        [comment],
+        boundary,
+        comment.id,
+        timeline,
+        headSha,
+      ) === comment;
+}
+
+function latestTerminalReviewStatus(
+  statuses,
+  pullNumber,
+  boundary,
+  comments,
+  timeline,
+  headSha,
+) {
+  const rateLimited = reviewFailureDescription(pullNumber, "rate-limited");
+  const timedOut = reviewFailureDescription(pullNumber, "timed-out");
   for (const status of statuses) {
     if (
       status?.context !== AUTOMATED_REVIEW_STATUS_CONTEXT ||
@@ -478,7 +533,17 @@ function latestTerminalReviewStatus(statuses, pullNumber, boundary) {
     ) continue;
     if (boundary !== undefined) {
       const createdAt = Date.parse(status?.created_at ?? "");
-      if (!Number.isFinite(createdAt) || createdAt <= boundary.time) continue;
+      if (!Number.isFinite(createdAt) || createdAt < boundary.time) continue;
+      if (
+        createdAt === boundary.time &&
+        !terminalStatusHasBoundaryProof(
+          status,
+          comments,
+          boundary,
+          timeline,
+          headSha,
+        )
+      ) continue;
     }
     return status;
   }
@@ -918,6 +983,7 @@ export async function publishAutomatedReviewStatus({
   reviewFailureCommentId = /** @type {number | undefined} */ (undefined),
   now = Date.now(),
   reviewTimeoutMs = /** @type {number | undefined} */ (undefined),
+  queuePropagationPending = false,
 }) {
   let review;
   let failure;
@@ -1043,6 +1109,9 @@ export async function publishAutomatedReviewStatus({
         statuses,
         pullNumber,
         reviewBoundary,
+        comments,
+        timeline,
+        headSha,
       );
       existingTerminalStatusIsLatest = existingTerminalStatus?.id ===
         latestReviewGateStatusForPull(statuses, pullNumber)?.id;
@@ -1143,12 +1212,12 @@ export async function publishAutomatedReviewStatus({
   else if (review) state = "success";
 
   let description;
-  if (failureKind === "rate-limited") {
-    description = `PR#${pullNumber} automated review rate limited`;
-  } else if (failureKind === "timed-out") {
-    description = `PR#${pullNumber} automated review timed out`;
-  } else if (failure) {
-    description = `PR#${pullNumber} review status unavailable`;
+  if (failure) {
+    description = reviewFailureDescription(
+      pullNumber,
+      failureKind ?? "unavailable",
+      queuePropagationPending,
+    );
   } else if (review) {
     description = `PR#${pullNumber} base:${baseBinding} by:${review.reviewer}`;
   } else if (resetPending) {
@@ -1194,6 +1263,7 @@ export async function publishAutomatedReviewStatus({
       statusId: existingPendingStatus.id,
     };
   }
+  let targetUrl = failureUrl ?? review?.url ?? pullUrl;
   const statusResponse = await github.rest.repos.createCommitStatus({
     owner,
     repo,
@@ -1201,14 +1271,19 @@ export async function publishAutomatedReviewStatus({
     state,
     context: AUTOMATED_REVIEW_STATUS_CONTEXT,
     description,
-    target_url: failureUrl ?? review?.url ?? pullUrl,
+    target_url: targetUrl,
   });
   let statusId = statusResponse?.data?.id;
   if (state === "success" && !isPositiveStatusId(statusId)) {
     failure = new TypeError("Published review status identity is malformed");
     state = "failure";
     review = undefined;
-    description = `PR#${pullNumber} review status unavailable`;
+    description = reviewFailureDescription(
+      pullNumber,
+      "unavailable",
+      queuePropagationPending,
+    );
+    targetUrl = pullUrl;
     const failureResponse = await github.rest.repos.createCommitStatus({
       owner,
       repo,
@@ -1226,7 +1301,15 @@ export async function publishAutomatedReviewStatus({
   if (statusId !== undefined && !isPositiveStatusId(statusId)) {
     throw new TypeError("Published review status identity is malformed");
   }
-  return { state, review, failure, description, baseRef, statusId };
+  return {
+    state,
+    review,
+    failure,
+    description,
+    baseRef,
+    statusId,
+    targetUrl,
+  };
 }
 
 function requireReviewTimeoutInputs(now, reviewTimeoutMs) {
@@ -1287,7 +1370,7 @@ const TIMED_OUT_AUTOMATED_REVIEWS_QUERY = `
   }
 `;
 
-function pendingReviewContext(pull, pullNumber) {
+function reviewTimeoutContext(pull, pullNumber) {
   const commitNodes = pull?.commits?.nodes;
   if (!Array.isArray(commitNodes)) {
     throw new TypeError(`PR #${pullNumber} commit rollup is malformed`);
@@ -1299,13 +1382,22 @@ function pendingReviewContext(pull, pullNumber) {
     throw new TypeError(`PR #${pullNumber} status rollup is malformed`);
   }
   const descriptionPrefix = `PR#${pullNumber} `;
-  return contexts.find((context) =>
-    context?.context === AUTOMATED_REVIEW_STATUS_CONTEXT &&
-    context?.state === "PENDING" &&
-    isPinnedGraphqlBot(context?.creator, GITHUB_ACTIONS_LOGIN) &&
-    typeof context?.description === "string" &&
-    context.description.startsWith(descriptionPrefix)
-  );
+  return contexts.find((context) => {
+    if (
+      context?.context !== AUTOMATED_REVIEW_STATUS_CONTEXT ||
+      !isPinnedGraphqlBot(context?.creator, GITHUB_ACTIONS_LOGIN) ||
+      typeof context?.description !== "string"
+    ) return false;
+    if (context.state === "PENDING") {
+      return context.description.startsWith(descriptionPrefix);
+    }
+    return context.state === "FAILURE" &&
+      reviewFailureKindFromDescription(
+          context.description,
+          pullNumber,
+          true,
+        ) !== undefined;
+  });
 }
 
 function timeoutDiscoveryPage(response) {
@@ -1333,9 +1425,12 @@ function timedOutReviewTarget(pull, now, reviewTimeoutMs) {
   if (typeof headSha !== "string" || !FULL_SHA.test(headSha)) {
     throw new TypeError(`PR #${pullNumber} head commit is invalid`);
   }
-  const pendingStatus = pendingReviewContext(pull, pullNumber);
-  if (!pendingStatus) return undefined;
-  const createdAt = Date.parse(pendingStatus?.createdAt ?? "");
+  const timeoutContext = reviewTimeoutContext(pull, pullNumber);
+  if (!timeoutContext) return undefined;
+  if (timeoutContext.state === "FAILURE") {
+    return { pullNumber, headSha: headSha.toLowerCase() };
+  }
+  const createdAt = Date.parse(timeoutContext?.createdAt ?? "");
   if (Number.isFinite(createdAt) && now - createdAt < reviewTimeoutMs) {
     return undefined;
   }
@@ -1369,6 +1464,77 @@ export async function findTimedOutAutomatedReviews({
     cursor = pageResult.cursor;
   }
   throw new Error("Timeout discovery exceeded 1,000 open pull requests");
+}
+
+function latestReviewPropagationRetryStatus(statuses, pullNumber) {
+  const status = latestReviewGateStatusForPull(statuses, pullNumber);
+  if (
+    status?.state !== "failure" ||
+    !isPositiveStatusId(status?.id) ||
+    !isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN)
+  ) return undefined;
+  const failureKind = reviewFailureKindFromDescription(
+    status.description,
+    pullNumber,
+    true,
+  );
+  return failureKind === undefined ? undefined : { status, failureKind };
+}
+
+async function finalizeReviewFailureStatus({
+  github,
+  owner,
+  repo,
+  pullNumber,
+  headSha,
+  failureKind,
+  targetUrl,
+}) {
+  const description = reviewFailureDescription(pullNumber, failureKind);
+  const response = await github.rest.repos.createCommitStatus({
+    owner,
+    repo,
+    sha: headSha,
+    state: "failure",
+    context: AUTOMATED_REVIEW_STATUS_CONTEXT,
+    description,
+    target_url: targetUrl,
+  });
+  const statusId = response?.data?.id;
+  if (!isPositiveStatusId(statusId)) {
+    throw new TypeError("Final review failure status identity is malformed");
+  }
+  return { description, statusId };
+}
+
+async function propagateAndFinalizeReviewFailure({
+  github,
+  owner,
+  repo,
+  pullNumber,
+  headSha,
+  sourceStatusId,
+  failureKind,
+  targetUrl,
+}) {
+  const resolution = await publishReviewResolutionFailure({
+    github,
+    owner,
+    repo,
+    pullNumber,
+    sourceHeadSha: headSha,
+    sourceStatusId,
+  });
+  const finalStatus = await finalizeReviewFailureStatus({
+    github,
+    owner,
+    repo,
+    pullNumber,
+    headSha,
+    failureKind,
+    targetUrl,
+  });
+  return { resolution, ...finalStatus };
 }
 
 /** Revalidate one discovered timeout and publish under the per-pull lock. */
@@ -1407,6 +1573,35 @@ export async function expireTimedOutAutomatedReview({
     { owner, repo, ref: headSha },
     "timeout review statuses",
   );
+  const pullUrl = typeof pull.html_url === "string"
+    ? pull.html_url
+    : `https://github.com/${owner}/${repo}/pull/${pullNumber}`;
+  const retryStatus = latestReviewPropagationRetryStatus(
+    statuses,
+    pullNumber,
+  );
+  if (retryStatus) {
+    const propagated = await propagateAndFinalizeReviewFailure({
+      github,
+      owner,
+      repo,
+      pullNumber,
+      headSha,
+      sourceStatusId: retryStatus.status.id,
+      failureKind: retryStatus.failureKind,
+      targetUrl: typeof retryStatus.status.target_url === "string"
+        ? retryStatus.status.target_url
+        : pullUrl,
+    });
+    return {
+      state: "failure",
+      failure: new Error("Automated review queue propagation was retried"),
+      baseRef: pull?.base?.ref,
+      expired: true,
+      retried: true,
+      ...propagated,
+    };
+  }
   const pendingStatus = latestPendingReviewStatus(statuses, pullNumber);
   if (!pendingStatus) {
     return { expired: false, reason: "status-changed" };
@@ -1415,9 +1610,6 @@ export async function expireTimedOutAutomatedReview({
     return { expired: false, reason: "not-expired" };
   }
 
-  const pullUrl = typeof pull.html_url === "string"
-    ? pull.html_url
-    : `https://github.com/${owner}/${repo}/pull/${pullNumber}`;
   const result = await publishAutomatedReviewStatus({
     github,
     owner,
@@ -1427,17 +1619,32 @@ export async function expireTimedOutAutomatedReview({
     pullUrl,
     now,
     reviewTimeoutMs,
+    queuePropagationPending: true,
   });
   if (result.state === "failure") {
-    const resolution = await publishReviewResolutionFailure({
+    const failureKind = reviewFailureKindFromDescription(
+      result.description,
+      pullNumber,
+      true,
+    );
+    if (failureKind === undefined || !isPositiveStatusId(result.statusId)) {
+      throw new Error("Review failure retry status is malformed");
+    }
+    const propagated = await propagateAndFinalizeReviewFailure({
       github,
       owner,
       repo,
       pullNumber,
-      sourceHeadSha: headSha,
+      headSha,
       sourceStatusId: result.statusId,
+      failureKind,
+      targetUrl: result.targetUrl ?? pullUrl,
     });
-    return { ...result, expired: true, resolution };
+    return {
+      ...result,
+      ...propagated,
+      expired: true,
+    };
   }
   if (result.state === "success" && typeof result.baseRef === "string") {
     const queueResults = await reconcileActiveMergeGroupReviewStatuses({

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -369,6 +369,25 @@ function pendingReviewAge(status, now) {
     : Number.POSITIVE_INFINITY;
 }
 
+function pendingStatusBelongsToReviewEpoch(
+  status,
+  boundary,
+  pullNumber,
+  baseBinding,
+) {
+  if (status === undefined) return false;
+  if (boundary === undefined) return true;
+  const createdAt = Date.parse(status.created_at ?? "");
+  if (!Number.isFinite(createdAt)) return false;
+  if (createdAt !== boundary.time) return createdAt > boundary.time;
+  const resetPrefix = reviewResetDescription(pullNumber, baseBinding);
+  const description = typeof status.description === "string"
+    ? status.description
+    : "";
+  return description === resetPrefix ||
+    description.startsWith(`${resetPrefix} key:`);
+}
+
 function latestCodexUsageLimit(
   comments,
   boundary,
@@ -879,6 +898,7 @@ export async function publishAutomatedReviewStatus({
   let resetPending = false;
   let existingPendingStatus;
   let existingTerminalStatus;
+  let existingTerminalStatusIsLatest = false;
   let reviewBoundary;
   let failureKind;
   let failureUrl;
@@ -981,11 +1001,21 @@ export async function publishAutomatedReviewStatus({
         reviewNotBefore,
         latestBaseRefChange(events),
       );
+      if (
+        !pendingStatusBelongsToReviewEpoch(
+          existingPendingStatus,
+          reviewBoundary,
+          pullNumber,
+          baseBinding,
+        )
+      ) existingPendingStatus = undefined;
       existingTerminalStatus = latestTerminalReviewStatus(
         statuses,
         pullNumber,
         reviewBoundary,
       );
+      existingTerminalStatusIsLatest = existingTerminalStatus?.id ===
+        latestReviewGateStatusForPull(statuses, pullNumber)?.id;
       if (!resetPending && !isDraft) {
         review = await findAutomatedReview(
           { reviews, comments, events, timeline },
@@ -1100,6 +1130,7 @@ export async function publishAutomatedReviewStatus({
   }
   if (
     state === "failure" &&
+    existingTerminalStatusIsLatest &&
     existingTerminalStatus?.description === description &&
     isPositiveStatusId(existingTerminalStatus.id)
   ) {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -371,12 +371,11 @@ function pendingReviewAge(status, now) {
 
 function latestCodexUsageLimit(
   comments,
-  pendingStatus,
+  boundary,
   reviewFailureCommentId,
   timeline,
   headSha,
 ) {
-  const pendingAt = Date.parse(pendingStatus?.created_at ?? "");
   let latest;
   let latestAt = Number.NEGATIVE_INFINITY;
   for (const comment of comments) {
@@ -388,16 +387,13 @@ function latestCodexUsageLimit(
       !CODEX_USAGE_LIMIT.test(comment.body.trim()) ||
       (!isTrigger && !isProvablyUneditedComment(comment))
     ) continue;
+    if (!commentFollowsHeadCommit(timeline, comment.id, headSha)) continue;
     if (
-      isTrigger &&
-      commentFollowsHeadCommit(timeline, comment.id, headSha)
-    ) return comment;
-    const createdAt = Date.parse(comment.created_at ?? "");
-    if (
-      !Number.isFinite(pendingAt) ||
-      !Number.isFinite(createdAt) ||
-      createdAt < pendingAt
+      evidenceFreshness(comment, "commented", boundary, timeline) !== "newer"
     ) continue;
+    if (isTrigger) return comment;
+    const createdAt = Date.parse(comment.created_at ?? "");
+    if (!Number.isFinite(createdAt)) continue;
     if (createdAt >= latestAt) {
       latest = comment;
       latestAt = createdAt;
@@ -421,17 +417,23 @@ function commentFollowsHeadCommit(timeline, commentId, headSha) {
   return headIndex >= 0 && commentIndex > headIndex;
 }
 
-function latestTerminalReviewStatus(statuses, pullNumber) {
-  const status = latestReviewGateStatusForPull(statuses, pullNumber);
-  if (
-    status?.state !== "failure" ||
-    !isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN)
-  ) return undefined;
+function latestTerminalReviewStatus(statuses, pullNumber, boundary) {
   const rateLimited = `PR#${pullNumber} automated review rate limited`;
   const timedOut = `PR#${pullNumber} automated review timed out`;
-  return status?.description === rateLimited || status?.description === timedOut
-    ? status
-    : undefined;
+  for (const status of statuses) {
+    if (
+      status?.state !== "failure" ||
+      !isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN) ||
+      (status?.description !== rateLimited &&
+        status?.description !== timedOut)
+    ) continue;
+    if (boundary !== undefined) {
+      const createdAt = Date.parse(status?.created_at ?? "");
+      if (!Number.isFinite(createdAt) || createdAt <= boundary.time) continue;
+    }
+    return status;
+  }
+  return undefined;
 }
 
 function canReusePendingStatus(
@@ -877,6 +879,7 @@ export async function publishAutomatedReviewStatus({
   let resetPending = false;
   let existingPendingStatus;
   let existingTerminalStatus;
+  let reviewBoundary;
   let failureKind;
   let failureUrl;
   if (
@@ -968,9 +971,20 @@ export async function publishAutomatedReviewStatus({
         statuses,
         pullNumber,
       );
+      const reviewNotBefore = latestReviewResetTime(
+        statuses,
+        pullNumber,
+        baseBinding,
+      );
+      reviewBoundary = activeReviewBoundary(
+        latestReviewRequest(comments, headSha),
+        reviewNotBefore,
+        latestBaseRefChange(events),
+      );
       existingTerminalStatus = latestTerminalReviewStatus(
         statuses,
         pullNumber,
+        reviewBoundary,
       );
       if (!resetPending && !isDraft) {
         review = await findAutomatedReview(
@@ -983,12 +997,12 @@ export async function publishAutomatedReviewStatus({
               login,
               pullAuthor,
             }),
-          latestReviewResetTime(statuses, pullNumber, baseBinding),
+          reviewNotBefore,
         );
         if (!review) {
           const usageLimit = latestCodexUsageLimit(
             comments,
-            existingPendingStatus,
+            reviewBoundary,
             reviewFailureCommentId,
             timeline,
             headSha,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -441,6 +441,14 @@ function latestCodexUsageLimit(
   return latest;
 }
 
+function forcePushedHeadSha(event) {
+  const afterCommit = event?.after_commit;
+  if (typeof afterCommit === "string") return afterCommit;
+  if (typeof afterCommit?.sha === "string") return afterCommit.sha;
+  if (typeof afterCommit?.oid === "string") return afterCommit.oid;
+  return typeof event?.commit_id === "string" ? event.commit_id : undefined;
+}
+
 function commentFollowsHeadCommit(timeline, commentId, headSha) {
   const commentIndex = timeline.findIndex((item) =>
     item?.event === "commented" && item?.id === commentId
@@ -450,7 +458,8 @@ function commentFollowsHeadCommit(timeline, commentId, headSha) {
   for (const [index, item] of timeline.entries()) {
     if (
       (item?.event === "committed" && item?.sha === headSha) ||
-      (item?.event === "head_ref_force_pushed" && item?.after === headSha)
+      (item?.event === "head_ref_force_pushed" &&
+        forcePushedHeadSha(item) === headSha)
     ) headIndex = index;
   }
   return headIndex >= 0 && commentIndex > headIndex;

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -373,19 +373,25 @@ function latestCodexUsageLimit(
   comments,
   pendingStatus,
   reviewFailureCommentId,
+  timeline,
+  headSha,
 ) {
   const pendingAt = Date.parse(pendingStatus?.created_at ?? "");
   let latest;
   let latestAt = Number.NEGATIVE_INFINITY;
   for (const comment of comments) {
-    const isTrigger = comment?.id === reviewFailureCommentId;
+    const isTrigger = reviewFailureCommentId !== undefined &&
+      comment?.id === reviewFailureCommentId;
     if (
       !isPinnedBot(comment?.user, CODEX_LOGIN) ||
       typeof comment?.body !== "string" ||
       !CODEX_USAGE_LIMIT.test(comment.body.trim()) ||
       (!isTrigger && !isProvablyUneditedComment(comment))
     ) continue;
-    if (isTrigger) return comment;
+    if (
+      isTrigger &&
+      commentFollowsHeadCommit(timeline, comment.id, headSha)
+    ) return comment;
     const createdAt = Date.parse(comment.created_at ?? "");
     if (
       !Number.isFinite(pendingAt) ||
@@ -398,6 +404,34 @@ function latestCodexUsageLimit(
     }
   }
   return latest;
+}
+
+function commentFollowsHeadCommit(timeline, commentId, headSha) {
+  const commentIndex = timeline.findIndex((item) =>
+    item?.event === "commented" && item?.id === commentId
+  );
+  if (commentIndex < 0) return false;
+  let headIndex = -1;
+  for (const [index, item] of timeline.entries()) {
+    if (
+      (item?.event === "committed" && item?.sha === headSha) ||
+      (item?.event === "head_ref_force_pushed" && item?.after === headSha)
+    ) headIndex = index;
+  }
+  return headIndex >= 0 && commentIndex > headIndex;
+}
+
+function latestTerminalReviewStatus(statuses, pullNumber) {
+  const status = latestReviewGateStatusForPull(statuses, pullNumber);
+  if (
+    status?.state !== "failure" ||
+    !isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN)
+  ) return undefined;
+  const rateLimited = `PR#${pullNumber} automated review rate limited`;
+  const timedOut = `PR#${pullNumber} automated review timed out`;
+  return status?.description === rateLimited || status?.description === timedOut
+    ? status
+    : undefined;
 }
 
 function canReusePendingStatus(
@@ -842,6 +876,7 @@ export async function publishAutomatedReviewStatus({
   let isDraft = false;
   let resetPending = false;
   let existingPendingStatus;
+  let existingTerminalStatus;
   let failureKind;
   let failureUrl;
   if (
@@ -933,6 +968,10 @@ export async function publishAutomatedReviewStatus({
         statuses,
         pullNumber,
       );
+      existingTerminalStatus = latestTerminalReviewStatus(
+        statuses,
+        pullNumber,
+      );
       if (!resetPending && !isDraft) {
         review = await findAutomatedReview(
           { reviews, comments, events, timeline },
@@ -951,6 +990,8 @@ export async function publishAutomatedReviewStatus({
             comments,
             existingPendingStatus,
             reviewFailureCommentId,
+            timeline,
+            headSha,
           );
           if (usageLimit) {
             failure = new Error("Automated review was rate limited");
@@ -965,6 +1006,21 @@ export async function publishAutomatedReviewStatus({
           ) {
             failure = new Error("Automated review timed out");
             failureKind = "timed-out";
+          }
+          if (!failure && existingTerminalStatus) {
+            failureKind = existingTerminalStatus.description.endsWith(
+                "rate limited",
+              )
+              ? "rate-limited"
+              : "timed-out";
+            failure = new Error(
+              failureKind === "rate-limited"
+                ? "Automated review remains rate limited"
+                : "Automated review remains timed out",
+            );
+            failureUrl = typeof existingTerminalStatus.target_url === "string"
+              ? existingTerminalStatus.target_url
+              : undefined;
           }
         }
       }
@@ -1027,6 +1083,21 @@ export async function publishAutomatedReviewStatus({
   } else if (isDraft) description = `PR#${pullNumber} draft waits for review`;
   else {
     description = `PR#${pullNumber} waits for review ${headSha.slice(0, 12)}`;
+  }
+  if (
+    state === "failure" &&
+    existingTerminalStatus &&
+    existingTerminalStatus.description === description &&
+    isPositiveStatusId(existingTerminalStatus.id)
+  ) {
+    return {
+      state,
+      review,
+      failure,
+      description,
+      baseRef,
+      statusId: existingTerminalStatus.id,
+    };
   }
   if (
     state === "pending" &&
@@ -1198,7 +1269,7 @@ export async function findTimedOutAutomatedReviews({
     }
     cursor = pageInfo.endCursor;
   }
-  return targets;
+  throw new Error("Timeout discovery exceeded 1,000 open pull requests");
 }
 
 /** Revalidate one discovered timeout and publish under the per-pull lock. */

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -1086,8 +1086,7 @@ export async function publishAutomatedReviewStatus({
   }
   if (
     state === "failure" &&
-    existingTerminalStatus &&
-    existingTerminalStatus.description === description &&
+    existingTerminalStatus?.description === description &&
     isPositiveStatusId(existingTerminalStatus.id)
   ) {
     return {

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -1128,7 +1128,7 @@ export async function publishAutomatedReviewStatus({
   });
   let statusId = statusResponse?.data?.id;
   if (state === "success" && !isPositiveStatusId(statusId)) {
-    failure = new Error("Published review status identity is malformed");
+    failure = new TypeError("Published review status identity is malformed");
     state = "failure";
     review = undefined;
     description = `PR#${pullNumber} review status unavailable`;
@@ -1147,17 +1147,17 @@ export async function publishAutomatedReviewStatus({
     }
   }
   if (statusId !== undefined && !isPositiveStatusId(statusId)) {
-    throw new Error("Published review status identity is malformed");
+    throw new TypeError("Published review status identity is malformed");
   }
   return { state, review, failure, description, baseRef, statusId };
 }
 
 function requireReviewTimeoutInputs(now, reviewTimeoutMs) {
   if (!Number.isFinite(now)) {
-    throw new Error("Review timeout discovery time is invalid");
+    throw new TypeError("Review timeout discovery time is invalid");
   }
   if (!Number.isSafeInteger(reviewTimeoutMs) || reviewTimeoutMs < 1) {
-    throw new Error("Review timeout is invalid");
+    throw new TypeError("Review timeout is invalid");
   }
 }
 
@@ -1206,13 +1206,13 @@ const TIMED_OUT_AUTOMATED_REVIEWS_QUERY = `
 function pendingReviewContext(pull, pullNumber) {
   const commitNodes = pull?.commits?.nodes;
   if (!Array.isArray(commitNodes)) {
-    throw new Error(`PR #${pullNumber} commit rollup is malformed`);
+    throw new TypeError(`PR #${pullNumber} commit rollup is malformed`);
   }
   const status = commitNodes[0]?.commit?.status;
   if (status == null) return undefined;
   const contexts = status?.contexts;
   if (!Array.isArray(contexts)) {
-    throw new Error(`PR #${pullNumber} status rollup is malformed`);
+    throw new TypeError(`PR #${pullNumber} status rollup is malformed`);
   }
   const descriptionPrefix = `PR#${pullNumber} `;
   return contexts.find((context) =>
@@ -1221,6 +1221,40 @@ function pendingReviewContext(pull, pullNumber) {
     typeof context?.description === "string" &&
     context.description.startsWith(descriptionPrefix)
   );
+}
+
+function timeoutDiscoveryPage(response) {
+  const pullRequests = response?.repository?.pullRequests;
+  if (!Array.isArray(pullRequests?.nodes)) {
+    throw new TypeError("Open pull request rollup is malformed");
+  }
+  const pageInfo = pullRequests?.pageInfo;
+  if (pageInfo?.hasNextPage !== true) {
+    return { nodes: pullRequests.nodes, cursor: undefined };
+  }
+  if (typeof pageInfo?.endCursor !== "string" || !pageInfo.endCursor) {
+    throw new TypeError("Open pull request cursor is malformed");
+  }
+  return { nodes: pullRequests.nodes, cursor: pageInfo.endCursor };
+}
+
+function timedOutReviewTarget(pull, now, reviewTimeoutMs) {
+  if (pull?.isDraft === true) return undefined;
+  const pullNumber = pull?.number;
+  const headSha = pull?.headRefOid;
+  if (!Number.isSafeInteger(pullNumber) || pullNumber < 1) {
+    throw new TypeError("Open pull request number is invalid");
+  }
+  if (typeof headSha !== "string" || !FULL_SHA.test(headSha)) {
+    throw new TypeError(`PR #${pullNumber} head commit is invalid`);
+  }
+  const pendingStatus = pendingReviewContext(pull, pullNumber);
+  if (!pendingStatus) return undefined;
+  const createdAt = Date.parse(pendingStatus?.createdAt ?? "");
+  if (Number.isFinite(createdAt) && now - createdAt < reviewTimeoutMs) {
+    return undefined;
+  }
+  return { pullNumber, headSha: headSha.toLowerCase() };
 }
 
 export async function findTimedOutAutomatedReviews({
@@ -1239,35 +1273,15 @@ export async function findTimedOutAutomatedReviews({
       repo,
       cursor,
     });
-    const pullRequests = response?.repository?.pullRequests;
-    if (!Array.isArray(pullRequests?.nodes)) {
-      throw new Error("Open pull request rollup is malformed");
-    }
-    for (const pull of pullRequests.nodes) {
-      if (pull?.isDraft === true) continue;
-      const pullNumber = pull?.number;
-      const headSha = pull?.headRefOid;
-      if (!Number.isSafeInteger(pullNumber) || pullNumber < 1) {
-        throw new Error("Open pull request number is invalid");
-      }
-      if (typeof headSha !== "string" || !FULL_SHA.test(headSha)) {
-        throw new Error(`PR #${pullNumber} head commit is invalid`);
-      }
-      const pendingStatus = pendingReviewContext(pull, pullNumber);
-      if (!pendingStatus) continue;
-      const createdAt = Date.parse(pendingStatus?.createdAt ?? "");
-      if (Number.isFinite(createdAt) && now - createdAt < reviewTimeoutMs) {
-        continue;
-      }
-      targets.push({ pullNumber, headSha: headSha.toLowerCase() });
+    const pageResult = timeoutDiscoveryPage(response);
+    for (const pull of pageResult.nodes) {
+      const target = timedOutReviewTarget(pull, now, reviewTimeoutMs);
+      if (!target) continue;
+      targets.push(target);
       if (targets.length >= MAX_TIMEOUT_TARGETS_PER_RUN) return targets;
     }
-    const pageInfo = pullRequests?.pageInfo;
-    if (pageInfo?.hasNextPage !== true) return targets;
-    if (typeof pageInfo?.endCursor !== "string" || !pageInfo.endCursor) {
-      throw new Error("Open pull request cursor is malformed");
-    }
-    cursor = pageInfo.endCursor;
+    if (pageResult.cursor === undefined) return targets;
+    cursor = pageResult.cursor;
   }
   throw new Error("Timeout discovery exceeded 1,000 open pull requests");
 }
@@ -1284,10 +1298,10 @@ export async function expireTimedOutAutomatedReview({
 }) {
   requireReviewTimeoutInputs(now, reviewTimeoutMs);
   if (!Number.isSafeInteger(pullNumber) || pullNumber < 1) {
-    throw new Error("Timed-out pull request number is invalid");
+    throw new TypeError("Timed-out pull request number is invalid");
   }
   if (typeof headSha !== "string" || !FULL_SHA.test(headSha)) {
-    throw new Error("Timed-out pull request head is invalid");
+    throw new TypeError("Timed-out pull request head is invalid");
   }
   const response = await github.rest.pulls.get({
     owner,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -7,12 +7,15 @@ const BOTS = new Map([
 const CODEX_LOGIN = "chatgpt-codex-connector[bot]";
 const GITHUB_ACTIONS_LOGIN = "github-actions[bot]";
 const CODEX_NO_FINDINGS = "Codex Review: Didn't find any major issues.";
+const CODEX_USAGE_LIMIT =
+  /^You have reached your Codex usage limits(?: for [^.]+)?\. Please try again later\.$/i;
 const CODEX_REVIEWED_COMMIT = /\*\*Reviewed commit:\*\* `([0-9a-f]{10})`/i;
 const REVIEW_REQUEST_MARKER =
   /^<!-- automated-review-request: ([0-9a-f]{40})(?: ([a-z0-9-]{1,64}))? -->\n@codex review$/i;
 const FULL_SHA = /^[0-9a-f]{40}$/i;
 const REQUEST_KEY = /^[a-z0-9-]{1,64}$/i;
 const MAX_ITEMS_PER_SOURCE = 500;
+const MAX_TIMEOUT_TARGETS_PER_RUN = 25;
 const TRUSTED_PERMISSIONS = new Set(["admin", "maintain", "write"]);
 /** @type {(ref: string) => Promise<string | undefined>} */
 const NO_COMMIT = () => Promise.resolve(undefined);
@@ -20,6 +23,7 @@ const NO_COMMIT = () => Promise.resolve(undefined);
 const NO_TRUSTED_HUMAN = () => Promise.resolve(false);
 
 export const AUTOMATED_REVIEW_STATUS_CONTEXT = "Automated review";
+export const AUTOMATED_REVIEW_TIMEOUT_MS = 30 * 60 * 1000;
 
 const REVIEW_WAKEUP_PATH = ".github/workflows/automated-review-wakeup.yml";
 
@@ -345,6 +349,44 @@ function latestReviewResetTime(statuses, pullNumber, baseBinding) {
     const createdAt = Date.parse(status?.created_at ?? "");
     if (!Number.isFinite(createdAt)) return Number.POSITIVE_INFINITY;
     if (latest === undefined || createdAt > latest) latest = createdAt;
+  }
+  return latest;
+}
+
+function latestPendingReviewStatus(statuses, pullNumber) {
+  const status = latestReviewGateStatusForPull(statuses, pullNumber);
+  return status?.state === "pending" &&
+      isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN)
+    ? status
+    : undefined;
+}
+
+function pendingReviewAge(status, now) {
+  const createdAt = Date.parse(status?.created_at ?? "");
+  return Number.isFinite(createdAt)
+    ? now - createdAt
+    : Number.POSITIVE_INFINITY;
+}
+
+function latestCodexUsageLimit(comments, pendingStatus) {
+  if (!pendingStatus) return undefined;
+  const pendingAt = Date.parse(pendingStatus.created_at ?? "");
+  if (!Number.isFinite(pendingAt)) return undefined;
+  let latest;
+  let latestAt = Number.NEGATIVE_INFINITY;
+  for (const comment of comments) {
+    if (
+      !isPinnedBot(comment?.user, CODEX_LOGIN) ||
+      typeof comment?.body !== "string" ||
+      !CODEX_USAGE_LIMIT.test(comment.body.trim()) ||
+      !isProvablyUneditedComment(comment)
+    ) continue;
+    const createdAt = Date.parse(comment.created_at ?? "");
+    if (!Number.isFinite(createdAt) || createdAt < pendingAt) continue;
+    if (createdAt >= latestAt) {
+      latest = comment;
+      latestAt = createdAt;
+    }
   }
   return latest;
 }
@@ -743,6 +785,8 @@ export async function publishAutomatedReviewStatus({
   headSha,
   pullUrl,
   reviewResetKey = /** @type {string | undefined} */ (undefined),
+  now = Date.now(),
+  reviewTimeoutMs = /** @type {number | undefined} */ (undefined),
 }) {
   let review;
   let failure;
@@ -751,11 +795,20 @@ export async function publishAutomatedReviewStatus({
   let baseRef;
   let isDraft = false;
   let resetPending = false;
+  let failureKind;
+  let failureUrl;
   if (
     reviewResetKey !== undefined &&
     (typeof reviewResetKey !== "string" || !REQUEST_KEY.test(reviewResetKey))
   ) {
     failure = new Error("Review reset key is malformed");
+  } else if (!Number.isFinite(now)) {
+    failure = new Error("Review reconciliation time is invalid");
+  } else if (
+    reviewTimeoutMs !== undefined &&
+    (!Number.isSafeInteger(reviewTimeoutMs) || reviewTimeoutMs < 1)
+  ) {
+    failure = new Error("Review timeout is invalid");
   } else if (!FULL_SHA.test(headSha)) {
     failure = new Error("Captured head is malformed");
   } else {
@@ -836,6 +889,27 @@ export async function publishAutomatedReviewStatus({
             }),
           latestReviewResetTime(statuses, pullNumber, baseBinding),
         );
+        if (!review) {
+          const pendingStatus = latestPendingReviewStatus(
+            statuses,
+            pullNumber,
+          );
+          const usageLimit = latestCodexUsageLimit(comments, pendingStatus);
+          if (usageLimit) {
+            failure = new Error("Automated review was rate limited");
+            failureKind = "rate-limited";
+            failureUrl = typeof usageLimit.html_url === "string"
+              ? usageLimit.html_url
+              : undefined;
+          } else if (
+            pendingStatus &&
+            reviewTimeoutMs !== undefined &&
+            pendingReviewAge(pendingStatus, now) >= reviewTimeoutMs
+          ) {
+            failure = new Error("Automated review timed out");
+            failureKind = "timed-out";
+          }
+        }
       }
     } catch (error) {
       review = undefined;
@@ -864,6 +938,8 @@ export async function publishAutomatedReviewStatus({
   } catch (error) {
     review = undefined;
     failure = error instanceof Error ? error : new Error(String(error));
+    failureKind = undefined;
+    failureUrl = undefined;
   }
 
   // No proof for the captured head is the normal state right after a push,
@@ -877,8 +953,13 @@ export async function publishAutomatedReviewStatus({
   else if (review) state = "success";
 
   let description;
-  if (failure) description = `PR#${pullNumber} review status unavailable`;
-  else if (resetPending) {
+  if (failureKind === "rate-limited") {
+    description = `PR#${pullNumber} automated review rate limited`;
+  } else if (failureKind === "timed-out") {
+    description = `PR#${pullNumber} automated review timed out`;
+  } else if (failure) {
+    description = `PR#${pullNumber} review status unavailable`;
+  } else if (resetPending) {
     description = reviewResetDescription(
       pullNumber,
       baseBinding,
@@ -897,7 +978,7 @@ export async function publishAutomatedReviewStatus({
     state,
     context: AUTOMATED_REVIEW_STATUS_CONTEXT,
     description,
-    target_url: review?.url ?? pullUrl,
+    target_url: failureUrl ?? review?.url ?? pullUrl,
   });
   let statusId = statusResponse?.data?.id;
   if (state === "success" && !isPositiveStatusId(statusId)) {
@@ -923,6 +1004,154 @@ export async function publishAutomatedReviewStatus({
     throw new Error("Published review status identity is malformed");
   }
   return { state, review, failure, description, baseRef, statusId };
+}
+
+function requireReviewTimeoutInputs(now, reviewTimeoutMs) {
+  if (!Number.isFinite(now)) {
+    throw new Error("Review timeout discovery time is invalid");
+  }
+  if (!Number.isSafeInteger(reviewTimeoutMs) || reviewTimeoutMs < 1) {
+    throw new Error("Review timeout is invalid");
+  }
+}
+
+/** Discover current non-draft pull request heads whose review status expired. */
+export async function findTimedOutAutomatedReviews({
+  github,
+  owner,
+  repo,
+  now = Date.now(),
+  reviewTimeoutMs = AUTOMATED_REVIEW_TIMEOUT_MS,
+}) {
+  requireReviewTimeoutInputs(now, reviewTimeoutMs);
+  const pulls = await collectAll(
+    github,
+    github.rest.pulls.list,
+    { owner, repo, state: "open", sort: "created", direction: "asc" },
+    "open pull requests",
+  );
+  const targets = [];
+  for (const pull of pulls) {
+    if (pull?.state !== "open" || pull?.draft === true) continue;
+    const pullNumber = pull?.number;
+    const headSha = pull?.head?.sha;
+    if (!Number.isSafeInteger(pullNumber) || pullNumber < 1) {
+      throw new Error("Open pull request number is invalid");
+    }
+    if (typeof headSha !== "string" || !FULL_SHA.test(headSha)) {
+      throw new Error(`PR #${pullNumber} head commit is invalid`);
+    }
+    const statuses = await collectAll(
+      github,
+      github.rest.repos.listCommitStatusesForRef,
+      { owner, repo, ref: headSha },
+      `PR #${pullNumber} review statuses`,
+    );
+    const pendingStatus = latestPendingReviewStatus(statuses, pullNumber);
+    if (
+      !pendingStatus ||
+      !isPositiveStatusId(pendingStatus.id) ||
+      pendingReviewAge(pendingStatus, now) < reviewTimeoutMs
+    ) continue;
+    targets.push({
+      pullNumber,
+      headSha: headSha.toLowerCase(),
+      pendingStatusId: pendingStatus.id,
+    });
+    if (targets.length >= MAX_TIMEOUT_TARGETS_PER_RUN) break;
+  }
+  return targets;
+}
+
+/** Revalidate one discovered timeout and publish under the per-pull lock. */
+export async function expireTimedOutAutomatedReview({
+  github,
+  owner,
+  repo,
+  pullNumber,
+  headSha,
+  pendingStatusId,
+  now = Date.now(),
+  reviewTimeoutMs = AUTOMATED_REVIEW_TIMEOUT_MS,
+}) {
+  requireReviewTimeoutInputs(now, reviewTimeoutMs);
+  if (!Number.isSafeInteger(pullNumber) || pullNumber < 1) {
+    throw new Error("Timed-out pull request number is invalid");
+  }
+  if (typeof headSha !== "string" || !FULL_SHA.test(headSha)) {
+    throw new Error("Timed-out pull request head is invalid");
+  }
+  if (!isPositiveStatusId(pendingStatusId)) {
+    throw new Error("Timed-out review status identity is invalid");
+  }
+
+  const response = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: pullNumber,
+  });
+  const pull = response?.data;
+  if (
+    pull?.state !== "open" ||
+    typeof pull?.head?.sha !== "string" ||
+    pull.head.sha.toLowerCase() !== headSha.toLowerCase()
+  ) return { expired: false, reason: "stale-head" };
+  if (pull?.draft === true) return { expired: false, reason: "draft" };
+
+  const statuses = await collectAll(
+    github,
+    github.rest.repos.listCommitStatusesForRef,
+    { owner, repo, ref: headSha },
+    "timeout review statuses",
+  );
+  const pendingStatus = latestPendingReviewStatus(statuses, pullNumber);
+  if (pendingStatus?.id !== pendingStatusId) {
+    return { expired: false, reason: "status-changed" };
+  }
+  if (pendingReviewAge(pendingStatus, now) < reviewTimeoutMs) {
+    return { expired: false, reason: "not-expired" };
+  }
+
+  const pullUrl = typeof pull.html_url === "string"
+    ? pull.html_url
+    : `https://github.com/${owner}/${repo}/pull/${pullNumber}`;
+  const result = await publishAutomatedReviewStatus({
+    github,
+    owner,
+    repo,
+    pullNumber,
+    headSha,
+    pullUrl,
+    now,
+    reviewTimeoutMs,
+  });
+  if (result.state === "failure") {
+    const resolution = await publishReviewResolutionFailure({
+      github,
+      owner,
+      repo,
+      pullNumber,
+      sourceHeadSha: headSha,
+    });
+    return { ...result, expired: true, resolution };
+  }
+  if (result.state === "success" && typeof result.baseRef === "string") {
+    const queueResults = await reconcileActiveMergeGroupReviewStatuses({
+      github,
+      owner,
+      repo,
+      pullNumber,
+      sourceHeadSha: headSha,
+      baseRef: result.baseRef,
+    });
+    return {
+      ...result,
+      expired: false,
+      reason: "reviewed",
+      queueResults,
+    };
+  }
+  return { ...result, expired: false, reason: "revalidated" };
 }
 
 /**

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -995,6 +995,8 @@ export async function publishAutomatedReviewStatus({
   let existingPendingStatus;
   let existingTerminalStatus;
   let existingTerminalStatusIsLatest = false;
+  let existingPropagationRetryStatus;
+  let existingPropagationRetryKind;
   let reviewBoundary;
   let failureKind;
   let failureUrl;
@@ -1115,6 +1117,16 @@ export async function publishAutomatedReviewStatus({
       );
       existingTerminalStatusIsLatest = existingTerminalStatus?.id ===
         latestReviewGateStatusForPull(statuses, pullNumber)?.id;
+      const propagationRetry = latestReviewPropagationRetryStatus(
+        statuses,
+        pullNumber,
+        reviewBoundary,
+        comments,
+        timeline,
+        headSha,
+      );
+      existingPropagationRetryStatus = propagationRetry?.status;
+      existingPropagationRetryKind = propagationRetry?.failureKind;
       if (
         !isDraft &&
         (!resetPending || REVIEW_EPOCH_EVENTS.has(reviewBoundary?.kind))
@@ -1132,41 +1144,51 @@ export async function publishAutomatedReviewStatus({
           reviewNotBefore,
         );
         if (!review) {
-          const usageLimit = latestCodexUsageLimit(
-            comments,
-            reviewBoundary,
-            reviewFailureCommentId,
-            timeline,
-            headSha,
-          );
-          if (usageLimit) {
-            failure = new Error("Automated review was rate limited");
-            failureKind = "rate-limited";
-            failureUrl = typeof usageLimit.html_url === "string"
-              ? usageLimit.html_url
+          if (existingPropagationRetryStatus) {
+            failure = new Error("Automated review queue propagation is pending");
+            failureKind = existingPropagationRetryKind;
+            failureUrl = typeof existingPropagationRetryStatus.target_url ===
+                "string"
+              ? existingPropagationRetryStatus.target_url
               : undefined;
-          } else if (
-            existingPendingStatus &&
-            reviewTimeoutMs !== undefined &&
-            pendingReviewAge(existingPendingStatus, now) >= reviewTimeoutMs
-          ) {
-            failure = new Error("Automated review timed out");
-            failureKind = "timed-out";
-          }
-          if (!failure && existingTerminalStatus) {
-            failureKind = existingTerminalStatus.description.endsWith(
-                "rate limited",
-              )
-              ? "rate-limited"
-              : "timed-out";
-            failure = new Error(
-              failureKind === "rate-limited"
-                ? "Automated review remains rate limited"
-                : "Automated review remains timed out",
+          } else {
+            const usageLimit = latestCodexUsageLimit(
+              comments,
+              reviewBoundary,
+              reviewFailureCommentId,
+              timeline,
+              headSha,
             );
-            failureUrl = typeof existingTerminalStatus.target_url === "string"
-              ? existingTerminalStatus.target_url
-              : undefined;
+            if (usageLimit) {
+              failure = new Error("Automated review was rate limited");
+              failureKind = "rate-limited";
+              failureUrl = typeof usageLimit.html_url === "string"
+                ? usageLimit.html_url
+                : undefined;
+            } else if (
+              existingPendingStatus &&
+              reviewTimeoutMs !== undefined &&
+              pendingReviewAge(existingPendingStatus, now) >= reviewTimeoutMs
+            ) {
+              failure = new Error("Automated review timed out");
+              failureKind = "timed-out";
+            }
+            if (!failure && existingTerminalStatus) {
+              failureKind = existingTerminalStatus.description.endsWith(
+                  "rate limited",
+                )
+                ? "rate-limited"
+                : "timed-out";
+              failure = new Error(
+                failureKind === "rate-limited"
+                  ? "Automated review remains rate limited"
+                  : "Automated review remains timed out",
+              );
+              failureUrl = typeof existingTerminalStatus.target_url ===
+                  "string"
+                ? existingTerminalStatus.target_url
+                : undefined;
+            }
           }
         }
       }
@@ -1212,7 +1234,9 @@ export async function publishAutomatedReviewStatus({
   else if (review) state = "success";
 
   let description;
-  if (failure) {
+  if (failure && existingPropagationRetryStatus) {
+    description = existingPropagationRetryStatus.description;
+  } else if (failure) {
     description = reviewFailureDescription(
       pullNumber,
       failureKind ?? "unavailable",
@@ -1229,6 +1253,21 @@ export async function publishAutomatedReviewStatus({
   } else if (isDraft) description = `PR#${pullNumber} draft waits for review`;
   else {
     description = `PR#${pullNumber} waits for review ${headSha.slice(0, 12)}`;
+  }
+  if (
+    state === "failure" &&
+    existingPropagationRetryStatus?.description === description &&
+    isPositiveStatusId(existingPropagationRetryStatus.id)
+  ) {
+    return {
+      state,
+      review,
+      failure,
+      description,
+      baseRef,
+      statusId: existingPropagationRetryStatus.id,
+      targetUrl: existingPropagationRetryStatus.target_url,
+    };
   }
   if (
     state === "failure" &&
@@ -1466,7 +1505,14 @@ export async function findTimedOutAutomatedReviews({
   throw new Error("Timeout discovery exceeded 1,000 open pull requests");
 }
 
-function latestReviewPropagationRetryStatus(statuses, pullNumber) {
+function latestReviewPropagationRetryStatus(
+  statuses,
+  pullNumber,
+  boundary,
+  comments = [],
+  timeline = [],
+  headSha = "",
+) {
   const status = latestReviewGateStatusForPull(statuses, pullNumber);
   if (
     status?.state !== "failure" ||
@@ -1478,7 +1524,24 @@ function latestReviewPropagationRetryStatus(statuses, pullNumber) {
     pullNumber,
     true,
   );
-  return failureKind === undefined ? undefined : { status, failureKind };
+  if (failureKind === undefined) return undefined;
+  if (boundary !== undefined) {
+    const createdAt = Date.parse(status?.created_at ?? "");
+    if (!Number.isFinite(createdAt) || createdAt < boundary.time) {
+      return undefined;
+    }
+    if (
+      createdAt === boundary.time &&
+      !terminalStatusHasBoundaryProof(
+        status,
+        comments,
+        boundary,
+        timeline,
+        headSha,
+      )
+    ) return undefined;
+  }
+  return { status, failureKind };
 }
 
 async function finalizeReviewFailureStatus({

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -369,27 +369,50 @@ function pendingReviewAge(status, now) {
     : Number.POSITIVE_INFINITY;
 }
 
-function latestCodexUsageLimit(comments, pendingStatus) {
-  if (!pendingStatus) return undefined;
-  const pendingAt = Date.parse(pendingStatus.created_at ?? "");
-  if (!Number.isFinite(pendingAt)) return undefined;
+function latestCodexUsageLimit(
+  comments,
+  pendingStatus,
+  reviewFailureCommentId,
+) {
+  const pendingAt = Date.parse(pendingStatus?.created_at ?? "");
   let latest;
   let latestAt = Number.NEGATIVE_INFINITY;
   for (const comment of comments) {
+    const isTrigger = comment?.id === reviewFailureCommentId;
     if (
       !isPinnedBot(comment?.user, CODEX_LOGIN) ||
       typeof comment?.body !== "string" ||
       !CODEX_USAGE_LIMIT.test(comment.body.trim()) ||
-      !isProvablyUneditedComment(comment)
+      (!isTrigger && !isProvablyUneditedComment(comment))
     ) continue;
+    if (isTrigger) return comment;
     const createdAt = Date.parse(comment.created_at ?? "");
-    if (!Number.isFinite(createdAt) || createdAt < pendingAt) continue;
+    if (
+      !Number.isFinite(pendingAt) ||
+      !Number.isFinite(createdAt) ||
+      createdAt < pendingAt
+    ) continue;
     if (createdAt >= latestAt) {
       latest = comment;
       latestAt = createdAt;
     }
   }
   return latest;
+}
+
+function canReusePendingStatus(
+  status,
+  pullNumber,
+  isDraft,
+  resetPending,
+) {
+  if (!status || !isPositiveStatusId(status.id) || resetPending) return false;
+  const description = typeof status.description === "string"
+    ? status.description
+    : "";
+  if (isDraft) return description === `PR#${pullNumber} draft waits for review`;
+  return description.startsWith(`PR#${pullNumber} waits for review `) ||
+    description.startsWith(`PR#${pullNumber} reset base:`);
 }
 
 /** Find one authenticated automated-review proof for the captured head. */
@@ -707,6 +730,7 @@ export async function publishReviewResolutionFailure({
   repo,
   pullNumber,
   sourceHeadSha,
+  sourceStatusId = /** @type {number | undefined} */ (undefined),
   pullUrl = `https://github.com/${owner}/${repo}/pull/${pullNumber}`,
 }) {
   if (!Number.isSafeInteger(pullNumber) || pullNumber < 1) {
@@ -714,6 +738,9 @@ export async function publishReviewResolutionFailure({
   }
   if (!FULL_SHA.test(sourceHeadSha)) {
     throw new Error("Pull request source commit is malformed");
+  }
+  if (sourceStatusId !== undefined && !isPositiveStatusId(sourceStatusId)) {
+    throw new Error("Source review status identity is malformed");
   }
   const currentHeadSha = await resolveCommitRef(
     github,
@@ -723,15 +750,32 @@ export async function publishReviewResolutionFailure({
   if (currentHeadSha?.toLowerCase() !== sourceHeadSha.toLowerCase()) {
     return { queueFailures: 0, skipped: true };
   }
-  await github.rest.repos.createCommitStatus({
-    owner,
-    repo,
-    sha: sourceHeadSha,
-    state: "failure",
-    context: AUTOMATED_REVIEW_STATUS_CONTEXT,
-    description: `PR#${pullNumber} review status unavailable`,
-    target_url: pullUrl,
-  });
+  if (sourceStatusId === undefined) {
+    await github.rest.repos.createCommitStatus({
+      owner,
+      repo,
+      sha: sourceHeadSha,
+      state: "failure",
+      context: AUTOMATED_REVIEW_STATUS_CONTEXT,
+      description: `PR#${pullNumber} review status unavailable`,
+      target_url: pullUrl,
+    });
+  } else {
+    const statuses = await collectAll(
+      github,
+      github.rest.repos.listCommitStatusesForRef,
+      { owner, repo, ref: sourceHeadSha },
+      "source review statuses",
+    );
+    const latestStatus = latestReviewGateStatusForPull(statuses, pullNumber);
+    if (
+      latestStatus?.id !== sourceStatusId ||
+      latestStatus?.state !== "failure" ||
+      !isPinnedBot(latestStatus?.creator, GITHUB_ACTIONS_LOGIN)
+    ) {
+      throw new Error("Source review failure changed before queue propagation");
+    }
+  }
   const refs = await collectAll(
     github,
     github.rest.git.listMatchingRefs,
@@ -786,6 +830,7 @@ export async function publishAutomatedReviewStatus({
   headSha,
   pullUrl,
   reviewResetKey = /** @type {string | undefined} */ (undefined),
+  reviewFailureCommentId = /** @type {number | undefined} */ (undefined),
   now = Date.now(),
   reviewTimeoutMs = /** @type {number | undefined} */ (undefined),
 }) {
@@ -796,6 +841,7 @@ export async function publishAutomatedReviewStatus({
   let baseRef;
   let isDraft = false;
   let resetPending = false;
+  let existingPendingStatus;
   let failureKind;
   let failureUrl;
   if (
@@ -803,6 +849,12 @@ export async function publishAutomatedReviewStatus({
     (typeof reviewResetKey !== "string" || !REQUEST_KEY.test(reviewResetKey))
   ) {
     failure = new Error("Review reset key is malformed");
+  } else if (
+    reviewFailureCommentId !== undefined &&
+    (!Number.isSafeInteger(reviewFailureCommentId) ||
+      reviewFailureCommentId < 1)
+  ) {
+    failure = new Error("Review failure comment identity is malformed");
   } else if (!Number.isFinite(now)) {
     failure = new Error("Review reconciliation time is invalid");
   } else if (
@@ -877,6 +929,10 @@ export async function publishAutomatedReviewStatus({
           baseBinding,
           reviewResetKey,
         );
+      existingPendingStatus = latestPendingReviewStatus(
+        statuses,
+        pullNumber,
+      );
       if (!resetPending && !isDraft) {
         review = await findAutomatedReview(
           { reviews, comments, events, timeline },
@@ -891,11 +947,11 @@ export async function publishAutomatedReviewStatus({
           latestReviewResetTime(statuses, pullNumber, baseBinding),
         );
         if (!review) {
-          const pendingStatus = latestPendingReviewStatus(
-            statuses,
-            pullNumber,
+          const usageLimit = latestCodexUsageLimit(
+            comments,
+            existingPendingStatus,
+            reviewFailureCommentId,
           );
-          const usageLimit = latestCodexUsageLimit(comments, pendingStatus);
           if (usageLimit) {
             failure = new Error("Automated review was rate limited");
             failureKind = "rate-limited";
@@ -903,9 +959,9 @@ export async function publishAutomatedReviewStatus({
               ? usageLimit.html_url
               : undefined;
           } else if (
-            pendingStatus &&
+            existingPendingStatus &&
             reviewTimeoutMs !== undefined &&
-            pendingReviewAge(pendingStatus, now) >= reviewTimeoutMs
+            pendingReviewAge(existingPendingStatus, now) >= reviewTimeoutMs
           ) {
             failure = new Error("Automated review timed out");
             failureKind = "timed-out";
@@ -971,6 +1027,24 @@ export async function publishAutomatedReviewStatus({
   } else if (isDraft) description = `PR#${pullNumber} draft waits for review`;
   else {
     description = `PR#${pullNumber} waits for review ${headSha.slice(0, 12)}`;
+  }
+  if (
+    state === "pending" &&
+    canReusePendingStatus(
+      existingPendingStatus,
+      pullNumber,
+      isDraft,
+      resetPending,
+    )
+  ) {
+    return {
+      state,
+      review,
+      failure,
+      description: existingPendingStatus.description,
+      baseRef,
+      statusId: existingPendingStatus.id,
+    };
   }
   const statusResponse = await github.rest.repos.createCommitStatus({
     owner,
@@ -1197,6 +1271,7 @@ export async function expireTimedOutAutomatedReview({
       repo,
       pullNumber,
       sourceHeadSha: headSha,
+      sourceStatusId: result.statusId,
     });
     return { ...result, expired: true, resolution };
   }

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -118,6 +118,13 @@ function isPinnedBot(user, login) {
     user?.type === "Bot";
 }
 
+function isPinnedGraphqlBot(user, login) {
+  const graphqlLogin = login.endsWith("[bot]") ? login.slice(0, -5) : login;
+  return user?.login === graphqlLogin &&
+    user?.databaseId === BOTS.get(login) &&
+    user?.__typename === "Bot";
+}
+
 function isLaterReview(candidate, current, candidateIndex, currentIndex) {
   const candidateTime = Date.parse(candidate?.submitted_at ?? "");
   const currentTime = Date.parse(current?.submitted_at ?? "");
@@ -1238,6 +1245,13 @@ const TIMED_OUT_AUTOMATED_REVIEWS_QUERY = `
                     state
                     description
                     createdAt
+                    creator {
+                      __typename
+                      login
+                      ... on Bot {
+                        databaseId
+                      }
+                    }
                   }
                 }
               }
@@ -1268,6 +1282,7 @@ function pendingReviewContext(pull, pullNumber) {
   return contexts.find((context) =>
     context?.context === AUTOMATED_REVIEW_STATUS_CONTEXT &&
     context?.state === "PENDING" &&
+    isPinnedGraphqlBot(context?.creator, GITHUB_ACTIONS_LOGIN) &&
     typeof context?.description === "string" &&
     context.description.startsWith(descriptionPrefix)
   );

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -215,8 +215,15 @@ function latestReviewEpochChange(events) {
     if (!Number.isFinite(time)) {
       return { time: Number.POSITIVE_INFINITY, kind };
     }
-    if (latest === undefined || time > latest.time) {
-      latest = { time, kind };
+    const id = Number.isSafeInteger(item?.id) && item.id > 0
+      ? item.id
+      : undefined;
+    const laterAtSameTime = time === latest?.time && id !== undefined &&
+      (!Number.isSafeInteger(latest?.id) || id > latest.id);
+    if (latest === undefined || time > latest.time || laterAtSameTime) {
+      latest = id === undefined
+        ? { time, kind }
+        : { time, kind, id, timelineEvent: kind };
     }
   }
   return latest;
@@ -454,6 +461,7 @@ function latestTerminalReviewStatus(statuses, pullNumber, boundary) {
   const timedOut = `PR#${pullNumber} automated review timed out`;
   for (const status of statuses) {
     if (
+      status?.context !== AUTOMATED_REVIEW_STATUS_CONTEXT ||
       status?.state !== "failure" ||
       !isPinnedBot(status?.creator, GITHUB_ACTIONS_LOGIN) ||
       (status?.description !== rateLimited &&
@@ -1029,7 +1037,10 @@ export async function publishAutomatedReviewStatus({
       );
       existingTerminalStatusIsLatest = existingTerminalStatus?.id ===
         latestReviewGateStatusForPull(statuses, pullNumber)?.id;
-      if (!resetPending && !isDraft) {
+      if (
+        !isDraft &&
+        (!resetPending || REVIEW_EPOCH_EVENTS.has(reviewBoundary?.kind))
+      ) {
         review = await findAutomatedReview(
           { reviews, comments, events, timeline },
           headSha,
@@ -1129,14 +1140,14 @@ export async function publishAutomatedReviewStatus({
     description = `PR#${pullNumber} automated review timed out`;
   } else if (failure) {
     description = `PR#${pullNumber} review status unavailable`;
+  } else if (review) {
+    description = `PR#${pullNumber} base:${baseBinding} by:${review.reviewer}`;
   } else if (resetPending) {
     description = reviewResetDescription(
       pullNumber,
       baseBinding,
       reviewResetKey,
     );
-  } else if (review) {
-    description = `PR#${pullNumber} base:${baseBinding} by:${review.reviewer}`;
   } else if (isDraft) description = `PR#${pullNumber} draft waits for review`;
   else {
     description = `PR#${pullNumber} waits for review ${headSha.slice(0, 12)}`;

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -18,6 +18,11 @@ const MAX_ITEMS_PER_SOURCE = 500;
 const MAX_TIMEOUT_TARGETS_PER_RUN = 25;
 const MAX_TIMEOUT_DISCOVERY_PAGES = 20;
 const TRUSTED_PERMISSIONS = new Set(["admin", "maintain", "write"]);
+const REVIEW_EPOCH_EVENTS = new Set([
+  "base_ref_changed",
+  "reopened",
+  "ready_for_review",
+]);
 /** @type {(ref: string) => Promise<string | undefined>} */
 const NO_COMMIT = () => Promise.resolve(undefined);
 /** @type {(login: string) => Promise<boolean>} */
@@ -194,26 +199,27 @@ function timelinePosition(timeline, event, id) {
   return position;
 }
 
-function latestBaseRefChange(events) {
+function latestReviewEpochChange(events) {
   let latest;
   for (const item of events) {
-    if (item?.event !== "base_ref_changed") continue;
+    if (!REVIEW_EPOCH_EVENTS.has(item?.event)) continue;
+    const kind = item.event;
     const time = Date.parse(item?.created_at ?? "");
     if (!Number.isFinite(time)) {
-      return { time: Number.POSITIVE_INFINITY, kind: "base-change" };
+      return { time: Number.POSITIVE_INFINITY, kind };
     }
     if (latest === undefined || time > latest.time) {
-      latest = { time, kind: "base-change" };
+      latest = { time, kind };
     }
   }
   return latest;
 }
 
-function activeReviewBoundary(request, reviewNotBefore, baseChange) {
-  // The issue event is GitHub's durable record of the policy change. The
+function activeReviewBoundary(request, reviewNotBefore, epochChange) {
+  // The issue event is GitHub's durable record of the review-epoch change. The
   // workflow writes its reset status later, so letting that timestamp replace
   // the event would reject valid evidence submitted between the two writes.
-  if (baseChange !== undefined) return baseChange;
+  if (epochChange !== undefined) return epochChange;
   const boundary = reviewNotBefore === undefined
     ? undefined
     : { time: reviewNotBefore, kind: "status" };
@@ -492,7 +498,7 @@ export async function findAutomatedReview(
   const boundary = activeReviewBoundary(
     request,
     validReviewNotBefore,
-    latestBaseRefChange(events),
+    latestReviewEpochChange(events),
   );
   const codexSuccesses = [];
   const codexFindings = [];
@@ -999,7 +1005,7 @@ export async function publishAutomatedReviewStatus({
       reviewBoundary = activeReviewBoundary(
         latestReviewRequest(comments, headSha),
         reviewNotBefore,
-        latestBaseRefChange(events),
+        latestReviewEpochChange(events),
       );
       if (
         !pendingStatusBelongsToReviewEpoch(
@@ -2107,10 +2113,11 @@ export async function reconcileActiveMergeGroupReviewStatuses({
  * that suppress the request would let anyone silence the review nudge for a
  * head commit.
  *
- * Immediately before posting, re-fetch the pull request and require its
- * current head to match the event head. That prevents a queued synchronize
- * run from marking an old SHA while its unqualified request targets a newer
- * current head.
+ * Immediately before posting, re-fetch the pull request and require it to
+ * remain open and non-draft with a current head that matches the event head.
+ * That prevents a queued run from consuming review quota after the pull
+ * request becomes ineligible or marking an old SHA while its unqualified
+ * request targets a newer current head.
  */
 export async function requestAutomatedReview({
   github,
@@ -2161,6 +2168,9 @@ export async function requestAutomatedReview({
   }
   if (currentHeadSha.toLowerCase() !== headSha.toLowerCase()) {
     return { requested: false, marker, reason: "stale-head" };
+  }
+  if (response?.data?.state !== "open" || response?.data?.draft !== false) {
+    return { requested: false, marker, reason: "ineligible-pull" };
   }
   await github.rest.issues.createComment({
     owner,

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -3398,6 +3398,42 @@ describe("automated review publication", () => {
     assertEquals(result.review, undefined);
     assertEquals(fixture.published[0]?.state, "failure");
   });
+
+  it("rechecks durable lifecycle events before publishing success", async () => {
+    const oldEpoch = {
+      event: "base_ref_changed",
+      id: 42,
+      created_at: "2026-08-25T08:00:00Z",
+    };
+    const fixture = githubFixture({
+      pages: { comments: [[codexComment(HEAD.slice(0, 10), {
+        created_at: "2026-08-25T08:30:00Z",
+        updated_at: "2026-08-25T08:30:00Z",
+      })]] },
+      pageResponses: {
+        events: [
+          [[oldEpoch]],
+          [[oldEpoch, {
+            event: "ready_for_review",
+            id: 43,
+            created_at: "2026-08-25T09:00:00Z",
+          }]],
+        ],
+      },
+      commit: HEAD,
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+
+    assertEquals(result.state, "failure");
+    assertEquals(result.review, undefined);
+  });
 });
 
 describe("automated review timeout watchdog", () => {
@@ -4117,8 +4153,37 @@ describe("automated review timeout watchdog", () => {
     assertEquals(requestOutage.published[0]?.state, "pending");
     assertEquals(
       requestOutage.published.at(-1)?.description,
-      "PR#1 review status unavailable; epoch:9f2e6d33a371; queue retry pending",
+      "PR#1 review request unavailable; epoch:9f2e6d33a371; queue retry pending",
     );
+
+    const requestRetryStatus = automatedReviewStatus({
+      id: 107,
+      state: "failure",
+      description:
+        "PR#1 review request unavailable; epoch:9f2e6d33a371; queue retry pending",
+      created_at: "2026-08-25T08:05:00Z",
+    });
+    const requestRetry = githubFixture({
+      pageResponses: {
+        statuses: [
+          [[requestRetryStatus, pendingAutomatedReviewStatus()]],
+          [[requestRetryStatus, pendingAutomatedReviewStatus()]],
+        ],
+      },
+      pages: { refs: [[]] },
+      statusIds: [1001],
+    });
+    const requestRetryResult = await expireTimedOutAutomatedReview({
+      github: requestRetry.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      now: Date.parse("2026-08-25T08:10:00Z"),
+      reviewTimeoutMs: 1_800_000,
+    });
+    assertEquals(requestRetryResult.state, "pending");
+    assertEquals(requestRetry.commentsPosted.length, 1);
   });
 
   it("marks a propagated unavailable retry as finalized", async () => {
@@ -4629,6 +4694,46 @@ describe("merge queue review propagation", () => {
     assertEquals(result.state, "success");
     assertEquals(fixture.published[0]?.sha, OTHER_HEAD);
     assertEquals(fixture.published[0]?.state, "success");
+  });
+
+  it("honors an active run-bound reset during merge-group proof checks", async () => {
+    const fixture = githubFixture({
+      pages: {
+        comments: [[codexComment(HEAD.slice(0, 10), {
+          id: 103,
+          created_at: "2026-08-25T09:00:00Z",
+          updated_at: "2026-08-25T09:00:00Z",
+        })]],
+        events: [[{
+          event: "ready_for_review",
+          id: 41,
+          created_at: "2026-08-25T08:00:00Z",
+        }]],
+        statuses: [[
+          automatedReviewStatus(),
+          automatedReviewResetStatus("2026-08-25T10:00:00Z", {
+            id: 104,
+            description: `PR#1 reset base:${
+              reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
+            } key:ready-run-9001-at-1787644800000-event-41`,
+          }),
+        ]],
+      },
+      commit: HEAD,
+      headResponses: [HEAD, HEAD],
+    });
+    const result = await publishMergeGroupReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      sourceHeadSha: HEAD,
+      baseHeadSha: BASE_HEAD,
+      mergeGroupSha: OTHER_HEAD,
+    });
+
+    assertEquals(result.state, "failure");
+    assertEquals(fixture.published[0]?.state, "failure");
   });
 
   it("does not reuse a source review status from another pull request", async () => {
@@ -5295,12 +5400,22 @@ describe("automated review request", () => {
   });
 
   it("rejects a lifecycle request when the final pull snapshot advances", async () => {
+    const oldEpoch = {
+      event: "base_ref_changed",
+      id: 42,
+      created_at: "2026-08-25T08:00:00Z",
+    };
     const fixture = requestFixture({
-      events: [{
-        event: "base_ref_changed",
-        id: 42,
-        created_at: "2026-08-25T08:00:00Z",
-      }],
+      eventResponses: [
+        [oldEpoch],
+        [oldEpoch],
+        [oldEpoch],
+        [oldEpoch, {
+          event: "ready_for_review",
+          id: 43,
+          created_at: "2026-08-25T09:00:00Z",
+        }],
+      ],
       updatedAtResponses: [
         "2026-08-25T08:00:00Z",
         "2026-08-25T09:00:00Z",
@@ -5320,6 +5435,51 @@ describe("automated review request", () => {
     assertEquals(result.requested, false);
     assertEquals(result.reason, "stale-epoch");
     assertEquals(fixture.posted, []);
+
+    const unrelatedUpdate = requestFixture({
+      events: [oldEpoch],
+      updatedAtResponses: [
+        "2026-08-25T08:00:00Z",
+        "2026-08-25T09:00:00Z",
+      ],
+    });
+    const unrelatedResult = await requestAutomatedReview({
+      github: unrelatedUpdate.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      requestKey: "base-42",
+      validateRequestEpoch: true,
+      revalidateReviewEvidence: true,
+    });
+    assertEquals(unrelatedResult.requested, true);
+
+    const synchronize = requestFixture({
+      eventResponses: [
+        [oldEpoch],
+        [oldEpoch, {
+          event: "ready_for_review",
+          id: 43,
+          created_at: "2026-08-25T09:00:00Z",
+        }],
+      ],
+      updatedAtResponses: [
+        "2026-08-25T08:00:00Z",
+        "2026-08-25T09:00:00Z",
+      ],
+    });
+    const synchronizeResult = await requestAutomatedReview({
+      github: synchronize.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      revalidateReviewEvidence: true,
+    });
+    assertEquals(synchronizeResult.requested, false);
+    assertEquals(synchronizeResult.reason, "stale-epoch");
+    assertEquals(synchronize.posted, []);
   });
 
   it("does not post when the pull request is closed or draft", async () => {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2610,8 +2610,46 @@ describe("automated review publication", () => {
       fixture.published[0]?.description,
       `PR#1 reset base:${
         reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
-      } key:ready-run-9001-at-1787648400000`,
+      } key:ready-run-9001-at-1787648400000-event-41`,
     );
+  });
+
+  it("keeps a published run-bound reset as the active proof boundary", async () => {
+    const fixture = githubFixture({
+      commit: HEAD,
+      pages: {
+        comments: [[codexComment(HEAD.slice(0, 10), {
+          id: 103,
+          created_at: "2026-08-25T09:00:00Z",
+          updated_at: "2026-08-25T09:00:00Z",
+        })]],
+        events: [[{
+          event: "ready_for_review",
+          id: 41,
+          created_at: "2026-08-25T08:00:00Z",
+        }]],
+        statuses: [[automatedReviewStatus({
+          id: 104,
+          state: "pending",
+          description: `PR#1 reset base:${
+            reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
+          } key:ready-run-9001-at-1787644800000-event-41`,
+          created_at: "2026-08-25T10:00:00Z",
+        })]],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+
+    assertEquals(result.state, "pending");
+    assertEquals(result.review, undefined);
+    assertEquals(fixture.published, []);
   });
 
   it("starts a fresh pending epoch when a pull request reopens", async () => {
@@ -2784,7 +2822,7 @@ describe("automated review publication", () => {
       tiedFixture.published[0]?.description,
       `PR#1 reset base:${
         reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
-      } key:reopen-run-9001-at-1787648400000`,
+      } key:reopen-run-9001-at-1787648400000-event-41`,
     );
 
     const runReset = automatedReviewResetStatus(
@@ -2793,7 +2831,7 @@ describe("automated review publication", () => {
         id: 101,
         description: `PR#1 reset base:${
           reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
-        } key:reopen-run-9001-at-1787648400000`,
+        } key:reopen-run-9001-at-1787648400000-event-41`,
       },
     );
 
@@ -3796,7 +3834,7 @@ describe("automated review timeout watchdog", () => {
         id: 100,
         description: `PR#1 reset base:${
           reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
-        } key:base-run-9001-at-1787644800000`,
+        } key:base-run-9001-at-1787644800000-event-42`,
       },
     );
     const runRecovery = githubFixture({
@@ -3831,7 +3869,7 @@ describe("automated review timeout watchdog", () => {
     assertEquals(runRecoveryResult.reason, "revalidated");
     assertEquals(
       runRecovery.commentsPosted[0]?.body,
-      `<!-- automated-review-request: ${HEAD} base-run-9001-at-1787644800000 -->\n@codex review`,
+      `<!-- automated-review-request: ${HEAD} base-run-9001-at-1787644800000-event-42 -->\n@codex review`,
     );
 
     const queueOutage = githubFixture({
@@ -5263,13 +5301,41 @@ describe("automated review request", () => {
       repo: "veryfront-code",
       pullNumber: 1,
       headSha: HEAD,
-      requestKey: "base-run-9001-at-1787644800000",
+      requestKey: "base-run-9001-at-1787644800000-event-42",
       validateRequestEpoch: true,
       reviewEpochNotAfter: "2026-08-25T08:00:00Z",
     });
     assertEquals(staleRunResult.requested, false);
     assertEquals(staleRunResult.reason, "stale-epoch");
     assertEquals(staleRunBound.posted, []);
+
+    const tiedRunBound = requestFixture({
+      events: [
+        {
+          event: "base_ref_changed",
+          id: 42,
+          created_at: "2026-08-25T08:00:00Z",
+        },
+        {
+          event: "base_ref_changed",
+          id: 43,
+          created_at: "2026-08-25T08:00:00Z",
+        },
+      ],
+    });
+    const tiedRunResult = await requestAutomatedReview({
+      github: tiedRunBound.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      requestKey: "base-run-9001-at-1787644800000-event-42",
+      validateRequestEpoch: true,
+      reviewEpochNotAfter: "2026-08-25T08:00:00Z",
+    });
+    assertEquals(tiedRunResult.requested, false);
+    assertEquals(tiedRunResult.reason, "stale-epoch");
+    assertEquals(tiedRunBound.posted, []);
   });
 
   it("refuses to request a review of a malformed head commit", async () => {
@@ -6199,6 +6265,12 @@ describe("automated review workflow", () => {
       !requestCondition.includes("github.event.action == 'opened'"),
       "open events are already handled by the connector",
     );
+    assert(
+      requestCondition.includes(
+        "steps.publish.outputs.explicit-ready-request == 'true'",
+      ),
+      "ready events must request explicitly only when an ambiguous reset needs replacement proof",
+    );
     const requestScript = String(
       record(request.with, "request inputs").script,
     );
@@ -6254,6 +6326,10 @@ describe("automated review workflow", () => {
         script.includes('? "ready"'),
       "ready publishers must establish a visible lifecycle epoch",
     );
+    assert(
+      script.includes('core.setOutput("explicit-ready-request", "true")'),
+      "the publisher must expose only a run-bound ready reset to the request step",
+    );
     assert(!script.includes("`reopen-${context.runId}`"));
     assert(
       script.includes('context.payload.action === "edited"') &&
@@ -6275,6 +6351,7 @@ describe("automated review workflow", () => {
         "github.event_name == 'issue_comment'",
         "github.event_name == 'workflow_run'",
         "github.event_name == 'pull_request_target'",
+        "github.event.action == 'synchronize'",
         "github.event.action == 'edited'",
         "github.event.action == 'reopened'",
         "github.event.action == 'ready_for_review'",

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2676,13 +2676,23 @@ describe("automated review publication", () => {
     );
     const tiedFixture = githubFixture({
       pages: {
+        comments: [[codexComment(HEAD.slice(0, 10), {
+          id: 103,
+          created_at: "2026-08-25T09:00:00Z",
+          updated_at: "2026-08-25T09:00:00Z",
+        })]],
         events: [[{
           event: "reopened",
           id: 41,
           created_at: "2026-08-25T09:00:00Z",
         }]],
         statuses: [[tiedReset]],
+        timeline: [[
+          { event: "reopened", id: 41 },
+          { event: "commented", id: 103 },
+        ]],
       },
+      commit: HEAD,
     });
     const tiedResult = await publishAutomatedReviewStatus({
       github: tiedFixture.github,

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2073,6 +2073,40 @@ describe("automated review publication", () => {
     });
     assertEquals(staleResult.state, "pending");
     assertEquals(staleFixture.published[0]?.state, "pending");
+
+    const lateTerminalStatus = automatedReviewStatus({
+      id: 106,
+      state: "failure",
+      description: "PR#1 automated review rate limited",
+      target_url: limitComment.html_url,
+      created_at: "2026-08-25T10:00:00Z",
+    });
+    const lateFixture = githubFixture({
+      pages: {
+        comments: [[limitComment]],
+        events: [[{
+          event: "reopened",
+          id: 102,
+          created_at: "2026-08-25T09:00:00Z",
+        }]],
+        statuses: [[lateTerminalStatus]],
+        timeline: [[
+          { event: "committed", sha: HEAD },
+          { event: "commented", id: 103 },
+          { event: "reopened", id: 102 },
+        ]],
+      },
+    });
+    const lateResult = await publishAutomatedReviewStatus({
+      github: lateFixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+    assertEquals(lateResult.state, "pending");
+    assertEquals(lateFixture.published[0]?.state, "pending");
   });
 
   it("ignores terminal descriptions from another status context", async () => {
@@ -4804,6 +4838,33 @@ describe("automated review request", () => {
       "current review epoch event is not visible",
     );
     assertEquals(notVisible.posted, []);
+
+    const staleConcrete = requestFixture({
+      events: [
+        {
+          event: "base_ref_changed",
+          id: 42,
+          created_at: "2026-08-25T09:00:00Z",
+        },
+        {
+          event: "reopened",
+          id: 43,
+          created_at: "2026-08-25T10:00:00Z",
+        },
+      ],
+    });
+    const staleConcreteResult = await requestAutomatedReview({
+      github: staleConcrete.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      requestKey: "base-42",
+      validateRequestEpoch: true,
+    });
+    assertEquals(staleConcreteResult.requested, false);
+    assertEquals(staleConcreteResult.reason, "stale-epoch");
+    assertEquals(staleConcrete.posted, []);
   });
 
   it("refuses to request a review of a malformed head commit", async () => {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2226,6 +2226,35 @@ describe("automated review publication", () => {
       hiddenFixture.published[0]?.description,
       retryStatus.description,
     );
+
+    const sameSecondRetry = automatedReviewStatus({
+      id: 107,
+      state: "failure",
+      description: "PR#1 review status unavailable; queue retry pending",
+      created_at: "2026-08-25T09:00:00Z",
+    });
+    const sameSecondFixture = githubFixture({
+      pages: {
+        events: [[{
+          event: "ready_for_review",
+          id: 108,
+          created_at: "2026-08-25T09:00:00Z",
+        }]],
+        statuses: [[sameSecondRetry]],
+      },
+    });
+    const sameSecondResult = await publishAutomatedReviewStatus({
+      github: sameSecondFixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+    assertEquals(sameSecondResult.state, "failure");
+    assertEquals(sameSecondResult.statusId, 107);
+    assertEquals(sameSecondResult.description, sameSecondRetry.description);
+    assertEquals(sameSecondFixture.published, []);
   });
 
   it("does not time out a pending status from before a base reset", async () => {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2693,10 +2693,25 @@ describe("automated review publication", () => {
       pullUrl: "https://example.test/pr/1",
       reviewResetKey: "reopen",
       reviewEpochNotBefore: "2026-08-25T09:00:00Z",
-      reviewEpochRunAttempt: 1,
+      reviewEpochRunKey: "9001",
     });
-    assertEquals(tiedResult.state, "failure");
-    assertEquals(tiedResult.description, "PR#1 review status unavailable");
+    assertEquals(tiedResult.state, "pending");
+    assertEquals(
+      tiedFixture.published[0]?.description,
+      `PR#1 reset base:${
+        reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
+      } key:bb86ec90ecc2`,
+    );
+
+    const runReset = automatedReviewResetStatus(
+      "2026-08-25T09:00:01Z",
+      {
+        id: 101,
+        description: `PR#1 reset base:${
+          reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
+        } key:bb86ec90ecc2`,
+      },
+    );
 
     const rerun = await publishAutomatedReviewStatus({
       github: githubFixture({
@@ -2706,7 +2721,7 @@ describe("automated review publication", () => {
             id: 41,
             created_at: "2026-08-25T09:00:00Z",
           }]],
-          statuses: [[tiedReset]],
+          statuses: [[runReset, tiedReset]],
         },
       }).github,
       owner: "veryfront",
@@ -2716,10 +2731,10 @@ describe("automated review publication", () => {
       pullUrl: "https://example.test/pr/1",
       reviewResetKey: "reopen",
       reviewEpochNotBefore: "2026-08-25T09:00:00Z",
-      reviewEpochRunAttempt: 2,
+      reviewEpochRunKey: "9001",
     });
     assertEquals(rerun.state, "pending");
-    assertEquals(rerun.statusId, 100);
+    assertEquals(rerun.statusId, 101);
   });
 
   it("fails when exact-ref lookup is operationally unavailable", async () => {
@@ -5707,7 +5722,7 @@ describe("automated review workflow", () => {
     assert(
       script.includes("reviewEpochNotBefore") &&
         script.includes("context.payload.pull_request?.updated_at") &&
-        script.includes("reviewEpochRunAttempt: context.runAttempt"),
+        script.includes("reviewEpochRunKey: String(context.runId)"),
       "lifecycle publishers must wait for the triggering durable event",
     );
     assert(script.includes("sourceStatusId: result.statusId"));
@@ -5805,7 +5820,8 @@ describe("automated review workflow", () => {
     assert(requestScript.includes("requestKey"));
     assert(
       requestScript.includes("reviewEpochNotBefore") &&
-        requestScript.includes("context.payload.pull_request?.updated_at"),
+        requestScript.includes("context.payload.pull_request?.updated_at") &&
+        requestScript.includes("reviewEpochRunKey: String(context.runId)"),
       "lifecycle requests must wait for the triggering durable event",
     );
     assert(

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1060,6 +1060,7 @@ function githubFixture(options: {
   queueRefHeads?: (string | undefined)[];
   queueRefError?: Error;
   statusIds?: unknown[];
+  commentError?: Error;
 } = {}) {
   const endpoints = {
     reviews: () => undefined,
@@ -1136,6 +1137,7 @@ function githubFixture(options: {
         listEvents: endpoints.events,
         listEventsForTimeline: endpoints.timeline,
         createComment: (comment: Record<string, unknown>) => {
+          if (options.commentError) return Promise.reject(options.commentError);
           commentsPosted.push(comment);
           return Promise.resolve();
         },
@@ -2571,6 +2573,47 @@ describe("automated review publication", () => {
     assertEquals(fixture.published[0]?.state, "pending");
   });
 
+  it("forces a run-bound reset when ready evidence is ambiguous", async () => {
+    const fixture = githubFixture({
+      pages: {
+        comments: [[codexComment(HEAD.slice(0, 10), {
+          id: 103,
+          created_at: "2026-08-25T09:00:00Z",
+          updated_at: "2026-08-25T09:00:00Z",
+        })]],
+        events: [[{
+          event: "ready_for_review",
+          id: 41,
+          created_at: "2026-08-25T09:00:00Z",
+        }]],
+        timeline: [[
+          { event: "ready_for_review", id: 41 },
+          { event: "commented", id: 103 },
+        ]],
+      },
+      commit: HEAD,
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      reviewResetKey: "ready",
+      reviewEpochNotBefore: "2026-08-25T09:00:00Z",
+      reviewEpochRunKey: "9001",
+    });
+
+    assertEquals(result.state, "pending");
+    assertEquals(
+      fixture.published[0]?.description,
+      `PR#1 reset base:${
+        reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
+      } key:83510c2f2105`,
+    );
+  });
+
   it("starts a fresh pending epoch when a pull request reopens", async () => {
     const fixture = githubFixture({
       pages: {
@@ -3783,6 +3826,37 @@ describe("automated review timeout watchdog", () => {
     assertEquals(queueOutage.published[0]?.state, "pending");
     assertEquals(
       queueOutage.published.at(-1)?.description,
+      "PR#1 review status unavailable; queue retry pending",
+    );
+
+    const requestOutage = githubFixture({
+      pageResponses: {
+        statuses: [
+          [[unavailableStatus]],
+          [[unavailableStatus]],
+        ],
+      },
+      pages: { refs: [[]] },
+      commentError: new Error("request comment unavailable"),
+      statusIds: [1001, 1002],
+    });
+    await assertRejects(
+      () =>
+        expireTimedOutAutomatedReview({
+          github: requestOutage.github,
+          owner: "veryfront",
+          repo: "veryfront-code",
+          pullNumber: 1,
+          headSha: HEAD,
+          now: Date.parse("2026-08-25T08:30:01Z"),
+          reviewTimeoutMs: 1_800_000,
+        }),
+      Error,
+      "request comment unavailable",
+    );
+    assertEquals(requestOutage.published[0]?.state, "pending");
+    assertEquals(
+      requestOutage.published.at(-1)?.description,
       "PR#1 review status unavailable; queue retry pending",
     );
   });
@@ -5970,6 +6044,11 @@ describe("automated review workflow", () => {
       script.includes('context.payload.action === "reopened"') &&
         script.includes('? "reopen"'),
       "reopened publishers must derive their key from the durable epoch",
+    );
+    assert(
+      script.includes('context.payload.action === "ready_for_review"') &&
+        script.includes('? "ready"'),
+      "ready publishers must establish a visible lifecycle epoch",
     );
     assert(!script.includes("`reopen-${context.runId}`"));
     assert(

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -7,6 +7,7 @@ import {
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { parse } from "#std/yaml/parse";
 import {
+  completeReviewFailurePropagation,
   expireTimedOutAutomatedReview,
   findAutomatedReview,
   findTimedOutAutomatedReviews,
@@ -2532,6 +2533,32 @@ describe("automated review publication", () => {
       supersededBase.published[0]?.description,
       `PR#1 waits for review ${HEAD.slice(0, 12)}`,
     );
+
+    const notVisible = githubFixture({
+      pages: {
+        events: [[{
+          event: "reopened",
+          id: 41,
+          created_at: "2026-08-25T08:00:00Z",
+        }]],
+        statuses: [[pendingAutomatedReviewStatus()]],
+      },
+    });
+    const notVisibleResult = await publishAutomatedReviewStatus({
+      github: notVisible.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      reviewResetKey: "reopen",
+      reviewEpochNotBefore: "2026-08-25T09:00:00Z",
+    });
+    assertEquals(notVisibleResult.state, "failure");
+    assertEquals(
+      notVisibleResult.description,
+      "PR#1 review status unavailable",
+    );
   });
 
   it("fails when exact-ref lookup is operationally unavailable", async () => {
@@ -3162,10 +3189,10 @@ describe("automated review timeout watchdog", () => {
   });
 
   it("revalidates and expires the same pending status under the publisher", async () => {
-    const preservedTimeoutStatus = automatedReviewStatus({
+    const retryTimeoutStatus = automatedReviewStatus({
       id: 1001,
       state: "failure",
-      description: "PR#1 automated review timed out",
+      description: "PR#1 automated review timed out; queue retry pending",
     });
     const fixture = githubFixture({
       pages: {
@@ -3175,7 +3202,8 @@ describe("automated review timeout watchdog", () => {
         statuses: [
           [[pendingAutomatedReviewStatus()]],
           [[pendingAutomatedReviewStatus()]],
-          [[preservedTimeoutStatus]],
+          [[retryTimeoutStatus]],
+          [[retryTimeoutStatus]],
         ],
       },
       commit: HEAD,
@@ -3313,6 +3341,7 @@ describe("automated review timeout watchdog", () => {
           [[retryStatus]],
           [[retryStatus]],
           [[retryStatus]],
+          [[retryStatus]],
         ],
       },
       pages: { refs: [[]] },
@@ -3349,6 +3378,7 @@ describe("automated review timeout watchdog", () => {
         statuses: [
           [[retryStatus]],
           [[], []],
+          [[unavailableRetryStatus]],
           [[unavailableRetryStatus]],
         ],
       },
@@ -3484,6 +3514,49 @@ describe("automated review timeout watchdog", () => {
     assert("state" in result);
     assertEquals(result.state, "pending");
     assertEquals(fixture.published[0]?.state, "pending");
+  });
+
+  it("does not finalize a retry after a newer lifecycle epoch", async () => {
+    const retryStatus = automatedReviewStatus({
+      id: 1001,
+      state: "failure",
+      description: "PR#1 automated review timed out; queue retry pending",
+      target_url: "https://example.test/pr/1",
+      created_at: "2026-08-25T08:00:00Z",
+    });
+    const fixture = githubFixture({
+      pageResponses: {
+        statuses: [
+          [[retryStatus]],
+          [[retryStatus]],
+        ],
+      },
+      pages: {
+        comments: [[]],
+        events: [[{
+          event: "base_ref_changed",
+          id: 102,
+          created_at: "2026-08-25T09:00:00Z",
+        }]],
+        refs: [[]],
+        timeline: [[]],
+      },
+      commit: HEAD,
+    });
+
+    const result = await completeReviewFailurePropagation({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      sourceStatusId: 1001,
+      description: retryStatus.description,
+      targetUrl: retryStatus.target_url,
+    });
+    assertEquals(result.finalized, false);
+    assertEquals(result.statusId, 1001);
+    assertEquals(fixture.published, []);
   });
 
   it("publishes review proof that arrives before timeout revalidation", async () => {
@@ -4566,6 +4639,29 @@ describe("automated review request", () => {
     assertEquals(supersededBaseResult.requested, false);
     assertEquals(supersededBaseResult.reason, "stale-epoch");
     assertEquals(supersededBase.posted, []);
+
+    const notVisible = requestFixture({
+      events: [{
+        event: "reopened",
+        id: 41,
+        created_at: "2026-08-25T08:00:00Z",
+      }],
+    });
+    await assertRejects(
+      () =>
+        requestAutomatedReview({
+          github: notVisible.github,
+          owner: "veryfront",
+          repo: "veryfront-code",
+          pullNumber: 1,
+          headSha: HEAD,
+          requestKey: "reopen",
+          reviewEpochNotBefore: "2026-08-25T09:00:00Z",
+        }),
+      Error,
+      "current review epoch event is not visible",
+    );
+    assertEquals(notVisible.posted, []);
   });
 
   it("refuses to request a review of a malformed head commit", async () => {
@@ -5405,6 +5501,11 @@ describe("automated review workflow", () => {
     assert(script.includes("completeReviewFailurePropagation"));
     assert(script.includes("publishReviewPropagationRetryStatus"));
     assert(script.includes("queuePropagationPending: true"));
+    assert(
+      script.includes("reviewEpochNotBefore") &&
+        script.includes("context.payload.pull_request?.updated_at"),
+      "lifecycle publishers must wait for the triggering durable event",
+    );
     assert(script.includes("sourceStatusId: result.statusId"));
     assert(script.includes("reconcileActiveMergeGroupReviewStatuses"));
     assert(!script.includes("github.rest.pulls.get"));
@@ -5498,6 +5599,11 @@ describe("automated review workflow", () => {
       "the workflow must post review requests through the tested gate helper",
     );
     assert(requestScript.includes("requestKey"));
+    assert(
+      requestScript.includes("reviewEpochNotBefore") &&
+        requestScript.includes("context.payload.pull_request?.updated_at"),
+      "lifecycle requests must wait for the triggering durable event",
+    );
     assert(
       requestScript.includes('context.payload.action === "edited"') &&
         requestScript.includes('? "base"'),

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1070,6 +1070,7 @@ function githubFixture(options: {
     timeline: () => undefined,
   };
   const published: Record<string, unknown>[] = [];
+  const commentsPosted: Record<string, unknown>[] = [];
   const refReads: Record<string, unknown>[] = [];
   const graphqlReads: { query: unknown; variables: unknown }[] = [];
   const pageReads = new Map<string, number>();
@@ -1134,6 +1135,10 @@ function githubFixture(options: {
         listComments: endpoints.comments,
         listEvents: endpoints.events,
         listEventsForTimeline: endpoints.timeline,
+        createComment: (comment: Record<string, unknown>) => {
+          commentsPosted.push(comment);
+          return Promise.resolve();
+        },
       },
       git: {
         listMatchingRefs: endpoints.refs,
@@ -1176,7 +1181,7 @@ function githubFixture(options: {
       },
     },
   };
-  return { github, published, refReads, graphqlReads };
+  return { github, published, commentsPosted, refReads, graphqlReads };
 }
 
 describe("automated review publication", () => {
@@ -2256,6 +2261,72 @@ describe("automated review publication", () => {
     assertEquals(sameSecondResult.statusId, 107);
     assertEquals(sameSecondResult.description, sameSecondRetry.description);
     assertEquals(sameSecondFixture.published, []);
+
+    const oldLimitComment = codexRateLimitComment(
+      "2026-08-25T08:00:00Z",
+    );
+    const lateRateMarker = automatedReviewStatus({
+      id: 109,
+      state: "failure",
+      description:
+        "PR#1 automated review rate limited; queue retry pending",
+      target_url: oldLimitComment.html_url,
+      created_at: "2026-08-25T10:00:00Z",
+    });
+    const staleRateFixture = githubFixture({
+      pages: {
+        comments: [[oldLimitComment]],
+        events: [[{
+          event: "ready_for_review",
+          id: 108,
+          created_at: "2026-08-25T09:00:00Z",
+        }]],
+        statuses: [[lateRateMarker]],
+        timeline: [[
+          { event: "committed", sha: HEAD },
+          { event: "commented", id: 103 },
+          { event: "ready_for_review", id: 108 },
+        ]],
+      },
+    });
+    const staleRateResult = await publishAutomatedReviewStatus({
+      github: staleRateFixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+    assertEquals(staleRateResult.state, "pending");
+
+    const lateTimeoutMarker = automatedReviewStatus({
+      id: 110,
+      state: "failure",
+      description: "PR#1 automated review timed out; queue retry pending",
+      created_at: "2026-08-25T10:00:00Z",
+    });
+    const staleTimeoutFixture = githubFixture({
+      pages: {
+        events: [[{
+          event: "ready_for_review",
+          id: 108,
+          created_at: "2026-08-25T09:00:00Z",
+        }]],
+        statuses: [[
+          lateTimeoutMarker,
+          pendingAutomatedReviewStatus("2026-08-25T08:00:00Z"),
+        ]],
+      },
+    });
+    const staleTimeoutResult = await publishAutomatedReviewStatus({
+      github: staleTimeoutFixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+    assertEquals(staleTimeoutResult.state, "pending");
   });
 
   it("does not time out a pending status from before a base reset", async () => {
@@ -2559,6 +2630,62 @@ describe("automated review publication", () => {
       notVisibleResult.description,
       "PR#1 review status unavailable",
     );
+
+    const tiedReset = automatedReviewResetStatus(
+      "2026-08-25T09:00:00Z",
+      {
+        id: 100,
+        description: `PR#1 reset base:${
+          reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
+        } key:160accde50a8`,
+      },
+    );
+    const tiedFixture = githubFixture({
+      pages: {
+        events: [[{
+          event: "reopened",
+          id: 41,
+          created_at: "2026-08-25T09:00:00Z",
+        }]],
+        statuses: [[tiedReset]],
+      },
+    });
+    const tiedResult = await publishAutomatedReviewStatus({
+      github: tiedFixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      reviewResetKey: "reopen",
+      reviewEpochNotBefore: "2026-08-25T09:00:00Z",
+      reviewEpochRunAttempt: 1,
+    });
+    assertEquals(tiedResult.state, "failure");
+    assertEquals(tiedResult.description, "PR#1 review status unavailable");
+
+    const rerun = await publishAutomatedReviewStatus({
+      github: githubFixture({
+        pages: {
+          events: [[{
+            event: "reopened",
+            id: 41,
+            created_at: "2026-08-25T09:00:00Z",
+          }]],
+          statuses: [[tiedReset]],
+        },
+      }).github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      reviewResetKey: "reopen",
+      reviewEpochNotBefore: "2026-08-25T09:00:00Z",
+      reviewEpochRunAttempt: 2,
+    });
+    assertEquals(rerun.state, "pending");
+    assertEquals(rerun.statusId, 100);
   });
 
   it("fails when exact-ref lookup is operationally unavailable", async () => {
@@ -3514,6 +3641,10 @@ describe("automated review timeout watchdog", () => {
     assert("state" in result);
     assertEquals(result.state, "pending");
     assertEquals(fixture.published[0]?.state, "pending");
+    assertEquals(
+      fixture.commentsPosted[0]?.body,
+      `<!-- automated-review-request: ${HEAD} -->\n@codex review`,
+    );
   });
 
   it("does not finalize a retry after a newer lifecycle epoch", async () => {
@@ -5209,7 +5340,7 @@ describe("automated review workflow", () => {
       record(timeoutJob.permissions, "timeout publisher permissions"),
       {
         contents: "read",
-        "pull-requests": "read",
+        "pull-requests": "write",
         statuses: "write",
       },
     );
@@ -5503,7 +5634,8 @@ describe("automated review workflow", () => {
     assert(script.includes("queuePropagationPending: true"));
     assert(
       script.includes("reviewEpochNotBefore") &&
-        script.includes("context.payload.pull_request?.updated_at"),
+        script.includes("context.payload.pull_request?.updated_at") &&
+        script.includes("reviewEpochRunAttempt: context.runAttempt"),
       "lifecycle publishers must wait for the triggering durable event",
     );
     assert(script.includes("sourceStatusId: result.statusId"));

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2610,7 +2610,7 @@ describe("automated review publication", () => {
       fixture.published[0]?.description,
       `PR#1 reset base:${
         reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
-      } key:ready-run-9001`,
+      } key:ready-run-9001-at-1787648400000`,
     );
   });
 
@@ -2784,7 +2784,7 @@ describe("automated review publication", () => {
       tiedFixture.published[0]?.description,
       `PR#1 reset base:${
         reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
-      } key:reopen-run-9001`,
+      } key:reopen-run-9001-at-1787648400000`,
     );
 
     const runReset = automatedReviewResetStatus(
@@ -2793,7 +2793,7 @@ describe("automated review publication", () => {
         id: 101,
         description: `PR#1 reset base:${
           reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
-        } key:reopen-run-9001`,
+        } key:reopen-run-9001-at-1787648400000`,
       },
     );
 
@@ -3796,7 +3796,7 @@ describe("automated review timeout watchdog", () => {
         id: 100,
         description: `PR#1 reset base:${
           reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
-        } key:base-run-9001`,
+        } key:base-run-9001-at-1787644800000`,
       },
     );
     const runRecovery = githubFixture({
@@ -3831,7 +3831,7 @@ describe("automated review timeout watchdog", () => {
     assertEquals(runRecoveryResult.reason, "revalidated");
     assertEquals(
       runRecovery.commentsPosted[0]?.body,
-      `<!-- automated-review-request: ${HEAD} base-run-9001 -->\n@codex review`,
+      `<!-- automated-review-request: ${HEAD} base-run-9001-at-1787644800000 -->\n@codex review`,
     );
 
     const queueOutage = githubFixture({
@@ -4777,6 +4777,7 @@ function requestFixture(options: {
   comments?: Record<string, unknown>[];
   events?: Record<string, unknown>[];
   eventResponses?: Record<string, unknown>[][];
+  reviews?: Record<string, unknown>[];
   currentHead?: string;
   currentState?: string;
   draft?: boolean;
@@ -4785,12 +4786,16 @@ function requestFixture(options: {
   const state = {
     comments: options.comments ?? [],
     events: options.events ?? [],
+    reviews: options.reviews ?? [],
     currentHead: options.currentHead ?? HEAD,
     currentState: options.currentState ?? "open",
     draft: options.draft ?? false,
   };
   const listComments = () => undefined;
   const listEvents = () => undefined;
+  const listReviews = () => undefined;
+  const listStatuses = () => undefined;
+  const listTimeline = () => undefined;
   let eventRead = 0;
   const github = {
     paginate: {
@@ -4801,6 +4806,9 @@ function requestFixture(options: {
             Math.min(eventRead++, options.eventResponses.length - 1)
           ] ?? state.events;
           yield { data: events };
+        } else if (endpoint === listReviews) yield { data: state.reviews };
+        else if (endpoint === listStatuses || endpoint === listTimeline) {
+          yield { data: [] };
         }
         else throw new Error("unknown endpoint");
       },
@@ -4809,20 +4817,28 @@ function requestFixture(options: {
       issues: {
         listComments,
         listEvents,
+        listEventsForTimeline: listTimeline,
         createComment: (comment: Record<string, unknown>) => {
           posted.push(comment);
           return Promise.resolve();
         },
       },
       pulls: {
+        listReviews,
         get: () =>
           Promise.resolve({
             data: {
               head: { sha: state.currentHead },
+              base: { ref: BASE_REF, repo: { id: BASE_REPOSITORY_ID } },
+              user: { login: "pull-author" },
               state: state.currentState,
               draft: state.draft,
             },
           }),
+      },
+      repos: {
+        listCommitStatusesForRef: listStatuses,
+        getCommit: () => Promise.resolve({ data: { sha: HEAD } }),
       },
     },
   };
@@ -4900,6 +4916,23 @@ describe("automated review request", () => {
     assertEquals(result.requested, false);
     assertEquals(result.reason, "stale-head");
     assertEquals(fixture.posted.length, 0);
+  });
+
+  it("does not request after exact-head proof arrives", async () => {
+    const fixture = requestFixture({
+      reviews: [review({ state: "APPROVED" })],
+    });
+    const result = await requestAutomatedReview({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      revalidateReviewEvidence: true,
+    });
+    assertEquals(result.requested, false);
+    assertEquals(result.reason, "reviewed");
+    assertEquals(fixture.posted, []);
   });
 
   it("does not post when the pull request is closed or draft", async () => {
@@ -5171,9 +5204,9 @@ describe("automated review request", () => {
       repo: "veryfront-code",
       pullNumber: 1,
       headSha: HEAD,
-      requestKey: "base-run-9001",
+      requestKey: "base-run-9001-at-1787644800000",
       validateRequestEpoch: true,
-      reviewEpochNotAfter: "2026-08-25T09:00:00Z",
+      reviewEpochNotAfter: "2026-08-25T08:00:00Z",
     });
     assertEquals(staleRunResult.requested, false);
     assertEquals(staleRunResult.reason, "stale-epoch");
@@ -6092,6 +6125,7 @@ describe("automated review workflow", () => {
         "github.event.pull_request.draft == false",
         "github.event.action == 'synchronize'",
         "github.event.action == 'reopened'",
+        "github.event.action == 'ready_for_review'",
         "github.event.action == 'edited'",
         "github.event.changes.base",
         "steps.publish.outputs.result == 'pending'",
@@ -6103,9 +6137,8 @@ describe("automated review workflow", () => {
       );
     }
     assert(
-      !requestCondition.includes("github.event.action == 'ready_for_review'") &&
-        !requestCondition.includes("github.event.action == 'opened'"),
-      "open and ready-for-review events are already handled by the connector",
+      !requestCondition.includes("github.event.action == 'opened'"),
+      "open events are already handled by the connector",
     );
     const requestScript = String(
       record(request.with, "request inputs").script,
@@ -6123,6 +6156,10 @@ describe("automated review workflow", () => {
       "lifecycle requests must wait for the triggering durable event",
     );
     assert(
+      requestScript.includes("revalidateReviewEvidence: true"),
+      "request posting must recheck exact-head proof at the final boundary",
+    );
+    assert(
       requestScript.includes('context.payload.action === "edited"') &&
         requestScript.includes('? "base"'),
       "base-edit requests must derive their key from the durable epoch",
@@ -6134,6 +6171,11 @@ describe("automated review workflow", () => {
       "reopened requests must derive their key from the durable epoch",
     );
     assert(!requestScript.includes("`reopen-${context.runId}`"));
+    assert(
+      requestScript.includes('context.payload.action === "ready_for_review"') &&
+        requestScript.includes('? "ready"'),
+      "ready resets must explicitly request replacement proof",
+    );
     assert(
       requestScript.includes('result.reason === "ineligible-pull"'),
       "a delayed request must report that the pull request is no longer eligible",

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2198,6 +2198,34 @@ describe("automated review publication", () => {
     });
     assertEquals(resetResult.state, "pending");
     assertEquals(resetFixture.published[0]?.state, "pending");
+
+    const hiddenFixture = githubFixture({
+      pages: {
+        statuses: [[
+          automatedReviewStatus({
+            id: 106,
+            state: "failure",
+            description: "PR#1 review status unavailable",
+          }),
+          retryStatus,
+        ]],
+      },
+    });
+    const hiddenResult = await publishAutomatedReviewStatus({
+      github: hiddenFixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+    assertEquals(hiddenResult.state, "failure");
+    assertEquals(hiddenResult.description, retryStatus.description);
+    assertEquals(hiddenFixture.published[0]?.state, "failure");
+    assertEquals(
+      hiddenFixture.published[0]?.description,
+      retryStatus.description,
+    );
   });
 
   it("does not time out a pending status from before a base reset", async () => {
@@ -3356,6 +3384,77 @@ describe("automated review timeout watchdog", () => {
       queueOutage.published.at(-1)?.description,
       retryDescription,
     );
+
+    const publishedQueueFailure = githubFixture({
+      pages: {
+        reviews: [[review({ state: "APPROVED" })]],
+        refs: [[{
+          ref: `refs/heads/gh-readonly-queue/${BASE_REF}/pr-1-${BASE_HEAD}`,
+          object: { sha: OTHER_HEAD },
+        }]],
+      },
+      pageResponses: {
+        statuses: [
+          [[retryStatus]],
+          [[retryStatus]],
+          [[pendingAutomatedReviewStatus()]],
+        ],
+      },
+      statusIds: [1001, 1002, 1003],
+    });
+    await assertRejects(
+      () =>
+        expireTimedOutAutomatedReview({
+          github: publishedQueueFailure.github,
+          owner: "veryfront",
+          repo: "veryfront-code",
+          pullNumber: 1,
+          headSha: HEAD,
+          now: Date.parse("2026-08-25T08:30:01Z"),
+          reviewTimeoutMs: 1_800_000,
+        }),
+      Error,
+      "active merge queue review failed",
+    );
+    assertEquals(publishedQueueFailure.published[0]?.state, "success");
+    assertEquals(publishedQueueFailure.published[1]?.sha, OTHER_HEAD);
+    assertEquals(publishedQueueFailure.published[1]?.state, "failure");
+    assertEquals(
+      publishedQueueFailure.published.at(-1)?.description,
+      retryDescription,
+    );
+  });
+
+  it("reconciles an unavailable failure without a pending anchor", async () => {
+    const unavailableStatus = automatedReviewStatus({
+      id: 106,
+      state: "failure",
+      description: "PR#1 review status unavailable",
+    });
+    const fixture = githubFixture({
+      pageResponses: {
+        statuses: [
+          [[unavailableStatus]],
+          [[unavailableStatus]],
+        ],
+      },
+      pages: { refs: [[]] },
+    });
+    const result = await expireTimedOutAutomatedReview({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      now: Date.parse("2026-08-25T08:30:01Z"),
+      reviewTimeoutMs: 1_800_000,
+    });
+
+    assertEquals(result.expired, false);
+    assertEquals(result.reason, "revalidated");
+    assert("state" in result);
+    assertEquals(result.state, "pending");
+    assertEquals(fixture.published[0]?.state, "pending");
   });
 
   it("publishes review proof that arrives before timeout revalidation", async () => {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -3433,6 +3433,31 @@ describe("automated review publication", () => {
 
     assertEquals(result.state, "failure");
     assertEquals(result.review, undefined);
+
+    const delayedEvent = githubFixture({
+      pages: {
+        comments: [[codexComment(HEAD.slice(0, 10), {
+          created_at: "2026-08-25T08:30:00Z",
+          updated_at: "2026-08-25T08:30:00Z",
+        })]],
+        events: [[oldEpoch]],
+      },
+      pullResponses: [
+        associatedPull({ updated_at: "2026-08-25T08:00:00Z" }),
+        associatedPull({ updated_at: "2026-08-25T09:00:00Z" }),
+      ],
+      commit: HEAD,
+    });
+    const delayedResult = await publishAutomatedReviewStatus({
+      github: delayedEvent.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+    assertEquals(delayedResult.state, "failure");
+    assertEquals(delayedResult.review, undefined);
   });
 });
 
@@ -4219,6 +4244,36 @@ describe("automated review timeout watchdog", () => {
       fixture.published.at(-1)?.description,
       "PR#1 review status unavailable; retry finalized",
     );
+
+    const requestRetry = automatedReviewStatus({
+      id: 1001,
+      state: "failure",
+      description:
+        "PR#1 review request unavailable; epoch:9f2e6d33a371; queue retry pending",
+      target_url: "https://example.test/pr/1",
+      created_at: "2026-08-25T08:00:00Z",
+    });
+    const requestFixture = githubFixture({
+      pages: {
+        statuses: [[requestRetry]],
+        refs: [[]],
+      },
+      commit: HEAD,
+      statusIds: [1002],
+    });
+    const requestResult = await completeReviewFailurePropagation({
+      github: requestFixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      sourceStatusId: 1001,
+      description: requestRetry.description,
+      targetUrl: requestRetry.target_url,
+    });
+    assertEquals(requestResult.finalized, false);
+    assertEquals(requestResult.description, requestRetry.description);
+    assertEquals(requestFixture.published, []);
   });
 
   it("does not finalize a retry after a newer lifecycle epoch", async () => {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2610,7 +2610,7 @@ describe("automated review publication", () => {
       fixture.published[0]?.description,
       `PR#1 reset base:${
         reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
-      } key:83510c2f2105`,
+      } key:ready-run-9001`,
     );
   });
 
@@ -2784,7 +2784,7 @@ describe("automated review publication", () => {
       tiedFixture.published[0]?.description,
       `PR#1 reset base:${
         reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
-      } key:bb86ec90ecc2`,
+      } key:reopen-run-9001`,
     );
 
     const runReset = automatedReviewResetStatus(
@@ -2793,7 +2793,7 @@ describe("automated review publication", () => {
         id: 101,
         description: `PR#1 reset base:${
           reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
-        } key:bb86ec90ecc2`,
+        } key:reopen-run-9001`,
       },
     );
 
@@ -3788,6 +3788,50 @@ describe("automated review timeout watchdog", () => {
     assertEquals(
       fixture.commentsPosted[0]?.body,
       `<!-- automated-review-request: ${HEAD} base-42 -->\n@codex review`,
+    );
+
+    const runReset = automatedReviewResetStatus(
+      "2026-08-25T08:00:00Z",
+      {
+        id: 100,
+        description: `PR#1 reset base:${
+          reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
+        } key:base-run-9001`,
+      },
+    );
+    const runRecovery = githubFixture({
+      pageResponses: {
+        statuses: [
+          [[unavailableStatus, runReset]],
+          [[unavailableStatus, runReset]],
+        ],
+      },
+      pages: {
+        comments: [[{
+          user: bot("github-actions[bot]", GITHUB_ACTIONS_ID),
+          body: `<!-- automated-review-request: ${HEAD} base-42 -->\n@codex review`,
+        }]],
+        events: [[{
+          event: "base_ref_changed",
+          id: 42,
+          created_at: "2026-08-25T08:00:00Z",
+        }]],
+        refs: [[]],
+      },
+    });
+    const runRecoveryResult = await expireTimedOutAutomatedReview({
+      github: runRecovery.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      now: Date.parse("2026-08-25T08:05:00Z"),
+      reviewTimeoutMs: 1_800_000,
+    });
+    assertEquals(runRecoveryResult.reason, "revalidated");
+    assertEquals(
+      runRecovery.commentsPosted[0]?.body,
+      `<!-- automated-review-request: ${HEAD} base-run-9001 -->\n@codex review`,
     );
 
     const queueOutage = githubFixture({

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -5119,6 +5119,30 @@ describe("automated review request", () => {
     assertEquals(changedResult.requested, false);
     assertEquals(changedResult.reason, "stale-epoch");
     assertEquals(changedDuringRequest.posted, []);
+
+    const tiedOtherKind = requestFixture({
+      events: [{
+        event: "ready_for_review",
+        id: 44,
+        created_at: "2026-08-25T11:00:00Z",
+      }],
+    });
+    await assertRejects(
+      () =>
+        requestAutomatedReview({
+          github: tiedOtherKind.github,
+          owner: "veryfront",
+          repo: "veryfront-code",
+          pullNumber: 1,
+          headSha: HEAD,
+          requestKey: "base",
+          reviewEpochNotBefore: "2026-08-25T11:00:00Z",
+          reviewEpochRunKey: "9001",
+        }),
+      Error,
+      "current review epoch event is not visible",
+    );
+    assertEquals(tiedOtherKind.posted, []);
   });
 
   it("refuses to request a review of a malformed head commit", async () => {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2107,6 +2107,37 @@ describe("automated review publication", () => {
     });
     assertEquals(lateResult.state, "pending");
     assertEquals(lateFixture.published[0]?.state, "pending");
+
+    const oldTimeout = automatedReviewStatus({
+      id: 107,
+      state: "failure",
+      description: "PR#1 automated review timed out",
+      created_at: "2026-08-25T08:00:00Z",
+    });
+    const newPending = pendingAutomatedReviewStatus(
+      "2026-08-25T09:01:00Z",
+    );
+    const oldTimeoutFixture = githubFixture({
+      pages: {
+        events: [[{
+          event: "ready_for_review",
+          id: 108,
+          created_at: "2026-08-25T09:00:00Z",
+        }]],
+        statuses: [[newPending, oldTimeout]],
+      },
+    });
+    const oldTimeoutResult = await publishAutomatedReviewStatus({
+      github: oldTimeoutFixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+    assertEquals(oldTimeoutResult.state, "pending");
+    assertEquals(oldTimeoutResult.statusId, 100);
+    assertEquals(oldTimeoutFixture.published, []);
   });
 
   it("ignores terminal descriptions from another status context", async () => {
@@ -3715,6 +3746,45 @@ describe("automated review timeout watchdog", () => {
       fixture.commentsPosted[0]?.body,
       `<!-- automated-review-request: ${HEAD} base-42 -->\n@codex review`,
     );
+
+    const queueOutage = githubFixture({
+      pageResponses: {
+        statuses: [
+          [[unavailableStatus]],
+          [[unavailableStatus]],
+        ],
+      },
+      pages: {
+        refs: [[{
+          ref: `refs/heads/gh-readonly-queue/${BASE_REF}/pr-1-${BASE_HEAD}`,
+          object: { sha: OTHER_HEAD },
+        }]],
+      },
+      queueBindingError: Object.assign(
+        new Error("queue binding unavailable"),
+        { status: 503 },
+      ),
+      statusIds: [1001, 1002],
+    });
+    await assertRejects(
+      () =>
+        expireTimedOutAutomatedReview({
+          github: queueOutage.github,
+          owner: "veryfront",
+          repo: "veryfront-code",
+          pullNumber: 1,
+          headSha: HEAD,
+          now: Date.parse("2026-08-25T08:30:01Z"),
+          reviewTimeoutMs: 1_800_000,
+        }),
+      Error,
+      "queue binding unavailable",
+    );
+    assertEquals(queueOutage.published[0]?.state, "pending");
+    assertEquals(
+      queueOutage.published.at(-1)?.description,
+      "PR#1 review status unavailable; queue retry pending",
+    );
   });
 
   it("does not finalize a retry after a newer lifecycle epoch", async () => {
@@ -4588,6 +4658,7 @@ describe("merge queue review propagation", () => {
 function requestFixture(options: {
   comments?: Record<string, unknown>[];
   events?: Record<string, unknown>[];
+  eventResponses?: Record<string, unknown>[][];
   currentHead?: string;
   currentState?: string;
   draft?: boolean;
@@ -4602,11 +4673,17 @@ function requestFixture(options: {
   };
   const listComments = () => undefined;
   const listEvents = () => undefined;
+  let eventRead = 0;
   const github = {
     paginate: {
       async *iterator(endpoint: unknown) {
         if (endpoint === listComments) yield { data: state.comments };
-        else if (endpoint === listEvents) yield { data: state.events };
+        else if (endpoint === listEvents) {
+          const events = options.eventResponses?.[
+            Math.min(eventRead++, options.eventResponses.length - 1)
+          ] ?? state.events;
+          yield { data: events };
+        }
         else throw new Error("unknown endpoint");
       },
     },
@@ -4890,6 +4967,40 @@ describe("automated review request", () => {
     assertEquals(staleConcreteResult.requested, false);
     assertEquals(staleConcreteResult.reason, "stale-epoch");
     assertEquals(staleConcrete.posted, []);
+
+    const changedDuringRequest = requestFixture({
+      eventResponses: [
+        [{
+          event: "base_ref_changed",
+          id: 42,
+          created_at: "2026-08-25T09:00:00Z",
+        }],
+        [
+          {
+            event: "base_ref_changed",
+            id: 42,
+            created_at: "2026-08-25T09:00:00Z",
+          },
+          {
+            event: "reopened",
+            id: 43,
+            created_at: "2026-08-25T10:00:00Z",
+          },
+        ],
+      ],
+    });
+    const changedResult = await requestAutomatedReview({
+      github: changedDuringRequest.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      requestKey: "base-42",
+      validateRequestEpoch: true,
+    });
+    assertEquals(changedResult.requested, false);
+    assertEquals(changedResult.reason, "stale-epoch");
+    assertEquals(changedDuringRequest.posted, []);
   });
 
   it("refuses to request a review of a malformed head commit", async () => {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -4779,6 +4779,7 @@ function requestFixture(options: {
   eventResponses?: Record<string, unknown>[][];
   reviews?: Record<string, unknown>[];
   currentHead?: string;
+  headResponses?: string[];
   currentState?: string;
   draft?: boolean;
 } = {}) {
@@ -4797,6 +4798,7 @@ function requestFixture(options: {
   const listStatuses = () => undefined;
   const listTimeline = () => undefined;
   let eventRead = 0;
+  let pullRead = 0;
   const github = {
     paginate: {
       async *iterator(endpoint: unknown) {
@@ -4828,7 +4830,11 @@ function requestFixture(options: {
         get: () =>
           Promise.resolve({
             data: {
-              head: { sha: state.currentHead },
+              head: {
+                sha: options.headResponses?.[
+                  Math.min(pullRead++, options.headResponses.length - 1)
+                ] ?? state.currentHead,
+              },
               base: { ref: BASE_REF, repo: { id: BASE_REPOSITORY_ID } },
               user: { login: "pull-author" },
               state: state.currentState,
@@ -4933,6 +4939,59 @@ describe("automated review request", () => {
     assertEquals(result.requested, false);
     assertEquals(result.reason, "reviewed");
     assertEquals(fixture.posted, []);
+
+    const changedHead = requestFixture({ headResponses: [HEAD, OTHER_HEAD] });
+    const changedHeadResult = await requestAutomatedReview({
+      github: changedHead.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      revalidateReviewEvidence: true,
+    });
+    assertEquals(changedHeadResult.requested, false);
+    assertEquals(changedHeadResult.reason, "stale-head");
+    assertEquals(changedHead.posted, []);
+
+    const changedEpoch = requestFixture({
+      eventResponses: [
+        [{
+          event: "base_ref_changed",
+          id: 42,
+          created_at: "2026-08-25T09:00:00Z",
+        }],
+        [{
+          event: "base_ref_changed",
+          id: 42,
+          created_at: "2026-08-25T09:00:00Z",
+        }],
+        [
+          {
+            event: "base_ref_changed",
+            id: 42,
+            created_at: "2026-08-25T09:00:00Z",
+          },
+          {
+            event: "reopened",
+            id: 43,
+            created_at: "2026-08-25T10:00:00Z",
+          },
+        ],
+      ],
+    });
+    const changedEpochResult = await requestAutomatedReview({
+      github: changedEpoch.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      requestKey: "base-42",
+      validateRequestEpoch: true,
+      revalidateReviewEvidence: true,
+    });
+    assertEquals(changedEpochResult.requested, false);
+    assertEquals(changedEpochResult.reason, "stale-epoch");
+    assertEquals(changedEpoch.posted, []);
   });
 
   it("does not post when the pull request is closed or draft", async () => {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2651,7 +2651,7 @@ describe("automated review publication", () => {
       fixture.published[0]?.description,
       `PR#1 reset base:${
         reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
-      } key:ready-r-6y1-t-mt8fp9c0-e-15`,
+      } key:ready-r-15-t-mt8fp9c0-e-15`,
     );
   });
 
@@ -2968,7 +2968,7 @@ describe("automated review publication", () => {
       tiedFixture.published[0]?.description,
       `PR#1 reset base:${
         reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
-      } key:reopen-r-6y1-t-mt8fp9c0-e-15`,
+      } key:reopen-r-15-t-mt8fp9c0-e-15`,
     );
 
     const runReset = automatedReviewResetStatus(
@@ -2977,7 +2977,7 @@ describe("automated review publication", () => {
         id: 101,
         description: `PR#1 reset base:${
           reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
-        } key:reopen-r-6y1-t-mt8fp9c0-e-15`,
+        } key:reopen-r-15-t-mt8fp9c0-e-15`,
       },
     );
 
@@ -5841,6 +5841,37 @@ describe("automated review request", () => {
     assertEquals(tiedRunResult.requested, false);
     assertEquals(tiedRunResult.reason, "stale-epoch");
     assertEquals(tiedRunBound.posted, []);
+  });
+
+  it("coalesces same-second runs on the same durable event", async () => {
+    const fixture = requestFixture({
+      events: [{
+        event: "base_ref_changed",
+        id: 42,
+        created_at: "2026-08-25T08:00:00Z",
+      }],
+    });
+    const request = (reviewEpochRunKey: string) =>
+      requestAutomatedReview({
+        github: fixture.github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        pullNumber: 1,
+        headSha: HEAD,
+        requestKey: "base",
+        reviewEpochNotBefore: "2026-08-25T08:00:00Z",
+        reviewEpochRunKey,
+      });
+    const first = await request("9001");
+    fixture.state.comments.push({
+      user: bot("github-actions[bot]", GITHUB_ACTIONS_ID),
+      body: fixture.posted[0]?.body,
+    });
+    const second = await request("9002");
+
+    assertEquals(first.requested, true);
+    assertEquals(second.requested, false);
+    assertEquals(fixture.posted.length, 1);
   });
 
   it("refuses to request a review of a malformed head commit", async () => {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -5143,6 +5143,41 @@ describe("automated review request", () => {
       "current review epoch event is not visible",
     );
     assertEquals(tiedOtherKind.posted, []);
+
+    const staleRunBound = requestFixture({
+      eventResponses: [
+        [{
+          event: "base_ref_changed",
+          id: 42,
+          created_at: "2026-08-25T08:00:00Z",
+        }],
+        [
+          {
+            event: "base_ref_changed",
+            id: 42,
+            created_at: "2026-08-25T08:00:00Z",
+          },
+          {
+            event: "reopened",
+            id: 43,
+            created_at: "2026-08-25T10:00:00Z",
+          },
+        ],
+      ],
+    });
+    const staleRunResult = await requestAutomatedReview({
+      github: staleRunBound.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      requestKey: "base-run-9001",
+      validateRequestEpoch: true,
+      reviewEpochNotAfter: "2026-08-25T09:00:00Z",
+    });
+    assertEquals(staleRunResult.requested, false);
+    assertEquals(staleRunResult.reason, "stale-epoch");
+    assertEquals(staleRunBound.posted, []);
   });
 
   it("refuses to request a review of a malformed head commit", async () => {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2321,7 +2321,14 @@ describe("automated review publication", () => {
 
   it("starts a fresh pending epoch when a pull request reopens", async () => {
     const fixture = githubFixture({
-      pages: { statuses: [[pendingAutomatedReviewStatus()]] },
+      pages: {
+        events: [[{
+          event: "reopened",
+          id: 42,
+          created_at: "2026-08-25T09:00:00Z",
+        }]],
+        statuses: [[pendingAutomatedReviewStatus()]],
+      },
     });
     const result = await publishAutomatedReviewStatus({
       github: fixture.github,
@@ -2330,15 +2337,17 @@ describe("automated review publication", () => {
       pullNumber: 1,
       headSha: HEAD,
       pullUrl: "https://example.test/pr/1",
-      reviewResetKey: "reopen-42",
+      reviewResetKey: "reopen",
     });
 
     assertEquals(result.state, "pending");
     assertEquals(fixture.published.length, 1);
     assertEquals(fixture.published[0]?.state, "pending");
-    assertStringIncludes(
-      String(fixture.published[0]?.description),
-      "PR#1 reset base:",
+    assertEquals(
+      fixture.published[0]?.description,
+      `PR#1 reset base:${
+        reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
+      } key:10c4ec5f2d10`,
     );
   });
 
@@ -3946,6 +3955,7 @@ describe("merge queue review propagation", () => {
 
 function requestFixture(options: {
   comments?: Record<string, unknown>[];
+  events?: Record<string, unknown>[];
   currentHead?: string;
   currentState?: string;
   draft?: boolean;
@@ -3953,21 +3963,25 @@ function requestFixture(options: {
   const posted: Record<string, unknown>[] = [];
   const state = {
     comments: options.comments ?? [],
+    events: options.events ?? [],
     currentHead: options.currentHead ?? HEAD,
     currentState: options.currentState ?? "open",
     draft: options.draft ?? false,
   };
   const listComments = () => undefined;
+  const listEvents = () => undefined;
   const github = {
     paginate: {
       async *iterator(endpoint: unknown) {
-        if (endpoint !== listComments) throw new Error("unknown endpoint");
-        yield { data: state.comments };
+        if (endpoint === listComments) yield { data: state.comments };
+        else if (endpoint === listEvents) yield { data: state.events };
+        else throw new Error("unknown endpoint");
       },
     },
     rest: {
       issues: {
         listComments,
+        listEvents,
         createComment: (comment: Record<string, unknown>) => {
           posted.push(comment);
           return Promise.resolve();
@@ -4106,6 +4120,36 @@ describe("automated review request", () => {
     assertEquals((await request()).requested, false);
   });
 
+  it("coalesces reopen requests on the latest durable epoch", async () => {
+    const fixture = requestFixture({
+      events: [
+        { event: "reopened", id: 41 },
+        { event: "reopened", id: 42 },
+      ],
+    });
+    const request = () =>
+      requestAutomatedReview({
+        github: fixture.github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        pullNumber: 1,
+        headSha: HEAD,
+        requestKey: "reopen",
+      });
+
+    assertEquals((await request()).requested, true);
+    assertEquals(
+      fixture.posted[0]?.body,
+      `<!-- automated-review-request: ${HEAD} reopen-42 -->\n@codex review`,
+    );
+    fixture.state.comments.push({
+      user: bot("github-actions[bot]", GITHUB_ACTIONS_ID),
+      body: fixture.posted[0]?.body,
+    });
+    assertEquals((await request()).requested, false);
+    assertEquals(fixture.posted.length, 1);
+  });
+
   it("refuses to request a review of a malformed head commit", async () => {
     const fixture = requestFixture();
     for (
@@ -4227,6 +4271,37 @@ describe("review proof invalidation", () => {
 
     assertEquals(result.skipped, false);
     assertEquals(fixture.published[0]?.state, "failure");
+  });
+
+  it("preserves a queue-retry marker during fallback invalidation", async () => {
+    const retryStatus = automatedReviewStatus({
+      id: 105,
+      state: "failure",
+      description: "PR#1 automated review rate limited; queue retry pending",
+      target_url: "https://example.test/rate-limit",
+    });
+    const fixture = githubFixture({
+      commit: HEAD,
+      headResponses: [HEAD],
+      pageResponses: {
+        statuses: [
+          [[retryStatus]],
+          [[retryStatus]],
+        ],
+      },
+      pages: { refs: [[]] },
+    });
+    const result = await invalidateReviewProof({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      reconciliationStatusId: 105,
+    });
+
+    assertEquals(result.skipped, false);
+    assertEquals(result.queueFailures, 0);
+    assertEquals(fixture.published, []);
   });
 
   it("closes source and queued gates a dropped reconciliation left behind", async () => {
@@ -4909,6 +4984,8 @@ describe("automated review workflow", () => {
     );
     assert(script.includes("publishAutomatedReviewStatus"));
     assert(script.includes("publishReviewResolutionFailure"));
+    assert(script.includes("completeReviewFailurePropagation"));
+    assert(script.includes("queuePropagationPending: true"));
     assert(script.includes("sourceStatusId: result.statusId"));
     assert(script.includes("reconcileActiveMergeGroupReviewStatuses"));
     assert(!script.includes("github.rest.pulls.get"));
@@ -5008,9 +5085,11 @@ describe("automated review workflow", () => {
       "a base-edit rerun must reuse the original reset epoch",
     );
     assert(
-      requestScript.includes("`reopen-${context.runId}`"),
-      "a reopened pull request must request review in its fresh epoch",
+      requestScript.includes('context.payload.action === "reopened"') &&
+        requestScript.includes('? "reopen"'),
+      "reopened requests must derive their key from the durable epoch",
     );
+    assert(!requestScript.includes("`reopen-${context.runId}`"));
     assert(
       requestScript.includes('result.reason === "ineligible-pull"'),
       "a delayed request must report that the pull request is no longer eligible",
@@ -5021,9 +5100,11 @@ describe("automated review workflow", () => {
     );
     assert(script.includes("reviewResetKey"));
     assert(
-      script.includes("`reopen-${context.runId}`"),
-      "reopened pull requests must establish a fresh review epoch",
+      script.includes('context.payload.action === "reopened"') &&
+        script.includes('? "reopen"'),
+      "reopened publishers must derive their key from the durable epoch",
     );
+    assert(!script.includes("`reopen-${context.runId}`"));
 
     const invalidateJob = record(jobs.invalidate, "invalidate job");
     assertEquals(

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -17,6 +17,7 @@ import {
   parseReviewWakeupRun,
   publishAutomatedReviewStatus,
   publishMergeGroupReviewStatus,
+  publishReviewPropagationRetryStatus,
   publishReviewResolutionFailure,
   reconcileActiveMergeGroupReviewStatuses,
   requestAutomatedReview,
@@ -2396,6 +2397,46 @@ describe("automated review publication", () => {
     assertEquals(staleTimeoutResult.state, "pending");
   });
 
+  it("does not adopt an unavailable retry from an older review epoch", async () => {
+    const origin = githubFixture();
+    const retry = await publishReviewPropagationRetryStatus({
+      github: origin.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      failureKind: "unavailable",
+      targetUrl: "https://example.test/pr/1",
+      reviewRequestKey: "base-42",
+    });
+    const fixture = githubFixture({
+      pages: {
+        events: [[{
+          event: "base_ref_changed",
+          id: 43,
+          created_at: "2026-08-25T09:00:00Z",
+        }]],
+        statuses: [[automatedReviewStatus({
+          id: 105,
+          state: "failure",
+          description: retry.description,
+          created_at: "2026-08-25T09:00:01Z",
+        })]],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+
+    assertEquals(result.state, "pending");
+    assertEquals(result.reviewRequestKey, "base-43");
+  });
+
   it("does not time out a pending status from before a base reset", async () => {
     const fixture = githubFixture({
       pages: {
@@ -3764,7 +3805,7 @@ describe("automated review timeout watchdog", () => {
     assertEquals(outageResult.state, "failure");
     assertEquals(
       revalidationOutage.published[0]?.description,
-      "PR#1 review status unavailable; queue retry pending",
+      "PR#1 review status unavailable; epoch:9f2e6d33a371; queue retry pending",
     );
 
     const queueOutage = githubFixture({
@@ -3974,7 +4015,7 @@ describe("automated review timeout watchdog", () => {
     assertEquals(queueOutage.published[0]?.state, "pending");
     assertEquals(
       queueOutage.published.at(-1)?.description,
-      "PR#1 review status unavailable; queue retry pending",
+      "PR#1 review status unavailable; epoch:9f2e6d33a371; queue retry pending",
     );
 
     const requestOutage = githubFixture({
@@ -4005,7 +4046,7 @@ describe("automated review timeout watchdog", () => {
     assertEquals(requestOutage.published[0]?.state, "pending");
     assertEquals(
       requestOutage.published.at(-1)?.description,
-      "PR#1 review status unavailable; queue retry pending",
+      "PR#1 review status unavailable; epoch:9f2e6d33a371; queue retry pending",
     );
   });
 
@@ -4886,6 +4927,7 @@ function requestFixture(options: {
   timeline?: Record<string, unknown>[];
   currentHead?: string;
   headResponses?: string[];
+  updatedAtResponses?: string[];
   currentState?: string;
   draft?: boolean;
 } = {}) {
@@ -4907,6 +4949,7 @@ function requestFixture(options: {
   const listTimeline = () => undefined;
   let eventRead = 0;
   let pullRead = 0;
+  let updatedAtRead = 0;
   const github = {
     paginate: {
       async *iterator(endpoint: unknown) {
@@ -4946,6 +4989,12 @@ function requestFixture(options: {
               user: { login: "pull-author" },
               state: state.currentState,
               draft: state.draft,
+              updated_at: options.updatedAtResponses?.[
+                Math.min(
+                  updatedAtRead++,
+                  options.updatedAtResponses.length - 1,
+                )
+              ] ?? "2026-08-25T08:00:00Z",
             },
           }),
       },
@@ -5137,6 +5186,34 @@ describe("automated review request", () => {
       fixture.posted[0]?.body,
       `<!-- automated-review-request: ${HEAD} ready-run-9001-at-1787644800000-event-41 -->\n@codex review`,
     );
+  });
+
+  it("rejects a lifecycle request when the final pull snapshot advances", async () => {
+    const fixture = requestFixture({
+      events: [{
+        event: "base_ref_changed",
+        id: 42,
+        created_at: "2026-08-25T08:00:00Z",
+      }],
+      updatedAtResponses: [
+        "2026-08-25T08:00:00Z",
+        "2026-08-25T09:00:00Z",
+      ],
+    });
+    const result = await requestAutomatedReview({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      requestKey: "base-42",
+      validateRequestEpoch: true,
+      revalidateReviewEvidence: true,
+    });
+
+    assertEquals(result.requested, false);
+    assertEquals(result.reason, "stale-epoch");
+    assertEquals(fixture.posted, []);
   });
 
   it("does not post when the pull request is closed or draft", async () => {
@@ -6281,6 +6358,10 @@ describe("automated review workflow", () => {
     assert(script.includes("publishReviewResolutionFailure"));
     assert(script.includes("completeReviewFailurePropagation"));
     assert(script.includes("publishReviewPropagationRetryStatus"));
+    assert(
+      script.includes("reviewRequestKey: result.reviewRequestKey"),
+      "normal-workflow retry markers must retain their originating review epoch",
+    );
     assert(script.includes("queuePropagationPending: true"));
     assert(
       script.includes("reviewEpochNotBefore") &&

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2722,6 +2722,45 @@ describe("automated review publication", () => {
     assertEquals(fixture.published, []);
   });
 
+  it("applies a run-bound reset when validating terminal failures", async () => {
+    const reset = automatedReviewResetStatus("2026-08-25T10:00:00Z", {
+      id: 106,
+      description: `PR#1 reset base:${
+        reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
+      } key:ready-run-9001-at-1787644800000-event-41`,
+    });
+    const fixture = githubFixture({
+      pages: {
+        events: [[{
+          event: "ready_for_review",
+          id: 41,
+          created_at: "2026-08-25T08:00:00Z",
+        }]],
+        statuses: [[
+          reset,
+          automatedReviewStatus({
+            id: 105,
+            state: "failure",
+            description: "PR#1 automated review timed out",
+            created_at: "2026-08-25T09:00:00Z",
+          }),
+          pendingAutomatedReviewStatus("2026-08-25T08:30:00Z"),
+        ]],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+
+    assertEquals(result.state, "pending");
+    assertEquals(result.statusId, 106);
+  });
+
   it("prefers a newly visible epoch over a superseded run-bound reset", async () => {
     const reset = automatedReviewResetStatus("2026-08-25T08:00:00Z", {
       id: 104,
@@ -3505,7 +3544,39 @@ describe("automated review timeout watchdog", () => {
       reviewTimeoutMs: 1_800_000,
     });
     assertEquals(targets.length, 25);
-    assertEquals(targets.at(-1)?.pullNumber, 25);
+  });
+
+  it("rotates bounded discovery across eligible pull requests", async () => {
+    const pulls = Array.from({ length: 30 }, (_, index) =>
+      timeoutPull(index + 1, "2026-08-25T08:00:00Z")
+    );
+    const discover = (now: string) =>
+      findTimedOutAutomatedReviews({
+        github: timeoutDiscoveryFixture([pulls]),
+        owner: "veryfront",
+        repo: "veryfront-code",
+        now: Date.parse(now),
+        reviewTimeoutMs: 1_800_000,
+      });
+    const first = await discover("2026-08-25T08:30:00Z");
+    const second = await discover("2026-08-25T08:40:00Z");
+
+    assertEquals(first.length, 25);
+    assertEquals(second.length, 25);
+    assert(
+      first.some((target: { pullNumber: number }, index: number) =>
+        target.pullNumber !== second[index]?.pullNumber
+      ),
+      "successive watchdog intervals must not select the same bounded batch",
+    );
+    assertEquals(
+      new Set(
+        [...first, ...second].map((target: { pullNumber: number }) =>
+          target.pullNumber
+        ),
+      ).size,
+      30,
+    );
   });
 
   it("does not let spoofed pending statuses starve the timeout batch", async () => {
@@ -4047,6 +4118,41 @@ describe("automated review timeout watchdog", () => {
     assertEquals(
       requestOutage.published.at(-1)?.description,
       "PR#1 review status unavailable; epoch:9f2e6d33a371; queue retry pending",
+    );
+  });
+
+  it("marks a propagated unavailable retry as finalized", async () => {
+    const retryStatus = automatedReviewStatus({
+      id: 1001,
+      state: "failure",
+      description:
+        "PR#1 review status unavailable; epoch:9f2e6d33a371; queue retry pending",
+      target_url: "https://example.test/pr/1",
+      created_at: "2026-08-25T08:00:00Z",
+    });
+    const fixture = githubFixture({
+      pages: {
+        statuses: [[retryStatus]],
+        refs: [[]],
+      },
+      commit: HEAD,
+      statusIds: [1002],
+    });
+    const result = await completeReviewFailurePropagation({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      sourceStatusId: 1001,
+      description: retryStatus.description,
+      targetUrl: retryStatus.target_url,
+    });
+
+    assertEquals(result.finalized, true);
+    assertEquals(
+      fixture.published.at(-1)?.description,
+      "PR#1 review status unavailable; retry finalized",
     );
   });
 

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2610,7 +2610,36 @@ describe("automated review publication", () => {
       fixture.published[0]?.description,
       `PR#1 reset base:${
         reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
-      } key:ready-run-9001-at-1787648400000-event-41`,
+      } key:ready-r-6y1-t-mt8fp9c0-e-15`,
+    );
+  });
+
+  it("keeps run-bound reset descriptions within GitHub's status limit", async () => {
+    const fixture = githubFixture({
+      pages: {
+        events: [[{
+          event: "base_ref_changed",
+          id: 12_345_678_901,
+          created_at: "2026-08-25T09:00:00Z",
+        }]],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1234,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1234",
+      reviewResetKey: "base",
+      reviewEpochNotBefore: "2026-08-25T09:00:00Z",
+      reviewEpochRunKey: "12345678901",
+    });
+
+    assertEquals(result.state, "pending");
+    assert(
+      result.description.length <= 140,
+      "commit-status descriptions must fit GitHub's 140-character limit",
     );
   });
 
@@ -2650,6 +2679,43 @@ describe("automated review publication", () => {
     assertEquals(result.state, "pending");
     assertEquals(result.review, undefined);
     assertEquals(fixture.published, []);
+  });
+
+  it("prefers a newly visible epoch over a superseded run-bound reset", async () => {
+    const reset = automatedReviewResetStatus("2026-08-25T08:00:00Z", {
+      id: 104,
+      description: `PR#1 reset base:${
+        reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
+      } key:base-run-9001-at-1787644800000-event-42`,
+    });
+    const fixture = githubFixture({
+      pages: {
+        events: [[
+          {
+            event: "base_ref_changed",
+            id: 42,
+            created_at: "2026-08-25T08:00:00Z",
+          },
+          {
+            event: "base_ref_changed",
+            id: 43,
+            created_at: "2026-08-25T08:00:00Z",
+          },
+        ]],
+        statuses: [[reset]],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+
+    assertEquals(result.state, "pending");
+    assertEquals(result.reviewRequestKey, "base-43");
   });
 
   it("starts a fresh pending epoch when a pull request reopens", async () => {
@@ -2822,7 +2888,7 @@ describe("automated review publication", () => {
       tiedFixture.published[0]?.description,
       `PR#1 reset base:${
         reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
-      } key:reopen-run-9001-at-1787648400000-event-41`,
+      } key:reopen-r-6y1-t-mt8fp9c0-e-15`,
     );
 
     const runReset = automatedReviewResetStatus(
@@ -2831,7 +2897,7 @@ describe("automated review publication", () => {
         id: 101,
         description: `PR#1 reset base:${
           reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
-        } key:reopen-run-9001-at-1787648400000-event-41`,
+        } key:reopen-r-6y1-t-mt8fp9c0-e-15`,
       },
     );
 
@@ -4816,6 +4882,8 @@ function requestFixture(options: {
   events?: Record<string, unknown>[];
   eventResponses?: Record<string, unknown>[][];
   reviews?: Record<string, unknown>[];
+  statuses?: Record<string, unknown>[];
+  timeline?: Record<string, unknown>[];
   currentHead?: string;
   headResponses?: string[];
   currentState?: string;
@@ -4826,6 +4894,8 @@ function requestFixture(options: {
     comments: options.comments ?? [],
     events: options.events ?? [],
     reviews: options.reviews ?? [],
+    statuses: options.statuses ?? [],
+    timeline: options.timeline ?? [],
     currentHead: options.currentHead ?? HEAD,
     currentState: options.currentState ?? "open",
     draft: options.draft ?? false,
@@ -4847,9 +4917,8 @@ function requestFixture(options: {
           ] ?? state.events;
           yield { data: events };
         } else if (endpoint === listReviews) yield { data: state.reviews };
-        else if (endpoint === listStatuses || endpoint === listTimeline) {
-          yield { data: [] };
-        }
+        else if (endpoint === listStatuses) yield { data: state.statuses };
+        else if (endpoint === listTimeline) yield { data: state.timeline };
         else throw new Error("unknown endpoint");
       },
     },
@@ -5030,6 +5099,44 @@ describe("automated review request", () => {
     assertEquals(changedEpochResult.requested, false);
     assertEquals(changedEpochResult.reason, "stale-epoch");
     assertEquals(changedEpoch.posted, []);
+  });
+
+  it("honors a run-bound reset during the final proof refresh", async () => {
+    const fixture = requestFixture({
+      comments: [codexComment(HEAD.slice(0, 10), {
+        id: 103,
+        created_at: "2026-08-25T09:00:00Z",
+        updated_at: "2026-08-25T09:00:00Z",
+      })],
+      events: [{
+        event: "ready_for_review",
+        id: 41,
+        created_at: "2026-08-25T08:00:00Z",
+      }],
+      statuses: [automatedReviewResetStatus("2026-08-25T10:00:00Z", {
+        id: 104,
+        description: `PR#1 reset base:${
+          reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
+        } key:ready-run-9001-at-1787644800000-event-41`,
+      })],
+    });
+    const result = await requestAutomatedReview({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      requestKey: "ready-run-9001-at-1787644800000-event-41",
+      reviewEpochNotAfter: "2026-08-25T08:00:00Z",
+      validateRequestEpoch: true,
+      revalidateReviewEvidence: true,
+    });
+
+    assertEquals(result.requested, true);
+    assertEquals(
+      fixture.posted[0]?.body,
+      `<!-- automated-review-request: ${HEAD} ready-run-9001-at-1787644800000-event-41 -->\n@codex review`,
+    );
   });
 
   it("does not post when the pull request is closed or draft", async () => {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2441,6 +2441,40 @@ describe("automated review publication", () => {
       superseded.published[0]?.description,
       `PR#1 waits for review ${HEAD.slice(0, 12)}`,
     );
+
+    const supersededBase = githubFixture({
+      pages: {
+        events: [[
+          {
+            event: "base_ref_changed",
+            id: 42,
+            created_at: "2026-08-25T09:00:00Z",
+          },
+          {
+            event: "reopened",
+            id: 43,
+            created_at: "2026-08-25T10:00:00Z",
+          },
+        ]],
+        statuses: [[pendingAutomatedReviewStatus(
+          "2026-08-25T09:00:00Z",
+        )]],
+      },
+    });
+    const supersededBaseResult = await publishAutomatedReviewStatus({
+      github: supersededBase.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      reviewResetKey: "base",
+    });
+    assertEquals(supersededBaseResult.state, "pending");
+    assertEquals(
+      supersededBase.published[0]?.description,
+      `PR#1 waits for review ${HEAD.slice(0, 12)}`,
+    );
   });
 
   it("fails when exact-ref lookup is operationally unavailable", async () => {
@@ -4378,6 +4412,32 @@ describe("automated review request", () => {
     assertEquals(supersededResult.requested, false);
     assertEquals(supersededResult.reason, "stale-epoch");
     assertEquals(superseded.posted, []);
+
+    const supersededBase = requestFixture({
+      events: [
+        {
+          event: "base_ref_changed",
+          id: 42,
+          created_at: "2026-08-25T09:00:00Z",
+        },
+        {
+          event: "reopened",
+          id: 43,
+          created_at: "2026-08-25T10:00:00Z",
+        },
+      ],
+    });
+    const supersededBaseResult = await requestAutomatedReview({
+      github: supersededBase.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      requestKey: "base",
+    });
+    assertEquals(supersededBaseResult.requested, false);
+    assertEquals(supersededBaseResult.reason, "stale-epoch");
+    assertEquals(supersededBase.posted, []);
   });
 
   it("refuses to request a review of a malformed head commit", async () => {
@@ -5309,11 +5369,12 @@ describe("automated review workflow", () => {
       "the workflow must post review requests through the tested gate helper",
     );
     assert(requestScript.includes("requestKey"));
-    assert(requestScript.includes("context.runId"));
     assert(
-      requestScript.includes("`base-${context.runId}`"),
-      "a base-edit rerun must reuse the original reset epoch",
+      requestScript.includes('context.payload.action === "edited"') &&
+        requestScript.includes('? "base"'),
+      "base-edit requests must derive their key from the durable epoch",
     );
+    assert(!requestScript.includes("`base-${context.runId}`"));
     assert(
       requestScript.includes('context.payload.action === "reopened"') &&
         requestScript.includes('? "reopen"'),
@@ -5335,6 +5396,12 @@ describe("automated review workflow", () => {
       "reopened publishers must derive their key from the durable epoch",
     );
     assert(!script.includes("`reopen-${context.runId}`"));
+    assert(
+      script.includes('context.payload.action === "edited"') &&
+        script.includes('? "base"'),
+      "base-edit publishers must derive their key from the durable epoch",
+    );
+    assert(!script.includes("`base-${context.runId}`"));
 
     const invalidateJob = record(jobs.invalidate, "invalidate job");
     assertEquals(

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -3624,7 +3624,18 @@ describe("automated review timeout watchdog", () => {
           [[unavailableStatus]],
         ],
       },
-      pages: { refs: [[]] },
+      pages: {
+        comments: [[{
+          user: bot("github-actions[bot]", GITHUB_ACTIONS_ID),
+          body: `<!-- automated-review-request: ${HEAD} -->\n@codex review`,
+        }]],
+        events: [[{
+          event: "base_ref_changed",
+          id: 42,
+          created_at: "2026-08-25T08:00:00Z",
+        }]],
+        refs: [[]],
+      },
     });
     const result = await expireTimedOutAutomatedReview({
       github: fixture.github,
@@ -3643,7 +3654,7 @@ describe("automated review timeout watchdog", () => {
     assertEquals(fixture.published[0]?.state, "pending");
     assertEquals(
       fixture.commentsPosted[0]?.body,
-      `<!-- automated-review-request: ${HEAD} -->\n@codex review`,
+      `<!-- automated-review-request: ${HEAD} base-42 -->\n@codex review`,
     );
   });
 

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1943,6 +1943,36 @@ describe("automated review publication", () => {
     assertEquals(fixture.published, []);
   });
 
+  it("retains the pending anchor behind an operational failure", async () => {
+    const fixture = githubFixture({
+      pages: {
+        statuses: [[
+          automatedReviewStatus({
+            id: 106,
+            state: "failure",
+            description: "PR#1 review status unavailable",
+            created_at: "2026-08-25T08:05:00Z",
+          }),
+          pendingAutomatedReviewStatus("2026-08-25T08:00:00Z"),
+        ]],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      now: Date.parse("2026-08-25T08:30:00Z"),
+      reviewTimeoutMs: 1_800_000,
+    });
+
+    assertEquals(result.state, "failure");
+    assertEquals(result.description, "PR#1 automated review timed out");
+    assertEquals(fixture.published[0]?.state, "failure");
+  });
+
   it("preserves a terminal review failure across unrelated edits", async () => {
     const terminalStatus = automatedReviewStatus({
       id: 105,
@@ -2198,6 +2228,34 @@ describe("automated review publication", () => {
     assertEquals(fixture.published[0]?.state, "pending");
   });
 
+  it("times out a same-second pending status created by ready-for-review", async () => {
+    const fixture = githubFixture({
+      pages: {
+        events: [[{
+          event: "ready_for_review",
+          id: 102,
+          created_at: "2026-08-25T08:00:00Z",
+        }]],
+        statuses: [[pendingAutomatedReviewStatus(
+          "2026-08-25T08:00:00Z",
+        )]],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      now: Date.parse("2026-08-25T08:30:00Z"),
+      reviewTimeoutMs: 1_800_000,
+    });
+
+    assertEquals(result.state, "failure");
+    assertEquals(result.description, "PR#1 automated review timed out");
+  });
+
   it("lets a reopen epoch supersede an older base change", async () => {
     const verdict = codexComment(HEAD.slice(0, 10), {
       id: 104,
@@ -2348,6 +2406,40 @@ describe("automated review publication", () => {
       `PR#1 reset base:${
         reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
       } key:10c4ec5f2d10`,
+    );
+
+    const superseded = githubFixture({
+      pages: {
+        events: [[
+          {
+            event: "reopened",
+            id: 42,
+            created_at: "2026-08-25T09:00:00Z",
+          },
+          {
+            event: "ready_for_review",
+            id: 43,
+            created_at: "2026-08-25T10:00:00Z",
+          },
+        ]],
+        statuses: [[pendingAutomatedReviewStatus(
+          "2026-08-25T09:00:00Z",
+        )]],
+      },
+    });
+    const supersededResult = await publishAutomatedReviewStatus({
+      github: superseded.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      reviewResetKey: "reopen",
+    });
+    assertEquals(supersededResult.state, "pending");
+    assertEquals(
+      superseded.published[0]?.description,
+      `PR#1 waits for review ${HEAD.slice(0, 12)}`,
     );
   });
 
@@ -2848,6 +2940,34 @@ describe("automated review timeout watchdog", () => {
     );
   });
 
+  it("rediscovers operational failures that may hide a pending anchor", async () => {
+    const github = timeoutDiscoveryFixture([[
+      timeoutPull(
+        1,
+        "2026-08-25T08:05:00Z",
+        {},
+        "FAILURE",
+        {
+          __typename: "Bot",
+          login: "github-actions",
+          databaseId: GITHUB_ACTIONS_ID,
+        },
+        "PR#1 review status unavailable",
+      ),
+    ]]);
+
+    assertEquals(
+      await findTimedOutAutomatedReviews({
+        github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        now: Date.parse("2026-08-25T08:06:00Z"),
+        reviewTimeoutMs: 1_800_000,
+      }),
+      [{ pullNumber: 1, headSha: HEAD }],
+    );
+  });
+
   it("bounds scheduled fan-out when many reviews time out together", async () => {
     const pulls = Array.from({ length: 26 }, (_, index) =>
       timeoutPull(index + 1, "2026-08-25T08:00:00Z")
@@ -3125,6 +3245,82 @@ describe("automated review timeout watchdog", () => {
     assertEquals(
       retry.published[0]?.description,
       "PR#1 automated review timed out",
+    );
+
+    const unavailableRetryStatus = automatedReviewStatus({
+      id: 1001,
+      state: "failure",
+      description: "PR#1 review status unavailable; queue retry pending",
+      target_url: "https://example.test/pr/1",
+    });
+    const revalidationOutage = githubFixture({
+      pageResponses: {
+        statuses: [
+          [[retryStatus]],
+          [[], []],
+          [[unavailableRetryStatus]],
+        ],
+      },
+      pages: { refs: [[]] },
+      failAfterFirstPage: "statuses",
+      commit: HEAD,
+      statusIds: [1001, 1002],
+    });
+    const outageResult = await expireTimedOutAutomatedReview({
+      github: revalidationOutage.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      now: Date.parse("2026-08-25T08:30:01Z"),
+      reviewTimeoutMs: 1_800_000,
+    });
+    assert("state" in outageResult);
+    assertEquals(outageResult.state, "failure");
+    assertEquals(
+      revalidationOutage.published[0]?.description,
+      "PR#1 review status unavailable; queue retry pending",
+    );
+
+    const queueOutage = githubFixture({
+      pages: {
+        comments: [[codexComment()]],
+        refs: [[{
+          ref: `refs/heads/gh-readonly-queue/${BASE_REF}/pr-1-${BASE_HEAD}`,
+          object: { sha: OTHER_HEAD },
+        }]],
+      },
+      pageResponses: {
+        statuses: [
+          [[retryStatus]],
+          [[retryStatus]],
+        ],
+      },
+      commit: HEAD,
+      statusIds: [1001, 1002],
+      queueBindingError: Object.assign(
+        new Error("queue binding unavailable"),
+        { status: 503 },
+      ),
+    });
+    await assertRejects(
+      () =>
+        expireTimedOutAutomatedReview({
+          github: queueOutage.github,
+          owner: "veryfront",
+          repo: "veryfront-code",
+          pullNumber: 1,
+          headSha: HEAD,
+          now: Date.parse("2026-08-25T08:30:01Z"),
+          reviewTimeoutMs: 1_800_000,
+        }),
+      Error,
+      "queue binding unavailable",
+    );
+    assertEquals(queueOutage.published[0]?.state, "success");
+    assertEquals(
+      queueOutage.published.at(-1)?.description,
+      retryDescription,
     );
   });
 
@@ -4123,8 +4319,16 @@ describe("automated review request", () => {
   it("coalesces reopen requests on the latest durable epoch", async () => {
     const fixture = requestFixture({
       events: [
-        { event: "reopened", id: 41 },
-        { event: "reopened", id: 42 },
+        {
+          event: "reopened",
+          id: 41,
+          created_at: "2026-08-25T08:00:00Z",
+        },
+        {
+          event: "reopened",
+          id: 42,
+          created_at: "2026-08-25T09:00:00Z",
+        },
       ],
     });
     const request = () =>
@@ -4148,6 +4352,32 @@ describe("automated review request", () => {
     });
     assertEquals((await request()).requested, false);
     assertEquals(fixture.posted.length, 1);
+
+    const superseded = requestFixture({
+      events: [
+        {
+          event: "reopened",
+          id: 42,
+          created_at: "2026-08-25T09:00:00Z",
+        },
+        {
+          event: "ready_for_review",
+          id: 43,
+          created_at: "2026-08-25T10:00:00Z",
+        },
+      ],
+    });
+    const supersededResult = await requestAutomatedReview({
+      github: superseded.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      requestKey: "reopen",
+    });
+    assertEquals(supersededResult.requested, false);
+    assertEquals(supersededResult.reason, "stale-epoch");
+    assertEquals(superseded.posted, []);
   });
 
   it("refuses to request a review of a malformed head commit", async () => {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -3059,9 +3059,38 @@ describe("automated review timeout watchdog", () => {
       [{ pullNumber: 1, headSha: HEAD }],
     );
 
+    const repaired = githubFixture({
+      pages: {
+        comments: [[codexComment()]],
+        refs: [[]],
+      },
+      pageResponses: {
+        statuses: [
+          [[retryStatus]],
+          [[retryStatus]],
+        ],
+      },
+      commit: HEAD,
+    });
+    const repairedResult = await expireTimedOutAutomatedReview({
+      github: repaired.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      now: Date.parse("2026-08-25T08:30:01Z"),
+      reviewTimeoutMs: 1_800_000,
+    });
+    assertEquals(repairedResult.expired, false);
+    assertEquals(repairedResult.reason, "reviewed");
+    assert("state" in repairedResult);
+    assertEquals(repairedResult.state, "success");
+    assertEquals(repaired.published[0]?.state, "success");
+
     const retry = githubFixture({
       pageResponses: {
         statuses: [
+          [[retryStatus]],
           [[retryStatus]],
           [[retryStatus]],
         ],

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -5374,6 +5374,7 @@ describe("automated review workflow", () => {
     assert(script.includes("publishAutomatedReviewStatus"));
     assert(script.includes("publishReviewResolutionFailure"));
     assert(script.includes("completeReviewFailurePropagation"));
+    assert(script.includes("publishReviewPropagationRetryStatus"));
     assert(script.includes("queuePropagationPending: true"));
     assert(script.includes("sourceStatusId: result.statusId"));
     assert(script.includes("reconcileActiveMergeGroupReviewStatuses"));
@@ -5383,10 +5384,10 @@ describe("automated review workflow", () => {
     assert(script.includes("Number.isSafeInteger"));
     assert(script.includes("result.baseRef"));
     assert(
-      script.includes(
-        'entry?.state === "failure" && entry?.published !== true',
-      ) && script.includes("Review proof was not replaced"),
-      "an unreplaced merge queue failure must fail the run so the fallback invalidation job fires",
+      script.includes('entry?.state === "failure"') &&
+        !script.includes('entry?.published !== true') &&
+        script.includes("active merge queue review failed"),
+      "every merge queue failure must keep the source retryable",
     );
     assert(
       script.includes('core.setOutput("force-invalidate", "true")'),
@@ -5394,7 +5395,7 @@ describe("automated review workflow", () => {
     );
     assert(
       script.includes('core.setOutput("source-status-id"') &&
-        script.includes("result.statusId"),
+        script.includes("retryStatus.statusId"),
       "fallback invalidation must receive the source status written by this failed run",
     );
     assert(

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2119,20 +2119,17 @@ describe("automated review timeout watchdog", () => {
     commits: {
       nodes: [{
         commit: {
-          statusCheckRollup: {
-            contexts: {
-              nodes: createdAt === undefined
-                ? []
-                : [{
-                  __typename: "StatusContext",
-                  context: "Automated review",
-                  state: "PENDING",
-                  description: `PR#${pullNumber} waits for review ${
-                    HEAD.slice(0, 12)
-                  }`,
-                  createdAt,
-                }],
-            },
+          status: {
+            contexts: createdAt === undefined
+              ? []
+              : [{
+                context: "Automated review",
+                state: "PENDING",
+                description: `PR#${pullNumber} waits for review ${
+                  HEAD.slice(0, 12)
+                }`,
+                createdAt,
+              }],
           },
         },
       }],

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1584,7 +1584,13 @@ describe("automated review publication", () => {
 
   it("fails a triggering usage-limit reply that beats the first pending status", async () => {
     const fixture = githubFixture({
-      pages: { comments: [[codexRateLimitComment()]] },
+      pages: {
+        comments: [[codexRateLimitComment()]],
+        timeline: [[
+          { event: "committed", sha: HEAD },
+          { event: "commented", id: 103 },
+        ]],
+      },
     });
     const result = await publishAutomatedReviewStatus({
       github: fixture.github,
@@ -1599,6 +1605,55 @@ describe("automated review publication", () => {
     assertEquals(result.state, "failure");
     assertEquals(result.description, "PR#1 automated review rate limited");
     assertEquals(fixture.published[0]?.state, "failure");
+  });
+
+  it("does not bind a delayed limit-comment event to a newer head", async () => {
+    const fixture = githubFixture({
+      pages: {
+        comments: [[codexRateLimitComment()]],
+        timeline: [[
+          { event: "commented", id: 103 },
+          { event: "committed", sha: HEAD },
+        ]],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      reviewFailureCommentId: 103,
+    });
+
+    assertEquals(result.state, "pending");
+    assertEquals(fixture.published[0]?.state, "pending");
+  });
+
+  it("does not treat two missing comment ids as a triggering limit reply", async () => {
+    const comment = {
+      ...codexRateLimitComment("2026-08-25T07:59:59Z"),
+      id: undefined,
+    };
+    const fixture = githubFixture({
+      pages: {
+        comments: [[comment]],
+        statuses: [[pendingAutomatedReviewStatus()]],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+
+    assertEquals(result.state, "pending");
+    assertEquals(result.statusId, 100);
+    assertEquals(fixture.published, []);
   });
 
   it("does not apply an old-head usage-limit reply to a newer pending epoch", async () => {
@@ -1709,6 +1764,31 @@ describe("automated review publication", () => {
 
     assertEquals(result.state, "pending");
     assertEquals(result.statusId, 100);
+    assertEquals(fixture.published, []);
+  });
+
+  it("preserves a terminal review failure across unrelated edits", async () => {
+    const terminalStatus = automatedReviewStatus({
+      id: 105,
+      state: "failure",
+      description: "PR#1 automated review rate limited",
+      target_url: "https://example.test/rate-limit",
+    });
+    const fixture = githubFixture({
+      pages: { statuses: [[terminalStatus]] },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+
+    assertEquals(result.state, "failure");
+    assertEquals(result.statusId, 105);
+    assertEquals(result.description, "PR#1 automated review rate limited");
     assertEquals(fixture.published, []);
   });
 
@@ -2237,6 +2317,28 @@ describe("automated review timeout watchdog", () => {
         reviewTimeoutMs: 1_800_000,
       }),
       [{ pullNumber: 550, headSha: HEAD }],
+    );
+  });
+
+  it("fails visibly instead of silently truncating beyond 1,000 pulls", async () => {
+    const pages = Array.from({ length: 21 }, (_, pageIndex) =>
+      Array.from({ length: 50 }, (_, itemIndex) =>
+        timeoutPull(pageIndex * 50 + itemIndex + 1, undefined)
+      )
+    );
+    const github = timeoutDiscoveryFixture(pages);
+
+    await assertRejects(
+      () =>
+        findTimedOutAutomatedReviews({
+          github,
+          owner: "veryfront",
+          repo: "veryfront-code",
+          now: Date.parse("2026-08-25T08:30:00Z"),
+          reviewTimeoutMs: 1_800_000,
+        }),
+      Error,
+      "exceeded 1,000 open pull requests",
     );
   });
 

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2459,6 +2459,11 @@ describe("automated review timeout watchdog", () => {
     createdAt?: string,
     overrides: Record<string, unknown> = {},
     statusState = "PENDING",
+    statusCreator: Record<string, unknown> = {
+      __typename: "Bot",
+      login: "github-actions",
+      databaseId: GITHUB_ACTIONS_ID,
+    },
   ) => ({
     number: pullNumber,
     isDraft: false,
@@ -2476,6 +2481,7 @@ describe("automated review timeout watchdog", () => {
                   HEAD.slice(0, 12)
                 }`,
                 createdAt,
+                creator: statusCreator,
               }],
           },
         },
@@ -2486,11 +2492,13 @@ describe("automated review timeout watchdog", () => {
 
   const timeoutDiscoveryFixture = (
     pages: Array<Record<string, unknown>[]>,
+    queryReads: unknown[] = [],
   ) => {
     let read = 0;
     return {
       graphql: (query: unknown, variables: Record<string, unknown>) => {
         assert(String(query).includes("TimedOutAutomatedReviews"));
+        queryReads.push(query);
         const nodes = pages[read] ?? [];
         const hasNextPage = read < pages.length - 1;
         read += 1;
@@ -2561,6 +2569,45 @@ describe("automated review timeout watchdog", () => {
     });
     assertEquals(targets.length, 25);
     assertEquals(targets.at(-1)?.pullNumber, 25);
+  });
+
+  it("does not let spoofed pending statuses starve the timeout batch", async () => {
+    const spoofedCreator = {
+      __typename: "Bot",
+      login: "github-actions",
+      databaseId: GITHUB_ACTIONS_ID + 1,
+    };
+    const pulls = [
+      ...Array.from({ length: 25 }, (_, index) =>
+        timeoutPull(
+          index + 1,
+          "2026-08-25T08:00:00Z",
+          {},
+          "PENDING",
+          spoofedCreator,
+        )),
+      timeoutPull(26, "2026-08-25T08:00:00Z"),
+    ];
+    const queryReads: unknown[] = [];
+    const github = timeoutDiscoveryFixture([pulls], queryReads);
+
+    assertEquals(
+      await findTimedOutAutomatedReviews({
+        github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        now: Date.parse("2026-08-25T08:30:00Z"),
+        reviewTimeoutMs: 1_800_000,
+      }),
+      [{ pullNumber: 26, headSha: HEAD }],
+    );
+    const query = String(queryReads[0]);
+    for (const field of ["creator", "__typename", "login", "databaseId"]) {
+      assert(
+        query.includes(field),
+        `timeout discovery must request the status creator ${field} field`,
+      );
+    }
   });
 
   it("continues bounded discovery beyond 500 open pull requests", async () => {
@@ -4573,6 +4620,8 @@ describe("automated review workflow", () => {
         "github.event_name == 'workflow_run'",
         "github.event_name == 'pull_request_target'",
         "github.event.action == 'edited'",
+        "github.event.action == 'reopened'",
+        "github.event.action == 'ready_for_review'",
         "github.event.changes.base",
       ]
     ) {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1690,7 +1690,12 @@ describe("automated review publication", () => {
             updated_at: "2026-08-25T08:02:00Z",
           }),
         ]],
-        statuses: [[pendingAutomatedReviewStatus()]],
+        statuses: [[automatedReviewStatus({
+          id: 105,
+          state: "failure",
+          description: "PR#1 automated review rate limited",
+          target_url: "https://example.test/rate-limit",
+        })]],
       },
       commit: HEAD,
     });
@@ -2192,6 +2197,7 @@ describe("automated review timeout watchdog", () => {
     pullNumber: number,
     createdAt?: string,
     overrides: Record<string, unknown> = {},
+    statusState = "PENDING",
   ) => ({
     number: pullNumber,
     isDraft: false,
@@ -2204,7 +2210,7 @@ describe("automated review timeout watchdog", () => {
               ? []
               : [{
                 context: "Automated review",
-                state: "PENDING",
+                state: statusState,
                 description: `PR#${pullNumber} waits for review ${
                   HEAD.slice(0, 12)
                 }`,
@@ -2264,7 +2270,7 @@ describe("automated review timeout watchdog", () => {
   it("does not discover a younger pending status or a completed status", async () => {
     const github = timeoutDiscoveryFixture([[
       timeoutPull(1, "2026-08-25T08:00:01Z"),
-      timeoutPull(2, undefined),
+      timeoutPull(2, "2026-08-25T08:00:00Z", {}, "SUCCESS"),
     ]]);
 
     assertEquals(

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1060,7 +1060,6 @@ function githubFixture(options: {
   statusIds?: unknown[];
 } = {}) {
   const endpoints = {
-    openPulls: () => undefined,
     reviews: () => undefined,
     comments: () => undefined,
     events: () => undefined,
@@ -1109,7 +1108,6 @@ function githubFixture(options: {
     },
     rest: {
       pulls: {
-        list: endpoints.openPulls,
         listReviews: endpoints.reviews,
         get: () => {
           if (options.pullError) return Promise.reject(options.pullError);
@@ -2071,57 +2069,91 @@ describe("automated review publication", () => {
 });
 
 describe("automated review timeout watchdog", () => {
-  it("discovers only expired pending reviews for open non-draft heads", async () => {
-    const fixture = githubFixture({
-      pages: {
-        openPulls: [[
-          associatedPull({ number: 1, state: "open", draft: false }),
-          associatedPull({
-            number: 2,
-            state: "open",
-            draft: true,
-            head: { sha: OTHER_HEAD },
-          }),
-        ]],
-        statuses: [[pendingAutomatedReviewStatus()]],
+  const timeoutPull = (
+    pullNumber: number,
+    createdAt?: string,
+    overrides: Record<string, unknown> = {},
+  ) => ({
+    number: pullNumber,
+    isDraft: false,
+    headRefOid: HEAD,
+    commits: {
+      nodes: [{
+        commit: {
+          statusCheckRollup: {
+            contexts: {
+              nodes: createdAt === undefined
+                ? []
+                : [{
+                  __typename: "StatusContext",
+                  context: "Automated review",
+                  state: "PENDING",
+                  description: `PR#${pullNumber} waits for review ${
+                    HEAD.slice(0, 12)
+                  }`,
+                  createdAt,
+                }],
+            },
+          },
+        },
+      }],
+    },
+    ...overrides,
+  });
+
+  const timeoutDiscoveryFixture = (
+    pages: Array<Record<string, unknown>[]>,
+  ) => {
+    let read = 0;
+    return {
+      graphql: (query: unknown, variables: Record<string, unknown>) => {
+        assert(String(query).includes("TimedOutAutomatedReviews"));
+        const nodes = pages[read] ?? [];
+        const hasNextPage = read < pages.length - 1;
+        read += 1;
+        return Promise.resolve({
+          repository: {
+            pullRequests: {
+              nodes,
+              pageInfo: {
+                hasNextPage,
+                endCursor: hasNextPage ? `cursor-${read}` : null,
+              },
+            },
+          },
+          variables,
+        });
       },
-    });
+    };
+  };
+
+  it("discovers only expired pending reviews for open non-draft heads", async () => {
+    const github = timeoutDiscoveryFixture([[
+      timeoutPull(1, "2026-08-25T08:00:00Z"),
+      timeoutPull(2, "2026-08-25T08:00:00Z", { isDraft: true }),
+    ]]);
 
     assertEquals(
       await findTimedOutAutomatedReviews({
-        github: fixture.github,
+        github,
         owner: "veryfront",
         repo: "veryfront-code",
         now: Date.parse("2026-08-25T08:30:00Z"),
         reviewTimeoutMs: 1_800_000,
       }),
-      [{ pullNumber: 1, headSha: HEAD, pendingStatusId: 100 }],
+      [{ pullNumber: 1, headSha: HEAD }],
     );
   });
 
   it("does not discover a younger pending status or a completed status", async () => {
-    const pulls = [[
-      associatedPull({ number: 1, state: "open", draft: false }),
-      associatedPull({
-        number: 2,
-        state: "open",
-        draft: false,
-        head: { sha: OTHER_HEAD },
-      }),
-    ]];
-    const fixture = githubFixture({
-      pages: { openPulls: pulls },
-      pageResponses: {
-        statuses: [
-          [[pendingAutomatedReviewStatus("2026-08-25T08:00:01Z")]],
-          [[automatedReviewStatus({ id: 101 })]],
-        ],
-      },
-    });
+    const github = timeoutDiscoveryFixture([[
+      timeoutPull(1, "2026-08-25T08:00:01Z"),
+      timeoutPull(2, undefined),
+    ]]);
 
     assertEquals(
       await findTimedOutAutomatedReviews({
-        github: fixture.github,
+        github,
         owner: "veryfront",
         repo: "veryfront-code",
         now: Date.parse("2026-08-25T08:30:00Z"),
@@ -2133,25 +2165,12 @@ describe("automated review timeout watchdog", () => {
 
   it("bounds scheduled fan-out when many reviews time out together", async () => {
     const pulls = Array.from({ length: 26 }, (_, index) =>
-      associatedPull({
-        number: index + 1,
-        state: "open",
-        draft: false,
-      })
+      timeoutPull(index + 1, "2026-08-25T08:00:00Z")
     );
-    const fixture = githubFixture({
-      pages: { openPulls: [pulls] },
-      pageResponses: {
-        statuses: pulls.map((pull) => [[pendingAutomatedReviewStatus(
-          "2026-08-25T08:00:00Z",
-          Number(pull.number),
-          100 + Number(pull.number),
-        )]]),
-      },
-    });
+    const github = timeoutDiscoveryFixture([pulls]);
 
     const targets = await findTimedOutAutomatedReviews({
-      github: fixture.github,
+      github,
       owner: "veryfront",
       repo: "veryfront-code",
       now: Date.parse("2026-08-25T08:30:00Z"),
@@ -2159,6 +2178,30 @@ describe("automated review timeout watchdog", () => {
     });
     assertEquals(targets.length, 25);
     assertEquals(targets.at(-1)?.pullNumber, 25);
+  });
+
+  it("continues bounded discovery beyond 500 open pull requests", async () => {
+    const pages = Array.from({ length: 11 }, (_, pageIndex) =>
+      Array.from({ length: 50 }, (_, itemIndex) => {
+        const pullNumber = pageIndex * 50 + itemIndex + 1;
+        return timeoutPull(
+          pullNumber,
+          pullNumber === 550 ? "2026-08-25T08:00:00Z" : undefined,
+        );
+      })
+    );
+    const github = timeoutDiscoveryFixture(pages);
+
+    assertEquals(
+      await findTimedOutAutomatedReviews({
+        github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        now: Date.parse("2026-08-25T08:30:00Z"),
+        reviewTimeoutMs: 1_800_000,
+      }),
+      [{ pullNumber: 550, headSha: HEAD }],
+    );
   });
 
   it("revalidates and expires the same pending status under the publisher", async () => {
@@ -2175,7 +2218,6 @@ describe("automated review timeout watchdog", () => {
       repo: "veryfront-code",
       pullNumber: 1,
       headSha: HEAD,
-      pendingStatusId: 100,
       now: Date.parse("2026-08-25T08:30:00Z"),
       reviewTimeoutMs: 1_800_000,
     });
@@ -2205,7 +2247,6 @@ describe("automated review timeout watchdog", () => {
       repo: "veryfront-code",
       pullNumber: 1,
       headSha: HEAD,
-      pendingStatusId: 100,
       now: Date.parse("2026-08-25T08:30:00Z"),
       reviewTimeoutMs: 1_800_000,
     });
@@ -2229,7 +2270,6 @@ describe("automated review timeout watchdog", () => {
         repo: "veryfront-code",
         pullNumber: 1,
         headSha: HEAD,
-        pendingStatusId: 100,
         now: Date.parse("2026-08-25T08:30:00Z"),
         reviewTimeoutMs: 1_800_000,
       }),
@@ -2245,7 +2285,6 @@ describe("automated review timeout watchdog", () => {
         repo: "veryfront-code",
         pullNumber: 1,
         headSha: HEAD,
-        pendingStatusId: 100,
         now: Date.parse("2026-08-25T08:30:00Z"),
         reviewTimeoutMs: 1_800_000,
       }),
@@ -3618,7 +3657,7 @@ describe("automated review workflow", () => {
     );
     assertEquals(
       triggers.schedule,
-      [{ cron: "*/5 * * * *" }],
+      [{ cron: "*/10 * * * *" }],
       "the timeout watchdog must revisit silent pending reviews",
     );
     assertEquals("status" in triggers, false);

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1636,6 +1636,41 @@ describe("automated review publication", () => {
     assertEquals(fixture.published[0]?.state, "pending");
   });
 
+  it("binds a limit reply to the force-pushed head", async () => {
+    for (
+      const forcePush of [
+        { after_commit: HEAD },
+        { after_commit: { sha: HEAD } },
+        { after_commit: null, commit_id: HEAD },
+      ]
+    ) {
+      const fixture = githubFixture({
+        pages: {
+          comments: [[codexRateLimitComment()]],
+          timeline: [[
+            { event: "head_ref_force_pushed", ...forcePush },
+            { event: "commented", id: 103 },
+          ]],
+        },
+      });
+      const result = await publishAutomatedReviewStatus({
+        github: fixture.github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        pullNumber: 1,
+        headSha: HEAD,
+        pullUrl: "https://example.test/pr/1",
+        reviewFailureCommentId: 103,
+      });
+
+      assertEquals(result.state, "failure");
+      assertEquals(
+        result.description,
+        "PR#1 automated review rate limited",
+      );
+    }
+  });
+
   it("does not bind a delayed limit reply across a same-head base reset", async () => {
     const resetStatus = automatedReviewResetStatus(
       "2026-08-25T08:01:00Z",

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1969,6 +1969,76 @@ describe("automated review publication", () => {
     assertEquals(fixture.published, []);
   });
 
+  it("preserves a same-second terminal failure proven after a lifecycle reset", async () => {
+    const limitComment = {
+      ...codexRateLimitComment("2026-08-25T08:00:00Z"),
+      updated_at: "2026-08-25T08:00:01Z",
+    };
+    const terminalStatus = automatedReviewStatus({
+      id: 105,
+      state: "failure",
+      description: "PR#1 automated review rate limited",
+      target_url: limitComment.html_url,
+      created_at: "2026-08-25T08:00:00Z",
+    });
+    const fixture = githubFixture({
+      pages: {
+        comments: [[limitComment]],
+        events: [[{
+          event: "reopened",
+          id: 102,
+          created_at: "2026-08-25T08:00:00Z",
+        }]],
+        statuses: [[terminalStatus]],
+        timeline: [[
+          { event: "committed", sha: HEAD },
+          { event: "reopened", id: 102 },
+          { event: "commented", id: 103 },
+        ]],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+
+    assertEquals(result.state, "failure");
+    assertEquals(result.statusId, 105);
+    assertEquals(result.description, "PR#1 automated review rate limited");
+    assertEquals(fixture.published, []);
+
+    const staleFixture = githubFixture({
+      pages: {
+        comments: [[limitComment]],
+        events: [[{
+          event: "reopened",
+          id: 102,
+          created_at: "2026-08-25T08:00:00Z",
+        }]],
+        statuses: [[terminalStatus]],
+        timeline: [[
+          { event: "committed", sha: HEAD },
+          { event: "commented", id: 103 },
+          { event: "reopened", id: 102 },
+        ]],
+      },
+    });
+    const staleResult = await publishAutomatedReviewStatus({
+      github: staleFixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+    assertEquals(staleResult.state, "pending");
+    assertEquals(staleFixture.published[0]?.state, "pending");
+  });
+
   it("ignores terminal descriptions from another status context", async () => {
     const fixture = githubFixture({
       pages: {
@@ -2632,6 +2702,9 @@ describe("automated review timeout watchdog", () => {
       login: "github-actions",
       databaseId: GITHUB_ACTIONS_ID,
     },
+    statusDescription = `PR#${pullNumber} waits for review ${
+      HEAD.slice(0, 12)
+    }`,
   ) => ({
     number: pullNumber,
     isDraft: false,
@@ -2645,9 +2718,7 @@ describe("automated review timeout watchdog", () => {
               : [{
                 context: "Automated review",
                 state: statusState,
-                description: `PR#${pullNumber} waits for review ${
-                  HEAD.slice(0, 12)
-                }`,
+                description: statusDescription,
                 createdAt,
                 creator: statusCreator,
               }],
@@ -2865,6 +2936,111 @@ describe("automated review timeout watchdog", () => {
       fixture.published.at(-1)?.description,
       "PR#1 automated review timed out",
       "queue propagation must preserve the terminal source diagnosis",
+    );
+  });
+
+  it("retries queue propagation after a terminal timeout failure", async () => {
+    const retryDescription =
+      "PR#1 automated review timed out; queue retry pending";
+    const retryStatus = automatedReviewStatus({
+      id: 1001,
+      state: "failure",
+      description: retryDescription,
+      target_url: "https://example.test/pr/1",
+    });
+    const firstAttempt = githubFixture({
+      pageResponses: {
+        statuses: [
+          [[pendingAutomatedReviewStatus()]],
+          [[pendingAutomatedReviewStatus()]],
+          [[retryStatus]],
+        ],
+      },
+      pages: {
+        refs: [[{
+          ref: `refs/heads/gh-readonly-queue/main/pr-1-${BASE_HEAD}`,
+          object: { sha: OTHER_HEAD },
+        }]],
+      },
+      commit: HEAD,
+      queueBindingError: Object.assign(
+        new Error("queue binding unavailable"),
+        { status: 503 },
+      ),
+      queueRefError: Object.assign(new Error("queue ref unavailable"), {
+        status: 503,
+      }),
+    });
+
+    await assertRejects(
+      () =>
+        expireTimedOutAutomatedReview({
+          github: firstAttempt.github,
+          owner: "veryfront",
+          repo: "veryfront-code",
+          pullNumber: 1,
+          headSha: HEAD,
+          now: Date.parse("2026-08-25T08:30:00Z"),
+          reviewTimeoutMs: 1_800_000,
+        }),
+      Error,
+      "queue ref unavailable",
+    );
+    assertEquals(firstAttempt.published[0]?.description, retryDescription);
+
+    const discovery = timeoutDiscoveryFixture([[
+      timeoutPull(
+        1,
+        "2026-08-25T08:30:00Z",
+        {},
+        "FAILURE",
+        {
+          __typename: "Bot",
+          login: "github-actions",
+          databaseId: GITHUB_ACTIONS_ID,
+        },
+        retryDescription,
+      ),
+    ]]);
+    assertEquals(
+      await findTimedOutAutomatedReviews({
+        github: discovery,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        now: Date.parse("2026-08-25T08:30:01Z"),
+        reviewTimeoutMs: 1_800_000,
+      }),
+      [{ pullNumber: 1, headSha: HEAD }],
+    );
+
+    const retry = githubFixture({
+      pageResponses: {
+        statuses: [
+          [[retryStatus]],
+          [[retryStatus]],
+        ],
+      },
+      pages: { refs: [[]] },
+      commit: HEAD,
+      statusIds: [1002],
+    });
+    const result = await expireTimedOutAutomatedReview({
+      github: retry.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      now: Date.parse("2026-08-25T08:30:01Z"),
+      reviewTimeoutMs: 1_800_000,
+    });
+    assertEquals(result.expired, true);
+    assert("retried" in result);
+    assert("statusId" in result);
+    assertEquals(result.retried, true);
+    assertEquals(result.statusId, 1002);
+    assertEquals(
+      retry.published[0]?.description,
+      "PR#1 automated review timed out",
     );
   });
 

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1870,24 +1870,34 @@ describe("automated review publication", () => {
     assertEquals(fixture.published, []);
   });
 
-  it("finds terminal evidence behind a later generic failure", async () => {
+  it("republishes terminal evidence hidden behind a later generic failure", async () => {
+    const republishedTerminalStatus = automatedReviewStatus({
+      id: 1001,
+      state: "failure",
+      description: "PR#1 automated review timed out",
+      created_at: "2026-08-25T08:02:00Z",
+    });
     const fixture = githubFixture({
-      pages: {
-        statuses: [[
-          automatedReviewStatus({
-            id: 106,
-            state: "failure",
-            description: "PR#1 review status unavailable",
-            created_at: "2026-08-25T08:01:00Z",
-          }),
-          automatedReviewStatus({
-            id: 105,
-            state: "failure",
-            description: "PR#1 automated review timed out",
-            created_at: "2026-08-25T08:00:00Z",
-          }),
-        ]],
+      pageResponses: {
+        statuses: [
+          [[
+            automatedReviewStatus({
+              id: 106,
+              state: "failure",
+              description: "PR#1 review status unavailable",
+              created_at: "2026-08-25T08:01:00Z",
+            }),
+            automatedReviewStatus({
+              id: 105,
+              state: "failure",
+              description: "PR#1 automated review timed out",
+              created_at: "2026-08-25T08:00:00Z",
+            }),
+          ]],
+          [[republishedTerminalStatus]],
+        ],
       },
+      commit: HEAD,
     });
     const result = await publishAutomatedReviewStatus({
       github: fixture.github,
@@ -1899,9 +1909,52 @@ describe("automated review publication", () => {
     });
 
     assertEquals(result.state, "failure");
-    assertEquals(result.statusId, 105);
+    assertEquals(result.statusId, 1001);
     assertEquals(result.description, "PR#1 automated review timed out");
-    assertEquals(fixture.published, []);
+    assertEquals(fixture.published[0]?.state, "failure");
+    assertEquals(
+      fixture.published[0]?.target_url,
+      "https://example.test/review-proof",
+    );
+    assertEquals(
+      await publishReviewResolutionFailure({
+        github: fixture.github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        pullNumber: 1,
+        sourceHeadSha: HEAD,
+        sourceStatusId: result.statusId,
+      }),
+      { queueFailures: 0, skipped: false },
+    );
+  });
+
+  it("does not time out a pending status from before a base reset", async () => {
+    const fixture = githubFixture({
+      pages: {
+        events: [[{
+          event: "base_ref_changed",
+          created_at: "2026-08-25T08:00:00Z",
+        }]],
+        statuses: [[pendingAutomatedReviewStatus(
+          "2026-08-25T07:00:00Z",
+        )]],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      now: Date.parse("2026-08-25T08:30:00Z"),
+      reviewTimeoutMs: 1_800_000,
+    });
+
+    assertEquals(result.state, "pending");
+    assertEquals(fixture.published.length, 1);
+    assertEquals(fixture.published[0]?.state, "pending");
   });
 
   it("starts a fresh pending epoch when a pull request reopens", async () => {
@@ -4349,6 +4402,7 @@ describe("automated review workflow", () => {
         "github.event_name == 'pull_request_target'",
         "github.event.pull_request.draft == false",
         "github.event.action == 'synchronize'",
+        "github.event.action == 'reopened'",
         "github.event.action == 'edited'",
         "github.event.changes.base",
         "steps.publish.outputs.result == 'pending'",
@@ -4360,8 +4414,8 @@ describe("automated review workflow", () => {
       );
     }
     assert(
-      !requestCondition.includes("ready_for_review") &&
-        !requestCondition.includes("opened"),
+      !requestCondition.includes("github.event.action == 'ready_for_review'") &&
+        !requestCondition.includes("github.event.action == 'opened'"),
       "open and ready-for-review events are already handled by the connector",
     );
     const requestScript = String(
@@ -4377,6 +4431,10 @@ describe("automated review workflow", () => {
     assert(
       requestScript.includes("`base-${context.runId}`"),
       "a base-edit rerun must reuse the original reset epoch",
+    );
+    assert(
+      requestScript.includes("`reopen-${context.runId}`"),
+      "a reopened pull request must request review in its fresh epoch",
     );
     assert(
       !("RUN_ATTEMPT" in record(request.env, "request environment")),

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1703,6 +1703,70 @@ describe("automated review publication", () => {
     assertEquals(fixture.published, []);
   });
 
+  it("orders same-second limit replies after lifecycle events", async () => {
+    for (
+      const event of ["base_ref_changed", "reopened", "ready_for_review"]
+    ) {
+      const fixture = githubFixture({
+        pages: {
+          comments: [[codexRateLimitComment("2026-08-25T08:00:00Z")]],
+          events: [[{
+            event,
+            id: 102,
+            created_at: "2026-08-25T08:00:00Z",
+          }]],
+          timeline: [[
+            { event: "committed", sha: HEAD },
+            { event, id: 102 },
+            { event: "commented", id: 103 },
+          ]],
+        },
+      });
+      const result = await publishAutomatedReviewStatus({
+        github: fixture.github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        pullNumber: 1,
+        headSha: HEAD,
+        pullUrl: "https://example.test/pr/1",
+        reviewFailureCommentId: 103,
+      });
+
+      assertEquals(result.state, "failure", event);
+      assertEquals(
+        result.description,
+        "PR#1 automated review rate limited",
+        event,
+      );
+
+      const staleFixture = githubFixture({
+        pages: {
+          comments: [[codexRateLimitComment("2026-08-25T08:00:00Z")]],
+          events: [[{
+            event,
+            id: 102,
+            created_at: "2026-08-25T08:00:00Z",
+          }]],
+          timeline: [[
+            { event: "committed", sha: HEAD },
+            { event: "commented", id: 103 },
+            { event, id: 102 },
+          ]],
+        },
+      });
+      const staleResult = await publishAutomatedReviewStatus({
+        github: staleFixture.github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        pullNumber: 1,
+        headSha: HEAD,
+        pullUrl: "https://example.test/pr/1",
+        reviewFailureCommentId: 103,
+      });
+      assertEquals(staleResult.state, "pending", event);
+    }
+  });
+
   it("does not treat two missing comment ids as a triggering limit reply", async () => {
     const comment = {
       ...codexRateLimitComment("2026-08-25T07:59:59Z"),
@@ -1870,6 +1934,32 @@ describe("automated review publication", () => {
     assertEquals(fixture.published, []);
   });
 
+  it("ignores terminal descriptions from another status context", async () => {
+    const fixture = githubFixture({
+      pages: {
+        statuses: [[automatedReviewStatus({
+          id: 105,
+          context: "Unrelated check",
+          state: "failure",
+          description: "PR#1 automated review timed out",
+          created_at: "2026-08-25T08:00:00Z",
+        })]],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+
+    assertEquals(result.state, "pending");
+    assertEquals(fixture.published.length, 1);
+    assertEquals(fixture.published[0]?.state, "pending");
+  });
+
   it("republishes terminal evidence hidden behind a later generic failure", async () => {
     const republishedTerminalStatus = automatedReviewStatus({
       id: 1001,
@@ -1996,6 +2086,49 @@ describe("automated review publication", () => {
     assertEquals(result.state, "pending");
     assertEquals(result.statusId, 100);
     assertEquals(fixture.published, []);
+  });
+
+  it("preserves fresh proof that wins the reopen publisher race", async () => {
+    const verdict = codexComment(HEAD.slice(0, 10), {
+      id: 103,
+      created_at: "2026-08-25T09:00:01Z",
+      updated_at: "2026-08-25T09:00:01Z",
+    });
+    const fixture = githubFixture({
+      pages: {
+        comments: [[verdict]],
+        events: [[{
+          event: "reopened",
+          id: 102,
+          created_at: "2026-08-25T09:00:00Z",
+        }]],
+        timeline: [[
+          { event: "reopened", id: 102 },
+          { event: "commented", id: 103 },
+        ]],
+      },
+      commit: HEAD,
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      reviewResetKey: "reopen-42",
+    });
+
+    assertEquals(result.state, "success");
+    assertEquals(result.review?.source, "codex-comment");
+    assertEquals(fixture.published.length, 1);
+    assertEquals(fixture.published[0]?.state, "success");
+    assertEquals(
+      fixture.published[0]?.description,
+      `PR#1 base:${
+        reviewBaseBinding(BASE_REPOSITORY_ID, BASE_REF)
+      } by:chatgpt-codex-connector[bot]`,
+    );
   });
 
   it("clears terminal evidence when a pull request becomes ready", async () => {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1957,6 +1957,84 @@ describe("automated review publication", () => {
     assertEquals(fixture.published[0]?.state, "pending");
   });
 
+  it("lets a reopen epoch supersede an older base change", async () => {
+    const verdict = codexComment(HEAD.slice(0, 10), {
+      id: 104,
+      created_at: "2026-08-25T08:01:00Z",
+      updated_at: "2026-08-25T08:01:00Z",
+    });
+    const fixture = githubFixture({
+      pages: {
+        comments: [[verdict]],
+        events: [[
+          {
+            event: "base_ref_changed",
+            created_at: "2026-08-25T08:00:00Z",
+          },
+          {
+            event: "reopened",
+            created_at: "2026-08-25T09:00:00Z",
+          },
+        ]],
+        statuses: [[automatedReviewResetStatus(
+          "2026-08-25T09:00:00Z",
+          { id: 100 },
+        )]],
+        timeline: [[{ event: "commented", id: 104 }]],
+      },
+      commit: HEAD,
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+
+    assertEquals(result.state, "pending");
+    assertEquals(result.statusId, 100);
+    assertEquals(fixture.published, []);
+  });
+
+  it("clears terminal evidence when a pull request becomes ready", async () => {
+    const fixture = githubFixture({
+      pages: {
+        events: [[{
+          event: "ready_for_review",
+          created_at: "2026-08-25T09:00:00Z",
+        }]],
+        statuses: [[
+          automatedReviewStatus({
+            id: 106,
+            state: "pending",
+            description: "PR#1 draft waits for review",
+            created_at: "2026-08-25T08:30:00Z",
+          }),
+          automatedReviewStatus({
+            id: 105,
+            state: "failure",
+            description: "PR#1 automated review timed out",
+            created_at: "2026-08-25T08:00:00Z",
+          }),
+        ]],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+
+    assertEquals(result.state, "pending");
+    assertEquals(fixture.published.length, 1);
+    assertEquals(fixture.published[0]?.state, "pending");
+  });
+
   it("starts a fresh pending epoch when a pull request reopens", async () => {
     const fixture = githubFixture({
       pages: { statuses: [[pendingAutomatedReviewStatus()]] },
@@ -3403,11 +3481,15 @@ describe("merge queue review propagation", () => {
 function requestFixture(options: {
   comments?: Record<string, unknown>[];
   currentHead?: string;
+  currentState?: string;
+  draft?: boolean;
 } = {}) {
   const posted: Record<string, unknown>[] = [];
   const state = {
     comments: options.comments ?? [],
     currentHead: options.currentHead ?? HEAD,
+    currentState: options.currentState ?? "open",
+    draft: options.draft ?? false,
   };
   const listComments = () => undefined;
   const github = {
@@ -3427,7 +3509,13 @@ function requestFixture(options: {
       },
       pulls: {
         get: () =>
-          Promise.resolve({ data: { head: { sha: state.currentHead } } }),
+          Promise.resolve({
+            data: {
+              head: { sha: state.currentHead },
+              state: state.currentState,
+              draft: state.draft,
+            },
+          }),
       },
     },
   };
@@ -3505,6 +3593,27 @@ describe("automated review request", () => {
     assertEquals(result.requested, false);
     assertEquals(result.reason, "stale-head");
     assertEquals(fixture.posted.length, 0);
+  });
+
+  it("does not post when the pull request is closed or draft", async () => {
+    for (
+      const fixture of [
+        requestFixture({ currentState: "closed" }),
+        requestFixture({ draft: true }),
+      ]
+    ) {
+      const result = await requestAutomatedReview({
+        github: fixture.github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        pullNumber: 1,
+        headSha: HEAD,
+        requestKey: "reopen-42",
+      });
+      assertEquals(result.requested, false);
+      assertEquals(result.reason, "ineligible-pull");
+      assertEquals(fixture.posted, []);
+    }
   });
 
   it("uses an idempotent base-edit request key to create a fresh epoch", async () => {
@@ -4435,6 +4544,10 @@ describe("automated review workflow", () => {
     assert(
       requestScript.includes("`reopen-${context.runId}`"),
       "a reopened pull request must request review in its fresh epoch",
+    );
+    assert(
+      requestScript.includes('result.reason === "ineligible-pull"'),
+      "a delayed request must report that the pull request is no longer eligible",
     );
     assert(
       !("RUN_ATTEMPT" in record(request.env, "request environment")),

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1582,6 +1582,25 @@ describe("automated review publication", () => {
     );
   });
 
+  it("fails a triggering usage-limit reply that beats the first pending status", async () => {
+    const fixture = githubFixture({
+      pages: { comments: [[codexRateLimitComment()]] },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      reviewFailureCommentId: 103,
+    });
+
+    assertEquals(result.state, "failure");
+    assertEquals(result.description, "PR#1 automated review rate limited");
+    assertEquals(fixture.published[0]?.state, "failure");
+  });
+
   it("does not apply an old-head usage-limit reply to a newer pending epoch", async () => {
     const fixture = githubFixture({
       pages: {
@@ -1601,7 +1620,8 @@ describe("automated review publication", () => {
     });
 
     assertEquals(result.state, "pending");
-    assertEquals(fixture.published[0]?.state, "pending");
+    assertEquals(result.statusId, 100);
+    assertEquals(fixture.published, []);
   });
 
   it("lets later exact-head proof recover a rate-limited review", async () => {
@@ -1670,7 +1690,26 @@ describe("automated review publication", () => {
     });
 
     assertEquals(result.state, "pending");
-    assertEquals(fixture.published[0]?.state, "pending");
+    assertEquals(result.statusId, 100);
+    assertEquals(fixture.published, []);
+  });
+
+  it("reuses the first pending status instead of refreshing its timeout", async () => {
+    const fixture = githubFixture({
+      pages: { statuses: [[pendingAutomatedReviewStatus()]] },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+
+    assertEquals(result.state, "pending");
+    assertEquals(result.statusId, 100);
+    assertEquals(fixture.published, []);
   });
 
   it("fails when exact-ref lookup is operationally unavailable", async () => {
@@ -2205,10 +2244,21 @@ describe("automated review timeout watchdog", () => {
   });
 
   it("revalidates and expires the same pending status under the publisher", async () => {
+    const preservedTimeoutStatus = automatedReviewStatus({
+      id: 1001,
+      state: "failure",
+      description: "PR#1 automated review timed out",
+    });
     const fixture = githubFixture({
       pages: {
-        statuses: [[pendingAutomatedReviewStatus()]],
         refs: [[]],
+      },
+      pageResponses: {
+        statuses: [
+          [[pendingAutomatedReviewStatus()]],
+          [[pendingAutomatedReviewStatus()]],
+          [[preservedTimeoutStatus]],
+        ],
       },
       commit: HEAD,
     });
@@ -2229,6 +2279,11 @@ describe("automated review timeout watchdog", () => {
     assertEquals(
       fixture.published.every((status) => status.state === "failure"),
       true,
+    );
+    assertEquals(
+      fixture.published.at(-1)?.description,
+      "PR#1 automated review timed out",
+      "queue propagation must preserve the terminal source diagnosis",
     );
   });
 
@@ -3991,6 +4046,7 @@ describe("automated review workflow", () => {
     );
     assert(script.includes("publishAutomatedReviewStatus"));
     assert(script.includes("publishReviewResolutionFailure"));
+    assert(script.includes("sourceStatusId: result.statusId"));
     assert(script.includes("reconcileActiveMergeGroupReviewStatuses"));
     assert(!script.includes("github.rest.pulls.get"));
     assert(script.includes("process.env.TARGET_SHA"));
@@ -4031,8 +4087,13 @@ describe("automated review workflow", () => {
     assert(!script.includes("listPullRequestsAssociatedWithCommit"));
     assert(!script.includes("allowPullRequestReviews"));
     assert(
-      !script.includes("context.payload.comment"),
-      "deleted comments must reconcile from current API evidence, not comment payload data",
+      script.includes("reviewFailureCommentId") &&
+        script.includes("context.payload.comment?.id"),
+      "the pinned triggering comment id must cover a limit reply that beats pending publication",
+    );
+    assert(
+      !script.includes("context.payload.comment?.body"),
+      "comment content must reconcile from current API evidence, not payload data",
     );
     assert(script.includes("Review gate is unavailable on the default branch"));
     assertEquals(

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2,6 +2,7 @@ import {
   assert,
   assertEquals,
   assertRejects,
+  assertStringIncludes,
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { parse } from "#std/yaml/parse";
@@ -1560,6 +1561,10 @@ describe("automated review publication", () => {
       pages: {
         comments: [[codexRateLimitComment()]],
         statuses: [[pendingAutomatedReviewStatus()]],
+        timeline: [[
+          { event: "committed", sha: HEAD },
+          { event: "commented", id: 103 },
+        ]],
       },
     });
     const result = await publishAutomatedReviewStatus({
@@ -1629,6 +1634,73 @@ describe("automated review publication", () => {
 
     assertEquals(result.state, "pending");
     assertEquals(fixture.published[0]?.state, "pending");
+  });
+
+  it("does not bind a delayed limit reply across a same-head base reset", async () => {
+    const resetStatus = automatedReviewResetStatus(
+      "2026-08-25T08:01:00Z",
+      { id: 100 },
+    );
+    const fixture = githubFixture({
+      pages: {
+        comments: [[codexRateLimitComment("2026-08-25T08:00:00Z")]],
+        events: [[{
+          event: "base_ref_changed",
+          created_at: "2026-08-25T08:01:00Z",
+        }]],
+        statuses: [[resetStatus]],
+        timeline: [[
+          { event: "committed", sha: HEAD },
+          { event: "commented", id: 103 },
+        ]],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      reviewFailureCommentId: 103,
+    });
+
+    assertEquals(result.state, "pending");
+    assertEquals(result.statusId, 100);
+    assertEquals(fixture.published, []);
+  });
+
+  it("rejects a same-second old-epoch limit reply as ambiguous", async () => {
+    const resetStatus = automatedReviewResetStatus(
+      "2026-08-25T08:00:00Z",
+      { id: 100 },
+    );
+    const fixture = githubFixture({
+      pages: {
+        comments: [[codexRateLimitComment("2026-08-25T08:00:00Z")]],
+        events: [[{
+          event: "base_ref_changed",
+          created_at: "2026-08-25T08:00:00Z",
+        }]],
+        statuses: [[resetStatus]],
+        timeline: [[
+          { event: "committed", sha: HEAD },
+          { event: "commented", id: 103 },
+        ]],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+
+    assertEquals(result.state, "pending");
+    assertEquals(result.statusId, 100);
+    assertEquals(fixture.published, []);
   });
 
   it("does not treat two missing comment ids as a triggering limit reply", async () => {
@@ -1778,6 +1850,7 @@ describe("automated review publication", () => {
       state: "failure",
       description: "PR#1 automated review rate limited",
       target_url: "https://example.test/rate-limit",
+      created_at: "2026-08-25T08:00:00Z",
     });
     const fixture = githubFixture({
       pages: { statuses: [[terminalStatus]] },
@@ -1795,6 +1868,63 @@ describe("automated review publication", () => {
     assertEquals(result.statusId, 105);
     assertEquals(result.description, "PR#1 automated review rate limited");
     assertEquals(fixture.published, []);
+  });
+
+  it("finds terminal evidence behind a later generic failure", async () => {
+    const fixture = githubFixture({
+      pages: {
+        statuses: [[
+          automatedReviewStatus({
+            id: 106,
+            state: "failure",
+            description: "PR#1 review status unavailable",
+            created_at: "2026-08-25T08:01:00Z",
+          }),
+          automatedReviewStatus({
+            id: 105,
+            state: "failure",
+            description: "PR#1 automated review timed out",
+            created_at: "2026-08-25T08:00:00Z",
+          }),
+        ]],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+
+    assertEquals(result.state, "failure");
+    assertEquals(result.statusId, 105);
+    assertEquals(result.description, "PR#1 automated review timed out");
+    assertEquals(fixture.published, []);
+  });
+
+  it("starts a fresh pending epoch when a pull request reopens", async () => {
+    const fixture = githubFixture({
+      pages: { statuses: [[pendingAutomatedReviewStatus()]] },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      reviewResetKey: "reopen-42",
+    });
+
+    assertEquals(result.state, "pending");
+    assertEquals(fixture.published.length, 1);
+    assertEquals(fixture.published[0]?.state, "pending");
+    assertStringIncludes(
+      String(fixture.published[0]?.description),
+      "PR#1 reset base:",
+    );
   });
 
   it("fails when exact-ref lookup is operationally unavailable", async () => {
@@ -4253,6 +4383,10 @@ describe("automated review workflow", () => {
       "a rerun must not create a second reset epoch",
     );
     assert(script.includes("reviewResetKey"));
+    assert(
+      script.includes("`reopen-${context.runId}`"),
+      "reopened pull requests must establish a fresh review epoch",
+    );
 
     const invalidateJob = record(jobs.invalidate, "invalidate job");
     assertEquals(

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -2124,6 +2124,52 @@ describe("automated review publication", () => {
     );
   });
 
+  it("preserves queue-retry failures until propagation completes", async () => {
+    const retryStatus = automatedReviewStatus({
+      id: 105,
+      state: "failure",
+      description: "PR#1 automated review timed out; queue retry pending",
+      target_url: "https://example.test/pr/1",
+      created_at: "2026-08-25T08:00:00Z",
+    });
+    const fixture = githubFixture({
+      pages: { statuses: [[retryStatus]] },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+
+    assertEquals(result.state, "failure");
+    assertEquals(result.statusId, 105);
+    assertEquals(result.description, retryStatus.description);
+    assertEquals(fixture.published, []);
+
+    const resetFixture = githubFixture({
+      pages: {
+        events: [[{
+          event: "ready_for_review",
+          created_at: "2026-08-25T09:00:00Z",
+        }]],
+        statuses: [[retryStatus]],
+      },
+    });
+    const resetResult = await publishAutomatedReviewStatus({
+      github: resetFixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+    });
+    assertEquals(resetResult.state, "pending");
+    assertEquals(resetFixture.published[0]?.state, "pending");
+  });
+
   it("does not time out a pending status from before a base reset", async () => {
     const fixture = githubFixture({
       pages: {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -6,7 +6,9 @@ import {
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { parse } from "#std/yaml/parse";
 import {
+  expireTimedOutAutomatedReview,
   findAutomatedReview,
+  findTimedOutAutomatedReviews,
   invalidateReviewProof,
   matchesReviewWakeupPullRequest,
   parseMergeQueuePullNumber,
@@ -124,6 +126,33 @@ function codexFindingComment(
     html_url: "https://example.test/finding",
     ...overrides,
   };
+}
+
+function codexRateLimitComment(
+  createdAt = "2026-08-25T08:01:00Z",
+) {
+  return {
+    id: 103,
+    user: bot("chatgpt-codex-connector[bot]", CODEX_ID),
+    body:
+      "You have reached your Codex usage limits for security reviews. Please try again later.",
+    html_url: "https://example.test/rate-limit",
+    created_at: createdAt,
+    updated_at: createdAt,
+  };
+}
+
+function pendingAutomatedReviewStatus(
+  createdAt = "2026-08-25T08:00:00Z",
+  pullNumber = 1,
+  id = 100,
+) {
+  return automatedReviewStatus({
+    id,
+    state: "pending",
+    description: `PR#${pullNumber} waits for review ${HEAD.slice(0, 12)}`,
+    created_at: createdAt,
+  });
 }
 
 function associatedPull(overrides: Record<string, unknown> = {}) {
@@ -1031,6 +1060,7 @@ function githubFixture(options: {
   statusIds?: unknown[];
 } = {}) {
   const endpoints = {
+    openPulls: () => undefined,
     reviews: () => undefined,
     comments: () => undefined,
     events: () => undefined,
@@ -1079,6 +1109,7 @@ function githubFixture(options: {
     },
     rest: {
       pulls: {
+        list: endpoints.openPulls,
         listReviews: endpoints.reviews,
         get: () => {
           if (options.pullError) return Promise.reject(options.pullError);
@@ -1526,6 +1557,124 @@ describe("automated review publication", () => {
     );
   });
 
+  it("fails a current-head Codex usage-limit reply", async () => {
+    const fixture = githubFixture({
+      pages: {
+        comments: [[codexRateLimitComment()]],
+        statuses: [[pendingAutomatedReviewStatus()]],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      now: Date.parse("2026-08-25T08:05:00Z"),
+      reviewTimeoutMs: 1_800_000,
+    });
+
+    assertEquals(result.state, "failure");
+    assertEquals(result.description, "PR#1 automated review rate limited");
+    assertEquals(fixture.published[0]?.state, "failure");
+    assertEquals(
+      fixture.published[0]?.target_url,
+      "https://example.test/rate-limit",
+    );
+  });
+
+  it("does not apply an old-head usage-limit reply to a newer pending epoch", async () => {
+    const fixture = githubFixture({
+      pages: {
+        comments: [[codexRateLimitComment("2026-08-25T07:59:59Z")]],
+        statuses: [[pendingAutomatedReviewStatus()]],
+      },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      now: Date.parse("2026-08-25T08:05:00Z"),
+      reviewTimeoutMs: 1_800_000,
+    });
+
+    assertEquals(result.state, "pending");
+    assertEquals(fixture.published[0]?.state, "pending");
+  });
+
+  it("lets later exact-head proof recover a rate-limited review", async () => {
+    const fixture = githubFixture({
+      pages: {
+        comments: [[
+          codexRateLimitComment(),
+          codexComment(HEAD.slice(0, 10), {
+            id: 104,
+            created_at: "2026-08-25T08:02:00Z",
+            updated_at: "2026-08-25T08:02:00Z",
+          }),
+        ]],
+        statuses: [[pendingAutomatedReviewStatus()]],
+      },
+      commit: HEAD,
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      now: Date.parse("2026-08-25T08:05:00Z"),
+      reviewTimeoutMs: 1_800_000,
+    });
+
+    assertEquals(result.state, "success");
+    assertEquals(fixture.published[0]?.state, "success");
+  });
+
+  it("fails pending review evidence at the 30-minute timeout", async () => {
+    const fixture = githubFixture({
+      pages: { statuses: [[pendingAutomatedReviewStatus()]] },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      now: Date.parse("2026-08-25T08:30:00Z"),
+      reviewTimeoutMs: 1_800_000,
+    });
+
+    assertEquals(result.state, "failure");
+    assertEquals(result.description, "PR#1 automated review timed out");
+    assertEquals(fixture.published[0]?.state, "failure");
+  });
+
+  it("keeps a younger unreviewed head pending", async () => {
+    const fixture = githubFixture({
+      pages: { statuses: [[pendingAutomatedReviewStatus()]] },
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      now: Date.parse("2026-08-25T08:29:59Z"),
+      reviewTimeoutMs: 1_800_000,
+    });
+
+    assertEquals(result.state, "pending");
+    assertEquals(fixture.published[0]?.state, "pending");
+  });
+
   it("fails when exact-ref lookup is operationally unavailable", async () => {
     const fixture = githubFixture({
       pages: { comments: [[codexComment()]] },
@@ -1918,6 +2067,191 @@ describe("automated review publication", () => {
     assertEquals(result.state, "failure");
     assertEquals(result.review, undefined);
     assertEquals(fixture.published[0]?.state, "failure");
+  });
+});
+
+describe("automated review timeout watchdog", () => {
+  it("discovers only expired pending reviews for open non-draft heads", async () => {
+    const fixture = githubFixture({
+      pages: {
+        openPulls: [[
+          associatedPull({ number: 1, state: "open", draft: false }),
+          associatedPull({
+            number: 2,
+            state: "open",
+            draft: true,
+            head: { sha: OTHER_HEAD },
+          }),
+        ]],
+        statuses: [[pendingAutomatedReviewStatus()]],
+      },
+    });
+
+    assertEquals(
+      await findTimedOutAutomatedReviews({
+        github: fixture.github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        now: Date.parse("2026-08-25T08:30:00Z"),
+        reviewTimeoutMs: 1_800_000,
+      }),
+      [{ pullNumber: 1, headSha: HEAD, pendingStatusId: 100 }],
+    );
+  });
+
+  it("does not discover a younger pending status or a completed status", async () => {
+    const pulls = [[
+      associatedPull({ number: 1, state: "open", draft: false }),
+      associatedPull({
+        number: 2,
+        state: "open",
+        draft: false,
+        head: { sha: OTHER_HEAD },
+      }),
+    ]];
+    const fixture = githubFixture({
+      pages: { openPulls: pulls },
+      pageResponses: {
+        statuses: [
+          [[pendingAutomatedReviewStatus("2026-08-25T08:00:01Z")]],
+          [[automatedReviewStatus({ id: 101 })]],
+        ],
+      },
+    });
+
+    assertEquals(
+      await findTimedOutAutomatedReviews({
+        github: fixture.github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        now: Date.parse("2026-08-25T08:30:00Z"),
+        reviewTimeoutMs: 1_800_000,
+      }),
+      [],
+    );
+  });
+
+  it("bounds scheduled fan-out when many reviews time out together", async () => {
+    const pulls = Array.from({ length: 26 }, (_, index) =>
+      associatedPull({
+        number: index + 1,
+        state: "open",
+        draft: false,
+      })
+    );
+    const fixture = githubFixture({
+      pages: { openPulls: [pulls] },
+      pageResponses: {
+        statuses: pulls.map((pull) => [[pendingAutomatedReviewStatus(
+          "2026-08-25T08:00:00Z",
+          Number(pull.number),
+          100 + Number(pull.number),
+        )]]),
+      },
+    });
+
+    const targets = await findTimedOutAutomatedReviews({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      now: Date.parse("2026-08-25T08:30:00Z"),
+      reviewTimeoutMs: 1_800_000,
+    });
+    assertEquals(targets.length, 25);
+    assertEquals(targets.at(-1)?.pullNumber, 25);
+  });
+
+  it("revalidates and expires the same pending status under the publisher", async () => {
+    const fixture = githubFixture({
+      pages: {
+        statuses: [[pendingAutomatedReviewStatus()]],
+        refs: [[]],
+      },
+      commit: HEAD,
+    });
+    const result = await expireTimedOutAutomatedReview({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pendingStatusId: 100,
+      now: Date.parse("2026-08-25T08:30:00Z"),
+      reviewTimeoutMs: 1_800_000,
+    });
+
+    assertEquals(result.expired, true);
+    assert("state" in result);
+    assertEquals(result.state, "failure");
+    assert(fixture.published.length > 0);
+    assertEquals(
+      fixture.published.every((status) => status.state === "failure"),
+      true,
+    );
+  });
+
+  it("publishes review proof that arrives before timeout revalidation", async () => {
+    const fixture = githubFixture({
+      pages: {
+        comments: [[codexComment()]],
+        statuses: [[pendingAutomatedReviewStatus()]],
+        refs: [[]],
+      },
+      commit: HEAD,
+    });
+    const result = await expireTimedOutAutomatedReview({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pendingStatusId: 100,
+      now: Date.parse("2026-08-25T08:30:00Z"),
+      reviewTimeoutMs: 1_800_000,
+    });
+
+    assertEquals(result.expired, false);
+    assertEquals(result.reason, "reviewed");
+    assert("state" in result);
+    assertEquals(result.state, "success");
+    assertEquals(fixture.published[0]?.state, "success");
+  });
+
+  it("does not overwrite a later status or a changed head", async () => {
+    const laterStatus = automatedReviewStatus({ id: 101 });
+    const changedStatusFixture = githubFixture({
+      pages: { statuses: [[laterStatus]] },
+    });
+    assertEquals(
+      await expireTimedOutAutomatedReview({
+        github: changedStatusFixture.github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        pullNumber: 1,
+        headSha: HEAD,
+        pendingStatusId: 100,
+        now: Date.parse("2026-08-25T08:30:00Z"),
+        reviewTimeoutMs: 1_800_000,
+      }),
+      { expired: false, reason: "status-changed" },
+    );
+    assertEquals(changedStatusFixture.published, []);
+
+    const changedHeadFixture = githubFixture({ headResponses: [OTHER_HEAD] });
+    assertEquals(
+      await expireTimedOutAutomatedReview({
+        github: changedHeadFixture.github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        pullNumber: 1,
+        headSha: HEAD,
+        pendingStatusId: 100,
+        now: Date.parse("2026-08-25T08:30:00Z"),
+        reviewTimeoutMs: 1_800_000,
+      }),
+      { expired: false, reason: "stale-head" },
+    );
+    assertEquals(changedHeadFixture.published, []);
   });
 });
 
@@ -3282,12 +3616,81 @@ describe("automated review workflow", () => {
       record(triggers.merge_group, "merge group trigger").types,
       ["checks_requested"],
     );
+    assertEquals(
+      triggers.schedule,
+      [{ cron: "*/5 * * * *" }],
+      "the timeout watchdog must revisit silent pending reviews",
+    );
     assertEquals("status" in triggers, false);
     const jobs = record(workflow.jobs, "jobs");
+    const timeoutTargetsJob = record(
+      jobs.timeout_targets,
+      "timeout target discovery job",
+    );
+    assertEquals(timeoutTargetsJob.if, "github.event_name == 'schedule'");
+    assertEquals(
+      record(timeoutTargetsJob.permissions, "timeout discovery permissions"),
+      {
+        contents: "read",
+        "pull-requests": "read",
+        statuses: "read",
+      },
+      "timeout discovery must stay read-only",
+    );
+    const timeoutTargetSteps = timeoutTargetsJob.steps;
+    assert(Array.isArray(timeoutTargetSteps));
+    const timeoutTargetScript = String(
+      record(
+        record(timeoutTargetSteps[0], "timeout target discovery").with,
+        "timeout target discovery inputs",
+      ).script,
+    );
+    assertTrustedGateLoad(timeoutTargetScript);
+    assert(timeoutTargetScript.includes("findTimedOutAutomatedReviews"));
+    assert(timeoutTargetScript.includes("AUTOMATED_REVIEW_TIMEOUT_MS"));
+
+    const timeoutJob = record(jobs.timeout, "timeout publisher job");
+    assertEquals(timeoutJob.needs, "timeout_targets");
+    assertEquals(timeoutJob.if, "needs.timeout_targets.outputs.targets != '[]'");
+    assertEquals(
+      record(
+        record(timeoutJob.strategy, "timeout publisher strategy").matrix,
+        "timeout publisher matrix",
+      ).target,
+      "${{ fromJSON(needs.timeout_targets.outputs.targets) }}",
+    );
+    assertEquals(
+      record(timeoutJob.permissions, "timeout publisher permissions"),
+      {
+        contents: "read",
+        "pull-requests": "read",
+        statuses: "write",
+      },
+    );
+    assertEquals(
+      record(timeoutJob.concurrency, "timeout publisher concurrency"),
+      {
+        group: "automated-review-pr-${{ matrix.target.pullNumber }}",
+        queue: "max",
+      },
+      "timeout publication must serialize with normal per-pull publication",
+    );
+    const timeoutSteps = timeoutJob.steps;
+    assert(Array.isArray(timeoutSteps));
+    const timeoutScript = String(
+      record(
+        record(timeoutSteps[0], "timeout publisher").with,
+        "timeout publisher inputs",
+      ).script,
+    );
+    assertTrustedGateLoad(timeoutScript);
+    assert(timeoutScript.includes("expireTimedOutAutomatedReview"));
+    assert(timeoutScript.includes("AUTOMATED_REVIEW_TIMEOUT_MS"));
     const targetJob = record(jobs.target, "target job");
     const targetIf = String(targetJob.if);
     for (
       const condition of [
+        "github.event_name != 'schedule'",
         "github.event_name == 'merge_group'",
         "github.event.issue.pull_request",
         "github.event.comment.user.login == 'chatgpt-codex-connector[bot]'",


### PR DESCRIPTION
## Summary

- classify the pinned Codex usage-limit reply as a terminal failed `Automated review` status until valid exact-head proof arrives
- discover non-draft pending reviews at the merge queue 30-minute timeout on a ten-minute schedule
- batch discovery through GraphQL legacy commit statuses, up to 50 recent open PRs per request, and stop after 25 expired targets
- reuse only a pending status from the active review epoch so unrelated edits cannot refresh a timeout and base resets cannot inherit an old timeout
- bind a racing pre-pending limit reply through the authenticated triggering comment ID while reading content from the current API
- revalidate the exact head and pinned pending status under the existing per-PR publisher lock before writing
- republish preserved rate-limit and timeout diagnostics as the latest source status before propagating failure to active merge groups
- start and request a fresh idempotent review epoch when a pull request reopens

## Red-green TDD

- RED 1: rate-limit and 30-minute publisher tests returned `pending` instead of `failure`
- GREEN 1: terminal publisher behavior passed
- RED 2: workflow contract had no schedule or timeout jobs
- GREEN 2: scheduled discovery and per-PR locked publication passed
- REVIEW: replaced per-PR REST discovery with batched GraphQL legacy status lookup and added coverage beyond 500 open PRs
- REVIEW: anchored timeouts to the first active-epoch pending status, preserved terminal diagnostics, and covered the pre-pending rate-limit race
- REVIEW: reproduced and fixed reopening without a review request, terminal evidence hidden behind a generic failure, and pre-reset pending evidence timing out a new base
- REVIEW: made reopen and ready-for-review durable epoch boundaries and suppressed delayed requests after a pull request becomes closed or draft
- REVIEW: authenticated GraphQL timeout creators before bounded fan-out and extended fallback invalidation to failed reopen and ready runs
- REVIEW: ordered same-second lifecycle evidence through event IDs, pinned terminal status context, and preserved proof that wins a delayed reset race
- REVIEW: bound usage-limit replies to the REST force-push commit across observed and documented payload variants
- REVIEW: preserved boundary-second terminal proof and made failed queue propagation discoverable until a locked retry succeeds
- REVIEW: retained queue-retry failures across unrelated reconciliation while allowing fresh proof and lifecycle resets to supersede them
- REVIEW: revalidated current exact-head evidence before retrying a stored queue-propagation failure
- REVIEW: persisted normal propagation failures through fallback recovery and coalesced concurrent reopen runs on the durable event ID
- REVIEW: retained pending anchors behind outages, kept scheduled recovery discoverable, and rejected reopen runs superseded by a newer lifecycle epoch
- REVIEW: coalesced base-edit runs on durable event IDs and rejected base runs superseded by later lifecycle epochs
- REVIEW: recovered retry markers hidden by generic failures, reconciled standalone outages, and retried returned merge-group failures
- REVIEW: persisted a source retry marker for every normal-workflow merge-group failure, including failures already published to the queue commit
- REVIEW: preserved same-second operational retry markers across lifecycle boundaries without weakening comment-derived evidence checks
- REVIEW: revalidated retry-marker epochs before finalization and gated durable event lookup by the triggering webhook timestamp
- REVIEW: failed closed on ambiguous same-second triggers, bound retry markers to their underlying evidence epoch, and requested review after scheduled recovery
- REVIEW: carried the current durable lifecycle request key through scheduled recovery so older unkeyed markers cannot suppress a review
- REVIEW: validated terminal evidence and concrete recovered request keys against live lifecycle state immediately before their final writes
- REVIEW: bound ambiguous same-second lifecycle transitions to workflow run IDs and required timeout anchors to precede their failure evidence
- REVIEW: forced pending run-bound resets before evaluating any proof from an ambiguous lifecycle transition
- REVIEW: ordered timeout anchors before failures, revalidated request epochs at the final comment write, and retained pending queue-recovery markers
- REVIEW: retried failed scheduled review requests and extended run-bound lifecycle validation to ready-for-review
- REVIEW: persisted run-bound reset identities in trusted statuses so scheduled recovery cannot fall back to an older event key
- REVIEW: rejected equal-timestamp run-key fallback when the visible lifecycle event kind does not match the triggering action
- REVIEW: carried run-reset creation time into scheduled recovery and rejected any newer lifecycle event before final request posting
- REVIEW: embedded trigger time in run-bound keys, requested replacement proof after ready resets, and rechecked exact-head proof before every request write
- REVIEW: revalidated lifecycle identity and live pull head/state after the final evidence refresh and before comment creation
- REVIEW: retried failed synchronize requests through discoverable fallback invalidation, pinned recovered run keys to exact lifecycle event IDs, retained published run-bound proof boundaries, and limited explicit ready requests to ambiguous resets
- REVIEW: split timeout discovery, recovery, and final request revalidation into focused helpers and used typed input errors to satisfy the Sonar maintainability findings
- REVIEW: carried strict run-bound boundaries into the final proof refresh, preferred newly visible lifecycle epochs over superseded run resets, and compacted pinned identities within GitHub's status-description limit while retaining legacy parsing
- REVIEW: split retry-status selection from boundary-proof validation to clear the final Sonar complexity finding
- REVIEW: rejected final request writes when the pull lifecycle snapshot advances and bound unavailable retry markers to their normalized originating review epoch across direct, scheduled, and fallback publication
- REVIEW: marked propagated unavailable retries as finalized, applied active run-bound resets to terminal evidence, and rotated the bounded 25-target watchdog batch across the 1,000-PR discovery window
- REVIEW: used a typed lifecycle-snapshot error and an options object to clear the follow-up Sonar maintainability findings
- REVIEW: separated request-posting retries from queue propagation, rechecked durable lifecycle identity before source success and request writes, ignored unrelated pull updates, covered synchronize races, and applied strict run-bound proof boundaries in merge groups
- REVIEW: compared initial and final pull snapshots before source success even when lifecycle events are delayed, and kept request-posting retries discoverable across later recovery failures
- REVIEW: coalesced same-second workflow runs on the shared durable lifecycle event identity while retaining run-specific fallback only when no event ID is visible
- GREEN: `deno task test:file scripts/ci/automated-review-gate.test.ts`, 148 focused steps

## Verification

- live GitHub GraphQL schema probe returned the current `Automated review` legacy commit status
- `deno check --config=scripts/test.deno.json scripts/ci/automated-review-gate.test.ts scripts/ci/automated-review-gate.mjs`
- `deno task typecheck`
- `deno task lint:ci`
- `git diff --check`
- security review: no unresolved access-control, injection, permission, integrity, race, secret, resource-exhaustion, or dependency findings

`deno task test:scripts` ran 1,033 steps and retained two clean-tree failures in untouched `scripts/build/npm-package-metadata.test.ts`: the existing extension dependency baseline mismatch and missing built `npm/` artifact. The focused review-gate suite passed within that run.

Closes veryfront/veryfront-issue-inbox#890

Parent: veryfront/veryfront-issue-inbox#881 item 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of automated review rate limits and timeouts.
  - Prevented outdated comments or statuses from affecting newer commits.
  - Preserved terminal failure results and avoided duplicate status updates.
  - Ensured reopened changes begin a fresh review cycle.

- **Reliability Improvements**
  - Added a scheduled watchdog to identify and expire reviews exceeding the timeout.
  - Improved review discovery across large numbers of open changes.
  - Revalidated review status before marking reviews as timed out.

- **Tests**
  - Expanded coverage for timeout, pagination, rate-limit, status reuse, and stale-result scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
