### PR TITLE
fix(agent): filter provider rate-limit error logs from Sentry capture

### DIFF
--- a/src/agent/service/node-sentry.test.ts
+++ b/src/agent/service/node-sentry.test.ts
@@ -296,6 +296,41 @@ describe("agent/service/node-sentry", () => {
     }
   });
 
+  it("filters provider rate-limit error logs as expected upstream throttling", () => {
+    // Sentry group VERYFRONT-AGENT-G (veryfront-issue-inbox#829): a provider
+    // 429 thrown as ProviderRateLimitError reaches the agent error log without
+    // a context statusCode, so the emitter reports expected upstream
+    // throttling as an application error.
+    const reporter = createReporter();
+    const emitter = createNodeAgentServiceLogApplicationErrorEmitter();
+
+    try {
+      setApplicationErrorReporter(reporter);
+      emitter({
+        timestamp: "2026-08-30T00:00:00.000Z",
+        level: "error",
+        service: "agent",
+        component: "runtime",
+        veryfrontVersion: "0.0.0",
+        message: "Chat stream failed",
+        error: {
+          name: "ProviderRateLimitError",
+          message: "veryfront-cloud request failed: Provider request failed with status 429",
+          stack: "ProviderRateLimitError: veryfront-cloud request failed: " +
+            "Provider request failed with status 429\n    at buildProviderError",
+        },
+      });
+
+      assertEquals(
+        reporter.captured,
+        [],
+        "a provider rate-limit error log must not reach Sentry",
+      );
+    } finally {
+      setApplicationErrorReporter(undefined);
+    }
+  });
+
   it("reports message-only Agent error logs under their own log message", () => {
     const reporter = createReporter();
     const emitter = createNodeAgentServiceLogApplicationErrorEmitter();

--- a/src/agent/service/node-sentry.ts
+++ b/src/agent/service/node-sentry.ts
@@ -43,6 +43,13 @@ const DEFAULT_ENVIRONMENT = "production";
 const DEFAULT_FLUSH_TIMEOUT_MS = 2_000;
 const MISSING_DSN_WARNING =
   "Sentry is enabled, but SENTRY_DSN is empty. Sentry reporting is disabled.";
+const EXPECTED_ERROR_NAMES = new Set([
+  "AbortError",
+  // Provider 429s surface to users as RATE_LIMITED after bounded retries;
+  // the serialized error carries no context statusCode, so filter by name
+  // (Sentry group VERYFRONT-AGENT-G).
+  "ProviderRateLimitError",
+]);
 const EXPECTED_ERROR_CODES = new Set([
   "AUTHENTICATION_REQUIRED",
   "CONTROL_PLANE_RUN_ID_MISMATCH",
@@ -118,7 +125,8 @@ function getProcessRole(entry: LogEntry): string | undefined {
 }
 
 function isExpectedAgentErrorLog(entry: LogEntry): boolean {
-  if (entry.error?.name === "AbortError") return true;
+  const errorName = entry.error?.name;
+  if (errorName && EXPECTED_ERROR_NAMES.has(errorName)) return true;
   const errorCode = getExpectedErrorCode(entry);
   if (errorCode && EXPECTED_ERROR_CODES.has(errorCode)) return true;
   const statusCode = getStatusCode(entry);


### PR DESCRIPTION
Provider 429 responses (ProviderRateLimitError, the VERYFRONT-AGENT-G Sentry signature "veryfront-cloud request failed: Provider request failed with status 429") were being captured as unexpected application errors by `createNodeAgentServiceLogApplicationErrorEmitter` even though they are expected upstream throttling: `requestStream` already retries with backoff honoring Retry-After, and users already get a clean RATE_LIMITED surface via `src/chat/provider-errors.ts`. Serialized log errors carry only name/message/stack, so `isExpectedAgentErrorLog` in `src/agent/service/node-sentry.ts` now filters serialized error names against a new `EXPECTED_ERROR_NAMES` set ("AbortError", "ProviderRateLimitError"), replacing the inline AbortError-only check and following the file's existing `EXPECTED_ERROR_CODES` whitelist pattern. Unexpected errors (5xx statuses, non-whitelisted error codes, unknown error names) still reach Sentry.

Fixes veryfront/veryfront-issue-inbox#829

## Red

```
deno task test:file src/agent/service/node-sentry.test.ts
```

```
agent/service/node-sentry ... filters provider rate-limit error logs as expected upstream throttling
error: AssertionError: Values are not equal: a provider rate-limit error log must not reach Sentry
    [Diff] Actual / Expected
-   [
-     {
-       context: {
-         attributes: { "log.component": "runtime", "log.service": "agent" },
-         boundary: "agent.framework-log",
-       },
-       error: Error [ProviderRateLimitError]: veryfront-cloud request failed: Provider request failed with status 429
-           at buildProviderError,
-     },
-   ]
+   []
    at src/agent/service/node-sentry.test.ts:324:7
FAILED | 0 passed (15 steps) | 1 failed (1 step) (14ms)
```

## Green

```
deno task test:file src/agent/service/node-sentry.test.ts
agent/service/node-sentry ... ok (12ms)
  ... filters provider rate-limit error logs as expected upstream throttling ... ok
ok | 1 passed (16 steps) | 0 failed (15ms)
```

Suite: `deno task test:file src/agent/service/` -> ok | 57 passed (145 steps) | 0 failed (14s). `deno check src/agent/service/node-sentry.ts` -> ok. `deno lint` -> clean. `deno fmt --check` -> clean.

## Revert check

With the fix commit reverted in the working tree (`git revert --no-commit 5686c9cfe`), the test run fails on exactly the new step: "filters provider rate-limit error logs as expected upstream throttling => FAILED | 0 passed (15 steps) | 1 failed (1 step) -- AssertionError at src/agent/service/node-sentry.test.ts:324" (all 15 pre-existing steps still passed). After restoring (`git reset --hard 5686c9cfe`), the run is green again: ok | 1 passed (16 steps) | 0 failed.

## Acceptance criteria

- [x] An error-level agent framework log entry whose serialized error is ProviderRateLimitError (signature: "veryfront-cloud request failed: Provider request failed with status 429") is classified as expected and is NOT captured as a Sentry application error by `createNodeAgentServiceLogApplicationErrorEmitter`
- [x] Unexpected error logs (5xx statuses, non-whitelisted error codes, unknown error names) still reach Sentry — the existing 15 test steps in `src/agent/service/node-sentry.test.ts` keep passing
- [x] The user-facing surfacing of rate limits (RATE_LIMITED classification in `src/chat/provider-errors.ts`) and the existing `requestStream` retry/backoff behavior remain unchanged (neither file touched)

Note: the issue label points at the deployment repo (veryfront-agent), but its `main.ts` is service bootstrap only — the Sentry emitter and the provider error chain live in veryfront-code, so the branch was cut here.
