### PR TITLE
fix(security): scope hosted workflow Redis state per project

### DIFF
--- a/src/rendering/ssr-renderer.test.ts
+++ b/src/rendering/ssr-renderer.test.ts
@@ -24,6 +24,18 @@ import { resolveCommittedHeadFromHTML } from "./orchestrator/html-head.ts";
 
 type PipeableSSRStream = ReturnType<NonNullable<ReactDOMServer["renderToPipeableStream"]>>;
 
+/**
+ * React's own nonce option type, read back off the injected render signature.
+ *
+ * React 19 widened `nonce` from a bare string to a string-or-per-directive
+ * object, so binding the observed value to the render option's declared type
+ * keeps this test compiling against whichever shape the installed React
+ * typings expose instead of pinning it to `string`.
+ */
+type ReadableStreamNonceOption = NonNullable<
+  Parameters<NonNullable<ReactDOMServer["renderToReadableStream"]>>[1]
+>["nonce"];
+
 function createPipeableSSRStream(
   pipeImpl: (writable: NodeJS.WritableStream) => void,
   abortImpl: () => void = () => {},
@@ -94,7 +106,7 @@ describe("rendering/ssr-renderer", () => {
   });
 
   it("forwards the response nonce to React-owned streaming scripts", async () => {
-    let observedNonce: string | undefined;
+    let observedNonce: ReadableStreamNonceOption;
     const streamAllReady: Promise<void> = Promise.resolve();
     __injectReactDOMServerForTests({
       renderToString: () => "<div>unused</div>",

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -1,7 +1,12 @@
 import { toolRegistryInternal } from "#veryfront/tool/registry.ts";
 import "#veryfront/schemas/_test-setup.ts";
 import "#veryfront/html/styles-builder/__tests__/css-processor-setup.ts";
-import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import {
+  assertEquals,
+  assertExists,
+  assertStringIncludes,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import type { Agent } from "#veryfront/agent";
 import type { Message } from "#veryfront/agent/types.ts";
@@ -88,6 +93,18 @@ describe("projectWorkflowRedisPrefix", () => {
       streamKey: "vf:workflow:project:.20.proj-1:stream",
       groupName: "vf:workflow:project:.20.proj-1:workers",
     });
+  });
+
+  it("refuses to configure durable persistence without a project scope", () => {
+    // An unscoped prefix would let one project's recovery scan enumerate
+    // every other project's durable workflow keys, so an empty scope must
+    // fail closed instead of falling back to a shared namespace.
+    const error = assertThrows(() => projectWorkflowRedisConfig("")) as {
+      slug?: string;
+      detail?: string;
+    };
+    assertEquals(error.slug, "input-validation-failed");
+    assertStringIncludes(error.detail ?? "", "requires a project scope");
   });
 });
 

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -82,6 +82,27 @@ describe("projectWorkflowRedisPrefix", () => {
     );
   });
 
+  it("does not use project-controlled string encoding methods", () => {
+    const originalReplace = String.prototype.replace;
+    const originalCharCodeAt = String.prototype.charCodeAt;
+    const originalNumberToString = Number.prototype.toString;
+    let first: string | undefined;
+    let second: string | undefined;
+    try {
+      String.prototype.replace = () => "shared";
+      String.prototype.charCodeAt = () => 0;
+      Number.prototype.toString = () => "0";
+      first = projectWorkflowRedisPrefix("project.*");
+      second = projectWorkflowRedisPrefix("project.?");
+    } finally {
+      String.prototype.replace = originalReplace;
+      String.prototype.charCodeAt = originalCharCodeAt;
+      Number.prototype.toString = originalNumberToString;
+    }
+
+    assertEquals(first === second, false);
+  });
+
   it("preserves whitespace in the verified project id when configuring Redis", () => {
     const canonical = projectWorkflowRedisConfig("proj-1");
     const whitespacePrefixed = projectWorkflowRedisConfig(" proj-1");

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -63,7 +63,7 @@ describe("projectWorkflowRedisPrefix", () => {
   it("namespaces durable workflow state per project", () => {
     assertEquals(
       projectWorkflowRedisPrefix("proj-1"),
-      "vf:workflow:project:proj-1:target::environment::branch::",
+      "vf:workflow:project:proj-1:target:main_branch:environment::branch::",
     );
     assertEquals(
       projectWorkflowRedisPrefix("proj-1") === projectWorkflowRedisPrefix("proj-2"),
@@ -87,15 +87,65 @@ describe("projectWorkflowRedisPrefix", () => {
     const whitespacePrefixed = projectWorkflowRedisConfig(" proj-1");
 
     assertEquals(canonical, {
-      prefix: "vf:workflow:project:proj-1:target::environment::branch::",
-      streamKey: "vf:workflow:project:proj-1:target::environment::branch::stream",
-      groupName: "vf:workflow:project:proj-1:target::environment::branch::workers",
+      prefix: "vf:workflow:project:proj-1:target:main_branch:environment::branch::",
+      streamKey: "vf:workflow:project:proj-1:target:main_branch:environment::branch::stream",
+      groupName: "vf:workflow:project:proj-1:target:main_branch:environment::branch::workers",
     });
     assertEquals(whitespacePrefixed, {
-      prefix: "vf:workflow:project:.20.proj-1:target::environment::branch::",
-      streamKey: "vf:workflow:project:.20.proj-1:target::environment::branch::stream",
-      groupName: "vf:workflow:project:.20.proj-1:target::environment::branch::workers",
+      prefix: "vf:workflow:project:.20.proj-1:target:main_branch:environment::branch::",
+      streamKey: "vf:workflow:project:.20.proj-1:target:main_branch:environment::branch::stream",
+      groupName: "vf:workflow:project:.20.proj-1:target:main_branch:environment::branch::workers",
     });
+  });
+
+  it("canonicalizes an omitted runtime target kind to the default branch", () => {
+    // The control-plane wire format leaves runtimeTargetKind optional and
+    // resolveControlPlaneBranchBinding reads an omitted kind as main_branch.
+    // Both spellings must land in one namespace or an approval waiting under
+    // the explicit spelling is invisible to a recovery scan started under the
+    // implicit one.
+    assertEquals(
+      projectWorkflowRedisPrefix("proj-1", {}),
+      projectWorkflowRedisPrefix("proj-1", { runtimeTargetKind: "main_branch" }),
+    );
+  });
+
+  it("ignores identifiers that do not belong to the selected target kind", () => {
+    // A default-branch or environment run carries no preview branch id, so a
+    // stray identifier must not split one target across two namespaces.
+    const mainBranch = projectWorkflowRedisPrefix("proj-1", {
+      runtimeTargetKind: "main_branch",
+    });
+    assertEquals(
+      projectWorkflowRedisPrefix("proj-1", {
+        runtimeTargetKind: "main_branch",
+        runtimeTargetEnvironmentId: "env-1",
+        runtimeTargetBranchId: "branch-1",
+      }),
+      mainBranch,
+    );
+    assertEquals(
+      projectWorkflowRedisPrefix("proj-1", {
+        runtimeTargetKind: "environment",
+        runtimeTargetEnvironmentId: "env-1",
+        runtimeTargetBranchId: "branch-1",
+      }),
+      projectWorkflowRedisPrefix("proj-1", {
+        runtimeTargetKind: "environment",
+        runtimeTargetEnvironmentId: "env-1",
+      }),
+    );
+    assertEquals(
+      projectWorkflowRedisPrefix("proj-1", {
+        runtimeTargetKind: "preview_branch",
+        runtimeTargetEnvironmentId: "env-1",
+        runtimeTargetBranchId: "branch-1",
+      }),
+      projectWorkflowRedisPrefix("proj-1", {
+        runtimeTargetKind: "preview_branch",
+        runtimeTargetBranchId: "branch-1",
+      }),
+    );
   });
 
   it("namespaces durable workflow state per runtime target", () => {

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -20,6 +20,7 @@ import {
   createKnowledgeEventLogger,
   ProjectRunExecuteHandler,
   type ProjectRunExecuteHandlerDeps,
+  projectWorkflowRedisConfig,
   projectWorkflowRedisPrefix,
 } from "./project-run-execute.handler.ts";
 import { createControlPlaneSignature, createCtx } from "./internal-agent-run.test-helpers.ts";
@@ -71,6 +72,22 @@ describe("projectWorkflowRedisPrefix", () => {
       projectWorkflowRedisPrefix("a.b") === projectWorkflowRedisPrefix("a.2e.b"),
       false,
     );
+  });
+
+  it("preserves whitespace in the verified project id when configuring Redis", () => {
+    const canonical = projectWorkflowRedisConfig("proj-1");
+    const whitespacePrefixed = projectWorkflowRedisConfig(" proj-1");
+
+    assertEquals(canonical, {
+      prefix: "vf:workflow:project:proj-1:",
+      streamKey: "vf:workflow:project:proj-1:stream",
+      groupName: "vf:workflow:project:proj-1:workers",
+    });
+    assertEquals(whitespacePrefixed, {
+      prefix: "vf:workflow:project:.20.proj-1:",
+      streamKey: "vf:workflow:project:.20.proj-1:stream",
+      groupName: "vf:workflow:project:.20.proj-1:workers",
+    });
   });
 });
 

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -61,7 +61,10 @@ describe("createKnowledgeEventLogger", () => {
 
 describe("projectWorkflowRedisPrefix", () => {
   it("namespaces durable workflow state per project", () => {
-    assertEquals(projectWorkflowRedisPrefix("proj-1"), "vf:workflow:project:proj-1:");
+    assertEquals(
+      projectWorkflowRedisPrefix("proj-1"),
+      "vf:workflow:project:proj-1:target::environment::branch::",
+    );
     assertEquals(
       projectWorkflowRedisPrefix("proj-1") === projectWorkflowRedisPrefix("proj-2"),
       false,
@@ -84,15 +87,35 @@ describe("projectWorkflowRedisPrefix", () => {
     const whitespacePrefixed = projectWorkflowRedisConfig(" proj-1");
 
     assertEquals(canonical, {
-      prefix: "vf:workflow:project:proj-1:",
-      streamKey: "vf:workflow:project:proj-1:stream",
-      groupName: "vf:workflow:project:proj-1:workers",
+      prefix: "vf:workflow:project:proj-1:target::environment::branch::",
+      streamKey: "vf:workflow:project:proj-1:target::environment::branch::stream",
+      groupName: "vf:workflow:project:proj-1:target::environment::branch::workers",
     });
     assertEquals(whitespacePrefixed, {
-      prefix: "vf:workflow:project:.20.proj-1:",
-      streamKey: "vf:workflow:project:.20.proj-1:stream",
-      groupName: "vf:workflow:project:.20.proj-1:workers",
+      prefix: "vf:workflow:project:.20.proj-1:target::environment::branch::",
+      streamKey: "vf:workflow:project:.20.proj-1:target::environment::branch::stream",
+      groupName: "vf:workflow:project:.20.proj-1:target::environment::branch::workers",
     });
+  });
+
+  it("namespaces durable workflow state per runtime target", () => {
+    const main = projectWorkflowRedisPrefix("proj-1", {
+      runtimeTargetKind: "main_branch",
+    });
+    const environment = projectWorkflowRedisPrefix("proj-1", {
+      runtimeTargetKind: "environment",
+      runtimeTargetEnvironmentId: "env-1",
+    });
+    const otherEnvironment = projectWorkflowRedisPrefix("proj-1", {
+      runtimeTargetKind: "environment",
+      runtimeTargetEnvironmentId: "env-2",
+    });
+    const preview = projectWorkflowRedisPrefix("proj-1", {
+      runtimeTargetKind: "preview_branch",
+      runtimeTargetBranchId: "branch-1",
+    });
+
+    assertEquals(new Set([main, environment, otherEnvironment, preview]).size, 4);
   });
 
   it("refuses to configure durable persistence without a project scope", () => {
@@ -1632,11 +1655,16 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     assertEquals(order, ["discover", "create-client", "start"]);
   });
 
-  it("scopes the workflow client to the verified request project", async () => {
-    let clientProjectId: string | undefined;
+  it("scopes the workflow client to the verified project and runtime target", async () => {
+    let clientScope: {
+      projectId: string;
+      runtimeTargetKind?: string;
+      runtimeTargetEnvironmentId?: string | null;
+      runtimeTargetBranchId?: string | null;
+    } | undefined;
     const handler = new ProjectRunExecuteHandler(createDeps({
       createWorkflowClient: (_config, options) => {
-        clientProjectId = options.projectId;
+        clientScope = options;
         return {
           register: () => {},
           start: async (
@@ -1657,6 +1685,8 @@ describe("server/handlers/request/project-run-execute.handler", () => {
       kind: "workflow",
       target: "workflow:publish",
       projectId: "proj-1",
+      runtimeTargetKind: "environment",
+      runtimeTargetEnvironmentId: "env-1",
     };
     const { request, publicKeyPem } = await signedRequest(
       "/api/control-plane/runs/run_workflow_scope_1/execute",
@@ -1668,7 +1698,12 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     assertExists(result.response);
     assertEquals(result.response.status, 200);
     assertEquals((await result.response.json()).success, true);
-    assertEquals(clientProjectId, "proj-1");
+    assertEquals(clientScope, {
+      projectId: "proj-1",
+      runtimeTargetKind: "environment",
+      runtimeTargetEnvironmentId: "env-1",
+      runtimeTargetBranchId: undefined,
+    });
   });
 
   it("executes discovered project tool steps from control-plane workflow runs", async () => {

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -20,6 +20,7 @@ import {
   createKnowledgeEventLogger,
   ProjectRunExecuteHandler,
   type ProjectRunExecuteHandlerDeps,
+  projectWorkflowRedisPrefix,
 } from "./project-run-execute.handler.ts";
 import { createControlPlaneSignature, createCtx } from "./internal-agent-run.test-helpers.ts";
 import { stop as stopEsbuild } from "veryfront/extensions/bundler";
@@ -49,6 +50,27 @@ describe("createKnowledgeEventLogger", () => {
 
     assertEquals(encoder.encode(lines.join("\n")).byteLength <= 256 * 1_024, true);
     assertStringIncludes(lines.at(-1) ?? "", "Knowledge ingest logs were truncated");
+  });
+});
+
+describe("projectWorkflowRedisPrefix", () => {
+  it("namespaces durable workflow state per project", () => {
+    assertEquals(projectWorkflowRedisPrefix("proj-1"), "vf:workflow:project:proj-1:");
+    assertEquals(
+      projectWorkflowRedisPrefix("proj-1") === projectWorkflowRedisPrefix("proj-2"),
+      false,
+    );
+  });
+
+  it("escapes characters that could collide or match Redis SCAN globs", () => {
+    const prefix = projectWorkflowRedisPrefix("proj*:[a]?");
+    assertEquals(/^[A-Za-z0-9_.:-]+$/.test(prefix), true);
+    // Escaping is injective: ids that differ only in escaped characters
+    // never produce the same namespace.
+    assertEquals(
+      projectWorkflowRedisPrefix("a.b") === projectWorkflowRedisPrefix("a.2e.b"),
+      false,
+    );
   });
 });
 
@@ -1574,6 +1596,45 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     assertEquals(hasAgentRegistry, true);
     assertEquals(hasToolRegistry, true);
     assertEquals(order, ["discover", "create-client", "start"]);
+  });
+
+  it("scopes the workflow client to the verified request project", async () => {
+    let clientProjectId: string | undefined;
+    const handler = new ProjectRunExecuteHandler(createDeps({
+      createWorkflowClient: (_config, options) => {
+        clientProjectId = options.projectId;
+        return {
+          register: () => {},
+          start: async (
+            _workflowId: string,
+            _input: unknown,
+            startOptions?: { runId?: string },
+          ) => ({ runId: startOptions?.runId ?? "workflow-run" }),
+          getRun: async () => ({
+            status: "completed",
+            output: { deployed: true },
+          }),
+          destroy: async () => {},
+        };
+      },
+    }));
+    const body = {
+      runId: "run_workflow_scope_1",
+      kind: "workflow",
+      target: "workflow:publish",
+      projectId: "proj-1",
+    };
+    const { request, publicKeyPem } = await signedRequest(
+      "/api/control-plane/runs/run_workflow_scope_1/execute",
+      body,
+    );
+
+    const result = await handler.handle(request, createCtx(publicKeyPem));
+
+    assertExists(result.response);
+    assertEquals(result.response.status, 200);
+    assertEquals((await result.response.json()).success, true);
+    assertEquals(clientProjectId, "proj-1");
   });
 
   it("executes discovered project tool steps from control-plane workflow runs", async () => {

--- a/src/server/handlers/request/project-run-execute.handler.test.ts
+++ b/src/server/handlers/request/project-run-execute.handler.test.ts
@@ -2074,4 +2074,83 @@ describe("server/handlers/request/project-run-execute.handler", () => {
     assertEquals(result.response.status, 401);
     assertEquals(await result.response.json(), { error: "Missing control-plane signature" });
   });
+
+  it("rejects runtime targets that carry no identifier for their kind", async () => {
+    // Both selections would canonicalize to the empty identifier, so every
+    // environment run missing its environment id — and every preview run
+    // missing its branch id — would share one durable workflow namespace and
+    // could resume another target's runs and approval decision claims.
+    const handler = new ProjectRunExecuteHandler(createDeps());
+
+    for (
+      const body of [
+        {
+          runId: "run_bad_environment",
+          kind: "task",
+          target: "task:sync-calendar-events",
+          projectId: "proj-1",
+          runtimeTargetKind: "environment",
+        },
+        {
+          runId: "run_bad_preview",
+          kind: "task",
+          target: "task:sync-calendar-events",
+          projectId: "proj-1",
+          runtimeTargetKind: "preview_branch",
+        },
+      ]
+    ) {
+      const { request, publicKeyPem } = await signedRequest(
+        `/api/control-plane/runs/${body.runId}/execute`,
+        body,
+      );
+
+      const result = await handler.handle(request, createCtx(publicKeyPem));
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 400);
+    }
+  });
+
+  it("rejects runtime targets carrying an identifier from a different kind", async () => {
+    // A selection that names both an environment and a preview branch is
+    // malformed rather than a namespace: it is exactly what
+    // validateRuntimeAgentTargetSelection rejects on the agent invocation
+    // contract, and accepting it here would let one request choose which
+    // target's durable state it resumes.
+    const handler = new ProjectRunExecuteHandler(createDeps());
+
+    for (
+      const body of [
+        {
+          runId: "run_cross_environment",
+          kind: "task",
+          target: "task:sync-calendar-events",
+          projectId: "proj-1",
+          runtimeTargetKind: "environment",
+          runtimeTargetEnvironmentId: "env-1",
+          runtimeTargetBranchId: "branch-1",
+        },
+        {
+          runId: "run_cross_preview",
+          kind: "task",
+          target: "task:sync-calendar-events",
+          projectId: "proj-1",
+          runtimeTargetKind: "preview_branch",
+          runtimeTargetEnvironmentId: "env-1",
+          runtimeTargetBranchId: "branch-1",
+        },
+      ]
+    ) {
+      const { request, publicKeyPem } = await signedRequest(
+        `/api/control-plane/runs/${body.runId}/execute`,
+        body,
+      );
+
+      const result = await handler.handle(request, createCtx(publicKeyPem));
+
+      assertExists(result.response);
+      assertEquals(result.response.status, 400);
+    }
+  });
 });

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -147,7 +147,7 @@ export interface ProjectRunExecuteHandlerDeps {
   ): Promise<DiscoveredEval | null>;
   createWorkflowClient(
     config: WorkflowClientConfig | undefined,
-    options: { projectId: string },
+    options: { projectId: string } & ProjectWorkflowRedisTargetScope,
   ): WorkflowClientView | Promise<WorkflowClientView>;
   runEval(definition: EvalDefinition, options: RunEvalOptions): Promise<EvalReport>;
   createEvalAgentAdapter(config: AgentServiceEvalAdapterConfig): EvalAgentAdapter;
@@ -315,24 +315,45 @@ function createExecutionFailure(error: unknown, durationMs: number): ProjectRunE
 }
 
 /**
- * Build the Redis key prefix for one project's durable workflow state.
+ * Build the Redis key prefix for one project's durable workflow state on one
+ * runtime target.
  *
  * Hosted project runtimes share a single Redis instance, so every durable
- * workflow key must be namespaced per project. Without this isolation the
- * approval decision claim recovery scan in one project's runtime can
- * enumerate and resume runs that belong to a different project. Characters
- * outside a conservative allowlist are escaped so distinct project ids can
- * never produce colliding prefixes or Redis SCAN glob metacharacters.
+ * workflow key must be namespaced per project and runtime target. Without this
+ * isolation the approval decision claim recovery scan in one runtime can
+ * enumerate and resume runs that belong to a different project, environment,
+ * or preview branch. Characters outside a conservative allowlist are escaped
+ * so distinct identifiers cannot produce colliding prefixes or Redis SCAN
+ * glob metacharacters.
  */
-export function projectWorkflowRedisPrefix(projectId: string): string {
-  const scope = projectId.replace(
+function encodeWorkflowRedisScope(value: string): string {
+  return value.replace(
     /[^A-Za-z0-9_-]/g,
     (char) => `.${char.codePointAt(0)!.toString(16)}.`,
   );
-  return `vf:workflow:project:${scope}:`;
 }
 
-export function projectWorkflowRedisConfig(projectId: string): {
+export interface ProjectWorkflowRedisTargetScope {
+  runtimeTargetKind?: ProjectRunExecuteRequest["runtimeTargetKind"];
+  runtimeTargetEnvironmentId?: string | null;
+  runtimeTargetBranchId?: string | null;
+}
+
+export function projectWorkflowRedisPrefix(
+  projectId: string,
+  target: ProjectWorkflowRedisTargetScope = {},
+): string {
+  const projectScope = encodeWorkflowRedisScope(projectId);
+  const targetKind = encodeWorkflowRedisScope(target.runtimeTargetKind ?? "");
+  const environmentScope = encodeWorkflowRedisScope(target.runtimeTargetEnvironmentId ?? "");
+  const branchScope = encodeWorkflowRedisScope(target.runtimeTargetBranchId ?? "");
+  return `vf:workflow:project:${projectScope}:target:${targetKind}:environment:${environmentScope}:branch:${branchScope}:`;
+}
+
+export function projectWorkflowRedisConfig(
+  projectId: string,
+  target: ProjectWorkflowRedisTargetScope = {},
+): {
   prefix: string;
   streamKey: string;
   groupName: string;
@@ -343,7 +364,7 @@ export function projectWorkflowRedisConfig(projectId: string): {
     });
   }
 
-  const prefix = projectWorkflowRedisPrefix(projectId);
+  const prefix = projectWorkflowRedisPrefix(projectId, target);
   return {
     prefix,
     streamKey: `${prefix}stream`,
@@ -353,7 +374,7 @@ export function projectWorkflowRedisConfig(projectId: string): {
 
 async function createRuntimeWorkflowClient(
   config: WorkflowClientConfig | undefined,
-  options: { projectId: string },
+  options: { projectId: string } & ProjectWorkflowRedisTargetScope,
 ): Promise<WorkflowClientView> {
   const clientConfig = withRuntimeStepRegistries(config);
   const redisUrl = getHostEnv("REDIS_URL")?.trim();
@@ -365,7 +386,7 @@ async function createRuntimeWorkflowClient(
 
   const backend = new RedisBackend({
     url: redisUrl,
-    ...projectWorkflowRedisConfig(options.projectId),
+    ...projectWorkflowRedisConfig(options.projectId, options),
     debug: config?.debug,
   });
   if (backend.initialize) {
@@ -489,7 +510,12 @@ async function executeWorkflowRun(
 
   const client = await deps.createWorkflowClient(
     withRuntimeStepRegistries({ debug: ctx.debug }),
-    { projectId: request.projectId },
+    {
+      projectId: request.projectId,
+      runtimeTargetKind: request.runtimeTargetKind,
+      runtimeTargetEnvironmentId: request.runtimeTargetEnvironmentId,
+      runtimeTargetBranchId: request.runtimeTargetBranchId,
+    },
   );
   try {
     client.register(workflow.definition);

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -68,6 +68,9 @@ const KNOWLEDGE_LOG_TRUNCATED_LINE = JSON.stringify({
   level: "warn",
   message: "Knowledge ingest logs were truncated",
 });
+const ReflectApply = Reflect.apply;
+const NumberPrototypeToString = Number.prototype.toString;
+const StringPrototypeCharCodeAt = String.prototype.charCodeAt;
 
 export interface ProjectRunExecuteRequest {
   runId: string;
@@ -372,10 +375,18 @@ function createExecutionFailure(error: unknown, durationMs: number): ProjectRunE
  * glob metacharacters.
  */
 function encodeWorkflowRedisScope(value: string): string {
-  return value.replace(
-    /[^A-Za-z0-9_-]/g,
-    (char) => `.${char.codePointAt(0)!.toString(16)}.`,
-  );
+  let encoded = "";
+  for (let index = 0; index < value.length; index++) {
+    const codeUnit = ReflectApply(StringPrototypeCharCodeAt, value, [index]) as number;
+    const allowed = codeUnit >= 48 && codeUnit <= 57 ||
+      codeUnit >= 65 && codeUnit <= 90 ||
+      codeUnit >= 97 && codeUnit <= 122 ||
+      codeUnit === 45 || codeUnit === 95;
+    encoded += allowed
+      ? value[index]
+      : `.${ReflectApply(NumberPrototypeToString, codeUnit, [16]) as string}.`;
+  }
+  return encoded;
 }
 
 export interface ProjectWorkflowRedisTargetScope {

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -339,14 +339,36 @@ export interface ProjectWorkflowRedisTargetScope {
   runtimeTargetBranchId?: string | null;
 }
 
+/**
+ * Reduce a runtime target selection to its one canonical form.
+ *
+ * `runtimeTargetKind` is optional on the wire and an omitted kind means the
+ * default branch, exactly as `resolveControlPlaneBranchBinding` treats it. The
+ * identifier fields are also only meaningful for the kind that owns them. If
+ * either were encoded verbatim, two wire representations of the same target
+ * would derive different Redis namespaces and approval recovery started under
+ * one representation could not see runs waiting under the other.
+ */
+function canonicalWorkflowRedisTarget(
+  target: ProjectWorkflowRedisTargetScope,
+): { kind: string; environmentId: string; branchId: string } {
+  const kind = target.runtimeTargetKind ?? "main_branch";
+  return {
+    kind,
+    environmentId: kind === "environment" ? target.runtimeTargetEnvironmentId ?? "" : "",
+    branchId: kind === "preview_branch" ? target.runtimeTargetBranchId ?? "" : "",
+  };
+}
+
 export function projectWorkflowRedisPrefix(
   projectId: string,
   target: ProjectWorkflowRedisTargetScope = {},
 ): string {
+  const canonical = canonicalWorkflowRedisTarget(target);
   const projectScope = encodeWorkflowRedisScope(projectId);
-  const targetKind = encodeWorkflowRedisScope(target.runtimeTargetKind ?? "");
-  const environmentScope = encodeWorkflowRedisScope(target.runtimeTargetEnvironmentId ?? "");
-  const branchScope = encodeWorkflowRedisScope(target.runtimeTargetBranchId ?? "");
+  const targetKind = encodeWorkflowRedisScope(canonical.kind);
+  const environmentScope = encodeWorkflowRedisScope(canonical.environmentId);
+  const branchScope = encodeWorkflowRedisScope(canonical.branchId);
   return `vf:workflow:project:${projectScope}:target:${targetKind}:environment:${environmentScope}:branch:${branchScope}:`;
 }
 

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -221,6 +221,42 @@ function parseOptionalNullableString(value: unknown, fieldName: string): string 
   return value;
 }
 
+/**
+ * Reject runtime target selections that carry no identifier for their kind.
+ *
+ * `validateRuntimeAgentTargetSelection` already treats these combinations as
+ * invalid for the same selection, but that check runs on the agent invocation
+ * contract, not on this wire format. Without it here, an `environment` target
+ * missing its environment id — or a `preview_branch` target missing its branch
+ * id — canonicalizes to the empty identifier, so every such request shares one
+ * durable workflow namespace and can see another target's runs and approval
+ * decision claims. An identifier belonging to a different kind is rejected for
+ * the same reason: it is a malformed selection, not a namespace.
+ *
+ * A `main_branch` selection, or an omitted kind, is left alone. Omitted kinds
+ * still reach this handler alongside a `runtimeTargetEnvironmentId` that
+ * `executeTaskRun` reads as the legacy environment override, and
+ * `canonicalWorkflowRedisTarget` already drops identifiers the default branch
+ * does not own, so those cannot fork the namespace.
+ */
+function validateRuntimeTargetSelection(
+  kind: ProjectRunExecuteRequest["runtimeTargetKind"],
+  environmentId: string | null | undefined,
+  branchId: string | null | undefined,
+): void {
+  if (kind === "environment" && (!environmentId || branchId)) {
+    throw INPUT_VALIDATION_FAILED.create({
+      detail: "environment target requires runtimeTargetEnvironmentId and no runtimeTargetBranchId",
+    });
+  }
+  if (kind === "preview_branch" && (!branchId || environmentId)) {
+    throw INPUT_VALIDATION_FAILED.create({
+      detail:
+        "preview_branch target requires runtimeTargetBranchId and no runtimeTargetEnvironmentId",
+    });
+  }
+}
+
 function parseExecuteRequest(value: unknown, pathRunId: string): ProjectRunExecuteRequest {
   if (!isRecord(value)) throw INPUT_VALIDATION_FAILED.create({ detail: "Expected object" });
 
@@ -254,21 +290,30 @@ function parseExecuteRequest(value: unknown, pathRunId: string): ProjectRunExecu
     throw INPUT_VALIDATION_FAILED.create({ detail: "Invalid eval target" });
   }
 
+  const runtimeTargetKind = parseRuntimeTargetKind(value.runtimeTargetKind);
+  const runtimeTargetEnvironmentId = parseOptionalNullableString(
+    value.runtimeTargetEnvironmentId,
+    "runtimeTargetEnvironmentId",
+  );
+  const runtimeTargetBranchId = parseOptionalNullableString(
+    value.runtimeTargetBranchId,
+    "runtimeTargetBranchId",
+  );
+  validateRuntimeTargetSelection(
+    runtimeTargetKind,
+    runtimeTargetEnvironmentId,
+    runtimeTargetBranchId,
+  );
+
   return {
     runId,
     kind,
     target,
     projectId,
     runtimeAgUiEndpoint: parseOptionalUrl(value.runtimeAgUiEndpoint, "runtimeAgUiEndpoint"),
-    runtimeTargetKind: parseRuntimeTargetKind(value.runtimeTargetKind),
-    runtimeTargetEnvironmentId: parseOptionalNullableString(
-      value.runtimeTargetEnvironmentId,
-      "runtimeTargetEnvironmentId",
-    ),
-    runtimeTargetBranchId: parseOptionalNullableString(
-      value.runtimeTargetBranchId,
-      "runtimeTargetBranchId",
-    ),
+    runtimeTargetKind,
+    runtimeTargetEnvironmentId,
+    runtimeTargetBranchId,
     config: parseRecord(value.config),
     input: parseRecord(value.input),
   };

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -332,6 +332,25 @@ export function projectWorkflowRedisPrefix(projectId: string): string {
   return `vf:workflow:project:${scope}:`;
 }
 
+export function projectWorkflowRedisConfig(projectId: string): {
+  prefix: string;
+  streamKey: string;
+  groupName: string;
+} {
+  if (!projectId) {
+    throw INPUT_VALIDATION_FAILED.create({
+      detail: "Durable workflow persistence requires a project scope",
+    });
+  }
+
+  const prefix = projectWorkflowRedisPrefix(projectId);
+  return {
+    prefix,
+    streamKey: `${prefix}stream`,
+    groupName: `${prefix}workers`,
+  };
+}
+
 async function createRuntimeWorkflowClient(
   config: WorkflowClientConfig | undefined,
   options: { projectId: string },
@@ -344,19 +363,9 @@ async function createRuntimeWorkflowClient(
     });
   }
 
-  const projectId = options.projectId?.trim();
-  if (!projectId) {
-    throw INPUT_VALIDATION_FAILED.create({
-      detail: "Durable workflow persistence requires a project scope",
-    });
-  }
-
-  const prefix = projectWorkflowRedisPrefix(projectId);
   const backend = new RedisBackend({
     url: redisUrl,
-    prefix,
-    streamKey: `${prefix}stream`,
-    groupName: `${prefix}workers`,
+    ...projectWorkflowRedisConfig(options.projectId),
     debug: config?.debug,
   });
   if (backend.initialize) {

--- a/src/server/handlers/request/project-run-execute.handler.ts
+++ b/src/server/handlers/request/project-run-execute.handler.ts
@@ -146,7 +146,8 @@ export interface ProjectRunExecuteHandlerDeps {
     },
   ): Promise<DiscoveredEval | null>;
   createWorkflowClient(
-    config?: WorkflowClientConfig,
+    config: WorkflowClientConfig | undefined,
+    options: { projectId: string },
   ): WorkflowClientView | Promise<WorkflowClientView>;
   runEval(definition: EvalDefinition, options: RunEvalOptions): Promise<EvalReport>;
   createEvalAgentAdapter(config: AgentServiceEvalAdapterConfig): EvalAgentAdapter;
@@ -313,8 +314,27 @@ function createExecutionFailure(error: unknown, durationMs: number): ProjectRunE
   };
 }
 
+/**
+ * Build the Redis key prefix for one project's durable workflow state.
+ *
+ * Hosted project runtimes share a single Redis instance, so every durable
+ * workflow key must be namespaced per project. Without this isolation the
+ * approval decision claim recovery scan in one project's runtime can
+ * enumerate and resume runs that belong to a different project. Characters
+ * outside a conservative allowlist are escaped so distinct project ids can
+ * never produce colliding prefixes or Redis SCAN glob metacharacters.
+ */
+export function projectWorkflowRedisPrefix(projectId: string): string {
+  const scope = projectId.replace(
+    /[^A-Za-z0-9_-]/g,
+    (char) => `.${char.codePointAt(0)!.toString(16)}.`,
+  );
+  return `vf:workflow:project:${scope}:`;
+}
+
 async function createRuntimeWorkflowClient(
-  config?: WorkflowClientConfig,
+  config: WorkflowClientConfig | undefined,
+  options: { projectId: string },
 ): Promise<WorkflowClientView> {
   const clientConfig = withRuntimeStepRegistries(config);
   const redisUrl = getHostEnv("REDIS_URL")?.trim();
@@ -324,7 +344,21 @@ async function createRuntimeWorkflowClient(
     });
   }
 
-  const backend = new RedisBackend({ url: redisUrl, debug: config?.debug });
+  const projectId = options.projectId?.trim();
+  if (!projectId) {
+    throw INPUT_VALIDATION_FAILED.create({
+      detail: "Durable workflow persistence requires a project scope",
+    });
+  }
+
+  const prefix = projectWorkflowRedisPrefix(projectId);
+  const backend = new RedisBackend({
+    url: redisUrl,
+    prefix,
+    streamKey: `${prefix}stream`,
+    groupName: `${prefix}workers`,
+    debug: config?.debug,
+  });
   if (backend.initialize) {
     await backend.initialize();
   }
@@ -444,7 +478,10 @@ async function executeWorkflowRun(
     };
   }
 
-  const client = await deps.createWorkflowClient(withRuntimeStepRegistries({ debug: ctx.debug }));
+  const client = await deps.createWorkflowClient(
+    withRuntimeStepRegistries({ debug: ctx.debug }),
+    { projectId: request.projectId },
+  );
   try {
     client.register(workflow.definition);
     const handle = await client.start(workflow.id, request.input ?? {}, { runId: request.runId });


### PR DESCRIPTION
## Summary

In the hosted project-run path, `project-run-execute.handler.ts` built its durable workflow backend as `new RedisBackend({ url: redisUrl, debug })` from the host `REDIS_URL`, inheriting the shared default `vf:workflow:` key prefix. Since every per-project runtime pod receives the same `REDIS_URL`, all tenants' durable workflow state (runs, approvals, decision claims, queue stream) lived in one shared Redis namespace. The `ApprovalManager` constructor auto-starts decision claim recovery, which calls `listApprovalDecisionClaims()` with no run or tenant filter and scans every `approvals:*` key under that shared prefix. Recovery verifies only the wait-instance identity and worker ownership, never a tenant/project binding, and `WorkflowExecutor.resume` selects the definition solely by the run's `workflowId` from the local registry while executing under the victim run's persisted `_tenant` context. A tenant registering a workflow id that collides with a victim's could therefore, once an approved decision claim aged past the recovery delay, have its own workflow definition executed with the victim's project token, request context, cache scope, and persisted `context.env`, disclosing victim secrets and performing victim-scoped side effects.

## Finding

- Codex finding id: `b6679e7241d881919077c76add774dca` (finding 20, severity: medium)
- Introduced in 8700955b4 (durable mailbox / decision claim recovery)
- Note: the currently pinned `veryfront` npm package in veryfront-api (0.1.1255) predates the recovery mechanism; this fixes main before the next package bump propagates the vulnerable code.

## Fix

- `createRuntimeWorkflowClient` now derives a per-project Redis namespace from the control-plane-verified `request.projectId` (the handler already rejects requests whose `projectId` does not match the signed claims): the key prefix, queue `streamKey`, and consumer `groupName` all become `vf:workflow:project:<id>:` scoped, so one project's backend can never scan, reserve, or resume another project's runs or approval decision claims.
- Project ids are escaped onto a conservative `[A-Za-z0-9_-]` charset (other characters become `.<hex>.`), so distinct ids can never produce colliding prefixes or inject Redis SCAN glob metacharacters. The trailing `:` delimiter keeps one project's prefix from being a string prefix of another's.
- Fail closed: if durable persistence is configured (`REDIS_URL` set) but no project scope is available, the client refuses to construct an unscoped backend instead of falling back to the shared namespace.

Deployment note: in-flight waiting runs stored under the old shared prefix are not visible under the new project-scoped namespace after rollout.

## Test evidence

- `deno task test:file src/server/handlers/request/project-run-execute.handler.test.ts` - 3 passed (33 steps), 0 failed, including new tests: `projectWorkflowRedisPrefix` namespacing/escaping/injectivity and `scopes the workflow client to the verified request project`.
- `deno fmt --check` clean on both touched files.
- `deno check src/server/handlers/request/project-run-execute.handler.ts` clean; `deno run scripts/lint/check-test-typecheck-baseline.ts` reports baseline holds, 0 new.
- `deno lint` clean on both touched files.

https://claude.ai/code/session_01QfWNMiUhvWMKWi6BGfVdY3
