### PR TITLE
fix(security): redact gate failure evidence in exported eval reports

### DIFF
--- a/src/extensions/eval/eval-report-exporter.test.ts
+++ b/src/extensions/eval/eval-report-exporter.test.ts
@@ -1,7 +1,8 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assert, assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import type { EvalReport } from "veryfront/eval";
+import type { EvalMetricResult, EvalReport } from "veryfront/eval";
+import { summarizeEvalRecords } from "veryfront/eval";
 import {
   createEvalReportExporterRegistry,
   redactEvalReportForExport,
@@ -93,6 +94,34 @@ function createReport(): EvalReport {
       },
     ],
   };
+}
+
+const failingCitationMetric: EvalMetricResult = {
+  name: "knowledge.citationPrecision",
+  family: "knowledge",
+  severity: "gate",
+  score: 0,
+  pass: false,
+  explanation: "0 of 1 citations were supported.",
+  evidence: {
+    tool: "knowledge.search",
+    citations: ["[1] secret roadmap passage"],
+    expected: ["Private roadmap: secret roadmap passage"],
+    supported: [],
+    unsupported: ["[1] secret roadmap passage"],
+    supportedCount: 0,
+    citationCount: 1,
+  },
+};
+
+/** Report whose only metric is a failing citation gate, so the summary carries a gate failure. */
+function createCitationFailureReport(): EvalReport {
+  const report = createReport();
+  const record = report.records[0];
+  assert(record);
+  record.metrics = [failingCitationMetric];
+  report.summary = summarizeEvalRecords(report.records);
+  return report;
 }
 
 describe("EvalReportExporterRegistry", () => {
@@ -399,6 +428,51 @@ describe("EvalReportExporterRegistry", () => {
       },
       redaction: { metadataAllowlist: ["topic"] },
     });
+  });
+
+  it("redacts gate failure evidence and explanations copied into the summary", async () => {
+    const registry = createEvalReportExporterRegistry();
+    const exportedReports: EvalReport[] = [];
+
+    registry.register({
+      id: "capture",
+      export(report) {
+        exportedReports.push(report);
+      },
+    });
+
+    await registry.export(createCitationFailureReport());
+
+    const exportedReport = exportedReports[0];
+    assert(exportedReport);
+    const gateFailure = exportedReport.summary.gateFailures?.[0];
+    assert(gateFailure, "the failing citation gate must still be reported");
+    assertEquals(gateFailure.name, "knowledge.citationPrecision");
+    assertEquals(gateFailure.evidence, undefined);
+    assertEquals(gateFailure.explanation, undefined);
+    // Citation labels and expected-source labels are content-derived, so no part of the exported
+    // report may still carry them.
+    const serialized = JSON.stringify(exportedReport);
+    assert(
+      !serialized.includes("secret roadmap passage"),
+      "citation evidence must not survive default export redaction",
+    );
+    assert(
+      !serialized.includes("Private roadmap"),
+      "expected source labels must not survive default export redaction",
+    );
+  });
+
+  it("keeps gate failure details when export redaction explicitly allows them", () => {
+    const redacted = redactEvalReportForExport(createCitationFailureReport(), {
+      includeMetricEvidence: true,
+      includeMetricExplanations: true,
+    });
+
+    const gateFailure = redacted.summary.gateFailures?.[0];
+    assert(gateFailure);
+    assertEquals(gateFailure.explanation, "0 of 1 citations were supported.");
+    assertEquals(gateFailure.evidence, failingCitationMetric.evidence);
   });
 
   it("keeps full record fields only when export redaction explicitly allows them", () => {

--- a/src/extensions/eval/eval-report-exporter.ts
+++ b/src/extensions/eval/eval-report-exporter.ts
@@ -8,7 +8,12 @@
  * @module extensions/eval/eval-report-exporter
  */
 
-import type { EvalMetricResult, EvalRecord, EvalReport } from "#veryfront/eval/types.ts";
+import type {
+  EvalGateFailureSummary,
+  EvalMetricResult,
+  EvalRecord,
+  EvalReport,
+} from "#veryfront/eval/types.ts";
 import { assertRegistrationMethod, captureRegistrationId } from "../runtime-validation.ts";
 import { describeThrownValue } from "../safe-value.ts";
 
@@ -35,11 +40,15 @@ export interface EvalReportExportRedaction {
   includeRetrievedContext?: boolean;
   /** Include answer citation payloads. Defaults to false. */
   includeCitations?: boolean;
-  /** Include metric/check explanations. Defaults to false. */
+  /**
+   * Include metric/check explanations. Defaults to false. Applies to record results and to the
+   * summary gate failures that copy them.
+   */
   includeMetricExplanations?: boolean;
   /**
-   * Include metric/check evidence payloads. Defaults to false. Metric labels restate the same
-   * configured parameters, so they follow this setting on both record and summary metrics.
+   * Include metric/check evidence payloads. Defaults to false. Applies to record results and to the
+   * summary gate failures that copy them. Metric labels restate the same configured parameters, so
+   * they follow this setting on both record and summary metrics.
    */
   includeMetricEvidence?: boolean;
   /** Include dataset source paths. Defaults to false. */
@@ -185,19 +194,41 @@ function redactMetricResults(
   });
 }
 
-function redactMetricSummaries(
+function redactGateFailures(
+  gateFailures: EvalGateFailureSummary[],
+  redaction: EvalReportExportRedaction,
+): EvalGateFailureSummary[] {
+  return gateFailures.map((failure) => {
+    const redacted: EvalGateFailureSummary = { ...failure };
+    if (!redaction.includeMetricExplanations) {
+      delete redacted.explanation;
+    }
+    if (!redaction.includeMetricEvidence) {
+      delete redacted.evidence;
+    }
+    return redacted;
+  });
+}
+
+function redactSummary(
   summary: EvalReport["summary"],
   redaction: EvalReportExportRedaction,
 ): EvalReport["summary"] {
-  if (redaction.includeMetricEvidence) return summary;
-  return {
-    ...summary,
-    metrics: summary.metrics.map((metric) => {
-      const redacted = { ...metric };
-      delete redacted.label;
-      return redacted;
-    }),
-  };
+  const redacted: EvalReport["summary"] = { ...summary };
+  if (!redaction.includeMetricEvidence) {
+    redacted.metrics = summary.metrics.map((metric) => {
+      const redactedMetric = { ...metric };
+      delete redactedMetric.label;
+      return redactedMetric;
+    });
+  }
+  // Every gate failure copies the blocking result's explanation and evidence verbatim, so citation
+  // labels and retrieved-source labels reach the summary too. They leave on the same terms as the
+  // record-level metric they came from.
+  if (summary.gateFailures) {
+    redacted.gateFailures = redactGateFailures(summary.gateFailures, redaction);
+  }
+  return redacted;
 }
 
 function cloneRedaction(
@@ -252,7 +283,7 @@ export function redactEvalReportForExport(
   return {
     ...cloned,
     ...(cloned.dataset ? { dataset: redactDatasetMetadata(cloned.dataset, redaction) } : {}),
-    summary: redactMetricSummaries(cloned.summary, redaction),
+    summary: redactSummary(cloned.summary, redaction),
     records: cloned.records.map((record) => redactRecord(record, redaction)),
   };
 }


### PR DESCRIPTION
## Vulnerability

Eval report exporters are documented and implemented as receiving redacted reports by default, but `redactEvalReportForExport` only sanitized `records` and `summary.metrics[].label`. `createResultFailure` (`src/eval/report.ts:196-210`) copies each blocking result's `evidence` and `explanation` verbatim into `summary.gateFailures`, and the RAG citation metrics `knowledge.citationPrecision` / `knowledge.citationRecall` put citation labels plus expected/retrieved source labels into that evidence (with `expectedSourceLabel` falling back to `contentMatch` / `verificationQuote` / `content` / `text`, i.e. content-derived text). Because those metrics are gates at `min: 1`, any failing citation check pushed private RAG citation and source detail into `summary.gateFailures`, and the exporter registry then handed that report to every configured third-party exporter — even with `includeCitations`, `includeRetrievedContext`, `includeMetricEvidence`, and `includeMetricExplanations` all left at their fail-closed defaults. Impact: private evaluation content leaves the process to an external observability vendor precisely in the case default redaction is documented to protect.

- Codex finding id: `8f8421e22e948191a0882b08c437ffd6`
- Severity: medium
- Introduced in: `9604ba031` (Eval V2: add RAG citation metrics, #2905)

## Fix

`redactMetricSummaries` becomes `redactSummary`, which now also walks `summary.gateFailures` and applies the same policy the per-record results already follow: `evidence` survives only under `includeMetricEvidence`, `explanation` only under `includeMetricExplanations`. The failure entry itself (record id, example id, repetition, metric name, family, severity) still reaches exporters, so gate-failure counts and shapes in downstream exporters (for example `ext-eval-report-mlflow`, which reads `gateFailures.length`) are unchanged. CLI output and on-disk reports are untouched; this boundary governs only what reaches an exporter. The redaction option docs were updated to state that both flags cover summary gate failures.

## Tests

Two cases added to `src/extensions/eval/eval-report-exporter.test.ts`, built from a failing `knowledge.citationPrecision` record whose summary is produced by the real `summarizeEvalRecords`, so the report.ts → exporter copy path is exercised end to end:

- default redaction leaves the gate failure present but drops `evidence` and `explanation`, and no citation text or expected-source label appears anywhere in the serialized exported report;
- `includeMetricEvidence` + `includeMetricExplanations` still deliver both.

Verified in the worktree:

- `deno task test:file src/extensions/eval/eval-report-exporter.test.ts` — ok, 12 steps (the new default-redaction case fails against `origin/main`'s exporter, confirmed by reverting the source file and re-running).
- `deno task test:file src/eval/report.test.ts` — ok, 9 steps.
- `deno task test:file src/eval/runner.test.ts` — ok, 21 steps.
- `deno fmt --check`, `deno lint`, `deno check` on both touched files — clean.

https://claude.ai/code/session_01QfWNMiUhvWMKWi6BGfVdY3
