### PR TITLE
Fix OPTIONS authentication before project middleware

### DIFF
--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -148,6 +148,11 @@ type OptionsMiddlewareAdmission =
   | "continue"
   | "bypass-middleware";
 
+/**
+ * Request-scoped auth handoff consumed by handle(). The runtime creates a fresh
+ * HandlerContext for every attempt, and the weak key makes an abandoned prepare
+ * harmless; handle() deletes the entry as soon as it consumes it.
+ */
 const preparedOptionsAdmissions = new WeakMap<HandlerContext, Response | null>();
 
 /** Function signature for API route handlers. */

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -703,7 +703,7 @@ export class APIRouteHandler {
       : DEFAULT_CORS_METHODS.join(", ");
     const response = await handleCORSPreflight({
       request,
-      config: ctx?.securityConfig?.cors ?? this.corsConfig ?? undefined,
+      config: this.corsConfig ?? undefined,
       allowMethods,
       allowHeaders: getApplicationPreflightHeaders(request, {
         denyHeaders: ctx?.applicationIdentityHeaderNames,

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -703,7 +703,7 @@ export class APIRouteHandler {
       : DEFAULT_CORS_METHODS.join(", ");
     const response = await handleCORSPreflight({
       request,
-      config: this.corsConfig ?? undefined,
+      config: this.corsConfig ?? ctx?.config?.security?.cors ?? undefined,
       allowMethods,
       allowHeaders: getApplicationPreflightHeaders(request, {
         denyHeaders: ctx?.applicationIdentityHeaderNames,

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -252,15 +252,17 @@ export class APIRouteHandler {
     request: Request,
     ctx?: HandlerContext,
   ): Promise<{ frameworkOwned: boolean; response?: Response }> {
-    if (!isPreflightRequest(request)) return { frameworkOwned: false };
+    if (request.method.toUpperCase() !== "OPTIONS") return { frameworkOwned: false };
+    const isBrowserPreflight = isPreflightRequest(request);
     if (requiresIsolatedProjectRuntime(ctx)) {
       // The denied-execution wrapper creates the public fallback response.
-      return { frameworkOwned: true };
+      return { frameworkOwned: isBrowserPreflight };
     }
 
     const { pathname } = new URL(request.url);
     const match = this.router.match(pathname);
     if (!match) {
+      if (!isBrowserPreflight) return { frameworkOwned: false };
       return {
         frameworkOwned: true,
         response: await this.automaticPreflight(request, undefined, ctx),
@@ -279,17 +281,17 @@ export class APIRouteHandler {
       return { frameworkOwned: false };
     }
 
-    return {
-      frameworkOwned: true,
-      response: await this.automaticPreflight(
+    const response = isBrowserPreflight
+      ? await this.automaticPreflight(
         request,
         await resolveStaticRouteMethodsFromSource(
           source,
           this.requestedPreflightMethod(request),
         ),
         ctx,
-      ),
-    };
+      )
+      : undefined;
+    return { frameworkOwned: true, ...(response ? { response } : {}) };
   }
 
   /**
@@ -701,7 +703,7 @@ export class APIRouteHandler {
       : DEFAULT_CORS_METHODS.join(", ");
     const response = await handleCORSPreflight({
       request,
-      config: this.corsConfig ?? undefined,
+      config: ctx?.securityConfig?.cors ?? this.corsConfig ?? undefined,
       allowMethods,
       allowHeaders: getApplicationPreflightHeaders(request, {
         denyHeaders: ctx?.applicationIdentityHeaderNames,

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -143,6 +143,13 @@ export interface APIRouteHandleOptions {
   beforeOptionsDispatch?: () => Promise<void>;
 }
 
+type OptionsMiddlewareAdmission =
+  | "not-applicable"
+  | "continue"
+  | "bypass-middleware";
+
+const preparedOptionsAdmissions = new WeakMap<HandlerContext, Response | null>();
+
 /** Function signature for API route handlers. */
 export type APIHandler = (ctx: APIContext) => Promise<Response> | Response;
 
@@ -285,6 +292,39 @@ export class APIRouteHandler {
     };
   }
 
+  /**
+   * Admit a matched OPTIONS route before project middleware runs.
+   *
+   * This phase inspects route source without importing the route module. It
+   * authenticates only a route that may execute OPTIONS. Automatic fallback
+   * stays public and bypasses identity-gated project middleware.
+   */
+  async prepareOptionsMiddlewareAdmission(
+    request: Request,
+    ctx: HandlerContext,
+  ): Promise<OptionsMiddlewareAdmission> {
+    if (request.method.toUpperCase() !== "OPTIONS") return "not-applicable";
+
+    const pathname = new URL(request.url).pathname;
+    const match = this.router.match(pathname);
+    if (!match) return "not-applicable";
+
+    const adapter = await this.ensureAdapter();
+    await this.ensureCorsConfig(adapter);
+    if (
+      !isPreflightRequest(request) &&
+      await this.resolveStaticOptionsCapability(match.route.page, adapter) === "absent"
+    ) {
+      return "bypass-middleware";
+    }
+
+    const authResponse = await this.authenticateOptionsRoute(request, ctx);
+    preparedOptionsAdmissions.set(ctx, authResponse);
+    if (authResponse) return "bypass-middleware";
+
+    return "continue";
+  }
+
   handle(
     request: Request,
     ctx?: HandlerContext,
@@ -339,6 +379,11 @@ export class APIRouteHandler {
         });
 
         if (method === "OPTIONS") {
+          const hasPreparedAdmission = ctx ? preparedOptionsAdmissions.has(ctx) : false;
+          const preparedAuthResponse = ctx && hasPreparedAdmission
+            ? preparedOptionsAdmissions.get(ctx) ?? null
+            : null;
+          if (ctx && hasPreparedAdmission) preparedOptionsAdmissions.delete(ctx);
           if (
             !isPreflightRequest(request) &&
             await this.resolveStaticOptionsCapability(match.route.page, adapter) === "absent"
@@ -346,7 +391,9 @@ export class APIRouteHandler {
             return this.automaticPreflight(request, undefined, ctx);
           }
 
-          const authResponse = await this.authenticateOptionsRoute(request, ctx);
+          const authResponse = hasPreparedAdmission
+            ? preparedAuthResponse
+            : await this.authenticateOptionsRoute(request, ctx);
           if (authResponse) {
             if (isPreflightRequest(request)) {
               return this.automaticPreflight(

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -311,10 +311,7 @@ export class APIRouteHandler {
 
     const adapter = await this.ensureAdapter();
     await this.ensureCorsConfig(adapter);
-    if (
-      !isPreflightRequest(request) &&
-      await this.resolveStaticOptionsCapability(match.route.page, adapter) === "absent"
-    ) {
+    if (await this.resolveStaticOptionsCapability(match.route.page, adapter) === "absent") {
       return "bypass-middleware";
     }
 

--- a/src/routing/api/handler.ts
+++ b/src/routing/api/handler.ts
@@ -143,7 +143,7 @@ export interface APIRouteHandleOptions {
   beforeOptionsDispatch?: () => Promise<void>;
 }
 
-type OptionsMiddlewareAdmission =
+export type OptionsMiddlewareAdmission =
   | "not-applicable"
   | "continue"
   | "bypass-middleware";

--- a/src/server/handlers/request/api/api-handler-wrapper.test.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.test.ts
@@ -5,6 +5,7 @@ import type { HandlerContext } from "#veryfront/types";
 import { createMockAdapter as createFileAdapter } from "#veryfront/platform/adapters/mock.ts";
 import { ApiHandlerWrapper } from "./api-handler-wrapper.ts";
 import { __injectDepsForTests as injectMemoryPressureDeps } from "#veryfront/server/shared/renderer/memory/pressure.ts";
+import { runWithRetainedPreviewDocumentSourceSnapshot } from "#veryfront/server/handlers/request/source-snapshot-freshness.ts";
 
 function createCtx(captured: { options?: Record<string, unknown> }): HandlerContext {
   return {
@@ -72,6 +73,56 @@ describe("ApiHandlerWrapper", () => {
 
     assertEquals(result.response?.status, 204);
     assertEquals(result.response?.headers.get("Allow"), "GET, HEAD, OPTIONS");
+  });
+
+  it("retains a framework-owned preflight snapshot through dispatch", async () => {
+    const projectDir = "test-fixtures/api-wrapper-preflight-snapshot";
+    const adapter = createFileAdapter();
+    adapter.fs.files.set(
+      `${projectDir}/pages/api/get-only.ts`,
+      "export function GET() { return new Response('get'); }",
+    );
+    let sourceVersion = 1;
+    Object.assign(adapter.fs, {
+      sourceSnapshotFreshnessOptionsVersion: 1,
+      ensureSourceSnapshotFresh: () => Promise.resolve(),
+      getSourceSnapshotIdentity: () => "branch:preflight-snapshot:main",
+      getSourceSnapshotVersion: () => sourceVersion,
+    });
+    const ctx = {
+      projectDir,
+      adapter,
+      securityConfig: null,
+      projectSlug: "preflight-snapshot",
+      projectId: "project-preflight-snapshot",
+      resolvedEnvironment: "preview",
+      requestContext: {
+        token: "proxy-token",
+        slug: "preflight-snapshot",
+        branch: "main",
+        mode: "preview",
+      },
+      isLocalProject: false,
+      allowHostProjectCodeExecution: true,
+    } as unknown as HandlerContext;
+    const wrapper = new ApiHandlerWrapper(projectDir, adapter);
+    const request = new Request("http://localhost/api/get-only", {
+      method: "OPTIONS",
+      headers: {
+        origin: "https://client.example",
+        "access-control-request-method": "GET",
+      },
+    });
+
+    assertEquals(await wrapper.prepareFrameworkOwnedPreflight(request, ctx), true);
+    sourceVersion++;
+
+    await assertRejects(() =>
+      runWithRetainedPreviewDocumentSourceSnapshot(
+        ctx,
+        () => wrapper.handle(request, ctx),
+      )
+    );
   });
 
   it("prepares framework-owned preflight inside a multi-project context", async () => {

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -71,10 +71,11 @@ export class ApiHandlerWrapper extends BaseHandler {
   }
 
   async prepareFrameworkOwnedPreflight(req: Request, ctx: HandlerContext): Promise<boolean> {
-    if (!isPreflightRequest(req)) return false;
+    if (req.method.toUpperCase() !== "OPTIONS") return false;
+    const isBrowserPreflight = isPreflightRequest(req);
     if (requiresIsolatedProjectRuntime(ctx)) {
-      ctx.frameworkOwnedPreflight = true;
-      return true;
+      if (isBrowserPreflight) ctx.frameworkOwnedPreflight = true;
+      return isBrowserPreflight;
     }
 
     const fsWrapper = ctx.adapter.fs as FsWrapper;

--- a/src/server/handlers/request/api/api-handler-wrapper.ts
+++ b/src/server/handlers/request/api/api-handler-wrapper.ts
@@ -83,7 +83,7 @@ export class ApiHandlerWrapper extends BaseHandler {
       typeof fsWrapper.isMultiProjectMode === "function" &&
       fsWrapper.isMultiProjectMode();
     const inspect = async (): Promise<boolean> => {
-      await ensurePreviewSourceSnapshotFresh(ctx);
+      await preparePreviewDocumentSourceSnapshot(ctx);
       const result = await withApiHandler(
         ctx,
         (api) => api.prepareFrameworkOwnedPreflight(req, ctx),

--- a/src/server/handlers/request/api/index.ts
+++ b/src/server/handlers/request/api/index.ts
@@ -7,6 +7,11 @@
 export { ApiHandlerWrapper } from "./api-handler-wrapper.ts";
 export { handleAppRouter } from "./app-router-handler.ts";
 export { resolveAppRouteFile } from "./app-router-resolver.ts";
-export { getApiHandler, resetApiHandler, resetApiHandlerForProject } from "./pages-api-handler.ts";
+export {
+  getApiHandler,
+  resetApiHandler,
+  resetApiHandlerForProject,
+  withApiHandler,
+} from "./pages-api-handler.ts";
 export { applySecurityHeaders, buildCSP, getSecurityHeader } from "./security-headers.ts";
 export type { AppRouteMatch, HandlerFn, RouteHandlerModule } from "./types.ts";

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -1542,6 +1542,63 @@ describe("server/runtime-handler/index", () => {
     });
   });
 
+  it("keeps shared-runtime automatic OPTIONS ahead of project middleware", async () => {
+    const projectDir = "/tmp/test-shared-options-fallback";
+    const adapter = createRouteMockAdapter();
+    adapter.fs.files.set(
+      `${projectDir}/veryfront.config.ts`,
+      "export default {};",
+    );
+    const fs = adapter.fs as typeof adapter.fs & {
+      isVeryfrontAdapter: () => boolean;
+      getUnderlyingAdapter: () => typeof adapter.fs;
+      isMultiProjectMode: () => boolean;
+      isContextualMode: () => boolean;
+      runWithContext: <T>(
+        slug: string,
+        token: string,
+        operation: () => Promise<T>,
+        projectId?: string,
+        options?: { branch?: string | null },
+      ) => Promise<T>;
+      sourceSnapshotFreshnessOptionsVersion: 1;
+      ensureSourceSnapshotFresh: () => Promise<void>;
+      getSourceSnapshotIdentity: () => string;
+      getSourceSnapshotVersion: () => number;
+    };
+    fs.isVeryfrontAdapter = () => true;
+    fs.getUnderlyingAdapter = () => fs;
+    fs.isMultiProjectMode = () => true;
+    fs.isContextualMode = () => true;
+    fs.runWithContext = (slug, token, operation, projectId, options) =>
+      runWithRequestContext({ projectSlug: slug, token, projectId, ...options }, operation);
+    fs.sourceSnapshotFreshnessOptionsVersion = 1;
+    fs.ensureSourceSnapshotFresh = () => Promise.resolve();
+    fs.getSourceSnapshotIdentity = () => "branch:shared-options:main";
+    fs.getSourceSnapshotVersion = () => 1;
+    const handler = createVeryfrontHandler(projectDir, adapter, {
+      projectDir,
+      config: { fs: { veryfront: { proxyMode: true } } } as any,
+    });
+    Deno.env.set("VERYFRONT_TRUST_FORWARDED_HEADERS", "1");
+
+    const response = await handler(
+      new Request("http://runtime.internal/api/private", {
+        method: "OPTIONS",
+        headers: {
+          "x-project-slug": "shared-options",
+          "x-project-id": "project-shared-options",
+          "x-token": "proxy-token",
+          "x-environment": "preview",
+          "x-forwarded-host": "shared-options.preview.veryfront.com",
+          "x-forwarded-proto": "https",
+        },
+      }),
+    );
+
+    assertEquals(response.status, 204);
+  });
+
   it("allows proxy context only behind the operator-trusted topology", async () => {
     const handler = createProxyModeHandler();
     const isolationCalls = { check: 0, start: 0, complete: 0 };

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -2,7 +2,7 @@
 // intentionally exclude this file because it exercises Deno.env and the Deno adapter.
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
-import { afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { afterAll, afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeAdapter, RuntimeId } from "#veryfront/platform/adapters/base.ts";
 import { createMockAdapter as createRouteMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import type { VeryfrontConfig } from "#veryfront/config";
@@ -23,6 +23,7 @@ import { recordRequestPeerFromTransport } from "#veryfront/platform/adapters/run
 import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { createMockOidcProvider } from "#veryfront/security/application-auth/mock-oidc-provider.ts";
 import { createSessionCookie } from "#veryfront/security/application-auth/cookies.ts";
+import { createMockAdapter as createRouteMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import type { MiddlewareFunction } from "#veryfront/server/dev-server/middleware.ts";
 import {
   createSnapshot,
@@ -176,6 +177,36 @@ function withTrustedPeer(request: Request): Request {
   return request;
 }
 
+function createTrustedOptionsMiddlewareHandler(options: {
+  projectDir: string;
+  routePath: string;
+  routeSource: string;
+  middleware: MiddlewareFunction;
+  corsOrigin?: string;
+}) {
+  const adapter = createRouteMockAdapter();
+  adapter.fs.files.set(
+    `${options.projectDir}/${options.routePath}`,
+    options.routeSource,
+  );
+  return createVeryfrontHandler(options.projectDir, adapter, {
+    projectDir: options.projectDir,
+    config: {
+      security: {
+        ...(options.corsOrigin ? { cors: { origin: [options.corsOrigin] } } : {}),
+        auth: {
+          trustedProxy: {
+            trustedPeers: ["127.0.0.1"],
+            headers: { subject: "x-auth-subject" },
+          },
+        },
+      },
+      middleware: { custom: [options.middleware] },
+    } as any,
+    allowHostProjectCodeExecution: true,
+  });
+}
+
 function captureOtelHttpRequestCount(): { count: () => number } {
   let count = 0;
   const meter = {
@@ -201,6 +232,11 @@ function captureOtelHttpRequestCount(): { count: () => number } {
 }
 
 describe("server/runtime-handler/index", () => {
+  afterAll(async () => {
+    const { stop } = await import("veryfront/extensions/bundler");
+    await stop();
+  });
+
   beforeEach(() => {
     resetMetrics();
     resetOtelInstruments();
@@ -727,6 +763,113 @@ describe("server/runtime-handler/index", () => {
     );
 
     assertEquals(response.status, 204);
+    assertEquals(middlewareCalls, 0);
+  });
+
+  it("admits an explicit OPTIONS route before identity-gated project middleware", async () => {
+    const projectDir = "/tmp/test-options-middleware-auth";
+    let middlewareCalls = 0;
+    const identityMiddleware: MiddlewareFunction = async (context, next) => {
+      middlewareCalls++;
+      if (context.identity?.subject !== "user-123") {
+        return new Response("middleware unauthorized", { status: 403 });
+      }
+      return await next();
+    };
+    const handler = createTrustedOptionsMiddlewareHandler({
+      projectDir,
+      routePath: "pages/api/protected-options.ts",
+      routeSource: 'export function OPTIONS() { return new Response("route options"); }',
+      middleware: identityMiddleware,
+    });
+
+    const response = await handler(withTrustedPeer(
+      new Request("http://localhost/api/protected-options", {
+        method: "OPTIONS",
+        headers: { "x-auth-subject": "user-123" },
+      }),
+    ));
+
+    assertEquals(response.status, 200);
+    assertEquals(await response.text(), "route options");
+    assertEquals(middlewareCalls, 1);
+  });
+
+  it("keeps automatic OPTIONS public before identity-gated project middleware", async () => {
+    const projectDir = "/tmp/test-options-middleware-fallback";
+    let middlewareCalls = 0;
+    const identityGate: MiddlewareFunction = () => {
+      middlewareCalls++;
+      return new Response("middleware unauthorized", { status: 403 });
+    };
+    const handler = createTrustedOptionsMiddlewareHandler({
+      projectDir,
+      routePath: "pages/api/protected-get-only.ts",
+      routeSource: 'export function GET() { return new Response("get"); }',
+      middleware: identityGate,
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/protected-get-only", { method: "OPTIONS" }),
+    );
+
+    assertEquals(response.status, 204);
+    assertEquals(middlewareCalls, 0);
+  });
+
+  it("short-circuits rejected explicit OPTIONS auth before project middleware", async () => {
+    const projectDir = "/tmp/test-options-middleware-rejection";
+    let middlewareCalls = 0;
+    const middleware: MiddlewareFunction = () => {
+      middlewareCalls++;
+      return new Response("middleware ran", { status: 418 });
+    };
+    const handler = createTrustedOptionsMiddlewareHandler({
+      projectDir,
+      routePath: "pages/api/protected-options.ts",
+      routeSource: 'export function OPTIONS() { return new Response("must not run"); }',
+      middleware,
+    });
+
+    const response = await handler(
+      new Request("http://localhost/api/protected-options", {
+        method: "OPTIONS",
+        headers: { "x-auth-subject": "forged-user" },
+      }),
+    );
+
+    assertEquals(response.status, 401);
+    assertEquals(await response.text(), "Unauthorized");
+    assertEquals(middlewareCalls, 0);
+  });
+
+  it("keeps unauthenticated App-route preflight public before project middleware", async () => {
+    const projectDir = "/tmp/test-options-app-route-preflight";
+    let middlewareCalls = 0;
+    const middleware: MiddlewareFunction = () => {
+      middlewareCalls++;
+      return new Response("middleware ran", { status: 418 });
+    };
+    const handler = createTrustedOptionsMiddlewareHandler({
+      projectDir,
+      routePath: "app/webhooks/github/route.ts",
+      routeSource: 'export function OPTIONS() { return new Response("must not run"); }',
+      middleware,
+      corsOrigin: "https://client.example",
+    });
+
+    const response = await handler(
+      new Request("http://localhost/webhooks/github", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://client.example",
+          "access-control-request-method": "POST",
+        },
+      }),
+    );
+
+    assertEquals(response.status, 204);
+    assertEquals(response.headers.get("access-control-allow-origin"), "https://client.example");
     assertEquals(middlewareCalls, 0);
   });
 

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -1,10 +1,11 @@
 // Deno-only end-to-end runtime-handler coverage. Node and Bun planners
 // intentionally exclude this file because it exercises Deno.env and the Deno adapter.
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { afterAll, afterEach, beforeEach, describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeAdapter, RuntimeId } from "#veryfront/platform/adapters/base.ts";
 import { createMockAdapter as createRouteMockAdapter } from "#veryfront/platform/adapters/mock.ts";
+import type { HandlerContext } from "#veryfront/types";
 import type { VeryfrontConfig } from "#veryfront/config";
 import { SOURCE_SNAPSHOT_FRESHNESS_UNAVAILABLE } from "#veryfront/errors";
 import { DenoAdapter } from "#veryfront/platform/adapters/runtime/deno/index.ts";
@@ -16,7 +17,11 @@ import {
 } from "#veryfront/utils/logger/logger.ts";
 import { HMRHandler } from "../handlers/preview/hmr.handler.ts";
 import { runWithProjectEnv } from "../project-env/storage.ts";
-import { createVeryfrontHandler } from "./index.ts";
+import {
+  createVeryfrontHandler,
+  prepareOptionsBeforeProjectMiddleware,
+  shouldRetrySourceSnapshotFreshness,
+} from "./index.ts";
 import { __injectDepsForTests as injectIsolationDepsForTests } from "./isolation.ts";
 import { requestTracker } from "./request-tracker.ts";
 import { recordRequestPeerFromTransport } from "#veryfront/platform/adapters/runtime/shared/request-peer.ts";
@@ -25,6 +30,8 @@ import { createMockOidcProvider } from "#veryfront/security/application-auth/moc
 import { createSessionCookie } from "#veryfront/security/application-auth/cookies.ts";
 import { createMockAdapter as createRouteMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import type { MiddlewareFunction } from "#veryfront/server/dev-server/middleware.ts";
+import { ProjectMiddlewareRuntime } from "./project-middleware.ts";
+import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
 import {
   createSnapshot,
   resetMetrics,
@@ -39,6 +46,7 @@ import {
   getCurrentRequestContext,
   runWithRequestContext,
 } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
+import { seedPreviewDocumentSourceSnapshot } from "../handlers/request/source-snapshot-freshness.ts";
 
 function createMockAdapter(
   envValues: Record<string, string> = {},
@@ -697,6 +705,77 @@ describe("server/runtime-handler/index", () => {
     assertEquals(sourceVersion, 2);
     assertEquals(createSnapshot().requests, 1);
     assertEquals(otelRequestCount, 1);
+  });
+
+  it("allows automatic OPTIONS snapshot failures to retry before middleware", () => {
+    const error = SOURCE_SNAPSHOT_FRESHNESS_UNAVAILABLE.create({ detail: "snapshot changed" });
+
+    assertEquals(
+      shouldRetrySourceSnapshotFreshness(
+        new Request("http://localhost/api/protected", { method: "OPTIONS" }),
+        error,
+        0,
+        false,
+      ),
+      true,
+    );
+  });
+
+  it("retains an unmatched OPTIONS admission snapshot through middleware dispatch", async () => {
+    let sourceVersion = 1;
+    const adapter = createRouteMockAdapter();
+    const fs = adapter.fs as typeof adapter.fs & {
+      getSourceSnapshotIdentity: () => string;
+      getSourceSnapshotVersion: () => number;
+    };
+    fs.getSourceSnapshotIdentity = () => "branch:unmatched-options:main";
+    fs.getSourceSnapshotVersion = () => sourceVersion;
+    const context: HandlerContext = {
+      projectDir: "/tmp/test-unmatched-options",
+      adapter,
+      config: {},
+      securityConfig: null,
+      projectSlug: "unmatched-options",
+      projectId: "project-unmatched-options",
+      proxyToken: "proxy-token",
+      resolvedEnvironment: "preview",
+      requestContext: {
+        token: "proxy-token",
+        slug: "unmatched-options",
+        branch: "main",
+        mode: "preview",
+      },
+      isLocalProject: false,
+    };
+    const request = new Request("http://localhost/api/late-route", { method: "OPTIONS" });
+    seedPreviewDocumentSourceSnapshot(context, {
+      identity: "branch:unmatched-options:main",
+      version: sourceVersion,
+    });
+
+    const admission = await prepareOptionsBeforeProjectMiddleware({
+      request,
+      ctx: context,
+      sourceIntegrationPolicy: normalizeSourceIntegrationPolicy(undefined),
+      runInFilesystemContext: (operation) => operation(),
+      runInRequestProjectEnv: (operation) => operation(),
+    });
+
+    assertEquals(admission, "not-applicable");
+    sourceVersion++;
+
+    const runtime = new ProjectMiddlewareRuntime({ loadMiddleware: () => Promise.resolve([]) });
+    await assertRejects(
+      () =>
+        runtime.execute({
+          request,
+          handlerContext: context,
+          isSharedProxy: false,
+          next: () => Promise.resolve(new Response("late route")),
+        }),
+      Error,
+      "changed after request configuration was derived",
+    );
   });
 
   it("does not replay project middleware after a downstream snapshot failure", async () => {

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -761,7 +761,7 @@ describe("server/runtime-handler/index", () => {
       runInRequestProjectEnv: (operation) => operation(),
     });
 
-    assertEquals(admission, "not-applicable");
+    assertEquals(admission, "bypass-middleware-retained");
     sourceVersion++;
 
     const runtime = new ProjectMiddlewareRuntime({ loadMiddleware: () => Promise.resolve([]) });
@@ -776,6 +776,33 @@ describe("server/runtime-handler/index", () => {
       Error,
       "changed after request configuration was derived",
     );
+  });
+
+  it("keeps unmatched API OPTIONS public before project middleware", async () => {
+    let middlewareCalls = 0;
+    const handler = createVeryfrontHandler(
+      "/tmp/test-unmatched-options-public",
+      createMockAdapter(),
+      {
+        projectDir: "/tmp/test-unmatched-options-public",
+        config: {
+          middleware: {
+            custom: [() => {
+              middlewareCalls++;
+              return new Response("middleware ran", { status: 403 });
+            }],
+          },
+        } satisfies VeryfrontConfig,
+        allowHostProjectCodeExecution: true,
+      },
+    );
+
+    const response = await handler(
+      new Request("http://localhost/api/missing", { method: "OPTIONS" }),
+    );
+
+    assertEquals(response.status, 204);
+    assertEquals(middlewareCalls, 0);
   });
 
   it("does not replay project middleware after a downstream snapshot failure", async () => {

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -715,8 +715,19 @@ describe("server/runtime-handler/index", () => {
         error,
         0,
         false,
+        true,
       ),
       true,
+    );
+    assertEquals(
+      shouldRetrySourceSnapshotFreshness(
+        new Request("http://localhost/api/protected", { method: "OPTIONS" }),
+        error,
+        0,
+        false,
+        false,
+      ),
+      false,
     );
   });
 

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -28,7 +28,6 @@ import { recordRequestPeerFromTransport } from "#veryfront/platform/adapters/run
 import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { createMockOidcProvider } from "#veryfront/security/application-auth/mock-oidc-provider.ts";
 import { createSessionCookie } from "#veryfront/security/application-auth/cookies.ts";
-import { createMockAdapter as createRouteMockAdapter } from "#veryfront/platform/adapters/mock.ts";
 import type { MiddlewareFunction } from "#veryfront/server/dev-server/middleware.ts";
 import { ProjectMiddlewareRuntime } from "./project-middleware.ts";
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
@@ -761,7 +760,7 @@ describe("server/runtime-handler/index", () => {
       runInRequestProjectEnv: (operation) => operation(),
     });
 
-    assertEquals(admission, "bypass-middleware-retained");
+    assertEquals(admission, "not-applicable");
     sourceVersion++;
 
     const runtime = new ProjectMiddlewareRuntime({ loadMiddleware: () => Promise.resolve([]) });
@@ -776,33 +775,6 @@ describe("server/runtime-handler/index", () => {
       Error,
       "changed after request configuration was derived",
     );
-  });
-
-  it("keeps unmatched API OPTIONS public before project middleware", async () => {
-    let middlewareCalls = 0;
-    const handler = createVeryfrontHandler(
-      "/tmp/test-unmatched-options-public",
-      createMockAdapter(),
-      {
-        projectDir: "/tmp/test-unmatched-options-public",
-        config: {
-          middleware: {
-            custom: [() => {
-              middlewareCalls++;
-              return new Response("middleware ran", { status: 403 });
-            }],
-          },
-        } satisfies VeryfrontConfig,
-        allowHostProjectCodeExecution: true,
-      },
-    );
-
-    const response = await handler(
-      new Request("http://localhost/api/missing", { method: "OPTIONS" }),
-    );
-
-    assertEquals(response.status, 204);
-    assertEquals(middlewareCalls, 0);
   });
 
   it("does not replay project middleware after a downstream snapshot failure", async () => {

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -29,7 +29,7 @@ import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { createMockOidcProvider } from "#veryfront/security/application-auth/mock-oidc-provider.ts";
 import { createSessionCookie } from "#veryfront/security/application-auth/cookies.ts";
 import type { MiddlewareFunction } from "#veryfront/server/dev-server/middleware.ts";
-import { ProjectMiddlewareRuntime } from "./project-middleware.ts";
+import { ProjectMiddlewareRuntime } from "#veryfront/server/runtime-handler/project-middleware.ts";
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
 import {
   createSnapshot,
@@ -45,7 +45,16 @@ import {
   getCurrentRequestContext,
   runWithRequestContext,
 } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
-import { seedPreviewDocumentSourceSnapshot } from "../handlers/request/source-snapshot-freshness.ts";
+import { seedPreviewDocumentSourceSnapshot } from "#veryfront/server/handlers/request/source-snapshot-freshness.ts";
+import { fromFileUrl, join } from "#veryfront/compat/path/index.ts";
+
+const TEST_FIXTURES_ROOT = fromFileUrl(
+  new URL("../../../test-fixtures/", import.meta.url),
+);
+
+function testProjectDir(name: string): string {
+  return join(TEST_FIXTURES_ROOT, name);
+}
 
 function createMockAdapter(
   envValues: Record<string, string> = {},
@@ -741,7 +750,7 @@ describe("server/runtime-handler/index", () => {
     fs.getSourceSnapshotIdentity = () => "branch:unmatched-options:main";
     fs.getSourceSnapshotVersion = () => sourceVersion;
     const context: HandlerContext = {
-      projectDir: "/tmp/test-unmatched-options",
+      projectDir: testProjectDir("unmatched-options"),
       adapter,
       config: {},
       securityConfig: null,
@@ -856,7 +865,7 @@ describe("server/runtime-handler/index", () => {
   });
 
   it("admits an explicit OPTIONS route before identity-gated project middleware", async () => {
-    const projectDir = "/tmp/test-options-middleware-auth";
+    const projectDir = testProjectDir("options-middleware-auth");
     let middlewareCalls = 0;
     const identityMiddleware: MiddlewareFunction = async (context, next) => {
       middlewareCalls++;
@@ -885,7 +894,7 @@ describe("server/runtime-handler/index", () => {
   });
 
   it("keeps automatic OPTIONS public before identity-gated project middleware", async () => {
-    const projectDir = "/tmp/test-options-middleware-fallback";
+    const projectDir = testProjectDir("options-middleware-fallback");
     let middlewareCalls = 0;
     const identityGate: MiddlewareFunction = () => {
       middlewareCalls++;
@@ -907,7 +916,7 @@ describe("server/runtime-handler/index", () => {
   });
 
   it("keeps authenticated automatic preflight ahead of project middleware", async () => {
-    const projectDir = "/tmp/test-options-authenticated-preflight";
+    const projectDir = testProjectDir("options-authenticated-preflight");
     let middlewareCalls = 0;
     const middleware: MiddlewareFunction = () => {
       middlewareCalls++;
@@ -938,7 +947,7 @@ describe("server/runtime-handler/index", () => {
   });
 
   it("short-circuits rejected explicit OPTIONS auth before project middleware", async () => {
-    const projectDir = "/tmp/test-options-middleware-rejection";
+    const projectDir = testProjectDir("options-middleware-rejection");
     let middlewareCalls = 0;
     const middleware: MiddlewareFunction = () => {
       middlewareCalls++;
@@ -964,7 +973,7 @@ describe("server/runtime-handler/index", () => {
   });
 
   it("keeps unauthenticated App-route preflight public before project middleware", async () => {
-    const projectDir = "/tmp/test-options-app-route-preflight";
+    const projectDir = testProjectDir("options-app-route-preflight");
     let middlewareCalls = 0;
     const middleware: MiddlewareFunction = () => {
       middlewareCalls++;
@@ -1663,7 +1672,7 @@ describe("server/runtime-handler/index", () => {
   });
 
   it("keeps shared-runtime automatic OPTIONS ahead of project middleware", async () => {
-    const projectDir = "/tmp/test-shared-options-fallback";
+    const projectDir = testProjectDir("shared-options-fallback");
     const adapter = createRouteMockAdapter();
     adapter.fs.files.set(
       `${projectDir}/veryfront.config.ts`,

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -817,6 +817,37 @@ describe("server/runtime-handler/index", () => {
     assertEquals(middlewareCalls, 0);
   });
 
+  it("keeps authenticated automatic preflight ahead of project middleware", async () => {
+    const projectDir = "/tmp/test-options-authenticated-preflight";
+    let middlewareCalls = 0;
+    const middleware: MiddlewareFunction = () => {
+      middlewareCalls++;
+      return new Response("middleware ran", { status: 403 });
+    };
+    const handler = createTrustedOptionsMiddlewareHandler({
+      projectDir,
+      routePath: "pages/api/protected-get-only.ts",
+      routeSource: 'export function GET() { return new Response("get"); }',
+      middleware,
+      corsOrigin: "https://client.example",
+    });
+
+    const response = await handler(withTrustedPeer(
+      new Request("http://localhost/api/protected-get-only", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://client.example",
+          "access-control-request-method": "GET",
+          "x-auth-subject": "user-123",
+        },
+      }),
+    ));
+
+    assertEquals(response.status, 204);
+    assertEquals(response.headers.get("access-control-allow-origin"), "https://client.example");
+    assertEquals(middlewareCalls, 0);
+  });
+
   it("short-circuits rejected explicit OPTIONS auth before project middleware", async () => {
     const projectDir = "/tmp/test-options-middleware-rejection";
     let middlewareCalls = 0;

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -194,7 +194,10 @@ async function prepareOptionsBeforeProjectMiddleware(input: {
     runWithRetainedPreviewDocumentSourceSnapshot(
       input.ctx,
       prepareWithSourcePolicy,
-      { runDeferredOperation: input.runInFilesystemContext },
+      {
+        retainAfterOperation: (result) => result === "continue",
+        runDeferredOperation: input.runInFilesystemContext,
+      },
     )
   );
 }

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -211,10 +211,13 @@ export function shouldRetrySourceSnapshotFreshness(
   error: unknown,
   retries: number,
   projectMiddlewareStarted: boolean,
+  isFrameworkOwnedPreflight = false,
 ): boolean {
+  const methodCanRetry = request.method === "GET" || request.method === "HEAD" ||
+    (request.method === "OPTIONS" && isFrameworkOwnedPreflight);
   return retries < SOURCE_SNAPSHOT_FRESHNESS_RETRY_LIMIT &&
     !projectMiddlewareStarted &&
-    (request.method === "GET" || request.method === "HEAD" || request.method === "OPTIONS") &&
+    methodCanRetry &&
     isVeryfrontError(error) &&
     error.slug === SOURCE_SNAPSHOT_FRESHNESS_UNAVAILABLE.slug;
 }
@@ -659,10 +662,12 @@ export function createVeryfrontHandler(
 
         let requestMetricsIncremented = false;
         let projectMiddlewareStarted = false;
+        let isFrameworkOwnedPreflightForRetry = false;
         const markProjectMiddlewareStarted = () => {
           projectMiddlewareStarted = true;
         };
         const executeHandlerAttempt = async (request: Request): Promise<Response> => {
+          isFrameworkOwnedPreflightForRetry = false;
           // Fast rejection of vulnerability scanner probes before any async work
           if (SCANNER_PATH_PATTERN.test(url.pathname)) {
             return new Response("Not Found", { status: 404 });
@@ -792,6 +797,7 @@ export function createVeryfrontHandler(
             request,
             ctx,
           );
+          isFrameworkOwnedPreflightForRetry = isFrameworkOwnedPreflight;
           const isOptionsRequest = request.method.toUpperCase() === "OPTIONS";
           const isBrowserPreflight = isOptionsRequest && isPreflightRequest(request);
           let skipProjectMiddleware = false;
@@ -910,6 +916,7 @@ export function createVeryfrontHandler(
                   error,
                   retries,
                   projectMiddlewareStarted,
+                  isFrameworkOwnedPreflightForRetry,
                 )
               ) throw error;
               retries++;

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -202,6 +202,11 @@ export async function prepareOptionsBeforeProjectMiddleware(input: {
       },
     )
   );
+  if (admission === "not-applicable") {
+    const pathname = new URL(input.request.url).pathname;
+    const isApiPath = pathname === "/api" || pathname.startsWith("/api/");
+    if (isApiPath) return "bypass-middleware-retained";
+  }
   return admission === "bypass-middleware" ? "bypass-middleware-retained" : admission;
 }
 

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -72,7 +72,7 @@ import { ProdHydrationModuleHandler } from "../handlers/request/prod-hydration-m
 import { CSSHandler } from "../handlers/request/css.handler.ts";
 import { RSCHandler } from "../handlers/request/rsc/index.ts";
 import { ModuleHandler } from "../handlers/request/module/index.ts";
-import { ApiHandlerWrapper, withApiHandler } from "../handlers/request/api/index.ts";
+import { ApiHandlerWrapper, withApiHandler } from "#veryfront/server/handlers/request/api/index.ts";
 import { SSRHandler } from "../handlers/request/ssr/index.ts";
 import { NotFoundHandler } from "../handlers/response/not-found.ts";
 import { HMRHandler } from "../handlers/preview/hmr.handler.ts";

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -20,6 +20,7 @@ import {
   UNKNOWN_ERROR,
 } from "#veryfront/errors";
 import { RouteRegistry } from "#veryfront/routing/registry/index.ts";
+import type { OptionsMiddlewareAdmission as ApiOptionsMiddlewareAdmission } from "#veryfront/routing/api/handler.ts";
 import type { Handler } from "#veryfront/types";
 import { SecurityConfigLoader } from "#veryfront/security/http/config.ts";
 import { runWithExactSourceIntegrationPolicy } from "#veryfront/integrations/source-policy-context.ts";
@@ -160,10 +161,8 @@ const logger = baseLogger.component("runtime-handler");
 
 const SOURCE_SNAPSHOT_FRESHNESS_RETRY_LIMIT = 1;
 
-type OptionsMiddlewareAdmission =
-  | "not-applicable"
-  | "continue"
-  | "bypass-middleware"
+type RuntimeOptionsMiddlewareAdmission =
+  | ApiOptionsMiddlewareAdmission
   | "bypass-middleware-retained";
 
 type ProjectEnvironmentRunner = <T>(operation: () => T) => T;
@@ -175,7 +174,7 @@ export async function prepareOptionsBeforeProjectMiddleware(input: {
   sourceIntegrationPolicy: SourceIntegrationPolicyManifest;
   runInFilesystemContext: <T>(operation: () => Promise<T>) => Promise<T>;
   runInRequestProjectEnv: ProjectEnvironmentRunner;
-}): Promise<OptionsMiddlewareAdmission> {
+}): Promise<RuntimeOptionsMiddlewareAdmission> {
   if (input.request.method !== "OPTIONS") return "not-applicable";
   if (requiresIsolatedProjectRuntime(input.ctx)) return "bypass-middleware";
 

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -168,7 +168,8 @@ type OptionsMiddlewareAdmission =
 
 type ProjectEnvironmentRunner = <T>(operation: () => T) => T;
 
-async function prepareOptionsBeforeProjectMiddleware(input: {
+/** @internal Exported for the runtime admission regression tests. */
+export async function prepareOptionsBeforeProjectMiddleware(input: {
   request: Request;
   ctx: _HandlerContext;
   sourceIntegrationPolicy: SourceIntegrationPolicyManifest;
@@ -196,7 +197,7 @@ async function prepareOptionsBeforeProjectMiddleware(input: {
       input.ctx,
       prepareWithSourcePolicy,
       {
-        retainAfterOperation: (result) => result !== "not-applicable",
+        retainAfterOperation: () => true,
         runDeferredOperation: input.runInFilesystemContext,
       },
     )
@@ -204,7 +205,8 @@ async function prepareOptionsBeforeProjectMiddleware(input: {
   return admission === "bypass-middleware" ? "bypass-middleware-retained" : admission;
 }
 
-function shouldRetrySourceSnapshotFreshness(
+/** Whether a request can be replayed before project middleware has started. */
+export function shouldRetrySourceSnapshotFreshness(
   request: Request,
   error: unknown,
   retries: number,
@@ -212,7 +214,7 @@ function shouldRetrySourceSnapshotFreshness(
 ): boolean {
   return retries < SOURCE_SNAPSHOT_FRESHNESS_RETRY_LIMIT &&
     !projectMiddlewareStarted &&
-    (request.method === "GET" || request.method === "HEAD") &&
+    (request.method === "GET" || request.method === "HEAD" || request.method === "OPTIONS") &&
     isVeryfrontError(error) &&
     error.slug === SOURCE_SNAPSHOT_FRESHNESS_UNAVAILABLE.slug;
 }

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -72,7 +72,7 @@ import { ProdHydrationModuleHandler } from "../handlers/request/prod-hydration-m
 import { CSSHandler } from "../handlers/request/css.handler.ts";
 import { RSCHandler } from "../handlers/request/rsc/index.ts";
 import { ModuleHandler } from "../handlers/request/module/index.ts";
-import { ApiHandlerWrapper } from "../handlers/request/api/index.ts";
+import { ApiHandlerWrapper, withApiHandler } from "../handlers/request/api/index.ts";
 import { SSRHandler } from "../handlers/request/ssr/index.ts";
 import { NotFoundHandler } from "../handlers/response/not-found.ts";
 import { HMRHandler } from "../handlers/preview/hmr.handler.ts";
@@ -148,6 +148,7 @@ import {
   resolveProjectRuntimeContext,
 } from "./project-runtime-context.ts";
 import { runWithRetainedPreviewDocumentSourceSnapshot } from "#veryfront/server/handlers/request/source-snapshot-freshness.ts";
+import { requiresIsolatedProjectRuntime } from "#veryfront/security/project-locality.ts";
 
 // Re-export from dedicated module for lightweight imports
 export { parseProxyEnvironment, type ProxyEnvironment } from "./proxy-environment.ts";
@@ -728,6 +729,10 @@ export function createVeryfrontHandler(
               ? operation()
               : runWithProjectEnv(isolatedEnvForRequest, operation);
 
+          const runInFilesystemContext = <T>(operation: () => Promise<T>) =>
+            runInProjectFilesystemContext(ctx, isProxyMode, operation);
+          const sourceIntegrationPolicy = runtimeContext.sourceIntegrationPolicy;
+
           if (!requestMetricsIncremented) {
             await incrementRequestMetrics();
             requestMetricsIncremented = true;
@@ -744,8 +749,6 @@ export function createVeryfrontHandler(
           const isBrowserPreflight = isOptionsRequest && isPreflightRequest(request);
           let skipProjectMiddleware = false;
           if (!skipsApplicationAuth(request, url.pathname, isFrameworkOwnedPreflight)) {
-            const runInFilesystemContext = <T>(operation: () => Promise<T>) =>
-              runInProjectFilesystemContext(ctx, isProxyMode, operation);
             const authResult = await runInFilesystemContext(
               () =>
                 runWithRetainedPreviewDocumentSourceSnapshot(
@@ -783,17 +786,42 @@ export function createVeryfrontHandler(
             skipProjectMiddleware = authOutcome.skipProjectMiddleware;
           }
 
-          const sourceIntegrationPolicy = runtimeContext.sourceIntegrationPolicy;
+          const optionsAdmission = request.method === "OPTIONS"
+            ? requiresIsolatedProjectRuntime(ctx)
+              ? "bypass-middleware"
+              : await runInFilesystemContext(() =>
+                runWithRetainedPreviewDocumentSourceSnapshot(
+                  ctx,
+                  () =>
+                    runWithExactSourceIntegrationPolicy(
+                      sourceIntegrationPolicy,
+                      () =>
+                        runInRequestProjectEnv(() =>
+                          withApiHandler(
+                            ctx,
+                            (api) => api.prepareOptionsMiddlewareAdmission(request, ctx),
+                            { sourceSnapshotReady: true },
+                          )
+                        ),
+                    ),
+                  { runDeferredOperation: runInFilesystemContext },
+                )
+              )
+            : "not-applicable";
+
+          const executeRegistry = async () => (await registry.execute(request, ctx)) ?? undefined;
           const executeProjectRoute = () =>
-            projectMiddlewareRuntime.execute({
-              request,
-              handlerContext: ctx,
-              isSharedProxy: isProxyMode,
-              isFrameworkOwnedPreflight,
-              skipProjectMiddleware,
-              next: async () => (await registry.execute(request, ctx)) ?? undefined,
-              onMiddlewareStart: markProjectMiddlewareStarted,
-            });
+            optionsAdmission === "bypass-middleware"
+              ? executeRegistry()
+              : projectMiddlewareRuntime.execute({
+                request,
+                handlerContext: ctx,
+                isSharedProxy: isProxyMode,
+                isFrameworkOwnedPreflight,
+                skipProjectMiddleware,
+                next: executeRegistry,
+                onMiddlewareStart: markProjectMiddlewareStarted,
+              });
           const executeRoute = () =>
             runWithExactSourceIntegrationPolicy(
               sourceIntegrationPolicy,

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -23,6 +23,7 @@ import { RouteRegistry } from "#veryfront/routing/registry/index.ts";
 import type { Handler } from "#veryfront/types";
 import { SecurityConfigLoader } from "#veryfront/security/http/config.ts";
 import { runWithExactSourceIntegrationPolicy } from "#veryfront/integrations/source-policy-context.ts";
+import type { SourceIntegrationPolicyManifest } from "#veryfront/integrations/source-policy.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { isTruthyEnvValue } from "#veryfront/utils/constants/env.ts";
 import {
@@ -158,6 +159,45 @@ const baseLogger = getBaseLogger("SERVER");
 const logger = baseLogger.component("runtime-handler");
 
 const SOURCE_SNAPSHOT_FRESHNESS_RETRY_LIMIT = 1;
+
+type OptionsMiddlewareAdmission =
+  | "not-applicable"
+  | "continue"
+  | "bypass-middleware";
+
+type ProjectEnvironmentRunner = <T>(operation: () => T) => T;
+
+async function prepareOptionsBeforeProjectMiddleware(input: {
+  request: Request;
+  ctx: _HandlerContext;
+  sourceIntegrationPolicy: SourceIntegrationPolicyManifest;
+  runInFilesystemContext: <T>(operation: () => Promise<T>) => Promise<T>;
+  runInRequestProjectEnv: ProjectEnvironmentRunner;
+}): Promise<OptionsMiddlewareAdmission> {
+  if (input.request.method !== "OPTIONS") return "not-applicable";
+  if (requiresIsolatedProjectRuntime(input.ctx)) return "bypass-middleware";
+
+  const prepareApiAdmission = () =>
+    withApiHandler(
+      input.ctx,
+      (api) => api.prepareOptionsMiddlewareAdmission(input.request, input.ctx),
+      { sourceSnapshotReady: true },
+    );
+  const prepareInProjectEnv = () => input.runInRequestProjectEnv(prepareApiAdmission);
+  const prepareWithSourcePolicy = () =>
+    runWithExactSourceIntegrationPolicy(
+      input.sourceIntegrationPolicy,
+      prepareInProjectEnv,
+    );
+
+  return await input.runInFilesystemContext(() =>
+    runWithRetainedPreviewDocumentSourceSnapshot(
+      input.ctx,
+      prepareWithSourcePolicy,
+      { runDeferredOperation: input.runInFilesystemContext },
+    )
+  );
+}
 
 function shouldRetrySourceSnapshotFreshness(
   request: Request,
@@ -786,28 +826,13 @@ export function createVeryfrontHandler(
             skipProjectMiddleware = authOutcome.skipProjectMiddleware;
           }
 
-          const optionsAdmission = request.method === "OPTIONS"
-            ? requiresIsolatedProjectRuntime(ctx)
-              ? "bypass-middleware"
-              : await runInFilesystemContext(() =>
-                runWithRetainedPreviewDocumentSourceSnapshot(
-                  ctx,
-                  () =>
-                    runWithExactSourceIntegrationPolicy(
-                      sourceIntegrationPolicy,
-                      () =>
-                        runInRequestProjectEnv(() =>
-                          withApiHandler(
-                            ctx,
-                            (api) => api.prepareOptionsMiddlewareAdmission(request, ctx),
-                            { sourceSnapshotReady: true },
-                          )
-                        ),
-                    ),
-                  { runDeferredOperation: runInFilesystemContext },
-                )
-              )
-            : "not-applicable";
+          const optionsAdmission = await prepareOptionsBeforeProjectMiddleware({
+            request,
+            ctx,
+            sourceIntegrationPolicy,
+            runInFilesystemContext,
+            runInRequestProjectEnv,
+          });
 
           const executeRegistry = async () => (await registry.execute(request, ctx)) ?? undefined;
           const executeProjectRoute = () =>

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -202,11 +202,6 @@ export async function prepareOptionsBeforeProjectMiddleware(input: {
       },
     )
   );
-  if (admission === "not-applicable") {
-    const pathname = new URL(input.request.url).pathname;
-    const isApiPath = pathname === "/api" || pathname.startsWith("/api/");
-    if (isApiPath) return "bypass-middleware-retained";
-  }
   return admission === "bypass-middleware" ? "bypass-middleware-retained" : admission;
 }
 
@@ -838,13 +833,15 @@ export function createVeryfrontHandler(
             skipProjectMiddleware = authOutcome.skipProjectMiddleware;
           }
 
-          const optionsAdmission = await prepareOptionsBeforeProjectMiddleware({
-            request,
-            ctx,
-            sourceIntegrationPolicy,
-            runInFilesystemContext,
-            runInRequestProjectEnv,
-          });
+          const optionsAdmission = isFrameworkOwnedPreflight
+            ? "not-applicable"
+            : await prepareOptionsBeforeProjectMiddleware({
+              request,
+              ctx,
+              sourceIntegrationPolicy,
+              runInFilesystemContext,
+              runInRequestProjectEnv,
+            });
 
           const executeRegistry = async () => (await registry.execute(request, ctx)) ?? undefined;
           const executeRegistryWithRetainedSnapshot = () =>

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -163,7 +163,8 @@ const SOURCE_SNAPSHOT_FRESHNESS_RETRY_LIMIT = 1;
 type OptionsMiddlewareAdmission =
   | "not-applicable"
   | "continue"
-  | "bypass-middleware";
+  | "bypass-middleware"
+  | "bypass-middleware-retained";
 
 type ProjectEnvironmentRunner = <T>(operation: () => T) => T;
 
@@ -190,16 +191,17 @@ async function prepareOptionsBeforeProjectMiddleware(input: {
       prepareInProjectEnv,
     );
 
-  return await input.runInFilesystemContext(() =>
+  const admission = await input.runInFilesystemContext(() =>
     runWithRetainedPreviewDocumentSourceSnapshot(
       input.ctx,
       prepareWithSourcePolicy,
       {
-        retainAfterOperation: (result) => result === "continue",
+        retainAfterOperation: (result) => result !== "not-applicable",
         runDeferredOperation: input.runInFilesystemContext,
       },
     )
   );
+  return admission === "bypass-middleware" ? "bypass-middleware-retained" : admission;
 }
 
 function shouldRetrySourceSnapshotFreshness(
@@ -838,18 +840,29 @@ export function createVeryfrontHandler(
           });
 
           const executeRegistry = async () => (await registry.execute(request, ctx)) ?? undefined;
-          const executeProjectRoute = () =>
-            optionsAdmission === "bypass-middleware"
-              ? executeRegistry()
-              : projectMiddlewareRuntime.execute({
-                request,
-                handlerContext: ctx,
-                isSharedProxy: isProxyMode,
-                isFrameworkOwnedPreflight,
-                skipProjectMiddleware,
-                next: executeRegistry,
-                onMiddlewareStart: markProjectMiddlewareStarted,
-              });
+          const executeRegistryWithRetainedSnapshot = () =>
+            runInFilesystemContext(() =>
+              runWithRetainedPreviewDocumentSourceSnapshot(
+                ctx,
+                executeRegistry,
+                { runDeferredOperation: runInFilesystemContext },
+              )
+            );
+          const executeProjectRoute = () => {
+            if (optionsAdmission === "bypass-middleware") return executeRegistry();
+            if (optionsAdmission === "bypass-middleware-retained") {
+              return executeRegistryWithRetainedSnapshot();
+            }
+            return projectMiddlewareRuntime.execute({
+              request,
+              handlerContext: ctx,
+              isSharedProxy: isProxyMode,
+              isFrameworkOwnedPreflight,
+              skipProjectMiddleware,
+              next: executeRegistry,
+              onMiddlewareStart: markProjectMiddlewareStarted,
+            });
+          };
           const executeRoute = () =>
             runWithExactSourceIntegrationPolicy(
               sourceIntegrationPolicy,

--- a/src/server/runtime-handler/project-middleware.test.ts
+++ b/src/server/runtime-handler/project-middleware.test.ts
@@ -360,6 +360,47 @@ describe("ProjectMiddlewareRuntime", () => {
     );
   });
 
+  it("validates framework-owned OPTIONS dispatch against the retained snapshot", async () => {
+    let sourceVersion = 1;
+    const adapter = createAdapter();
+    adapter.fs.getSourceSnapshotIdentity = () => "branch:trusted-project:main";
+    adapter.fs.getSourceSnapshotVersion = () => sourceVersion;
+    const context = createContext(adapter, {
+      releaseId: undefined,
+      environmentName: "Preview",
+      resolvedEnvironment: "preview",
+      requestContext: {
+        token: "trusted-token",
+        slug: "trusted-project",
+        branch: "main",
+        mode: "preview",
+      },
+    });
+    seedPreviewDocumentSourceSnapshot(context, {
+      identity: "branch:trusted-project:main",
+      version: sourceVersion,
+    });
+    const runtime = new ProjectMiddlewareRuntime({
+      loadMiddleware: () => Promise.resolve([]),
+    });
+
+    await assertRejects(
+      () =>
+        runtime.execute({
+          request: new Request("https://example.com/api/automatic", { method: "OPTIONS" }),
+          handlerContext: context,
+          isSharedProxy: false,
+          isFrameworkOwnedPreflight: true,
+          next: async () => {
+            sourceVersion++;
+            return new Response(null, { status: 204 });
+          },
+        }),
+      Error,
+      "changed after request configuration was derived",
+    );
+  });
+
   it("validates the config marker before forwarding a streamed response chunk", async () => {
     let sourceVersion = 1;
     let releaseBody!: () => void;

--- a/src/server/runtime-handler/project-middleware.ts
+++ b/src/server/runtime-handler/project-middleware.ts
@@ -147,12 +147,10 @@ export class ProjectMiddlewareRuntime {
       skipProjectMiddleware,
     } = input;
     const pathname = new URL(request.url).pathname;
+    const runInFilesystemContext = <T>(operation: () => Promise<T>) =>
+      runInProjectFilesystemContext(ctx, isSharedProxy, operation);
 
     if (isWebSocketPath(pathname)) {
-      return next();
-    }
-
-    if (skipProjectMiddleware) {
       return next();
     }
 
@@ -160,8 +158,12 @@ export class ProjectMiddlewareRuntime {
     // prepared the response from the same source snapshot. Keep middleware on
     // every ambiguous or authored route shape. The auth-terminal bypass above
     // is the separate browser-preflight path and is mutually exclusive.
-    if (isFrameworkOwnedPreflight) {
-      return next();
+    if (skipProjectMiddleware || isFrameworkOwnedPreflight) {
+      return await runInFilesystemContext(() =>
+        runWithRetainedPreviewDocumentSourceSnapshot(ctx, next, {
+          runDeferredOperation: runInFilesystemContext,
+        })
+      );
     }
 
     // A control-plane dispatch is not the project's traffic. It addresses a
@@ -274,8 +276,6 @@ export class ProjectMiddlewareRuntime {
       );
       return await composed(middlewareContext, next);
     };
-    const runInFilesystemContext = <T>(operation: () => Promise<T>) =>
-      runInProjectFilesystemContext(ctx, isSharedProxy, operation);
     const executeWithPreparedSnapshot = () =>
       runWithRetainedPreviewDocumentSourceSnapshot(ctx, executeMiddleware, {
         runDeferredOperation: runInFilesystemContext,


### PR DESCRIPTION
## Summary

- admit a matched executable `OPTIONS` route before root project middleware runs
- expose the admitted application identity to middleware without repeating auth during route dispatch
- keep matched automatic fallback and unauthenticated browser preflight public by bypassing project middleware
- preserve the no-project-code automatic path in shared runtimes
- cover Pages API routes and route-generic App Router paths such as `/webhooks/github`

## Red-green TDD

RED on merged `main`:

- valid trusted-proxy explicit `OPTIONS` returned middleware 403 because middleware saw `null` identity
- a GET-only matched route returned middleware 403 instead of automatic 204
- rejected explicit auth reached middleware instead of returning 401 first
- unauthenticated App-route preflight reached middleware instead of returning policy-driven 204

GREEN:

- valid explicit route returns its authored response and middleware sees the admitted identity
- automatic fallback and App-route preflight return 204 without middleware execution
- rejected explicit auth returns 401 without middleware execution

## Verification

- `deno task test:file src/server/runtime-handler/index.test.ts` (36 steps passed)
- `deno task test:file src/routing/api` (840 steps passed)
- `deno task test:file src/server/handlers/request/api` (102 steps passed)
- `deno task test:file src/server/runtime-handler` (484 steps passed)
- `deno task test:file src/security/http` (494 steps passed)
- `deno task test:file tests/integration/server/cors-handler.test.ts` passed
- dev-server integration passed (24 steps, 1 ignored)
- production API integration passed (3 steps)
- adapter-backed production integration passed (15 steps)
- `deno task test:unit` passed
- `deno task lint:test-typecheck` passed, 0 new baseline files
- `deno task lint:test-semantic-dispositions` passed
- `deno task lint:anti-slop` passed
- targeted lint, direct changed-file typecheck, and `git diff --check` passed

Follow-up to the unresolved exact-head finding on #4346: https://github.com/veryfront/veryfront-code/pull/4346#discussion_r3895965906

Closes veryfront/veryfront-issue-inbox#902


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of browser OPTIONS requests and CORS preflight checks.
  * Automatic preflight responses remain publicly accessible when appropriate.
  * Extended consistent OPTIONS behavior across application, shared, and isolated runtime environments.
  * Added API handler support for middleware-based request handling.

* **Bug Fixes**
  * Prevented duplicate authentication during OPTIONS processing.
  * Ensured explicit OPTIONS routes authenticate before project middleware.
  * Rejected unauthorized requests before middleware runs.
  * Improved CORS responses and request freshness handling for preflight requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->