### PR TITLE
fix(cli): register bundler before deploy

### DIFF
--- a/cli/commands/deploy/handler.test.ts
+++ b/cli/commands/deploy/handler.test.ts
@@ -26,6 +26,23 @@ describe("Deploy Handler", () => {
     it("accepts a single ParsedArgs parameter", () => {
       assertEquals(handleDeployCommand.length, 1);
     });
+
+    it("registers the builtin bundler before deploying", async () => {
+      const calls: string[] = [];
+
+      await handleDeployCommand(createArgs(), {
+        ensureBundlerContracts: () => {
+          calls.push("ensure");
+          return Promise.resolve();
+        },
+        deploy: () => {
+          calls.push("deploy");
+          return Promise.resolve(null);
+        },
+      });
+
+      assertEquals(calls, ["ensure", "deploy"]);
+    });
   });
 
   describe("parseDeployArgs via handler", () => {

--- a/cli/commands/deploy/handler.ts
+++ b/cli/commands/deploy/handler.ts
@@ -6,8 +6,24 @@ import { deployCommand, parseDeployArgs } from "./command.ts";
 import { showHeader } from "#cli/utils";
 import type { ParsedArgs } from "#cli/shared/types";
 import { parseArgsOrThrow } from "#cli/shared/args";
+import { ensureCliBundlerContracts } from "#cli/shared/default-contracts";
 
-export async function handleDeployCommand(args: ParsedArgs): Promise<void> {
+interface DeployHandlerDependencies {
+  ensureBundlerContracts: () => Promise<void>;
+  deploy: typeof deployCommand;
+}
+
+const defaultDependencies: DeployHandlerDependencies = {
+  ensureBundlerContracts: ensureCliBundlerContracts,
+  deploy: deployCommand,
+};
+
+export async function handleDeployCommand(
+  args: ParsedArgs,
+  dependencies: DeployHandlerDependencies = defaultDependencies,
+): Promise<void> {
   showHeader();
-  await deployCommand(parseArgsOrThrow(parseDeployArgs, "deploy", args));
+  const options = parseArgsOrThrow(parseDeployArgs, "deploy", args);
+  await dependencies.ensureBundlerContracts();
+  await dependencies.deploy(options);
 }


### PR DESCRIPTION
Fixes veryfront/veryfront-issue-inbox#925

## What changed

- register the built-in bundler contracts before deploy enters project configuration and build work
- preserve argument validation before extension setup
- add an order-sensitive deploy handler regression test

## RED-GREEN TDD

RED: the handler ignored the registration dependency and entered live deploy work, where the test failed on an attempted network request.

GREEN: the handler records bundler registration before deploy execution and performs no external work in the focused test.

## Verification

- deno task test:file cli/commands/deploy/handler.test.ts
- deno task typecheck
- deno task lint:ci
- source CLI staging dry-run completed through config and target resolution
- git diff --check