### PR TITLE
ci: cross-compile the darwin binaries on Linux runners

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -873,12 +873,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          # The darwin binaries cross-compile on Linux: deno compile --target
+          # downloads the matching denort runtime and ad-hoc signs the output,
+          # and no step here codesigns, notarizes, or smoke-tests on macOS.
+          # macOS runners bill at 10x the Linux rate for the same compile.
+          - os: ubuntu-latest
             target: aarch64-apple-darwin
             name: veryfront-macos-arm64
             entrypoint: cli/main.ts
             profile: full
-          - os: macos-latest
+          - os: ubuntu-latest
             target: x86_64-apple-darwin
             name: veryfront-macos-x64
             entrypoint: cli/main.ts


### PR DESCRIPTION
## Why

The two macOS legs of `build-binaries` bill at 10x the Linux per-minute rate (7,608 macOS minutes = $472 gross in August) and do nothing macOS-specific: no codesigning, no notarization, no macOS smoke test. `deno compile --target` cross-compiles by downloading the matching denort runtime and ad-hoc signing the output, so the same compile on `ubuntu-latest` costs ~10% as much.

## What

The `aarch64-apple-darwin` and `x86_64-apple-darwin` matrix legs move from `macos-latest` to `ubuntu-latest`. Nothing else changes: artifact names, release assets, SHA256SUMS inputs, and the Homebrew formula placeholders are byte-identical.

## Verification

- `build-binaries` is main-only, so the first push to main after merge is the proving run; I'll watch both darwin legs there and revert if either fails.
- `compile-binary.test.ts` (20 tests) passes; the compile script has no host-OS assumptions (no `Deno.build.os` branching).
- Windows keeps its own runner and `continue-on-error`, unchanged.

https://claude.ai/code/session_0145mkV9Y8k6cWjtQt5H676r