### PR TITLE
fix(security): strip authToken cookie before forwarding to project code

### DIFF
--- a/src/proxy/handler.test.ts
+++ b/src/proxy/handler.test.ts
@@ -4091,6 +4091,58 @@ describe("Proxy Handler", () => {
       assertEquals(injected.headers.get("x-environment-name"), null);
     });
 
+    it("strips the authToken cookie before the request reaches project code", () => {
+      const req = new Request("http://example.com/api/test", {
+        headers: {
+          cookie: "session=abc; authToken=deployer-session-jwt; theme=dark",
+        },
+      });
+      const ctx: ProxyContext = {
+        token: "test-token",
+        projectSlug: "my-project",
+        environment: "preview",
+        contentSourceId: "cs-123",
+        host: "example.com",
+        parsedDomain: {
+          slug: "my-project",
+          branch: null,
+          environment: "preview",
+          isVeryfrontDomain: true,
+          isDraft: true,
+          allowIframeEmbed: true,
+        },
+        isLocalProject: false,
+      };
+
+      const injected = injectContextHeaders(req, ctx);
+      assertEquals(injected.headers.get("cookie"), "session=abc; theme=dark");
+    });
+
+    it("drops the cookie header entirely when authToken is the only cookie", () => {
+      const req = new Request("http://example.com/api/test", {
+        headers: { cookie: "authToken=deployer-session-jwt" },
+      });
+      const ctx: ProxyContext = {
+        token: "test-token",
+        projectSlug: "my-project",
+        environment: "preview",
+        contentSourceId: "cs-123",
+        host: "example.com",
+        parsedDomain: {
+          slug: "my-project",
+          branch: null,
+          environment: "preview",
+          isVeryfrontDomain: true,
+          isDraft: true,
+          allowIframeEmbed: true,
+        },
+        isLocalProject: false,
+      };
+
+      const injected = injectContextHeaders(req, ctx);
+      assertEquals(injected.headers.get("cookie"), null);
+    });
+
     it("refuses to forward a partial environment identity", () => {
       const req = new Request("http://example.com/api/test");
       const ctx: ProxyContext = {

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -1371,16 +1371,18 @@ export function createProxyContextHeaders(
   const headers = createProxyEndToEndHeaders(sourceHeaders);
   for (const header of INTERNAL_PROXY_HEADERS) headers.delete(header);
 
-  // The `authToken` cookie carries the caller's Veryfront credential (a user
-  // session JWT, or an exchanged environment access token). The proxy has
-  // already consumed it (resolveProxyRequestToken) and forwards the resolved
-  // identity via `x-token`; the raw credential must never reach
-  // tenant-controlled project code. Application cookies pass through intact.
-  const cookieHeader = headers.get("cookie");
-  if (cookieHeader !== null) {
-    const remainingCookies = stripUserTokenCookie(cookieHeader);
-    if (remainingCookies === undefined) headers.delete("cookie");
-    else headers.set("cookie", remainingCookies);
+  // For hosted projects, the `authToken` cookie carries the caller's Veryfront
+  // credential. The proxy has already consumed it (resolveProxyRequestToken)
+  // and forwards the resolved identity via `x-token`, so the raw credential
+  // must not reach tenant-controlled project code. Local projects skip that
+  // token flow, where the same cookie name belongs to the application.
+  if (!ctx.isLocalProject) {
+    const cookieHeader = headers.get("cookie");
+    if (cookieHeader !== null) {
+      const remainingCookies = stripUserTokenCookie(cookieHeader);
+      if (remainingCookies === undefined) headers.delete("cookie");
+      else headers.set("cookie", remainingCookies);
+    }
   }
 
   // The `x-veryfront-*-jws` signature headers are deliberately NOT stripped:

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -10,7 +10,11 @@ import { computeContentSourceId } from "#veryfront/cache/keys.ts";
 import { getEnv } from "#veryfront/platform/compat/process.ts";
 import { checkProtectedProxyAccess } from "./proxy-access-control.ts";
 import { createLocalProjectResolver } from "./local-project-resolver.ts";
-import { isMissingProxyProjectError, resolveProxyRequestToken } from "./proxy-token-resolution.ts";
+import {
+  isMissingProxyProjectError,
+  resolveProxyRequestToken,
+  stripUserTokenCookie,
+} from "./proxy-token-resolution.ts";
 import {
   createProjectNotFoundProxyContext,
   createProxyErrorContext,
@@ -1366,6 +1370,18 @@ export function createProxyContextHeaders(
   }
   const headers = createProxyEndToEndHeaders(sourceHeaders);
   for (const header of INTERNAL_PROXY_HEADERS) headers.delete(header);
+
+  // The `authToken` cookie carries the caller's Veryfront credential (a user
+  // session JWT, or an exchanged environment access token). The proxy has
+  // already consumed it (resolveProxyRequestToken) and forwards the resolved
+  // identity via `x-token`; the raw credential must never reach
+  // tenant-controlled project code. Application cookies pass through intact.
+  const cookieHeader = headers.get("cookie");
+  if (cookieHeader !== null) {
+    const remainingCookies = stripUserTokenCookie(cookieHeader);
+    if (remainingCookies === undefined) headers.delete("cookie");
+    else headers.set("cookie", remainingCookies);
+  }
 
   // The `x-veryfront-*-jws` signature headers are deliberately NOT stripped:
   // the downstream renderer re-verifies them against the raw request body and

--- a/src/proxy/proxy-token-resolution.test.ts
+++ b/src/proxy/proxy-token-resolution.test.ts
@@ -5,6 +5,7 @@ import {
   extractUserToken,
   isMissingProxyProjectError,
   resolveProxyRequestToken,
+  stripUserTokenCookie,
 } from "./proxy-token-resolution.ts";
 import { OAuthTokenRequestError } from "./oauth-client.ts";
 
@@ -21,6 +22,22 @@ describe("proxy/proxy-token-resolution", () => {
       extractUserToken(`authToken=${"x".repeat(64 * 1024 + 1)}`),
       undefined,
     );
+  });
+
+  it("strips every authToken pair while preserving application cookies", () => {
+    assertEquals(stripUserTokenCookie("authToken=secret"), undefined);
+    assertEquals(stripUserTokenCookie("authToken=first; authToken=second"), undefined);
+    assertEquals(
+      stripUserTokenCookie("session=abc; authToken=secret; theme=dark"),
+      "session=abc; theme=dark",
+    );
+    assertEquals(
+      stripUserTokenCookie(" authToken = secret ; app=1"),
+      "app=1",
+    );
+    assertEquals(stripUserTokenCookie("authToken; app=1"), "app=1");
+    assertEquals(stripUserTokenCookie("authTokenX=1; XauthToken=2"), "authTokenX=1; XauthToken=2");
+    assertEquals(stripUserTokenCookie(""), undefined);
   });
 
   it("prefers signed internal control-plane tokens over preview user cookies", async () => {

--- a/src/proxy/proxy-token-resolution.ts
+++ b/src/proxy/proxy-token-resolution.ts
@@ -84,6 +84,30 @@ export function extractUserToken(cookieHeader: string): string | undefined {
 }
 
 /**
+ * Remove the platform `authToken` pair from a Cookie header before a request
+ * crosses into tenant-controlled project code. The cookie carries a Veryfront
+ * credential (a user session JWT, or an exchanged environment access token);
+ * the proxy consumes it via {@linkcode extractUserToken} and forwards the
+ * resolved identity through `x-token`, so the raw credential must never be
+ * observable by deployed pages, API routes, or middleware. Every other cookie
+ * is preserved verbatim for the application. Returns `undefined` when nothing
+ * remains.
+ */
+export function stripUserTokenCookie(cookieHeader: string): string | undefined {
+  const kept: string[] = [];
+  for (const part of cookieHeader.split(";")) {
+    const trimmed = part.trim();
+    if (trimmed === "") continue;
+    const separatorIndex = trimmed.indexOf("=");
+    const name = separatorIndex === -1 ? trimmed : trimmed.slice(0, separatorIndex).trim();
+    if (name === "authToken") continue;
+    kept.push(trimmed);
+  }
+  if (kept.length === 0) return undefined;
+  return kept.join("; ");
+}
+
+/**
  * Token service deployments report an unknown project identity with either
  * HTTP 400 (legacy) or HTTP 404. Classify that contract at the typed HTTP
  * boundary without coupling the proxy to response prose.

--- a/src/proxy/token-priority.test.ts
+++ b/src/proxy/token-priority.test.ts
@@ -7,7 +7,7 @@ import "#veryfront/schemas/_test-setup.ts";
  */
 import { assertEquals } from "#veryfront/testing/assert";
 import { describe, it } from "#veryfront/testing/bdd";
-import { createProxyHandler } from "./handler.ts";
+import { createProxyHandler, injectContextHeaders } from "./handler.ts";
 import { createMockServer } from "../../tests/_helpers/utils.ts";
 
 function createHandler(port: number) {
@@ -378,7 +378,7 @@ describe("Token Priority Cascade", () => {
   });
 
   describe("local project bypasses token fetch", () => {
-    it("skips token fetch for local projects", async () => {
+    it("skips token consumption and preserves application authToken cookies", async () => {
       const handler = createProxyHandler({
         config: {
           apiBaseUrl: "http://localhost:9999",
@@ -392,7 +392,10 @@ describe("Token Priority Cascade", () => {
       });
 
       const req = new Request("http://local-proj.preview.veryfront.com/page", {
-        headers: { host: "local-proj.preview.veryfront.com" },
+        headers: {
+          host: "local-proj.preview.veryfront.com",
+          cookie: "session=abc; authToken=application-session; theme=dark",
+        },
       });
 
       const ctx = await handler.processRequest(req);
@@ -401,6 +404,10 @@ describe("Token Priority Cascade", () => {
       assertEquals(ctx.isLocalProject, true);
       assertEquals(ctx.localPath, "/tmp/local-proj");
       assertEquals(ctx.error, undefined);
+      assertEquals(
+        injectContextHeaders(req, ctx).headers.get("cookie"),
+        "session=abc; authToken=application-session; theme=dark",
+      );
 
       await handler.close();
     });


### PR DESCRIPTION
## Summary

The hosted proxy consumes the `authToken` cookie (via `extractUserToken` in `src/proxy/proxy-token-resolution.ts`) to resolve the caller's Veryfront identity, but `createProxyContextHeaders` then forwarded the Cookie header verbatim to the deployed project — it only removed internal `x-*` proxy headers, `host`, and hop-by-hop fields. Any tenant-controlled page, API route, or middleware in a protected environment could therefore read the raw Veryfront credential of anyone who visited it. This includes the deployer's account session JWT: the CLI's post-deploy readiness probe (`waitForEnvironmentReady` in `cli/shared/deployment/deploy-project.ts`) sends `Cookie: authToken=<token>` to a normal app route, and for `veryfront login` session credentials no environment-scoped token exchange applies (only opaque API keys were exchanged, per #3959/#3966). A malicious project collaborator or compromised dependency could exfiltrate the deployer's live full-account credential during every deploy — a real privilege escalation across the platform/tenant boundary.

## Finding

- Codex finding id: `67637779a99c8191877f33f62588ec2b` — severity: high
- Introduced in cdccb25a76aa86f86fb1eaf3a3d67414af10aa5e

## Fix

`createProxyContextHeaders` (`src/proxy/handler.ts`) now strips every `authToken` pair from the Cookie header before building the downstream request, dropping the header entirely when no other cookies remain. A new `stripUserTokenCookie` helper lives next to `extractUserToken` so consumption and redaction stay in one place. The proxy already forwards the resolved identity via `x-token`, so nothing downstream loses information, and application cookies pass through unchanged. All downstream forwarding paths (HTTP forward, split forward, WebSocket bridge) share `createProxyContextHeaders`, so each is covered. The only other `authToken` cookie consumer (`src/agent/service/auth.ts`) runs as a standalone service on its own port and also accepts `Authorization: Bearer`, so it is unaffected.

Defense-in-depth follow-up (not in this PR): extend the CLI's `resolveEnvironmentAccess` exchange to also cover session JWTs so the readiness probe only ever presents a short-lived environment-bound token; requires control-plane support for exchanging session credentials.

## Test evidence

- New unit tests: `stripUserTokenCookie` edge cases (multiple pairs, whitespace, bare `authToken`, name lookalikes preserved) in `src/proxy/proxy-token-resolution.test.ts`; `injectContextHeaders` strips the `authToken` cookie while preserving app cookies and drops the header when it was the only cookie, in `src/proxy/handler.test.ts`.
- `deno task test:file` green on: `src/proxy/proxy-token-resolution.test.ts` (7 steps), `src/proxy/handler.test.ts` (75 steps), `src/proxy/split-forward-request.test.ts`, `src/proxy/proxy-access-control.test.ts`, `src/proxy/websocket-proxy.test.ts`, `src/proxy/mode-parity.test.ts`, `src/proxy/websocket-bridge-identity.test.ts`, `src/proxy/hop-by-hop-headers.test.ts` — 0 failures.
- `deno fmt --check`, `deno lint`, and `deno check` clean on all touched files.

https://claude.ai/code/session_01QfWNMiUhvWMKWi6BGfVdY3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Hosted project requests no longer forward the platform authentication cookie.
  - Other cookies remain intact, while the cookie header is removed when no cookies remain.
  - Local project requests continue preserving application authentication cookies.

- **Tests**
  - Added coverage for mixed, token-only, whitespace, valueless, and similarly named cookies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->