### PR TITLE
Fix redaction of CSI-split URL schemes

### DIFF
--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -6896,6 +6896,19 @@ export default config as const;
         assertStringIncludes(prose.message, "Status h ttps: retry");
       });
 
+      it("does not restore a split scheme before an empty colorized payload", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-split-empty-payload-",
+          `throw new Error(${
+            JSON.stringify(`Status htt${escape}[p:${escape}[31m unavailable`)
+          });\n`,
+        );
+
+        assertStringIncludes(error.message, "Status htt: unavailable");
+        assertEquals(error.message.includes("http: unavailable"), false);
+      });
+
       it("creates CSI reconstruction slots without inherited setters", async () => {
         const original = TestObjectGetOwnPropertyDescriptor(Array.prototype, "32");
         try {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -5887,6 +5887,16 @@ export default config as const;
         assertEquals(error.slug, CONFIG_PARSE_ERROR_SLUG);
       });
 
+      it("ignores dense CSI content after the retained first line", async () => {
+        const error = await loadFailure(
+          "vf-config-dense-csi-second-line-",
+          `throw new Error("actionable failure\\n" + (String.fromCharCode(27) + "[31m").repeat(65));\n`,
+        );
+
+        assertStringIncludes(error.message, "actionable failure");
+        assertEquals(error.message.includes("[REDACTED]"), false);
+      });
+
       it("redacts a path with a CSI introducer glued to its first character", async () => {
         const posix = await loadFailure(
           "vf-config-csi-glued-posix-",
@@ -6988,6 +6998,44 @@ export default config as const;
 
         assertEquals(error.message.includes("内部.example"), false);
         assertStringIncludes(error.message, "Load [url]");
+      });
+
+      it("preserves scheme context across ordinary CSI before a consumed colon", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-context-before-consumed-colon-",
+          `throw new Error(${
+            JSON.stringify(`Load ht${escape}[31mtp${escape}[:@registry.internal/config.ts`)
+          });\n`,
+        );
+
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertStringIncludes(error.message, "Load [url]");
+      });
+
+      it("fails closed when a CSI-consumed file URL reaches the lookahead bound", async () => {
+        const error = await loadFailure(
+          "vf-config-csi-file-lookahead-bound-",
+          `throw new Error("Load file:" + String.fromCharCode(27) + "[///h" + "a".repeat(4096) + "alice/config.ts");\n`,
+        );
+
+        assertEquals(error.message.includes("alice"), false);
+        assertStringIncludes(error.message, "[path]");
+      });
+
+      it("preserves rejected Unicode prose after a CSI-rebuilt URL", async () => {
+        const escape = String.fromCharCode(27);
+        const control = await loadFailure(
+          "vf-config-csi-unicode-boundary-control-",
+          `throw new Error(${JSON.stringify("Load https:a例え.internal…Retry")});\n`,
+        );
+        const split = await loadFailure(
+          "vf-config-csi-unicode-boundary-split-",
+          `throw new Error(${JSON.stringify(`Load https${escape}[:a例え.internal…Retry`)});\n`,
+        );
+
+        assertEquals(split.message, control.message);
+        assertStringIncludes(split.message, "…Retry");
       });
 
       it("redacts a file URL whose path delimiters are consumed by CSI", async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -5979,6 +5979,30 @@ export default config as const;
         assertEquals(colorAndSplit.message.includes("registry.internal"), false);
         assertStringIncludes(colorAndSplit.message, "[url]");
 
+        const generic = await loadFailure(
+          "vf-config-csi-zero-slash-generic-",
+          `throw new Error(String.fromCharCode(27) + "[s3://internal-bucket/config.ts");\n`,
+        );
+
+        assertEquals(generic.message.includes("internal-bucket"), false);
+        assertStringIncludes(generic.message, "[url]");
+
+        const ambiguous = await loadFailure(
+          "vf-config-csi-zero-slash-ambiguous-",
+          `throw new Error(String.fromCharCode(27) + "[h" + String.fromCharCode(27) + "[f" + String.fromCharCode(27) + "[t" + String.fromCharCode(27) + "[t" + String.fromCharCode(27) + "[p:registry.internal/config.ts");\n`,
+        );
+
+        assertEquals(ambiguous.message.includes("registry.internal"), false);
+        assertStringIncludes(ambiguous.message, "[url]");
+
+        const schemeProse = await loadFailure(
+          "vf-config-csi-zero-slash-prose-payload-",
+          `throw new Error("http" + String.fromCharCode(27) + "[s: unavailable");\n`,
+        );
+
+        assertStringIncludes(schemeProse.message, "http: unavailable");
+        assertEquals(schemeProse.message.includes("https: unavailable"), false);
+
         const singleSlash = await loadFailure(
           "vf-config-csi-single-slash-url-",
           `throw new Error(String.fromCharCode(27) + "[https:/registry.internal/veryfront.config.ts");\n`,

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -7035,6 +7035,17 @@ export default config as const;
         assertStringIncludes(error.message, "Load [url]");
       });
 
+      it("fails closed when restored-URL lookahead bisects a later CSI", async () => {
+        const error = await loadFailure(
+          "vf-config-csi-restored-tail-boundary-sequence-",
+          `throw new Error("Load ht" + String.fromCharCode(27) + "[tp://reg" + String.fromCharCode(27) + "[31m" + "a".repeat(4088) + String.fromCharCode(27) + "[31mistry.internal/SECRET");\n`,
+        );
+
+        assertEquals(error.message.includes("istry.internal"), false);
+        assertEquals(error.message.includes("SECRET"), false);
+        assertStringIncludes(error.message, "Load [url]");
+      });
+
       it("does not restore a split scheme before an empty colorized payload", async () => {
         const escape = String.fromCharCode(27);
         const error = await loadFailure(
@@ -7201,6 +7212,18 @@ export default config as const;
 
         assertEquals(error.message.includes("registry.internal"), false);
         assertEquals(error.message, "Failed to load veryfront.config.js: Load [url]");
+      });
+
+      it("redacts a generic reconstructed URL with a Unicode authority", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-generic-unicode-authority-",
+          `throw new Error(${JSON.stringify(`Load x${escape}[y${escape}[:@r例.internal/秘密`)});\n`,
+        );
+
+        assertEquals(error.message.includes("例.internal"), false);
+        assertEquals(error.message.includes("秘密"), false);
+        assertStringIncludes(error.message, "Load [url]");
       });
 
       it("redacts bracketed IPv6 after a CSI-consumed colon", async () => {
@@ -7383,6 +7406,22 @@ export default config as const;
         );
 
         assertEquals(error.message.includes("例.internal"), false);
+        assertEquals(error.message.includes("秘密"), false);
+        assertStringIncludes(error.message, "Load [url]");
+      });
+
+      it("strips every consecutive CSI before a restored Unicode payload", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-consecutive-restored-payload-",
+          `throw new Error(${
+            JSON.stringify(
+              `Load htt${escape}[p://${escape}[31m${escape}[31mregistry.internal/x秘密`,
+            )
+          });\n`,
+        );
+
+        assertEquals(error.message.includes("registry.internal"), false);
         assertEquals(error.message.includes("秘密"), false);
         assertStringIncludes(error.message, "Load [url]");
       });

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -7048,6 +7048,43 @@ export default config as const;
         assertEquals(error.message, "Failed to load veryfront.config.js: Load [url]");
       });
 
+      it("keeps non-SGR CSI parameter colons out of ordinary prose", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-non-sgr-parameter-colon-",
+          `throw new Error(${JSON.stringify(`Status http${escape}[:Hretry`)});\n`,
+        );
+
+        assertEquals(error.message, "Failed to load veryfront.config.js: Status httpretry");
+        assertEquals(error.message.includes("[url]"), false);
+      });
+
+      it("preserves an earlier CSI-supplied split-scheme byte", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-split-prefix-before-consumed-colon-",
+          `throw new Error(${
+            JSON.stringify(`Load h${escape}[ttp${escape}[:@registry.internal/config.ts`)
+          });\n`,
+        );
+
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertEquals(error.message, "Failed to load veryfront.config.js: Load [url]");
+      });
+
+      it("redacts a consumed colon before an excluded CSI final", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-consumed-colon-excluded-final-",
+          `throw new Error(${
+            JSON.stringify(`Load http${escape}[:\\registry.internal/config.ts`)
+          });\n`,
+        );
+
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertEquals(error.message, "Failed to load veryfront.config.js: Load [url]");
+      });
+
       it("preserves a CSI-glued local path when no URL scheme is selected", async () => {
         const escape = String.fromCharCode(27);
         const error = await loadFailure(

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -7019,6 +7019,22 @@ export default config as const;
         assertStringIncludes(error.message, "Load [url]");
       });
 
+      it("redacts a restored URL through later formatting CSI", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-restored-formatting-tail-",
+          `throw new Error(${
+            JSON.stringify(
+              `Load ht${escape}[tp://reg${escape}[31mistry.internal/config/PRIVATE`,
+            )
+          });\n`,
+        );
+
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertEquals(error.message.includes("PRIVATE"), false);
+        assertStringIncludes(error.message, "Load [url]");
+      });
+
       it("does not restore a split scheme before an empty colorized payload", async () => {
         const escape = String.fromCharCode(27);
         const error = await loadFailure(

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -5910,6 +5910,29 @@ export default config as const;
         assertEquals(error.slug, CONFIG_PARSE_ERROR_SLUG);
       });
 
+      it("bounds total prefix reconstruction for colon-bearing CSI", async () => {
+        const gap = 4096;
+        const repeats = 32;
+        const control = await fastestLoad(
+          "vf-config-spaced-colon-csi-control-",
+          `throw new Error("a".repeat(${gap + 4}).repeat(${repeats}));\n`,
+          1,
+        );
+        const controlMs = Math.max(1, control.ms);
+        const { ms: probeMs, error } = await fastestLoad(
+          "vf-config-spaced-colon-csi-probe-",
+          `throw new Error(("a".repeat(${gap}) + String.fromCharCode(27) + "[:H").repeat(${repeats}));\n`,
+          1,
+        );
+
+        assertEquals(
+          probeMs < controlMs * 20,
+          true,
+          `probe ${probeMs}ms vs control ${controlMs}ms`,
+        );
+        assertStringIncludes(error.message, "[REDACTED]");
+      });
+
       it("ignores dense CSI content after the retained first line", async () => {
         const error = await loadFailure(
           "vf-config-dense-csi-second-line-",
@@ -6949,6 +6972,20 @@ export default config as const;
         );
 
         assertStringIncludes(prose.message, "Status h ttps: retry");
+      });
+
+      it("prefers a CSI suffix that completes the longer special scheme", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-longer-special-scheme-",
+          `throw new Error(${
+            JSON.stringify(`Load http${escape}[s://registry.internal/config/(PRIVATE)`)
+          });\n`,
+        );
+
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertEquals(error.message.includes("PRIVATE"), false);
+        assertStringIncludes(error.message, "Load [url]");
       });
 
       it("does not restore a split scheme before an empty colorized payload", async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -6785,6 +6785,49 @@ export default config as const;
         assertEquals(error.message.includes("31m"), false);
       });
 
+      it("redacts a URL whose scheme is split by a CSI sequence", async () => {
+        const escape = String.fromCharCode(27);
+        const csi = String.fromCharCode(0x9b);
+        const cases = [
+          ["https-after-h", `h${escape}[ttps:`],
+          ["https-after-ht", `ht${escape}[tps:`],
+          ["https-after-htt", `htt${escape}[ps:`],
+          ["https-before-s", `http${escape}[s:`],
+          ["parameterized", `h${escape}[31ttps:`],
+          ["eight-bit", `h${csi}ttps:`],
+          ["uppercase", `H${escape}[TTPS:`],
+          ["websocket", `w${escape}[ss:`],
+          ["ftp", `f${escape}[tp:`],
+        ] as const;
+
+        for (const [label, splitScheme] of cases) {
+          const error = await loadFailure(
+            `vf-config-csi-split-url-scheme-${label}-`,
+            `throw new Error(${
+              JSON.stringify(`Load ${splitScheme}registry.internal/config.ts`)
+            });\n`,
+          );
+
+          assertEquals(error.message.includes("registry.internal"), false, label);
+          assertStringIncludes(error.message, "Load [url]", label);
+        }
+
+        const fileUrl = await loadFailure(
+          "vf-config-csi-split-file-url-scheme-",
+          `throw new Error(${JSON.stringify(`Load fi${escape}[le:///home/alice/config.ts`)});\n`,
+        );
+        assertEquals(fileUrl.message.includes("alice"), false);
+        assertEquals(fileUrl.message.includes("[url]"), false);
+        assertStringIncludes(fileUrl.message, "Load [path]");
+
+        const prose = await loadFailure(
+          "vf-config-csi-before-scheme-like-prose-",
+          `throw new Error("Status h${escape}[31m ttps: retry");\n`,
+        );
+
+        assertStringIncludes(prose.message, "Status h ttps: retry");
+      });
+
       it("redacts credentials both before and after stripping CSI sequences", async () => {
         const escape = String.fromCharCode(27);
         const error = await loadFailure(

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -7038,6 +7038,31 @@ export default config as const;
         assertStringIncludes(split.message, "…Retry");
       });
 
+      it("redacts a raw Unicode path after CSI-consumed URL delimiters", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-consumed-unicode-path-",
+          `throw new Error(${
+            JSON.stringify(`Load http${escape}[://registry.internal/config/秘密`)
+          });\n`,
+        );
+
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertEquals(error.message.includes("秘密"), false);
+        assertStringIncludes(error.message, "Load [url]");
+      });
+
+      it("does not manufacture a scheme from an ordinary SGR sequence", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-ordinary-sgr-scheme-",
+          `throw new Error(${JSON.stringify(`Status a${escape}[31m://retry`)});\n`,
+        );
+
+        assertStringIncludes(error.message, "Status a [path]");
+        assertEquals(error.message.includes("[url]"), false);
+      });
+
       it("redacts a file URL whose path delimiters are consumed by CSI", async () => {
         const escape = String.fromCharCode(27);
         const error = await loadFailure(

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -7024,6 +7024,17 @@ export default config as const;
         assertStringIncludes(error.message, "Load [path]");
       });
 
+      it("ignores CSI parameters between a consumed colon and URL slashes", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-parameter-after-url-colon-",
+          `throw new Error(${JSON.stringify(`Load s3${escape}[:31//registry.internal/config`)});\n`,
+        );
+
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertEquals(error.message, "Failed to load veryfront.config.js: Load [url]");
+      });
+
       it("redacts the full Unicode path after a Unicode authority", async () => {
         const escape = String.fromCharCode(27);
         const error = await loadFailure(
@@ -7061,6 +7072,33 @@ export default config as const;
         assertEquals(error.message.includes("registry"), false);
         assertEquals(error.message.includes("internal"), false);
         assertStringIncludes(error.message, "Load [url]");
+      });
+
+      it("extends a reconstructed URL through an accepted raw ASCII tail", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-accepted-raw-url-tail-",
+          `throw new Error(${
+            JSON.stringify(
+              `Load http${escape}[://registry.internal/config/<PRIVATE_SEGMENT>`,
+            )
+          });\n`,
+        );
+
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertEquals(error.message.includes("PRIVATE_SEGMENT"), false);
+        assertEquals(error.message, "Failed to load veryfront.config.js: Load [url]");
+      });
+
+      it("treats colon-separated SGR as zero-width during URL reconstruction", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-colon-sgr-scheme-",
+          `throw new Error(${JSON.stringify(`Status http${escape}[38:5:1mretry`)});\n`,
+        );
+
+        assertStringIncludes(error.message, "Status httpretry");
+        assertEquals(error.message.includes("[url]"), false);
       });
 
       it("fails closed when a CSI-consumed file URL reaches the lookahead bound", async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -6979,6 +6979,17 @@ export default config as const;
         assertStringIncludes(error.message, "Load [url]");
       });
 
+      it("redacts a split zero-slash URL with a Unicode hostname", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-split-unicode-host-",
+          `throw new Error(${JSON.stringify(`Load htt${escape}[p:内部.example/config.ts`)});\n`,
+        );
+
+        assertEquals(error.message.includes("内部.example"), false);
+        assertStringIncludes(error.message, "Load [url]");
+      });
+
       it("redacts a file URL whose path delimiters are consumed by CSI", async () => {
         const escape = String.fromCharCode(27);
         const error = await loadFailure(

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -5887,6 +5887,29 @@ export default config as const;
         assertEquals(error.slug, CONFIG_PARSE_ERROR_SLUG);
       });
 
+      it("skips reconstruction for formatting CSI after long literal spans", async () => {
+        const gap = 4096;
+        const repeats = 32;
+        const control = await fastestLoad(
+          "vf-config-spaced-csi-control-",
+          `throw new Error("a".repeat(${gap + 5}).repeat(${repeats}));\n`,
+          1,
+        );
+        const controlMs = Math.max(1, control.ms);
+        const { ms: probeMs, error } = await fastestLoad(
+          "vf-config-spaced-csi-probe-",
+          `throw new Error(("a".repeat(${gap}) + String.fromCharCode(27) + "[31m").repeat(${repeats}));\n`,
+          1,
+        );
+
+        assertEquals(
+          probeMs < controlMs * 20,
+          true,
+          `probe ${probeMs}ms vs control ${controlMs}ms`,
+        );
+        assertEquals(error.slug, CONFIG_PARSE_ERROR_SLUG);
+      });
+
       it("ignores dense CSI content after the retained first line", async () => {
         const error = await loadFailure(
           "vf-config-dense-csi-second-line-",
@@ -7059,6 +7082,17 @@ export default config as const;
         assertEquals(error.message.includes("[url]"), false);
       });
 
+      it("limits consumed-colon evidence to the matched URL token", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-consumed-colon-later-path-",
+          `throw new Error(${JSON.stringify(`Status http${escape}[:Hretry, see /docs`)});\n`,
+        );
+
+        assertEquals(error.message.includes("[url]"), false);
+        assertStringIncludes(error.message, "Status httpretry, see [path]");
+      });
+
       it("preserves an earlier CSI-supplied split-scheme byte", async () => {
         const escape = String.fromCharCode(27);
         const error = await loadFailure(
@@ -7158,6 +7192,26 @@ export default config as const;
         assertEquals(error.message.includes("registry"), false);
         assertEquals(error.message.includes("internal"), false);
         assertStringIncludes(error.message, "Load [url]");
+      });
+
+      it("fails closed when an overlong formatting CSI separates a URL scheme", async () => {
+        const error = await loadFailure(
+          "vf-config-csi-overlong-prefix-sequence-",
+          `throw new Error("http" + String.fromCharCode(27) + "[" + "1;".repeat(2050) + "m" + String.fromCharCode(27) + "[:@registry.internal/config.ts");\n`,
+        );
+
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertStringIncludes(error.message, "[REDACTED]");
+      });
+
+      it("fails closed when URL-tail lookahead ends inside an overlong CSI", async () => {
+        const error = await loadFailure(
+          "vf-config-csi-overlong-tail-sequence-",
+          `throw new Error("http" + String.fromCharCode(27) + "[://reg" + String.fromCharCode(27) + "[" + "1;".repeat(2050) + "mistry.internal/config.ts");\n`,
+        );
+
+        assertEquals(error.message.includes("istry.internal"), false);
+        assertStringIncludes(error.message, "[REDACTED]");
       });
 
       it("extends a reconstructed URL through an accepted raw ASCII tail", async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -7035,6 +7035,31 @@ export default config as const;
         assertEquals(error.message, "Failed to load veryfront.config.js: Load [url]");
       });
 
+      it("reuses a literal generic colon before CSI-consumed slashes", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-literal-colon-before-consumed-slashes-",
+          `throw new Error(${
+            JSON.stringify(`Load s3:${escape}[:31//registry.internal/config`)
+          });\n`,
+        );
+
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertEquals(error.message, "Failed to load veryfront.config.js: Load [url]");
+      });
+
+      it("preserves a CSI-glued local path when no URL scheme is selected", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-non-url-colon-before-glued-path-",
+          `throw new Error(${JSON.stringify(`Load C:${escape}[/Users/alice/config.ts`)});\n`,
+        );
+
+        assertEquals(error.message.includes("Users"), false);
+        assertEquals(error.message.includes("alice"), false);
+        assertEquals(error.message, "Failed to load veryfront.config.js: Load C: [path]");
+      });
+
       it("redacts the full Unicode path after a Unicode authority", async () => {
         const escape = String.fromCharCode(27);
         const error = await loadFailure(

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -7010,6 +7010,56 @@ export default config as const;
         );
 
         assertEquals(error.message.includes("registry.internal"), false);
+        assertEquals(error.message, "Failed to load veryfront.config.js: Load [url]");
+      });
+
+      it("ignores CSI parameters before consumed file URL delimiters", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-parameter-before-file-delimiters-",
+          `throw new Error(${JSON.stringify(`Load file:${escape}[31///home/alice/config.ts`)});\n`,
+        );
+
+        assertEquals(error.message.includes("alice"), false);
+        assertStringIncludes(error.message, "Load [path]");
+      });
+
+      it("redacts the full Unicode path after a Unicode authority", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-unicode-authority-and-path-",
+          `throw new Error(${JSON.stringify(`Load http${escape}[://r例.internal/秘密`)});\n`,
+        );
+
+        assertEquals(error.message.includes("r例.internal"), false);
+        assertEquals(error.message.includes("秘密"), false);
+        assertStringIncludes(error.message, "Load [url]");
+      });
+
+      it("preserves a generic scheme colon across formatting CSI", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-context-after-generic-colon-",
+          `throw new Error(${
+            JSON.stringify(`Load s3:${escape}[31m${escape}[//registry.internal/config`)
+          });\n`,
+        );
+
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertStringIncludes(error.message, "Load [url]");
+      });
+
+      it("redacts through formatting CSI inside a reconstructed URL tail", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-formatting-inside-url-tail-",
+          `throw new Error(${
+            JSON.stringify(`Load http${escape}[://registry${escape}[31m.internal/config`)
+          });\n`,
+        );
+
+        assertEquals(error.message.includes("registry"), false);
+        assertEquals(error.message.includes("internal"), false);
         assertStringIncludes(error.message, "Load [url]");
       });
 

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -5865,6 +5865,28 @@ export default config as const;
         assertEquals(error.slug, CONFIG_PARSE_ERROR_SLUG);
       });
 
+      it("bounds reconstruction for a CSI-dense config error", async () => {
+        const repeats = 20000;
+        const control = await fastestLoad(
+          "vf-config-dense-csi-control-",
+          `throw new Error("aaaaa".repeat(${repeats}));\n`,
+          1,
+        );
+        const controlMs = Math.max(1, control.ms);
+        const { ms: probeMs, error } = await fastestLoad(
+          "vf-config-dense-csi-probe-",
+          `throw new Error((String.fromCharCode(27) + "[31m").repeat(${repeats}));\n`,
+          1,
+        );
+
+        assertEquals(
+          probeMs < controlMs * 20,
+          true,
+          `probe ${probeMs}ms vs control ${controlMs}ms`,
+        );
+        assertEquals(error.slug, CONFIG_PARSE_ERROR_SLUG);
+      });
+
       it("redacts a path with a CSI introducer glued to its first character", async () => {
         const posix = await loadFailure(
           "vf-config-csi-glued-posix-",
@@ -6942,6 +6964,41 @@ export default config as const;
 
         assertStringIncludes(error.message, "Status İ [path]");
         assertEquals(error.message.includes("Status İa [path]"), false);
+      });
+
+      it("redacts a zero-slash URL whose colon is consumed by CSI", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-consumed-zero-slash-colon-",
+          `throw new Error(${
+            JSON.stringify(`Load http${escape}[:@registry.internal/config.ts`)
+          });\n`,
+        );
+
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertStringIncludes(error.message, "Load [url]");
+      });
+
+      it("redacts a file URL whose path delimiters are consumed by CSI", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-consumed-file-delimiters-",
+          `throw new Error(${JSON.stringify(`Load file:${escape}[///home/alice/config.ts`)});\n`,
+        );
+
+        assertEquals(error.message.includes("alice"), false);
+        assertStringIncludes(error.message, "Load [path]");
+      });
+
+      it("does not restore file before an unsupported malformed payload", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-malformed-file-payload-",
+          `throw new Error(${JSON.stringify(`Status fil${escape}[e:value`)});\n`,
+        );
+
+        assertStringIncludes(error.message, "Status fil:value");
+        assertEquals(error.message.includes("file:value"), false);
       });
 
       it("creates CSI reconstruction slots without inherited setters", async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -7072,6 +7072,30 @@ export default config as const;
         assertEquals(error.message, "Failed to load veryfront.config.js: Load [url]");
       });
 
+      it("preserves an earlier CSI-supplied generic scheme byte", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-generic-split-prefix-before-consumed-colon-",
+          `throw new Error(${
+            JSON.stringify(`Load x${escape}[y${escape}[:@registry.internal/config.ts`)
+          });\n`,
+        );
+
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertEquals(error.message, "Failed to load veryfront.config.js: Load [url]");
+      });
+
+      it("redacts bracketed IPv6 after a CSI-consumed colon", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-consumed-colon-ipv6-",
+          `throw new Error(${JSON.stringify(`Load http${escape}[:@[fd00::1]`)});\n`,
+        );
+
+        assertEquals(error.message.includes("fd00"), false);
+        assertEquals(error.message, "Failed to load veryfront.config.js: Load [url]");
+      });
+
       it("redacts a consumed colon before an excluded CSI final", async () => {
         const escape = String.fromCharCode(27);
         const error = await loadFailure(

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -5930,7 +5930,7 @@ export default config as const;
           true,
           `probe ${probeMs}ms vs control ${controlMs}ms`,
         );
-        assertStringIncludes(error.message, "[REDACTED]");
+        assertEquals(error.slug, CONFIG_PARSE_ERROR_SLUG);
       });
 
       it("ignores dense CSI content after the retained first line", async () => {
@@ -5941,6 +5941,25 @@ export default config as const;
 
         assertStringIncludes(error.message, "actionable failure");
         assertEquals(error.message.includes("[REDACTED]"), false);
+      });
+
+      it("keeps the retained prefix when later same-line CSI exceeds reconstruction limits", async () => {
+        const escape = String.fromCharCode(27);
+        const overlong = await loadFailure(
+          "vf-config-late-overlong-csi-",
+          `throw new Error("actionable failure " + "a".repeat(256) + String.fromCharCode(27) + "[" + "1;".repeat(2050) + "m");\n`,
+        );
+        const structural = await loadFailure(
+          "vf-config-late-structural-csi-",
+          `throw new Error(${JSON.stringify("actionable failure " + "a".repeat(4096))} + ${
+            JSON.stringify(`${escape}[:H${escape}[:H${escape}[:H`)
+          });\n`,
+        );
+
+        for (const error of [overlong, structural]) {
+          assertStringIncludes(error.message, "actionable failure");
+          assertEquals(error.message.includes("[REDACTED]"), false);
+        }
       });
 
       it("redacts a path with a CSI introducer glued to its first character", async () => {
@@ -7315,6 +7334,17 @@ export default config as const;
         assertEquals(error.message.includes("registry.internal"), false);
         assertEquals(error.message.includes("秘密"), false);
         assertStringIncludes(error.message, "Load [url]");
+      });
+
+      it("redacts a mixed ASCII and Unicode file segment after consumed delimiters", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-consumed-mixed-file-segment-",
+          `throw new Error(${JSON.stringify(`Load file:${escape}[///h秘密`)});\n`,
+        );
+
+        assertEquals(error.message.includes("秘密"), false);
+        assertEquals(error.message, "Failed to load veryfront.config.js: Load [path]");
       });
 
       it("does not manufacture a scheme from an ordinary SGR sequence", async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -7250,6 +7250,20 @@ export default config as const;
         assertEquals(error.message, "Failed to load veryfront.config.js: Load [url]");
       });
 
+      it("redacts consumed URL slashes before an excluded CSI final", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-consumed-slashes-excluded-final-",
+          `throw new Error(${
+            JSON.stringify(`Load http${escape}[://\\registry.internal/SECRET`)
+          });\n`,
+        );
+
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertEquals(error.message.includes("SECRET"), false);
+        assertEquals(error.message, "Failed to load veryfront.config.js: Load [url]");
+      });
+
       it("preserves a CSI-glued local path when no URL scheme is selected", async () => {
         const escape = String.fromCharCode(27);
         const error = await loadFailure(

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -6909,6 +6909,41 @@ export default config as const;
         assertEquals(error.message.includes("http: unavailable"), false);
       });
 
+      it("classifies generic slash payloads after stripping CSI", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-before-generic-slashes-",
+          `throw new Error(${
+            JSON.stringify(`${escape}[s3:${escape}[31m//registry.internal/config`)
+          });\n`,
+        );
+
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertStringIncludes(error.message, "[url]");
+      });
+
+      it("does not restore a split scheme before non-URL punctuation", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-split-punctuation-payload-",
+          `throw new Error(${JSON.stringify(`Status htt${escape}[p:( unavailable`)});\n`,
+        );
+
+        assertStringIncludes(error.message, "Status htt:( unavailable");
+        assertEquals(error.message.includes("http:( unavailable"), false);
+      });
+
+      it("does not treat a Unicode case expansion as an ASCII scheme character", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-unicode-scheme-expansion-",
+          `throw new Error(${JSON.stringify(`Status İ${escape}[a://retry`)});\n`,
+        );
+
+        assertStringIncludes(error.message, "Status İ [path]");
+        assertEquals(error.message.includes("Status İa [path]"), false);
+      });
+
       it("creates CSI reconstruction slots without inherited setters", async () => {
         const original = TestObjectGetOwnPropertyDescriptor(Array.prototype, "32");
         try {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -5845,6 +5845,26 @@ export default config as const;
         assertEquals(error.slug, CONFIG_PARSE_ERROR_SLUG);
       });
 
+      it("bounds CSI scheme reconstruction after an ordinary sequence", async () => {
+        const size = 200000;
+        const control = await fastestLoad(
+          "vf-config-long-csi-control-",
+          `throw new Error("a".repeat(${size}));\n`,
+        );
+        const controlMs = Math.max(1, control.ms);
+        const { ms: probeMs, error } = await fastestLoad(
+          "vf-config-long-csi-probe-",
+          `throw new Error(String.fromCharCode(27) + "[31m" + "a".repeat(${size}));\n`,
+        );
+
+        assertEquals(
+          probeMs < controlMs * 3,
+          true,
+          `probe ${probeMs}ms vs control ${controlMs}ms`,
+        );
+        assertEquals(error.slug, CONFIG_PARSE_ERROR_SLUG);
+      });
+
       it("redacts a path with a CSI introducer glued to its first character", async () => {
         const posix = await loadFailure(
           "vf-config-csi-glued-posix-",
@@ -6874,6 +6894,27 @@ export default config as const;
         );
 
         assertStringIncludes(prose.message, "Status h ttps: retry");
+      });
+
+      it("creates CSI reconstruction slots without inherited setters", async () => {
+        const original = TestObjectGetOwnPropertyDescriptor(Array.prototype, "32");
+        try {
+          const error = await loadFailure(
+            "vf-config-csi-array-setter-",
+            `Object.defineProperty(Array.prototype, "32", {
+              configurable: true,
+              set() { throw new Error("poisoned indexed setter"); },
+            });
+            throw new Error("Load h" + String.fromCharCode(27) + "[ttps://registry.internal/config.ts");\n`,
+          );
+
+          assertEquals(error.slug, CONFIG_PARSE_ERROR_SLUG);
+          assertEquals(error.message.includes("registry.internal"), false);
+          assertStringIncludes(error.message, "Load [url]");
+        } finally {
+          if (original) TestObjectDefineProperty(Array.prototype, "32", original);
+          else TestReflectApply(TestReflectDeleteProperty, Reflect, [Array.prototype, "32"]);
+        }
       });
 
       it("redacts credentials both before and after stripping CSI sequences", async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -5963,6 +5963,22 @@ export default config as const;
         assertEquals(multiple.message.includes("registry.internal"), false);
         assertStringIncludes(multiple.message, "[url]");
 
+        const firstAndLater = await loadFailure(
+          "vf-config-csi-zero-slash-first-and-later-",
+          `throw new Error(String.fromCharCode(27) + "[ht" + String.fromCharCode(27) + "[tps:registry.internal/veryfront.config.ts");\n`,
+        );
+
+        assertEquals(firstAndLater.message.includes("registry.internal"), false);
+        assertStringIncludes(firstAndLater.message, "[url]");
+
+        const colorAndSplit = await loadFailure(
+          "vf-config-csi-zero-slash-color-and-split-",
+          `throw new Error("h" + String.fromCharCode(27) + "[31m" + String.fromCharCode(27) + "[ttps:registry.internal/veryfront.config.ts");\n`,
+        );
+
+        assertEquals(colorAndSplit.message.includes("registry.internal"), false);
+        assertStringIncludes(colorAndSplit.message, "[url]");
+
         const singleSlash = await loadFailure(
           "vf-config-csi-single-slash-url-",
           `throw new Error(String.fromCharCode(27) + "[https:/registry.internal/veryfront.config.ts");\n`,

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -7007,6 +7007,18 @@ export default config as const;
         assertStringIncludes(error.message, "Load [url]");
       });
 
+      it("redacts a mixed Unicode tail after restoring a split scheme", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-restored-mixed-unicode-tail-",
+          `throw new Error(${JSON.stringify(`Load ht${escape}[tp://registry.internal/x秘密`)});\n`,
+        );
+
+        assertEquals(error.message.includes("registry.internal"), false);
+        assertEquals(error.message.includes("秘密"), false);
+        assertStringIncludes(error.message, "Load [url]");
+      });
+
       it("does not restore a split scheme before an empty colorized payload", async () => {
         const escape = String.fromCharCode(27);
         const error = await loadFailure(
@@ -7345,6 +7357,18 @@ export default config as const;
 
         assertEquals(error.message.includes("秘密"), false);
         assertEquals(error.message, "Failed to load veryfront.config.js: Load [path]");
+      });
+
+      it("redacts a mixed Unicode authority after consumed triple slashes", async () => {
+        const escape = String.fromCharCode(27);
+        const error = await loadFailure(
+          "vf-config-csi-consumed-triple-slash-unicode-authority-",
+          `throw new Error(${JSON.stringify(`Load http${escape}[:///r例.internal/秘密`)});\n`,
+        );
+
+        assertEquals(error.message.includes("例.internal"), false);
+        assertEquals(error.message.includes("秘密"), false);
+        assertStringIncludes(error.message, "Load [url]");
       });
 
       it("does not manufacture a scheme from an ordinary SGR sequence", async () => {

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -5955,6 +5955,14 @@ export default config as const;
         assertEquals(eightBit.message.includes("registry.internal"), false);
         assertStringIncludes(eightBit.message, "[url]");
 
+        const multiple = await loadFailure(
+          "vf-config-csi-zero-slash-multiple-",
+          `throw new Error("h" + String.fromCharCode(27) + "[t" + String.fromCharCode(27) + "[tps:registry.internal/veryfront.config.ts");\n`,
+        );
+
+        assertEquals(multiple.message.includes("registry.internal"), false);
+        assertStringIncludes(multiple.message, "[url]");
+
         const singleSlash = await loadFailure(
           "vf-config-csi-single-slash-url-",
           `throw new Error(String.fromCharCode(27) + "[https:/registry.internal/veryfront.config.ts");\n`,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1945,15 +1945,27 @@ interface CsiRestorationStates {
 type CsiUrlPayloadKind = "generic" | "special" | "none";
 
 const MAX_GENERIC_URL_SCHEME_LENGTH = 32;
+const MAX_CSI_LITERAL_GAP = MAX_GENERIC_URL_SCHEME_LENGTH * 2;
 const GENERIC_URL_SCHEME_FIRST_CHARACTER = /[A-Za-z]/;
 const GENERIC_URL_SCHEME_CHARACTER = /[A-Za-z0-9+.-]/;
 const CSI_URL_PAYLOAD_CHARACTER = /[^\s"'\\]/u;
 
 function appendCsiSchemeMatch(path: readonly number[], matchIndex: number): readonly number[] {
   const appended: number[] = [];
-  for (let index = 0; index < path.length; index++) appended[index] = path[index]!;
-  appended[path.length] = matchIndex;
+  for (let index = 0; index < path.length; index++) {
+    defineOwnArrayElement(appended, index, path[index]!);
+  }
+  defineOwnArrayElement(appended, path.length, matchIndex);
   return appended;
+}
+
+function defineOwnArrayElement<T>(target: T[], index: number, value: T): void {
+  const descriptor = createNullPrototypeDescriptor();
+  descriptor.value = value;
+  descriptor.writable = true;
+  descriptor.enumerable = true;
+  descriptor.configurable = true;
+  ReflectApply(ObjectDefineProperty, Object, [target, index, descriptor]);
 }
 
 function keepShorterCsiSchemePath(
@@ -1989,14 +2001,16 @@ function keepPreferredGenericCsiPath(
 
 function createDenseCsiPathStates(length: number): Array<readonly number[] | undefined> {
   const states: Array<readonly number[] | undefined> = [];
-  for (let index = 0; index <= length; index++) states[index] = undefined;
+  for (let index = 0; index <= length; index++) {
+    defineOwnArrayElement(states, index, undefined);
+  }
   return states;
 }
 
 function createDenseGenericCsiStates(): CsiGenericSchemeStates {
   const states: CsiGenericSchemeStates = [];
   for (let index = 0; index <= MAX_GENERIC_URL_SCHEME_LENGTH; index++) {
-    states[index] = undefined;
+    defineOwnArrayElement(states, index, undefined);
   }
   return states;
 }
@@ -2004,7 +2018,11 @@ function createDenseGenericCsiStates(): CsiGenericSchemeStates {
 function createCsiSchemeStates(): CsiSchemeStates {
   const states: CsiSchemeStates = [];
   for (let index = 0; index < CSI_SPLITTABLE_URL_SCHEMES.length; index++) {
-    states[index] = createDenseCsiPathStates(CSI_SPLITTABLE_URL_SCHEMES[index]!.length);
+    defineOwnArrayElement(
+      states,
+      index,
+      createDenseCsiPathStates(CSI_SPLITTABLE_URL_SCHEMES[index]!.length),
+    );
   }
   return states;
 }
@@ -2197,6 +2215,24 @@ function advanceCsiSchemeSequence(
   return { special, generic };
 }
 
+function advanceCsiLiteralRange(
+  states: CsiRestorationStates,
+  value: string,
+  startIndex: number,
+  endIndex: number,
+  restoreMatches: Set<number>,
+): CsiRestorationStates {
+  for (let index = startIndex; index < endIndex; index++) {
+    const literal = ReflectApply(
+      StringPrototypeToLowerCase,
+      stringSlice(value, index, index + 1),
+      [],
+    ) as string;
+    states = advanceCsiSchemeLiteral(states, literal, value, index, restoreMatches);
+  }
+  return states;
+}
+
 /**
  * Restore a URL-scheme character consumed as a CSI final byte.
  *
@@ -2225,13 +2261,33 @@ function restoreCsiSplitUrlSchemes(value: string): string {
     let inputOffset = 0;
     while (match !== null) {
       const matched = match[0];
-      for (let index = inputOffset; index < match.index; index++) {
-        const literal = ReflectApply(
-          StringPrototypeToLowerCase,
-          stringSlice(value, index, index + 1),
-          [],
-        ) as string;
-        states = advanceCsiSchemeLiteral(states, literal, value, index, restoreMatches);
+      const gapLength = match.index - inputOffset;
+      if (gapLength > MAX_CSI_LITERAL_GAP) {
+        if (matches.length > 0) {
+          states = advanceCsiLiteralRange(
+            states,
+            value,
+            inputOffset,
+            inputOffset + MAX_GENERIC_URL_SCHEME_LENGTH,
+            restoreMatches,
+          );
+        }
+        states = createCsiRestorationStates();
+        states = advanceCsiLiteralRange(
+          states,
+          value,
+          match.index - MAX_GENERIC_URL_SCHEME_LENGTH,
+          match.index,
+          restoreMatches,
+        );
+      } else {
+        states = advanceCsiLiteralRange(
+          states,
+          value,
+          inputOffset,
+          match.index,
+          restoreMatches,
+        );
       }
       const finalByte = ReflectApply(
         StringPrototypeToLowerCase,
@@ -2239,11 +2295,11 @@ function restoreCsiSplitUrlSchemes(value: string): string {
         [],
       ) as string;
       const matchIndex = matches.length;
-      matches[matchIndex] = {
+      defineOwnArrayElement(matches, matchIndex, {
         matched,
         inputIndex: match.index,
         inputEnd: ANSI_CSI_SEQUENCE.lastIndex,
-      };
+      });
       states = advanceCsiSchemeSequence(states, finalByte, matchIndex, match.index);
       inputOffset = ANSI_CSI_SEQUENCE.lastIndex;
       match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE, [value]) as
@@ -2251,14 +2307,10 @@ function restoreCsiSplitUrlSchemes(value: string): string {
         | null;
     }
 
-    for (let index = inputOffset; index < value.length; index++) {
-      const literal = ReflectApply(
-        StringPrototypeToLowerCase,
-        stringSlice(value, index, index + 1),
-        [],
-      ) as string;
-      states = advanceCsiSchemeLiteral(states, literal, value, index, restoreMatches);
-    }
+    const tailWindowEnd = inputOffset + MAX_GENERIC_URL_SCHEME_LENGTH < value.length
+      ? inputOffset + MAX_GENERIC_URL_SCHEME_LENGTH
+      : value.length;
+    advanceCsiLiteralRange(states, value, inputOffset, tailWindowEnd, restoreMatches);
 
     let output = "";
     let outputOffset = 0;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1913,6 +1913,10 @@ const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F-\u009F]/g;
 // Strip complete CSI sequences before matching paths and URLs.
 // deno-lint-ignore no-control-regex
 const ANSI_CSI_SEQUENCE = /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\u0040-\u007E]/g;
+// Keep payload lookahead independent from the global reconstruction cursor.
+const ANSI_CSI_SEQUENCE_AT_INDEX =
+  // deno-lint-ignore no-control-regex
+  /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\u0040-\u007E]/y;
 const CSI_SPLITTABLE_URL_SCHEMES = freezeObject([
   "http",
   "https",
@@ -2062,8 +2066,23 @@ function markCsiSchemePath(path: readonly number[] | undefined, restoreMatches: 
   }
 }
 
+function skipCompleteCsiSequences(value: string, index: number): number {
+  try {
+    while (index < value.length) {
+      ANSI_CSI_SEQUENCE_AT_INDEX.lastIndex = index;
+      const match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_AT_INDEX, [value]);
+      if (match === null) break;
+      index = ANSI_CSI_SEQUENCE_AT_INDEX.lastIndex;
+    }
+    return index;
+  } finally {
+    ANSI_CSI_SEQUENCE_AT_INDEX.lastIndex = 0;
+  }
+}
+
 function hasCsiUrlPayloadCharacter(value: string, index: number): boolean {
-  const character = stringSlice(value, index, index + 1);
+  const payloadIndex = skipCompleteCsiSequences(value, index);
+  const character = stringSlice(value, payloadIndex, payloadIndex + 1);
   return character !== "" &&
     ReflectApply(RegExpPrototypeExec, CSI_URL_PAYLOAD_CHARACTER, [character]) !== null;
 }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1946,9 +1946,15 @@ const CSI_SPLITTABLE_URL_SCHEME_LOOKAROUND = (() => {
  */
 function restoreCsiSplitUrlSchemes(value: string): string {
   ANSI_CSI_SEQUENCE.lastIndex = 0;
-  let output = "";
-  let offset = 0;
   try {
+    const matches: Array<{
+      matched: string;
+      inputIndex: number;
+      inputEnd: number;
+      candidateIndex: number;
+    }> = [];
+    let candidate = "";
+    let inputOffset = 0;
     while (true) {
       const match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE, [value]) as
         | RegExpExecArray
@@ -1956,25 +1962,42 @@ function restoreCsiSplitUrlSchemes(value: string): string {
       if (match === null) break;
 
       const matched = match[0];
+      candidate += stringSlice(value, inputOffset, match.index);
+      const candidateIndex = candidate.length;
+      candidate += stringSlice(matched, -1);
+      matches[matches.length] = {
+        matched,
+        inputIndex: match.index,
+        inputEnd: ANSI_CSI_SEQUENCE.lastIndex,
+        candidateIndex,
+      };
+      inputOffset = ANSI_CSI_SEQUENCE.lastIndex;
+    }
+    candidate += stringSlice(value, inputOffset);
+
+    let output = "";
+    let outputOffset = 0;
+    for (let matchIndex = 0; matchIndex < matches.length; matchIndex++) {
+      const match = matches[matchIndex]!;
       const finalByte = ReflectApply(
         StringPrototypeToLowerCase,
-        stringSlice(matched, -1),
+        stringSlice(match.matched, -1),
         [],
       ) as string;
-      const prefixStart = match.index > CSI_SPLITTABLE_URL_SCHEME_LOOKAROUND
-        ? match.index - CSI_SPLITTABLE_URL_SCHEME_LOOKAROUND
+      const prefixStart = match.candidateIndex > CSI_SPLITTABLE_URL_SCHEME_LOOKAROUND
+        ? match.candidateIndex - CSI_SPLITTABLE_URL_SCHEME_LOOKAROUND
         : 0;
       const preceding = ReflectApply(
         StringPrototypeToLowerCase,
-        stringSlice(value, prefixStart, match.index),
+        stringSlice(candidate, prefixStart, match.candidateIndex),
         [],
       ) as string;
       const following = ReflectApply(
         StringPrototypeToLowerCase,
         stringSlice(
-          value,
-          ANSI_CSI_SEQUENCE.lastIndex,
-          ANSI_CSI_SEQUENCE.lastIndex + CSI_SPLITTABLE_URL_SCHEME_LOOKAROUND,
+          candidate,
+          match.candidateIndex + 1,
+          match.candidateIndex + 1 + CSI_SPLITTABLE_URL_SCHEME_LOOKAROUND,
         ),
         [],
       ) as string;
@@ -1997,11 +2020,11 @@ function restoreCsiSplitUrlSchemes(value: string): string {
         }
       }
 
-      output += stringSlice(value, offset, match.index);
-      output += restoresScheme ? stringSlice(matched, -1) : matched;
-      offset = ANSI_CSI_SEQUENCE.lastIndex;
+      output += stringSlice(value, outputOffset, match.inputIndex);
+      output += restoresScheme ? stringSlice(match.matched, -1) : match.matched;
+      outputOffset = match.inputEnd;
     }
-    return output + stringSlice(value, offset);
+    return output + stringSlice(value, outputOffset);
   } finally {
     ANSI_CSI_SEQUENCE.lastIndex = 0;
   }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2597,7 +2597,7 @@ type CsiConsumedSpecialPrefixStates = Array<
 >;
 type CsiConsumedGenericPrefixStates = Array<CsiConsumedUrlPrefix | undefined>;
 
-const STRONG_CSI_CONSUMED_URL_PAYLOAD_CHARACTERS = "./@?#\\[]:";
+const STRONG_CSI_CONSUMED_URL_PAYLOAD_CHARACTERS = String.raw`./@?#\[]:`;
 
 function createCsiConsumedSpecialPrefixStates(): CsiConsumedSpecialPrefixStates {
   const states: CsiConsumedSpecialPrefixStates = [];
@@ -3020,7 +3020,7 @@ function hasStrongCsiConsumedUrlPayload(value: string, endIndex: number): boolea
   if (colon === -1 || colon >= endIndex) return false;
   const payload = stringSlice(value, colon + 1, endIndex);
   if (containsNonAscii(payload)) return true;
-  for (let index = 0; index < payload.length; index++) {
+  for (let index = 0; index < payload.length; index++) { // NOSONAR: Avoid mutable iterator hooks.
     if (stringIncludes(STRONG_CSI_CONSUMED_URL_PAYLOAD_CHARACTERS, payload[index]!)) return true;
   }
   return false;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1921,6 +1921,14 @@ const CSI_SPLITTABLE_URL_SCHEMES = freezeObject([
   "ftp",
   "file",
 ]) as readonly string[];
+const CSI_SPLITTABLE_URL_SCHEME_LOOKAROUND = (() => {
+  let longest = 0;
+  for (let index = 0; index < CSI_SPLITTABLE_URL_SCHEMES.length; index++) {
+    const length = CSI_SPLITTABLE_URL_SCHEMES[index]!.length;
+    if (length > longest) longest = length;
+  }
+  return longest;
+})();
 
 /**
  * Restore a URL-scheme character consumed as a CSI final byte.
@@ -1953,7 +1961,9 @@ function restoreCsiSplitUrlSchemes(value: string): string {
         stringSlice(matched, -1),
         [],
       ) as string;
-      const prefixStart = match.index > 5 ? match.index - 5 : 0;
+      const prefixStart = match.index > CSI_SPLITTABLE_URL_SCHEME_LOOKAROUND
+        ? match.index - CSI_SPLITTABLE_URL_SCHEME_LOOKAROUND
+        : 0;
       const preceding = ReflectApply(
         StringPrototypeToLowerCase,
         stringSlice(value, prefixStart, match.index),
@@ -1961,7 +1971,11 @@ function restoreCsiSplitUrlSchemes(value: string): string {
       ) as string;
       const following = ReflectApply(
         StringPrototypeToLowerCase,
-        stringSlice(value, ANSI_CSI_SEQUENCE.lastIndex, ANSI_CSI_SEQUENCE.lastIndex + 5),
+        stringSlice(
+          value,
+          ANSI_CSI_SEQUENCE.lastIndex,
+          ANSI_CSI_SEQUENCE.lastIndex + CSI_SPLITTABLE_URL_SCHEME_LOOKAROUND,
+        ),
         [],
       ) as string;
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1918,6 +1918,10 @@ const ANSI_CSI_SEQUENCE = /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\
 const ANSI_CSI_SEQUENCE_AT_INDEX =
   // deno-lint-ignore no-control-regex
   /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\u0040-\u007E]/y;
+// Use a separate cursor while detecting URLs that CSI swallowed intact.
+const ANSI_CSI_SEQUENCE_FOR_URL_REDACTION =
+  // deno-lint-ignore no-control-regex
+  /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\u0040-\u007E]/g;
 const CSI_SPLITTABLE_URL_SCHEMES = freezeObject([
   "http",
   "https",
@@ -1951,6 +1955,8 @@ type CsiUrlPayloadKind = "generic" | "special" | "none";
 
 const MAX_GENERIC_URL_SCHEME_LENGTH = 32;
 const MAX_CSI_LITERAL_GAP = MAX_GENERIC_URL_SCHEME_LENGTH * 2;
+const MAX_CSI_RECONSTRUCTION_MATCHES = 64;
+const MAX_CSI_CONSUMED_URL_LOOKAHEAD = 4096;
 const GENERIC_URL_SCHEME_FIRST_CHARACTER = /^[A-Za-z]$/;
 const GENERIC_URL_SCHEME_CHARACTER = /^[A-Za-z0-9+.-]$/;
 
@@ -2038,9 +2044,15 @@ function createCsiRestorationStates(): CsiRestorationStates {
   };
 }
 
-function chooseCompletedSpecialCsiPath(states: CsiSchemeStates): readonly number[] | undefined {
+function chooseCompletedSpecialCsiPath(
+  states: CsiSchemeStates,
+  allowFile: boolean,
+): readonly number[] | undefined {
   let selected: readonly number[] | undefined;
-  for (let schemeIndex = 0; schemeIndex < CSI_SPLITTABLE_URL_SCHEMES.length; schemeIndex++) {
+  const schemeCount = allowFile
+    ? CSI_SPLITTABLE_URL_SCHEMES.length
+    : CSI_SPLITTABLE_URL_SCHEMES.length - 1;
+  for (let schemeIndex = 0; schemeIndex < schemeCount; schemeIndex++) {
     const scheme = CSI_SPLITTABLE_URL_SCHEMES[schemeIndex]!;
     const path = states[schemeIndex]![scheme.length];
     if (path !== undefined) selected = keepShorterCsiSchemePath(selected, path);
@@ -2178,11 +2190,11 @@ function advanceCsiSchemeLiteral(
   if (value === ":") {
     const payload = classifyCsiUrlPayload(input, inputIndex, stripSequenceStarts);
     if (payload === "generic") {
-      const special = chooseCompletedSpecialCsiPath(states.special);
+      const special = chooseCompletedSpecialCsiPath(states.special, true);
       const path = special ?? chooseCompletedGenericCsiPath(states.generic)?.matches;
       markCsiSchemePath(path, restoreMatches);
     } else if (payload === "special") {
-      markCsiSchemePath(chooseCompletedSpecialCsiPath(states.special), restoreMatches);
+      markCsiSchemePath(chooseCompletedSpecialCsiPath(states.special, false), restoreMatches);
     }
     return createCsiRestorationStates();
   }
@@ -2532,6 +2544,123 @@ const NON_ASCII_FILE_URL_PATH = new RegExp(
 const WINDOWS_ABSOLUTE_PATH = /(?:[A-Za-z]:[\\/]|\\\\)[^\s"'()]+/g;
 const POSIX_ABSOLUTE_PATH = /(?<![A-Za-z0-9:/.\\])\/[^\s"'()]+/g;
 
+interface CsiConsumedUrlRedaction {
+  endIndex: number;
+  marker: "[path]" | "[url]";
+}
+
+function csiConsumedUrlPrefixStart(
+  value: string,
+  matchIndex: number,
+  minimumIndex: number,
+): number | undefined {
+  let schemeEnd = matchIndex;
+  if (stringSlice(value, schemeEnd - 1, schemeEnd) === ":") schemeEnd -= 1;
+  let startIndex = schemeEnd;
+  while (
+    startIndex > minimumIndex &&
+    schemeEnd - startIndex < MAX_GENERIC_URL_SCHEME_LENGTH &&
+    ReflectApply(RegExpPrototypeExec, GENERIC_URL_SCHEME_CHARACTER, [
+        stringSlice(value, startIndex - 1, startIndex),
+      ]) !== null
+  ) {
+    startIndex -= 1;
+  }
+  if (startIndex === schemeEnd) return undefined;
+  return ReflectApply(RegExpPrototypeExec, GENERIC_URL_SCHEME_FIRST_CHARACTER, [
+      stringSlice(value, startIndex, startIndex + 1),
+    ]) !== null
+    ? startIndex
+    : undefined;
+}
+
+function matchPatternAtStart(pattern: RegExp, value: string): number {
+  pattern.lastIndex = 0;
+  try {
+    const match = ReflectApply(RegExpPrototypeExec, pattern, [value]) as
+      | RegExpExecArray
+      | null;
+    return match?.index === 0 ? pattern.lastIndex : 0;
+  } finally {
+    pattern.lastIndex = 0;
+  }
+}
+
+function matchCsiConsumedUrlCandidate(value: string): {
+  endIndex: number;
+  marker: "[path]" | "[url]";
+} | undefined {
+  let endIndex = matchPatternAtStart(FILE_URL_ABSOLUTE_PATH, value);
+  if (endIndex === 0 && containsNonAscii(value)) {
+    endIndex = matchPatternAtStart(NON_ASCII_FILE_URL_PATH, value);
+  }
+  if (endIndex !== 0) return { endIndex, marker: "[path]" };
+
+  endIndex = matchPatternAtStart(SCHEME_URL, value);
+  if (endIndex === 0) endIndex = matchPatternAtStart(MALFORMED_SCHEME_URL, value);
+  if (endIndex === 0) endIndex = matchPatternAtStart(ZERO_SLASH_SCHEME_URL, value);
+  if (endIndex === 0 && containsNonAscii(value)) {
+    endIndex = matchPatternAtStart(NON_ASCII_AUTHORITY_URL, value);
+    if (endIndex === 0) endIndex = matchPatternAtStart(NON_ASCII_URL_PATH, value);
+    if (endIndex === 0) {
+      endIndex = matchPatternAtStart(NON_ASCII_MALFORMED_AUTHORITY_URL, value);
+    }
+    if (endIndex === 0) endIndex = matchPatternAtStart(NON_ASCII_MALFORMED_URL_PATH, value);
+    if (endIndex === 0) {
+      endIndex = matchPatternAtStart(NON_ASCII_ZERO_SLASH_AUTHORITY_URL, value);
+    }
+    if (endIndex === 0) endIndex = matchPatternAtStart(NON_ASCII_ZERO_SLASH_URL_PATH, value);
+  }
+  return endIndex === 0 ? undefined : { endIndex, marker: "[url]" };
+}
+
+function redactCsiConsumedUrls(value: string): string {
+  ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex = 0;
+  try {
+    let output = "";
+    let outputOffset = 0;
+    let literalStart = 0;
+    let matchCount = 0;
+    let match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_FOR_URL_REDACTION, [value]) as
+      | RegExpExecArray
+      | null;
+    while (match !== null) {
+      const matchEnd = ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex;
+      matchCount += 1;
+      if (matchCount > MAX_CSI_RECONSTRUCTION_MATCHES) return "[REDACTED]";
+      if (match.index >= outputOffset) {
+        const prefixStart = csiConsumedUrlPrefixStart(value, match.index, literalStart);
+        if (prefixStart !== undefined) {
+          const matched = match[0];
+          const introducerLength = stringSlice(matched, 0, 1) === "\u001B" ? 2 : 1;
+          const lookaheadEnd = MathMin(
+            value.length,
+            matchEnd + MAX_CSI_CONSUMED_URL_LOOKAHEAD,
+          );
+          const prefix = stringSlice(value, prefixStart, match.index);
+          const candidate = prefix + stringSlice(matched, introducerLength) +
+            stringSlice(value, matchEnd, lookaheadEnd);
+          const redaction = matchCsiConsumedUrlCandidate(candidate);
+          if (redaction) {
+            const endIndex = prefixStart + redaction.endIndex + introducerLength;
+            output += stringSlice(value, outputOffset, prefixStart) + redaction.marker;
+            outputOffset = endIndex;
+            ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex = endIndex;
+            literalStart = endIndex;
+          }
+        }
+      }
+      if (literalStart < matchEnd) literalStart = matchEnd;
+      match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_FOR_URL_REDACTION, [value]) as
+        | RegExpExecArray
+        | null;
+    }
+    return output + stringSlice(value, outputOffset);
+  } finally {
+    ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex = 0;
+  }
+}
+
 function stickyMatchEnd(pattern: RegExp, value: string, offset: number): number {
   pattern.lastIndex = offset;
   try {
@@ -2736,7 +2865,8 @@ function summarizeConfigLoadCause(error: unknown): string | undefined {
   if (message === undefined) return undefined;
   // Sanitize on both sides because stripping CSI can join or consume credential bytes.
   const initiallyRedacted = sanitizeUrlCredentials(message);
-  const restoredUrlSchemes = restoreCsiSplitUrlSchemes(initiallyRedacted);
+  const intactUrlRedacted = redactCsiConsumedUrls(initiallyRedacted);
+  const restoredUrlSchemes = restoreCsiSplitUrlSchemes(intactUrlRedacted);
   // Replacing a glued CSI introducer with space preserves the path or scheme start
   // without joining it to preceding prose. Machine paths are redacted afterward.
   const unglued = replaceMatchesWithCapturedExec(restoredUrlSchemes, CSI_GLUED_PATH, " ");

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -3244,6 +3244,27 @@ function restoredIndexFallsWithin(
   return false;
 }
 
+function mappedRestoredCsiUrlRedaction(
+  value: string,
+  match: RegExpExecArray,
+  matchEnd: number,
+): CsiConsumedUrlRedaction | undefined {
+  const candidate: MappedCsiUrlCandidate = { inputEnds: [], value: "" };
+  appendMappedInputRange(candidate, value, match.index, matchEnd);
+  const lookaheadEnd = MathMin(value.length, matchEnd + MAX_CSI_CONSUMED_URL_LOOKAHEAD);
+  appendMappedCsiUrlTail(candidate, value, matchEnd, lookaheadEnd);
+  const redaction = matchCsiConsumedUrlCandidate(candidate.value);
+  if (redaction === undefined) return undefined;
+  const mappedEnd = candidate.inputEnds[redaction.endIndex - 1];
+  if (mappedEnd === undefined) return undefined;
+  return {
+    endIndex: redaction.endIndex === candidate.value.length && lookaheadEnd < value.length
+      ? value.length
+      : mappedEnd,
+    marker: redaction.marker,
+  };
+}
+
 function redactRestoredCsiSchemeUrls(
   value: string,
   restoredIndexes: readonly number[],
@@ -3257,14 +3278,17 @@ function redactRestoredCsiSchemeUrls(
     while (match !== null) {
       const matchEnd = SCHEME_URL.lastIndex;
       if (restoredIndexFallsWithin(restoredIndexes, match.index, matchEnd)) {
-        const endIndex = mixedSlashedUrlMatchEnd(value, match[0], matchEnd);
-        const scheme = ReflectApply(
-          StringPrototypeToLowerCase,
-          stringSlice(match[0], 0, 5),
-          [],
-        ) as string;
+        const mapped = mappedRestoredCsiUrlRedaction(value, match, matchEnd);
+        const endIndex = mapped?.endIndex ?? mixedSlashedUrlMatchEnd(value, match[0], matchEnd);
+        const scheme = mapped === undefined
+          ? ReflectApply(
+            StringPrototypeToLowerCase,
+            stringSlice(match[0], 0, 5),
+            [],
+          ) as string
+          : "";
         output += stringSlice(value, outputOffset, match.index) +
-          (scheme === "file:" ? "[path]" : "[url]");
+          (mapped?.marker ?? (scheme === "file:" ? "[path]" : "[url]"));
         outputOffset = endIndex;
         SCHEME_URL.lastIndex = endIndex;
       }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -110,6 +110,7 @@ const MapPrototypeDelete = Map.prototype.delete;
 const MapPrototypeForEach = Map.prototype.forEach;
 const MapPrototypeGet = Map.prototype.get;
 const MapPrototypeSet = Map.prototype.set;
+const MathMin = Math.min;
 const NumberPrototypeToString = Number.prototype.toString;
 const ObjectCreate = Object.create;
 const ObjectDefineProperty = Object.defineProperty;
@@ -2380,9 +2381,10 @@ function restoreCsiSplitUrlSchemes(value: string): string {
         | null;
     }
 
-    const tailWindowEnd = inputOffset + MAX_GENERIC_URL_SCHEME_LENGTH < value.length
-      ? inputOffset + MAX_GENERIC_URL_SCHEME_LENGTH
-      : value.length;
+    const tailWindowEnd = MathMin(
+      inputOffset + MAX_GENERIC_URL_SCHEME_LENGTH,
+      value.length,
+    );
     advanceCsiLiteralRange(
       states,
       value,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2676,18 +2676,30 @@ function matchCsiConsumedNonAsciiUrl(value: string): number {
   return longest;
 }
 
+function extendCsiConsumedUrlMatch(value: string, endIndex: number): number {
+  return rawUrlMatchEnd(value, stringSlice(value, 0, endIndex), endIndex);
+}
+
 function matchCsiConsumedUrlCandidate(value: string): CsiConsumedUrlRedaction | undefined {
   const hasNonAscii = containsNonAscii(value);
   const fileEndIndex = hasNonAscii
     ? matchPatternAtStart(NON_ASCII_FILE_URL_PATH, value) ||
       matchPatternAtStart(FILE_URL_ABSOLUTE_PATH, value)
     : matchPatternAtStart(FILE_URL_ABSOLUTE_PATH, value);
-  if (fileEndIndex !== 0) return { endIndex: fileEndIndex, marker: "[path]" };
+  if (fileEndIndex !== 0) {
+    return {
+      endIndex: extendCsiConsumedUrlMatch(value, fileEndIndex),
+      marker: "[path]",
+    };
+  }
 
   const urlEndIndex = hasNonAscii
     ? matchCsiConsumedNonAsciiUrl(value) || matchCsiConsumedAsciiUrl(value)
     : matchCsiConsumedAsciiUrl(value);
-  return urlEndIndex === 0 ? undefined : { endIndex: urlEndIndex, marker: "[url]" };
+  return urlEndIndex === 0 ? undefined : {
+    endIndex: extendCsiConsumedUrlMatch(value, urlEndIndex),
+    marker: "[url]",
+  };
 }
 
 interface CsiConsumedUrlSpan extends CsiConsumedUrlRedaction {
@@ -2711,13 +2723,35 @@ function appendMappedInputRange(
   }
 }
 
-function csiUrlStructureStart(matched: string): number {
+function appendMappedCsiUrlStructure(
+  candidate: MappedCsiUrlCandidate,
+  input: string,
+  inputStart: number,
+  matched: string,
+): boolean {
+  if (ReflectApply(RegExpPrototypeExec, ANSI_SGR_SEQUENCE, [matched]) !== null) return false;
   const introducerLength = stringSlice(matched, 0, 1) === "\u001B" ? 2 : 1;
   const colon = stringIndexOf(matched, ":", introducerLength);
   const slash = stringIndexOf(matched, "/", introducerLength);
-  if (colon === -1) return slash;
-  if (slash === -1) return colon;
-  return colon < slash ? colon : slash;
+  if (colon === -1 && slash === -1) return false;
+  if (colon !== -1) {
+    appendMappedInputRange(candidate, input, inputStart + colon, inputStart + colon + 1);
+    const suffixStart = slash === -1 ? matched.length - 1 : slash;
+    appendMappedInputRange(
+      candidate,
+      input,
+      inputStart + suffixStart,
+      inputStart + matched.length,
+    );
+    return true;
+  }
+  appendMappedInputRange(
+    candidate,
+    input,
+    inputStart + slash,
+    inputStart + matched.length,
+  );
+  return true;
 }
 
 function appendMappedCsiUrlTail(
@@ -2735,15 +2769,7 @@ function appendMappedCsiUrlTail(
         | null;
       const sequenceEnd = ANSI_CSI_SEQUENCE_AT_INDEX.lastIndex;
       if (sequence !== null && sequenceEnd <= end) {
-        const structureStart = csiUrlStructureStart(sequence[0]);
-        if (structureStart !== -1) {
-          appendMappedInputRange(
-            candidate,
-            input,
-            index + structureStart,
-            sequenceEnd,
-          );
-        }
+        appendMappedCsiUrlStructure(candidate, input, index, sequence[0]);
         index = sequenceEnd;
         continue;
       }
@@ -2767,19 +2793,12 @@ function csiConsumedUrlSpan(
   if (prefix === undefined || prefix.startIndex < outputOffset) return undefined;
 
   const matched = match[0];
-  const structureStart = csiUrlStructureStart(matched);
-  if (structureStart === -1) return undefined;
   const lookaheadEnd = MathMin(value.length, matchEnd + MAX_CSI_CONSUMED_URL_LOOKAHEAD);
   const candidate: MappedCsiUrlCandidate = {
     inputEnds: prefix.inputEnds,
     value: prefix.value,
   };
-  appendMappedInputRange(
-    candidate,
-    value,
-    match.index + structureStart,
-    matchEnd,
-  );
+  if (!appendMappedCsiUrlStructure(candidate, value, match.index, matched)) return undefined;
   appendMappedCsiUrlTail(candidate, value, matchEnd, lookaheadEnd);
   const redaction = matchCsiConsumedUrlCandidate(candidate.value);
   const reachesLookaheadBound = redaction?.endIndex === candidate.value.length &&

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2079,8 +2079,7 @@ function chooseCompletedGenericCsiPath(
   return selected;
 }
 
-function markCsiSchemePath(path: readonly number[] | undefined, restoreMatches: Set<number>): void {
-  if (path === undefined) return;
+function markCsiSchemePath(path: readonly number[], restoreMatches: Set<number>): void {
   for (let pathIndex = 0; pathIndex < path.length; pathIndex++) { // NOSONAR: Avoid mutable iterator hooks.
     setAdd(restoreMatches, path[pathIndex]!);
   }
@@ -2591,8 +2590,156 @@ interface CsiConsumedUrlPrefix {
   value: string;
 }
 
+type CsiConsumedSpecialPrefixStates = Array<
+  Array<CsiConsumedUrlPrefix | undefined>
+>;
+
+const STRONG_CSI_CONSUMED_URL_PAYLOAD = /[.\/@?#\\]/u;
+
 function createCsiConsumedUrlPrefix(startIndex: number): CsiConsumedUrlPrefix {
   return { startIndex, inputEnds: [], value: "" };
+}
+
+function createCsiConsumedSpecialPrefixStates(): CsiConsumedSpecialPrefixStates {
+  const states: CsiConsumedSpecialPrefixStates = [];
+  for (let schemeIndex = 0; schemeIndex < CSI_SPLITTABLE_URL_SCHEMES.length; schemeIndex++) {
+    const paths: Array<CsiConsumedUrlPrefix | undefined> = [];
+    for (
+      let characterIndex = 0;
+      characterIndex <= CSI_SPLITTABLE_URL_SCHEMES[schemeIndex]!.length;
+      characterIndex++
+    ) {
+      defineOwnArrayElement(paths, characterIndex, undefined);
+    }
+    defineOwnArrayElement(
+      states,
+      schemeIndex,
+      paths,
+    );
+  }
+  return states;
+}
+
+function appendCsiConsumedSpecialPrefix(
+  prefix: CsiConsumedUrlPrefix,
+  character: string,
+  inputEnd: number,
+): CsiConsumedUrlPrefix {
+  const inputEnds: number[] = [];
+  for (let index = 0; index < prefix.inputEnds.length; index++) {
+    defineOwnArrayElement(inputEnds, index, prefix.inputEnds[index]!);
+  }
+  defineOwnArrayElement(inputEnds, inputEnds.length, inputEnd);
+  return {
+    startIndex: prefix.startIndex,
+    inputEnds,
+    value: prefix.value + character,
+  };
+}
+
+function keepCsiConsumedSpecialPrefix(
+  current: CsiConsumedUrlPrefix | undefined,
+  candidate: CsiConsumedUrlPrefix,
+): CsiConsumedUrlPrefix {
+  return current === undefined || candidate.startIndex < current.startIndex ? candidate : current;
+}
+
+function advanceCsiConsumedSpecialLiteral(
+  states: CsiConsumedSpecialPrefixStates,
+  character: string,
+  inputIndex: number,
+): CsiConsumedSpecialPrefixStates {
+  const next = createCsiConsumedSpecialPrefixStates();
+  const lower = ReflectApply(StringPrototypeToLowerCase, character, []) as string;
+  for (let schemeIndex = 0; schemeIndex < CSI_SPLITTABLE_URL_SCHEMES.length; schemeIndex++) {
+    const scheme = CSI_SPLITTABLE_URL_SCHEMES[schemeIndex]!;
+    for (let characterIndex = 1; characterIndex < scheme.length; characterIndex++) {
+      const prefix = states[schemeIndex]![characterIndex];
+      if (
+        prefix === undefined || stringSlice(scheme, characterIndex, characterIndex + 1) !== lower
+      ) {
+        continue;
+      }
+      next[schemeIndex]![characterIndex + 1] = appendCsiConsumedSpecialPrefix(
+        prefix,
+        character,
+        inputIndex + 1,
+      );
+    }
+    if (stringSlice(scheme, 0, 1) === lower) {
+      next[schemeIndex]![1] = {
+        startIndex: inputIndex,
+        inputEnds: [inputIndex + 1],
+        value: character,
+      };
+    }
+  }
+  return next;
+}
+
+function advanceCsiConsumedSpecialSequence(
+  states: CsiConsumedSpecialPrefixStates,
+  matched: string,
+  inputIndex: number,
+  inputEnd: number,
+): CsiConsumedSpecialPrefixStates {
+  const next = createCsiConsumedSpecialPrefixStates();
+  const isSgr = ReflectApply(RegExpPrototypeExec, ANSI_SGR_SEQUENCE, [matched]) !== null;
+  const finalByte = ReflectApply(
+    StringPrototypeToLowerCase,
+    stringSlice(matched, -1),
+    [],
+  ) as string;
+  for (let schemeIndex = 0; schemeIndex < CSI_SPLITTABLE_URL_SCHEMES.length; schemeIndex++) {
+    const scheme = CSI_SPLITTABLE_URL_SCHEMES[schemeIndex]!;
+    for (let characterIndex = 1; characterIndex <= scheme.length; characterIndex++) {
+      const prefix = states[schemeIndex]![characterIndex];
+      if (prefix === undefined) continue;
+      next[schemeIndex]![characterIndex] = keepCsiConsumedSpecialPrefix(
+        next[schemeIndex]![characterIndex],
+        prefix,
+      );
+      if (
+        !isSgr && characterIndex < scheme.length &&
+        stringSlice(scheme, characterIndex, characterIndex + 1) === finalByte
+      ) {
+        const restored = appendCsiConsumedSpecialPrefix(
+          prefix,
+          stringSlice(matched, -1),
+          inputEnd,
+        );
+        next[schemeIndex]![characterIndex + 1] = keepCsiConsumedSpecialPrefix(
+          next[schemeIndex]![characterIndex + 1],
+          restored,
+        );
+      }
+    }
+    if (!isSgr && stringSlice(scheme, 0, 1) === finalByte) {
+      next[schemeIndex]![1] = keepCsiConsumedSpecialPrefix(
+        next[schemeIndex]![1],
+        {
+          startIndex: inputIndex,
+          inputEnds: [inputEnd],
+          value: stringSlice(matched, -1),
+        },
+      );
+    }
+  }
+  return next;
+}
+
+function chooseCsiConsumedSpecialPrefix(
+  states: CsiConsumedSpecialPrefixStates,
+): CsiConsumedUrlPrefix | undefined {
+  let selected: CsiConsumedUrlPrefix | undefined;
+  for (let schemeIndex = 0; schemeIndex < CSI_SPLITTABLE_URL_SCHEMES.length; schemeIndex++) {
+    const scheme = CSI_SPLITTABLE_URL_SCHEMES[schemeIndex]!;
+    const candidate = states[schemeIndex]![scheme.length];
+    if (candidate !== undefined) {
+      selected = keepCsiConsumedSpecialPrefix(selected, candidate);
+    }
+  }
+  return selected;
 }
 
 function advanceCsiConsumedSchemePrefix(
@@ -2648,18 +2795,28 @@ function csiConsumedUrlPrefix(
     ? matchIndex - MAX_CSI_CONSUMED_URL_LOOKAHEAD
     : 0;
   let prefix = createCsiConsumedUrlPrefix(matchIndex);
+  let specialStates = createCsiConsumedSpecialPrefixStates();
   let index = windowStart;
   while (index < matchIndex) {
     const sequenceEnd = completeCsiSequenceEndAtIndex(value, index, matchIndex);
     if (sequenceEnd !== index) {
+      specialStates = advanceCsiConsumedSpecialSequence(
+        specialStates,
+        stringSlice(value, index, sequenceEnd),
+        index,
+        sequenceEnd,
+      );
       index = sequenceEnd;
       continue;
     }
 
     const character = stringSlice(value, index, index + 1);
+    specialStates = advanceCsiConsumedSpecialLiteral(specialStates, character, index);
     prefix = advanceCsiConsumedUrlPrefix(prefix, character, index, matchIndex);
     index += 1;
   }
+  const special = chooseCsiConsumedSpecialPrefix(specialStates);
+  if (special !== undefined) return special;
   return prefix.value === "" ? undefined : prefix;
 }
 
@@ -2765,13 +2922,14 @@ function appendMappedCsiUrlStructure(
     if (!stringEndsWith(candidate.value, ":")) {
       appendMappedInputRange(candidate, input, inputStart + colon, inputStart + colon + 1);
     }
-    const suffixStart = slash === -1 ? matched.length - 1 : slash;
-    appendMappedInputRange(
-      candidate,
-      input,
-      inputStart + suffixStart,
-      inputStart + matched.length,
-    );
+    if (slash !== -1) {
+      appendMappedInputRange(
+        candidate,
+        input,
+        inputStart + slash,
+        inputStart + matched.length,
+      );
+    }
     return true;
   }
   appendMappedInputRange(
@@ -2781,6 +2939,14 @@ function appendMappedCsiUrlStructure(
     inputStart + matched.length,
   );
   return true;
+}
+
+function hasStrongCsiConsumedUrlPayload(value: string): boolean {
+  const colon = stringIndexOf(value, ":");
+  if (colon === -1) return false;
+  const payload = stringSlice(value, colon + 1);
+  return containsNonAscii(payload) ||
+    ReflectApply(RegExpPrototypeExec, STRONG_CSI_CONSUMED_URL_PAYLOAD, [payload]) !== null;
 }
 
 function appendMappedCsiUrlTail(
@@ -2829,6 +2995,12 @@ function csiConsumedUrlSpan(
   };
   if (!appendMappedCsiUrlStructure(candidate, value, match.index, matched)) return undefined;
   appendMappedCsiUrlTail(candidate, value, matchEnd, lookaheadEnd);
+  const introducerLength = stringSlice(matched, 0, 1) === "\u001B" ? 2 : 1;
+  const colon = stringIndexOf(matched, ":", introducerLength);
+  const slash = stringIndexOf(matched, "/", introducerLength);
+  if (colon !== -1 && slash === -1 && !hasStrongCsiConsumedUrlPayload(candidate.value)) {
+    return undefined;
+  }
   const redaction = matchCsiConsumedUrlCandidate(candidate.value);
   const reachesLookaheadBound = redaction?.endIndex === candidate.value.length &&
     lookaheadEnd < value.length;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1913,6 +1913,85 @@ const CONTROL_CHARACTERS = /[\u0000-\u001F\u007F-\u009F]/g;
 // Strip complete CSI sequences before matching paths and URLs.
 // deno-lint-ignore no-control-regex
 const ANSI_CSI_SEQUENCE = /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\u0040-\u007E]/g;
+const CSI_SPLITTABLE_URL_SCHEMES = freezeObject([
+  "http",
+  "https",
+  "ws",
+  "wss",
+  "ftp",
+  "file",
+]) as readonly string[];
+
+/**
+ * Restore a URL-scheme character consumed as a CSI final byte.
+ *
+ * In `h<ESC>[ttps:host/path`, `t` is both a legal CSI final byte and the
+ * second character of `https`. Ordinary de-colorization therefore leaves the
+ * unrecognized token `htps:host/path`. Restore the final byte only when the
+ * bounded text immediately before and after the sequence completes a scheme
+ * the URL redactor already recognizes. The normal redaction pass then removes
+ * the whole URL.
+ *
+ * Keep the CSI grammar unchanged. Restricting its final byte would leave real
+ * sequences behind, while matching arbitrary damaged schemes would erase
+ * ordinary colon-delimited prose.
+ */
+function restoreCsiSplitUrlSchemes(value: string): string {
+  ANSI_CSI_SEQUENCE.lastIndex = 0;
+  let output = "";
+  let offset = 0;
+  try {
+    while (true) {
+      const match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE, [value]) as
+        | RegExpExecArray
+        | null;
+      if (match === null) break;
+
+      const matched = match[0];
+      const finalByte = ReflectApply(
+        StringPrototypeToLowerCase,
+        stringSlice(matched, -1),
+        [],
+      ) as string;
+      const prefixStart = match.index > 5 ? match.index - 5 : 0;
+      const preceding = ReflectApply(
+        StringPrototypeToLowerCase,
+        stringSlice(value, prefixStart, match.index),
+        [],
+      ) as string;
+      const following = ReflectApply(
+        StringPrototypeToLowerCase,
+        stringSlice(value, ANSI_CSI_SEQUENCE.lastIndex, ANSI_CSI_SEQUENCE.lastIndex + 5),
+        [],
+      ) as string;
+
+      let restoresScheme = false;
+      for (
+        let schemeIndex = 0;
+        schemeIndex < CSI_SPLITTABLE_URL_SCHEMES.length && !restoresScheme;
+        schemeIndex++
+      ) {
+        const scheme = CSI_SPLITTABLE_URL_SCHEMES[schemeIndex]!;
+        for (let splitIndex = 1; splitIndex < scheme.length; splitIndex++) {
+          if (stringSlice(scheme, splitIndex, splitIndex + 1) !== finalByte) continue;
+          const prefix = stringSlice(scheme, 0, splitIndex);
+          const suffix = `${stringSlice(scheme, splitIndex + 1)}:`;
+          if (stringEndsWith(preceding, prefix) && stringStartsWith(following, suffix)) {
+            restoresScheme = true;
+            break;
+          }
+        }
+      }
+
+      output += stringSlice(value, offset, match.index);
+      output += restoresScheme ? stringSlice(matched, -1) : matched;
+      offset = ANSI_CSI_SEQUENCE.lastIndex;
+    }
+    return output + stringSlice(value, offset);
+  } finally {
+    ANSI_CSI_SEQUENCE.lastIndex = 0;
+  }
+}
 // Remove a CSI prefix separately when its grammar could consume the first path
 // byte. Preserve `/`, both UNC separators, and drive-letter starts for redaction.
 const CSI_GLUED_PATH =
@@ -2235,9 +2314,10 @@ function summarizeConfigLoadCause(error: unknown): string | undefined {
   if (message === undefined) return undefined;
   // Sanitize on both sides because stripping CSI can join or consume credential bytes.
   const initiallyRedacted = sanitizeUrlCredentials(message);
+  const restoredUrlSchemes = restoreCsiSplitUrlSchemes(initiallyRedacted);
   // Replacing a glued CSI introducer with space preserves the path or scheme start
   // without joining it to preceding prose. Machine paths are redacted afterward.
-  const unglued = replaceMatchesWithCapturedExec(initiallyRedacted, CSI_GLUED_PATH, " ");
+  const unglued = replaceMatchesWithCapturedExec(restoredUrlSchemes, CSI_GLUED_PATH, " ");
   const ungluedUrl = replaceMatchesWithCapturedExec(unglued, CSI_GLUED_URL, " ");
   const deColorized = replaceMatchesWithCapturedExec(
     ungluedUrl,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1955,7 +1955,7 @@ function markCompletedCsiSchemes(states: CsiSchemeStates, restoreMatches: boolea
     const scheme = CSI_SPLITTABLE_URL_SCHEMES[schemeIndex]!;
     const path = states[schemeIndex]?.[scheme.length];
     if (path === undefined) continue;
-    for (let pathIndex = 0; pathIndex < path.length; pathIndex++) {
+    for (let pathIndex = 0; pathIndex < path.length; pathIndex++) { // NOSONAR: Avoid mutable iterator hooks.
       restoreMatches[path[pathIndex]!] = true;
     }
   }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2549,38 +2549,67 @@ interface CsiConsumedUrlRedaction {
   marker: "[path]" | "[url]";
 }
 
-function csiConsumedUrlPrefixStart(
-  value: string,
-  matchIndex: number,
-  minimumIndex: number,
-): number | undefined {
-  let schemeEnd = matchIndex;
-  if (stringSlice(value, schemeEnd - 1, schemeEnd) === ":") schemeEnd -= 1;
-  let startIndex = schemeEnd;
-  while (
-    startIndex > minimumIndex &&
-    schemeEnd - startIndex < MAX_GENERIC_URL_SCHEME_LENGTH &&
-    ReflectApply(RegExpPrototypeExec, GENERIC_URL_SCHEME_CHARACTER, [
-        stringSlice(value, startIndex - 1, startIndex),
-      ]) !== null
-  ) {
-    startIndex -= 1;
-  }
-  if (startIndex === schemeEnd) return undefined;
-  return ReflectApply(RegExpPrototypeExec, GENERIC_URL_SCHEME_FIRST_CHARACTER, [
-      stringSlice(value, startIndex, startIndex + 1),
-    ]) !== null
-    ? startIndex
-    : undefined;
+interface CsiConsumedUrlPrefix {
+  startIndex: number;
+  value: string;
 }
 
-function matchPatternAtStart(pattern: RegExp, value: string): number {
+function csiConsumedUrlPrefix(
+  value: string,
+  matchIndex: number,
+): CsiConsumedUrlPrefix | undefined {
+  const windowStart = matchIndex > MAX_CSI_CONSUMED_URL_LOOKAHEAD
+    ? matchIndex - MAX_CSI_CONSUMED_URL_LOOKAHEAD
+    : 0;
+  let startIndex = matchIndex;
+  let prefix = "";
+  let index = windowStart;
+  while (index < matchIndex) {
+    const sequenceEnd = skipCompleteCsiSequences(value, index);
+    if (sequenceEnd !== index && sequenceEnd <= matchIndex) {
+      index = sequenceEnd;
+      continue;
+    }
+
+    const character = stringSlice(value, index, index + 1);
+    const isSchemeCharacter = ReflectApply(RegExpPrototypeExec, GENERIC_URL_SCHEME_CHARACTER, [
+      character,
+    ]) !== null;
+    if (isSchemeCharacter) {
+      const canStart = ReflectApply(RegExpPrototypeExec, GENERIC_URL_SCHEME_FIRST_CHARACTER, [
+        character,
+      ]) !== null;
+      if (prefix === "" || prefix.length >= MAX_GENERIC_URL_SCHEME_LENGTH) {
+        prefix = canStart ? character : "";
+        startIndex = canStart ? index : matchIndex;
+      } else {
+        prefix += character;
+      }
+    } else if (character === ":" && index === matchIndex - 1 && prefix !== "") {
+      prefix += character;
+    } else {
+      prefix = "";
+      startIndex = matchIndex;
+    }
+    index += 1;
+  }
+  return prefix === "" ? undefined : { startIndex, value: prefix };
+}
+
+function matchPatternAtStart(
+  pattern: RegExp,
+  value: string,
+  validateUnicodeHostBoundary = false,
+): number {
   pattern.lastIndex = 0;
   try {
     const match = ReflectApply(RegExpPrototypeExec, pattern, [value]) as
       | RegExpExecArray
       | null;
-    return match?.index === 0 ? pattern.lastIndex : 0;
+    if (match?.index !== 0) return 0;
+    return validateUnicodeHostBoundary
+      ? acceptedUnicodeHostMatchEnd(match[0], 0)
+      : pattern.lastIndex;
   } finally {
     pattern.lastIndex = 0;
   }
@@ -2593,22 +2622,25 @@ function matchCsiConsumedAsciiUrl(value: string): number {
 }
 
 function matchCsiConsumedNonAsciiUrl(value: string): number {
-  return matchPatternAtStart(NON_ASCII_AUTHORITY_URL, value) ||
+  return matchPatternAtStart(NON_ASCII_AUTHORITY_URL, value, true) ||
     matchPatternAtStart(NON_ASCII_URL_PATH, value) ||
-    matchPatternAtStart(NON_ASCII_MALFORMED_AUTHORITY_URL, value) ||
+    matchPatternAtStart(NON_ASCII_MALFORMED_AUTHORITY_URL, value, true) ||
     matchPatternAtStart(NON_ASCII_MALFORMED_URL_PATH, value) ||
-    matchPatternAtStart(NON_ASCII_ZERO_SLASH_AUTHORITY_URL, value) ||
+    matchPatternAtStart(NON_ASCII_ZERO_SLASH_AUTHORITY_URL, value, true) ||
     matchPatternAtStart(NON_ASCII_ZERO_SLASH_URL_PATH, value);
 }
 
 function matchCsiConsumedUrlCandidate(value: string): CsiConsumedUrlRedaction | undefined {
   const hasNonAscii = containsNonAscii(value);
-  const fileEndIndex = matchPatternAtStart(FILE_URL_ABSOLUTE_PATH, value) ||
-    (hasNonAscii ? matchPatternAtStart(NON_ASCII_FILE_URL_PATH, value) : 0);
+  const fileEndIndex = hasNonAscii
+    ? matchPatternAtStart(NON_ASCII_FILE_URL_PATH, value) ||
+      matchPatternAtStart(FILE_URL_ABSOLUTE_PATH, value)
+    : matchPatternAtStart(FILE_URL_ABSOLUTE_PATH, value);
   if (fileEndIndex !== 0) return { endIndex: fileEndIndex, marker: "[path]" };
 
-  const urlEndIndex = matchCsiConsumedAsciiUrl(value) ||
-    (hasNonAscii ? matchCsiConsumedNonAsciiUrl(value) : 0);
+  const urlEndIndex = hasNonAscii
+    ? matchCsiConsumedNonAsciiUrl(value) || matchCsiConsumedAsciiUrl(value)
+    : matchCsiConsumedAsciiUrl(value);
   return urlEndIndex === 0 ? undefined : { endIndex: urlEndIndex, marker: "[url]" };
 }
 
@@ -2620,51 +2652,64 @@ function csiConsumedUrlSpan(
   value: string,
   match: RegExpExecArray,
   matchEnd: number,
-  literalStart: number,
   outputOffset: number,
 ): CsiConsumedUrlSpan | undefined {
   if (match.index < outputOffset) return undefined;
-  const prefixStart = csiConsumedUrlPrefixStart(value, match.index, literalStart);
-  if (prefixStart === undefined) return undefined;
+  const prefix = csiConsumedUrlPrefix(value, match.index);
+  if (prefix === undefined || prefix.startIndex < outputOffset) return undefined;
 
   const matched = match[0];
   const introducerLength = stringSlice(matched, 0, 1) === "\u001B" ? 2 : 1;
   const lookaheadEnd = MathMin(value.length, matchEnd + MAX_CSI_CONSUMED_URL_LOOKAHEAD);
-  const prefix = stringSlice(value, prefixStart, match.index);
-  const candidate = prefix + stringSlice(matched, introducerLength) +
+  const candidate = prefix.value + stringSlice(matched, introducerLength) +
     stringSlice(value, matchEnd, lookaheadEnd);
   const redaction = matchCsiConsumedUrlCandidate(candidate);
+  const reachesLookaheadBound = redaction?.endIndex === candidate.length &&
+    lookaheadEnd < value.length;
   return redaction
     ? {
-      startIndex: prefixStart,
-      endIndex: prefixStart + redaction.endIndex + introducerLength,
+      startIndex: prefix.startIndex,
+      endIndex: reachesLookaheadBound
+        ? value.length
+        : prefix.startIndex + redaction.endIndex + introducerLength,
       marker: redaction.marker,
     }
     : undefined;
 }
 
+function exceedsCsiReconstructionLimit(value: string): boolean {
+  ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex = 0;
+  let matchCount = 0;
+  try {
+    while (
+      ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_FOR_URL_REDACTION, [value]) !== null
+    ) {
+      matchCount += 1;
+      if (matchCount > MAX_CSI_RECONSTRUCTION_MATCHES) return true;
+    }
+    return false;
+  } finally {
+    ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex = 0;
+  }
+}
+
 function redactCsiConsumedUrls(value: string): string {
+  if (exceedsCsiReconstructionLimit(value)) return "[REDACTED]";
   ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex = 0;
   try {
     let output = "";
     let outputOffset = 0;
-    let literalStart = 0;
-    let matchCount = 0;
     let match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_FOR_URL_REDACTION, [value]) as
       | RegExpExecArray
       | null;
     while (match !== null) {
       const matchEnd = ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex;
-      matchCount += 1;
-      if (matchCount > MAX_CSI_RECONSTRUCTION_MATCHES) return "[REDACTED]";
-      const span = csiConsumedUrlSpan(value, match, matchEnd, literalStart, outputOffset);
+      const span = csiConsumedUrlSpan(value, match, matchEnd, outputOffset);
       if (span) {
         output += stringSlice(value, outputOffset, span.startIndex) + span.marker;
         outputOffset = span.endIndex;
         ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex = span.endIndex;
-        literalStart = span.endIndex;
       }
-      if (literalStart < matchEnd) literalStart = matchEnd;
       match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_FOR_URL_REDACTION, [value]) as
         | RegExpExecArray
         | null;
@@ -2877,8 +2922,10 @@ function summarizeConfigLoadCause(error: unknown): string | undefined {
     ? readOwnDataString(error, "message")
     : undefined;
   if (message === undefined) return undefined;
+  const retainedLine = (ReflectApply(StringPrototypeSplit, message, ["\n", 1]) as string[])[0] ??
+    "";
   // Sanitize on both sides because stripping CSI can join or consume credential bytes.
-  const initiallyRedacted = sanitizeUrlCredentials(message);
+  const initiallyRedacted = sanitizeUrlCredentials(retainedLine);
   const intactUrlRedacted = redactCsiConsumedUrls(initiallyRedacted);
   const restoredUrlSchemes = restoreCsiSplitUrlSchemes(intactUrlRedacted);
   // Replacing a glued CSI introducer with space preserves the path or scheme start
@@ -2891,9 +2938,7 @@ function summarizeConfigLoadCause(error: unknown): string | undefined {
     "",
   );
   const redacted = sanitizeUrlCredentials(deColorized);
-  const firstLine = (ReflectApply(StringPrototypeSplit, redacted, ["\n", 1]) as string[])[0] ??
-    "";
-  const replaced = replaceMatchesWithCapturedExec(firstLine, CONTROL_CHARACTERS, " ");
+  const replaced = replaceMatchesWithCapturedExec(redacted, CONTROL_CHARACTERS, " ");
   const clean = ReflectApply(StringPrototypeTrim, redactMachinePaths(replaced), []) as string;
   if (clean.length === 0) return undefined;
   return clean.length > MAX_CONFIG_LOAD_CAUSE_CHARACTERS

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2531,6 +2531,10 @@ const ZERO_SLASH_SCHEME_URL = new RegExp(
   String.raw`${ASCII_SPECIAL_SCHEME_SOURCE}:(?![/\s])(?:[^\s"/]{0,512}@)?${URL_TOKEN_TAIL_SOURCE}`,
   "gu",
 );
+const CSI_CONSUMED_ZERO_SLASH_SCHEME_URL = new RegExp(
+  String.raw`[A-Za-z][A-Za-z0-9+.-]{1,31}:(?![/\s])(?:[^\s"/]{0,512}@)?${URL_TOKEN_TAIL_SOURCE}`,
+  "gu",
+);
 // Mirror the single-slash and zero-slash forms for raw IRI hosts and paths.
 const NON_ASCII_MALFORMED_AUTHORITY_URL = new RegExp(
   String
@@ -2591,12 +2595,9 @@ interface CsiConsumedUrlPrefix {
 type CsiConsumedSpecialPrefixStates = Array<
   Array<CsiConsumedUrlPrefix | undefined>
 >;
+type CsiConsumedGenericPrefixStates = Array<CsiConsumedUrlPrefix | undefined>;
 
-const STRONG_CSI_CONSUMED_URL_PAYLOAD = /[.\/@?#\\]/u;
-
-function createCsiConsumedUrlPrefix(startIndex: number): CsiConsumedUrlPrefix {
-  return { startIndex, inputEnds: [], value: "" };
-}
+const STRONG_CSI_CONSUMED_URL_PAYLOAD = /[.\/@?#\\[\]:]/u;
 
 function createCsiConsumedSpecialPrefixStates(): CsiConsumedSpecialPrefixStates {
   const states: CsiConsumedSpecialPrefixStates = [];
@@ -2740,49 +2741,95 @@ function chooseCsiConsumedSpecialPrefix(
   return selected;
 }
 
-function advanceCsiConsumedSchemePrefix(
-  prefix: CsiConsumedUrlPrefix,
-  character: string,
-  index: number,
-  matchIndex: number,
-): CsiConsumedUrlPrefix {
-  if (
-    prefix.value === "" || stringEndsWith(prefix.value, ":") ||
-    prefix.value.length >= MAX_GENERIC_URL_SCHEME_LENGTH
-  ) {
-    const restarted = createCsiConsumedUrlPrefix(matchIndex);
-    const canStart = ReflectApply(RegExpPrototypeExec, GENERIC_URL_SCHEME_FIRST_CHARACTER, [
-      character,
-    ]) !== null;
-    if (!canStart) return restarted;
-    restarted.startIndex = index;
-    restarted.value = character;
-    defineOwnArrayElement(restarted.inputEnds, 0, index + 1);
-    return restarted;
+function createCsiConsumedGenericPrefixStates(): CsiConsumedGenericPrefixStates {
+  const states: CsiConsumedGenericPrefixStates = [];
+  for (let length = 0; length <= MAX_GENERIC_URL_SCHEME_LENGTH; length++) {
+    defineOwnArrayElement(states, length, undefined);
   }
-  prefix.value += character;
-  defineOwnArrayElement(prefix.inputEnds, prefix.inputEnds.length, index + 1);
-  return prefix;
+  return states;
 }
 
-function advanceCsiConsumedUrlPrefix(
-  prefix: CsiConsumedUrlPrefix,
+function advanceCsiConsumedGenericLiteral(
+  states: CsiConsumedGenericPrefixStates,
   character: string,
-  index: number,
-  matchIndex: number,
-): CsiConsumedUrlPrefix {
+  inputIndex: number,
+): CsiConsumedGenericPrefixStates {
+  const next = createCsiConsumedGenericPrefixStates();
   const isSchemeCharacter = ReflectApply(RegExpPrototypeExec, GENERIC_URL_SCHEME_CHARACTER, [
     character,
   ]) !== null;
   if (isSchemeCharacter) {
-    return advanceCsiConsumedSchemePrefix(prefix, character, index, matchIndex);
+    for (let length = 1; length < MAX_GENERIC_URL_SCHEME_LENGTH; length++) {
+      const prefix = states[length];
+      if (prefix !== undefined) {
+        next[length + 1] = appendCsiConsumedSpecialPrefix(
+          prefix,
+          character,
+          inputIndex + 1,
+        );
+      }
+    }
   }
-  if (character === ":" && prefix.value !== "" && !stringEndsWith(prefix.value, ":")) {
-    prefix.value += character;
-    defineOwnArrayElement(prefix.inputEnds, prefix.inputEnds.length, index + 1);
-    return prefix;
+  const canStart = ReflectApply(RegExpPrototypeExec, GENERIC_URL_SCHEME_FIRST_CHARACTER, [
+    character,
+  ]) !== null;
+  if (canStart) {
+    next[1] = {
+      startIndex: inputIndex,
+      inputEnds: [inputIndex + 1],
+      value: character,
+    };
   }
-  return createCsiConsumedUrlPrefix(matchIndex);
+  return next;
+}
+
+function advanceCsiConsumedGenericSequence(
+  states: CsiConsumedGenericPrefixStates,
+  matched: string,
+  inputIndex: number,
+  inputEnd: number,
+): CsiConsumedGenericPrefixStates {
+  const next = createCsiConsumedGenericPrefixStates();
+  const isSgr = ReflectApply(RegExpPrototypeExec, ANSI_SGR_SEQUENCE, [matched]) !== null;
+  const finalByte = stringSlice(matched, -1);
+  const isSchemeCharacter = !isSgr &&
+    ReflectApply(RegExpPrototypeExec, GENERIC_URL_SCHEME_CHARACTER, [finalByte]) !== null;
+  for (let length = 1; length <= MAX_GENERIC_URL_SCHEME_LENGTH; length++) {
+    const prefix = states[length];
+    if (prefix === undefined) continue;
+    next[length] = prefix;
+    if (isSchemeCharacter && length < MAX_GENERIC_URL_SCHEME_LENGTH) {
+      next[length + 1] = appendCsiConsumedSpecialPrefix(prefix, finalByte, inputEnd);
+    }
+  }
+  const canStart = !isSgr &&
+    ReflectApply(RegExpPrototypeExec, GENERIC_URL_SCHEME_FIRST_CHARACTER, [finalByte]) !== null;
+  if (canStart) {
+    next[1] = {
+      startIndex: inputIndex,
+      inputEnds: [inputEnd],
+      value: finalByte,
+    };
+  }
+  return next;
+}
+
+function chooseCsiConsumedGenericPrefix(
+  states: CsiConsumedGenericPrefixStates,
+): CsiConsumedUrlPrefix | undefined {
+  let selected: CsiConsumedUrlPrefix | undefined;
+  for (let length = 2; length <= MAX_GENERIC_URL_SCHEME_LENGTH; length++) {
+    const candidate = states[length];
+    if (
+      candidate !== undefined &&
+      (selected === undefined || candidate.startIndex < selected.startIndex ||
+        (candidate.startIndex === selected.startIndex &&
+          candidate.value.length > selected.value.length))
+    ) {
+      selected = candidate;
+    }
+  }
+  return selected;
 }
 
 function csiConsumedUrlPrefix(
@@ -2792,8 +2839,9 @@ function csiConsumedUrlPrefix(
   const windowStart = matchIndex > MAX_CSI_CONSUMED_URL_LOOKAHEAD
     ? matchIndex - MAX_CSI_CONSUMED_URL_LOOKAHEAD
     : 0;
-  let prefix = createCsiConsumedUrlPrefix(matchIndex);
   let specialStates = createCsiConsumedSpecialPrefixStates();
+  let genericStates = createCsiConsumedGenericPrefixStates();
+  let literalColonPrefix: CsiConsumedUrlPrefix | undefined;
   let index = windowStart;
   while (index < matchIndex) {
     const sequenceEnd = completeCsiSequenceEndAtIndex(value, index, matchIndex);
@@ -2804,18 +2852,34 @@ function csiConsumedUrlPrefix(
         index,
         sequenceEnd,
       );
+      genericStates = advanceCsiConsumedGenericSequence(
+        genericStates,
+        stringSlice(value, index, sequenceEnd),
+        index,
+        sequenceEnd,
+      );
       index = sequenceEnd;
       continue;
     }
 
     const character = stringSlice(value, index, index + 1);
+    if (character === ":") {
+      const completed = chooseCsiConsumedSpecialPrefix(specialStates) ??
+        chooseCsiConsumedGenericPrefix(genericStates);
+      literalColonPrefix = completed === undefined
+        ? undefined
+        : appendCsiConsumedSpecialPrefix(completed, character, index + 1);
+    } else {
+      literalColonPrefix = undefined;
+    }
     specialStates = advanceCsiConsumedSpecialLiteral(specialStates, character, index);
-    prefix = advanceCsiConsumedUrlPrefix(prefix, character, index, matchIndex);
+    genericStates = advanceCsiConsumedGenericLiteral(genericStates, character, index);
     index += 1;
   }
+  if (literalColonPrefix !== undefined) return literalColonPrefix;
   const special = chooseCsiConsumedSpecialPrefix(specialStates);
   if (special !== undefined) return special;
-  return prefix.value === "" ? undefined : prefix;
+  return chooseCsiConsumedGenericPrefix(genericStates);
 }
 
 function matchPatternAtStart(
@@ -2840,7 +2904,8 @@ function matchPatternAtStart(
 function matchCsiConsumedAsciiUrl(value: string): number {
   return matchPatternAtStart(SCHEME_URL, value) ||
     matchPatternAtStart(MALFORMED_SCHEME_URL, value) ||
-    matchPatternAtStart(ZERO_SLASH_SCHEME_URL, value);
+    matchPatternAtStart(ZERO_SLASH_SCHEME_URL, value) ||
+    matchPatternAtStart(CSI_CONSUMED_ZERO_SLASH_SCHEME_URL, value);
 }
 
 function matchCsiConsumedNonAsciiUrl(value: string): number {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2958,6 +2958,11 @@ interface MappedCsiUrlCandidate {
   value: string;
 }
 
+interface CsiConsumedUrlStructure {
+  colon: number;
+  slash: number;
+}
+
 function appendMappedInputRange(
   candidate: MappedCsiUrlCandidate,
   input: string,
@@ -2970,17 +2975,23 @@ function appendMappedInputRange(
   }
 }
 
+function csiConsumedUrlStructure(matched: string): CsiConsumedUrlStructure | undefined {
+  if (ReflectApply(RegExpPrototypeExec, ANSI_SGR_SEQUENCE, [matched]) !== null) return undefined;
+  const introducerLength = stringSlice(matched, 0, 1) === "\u001B" ? 2 : 1;
+  const colon = stringIndexOf(matched, ":", introducerLength);
+  const slash = stringIndexOf(matched, "/", introducerLength);
+  return colon === -1 && slash === -1 ? undefined : { colon, slash };
+}
+
 function appendMappedCsiUrlStructure(
   candidate: MappedCsiUrlCandidate,
   input: string,
   inputStart: number,
   matched: string,
+  structure = csiConsumedUrlStructure(matched),
 ): boolean {
-  if (ReflectApply(RegExpPrototypeExec, ANSI_SGR_SEQUENCE, [matched]) !== null) return false;
-  const introducerLength = stringSlice(matched, 0, 1) === "\u001B" ? 2 : 1;
-  const colon = stringIndexOf(matched, ":", introducerLength);
-  const slash = stringIndexOf(matched, "/", introducerLength);
-  if (colon === -1 && slash === -1) return false;
+  if (structure === undefined) return false;
+  const { colon, slash } = structure;
   if (colon !== -1) {
     if (!stringEndsWith(candidate.value, ":")) {
       appendMappedInputRange(candidate, input, inputStart + colon, inputStart + colon + 1);
@@ -3004,10 +3015,10 @@ function appendMappedCsiUrlStructure(
   return true;
 }
 
-function hasStrongCsiConsumedUrlPayload(value: string): boolean {
+function hasStrongCsiConsumedUrlPayload(value: string, endIndex: number): boolean {
   const colon = stringIndexOf(value, ":");
-  if (colon === -1) return false;
-  const payload = stringSlice(value, colon + 1);
+  if (colon === -1 || colon >= endIndex) return false;
+  const payload = stringSlice(value, colon + 1, endIndex);
   if (containsNonAscii(payload)) return true;
   for (let index = 0; index < payload.length; index++) {
     if (stringIncludes(STRONG_CSI_CONSUMED_URL_PAYLOAD_CHARACTERS, payload[index]!)) return true;
@@ -3050,24 +3061,27 @@ function csiConsumedUrlSpan(
   outputOffset: number,
 ): CsiConsumedUrlSpan | undefined {
   if (match.index < outputOffset) return undefined;
+  const matched = match[0];
+  const structure = csiConsumedUrlStructure(matched);
+  if (structure === undefined) return undefined;
   const prefix = csiConsumedUrlPrefix(value, match.index);
   if (prefix === undefined || prefix.startIndex < outputOffset) return undefined;
 
-  const matched = match[0];
   const lookaheadEnd = MathMin(value.length, matchEnd + MAX_CSI_CONSUMED_URL_LOOKAHEAD);
   const candidate: MappedCsiUrlCandidate = {
     inputEnds: prefix.inputEnds,
     value: prefix.value,
   };
-  if (!appendMappedCsiUrlStructure(candidate, value, match.index, matched)) return undefined;
+  appendMappedCsiUrlStructure(candidate, value, match.index, matched, structure);
   appendMappedCsiUrlTail(candidate, value, matchEnd, lookaheadEnd);
   const introducerLength = stringSlice(matched, 0, 1) === "\u001B" ? 2 : 1;
   const colon = stringIndexOf(matched, ":", introducerLength);
   const slash = stringIndexOf(matched, "/", introducerLength);
-  if (colon !== -1 && slash === -1 && !hasStrongCsiConsumedUrlPayload(candidate.value)) {
-    return undefined;
-  }
   const redaction = matchCsiConsumedUrlCandidate(candidate.value);
+  if (
+    redaction !== undefined && colon !== -1 && slash === -1 &&
+    !hasStrongCsiConsumedUrlPayload(candidate.value, redaction.endIndex)
+  ) return undefined;
   const reachesLookaheadBound = redaction?.endIndex === candidate.value.length &&
     lookaheadEnd < value.length;
   const mappedEnd = redaction === undefined
@@ -3085,11 +3099,18 @@ function exceedsCsiReconstructionLimit(value: string): boolean {
   ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex = 0;
   let matchCount = 0;
   try {
-    while (
-      ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_FOR_URL_REDACTION, [value]) !== null
-    ) {
+    let match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_FOR_URL_REDACTION, [value]) as
+      | RegExpExecArray
+      | null;
+    while (match !== null) {
       matchCount += 1;
-      if (matchCount > MAX_CSI_RECONSTRUCTION_MATCHES) return true;
+      if (
+        matchCount > MAX_CSI_RECONSTRUCTION_MATCHES ||
+        match[0].length > MAX_CSI_CONSUMED_URL_LOOKAHEAD
+      ) return true;
+      match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_FOR_URL_REDACTION, [value]) as
+        | RegExpExecArray
+        | null;
     }
     return false;
   } finally {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2399,11 +2399,13 @@ function restoreCsiSplitUrlSchemes(value: string): string {
     for (let matchIndex = 0; matchIndex < matches.length; matchIndex++) {
       const match = matches[matchIndex]!;
       output += stringSlice(value, outputOffset, match.inputIndex);
-      output += setHas(stripSequenceStarts, match.inputIndex)
-        ? ""
-        : setHas(restoreMatches, matchIndex)
-        ? stringSlice(match.matched, -1)
-        : match.matched;
+      let replacement = match.matched;
+      if (setHas(stripSequenceStarts, match.inputIndex)) {
+        replacement = "";
+      } else if (setHas(restoreMatches, matchIndex)) {
+        replacement = stringSlice(match.matched, -1);
+      }
+      output += replacement;
       outputOffset = match.inputEnd;
     }
     return output + stringSlice(value, outputOffset);

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2440,6 +2440,7 @@ function restoreCsiSplitUrlSchemes(value: string): string {
 
     let output = "";
     let outputOffset = 0;
+    const restoredOutputIndexes: number[] = [];
     for (let matchIndex = 0; matchIndex < matches.length; matchIndex++) {
       const match = matches[matchIndex]!;
       output += stringSlice(value, outputOffset, match.inputIndex);
@@ -2448,11 +2449,15 @@ function restoreCsiSplitUrlSchemes(value: string): string {
         replacement = "";
       } else if (setHas(restoreMatches, matchIndex)) {
         replacement = stringSlice(match.matched, -1);
+        defineOwnArrayElement(restoredOutputIndexes, restoredOutputIndexes.length, output.length);
       }
       output += replacement;
       outputOffset = match.inputEnd;
     }
-    return output + stringSlice(value, outputOffset);
+    return redactRestoredCsiSchemeUrls(
+      output + stringSlice(value, outputOffset),
+      restoredOutputIndexes,
+    );
   } finally {
     ANSI_CSI_SEQUENCE.lastIndex = 0;
   }
@@ -2932,7 +2937,7 @@ function matchCsiConsumedNonAsciiUrl(value: string): number {
 }
 
 function extendCsiConsumedUrlMatch(value: string, endIndex: number): number {
-  return rawUrlMatchEnd(value, stringSlice(value, 0, endIndex), endIndex);
+  return mixedSlashedUrlMatchEnd(value, stringSlice(value, 0, endIndex), endIndex);
 }
 
 function extendCsiConsumedFileMatch(value: string, endIndex: number): number {
@@ -3217,6 +3222,58 @@ function rawUrlMatchEnd(value: string, matched: string, offset: number): number 
     (ReflectApply(StringPrototypeIncludes, acceptedRemainder, ["/"]) as boolean) ||
     ReflectApply(RegExpPrototypeExec, RAW_ACCEPTED_URL_PAYLOAD, [acceptedRemainder]) !== null;
   return structurallyDelimited ? acceptedEnd : offset;
+}
+
+function mixedSlashedUrlMatchEnd(value: string, matched: string, offset: number): number {
+  if (ReflectApply(StringPrototypeIncludes, matched, ["/"]) as boolean) {
+    const iriEnd = stickyMatchEnd(RAW_IRI_REMAINDER, value, offset);
+    if (iriEnd !== offset) return iriEnd;
+  }
+  return rawUrlMatchEnd(value, matched, offset);
+}
+
+function restoredIndexFallsWithin(
+  restoredIndexes: readonly number[],
+  startIndex: number,
+  endIndex: number,
+): boolean {
+  for (let index = 0; index < restoredIndexes.length; index++) {
+    const restoredIndex = restoredIndexes[index]!;
+    if (restoredIndex >= startIndex && restoredIndex < endIndex) return true;
+  }
+  return false;
+}
+
+function redactRestoredCsiSchemeUrls(
+  value: string,
+  restoredIndexes: readonly number[],
+): string {
+  if (restoredIndexes.length === 0) return value;
+  SCHEME_URL.lastIndex = 0;
+  let output = "";
+  let outputOffset = 0;
+  try {
+    let match = ReflectApply(RegExpPrototypeExec, SCHEME_URL, [value]) as RegExpExecArray | null;
+    while (match !== null) {
+      const matchEnd = SCHEME_URL.lastIndex;
+      if (restoredIndexFallsWithin(restoredIndexes, match.index, matchEnd)) {
+        const endIndex = mixedSlashedUrlMatchEnd(value, match[0], matchEnd);
+        const scheme = ReflectApply(
+          StringPrototypeToLowerCase,
+          stringSlice(match[0], 0, 5),
+          [],
+        ) as string;
+        output += stringSlice(value, outputOffset, match.index) +
+          (scheme === "file:" ? "[path]" : "[url]");
+        outputOffset = endIndex;
+        SCHEME_URL.lastIndex = endIndex;
+      }
+      match = ReflectApply(RegExpPrototypeExec, SCHEME_URL, [value]) as RegExpExecArray | null;
+    }
+    return output + stringSlice(value, outputOffset);
+  } finally {
+    SCHEME_URL.lastIndex = 0;
+  }
 }
 
 const URL_BOUNDARY_PROSE_REMAINDER = /^(?:[A-Za-z0-9!(),;-]|(?!\s)\P{ASCII})+$/u;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2591,6 +2591,55 @@ interface CsiConsumedUrlPrefix {
   value: string;
 }
 
+function createCsiConsumedUrlPrefix(startIndex: number): CsiConsumedUrlPrefix {
+  return { startIndex, inputEnds: [], value: "" };
+}
+
+function advanceCsiConsumedSchemePrefix(
+  prefix: CsiConsumedUrlPrefix,
+  character: string,
+  index: number,
+  matchIndex: number,
+): CsiConsumedUrlPrefix {
+  if (
+    prefix.value === "" || stringEndsWith(prefix.value, ":") ||
+    prefix.value.length >= MAX_GENERIC_URL_SCHEME_LENGTH
+  ) {
+    const restarted = createCsiConsumedUrlPrefix(matchIndex);
+    const canStart = ReflectApply(RegExpPrototypeExec, GENERIC_URL_SCHEME_FIRST_CHARACTER, [
+      character,
+    ]) !== null;
+    if (!canStart) return restarted;
+    restarted.startIndex = index;
+    restarted.value = character;
+    defineOwnArrayElement(restarted.inputEnds, 0, index + 1);
+    return restarted;
+  }
+  prefix.value += character;
+  defineOwnArrayElement(prefix.inputEnds, prefix.inputEnds.length, index + 1);
+  return prefix;
+}
+
+function advanceCsiConsumedUrlPrefix(
+  prefix: CsiConsumedUrlPrefix,
+  character: string,
+  index: number,
+  matchIndex: number,
+): CsiConsumedUrlPrefix {
+  const isSchemeCharacter = ReflectApply(RegExpPrototypeExec, GENERIC_URL_SCHEME_CHARACTER, [
+    character,
+  ]) !== null;
+  if (isSchemeCharacter) {
+    return advanceCsiConsumedSchemePrefix(prefix, character, index, matchIndex);
+  }
+  if (character === ":" && prefix.value !== "" && !stringEndsWith(prefix.value, ":")) {
+    prefix.value += character;
+    defineOwnArrayElement(prefix.inputEnds, prefix.inputEnds.length, index + 1);
+    return prefix;
+  }
+  return createCsiConsumedUrlPrefix(matchIndex);
+}
+
 function csiConsumedUrlPrefix(
   value: string,
   matchIndex: number,
@@ -2598,9 +2647,7 @@ function csiConsumedUrlPrefix(
   const windowStart = matchIndex > MAX_CSI_CONSUMED_URL_LOOKAHEAD
     ? matchIndex - MAX_CSI_CONSUMED_URL_LOOKAHEAD
     : 0;
-  let startIndex = matchIndex;
-  let inputEnds: number[] = [];
-  let prefix = "";
+  let prefix = createCsiConsumedUrlPrefix(matchIndex);
   let index = windowStart;
   while (index < matchIndex) {
     const sequenceEnd = completeCsiSequenceEndAtIndex(value, index, matchIndex);
@@ -2610,35 +2657,10 @@ function csiConsumedUrlPrefix(
     }
 
     const character = stringSlice(value, index, index + 1);
-    const isSchemeCharacter = ReflectApply(RegExpPrototypeExec, GENERIC_URL_SCHEME_CHARACTER, [
-      character,
-    ]) !== null;
-    if (isSchemeCharacter) {
-      const canStart = ReflectApply(RegExpPrototypeExec, GENERIC_URL_SCHEME_FIRST_CHARACTER, [
-        character,
-      ]) !== null;
-      if (
-        prefix === "" || stringEndsWith(prefix, ":") ||
-        prefix.length >= MAX_GENERIC_URL_SCHEME_LENGTH
-      ) {
-        prefix = canStart ? character : "";
-        startIndex = canStart ? index : matchIndex;
-        inputEnds = [];
-      } else {
-        prefix += character;
-      }
-      if (prefix !== "") defineOwnArrayElement(inputEnds, inputEnds.length, index + 1);
-    } else if (character === ":" && prefix !== "" && !stringEndsWith(prefix, ":")) {
-      prefix += character;
-      defineOwnArrayElement(inputEnds, inputEnds.length, index + 1);
-    } else {
-      prefix = "";
-      startIndex = matchIndex;
-      inputEnds = [];
-    }
+    prefix = advanceCsiConsumedUrlPrefix(prefix, character, index, matchIndex);
     index += 1;
   }
-  return prefix === "" ? undefined : { startIndex, inputEnds, value: prefix };
+  return prefix.value === "" ? undefined : prefix;
 }
 
 function matchPatternAtStart(

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1921,14 +1921,111 @@ const CSI_SPLITTABLE_URL_SCHEMES = freezeObject([
   "ftp",
   "file",
 ]) as readonly string[];
-const CSI_SPLITTABLE_URL_SCHEME_LOOKAROUND = (() => {
-  let longest = 0;
-  for (let index = 0; index < CSI_SPLITTABLE_URL_SCHEMES.length; index++) {
-    const length = CSI_SPLITTABLE_URL_SCHEMES[index]!.length;
-    if (length > longest) longest = length;
+
+interface CsiSchemeMatch {
+  matched: string;
+  inputIndex: number;
+  inputEnd: number;
+}
+
+type CsiSchemeStates = Array<Array<readonly number[] | undefined>>;
+
+function appendCsiSchemeMatch(path: readonly number[], matchIndex: number): readonly number[] {
+  const appended: number[] = [];
+  for (let index = 0; index < path.length; index++) appended[index] = path[index]!;
+  appended[path.length] = matchIndex;
+  return appended;
+}
+
+function keepShorterCsiSchemePath(
+  current: readonly number[] | undefined,
+  candidate: readonly number[],
+): readonly number[] {
+  return current === undefined || candidate.length < current.length ? candidate : current;
+}
+
+function createCsiSchemeStates(): CsiSchemeStates {
+  const states: CsiSchemeStates = [];
+  for (let index = 0; index < CSI_SPLITTABLE_URL_SCHEMES.length; index++) states[index] = [];
+  return states;
+}
+
+function markCompletedCsiSchemes(states: CsiSchemeStates, restoreMatches: boolean[]): void {
+  for (let schemeIndex = 0; schemeIndex < CSI_SPLITTABLE_URL_SCHEMES.length; schemeIndex++) {
+    const scheme = CSI_SPLITTABLE_URL_SCHEMES[schemeIndex]!;
+    const path = states[schemeIndex]?.[scheme.length];
+    if (path === undefined) continue;
+    for (let pathIndex = 0; pathIndex < path.length; pathIndex++) {
+      restoreMatches[path[pathIndex]!] = true;
+    }
   }
-  return longest;
-})();
+}
+
+function advanceCsiSchemeLiteral(
+  states: CsiSchemeStates,
+  value: string,
+  restoreMatches: boolean[],
+): CsiSchemeStates {
+  if (value === ":") {
+    markCompletedCsiSchemes(states, restoreMatches);
+    return createCsiSchemeStates();
+  }
+
+  const next = createCsiSchemeStates();
+  for (let schemeIndex = 0; schemeIndex < CSI_SPLITTABLE_URL_SCHEMES.length; schemeIndex++) {
+    const scheme = CSI_SPLITTABLE_URL_SCHEMES[schemeIndex]!;
+    const current = states[schemeIndex]!;
+    const advanced = next[schemeIndex]!;
+    for (let characterIndex = 1; characterIndex < scheme.length; characterIndex++) {
+      const path = current[characterIndex];
+      if (
+        path !== undefined &&
+        stringSlice(scheme, characterIndex, characterIndex + 1) === value
+      ) {
+        advanced[characterIndex + 1] = keepShorterCsiSchemePath(
+          advanced[characterIndex + 1],
+          path,
+        );
+      }
+    }
+    if (stringSlice(scheme, 0, 1) === value) {
+      advanced[1] = keepShorterCsiSchemePath(advanced[1], []);
+    }
+  }
+  return next;
+}
+
+function advanceCsiSchemeSequence(
+  states: CsiSchemeStates,
+  value: string,
+  matchIndex: number,
+): CsiSchemeStates {
+  const next = createCsiSchemeStates();
+  for (let schemeIndex = 0; schemeIndex < CSI_SPLITTABLE_URL_SCHEMES.length; schemeIndex++) {
+    const scheme = CSI_SPLITTABLE_URL_SCHEMES[schemeIndex]!;
+    const current = states[schemeIndex]!;
+    const advanced = next[schemeIndex]!;
+    for (let characterIndex = 1; characterIndex <= scheme.length; characterIndex++) {
+      const path = current[characterIndex];
+      if (path === undefined) continue;
+      advanced[characterIndex] = keepShorterCsiSchemePath(advanced[characterIndex], path);
+      if (
+        characterIndex < scheme.length &&
+        stringSlice(scheme, characterIndex, characterIndex + 1) === value
+      ) {
+        const restored = appendCsiSchemeMatch(path, matchIndex);
+        advanced[characterIndex + 1] = keepShorterCsiSchemePath(
+          advanced[characterIndex + 1],
+          restored,
+        );
+      }
+    }
+    if (stringSlice(scheme, 0, 1) === value) {
+      advanced[1] = keepShorterCsiSchemePath(advanced[1], [matchIndex]);
+    }
+  }
+  return next;
+}
 
 /**
  * Restore a URL-scheme character consumed as a CSI final byte.
@@ -1947,13 +2044,9 @@ const CSI_SPLITTABLE_URL_SCHEME_LOOKAROUND = (() => {
 function restoreCsiSplitUrlSchemes(value: string): string {
   ANSI_CSI_SEQUENCE.lastIndex = 0;
   try {
-    const matches: Array<{
-      matched: string;
-      inputIndex: number;
-      inputEnd: number;
-      candidateIndex: number;
-    }> = [];
-    let candidate = "";
+    const matches: CsiSchemeMatch[] = [];
+    const restoreMatches: boolean[] = [];
+    let states = createCsiSchemeStates();
     let inputOffset = 0;
     while (true) {
       const match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE, [value]) as
@@ -1962,66 +2055,46 @@ function restoreCsiSplitUrlSchemes(value: string): string {
       if (match === null) break;
 
       const matched = match[0];
-      candidate += stringSlice(value, inputOffset, match.index);
-      const candidateIndex = candidate.length;
-      candidate += stringSlice(matched, -1);
-      matches[matches.length] = {
+      for (let index = inputOffset; index < match.index; index++) {
+        const literal = ReflectApply(
+          StringPrototypeToLowerCase,
+          stringSlice(value, index, index + 1),
+          [],
+        ) as string;
+        states = advanceCsiSchemeLiteral(states, literal, restoreMatches);
+      }
+      const finalByte = ReflectApply(
+        StringPrototypeToLowerCase,
+        stringSlice(matched, -1),
+        [],
+      ) as string;
+      const matchIndex = matches.length;
+      matches[matchIndex] = {
         matched,
         inputIndex: match.index,
         inputEnd: ANSI_CSI_SEQUENCE.lastIndex,
-        candidateIndex,
       };
+      states = advanceCsiSchemeSequence(states, finalByte, matchIndex);
       inputOffset = ANSI_CSI_SEQUENCE.lastIndex;
     }
-    candidate += stringSlice(value, inputOffset);
+
+    for (let index = inputOffset; index < value.length; index++) {
+      const literal = ReflectApply(
+        StringPrototypeToLowerCase,
+        stringSlice(value, index, index + 1),
+        [],
+      ) as string;
+      states = advanceCsiSchemeLiteral(states, literal, restoreMatches);
+    }
 
     let output = "";
     let outputOffset = 0;
     for (let matchIndex = 0; matchIndex < matches.length; matchIndex++) {
       const match = matches[matchIndex]!;
-      const finalByte = ReflectApply(
-        StringPrototypeToLowerCase,
-        stringSlice(match.matched, -1),
-        [],
-      ) as string;
-      const prefixStart = match.candidateIndex > CSI_SPLITTABLE_URL_SCHEME_LOOKAROUND
-        ? match.candidateIndex - CSI_SPLITTABLE_URL_SCHEME_LOOKAROUND
-        : 0;
-      const preceding = ReflectApply(
-        StringPrototypeToLowerCase,
-        stringSlice(candidate, prefixStart, match.candidateIndex),
-        [],
-      ) as string;
-      const following = ReflectApply(
-        StringPrototypeToLowerCase,
-        stringSlice(
-          candidate,
-          match.candidateIndex + 1,
-          match.candidateIndex + 1 + CSI_SPLITTABLE_URL_SCHEME_LOOKAROUND,
-        ),
-        [],
-      ) as string;
-
-      let restoresScheme = false;
-      for (
-        let schemeIndex = 0;
-        schemeIndex < CSI_SPLITTABLE_URL_SCHEMES.length && !restoresScheme;
-        schemeIndex++
-      ) {
-        const scheme = CSI_SPLITTABLE_URL_SCHEMES[schemeIndex]!;
-        for (let splitIndex = 1; splitIndex < scheme.length; splitIndex++) {
-          if (stringSlice(scheme, splitIndex, splitIndex + 1) !== finalByte) continue;
-          const prefix = stringSlice(scheme, 0, splitIndex);
-          const suffix = `${stringSlice(scheme, splitIndex + 1)}:`;
-          if (stringEndsWith(preceding, prefix) && stringStartsWith(following, suffix)) {
-            restoresScheme = true;
-            break;
-          }
-        }
-      }
-
       output += stringSlice(value, outputOffset, match.inputIndex);
-      output += restoresScheme ? stringSlice(match.matched, -1) : match.matched;
+      output += restoreMatches[matchIndex] === true
+        ? stringSlice(match.matched, -1)
+        : match.matched;
       outputOffset = match.inputEnd;
     }
     return output + stringSlice(value, outputOffset);

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1930,6 +1930,25 @@ interface CsiSchemeMatch {
 
 type CsiSchemeStates = Array<Array<readonly number[] | undefined>>;
 
+interface CsiGenericSchemePath {
+  matches: readonly number[];
+  startIndex: number;
+}
+
+type CsiGenericSchemeStates = Array<CsiGenericSchemePath | undefined>;
+
+interface CsiRestorationStates {
+  special: CsiSchemeStates;
+  generic: CsiGenericSchemeStates;
+}
+
+type CsiUrlPayloadKind = "generic" | "special" | "none";
+
+const MAX_GENERIC_URL_SCHEME_LENGTH = 32;
+const GENERIC_URL_SCHEME_FIRST_CHARACTER = /[A-Za-z]/;
+const GENERIC_URL_SCHEME_CHARACTER = /[A-Za-z0-9+.-]/;
+const CSI_URL_PAYLOAD_CHARACTER = /[^\s"'\\]/u;
+
 function appendCsiSchemeMatch(path: readonly number[], matchIndex: number): readonly number[] {
   const appended: number[] = [];
   for (let index = 0; index < path.length; index++) appended[index] = path[index]!;
@@ -1944,37 +1963,154 @@ function keepShorterCsiSchemePath(
   return current === undefined || candidate.length < current.length ? candidate : current;
 }
 
-function createCsiSchemeStates(): CsiSchemeStates {
-  const states: CsiSchemeStates = [];
-  for (let index = 0; index < CSI_SPLITTABLE_URL_SCHEMES.length; index++) states[index] = [];
+function appendGenericCsiSchemeMatch(
+  path: CsiGenericSchemePath,
+  matchIndex: number,
+): CsiGenericSchemePath {
+  return {
+    matches: appendCsiSchemeMatch(path.matches, matchIndex),
+    startIndex: path.startIndex,
+  };
+}
+
+function keepPreferredGenericCsiPath(
+  current: CsiGenericSchemePath | undefined,
+  candidate: CsiGenericSchemePath,
+): CsiGenericSchemePath {
+  if (current === undefined || candidate.startIndex < current.startIndex) return candidate;
+  if (
+    candidate.startIndex === current.startIndex &&
+    candidate.matches.length < current.matches.length
+  ) {
+    return candidate;
+  }
+  return current;
+}
+
+function createDenseCsiPathStates(length: number): Array<readonly number[] | undefined> {
+  const states: Array<readonly number[] | undefined> = [];
+  for (let index = 0; index <= length; index++) states[index] = undefined;
   return states;
 }
 
-function markCompletedCsiSchemes(states: CsiSchemeStates, restoreMatches: boolean[]): void {
+function createDenseGenericCsiStates(): CsiGenericSchemeStates {
+  const states: CsiGenericSchemeStates = [];
+  for (let index = 0; index <= MAX_GENERIC_URL_SCHEME_LENGTH; index++) {
+    states[index] = undefined;
+  }
+  return states;
+}
+
+function createCsiSchemeStates(): CsiSchemeStates {
+  const states: CsiSchemeStates = [];
+  for (let index = 0; index < CSI_SPLITTABLE_URL_SCHEMES.length; index++) {
+    states[index] = createDenseCsiPathStates(CSI_SPLITTABLE_URL_SCHEMES[index]!.length);
+  }
+  return states;
+}
+
+function createCsiRestorationStates(): CsiRestorationStates {
+  return {
+    special: createCsiSchemeStates(),
+    generic: createDenseGenericCsiStates(),
+  };
+}
+
+function chooseCompletedSpecialCsiPath(states: CsiSchemeStates): readonly number[] | undefined {
+  let selected: readonly number[] | undefined;
   for (let schemeIndex = 0; schemeIndex < CSI_SPLITTABLE_URL_SCHEMES.length; schemeIndex++) {
     const scheme = CSI_SPLITTABLE_URL_SCHEMES[schemeIndex]!;
-    const path = states[schemeIndex]?.[scheme.length];
-    if (path === undefined) continue;
-    for (let pathIndex = 0; pathIndex < path.length; pathIndex++) { // NOSONAR: Avoid mutable iterator hooks.
-      restoreMatches[path[pathIndex]!] = true;
-    }
+    const path = states[schemeIndex]![scheme.length];
+    if (path !== undefined) selected = keepShorterCsiSchemePath(selected, path);
+  }
+  return selected;
+}
+
+function chooseCompletedGenericCsiPath(
+  states: CsiGenericSchemeStates,
+): CsiGenericSchemePath | undefined {
+  let selected: CsiGenericSchemePath | undefined;
+  for (let length = 2; length <= MAX_GENERIC_URL_SCHEME_LENGTH; length++) {
+    const path = states[length];
+    if (path !== undefined) selected = keepPreferredGenericCsiPath(selected, path);
+  }
+  return selected;
+}
+
+function markCsiSchemePath(path: readonly number[] | undefined, restoreMatches: Set<number>): void {
+  if (path === undefined) return;
+  for (let pathIndex = 0; pathIndex < path.length; pathIndex++) { // NOSONAR: Avoid mutable iterator hooks.
+    setAdd(restoreMatches, path[pathIndex]!);
   }
 }
 
-function advanceCsiSchemeLiteral(
-  states: CsiSchemeStates,
+function hasCsiUrlPayloadCharacter(value: string, index: number): boolean {
+  const character = stringSlice(value, index, index + 1);
+  return character !== "" &&
+    ReflectApply(RegExpPrototypeExec, CSI_URL_PAYLOAD_CHARACTER, [character]) !== null;
+}
+
+function classifyCsiUrlPayload(value: string, colonIndex: number): CsiUrlPayloadKind {
+  if (stringSlice(value, colonIndex + 1, colonIndex + 2) !== "/") {
+    return hasCsiUrlPayloadCharacter(value, colonIndex + 1) ? "special" : "none";
+  }
+  if (stringSlice(value, colonIndex + 2, colonIndex + 3) !== "/") {
+    return hasCsiUrlPayloadCharacter(value, colonIndex + 2) ? "special" : "none";
+  }
+  return hasCsiUrlPayloadCharacter(value, colonIndex + 3) ? "generic" : "none";
+}
+
+function advanceGenericCsiLiteral(
+  current: CsiGenericSchemeStates,
   value: string,
-  restoreMatches: boolean[],
-): CsiSchemeStates {
+  inputIndex: number,
+): CsiGenericSchemeStates {
+  const advanced = createDenseGenericCsiStates();
+  const isSchemeCharacter = ReflectApply(
+    RegExpPrototypeExec,
+    GENERIC_URL_SCHEME_CHARACTER,
+    [value],
+  ) !== null;
+  if (isSchemeCharacter) {
+    for (let length = 1; length < MAX_GENERIC_URL_SCHEME_LENGTH; length++) {
+      const path = current[length];
+      if (path !== undefined) {
+        advanced[length + 1] = keepPreferredGenericCsiPath(advanced[length + 1], path);
+      }
+    }
+  }
+  if (ReflectApply(RegExpPrototypeExec, GENERIC_URL_SCHEME_FIRST_CHARACTER, [value]) !== null) {
+    advanced[1] = keepPreferredGenericCsiPath(advanced[1], {
+      matches: [],
+      startIndex: inputIndex,
+    });
+  }
+  return advanced;
+}
+
+function advanceCsiSchemeLiteral(
+  states: CsiRestorationStates,
+  value: string,
+  input: string,
+  inputIndex: number,
+  restoreMatches: Set<number>,
+): CsiRestorationStates {
   if (value === ":") {
-    markCompletedCsiSchemes(states, restoreMatches);
-    return createCsiSchemeStates();
+    const payload = classifyCsiUrlPayload(input, inputIndex);
+    if (payload === "generic") {
+      const special = chooseCompletedSpecialCsiPath(states.special);
+      const path = special ?? chooseCompletedGenericCsiPath(states.generic)?.matches;
+      markCsiSchemePath(path, restoreMatches);
+    } else if (payload === "special") {
+      markCsiSchemePath(chooseCompletedSpecialCsiPath(states.special), restoreMatches);
+    }
+    return createCsiRestorationStates();
   }
 
   const next = createCsiSchemeStates();
   for (let schemeIndex = 0; schemeIndex < CSI_SPLITTABLE_URL_SCHEMES.length; schemeIndex++) {
     const scheme = CSI_SPLITTABLE_URL_SCHEMES[schemeIndex]!;
-    const current = states[schemeIndex]!;
+    const current = states.special[schemeIndex]!;
     const advanced = next[schemeIndex]!;
     for (let characterIndex = 1; characterIndex < scheme.length; characterIndex++) {
       const path = current[characterIndex];
@@ -1992,18 +2128,22 @@ function advanceCsiSchemeLiteral(
       advanced[1] = keepShorterCsiSchemePath(advanced[1], []);
     }
   }
-  return next;
+  return {
+    special: next,
+    generic: advanceGenericCsiLiteral(states.generic, value, inputIndex),
+  };
 }
 
 function advanceCsiSchemeSequence(
-  states: CsiSchemeStates,
+  states: CsiRestorationStates,
   value: string,
   matchIndex: number,
-): CsiSchemeStates {
+  inputIndex: number,
+): CsiRestorationStates {
   const next = createCsiSchemeStates();
   for (let schemeIndex = 0; schemeIndex < CSI_SPLITTABLE_URL_SCHEMES.length; schemeIndex++) {
     const scheme = CSI_SPLITTABLE_URL_SCHEMES[schemeIndex]!;
-    const current = states[schemeIndex]!;
+    const current = states.special[schemeIndex]!;
     const advanced = next[schemeIndex]!;
     for (let characterIndex = 1; characterIndex <= scheme.length; characterIndex++) {
       const path = current[characterIndex];
@@ -2024,7 +2164,29 @@ function advanceCsiSchemeSequence(
       advanced[1] = keepShorterCsiSchemePath(advanced[1], [matchIndex]);
     }
   }
-  return next;
+
+  const generic = createDenseGenericCsiStates();
+  const isSchemeCharacter = ReflectApply(
+    RegExpPrototypeExec,
+    GENERIC_URL_SCHEME_CHARACTER,
+    [value],
+  ) !== null;
+  for (let length = 1; length <= MAX_GENERIC_URL_SCHEME_LENGTH; length++) {
+    const path = states.generic[length];
+    if (path === undefined) continue;
+    generic[length] = keepPreferredGenericCsiPath(generic[length], path);
+    if (isSchemeCharacter && length < MAX_GENERIC_URL_SCHEME_LENGTH) {
+      const restored = appendGenericCsiSchemeMatch(path, matchIndex);
+      generic[length + 1] = keepPreferredGenericCsiPath(generic[length + 1], restored);
+    }
+  }
+  if (ReflectApply(RegExpPrototypeExec, GENERIC_URL_SCHEME_FIRST_CHARACTER, [value]) !== null) {
+    generic[1] = keepPreferredGenericCsiPath(generic[1], {
+      matches: [matchIndex],
+      startIndex: inputIndex,
+    });
+  }
+  return { special: next, generic };
 }
 
 /**
@@ -2044,16 +2206,16 @@ function advanceCsiSchemeSequence(
 function restoreCsiSplitUrlSchemes(value: string): string {
   ANSI_CSI_SEQUENCE.lastIndex = 0;
   try {
-    const matches: CsiSchemeMatch[] = [];
-    const restoreMatches: boolean[] = [];
-    let states = createCsiSchemeStates();
-    let inputOffset = 0;
-    while (true) {
-      const match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE, [value]) as
-        | RegExpExecArray
-        | null;
-      if (match === null) break;
+    let match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE, [value]) as
+      | RegExpExecArray
+      | null;
+    if (match === null) return value;
 
+    const matches: CsiSchemeMatch[] = [];
+    const restoreMatches = new IntrinsicSet<number>();
+    let states = createCsiRestorationStates();
+    let inputOffset = 0;
+    while (match !== null) {
       const matched = match[0];
       for (let index = inputOffset; index < match.index; index++) {
         const literal = ReflectApply(
@@ -2061,7 +2223,7 @@ function restoreCsiSplitUrlSchemes(value: string): string {
           stringSlice(value, index, index + 1),
           [],
         ) as string;
-        states = advanceCsiSchemeLiteral(states, literal, restoreMatches);
+        states = advanceCsiSchemeLiteral(states, literal, value, index, restoreMatches);
       }
       const finalByte = ReflectApply(
         StringPrototypeToLowerCase,
@@ -2074,8 +2236,11 @@ function restoreCsiSplitUrlSchemes(value: string): string {
         inputIndex: match.index,
         inputEnd: ANSI_CSI_SEQUENCE.lastIndex,
       };
-      states = advanceCsiSchemeSequence(states, finalByte, matchIndex);
+      states = advanceCsiSchemeSequence(states, finalByte, matchIndex, match.index);
       inputOffset = ANSI_CSI_SEQUENCE.lastIndex;
+      match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE, [value]) as
+        | RegExpExecArray
+        | null;
     }
 
     for (let index = inputOffset; index < value.length; index++) {
@@ -2084,7 +2249,7 @@ function restoreCsiSplitUrlSchemes(value: string): string {
         stringSlice(value, index, index + 1),
         [],
       ) as string;
-      states = advanceCsiSchemeLiteral(states, literal, restoreMatches);
+      states = advanceCsiSchemeLiteral(states, literal, value, index, restoreMatches);
     }
 
     let output = "";
@@ -2092,9 +2257,7 @@ function restoreCsiSplitUrlSchemes(value: string): string {
     for (let matchIndex = 0; matchIndex < matches.length; matchIndex++) {
       const match = matches[matchIndex]!;
       output += stringSlice(value, outputOffset, match.inputIndex);
-      output += restoreMatches[matchIndex] === true
-        ? stringSlice(match.matched, -1)
-        : match.matched;
+      output += setHas(restoreMatches, matchIndex) ? stringSlice(match.matched, -1) : match.matched;
       outputOffset = match.inputEnd;
     }
     return output + stringSlice(value, outputOffset);

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -3019,6 +3019,16 @@ function csiConsumedUrlStructure(matched: string): CsiConsumedUrlStructure | und
   return colon === -1 && slash === -1 ? undefined : { colon, slash };
 }
 
+function appendMappedCsiUrlFinal(
+  candidate: MappedCsiUrlCandidate,
+  input: string,
+  finalIndex: number,
+): void {
+  if (hasStickyMatchAtIndex(URL_TOKEN_TAIL_AT_INDEX, input, finalIndex)) {
+    appendMappedInputRange(candidate, input, finalIndex, finalIndex + 1);
+  }
+}
+
 function appendMappedCsiUrlStructure(
   candidate: MappedCsiUrlCandidate,
   input: string,
@@ -3033,21 +3043,25 @@ function appendMappedCsiUrlStructure(
       appendMappedInputRange(candidate, input, inputStart + colon, inputStart + colon + 1);
     }
     if (slash !== -1) {
+      const finalIndex = inputStart + matched.length - 1;
       appendMappedInputRange(
         candidate,
         input,
         inputStart + slash,
-        inputStart + matched.length,
+        finalIndex,
       );
+      appendMappedCsiUrlFinal(candidate, input, finalIndex);
     }
     return true;
   }
+  const finalIndex = inputStart + matched.length - 1;
   appendMappedInputRange(
     candidate,
     input,
     inputStart + slash,
-    inputStart + matched.length,
+    finalIndex,
   );
+  appendMappedCsiUrlFinal(candidate, input, finalIndex);
   return true;
 }
 

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1950,9 +1950,8 @@ type CsiUrlPayloadKind = "generic" | "special" | "none";
 
 const MAX_GENERIC_URL_SCHEME_LENGTH = 32;
 const MAX_CSI_LITERAL_GAP = MAX_GENERIC_URL_SCHEME_LENGTH * 2;
-const GENERIC_URL_SCHEME_FIRST_CHARACTER = /[A-Za-z]/;
-const GENERIC_URL_SCHEME_CHARACTER = /[A-Za-z0-9+.-]/;
-const CSI_URL_PAYLOAD_CHARACTER = /[^\s"'\\]/u;
+const GENERIC_URL_SCHEME_FIRST_CHARACTER = /^[A-Za-z]$/;
+const GENERIC_URL_SCHEME_CHARACTER = /^[A-Za-z0-9+.-]$/;
 
 function appendCsiSchemeMatch(path: readonly number[], matchIndex: number): readonly number[] {
   const appended: number[] = [];
@@ -2080,21 +2079,63 @@ function skipCompleteCsiSequences(value: string, index: number): number {
   }
 }
 
-function hasCsiUrlPayloadCharacter(value: string, index: number): boolean {
+function hasRedactableCsiUrlPayload(value: string, index: number): boolean {
   const payloadIndex = skipCompleteCsiSequences(value, index);
-  const character = stringSlice(value, payloadIndex, payloadIndex + 1);
-  return character !== "" &&
-    ReflectApply(RegExpPrototypeExec, CSI_URL_PAYLOAD_CHARACTER, [character]) !== null;
+  URL_TOKEN_TAIL_AT_INDEX.lastIndex = payloadIndex;
+  try {
+    return ReflectApply(RegExpPrototypeExec, URL_TOKEN_TAIL_AT_INDEX, [value]) !== null;
+  } finally {
+    URL_TOKEN_TAIL_AT_INDEX.lastIndex = 0;
+  }
 }
 
-function classifyCsiUrlPayload(value: string, colonIndex: number): CsiUrlPayloadKind {
-  if (stringSlice(value, colonIndex + 1, colonIndex + 2) !== "/") {
-    return hasCsiUrlPayloadCharacter(value, colonIndex + 1) ? "special" : "none";
+function markCompleteCsiSequenceStarts(
+  value: string,
+  startIndex: number,
+  endIndex: number,
+  stripSequenceStarts: Set<number>,
+): void {
+  while (startIndex < endIndex) {
+    const nextIndex = skipCompleteCsiSequences(value, startIndex);
+    if (nextIndex === startIndex) {
+      startIndex += 1;
+      continue;
+    }
+    setAdd(stripSequenceStarts, startIndex);
+    startIndex = nextIndex;
   }
-  if (stringSlice(value, colonIndex + 2, colonIndex + 3) !== "/") {
-    return hasCsiUrlPayloadCharacter(value, colonIndex + 2) ? "special" : "none";
+}
+
+function classifyCsiUrlPayload(
+  value: string,
+  colonIndex: number,
+  stripSequenceStarts: Set<number>,
+): CsiUrlPayloadKind {
+  const firstSlashIndex = skipCompleteCsiSequences(value, colonIndex + 1);
+  let payloadIndex: number;
+  let payload: CsiUrlPayloadKind;
+  if (stringSlice(value, firstSlashIndex, firstSlashIndex + 1) !== "/") {
+    payloadIndex = firstSlashIndex;
+    payload = hasRedactableCsiUrlPayload(value, payloadIndex) ? "special" : "none";
+  } else {
+    const secondSlashIndex = skipCompleteCsiSequences(value, firstSlashIndex + 1);
+    if (stringSlice(value, secondSlashIndex, secondSlashIndex + 1) !== "/") {
+      payloadIndex = secondSlashIndex;
+      payload = hasRedactableCsiUrlPayload(value, payloadIndex) ? "special" : "none";
+    } else {
+      payloadIndex = skipCompleteCsiSequences(value, secondSlashIndex + 1);
+      payload = hasRedactableCsiUrlPayload(value, payloadIndex) ? "generic" : "none";
+    }
   }
-  return hasCsiUrlPayloadCharacter(value, colonIndex + 3) ? "generic" : "none";
+  if (payload !== "none") {
+    markCompleteCsiSequenceStarts(
+      value,
+      colonIndex + 1,
+      payloadIndex,
+      stripSequenceStarts,
+    );
+  }
+  return payload;
 }
 
 function advanceGenericCsiLiteral(
@@ -2131,9 +2172,10 @@ function advanceCsiSchemeLiteral(
   input: string,
   inputIndex: number,
   restoreMatches: Set<number>,
+  stripSequenceStarts: Set<number>,
 ): CsiRestorationStates {
   if (value === ":") {
-    const payload = classifyCsiUrlPayload(input, inputIndex);
+    const payload = classifyCsiUrlPayload(input, inputIndex, stripSequenceStarts);
     if (payload === "generic") {
       const special = chooseCompletedSpecialCsiPath(states.special);
       const path = special ?? chooseCompletedGenericCsiPath(states.generic)?.matches;
@@ -2240,6 +2282,7 @@ function advanceCsiLiteralRange(
   startIndex: number,
   endIndex: number,
   restoreMatches: Set<number>,
+  stripSequenceStarts: Set<number>,
 ): CsiRestorationStates {
   for (let index = startIndex; index < endIndex; index++) {
     const literal = ReflectApply(
@@ -2247,7 +2290,14 @@ function advanceCsiLiteralRange(
       stringSlice(value, index, index + 1),
       [],
     ) as string;
-    states = advanceCsiSchemeLiteral(states, literal, value, index, restoreMatches);
+    states = advanceCsiSchemeLiteral(
+      states,
+      literal,
+      value,
+      index,
+      restoreMatches,
+      stripSequenceStarts,
+    );
   }
   return states;
 }
@@ -2276,6 +2326,7 @@ function restoreCsiSplitUrlSchemes(value: string): string {
 
     const matches: CsiSchemeMatch[] = [];
     const restoreMatches = new IntrinsicSet<number>();
+    const stripSequenceStarts = new IntrinsicSet<number>();
     let states = createCsiRestorationStates();
     let inputOffset = 0;
     while (match !== null) {
@@ -2283,12 +2334,13 @@ function restoreCsiSplitUrlSchemes(value: string): string {
       const gapLength = match.index - inputOffset;
       if (gapLength > MAX_CSI_LITERAL_GAP) {
         if (matches.length > 0) {
-          states = advanceCsiLiteralRange(
+          advanceCsiLiteralRange(
             states,
             value,
             inputOffset,
             inputOffset + MAX_GENERIC_URL_SCHEME_LENGTH,
             restoreMatches,
+            stripSequenceStarts,
           );
         }
         states = createCsiRestorationStates();
@@ -2298,6 +2350,7 @@ function restoreCsiSplitUrlSchemes(value: string): string {
           match.index - MAX_GENERIC_URL_SCHEME_LENGTH,
           match.index,
           restoreMatches,
+          stripSequenceStarts,
         );
       } else {
         states = advanceCsiLiteralRange(
@@ -2306,6 +2359,7 @@ function restoreCsiSplitUrlSchemes(value: string): string {
           inputOffset,
           match.index,
           restoreMatches,
+          stripSequenceStarts,
         );
       }
       const finalByte = ReflectApply(
@@ -2329,14 +2383,25 @@ function restoreCsiSplitUrlSchemes(value: string): string {
     const tailWindowEnd = inputOffset + MAX_GENERIC_URL_SCHEME_LENGTH < value.length
       ? inputOffset + MAX_GENERIC_URL_SCHEME_LENGTH
       : value.length;
-    advanceCsiLiteralRange(states, value, inputOffset, tailWindowEnd, restoreMatches);
+    advanceCsiLiteralRange(
+      states,
+      value,
+      inputOffset,
+      tailWindowEnd,
+      restoreMatches,
+      stripSequenceStarts,
+    );
 
     let output = "";
     let outputOffset = 0;
     for (let matchIndex = 0; matchIndex < matches.length; matchIndex++) {
       const match = matches[matchIndex]!;
       output += stringSlice(value, outputOffset, match.inputIndex);
-      output += setHas(restoreMatches, matchIndex) ? stringSlice(match.matched, -1) : match.matched;
+      output += setHas(stripSequenceStarts, match.inputIndex)
+        ? ""
+        : setHas(restoreMatches, matchIndex)
+        ? stringSlice(match.matched, -1)
+        : match.matched;
       outputOffset = match.inputEnd;
     }
     return output + stringSlice(value, outputOffset);
@@ -2363,6 +2428,7 @@ const URI_PAREN_INTERIOR_SOURCE = String.raw`[A-Za-z0-9\-._~:/?#\[\]@!$&()*+,;=%
 const URL_BALANCED_PAREN_SEGMENT_SOURCE = String.raw`\([^\s"']{0,512}\)`;
 const URL_TOKEN_TAIL_SOURCE = String
   .raw`(?:${URI_TOKEN_CHARACTER_SOURCE}|${URL_BALANCED_PAREN_SEGMENT_SOURCE}|\((?=(?:${URI_PAREN_INTERIOR_SOURCE}|\P{ASCII}))|\)(?=${URI_PAREN_INTERIOR_SOURCE})(?![\p{P}\p{S}\p{M}\p{Cf}]{0,16}(?:[\s"']|$)))+`;
+const URL_TOKEN_TAIL_AT_INDEX = new RegExp(URL_TOKEN_TAIL_SOURCE, "uy");
 // Require a bounded, multi-character scheme so drive-letter paths remain paths.
 const SCHEME_URL = new RegExp(
   String.raw`[A-Za-z][A-Za-z0-9+.-]{1,31}://(?:[^\s"/]{0,512}@)?${URL_TOKEN_TAIL_SOURCE}`,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2586,32 +2586,61 @@ function matchPatternAtStart(pattern: RegExp, value: string): number {
   }
 }
 
-function matchCsiConsumedUrlCandidate(value: string): {
-  endIndex: number;
-  marker: "[path]" | "[url]";
-} | undefined {
-  let endIndex = matchPatternAtStart(FILE_URL_ABSOLUTE_PATH, value);
-  if (endIndex === 0 && containsNonAscii(value)) {
-    endIndex = matchPatternAtStart(NON_ASCII_FILE_URL_PATH, value);
-  }
-  if (endIndex !== 0) return { endIndex, marker: "[path]" };
+function matchCsiConsumedAsciiUrl(value: string): number {
+  return matchPatternAtStart(SCHEME_URL, value) ||
+    matchPatternAtStart(MALFORMED_SCHEME_URL, value) ||
+    matchPatternAtStart(ZERO_SLASH_SCHEME_URL, value);
+}
 
-  endIndex = matchPatternAtStart(SCHEME_URL, value);
-  if (endIndex === 0) endIndex = matchPatternAtStart(MALFORMED_SCHEME_URL, value);
-  if (endIndex === 0) endIndex = matchPatternAtStart(ZERO_SLASH_SCHEME_URL, value);
-  if (endIndex === 0 && containsNonAscii(value)) {
-    endIndex = matchPatternAtStart(NON_ASCII_AUTHORITY_URL, value);
-    if (endIndex === 0) endIndex = matchPatternAtStart(NON_ASCII_URL_PATH, value);
-    if (endIndex === 0) {
-      endIndex = matchPatternAtStart(NON_ASCII_MALFORMED_AUTHORITY_URL, value);
+function matchCsiConsumedNonAsciiUrl(value: string): number {
+  return matchPatternAtStart(NON_ASCII_AUTHORITY_URL, value) ||
+    matchPatternAtStart(NON_ASCII_URL_PATH, value) ||
+    matchPatternAtStart(NON_ASCII_MALFORMED_AUTHORITY_URL, value) ||
+    matchPatternAtStart(NON_ASCII_MALFORMED_URL_PATH, value) ||
+    matchPatternAtStart(NON_ASCII_ZERO_SLASH_AUTHORITY_URL, value) ||
+    matchPatternAtStart(NON_ASCII_ZERO_SLASH_URL_PATH, value);
+}
+
+function matchCsiConsumedUrlCandidate(value: string): CsiConsumedUrlRedaction | undefined {
+  const hasNonAscii = containsNonAscii(value);
+  const fileEndIndex = matchPatternAtStart(FILE_URL_ABSOLUTE_PATH, value) ||
+    (hasNonAscii ? matchPatternAtStart(NON_ASCII_FILE_URL_PATH, value) : 0);
+  if (fileEndIndex !== 0) return { endIndex: fileEndIndex, marker: "[path]" };
+
+  const urlEndIndex = matchCsiConsumedAsciiUrl(value) ||
+    (hasNonAscii ? matchCsiConsumedNonAsciiUrl(value) : 0);
+  return urlEndIndex === 0 ? undefined : { endIndex: urlEndIndex, marker: "[url]" };
+}
+
+interface CsiConsumedUrlSpan extends CsiConsumedUrlRedaction {
+  startIndex: number;
+}
+
+function csiConsumedUrlSpan(
+  value: string,
+  match: RegExpExecArray,
+  matchEnd: number,
+  literalStart: number,
+  outputOffset: number,
+): CsiConsumedUrlSpan | undefined {
+  if (match.index < outputOffset) return undefined;
+  const prefixStart = csiConsumedUrlPrefixStart(value, match.index, literalStart);
+  if (prefixStart === undefined) return undefined;
+
+  const matched = match[0];
+  const introducerLength = stringSlice(matched, 0, 1) === "\u001B" ? 2 : 1;
+  const lookaheadEnd = MathMin(value.length, matchEnd + MAX_CSI_CONSUMED_URL_LOOKAHEAD);
+  const prefix = stringSlice(value, prefixStart, match.index);
+  const candidate = prefix + stringSlice(matched, introducerLength) +
+    stringSlice(value, matchEnd, lookaheadEnd);
+  const redaction = matchCsiConsumedUrlCandidate(candidate);
+  return redaction
+    ? {
+      startIndex: prefixStart,
+      endIndex: prefixStart + redaction.endIndex + introducerLength,
+      marker: redaction.marker,
     }
-    if (endIndex === 0) endIndex = matchPatternAtStart(NON_ASCII_MALFORMED_URL_PATH, value);
-    if (endIndex === 0) {
-      endIndex = matchPatternAtStart(NON_ASCII_ZERO_SLASH_AUTHORITY_URL, value);
-    }
-    if (endIndex === 0) endIndex = matchPatternAtStart(NON_ASCII_ZERO_SLASH_URL_PATH, value);
-  }
-  return endIndex === 0 ? undefined : { endIndex, marker: "[url]" };
+    : undefined;
 }
 
 function redactCsiConsumedUrls(value: string): string {
@@ -2628,27 +2657,12 @@ function redactCsiConsumedUrls(value: string): string {
       const matchEnd = ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex;
       matchCount += 1;
       if (matchCount > MAX_CSI_RECONSTRUCTION_MATCHES) return "[REDACTED]";
-      if (match.index >= outputOffset) {
-        const prefixStart = csiConsumedUrlPrefixStart(value, match.index, literalStart);
-        if (prefixStart !== undefined) {
-          const matched = match[0];
-          const introducerLength = stringSlice(matched, 0, 1) === "\u001B" ? 2 : 1;
-          const lookaheadEnd = MathMin(
-            value.length,
-            matchEnd + MAX_CSI_CONSUMED_URL_LOOKAHEAD,
-          );
-          const prefix = stringSlice(value, prefixStart, match.index);
-          const candidate = prefix + stringSlice(matched, introducerLength) +
-            stringSlice(value, matchEnd, lookaheadEnd);
-          const redaction = matchCsiConsumedUrlCandidate(candidate);
-          if (redaction) {
-            const endIndex = prefixStart + redaction.endIndex + introducerLength;
-            output += stringSlice(value, outputOffset, prefixStart) + redaction.marker;
-            outputOffset = endIndex;
-            ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex = endIndex;
-            literalStart = endIndex;
-          }
-        }
+      const span = csiConsumedUrlSpan(value, match, matchEnd, literalStart, outputOffset);
+      if (span) {
+        output += stringSlice(value, outputOffset, span.startIndex) + span.marker;
+        outputOffset = span.endIndex;
+        ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex = span.endIndex;
+        literalStart = span.endIndex;
       }
       if (literalStart < matchEnd) literalStart = matchEnd;
       match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_FOR_URL_REDACTION, [value]) as

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2597,7 +2597,7 @@ type CsiConsumedSpecialPrefixStates = Array<
 >;
 type CsiConsumedGenericPrefixStates = Array<CsiConsumedUrlPrefix | undefined>;
 
-const STRONG_CSI_CONSUMED_URL_PAYLOAD = /[.\/@?#\\[\]:]/u;
+const STRONG_CSI_CONSUMED_URL_PAYLOAD_CHARACTERS = "./@?#\\[]:";
 
 function createCsiConsumedSpecialPrefixStates(): CsiConsumedSpecialPrefixStates {
   const states: CsiConsumedSpecialPrefixStates = [];
@@ -3008,8 +3008,11 @@ function hasStrongCsiConsumedUrlPayload(value: string): boolean {
   const colon = stringIndexOf(value, ":");
   if (colon === -1) return false;
   const payload = stringSlice(value, colon + 1);
-  return containsNonAscii(payload) ||
-    ReflectApply(RegExpPrototypeExec, STRONG_CSI_CONSUMED_URL_PAYLOAD, [payload]) !== null;
+  if (containsNonAscii(payload)) return true;
+  for (let index = 0; index < payload.length; index++) {
+    if (stringIncludes(STRONG_CSI_CONSUMED_URL_PAYLOAD_CHARACTERS, payload[index]!)) return true;
+  }
+  return false;
 }
 
 function appendMappedCsiUrlTail(

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1965,6 +1965,7 @@ const MAX_GENERIC_URL_SCHEME_LENGTH = 32;
 const MAX_CSI_LITERAL_GAP = MAX_GENERIC_URL_SCHEME_LENGTH * 2;
 const MAX_CSI_RECONSTRUCTION_MATCHES = 64;
 const MAX_CSI_CONSUMED_URL_LOOKAHEAD = 4096;
+const MAX_CSI_PREFIX_RECONSTRUCTION_CHARACTERS = MAX_CSI_CONSUMED_URL_LOOKAHEAD * 2;
 const GENERIC_URL_SCHEME_FIRST_CHARACTER = /^[A-Za-z]$/;
 const GENERIC_URL_SCHEME_CHARACTER = /^[A-Za-z0-9+.-]$/;
 
@@ -2057,11 +2058,18 @@ function chooseCompletedSpecialCsiPath(
   allowFile: boolean,
 ): readonly number[] | undefined {
   let selected: readonly number[] | undefined;
+  let selectedSchemeLength = 0;
   for (let schemeIndex = 0; schemeIndex < CSI_SPLITTABLE_URL_SCHEMES.length; schemeIndex++) {
     const scheme = CSI_SPLITTABLE_URL_SCHEMES[schemeIndex]!;
     if (!allowFile && scheme === "file") continue;
     const path = states[schemeIndex]![scheme.length];
-    if (path !== undefined) selected = keepShorterCsiSchemePath(selected, path);
+    if (path === undefined) continue;
+    if (scheme.length > selectedSchemeLength) {
+      selected = path;
+      selectedSchemeLength = scheme.length;
+    } else if (scheme.length === selectedSchemeLength) {
+      selected = keepShorterCsiSchemePath(selected, path);
+    }
   }
   return selected;
 }
@@ -3098,6 +3106,7 @@ function csiConsumedUrlSpan(
 function exceedsCsiReconstructionLimit(value: string): boolean {
   ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex = 0;
   let matchCount = 0;
+  let prefixReconstructionCharacters = 0;
   try {
     let match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_FOR_URL_REDACTION, [value]) as
       | RegExpExecArray
@@ -3108,6 +3117,15 @@ function exceedsCsiReconstructionLimit(value: string): boolean {
         matchCount > MAX_CSI_RECONSTRUCTION_MATCHES ||
         match[0].length > MAX_CSI_CONSUMED_URL_LOOKAHEAD
       ) return true;
+      if (csiConsumedUrlStructure(match[0]) !== undefined) {
+        prefixReconstructionCharacters += MathMin(
+          match.index,
+          MAX_CSI_CONSUMED_URL_LOOKAHEAD,
+        );
+        if (prefixReconstructionCharacters > MAX_CSI_PREFIX_RECONSTRUCTION_CHARACTERS) {
+          return true;
+        }
+      }
       match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_FOR_URL_REDACTION, [value]) as
         | RegExpExecArray
         | null;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2138,7 +2138,7 @@ function markCompleteCsiSequenceStarts(
   stripSequenceStarts: Set<number>,
 ): void {
   while (startIndex < endIndex) {
-    const nextIndex = skipCompleteCsiSequences(value, startIndex);
+    const nextIndex = completeCsiSequenceEndAtIndex(value, startIndex);
     if (nextIndex === startIndex) {
       startIndex += 1;
       continue;
@@ -2569,6 +2569,16 @@ const NON_ASCII_ZERO_SLASH_URL_PATH = new RegExp(
     .raw`${ASCII_SPECIAL_SCHEME_SOURCE}:(?![/\s])(?:[^\s"/]{0,512}@)?[^\s"/]{1,512}(?:/${URI_TOKEN_CHARACTER_SOURCE}{0,2048})?/(?=[^\x00-\x7F])[^\s"']*`,
   "gu",
 );
+const NON_ASCII_CSI_CONSUMED_ZERO_SLASH_AUTHORITY_URL = new RegExp(
+  String
+    .raw`[A-Za-z][A-Za-z0-9+.-]{1,31}:(?![/\s])(?:[^\s"/]{0,512}@)?${NON_ASCII_HOST_SOURCE}(?:${URL_TOKEN_TAIL_SOURCE})?`,
+  "gu",
+);
+const NON_ASCII_CSI_CONSUMED_ZERO_SLASH_URL_PATH = new RegExp(
+  String
+    .raw`[A-Za-z][A-Za-z0-9+.-]{1,31}:(?![/\s])(?:[^\s"/]{0,512}@)?[^\s"/]{1,512}(?:/${URI_TOKEN_CHARACTER_SOURCE}{0,2048})?/(?=[^\x00-\x7F])[^\s"']*`,
+  "gu",
+);
 const NON_ASCII_AUTHORITY_PAYLOAD_AT_INDEX = new RegExp(
   String.raw`(?:[^\s"/]{0,512}@)?${NON_ASCII_HOST_SOURCE}(?:${URL_TOKEN_TAIL_SOURCE})?`,
   "uy",
@@ -2933,6 +2943,14 @@ function matchCsiConsumedNonAsciiUrl(value: string): number {
   if (candidate > longest) longest = candidate;
   candidate = matchPatternAtStart(NON_ASCII_ZERO_SLASH_URL_PATH, value);
   if (candidate > longest) longest = candidate;
+  candidate = matchPatternAtStart(
+    NON_ASCII_CSI_CONSUMED_ZERO_SLASH_AUTHORITY_URL,
+    value,
+    true,
+  );
+  if (candidate > longest) longest = candidate;
+  candidate = matchPatternAtStart(NON_ASCII_CSI_CONSUMED_ZERO_SLASH_URL_PATH, value);
+  if (candidate > longest) longest = candidate;
   return longest;
 }
 
@@ -3049,8 +3067,9 @@ function appendMappedCsiUrlTail(
   input: string,
   start: number,
   end: number,
-): void {
+): boolean {
   let index = start;
+  let crossedBoundary = false;
   try {
     while (index < end) {
       ANSI_CSI_SEQUENCE_AT_INDEX.lastIndex = index;
@@ -3058,7 +3077,8 @@ function appendMappedCsiUrlTail(
         | RegExpExecArray
         | null;
       const sequenceEnd = ANSI_CSI_SEQUENCE_AT_INDEX.lastIndex;
-      if (sequence !== null && sequenceEnd <= end) {
+      if (sequence !== null) {
+        if (sequenceEnd > end) crossedBoundary = true;
         appendMappedCsiUrlStructure(candidate, input, index, sequence[0]);
         index = sequenceEnd;
         continue;
@@ -3067,6 +3087,7 @@ function appendMappedCsiUrlTail(
       appendMappedInputRange(candidate, input, index, index + 1);
       index += 1;
     }
+    return crossedBoundary;
   } finally {
     ANSI_CSI_SEQUENCE_AT_INDEX.lastIndex = 0;
   }
@@ -3091,7 +3112,7 @@ function csiConsumedUrlSpan(
     value: prefix.value,
   };
   appendMappedCsiUrlStructure(candidate, value, match.index, matched, structure);
-  appendMappedCsiUrlTail(candidate, value, matchEnd, lookaheadEnd);
+  const tailCrossedBoundary = appendMappedCsiUrlTail(candidate, value, matchEnd, lookaheadEnd);
   const introducerLength = stringSlice(matched, 0, 1) === "\u001B" ? 2 : 1;
   const colon = stringIndexOf(matched, ":", introducerLength);
   const slash = stringIndexOf(matched, "/", introducerLength);
@@ -3100,8 +3121,8 @@ function csiConsumedUrlSpan(
     redaction !== undefined && colon !== -1 && slash === -1 &&
     !hasStrongCsiConsumedUrlPayload(candidate.value, redaction.endIndex)
   ) return undefined;
-  const reachesLookaheadBound = redaction?.endIndex === candidate.value.length &&
-    lookaheadEnd < value.length;
+  const reachesLookaheadBound = tailCrossedBoundary ||
+    (redaction?.endIndex === candidate.value.length && lookaheadEnd < value.length);
   const mappedEnd = redaction === undefined
     ? undefined
     : candidate.inputEnds[redaction.endIndex - 1];
@@ -3252,13 +3273,19 @@ function mappedRestoredCsiUrlRedaction(
   const candidate: MappedCsiUrlCandidate = { inputEnds: [], value: "" };
   appendMappedInputRange(candidate, value, match.index, matchEnd);
   const lookaheadEnd = MathMin(value.length, matchEnd + MAX_CSI_CONSUMED_URL_LOOKAHEAD);
-  appendMappedCsiUrlTail(candidate, value, matchEnd, lookaheadEnd);
+  const tailCrossedBoundary = appendMappedCsiUrlTail(
+    candidate,
+    value,
+    matchEnd,
+    lookaheadEnd,
+  );
   const redaction = matchCsiConsumedUrlCandidate(candidate.value);
   if (redaction === undefined) return undefined;
   const mappedEnd = candidate.inputEnds[redaction.endIndex - 1];
   if (mappedEnd === undefined) return undefined;
   return {
-    endIndex: redaction.endIndex === candidate.value.length && lookaheadEnd < value.length
+    endIndex: tailCrossedBoundary ||
+        (redaction.endIndex === candidate.value.length && lookaheadEnd < value.length)
       ? value.length
       : mappedEnd,
     marker: redaction.marker,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2081,18 +2081,28 @@ function markCsiSchemePath(path: readonly number[] | undefined, restoreMatches: 
   }
 }
 
-function skipCompleteCsiSequences(value: string, index: number): number {
+function completeCsiSequenceEndAtIndex(
+  value: string,
+  index: number,
+  maximumEnd = value.length,
+): number {
   try {
-    while (index < value.length) {
-      ANSI_CSI_SEQUENCE_AT_INDEX.lastIndex = index;
-      const match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_AT_INDEX, [value]);
-      if (match === null) break;
-      index = ANSI_CSI_SEQUENCE_AT_INDEX.lastIndex;
-    }
-    return index;
+    ANSI_CSI_SEQUENCE_AT_INDEX.lastIndex = index;
+    const match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_AT_INDEX, [value]);
+    const sequenceEnd = ANSI_CSI_SEQUENCE_AT_INDEX.lastIndex;
+    return match !== null && sequenceEnd <= maximumEnd ? sequenceEnd : index;
   } finally {
     ANSI_CSI_SEQUENCE_AT_INDEX.lastIndex = 0;
   }
+}
+
+function skipCompleteCsiSequences(value: string, index: number): number {
+  let sequenceEnd = completeCsiSequenceEndAtIndex(value, index);
+  while (sequenceEnd !== index) {
+    index = sequenceEnd;
+    sequenceEnd = completeCsiSequenceEndAtIndex(value, index);
+  }
+  return index;
 }
 
 function hasStickyMatchAtIndex(pattern: RegExp, value: string, index: number): boolean {
@@ -2572,6 +2582,7 @@ interface CsiConsumedUrlRedaction {
 
 interface CsiConsumedUrlPrefix {
   startIndex: number;
+  inputEnds: number[];
   value: string;
 }
 
@@ -2583,11 +2594,12 @@ function csiConsumedUrlPrefix(
     ? matchIndex - MAX_CSI_CONSUMED_URL_LOOKAHEAD
     : 0;
   let startIndex = matchIndex;
+  let inputEnds: number[] = [];
   let prefix = "";
   let index = windowStart;
   while (index < matchIndex) {
-    const sequenceEnd = skipCompleteCsiSequences(value, index);
-    if (sequenceEnd !== index && sequenceEnd <= matchIndex) {
+    const sequenceEnd = completeCsiSequenceEndAtIndex(value, index, matchIndex);
+    if (sequenceEnd !== index) {
       index = sequenceEnd;
       continue;
     }
@@ -2600,21 +2612,28 @@ function csiConsumedUrlPrefix(
       const canStart = ReflectApply(RegExpPrototypeExec, GENERIC_URL_SCHEME_FIRST_CHARACTER, [
         character,
       ]) !== null;
-      if (prefix === "" || prefix.length >= MAX_GENERIC_URL_SCHEME_LENGTH) {
+      if (
+        prefix === "" || stringEndsWith(prefix, ":") ||
+        prefix.length >= MAX_GENERIC_URL_SCHEME_LENGTH
+      ) {
         prefix = canStart ? character : "";
         startIndex = canStart ? index : matchIndex;
+        inputEnds = [];
       } else {
         prefix += character;
       }
-    } else if (character === ":" && index === matchIndex - 1 && prefix !== "") {
+      if (prefix !== "") defineOwnArrayElement(inputEnds, inputEnds.length, index + 1);
+    } else if (character === ":" && prefix !== "" && !stringEndsWith(prefix, ":")) {
       prefix += character;
+      defineOwnArrayElement(inputEnds, inputEnds.length, index + 1);
     } else {
       prefix = "";
       startIndex = matchIndex;
+      inputEnds = [];
     }
     index += 1;
   }
-  return prefix === "" ? undefined : { startIndex, value: prefix };
+  return prefix === "" ? undefined : { startIndex, inputEnds, value: prefix };
 }
 
 function matchPatternAtStart(
@@ -2643,12 +2662,18 @@ function matchCsiConsumedAsciiUrl(value: string): number {
 }
 
 function matchCsiConsumedNonAsciiUrl(value: string): number {
-  return matchPatternAtStart(NON_ASCII_AUTHORITY_URL, value, true) ||
-    matchPatternAtStart(NON_ASCII_URL_PATH, value) ||
-    matchPatternAtStart(NON_ASCII_MALFORMED_AUTHORITY_URL, value, true) ||
-    matchPatternAtStart(NON_ASCII_MALFORMED_URL_PATH, value) ||
-    matchPatternAtStart(NON_ASCII_ZERO_SLASH_AUTHORITY_URL, value, true) ||
-    matchPatternAtStart(NON_ASCII_ZERO_SLASH_URL_PATH, value);
+  let longest = matchPatternAtStart(NON_ASCII_AUTHORITY_URL, value, true);
+  let candidate = matchPatternAtStart(NON_ASCII_URL_PATH, value);
+  if (candidate > longest) longest = candidate;
+  candidate = matchPatternAtStart(NON_ASCII_MALFORMED_AUTHORITY_URL, value, true);
+  if (candidate > longest) longest = candidate;
+  candidate = matchPatternAtStart(NON_ASCII_MALFORMED_URL_PATH, value);
+  if (candidate > longest) longest = candidate;
+  candidate = matchPatternAtStart(NON_ASCII_ZERO_SLASH_AUTHORITY_URL, value, true);
+  if (candidate > longest) longest = candidate;
+  candidate = matchPatternAtStart(NON_ASCII_ZERO_SLASH_URL_PATH, value);
+  if (candidate > longest) longest = candidate;
+  return longest;
 }
 
 function matchCsiConsumedUrlCandidate(value: string): CsiConsumedUrlRedaction | undefined {
@@ -2669,6 +2694,68 @@ interface CsiConsumedUrlSpan extends CsiConsumedUrlRedaction {
   startIndex: number;
 }
 
+interface MappedCsiUrlCandidate {
+  inputEnds: number[];
+  value: string;
+}
+
+function appendMappedInputRange(
+  candidate: MappedCsiUrlCandidate,
+  input: string,
+  start: number,
+  end: number,
+): void {
+  for (let index = start; index < end; index++) {
+    candidate.value += stringSlice(input, index, index + 1);
+    defineOwnArrayElement(candidate.inputEnds, candidate.inputEnds.length, index + 1);
+  }
+}
+
+function csiUrlStructureStart(matched: string): number {
+  const introducerLength = stringSlice(matched, 0, 1) === "\u001B" ? 2 : 1;
+  const colon = stringIndexOf(matched, ":", introducerLength);
+  const slash = stringIndexOf(matched, "/", introducerLength);
+  if (colon === -1) return slash;
+  if (slash === -1) return colon;
+  return colon < slash ? colon : slash;
+}
+
+function appendMappedCsiUrlTail(
+  candidate: MappedCsiUrlCandidate,
+  input: string,
+  start: number,
+  end: number,
+): void {
+  let index = start;
+  try {
+    while (index < end) {
+      ANSI_CSI_SEQUENCE_AT_INDEX.lastIndex = index;
+      const sequence = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_AT_INDEX, [input]) as
+        | RegExpExecArray
+        | null;
+      const sequenceEnd = ANSI_CSI_SEQUENCE_AT_INDEX.lastIndex;
+      if (sequence !== null && sequenceEnd <= end) {
+        const structureStart = csiUrlStructureStart(sequence[0]);
+        if (structureStart !== -1) {
+          appendMappedInputRange(
+            candidate,
+            input,
+            index + structureStart,
+            sequenceEnd,
+          );
+        }
+        index = sequenceEnd;
+        continue;
+      }
+
+      appendMappedInputRange(candidate, input, index, index + 1);
+      index += 1;
+    }
+  } finally {
+    ANSI_CSI_SEQUENCE_AT_INDEX.lastIndex = 0;
+  }
+}
+
 function csiConsumedUrlSpan(
   value: string,
   match: RegExpExecArray,
@@ -2680,27 +2767,32 @@ function csiConsumedUrlSpan(
   if (prefix === undefined || prefix.startIndex < outputOffset) return undefined;
 
   const matched = match[0];
-  const introducerLength = stringSlice(matched, 0, 1) === "\u001B" ? 2 : 1;
-  const rawBody = stringSlice(matched, introducerLength);
-  const swallowedUrlStructure =
-    (ReflectApply(StringPrototypeIncludes, rawBody, [":"]) as boolean) ||
-    (ReflectApply(StringPrototypeIncludes, rawBody, ["/"]) as boolean);
-  if (!swallowedUrlStructure) return undefined;
+  const structureStart = csiUrlStructureStart(matched);
+  if (structureStart === -1) return undefined;
   const lookaheadEnd = MathMin(value.length, matchEnd + MAX_CSI_CONSUMED_URL_LOOKAHEAD);
-  const candidate = prefix.value + rawBody +
-    stringSlice(value, matchEnd, lookaheadEnd);
-  const redaction = matchCsiConsumedUrlCandidate(candidate);
-  const reachesLookaheadBound = redaction?.endIndex === candidate.length &&
+  const candidate: MappedCsiUrlCandidate = {
+    inputEnds: prefix.inputEnds,
+    value: prefix.value,
+  };
+  appendMappedInputRange(
+    candidate,
+    value,
+    match.index + structureStart,
+    matchEnd,
+  );
+  appendMappedCsiUrlTail(candidate, value, matchEnd, lookaheadEnd);
+  const redaction = matchCsiConsumedUrlCandidate(candidate.value);
+  const reachesLookaheadBound = redaction?.endIndex === candidate.value.length &&
     lookaheadEnd < value.length;
-  return redaction
-    ? {
-      startIndex: prefix.startIndex,
-      endIndex: reachesLookaheadBound
-        ? value.length
-        : prefix.startIndex + redaction.endIndex + introducerLength,
-      marker: redaction.marker,
-    }
-    : undefined;
+  const mappedEnd = redaction === undefined
+    ? undefined
+    : candidate.inputEnds[redaction.endIndex - 1];
+  if (redaction === undefined || mappedEnd === undefined) return undefined;
+  return {
+    startIndex: prefix.startIndex,
+    endIndex: reachesLookaheadBound ? value.length : mappedEnd,
+    marker: redaction.marker,
+  };
 }
 
 function exceedsCsiReconstructionLimit(value: string): boolean {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1965,7 +1965,7 @@ const MAX_GENERIC_URL_SCHEME_LENGTH = 32;
 const MAX_CSI_LITERAL_GAP = MAX_GENERIC_URL_SCHEME_LENGTH * 2;
 const MAX_CSI_RECONSTRUCTION_MATCHES = 64;
 const MAX_CSI_CONSUMED_URL_LOOKAHEAD = 4096;
-const MAX_CSI_PREFIX_RECONSTRUCTION_CHARACTERS = MAX_CSI_CONSUMED_URL_LOOKAHEAD * 2;
+const MAX_CSI_PREFIX_RECONSTRUCTION_CHARACTERS = 1024;
 const GENERIC_URL_SCHEME_FIRST_CHARACTER = /^[A-Za-z]$/;
 const GENERIC_URL_SCHEME_CHARACTER = /^[A-Za-z0-9+.-]$/;
 
@@ -2935,6 +2935,11 @@ function extendCsiConsumedUrlMatch(value: string, endIndex: number): number {
   return rawUrlMatchEnd(value, stringSlice(value, 0, endIndex), endIndex);
 }
 
+function extendCsiConsumedFileMatch(value: string, endIndex: number): number {
+  const iriEnd = stickyMatchEnd(RAW_IRI_REMAINDER, value, endIndex);
+  return iriEnd === endIndex ? extendCsiConsumedUrlMatch(value, endIndex) : iriEnd;
+}
+
 function matchCsiConsumedUrlCandidate(value: string): CsiConsumedUrlRedaction | undefined {
   const hasNonAscii = containsNonAscii(value);
   const fileEndIndex = hasNonAscii
@@ -2943,7 +2948,7 @@ function matchCsiConsumedUrlCandidate(value: string): CsiConsumedUrlRedaction | 
     : matchPatternAtStart(FILE_URL_ABSOLUTE_PATH, value);
   if (fileEndIndex !== 0) {
     return {
-      endIndex: extendCsiConsumedUrlMatch(value, fileEndIndex),
+      endIndex: extendCsiConsumedFileMatch(value, fileEndIndex),
       marker: "[path]",
     };
   }
@@ -3103,7 +3108,7 @@ function csiConsumedUrlSpan(
   };
 }
 
-function exceedsCsiReconstructionLimit(value: string): boolean {
+function csiReconstructionLimitIndex(value: string): number | undefined {
   ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex = 0;
   let matchCount = 0;
   let prefixReconstructionCharacters = 0;
@@ -3116,48 +3121,56 @@ function exceedsCsiReconstructionLimit(value: string): boolean {
       if (
         matchCount > MAX_CSI_RECONSTRUCTION_MATCHES ||
         match[0].length > MAX_CSI_CONSUMED_URL_LOOKAHEAD
-      ) return true;
+      ) return match.index;
       if (csiConsumedUrlStructure(match[0]) !== undefined) {
         prefixReconstructionCharacters += MathMin(
           match.index,
           MAX_CSI_CONSUMED_URL_LOOKAHEAD,
         );
         if (prefixReconstructionCharacters > MAX_CSI_PREFIX_RECONSTRUCTION_CHARACTERS) {
-          return true;
+          return match.index;
         }
       }
       match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_FOR_URL_REDACTION, [value]) as
         | RegExpExecArray
         | null;
     }
-    return false;
+    return undefined;
   } finally {
     ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex = 0;
   }
 }
 
 function redactCsiConsumedUrls(value: string): string {
-  if (exceedsCsiReconstructionLimit(value)) return "[REDACTED]";
+  const reconstructionLimitIndex = csiReconstructionLimitIndex(value);
+  const reconstructionValue = reconstructionLimitIndex === undefined
+    ? value
+    : stringSlice(value, 0, reconstructionLimitIndex);
   ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex = 0;
   try {
     let output = "";
     let outputOffset = 0;
-    let match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_FOR_URL_REDACTION, [value]) as
+    let match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_FOR_URL_REDACTION, [
+      reconstructionValue,
+    ]) as
       | RegExpExecArray
       | null;
     while (match !== null) {
       const matchEnd = ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex;
-      const span = csiConsumedUrlSpan(value, match, matchEnd, outputOffset);
+      const span = csiConsumedUrlSpan(reconstructionValue, match, matchEnd, outputOffset);
       if (span) {
-        output += stringSlice(value, outputOffset, span.startIndex) + span.marker;
+        output += stringSlice(reconstructionValue, outputOffset, span.startIndex) + span.marker;
         outputOffset = span.endIndex;
         ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex = span.endIndex;
       }
-      match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_FOR_URL_REDACTION, [value]) as
+      match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE_FOR_URL_REDACTION, [
+        reconstructionValue,
+      ]) as
         | RegExpExecArray
         | null;
     }
-    return output + stringSlice(value, outputOffset);
+    const redactedPrefix = output + stringSlice(reconstructionValue, outputOffset);
+    return reconstructionLimitIndex === undefined ? redactedPrefix : redactedPrefix + "[REDACTED]";
   } finally {
     ANSI_CSI_SEQUENCE_FOR_URL_REDACTION.lastIndex = 0;
   }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1922,6 +1922,9 @@ const ANSI_CSI_SEQUENCE_AT_INDEX =
 const ANSI_CSI_SEQUENCE_FOR_URL_REDACTION =
   // deno-lint-ignore no-control-regex
   /(?:\u001B\[|\u009B)[\u0030-\u003F]*[\u0020-\u002F]*[\u0040-\u007E]/g;
+// Numeric SGR changes presentation only; its final `m` is not source text.
+// deno-lint-ignore no-control-regex
+const ANSI_SGR_SEQUENCE = /^(?:\u001B\[|\u009B)[0-9:;]*m$/u;
 const CSI_SPLITTABLE_URL_SCHEMES = freezeObject([
   "http",
   "https",
@@ -2092,14 +2095,20 @@ function skipCompleteCsiSequences(value: string, index: number): number {
   }
 }
 
+function hasStickyMatchAtIndex(pattern: RegExp, value: string, index: number): boolean {
+  pattern.lastIndex = index;
+  try {
+    return ReflectApply(RegExpPrototypeExec, pattern, [value]) !== null;
+  } finally {
+    pattern.lastIndex = 0;
+  }
+}
+
 function hasRedactableCsiUrlPayload(value: string, index: number): boolean {
   const payloadIndex = skipCompleteCsiSequences(value, index);
-  URL_TOKEN_TAIL_AT_INDEX.lastIndex = payloadIndex;
-  try {
-    return ReflectApply(RegExpPrototypeExec, URL_TOKEN_TAIL_AT_INDEX, [value]) !== null;
-  } finally {
-    URL_TOKEN_TAIL_AT_INDEX.lastIndex = 0;
-  }
+  return hasStickyMatchAtIndex(URL_TOKEN_TAIL_AT_INDEX, value, payloadIndex) ||
+    hasStickyMatchAtIndex(NON_ASCII_AUTHORITY_PAYLOAD_AT_INDEX, value, payloadIndex) ||
+    hasStickyMatchAtIndex(NON_ASCII_PATH_PAYLOAD_AT_INDEX, value, payloadIndex);
 }
 
 function markCompleteCsiSequenceStarts(
@@ -2380,13 +2389,16 @@ function restoreCsiSplitUrlSchemes(value: string): string {
         stringSlice(matched, -1),
         [],
       ) as string;
+      const schemeByte = ReflectApply(RegExpPrototypeExec, ANSI_SGR_SEQUENCE, [matched]) === null
+        ? finalByte
+        : "";
       const matchIndex = matches.length;
       defineOwnArrayElement(matches, matchIndex, {
         matched,
         inputIndex: match.index,
         inputEnd: ANSI_CSI_SEQUENCE.lastIndex,
       });
-      states = advanceCsiSchemeSequence(states, finalByte, matchIndex, match.index);
+      states = advanceCsiSchemeSequence(states, schemeByte, matchIndex, match.index);
       inputOffset = ANSI_CSI_SEQUENCE.lastIndex;
       match = ReflectApply(RegExpPrototypeExec, ANSI_CSI_SEQUENCE, [value]) as
         | RegExpExecArray
@@ -2528,6 +2540,15 @@ const NON_ASCII_ZERO_SLASH_URL_PATH = new RegExp(
     .raw`${ASCII_SPECIAL_SCHEME_SOURCE}:(?![/\s])(?:[^\s"/]{0,512}@)?[^\s"/]{1,512}(?:/${URI_TOKEN_CHARACTER_SOURCE}{0,2048})?/(?=[^\x00-\x7F])[^\s"']*`,
   "gu",
 );
+const NON_ASCII_AUTHORITY_PAYLOAD_AT_INDEX = new RegExp(
+  String.raw`(?:[^\s"/]{0,512}@)?${NON_ASCII_HOST_SOURCE}(?:${URL_TOKEN_TAIL_SOURCE})?`,
+  "uy",
+);
+const NON_ASCII_PATH_PAYLOAD_AT_INDEX = new RegExp(
+  String
+    .raw`(?:[^\s"/]{0,512}@)?[^\s"/]{1,512}(?:/${URI_TOKEN_CHARACTER_SOURCE}{0,2048})?/(?=[^\x00-\x7F])[^\s"']*`,
+  "uy",
+);
 const QUOTED_WINDOWS_ABSOLUTE_PATH = /(?<=["'])(?:[A-Za-z]:[\\/]|\\\\)[^"'\r\n]+(?=["'])/g;
 const QUOTED_POSIX_ABSOLUTE_PATH = /(?<=["'])\/[^"'\r\n]+(?=["'])/g;
 // Match case-insensitively so uppercase file URLs remain paths, not remote URLs.
@@ -2660,8 +2681,13 @@ function csiConsumedUrlSpan(
 
   const matched = match[0];
   const introducerLength = stringSlice(matched, 0, 1) === "\u001B" ? 2 : 1;
+  const rawBody = stringSlice(matched, introducerLength);
+  const swallowedUrlStructure =
+    (ReflectApply(StringPrototypeIncludes, rawBody, [":"]) as boolean) ||
+    (ReflectApply(StringPrototypeIncludes, rawBody, ["/"]) as boolean);
+  if (!swallowedUrlStructure) return undefined;
   const lookaheadEnd = MathMin(value.length, matchEnd + MAX_CSI_CONSUMED_URL_LOOKAHEAD);
-  const candidate = prefix.value + stringSlice(matched, introducerLength) +
+  const candidate = prefix.value + rawBody +
     stringSlice(value, matchEnd, lookaheadEnd);
   const redaction = matchCsiConsumedUrlCandidate(candidate);
   const reachesLookaheadBound = redaction?.endIndex === candidate.length &&

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2134,16 +2134,15 @@ function advanceCsiSchemeLiteral(
   };
 }
 
-function advanceCsiSchemeSequence(
-  states: CsiRestorationStates,
+function advanceSpecialCsiSequence(
+  states: CsiSchemeStates,
   value: string,
   matchIndex: number,
-  inputIndex: number,
-): CsiRestorationStates {
+): CsiSchemeStates {
   const next = createCsiSchemeStates();
   for (let schemeIndex = 0; schemeIndex < CSI_SPLITTABLE_URL_SCHEMES.length; schemeIndex++) {
     const scheme = CSI_SPLITTABLE_URL_SCHEMES[schemeIndex]!;
-    const current = states.special[schemeIndex]!;
+    const current = states[schemeIndex]!;
     const advanced = next[schemeIndex]!;
     for (let characterIndex = 1; characterIndex <= scheme.length; characterIndex++) {
       const path = current[characterIndex];
@@ -2164,7 +2163,16 @@ function advanceCsiSchemeSequence(
       advanced[1] = keepShorterCsiSchemePath(advanced[1], [matchIndex]);
     }
   }
+  return next;
+}
 
+function advanceCsiSchemeSequence(
+  states: CsiRestorationStates,
+  value: string,
+  matchIndex: number,
+  inputIndex: number,
+): CsiRestorationStates {
+  const special = advanceSpecialCsiSequence(states.special, value, matchIndex);
   const generic = createDenseGenericCsiStates();
   const isSchemeCharacter = ReflectApply(
     RegExpPrototypeExec,
@@ -2186,7 +2194,7 @@ function advanceCsiSchemeSequence(
       startIndex: inputIndex,
     });
   }
-  return { special: next, generic };
+  return { special, generic };
 }
 
 /**

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -2057,11 +2057,9 @@ function chooseCompletedSpecialCsiPath(
   allowFile: boolean,
 ): readonly number[] | undefined {
   let selected: readonly number[] | undefined;
-  const schemeCount = allowFile
-    ? CSI_SPLITTABLE_URL_SCHEMES.length
-    : CSI_SPLITTABLE_URL_SCHEMES.length - 1;
-  for (let schemeIndex = 0; schemeIndex < schemeCount; schemeIndex++) {
+  for (let schemeIndex = 0; schemeIndex < CSI_SPLITTABLE_URL_SCHEMES.length; schemeIndex++) {
     const scheme = CSI_SPLITTABLE_URL_SCHEMES[schemeIndex]!;
+    if (!allowFile && scheme === "file") continue;
     const path = states[schemeIndex]![scheme.length];
     if (path !== undefined) selected = keepShorterCsiSchemePath(selected, path);
   }

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1956,6 +1956,11 @@ interface CsiRestorationStates {
 
 type CsiUrlPayloadKind = "generic" | "special" | "none";
 
+interface ClassifiedCsiUrlPayload {
+  kind: CsiUrlPayloadKind;
+  payloadIndex: number;
+}
+
 const MAX_GENERIC_URL_SCHEME_LENGTH = 32;
 const MAX_CSI_LITERAL_GAP = MAX_GENERIC_URL_SCHEME_LENGTH * 2;
 const MAX_CSI_RECONSTRUCTION_MATCHES = 64;
@@ -2141,8 +2146,7 @@ function markCompleteCsiSequenceStarts(
 function classifyCsiUrlPayload(
   value: string,
   colonIndex: number,
-  stripSequenceStarts: Set<number>,
-): CsiUrlPayloadKind {
+): ClassifiedCsiUrlPayload {
   const firstSlashIndex = skipCompleteCsiSequences(value, colonIndex + 1);
   let payloadIndex: number;
   let payload: CsiUrlPayloadKind;
@@ -2159,15 +2163,7 @@ function classifyCsiUrlPayload(
       payload = hasRedactableCsiUrlPayload(value, payloadIndex) ? "generic" : "none";
     }
   }
-  if (payload !== "none") {
-    markCompleteCsiSequenceStarts(
-      value,
-      colonIndex + 1,
-      payloadIndex,
-      stripSequenceStarts,
-    );
-  }
-  return payload;
+  return { kind: payload, payloadIndex };
 }
 
 function advanceGenericCsiLiteral(
@@ -2207,13 +2203,22 @@ function advanceCsiSchemeLiteral(
   stripSequenceStarts: Set<number>,
 ): CsiRestorationStates {
   if (value === ":") {
-    const payload = classifyCsiUrlPayload(input, inputIndex, stripSequenceStarts);
-    if (payload === "generic") {
+    const payload = classifyCsiUrlPayload(input, inputIndex);
+    let path: readonly number[] | undefined;
+    if (payload.kind === "generic") {
       const special = chooseCompletedSpecialCsiPath(states.special, true);
-      const path = special ?? chooseCompletedGenericCsiPath(states.generic)?.matches;
+      path = special ?? chooseCompletedGenericCsiPath(states.generic)?.matches;
+    } else if (payload.kind === "special") {
+      path = chooseCompletedSpecialCsiPath(states.special, false);
+    }
+    if (path !== undefined) {
       markCsiSchemePath(path, restoreMatches);
-    } else if (payload === "special") {
-      markCsiSchemePath(chooseCompletedSpecialCsiPath(states.special, false), restoreMatches);
+      markCompleteCsiSequenceStarts(
+        input,
+        inputIndex + 1,
+        payload.payloadIndex,
+        stripSequenceStarts,
+      );
     }
     return createCsiRestorationStates();
   }
@@ -2735,7 +2740,9 @@ function appendMappedCsiUrlStructure(
   const slash = stringIndexOf(matched, "/", introducerLength);
   if (colon === -1 && slash === -1) return false;
   if (colon !== -1) {
-    appendMappedInputRange(candidate, input, inputStart + colon, inputStart + colon + 1);
+    if (!stringEndsWith(candidate.value, ":")) {
+      appendMappedInputRange(candidate, input, inputStart + colon, inputStart + colon + 1);
+    }
     const suffixStart = slash === -1 ? matched.length - 1 : slash;
     appendMappedInputRange(
       candidate,


### PR DESCRIPTION
## Summary

- redact hostnames when a CSI final byte consumes a character inside a supported URL scheme
- preserve real CSI grammar and empty-string removal so split credentials still rejoin for redaction
- bound damaged-scheme recognition to supported schemes and avoid broad prose matching

## Red-green TDD

RED on main: `h<CSI>ttps:registry.internal/config.ts` was normalized to a damaged scheme and exposed `registry.internal` in caller-visible config errors.

GREEN: the damaged scheme is classified and redacted after de-colorization. Coverage includes every HTTPS split position, parameterized and 8-bit CSI, uppercase schemes, WebSocket, FTP, file URLs, split credentials, CSI-glued paths and URLs, and ordinary colon prose that must remain visible.

## Verification

- `deno task test:file src/config` (46 files, 738 steps passed)
- changed-file format and lint passed
- `deno task lint:test-typecheck` passed with 0 new baseline files
- `deno task lint:test-semantic-dispositions` passed
- `deno task lint:anti-slop` passed
- `git diff --check` passed

Closes veryfront/veryfront-issue-inbox#846

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration error-message redaction for URLs and file paths containing split, escaped, dense, or multiline terminal-control sequences.
  - Ensures sensitive HTTP, WebSocket, FTP, S3, and file URLs are consistently masked while preserving actionable first-line content and surrounding prose.
  - Improved handling of complex, fragmented, colorized, Unicode, and malformed URL patterns with bounded processing.

- **Tests**
  - Added extensive coverage for URL reconstruction, redaction edge cases, performance limits, and unaffected text patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->