### PR TITLE
fix(security): scope bundled API route module reuse to project and env identity

### DIFF
--- a/src/cache/cache-key-builder.ts
+++ b/src/cache/cache-key-builder.ts
@@ -8,6 +8,7 @@ import { currentRequestContext } from "#veryfront/platform/request-context-acces
 type MultiProjectRequestContextType = NonNullable<ReturnType<typeof currentRequestContext>>;
 const trustedRequestContextAccessor = currentRequestContext;
 const registryScopeOwners = new WeakMap<object, object>();
+const IntrinsicEncodeURIComponent = encodeURIComponent;
 
 export type { CacheKeyContext };
 
@@ -19,7 +20,7 @@ export interface RegistryScopeContext {
 
 function encodeRegistryScopeSegment(value: string): string {
   try {
-    return encodeURIComponent(value);
+    return IntrinsicEncodeURIComponent(value);
   } catch (error) {
     if (!(error instanceof URIError)) throw error;
 
@@ -43,11 +44,11 @@ function encodeRegistryScopeSegment(value: string): string {
       }
       if (!isHighSurrogate && !isLowSurrogate) continue;
 
-      encoded += encodeURIComponent(value.slice(chunkStart, index));
+      encoded += IntrinsicEncodeURIComponent(value.slice(chunkStart, index));
       encoded += `%u${codeUnit.toString(16).toUpperCase().padStart(4, "0")}`;
       chunkStart = index + 1;
     }
-    return encoded + encodeURIComponent(value.slice(chunkStart));
+    return encoded + IntrinsicEncodeURIComponent(value.slice(chunkStart));
   }
 }
 

--- a/src/cache/cache-key-builder.ts
+++ b/src/cache/cache-key-builder.ts
@@ -9,6 +9,12 @@ type MultiProjectRequestContextType = NonNullable<ReturnType<typeof currentReque
 const trustedRequestContextAccessor = currentRequestContext;
 const registryScopeOwners = new WeakMap<object, object>();
 const IntrinsicEncodeURIComponent = encodeURIComponent;
+const IntrinsicReflectApply = Reflect.apply;
+const NumberPrototypeToString = Number.prototype.toString;
+const StringPrototypeCharCodeAt = String.prototype.charCodeAt;
+const StringPrototypePadStart = String.prototype.padStart;
+const StringPrototypeSlice = String.prototype.slice;
+const StringPrototypeToUpperCase = String.prototype.toUpperCase;
 
 export type { CacheKeyContext };
 
@@ -21,9 +27,7 @@ export interface RegistryScopeContext {
 function encodeRegistryScopeSegment(value: string): string {
   try {
     return IntrinsicEncodeURIComponent(value);
-  } catch (error) {
-    if (!(error instanceof URIError)) throw error;
-
+  } catch {
     // encodeURIComponent rejects lone UTF-16 surrogates. Project identity comes
     // from external boundaries, so keep this encoder total without collapsing
     // malformed strings onto the replacement character. `%uXXXX` cannot collide
@@ -31,24 +35,35 @@ function encodeRegistryScopeSegment(value: string): string {
     let encoded = "";
     let chunkStart = 0;
     for (let index = 0; index < value.length; index++) {
-      const codeUnit = value.charCodeAt(index);
+      const codeUnit = IntrinsicReflectApply(StringPrototypeCharCodeAt, value, [index]) as number;
       const isHighSurrogate = codeUnit >= 0xd800 && codeUnit <= 0xdbff;
       const isLowSurrogate = codeUnit >= 0xdc00 && codeUnit <= 0xdfff;
 
       if (
         isHighSurrogate && index + 1 < value.length &&
-        value.charCodeAt(index + 1) >= 0xdc00 && value.charCodeAt(index + 1) <= 0xdfff
+        (IntrinsicReflectApply(StringPrototypeCharCodeAt, value, [index + 1]) as number) >=
+          0xdc00 &&
+        (IntrinsicReflectApply(StringPrototypeCharCodeAt, value, [index + 1]) as number) <= 0xdfff
       ) {
         index++;
         continue;
       }
       if (!isHighSurrogate && !isLowSurrogate) continue;
 
-      encoded += IntrinsicEncodeURIComponent(value.slice(chunkStart, index));
-      encoded += `%u${codeUnit.toString(16).toUpperCase().padStart(4, "0")}`;
+      encoded += IntrinsicEncodeURIComponent(
+        IntrinsicReflectApply(StringPrototypeSlice, value, [chunkStart, index]) as string,
+      );
+      const hex = IntrinsicReflectApply(NumberPrototypeToString, codeUnit, [16]) as string;
+      const upperHex = IntrinsicReflectApply(StringPrototypeToUpperCase, hex, []) as string;
+      encoded += `%u${IntrinsicReflectApply(StringPrototypePadStart, upperHex, [
+        4,
+        "0",
+      ]) as string}`;
       chunkStart = index + 1;
     }
-    return encoded + IntrinsicEncodeURIComponent(value.slice(chunkStart));
+    return encoded + IntrinsicEncodeURIComponent(
+      IntrinsicReflectApply(StringPrototypeSlice, value, [chunkStart]) as string,
+    );
   }
 }
 
@@ -77,7 +92,6 @@ export function buildVersionedRegistryScopeId(
 }
 
 const cacheKeyContextStorage = new AsyncLocalStorage<CacheKeyContext | null>();
-const IntrinsicReflectApply = Reflect.apply;
 const IntrinsicObjectDefineProperty = Object.defineProperty;
 const AsyncLocalStoragePrototype = AsyncLocalStorage.prototype;
 const AsyncLocalStorageDisable = AsyncLocalStoragePrototype.disable;

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -10,6 +10,7 @@ import {
 import { afterAll, describe, it } from "#veryfront/testing/bdd.ts";
 import { join, toFileUrl } from "#veryfront/compat/path";
 import {
+  bundledModuleScopeDiscriminator,
   bundlerForcesTypeScript,
   canDirectImportSpecifier,
   generateCompiledBinaryRequireShim,
@@ -18,6 +19,7 @@ import {
   isBareModuleSpecifier,
   isSpecifierResolutionError,
   loadHandlerModule as loadHandlerModuleRaw,
+  loadModuleFromCode,
   lookupImportMapEntry,
   prepareHandlerModule,
   readDenoImportMap,
@@ -46,10 +48,63 @@ import type { APIRoute, AppRouteContext, AppRouteHandler } from "./types.ts";
 import { isDeno } from "#veryfront/platform/compat/runtime.ts";
 import { runWithProjectEnv } from "#veryfront/server/project-env/storage.ts";
 import { runWithCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
+import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/multi-project-adapter.ts";
 
 const fs = createFileSystem();
 const appRouteContext: AppRouteContext = { params: {}, identity: null, env: {} };
 const denoIt = isDeno ? it : it.skip;
+
+describe("bundledModuleScopeDiscriminator", () => {
+  const hostedScope = (environmentName: string, value: string) =>
+    runWithRequestContext(
+      {
+        projectSlug: "project-one",
+        projectId: "project-one-id",
+        token: "test-token",
+        productionMode: true,
+        releaseId: "release-one",
+        environmentName,
+      },
+      () => runWithProjectEnv({ TENANT_VALUE: value }, bundledModuleScopeDiscriminator),
+    );
+
+  it("includes the named environment when project and release match", async () => {
+    assertNotEquals(
+      await hostedScope("production", "same"),
+      await hostedScope("staging", "same"),
+    );
+  });
+
+  it("preserves raw UTF-16 identity in environment values", async () => {
+    assertNotEquals(
+      await hostedScope("production", "\uD800"),
+      await hostedScope("production", "\uFFFD"),
+    );
+  });
+
+  it("does not use project-controlled Object or Array helpers", async () => {
+    const originalKeys = Object.keys;
+    const originalJoin = Array.prototype.join;
+    const originalPush = Array.prototype.push;
+    const poison = () => {
+      throw new Error("ambient environment serialization method must not run");
+    };
+
+    let discriminator: string | undefined;
+    try {
+      Object.keys = poison as typeof Object.keys;
+      Array.prototype.join = poison as typeof Array.prototype.join;
+      Array.prototype.push = poison as typeof Array.prototype.push;
+      discriminator = await hostedScope("production", "safe");
+    } finally {
+      Object.keys = originalKeys;
+      Array.prototype.join = originalJoin;
+      Array.prototype.push = originalPush;
+    }
+
+    assertEquals(discriminator?.length, 64);
+  });
+});
 
 describe("canDirectImportSpecifier", () => {
   it("routes import-map-eligible bare and scoped names through the bundler", () => {
@@ -876,6 +931,28 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
       await getText(after),
       "after",
       "a bundled route must not keep serving a stale module after its source changes",
+    );
+  });
+
+  it("keeps one reusable module identity beyond the former lookup limit", async () => {
+    const owner = `retained-module-${crypto.randomUUID()}`;
+    const code = [
+      "let count = 0;",
+      "export function GET() { return new Response(String(++count)); }",
+    ].join("\n");
+
+    const first = await loadModuleFromCode(code, fs, owner);
+    assertEquals(await getText(first), "1");
+
+    for (let index = 0; index < 65; index += 1) {
+      await loadModuleFromCode(code, fs, `${owner}-${index}`);
+    }
+
+    const reused = await loadModuleFromCode(code, fs, owner);
+    assertEquals(
+      await getText(reused),
+      "2",
+      "returning to an older scope must reuse its retained ESM module",
     );
   });
 

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -44,6 +44,8 @@ import { runWithExactSourceIntegrationPolicy } from "#veryfront/integrations/sou
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
 import type { APIRoute, AppRouteContext, AppRouteHandler } from "./types.ts";
 import { isDeno } from "#veryfront/platform/compat/runtime.ts";
+import { runWithProjectEnv } from "#veryfront/server/project-env/storage.ts";
+import { runWithCacheKeyContext } from "#veryfront/cache/cache-key-builder.ts";
 
 const fs = createFileSystem();
 const appRouteContext: AppRouteContext = { params: {}, identity: null, env: {} };
@@ -874,6 +876,93 @@ describe("loadHandlerModule", { sanitizeResources: false, sanitizeOps: false }, 
       await getText(after),
       "after",
       "a bundled route must not keep serving a stale module after its source changes",
+    );
+  });
+
+  // Hosted proxy execution resolves every project to the host runtime's shared
+  // project dir and applies per-request env isolation with runWithProjectEnv.
+  // Without a scope discriminator in the cache owner, a module whose top-level
+  // init captured one scope's env overlay would be served from cache to a later
+  // request in a different scope with matching path and generated source,
+  // leaking module-level clients, secrets, and mutable state across tenants.
+  it("does not reuse a bundled module across different project env overlays", async () => {
+    const projectDir = await makeTempDir();
+    await fs.mkdir(join(projectDir, "lib"), { recursive: true });
+    await fs.mkdir(join(projectDir, "pages", "api"), { recursive: true });
+
+    await fs.writeTextFile(
+      join(projectDir, "lib", "counter.ts"),
+      `let count = 0;\nexport const bump = () => ++count;`,
+    );
+    const modulePath = join(projectDir, "pages", "api", "env-scoped.ts");
+    await fs.writeTextFile(
+      modulePath,
+      [
+        `import { bump } from "@/lib/counter.ts";`,
+        `export function GET() { return new Response(String(bump())); }`,
+      ].join("\n"),
+    );
+
+    const config: VeryfrontConfig = {
+      resolve: { importMap: { imports: { "@/": "./" } } },
+    };
+    const load = () => loadHandlerModule({ projectDir, modulePath, adapter, config });
+
+    const tenantA = await runWithProjectEnv({ TENANT_SECRET: "a" }, load);
+    assertEquals(await getText(tenantA), "1");
+
+    const tenantB = await runWithProjectEnv({ TENANT_SECRET: "b" }, load);
+    assertEquals(
+      await getText(tenantB),
+      "1",
+      "a module initialized under one env overlay must not be reused under another",
+    );
+
+    const tenantAAgain = await runWithProjectEnv({ TENANT_SECRET: "a" }, load);
+    assertEquals(
+      await getText(tenantAAgain),
+      "2",
+      "the same env scope must keep reusing its own module",
+    );
+  });
+
+  it("does not reuse a bundled module across different hosted project scopes", async () => {
+    const projectDir = await makeTempDir();
+    await fs.mkdir(join(projectDir, "lib"), { recursive: true });
+    await fs.mkdir(join(projectDir, "pages", "api"), { recursive: true });
+
+    await fs.writeTextFile(
+      join(projectDir, "lib", "counter.ts"),
+      `let count = 0;\nexport const bump = () => ++count;`,
+    );
+    const modulePath = join(projectDir, "pages", "api", "project-scoped.ts");
+    await fs.writeTextFile(
+      modulePath,
+      [
+        `import { bump } from "@/lib/counter.ts";`,
+        `export function GET() { return new Response(String(bump())); }`,
+      ].join("\n"),
+    );
+
+    const config: VeryfrontConfig = {
+      resolve: { importMap: { imports: { "@/": "./" } } },
+    };
+    const load = () => loadHandlerModule({ projectDir, modulePath, adapter, config });
+
+    const projectOne = await runWithCacheKeyContext(
+      { projectId: "project-one", mode: "production", versionId: "rel_1" },
+      load,
+    );
+    assertEquals(await getText(projectOne), "1");
+
+    const projectTwo = await runWithCacheKeyContext(
+      { projectId: "project-two", mode: "production", versionId: "rel_1" },
+      load,
+    );
+    assertEquals(
+      await getText(projectTwo),
+      "1",
+      "two hosted projects sharing a path and byte-identical output must not share a module",
     );
   });
 

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -55,11 +55,11 @@ const appRouteContext: AppRouteContext = { params: {}, identity: null, env: {} }
 const denoIt = isDeno ? it : it.skip;
 
 describe("bundledModuleScopeDiscriminator", () => {
-  const hostedScope = (environmentName: string, value: string) =>
+  const hostedScope = (environmentName: string, value: string, projectId = "project-one-id") =>
     runWithRequestContext(
       {
         projectSlug: "project-one",
-        projectId: "project-one-id",
+        projectId,
         token: "test-token",
         productionMode: true,
         releaseId: "release-one",
@@ -103,6 +103,19 @@ describe("bundledModuleScopeDiscriminator", () => {
     }
 
     assertEquals(discriminator?.length, 64);
+  });
+
+  it("does not use a project-controlled registry-scope encoder", async () => {
+    const originalEncodeURIComponent = globalThis.encodeURIComponent;
+    try {
+      globalThis.encodeURIComponent = () => "shared";
+      assertNotEquals(
+        await hostedScope("production", "safe", "project-one-id"),
+        await hostedScope("production", "safe", "project-two-id"),
+      );
+    } finally {
+      globalThis.encodeURIComponent = originalEncodeURIComponent;
+    }
   });
 });
 

--- a/src/routing/api/module-loader/loader.test.ts
+++ b/src/routing/api/module-loader/loader.test.ts
@@ -107,14 +107,30 @@ describe("bundledModuleScopeDiscriminator", () => {
 
   it("does not use a project-controlled registry-scope encoder", async () => {
     const originalEncodeURIComponent = globalThis.encodeURIComponent;
+    const originalSlice = String.prototype.slice;
+    const originalNumberToString = Number.prototype.toString;
+    const originalToUpperCase = String.prototype.toUpperCase;
+    const originalPadStart = String.prototype.padStart;
     try {
       globalThis.encodeURIComponent = () => "shared";
+      String.prototype.slice = () => "";
+      Number.prototype.toString = () => "0";
+      String.prototype.toUpperCase = function () {
+        return String(this);
+      };
+      String.prototype.padStart = function () {
+        return String(this);
+      };
       assertNotEquals(
-        await hostedScope("production", "safe", "project-one-id"),
-        await hostedScope("production", "safe", "project-two-id"),
+        await hostedScope("production", "safe", "project-\uD800"),
+        await hostedScope("production", "safe", "project-\uD801"),
       );
     } finally {
       globalThis.encodeURIComponent = originalEncodeURIComponent;
+      String.prototype.slice = originalSlice;
+      Number.prototype.toString = originalNumberToString;
+      String.prototype.toUpperCase = originalToUpperCase;
+      String.prototype.padStart = originalPadStart;
     }
   });
 });

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -2087,7 +2087,11 @@ export function getUserDependencies(
  * overlay. A module whose top-level init ran under one tenant's or
  * environment's env overlay is never reused under another.
  */
-const bundledModules = new IntrinsicMap<string, Promise<APIRoute>>();
+interface BundledModuleRecord {
+  readonly loading: Promise<APIRoute>;
+}
+
+const bundledModules = new IntrinsicMap<string, BundledModuleRecord>();
 
 /**
  * Identity of the scope a bundled module may be reused within.
@@ -2142,12 +2146,13 @@ export async function loadModuleFromCode(
 ): Promise<APIRoute> {
   const key = await bundledModuleKey(owner, code);
   const cached = IntrinsicReflectApply(MapPrototypeGet, bundledModules, [key]) as
-    | Promise<APIRoute>
+    | BundledModuleRecord
     | undefined;
-  if (cached) return await cached;
+  if (cached) return await cached.loading;
 
   const loading = importModuleFromCode(code, fs);
-  IntrinsicReflectApply(MapPrototypeSet, bundledModules, [key, loading]);
+  const record = { loading } satisfies BundledModuleRecord;
+  IntrinsicReflectApply(MapPrototypeSet, bundledModules, [key, record]);
 
   // Deno retains every imported ESM record for the life of the process. Keep
   // one matching lookup entry too: evicting only this map caused a later visit
@@ -2156,7 +2161,7 @@ export async function loadModuleFromCode(
   try {
     return await loading;
   } catch (error) {
-    if (IntrinsicReflectApply(MapPrototypeGet, bundledModules, [key]) === loading) {
+    if (IntrinsicReflectApply(MapPrototypeGet, bundledModules, [key]) === record) {
       IntrinsicReflectApply(MapPrototypeDelete, bundledModules, [key]);
     }
     throw error;

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -53,6 +53,8 @@ import {
   ProjectBoundaryViolationError,
   type ProjectSourceSnapshot,
 } from "./project-source-snapshot.ts";
+import { tryGetRegistryScopeId } from "#veryfront/cache/cache-key-builder.ts";
+import { getProjectEnvSnapshot } from "#veryfront/server/project-env/storage.ts";
 export {
   generateCompiledBinaryRequireShim,
   getNodeExternalPackagesToResolve,
@@ -1781,7 +1783,11 @@ async function loadAndTranspileModule(
     decoratorOptions,
     allowHostTypeScriptConfigReads,
   );
-  return await loadModuleFromCode(source, fs, `${projectDir}\u0000${modulePath}`);
+  return await loadModuleFromCode(
+    source,
+    fs,
+    `${projectDir}\u0000${modulePath}\u0000${await bundledModuleScopeDiscriminator()}`,
+  );
 }
 
 function buildTranspiledModuleSource(
@@ -2067,12 +2073,45 @@ export function getUserDependencies(
  *
  * The key carries the project and route path as well as the code, so two
  * projects that happen to bundle byte-identical output never share a module,
- * and with it module state.
+ * and with it module state. Hosted projects can share one virtual project dir,
+ * so the owner also carries the request's scope discriminator: the registry
+ * scope (project, mode, version) and a digest of the active project-env
+ * overlay. A module whose top-level init ran under one tenant's or
+ * environment's env overlay is never reused under another.
  */
 const bundledModules = new Map<string, Promise<APIRoute>>();
 
 /** Bundled routes a dev session can hold before the oldest is dropped. */
 const MAX_BUNDLED_MODULES = 64;
+
+/**
+ * Identity of the scope a bundled module may be reused within.
+ *
+ * In proxy mode every hosted project resolves to the host runtime's shared
+ * project dir, and per-request env isolation (`runWithProjectEnv`) hands each
+ * scope its own env overlay, so `projectDir`/`modulePath`/code alone would let
+ * a module initialized under one project's or environment's overlay serve a
+ * later request in a different scope — leaking module-level clients, secrets,
+ * and mutable state across tenants. Fold the ambient registry scope (project,
+ * mode, version) and a digest of the active env overlay into the owner so
+ * reuse stays within one scope. Local single-tenant loads carry neither and
+ * keep their current key.
+ */
+async function bundledModuleScopeDiscriminator(): Promise<string> {
+  const scopeId = tryGetRegistryScopeId() ?? "";
+  const envSnapshot = getProjectEnvSnapshot();
+  let envDigest = "";
+  if (envSnapshot) {
+    // Snapshot keys are sorted and contain no NUL or "=", and values contain
+    // no NUL, so this serialization is canonical and collision-free.
+    const entries: string[] = [];
+    for (const key of Object.keys(envSnapshot)) {
+      entries.push(`${key}=${envSnapshot[key]}`);
+    }
+    envDigest = await computeHash(entries.join("\u0000"));
+  }
+  return `${scopeId}\u0000${envDigest}`;
+}
 
 async function bundledModuleKey(owner: string, code: string): Promise<string> {
   return await computeHash(`${owner}\u0000${code}`);

--- a/src/routing/api/module-loader/loader.ts
+++ b/src/routing/api/module-loader/loader.ts
@@ -1,4 +1,4 @@
-import { computeHash, isCompiledBinary, serverLogger } from "#veryfront/utils";
+import { computeCodeHash, computeHash, isCompiledBinary, serverLogger } from "#veryfront/utils";
 import type {
   BuildResult,
   BundleOptions,
@@ -55,6 +55,7 @@ import {
 } from "./project-source-snapshot.ts";
 import { tryGetRegistryScopeId } from "#veryfront/cache/cache-key-builder.ts";
 import { getProjectEnvSnapshot } from "#veryfront/server/project-env/storage.ts";
+import { currentRequestContext } from "#veryfront/platform/request-context-access.ts";
 export {
   generateCompiledBinaryRequireShim,
   getNodeExternalPackagesToResolve,
@@ -69,6 +70,13 @@ export {
 } from "./external-import-rewriter.ts";
 
 const logger = serverLogger.component("api");
+const IntrinsicMap = Map;
+const IntrinsicReflectApply = Reflect.apply;
+const IntrinsicReflectOwnKeys = Reflect.ownKeys;
+const MapPrototypeDelete = Map.prototype.delete;
+const MapPrototypeGet = Map.prototype.get;
+const MapPrototypeSet = Map.prototype.set;
+const trustedRequestContextAccessor = currentRequestContext;
 
 /**
  * A specifier the HTTP plugin fetches rather than a path. URL schemes are
@@ -2079,10 +2087,7 @@ export function getUserDependencies(
  * overlay. A module whose top-level init ran under one tenant's or
  * environment's env overlay is never reused under another.
  */
-const bundledModules = new Map<string, Promise<APIRoute>>();
-
-/** Bundled routes a dev session can hold before the oldest is dropped. */
-const MAX_BUNDLED_MODULES = 64;
+const bundledModules = new IntrinsicMap<string, Promise<APIRoute>>();
 
 /**
  * Identity of the scope a bundled module may be reused within.
@@ -2097,47 +2102,65 @@ const MAX_BUNDLED_MODULES = 64;
  * reuse stays within one scope. Local single-tenant loads carry neither and
  * keep their current key.
  */
-async function bundledModuleScopeDiscriminator(): Promise<string> {
+export async function bundledModuleScopeDiscriminator(): Promise<string> {
   const scopeId = tryGetRegistryScopeId() ?? "";
+  const environmentName = trustedRequestContextAccessor()?.environmentName ?? "";
   const envSnapshot = getProjectEnvSnapshot();
-  let envDigest = "";
+  let serializedEnv = "";
   if (envSnapshot) {
-    // Snapshot keys are sorted and contain no NUL or "=", and values contain
-    // no NUL, so this serialization is canonical and collision-free.
-    const entries: string[] = [];
-    for (const key of Object.keys(envSnapshot)) {
-      entries.push(`${key}=${envSnapshot[key]}`);
+    // Project code executes in this realm and can replace ordinary Object and
+    // Array methods. The snapshot is a frozen, null-prototype record whose own
+    // keys were inserted in deterministic order, so captured own-key traversal
+    // plus length framing gives a canonical encoding without crossing a
+    // mutable prototype.
+    const keys = IntrinsicReflectOwnKeys(envSnapshot);
+    for (let index = 0; index < keys.length; index += 1) {
+      const key = keys[index];
+      if (typeof key !== "string") continue;
+      const value = envSnapshot[key]!;
+      serializedEnv += `${key.length}:${key}${value.length}:${value}`;
     }
-    envDigest = await computeHash(entries.join("\u0000"));
   }
-  return `${scopeId}\u0000${envDigest}`;
+
+  // Raw UTF-16 framing keeps lone surrogates distinct from U+FFFD. TextEncoder
+  // normalizes both to the same UTF-8 replacement bytes.
+  return await computeCodeHash({
+    code: scopeId,
+    css: environmentName,
+    sourceMap: serializedEnv,
+  });
 }
 
 async function bundledModuleKey(owner: string, code: string): Promise<string> {
-  return await computeHash(`${owner}\u0000${code}`);
+  return await computeCodeHash({ code: owner, css: code });
 }
 
-function loadModuleFromCode(
+export async function loadModuleFromCode(
   code: string,
   fs: FileSystem,
   owner: string,
 ): Promise<APIRoute> {
-  return bundledModuleKey(owner, code).then((key) => {
-    const cached = bundledModules.get(key);
-    if (cached) return cached;
+  const key = await bundledModuleKey(owner, code);
+  const cached = IntrinsicReflectApply(MapPrototypeGet, bundledModules, [key]) as
+    | Promise<APIRoute>
+    | undefined;
+  if (cached) return await cached;
 
-    const loading = importModuleFromCode(code, fs);
-    bundledModules.set(key, loading);
+  const loading = importModuleFromCode(code, fs);
+  IntrinsicReflectApply(MapPrototypeSet, bundledModules, [key, loading]);
 
-    // A failed build must not be remembered as this route's module.
-    loading.catch(() => bundledModules.delete(key));
-
-    if (bundledModules.size > MAX_BUNDLED_MODULES) {
-      const oldest = bundledModules.keys().next();
-      if (!oldest.done) bundledModules.delete(oldest.value);
+  // Deno retains every imported ESM record for the life of the process. Keep
+  // one matching lookup entry too: evicting only this map caused a later visit
+  // to import the same scope under a fresh temp URL, retaining a duplicate ESM
+  // record and resetting its module state each time.
+  try {
+    return await loading;
+  } catch (error) {
+    if (IntrinsicReflectApply(MapPrototypeGet, bundledModules, [key]) === loading) {
+      IntrinsicReflectApply(MapPrototypeDelete, bundledModules, [key]);
     }
-    return loading;
-  });
+    throw error;
+  }
 }
 
 async function importModuleFromCode(

--- a/src/server/handlers/request/api/pages-api-handler.test.ts
+++ b/src/server/handlers/request/api/pages-api-handler.test.ts
@@ -13,6 +13,7 @@ import {
   resetApiHandlerForProject,
   withApiHandler,
 } from "./pages-api-handler.ts";
+import { runWithProjectEnv } from "#veryfront/server/project-env/storage.ts";
 
 type MockHandler = { destroyed: boolean; destroy(): void };
 
@@ -201,6 +202,35 @@ describe("server/handlers/request/api/pages-api-handler", () => {
       );
       assertEquals(cache.store.size, 3);
       assertEquals(productionHandler === updatedProductionHandler, false);
+    });
+
+    it("does not cache config-less handlers across environment snapshots", async () => {
+      const cache = createMockCache();
+      const adapter = createMockAdapter();
+      __injectCacheForTests(cache as any);
+      __injectApiRouteDepsForTests({
+        getConfig: () => Promise.resolve({}),
+      });
+      const ctx = createHandlerContext({
+        adapter,
+        projectSlug: "hosted-project",
+        mode: "production",
+        releaseId: "shared-release",
+        environmentId: "production",
+        environmentName: "production",
+      });
+
+      const first = await runWithProjectEnv(
+        { TENANT_VALUE: "first" },
+        () => getApiHandler(ctx),
+      );
+      const second = await runWithProjectEnv(
+        { TENANT_VALUE: "second" },
+        () => getApiHandler(ctx),
+      );
+
+      assertEquals(first === second, false);
+      assertEquals(cache.store.size, 0);
     });
   });
 

--- a/src/server/handlers/request/api/pages-api-handler.ts
+++ b/src/server/handlers/request/api/pages-api-handler.ts
@@ -16,6 +16,7 @@ import {
 } from "#veryfront/cache/cache-key-builder.ts";
 import type { HandlerContext } from "../../types.ts";
 import { ensurePreviewSourceSnapshotFresh } from "../source-snapshot-freshness.ts";
+import { getProjectEnvSnapshot } from "#veryfront/server/project-env/storage.ts";
 
 const logger = serverLogger.component("reset-api-handler");
 
@@ -140,6 +141,12 @@ function getCacheKey(ctx: HandlerContext): string {
 
 function shouldCacheApiHandler(ctx: HandlerContext): boolean {
   if (!ctx.projectSlug) return true;
+
+  // A config-less hosted handler has no environment fingerprint in its outer
+  // cache key. Recreate it for each request so route loading reaches the
+  // environment-scoped module discriminator instead of returning a route
+  // initialized under an earlier environment snapshot.
+  if (ctx.config === undefined && getProjectEnvSnapshot() !== undefined) return false;
 
   // Cannot confirm a production context → do not cache.
   return getApiHandlerCacheContext(ctx)?.mode === "production";


### PR DESCRIPTION
## Summary

The process-global bundled-module cache below `APIRouteHandler` (introduced in #3912) keyed entries only on `projectDir`, `modulePath`, and the generated source hash. In hosted proxy execution every non-local project resolves to the host runtime's shared project directory, and per-request environment isolation is applied with `runWithProjectEnv` before route loading and execution. A route module therefore runs its top-level initialization under one project's or environment's env overlay and can then be served from the cache to a later load in a different scope whenever the virtual path and bundled output match — making module-level clients, secrets, and mutable state initialized in the first scope available to the second. The leak fires between tenants and even between environments of a single project (identical release code, different env vars). It is reachable when host-realm API execution is granted (operator-granted host execution with worker isolation disabled); the default shared-runtime path that denies host project execution is not affected.

## Finding

- Codex finding id: `dbf02b16ffc881919b8edfcdc189d40b` (finding 29)
- Severity: medium
- Introduced in: 199bd13c319f551079969e520c933095b27fa7fe (#3912)

## Fix

`loadAndTranspileModule` now folds a scope discriminator into the bundled-module cache owner alongside `projectDir` and `modulePath`:

- the ambient registry scope id (`tryGetRegistryScopeId()`: project, mode, version) — the same scope identity the higher-level API handler cache uses, so two hosted projects sharing the virtual project dir and byte-identical bundled output never share a module; and
- a digest of the active project-env overlay (`getProjectEnvSnapshot()`), so a module initialized under one environment's env overlay is never reused under another, including between environments of one project. Snapshot keys are sorted and free of NUL/`=` and values are free of NUL, so the digested serialization is canonical.

Local single-tenant loads (no request context, no env overlay) carry an empty discriminator and keep their existing cache key, preserving the dev-mode module-state reuse that #3912 introduced.

## Test evidence

Two regression tests added to `src/routing/api/module-loader/loader.test.ts`, both failing on the unfixed loader and passing with the fix:

- `does not reuse a bundled module across different project env overlays` — a bundled route with module-level state loaded under `runWithProjectEnv({TENANT_SECRET:"a"})` is not reused under `{TENANT_SECRET:"b"}`, while a repeat load under the same overlay keeps its module.
- `does not reuse a bundled module across different hosted project scopes` — the same path/output under two different `runWithCacheKeyContext` project identities yields distinct modules.

Verified locally:

- `deno test --preload=src/testing/preload.ts --no-check --allow-all --unstable-worker-options --unstable-net src/routing/api/module-loader/loader.test.ts` — 9 passed (167 steps), 0 failed
- with the loader change stashed, the two new tests fail (module reuse across scopes observed), confirming they pin the vulnerability
- `deno check src/routing/api/module-loader/loader.ts src/routing/api/module-loader/loader.test.ts` — clean
- `deno lint` and `deno fmt --check` on both touched files — clean

https://claude.ai/code/session_01QfWNMiUhvWMKWi6BGfVdY3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Route modules are now isolated correctly between projects, hosted scopes, and environment configurations.
  - Reusable route modules continue to work reliably after many other modules have been loaded.
  - Improved module-cache stability when application code modifies built-in object or collection behavior.
  - Failed module loads are cleaned up more reliably, preventing invalid entries from affecting later requests.
  - Configuration-free API handlers now correctly reflect the current environment instead of reusing handlers from an earlier configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->