### PR TITLE
ci: enforce SonarCloud quality gate before merge

### DIFF
--- a/.github/QUALITY_GATES.md
+++ b/.github/QUALITY_GATES.md
@@ -11,7 +11,9 @@ four-shard coverage dependency with its 80 percent floor, integration tests,
 the full Node and Bun runtime suites, binary end-to-end tests, and RSC browser
 end-to-end tests to succeed for pull requests, merge queue runs, and main
 pushes. Sonar analysis is also mandatory for merge queue runs, main pushes,
-manually dispatched runs, and trusted pull requests. A failed, skipped, or
+manually dispatched runs, and trusted pull requests. The scanner waits for the
+server-side SonarCloud Quality Gate, so the required `sonar` check fails when
+that gate fails rather than only when report upload fails. A failed, skipped, or
 cancelled dependency fails the aggregate check, except that Sonar is
 intentionally skipped and ignored for fork and Dependabot pull requests because
 those runs cannot receive `SONAR_TOKEN`. Fork pull requests still skip other
@@ -34,8 +36,9 @@ For pull requests and merge queue runs, `quality gate (artifact)` is a separate
 stable required check from `quality gate (merge)`. Runtime compatibility lanes
 are aggregated only by the artifact gate, so `quality-gate-merge` does not
 duplicate them. The workflow exposes both stable check names for repository
-rules to require. Those external branch protection or ruleset settings are not
-configured or asserted by this document.
+rules to require. The main ruleset also requires SonarCloud's
+`SonarCloud Code Analysis` check so the external quality-gate result cannot be
+silently omitted from a merge.
 
 Evidence: [artifact implementation](../scripts/ci/npm-compatibility-artifact.ts),
 [artifact contract](../tests/integration/ci/npm-compatibility-artifact.test.ts),

--- a/.github/QUALITY_GATES.md
+++ b/.github/QUALITY_GATES.md
@@ -20,6 +20,11 @@ those runs cannot receive `SONAR_TOKEN`. Fork pull requests still skip other
 protected dependency jobs and therefore fail this aggregate gate closed.
 Codecov reporting remains advisory.
 
+The active merge queue ruleset gives required checks at least 65 minutes to
+report a conclusion. This covers the configured sequential maximum of 20
+minutes for coverage shards, 35 minutes for Sonar, and 2 minutes for the
+aggregate merge gate, plus 8 minutes of runner scheduling headroom.
+
 Evidence: [CI workflow](workflows/cicd.yml) and
 [merge gate contract](../tests/integration/ci/merge-quality-gate-workflow.test.ts).
 

--- a/.github/QUALITY_GATES.md
+++ b/.github/QUALITY_GATES.md
@@ -20,10 +20,11 @@ those runs cannot receive `SONAR_TOKEN`. Fork pull requests still skip other
 protected dependency jobs and therefore fail this aggregate gate closed.
 Codecov reporting remains advisory.
 
-The active merge queue ruleset gives required checks at least 65 minutes to
-report a conclusion. This covers the configured sequential maximum of 20
-minutes for coverage shards, 35 minutes for Sonar, and 2 minutes for the
-aggregate merge gate, plus 8 minutes of runner scheduling headroom.
+The active merge queue ruleset gives required checks at least 70 minutes to
+report a conclusion. This covers the longest configured dependency path: 60
+minutes for binary end-to-end tests and 2 minutes for the aggregate merge gate,
+plus 8 minutes of runner scheduling headroom. The sequential coverage and Sonar
+path has a lower 57-minute maximum.
 
 Evidence: [CI workflow](workflows/cicd.yml) and
 [merge gate contract](../tests/integration/ci/merge-quality-gate-workflow.test.ts).

--- a/.github/QUALITY_GATES.md
+++ b/.github/QUALITY_GATES.md
@@ -36,9 +36,10 @@ For pull requests and merge queue runs, `quality gate (artifact)` is a separate
 stable required check from `quality gate (merge)`. Runtime compatibility lanes
 are aggregated only by the artifact gate, so `quality-gate-merge` does not
 duplicate them. The workflow exposes both stable check names for repository
-rules to require. The main ruleset also requires SonarCloud's
-`SonarCloud Code Analysis` check so the external quality-gate result cannot be
-silently omitted from a merge.
+rules to require. The required `sonar` check is the merge-blocking SonarCloud
+quality gate. The separate `SonarCloud Code Analysis` decoration remains
+informational because secret-dependent analysis is intentionally skipped for
+Dependabot and fork pull requests.
 
 Evidence: [artifact implementation](../scripts/ci/npm-compatibility-artifact.ts),
 [artifact contract](../tests/integration/ci/npm-compatibility-artifact.test.ts),

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -29,6 +29,7 @@ jobs:
   ci:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -455,9 +455,12 @@ jobs:
   # Skipped for forks and for Dependabot: both reach the scan without SONAR_TOKEN
   # (Dependabot branches live in this repository, but Actions secrets are not
   # exposed to Dependabot-triggered runs), and an empty token fails the scan.
+  # The scan waits for SonarCloud's server-side Quality Gate before this
+  # required job succeeds; the timeout leaves room for the observed analysis
+  # and report-processing latency.
   sonar:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 35
     name: sonar
     needs: [coverage-shards]
     if: ${{ needs.coverage-shards.result == 'success' && ((github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]')) }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,12 @@ sonar.sourceEncoding=UTF-8
 sonar.sources=.
 sonar.exclusions=coverage-profiles/**
 
+# The required CI `sonar` check must represent the server-side Quality Gate,
+# not only successful report upload. Keep enough time for SonarCloud to process
+# this repository's large analysis before the scanner reports the result.
+sonar.qualitygate.wait=true
+sonar.qualitygate.timeout=1200
+
 # Test fixtures and assertions are intentionally repetitive. Keep test files
 # in the analysis so their issues remain visible, but exclude them from CPD so
 # the duplication gate measures production implementation duplication.

--- a/tests/integration/ci/merge-quality-gate-workflow.test.ts
+++ b/tests/integration/ci/merge-quality-gate-workflow.test.ts
@@ -1,8 +1,4 @@
-import {
-  assert,
-  assertEquals,
-  assertStringIncludes,
-} from "#veryfront/testing/assert.ts";
+import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { parse } from "#std/yaml/parse";
 

--- a/tests/integration/ci/merge-quality-gate-workflow.test.ts
+++ b/tests/integration/ci/merge-quality-gate-workflow.test.ts
@@ -1,4 +1,8 @@
-import { assert, assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { parse } from "#std/yaml/parse";
 
@@ -35,6 +39,8 @@ const SONAR_REQUIRED_CONDITION =
 const SONAR_REQUIRED_EXPRESSION = `\${{ ${SONAR_REQUIRED_CONDITION} }}`;
 const SONAR_JOB_EXPRESSION =
   `\${{ needs.coverage-shards.result == 'success' && (${SONAR_REQUIRED_CONDITION}) }}`;
+const SONAR_JOB_TIMEOUT_MINUTES = 35;
+const SONAR_QUALITY_GATE_TIMEOUT_SECONDS = 1200;
 
 function asRecord(value: unknown, context: string): YamlRecord {
   assert(
@@ -150,6 +156,23 @@ describe("merge quality gate workflow", () => {
 
     assertEquals(sonar.if, SONAR_JOB_EXPRESSION);
     assertEquals(gateEnv.SONAR_REQUIRED, SONAR_REQUIRED_EXPRESSION);
+  });
+
+  it("makes the required Sonar check wait for the server-side quality gate", async () => {
+    const workflow = await readWorkflow();
+    const jobs = asRecord(workflow.jobs, "cicd workflow jobs");
+    const sonar = asRecord(jobs.sonar, "sonar job");
+    const sonarProperties = await readRepoFile("sonar-project.properties");
+
+    assertEquals(sonar["timeout-minutes"], SONAR_JOB_TIMEOUT_MINUTES);
+    assertStringIncludes(
+      sonarProperties,
+      "sonar.qualitygate.wait=true",
+    );
+    assertStringIncludes(
+      sonarProperties,
+      `sonar.qualitygate.timeout=${SONAR_QUALITY_GATE_TIMEOUT_SECONDS}`,
+    );
   });
 
   it("documents Sonar enforcement for manually dispatched runs", async () => {

--- a/tests/integration/ci/merge-quality-gate-workflow.test.ts
+++ b/tests/integration/ci/merge-quality-gate-workflow.test.ts
@@ -37,6 +37,8 @@ const SONAR_JOB_EXPRESSION =
   `\${{ needs.coverage-shards.result == 'success' && (${SONAR_REQUIRED_CONDITION}) }}`;
 const SONAR_JOB_TIMEOUT_MINUTES = 35;
 const SONAR_QUALITY_GATE_TIMEOUT_SECONDS = 1200;
+const MERGE_QUEUE_RESPONSE_TIMEOUT_MINUTES = 65;
+const MERGE_QUEUE_SCHEDULING_HEADROOM_MINUTES = 8;
 
 function asRecord(value: unknown, context: string): YamlRecord {
   assert(
@@ -55,6 +57,24 @@ async function readWorkflow(): Promise<YamlRecord> {
 
 async function readRepoFile(path: string): Promise<string> {
   return await Deno.readTextFile(new URL(`../../../${path}`, import.meta.url));
+}
+
+function parseProperties(content: string): Map<string, string> {
+  const properties = new Map<string, string>();
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "" || line.startsWith("#")) continue;
+
+    const separator = line.indexOf("=");
+    assert(separator > 0, `invalid property line: ${line}`);
+    properties.set(
+      line.slice(0, separator).trim(),
+      line.slice(separator + 1).trim(),
+    );
+  }
+
+  return properties;
 }
 
 async function readMergeGate(): Promise<YamlRecord> {
@@ -158,16 +178,45 @@ describe("merge quality gate workflow", () => {
     const workflow = await readWorkflow();
     const jobs = asRecord(workflow.jobs, "cicd workflow jobs");
     const sonar = asRecord(jobs.sonar, "sonar job");
-    const sonarProperties = await readRepoFile("sonar-project.properties");
+    const sonarProperties = parseProperties(
+      await readRepoFile("sonar-project.properties"),
+    );
 
     assertEquals(sonar["timeout-minutes"], SONAR_JOB_TIMEOUT_MINUTES);
-    assertStringIncludes(
-      sonarProperties,
-      "sonar.qualitygate.wait=true",
+    assertEquals(
+      sonarProperties.get("sonar.qualitygate.wait"),
+      "true",
+    );
+    assertEquals(
+      sonarProperties.get("sonar.qualitygate.timeout"),
+      String(SONAR_QUALITY_GATE_TIMEOUT_SECONDS),
+    );
+  });
+
+  it("keeps the sequential Sonar path within the merge queue response budget", async () => {
+    const workflow = await readWorkflow();
+    const jobs = asRecord(workflow.jobs, "cicd workflow jobs");
+    const coverageShards = asRecord(
+      jobs["coverage-shards"],
+      "coverage shards job",
+    );
+    const sonar = asRecord(jobs.sonar, "sonar job");
+    const mergeGate = asRecord(
+      jobs["quality-gate-merge"],
+      "merge quality gate job",
+    );
+    const maximumSequentialMinutes = Number(coverageShards["timeout-minutes"]) +
+      Number(sonar["timeout-minutes"]) +
+      Number(mergeGate["timeout-minutes"]);
+
+    assert(
+      maximumSequentialMinutes + MERGE_QUEUE_SCHEDULING_HEADROOM_MINUTES <=
+        MERGE_QUEUE_RESPONSE_TIMEOUT_MINUTES,
+      "merge queue response timeout must cover the sequential coverage, Sonar, and merge-gate timeouts with scheduling headroom",
     );
     assertStringIncludes(
-      sonarProperties,
-      `sonar.qualitygate.timeout=${SONAR_QUALITY_GATE_TIMEOUT_SECONDS}`,
+      await readRepoFile(".github/QUALITY_GATES.md"),
+      `at least ${MERGE_QUEUE_RESPONSE_TIMEOUT_MINUTES} minutes`,
     );
   });
 

--- a/tests/integration/ci/merge-quality-gate-workflow.test.ts
+++ b/tests/integration/ci/merge-quality-gate-workflow.test.ts
@@ -37,7 +37,7 @@ const SONAR_JOB_EXPRESSION =
   `\${{ needs.coverage-shards.result == 'success' && (${SONAR_REQUIRED_CONDITION}) }}`;
 const SONAR_JOB_TIMEOUT_MINUTES = 35;
 const SONAR_QUALITY_GATE_TIMEOUT_SECONDS = 1200;
-const MERGE_QUEUE_RESPONSE_TIMEOUT_MINUTES = 65;
+const MERGE_QUEUE_RESPONSE_TIMEOUT_MINUTES = 70;
 const MERGE_QUEUE_SCHEDULING_HEADROOM_MINUTES = 8;
 
 function asRecord(value: unknown, context: string): YamlRecord {
@@ -193,26 +193,30 @@ describe("merge quality gate workflow", () => {
     );
   });
 
-  it("keeps the sequential Sonar path within the merge queue response budget", async () => {
+  it("keeps the longest merge-gate path within the merge queue response budget", async () => {
     const workflow = await readWorkflow();
     const jobs = asRecord(workflow.jobs, "cicd workflow jobs");
-    const coverageShards = asRecord(
-      jobs["coverage-shards"],
-      "coverage shards job",
-    );
-    const sonar = asRecord(jobs.sonar, "sonar job");
     const mergeGate = asRecord(
       jobs["quality-gate-merge"],
       "merge quality gate job",
     );
-    const maximumSequentialMinutes = Number(coverageShards["timeout-minutes"]) +
-      Number(sonar["timeout-minutes"]) +
-      Number(mergeGate["timeout-minutes"]);
+    const dependencyTimeouts = REQUIRED_DEPENDENCIES.map((jobName) => {
+      const job = asRecord(jobs[jobName], `${jobName} job`);
+      const timeout = Number(job["timeout-minutes"]);
+      assert(
+        Number.isFinite(timeout) && timeout > 0,
+        `${jobName} must have a positive timeout-minutes value`,
+      );
+      return timeout;
+    });
+    const maximumDependencyMinutes = Math.max(...dependencyTimeouts);
+    const mergeGateMinutes = Number(mergeGate["timeout-minutes"]);
 
     assert(
-      maximumSequentialMinutes + MERGE_QUEUE_SCHEDULING_HEADROOM_MINUTES <=
+      maximumDependencyMinutes + mergeGateMinutes +
+          MERGE_QUEUE_SCHEDULING_HEADROOM_MINUTES <=
         MERGE_QUEUE_RESPONSE_TIMEOUT_MINUTES,
-      "merge queue response timeout must cover the sequential coverage, Sonar, and merge-gate timeouts with scheduling headroom",
+      "merge queue response timeout must cover the longest merge-gate dependency and aggregate timeouts with scheduling headroom",
     );
     assertStringIncludes(
       await readRepoFile(".github/QUALITY_GATES.md"),


### PR DESCRIPTION
## Problem
The required `sonar` job previously passed when SonarCloud accepted the report upload, even if the server-side Quality Gate failed later.

## Change
- make the scanner wait for the SonarCloud Quality Gate
- allow 20 minutes for report processing and 35 minutes for the job
- add a workflow contract test for the enforcement settings
- document that `sonar` is the merge-blocking gate

The repository ruleset requires the quality-gate-aware `sonar` job and `quality gate (merge)`. The separate SonarCloud decoration remains informational because secret-dependent analysis is intentionally skipped for Dependabot and fork pull requests.


## Rollout
- set the active merge queue required-check response timeout to 70 minutes, covering the 60-minute binary E2E dependency plus the 2-minute aggregate gate and 8 minutes of runner scheduling headroom

