### PR TITLE
fix: authenticate plain OPTIONS before project middleware

### DIFF
--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -15,6 +15,7 @@ import { HOST_PROJECT_EXECUTION_OVERRIDE_ENV } from "#veryfront/security/host-ex
 import { runWithExactSourceIntegrationPolicy } from "#veryfront/integrations/source-policy-context.ts";
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
 import type { ApplicationIdentity } from "#veryfront/security/application-auth/types.ts";
+import { markTrustedProxyApplicationAuthAdmittedRequest } from "#veryfront/security/application-auth/trusted-proxy.ts";
 import { recordRequestPeerFromTransport } from "#veryfront/platform/adapters/runtime/shared/request-peer.ts";
 import { deleteEnv, getEnv, setEnv } from "#veryfront/compat/process.ts";
 import { isDeno } from "#veryfront/platform/compat/runtime.ts";
@@ -1221,8 +1222,10 @@ describe("APIRouteHandler", () => {
         adapter,
         { security: securityConfig } as HandlerConfig,
       );
+      const request = new Request("http://localhost/api/precomputed-auth", { method: "OPTIONS" });
+      markTrustedProxyApplicationAuthAdmittedRequest(request);
       const response = await handler.handle(
-        new Request("http://localhost/api/precomputed-auth", { method: "OPTIONS" }),
+        request,
         {
           ...localContext(adapter),
           securityConfig,

--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -844,6 +844,72 @@ describe("APIRouteHandler", () => {
       assertEquals(await response?.text(), "named options");
     });
 
+    it("prepares an automatic preflight for an unmatched route", async () => {
+      const adapter = createMockAdapter();
+      const handler = await createInitializedHandler("/test/project", adapter);
+      const preparation = await handler.prepareFrameworkOwnedPreflight(
+        new Request("http://localhost/api/missing", {
+          method: "OPTIONS",
+          headers: {
+            origin: "https://client.example",
+            "access-control-request-method": "GET",
+          },
+        }),
+        localContext(adapter),
+      );
+
+      assertEquals(preparation.frameworkOwned, true);
+      assertEquals(preparation.response?.status, 204);
+    });
+
+    it("prepares a static automatic preflight from the same route source", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/test/project/pages/api/get-only.ts",
+        "export function GET() { return new Response('get'); }",
+      );
+      const handler = await createInitializedHandler("/test/project", adapter);
+      const preparation = await handler.prepareFrameworkOwnedPreflight(
+        new Request("http://localhost/api/get-only", {
+          method: "OPTIONS",
+          headers: {
+            origin: "https://client.example",
+            "access-control-request-method": "POST",
+          },
+        }),
+        localContext(adapter),
+      );
+
+      assertEquals(preparation.frameworkOwned, true);
+      assertEquals(preparation.response?.status, 204);
+      assertEquals(preparation.response?.headers.get("Allow"), "GET, HEAD, OPTIONS");
+    });
+
+    it("keeps authored and uninspectable preflights in the middleware path", async () => {
+      const adapter = createMockAdapter();
+      const authoredPath = "/test/project/pages/api/authored.ts";
+      adapter.fs.files.set(authoredPath, "export function OPTIONS() {}\n");
+      const handler = await createInitializedHandler("/test/project", adapter);
+      const request = new Request("http://localhost/api/authored", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://client.example",
+          "access-control-request-method": "GET",
+        },
+      });
+
+      const authored = await handler.prepareFrameworkOwnedPreflight(request, localContext(adapter));
+      assertEquals(authored.frameworkOwned, false);
+      assertEquals(authored.response, undefined);
+
+      adapter.fs.readFile = () => Promise.reject(new Error("source unavailable"));
+      const uninspectable = await handler.prepareFrameworkOwnedPreflight(
+        request,
+        localContext(adapter),
+      );
+      assertEquals(uninspectable.frameworkOwned, false);
+    });
+
     it("discovers project primitives after OPTIONS auth and before dispatch", async () => {
       const adapter = createMockAdapter();
       adapter.fs.files.set(

--- a/src/routing/api/handler.test.ts
+++ b/src/routing/api/handler.test.ts
@@ -1199,6 +1199,46 @@ describe("APIRouteHandler", () => {
       assertEquals(discoveryCalls, 1);
     });
 
+    it("reuses application auth admitted before middleware", async () => {
+      const adapter = createMockAdapter();
+      adapter.fs.files.set(
+        "/test/project/pages/api/precomputed-auth.ts",
+        "export function OPTIONS() { return new Response('dispatched'); }",
+      );
+      __injectDepsForTests({
+        loadHandlerModule: () => Promise.resolve({ OPTIONS: () => new Response("dispatched") }),
+      });
+      const securityConfig = {
+        auth: {
+          trustedProxy: {
+            trustedPeers: ["127.0.0.1"],
+            headers: { subject: "x-auth-subject" },
+          },
+        },
+      } as HandlerContext["securityConfig"];
+      const handler = await createInitializedHandler(
+        "/test/project",
+        adapter,
+        { security: securityConfig } as HandlerConfig,
+      );
+      const response = await handler.handle(
+        new Request("http://localhost/api/precomputed-auth", { method: "OPTIONS" }),
+        {
+          ...localContext(adapter),
+          securityConfig,
+          applicationAuthResult: {
+            metadata: {
+              applicationIdentity: createIdentity(),
+              applicationIdentityHeaderNames: ["x-auth-subject"],
+            },
+          },
+        },
+      );
+
+      assertEquals(response?.status, 200);
+      assertEquals(await response?.text(), "dispatched");
+    });
+
     it("keeps plain OPTIONS automatic when a protected route has no OPTIONS export", async () => {
       const adapter = createMockAdapter();
       adapter.fs.files.set(

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -246,7 +246,10 @@ export class APIRouteHandler {
     ctx?: HandlerContext,
   ): Promise<{ frameworkOwned: boolean; response?: Response }> {
     if (!isPreflightRequest(request)) return { frameworkOwned: false };
-    if (requiresIsolatedProjectRuntime(ctx)) return { frameworkOwned: true };
+    if (requiresIsolatedProjectRuntime(ctx)) {
+      // The denied-execution wrapper creates the public fallback response.
+      return { frameworkOwned: true };
+    }
 
     const { pathname } = new URL(request.url);
     const match = this.router.match(pathname);

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -652,7 +652,9 @@ export class APIRouteHandler {
   ): Promise<Response | null> {
     if (!ctx) return null;
 
-    const applicationAuth = await this.applicationAuth(request, ctx);
+    const applicationAuth = ctx?.applicationAuthResult === undefined
+      ? await this.applicationAuth(request, ctx)
+      : ctx.applicationAuthResult;
     if (applicationAuth?.response) return applicationAuth.response;
     if (applicationAuth) {
       ctx.applicationIdentity = applicationAuth.metadata?.applicationIdentity ?? null;

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -251,10 +251,9 @@ export class APIRouteHandler {
     const { pathname } = new URL(request.url);
     const match = this.router.match(pathname);
     if (!match) {
-      const isApiPath = pathname === "/api" || pathname.startsWith("/api/");
       return {
         frameworkOwned: true,
-        response: isApiPath ? await this.automaticPreflight(request, undefined, ctx) : undefined,
+        response: await this.automaticPreflight(request, undefined, ctx),
       };
     }
 

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -241,6 +241,29 @@ export class APIRouteHandler {
     );
   }
 
+  /**
+   * Determine whether a CORS preflight is guaranteed to be handled by the
+   * framework without executing an authored route handler.
+   *
+   * An unknown source shape stays in the middleware path. This conservative
+   * result protects authored OPTIONS/default handlers from being hidden by a
+   * preflight-looking request.
+   */
+  async isFrameworkOwnedPreflight(
+    request: Request,
+    ctx?: HandlerContext,
+  ): Promise<boolean> {
+    if (!isPreflightRequest(request)) return false;
+    if (requiresIsolatedProjectRuntime(ctx)) return true;
+
+    const { pathname } = new URL(request.url);
+    const match = this.router.match(pathname);
+    if (!match) return true;
+
+    const adapter = await this.ensureAdapter();
+    return await this.resolveStaticOptionsCapability(match.route.page, adapter) === "absent";
+  }
+
   handle(
     request: Request,
     ctx?: HandlerContext,

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -241,27 +241,46 @@ export class APIRouteHandler {
     );
   }
 
-  /**
-   * Determine whether a CORS preflight is guaranteed to be handled by the
-   * framework without executing an authored route handler.
-   *
-   * An unknown source shape stays in the middleware path. This conservative
-   * result protects authored OPTIONS/default handlers from being hidden by a
-   * preflight-looking request.
-   */
-  async isFrameworkOwnedPreflight(
+  async prepareFrameworkOwnedPreflight(
     request: Request,
     ctx?: HandlerContext,
-  ): Promise<boolean> {
-    if (!isPreflightRequest(request)) return false;
-    if (requiresIsolatedProjectRuntime(ctx)) return true;
+  ): Promise<{ frameworkOwned: boolean; response?: Response }> {
+    if (!isPreflightRequest(request)) return { frameworkOwned: false };
+    if (requiresIsolatedProjectRuntime(ctx)) return { frameworkOwned: true };
 
     const { pathname } = new URL(request.url);
     const match = this.router.match(pathname);
-    if (!match) return true;
+    if (!match) {
+      const isApiPath = pathname === "/api" || pathname.startsWith("/api/");
+      return {
+        frameworkOwned: true,
+        response: isApiPath ? await this.automaticPreflight(request, undefined, ctx) : undefined,
+      };
+    }
 
     const adapter = await this.ensureAdapter();
-    return await this.resolveStaticOptionsCapability(match.route.page, adapter) === "absent";
+    let source: string;
+    try {
+      source = await adapter.fs.readFile(match.route.page);
+    } catch {
+      return { frameworkOwned: false };
+    }
+
+    if (await resolveStaticRouteOptionsCapability(source) !== "absent") {
+      return { frameworkOwned: false };
+    }
+
+    return {
+      frameworkOwned: true,
+      response: await this.automaticPreflight(
+        request,
+        await resolveStaticRouteMethodsFromSource(
+          source,
+          this.requestedPreflightMethod(request),
+        ),
+        ctx,
+      ),
+    };
   }
 
   handle(

--- a/src/server/handlers/request/api/api-handler-wrapper.test.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.test.ts
@@ -130,6 +130,47 @@ describe("ApiHandlerWrapper", () => {
     assertEquals(contextEntries, 2);
   });
 
+  it("keeps a prepared automatic preflight when route source changes", async () => {
+    const projectDir = `/tmp/api-wrapper-source-change-${crypto.randomUUID()}`;
+    const routePath = `${projectDir}/pages/api/get-only.ts`;
+    const adapter = createFileAdapter();
+    adapter.fs.files.set(routePath, "export function GET() { return new Response('get'); }");
+    const originalReadFile = adapter.fs.readFile;
+    let routeReads = 0;
+    adapter.fs.readFile = async (path) => {
+      const source = await originalReadFile(path);
+      if (path === routePath && routeReads++ === 0) {
+        adapter.fs.files.set(
+          routePath,
+          "export function OPTIONS() { return new Response('must not run'); }",
+        );
+      }
+      return source;
+    };
+    const ctx = {
+      projectDir,
+      adapter,
+      securityConfig: null,
+      isLocalProject: true,
+      allowHostProjectCodeExecution: true,
+    } as HandlerContext;
+    const wrapper = new ApiHandlerWrapper(projectDir, adapter);
+    const request = new Request("http://localhost/api/get-only", {
+      method: "OPTIONS",
+      headers: {
+        origin: "https://client.example",
+        "access-control-request-method": "GET",
+      },
+    });
+
+    assertEquals(await wrapper.prepareFrameworkOwnedPreflight(request, ctx), true);
+    const result = await wrapper.handle(request, ctx);
+
+    assertEquals(result.response?.status, 204);
+    assertEquals(result.response?.headers.get("Allow"), "GET, HEAD, OPTIONS");
+    assertEquals(routeReads, 1);
+  });
+
   it("keeps denied shared runtimes on the automatic preflight path", async () => {
     const adapter = createFileAdapter();
     const fs = adapter.fs as typeof adapter.fs & {

--- a/src/server/handlers/request/api/api-handler-wrapper.test.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertNotEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { HandlerContext } from "#veryfront/types";
+import { createMockAdapter as createFileAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { ApiHandlerWrapper } from "./api-handler-wrapper.ts";
 import { __injectDepsForTests as injectMemoryPressureDeps } from "#veryfront/server/shared/renderer/memory/pressure.ts";
 
@@ -43,6 +44,102 @@ function createCtx(captured: { options?: Record<string, unknown> }): HandlerCont
 }
 
 describe("ApiHandlerWrapper", () => {
+  it("prepares and reuses a framework-owned preflight response", async () => {
+    const projectDir = `/tmp/api-wrapper-preflight-${crypto.randomUUID()}`;
+    const adapter = createFileAdapter();
+    adapter.fs.files.set(
+      `${projectDir}/pages/api/get-only.ts`,
+      "export function GET() { return new Response('get'); }",
+    );
+    const ctx = {
+      projectDir,
+      adapter,
+      securityConfig: null,
+      isLocalProject: true,
+      allowHostProjectCodeExecution: true,
+    } as HandlerContext;
+    const wrapper = new ApiHandlerWrapper(projectDir, adapter);
+    const request = new Request("http://localhost/api/get-only", {
+      method: "OPTIONS",
+      headers: {
+        origin: "https://client.example",
+        "access-control-request-method": "GET",
+      },
+    });
+
+    assertEquals(await wrapper.isFrameworkOwnedPreflight(request, ctx), true);
+    const result = await wrapper.handle(request, ctx);
+
+    assertEquals(result.response?.status, 204);
+    assertEquals(result.response?.headers.get("Allow"), "GET, HEAD, OPTIONS");
+  });
+
+  it("keeps denied shared runtimes on the automatic preflight path", async () => {
+    const adapter = createFileAdapter();
+    const fs = adapter.fs as typeof adapter.fs & {
+      isMultiProjectMode: () => boolean;
+      runWithContext: <T>(slug: string, token: string, fn: () => Promise<T>) => Promise<T>;
+    };
+    fs.isMultiProjectMode = () => true;
+    fs.runWithContext = async <T>(
+      _slug: string,
+      _token: string,
+      fn: () => Promise<T>,
+    ): Promise<T> => await fn();
+    const ctx = {
+      projectDir: "/tmp/denied-preflight",
+      adapter,
+      securityConfig: null,
+      projectSlug: "denied-project",
+      projectId: "project-123",
+      proxyToken: "proxy-token",
+      requestContext: { token: "proxy-token", mode: "preview" },
+      isLocalProject: false,
+      allowHostProjectCodeExecution: false,
+    } as unknown as HandlerContext;
+    const wrapper = new ApiHandlerWrapper(ctx.projectDir, adapter);
+    const request = new Request("http://localhost/api/private", {
+      method: "OPTIONS",
+      headers: {
+        origin: "https://client.example",
+        "access-control-request-method": "GET",
+      },
+    });
+
+    assertEquals(await wrapper.isFrameworkOwnedPreflight(request, ctx), true);
+    const result = await wrapper.handle(request, ctx);
+
+    assertEquals(result.response?.status, 204);
+  });
+
+  it("keeps allowed contextual runtimes conservative during preflight inspection", async () => {
+    const adapter = createFileAdapter();
+    const fs = adapter.fs as typeof adapter.fs & { isContextualMode: () => boolean };
+    fs.isContextualMode = () => true;
+    const ctx = {
+      projectDir: "/tmp/contextual-preflight",
+      adapter,
+      securityConfig: null,
+      isLocalProject: true,
+      allowHostProjectCodeExecution: true,
+    } as unknown as HandlerContext;
+    const wrapper = new ApiHandlerWrapper(ctx.projectDir, adapter);
+
+    assertEquals(
+      await wrapper.isFrameworkOwnedPreflight(
+        new Request("http://localhost/api/private", {
+          method: "OPTIONS",
+          headers: {
+            origin: "https://client.example",
+            "access-control-request-method": "GET",
+          },
+        }),
+        ctx,
+      ),
+      false,
+    );
+  });
+
   it("does not discover project primitives before routing an OPTIONS request", async () => {
     const ctx = createCtx({});
     ctx.allowHostProjectCodeExecution = true;

--- a/src/server/handlers/request/api/api-handler-wrapper.test.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.test.ts
@@ -74,6 +74,62 @@ describe("ApiHandlerWrapper", () => {
     assertEquals(result.response?.headers.get("Allow"), "GET, HEAD, OPTIONS");
   });
 
+  it("prepares framework-owned preflight inside a multi-project context", async () => {
+    const projectDir = `/tmp/api-wrapper-multi-preflight-${crypto.randomUUID()}`;
+    const adapter = createFileAdapter();
+    adapter.fs.files.set(
+      `${projectDir}/pages/api/get-only.ts`,
+      "export function GET() { return new Response('get'); }",
+    );
+    const fs = adapter.fs as typeof adapter.fs & {
+      isMultiProjectMode: () => boolean;
+      runWithContext: <T>(slug: string, token: string, fn: () => Promise<T>) => Promise<T>;
+    };
+    let contextEntries = 0;
+    fs.isMultiProjectMode = () => true;
+    fs.runWithContext = async <T>(
+      _slug: string,
+      _token: string,
+      fn: () => Promise<T>,
+    ): Promise<T> => {
+      contextEntries++;
+      return await fn();
+    };
+    const ctx = {
+      projectDir,
+      adapter,
+      securityConfig: null,
+      projectSlug: "multi-project",
+      projectId: "project-123",
+      proxyToken: "proxy-token",
+      releaseId: "release-123",
+      environmentName: "Production",
+      requestContext: {
+        token: "proxy-token",
+        slug: "multi-project",
+        branch: "main",
+        mode: "production",
+      },
+      isLocalProject: false,
+      allowHostProjectCodeExecution: true,
+    } as unknown as HandlerContext;
+    const wrapper = new ApiHandlerWrapper(projectDir, adapter);
+    const request = new Request("http://localhost/api/get-only", {
+      method: "OPTIONS",
+      headers: {
+        origin: "https://client.example",
+        "access-control-request-method": "GET",
+      },
+    });
+
+    assertEquals(await wrapper.prepareFrameworkOwnedPreflight(request, ctx), true);
+    assertEquals(contextEntries, 1);
+    const result = await wrapper.handle(request, ctx);
+
+    assertEquals(result.response?.status, 204);
+    assertEquals(contextEntries, 2);
+  });
+
   it("keeps denied shared runtimes on the automatic preflight path", async () => {
     const adapter = createFileAdapter();
     const fs = adapter.fs as typeof adapter.fs & {

--- a/src/server/handlers/request/api/api-handler-wrapper.test.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.test.ts
@@ -67,7 +67,7 @@ describe("ApiHandlerWrapper", () => {
       },
     });
 
-    assertEquals(await wrapper.isFrameworkOwnedPreflight(request, ctx), true);
+    assertEquals(await wrapper.prepareFrameworkOwnedPreflight(request, ctx), true);
     const result = await wrapper.handle(request, ctx);
 
     assertEquals(result.response?.status, 204);
@@ -108,7 +108,7 @@ describe("ApiHandlerWrapper", () => {
       },
     });
 
-    assertEquals(await wrapper.isFrameworkOwnedPreflight(request, ctx), true);
+    assertEquals(await wrapper.prepareFrameworkOwnedPreflight(request, ctx), true);
     const result = await wrapper.handle(request, ctx);
 
     assertEquals(result.response?.status, 204);
@@ -129,7 +129,7 @@ describe("ApiHandlerWrapper", () => {
     const wrapper = new ApiHandlerWrapper(ctx.projectDir, adapter);
 
     assertEquals(
-      await wrapper.isFrameworkOwnedPreflight(
+      await wrapper.prepareFrameworkOwnedPreflight(
         new Request("http://localhost/api/private", {
           method: "OPTIONS",
           headers: {
@@ -240,7 +240,7 @@ describe("ApiHandlerWrapper", () => {
 
     await assertRejects(
       () =>
-        new ApiHandlerWrapper("/tmp/project", ctx.adapter).isFrameworkOwnedPreflight(
+        new ApiHandlerWrapper("/tmp/project", ctx.adapter).prepareFrameworkOwnedPreflight(
           new Request("http://localhost/api/options", {
             method: "OPTIONS",
             headers: {

--- a/src/server/handlers/request/api/api-handler-wrapper.test.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.test.ts
@@ -89,7 +89,8 @@ describe("ApiHandlerWrapper", () => {
     const ctx = {
       projectDir: "/tmp/denied-preflight",
       adapter,
-      securityConfig: null,
+      securityConfig: { cors: true },
+      applicationIdentityHeaderNames: ["x-auth-subject"],
       projectSlug: "denied-project",
       projectId: "project-123",
       proxyToken: "proxy-token",
@@ -103,6 +104,7 @@ describe("ApiHandlerWrapper", () => {
       headers: {
         origin: "https://client.example",
         "access-control-request-method": "GET",
+        "access-control-request-headers": "x-auth-subject, content-type",
       },
     });
 
@@ -110,6 +112,7 @@ describe("ApiHandlerWrapper", () => {
     const result = await wrapper.handle(request, ctx);
 
     assertEquals(result.response?.status, 204);
+    assertEquals(result.response?.headers.get("Access-Control-Allow-Headers"), "content-type");
   });
 
   it("keeps allowed contextual runtimes conservative during preflight inspection", async () => {

--- a/src/server/handlers/request/api/api-handler-wrapper.test.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.test.ts
@@ -122,6 +122,39 @@ describe("ApiHandlerWrapper", () => {
     );
   });
 
+  it("propagates preflight classification failures before auth or middleware", async () => {
+    const ctx = createCtx({});
+    ctx.allowHostProjectCodeExecution = true;
+    ctx.requestContext!.mode = "preview";
+    ctx.releaseId = undefined;
+    const fs = ctx.adapter.fs as unknown as {
+      runWithContext: (
+        slug: string,
+        token: string,
+        fn: () => Promise<unknown>,
+      ) => Promise<unknown>;
+      refreshSourceSnapshot: (reason?: string) => Promise<void>;
+    };
+    fs.runWithContext = async (_slug, _token, fn) => await fn();
+    fs.refreshSourceSnapshot = () => Promise.reject(new Error("preflight snapshot failed"));
+
+    await assertRejects(
+      () =>
+        new ApiHandlerWrapper("/tmp/project", ctx.adapter).isFrameworkOwnedPreflight(
+          new Request("http://localhost/api/options", {
+            method: "OPTIONS",
+            headers: {
+              origin: "https://client.example",
+              "access-control-request-method": "GET",
+            },
+          }),
+          ctx,
+        ),
+      Error,
+      "preflight snapshot failed",
+    );
+  });
+
   it("routes known pages without remote stat misses or full API discovery", async () => {
     let enteredProjectContext = false;
     let remoteStatMisses = 0;

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -268,7 +268,7 @@ export class ApiHandlerWrapper extends BaseHandler {
             ctx,
           );
 
-          const finalRes = this.finalizeResponse(req, ctx, apiRes);
+          const finalRes = this.finalizeApiResponse(req, ctx, apiRes);
 
           return this.respond(finalRes);
         } catch (error) {
@@ -306,7 +306,7 @@ export class ApiHandlerWrapper extends BaseHandler {
         allowMethods: DEFAULT_CORS_METHODS.join(", "),
       });
       response.headers.set("Allow", DEFAULT_CORS_METHODS.join(", "));
-      return this.respond(this.finalizeResponse(req, ctx, response));
+      return this.respond(this.finalizePreflightResponse(ctx, response));
     }
     // A shared runtime without an explicit execution grant cannot serve any
     // project-owned route. Reject before refreshing or classifying tenant
@@ -319,7 +319,7 @@ export class ApiHandlerWrapper extends BaseHandler {
     ctx: HandlerContext,
   ): HandlerResult | null {
     if (req.method.toUpperCase() !== "OPTIONS" || !ctx.frameworkPreflightResponse) return null;
-    return this.respond(this.finalizeResponse(req, ctx, ctx.frameworkPreflightResponse));
+    return this.respond(this.finalizePreflightResponse(ctx, ctx.frameworkPreflightResponse));
   }
 
   private projectExecutionUnavailable(
@@ -345,7 +345,14 @@ export class ApiHandlerWrapper extends BaseHandler {
     return this.respond(response, { executionTopology: "dedicated-runtime-required" });
   }
 
-  private finalizeResponse(req: Request, ctx: HandlerContext, response: Response): Response {
+  private finalizePreflightResponse(ctx: HandlerContext, response: Response): Response {
+    return this.createResponseBuilder(ctx)
+      .withSecurity(ctx.securityConfig ?? undefined)
+      .withHeaders(response.headers)
+      .build(response.body, response.status);
+  }
+
+  private finalizeApiResponse(req: Request, ctx: HandlerContext, response: Response): Response {
     return this.createResponseBuilder(ctx)
       .withCORS(req, ctx.securityConfig?.cors)
       .withSecurity(ctx.securityConfig ?? undefined, req)

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -19,6 +19,7 @@ import {
   PROJECT_EXECUTION_UNAVAILABLE,
 } from "#veryfront/errors";
 import { requiresIsolatedProjectRuntime } from "#veryfront/security/project-locality.ts";
+import { isPreflightRequest } from "#veryfront/security/http/cors/preflight.ts";
 
 type FsWrapper = {
   isMultiProjectMode?: () => boolean;
@@ -65,6 +66,49 @@ export class ApiHandlerWrapper extends BaseHandler {
     })();
 
     await this.initPromise;
+  }
+
+  async isFrameworkOwnedPreflight(req: Request, ctx: HandlerContext): Promise<boolean> {
+    if (!isPreflightRequest(req)) return false;
+
+    const fsWrapper = ctx.adapter.fs as FsWrapper;
+    const isMultiProject = !!ctx.projectSlug &&
+      typeof fsWrapper.isMultiProjectMode === "function" &&
+      fsWrapper.isMultiProjectMode();
+    const inspect = async (): Promise<boolean> => {
+      await ensurePreviewSourceSnapshotFresh(ctx);
+      return await withApiHandler(
+        ctx,
+        (api) => api.isFrameworkOwnedPreflight(req, ctx),
+        { sourceSnapshotReady: true },
+      );
+    };
+
+    try {
+      if (!isMultiProject) {
+        if (fsWrapper.isContextualMode?.() === true) return false;
+        return await inspect();
+      }
+
+      return await fsWrapper.runWithContext!(
+        ctx.projectSlug!,
+        ctx.proxyToken ?? "",
+        inspect,
+        ctx.projectId,
+        {
+          productionMode: ctx.requestContext?.mode === "production",
+          releaseId: ctx.releaseId,
+          branch: ctx.requestContext?.mode === "production"
+            ? null
+            : ctx.requestContext?.branch ?? ctx.parsedDomain?.branch ?? null,
+          environmentName: ctx.environmentName,
+        },
+      );
+    } catch {
+      // Classification is an optimization. If route inspection cannot be
+      // completed, retain middleware and route execution for correctness.
+      return false;
+    }
   }
 
   async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -300,13 +300,13 @@ export class ApiHandlerWrapper extends BaseHandler {
     ctx: HandlerContext,
     pathname: string,
   ): Promise<HandlerResult> {
-    if (req.method.toUpperCase() === "OPTIONS" && isPreflightRequest(req)) {
+    if (isPreflightRequest(req)) {
       const response = await handleCORSPreflight({
         request: req,
         config: ctx.securityConfig?.cors,
         allowMethods: DEFAULT_CORS_METHODS.join(", "),
         allowHeaders: getApplicationPreflightHeaders(req, {
-          denyHeaders: ctx.applicationIdentityHeaderNames,
+          denyHeaders: ctx.applicationIdentityHeaderNames ?? [],
         }),
       });
       response.headers.set("Allow", DEFAULT_CORS_METHODS.join(", "));

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -310,7 +310,7 @@ export class ApiHandlerWrapper extends BaseHandler {
         }),
       });
       response.headers.set("Allow", DEFAULT_CORS_METHODS.join(", "));
-      return this.respond(this.finalizePreflightResponse(ctx, response));
+      return this.respond(this.finalizePreflightResponse(req, ctx, response));
     }
     // A shared runtime without an explicit execution grant cannot serve any
     // project-owned route. Reject before refreshing or classifying tenant
@@ -323,7 +323,7 @@ export class ApiHandlerWrapper extends BaseHandler {
     ctx: HandlerContext,
   ): HandlerResult | null {
     if (req.method.toUpperCase() !== "OPTIONS" || !ctx.frameworkPreflightResponse) return null;
-    return this.respond(this.finalizePreflightResponse(ctx, ctx.frameworkPreflightResponse));
+    return this.respond(this.finalizePreflightResponse(req, ctx, ctx.frameworkPreflightResponse));
   }
 
   private projectExecutionUnavailable(
@@ -349,11 +349,15 @@ export class ApiHandlerWrapper extends BaseHandler {
     return this.respond(response, { executionTopology: "dedicated-runtime-required" });
   }
 
-  private finalizePreflightResponse(ctx: HandlerContext, response: Response): Response {
+  private finalizePreflightResponse(
+    req: Request,
+    ctx: HandlerContext,
+    response: Response,
+  ): Response {
     // The prepared response already carries the validated CORS policy headers;
     // only security and response headers are added here.
     return this.createResponseBuilder(ctx)
-      .withSecurity(ctx.securityConfig ?? undefined)
+      .withSecurity(ctx.securityConfig ?? undefined, req)
       .withHeaders(response.headers)
       .build(response.body, response.status);
   }

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -191,24 +191,11 @@ export class ApiHandlerWrapper extends BaseHandler {
         if (req.signal.aborted) throw req.signal.reason;
 
         if (mustDenyProjectExecution) {
-          if (req.method.toUpperCase() === "OPTIONS" && isPreflightRequest(req)) {
-            const response = await handleCORSPreflight({
-              request: req,
-              config: ctx.securityConfig?.cors,
-              allowMethods: DEFAULT_CORS_METHODS.join(", "),
-            });
-            response.headers.set("Allow", DEFAULT_CORS_METHODS.join(", "));
-            return this.respond(this.finalizeResponse(req, ctx, response));
-          }
-          // A shared runtime without an explicit execution grant cannot serve
-          // any project-owned route. Reject before refreshing or classifying
-          // tenant source that no downstream handler is allowed to execute.
-          return this.projectExecutionUnavailable(req, ctx, pathname);
+          return await this.handleDeniedProjectExecution(req, ctx, pathname);
         }
 
-        if (req.method.toUpperCase() === "OPTIONS" && ctx.frameworkPreflightResponse) {
-          return this.respond(this.finalizeResponse(req, ctx, ctx.frameworkPreflightResponse));
-        }
+        const preparedResponse = this.handlePreparedFrameworkPreflight(req, ctx);
+        if (preparedResponse) return preparedResponse;
 
         const canResolveAsPage = pathname !== "/api" &&
           !pathname.startsWith("/api/") &&
@@ -305,6 +292,34 @@ export class ApiHandlerWrapper extends BaseHandler {
         "api.projectSlug": ctx.projectSlug ?? "unknown",
       },
     );
+  }
+
+  private async handleDeniedProjectExecution(
+    req: Request,
+    ctx: HandlerContext,
+    pathname: string,
+  ): Promise<HandlerResult> {
+    if (req.method.toUpperCase() === "OPTIONS" && isPreflightRequest(req)) {
+      const response = await handleCORSPreflight({
+        request: req,
+        config: ctx.securityConfig?.cors,
+        allowMethods: DEFAULT_CORS_METHODS.join(", "),
+      });
+      response.headers.set("Allow", DEFAULT_CORS_METHODS.join(", "));
+      return this.respond(this.finalizeResponse(req, ctx, response));
+    }
+    // A shared runtime without an explicit execution grant cannot serve any
+    // project-owned route. Reject before refreshing or classifying tenant
+    // source that no downstream handler is allowed to execute.
+    return this.projectExecutionUnavailable(req, ctx, pathname);
+  }
+
+  private handlePreparedFrameworkPreflight(
+    req: Request,
+    ctx: HandlerContext,
+  ): HandlerResult | null {
+    if (req.method.toUpperCase() !== "OPTIONS" || !ctx.frameworkPreflightResponse) return null;
+    return this.respond(this.finalizeResponse(req, ctx, ctx.frameworkPreflightResponse));
   }
 
   private projectExecutionUnavailable(

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -84,31 +84,25 @@ export class ApiHandlerWrapper extends BaseHandler {
       );
     };
 
-    try {
-      if (!isMultiProject) {
-        if (fsWrapper.isContextualMode?.() === true) return false;
-        return await inspect();
-      }
-
-      return await fsWrapper.runWithContext!(
-        ctx.projectSlug!,
-        ctx.proxyToken ?? "",
-        inspect,
-        ctx.projectId,
-        {
-          productionMode: ctx.requestContext?.mode === "production",
-          releaseId: ctx.releaseId,
-          branch: ctx.requestContext?.mode === "production"
-            ? null
-            : ctx.requestContext?.branch ?? ctx.parsedDomain?.branch ?? null,
-          environmentName: ctx.environmentName,
-        },
-      );
-    } catch {
-      // Classification is an optimization. If route inspection cannot be
-      // completed, retain middleware and route execution for correctness.
-      return false;
+    if (!isMultiProject) {
+      if (fsWrapper.isContextualMode?.() === true) return false;
+      return await inspect();
     }
+
+    return await fsWrapper.runWithContext!(
+      ctx.projectSlug!,
+      ctx.proxyToken ?? "",
+      inspect,
+      ctx.projectId,
+      {
+        productionMode: ctx.requestContext?.mode === "production",
+        releaseId: ctx.releaseId,
+        branch: ctx.requestContext?.mode === "production"
+          ? null
+          : ctx.requestContext?.branch ?? ctx.parsedDomain?.branch ?? null,
+        environmentName: ctx.environmentName,
+      },
+    );
   }
 
   async handle(req: Request, ctx: HandlerContext): Promise<HandlerResult> {

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -20,6 +20,7 @@ import {
 } from "#veryfront/errors";
 import { requiresIsolatedProjectRuntime } from "#veryfront/security/project-locality.ts";
 import { isPreflightRequest } from "#veryfront/security/http/cors/preflight.ts";
+import { DEFAULT_CORS_METHODS, handleCORSPreflight } from "#veryfront/security";
 
 type FsWrapper = {
   isMultiProjectMode?: () => boolean;
@@ -70,6 +71,10 @@ export class ApiHandlerWrapper extends BaseHandler {
 
   async isFrameworkOwnedPreflight(req: Request, ctx: HandlerContext): Promise<boolean> {
     if (!isPreflightRequest(req)) return false;
+    if (requiresIsolatedProjectRuntime(ctx)) {
+      ctx.frameworkOwnedPreflight = true;
+      return true;
+    }
 
     const fsWrapper = ctx.adapter.fs as FsWrapper;
     const isMultiProject = !!ctx.projectSlug &&
@@ -77,11 +82,14 @@ export class ApiHandlerWrapper extends BaseHandler {
       fsWrapper.isMultiProjectMode();
     const inspect = async (): Promise<boolean> => {
       await ensurePreviewSourceSnapshotFresh(ctx);
-      return await withApiHandler(
+      const result = await withApiHandler(
         ctx,
-        (api) => api.isFrameworkOwnedPreflight(req, ctx),
+        (api) => api.prepareFrameworkOwnedPreflight(req, ctx),
         { sourceSnapshotReady: true },
       );
+      ctx.frameworkOwnedPreflight = result.frameworkOwned;
+      if (result.response) ctx.frameworkPreflightResponse = result.response;
+      return result.frameworkOwned;
     };
 
     if (!isMultiProject) {
@@ -183,10 +191,23 @@ export class ApiHandlerWrapper extends BaseHandler {
         if (req.signal.aborted) throw req.signal.reason;
 
         if (mustDenyProjectExecution) {
+          if (req.method.toUpperCase() === "OPTIONS" && isPreflightRequest(req)) {
+            const response = await handleCORSPreflight({
+              request: req,
+              config: ctx.securityConfig?.cors,
+              allowMethods: DEFAULT_CORS_METHODS.join(", "),
+            });
+            response.headers.set("Allow", DEFAULT_CORS_METHODS.join(", "));
+            return this.respond(this.finalizeResponse(req, ctx, response));
+          }
           // A shared runtime without an explicit execution grant cannot serve
           // any project-owned route. Reject before refreshing or classifying
           // tenant source that no downstream handler is allowed to execute.
           return this.projectExecutionUnavailable(req, ctx, pathname);
+        }
+
+        if (req.method.toUpperCase() === "OPTIONS" && ctx.frameworkPreflightResponse) {
+          return this.respond(this.finalizeResponse(req, ctx, ctx.frameworkPreflightResponse));
         }
 
         const canResolveAsPage = pathname !== "/api" &&
@@ -260,12 +281,7 @@ export class ApiHandlerWrapper extends BaseHandler {
             ctx,
           );
 
-          const builder = this.createResponseBuilder(ctx);
-          const finalRes = builder
-            .withCORS(req, ctx.securityConfig?.cors)
-            .withSecurity(ctx.securityConfig ?? undefined, req)
-            .withHeaders(apiRes.headers)
-            .build(apiRes.body, apiRes.status);
+          const finalRes = this.finalizeResponse(req, ctx, apiRes);
 
           return this.respond(finalRes);
         } catch (error) {
@@ -312,6 +328,14 @@ export class ApiHandlerWrapper extends BaseHandler {
       .withHeaders(problem.headers)
       .build(req.method === "HEAD" ? null : problem.body, problem.status);
     return this.respond(response, { executionTopology: "dedicated-runtime-required" });
+  }
+
+  private finalizeResponse(req: Request, ctx: HandlerContext, response: Response): Response {
+    return this.createResponseBuilder(ctx)
+      .withCORS(req, ctx.securityConfig?.cors)
+      .withSecurity(ctx.securityConfig ?? undefined, req)
+      .withHeaders(response.headers)
+      .build(null, response.status);
   }
 
   private async isPageRequest(

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -20,6 +20,7 @@ import {
 } from "#veryfront/errors";
 import { requiresIsolatedProjectRuntime } from "#veryfront/security/project-locality.ts";
 import { isPreflightRequest } from "#veryfront/security/http/cors/preflight.ts";
+import { getApplicationPreflightHeaders } from "#veryfront/security/http/application-request.ts";
 import { DEFAULT_CORS_METHODS, handleCORSPreflight } from "#veryfront/security";
 
 type FsWrapper = {
@@ -304,6 +305,9 @@ export class ApiHandlerWrapper extends BaseHandler {
         request: req,
         config: ctx.securityConfig?.cors,
         allowMethods: DEFAULT_CORS_METHODS.join(", "),
+        allowHeaders: getApplicationPreflightHeaders(req, {
+          denyHeaders: ctx.applicationIdentityHeaderNames,
+        }),
       });
       response.headers.set("Allow", DEFAULT_CORS_METHODS.join(", "));
       return this.respond(this.finalizePreflightResponse(ctx, response));

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -335,7 +335,7 @@ export class ApiHandlerWrapper extends BaseHandler {
       .withCORS(req, ctx.securityConfig?.cors)
       .withSecurity(ctx.securityConfig ?? undefined, req)
       .withHeaders(response.headers)
-      .build(null, response.status);
+      .build(response.body, response.status);
   }
 
   private async isPageRequest(

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -70,7 +70,7 @@ export class ApiHandlerWrapper extends BaseHandler {
     await this.initPromise;
   }
 
-  async isFrameworkOwnedPreflight(req: Request, ctx: HandlerContext): Promise<boolean> {
+  async prepareFrameworkOwnedPreflight(req: Request, ctx: HandlerContext): Promise<boolean> {
     if (!isPreflightRequest(req)) return false;
     if (requiresIsolatedProjectRuntime(ctx)) {
       ctx.frameworkOwnedPreflight = true;
@@ -350,6 +350,8 @@ export class ApiHandlerWrapper extends BaseHandler {
   }
 
   private finalizePreflightResponse(ctx: HandlerContext, response: Response): Response {
+    // The prepared response already carries the validated CORS policy headers;
+    // only security and response headers are added here.
     return this.createResponseBuilder(ctx)
       .withSecurity(ctx.securityConfig ?? undefined)
       .withHeaders(response.headers)

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -457,6 +457,18 @@ describe("server/runtime-handler/index", () => {
       assertEquals(await response.text(), expectedBody);
       assertEquals(response.headers.get("x-project-middleware"), "ran");
       assertEquals(middlewareCalls, 1);
+
+      const publicPreflight = await handler(
+        new Request("http://localhost/api/options", {
+          method: "OPTIONS",
+          headers: {
+            origin: "https://client.example",
+            "access-control-request-method": "GET",
+          },
+        }),
+      );
+      assertEquals(publicPreflight.status, 204);
+      assertEquals(middlewareCalls, 1);
     });
   }
 
@@ -743,6 +755,55 @@ describe("server/runtime-handler/index", () => {
 
     assertEquals(response.status, 204);
     assertEquals(middlewareCalls, 0);
+  });
+
+  it("revalidates framework-owned preflight before bypassing middleware", async () => {
+    const projectDir = `/tmp/test-options-revalidation-${crypto.randomUUID()}`;
+    const routePath = `${projectDir}/pages/api/options.ts`;
+    const adapter = createRouteMockAdapter();
+    adapter.fs.files.set(routePath, "export function GET() { return new Response('get'); }");
+    const originalReadFile = adapter.fs.readFile;
+    let routeReads = 0;
+    adapter.fs.readFile = async (path) => {
+      const source = await originalReadFile(path);
+      if (path === routePath && routeReads++ === 0) {
+        adapter.fs.files.set(
+          routePath,
+          "export function OPTIONS() { return new Response('options'); }",
+        );
+      }
+      return source;
+    };
+    let middlewareCalls = 0;
+    const handler = createVeryfrontHandler(projectDir, adapter, {
+      projectDir,
+      config: {
+        middleware: {
+          custom: [
+            () => {
+              middlewareCalls++;
+              return new Response("middleware ran");
+            },
+          ],
+        },
+      } as any,
+      allowHostProjectCodeExecution: true,
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/options", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://client.example",
+          "access-control-request-method": "GET",
+        },
+      }),
+    );
+
+    assertEquals(response.status, 200);
+    assertEquals(await response.text(), "middleware ran");
+    assertEquals(middlewareCalls, 1);
+    assertEquals(routeReads, 2);
   });
 
   it("keeps CSP reports ahead of application auth admission", async () => {

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -4,6 +4,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeAdapter, RuntimeId } from "#veryfront/platform/adapters/base.ts";
+import { createMockAdapter as createRouteMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { SOURCE_SNAPSHOT_FRESHNESS_UNAVAILABLE } from "#veryfront/errors";
 import { DenoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
@@ -399,6 +400,52 @@ describe("server/runtime-handler/index", () => {
     assertEquals(middlewareCalls, 1);
   });
 
+  it("runs middleware for authored OPTIONS preflight routes", async () => {
+    const adapter = createRouteMockAdapter();
+    adapter.fs.files.set(
+      "/tmp/test-project/pages/api/options.ts",
+      "export function OPTIONS() { return new Response('unused'); }",
+    );
+    let middlewareCalls = 0;
+    const handler = createVeryfrontHandler("/tmp/test-project", adapter, {
+      projectDir: "/tmp/test-project",
+      config: {
+        security: {
+          auth: {
+            trustedProxy: {
+              trustedPeers: ["127.0.0.1"],
+              headers: { subject: "x-auth-subject" },
+            },
+          },
+        },
+        middleware: {
+          custom: [
+            (c: { identity: { subject?: string } | null }) => {
+              middlewareCalls++;
+              return Response.json({ subject: c.identity?.subject ?? null });
+            },
+          ],
+        },
+      } as any,
+      allowHostProjectCodeExecution: true,
+    });
+
+    const response = await handler(withTrustedPeer(
+      new Request("http://localhost/api/options", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://client.example",
+          "access-control-request-method": "GET",
+          "x-auth-subject": "user-123",
+        },
+      }),
+    ));
+
+    assertEquals(response.status, 200);
+    assertEquals(await response.json(), { subject: "user-123" });
+    assertEquals(middlewareCalls, 1);
+  });
+
   it("short-circuits terminal application auth responses before project middleware", async () => {
     let middlewareCalls = 0;
     const handler = createVeryfrontHandler("/tmp/test-project", createMockAdapter(), {
@@ -646,45 +693,6 @@ describe("server/runtime-handler/index", () => {
   });
 
   it("keeps CORS preflight ahead of application auth admission", async () => {
-    let middlewareCalls = 0;
-    const handler = createVeryfrontHandler("/tmp/test-project", createMockAdapter(), {
-      projectDir: "/tmp/test-project",
-      config: {
-        security: {
-          auth: {
-            trustedProxy: {
-              trustedPeers: ["127.0.0.1"],
-              headers: { subject: "x-auth-subject" },
-            },
-          },
-        },
-        middleware: {
-          custom: [
-            () => {
-              middlewareCalls++;
-              return new Response(null, { status: 204 });
-            },
-          ],
-        },
-      } as any,
-      allowHostProjectCodeExecution: true,
-    });
-
-    const response = await handler(
-      new Request("http://localhost/dashboard", {
-        method: "OPTIONS",
-        headers: {
-          origin: "https://client.example",
-          "access-control-request-method": "GET",
-        },
-      }),
-    );
-
-    assertEquals(response.status, 204);
-    assertEquals(middlewareCalls, 1);
-  });
-
-  it("bypasses project middleware for public CORS preflight", async () => {
     let middlewareCalls = 0;
     const handler = createVeryfrontHandler("/tmp/test-project", createMockAdapter(), {
       projectDir: "/tmp/test-project",

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -400,52 +400,65 @@ describe("server/runtime-handler/index", () => {
     assertEquals(middlewareCalls, 1);
   });
 
-  it("runs middleware for authored OPTIONS preflight routes", async () => {
-    const projectDir = `/tmp/test-options-auth-${crypto.randomUUID()}`;
-    const adapter = createRouteMockAdapter();
-    adapter.fs.files.set(
-      `${projectDir}/pages/api/options.ts`,
-      "export function OPTIONS() { return new Response('unused'); }",
-    );
-    let middlewareCalls = 0;
-    const handler = createVeryfrontHandler(projectDir, adapter, {
-      projectDir,
-      config: {
-        security: {
-          auth: {
-            trustedProxy: {
-              trustedPeers: ["127.0.0.1"],
-              headers: { subject: "x-auth-subject" },
+  for (
+    const [exportName, source, expectedBody] of [
+      [
+        "OPTIONS",
+        "export function OPTIONS() { return new Response('named options'); }",
+        "named options",
+      ],
+      [
+        "default",
+        "export default function handler() { return new Response('default options'); }",
+        "default options",
+      ],
+    ] as const
+  ) {
+    it(`runs middleware before authored ${exportName} OPTIONS preflight route`, async () => {
+      const projectDir = `/tmp/test-options-auth-${crypto.randomUUID()}`;
+      const adapter = createRouteMockAdapter();
+      adapter.fs.files.set(`${projectDir}/pages/api/options.ts`, source);
+      let middlewareCalls = 0;
+      const middleware: MiddlewareFunction = async (context, next) => {
+        middlewareCalls++;
+        assertEquals(context.identity?.subject, "user-123");
+        const response = await next();
+        response?.headers.set("x-project-middleware", "ran");
+        return response;
+      };
+      const handler = createVeryfrontHandler(projectDir, adapter, {
+        projectDir,
+        config: {
+          security: {
+            auth: {
+              trustedProxy: {
+                trustedPeers: ["127.0.0.1"],
+                headers: { subject: "x-auth-subject" },
+              },
             },
           },
-        },
-        middleware: {
-          custom: [
-            (c: { identity: { subject?: string } | null }) => {
-              middlewareCalls++;
-              return Response.json({ subject: c.identity?.subject ?? null });
-            },
-          ],
-        },
-      } as any,
-      allowHostProjectCodeExecution: true,
+          middleware: { custom: [middleware] },
+        } as any,
+        allowHostProjectCodeExecution: true,
+      });
+
+      const response = await handler(withTrustedPeer(
+        new Request("http://localhost/api/options", {
+          method: "OPTIONS",
+          headers: {
+            origin: "https://client.example",
+            "access-control-request-method": "GET",
+            "x-auth-subject": "user-123",
+          },
+        }),
+      ));
+
+      assertEquals(response.status, 200);
+      assertEquals(await response.text(), expectedBody);
+      assertEquals(response.headers.get("x-project-middleware"), "ran");
+      assertEquals(middlewareCalls, 1);
     });
-
-    const response = await handler(withTrustedPeer(
-      new Request("http://localhost/api/options", {
-        method: "OPTIONS",
-        headers: {
-          origin: "https://client.example",
-          "access-control-request-method": "GET",
-          "x-auth-subject": "user-123",
-        },
-      }),
-    ));
-
-    assertEquals(response.status, 200);
-    assertEquals(await response.json(), { subject: "user-123" });
-    assertEquals(middlewareCalls, 1);
-  });
+  }
 
   it("short-circuits terminal application auth responses before project middleware", async () => {
     let middlewareCalls = 0;

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -362,6 +362,43 @@ describe("server/runtime-handler/index", () => {
     });
   });
 
+  it("runs application auth admission before project middleware for plain OPTIONS", async () => {
+    let middlewareCalls = 0;
+    const handler = createVeryfrontHandler("/tmp/test-project", createMockAdapter(), {
+      projectDir: "/tmp/test-project",
+      config: {
+        security: {
+          auth: {
+            trustedProxy: {
+              trustedPeers: ["127.0.0.1"],
+              headers: { subject: "x-auth-subject" },
+            },
+          },
+        },
+        middleware: {
+          custom: [
+            (c: { identity: { subject?: string } | null }) => {
+              middlewareCalls++;
+              return Response.json({ subject: c.identity?.subject ?? null });
+            },
+          ],
+        },
+      } as any,
+      allowHostProjectCodeExecution: true,
+    });
+
+    const response = await handler(withTrustedPeer(
+      new Request("http://localhost/api/options", {
+        method: "OPTIONS",
+        headers: { "x-auth-subject": "user-123" },
+      }),
+    ));
+
+    assertEquals(response.status, 200);
+    assertEquals(await response.json(), { subject: "user-123" });
+    assertEquals(middlewareCalls, 1);
+  });
+
   it("short-circuits terminal application auth responses before project middleware", async () => {
     let middlewareCalls = 0;
     const handler = createVeryfrontHandler("/tmp/test-project", createMockAdapter(), {
@@ -634,11 +671,56 @@ describe("server/runtime-handler/index", () => {
     });
 
     const response = await handler(
-      new Request("http://localhost/dashboard", { method: "OPTIONS" }),
+      new Request("http://localhost/dashboard", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://client.example",
+          "access-control-request-method": "GET",
+        },
+      }),
     );
 
     assertEquals(response.status, 204);
     assertEquals(middlewareCalls, 1);
+  });
+
+  it("bypasses project middleware for public CORS preflight", async () => {
+    let middlewareCalls = 0;
+    const handler = createVeryfrontHandler("/tmp/test-project", createMockAdapter(), {
+      projectDir: "/tmp/test-project",
+      config: {
+        security: {
+          auth: {
+            trustedProxy: {
+              trustedPeers: ["127.0.0.1"],
+              headers: { subject: "x-auth-subject" },
+            },
+          },
+        },
+        middleware: {
+          custom: [
+            () => {
+              middlewareCalls++;
+              return new Response("middleware must not run", { status: 401 });
+            },
+          ],
+        },
+      } as any,
+      allowHostProjectCodeExecution: true,
+    });
+
+    const response = await handler(
+      new Request("http://localhost/dashboard", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://client.example",
+          "access-control-request-method": "GET",
+        },
+      }),
+    );
+
+    assertEquals(response.status, 204);
+    assertEquals(middlewareCalls, 0);
   });
 
   it("keeps CSP reports ahead of application auth admission", async () => {

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -4,7 +4,6 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeAdapter, RuntimeId } from "#veryfront/platform/adapters/base.ts";
-import { createMockAdapter as createRouteMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { SOURCE_SNAPSHOT_FRESHNESS_UNAVAILABLE } from "#veryfront/errors";
 import { DenoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
@@ -400,78 +399,6 @@ describe("server/runtime-handler/index", () => {
     assertEquals(middlewareCalls, 1);
   });
 
-  for (
-    const [exportName, source, expectedBody] of [
-      [
-        "OPTIONS",
-        "export function OPTIONS() { return new Response('named options'); }",
-        "named options",
-      ],
-      [
-        "default",
-        "export default function handler() { return new Response('default options'); }",
-        "default options",
-      ],
-    ] as const
-  ) {
-    it(`runs middleware before authored ${exportName} OPTIONS preflight route`, async () => {
-      const projectDir = `/tmp/test-options-auth-${crypto.randomUUID()}`;
-      const adapter = createRouteMockAdapter();
-      adapter.fs.files.set(`${projectDir}/pages/api/options.ts`, source);
-      let middlewareCalls = 0;
-      const middleware: MiddlewareFunction = async (context, next) => {
-        middlewareCalls++;
-        assertEquals(context.identity?.subject, "user-123");
-        const response = await next();
-        response?.headers.set("x-project-middleware", "ran");
-        return response;
-      };
-      const handler = createVeryfrontHandler(projectDir, adapter, {
-        projectDir,
-        config: {
-          security: {
-            auth: {
-              trustedProxy: {
-                trustedPeers: ["127.0.0.1"],
-                headers: { subject: "x-auth-subject" },
-              },
-            },
-          },
-          middleware: { custom: [middleware] },
-        } as any,
-        allowHostProjectCodeExecution: true,
-      });
-
-      const response = await handler(withTrustedPeer(
-        new Request("http://localhost/api/options", {
-          method: "OPTIONS",
-          headers: {
-            origin: "https://client.example",
-            "access-control-request-method": "GET",
-            "x-auth-subject": "user-123",
-          },
-        }),
-      ));
-
-      assertEquals(response.status, 200);
-      assertEquals(await response.text(), expectedBody);
-      assertEquals(response.headers.get("x-project-middleware"), "ran");
-      assertEquals(middlewareCalls, 1);
-
-      const publicPreflight = await handler(
-        new Request("http://localhost/api/options", {
-          method: "OPTIONS",
-          headers: {
-            origin: "https://client.example",
-            "access-control-request-method": "GET",
-          },
-        }),
-      );
-      assertEquals(publicPreflight.status, 204);
-      assertEquals(middlewareCalls, 1);
-    });
-  }
-
   it("short-circuits terminal application auth responses before project middleware", async () => {
     let middlewareCalls = 0;
     const handler = createVeryfrontHandler("/tmp/test-project", createMockAdapter(), {
@@ -755,55 +682,6 @@ describe("server/runtime-handler/index", () => {
 
     assertEquals(response.status, 204);
     assertEquals(middlewareCalls, 0);
-  });
-
-  it("retains a framework-owned preflight response across source changes", async () => {
-    const projectDir = `/tmp/test-options-revalidation-${crypto.randomUUID()}`;
-    const routePath = `${projectDir}/pages/api/options.ts`;
-    const adapter = createRouteMockAdapter();
-    adapter.fs.files.set(routePath, "export function GET() { return new Response('get'); }");
-    const originalReadFile = adapter.fs.readFile;
-    let routeReads = 0;
-    adapter.fs.readFile = async (path) => {
-      const source = await originalReadFile(path);
-      if (path === routePath && routeReads++ === 0) {
-        adapter.fs.files.set(
-          routePath,
-          "export function OPTIONS() { return new Response('options'); }",
-        );
-      }
-      return source;
-    };
-    let middlewareCalls = 0;
-    const handler = createVeryfrontHandler(projectDir, adapter, {
-      projectDir,
-      config: {
-        middleware: {
-          custom: [
-            () => {
-              middlewareCalls++;
-              return new Response("middleware ran");
-            },
-          ],
-        },
-      } as any,
-      allowHostProjectCodeExecution: true,
-    });
-
-    const response = await handler(
-      new Request("http://localhost/api/options", {
-        method: "OPTIONS",
-        headers: {
-          origin: "https://client.example",
-          "access-control-request-method": "GET",
-        },
-      }),
-    );
-
-    assertEquals(response.status, 204);
-    assertEquals(await response.text(), "");
-    assertEquals(middlewareCalls, 0);
-    assertEquals(routeReads, 1);
   });
 
   it("keeps CSP reports ahead of application auth admission", async () => {

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -401,14 +401,15 @@ describe("server/runtime-handler/index", () => {
   });
 
   it("runs middleware for authored OPTIONS preflight routes", async () => {
+    const projectDir = `/tmp/test-options-auth-${crypto.randomUUID()}`;
     const adapter = createRouteMockAdapter();
     adapter.fs.files.set(
-      "/tmp/test-project/pages/api/options.ts",
+      `${projectDir}/pages/api/options.ts`,
       "export function OPTIONS() { return new Response('unused'); }",
     );
     let middlewareCalls = 0;
-    const handler = createVeryfrontHandler("/tmp/test-project", adapter, {
-      projectDir: "/tmp/test-project",
+    const handler = createVeryfrontHandler(projectDir, adapter, {
+      projectDir,
       config: {
         security: {
           auth: {

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -4,6 +4,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeAdapter, RuntimeId } from "#veryfront/platform/adapters/base.ts";
+import { createMockAdapter as createRouteMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { SOURCE_SNAPSHOT_FRESHNESS_UNAVAILABLE } from "#veryfront/errors";
 import { DenoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
@@ -397,6 +398,51 @@ describe("server/runtime-handler/index", () => {
     assertEquals(response.status, 200);
     assertEquals(await response.json(), { subject: "user-123" });
     assertEquals(middlewareCalls, 1);
+  });
+
+  it("defers terminal application auth to automatic preflight", async () => {
+    const projectDir = `/tmp/test-options-public-${crypto.randomUUID()}`;
+    const adapter = createRouteMockAdapter();
+    adapter.fs.files.set(
+      `${projectDir}/pages/api/options.ts`,
+      "export function OPTIONS() { return new Response('must not run'); }",
+    );
+    let middlewareCalls = 0;
+    const handler = createVeryfrontHandler(projectDir, adapter, {
+      projectDir,
+      config: {
+        security: {
+          auth: {
+            trustedProxy: {
+              trustedPeers: ["127.0.0.1"],
+              headers: { subject: "x-auth-subject" },
+            },
+          },
+        },
+        middleware: {
+          custom: [
+            () => {
+              middlewareCalls++;
+              return new Response("middleware must not run", { status: 401 });
+            },
+          ],
+        },
+      } as any,
+      allowHostProjectCodeExecution: true,
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/options", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://client.example",
+          "access-control-request-method": "GET",
+        },
+      }),
+    );
+
+    assertEquals(response.status, 204);
+    assertEquals(middlewareCalls, 0);
   });
 
   it("short-circuits terminal application auth responses before project middleware", async () => {

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -757,7 +757,7 @@ describe("server/runtime-handler/index", () => {
     assertEquals(middlewareCalls, 0);
   });
 
-  it("revalidates framework-owned preflight before bypassing middleware", async () => {
+  it("retains a framework-owned preflight response across source changes", async () => {
     const projectDir = `/tmp/test-options-revalidation-${crypto.randomUUID()}`;
     const routePath = `${projectDir}/pages/api/options.ts`;
     const adapter = createRouteMockAdapter();
@@ -800,10 +800,10 @@ describe("server/runtime-handler/index", () => {
       }),
     );
 
-    assertEquals(response.status, 200);
-    assertEquals(await response.text(), "middleware ran");
-    assertEquals(middlewareCalls, 1);
-    assertEquals(routeReads, 2);
+    assertEquals(response.status, 204);
+    assertEquals(await response.text(), "");
+    assertEquals(middlewareCalls, 0);
+    assertEquals(routeReads, 1);
   });
 
   it("keeps CSP reports ahead of application auth admission", async () => {
@@ -1160,6 +1160,19 @@ describe("server/runtime-handler/index", () => {
     const response = await handler(new Request("http://localhost/healthz"));
 
     assertEquals(response.status, 200);
+    assertEquals(middlewareCalls, 0);
+
+    const preflight = await handler(
+      new Request("http://localhost/healthz", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://client.example",
+          "access-control-request-method": "GET",
+        },
+      }),
+    );
+
+    assertEquals(preflight.status, 204);
     assertEquals(middlewareCalls, 0);
   });
 

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -33,6 +33,7 @@ import {
 import { createApplicationAuthRequestHandler } from "#veryfront/security/application-auth/application-auth-runtime.ts";
 import { applyCORSHeaders } from "#veryfront/security/http/cors/headers.ts";
 import { isCspReportRequest } from "#veryfront/security/http/csp-report-endpoint.ts";
+import { isPreflightRequest } from "#veryfront/security/http/cors/preflight.ts";
 import { getEffectiveRequestOrigin } from "../utils/request-host.ts";
 
 // Re-export is at the bottom of the file
@@ -168,7 +169,7 @@ function shouldRetrySourceSnapshotFreshness(
 }
 
 function skipsApplicationAuth(request: Request, pathname: string): boolean {
-  return request.method === "OPTIONS" ||
+  return (request.method === "OPTIONS" && isPreflightRequest(request)) ||
     isCspReportRequest(request.method, pathname) ||
     isSignedControlPlaneDispatch(request) ||
     isSignedChannelDispatch(request) ||

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -33,7 +33,6 @@ import {
 import { createApplicationAuthRequestHandler } from "#veryfront/security/application-auth/application-auth-runtime.ts";
 import { applyCORSHeaders } from "#veryfront/security/http/cors/headers.ts";
 import { isCspReportRequest } from "#veryfront/security/http/csp-report-endpoint.ts";
-import { isPreflightRequest } from "#veryfront/security/http/cors/preflight.ts";
 import { getEffectiveRequestOrigin } from "../utils/request-host.ts";
 
 // Re-export is at the bottom of the file
@@ -168,8 +167,12 @@ function shouldRetrySourceSnapshotFreshness(
     error.slug === SOURCE_SNAPSHOT_FRESHNESS_UNAVAILABLE.slug;
 }
 
-function skipsApplicationAuth(request: Request, pathname: string): boolean {
-  return (request.method === "OPTIONS" && isPreflightRequest(request)) ||
+function skipsApplicationAuth(
+  request: Request,
+  pathname: string,
+  isFrameworkOwnedPreflight = false,
+): boolean {
+  return (request.method === "OPTIONS" && isFrameworkOwnedPreflight) ||
     isCspReportRequest(request.method, pathname) ||
     isSignedControlPlaneDispatch(request) ||
     isSignedChannelDispatch(request) ||
@@ -700,7 +703,11 @@ export function createVeryfrontHandler(
             requestMetricsIncremented = true;
           }
 
-          if (!skipsApplicationAuth(request, url.pathname)) {
+          const isFrameworkOwnedPreflight = await apiHandler.isFrameworkOwnedPreflight(
+            request,
+            ctx,
+          );
+          if (!skipsApplicationAuth(request, url.pathname, isFrameworkOwnedPreflight)) {
             const runInFilesystemContext = <T>(operation: () => Promise<T>) =>
               runInProjectFilesystemContext(ctx, isProxyMode, operation);
             const authResult = await runInFilesystemContext(
@@ -742,6 +749,7 @@ export function createVeryfrontHandler(
               request,
               handlerContext: ctx,
               isSharedProxy: isProxyMode,
+              isFrameworkOwnedPreflight,
               next: async () => (await registry.execute(request, ctx)) ?? undefined,
               onMiddlewareStart: markProjectMiddlewareStarted,
             });

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -443,7 +443,11 @@ export function createVeryfrontHandler(
         if (!isProxyMode) await securityLoader.ensureLoaded();
 
         const requiresApplicationAuth = !isPlatformLivenessProbe(req.method, url.pathname) &&
-          !skipsApplicationAuth(req, url.pathname);
+          !skipsApplicationAuth(
+            req,
+            url.pathname,
+            req.method.toUpperCase() === "OPTIONS" && isPreflightRequest(req),
+          );
         let requestOrigin: string | null | undefined;
         if (requiresApplicationAuth) {
           const preparedMonitoringRequest = await prepareProjectRequest({
@@ -761,9 +765,6 @@ export function createVeryfrontHandler(
               isSharedProxy: isProxyMode,
               isFrameworkOwnedPreflight,
               skipProjectMiddleware,
-              revalidateFrameworkOwnedPreflight: isFrameworkOwnedPreflight
-                ? () => apiHandler.isFrameworkOwnedPreflight(request, ctx)
-                : undefined,
               next: async () => (await registry.execute(request, ctx)) ?? undefined,
               onMiddlewareStart: markProjectMiddlewareStarted,
             });

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -30,7 +30,10 @@ import {
   isSignedChannelDispatch,
   isSignedControlPlaneDispatch,
 } from "#veryfront/channels/control-plane.ts";
-import { createApplicationAuthRequestHandler } from "#veryfront/security/application-auth/application-auth-runtime.ts";
+import {
+  type ApplicationAuthHandlerResult,
+  createApplicationAuthRequestHandler,
+} from "#veryfront/security/application-auth/application-auth-runtime.ts";
 import { applyCORSHeaders } from "#veryfront/security/http/cors/headers.ts";
 import { isCspReportRequest } from "#veryfront/security/http/csp-report-endpoint.ts";
 import { isPreflightRequest } from "#veryfront/security/http/cors/preflight.ts";
@@ -178,6 +181,24 @@ function skipsApplicationAuth(
     isSignedControlPlaneDispatch(request) ||
     isSignedChannelDispatch(request) ||
     isConfigOptionalControlPlaneRunRequest(request.method, pathname);
+}
+
+function applyApplicationAuthResult(
+  authResult: ApplicationAuthHandlerResult | Response | null,
+  ctx: _HandlerContext,
+  isOptionsRequest: boolean,
+  isBrowserPreflight: boolean,
+): { response: Response | null; skipProjectMiddleware: boolean } {
+  if (authResult instanceof Response) {
+    if (!isBrowserPreflight) return { response: authResult, skipProjectMiddleware: false };
+    ctx.applicationAuthResult = { response: authResult };
+    return { response: null, skipProjectMiddleware: true };
+  }
+
+  if (isOptionsRequest) ctx.applicationAuthResult = authResult;
+  ctx.applicationIdentity = authResult?.metadata?.applicationIdentity ?? null;
+  ctx.applicationIdentityHeaderNames = authResult?.metadata?.applicationIdentityHeaderNames ?? [];
+  return { response: null, skipProjectMiddleware: false };
 }
 
 /** Handler names in registration order. */
@@ -745,16 +766,14 @@ export function createVeryfrontHandler(
                   },
                 ),
             );
-            if (authResult instanceof Response) {
-              if (!isBrowserPreflight) return authResult;
-              ctx.applicationAuthResult = { response: authResult };
-              skipProjectMiddleware = true;
-            } else {
-              if (isOptionsRequest) ctx.applicationAuthResult = authResult;
-              ctx.applicationIdentity = authResult?.metadata?.applicationIdentity ?? null;
-              ctx.applicationIdentityHeaderNames =
-                authResult?.metadata?.applicationIdentityHeaderNames ?? [];
-            }
+            const authOutcome = applyApplicationAuthResult(
+              authResult,
+              ctx,
+              isOptionsRequest,
+              isBrowserPreflight,
+            );
+            if (authOutcome.response) return authOutcome.response;
+            skipProjectMiddleware = authOutcome.skipProjectMiddleware;
           }
 
           const sourceIntegrationPolicy = runtimeContext.sourceIntegrationPolicy;

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -733,7 +733,7 @@ export function createVeryfrontHandler(
             requestMetricsIncremented = true;
           }
 
-          const isFrameworkOwnedPreflight = await apiHandler.isFrameworkOwnedPreflight(
+          const isFrameworkOwnedPreflight = await apiHandler.prepareFrameworkOwnedPreflight(
             request,
             ctx,
           );

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -463,11 +463,15 @@ export function createVeryfrontHandler(
         await readyPromise;
         if (!isProxyMode) await securityLoader.ensureLoaded();
 
+        // Monitoring endpoints are always framework-owned; their browser
+        // preflights stay public without project or application auth.
+        const isFrameworkOwnedMonitoringPreflight = req.method.toUpperCase() === "OPTIONS" &&
+          isPreflightRequest(req);
         const requiresApplicationAuth = !isPlatformLivenessProbe(req.method, url.pathname) &&
           !skipsApplicationAuth(
             req,
             url.pathname,
-            req.method.toUpperCase() === "OPTIONS" && isPreflightRequest(req),
+            isFrameworkOwnedMonitoringPreflight,
           );
         let requestOrigin: string | null | undefined;
         if (requiresApplicationAuth) {

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -733,6 +733,9 @@ export function createVeryfrontHandler(
             requestMetricsIncremented = true;
           }
 
+          // This parser-only inspection intentionally precedes application
+          // auth: it never evaluates project code and keeps framework-owned
+          // automatic preflight public without widening authored-route access.
           const isFrameworkOwnedPreflight = await apiHandler.prepareFrameworkOwnedPreflight(
             request,
             ctx,

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -33,6 +33,7 @@ import {
 import { createApplicationAuthRequestHandler } from "#veryfront/security/application-auth/application-auth-runtime.ts";
 import { applyCORSHeaders } from "#veryfront/security/http/cors/headers.ts";
 import { isCspReportRequest } from "#veryfront/security/http/csp-report-endpoint.ts";
+import { isPreflightRequest } from "#veryfront/security/http/cors/preflight.ts";
 import { getEffectiveRequestOrigin } from "../utils/request-host.ts";
 
 // Re-export is at the bottom of the file
@@ -707,6 +708,9 @@ export function createVeryfrontHandler(
             request,
             ctx,
           );
+          const isOptionsRequest = request.method.toUpperCase() === "OPTIONS";
+          const isBrowserPreflight = isOptionsRequest && isPreflightRequest(request);
+          let skipProjectMiddleware = false;
           if (!skipsApplicationAuth(request, url.pathname, isFrameworkOwnedPreflight)) {
             const runInFilesystemContext = <T>(operation: () => Promise<T>) =>
               runInProjectFilesystemContext(ctx, isProxyMode, operation);
@@ -737,10 +741,16 @@ export function createVeryfrontHandler(
                   },
                 ),
             );
-            if (authResult instanceof Response) return authResult;
-            ctx.applicationIdentity = authResult?.metadata?.applicationIdentity ?? null;
-            ctx.applicationIdentityHeaderNames =
-              authResult?.metadata?.applicationIdentityHeaderNames ?? [];
+            if (authResult instanceof Response) {
+              if (!isBrowserPreflight) return authResult;
+              ctx.applicationAuthResult = { response: authResult };
+              skipProjectMiddleware = true;
+            } else {
+              if (isOptionsRequest) ctx.applicationAuthResult = authResult;
+              ctx.applicationIdentity = authResult?.metadata?.applicationIdentity ?? null;
+              ctx.applicationIdentityHeaderNames =
+                authResult?.metadata?.applicationIdentityHeaderNames ?? [];
+            }
           }
 
           const sourceIntegrationPolicy = runtimeContext.sourceIntegrationPolicy;
@@ -750,6 +760,10 @@ export function createVeryfrontHandler(
               handlerContext: ctx,
               isSharedProxy: isProxyMode,
               isFrameworkOwnedPreflight,
+              skipProjectMiddleware,
+              revalidateFrameworkOwnedPreflight: isFrameworkOwnedPreflight
+                ? () => apiHandler.isFrameworkOwnedPreflight(request, ctx)
+                : undefined,
               next: async () => (await registry.execute(request, ctx)) ?? undefined,
               onMiddlewareStart: markProjectMiddlewareStarted,
             });

--- a/src/server/runtime-handler/project-middleware.ts
+++ b/src/server/runtime-handler/project-middleware.ts
@@ -52,8 +52,6 @@ export interface ProjectMiddlewareRuntimeContext {
   isFrameworkOwnedPreflight?: boolean;
   /** True when a preflight auth response should flow to the API fallback. */
   skipProjectMiddleware?: boolean;
-  /** Rechecks a framework-owned preflight before bypassing project code. */
-  revalidateFrameworkOwnedPreflight?: () => Promise<boolean>;
 }
 
 function cacheSegment(value: string): string {
@@ -146,7 +144,6 @@ export class ProjectMiddlewareRuntime {
       next,
       onMiddlewareStart,
       request,
-      revalidateFrameworkOwnedPreflight,
       skipProjectMiddleware,
     } = input;
     const pathname = new URL(request.url).pathname;
@@ -159,15 +156,10 @@ export class ProjectMiddlewareRuntime {
       return next();
     }
 
-    // Browser preflight is framework-owned only after route inspection proves
-    // that no authored OPTIONS/default handler can execute. Revalidate the
-    // proof immediately before bypassing project code so a source change
-    // cannot turn an automatic response into authored route execution.
-    if (
-      isFrameworkOwnedPreflight &&
-      (revalidateFrameworkOwnedPreflight === undefined ||
-        await revalidateFrameworkOwnedPreflight())
-    ) {
+    // Browser preflight is framework-owned only after route inspection
+    // prepared the response from the same source snapshot. Keep middleware on
+    // every ambiguous or authored route shape.
+    if (isFrameworkOwnedPreflight) {
       return next();
     }
 

--- a/src/server/runtime-handler/project-middleware.ts
+++ b/src/server/runtime-handler/project-middleware.ts
@@ -25,7 +25,6 @@ import { isWebSocketPath } from "#veryfront/server/runtime-handler/request-utils
 import { isHostProjectCodeExecutionAllowed } from "#veryfront/security/project-locality.ts";
 import { createApplicationRequest } from "#veryfront/security/http/application-request.ts";
 import { runWithRetainedPreviewDocumentSourceSnapshot } from "../handlers/request/source-snapshot-freshness.ts";
-import { isPreflightRequest } from "#veryfront/security/http/cors/preflight.ts";
 
 const DEFAULT_MAX_ENTRIES = 100;
 const logger = serverLogger.component("project-middleware");
@@ -49,6 +48,8 @@ export interface ProjectMiddlewareRuntimeContext {
   next: () => Promise<Response | undefined>;
   /** Signals before project middleware can perform request-scoped side effects. */
   onMiddlewareStart?: () => void;
+  /** True only when route inspection proved the response is framework-owned. */
+  isFrameworkOwnedPreflight?: boolean;
 }
 
 function cacheSegment(value: string): string {
@@ -134,18 +135,24 @@ export class ProjectMiddlewareRuntime {
   }
 
   async execute(input: ProjectMiddlewareRuntimeContext): Promise<Response | undefined> {
-    const { handlerContext: ctx, isSharedProxy, next, onMiddlewareStart, request } = input;
+    const {
+      handlerContext: ctx,
+      isFrameworkOwnedPreflight,
+      isSharedProxy,
+      next,
+      onMiddlewareStart,
+      request,
+    } = input;
     const pathname = new URL(request.url).pathname;
 
     if (isWebSocketPath(pathname)) {
       return next();
     }
 
-    // Browser preflight is framework-owned and must remain public. It is
-    // handled by the registry after route-independent CORS validation, so a
-    // project middleware identity gate must not turn it into an application
-    // authorization failure.
-    if (isPreflightRequest(request)) {
+    // Browser preflight is framework-owned only after route inspection proves
+    // that no authored OPTIONS/default handler can execute. Keep middleware
+    // on every ambiguous or authored route shape.
+    if (isFrameworkOwnedPreflight) {
       return next();
     }
 

--- a/src/server/runtime-handler/project-middleware.ts
+++ b/src/server/runtime-handler/project-middleware.ts
@@ -158,7 +158,8 @@ export class ProjectMiddlewareRuntime {
 
     // Browser preflight is framework-owned only after route inspection
     // prepared the response from the same source snapshot. Keep middleware on
-    // every ambiguous or authored route shape.
+    // every ambiguous or authored route shape. The auth-terminal bypass above
+    // is the separate browser-preflight path and is mutually exclusive.
     if (isFrameworkOwnedPreflight) {
       return next();
     }

--- a/src/server/runtime-handler/project-middleware.ts
+++ b/src/server/runtime-handler/project-middleware.ts
@@ -25,6 +25,7 @@ import { isWebSocketPath } from "#veryfront/server/runtime-handler/request-utils
 import { isHostProjectCodeExecutionAllowed } from "#veryfront/security/project-locality.ts";
 import { createApplicationRequest } from "#veryfront/security/http/application-request.ts";
 import { runWithRetainedPreviewDocumentSourceSnapshot } from "../handlers/request/source-snapshot-freshness.ts";
+import { isPreflightRequest } from "#veryfront/security/http/cors/preflight.ts";
 
 const DEFAULT_MAX_ENTRIES = 100;
 const logger = serverLogger.component("project-middleware");
@@ -137,6 +138,14 @@ export class ProjectMiddlewareRuntime {
     const pathname = new URL(request.url).pathname;
 
     if (isWebSocketPath(pathname)) {
+      return next();
+    }
+
+    // Browser preflight is framework-owned and must remain public. It is
+    // handled by the registry after route-independent CORS validation, so a
+    // project middleware identity gate must not turn it into an application
+    // authorization failure.
+    if (isPreflightRequest(request)) {
       return next();
     }
 

--- a/src/server/runtime-handler/project-middleware.ts
+++ b/src/server/runtime-handler/project-middleware.ts
@@ -50,6 +50,10 @@ export interface ProjectMiddlewareRuntimeContext {
   onMiddlewareStart?: () => void;
   /** True only when route inspection proved the response is framework-owned. */
   isFrameworkOwnedPreflight?: boolean;
+  /** True when a preflight auth response should flow to the API fallback. */
+  skipProjectMiddleware?: boolean;
+  /** Rechecks a framework-owned preflight before bypassing project code. */
+  revalidateFrameworkOwnedPreflight?: () => Promise<boolean>;
 }
 
 function cacheSegment(value: string): string {
@@ -142,6 +146,8 @@ export class ProjectMiddlewareRuntime {
       next,
       onMiddlewareStart,
       request,
+      revalidateFrameworkOwnedPreflight,
+      skipProjectMiddleware,
     } = input;
     const pathname = new URL(request.url).pathname;
 
@@ -149,10 +155,19 @@ export class ProjectMiddlewareRuntime {
       return next();
     }
 
+    if (skipProjectMiddleware) {
+      return next();
+    }
+
     // Browser preflight is framework-owned only after route inspection proves
-    // that no authored OPTIONS/default handler can execute. Keep middleware
-    // on every ambiguous or authored route shape.
-    if (isFrameworkOwnedPreflight) {
+    // that no authored OPTIONS/default handler can execute. Revalidate the
+    // proof immediately before bypassing project code so a source change
+    // cannot turn an automatic response into authored route execution.
+    if (
+      isFrameworkOwnedPreflight &&
+      (revalidateFrameworkOwnedPreflight === undefined ||
+        await revalidateFrameworkOwnedPreflight())
+    ) {
       return next();
     }
 

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -109,6 +109,10 @@ export interface HandlerContext {
       applicationIdentityHeaderNames?: readonly string[];
     };
   } | null;
+  /** Whether this request's preflight was proven framework-owned. */
+  frameworkOwnedPreflight?: boolean;
+  /** Prepared framework-owned preflight response from the inspected source. */
+  frameworkPreflightResponse?: Response;
   /**
    * Prepares this request's authenticated hosted evaluation context.
    *

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -101,6 +101,14 @@ export interface HandlerContext {
   applicationIdentity?: ApplicationIdentity | null;
   /** Application-auth identity headers to strip before project code sees the request. */
   applicationIdentityHeaderNames?: readonly string[];
+  /** Application-auth result already computed before project middleware. */
+  applicationAuthResult?: {
+    response?: Response;
+    metadata?: {
+      applicationIdentity?: ApplicationIdentity;
+      applicationIdentityHeaderNames?: readonly string[];
+    };
+  } | null;
   /**
    * Prepares this request's authenticated hosted evaluation context.
    *


### PR DESCRIPTION
## Summary

- admit non-preflight OPTIONS requests before project middleware so trusted application identity is available to middleware
- keep browser CORS preflight public and bypass project middleware for that framework-owned path
- add runtime regression coverage for both behaviors

This follow-up addresses the late review comment on merged PR #4346: https://github.com/veryfront/veryfront-code/pull/4346#discussion_r3895965906

## Verification

- `deno fmt --check src/server/runtime-handler/index.ts src/server/runtime-handler/project-middleware.ts src/server/runtime-handler/index.test.ts`
- `deno lint src/server/runtime-handler/index.ts src/server/runtime-handler/project-middleware.ts src/server/runtime-handler/index.test.ts`
- `deno check --no-lock ...` reaches only existing repository-wide host-type errors; hosted CI is required for the pinned Deno test runner
- pinned local Deno test runner is blocked by the host bdd environment facade; hosted CI will validate the full matrix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic CORS preflight handling with appropriate `204` responses and `Allow` headers.
  * Preflight requests are handled consistently across isolated, shared, and contextual runtimes.
  * Application authentication now supports trusted-proxy identities for regular `OPTIONS` requests.
* **Bug Fixes**
  * Prevented framework-owned preflight requests from unnecessarily invoking project middleware.
  * Improved handling for unmatched routes, unavailable project execution, and monitoring endpoints.
  * Preserved authentication and error responses during preflight processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->