### PR TITLE
fix(security): bound prewarm resolver probes

### DIFF
--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -1847,6 +1847,70 @@ describe("Renderer release asset cache isolation", () => {
     }
   });
 
+  it("samples beyond an invalid candidate prefix", async () => {
+    const renderer = new Renderer({ cache: { store: createInMemoryStore() } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    let probeCount = 0;
+    (renderer as unknown as {
+      pageExists: (slug: string) => Promise<boolean>;
+    }).pageExists = (slug) => {
+      probeCount++;
+      return Promise.resolve(slug === "/valid-app-route");
+    };
+
+    const slugs = Array.from({ length: 499 }, (_, index) => `/legacy-${index}`);
+    slugs.push("/valid-app-route");
+    const maxRoutes = 12;
+    const resolvable = await (renderer as unknown as {
+      filterResolvablePrewarmSlugs: (
+        ctx: RenderContext,
+        slugs: string[],
+        maxRoutes: number,
+      ) => Promise<string[]>;
+    }).filterResolvablePrewarmSlugs(makeRenderContext(), slugs, maxRoutes);
+
+    try {
+      assertEquals(resolvable, ["/valid-app-route"]);
+      assertEquals(probeCount <= maxRoutes * 4, true);
+    } finally {
+      await renderer.destroy();
+    }
+  });
+
+  it("uses one deadline for the complete resolver probe batch", async () => {
+    using time = new FakeTime();
+    const renderer = new Renderer({ cache: { store: createInMemoryStore() } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    let probeCount = 0;
+    (renderer as unknown as {
+      pageExists: (slug: string) => Promise<boolean>;
+    }).pageExists = () => {
+      probeCount++;
+      return new Promise<boolean>(() => {});
+    };
+
+    const filtering = (renderer as unknown as {
+      filterResolvablePrewarmSlugs: (
+        ctx: RenderContext,
+        slugs: string[],
+        maxRoutes: number,
+      ) => Promise<string[]>;
+    }).filterResolvablePrewarmSlugs(
+      makeRenderContext(),
+      Array.from({ length: 500 }, (_, index) => `/stalled-${index}`),
+      12,
+    );
+
+    await time.tickAsync(5_000);
+
+    try {
+      assertEquals(await filtering, []);
+      assertEquals(probeCount, 1);
+    } finally {
+      await renderer.destroy();
+    }
+  });
+
   it("prioritizes route-family siblings when prewarming production routes", async () => {
     const store = createInMemoryStore();
     const renderedSlugs: string[] = [];

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -1924,6 +1924,9 @@ describe("Renderer release asset cache isolation", () => {
     using time = new FakeTime();
     const renderer = new Renderer({ cache: { store: createInMemoryStore() } });
     (renderer as unknown as { initialized: boolean }).initialized = true;
+    // Production uses the clock captured before tenant modules load. Point this
+    // instance at FakeTime's clock so the deadline remains deterministic here.
+    (renderer as unknown as { prewarmNow: () => number }).prewarmNow = Date.now;
     let probeCount = 0;
     const probeOptions: { signal?: AbortSignal; deadline?: number }[] = [];
     (renderer as unknown as {

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -1813,6 +1813,40 @@ describe("Renderer release asset cache isolation", () => {
     }
   });
 
+  it("bounds resolver probes while validating prewarm candidates", async () => {
+    const renderer = new Renderer({ cache: { store: createInMemoryStore() } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    let probeCount = 0;
+    (renderer as unknown as {
+      pageExists: (slug: string) => Promise<boolean>;
+    }).pageExists = () => {
+      probeCount++;
+      return Promise.resolve(false);
+    };
+
+    // Tenant-shaped worst case: many page-like candidates that never resolve.
+    const doomedSlugs = Array.from({ length: 500 }, (_, index) => `/doomed-${index}`);
+    const maxRoutes = 12;
+    const resolvable = await (renderer as unknown as {
+      filterResolvablePrewarmSlugs: (
+        ctx: RenderContext,
+        slugs: string[],
+        maxRoutes: number,
+      ) => Promise<string[]>;
+    }).filterResolvablePrewarmSlugs(makeRenderContext(), doomedSlugs, maxRoutes);
+
+    try {
+      assertEquals(resolvable, []);
+      assertEquals(
+        probeCount <= maxRoutes * 4,
+        true,
+        `resolver probes must stay bounded even when no candidate resolves (got ${probeCount})`,
+      );
+    } finally {
+      await renderer.destroy();
+    }
+  });
+
   it("prioritizes route-family siblings when prewarming production routes", async () => {
     const store = createInMemoryStore();
     const renderedSlugs: string[] = [];

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -1877,6 +1877,45 @@ describe("Renderer release asset cache isolation", () => {
     }
   });
 
+  it("keeps the prioritized candidate prefix when bounding probes", async () => {
+    const renderer = new Renderer({ cache: { store: createInMemoryStore() } });
+    (renderer as unknown as { initialized: boolean }).initialized = true;
+    let probeCount = 0;
+    (renderer as unknown as {
+      pageExists: (slug: string) => Promise<boolean>;
+    }).pageExists = () => {
+      probeCount++;
+      return Promise.resolve(true);
+    };
+
+    // selectPrewarmSlugs ranks route-family siblings first; the probe cap must
+    // not thin them out by striding uniformly across the whole candidate list.
+    const siblings = Array.from(
+      { length: 12 },
+      (_, index) => `/blog/articles/sibling-${index}`,
+    );
+    const unrelated = Array.from({ length: 488 }, (_, index) => `/unrelated-${index}`);
+    const maxRoutes = 12;
+    const resolvable = await (renderer as unknown as {
+      filterResolvablePrewarmSlugs: (
+        ctx: RenderContext,
+        slugs: string[],
+        maxRoutes: number,
+      ) => Promise<string[]>;
+    }).filterResolvablePrewarmSlugs(
+      makeRenderContext(),
+      [...siblings, ...unrelated],
+      maxRoutes,
+    );
+
+    try {
+      assertEquals(resolvable, siblings);
+      assertEquals(probeCount <= maxRoutes * 4, true);
+    } finally {
+      await renderer.destroy();
+    }
+  });
+
   it("uses one deadline for the complete resolver probe batch", async () => {
     using time = new FakeTime();
     const renderer = new Renderer({ cache: { store: createInMemoryStore() } });

--- a/src/rendering/renderer.test.ts
+++ b/src/rendering/renderer.test.ts
@@ -1836,10 +1836,13 @@ describe("Renderer release asset cache isolation", () => {
     }).filterResolvablePrewarmSlugs(makeRenderContext(), doomedSlugs, maxRoutes);
 
     try {
+      // Graceful degradation: nothing prewarms when no candidate resolves, and
+      // the probe count is pinned in both directions so neither an unbounded
+      // loop nor a silently probe-nothing implementation can pass.
       assertEquals(resolvable, []);
       assertEquals(
-        probeCount <= maxRoutes * 4,
-        true,
+        probeCount,
+        maxRoutes * 4,
         `resolver probes must stay bounded even when no candidate resolves (got ${probeCount})`,
       );
     } finally {
@@ -1871,7 +1874,7 @@ describe("Renderer release asset cache isolation", () => {
 
     try {
       assertEquals(resolvable, ["/valid-app-route"]);
-      assertEquals(probeCount <= maxRoutes * 4, true);
+      assertEquals(probeCount, maxRoutes * 4);
     } finally {
       await renderer.destroy();
     }
@@ -1910,7 +1913,8 @@ describe("Renderer release asset cache isolation", () => {
 
     try {
       assertEquals(resolvable, siblings);
-      assertEquals(probeCount <= maxRoutes * 4, true);
+      // Stops as soon as the route cap is met, well inside the probe budget.
+      assertEquals(probeCount, maxRoutes);
     } finally {
       await renderer.destroy();
     }
@@ -1921,13 +1925,20 @@ describe("Renderer release asset cache isolation", () => {
     const renderer = new Renderer({ cache: { store: createInMemoryStore() } });
     (renderer as unknown as { initialized: boolean }).initialized = true;
     let probeCount = 0;
+    const probeOptions: { signal?: AbortSignal; deadline?: number }[] = [];
     (renderer as unknown as {
-      pageExists: (slug: string) => Promise<boolean>;
-    }).pageExists = () => {
+      pageExists: (
+        slug: string,
+        ctx: RenderContext,
+        options: { signal?: AbortSignal; deadline?: number },
+      ) => Promise<boolean>;
+    }).pageExists = (_slug, _ctx, options) => {
       probeCount++;
+      probeOptions.push(options);
       return new Promise<boolean>(() => {});
     };
 
+    const startedAt = Date.now();
     const filtering = (renderer as unknown as {
       filterResolvablePrewarmSlugs: (
         ctx: RenderContext,
@@ -1945,6 +1956,10 @@ describe("Renderer release asset cache isolation", () => {
     try {
       assertEquals(await filtering, []);
       assertEquals(probeCount, 1);
+      // The stalled probe is cancelled and carries the batch deadline, so the
+      // resolver slot is not held for entity resolution's own default window.
+      assertEquals(probeOptions[0]?.signal?.aborted, true);
+      assertEquals(probeOptions[0]?.deadline, startedAt + 5_000);
     } finally {
       await renderer.destroy();
     }

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -121,6 +121,12 @@ const DEFAULT_RENDER_PREWARM_MAX_ROUTES = 12;
 const DEFAULT_RENDER_PREWARM_CONCURRENCY = 1;
 /** Bound remembered release contexts so multi-tenant processes cannot grow without limit. */
 const RENDER_PREWARM_CONTEXT_MAX_ENTRIES = 500;
+/**
+ * Bound resolver probes per prewarm run to a small multiple of the route cap.
+ * Tenant-controlled sources can surface many page-like candidates that never
+ * resolve, so validation work must stay bounded alongside the render count.
+ */
+const RENDER_PREWARM_PROBE_MULTIPLIER = 4;
 
 type RenderAdmission = "foreground" | "background";
 
@@ -1205,9 +1211,10 @@ export class Renderer {
   ): Promise<string[]> {
     if (maxRoutes <= 0) return [];
 
+    const maxProbes = maxRoutes * RENDER_PREWARM_PROBE_MULTIPLIER;
     const resolvable: string[] = [];
 
-    for (const slug of slugs) {
+    for (const slug of slugs.slice(0, maxProbes)) {
       try {
         if (await this.pageExists(slug, ctx)) {
           resolvable.push(slug);

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -108,6 +108,8 @@ const logger = rendererLogger.component("renderer");
 const IntrinsicArray = Array;
 const IntrinsicDateNow = Date.now;
 const IntrinsicMathFloor = Math.floor;
+const IntrinsicMathMax = Math.max;
+const IntrinsicMathMin = Math.min;
 
 /**
  * Master timeout for entire render pipeline (must be less than REQUEST_TIMEOUT_MS).
@@ -132,6 +134,14 @@ const RENDER_PREWARM_PROBE_BUDGET_MS = 5_000;
  * resolve, so validation work must stay bounded alongside the render count.
  */
 const RENDER_PREWARM_PROBE_MULTIPLIER = 4;
+/**
+ * Share of the probe budget reserved for the highest-priority candidates.
+ * `selectPrewarmSlugs` ranks candidates against the slug being rendered, so the
+ * prefix holds the route-family siblings that prewarming exists to warm; the
+ * rest of the budget spreads across the remainder so an unresolvable prefix
+ * cannot hide every valid route.
+ */
+const RENDER_PREWARM_PROBE_PREFIX_RATIO = 0.5;
 
 type RenderAdmission = "foreground" | "background";
 
@@ -148,19 +158,55 @@ const RENDER_PREWARM_CONCURRENCY = getBoundedEnvNumber(
   8,
 );
 
+/**
+ * Choose which prewarm candidates may reach the resolver once the candidate
+ * list exceeds the probe budget.
+ *
+ * The budget is split in two so neither failure mode wins outright:
+ *
+ *  - a prioritized prefix keeps the route-family ordering `selectPrewarmSlugs`
+ *    established, so siblings of the slug being rendered are still probed
+ *    first instead of being thinned out by a uniform stride;
+ *  - the remaining budget samples the suffix at an even stride and always ends
+ *    on the final candidate, so a long unresolvable prefix cannot hide every
+ *    route the selected router would accept.
+ *
+ * Sampling is positional rather than router-aware because `getAllPages()`
+ * returns slugs without provenance. The prefix carries most of the weight
+ * anyway: ranking is anchored on the currently rendering slug, which the
+ * selected router already resolved, so its nearest neighbours come from that
+ * same router in practice.
+ */
 function selectPrewarmProbeCandidates(slugs: string[], maxProbes: number): string[] {
   if (slugs.length <= maxProbes) return slugs;
 
-  // Preserve the priority order while sampling the entire candidate range.
-  // Always include both ends so an invalid prefix cannot hide every route from
-  // the selected router.
+  const prefixCount = IntrinsicMathMax(
+    1,
+    IntrinsicMathMin(
+      maxProbes - 1,
+      IntrinsicMathFloor(maxProbes * RENDER_PREWARM_PROBE_PREFIX_RATIO),
+    ),
+  );
+  const sampleCount = maxProbes - prefixCount;
   const selected = new IntrinsicArray<string>(maxProbes);
+  for (let prefixIndex = 0; prefixIndex < prefixCount; prefixIndex += 1) {
+    selected[prefixIndex] = slugs[prefixIndex]!;
+  }
+
   const lastIndex = slugs.length - 1;
-  for (let probeIndex = 0; probeIndex < maxProbes; probeIndex += 1) {
-    const sourceIndex = IntrinsicMathFloor(
-      (probeIndex * lastIndex) / (maxProbes - 1),
+  if (sampleCount === 1) {
+    selected[prefixCount] = slugs[lastIndex]!;
+    return selected;
+  }
+
+  // slugs.length > maxProbes, so the suffix is at least `sampleCount` wide and
+  // the stride below never repeats an index.
+  const suffixSpan = lastIndex - prefixCount;
+  for (let sampleIndex = 0; sampleIndex < sampleCount; sampleIndex += 1) {
+    const sourceIndex = prefixCount + IntrinsicMathFloor(
+      (sampleIndex * suffixSpan) / (sampleCount - 1),
     );
-    selected[probeIndex] = slugs[sourceIndex]!;
+    selected[prefixCount + sampleIndex] = slugs[sourceIndex]!;
   }
   return selected;
 }

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -105,6 +105,9 @@ import {
 import { resolveSSRControlOutcome } from "./ssr-outcome.ts";
 
 const logger = rendererLogger.component("renderer");
+const IntrinsicArray = Array;
+const IntrinsicDateNow = Date.now;
+const IntrinsicMathFloor = Math.floor;
 
 /**
  * Master timeout for entire render pipeline (must be less than REQUEST_TIMEOUT_MS).
@@ -121,6 +124,8 @@ const DEFAULT_RENDER_PREWARM_MAX_ROUTES = 12;
 const DEFAULT_RENDER_PREWARM_CONCURRENCY = 1;
 /** Bound remembered release contexts so multi-tenant processes cannot grow without limit. */
 const RENDER_PREWARM_CONTEXT_MAX_ENTRIES = 500;
+/** Total time allowed for one background prewarm resolver probe batch. */
+const RENDER_PREWARM_PROBE_BUDGET_MS = 5_000;
 /**
  * Bound resolver probes per prewarm run to a small multiple of the route cap.
  * Tenant-controlled sources can surface many page-like candidates that never
@@ -142,6 +147,23 @@ const RENDER_PREWARM_CONCURRENCY = getBoundedEnvNumber(
   1,
   8,
 );
+
+function selectPrewarmProbeCandidates(slugs: string[], maxProbes: number): string[] {
+  if (slugs.length <= maxProbes) return slugs;
+
+  // Preserve the priority order while sampling the entire candidate range.
+  // Always include both ends so an invalid prefix cannot hide every route from
+  // the selected router.
+  const selected = new IntrinsicArray<string>(maxProbes);
+  const lastIndex = slugs.length - 1;
+  for (let probeIndex = 0; probeIndex < maxProbes; probeIndex += 1) {
+    const sourceIndex = IntrinsicMathFloor(
+      (probeIndex * lastIndex) / (maxProbes - 1),
+    );
+    selected[probeIndex] = slugs[sourceIndex]!;
+  }
+  return selected;
+}
 
 /**
  * Options for initializing the Renderer
@@ -1212,11 +1234,21 @@ export class Renderer {
     if (maxRoutes <= 0) return [];
 
     const maxProbes = maxRoutes * RENDER_PREWARM_PROBE_MULTIPLIER;
+    const deadline = IntrinsicDateNow() + RENDER_PREWARM_PROBE_BUDGET_MS;
     const resolvable: string[] = [];
 
-    for (const slug of slugs.slice(0, maxProbes)) {
+    for (const slug of selectPrewarmProbeCandidates(slugs, maxProbes)) {
+      const remainingMs = deadline - IntrinsicDateNow();
+      if (remainingMs <= 0) break;
+
       try {
-        if (await this.pageExists(slug, ctx)) {
+        if (
+          await withTimeoutThrow(
+            this.pageExists(slug, ctx),
+            remainingMs,
+            "Production render prewarm route validation",
+          )
+        ) {
           resolvable.push(slug);
           if (resolvable.length >= maxRoutes) break;
         }
@@ -1227,6 +1259,7 @@ export class Renderer {
           releaseId: ctx.releaseId,
           error: error instanceof Error ? error.message : String(error),
         });
+        if (error instanceof TimeoutError) break;
       }
     }
 

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -140,6 +140,7 @@ const RENDER_PREWARM_PROBE_MULTIPLIER = 4;
 const RENDER_PREWARM_PROBE_PREFIX_RATIO = 0.5;
 
 type RenderAdmission = "foreground" | "background";
+type PrewarmProbeResult = "resolvable" | "missing" | "timed-out";
 
 const RENDER_PREWARM_MAX_ROUTES = getBoundedEnvNumber(
   "VERYFRONT_RENDER_PREWARM_MAX_ROUTES",
@@ -1310,42 +1311,50 @@ export class Renderer {
     const resolvable: string[] = [];
 
     for (const slug of candidates) {
-      const remainingMs = deadline - Date.now();
-      if (remainingMs <= 0) break;
-
-      // Cancel the probe when the batch budget expires so the resolver slot is
-      // released instead of being held until entity resolution's own default
-      // deadline. The deadline is threaded through as well, so the lookup can
-      // never outlive this batch even if it never observes the abort.
-      const probeAbort = new AbortController();
-      const probe = this.pageExists(slug, ctx, { signal: probeAbort.signal, deadline });
-      // The probe outlives a timeout rejection; keep its late outcome handled.
-      void probe.catch(() => {});
-
-      try {
-        if (
-          await withTimeoutThrow(
-            probe,
-            remainingMs,
-            "Production render prewarm route validation",
-            { onTimeout: () => probeAbort.abort() },
-          )
-        ) {
-          resolvable.push(slug);
-          if (resolvable.length >= maxRoutes) break;
-        }
-      } catch (error) {
-        logger.warn("Production render prewarm route validation failed", {
-          slug,
-          projectId: ctx.projectId,
-          releaseId: ctx.releaseId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        if (error instanceof TimeoutError) break;
-      }
+      const result = await this.probePrewarmCandidate(ctx, slug, deadline);
+      if (result === "timed-out") break;
+      if (result !== "resolvable") continue;
+      resolvable.push(slug);
+      if (resolvable.length >= maxRoutes) break;
     }
 
     return resolvable;
+  }
+
+  private async probePrewarmCandidate(
+    ctx: RenderContext,
+    slug: string,
+    deadline: number,
+  ): Promise<PrewarmProbeResult> {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) return "timed-out";
+
+    // Cancel the probe when the batch budget expires so the resolver slot is
+    // released instead of being held until entity resolution's own default
+    // deadline. The deadline is threaded through as well, so the lookup can
+    // never outlive this batch even if it never observes the abort.
+    const probeAbort = new AbortController();
+    const probe = this.pageExists(slug, ctx, { signal: probeAbort.signal, deadline });
+    // The probe outlives a timeout rejection; keep its late outcome handled.
+    void probe.catch(() => {});
+
+    try {
+      const exists = await withTimeoutThrow(
+        probe,
+        remainingMs,
+        "Production render prewarm route validation",
+        { onTimeout: () => probeAbort.abort() },
+      );
+      return exists ? "resolvable" : "missing";
+    } catch (error) {
+      logger.warn("Production render prewarm route validation failed", {
+        slug,
+        projectId: ctx.projectId,
+        releaseId: ctx.releaseId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return error instanceof TimeoutError ? "timed-out" : "missing";
+    }
   }
 
   async clearCache(ctx: RenderContext, slug?: string): Promise<void> {

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -106,6 +106,7 @@ import {
 import { resolveSSRControlOutcome } from "./ssr-outcome.ts";
 
 const logger = rendererLogger.component("renderer");
+const IntrinsicDateNow = Date.now;
 
 /**
  * Master timeout for entire render pipeline (must be less than REQUEST_TIMEOUT_MS).
@@ -356,6 +357,8 @@ export class Renderer {
   /** Lets foreground followers recover when a background leader fails fast at capacity. */
   private renderFlightAdmissions = new Map<string, RenderAdmission>();
   private productionPrewarmContexts = new Map<string, Promise<void>>();
+  /** Clock captured before tenant modules can replace `Date.now`. */
+  private prewarmNow = IntrinsicDateNow;
 
   constructor(options: RendererOptions = {}) {
     this.cache = new ContextAwareCacheCoordinator(options.cache);
@@ -1298,7 +1301,7 @@ export class Renderer {
     if (maxRoutes <= 0) return [];
 
     const maxProbes = maxRoutes * RENDER_PREWARM_PROBE_MULTIPLIER;
-    const deadline = Date.now() + RENDER_PREWARM_PROBE_BUDGET_MS;
+    const deadline = this.prewarmNow() + RENDER_PREWARM_PROBE_BUDGET_MS;
     const candidates = selectPrewarmProbeCandidates(slugs, maxProbes);
     if (candidates.length < slugs.length) {
       logger.debug("Production render prewarm probe budget truncated candidates", {
@@ -1326,7 +1329,7 @@ export class Renderer {
     slug: string,
     deadline: number,
   ): Promise<PrewarmProbeResult> {
-    const remainingMs = deadline - Date.now();
+    const remainingMs = deadline - this.prewarmNow();
     if (remainingMs <= 0) return "timed-out";
 
     // Cancel the probe when the batch budget expires so the resolver slot is

--- a/src/rendering/renderer.ts
+++ b/src/rendering/renderer.ts
@@ -80,6 +80,7 @@ import { RenderPipeline } from "./orchestrator/pipeline.ts";
 import { createLayoutComponentCache } from "./layouts/utils/component-loader.ts";
 import type { PageDataResponse, RenderOptions, RenderResult } from "./orchestrator/types.ts";
 import type { HandlerContext } from "#veryfront/types";
+import type { EntityResolutionOptions } from "#veryfront/types/entities/getEntityInfo.ts";
 import { TimeoutError, withTimeoutThrow } from "./utils/stream-utils.ts";
 import { Singleflight, SingleflightFollowerLimitError } from "#veryfront/utils/singleflight.ts";
 import {
@@ -105,11 +106,6 @@ import {
 import { resolveSSRControlOutcome } from "./ssr-outcome.ts";
 
 const logger = rendererLogger.component("renderer");
-const IntrinsicArray = Array;
-const IntrinsicDateNow = Date.now;
-const IntrinsicMathFloor = Math.floor;
-const IntrinsicMathMax = Math.max;
-const IntrinsicMathMin = Math.min;
 
 /**
  * Master timeout for entire render pipeline (must be less than REQUEST_TIMEOUT_MS).
@@ -180,15 +176,15 @@ const RENDER_PREWARM_CONCURRENCY = getBoundedEnvNumber(
 function selectPrewarmProbeCandidates(slugs: string[], maxProbes: number): string[] {
   if (slugs.length <= maxProbes) return slugs;
 
-  const prefixCount = IntrinsicMathMax(
+  const prefixCount = Math.max(
     1,
-    IntrinsicMathMin(
+    Math.min(
       maxProbes - 1,
-      IntrinsicMathFloor(maxProbes * RENDER_PREWARM_PROBE_PREFIX_RATIO),
+      Math.floor(maxProbes * RENDER_PREWARM_PROBE_PREFIX_RATIO),
     ),
   );
   const sampleCount = maxProbes - prefixCount;
-  const selected = new IntrinsicArray<string>(maxProbes);
+  const selected = new Array<string>(maxProbes);
   for (let prefixIndex = 0; prefixIndex < prefixCount; prefixIndex += 1) {
     selected[prefixIndex] = slugs[prefixIndex]!;
   }
@@ -203,7 +199,7 @@ function selectPrewarmProbeCandidates(slugs: string[], maxProbes: number): strin
   // the stride below never repeats an index.
   const suffixSpan = lastIndex - prefixCount;
   for (let sampleIndex = 0; sampleIndex < sampleCount; sampleIndex += 1) {
-    const sourceIndex = prefixCount + IntrinsicMathFloor(
+    const sourceIndex = prefixCount + Math.floor(
       (sampleIndex * suffixSpan) / (sampleCount - 1),
     );
     selected[prefixCount + sampleIndex] = slugs[sourceIndex]!;
@@ -1267,16 +1263,32 @@ export class Renderer {
     return createPageResolver(ctx).getAllPages();
   }
 
-  async pageExists(slug: string, ctx: RenderContext): Promise<boolean> {
+  async pageExists(
+    slug: string,
+    ctx: RenderContext,
+    options: EntityResolutionOptions = {},
+  ): Promise<boolean> {
     if (!this.initialized) {
       throw INITIALIZATION_ERROR.create({
         detail: "Renderer not initialized. Call initialize() first.",
       });
     }
 
-    return createPageResolver(ctx).pageExists(slug);
+    return createPageResolver(ctx).pageExists(slug, options);
   }
 
+  /**
+   * Probe prewarm candidates for resolvability under a bounded probe budget.
+   *
+   * Prewarming degrades gracefully rather than exhaustively: at most
+   * `maxRoutes * RENDER_PREWARM_PROBE_MULTIPLIER` candidates reach the
+   * resolver, and the whole batch shares one `RENDER_PREWARM_PROBE_BUDGET_MS`
+   * deadline. A project whose candidate list is dominated by slugs the
+   * selected router cannot resolve can therefore end up prewarming nothing.
+   * That is the accepted trade: prewarming is a cache optimization, while an
+   * unbounded probe loop is a resource-exhaustion vector on shared renderer
+   * pods. Truncation is logged so the degraded case stays visible.
+   */
   private async filterResolvablePrewarmSlugs(
     ctx: RenderContext,
     slugs: string[],
@@ -1285,19 +1297,38 @@ export class Renderer {
     if (maxRoutes <= 0) return [];
 
     const maxProbes = maxRoutes * RENDER_PREWARM_PROBE_MULTIPLIER;
-    const deadline = IntrinsicDateNow() + RENDER_PREWARM_PROBE_BUDGET_MS;
+    const deadline = Date.now() + RENDER_PREWARM_PROBE_BUDGET_MS;
+    const candidates = selectPrewarmProbeCandidates(slugs, maxProbes);
+    if (candidates.length < slugs.length) {
+      logger.debug("Production render prewarm probe budget truncated candidates", {
+        projectId: ctx.projectId,
+        releaseId: ctx.releaseId,
+        candidateCount: slugs.length,
+        probeCount: candidates.length,
+      });
+    }
     const resolvable: string[] = [];
 
-    for (const slug of selectPrewarmProbeCandidates(slugs, maxProbes)) {
-      const remainingMs = deadline - IntrinsicDateNow();
+    for (const slug of candidates) {
+      const remainingMs = deadline - Date.now();
       if (remainingMs <= 0) break;
+
+      // Cancel the probe when the batch budget expires so the resolver slot is
+      // released instead of being held until entity resolution's own default
+      // deadline. The deadline is threaded through as well, so the lookup can
+      // never outlive this batch even if it never observes the abort.
+      const probeAbort = new AbortController();
+      const probe = this.pageExists(slug, ctx, { signal: probeAbort.signal, deadline });
+      // The probe outlives a timeout rejection; keep its late outcome handled.
+      void probe.catch(() => {});
 
       try {
         if (
           await withTimeoutThrow(
-            this.pageExists(slug, ctx),
+            probe,
             remainingMs,
             "Production render prewarm route validation",
+            { onTimeout: () => probeAbort.abort() },
           )
         ) {
           resolvable.push(slug);

--- a/src/rendering/ssr-renderer.test.ts
+++ b/src/rendering/ssr-renderer.test.ts
@@ -24,6 +24,16 @@ import { resolveCommittedHeadFromHTML } from "./orchestrator/html-head.ts";
 
 type PipeableSSRStream = ReturnType<NonNullable<ReactDOMServer["renderToPipeableStream"]>>;
 
+/**
+ * React's own nonce option type. React 19.2 widened it from `string` to
+ * `string | { script?: string; style?: string }`, so observing it through this
+ * alias keeps the assertion honest across React type versions instead of
+ * pinning the test to whichever shape happened to ship first.
+ */
+type ReadableStreamNonce = NonNullable<
+  Parameters<NonNullable<ReactDOMServer["renderToReadableStream"]>>[1]
+>["nonce"];
+
 function createPipeableSSRStream(
   pipeImpl: (writable: NodeJS.WritableStream) => void,
   abortImpl: () => void = () => {},
@@ -94,7 +104,7 @@ describe("rendering/ssr-renderer", () => {
   });
 
   it("forwards the response nonce to React-owned streaming scripts", async () => {
-    let observedNonce: string | undefined;
+    let observedNonce: ReadableStreamNonce;
     const streamAllReady: Promise<void> = Promise.resolve();
     __injectReactDOMServerForTests({
       renderToString: () => "<div>unused</div>",


### PR DESCRIPTION
## Vulnerability

Production render prewarm is meant to be bounded by `VERYFRONT_RENDER_PREWARM_MAX_ROUTES`, but only the render count was capped, not the validation work. `selectPrewarmSlugs` (`src/rendering/renderer.ts`) returns every concrete candidate it finds, and `runProductionRenderPrewarm` passes that full, uncapped list into `filterResolvablePrewarmSlugs`, which calls `pageExists` sequentially for each candidate until `maxRoutes` resolvable routes are found, with no probe cap, no time budget, and no abort signal (non-file-not-found errors are logged and the loop continues). Because `getAllPages` in `src/rendering/page-resolution/page-resolver.ts` discovers slugs from the app dir, the pages dir, and project-root page-like files regardless of `config.router`, while `resolvePage` with `config.router === "app"` resolves only via `getAppRouteEntity`, tenant-controlled source can produce thousands of candidates that all fail resolution. Each failed probe is a full `resolvePage` (tracing span, entity-resolution admission session, filesystem work). A single cacheable production request can therefore kick off thousands of background resolver probes on shared multi-tenant renderer pods, and the per-process dedup map is FIFO-evicted at 500 entries and cleared on failure, so it is re-triggerable across releases, pod restarts, and key churn. Impact is resource exhaustion against shared renderer capacity; severity is tempered by probes running sequentially in a single background loop and the render count itself staying capped.

- Codex finding id: `88e944b7f1088191a5f9091f1b2a5f19`
- Severity: medium

## Fix

`filterResolvablePrewarmSlugs` now bounds probe work along three axes, so both renders and resolver probes are capped per prewarm run.

1. **Probe count cap.** `RENDER_PREWARM_PROBE_MULTIPLIER = 4` allows at most `maxRoutes * 4` resolver probes per run (48 at the default cap of 12).
2. **Shared batch deadline.** `RENDER_PREWARM_PROBE_BUDGET_MS = 5_000` gives the whole batch one deadline. Each probe is wrapped in `withTimeoutThrow` with the remaining budget, and a `TimeoutError` breaks the loop rather than moving to the next candidate. The deadline is also threaded into the lookup as `EntityResolutionOptions.deadline`, and `onTimeout` aborts a per-probe `AbortController` whose signal reaches `PageResolver.pageExists` / `resolvePage`, so a stalled tenant filesystem releases its resolver slot at the batch deadline instead of running to entity resolution's own default window. `Renderer.pageExists` gained an optional third `EntityResolutionOptions` argument to carry this; the existing two-argument call shape is unchanged.
3. **Candidate sampling.** When the candidate list exceeds the probe budget, `selectPrewarmProbeCandidates` splits the budget by `RENDER_PREWARM_PROBE_PREFIX_RATIO = 0.5`: half goes to the highest-ranked prefix (the route-family siblings `selectPrewarmSlugs` ordered against the slug being rendered), and half strides evenly across the remainder, always including the final candidate. A uniform stride alone would thin out the siblings prewarming exists to warm; a plain prefix alone would let a long unresolvable prefix hide every route the selected router accepts. Sampling is positional, not router-aware, because `getAllPages()` returns bare slugs with no provenance.

### Accepted trade-off

Prewarming now degrades gracefully instead of exhaustively. A project with an explicit `config.router` and a candidate list dominated by cross-router slugs can end up prewarming nothing, where the previous unbounded loop would eventually have found valid routes. That is intentional: prewarming is a cache optimization, an unbounded probe loop is a resource-exhaustion vector on shared pods. To keep the degraded case visible, `filterResolvablePrewarmSlugs` emits a `debug` log ("Production render prewarm probe budget truncated candidates", with `candidateCount` and `probeCount`) whenever the budget truncates the candidate list, and the contract is documented on the method.

Residual limitation: aborting a probe reports cancellation immediately, but `withEntityResolutionAdmission` still holds its permits until any adapter promise that cannot be cancelled settles. The exhaustion vector is closed (at most one lookup per prewarm run can be left settling), but a truly wedged filesystem call is not forcibly reclaimed.

## Test evidence

Four tests in `src/rendering/renderer.test.ts` cover `filterResolvablePrewarmSlugs`:

- `bounds resolver probes while validating prewarm candidates` feeds 500 candidates that never resolve and asserts the probe count is exactly `maxRoutes * 4`, pinning the cap in both directions so a probe-nothing implementation fails too.
- `samples beyond an invalid candidate prefix` puts the only resolvable route last behind 499 unresolvable ones and asserts it is still found within the same exact probe count.
- `keeps the prioritized candidate prefix when bounding probes` asserts the 12 ranked route-family siblings are all probed and returned, and that the loop stops at exactly `maxRoutes` probes.
- `uses one deadline for the complete resolver probe batch` uses `FakeTime` with a stalled `pageExists` and asserts only one probe starts, the batch returns empty at the 5s deadline, and the in-flight probe received the batch `deadline` and an aborted signal.

- `deno task test:file src/rendering/renderer.test.ts` -> `ok | 5 passed (70 steps) | 0 failed`
- `deno task test:file src/rendering/page-resolution/page-resolver.test.ts` -> `ok | 1 passed (34 steps) | 0 failed`
- Regression check: with the probe cap reverted, the bounded-probe test fails with `resolver probes must stay bounded even when no candidate resolves (got 500)`
- `deno fmt`, `deno lint`, `deno check` on `src/rendering/renderer.ts` and `src/rendering/renderer.test.ts` -> clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited route prewarming validation checks to a bounded number of candidates.
  * Added a shared time budget for prewarm route validation and cancellation of stalled lookups.
  * Improved performance and predictability when processing large sets of unresolvable routes.

* **Tests**
  * Added coverage confirming that resolver checks remain within the configured limit, sample past unresolvable candidates, and stop at the batch deadline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
