### PR TITLE
fix(release): finalize dependency-pinned module paths

### DIFF
--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -3882,7 +3882,8 @@ describe("release asset build executor", () => {
 
   it("finalizes dependency-pinned project module paths", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
-    const pinnedChild = "/_vf_modules/_pins/on%3Asnapshot-a/components/Child.js";
+    const pinnedChild =
+      "https://preview.example.test/_vf_modules/_pins/on%3Asnapshot-a/components/Child.js?v=1#child";
     const files = [
       {
         path: "pages/index.tsx",
@@ -3918,8 +3919,10 @@ describe("release asset build executor", () => {
 
   it("discovers dependency-pinned framework module paths", async () => {
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
-    const pinnedHead = "/_vf_modules/_pins/on%3Asnapshot-a/_veryfront/react/runtime/core.js";
-    const pinnedUi = "/_vf_modules/_pins/on%3Asnapshot-a/_veryfront/react/components/ui/index.js";
+    const pinnedHead =
+      "/_vf_modules/_pins/on%3Asnapshot-a/_veryfront/react/runtime/core.js?v=1#head";
+    const pinnedUi =
+      "https://preview.example.test/_vf_modules/_pins/on%3Asnapshot-a/_veryfront/react/components/ui/index.js?v=1#ui";
     const files = [{
       path: "pages/index.tsx",
       content: 'import { Head } from "veryfront/head"; export default Head;',
@@ -3959,6 +3962,26 @@ describe("release asset build executor", () => {
     assertEquals(headSpecifiers.length, 1);
     assert(headSpecifiers[0]?.startsWith("/_vf/assets/"));
     assertEquals(headUpload.text.includes("/_vf_modules/_pins/"), false);
+  });
+
+  it("fails closed on malformed dependency-pinning module paths", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const files = [{
+      path: "pages/index.tsx",
+      content: 'import Child from "@/components/Child"; export default Child;',
+    }];
+    const transform = () =>
+      Promise.resolve(
+        'import Child from "/_vf_modules/_pins/%E0%A4%A/components/Child.js"; ' +
+          "export default Child;",
+      );
+
+    const result = await runReleaseAssetBuild(
+      baseInput(makeClient(files, rec), transform),
+      await tmp(),
+    );
+
+    assertCoverageFailure(result, rec, "module-rewrite-failed:pages/index.tsx");
   });
 
   it("rewrites transitive framework dependency imports to immutable assets", async () => {

--- a/src/release-assets/build-executor.test.ts
+++ b/src/release-assets/build-executor.test.ts
@@ -3880,6 +3880,87 @@ describe("release asset build executor", () => {
     assert(!pageUpload.text.includes(frameworkUrl));
   });
 
+  it("finalizes dependency-pinned project module paths", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const pinnedChild = "/_vf_modules/_pins/on%3Asnapshot-a/components/Child.js";
+    const files = [
+      {
+        path: "pages/index.tsx",
+        content: 'import Child from "@/components/Child"; export default Child;',
+      },
+      {
+        path: "components/Child.tsx",
+        content: "export default function Child() { return null; }",
+      },
+    ];
+    const client = makeClient(files, rec);
+    const transform = (_source: string, sourceFile: string) =>
+      Promise.resolve(
+        sourceFile.endsWith("pages/index.tsx")
+          ? `import Child from ${JSON.stringify(pinnedChild)}; export default Child;`
+          : "export default function Child() { return null; }",
+      );
+
+    const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    assertEquals(result.success, true);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    const childHash = manifest.modules["components/Child.tsx"]?.contentHash;
+    const pageHash = manifest.modules["pages/index.tsx"]?.contentHash;
+    assertExists(childHash);
+    assertExists(pageHash);
+    const pageUpload = rec.uploads.find((upload) => upload.hash === pageHash);
+    assertExists(pageUpload);
+    assertStringIncludes(pageUpload.text, `"/_vf/assets/${childHash}.js"`);
+    assertEquals(pageUpload.text.includes("/_vf_modules/_pins/"), false);
+  });
+
+  it("discovers dependency-pinned framework module paths", async () => {
+    const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };
+    const pinnedHead = "/_vf_modules/_pins/on%3Asnapshot-a/_veryfront/react/runtime/core.js";
+    const pinnedUi = "/_vf_modules/_pins/on%3Asnapshot-a/_veryfront/react/components/ui/index.js";
+    const files = [{
+      path: "pages/index.tsx",
+      content: 'import { Head } from "veryfront/head"; export default Head;',
+    }];
+    const client = makeClient(files, rec);
+    const transform = (_source: string, sourceFile: string) => {
+      if (sourceFile.endsWith("pages/index.tsx")) {
+        return Promise.resolve(
+          `import { Head } from ${JSON.stringify(pinnedHead)}; export default Head;`,
+        );
+      }
+      if (sourceFile.endsWith("src/react/runtime/core.ts")) {
+        return Promise.resolve(
+          `import { ColorModeProvider } from ${JSON.stringify(pinnedUi)}; ` +
+            "export function Head() { return ColorModeProvider; }",
+        );
+      }
+      return Promise.resolve("export function ColorModeProvider() { return null; }");
+    };
+
+    const result = await runReleaseAssetBuild(baseInput(client, transform), await tmp());
+
+    assertEquals(result.success, true);
+    const manifest = parseReleaseAssetManifest(rec.manifest);
+    assertExists(manifest);
+    const headHash = manifest.dependencies["veryfront/head"]?.contentHash;
+    const pageHash = manifest.modules["pages/index.tsx"]?.contentHash;
+    assertExists(headHash);
+    assertExists(pageHash);
+    const pageUpload = rec.uploads.find((upload) => upload.hash === pageHash);
+    const headUpload = rec.uploads.find((upload) => upload.hash === headHash);
+    assertExists(pageUpload);
+    assertExists(headUpload);
+    assertStringIncludes(pageUpload.text, `"/_vf/assets/${headHash}.js"`);
+    assertEquals(pageUpload.text.includes("/_vf_modules/_pins/"), false);
+    const headSpecifiers = await moduleSpecifiers(headUpload.text);
+    assertEquals(headSpecifiers.length, 1);
+    assert(headSpecifiers[0]?.startsWith("/_vf/assets/"));
+    assertEquals(headUpload.text.includes("/_vf_modules/_pins/"), false);
+  });
+
   it("rewrites transitive framework dependency imports to immutable assets", async () => {
     enableDependencyImportMap();
     const rec: Recorded = { began: false, uploads: [], manifest: null, states: [] };

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -707,8 +707,27 @@ function normalizeLogicalPath(path: string): string | null {
 }
 
 function normalizeReleaseModuleSpecifier(specifier: string): string | null {
-  const extracted = extractDependencyPinningPathKey(specifier);
-  return extracted.malformed ? null : extracted.pathname;
+  const { path } = splitSpecifierSuffix(specifier);
+  let pathname = path;
+  if (/^https?:\/\//i.test(path) || path.startsWith("//")) {
+    try {
+      const absolute = new URL(path, "https://veryfront.invalid");
+      if (
+        (absolute.protocol !== "http:" && absolute.protocol !== "https:") ||
+        absolute.username !== "" ||
+        absolute.password !== ""
+      ) {
+        return specifier;
+      }
+      pathname = absolute.pathname;
+    } catch {
+      return specifier;
+    }
+  }
+
+  const extracted = extractDependencyPinningPathKey(pathname);
+  if (extracted.malformed) return null;
+  return extracted.found ? extracted.pathname : specifier;
 }
 
 function normalizeProjectSpecifier(specifier: string, logicalPath: string): string | null {

--- a/src/release-assets/build-executor.ts
+++ b/src/release-assets/build-executor.ts
@@ -63,7 +63,10 @@ import {
   resolveEsmShThroughImportMap,
 } from "#veryfront/transforms/shared/esm-sh-import-map.ts";
 import { isRuntimeImportMapSpecifier } from "#veryfront/transforms/import-rewriter/strategies/import-map-strategy.ts";
-import { isEsmShUrl } from "#veryfront/transforms/import-rewriter/url-builder.ts";
+import {
+  extractDependencyPinningPathKey,
+  isEsmShUrl,
+} from "#veryfront/transforms/import-rewriter/url-builder.ts";
 import { tryResolve } from "#veryfront/extensions/contracts.ts";
 import type { CodeParser } from "#veryfront/extensions/parser/code-parser.ts";
 import { ensureDefaultParserContracts } from "#veryfront/extensions/parser/defaults.ts";
@@ -703,30 +706,39 @@ function normalizeLogicalPath(path: string): string | null {
   return parts.length > 0 ? parts.join("/") : null;
 }
 
+function normalizeReleaseModuleSpecifier(specifier: string): string | null {
+  const extracted = extractDependencyPinningPathKey(specifier);
+  return extracted.malformed ? null : extracted.pathname;
+}
+
 function normalizeProjectSpecifier(specifier: string, logicalPath: string): string | null {
+  const normalizedSpecifier = normalizeReleaseModuleSpecifier(specifier);
+  if (normalizedSpecifier === null) return null;
   if (
-    specifier.startsWith("//") ||
-    /^[A-Za-z][A-Za-z0-9+.-]*:/.test(specifier) ||
-    specifier.startsWith("#")
+    normalizedSpecifier.startsWith("//") ||
+    /^[A-Za-z][A-Za-z0-9+.-]*:/.test(normalizedSpecifier) ||
+    normalizedSpecifier.startsWith("#")
   ) {
     return null;
   }
 
-  if (specifier.startsWith("/_vf_modules/_veryfront/")) return null;
-  if (specifier.startsWith("/_vf_modules/")) return specifier;
-  if (specifier.startsWith("_veryfront/")) return null;
-  if (specifier.startsWith("@/")) return specifier.slice(2);
+  if (normalizedSpecifier.startsWith("/_vf_modules/_veryfront/")) return null;
+  if (normalizedSpecifier.startsWith("/_vf_modules/")) return normalizedSpecifier;
+  if (normalizedSpecifier.startsWith("_veryfront/")) return null;
+  if (normalizedSpecifier.startsWith("@/")) return normalizedSpecifier.slice(2);
 
-  if (specifier.startsWith("./") || specifier.startsWith("../")) {
+  if (normalizedSpecifier.startsWith("./") || normalizedSpecifier.startsWith("../")) {
     const dir = logicalPath.includes("/")
       ? logicalPath.slice(0, logicalPath.lastIndexOf("/"))
       : ".";
-    return `${dir}/${specifier}`;
+    return `${dir}/${normalizedSpecifier}`;
   }
 
-  if (specifier.startsWith("/")) return specifier;
+  if (normalizedSpecifier.startsWith("/")) return normalizedSpecifier;
 
-  if (PROJECT_IMPORT_ROOTS.some((dir) => specifier.startsWith(dir))) return specifier;
+  if (PROJECT_IMPORT_ROOTS.some((dir) => normalizedSpecifier.startsWith(dir))) {
+    return normalizedSpecifier;
+  }
 
   return null;
 }
@@ -1464,12 +1476,19 @@ function dependencyUrlForSpecifier(
   dependencyUrls: Map<string, string>,
   specifier: string,
 ): string | null {
+  const normalizedReleaseSpecifier = normalizeReleaseModuleSpecifier(specifier);
+  if (normalizedReleaseSpecifier === null) return null;
   const direct = dependencyUrls.get(specifier) ??
-    dependencyUrls.get(normalizeDependencySpecifier(specifier));
+    dependencyUrls.get(normalizeDependencySpecifier(specifier)) ??
+    dependencyUrls.get(normalizedReleaseSpecifier) ??
+    dependencyUrls.get(normalizeDependencySpecifier(normalizedReleaseSpecifier));
   if (direct) return direct;
 
-  if (specifier.startsWith("http://") || specifier.startsWith("https://")) {
-    const normalized = normalizeHttpUrl(specifier);
+  if (
+    normalizedReleaseSpecifier.startsWith("http://") ||
+    normalizedReleaseSpecifier.startsWith("https://")
+  ) {
+    const normalized = normalizeHttpUrl(normalizedReleaseSpecifier);
     return dependencyUrls.get(normalized) ??
       dependencyUrls.get(normalizeDependencySpecifier(normalized)) ?? null;
   }
@@ -2698,8 +2717,13 @@ async function buildFrameworkDependencies(
     specifier: string,
     fromSourcePath: string,
   ): Promise<string | null> {
-    if (specifier.startsWith("./") || specifier.startsWith("../")) {
-      const resolvedPath = await resolveRelativeFrameworkSourceImport(specifier, fromSourcePath);
+    const normalizedSpecifier = normalizeReleaseModuleSpecifier(specifier);
+    if (normalizedSpecifier === null) return null;
+    if (normalizedSpecifier.startsWith("./") || normalizedSpecifier.startsWith("../")) {
+      const resolvedPath = await resolveRelativeFrameworkSourceImport(
+        normalizedSpecifier,
+        fromSourcePath,
+      );
       if (!resolvedPath) return null;
       const helperName = matchPublishedRuntimeHelper(resolvedPath, fromSourcePath);
       if (helperName) {
@@ -2717,8 +2741,8 @@ async function buildFrameworkDependencies(
       return frameworkSourcePathToSourceKey(resolvedPath, lookupDirs);
     }
 
-    if (specifier.startsWith(FRAMEWORK_MODULE_URL_PREFIX)) {
-      return frameworkModuleUrlToSourceKey(specifier);
+    if (normalizedSpecifier.startsWith(FRAMEWORK_MODULE_URL_PREFIX)) {
+      return frameworkModuleUrlToSourceKey(normalizedSpecifier);
     }
 
     return null;
@@ -2847,8 +2871,10 @@ async function collectRequestedFrameworkSpecifiers(
   for (const transformed of transformedModules.values()) {
     for (const imp of await parseImports(transformed.code)) {
       if (!imp.n) continue;
-      if (Object.hasOwn(PLATFORM_UTILITIES, imp.n)) requested.add(imp.n);
-      for (const alias of specifiersByModuleUrl.get(imp.n) ?? []) requested.add(alias);
+      const specifier = normalizeReleaseModuleSpecifier(imp.n);
+      if (specifier === null) continue;
+      if (Object.hasOwn(PLATFORM_UTILITIES, specifier)) requested.add(specifier);
+      for (const alias of specifiersByModuleUrl.get(specifier) ?? []) requested.add(alias);
     }
   }
 


### PR DESCRIPTION
## Summary

- normalize validated dependency-pinning path transports before release project and framework resolution
- discover and finalize pinned Veryfront framework dependencies, including pinned transitive framework imports
- keep malformed pin transports fail-closed
- add RED-GREEN release coverage for pinned project modules and framework modules

## Verification

- `deno task test:file src/release-assets/build-executor.test.ts` (205 steps)
- `deno task typecheck`
- `deno task lint`
- `deno task build:npm`
- `deno task build`
- pinning-enabled production build of the affected 40-file staging snapshot

Closes veryfront/veryfront-issue-inbox#938