### PR TITLE
fix(agent): escalate mirror flush retry log to error once per failure streak

### DIFF
--- a/src/agent/conversation/run-chunk-mirror.test.ts
+++ b/src/agent/conversation/run-chunk-mirror.test.ts
@@ -620,4 +620,93 @@ describe("agent/conversation-run-chunk-mirror", () => {
       "an oversized-event stop must be reported at error level with the cursor metadata",
     );
   });
+
+  // VERYFRONT-AGENT-3 (veryfront-issue-inbox#821): the threshold added for the
+  // first incident stopped the first four retries from paging, but every
+  // attempt at or past the threshold still logged at error level. Retry
+  // backoff caps at ~5s, so one persistent append outage resumes emitting a
+  // Sentry error every ~5s per active run once the streak reaches five.
+  // Escalation must fire once per failure streak; the remaining attempts in
+  // the same streak stay at warn. A successful flush ends the streak, so the
+  // next persistent outage must escalate again.
+  it("escalates a persistent retry streak to error once, not on every attempt", async () => {
+    const logs: Array<{ level: "warn" | "error"; message: string; consecutiveFailures: unknown }> =
+      [];
+    let failing = true;
+    const flakyFetch = (() =>
+      Promise.resolve(
+        failing
+          ? new Response(
+            JSON.stringify({ detail: "upstream unavailable" }),
+            { status: 503, headers: { "Content-Type": "application/json" } },
+          )
+          : new Response(
+            JSON.stringify({
+              latestEventId: 1,
+              latestExternalEventSequence: 1,
+              appendedCount: 1,
+              run: {
+                runId: "run-1",
+                conversationId: "11111111-1111-4111-8111-111111111111",
+                latestEventId: 1,
+                latestExternalEventSequence: 1,
+              },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+      )) as typeof fetch;
+    const mirror = createHostedConversationRunChunkMirror({
+      authToken: "token",
+      apiUrl: "https://api.example.test",
+      conversationId: "11111111-1111-4111-8111-111111111111",
+      runId: "run-1",
+      latestEventId: 0,
+      fetch: flakyFetch,
+      instrumentation: {
+        warn: (message, metadata) => {
+          logs.push({ level: "warn", message, consecutiveFailures: metadata.consecutiveFailures });
+        },
+        error: (message, metadata) => {
+          logs.push({ level: "error", message, consecutiveFailures: metadata.consecutiveFailures });
+        },
+      },
+    });
+
+    await mirror.appendEvents([{ type: "TEXT_MESSAGE_CONTENT", delta: "persisted" }]);
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      await mirror.flush();
+    }
+
+    failing = false;
+    await mirror.flush();
+
+    failing = true;
+    await mirror.appendEvents([{ type: "TEXT_MESSAGE_CONTENT", delta: "queued again" }]);
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      await mirror.flush();
+    }
+    mirror.dispose();
+
+    assertEquals(
+      logs,
+      [
+        { level: "warn", message: RETRY_LOG_MESSAGE, consecutiveFailures: 1 },
+        { level: "warn", message: RETRY_LOG_MESSAGE, consecutiveFailures: 2 },
+        { level: "warn", message: RETRY_LOG_MESSAGE, consecutiveFailures: 3 },
+        { level: "warn", message: RETRY_LOG_MESSAGE, consecutiveFailures: 4 },
+        { level: "error", message: RETRY_LOG_MESSAGE, consecutiveFailures: 5 },
+        { level: "warn", message: RETRY_LOG_MESSAGE, consecutiveFailures: 6 },
+        { level: "warn", message: RETRY_LOG_MESSAGE, consecutiveFailures: 7 },
+        { level: "warn", message: RETRY_LOG_MESSAGE, consecutiveFailures: 8 },
+        { level: "warn", message: RETRY_LOG_MESSAGE, consecutiveFailures: 1 },
+        { level: "warn", message: RETRY_LOG_MESSAGE, consecutiveFailures: 2 },
+        { level: "warn", message: RETRY_LOG_MESSAGE, consecutiveFailures: 3 },
+        { level: "warn", message: RETRY_LOG_MESSAGE, consecutiveFailures: 4 },
+        { level: "error", message: RETRY_LOG_MESSAGE, consecutiveFailures: 5 },
+      ],
+      "a failure streak must escalate to error exactly once at the threshold; " +
+        "later attempts in the same streak stay at warn, and a recovered flush " +
+        "resets the streak so the next persistent outage escalates again",
+    );
+  });
 });

--- a/src/agent/conversation/run-chunk-mirror.ts
+++ b/src/agent/conversation/run-chunk-mirror.ts
@@ -270,9 +270,12 @@ async function runHostedChunkMirrorTrace<T>(
 
 // Retries are self-healing and back off to only a few seconds, so logging
 // every attempt at error level turns one degraded append window into a Sentry
-// error every few seconds per active run (VERYFRONT-AGENT-3). Escalate only
-// once the failure streak suggests the outage is persistent; terminal
-// stop/disable paths report at error level separately.
+// error every few seconds per active run (VERYFRONT-AGENT-3). Escalate
+// exactly once per failure streak, at the attempt where the streak first
+// reaches this threshold: the counter increments by one per scheduled retry
+// and resets to zero on a successful flush, so strict equality fires once
+// and re-arms after recovery. Terminal stop/disable paths report at error
+// level separately.
 const HOSTED_CHUNK_MIRROR_RETRY_ERROR_THRESHOLD = 5;
 
 function recordHostedChunkMirrorRetryScheduled(input: {
@@ -290,7 +293,7 @@ function recordHostedChunkMirrorRetryScheduled(input: {
     consecutiveFailures: input.flushAttempt.consecutiveFailures,
   });
   const message = "Durable run mirror flush failed; queued for retry";
-  if (input.flushAttempt.consecutiveFailures >= HOSTED_CHUNK_MIRROR_RETRY_ERROR_THRESHOLD) {
+  if (input.flushAttempt.consecutiveFailures === HOSTED_CHUNK_MIRROR_RETRY_ERROR_THRESHOLD) {
     input.instrumentation?.error?.(message, metadata);
     return;
   }


### PR DESCRIPTION
The hosted chunk mirror's retry-scheduled log ("Durable run mirror flush failed; queued for retry") escalated to error level with a `>=` comparison against `HOSTED_CHUNK_MIRROR_RETRY_ERROR_THRESHOLD`, so during a persistent outage every retry at/after the 5th attempt logged at error. Since `run-mirror.ts` retries indefinitely with backoff capped at 5s, one outage produced a captured Sentry error roughly every 5 seconds per active run (the unresolved VERYFRONT-AGENT-3 group). This change switches the escalation to strict equality (`=== HOSTED_CHUNK_MIRROR_RETRY_ERROR_THRESHOLD`): `consecutiveFailures` increments by exactly 1 per scheduled retry and resets to 0 on a successful flush (`src/agent/conversation/durable.ts`), so the error fires exactly once per failure streak and re-arms after recovery. Later attempts in the same streak stay at warn, and terminal stop/disable paths (auth_rejected, payload_too_large, cursor_resyncs_exhausted) keep reporting at error level. One error per persistent-outage streak remains expected signal for the Sentry group, not suppressed. Note: veryfront-agent consumes this code via the veryfront npm package and needs a dependency bump after release before VERYFRONT-AGENT-3 goes quiet.

Fixes veryfront/veryfront-issue-inbox#821

## Red

```
deno task test:file src/agent/conversation/run-chunk-mirror.test.ts
```

```
agent/conversation-run-chunk-mirror ...
  escalates a persistent retry streak to error once, not on every attempt ... FAILED (2ms)

error: AssertionError: Values are not equal: a failure streak must escalate to error exactly once at the threshold; later attempts in the same streak stay at warn, and a recovered flush resets the streak so the next persistent outage escalates again

    [diff, expected (+) vs actual (-)]
      { consecutiveFailures: 1..4, level: "warn" }   (unchanged)
      { consecutiveFailures: 5, level: "error" }     (unchanged)
      { consecutiveFailures: 6,
-       level: "error",
+       level: "warn" }
      { consecutiveFailures: 7,
-       level: "error",
+       level: "warn" }
      { consecutiveFailures: 8,
-       level: "error",
+       level: "warn" }
      [second streak after recovery: warn 1..4, error at 5]  (unchanged)

    at src/agent/conversation/run-chunk-mirror.test.ts:690

FAILED | 0 passed (14 steps) | 1 failed (1 step) (14ms)
```

## Green

```
agent/conversation-run-chunk-mirror ...
  escalates a persistent retry streak to error once, not on every attempt ... ok (2ms)
agent/conversation-run-chunk-mirror ... ok (11ms)
ok | 1 passed (15 steps) | 0 failed (12ms)
```

Suite results:

- `deno task test:file src/agent/conversation`: ok | 21 passed (247 steps) | 0 failed (2s)
- `deno task test:file src/agent/hosted`: ok | 498 passed (417 steps) | 0 failed (11s)
- `deno fmt --check` / `deno lint` / `deno check` on `src/agent/conversation/run-chunk-mirror.ts`: all clean

## Revert check

Recorded HEAD 3a22b254c3533a056b8752cb8bb3e318aa7c43c8. `git revert --no-commit 3a22b254c` (clean revert, only `src/agent/conversation/run-chunk-mirror.ts` modified) -> `deno task test:file src/agent/conversation/run-chunk-mirror.test.ts` FAILED: "escalates a persistent retry streak to error once, not on every attempt ... FAILED" with the AssertionError at run-chunk-mirror.test.ts:690 (attempts 6-8 logged at error instead of warn) — "FAILED | 0 passed (14 steps) | 1 failed (1 step)". Restored with `git reset --hard 3a22b254c` -> same command PASSED — "ok | 1 passed (15 steps) | 0 failed (13ms)".

## Acceptance criteria

- [x] With a persistently failing append endpoint (HTTP 503), the retry-scheduled log "Durable run mirror flush failed; queued for retry" is emitted at warn level for attempts 1-4 of a failure streak.
- [x] The escalation to error level fires exactly once per failure streak, at the attempt where `consecutiveFailures` first reaches the threshold (5); attempts 6+ in the same streak stay at warn.
- [x] A successful flush resets the streak, and a subsequent persistent outage in the same run escalates to error again (once, at its own threshold crossing).
- [x] Existing contracts intact: terminal stop/disable paths (auth_rejected, payload_too_large, cursor_resyncs_exhausted) still report at error level, run_terminal still warns, and the pre-existing "warns on early retry attempts and escalates to error at the failure threshold" test stays green.
- [x] Lint, typecheck (deno fmt/lint/check), and `deno task test:file src/agent/conversation/run-chunk-mirror.test.ts` pass after the fix.

The issue is filed in veryfront-issue-inbox against veryfront-agent's Sentry group, but the culprit code lives here: veryfront-agent consumes `recordHostedChunkMirrorRetryScheduled` from this repo via the veryfront npm package. No overlap with open PR #4326, which touches only `src/agent/hosted/durable-run-event-sink.{ts,test.ts}`; the two are compatible in either merge order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Retry failures now escalate to an error exactly once at the configured threshold, while subsequent attempts remain warnings.
  * Retry escalation resets after a successful flush, improving log clarity for new failure streaks.

* **Tests**
  * Added coverage verifying retry logging behavior across repeated failures and successful recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->