### PR TITLE
fix(agent): treat run_terminal mirror stop as cancellation in durable run event sink

### DIFF
--- a/src/agent/hosted/durable-run-event-sink.test.ts
+++ b/src/agent/hosted/durable-run-event-sink.test.ts
@@ -465,6 +465,79 @@ describe("agent/hosted/durable-run-event-sink", () => {
     }
   });
 
+  it("treats a mirror already stopped by a terminal run as cancellation, not a failure", async () => {
+    // veryfront-issue-inbox#872 (Sentry VERYFRONT-AGENT-7): `run_terminal` means
+    // the API already told the mirror the run is finished server-side (a project
+    // delete cancels its in-flight runs first, see veryfront-issue-inbox#743).
+    // Nothing the runtime can still write is lost, so every other consumer of the
+    // reason treats it as a clean stop. The sink must do the same: the model
+    // dispatch is still refused, but as the runtime's abort shape rather than the
+    // DurableRunEventPersistenceError that pages an operator for a run that
+    // simply no longer exists.
+    const target = mirror();
+    const error = await assertRejects(
+      async () =>
+        await createDurableRunEventSink({
+          mirror: {
+            ...target.result,
+            getSnapshot: () => snapshot({ disabled: true, disableReason: "run_terminal" }),
+          },
+        })({
+          type: "AGENT_RUN_MODEL_CALL_CONTEXT",
+          messages: [],
+        }),
+      DOMException,
+      undefined,
+      "a terminal-run stop must refuse the dispatch as a cancellation, not a persistence failure",
+    );
+
+    assertInstanceOf(error, DOMException);
+    assertEquals(
+      error.name,
+      "AbortError",
+      "the runtime recognizes DOMException AbortError as a clean cancellation",
+    );
+    assertEquals(
+      target.appended.length,
+      0,
+      "nothing can be appended to a run that is already terminal",
+    );
+  });
+
+  it("treats a run turning terminal during persistence as cancellation, not a failure", async () => {
+    // The production path behind the Sentry group: the append attempt is rejected
+    // with a terminal-run error, recovery disables the mirror with reason
+    // `run_terminal`, and the post-append flush hands that snapshot back to the
+    // sink. The persisted context is not lost and the run is finished, so the
+    // sink must wind down as a cancellation instead of raising
+    // "Required durable run event mirror is disabled: run_terminal".
+    const target = mirror({
+      flush: async () => snapshot({ disabled: true, disableReason: "run_terminal" }),
+    });
+    const error = await assertRejects(
+      async () =>
+        await createDurableRunEventSink({ mirror: target.result })({
+          type: "AGENT_RUN_MODEL_CALL_CONTEXT",
+          messages: [],
+        }),
+      DOMException,
+      undefined,
+      "a run that turns terminal mid-persistence must reject as a cancellation",
+    );
+
+    assertInstanceOf(error, DOMException);
+    assertEquals(
+      error.name,
+      "AbortError",
+      "the runtime recognizes DOMException AbortError as a clean cancellation",
+    );
+    assertEquals(
+      target.appended.length,
+      1,
+      "the context was appended before the run was discovered to be terminal",
+    );
+  });
+
   it("does not mask later persistence failures with a rejected tail", async () => {
     const firstAppendStarted = Promise.withResolvers<void>();
     const releaseFirstAppend = Promise.withResolvers<void>();

--- a/src/agent/hosted/durable-run-event-sink.ts
+++ b/src/agent/hosted/durable-run-event-sink.ts
@@ -18,12 +18,23 @@ const persistenceTails = new WeakMap<ConversationRunChunkMirror, Promise<void>>(
 export { DurableRunEventPersistenceError } from "../conversation/private-run-event.ts";
 
 function assertEnabled(snapshot: ConversationRunMirrorSnapshot): void {
-  if (snapshot.disabled) {
-    const suffix = snapshot.disableReason === undefined ? "" : `: ${snapshot.disableReason}`;
-    throw new DurableRunEventPersistenceError(
-      `Required durable run event mirror is disabled${suffix}`,
+  if (!snapshot.disabled) return;
+  // veryfront-issue-inbox#872: `run_terminal` means the API already declared the
+  // run finished server-side (a project delete cancels its in-flight runs first,
+  // see veryfront-issue-inbox#743). Nothing the runtime can still write is lost,
+  // and every other consumer of the reason treats it as a clean stop
+  // (run-chunk-mirror.ts, hosted-chat-finalization.ts). The dispatch is still
+  // refused, but as the runtime's abort shape rather than a persistence failure.
+  if (snapshot.disableReason === "run_terminal") {
+    throw new DOMException(
+      "Durable run event mirror stopped: the run is already terminal",
+      "AbortError",
     );
   }
+  const suffix = snapshot.disableReason === undefined ? "" : `: ${snapshot.disableReason}`;
+  throw new DurableRunEventPersistenceError(
+    `Required durable run event mirror is disabled${suffix}`,
+  );
 }
 
 function isDrained(snapshot: ConversationRunMirrorSnapshot): boolean {


### PR DESCRIPTION
When the durable run event mirror is disabled with reason `run_terminal` (the API declared the run terminal, e.g. a project delete cancelled in-flight runs — a clean stop per veryfront-issue-inbox#743, already treated as such by `run-chunk-mirror.ts` and `hosted-chat-finalization.ts`), `assertEnabled()` in `src/agent/hosted/durable-run-event-sink.ts` still escalated it to `DurableRunEventPersistenceError: Required durable run event mirror is disabled: run_terminal`, paging Sentry (VERYFRONT-AGENT-7). The fix special-cases `run_terminal` in `assertEnabled()` to reject with `DOMException("Durable run event mirror stopped: the run is already terminal", "AbortError")` — the runtime's recognized cancellation shape — while every other disable reason (`auth_rejected`, `payload_too_large`, ...) keeps failing hard, and the fail-closed contract is preserved: the sink still rejects, so the model call is never dispatched for a terminal run. Because both discovery points (the entry check before append, and the post-append flush) funnel through `assertEnabled()`, one guard covers both.

Note: the Sentry culprit `veryfront.esm.src.agent.hosted:durable-run-event-sink` is framework code that veryfront-agent consumes via the prebuilt `veryfront` npm package, so the fix lands here in veryfront-code rather than veryfront-agent; veryfront-agent will need a `veryfront` dependency bump after this ships before the Sentry group goes quiet.

Fixes veryfront/veryfront-issue-inbox#872

## Red

```
deno task test:file src/agent/hosted/durable-run-event-sink.test.ts
```

Before the fix:

```
agent/hosted/durable-run-event-sink ...
  treats a mirror already stopped by a terminal run as cancellation, not a failure ... FAILED (0ms)
  treats a run turning terminal during persistence as cancellation, not a failure ... FAILED (0ms)

 ERRORS

treats a mirror already stopped by a terminal run as cancellation, not a failure
error: AssertionError: Expected error to be instance of "DOMException", but was "DurableRunEventPersistenceError": a terminal-run stop must refuse the dispatch as a cancellation, not a persistence failure
    at async durable-run-event-sink.test.ts:478

treats a run turning terminal during persistence as cancellation, not a failure
error: AssertionError: Expected error to be instance of "DOMException", but was "DurableRunEventPersistenceError": a run that turns terminal mid-persistence must reject as a cancellation
    at async durable-run-event-sink.test.ts:518

FAILED | 0 passed (19 steps) | 1 failed (2 steps)
```

The raised error in both cases is `DurableRunEventPersistenceError "Required durable run event mirror is disabled: run_terminal"` — the exact Sentry VERYFRONT-AGENT-7 signature.

## Green

```
deno task test:file src/agent/hosted/durable-run-event-sink.test.ts
  treats a mirror already stopped by a terminal run as cancellation, not a failure ... ok
  treats a run turning terminal during persistence as cancellation, not a failure ... ok
  reports the concrete disable reason when a required mirror is already disabled ... ok
  ...
agent/hosted/durable-run-event-sink ... ok (426ms)
ok | 1 passed (21 steps) | 0 failed (430ms)
```

Affected suites:

```
deno task test:file src/agent/hosted        => ok | 498 passed (419 steps) | 0 failed (11s)
deno task test:file src/agent/conversation  => ok | 21 passed (246 steps) | 0 failed (2s)
deno fmt --check / deno lint / deno check on durable-run-event-sink.ts: all clean
```

## Revert check

With the fix commit reverted (`git revert --no-commit a2fddccf`, only `src/agent/hosted/durable-run-event-sink.ts` modified), the regression tests fail again with the original signature:

```
treats a mirror already stopped by a terminal run as cancellation, not a failure
  => AssertionError: Expected error to be instance of "DOMException", but was "DurableRunEventPersistenceError": a terminal-run stop must refuse the dispatch as a cancellation, not a persistence failure
treats a run turning terminal during persistence as cancellation, not a failure
  => AssertionError: Expected error to be instance of "DOMException", but was "DurableRunEventPersistenceError"
FAILED | 0 passed (19 steps) | 1 failed (2 steps) (401ms)
```

Restored to the fix (`git reset --hard a2fddccf`), the suite passes again:

```
agent/hosted/durable-run-event-sink ... ok (409ms)
ok | 1 passed (21 steps) | 0 failed (413ms)
```

## Acceptance criteria

- [x] Deterministic regression test reproduces the Sentry signature (`DurableRunEventPersistenceError "Required durable run event mirror is disabled: run_terminal"` from `assertEnabled`) using synthetic mirror fixtures only.
- [x] A `run_terminal` mirror stop refuses the model dispatch as a clean cancellation (`DOMException` named `AbortError`), not `DurableRunEventPersistenceError`.
- [x] Both discovery points covered: mirror already disabled before append (nothing appended), and mirror disabled by the post-append flush (context already appended).
- [x] Every other disable reason (`auth_rejected`, `payload_too_large`, ...) keeps failing hard with `DurableRunEventPersistenceError`; the existing "reports the concrete disable reason" test stays green.
- [x] Fail-closed contract preserved: the sink still rejects and the model call is never dispatched for a terminal run; no weakened assertions, no Sentry suppression.
- [x] Lint, typecheck, and targeted tests pass (`deno fmt`/`lint`/`check` clean on the changed files).
