### PR TITLE
fix(mdx): keep npm Head on one React runtime

### DIFF
--- a/src/transforms/mdx/esm-module-loader/module-fetcher/dependency-recovery.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/dependency-recovery.ts
@@ -37,7 +37,7 @@ interface EnsureMdxModuleDependenciesResult {
   missing: string[];
 }
 
-export function extractMdxModuleDependencyPaths(code: string): string[] {
+function extractMdxModuleDependencyPaths(code: string): string[] {
   const paths: string[] = [];
   const seen = new Set<string>();
   let match: RegExpExecArray | null;

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/dependency-recovery.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/dependency-recovery.ts
@@ -37,7 +37,7 @@ interface EnsureMdxModuleDependenciesResult {
   missing: string[];
 }
 
-function extractMdxModuleDependencyPaths(code: string): string[] {
+export function extractMdxModuleDependencyPaths(code: string): string[] {
   const paths: string[] = [];
   const seen = new Set<string>();
   let match: RegExpExecArray | null;

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.test.ts
@@ -326,18 +326,23 @@ describe("module-fetcher/distributed-cache", () => {
       log,
     );
 
-    const primary = cache.values.get("transform:write");
-    const recovery = cache.setCalls.find((call) => call.key.endsWith(":vfmod"));
-
     // dependency-recovery.ts looks the entry up by the file name cacheModule
     // writes locally, so the two producers must agree on that name.
     const localPath = await withTempDir((esmCacheDir) =>
       cacheModule("app/page.mdx", moduleCode, esmCacheDir, new Map<string, string>(), log)
     );
     assertEquals(typeof localPath, "string", "cacheModule must write the module locally");
+    const expectedRecoveryKey = buildMdxEsmModuleRecoveryCacheKey(
+      "project-a",
+      "preview-main",
+      basename(localPath!),
+    );
+    await waitForSetKeys(cache, ["transform:write", expectedRecoveryKey]);
+    const primary = cache.values.get("transform:write");
+    const recovery = cache.setCalls.find((call) => call.key === expectedRecoveryKey);
     assertEquals(
       recovery?.key,
-      buildMdxEsmModuleRecoveryCacheKey("project-a", "preview-main", basename(localPath!)),
+      expectedRecoveryKey,
       "recovery key must carry the same file name cacheModule writes locally",
     );
 
@@ -349,6 +354,86 @@ describe("module-fetcher/distributed-cache", () => {
     assertEquals(cache.setCalls[0]?.ttlSeconds, TRANSFORM_DISTRIBUTED_TTL_SEC);
     assertEquals(recovery?.ttlSeconds, TRANSFORM_DISTRIBUTED_TTL_SEC);
     assertEquals(recovery?.value, primary);
+  });
+
+  it("publishes recursive framework vfmods for fresh-worker recovery", async () => {
+    await withTempDir(async (tempDir) => {
+      const cacheDir = join(tempDir, ".cache", "veryfront-mdx-esm", "framework");
+      const tenantCacheDir = join(tempDir, ".cache", "veryfront-mdx-esm", "project-a");
+      const childPath = join(cacheDir, "vfmod-child.mjs");
+      const grandchildPath = join(cacheDir, "vfmod-grandchild.mjs");
+      const tenantPath = join(tenantCacheDir, "vfmod-tenant.mjs");
+      await Deno.mkdir(cacheDir, { recursive: true });
+      await Deno.mkdir(tenantCacheDir, { recursive: true });
+      await Deno.writeTextFile(grandchildPath, `export const value = 1;`);
+      await Deno.writeTextFile(tenantPath, `export const tenant = true;`);
+      await Deno.writeTextFile(
+        childPath,
+        `import { value } from "file://${grandchildPath}"; export default value;`,
+      );
+
+      const cache = new FakeDistributedCache();
+      const { log } = createCapturingLogger();
+      const parentCode = [
+        `import child from "file://${childPath}";`,
+        `import { tenant } from "file://${tenantPath}";`,
+        `export default tenant ? child : null;`,
+      ].join("\n");
+      writeDistributedCache(
+        cache,
+        "transform:framework-entry",
+        "project-a",
+        "preview-main",
+        parentCode,
+        "_vf_modules/_veryfront/react/runtime/core.js",
+        log,
+      );
+
+      const childKey = buildMdxEsmModuleRecoveryCacheKey(
+        "project-a",
+        "preview-main",
+        basename(childPath),
+      );
+      const grandchildKey = buildMdxEsmModuleRecoveryCacheKey(
+        "project-a",
+        "preview-main",
+        basename(grandchildPath),
+      );
+      await waitForSetKeys(cache, [
+        grandchildKey,
+        childKey,
+        "transform:framework-entry",
+      ]);
+      assertEquals(cache.values.has(childKey), true);
+      assertEquals(cache.values.has(grandchildKey), true);
+      assertEquals(
+        cache.values.has(
+          buildMdxEsmModuleRecoveryCacheKey(
+            "project-a",
+            "preview-main",
+            basename(tenantPath),
+          ),
+        ),
+        false,
+      );
+      assertEquals(cache.values.get(childKey)?.includes(tempDir), false);
+      assertEquals(
+        cache.values.get(childKey)?.includes(
+          "file://__VF_CACHE_DIR__/veryfront-mdx-esm/framework/vfmod-grandchild.mjs",
+        ),
+        true,
+      );
+      assertEquals(
+        cache.setCalls.every((call) => call.ttlSeconds === TRANSFORM_DISTRIBUTED_TTL_SEC),
+        true,
+      );
+      const publishedKeys = cache.setCalls.map((call) => call.key);
+      assertEquals(publishedKeys.indexOf(grandchildKey) < publishedKeys.indexOf(childKey), true);
+      assertEquals(
+        publishedKeys.indexOf(childKey) < publishedKeys.indexOf("transform:framework-entry"),
+        true,
+      );
+    });
   });
 
   it("hashes keys whose fully prefixed identity exceeds API constraints", async () => {

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.test.ts
@@ -358,81 +358,90 @@ describe("module-fetcher/distributed-cache", () => {
 
   it("publishes recursive framework vfmods for fresh-worker recovery", async () => {
     await withTempDir(async (tempDir) => {
-      const cacheDir = join(tempDir, ".cache", "veryfront-mdx-esm", "framework");
-      const tenantCacheDir = join(tempDir, ".cache", "veryfront-mdx-esm", "project-a");
-      const childPath = join(cacheDir, "vfmod-child.mjs");
-      const grandchildPath = join(cacheDir, "vfmod-grandchild.mjs");
-      const tenantPath = join(tenantCacheDir, "vfmod-tenant.mjs");
-      await Deno.mkdir(cacheDir, { recursive: true });
-      await Deno.mkdir(tenantCacheDir, { recursive: true });
-      await Deno.writeTextFile(grandchildPath, `export const value = 1;`);
-      await Deno.writeTextFile(tenantPath, `export const tenant = true;`);
-      await Deno.writeTextFile(
-        childPath,
-        `import { value } from "file://${grandchildPath}"; export default value;`,
-      );
+      await runWithCacheDir(tempDir, async () => {
+        const cacheDir = join(getMdxEsmCacheDir(), "framework");
+        const tenantCacheDir = join(getMdxEsmCacheDir(), "project-a");
+        const childPath = join(cacheDir, "vfmod-child.mjs");
+        const grandchildPath = join(cacheDir, "vfmod-grandchild.mjs");
+        const tenantPath = join(tenantCacheDir, "vfmod-tenant.mjs");
+        const privatePath = join(tempDir, "private.mjs");
+        const escapedPrivatePath = `${cacheDir}/../../private.mjs`;
+        await Deno.mkdir(cacheDir, { recursive: true });
+        await Deno.mkdir(tenantCacheDir, { recursive: true });
+        await Deno.writeTextFile(grandchildPath, `export const value = 1;`);
+        await Deno.writeTextFile(tenantPath, `export const tenant = true;`);
+        await Deno.writeTextFile(privatePath, `export const privateValue = true;`);
+        await Deno.writeTextFile(
+          childPath,
+          `import { value } from "file://${grandchildPath}"; export default value;`,
+        );
 
-      const cache = new FakeDistributedCache();
-      const { log } = createCapturingLogger();
-      const parentCode = [
-        `import child from "file://${childPath}";`,
-        `import { tenant } from "file://${tenantPath}";`,
-        `export default tenant ? child : null;`,
-      ].join("\n");
-      writeDistributedCache(
-        cache,
-        "transform:framework-entry",
-        "project-a",
-        "preview-main",
-        parentCode,
-        "_vf_modules/_veryfront/react/runtime/core.js",
-        log,
-      );
+        const cache = new FakeDistributedCache();
+        const { log } = createCapturingLogger();
+        const parentCode = [
+          `import child from "file://${childPath}";`,
+          `import { tenant } from "file://${tenantPath}";`,
+          `import "file://${escapedPrivatePath}";`,
+          `const decoy = "file://${escapedPrivatePath}";`,
+          `export default tenant ? child : decoy;`,
+        ].join("\n");
+        writeDistributedCache(
+          cache,
+          "transform:framework-entry",
+          "project-a",
+          "preview-main",
+          parentCode,
+          "_vf_modules/_veryfront/react/runtime/core.js",
+          log,
+        );
 
-      const childKey = buildMdxEsmModuleRecoveryCacheKey(
-        "project-a",
-        "preview-main",
-        basename(childPath),
-      );
-      const grandchildKey = buildMdxEsmModuleRecoveryCacheKey(
-        "project-a",
-        "preview-main",
-        basename(grandchildPath),
-      );
-      await waitForSetKeys(cache, [
-        grandchildKey,
-        childKey,
-        "transform:framework-entry",
-      ]);
-      assertEquals(cache.values.has(childKey), true);
-      assertEquals(cache.values.has(grandchildKey), true);
-      assertEquals(
-        cache.values.has(
-          buildMdxEsmModuleRecoveryCacheKey(
-            "project-a",
-            "preview-main",
-            basename(tenantPath),
+        const childKey = buildMdxEsmModuleRecoveryCacheKey(
+          "project-a",
+          "preview-main",
+          basename(childPath),
+        );
+        const grandchildKey = buildMdxEsmModuleRecoveryCacheKey(
+          "project-a",
+          "preview-main",
+          basename(grandchildPath),
+        );
+        await waitForSetKeys(cache, [
+          grandchildKey,
+          childKey,
+          "transform:framework-entry",
+        ]);
+        assertEquals(cache.values.has(childKey), true);
+        assertEquals(cache.values.has(grandchildKey), true);
+        for (const excludedPath of [tenantPath, privatePath]) {
+          assertEquals(
+            cache.values.has(
+              buildMdxEsmModuleRecoveryCacheKey(
+                "project-a",
+                "preview-main",
+                basename(excludedPath),
+              ),
+            ),
+            false,
+          );
+        }
+        assertEquals(cache.values.get(childKey)?.includes(tempDir), false);
+        assertEquals(
+          cache.values.get(childKey)?.includes(
+            "file://__VF_CACHE_DIR__/veryfront-mdx-esm/framework/vfmod-grandchild.mjs",
           ),
-        ),
-        false,
-      );
-      assertEquals(cache.values.get(childKey)?.includes(tempDir), false);
-      assertEquals(
-        cache.values.get(childKey)?.includes(
-          "file://__VF_CACHE_DIR__/veryfront-mdx-esm/framework/vfmod-grandchild.mjs",
-        ),
-        true,
-      );
-      assertEquals(
-        cache.setCalls.every((call) => call.ttlSeconds === TRANSFORM_DISTRIBUTED_TTL_SEC),
-        true,
-      );
-      const publishedKeys = cache.setCalls.map((call) => call.key);
-      assertEquals(publishedKeys.indexOf(grandchildKey) < publishedKeys.indexOf(childKey), true);
-      assertEquals(
-        publishedKeys.indexOf(childKey) < publishedKeys.indexOf("transform:framework-entry"),
-        true,
-      );
+          true,
+        );
+        assertEquals(
+          cache.setCalls.every((call) => call.ttlSeconds === TRANSFORM_DISTRIBUTED_TTL_SEC),
+          true,
+        );
+        const publishedKeys = cache.setCalls.map((call) => call.key);
+        assertEquals(publishedKeys.indexOf(grandchildKey) < publishedKeys.indexOf(childKey), true);
+        assertEquals(
+          publishedKeys.indexOf(childKey) < publishedKeys.indexOf("transform:framework-entry"),
+          true,
+        );
+      });
     });
   });
 

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Logger } from "#veryfront/utils";
+import { basename } from "#veryfront/compat/path/index.ts";
 import { detokenizeAllCachePaths, tokenizeAllVeryFrontPaths } from "#veryfront/cache/paths.ts";
 import { cacheHttpImportsToLocal } from "../../../esm/http-cache.ts";
 import { loadImportMap } from "#veryfront/modules/import-map/index.ts";
@@ -23,10 +24,14 @@ import {
   findMissingFileDependenciesInCode,
   hasIncompatibleFrameworkPaths,
 } from "./framework-validator.ts";
-import { ensureMdxModuleDependencies } from "./dependency-recovery.ts";
+import {
+  ensureMdxModuleDependencies,
+  extractMdxModuleDependencyPaths,
+} from "./dependency-recovery.ts";
 import { buildMdxEsmModuleFileName, buildMdxEsmModuleRecoveryCacheKey } from "../cache-format.ts";
 import { hashString } from "../utils/hash.ts";
 import { computeHash } from "#veryfront/utils/hash-utils.ts";
+import { getLocalFs } from "../cache/local-fs.ts";
 
 /** TTL for cached transforms (uses centralized config) */
 const TRANSFORM_CACHE_TTL_SECONDS = TRANSFORM_DISTRIBUTED_TTL_SEC;
@@ -263,6 +268,41 @@ export function writeDistributedCache(
   normalizedPath: string,
   log: Logger,
 ): void {
+  void writeDistributedCacheEntries(
+    distributedCache,
+    transformCacheKey,
+    projectId,
+    contentSourceId,
+    moduleCode,
+    normalizedPath,
+    log,
+  ).catch((error) => {
+    log.debug(`${LOG_PREFIX_MDX_LOADER} Distributed dependency recovery publish failed`, {
+      normalizedPath,
+      error,
+    });
+  });
+}
+
+async function writeDistributedCacheEntries(
+  distributedCache: DistributedCache,
+  transformCacheKey: string,
+  projectId: string,
+  contentSourceId: string,
+  moduleCode: string,
+  normalizedPath: string,
+  log: Logger,
+): Promise<void> {
+  // A fresh worker must be able to restore every recursively materialized
+  // framework file before it accepts the parent transform cache entry.
+  await publishFrameworkModuleRecoveryDependencies(
+    distributedCache,
+    projectId,
+    contentSourceId,
+    moduleCode,
+    log,
+  );
+
   // Tokenize all cache paths for cross-environment portability
   // Uses aggressive tokenization to catch paths from ANY environment (build server, other pods)
   const portableCode = tokenizeAllVeryFrontPaths(moduleCode);
@@ -319,4 +359,49 @@ export function writeDistributedCache(
       }
     })();
   }
+}
+
+/** Publish locally materialized vfmod dependencies for recovery on fresh workers. */
+async function publishFrameworkModuleRecoveryDependencies(
+  distributedCache: DistributedCache,
+  projectId: string,
+  contentSourceId: string,
+  moduleCode: string,
+  log: Logger,
+): Promise<void> {
+  const localFs = getLocalFs();
+  const visited = new Set<string>();
+
+  const publishCodeDependencies = async (code: string): Promise<void> => {
+    for (const dependencyPath of extractMdxModuleDependencyPaths(code)) {
+      if (!dependencyPath.includes("/veryfront-mdx-esm/framework/")) continue;
+      if (visited.has(dependencyPath)) continue;
+      visited.add(dependencyPath);
+
+      let dependencyCode: string;
+      try {
+        dependencyCode = await localFs.readTextFile(dependencyPath);
+      } catch (error) {
+        log.debug(`${LOG_PREFIX_MDX_LOADER} Local vfmod dependency unavailable for recovery`, {
+          dependencyFile: basename(dependencyPath),
+          error,
+        });
+        throw error;
+      }
+
+      await publishCodeDependencies(dependencyCode);
+      const recoveryKey = buildMdxEsmModuleRecoveryCacheKey(
+        projectId,
+        contentSourceId,
+        basename(dependencyPath),
+      );
+      await distributedCache.set(
+        recoveryKey,
+        tokenizeAllVeryFrontPaths(dependencyCode),
+        TRANSFORM_CACHE_TTL_SECONDS,
+      );
+    }
+  };
+
+  await publishCodeDependencies(moduleCode);
 }

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/distributed-cache.ts
@@ -8,14 +8,15 @@
  */
 
 import type { Logger } from "#veryfront/utils";
-import { basename } from "#veryfront/compat/path/index.ts";
+import { basename, fromFileUrl, join, resolve } from "#veryfront/compat/path/index.ts";
 import { detokenizeAllCachePaths, tokenizeAllVeryFrontPaths } from "#veryfront/cache/paths.ts";
+import { isPathContainedBy } from "#veryfront/platform/adapters/path-containment.ts";
 import { cacheHttpImportsToLocal } from "../../../esm/http-cache.ts";
 import { loadImportMap } from "#veryfront/modules/import-map/index.ts";
 import { extractHttpBundlePaths } from "#veryfront/modules/react-loader/ssr-module-loader/http-bundle-helpers.ts";
 import { createBundleManifest, storeBundleManifest } from "../../../esm/bundle-manifest.ts";
 import { validateCachedBundlesByManifestOrCode } from "../../../esm/cached-bundle-validation.ts";
-import { getHttpBundleCacheDir } from "#veryfront/utils/cache-dir.ts";
+import { getHttpBundleCacheDir, getMdxEsmCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { FRAMEWORK_ROOT, LOG_PREFIX_MDX_LOADER } from "../constants.ts";
 import { getDistributedTransformBackend } from "#veryfront/transforms/esm/transform-cache.ts";
 import { TRANSFORM_DISTRIBUTED_TTL_SEC } from "#veryfront/utils/constants/cache.ts";
@@ -24,14 +25,12 @@ import {
   findMissingFileDependenciesInCode,
   hasIncompatibleFrameworkPaths,
 } from "./framework-validator.ts";
-import {
-  ensureMdxModuleDependencies,
-  extractMdxModuleDependencyPaths,
-} from "./dependency-recovery.ts";
+import { ensureMdxModuleDependencies } from "./dependency-recovery.ts";
 import { buildMdxEsmModuleFileName, buildMdxEsmModuleRecoveryCacheKey } from "../cache-format.ts";
 import { hashString } from "../utils/hash.ts";
 import { computeHash } from "#veryfront/utils/hash-utils.ts";
 import { getLocalFs } from "../cache/local-fs.ts";
+import { parseImports } from "#veryfront/transforms/esm/lexer.ts";
 
 /** TTL for cached transforms (uses centralized config) */
 const TRANSFORM_CACHE_TTL_SECONDS = TRANSFORM_DISTRIBUTED_TTL_SEC;
@@ -362,6 +361,40 @@ async function writeDistributedCacheEntries(
 }
 
 /** Publish locally materialized vfmod dependencies for recovery on fresh workers. */
+async function extractFrameworkModuleDependencyPaths(code: string): Promise<string[]> {
+  const frameworkCacheRoot = resolve(join(getMdxEsmCacheDir(), "framework"));
+  const dependencies: string[] = [];
+  const seen = new Set<string>();
+
+  for (const imported of await parseImports(code)) {
+    const specifier = imported.n;
+    if (!specifier?.startsWith("file:")) continue;
+
+    try {
+      const url = new URL(specifier);
+      if (url.protocol !== "file:") continue;
+      url.search = "";
+      url.hash = "";
+      const dependencyPath = resolve(fromFileUrl(url));
+      if (
+        dependencyPath === frameworkCacheRoot ||
+        !isPathContainedBy(dependencyPath, frameworkCacheRoot) ||
+        !dependencyPath.endsWith(".mjs") ||
+        seen.has(dependencyPath)
+      ) {
+        continue;
+      }
+      seen.add(dependencyPath);
+      dependencies.push(dependencyPath);
+    } catch {
+      // Ignore malformed and non-local file URLs. The module validator reports
+      // unresolved imports separately without expanding filesystem access.
+    }
+  }
+
+  return dependencies;
+}
+
 async function publishFrameworkModuleRecoveryDependencies(
   distributedCache: DistributedCache,
   projectId: string,
@@ -373,8 +406,7 @@ async function publishFrameworkModuleRecoveryDependencies(
   const visited = new Set<string>();
 
   const publishCodeDependencies = async (code: string): Promise<void> => {
-    for (const dependencyPath of extractMdxModuleDependencyPaths(code)) {
-      if (!dependencyPath.includes("/veryfront-mdx-esm/framework/")) continue;
+    for (const dependencyPath of await extractFrameworkModuleDependencyPaths(code)) {
       if (visited.has(dependencyPath)) continue;
       visited.add(dependencyPath);
 

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/index.ts
@@ -21,7 +21,10 @@ import type { ModuleFetcherContext } from "../types.ts";
 import { getModulePathCache } from "../cache/index.ts";
 import { hashString } from "../utils/hash.ts";
 import { resolveModuleFile } from "../resolution/file-finder.ts";
-import { canonicalizeContainedModulePath } from "../resolution/module-path.ts";
+import {
+  canonicalizeContainedModulePath,
+  frameworkSourceKeyOf,
+} from "../resolution/module-path.ts";
 import {
   isPublicFrameworkSourceKey,
 } from "#veryfront/platform/compat/framework-source-resolver.ts";
@@ -153,18 +156,6 @@ function unwrapDependencyPinningPath(
   // implies SSR and the cache variant comes from the context's snapshot key,
   // not from the URL. An unpinned path keeps its query untouched.
   return extracted.pathname;
-}
-
-/**
- * Return the framework-relative source key for a `_veryfront/` module path,
- * or null when the path does not address framework source.
- */
-function frameworkSourceKeyOf(modulePath: string): string | null {
-  const withoutVfModules = modulePath.startsWith("_vf_modules/")
-    ? modulePath.slice("_vf_modules/".length)
-    : modulePath;
-  if (!withoutVfModules.startsWith("_veryfront/")) return null;
-  return withoutVfModules.slice("_veryfront/".length);
 }
 
 /**

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.test.ts
@@ -76,10 +76,10 @@ describe("module-fetcher/source-transform", () => {
     const reactVersions: string[] = [];
     await transformResolvedModuleSource({
       sourceCode: `export const value = 1;`,
-      actualFilePath: "/node_modules/veryfront/esm/src/value.js",
+      actualFilePath: "/node_modules/veryfront/esm/src/react/runtime/core.js",
       projectDir: "/project",
       projectId: "project-1",
-      normalizedPath: "_veryfront/value.js",
+      normalizedPath: "_veryfront/react/runtime/core.js",
       projectSlug: "docs",
       dev: false,
       adapter: {} as RuntimeAdapter,
@@ -97,6 +97,39 @@ describe("module-fetcher/source-transform", () => {
     assertEquals(reactVersions, [REACT_DEFAULT_VERSION]);
   });
 
+  it("keeps other framework entries on the dependency-pinned generic path", async () => {
+    const calls: string[] = [];
+    const result = await transformResolvedModuleSource({
+      sourceCode: `import { createOpenAIProviderModel } from "@veryfront/ext-llm-openai";`,
+      actualFilePath: "/node_modules/veryfront/esm/src/provider/index.js",
+      projectDir: "/project",
+      projectId: "project-1",
+      normalizedPath: "_vf_modules/_veryfront/provider/index.js",
+      projectSlug: "docs",
+      dependencyPinningCacheKey: "on:snapshot-a",
+      dependencyPinningDependencies: { "@veryfront/ext-llm-openai": "0.1.1200" },
+      dev: false,
+      adapter: {} as RuntimeAdapter,
+      log: noopLog,
+      transformToEsm: (_source, _path, _projectDir, _adapter, options) => {
+        calls.push("transformToEsm");
+        assertEquals(options.dependencyPinningCacheKey, "on:snapshot-a");
+        assertEquals(options.dependencyPinningDependencies, {
+          "@veryfront/ext-llm-openai": "0.1.1200",
+        });
+        return Promise.resolve(`export const provider = true;`);
+      },
+      loadImportMap: () => Promise.resolve({ imports: {} }),
+      cacheHttpImportsToLocal: (code) => Promise.resolve({ code }),
+      transformFrameworkSource: () => {
+        throw new Error("non-runtime framework entries must retain dependency pinning");
+      },
+    });
+
+    assertEquals(calls, ["transformToEsm"]);
+    assertEquals(result, `export const provider = true;`);
+  });
+
   it("logs module context when a framework transform fails", async () => {
     const errorCalls: unknown[] = [];
     const sourceCode = `export const broken = true;`;
@@ -106,10 +139,10 @@ describe("module-fetcher/source-transform", () => {
       () =>
         transformResolvedModuleSource({
           sourceCode,
-          actualFilePath: "/node_modules/veryfront/esm/src/broken.js",
+          actualFilePath: "/node_modules/veryfront/esm/src/react/runtime/core.js",
           projectDir: "/project",
           projectId: "project-1",
-          normalizedPath: "_vf_modules/_veryfront/broken.js",
+          normalizedPath: "_vf_modules/_veryfront/react/runtime/core.js",
           projectSlug: "docs",
           dev: false,
           adapter: {} as RuntimeAdapter,
@@ -127,8 +160,8 @@ describe("module-fetcher/source-transform", () => {
     assertEquals(errorCalls, [[
       "[mdx-loader] Transform failed for module",
       {
-        normalizedPath: "_vf_modules/_veryfront/broken.js",
-        actualFilePath: "/node_modules/veryfront/esm/src/broken.js",
+        normalizedPath: "_vf_modules/_veryfront/react/runtime/core.js",
+        actualFilePath: "/node_modules/veryfront/esm/src/react/runtime/core.js",
         sourceLength: sourceCode.length,
         sourcePreview: sourceCode,
         error: failure.message,

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.test.ts
@@ -12,6 +12,61 @@ const noopLog = {
 } as const;
 
 describe("module-fetcher/source-transform", () => {
+  it("recursively transforms public framework entries before caching them", async () => {
+    const calls: string[] = [];
+    const importMap = { imports: {} };
+    const result = await transformResolvedModuleSource({
+      sourceCode: `import { useServerRenderContext } from "../server-render-context.js";`,
+      actualFilePath: "/node_modules/veryfront/esm/src/react/runtime/core.js",
+      projectDir: "/project",
+      projectId: "project-1",
+      normalizedPath: "_vf_modules/_veryfront/react/runtime/core.js",
+      projectSlug: "docs",
+      reactVersion: "19.2.4",
+      dev: false,
+      adapter: {} as RuntimeAdapter,
+      log: noopLog,
+      loadImportMap: (projectDir) => {
+        calls.push("loadImportMap");
+        assertEquals(projectDir, "/project");
+        return Promise.resolve(importMap);
+      },
+      transformFrameworkSource: (
+        source,
+        sourcePath,
+        reactVersion,
+        projectDir,
+        _fs,
+        _onProgress,
+        receivedImportMap,
+      ) => {
+        calls.push("transformFrameworkSource");
+        assertEquals(
+          { source, sourcePath, reactVersion, projectDir },
+          {
+            source: `import { useServerRenderContext } from "../server-render-context.js";`,
+            sourcePath: "/node_modules/veryfront/esm/src/react/runtime/core.js",
+            reactVersion: "19.2.4",
+            projectDir: "/project",
+          },
+        );
+        assertEquals(receivedImportMap, importMap);
+        return Promise.resolve(
+          `import { useServerRenderContext } from "file:///cache/server-render-context.mjs";`,
+        );
+      },
+      transformToEsm: () => {
+        throw new Error("generic tenant transform must not handle framework entries");
+      },
+    });
+
+    assertEquals(calls, ["loadImportMap", "transformFrameworkSource"]);
+    assertEquals(
+      result,
+      `import { useServerRenderContext } from "file:///cache/server-render-context.mjs";`,
+    );
+  });
+
   it("preprocesses veryfront imports before transform and caches HTTP imports after transform", async () => {
     const calls: string[] = [];
     const adapter = {} as RuntimeAdapter;

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.test.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.test.ts
@@ -1,7 +1,9 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { fingerprintImportMap } from "#veryfront/transforms/esm/http-cache-helpers.ts";
+import { REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import { transformResolvedModuleSource } from "./source-transform.ts";
 
 const noopLog = {
@@ -15,6 +17,7 @@ describe("module-fetcher/source-transform", () => {
   it("recursively transforms public framework entries before caching them", async () => {
     const calls: string[] = [];
     const importMap = { imports: {} };
+    const expectedImportMapFingerprint = await fingerprintImportMap(importMap);
     const result = await transformResolvedModuleSource({
       sourceCode: `import { useServerRenderContext } from "../server-render-context.js";`,
       actualFilePath: "/node_modules/veryfront/esm/src/react/runtime/core.js",
@@ -39,6 +42,7 @@ describe("module-fetcher/source-transform", () => {
         _fs,
         _onProgress,
         receivedImportMap,
+        importMapFingerprint,
       ) => {
         calls.push("transformFrameworkSource");
         assertEquals(
@@ -51,6 +55,7 @@ describe("module-fetcher/source-transform", () => {
           },
         );
         assertEquals(receivedImportMap, importMap);
+        assertEquals(importMapFingerprint, expectedImportMapFingerprint);
         return Promise.resolve(
           `import { useServerRenderContext } from "file:///cache/server-render-context.mjs";`,
         );
@@ -65,6 +70,70 @@ describe("module-fetcher/source-transform", () => {
       result,
       `import { useServerRenderContext } from "file:///cache/server-render-context.mjs";`,
     );
+  });
+
+  it("recognizes bare framework paths and defaults the React version", async () => {
+    const reactVersions: string[] = [];
+    await transformResolvedModuleSource({
+      sourceCode: `export const value = 1;`,
+      actualFilePath: "/node_modules/veryfront/esm/src/value.js",
+      projectDir: "/project",
+      projectId: "project-1",
+      normalizedPath: "_veryfront/value.js",
+      projectSlug: "docs",
+      dev: false,
+      adapter: {} as RuntimeAdapter,
+      log: noopLog,
+      loadImportMap: () => Promise.resolve({ imports: {} }),
+      transformFrameworkSource: (_source, _path, reactVersion) => {
+        reactVersions.push(reactVersion);
+        return Promise.resolve(`export const value = 1;`);
+      },
+      transformToEsm: () => {
+        throw new Error("generic tenant transform must not handle framework entries");
+      },
+    });
+
+    assertEquals(reactVersions, [REACT_DEFAULT_VERSION]);
+  });
+
+  it("logs module context when a framework transform fails", async () => {
+    const errorCalls: unknown[] = [];
+    const sourceCode = `export const broken = true;`;
+    const failure = new Error("framework transform failed");
+
+    await assertRejects(
+      () =>
+        transformResolvedModuleSource({
+          sourceCode,
+          actualFilePath: "/node_modules/veryfront/esm/src/broken.js",
+          projectDir: "/project",
+          projectId: "project-1",
+          normalizedPath: "_vf_modules/_veryfront/broken.js",
+          projectSlug: "docs",
+          dev: false,
+          adapter: {} as RuntimeAdapter,
+          log: {
+            ...noopLog,
+            error: (message, context) => errorCalls.push([message, context]),
+          },
+          loadImportMap: () => Promise.resolve({ imports: {} }),
+          transformFrameworkSource: () => Promise.reject(failure),
+        }),
+      Error,
+      failure.message,
+    );
+
+    assertEquals(errorCalls, [[
+      "[mdx-loader] Transform failed for module",
+      {
+        normalizedPath: "_vf_modules/_veryfront/broken.js",
+        actualFilePath: "/node_modules/veryfront/esm/src/broken.js",
+        sourceLength: sourceCode.length,
+        sourcePreview: sourceCode,
+        error: failure.message,
+      },
+    ]]);
   });
 
   it("preprocesses veryfront imports before transform and caches HTTP imports after transform", async () => {

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.ts
@@ -5,6 +5,7 @@
  */
 
 import { cacheHttpImportsToLocal } from "../../../esm/http-cache.ts";
+import { fingerprintImportMap } from "../../../esm/http-cache-helpers.ts";
 import { loadImportMap } from "#veryfront/modules/import-map/index.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
@@ -14,6 +15,7 @@ import { REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import type { Logger } from "#veryfront/utils";
 import type { DependencyPinningSourceInput } from "#veryfront/transforms/esm/package-registry.ts";
 import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
+import { frameworkSourceKeyOf } from "../resolution/module-path.ts";
 import { rewriteDntImports, rewriteVeryfrontImports } from "./import-rewriter.ts";
 import { transformFrameworkSource } from "#veryfront/transforms/pipeline/stages/ssr-vf-modules/transform.ts";
 
@@ -22,11 +24,6 @@ type LoadImportMapFn = typeof loadImportMap;
 type CacheHttpImportsToLocalFn = typeof cacheHttpImportsToLocal;
 type TransformFrameworkSourceFn = typeof transformFrameworkSource;
 type SourceTransformLogger = Pick<Logger, "debug" | "error">;
-
-function isFrameworkEntry(normalizedPath: string): boolean {
-  const path = normalizedPath.split(/[?#]/, 1)[0] ?? normalizedPath;
-  return path.startsWith("_vf_modules/_veryfront/") || path.startsWith("_veryfront/");
-}
 
 export interface TransformResolvedModuleSourceInput {
   sourceCode: string;
@@ -55,6 +52,19 @@ export interface TransformResolvedModuleSourceInput {
   transformFrameworkSource?: TransformFrameworkSourceFn;
 }
 
+function logTransformFailure(
+  input: TransformResolvedModuleSourceInput,
+  transformError: unknown,
+): void {
+  input.log.error(`${LOG_PREFIX_MDX_LOADER} Transform failed for module`, {
+    normalizedPath: input.normalizedPath,
+    actualFilePath: input.actualFilePath,
+    sourceLength: input.sourceCode.length,
+    sourcePreview: input.sourceCode.slice(0, 200),
+    error: transformError instanceof Error ? transformError.message : String(transformError),
+  });
+}
+
 /**
  * Transform a resolved source file into cache-safe ESM module code.
  */
@@ -71,19 +81,26 @@ export async function transformResolvedModuleSource(
   // Framework entries must keep their full dependency graph on one transformed
   // React runtime. The generic tenant transform can leave npm package file URLs
   // intact, which loads a second React instance during static MDX rendering.
-  if (isFrameworkEntry(input.normalizedPath)) {
+  if (frameworkSourceKeyOf(input.normalizedPath) !== null) {
     const readImportMap = input.loadImportMap ?? loadImportMap;
     const importMap = await readImportMap(input.projectDir);
+    const importMapFingerprint = await fingerprintImportMap(importMap);
     const transformFramework = input.transformFrameworkSource ?? transformFrameworkSource;
-    return await transformFramework(
-      input.sourceCode,
-      input.actualFilePath,
-      input.reactVersion ?? REACT_DEFAULT_VERSION,
-      input.projectDir,
-      createFileSystem(),
-      undefined,
-      importMap,
-    );
+    try {
+      return await transformFramework(
+        input.sourceCode,
+        input.actualFilePath,
+        input.reactVersion ?? REACT_DEFAULT_VERSION,
+        input.projectDir,
+        createFileSystem(),
+        undefined,
+        importMap,
+        importMapFingerprint,
+      );
+    } catch (transformError) {
+      logTransformFailure(input, transformError);
+      throw transformError;
+    }
   }
 
   const preprocessedSource = rewriteVeryfrontImports(input.sourceCode);
@@ -113,13 +130,7 @@ export async function transformResolvedModuleSource(
       },
     );
   } catch (transformError) {
-    input.log.error(`${LOG_PREFIX_MDX_LOADER} Transform failed for module`, {
-      normalizedPath: input.normalizedPath,
-      actualFilePath: input.actualFilePath,
-      sourceLength: input.sourceCode.length,
-      sourcePreview: input.sourceCode.slice(0, 200),
-      error: transformError instanceof Error ? transformError.message : String(transformError),
-    });
+    logTransformFailure(input, transformError);
     throw transformError;
   }
 

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.ts
@@ -25,6 +25,12 @@ type CacheHttpImportsToLocalFn = typeof cacheHttpImportsToLocal;
 type TransformFrameworkSourceFn = typeof transformFrameworkSource;
 type SourceTransformLogger = Pick<Logger, "debug" | "error">;
 
+const RECURSIVE_REACT_RUNTIME_SOURCE_KEY = "react/runtime/core.js";
+
+function isRecursiveReactRuntimeEntry(normalizedPath: string): boolean {
+  return frameworkSourceKeyOf(normalizedPath) === RECURSIVE_REACT_RUNTIME_SOURCE_KEY;
+}
+
 export interface TransformResolvedModuleSourceInput {
   sourceCode: string;
   actualFilePath: string;
@@ -78,10 +84,10 @@ export async function transformResolvedModuleSource(
     sourceLength: input.sourceCode.length,
   });
 
-  // Framework entries must keep their full dependency graph on one transformed
-  // React runtime. The generic tenant transform can leave npm package file URLs
-  // intact, which loads a second React instance during static MDX rendering.
-  if (frameworkSourceKeyOf(input.normalizedPath) !== null) {
+  // Head, Router, and context share this public runtime entry. Keep its full
+  // framework graph on one transformed React runtime. Other framework entries
+  // retain the generic path because it applies the project's dependency pins.
+  if (isRecursiveReactRuntimeEntry(input.normalizedPath)) {
     const readImportMap = input.loadImportMap ?? loadImportMap;
     const importMap = await readImportMap(input.projectDir);
     const importMapFingerprint = await fingerprintImportMap(importMap);

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.ts
@@ -7,17 +7,26 @@
 import { cacheHttpImportsToLocal } from "../../../esm/http-cache.ts";
 import { loadImportMap } from "#veryfront/modules/import-map/index.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
 import { transformToESM } from "../../../esm-transform.ts";
 import { getHttpBundleCacheDir } from "#veryfront/utils/cache-dir.ts";
+import { REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import type { Logger } from "#veryfront/utils";
 import type { DependencyPinningSourceInput } from "#veryfront/transforms/esm/package-registry.ts";
 import { LOG_PREFIX_MDX_LOADER } from "../constants.ts";
 import { rewriteDntImports, rewriteVeryfrontImports } from "./import-rewriter.ts";
+import { transformFrameworkSource } from "#veryfront/transforms/pipeline/stages/ssr-vf-modules/transform.ts";
 
 type TransformToEsmFn = typeof transformToESM;
 type LoadImportMapFn = typeof loadImportMap;
 type CacheHttpImportsToLocalFn = typeof cacheHttpImportsToLocal;
+type TransformFrameworkSourceFn = typeof transformFrameworkSource;
 type SourceTransformLogger = Pick<Logger, "debug" | "error">;
+
+function isFrameworkEntry(normalizedPath: string): boolean {
+  const path = normalizedPath.split(/[?#]/, 1)[0] ?? normalizedPath;
+  return path.startsWith("_vf_modules/_veryfront/") || path.startsWith("_veryfront/");
+}
 
 export interface TransformResolvedModuleSourceInput {
   sourceCode: string;
@@ -43,6 +52,7 @@ export interface TransformResolvedModuleSourceInput {
   transformToEsm?: TransformToEsmFn;
   loadImportMap?: LoadImportMapFn;
   cacheHttpImportsToLocal?: CacheHttpImportsToLocalFn;
+  transformFrameworkSource?: TransformFrameworkSourceFn;
 }
 
 /**
@@ -57,6 +67,24 @@ export async function transformResolvedModuleSource(
     actualFilePath: input.actualFilePath,
     sourceLength: input.sourceCode.length,
   });
+
+  // Framework entries must keep their full dependency graph on one transformed
+  // React runtime. The generic tenant transform can leave npm package file URLs
+  // intact, which loads a second React instance during static MDX rendering.
+  if (isFrameworkEntry(input.normalizedPath)) {
+    const readImportMap = input.loadImportMap ?? loadImportMap;
+    const importMap = await readImportMap(input.projectDir);
+    const transformFramework = input.transformFrameworkSource ?? transformFrameworkSource;
+    return await transformFramework(
+      input.sourceCode,
+      input.actualFilePath,
+      input.reactVersion ?? REACT_DEFAULT_VERSION,
+      input.projectDir,
+      createFileSystem(),
+      undefined,
+      importMap,
+    );
+  }
 
   const preprocessedSource = rewriteVeryfrontImports(input.sourceCode);
   const transform = input.transformToEsm ?? transformToESM;

--- a/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.ts
+++ b/src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.ts
@@ -4,12 +4,12 @@
  * @module transforms/mdx/esm-module-loader/module-fetcher/source-transform
  */
 
-import { cacheHttpImportsToLocal } from "../../../esm/http-cache.ts";
-import { fingerprintImportMap } from "../../../esm/http-cache-helpers.ts";
+import { fingerprintImportMap } from "#veryfront/transforms/esm/http-cache-helpers.ts";
+import { cacheHttpImportsToLocal } from "#veryfront/transforms/esm/http-cache.ts";
 import { loadImportMap } from "#veryfront/modules/import-map/index.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { createFileSystem } from "#veryfront/platform/compat/fs.ts";
-import { transformToESM } from "../../../esm-transform.ts";
+import { transformToESM } from "#veryfront/transforms/esm-transform.ts";
 import { getHttpBundleCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { REACT_DEFAULT_VERSION } from "#veryfront/utils/constants/cdn.ts";
 import type { Logger } from "#veryfront/utils";

--- a/src/transforms/mdx/esm-module-loader/resolution/module-path.ts
+++ b/src/transforms/mdx/esm-module-loader/resolution/module-path.ts
@@ -4,6 +4,18 @@ const VF_MODULE_ROOT = "_vf_modules";
 const VF_MODULE_PREFIX = `${VF_MODULE_ROOT}/`;
 
 /**
+ * Return the framework-relative source key for a `_veryfront/` module path,
+ * or null when the path does not address framework source.
+ */
+export function frameworkSourceKeyOf(modulePath: string): string | null {
+  const withoutVfModules = modulePath.startsWith(VF_MODULE_PREFIX)
+    ? modulePath.slice(VF_MODULE_PREFIX.length)
+    : modulePath;
+  if (!withoutVfModules.startsWith("_veryfront/")) return null;
+  return withoutVfModules.slice("_veryfront/".length);
+}
+
+/**
  * Canonicalize a module path only when it remains project-relative and, when
  * rooted in `_vf_modules`, remains below that virtual root.
  */


### PR DESCRIPTION
## Summary

- route framework entries from the MDX module fetcher through the recursive framework transform
- materialize relative framework dependencies and React imports into one SSR cache graph
- preserve the generic transform path for tenant modules

## Root cause

The npm MDX loader transformed `veryfront/head` through the generic tenant path. Its generated `Head` module kept a direct package file URL for `server-render-context.js`, so `useServerRenderContext` loaded npm React while `react-dom/server` rendered with the cached esm.sh React instance. Static generation then failed with an invalid hook call.

## RED-GREEN

RED: the focused regression failed because a framework entry reached the generic tenant transform.

GREEN: the same test now proves framework entries use the recursive transform and receive the project import map, while existing tenant-path tests remain green.

A packed local npm artifact was installed into the reproducing MDX project. `npm run build` completed successfully with 1 page, 1 chunk, and 1.17 MB output. The generated `Head` graph points at the recursively transformed cached server context.

## Verification

- `deno task test:file src/transforms/mdx/esm-module-loader/module-fetcher/source-transform.test.ts`
- `deno task test:file src/transforms/mdx/esm-module-loader/module-fetcher`
- `deno task test:file src/transforms/pipeline/stages/ssr-vf-modules.test.ts`
- `deno task typecheck`
- `deno task lint:ci`
- `deno task build:npm`
- packed npm MDX build: `npm run build`

Fixes veryfront/veryfront-issue-inbox#913
Related to veryfront/veryfront-issue-inbox#604


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading and transformation of public framework modules, including paths with query parameters or URL fragments.
  * Improved cache recovery so framework dependencies remain available across workers and are restored in the correct order.
  * Enhanced failure logging with useful module context when source transformation fails.

* **Tests**
  * Added coverage for framework entry handling, default React versions, transformation failures, and distributed cache recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->