### PR TITLE
fix(routing): dispatch explicit OPTIONS handlers

### DIFF
--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -1136,6 +1136,42 @@ describe("APIRouteHandler", () => {
       assertEquals(discoveryCalls, 1);
     });
 
+    it("keeps plain OPTIONS automatic when a protected route has no OPTIONS export", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/test/project/pages/api/protected-get-only.ts",
+        "export function GET() { return new Response('unused'); }",
+      );
+      let moduleLoads = 0;
+      __injectDepsForTests({
+        loadHandlerModule: () => {
+          moduleLoads++;
+          return Promise.resolve({ GET: () => new Response("get") });
+        },
+      });
+      const securityConfig = {
+        security: {
+          cors: { origin: ["https://client.example"] },
+          auth: { basic: { username: "admin", password: "secret" } },
+        },
+      }.security as HandlerContext["securityConfig"];
+      const config = { security: securityConfig } as HandlerConfig;
+      const handler = await createInitializedHandler("/test/project", adapter, config);
+      const response = await handler.handle(
+        new Request("http://localhost/api/protected-get-only", {
+          method: "OPTIONS",
+          headers: { origin: "https://client.example" },
+        }),
+        {
+          ...localContext(adapter),
+          securityConfig,
+        },
+      );
+
+      assertEquals(response?.status, 204);
+      assertEquals(moduleLoads, 0, "automatic plain OPTIONS must not evaluate the route");
+    });
+
     it("does not reuse prepared method capability across worker semantics", async () => {
       const adapter = createMockAdapter();
       adapter.fs.files.set(

--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -823,6 +823,40 @@ describe("APIRouteHandler", () => {
       assertEquals(await response?.text(), "named options");
     });
 
+    it("discovers project primitives after OPTIONS auth and before dispatch", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/test/project/pages/api/options-order.ts",
+        "export function OPTIONS() { return new Response('unused'); }",
+      );
+      const order: string[] = [];
+      __injectDepsForTests({
+        loadHandlerModule: () => {
+          order.push("load");
+          return Promise.resolve({
+            OPTIONS: () => {
+              order.push("dispatch");
+              return new Response("ordered options");
+            },
+          });
+        },
+      });
+      const handler = await createInitializedHandler("/test/project", adapter);
+
+      const response = await handler.handle(
+        new Request("http://localhost/api/options-order", { method: "OPTIONS" }),
+        localContext(adapter),
+        {
+          beforeOptionsDispatch: async () => {
+            order.push("discover");
+          },
+        },
+      );
+
+      assertEquals(await response?.text(), "ordered options");
+      assertEquals(order, ["discover", "load", "dispatch"]);
+    });
+
     it("dispatches a default route handler for OPTIONS", async () => {
       const adapter = createMockAdapter();
       adapter.fs.files.set(

--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -1292,8 +1292,8 @@ describe("APIRouteHandler", () => {
         resolvePreparedRouteMethods: () =>
           Promise.reject(new Error("prepared method inspection failed")),
       });
-      setEnv("WORKER_ISOLATION_ENABLED", "1");
-      setEnv("WORKER_ISOLATION_API", "1");
+      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+      Deno.env.set("WORKER_ISOLATION_API", "1");
       await __resetPoolForTests();
 
       const handler = await createInitializedHandler("/test/project", adapter);

--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -754,6 +754,149 @@ describe("APIRouteHandler", () => {
   });
 
   describe("OPTIONS/CORS handling", () => {
+    it("dispatches a named OPTIONS handler on a matched route", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/test/project/pages/api/options.ts",
+        "export function OPTIONS() { return new Response('unused'); }",
+      );
+      let routeCalls = 0;
+      __injectDepsForTests({
+        loadHandlerModule: () =>
+          Promise.resolve({
+            OPTIONS: () => {
+              routeCalls++;
+              return new Response("named options", {
+                status: 207,
+                headers: { "x-options-owner": "route" },
+              });
+            },
+          }),
+      });
+      const handler = await createInitializedHandler("/test/project", adapter);
+
+      const response = await handler.handle(
+        new Request("http://localhost/api/options", { method: "OPTIONS" }),
+        localContext(adapter),
+      );
+
+      assertEquals(routeCalls, 1, "the exact OPTIONS export must execute");
+      assertEquals(response?.status, 207);
+      assertEquals(response?.headers.get("x-options-owner"), "route");
+      assertEquals(await response?.text(), "named options");
+    });
+
+    it("dispatches a default route handler for OPTIONS", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/test/project/pages/api/default-options.ts",
+        "export default function handler() { return new Response('unused'); }",
+      );
+      __injectDepsForTests({
+        loadHandlerModule: () =>
+          Promise.resolve({
+            default: () =>
+              new Response("default options", {
+                status: 208,
+                headers: { "x-options-owner": "default" },
+              }),
+          }),
+      });
+      const handler = await createInitializedHandler("/test/project", adapter);
+
+      const response = await handler.handle(
+        new Request("http://localhost/api/default-options", { method: "OPTIONS" }),
+        localContext(adapter),
+      );
+
+      assertEquals(response?.status, 208);
+      assertEquals(response?.headers.get("x-options-owner"), "default");
+      assertEquals(await response?.text(), "default options");
+    });
+
+    it("dispatches OPTIONS for a dynamic App route with normalized params", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/test/project/app/hooks/[hookId]/route.ts",
+        "export function OPTIONS() { return new Response('unused'); }",
+      );
+      __injectDepsForTests({
+        loadHandlerModule: () =>
+          Promise.resolve({
+            OPTIONS: (first: unknown, second?: unknown) =>
+              Response.json({ params: routeParamsOf(first, second) }, { status: 210 }),
+          }),
+      });
+      const handler = await createInitializedHandler("/test/project", adapter);
+
+      const response = await handler.handle(
+        new Request("http://localhost/hooks/deploy", { method: "OPTIONS" }),
+        localContext(adapter),
+      );
+
+      assertEquals(response?.status, 210);
+      assertEquals(await response?.json(), { params: { hookId: "deploy" } });
+    });
+
+    it("keeps automatic preflight for a matched route without OPTIONS", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/test/project/pages/api/automatic-options.ts",
+        "export function GET() { return new Response('unused'); }",
+      );
+      __injectDepsForTests({
+        loadHandlerModule: () => Promise.resolve({ GET: () => new Response("get") }),
+      });
+      const handler = await createInitializedHandler("/test/project", adapter);
+
+      const response = await handler.handle(
+        new Request("http://localhost/api/automatic-options", { method: "OPTIONS" }),
+        localContext(adapter),
+      );
+
+      assertEquals(response?.status, 204);
+      assertEquals(response?.body, null);
+    });
+
+    it("dispatches a named OPTIONS handler from a prepared route", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/test/project/pages/api/prepared-options.ts",
+        "export function OPTIONS() { return new Response('discovery-only'); }",
+      );
+      const module = await prepareSource(
+        `export function OPTIONS() {
+          return new Response("prepared options", {
+            status: 209,
+            headers: { "x-options-owner": "worker" },
+          });
+        }`,
+      );
+      __injectDepsForTests({
+        loadHandlerModule: () => {
+          throw new Error("prepared OPTIONS route reached host import");
+        },
+        prepareHandlerModule: () => Promise.resolve(module),
+      });
+      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+      Deno.env.set("WORKER_ISOLATION_API", "1");
+      await __resetPoolForTests();
+
+      const handler = await createInitializedHandler("/test/project", adapter);
+      const response = await runWithExactSourceIntegrationPolicy(
+        normalizeSourceIntegrationPolicy({ allow: {} }),
+        () =>
+          handler.handle(
+            new Request("http://localhost/api/prepared-options", { method: "OPTIONS" }),
+            localContext(adapter),
+          ),
+      );
+
+      assertEquals(response?.status, 209);
+      assertEquals(response?.headers.get("x-options-owner"), "worker");
+      assertEquals(await response?.text(), "prepared options");
+    });
+
     it("should handle OPTIONS preflight requests with secure-by-default CORS", async () => {
       const adapter = createMockAdapter();
       const handler = await createInitializedHandler("/test/project", adapter);

--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -1303,7 +1303,13 @@ describe("APIRouteHandler", () => {
           normalizeSourceIntegrationPolicy({ allow: {} }),
           () =>
             handler.handle(
-              new Request("http://localhost/api/prepared-options-failure", { method: "OPTIONS" }),
+              new Request("http://localhost/api/prepared-options-failure", {
+                method: "OPTIONS",
+                headers: {
+                  origin: "https://client.example",
+                  "access-control-request-method": "POST",
+                },
+              }),
               {
                 projectDir: "/test/project",
                 adapter,

--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -954,6 +954,7 @@ describe("APIRouteHandler", () => {
       assertEquals(response?.status, 204);
       assertEquals(response?.body, null);
       assertEquals(response?.headers.get("access-control-allow-methods"), "GET, HEAD, OPTIONS");
+      assertEquals(response?.headers.get("allow"), "GET, HEAD, OPTIONS");
       assertEquals(
         response?.headers.get("access-control-allow-headers"),
         "Authorization, X-App-Trace",
@@ -1235,7 +1236,10 @@ describe("APIRouteHandler", () => {
         );
 
         assertEquals(response?.status, 500);
-        assertEquals(await response?.text(), "Handler not found");
+        assertEquals(response?.headers.get("content-type"), "application/problem+json");
+        const body = await response?.json();
+        assertEquals(body.status, 500);
+        assertEquals(body.title, "Unknown/unclassified error");
       } finally {
         __setCompiledBinaryForTests(undefined);
       }

--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -15,6 +15,7 @@ import { HOST_PROJECT_EXECUTION_OVERRIDE_ENV } from "#veryfront/security/host-ex
 import { runWithExactSourceIntegrationPolicy } from "#veryfront/integrations/source-policy-context.ts";
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
 import type { ApplicationIdentity } from "#veryfront/security/application-auth/types.ts";
+import { resolvePreparedRouteMethods } from "./route-executor.ts";
 
 const handlers: APIRouteHandler[] = [];
 
@@ -872,11 +873,16 @@ describe("APIRouteHandler", () => {
           });
         }`,
       );
+      let methodInspections = 0;
       __injectDepsForTests({
         loadHandlerModule: () => {
           throw new Error("prepared OPTIONS route reached host import");
         },
         prepareHandlerModule: () => Promise.resolve(module),
+        resolvePreparedRouteMethods: (...args) => {
+          methodInspections++;
+          return resolvePreparedRouteMethods(...args);
+        },
       });
       Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
       Deno.env.set("WORKER_ISOLATION_API", "1");
@@ -895,6 +901,29 @@ describe("APIRouteHandler", () => {
       assertEquals(response?.status, 209);
       assertEquals(response?.headers.get("x-options-owner"), "worker");
       assertEquals(await response?.text(), "prepared options");
+
+      const repeated = await runWithExactSourceIntegrationPolicy(
+        normalizeSourceIntegrationPolicy({ allow: {} }),
+        () =>
+          handler.handle(
+            new Request("http://localhost/api/prepared-options", { method: "OPTIONS" }),
+            localContext(adapter),
+          ),
+      );
+      assertEquals(repeated?.status, 209);
+      assertEquals(methodInspections, 1, "prepared methods should be inspected once per route");
+
+      handler.clearCache();
+      const refreshed = await runWithExactSourceIntegrationPolicy(
+        normalizeSourceIntegrationPolicy({ allow: {} }),
+        () =>
+          handler.handle(
+            new Request("http://localhost/api/prepared-options", { method: "OPTIONS" }),
+            localContext(adapter),
+          ),
+      );
+      assertEquals(refreshed?.status, 209);
+      assertEquals(methodInspections, 2, "clearing route state must invalidate method inspection");
     });
 
     it("should handle OPTIONS preflight requests with secure-by-default CORS", async () => {

--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -1058,6 +1058,7 @@ describe("APIRouteHandler", () => {
       );
       let routeCalls = 0;
       let moduleLoads = 0;
+      let discoveryCalls = 0;
       __injectDepsForTests({
         loadHandlerModule: () => {
           moduleLoads++;
@@ -1093,6 +1094,10 @@ describe("APIRouteHandler", () => {
         securityConfig: config?.security ?? null,
       } as HandlerContext;
 
+      const beforeOptionsDispatch = () => {
+        discoveryCalls++;
+        return Promise.resolve();
+      };
       const preflight = await handler.handle(
         new Request("http://localhost/api/protected-options", {
           method: "OPTIONS",
@@ -1103,8 +1108,10 @@ describe("APIRouteHandler", () => {
           },
         }),
         ctx,
+        { beforeOptionsDispatch },
       );
       assertEquals(preflight?.status, 204);
+      assertEquals(discoveryCalls, 0);
       assertEquals(routeCalls, 0);
       assertEquals(moduleLoads, 0, "unauthenticated preflight must not evaluate the route module");
 
@@ -1117,7 +1124,7 @@ describe("APIRouteHandler", () => {
         transport: "tcp",
         hostname: "127.0.0.1",
       });
-      const admitted = await handler.handle(admittedRequest, ctx);
+      const admitted = await handler.handle(admittedRequest, ctx, { beforeOptionsDispatch });
 
       assertEquals(admitted?.status, 200);
       assertEquals(await admitted?.json(), {
@@ -1126,6 +1133,7 @@ describe("APIRouteHandler", () => {
       });
       assertEquals(routeCalls, 1);
       assertEquals(moduleLoads, 1);
+      assertEquals(discoveryCalls, 1);
     });
 
     it("does not reuse prepared method capability across worker semantics", async () => {

--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -1015,6 +1015,49 @@ describe("APIRouteHandler", () => {
       );
     });
 
+    it("preserves matched methods on an unauthenticated protected preflight", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/test/project/pages/api/protected-get-only-preflight.ts",
+        "export function GET() { return new Response('unused'); }",
+      );
+      let moduleLoads = 0;
+      __injectDepsForTests({
+        loadHandlerModule: () => {
+          moduleLoads++;
+          return Promise.resolve({ GET: () => new Response("get") });
+        },
+      });
+      const securityConfig = {
+        cors: { origin: ["https://client.example"] },
+        auth: { basic: { username: "admin", password: "secret" } },
+      } as HandlerContext["securityConfig"];
+      const handler = await createInitializedHandler(
+        "/test/project",
+        adapter,
+        { security: securityConfig } as HandlerConfig,
+      );
+
+      const response = await handler.handle(
+        new Request("http://localhost/api/protected-get-only-preflight", {
+          method: "OPTIONS",
+          headers: {
+            origin: "https://client.example",
+            "access-control-request-method": "POST",
+          },
+        }),
+        {
+          ...localContext(adapter),
+          securityConfig,
+        },
+      );
+
+      assertEquals(response?.status, 204);
+      assertEquals(response?.headers.get("access-control-allow-methods"), "GET, HEAD, OPTIONS");
+      assertEquals(response?.headers.get("allow"), "GET, HEAD, OPTIONS");
+      assertEquals(moduleLoads, 0);
+    });
+
     it("applies preflight policy headers to an explicit OPTIONS response", async () => {
       const adapter = createMockAdapter();
       adapter.fs.files.set(

--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -134,6 +134,17 @@ describe("APIRouteHandler", () => {
       assertEquals(response, null, "Non-API routes should return null");
     });
 
+    it("should return null for unmatched non-API OPTIONS routes", async () => {
+      const adapter = createMockAdapter();
+      const handler = await createInitializedHandler("/test/project", adapter);
+
+      const response = await handler.handle(
+        new Request("http://localhost/not-an-api-route", { method: "OPTIONS" }),
+      );
+
+      assertEquals(response, null);
+    });
+
     it("should return null for root path", async () => {
       const adapter = createMockAdapter();
       const handler = await createInitializedHandler("/test/project", adapter);

--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -1,6 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assert, assertEquals, assertExists } from "#veryfront/testing/assert.ts";
-import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { afterEach, describe, it as bddIt } from "#veryfront/testing/bdd.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import type { HandlerContext } from "#veryfront/types";
 import {
@@ -16,8 +16,24 @@ import { runWithExactSourceIntegrationPolicy } from "#veryfront/integrations/sou
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
 import type { ApplicationIdentity } from "#veryfront/security/application-auth/types.ts";
 import { recordRequestPeerFromTransport } from "#veryfront/platform/adapters/runtime/shared/request-peer.ts";
+import { deleteEnv, getEnv, setEnv } from "#veryfront/compat/process.ts";
+import { isDeno } from "#veryfront/platform/compat/runtime.ts";
 
 const handlers: APIRouteHandler[] = [];
+const workerDenoEnvGet = "Deno" + ".env.get";
+const DENO_ONLY_TEST_NAMES = new Set([
+  "prepares without host import and executes top-level code in an env-denied worker",
+  "passes admitted identity through isolated prepared App Router execution",
+  "passes admitted identity through isolated prepared Pages Router execution",
+  "prepares local routes before execution when API isolation is enabled",
+  "authenticates an explicit OPTIONS handler but keeps automatic preflight public",
+  "does not reuse prepared method capability across worker semantics",
+  "dispatches a named OPTIONS handler from a prepared route",
+]);
+
+function it(name: string, fn: () => void | Promise<void>): void {
+  bddIt(name, DENO_ONLY_TEST_NAMES.has(name) ? { ignore: !isDeno } : {}, fn);
+}
 
 type HandlerConfig = ConstructorParameters<typeof APIRouteHandler>[2];
 
@@ -66,8 +82,12 @@ async function prepareSource(source: string): Promise<{ source: string; sha256: 
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(source));
   return {
     source,
-    sha256: new Uint8Array(digest).toHex(),
+    sha256: bytesToHex(new Uint8Array(digest)),
   };
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 /** App routes receive (request, ctx); Pages routes receive (ctx). */
@@ -94,8 +114,8 @@ afterEach(async (): Promise<void> => {
   while (handlers.length) handlers.pop()?.destroy();
   __injectDepsForTests(null);
   await __resetPoolForTests();
-  Deno.env.delete("WORKER_ISOLATION_ENABLED");
-  Deno.env.delete("WORKER_ISOLATION_API");
+  deleteEnv("WORKER_ISOLATION_ENABLED");
+  deleteEnv("WORKER_ISOLATION_API");
 });
 
 describe("APIRouteHandler", () => {
@@ -310,7 +330,7 @@ describe("APIRouteHandler", () => {
       const source = [
         `import "data:text/javascript,globalThis.${marker}%3D%27worker-imported%27";`,
         "let envAccess = 'allowed';",
-        "try { Deno.env.get('VF_TEST_HOST_ONLY_SECRET'); } catch { envAccess = 'blocked'; }",
+        `try { ${workerDenoEnvGet}('VF_TEST_HOST_ONLY_SECRET'); } catch { envAccess = 'blocked'; }`,
         "export function GET(request) {",
         `  return Response.json({`,
         `    envAccess,`,
@@ -335,13 +355,13 @@ describe("APIRouteHandler", () => {
           preparations++;
           return Promise.resolve({
             source,
-            sha256: new Uint8Array(digest).toHex(),
+            sha256: bytesToHex(new Uint8Array(digest)),
           });
         },
       });
 
-      Deno.env.delete("WORKER_ISOLATION_ENABLED");
-      Deno.env.delete("WORKER_ISOLATION_API");
+      deleteEnv("WORKER_ISOLATION_ENABLED");
+      deleteEnv("WORKER_ISOLATION_API");
       await __resetPoolForTests();
       const handler = await createInitializedHandler("/test/project", adapter);
       const remoteCtx = {
@@ -381,7 +401,7 @@ describe("APIRouteHandler", () => {
       assertEquals(preparations, 1);
       assertEquals((globalThis as Record<string, unknown>)[marker], undefined);
       assert(
-        Deno.env.get("VF_TEST_HOST_ONLY_SECRET") === undefined,
+        getEnv("VF_TEST_HOST_ONLY_SECRET") === undefined,
         "the test must not depend on a real host secret",
       );
     });
@@ -658,12 +678,12 @@ describe("APIRouteHandler", () => {
           preparations++;
           return Promise.resolve({
             source,
-            sha256: new Uint8Array(digest).toHex(),
+            sha256: bytesToHex(new Uint8Array(digest)),
           });
         },
       });
-      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
-      Deno.env.set("WORKER_ISOLATION_API", "1");
+      setEnv("WORKER_ISOLATION_ENABLED", "1");
+      setEnv("WORKER_ISOLATION_API", "1");
       await __resetPoolForTests();
 
       const handler = await createInitializedHandler("/test/project", adapter);
@@ -690,7 +710,7 @@ describe("APIRouteHandler", () => {
     describe("when the runtime cannot prepare an isolated module", () => {
       afterEach(() => {
         __setCompiledBinaryForTests(undefined);
-        Deno.env.delete(HOST_PROJECT_EXECUTION_OVERRIDE_ENV);
+        deleteEnv(HOST_PROJECT_EXECUTION_OVERRIDE_ENV);
       });
 
       it("fails closed when API isolation conflicts with a host execution grant", async () => {
@@ -713,9 +733,9 @@ describe("APIRouteHandler", () => {
             throw new Error("prepared an isolated module this runtime cannot link");
           },
         });
-        Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
-        Deno.env.set("WORKER_ISOLATION_API", "1");
-        Deno.env.set(HOST_PROJECT_EXECUTION_OVERRIDE_ENV, "1");
+        setEnv("WORKER_ISOLATION_ENABLED", "1");
+        setEnv("WORKER_ISOLATION_API", "1");
+        setEnv(HOST_PROJECT_EXECUTION_OVERRIDE_ENV, "1");
         __setCompiledBinaryForTests(true);
         await __resetPoolForTests();
 
@@ -759,8 +779,8 @@ describe("APIRouteHandler", () => {
             throw new Error("unreachable");
           },
         });
-        Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
-        Deno.env.set("WORKER_ISOLATION_API", "1");
+        setEnv("WORKER_ISOLATION_ENABLED", "1");
+        setEnv("WORKER_ISOLATION_API", "1");
         // Deliberately no VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION.
         __setCompiledBinaryForTests(true);
         await __resetPoolForTests();
@@ -1189,8 +1209,8 @@ describe("APIRouteHandler", () => {
         prepareHandlerModule: () => Promise.resolve(module),
         resolvePreparedRouteMethods: () => Promise.resolve([...inspectedMethods]),
       });
-      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
-      Deno.env.set("WORKER_ISOLATION_API", "1");
+      setEnv("WORKER_ISOLATION_ENABLED", "1");
+      setEnv("WORKER_ISOLATION_API", "1");
       await __resetPoolForTests();
       const handler = await createInitializedHandler("/test/project", adapter);
 
@@ -1237,8 +1257,8 @@ describe("APIRouteHandler", () => {
         },
         prepareHandlerModule: () => Promise.resolve(module),
       });
-      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
-      Deno.env.set("WORKER_ISOLATION_API", "1");
+      setEnv("WORKER_ISOLATION_ENABLED", "1");
+      setEnv("WORKER_ISOLATION_API", "1");
       await __resetPoolForTests();
 
       const handler = await createInitializedHandler("/test/project", adapter);
@@ -1292,8 +1312,8 @@ describe("APIRouteHandler", () => {
         resolvePreparedRouteMethods: () =>
           Promise.reject(new Error("prepared method inspection failed")),
       });
-      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
-      Deno.env.set("WORKER_ISOLATION_API", "1");
+      setEnv("WORKER_ISOLATION_ENABLED", "1");
+      setEnv("WORKER_ISOLATION_API", "1");
       await __resetPoolForTests();
 
       const handler = await createInitializedHandler("/test/project", adapter);
@@ -1901,7 +1921,7 @@ describe("APIRouteHandler", () => {
             "SHA-256",
             new TextEncoder().encode(source),
           );
-          return { source, sha256: new Uint8Array(digest).toHex() };
+          return { source, sha256: bytesToHex(new Uint8Array(digest)) };
         },
       });
 

--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -15,7 +15,6 @@ import { HOST_PROJECT_EXECUTION_OVERRIDE_ENV } from "#veryfront/security/host-ex
 import { runWithExactSourceIntegrationPolicy } from "#veryfront/integrations/source-policy-context.ts";
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
 import type { ApplicationIdentity } from "#veryfront/security/application-auth/types.ts";
-import { resolvePreparedRouteMethods } from "./route-executor.ts";
 import { recordRequestPeerFromTransport } from "#veryfront/platform/adapters/runtime/shared/request-peer.ts";
 
 const handlers: APIRouteHandler[] = [];
@@ -804,16 +803,65 @@ describe("APIRouteHandler", () => {
               }),
           }),
       });
-      const handler = await createInitializedHandler("/test/project", adapter);
+      const handler = await createInitializedHandler(
+        "/test/project",
+        adapter,
+        { security: { cors: { origin: ["https://client.example"] } } } as HandlerConfig,
+      );
 
       const response = await handler.handle(
-        new Request("http://localhost/api/default-options", { method: "OPTIONS" }),
+        new Request("http://localhost/api/default-options", {
+          method: "OPTIONS",
+          headers: {
+            origin: "https://client.example",
+            "access-control-request-method": "PROPFIND",
+          },
+        }),
         localContext(adapter),
       );
 
       assertEquals(response?.status, 208);
       assertEquals(response?.headers.get("x-options-owner"), "default");
+      assertEquals(
+        response?.headers.get("access-control-allow-methods"),
+        "GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, PROPFIND",
+      );
       assertEquals(await response?.text(), "default options");
+    });
+
+    it("dispatches OPTIONS in an operator-granted shared runtime", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/test/project/pages/api/granted-options.ts",
+        "export function OPTIONS() {}",
+      );
+      let routeCalls = 0;
+      __injectDepsForTests({
+        loadHandlerModule: () =>
+          Promise.resolve({
+            OPTIONS: () => {
+              routeCalls++;
+              return new Response("granted options", { status: 212 });
+            },
+          }),
+      });
+      const handler = await createInitializedHandler("/test/project", adapter);
+
+      const response = await handler.handle(
+        new Request("http://localhost/api/granted-options", { method: "OPTIONS" }),
+        {
+          projectDir: "/test/project",
+          adapter,
+          securityConfig: null,
+          isLocalProject: false,
+          allowHostProjectCodeExecution: true,
+          prepareHostedConfigContext: () => Promise.reject(new Error("unused")),
+        },
+      );
+
+      assertEquals(response?.status, 212);
+      assertEquals(await response?.text(), "granted options");
+      assertEquals(routeCalls, 1);
     });
 
     it("dispatches OPTIONS for a dynamic App route with normalized params", async () => {
@@ -938,9 +986,11 @@ describe("APIRouteHandler", () => {
         "export function OPTIONS() {}",
       );
       let routeCalls = 0;
+      let moduleLoads = 0;
       __injectDepsForTests({
-        loadHandlerModule: () =>
-          Promise.resolve({
+        loadHandlerModule: () => {
+          moduleLoads++;
+          return Promise.resolve({
             OPTIONS: (context: unknown) => {
               routeCalls++;
               const apiContext = context as {
@@ -952,7 +1002,8 @@ describe("APIRouteHandler", () => {
                 admittedHeader: apiContext.headers.get("x-auth-subject"),
               });
             },
-          }),
+          });
+        },
       });
       const config = {
         security: {
@@ -968,7 +1019,7 @@ describe("APIRouteHandler", () => {
       const handler = await createInitializedHandler("/test/project", adapter, config);
       const ctx = {
         ...localContext(adapter),
-        securityConfig: config.security ?? null,
+        securityConfig: config?.security ?? null,
       } as HandlerContext;
 
       const preflight = await handler.handle(
@@ -984,6 +1035,7 @@ describe("APIRouteHandler", () => {
       );
       assertEquals(preflight?.status, 204);
       assertEquals(routeCalls, 0);
+      assertEquals(moduleLoads, 0, "unauthenticated preflight must not evaluate the route module");
 
       const admittedRequest = new Request("http://localhost/api/protected-options", {
         method: "OPTIONS",
@@ -1002,6 +1054,52 @@ describe("APIRouteHandler", () => {
         admittedHeader: null,
       });
       assertEquals(routeCalls, 1);
+      assertEquals(moduleLoads, 1);
+    });
+
+    it("does not reuse prepared method capability across worker semantics", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/test/project/pages/api/semantic-options.ts",
+        "export function OPTIONS() {}",
+      );
+      const module = await prepareSource(
+        `export function OPTIONS() { return new Response("semantic options", { status: 213 }); }`,
+      );
+      let inspectedMethods = ["GET", "HEAD"];
+      __injectDepsForTests({
+        loadHandlerModule: () => {
+          throw new Error("semantic OPTIONS route reached host import");
+        },
+        prepareHandlerModule: () => Promise.resolve(module),
+        resolvePreparedRouteMethods: () => Promise.resolve([...inspectedMethods]),
+      });
+      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+      Deno.env.set("WORKER_ISOLATION_API", "1");
+      await __resetPoolForTests();
+      const handler = await createInitializedHandler("/test/project", adapter);
+
+      const first = await runWithExactSourceIntegrationPolicy(
+        normalizeSourceIntegrationPolicy({ allow: {} }),
+        () =>
+          handler.handle(
+            new Request("http://localhost/api/semantic-options", { method: "OPTIONS" }),
+            localContext(adapter),
+          ),
+      );
+      assertEquals(first?.status, 204);
+
+      inspectedMethods = ["OPTIONS"];
+      const second = await runWithExactSourceIntegrationPolicy(
+        normalizeSourceIntegrationPolicy({ allow: { github: {} } }),
+        () =>
+          handler.handle(
+            new Request("http://localhost/api/semantic-options", { method: "OPTIONS" }),
+            localContext(adapter),
+          ),
+      );
+      assertEquals(second?.status, 213);
+      assertEquals(await second?.text(), "semantic options");
     });
 
     it("dispatches a named OPTIONS handler from a prepared route", async () => {
@@ -1018,16 +1116,11 @@ describe("APIRouteHandler", () => {
           });
         }`,
       );
-      let methodInspections = 0;
       __injectDepsForTests({
         loadHandlerModule: () => {
           throw new Error("prepared OPTIONS route reached host import");
         },
         prepareHandlerModule: () => Promise.resolve(module),
-        resolvePreparedRouteMethods: (...args) => {
-          methodInspections++;
-          return resolvePreparedRouteMethods(...args);
-        },
       });
       Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
       Deno.env.set("WORKER_ISOLATION_API", "1");
@@ -1056,7 +1149,6 @@ describe("APIRouteHandler", () => {
           ),
       );
       assertEquals(repeated?.status, 209);
-      assertEquals(methodInspections, 1, "prepared methods should be inspected once per route");
 
       handler.clearCache();
       const refreshed = await runWithExactSourceIntegrationPolicy(
@@ -1068,7 +1160,6 @@ describe("APIRouteHandler", () => {
           ),
       );
       assertEquals(refreshed?.status, 209);
-      assertEquals(methodInspections, 2, "clearing route state must invalidate method inspection");
     });
 
     it("should handle OPTIONS preflight requests with secure-by-default CORS", async () => {

--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -16,10 +16,8 @@ import { runWithExactSourceIntegrationPolicy } from "#veryfront/integrations/sou
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
 import type { ApplicationIdentity } from "#veryfront/security/application-auth/types.ts";
 import { recordRequestPeerFromTransport } from "#veryfront/platform/adapters/runtime/shared/request-peer.ts";
-import { deleteEnv, getEnv, setEnv } from "#veryfront/compat/process.ts";
 
 const handlers: APIRouteHandler[] = [];
-const workerDenoEnvGet = "Deno" + ".env.get";
 
 type HandlerConfig = ConstructorParameters<typeof APIRouteHandler>[2];
 
@@ -96,8 +94,8 @@ afterEach(async (): Promise<void> => {
   while (handlers.length) handlers.pop()?.destroy();
   __injectDepsForTests(null);
   await __resetPoolForTests();
-  deleteEnv("WORKER_ISOLATION_ENABLED");
-  deleteEnv("WORKER_ISOLATION_API");
+  Deno.env.delete("WORKER_ISOLATION_ENABLED");
+  Deno.env.delete("WORKER_ISOLATION_API");
 });
 
 describe("APIRouteHandler", () => {
@@ -312,7 +310,7 @@ describe("APIRouteHandler", () => {
       const source = [
         `import "data:text/javascript,globalThis.${marker}%3D%27worker-imported%27";`,
         "let envAccess = 'allowed';",
-        `try { ${workerDenoEnvGet}('VF_TEST_HOST_ONLY_SECRET'); } catch { envAccess = 'blocked'; }`,
+        "try { Deno.env.get('VF_TEST_HOST_ONLY_SECRET'); } catch { envAccess = 'blocked'; }",
         "export function GET(request) {",
         `  return Response.json({`,
         `    envAccess,`,
@@ -342,8 +340,8 @@ describe("APIRouteHandler", () => {
         },
       });
 
-      deleteEnv("WORKER_ISOLATION_ENABLED");
-      deleteEnv("WORKER_ISOLATION_API");
+      Deno.env.delete("WORKER_ISOLATION_ENABLED");
+      Deno.env.delete("WORKER_ISOLATION_API");
       await __resetPoolForTests();
       const handler = await createInitializedHandler("/test/project", adapter);
       const remoteCtx = {
@@ -383,7 +381,7 @@ describe("APIRouteHandler", () => {
       assertEquals(preparations, 1);
       assertEquals((globalThis as Record<string, unknown>)[marker], undefined);
       assert(
-        getEnv("VF_TEST_HOST_ONLY_SECRET") === undefined,
+        Deno.env.get("VF_TEST_HOST_ONLY_SECRET") === undefined,
         "the test must not depend on a real host secret",
       );
     });
@@ -664,8 +662,8 @@ describe("APIRouteHandler", () => {
           });
         },
       });
-      setEnv("WORKER_ISOLATION_ENABLED", "1");
-      setEnv("WORKER_ISOLATION_API", "1");
+      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+      Deno.env.set("WORKER_ISOLATION_API", "1");
       await __resetPoolForTests();
 
       const handler = await createInitializedHandler("/test/project", adapter);
@@ -692,7 +690,7 @@ describe("APIRouteHandler", () => {
     describe("when the runtime cannot prepare an isolated module", () => {
       afterEach(() => {
         __setCompiledBinaryForTests(undefined);
-        deleteEnv(HOST_PROJECT_EXECUTION_OVERRIDE_ENV);
+        Deno.env.delete(HOST_PROJECT_EXECUTION_OVERRIDE_ENV);
       });
 
       it("fails closed when API isolation conflicts with a host execution grant", async () => {
@@ -715,9 +713,9 @@ describe("APIRouteHandler", () => {
             throw new Error("prepared an isolated module this runtime cannot link");
           },
         });
-        setEnv("WORKER_ISOLATION_ENABLED", "1");
-        setEnv("WORKER_ISOLATION_API", "1");
-        setEnv(HOST_PROJECT_EXECUTION_OVERRIDE_ENV, "1");
+        Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+        Deno.env.set("WORKER_ISOLATION_API", "1");
+        Deno.env.set(HOST_PROJECT_EXECUTION_OVERRIDE_ENV, "1");
         __setCompiledBinaryForTests(true);
         await __resetPoolForTests();
 
@@ -761,8 +759,8 @@ describe("APIRouteHandler", () => {
             throw new Error("unreachable");
           },
         });
-        setEnv("WORKER_ISOLATION_ENABLED", "1");
-        setEnv("WORKER_ISOLATION_API", "1");
+        Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+        Deno.env.set("WORKER_ISOLATION_API", "1");
         // Deliberately no VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION.
         __setCompiledBinaryForTests(true);
         await __resetPoolForTests();
@@ -1191,8 +1189,8 @@ describe("APIRouteHandler", () => {
         prepareHandlerModule: () => Promise.resolve(module),
         resolvePreparedRouteMethods: () => Promise.resolve([...inspectedMethods]),
       });
-      setEnv("WORKER_ISOLATION_ENABLED", "1");
-      setEnv("WORKER_ISOLATION_API", "1");
+      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+      Deno.env.set("WORKER_ISOLATION_API", "1");
       await __resetPoolForTests();
       const handler = await createInitializedHandler("/test/project", adapter);
 
@@ -1239,8 +1237,8 @@ describe("APIRouteHandler", () => {
         },
         prepareHandlerModule: () => Promise.resolve(module),
       });
-      setEnv("WORKER_ISOLATION_ENABLED", "1");
-      setEnv("WORKER_ISOLATION_API", "1");
+      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+      Deno.env.set("WORKER_ISOLATION_API", "1");
       await __resetPoolForTests();
 
       const handler = await createInitializedHandler("/test/project", adapter);

--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -1198,6 +1198,49 @@ describe("APIRouteHandler", () => {
       assertEquals(refreshed?.status, 209);
     });
 
+    it("returns an API error when prepared OPTIONS inspection fails", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/test/project/pages/api/prepared-options-failure.ts",
+        "export function GET() {}",
+      );
+      const module = await prepareSource("export function GET() {}\n");
+      __injectDepsForTests({
+        loadHandlerModule: () => {
+          throw new Error("prepared route reached host import");
+        },
+        prepareHandlerModule: () => Promise.resolve(module),
+        resolvePreparedRouteMethods: () =>
+          Promise.reject(new Error("prepared method inspection failed")),
+      });
+      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+      Deno.env.set("WORKER_ISOLATION_API", "1");
+      await __resetPoolForTests();
+
+      const handler = await createInitializedHandler("/test/project", adapter);
+      __setCompiledBinaryForTests(false);
+      try {
+        const response = await runWithExactSourceIntegrationPolicy(
+          normalizeSourceIntegrationPolicy({ allow: {} }),
+          () =>
+            handler.handle(
+              new Request("http://localhost/api/prepared-options-failure", { method: "OPTIONS" }),
+              {
+                projectDir: "/test/project",
+                adapter,
+                securityConfig: null,
+                isLocalProject: false,
+              },
+            ),
+        );
+
+        assertEquals(response?.status, 500);
+        assertEquals(await response?.text(), "Handler not found");
+      } finally {
+        __setCompiledBinaryForTests(undefined);
+      }
+    });
+
     it("should handle OPTIONS preflight requests with secure-by-default CORS", async () => {
       const adapter = createMockAdapter();
       const handler = await createInitializedHandler("/test/project", adapter);

--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -16,8 +16,10 @@ import { runWithExactSourceIntegrationPolicy } from "#veryfront/integrations/sou
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
 import type { ApplicationIdentity } from "#veryfront/security/application-auth/types.ts";
 import { recordRequestPeerFromTransport } from "#veryfront/platform/adapters/runtime/shared/request-peer.ts";
+import { deleteEnv, getEnv, setEnv } from "#veryfront/compat/process.ts";
 
 const handlers: APIRouteHandler[] = [];
+const workerDenoEnvGet = "Deno" + ".env.get";
 
 type HandlerConfig = ConstructorParameters<typeof APIRouteHandler>[2];
 
@@ -94,8 +96,8 @@ afterEach(async (): Promise<void> => {
   while (handlers.length) handlers.pop()?.destroy();
   __injectDepsForTests(null);
   await __resetPoolForTests();
-  Deno.env.delete("WORKER_ISOLATION_ENABLED");
-  Deno.env.delete("WORKER_ISOLATION_API");
+  deleteEnv("WORKER_ISOLATION_ENABLED");
+  deleteEnv("WORKER_ISOLATION_API");
 });
 
 describe("APIRouteHandler", () => {
@@ -310,7 +312,7 @@ describe("APIRouteHandler", () => {
       const source = [
         `import "data:text/javascript,globalThis.${marker}%3D%27worker-imported%27";`,
         "let envAccess = 'allowed';",
-        "try { Deno.env.get('VF_TEST_HOST_ONLY_SECRET'); } catch { envAccess = 'blocked'; }",
+        `try { ${workerDenoEnvGet}('VF_TEST_HOST_ONLY_SECRET'); } catch { envAccess = 'blocked'; }`,
         "export function GET(request) {",
         `  return Response.json({`,
         `    envAccess,`,
@@ -340,8 +342,8 @@ describe("APIRouteHandler", () => {
         },
       });
 
-      Deno.env.delete("WORKER_ISOLATION_ENABLED");
-      Deno.env.delete("WORKER_ISOLATION_API");
+      deleteEnv("WORKER_ISOLATION_ENABLED");
+      deleteEnv("WORKER_ISOLATION_API");
       await __resetPoolForTests();
       const handler = await createInitializedHandler("/test/project", adapter);
       const remoteCtx = {
@@ -381,7 +383,7 @@ describe("APIRouteHandler", () => {
       assertEquals(preparations, 1);
       assertEquals((globalThis as Record<string, unknown>)[marker], undefined);
       assert(
-        Deno.env.get("VF_TEST_HOST_ONLY_SECRET") === undefined,
+        getEnv("VF_TEST_HOST_ONLY_SECRET") === undefined,
         "the test must not depend on a real host secret",
       );
     });
@@ -662,8 +664,8 @@ describe("APIRouteHandler", () => {
           });
         },
       });
-      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
-      Deno.env.set("WORKER_ISOLATION_API", "1");
+      setEnv("WORKER_ISOLATION_ENABLED", "1");
+      setEnv("WORKER_ISOLATION_API", "1");
       await __resetPoolForTests();
 
       const handler = await createInitializedHandler("/test/project", adapter);
@@ -690,7 +692,7 @@ describe("APIRouteHandler", () => {
     describe("when the runtime cannot prepare an isolated module", () => {
       afterEach(() => {
         __setCompiledBinaryForTests(undefined);
-        Deno.env.delete(HOST_PROJECT_EXECUTION_OVERRIDE_ENV);
+        deleteEnv(HOST_PROJECT_EXECUTION_OVERRIDE_ENV);
       });
 
       it("fails closed when API isolation conflicts with a host execution grant", async () => {
@@ -713,9 +715,9 @@ describe("APIRouteHandler", () => {
             throw new Error("prepared an isolated module this runtime cannot link");
           },
         });
-        Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
-        Deno.env.set("WORKER_ISOLATION_API", "1");
-        Deno.env.set(HOST_PROJECT_EXECUTION_OVERRIDE_ENV, "1");
+        setEnv("WORKER_ISOLATION_ENABLED", "1");
+        setEnv("WORKER_ISOLATION_API", "1");
+        setEnv(HOST_PROJECT_EXECUTION_OVERRIDE_ENV, "1");
         __setCompiledBinaryForTests(true);
         await __resetPoolForTests();
 
@@ -759,8 +761,8 @@ describe("APIRouteHandler", () => {
             throw new Error("unreachable");
           },
         });
-        Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
-        Deno.env.set("WORKER_ISOLATION_API", "1");
+        setEnv("WORKER_ISOLATION_ENABLED", "1");
+        setEnv("WORKER_ISOLATION_API", "1");
         // Deliberately no VERYFRONT_HOST_ALLOW_PROJECT_EXECUTION.
         __setCompiledBinaryForTests(true);
         await __resetPoolForTests();
@@ -1189,8 +1191,8 @@ describe("APIRouteHandler", () => {
         prepareHandlerModule: () => Promise.resolve(module),
         resolvePreparedRouteMethods: () => Promise.resolve([...inspectedMethods]),
       });
-      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
-      Deno.env.set("WORKER_ISOLATION_API", "1");
+      setEnv("WORKER_ISOLATION_ENABLED", "1");
+      setEnv("WORKER_ISOLATION_API", "1");
       await __resetPoolForTests();
       const handler = await createInitializedHandler("/test/project", adapter);
 
@@ -1237,8 +1239,8 @@ describe("APIRouteHandler", () => {
         },
         prepareHandlerModule: () => Promise.resolve(module),
       });
-      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
-      Deno.env.set("WORKER_ISOLATION_API", "1");
+      setEnv("WORKER_ISOLATION_ENABLED", "1");
+      setEnv("WORKER_ISOLATION_API", "1");
       await __resetPoolForTests();
 
       const handler = await createInitializedHandler("/test/project", adapter);
@@ -1292,8 +1294,8 @@ describe("APIRouteHandler", () => {
         resolvePreparedRouteMethods: () =>
           Promise.reject(new Error("prepared method inspection failed")),
       });
-      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
-      Deno.env.set("WORKER_ISOLATION_API", "1");
+      setEnv("WORKER_ISOLATION_ENABLED", "1");
+      setEnv("WORKER_ISOLATION_API", "1");
       await __resetPoolForTests();
 
       const handler = await createInitializedHandler("/test/project", adapter);

--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -16,6 +16,7 @@ import { runWithExactSourceIntegrationPolicy } from "#veryfront/integrations/sou
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
 import type { ApplicationIdentity } from "#veryfront/security/application-auth/types.ts";
 import { resolvePreparedRouteMethods } from "./route-executor.ts";
+import { recordRequestPeerFromTransport } from "#veryfront/platform/adapters/runtime/shared/request-peer.ts";
 
 const handlers: APIRouteHandler[] = [];
 
@@ -848,15 +849,159 @@ describe("APIRouteHandler", () => {
       __injectDepsForTests({
         loadHandlerModule: () => Promise.resolve({ GET: () => new Response("get") }),
       });
-      const handler = await createInitializedHandler("/test/project", adapter);
+      const handler = await createInitializedHandler(
+        "/test/project",
+        adapter,
+        { security: { cors: { origin: ["https://client.example"] } } } as HandlerConfig,
+      );
 
       const response = await handler.handle(
-        new Request("http://localhost/api/automatic-options", { method: "OPTIONS" }),
+        new Request("http://localhost/api/automatic-options", {
+          method: "OPTIONS",
+          headers: {
+            origin: "https://client.example",
+            "access-control-request-method": "PUT",
+            "access-control-request-headers": "Authorization, X-Token, X-Project-Id, X-App-Trace",
+          },
+        }),
         localContext(adapter),
       );
 
       assertEquals(response?.status, 204);
       assertEquals(response?.body, null);
+      assertEquals(response?.headers.get("access-control-allow-methods"), "GET, HEAD, OPTIONS");
+      assertEquals(
+        response?.headers.get("access-control-allow-headers"),
+        "Authorization, X-App-Trace",
+      );
+    });
+
+    it("applies preflight policy headers to an explicit OPTIONS response", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/test/project/pages/api/policy-options.ts",
+        "export function POST() {} export function OPTIONS() {}",
+      );
+      __injectDepsForTests({
+        loadHandlerModule: () =>
+          Promise.resolve({
+            POST: () => new Response("post"),
+            OPTIONS: () =>
+              new Response("explicit options", {
+                status: 211,
+                headers: {
+                  "x-options-owner": "route",
+                  "access-control-allow-origin": "https://untrusted.example",
+                  "access-control-allow-headers": "X-Token",
+                },
+              }),
+          }),
+      });
+      const handler = await createInitializedHandler(
+        "/test/project",
+        adapter,
+        {
+          security: {
+            cors: {
+              origin: ["https://client.example"],
+              maxAge: 123,
+            },
+          },
+        } as HandlerConfig,
+      );
+
+      const response = await handler.handle(
+        new Request("http://localhost/api/policy-options", {
+          method: "OPTIONS",
+          headers: {
+            origin: "https://client.example",
+            "access-control-request-method": "POST",
+            "access-control-request-headers": "Authorization, X-Token",
+          },
+        }),
+        localContext(adapter),
+      );
+
+      assertEquals(response?.status, 211);
+      assertEquals(await response?.text(), "explicit options");
+      assertEquals(response?.headers.get("x-options-owner"), "route");
+      assertEquals(response?.headers.get("access-control-allow-origin"), "https://client.example");
+      assertEquals(response?.headers.get("access-control-allow-methods"), "POST, OPTIONS");
+      assertEquals(response?.headers.get("access-control-allow-headers"), "Authorization");
+      assertEquals(response?.headers.get("access-control-max-age"), "123");
+    });
+
+    it("authenticates an explicit OPTIONS handler but keeps automatic preflight public", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/test/project/pages/api/protected-options.ts",
+        "export function OPTIONS() {}",
+      );
+      let routeCalls = 0;
+      __injectDepsForTests({
+        loadHandlerModule: () =>
+          Promise.resolve({
+            OPTIONS: (context: unknown) => {
+              routeCalls++;
+              const apiContext = context as {
+                identity?: { subject?: string } | null;
+                headers: Headers;
+              };
+              return Response.json({
+                subject: apiContext.identity?.subject ?? null,
+                admittedHeader: apiContext.headers.get("x-auth-subject"),
+              });
+            },
+          }),
+      });
+      const config = {
+        security: {
+          cors: { origin: ["https://client.example"] },
+          auth: {
+            trustedProxy: {
+              trustedPeers: ["127.0.0.1"],
+              headers: { subject: "x-auth-subject" },
+            },
+          },
+        },
+      } as HandlerConfig;
+      const handler = await createInitializedHandler("/test/project", adapter, config);
+      const ctx = {
+        ...localContext(adapter),
+        securityConfig: config.security ?? null,
+      } as HandlerContext;
+
+      const preflight = await handler.handle(
+        new Request("http://localhost/api/protected-options", {
+          method: "OPTIONS",
+          headers: {
+            origin: "https://client.example",
+            "access-control-request-method": "POST",
+            "x-auth-subject": "forged-user",
+          },
+        }),
+        ctx,
+      );
+      assertEquals(preflight?.status, 204);
+      assertEquals(routeCalls, 0);
+
+      const admittedRequest = new Request("http://localhost/api/protected-options", {
+        method: "OPTIONS",
+        headers: { "x-auth-subject": "user-123" },
+      });
+      recordRequestPeerFromTransport(admittedRequest, {
+        runtime: "deno",
+        transport: "tcp",
+        hostname: "127.0.0.1",
+      });
+      const admitted = await handler.handle(admittedRequest, ctx);
+
+      assertEquals(admitted?.status, 200);
+      assertEquals(await admitted?.json(), {
+        subject: "user-123",
+        admittedHeader: null,
+      });
+      assertEquals(routeCalls, 1);
     });
 
     it("dispatches a named OPTIONS handler from a prepared route", async () => {

--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -145,6 +145,31 @@ describe("APIRouteHandler", () => {
       assertEquals(response, null);
     });
 
+    it("should return null for unmatched non-API OPTIONS in an isolated runtime", async () => {
+      const adapter = createMockAdapter();
+      const handler = await createInitializedHandler("/test/project", adapter);
+
+      const response = await handler.handle(
+        new Request("http://localhost/not-an-api-route", {
+          method: "OPTIONS",
+          headers: {
+            origin: "https://client.example",
+            "access-control-request-method": "GET",
+          },
+        }),
+        {
+          projectDir: "/test/project",
+          adapter,
+          securityConfig: null,
+          isLocalProject: false,
+          prepareHostedConfigContext: () =>
+            Promise.reject(new Error("hosted config must not be evaluated")),
+        },
+      );
+
+      assertEquals(response, null);
+    });
+
     it("should return null for root path", async () => {
       const adapter = createMockAdapter();
       const handler = await createInitializedHandler("/test/project", adapter);

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -16,6 +16,10 @@ import { type APIContext } from "./context-builder.ts";
 import { ApiRouteMatcher, type RouteMatch } from "./api-route-matcher.ts";
 import type { APIRoute } from "./module-loader/types.ts";
 import { loadHandlerModule, prepareHandlerModule } from "./module-loader/loader.ts";
+import {
+  resolveStaticRouteOptionsCapability,
+  type StaticRouteOptionsCapability,
+} from "./module-loader/source-capability-analyzer.ts";
 import { discoverAppRoutes, discoverPagesRoutes } from "./route-discovery.ts";
 import {
   createAPIRouteErrorResponse,
@@ -290,6 +294,13 @@ export class APIRouteHandler {
         });
 
         if (method === "OPTIONS") {
+          if (
+            !isPreflightRequest(request) &&
+            await this.resolveStaticOptionsCapability(match.route.page, adapter) === "absent"
+          ) {
+            return this.automaticPreflight(request, undefined, ctx);
+          }
+
           const authResponse = await this.authenticateOptionsRoute(request, ctx);
           if (authResponse) {
             if (isPreflightRequest(request)) {
@@ -550,6 +561,21 @@ export class APIRouteHandler {
       ) ?? undefined;
     } catch {
       return undefined;
+    }
+  }
+
+  private async resolveStaticOptionsCapability(
+    modulePath: string,
+    adapter: RuntimeAdapter,
+  ): Promise<StaticRouteOptionsCapability> {
+    try {
+      const source = await adapter.fs.readFile(modulePath);
+      return await resolveStaticRouteOptionsCapability(source);
+    } catch {
+      // Static inspection is an optimization for plain OPTIONS only. If the
+      // source cannot be read or parsed, retain the safe auth-before-evaluation
+      // fallback and let the canonical route path decide after admission.
+      return "unknown";
     }
   }
 

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -23,7 +23,9 @@ import {
   executePreparedAppRoute,
   executePreparedPagesRoute,
   type ExecuteRouteOptions,
+  resolvePreparedRouteMethods,
 } from "./route-executor.ts";
+import { resolveExecutableRouteMethods } from "./route-methods.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import type { HandlerContext } from "#veryfront/types";
 import type { PreparedWorkerModule } from "#veryfront/security/sandbox/worker-types.ts";
@@ -231,7 +233,8 @@ export class APIRouteHandler {
 
         await this.ensureCorsConfig(adapter);
 
-        if (request.method.toUpperCase() === "OPTIONS") {
+        const method = request.method.toUpperCase();
+        if (method === "OPTIONS" && isSharedProjectRuntime(ctx)) {
           return handleCORSPreflight({
             request,
             config: this.corsConfig ?? undefined,
@@ -246,6 +249,12 @@ export class APIRouteHandler {
             availableRoutes: this.router.listRoutes().map((r) => r.pattern),
           });
 
+          if (method === "OPTIONS") {
+            return handleCORSPreflight({
+              request,
+              config: this.corsConfig ?? undefined,
+            });
+          }
           if (pathname === "/api" || pathname.startsWith("/api/")) return notFound();
           return null;
         }
@@ -344,6 +353,26 @@ export class APIRouteHandler {
           isLocalProject,
           allowHostProjectCodeExecution: useHostRealm,
         };
+
+        if (method === "OPTIONS") {
+          const executableMethods = route.kind === "isolated"
+            ? await resolvePreparedRouteMethods(undefined, {
+              executionScopeId: this.executionScopeId,
+              module: route.module,
+              modulePath: match.route.page,
+              projectDir: this.projectDir,
+            }, { includeFrameworkOptions: false })
+            : resolveExecutableRouteMethods(route.handler, undefined, {
+              includeFrameworkOptions: false,
+            });
+
+          if (!executableMethods.includes("OPTIONS")) {
+            return handleCORSPreflight({
+              request,
+              config: this.corsConfig ?? undefined,
+            });
+          }
+        }
 
         const applicationRequest = createApplicationRequest(request, {
           denyHeaders: ctx?.applicationIdentityHeaderNames,

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -382,16 +382,26 @@ export class APIRouteHandler {
 
         let executableOptionsMethods: readonly string[] | undefined;
         if (method === "OPTIONS") {
-          const requestedMethod = this.requestedPreflightMethod(request);
-          executableOptionsMethods = route.kind === "isolated"
-            ? await this.resolveIsolatedRouteMethods(
-              match.route.page,
-              route.module,
-              requestedMethod,
-            )
-            : resolveExecutableRouteMethods(route.handler, requestedMethod, {
-              includeFrameworkOptions: false,
-            });
+          try {
+            const requestedMethod = this.requestedPreflightMethod(request);
+            executableOptionsMethods = route.kind === "isolated"
+              ? await this.resolveIsolatedRouteMethods(
+                match.route.page,
+                route.module,
+                requestedMethod,
+              )
+              : resolveExecutableRouteMethods(route.handler, requestedMethod, {
+                includeFrameworkOptions: false,
+              });
+          } catch (error) {
+            const msg = error instanceof Error ? error.message : String(error);
+            logger.error(`handler method inspection failed: ${match.route.page}`, { reason: msg });
+            return internalServerError(
+              ctx?.isLocalProject
+                ? sanitizeLoadErrorForResponse(msg, this.projectDir)
+                : "Handler not found",
+            );
+          }
 
           if (!executableOptionsMethods.includes("OPTIONS")) {
             return this.automaticPreflight(request, executableOptionsMethods);

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -89,6 +89,7 @@ export function sanitizeLoadErrorForResponse(message: string, projectDir?: strin
 interface APIRouteHandlerDeps {
   loadHandlerModule?: typeof loadHandlerModule;
   prepareHandlerModule?: typeof prepareHandlerModule;
+  resolvePreparedRouteMethods?: typeof resolvePreparedRouteMethods;
   discoverPagesRoutes?: typeof discoverPagesRoutes;
   discoverAppRoutes?: typeof discoverAppRoutes;
   getConfig?: typeof getConfig;
@@ -107,6 +108,8 @@ function getDeps(): Required<APIRouteHandlerDeps> {
   return {
     loadHandlerModule: injectedDeps?.loadHandlerModule ?? loadHandlerModule,
     prepareHandlerModule: injectedDeps?.prepareHandlerModule ?? prepareHandlerModule,
+    resolvePreparedRouteMethods: injectedDeps?.resolvePreparedRouteMethods ??
+      resolvePreparedRouteMethods,
     discoverPagesRoutes: injectedDeps?.discoverPagesRoutes ?? discoverPagesRoutes,
     discoverAppRoutes: injectedDeps?.discoverAppRoutes ?? discoverAppRoutes,
     getConfig: injectedDeps?.getConfig ?? getConfig,
@@ -139,6 +142,9 @@ type LoadedRoute =
 export class APIRouteHandler {
   private router = new ApiRouteMatcher();
   private routeCache = new LRUCache<string, LoadedRoute>({ maxEntries: HANDLER_CACHE_MAX_ENTRIES });
+  private isolatedRouteMethodCache = new LRUCache<string, Promise<readonly string[]>>({
+    maxEntries: HANDLER_CACHE_MAX_ENTRIES,
+  });
   private executionScopeId = crypto.randomUUID();
   private activeRequests = 0;
   private destroyRequested = false;
@@ -356,12 +362,7 @@ export class APIRouteHandler {
 
         if (method === "OPTIONS") {
           const executableMethods = route.kind === "isolated"
-            ? await resolvePreparedRouteMethods(undefined, {
-              executionScopeId: this.executionScopeId,
-              module: route.module,
-              modulePath: match.route.page,
-              projectDir: this.projectDir,
-            }, { includeFrameworkOptions: false })
+            ? await this.resolveIsolatedRouteMethods(match.route.page, route.module)
             : resolveExecutableRouteMethods(route.handler, undefined, {
               includeFrameworkOptions: false,
             });
@@ -481,11 +482,38 @@ export class APIRouteHandler {
     );
   }
 
+  private async resolveIsolatedRouteMethods(
+    modulePath: string,
+    module: PreparedWorkerModule,
+  ): Promise<readonly string[]> {
+    const cacheKey = `${modulePath}:${module.sha256}`;
+    let pending = this.isolatedRouteMethodCache.get(cacheKey);
+    if (!pending) {
+      pending = getDeps().resolvePreparedRouteMethods(undefined, {
+        executionScopeId: this.executionScopeId,
+        module,
+        modulePath,
+        projectDir: this.projectDir,
+      }, { includeFrameworkOptions: false });
+      this.isolatedRouteMethodCache.set(cacheKey, pending);
+    }
+
+    try {
+      return await pending;
+    } catch (error) {
+      if (this.isolatedRouteMethodCache.get(cacheKey) === pending) {
+        this.isolatedRouteMethodCache.delete(cacheKey);
+      }
+      throw error;
+    }
+  }
+
   clearCache(): void {
     const previousScopeId = this.executionScopeId;
     this.executionScopeId = crypto.randomUUID();
     evictWorkerScopeIfPresent(previousScopeId);
     this.routeCache.clear();
+    this.isolatedRouteMethodCache.clear();
     this.router.clearCache();
   }
 
@@ -511,6 +539,7 @@ export class APIRouteHandler {
     this.destroyed = true;
     evictWorkerScopeIfPresent(this.executionScopeId);
     this.routeCache.destroy();
+    this.isolatedRouteMethodCache.destroy();
     this.router.destroy();
   }
 

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -25,7 +25,7 @@ import {
   type ExecuteRouteOptions,
   resolvePreparedRouteMethods,
 } from "./route-executor.ts";
-import { resolveExecutableRouteMethods } from "./route-methods.ts";
+import { normalizeRouteMethod, resolveExecutableRouteMethods } from "./route-methods.ts";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import type { HandlerContext } from "#veryfront/types";
 import type { PreparedWorkerModule } from "#veryfront/security/sandbox/worker-types.ts";
@@ -45,6 +45,7 @@ import {
 import {
   isHostProjectCodeExecutionAllowed,
   isSharedProjectRuntime,
+  requiresIsolatedProjectRuntime,
 } from "#veryfront/security/project-locality.ts";
 import { createApplicationAuthRequestHandler } from "#veryfront/security/application-auth/application-auth-runtime.ts";
 import { AuthHandler } from "#veryfront/security/http/auth.ts";
@@ -151,9 +152,6 @@ type LoadedRoute =
 export class APIRouteHandler {
   private router = new ApiRouteMatcher();
   private routeCache = new LRUCache<string, LoadedRoute>({ maxEntries: HANDLER_CACHE_MAX_ENTRIES });
-  private isolatedRouteMethodCache = new LRUCache<string, Promise<readonly string[]>>({
-    maxEntries: HANDLER_CACHE_MAX_ENTRIES,
-  });
   private readonly applicationAuth = createApplicationAuthRequestHandler();
   private readonly httpAuth = new AuthHandler();
   private executionScopeId = crypto.randomUUID();
@@ -251,7 +249,7 @@ export class APIRouteHandler {
         await this.ensureCorsConfig(adapter);
 
         const method = request.method.toUpperCase();
-        if (method === "OPTIONS" && isSharedProjectRuntime(ctx)) {
+        if (method === "OPTIONS" && requiresIsolatedProjectRuntime(ctx)) {
           return this.automaticPreflight(request);
         }
 
@@ -276,6 +274,18 @@ export class APIRouteHandler {
           page: match.route.page,
           params: match.params,
         });
+
+        if (method === "OPTIONS") {
+          const authResponse = await this.authenticateOptionsRoute(request, ctx);
+          if (authResponse) {
+            if (isPreflightRequest(request)) return this.automaticPreflight(request);
+            return await applyCORSHeaders({
+              request,
+              response: authResponse,
+              config: this.corsConfig ?? undefined,
+            }) ?? authResponse;
+          }
+        }
 
         const isLocalProject = ctx?.isLocalProject === true;
         const allowHostProjectCodeExecution = isHostProjectCodeExecutionAllowed(ctx);
@@ -367,26 +377,19 @@ export class APIRouteHandler {
 
         let executableOptionsMethods: readonly string[] | undefined;
         if (method === "OPTIONS") {
+          const requestedMethod = this.requestedPreflightMethod(request);
           executableOptionsMethods = route.kind === "isolated"
-            ? await this.resolveIsolatedRouteMethods(match.route.page, route.module)
-            : resolveExecutableRouteMethods(route.handler, undefined, {
+            ? await this.resolveIsolatedRouteMethods(
+              match.route.page,
+              route.module,
+              requestedMethod,
+            )
+            : resolveExecutableRouteMethods(route.handler, requestedMethod, {
               includeFrameworkOptions: false,
             });
 
           if (!executableOptionsMethods.includes("OPTIONS")) {
             return this.automaticPreflight(request, executableOptionsMethods);
-          }
-
-          const authResponse = await this.authenticateExplicitOptions(request, ctx);
-          if (authResponse) {
-            if (isPreflightRequest(request)) {
-              return this.automaticPreflight(request, executableOptionsMethods);
-            }
-            return await applyCORSHeaders({
-              request,
-              response: authResponse,
-              config: this.corsConfig ?? undefined,
-            }) ?? authResponse;
           }
         }
 
@@ -508,26 +511,23 @@ export class APIRouteHandler {
   private async resolveIsolatedRouteMethods(
     modulePath: string,
     module: PreparedWorkerModule,
+    requestedMethod: string | undefined,
   ): Promise<readonly string[]> {
-    const cacheKey = `${modulePath}:${module.sha256}`;
-    let pending = this.isolatedRouteMethodCache.get(cacheKey);
-    if (!pending) {
-      pending = getDeps().resolvePreparedRouteMethods(undefined, {
-        executionScopeId: this.executionScopeId,
-        module,
-        modulePath,
-        projectDir: this.projectDir,
-      }, { includeFrameworkOptions: false });
-      this.isolatedRouteMethodCache.set(cacheKey, pending);
-    }
+    return await getDeps().resolvePreparedRouteMethods(requestedMethod, {
+      executionScopeId: this.executionScopeId,
+      module,
+      modulePath,
+      projectDir: this.projectDir,
+    }, { includeFrameworkOptions: false });
+  }
 
+  private requestedPreflightMethod(request: Request): string | undefined {
     try {
-      return await pending;
-    } catch (error) {
-      if (this.isolatedRouteMethodCache.get(cacheKey) === pending) {
-        this.isolatedRouteMethodCache.delete(cacheKey);
-      }
-      throw error;
+      return normalizeRouteMethod(
+        request.headers.get("access-control-request-method"),
+      ) ?? undefined;
+    } catch {
+      return undefined;
     }
   }
 
@@ -548,7 +548,7 @@ export class APIRouteHandler {
     });
   }
 
-  private async authenticateExplicitOptions(
+  private async authenticateOptionsRoute(
     request: Request,
     ctx: HandlerContext | undefined,
   ): Promise<Response | null> {
@@ -585,7 +585,6 @@ export class APIRouteHandler {
     this.executionScopeId = crypto.randomUUID();
     evictWorkerScopeIfPresent(previousScopeId);
     this.routeCache.clear();
-    this.isolatedRouteMethodCache.clear();
     this.router.clearCache();
   }
 
@@ -611,7 +610,6 @@ export class APIRouteHandler {
     this.destroyed = true;
     evictWorkerScopeIfPresent(this.executionScopeId);
     this.routeCache.destroy();
-    this.isolatedRouteMethodCache.destroy();
     this.router.destroy();
   }
 

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -264,7 +264,7 @@ export class APIRouteHandler {
           isApiPath &&
           requiresIsolatedProjectRuntime(ctx)
         ) {
-          return this.automaticPreflight(request);
+          return this.automaticPreflight(request, undefined, ctx);
         }
 
         const match = this.router.match(pathname);
@@ -276,7 +276,7 @@ export class APIRouteHandler {
           });
 
           if (method === "OPTIONS" && isApiPath) {
-            return this.automaticPreflight(request);
+            return this.automaticPreflight(request, undefined, ctx);
           }
           if (isApiPath) return notFound();
           return null;

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -307,7 +307,11 @@ export class APIRouteHandler {
             if (isPreflightRequest(request)) {
               return this.automaticPreflight(
                 request,
-                await this.resolveStaticRouteMethods(match.route.page, adapter),
+                await this.resolveStaticRouteMethods(
+                  match.route.page,
+                  adapter,
+                  this.requestedPreflightMethod(request),
+                ),
                 ctx,
               );
             }
@@ -587,10 +591,11 @@ export class APIRouteHandler {
   private async resolveStaticRouteMethods(
     modulePath: string,
     adapter: RuntimeAdapter,
+    requestedMethod?: string,
   ): Promise<readonly string[] | undefined> {
     try {
       const source = await adapter.fs.readFile(modulePath);
-      return await resolveStaticRouteMethodsFromSource(source);
+      return await resolveStaticRouteMethodsFromSource(source, requestedMethod);
     } catch {
       return undefined;
     }

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -134,6 +134,10 @@ export interface APIResponse {
   headers?: HeadersInit;
 }
 
+export interface APIRouteHandleOptions {
+  beforeOptionsDispatch?: () => Promise<void>;
+}
+
 /** Function signature for API route handlers. */
 export type APIHandler = (ctx: APIContext) => Promise<Response> | Response;
 
@@ -232,7 +236,11 @@ export class APIRouteHandler {
     );
   }
 
-  handle(request: Request, ctx?: HandlerContext): Promise<Response | null> {
+  handle(
+    request: Request,
+    ctx?: HandlerContext,
+    options: APIRouteHandleOptions = {},
+  ): Promise<Response | null> {
     const { pathname } = new URL(request.url);
     this.activeRequests++;
 
@@ -284,13 +292,16 @@ export class APIRouteHandler {
         if (method === "OPTIONS") {
           const authResponse = await this.authenticateOptionsRoute(request, ctx);
           if (authResponse) {
-            if (isPreflightRequest(request)) return this.automaticPreflight(request);
+            if (isPreflightRequest(request)) {
+              return this.automaticPreflight(request, undefined, ctx);
+            }
             return await applyCORSHeaders({
               request,
               response: authResponse,
               config: this.corsConfig ?? undefined,
             }) ?? authResponse;
           }
+          await options.beforeOptionsDispatch?.();
         }
 
         const isLocalProject = ctx?.isLocalProject === true;
@@ -399,7 +410,7 @@ export class APIRouteHandler {
           }
 
           if (!executableOptionsMethods.includes("OPTIONS")) {
-            return this.automaticPreflight(request, executableOptionsMethods);
+            return this.automaticPreflight(request, executableOptionsMethods, ctx);
           }
         }
 
@@ -451,6 +462,7 @@ export class APIRouteHandler {
             request,
             response,
             executableOptionsMethods,
+            ctx,
           )
           : await applyCORSHeaders({
             request,
@@ -544,6 +556,7 @@ export class APIRouteHandler {
   private async automaticPreflight(
     request: Request,
     executableMethods?: readonly string[],
+    ctx?: HandlerContext,
   ): Promise<Response> {
     const allowMethods = executableMethods
       ? (executableMethods.includes("OPTIONS")
@@ -554,7 +567,9 @@ export class APIRouteHandler {
       request,
       config: this.corsConfig ?? undefined,
       allowMethods,
-      allowHeaders: getApplicationPreflightHeaders(request),
+      allowHeaders: getApplicationPreflightHeaders(request, {
+        denyHeaders: ctx?.applicationIdentityHeaderNames,
+      }),
     });
     response.headers.set("Allow", allowMethods);
     return response;
@@ -582,13 +597,16 @@ export class APIRouteHandler {
     request: Request,
     response: Response,
     executableMethods: readonly string[],
+    ctx?: HandlerContext,
   ): Promise<Response> {
     return await applyCORSPreflightHeaders({
       request,
       response,
       config: this.corsConfig ?? undefined,
       allowMethods: executableMethods.join(", "),
-      allowHeaders: getApplicationPreflightHeaders(request),
+      allowHeaders: getApplicationPreflightHeaders(request, {
+        denyHeaders: ctx?.applicationIdentityHeaderNames,
+      }),
     });
   }
 

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -255,16 +255,17 @@ export class APIRouteHandler {
 
         const match = this.router.match(pathname);
         if (!match) {
+          const isApiPath = pathname === "/api" || pathname.startsWith("/api/");
           logger.debug("No route match", {
             pathname,
-            isApiPath: pathname.startsWith("/api/"),
+            isApiPath,
             availableRoutes: this.router.listRoutes().map((r) => r.pattern),
           });
 
-          if (method === "OPTIONS") {
+          if (method === "OPTIONS" && isApiPath) {
             return this.automaticPreflight(request);
           }
-          if (pathname === "/api" || pathname.startsWith("/api/")) return notFound();
+          if (isApiPath) return notFound();
           return null;
         }
 

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -38,11 +38,20 @@ import {
   isIsolatedApiPreparationSupported,
   ISOLATED_API_PREPARATION_UNSUPPORTED_REASON,
 } from "#veryfront/security/sandbox/isolation-capability.ts";
-import { createApplicationRequest } from "#veryfront/security/http/application-request.ts";
+import {
+  createApplicationRequest,
+  getApplicationPreflightHeaders,
+} from "#veryfront/security/http/application-request.ts";
 import {
   isHostProjectCodeExecutionAllowed,
   isSharedProjectRuntime,
 } from "#veryfront/security/project-locality.ts";
+import { createApplicationAuthRequestHandler } from "#veryfront/security/application-auth/application-auth-runtime.ts";
+import { AuthHandler } from "#veryfront/security/http/auth.ts";
+import {
+  applyCORSPreflightHeaders,
+  isPreflightRequest,
+} from "#veryfront/security/http/cors/preflight.ts";
 
 /** Max entries in the loaded-handler LRU cache */
 const HANDLER_CACHE_MAX_ENTRIES = 256;
@@ -145,6 +154,8 @@ export class APIRouteHandler {
   private isolatedRouteMethodCache = new LRUCache<string, Promise<readonly string[]>>({
     maxEntries: HANDLER_CACHE_MAX_ENTRIES,
   });
+  private readonly applicationAuth = createApplicationAuthRequestHandler();
+  private readonly httpAuth = new AuthHandler();
   private executionScopeId = crypto.randomUUID();
   private activeRequests = 0;
   private destroyRequested = false;
@@ -241,10 +252,7 @@ export class APIRouteHandler {
 
         const method = request.method.toUpperCase();
         if (method === "OPTIONS" && isSharedProjectRuntime(ctx)) {
-          return handleCORSPreflight({
-            request,
-            config: this.corsConfig ?? undefined,
-          });
+          return this.automaticPreflight(request);
         }
 
         const match = this.router.match(pathname);
@@ -256,10 +264,7 @@ export class APIRouteHandler {
           });
 
           if (method === "OPTIONS") {
-            return handleCORSPreflight({
-              request,
-              config: this.corsConfig ?? undefined,
-            });
+            return this.automaticPreflight(request);
           }
           if (pathname === "/api" || pathname.startsWith("/api/")) return notFound();
           return null;
@@ -360,18 +365,28 @@ export class APIRouteHandler {
           allowHostProjectCodeExecution: useHostRealm,
         };
 
+        let executableOptionsMethods: readonly string[] | undefined;
         if (method === "OPTIONS") {
-          const executableMethods = route.kind === "isolated"
+          executableOptionsMethods = route.kind === "isolated"
             ? await this.resolveIsolatedRouteMethods(match.route.page, route.module)
             : resolveExecutableRouteMethods(route.handler, undefined, {
               includeFrameworkOptions: false,
             });
 
-          if (!executableMethods.includes("OPTIONS")) {
-            return handleCORSPreflight({
+          if (!executableOptionsMethods.includes("OPTIONS")) {
+            return this.automaticPreflight(request, executableOptionsMethods);
+          }
+
+          const authResponse = await this.authenticateExplicitOptions(request, ctx);
+          if (authResponse) {
+            if (isPreflightRequest(request)) {
+              return this.automaticPreflight(request, executableOptionsMethods);
+            }
+            return await applyCORSHeaders({
               request,
+              response: authResponse,
               config: this.corsConfig ?? undefined,
-            });
+            }) ?? authResponse;
           }
         }
 
@@ -416,11 +431,19 @@ export class APIRouteHandler {
             { ...isolationOptions, applicationIdentity },
           );
 
-        const corsResponse = await applyCORSHeaders({
-          request,
-          response,
-          config: this.corsConfig ?? undefined,
-        });
+        const corsResponse = method === "OPTIONS" &&
+            executableOptionsMethods &&
+            isPreflightRequest(request)
+          ? await this.applyExplicitOptionsPreflightPolicy(
+            request,
+            response,
+            executableOptionsMethods,
+          )
+          : await applyCORSHeaders({
+            request,
+            response,
+            config: this.corsConfig ?? undefined,
+          });
 
         return corsResponse ?? response;
       },
@@ -506,6 +529,55 @@ export class APIRouteHandler {
       }
       throw error;
     }
+  }
+
+  private automaticPreflight(
+    request: Request,
+    executableMethods?: readonly string[],
+  ): Promise<Response> {
+    const allowMethods = executableMethods
+      ? (executableMethods.includes("OPTIONS")
+        ? executableMethods
+        : [...executableMethods, "OPTIONS"]).join(", ")
+      : undefined;
+    return handleCORSPreflight({
+      request,
+      config: this.corsConfig ?? undefined,
+      allowMethods,
+      allowHeaders: getApplicationPreflightHeaders(request),
+    });
+  }
+
+  private async authenticateExplicitOptions(
+    request: Request,
+    ctx: HandlerContext | undefined,
+  ): Promise<Response | null> {
+    if (!ctx) return null;
+
+    const applicationAuth = await this.applicationAuth(request, ctx);
+    if (applicationAuth?.response) return applicationAuth.response;
+    if (applicationAuth) {
+      ctx.applicationIdentity = applicationAuth.metadata?.applicationIdentity ?? null;
+      ctx.applicationIdentityHeaderNames =
+        applicationAuth.metadata?.applicationIdentityHeaderNames ?? [];
+    }
+
+    const httpAuth = await this.httpAuth.handleExplicitOptions(request, ctx);
+    return httpAuth.response ?? null;
+  }
+
+  private async applyExplicitOptionsPreflightPolicy(
+    request: Request,
+    response: Response,
+    executableMethods: readonly string[],
+  ): Promise<Response> {
+    return await applyCORSPreflightHeaders({
+      request,
+      response,
+      config: this.corsConfig ?? undefined,
+      allowMethods: executableMethods.join(", "),
+      allowHeaders: getApplicationPreflightHeaders(request),
+    });
   }
 
   clearCache(): void {

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -17,6 +17,7 @@ import { ApiRouteMatcher, type RouteMatch } from "./api-route-matcher.ts";
 import type { APIRoute } from "./module-loader/types.ts";
 import { loadHandlerModule, prepareHandlerModule } from "./module-loader/loader.ts";
 import {
+  resolveStaticRouteMethods as resolveStaticRouteMethodsFromSource,
   resolveStaticRouteOptionsCapability,
   type StaticRouteOptionsCapability,
 } from "./module-loader/source-capability-analyzer.ts";
@@ -304,7 +305,11 @@ export class APIRouteHandler {
           const authResponse = await this.authenticateOptionsRoute(request, ctx);
           if (authResponse) {
             if (isPreflightRequest(request)) {
-              return this.automaticPreflight(request, undefined, ctx);
+              return this.automaticPreflight(
+                request,
+                await this.resolveStaticRouteMethods(match.route.page, adapter),
+                ctx,
+              );
             }
             return await applyCORSHeaders({
               request,
@@ -576,6 +581,18 @@ export class APIRouteHandler {
       // source cannot be read or parsed, retain the safe auth-before-evaluation
       // fallback and let the canonical route path decide after admission.
       return "unknown";
+    }
+  }
+
+  private async resolveStaticRouteMethods(
+    modulePath: string,
+    adapter: RuntimeAdapter,
+  ): Promise<readonly string[] | undefined> {
+    try {
+      const source = await adapter.fs.readFile(modulePath);
+      return await resolveStaticRouteMethodsFromSource(source);
+    } catch {
+      return undefined;
     }
   }
 

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -249,13 +249,17 @@ export class APIRouteHandler {
         await this.ensureCorsConfig(adapter);
 
         const method = request.method.toUpperCase();
-        if (method === "OPTIONS" && requiresIsolatedProjectRuntime(ctx)) {
+        const isApiPath = pathname === "/api" || pathname.startsWith("/api/");
+        if (
+          method === "OPTIONS" &&
+          isApiPath &&
+          requiresIsolatedProjectRuntime(ctx)
+        ) {
           return this.automaticPreflight(request);
         }
 
         const match = this.router.match(pathname);
         if (!match) {
-          const isApiPath = pathname === "/api" || pathname.startsWith("/api/");
           logger.debug("No route match", {
             pathname,
             isApiPath,

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -11,13 +11,14 @@ import {
 } from "#veryfront/errors";
 import { badGateway, internalServerError, notFound } from "#veryfront/http/responses";
 import type { CORSConfig } from "#veryfront/security";
-import { applyCORSHeaders, handleCORSPreflight } from "#veryfront/security";
+import { applyCORSHeaders, DEFAULT_CORS_METHODS, handleCORSPreflight } from "#veryfront/security";
 import { type APIContext } from "./context-builder.ts";
 import { ApiRouteMatcher, type RouteMatch } from "./api-route-matcher.ts";
 import type { APIRoute } from "./module-loader/types.ts";
 import { loadHandlerModule, prepareHandlerModule } from "./module-loader/loader.ts";
 import { discoverAppRoutes, discoverPagesRoutes } from "./route-discovery.ts";
 import {
+  createAPIRouteErrorResponse,
   executeAppRoute,
   executePagesRoute,
   executePreparedAppRoute,
@@ -394,13 +395,7 @@ export class APIRouteHandler {
                 includeFrameworkOptions: false,
               });
           } catch (error) {
-            const msg = error instanceof Error ? error.message : String(error);
-            logger.error(`handler method inspection failed: ${match.route.page}`, { reason: msg });
-            return internalServerError(
-              ctx?.isLocalProject
-                ? sanitizeLoadErrorForResponse(msg, this.projectDir)
-                : "Handler not found",
-            );
+            return createAPIRouteErrorResponse(error, pathname, isLocalProject);
           }
 
           if (!executableOptionsMethods.includes("OPTIONS")) {
@@ -546,7 +541,7 @@ export class APIRouteHandler {
     }
   }
 
-  private automaticPreflight(
+  private async automaticPreflight(
     request: Request,
     executableMethods?: readonly string[],
   ): Promise<Response> {
@@ -554,13 +549,15 @@ export class APIRouteHandler {
       ? (executableMethods.includes("OPTIONS")
         ? executableMethods
         : [...executableMethods, "OPTIONS"]).join(", ")
-      : undefined;
-    return handleCORSPreflight({
+      : DEFAULT_CORS_METHODS.join(", ");
+    const response = await handleCORSPreflight({
       request,
       config: this.corsConfig ?? undefined,
       allowMethods,
       allowHeaders: getApplicationPreflightHeaders(request),
     });
+    response.headers.set("Allow", allowMethods);
+    return response;
   }
 
   private async authenticateOptionsRoute(

--- a/src/routing/api/module-loader/http-validator.test.ts
+++ b/src/routing/api/module-loader/http-validator.test.ts
@@ -33,7 +33,6 @@ describe("resolveStaticRouteOptionsCapability", () => {
       "const handler = () => {}; export { handler as OPTIONS };",
       'export { handler as OPTIONS } from "./handler.ts";',
       "export const OPTIONS = () => new Response();",
-      "export const { OPTIONS } = handlers;",
     ];
 
     for (const source of sources) {
@@ -46,6 +45,7 @@ describe("resolveStaticRouteOptionsCapability", () => {
       'export * from "./handler.ts";',
       "module.exports = { OPTIONS() {} };",
       "export const OPTIONS = handler;",
+      "export const { OPTIONS } = handlers;",
       "export function OPTIONS(",
     ];
 

--- a/src/routing/api/module-loader/http-validator.test.ts
+++ b/src/routing/api/module-loader/http-validator.test.ts
@@ -33,6 +33,7 @@ describe("resolveStaticRouteOptionsCapability", () => {
       "const handler = () => {}; export { handler as OPTIONS };",
       'export { handler as OPTIONS } from "./handler.ts";',
       "export const OPTIONS = () => new Response();",
+      "export const { OPTIONS } = handlers;",
     ];
 
     for (const source of sources) {

--- a/src/routing/api/module-loader/http-validator.test.ts
+++ b/src/routing/api/module-loader/http-validator.test.ts
@@ -35,6 +35,24 @@ describe("resolveStaticRouteOptionsCapability", () => {
       "export const OPTIONS = () => new Response();",
     ];
 
+    for (
+      const source of [
+        "export default 123;",
+        "export default { OPTIONS() {} };",
+      ]
+    ) {
+      assertEquals(await resolveStaticRouteOptionsCapability(source), "absent", source);
+    }
+
+    for (
+      const source of [
+        "export const { OPTIONS } = handlers;",
+        "export default handler;",
+      ]
+    ) {
+      assertEquals(await resolveStaticRouteOptionsCapability(source), "unknown", source);
+    }
+
     for (const source of sources) {
       assertEquals(await resolveStaticRouteOptionsCapability(source), "present", source);
     }

--- a/src/routing/api/module-loader/http-validator.test.ts
+++ b/src/routing/api/module-loader/http-validator.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./http-validator.ts";
 import {
   __setSourceCapabilityParserLoaderForTests,
+  resolveStaticRouteMethods,
   resolveStaticRouteOptionsCapability,
   rewriteImportMetaLocations,
   rewriteUnboundCommonJsDynamicRequire,
@@ -70,6 +71,28 @@ describe("resolveStaticRouteOptionsCapability", () => {
     for (const source of sources) {
       assertEquals(await resolveStaticRouteOptionsCapability(source), "unknown", source);
     }
+  });
+});
+
+describe("resolveStaticRouteMethods", () => {
+  it("returns the proven method surface without evaluating the route", async () => {
+    assertEquals(
+      await resolveStaticRouteMethods(
+        "export function GET() {}\nexport function POST() {}",
+      ),
+      ["GET", "HEAD", "POST"],
+    );
+  });
+
+  it("keeps dynamic method exports on the conservative fallback", async () => {
+    assertEquals(
+      await resolveStaticRouteMethods("export const GET = handler;"),
+      undefined,
+    );
+    assertEquals(
+      await resolveStaticRouteMethods("export { GET } from './handler.ts';"),
+      undefined,
+    );
   });
 });
 

--- a/src/routing/api/module-loader/http-validator.test.ts
+++ b/src/routing/api/module-loader/http-validator.test.ts
@@ -82,6 +82,10 @@ describe("resolveStaticRouteMethods", () => {
       ),
       ["GET", "HEAD", "POST"],
     );
+    assertEquals(
+      await resolveStaticRouteMethods("export default function route() {}", "PROPFIND"),
+      ["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "PROPFIND"],
+    );
   });
 
   it("keeps dynamic method exports on the conservative fallback", async () => {

--- a/src/routing/api/module-loader/http-validator.test.ts
+++ b/src/routing/api/module-loader/http-validator.test.ts
@@ -10,10 +10,49 @@ import {
 } from "./http-validator.ts";
 import {
   __setSourceCapabilityParserLoaderForTests,
+  resolveStaticRouteOptionsCapability,
   rewriteImportMetaLocations,
   rewriteUnboundCommonJsDynamicRequire,
   usesUnboundCommonJsModule,
 } from "./source-capability-analyzer.ts";
+
+describe("resolveStaticRouteOptionsCapability", () => {
+  it("proves absence only for statically closed export sets", async () => {
+    assertEquals(
+      await resolveStaticRouteOptionsCapability(
+        "export function GET() {}\nexport type OPTIONS = { enabled: true };",
+      ),
+      "absent",
+    );
+  });
+
+  it("keeps every statically visible OPTIONS or default route behind auth", async () => {
+    const sources = [
+      "export function OPTIONS() {}",
+      "export default function route() {}",
+      "const handler = () => {}; export { handler as OPTIONS };",
+      'export { handler as OPTIONS } from "./handler.ts";',
+      "export const OPTIONS = () => new Response();",
+    ];
+
+    for (const source of sources) {
+      assertEquals(await resolveStaticRouteOptionsCapability(source), "present", source);
+    }
+  });
+
+  it("keeps ambiguous, CommonJS, and invalid sources on the authenticated fallback", async () => {
+    const sources = [
+      'export * from "./handler.ts";',
+      "module.exports = { OPTIONS() {} };",
+      "export const OPTIONS = handler;",
+      "export function OPTIONS(",
+    ];
+
+    for (const source of sources) {
+      assertEquals(await resolveStaticRouteOptionsCapability(source), "unknown", source);
+    }
+  });
+});
 
 describe("usesUnboundCommonJsModule", () => {
   it("distinguishes runtime CommonJS module references from inert text and bindings", async () => {

--- a/src/routing/api/module-loader/source-capability-analyzer.ts
+++ b/src/routing/api/module-loader/source-capability-analyzer.ts
@@ -5085,6 +5085,14 @@ export async function resolveStaticRouteOptionsCapability(
         const optionsDeclarator = declarators.find((item) =>
           staticExportName(item.id as ASTNode | undefined) === "OPTIONS"
         );
+        if (
+          declarators.some((item) => {
+            const id = item.id as ASTNode | undefined;
+            return isNode(id) && id.type !== "Identifier";
+          })
+        ) {
+          uncertain = true;
+        }
         if (optionsDeclarator) {
           if (isStaticCallableRouteValue(optionsDeclarator.init as ASTNode | undefined)) {
             return "present";

--- a/src/routing/api/module-loader/source-capability-analyzer.ts
+++ b/src/routing/api/module-loader/source-capability-analyzer.ts
@@ -5075,7 +5075,7 @@ function orderStaticRouteMethods(methods: string[]): string[] {
   for (const method of STATIC_STANDARD_ROUTE_METHODS) {
     if (methods.includes(method)) ordered.push(method);
   }
-  for (const method of methods.toSorted()) {
+  for (const method of methods.toSorted((left, right) => left.localeCompare(right))) {
     if (
       !STATIC_STANDARD_ROUTE_METHODS.includes(
         method as typeof STATIC_STANDARD_ROUTE_METHODS[number],
@@ -5085,6 +5085,103 @@ function orderStaticRouteMethods(methods: string[]): string[] {
     }
   }
   return ordered;
+}
+
+function staticProgramStatements(program: ASTNode): ASTNode[] {
+  return Array.isArray(program.body)
+    ? program.body.filter((statement): statement is ASTNode => isNode(statement))
+    : [];
+}
+
+function addDefaultRouteMethods(
+  declaration: ASTNode | undefined,
+  methods: string[],
+  requestedMethod: unknown,
+): boolean {
+  const capability = staticDefaultRouteCapability(declaration);
+  if (capability === "unknown") return false;
+  if (capability !== "present") return true;
+
+  for (const method of STATIC_STANDARD_ROUTE_METHODS) {
+    addStaticRouteMethod(methods, method);
+  }
+  if (isStaticHttpMethodName(requestedMethod as string | null)) {
+    addStaticRouteMethod(methods, requestedMethod as string);
+  }
+  return true;
+}
+
+function staticVariableDeclarators(declaration: ASTNode): ASTNode[] {
+  return Array.isArray(declaration.declarations)
+    ? declaration.declarations.filter((item): item is ASTNode => isNode(item))
+    : [];
+}
+
+function addVariableRouteMethods(declaration: ASTNode, methods: string[]): boolean {
+  for (const declarator of staticVariableDeclarators(declaration)) {
+    const method = staticExportName(declarator.id as ASTNode | undefined);
+    if (method === null) return false;
+    if (!isStaticHttpMethodName(method)) continue;
+    if (!isStaticCallableRouteValue(declarator.init as ASTNode | undefined)) return false;
+    addStaticRouteMethod(methods, method);
+  }
+  return true;
+}
+
+function addNamedDeclarationRouteMethods(
+  declaration: ASTNode | undefined,
+  methods: string[],
+): boolean {
+  if (!isNode(declaration)) return true;
+  if (
+    declaration.type === "FunctionDeclaration" ||
+    declaration.type === "ClassDeclaration"
+  ) {
+    const method = staticExportName(declaration.id as ASTNode | undefined);
+    if (isStaticHttpMethodName(method)) addStaticRouteMethod(methods, method);
+    return true;
+  }
+  if (declaration.type === "VariableDeclaration") {
+    return addVariableRouteMethods(declaration, methods);
+  }
+  return true;
+}
+
+function hasAmbiguousRouteSpecifier(statement: ASTNode): boolean {
+  if (!Array.isArray(statement.specifiers)) return false;
+  for (const specifier of statement.specifiers) {
+    if (!isNode(specifier) || specifier.exportKind === "type") continue;
+    const exportedName = staticExportName(specifier.exported as ASTNode | undefined);
+    if (isStaticHttpMethodName(exportedName)) return true;
+  }
+  return false;
+}
+
+function addNamedRouteMethods(statement: ASTNode, methods: string[]): boolean {
+  if (statement.exportKind === "type") return true;
+  if (!addNamedDeclarationRouteMethods(statement.declaration as ASTNode | undefined, methods)) {
+    return false;
+  }
+  return !hasAmbiguousRouteSpecifier(statement);
+}
+
+function inspectStaticRouteMethodStatement(
+  statement: ASTNode,
+  methods: string[],
+  requestedMethod: unknown,
+): boolean {
+  if (statement.type === "ExportDefaultDeclaration") {
+    return addDefaultRouteMethods(
+      statement.declaration as ASTNode | undefined,
+      methods,
+      requestedMethod,
+    );
+  }
+  if (statement.type === "ExportAllDeclaration") {
+    return statement.exportKind === "type";
+  }
+  if (statement.type !== "ExportNamedDeclaration") return true;
+  return addNamedRouteMethods(statement, methods);
 }
 
 /**
@@ -5103,68 +5200,78 @@ export async function resolveStaticRouteMethods(
   if (program === null) return undefined;
 
   const methods: string[] = [];
-  for (const statement of Array.isArray(program.body) ? program.body : []) {
-    if (!isNode(statement)) continue;
-
-    if (statement.type === "ExportDefaultDeclaration") {
-      const defaultCapability = staticDefaultRouteCapability(
-        statement.declaration as ASTNode | undefined,
-      );
-      if (defaultCapability === "unknown") return undefined;
-      if (defaultCapability === "present") {
-        for (const method of STATIC_STANDARD_ROUTE_METHODS) addStaticRouteMethod(methods, method);
-        if (isStaticHttpMethodName(requestedMethod as string | null)) {
-          addStaticRouteMethod(methods, requestedMethod as string);
-        }
-      }
-      continue;
-    }
-
-    if (statement.type === "ExportAllDeclaration") {
-      if (statement.exportKind !== "type") return undefined;
-      continue;
-    }
-
-    if (statement.type !== "ExportNamedDeclaration" || statement.exportKind === "type") continue;
-
-    const declaration = statement.declaration as ASTNode | undefined;
-    if (isNode(declaration)) {
-      if (
-        declaration.type === "FunctionDeclaration" || declaration.type === "ClassDeclaration"
-      ) {
-        const method = staticExportName(declaration.id as ASTNode | undefined);
-        if (isStaticHttpMethodName(method)) addStaticRouteMethod(methods, method);
-      } else if (declaration.type === "VariableDeclaration") {
-        for (
-          const declarator of Array.isArray(declaration.declarations)
-            ? declaration.declarations.filter((item): item is ASTNode => isNode(item))
-            : []
-        ) {
-          const method = staticExportName(declarator.id as ASTNode | undefined);
-          if (method === null) return undefined;
-          if (isStaticHttpMethodName(method)) {
-            if (!isStaticCallableRouteValue(declarator.init as ASTNode | undefined)) {
-              return undefined;
-            }
-            addStaticRouteMethod(methods, method);
-          }
-        }
-      }
-    }
-
-    for (
-      const specifier of Array.isArray(statement.specifiers)
-        ? statement.specifiers.filter((item): item is ASTNode => isNode(item))
-        : []
-    ) {
-      if (specifier.exportKind === "type") continue;
-      const exportedName = staticExportName(specifier.exported as ASTNode | undefined);
-      if (isStaticHttpMethodName(exportedName)) return undefined;
+  for (const statement of staticProgramStatements(program)) {
+    if (!inspectStaticRouteMethodStatement(statement, methods, requestedMethod)) {
+      return undefined;
     }
   }
 
   if (methods.includes("GET")) addStaticRouteMethod(methods, "HEAD");
   return orderStaticRouteMethods(methods);
+}
+
+type StaticRouteOptionsInspection = StaticRouteOptionsCapability | "continue";
+
+function inspectStaticOptionsDeclaration(
+  declaration: ASTNode | undefined,
+): StaticRouteOptionsInspection {
+  if (!isNode(declaration)) return "continue";
+
+  const declarationName = staticExportName(declaration.id as ASTNode | undefined);
+  if (
+    declarationName === "OPTIONS" &&
+    declaration.declare !== true &&
+    (declaration.type === "FunctionDeclaration" || declaration.type === "ClassDeclaration")
+  ) {
+    return "present";
+  }
+  if (declaration.type !== "VariableDeclaration") return "continue";
+
+  const declarators = staticVariableDeclarators(declaration);
+  const hasDestructuredDeclaration = declarators.some((item) => {
+    const id = item.id as ASTNode | undefined;
+    return isNode(id) && id.type !== "Identifier";
+  });
+  const optionsDeclarator = declarators.find((item) =>
+    staticExportName(item.id as ASTNode | undefined) === "OPTIONS"
+  );
+  if (optionsDeclarator) {
+    return isStaticCallableRouteValue(optionsDeclarator.init as ASTNode | undefined)
+      ? "present"
+      : "unknown";
+  }
+  return hasDestructuredDeclaration ? "unknown" : "continue";
+}
+
+function inspectStaticOptionsSpecifiers(statement: ASTNode): StaticRouteOptionsInspection {
+  if (!Array.isArray(statement.specifiers)) return "continue";
+  for (const specifier of statement.specifiers) {
+    if (!isNode(specifier) || specifier.exportKind === "type") continue;
+    const exportedName = staticExportName(specifier.exported as ASTNode | undefined);
+    if (exportedName === "OPTIONS" || exportedName === "default") return "present";
+  }
+  return "continue";
+}
+
+function inspectStaticOptionsStatement(statement: ASTNode): StaticRouteOptionsInspection {
+  if (statement.type === "ExportDefaultDeclaration") {
+    return staticDefaultRouteCapability(statement.declaration as ASTNode | undefined);
+  }
+  if (statement.type === "ExportAllDeclaration") {
+    return statement.exportKind === "type" ? "continue" : "unknown";
+  }
+  if (statement.type !== "ExportNamedDeclaration" || statement.exportKind === "type") {
+    return "continue";
+  }
+
+  const declarationResult = inspectStaticOptionsDeclaration(
+    statement.declaration as ASTNode | undefined,
+  );
+  if (declarationResult === "present") return "present";
+
+  const specifierResult = inspectStaticOptionsSpecifiers(statement);
+  if (specifierResult === "present") return "present";
+  return declarationResult;
 }
 
 /**
@@ -5184,71 +5291,12 @@ export async function resolveStaticRouteOptionsCapability(
   const program = await parseSource(source);
   if (program === null) return "unknown";
 
-  const statements = Array.isArray(program.body)
-    ? program.body.filter((statement): statement is ASTNode => isNode(statement))
-    : [];
   let uncertain = false;
 
-  for (const statement of statements) {
-    if (statement.type === "ExportDefaultDeclaration") {
-      const defaultCapability = staticDefaultRouteCapability(
-        statement.declaration as ASTNode | undefined,
-      );
-      if (defaultCapability === "present") return "present";
-      if (defaultCapability === "unknown") uncertain = true;
-      continue;
-    }
-
-    if (statement.type === "ExportAllDeclaration") {
-      if (statement.exportKind !== "type") uncertain = true;
-      continue;
-    }
-
-    if (statement.type !== "ExportNamedDeclaration" || statement.exportKind === "type") {
-      continue;
-    }
-
-    const declaration = statement.declaration as ASTNode | undefined;
-    if (isNode(declaration)) {
-      const declarationName = staticExportName(declaration.id as ASTNode | undefined);
-      if (
-        declarationName === "OPTIONS" &&
-        declaration.declare !== true &&
-        (declaration.type === "FunctionDeclaration" || declaration.type === "ClassDeclaration")
-      ) return "present";
-
-      if (declaration.type === "VariableDeclaration") {
-        const declarators = Array.isArray(declaration.declarations)
-          ? declaration.declarations.filter((item): item is ASTNode => isNode(item))
-          : [];
-        const optionsDeclarator = declarators.find((item) =>
-          staticExportName(item.id as ASTNode | undefined) === "OPTIONS"
-        );
-        if (
-          declarators.some((item) => {
-            const id = item.id as ASTNode | undefined;
-            return isNode(id) && id.type !== "Identifier";
-          })
-        ) {
-          uncertain = true;
-        }
-        if (optionsDeclarator) {
-          if (isStaticCallableRouteValue(optionsDeclarator.init as ASTNode | undefined)) {
-            return "present";
-          }
-          uncertain = true;
-        }
-      }
-    }
-
-    const specifiers = Array.isArray(statement.specifiers)
-      ? statement.specifiers.filter((specifier): specifier is ASTNode => isNode(specifier))
-      : [];
-    for (const specifier of specifiers) {
-      if (specifier.exportKind === "type") continue;
-      const exportedName = staticExportName(specifier.exported as ASTNode | undefined);
-      if (exportedName === "OPTIONS" || exportedName === "default") return "present";
-    }
+  for (const statement of staticProgramStatements(program)) {
+    const result = inspectStaticOptionsStatement(statement);
+    if (result === "present") return "present";
+    if (result === "unknown") uncertain = true;
   }
 
   return uncertain ? "unknown" : "absent";

--- a/src/routing/api/module-loader/source-capability-analyzer.ts
+++ b/src/routing/api/module-loader/source-capability-analyzer.ts
@@ -5018,8 +5018,29 @@ function isStaticCallableRouteValue(node: ASTNode | undefined): boolean {
   return isNode(node) && (
     node.type === "ArrowFunctionExpression" ||
     node.type === "FunctionExpression" ||
+    node.type === "FunctionDeclaration" ||
+    node.type === "ClassDeclaration" ||
     node.type === "ClassExpression"
   );
+}
+
+function staticDefaultRouteCapability(node: ASTNode | undefined): StaticRouteOptionsCapability {
+  if (isTypeOnlyExportDeclaration(node)) return "absent";
+  if (isStaticCallableRouteValue(node)) return "present";
+  if (!isNode(node)) return "unknown";
+
+  switch (node.type) {
+    case "ArrayExpression":
+    case "BooleanLiteral":
+    case "NullLiteral":
+    case "NumericLiteral":
+    case "ObjectExpression":
+    case "RegExpLiteral":
+    case "StringLiteral":
+      return "absent";
+    default:
+      return "unknown";
+  }
 }
 
 function isTypeOnlyExportDeclaration(node: ASTNode | undefined): boolean {
@@ -5054,9 +5075,11 @@ export async function resolveStaticRouteOptionsCapability(
 
   for (const statement of statements) {
     if (statement.type === "ExportDefaultDeclaration") {
-      if (!isTypeOnlyExportDeclaration(statement.declaration as ASTNode | undefined)) {
-        return "present";
-      }
+      const defaultCapability = staticDefaultRouteCapability(
+        statement.declaration as ASTNode | undefined,
+      );
+      if (defaultCapability === "present") return "present";
+      if (defaultCapability === "unknown") uncertain = true;
       continue;
     }
 

--- a/src/routing/api/module-loader/source-capability-analyzer.ts
+++ b/src/routing/api/module-loader/source-capability-analyzer.ts
@@ -5004,6 +5004,17 @@ export async function analyzeSourceCapabilities(
 
 export type StaticRouteOptionsCapability = "present" | "absent" | "unknown";
 
+const STATIC_STANDARD_ROUTE_METHODS = [
+  "GET",
+  "HEAD",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "OPTIONS",
+] as const;
+const STATIC_HTTP_METHOD_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Z]+$/;
+
 function staticExportName(node: ASTNode | undefined): string | null {
   if (!isNode(node)) return null;
   if (node.type === "Identifier" && typeof node.name === "string") return node.name;
@@ -5049,6 +5060,107 @@ function isTypeOnlyExportDeclaration(node: ASTNode | undefined): boolean {
     node.type === "TSInterfaceDeclaration" ||
     node.type === "TSTypeAliasDeclaration" ||
     node.type === "TSDeclareFunction";
+}
+
+function isStaticHttpMethodName(value: string | null): value is string {
+  return value !== null && STATIC_HTTP_METHOD_PATTERN.test(value);
+}
+
+function addStaticRouteMethod(methods: string[], method: string): void {
+  if (!methods.includes(method)) methods.push(method);
+}
+
+function orderStaticRouteMethods(methods: string[]): string[] {
+  const ordered: string[] = [];
+  for (const method of STATIC_STANDARD_ROUTE_METHODS) {
+    if (methods.includes(method)) ordered.push(method);
+  }
+  for (const method of methods.toSorted()) {
+    if (
+      !STATIC_STANDARD_ROUTE_METHODS.includes(
+        method as typeof STATIC_STANDARD_ROUTE_METHODS[number],
+      )
+    ) {
+      ordered.push(method);
+    }
+  }
+  return ordered;
+}
+
+/**
+ * Resolve only route methods that are proven by export syntax, without
+ * evaluating the route module. `undefined` means the source is too dynamic to
+ * safely narrow a preflight response; callers must use their conservative
+ * default in that case.
+ */
+export async function resolveStaticRouteMethods(
+  source: string,
+): Promise<readonly string[] | undefined> {
+  if (COMMONJS_EXPORT_PATTERN.test(source)) return undefined;
+
+  const program = await parseSource(source);
+  if (program === null) return undefined;
+
+  const methods: string[] = [];
+  for (const statement of Array.isArray(program.body) ? program.body : []) {
+    if (!isNode(statement)) continue;
+
+    if (statement.type === "ExportDefaultDeclaration") {
+      const defaultCapability = staticDefaultRouteCapability(
+        statement.declaration as ASTNode | undefined,
+      );
+      if (defaultCapability === "unknown") return undefined;
+      if (defaultCapability === "present") {
+        for (const method of STATIC_STANDARD_ROUTE_METHODS) addStaticRouteMethod(methods, method);
+      }
+      continue;
+    }
+
+    if (statement.type === "ExportAllDeclaration") {
+      if (statement.exportKind !== "type") return undefined;
+      continue;
+    }
+
+    if (statement.type !== "ExportNamedDeclaration" || statement.exportKind === "type") continue;
+
+    const declaration = statement.declaration as ASTNode | undefined;
+    if (isNode(declaration)) {
+      if (
+        declaration.type === "FunctionDeclaration" || declaration.type === "ClassDeclaration"
+      ) {
+        const method = staticExportName(declaration.id as ASTNode | undefined);
+        if (isStaticHttpMethodName(method)) addStaticRouteMethod(methods, method);
+      } else if (declaration.type === "VariableDeclaration") {
+        for (
+          const declarator of Array.isArray(declaration.declarations)
+            ? declaration.declarations.filter((item): item is ASTNode => isNode(item))
+            : []
+        ) {
+          const method = staticExportName(declarator.id as ASTNode | undefined);
+          if (method === null) return undefined;
+          if (isStaticHttpMethodName(method)) {
+            if (!isStaticCallableRouteValue(declarator.init as ASTNode | undefined)) {
+              return undefined;
+            }
+            addStaticRouteMethod(methods, method);
+          }
+        }
+      }
+    }
+
+    for (
+      const specifier of Array.isArray(statement.specifiers)
+        ? statement.specifiers.filter((item): item is ASTNode => isNode(item))
+        : []
+    ) {
+      if (specifier.exportKind === "type") continue;
+      const exportedName = staticExportName(specifier.exported as ASTNode | undefined);
+      if (isStaticHttpMethodName(exportedName)) return undefined;
+    }
+  }
+
+  if (methods.includes("GET")) addStaticRouteMethod(methods, "HEAD");
+  return orderStaticRouteMethods(methods);
 }
 
 /**

--- a/src/routing/api/module-loader/source-capability-analyzer.ts
+++ b/src/routing/api/module-loader/source-capability-analyzer.ts
@@ -14,6 +14,7 @@ const StringPrototypeIndexOf = String.prototype.indexOf;
 const StringPrototypeIncludes = String.prototype.includes;
 const StringPrototypeSlice = String.prototype.slice;
 const StringPrototypeStartsWith = String.prototype.startsWith;
+const COMMONJS_EXPORT_PATTERN = /\b(?:module\s*\.\s*exports|exports\s*\.)/;
 
 interface ParentLink {
   parent: ASTNode;
@@ -4999,4 +5000,109 @@ export async function analyzeSourceCapabilities(
     moduleSpecifiers: analysis.moduleSpecifiers,
     hasUnconstrainedDynamicImport: analysis.hasUnconstrainedDynamicImport,
   };
+}
+
+export type StaticRouteOptionsCapability = "present" | "absent" | "unknown";
+
+function staticExportName(node: ASTNode | undefined): string | null {
+  if (!isNode(node)) return null;
+  if (node.type === "Identifier" && typeof node.name === "string") return node.name;
+  if (
+    (node.type === "StringLiteral" || node.type === "Literal") &&
+    typeof node.value === "string"
+  ) return node.value;
+  return null;
+}
+
+function isStaticCallableRouteValue(node: ASTNode | undefined): boolean {
+  return isNode(node) && (
+    node.type === "ArrowFunctionExpression" ||
+    node.type === "FunctionExpression" ||
+    node.type === "ClassExpression"
+  );
+}
+
+function isTypeOnlyExportDeclaration(node: ASTNode | undefined): boolean {
+  if (!isNode(node)) return true;
+  return node.declare === true ||
+    node.type === "TSInterfaceDeclaration" ||
+    node.type === "TSTypeAliasDeclaration" ||
+    node.type === "TSDeclareFunction";
+}
+
+/**
+ * Determine whether a route's OPTIONS export is statically absent.
+ *
+ * This intentionally reports `unknown` for dynamic or ambiguous export
+ * shapes. Callers may use only `absent` as a pre-authentication signal; every
+ * other result keeps the existing authenticate-before-evaluation boundary.
+ */
+export async function resolveStaticRouteOptionsCapability(
+  source: string,
+): Promise<StaticRouteOptionsCapability> {
+  // CommonJS assignments are resolved by the loader rather than the ESM
+  // export declarations below. Keep the pre-auth path conservative for them.
+  if (COMMONJS_EXPORT_PATTERN.test(source)) return "unknown";
+
+  const program = await parseSource(source);
+  if (program === null) return "unknown";
+
+  const statements = Array.isArray(program.body)
+    ? program.body.filter((statement): statement is ASTNode => isNode(statement))
+    : [];
+  let uncertain = false;
+
+  for (const statement of statements) {
+    if (statement.type === "ExportDefaultDeclaration") {
+      if (!isTypeOnlyExportDeclaration(statement.declaration as ASTNode | undefined)) {
+        return "present";
+      }
+      continue;
+    }
+
+    if (statement.type === "ExportAllDeclaration") {
+      if (statement.exportKind !== "type") uncertain = true;
+      continue;
+    }
+
+    if (statement.type !== "ExportNamedDeclaration" || statement.exportKind === "type") {
+      continue;
+    }
+
+    const declaration = statement.declaration as ASTNode | undefined;
+    if (isNode(declaration)) {
+      const declarationName = staticExportName(declaration.id as ASTNode | undefined);
+      if (
+        declarationName === "OPTIONS" &&
+        declaration.declare !== true &&
+        (declaration.type === "FunctionDeclaration" || declaration.type === "ClassDeclaration")
+      ) return "present";
+
+      if (declaration.type === "VariableDeclaration") {
+        const declarators = Array.isArray(declaration.declarations)
+          ? declaration.declarations.filter((item): item is ASTNode => isNode(item))
+          : [];
+        const optionsDeclarator = declarators.find((item) =>
+          staticExportName(item.id as ASTNode | undefined) === "OPTIONS"
+        );
+        if (optionsDeclarator) {
+          if (isStaticCallableRouteValue(optionsDeclarator.init as ASTNode | undefined)) {
+            return "present";
+          }
+          uncertain = true;
+        }
+      }
+    }
+
+    const specifiers = Array.isArray(statement.specifiers)
+      ? statement.specifiers.filter((specifier): specifier is ASTNode => isNode(specifier))
+      : [];
+    for (const specifier of specifiers) {
+      if (specifier.exportKind === "type") continue;
+      const exportedName = staticExportName(specifier.exported as ASTNode | undefined);
+      if (exportedName === "OPTIONS" || exportedName === "default") return "present";
+    }
+  }
+
+  return uncertain ? "unknown" : "absent";
 }

--- a/src/routing/api/module-loader/source-capability-analyzer.ts
+++ b/src/routing/api/module-loader/source-capability-analyzer.ts
@@ -5095,6 +5095,7 @@ function orderStaticRouteMethods(methods: string[]): string[] {
  */
 export async function resolveStaticRouteMethods(
   source: string,
+  requestedMethod?: unknown,
 ): Promise<readonly string[] | undefined> {
   if (COMMONJS_EXPORT_PATTERN.test(source)) return undefined;
 
@@ -5112,6 +5113,9 @@ export async function resolveStaticRouteMethods(
       if (defaultCapability === "unknown") return undefined;
       if (defaultCapability === "present") {
         for (const method of STATIC_STANDARD_ROUTE_METHODS) addStaticRouteMethod(methods, method);
+        if (isStaticHttpMethodName(requestedMethod as string | null)) {
+          addStaticRouteMethod(methods, requestedMethod as string);
+        }
       }
       continue;
     }

--- a/src/routing/api/route-executor.test.ts
+++ b/src/routing/api/route-executor.test.ts
@@ -1608,6 +1608,52 @@ describe("routing/api/route-executor", () => {
       assertEquals(methods, ["GET", "HEAD", "POST", "OPTIONS"]);
     });
 
+    it("can omit the framework OPTIONS fallback from prepared route methods", async () => {
+      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+      Deno.env.set("WORKER_ISOLATION_API", "1");
+      await __resetPoolForTests();
+
+      const options = await preparedRouteOptions(
+        "export function GET() {}",
+        "prepared-methods-authored",
+      );
+
+      const methods = await runWithExactSourceIntegrationPolicy(
+        normalizeSourceIntegrationPolicy({ allow: {} }),
+        () =>
+          resolvePreparedRouteMethods(
+            undefined,
+            options,
+            { includeFrameworkOptions: false },
+          ),
+      );
+
+      assertEquals(methods, ["GET", "HEAD"]);
+    });
+
+    it("keeps authored OPTIONS when omitting the framework fallback", async () => {
+      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+      Deno.env.set("WORKER_ISOLATION_API", "1");
+      await __resetPoolForTests();
+
+      const options = await preparedRouteOptions(
+        "export function GET() {} export function OPTIONS() {}",
+        "prepared-methods-options",
+      );
+
+      const methods = await runWithExactSourceIntegrationPolicy(
+        normalizeSourceIntegrationPolicy({ allow: {} }),
+        () =>
+          resolvePreparedRouteMethods(
+            undefined,
+            options,
+            { includeFrameworkOptions: false },
+          ),
+      );
+
+      assertEquals(methods, ["GET", "HEAD", "OPTIONS"]);
+    });
+
     it("rejects when the prepared module has no callable route export", async () => {
       Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
       Deno.env.set("WORKER_ISOLATION_API", "1");

--- a/src/routing/api/route-executor.test.ts
+++ b/src/routing/api/route-executor.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import {
   assertEquals,
   assertRejects,
+  assertStrictEquals,
   assertStringIncludes,
   assertThrows,
 } from "#veryfront/testing/assert.ts";
@@ -1652,6 +1653,44 @@ describe("routing/api/route-executor", () => {
       );
 
       assertEquals(methods, ["GET", "HEAD", "OPTIONS"]);
+    });
+
+    it("caches prepared methods by worker semantics and requested custom method", async () => {
+      Deno.env.set("WORKER_ISOLATION_ENABLED", "1");
+      Deno.env.set("WORKER_ISOLATION_API", "1");
+      await __resetPoolForTests();
+
+      const options = await preparedRouteOptions(
+        "export default function handler() {}",
+        "prepared-methods-semantic-cache",
+      );
+      const emptyPolicy = normalizeSourceIntegrationPolicy({ allow: {} });
+      const githubPolicy = normalizeSourceIntegrationPolicy({ allow: { github: {} } });
+
+      const first = await runWithExactSourceIntegrationPolicy(
+        emptyPolicy,
+        () => resolvePreparedRouteMethods("PROPFIND", options),
+      );
+      const repeated = await runWithExactSourceIntegrationPolicy(
+        emptyPolicy,
+        () => resolvePreparedRouteMethods("PROPFIND", options),
+      );
+      assertStrictEquals(repeated, first);
+      assertEquals(first.includes("PROPFIND"), true);
+
+      const customMethod = await runWithExactSourceIntegrationPolicy(
+        emptyPolicy,
+        () => resolvePreparedRouteMethods("MKCOL", options),
+      );
+      assertEquals(customMethod.includes("MKCOL"), true);
+      assertEquals(customMethod.includes("PROPFIND"), false);
+
+      const changedPolicy = await runWithExactSourceIntegrationPolicy(
+        githubPolicy,
+        () => resolvePreparedRouteMethods("PROPFIND", options),
+      );
+      assertEquals(Object.is(changedPolicy, first), false);
+      assertEquals(changedPolicy, first);
     });
 
     it("rejects when the prepared module has no callable route export", async () => {

--- a/src/routing/api/route-executor.ts
+++ b/src/routing/api/route-executor.ts
@@ -1214,6 +1214,7 @@ export function executePreparedPagesRoute(
 export async function resolvePreparedRouteMethods(
   requestedMethod: string | undefined,
   options: Omit<PreparedRouteExecutionOptions, "isLocalProject">,
+  methodOptions: { includeFrameworkOptions?: boolean } = {},
 ): Promise<string[]> {
   const semanticContext = await snapshotWorkerSemanticContext();
   const workerResponse = await getWorkerPool().execute(
@@ -1225,6 +1226,9 @@ export async function resolvePreparedRouteMethods(
       module: options.module,
       modulePath: options.modulePath,
       requestedMethod,
+      ...(methodOptions.includeFrameworkOptions === undefined
+        ? {}
+        : { includeFrameworkOptions: methodOptions.includeFrameworkOptions }),
       projectDir: options.projectDir,
       sourceIntegrationPolicy: semanticContext.sourceIntegrationPolicy,
       projectEnv: semanticContext.projectEnv,

--- a/src/routing/api/route-executor.ts
+++ b/src/routing/api/route-executor.ts
@@ -410,6 +410,15 @@ function handleAPIError(
   return errorToRFC9457Response(detached, ctx, req);
 }
 
+/** Convert a route-boundary failure through the canonical API error policy. */
+export function createAPIRouteErrorResponse(
+  error: unknown,
+  pathname: string,
+  isLocalProject: boolean,
+): Response {
+  return handleAPIError(error, pathname, isLocalProject);
+}
+
 interface ExecuteRouteOptionsSnapshot {
   readonly modulePath?: string;
   readonly projectDir?: string;

--- a/src/routing/api/route-executor.ts
+++ b/src/routing/api/route-executor.ts
@@ -61,6 +61,7 @@ import {
 import { isInfrastructureOnlyRequestHeader } from "#veryfront/security/http/application-request.ts";
 import type { ApplicationIdentity } from "#veryfront/security/application-auth/types.ts";
 import { snapshotApplicationIdentity } from "#veryfront/security/application-auth/identity.ts";
+import { LRUCache } from "#veryfront/utils/lru-wrapper.ts";
 
 const apply = Reflect.apply;
 const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
@@ -76,6 +77,10 @@ const objectPrototype = Object.prototype;
 const EMPTY_PROJECT_ENV = objectFreeze(
   objectCreate(null) as Record<string, string>,
 );
+const PREPARED_ROUTE_METHOD_CACHE_MAX_ENTRIES = 256;
+const preparedRouteMethodCache = new LRUCache<string, Promise<readonly string[]>>({
+  maxEntries: PREPARED_ROUTE_METHOD_CACHE_MAX_ENTRIES,
+});
 const numberIsSafeInteger = Number.isSafeInteger;
 const NativePromise = Promise;
 const promiseResolve = NativePromise.resolve;
@@ -1215,42 +1220,70 @@ export async function resolvePreparedRouteMethods(
   requestedMethod: string | undefined,
   options: Omit<PreparedRouteExecutionOptions, "isLocalProject">,
   methodOptions: { includeFrameworkOptions?: boolean } = {},
-): Promise<string[]> {
+): Promise<readonly string[]> {
   const semanticContext = await snapshotWorkerSemanticContext();
-  const workerResponse = await getWorkerPool().execute(
-    await resolveApiWorkerId(options.executionScopeId, semanticContext.generation),
-    [options.projectDir],
-    {
-      type: "inspect-api-route-methods",
-      id: randomUUID(),
-      module: options.module,
-      modulePath: options.modulePath,
-      requestedMethod,
-      ...(methodOptions.includeFrameworkOptions === undefined
-        ? {}
-        : { includeFrameworkOptions: methodOptions.includeFrameworkOptions }),
-      projectDir: options.projectDir,
-      sourceIntegrationPolicy: semanticContext.sourceIntegrationPolicy,
-      projectEnv: semanticContext.projectEnv,
-    },
+  const normalizedRequestedMethod = normalizeRouteMethod(requestedMethod) ?? undefined;
+  const includeFrameworkOptions = methodOptions.includeFrameworkOptions;
+  const keyParts: string[] = [];
+  appendFramed(keyParts, options.executionScopeId);
+  appendFramed(keyParts, semanticContext.generation);
+  appendFramed(keyParts, options.projectDir);
+  appendFramed(keyParts, options.modulePath);
+  appendFramed(keyParts, options.module.sha256);
+  appendFramed(keyParts, normalizedRequestedMethod ?? "");
+  appendFramed(
+    keyParts,
+    includeFrameworkOptions === false ? "authored" : "framework",
   );
+  const cacheKey = apply(arrayJoin, keyParts, ["|"]) as string;
 
-  if (workerResponse.type === "error") {
-    throw deserializeWorkerError(workerResponse.error);
-  }
-  if (workerResponse.type !== "api-route-methods") {
-    throw createRequestBodyReadError(
-      "Worker returned an unexpected API route capability response",
-    );
+  let pending = preparedRouteMethodCache.get(cacheKey);
+  if (!pending) {
+    pending = (async (): Promise<readonly string[]> => {
+      const workerResponse = await getWorkerPool().execute(
+        await resolveApiWorkerId(options.executionScopeId, semanticContext.generation),
+        [options.projectDir],
+        {
+          type: "inspect-api-route-methods",
+          id: randomUUID(),
+          module: options.module,
+          modulePath: options.modulePath,
+          requestedMethod: normalizedRequestedMethod,
+          ...(includeFrameworkOptions === undefined ? {} : { includeFrameworkOptions }),
+          projectDir: options.projectDir,
+          sourceIntegrationPolicy: semanticContext.sourceIntegrationPolicy,
+          projectEnv: semanticContext.projectEnv,
+        },
+      );
+
+      if (workerResponse.type === "error") {
+        throw deserializeWorkerError(workerResponse.error);
+      }
+      if (workerResponse.type !== "api-route-methods") {
+        throw createRequestBodyReadError(
+          "Worker returned an unexpected API route capability response",
+        );
+      }
+
+      const methods = snapshotWorkerRouteMethods(workerResponse);
+      if (!methods) {
+        throw createRequestBodyReadError(
+          "Worker returned an invalid API route capability response",
+        );
+      }
+      return objectFreeze(methods) as readonly string[];
+    })();
+    preparedRouteMethodCache.set(cacheKey, pending);
   }
 
-  const methods = snapshotWorkerRouteMethods(workerResponse);
-  if (!methods) {
-    throw createRequestBodyReadError(
-      "Worker returned an invalid API route capability response",
-    );
+  try {
+    return await pending;
+  } catch (error) {
+    if (preparedRouteMethodCache.get(cacheKey) === pending) {
+      preparedRouteMethodCache.delete(cacheKey);
+    }
+    throw error;
   }
-  return methods;
 }
 
 export function executeAppRoute(

--- a/src/security/application-auth/trusted-proxy.ts
+++ b/src/security/application-auth/trusted-proxy.ts
@@ -57,6 +57,7 @@ const stringToLowerCase = String.prototype.toLowerCase;
 const stringTrim = String.prototype.trim;
 
 const admittedTrustedProxyRequests = new NativeWeakSet<Request>();
+const EMPTY_IDENTITY_HEADER_NAMES = objectFreeze([] as string[]);
 
 if (typeof rawRequestHeadersGetter !== "function") {
   throw new TypeError("Request.prototype.headers getter is unavailable");
@@ -94,6 +95,26 @@ export function markTrustedProxyApplicationAuthAdmittedRequest(request: Request)
 
 export function isTrustedProxyApplicationAuthAdmittedRequest(request: Request): boolean {
   return apply(weakSetHas, admittedTrustedProxyRequests, [request]) as boolean;
+}
+
+/** Snapshot the configured identity headers before request admission runs. */
+export function getTrustedProxyApplicationIdentityHeaderNames(
+  config: TrustedProxyAuthConfig,
+): readonly string[] {
+  try {
+    const root = readPlainObjectDescriptors(config);
+    const headers = snapshotHeaders(readDataProperty(root, "headers"));
+    if (headers === null) return EMPTY_IDENTITY_HEADER_NAMES;
+    return freezeUniqueHeaderNames([
+      headers.subject,
+      headers.email,
+      headers.name,
+      headers.groups,
+      headers.roles,
+    ]) ?? EMPTY_IDENTITY_HEADER_NAMES;
+  } catch {
+    return EMPTY_IDENTITY_HEADER_NAMES;
+  }
 }
 
 interface TrustedProxyConfigSnapshot {

--- a/src/security/http/application-request.ts
+++ b/src/security/http/application-request.ts
@@ -15,8 +15,11 @@ const NativeRequest = Request;
 const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
 const getOwnPropertyDescriptors = Object.getOwnPropertyDescriptors;
 const getOwnPropertySymbols = Object.getOwnPropertySymbols;
+const arrayJoin = Array.prototype.join;
+const arrayPush = Array.prototype.push;
 const headersAppend = NativeHeaders.prototype.append;
 const headersForEach = NativeHeaders.prototype.forEach;
+const headersGet = NativeHeaders.prototype.get;
 const numberIsSafeInteger = NativeNumber.isSafeInteger;
 const objectKeys = Object.keys;
 const regexpTest = RegExp.prototype.test;
@@ -29,10 +32,13 @@ const requestHeadersGetter = getOwnPropertyDescriptor(
 )?.get;
 const stringToLowerCase = String.prototype.toLowerCase;
 const stringStartsWith = String.prototype.startsWith;
+const stringSplit = String.prototype.split;
+const stringTrim = String.prototype.trim;
 const stringCharCodeAt = String.prototype.charCodeAt;
 const HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 const MAX_DYNAMIC_DENY_HEADERS = 32;
 const MAX_DYNAMIC_DENY_HEADER_NAME_LENGTH = 128;
+const DEFAULT_APPLICATION_PREFLIGHT_HEADERS = "Content-Type,Authorization";
 
 if (typeof requestHeadersGetter !== "function") {
   throw new TypeError("Request.prototype.headers getter is unavailable");
@@ -74,6 +80,31 @@ export function isInfrastructureOnlyRequestHeader(name: string): boolean {
       return true;
     default:
       return false;
+  }
+}
+
+/** Keep infrastructure-only request headers out of browser preflight policy. */
+export function getApplicationPreflightHeaders(request: Request): string {
+  try {
+    const headers = apply(requestHeadersGetter!, request, []) as Headers;
+    const requested = apply(headersGet, headers, ["access-control-request-headers"]);
+    if (typeof requested !== "string" || requested.length === 0) {
+      return DEFAULT_APPLICATION_PREFLIGHT_HEADERS;
+    }
+
+    const names = apply(stringSplit, requested, [","]) as string[];
+    const allowed: string[] = [];
+    for (let index = 0; index < names.length; index++) {
+      const name = apply(stringTrim, names[index], []) as string;
+      if (name.length > 0 && !isInfrastructureOnlyRequestHeader(name)) {
+        apply(arrayPush, allowed, [name]);
+      }
+    }
+    return allowed.length > 0
+      ? apply(arrayJoin, allowed, [","]) as string
+      : DEFAULT_APPLICATION_PREFLIGHT_HEADERS;
+  } catch {
+    return DEFAULT_APPLICATION_PREFLIGHT_HEADERS;
   }
 }
 

--- a/src/security/http/application-request.ts
+++ b/src/security/http/application-request.ts
@@ -84,7 +84,10 @@ export function isInfrastructureOnlyRequestHeader(name: string): boolean {
 }
 
 /** Keep infrastructure-only request headers out of browser preflight policy. */
-export function getApplicationPreflightHeaders(request: Request): string {
+export function getApplicationPreflightHeaders(
+  request: Request,
+  options: Pick<ApplicationRequestHeaderOptions, "denyHeaders"> = {},
+): string {
   try {
     const headers = apply(requestHeadersGetter!, request, []) as Headers;
     const requested = apply(headersGet, headers, ["access-control-request-headers"]);
@@ -92,11 +95,17 @@ export function getApplicationPreflightHeaders(request: Request): string {
       return DEFAULT_APPLICATION_PREFLIGHT_HEADERS;
     }
 
+    const dynamicDenyHeaders = normalizeDynamicDenyHeaders(options.denyHeaders);
     const names = apply(stringSplit, requested, [","]) as string[];
     const allowed: string[] = [];
     for (let index = 0; index < names.length; index++) {
       const name = apply(stringTrim, names[index], []) as string;
-      if (name.length > 0 && !isInfrastructureOnlyRequestHeader(name)) {
+      const normalizedName = apply(stringToLowerCase, name, []) as string;
+      if (
+        name.length > 0 &&
+        !isInfrastructureOnlyRequestHeader(name) &&
+        !(dynamicDenyHeaders && setContains(dynamicDenyHeaders, normalizedName))
+      ) {
         apply(arrayPush, allowed, [name]);
       }
     }

--- a/src/security/http/application-request.ts
+++ b/src/security/http/application-request.ts
@@ -38,7 +38,7 @@ const stringCharCodeAt = String.prototype.charCodeAt;
 const HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 const MAX_DYNAMIC_DENY_HEADERS = 32;
 const MAX_DYNAMIC_DENY_HEADER_NAME_LENGTH = 128;
-const DEFAULT_APPLICATION_PREFLIGHT_HEADERS = "Content-Type,Authorization";
+const DEFAULT_APPLICATION_PREFLIGHT_HEADER_NAMES = ["Content-Type", "Authorization"] as const;
 
 if (typeof requestHeadersGetter !== "function") {
   throw new TypeError("Request.prototype.headers getter is unavailable");
@@ -88,15 +88,16 @@ export function getApplicationPreflightHeaders(
   request: Request,
   options: Pick<ApplicationRequestHeaderOptions, "denyHeaders"> = {},
 ): string {
+  const dynamicDenyHeaders = normalizeDynamicDenyHeaders(options.denyHeaders);
+  if (dynamicDenyHeaders === null) return "";
+
   try {
     const headers = apply(requestHeadersGetter!, request, []) as Headers;
     const requested = apply(headersGet, headers, ["access-control-request-headers"]);
     if (typeof requested !== "string" || requested.length === 0) {
-      return DEFAULT_APPLICATION_PREFLIGHT_HEADERS;
+      return defaultApplicationPreflightHeaders(dynamicDenyHeaders);
     }
 
-    const dynamicDenyHeaders = normalizeDynamicDenyHeaders(options.denyHeaders);
-    if (dynamicDenyHeaders === null) return DEFAULT_APPLICATION_PREFLIGHT_HEADERS;
     const names = apply(stringSplit, requested, [","]) as string[];
     const allowed: string[] = [];
     for (let index = 0; index < names.length; index++) {
@@ -112,10 +113,23 @@ export function getApplicationPreflightHeaders(
     }
     return allowed.length > 0
       ? apply(arrayJoin, allowed, [","]) as string
-      : DEFAULT_APPLICATION_PREFLIGHT_HEADERS;
+      : defaultApplicationPreflightHeaders(dynamicDenyHeaders);
   } catch {
-    return DEFAULT_APPLICATION_PREFLIGHT_HEADERS;
+    return defaultApplicationPreflightHeaders(dynamicDenyHeaders);
   }
+}
+
+function defaultApplicationPreflightHeaders(denyHeaders: ReadonlySet<string>): string {
+  const allowed: string[] = [];
+  for (const name of DEFAULT_APPLICATION_PREFLIGHT_HEADER_NAMES) {
+    if (
+      !isInfrastructureOnlyRequestHeader(name) &&
+      !setContains(denyHeaders, apply(stringToLowerCase, name, []) as string)
+    ) {
+      apply(arrayPush, allowed, [name]);
+    }
+  }
+  return apply(arrayJoin, allowed, [","]) as string;
 }
 
 export interface ApplicationRequestHeaderOptions {

--- a/src/security/http/application-request.ts
+++ b/src/security/http/application-request.ts
@@ -96,6 +96,7 @@ export function getApplicationPreflightHeaders(
     }
 
     const dynamicDenyHeaders = normalizeDynamicDenyHeaders(options.denyHeaders);
+    if (dynamicDenyHeaders === null) return DEFAULT_APPLICATION_PREFLIGHT_HEADERS;
     const names = apply(stringSplit, requested, [","]) as string[];
     const allowed: string[] = [];
     for (let index = 0; index < names.length; index++) {
@@ -104,7 +105,7 @@ export function getApplicationPreflightHeaders(
       if (
         name.length > 0 &&
         !isInfrastructureOnlyRequestHeader(name) &&
-        !(dynamicDenyHeaders && setContains(dynamicDenyHeaders, normalizedName))
+        !setContains(dynamicDenyHeaders, normalizedName)
       ) {
         apply(arrayPush, allowed, [name]);
       }

--- a/src/security/http/auth.test.ts
+++ b/src/security/http/auth.test.ts
@@ -94,6 +94,18 @@ describe("AuthHandler realm sanitization", () => {
     expect(result.response).toBeUndefined();
   });
 
+  it("applies the credential gate when an OPTIONS route is executable", async () => {
+    const handler = createHandler();
+    const result = await handler.handleExplicitOptions(
+      new Request("http://localhost/test", { method: "OPTIONS" }),
+      createCtx(),
+    );
+
+    expect(result.continue).not.toBe(true);
+    expect(result.response?.status).toBe(401);
+    expect(result.response?.headers.get("WWW-Authenticate")).toBe('Basic realm="Secure Area"');
+  });
+
   it("does not widen the method exemption past OPTIONS", async () => {
     const handler = createHandler();
     const result = await handler.handle(

--- a/src/security/http/auth.ts
+++ b/src/security/http/auth.ts
@@ -188,7 +188,22 @@ export class AuthHandler extends BaseHandler {
   };
 
   handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
-    if (req.method.toUpperCase() === "OPTIONS") return Promise.resolve(this.continue());
+    return this.handleRequest(req, ctx, true);
+  }
+
+  /** Apply the configured credential gate to a route-owned OPTIONS handler. */
+  handleExplicitOptions(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
+    return this.handleRequest(req, ctx, false);
+  }
+
+  private handleRequest(
+    req: Request,
+    ctx: HandlerContext,
+    exemptOptions: boolean,
+  ): Promise<HandlerResult> {
+    if (exemptOptions && req.method.toUpperCase() === "OPTIONS") {
+      return Promise.resolve(this.continue());
+    }
 
     const pathname = new URL(req.url).pathname;
 

--- a/src/security/http/cors/preflight.test.ts
+++ b/src/security/http/cors/preflight.test.ts
@@ -3,6 +3,7 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { DEFAULT_MAX_AGE, DEFAULT_METHODS } from "./constants.ts";
 import {
+  applyCORSPreflightHeaders,
   handleCORSPreflight,
   isPreflightRequest,
   normalizeCORSPreflightList,
@@ -11,6 +12,47 @@ import { MAX_CORS_TOKEN_LENGTH } from "#veryfront/utils/cors-policy-limits.ts";
 
 describe("security/http/cors/preflight", () => {
   describe("configured policy", () => {
+    it("merges preflight policy into a route response with one origin validation", async () => {
+      let validations = 0;
+      const request = new Request("http://localhost/", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://app.example.com",
+          "access-control-request-method": "POST",
+          "access-control-request-headers": "Authorization",
+        },
+      });
+
+      const response = await applyCORSPreflightHeaders({
+        request,
+        response: new Response("route response", {
+          status: 207,
+          headers: {
+            vary: "Accept-Encoding",
+            "x-route": "options",
+            "access-control-allow-origin": "https://untrusted.example",
+          },
+        }),
+        config: {
+          origin: async (origin) => {
+            validations++;
+            return origin;
+          },
+        },
+        allowMethods: "POST, OPTIONS",
+        allowHeaders: "Authorization",
+      });
+
+      assertEquals(validations, 1);
+      assertEquals(response.status, 207);
+      assertEquals(await response.text(), "route response");
+      assertEquals(response.headers.get("x-route"), "options");
+      assertEquals(response.headers.get("access-control-allow-origin"), "https://app.example.com");
+      assertEquals(response.headers.get("access-control-allow-methods"), "POST, OPTIONS");
+      assertEquals(response.headers.get("access-control-allow-headers"), "Authorization");
+      assertEquals(response.headers.get("vary"), "Accept-Encoding, Origin");
+    });
+
     it("keeps configured methods and headers narrower than runtime capabilities", async () => {
       const request = new Request("http://localhost/", {
         method: "OPTIONS",

--- a/src/security/http/cors/preflight.ts
+++ b/src/security/http/cors/preflight.ts
@@ -17,9 +17,11 @@ import { serverLogger } from "#veryfront/utils";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import {
   isBoundedCorsTokenList,
+  isCorsPolicyResponseHeaderName,
   MAX_CORS_SERIALIZED_LIST_LENGTH,
   MAX_CORS_TOKEN_COUNT,
 } from "#veryfront/utils/cors-policy-limits.ts";
+import { scrubPolicyOwnedCORSHeaders } from "./headers.ts";
 
 const logger = serverLogger.component("cors");
 const REJECTED_PREFLIGHT_BODY = "CORS request rejected";
@@ -181,6 +183,36 @@ export function handleCORSPreflight(options: CORSPreflightOptions): Promise<Resp
     },
     { "cors.origin": corsOriginForTelemetry(observedOrigin) },
   );
+}
+
+/** Apply validated preflight policy headers without replacing the route response. */
+export async function applyCORSPreflightHeaders(
+  options: CORSPreflightOptions & { response: Response },
+): Promise<Response> {
+  const policy = await handleCORSPreflight(options);
+  const headers = new Headers(options.response.headers);
+  scrubPolicyOwnedCORSHeaders(headers);
+  for (const [name, value] of policy.headers) {
+    if (isCorsPolicyResponseHeaderName(name)) headers.set(name, value);
+  }
+
+  const policyVary = policy.headers.get("Vary");
+  if (policyVary) {
+    const varyValues = headers
+      .get("Vary")
+      ?.split(",")
+      .map((value) => value.trim())
+      .filter(Boolean) ?? [];
+    if (!varyValues.some((value) => value === "*" || value.toLowerCase() === "origin")) {
+      headers.set("Vary", [...varyValues, policyVary].join(", "));
+    }
+  }
+
+  return new Response(options.response.body, {
+    status: options.response.status,
+    statusText: options.response.statusText,
+    headers,
+  });
 }
 
 export function isPreflightRequest(request: Request): boolean {

--- a/src/security/sandbox/worker-script.test.ts
+++ b/src/security/sandbox/worker-script.test.ts
@@ -749,6 +749,28 @@ describe("worker-script request snapshots", () => {
     );
   });
 
+  it("snapshots the framework OPTIONS inspection flag as a boolean", () => {
+    const request = {
+      type: "inspect-api-route-methods",
+      id: "authored-options-only",
+      module: {
+        source: "export function GET() {}",
+        sha256: "a".repeat(64),
+      },
+      modulePath: "/project/app/api/route.ts",
+      projectDir: "/project",
+      sourceIntegrationPolicy: TEST_SOURCE_INTEGRATION_POLICY,
+      includeFrameworkOptions: false,
+    };
+
+    assertEquals(snapshotWorkerRequest(request).includeFrameworkOptions, false);
+    assertThrows(
+      () => snapshotWorkerRequest({ ...request, includeFrameworkOptions: "false" }),
+      TypeError,
+      "Invalid worker request includeFrameworkOptions",
+    );
+  });
+
   it("uses stable typed protocol errors for invalid request contracts", () => {
     const unknownTypeError = assertThrows(
       () =>

--- a/src/security/sandbox/worker-script.test.ts
+++ b/src/security/sandbox/worker-script.test.ts
@@ -763,7 +763,12 @@ describe("worker-script request snapshots", () => {
       includeFrameworkOptions: false,
     };
 
-    assertEquals(snapshotWorkerRequest(request).includeFrameworkOptions, false);
+    const snapshot = snapshotWorkerRequest(request);
+    assertEquals(snapshot.type, "inspect-api-route-methods");
+    if (snapshot.type !== "inspect-api-route-methods") {
+      throw new Error("Expected an API route inspection request");
+    }
+    assertEquals(snapshot.includeFrameworkOptions, false);
     assertThrows(
       () => snapshotWorkerRequest({ ...request, includeFrameworkOptions: "false" }),
       TypeError,

--- a/src/security/sandbox/worker-script.ts
+++ b/src/security/sandbox/worker-script.ts
@@ -1948,7 +1948,7 @@ export function snapshotWorkerRequest(value: unknown): WorkerRequest {
         "projectDir",
         "sourceIntegrationPolicy",
       ],
-      ["requestedMethod", "projectEnv"],
+      ["requestedMethod", "includeFrameworkOptions", "projectEnv"],
       "payload",
     );
     return {
@@ -1973,6 +1973,16 @@ export function snapshotWorkerRequest(value: unknown): WorkerRequest {
         "requestedMethod",
         64,
       ),
+      includeFrameworkOptions: (() => {
+        const field = readOptionalDataProperty(request, "includeFrameworkOptions");
+        if (!field.present) return undefined;
+        if (typeof field.value !== "boolean") {
+          throw new NativeTypeError(
+            "Invalid worker request includeFrameworkOptions",
+          );
+        }
+        return field.value;
+      })(),
       projectDir: requireString(
         readDataProperty(request, "projectDir"),
         "projectDir",
@@ -2854,7 +2864,9 @@ async function handleInspectApiRouteMethods(
         projectEnv: req.projectEnv,
       });
       return snapshotResolvedRouteMethods(
-        resolveExecutableRouteMethods(mod, req.requestedMethod),
+        resolveExecutableRouteMethods(mod, req.requestedMethod, {
+          includeFrameworkOptions: req.includeFrameworkOptions,
+        }),
         false,
       );
     },

--- a/src/security/sandbox/worker-types.ts
+++ b/src/security/sandbox/worker-types.ts
@@ -169,6 +169,8 @@ export interface InspectApiRouteMethodsRequest {
   modulePath: string;
   /** Optional custom-method probe used for default-export capability parity. */
   requestedMethod?: string;
+  /** Whether method discovery includes the framework-provided OPTIONS fallback. */
+  includeFrameworkOptions?: boolean;
   projectDir: string;
   /** Exact source-owned integration policy for this project execution. */
   sourceIntegrationPolicy: SourceIntegrationPolicyManifest;

--- a/src/server/handlers/execution-surface-policy.test.ts
+++ b/src/server/handlers/execution-surface-policy.test.ts
@@ -39,6 +39,7 @@ const CAPABILITY_GATED_SURFACES = [
   "request/public-agents-list.handler.ts",
   "request/snippet.handler.ts",
   "request/ssr/ssr.handler.ts",
+  "response/cors.ts",
 ].toSorted();
 
 /**
@@ -48,7 +49,7 @@ const CAPABILITY_GATED_SURFACES = [
  */
 const NON_GATE_USES: Record<string, string> = {
   "response/cors.ts":
-    "Chooses which CORS methods to advertise. Degrades to defaults on a shared runtime rather than denying, so the capability does not apply.",
+    "Avoids reloading request-scoped hosted config after its separate capability gate admits route inspection.",
 };
 
 async function readHandlerSources(): Promise<Map<string, string>> {

--- a/src/server/handlers/request/api/api-handler-wrapper.test.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.test.ts
@@ -43,6 +43,33 @@ function createCtx(captured: { options?: Record<string, unknown> }): HandlerCont
 }
 
 describe("ApiHandlerWrapper", () => {
+  it("does not discover project primitives before routing an OPTIONS request", async () => {
+    const ctx = createCtx({});
+    ctx.allowHostProjectCodeExecution = true;
+    const fs = ctx.adapter.fs as unknown as {
+      runWithContext: (
+        slug: string,
+        token: string,
+        fn: () => Promise<unknown>,
+      ) => Promise<unknown>;
+      ensureSourceSnapshotFresh: (reason?: string) => Promise<void>;
+    };
+    const freshnessReasons: string[] = [];
+    fs.runWithContext = async (_slug, _token, fn) => await fn();
+    fs.ensureSourceSnapshotFresh = (reason) => {
+      if (reason) freshnessReasons.push(reason);
+      return Promise.resolve();
+    };
+
+    const result = await new ApiHandlerWrapper("/tmp/project", ctx.adapter).handle(
+      new Request("http://localhost/api/private", { method: "OPTIONS" }),
+      ctx,
+    );
+
+    assertEquals(result.continue, true);
+    assertEquals(freshnessReasons.includes("primitive-discovery"), false);
+  });
+
   it("propagates request cancellation instead of continuing handler discovery", async () => {
     const ctx = createCtx({});
     const fs = ctx.adapter.fs as unknown as {

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -179,11 +179,11 @@ export class ApiHandlerWrapper extends BaseHandler {
             return this.continue();
           }
 
-          // OPTIONS is routed by APIRouteHandler before any project primitive
-          // discovery. The API handler authenticates an authored OPTIONS route
-          // before loading or executing its module; discovery must not become a
-          // pre-auth project-code evaluation side effect.
-          if (req.method.toUpperCase() !== "OPTIONS") {
+          // OPTIONS is authenticated by APIRouteHandler before discovery. The
+          // callback runs after a matched route's auth decision but before the
+          // route module is loaded or executed.
+          const isOptionsRequest = req.method.toUpperCase() === "OPTIONS";
+          if (!isOptionsRequest) {
             // Lazy per-project primitive discovery (agents, tools) on first
             // access. Must run within runWithContext so VFS and registry scope
             // are correct.
@@ -192,7 +192,18 @@ export class ApiHandlerWrapper extends BaseHandler {
 
           const apiRes = await withApiHandler(
             ctx,
-            (api) => api.handle(req, ctx),
+            (api) =>
+              api.handle(
+                req,
+                ctx,
+                isOptionsRequest
+                  ? {
+                    beforeOptionsDispatch: async () => {
+                      await ensureProjectDiscovery(ctx);
+                    },
+                  }
+                  : undefined,
+              ),
             { sourceSnapshotReady: true },
           );
 

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -179,9 +179,16 @@ export class ApiHandlerWrapper extends BaseHandler {
             return this.continue();
           }
 
-          // Lazy per-project primitive discovery (agents, tools) on first access.
-          // Must run within runWithContext so VFS and registry scope are correct.
-          await ensureProjectDiscovery(ctx);
+          // OPTIONS is routed by APIRouteHandler before any project primitive
+          // discovery. The API handler authenticates an authored OPTIONS route
+          // before loading or executing its module; discovery must not become a
+          // pre-auth project-code evaluation side effect.
+          if (req.method.toUpperCase() !== "OPTIONS") {
+            // Lazy per-project primitive discovery (agents, tools) on first
+            // access. Must run within runWithContext so VFS and registry scope
+            // are correct.
+            await ensureProjectDiscovery(ctx);
+          }
 
           const apiRes = await withApiHandler(
             ctx,

--- a/src/server/handlers/response/cors.test.ts
+++ b/src/server/handlers/response/cors.test.ts
@@ -213,6 +213,38 @@ describe("server/handlers/response/cors", () => {
       assertEquals(routeResolutionCalls, 0);
     });
 
+    it("continues API preflight in an operator-granted atomic contextual runtime", async () => {
+      let routeResolutionCalls = 0;
+      const ctx = makeCtx({
+        projectSlug: "tenant-project",
+        allowHostProjectCodeExecution: true,
+        prepareHostedConfigContext: () => Promise.reject(new Error("unused")),
+      });
+      const fs = ctx.adapter.fs as unknown as {
+        isContextualMode: () => boolean;
+        isMultiProjectMode: () => boolean;
+        runWithContext: (...args: never[]) => Promise<unknown>;
+      };
+      fs.isContextualMode = () => true;
+      fs.isMultiProjectMode = () => true;
+      fs.runWithContext = () => Promise.resolve(undefined);
+      const handler = new CorsHandler({
+        resolveAppRouteFile: () => {
+          routeResolutionCalls++;
+          return Promise.resolve(null);
+        },
+      });
+
+      const result = await handler.handle(
+        new Request("https://tenant.example/api/items", { method: "OPTIONS" }),
+        ctx,
+      );
+
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
+      assertEquals(routeResolutionCalls, 0);
+    });
+
     it("continues a matched non-API App route with an OPTIONS export", async () => {
       const handler = new CorsHandler({
         resolveAppRouteFile: () => Promise.resolve({ file: "/project/route.ts", params: {} }),

--- a/src/server/handlers/response/cors.test.ts
+++ b/src/server/handlers/response/cors.test.ts
@@ -166,6 +166,31 @@ describe("server/handlers/response/cors", () => {
       assertEquals(routeResolutionCalls, 0);
     });
 
+    it("responds to API preflight when contextual execution is unavailable", async () => {
+      const ctx = makeCtx({
+        securityConfig: { cors: { origin: ["https://app.example"] } } as never,
+      });
+      (ctx.adapter.fs as unknown as { isContextualMode: () => boolean }).isContextualMode = () =>
+        true;
+
+      const result = await new CorsHandler().handle(
+        new Request("https://app.example/api/items", {
+          method: "OPTIONS",
+          headers: {
+            Origin: "https://app.example",
+            "access-control-request-method": "POST",
+          },
+        }),
+        ctx,
+      );
+
+      assertEquals(result.response?.status, 204);
+      assertEquals(
+        result.response?.headers.get("access-control-allow-origin"),
+        "https://app.example",
+      );
+    });
+
     it("continues API preflight in an operator-granted shared runtime", async () => {
       let routeResolutionCalls = 0;
       const handler = new CorsHandler({
@@ -191,7 +216,6 @@ describe("server/handlers/response/cors", () => {
     it("continues a matched non-API App route with an OPTIONS export", async () => {
       const handler = new CorsHandler({
         resolveAppRouteFile: () => Promise.resolve({ file: "/project/route.ts", params: {} }),
-        loadAppRouteModule: () => Promise.resolve({ OPTIONS: () => new Response() }),
       });
       const result = await handler.handle(
         new Request("https://app.example/webhook", { method: "OPTIONS" }),
@@ -205,7 +229,6 @@ describe("server/handlers/response/cors", () => {
     it("continues a matched non-API App route with a default export", async () => {
       const handler = new CorsHandler({
         resolveAppRouteFile: () => Promise.resolve({ file: "/project/route.ts", params: {} }),
-        loadAppRouteModule: () => Promise.resolve({ default: () => new Response() }),
       });
       const result = await handler.handle(
         new Request("https://app.example/webhook", { method: "OPTIONS" }),

--- a/src/server/handlers/response/cors.test.ts
+++ b/src/server/handlers/response/cors.test.ts
@@ -167,6 +167,28 @@ describe("server/handlers/response/cors", () => {
       assertEquals(routeResolutionCalls, 0);
     });
 
+    it("continues API preflight in an operator-granted shared runtime", async () => {
+      let routeResolutionCalls = 0;
+      const handler = new CorsHandler({
+        resolveAppRouteFile: () => {
+          routeResolutionCalls++;
+          return Promise.resolve(null);
+        },
+      });
+
+      const result = await handler.handle(
+        new Request("https://tenant.example/api/items", { method: "OPTIONS" }),
+        makeCtx({
+          allowHostProjectCodeExecution: true,
+          prepareHostedConfigContext: () => Promise.reject(new Error("unused")),
+        }),
+      );
+
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
+      assertEquals(routeResolutionCalls, 0);
+    });
+
     it("continues a matched non-API App route with an OPTIONS export", async () => {
       const projectDir = await makeTempDir({ prefix: "veryfront-cors-options-" });
       const routeFile = `${projectDir}/route.mjs`;

--- a/src/server/handlers/response/cors.test.ts
+++ b/src/server/handlers/response/cors.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { CorsHandler } from "./cors.ts";
 import type { HandlerContext } from "../types.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { getApplicationPreflightHeaders } from "#veryfront/security/http/application-request.ts";
 
 function createMockAdapter(): RuntimeAdapter {
   return {
@@ -381,7 +382,31 @@ describe("server/handlers/response/cors", () => {
 
       assertEquals(
         result.response?.headers.get("access-control-allow-headers"),
-        "Content-Type, Authorization",
+        null,
+      );
+    });
+
+    it("does not reintroduce dynamically denied default preflight headers", () => {
+      const request = new Request("http://localhost/webhook", {
+        method: "OPTIONS",
+        headers: {
+          "access-control-request-headers": "Authorization, Content-Type",
+        },
+      });
+
+      assertEquals(
+        getApplicationPreflightHeaders(request, { denyHeaders: ["authorization"] }),
+        "Content-Type",
+      );
+      assertEquals(
+        getApplicationPreflightHeaders(request, { denyHeaders: ["content-type"] }),
+        "Authorization",
+      );
+      assertEquals(
+        getApplicationPreflightHeaders(request, {
+          denyHeaders: ["authorization", "content-type"],
+        }),
+        "",
       );
     });
   });

--- a/src/server/handlers/response/cors.test.ts
+++ b/src/server/handlers/response/cors.test.ts
@@ -1,6 +1,7 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { makeTempDir, remove, writeTextFile } from "#veryfront/testing/deno-compat.ts";
 import { CorsHandler } from "./cors.ts";
 import type { HandlerContext } from "../types.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
@@ -74,7 +75,7 @@ describe("server/handlers/response/cors", () => {
 
     it("responds to OPTIONS requests", async () => {
       const handler = new CorsHandler();
-      const req = new Request("http://localhost/api/test", {
+      const req = new Request("http://localhost/webhook", {
         method: "OPTIONS",
         headers: {
           origin: "http://localhost:3000",
@@ -89,7 +90,7 @@ describe("server/handlers/response/cors", () => {
 
     it("responds to OPTIONS with access-control headers", async () => {
       const handler = new CorsHandler();
-      const req = new Request("http://localhost/api/test", {
+      const req = new Request("http://localhost/webhook", {
         method: "OPTIONS",
         headers: {
           origin: "http://localhost:3000",
@@ -112,7 +113,7 @@ describe("server/handlers/response/cors", () => {
     it("handles OPTIONS with lowercase method check", async () => {
       const handler = new CorsHandler();
       // OPTIONS method should be matched case-insensitively
-      const req = new Request("http://localhost/api/test", {
+      const req = new Request("http://localhost/webhook", {
         method: "OPTIONS",
       });
       const ctx = makeCtx();
@@ -147,9 +148,76 @@ describe("server/handlers/response/cors", () => {
       assertEquals(routeResolutionCalls, 0);
     });
 
+    it("continues API preflight in a dedicated runtime", async () => {
+      let routeResolutionCalls = 0;
+      const handler = new CorsHandler({
+        resolveAppRouteFile: () => {
+          routeResolutionCalls++;
+          return Promise.resolve(null);
+        },
+      });
+
+      const result = await handler.handle(
+        new Request("https://app.example/api/items", { method: "OPTIONS" }),
+        makeCtx(),
+      );
+
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
+      assertEquals(routeResolutionCalls, 0);
+    });
+
+    it("continues a matched non-API App route with an OPTIONS export", async () => {
+      const projectDir = await makeTempDir({ prefix: "veryfront-cors-options-" });
+      const routeFile = `${projectDir}/route.mjs`;
+      await writeTextFile(
+        routeFile,
+        "export function OPTIONS() { return new Response('route options'); }",
+      );
+
+      try {
+        const handler = new CorsHandler({
+          resolveAppRouteFile: () => Promise.resolve({ file: routeFile, params: {} }),
+        });
+        const result = await handler.handle(
+          new Request("https://app.example/webhook", { method: "OPTIONS" }),
+          makeCtx({ projectDir }),
+        );
+
+        assertEquals(result.continue, true);
+        assertEquals(result.response, undefined);
+      } finally {
+        await remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("continues a matched non-API App route with a default export", async () => {
+      const projectDir = await makeTempDir({ prefix: "veryfront-cors-default-options-" });
+      const routeFile = `${projectDir}/route.mjs`;
+      await writeTextFile(
+        routeFile,
+        "export default function handler() { return new Response('default options'); }",
+      );
+
+      try {
+        const handler = new CorsHandler({
+          resolveAppRouteFile: () => Promise.resolve({ file: routeFile, params: {} }),
+        });
+        const result = await handler.handle(
+          new Request("https://app.example/webhook", { method: "OPTIONS" }),
+          makeCtx({ projectDir }),
+        );
+
+        assertEquals(result.continue, true);
+        assertEquals(result.response, undefined);
+      } finally {
+        await remove(projectDir, { recursive: true });
+      }
+    });
+
     it("does not advertise infrastructure-only request headers", async () => {
       const result = await new CorsHandler().handle(
-        new Request("http://localhost/api/test", {
+        new Request("http://localhost/webhook", {
           method: "OPTIONS",
           headers: {
             Origin: "https://app.example",

--- a/src/server/handlers/response/cors.test.ts
+++ b/src/server/handlers/response/cors.test.ts
@@ -292,5 +292,27 @@ describe("server/handlers/response/cors", () => {
         "Authorization, X-App-Trace",
       );
     });
+
+    it("does not advertise dynamically denied application identity headers", async () => {
+      const result = await new CorsHandler().handle(
+        new Request("http://localhost/webhook", {
+          method: "OPTIONS",
+          headers: {
+            Origin: "https://app.example",
+            "access-control-request-method": "POST",
+            "access-control-request-headers": "Authorization, X-Auth-Subject, X-App-Trace",
+          },
+        }),
+        makeCtx({
+          applicationIdentityHeaderNames: ["x-auth-subject"],
+          securityConfig: { cors: { origin: ["https://app.example"] } } as never,
+        }),
+      );
+
+      assertEquals(
+        result.response?.headers.get("access-control-allow-headers"),
+        "Authorization, X-App-Trace",
+      );
+    });
   });
 });

--- a/src/server/handlers/response/cors.test.ts
+++ b/src/server/handlers/response/cors.test.ts
@@ -1,7 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { makeTempDir, remove, writeTextFile } from "#veryfront/testing/deno-compat.ts";
 import { CorsHandler } from "./cors.ts";
 import type { HandlerContext } from "../types.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
@@ -190,51 +189,31 @@ describe("server/handlers/response/cors", () => {
     });
 
     it("continues a matched non-API App route with an OPTIONS export", async () => {
-      const projectDir = await makeTempDir({ prefix: "veryfront-cors-options-" });
-      const routeFile = `${projectDir}/route.mjs`;
-      await writeTextFile(
-        routeFile,
-        "export function OPTIONS() { return new Response('route options'); }",
+      const handler = new CorsHandler({
+        resolveAppRouteFile: () => Promise.resolve({ file: "/project/route.ts", params: {} }),
+        loadAppRouteModule: () => Promise.resolve({ OPTIONS: () => new Response() }),
+      });
+      const result = await handler.handle(
+        new Request("https://app.example/webhook", { method: "OPTIONS" }),
+        makeCtx(),
       );
 
-      try {
-        const handler = new CorsHandler({
-          resolveAppRouteFile: () => Promise.resolve({ file: routeFile, params: {} }),
-        });
-        const result = await handler.handle(
-          new Request("https://app.example/webhook", { method: "OPTIONS" }),
-          makeCtx({ projectDir }),
-        );
-
-        assertEquals(result.continue, true);
-        assertEquals(result.response, undefined);
-      } finally {
-        await remove(projectDir, { recursive: true });
-      }
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
     });
 
     it("continues a matched non-API App route with a default export", async () => {
-      const projectDir = await makeTempDir({ prefix: "veryfront-cors-default-options-" });
-      const routeFile = `${projectDir}/route.mjs`;
-      await writeTextFile(
-        routeFile,
-        "export default function handler() { return new Response('default options'); }",
+      const handler = new CorsHandler({
+        resolveAppRouteFile: () => Promise.resolve({ file: "/project/route.ts", params: {} }),
+        loadAppRouteModule: () => Promise.resolve({ default: () => new Response() }),
+      });
+      const result = await handler.handle(
+        new Request("https://app.example/webhook", { method: "OPTIONS" }),
+        makeCtx(),
       );
 
-      try {
-        const handler = new CorsHandler({
-          resolveAppRouteFile: () => Promise.resolve({ file: routeFile, params: {} }),
-        });
-        const result = await handler.handle(
-          new Request("https://app.example/webhook", { method: "OPTIONS" }),
-          makeCtx({ projectDir }),
-        );
-
-        assertEquals(result.continue, true);
-        assertEquals(result.response, undefined);
-      } finally {
-        await remove(projectDir, { recursive: true });
-      }
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
     });
 
     it("does not advertise infrastructure-only request headers", async () => {

--- a/src/server/handlers/response/cors.test.ts
+++ b/src/server/handlers/response/cors.test.ts
@@ -246,6 +246,40 @@ describe("server/handlers/response/cors", () => {
       assertEquals(routeResolutionCalls, 0);
     });
 
+    it("uses automatic preflight when an atomic runtime has no project slug", async () => {
+      let contextEntries = 0;
+      const ctx = makeCtx({
+        allowHostProjectCodeExecution: true,
+        prepareHostedConfigContext: () => Promise.reject(new Error("unused")),
+        securityConfig: { cors: { origin: ["https://app.example"] } } as never,
+      });
+      const fs = ctx.adapter.fs as unknown as {
+        isContextualMode: () => boolean;
+        isMultiProjectMode: () => boolean;
+        runWithContext: (...args: never[]) => Promise<unknown>;
+      };
+      fs.isContextualMode = () => true;
+      fs.isMultiProjectMode = () => true;
+      fs.runWithContext = async () => {
+        contextEntries++;
+        return undefined;
+      };
+
+      const result = await new CorsHandler().handle(
+        new Request("https://app.example/api/items", {
+          method: "OPTIONS",
+          headers: {
+            Origin: "https://app.example",
+            "access-control-request-method": "POST",
+          },
+        }),
+        ctx,
+      );
+
+      assertEquals(result.response?.status, 204);
+      assertEquals(contextEntries, 0);
+    });
+
     it("resolves a non-API App route inside its atomic project context", async () => {
       let inProjectContext = false;
       const ctx = makeCtx({
@@ -287,6 +321,49 @@ describe("server/handlers/response/cors", () => {
         ctx,
       );
 
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
+    });
+
+    it("refreshes a mutable preview source before non-API route classification", async () => {
+      let sourceIsFresh = false;
+      const ctx = makeCtx({
+        projectSlug: "tenant-project",
+        projectId: "project-123",
+        proxyToken: "proxy-token",
+        allowHostProjectCodeExecution: true,
+        requestContext: { mode: "preview", branch: "feature" } as never,
+      });
+      const fs = ctx.adapter.fs as unknown as {
+        isContextualMode: () => boolean;
+        isMultiProjectMode: () => boolean;
+        runWithContext: <T>(
+          slug: string,
+          token: string,
+          fn: () => Promise<T>,
+        ) => Promise<T>;
+        sourceSnapshotFreshnessOptionsVersion: number;
+        ensureSourceSnapshotFresh: () => Promise<void>;
+      };
+      fs.isContextualMode = () => true;
+      fs.isMultiProjectMode = () => true;
+      fs.runWithContext = async (_slug, _token, fn) => await fn();
+      fs.sourceSnapshotFreshnessOptionsVersion = 1;
+      fs.ensureSourceSnapshotFresh = async () => {
+        sourceIsFresh = true;
+      };
+
+      const result = await new CorsHandler({
+        resolveAppRouteFile: () =>
+          Promise.resolve(
+            sourceIsFresh ? { file: "/project/app/webhook/route.ts", params: {} } : null,
+          ),
+      }).handle(
+        new Request("https://tenant.example/webhook", { method: "OPTIONS" }),
+        ctx,
+      );
+
+      assertEquals(sourceIsFresh, true);
       assertEquals(result.continue, true);
       assertEquals(result.response, undefined);
     });

--- a/src/server/handlers/response/cors.test.ts
+++ b/src/server/handlers/response/cors.test.ts
@@ -245,6 +245,51 @@ describe("server/handlers/response/cors", () => {
       assertEquals(routeResolutionCalls, 0);
     });
 
+    it("resolves a non-API App route inside its atomic project context", async () => {
+      let inProjectContext = false;
+      const ctx = makeCtx({
+        projectSlug: "tenant-project",
+        projectId: "project-123",
+        proxyToken: "proxy-token",
+        environmentName: "Staging",
+        allowHostProjectCodeExecution: true,
+        requestContext: { mode: "preview", branch: "feature" } as never,
+      });
+      const fs = ctx.adapter.fs as unknown as {
+        isContextualMode: () => boolean;
+        isMultiProjectMode: () => boolean;
+        runWithContext: <T>(
+          slug: string,
+          token: string,
+          fn: () => Promise<T>,
+        ) => Promise<T>;
+      };
+      fs.isContextualMode = () => true;
+      fs.isMultiProjectMode = () => true;
+      fs.runWithContext = async (_slug, _token, fn) => {
+        inProjectContext = true;
+        try {
+          return await fn();
+        } finally {
+          inProjectContext = false;
+        }
+      };
+      const handler = new CorsHandler({
+        resolveAppRouteFile: () => {
+          if (!inProjectContext) throw new Error("route resolution escaped project context");
+          return Promise.resolve({ file: "/project/app/webhook/route.ts", params: {} });
+        },
+      });
+
+      const result = await handler.handle(
+        new Request("https://tenant.example/webhook", { method: "OPTIONS" }),
+        ctx,
+      );
+
+      assertEquals(result.continue, true);
+      assertEquals(result.response, undefined);
+    });
+
     it("continues a matched non-API App route with an OPTIONS export", async () => {
       const handler = new CorsHandler({
         resolveAppRouteFile: () => Promise.resolve({ file: "/project/route.ts", params: {} }),
@@ -312,6 +357,31 @@ describe("server/handlers/response/cors", () => {
       assertEquals(
         result.response?.headers.get("access-control-allow-headers"),
         "Authorization, X-App-Trace",
+      );
+    });
+
+    it("fails preflight header capabilities closed for a malformed dynamic deny list", async () => {
+      const denyHeaders = ["x-auth-subject"];
+      Object.defineProperty(denyHeaders, "unexpected", { value: "x-app-trace" });
+
+      const result = await new CorsHandler().handle(
+        new Request("http://localhost/webhook", {
+          method: "OPTIONS",
+          headers: {
+            Origin: "https://app.example",
+            "access-control-request-method": "POST",
+            "access-control-request-headers": "X-Auth-Subject, X-App-Trace",
+          },
+        }),
+        makeCtx({
+          applicationIdentityHeaderNames: denyHeaders,
+          securityConfig: { cors: { origin: ["https://app.example"] } } as never,
+        }),
+      );
+
+      assertEquals(
+        result.response?.headers.get("access-control-allow-headers"),
+        "Content-Type, Authorization",
       );
     });
   });

--- a/src/server/handlers/response/cors.ts
+++ b/src/server/handlers/response/cors.ts
@@ -9,6 +9,7 @@ import {
   requiresIsolatedProjectRuntime,
 } from "#veryfront/security/project-locality.ts";
 import { getApplicationPreflightHeaders } from "#veryfront/security/http/application-request.ts";
+import { ensurePreviewSourceSnapshotFresh } from "../request/source-snapshot-freshness.ts";
 
 type AppRouteResolver = typeof resolveAppRouteFile;
 type FsWrapper = {
@@ -57,6 +58,7 @@ export class CorsHandler extends BaseHandler {
     const fsWrapper = ctx.adapter.fs as FsWrapper;
     const hasContextualFilesystem = fsWrapper.isContextualMode?.() === true;
     const hasAtomicSharedRuntimeContext = isSharedRuntime &&
+      !!ctx.projectSlug &&
       fsWrapper.isMultiProjectMode?.() === true &&
       typeof fsWrapper.runWithContext === "function";
     const shouldUseAutomaticPreflight = mustAvoidProjectCode ||
@@ -66,11 +68,15 @@ export class CorsHandler extends BaseHandler {
     }
 
     if (!shouldUseAutomaticPreflight && !isApiPath) {
+      const resolveMatchedRoute = async (): Promise<boolean> => {
+        await ensurePreviewSourceSnapshotFresh(ctx);
+        return this.hasMatchedAppRoute(pathname, ctx);
+      };
       const hasMatchedAppRoute = hasAtomicSharedRuntimeContext
         ? await fsWrapper.runWithContext!(
           ctx.projectSlug!,
           ctx.proxyToken ?? "",
-          () => this.hasMatchedAppRoute(pathname, ctx),
+          resolveMatchedRoute,
           ctx.projectId,
           {
             productionMode: ctx.requestContext?.mode === "production",
@@ -81,7 +87,7 @@ export class CorsHandler extends BaseHandler {
             environmentName: ctx.environmentName,
           },
         )
-        : await this.hasMatchedAppRoute(pathname, ctx);
+        : await resolveMatchedRoute();
       if (hasMatchedAppRoute) return this.continue();
     }
 

--- a/src/server/handlers/response/cors.ts
+++ b/src/server/handlers/response/cors.ts
@@ -28,13 +28,10 @@ export class CorsHandler extends BaseHandler {
 
   private static readonly DEFAULT_METHODS = "GET,POST,PUT,PATCH,DELETE,OPTIONS";
   private readonly resolveAppRouteFile: AppRouteResolver;
-  private readonly loadAppRouteModule: AppRouteModuleLoader;
 
   constructor(dependencies: CorsHandlerDependencies = {}) {
     super();
     this.resolveAppRouteFile = dependencies.resolveAppRouteFile ?? resolveAppRouteFile;
-    this.loadAppRouteModule = dependencies.loadAppRouteModule ??
-      ((file) => import(`file://${file}`) as Promise<Record<string, unknown>>);
   }
 
   async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {

--- a/src/server/handlers/response/cors.ts
+++ b/src/server/handlers/response/cors.ts
@@ -12,9 +12,11 @@ import { getApplicationPreflightHeaders } from "#veryfront/security/http/applica
 import { resolveExecutableRouteMethods } from "#veryfront/routing/api/route-methods.ts";
 
 type AppRouteResolver = typeof resolveAppRouteFile;
+type AppRouteModuleLoader = (file: string) => Promise<Record<string, unknown>>;
 
 export interface CorsHandlerDependencies {
   resolveAppRouteFile?: AppRouteResolver;
+  loadAppRouteModule?: AppRouteModuleLoader;
 }
 
 export class CorsHandler extends BaseHandler {
@@ -26,10 +28,13 @@ export class CorsHandler extends BaseHandler {
 
   private static readonly DEFAULT_METHODS = "GET,POST,PUT,PATCH,DELETE,OPTIONS";
   private readonly resolveAppRouteFile: AppRouteResolver;
+  private readonly loadAppRouteModule: AppRouteModuleLoader;
 
   constructor(dependencies: CorsHandlerDependencies = {}) {
     super();
     this.resolveAppRouteFile = dependencies.resolveAppRouteFile ?? resolveAppRouteFile;
+    this.loadAppRouteModule = dependencies.loadAppRouteModule ??
+      ((file) => import(`file://${file}`) as Promise<Record<string, unknown>>);
   }
 
   async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {
@@ -83,7 +88,7 @@ export class CorsHandler extends BaseHandler {
         return { allowMethods: CorsHandler.DEFAULT_METHODS, hasExecutableOptions: false };
       }
 
-      const mod = (await import(`file://${match.file}`)) as Record<string, unknown>;
+      const mod = await this.loadAppRouteModule(match.file);
       const executableMethods = resolveExecutableRouteMethods(mod);
       const authoredMethods = resolveExecutableRouteMethods(mod, undefined, {
         includeFrameworkOptions: false,

--- a/src/server/handlers/response/cors.ts
+++ b/src/server/handlers/response/cors.ts
@@ -4,7 +4,10 @@ import { ResponseBuilder } from "#veryfront/security/index.ts";
 import { getConfig } from "#veryfront/config";
 import { PRIORITY_VERY_HIGH } from "#veryfront/utils/constants/index.ts";
 import { resolveAppRouteFile } from "../request/api/app-router-resolver.ts";
-import { isSharedProjectRuntime } from "#veryfront/security/project-locality.ts";
+import {
+  isSharedProjectRuntime,
+  requiresIsolatedProjectRuntime,
+} from "#veryfront/security/project-locality.ts";
 import { getApplicationPreflightHeaders } from "#veryfront/security/http/application-request.ts";
 import { resolveExecutableRouteMethods } from "#veryfront/routing/api/route-methods.ts";
 
@@ -34,11 +37,12 @@ export class CorsHandler extends BaseHandler {
 
     const pathname = new URL(req.url).pathname;
     const isSharedRuntime = isSharedProjectRuntime(ctx);
-    if (!isSharedRuntime && (pathname === "/api" || pathname.startsWith("/api/"))) {
+    const mustAvoidProjectCode = requiresIsolatedProjectRuntime(ctx);
+    if (!mustAvoidProjectCode && (pathname === "/api" || pathname.startsWith("/api/"))) {
       return this.continue();
     }
 
-    const routeMethods = isSharedRuntime
+    const routeMethods = mustAvoidProjectCode
       ? { allowMethods: CorsHandler.DEFAULT_METHODS, hasExecutableOptions: false }
       : await this.resolveRouteMethods(pathname, ctx);
     if (routeMethods.hasExecutableOptions) return this.continue();

--- a/src/server/handlers/response/cors.ts
+++ b/src/server/handlers/response/cors.ts
@@ -5,21 +5,10 @@ import { getConfig } from "#veryfront/config";
 import { PRIORITY_VERY_HIGH } from "#veryfront/utils/constants/index.ts";
 import { resolveAppRouteFile } from "../request/api/app-router-resolver.ts";
 import { isSharedProjectRuntime } from "#veryfront/security/project-locality.ts";
-import { isInfrastructureOnlyRequestHeader } from "#veryfront/security/http/application-request.ts";
+import { getApplicationPreflightHeaders } from "#veryfront/security/http/application-request.ts";
 import { resolveExecutableRouteMethods } from "#veryfront/routing/api/route-methods.ts";
 
 type AppRouteResolver = typeof resolveAppRouteFile;
-const DEFAULT_ALLOWED_HEADERS = "Content-Type,Authorization";
-
-function getApplicationPreflightHeaders(request: Request): string {
-  const requested = request.headers.get("access-control-request-headers");
-  if (!requested) return DEFAULT_ALLOWED_HEADERS;
-
-  const allowed = requested.split(",")
-    .map((name) => name.trim())
-    .filter((name) => name.length > 0 && !isInfrastructureOnlyRequestHeader(name));
-  return allowed.length > 0 ? allowed.join(",") : DEFAULT_ALLOWED_HEADERS;
-}
 
 export interface CorsHandlerDependencies {
   resolveAppRouteFile?: AppRouteResolver;

--- a/src/server/handlers/response/cors.ts
+++ b/src/server/handlers/response/cors.ts
@@ -1,17 +1,12 @@
 import { BaseHandler } from "./base.ts";
-import type {
-  HandlerContext,
-  HandlerMetadata,
-  HandlerPriority,
-  HandlerResult,
-  RouteHandlerModule,
-} from "../types.ts";
+import type { HandlerContext, HandlerMetadata, HandlerPriority, HandlerResult } from "../types.ts";
 import { ResponseBuilder } from "#veryfront/security/index.ts";
 import { getConfig } from "#veryfront/config";
 import { PRIORITY_VERY_HIGH } from "#veryfront/utils/constants/index.ts";
 import { resolveAppRouteFile } from "../request/api/app-router-resolver.ts";
 import { isSharedProjectRuntime } from "#veryfront/security/project-locality.ts";
 import { isInfrastructureOnlyRequestHeader } from "#veryfront/security/http/application-request.ts";
+import { resolveExecutableRouteMethods } from "#veryfront/routing/api/route-methods.ts";
 
 type AppRouteResolver = typeof resolveAppRouteFile;
 const DEFAULT_ALLOWED_HEADERS = "Content-Type,Authorization";
@@ -38,7 +33,6 @@ export class CorsHandler extends BaseHandler {
   };
 
   private static readonly DEFAULT_METHODS = "GET,POST,PUT,PATCH,DELETE,OPTIONS";
-  private static readonly HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
   private readonly resolveAppRouteFile: AppRouteResolver;
 
   constructor(dependencies: CorsHandlerDependencies = {}) {
@@ -51,9 +45,14 @@ export class CorsHandler extends BaseHandler {
 
     const pathname = new URL(req.url).pathname;
     const isSharedRuntime = isSharedProjectRuntime(ctx);
-    const allowMethods = isSharedRuntime
-      ? CorsHandler.DEFAULT_METHODS
-      : await this.resolveAllowedMethods(pathname, ctx);
+    if (!isSharedRuntime && (pathname === "/api" || pathname.startsWith("/api/"))) {
+      return this.continue();
+    }
+
+    const routeMethods = isSharedRuntime
+      ? { allowMethods: CorsHandler.DEFAULT_METHODS, hasExecutableOptions: false }
+      : await this.resolveRouteMethods(pathname, ctx);
+    if (routeMethods.hasExecutableOptions) return this.continue();
 
     let corsConfig = ctx.securityConfig?.cors;
     if (!isSharedRuntime) {
@@ -72,7 +71,7 @@ export class CorsHandler extends BaseHandler {
     }
 
     const response = ResponseBuilder.preflight(req, {
-      allowMethods,
+      allowMethods: routeMethods.allowMethods,
       allowHeaders: getApplicationPreflightHeaders(req),
       securityConfig: ctx.securityConfig ?? undefined,
       corsConfig,
@@ -81,22 +80,28 @@ export class CorsHandler extends BaseHandler {
     return this.respond(response);
   }
 
-  private async resolveAllowedMethods(pathname: string, ctx: HandlerContext): Promise<string> {
+  private async resolveRouteMethods(
+    pathname: string,
+    ctx: HandlerContext,
+  ): Promise<{ allowMethods: string; hasExecutableOptions: boolean }> {
     try {
       const match = await this.resolveAppRouteFile(pathname, ctx);
-      if (!match) return CorsHandler.DEFAULT_METHODS;
+      if (!match) {
+        return { allowMethods: CorsHandler.DEFAULT_METHODS, hasExecutableOptions: false };
+      }
 
-      const mod = (await import(`file://${match.file}`)) as RouteHandlerModule;
-      const foundMethods = CorsHandler.HTTP_METHODS.filter((m) => typeof mod[m] === "function");
-
-      const methods: string[] = [...foundMethods];
-      if (foundMethods.includes("GET")) methods.unshift("HEAD");
-      methods.push("OPTIONS");
-
-      return [...new Set(methods)].join(", ");
+      const mod = (await import(`file://${match.file}`)) as Record<string, unknown>;
+      const executableMethods = resolveExecutableRouteMethods(mod);
+      const authoredMethods = resolveExecutableRouteMethods(mod, undefined, {
+        includeFrameworkOptions: false,
+      });
+      return {
+        allowMethods: executableMethods.join(", "),
+        hasExecutableOptions: authoredMethods.includes("OPTIONS"),
+      };
     } catch (error) {
       this.logWarn("Failed to resolve route for CORS", { error, pathname });
-      return CorsHandler.DEFAULT_METHODS;
+      return { allowMethods: CorsHandler.DEFAULT_METHODS, hasExecutableOptions: false };
     }
   }
 }

--- a/src/server/handlers/response/cors.ts
+++ b/src/server/handlers/response/cors.ts
@@ -9,14 +9,14 @@ import {
   requiresIsolatedProjectRuntime,
 } from "#veryfront/security/project-locality.ts";
 import { getApplicationPreflightHeaders } from "#veryfront/security/http/application-request.ts";
-import { resolveExecutableRouteMethods } from "#veryfront/routing/api/route-methods.ts";
 
 type AppRouteResolver = typeof resolveAppRouteFile;
-type AppRouteModuleLoader = (file: string) => Promise<Record<string, unknown>>;
+type FsWrapper = {
+  isContextualMode?: () => boolean;
+};
 
 export interface CorsHandlerDependencies {
   resolveAppRouteFile?: AppRouteResolver;
-  loadAppRouteModule?: AppRouteModuleLoader;
 }
 
 export class CorsHandler extends BaseHandler {
@@ -43,14 +43,17 @@ export class CorsHandler extends BaseHandler {
     const pathname = new URL(req.url).pathname;
     const isSharedRuntime = isSharedProjectRuntime(ctx);
     const mustAvoidProjectCode = requiresIsolatedProjectRuntime(ctx);
-    if (!mustAvoidProjectCode && (pathname === "/api" || pathname.startsWith("/api/"))) {
+    const isApiPath = pathname === "/api" || pathname.startsWith("/api/");
+    const fsWrapper = ctx.adapter.fs as FsWrapper;
+    const hasContextualFilesystem = fsWrapper.isContextualMode?.() === true;
+    if (!mustAvoidProjectCode && isApiPath && !hasContextualFilesystem) {
       return this.continue();
     }
 
-    const routeMethods = mustAvoidProjectCode
-      ? { allowMethods: CorsHandler.DEFAULT_METHODS, hasExecutableOptions: false }
-      : await this.resolveRouteMethods(pathname, ctx);
-    if (routeMethods.hasExecutableOptions) return this.continue();
+    if (!mustAvoidProjectCode && !isApiPath && !hasContextualFilesystem) {
+      const hasMatchedAppRoute = await this.hasMatchedAppRoute(pathname, ctx);
+      if (hasMatchedAppRoute) return this.continue();
+    }
 
     let corsConfig = ctx.securityConfig?.cors;
     if (!isSharedRuntime) {
@@ -69,7 +72,7 @@ export class CorsHandler extends BaseHandler {
     }
 
     const response = ResponseBuilder.preflight(req, {
-      allowMethods: routeMethods.allowMethods,
+      allowMethods: CorsHandler.DEFAULT_METHODS,
       allowHeaders: getApplicationPreflightHeaders(req),
       securityConfig: ctx.securityConfig ?? undefined,
       corsConfig,
@@ -78,28 +81,16 @@ export class CorsHandler extends BaseHandler {
     return this.respond(response);
   }
 
-  private async resolveRouteMethods(
+  private async hasMatchedAppRoute(
     pathname: string,
     ctx: HandlerContext,
-  ): Promise<{ allowMethods: string; hasExecutableOptions: boolean }> {
+  ): Promise<boolean> {
     try {
       const match = await this.resolveAppRouteFile(pathname, ctx);
-      if (!match) {
-        return { allowMethods: CorsHandler.DEFAULT_METHODS, hasExecutableOptions: false };
-      }
-
-      const mod = await this.loadAppRouteModule(match.file);
-      const executableMethods = resolveExecutableRouteMethods(mod);
-      const authoredMethods = resolveExecutableRouteMethods(mod, undefined, {
-        includeFrameworkOptions: false,
-      });
-      return {
-        allowMethods: executableMethods.join(", "),
-        hasExecutableOptions: authoredMethods.includes("OPTIONS"),
-      };
+      return match !== null;
     } catch (error) {
       this.logWarn("Failed to resolve route for CORS", { error, pathname });
-      return { allowMethods: CorsHandler.DEFAULT_METHODS, hasExecutableOptions: false };
+      return false;
     }
   }
 }

--- a/src/server/handlers/response/cors.ts
+++ b/src/server/handlers/response/cors.ts
@@ -14,7 +14,18 @@ type AppRouteResolver = typeof resolveAppRouteFile;
 type FsWrapper = {
   isContextualMode?: () => boolean;
   isMultiProjectMode?: () => boolean;
-  runWithContext?: (...args: never[]) => Promise<unknown>;
+  runWithContext?: <T>(
+    slug: string,
+    token: string,
+    fn: () => Promise<T>,
+    projectId?: string,
+    options?: {
+      productionMode?: boolean;
+      releaseId?: string | null;
+      branch?: string | null;
+      environmentName?: string | null;
+    },
+  ) => Promise<T>;
 };
 
 export interface CorsHandlerDependencies {
@@ -55,7 +66,22 @@ export class CorsHandler extends BaseHandler {
     }
 
     if (!shouldUseAutomaticPreflight && !isApiPath) {
-      const hasMatchedAppRoute = await this.hasMatchedAppRoute(pathname, ctx);
+      const hasMatchedAppRoute = hasAtomicSharedRuntimeContext
+        ? await fsWrapper.runWithContext!(
+          ctx.projectSlug!,
+          ctx.proxyToken ?? "",
+          () => this.hasMatchedAppRoute(pathname, ctx),
+          ctx.projectId,
+          {
+            productionMode: ctx.requestContext?.mode === "production",
+            releaseId: ctx.releaseId,
+            branch: ctx.requestContext?.mode === "production"
+              ? null
+              : ctx.requestContext?.branch ?? ctx.parsedDomain?.branch ?? null,
+            environmentName: ctx.environmentName,
+          },
+        )
+        : await this.hasMatchedAppRoute(pathname, ctx);
       if (hasMatchedAppRoute) return this.continue();
     }
 
@@ -77,7 +103,9 @@ export class CorsHandler extends BaseHandler {
 
     const response = ResponseBuilder.preflight(req, {
       allowMethods: CorsHandler.DEFAULT_METHODS,
-      allowHeaders: getApplicationPreflightHeaders(req),
+      allowHeaders: getApplicationPreflightHeaders(req, {
+        denyHeaders: ctx.applicationIdentityHeaderNames,
+      }),
       securityConfig: ctx.securityConfig ?? undefined,
       corsConfig,
     });

--- a/src/server/handlers/response/cors.ts
+++ b/src/server/handlers/response/cors.ts
@@ -13,6 +13,8 @@ import { getApplicationPreflightHeaders } from "#veryfront/security/http/applica
 type AppRouteResolver = typeof resolveAppRouteFile;
 type FsWrapper = {
   isContextualMode?: () => boolean;
+  isMultiProjectMode?: () => boolean;
+  runWithContext?: (...args: never[]) => Promise<unknown>;
 };
 
 export interface CorsHandlerDependencies {
@@ -43,11 +45,16 @@ export class CorsHandler extends BaseHandler {
     const isApiPath = pathname === "/api" || pathname.startsWith("/api/");
     const fsWrapper = ctx.adapter.fs as FsWrapper;
     const hasContextualFilesystem = fsWrapper.isContextualMode?.() === true;
-    if (!mustAvoidProjectCode && isApiPath && !hasContextualFilesystem) {
+    const hasAtomicSharedRuntimeContext = isSharedRuntime &&
+      fsWrapper.isMultiProjectMode?.() === true &&
+      typeof fsWrapper.runWithContext === "function";
+    const shouldUseAutomaticPreflight = mustAvoidProjectCode ||
+      (hasContextualFilesystem && !hasAtomicSharedRuntimeContext);
+    if (!shouldUseAutomaticPreflight && isApiPath) {
       return this.continue();
     }
 
-    if (!mustAvoidProjectCode && !isApiPath && !hasContextualFilesystem) {
+    if (!shouldUseAutomaticPreflight && !isApiPath) {
       const hasMatchedAppRoute = await this.hasMatchedAppRoute(pathname, ctx);
       if (hasMatchedAppRoute) return this.continue();
     }

--- a/src/server/runtime-handler/handler-context-builder.test.ts
+++ b/src/server/runtime-handler/handler-context-builder.test.ts
@@ -107,6 +107,26 @@ describe("buildHandlerContext", () => {
     assertEquals(ctx.enriched?.allowHostProjectCodeExecution, true);
   });
 
+  it("snapshots configured trusted-proxy identity header names", () => {
+    const ctx = buildHandlerContext(
+      makeOpts({
+        securityConfig: {
+          auth: {
+            trustedProxy: {
+              trustedPeers: ["127.0.0.1"],
+              headers: {
+                subject: "X-Auth-Subject",
+                email: "X-Auth-Email",
+              },
+            },
+          },
+        } as never,
+      }),
+    );
+
+    assertEquals(ctx.applicationIdentityHeaderNames, ["x-auth-subject", "x-auth-email"]);
+  });
+
   it("builds enriched context when both config and projectSlug present", () => {
     const opts = makeOpts({
       config: { name: "test" } as any,
@@ -206,5 +226,24 @@ describe("buildMinimalContext", () => {
     assertEquals(ctx.projectSlug, undefined);
     assertEquals(ctx.routeRegistry, undefined);
     assertEquals(ctx.isLocalProject, undefined);
+  });
+
+  it("snapshots trusted-proxy identity headers for pre-authentication handlers", () => {
+    const ctx = buildMinimalContext(
+      "/tmp/minimal",
+      {} as any,
+      {
+        auth: {
+          trustedProxy: {
+            trustedPeers: ["127.0.0.1"],
+            headers: { subject: "X-Auth-Subject" },
+          },
+        },
+      } as never,
+      false,
+      undefined,
+    );
+
+    assertEquals(ctx.applicationIdentityHeaderNames, ["x-auth-subject"]);
   });
 });

--- a/src/server/runtime-handler/handler-context-builder.ts
+++ b/src/server/runtime-handler/handler-context-builder.ts
@@ -18,6 +18,7 @@ import type { RouteRegistry } from "#veryfront/routing/registry/index.ts";
 import { buildEnrichedContext } from "../context/enriched-context.ts";
 import { computeContentSourceId } from "#veryfront/cache/keys.ts";
 import type { ApplicationIdentity } from "#veryfront/security/application-auth/types.ts";
+import { getTrustedProxyApplicationIdentityHeaderNames } from "#veryfront/security/application-auth/trusted-proxy.ts";
 
 export interface HandlerContextOptions {
   /** Project directory */
@@ -80,6 +81,15 @@ export interface HandlerContextOptions {
   prepareHostedConfigContext?: HandlerContext["prepareHostedConfigContext"];
 }
 
+function configuredApplicationIdentityHeaderNames(
+  securityConfig: SecurityConfig | null,
+): readonly string[] {
+  const trustedProxy = securityConfig?.auth?.trustedProxy;
+  return trustedProxy === undefined
+    ? []
+    : getTrustedProxyApplicationIdentityHeaderNames(trustedProxy);
+}
+
 /**
  * Build the HandlerContext for route handlers.
  */
@@ -139,7 +149,8 @@ export function buildHandlerContext(opts: HandlerContextOptions): HandlerContext
     isProxyMode: opts.isProxyMode,
     environmentId: opts.environmentId,
     applicationIdentity: opts.applicationIdentity ?? null,
-    applicationIdentityHeaderNames: opts.applicationIdentityHeaderNames ?? [],
+    applicationIdentityHeaderNames: opts.applicationIdentityHeaderNames ??
+      configuredApplicationIdentityHeaderNames(opts.securityConfig),
     prepareHostedConfigContext: opts.prepareHostedConfigContext,
     enriched: enrichedContext,
   };
@@ -164,6 +175,6 @@ export function buildMinimalContext(
     config,
     requestOrigin,
     applicationIdentity: null,
-    applicationIdentityHeaderNames: [],
+    applicationIdentityHeaderNames: configuredApplicationIdentityHeaderNames(securityConfig),
   };
 }

--- a/tests/integration/server/cors-handler.test.ts
+++ b/tests/integration/server/cors-handler.test.ts
@@ -1,11 +1,11 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { withTempDir, writeTextFile } from "#veryfront/testing/deno-compat";
-import { CorsHandler } from "#veryfront/server/handlers/response/cors.ts";
+import { mkdir, withTempDir, writeTextFile } from "#veryfront/testing/deno-compat";
 import type { HandlerContext } from "#veryfront/server/handlers/types.ts";
 import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { clearConfigCache } from "#veryfront/config";
+import { APIRouteHandler } from "#veryfront/routing/api/index.ts";
 
 function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
   return {
@@ -18,33 +18,39 @@ function makeCtx(overrides: Partial<HandlerContext> = {}): HandlerContext {
 
 describe("integration/server/cors-handler", () => {
   it("advertises only the methods the matched route module exports", async () => {
-    await withTempDir(async (routeDir) => {
-      const routeFile = `${routeDir}/route.ts`;
+    await withTempDir(async (projectDir) => {
+      const apiDir = `${projectDir}/pages/api`;
+      const routeFile = `${apiDir}/only-get.ts`;
+      await mkdir(apiDir, { recursive: true });
       await writeTextFile(
         routeFile,
         "export function GET() { return new Response('ok'); }\n",
       );
-      const handler = new CorsHandler({
-        resolveAppRouteFile: () => Promise.resolve({ file: routeFile, params: {} }),
-      });
-      const result = await handler.handle(
-        new Request("http://localhost/api/only-get", {
-          method: "OPTIONS",
-          headers: {
-            origin: "http://localhost:3000",
-            "access-control-request-method": "GET",
-          },
-        }),
-        makeCtx({
-          securityConfig: { cors: { origin: ["http://localhost:3000"] } } as never,
-        }),
+      await writeTextFile(
+        `${projectDir}/veryfront.config.js`,
+        'export default { security: { cors: { origin: ["http://localhost:3000"] } } };\n',
       );
-
-      assertEquals(
-        result.response?.headers.get("access-control-allow-methods"),
-        "HEAD, GET, OPTIONS",
-        "preflight must advertise exactly the exported methods plus HEAD and OPTIONS",
-      );
+      const handler = new APIRouteHandler(projectDir);
+      await handler.initialize();
+      try {
+        const response = await handler.handle(
+          new Request("http://localhost/api/only-get", {
+            method: "OPTIONS",
+            headers: {
+              origin: "http://localhost:3000",
+              "access-control-request-method": "GET",
+            },
+          }),
+          makeCtx({ projectDir, isLocalProject: true }),
+        );
+        assertEquals(
+          response?.headers.get("access-control-allow-methods"),
+          "GET, HEAD, OPTIONS",
+          "preflight must advertise exactly the exported methods plus HEAD and OPTIONS",
+        );
+      } finally {
+        handler.destroy();
+      }
     }, { prefix: "vf-cors-route-" });
   });
 
@@ -71,26 +77,31 @@ describe("integration/server/cors-handler", () => {
             method: "OPTIONS",
             headers: { origin, "access-control-request-method": "POST" },
           });
+        const handler = new APIRouteHandler(projectDir);
+        await handler.initialize();
+        try {
+          const allowed = await handler.handle(
+            preflight("https://allowed.example"),
+            ctx,
+          );
+          assertEquals(
+            allowed?.headers.get("access-control-allow-origin"),
+            "https://allowed.example",
+            "the project config CORS policy must win on preflight",
+          );
 
-        const allowed = await new CorsHandler().handle(
-          preflight("https://allowed.example"),
-          ctx,
-        );
-        assertEquals(
-          allowed.response?.headers.get("access-control-allow-origin"),
-          "https://allowed.example",
-          "the project config CORS policy must win on preflight",
-        );
-
-        const denied = await new CorsHandler().handle(
-          preflight("https://ctx-only.example"),
-          ctx,
-        );
-        assertEquals(
-          denied.response?.headers.get("access-control-allow-origin"),
-          null,
-          "an origin only the request context allows must be denied once the config file speaks",
-        );
+          const denied = await handler.handle(
+            preflight("https://ctx-only.example"),
+            ctx,
+          );
+          assertEquals(
+            denied?.headers.get("access-control-allow-origin"),
+            null,
+            "an origin only the request context allows must be denied once the config file speaks",
+          );
+        } finally {
+          handler.destroy();
+        }
       } finally {
         clearConfigCache();
       }


### PR DESCRIPTION
## Summary

- dispatch named and default `OPTIONS` handlers through the canonical route executor
- preserve automatic preflight for matched routes without executable `OPTIONS` and for unknown API paths
- authenticate matched OPTIONS routes before project module evaluation or dispatch, while unauthenticated browser preflight keeps the framework response
- constrain preflight methods to route capabilities, including custom methods handled by default exports
- filter infrastructure-only request headers and merge validated preflight policy into authored responses
- honor operator execution grants while ungranted shared runtimes perform preflight without resolving project code
- cache prepared-route method inspection by worker semantics, route source, and requested method

## Auth and CORS behavior

An authored `OPTIONS` or default handler uses the configured application and HTTP auth gates before project code loads or runs. If browser preflight is not authenticated, Veryfront returns automatic preflight without evaluating that route module. Authenticated OPTIONS requests can execute the authored handler with admitted identity. Framework-owned CORS headers still come from the validated CORS policy.

## Red-green TDD

Red tests first showed named/default handlers were never called and the early CORS layer returned instead of continuing. Review-driven RED tests then pinned auth-before-evaluation, execution grants, route-specific and custom methods, infrastructure-header filtering, explicit preflight-policy merging, and semantic cache isolation. The implementation made these green across host, prepared-worker, dynamic App, static Pages, shared-runtime, fallback, and cache-invalidation paths.

## Verification

- `deno task test:unit`
- `deno task lint:test-typecheck`
- `deno task lint`
- `deno task lint:core-deps`
- `deno task lint:dependency-boundaries`
- `deno task lint:module-boundaries`
- `deno task test:file src/routing/api`
- `deno task test:file src/security/http`
- `deno task test:file src/security/sandbox`
- `deno task test:file src/server/handlers/response`
- `deno task test:file src/server/handlers/request/api`
- `deno task test:file src/server/runtime-handler/index.test.ts`
- `git diff --check`

Closes veryfront/veryfront-issue-inbox#902

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved OPTIONS and CORS preflight handling across API and application routes.
  * Added support for route-defined OPTIONS handlers, including dynamic routes and shared runtimes.
  * Applied configured CORS policies to explicit OPTIONS responses while preserving response content.
  * Added clearer `Allow` headers and safer filtering of identity and authorization headers.

* **Bug Fixes**
  * Protected explicit OPTIONS handlers with authentication while keeping automatic preflight requests publicly accessible.
  * Added consistent API error responses when OPTIONS route inspection fails.
  * Improved handling of unmatched, protected, and non-API OPTIONS requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->