### PR TITLE
fix(release): transform materialized project sources locally

### DIFF
--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -26,6 +26,7 @@ import { VERSION } from "#veryfront/utils/version.ts";
 import { createFileSystem, isNotFoundError, realPath } from "#veryfront/platform/compat/fs.ts";
 import { getOsType } from "#veryfront/platform/compat/process.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
 import { STAT_OPERATION_EXTENSION_PRIORITY } from "#veryfront/platform/adapters/fs/veryfront/extension-priority.ts";
 import {
   dirname,
@@ -864,6 +865,22 @@ function releaseLogicalPathFromMaterializedPath(
 export const releaseAssetBuildInternals = Object.freeze({
   releaseLogicalPathFromMaterializedPath,
 });
+
+/**
+ * Bind transforms to the immutable source snapshot materialized for this build.
+ *
+ * Hosted execution enters through a request-scoped Veryfront API adapter. That
+ * adapter remains the authority used to fetch the release once, but absolute
+ * paths beneath `tempDir` belong to the build-owned local snapshot. Sending
+ * those paths back to the project API returns 404 and leaves aliases or
+ * relative imports unresolved during finalization.
+ */
+async function createMaterializedReleaseTransformAdapter(
+  adapter: RuntimeAdapter,
+): Promise<RuntimeAdapter> {
+  const localAdapter = await getLocalAdapter();
+  return { ...adapter, fs: localAdapter.fs };
+}
 
 /**
  * Import edges of an App Router server module, read from its authored source.
@@ -3200,6 +3217,7 @@ async function runBuildInner(
   // Bytes are held per-hash only until uploaded, then dropped (M3).
   const pendingBytes = createPendingAssetStore();
   const knownPaths = new Set(sourceByPath.keys());
+  const transformAdapter = await createMaterializedReleaseTransformAdapter(input.adapter);
   const vendorDependencies = input.dependencyMode === "immutable";
   const configuredVendor = input.vendorHttpImports;
   const vendorHttpImports = vendorDependencies ? configuredVendor : undefined;
@@ -3329,7 +3347,7 @@ async function runBuildInner(
           tempDir,
           knownPaths,
           projectImportAliases,
-          input.adapter,
+          transformAdapter,
         );
         serverModuleImports.set(logicalPath, imports);
         // Everything a server module reaches is server code by default. A
@@ -3369,7 +3387,7 @@ async function runBuildInner(
     }
     let code: string;
     try {
-      code = await transform(source, sourceFile, tempDir, input.adapter, {
+      code = await transform(source, sourceFile, tempDir, transformAdapter, {
         projectId: input.projectId,
         dev: false,
         ssr: false,
@@ -3647,7 +3665,7 @@ async function runBuildInner(
   const frameworkDependencies = await buildFrameworkDependencies(
     {
       projectId: input.projectId,
-      adapter: input.adapter,
+      adapter: transformAdapter,
       reactVersion: releaseReactVersion,
       allowHttp: !vendorDependencies,
       requestedSpecifiers: requestedFrameworkSpecifiers,

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -28,6 +28,7 @@ import { getOsType } from "#veryfront/platform/compat/process.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { getLocalAdapter } from "#veryfront/platform/adapters/registry.ts";
 import { STAT_OPERATION_EXTENSION_PRIORITY } from "#veryfront/platform/adapters/fs/veryfront/extension-priority.ts";
+import { wrapAdapterWithSecurity } from "#veryfront/security/secure-fs.ts";
 import {
   dirname,
   fromFileUrl,
@@ -877,9 +878,21 @@ export const releaseAssetBuildInternals = Object.freeze({
  */
 async function createMaterializedReleaseTransformAdapter(
   adapter: RuntimeAdapter,
+  tempDir: string,
 ): Promise<RuntimeAdapter> {
   const localAdapter = await getLocalAdapter();
-  return { ...adapter, fs: localAdapter.fs };
+  const securedLocalAdapter = wrapAdapterWithSecurity(localAdapter, {
+    baseDir: tempDir,
+    context: "module-loading",
+  });
+  return {
+    ...adapter,
+    fs: Object.freeze({
+      ...securedLocalAdapter.fs,
+      symlinkSemantics: "none" as const,
+      projectContextSemantics: "fixed" as const,
+    }),
+  };
 }
 
 /**
@@ -3217,7 +3230,7 @@ async function runBuildInner(
   // Bytes are held per-hash only until uploaded, then dropped (M3).
   const pendingBytes = createPendingAssetStore();
   const knownPaths = new Set(sourceByPath.keys());
-  const transformAdapter = await createMaterializedReleaseTransformAdapter(input.adapter);
+  const transformAdapter = await createMaterializedReleaseTransformAdapter(input.adapter, tempDir);
   const vendorDependencies = input.dependencyMode === "immutable";
   const configuredVendor = input.vendorHttpImports;
   const vendorHttpImports = vendorDependencies ? configuredVendor : undefined;

--- a/src/release-assets/scaffolded-project-build.test.ts
+++ b/src/release-assets/scaffolded-project-build.test.ts
@@ -353,6 +353,9 @@ describe("release assets: scaffolded project build", () => {
   }
 
   it("resolves project imports from the materialized release instead of the remote adapter", async () => {
+    const outsideDir = await tmp();
+    const outsidePath = `${outsideDir}/outside-project.ts`;
+    await Deno.writeTextFile(outsidePath, 'export const outside = "must-not-be-read";');
     const sources = [
       {
         path: "pages/index.mdx",
@@ -379,6 +382,7 @@ describe("release assets: scaffolded project build", () => {
       },
     } as RuntimeAdapter;
     const rec: Recorded = { uploads: [], manifest: null, states: [] };
+    let escapedRead = false;
 
     const result = await runReleaseAssetBuild({
       projectReference: "remote-project",
@@ -390,19 +394,26 @@ describe("release assets: scaffolded project build", () => {
       dependencyMode: "source",
       loadConfig: () => Promise.resolve({ experimental: { rsc: true } } as VeryfrontConfig),
       client: makeClient(sources, rec, "remote-project"),
-      transform: (source, sourceFile, projectDir, adapter, options) =>
-        transformToESM(source, sourceFile, projectDir, adapter, {
+      transform: async (source, sourceFile, projectDir, adapter, options) => {
+        try {
+          escapedRead ||= (await adapter.fs.readFile(outsidePath)).includes("must-not-be-read");
+        } catch {
+          // The materialized adapter must reject paths outside this release.
+        }
+        return await transformToESM(source, sourceFile, projectDir, adapter, {
           projectId: options.projectId,
           dev: options.dev,
           ssr: options.ssr,
           reactVersion: options.reactVersion,
-        }),
+        });
+      },
     }, await tmp());
 
     assertEquals(result.error, undefined);
     assertEquals(result.success, true);
     assertEquals(result.state, "ready");
     assertEquals(remoteReads, []);
+    assertEquals(escapedRead, false);
     const manifest = parseReleaseAssetManifest(rec.manifest);
     assertExists(manifest);
     assertEquals(

--- a/src/release-assets/scaffolded-project-build.test.ts
+++ b/src/release-assets/scaffolded-project-build.test.ts
@@ -351,4 +351,63 @@ describe("release assets: scaffolded project build", () => {
       );
     });
   }
+
+  it("resolves project imports from the materialized release instead of the remote adapter", async () => {
+    const sources = [
+      {
+        path: "pages/index.mdx",
+        content: 'import { Card } from "@/components/Card"\n\n<Card />',
+      },
+      {
+        path: "components/Card.tsx",
+        content: 'export function Card() { return <div className="p-4">ready</div>; }',
+      },
+      {
+        path: "package.json",
+        content: JSON.stringify({ dependencies: { react: "19.2.4", "react-dom": "19.2.4" } }),
+      },
+    ];
+    const remoteReads: string[] = [];
+    const remoteAdapter = {
+      ...fsAdapter,
+      fs: {
+        ...fsAdapter.fs,
+        readFile(path: string): Promise<string> {
+          remoteReads.push(path);
+          return Promise.reject(new Error(`Unexpected remote release read: ${path}`));
+        },
+      },
+    } as RuntimeAdapter;
+    const rec: Recorded = { uploads: [], manifest: null, states: [] };
+
+    const result = await runReleaseAssetBuild({
+      projectReference: "remote-project",
+      projectId: "proj-uuid",
+      releaseId: "rel-uuid",
+      releaseVersion: 1,
+      releaseVersionRef: "rel-uuid",
+      adapter: remoteAdapter,
+      dependencyMode: "source",
+      loadConfig: () => Promise.resolve({ experimental: { rsc: true } } as VeryfrontConfig),
+      client: makeClient(sources, rec, "remote-project"),
+      transform: (source, sourceFile, projectDir, adapter, options) =>
+        transformToESM(source, sourceFile, projectDir, adapter, {
+          projectId: options.projectId,
+          dev: options.dev,
+          ssr: options.ssr,
+          reactVersion: options.reactVersion,
+        }),
+    }, await tmp());
+
+    assertEquals(result.error, undefined);
+    assertEquals(result.success, true);
+    assertEquals(result.state, "ready");
+    assertEquals(remoteReads, []);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    assertEquals(
+      Object.keys(manifest.modules).sort(),
+      ["components/Card.tsx", "pages/index.mdx"],
+    );
+  });
 });


### PR DESCRIPTION
Fixes veryfront/veryfront-issue-inbox#924

## What changed

- use the native runtime filesystem for transforms after the release source is materialized
- retain the request-scoped adapter for control-plane source retrieval and publication
- cover an MDX route with an aliased project component import against a rejecting remote filesystem adapter

## RED-GREEN TDD

RED: the regression build reached ready state but attempted to read the materialized page and component through the remote adapter.

GREEN: the same build publishes both modules without any remote filesystem reads.

## Verification

- deno task test:file src/release-assets/scaffolded-project-build.test.ts
- deno task test:file src/release-assets
- deno task typecheck
- deno task lint:ci
- deno task build:npm
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release builds to correctly resolve aliases and relative imports from the materialized project files.
  * Prevented unnecessary remote file requests during release asset generation.
  * Ensured project dependencies are included correctly in the generated release manifest.

* **Tests**
  * Added coverage verifying builds succeed using local release files and include all expected project modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->