### PR TITLE
ci: merge coverage shards 8 into 4

### DIFF
--- a/.github/QUALITY_GATES.md
+++ b/.github/QUALITY_GATES.md
@@ -7,7 +7,7 @@ protects a distinct delivery boundary.
 ## 1. Merge correctness
 
 `quality gate (merge)` requires source checks, unit tests, the existing
-eight-shard coverage dependency with its 80 percent floor, integration tests,
+four-shard coverage dependency with its 80 percent floor, integration tests,
 the full Node and Bun runtime suites, binary end-to-end tests, and RSC browser
 end-to-end tests to succeed for pull requests, merge queue runs, and main
 pushes. Sonar analysis is also mandatory for merge queue runs, main pushes,

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -457,7 +457,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           use_oidc: true
-          # Comma separated, the form the action documents. All 8 files go up
+          # Comma separated, the form the action documents. All 4 files go up
           # in one call, so Codecov records one upload per commit.
           files: coverage-profiles/coverage-shard-1/lcov.info,coverage-profiles/coverage-shard-2/lcov.info,coverage-profiles/coverage-shard-3/lcov.info,coverage-profiles/coverage-shard-4/lcov.info
           disable_search: true

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -334,12 +334,12 @@ jobs:
   coverage-shards:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    name: coverage shard ${{ matrix.shard }}/8
+    timeout-minutes: 20
+    name: coverage shard ${{ matrix.shard }}/4
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -350,7 +350,7 @@ jobs:
         id: coverage
         run: |
           START=$(date +%s)
-          deno task coverage:ci:shard -- --shard=${{ matrix.shard }}/8 --coverage-dir=coverage-shard-${{ matrix.shard }}
+          deno task coverage:ci:shard -- --shard=${{ matrix.shard }}/4 --coverage-dir=coverage-shard-${{ matrix.shard }}
           echo "duration=$(($(date +%s) - START))s" >> "$GITHUB_OUTPUT"
       - name: Upload unit coverage lcov
         if: ${{ !cancelled() }}
@@ -360,7 +360,7 @@ jobs:
           path: coverage-shard-${{ matrix.shard }}/lcov.info
           retention-days: 1
       - name: Add coverage shard summary
-        run: echo "### Coverage shard ${{ matrix.shard }}/8 completed in ${{ steps.coverage.outputs.duration }}" >> "$GITHUB_STEP_SUMMARY"
+        run: echo "### Coverage shard ${{ matrix.shard }}/4 completed in ${{ steps.coverage.outputs.duration }}" >> "$GITHUB_STEP_SUMMARY"
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -459,7 +459,7 @@ jobs:
           use_oidc: true
           # Comma separated, the form the action documents. All 8 files go up
           # in one call, so Codecov records one upload per commit.
-          files: coverage-profiles/coverage-shard-1/lcov.info,coverage-profiles/coverage-shard-2/lcov.info,coverage-profiles/coverage-shard-3/lcov.info,coverage-profiles/coverage-shard-4/lcov.info,coverage-profiles/coverage-shard-5/lcov.info,coverage-profiles/coverage-shard-6/lcov.info,coverage-profiles/coverage-shard-7/lcov.info,coverage-profiles/coverage-shard-8/lcov.info
+          files: coverage-profiles/coverage-shard-1/lcov.info,coverage-profiles/coverage-shard-2/lcov.info,coverage-profiles/coverage-shard-3/lcov.info,coverage-profiles/coverage-shard-4/lcov.info
           disable_search: true
           name: unit
           fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@
 # Docs: https://docs.codecov.com/docs/codecov-yaml
 #
 # Coverage is uploaded by the `codecov upload` job in
-# .github/workflows/cicd.yml, which sends all 8 shard lcov files in one call.
+# .github/workflows/cicd.yml, which sends all 4 shard lcov files in one call.
 #
 # Codecov is ADVISORY here. The blocking threshold is still enforced in CI by
 # `deno task coverage:gate` (scripts/lint/check-coverage.ts, 80% line coverage).
@@ -12,7 +12,7 @@
 codecov:
   require_ci_to_pass: true
   notify:
-    # The `codecov upload` job sends all 8 shard lcov files in one call, so
+    # The `codecov upload` job sends all 4 shard lcov files in one call, so
     # there is exactly one upload per commit and reporting must not wait for
     # more. Raise this if uploads are ever split back out per shard.
     after_n_builds: 1

--- a/scripts/ci/setup-deno-workflow.test.ts
+++ b/scripts/ci/setup-deno-workflow.test.ts
@@ -901,7 +901,7 @@ jobs:
       asRecord(ci.jobs, "cicd jobs")["coverage-shards"],
       "coverage-shards job",
     );
-    assertEquals(coverageShards["timeout-minutes"], 15);
+    assertEquals(coverageShards["timeout-minutes"], 20);
     const coverageSetup = asSteps(
       coverageShards.steps,
       "coverage-shards steps",

--- a/scripts/lint/audit-cwd-relative-test-reads.ts
+++ b/scripts/lint/audit-cwd-relative-test-reads.ts
@@ -10,7 +10,7 @@
  * directory.
  *
  * Which test files share a process is decided by the suite planner's ordinal
- * shard selection (`index % 8` over the sorted file list), so adding any test
+ * shard selection (`index % shard count` over the sorted file list), so adding any test
  * file anywhere reshuffles the pairings. A test that reads a
  * repo file by cwd-relative path is therefore not stably correct — it is
  * correct until an unrelated file lands beside it.

--- a/src/config/cicd-coverage-workflow.test.ts
+++ b/src/config/cicd-coverage-workflow.test.ts
@@ -20,7 +20,7 @@ import { fromFileUrl } from "#veryfront/platform/compat/path/index.ts";
  *    It restores in a `finally`, but that only closes the window afterwards — a
  *    concurrent reader inside the window still resolves against the wrong
  *    directory. Which files share a process is decided by the suite planner's
- *    ordinal shard selection (`index % 8` over the sorted file list), so adding
+ *    ordinal shard selection (`index % shard count` over the sorted file list), so adding
  *    any test file anywhere reshuffles the pairing. This module read repo files
  *    by cwd-relative path and failed in CI with `NotFound: readfile
  *    '.github/workflows/cicd.yml'` the moment a shard reshuffle put it beside a
@@ -111,17 +111,17 @@ describe("cicd coverage workflow", () => {
     const workflow = await readWorkflow();
 
     assertStringIncludes(workflow, "coverage-shards:");
-    assertStringIncludes(workflow, "name: coverage shard ${{ matrix.shard }}/8");
+    assertStringIncludes(workflow, "name: coverage shard ${{ matrix.shard }}/4");
     assertEquals(
       jobTimeoutMinutes(workflow, "coverage-shards"),
-      15,
-      "coverage shard job-level timeout must stay at 15 minutes",
+      20,
+      "coverage shard job-level timeout must stay at 20 minutes",
     );
     assertSetupDenoStepTimeout(workflow, "coverage-shards");
-    assertStringIncludes(workflow, "shard: [1, 2, 3, 4, 5, 6, 7, 8]");
+    assertStringIncludes(workflow, "shard: [1, 2, 3, 4]");
     assertStringIncludes(
       workflow,
-      "deno task coverage:ci:shard -- --shard=${{ matrix.shard }}/8 --coverage-dir=coverage-shard-${{ matrix.shard }}",
+      "deno task coverage:ci:shard -- --shard=${{ matrix.shard }}/4 --coverage-dir=coverage-shard-${{ matrix.shard }}",
     );
     assertStringIncludes(workflow, "actions/upload-artifact");
     assertStringIncludes(workflow, "name: coverage-shard-${{ matrix.shard }}");

--- a/tests/integration/ci/merge-quality-gate-workflow.test.ts
+++ b/tests/integration/ci/merge-quality-gate-workflow.test.ts
@@ -189,7 +189,7 @@ describe("merge quality gate workflow", () => {
     const unitTests = asRecord(jobs["unit-tests"], "unit sentinel job");
     const coverage = asRecord(jobs.coverage, "coverage gate job");
 
-    assertEquals(matrix.shard, [1, 2, 3, 4, 5, 6, 7, 8]);
+    assertEquals(matrix.shard, [1, 2, 3, 4]);
     assertEquals(unitTests.name, "tests (unit)");
     assertEquals(unitTests.needs, ["coverage-shards"]);
     assertEquals(coverage.name, "coverage gate");


### PR DESCRIPTION
## Why

Coverage shards averaged under 2 minutes of tests on top of ~2 minutes of checkout/setup-deno, so more than half of each shard job's billed minutes were fixed provisioning overhead, plus per-job round-up-to-the-minute. At August's ~8.8k CI/CD runs that overhead is roughly 175k runner-minutes/month.

## What

- `coverage-shards` matrix 8 → 4; `--shard=N/4`; job timeout 15 → 20 minutes for the doubled per-shard test time (worst observed shard was ~4.3 min at 8 shards).
- `codecov-upload` file list follows (still one upload per commit); the `coverage:ci:merge` glob is shard-count agnostic.
- Contract tests updated: shard matrix in `merge-quality-gate-workflow.test.ts`, timeout in `setup-deno-workflow.test.ts`.

## Invariants

No job added, removed, or renamed; the coverage threshold and gate semantics are untouched — the same tests run, in fewer, longer jobs.

https://claude.ai/code/session_0145mkV9Y8k6cWjtQt5H676r