### PR TITLE
Preserve cancellation across delayed durable starts

### DIFF
--- a/src/agent/ag-ui/detached-start.test.ts
+++ b/src/agent/ag-ui/detached-start.test.ts
@@ -383,7 +383,7 @@ describe("agent/ag-ui-detached-start", () => {
     const response = await handler(createDetachedRequest());
 
     assertEquals(response.status, 410);
-    assertEquals(await response.json(), { error: "RUN_CANCELLED" });
+    assertEquals(await response.json(), { errorCode: "RUN_CANCELLED" });
     assertEquals(started, false);
   });
 

--- a/src/agent/ag-ui/detached-start.test.ts
+++ b/src/agent/ag-ui/detached-start.test.ts
@@ -365,6 +365,28 @@ describe("agent/ag-ui-detached-start", () => {
     sessionManager.cancelRun("run_1");
   });
 
+  it("rejects a detached start that arrives after its cancellation", async () => {
+    const sessionManager = new RunResumeSessionManager<{
+      result: unknown;
+      isError: boolean;
+    }>();
+    let started = false;
+    sessionManager.cancelRun("run_1", { rememberIfMissing: true });
+
+    const handler = createAgUiDetachedStartHandler({
+      sessionManager,
+      startDetachedExecution: async () => {
+        started = true;
+      },
+    });
+
+    const response = await handler(createDetachedRequest());
+
+    assertEquals(response.status, 410);
+    assertEquals(await response.json(), { error: "RUN_CANCELLED" });
+    assertEquals(started, false);
+  });
+
   it("returns 400 for malformed detached start payloads", async () => {
     const handler = createAgUiDetachedStartHandler({
       agent: createTestAgent(),

--- a/src/agent/ag-ui/detached-start.ts
+++ b/src/agent/ag-ui/detached-start.ts
@@ -13,6 +13,7 @@ import { type AgUiResumeValue, buildMergedAgUiTools } from "./tool-shared.ts";
 import {
   AgentRuntime,
   RunAlreadyExistsError,
+  RunCancelledError,
   type RunResumeSessionManager,
 } from "../runtime/index.ts";
 import type { Agent } from "../types.ts";
@@ -380,6 +381,10 @@ export async function executeAgUiDetachedStart(
       { status: 202 },
     );
   } catch (error) {
+    if (error instanceof RunCancelledError) {
+      return Response.json({ error: "RUN_CANCELLED" }, { status: 410 });
+    }
+
     if (error instanceof RunAlreadyExistsError) {
       await options.onDuplicate?.({
         request: input.request,

--- a/src/agent/ag-ui/detached-start.ts
+++ b/src/agent/ag-ui/detached-start.ts
@@ -382,7 +382,7 @@ export async function executeAgUiDetachedStart(
     );
   } catch (error) {
     if (error instanceof RunCancelledError) {
-      return Response.json({ error: "RUN_CANCELLED" }, { status: 410 });
+      return Response.json({ errorCode: "RUN_CANCELLED" }, { status: 410 });
     }
 
     if (error instanceof RunAlreadyExistsError) {

--- a/src/agent/ag-ui/run-control.ts
+++ b/src/agent/ag-ui/run-control.ts
@@ -156,7 +156,7 @@ export function createAgUiCancelHandler<T = unknown>(
       return Response.json({ error: "Run not found" }, { status: 404 });
     }
 
-    const accepted = options.sessionManager.cancelRun(runId);
+    const accepted = options.sessionManager.cancelRun(runId, { rememberIfMissing: true });
     if (accepted) {
       return Response.json({ accepted: true }, { status: 202 });
     }

--- a/src/agent/hosted/durable-chat-run-start.test.ts
+++ b/src/agent/hosted/durable-chat-run-start.test.ts
@@ -12,6 +12,7 @@ import {
   type AgUiResumeValue,
   createDetachedRunTracker,
   type ParsedHostedChatRequest,
+  RunResumeSessionManager,
 } from "../index.ts";
 import {
   durableChatRunStartInternals,
@@ -232,6 +233,61 @@ describe("agent/hosted-durable-chat-run-start", () => {
       [{ execution, runId, conversationId }],
       "duplicate detected after prepare must release the prepared execution",
     );
+  });
+
+  it("releases a prepared execution when cancellation wins before start", async () => {
+    const tracker = createDetachedRunTracker<AgUiResumeValue>();
+    const req = createParsedRequest();
+    if (!req.durableRootRun || !req.conversationId) {
+      throw new Error("Expected durable request");
+    }
+    const runId = req.durableRootRun.runId;
+    const conversationId = req.conversationId;
+    const execution = { id: "execution-1" };
+    const cleanupCalls: unknown[] = [];
+    tracker.sessionManager.cancelRun(runId, { rememberIfMissing: true });
+
+    const response = await executeHostedDurableChatRun({
+      req,
+      rawRequest: createRequest(),
+      tracker,
+      prepareExecution: async () => execution,
+      cleanupExecution: async (input) => {
+        cleanupCalls.push(input);
+      },
+      startDetachedExecution: async () => {},
+    });
+
+    assertEquals(response.status, 410);
+    assertEquals(
+      cleanupCalls,
+      [{ execution, runId, conversationId }],
+      "cancel-before-start must release the prepared execution",
+    );
+  });
+
+  it("releases a prepared execution when detached admission throws", async () => {
+    const sessionManager = new RunResumeSessionManager<AgUiResumeValue>({
+      maxConcurrentSessions: 1,
+    });
+    sessionManager.startRun({ runId: "existing-run", threadId: crypto.randomUUID() });
+    const tracker = createDetachedRunTracker<AgUiResumeValue>({ sessionManager });
+    const execution = { id: "execution-1" };
+    const cleanupCalls: unknown[] = [];
+
+    const response = await executeHostedDurableChatRun({
+      req: createParsedRequest(),
+      rawRequest: createRequest(),
+      tracker,
+      prepareExecution: async () => execution,
+      cleanupExecution: async (input) => {
+        cleanupCalls.push(input);
+      },
+      startDetachedExecution: async () => {},
+    });
+
+    assertEquals(response.status, 500);
+    assertEquals(cleanupCalls.length, 1);
   });
 
   it("returns a stable error when durable conversation context is missing", async () => {

--- a/src/agent/hosted/durable-chat-run-start.ts
+++ b/src/agent/hosted/durable-chat-run-start.ts
@@ -194,6 +194,16 @@ async function executeHostedDurableChatRunStart<TExecution>(
   }
 
   const execution = await input.prepareExecution(input.req);
+  let executionDisposition: "prepared" | "transferred" | "released" = "prepared";
+  const releasePreparedExecution = async (): Promise<void> => {
+    if (executionDisposition !== "prepared") return;
+    executionDisposition = "released";
+    await input.cleanupExecution?.({
+      execution,
+      runId: durableRootRun.runId,
+      conversationId,
+    });
+  };
   const historicalToolInputCompactions: HistoricalToolInputCompactionDiagnostic[] = [];
   const detachedStartRequest = buildDetachedAgUiStartRequest({
     runId: durableRootRun.runId,
@@ -213,49 +223,53 @@ async function executeHostedDurableChatRunStart<TExecution>(
       toolInputCompactions: historicalToolInputCompactions,
     });
   }
-  const detachedStartResponse = await executeAgUiDetachedStart(
-    {
-      sessionManager: input.tracker.sessionManager,
-      startDetachedExecution: async ({ abortSignal, rawRequest }) => {
-        const detachedExecution = input.startDetachedExecution({
-          execution,
-          abortSignal,
-          rawRequest,
-        });
-        input.tracker.registerExecution(durableRootRun.runId, detachedExecution);
-        await detachedExecution;
+  try {
+    const detachedStartResponse = await executeAgUiDetachedStart(
+      {
+        sessionManager: input.tracker.sessionManager,
+        startDetachedExecution: async ({ abortSignal, rawRequest }) => {
+          const detachedExecution = input.startDetachedExecution({
+            execution,
+            abortSignal,
+            rawRequest,
+          });
+          input.tracker.registerExecution(durableRootRun.runId, detachedExecution);
+          await detachedExecution;
+        },
+        onDuplicate: releasePreparedExecution,
+        onAccepted: async () => {
+          executionDisposition = "transferred";
+          input.tracker.trackRun(durableRootRun.runId);
+        },
+        onError: async ({ error }) => {
+          input.tracker.untrackRun(durableRootRun.runId);
+          input.logger?.error("Detached durable run execution failed", {
+            runId: durableRootRun.runId,
+            conversationId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        },
       },
-      onDuplicate: async () => {
-        await input.cleanupExecution?.({
-          execution,
-          runId: durableRootRun.runId,
-          conversationId,
-        });
+      {
+        request: detachedStartRequest,
+        rawRequest: input.rawRequest,
+        requestOrCtx: input.requestOrCtx ?? input.rawRequest,
       },
-      onAccepted: async () => {
-        input.tracker.trackRun(durableRootRun.runId);
-      },
-      onError: async ({ error }) => {
-        input.tracker.untrackRun(durableRootRun.runId);
-        input.logger?.error("Detached durable run execution failed", {
-          runId: durableRootRun.runId,
-          conversationId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      },
-    },
-    {
-      request: detachedStartRequest,
-      rawRequest: input.rawRequest,
-      requestOrCtx: input.requestOrCtx ?? input.rawRequest,
-    },
-  );
+    );
 
-  if (detachedStartResponse.status !== 202) {
-    return detachedStartResponse;
+    if (detachedStartResponse.status !== 202) {
+      await releasePreparedExecution();
+      if (detachedStartResponse.status === 410) {
+        return Response.json({ errorCode: "RUN_CANCELLED" }, { status: 410 });
+      }
+      return detachedStartResponse;
+    }
+
+    return await parseAcceptedDetachedStartResponse(detachedStartResponse);
+  } catch (error) {
+    await releasePreparedExecution();
+    throw error;
   }
-
-  return await parseAcceptedDetachedStartResponse(detachedStartResponse);
 }
 
 /** Test-only internals for durable chat run start behavior. */

--- a/src/agent/runtime/resume-session.test.ts
+++ b/src/agent/runtime/resume-session.test.ts
@@ -137,6 +137,16 @@ describe("agent/runtime/resume-session", () => {
     assertEquals(signal.aborted, false);
   });
 
+  it("does not remember an ordinary active-run cancellation", () => {
+    const manager = new RunResumeSessionManager<{ ok: boolean }>();
+    manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+
+    assertEquals(manager.cancelRun("run_1"), true);
+
+    const signal = manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    assertEquals(signal.aborted, false);
+  });
+
   it("rejects submissions for wait keys that are not currently pending", () => {
     const manager = new RunResumeSessionManager<{ ok: boolean }>();
     manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });

--- a/src/agent/runtime/resume-session.test.ts
+++ b/src/agent/runtime/resume-session.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { FakeTime } from "#std/testing/time";
 import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
@@ -89,6 +90,51 @@ describe("agent/runtime/resume-session", () => {
       undefined,
       "the original parked waiter must still be settled by the cancel",
     );
+  });
+
+  it("rejects a start that arrives after cancellation and expires the cancellation tombstone", () => {
+    using time = new FakeTime(1_000);
+    const manager = new RunResumeSessionManager<{ ok: boolean }>({
+      cancellationTtlMs: 1,
+    });
+
+    assertEquals(manager.cancelRun("run_1", { rememberIfMissing: true }), false);
+    assertThrows(
+      () => manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() }),
+      RunCancelledError,
+      "cancelled before start",
+    );
+
+    time.tick(2);
+
+    const signal = manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    assertEquals(signal.aborted, false);
+  });
+
+  it("bounds remembered cancellations while preserving the newest tombstone", () => {
+    const manager = new RunResumeSessionManager<{ ok: boolean }>({
+      maxCancellationTombstones: 1,
+    });
+
+    assertEquals(manager.cancelRun("run_1", { rememberIfMissing: true }), false);
+    assertEquals(manager.cancelRun("run_2", { rememberIfMissing: true }), false);
+
+    const first = manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    assertEquals(first.aborted, false);
+    assertThrows(
+      () => manager.startRun({ runId: "run_2", threadId: crypto.randomUUID() }),
+      RunCancelledError,
+      "cancelled before start",
+    );
+  });
+
+  it("keeps an ordinary missing-run cancellation as a no-op", () => {
+    const manager = new RunResumeSessionManager<{ ok: boolean }>();
+
+    assertEquals(manager.cancelRun("run_1"), false);
+
+    const signal = manager.startRun({ runId: "run_1", threadId: crypto.randomUUID() });
+    assertEquals(signal.aborted, false);
   });
 
   it("rejects submissions for wait keys that are not currently pending", () => {

--- a/src/agent/runtime/resume-session.ts
+++ b/src/agent/runtime/resume-session.ts
@@ -379,7 +379,9 @@ export class RunResumeSessionManager<T> {
       return false;
     }
 
-    this.rememberCancellation(runId);
+    if (options.rememberIfMissing) {
+      this.rememberCancellation(runId);
+    }
 
     if (
       session.status === "completed" || session.status === "failed" ||

--- a/src/agent/runtime/resume-session.ts
+++ b/src/agent/runtime/resume-session.ts
@@ -72,12 +72,18 @@ type RunSession<T> = {
 };
 
 const DEFAULT_WAITING_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_CANCELLATION_TTL_MS = 5 * 60 * 1000;
+const DEFAULT_MAX_CANCELLATION_TOMBSTONES = 1_000;
 const DEFAULT_MAX_CONCURRENT_SESSIONS = 100;
 
 /** Options accepted by run resume session manager. */
 export interface RunResumeSessionManagerOptions<T> {
   waitingTtlMs?: number;
   sessionTtlMs?: number | null;
+  /** How long an explicit cancellation can reject a delayed start for the same run. */
+  cancellationTtlMs?: number;
+  /** Maximum delayed-start cancellations retained by one manager instance. */
+  maxCancellationTombstones?: number;
   maxConcurrentSessions?: number;
   setTimeoutFn?: typeof setTimeout;
   clearTimeoutFn?: typeof clearTimeout;
@@ -91,6 +97,7 @@ function defaultConflictKey(value: unknown): string {
 /** Implement run resume session manager. */
 export class RunResumeSessionManager<T> {
   private readonly sessions = new Map<string, RunSession<T>>();
+  private readonly cancellationTombstones = new Map<string, number>();
 
   constructor(
     private readonly options: RunResumeSessionManagerOptions<T> = {},
@@ -102,6 +109,17 @@ export class RunResumeSessionManager<T> {
 
   private get sessionTtlMs(): number | null {
     return this.options.sessionTtlMs ?? null;
+  }
+
+  private get cancellationTtlMs(): number {
+    return Math.max(1, this.options.cancellationTtlMs ?? DEFAULT_CANCELLATION_TTL_MS);
+  }
+
+  private get maxCancellationTombstones(): number {
+    return Math.max(
+      1,
+      this.options.maxCancellationTombstones ?? DEFAULT_MAX_CANCELLATION_TOMBSTONES,
+    );
   }
 
   private get maxConcurrentSessions(): number {
@@ -116,9 +134,42 @@ export class RunResumeSessionManager<T> {
     return this.options.clearTimeoutFn ?? globalThis.clearTimeout.bind(globalThis);
   }
 
+  private get nowMs(): number {
+    return Date.now();
+  }
+
   private getConflictKey(value: T): string {
     const createConflictKey = this.options.getConflictKey ?? defaultConflictKey;
     return createConflictKey(value);
+  }
+
+  private rememberCancellation(runId: string): void {
+    const now = this.nowMs;
+    for (const [candidateRunId, expiresAt] of this.cancellationTombstones) {
+      if (expiresAt <= now) {
+        this.cancellationTombstones.delete(candidateRunId);
+      }
+    }
+
+    this.cancellationTombstones.delete(runId);
+
+    while (this.cancellationTombstones.size >= this.maxCancellationTombstones) {
+      const oldestRunId = this.cancellationTombstones.keys().next().value;
+      if (oldestRunId === undefined) break;
+      this.cancellationTombstones.delete(oldestRunId);
+    }
+
+    this.cancellationTombstones.set(runId, now + this.cancellationTtlMs);
+  }
+
+  private hasCancellationTombstone(runId: string): boolean {
+    const expiresAt = this.cancellationTombstones.get(runId);
+    if (expiresAt === undefined) return false;
+    if (expiresAt <= this.nowMs) {
+      this.cancellationTombstones.delete(runId);
+      return false;
+    }
+    return true;
   }
 
   private clearWaitingTimeout(session: RunSession<T>): void {
@@ -166,6 +217,10 @@ export class RunResumeSessionManager<T> {
   }
 
   startRun(input: { runId: string; threadId: string }): AbortSignal {
+    if (this.hasCancellationTombstone(input.runId)) {
+      throw new RunCancelledError(`Run "${input.runId}" was cancelled before start`);
+    }
+
     const existing = this.sessions.get(input.runId);
     if (existing && (existing.status === "running" || existing.status === "waiting")) {
       throw new RunAlreadyExistsError(input.runId);
@@ -315,9 +370,16 @@ export class RunResumeSessionManager<T> {
     return { accepted: true };
   }
 
-  cancelRun(runId: string): boolean {
+  cancelRun(runId: string, options: { rememberIfMissing?: boolean } = {}): boolean {
     const session = this.sessions.get(runId);
-    if (!session) return false;
+    if (!session) {
+      if (options.rememberIfMissing) {
+        this.rememberCancellation(runId);
+      }
+      return false;
+    }
+
+    this.rememberCancellation(runId);
 
     if (
       session.status === "completed" || session.status === "failed" ||
@@ -357,5 +419,6 @@ export class RunResumeSessionManager<T> {
     for (const runId of [...this.sessions.keys()]) {
       this.cancelRun(runId);
     }
+    this.cancellationTombstones.clear();
   }
 }

--- a/src/agent/service/routes.test.ts
+++ b/src/agent/service/routes.test.ts
@@ -787,6 +787,39 @@ Deno.test("agent service routes cancel AG-UI runs", async () => {
   assertEquals(response.status, 204);
 });
 
+it("agent service routes reject a durable start that arrives after cancellation", async () => {
+  let starts = 0;
+  const { routeSet } = createRouteSet({
+    startDetachedExecution: async () => {
+      starts += 1;
+    },
+  });
+  const cancelResponse = await routeSet.handleDurableChatRunCancelRequest({
+    request: createAuthenticatedRequest("/api/runs/run-1", {}, "DELETE"),
+    runId: "run-1",
+  });
+
+  const startResponse = await routeSet.handleDurableChatRunExecuteRequest({
+    request: createAuthenticatedRequest("/api/runs", {
+      messages: [],
+      context: {
+        conversationId: "00000000-0000-4000-8000-000000000001",
+        projectId: "00000000-0000-4000-8000-000000000005",
+        branchId: null,
+      },
+      durableRootRun: {
+        runId: "run-1",
+        messageId: "00000000-0000-4000-8000-000000000002",
+      },
+    }),
+  });
+
+  assertEquals(cancelResponse.status, 204);
+  assertEquals(startResponse.status, 410);
+  assertEquals(await startResponse.json(), { errorCode: "RUN_CANCELLED" });
+  assertEquals(starts, 0);
+});
+
 it("agent service routes accept cancellation of a live AG-UI run", async () => {
   const { routeSet, tracker } = createRouteSet();
   tracker.sessionManager.startRun({ runId: "run-1", threadId: crypto.randomUUID() });


### PR DESCRIPTION
## Summary

- retain an explicit, bounded cancellation tombstone when DELETE races ahead of delayed run admission
- reject the later detached start with a stable 410 / `RUN_CANCELLED` envelope before any work starts
- release hosted prepared executions exactly once across duplicate, cancelled, rejected, and thrown admission paths

## Why

A durable API cancellation can reach the runtime before its corresponding POST. Without a short-lived tombstone, the delayed POST can recreate and execute work that the control plane already cancelled.

## Verification

- focused Deno suites: resume session, detached start, hosted durable start, and service routes
- full pre-push gate: format, lint, typecheck, complete unit suite
- API reference generation check
- independent read-only review: approved with no actionable correctness, compatibility, security, or resource-leak findings

## Notes

The tombstone store is lazy-expiring and hard-bounded (5 minute default, 1,000 entries) without timers. Ordinary missing-run cancellation keeps its existing no-op behavior; only the explicit HTTP cancellation boundary remembers a missing run.