### PR TITLE
fix(security): stop validating env and stored tokens against project veryfront.json apiUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ versions are listed at
 
 ## Unreleased
 
+### Breaking: project API URLs no longer steer ambient credentials
+
+Veryfront no longer sends a shell, `.env`, or stored CLI credential to the
+`apiUrl` in a project's `veryfront.json` during login, `whoami`, or an
+authentication preflight. Those credentials use the API URL selected by your
+environment, or the default Veryfront API URL when you do not set one. A token
+defined in the same `veryfront.json` still uses that file's `apiUrl`.
+
+If you use a self-hosted control plane with an ambient credential, set
+`VERYFRONT_API_URL` or `VERYFRONT_API_BASE_URL` in your trusted environment.
+
 ### Breaking: Redis workflow `runTtl` no longer expires runs
 
 `RedisBackendConfig.runTtl` is now a deprecated no-op. It previously started a

--- a/cli/auth/login.test.ts
+++ b/cli/auth/login.test.ts
@@ -1608,7 +1608,7 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
       }
     });
 
-    it("validates an environment token against the configured API URL in JSON mode", async () => {
+    it("validates an environment token against the default API URL, not a veryfront.json apiUrl, in JSON mode", async () => {
       const originalFetch = globalThis.fetch;
       const originalLog = console.log;
       const originalError = console.error;
@@ -1630,7 +1630,7 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
         globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
           requestedUrls.push(String(input));
           requestedAuth.push(String(new Headers(init?.headers).get("authorization") ?? ""));
-          if (String(input) === "https://control.example.test/api/me") {
+          if (String(input) === "https://api.veryfront.com/me") {
             return Promise.resolve(
               Response.json({ id: "env-user", email: "env@example.com" }),
             );
@@ -1657,7 +1657,7 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
           email: "env@example.com",
           source: "env",
         });
-        assertEquals(requestedUrls, ["https://control.example.test/api/me"]);
+        assertEquals(requestedUrls, ["https://api.veryfront.com/me"]);
         assertEquals(requestedAuth, ["Bearer env-valid-token"]);
         assertEquals(output.join("\n").includes("env-valid-token"), false);
         assertEquals(errors, []);
@@ -1673,7 +1673,7 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
       }
     });
 
-    it("validates a stored token against the configured API URL in JSON mode", async () => {
+    it("validates a stored token against the default API URL, not a veryfront.json apiUrl, in JSON mode", async () => {
       const originalFetch = globalThis.fetch;
       const originalLog = console.log;
       const originalError = console.error;
@@ -1696,7 +1696,7 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
         globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
           requestedUrls.push(String(input));
           requestedAuth.push(String(new Headers(init?.headers).get("authorization") ?? ""));
-          if (String(input) === "https://control.example.test/api/me") {
+          if (String(input) === "https://api.veryfront.com/me") {
             return Promise.resolve(
               Response.json({ id: "stored-user", email: "stored@example.com" }),
             );
@@ -1720,7 +1720,7 @@ describe("Login Module", { sanitizeOps: false, sanitizeResources: false }, () =>
           email: "stored@example.com",
           source: "token-store",
         });
-        assertEquals(requestedUrls, ["https://control.example.test/api/me"]);
+        assertEquals(requestedUrls, ["https://api.veryfront.com/me"]);
         assertEquals(requestedAuth, ["Bearer stored-valid-token"]);
         assertEquals(output.join("\n").includes("stored-valid-token"), false);
         assertEquals(errors, []);

--- a/cli/shared/config.test.ts
+++ b/cli/shared/config.test.ts
@@ -18,6 +18,7 @@ import {
 import type { ResolvedConfig } from "./config.ts";
 import type { EnvironmentConfig } from "#veryfront/config/environment-config.ts";
 import { join } from "veryfront/platform/path";
+import { withTempDir } from "#veryfront/testing/deno-compat";
 import { __resetEnvLoaderForTests, loadEnv } from "veryfront/utils/env-loader";
 import { deleteToken, saveToken } from "../auth/token-store.ts";
 
@@ -948,8 +949,7 @@ describe("readConfigFile", () => {
 
 describe("resolveApiCredentialCandidatesForAuth", () => {
   it("keeps a project veryfront.json apiUrl away from non-config credentials", async () => {
-    const tempDir = await Deno.makeTempDir();
-    try {
+    await withTempDir(async (tempDir) => {
       await Deno.writeTextFile(
         join(tempDir, "veryfront.json"),
         JSON.stringify({
@@ -967,14 +967,11 @@ describe("resolveApiCredentialCandidatesForAuth", () => {
         if (candidate.apiTokenSource === "config-file") continue;
         assertEquals(candidate.validationEnv.apiUrl, "https://api.veryfront.com");
       }
-    } finally {
-      await Deno.remove(tempDir, { recursive: true });
-    }
+    });
   });
 
   it("still validates the config-file token against its own apiUrl", async () => {
-    const tempDir = await Deno.makeTempDir();
-    try {
+    await withTempDir(async (tempDir) => {
       await Deno.writeTextFile(
         join(tempDir, "veryfront.json"),
         JSON.stringify({
@@ -991,8 +988,6 @@ describe("resolveApiCredentialCandidatesForAuth", () => {
       );
       assertEquals(configCandidate?.apiToken, "config-token");
       assertEquals(configCandidate?.validationEnv.apiUrl, "https://api.veryfront.org");
-    } finally {
-      await Deno.remove(tempDir, { recursive: true });
-    }
+    });
   });
 });

--- a/cli/shared/config.test.ts
+++ b/cli/shared/config.test.ts
@@ -10,6 +10,7 @@ import {
   createApiClient,
   isRetryableApiReadError,
   readConfigFile,
+  resolveApiCredentialCandidatesForAuth,
   resolveConfig,
   resolveConfigWithAuth,
   resolveConfigWithAuthDetails,
@@ -939,6 +940,57 @@ describe("readConfigFile", () => {
 
       assertEquals(config?.projectSlug, "json-only");
       assertEquals(config?.apiUrl, "https://api.veryfront.org");
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+});
+
+describe("resolveApiCredentialCandidatesForAuth", () => {
+  it("keeps a project veryfront.json apiUrl away from non-config credentials", async () => {
+    const tempDir = await Deno.makeTempDir();
+    try {
+      await Deno.writeTextFile(
+        join(tempDir, "veryfront.json"),
+        JSON.stringify({
+          apiUrl: "https://attacker.example",
+          apiToken: "config-token",
+        }),
+      );
+      const env = createMockEnv({ apiToken: "shell-token" });
+
+      const candidates = await resolveApiCredentialCandidatesForAuth(env, tempDir, false);
+
+      const envCandidate = candidates.find((candidate) => candidate.apiTokenSource === "env");
+      assertEquals(envCandidate?.apiToken, "shell-token");
+      for (const candidate of candidates) {
+        if (candidate.apiTokenSource === "config-file") continue;
+        assertEquals(candidate.validationEnv.apiUrl, "https://api.veryfront.com");
+      }
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  });
+
+  it("still validates the config-file token against its own apiUrl", async () => {
+    const tempDir = await Deno.makeTempDir();
+    try {
+      await Deno.writeTextFile(
+        join(tempDir, "veryfront.json"),
+        JSON.stringify({
+          apiUrl: "https://api.veryfront.org",
+          apiToken: "config-token",
+        }),
+      );
+      const env = createMockEnv({});
+
+      const candidates = await resolveApiCredentialCandidatesForAuth(env, tempDir, false);
+
+      const configCandidate = candidates.find(
+        (candidate) => candidate.apiTokenSource === "config-file",
+      );
+      assertEquals(configCandidate?.apiToken, "config-token");
+      assertEquals(configCandidate?.validationEnv.apiUrl, "https://api.veryfront.org");
     } finally {
       await Deno.remove(tempDir, { recursive: true });
     }

--- a/cli/shared/config.ts
+++ b/cli/shared/config.ts
@@ -240,6 +240,7 @@ async function resolveApiCredentialCandidates(
   configFile: VeryfrontConfig | null,
   interactive: boolean,
   validationEnv: EnvironmentConfig,
+  configFileValidationEnv: EnvironmentConfig = validationEnv,
 ): Promise<ApiCredentialCandidate[]> {
   const envToken = env.apiToken;
   const envSource = envToken ? getEnvSource("VERYFRONT_API_TOKEN") : { source: "unset" as const };
@@ -263,7 +264,7 @@ async function resolveApiCredentialCandidates(
     candidates.push({
       apiToken: configFile.apiToken,
       apiTokenSource: "config-file",
-      validationEnv,
+      validationEnv: configFileValidationEnv,
       authoritative: true,
     });
   }
@@ -304,12 +305,27 @@ export async function resolveApiCredentialCandidatesForAuth(
   interactive = true,
 ): Promise<ApiCredentialCandidate[]> {
   const configFile = await readConfigJsonFile(projectDir);
+  // A checked-in veryfront.json apiUrl only steers the credential that came
+  // from that same file. Shell-environment, .env-file, and token-store
+  // credentials validate against the environment-derived API URL, so a
+  // malicious repository config cannot redirect their Authorization headers
+  // to an attacker-controlled host.
   const validationEnv = {
+    ...env,
+    apiUrl: resolveCliApiUrl(env),
+  };
+  const configFileValidationEnv = {
     ...env,
     apiUrl: resolveCliApiUrl(env, configFile?.apiUrl),
   };
 
-  return resolveApiCredentialCandidates(env, configFile, interactive, validationEnv);
+  return resolveApiCredentialCandidates(
+    env,
+    configFile,
+    interactive,
+    validationEnv,
+    configFileValidationEnv,
+  );
 }
 
 async function resolveConfigBase(


### PR DESCRIPTION
## Summary

`resolveApiCredentialCandidatesForAuth` (`cli/shared/config.ts`) read `veryfront.json` from the current project directory and built a single `validationEnv` whose `apiUrl` came from that file, then attached it to every credential candidate — shell-environment (`VERYFRONT_API_TOKEN`), `.env`-file, and token-store credentials included. `veryfront login` and `veryfront whoami` validate those candidates by fetching `${apiUrl}/me` (or `/projects`) with `Authorization: Bearer <token>`. A malicious repository could therefore check in `veryfront.json` with `"apiUrl": "https://attacker.example"`, and any developer with a stored Veryfront token or `VERYFRONT_API_TOKEN` who ran `veryfront login` or `veryfront whoami` inside that directory would send their credential to the attacker-controlled host.

## Finding

- Codex finding id: `dbaac2593a00819193938d6155b42c8f` (finding 36), severity: medium
- Introduced in 71356afcf94da86bc63997ef6eca397090f8a9d2

## Fix

`resolveApiCredentialCandidatesForAuth` now builds two validation environments:

- a baseline `validationEnv` derived from the environment only (`resolveCliApiUrl(env)` — `VERYFRONT_API_URL`, an explicit non-default `VERYFRONT_API_BASE_URL`, or the default production URL), used for shell-environment, `.env`-file, and token-store candidates; and
- a `configFileValidationEnv` that includes the project `veryfront.json` `apiUrl`, used only for the credential that itself came from that same config file.

A checked-in `veryfront.json` can no longer redirect credentials it did not supply. Operators who intentionally target a different API still can via `VERYFRONT_API_URL` / `VERYFRONT_API_BASE_URL`.

## Test evidence

- New regression tests in `cli/shared/config.test.ts` (`resolveApiCredentialCandidatesForAuth`): non-config candidates keep the default API URL even when `veryfront.json` sets `apiUrl: "https://attacker.example"`, while the config-file token still validates against its own `apiUrl`. The first test was verified to fail against the unfixed code.
- Updated two tests in `cli/auth/login.test.ts` that had encoded the vulnerable behavior (env/stored tokens validated against the `veryfront.json` apiUrl); they now assert validation goes to the default API URL and never touches the config host.
- Local runs, all passing: `deno task test:file cli/shared/config.test.ts` (7 passed, 42 steps), `deno task test:file cli/auth/login.test.ts` (94 steps), `deno task test:file cli/shared/constants.test.ts`, `deno task test:file cli/auth/auth.integration.test.ts`; `deno fmt --check` and `deno lint` clean on touched files; `deno check cli/shared/config.ts cli/shared/config.test.ts` clean.

https://claude.ai/code/session_01QfWNMiUhvWMKWi6BGfVdY3
