### PR TITLE
ci: remove duplicate unit test sentinel

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -362,22 +362,6 @@ jobs:
       - name: Add coverage shard summary
         run: echo "### Coverage shard ${{ matrix.shard }}/4 completed in ${{ steps.coverage.outputs.duration }}" >> "$GITHUB_STEP_SUMMARY"
 
-  unit-tests:
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    name: tests (unit)
-    needs: [coverage-shards]
-    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-    steps:
-      - name: Require all unit test shards
-        env:
-          COVERAGE_SHARDS_RESULT: ${{ needs.coverage-shards.result }}
-        run: |
-          if [ "$COVERAGE_SHARDS_RESULT" != "success" ]; then
-            echo "::error::Unit test shards finished with $COVERAGE_SHARDS_RESULT"
-            exit 1
-          fi
-
   coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -553,7 +537,6 @@ jobs:
     timeout-minutes: 2
     needs:
       - ci
-      - unit-tests
       - coverage
       - tests
       - tests-node
@@ -570,7 +553,6 @@ jobs:
           # skip it. Pushes, merge-group runs, and trusted PRs must block on it.
           SONAR_REQUIRED: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') }}
           SOURCE_CHECKS_RESULT: ${{ needs.ci.result }}
-          UNIT_TESTS_RESULT: ${{ needs.unit-tests.result }}
           COVERAGE_RESULT: ${{ needs.coverage.result }}
           SONAR_RESULT: ${{ needs.sonar.result }}
           INTEGRATION_TESTS_RESULT: ${{ needs.tests.result }}
@@ -583,7 +565,6 @@ jobs:
           failed=0
           for result_name in \
             SOURCE_CHECKS_RESULT \
-            UNIT_TESTS_RESULT \
             COVERAGE_RESULT \
             SONAR_RESULT \
             INTEGRATION_TESTS_RESULT \

--- a/tests/integration/ci/merge-quality-gate-workflow.test.ts
+++ b/tests/integration/ci/merge-quality-gate-workflow.test.ts
@@ -10,7 +10,6 @@ const WORKFLOW_PATH = new URL(
 );
 const REQUIRED_DEPENDENCIES = [
   "ci",
-  "unit-tests",
   "coverage",
   "tests",
   "tests-node",
@@ -22,7 +21,6 @@ const REQUIRED_DEPENDENCIES = [
 ] as const;
 const RESULT_ENV = {
   SOURCE_CHECKS_RESULT: "${{ needs.ci.result }}",
-  UNIT_TESTS_RESULT: "${{ needs.unit-tests.result }}",
   COVERAGE_RESULT: "${{ needs.coverage.result }}",
   SONAR_RESULT: "${{ needs.sonar.result }}",
   INTEGRATION_TESTS_RESULT: "${{ needs.tests.result }}",
@@ -174,7 +172,7 @@ describe("merge quality gate workflow", () => {
     }
   });
 
-  it("preserves all required coverage shards, the unit sentinel, and the floor", async () => {
+  it("preserves all required coverage shards, the aggregate gate, and the floor", async () => {
     const workflow = await readWorkflow();
     const jobs = asRecord(workflow.jobs, "cicd workflow jobs");
     const coverageShards = asRecord(
@@ -186,12 +184,10 @@ describe("merge quality gate workflow", () => {
       "coverage shard strategy",
     );
     const matrix = asRecord(strategy.matrix, "coverage shard matrix");
-    const unitTests = asRecord(jobs["unit-tests"], "unit sentinel job");
     const coverage = asRecord(jobs.coverage, "coverage gate job");
 
     assertEquals(matrix.shard, [1, 2, 3, 4]);
-    assertEquals(unitTests.name, "tests (unit)");
-    assertEquals(unitTests.needs, ["coverage-shards"]);
+    assertEquals("unit-tests" in jobs, false);
     assertEquals(coverage.name, "coverage gate");
     assertEquals(coverage.needs, ["coverage-shards"]);
     assertStringIncludes(

--- a/tests/integration/ci/registry-release-workflow.test.ts
+++ b/tests/integration/ci/registry-release-workflow.test.ts
@@ -7,7 +7,6 @@ import { parse } from "#std/yaml/parse";
 type YamlRecord = Record<string, unknown>;
 const MERGE_CORRECTNESS_DEPENDENCIES = [
   "ci",
-  "unit-tests",
   "coverage",
   "tests",
   "tests-node",


### PR DESCRIPTION
## Summary

- remove the duplicate `unit-tests` sentinel job and `tests (unit)` check
- keep all four coverage shards and `coverage gate` unchanged
- make `quality gate (merge)` and release workflow contracts depend on the single coverage aggregate

## Red-green TDD

- RED: the merge-gate workflow contract failed because `unit-tests`, `UNIT_TESTS_RESULT`, and the duplicate job still existed
- GREEN: the merge-gate contract passed 12 steps and the registry-release contract passed 17 steps after removing only the duplicate fan-in

## Verification

- `deno task test:file tests/integration/ci/merge-quality-gate-workflow.test.ts`
- `deno task test:file tests/integration/ci/registry-release-workflow.test.ts`
- `deno task lint:ci`
- `git diff --check`

Classic branch protection and the active required-check ruleset were updated after this exact PR head became otherwise ready. Every required context except `tests (unit)` remains unchanged, and `coverage gate` remains required.

Closes veryfront/veryfront-issue-inbox#899

Parent: veryfront/veryfront-issue-inbox#881 item 5.
