### PR TITLE
fix(transforms): contain dependency hash reads

### DIFF
--- a/src/transforms/pipeline/index.test.ts
+++ b/src/transforms/pipeline/index.test.ts
@@ -1,17 +1,18 @@
 import "#veryfront/schemas/_test-setup.ts";
 /** @module transforms/pipeline/index.test */
 
-import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import {
   makeTempDir,
+  mkdir,
   readTextFile,
   remove,
   writeTextFile,
 } from "#veryfront/testing/deno-compat.ts";
 import { join } from "#veryfront/compat/path";
 import * as esbuild from "veryfront/extensions/bundler";
-import { runPipeline, TransformStage, transformToESM } from "./index.ts";
+import { pipelineInternals, runPipeline, TransformStage, transformToESM } from "./index.ts";
 import { getHostEnv, setEnv } from "#veryfront/platform/compat/process.ts";
 import { DEPENDENCY_PINNING_ENV_FLAG } from "../../release-assets/constants.ts";
 import {
@@ -33,6 +34,7 @@ import {
 } from "../esm/npm-registry-client.ts";
 import { computeConfigHash } from "../../cache/config-hash.ts";
 import { computeShortContentHash } from "../esm/transform-utils.ts";
+import { FRAMEWORK_SRC_DIR } from "#veryfront/platform/compat/framework-source-resolver.ts";
 
 describe(
   "transformToESM readFile routing",
@@ -41,17 +43,14 @@ describe(
       await esbuild.stop();
     });
 
-    it("uses local fs for file:// deps outside projectDir", async () => {
+    it("rejects dependency reads outside projectDir before reaching any filesystem", async () => {
       const projectDir = await makeTempDir({ prefix: "vf-pipeline-proj-" });
       const externalDir = await makeTempDir({ prefix: "vf-pipeline-ext-" });
       const mainFile = join(projectDir, "main.tsx");
       const externalFile = join(externalDir, "dep.ts");
 
       try {
-        const mainSource = `import { dep } from "file://${externalFile}";
-export default function App() { return dep; }`;
-
-        await writeTextFile(mainFile, mainSource);
+        await writeTextFile(mainFile, "export const value = 1;");
         await writeTextFile(externalFile, "export const dep = 1;");
 
         const readCalls: string[] = [];
@@ -59,26 +58,19 @@ export default function App() { return dep; }`;
           fs: {
             readFile: async (path: string): Promise<string> => {
               readCalls.push(path);
-              if (path === externalFile) {
-                throw new Error(
-                  "Adapter should not read external file:// dependency",
-                );
-              }
               return await readTextFile(path);
             },
           },
         };
+        const readFile = pipelineInternals.buildReadFile(adapter, projectDir);
 
-        await transformToESM(mainSource, mainFile, projectDir, adapter, {
-          ssr: true,
-          dev: true,
-          projectId: "test-project",
-        });
+        assertEquals(await readFile(mainFile), "export const value = 1;");
+        await assertRejects(() => readFile(externalFile), Error, "outside project root");
 
         assertEquals(
           readCalls.includes(externalFile),
           false,
-          "external file:// deps must bypass the adapter",
+          "an escaping dependency must not reach the adapter",
         );
         assertEquals(
           readCalls.includes(mainFile),
@@ -88,6 +80,55 @@ export default function App() { return dep; }`;
       } finally {
         await remove(projectDir, { recursive: true });
         await remove(externalDir, { recursive: true });
+      }
+    });
+
+    it("does not treat a project-directory prefix collision as contained", async () => {
+      const parentDir = await makeTempDir({ prefix: "vf-pipeline-prefix-" });
+      const projectDir = join(parentDir, "project");
+      const collisionDir = join(parentDir, "project-external");
+      const collisionFile = join(collisionDir, "dep.ts");
+
+      try {
+        await mkdir(projectDir);
+        await mkdir(collisionDir);
+        await writeTextFile(collisionFile, "export const dep = 1;");
+        const readCalls: string[] = [];
+        const readFile = pipelineInternals.buildReadFile({
+          fs: {
+            readFile: async (path: string): Promise<string> => {
+              readCalls.push(path);
+              return await readTextFile(path);
+            },
+          },
+        }, projectDir);
+
+        await assertRejects(() => readFile(collisionFile), Error, "outside project root");
+        assertEquals(readCalls, []);
+      } finally {
+        await remove(parentDir, { recursive: true });
+      }
+    });
+
+    it("reads verified framework sources locally without using the project adapter", async () => {
+      const projectDir = await makeTempDir({ prefix: "vf-pipeline-framework-" });
+      const frameworkFile = join(FRAMEWORK_SRC_DIR, "transforms/pipeline/index.ts");
+      const readCalls: string[] = [];
+
+      try {
+        const readFile = pipelineInternals.buildReadFile({
+          fs: {
+            readFile: (path: string): Promise<string> => {
+              readCalls.push(path);
+              return Promise.reject(new Error("Framework source reached project adapter"));
+            },
+          },
+        }, projectDir);
+
+        assertStringIncludes(await readFile(frameworkFile), "function buildReadFile");
+        assertEquals(readCalls, []);
+      } finally {
+        await remove(projectDir, { recursive: true });
       }
     });
 

--- a/src/transforms/pipeline/index.test.ts
+++ b/src/transforms/pipeline/index.test.ts
@@ -56,6 +56,7 @@ describe(
         const readCalls: string[] = [];
         const adapter = {
           fs: {
+            symlinkSemantics: "none" as const,
             readFile: async (path: string): Promise<string> => {
               readCalls.push(path);
               return await readTextFile(path);
@@ -96,6 +97,7 @@ describe(
         const readCalls: string[] = [];
         const readFile = pipelineInternals.buildReadFile({
           fs: {
+            symlinkSemantics: "none" as const,
             readFile: async (path: string): Promise<string> => {
               readCalls.push(path);
               return await readTextFile(path);
@@ -110,6 +112,33 @@ describe(
       }
     });
 
+    it("rejects a canonically escaping project path before reading it", async () => {
+      const projectDir = await makeTempDir({ prefix: "vf-pipeline-canonical-" });
+      const externalDir = await makeTempDir({ prefix: "vf-pipeline-canonical-ext-" });
+      const linkedPath = join(projectDir, "linked.ts");
+      const externalPath = join(externalDir, "outside.ts");
+      const readCalls: string[] = [];
+
+      try {
+        const readFile = pipelineInternals.buildReadFile({
+          fs: {
+            readFile: (path: string): Promise<string> => {
+              readCalls.push(path);
+              return Promise.resolve("must-not-be-read");
+            },
+            realPath: (path: string): Promise<string> =>
+              Promise.resolve(path === linkedPath ? externalPath : path),
+          },
+        }, projectDir);
+
+        await assertRejects(() => readFile(linkedPath), Error, "outside project root");
+        assertEquals(readCalls, []);
+      } finally {
+        await remove(projectDir, { recursive: true });
+        await remove(externalDir, { recursive: true });
+      }
+    });
+
     it("reads verified framework sources locally without using the project adapter", async () => {
       const projectDir = await makeTempDir({ prefix: "vf-pipeline-framework-" });
       const frameworkFile = join(FRAMEWORK_SRC_DIR, "transforms/pipeline/index.ts");
@@ -118,6 +147,7 @@ describe(
       try {
         const readFile = pipelineInternals.buildReadFile({
           fs: {
+            symlinkSemantics: "none" as const,
             readFile: (path: string): Promise<string> => {
               readCalls.push(path);
               return Promise.reject(new Error("Framework source reached project adapter"));
@@ -127,6 +157,39 @@ describe(
 
         assertStringIncludes(await readFile(frameworkFile), "function buildReadFile");
         assertEquals(readCalls, []);
+      } finally {
+        await remove(projectDir, { recursive: true });
+      }
+    });
+
+    it("wires contained dependency reads through transformToESM", async () => {
+      const projectDir = await makeTempDir({ prefix: "vf-pipeline-contained-" });
+      const mainFile = join(projectDir, "main.tsx");
+      const dependencyFile = join(projectDir, "dep.js");
+      const mainSource = 'import { dep } from "./dep.js"; export const value = dep;';
+      const readCalls: string[] = [];
+
+      try {
+        await writeTextFile(mainFile, mainSource);
+        await writeTextFile(dependencyFile, "export const dep = 1;");
+        const adapter = {
+          fs: {
+            symlinkSemantics: "none" as const,
+            readFile: async (path: string): Promise<string> => {
+              readCalls.push(path);
+              return await readTextFile(path);
+            },
+          },
+        };
+
+        await transformToESM(mainSource, mainFile, projectDir, adapter, {
+          ssr: true,
+          dev: true,
+          projectId: "contained-read-project",
+        });
+
+        assertEquals(readCalls.includes(mainFile), true);
+        assertEquals(readCalls.includes(dependencyFile), true);
       } finally {
         await remove(projectDir, { recursive: true });
       }

--- a/src/transforms/pipeline/index.ts
+++ b/src/transforms/pipeline/index.ts
@@ -45,6 +45,8 @@ import { getDependencyResolutionObservations } from "./stages/resolve-imports.ts
 import { loadImportMap, preloadImportMap } from "#veryfront/modules/import-map/index.ts";
 import type { ImportMapConfig } from "#veryfront/modules/import-map/types.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
+import { isAbsolute, relative, resolve } from "#veryfront/compat/path/index.ts";
+import { isFrameworkSourcePath } from "#veryfront/platform/compat/framework-source-resolver.ts";
 import {
   computePipelineConfigIdentity,
   fingerprintPipelineImportMap,
@@ -489,20 +491,28 @@ function extractReadFile(adapter: unknown): ((path: string) => Promise<string>) 
 function buildReadFile(adapter: unknown, projectDir: string): (path: string) => Promise<string> {
   const adapterRead = extractReadFile(adapter);
   const fs = createFileSystem();
-  const normalizedProjectDir = projectDir.replace(/\/+$/, "");
+  const projectRoot = resolve(projectDir);
 
   return async (path: string): Promise<string> => {
     const normalizedPath = path.startsWith("file://") ? path.slice("file://".length) : path;
+    const candidatePath = resolve(projectRoot, normalizedPath);
+    const projectRelativePath = relative(projectRoot, candidatePath);
+    const isOutsideProject = projectRelativePath === ".." ||
+      projectRelativePath.startsWith("../") ||
+      projectRelativePath.startsWith("..\\") ||
+      isAbsolute(projectRelativePath);
 
-    const isOutsideProject = normalizedPath.startsWith("/") &&
-      normalizedProjectDir.length > 0 &&
-      !normalizedPath.startsWith(normalizedProjectDir);
-
-    if (isOutsideProject) return fs.readTextFile(normalizedPath);
+    if (isOutsideProject) {
+      if (isFrameworkSourcePath(candidatePath)) return fs.readTextFile(candidatePath);
+      throw new Error("Transform dependency path is outside project root");
+    }
     if (adapterRead) return adapterRead(normalizedPath);
-    return fs.readTextFile(normalizedPath);
+    return fs.readTextFile(candidatePath);
   };
 }
+
+/** @internal Test seams for transform dependency read routing. */
+export const pipelineInternals = Object.freeze({ buildReadFile });
 
 export type {
   PipelineConfig,

--- a/src/transforms/pipeline/index.ts
+++ b/src/transforms/pipeline/index.ts
@@ -31,7 +31,11 @@ import {
   ssrHttpStubPlugin,
   ssrVfModulesPlugin,
 } from "./stages/index.ts";
-import { createFileSystem, exists } from "#veryfront/platform/compat/fs.ts";
+import {
+  createFileSystem,
+  exists,
+  realPath as nativeRealPath,
+} from "#veryfront/platform/compat/fs.ts";
 import { getHttpBundleCacheDir } from "#veryfront/utils/cache-dir.ts";
 import { validateCachedBundlesByManifestOrCode } from "../esm/cached-bundle-validation.ts";
 import { findMissingFrameworkBundlePaths } from "../shared/framework-bundle-paths.ts";
@@ -45,8 +49,9 @@ import { getDependencyResolutionObservations } from "./stages/resolve-imports.ts
 import { loadImportMap, preloadImportMap } from "#veryfront/modules/import-map/index.ts";
 import type { ImportMapConfig } from "#veryfront/modules/import-map/types.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
-import { isAbsolute, relative, resolve } from "#veryfront/compat/path/index.ts";
+import { resolve } from "#veryfront/compat/path/index.ts";
 import { isFrameworkSourcePath } from "#veryfront/platform/compat/framework-source-resolver.ts";
+import { isWithinDirectory } from "#veryfront/utils/path-utils.ts";
 import {
   computePipelineConfigIdentity,
   fingerprintPipelineImportMap,
@@ -481,33 +486,80 @@ function extractReadFile(adapter: unknown): ((path: string) => Promise<string>) 
   return (path: string) => readFile.call(a!.fs, path);
 }
 
+function extractRealPath(adapter: unknown): ((path: string) => Promise<string>) | undefined {
+  const a = adapter as { fs?: { realPath?: (path: string) => Promise<string> } } | null;
+  const realPath = a?.fs?.realPath;
+  if (typeof realPath !== "function") return undefined;
+  return (path: string) => realPath.call(a!.fs, path);
+}
+
+function hasSymlinkFreeSemantics(adapter: unknown): boolean {
+  const fs = (adapter as { fs?: object } | null)?.fs;
+  if (!fs) return false;
+  const descriptor = Object.getOwnPropertyDescriptor(fs, "symlinkSemantics");
+  return descriptor !== undefined && "value" in descriptor && descriptor.value === "none";
+}
+
 /**
  * Build a readFile helper that avoids routing local framework paths
  * through the remote adapter.
  *
- * This prevents API fetches for file:// or absolute paths outside projectDir
- * (e.g. framework files under /usr/local/lib/node_modules/veryfront).
+ * Project dependencies must remain inside `projectDir`. Verified framework
+ * source roots are the only native-read exception. Every other outside path
+ * rejects before either filesystem can inspect it.
  */
 function buildReadFile(adapter: unknown, projectDir: string): (path: string) => Promise<string> {
   const adapterRead = extractReadFile(adapter);
+  const adapterRealPath = extractRealPath(adapter);
+  const adapterIsSymlinkFree = hasSymlinkFreeSemantics(adapter);
   const fs = createFileSystem();
   const projectRoot = resolve(projectDir);
+  let canonicalProjectRoot: Promise<string> | undefined;
+
+  const rejectOutsideProject = (): never => {
+    throw new Error("Transform dependency path is outside project root");
+  };
+
+  const canonicalizeProjectPath = async (candidatePath: string): Promise<string> => {
+    if (adapterIsSymlinkFree) return candidatePath;
+    const canonicalize = adapterRead ? adapterRealPath : nativeRealPath;
+    if (!canonicalize) {
+      throw new Error("Transform dependency reader cannot verify project containment");
+    }
+    let canonicalRoot: string;
+    let canonicalCandidate: string;
+    try {
+      canonicalProjectRoot ??= canonicalize(projectRoot);
+      [canonicalRoot, canonicalCandidate] = await Promise.all([
+        canonicalProjectRoot,
+        canonicalize(candidatePath),
+      ]);
+    } catch {
+      throw new Error("Transform dependency reader cannot verify project containment");
+    }
+    if (!isWithinDirectory(canonicalRoot, canonicalCandidate)) rejectOutsideProject();
+    return canonicalCandidate;
+  };
 
   return async (path: string): Promise<string> => {
     const normalizedPath = path.startsWith("file://") ? path.slice("file://".length) : path;
     const candidatePath = resolve(projectRoot, normalizedPath);
-    const projectRelativePath = relative(projectRoot, candidatePath);
-    const isOutsideProject = projectRelativePath === ".." ||
-      projectRelativePath.startsWith("../") ||
-      projectRelativePath.startsWith("..\\") ||
-      isAbsolute(projectRelativePath);
-
-    if (isOutsideProject) {
-      if (isFrameworkSourcePath(candidatePath)) return fs.readTextFile(candidatePath);
-      throw new Error("Transform dependency path is outside project root");
+    if (!isWithinDirectory(projectRoot, candidatePath)) {
+      if (isFrameworkSourcePath(candidatePath)) {
+        try {
+          const canonicalFrameworkPath = await nativeRealPath(candidatePath);
+          if (isFrameworkSourcePath(canonicalFrameworkPath)) {
+            return await fs.readTextFile(canonicalFrameworkPath);
+          }
+        } catch {
+          // Treat an unverifiable framework path like every other external path.
+        }
+      }
+      rejectOutsideProject();
     }
-    if (adapterRead) return adapterRead(normalizedPath);
-    return fs.readTextFile(candidatePath);
+    const readPath = await canonicalizeProjectPath(candidatePath);
+    if (adapterRead) return adapterRead(adapterIsSymlinkFree ? normalizedPath : readPath);
+    return fs.readTextFile(readPath);
   };
 }
 


### PR DESCRIPTION
Fixes veryfront/veryfront-issue-inbox#926

## What changed

- resolve dependency-read candidates against the project root and use path-aware containment
- reject external and prefix-collision paths before either the project adapter or native filesystem can read them
- retain native reads only for verified Veryfront framework source roots
- replace the prior external-file allowance test with RED-GREEN containment coverage

## RED-GREEN TDD

RED: both a sibling external path and a project-directory prefix collision were read successfully.

GREEN: both reject before any adapter call, while contained project reads still use the project adapter and verified framework sources still use the native filesystem.

## Verification

- deno task test:file src/transforms/pipeline/index.test.ts
- deno task test:file src/cache/dependency-tracking.test.ts
- deno task typecheck
- deno task lint:ci
- deno task build:npm
- deno lint src/transforms/pipeline/index.ts src/transforms/pipeline/index.test.ts
- git diff --check