### PR TITLE
fix(security): never cache renders carrying an admitted application identity

### DIFF
--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -821,6 +821,50 @@ describe("RenderPipeline behavior", () => {
     assertEquals(persists, [], "personalized HTML must never be persisted");
   });
 
+  it("never caches HTML rendered for an admitted application identity", async () => {
+    const checks: Array<string | undefined> = [];
+    const persists: Array<string | undefined> = [];
+    const pipeline = createPipeline("/project/pages/index.mdx", {
+      cacheCoordinator: {
+        checkCache: async (slug, cacheKey) => {
+          checks.push(cacheKey);
+          return {
+            depAwareSlug: slug,
+            moduleCacheKey: cacheKey ?? slug,
+            cacheStatus: "miss",
+            lookupDurationMs: 0,
+          };
+        },
+        persistResult: async (_result, _slug, cacheKey) => {
+          persists.push(cacheKey);
+        },
+      },
+    } as Partial<RenderPipelineConfig>);
+
+    // Trusted-proxy auth strips identity headers from the application request,
+    // so the request itself carries no cache-sensitive state; only the
+    // admitted identity marks this render as personalized.
+    await pipeline.renderPage("", {
+      delivery: "string",
+      request: new Request("http://localhost/"),
+      applicationIdentity: {
+        issuer: "https://issuer.example.test",
+        subject: "user-123",
+        groups: ["engineering"],
+        roles: ["reader"],
+        groupsComplete: true,
+        claims: { sub: "user-123" },
+      },
+    });
+
+    assertEquals(
+      checks,
+      [],
+      "identity-scoped HTML must never be read from the shared render cache",
+    );
+    assertEquals(persists, [], "identity-scoped HTML must never be persisted");
+  });
+
   it("bounds the complete API render key for a flag-off override", () => {
     const cachePrefix = "project:preview:branch:v1";
     const pipeline = createPipeline("/project/pages/index.mdx", {

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -1489,8 +1489,9 @@ export class RenderPipeline {
 
   /**
    * Build a cache key that is safe for multi-tenant + query-param aware caching.
-   * Returns null when request contains sensitive headers (Authorization/Cookie) and
-   * no explicit cacheKey override was provided, to avoid leaking personalized HTML.
+   * Returns null when request contains sensitive headers (Authorization/Cookie) or an
+   * admitted application identity, and no explicit cacheKey override was provided, to
+   * avoid leaking personalized HTML.
    *
    * Query param handling uses config.queryParamOptions for filtering (utm_*, gclid, etc.).
    */
@@ -1513,6 +1514,10 @@ export class RenderPipeline {
         composition,
       );
     }
+    // Trusted-proxy identities arrive via headers that are stripped from the
+    // application request before this check runs, so an identity-bearing
+    // render must never share the anonymous slug-based cache key.
+    if (options?.applicationIdentity != null) return null;
     const req = options?.request;
     if (req) {
       if (requestHasCacheSensitiveState(req)) return null;

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -2965,6 +2965,37 @@ describe("Renderer dependency pin cache isolation", () => {
     );
   });
 
+  it("returns no render cache key for an admitted application identity", () => {
+    const renderer = new Renderer();
+    const buildCacheKey = (renderer as unknown as {
+      buildCacheKey(
+        slug: string,
+        ctx: RenderContext,
+        options?: RenderOptions,
+      ): string | null;
+    }).buildCacheKey.bind(renderer);
+    const ctx = makeRenderContext();
+
+    // Trusted-proxy auth strips identity headers from the application request,
+    // so the request itself carries no cache-sensitive state; only the
+    // admitted identity marks this render as personalized.
+    assertEquals(
+      buildCacheKey("/", ctx, {
+        request: new Request("http://localhost/"),
+        url: new URL("http://localhost/"),
+        applicationIdentity: {
+          issuer: "https://issuer.example.test",
+          subject: "user-123",
+          groups: ["engineering"],
+          roles: ["reader"],
+          groupsComplete: true,
+          claims: { sub: "user-123" },
+        },
+      }),
+      null,
+    );
+  });
+
   it("misses the outer render cache when the package map changes", async () => {
     const originalFlag = getHostEnv(DEPENDENCY_PINNING_ENV_FLAG);
     const projectDir = await Deno.makeTempDir({ prefix: "vf-renderer-pins-" });

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -458,7 +458,8 @@ export class Renderer {
 
   /**
    * Compute a cache key that is query-aware and avoids caching personalized responses
-   * (Authorization / Cookie / x-api-key) unless the caller explicitly provides one.
+   * (Authorization / Cookie / x-api-key / admitted application identity) unless the
+   * caller explicitly provides one.
    *
    * Query param handling is configurable via `config.cache.queryParams`:
    * - "ignore-all": Ignore all query params (pages share cache regardless of URL params)
@@ -485,6 +486,10 @@ export class Renderer {
       );
     }
 
+    // Trusted-proxy identities arrive via headers that are stripped from the
+    // application request before this check runs, so an identity-bearing
+    // render must never share the anonymous slug-based cache key.
+    if (options?.applicationIdentity != null) return null;
     const req = options?.request;
     if (req) {
       if (requestHasCacheSensitiveState(req)) return null;


### PR DESCRIPTION
## Summary

The legacy `/_veryfront/data/*.json` endpoint builds an application request with the configured identity headers removed (`denyHeaders: ctx.applicationIdentityHeaderNames`) and then calls `renderer.renderPage(..., { applicationIdentity: ctx.applicationIdentity })` with no cache guard. For trusted-proxy authentication the user's identity exists only in those stripped headers (e.g. `x-auth-subject`), so `buildCacheKey`'s `requestHasCacheSensitiveState` check — which only looks for Authorization/Cookie/x-api-key on the application request — never fires. An identity-dependent page/`getServerData` result could therefore be persisted under the public slug-based render cache key and later served to a *different* authenticated trusted-proxy user requesting the same URL: a cross-user data leak. The adjacent SSR service (`ssr.service.ts` — `mustNotCache = ... || hasApplicationIdentity`) and page-data endpoint (`page-data-endpoint-handler.ts` — `!hasApplicationIdentity` gates the cache key) already guard against exactly this; the legacy data path missed it.

## Finding

- Codex finding id: `6af1308533bc8191a2608e50a4e76918`
- Severity: medium
- Introduced in: 05f9e36d3 (feat(auth): add provider-neutral application authentication)

## Fix

Fail closed at the cache-key level, covering the legacy data endpoint and every other `renderPage` caller uniformly: both `Renderer.buildCacheKey` (`src/rendering/renderer.ts`) and `RenderPipeline.buildCacheKey` (`src/rendering/orchestrator/pipeline.ts`) now return `null` whenever `options.applicationIdentity` is non-null (alongside the existing sensitive-header check, so the documented explicit `cacheKey` override semantics are unchanged). A `null` cache key disables both cache lookup and cache persistence, so identity-bearing renders never read from or write to the shared render cache.

## Test evidence

- New regression tests:
  - `src/rendering/orchestrator/pipeline.behavior.test.ts` — "never caches HTML rendered for an admitted application identity": renders with an `applicationIdentity` and a header-stripped request, asserts zero `checkCache`/`persistResult` calls.
  - `src/rendering/renderer.test.ts` — "returns no render cache key for an admitted application identity": asserts `buildCacheKey` yields `null` for an identity-bearing request with no sensitive headers.
- `deno task test:file src/rendering/orchestrator/pipeline.behavior.test.ts` — ok, 1 passed (56 steps), 0 failed
- `deno task test:file src/rendering/renderer.test.ts` — ok, 5 passed (66 steps), 0 failed
- `deno task test:file src/server/handlers/request/module/data-endpoint-handler.test.ts` — ok, 1 passed (18 steps), 0 failed
- `deno task test:file tests/integration/server/module-handler-cache.test.ts` — ok, 1 passed (4 steps), 0 failed
- `deno fmt --check` clean and `deno lint` clean on all touched files; `deno check src/rendering/index.ts src/server/index.ts` passes

https://claude.ai/code/session_01QfWNMiUhvWMKWi6BGfVdY3