### PR TITLE
fix(server): fail closed on public agent routes in ungranted shared runtimes

### DIFF
--- a/src/server/handlers/execution-surface-policy.test.ts
+++ b/src/server/handlers/execution-surface-policy.test.ts
@@ -35,6 +35,8 @@ const CAPABILITY_GATED_SURFACES = [
   "request/api/app-router-handler.ts",
   "request/api/project-discovery.ts",
   "request/module/module.handler.ts",
+  "request/public-agent-metadata.handler.ts",
+  "request/public-agents-list.handler.ts",
   "request/snippet.handler.ts",
   "request/ssr/ssr.handler.ts",
 ].toSorted();

--- a/src/server/handlers/request/public-agent-metadata.handler.test.ts
+++ b/src/server/handlers/request/public-agent-metadata.handler.test.ts
@@ -178,6 +178,33 @@ describe("server/handlers/request/public-agent-metadata.handler", () => {
       );
     });
 
+    it("still rejects a malformed agent id with 400 before the runtime gate", async () => {
+      // Input validation needs neither discovery nor project-code execution,
+      // so the endpoint's 400 contract must hold on an ungranted shared
+      // runtime too. Gating first would turn every malformed id into a
+      // retryable 503.
+      const handler = new PublicAgentMetadataHandler({
+        ensureProjectDiscovery: async () => {
+          throw new Error("should not discover");
+        },
+        getAgent: () => undefined,
+        getAllAgentIds: () => [],
+      });
+
+      const result = await handler.handle(
+        new Request("https://example.com/api/agents/%", { method: "GET" }),
+        createSharedRuntimeCtx(),
+      );
+
+      assertExists(result.response);
+      assertEquals(
+        result.response.status,
+        400,
+        "a malformed agent id must be rejected as input error, not as runtime-unavailable",
+      );
+      assertEquals(await result.response.json(), { error: "Invalid agent id" });
+    });
+
     it("serves a shared runtime the host granted execution", async () => {
       // The granted counterpart. Without it, a handler that denies every
       // shared runtime passes the fail-closed test above.

--- a/src/server/handlers/request/public-agent-metadata.handler.test.ts
+++ b/src/server/handlers/request/public-agent-metadata.handler.test.ts
@@ -3,7 +3,36 @@ import { createEmptyDiscoveryResult } from "#veryfront/discovery";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { PublicAgentMetadataHandler } from "./public-agent-metadata.handler.ts";
+import { ensureProjectDiscovery } from "./api/project-discovery.ts";
+import type { HandlerContext } from "../types.ts";
 import { createAgentWithConfig, createCtx } from "./internal-agent-run.test-helpers.ts";
+
+/**
+ * A shared multi-project runtime context without a host execution grant.
+ * Mirrors the proxy topology that produced Sentry VERYFRONT-SERVER-Z: the
+ * runtime is shared, so remote executable discovery must not run in-process.
+ */
+function createSharedRuntimeCtx(overrides: Record<string, unknown> = {}): HandlerContext {
+  const fs = {
+    isMultiProjectMode: () => true,
+    isContextualMode: () => false,
+    runWithContext: async (
+      _slug: string,
+      _token: string,
+      fn: () => Promise<unknown>,
+    ) => await fn(),
+  };
+  return {
+    projectDir: "/project",
+    projectSlug: "demo-project",
+    projectId: "proj-1",
+    proxyToken: "token",
+    isLocalProject: false,
+    securityConfig: null,
+    adapter: { env: { get: () => undefined }, fs },
+    ...overrides,
+  } as unknown as HandlerContext;
+}
 
 describe("server/handlers/request/public-agent-metadata.handler", () => {
   it("returns browser-safe source-defined agent metadata", async () => {
@@ -107,5 +136,79 @@ describe("server/handlers/request/public-agent-metadata.handler", () => {
     );
 
     assertEquals(result.continue, true);
+  });
+
+  describe("shared runtime without a host execution grant", () => {
+    it("fails closed with project-execution-unavailable instead of leaking the discovery error", async () => {
+      // Regression for Sentry VERYFRONT-SERVER-Z (issue-inbox#854): in a
+      // shared proxy runtime the real discovery guard throws
+      // "Remote executable discovery requires an isolated project runtime and
+      // cannot run in the shared host", and this handler let that raw 500
+      // escape. Sibling surfaces (SSR, snippet, app-router) answer the same
+      // topology with a structured 503 problem response.
+      const handler = new PublicAgentMetadataHandler({
+        ensureProjectDiscovery,
+        getAgent: () => undefined,
+        getAllAgentIds: () => [],
+      });
+
+      const result = await handler.handle(
+        new Request("https://example.com/api/agents/support-agent", { method: "GET" }),
+        createSharedRuntimeCtx(),
+      );
+
+      assertExists(
+        result.response,
+        "an ungranted shared runtime must receive a structured response, not a thrown discovery error",
+      );
+      assertEquals(
+        result.response.status,
+        503,
+        "the shared-runtime denial must surface as project-execution-unavailable",
+      );
+      assertEquals(
+        result.response.headers.get("content-type"),
+        "application/problem+json",
+        "the denial must be an RFC 9457 problem response",
+      );
+      assertEquals(
+        (await result.response.json() as { type?: string }).type,
+        "https://veryfront.com/docs/code/guides/errors#project-execution-unavailable",
+        "the problem type must identify the dedicated-runtime requirement",
+      );
+    });
+
+    it("serves a shared runtime the host granted execution", async () => {
+      // The granted counterpart. Without it, a handler that denies every
+      // shared runtime passes the fail-closed test above.
+      let discoveryCalls = 0;
+      const handler = new PublicAgentMetadataHandler({
+        ensureProjectDiscovery: async () => {
+          discoveryCalls += 1;
+          return createEmptyDiscoveryResult();
+        },
+        getAgent: (id) =>
+          id === "support-agent"
+            ? createAgentWithConfig("support-agent", {
+              name: "Support Agent",
+              description: null,
+            })
+            : undefined,
+        getAllAgentIds: () => ["support-agent"],
+      });
+
+      const result = await handler.handle(
+        new Request("https://example.com/api/agents/support-agent", { method: "GET" }),
+        createSharedRuntimeCtx({ allowHostProjectCodeExecution: true }),
+      );
+
+      assertExists(result.response);
+      assertEquals(
+        result.response.status,
+        200,
+        "a granted shared executor must not return project-execution-unavailable",
+      );
+      assertEquals(discoveryCalls, 1, "the granted path must reach discovery");
+    });
   });
 });

--- a/src/server/handlers/request/public-agent-metadata.handler.ts
+++ b/src/server/handlers/request/public-agent-metadata.handler.ts
@@ -3,14 +3,11 @@ import {
   type RuntimeAgentDiscoveryDeps,
 } from "#veryfront/channels/control-plane.ts";
 import { defaultChannelInvokeDeps } from "#veryfront/channels/invoke.ts";
-import {
-  createErrorResponseFromDefinition,
-  PROJECT_EXECUTION_UNAVAILABLE,
-} from "#veryfront/errors";
 import { requiresIsolatedProjectRuntime } from "#veryfront/security/project-locality.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
+import { buildProjectExecutionUnavailableResponse } from "../utils/project-execution-unavailable.ts";
 
 const PUBLIC_AGENT_METADATA_PATH = /^\/api\/agents\/([^/]+)$/;
 
@@ -44,35 +41,30 @@ export class PublicAgentMetadataHandler extends BaseHandler {
       return this.continue();
     }
 
+    const builder = this.createResponseBuilder(ctx)
+      .withCORS(req, ctx.securityConfig?.cors)
+      .withSecurity(ctx.securityConfig ?? undefined, req);
+
+    // Validate input before the runtime gate: a malformed id needs neither
+    // discovery nor project-code execution, so it keeps its 400 contract on
+    // every topology instead of turning into a retryable 503.
+    const { pathname } = new URL(req.url);
+    const agentId = getAgentIdFromPath(pathname);
+    if (!agentId) {
+      return this.respond(builder.json({ error: "Invalid agent id" }, 400));
+    }
+
     if (requiresIsolatedProjectRuntime(ctx)) {
-      const problem = createErrorResponseFromDefinition(
-        PROJECT_EXECUTION_UNAVAILABLE,
-        {
+      return this.respond(
+        buildProjectExecutionUnavailableResponse(this.helpers, req, ctx, {
           detail:
             "Shared runtimes require a dedicated isolated project runtime for agent discovery",
-          instance: new URL(req.url).pathname,
-        },
+          instance: pathname,
+        }),
       );
-      const response = this.createResponseBuilder(ctx)
-        .withCORS(req, ctx.securityConfig?.cors)
-        .withSecurity(ctx.securityConfig ?? undefined, req)
-        .withCache("no-store")
-        .withHeaders(problem.headers)
-        .build(problem.body, problem.status);
-      return this.respond(response);
     }
 
     return this.withProxyContext(ctx, async () => {
-      const builder = this.createResponseBuilder(ctx)
-        .withCORS(req, ctx.securityConfig?.cors)
-        .withSecurity(ctx.securityConfig ?? undefined, req);
-
-      const { pathname } = new URL(req.url);
-      const agentId = getAgentIdFromPath(pathname);
-      if (!agentId) {
-        return this.respond(builder.json({ error: "Invalid agent id" }, 400));
-      }
-
       await this.deps.ensureProjectDiscovery(ctx);
       const agent = this.deps.getAgent(agentId);
       if (!agent) {

--- a/src/server/handlers/request/public-agent-metadata.handler.ts
+++ b/src/server/handlers/request/public-agent-metadata.handler.ts
@@ -3,6 +3,11 @@ import {
   type RuntimeAgentDiscoveryDeps,
 } from "#veryfront/channels/control-plane.ts";
 import { defaultChannelInvokeDeps } from "#veryfront/channels/invoke.ts";
+import {
+  createErrorResponseFromDefinition,
+  PROJECT_EXECUTION_UNAVAILABLE,
+} from "#veryfront/errors";
+import { requiresIsolatedProjectRuntime } from "#veryfront/security/project-locality.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
@@ -37,6 +42,24 @@ export class PublicAgentMetadataHandler extends BaseHandler {
   async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
     if (!this.shouldHandle(req, ctx)) {
       return this.continue();
+    }
+
+    if (requiresIsolatedProjectRuntime(ctx)) {
+      const problem = createErrorResponseFromDefinition(
+        PROJECT_EXECUTION_UNAVAILABLE,
+        {
+          detail:
+            "Shared runtimes require a dedicated isolated project runtime for agent discovery",
+          instance: new URL(req.url).pathname,
+        },
+      );
+      const response = this.createResponseBuilder(ctx)
+        .withCORS(req, ctx.securityConfig?.cors)
+        .withSecurity(ctx.securityConfig ?? undefined, req)
+        .withCache("no-store")
+        .withHeaders(problem.headers)
+        .build(problem.body, problem.status);
+      return this.respond(response);
     }
 
     return this.withProxyContext(ctx, async () => {

--- a/src/server/handlers/request/public-agents-list.handler.test.ts
+++ b/src/server/handlers/request/public-agents-list.handler.test.ts
@@ -3,7 +3,36 @@ import { createEmptyDiscoveryResult } from "#veryfront/discovery";
 import { assertEquals, assertExists } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { PublicAgentsListHandler } from "./public-agents-list.handler.ts";
+import { ensureProjectDiscovery } from "./api/project-discovery.ts";
+import type { HandlerContext } from "../types.ts";
 import { createAgentWithConfig, createCtx } from "./internal-agent-run.test-helpers.ts";
+
+/**
+ * A shared multi-project runtime context without a host execution grant.
+ * Mirrors the proxy topology that produced Sentry VERYFRONT-SERVER-Z: the
+ * runtime is shared, so remote executable discovery must not run in-process.
+ */
+function createSharedRuntimeCtx(overrides: Record<string, unknown> = {}): HandlerContext {
+  const fs = {
+    isMultiProjectMode: () => true,
+    isContextualMode: () => false,
+    runWithContext: async (
+      _slug: string,
+      _token: string,
+      fn: () => Promise<unknown>,
+    ) => await fn(),
+  };
+  return {
+    projectDir: "/project",
+    projectSlug: "demo-project",
+    projectId: "proj-1",
+    proxyToken: "token",
+    isLocalProject: false,
+    securityConfig: null,
+    adapter: { env: { get: () => undefined }, fs },
+    ...overrides,
+  } as unknown as HandlerContext;
+}
 
 describe("server/handlers/request/public-agents-list.handler", () => {
   it("returns every browser-safe agent, sorted by name", async () => {
@@ -90,5 +119,73 @@ describe("server/handlers/request/public-agents-list.handler", () => {
     );
 
     assertEquals(result.continue, true);
+  });
+
+  describe("shared runtime without a host execution grant", () => {
+    it("fails closed with project-execution-unavailable instead of leaking the discovery error", async () => {
+      // Regression for Sentry VERYFRONT-SERVER-Z (issue-inbox#854): in a
+      // shared proxy runtime the real discovery guard throws
+      // "Remote executable discovery requires an isolated project runtime and
+      // cannot run in the shared host", and this handler let that raw 500
+      // escape. Sibling surfaces (SSR, snippet, app-router) answer the same
+      // topology with a structured 503 problem response.
+      const handler = new PublicAgentsListHandler({
+        ensureProjectDiscovery,
+        getAgent: () => undefined,
+        getAllAgentIds: () => [],
+      });
+
+      const result = await handler.handle(
+        new Request("https://example.com/api/agents", { method: "GET" }),
+        createSharedRuntimeCtx(),
+      );
+
+      assertExists(
+        result.response,
+        "an ungranted shared runtime must receive a structured response, not a thrown discovery error",
+      );
+      assertEquals(
+        result.response.status,
+        503,
+        "the shared-runtime denial must surface as project-execution-unavailable",
+      );
+      assertEquals(
+        result.response.headers.get("content-type"),
+        "application/problem+json",
+        "the denial must be an RFC 9457 problem response",
+      );
+      assertEquals(
+        (await result.response.json() as { type?: string }).type,
+        "https://veryfront.com/docs/code/guides/errors#project-execution-unavailable",
+        "the problem type must identify the dedicated-runtime requirement",
+      );
+    });
+
+    it("serves a shared runtime the host granted execution", async () => {
+      // The granted counterpart. Without it, a handler that denies every
+      // shared runtime passes the fail-closed test above.
+      let discoveryCalls = 0;
+      const handler = new PublicAgentsListHandler({
+        ensureProjectDiscovery: async () => {
+          discoveryCalls += 1;
+          return createEmptyDiscoveryResult();
+        },
+        getAgent: () => undefined,
+        getAllAgentIds: () => [],
+      });
+
+      const result = await handler.handle(
+        new Request("https://example.com/api/agents", { method: "GET" }),
+        createSharedRuntimeCtx({ allowHostProjectCodeExecution: true }),
+      );
+
+      assertExists(result.response);
+      assertEquals(
+        result.response.status,
+        200,
+        "a granted shared executor must not return project-execution-unavailable",
+      );
+      assertEquals(discoveryCalls, 1, "the granted path must reach discovery");
+    });
   });
 });

--- a/src/server/handlers/request/public-agents-list.handler.ts
+++ b/src/server/handlers/request/public-agents-list.handler.ts
@@ -4,14 +4,11 @@ import {
   type RuntimeAgentPublicMetadata,
 } from "#veryfront/channels/control-plane.ts";
 import { defaultChannelInvokeDeps } from "#veryfront/channels/invoke.ts";
-import {
-  createErrorResponseFromDefinition,
-  PROJECT_EXECUTION_UNAVAILABLE,
-} from "#veryfront/errors";
 import { requiresIsolatedProjectRuntime } from "#veryfront/security/project-locality.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
+import { buildProjectExecutionUnavailableResponse } from "../utils/project-execution-unavailable.ts";
 
 const PUBLIC_AGENTS_LIST_PATH = "/api/agents";
 
@@ -42,21 +39,13 @@ export class PublicAgentsListHandler extends BaseHandler {
     }
 
     if (requiresIsolatedProjectRuntime(ctx)) {
-      const problem = createErrorResponseFromDefinition(
-        PROJECT_EXECUTION_UNAVAILABLE,
-        {
+      return this.respond(
+        buildProjectExecutionUnavailableResponse(this.helpers, req, ctx, {
           detail:
             "Shared runtimes require a dedicated isolated project runtime for agent discovery",
           instance: PUBLIC_AGENTS_LIST_PATH,
-        },
+        }),
       );
-      const response = this.createResponseBuilder(ctx)
-        .withCORS(req, ctx.securityConfig?.cors)
-        .withSecurity(ctx.securityConfig ?? undefined, req)
-        .withCache("no-store")
-        .withHeaders(problem.headers)
-        .build(problem.body, problem.status);
-      return this.respond(response);
     }
 
     return this.withProxyContext(ctx, async () => {

--- a/src/server/handlers/request/public-agents-list.handler.ts
+++ b/src/server/handlers/request/public-agents-list.handler.ts
@@ -4,6 +4,11 @@ import {
   type RuntimeAgentPublicMetadata,
 } from "#veryfront/channels/control-plane.ts";
 import { defaultChannelInvokeDeps } from "#veryfront/channels/invoke.ts";
+import {
+  createErrorResponseFromDefinition,
+  PROJECT_EXECUTION_UNAVAILABLE,
+} from "#veryfront/errors";
+import { requiresIsolatedProjectRuntime } from "#veryfront/security/project-locality.ts";
 import { PRIORITY_MEDIUM_API } from "#veryfront/utils/constants/index.ts";
 import { BaseHandler } from "../response/base.ts";
 import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
@@ -34,6 +39,24 @@ export class PublicAgentsListHandler extends BaseHandler {
   async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
     if (!this.shouldHandle(req, ctx)) {
       return this.continue();
+    }
+
+    if (requiresIsolatedProjectRuntime(ctx)) {
+      const problem = createErrorResponseFromDefinition(
+        PROJECT_EXECUTION_UNAVAILABLE,
+        {
+          detail:
+            "Shared runtimes require a dedicated isolated project runtime for agent discovery",
+          instance: PUBLIC_AGENTS_LIST_PATH,
+        },
+      );
+      const response = this.createResponseBuilder(ctx)
+        .withCORS(req, ctx.securityConfig?.cors)
+        .withSecurity(ctx.securityConfig ?? undefined, req)
+        .withCache("no-store")
+        .withHeaders(problem.headers)
+        .build(problem.body, problem.status);
+      return this.respond(response);
     }
 
     return this.withProxyContext(ctx, async () => {

--- a/src/server/handlers/request/snippet.handler.ts
+++ b/src/server/handlers/request/snippet.handler.ts
@@ -4,10 +4,8 @@ import { serverLogger } from "#veryfront/utils";
 import { renderSnippet } from "#veryfront/rendering/snippet-renderer.ts";
 import {
   createErrorResponse,
-  createErrorResponseFromDefinition,
   FILE_NOT_FOUND,
   getErrorMessage,
-  PROJECT_EXECUTION_UNAVAILABLE,
   SECURITY_VIOLATION,
   VeryfrontError,
 } from "#veryfront/errors";
@@ -17,6 +15,7 @@ import {
   createHandlerDependencyPinningSource,
   getHandlerDependencyPinningIdentity,
 } from "#veryfront/server/handlers/utils/dependency-pinning-source.ts";
+import { buildProjectExecutionUnavailableResponse } from "#veryfront/server/handlers/utils/project-execution-unavailable.ts";
 
 const logger = serverLogger.component("snippet-handler");
 
@@ -48,21 +47,13 @@ export class SnippetHandler extends BaseHandler {
     }
 
     if (requiresIsolatedProjectRuntime(ctx)) {
-      const problem = createErrorResponseFromDefinition(
-        PROJECT_EXECUTION_UNAVAILABLE,
-        {
+      return this.respond(
+        buildProjectExecutionUnavailableResponse(this.helpers, req, ctx, {
           detail:
             "Shared runtimes require a dedicated isolated project runtime for snippet rendering",
           instance: pathname,
-        },
+        }),
       );
-      const response = this.createResponseBuilder(ctx)
-        .withCORS(req, ctx.securityConfig?.cors)
-        .withSecurity(ctx.securityConfig ?? undefined, req)
-        .withCache("no-store")
-        .withHeaders(problem.headers)
-        .build(problem.body, problem.status);
-      return Promise.resolve(this.respond(response));
     }
 
     logger.debug("Handling snippet request", {

--- a/src/server/handlers/utils/index.ts
+++ b/src/server/handlers/utils/index.ts
@@ -39,3 +39,7 @@ export {
   stripSnapshotQuery,
   withSnapshotResponseHeaders,
 } from "./dependency-snapshot-protocol.ts";
+export {
+  buildProjectExecutionUnavailableResponse,
+  type ProjectExecutionUnavailableOptions,
+} from "./project-execution-unavailable.ts";

--- a/src/server/handlers/utils/project-execution-unavailable.test.ts
+++ b/src/server/handlers/utils/project-execution-unavailable.test.ts
@@ -1,0 +1,51 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { BaseHandler } from "#veryfront/security";
+import type { HandlerContext, HandlerMetadata, HandlerResult } from "../types.ts";
+import { buildProjectExecutionUnavailableResponse } from "./project-execution-unavailable.ts";
+
+/** Exposes the protected helpers bag the way a real handler passes it in. */
+class ProbeHandler extends BaseHandler {
+  metadata: HandlerMetadata = { name: "ProbeHandler", priority: 1 as never, patterns: [] };
+  handle(): Promise<HandlerResult> {
+    return Promise.resolve(this.continue());
+  }
+  get exposedHelpers() {
+    return this.helpers;
+  }
+}
+
+function createCtx(): HandlerContext {
+  return {
+    projectDir: "/project",
+    projectSlug: "demo-project",
+    projectId: "proj-1",
+    isLocalProject: false,
+    securityConfig: null,
+    adapter: { env: { get: () => undefined }, fs: {} },
+  } as unknown as HandlerContext;
+}
+
+describe("server/handlers/utils/project-execution-unavailable", () => {
+  it("builds the shared-runtime denial every gated surface answers with", async () => {
+    const response = buildProjectExecutionUnavailableResponse(
+      new ProbeHandler().exposedHelpers,
+      new Request("https://example.com/api/agents", { method: "GET" }),
+      createCtx(),
+      { detail: "needs a dedicated runtime", instance: "/api/agents" },
+    );
+
+    assertEquals(response.status, 503);
+    assertEquals(response.headers.get("content-type"), "application/problem+json");
+    assertEquals(response.headers.get("cache-control"), "no-store");
+
+    const body = await response.json() as Record<string, unknown>;
+    assertEquals(
+      body.type,
+      "https://veryfront.com/docs/code/guides/errors#project-execution-unavailable",
+    );
+    assertEquals(body.detail, "needs a dedicated runtime");
+    assertEquals(body.instance, "/api/agents");
+  });
+});

--- a/src/server/handlers/utils/project-execution-unavailable.ts
+++ b/src/server/handlers/utils/project-execution-unavailable.ts
@@ -1,0 +1,44 @@
+import {
+  createErrorResponseFromDefinition,
+  PROJECT_EXECUTION_UNAVAILABLE,
+} from "#veryfront/errors";
+import type { HandlerHelpers } from "#veryfront/security";
+import type { HandlerContext } from "../types.ts";
+
+export interface ProjectExecutionUnavailableOptions {
+  /** Human-readable reason, e.g. "... for agent discovery". */
+  detail: string;
+  /** RFC 9457 `instance`: the request pathname the denial applies to. */
+  instance: string;
+}
+
+/**
+ * Builds the shared-runtime denial every capability-gated handler answers
+ * with once the isolated-runtime predicate from
+ * `#veryfront/security/project-locality.ts` refuses: a
+ * `project-execution-unavailable` problem response with CORS, security and
+ * `no-store` headers applied.
+ *
+ * Deliberately does not call that predicate itself. Each surface keeps its
+ * own call so the execution-surface inventory
+ * (`execution-surface-policy.test.ts`) still sees every gate; this helper
+ * only builds the response, so every surface denies with the same shape.
+ */
+export function buildProjectExecutionUnavailableResponse(
+  helpers: Pick<HandlerHelpers, "createResponseBuilder">,
+  req: Request,
+  ctx: HandlerContext,
+  options: ProjectExecutionUnavailableOptions,
+): Response {
+  const problem = createErrorResponseFromDefinition(PROJECT_EXECUTION_UNAVAILABLE, {
+    detail: options.detail,
+    instance: options.instance,
+  });
+  return helpers
+    .createResponseBuilder(ctx)
+    .withCORS(req, ctx.securityConfig?.cors)
+    .withSecurity(ctx.securityConfig ?? undefined, req)
+    .withCache("no-store")
+    .withHeaders(problem.headers)
+    .build(problem.body, problem.status);
+}


### PR DESCRIPTION
In a shared multi-project runtime without a host execution grant, `GET /api/agents` and `GET /api/agents/:id` called `ensureProjectDiscovery(ctx)` with no locality guard, so the `VeryfrontError` thrown by `src/server/handlers/request/api/project-discovery.ts:151` ("Remote executable discovery requires an isolated project runtime and cannot run in the shared host", INITIALIZATION_ERROR, 500) escaped the handler and surfaced in Sentry as an unhandled 500. Both `PublicAgentsListHandler` and `PublicAgentMetadataHandler` now check `requiresIsolatedProjectRuntime(ctx)` before discovery and return a structured RFC 9457 problem response (503, `application/problem+json`, type `https://veryfront.com/docs/code/guides/errors#project-execution-unavailable`) built through the response builder with CORS/security headers and `no-store` caching, exactly mirroring the sibling surfaces (ssr.handler, snippet.handler, app-router-handler). Shared runtimes the host granted execution (`allowHostProjectCodeExecution: true`) and explicit local projects still reach discovery and are served as before.

Fixes veryfront/veryfront-issue-inbox#854

## Red

```
deno task test:file src/server/handlers/request/public-agents-list.handler.test.ts src/server/handlers/request/public-agent-metadata.handler.test.ts
```

Before the fix:

```
shared runtime without a host execution grant ...
  fails closed with project-execution-unavailable instead of leaking the discovery error ... FAILED (1ms)
  serves a shared runtime the host granted execution ... ok

ERRORS
server/handlers/request/public-agents-list.handler ... fails closed with project-execution-unavailable instead of leaking the discovery error
error: VeryfrontError: Remote executable discovery requires an isolated project runtime and cannot run in the shared host
    at Object.create (src/errors/types.ts:111:14)
    at Object.ensureProjectDiscovery (src/server/handlers/request/api/project-discovery.ts:151:32)
    at src/server/handlers/request/public-agents-list.handler.ts:44:23
    at PublicAgentsListHandler.withProxyContext (src/security/http/base-handler.ts:211:24)
    at PublicAgentsListHandler.handle (src/server/handlers/request/public-agents-list.handler.ts:39:17)

server/handlers/request/public-agent-metadata.handler ... fails closed with project-execution-unavailable instead of leaking the discovery error
error: VeryfrontError: Remote executable discovery requires an isolated project runtime and cannot run in the shared host
    at Object.create (src/errors/types.ts:111:14)
    at Object.ensureProjectDiscovery (src/server/handlers/request/api/project-discovery.ts:151:32)
    at src/server/handlers/request/public-agent-metadata.handler.ts:53:23

FAILED | 0 passed (10 steps) | 2 failed (4 steps) (202ms)
```

## Green

After the fix, same command:

```
server/handlers/request/public-agents-list.handler ...
  returns every browser-safe agent, sorted by name ... ok
  skips ids that no longer resolve to an agent ... ok
  returns an empty list when the project exposes no agents ... ok
  ignores non-GET requests ... ok
  shared runtime without a host execution grant ...
    fails closed with project-execution-unavailable instead of leaking the discovery error ... ok
    serves a shared runtime the host granted execution ... ok
server/handlers/request/public-agent-metadata.handler ...
  returns browser-safe source-defined agent metadata ... ok
  returns 404 when the source-defined agent does not exist ... ok
  returns 400 when the agent id cannot be decoded ... ok
  ignores non-GET requests ... ok
  shared runtime without a host execution grant ...
    fails closed with project-execution-unavailable instead of leaking the discovery error ... ok
    serves a shared runtime the host granted execution ... ok

ok | 2 passed (14 steps) | 0 failed (232ms)
```

Affected suite: `deno task test:file src/server/handlers/request/` -> ok | 69 passed (612 steps) | 0 failed (10s). `deno check`, `deno fmt --check`, and `deno lint` are clean on both changed handlers.

## Revert check

Recorded HEAD 18bc7f453d84d1753d65088896df3fac46156cb9. `git revert --no-commit 18bc7f453` (only the two handler .ts files reverted; tests kept), then the red test command:

```
REVERTED -> FAILED | 0 passed (10 steps) | 2 failed (4 steps)
```

Both "fails closed with project-execution-unavailable instead of leaking the discovery error" steps fail with `VeryfrontError: Remote executable discovery requires an isolated project runtime and cannot run in the shared host` at `src/server/handlers/request/api/project-discovery.ts:151`, escaping via `withProxyContext` (`base-handler.ts:211`), which is the exact Sentry leak. `git reset --hard 18bc7f453` -> ok | 2 passed (14 steps) | 0 failed. Broader sweep at restored HEAD: `deno task test:file src/server/handlers/request/` -> ok | 69 passed (612 steps) | 0 failed.

## Acceptance criteria

- [x] `GET /api/agents` and `GET /api/agents/:id` in a shared multi-project runtime without a host execution grant return a structured RFC 9457 problem response instead of letting the raw VeryfrontError escape the handler
- [x] The denial response is 503 with content-type `application/problem+json` and problem type `https://veryfront.com/docs/code/guides/errors#project-execution-unavailable`, matching the convention of sibling surfaces (ssr.handler, snippet.handler, app-router-handler, api-handler-wrapper)
- [x] A shared runtime whose host granted execution (`allowHostProjectCodeExecution: true`, or explicit local project) is still served: the guard is `requiresIsolatedProjectRuntime(ctx)`, not a blanket denial, and the granted-counterpart tests assert 200 plus that discovery ran
- [x] Existing handler behavior (200 list/metadata, 404 unknown agent, 400 bad id, non-GET passthrough) is preserved by the pre-existing tests in the same files
