### PR TITLE
fix(ci): use HTTPS for Chromium apt mirrors

### DIFF
--- a/.github/actions/install-chromium/action.yml
+++ b/.github/actions/install-chromium/action.yml
@@ -17,9 +17,9 @@ runs:
     - name: Configure apt sources, retries, and mirrors
       shell: bash
       run: |
-        sudo sed -i \
-          -e 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
-          -e 's|http://security.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' \
+        sudo sed -E -i \
+          -e 's|[[:alpha:]]*://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+          -e 's|[[:alpha:]]*://security.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
           /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources 2>/dev/null || true
         {
           echo 'Acquire::ForceIPv4 "true";'

--- a/scripts/ci/setup-deno-workflow.test.ts
+++ b/scripts/ci/setup-deno-workflow.test.ts
@@ -922,6 +922,27 @@ jobs:
     ).find((step) => step.name === "Install Chromium");
     assert(chromiumInstall, "the shared action must install Chromium");
     const install = String(chromiumInstall.run);
+    const chromiumAptSetup = asSteps(
+      chromiumRuns.steps,
+      "install-chromium steps",
+    ).find((step) =>
+      step.name === "Configure apt sources, retries, and mirrors"
+    );
+    assert(chromiumAptSetup, "the shared action must configure apt sources");
+    const aptSetup = String(chromiumAptSetup.run);
+    assertStringIncludes(
+      aptSetup,
+      "-e 's|[[:alpha:]]*://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g'",
+    );
+    assertStringIncludes(
+      aptSetup,
+      "-e 's|[[:alpha:]]*://security.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g'",
+    );
+    assertEquals(
+      aptSetup.includes("http://"),
+      false,
+      "APT mirror rewrites must not contain clear-text HTTP URLs",
+    );
     for (
       const expected of [
         'for attempt in $(seq 1 "${install_attempts}")',


### PR DESCRIPTION
## Summary

SonarCloud marks `main` as failing `githubactions:S5332` because the shared Chromium install action rewrites Ubuntu APT sources through clear-text HTTP URLs.

This PR matches either existing protocol and rewrites both Ubuntu mirrors to HTTPS, leaving no clear-text URL literal in the action. The CI contract test now locks that security invariant.

## Verification

- Deno 2.7.7: `scripts/ci/setup-deno-workflow.test.ts` passed, 2 tests and 11 steps
- Formatting and lint checks passed for the changed test
- Shell replay confirmed both HTTP and HTTPS source entries rewrite to `https://archive.ubuntu.com/ubuntu`
- `git diff --check` passed
