### PR TITLE
fix(cli): register bundler before up

### DIFF
--- a/cli/commands/up/handler.test.ts
+++ b/cli/commands/up/handler.test.ts
@@ -25,6 +25,23 @@ describe("Up Handler", () => {
     it("accepts a single ParsedArgs parameter", () => {
       assertEquals(handleUpCommand.length, 1);
     });
+
+    it("registers the builtin bundler before publishing the preview", async () => {
+      const calls: string[] = [];
+
+      await handleUpCommand(createArgs(), {
+        ensureBundlerContracts: () => {
+          calls.push("ensure");
+          return Promise.resolve();
+        },
+        up: () => {
+          calls.push("up");
+          return Promise.resolve();
+        },
+      });
+
+      assertEquals(calls, ["ensure", "up"]);
+    });
   });
 
   describe("parseUpArgs via handler", () => {

--- a/cli/commands/up/handler.ts
+++ b/cli/commands/up/handler.ts
@@ -6,8 +6,24 @@ import { parseUpArgs, upCommand } from "./command.ts";
 import { showLogo } from "#cli/utils";
 import type { ParsedArgs } from "#cli/shared/types";
 import { parseArgsOrThrow } from "#cli/shared/args";
+import { ensureCliBundlerContracts } from "#cli/shared/default-contracts";
 
-export async function handleUpCommand(args: ParsedArgs): Promise<void> {
+interface UpHandlerDependencies {
+  ensureBundlerContracts: () => Promise<void>;
+  up: typeof upCommand;
+}
+
+const defaultDependencies: UpHandlerDependencies = {
+  ensureBundlerContracts: ensureCliBundlerContracts,
+  up: upCommand,
+};
+
+export async function handleUpCommand(
+  args: ParsedArgs,
+  dependencies: UpHandlerDependencies = defaultDependencies,
+): Promise<void> {
   showLogo();
-  await upCommand(parseArgsOrThrow(parseUpArgs, "up", args));
+  const options = parseArgsOrThrow(parseUpArgs, "up", args);
+  await dependencies.ensureBundlerContracts();
+  await dependencies.up(options);
 }


### PR DESCRIPTION
## Summary

- register the built-in Bundler and ModuleLexer contracts before `veryfront up` publishes its initial preview
- preserve argument validation before contract registration
- add RED-GREEN coverage for handler ordering

## Verification

- `deno task test:file cli/commands/up cli/commands/deploy/handler.test.ts`
- `deno task typecheck`
- `deno task lint`
- `deno task build:npm`

Closes veryfront/veryfront-issue-inbox#937

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `up` command now automatically ensures required bundler contracts are available before publishing.

* **Bug Fixes**
  * Improved command execution reliability by completing contract setup before the publishing operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->