### PR TITLE
docs(middleware): clarify CORS preflight ownership

### DIFF
--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -31,6 +31,60 @@ const corsMiddleware = cors({
 });
 ```
 
+#### Choose who owns preflight
+
+Global `security.cors` owns automatic preflight. Use it when every matching
+route can share one policy:
+
+```ts
+// veryfront.config.ts
+import { defineConfig } from "veryfront";
+
+export default defineConfig({
+  security: {
+    cors: {
+      origin: "https://example.com",
+      methods: ["GET", "POST", "OPTIONS"],
+      allowedHeaders: ["Content-Type", "Authorization"],
+      maxAge: 86400,
+    },
+  },
+});
+```
+
+Method-local `cors()` middleware runs only inside the handler that calls it.
+It does not configure the framework-generated automatic `OPTIONS` response.
+
+For a route-specific policy, export `OPTIONS` and apply the same policy to the
+actual response. An explicit `OPTIONS` export is authoritative. Veryfront uses
+automatic preflight only when the matched route has no executable `OPTIONS`
+handler. A callable default Pages route is also authoritative for `OPTIONS` and
+must branch on `ctx.request.method` when it owns multiple methods.
+
+```ts
+// app/api/report/route.ts
+import { applyCORSHeaders, type CORSConfig, handleCORSPreflight } from "veryfront/security";
+
+const corsConfig: CORSConfig = {
+  origin: "https://example.com",
+  methods: ["GET", "OPTIONS"],
+  allowedHeaders: ["Authorization"],
+  maxAge: 86400,
+};
+
+export function OPTIONS(request: Request): Promise<Response> {
+  return handleCORSPreflight({ request, config: corsConfig });
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const response = Response.json({ report: "ready" });
+  return await applyCORSHeaders({ request, response, config: corsConfig }) ?? response;
+}
+```
+
+In a Pages API route, use the same exports and policy, accept `APIContext`, and
+pass `ctx.request` to `handleCORSPreflight` and `applyCORSHeaders`.
+
 ### Rate limiting
 
 ```ts

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -63,6 +63,11 @@ also authoritative for `OPTIONS` and must branch on `ctx.request.method` when
 it owns multiple methods. Veryfront replaces policy-owned CORS headers on both
 forms with the validated global `security.cors` policy.
 
+An unauthenticated preflight for an auth-protected route is the exception.
+Veryfront returns automatic preflight without executing the explicit handler,
+so the browser can evaluate the global CORS policy before the actual request
+performs application authentication.
+
 ### Rate limiting
 
 ```ts

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -4,7 +4,7 @@ description: "CORS, rate limiting, logging, and custom middleware pipelines."
 order: 15
 ---
 
-Middleware runs before your route handler. Use it for CORS headers, rate limits, logging, timeouts, and auth checks. A `MiddlewarePipeline` chains middleware together and short-circuits to a `Response` when one rejects the request.
+Middleware runs before your route handler. Use it for rate limits, logging, timeouts, and auth checks. A `MiddlewarePipeline` chains middleware together and short-circuits to a `Response` when one rejects the request.
 
 The pipeline works in both router styles. The route module wrapper changes:
 
@@ -20,19 +20,7 @@ The pipeline works in both router styles. The route module wrapper changes:
 
 ### CORS
 
-```ts
-import { cors } from "veryfront/middleware";
-
-const corsMiddleware = cors({
-  origin: "https://example.com", // or "*" or ["https://a.com", "https://b.com"]
-  methods: ["GET", "POST"],
-  allowedHeaders: ["Content-Type", "Authorization"],
-  maxAge: 86400,
-});
-```
-
-#### Choose who owns preflight
-
+For App and Pages API routes, configure CORS globally.
 Global `security.cors` is authoritative for CORS headers on automatic
 preflight, explicit `OPTIONS`, and actual route responses:
 
@@ -52,9 +40,15 @@ export default defineConfig({
 });
 ```
 
+#### Ownership rules
+
 Method-local `cors()` middleware runs only inside the handler that calls it.
 It does not configure the framework-generated automatic `OPTIONS` response and
 cannot override the global policy after route dispatch.
+
+Use method-local `cors()` only in a lower-level pipeline whose response does
+not return through the Veryfront API router, such as a custom server adapter.
+Do not use it to configure CORS for an App or Pages API route.
 
 An explicit `OPTIONS` export is authoritative for the response status, body,
 and non-CORS headers. Veryfront uses automatic preflight only when the matched
@@ -105,10 +99,9 @@ const timer = timeout({ timeoutMs: 30_000 }); // 30 seconds
 Combine middleware into a pipeline:
 
 ```ts
-import { cors, logger, MiddlewarePipeline, rateLimit, timeout } from "veryfront/middleware";
+import { logger, MiddlewarePipeline, rateLimit, timeout } from "veryfront/middleware";
 
 const pipeline = new MiddlewarePipeline()
-  .use(cors({ origin: "*" }))
   .use(rateLimit({ maxRequests: 100, windowMs: 60_000 }))
   .use(logger({ format: "short" }))
   .use(timeout({ timeoutMs: 30_000 }));
@@ -120,7 +113,6 @@ Apply middleware only to matching URL patterns:
 
 ```ts
 const pipeline = new MiddlewarePipeline()
-  .use(cors({ origin: "*" }))
   .useFor(/^\/api\//, rateLimit({ maxRequests: 50, windowMs: 60_000 }))
   .useFor(/^\/api\/chat\//, timeout({ timeoutMs: 120_000 }));
 ```
@@ -157,7 +149,9 @@ Try it with the dev server running:
 curl -i http://localhost:3000/api/users
 ```
 
-The response includes any headers added by the middleware that matched the request.
+The response includes non-CORS headers added by the middleware that matched the
+request. The API router replaces policy-owned CORS headers with the global
+`security.cors` policy after the handler returns.
 
 > **`handle()` vs `execute()`.** `execute()` is a lower-level variant with **no terminal handler**: it returns the short-circuiting middleware's `Response`, or a synthesized **404 Not Found** when the chain passes through. It always resolves to a `Response` (never `undefined`), so `if (await pipeline.execute(request))` is always truthy; use `execute()` only when a middleware is always expected to produce the response. For the common "middleware, then my route handler" case, prefer `handle()`.
 
@@ -213,9 +207,7 @@ const auth: MiddlewareHandler = async (c, next) => {
 Add it to a pipeline:
 
 ```ts
-const pipeline = new MiddlewarePipeline()
-  .use(auth)
-  .use(cors({ origin: "*" }));
+const pipeline = new MiddlewarePipeline().use(auth);
 ```
 
 ## Project-wide root middleware
@@ -398,5 +390,5 @@ curl -i http://localhost:3000/api/protected \
   -H "Authorization: Bearer <TOKEN>"
 ```
 
-For CORS, include an `Origin` header and confirm
-`Access-Control-Allow-Origin` is set on the response.
+For global CORS, include an `Origin` header and confirm the configured
+`Access-Control-Allow-Origin` value is set on the response.

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -33,8 +33,8 @@ const corsMiddleware = cors({
 
 #### Choose who owns preflight
 
-Global `security.cors` owns automatic preflight. Use it when every matching
-route can share one policy:
+Global `security.cors` is authoritative for CORS headers on automatic
+preflight, explicit `OPTIONS`, and actual route responses:
 
 ```ts
 // veryfront.config.ts
@@ -53,37 +53,15 @@ export default defineConfig({
 ```
 
 Method-local `cors()` middleware runs only inside the handler that calls it.
-It does not configure the framework-generated automatic `OPTIONS` response.
+It does not configure the framework-generated automatic `OPTIONS` response and
+cannot override the global policy after route dispatch.
 
-For a route-specific policy, export `OPTIONS` and apply the same policy to the
-actual response. An explicit `OPTIONS` export is authoritative. Veryfront uses
-automatic preflight only when the matched route has no executable `OPTIONS`
-handler. A callable default Pages route is also authoritative for `OPTIONS` and
-must branch on `ctx.request.method` when it owns multiple methods.
-
-```ts
-// app/api/report/route.ts
-import { applyCORSHeaders, type CORSConfig, handleCORSPreflight } from "veryfront/security";
-
-const corsConfig: CORSConfig = {
-  origin: "https://example.com",
-  methods: ["GET", "OPTIONS"],
-  allowedHeaders: ["Authorization"],
-  maxAge: 86400,
-};
-
-export function OPTIONS(request: Request): Promise<Response> {
-  return handleCORSPreflight({ request, config: corsConfig });
-}
-
-export async function GET(request: Request): Promise<Response> {
-  const response = Response.json({ report: "ready" });
-  return await applyCORSHeaders({ request, response, config: corsConfig }) ?? response;
-}
-```
-
-In a Pages API route, use the same exports and policy, accept `APIContext`, and
-pass `ctx.request` to `handleCORSPreflight` and `applyCORSHeaders`.
+An explicit `OPTIONS` export is authoritative for the response status, body,
+and non-CORS headers. Veryfront uses automatic preflight only when the matched
+route has no executable `OPTIONS` handler. A callable default Pages route is
+also authoritative for `OPTIONS` and must branch on `ctx.request.method` when
+it owns multiple methods. Veryfront replaces policy-owned CORS headers on both
+forms with the validated global `security.cors` policy.
 
 ### Rate limiting
 

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -22,7 +22,8 @@ The pipeline works in both router styles. The route module wrapper changes:
 
 For App and Pages API routes, configure CORS globally.
 Global `security.cors` is authoritative for CORS headers on automatic
-preflight, explicit `OPTIONS`, and actual route responses:
+preflight, explicit `OPTIONS`, and actual route responses. This authority applies
+at the API router boundary:
 
 ```ts
 // veryfront.config.ts
@@ -49,6 +50,10 @@ cannot override the global policy after route dispatch.
 Use method-local `cors()` only in a lower-level pipeline whose response does
 not return through the Veryfront API router, such as a custom server adapter.
 Do not use it to configure CORS for an App or Pages API route.
+
+Root middleware resumes after the route returns and can change the final wire
+response after this boundary. Do not set policy-owned CORS headers in root
+middleware unless it deliberately owns the final CORS policy for that request.
 
 An explicit `OPTIONS` export is authoritative for the response status, body,
 and non-CORS headers. Veryfront uses automatic preflight only when the matched
@@ -151,7 +156,8 @@ curl -i http://localhost:3000/api/users
 
 The response includes non-CORS headers added by the middleware that matched the
 request. The API router replaces policy-owned CORS headers with the global
-`security.cors` policy after the handler returns.
+`security.cors` policy after the handler returns. Root middleware can
+subsequently change the response, so keep CORS ownership in one layer.
 
 > **`handle()` vs `execute()`.** `execute()` is a lower-level variant with **no terminal handler**: it returns the short-circuiting middleware's `Response`, or a synthesized **404 Not Found** when the chain passes through. It always resolves to a `Response` (never `undefined`), so `if (await pipeline.execute(request))` is always truthy; use `execute()` only when a middleware is always expected to produce the response. For the common "middleware, then my route handler" case, prefer `handle()`.
 

--- a/docs/guides/workflows-advanced.md
+++ b/docs/guides/workflows-advanced.md
@@ -234,10 +234,28 @@ the fields the application needs. Use `useApproval` for approval payloads.
 ### Call the hooks across origins
 
 A cross-origin `apiBase` needs CORS on both the preflight and the actual
-response. `createWorkflowHandler` owns `GET` and `POST`; the route module must
-export `OPTIONS` and add the same CORS headers to the handler responses. Allow
-only the application origins you control, and list every request header the
-hooks send:
+response. Configure the global policy with only the application origins you
+control and every request header the hooks send:
+
+```ts theme={null}
+// veryfront.config.ts
+import { defineConfig } from "veryfront";
+
+export default defineConfig({
+  security: {
+    cors: {
+      origin: "https://app.example.com",
+      methods: ["GET", "POST", "OPTIONS"],
+      allowedHeaders: ["Authorization", "Content-Type", "X-CSRF-Token"],
+      credentials: true,
+    },
+  },
+});
+```
+
+`createWorkflowHandler` owns `GET` and `POST`. Export those handlers normally;
+Veryfront uses `security.cors` for automatic preflight and for the actual
+responses:
 
 ```ts theme={null}
 // app/api/workflows/[...path]/route.ts
@@ -245,55 +263,23 @@ import { createWorkflowHandler } from "veryfront/workflow";
 import { getSession } from "../../../../lib/auth.ts";
 import { workflows } from "../../../../lib/workflows.ts";
 
-const applicationOrigin = "https://app.example.com";
 const handlers = createWorkflowHandler(workflows, {
   authorize: async (request) => (await getSession(request))?.user.id ?? null,
 });
 
-function cors(request: Request, response: Response): Response {
-  if (request.headers.get("Origin") !== applicationOrigin) return response;
-  const headers = new Headers(response.headers);
-  headers.set("Access-Control-Allow-Origin", applicationOrigin);
-  headers.set("Access-Control-Allow-Credentials", "true");
-  headers.append("Vary", "Origin");
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  });
-}
-
-export async function GET(request: Request): Promise<Response> {
-  return cors(request, await handlers.GET(request));
-}
-
-export async function POST(request: Request): Promise<Response> {
-  return cors(request, await handlers.POST(request));
-}
-
-export function OPTIONS(request: Request): Response {
-  if (request.headers.get("Origin") !== applicationOrigin) {
-    return new Response(null, { status: 403 });
-  }
-  return new Response(null, {
-    status: 204,
-    headers: {
-      "Access-Control-Allow-Origin": applicationOrigin,
-      "Access-Control-Allow-Credentials": "true",
-      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-      "Access-Control-Allow-Headers": "Authorization, Content-Type, X-CSRF-Token",
-      "Vary": "Origin",
-    },
-  });
-}
+export const GET = handlers.GET;
+export const POST = handlers.POST;
 ```
+
+Do not wrap these API route responses in a route-local CORS helper. The API
+router replaces policy-owned CORS headers with the validated global policy.
 
 Pass an authorization header through the hook `headers` option when the
 workflow origin uses bearer authentication. Set `credentials: "include"` only
 for a credentialed cookie session; that mode requires the exact-origin
 `Access-Control-Allow-Origin` and `Access-Control-Allow-Credentials: true`
-headers shown above. The preflight must allow `Content-Type`, `Authorization`,
-and any configured CSRF header the client sends.
+settings shown above. The global preflight policy must allow `Content-Type`,
+`Authorization`, and any configured CSRF header the client sends.
 
 ### Stream run events
 

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -205,13 +205,18 @@ describe("Guide code example coverage", () => {
 });
 
 describe("Guide: middleware.md", () => {
-  it("uses one route-specific CORS policy for preflight and the actual response", async () => {
-    const corsConfig: CORSConfig = {
-      origin: "https://example.com",
-      methods: ["GET", "OPTIONS"],
-      allowedHeaders: ["Authorization"],
-      maxAge: 86400,
-    };
+  it("uses the global CORS policy for preflight and the actual response", async () => {
+    const config = defineConfig({
+      security: {
+        cors: {
+          origin: "https://example.com",
+          methods: ["GET", "OPTIONS"],
+          allowedHeaders: ["Authorization"],
+          maxAge: 86400,
+        } satisfies CORSConfig,
+      },
+    });
+    const corsConfig = config.security?.cors;
     const preflight = await handleCORSPreflight({
       request: new Request("http://localhost/api/report", {
         method: "OPTIONS",

--- a/tests/docs/guide-code-examples.test.ts
+++ b/tests/docs/guide-code-examples.test.ts
@@ -32,6 +32,11 @@ import {
 } from "../../src/chat/index.ts";
 import { createUploadHandler, ragStore } from "../../src/embedding/index.ts";
 import { defineConfig } from "../../src/config/index.ts";
+import {
+  applyCORSHeaders,
+  type CORSConfig,
+  handleCORSPreflight,
+} from "../../src/security/index.ts";
 import { buildCSP } from "../../src/security/http/response/security-handler.ts";
 import { datasets, evalAgent, evalDataset, metrics, runEval } from "../../src/eval/index.ts";
 import { metrics as projectMetrics } from "../../src/metrics/index.ts";
@@ -196,6 +201,36 @@ describe("Guide code example coverage", () => {
     const guideFiles = new Set(await guideFilesWithCodeFences());
     const stale = [...GUIDE_CODE_EXAMPLE_COVERAGE].filter((name) => !guideFiles.has(name));
     assertEquals(stale, []);
+  });
+});
+
+describe("Guide: middleware.md", () => {
+  it("uses one route-specific CORS policy for preflight and the actual response", async () => {
+    const corsConfig: CORSConfig = {
+      origin: "https://example.com",
+      methods: ["GET", "OPTIONS"],
+      allowedHeaders: ["Authorization"],
+      maxAge: 86400,
+    };
+    const preflight = await handleCORSPreflight({
+      request: new Request("http://localhost/api/report", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://example.com",
+          "access-control-request-method": "GET",
+          "access-control-request-headers": "Authorization",
+        },
+      }),
+      config: corsConfig,
+    });
+    assertEquals(preflight.headers.get("access-control-allow-origin"), "https://example.com");
+
+    const request = new Request("http://localhost/api/report", {
+      headers: { origin: "https://example.com" },
+    });
+    const response = Response.json({ report: "ready" });
+    const actual = await applyCORSHeaders({ request, response, config: corsConfig }) ?? response;
+    assertEquals(actual.headers.get("access-control-allow-origin"), "https://example.com");
   });
 });
 

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -146,6 +146,11 @@ describe("guide content contracts", () => {
     assertStringIncludes(guide, "A callable default Pages route is");
     assertStringIncludes(guide, "cannot override the global policy after route dispatch");
     assertStringIncludes(guide, "validated global `security.cors` policy");
+    assertStringIncludes(
+      guide,
+      "An unauthenticated preflight for an auth-protected route is the exception",
+    );
+    assertStringIncludes(guide, "without executing the explicit handler");
   });
 
   it("describes the server-bound workflow approval identity", async () => {

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -134,16 +134,18 @@ describe("guide content contracts", () => {
       new URL("docs/guides/middleware.md", repoRoot),
     );
 
-    assertStringIncludes(guide, "Global `security.cors` owns automatic preflight");
+    assertStringIncludes(
+      guide,
+      "Global `security.cors` is authoritative for CORS headers",
+    );
     assertStringIncludes(
       guide,
       "Method-local `cors()` middleware runs only inside the handler that calls it",
     );
     assertStringIncludes(guide, "An explicit `OPTIONS` export is authoritative");
-    assertStringIncludes(guide, "A callable default Pages route is also authoritative");
-    assertStringIncludes(guide, "export function OPTIONS(request: Request): Promise<Response>");
-    assertStringIncludes(guide, "handleCORSPreflight({ request, config: corsConfig })");
-    assertStringIncludes(guide, "applyCORSHeaders({ request, response, config: corsConfig })");
+    assertStringIncludes(guide, "A callable default Pages route is");
+    assertStringIncludes(guide, "cannot override the global policy after route dispatch");
+    assertStringIncludes(guide, "validated global `security.cors` policy");
   });
 
   it("describes the server-bound workflow approval identity", async () => {

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -129,6 +129,23 @@ describe("guide content contracts", () => {
     assertStringIncludes(guide, "return cors(request, await handlers.POST(request));");
   });
 
+  it("documents who owns automatic and route-specific CORS preflight", async () => {
+    const guide = await Deno.readTextFile(
+      new URL("docs/guides/middleware.md", repoRoot),
+    );
+
+    assertStringIncludes(guide, "Global `security.cors` owns automatic preflight");
+    assertStringIncludes(
+      guide,
+      "Method-local `cors()` middleware runs only inside the handler that calls it",
+    );
+    assertStringIncludes(guide, "An explicit `OPTIONS` export is authoritative");
+    assertStringIncludes(guide, "A callable default Pages route is also authoritative");
+    assertStringIncludes(guide, "export function OPTIONS(request: Request): Promise<Response>");
+    assertStringIncludes(guide, "handleCORSPreflight({ request, config: corsConfig })");
+    assertStringIncludes(guide, "applyCORSHeaders({ request, response, config: corsConfig })");
+  });
+
   it("describes the server-bound workflow approval identity", async () => {
     const guide = await Deno.readTextFile(
       new URL("docs/guides/workflows.md", repoRoot),

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -117,16 +117,18 @@ describe("guide content contracts", () => {
       new URL("docs/guides/workflows-advanced.md", repoRoot),
     );
 
-    assertStringIncludes(guide, "export function OPTIONS(request: Request): Response");
-    assertStringIncludes(guide, '"Access-Control-Allow-Origin": applicationOrigin');
-    assertStringIncludes(guide, '"Access-Control-Allow-Credentials": "true"');
-    assertStringIncludes(guide, '"Access-Control-Allow-Methods": "GET, POST, OPTIONS"');
+    assertStringIncludes(guide, "security: {");
+    assertStringIncludes(guide, 'origin: "https://app.example.com"');
+    assertStringIncludes(guide, 'methods: ["GET", "POST", "OPTIONS"]');
     assertStringIncludes(
       guide,
-      '"Access-Control-Allow-Headers": "Authorization, Content-Type, X-CSRF-Token"',
+      'allowedHeaders: ["Authorization", "Content-Type", "X-CSRF-Token"]',
     );
-    assertStringIncludes(guide, "return cors(request, await handlers.GET(request));");
-    assertStringIncludes(guide, "return cors(request, await handlers.POST(request));");
+    assertStringIncludes(guide, "credentials: true");
+    assertStringIncludes(guide, "export const GET = handlers.GET;");
+    assertStringIncludes(guide, "export const POST = handlers.POST;");
+    assertEquals(guide.includes("export function OPTIONS"), false);
+    assertEquals(guide.includes("return cors(request"), false);
   });
 
   it("documents who owns automatic and route-specific CORS preflight", async () => {
@@ -155,6 +157,8 @@ describe("guide content contracts", () => {
       "An unauthenticated preflight for an auth-protected route is the exception",
     );
     assertStringIncludes(guide, "without executing the explicit handler");
+    assertStringIncludes(guide, "at the API router boundary");
+    assertStringIncludes(guide, "Root middleware resumes after the route returns");
     assertEquals(
       guide.includes('import { cors } from "veryfront/middleware";'),
       false,

--- a/tests/docs/guide-content.test.ts
+++ b/tests/docs/guide-content.test.ts
@@ -140,6 +140,10 @@ describe("guide content contracts", () => {
     );
     assertStringIncludes(
       guide,
+      "For App and Pages API routes, configure CORS globally",
+    );
+    assertStringIncludes(
+      guide,
       "Method-local `cors()` middleware runs only inside the handler that calls it",
     );
     assertStringIncludes(guide, "An explicit `OPTIONS` export is authoritative");
@@ -151,6 +155,16 @@ describe("guide content contracts", () => {
       "An unauthenticated preflight for an auth-protected route is the exception",
     );
     assertStringIncludes(guide, "without executing the explicit handler");
+    assertEquals(
+      guide.includes('import { cors } from "veryfront/middleware";'),
+      false,
+      "the API route guide must not present method-local CORS as a working router policy",
+    );
+    assertEquals(
+      guide.includes(".use(cors("),
+      false,
+      "API route pipeline recipes must leave CORS ownership to security.cors",
+    );
   });
 
   it("describes the server-bound workflow approval identity", async () => {


### PR DESCRIPTION
## Summary

- document that global security.cors owns framework-generated automatic preflight
- remove ineffective route-local cors() recipes from every API route guide and limit method-local CORS to responses outside the API router
- show a complete global policy used consistently by preflight and actual responses
- record that explicit OPTIONS and callable Pages defaults own status, body, and non-CORS headers at the router boundary
- document that root middleware can deliberately change the final wire policy after routing

## Scope

PRs #4346 and #4351 completed the runtime portion by dispatching explicit OPTIONS handlers consistently. This change completes the approved documentation contract from the issue without adding route metadata or executing GET to infer policy.

## Red-green TDD

RED: guide-content contracts failed because the middleware guide did not state the ownership boundaries and still presented route-local cors() as a working API-router policy.

GREEN: the contracts pass, prohibit ineffective route-local CORS recipes across the API-route guides, qualify the root-middleware boundary, and verify that the documented global policy emits the same allowed origin on preflight and the actual response.

## Verification

- deno task test:file tests/docs/guide-content.test.ts
- deno task test:file tests/docs/guide-code-examples.test.ts
- deno task docs:public:check
- deno task typecheck
- deno task lint:ci
- focused format, lint, and diff checks

Closes veryfront/veryfront-issue-inbox#201