### PR TITLE
fix(security): bind direct OTLP metric samples to their export target at enqueue time

### DIFF
--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -580,6 +580,55 @@ describe("metrics public SDK", () => {
     );
   });
 
+  it("exports later target groups when the first endpoint stalls", async () => {
+    const requestedUrls: string[] = [];
+
+    await withEnv({
+      SERVER_ID: "server-1",
+      ENVIRONMENT_IDS: "env-project,env-internal",
+      OTEL_METRICS_ENABLED: "true",
+      VERYFRONT_API_BASE_URL: "http://veryfront-api:80",
+      VERYFRONT_API_INTERNAL_USER: "internal-user",
+      VERYFRONT_API_INTERNAL_PASS: "internal-pass",
+    }, async () => {
+      await withMockFetch(
+        ((url: string | URL | Request, init?: RequestInit) => {
+          const requestedUrl = String(url);
+          requestedUrls[requestedUrls.length] = requestedUrl;
+          if (requestedUrl !== "https://stalled.example/v1/metrics") {
+            return Promise.resolve(new Response("{}", { status: 200 }));
+          }
+
+          return new Promise<Response>((resolve) => {
+            const finish = () => resolve(new Response("{}", { status: 504 }));
+            if (init?.signal?.aborted) {
+              finish();
+            } else {
+              init?.signal?.addEventListener("abort", finish, { once: true });
+            }
+          });
+        }) as typeof fetch,
+        async () => {
+          metrics.__setDirectExportTimeoutForTests(25);
+          await runWithProjectEnv({
+            OTEL_METRICS_ENABLED: "true",
+            OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://stalled.example/v1/metrics",
+          }, () => {
+            metrics.counter("vf_stalled_metric_total", 1);
+          });
+          metrics.counter("vf_internal_metric_total", 1);
+
+          await metrics.__flushForTests();
+        },
+      );
+    });
+
+    assertEquals(requestedUrls, [
+      "https://stalled.example/v1/metrics",
+      "http://veryfront-api:80/internal/metrics/otlp/v1/metrics",
+    ]);
+  });
+
   it("does not expose internal metrics credentials to replaced target-grouping intrinsics", async () => {
     const requests: Array<{ url: string; init?: RequestInit }> = [];
     const observed: string[] = [];
@@ -590,11 +639,11 @@ describe("metrics public SDK", () => {
     const record = (values: unknown[]): void => {
       for (const value of values) {
         if (typeof value === "string") {
-          observed.push(value);
+          observed[observed.length] = value;
           continue;
         }
         try {
-          observed.push(String(nativeStringify(value)));
+          observed[observed.length] = String(nativeStringify(value));
         } catch {
           // Unserializable values cannot carry the credential as data.
         }
@@ -602,12 +651,18 @@ describe("metrics public SDK", () => {
     };
 
     const nativeEntries = Object.entries;
+    const nativeMap = Array.prototype.map;
+    const nativePush = Array.prototype.push;
+    const nativeSplice = Array.prototype.splice;
     const nativeSort = Array.prototype.sort;
     const nativeLocaleCompare = String.prototype.localeCompare;
     const nativeMapSet = Map.prototype.set;
 
     const restore = () => {
       Object.entries = nativeEntries;
+      Array.prototype.map = nativeMap;
+      Array.prototype.push = nativePush;
+      Array.prototype.splice = nativeSplice;
       Array.prototype.sort = nativeSort;
       String.prototype.localeCompare = nativeLocaleCompare;
       Map.prototype.set = nativeMapSet;
@@ -624,7 +679,7 @@ describe("metrics public SDK", () => {
     }, async () => {
       await withMockFetch(
         ((url: string | URL | Request, init?: RequestInit) => {
-          requests.push({ url: String(url), init });
+          requests[requests.length] = { url: String(url), init };
           return Promise.resolve(new Response("{}", { status: 200 }));
         }) as typeof fetch,
         async () => {
@@ -632,6 +687,27 @@ describe("metrics public SDK", () => {
             record([value]);
             return nativeEntries(value);
           }) as typeof Object.entries;
+          Array.prototype.map = function (this: unknown[], callback, thisArg?) {
+            record([this]);
+            return nativeMap.call(this, callback, thisArg);
+          } as typeof Array.prototype.map;
+          Array.prototype.push = function (this: unknown[], ...values: unknown[]) {
+            record([this, ...values]);
+            return nativePush.apply(this, values);
+          } as typeof Array.prototype.push;
+          Array.prototype.splice = function (
+            this: unknown[],
+            start: number,
+            deleteCount?: number,
+            ...items: unknown[]
+          ) {
+            record([this, ...items]);
+            return Reflect.apply(
+              nativeSplice,
+              this,
+              deleteCount === undefined ? [start] : [start, deleteCount, ...items],
+            );
+          } as typeof Array.prototype.splice;
           Array.prototype.sort = function (this: unknown[], compare?) {
             record([this]);
             return nativeSort.call(this, compare) as unknown[];

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -1468,6 +1468,57 @@ describe("metrics public SDK", () => {
     );
   });
 
+  it("keeps project ids and project slugs in separate quota namespaces", async () => {
+    const requestedUrls: string[] = [];
+    const stalled = Promise.withResolvers<Response>();
+
+    await withEnv({
+      SERVER_ID: "server-1",
+      ENVIRONMENT_IDS: "env-a,env-b",
+      OTEL_METRICS_ENABLED: "true",
+    }, async () => {
+      await withMockFetch(
+        ((url: string | URL | Request) => {
+          const requestedUrl = String(url);
+          requestedUrls[requestedUrls.length] = requestedUrl;
+          return requestedUrl === "https://tenant-id.example/v1/metrics"
+            ? stalled.promise
+            : Promise.resolve(new Response("{}", { status: 200 }));
+        }) as typeof fetch,
+        async () => {
+          metrics.__setDirectExportTimeoutForTests(5_000);
+          for (let index = 0; index < 200; index++) {
+            runWithTrustedProjectEnv(
+              {
+                OTEL_METRICS_ENABLED: "true",
+                OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://tenant-id.example/v1/metrics",
+              },
+              { projectId: "shared-identity", projectSlug: "tenant-a", environmentId: "env-a" },
+              () => metrics.counter("vf_project_id_scope_total", 1),
+            );
+          }
+          runWithTrustedProjectEnv(
+            {
+              OTEL_METRICS_ENABLED: "true",
+              OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://tenant-slug.example/v1/metrics",
+            },
+            { projectId: "", projectSlug: "shared-identity", environmentId: "env-b" },
+            () => metrics.counter("vf_project_slug_scope_total", 1),
+          );
+
+          stalled.resolve(new Response("{}", { status: 200 }));
+          await metrics.__flushForTests();
+        },
+      );
+    });
+
+    assertEquals(
+      new Set(requestedUrls).has("https://tenant-slug.example/v1/metrics"),
+      true,
+      "an id and slug with equal text must not share a capacity scope",
+    );
+  });
+
   it("reserves queue capacity for platform metrics when tenants saturate the queue", async () => {
     const requestedUrls: string[] = [];
     const stalled = Promise.withResolvers<Response>();

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -12,6 +12,11 @@ import {
   runWithProjectEnv,
   runWithTrustedProjectEnv,
 } from "#veryfront/server/project-env/storage.ts";
+import {
+  __resetLoggerConfigForTests,
+  __subscribeLogRecordEmitter,
+  type LogEntry,
+} from "#veryfront/utils/logger/logger.ts";
 import { withEnv } from "#veryfront/testing/deno-compat.ts";
 import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { metrics } from "./index.ts";
@@ -1256,5 +1261,330 @@ describe("metrics public SDK", () => {
     const metric = body.resourceMetrics[0].scopeMetrics[0].metrics[0];
     assertEquals(metric.name, "vf_queue_depth");
     assertEquals(metric.gauge.dataPoints[0].asDouble, 3);
+  });
+
+  it("keeps accepting a tenant's samples while its own export is in flight", async () => {
+    const bodies: string[] = [];
+    const stalled = Promise.withResolvers<Response>();
+
+    await withEnv({
+      SERVER_ID: "server-1",
+      ENVIRONMENT_IDS: "env-a",
+      OTEL_METRICS_ENABLED: "true",
+    }, async () => {
+      await withMockFetch(
+        ((_url: string | URL | Request, init?: RequestInit) => {
+          bodies[bodies.length] = String(init?.body);
+          return bodies.length === 1
+            ? stalled.promise
+            : Promise.resolve(new Response("{}", { status: 200 }));
+        }) as typeof fetch,
+        async () => {
+          metrics.__setDirectExportTimeoutForTests(5_000);
+          const emit = (name: string) =>
+            runWithTrustedProjectEnv(
+              {
+                OTEL_METRICS_ENABLED: "true",
+                OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://tenant.example/v1/metrics",
+              },
+              { projectId: "project-a", environmentId: "env-a" },
+              () => metrics.counter(name, 1),
+            );
+
+          // One full batch leaves the queue immediately and sits on the wire.
+          for (let index = 0; index < 100; index++) emit("vf_batched_metric_total");
+          assertEquals(bodies.length, 1, "the full batch must already be exporting");
+
+          emit("vf_late_metric_total");
+          stalled.resolve(new Response("{}", { status: 200 }));
+          await metrics.__flushForTests();
+        },
+      );
+    });
+
+    assertEquals(
+      bodies.length,
+      2,
+      "samples emitted while an export is in flight must not consume the pending quota",
+    );
+    assertEquals(
+      JSON.parse(String(bodies[1])).resourceMetrics[0].scopeMetrics[0].metrics.map((
+        entry: { name: string },
+      ) => entry.name),
+      ["vf_late_metric_total"],
+    );
+  });
+
+  it("keeps cumulative direct totals separate per export target", async () => {
+    const requests: Array<{ url: string; body: string }> = [];
+
+    await withEnv({
+      SERVER_ID: "server-1",
+      ENVIRONMENT_IDS: "env-a,env-b",
+      OTEL_METRICS_ENABLED: "true",
+    }, async () => {
+      await withMockFetch(
+        ((url: string | URL | Request, init?: RequestInit) => {
+          requests[requests.length] = { url: String(url), body: String(init?.body) };
+          return Promise.resolve(new Response("{}", { status: 200 }));
+        }) as typeof fetch,
+        async () => {
+          const emitTo = (endpoint: string) =>
+            runWithProjectEnv({
+              OTEL_METRICS_ENABLED: "true",
+              OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: endpoint,
+            }, () => {
+              metrics.counter("vf_shared_metric_total", 1, { outcome: "pass" });
+              metrics.histogram("vf_shared_latency_ms", 42, { outcome: "pass" });
+            });
+
+          emitTo("https://first.example/v1/metrics");
+          await metrics.__flushForTests();
+          emitTo("https://second.example/v1/metrics");
+          await metrics.__flushForTests();
+        },
+      );
+    });
+
+    assertEquals(requests.length, 2);
+    assertEquals(requests[1]?.url, "https://second.example/v1/metrics");
+    const exported = JSON.parse(String(requests[1]?.body))
+      .resourceMetrics[0].scopeMetrics[0].metrics;
+    assertEquals(
+      exported[0].sum.dataPoints[0].asDouble,
+      1,
+      "a counter total must not carry another target's accumulated value",
+    );
+    assertEquals(
+      exported[1].histogram.dataPoints[0].count,
+      1,
+      "a histogram total must not carry another target's accumulated count",
+    );
+  });
+
+  it("takes resource attributes from the enqueue-time target, not the flushing context", async () => {
+    const requests: Array<{ url: string; body: string }> = [];
+
+    await withEnv({
+      SERVER_ID: "server-1",
+      ENVIRONMENT_IDS: "env-a,env-b",
+      OTEL_METRICS_ENABLED: "true",
+    }, async () => {
+      await withMockFetch(
+        ((url: string | URL | Request, init?: RequestInit) => {
+          requests[requests.length] = { url: String(url), body: String(init?.body) };
+          return Promise.resolve(new Response("{}", { status: 200 }));
+        }) as typeof fetch,
+        async () => {
+          runWithProjectEnv({
+            OTEL_METRICS_ENABLED: "true",
+            OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://enqueued.example/v1/metrics",
+            OTEL_SERVICE_NAME: "enqueue-time-service",
+          }, () => metrics.counter("vf_enqueued_total", 1));
+
+          // The flush runs under a different environment's context, exactly as
+          // the shared flush timer does in a dedicated runtime.
+          await runWithProjectEnv({
+            OTEL_METRICS_ENABLED: "true",
+            OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://flusher.example/v1/metrics",
+            OTEL_SERVICE_NAME: "flush-time-service",
+          }, async () => {
+            metrics.counter("vf_flusher_total", 1);
+            await metrics.__flushForTests();
+          });
+        },
+      );
+    });
+
+    const serviceNameOf = (url: string): string =>
+      JSON.parse(
+        String(requests.find((request) => request.url === url)?.body),
+      ).resourceMetrics[0].resource.attributes.find(
+        (attribute: { key: string }) => attribute.key === "service.name",
+      ).value.stringValue;
+
+    assertEquals(requests.length, 2);
+    assertEquals(
+      serviceNameOf("https://enqueued.example/v1/metrics"),
+      "enqueue-time-service",
+      "resource attributes must describe the environment that enqueued the sample",
+    );
+    assertEquals(
+      serviceNameOf("https://flusher.example/v1/metrics"),
+      "flush-time-service",
+    );
+  });
+
+  it("keeps tenants with an empty trusted project id in separate quota buckets", async () => {
+    const requestedUrls: string[] = [];
+    const stalled = Promise.withResolvers<Response>();
+
+    await withEnv({
+      SERVER_ID: "server-1",
+      ENVIRONMENT_IDS: "env-a,env-b",
+      OTEL_METRICS_ENABLED: "true",
+    }, async () => {
+      await withMockFetch(
+        ((url: string | URL | Request) => {
+          const requestedUrl = String(url);
+          requestedUrls[requestedUrls.length] = requestedUrl;
+          return requestedUrl === "https://tenant-a.example/v1/metrics"
+            ? stalled.promise
+            : Promise.resolve(new Response("{}", { status: 200 }));
+        }) as typeof fetch,
+        async () => {
+          metrics.__setDirectExportTimeoutForTests(5_000);
+          // Both runtimes report an empty project id, so only the slug tells
+          // the two tenants apart.
+          for (let index = 0; index < 200; index++) {
+            runWithTrustedProjectEnv(
+              {
+                OTEL_METRICS_ENABLED: "true",
+                OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://tenant-a.example/v1/metrics",
+              },
+              { projectId: "", projectSlug: "tenant-a", environmentId: "env-a" },
+              () => metrics.counter("vf_tenant_a_total", 1),
+            );
+          }
+          runWithTrustedProjectEnv(
+            {
+              OTEL_METRICS_ENABLED: "true",
+              OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://tenant-b.example/v1/metrics",
+            },
+            { projectId: "", projectSlug: "tenant-b", environmentId: "env-b" },
+            () => metrics.counter("vf_tenant_b_total", 1),
+          );
+
+          stalled.resolve(new Response("{}", { status: 200 }));
+          await metrics.__flushForTests();
+        },
+      );
+    });
+
+    assertEquals(
+      requestedUrls.includes("https://tenant-b.example/v1/metrics"),
+      true,
+      "one tenant saturating its quota must not silence a different tenant",
+    );
+  });
+
+  it("reserves queue capacity for platform metrics when tenants saturate the queue", async () => {
+    const requestedUrls: string[] = [];
+    const stalled = Promise.withResolvers<Response>();
+
+    await withEnv({
+      SERVER_ID: "server-1",
+      ENVIRONMENT_IDS: "env-1,env-2,env-3,env-4,env-5,env-6",
+      OTEL_METRICS_ENABLED: "true",
+      VERYFRONT_API_BASE_URL: "http://veryfront-api:80",
+      VERYFRONT_API_INTERNAL_USER: "internal-user",
+      VERYFRONT_API_INTERNAL_PASS: "internal-pass",
+    }, async () => {
+      await withMockFetch(
+        ((url: string | URL | Request) => {
+          const requestedUrl = String(url);
+          requestedUrls[requestedUrls.length] = requestedUrl;
+          return requestedUrl.startsWith("https://tenant-")
+            ? stalled.promise
+            : Promise.resolve(new Response("{}", { status: 200 }));
+        }) as typeof fetch,
+        async () => {
+          metrics.__setDirectExportTimeoutForTests(5_000);
+          const emitTenantSamples = (tenant: number, count: number) => {
+            for (let index = 0; index < count; index++) {
+              runWithTrustedProjectEnv(
+                {
+                  OTEL_METRICS_ENABLED: "true",
+                  OTEL_EXPORTER_OTLP_METRICS_ENDPOINT:
+                    `https://tenant-${tenant}.example/v1/metrics`,
+                },
+                { projectId: `project-${tenant}`, environmentId: `env-${tenant}` },
+                () => metrics.counter("vf_tenant_metric_total", 1),
+              );
+            }
+          };
+
+          // Every tenant endpoint stalls, so tenant samples pile up against the
+          // shared queue bound.
+          for (let tenant = 1; tenant <= 5; tenant++) emitTenantSamples(tenant, 300);
+          const droppedBeforeOverflow = metrics.__getDroppedDirectSampleCountForTests();
+          emitTenantSamples(6, 1);
+          assertEquals(
+            metrics.__getDroppedDirectSampleCountForTests() > droppedBeforeOverflow,
+            true,
+            "tenant traffic must stop at the tenant share of the queue",
+          );
+
+          // A platform metric carries no tenant scope and must still be queued.
+          metrics.counter("vf_platform_metric_total", 1);
+
+          stalled.resolve(new Response("{}", { status: 200 }));
+          await metrics.__flushForTests();
+        },
+      );
+    });
+
+    assertEquals(
+      requestedUrls.includes("http://veryfront-api:80/internal/metrics/otlp/v1/metrics"),
+      true,
+      "the platform reserve must keep internal metrics exportable under tenant load",
+    );
+  });
+
+  it("reports dropped direct samples instead of discarding them silently", async () => {
+    const records: LogEntry[] = [];
+    const stalled = Promise.withResolvers<Response>();
+    let unsubscribe = () => {};
+
+    await withEnv({
+      SERVER_ID: "server-1",
+      ENVIRONMENT_IDS: "env-a",
+      OTEL_METRICS_ENABLED: "true",
+      LOG_LEVEL: "DEBUG",
+    }, async () => {
+      __resetLoggerConfigForTests();
+      unsubscribe = __subscribeLogRecordEmitter((record) => {
+        records[records.length] = record;
+      });
+      try {
+        await withMockFetch(
+          ((url: string | URL | Request) => {
+            return String(url) === "https://tenant.example/v1/metrics"
+              ? stalled.promise
+              : Promise.resolve(new Response("{}", { status: 200 }));
+          }) as typeof fetch,
+          async () => {
+            metrics.__setDirectExportTimeoutForTests(5_000);
+            for (let index = 0; index < 301; index++) {
+              runWithTrustedProjectEnv(
+                {
+                  OTEL_METRICS_ENABLED: "true",
+                  OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://tenant.example/v1/metrics",
+                },
+                { projectId: "project-a", environmentId: "env-a" },
+                () => metrics.counter("vf_tenant_metric_total", 1),
+              );
+            }
+
+            stalled.resolve(new Response("{}", { status: 200 }));
+            await metrics.__flushForTests();
+          },
+        );
+      } finally {
+        unsubscribe();
+        __resetLoggerConfigForTests();
+      }
+    });
+
+    assertEquals(
+      metrics.__getDroppedDirectSampleCountForTests() > 0,
+      true,
+      "an over-quota sample must be counted",
+    );
+    assertEquals(
+      records.some((record) => record.message === "metrics: direct OTLP sample dropped"),
+      true,
+      "an over-quota drop must be observable in the logs",
+    );
   });
 });

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -8,7 +8,10 @@ import {
   setGlobalMetricsAPI,
 } from "#veryfront/observability/tracing/api-shim.ts";
 import { runWithRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
-import { runWithProjectEnv } from "#veryfront/server/project-env/storage.ts";
+import {
+  runWithProjectEnv,
+  runWithTrustedProjectEnv,
+} from "#veryfront/server/project-env/storage.ts";
 import { withEnv } from "#veryfront/testing/deno-compat.ts";
 import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { metrics } from "./index.ts";
@@ -629,6 +632,62 @@ describe("metrics public SDK", () => {
     ]);
   });
 
+  it("dispatches another project while a tenant target pipeline is stalled", async () => {
+    const requestedUrls: string[] = [];
+    const stalledResponse = Promise.withResolvers<Response>();
+
+    await withEnv({
+      SERVER_ID: "server-1",
+      ENVIRONMENT_IDS: "env-a,env-b",
+      OTEL_METRICS_ENABLED: "true",
+    }, async () => {
+      await withMockFetch(
+        ((url: string | URL | Request) => {
+          const requestedUrl = String(url);
+          requestedUrls[requestedUrls.length] = requestedUrl;
+          return requestedUrl === "https://stalled.example/v1/metrics"
+            ? stalledResponse.promise
+            : Promise.resolve(new Response("{}", { status: 200 }));
+        }) as typeof fetch,
+        async () => {
+          metrics.__setDirectExportTimeoutForTests(5_000);
+          runWithTrustedProjectEnv(
+            {
+              OTEL_METRICS_ENABLED: "true",
+              OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://stalled.example/v1/metrics",
+            },
+            { projectId: "project-a", environmentId: "env-a" },
+            () => {
+              for (let index = 0; index < 1_000; index++) {
+                metrics.counter("vf_stalled_metric_total", 1);
+              }
+            },
+          );
+
+          runWithTrustedProjectEnv(
+            {
+              OTEL_METRICS_ENABLED: "true",
+              OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://later.example/v1/metrics",
+            },
+            { projectId: "project-b", environmentId: "env-b" },
+            () => metrics.counter("vf_later_metric_total", 1),
+          );
+          const flush = metrics.__flushForTests();
+          for (let attempt = 0; attempt < 20 && requestedUrls.length < 2; attempt++) {
+            await Promise.resolve();
+          }
+
+          assertEquals(requestedUrls, [
+            "https://stalled.example/v1/metrics",
+            "https://later.example/v1/metrics",
+          ]);
+          stalledResponse.resolve(new Response("{}", { status: 200 }));
+          await flush;
+        },
+      );
+    });
+  });
+
   it("does not expose internal metrics credentials to replaced target-grouping intrinsics", async () => {
     const requests: Array<{ url: string; init?: RequestInit }> = [];
     const observed: string[] = [];
@@ -800,20 +859,28 @@ describe("metrics public SDK", () => {
         (() => Promise.resolve(new Response("{}", { status: 200 }))) as typeof fetch,
         async () => {
           for (let index = 0; index < 150; index++) {
-            await runWithProjectEnv({
-              OTEL_METRICS_ENABLED: "true",
-              OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://collector.example/v1/metrics",
-              OTEL_SERVICE_NAME: `project-${index}`,
-              VERYFRONT_PROJECT_ID: "project-a",
-            }, () => metrics.counter("vf_project_metric_total", 1));
+            runWithTrustedProjectEnv(
+              {
+                OTEL_METRICS_ENABLED: "true",
+                OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://collector.example/v1/metrics",
+                OTEL_SERVICE_NAME: `project-${index}`,
+                VERYFRONT_PROJECT_ID: `forged-project-${index}`,
+              },
+              { projectId: "project-a", environmentId: "env-a" },
+              () => metrics.counter("vf_project_metric_total", 1),
+            );
           }
           await metrics.__flushForTests();
-          await runWithProjectEnv({
-            OTEL_METRICS_ENABLED: "true",
-            OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://collector.example/v1/metrics",
-            OTEL_SERVICE_NAME: "project-b",
-            VERYFRONT_PROJECT_ID: "project-b",
-          }, () => metrics.counter("vf_project_metric_total", 1));
+          runWithTrustedProjectEnv(
+            {
+              OTEL_METRICS_ENABLED: "true",
+              OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://collector.example/v1/metrics",
+              OTEL_SERVICE_NAME: "project-b",
+              VERYFRONT_PROJECT_ID: "forged-project-a",
+            },
+            { projectId: "project-b", environmentId: "env-b" },
+            () => metrics.counter("vf_project_metric_total", 1),
+          );
           await metrics.__flushForTests();
         },
       );

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -517,6 +517,71 @@ describe("metrics public SDK", () => {
     );
   });
 
+  it("never exports one environment's queued samples to another environment's OTLP target", async () => {
+    const originalFetch = globalThis.fetch;
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+
+    await withEnv({
+      SERVER_ID: "server-1",
+      ENVIRONMENT_IDS: "env-victim,env-attacker",
+      OTEL_METRICS_ENABLED: "true",
+      VERYFRONT_API_BASE_URL: "http://veryfront-api:80",
+      VERYFRONT_API_INTERNAL_USER: "internal-user",
+      VERYFRONT_API_INTERNAL_PASS: "internal-pass",
+    }, async () => {
+      globalThis.fetch = ((url: string | URL | Request, init?: RequestInit) => {
+        requests.push({ url: String(url), init });
+        return Promise.resolve(new Response("{}", { status: 200 }));
+      }) as typeof fetch;
+
+      try {
+        // A victim environment enqueues a sample bound for the internal proxy.
+        metrics.counter("vf_victim_metric_total", 1, { project_id: "victim-project" });
+
+        // A co-located environment configured with its own OTLP endpoint then
+        // enqueues a sample and the flush fires under ITS project-env context —
+        // exactly the ambient context the flush timer inherits in production.
+        await runWithProjectEnv({
+          OTEL_METRICS_ENABLED: "true",
+          OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://attacker.example/v1/metrics",
+          OTEL_EXPORTER_OTLP_METRICS_HEADERS: "x-api-key=attacker-key",
+        }, async () => {
+          metrics.counter("vf_attacker_metric_total", 1, { project_id: "attacker-project" });
+          await (metrics as unknown as { __flushForTests(): Promise<void> }).__flushForTests();
+        });
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    assertEquals(requests.length, 2, "each environment's samples must be exported separately");
+
+    const byUrl = new Map(requests.map((request) => [request.url, request]));
+    const internalRequest = byUrl.get("http://veryfront-api:80/internal/metrics/otlp/v1/metrics");
+    const attackerRequest = byUrl.get("https://attacker.example/v1/metrics");
+
+    const internalMetrics = JSON.parse(String(internalRequest?.init?.body))
+      .resourceMetrics[0].scopeMetrics[0].metrics.map((entry: { name: string }) => entry.name);
+    assertEquals(
+      internalMetrics,
+      ["vf_victim_metric_total"],
+      "the victim's sample must go to the target bound when it was enqueued",
+    );
+
+    const attackerMetrics = JSON.parse(String(attackerRequest?.init?.body))
+      .resourceMetrics[0].scopeMetrics[0].metrics.map((entry: { name: string }) => entry.name);
+    assertEquals(
+      attackerMetrics,
+      ["vf_attacker_metric_total"],
+      "a project-configured OTLP endpoint must never receive other environments' samples",
+    );
+    assertEquals(
+      (attackerRequest?.init?.headers as Record<string, string>).Authorization,
+      undefined,
+      "internal proxy credentials must never reach a project-configured endpoint",
+    );
+  });
+
   it("routes dedicated runtime host OTLP metrics through the internal API proxy without project env", async () => {
     const originalFetch = globalThis.fetch;
     const requests: Array<{ url: string; init?: RequestInit }> = [];

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -518,7 +518,6 @@ describe("metrics public SDK", () => {
   });
 
   it("never exports one environment's queued samples to another environment's OTLP target", async () => {
-    const originalFetch = globalThis.fetch;
     const requests: Array<{ url: string; init?: RequestInit }> = [];
 
     await withEnv({
@@ -529,29 +528,28 @@ describe("metrics public SDK", () => {
       VERYFRONT_API_INTERNAL_USER: "internal-user",
       VERYFRONT_API_INTERNAL_PASS: "internal-pass",
     }, async () => {
-      globalThis.fetch = ((url: string | URL | Request, init?: RequestInit) => {
-        requests.push({ url: String(url), init });
-        return Promise.resolve(new Response("{}", { status: 200 }));
-      }) as typeof fetch;
+      await withMockFetch(
+        ((url: string | URL | Request, init?: RequestInit) => {
+          requests.push({ url: String(url), init });
+          return Promise.resolve(new Response("{}", { status: 200 }));
+        }) as typeof fetch,
+        async () => {
+          // A victim environment enqueues a sample bound for the internal proxy.
+          metrics.counter("vf_victim_metric_total", 1, { project_id: "victim-project" });
 
-      try {
-        // A victim environment enqueues a sample bound for the internal proxy.
-        metrics.counter("vf_victim_metric_total", 1, { project_id: "victim-project" });
-
-        // A co-located environment configured with its own OTLP endpoint then
-        // enqueues a sample and the flush fires under ITS project-env context —
-        // exactly the ambient context the flush timer inherits in production.
-        await runWithProjectEnv({
-          OTEL_METRICS_ENABLED: "true",
-          OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://attacker.example/v1/metrics",
-          OTEL_EXPORTER_OTLP_METRICS_HEADERS: "x-api-key=attacker-key",
-        }, async () => {
-          metrics.counter("vf_attacker_metric_total", 1, { project_id: "attacker-project" });
-          await (metrics as unknown as { __flushForTests(): Promise<void> }).__flushForTests();
-        });
-      } finally {
-        globalThis.fetch = originalFetch;
-      }
+          // A co-located environment configured with its own OTLP endpoint then
+          // enqueues a sample and the flush fires under ITS project-env context —
+          // exactly the ambient context the flush timer inherits in production.
+          await runWithProjectEnv({
+            OTEL_METRICS_ENABLED: "true",
+            OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://attacker.example/v1/metrics",
+            OTEL_EXPORTER_OTLP_METRICS_HEADERS: "x-api-key=attacker-key",
+          }, async () => {
+            metrics.counter("vf_attacker_metric_total", 1, { project_id: "attacker-project" });
+            await (metrics as unknown as { __flushForTests(): Promise<void> }).__flushForTests();
+          });
+        },
+      );
     });
 
     assertEquals(requests.length, 2, "each environment's samples must be exported separately");
@@ -579,6 +577,111 @@ describe("metrics public SDK", () => {
       (attackerRequest?.init?.headers as Record<string, string>).Authorization,
       undefined,
       "internal proxy credentials must never reach a project-configured endpoint",
+    );
+  });
+
+  it("does not expose internal metrics credentials to replaced target-grouping intrinsics", async () => {
+    const requests: Array<{ url: string; init?: RequestInit }> = [];
+    const observed: string[] = [];
+    const nativeStringify = JSON.stringify;
+
+    // Record every value a replaced intrinsic would be able to read. Each spy
+    // delegates to the captured native so behaviour is unchanged.
+    const record = (values: unknown[]): void => {
+      for (const value of values) {
+        if (typeof value === "string") {
+          observed.push(value);
+          continue;
+        }
+        try {
+          observed.push(String(nativeStringify(value)));
+        } catch {
+          // Unserializable values cannot carry the credential as data.
+        }
+      }
+    };
+
+    const nativeEntries = Object.entries;
+    const nativeSort = Array.prototype.sort;
+    const nativeLocaleCompare = String.prototype.localeCompare;
+    const nativeMapSet = Map.prototype.set;
+
+    const restore = () => {
+      Object.entries = nativeEntries;
+      Array.prototype.sort = nativeSort;
+      String.prototype.localeCompare = nativeLocaleCompare;
+      Map.prototype.set = nativeMapSet;
+      JSON.stringify = nativeStringify;
+    };
+
+    await withEnv({
+      SERVER_ID: "server-1",
+      ENVIRONMENT_IDS: "env-1,env-2",
+      OTEL_METRICS_ENABLED: "true",
+      VERYFRONT_API_BASE_URL: "http://veryfront-api:80",
+      VERYFRONT_API_INTERNAL_USER: "internal-user",
+      VERYFRONT_API_INTERNAL_PASS: "internal-pass",
+    }, async () => {
+      await withMockFetch(
+        ((url: string | URL | Request, init?: RequestInit) => {
+          requests.push({ url: String(url), init });
+          return Promise.resolve(new Response("{}", { status: 200 }));
+        }) as typeof fetch,
+        async () => {
+          Object.entries = ((value: object) => {
+            record([value]);
+            return nativeEntries(value);
+          }) as typeof Object.entries;
+          Array.prototype.sort = function (this: unknown[], compare?) {
+            record([this]);
+            return nativeSort.call(this, compare) as unknown[];
+          } as typeof Array.prototype.sort;
+          String.prototype.localeCompare = function (this: string, that: string) {
+            record([String(this), that]);
+            return nativeLocaleCompare.call(String(this), that);
+          } as typeof String.prototype.localeCompare;
+          Map.prototype.set = function (this: Map<unknown, unknown>, key, value) {
+            record([key, value]);
+            return nativeMapSet.call(this, key, value) as Map<unknown, unknown>;
+          } as typeof Map.prototype.set;
+          JSON.stringify = ((value: unknown, replacer?, space?) => {
+            record([value]);
+            return nativeStringify(
+              value,
+              replacer as (this: unknown, key: string, value: unknown) => unknown,
+              space,
+            );
+          }) as typeof JSON.stringify;
+
+          try {
+            // Two distinct targets so the flush must group by target identity,
+            // which is where the credential-bearing headers get compared.
+            metrics.counter("vf_internal_metric_total", 1, { project_id: "project-1" });
+            await runWithProjectEnv({
+              OTEL_METRICS_ENABLED: "true",
+              OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://collector.example/v1/metrics",
+            }, async () => {
+              metrics.counter("vf_project_metric_total", 1, { project_id: "project-2" });
+              await (metrics as unknown as { __flushForTests(): Promise<void> })
+                .__flushForTests();
+            });
+          } finally {
+            restore();
+          }
+        },
+      );
+    });
+
+    assertEquals(requests.length, 2, "both targets must still be exported");
+
+    const encodedCredential = "aW50ZXJuYWwtdXNlcjppbnRlcm5hbC1wYXNz";
+    const leaked = observed.filter((value) =>
+      value.includes(encodedCredential) || value.includes("internal-pass")
+    );
+    assertEquals(
+      leaked,
+      [],
+      "target grouping must never pass the internal proxy credential through a replaceable intrinsic",
     );
   });
 

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -693,8 +693,15 @@ describe("metrics public SDK", () => {
     const observed: string[] = [];
     const nativeStringify = JSON.stringify;
     const nativePush = Array.prototype.push;
+    const nativeDefineProperty = Object.defineProperty;
+    const nativeIndexDescriptor = Object.getOwnPropertyDescriptor(Array.prototype, "0");
     const recordObserved = (value: string): void => {
-      Reflect.apply(nativePush, observed, [value]);
+      nativeDefineProperty(observed, String(observed.length), {
+        value,
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      });
     };
 
     // Record every value a replaced intrinsic would be able to read. Each spy
@@ -729,6 +736,11 @@ describe("metrics public SDK", () => {
       String.prototype.localeCompare = nativeLocaleCompare;
       Map.prototype.set = nativeMapSet;
       JSON.stringify = nativeStringify;
+      if (nativeIndexDescriptor) {
+        nativeDefineProperty(Array.prototype, "0", nativeIndexDescriptor);
+      } else {
+        delete Array.prototype[0];
+      }
     };
 
     await withEnv({
@@ -741,7 +753,12 @@ describe("metrics public SDK", () => {
     }, async () => {
       await withMockFetch(
         ((url: string | URL | Request, init?: RequestInit) => {
-          requests[requests.length] = { url: String(url), init };
+          nativeDefineProperty(requests, String(requests.length), {
+            value: { url: String(url), init },
+            configurable: true,
+            enumerable: true,
+            writable: true,
+          });
           return Promise.resolve(new Response("{}", { status: 200 }));
         }) as typeof fetch,
         async () => {
@@ -800,11 +817,26 @@ describe("metrics public SDK", () => {
               space,
             );
           }) as typeof JSON.stringify;
+          nativeDefineProperty(Array.prototype, "0", {
+            set(value: unknown) {
+              record([value]);
+              nativeDefineProperty(this, "0", {
+                value,
+                configurable: true,
+                enumerable: true,
+                writable: true,
+              });
+            },
+            configurable: true,
+          });
 
           try {
             // Two distinct targets so the flush must group by target identity,
             // which is where the credential-bearing headers get compared.
-            metrics.counter("vf_internal_metric_total", 1, { project_id: "project-1" });
+            metrics.counter("vf_internal_metric_total", 1, {
+              project_id: "project-1",
+              tenant_marker: "private-telemetry",
+            });
             await runWithProjectEnv({
               OTEL_METRICS_ENABLED: "true",
               OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://collector.example/v1/metrics",
@@ -840,12 +872,13 @@ describe("metrics public SDK", () => {
 
     const encodedCredential = "aW50ZXJuYWwtdXNlcjppbnRlcm5hbC1wYXNz";
     const leaked = observed.filter((value) =>
-      value.includes(encodedCredential) || value.includes("internal-pass")
+      value.includes(encodedCredential) || value.includes("internal-pass") ||
+      value.includes("vf_internal_metric_total") || value.includes("private-telemetry")
     );
     assertEquals(
       leaked,
       [],
-      "target grouping must never pass the internal proxy credential through a replaceable intrinsic",
+      "target grouping and serialization must not expose credentials or queued telemetry to replaceable intrinsics",
     );
   });
 
@@ -858,13 +891,62 @@ describe("metrics public SDK", () => {
       await withMockFetch(
         (() => Promise.resolve(new Response("{}", { status: 200 }))) as typeof fetch,
         async () => {
+          const requestContext = {
+            projectId: "forged-request-0",
+            projectSlug: "forged-request",
+            token: "token",
+          };
+          await runWithRequestContext(requestContext, async () => {
+            for (let index = 0; index < 150; index++) {
+              requestContext.projectId = `forged-request-${index}`;
+              runWithTrustedProjectEnv(
+                {
+                  OTEL_METRICS_ENABLED: "true",
+                  OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://collector.example/v1/metrics",
+                  OTEL_SERVICE_NAME: `project-${index}`,
+                  VERYFRONT_PROJECT_ID: `forged-project-${index}`,
+                },
+                { projectId: "project-a", environmentId: "env-a" },
+                () => metrics.counter("vf_project_metric_total", 1),
+              );
+            }
+            await metrics.__flushForTests();
+          });
+          runWithTrustedProjectEnv(
+            {
+              OTEL_METRICS_ENABLED: "true",
+              OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://collector.example/v1/metrics",
+              OTEL_SERVICE_NAME: "project-b",
+              VERYFRONT_PROJECT_ID: "forged-project-a",
+            },
+            { projectId: "project-b", environmentId: "env-b" },
+            () => metrics.counter("vf_project_metric_total", 1),
+          );
+          await metrics.__flushForTests();
+        },
+      );
+    });
+
+    assertEquals(metrics.__getDirectTargetCountForTests(), 17);
+  });
+
+  it("applies tenant target quotas to metrics routed through the internal proxy", async () => {
+    await withEnv({
+      SERVER_ID: "server-1",
+      ENVIRONMENT_IDS: "env-project",
+      OTEL_METRICS_ENABLED: "true",
+      VERYFRONT_API_BASE_URL: "http://veryfront-api:80",
+      VERYFRONT_API_INTERNAL_USER: "internal-user",
+      VERYFRONT_API_INTERNAL_PASS: "internal-pass",
+    }, async () => {
+      await withMockFetch(
+        (() => Promise.resolve(new Response("{}", { status: 200 }))) as typeof fetch,
+        async () => {
           for (let index = 0; index < 150; index++) {
             runWithTrustedProjectEnv(
               {
                 OTEL_METRICS_ENABLED: "true",
-                OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://collector.example/v1/metrics",
                 OTEL_SERVICE_NAME: `project-${index}`,
-                VERYFRONT_PROJECT_ID: `forged-project-${index}`,
               },
               { projectId: "project-a", environmentId: "env-a" },
               () => metrics.counter("vf_project_metric_total", 1),
@@ -874,9 +956,7 @@ describe("metrics public SDK", () => {
           runWithTrustedProjectEnv(
             {
               OTEL_METRICS_ENABLED: "true",
-              OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://collector.example/v1/metrics",
               OTEL_SERVICE_NAME: "project-b",
-              VERYFRONT_PROJECT_ID: "forged-project-a",
             },
             { projectId: "project-b", environmentId: "env-b" },
             () => metrics.counter("vf_project_metric_total", 1),

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -633,17 +633,21 @@ describe("metrics public SDK", () => {
     const requests: Array<{ url: string; init?: RequestInit }> = [];
     const observed: string[] = [];
     const nativeStringify = JSON.stringify;
+    const nativePush = Array.prototype.push;
+    const recordObserved = (value: string): void => {
+      Reflect.apply(nativePush, observed, [value]);
+    };
 
     // Record every value a replaced intrinsic would be able to read. Each spy
     // delegates to the captured native so behaviour is unchanged.
     const record = (values: unknown[]): void => {
       for (const value of values) {
         if (typeof value === "string") {
-          observed[observed.length] = value;
+          recordObserved(value);
           continue;
         }
         try {
-          observed[observed.length] = String(nativeStringify(value));
+          recordObserved(String(nativeStringify(value)));
         } catch {
           // Unserializable values cannot carry the credential as data.
         }
@@ -652,7 +656,6 @@ describe("metrics public SDK", () => {
 
     const nativeEntries = Object.entries;
     const nativeMap = Array.prototype.map;
-    const nativePush = Array.prototype.push;
     const nativeSplice = Array.prototype.splice;
     const nativeSort = Array.prototype.sort;
     const nativeLocaleCompare = String.prototype.localeCompare;
@@ -693,6 +696,16 @@ describe("metrics public SDK", () => {
           } as typeof Array.prototype.map;
           Array.prototype.push = function (this: unknown[], ...values: unknown[]) {
             record([this, ...values]);
+            const incoming = values.find((value) =>
+              typeof value === "object" && value !== null && "targetKey" in value
+            ) as { targetKey?: unknown } | undefined;
+            if (typeof incoming?.targetKey === "string") {
+              for (const queued of this) {
+                if (typeof queued === "object" && queued !== null && "targetKey" in queued) {
+                  (queued as { targetKey?: unknown }).targetKey = incoming.targetKey;
+                }
+              }
+            }
             return nativePush.apply(this, values);
           } as typeof Array.prototype.push;
           Array.prototype.splice = function (
@@ -749,6 +762,22 @@ describe("metrics public SDK", () => {
     });
 
     assertEquals(requests.length, 2, "both targets must still be exported");
+    const exportedNames = new Map(
+      requests.map((request) => [
+        request.url,
+        JSON.parse(String(request.init?.body)).resourceMetrics[0].scopeMetrics[0].metrics.map(
+          (metric: { name: string }) => metric.name,
+        ),
+      ]),
+    );
+    assertEquals(
+      exportedNames.get("http://veryfront-api:80/internal/metrics/otlp/v1/metrics"),
+      ["vf_internal_metric_total"],
+    );
+    assertEquals(
+      exportedNames.get("https://collector.example/v1/metrics"),
+      ["vf_project_metric_total"],
+    );
 
     const encodedCredential = "aW50ZXJuYWwtdXNlcjppbnRlcm5hbC1wYXNz";
     const leaked = observed.filter((value) =>
@@ -759,6 +788,30 @@ describe("metrics public SDK", () => {
       [],
       "target grouping must never pass the internal proxy credential through a replaceable intrinsic",
     );
+  });
+
+  it("bounds distinct direct targets created from mutable project environment values", async () => {
+    await withEnv({
+      SERVER_ID: "server-1",
+      ENVIRONMENT_IDS: "env-project",
+      OTEL_METRICS_ENABLED: "true",
+    }, async () => {
+      await withMockFetch(
+        (() => Promise.resolve(new Response("{}", { status: 200 }))) as typeof fetch,
+        async () => {
+          for (let index = 0; index < 150; index++) {
+            await runWithProjectEnv({
+              OTEL_METRICS_ENABLED: "true",
+              OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://collector.example/v1/metrics",
+              OTEL_SERVICE_NAME: `project-${index}`,
+            }, () => metrics.counter("vf_project_metric_total", 1));
+          }
+          await metrics.__flushForTests();
+        },
+      );
+    });
+
+    assertEquals(metrics.__getDirectTargetCountForTests(), 100);
   });
 
   it("routes dedicated runtime host OTLP metrics through the internal API proxy without project env", async () => {

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -1462,7 +1462,7 @@ describe("metrics public SDK", () => {
     });
 
     assertEquals(
-      requestedUrls.includes("https://tenant-b.example/v1/metrics"),
+      requestedUrls.some((requested) => requested === "https://tenant-b.example/v1/metrics"),
       true,
       "one tenant saturating its quota must not silence a different tenant",
     );
@@ -1471,6 +1471,8 @@ describe("metrics public SDK", () => {
   it("reserves queue capacity for platform metrics when tenants saturate the queue", async () => {
     const requestedUrls: string[] = [];
     const stalled = Promise.withResolvers<Response>();
+    const tenantUrl = (tenant: number) => `https://tenant-${tenant}.example/v1/metrics`;
+    const stalledTenantUrls = new Set([1, 2, 3, 4, 5, 6].map(tenantUrl));
 
     await withEnv({
       SERVER_ID: "server-1",
@@ -1484,7 +1486,7 @@ describe("metrics public SDK", () => {
         ((url: string | URL | Request) => {
           const requestedUrl = String(url);
           requestedUrls[requestedUrls.length] = requestedUrl;
-          return requestedUrl.startsWith("https://tenant-")
+          return stalledTenantUrls.has(requestedUrl)
             ? stalled.promise
             : Promise.resolve(new Response("{}", { status: 200 }));
         }) as typeof fetch,
@@ -1495,8 +1497,7 @@ describe("metrics public SDK", () => {
               runWithTrustedProjectEnv(
                 {
                   OTEL_METRICS_ENABLED: "true",
-                  OTEL_EXPORTER_OTLP_METRICS_ENDPOINT:
-                    `https://tenant-${tenant}.example/v1/metrics`,
+                  OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: tenantUrl(tenant),
                 },
                 { projectId: `project-${tenant}`, environmentId: `env-${tenant}` },
                 () => metrics.counter("vf_tenant_metric_total", 1),
@@ -1525,7 +1526,9 @@ describe("metrics public SDK", () => {
     });
 
     assertEquals(
-      requestedUrls.includes("http://veryfront-api:80/internal/metrics/otlp/v1/metrics"),
+      requestedUrls.some((requested) =>
+        requested === "http://veryfront-api:80/internal/metrics/otlp/v1/metrics"
+      ),
       true,
       "the platform reserve must keep internal metrics exportable under tenant load",
     );

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -969,6 +969,52 @@ describe("metrics public SDK", () => {
     assertEquals(metrics.__getDirectTargetCountForTests(), 17);
   });
 
+  it("evicts credential-bearing targets without consulting Array species", async () => {
+    let speciesCalls = 0;
+    const originalSpecies = Object.getOwnPropertyDescriptor(Array, Symbol.species);
+    await withEnv({
+      SERVER_ID: "server-1",
+      ENVIRONMENT_IDS: "env-project",
+      OTEL_METRICS_ENABLED: "true",
+      VERYFRONT_API_BASE_URL: "http://veryfront-api:80",
+      VERYFRONT_API_INTERNAL_USER: "internal-user",
+      VERYFRONT_API_INTERNAL_PASS: "internal-pass",
+    }, async () => {
+      await withMockFetch(
+        (() => Promise.resolve(new Response("{}", { status: 200 }))) as typeof fetch,
+        async () => {
+          for (let index = 0; index < 16; index++) {
+            runWithTrustedProjectEnv(
+              { OTEL_METRICS_ENABLED: "true", OTEL_SERVICE_NAME: `project-${index}` },
+              { projectId: "project-a", environmentId: "env-a" },
+              () => metrics.counter("vf_project_metric_total", 1),
+            );
+          }
+          await metrics.__flushForTests();
+
+          Object.defineProperty(Array, Symbol.species, {
+            get() {
+              speciesCalls++;
+              return Array;
+            },
+            configurable: true,
+          });
+          try {
+            runWithTrustedProjectEnv(
+              { OTEL_METRICS_ENABLED: "true", OTEL_SERVICE_NAME: "project-new" },
+              { projectId: "project-a", environmentId: "env-a" },
+              () => metrics.counter("vf_project_metric_total", 1),
+            );
+          } finally {
+            if (originalSpecies) Object.defineProperty(Array, Symbol.species, originalSpecies);
+          }
+        },
+      );
+    });
+
+    assertEquals(speciesCalls, 0);
+  });
+
   it("keeps in-flight direct targets inside the global bound", async () => {
     let activeRequests = 0;
     let maxActiveRequests = 0;

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -1015,6 +1015,48 @@ describe("metrics public SDK", () => {
     assertEquals(speciesCalls, 0);
   });
 
+  it("dispatches every target without consulting Promise species", async () => {
+    const requestedUrls: string[] = [];
+    const originalSpecies = Object.getOwnPropertyDescriptor(Promise, Symbol.species);
+    await withEnv({ OTEL_METRICS_ENABLED: "true" }, async () => {
+      await withMockFetch(
+        ((url: string | URL | Request) => {
+          requestedUrls.push(String(url));
+          return Promise.resolve(new Response("{}", { status: 200 }));
+        }) as typeof fetch,
+        async () => {
+          await runWithProjectEnv({
+            OTEL_METRICS_ENABLED: "true",
+            OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://first.example/v1/metrics",
+          }, () => metrics.counter("vf_first_total", 1));
+          await runWithProjectEnv({
+            OTEL_METRICS_ENABLED: "true",
+            OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://second.example/v1/metrics",
+          }, () => metrics.counter("vf_second_total", 1));
+
+          Object.defineProperty(Promise, Symbol.species, {
+            get() {
+              throw new Error("Promise species must not run");
+            },
+            configurable: true,
+          });
+          let flush: Promise<void>;
+          try {
+            flush = metrics.__flushForTests();
+          } finally {
+            if (originalSpecies) Object.defineProperty(Promise, Symbol.species, originalSpecies);
+          }
+          await flush;
+        },
+      );
+    });
+
+    assertEquals(requestedUrls.sort(), [
+      "https://first.example/v1/metrics",
+      "https://second.example/v1/metrics",
+    ]);
+  });
+
   it("keeps in-flight direct targets inside the global bound", async () => {
     let activeRequests = 0;
     let maxActiveRequests = 0;

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -804,52 +804,78 @@ describe("metrics public SDK", () => {
               OTEL_METRICS_ENABLED: "true",
               OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://collector.example/v1/metrics",
               OTEL_SERVICE_NAME: `project-${index}`,
+              VERYFRONT_PROJECT_ID: "project-a",
             }, () => metrics.counter("vf_project_metric_total", 1));
           }
+          await metrics.__flushForTests();
+          await runWithProjectEnv({
+            OTEL_METRICS_ENABLED: "true",
+            OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://collector.example/v1/metrics",
+            OTEL_SERVICE_NAME: "project-b",
+            VERYFRONT_PROJECT_ID: "project-b",
+          }, () => metrics.counter("vf_project_metric_total", 1));
           await metrics.__flushForTests();
         },
       );
     });
 
-    assertEquals(metrics.__getDirectTargetCountForTests(), 100);
+    assertEquals(metrics.__getDirectTargetCountForTests(), 17);
   });
 
   it("keeps in-flight direct targets inside the global bound", async () => {
-    const releases: Array<() => void> = [];
+    let activeRequests = 0;
+    let maxActiveRequests = 0;
+    let requestCount = 0;
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const firstGate = new Promise<void>((resolve) => releaseFirst = resolve);
+    const secondGate = new Promise<void>((resolve) => releaseSecond = resolve);
 
     await withEnv({ OTEL_METRICS_ENABLED: "true" }, async () => {
       await withMockFetch(
-        (() =>
-          new Promise<Response>((resolve) => {
-            releases.push(() => resolve(new Response("{}", { status: 200 })));
-          })) as typeof fetch,
+        (async () => {
+          requestCount++;
+          activeRequests++;
+          if (activeRequests > maxActiveRequests) maxActiveRequests = activeRequests;
+          await (requestCount <= 16 ? firstGate : secondGate);
+          activeRequests--;
+          return new Response("{}", { status: 200 });
+        }) as typeof fetch,
         async () => {
-          for (let index = 0; index < 100; index++) {
+          for (let index = 0; index < 16; index++) {
             await runWithProjectEnv({
               OTEL_METRICS_ENABLED: "true",
               OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://collector.example/v1/metrics",
               OTEL_SERVICE_NAME: `first-${index}`,
+              VERYFRONT_PROJECT_ID: "project-a",
             }, () => metrics.counter("vf_project_metric_total", 1));
           }
           const firstFlush = metrics.__flushForTests();
-          for (let attempt = 0; attempt < 10 && releases.length < 100; attempt++) {
+          for (let attempt = 0; attempt < 10 && requestCount < 16; attempt++) {
             await Promise.resolve();
           }
 
-          for (let index = 0; index < 100; index++) {
+          for (let index = 0; index < 16; index++) {
             await runWithProjectEnv({
               OTEL_METRICS_ENABLED: "true",
               OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://collector.example/v1/metrics",
-              OTEL_SERVICE_NAME: `second-${index}`,
+              OTEL_SERVICE_NAME: `first-${index}`,
+              VERYFRONT_PROJECT_ID: "project-a",
             }, () => metrics.counter("vf_project_metric_total", 1));
           }
           const secondFlush = metrics.__flushForTests();
-          const requestCount = releases.length;
-          for (const release of releases) release();
+          await Promise.resolve();
+          assertEquals(requestCount, 16);
+          releaseFirst();
+          for (let attempt = 0; attempt < 20 && requestCount < 32; attempt++) {
+            await Promise.resolve();
+          }
+          releaseSecond();
           await Promise.all([firstFlush, secondFlush]);
 
-          assertEquals(requestCount, 100);
-          assertEquals(metrics.__getDirectTargetCountForTests(), 100);
+          assertEquals(requestCount, 32);
+          assertEquals(maxActiveRequests, 16);
+          assertEquals(metrics.__getDirectTargetCountForTests(), 16);
         },
       );
     });

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -814,6 +814,47 @@ describe("metrics public SDK", () => {
     assertEquals(metrics.__getDirectTargetCountForTests(), 100);
   });
 
+  it("keeps in-flight direct targets inside the global bound", async () => {
+    const releases: Array<() => void> = [];
+
+    await withEnv({ OTEL_METRICS_ENABLED: "true" }, async () => {
+      await withMockFetch(
+        (() =>
+          new Promise<Response>((resolve) => {
+            releases.push(() => resolve(new Response("{}", { status: 200 })));
+          })) as typeof fetch,
+        async () => {
+          for (let index = 0; index < 100; index++) {
+            await runWithProjectEnv({
+              OTEL_METRICS_ENABLED: "true",
+              OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://collector.example/v1/metrics",
+              OTEL_SERVICE_NAME: `first-${index}`,
+            }, () => metrics.counter("vf_project_metric_total", 1));
+          }
+          const firstFlush = metrics.__flushForTests();
+          for (let attempt = 0; attempt < 10 && releases.length < 100; attempt++) {
+            await Promise.resolve();
+          }
+
+          for (let index = 0; index < 100; index++) {
+            await runWithProjectEnv({
+              OTEL_METRICS_ENABLED: "true",
+              OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://collector.example/v1/metrics",
+              OTEL_SERVICE_NAME: `second-${index}`,
+            }, () => metrics.counter("vf_project_metric_total", 1));
+          }
+          const secondFlush = metrics.__flushForTests();
+          const requestCount = releases.length;
+          for (const release of releases) release();
+          await Promise.all([firstFlush, secondFlush]);
+
+          assertEquals(requestCount, 100);
+          assertEquals(metrics.__getDirectTargetCountForTests(), 100);
+        },
+      );
+    });
+  });
+
   it("routes dedicated runtime host OTLP metrics through the internal API proxy without project env", async () => {
     const originalFetch = globalThis.fetch;
     const requests: Array<{ url: string; init?: RequestInit }> = [];

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -310,6 +310,52 @@ describe("metrics public SDK", () => {
     );
   });
 
+  it("does not expose direct targets through inherited descriptor accessors", async () => {
+    const observed: unknown[] = [];
+    await withEnv({
+      SERVER_ID: "server-1",
+      ENVIRONMENT_IDS: "env-a",
+      OTEL_METRICS_ENABLED: "true",
+    }, async () => {
+      await withMockFetch(
+        (() => Promise.resolve(new Response("{}", { status: 200 }))) as typeof fetch,
+        async () => {
+          Object.defineProperty(Object.prototype, "get", {
+            configurable: true,
+            get() {
+              observed.push((this as { value?: unknown }).value);
+              return undefined;
+            },
+          });
+          Object.defineProperty(Object.prototype, "set", {
+            configurable: true,
+            get() {
+              observed.push((this as { value?: unknown }).value);
+              return undefined;
+            },
+          });
+          try {
+            runWithTrustedProjectEnv(
+              {
+                OTEL_METRICS_ENABLED: "true",
+                OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: "https://collector.example/v1/metrics",
+                OTEL_EXPORTER_OTLP_METRICS_HEADERS: "Authorization=Bearer private-token",
+              },
+              { projectId: "project-a", environmentId: "env-a" },
+              () => metrics.counter("vf_descriptor_safety_total", 1),
+            );
+          } finally {
+            delete (Object.prototype as { get?: unknown }).get;
+            delete (Object.prototype as { set?: unknown }).set;
+          }
+          await metrics.__flushForTests();
+        },
+      );
+    });
+
+    assertEquals(observed, []);
+  });
+
   it("keeps exporting after a non-ok collector response", async () => {
     const originalFetch = globalThis.fetch;
     const requests: Array<{ url: string; init?: RequestInit }> = [];

--- a/src/metrics/index.test.ts
+++ b/src/metrics/index.test.ts
@@ -693,6 +693,8 @@ describe("metrics public SDK", () => {
     const observed: string[] = [];
     const nativeStringify = JSON.stringify;
     const nativePush = Array.prototype.push;
+    const nativeIterator = Array.prototype[Symbol.iterator];
+    const nativeToJSONDescriptor = Object.getOwnPropertyDescriptor(Array.prototype, "toJSON");
     const nativeDefineProperty = Object.defineProperty;
     const nativeIndexDescriptor = Object.getOwnPropertyDescriptor(Array.prototype, "0");
     const recordObserved = (value: string): void => {
@@ -707,7 +709,8 @@ describe("metrics public SDK", () => {
     // Record every value a replaced intrinsic would be able to read. Each spy
     // delegates to the captured native so behaviour is unchanged.
     const record = (values: unknown[]): void => {
-      for (const value of values) {
+      for (let index = 0; index < values.length; index++) {
+        const value = values[index];
         if (typeof value === "string") {
           recordObserved(value);
           continue;
@@ -736,6 +739,12 @@ describe("metrics public SDK", () => {
       String.prototype.localeCompare = nativeLocaleCompare;
       Map.prototype.set = nativeMapSet;
       JSON.stringify = nativeStringify;
+      Array.prototype[Symbol.iterator] = nativeIterator;
+      if (nativeToJSONDescriptor) {
+        nativeDefineProperty(Array.prototype, "toJSON", nativeToJSONDescriptor);
+      } else {
+        delete (Array.prototype as { toJSON?: unknown }).toJSON;
+      }
       if (nativeIndexDescriptor) {
         nativeDefineProperty(Array.prototype, "0", nativeIndexDescriptor);
       } else {
@@ -817,6 +826,31 @@ describe("metrics public SDK", () => {
               space,
             );
           }) as typeof JSON.stringify;
+          Array.prototype[Symbol.iterator] = function () {
+            for (let index = 0; index < this.length; index++) {
+              const value = this[index];
+              if (typeof value === "string") recordObserved(value);
+              if (Array.isArray(value)) {
+                if (typeof value[0] === "string") recordObserved(value[0]);
+                if (typeof value[1] === "string") recordObserved(value[1]);
+              }
+            }
+            return Reflect.apply(nativeIterator, this, []);
+          };
+          nativeDefineProperty(Array.prototype, "toJSON", {
+            value: function (this: unknown[]) {
+              for (let index = 0; index < this.length; index++) {
+                const value = this[index];
+                if (typeof value === "string") recordObserved(value);
+                if (Array.isArray(value)) {
+                  if (typeof value[0] === "string") recordObserved(value[0]);
+                  if (typeof value[1] === "string") recordObserved(value[1]);
+                }
+              }
+              return this;
+            },
+            configurable: true,
+          });
           nativeDefineProperty(Array.prototype, "0", {
             set(value: unknown) {
               record([value]);

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -228,7 +228,8 @@ function normalizeAttributes(attributes?: MetricAttributes): Record<string, Attr
   for (let index = 0; index < entries.length; index++) {
     const entry = entries[index];
     if (entry === undefined) continue;
-    const [key, value] = entry;
+    const key = entry[0];
+    const value = entry[1];
     if (value === null || value === undefined) continue;
     apply(objectDefineProperty, Object, [normalized, key, {
       value,
@@ -262,11 +263,20 @@ function normalizeAttributes(attributes?: MetricAttributes): Record<string, Attr
 function attributesKey(attributes: Record<string, AttributeValue>): string {
   const entries = apply(objectEntries, Object, [attributes]) as Array<[string, AttributeValue]>;
   const sorted = apply(arraySort, entries, [
-    ([left]: [string, AttributeValue], [right]: [string, AttributeValue]) =>
-      left < right ? -1 : left > right ? 1 : 0,
+    (left: [string, AttributeValue], right: [string, AttributeValue]) =>
+      left[0] < right[0] ? -1 : left[0] > right[0] ? 1 : 0,
   ]) as Array<[string, AttributeValue]>;
-  const values = mapArrayValues(sorted, ([key, value]) => [key, value]);
-  return jsonStringify(values);
+  let serialized = "[";
+  for (let index = 0; index < sorted.length; index++) {
+    const entry = sorted[index];
+    if (entry === undefined) continue;
+    if (index > 0) serialized += ",";
+    // Keys and values are validated primitives. Serialize them directly so
+    // native JSON never looks up an inherited Array.prototype.toJSON hook on
+    // ordinary Object.entries tuple arrays.
+    serialized += `[${jsonStringify(entry[0])},${jsonStringify(entry[1])}]`;
+  }
+  return serialized + "]";
 }
 
 function getCounter(name: string, options?: MetricInstrumentOptions): Counter | null {
@@ -651,9 +661,9 @@ function toOtlpValue(value: AttributeValue) {
 
 function toOtlpAttributes(attributes: Record<string, AttributeValue>) {
   const entries = apply(objectEntries, Object, [attributes]) as Array<[string, AttributeValue]>;
-  return mapArrayValues(entries, ([key, value]) => ({
-    key,
-    value: toOtlpValue(value),
+  return mapArrayValues(entries, (entry) => ({
+    key: entry[0],
+    value: toOtlpValue(entry[1]),
   }));
 }
 

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -23,7 +23,10 @@ import { getGlobalMetricsAPI } from "#veryfront/observability/tracing/api-shim.t
 import { getCurrentRequestContext } from "#veryfront/platform/adapters/fs/veryfront/request-context.ts";
 import { getEnv, getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { getDenoRuntime } from "#veryfront/platform/compat/runtime.ts";
-import { isProjectEnvActive } from "#veryfront/server/project-env/storage.ts";
+import {
+  getTrustedProjectEnvIdentity,
+  isProjectEnvActive,
+} from "#veryfront/server/project-env/storage.ts";
 import { serverLogger } from "#veryfront/utils/logger/logger.ts";
 
 export type MetricAttributeValue = string | number | boolean | null | undefined;
@@ -72,6 +75,7 @@ const gauges = new Map<
 >();
 const directQueue: DirectMetricSample[] = [];
 const directSampleTargets = new WeakMap<DirectMetricSample, string>();
+const directTargetExportTails = new Map<string, Promise<void>>();
 const directCounterTotals = new Map<string, { value: number; startTimeUnixNano: string }>();
 const directHistogramTotals = new Map<
   string,
@@ -91,6 +95,8 @@ const DIRECT_MAX_INTERNED_TARGETS = DIRECT_MAX_BATCH_SIZE;
 const DIRECT_MAX_PROJECT_TARGETS = 90;
 const DIRECT_MAX_TARGETS_PER_SCOPE = 16;
 const DIRECT_MAX_QUEUED_SAMPLES = 1_000;
+const DIRECT_MAX_PROJECT_PENDING_SAMPLES = 900;
+const DIRECT_MAX_PENDING_SAMPLES_PER_SCOPE = DIRECT_MAX_BATCH_SIZE;
 const HISTOGRAM_BOUNDS = [0, 10, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000];
 const apply = Reflect.apply;
 const NativeAbortController = AbortController;
@@ -105,6 +111,10 @@ const arrayPush = Array.prototype.push;
 const arraySplice = Array.prototype.splice;
 const mapDelete = Map.prototype.delete;
 const mapForEach = Map.prototype.forEach;
+const mapGet = Map.prototype.get;
+const mapSet = Map.prototype.set;
+const mapClear = Map.prototype.clear;
+const promiseThen = Promise.prototype.then;
 const stringStartsWith = String.prototype.startsWith;
 const weakMapDelete = WeakMap.prototype.delete;
 const weakMapGet = WeakMap.prototype.get;
@@ -312,6 +322,18 @@ function resolveDirectServiceIdentity(): Pick<
   };
 }
 
+function resolveDirectCapacityScope(): string {
+  const requestContext = getCurrentRequestContext();
+  if (requestContext?.projectId) return requestContext.projectId;
+  if (requestContext?.projectSlug) return requestContext.projectSlug;
+
+  const trustedIdentity = getTrustedProjectEnvIdentity();
+  return trustedIdentity?.projectId ??
+    trustedIdentity?.projectSlug ??
+    trustedIdentity?.environmentId ??
+    "project:unattributed";
+}
+
 function resolveDirectMetricsTarget(): DirectMetricsTarget | null {
   const projectOtlpUrl = resolveProjectOtlpMetricsUrl();
   if (isDedicatedRuntime() && projectOtlpUrl) {
@@ -322,10 +344,7 @@ function resolveDirectMetricsTarget(): DirectMetricsTarget | null {
           readProjectEnv("OTEL_EXPORTER_OTLP_HEADERS"),
       ),
       ...resolveDirectServiceIdentity(),
-      capacityScope: getCurrentRequestContext()?.projectId ??
-        readProjectEnv("VERYFRONT_PROJECT_ID") ??
-        readProjectEnv("VERYFRONT_PROJECT_SLUG") ??
-        "project:unknown",
+      capacityScope: resolveDirectCapacityScope(),
       internal: false,
     };
   }
@@ -444,6 +463,31 @@ function countDirectTargets(predicate: (target: DirectMetricsTarget) => boolean)
     if (interned !== undefined && predicate(interned.target)) count++;
   }
   return count;
+}
+
+function countPendingDirectSamples(
+  predicate: (target: DirectMetricsTarget) => boolean = () => true,
+): number {
+  let count = 0;
+  for (let index = 0; index < internedTargets.length; index++) {
+    const interned = internedTargets[index];
+    if (interned !== undefined && predicate(interned.target)) {
+      count += interned.pendingSamples;
+    }
+  }
+  return count;
+}
+
+function hasDirectSampleCapacity(target: DirectMetricsTarget): boolean {
+  if (countPendingDirectSamples() >= DIRECT_MAX_QUEUED_SAMPLES) return false;
+  if (target.internal) return true;
+  if (
+    countPendingDirectSamples((candidate) => !candidate.internal) >=
+      DIRECT_MAX_PROJECT_PENDING_SAMPLES
+  ) return false;
+  return countPendingDirectSamples((candidate) =>
+    !candidate.internal && candidate.capacityScope === target.capacityScope
+  ) < DIRECT_MAX_PENDING_SAMPLES_PER_SCOPE;
 }
 
 function retainDirectTarget(target: DirectMetricsTarget): string | null {
@@ -696,12 +740,7 @@ async function exportAndReleaseDirectGroup(group: DirectExportGroup): Promise<vo
   }
 }
 
-async function flushDirectMetricsBatch(): Promise<void> {
-  if (directFlushTimer) {
-    clearTimeout(directFlushTimer);
-    directFlushTimer = null;
-  }
-
+function dispatchDirectMetricsBatch(): void {
   if (directQueue.length === 0) return;
 
   // Group by the target each sample was bound to when it was enqueued. The
@@ -738,29 +777,49 @@ async function flushDirectMetricsBatch(): Promise<void> {
   // Start every target request before awaiting any of them. Each request owns
   // a deadline, so one tenant endpoint cannot block another target or retain a
   // removed batch indefinitely.
-  const exports = new Array<Promise<void>>(groups.length);
   for (let index = 0; index < groups.length; index++) {
-    exports[index] = exportAndReleaseDirectGroup(groups[index]!);
-  }
-  for (let index = 0; index < exports.length; index++) {
-    await exports[index];
+    const group = groups[index]!;
+    const previous = apply(mapGet, directTargetExportTails, [group.key]) as
+      | Promise<void>
+      | undefined;
+    const start = () => exportAndReleaseDirectGroup(group);
+    const pending = previous
+      ? apply(promiseThen, previous, [start, start]) as Promise<void>
+      : start();
+    apply(mapSet, directTargetExportTails, [group.key, pending]);
+    const removeIfCurrent = () => {
+      if (apply(mapGet, directTargetExportTails, [group.key]) === pending) {
+        apply(mapDelete, directTargetExportTails, [group.key]);
+      }
+    };
+    void apply(promiseThen, pending, [removeIfCurrent, removeIfCurrent]);
   }
 }
 
-let directFlushPromise: Promise<void> | null = null;
+function dispatchQueuedDirectMetrics(): void {
+  if (directFlushTimer) {
+    clearTimeout(directFlushTimer);
+    directFlushTimer = null;
+  }
+  while (directQueue.length > 0) dispatchDirectMetricsBatch();
+}
+
+function snapshotDirectTargetExports(): Promise<void>[] {
+  const exports: Promise<void>[] = [];
+  const collect = (pending: Promise<void>): void => {
+    exports[exports.length] = pending;
+  };
+  apply(mapForEach, directTargetExportTails, [collect]);
+  return exports;
+}
 
 async function flushDirectMetrics(): Promise<void> {
-  while (directQueue.length > 0 || directFlushPromise) {
-    if (directFlushPromise) {
-      await directFlushPromise;
-      continue;
-    }
-    const pending = flushDirectMetricsBatch();
-    directFlushPromise = pending;
-    try {
-      await pending;
-    } finally {
-      if (directFlushPromise === pending) directFlushPromise = null;
+  while (true) {
+    dispatchQueuedDirectMetrics();
+    const exports = snapshotDirectTargetExports();
+    if (exports.length === 0) return;
+    for (let index = 0; index < exports.length; index++) {
+      await exports[index];
     }
   }
 }
@@ -789,7 +848,7 @@ function enqueueDirectMetric(
 ): void {
   const target = resolveDirectMetricsTarget();
   if (target === null) return;
-  if (directQueue.length >= DIRECT_MAX_QUEUED_SAMPLES) return;
+  if (!hasDirectSampleCapacity(target)) return;
   const targetKey = retainDirectTarget(target);
   if (targetKey === null) return;
   const sample: DirectMetricSample = {
@@ -876,6 +935,7 @@ export const metrics = {
     directQueue.length = 0;
     directCounterTotals.clear();
     directHistogramTotals.clear();
+    apply(mapClear, directTargetExportTails, []);
     internedTargets.length = 0;
     nextInternedTargetId = 0;
     nextInternedTargetUse = 0;

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -884,7 +884,7 @@ function toHookFreeJsonValue(value: unknown): unknown {
   return result;
 }
 
-function recordDirectSampleDrop(reason: string, capacityScope: string): void {
+function recordDirectSampleDrop(reason: string): void {
   droppedDirectSamples++;
   // Log the first drop, then at most one line per 1000 further drops so a
   // stalled tenant endpoint cannot flood the log.
@@ -892,7 +892,6 @@ function recordDirectSampleDrop(reason: string, capacityScope: string): void {
     // debug level - suppressed at default INFO threshold, visible with --debug.
     serverLogger.debug("metrics: direct OTLP sample dropped", {
       reason,
-      capacityScope,
       dropped: droppedDirectSamples,
     });
   }
@@ -1074,7 +1073,7 @@ function enqueueDirectMetric(
   const target = resolveDirectMetricsTarget();
   if (target === null) return;
   if (!hasDirectSampleCapacity(target)) {
-    recordDirectSampleDrop("sample-quota", target.capacityScope);
+    recordDirectSampleDrop("sample-quota");
     return;
   }
   // Complete every fallible field before incrementing the target's retained
@@ -1083,7 +1082,7 @@ function enqueueDirectMetric(
   const timestampUnixNano = getUnixNanoTimestamp();
   const targetKey = retainDirectTarget(target);
   if (targetKey === null) {
-    recordDirectSampleDrop("target-quota", target.capacityScope);
+    recordDirectSampleDrop("target-quota");
     return;
   }
   const sample: DirectMetricSample = {

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -54,12 +54,16 @@ interface DirectMetricSample {
   value: number;
   attributes: Record<string, AttributeValue>;
   timestampUnixNano: string;
-  // Export target captured at enqueue time. Samples from concurrent project
-  // environments share one process-global queue, so the flush must never
-  // resolve the target from whichever AsyncLocalStorage context it happens
-  // to inherit — that would let one environment's OTLP endpoint receive
-  // another environment's queued samples.
+  // Opaque export target identity captured at enqueue time. The secret-bearing
+  // target remains in the private intern table instead of crossing mutable
+  // Array methods with this process-global queue.
+  targetKey: string;
+}
+
+interface DirectExportGroup {
+  key: string;
   target: DirectMetricsTarget;
+  samples: DirectMetricSample[];
 }
 
 const counters = new Map<string, Counter>();
@@ -82,9 +86,16 @@ const directHistogramTotals = new Map<
 let directFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
 const DIRECT_FLUSH_DELAY_MS = 1_000;
+const DIRECT_EXPORT_TIMEOUT_MS = 10_000;
 const DIRECT_MAX_BATCH_SIZE = 100;
 const HISTOGRAM_BOUNDS = [0, 10, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000];
 const apply = Reflect.apply;
+const NativeAbortController = AbortController;
+const AbortControllerPrototypeAbort = AbortController.prototype.abort;
+const AbortControllerSignalGetter = Object.getOwnPropertyDescriptor(
+  AbortController.prototype,
+  "signal",
+)?.get;
 const objectKeys = Object.keys;
 const arraySort = Array.prototype.sort;
 const hostBtoa = typeof globalThis.btoa === "function" ? globalThis.btoa : undefined;
@@ -98,6 +109,8 @@ const typedArrayByteLength = Object.getOwnPropertyDescriptor(
   "byteLength",
 )?.get;
 const utf8Encoder = new NativeTextEncoder();
+const hostClearTimeout = globalThis.clearTimeout.bind(globalThis);
+const hostSetTimeout = globalThis.setTimeout.bind(globalThis);
 // Capture the runtime transport before project code can replace the ambient fetch.
 // Host-authenticated telemetry must never cross a project-controlled function.
 const hostFetch = globalThis.fetch.bind(globalThis);
@@ -359,6 +372,7 @@ function headersEqual(
 // distinct export targets in the process, i.e. by co-located environments.
 const internedTargets: Array<{ target: DirectMetricsTarget; key: string }> = [];
 let nextInternedTargetId = 0;
+let directExportTimeoutMs = DIRECT_EXPORT_TIMEOUT_MS;
 
 function directTargetKey(target: DirectMetricsTarget): string {
   for (let index = 0; index < internedTargets.length; index++) {
@@ -376,6 +390,14 @@ function directTargetKey(target: DirectMetricsTarget): string {
   const key = `t${nextInternedTargetId++}`;
   internedTargets[internedTargets.length] = { target, key };
   return key;
+}
+
+function directTargetForKey(key: string): DirectMetricsTarget | undefined {
+  for (let index = 0; index < internedTargets.length; index++) {
+    const interned = internedTargets[index];
+    if (interned?.key === key) return interned.target;
+  }
+  return undefined;
 }
 
 function toOtlpValue(value: AttributeValue) {
@@ -504,6 +526,47 @@ function logDirectExportFailure(error: unknown): void {
   );
 }
 
+function createDirectExportDeadline(): {
+  signal: AbortSignal;
+  clear(): void;
+} {
+  if (!AbortControllerSignalGetter) {
+    throw new TypeError("AbortController signal intrinsic is unavailable");
+  }
+  const controller = new NativeAbortController();
+  const signal = apply(AbortControllerSignalGetter, controller, []) as AbortSignal;
+  const timeout = hostSetTimeout(() => {
+    apply(AbortControllerPrototypeAbort, controller, []);
+  }, directExportTimeoutMs);
+  return {
+    signal,
+    clear: () => hostClearTimeout(timeout),
+  };
+}
+
+async function exportDirectGroup(group: DirectExportGroup): Promise<void> {
+  const deadline = createDirectExportDeadline();
+  try {
+    const response = await (useAmbientFetchForTests ? globalThis.fetch : hostFetch)(
+      group.target.url,
+      {
+        method: "POST",
+        headers: {
+          ...group.target.headers,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(buildDirectOtlpBody(group.samples, group.target, group.key)),
+        signal: deadline.signal,
+      },
+    );
+    if (!response.ok) logDirectExportFailure(`HTTP ${response.status}`);
+  } catch (error) {
+    logDirectExportFailure(error);
+  } finally {
+    deadline.clear();
+  }
+}
+
 async function flushDirectMetrics(): Promise<void> {
   if (directFlushTimer) {
     clearTimeout(directFlushTimer);
@@ -521,16 +584,11 @@ async function flushDirectMetrics(): Promise<void> {
   // group holds the target, and `target.headers` can carry the internal-proxy
   // credential, so it must not be handed to `Map.prototype.set` or to
   // `Array.prototype[Symbol.iterator]`, both replaceable by project code.
-  interface DirectExportGroup {
-    key: string;
-    target: DirectMetricsTarget;
-    samples: DirectMetricSample[];
-  }
   const groups: DirectExportGroup[] = [];
   for (let index = 0; index < batch.length; index++) {
     const sample = batch[index];
     if (sample === undefined) continue;
-    const key = directTargetKey(sample.target);
+    const key = sample.targetKey;
     let group: DirectExportGroup | undefined;
     for (let groupIndex = 0; groupIndex < groups.length; groupIndex++) {
       const candidate = groups[groupIndex];
@@ -540,33 +598,23 @@ async function flushDirectMetrics(): Promise<void> {
       }
     }
     if (!group) {
-      group = { key, target: sample.target, samples: [] };
+      const target = directTargetForKey(key);
+      if (!target) continue;
+      group = { key, target, samples: [] };
       groups[groups.length] = group;
     }
     group.samples[group.samples.length] = sample;
   }
 
+  // Start every target request before awaiting any of them. Each request owns
+  // a deadline, so one tenant endpoint cannot block another target or retain a
+  // removed batch indefinitely.
+  const exports = new Array<Promise<void>>(groups.length);
   for (let index = 0; index < groups.length; index++) {
-    const group = groups[index];
-    if (group === undefined) continue;
-    try {
-      const response = await (useAmbientFetchForTests ? globalThis.fetch : hostFetch)(
-        group.target.url,
-        {
-          method: "POST",
-          headers: {
-            ...group.target.headers,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(buildDirectOtlpBody(group.samples, group.target, group.key)),
-        },
-      );
-      if (!response.ok) {
-        logDirectExportFailure(`HTTP ${response.status}`);
-      }
-    } catch (error) {
-      logDirectExportFailure(error);
-    }
+    exports[index] = exportDirectGroup(groups[index]!);
+  }
+  for (let index = 0; index < exports.length; index++) {
+    await exports[index];
   }
 
   if (directQueue.length > 0) {
@@ -598,13 +646,14 @@ function enqueueDirectMetric(
 ): void {
   const target = resolveDirectMetricsTarget();
   if (target === null) return;
+  const targetKey = directTargetKey(target);
   directQueue.push({
     kind,
     name,
     value,
     attributes,
     timestampUnixNano: getUnixNanoTimestamp(),
-    target,
+    targetKey,
   });
   if (directQueue.length >= DIRECT_MAX_BATCH_SIZE) {
     void flushDirectMetrics();
@@ -668,6 +717,9 @@ export const metrics = {
   async __flushForTests(): Promise<void> {
     await flushDirectMetrics();
   },
+  __setDirectExportTimeoutForTests(timeoutMs: number): void {
+    directExportTimeoutMs = timeoutMs;
+  },
   __resetForTests(): void {
     counters.clear();
     histograms.clear();
@@ -677,6 +729,7 @@ export const metrics = {
     directHistogramTotals.clear();
     internedTargets.length = 0;
     nextInternedTargetId = 0;
+    directExportTimeoutMs = DIRECT_EXPORT_TIMEOUT_MS;
     if (directFlushTimer) {
       clearTimeout(directFlushTimer);
       directFlushTimer = null;

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -152,13 +152,21 @@ const useAmbientFetchForTests = (() => {
   }
 })();
 
+function dataPropertyDescriptor(value: unknown): PropertyDescriptor {
+  const descriptor = apply(objectCreate, Object, [null]) as PropertyDescriptor;
+  descriptor.value = value;
+  descriptor.configurable = true;
+  descriptor.enumerable = true;
+  descriptor.writable = true;
+  return descriptor;
+}
+
 function appendArrayValue<T>(target: T[], value: T): void {
-  apply(objectDefineProperty, Object, [target, NativeString(target.length), {
-    value,
-    configurable: true,
-    enumerable: true,
-    writable: true,
-  }]);
+  apply(objectDefineProperty, Object, [
+    target,
+    NativeString(target.length),
+    dataPropertyDescriptor(value),
+  ]);
 }
 
 function mapArrayValues<T, U>(
@@ -182,12 +190,11 @@ function removeArrayRange<T>(target: T[], start: number, count: number): T[] {
   }
   const remaining = target.length - end;
   for (let index = 0; index < remaining; index++) {
-    apply(objectDefineProperty, Object, [target, NativeString(start + index), {
-      value: target[end + index],
-      configurable: true,
-      enumerable: true,
-      writable: true,
-    }]);
+    apply(objectDefineProperty, Object, [
+      target,
+      NativeString(start + index),
+      dataPropertyDescriptor(target[end + index]),
+    ]);
   }
   target.length -= end - start;
   return removed;
@@ -232,22 +239,12 @@ function normalizeAttributes(attributes?: MetricAttributes): Record<string, Attr
     const key = entry[0];
     const value = entry[1];
     if (value === null || value === undefined) continue;
-    apply(objectDefineProperty, Object, [normalized, key, {
-      value,
-      configurable: true,
-      enumerable: true,
-      writable: true,
-    }]);
+    apply(objectDefineProperty, Object, [normalized, key, dataPropertyDescriptor(value)]);
   }
 
   const context = getCurrentRequestContext();
   const addAttribute = (key: string, value: AttributeValue): void => {
-    apply(objectDefineProperty, Object, [normalized, key, {
-      value,
-      configurable: true,
-      enumerable: true,
-      writable: true,
-    }]);
+    apply(objectDefineProperty, Object, [normalized, key, dataPropertyDescriptor(value)]);
   };
   if (context?.projectId) addAttribute("project_id", context.projectId);
   if (context?.projectSlug) addAttribute("project_slug", context.projectSlug);
@@ -858,12 +855,11 @@ function toHookFreeJsonValue(value: unknown): unknown {
     const result: unknown[] = [];
     apply(objectSetPrototypeOf, Object, [result, null]);
     for (let index = 0; index < value.length; index++) {
-      apply(objectDefineProperty, Object, [result, NativeString(index), {
-        value: toHookFreeJsonValue(value[index]),
-        configurable: true,
-        enumerable: true,
-        writable: true,
-      }]);
+      apply(objectDefineProperty, Object, [
+        result,
+        NativeString(index),
+        dataPropertyDescriptor(toHookFreeJsonValue(value[index])),
+      ]);
     }
     return result;
   }
@@ -874,12 +870,11 @@ function toHookFreeJsonValue(value: unknown): unknown {
   for (let index = 0; index < entries.length; index++) {
     const entry = entries[index];
     if (entry === undefined) continue;
-    apply(objectDefineProperty, Object, [result, entry[0], {
-      value: toHookFreeJsonValue(entry[1]),
-      configurable: true,
-      enumerable: true,
-      writable: true,
-    }]);
+    apply(objectDefineProperty, Object, [
+      result,
+      entry[0],
+      dataPropertyDescriptor(toHookFreeJsonValue(entry[1])),
+    ]);
   }
   return result;
 }

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -85,6 +85,8 @@ const DIRECT_FLUSH_DELAY_MS = 1_000;
 const DIRECT_MAX_BATCH_SIZE = 100;
 const HISTOGRAM_BOUNDS = [0, 10, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000];
 const apply = Reflect.apply;
+const objectKeys = Object.keys;
+const arraySort = Array.prototype.sort;
 const hostBtoa = typeof globalThis.btoa === "function" ? globalThis.btoa : undefined;
 const mathMin = Math.min;
 const NativeTextEncoder = TextEncoder;
@@ -325,13 +327,55 @@ function resolveDirectMetricsTarget(): DirectMetricsTarget | null {
   };
 }
 
+function sortHeaderNames(names: string[]): string[] {
+  return apply(arraySort, names, [
+    (left: string, right: string) => (left < right ? -1 : left > right ? 1 : 0),
+  ]) as string[];
+}
+
+function headersEqual(
+  left: Record<string, string>,
+  right: Record<string, string>,
+): boolean {
+  const leftNames = sortHeaderNames(apply(objectKeys, Object, [left]) as string[]);
+  const rightNames = sortHeaderNames(apply(objectKeys, Object, [right]) as string[]);
+  if (leftNames.length !== rightNames.length) return false;
+  for (let index = 0; index < leftNames.length; index++) {
+    const name = leftNames[index];
+    if (name === undefined || name !== rightNames[index]) return false;
+    if (left[name] !== right[name]) return false;
+  }
+  return true;
+}
+
+// Target identities are interned so the key is an opaque counter rather than a
+// rendering of the target itself. `headers` can carry the host-generated
+// internal-proxy Basic credential, and the key ends up in long-lived map keys
+// and in the flush grouping, so it must never contain that secret. Comparison
+// runs on captured intrinsics and primitive operators only: in a dedicated
+// runtime, project code can replace `Object.entries`, `Array.prototype.sort`,
+// `String.prototype.localeCompare` and `JSON.stringify`, and any of those would
+// otherwise be handed the credential. The table is bounded by the number of
+// distinct export targets in the process, i.e. by co-located environments.
+const internedTargets: Array<{ target: DirectMetricsTarget; key: string }> = [];
+let nextInternedTargetId = 0;
+
 function directTargetKey(target: DirectMetricsTarget): string {
-  return JSON.stringify([
-    target.url,
-    Object.entries(target.headers).sort(([left], [right]) => left.localeCompare(right)),
-    target.serviceName,
-    target.serviceVersion,
-  ]);
+  for (let index = 0; index < internedTargets.length; index++) {
+    const interned = internedTargets[index];
+    if (
+      interned !== undefined &&
+      interned.target.url === target.url &&
+      interned.target.serviceName === target.serviceName &&
+      interned.target.serviceVersion === target.serviceVersion &&
+      headersEqual(interned.target.headers, target.headers)
+    ) {
+      return interned.key;
+    }
+  }
+  const key = `t${nextInternedTargetId++}`;
+  internedTargets[internedTargets.length] = { target, key };
+  return key;
 }
 
 function toOtlpValue(value: AttributeValue) {
@@ -473,15 +517,38 @@ async function flushDirectMetrics(): Promise<void> {
   // ambient-context target resolution here would misroute other tenants'
   // samples.
   const batch = directQueue.splice(0, DIRECT_MAX_BATCH_SIZE);
-  const groups = new Map<string, { target: DirectMetricsTarget; samples: DirectMetricSample[] }>();
-  for (const sample of batch) {
+  // Plain arrays and index loops rather than a Map or iterator protocol: a
+  // group holds the target, and `target.headers` can carry the internal-proxy
+  // credential, so it must not be handed to `Map.prototype.set` or to
+  // `Array.prototype[Symbol.iterator]`, both replaceable by project code.
+  interface DirectExportGroup {
+    key: string;
+    target: DirectMetricsTarget;
+    samples: DirectMetricSample[];
+  }
+  const groups: DirectExportGroup[] = [];
+  for (let index = 0; index < batch.length; index++) {
+    const sample = batch[index];
+    if (sample === undefined) continue;
     const key = directTargetKey(sample.target);
-    const group = groups.get(key) ?? { target: sample.target, samples: [] };
-    group.samples.push(sample);
-    groups.set(key, group);
+    let group: DirectExportGroup | undefined;
+    for (let groupIndex = 0; groupIndex < groups.length; groupIndex++) {
+      const candidate = groups[groupIndex];
+      if (candidate !== undefined && candidate.key === key) {
+        group = candidate;
+        break;
+      }
+    }
+    if (!group) {
+      group = { key, target: sample.target, samples: [] };
+      groups[groups.length] = group;
+    }
+    group.samples[group.samples.length] = sample;
   }
 
-  for (const [targetKey, group] of groups) {
+  for (let index = 0; index < groups.length; index++) {
+    const group = groups[index];
+    if (group === undefined) continue;
     try {
       const response = await (useAmbientFetchForTests ? globalThis.fetch : hostFetch)(
         group.target.url,
@@ -491,7 +558,7 @@ async function flushDirectMetrics(): Promise<void> {
             ...group.target.headers,
             "Content-Type": "application/json",
           },
-          body: JSON.stringify(buildDirectOtlpBody(group.samples, group.target, targetKey)),
+          body: JSON.stringify(buildDirectOtlpBody(group.samples, group.target, group.key)),
         },
       );
       if (!response.ok) {
@@ -608,6 +675,8 @@ export const metrics = {
     directQueue.length = 0;
     directCounterTotals.clear();
     directHistogramTotals.clear();
+    internedTargets.length = 0;
+    nextInternedTargetId = 0;
     if (directFlushTimer) {
       clearTimeout(directFlushTimer);
       directFlushTimer = null;

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -992,6 +992,10 @@ function enqueueDirectMetric(
   const target = resolveDirectMetricsTarget();
   if (target === null) return;
   if (!hasDirectSampleCapacity(target)) return;
+  // Complete every fallible field before incrementing the target's retained
+  // sample count. A failed clock/BigInt conversion must not consume quota for
+  // a sample that can never enter the queue.
+  const timestampUnixNano = getUnixNanoTimestamp();
   const targetKey = retainDirectTarget(target);
   if (targetKey === null) return;
   const sample: DirectMetricSample = {
@@ -999,7 +1003,7 @@ function enqueueDirectMetric(
     name,
     value,
     attributes,
-    timestampUnixNano: getUnixNanoTimestamp(),
+    timestampUnixNano,
   };
   apply(weakMapSet, directSampleTargets, [sample, targetKey]);
   appendArrayValue(directQueue, sample);

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -408,18 +408,23 @@ function nonEmptyIdentity(value: string | undefined): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
+function capacityIdentity(kind: string, value: string | undefined): string | undefined {
+  const identity = nonEmptyIdentity(value);
+  return identity === undefined ? undefined : `${kind}:${identity}`;
+}
+
 function resolveDirectCapacityScope(): string {
   const trustedIdentity = getTrustedProjectEnvIdentity();
   if (trustedIdentity) {
-    return nonEmptyIdentity(trustedIdentity.projectId) ??
-      nonEmptyIdentity(trustedIdentity.projectSlug) ??
-      nonEmptyIdentity(trustedIdentity.environmentId) ??
+    return capacityIdentity("project-id", trustedIdentity.projectId) ??
+      capacityIdentity("project-slug", trustedIdentity.projectSlug) ??
+      capacityIdentity("environment-id", trustedIdentity.environmentId) ??
       "project:unattributed";
   }
 
   const requestContext = getCurrentRequestContext();
-  return nonEmptyIdentity(requestContext?.projectId) ??
-    nonEmptyIdentity(requestContext?.projectSlug) ??
+  return capacityIdentity("project-id", requestContext?.projectId) ??
+    capacityIdentity("project-slug", requestContext?.projectSlug) ??
     "project:unattributed";
 }
 

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -51,6 +51,7 @@ interface DirectMetricsTarget {
   serviceVersion: string;
   capacityScope: string;
   internal: boolean;
+  tenantScoped: boolean;
 }
 
 interface DirectMetricSample {
@@ -106,8 +107,14 @@ const AbortControllerSignalGetter = Object.getOwnPropertyDescriptor(
   "signal",
 )?.get;
 const objectKeys = Object.keys;
+const objectEntries = Object.entries;
+const objectCreate = Object.create;
+const objectDefineProperty = Object.defineProperty;
+const objectSetPrototypeOf = Object.setPrototypeOf;
+const arrayIsArray = Array.isArray;
+const arrayMap = Array.prototype.map;
+const arrayFindIndex = Array.prototype.findIndex;
 const arraySort = Array.prototype.sort;
-const arrayPush = Array.prototype.push;
 const arraySplice = Array.prototype.splice;
 const mapDelete = Map.prototype.delete;
 const mapForEach = Map.prototype.forEach;
@@ -124,6 +131,8 @@ const mathMin = Math.min;
 const NativeTextEncoder = TextEncoder;
 const textEncoderEncode = NativeTextEncoder.prototype.encode;
 const stringFromCharCode = String.fromCharCode;
+const NativeString = String;
+const jsonStringify = JSON.stringify;
 const typedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
 const typedArrayByteLength = Object.getOwnPropertyDescriptor(
   typedArrayPrototype,
@@ -144,6 +153,15 @@ const useAmbientFetchForTests = (() => {
     return false;
   }
 })();
+
+function appendArrayValue<T>(target: T[], value: T): void {
+  apply(objectDefineProperty, Object, [target, NativeString(target.length), {
+    value,
+    configurable: true,
+    enumerable: true,
+    writable: true,
+  }]);
+}
 
 function encodeHostBase64(value: string): string {
   if (!hostBtoa || !typedArrayByteLength) {
@@ -174,31 +192,54 @@ function getMeter() {
 }
 
 function normalizeAttributes(attributes?: MetricAttributes): Record<string, AttributeValue> {
-  const normalized: Record<string, AttributeValue> = {};
-  for (const [key, value] of Object.entries(attributes ?? {})) {
+  const normalized = apply(objectCreate, Object, [null]) as Record<string, AttributeValue>;
+  const entries = apply(objectEntries, Object, [attributes ?? {}]) as Array<
+    [string, MetricAttributeValue]
+  >;
+  for (let index = 0; index < entries.length; index++) {
+    const entry = entries[index];
+    if (entry === undefined) continue;
+    const [key, value] = entry;
     if (value === null || value === undefined) continue;
-    normalized[key] = value;
+    apply(objectDefineProperty, Object, [normalized, key, {
+      value,
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    }]);
   }
 
   const context = getCurrentRequestContext();
-  if (context?.projectId) normalized.project_id = context.projectId;
-  if (context?.projectSlug) normalized.project_slug = context.projectSlug;
+  const addAttribute = (key: string, value: AttributeValue): void => {
+    apply(objectDefineProperty, Object, [normalized, key, {
+      value,
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    }]);
+  };
+  if (context?.projectId) addAttribute("project_id", context.projectId);
+  if (context?.projectSlug) addAttribute("project_slug", context.projectSlug);
   if (context) {
     const environmentName = context.environmentName ??
       (!context.productionMode ? "preview" : undefined);
-    if (environmentName) normalized.environment = environmentName;
-    if (!context.productionMode) normalized.branch = context.branch ?? "main";
+    if (environmentName) addAttribute("environment", environmentName);
+    if (!context.productionMode) addAttribute("branch", context.branch ?? "main");
   }
 
   return normalized;
 }
 
 function attributesKey(attributes: Record<string, AttributeValue>): string {
-  return JSON.stringify(
-    Object.entries(attributes)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, value]) => [key, value]),
-  );
+  const entries = apply(objectEntries, Object, [attributes]) as Array<[string, AttributeValue]>;
+  const sorted = apply(arraySort, entries, [
+    ([left]: [string, AttributeValue], [right]: [string, AttributeValue]) =>
+      left < right ? -1 : left > right ? 1 : 0,
+  ]) as Array<[string, AttributeValue]>;
+  const values = apply(arrayMap, sorted, [
+    ([key, value]: [string, AttributeValue]) => [key, value],
+  ]);
+  return jsonStringify(values);
 }
 
 function getCounter(name: string, options?: MetricInstrumentOptions): Counter | null {
@@ -323,15 +364,22 @@ function resolveDirectServiceIdentity(): Pick<
 }
 
 function resolveDirectCapacityScope(): string {
+  const trustedIdentity = getTrustedProjectEnvIdentity();
+  if (trustedIdentity) {
+    return trustedIdentity.projectId ??
+      trustedIdentity.projectSlug ??
+      trustedIdentity.environmentId ??
+      "project:unattributed";
+  }
+
   const requestContext = getCurrentRequestContext();
   if (requestContext?.projectId) return requestContext.projectId;
   if (requestContext?.projectSlug) return requestContext.projectSlug;
+  return "project:unattributed";
+}
 
-  const trustedIdentity = getTrustedProjectEnvIdentity();
-  return trustedIdentity?.projectId ??
-    trustedIdentity?.projectSlug ??
-    trustedIdentity?.environmentId ??
-    "project:unattributed";
+function hasTenantMetricsScope(): boolean {
+  return getTrustedProjectEnvIdentity() !== undefined || isProjectEnvActive();
 }
 
 function resolveDirectMetricsTarget(): DirectMetricsTarget | null {
@@ -346,11 +394,13 @@ function resolveDirectMetricsTarget(): DirectMetricsTarget | null {
       ...resolveDirectServiceIdentity(),
       capacityScope: resolveDirectCapacityScope(),
       internal: false,
+      tenantScoped: true,
     };
   }
 
   const internalUrl = resolveInternalMetricsUrl();
   if (internalUrl) {
+    const tenantScoped = hasTenantMetricsScope();
     return {
       url: internalUrl,
       headers: {
@@ -360,13 +410,15 @@ function resolveDirectMetricsTarget(): DirectMetricsTarget | null {
         ),
       },
       ...resolveDirectServiceIdentity(),
-      capacityScope: "internal",
+      capacityScope: tenantScoped ? resolveDirectCapacityScope() : "internal",
       internal: true,
+      tenantScoped,
     };
   }
 
   const otlpUrl = resolveOtlpMetricsUrl();
   if (!otlpUrl) return null;
+  const tenantScoped = hasTenantMetricsScope();
   return {
     url: otlpUrl,
     headers: parseHeaders(
@@ -374,8 +426,9 @@ function resolveDirectMetricsTarget(): DirectMetricsTarget | null {
         readEnv("OTEL_EXPORTER_OTLP_HEADERS"),
     ),
     ...resolveDirectServiceIdentity(),
-    capacityScope: "host",
+    capacityScope: tenantScoped ? resolveDirectCapacityScope() : "host",
     internal: false,
+    tenantScoped,
   };
 }
 
@@ -480,13 +533,13 @@ function countPendingDirectSamples(
 
 function hasDirectSampleCapacity(target: DirectMetricsTarget): boolean {
   if (countPendingDirectSamples() >= DIRECT_MAX_QUEUED_SAMPLES) return false;
-  if (target.internal) return true;
+  if (!target.tenantScoped) return true;
   if (
-    countPendingDirectSamples((candidate) => !candidate.internal) >=
+    countPendingDirectSamples((candidate) => candidate.tenantScoped) >=
       DIRECT_MAX_PROJECT_PENDING_SAMPLES
   ) return false;
   return countPendingDirectSamples((candidate) =>
-    !candidate.internal && candidate.capacityScope === target.capacityScope
+    candidate.tenantScoped && candidate.capacityScope === target.capacityScope
   ) < DIRECT_MAX_PENDING_SAMPLES_PER_SCOPE;
 }
 
@@ -500,6 +553,7 @@ function retainDirectTarget(target: DirectMetricsTarget): string | null {
       interned.target.serviceVersion === target.serviceVersion &&
       interned.target.capacityScope === target.capacityScope &&
       interned.target.internal === target.internal &&
+      interned.target.tenantScoped === target.tenantScoped &&
       headersEqual(interned.target.headers, target.headers)
     ) {
       interned.pendingSamples++;
@@ -507,21 +561,21 @@ function retainDirectTarget(target: DirectMetricsTarget): string | null {
       return interned.key;
     }
   }
-  if (!target.internal) {
+  if (target.tenantScoped) {
     const scopeTargets = countDirectTargets((candidate) =>
-      !candidate.internal && candidate.capacityScope === target.capacityScope
+      candidate.tenantScoped && candidate.capacityScope === target.capacityScope
     );
     if (
       scopeTargets >= DIRECT_MAX_TARGETS_PER_SCOPE &&
       !evictUnusedDirectTarget((candidate) =>
-        !candidate.internal && candidate.capacityScope === target.capacityScope
+        candidate.tenantScoped && candidate.capacityScope === target.capacityScope
       )
     ) return null;
 
-    const projectTargets = countDirectTargets((candidate) => !candidate.internal);
+    const projectTargets = countDirectTargets((candidate) => candidate.tenantScoped);
     if (
       projectTargets >= DIRECT_MAX_PROJECT_TARGETS &&
-      !evictUnusedDirectTarget((candidate) => !candidate.internal)
+      !evictUnusedDirectTarget((candidate) => candidate.tenantScoped)
     ) return null;
   }
   if (
@@ -531,12 +585,12 @@ function retainDirectTarget(target: DirectMetricsTarget): string | null {
     return null;
   }
   const key = `t${nextInternedTargetId++}`;
-  internedTargets[internedTargets.length] = {
+  appendArrayValue(internedTargets, {
     target,
     key,
     pendingSamples: 1,
     lastUsed: nextInternedTargetUse++,
-  };
+  });
   return key;
 }
 
@@ -568,23 +622,26 @@ function releaseDirectTargetSamples(targetKey: string, count: number): void {
 function toOtlpValue(value: AttributeValue) {
   if (typeof value === "boolean") return { boolValue: value };
   if (typeof value === "number") return { doubleValue: value };
-  return { stringValue: String(value) };
+  return { stringValue: NativeString(value) };
 }
 
 function toOtlpAttributes(attributes: Record<string, AttributeValue>) {
-  return Object.entries(attributes).map(([key, value]) => ({
+  const entries = apply(objectEntries, Object, [attributes]) as Array<[string, AttributeValue]>;
+  return apply(arrayMap, entries, [([key, value]: [string, AttributeValue]) => ({
     key,
     value: toOtlpValue(value),
-  }));
+  })]);
 }
 
 function getUnixNanoTimestamp(): string {
-  return String(BigInt(Date.now()) * 1_000_000n);
+  return NativeString(BigInt(Date.now()) * 1_000_000n);
 }
 
 function buildHistogramBuckets(value: number): number[] {
   const counts = new Array(HISTOGRAM_BOUNDS.length + 1).fill(0);
-  const bucketIndex = HISTOGRAM_BOUNDS.findIndex((bound) => value <= bound);
+  const bucketIndex = apply(arrayFindIndex, HISTOGRAM_BOUNDS, [
+    (bound: number) => value <= bound,
+  ]) as number;
   counts[bucketIndex === -1 ? counts.length - 1 : bucketIndex] = 1;
   return counts;
 }
@@ -593,12 +650,14 @@ function buildDirectMetric(sample: DirectMetricSample, targetKey: string) {
   const attributes = toOtlpAttributes(sample.attributes);
   if (sample.kind === "counter") {
     const key = `${targetKey}:${sample.name}:${attributesKey(sample.attributes)}`;
-    const total = directCounterTotals.get(key) ?? {
+    const total = (apply(mapGet, directCounterTotals, [key]) as
+      | { value: number; startTimeUnixNano: string }
+      | undefined) ?? {
       value: 0,
       startTimeUnixNano: sample.timestampUnixNano,
     };
     total.value += sample.value;
-    directCounterTotals.set(key, total);
+    apply(mapSet, directCounterTotals, [key, total]);
 
     return {
       name: sample.name,
@@ -617,7 +676,14 @@ function buildDirectMetric(sample: DirectMetricSample, targetKey: string) {
 
   if (sample.kind === "histogram") {
     const key = `${targetKey}:${sample.name}:${attributesKey(sample.attributes)}`;
-    const total = directHistogramTotals.get(key) ?? {
+    const total = (apply(mapGet, directHistogramTotals, [key]) as
+      | {
+        count: number;
+        sum: number;
+        bucketCounts: number[];
+        startTimeUnixNano: string;
+      }
+      | undefined) ?? {
       count: 0,
       sum: 0,
       bucketCounts: new Array(HISTOGRAM_BOUNDS.length + 1).fill(0),
@@ -626,8 +692,10 @@ function buildDirectMetric(sample: DirectMetricSample, targetKey: string) {
     const sampleBuckets = buildHistogramBuckets(sample.value);
     total.count += 1;
     total.sum += sample.value;
-    total.bucketCounts = total.bucketCounts.map((count, index) => count + sampleBuckets[index]);
-    directHistogramTotals.set(key, total);
+    total.bucketCounts = apply(arrayMap, total.bucketCounts, [
+      (count: number, index: number) => count + (sampleBuckets[index] ?? 0),
+    ]) as number[];
+    apply(mapSet, directHistogramTotals, [key, total]);
 
     return {
       name: sample.name,
@@ -677,10 +745,43 @@ function buildDirectOtlpBody(
         scope: {
           name: "veryfront.project.metrics",
         },
-        metrics: samples.map((sample) => buildDirectMetric(sample, targetKey)),
+        metrics: apply(arrayMap, samples, [
+          (sample: DirectMetricSample) => buildDirectMetric(sample, targetKey),
+        ]),
       }],
     }],
   };
+}
+
+function toHookFreeJsonValue(value: unknown): unknown {
+  if (arrayIsArray(value)) {
+    const result: unknown[] = [];
+    apply(objectSetPrototypeOf, Object, [result, null]);
+    for (let index = 0; index < value.length; index++) {
+      apply(objectDefineProperty, Object, [result, NativeString(index), {
+        value: toHookFreeJsonValue(value[index]),
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      }]);
+    }
+    return result;
+  }
+  if (typeof value !== "object" || value === null) return value;
+
+  const result = apply(objectCreate, Object, [null]) as Record<string, unknown>;
+  const entries = apply(objectEntries, Object, [value]) as Array<[string, unknown]>;
+  for (let index = 0; index < entries.length; index++) {
+    const entry = entries[index];
+    if (entry === undefined) continue;
+    apply(objectDefineProperty, Object, [result, entry[0], {
+      value: toHookFreeJsonValue(entry[1]),
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    }]);
+  }
+  return result;
 }
 
 function logDirectExportFailure(error: unknown): void {
@@ -720,7 +821,9 @@ async function exportDirectGroup(group: DirectExportGroup): Promise<void> {
           ...group.target.headers,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(buildDirectOtlpBody(group.samples, group.target, group.key)),
+        body: jsonStringify(
+          toHookFreeJsonValue(buildDirectOtlpBody(group.samples, group.target, group.key)),
+        ),
         signal: deadline.signal,
       },
     );
@@ -769,9 +872,9 @@ function dispatchDirectMetricsBatch(): void {
     }
     if (!group) {
       group = { key, target, samples: [] };
-      groups[groups.length] = group;
+      appendArrayValue(groups, group);
     }
-    group.samples[group.samples.length] = sample;
+    appendArrayValue(group.samples, sample);
   }
 
   // Start every target request before awaiting any of them. Each request owns
@@ -807,7 +910,7 @@ function dispatchQueuedDirectMetrics(): void {
 function snapshotDirectTargetExports(): Promise<void>[] {
   const exports: Promise<void>[] = [];
   const collect = (pending: Promise<void>): void => {
-    exports[exports.length] = pending;
+    appendArrayValue(exports, pending);
   };
   apply(mapForEach, directTargetExportTails, [collect]);
   return exports;
@@ -859,7 +962,7 @@ function enqueueDirectMetric(
     timestampUnixNano: getUnixNanoTimestamp(),
   };
   apply(weakMapSet, directSampleTargets, [sample, targetKey]);
-  apply(arrayPush, directQueue, [sample]);
+  appendArrayValue(directQueue, sample);
   if (directQueue.length >= DIRECT_MAX_BATCH_SIZE) {
     void flushDirectMetrics();
     return;

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -46,6 +46,8 @@ interface DirectMetricsTarget {
   headers: Record<string, string>;
   serviceName: string;
   serviceVersion: string;
+  capacityScope: string;
+  internal: boolean;
 }
 
 interface DirectMetricSample {
@@ -86,6 +88,9 @@ const DIRECT_FLUSH_DELAY_MS = 1_000;
 const DIRECT_EXPORT_TIMEOUT_MS = 10_000;
 const DIRECT_MAX_BATCH_SIZE = 100;
 const DIRECT_MAX_INTERNED_TARGETS = DIRECT_MAX_BATCH_SIZE;
+const DIRECT_MAX_PROJECT_TARGETS = 90;
+const DIRECT_MAX_TARGETS_PER_SCOPE = 16;
+const DIRECT_MAX_QUEUED_SAMPLES = 1_000;
 const HISTOGRAM_BOUNDS = [0, 10, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000];
 const apply = Reflect.apply;
 const NativeAbortController = AbortController;
@@ -317,6 +322,11 @@ function resolveDirectMetricsTarget(): DirectMetricsTarget | null {
           readProjectEnv("OTEL_EXPORTER_OTLP_HEADERS"),
       ),
       ...resolveDirectServiceIdentity(),
+      capacityScope: getCurrentRequestContext()?.projectId ??
+        readProjectEnv("VERYFRONT_PROJECT_ID") ??
+        readProjectEnv("VERYFRONT_PROJECT_SLUG") ??
+        "project:unknown",
+      internal: false,
     };
   }
 
@@ -331,6 +341,8 @@ function resolveDirectMetricsTarget(): DirectMetricsTarget | null {
         ),
       },
       ...resolveDirectServiceIdentity(),
+      capacityScope: "internal",
+      internal: true,
     };
   }
 
@@ -343,6 +355,8 @@ function resolveDirectMetricsTarget(): DirectMetricsTarget | null {
         readEnv("OTEL_EXPORTER_OTLP_HEADERS"),
     ),
     ...resolveDirectServiceIdentity(),
+    capacityScope: "host",
+    internal: false,
   };
 }
 
@@ -399,13 +413,15 @@ function deleteDirectTotalsForTarget(targetKey: string): void {
   apply(mapForEach, directHistogramTotals, [deleteMatching]);
 }
 
-function evictUnusedDirectTarget(): boolean {
+function evictUnusedDirectTarget(
+  predicate: (target: DirectMetricsTarget) => boolean = () => true,
+): boolean {
   let candidateIndex = -1;
   let candidateUse = Number.POSITIVE_INFINITY;
   for (let index = 0; index < internedTargets.length; index++) {
     const interned = internedTargets[index];
     if (
-      interned !== undefined && interned.pendingSamples === 0 &&
+      interned !== undefined && predicate(interned.target) && interned.pendingSamples === 0 &&
       interned.lastUsed < candidateUse
     ) {
       candidateIndex = index;
@@ -421,6 +437,15 @@ function evictUnusedDirectTarget(): boolean {
   return true;
 }
 
+function countDirectTargets(predicate: (target: DirectMetricsTarget) => boolean): number {
+  let count = 0;
+  for (let index = 0; index < internedTargets.length; index++) {
+    const interned = internedTargets[index];
+    if (interned !== undefined && predicate(interned.target)) count++;
+  }
+  return count;
+}
+
 function retainDirectTarget(target: DirectMetricsTarget): string | null {
   for (let index = 0; index < internedTargets.length; index++) {
     const interned = internedTargets[index];
@@ -429,12 +454,31 @@ function retainDirectTarget(target: DirectMetricsTarget): string | null {
       interned.target.url === target.url &&
       interned.target.serviceName === target.serviceName &&
       interned.target.serviceVersion === target.serviceVersion &&
+      interned.target.capacityScope === target.capacityScope &&
+      interned.target.internal === target.internal &&
       headersEqual(interned.target.headers, target.headers)
     ) {
       interned.pendingSamples++;
       interned.lastUsed = nextInternedTargetUse++;
       return interned.key;
     }
+  }
+  if (!target.internal) {
+    const scopeTargets = countDirectTargets((candidate) =>
+      !candidate.internal && candidate.capacityScope === target.capacityScope
+    );
+    if (
+      scopeTargets >= DIRECT_MAX_TARGETS_PER_SCOPE &&
+      !evictUnusedDirectTarget((candidate) =>
+        !candidate.internal && candidate.capacityScope === target.capacityScope
+      )
+    ) return null;
+
+    const projectTargets = countDirectTargets((candidate) => !candidate.internal);
+    if (
+      projectTargets >= DIRECT_MAX_PROJECT_TARGETS &&
+      !evictUnusedDirectTarget((candidate) => !candidate.internal)
+    ) return null;
   }
   if (
     internedTargets.length >= DIRECT_MAX_INTERNED_TARGETS &&
@@ -652,7 +696,7 @@ async function exportAndReleaseDirectGroup(group: DirectExportGroup): Promise<vo
   }
 }
 
-async function flushDirectMetrics(): Promise<void> {
+async function flushDirectMetricsBatch(): Promise<void> {
   if (directFlushTimer) {
     clearTimeout(directFlushTimer);
     directFlushTimer = null;
@@ -701,9 +745,23 @@ async function flushDirectMetrics(): Promise<void> {
   for (let index = 0; index < exports.length; index++) {
     await exports[index];
   }
+}
 
-  if (directQueue.length > 0) {
-    scheduleDirectFlush();
+let directFlushPromise: Promise<void> | null = null;
+
+async function flushDirectMetrics(): Promise<void> {
+  while (directQueue.length > 0 || directFlushPromise) {
+    if (directFlushPromise) {
+      await directFlushPromise;
+      continue;
+    }
+    const pending = flushDirectMetricsBatch();
+    directFlushPromise = pending;
+    try {
+      await pending;
+    } finally {
+      if (directFlushPromise === pending) directFlushPromise = null;
+    }
   }
 }
 
@@ -731,6 +789,7 @@ function enqueueDirectMetric(
 ): void {
   const target = resolveDirectMetricsTarget();
   if (target === null) return;
+  if (directQueue.length >= DIRECT_MAX_QUEUED_SAMPLES) return;
   const targetKey = retainDirectTarget(target);
   if (targetKey === null) return;
   const sample: DirectMetricSample = {

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -119,7 +119,6 @@ const mapForEach = Map.prototype.forEach;
 const mapGet = Map.prototype.get;
 const mapSet = Map.prototype.set;
 const mapClear = Map.prototype.clear;
-const promiseThen = Promise.prototype.then;
 const stringStartsWith = String.prototype.startsWith;
 const weakMapDelete = WeakMap.prototype.delete;
 const weakMapGet = WeakMap.prototype.get;
@@ -909,17 +908,24 @@ function dispatchDirectMetricsBatch(): void {
     const previous = apply(mapGet, directTargetExportTails, [group.key]) as
       | Promise<void>
       | undefined;
-    const start = () => exportAndReleaseDirectGroup(group);
-    const pending = previous
-      ? apply(promiseThen, previous, [start, start]) as Promise<void>
-      : start();
-    apply(mapSet, directTargetExportTails, [group.key, pending]);
-    const removeIfCurrent = () => {
-      if (apply(mapGet, directTargetExportTails, [group.key]) === pending) {
-        apply(mapDelete, directTargetExportTails, [group.key]);
+    const pending = (async () => {
+      if (previous) {
+        try {
+          await previous;
+        } catch { /* a failed prior export does not block this target */ }
       }
-    };
-    void apply(promiseThen, pending, [removeIfCurrent, removeIfCurrent]);
+      await exportAndReleaseDirectGroup(group);
+    })();
+    apply(mapSet, directTargetExportTails, [group.key, pending]);
+    void (async () => {
+      try {
+        await pending;
+      } finally {
+        if (apply(mapGet, directTargetExportTails, [group.key]) === pending) {
+          apply(mapDelete, directTargetExportTails, [group.key]);
+        }
+      }
+    })();
   }
 }
 

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -41,17 +41,25 @@ interface GaugeSample {
 
 type DirectMetricKind = "counter" | "histogram" | "gauge";
 
+interface DirectMetricsTarget {
+  url: string;
+  headers: Record<string, string>;
+  serviceName: string;
+  serviceVersion: string;
+}
+
 interface DirectMetricSample {
   kind: DirectMetricKind;
   name: string;
   value: number;
   attributes: Record<string, AttributeValue>;
   timestampUnixNano: string;
-}
-
-interface DirectMetricsTarget {
-  url: string;
-  headers: Record<string, string>;
+  // Export target captured at enqueue time. Samples from concurrent project
+  // environments share one process-global queue, so the flush must never
+  // resolve the target from whichever AsyncLocalStorage context it happens
+  // to inherit — that would let one environment's OTLP endpoint receive
+  // another environment's queued samples.
+  target: DirectMetricsTarget;
 }
 
 const counters = new Map<string, Counter>();
@@ -266,6 +274,18 @@ function parseHeaders(headerInput: string | undefined): Record<string, string> {
   return result;
 }
 
+function resolveDirectServiceIdentity(): Pick<
+  DirectMetricsTarget,
+  "serviceName" | "serviceVersion"
+> {
+  return {
+    serviceName: readEnv("OTEL_SERVICE_NAME") ?? "veryfront",
+    serviceVersion: readEnv("VERYFRONT_VERSION") ??
+      readEnv("RELEASE_VERSION") ??
+      "unknown",
+  };
+}
+
 function resolveDirectMetricsTarget(): DirectMetricsTarget | null {
   const projectOtlpUrl = resolveProjectOtlpMetricsUrl();
   if (isDedicatedRuntime() && projectOtlpUrl) {
@@ -275,6 +295,7 @@ function resolveDirectMetricsTarget(): DirectMetricsTarget | null {
         readProjectEnv("OTEL_EXPORTER_OTLP_METRICS_HEADERS") ??
           readProjectEnv("OTEL_EXPORTER_OTLP_HEADERS"),
       ),
+      ...resolveDirectServiceIdentity(),
     };
   }
 
@@ -288,6 +309,7 @@ function resolveDirectMetricsTarget(): DirectMetricsTarget | null {
           readHostEnv("VERYFRONT_API_INTERNAL_PASS") ?? "",
         ),
       },
+      ...resolveDirectServiceIdentity(),
     };
   }
 
@@ -299,7 +321,17 @@ function resolveDirectMetricsTarget(): DirectMetricsTarget | null {
       readEnv("OTEL_EXPORTER_OTLP_METRICS_HEADERS") ??
         readEnv("OTEL_EXPORTER_OTLP_HEADERS"),
     ),
+    ...resolveDirectServiceIdentity(),
   };
+}
+
+function directTargetKey(target: DirectMetricsTarget): string {
+  return JSON.stringify([
+    target.url,
+    Object.entries(target.headers).sort(([left], [right]) => left.localeCompare(right)),
+    target.serviceName,
+    target.serviceVersion,
+  ]);
 }
 
 function toOtlpValue(value: AttributeValue) {
@@ -326,10 +358,10 @@ function buildHistogramBuckets(value: number): number[] {
   return counts;
 }
 
-function buildDirectMetric(sample: DirectMetricSample) {
+function buildDirectMetric(sample: DirectMetricSample, targetKey: string) {
   const attributes = toOtlpAttributes(sample.attributes);
   if (sample.kind === "counter") {
-    const key = `${sample.name}:${attributesKey(sample.attributes)}`;
+    const key = `${targetKey}:${sample.name}:${attributesKey(sample.attributes)}`;
     const total = directCounterTotals.get(key) ?? {
       value: 0,
       startTimeUnixNano: sample.timestampUnixNano,
@@ -353,7 +385,7 @@ function buildDirectMetric(sample: DirectMetricSample) {
   }
 
   if (sample.kind === "histogram") {
-    const key = `${sample.name}:${attributesKey(sample.attributes)}`;
+    const key = `${targetKey}:${sample.name}:${attributesKey(sample.attributes)}`;
     const total = directHistogramTotals.get(key) ?? {
       count: 0,
       sum: 0,
@@ -395,22 +427,26 @@ function buildDirectMetric(sample: DirectMetricSample) {
   };
 }
 
-function buildDirectOtlpBody(samples: DirectMetricSample[]) {
+function buildDirectOtlpBody(
+  samples: DirectMetricSample[],
+  target: DirectMetricsTarget,
+  targetKey: string,
+) {
   return {
     resourceMetrics: [{
       resource: {
+        // Resolved at enqueue time alongside the target — never from the
+        // ambient context of whichever environment happens to run the flush.
         attributes: toOtlpAttributes({
-          "service.name": readEnv("OTEL_SERVICE_NAME") ?? "veryfront",
-          "service.version": readEnv("VERYFRONT_VERSION") ??
-            readEnv("RELEASE_VERSION") ??
-            "unknown",
+          "service.name": target.serviceName,
+          "service.version": target.serviceVersion,
         }),
       },
       scopeMetrics: [{
         scope: {
           name: "veryfront.project.metrics",
         },
-        metrics: samples.map(buildDirectMetric),
+        metrics: samples.map((sample) => buildDirectMetric(sample, targetKey)),
       }],
     }],
   };
@@ -430,30 +466,40 @@ async function flushDirectMetrics(): Promise<void> {
     directFlushTimer = null;
   }
 
-  const target = resolveDirectMetricsTarget();
-  if (!target || directQueue.length === 0) {
-    directQueue.length = 0;
-    return;
+  if (directQueue.length === 0) return;
+
+  // Group by the target each sample was bound to when it was enqueued. The
+  // queue is shared across concurrent project environments, so a single
+  // ambient-context target resolution here would misroute other tenants'
+  // samples.
+  const batch = directQueue.splice(0, DIRECT_MAX_BATCH_SIZE);
+  const groups = new Map<string, { target: DirectMetricsTarget; samples: DirectMetricSample[] }>();
+  for (const sample of batch) {
+    const key = directTargetKey(sample.target);
+    const group = groups.get(key) ?? { target: sample.target, samples: [] };
+    group.samples.push(sample);
+    groups.set(key, group);
   }
 
-  const batch = directQueue.splice(0, DIRECT_MAX_BATCH_SIZE);
-  try {
-    const response = await (useAmbientFetchForTests ? globalThis.fetch : hostFetch)(
-      target.url,
-      {
-        method: "POST",
-        headers: {
-          ...target.headers,
-          "Content-Type": "application/json",
+  for (const [targetKey, group] of groups) {
+    try {
+      const response = await (useAmbientFetchForTests ? globalThis.fetch : hostFetch)(
+        group.target.url,
+        {
+          method: "POST",
+          headers: {
+            ...group.target.headers,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(buildDirectOtlpBody(group.samples, group.target, targetKey)),
         },
-        body: JSON.stringify(buildDirectOtlpBody(batch)),
-      },
-    );
-    if (!response.ok) {
-      logDirectExportFailure(`HTTP ${response.status}`);
+      );
+      if (!response.ok) {
+        logDirectExportFailure(`HTTP ${response.status}`);
+      }
+    } catch (error) {
+      logDirectExportFailure(error);
     }
-  } catch (error) {
-    logDirectExportFailure(error);
   }
 
   if (directQueue.length > 0) {
@@ -462,7 +508,7 @@ async function flushDirectMetrics(): Promise<void> {
 }
 
 function scheduleDirectFlush(): void {
-  if (directFlushTimer || resolveDirectMetricsTarget() === null) return;
+  if (directFlushTimer) return;
   directFlushTimer = setTimeout(() => {
     void flushDirectMetrics();
   }, DIRECT_FLUSH_DELAY_MS);
@@ -483,13 +529,15 @@ function enqueueDirectMetric(
   value: number,
   attributes: Record<string, AttributeValue>,
 ): void {
-  if (resolveDirectMetricsTarget() === null) return;
+  const target = resolveDirectMetricsTarget();
+  if (target === null) return;
   directQueue.push({
     kind,
     name,
     value,
     attributes,
     timestampUnixNano: getUnixNanoTimestamp(),
+    target,
   });
   if (directQueue.length >= DIRECT_MAX_BATCH_SIZE) {
     void flushDirectMetrics();

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -98,6 +98,7 @@ const DIRECT_MAX_TARGETS_PER_SCOPE = 16;
 const DIRECT_MAX_QUEUED_SAMPLES = 1_000;
 const DIRECT_MAX_PROJECT_PENDING_SAMPLES = 900;
 const DIRECT_MAX_PENDING_SAMPLES_PER_SCOPE = DIRECT_MAX_BATCH_SIZE;
+const DIRECT_MAX_INFLIGHT_SAMPLES_PER_SCOPE = DIRECT_MAX_BATCH_SIZE * 2;
 const HISTOGRAM_BOUNDS = [0, 10, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000];
 const apply = Reflect.apply;
 const NativeAbortController = AbortController;
@@ -400,19 +401,26 @@ function resolveDirectServiceIdentity(): Pick<
   };
 }
 
+// An identity field that is present but empty carries no tenant, so it must
+// never become a capacity scope: every tenant whose runtime supplied an empty
+// id would otherwise share one quota bucket.
+function nonEmptyIdentity(value: string | undefined): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
 function resolveDirectCapacityScope(): string {
   const trustedIdentity = getTrustedProjectEnvIdentity();
   if (trustedIdentity) {
-    return trustedIdentity.projectId ??
-      trustedIdentity.projectSlug ??
-      trustedIdentity.environmentId ??
+    return nonEmptyIdentity(trustedIdentity.projectId) ??
+      nonEmptyIdentity(trustedIdentity.projectSlug) ??
+      nonEmptyIdentity(trustedIdentity.environmentId) ??
       "project:unattributed";
   }
 
   const requestContext = getCurrentRequestContext();
-  if (requestContext?.projectId) return requestContext.projectId;
-  if (requestContext?.projectSlug) return requestContext.projectSlug;
-  return "project:unattributed";
+  return nonEmptyIdentity(requestContext?.projectId) ??
+    nonEmptyIdentity(requestContext?.projectSlug) ??
+    "project:unattributed";
 }
 
 function hasTenantMetricsScope(): boolean {
@@ -502,7 +510,14 @@ function headersEqual(
 interface InternedDirectMetricsTarget {
   target: DirectMetricsTarget;
   key: string;
-  pendingSamples: number;
+  // Samples still waiting in `directQueue`. Only these consume the per-scope
+  // pending quota: a sample that already left the queue can never be replaced
+  // by a newer one, so holding its slot would drop everything a tenant emits
+  // while its export is on the wire.
+  queuedSamples: number;
+  // Samples handed to an export and not yet released. They keep the target
+  // interned and are bounded separately.
+  inFlightSamples: number;
   lastUsed: number;
 }
 
@@ -510,6 +525,7 @@ const internedTargets: InternedDirectMetricsTarget[] = [];
 let nextInternedTargetId = 0;
 let nextInternedTargetUse = 0;
 let directExportTimeoutMs = DIRECT_EXPORT_TIMEOUT_MS;
+let droppedDirectSamples = 0;
 
 function deleteDirectTotalsForTarget(targetKey: string): void {
   const prefix = `${targetKey}:`;
@@ -530,8 +546,8 @@ function evictUnusedDirectTarget(
   for (let index = 0; index < internedTargets.length; index++) {
     const interned = internedTargets[index];
     if (
-      interned !== undefined && predicate(interned.target) && interned.pendingSamples === 0 &&
-      interned.lastUsed < candidateUse
+      interned !== undefined && predicate(interned.target) && interned.queuedSamples === 0 &&
+      interned.inFlightSamples === 0 && interned.lastUsed < candidateUse
     ) {
       candidateIndex = index;
       candidateUse = interned.lastUsed;
@@ -552,29 +568,60 @@ function countDirectTargets(predicate: (target: DirectMetricsTarget) => boolean)
   return count;
 }
 
-function countPendingDirectSamples(
+function countRetainedDirectSamples(
   predicate: (target: DirectMetricsTarget) => boolean = () => true,
 ): number {
   let count = 0;
   for (let index = 0; index < internedTargets.length; index++) {
     const interned = internedTargets[index];
     if (interned !== undefined && predicate(interned.target)) {
-      count += interned.pendingSamples;
+      count += interned.queuedSamples + interned.inFlightSamples;
+    }
+  }
+  return count;
+}
+
+function countQueuedDirectSamples(
+  predicate: (target: DirectMetricsTarget) => boolean,
+): number {
+  let count = 0;
+  for (let index = 0; index < internedTargets.length; index++) {
+    const interned = internedTargets[index];
+    if (interned !== undefined && predicate(interned.target)) {
+      count += interned.queuedSamples;
+    }
+  }
+  return count;
+}
+
+function countInFlightDirectSamples(
+  predicate: (target: DirectMetricsTarget) => boolean,
+): number {
+  let count = 0;
+  for (let index = 0; index < internedTargets.length; index++) {
+    const interned = internedTargets[index];
+    if (interned !== undefined && predicate(interned.target)) {
+      count += interned.inFlightSamples;
     }
   }
   return count;
 }
 
 function hasDirectSampleCapacity(target: DirectMetricsTarget): boolean {
-  if (countPendingDirectSamples() >= DIRECT_MAX_QUEUED_SAMPLES) return false;
+  // Retained totals bound memory, so they include samples already on the wire.
+  if (countRetainedDirectSamples() >= DIRECT_MAX_QUEUED_SAMPLES) return false;
   if (!target.tenantScoped) return true;
   if (
-    countPendingDirectSamples((candidate) => candidate.tenantScoped) >=
+    countRetainedDirectSamples((candidate) => candidate.tenantScoped) >=
       DIRECT_MAX_PROJECT_PENDING_SAMPLES
   ) return false;
-  return countPendingDirectSamples((candidate) =>
-    candidate.tenantScoped && candidate.capacityScope === target.capacityScope
-  ) < DIRECT_MAX_PENDING_SAMPLES_PER_SCOPE;
+  const inScope = (candidate: DirectMetricsTarget) =>
+    candidate.tenantScoped && candidate.capacityScope === target.capacityScope;
+  // The queue slot quota governs only what is still queued. A slow or stalled
+  // tenant endpoint holds its batch for the whole export deadline, and that
+  // must not silently discard everything the tenant emits meanwhile.
+  if (countQueuedDirectSamples(inScope) >= DIRECT_MAX_PENDING_SAMPLES_PER_SCOPE) return false;
+  return countInFlightDirectSamples(inScope) < DIRECT_MAX_INFLIGHT_SAMPLES_PER_SCOPE;
 }
 
 function retainDirectTarget(target: DirectMetricsTarget): string | null {
@@ -590,7 +637,7 @@ function retainDirectTarget(target: DirectMetricsTarget): string | null {
       interned.target.tenantScoped === target.tenantScoped &&
       headersEqual(interned.target.headers, target.headers)
     ) {
-      interned.pendingSamples++;
+      interned.queuedSamples++;
       interned.lastUsed = nextInternedTargetUse++;
       return interned.key;
     }
@@ -622,7 +669,8 @@ function retainDirectTarget(target: DirectMetricsTarget): string | null {
   appendArrayValue(internedTargets, {
     target,
     key,
-    pendingSamples: 1,
+    queuedSamples: 1,
+    inFlightSamples: 0,
     lastUsed: nextInternedTargetUse++,
   });
   return key;
@@ -643,12 +691,26 @@ function takeDirectTargetForSample(
   return undefined;
 }
 
+// Move a dispatched batch off the queue quota and onto the in-flight count.
+// Runs synchronously at dispatch so a batch waiting behind another export for
+// the same target never keeps holding queue slots.
+function beginDirectTargetExport(targetKey: string, count: number): void {
+  for (let index = 0; index < internedTargets.length; index++) {
+    const interned = internedTargets[index];
+    if (interned?.key !== targetKey) continue;
+    const remaining = interned.queuedSamples - count;
+    interned.queuedSamples = remaining > 0 ? remaining : 0;
+    interned.inFlightSamples += count;
+    return;
+  }
+}
+
 function releaseDirectTargetSamples(targetKey: string, count: number): void {
   for (let index = 0; index < internedTargets.length; index++) {
     const interned = internedTargets[index];
     if (interned?.key !== targetKey) continue;
-    const remaining = interned.pendingSamples - count;
-    interned.pendingSamples = remaining > 0 ? remaining : 0;
+    const remaining = interned.inFlightSamples - count;
+    interned.inFlightSamples = remaining > 0 ? remaining : 0;
     return;
   }
 }
@@ -817,6 +879,20 @@ function toHookFreeJsonValue(value: unknown): unknown {
   return result;
 }
 
+function recordDirectSampleDrop(reason: string, capacityScope: string): void {
+  droppedDirectSamples++;
+  // Log the first drop, then at most one line per 1000 further drops so a
+  // stalled tenant endpoint cannot flood the log.
+  if (droppedDirectSamples === 1 || droppedDirectSamples % 1_000 === 0) {
+    // debug level - suppressed at default INFO threshold, visible with --debug.
+    serverLogger.debug("metrics: direct OTLP sample dropped", {
+      reason,
+      capacityScope,
+      dropped: droppedDirectSamples,
+    });
+  }
+}
+
 function logDirectExportFailure(error: unknown): void {
   // debug level — suppressed at default INFO threshold, visible with --debug / LOG_LEVEL=DEBUG.
   serverLogger.debug(
@@ -915,6 +991,7 @@ function dispatchDirectMetricsBatch(): void {
   // removed batch indefinitely.
   for (let index = 0; index < groups.length; index++) {
     const group = groups[index]!;
+    beginDirectTargetExport(group.key, group.samples.length);
     const previous = apply(mapGet, directTargetExportTails, [group.key]) as
       | Promise<void>
       | undefined;
@@ -991,13 +1068,19 @@ function enqueueDirectMetric(
 ): void {
   const target = resolveDirectMetricsTarget();
   if (target === null) return;
-  if (!hasDirectSampleCapacity(target)) return;
+  if (!hasDirectSampleCapacity(target)) {
+    recordDirectSampleDrop("sample-quota", target.capacityScope);
+    return;
+  }
   // Complete every fallible field before incrementing the target's retained
   // sample count. A failed clock/BigInt conversion must not consume quota for
   // a sample that can never enter the queue.
   const timestampUnixNano = getUnixNanoTimestamp();
   const targetKey = retainDirectTarget(target);
-  if (targetKey === null) return;
+  if (targetKey === null) {
+    recordDirectSampleDrop("target-quota", target.capacityScope);
+    return;
+  }
   const sample: DirectMetricSample = {
     kind,
     name,
@@ -1075,6 +1158,9 @@ export const metrics = {
   __getDirectTargetCountForTests(): number {
     return internedTargets.length;
   },
+  __getDroppedDirectSampleCountForTests(): number {
+    return droppedDirectSamples;
+  },
   __resetForTests(): void {
     counters.clear();
     histograms.clear();
@@ -1086,6 +1172,7 @@ export const metrics = {
     internedTargets.length = 0;
     nextInternedTargetId = 0;
     nextInternedTargetUse = 0;
+    droppedDirectSamples = 0;
     directExportTimeoutMs = DIRECT_EXPORT_TIMEOUT_MS;
     if (directFlushTimer) {
       clearTimeout(directFlushTimer);

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -461,11 +461,20 @@ function takeDirectTargetForSample(
   for (let index = 0; index < internedTargets.length; index++) {
     const interned = internedTargets[index];
     if (interned?.key === key) {
-      interned.pendingSamples--;
       return { key, target: interned.target };
     }
   }
   return undefined;
+}
+
+function releaseDirectTargetSamples(targetKey: string, count: number): void {
+  for (let index = 0; index < internedTargets.length; index++) {
+    const interned = internedTargets[index];
+    if (interned?.key !== targetKey) continue;
+    const remaining = interned.pendingSamples - count;
+    interned.pendingSamples = remaining > 0 ? remaining : 0;
+    return;
+  }
 }
 
 function toOtlpValue(value: AttributeValue) {
@@ -635,6 +644,14 @@ async function exportDirectGroup(group: DirectExportGroup): Promise<void> {
   }
 }
 
+async function exportAndReleaseDirectGroup(group: DirectExportGroup): Promise<void> {
+  try {
+    await exportDirectGroup(group);
+  } finally {
+    releaseDirectTargetSamples(group.key, group.samples.length);
+  }
+}
+
 async function flushDirectMetrics(): Promise<void> {
   if (directFlushTimer) {
     clearTimeout(directFlushTimer);
@@ -679,7 +696,7 @@ async function flushDirectMetrics(): Promise<void> {
   // removed batch indefinitely.
   const exports = new Array<Promise<void>>(groups.length);
   for (let index = 0; index < groups.length; index++) {
-    exports[index] = exportDirectGroup(groups[index]!);
+    exports[index] = exportAndReleaseDirectGroup(groups[index]!);
   }
   for (let index = 0; index < exports.length; index++) {
     await exports[index];

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -112,10 +112,8 @@ const objectCreate = Object.create;
 const objectDefineProperty = Object.defineProperty;
 const objectSetPrototypeOf = Object.setPrototypeOf;
 const arrayIsArray = Array.isArray;
-const arrayMap = Array.prototype.map;
 const arrayFindIndex = Array.prototype.findIndex;
 const arraySort = Array.prototype.sort;
-const arraySplice = Array.prototype.splice;
 const mapDelete = Map.prototype.delete;
 const mapForEach = Map.prototype.forEach;
 const mapGet = Map.prototype.get;
@@ -161,6 +159,38 @@ function appendArrayValue<T>(target: T[], value: T): void {
     enumerable: true,
     writable: true,
   }]);
+}
+
+function mapArrayValues<T, U>(
+  target: readonly T[],
+  mapper: (value: T, index: number) => U,
+): U[] {
+  const mapped: U[] = [];
+  apply(objectSetPrototypeOf, Object, [mapped, null]);
+  for (let index = 0; index < target.length; index++) {
+    appendArrayValue(mapped, mapper(target[index]!, index));
+  }
+  return mapped;
+}
+
+function removeArrayRange<T>(target: T[], start: number, count: number): T[] {
+  const removed: T[] = [];
+  apply(objectSetPrototypeOf, Object, [removed, null]);
+  const end = apply(mathMin, undefined, [start + count, target.length]) as number;
+  for (let index = start; index < end; index++) {
+    appendArrayValue(removed, target[index]!);
+  }
+  const remaining = target.length - end;
+  for (let index = 0; index < remaining; index++) {
+    apply(objectDefineProperty, Object, [target, NativeString(start + index), {
+      value: target[end + index],
+      configurable: true,
+      enumerable: true,
+      writable: true,
+    }]);
+  }
+  target.length -= end - start;
+  return removed;
 }
 
 function encodeHostBase64(value: string): string {
@@ -236,9 +266,7 @@ function attributesKey(attributes: Record<string, AttributeValue>): string {
     ([left]: [string, AttributeValue], [right]: [string, AttributeValue]) =>
       left < right ? -1 : left > right ? 1 : 0,
   ]) as Array<[string, AttributeValue]>;
-  const values = apply(arrayMap, sorted, [
-    ([key, value]: [string, AttributeValue]) => [key, value],
-  ]);
+  const values = mapArrayValues(sorted, ([key, value]) => [key, value]);
   return jsonStringify(values);
 }
 
@@ -501,10 +529,7 @@ function evictUnusedDirectTarget(
     }
   }
   if (candidateIndex === -1) return false;
-  const evicted = apply(arraySplice, internedTargets, [
-    candidateIndex,
-    1,
-  ]) as InternedDirectMetricsTarget[];
+  const evicted = removeArrayRange(internedTargets, candidateIndex, 1);
   if (evicted[0]) deleteDirectTotalsForTarget(evicted[0].key);
   return true;
 }
@@ -627,10 +652,10 @@ function toOtlpValue(value: AttributeValue) {
 
 function toOtlpAttributes(attributes: Record<string, AttributeValue>) {
   const entries = apply(objectEntries, Object, [attributes]) as Array<[string, AttributeValue]>;
-  return apply(arrayMap, entries, [([key, value]: [string, AttributeValue]) => ({
+  return mapArrayValues(entries, ([key, value]) => ({
     key,
     value: toOtlpValue(value),
-  })]);
+  }));
 }
 
 function getUnixNanoTimestamp(): string {
@@ -692,9 +717,10 @@ function buildDirectMetric(sample: DirectMetricSample, targetKey: string) {
     const sampleBuckets = buildHistogramBuckets(sample.value);
     total.count += 1;
     total.sum += sample.value;
-    total.bucketCounts = apply(arrayMap, total.bucketCounts, [
-      (count: number, index: number) => count + (sampleBuckets[index] ?? 0),
-    ]) as number[];
+    total.bucketCounts = mapArrayValues(
+      total.bucketCounts,
+      (count, index) => count + (sampleBuckets[index] ?? 0),
+    );
     apply(mapSet, directHistogramTotals, [key, total]);
 
     return {
@@ -745,9 +771,7 @@ function buildDirectOtlpBody(
         scope: {
           name: "veryfront.project.metrics",
         },
-        metrics: apply(arrayMap, samples, [
-          (sample: DirectMetricSample) => buildDirectMetric(sample, targetKey),
-        ]),
+        metrics: mapArrayValues(samples, (sample) => buildDirectMetric(sample, targetKey)),
       }],
     }],
   };
@@ -850,7 +874,7 @@ function dispatchDirectMetricsBatch(): void {
   // queue is shared across concurrent project environments, so a single
   // ambient-context target resolution here would misroute other tenants'
   // samples.
-  const batch = apply(arraySplice, directQueue, [0, DIRECT_MAX_BATCH_SIZE]) as DirectMetricSample[];
+  const batch = removeArrayRange(directQueue, 0, DIRECT_MAX_BATCH_SIZE);
   // Plain arrays and index loops rather than a Map or iterator protocol: a
   // group holds the target, and `target.headers` can carry the internal-proxy
   // credential, so it must not be handed to `Map.prototype.set` or to

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -54,10 +54,6 @@ interface DirectMetricSample {
   value: number;
   attributes: Record<string, AttributeValue>;
   timestampUnixNano: string;
-  // Opaque export target identity captured at enqueue time. The secret-bearing
-  // target remains in the private intern table instead of crossing mutable
-  // Array methods with this process-global queue.
-  targetKey: string;
 }
 
 interface DirectExportGroup {
@@ -73,6 +69,7 @@ const gauges = new Map<
   { instrument: ObservableGauge; samples: Map<string, GaugeSample> }
 >();
 const directQueue: DirectMetricSample[] = [];
+const directSampleTargets = new WeakMap<DirectMetricSample, string>();
 const directCounterTotals = new Map<string, { value: number; startTimeUnixNano: string }>();
 const directHistogramTotals = new Map<
   string,
@@ -88,6 +85,7 @@ let directFlushTimer: ReturnType<typeof setTimeout> | null = null;
 const DIRECT_FLUSH_DELAY_MS = 1_000;
 const DIRECT_EXPORT_TIMEOUT_MS = 10_000;
 const DIRECT_MAX_BATCH_SIZE = 100;
+const DIRECT_MAX_INTERNED_TARGETS = DIRECT_MAX_BATCH_SIZE;
 const HISTOGRAM_BOUNDS = [0, 10, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000];
 const apply = Reflect.apply;
 const NativeAbortController = AbortController;
@@ -98,6 +96,14 @@ const AbortControllerSignalGetter = Object.getOwnPropertyDescriptor(
 )?.get;
 const objectKeys = Object.keys;
 const arraySort = Array.prototype.sort;
+const arrayPush = Array.prototype.push;
+const arraySplice = Array.prototype.splice;
+const mapDelete = Map.prototype.delete;
+const mapForEach = Map.prototype.forEach;
+const stringStartsWith = String.prototype.startsWith;
+const weakMapDelete = WeakMap.prototype.delete;
+const weakMapGet = WeakMap.prototype.get;
+const weakMapSet = WeakMap.prototype.set;
 const hostBtoa = typeof globalThis.btoa === "function" ? globalThis.btoa : undefined;
 const mathMin = Math.min;
 const NativeTextEncoder = TextEncoder;
@@ -368,13 +374,54 @@ function headersEqual(
 // runs on captured intrinsics and primitive operators only: in a dedicated
 // runtime, project code can replace `Object.entries`, `Array.prototype.sort`,
 // `String.prototype.localeCompare` and `JSON.stringify`, and any of those would
-// otherwise be handed the credential. The table is bounded by the number of
-// distinct export targets in the process, i.e. by co-located environments.
-const internedTargets: Array<{ target: DirectMetricsTarget; key: string }> = [];
+// otherwise be handed the credential. A fixed LRU bound prevents mutable
+// project telemetry settings from retaining an unbounded number of targets.
+interface InternedDirectMetricsTarget {
+  target: DirectMetricsTarget;
+  key: string;
+  pendingSamples: number;
+  lastUsed: number;
+}
+
+const internedTargets: InternedDirectMetricsTarget[] = [];
 let nextInternedTargetId = 0;
+let nextInternedTargetUse = 0;
 let directExportTimeoutMs = DIRECT_EXPORT_TIMEOUT_MS;
 
-function directTargetKey(target: DirectMetricsTarget): string {
+function deleteDirectTotalsForTarget(targetKey: string): void {
+  const prefix = `${targetKey}:`;
+  const deleteMatching = (_value: unknown, key: string, totals: Map<string, unknown>): void => {
+    if (apply(stringStartsWith, key, [prefix])) {
+      apply(mapDelete, totals, [key]);
+    }
+  };
+  apply(mapForEach, directCounterTotals, [deleteMatching]);
+  apply(mapForEach, directHistogramTotals, [deleteMatching]);
+}
+
+function evictUnusedDirectTarget(): boolean {
+  let candidateIndex = -1;
+  let candidateUse = Number.POSITIVE_INFINITY;
+  for (let index = 0; index < internedTargets.length; index++) {
+    const interned = internedTargets[index];
+    if (
+      interned !== undefined && interned.pendingSamples === 0 &&
+      interned.lastUsed < candidateUse
+    ) {
+      candidateIndex = index;
+      candidateUse = interned.lastUsed;
+    }
+  }
+  if (candidateIndex === -1) return false;
+  const evicted = apply(arraySplice, internedTargets, [
+    candidateIndex,
+    1,
+  ]) as InternedDirectMetricsTarget[];
+  if (evicted[0]) deleteDirectTotalsForTarget(evicted[0].key);
+  return true;
+}
+
+function retainDirectTarget(target: DirectMetricsTarget): string | null {
   for (let index = 0; index < internedTargets.length; index++) {
     const interned = internedTargets[index];
     if (
@@ -384,18 +431,39 @@ function directTargetKey(target: DirectMetricsTarget): string {
       interned.target.serviceVersion === target.serviceVersion &&
       headersEqual(interned.target.headers, target.headers)
     ) {
+      interned.pendingSamples++;
+      interned.lastUsed = nextInternedTargetUse++;
       return interned.key;
     }
   }
+  if (
+    internedTargets.length >= DIRECT_MAX_INTERNED_TARGETS &&
+    !evictUnusedDirectTarget()
+  ) {
+    return null;
+  }
   const key = `t${nextInternedTargetId++}`;
-  internedTargets[internedTargets.length] = { target, key };
+  internedTargets[internedTargets.length] = {
+    target,
+    key,
+    pendingSamples: 1,
+    lastUsed: nextInternedTargetUse++,
+  };
   return key;
 }
 
-function directTargetForKey(key: string): DirectMetricsTarget | undefined {
+function takeDirectTargetForSample(
+  sample: DirectMetricSample,
+): { key: string; target: DirectMetricsTarget } | undefined {
+  const key = apply(weakMapGet, directSampleTargets, [sample]) as string | undefined;
+  apply(weakMapDelete, directSampleTargets, [sample]);
+  if (key === undefined) return undefined;
   for (let index = 0; index < internedTargets.length; index++) {
     const interned = internedTargets[index];
-    if (interned?.key === key) return interned.target;
+    if (interned?.key === key) {
+      interned.pendingSamples--;
+      return { key, target: interned.target };
+    }
   }
   return undefined;
 }
@@ -579,7 +647,7 @@ async function flushDirectMetrics(): Promise<void> {
   // queue is shared across concurrent project environments, so a single
   // ambient-context target resolution here would misroute other tenants'
   // samples.
-  const batch = directQueue.splice(0, DIRECT_MAX_BATCH_SIZE);
+  const batch = apply(arraySplice, directQueue, [0, DIRECT_MAX_BATCH_SIZE]) as DirectMetricSample[];
   // Plain arrays and index loops rather than a Map or iterator protocol: a
   // group holds the target, and `target.headers` can carry the internal-proxy
   // credential, so it must not be handed to `Map.prototype.set` or to
@@ -588,7 +656,9 @@ async function flushDirectMetrics(): Promise<void> {
   for (let index = 0; index < batch.length; index++) {
     const sample = batch[index];
     if (sample === undefined) continue;
-    const key = sample.targetKey;
+    const binding = takeDirectTargetForSample(sample);
+    if (!binding) continue;
+    const { key, target } = binding;
     let group: DirectExportGroup | undefined;
     for (let groupIndex = 0; groupIndex < groups.length; groupIndex++) {
       const candidate = groups[groupIndex];
@@ -598,8 +668,6 @@ async function flushDirectMetrics(): Promise<void> {
       }
     }
     if (!group) {
-      const target = directTargetForKey(key);
-      if (!target) continue;
       group = { key, target, samples: [] };
       groups[groups.length] = group;
     }
@@ -646,15 +714,17 @@ function enqueueDirectMetric(
 ): void {
   const target = resolveDirectMetricsTarget();
   if (target === null) return;
-  const targetKey = directTargetKey(target);
-  directQueue.push({
+  const targetKey = retainDirectTarget(target);
+  if (targetKey === null) return;
+  const sample: DirectMetricSample = {
     kind,
     name,
     value,
     attributes,
     timestampUnixNano: getUnixNanoTimestamp(),
-    targetKey,
-  });
+  };
+  apply(weakMapSet, directSampleTargets, [sample, targetKey]);
+  apply(arrayPush, directQueue, [sample]);
   if (directQueue.length >= DIRECT_MAX_BATCH_SIZE) {
     void flushDirectMetrics();
     return;
@@ -720,6 +790,9 @@ export const metrics = {
   __setDirectExportTimeoutForTests(timeoutMs: number): void {
     directExportTimeoutMs = timeoutMs;
   },
+  __getDirectTargetCountForTests(): number {
+    return internedTargets.length;
+  },
   __resetForTests(): void {
     counters.clear();
     histograms.clear();
@@ -729,6 +802,7 @@ export const metrics = {
     directHistogramTotals.clear();
     internedTargets.length = 0;
     nextInternedTargetId = 0;
+    nextInternedTargetUse = 0;
     directExportTimeoutMs = DIRECT_EXPORT_TIMEOUT_MS;
     if (directFlushTimer) {
       clearTimeout(directFlushTimer);

--- a/src/server/handlers/request/agent-stream.handler.test.ts
+++ b/src/server/handlers/request/agent-stream.handler.test.ts
@@ -1,4 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
+import { getTrustedProjectEnvIdentity } from "#veryfront/server/project-env/storage.ts";
 import { INVALID_ARGUMENT, NETWORK_ERROR, SERVICE_OVERLOADED } from "#veryfront/errors";
 import {
   __registerLogRecordEmitter,
@@ -3696,6 +3697,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
       }
       | undefined;
     let observedEnvironmentTargetKeys: string[] = [];
+    let observedTrustedIdentity: ReturnType<typeof getTrustedProjectEnvIdentity>;
 
     const handler = createTestAgentStreamHandler({
       loadAgentSourceEnvironment: (_ctx, source, target, token) => {
@@ -3717,6 +3719,7 @@ describe("server/handlers/request/agent-stream.handler", () => {
       sessionManager: new AgentRunSessionManager(),
       createRuntime: () => ({
         stream: async (_messages, _context, callbacks) => {
+          observedTrustedIdentity = getTrustedProjectEnvIdentity();
           callbacks?.onFinish?.({
             text: "resolved from main",
             messages: [],
@@ -3835,6 +3838,11 @@ describe("server/handlers/request/agent-stream.handler", () => {
       projectSlug: "demo-project",
     });
     assertEquals(observedCacheCredential, undefined);
+    assertEquals(observedTrustedIdentity, {
+      projectId: "proj-1",
+      projectSlug: "demo-project",
+      environmentId: "10000000-1000-4000-8000-100000000098",
+    });
     assertEquals(observedSourceContextCredentials, [undefined, undefined]);
     assertEquals(getVerifiedCacheApiCredential(), undefined);
   });

--- a/src/server/handlers/request/agent-stream.handler.ts
+++ b/src/server/handlers/request/agent-stream.handler.ts
@@ -91,6 +91,7 @@ import {
   runWithProjectEnv,
   unwrapReplayedProjectEnvironmentFailure,
 } from "../../project-env/index.ts";
+import { runWithTrustedProjectEnv } from "../../project-env/storage.ts";
 import { getHostedConfig, type VeryfrontConfig } from "#veryfront/config/loader.ts";
 import { prepareDeclarativeConfigContext } from "#veryfront/config/declarative-evaluator.ts";
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
@@ -1232,15 +1233,27 @@ export class AgentStreamHandler extends BaseHandler {
                             },
                           });
                         const shouldIsolateEnv = apiAuthToken.length > 0;
+                        const agentEnv = buildAgentStreamEnv({
+                          envVars: envVarsForAgent,
+                          proxyToken: projectRuntimeToken,
+                          projectSlug: projectScopedContext.projectSlug,
+                        });
+                        const trustedIdentity = projectScopedContext.projectId ||
+                            projectScopedContext.projectSlug || projectScopedContext.environmentId
+                          ? {
+                            projectId: projectScopedContext.projectId,
+                            projectSlug: projectScopedContext.projectSlug,
+                            environmentId: projectScopedContext.environmentId,
+                          }
+                          : undefined;
                         const response = shouldIsolateEnv
-                          ? await runWithProjectEnv(
-                            buildAgentStreamEnv({
-                              envVars: envVarsForAgent,
-                              proxyToken: projectRuntimeToken,
-                              projectSlug: projectScopedContext.projectSlug,
-                            }),
-                            runAgentStream,
-                          )
+                          ? trustedIdentity
+                            ? await runWithTrustedProjectEnv(
+                              agentEnv,
+                              trustedIdentity,
+                              runAgentStream,
+                            )
+                            : await runWithProjectEnv(agentEnv, runAgentStream)
                           : await runAgentStream();
                         logger.info("Internal agent stream response created", {
                           runId: payload.runId,

--- a/src/server/project-env/storage.test.ts
+++ b/src/server/project-env/storage.test.ts
@@ -62,6 +62,36 @@ describe("project-env/storage", () => {
     }
   });
 
+  it("does not expose tenant values through inherited descriptor accessors", () => {
+    const observed: unknown[] = [];
+    Object.defineProperty(Object.prototype, "get", {
+      configurable: true,
+      get() {
+        observed.push((this as { value?: unknown }).value);
+        return undefined;
+      },
+    });
+    Object.defineProperty(Object.prototype, "set", {
+      configurable: true,
+      get() {
+        observed.push((this as { value?: unknown }).value);
+        return undefined;
+      },
+    });
+    try {
+      runWithTrustedProjectEnv(
+        { PROVIDER_TOKEN: "private-provider-token" },
+        { projectId: "project-next" },
+        () => assertEquals(getProjectEnv("PROVIDER_TOKEN"), "private-provider-token"),
+      );
+    } finally {
+      delete (Object.prototype as { get?: unknown }).get;
+      delete (Object.prototype as { set?: unknown }).set;
+    }
+
+    assertEquals(observed, []);
+  });
+
   it("uses context operations captured before project prototype mutation", () => {
     const originalDisable = Object.getOwnPropertyDescriptor(
       AsyncLocalStorage.prototype,

--- a/src/server/project-env/storage.test.ts
+++ b/src/server/project-env/storage.test.ts
@@ -9,8 +9,10 @@ import {
 import {
   getProjectEnv,
   getProjectEnvSnapshot,
+  getTrustedProjectEnvIdentity,
   isProjectEnvActive,
   runWithProjectEnv,
+  runWithTrustedProjectEnv,
 } from "./storage.ts";
 import { AsyncLocalStorage } from "node:async_hooks";
 
@@ -23,6 +25,25 @@ describe("project-env/storage", () => {
     runWithProjectEnv({ FOO: "bar" }, () => {
       assertEquals(getProjectEnv("FOO"), "bar");
     });
+  });
+
+  it("keeps runtime identity separate from project environment values", () => {
+    runWithProjectEnv({ VERYFRONT_PROJECT_ID: "forged-project" }, () => {
+      assertEquals(getTrustedProjectEnvIdentity(), undefined);
+    });
+
+    runWithTrustedProjectEnv(
+      { VERYFRONT_PROJECT_ID: "forged-project" },
+      { projectId: "trusted-project", environmentId: "trusted-environment" },
+      () => {
+        const identity = getTrustedProjectEnvIdentity();
+        assertEquals(identity, {
+          projectId: "trusted-project",
+          environmentId: "trusted-environment",
+        });
+        assertEquals(Object.isFrozen(identity!), true);
+      },
+    );
   });
 
   it("uses context operations captured before project prototype mutation", () => {

--- a/src/server/project-env/storage.test.ts
+++ b/src/server/project-env/storage.test.ts
@@ -13,6 +13,7 @@ import {
   isProjectEnvActive,
   runWithProjectEnv,
   runWithTrustedProjectEnv,
+  type TrustedProjectEnvIdentity,
 } from "./storage.ts";
 import { AsyncLocalStorage } from "node:async_hooks";
 
@@ -44,6 +45,21 @@ describe("project-env/storage", () => {
         assertEquals(Object.isFrozen(identity!), true);
       },
     );
+  });
+
+  it("does not inherit a forged identity in an untrusted scope", () => {
+    const prototype = Object.prototype as { identity?: TrustedProjectEnvIdentity };
+    prototype.identity = {
+      projectId: "forged-project",
+      environmentId: "forged-environment",
+    };
+    try {
+      runWithProjectEnv({}, () => {
+        assertEquals(getTrustedProjectEnvIdentity(), undefined);
+      });
+    } finally {
+      delete prototype.identity;
+    }
   });
 
   it("uses context operations captured before project prototype mutation", () => {

--- a/src/server/project-env/storage.ts
+++ b/src/server/project-env/storage.ts
@@ -60,6 +60,31 @@ function getProjectEnvStore(): ProjectEnvStore | undefined {
     | undefined;
 }
 
+function dataDescriptor(value: unknown): PropertyDescriptor {
+  const descriptor = IntrinsicObjectCreate(null) as PropertyDescriptor;
+  descriptor.value = value;
+  descriptor.enumerable = true;
+  return descriptor;
+}
+
+function createProjectEnvStore(
+  snapshot: ProjectEnvSnapshot,
+  identity?: Readonly<TrustedProjectEnvIdentity>,
+): ProjectEnvStore {
+  const descriptors = IntrinsicObjectCreate(null) as PropertyDescriptorMap;
+  descriptors.snapshot = dataDescriptor(snapshot);
+  descriptors.identity = dataDescriptor(identity);
+  return IntrinsicObjectCreate(null, descriptors) as ProjectEnvStore;
+}
+
+function createTrustedIdentity(identity: TrustedProjectEnvIdentity): TrustedProjectEnvIdentity {
+  const trusted = IntrinsicObjectCreate(null) as TrustedProjectEnvIdentity;
+  if (identity.projectId !== undefined) trusted.projectId = identity.projectId;
+  if (identity.projectSlug !== undefined) trusted.projectSlug = identity.projectSlug;
+  if (identity.environmentId !== undefined) trusted.environmentId = identity.environmentId;
+  return IntrinsicObjectFreeze(trusted);
+}
+
 /**
  * Run a function with project-specific environment variables.
  * Within the callback, `getProjectEnv()` will return values from `vars`.
@@ -69,10 +94,7 @@ export function runWithProjectEnv<T>(
   fn: () => T,
 ): T {
   return IntrinsicReflectApply(AsyncLocalStorageRun, projectEnvStorage, [
-    IntrinsicObjectCreate(null, {
-      snapshot: { value: createProjectEnvSnapshot(vars), enumerable: true },
-      identity: { value: undefined, enumerable: true },
-    }) as ProjectEnvStore,
+    createProjectEnvStore(createProjectEnvSnapshot(vars)),
     fn,
   ]) as T;
 }
@@ -84,10 +106,7 @@ export function runWithTrustedProjectEnv<T>(
   fn: () => T,
 ): T {
   return IntrinsicReflectApply(AsyncLocalStorageRun, projectEnvStorage, [
-    IntrinsicObjectCreate(null, {
-      snapshot: { value: createProjectEnvSnapshot(vars), enumerable: true },
-      identity: { value: IntrinsicObjectFreeze({ ...identity }), enumerable: true },
-    }) as ProjectEnvStore,
+    createProjectEnvStore(createProjectEnvSnapshot(vars), createTrustedIdentity(identity)),
     fn,
   ]) as T;
 }

--- a/src/server/project-env/storage.ts
+++ b/src/server/project-env/storage.ts
@@ -11,9 +11,21 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { registerTrustedProjectEnvSnapshot } from "#veryfront/platform/compat/process/env.ts";
 import { createProjectEnvSnapshot, type ProjectEnvSnapshot } from "./snapshot.ts";
 
-const projectEnvStorage = new AsyncLocalStorage<ProjectEnvSnapshot>();
+export interface TrustedProjectEnvIdentity {
+  projectId?: string;
+  projectSlug?: string;
+  environmentId?: string;
+}
+
+interface ProjectEnvStore {
+  snapshot: ProjectEnvSnapshot;
+  identity?: Readonly<TrustedProjectEnvIdentity>;
+}
+
+const projectEnvStorage = new AsyncLocalStorage<ProjectEnvStore>();
 const IntrinsicReflectApply = Reflect.apply;
 const IntrinsicObjectDefineProperty = Object.defineProperty;
+const IntrinsicObjectFreeze = Object.freeze;
 const AsyncLocalStoragePrototype = AsyncLocalStorage.prototype;
 const AsyncLocalStorageDisable = AsyncLocalStoragePrototype.disable;
 const AsyncLocalStorageEnterWith = AsyncLocalStoragePrototype.enterWith;
@@ -41,9 +53,9 @@ IntrinsicObjectDefineProperty(projectEnvStorage, "run", {
   writable: false,
 });
 
-function getProjectEnvStore(): ProjectEnvSnapshot | undefined {
+function getProjectEnvStore(): ProjectEnvStore | undefined {
   return IntrinsicReflectApply(AsyncLocalStorageGetStore, projectEnvStorage, []) as
-    | ProjectEnvSnapshot
+    | ProjectEnvStore
     | undefined;
 }
 
@@ -56,9 +68,29 @@ export function runWithProjectEnv<T>(
   fn: () => T,
 ): T {
   return IntrinsicReflectApply(AsyncLocalStorageRun, projectEnvStorage, [
-    createProjectEnvSnapshot(vars),
+    { snapshot: createProjectEnvSnapshot(vars) },
     fn,
   ]) as T;
+}
+
+/** Run with project env values plus identity resolved at the authenticated runtime boundary. */
+export function runWithTrustedProjectEnv<T>(
+  vars: Readonly<Record<string, string>>,
+  identity: TrustedProjectEnvIdentity,
+  fn: () => T,
+): T {
+  return IntrinsicReflectApply(AsyncLocalStorageRun, projectEnvStorage, [
+    {
+      snapshot: createProjectEnvSnapshot(vars),
+      identity: IntrinsicObjectFreeze({ ...identity }),
+    },
+    fn,
+  ]) as T;
+}
+
+/** Return only the runtime-owned identity, never project-provided environment values. */
+export function getTrustedProjectEnvIdentity(): Readonly<TrustedProjectEnvIdentity> | undefined {
+  return getProjectEnvStore()?.identity;
 }
 
 /**
@@ -66,7 +98,7 @@ export function runWithProjectEnv<T>(
  * Returns undefined if no project env overlay is active or key is not present.
  */
 export function getProjectEnv(key: string): string | undefined {
-  return getProjectEnvStore()?.[key];
+  return getProjectEnvStore()?.snapshot[key];
 }
 
 /**
@@ -84,7 +116,7 @@ export function isProjectEnvActive(): boolean {
  * Used to forward env vars to isolated workers in proxy mode.
  */
 export function getProjectEnvSnapshot(): ProjectEnvSnapshot | undefined {
-  return getProjectEnvStore();
+  return getProjectEnvStore()?.snapshot;
 }
 
 registerTrustedProjectEnvSnapshot(getProjectEnvSnapshot);

--- a/src/server/project-env/storage.ts
+++ b/src/server/project-env/storage.ts
@@ -24,6 +24,7 @@ interface ProjectEnvStore {
 
 const projectEnvStorage = new AsyncLocalStorage<ProjectEnvStore>();
 const IntrinsicReflectApply = Reflect.apply;
+const IntrinsicObjectCreate = Object.create;
 const IntrinsicObjectDefineProperty = Object.defineProperty;
 const IntrinsicObjectFreeze = Object.freeze;
 const AsyncLocalStoragePrototype = AsyncLocalStorage.prototype;
@@ -68,7 +69,10 @@ export function runWithProjectEnv<T>(
   fn: () => T,
 ): T {
   return IntrinsicReflectApply(AsyncLocalStorageRun, projectEnvStorage, [
-    { snapshot: createProjectEnvSnapshot(vars) },
+    IntrinsicObjectCreate(null, {
+      snapshot: { value: createProjectEnvSnapshot(vars), enumerable: true },
+      identity: { value: undefined, enumerable: true },
+    }) as ProjectEnvStore,
     fn,
   ]) as T;
 }
@@ -80,10 +84,10 @@ export function runWithTrustedProjectEnv<T>(
   fn: () => T,
 ): T {
   return IntrinsicReflectApply(AsyncLocalStorageRun, projectEnvStorage, [
-    {
-      snapshot: createProjectEnvSnapshot(vars),
-      identity: IntrinsicObjectFreeze({ ...identity }),
-    },
+    IntrinsicObjectCreate(null, {
+      snapshot: { value: createProjectEnvSnapshot(vars), enumerable: true },
+      identity: { value: IntrinsicObjectFreeze({ ...identity }), enumerable: true },
+    }) as ProjectEnvStore,
     fn,
   ]) as T;
 }

--- a/src/server/runtime-handler/index.test.ts
+++ b/src/server/runtime-handler/index.test.ts
@@ -16,7 +16,11 @@ import {
   type LogEntry,
 } from "#veryfront/utils/logger/logger.ts";
 import { HMRHandler } from "../handlers/preview/hmr.handler.ts";
-import { runWithProjectEnv } from "../project-env/storage.ts";
+import {
+  getTrustedProjectEnvIdentity,
+  runWithProjectEnv,
+  type TrustedProjectEnvIdentity,
+} from "../project-env/storage.ts";
 import {
   createVeryfrontHandler,
   prepareOptionsBeforeProjectMiddleware,
@@ -29,7 +33,10 @@ import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { createMockOidcProvider } from "#veryfront/security/application-auth/mock-oidc-provider.ts";
 import { createSessionCookie } from "#veryfront/security/application-auth/cookies.ts";
 import type { MiddlewareFunction } from "#veryfront/server/dev-server/middleware.ts";
-import { ProjectMiddlewareRuntime } from "#veryfront/server/runtime-handler/project-middleware.ts";
+import {
+  ProjectMiddlewareRuntime,
+  projectMiddlewareRuntime,
+} from "#veryfront/server/runtime-handler/project-middleware.ts";
 import { normalizeSourceIntegrationPolicy } from "#veryfront/integrations/source-policy.ts";
 import {
   createSnapshot,
@@ -1782,6 +1789,102 @@ describe("server/runtime-handler/index", () => {
     } finally {
       Deno.env.delete("VERYFRONT_TRUST_FORWARDED_HEADERS");
     }
+  });
+
+  it("binds the trusted project identity to the request project env overlay", async () => {
+    const observed: Array<TrustedProjectEnvIdentity | undefined> = [];
+    injectIsolationDepsForTests({
+      checkRequest: () => ({ allowed: true }),
+      startRequest: () => {},
+      completeRequest: () => {},
+    });
+    const projectDir = "/tmp/trusted-identity-project";
+    const adapter = createRouteMockAdapter();
+    adapter.fs.files.set(`${projectDir}/veryfront.config.ts`, "export default {};");
+    const fs = adapter.fs as typeof adapter.fs & {
+      isVeryfrontAdapter: () => boolean;
+      getUnderlyingAdapter: () => typeof adapter.fs;
+      isMultiProjectMode: () => boolean;
+      isContextualMode: () => boolean;
+      runWithContext: <T>(
+        slug: string,
+        token: string,
+        operation: () => Promise<T>,
+        projectId?: string,
+        options?: { branch?: string | null },
+      ) => Promise<T>;
+      sourceSnapshotFreshnessOptionsVersion: 1;
+      ensureSourceSnapshotFresh: () => Promise<void>;
+      getSourceSnapshotIdentity: () => string;
+      getSourceSnapshotVersion: () => number;
+    };
+    fs.isVeryfrontAdapter = () => true;
+    fs.getUnderlyingAdapter = () => fs;
+    fs.isMultiProjectMode = () => true;
+    fs.isContextualMode = () => true;
+    fs.runWithContext = (slug, token, operation, projectId, options) =>
+      runWithRequestContext({ projectSlug: slug, token, projectId, ...options }, operation);
+    fs.sourceSnapshotFreshnessOptionsVersion = 1;
+    fs.ensureSourceSnapshotFresh = () => Promise.resolve();
+    fs.getSourceSnapshotIdentity = () => "branch:trusted-identity:main";
+    fs.getSourceSnapshotVersion = () => 1;
+    const handler = createVeryfrontHandler(projectDir, adapter, {
+      projectDir,
+      config: { fs: { veryfront: { proxyMode: true } } } as any,
+      allowHostProjectCodeExecution: true,
+    });
+    // Project middleware dispatch is the first project-owned step inside the
+    // request env overlay, so it observes what project code observes.
+    const originalExecute = ProjectMiddlewareRuntime.prototype.execute;
+    Object.defineProperty(projectMiddlewareRuntime, "execute", {
+      configurable: true,
+      value: function (context: Parameters<typeof originalExecute>[0]) {
+        observed.push(getTrustedProjectEnvIdentity());
+        return originalExecute.call(projectMiddlewareRuntime, context);
+      },
+    });
+    Deno.env.set("VERYFRONT_TRUST_FORWARDED_HEADERS", "1");
+    Deno.env.set("VERYFRONT_API_BASE_URL", "https://api.example.test/api");
+
+    try {
+      const response = await withMockFetch(
+        (() => Promise.resolve(Response.json({ data: [] }))) as typeof fetch,
+        () =>
+          handler(
+            new Request("http://localhost/page", {
+              headers: {
+                "x-project-slug": "my-project",
+                "x-project-id": "project-123",
+                "x-environment-id": "environment-456",
+                "x-environment-name": "Preview",
+                "x-environment": "preview",
+                "x-token": "proxy-token",
+                "x-forwarded-host": "my-project.preview.veryfront.com",
+              },
+            }),
+          ),
+      );
+
+      assertEquals(
+        response.status,
+        404,
+        "the request must reach project route execution rather than fail admission",
+      );
+    } finally {
+      Reflect.deleteProperty(projectMiddlewareRuntime, "execute");
+      Deno.env.delete("VERYFRONT_TRUST_FORWARDED_HEADERS");
+      Deno.env.delete("VERYFRONT_API_BASE_URL");
+    }
+
+    assertEquals(
+      observed,
+      [{
+        projectId: "project-123",
+        projectSlug: "my-project",
+        environmentId: "environment-456",
+      }],
+      "project code must run under the runtime-owned identity that scopes metric quotas",
+    );
   });
 
   it("returns 502 when trust-sensitive proxy context headers are present but untrusted", async () => {

--- a/src/server/runtime-handler/index.ts
+++ b/src/server/runtime-handler/index.ts
@@ -142,6 +142,7 @@ import {
   filterRuntimeProjectEnv,
   runWithProjectEnv,
 } from "../project-env/index.ts";
+import { runWithTrustedProjectEnv } from "../project-env/storage.ts";
 import { SCANNER_PATH_PATTERN } from "#veryfront/utils/constants/security.ts";
 import { projectMiddlewareRuntime, runInProjectFilesystemContext } from "./project-middleware.ts";
 import {
@@ -775,9 +776,22 @@ export function createVeryfrontHandler(
           const isolatedEnvForRequest = shouldIsolateEnv
             ? filterRuntimeProjectEnv(envVarsForRequest)
             : undefined;
+          const trustedProjectEnvIdentity = ctx.projectId || ctx.projectSlug || ctx.environmentId
+            ? {
+              projectId: ctx.projectId,
+              projectSlug: ctx.projectSlug,
+              environmentId: ctx.environmentId,
+            }
+            : undefined;
           const runInRequestProjectEnv = <T>(operation: () => T): T =>
             isolatedEnvForRequest === undefined
               ? operation()
+              : trustedProjectEnvIdentity
+              ? runWithTrustedProjectEnv(
+                isolatedEnvForRequest,
+                trustedProjectEnvIdentity,
+                operation,
+              )
               : runWithProjectEnv(isolatedEnvForRequest, operation);
 
           const runInFilesystemContext = <T>(operation: () => Promise<T>) =>


### PR DESCRIPTION
## Vulnerability

The direct metrics exporter in `src/metrics/index.ts` kept a single process-global `directQueue` whose samples carried no export target. `flushDirectMetrics()` resolved exactly one OTLP target at flush time from the ambient AsyncLocalStorage project-env context, and both the 1s flush timer and the queue-full synchronous flush run in whichever environment's context scheduled them. Dedicated runtimes (`SERVER_ID` + `ENVIRONMENT_IDS`) serve multiple environments — which can belong to different projects — and `filterRuntimeProjectEnv()` deliberately preserves project `OTEL_*` variables there. An environment configured with its own (attacker-controlled) OTLP endpoint could therefore have up to 99 queued samples from co-located environments/projects (project ids, slugs, environment/branch labels, metric names and values otherwise bound for the platform's internal collector) POSTed to its endpoint: a cross-tenant telemetry confidentiality leak.

- Codex finding id: 7eda1387351c8191a3bb12057cfd31de (finding 104)
- Severity: medium
- Confirmed by deep triage against the pinned veryfront@0.1.1255 build and current `main`.

## Fix

Bind each sample to its export destination when it is enqueued, and never consult the ambient context at flush time:

- `enqueueDirectMetric()` captures the resolved target (url, headers, and the OTLP resource service name/version) on the sample.
- `flushDirectMetrics()` groups the batch by target and POSTs each group only to its own target.
- Counter/histogram cumulative totals are keyed per target, so aggregates never mix across tenants.
- `buildDirectOtlpBody()` takes its resource attributes from the enqueue-time target instead of the flusher's ambient env.

## Test evidence

- New regression test "never exports one environment's queued samples to another environment's OTLP target" interleaves a victim environment (internal proxy target) with an environment that configures its own OTLP endpoint and flushes under that environment's context. It fails against the previous implementation (single batch delivered to the attacker endpoint) and passes with the fix, additionally asserting internal proxy credentials never reach the project endpoint.
- `deno task test:file src/metrics/index.test.ts`: 15 steps, all pass.
- `deno fmt --check` and `deno lint` clean on touched files; `deno check src/metrics/index.ts` clean; `deno task lint:test-typecheck` baseline holds (0 new).

A follow-up defense-in-depth option on the API side is to enforce that all environments linked to one server belong to a single project; this PR fixes the routing flaw at its source. Shipping requires a new veryfront release and a pin bump in veryfront-api.

https://claude.ai/code/session_01QfWNMiUhvWMKWi6BGfVdY3

## Direct queue capacity (review follow-up)

The direct queue is bounded per capacity scope so one tenant cannot spend the
shared queue. Two counters back that bound:

- Queued samples (still in `directQueue`) consume the per-scope queue quota
  (`DIRECT_MAX_PENDING_SAMPLES_PER_SCOPE`).
- In-flight samples (already handed to an export) have their own per-scope bound
  (`DIRECT_MAX_INFLIGHT_SAMPLES_PER_SCOPE`) and no longer hold queue slots, so a
  tenant keeps recording metrics while its export is on the wire, including for
  the whole 10s deadline when its endpoint stalls.
- Both counts still apply to the global bound and to the tenant share, so the
  platform keeps its 100-sample reserve.

An over-quota sample is counted and logged at debug level (throttled), instead of
being discarded silently. The capacity scope now selects the first non-empty
trusted identity field, so an empty project id cannot collapse distinct tenants
into one bucket.
