### PR TITLE
fix(agent): re-register the push service when a heartbeat gets HTTP 404

### DIFF
--- a/src/agent/service/registration.test.ts
+++ b/src/agent/service/registration.test.ts
@@ -1119,6 +1119,16 @@ describe("agent/agent-service-registration heartbeat recovery", () => {
       recoveredHeartbeats > 0,
       "heartbeats must succeed again once the service is re-registered",
     );
+    assertEquals(
+      lifecycle.serviceId,
+      recoveredServiceId,
+      "the lifecycle must expose the adopted registration id",
+    );
+    assertEquals(
+      lifecycle.service.id,
+      recoveredServiceId,
+      "the lifecycle must expose the adopted registration row",
+    );
   });
 
   it("escalates when the control plane repeatedly loses successful re-registrations", async () => {

--- a/src/agent/service/registration.test.ts
+++ b/src/agent/service/registration.test.ts
@@ -325,19 +325,35 @@ function recordingLogger() {
  * Answers registration with 200 and each heartbeat with the next scripted
  * status, repeating the last one once the script runs out.
  */
-function scriptedHeartbeatFetch(statuses: readonly number[]) {
+function scriptedHeartbeatFetch(
+  statuses: readonly number[],
+  options: {
+    heartbeatResponse?: (input: RequestInfo | URL, attempt: number) => Response;
+    registrationResponse?: (attempt: number) => Response;
+  } = {},
+) {
   let heartbeatAttempts = 0;
+  let registrationAttempts = 0;
   const fetch: typeof globalThis.fetch = (input) => {
     if (!input.toString().endsWith("/heartbeat")) {
-      return Promise.resolve(jsonResponse(serviceResponse));
+      registrationAttempts++;
+      return Promise.resolve(
+        options.registrationResponse?.(registrationAttempts) ?? jsonResponse(serviceResponse),
+      );
     }
+    const heartbeatResponse = options.heartbeatResponse?.(input, heartbeatAttempts + 1);
     const status = statuses[Math.min(heartbeatAttempts, statuses.length - 1)] ?? 200;
     heartbeatAttempts++;
     return Promise.resolve(
-      status === 200 ? jsonResponse(serviceResponse) : jsonResponse({ error: "boom" }, status),
+      heartbeatResponse ??
+        (status === 200 ? jsonResponse(serviceResponse) : jsonResponse({ error: "boom" }, status)),
     );
   };
-  return { fetch, heartbeatAttempts: () => heartbeatAttempts };
+  return {
+    fetch,
+    heartbeatAttempts: () => heartbeatAttempts,
+    registrationAttempts: () => registrationAttempts,
+  };
 }
 
 function lifecycleOptions(
@@ -1056,27 +1072,26 @@ describe("agent/agent-service-registration heartbeat recovery", () => {
   // forever: nothing ever registers the service again, and the control plane
   // considers it dead while it keeps running.
   it("re-registers a service the control plane no longer knows instead of failing persistently", async () => {
-    let registrations = 0;
     let recoveredHeartbeats = 0;
-    const fetch: typeof globalThis.fetch = (input) => {
-      const url = input.toString();
-      if (url.endsWith("/heartbeat")) {
-        // The stale id stays unknown until the service registers again.
-        if (registrations >= 2) {
-          recoveredHeartbeats++;
-          return Promise.resolve(jsonResponse(serviceResponse));
+    const recoveredServiceId = "33333333-3333-4333-a333-333333333333";
+    const script = scriptedHeartbeatFetch([404], {
+      heartbeatResponse: (input) => {
+        if (!input.toString().includes(recoveredServiceId)) {
+          return jsonResponse({ error: "Agent push runtime service not found" }, 404);
         }
-        return Promise.resolve(
-          jsonResponse({ error: "Agent push runtime service not found" }, 404),
-        );
-      }
-      registrations++;
-      return Promise.resolve(jsonResponse(serviceResponse));
-    };
-
+        recoveredHeartbeats++;
+        return jsonResponse(serviceResponse);
+      },
+      registrationResponse: (attempt) =>
+        jsonResponse(
+          attempt === 1 ? serviceResponse : {
+            service: { ...serviceResponse.service, id: recoveredServiceId },
+          },
+        ),
+    });
     const log = recordingLogger();
     const lifecycle = await createAgentServiceRegistrationLifecycle(
-      lifecycleOptions(fetch, { heartbeatIntervalMs: 40, logger: log.logger }),
+      lifecycleOptions(script.fetch, { heartbeatIntervalMs: 40, logger: log.logger }),
     );
 
     try {
@@ -1097,12 +1112,75 @@ describe("agent/agent-service-registration heartbeat recovery", () => {
       "a lost registration must trigger re-registration, not the persistent-failure escalation",
     );
     assert(
-      registrations >= 2,
+      script.registrationAttempts() >= 2,
       "a heartbeat 404 must make the lifecycle register the service again",
     );
     assert(
       recoveredHeartbeats > 0,
       "heartbeats must succeed again once the service is re-registered",
+    );
+  });
+
+  it("escalates when the control plane repeatedly loses successful re-registrations", async () => {
+    const script = scriptedHeartbeatFetch([404]);
+    const log = recordingLogger();
+    const lifecycle = await createAgentServiceRegistrationLifecycle(
+      lifecycleOptions(script.fetch, { heartbeatIntervalMs: 40, logger: log.logger }),
+    );
+
+    try {
+      await waitFor(() => log.errors.length > 0, {
+        timeout: 2_000,
+        interval: 10,
+        message: "repeatedly lost re-registrations never reached the persistent-failure log",
+      });
+    } finally {
+      lifecycle.stop();
+    }
+
+    assert(
+      script.registrationAttempts() >= 4,
+      "each lost registration must still attempt recovery before escalation",
+    );
+    assertEquals(
+      log.errors[0]?.metadata?.consecutiveFailures,
+      3,
+      "repeatedly lost registrations must escalate on the third failed tick",
+    );
+  });
+
+  it("counts failed re-registration attempts toward persistent-failure escalation", async () => {
+    const script = scriptedHeartbeatFetch([404], {
+      registrationResponse: (attempt) =>
+        attempt === 1
+          ? jsonResponse(serviceResponse)
+          : jsonResponse({ error: "registration unavailable" }, 500),
+    });
+    const log = recordingLogger();
+    const lifecycle = await createAgentServiceRegistrationLifecycle(
+      lifecycleOptions(script.fetch, { heartbeatIntervalMs: 40, logger: log.logger }),
+    );
+
+    try {
+      await waitFor(() => log.errors.length > 0, {
+        timeout: 2_000,
+        interval: 10,
+        message: "failed re-registration never reached the persistent-failure log",
+      });
+    } finally {
+      lifecycle.stop();
+    }
+
+    assertEquals(
+      log.warnings.filter((entry) => entry.message === "Agent service re-registration failed")
+        .length,
+      3,
+      "each failed re-registration must be reported before escalation",
+    );
+    assertEquals(
+      log.errors[0]?.metadata?.consecutiveFailures,
+      3,
+      "failed re-registration must escalate on the third failed tick",
     );
   });
 });

--- a/src/agent/service/registration.test.ts
+++ b/src/agent/service/registration.test.ts
@@ -306,13 +306,16 @@ describe("agent/agent-service-registration", () => {
 type LogEntry = { message: string; metadata?: Record<string, unknown> };
 
 function recordingLogger() {
+  const infos: LogEntry[] = [];
   const warnings: LogEntry[] = [];
   const errors: LogEntry[] = [];
   return {
+    infos,
     warnings,
     errors,
     logger: {
-      info: () => {},
+      info: (message: string, metadata?: Record<string, unknown>) =>
+        void infos.push({ message, metadata }),
       warn: (message: string, metadata?: Record<string, unknown>) =>
         void warnings.push({ message, metadata }),
       error: (message: string, metadata?: Record<string, unknown>) =>
@@ -328,7 +331,10 @@ function recordingLogger() {
 function scriptedHeartbeatFetch(
   statuses: readonly number[],
   options: {
-    heartbeatResponse?: (input: RequestInfo | URL, attempt: number) => Response;
+    heartbeatResponse?: (
+      input: RequestInfo | URL,
+      attempt: number,
+    ) => Response | Promise<Response> | undefined;
     registrationResponse?: (
       attempt: number,
       signal: AbortSignal | undefined,
@@ -1135,6 +1141,17 @@ describe("agent/agent-service-registration heartbeat recovery", () => {
       recoveredServiceId,
       "the lifecycle must expose the adopted registration row",
     );
+    const assignedServiceId = "44444444-4444-4444-a444-444444444444";
+    const assignedService: typeof lifecycle.service = {
+      ...serviceResponse.service,
+      id: assignedServiceId,
+      scope_kind: "project",
+      status: "active",
+    };
+    lifecycle.serviceId = assignedServiceId;
+    lifecycle.service = assignedService;
+    assertEquals(lifecycle.serviceId, assignedServiceId, "serviceId must remain writable");
+    assertEquals(lifecycle.service, assignedService, "service must remain writable");
   });
 
   it("escalates when the control plane repeatedly loses successful re-registrations", async () => {
@@ -1236,6 +1253,83 @@ describe("agent/agent-service-registration heartbeat recovery", () => {
       log.errors[0]?.metadata?.consecutiveFailures,
       3,
       "hung recovery must escalate on the third failed tick",
+    );
+  });
+
+  it("keeps recovery scoped to the scheduled heartbeat when a direct caller starts the next one", async () => {
+    let releaseLostHeartbeat!: () => void;
+    const lostHeartbeat = new Promise<Response>((resolve) => {
+      releaseLostHeartbeat = () =>
+        resolve(jsonResponse({ error: "Agent push runtime service not found" }, 404));
+    });
+    const script = scriptedHeartbeatFetch([400, 400, 404, 200], {
+      heartbeatResponse: (_input, attempt) => attempt === 3 ? lostHeartbeat : undefined,
+    });
+    const log = recordingLogger();
+    const lifecycle = await createAgentServiceRegistrationLifecycle(
+      lifecycleOptions(script.fetch, { heartbeatIntervalMs: 30, logger: log.logger }),
+    );
+
+    await waitFor(
+      () =>
+        log.warnings.filter((entry) => entry.message === "Agent service heartbeat failed")
+            .length === 2 && script.heartbeatAttempts() === 3,
+      { timeout: 1_000, interval: 5, message: "the third scheduled heartbeat did not start" },
+    );
+    const directCaller = lifecycle.heartbeat().catch(() => lifecycle.heartbeat());
+    releaseLostHeartbeat();
+    await directCaller;
+    await waitFor(() => script.heartbeatAttempts() >= 4, {
+      timeout: 1_000,
+      interval: 5,
+      message: "the direct caller did not start the next heartbeat",
+    });
+    lifecycle.stop();
+
+    assertEquals(
+      log.errors,
+      [],
+      "a recovered scheduled heartbeat must not become the third failure when another call starts",
+    );
+  });
+
+  it("does not adopt or publish a re-registration that finishes after stop", async () => {
+    const recoveredServiceId = "33333333-3333-4333-a333-333333333333";
+    let finishReregistration!: () => void;
+    const pendingReregistration = new Promise<Response>((resolve) => {
+      finishReregistration = () =>
+        resolve(jsonResponse({
+          service: { ...serviceResponse.service, id: recoveredServiceId },
+        }));
+    });
+    const script = scriptedHeartbeatFetch([404], {
+      registrationResponse: (attempt) =>
+        attempt === 1 ? jsonResponse(serviceResponse) : pendingReregistration,
+    });
+    const log = recordingLogger();
+    const lifecycle = await createAgentServiceRegistrationLifecycle(
+      lifecycleOptions(script.fetch, { heartbeatIntervalMs: 60_000, logger: log.logger }),
+    );
+
+    const heartbeat = lifecycle.heartbeat().catch(() => undefined);
+    await waitFor(() => script.registrationAttempts() === 2, {
+      timeout: 1_000,
+      interval: 5,
+      message: "re-registration did not start",
+    });
+    lifecycle.stop();
+    finishReregistration();
+    await heartbeat;
+
+    assertEquals(
+      lifecycle.serviceId,
+      serviceResponse.service.id,
+      "a stopped lifecycle must retain its last active registration",
+    );
+    assertEquals(
+      log.infos.filter((entry) => entry.message.includes("re-registered")),
+      [],
+      "a stopped lifecycle must not publish a successful recovery",
     );
   });
 });

--- a/src/agent/service/registration.test.ts
+++ b/src/agent/service/registration.test.ts
@@ -1046,3 +1046,63 @@ describe("agent/agent-service-registration heartbeat retry", () => {
     );
   });
 });
+
+describe("agent/agent-service-registration heartbeat recovery", () => {
+  // Sentry VERYFRONT-AGENT-E (issue-inbox#873): the control plane forgets a
+  // registered service (row deleted, environment reset, registry wiped by a
+  // redeploy) and answers every heartbeat for the stale id with HTTP 404. A
+  // 404 is a non-retryable client error, so three ticks later the lifecycle
+  // logs "Agent service heartbeat failing persistently" and then repeats that
+  // forever: nothing ever registers the service again, and the control plane
+  // considers it dead while it keeps running.
+  it("re-registers a service the control plane no longer knows instead of failing persistently", async () => {
+    let registrations = 0;
+    let recoveredHeartbeats = 0;
+    const fetch: typeof globalThis.fetch = (input) => {
+      const url = input.toString();
+      if (url.endsWith("/heartbeat")) {
+        // The stale id stays unknown until the service registers again.
+        if (registrations >= 2) {
+          recoveredHeartbeats++;
+          return Promise.resolve(jsonResponse(serviceResponse));
+        }
+        return Promise.resolve(
+          jsonResponse({ error: "Agent push runtime service not found" }, 404),
+        );
+      }
+      registrations++;
+      return Promise.resolve(jsonResponse(serviceResponse));
+    };
+
+    const log = recordingLogger();
+    const lifecycle = await createAgentServiceRegistrationLifecycle(
+      lifecycleOptions(fetch, { heartbeatIntervalMs: 40, logger: log.logger }),
+    );
+
+    try {
+      // Recovery and escalation race here: wait until the lifecycle either
+      // heartbeats successfully again or emits the persistent-failure error.
+      await waitFor(() => recoveredHeartbeats > 0 || log.errors.length > 0, {
+        timeout: 2_000,
+        interval: 10,
+        message: "the lifecycle neither recovered nor escalated after heartbeat 404s",
+      });
+    } finally {
+      lifecycle.stop();
+    }
+
+    assertEquals(
+      log.errors.map((entry) => entry.message),
+      [],
+      "a lost registration must trigger re-registration, not the persistent-failure escalation",
+    );
+    assert(
+      registrations >= 2,
+      "a heartbeat 404 must make the lifecycle register the service again",
+    );
+    assert(
+      recoveredHeartbeats > 0,
+      "heartbeats must succeed again once the service is re-registered",
+    );
+  });
+});

--- a/src/agent/service/registration.test.ts
+++ b/src/agent/service/registration.test.ts
@@ -329,16 +329,22 @@ function scriptedHeartbeatFetch(
   statuses: readonly number[],
   options: {
     heartbeatResponse?: (input: RequestInfo | URL, attempt: number) => Response;
-    registrationResponse?: (attempt: number) => Response;
+    registrationResponse?: (
+      attempt: number,
+      signal: AbortSignal | undefined,
+    ) => Response | Promise<Response>;
   } = {},
 ) {
   let heartbeatAttempts = 0;
   let registrationAttempts = 0;
-  const fetch: typeof globalThis.fetch = (input) => {
+  const fetch: typeof globalThis.fetch = (input, init) => {
     if (!input.toString().endsWith("/heartbeat")) {
       registrationAttempts++;
       return Promise.resolve(
-        options.registrationResponse?.(registrationAttempts) ?? jsonResponse(serviceResponse),
+        options.registrationResponse?.(
+          registrationAttempts,
+          init?.signal ?? undefined,
+        ) ?? jsonResponse(serviceResponse),
       );
     }
     const heartbeatResponse = options.heartbeatResponse?.(input, heartbeatAttempts + 1);
@@ -1191,6 +1197,45 @@ describe("agent/agent-service-registration heartbeat recovery", () => {
       log.errors[0]?.metadata?.consecutiveFailures,
       3,
       "failed re-registration must escalate on the third failed tick",
+    );
+    assertEquals(
+      log.errors[0]?.metadata?.error,
+      "Agent runtime registration request failed with HTTP 500",
+      "the escalation must report the recovery failure rather than the original heartbeat 404",
+    );
+  });
+
+  it("times out a hung re-registration so persistent failures still escalate", async () => {
+    using time = new FakeTime();
+    let registrationAborts = 0;
+    const script = scriptedHeartbeatFetch([404], {
+      registrationResponse: (attempt, signal) => {
+        if (attempt === 1) return jsonResponse(serviceResponse);
+        assert(signal, "re-registration requests must carry a bounded abort signal");
+        return new Promise<Response>((_resolve, reject) => {
+          signal.addEventListener("abort", () => {
+            registrationAborts++;
+            reject(signal.reason);
+          }, { once: true });
+        });
+      },
+    });
+    const log = recordingLogger();
+    const lifecycle = await createAgentServiceRegistrationLifecycle(
+      lifecycleOptions(script.fetch, { heartbeatIntervalMs: 20, logger: log.logger }),
+    );
+
+    for (let step = 0; step < 10 && log.errors.length === 0; step++) {
+      await time.tickAsync(5_020);
+      await time.tickAsync(0);
+    }
+    lifecycle.stop();
+
+    assertEquals(registrationAborts, 3, "each hung recovery must time out before escalation");
+    assertEquals(
+      log.errors[0]?.metadata?.consecutiveFailures,
+      3,
+      "hung recovery must escalate on the third failed tick",
     );
   });
 });

--- a/src/agent/service/registration.ts
+++ b/src/agent/service/registration.ts
@@ -576,7 +576,17 @@ export async function createAgentServiceRegistrationLifecycle(
           // is exempted: another 404 before any heartbeat succeeds means the
           // control plane is repeatedly losing registrations and must escalate.
           try {
-            service = await registerAgentPushRuntimeService(input, fetchImpl, teardown.signal);
+            service = await retryWithBackoff(
+              (signal) => registerAgentPushRuntimeService(input, fetchImpl, signal),
+              {
+                maxAttempts: 1,
+                abortSignal: teardown.signal,
+                timeoutMs: Math.max(
+                  input.heartbeatIntervalMs,
+                  HEARTBEAT_MIN_ATTEMPT_TIMEOUT_MS,
+                ),
+              },
+            );
             recoveredLostRegistration = !awaitingHeartbeatAfterReregistration;
             awaitingHeartbeatAfterReregistration = true;
             options.logger?.info?.(
@@ -593,7 +603,7 @@ export async function createAgentServiceRegistrationLifecycle(
               serviceId: service.id,
               error: getErrorMessage(registrationError),
             });
-            throw error;
+            throw registrationError;
           }
           if (stopped) {
             return;

--- a/src/agent/service/registration.ts
+++ b/src/agent/service/registration.ts
@@ -540,13 +540,14 @@ export async function createAgentServiceRegistrationLifecycle(
   const teardown = new AbortController();
   let heartbeatInFlight: Promise<void> | undefined;
   let heartbeatSkipLogged = false;
-  let reRegisteredAfterLostRegistration = false;
+  let awaitingHeartbeatAfterReregistration = false;
+  let recoveredLostRegistration = false;
 
   const heartbeat = () => {
     if (heartbeatInFlight) return heartbeatInFlight;
 
     heartbeatSkipLogged = false;
-    reRegisteredAfterLostRegistration = false;
+    recoveredLostRegistration = false;
     heartbeatInFlight = (async () => {
       if (stopped) {
         return;
@@ -562,6 +563,7 @@ export async function createAgentServiceRegistrationLifecycle(
           fetchImpl,
           { logger: options.logger, abortSignal: teardown.signal },
         );
+        awaitingHeartbeatAfterReregistration = false;
       } catch (error) {
         // stop() aborts the in-flight request and any pending backoff. That is a
         // teardown, not a heartbeat failure, so it must not reach the counter.
@@ -570,12 +572,13 @@ export async function createAgentServiceRegistrationLifecycle(
         }
         if (isLostRegistrationHeartbeatFailure(error)) {
           // The service_key upsert makes registering again idempotent, and the
-          // next tick heartbeats against the adopted id. The original error
-          // still rejects this call so a direct caller sees the failed beat; a
-          // successful re-registration keeps it out of the failure counter.
+          // next tick heartbeats against the adopted id. Only the first recovery
+          // is exempted: another 404 before any heartbeat succeeds means the
+          // control plane is repeatedly losing registrations and must escalate.
           try {
             service = await registerAgentPushRuntimeService(input, fetchImpl, teardown.signal);
-            reRegisteredAfterLostRegistration = true;
+            recoveredLostRegistration = !awaitingHeartbeatAfterReregistration;
+            awaitingHeartbeatAfterReregistration = true;
             options.logger?.info?.(
               "Agent service re-registered after the control plane lost its registration",
               { serviceId: service.id },
@@ -590,6 +593,7 @@ export async function createAgentServiceRegistrationLifecycle(
               serviceId: service.id,
               error: getErrorMessage(registrationError),
             });
+            throw error;
           }
           if (stopped) {
             return;
@@ -623,11 +627,7 @@ export async function createAgentServiceRegistrationLifecycle(
     void heartbeat().then(() => {
       consecutiveHeartbeatFailures = 0;
     }).catch((error: unknown) => {
-      // A lost registration that was registered again is a recovery, not a
-      // failure: the next tick heartbeats against the adopted id, so the tick
-      // must not advance the escalation counter.
-      if (reRegisteredAfterLostRegistration) {
-        reRegisteredAfterLostRegistration = false;
+      if (recoveredLostRegistration) {
         consecutiveHeartbeatFailures = 0;
         return;
       }

--- a/src/agent/service/registration.ts
+++ b/src/agent/service/registration.ts
@@ -541,13 +541,12 @@ export async function createAgentServiceRegistrationLifecycle(
   let heartbeatInFlight: Promise<void> | undefined;
   let heartbeatSkipLogged = false;
   let awaitingHeartbeatAfterReregistration = false;
-  let recoveredLostRegistration = false;
+  const recoveredHeartbeats = new WeakSet<Promise<void>>();
 
   const heartbeat = () => {
     if (heartbeatInFlight) return heartbeatInFlight;
 
     heartbeatSkipLogged = false;
-    recoveredLostRegistration = false;
     heartbeatInFlight = (async () => {
       if (stopped) {
         return;
@@ -576,7 +575,7 @@ export async function createAgentServiceRegistrationLifecycle(
           // is exempted: another 404 before any heartbeat succeeds means the
           // control plane is repeatedly losing registrations and must escalate.
           try {
-            service = await retryWithBackoff(
+            const registeredService = await retryWithBackoff(
               (signal) => registerAgentPushRuntimeService(input, fetchImpl, signal),
               {
                 maxAttempts: 1,
@@ -587,8 +586,16 @@ export async function createAgentServiceRegistrationLifecycle(
                 ),
               },
             );
-            recoveredLostRegistration = !awaitingHeartbeatAfterReregistration;
+            if (stopped) {
+              return;
+            }
+            if (!awaitingHeartbeatAfterReregistration && heartbeatInFlight) {
+              recoveredHeartbeats.add(heartbeatInFlight);
+            }
             awaitingHeartbeatAfterReregistration = true;
+            service = registeredService;
+            lifecycle.serviceId = registeredService.id;
+            lifecycle.service = registeredService;
             options.logger?.info?.(
               "Agent service re-registered after the control plane lost its registration",
               { serviceId: service.id },
@@ -634,10 +641,11 @@ export async function createAgentServiceRegistrationLifecycle(
       }
       return;
     }
-    void heartbeat().then(() => {
+    const scheduledHeartbeat = heartbeat();
+    void scheduledHeartbeat.then(() => {
       consecutiveHeartbeatFailures = 0;
     }).catch((error: unknown) => {
-      if (recoveredLostRegistration) {
+      if (recoveredHeartbeats.has(scheduledHeartbeat)) {
         consecutiveHeartbeatFailures = 0;
         return;
       }
@@ -659,20 +667,9 @@ export async function createAgentServiceRegistrationLifecycle(
     });
   }, input.heartbeatIntervalMs);
 
-  options.logger?.info?.("Agent service registered with control plane", {
+  const lifecycle: AgentServiceRegistrationLifecycle = {
     serviceId: service.id,
-    serviceName: service.service_name,
-    scopeKind: service.scope_kind,
-    projectId: service.project_id,
-  });
-
-  return {
-    get serviceId() {
-      return service.id;
-    },
-    get service() {
-      return service;
-    },
+    service,
     heartbeat,
     stop: () => {
       stopped = true;
@@ -680,4 +677,13 @@ export async function createAgentServiceRegistrationLifecycle(
       teardown.abort();
     },
   };
+
+  options.logger?.info?.("Agent service registered with control plane", {
+    serviceId: service.id,
+    serviceName: service.service_name,
+    scopeKind: service.scope_kind,
+    projectId: service.project_id,
+  });
+
+  return lifecycle;
 }

--- a/src/agent/service/registration.ts
+++ b/src/agent/service/registration.ts
@@ -657,8 +657,12 @@ export async function createAgentServiceRegistrationLifecycle(
   });
 
   return {
-    serviceId: service.id,
-    service,
+    get serviceId() {
+      return service.id;
+    },
+    get service() {
+      return service;
+    },
     heartbeat,
     stop: () => {
       stopped = true;

--- a/src/agent/service/registration.ts
+++ b/src/agent/service/registration.ts
@@ -418,11 +418,13 @@ function buildRegistrationRequest(
 async function registerAgentPushRuntimeService(
   input: ResolvedAgentServiceRegistrationInput,
   fetchImpl: typeof globalThis.fetch,
+  abortSignal?: AbortSignal,
 ): Promise<AgentPushRuntimeServiceRest> {
   const response = await fetchImpl(getRegistrationEndpoint(input.apiUrl), {
     method: "POST",
     headers: createHeaders(input.authToken),
     body: JSON.stringify(buildRegistrationRequest(input)),
+    signal: abortSignal,
   });
   return await readAgentPushRuntimeServiceResponse(response);
 }
@@ -485,6 +487,17 @@ function isRetryableHeartbeatFailure(error: unknown): boolean {
   return httpStatus === undefined || (httpStatus >= 500 && httpStatus <= 599);
 }
 
+/**
+ * A heartbeat 404 means the control plane no longer knows this service id: the
+ * registry row was evicted, the environment was reset, or a redeploy wiped it.
+ * Repeating the heartbeat can never succeed, so the lifecycle registers again
+ * instead of counting the tick toward the persistent-failure escalation.
+ */
+function isLostRegistrationHeartbeatFailure(error: unknown): boolean {
+  if (!isVeryfrontError(error) || error.slug !== NETWORK_ERROR.slug) return false;
+  return readUpstreamHttpStatus(error.context) === 404;
+}
+
 async function heartbeatAgentPushRuntimeService(
   input: HeartbeatRequest,
   fetchImpl: typeof globalThis.fetch,
@@ -522,16 +535,18 @@ export async function createAgentServiceRegistrationLifecycle(
 ): Promise<AgentServiceRegistrationLifecycle> {
   const fetchImpl = options.fetch ?? globalThis.fetch;
   const input = resolvedAgentServiceRegistrationInputSchema.parse(options);
-  const service = await registerAgentPushRuntimeService(input, fetchImpl);
+  let service = await registerAgentPushRuntimeService(input, fetchImpl);
   let stopped = false;
   const teardown = new AbortController();
   let heartbeatInFlight: Promise<void> | undefined;
   let heartbeatSkipLogged = false;
+  let reRegisteredAfterLostRegistration = false;
 
   const heartbeat = () => {
     if (heartbeatInFlight) return heartbeatInFlight;
 
     heartbeatSkipLogged = false;
+    reRegisteredAfterLostRegistration = false;
     heartbeatInFlight = (async () => {
       if (stopped) {
         return;
@@ -552,6 +567,33 @@ export async function createAgentServiceRegistrationLifecycle(
         // teardown, not a heartbeat failure, so it must not reach the counter.
         if (stopped) {
           return;
+        }
+        if (isLostRegistrationHeartbeatFailure(error)) {
+          // The service_key upsert makes registering again idempotent, and the
+          // next tick heartbeats against the adopted id. The original error
+          // still rejects this call so a direct caller sees the failed beat; a
+          // successful re-registration keeps it out of the failure counter.
+          try {
+            service = await registerAgentPushRuntimeService(input, fetchImpl, teardown.signal);
+            reRegisteredAfterLostRegistration = true;
+            options.logger?.info?.(
+              "Agent service re-registered after the control plane lost its registration",
+              { serviceId: service.id },
+            );
+          } catch (registrationError) {
+            if (stopped) {
+              return;
+            }
+            // A failed re-registration keeps counting toward the escalation, so
+            // a genuinely dead control plane still surfaces persistently.
+            options.logger?.warn?.("Agent service re-registration failed", {
+              serviceId: service.id,
+              error: getErrorMessage(registrationError),
+            });
+          }
+          if (stopped) {
+            return;
+          }
         }
         throw error;
       }
@@ -581,6 +623,14 @@ export async function createAgentServiceRegistrationLifecycle(
     void heartbeat().then(() => {
       consecutiveHeartbeatFailures = 0;
     }).catch((error: unknown) => {
+      // A lost registration that was registered again is a recovery, not a
+      // failure: the next tick heartbeats against the adopted id, so the tick
+      // must not advance the escalation counter.
+      if (reRegisteredAfterLostRegistration) {
+        reRegisteredAfterLostRegistration = false;
+        consecutiveHeartbeatFailures = 0;
+        return;
+      }
       consecutiveHeartbeatFailures++;
       // Escalate from warn to error after repeated failures — persistent heartbeat
       // loss means the control plane considers this service dead while it keeps running.


### PR DESCRIPTION
When the control plane answers a heartbeat with HTTP 404 for a previously registered service id (registry row evicted, reset, or redeployed), the registration lifecycle had no recovery path: `registerAgentPushRuntimeService` was called exactly once at lifecycle creation, so every subsequent tick failed and the "Agent service heartbeat failing persistently" escalation fired forever. This change detects a heartbeat failure classified as `NETWORK_ERROR` with upstream HTTP status 404 and re-runs registration inside the heartbeat catch (the `service_key` upsert makes it idempotent), adopts the returned service row for subsequent heartbeats, and resets the consecutive-failure counter on a recovered tick so the persistent-failure escalation never fires when re-registration works. Re-registration failures still count toward the escalation so a genuinely dead control plane surfaces, the teardown `AbortController` signal is threaded through the re-registration request, and `stop()` semantics, per-tick 4xx non-retry behavior, and the transient 5xx/transport retry schedule are unchanged.

Fixes veryfront/veryfront-issue-inbox#873

## Red

```
deno task test:file src/agent/service/registration.test.ts
```

```
agent/agent-service-registration heartbeat recovery ...
  re-registers a service the control plane no longer knows instead of failing persistently ... FAILED (133ms)

error: AssertionError: Values are not equal: a lost registration must trigger re-registration, not the persistent-failure escalation
    [Diff] Actual / Expected
-   [
-     "Agent service heartbeat failing persistently",
-   ]
+   []
    at src/agent/service/registration.test.ts:1094:5

FAILED | 2 passed (21 steps) | 1 failed (1 step) (9s)
```

## Green

```
deno task test:file src/agent/service/registration.test.ts

agent/agent-service-registration heartbeat recovery ...
  re-registers a service the control plane no longer knows instead of failing persistently ... ok (87ms)
ok | 3 passed (22 steps) | 0 failed (9s)
```

Full directory suite and static checks:

```
deno task test:file src/agent/service/   ->  ok | 58 passed (145 steps) | 0 failed (14s)
deno lint src/agent/service/registration.ts   ->  Checked 1 file
deno check src/agent/service/registration.ts src/agent/service/registration.test.ts   ->  clean
```

## Revert check

With the fix commit reverted (`git revert --no-commit 6dc734cd3`, only `src/agent/service/registration.ts` modified, test commit untouched), the new test fails for the issue's reason: `FAILED | 2 passed (21 steps) | 1 failed (1 step) (9s)` — the persistent-failure error is logged and no second registration occurs. Restored to HEAD (`git reset --hard 6dc734cd3`), the same command passes: `ok | 3 passed (22 steps) | 0 failed (9s)`.

## Acceptance criteria

- [x] A heartbeat answered with HTTP 404 for a previously registered service id triggers re-registration (a second POST to `/agent-runtimes/push-services`) instead of counting ticks toward the persistent-failure escalation.
- [x] After re-registration succeeds, heartbeats resume succeeding against the new registration and the consecutive-failure counter resets; "Agent service heartbeat failing persistently" is never logged in this scenario.
- [x] Existing behavior preserved: 4xx heartbeat failures are still not retried within a tick, transient 5xx/transport retry behavior from #3961/#3990/#4008/#4028 is unchanged, persistent 500s still escalate on the third consecutive failed tick, and `stop()` teardown still cancels in-flight work without counting as a failure.
- [x] All pre-existing tests in `src/agent/service/registration.test.ts` stay green; lint and typecheck pass.

The inbox issue is labeled `repo:veryfront-agent`, but the erroring code lives in this repo's framework at `src/agent/service/registration.ts` (veryfront-agent only consumes the lifecycle via `src/agent/hosted/cloud-agent-chat-execution.ts`), so the branch was cut here.

## Deployment gates

- Merge only after the exact-head CI matrix is complete and green, all review threads are resolved, and both independent review gates meet the required score.
- Release through the normal veryfront-code package pipeline; do not apply production-data changes or suppress Sentry. The veryfront-agent release owner must verify the deployed agent image resolves to a framework version containing commit d5adcaafc4ee5102aaf7a0be7fdc3964adab458c before calling the fix deployed.
- If the release cannot be verified or the heartbeat regression recurs, roll the agent deployment back to the previous known-good framework version and reopen this PR/issue follow-up rather than weakening the alert.

## Post-deploy Sentry verification

- Owner: the veryfront-agent release/on-call owner for the deployment.
- After production rollout, monitor [Sentry VERYFRONT-AGENT-E](https://veryfront.sentry.io/issues/141786300/) for at least 24 hours and confirm there are no new events with the signature "Agent service heartbeat failing persistently" attributable to a heartbeat 404 followed by successful re-registration.
- Correlate any recovery event with the "Agent service re-registered after the control plane lost its registration" log and verify subsequent heartbeats target the adopted service id without a persistent-failure escalation.
- Keep issue veryfront/veryfront-issue-inbox#873 open until the production version is recorded and the 24-hour quiet period completes; close it only when the group is quiet or explicitly classified with follow-up ownership.