### PR TITLE
Fix agent service heartbeat JSON body

### DIFF
--- a/src/agent/service/registration.test.ts
+++ b/src/agent/service/registration.test.ts
@@ -288,6 +288,11 @@ describe("agent/agent-service-registration", () => {
       "heartbeats must carry bearer auth",
     );
     assertEquals(calls[1]?.init?.method, "POST", "the heartbeat must be a POST");
+    assertEquals(
+      calls[1]?.init?.body,
+      "{}",
+      "the heartbeat must send the JSON object required by the control plane",
+    );
     assertEquals(JSON.parse(String(calls[0]?.init?.body)), {
       service_name: "docs-agent",
       service_key: "docs-agent:test",

--- a/src/agent/service/registration.ts
+++ b/src/agent/service/registration.ts
@@ -446,6 +446,7 @@ async function sendHeartbeatRequest(
     response = await fetchImpl(getHeartbeatEndpoint(input.apiUrl, input.serviceId), {
       method: "POST",
       headers: createHeaders(input.authToken),
+      body: JSON.stringify({}),
       signal: abortSignal,
     });
   } catch (cause) {


### PR DESCRIPTION
## Summary

- send the JSON object required by the strict control-plane heartbeat endpoint
- lock the wire contract in the hosted registration lifecycle test

## Why

The generic hosted agent replicas register successfully, then every heartbeat fails because the framework declares JSON without sending a body. The API deployment health gate correctly detects both registrations as stale.

## Verification

- red: focused registration test failed with an undefined heartbeat body
- green: `deno task test:file src/agent/service/registration.test.ts` (27 steps)
- `deno task typecheck`
- focused `deno fmt --check`
- focused `deno lint`
- repository pre-push suite: 129 batches, 2,012 steps, plus serial and working-directory exclusion suites

This fixes the client at the owning boundary. It does not relax the API parser or deployment health gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Heartbeat requests now include a valid empty JSON payload, improving compatibility with the control plane.

* **Tests**
  * Added validation to ensure heartbeat requests use the expected JSON body format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->