### PR TITLE
Revert "ci: cross-compile the darwin binaries on Linux runners"

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -854,16 +854,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # The darwin binaries cross-compile on Linux: deno compile --target
-          # downloads the matching denort runtime and ad-hoc signs the output,
-          # and no step here codesigns, notarizes, or smoke-tests on macOS.
-          # macOS runners bill at 10x the Linux rate for the same compile.
-          - os: ubuntu-latest
+          - os: macos-latest
             target: aarch64-apple-darwin
             name: veryfront-macos-arm64
             entrypoint: cli/main.ts
             profile: full
-          - os: ubuntu-latest
+          - os: macos-latest
             target: x86_64-apple-darwin
             name: veryfront-macos-x64
             entrypoint: cli/main.ts


### PR DESCRIPTION
Reverts #4329. I shipped that change and the post-merge verification showed it regressed the macOS artifact, so this puts the darwin legs back on `macos-latest`.

## What the proving run showed

`build-binaries` only runs on main, so the first main run after the merge was the real test. Both darwin legs **succeeded** — but success only meant the compile exited 0. The artifact changed materially:

| binary | macOS-built (run 33348772057) | Linux-built (run 33361786320) |
|---|---|---|
| `veryfront-macos-arm64` | 997,511,522 | **1,141,496,162** (+144 MB, +14%) |
| `veryfront-linux-x64` | 1,057,438,819 | 1,057,438,819 (identical) |

The linux-x64 binary being byte-identical across both runs is the control: no code change between those commits touched the payload, so the darwin delta is caused entirely by the runner switch.

## Mechanism

`deno compile` embeds every locked npm package. On a Linux host, `build:prepare` additionally resolves the host's native packages, which then get embedded into the darwin binary:

```
@esbuild/linux-x64@0.28.1
lightningcss-linux-x64-gnu@1.29.2
lightningcss-linux-x64-musl@1.29.2
@kreuzberg/node-linux-x64-gnu@4.4.2
```

Zero `linux-x64` package initializations appear in any macOS-built run. The 7 `darwin-arm64` packages are still present in both, so the binary is **not broken** — but every macOS user would download 144 MB of code that can never execute on their machine.

That growth is not a theoretical concern here: the comment block in `scripts/build/compile-binary.ts` records staging proxy pods exiting 137 (OOMKilled) after the universal binary grew ~63 MB, because startup cost tracks the embedded archive, not the JS heap.

## Cost note

The macOS legs bill ~$472/month gross, but that line was **fully covered by discounts in August ($0 net)**, so the change bought no actual cash — it was gross-exposure insurance. Trading a 14% artifact regression for that is a bad deal.

## Relanding

Reland once the full profile has a target-scoped lock, the approach `compile-binary.ts` already uses for the proxy profile (`--node-modules-dir=none` + a graph-specific frozen lock). Then the darwin binary would carry only darwin packages and the cross-compile saving is free.

No user-facing release shipped the bloat: no release was cut from that run (the version was unchanged), so this lands before the next version bump would publish it.

https://claude.ai/code/session_0145mkV9Y8k6cWjtQt5H676r