### PR TITLE
ci: extract shared composite actions, drop vanity metrics

### DIFF
--- a/.github/QUALITY_GATES.md
+++ b/.github/QUALITY_GATES.md
@@ -70,10 +70,8 @@ The successful baseline pull request run
 had 12 minutes 17 seconds of active CI wall time. Its 29 non-skipped jobs used
 74.9 observed runner-minutes, and `tests (node)` used 12 minutes 2 seconds.
 
-Estimated npm-build savings: the same-build artifact flow replaces five npm
-builds with one. The estimate is four times the measured producer duration,
-or 80 percent of npm-build runner time before artifact transfer overhead. This
-is a build-reuse estimate, not an observed post-change end-to-end CI result.
-The [workflow summary calculation](workflows/cicd.yml) and
-[contract example](../tests/integration/ci/npm-compatibility-artifact-workflow.test.ts)
-record the estimate from the measured producer duration.
+npm-build reuse: the [npm-compatibility-artifact job](workflows/cicd.yml)
+builds the npm output once per commit, and every consumer job downloads the
+built artifact instead of rebuilding it. The
+[workflow contract test](../tests/integration/ci/npm-compatibility-artifact-workflow.test.ts)
+pins the single-build invariant and the download ordering in each consumer.

--- a/.github/actions/install-chromium/action.yml
+++ b/.github/actions/install-chromium/action.yml
@@ -1,0 +1,108 @@
+name: Install Chromium
+description: >
+  Configure apt for reliable browser provisioning, then run a bounded, retried
+  Playwright Chromium install. Shared by every browser job; callers keep a
+  step-level `timeout-minutes: 20` on the invoking step, matching the retry
+  loop's ~17 minute worst case (two full attempts plus lock waits and backoff).
+
+inputs:
+  install-command:
+    description: Command that performs the Playwright Chromium install
+    required: false
+    default: deno run -A npm:playwright install --with-deps chromium
+
+runs:
+  using: composite
+  steps:
+    - name: Configure apt sources, retries, and mirrors
+      shell: bash
+      run: |
+        sudo sed -i \
+          -e 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
+          -e 's|http://security.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
+          /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
+        {
+          echo 'Acquire::ForceIPv4 "true";'
+          echo 'Acquire::Retries "5";'
+          echo 'Acquire::http::Timeout "30";'
+          echo 'Acquire::https::Timeout "30";'
+        } | sudo tee /etc/apt/apt.conf.d/99veryfront-ci-retries
+
+        # `playwright install --with-deps` shells out to `apt-get update`, which
+        # consults every repository configured on the runner image and fails the
+        # whole install when any single one of them is unreachable. The image
+        # ships third-party repositories (packages.microsoft.com/repos/azure-cli,
+        # packages.microsoft.com/ubuntu/24.04/prod, dl.google.com, ...) that
+        # Chromium's system libraries never come from, so an outage there is pure
+        # noise -- and because it is a persistent 403 rather than a blip, retrying
+        # cannot clear it. Park every non-Ubuntu source for the life of this job so
+        # only the archive that actually serves the dependencies can gate us.
+        if grep -rqE '\.ubuntu\.com' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then
+          sudo mkdir -p /etc/apt/sources.list.d.disabled
+          for source_file in /etc/apt/sources.list.d/*; do
+            [ -f "${source_file}" ] || continue
+            if grep -qE '\.ubuntu\.com' "${source_file}"; then
+              continue
+            fi
+            sudo mv "${source_file}" /etc/apt/sources.list.d.disabled/
+            echo "Disabled apt source unrelated to Chromium deps: ${source_file}"
+          done
+        else
+          echo "::warning::No Ubuntu archive apt source detected; leaving apt sources untouched"
+        fi
+
+    - name: Install Chromium
+      shell: bash
+      run: |
+        readonly install_attempts=2
+        readonly install_timeout_minutes=7
+        readonly install_kill_grace_seconds=15
+        readonly apt_lock_attempts=12
+        readonly apt_lock_sleep_seconds=5
+        readonly retry_backoff_seconds=20
+        readonly apt_lock_files="/var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock /var/lib/apt/lists/lock"
+
+        # Playwright shells out to apt-get itself, so a lock held by the
+        # runner image's own apt activity used to surface inside the install
+        # as an instant "Could not get lock" failure. A global lock timeout
+        # makes every apt invocation wait for the holder instead.
+        echo 'DPkg::Lock::Timeout "300";' | sudo tee /etc/apt/apt.conf.d/99vf-lock-timeout >/dev/null
+
+        wait_for_apt_locks() {
+          for _ in $(seq 1 "${apt_lock_attempts}"); do
+            if ! sudo fuser ${apt_lock_files} >/dev/null 2>&1; then
+              return 0
+            fi
+            sleep "${apt_lock_sleep_seconds}"
+          done
+          return 1
+        }
+
+        # `timeout` signals only the wrapper process, so a timed-out attempt
+        # orphans the sudo apt-get underneath it. That orphan keeps holding
+        # the dpkg locks and starved every later attempt on this VM. Reap
+        # the lock holders and repair any half-configured packages before
+        # trying again.
+        reap_apt_lock_holders() {
+          sudo fuser -k -TERM ${apt_lock_files} >/dev/null 2>&1 || true
+          sleep 5
+          sudo fuser -k -KILL ${apt_lock_files} >/dev/null 2>&1 || true
+          sudo dpkg --configure -a >/dev/null 2>&1 || true
+        }
+
+        for attempt in $(seq 1 "${install_attempts}"); do
+          if ! wait_for_apt_locks; then
+            echo "::warning::apt/dpkg locks still held; reaping the holders"
+            reap_apt_lock_holders
+          fi
+          timeout --signal=TERM --kill-after="${install_kill_grace_seconds}s" "${install_timeout_minutes}m" \
+            ${{ inputs.install-command }} && exit 0
+          status=$?
+
+          if [ "$attempt" -eq "${install_attempts}" ]; then
+            exit "$status"
+          fi
+
+          reap_apt_lock_holders
+          sleep "${retry_backoff_seconds}"
+        done

--- a/.github/actions/prepare-build-deps/action.yml
+++ b/.github/actions/prepare-build-deps/action.yml
@@ -1,0 +1,26 @@
+name: Prepare build dependencies
+description: >
+  Run `deno task build:prepare` with retries. It caches npm packages from the
+  registry, and a truncated response ("error reading a body from connection")
+  fails the whole leg, so retry before giving up rather than reddening a build
+  on registry weather.
+
+runs:
+  using: composite
+  steps:
+    - name: Prepare build dependencies
+      shell: bash
+      run: |
+        set -uo pipefail
+        for attempt in 1 2 3; do
+          if deno task build:prepare; then
+            exit 0
+          fi
+          if [ "$attempt" -lt 3 ]; then
+            delay=$((attempt * 10))
+            echo "build:prepare failed (attempt ${attempt}/3); retrying in ${delay}s" >&2
+            sleep "$delay"
+          fi
+        done
+        echo "build:prepare failed after 3 attempts" >&2
+        exit 1

--- a/.github/actions/restore-npm-workspace/action.yml
+++ b/.github/actions/restore-npm-workspace/action.yml
@@ -1,0 +1,21 @@
+name: Restore npm runtime workspace
+description: >
+  Download the canonical npm runtime workspace produced by the
+  npm-compatibility-artifact job for this commit, unpack it over the checkout,
+  and materialize the locked test dependencies. Callers must declare
+  `needs: [npm-compatibility-artifact]`.
+
+runs:
+  using: composite
+  steps:
+    - name: Download npm runtime workspace
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        name: npm-runtime-workspace-${{ github.sha }}
+        path: dist/npm-runtime-workspace
+    - name: Restore npm runtime workspace
+      shell: bash
+      run: tar -xzf dist/npm-runtime-workspace/npm-runtime-workspace.tar.gz
+    - name: Materialize locked test dependencies
+      shell: bash
+      run: deno install --frozen

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -150,36 +150,11 @@ jobs:
         with:
           node-version: "24"
           package-manager-cache: false
-      - name: Download npm runtime workspace
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: npm-runtime-workspace-${{ github.sha }}
-          path: dist/npm-runtime-workspace
-      - name: Restore npm runtime workspace
-        run: tar -xzf dist/npm-runtime-workspace/npm-runtime-workspace.tar.gz
-      - name: Materialize locked test dependencies
-        run: deno install --frozen
-      - name: Start Node shard timer
-        id: timer
-        run: echo "started_at=$(date +%s)" >> "$GITHUB_OUTPUT"
+      - uses: ./.github/actions/restore-npm-workspace
       - name: Run Node runtime shard
         env:
           VF_TEST_SHARD: ${{ matrix.shard }}/2
         run: node ./tests/node/run-tests.mjs --suite=runtime:node
-      - name: Report Node shard duration
-        if: ${{ always() }}
-        env:
-          SHARD: ${{ matrix.shard }}/2
-          STARTED_AT: ${{ steps.timer.outputs.started_at }}
-        run: |
-          case "$STARTED_AT" in
-            ''|*[!0-9]*)
-              echo "Node shard ${SHARD} did not start" >> "$GITHUB_STEP_SUMMARY"
-              exit 0
-              ;;
-          esac
-          duration_seconds=$(($(date +%s) - STARTED_AT))
-          echo "Node shard ${SHARD}: ${duration_seconds}s" >> "$GITHUB_STEP_SUMMARY"
 
   # Sandbox worker generation and prepared-module encoding on the minimum
   # supported Node. Only Node 22/24 lack the Uint8Array proposal methods
@@ -211,15 +186,7 @@ jobs:
         with:
           node-version: ${{ steps.node-version.outputs.version }}
           package-manager-cache: false
-      - name: Download npm runtime workspace
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: npm-runtime-workspace-${{ github.sha }}
-          path: dist/npm-runtime-workspace
-      - name: Restore npm runtime workspace
-        run: tar -xzf dist/npm-runtime-workspace/npm-runtime-workspace.tar.gz
-      - name: Materialize locked test dependencies
-        run: deno install --frozen
+      - uses: ./.github/actions/restore-npm-workspace
       - name: Run sandbox worker tests
         run: node ./tests/node/run-tests.mjs --suite=runtime:node 'src/security/sandbox/'
 
@@ -244,15 +211,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.3.6"
-      - name: Download npm runtime workspace
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: npm-runtime-workspace-${{ github.sha }}
-          path: dist/npm-runtime-workspace
-      - name: Restore npm runtime workspace
-        run: tar -xzf dist/npm-runtime-workspace/npm-runtime-workspace.tar.gz
-      - name: Materialize locked test dependencies
-        run: deno install --frozen
+      - uses: ./.github/actions/restore-npm-workspace
       - name: Run Bun runtime suite
         run: node --test tests/bun/runner-args.test.mjs tests/bun/workspace-packages.test.mjs && node ./tests/bun/run-tests.mjs --suite=runtime:bun
 
@@ -261,10 +220,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     name: npm compatibility artifact
-    outputs:
-      build_duration_seconds: ${{ steps.build.outputs.build_duration_seconds }}
-      runtime_workspace_archive_bytes: ${{ steps.runtime-workspace.outputs.archive_bytes }}
-      runtime_workspace_archive_duration_seconds: ${{ steps.runtime-workspace.outputs.archive_duration_seconds }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -278,9 +233,7 @@ jobs:
           node-version: "24"
           package-manager-cache: false
       - name: Build and pack tested npm output
-        id: build
         run: |
-          started_at=$(date +%s)
           BASE_VERSION=$(jq -r '.version' deno.json)
           if [ "${GITHUB_REF}" = "refs/heads/main" ] && [[ ! "${BASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             export VERSION="${BASE_VERSION}.${GITHUB_RUN_NUMBER}"
@@ -289,14 +242,8 @@ jobs:
           deno task build:npm
           deno run --config=scripts/test.deno.json --frozen --allow-read --allow-write --allow-run=npm,tar \
             scripts/ci/npm-compatibility-artifact.ts pack npm dist/npm-compatibility "${GITHUB_SHA}"
-          echo "build_duration_seconds=$(($(date +%s) - started_at))" >> "$GITHUB_OUTPUT"
       - name: Archive npm runtime workspace
-        id: runtime-workspace
-        run: |
-          started_at=$(date +%s)
-          tar -cf - npm | gzip -1 > dist/npm-runtime-workspace.tar.gz
-          echo "archive_bytes=$(wc -c < dist/npm-runtime-workspace.tar.gz | tr -d ' ')" >> "$GITHUB_OUTPUT"
-          echo "archive_duration_seconds=$(($(date +%s) - started_at))" >> "$GITHUB_OUTPUT"
+        run: tar -cf - npm | gzip -1 > dist/npm-runtime-workspace.tar.gz
       - name: Upload tested npm compatibility artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -565,96 +512,9 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-deno
         timeout-minutes: 5
-      - name: Configure apt sources, retries, and mirrors
-        run: |
-          sudo sed -i \
-            -e 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
-            -e 's|http://security.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
-            /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
-          {
-            echo 'Acquire::ForceIPv4 "true";'
-            echo 'Acquire::Retries "5";'
-            echo 'Acquire::http::Timeout "30";'
-            echo 'Acquire::https::Timeout "30";'
-          } | sudo tee /etc/apt/apt.conf.d/99veryfront-ci-retries
-
-          # `playwright install --with-deps` shells out to `apt-get update`, which
-          # consults every repository configured on the runner image and fails the
-          # whole install when any single one of them is unreachable. The image
-          # ships third-party repositories (packages.microsoft.com/repos/azure-cli,
-          # packages.microsoft.com/ubuntu/24.04/prod, dl.google.com, ...) that
-          # Chromium's system libraries never come from, so an outage there is pure
-          # noise -- and because it is a persistent 403 rather than a blip, retrying
-          # cannot clear it. Park every non-Ubuntu source for the life of this job so
-          # only the archive that actually serves the dependencies can gate us.
-          if grep -rqE '\.ubuntu\.com' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then
-            sudo mkdir -p /etc/apt/sources.list.d.disabled
-            for source_file in /etc/apt/sources.list.d/*; do
-              [ -f "${source_file}" ] || continue
-              if grep -qE '\.ubuntu\.com' "${source_file}"; then
-                continue
-              fi
-              sudo mv "${source_file}" /etc/apt/sources.list.d.disabled/
-              echo "Disabled apt source unrelated to Chromium deps: ${source_file}"
-            done
-          else
-            echo "::warning::No Ubuntu archive apt source detected; leaving apt sources untouched"
-          fi
       - name: Install Chromium
         timeout-minutes: 20
-        run: |
-          readonly install_attempts=2
-          readonly install_timeout_minutes=7
-          readonly install_kill_grace_seconds=15
-          readonly apt_lock_attempts=12
-          readonly apt_lock_sleep_seconds=5
-          readonly retry_backoff_seconds=20
-          readonly apt_lock_files="/var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock /var/lib/apt/lists/lock"
-
-          # Playwright shells out to apt-get itself, so a lock held by the
-          # runner image's own apt activity used to surface inside the install
-          # as an instant "Could not get lock" failure. A global lock timeout
-          # makes every apt invocation wait for the holder instead.
-          echo 'DPkg::Lock::Timeout "300";' | sudo tee /etc/apt/apt.conf.d/99vf-lock-timeout >/dev/null
-
-          wait_for_apt_locks() {
-            for _ in $(seq 1 "${apt_lock_attempts}"); do
-              if ! sudo fuser ${apt_lock_files} >/dev/null 2>&1; then
-                return 0
-              fi
-              sleep "${apt_lock_sleep_seconds}"
-            done
-            return 1
-          }
-
-          # `timeout` signals only the wrapper process, so a timed-out attempt
-          # orphans the sudo apt-get underneath it. That orphan keeps holding
-          # the dpkg locks and starved every later attempt on this VM. Reap
-          # the lock holders and repair any half-configured packages before
-          # trying again.
-          reap_apt_lock_holders() {
-            sudo fuser -k -TERM ${apt_lock_files} >/dev/null 2>&1 || true
-            sleep 5
-            sudo fuser -k -KILL ${apt_lock_files} >/dev/null 2>&1 || true
-            sudo dpkg --configure -a >/dev/null 2>&1 || true
-          }
-
-          for attempt in $(seq 1 "${install_attempts}"); do
-            if ! wait_for_apt_locks; then
-              echo "::warning::apt/dpkg locks still held; reaping the holders"
-              reap_apt_lock_holders
-            fi
-            timeout --signal=TERM --kill-after="${install_kill_grace_seconds}s" "${install_timeout_minutes}m" \
-              deno run -A npm:playwright install --with-deps chromium && exit 0
-            status=$?
-
-            if [ "$attempt" -eq "${install_attempts}" ]; then
-              exit "$status"
-            fi
-
-            reap_apt_lock_holders
-            sleep "${retry_backoff_seconds}"
-          done
+        uses: ./.github/actions/install-chromium
       - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 10
@@ -677,96 +537,9 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-deno
         timeout-minutes: 5
-      - name: Configure apt sources, retries, and mirrors
-        run: |
-          sudo sed -i \
-            -e 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
-            -e 's|http://security.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
-            /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
-          {
-            echo 'Acquire::ForceIPv4 "true";'
-            echo 'Acquire::Retries "5";'
-            echo 'Acquire::http::Timeout "30";'
-            echo 'Acquire::https::Timeout "30";'
-          } | sudo tee /etc/apt/apt.conf.d/99veryfront-ci-retries
-
-          # `playwright install --with-deps` shells out to `apt-get update`, which
-          # consults every repository configured on the runner image and fails the
-          # whole install when any single one of them is unreachable. The image
-          # ships third-party repositories (packages.microsoft.com/repos/azure-cli,
-          # packages.microsoft.com/ubuntu/24.04/prod, dl.google.com, ...) that
-          # Chromium's system libraries never come from, so an outage there is pure
-          # noise -- and because it is a persistent 403 rather than a blip, retrying
-          # cannot clear it. Park every non-Ubuntu source for the life of this job so
-          # only the archive that actually serves the dependencies can gate us.
-          if grep -rqE '\.ubuntu\.com' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then
-            sudo mkdir -p /etc/apt/sources.list.d.disabled
-            for source_file in /etc/apt/sources.list.d/*; do
-              [ -f "${source_file}" ] || continue
-              if grep -qE '\.ubuntu\.com' "${source_file}"; then
-                continue
-              fi
-              sudo mv "${source_file}" /etc/apt/sources.list.d.disabled/
-              echo "Disabled apt source unrelated to Chromium deps: ${source_file}"
-            done
-          else
-            echo "::warning::No Ubuntu archive apt source detected; leaving apt sources untouched"
-          fi
       - name: Install Chromium
         timeout-minutes: 20
-        run: |
-          readonly install_attempts=2
-          readonly install_timeout_minutes=7
-          readonly install_kill_grace_seconds=15
-          readonly apt_lock_attempts=12
-          readonly apt_lock_sleep_seconds=5
-          readonly retry_backoff_seconds=20
-          readonly apt_lock_files="/var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock /var/lib/apt/lists/lock"
-
-          # Playwright shells out to apt-get itself, so a lock held by the
-          # runner image's own apt activity used to surface inside the install
-          # as an instant "Could not get lock" failure. A global lock timeout
-          # makes every apt invocation wait for the holder instead.
-          echo 'DPkg::Lock::Timeout "300";' | sudo tee /etc/apt/apt.conf.d/99vf-lock-timeout >/dev/null
-
-          wait_for_apt_locks() {
-            for _ in $(seq 1 "${apt_lock_attempts}"); do
-              if ! sudo fuser ${apt_lock_files} >/dev/null 2>&1; then
-                return 0
-              fi
-              sleep "${apt_lock_sleep_seconds}"
-            done
-            return 1
-          }
-
-          # `timeout` signals only the wrapper process, so a timed-out attempt
-          # orphans the sudo apt-get underneath it. That orphan keeps holding
-          # the dpkg locks and starved every later attempt on this VM. Reap
-          # the lock holders and repair any half-configured packages before
-          # trying again.
-          reap_apt_lock_holders() {
-            sudo fuser -k -TERM ${apt_lock_files} >/dev/null 2>&1 || true
-            sleep 5
-            sudo fuser -k -KILL ${apt_lock_files} >/dev/null 2>&1 || true
-            sudo dpkg --configure -a >/dev/null 2>&1 || true
-          }
-
-          for attempt in $(seq 1 "${install_attempts}"); do
-            if ! wait_for_apt_locks; then
-              echo "::warning::apt/dpkg locks still held; reaping the holders"
-              reap_apt_lock_holders
-            fi
-            timeout --signal=TERM --kill-after="${install_kill_grace_seconds}s" "${install_timeout_minutes}m" \
-              deno run -A npm:playwright install --with-deps chromium && exit 0
-            status=$?
-
-            if [ "$attempt" -eq "${install_attempts}" ]; then
-              exit "$status"
-            fi
-
-            reap_apt_lock_holders
-            sleep "${retry_backoff_seconds}"
-          done
+        uses: ./.github/actions/install-chromium
       - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
           timeout_minutes: 30
@@ -933,51 +706,6 @@ jobs:
             fi
           done
           exit "$failed"
-      - name: Report npm build reuse
-        if: ${{ success() }}
-        env:
-          BUILD_DURATION_SECONDS: ${{ needs.npm-compatibility-artifact.outputs.build_duration_seconds }}
-          RUNTIME_WORKSPACE_ARCHIVE_BYTES: ${{ needs.npm-compatibility-artifact.outputs.runtime_workspace_archive_bytes }}
-          RUNTIME_WORKSPACE_ARCHIVE_DURATION_SECONDS: ${{ needs.npm-compatibility-artifact.outputs.runtime_workspace_archive_duration_seconds }}
-          LEGACY_BUILD_COUNT: "7"
-          PREVIOUS_BUILD_COUNT: "3"
-          CANONICAL_BUILD_COUNT: "1"
-        run: |
-          case "$BUILD_DURATION_SECONDS" in
-            ''|*[!0-9]*)
-              echo "::error::Missing numeric canonical npm build duration"
-              exit 1
-              ;;
-          esac
-          for metric_name in RUNTIME_WORKSPACE_ARCHIVE_BYTES RUNTIME_WORKSPACE_ARCHIVE_DURATION_SECONDS; do
-            case "${!metric_name}" in
-              ''|*[!0-9]*)
-                echo "::error::Missing numeric ${metric_name}"
-                exit 1
-                ;;
-            esac
-          done
-          before=$(awk -v seconds="$BUILD_DURATION_SECONDS" -v count="$LEGACY_BUILD_COUNT" \
-            'BEGIN { printf "%.2f", seconds * count / 60 }')
-          previous=$(awk -v seconds="$BUILD_DURATION_SECONDS" -v count="$PREVIOUS_BUILD_COUNT" \
-            'BEGIN { printf "%.2f", seconds * count / 60 }')
-          after=$(awk -v seconds="$BUILD_DURATION_SECONDS" -v count="$CANONICAL_BUILD_COUNT" \
-            'BEGIN { printf "%.2f", seconds * count / 60 }')
-          incremental_saved=$(awk -v previous="$previous" -v after="$after" \
-            'BEGIN { printf "%.2f", previous - after }')
-          runtime_workspace_mib=$(awk -v bytes="$RUNTIME_WORKSPACE_ARCHIVE_BYTES" \
-            'BEGIN { printf "%.2f", bytes / 1024 / 1024 }')
-          {
-            echo "### Canonical npm build reuse"
-            echo
-            echo "Measured producer duration: ${BUILD_DURATION_SECONDS}s"
-            echo "Estimate basis: seven legacy npm build sites (three runtime critical-flow jobs, two npm install-smoke jobs, Node tests, and Bun tests)"
-            echo "Legacy independent builds: ${before} npm build runner-minutes"
-            echo "Previous partial reuse: ${previous} npm build runner-minutes"
-            echo "Canonical build: ${after} npm build runner-minutes"
-            echo "Incremental savings: ${incremental_saved} npm build runner-minutes"
-            echo "Measured runtime workspace archive: ${runtime_workspace_mib} MiB in ${RUNTIME_WORKSPACE_ARCHIVE_DURATION_SECONDS}s"
-          } >> "$GITHUB_STEP_SUMMARY"
 
   tests-sentry-runtime-packages:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
@@ -1117,25 +845,7 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-deno
         timeout-minutes: 5
-      # Caches npm packages from the registry. A truncated response
-      # ("error reading a body from connection") fails the whole leg, so retry
-      # before giving up rather than reddening a build on registry weather.
-      - name: Prepare build dependencies
-        shell: bash
-        run: |
-          set -uo pipefail
-          for attempt in 1 2 3; do
-            if deno task build:prepare; then
-              exit 0
-            fi
-            if [ "$attempt" -lt 3 ]; then
-              delay=$((attempt * 10))
-              echo "build:prepare failed (attempt ${attempt}/3); retrying in ${delay}s" >&2
-              sleep "$delay"
-            fi
-          done
-          echo "build:prepare failed after 3 attempts" >&2
-          exit 1
+      - uses: ./.github/actions/prepare-build-deps
       - name: Verify proxy dependency lock is current
         run: |
           deno task build:proxy-lock
@@ -1212,25 +922,7 @@ jobs:
           VERSION: ${{ needs.version-check.outputs.version }}.${{ github.run_number }}
         run: deno run -A scripts/ci/prepare-rc-build.ts
 
-      # Caches npm packages from the registry. A truncated response
-      # ("error reading a body from connection") fails the whole leg, so retry
-      # before giving up rather than reddening a build on registry weather.
-      - name: Prepare build dependencies
-        shell: bash
-        run: |
-          set -uo pipefail
-          for attempt in 1 2 3; do
-            if deno task build:prepare; then
-              exit 0
-            fi
-            if [ "$attempt" -lt 3 ]; then
-              delay=$((attempt * 10))
-              echo "build:prepare failed (attempt ${attempt}/3); retrying in ${delay}s" >&2
-              sleep "$delay"
-            fi
-          done
-          echo "build:prepare failed after 3 attempts" >&2
-          exit 1
+      - uses: ./.github/actions/prepare-build-deps
 
       - name: Verify proxy dependency lock is current
         if: matrix.profile == 'proxy'

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -13,6 +13,7 @@ on:
       - "deno.lock"
       - ".github/workflows/e2e-playwright.yml"
       - ".github/actions/setup-deno/**"
+      - ".github/actions/install-chromium/**"
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -45,81 +45,11 @@ jobs:
       # inside `playwright install --with-deps`, then run the bounded, retried
       # installer. A report-only history poisoned by provisioning failures is
       # worthless.
-      - name: Configure apt sources, retries, and mirrors
-        run: |
-          sudo sed -i \
-            -e 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
-            -e 's|http://security.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
-            /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
-          {
-            echo 'Acquire::ForceIPv4 "true";'
-            echo 'Acquire::Retries "5";'
-            echo 'Acquire::http::Timeout "30";'
-            echo 'Acquire::https::Timeout "30";'
-          } | sudo tee /etc/apt/apt.conf.d/99veryfront-ci-retries
-
-          if grep -rqE '\.ubuntu\.com' /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then
-            sudo mkdir -p /etc/apt/sources.list.d.disabled
-            for source_file in /etc/apt/sources.list.d/*; do
-              [ -f "${source_file}" ] || continue
-              if grep -qE '\.ubuntu\.com' "${source_file}"; then
-                continue
-              fi
-              sudo mv "${source_file}" /etc/apt/sources.list.d.disabled/
-              echo "Disabled apt source unrelated to Chromium deps: ${source_file}"
-            done
-          else
-            echo "::warning::No Ubuntu archive apt source detected; leaving apt sources untouched"
-          fi
-      # Worst case of the retry loop is ~17 minutes (two full attempts plus
-      # lock waits and backoff), matching the 20-minute step deadline the
-      # cicd.yml browser jobs use.
       - name: Install Playwright Chromium
         timeout-minutes: 20
-        run: |
-          readonly install_attempts=2
-          readonly install_timeout_minutes=7
-          readonly install_kill_grace_seconds=15
-          readonly apt_lock_attempts=12
-          readonly apt_lock_sleep_seconds=5
-          readonly retry_backoff_seconds=20
-          readonly apt_lock_files="/var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock /var/lib/apt/lists/lock"
-
-          echo 'DPkg::Lock::Timeout "300";' | sudo tee /etc/apt/apt.conf.d/99vf-lock-timeout >/dev/null
-
-          wait_for_apt_locks() {
-            for _ in $(seq 1 "${apt_lock_attempts}"); do
-              if ! sudo fuser ${apt_lock_files} >/dev/null 2>&1; then
-                return 0
-              fi
-              sleep "${apt_lock_sleep_seconds}"
-            done
-            return 1
-          }
-
-          reap_apt_lock_holders() {
-            sudo fuser -k -TERM ${apt_lock_files} >/dev/null 2>&1 || true
-            sleep 5
-            sudo fuser -k -KILL ${apt_lock_files} >/dev/null 2>&1 || true
-            sudo dpkg --configure -a >/dev/null 2>&1 || true
-          }
-
-          for attempt in $(seq 1 "${install_attempts}"); do
-            if ! wait_for_apt_locks; then
-              echo "::warning::apt/dpkg locks still held; reaping the holders"
-              reap_apt_lock_holders
-            fi
-            timeout --signal=TERM --kill-after="${install_kill_grace_seconds}s" "${install_timeout_minutes}m" \
-              deno task test:e2e:playwright:install && exit 0
-            status=$?
-
-            if [ "$attempt" -eq "${install_attempts}" ]; then
-              exit "$status"
-            fi
-
-            reap_apt_lock_holders
-            sleep "${retry_backoff_seconds}"
-          done
+        uses: ./.github/actions/install-chromium
+        with:
+          install-command: deno task test:e2e:playwright:install
       - name: Run Playwright e2e suite
         run: deno task test:e2e:playwright
       - name: Upload traces and screenshots

--- a/deno.lock
+++ b/deno.lock
@@ -17,6 +17,7 @@
     "jsr:@std/path@1.1.4": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/testing@1.0.17": "1.0.17",
+    "jsr:@std/yaml@*": "1.1.0",
     "jsr:@std/yaml@1.1.0": "1.1.0",
     "npm:@aws-sdk/client-s3@3.980.0": "3.980.0",
     "npm:@aws-sdk/lib-storage@3.980.0": "3.980.0_@aws-sdk+client-s3@3.980.0",

--- a/scripts/build/compile-binary.test.ts
+++ b/scripts/build/compile-binary.test.ts
@@ -400,7 +400,7 @@ it("release binaries carry the numbered RC version", async () => {
   );
   assertEquals(
     buildBinariesJob.indexOf("Prepare RC build version") <
-      buildBinariesJob.indexOf("Prepare build dependencies"),
+      buildBinariesJob.indexOf("./.github/actions/prepare-build-deps"),
     true,
     "the RC version must be injected before generators bundle it",
   );

--- a/scripts/ci/setup-deno-workflow.test.ts
+++ b/scripts/ci/setup-deno-workflow.test.ts
@@ -909,54 +909,70 @@ jobs:
     assert(coverageSetup, "coverage shards must use setup-deno");
     assertEquals(coverageSetup["timeout-minutes"], MAX_SETUP_MINUTES);
 
+    const chromiumAction = await parseYamlFile(
+      ".github/actions/install-chromium/action.yml",
+    );
+    const chromiumRuns = asRecord(
+      chromiumAction.runs,
+      "install-chromium runs",
+    );
+    const chromiumInstall = asSteps(
+      chromiumRuns.steps,
+      "install-chromium steps",
+    ).find((step) => step.name === "Install Chromium");
+    assert(chromiumInstall, "the shared action must install Chromium");
+    const install = String(chromiumInstall.run);
+    for (
+      const expected of [
+        'for attempt in $(seq 1 "${install_attempts}")',
+        '--kill-after="${install_kill_grace_seconds}s" "${install_timeout_minutes}m"',
+        'for _ in $(seq 1 "${apt_lock_attempts}")',
+        'sleep "${apt_lock_sleep_seconds}"',
+        'sleep "${retry_backoff_seconds}"',
+      ]
+    ) {
+      assertStringIncludes(install, expected);
+    }
+    assertEquals(install.includes("apt-get clean"), false);
+    assertEquals(install.includes("rm -rf /var/lib/apt/lists"), false);
+
+    const attempts = shellInteger(install, "install_attempts");
+    const installSeconds = shellInteger(
+      install,
+      "install_timeout_minutes",
+    ) * 60;
+    const installKillGrace = shellInteger(
+      install,
+      "install_kill_grace_seconds",
+    );
+    const aptLockSeconds = shellInteger(install, "apt_lock_attempts") *
+      shellInteger(install, "apt_lock_sleep_seconds");
+    const backoffSeconds = shellInteger(install, "retry_backoff_seconds");
+    const worstCaseSeconds = attempts *
+        (aptLockSeconds + installSeconds + installKillGrace) +
+      (attempts - 1) * backoffSeconds;
+    assert(
+      worstCaseSeconds <=
+        CHROMIUM_STEP_MINUTES * 60 - CHROMIUM_OVERHEAD_MARGIN_SECONDS,
+      `Chromium retries need at least ${CHROMIUM_OVERHEAD_MARGIN_SECONDS}s of outer-step overhead margin; budget is ${worstCaseSeconds}s`,
+    );
+
     for (const jobName of ["tests-e2e-rsc-browser", "tests-binary-e2e"]) {
       const job = asRecord(
         asRecord(ci.jobs, "cicd jobs")[jobName],
         jobName,
       );
-      const chromiumInstall = asSteps(job.steps, `${jobName} steps`).find(
-        (step) => step.name === "Install Chromium",
+      const chromiumStep = asSteps(job.steps, `${jobName} steps`).find(
+        (step) => step.uses === "./.github/actions/install-chromium",
       );
-      assert(chromiumInstall, `${jobName} must install Chromium`);
+      assert(
+        chromiumStep,
+        `${jobName} must install Chromium via the shared action`,
+      );
       assertEquals(
-        chromiumInstall["timeout-minutes"],
+        chromiumStep["timeout-minutes"],
         CHROMIUM_STEP_MINUTES,
         `${jobName} Chromium provisioning needs a total step deadline`,
-      );
-      const install = String(chromiumInstall.run);
-      for (
-        const expected of [
-          'for attempt in $(seq 1 "${install_attempts}")',
-          '--kill-after="${install_kill_grace_seconds}s" "${install_timeout_minutes}m"',
-          'for _ in $(seq 1 "${apt_lock_attempts}")',
-          'sleep "${apt_lock_sleep_seconds}"',
-          'sleep "${retry_backoff_seconds}"',
-        ]
-      ) {
-        assertStringIncludes(install, expected);
-      }
-      assertEquals(install.includes("apt-get clean"), false);
-      assertEquals(install.includes("rm -rf /var/lib/apt/lists"), false);
-
-      const attempts = shellInteger(install, "install_attempts");
-      const installSeconds = shellInteger(
-        install,
-        "install_timeout_minutes",
-      ) * 60;
-      const installKillGrace = shellInteger(
-        install,
-        "install_kill_grace_seconds",
-      );
-      const aptLockSeconds = shellInteger(install, "apt_lock_attempts") *
-        shellInteger(install, "apt_lock_sleep_seconds");
-      const backoffSeconds = shellInteger(install, "retry_backoff_seconds");
-      const worstCaseSeconds = attempts *
-          (aptLockSeconds + installSeconds + installKillGrace) +
-        (attempts - 1) * backoffSeconds;
-      assert(
-        worstCaseSeconds <=
-          CHROMIUM_STEP_MINUTES * 60 - CHROMIUM_OVERHEAD_MARGIN_SECONDS,
-        `${jobName} Chromium retries need at least ${CHROMIUM_OVERHEAD_MARGIN_SECONDS}s of outer-step overhead margin; budget is ${worstCaseSeconds}s`,
       );
     }
   });

--- a/tests/integration/ci/npm-compatibility-artifact-workflow.test.ts
+++ b/tests/integration/ci/npm-compatibility-artifact-workflow.test.ts
@@ -1,12 +1,18 @@
 import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { parse } from "#std/yaml/parse";
-import { NPM_SMOKE_NODE_VERSIONS } from "../../../scripts/build/runtime-support.ts";
 
 type YamlRecord = Record<string, unknown>;
 
 const WORKFLOW_PATH = new URL(
   "../../../.github/workflows/cicd.yml",
+  import.meta.url,
+);
+
+const RESTORE_ACTION = "./.github/actions/restore-npm-workspace";
+
+const RESTORE_ACTION_PATH = new URL(
+  "../../../.github/actions/restore-npm-workspace/action.yml",
   import.meta.url,
 );
 
@@ -105,18 +111,9 @@ describe("canonical npm artifact workflow", () => {
       "The tested npm artifact must remain available through production approval",
     );
     const archive = namedStep(producer, "Archive npm runtime workspace");
-    assertEquals(archive.id, "runtime-workspace");
     assertStringIncludes(
       String(archive.run),
       "tar -cf - npm | gzip -1 > dist/npm-runtime-workspace.tar.gz",
-    );
-    assertStringIncludes(
-      String(archive.run),
-      'echo "archive_bytes=$(wc -c < dist/npm-runtime-workspace.tar.gz | tr -d \' \')" >> "$GITHUB_OUTPUT"',
-    );
-    assertStringIncludes(
-      String(archive.run),
-      'echo "archive_duration_seconds=$(($(date +%s) - started_at))" >> "$GITHUB_OUTPUT"',
     );
     const runtimeUpload = steps.find((step) =>
       String(step.uses).startsWith("actions/upload-artifact@") &&
@@ -139,20 +136,6 @@ describe("canonical npm artifact workflow", () => {
           steps.indexOf(archive) &&
         steps.indexOf(archive) < steps.indexOf(runtimeUpload),
       "The producer must archive and upload the already-built runtime workspace",
-    );
-    assertEquals(
-      asRecord(producer.outputs, "producer outputs").build_duration_seconds,
-      "${{ steps.build.outputs.build_duration_seconds }}",
-    );
-    assertEquals(
-      asRecord(producer.outputs, "producer outputs")
-        .runtime_workspace_archive_bytes,
-      "${{ steps.runtime-workspace.outputs.archive_bytes }}",
-    );
-    assertEquals(
-      asRecord(producer.outputs, "producer outputs")
-        .runtime_workspace_archive_duration_seconds,
-      "${{ steps.runtime-workspace.outputs.archive_duration_seconds }}",
     );
     const buildStep = namedStep(producer, "Build and pack tested npm output");
     const buildScript = String(buildStep.run);
@@ -243,6 +226,46 @@ describe("canonical npm artifact workflow", () => {
   it("feeds the built runtime workspace to Node and Bun without rebuilding it", async () => {
     const jobs = await readJobs();
 
+    // The download/extract/install sequence lives in the shared composite
+    // action, so its contract is asserted once against the action itself.
+    const action = asRecord(
+      parse(await Deno.readTextFile(RESTORE_ACTION_PATH)),
+      "restore-npm-workspace action",
+    );
+    const actionSteps = jobSteps(
+      asRecord(action.runs, "restore-npm-workspace runs"),
+      "restore-npm-workspace",
+    );
+    const download = actionSteps.find((step) =>
+      String(step.uses).startsWith("actions/download-artifact@")
+    );
+    assert(download, "the action must download the built runtime workspace");
+    assertEquals(
+      asRecord(download.with, "action artifact download").name,
+      "npm-runtime-workspace-${{ github.sha }}",
+    );
+    assertEquals(
+      asRecord(download.with, "action artifact download").path,
+      "dist/npm-runtime-workspace",
+    );
+    const restore = actionSteps.find((step) =>
+      step.name === "Restore npm runtime workspace"
+    );
+    const install = actionSteps.find((step) =>
+      step.name === "Materialize locked test dependencies"
+    );
+    assert(restore && install, "the action must restore and install");
+    assertStringIncludes(
+      String(restore.run),
+      "tar -xzf dist/npm-runtime-workspace/npm-runtime-workspace.tar.gz",
+    );
+    assertEquals(install.run, "deno install --frozen");
+    assert(
+      actionSteps.indexOf(download) < actionSteps.indexOf(restore) &&
+        actionSteps.indexOf(restore) < actionSteps.indexOf(install),
+      "the action must download, restore, then materialize dependencies",
+    );
+
     for (
       const [jobName, stepName, directCommand] of [
         [
@@ -259,32 +282,16 @@ describe("canonical npm artifact workflow", () => {
     ) {
       const job = asRecord(jobs[jobName], `${jobName} job`);
       assertEquals(job.needs, ["npm-compatibility-artifact"]);
-      const download = jobSteps(job, `${jobName} job`).find((step) =>
-        String(step.uses).startsWith("actions/download-artifact@")
-      );
-      assert(download, `${jobName} must download the built runtime workspace`);
-      assertEquals(
-        asRecord(download.with, `${jobName} artifact download`).name,
-        "npm-runtime-workspace-${{ github.sha }}",
-      );
-      assertEquals(
-        asRecord(download.with, `${jobName} artifact download`).path,
-        "dist/npm-runtime-workspace",
-      );
       const steps = jobSteps(job, `${jobName} job`);
-      const restore = namedStep(job, "Restore npm runtime workspace");
-      const install = namedStep(job, "Materialize locked test dependencies");
-      const run = namedStep(job, stepName);
-      assertStringIncludes(
-        String(restore.run),
-        "tar -xzf dist/npm-runtime-workspace/npm-runtime-workspace.tar.gz",
-      );
-      assertEquals(install.run, "deno install --frozen");
+      const restoreUse = steps.find((step) => step.uses === RESTORE_ACTION);
       assert(
-        steps.indexOf(download) < steps.indexOf(restore) &&
-          steps.indexOf(restore) < steps.indexOf(install) &&
-          steps.indexOf(install) < steps.indexOf(run),
-        `${jobName} must restore the runtime workspace and materialize cached dependencies before tests`,
+        restoreUse,
+        `${jobName} must restore the runtime workspace via the shared action`,
+      );
+      const run = namedStep(job, stepName);
+      assert(
+        steps.indexOf(restoreUse) < steps.indexOf(run),
+        `${jobName} must restore the runtime workspace before tests`,
       );
       assertEquals(run.run, directCommand);
       assertEquals(
@@ -310,9 +317,11 @@ describe("canonical npm artifact workflow", () => {
     assertEquals(node.name, "tests (node shard ${{ matrix.shard }}/2)");
     assertEquals(strategy["fail-fast"], false);
     assertEquals(matrix.shard, [1, 2]);
-    assertStringIncludes(
-      String(namedStep(node, "Restore npm runtime workspace").run),
-      "tar -xzf dist/npm-runtime-workspace/npm-runtime-workspace.tar.gz",
+    assert(
+      jobSteps(node, "Node sharding job").some((step) =>
+        step.uses === RESTORE_ACTION
+      ),
+      "Node shards must restore the runtime workspace via the shared action",
     );
     const run = namedStep(node, "Run Node runtime shard");
     assertEquals(
@@ -323,9 +332,6 @@ describe("canonical npm artifact workflow", () => {
       run.run,
       "node ./tests/node/run-tests.mjs --suite=runtime:node",
     );
-    const report = namedStep(node, "Report Node shard duration");
-    assertEquals(report.if, "${{ always() }}");
-    assertStringIncludes(String(report.run), "Node shard ${SHARD}: ${duration_seconds}s");
   });
 
   it("publishes the tested artifact for both prerelease and stable releases", async () => {
@@ -416,87 +422,4 @@ describe("canonical npm artifact workflow", () => {
     }
   });
 
-  it("reports the measured seven-to-one build reuse and incremental savings", async () => {
-    const jobs = await readJobs();
-    const runtime = asRecord(
-      jobs["tests-runtime-critical-flow"],
-      "runtime critical flow",
-    );
-    const runtimeStrategy = asRecord(runtime.strategy, "runtime critical flow strategy");
-    const runtimeMatrix = asRecord(runtimeStrategy.matrix, "runtime critical flow matrix");
-    const runtimes = runtimeMatrix.runtime;
-    assert(Array.isArray(runtimes), "runtime critical flow matrix runtimes must be an array");
-    assertEquals(runtimes.length, 3, "The runtime critical flow must have three consumers");
-    assertEquals(
-      NPM_SMOKE_NODE_VERSIONS.length,
-      2,
-      "The npm install smoke must have two Node consumers",
-    );
-    const legacyBuildSiteCount = runtimes.length + NPM_SMOKE_NODE_VERSIONS.length + 2;
-    assertEquals(legacyBuildSiteCount, 7);
-    const gate = asRecord(jobs["quality-gate-artifact"], "artifact gate");
-    const step = namedStep(gate, "Report npm build reuse");
-    assertEquals(
-      step.if,
-      "${{ success() }}",
-      "The build reuse report must not run after the aggregate dependency check fails",
-    );
-    assertEquals(
-      asRecord(step.env, "npm build reuse environment"),
-      {
-        BUILD_DURATION_SECONDS:
-          "${{ needs.npm-compatibility-artifact.outputs.build_duration_seconds }}",
-        RUNTIME_WORKSPACE_ARCHIVE_BYTES:
-          "${{ needs.npm-compatibility-artifact.outputs.runtime_workspace_archive_bytes }}",
-        RUNTIME_WORKSPACE_ARCHIVE_DURATION_SECONDS:
-          "${{ needs.npm-compatibility-artifact.outputs.runtime_workspace_archive_duration_seconds }}",
-        LEGACY_BUILD_COUNT: String(legacyBuildSiteCount),
-        PREVIOUS_BUILD_COUNT: "3",
-        CANONICAL_BUILD_COUNT: "1",
-      },
-    );
-    const summary = await Deno.makeTempFile({ prefix: "vf-ci-cost-" });
-    try {
-      const result = await new Deno.Command("bash", {
-        args: ["-c", String(step.run)],
-        env: {
-          GITHUB_STEP_SUMMARY: summary,
-          BUILD_DURATION_SECONDS: "120",
-          RUNTIME_WORKSPACE_ARCHIVE_BYTES: "26214400",
-          RUNTIME_WORKSPACE_ARCHIVE_DURATION_SECONDS: "1",
-          LEGACY_BUILD_COUNT: String(legacyBuildSiteCount),
-          PREVIOUS_BUILD_COUNT: "3",
-          CANONICAL_BUILD_COUNT: "1",
-        },
-      }).output();
-      assertEquals(result.code, 0);
-      const report = await Deno.readTextFile(summary);
-      assertStringIncludes(
-        report,
-        "Estimate basis: seven legacy npm build sites (three runtime critical-flow jobs, two npm install-smoke jobs, Node tests, and Bun tests)",
-      );
-      assertStringIncludes(
-        report,
-        "Legacy independent builds: 14.00 npm build runner-minutes",
-      );
-      assertStringIncludes(
-        report,
-        "Previous partial reuse: 6.00 npm build runner-minutes",
-      );
-      assertStringIncludes(
-        report,
-        "Canonical build: 2.00 npm build runner-minutes",
-      );
-      assertStringIncludes(
-        report,
-        "Incremental savings: 4.00 npm build runner-minutes",
-      );
-      assertStringIncludes(
-        report,
-        "Measured runtime workspace archive: 25.00 MiB in 1s",
-      );
-    } finally {
-      await Deno.remove(summary);
-    }
-  });
 });

--- a/tests/integration/ci/npm-compatibility-artifact-workflow.test.ts
+++ b/tests/integration/ci/npm-compatibility-artifact-workflow.test.ts
@@ -248,9 +248,7 @@ describe("canonical npm artifact workflow", () => {
       asRecord(download.with, "action artifact download").path,
       "dist/npm-runtime-workspace",
     );
-    const restore = actionSteps.find((step) =>
-      step.name === "Restore npm runtime workspace"
-    );
+    const restore = actionSteps.find((step) => step.name === "Restore npm runtime workspace");
     const install = actionSteps.find((step) =>
       step.name === "Materialize locked test dependencies"
     );
@@ -318,9 +316,7 @@ describe("canonical npm artifact workflow", () => {
     assertEquals(strategy["fail-fast"], false);
     assertEquals(matrix.shard, [1, 2]);
     assert(
-      jobSteps(node, "Node sharding job").some((step) =>
-        step.uses === RESTORE_ACTION
-      ),
+      jobSteps(node, "Node sharding job").some((step) => step.uses === RESTORE_ACTION),
       "Node shards must restore the runtime workspace via the shared action",
     );
     const run = namedStep(node, "Run Node runtime shard");
@@ -421,5 +417,4 @@ describe("canonical npm artifact workflow", () => {
       }
     }
   });
-
 });


### PR DESCRIPTION
## Why

The workflow YAML has grown to 3,730 lines with whole step sequences copy-pasted between jobs — three identical ~90-line Chromium install blocks, three identical npm-workspace restore sequences, two identical build-prepare retry loops, plus metric plumbing whose only consumer computed savings against a build layout that no longer exists.

## What

**Extracted composite actions** (incident-context comments preserved inside them):
- `.github/actions/install-chromium` — apt hardening + bounded, retried Playwright Chromium install. Used by `tests-e2e-rsc-browser`, `tests-binary-e2e`, and `e2e-playwright.yml` (install command is an input).
- `.github/actions/restore-npm-workspace` — download/extract/`deno install --frozen` of the canonical npm runtime workspace. Used by `tests-node`, `tests-node-sandbox`, `tests-bun`.
- `.github/actions/prepare-build-deps` — the `build:prepare` retry loop. Used by `tests-proxy-binary`, `build-binaries`.

**Deleted dead reporting:** Node shard timer steps, the `npm-compatibility-artifact` duration/archive-size outputs, and the `quality-gate-artifact` "npm build reuse" step-summary block (it hard-coded a legacy seven-build comparison). The gate's result checks are untouched.

## Invariants

No job added, removed, or renamed — required checks, triggers, `needs` edges, gates, and `if` conditions are byte-identical. Net **−378 lines**.

## Verification

- YAML parses; job count unchanged (29).
- All affected jobs run on this PR — green CI here exercises every extracted action except `build-binaries` (main-only; it uses the same `prepare-build-deps` action `tests-proxy-binary` proves here).

https://claude.ai/code/session_0145mkV9Y8k6cWjtQt5H676r