### PR TITLE
fix(parser): preserve JSX for embedded framework sources

### DIFF
--- a/extensions/ext-parser-babel/src/parser-only.test.ts
+++ b/extensions/ext-parser-babel/src/parser-only.test.ts
@@ -57,12 +57,19 @@ describe("BabelParseOnlyParser", () => {
       code: "const value = <string> input;",
       filePath: "helper.ts.src",
     });
-    const commonJs = await parser.parse({
-      code: "if (module.parent) return; module.exports = true;",
-      filePath: "entry.js.src",
-    });
+    const commonJs = await Promise.all(
+      ["entry.js.src", "entry.cjs.src"].map((filePath) =>
+        parser.parse({
+          code: "if (module.parent) return; module.exports = true;",
+          filePath,
+        })
+      ),
+    );
 
-    assertEquals([typedJsx.type, typeAssertion.type, commonJs.type], ["File", "File", "File"]);
+    assertEquals(
+      [typedJsx.type, typeAssertion.type, ...commonJs.map((ast) => ast.type)],
+      ["File", "File", "File", "File"],
+    );
   });
 
   it("keeps `<T>x` a type assertion for a `.ts` path", async () => {

--- a/extensions/ext-parser-babel/src/parser-only.test.ts
+++ b/extensions/ext-parser-babel/src/parser-only.test.ts
@@ -48,6 +48,23 @@ describe("BabelParseOnlyParser", () => {
     assertEquals(parsed.map((ast) => ast.type), ["File", "File", "File"]);
   });
 
+  it("uses the original grammar for embedded framework source suffixes", async () => {
+    const typedJsx = await parser.parse({
+      code: "export const view: JSX.Element = <main />;",
+      filePath: "tooltip.tsx.src",
+    });
+    const typeAssertion = await parser.parse({
+      code: "const value = <string> input;",
+      filePath: "helper.ts.src",
+    });
+    const commonJs = await parser.parse({
+      code: "if (module.parent) return; module.exports = true;",
+      filePath: "entry.js.src",
+    });
+
+    assertEquals([typedJsx.type, typeAssertion.type, commonJs.type], ["File", "File", "File"]);
+  });
+
   it("keeps `<T>x` a type assertion for a `.ts` path", async () => {
     const asserted = await parser.parse({
       code: "const value = <string> input;",

--- a/extensions/ext-parser-babel/src/parser-only.ts
+++ b/extensions/ext-parser-babel/src/parser-only.ts
@@ -48,9 +48,8 @@ function pickPlugins(
   filePath: string | undefined,
   syntax: "javascript" | "typescript",
 ): parser.ParserPlugin[] {
-  const normalizedPath = filePath?.toLowerCase() ?? "";
   const supportsJsx = !filePath ||
-    /\.(?:tsx|jsx|js|mjs|cjs)$/.test(normalizedPath);
+    /\.(?:tsx|jsx|js|mjs|cjs)$/.test(filePath);
   const plugins: parser.ParserPlugin[] = [
     "classProperties",
     "classPrivateProperties",

--- a/extensions/ext-parser-babel/src/parser-only.ts
+++ b/extensions/ext-parser-babel/src/parser-only.ts
@@ -28,19 +28,20 @@ export interface BabelParseOnlyOptions extends ParseOptions {
 /**
  * The path the plugin choice reasons about.
  *
- * Markdown and MDX can reach this parser as compiled JSX, and the authored
- * `.md` or `.mdx` extension would switch JSX off, so the emitted markup parses
- * as a regular expression and throws "Unterminated regular expression". Map
- * them onto a `.tsx` path for the plugin choice only. Nothing else reads this
- * value, and `.ts` keeps `<T>x` a type assertion because only Markdown paths
- * are rewritten.
+ * Embedded framework sources add a terminal `.src` to the original extension,
+ * so remove that wrapper before selecting syntax. Markdown and MDX can reach
+ * this parser as compiled JSX, and their authored extension would switch JSX
+ * off, so map them onto a JSX-capable path after unwrapping. Nothing else reads
+ * this value, and `.ts` keeps `<T>x` as a type assertion.
  */
 function parseablePath(
   filePath: string | undefined,
   syntax: "javascript" | "typescript",
 ): string | undefined {
   if (filePath === undefined) return undefined;
-  return filePath.replace(/\.mdx?$/i, syntax === "typescript" ? ".tsx" : ".jsx");
+  return filePath
+    .replace(/\.src$/i, "")
+    .replace(/\.mdx?$/i, syntax === "typescript" ? ".tsx" : ".jsx");
 }
 
 function pickPlugins(
@@ -96,14 +97,14 @@ function isAstNode(value: unknown): value is ASTNode {
  */
 export class BabelParseOnlyParser implements BabelParseOnlyParserContract {
   async parse(options: BabelParseOnlyOptions): Promise<ASTNode> {
-    const filePath = options.filePath?.toLowerCase() ?? "";
     const decoratorMode = options.decoratorMode ?? "compatible";
     const syntax = options.syntax ?? "typescript";
+    const filePath = parseablePath(options.filePath, syntax)?.toLowerCase() ?? "";
     const parseOptions: parser.ParserOptions = {
       sourceType: "unambiguous",
       allowReturnOutsideFunction: options.allowReturnOutsideFunction === true ||
         /\.(?:cjs|js)$/.test(filePath),
-      plugins: pickPlugins(parseablePath(options.filePath, syntax), syntax),
+      plugins: pickPlugins(filePath, syntax),
     };
     const ast = (() => {
       try {
@@ -116,7 +117,7 @@ export class BabelParseOnlyParser implements BabelParseOnlyParserContract {
           return parser.parse(options.code, {
             ...parseOptions,
             plugins: pickLegacyDecoratorPlugins(
-              parseablePath(options.filePath, syntax),
+              filePath,
               syntax,
             ),
           });

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
@@ -205,6 +205,19 @@ describe("browser-server-exports-strip", () => {
       assertEquals(await stripServerOnlyExports(code), code);
     });
 
+    it("parses embedded TSX framework source before deciding it has no server hooks", async () => {
+      const code = [
+        `export function TooltipProvider({ children }: { children: React.ReactNode }) {`,
+        `  return <TooltipContext.Provider value={{}}>{children}</TooltipContext.Provider>;`,
+        `}`,
+      ].join("\n");
+
+      assertEquals(
+        await stripServerOnlyExports(code, "react/components/ui/tooltip.tsx.src"),
+        code,
+      );
+    });
+
     it("does not treat a same-named string as a declaration", async () => {
       const code =
         `const label = "getServerData";\nexport default function Page() { return label; }`;

--- a/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
+++ b/src/transforms/pipeline/stages/browser-server-exports-strip.test.ts
@@ -207,8 +207,9 @@ describe("browser-server-exports-strip", () => {
 
     it("parses embedded TSX framework source before deciding it has no server hooks", async () => {
       const code = [
+        `const ids = "tooltip label".trim().split(/\\s+/);`,
         `export function TooltipProvider({ children }: { children: React.ReactNode }) {`,
-        `  return <TooltipContext.Provider value={{}}>{children}</TooltipContext.Provider>;`,
+        `  return <TooltipContext.Provider value={{ ids }}>{children}</TooltipContext.Provider>;`,
         `}`,
       ].join("\n");
 


### PR DESCRIPTION
## Summary

- unwrap the terminal `.src` suffix before the Babel parser selects source grammar
- preserve TypeScript assertions and CommonJS behavior for embedded `.ts.src` and `.js.src` files
- cover the release pipeline stage that parses embedded TSX framework sources

## Root cause

The release asset pipeline stores framework source paths such as `tooltip.tsx.src`. The loader correctly recognized the original TSX extension, but the Babel parse-only path checked only the terminal extension and therefore disabled JSX. Parsing the embedded tooltip component then failed before the browser server-export strip stage could classify it.

## RED-GREEN TDD

- RED: `deno task test:file extensions/ext-parser-babel/src/parser-only.test.ts` failed on `tooltip.tsx.src` with `Unexpected token, expected ","`.
- GREEN: the focused parser suite and the browser server-export strip integration suite pass after normalizing the embedded source suffix.

## Verification

- `deno task test:file extensions/ext-parser-babel/src/parser-only.test.ts`
- `deno task test:file extensions/ext-parser-babel/src`
- `deno task test:file src/transforms/pipeline/stages/browser-server-exports-strip.test.ts`
- exact embedded tooltip source probe through `stripServerOnlyExports`
- `deno task typecheck`
- `deno task lint:ci`
- `deno task build:npm`
- `git diff --check`

Fixes veryfront/veryfront-issue-inbox#920
Related to veryfront/veryfront-issue-inbox#604


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing for embedded framework source files, including `.tsx.src`, `.ts.src`, `.js.src`, and `.cjs.src` formats.
  * Fixed handling of Markdown and MDX files embedded within framework sources.
  * Corrected processing of embedded source files when checking for server-only hooks.

* **Tests**
  * Added coverage for parsing embedded source suffixes and preserving valid files during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->