### PR TITLE
fix(workflow): deprecate unsafe run TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,18 @@ fixed expiry when a run was created. That expiry could remove an active or
 approval-waiting run while leaving its checkpoints, approvals, and shared Redis
 index memberships behind.
 
-If you set `runTtl`, remove that option before upgrading. No Veryfront runtime
-or CLI entrypoint sets it automatically. To remove a run intentionally, call
-`RedisBackend.deleteRun(runId)` only after your application has made the run
-ineligible for retry or resume. The option remains in the public type so your
-existing configuration continues to compile while you migrate.
+If you set `runTtl`, drain and stop old workers, deploy the new framework, then
+call `RedisBackend.clearLegacyRunTtlExpirations()` before removing the option
+from deployment configuration. The migration scans run keys incrementally and
+removes existing TTLs from run hashes, observation streams, and approval
+journals. It does not change lock or stalled-claim lease TTLs. You can run it
+again safely; it returns the number of TTLs removed.
+
+No Veryfront runtime or CLI entrypoint sets `runTtl` automatically. To remove a
+run intentionally, call `RedisBackend.deleteRun(runId)` only after your
+application has made the run ineligible for retry or resume. The option remains
+in the public type so your existing configuration continues to compile while
+you migrate.
 
 ### Breaking: workflow HTTP reads return summaries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ versions are listed at
 
 ## Unreleased
 
+### Breaking: Redis workflow `runTtl` no longer expires runs
+
+`RedisBackendConfig.runTtl` is now a deprecated no-op. It previously started a
+fixed expiry when a run was created. That expiry could remove an active or
+approval-waiting run while leaving its checkpoints, approvals, and shared Redis
+index memberships behind.
+
+If you set `runTtl`, remove that option before upgrading. No Veryfront runtime
+or CLI entrypoint sets it automatically. To remove a run intentionally, call
+`RedisBackend.deleteRun(runId)` only after your application has made the run
+ineligible for retry or resume. The option remains in the public type so your
+existing configuration continues to compile while you migrate.
+
 ### Breaking: workflow HTTP reads return summaries
 
 The built-in workflow handler now returns `WorkflowRunSummary` from

--- a/src/workflow/backends/redis/index.test.ts
+++ b/src/workflow/backends/redis/index.test.ts
@@ -4514,19 +4514,33 @@ describe("RedisBackend", () => {
   });
 
   describe("runTtl config", () => {
-    it("should set expire when runTtl is configured", async () => {
+    it("does not apply partial creation-time expiry to live run state", async () => {
       const ttlBackend = new RedisBackend({
         client: mockRedis as unknown as RedisAdapter,
         prefix: "ttl:",
         runTtl: 3600,
       });
       await ttlBackend.createRun(createTestRun("run-ttl"));
+      await ttlBackend.updateRun("run-ttl", { status: "waiting" });
+      await ttlBackend.saveCheckpoint("run-ttl", {
+        id: "cp-ttl",
+        nodeId: "gate",
+        timestamp: new Date("2026-01-01T00:00:00Z"),
+        context: { input: {} },
+        nodeStates: {},
+      });
+      await ttlBackend.savePendingApproval("run-ttl", {
+        id: "approval-ttl",
+        nodeId: "gate",
+        status: "pending",
+        requestedAt: new Date("2026-01-01T00:00:00Z"),
+      });
 
-      assertEquals(mockRedis.expiries.has("ttl:schema-v1:run:run-ttl"), true);
-      assertEquals(
-        mockRedis.expiries.get("ttl:schema-v1:run-observation:run-ttl"),
-        3600,
-      );
+      assertEquals(mockRedis.expiries.size, 0);
+      assertEquals((await ttlBackend.getRun("run-ttl"))?.status, "waiting");
+      assertEquals((await ttlBackend.getCheckpoints("run-ttl")).length, 1);
+      assertEquals((await ttlBackend.getPendingApprovals("run-ttl")).length, 1);
+      assertEquals(await ttlBackend.countRuns({}), 1);
     });
   });
 

--- a/src/workflow/backends/redis/index.test.ts
+++ b/src/workflow/backends/redis/index.test.ts
@@ -4533,6 +4533,7 @@ describe("RedisBackend", () => {
         id: "approval-ttl",
         nodeId: "gate",
         status: "pending",
+        message: "Continue?",
         requestedAt: new Date("2026-01-01T00:00:00Z"),
       });
 

--- a/src/workflow/backends/redis/index.test.ts
+++ b/src/workflow/backends/redis/index.test.ts
@@ -203,6 +203,10 @@ class MockRedisAdapter implements RedisAdapter {
     this.lastScript = script;
     this.lastArgs = [...args];
 
+    if (script.includes("clear-legacy-run-ttl")) {
+      return Promise.resolve(this.expiries.delete(key) ? 1 : 0);
+    }
+
     if (script.includes("open-run-observation")) {
       const hash = this.hashes.get(key);
       if (!hash) return Promise.resolve(null);
@@ -4542,6 +4546,46 @@ describe("RedisBackend", () => {
       assertEquals((await ttlBackend.getCheckpoints("run-ttl")).length, 1);
       assertEquals((await ttlBackend.getPendingApprovals("run-ttl")).length, 1);
       assertEquals(await ttlBackend.countRuns({}), 1);
+    });
+
+    it("clears legacy run expiries without persisting lock leases", async () => {
+      const ttlBackend = new RedisBackend({
+        client: mockRedis as unknown as RedisAdapter,
+        prefix: "ttl-migration:",
+      });
+      mockRedis.scanPageSize = 1;
+      for (const runId of ["legacy-a", "legacy-b"]) {
+        await ttlBackend.createRun(createTestRun(runId));
+        await ttlBackend.savePendingApproval(runId, {
+          id: `approval-${runId}`,
+          nodeId: "gate",
+          status: "pending",
+          message: "Continue?",
+          requestedAt: new Date("2026-01-01T00:00:00Z"),
+        });
+        mockRedis.expiries.set(`ttl-migration:schema-v1:run:${runId}`, 3600);
+        mockRedis.expiries.set(`ttl-migration:schema-v1:run-observation:${runId}`, 3600);
+        mockRedis.expiries.set(
+          `ttl-migration:schema-v1:run-observation-approvals-v1:${runId}`,
+          3600,
+        );
+      }
+      await ttlBackend.acquireLock("legacy-a", 60_000);
+      mockRedis.expiries.set("ttl-migration:schema-v1:lock:legacy-a", 60_000);
+
+      assertEquals(await ttlBackend.clearLegacyRunTtlExpirations(), 6);
+      assertEquals(
+        [...mockRedis.expiries.keys()],
+        ["ttl-migration:schema-v1:lock:legacy-a"],
+      );
+      assertEquals(mockRedis.scanCalls.length > 1, true);
+      assertEquals(
+        mockRedis.scanCalls.every((call) =>
+          call.options?.MATCH === "ttl-migration:schema-v1:run:*" &&
+          call.options.COUNT === 100
+        ),
+        true,
+      );
     });
   });
 

--- a/src/workflow/backends/redis/index.ts
+++ b/src/workflow/backends/redis/index.ts
@@ -1545,11 +1545,6 @@ export class RedisBackend implements WorkflowBackend {
     await client.sadd(this.workflowIndexKey(run.workflowId), run.id);
     await client.sadd(this.allRunsIndexKey(), run.id);
     await client.xadd(this.runObservationKey(run.id), "*", serializeInitialRunObservation(run));
-
-    if (this.config.runTtl) {
-      await client.expire(this.runKey(run.id), this.config.runTtl);
-      await client.expire(this.runObservationKey(run.id), this.config.runTtl);
-    }
   }
 
   async getRun(runId: string): Promise<WorkflowRun | null> {

--- a/src/workflow/backends/redis/index.ts
+++ b/src/workflow/backends/redis/index.ts
@@ -61,6 +61,8 @@ const RUN_OBSERVATION_REVISION_FIELD = "__runObservationRevision";
 const RUN_OBSERVATION_STREAM_MAX_LENGTH = 64;
 const RUN_OBSERVATION_POLL_INTERVAL_MS = 20;
 const APPROVAL_RECOVERY_SCAN_COUNT = 100;
+const CLEAR_LEGACY_RUN_TTL_SCRIPT =
+  "-- clear-legacy-run-ttl\nreturn redis.call('persist', KEYS[1])";
 
 /**
  * Merge top-level JSON objects without decoding their values through Redis's
@@ -1545,6 +1547,50 @@ export class RedisBackend implements WorkflowBackend {
     await client.sadd(this.workflowIndexKey(run.workflowId), run.id);
     await client.sadd(this.allRunsIndexKey(), run.id);
     await client.xadd(this.runObservationKey(run.id), "*", serializeInitialRunObservation(run));
+  }
+
+  /**
+   * Remove TTLs written by the deprecated creation-time `runTtl` behavior.
+   *
+   * Run this once after old workers have drained and before removing `runTtl`
+   * from deployment configuration. The cursor scan avoids blocking Redis with
+   * a keyspace-wide `KEYS` command. Lock and stalled-claim TTLs remain intact
+   * because they are execution leases, not run-retention state.
+   *
+   * @returns Number of legacy TTLs removed.
+   */
+  async clearLegacyRunTtlExpirations(): Promise<number> {
+    const client = await this.ensureClient();
+    const runPrefix = `${this.storagePrefix()}run:`;
+    let cursor = 0;
+    let cleared = 0;
+    do {
+      const page = await client.scan(cursor, {
+        MATCH: `${runPrefix}*`,
+        COUNT: APPROVAL_RECOVERY_SCAN_COUNT,
+      });
+      cursor = page.cursor;
+      for (let index = 0; index < page.keys.length; index++) {
+        const runKey = page.keys[index]!;
+        const runId = runKey.slice(runPrefix.length);
+        cleared += Number(await client.eval(CLEAR_LEGACY_RUN_TTL_SCRIPT, [runKey], []));
+        cleared += Number(
+          await client.eval(
+            CLEAR_LEGACY_RUN_TTL_SCRIPT,
+            [this.runObservationKey(runId)],
+            [],
+          ),
+        );
+        cleared += Number(
+          await client.eval(
+            CLEAR_LEGACY_RUN_TTL_SCRIPT,
+            [this.runObservationApprovalsKey(runId)],
+            [],
+          ),
+        );
+      }
+    } while (cursor !== 0);
+    return cleared;
   }
 
   async getRun(runId: string): Promise<WorkflowRun | null> {

--- a/src/workflow/backends/redis/types.ts
+++ b/src/workflow/backends/redis/types.ts
@@ -38,9 +38,10 @@ export interface RedisBackendConfig extends BackendConfig {
    * @deprecated No-op retained for source compatibility.
    *
    * Creation-time expiry can remove an active or waiting run while leaving its
-   * checkpoints, approvals, and shared index memberships behind. Call
-   * `RedisBackend.deleteRun()` only after your application has made the run
-   * ineligible for retry or resume.
+   * checkpoints, approvals, and shared index memberships behind. After an
+   * upgrade, call `RedisBackend.clearLegacyRunTtlExpirations()` before removing
+   * this option. Call `RedisBackend.deleteRun()` only after your application has
+   * made the run ineligible for retry or resume.
    */
   runTtl?: number;
   /** Enable debug logging */

--- a/src/workflow/backends/redis/types.ts
+++ b/src/workflow/backends/redis/types.ts
@@ -34,7 +34,13 @@ export interface RedisBackendConfig extends BackendConfig {
   groupName?: string;
   /** Consumer name (unique per worker) */
   consumerName?: string;
-  /** Default TTL for runs (in seconds) */
+  /**
+   * @deprecated No-op retained for source compatibility.
+   *
+   * Creation-time expiry can remove an active or waiting run while leaving its
+   * checkpoints, approvals, and shared index memberships behind. Delete
+   * terminal runs explicitly instead.
+   */
   runTtl?: number;
   /** Enable debug logging */
   debug?: boolean;

--- a/src/workflow/backends/redis/types.ts
+++ b/src/workflow/backends/redis/types.ts
@@ -38,8 +38,9 @@ export interface RedisBackendConfig extends BackendConfig {
    * @deprecated No-op retained for source compatibility.
    *
    * Creation-time expiry can remove an active or waiting run while leaving its
-   * checkpoints, approvals, and shared index memberships behind. Delete
-   * terminal runs explicitly instead.
+   * checkpoints, approvals, and shared index memberships behind. Call
+   * `RedisBackend.deleteRun()` only after your application has made the run
+   * ineligible for retry or resume.
    */
   runTtl?: number;
   /** Enable debug logging */

--- a/src/workflow/backends/types.ts
+++ b/src/workflow/backends/types.ts
@@ -91,8 +91,8 @@ export interface BackendConfig {
   /**
    * @deprecated No-op retained for source compatibility.
    *
-   * Backends ignore this field. Use backend-specific TTL options, such as
-   * `RedisBackendConfig.runTtl`, when retention behavior is required.
+   * Backends ignore this field. Delete terminal runs explicitly when retention
+   * behavior is required.
    */
   defaultTtl?: number;
   debug?: boolean;


### PR DESCRIPTION
## Summary

- preserve RedisBackendConfig.runTtl for source compatibility but make future creation-time expiry an explicit no-op
- add clearLegacyRunTtlExpirations() to remove TTLs already stored by earlier releases
- document the upgrade-visible behavior change and exact Redis migration/deletion path

## Why

Creation-time expiry can remove an active or approval-parked run while leaving checkpoints, approvals, and shared Redis index memberships behind. Redis SET members cannot expire independently, so refreshing only per-run keys cannot make this behavior safe.

## Migration

Drain and stop old workers, deploy the new framework, call RedisBackend.clearLegacyRunTtlExpirations(), then remove runTtl from deployment configuration. The cursor scan persists run hashes, observation streams, and approval journals without touching lock or stalled-claim lease TTLs. The method is idempotent and returns the number of TTLs removed.

If an application intentionally deletes a run, call RedisBackend.deleteRun(runId) only after application-level synchronization has made the run ineligible for retry or resume.

A repository-wide search confirms no Veryfront runtime, CLI command, worker entrypoint, server handler, template, example, or guide sets runTtl. Only the backend declaration, implementation, and focused tests referenced it.

## Red-green TDD

RED: the Redis backend regression observed two expiry assignments after creating a run with runTtl. A second regression showed no migration method existed for TTLs already stored by previous releases.

GREEN: future configuration creates no expiries; the waiting run, checkpoint, pending approval, and run index remain readable; the migration clears all three legacy TTL-bearing keys across multiple cursor pages while preserving lock TTLs.

## Verification

- deno task test:file src/workflow/backends/redis/index.test.ts src/workflow/backends/types.test.ts, 165 steps passed
- deno check src/workflow/backends/redis/index.ts src/workflow/backends/redis/index.test.ts
- deno task lint:test-typecheck, 0 new failures
- deno task docs:api-reference:check
- deno task docs:public:check
- deno task lint
- deno task typecheck
- deno task lint:test-semantic-dispositions
- deno task lint:anti-slop
- deno fmt --check on changed files
- git diff --check

## Compatibility

The public option remains accepted, so existing callers continue to typecheck. This intentionally stops its unsafe runtime effect and is recorded under Unreleased in CHANGELOG.md.