### PR TITLE
fix(security): stop .vfignore negations from overriding secret ignore defaults

### DIFF
--- a/cli/commands/pull/command.ts
+++ b/cli/commands/pull/command.ts
@@ -407,7 +407,7 @@ async function listManagedLocalFiles(
       const path = join(currentDir, entry.name);
       const relativePath = relative(projectDir, path).replace(/\\/g, "/");
 
-      if (ignoreChecker.isIgnored(relativePath)) continue;
+      if (ignoreChecker.isIgnored(relativePath, { isDirectory: entry.isDirectory })) continue;
       if (entry.isSymlink) {
         if (ignoreChecker.isSupportedExtension(entry.name)) {
           throw new Error(

--- a/cli/commands/push/command-help.ts
+++ b/cli/commands/push/command-help.ts
@@ -52,6 +52,7 @@ export const pushHelp: CommandHelp = {
     "Use --prune to remove managed remote files that are missing locally",
     "Run veryfront deploy when the preview is ready for an environment",
     ".vfignore excludes matching local files and preserves matching remote files",
+    "With --prune, remote .env, .env.*, .veryfront, and .git paths are always removed",
     "--dry-run previews deletions only when --prune is present",
     "--dry-run never creates a project or branch, changes remote files, or writes a Push receipt",
   ],

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -4774,6 +4774,70 @@ describe("push deletion ownership", () => {
     }
   });
 
+  it("keeps protected deletion context when a preserved remote file lacks content", async () => {
+    const originalFetch = globalThis.fetch;
+    const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];
+    const savedEnv = envKeys.map((key) => Deno.env.get(key));
+
+    try {
+      await withGitProject(async ({ projectDir }) => {
+        Deno.env.set("VERYFRONT_API_TOKEN", "<TOKEN>");
+        Deno.env.set("VERYFRONT_API_URL", "https://control.example.test");
+        Deno.env.set("VERYFRONT_PROJECT_SLUG", "my-project");
+        _resetEnvironmentConfig();
+
+        let uploadedApp = false;
+        let protectedDeleted = false;
+        globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          const url = new URL(request.url);
+          if (request.method === "GET" && url.pathname === "/projects/my-project") {
+            return Response.json({ id: "project-123", slug: "my-project" });
+          }
+          if (request.method === "GET" && url.pathname === "/projects/my-project/files") {
+            return Response.json({
+              data: [
+                {
+                  path: "app.ts",
+                  content: uploadedApp ? "export const value = 1;\n" : "stale app",
+                },
+                ...(!protectedDeleted
+                  ? [{ path: ".env.production", content: "SECRET=<REDACTED>\n" }]
+                  : [{ path: "assets/logo.png" }]),
+              ],
+              page_info: {},
+            });
+          }
+          if (request.method === "PUT") {
+            uploadedApp = true;
+            return Response.json({});
+          }
+          if (request.method === "DELETE") {
+            protectedDeleted = true;
+            return Response.json({});
+          }
+          throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
+        }) as typeof fetch;
+
+        const error = await assertRejects(
+          () => pushCommand({ projectDir, branch: "main", prune: true, force: true, quiet: true }),
+          Error,
+          "Push finalization failed after remote files were deleted",
+        );
+
+        assertEquals(protectedDeleted, true);
+        assertEquals(
+          (error as Error & { context?: Record<string, unknown> }).context?.protectedDeleted,
+          [".env.production"],
+        );
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
+      _resetEnvironmentConfig();
+    }
+  });
+
   it("uses refreshed preserved remote bytes in normal push receipts", async () => {
     const originalFetch = globalThis.fetch;
     const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -3089,6 +3089,97 @@ describe("push divergence guard", () => {
     }
   });
 
+  it("keeps protected deletion context when final conflict recovery cannot write state", async () => {
+    const originalFetch = globalThis.fetch;
+    const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];
+    const savedEnv = envKeys.map((key) => Deno.env.get(key));
+
+    try {
+      await withGitProject(async ({ projectDir }) => {
+        Deno.env.set("VERYFRONT_API_TOKEN", "<TOKEN>");
+        Deno.env.set("VERYFRONT_API_URL", "https://control.example.test");
+        Deno.env.set("VERYFRONT_PROJECT_SLUG", "my-project");
+        _resetEnvironmentConfig();
+        await writeSyncTarget(projectDir, {
+          controlPlane: "https://control.example.test",
+          projectId: "project-123",
+          projectSlug: "my-project",
+          branch: "main",
+          files: {
+            "app.ts": {
+              digest: await computeContentDigest("export const value = 1;\n"),
+              versionId: "00000000-0000-4000-8000-000000000001",
+            },
+            ".env.production": {
+              digest: await computeContentDigest("SECRET=<REDACTED>\n"),
+              versionId: "00000000-0000-4000-8000-000000000002",
+            },
+          },
+        });
+
+        let fileListCalls = 0;
+        let protectedDeleted = false;
+        globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          const url = new URL(request.url);
+          if (request.method === "GET" && url.pathname === "/projects/my-project") {
+            return Response.json({ id: "project-123", slug: "my-project" });
+          }
+          if (request.method === "GET" && url.pathname === "/projects/my-project/files") {
+            fileListCalls++;
+            if (fileListCalls === 3) {
+              const syncStatePath = `${projectDir}/.veryfront/sync-state.json`;
+              await Deno.remove(syncStatePath);
+              await Deno.mkdir(syncStatePath);
+            }
+            return Response.json({
+              data: [
+                {
+                  path: "app.ts",
+                  content: fileListCalls === 3
+                    ? "export const remote = 2;\n"
+                    : "export const value = 1;\n",
+                  version_id: fileListCalls === 3
+                    ? "00000000-0000-4000-8000-000000000003"
+                    : "00000000-0000-4000-8000-000000000001",
+                },
+                ...(!protectedDeleted
+                  ? [{
+                    path: ".env.production",
+                    content: "SECRET=<REDACTED>\n",
+                    version_id: "00000000-0000-4000-8000-000000000002",
+                  }]
+                  : []),
+              ],
+              page_info: {},
+            });
+          }
+          if (request.method === "DELETE") {
+            protectedDeleted = true;
+            return Response.json({});
+          }
+          throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
+        }) as typeof fetch;
+
+        const error = await assertRejects(
+          () => pushCommand({ projectDir, prune: true, quiet: true }),
+          Error,
+        );
+
+        assertEquals(fileListCalls, 3);
+        assertEquals(protectedDeleted, true);
+        assertEquals(
+          (error as Error & { context?: Record<string, unknown> }).context?.protectedDeleted,
+          [".env.production"],
+        );
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
+      _resetEnvironmentConfig();
+    }
+  });
+
   it("records the applied baseline when local source changes after remote writes", async () => {
     const originalFetch = globalThis.fetch;
     const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -14,6 +14,7 @@ import {
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { _resetEnvironmentConfig } from "#veryfront/config/environment-config.ts";
+import { withMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import {
   buildPushUrls,
   capturePushSourceSnapshot,
@@ -4361,7 +4362,6 @@ describe("push deletion ownership", () => {
   });
 
   it("deletes leaked protected remote files during prune", async () => {
-    const originalFetch = globalThis.fetch;
     const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];
     const savedEnv = envKeys.map((key) => Deno.env.get(key));
 
@@ -4374,7 +4374,7 @@ describe("push deletion ownership", () => {
 
         const deleted: string[] = [];
         const deleteUrls: string[] = [];
-        globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        const fetchHandler = async (input: string | URL | Request, init?: RequestInit) => {
           const request = input instanceof Request ? input : new Request(input, init);
           const url = new URL(request.url);
 
@@ -4409,9 +4409,12 @@ describe("push deletion ownership", () => {
             return Response.json({});
           }
           throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
-        }) as typeof fetch;
+        };
 
-        await pushCommand({ projectDir, branch: "main", prune: true, quiet: true });
+        await withMockFetch(
+          fetchHandler,
+          () => pushCommand({ projectDir, branch: "main", prune: true, quiet: true }),
+        );
 
         assertEquals([...deleted].sort(), [".env.production.json", ".veryfront/state.json"]);
         // Each delete carries the observed version as an optimistic precondition.
@@ -4429,14 +4432,12 @@ describe("push deletion ownership", () => {
         );
       });
     } finally {
-      globalThis.fetch = originalFetch;
       envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
       _resetEnvironmentConfig();
     }
   });
 
   it("leaves leaked protected remote files alone without prune", async () => {
-    const originalFetch = globalThis.fetch;
     const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];
     const savedEnv = envKeys.map((key) => Deno.env.get(key));
 
@@ -4459,7 +4460,7 @@ describe("push deletion ownership", () => {
 
         const requests: string[] = [];
         const uploaded: string[] = [];
-        globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        const fetchHandler = async (input: string | URL | Request, init?: RequestInit) => {
           const request = input instanceof Request ? input : new Request(input, init);
           const url = new URL(request.url);
           requests.push(`${request.method} ${url.pathname}`);
@@ -4489,9 +4490,12 @@ describe("push deletion ownership", () => {
             return Response.json({});
           }
           throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
-        }) as typeof fetch;
+        };
 
-        await pushCommand({ projectDir, branch: "main", quiet: true });
+        await withMockFetch(
+          fetchHandler,
+          () => pushCommand({ projectDir, branch: "main", quiet: true }),
+        );
 
         // Without prune the leaked remote CLI state stays untouched.
         assertEquals(requests.some((request) => request.startsWith("DELETE ")), false);
@@ -4499,7 +4503,6 @@ describe("push deletion ownership", () => {
         assertEquals(uploaded, []);
       });
     } finally {
-      globalThis.fetch = originalFetch;
       envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
       _resetEnvironmentConfig();
     }

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -3098,7 +3098,6 @@ describe("push divergence guard", () => {
   });
 
   it("keeps protected deletion context when final conflict recovery cannot write state", async () => {
-    const originalFetch = globalThis.fetch;
     const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];
     const savedEnv = envKeys.map((key) => Deno.env.get(key));
 
@@ -3127,7 +3126,7 @@ describe("push divergence guard", () => {
 
         let fileListCalls = 0;
         let protectedDeleted = false;
-        globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        const fetchHandler = async (input: string | URL | Request, init?: RequestInit) => {
           const request = input instanceof Request ? input : new Request(input, init);
           const url = new URL(request.url);
           if (request.method === "GET" && url.pathname === "/projects/my-project") {
@@ -3167,22 +3166,23 @@ describe("push divergence guard", () => {
             return Response.json({});
           }
           throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
-        }) as typeof fetch;
+        };
 
-        const error = await assertRejects(
-          () => pushCommand({ projectDir, prune: true, quiet: true }),
-          Error,
-        );
+        await withMockFetch(fetchHandler, async () => {
+          const error = await assertRejects(
+            () => pushCommand({ projectDir, prune: true, quiet: true }),
+            Error,
+          );
 
-        assertEquals(fileListCalls, 3);
-        assertEquals(protectedDeleted, true);
-        assertEquals(
-          (error as Error & { context?: Record<string, unknown> }).context?.protectedDeleted,
-          [".env.production"],
-        );
+          assertEquals(fileListCalls, 3);
+          assertEquals(protectedDeleted, true);
+          assertEquals(
+            (error as Error & { context?: Record<string, unknown> }).context?.protectedDeleted,
+            [".env.production"],
+          );
+        });
       });
     } finally {
-      globalThis.fetch = originalFetch;
       envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
       _resetEnvironmentConfig();
     }
@@ -4775,7 +4775,6 @@ describe("push deletion ownership", () => {
   });
 
   it("keeps protected deletion context when a preserved remote file lacks content", async () => {
-    const originalFetch = globalThis.fetch;
     const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];
     const savedEnv = envKeys.map((key) => Deno.env.get(key));
 
@@ -4788,7 +4787,7 @@ describe("push deletion ownership", () => {
 
         let uploadedApp = false;
         let protectedDeleted = false;
-        globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+        const fetchHandler = async (input: string | URL | Request, init?: RequestInit) => {
           const request = input instanceof Request ? input : new Request(input, init);
           const url = new URL(request.url);
           if (request.method === "GET" && url.pathname === "/projects/my-project") {
@@ -4817,22 +4816,24 @@ describe("push deletion ownership", () => {
             return Response.json({});
           }
           throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
-        }) as typeof fetch;
+        };
 
-        const error = await assertRejects(
-          () => pushCommand({ projectDir, branch: "main", prune: true, force: true, quiet: true }),
-          Error,
-          "Push finalization failed after remote files were deleted",
-        );
+        await withMockFetch(fetchHandler, async () => {
+          const error = await assertRejects(
+            () =>
+              pushCommand({ projectDir, branch: "main", prune: true, force: true, quiet: true }),
+            Error,
+            "Push finalization failed after remote files were deleted",
+          );
 
-        assertEquals(protectedDeleted, true);
-        assertEquals(
-          (error as Error & { context?: Record<string, unknown> }).context?.protectedDeleted,
-          [".env.production"],
-        );
+          assertEquals(protectedDeleted, true);
+          assertEquals(
+            (error as Error & { context?: Record<string, unknown> }).context?.protectedDeleted,
+            [".env.production"],
+          );
+        });
       });
     } finally {
-      globalThis.fetch = originalFetch;
       envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
       _resetEnvironmentConfig();
     }

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -3747,7 +3747,7 @@ describe("push failure ordering", () => {
 
         const remoteFiles = new Map([
           ["app.ts", "export const remote = true;\n"],
-          ["stale-a.ts", "export const staleA = true;\n"],
+          [".env.production", "SECRET=<REDACTED>\n"],
           ["stale-b.ts", "export const staleB = true;\n"],
         ]);
         globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
@@ -3784,10 +3784,14 @@ describe("push failure ordering", () => {
           throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
         }) as typeof fetch;
 
-        await assertRejects(
+        const error = await assertRejects(
           () => pushCommand({ projectDir, branch: "main", prune: true, force: true, quiet: true }),
           Error,
           "during deletion",
+        );
+        assertEquals(
+          (error as Error & { context?: Record<string, unknown> }).context?.protectedDeleted,
+          [".env.production"],
         );
 
         assertEquals(await readPushReceipt(projectDir), null);
@@ -3800,7 +3804,7 @@ describe("push failure ordering", () => {
           target?.files["app.ts"]?.digest,
           await computeContentDigest("export const value = 1;\n"),
         );
-        assertEquals(target?.files["stale-a.ts"], undefined);
+        assertEquals(target?.files[".env.production"], undefined);
         assertEquals(
           target?.files["stale-b.ts"]?.digest,
           await computeContentDigest("export const staleB = true;\n"),

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -3156,7 +3156,7 @@ describe("push divergence guard", () => {
         const error = await assertRejects(
           () => pushCommand({ projectDir, quiet: true, prune: true }),
           Error,
-          "Local source changed during push",
+          "Push finalization failed after remote files were deleted",
         );
 
         assertEquals(fileListCalls, 3);

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -414,6 +414,7 @@ describe("push JSON output", () => {
           projectExists: true,
           wouldUpload: 0,
           wouldDelete: 0,
+          protectedWouldDelete: [],
           studioUrl: "https://veryfront.com/projects/json-project?branch=main",
           previewUrl: "https://json-project.preview.veryfront.com",
         },
@@ -470,6 +471,7 @@ describe("push JSON output", () => {
           projectExists: true,
           wouldUpload: 1,
           wouldDelete: 0,
+          protectedWouldDelete: [],
           studioUrl: "https://veryfront.com/projects/json-project?branch=main",
           previewUrl: "https://json-project.preview.veryfront.com",
         },
@@ -599,6 +601,72 @@ describe("push JSON output", () => {
       setJsonMode(false);
       console.log = originalLog;
       globalThis.fetch = originalFetch;
+      envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
+      _resetEnvironmentConfig();
+    }
+  });
+
+  it("names the pruned protected paths in the JSON result", async () => {
+    const originalLog = console.log;
+    const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];
+    const savedEnv = envKeys.map((key) => Deno.env.get(key));
+
+    try {
+      await withGitProject(async ({ projectDir }) => {
+        Deno.env.set("VERYFRONT_API_TOKEN", "<TOKEN>");
+        Deno.env.set("VERYFRONT_API_URL", "https://control.example.test");
+        Deno.env.set("VERYFRONT_PROJECT_SLUG", "json-project");
+        _resetEnvironmentConfig();
+        setJsonMode(true);
+
+        const deleted: string[] = [];
+        const fetchHandler = async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          const url = new URL(request.url);
+          if (request.method === "GET" && url.pathname === "/projects/json-project") {
+            return Response.json({ id: "proj_json", slug: "json-project" });
+          }
+          if (request.method === "GET" && url.pathname === "/projects/json-project/files") {
+            return Response.json({
+              data: [
+                {
+                  path: "app.ts",
+                  content: "export const value = 1;\n",
+                  version_id: "00000000-0000-4000-8000-000000000010",
+                },
+                ...(deleted.includes(".env.production.json") ? [] : [{
+                  path: ".env.production.json",
+                  content: '{"apiKey":"<REDACTED>"}\n',
+                  version_id: "00000000-0000-4000-8000-000000000020",
+                }]),
+              ],
+              page_info: {},
+            });
+          }
+          if (request.method === "DELETE") {
+            deleted.push(decodeURIComponent(url.pathname.split("/files/")[1] ?? ""));
+            return Response.json({});
+          }
+          throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
+        };
+
+        await withMockFetch(fetchHandler, async () => {
+          const dryRunOutput: string[] = [];
+          console.log = captureConsoleLog(dryRunOutput);
+          await pushCommand({ projectDir, dryRun: true, prune: true });
+          assertEquals(JSON.parse(dryRunOutput[0]!).data.protectedWouldDelete, [
+            ".env.production.json",
+          ]);
+
+          const pushOutput: string[] = [];
+          console.log = captureConsoleLog(pushOutput);
+          await pushCommand({ projectDir, prune: true });
+          assertEquals(JSON.parse(pushOutput[0]!).data.protectedDeleted, [".env.production.json"]);
+        });
+      });
+    } finally {
+      setJsonMode(false);
+      console.log = originalLog;
       envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
       _resetEnvironmentConfig();
     }

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -3112,6 +3112,7 @@ describe("push divergence guard", () => {
         });
 
         let fileListCalls = 0;
+        let protectedDeleted = false;
         globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
           const request = input instanceof Request ? input : new Request(input, init);
           const url = new URL(request.url);
@@ -3125,27 +3126,45 @@ describe("push divergence guard", () => {
               await Deno.writeTextFile(`${projectDir}/app.ts`, "export const value = 3;\n");
             }
             return Response.json({
-              data: [{
-                path: "app.ts",
-                content: applied ? "export const value = 2;\n" : "export const value = 1;\n",
-                version_id: applied
-                  ? "00000000-0000-4000-8000-000000000011"
-                  : "00000000-0000-4000-8000-000000000010",
-              }],
+              data: [
+                {
+                  path: "app.ts",
+                  content: applied ? "export const value = 2;\n" : "export const value = 1;\n",
+                  version_id: applied
+                    ? "00000000-0000-4000-8000-000000000011"
+                    : "00000000-0000-4000-8000-000000000010",
+                },
+                ...(!protectedDeleted
+                  ? [{
+                    path: ".env.production",
+                    content: "SECRET=<REDACTED>\n",
+                    version_id: "00000000-0000-4000-8000-000000000012",
+                  }]
+                  : []),
+              ],
               page_info: {},
             });
           }
           if (request.method === "PUT") return Response.json({});
+          if (request.method === "DELETE") {
+            protectedDeleted = true;
+            return Response.json({});
+          }
           throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
         }) as typeof fetch;
 
-        await assertRejects(
-          () => pushCommand({ projectDir, quiet: true }),
+        const error = await assertRejects(
+          () => pushCommand({ projectDir, quiet: true, prune: true }),
           Error,
           "Local source changed during push",
         );
 
         assertEquals(fileListCalls, 3);
+        assertEquals(protectedDeleted, true);
+        assertEquals(
+          (error as Error & { context?: Record<string, unknown> }).context?.protectedDeleted,
+          [".env.production"],
+        );
         assertEquals(await readPushReceipt(projectDir), null);
         assertEquals(
           await readSyncTarget(projectDir, {
@@ -5181,7 +5200,7 @@ describe("push deletion ownership", () => {
           throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
         }) as typeof fetch;
 
-        await pushCommand({ projectDir, branch: "main", prune: true, force: true });
+        await pushCommand({ projectDir, branch: "main", prune: true, force: true, quiet: true });
 
         assertEquals(fileListCalls, 3);
         assertEquals([...deleted].sort(), [".env.production", "late-remote.ts"]);

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -662,6 +662,14 @@ describe("push JSON output", () => {
           console.log = captureConsoleLog(pushOutput);
           await pushCommand({ projectDir, prune: true });
           assertEquals(JSON.parse(pushOutput[0]!).data.protectedDeleted, [".env.production.json"]);
+
+          // `quiet` still suppresses the envelope in JSON mode. Embedded callers
+          // such as the deploy bootstrap push pass it so the command the user ran
+          // stays the only result line on stdout.
+          const quietOutput: string[] = [];
+          console.log = captureConsoleLog(quietOutput);
+          await pushCommand({ projectDir, prune: true, quiet: true });
+          assertEquals(quietOutput, []);
         });
       });
     } finally {
@@ -5245,7 +5253,6 @@ describe("push deletion ownership", () => {
 
   it("reconciles late remote-only files during no-op forced prune", async () => {
     const originalFetch = globalThis.fetch;
-    const originalLog = console.log;
     const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];
     const savedEnv = envKeys.map((key) => Deno.env.get(key));
 
@@ -5260,9 +5267,6 @@ describe("push deletion ownership", () => {
 
         let fileListCalls = 0;
         const deleted: string[] = [];
-        const output: string[] = [];
-        setJsonMode(true);
-        console.log = captureConsoleLog(output);
         globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
           const request = input instanceof Request ? input : new Request(input, init);
           const url = new URL(request.url);
@@ -5295,7 +5299,6 @@ describe("push deletion ownership", () => {
 
         assertEquals(fileListCalls, 3);
         assertEquals([...deleted].sort(), [".env.production", "late-remote.ts"]);
-        assertEquals(JSON.parse(output[0]!).data.protectedDeleted, [".env.production"]);
         const receipt = await readPushReceipt(projectDir);
         assertExists(receipt);
         assertEquals(
@@ -5314,8 +5317,6 @@ describe("push deletion ownership", () => {
         );
       });
     } finally {
-      setJsonMode(false);
-      console.log = originalLog;
       globalThis.fetch = originalFetch;
       envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
       _resetEnvironmentConfig();

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -3028,6 +3028,11 @@ describe("push divergence guard", () => {
                       content: "export const old = 2;\n",
                       version_id: "00000000-0000-4000-8000-000000000031",
                     },
+                    {
+                      path: ".env.production",
+                      content: "SECRET=<REDACTED>\n",
+                      version_id: "00000000-0000-4000-8000-000000000040",
+                    },
                   ]),
               ],
               page_info: {},
@@ -3049,6 +3054,7 @@ describe("push divergence guard", () => {
         if (!(error instanceof Error)) throw new Error("Expected push to reject with an Error");
         assertEquals((error as Error & { slug?: string }).slug, "push-conflict");
         assertStringIncludes(error.message, '"old.ts"');
+        assertStringIncludes(error.message, '".env.production"');
         assertEquals(fileListCalls, 3);
         assertEquals(deletePaths.sort(), ["gone.ts", "old.ts"]);
         assertEquals(await readPushReceipt(projectDir), null);
@@ -5125,6 +5131,7 @@ describe("push deletion ownership", () => {
 
   it("reconciles late remote-only files during no-op forced prune", async () => {
     const originalFetch = globalThis.fetch;
+    const originalLog = console.log;
     const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];
     const savedEnv = envKeys.map((key) => Deno.env.get(key));
 
@@ -5139,6 +5146,9 @@ describe("push deletion ownership", () => {
 
         let fileListCalls = 0;
         const deleted: string[] = [];
+        const output: string[] = [];
+        setJsonMode(true);
+        console.log = captureConsoleLog(output);
         globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
           const request = input instanceof Request ? input : new Request(input, init);
           const url = new URL(request.url);
@@ -5167,10 +5177,11 @@ describe("push deletion ownership", () => {
           throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
         }) as typeof fetch;
 
-        await pushCommand({ projectDir, branch: "main", prune: true, force: true, quiet: true });
+        await pushCommand({ projectDir, branch: "main", prune: true, force: true });
 
         assertEquals(fileListCalls, 3);
         assertEquals([...deleted].sort(), [".env.production", "late-remote.ts"]);
+        assertEquals(JSON.parse(output[0]!).data.protectedDeleted, [".env.production"]);
         const receipt = await readPushReceipt(projectDir);
         assertExists(receipt);
         assertEquals(
@@ -5189,6 +5200,8 @@ describe("push deletion ownership", () => {
         );
       });
     } finally {
+      setJsonMode(false);
+      console.log = originalLog;
       globalThis.fetch = originalFetch;
       envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
       _resetEnvironmentConfig();

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -4360,6 +4360,151 @@ describe("push deletion ownership", () => {
     }
   });
 
+  it("deletes leaked protected remote files during prune", async () => {
+    const originalFetch = globalThis.fetch;
+    const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];
+    const savedEnv = envKeys.map((key) => Deno.env.get(key));
+
+    try {
+      await withGitProject(async ({ projectDir }) => {
+        Deno.env.set("VERYFRONT_API_TOKEN", "<TOKEN>");
+        Deno.env.set("VERYFRONT_API_URL", "https://control.example.test");
+        Deno.env.set("VERYFRONT_PROJECT_SLUG", "my-project");
+        _resetEnvironmentConfig();
+
+        const deleted: string[] = [];
+        const deleteUrls: string[] = [];
+        globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          const url = new URL(request.url);
+
+          if (request.method === "GET" && url.pathname === "/projects/my-project/files") {
+            return Response.json({
+              data: [
+                {
+                  path: "app.ts",
+                  content: "export const value = 1;\n",
+                  version_id: "00000000-0000-4000-8000-000000000010",
+                },
+                ...(deleted.includes(".env.production.json") ? [] : [{
+                  path: ".env.production.json",
+                  content: '{"apiKey":"<REDACTED>"}\n',
+                  version_id: "00000000-0000-4000-8000-000000000020",
+                }]),
+                ...(deleted.includes(".veryfront/state.json") ? [] : [{
+                  path: ".veryfront/state.json",
+                  content: '{"branch":"main"}\n',
+                  version_id: "00000000-0000-4000-8000-000000000030",
+                }]),
+              ],
+              page_info: {},
+            });
+          }
+          if (request.method === "GET" && url.pathname === "/projects/my-project") {
+            return Response.json({ id: "project-123", slug: "my-project" });
+          }
+          if (request.method === "DELETE") {
+            deleted.push(decodeURIComponent(url.pathname.split("/files/")[1] ?? ""));
+            deleteUrls.push(`${url.pathname}${url.search}`);
+            return Response.json({});
+          }
+          throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
+        }) as typeof fetch;
+
+        await pushCommand({ projectDir, branch: "main", prune: true, quiet: true });
+
+        assertEquals([...deleted].sort(), [".env.production.json", ".veryfront/state.json"]);
+        // Each delete carries the observed version as an optimistic precondition.
+        assertEquals(
+          deleteUrls.some((url) =>
+            url.includes("expected_version_id=00000000-0000-4000-8000-000000000020")
+          ),
+          true,
+        );
+        assertEquals(
+          deleteUrls.some((url) =>
+            url.includes("expected_version_id=00000000-0000-4000-8000-000000000030")
+          ),
+          true,
+        );
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
+      _resetEnvironmentConfig();
+    }
+  });
+
+  it("leaves leaked protected remote files alone without prune", async () => {
+    const originalFetch = globalThis.fetch;
+    const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];
+    const savedEnv = envKeys.map((key) => Deno.env.get(key));
+
+    try {
+      await withGitProject(async ({ projectDir, runGit }) => {
+        await Deno.writeTextFile(
+          `${projectDir}/.vfignore`,
+          "!.env*.json\n!.veryfront\n!.veryfront/**\n",
+        );
+        await runGit("add", ".vfignore");
+        await runGit("commit", "--quiet", "-m", "negate protected defaults");
+        await Deno.writeTextFile(
+          `${projectDir}/.env.production.json`,
+          '{"apiKey":"<REDACTED>"}\n',
+        );
+        Deno.env.set("VERYFRONT_API_TOKEN", "<TOKEN>");
+        Deno.env.set("VERYFRONT_API_URL", "https://control.example.test");
+        Deno.env.set("VERYFRONT_PROJECT_SLUG", "my-project");
+        _resetEnvironmentConfig();
+
+        const requests: string[] = [];
+        const uploaded: string[] = [];
+        globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+          const request = input instanceof Request ? input : new Request(input, init);
+          const url = new URL(request.url);
+          requests.push(`${request.method} ${url.pathname}`);
+
+          if (request.method === "GET" && url.pathname === "/projects/my-project/files") {
+            return Response.json({
+              data: [
+                {
+                  path: "app.ts",
+                  content: "export const value = 1;\n",
+                  version_id: "00000000-0000-4000-8000-000000000010",
+                },
+                {
+                  path: ".veryfront/state.json",
+                  content: '{"branch":"main"}\n',
+                  version_id: "00000000-0000-4000-8000-000000000030",
+                },
+              ],
+              page_info: {},
+            });
+          }
+          if (request.method === "GET" && url.pathname === "/projects/my-project") {
+            return Response.json({ id: "project-123", slug: "my-project" });
+          }
+          if (request.method === "PUT") {
+            uploaded.push(decodeURIComponent(url.pathname.split("/files/")[1] ?? ""));
+            return Response.json({});
+          }
+          throw new Error(`Unexpected request: ${request.method} ${url.pathname}`);
+        }) as typeof fetch;
+
+        await pushCommand({ projectDir, branch: "main", quiet: true });
+
+        // Without prune the leaked remote CLI state stays untouched.
+        assertEquals(requests.some((request) => request.startsWith("DELETE ")), false);
+        // The .vfignore negation never re-includes the local secret for upload.
+        assertEquals(uploaded, []);
+      });
+    } finally {
+      globalThis.fetch = originalFetch;
+      envKeys.forEach((key, index) => restoreEnv(key, savedEnv[index]));
+      _resetEnvironmentConfig();
+    }
+  });
+
   it("preserves unsupported remote files during prune", async () => {
     const originalFetch = globalThis.fetch;
     const envKeys = ["VERYFRONT_API_TOKEN", "VERYFRONT_API_URL", "VERYFRONT_PROJECT_SLUG"];

--- a/cli/commands/push/command.test.ts
+++ b/cli/commands/push/command.test.ts
@@ -4816,6 +4816,9 @@ describe("push deletion ownership", () => {
                 ...(fileListCalls > 1 && !deleted.includes("late-remote.ts")
                   ? [{ path: "late-remote.ts", content: "late remote source" }]
                   : []),
+                ...(fileListCalls > 1 && !deleted.includes(".env.production")
+                  ? [{ path: ".env.production", content: "SECRET=<REDACTED>\n" }]
+                  : []),
               ],
               page_info: {},
             });
@@ -4837,7 +4840,12 @@ describe("push deletion ownership", () => {
         await pushCommand({ projectDir, branch: "main", prune: true, force: true, quiet: true });
 
         assertEquals(fileListCalls, 3);
-        assertEquals(deleted.sort(), ["late-remote.ts", "stale.ts", "stale.ts"]);
+        assertEquals(deleted.sort(), [
+          ".env.production",
+          "late-remote.ts",
+          "stale.ts",
+          "stale.ts",
+        ]);
         assertEquals(
           await readSyncTarget(projectDir, {
             controlPlane: "https://control.example.test",
@@ -5142,6 +5150,9 @@ describe("push deletion ownership", () => {
                 ...(fileListCalls > 1 && !deleted.includes("late-remote.ts")
                   ? [{ path: "late-remote.ts", content: "late remote source" }]
                   : []),
+                ...(fileListCalls > 1 && !deleted.includes(".env.production")
+                  ? [{ path: ".env.production", content: "SECRET=<REDACTED>\n" }]
+                  : []),
               ],
               page_info: {},
             });
@@ -5159,7 +5170,7 @@ describe("push deletion ownership", () => {
         await pushCommand({ projectDir, branch: "main", prune: true, force: true, quiet: true });
 
         assertEquals(fileListCalls, 3);
-        assertEquals(deleted, ["late-remote.ts"]);
+        assertEquals([...deleted].sort(), [".env.production", "late-remote.ts"]);
         const receipt = await readPushReceipt(projectDir);
         assertExists(receipt);
         assertEquals(
@@ -5209,7 +5220,7 @@ describe("push deletion ownership", () => {
             return Response.json({
               data: [
                 ...(fileListCalls > 1
-                  ? [{ path: "late-remote.ts", content: "recreated remote source" }]
+                  ? [{ path: ".env.production", content: "SECRET=<REDACTED>\n" }]
                   : []),
               ],
               page_info: {},
@@ -5233,9 +5244,9 @@ describe("push deletion ownership", () => {
 
         if (!(error instanceof Error)) throw new Error("Expected push to reject with an Error");
         assertEquals((error as Error & { slug?: string }).slug, "push-conflict");
-        assertStringIncludes(error.message, '"late-remote.ts"');
+        assertStringIncludes(error.message, '".env.production"');
         assertEquals(fileListCalls, 3);
-        assertEquals(deleted, ["late-remote.ts"]);
+        assertEquals(deleted, [".env.production"]);
         assertEquals(await readPushReceipt(projectDir), null);
         assertEquals(
           await readSyncTarget(projectDir, {

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -708,9 +708,10 @@ function findRemoteFilesMissingLocally(
   return remoteFiles
     .map((file) => file.path)
     .filter((path) =>
-      ignoreChecker.isSupportedExtension(path) &&
-      !ignoreChecker.isIgnored(path) &&
-      !localPaths.has(path)
+      ignoreChecker.isProtected(path) ||
+      (ignoreChecker.isSupportedExtension(path) &&
+        !ignoreChecker.isIgnored(path) &&
+        !localPaths.has(path))
     );
 }
 
@@ -1093,13 +1094,16 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
         })
         : null;
       const managedRemoteFiles = target.remoteFiles.filter((file) =>
-        ignoreChecker.isSupportedExtension(file.path) && !ignoreChecker.isIgnored(file.path)
+        (pruneRemoteMissing && ignoreChecker.isProtected(file.path)) ||
+        (ignoreChecker.isSupportedExtension(file.path) && !ignoreChecker.isIgnored(file.path))
       );
+      const protectedDeletePaths = toDelete.filter((path) => ignoreChecker.isProtected(path));
       const plan = await planPushChanges({
         localFiles: ops,
         remoteFiles: managedRemoteFiles,
         baselineFiles: baseline?.files ?? {},
         deletePaths: toDelete,
+        protectedDeletePaths,
         force,
         remoteFilesAreBaseline,
       });

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -32,7 +32,7 @@ import {
   slugConflictAction,
 } from "#cli/shared/project-resolution";
 import { ProjectSlugConflictError, reserveProjectSlug } from "#cli/shared/reserve-slug";
-import { isVerbose, logInfo, logSuccess } from "#cli/utils";
+import { isVerbose, logInfo, logSuccess, logWarning } from "#cli/utils";
 import {
   INVALID_ARGUMENT,
   PREVIEW_HOSTNAME_TOO_LONG,
@@ -1263,6 +1263,17 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
       }
 
       spinner.stop();
+
+      if (protectedDeletePaths.length > 0 && !quiet && !jsonOutput) {
+        logWarning(
+          `Prune removes ${protectedDeletePaths.length} protected remote ${
+            protectedDeletePaths.length === 1 ? "path" : "paths"
+          } that .vfignore cannot re-include: ${protectedDeletePaths.join(", ")}.`,
+        );
+        logInfo(
+          "Use veryfront push --prune --dry-run first to review them.",
+        );
+      }
 
       if (!quiet && !jsonOutput && (dryRun || isVerbose())) {
         const parts = buildSummaryParts(uploadOps, deleteOps.map((op) => op.path));

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -1332,13 +1332,17 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
               throw attachProtectedDeleteContext(error, protectedDeleteContext());
             }
             if (project) {
-              await writeSyncTarget(projectDir, {
-                controlPlane: config.apiUrl,
-                projectId: project.id,
-                projectSlug: project.slug,
-                branch: branchName,
-                files: pushedSyncFiles,
-              });
+              try {
+                await writeSyncTarget(projectDir, {
+                  controlPlane: config.apiUrl,
+                  projectId: project.id,
+                  projectSlug: project.slug,
+                  branch: branchName,
+                  files: pushedSyncFiles,
+                });
+              } catch (error) {
+                throw attachProtectedDeleteContext(error, protectedDeleteContext());
+              }
             }
           }
         } finally {

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -753,7 +753,8 @@ function attachProtectedDeleteContext(
     } catch { /* fall through to a typed push error */ }
   }
   return pushMutationError(
-    error instanceof Error ? error.message : "Push finalization failed",
+    "Push finalization failed after remote files were deleted. " +
+      "Retry the push and rotate any credential named in protectedDeleted.",
     normalized,
   );
 }

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -724,6 +724,14 @@ function pushMutationError(detail: string, protectedDeleted: readonly string[]):
   });
 }
 
+function pushVerificationReadError(protectedDeleted: readonly string[]): Error {
+  return DEPLOYMENT_ERROR.create({
+    detail:
+      "Push verification could not read the remote target after files were deleted. Retry the push and rotate any credential named in protectedDeleted.",
+    context: { protectedDeleted: [...protectedDeleted] },
+  });
+}
+
 function requireRemoteContent(file: RemoteFile): string {
   if (typeof file.content === "string") return file.content;
   throw new Error(
@@ -1243,11 +1251,19 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
                 );
               }
               if (lateDeleteResult.deleted > 0) {
-                latestRemoteFiles = await listAllFiles(
-                  client,
-                  projectApiReference(config),
-                  target.source,
-                );
+                try {
+                  latestRemoteFiles = await listAllFiles(
+                    client,
+                    projectApiReference(config),
+                    target.source,
+                  );
+                } catch (error) {
+                  const protectedDeleted = protectedDeleteContext();
+                  if (protectedDeleted.length > 0) {
+                    throw pushVerificationReadError(protectedDeleted);
+                  }
+                  throw error;
+                }
               }
               const conflicts = findRemoteSnapshotChanges(
                 buildSyncFileDigestSnapshot(plan.nextFiles),
@@ -1405,6 +1421,10 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           );
         } catch (error) {
           await writeConfirmedAppliedSyncTarget();
+          const protectedDeleted = protectedDeleteContext();
+          if (protectedDeleted.length > 0) {
+            throw pushVerificationReadError(protectedDeleted);
+          }
           throw error;
         }
       };

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -1352,7 +1352,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
         } finally {
           spinner.stop();
         }
-        if (!quiet || jsonOutput) {
+        if (!quiet) {
           if (dryRun && jsonOutput) {
             outputPushDryRunResult(
               config.projectSlug,
@@ -1400,7 +1400,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           await deleteFiles(client, projectApiReference(config), target.branchId, deleteOps, true);
         }
 
-        if (jsonOutput) {
+        if (jsonOutput && !quiet) {
           outputPushDryRunResult(
             config.projectSlug,
             branchName,
@@ -1802,7 +1802,11 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
         spinner.stop();
       }
 
-      if (quiet && !jsonOutput) return;
+      // `quiet` suppresses the result envelope in every mode, JSON included:
+      // embedded callers (`deploy-project` bootstrap push, `createStagedPushOptions`)
+      // pass it precisely because they emit the single result envelope for the
+      // command the user actually ran, and a second one would break that contract.
+      if (quiet) return;
 
       outputPushResult(
         config.projectSlug,

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -69,6 +69,7 @@ import {
   writeSyncTarget,
 } from "../../sync/state.ts";
 
+const defineOwnProperty = Object.defineProperty;
 const PREVIEW_BRANCH_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 const BRANCH_SUFFIX_LENGTH = 6;
 const PREVIEW_BRANCH_ERROR =
@@ -732,6 +733,31 @@ function pushVerificationReadError(protectedDeleted: readonly string[]): Error {
   });
 }
 
+function attachProtectedDeleteContext(
+  error: unknown,
+  protectedDeleted: readonly string[],
+): Error {
+  if (protectedDeleted.length === 0) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+  const normalized = [...protectedDeleted];
+  if (error instanceof Error) {
+    try {
+      defineOwnProperty(error, "context", {
+        value: { protectedDeleted: normalized },
+        configurable: true,
+        enumerable: true,
+        writable: true,
+      });
+      return error;
+    } catch { /* fall through to a typed push error */ }
+  }
+  return pushMutationError(
+    error instanceof Error ? error.message : "Push finalization failed",
+    normalized,
+  );
+}
+
 function requireRemoteContent(file: RemoteFile): string {
   if (typeof file.content === "string") return file.content;
   throw new Error(
@@ -1291,15 +1317,19 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
             }
             await clearPushReceipt(projectDir);
             spinner.update("Verifying push target...");
-            await recordPushReceipt(
-              client,
-              config,
-              projectDir,
-              branchName,
-              sourceSnapshot,
-              ignoreChecker,
-              pushedSourceDigest,
-            );
+            try {
+              await recordPushReceipt(
+                client,
+                config,
+                projectDir,
+                branchName,
+                sourceSnapshot,
+                ignoreChecker,
+                pushedSourceDigest,
+              );
+            } catch (error) {
+              throw attachProtectedDeleteContext(error, protectedDeleteContext());
+            }
             if (project) {
               await writeSyncTarget(projectDir, {
                 controlPlane: config.apiUrl,
@@ -1313,7 +1343,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
         } finally {
           spinner.stop();
         }
-        if (!quiet) {
+        if (!quiet || jsonOutput) {
           if (dryRun && jsonOutput) {
             outputPushDryRunResult(
               config.projectSlug,
@@ -1361,7 +1391,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           await deleteFiles(client, projectApiReference(config), target.branchId, deleteOps, true);
         }
 
-        if (jsonOutput && !quiet) {
+        if (jsonOutput) {
           outputPushDryRunResult(
             config.projectSlug,
             branchName,
@@ -1745,15 +1775,19 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
             pushedSourceDigest,
           );
         } catch (error) {
-          await writePlannedSyncTarget();
-          throw error;
+          try {
+            await writePlannedSyncTarget();
+          } catch (writeError) {
+            throw attachProtectedDeleteContext(writeError, protectedDeleteContext());
+          }
+          throw attachProtectedDeleteContext(error, protectedDeleteContext());
         }
         await writePlannedSyncTarget();
       } finally {
         spinner.stop();
       }
 
-      if (quiet) return;
+      if (quiet && !jsonOutput) return;
 
       outputPushResult(
         config.projectSlug,

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -34,9 +34,11 @@ import {
 import { ProjectSlugConflictError, reserveProjectSlug } from "#cli/shared/reserve-slug";
 import { isVerbose, logInfo, logSuccess, logWarning } from "#cli/utils";
 import {
+  DEPLOYMENT_ERROR,
   INVALID_ARGUMENT,
   PREVIEW_HOSTNAME_TOO_LONG,
   PUSH_CONFLICT,
+  sanitizeTerminalDiagnosticText,
   VeryfrontError,
 } from "veryfront/errors";
 import { brand, createNoopSpinner, createSpinner, formatDuration } from "#cli/ui";
@@ -45,7 +47,6 @@ import { createIgnoreChecker, type IgnoreChecker, loadIgnorePatterns } from "../
 import { listAllFiles, type PullSource } from "../pull/index.ts";
 import { CommonArgs, createArgParser } from "#cli/shared/args";
 import { isNotFoundError, lstat } from "veryfront/fs";
-import { sanitizeLogText } from "#veryfront/utils/logger/core.ts";
 import {
   areSourceFilesTracked,
   clearPushReceipt,
@@ -421,7 +422,7 @@ function outputPushResult(
 
 function warnProtectedRemotePaths(paths: readonly string[], dryRun: boolean): void {
   if (paths.length === 0 || isJsonMode()) return;
-  const protectedPathList = paths.map(sanitizeLogText).join(", ");
+  const protectedPathList = paths.map(sanitizeTerminalDiagnosticText).join(", ");
   logWarning(
     `Prune ${dryRun ? "would remove" : "removes"} ${paths.length} protected remote ${
       paths.length === 1 ? "path" : "paths"
@@ -700,13 +701,26 @@ function buildConfirmParts(ops: UploadOp[], toDelete: string[]): string[] {
   return buildOpParts(ops, toDelete, (count) => `upload ${count}`, (count) => `delete ${count}`);
 }
 
-function pushConflictError(paths: readonly string[]): Error {
+function pushConflictError(
+  paths: readonly string[],
+  protectedDeleted: readonly string[] = [],
+): Error {
   const files = paths.map((path) => `"${path}"`).join(", ");
   return PUSH_CONFLICT.create({
     detail: `Push rejected because remote files changed since your last pull or push: ${files}. ` +
       "Commit or stash local changes, run veryfront pull, reconcile the changes with Git, then push again. " +
       "Use veryfront push --force only to intentionally overwrite remote changes.",
-    context: { paths: [...paths] },
+    context: {
+      paths: [...paths],
+      ...(protectedDeleted.length > 0 ? { protectedDeleted: [...protectedDeleted] } : {}),
+    },
+  });
+}
+
+function pushMutationError(detail: string, protectedDeleted: readonly string[]): Error {
+  return DEPLOYMENT_ERROR.create({
+    detail,
+    context: protectedDeleted.length > 0 ? { protectedDeleted: [...protectedDeleted] } : undefined,
   });
 }
 
@@ -1128,6 +1142,8 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
         for (const path of newlyApplied) appliedProtectedDeletePaths.add(path);
         warnProtectedRemotePaths(newlyApplied, false);
       };
+      const protectedDeleteContext = () =>
+        [...appliedProtectedDeletePaths].map(sanitizeTerminalDiagnosticText);
       // Protected paths are planner input only. The sync baseline must never
       // record them, because `plan.nextFiles` excludes them and no later pull or
       // push would ever reconcile such an entry away.
@@ -1216,13 +1232,14 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
               forcedPruneDeleteCount = lateDeleteResult.deleted;
               recordAppliedProtectedDeletes(lateDeleteResult.applied);
               if (lateDeleteResult.conflicts.length > 0) {
-                throw pushConflictError(lateDeleteResult.conflicts);
+                throw pushConflictError(lateDeleteResult.conflicts, protectedDeleteContext());
               }
               if (lateDeleteResult.failed > 0) {
-                throw new Error(
+                throw pushMutationError(
                   `Push failed for ${lateDeleteResult.failed} file${
                     lateDeleteResult.failed === 1 ? "" : "s"
                   } during forced prune reconciliation`,
+                  protectedDeleteContext(),
                 );
               }
               if (lateDeleteResult.deleted > 0) {
@@ -1237,7 +1254,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
                 await buildManagedRemoteSnapshot(latestRemoteFiles, ignoreChecker, false, true),
               );
               if (conflicts.length > 0) {
-                throw pushConflictError(conflicts);
+                throw pushConflictError(conflicts, protectedDeleteContext());
               }
               pushedSourceDigest = await computePushedSourceDigest(ops, latestRemoteFiles);
             } else {
@@ -1489,16 +1506,17 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           uploadOps.filter((op) => appliedUploads.has(op.path)),
           deleteOps.filter((op) => appliedDeletes.has(op.path)),
         );
-        throw pushConflictError(deleteResult.conflicts);
+        throw pushConflictError(deleteResult.conflicts, protectedDeleteContext());
       }
 
       if (deleteResult.failed > 0) {
         spinner.stop();
         await writeVerifiedAppliedSyncTarget();
-        throw new Error(
+        throw pushMutationError(
           `Push failed for ${deleteResult.failed} file${
             deleteResult.failed === 1 ? "" : "s"
           } during deletion`,
+          protectedDeleteContext(),
         );
       }
 
@@ -1595,14 +1613,15 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
             };
             if (lateDeleteResult.conflicts.length > 0) {
               await writeVerifiedAppliedSyncTarget();
-              throw pushConflictError(lateDeleteResult.conflicts);
+              throw pushConflictError(lateDeleteResult.conflicts, protectedDeleteContext());
             }
             if (lateDeleteResult.failed > 0) {
               await writeVerifiedAppliedSyncTarget();
-              throw new Error(
+              throw pushMutationError(
                 `Push failed for ${lateDeleteResult.failed} file${
                   lateDeleteResult.failed === 1 ? "" : "s"
                 } during forced prune reconciliation`,
+                protectedDeleteContext(),
               );
             }
           }

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -1183,7 +1183,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
             await buildManagedRemoteSnapshot(latestRemoteFiles, ignoreChecker),
           );
           if (conflicts.length > 0) {
-            throw pushConflictError(conflicts);
+            throw pushConflictError(conflicts, protectedDeleteContext());
           }
         } finally {
           spinner.stop();
@@ -1551,7 +1551,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
               stillApplied.uploads,
               stillApplied.deletes,
             );
-            throw pushConflictError(conflicts);
+            throw pushConflictError(conflicts, protectedDeleteContext());
           }
           pushedSourceDigest = await computePushedSourceDigest(ops, latestRemoteFiles);
         } else if (pruneRemoteMissing) {
@@ -1579,14 +1579,15 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
             };
             if (lateUploadResult.conflicts.length > 0) {
               await writeVerifiedAppliedSyncTarget();
-              throw pushConflictError(lateUploadResult.conflicts);
+              throw pushConflictError(lateUploadResult.conflicts, protectedDeleteContext());
             }
             if (lateUploadResult.failed > 0) {
               await writeVerifiedAppliedSyncTarget();
-              throw new Error(
+              throw pushMutationError(
                 `Push failed for ${lateUploadResult.failed} file${
                   lateUploadResult.failed === 1 ? "" : "s"
                 } during forced prune reconciliation`,
+                protectedDeleteContext(),
               );
             }
           }
@@ -1633,7 +1634,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
             );
             if (repairedConflicts.length > 0) {
               await writeVerifiedAppliedSyncTarget(repairedRemoteFiles);
-              throw pushConflictError(repairedConflicts);
+              throw pushConflictError(repairedConflicts, protectedDeleteContext());
             }
             pushedSourceDigest = await computePushedSourceDigest(ops, repairedRemoteFiles);
           } else {
@@ -1657,14 +1658,15 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           };
           if (repairUploadResult.conflicts.length > 0) {
             await writeVerifiedAppliedSyncTarget();
-            throw pushConflictError(repairUploadResult.conflicts);
+            throw pushConflictError(repairUploadResult.conflicts, protectedDeleteContext());
           }
           if (repairUploadResult.failed > 0) {
             await writeVerifiedAppliedSyncTarget();
-            throw new Error(
+            throw pushMutationError(
               `Push failed for ${repairUploadResult.failed} file${
                 repairUploadResult.failed === 1 ? "" : "s"
               } during forced push verification`,
+              protectedDeleteContext(),
             );
           }
           if (repairUploadResult.uploaded > 0) {
@@ -1690,7 +1692,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           );
           if (conflicts.length > 0) {
             await writeVerifiedAppliedSyncTarget(latestRemoteFiles);
-            throw pushConflictError(conflicts);
+            throw pushConflictError(conflicts, protectedDeleteContext());
           }
           pushedSourceDigest = await computePushedSourceDigest(ops, latestRemoteFiles);
           pushedSyncFiles = await buildSyncFilesAfterAppliedChanges(

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -1179,6 +1179,22 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
       };
       const protectedDeleteContext = () =>
         [...appliedProtectedDeletePaths].map(sanitizeTerminalDiagnosticText);
+      const buildVerificationSnapshot = async (
+        files: readonly RemoteFile[],
+        includeVersion = true,
+        includeProtected = false,
+      ) => {
+        try {
+          return await buildManagedRemoteSnapshot(
+            files,
+            ignoreChecker,
+            includeVersion,
+            includeProtected,
+          );
+        } catch (error) {
+          throw attachProtectedDeleteContext(error, protectedDeleteContext());
+        }
+      };
       // Protected paths are planner input only. The sync baseline must never
       // record them, because `plan.nextFiles` excludes them and no later pull or
       // push would ever reconcile such an entry away.
@@ -1214,8 +1230,8 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
             target.source,
           );
           const conflicts = findRemoteSnapshotChanges(
-            await buildManagedRemoteSnapshot(managedRemoteFiles, ignoreChecker),
-            await buildManagedRemoteSnapshot(latestRemoteFiles, ignoreChecker),
+            await buildVerificationSnapshot(managedRemoteFiles),
+            await buildVerificationSnapshot(latestRemoteFiles),
           );
           if (conflicts.length > 0) {
             throw pushConflictError(conflicts, protectedDeleteContext());
@@ -1237,10 +1253,9 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
                 target.source,
               );
               const conflicts = findRemoteSnapshotChanges(
-                await buildManagedRemoteSnapshot(managedRemoteFiles, ignoreChecker),
-                await buildManagedRemoteSnapshot(
+                await buildVerificationSnapshot(managedRemoteFiles),
+                await buildVerificationSnapshot(
                   latestRemoteFiles,
-                  ignoreChecker,
                   true,
                   pruneRemoteMissing,
                 ),
@@ -1298,7 +1313,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
               }
               const conflicts = findRemoteSnapshotChanges(
                 buildSyncFileDigestSnapshot(plan.nextFiles),
-                await buildManagedRemoteSnapshot(latestRemoteFiles, ignoreChecker, false, true),
+                await buildVerificationSnapshot(latestRemoteFiles, false, true),
               );
               if (conflicts.length > 0) {
                 throw pushConflictError(conflicts, protectedDeleteContext());
@@ -1479,9 +1494,8 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
         knownRemoteFiles?: readonly RemoteFile[],
       ) => {
         const latestRemoteFiles = knownRemoteFiles ?? await listAllFilesForVerification();
-        const latestRemoteSnapshot = await buildManagedRemoteSnapshot(
+        const latestRemoteSnapshot = await buildVerificationSnapshot(
           latestRemoteFiles,
-          ignoreChecker,
           false,
         );
         const appliedUploads = new Set(uploadResult.applied);
@@ -1585,9 +1599,8 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
       try {
         if (!force) {
           const latestRemoteFiles = await listAllFilesForVerification();
-          const latestRemoteSnapshot = await buildManagedRemoteSnapshot(
+          const latestRemoteSnapshot = await buildVerificationSnapshot(
             latestRemoteFiles,
-            ignoreChecker,
             false,
             pruneRemoteMissing,
           );
@@ -1695,7 +1708,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
             const repairedRemoteFiles = await listAllFilesForVerification();
             const repairedConflicts = findRemoteSnapshotChanges(
               buildSyncFileDigestSnapshot(plan.nextFiles),
-              await buildManagedRemoteSnapshot(repairedRemoteFiles, ignoreChecker, false, true),
+              await buildVerificationSnapshot(repairedRemoteFiles, false, true),
             );
             if (repairedConflicts.length > 0) {
               await writeVerifiedAppliedSyncTarget(repairedRemoteFiles);
@@ -1737,9 +1750,8 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           if (repairUploadResult.uploaded > 0) {
             latestRemoteFiles = await listAllFilesForVerification();
           }
-          const latestRemoteSnapshot = await buildManagedRemoteSnapshot(
+          const latestRemoteSnapshot = await buildVerificationSnapshot(
             latestRemoteFiles,
-            ignoreChecker,
             false,
           );
           const uploadPaths = new Set(uploadOps.map((upload) => upload.path));

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -419,6 +419,17 @@ function outputPushResult(
   console.log();
 }
 
+function warnProtectedRemotePaths(paths: readonly string[], dryRun: boolean): void {
+  if (paths.length === 0 || isJsonMode()) return;
+  const protectedPathList = paths.map(sanitizeLogText).join(", ");
+  logWarning(
+    `Prune ${dryRun ? "would remove" : "removes"} ${paths.length} protected remote ${
+      paths.length === 1 ? "path" : "paths"
+    } that .vfignore cannot re-include: ${protectedPathList}.`,
+  );
+  if (!dryRun) logInfo("Rotate any credential these paths contained.");
+}
+
 function outputPushDryRunResult(
   projectSlug: string,
   branchName: string,
@@ -1109,6 +1120,14 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
         (ignoreChecker.isSupportedExtension(file.path) && !ignoreChecker.isIgnored(file.path))
       );
       const protectedDeletePaths = toDelete.filter((path) => ignoreChecker.isProtected(path));
+      const appliedProtectedDeletePaths = new Set<string>();
+      const recordAppliedProtectedDeletes = (paths: readonly string[]) => {
+        const newlyApplied = paths.filter((path) =>
+          ignoreChecker.isProtected(path) && !appliedProtectedDeletePaths.has(path)
+        );
+        for (const path of newlyApplied) appliedProtectedDeletePaths.add(path);
+        warnProtectedRemotePaths(newlyApplied, false);
+      };
       // Protected paths are planner input only. The sync baseline must never
       // record them, because `plan.nextFiles` excludes them and no later pull or
       // push would ever reconcile such an entry away.
@@ -1168,7 +1187,12 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
               );
               const conflicts = findRemoteSnapshotChanges(
                 await buildManagedRemoteSnapshot(managedRemoteFiles, ignoreChecker),
-                await buildManagedRemoteSnapshot(latestRemoteFiles, ignoreChecker),
+                await buildManagedRemoteSnapshot(
+                  latestRemoteFiles,
+                  ignoreChecker,
+                  true,
+                  pruneRemoteMissing,
+                ),
               );
               if (conflicts.length > 0) {
                 throw pushConflictError(conflicts);
@@ -1190,6 +1214,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
                 plan.nextFiles,
               );
               forcedPruneDeleteCount = lateDeleteResult.deleted;
+              recordAppliedProtectedDeletes(lateDeleteResult.applied);
               if (lateDeleteResult.conflicts.length > 0) {
                 throw pushConflictError(lateDeleteResult.conflicts);
               }
@@ -1273,7 +1298,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
               branchName,
               0,
               forcedPruneDeleteCount,
-              protectedDeletePaths,
+              [...appliedProtectedDeletePaths],
               Date.now() - startTime,
             );
           }
@@ -1283,22 +1308,10 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
 
       spinner.stop();
 
-      // JSON runs get the same list as a structured field on the result
-      // envelope, so this human-readable form is the non-JSON counterpart. It
-      // stays outside the `quiet` gate because the delete is destructive and
-      // `--quiet` emits no result envelope at all.
-      if (protectedDeletePaths.length > 0 && !jsonOutput) {
-        const protectedPathList = protectedDeletePaths.map(sanitizeLogText).join(", ");
-        logWarning(
-          `Prune ${dryRun ? "would remove" : "removes"} ${protectedDeletePaths.length} protected ` +
-            `remote ${
-              protectedDeletePaths.length === 1 ? "path" : "paths"
-            } that .vfignore cannot re-include: ${protectedPathList}.`,
-        );
-        if (!dryRun) {
-          logInfo("Rotate any credential these paths contained.");
-        }
-      }
+      // Actual deletes are reported when each remote mutation completes so a
+      // late protected path and a partially failed push still get rotation
+      // guidance. A dry run has no applied operations, so report its plan here.
+      if (dryRun) warnProtectedRemotePaths(protectedDeletePaths, true);
 
       if (!quiet && !jsonOutput && (dryRun || isVerbose())) {
         const parts = buildSummaryParts(uploadOps, deleteOps.map((op) => op.path));
@@ -1460,6 +1473,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           deleteOps,
           false,
         );
+        recordAppliedProtectedDeletes(deleteResult.applied);
       }
 
       if (deleteResult.conflicts.length > 0) {
@@ -1496,6 +1510,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
             latestRemoteFiles,
             ignoreChecker,
             false,
+            pruneRemoteMissing,
           );
           const conflicts = findRemoteSnapshotChanges(
             buildSyncFileDigestSnapshot(plan.nextFiles),
@@ -1565,6 +1580,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
             ignoreChecker,
             plan.nextFiles,
           );
+          recordAppliedProtectedDeletes(lateDeleteResult.applied);
           if (
             lateDeleteResult.deleted > 0 ||
             lateDeleteResult.failed > 0 ||
@@ -1703,7 +1719,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
         branchName,
         uploadResult.uploaded,
         deleteResult.deleted,
-        protectedDeletePaths,
+        [...appliedProtectedDeletePaths],
         Date.now() - startTime,
       );
     },

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -1782,7 +1782,11 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           }
           throw attachProtectedDeleteContext(error, protectedDeleteContext());
         }
-        await writePlannedSyncTarget();
+        try {
+          await writePlannedSyncTarget();
+        } catch (error) {
+          throw attachProtectedDeleteContext(error, protectedDeleteContext());
+        }
       } finally {
         spinner.stop();
       }

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -584,6 +584,10 @@ export async function uploadFiles(
   return { uploaded, failed, conflicts, applied };
 }
 
+function reportDeleteFailure(path: string, error: unknown): void {
+  if (!isJsonMode()) cliLogger.error(`Failed to delete ${path}:`, error);
+}
+
 export async function deleteFiles(
   client: ApiClient,
   projectSlug: string,
@@ -619,7 +623,7 @@ export async function deleteFiles(
         conflicts.push(op.path);
         break;
       }
-      if (!isJsonMode()) cliLogger.error(`Failed to delete ${op.path}:`, error);
+      reportDeleteFailure(op.path, error);
       failed++;
     }
   }

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -378,6 +378,7 @@ function outputPushResult(
   branchName: string,
   uploaded: number,
   deleted: number,
+  protectedDeleted: readonly string[],
   duration?: number,
 ): void {
   const urls = buildPushUrls(projectSlug, branchName);
@@ -392,6 +393,7 @@ function outputPushResult(
         dryRun: false,
         uploaded,
         deleted,
+        protectedDeleted: [...protectedDeleted],
         studioUrl: urls.studio,
         previewUrl: urls.preview,
       },
@@ -422,6 +424,7 @@ function outputPushDryRunResult(
   projectExists: boolean,
   wouldUpload: number,
   wouldDelete: number,
+  protectedWouldDelete: readonly string[],
 ): void {
   const urls = buildPushUrls(projectSlug, branchName);
   streamJsonLine({
@@ -434,6 +437,7 @@ function outputPushDryRunResult(
       projectExists,
       wouldUpload,
       wouldDelete,
+      protectedWouldDelete: [...protectedWouldDelete],
       studioUrl: projectExists ? urls.studio : null,
       previewUrl: projectExists ? urls.preview : null,
     },
@@ -708,10 +712,12 @@ function findRemoteFilesMissingLocally(
   return remoteFiles
     .map((file) => file.path)
     .filter((path) =>
-      ignoreChecker.isProtected(path) ||
-      (ignoreChecker.isSupportedExtension(path) &&
-        !ignoreChecker.isIgnored(path) &&
-        !localPaths.has(path))
+      !localPaths.has(path) &&
+      // A protected path bypasses the extension and ignore filters: it is never
+      // scanned locally, so prune is the only way to remove a copy that an older
+      // CLI uploaded or that was authored in the web editor.
+      (ignoreChecker.isProtected(path) ||
+        (ignoreChecker.isSupportedExtension(path) && !ignoreChecker.isIgnored(path)))
     );
 }
 
@@ -1098,6 +1104,12 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
         (ignoreChecker.isSupportedExtension(file.path) && !ignoreChecker.isIgnored(file.path))
       );
       const protectedDeletePaths = toDelete.filter((path) => ignoreChecker.isProtected(path));
+      // Protected paths are planner input only. The sync baseline must never
+      // record them, because `plan.nextFiles` excludes them and no later pull or
+      // push would ever reconcile such an entry away.
+      const syncBaselineRemoteFiles = managedRemoteFiles.filter((file) =>
+        !ignoreChecker.isProtected(file.path)
+      );
       const plan = await planPushChanges({
         localFiles: ops,
         remoteFiles: managedRemoteFiles,
@@ -1246,6 +1258,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
               projectExists,
               0,
               0,
+              protectedDeletePaths,
             );
           } else if (dryRun) {
             logInfo("Dry run complete. No files would change.");
@@ -1255,6 +1268,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
               branchName,
               0,
               forcedPruneDeleteCount,
+              protectedDeletePaths,
               Date.now() - startTime,
             );
           }
@@ -1264,15 +1278,20 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
 
       spinner.stop();
 
-      if (protectedDeletePaths.length > 0 && !quiet && !jsonOutput) {
+      // JSON runs get the same list as a structured field on the result
+      // envelope, so this human-readable form is the non-JSON counterpart. It
+      // stays outside the `quiet` gate because the delete is destructive and
+      // `--quiet` emits no result envelope at all.
+      if (protectedDeletePaths.length > 0 && !jsonOutput) {
         logWarning(
-          `Prune removes ${protectedDeletePaths.length} protected remote ${
-            protectedDeletePaths.length === 1 ? "path" : "paths"
-          } that .vfignore cannot re-include: ${protectedDeletePaths.join(", ")}.`,
+          `Prune ${dryRun ? "would remove" : "removes"} ${protectedDeletePaths.length} protected ` +
+            `remote ${
+              protectedDeletePaths.length === 1 ? "path" : "paths"
+            } that .vfignore cannot re-include: ${protectedDeletePaths.join(", ")}.`,
         );
-        logInfo(
-          "Use veryfront push --prune --dry-run first to review them.",
-        );
+        if (!dryRun) {
+          logInfo("Rotate any credential these paths contained.");
+        }
       }
 
       if (!quiet && !jsonOutput && (dryRun || isVerbose())) {
@@ -1297,6 +1316,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
             projectExists,
             uploadOps.length,
             deleteOps.length,
+            protectedDeletePaths,
           );
         } else if (!quiet) {
           const parts = buildConfirmParts(uploadOps, deleteOps.map((op) => op.path));
@@ -1335,7 +1355,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           config,
           project,
           branchName,
-          managedRemoteFiles,
+          syncBaselineRemoteFiles,
           uploadOps.filter((op) => appliedUploads.has(op.path)),
           appliedDeletes,
         );
@@ -1374,7 +1394,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           config,
           project,
           branchName,
-          managedRemoteFiles,
+          syncBaselineRemoteFiles,
           stillApplied.uploads,
           stillApplied.deletes,
         );
@@ -1399,7 +1419,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           config,
           project,
           branchName,
-          managedRemoteFiles,
+          syncBaselineRemoteFiles,
           uploadOps.filter((op) => appliedUploads.has(op.path)),
           [],
         );
@@ -1414,7 +1434,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           config,
           project,
           branchName,
-          managedRemoteFiles,
+          syncBaselineRemoteFiles,
           uploadOps.filter((op) => appliedUploads.has(op.path)),
           [],
         );
@@ -1445,7 +1465,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           config,
           project,
           branchName,
-          managedRemoteFiles,
+          syncBaselineRemoteFiles,
           uploadOps.filter((op) => appliedUploads.has(op.path)),
           deleteOps.filter((op) => appliedDeletes.has(op.path)),
         );
@@ -1488,7 +1508,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
               config,
               project,
               branchName,
-              managedRemoteFiles,
+              syncBaselineRemoteFiles,
               stillApplied.uploads,
               stillApplied.deletes,
             );
@@ -1677,6 +1697,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
         branchName,
         uploadResult.uploaded,
         deleteResult.deleted,
+        protectedDeletePaths,
         Date.now() - startTime,
       );
     },

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -1437,15 +1437,19 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
         const appliedUploads = new Set(uploadResult.applied);
         const appliedDeletes = [...new Set(deleteResult.applied)]
           .map((path) => ({ path }));
-        await writeAppliedSyncTarget(
-          projectDir,
-          config,
-          project,
-          branchName,
-          syncBaselineRemoteFiles,
-          uploadOps.filter((op) => appliedUploads.has(op.path)),
-          appliedDeletes,
-        );
+        try {
+          await writeAppliedSyncTarget(
+            projectDir,
+            config,
+            project,
+            branchName,
+            syncBaselineRemoteFiles,
+            uploadOps.filter((op) => appliedUploads.has(op.path)),
+            appliedDeletes,
+          );
+        } catch (error) {
+          throw attachProtectedDeleteContext(error, protectedDeleteContext());
+        }
       };
       const listAllFilesForVerification = async () => {
         try {
@@ -1480,15 +1484,19 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           uploadOps.filter((op) => appliedUploads.has(op.path)),
           appliedDeletes,
         );
-        await writeAppliedSyncTarget(
-          projectDir,
-          config,
-          project,
-          branchName,
-          syncBaselineRemoteFiles,
-          stillApplied.uploads,
-          stillApplied.deletes,
-        );
+        try {
+          await writeAppliedSyncTarget(
+            projectDir,
+            config,
+            project,
+            branchName,
+            syncBaselineRemoteFiles,
+            stillApplied.uploads,
+            stillApplied.deletes,
+          );
+        } catch (error) {
+          throw attachProtectedDeleteContext(error, protectedDeleteContext());
+        }
       };
 
       if (uploadOps.length > 0) {

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -1558,17 +1558,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
 
       if (deleteResult.conflicts.length > 0) {
         spinner.stop();
-        const appliedUploads = new Set(uploadResult.applied);
-        const appliedDeletes = new Set(deleteResult.applied);
-        await writeAppliedSyncTarget(
-          projectDir,
-          config,
-          project,
-          branchName,
-          syncBaselineRemoteFiles,
-          uploadOps.filter((op) => appliedUploads.has(op.path)),
-          deleteOps.filter((op) => appliedDeletes.has(op.path)),
-        );
+        await writeConfirmedAppliedSyncTarget();
         throw pushConflictError(deleteResult.conflicts, protectedDeleteContext());
       }
 

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -1599,15 +1599,19 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
               uploadOps.filter((op) => appliedUploads.has(op.path)),
               deleteOps.filter((op) => appliedDeletes.has(op.path)),
             );
-            await writeAppliedSyncTarget(
-              projectDir,
-              config,
-              project,
-              branchName,
-              syncBaselineRemoteFiles,
-              stillApplied.uploads,
-              stillApplied.deletes,
-            );
+            try {
+              await writeAppliedSyncTarget(
+                projectDir,
+                config,
+                project,
+                branchName,
+                syncBaselineRemoteFiles,
+                stillApplied.uploads,
+                stillApplied.deletes,
+              );
+            } catch (error) {
+              throw attachProtectedDeleteContext(error, protectedDeleteContext());
+            }
             throw pushConflictError(conflicts, protectedDeleteContext());
           }
           pushedSourceDigest = await computePushedSourceDigest(ops, latestRemoteFiles);

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -45,6 +45,7 @@ import { createIgnoreChecker, type IgnoreChecker, loadIgnorePatterns } from "../
 import { listAllFiles, type PullSource } from "../pull/index.ts";
 import { CommonArgs, createArgParser } from "#cli/shared/args";
 import { isNotFoundError, lstat } from "veryfront/fs";
+import { sanitizeLogText } from "#veryfront/utils/logger/core.ts";
 import {
   areSourceFilesTracked,
   clearPushReceipt,
@@ -1283,11 +1284,12 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
       // stays outside the `quiet` gate because the delete is destructive and
       // `--quiet` emits no result envelope at all.
       if (protectedDeletePaths.length > 0 && !jsonOutput) {
+        const protectedPathList = protectedDeletePaths.map(sanitizeLogText).join(", ");
         logWarning(
           `Prune ${dryRun ? "would remove" : "removes"} ${protectedDeletePaths.length} protected ` +
             `remote ${
               protectedDeletePaths.length === 1 ? "path" : "paths"
-            } that .vfignore cannot re-include: ${protectedDeletePaths.join(", ")}.`,
+            } that .vfignore cannot re-include: ${protectedPathList}.`,
         );
         if (!dryRun) {
           logInfo("Rotate any credential these paths contained.");

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -1195,6 +1195,13 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
           throw attachProtectedDeleteContext(error, protectedDeleteContext());
         }
       };
+      const computeVerifiedSourceDigest = async (files: readonly RemoteFile[]) => {
+        try {
+          return await computePushedSourceDigest(ops, files);
+        } catch (error) {
+          throw attachProtectedDeleteContext(error, protectedDeleteContext());
+        }
+      };
       // Protected paths are planner input only. The sync baseline must never
       // record them, because `plan.nextFiles` excludes them and no later pull or
       // push would ever reconcile such an entry away.
@@ -1263,7 +1270,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
               if (conflicts.length > 0) {
                 throw pushConflictError(conflicts);
               }
-              pushedSourceDigest = await computePushedSourceDigest(ops, latestRemoteFiles);
+              pushedSourceDigest = await computeVerifiedSourceDigest(latestRemoteFiles);
             } else if (pruneRemoteMissing) {
               spinner.update("Verifying push target...");
               let latestRemoteFiles = await listAllFiles(
@@ -1318,14 +1325,14 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
               if (conflicts.length > 0) {
                 throw pushConflictError(conflicts, protectedDeleteContext());
               }
-              pushedSourceDigest = await computePushedSourceDigest(ops, latestRemoteFiles);
+              pushedSourceDigest = await computeVerifiedSourceDigest(latestRemoteFiles);
             } else {
               const latestRemoteFiles = await listAllFiles(
                 client,
                 projectApiReference(config),
                 target.source,
               );
-              pushedSourceDigest = await computePushedSourceDigest(ops, latestRemoteFiles);
+              pushedSourceDigest = await computeVerifiedSourceDigest(latestRemoteFiles);
               pushedSyncFiles = await buildSyncFilesAfterAppliedChanges(
                 latestRemoteFiles.filter((file) =>
                   ignoreChecker.isSupportedExtension(file.path) &&
@@ -1631,7 +1638,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
             }
             throw pushConflictError(conflicts, protectedDeleteContext());
           }
-          pushedSourceDigest = await computePushedSourceDigest(ops, latestRemoteFiles);
+          pushedSourceDigest = await computeVerifiedSourceDigest(latestRemoteFiles);
         } else if (pruneRemoteMissing) {
           const latestRemoteFiles = await listAllFilesForVerification();
           let repaired = false;
@@ -1714,9 +1721,9 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
               await writeVerifiedAppliedSyncTarget(repairedRemoteFiles);
               throw pushConflictError(repairedConflicts, protectedDeleteContext());
             }
-            pushedSourceDigest = await computePushedSourceDigest(ops, repairedRemoteFiles);
+            pushedSourceDigest = await computeVerifiedSourceDigest(repairedRemoteFiles);
           } else {
-            pushedSourceDigest = await computePushedSourceDigest(ops, latestRemoteFiles);
+            pushedSourceDigest = await computeVerifiedSourceDigest(latestRemoteFiles);
           }
         } else {
           let latestRemoteFiles = await listAllFilesForVerification();
@@ -1771,7 +1778,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
             await writeVerifiedAppliedSyncTarget(latestRemoteFiles);
             throw pushConflictError(conflicts, protectedDeleteContext());
           }
-          pushedSourceDigest = await computePushedSourceDigest(ops, latestRemoteFiles);
+          pushedSourceDigest = await computeVerifiedSourceDigest(latestRemoteFiles);
           pushedSyncFiles = await buildSyncFilesAfterAppliedChanges(
             latestRemoteFiles.filter((file) =>
               ignoreChecker.isSupportedExtension(file.path) &&

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -210,7 +210,7 @@ export async function scanLocalFiles(
       const entryPath = join(currentDir, entry.name);
       const relativePath = relative(projectDir, entryPath);
 
-      if (ignoreChecker.isIgnored(relativePath)) continue;
+      if (ignoreChecker.isIgnored(relativePath, { isDirectory: entry.isDirectory })) continue;
 
       if (entry.isSymlink) {
         if (ignoreChecker.isSupportedExtension(entry.name)) {

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -619,7 +619,7 @@ export async function deleteFiles(
         conflicts.push(op.path);
         break;
       }
-      cliLogger.error(`Failed to delete ${op.path}:`, error);
+      if (!isJsonMode()) cliLogger.error(`Failed to delete ${op.path}:`, error);
       failed++;
     }
   }
@@ -1256,6 +1256,10 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
                 projectApiReference(config),
                 target.source,
               );
+              // Late reconciliation can mutate a target whose initial plan
+              // was empty. Invalidate the old attestation before the first
+              // possible delete, matching the normal mutation path.
+              await clearPushReceipt(projectDir);
               const lateDeleteResult = await deleteForcedPruneRemoteOnlyFiles(
                 client,
                 projectApiReference(config),

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -1320,7 +1320,11 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
                 [],
               );
             }
-            await clearPushReceipt(projectDir);
+            try {
+              await clearPushReceipt(projectDir);
+            } catch (error) {
+              throw attachProtectedDeleteContext(error, protectedDeleteContext());
+            }
             spinner.update("Verifying push target...");
             try {
               await recordPushReceipt(

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -741,7 +741,7 @@ function attachProtectedDeleteContext(
     return error instanceof Error ? error : new Error(String(error));
   }
   const normalized = [...protectedDeleted];
-  if (error instanceof Error) {
+  if (error instanceof VeryfrontError) {
     try {
       defineOwnProperty(error, "context", {
         value: { protectedDeleted: normalized },

--- a/cli/commands/push/command.ts
+++ b/cli/commands/push/command.ts
@@ -625,8 +625,9 @@ async function deleteForcedPruneRemoteOnlyFiles(
   const plannedPaths = new Set(Object.keys(plannedFiles));
   const remoteOnlyDeletes = remoteFiles
     .filter((file) =>
-      ignoreChecker.isSupportedExtension(file.path) &&
-      !ignoreChecker.isIgnored(file.path) &&
+      (ignoreChecker.isProtected(file.path) ||
+        (ignoreChecker.isSupportedExtension(file.path) &&
+          !ignoreChecker.isIgnored(file.path))) &&
       !plannedPaths.has(file.path)
     )
     .map((file) => ({ path: file.path }));
@@ -738,10 +739,13 @@ async function buildManagedRemoteSnapshot(
   files: readonly RemoteFile[],
   ignoreChecker: IgnoreChecker,
   includeVersion = true,
+  includeProtected = false,
 ): Promise<Map<string, { digest: string; versionId?: string }>> {
   const snapshot = new Map<string, { digest: string; versionId?: string }>();
   for (const file of files) {
-    if (!ignoreChecker.isSupportedExtension(file.path) || ignoreChecker.isIgnored(file.path)) {
+    const managed = ignoreChecker.isSupportedExtension(file.path) &&
+      !ignoreChecker.isIgnored(file.path);
+    if (!managed && !(includeProtected && ignoreChecker.isProtected(file.path))) {
       continue;
     }
     snapshot.set(file.path, {
@@ -1205,7 +1209,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
               }
               const conflicts = findRemoteSnapshotChanges(
                 buildSyncFileDigestSnapshot(plan.nextFiles),
-                await buildManagedRemoteSnapshot(latestRemoteFiles, ignoreChecker, false),
+                await buildManagedRemoteSnapshot(latestRemoteFiles, ignoreChecker, false, true),
               );
               if (conflicts.length > 0) {
                 throw pushConflictError(conflicts);
@@ -1590,7 +1594,7 @@ export function pushCommand(options: PushOptions = {}): Promise<void> {
             const repairedRemoteFiles = await listAllFilesForVerification();
             const repairedConflicts = findRemoteSnapshotChanges(
               buildSyncFileDigestSnapshot(plan.nextFiles),
-              await buildManagedRemoteSnapshot(repairedRemoteFiles, ignoreChecker, false),
+              await buildManagedRemoteSnapshot(repairedRemoteFiles, ignoreChecker, false, true),
             );
             if (repairedConflicts.length > 0) {
               await writeVerifiedAppliedSyncTarget(repairedRemoteFiles);

--- a/cli/commands/push/plan.test.ts
+++ b/cli/commands/push/plan.test.ts
@@ -185,6 +185,24 @@ describe("planPushChanges", () => {
     assertEquals(plan.conflicts, ["changed.ts", "unknown.ts"]);
   });
 
+  it("cleans a protected remote path using its observed version", async () => {
+    const plan = await planPushChanges({
+      localFiles: [],
+      remoteFiles: [{ path: ".env/credentials.json", version_id: VERSION_2 }],
+      baselineFiles: {},
+      deletePaths: [".env/credentials.json"],
+      protectedDeletePaths: [".env/credentials.json"],
+      force: false,
+    });
+
+    assertEquals(plan.deletes, [{
+      path: ".env/credentials.json",
+      expectedVersionId: VERSION_2,
+    }]);
+    assertEquals(plan.conflicts, []);
+    assertEquals(plan.nextFiles, {});
+  });
+
   it("lets force intentionally bypass overwrite preconditions", async () => {
     const localDigest = await computeContentDigest("local\n");
     const plan = await planPushChanges({

--- a/cli/commands/push/plan.test.ts
+++ b/cli/commands/push/plan.test.ts
@@ -203,6 +203,24 @@ describe("planPushChanges", () => {
     assertEquals(plan.nextFiles, {});
   });
 
+  it("ignores a protected path that is not also queued for deletion", async () => {
+    const digest = await computeContentDigest("secret\n");
+    const plan = await planPushChanges({
+      localFiles: [],
+      remoteFiles: [{ path: ".env/credentials.json", content: "secret\n", version_id: VERSION_2 }],
+      baselineFiles: {},
+      deletePaths: [],
+      protectedDeletePaths: [".env/credentials.json"],
+      force: false,
+    });
+
+    assertEquals(plan.deletes, []);
+    assertEquals(plan.conflicts, []);
+    assertEquals(plan.nextFiles, {
+      ".env/credentials.json": { digest, versionId: VERSION_2 },
+    });
+  });
+
   it("lets force intentionally bypass overwrite preconditions", async () => {
     const localDigest = await computeContentDigest("local\n");
     const plan = await planPushChanges({

--- a/cli/commands/push/plan.ts
+++ b/cli/commands/push/plan.ts
@@ -33,7 +33,12 @@ export interface PlanPushChangesOptions {
   remoteFiles: readonly PushRemoteFile[];
   baselineFiles: Readonly<Record<string, SyncFileSnapshot>>;
   deletePaths: readonly string[];
-  /** Protected remote paths selected for unconditional cleanup during prune. */
+  /**
+   * Protected remote paths selected for unconditional cleanup during prune.
+   * Only entries that also appear in {@link PlanPushChangesOptions.deletePaths}
+   * are honoured: a protected path outside that set would be dropped from the
+   * sync baseline without ever being queued for deletion.
+   */
   protectedDeletePaths?: readonly string[];
   force: boolean;
   /** Treat the exact remote snapshot as the baseline for a newly created branch. */
@@ -64,7 +69,10 @@ function requiredContent(file: PushRemoteFile): string {
 export async function planPushChanges(
   options: PlanPushChangesOptions,
 ): Promise<PushChangePlan> {
-  const protectedDeletePaths = new Set(options.protectedDeletePaths ?? []);
+  const requestedDeletePaths = new Set(options.deletePaths);
+  const protectedDeletePaths = new Set(
+    (options.protectedDeletePaths ?? []).filter((path) => requestedDeletePaths.has(path)),
+  );
   const remoteByPath = new Map<string, PushRemoteFile>();
   const remoteDigests = new Map<string, string>();
   const nextFiles: Record<string, SyncFileSnapshot> = {};

--- a/cli/commands/push/plan.ts
+++ b/cli/commands/push/plan.ts
@@ -33,6 +33,8 @@ export interface PlanPushChangesOptions {
   remoteFiles: readonly PushRemoteFile[];
   baselineFiles: Readonly<Record<string, SyncFileSnapshot>>;
   deletePaths: readonly string[];
+  /** Protected remote paths selected for unconditional cleanup during prune. */
+  protectedDeletePaths?: readonly string[];
   force: boolean;
   /** Treat the exact remote snapshot as the baseline for a newly created branch. */
   remoteFilesAreBaseline?: boolean;
@@ -62,6 +64,7 @@ function requiredContent(file: PushRemoteFile): string {
 export async function planPushChanges(
   options: PlanPushChangesOptions,
 ): Promise<PushChangePlan> {
+  const protectedDeletePaths = new Set(options.protectedDeletePaths ?? []);
   const remoteByPath = new Map<string, PushRemoteFile>();
   const remoteDigests = new Map<string, string>();
   const nextFiles: Record<string, SyncFileSnapshot> = {};
@@ -69,6 +72,10 @@ export async function planPushChanges(
   for (const file of options.remoteFiles) {
     if (remoteByPath.has(file.path)) {
       throw new Error(`Veryfront returned duplicate remote file path "${file.path}".`);
+    }
+    if (protectedDeletePaths.has(file.path)) {
+      remoteByPath.set(file.path, file);
+      continue;
     }
     const digest = await computeContentDigest(requiredContent(file));
     remoteByPath.set(file.path, file);
@@ -138,6 +145,12 @@ export async function planPushChanges(
 
     if (options.force) {
       deletes.push({ path });
+      delete nextFiles[path];
+      continue;
+    }
+
+    if (protectedDeletePaths.has(path)) {
+      deletes.push({ path, expectedVersionId: requiredVersionId(remote) });
       delete nextFiles[path];
       continue;
     }

--- a/cli/router.test.ts
+++ b/cli/router.test.ts
@@ -4,7 +4,7 @@ import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { COMMANDS } from "./help/command-definitions.ts";
 import { parseLoginMethod } from "./auth/utils.ts";
-import { classifyCliError, routeCommand } from "./router.ts";
+import { classifyCliError, routeCommand, safeJsonErrorContext } from "./router.ts";
 import { INVALID_ARGUMENT, UNKNOWN_ERROR } from "veryfront/errors";
 import { cliLogger, VERSION } from "./utils/index.ts";
 import { setJsonMode } from "./shared/json-output.ts";
@@ -137,6 +137,16 @@ describe("cli/command-definitions integrity", () => {
 });
 
 describe("cli/router helpers", () => {
+  it("bounds oversized protected-deletion error context with truncation metadata", () => {
+    const context = safeJsonErrorContext({
+      protectedDeleted: Array.from({ length: 1_025 }, (_, index) => `.env.secret-${index}`),
+    });
+
+    assertEquals((context?.protectedDeleted as string[]).length, 1_000);
+    assertEquals(context?.protectedDeletedTruncated, true);
+    assertEquals(context?.protectedDeletedOmitted, 25);
+  });
+
   describe("classifyCliError", () => {
     it("uses typed exit metadata instead of message prefixes", () => {
       assertEquals(

--- a/cli/router.ts
+++ b/cli/router.ts
@@ -136,40 +136,46 @@ function commandNameForJson(args: ParsedArgs): string {
   return typeof command === "string" && command.length > 0 ? command : "cli";
 }
 
-export function safeJsonErrorContext(context: unknown): Record<string, unknown> | undefined {
-  if (context === undefined) return undefined;
-  if (context !== null && typeof context === "object" && !Array.isArray(context)) {
-    const protectedDeleted = (context as Record<string, unknown>).protectedDeleted;
-    if (Array.isArray(protectedDeleted)) {
-      const limit = 1_000;
-      const bounded: string[] = [];
-      for (let index = 0; index < protectedDeleted.length && bounded.length < limit; index++) {
-        const path = protectedDeleted[index];
-        if (typeof path === "string") bounded.push(path);
-      }
-      const redactedBounded = redactForSerialization(bounded);
-      if (Array.isArray(redactedBounded)) {
-        return {
-          protectedDeleted: redactedBounded,
-          ...(protectedDeleted.length > bounded.length
-            ? {
-              protectedDeletedTruncated: true,
-              protectedDeletedOmitted: protectedDeleted.length - bounded.length,
-            }
-            : {}),
-        };
-      }
-    }
+const PROTECTED_DELETE_CONTEXT_LIMIT = 1_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function boundedProtectedDeleteContext(context: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(context) || !Array.isArray(context.protectedDeleted)) return undefined;
+  const protectedDeleted = context.protectedDeleted;
+  const bounded: string[] = [];
+  for (const path of protectedDeleted) {
+    if (typeof path === "string") bounded.push(path);
+    if (bounded.length === PROTECTED_DELETE_CONTEXT_LIMIT) break;
   }
+  const redactedBounded = redactForSerialization(bounded);
+  if (!Array.isArray(redactedBounded)) return undefined;
+  return {
+    protectedDeleted: redactedBounded,
+    ...(protectedDeleted.length > bounded.length
+      ? {
+        protectedDeletedTruncated: true,
+        protectedDeletedOmitted: protectedDeleted.length - bounded.length,
+      }
+      : {}),
+  };
+}
+
+function redactedProtectedDeleteContext(context: unknown): Record<string, unknown> | undefined {
   const redacted = redactForSerialization(context);
-  if (redacted === null || typeof redacted !== "object" || Array.isArray(redacted)) {
-    return undefined;
-  }
-  const protectedDeleted = (redacted as Record<string, unknown>).protectedDeleted;
+  if (!isRecord(redacted)) return undefined;
+  const protectedDeleted = redacted.protectedDeleted;
   return Array.isArray(protectedDeleted) &&
       protectedDeleted.every((path) => typeof path === "string")
     ? { protectedDeleted }
     : undefined;
+}
+
+export function safeJsonErrorContext(context: unknown): Record<string, unknown> | undefined {
+  if (context === undefined) return undefined;
+  return boundedProtectedDeleteContext(context) ?? redactedProtectedDeleteContext(context);
 }
 
 async function outputCliJsonError(

--- a/cli/router.ts
+++ b/cli/router.ts
@@ -21,6 +21,7 @@ import {
 } from "./shared/json-output.ts";
 import { detectCI, setAutoConfirm, setNonInteractive } from "./shared/interactive.ts";
 import type { ParsedArgs } from "./shared/types.ts";
+import { redactForSerialization } from "veryfront/utils";
 
 type CommandHandler = (args: ParsedArgs) => Promise<void>;
 type CommandLoader = () => Promise<CommandHandler>;
@@ -133,6 +134,14 @@ function showHelp(command?: string, showAll = false): void {
 function commandNameForJson(args: ParsedArgs): string {
   const command = args._[0];
   return typeof command === "string" && command.length > 0 ? command : "cli";
+}
+
+function safeJsonErrorContext(context: unknown): Record<string, unknown> | undefined {
+  if (context === undefined) return undefined;
+  const redacted = redactForSerialization(context);
+  return redacted !== null && typeof redacted === "object" && !Array.isArray(redacted)
+    ? redacted as Record<string, unknown>
+    : undefined;
 }
 
 async function outputCliJsonError(
@@ -301,6 +310,7 @@ export async function routeCommand(args: ParsedArgs): Promise<void> {
         slug: classification.slug,
         registrySlug: vfError.slug,
         message: vfError.detail ?? message,
+        context: safeJsonErrorContext(vfError.context),
       });
     },
     getExitCode: (_error, vfError) => classifyCliError(vfError).exitCode,

--- a/cli/router.ts
+++ b/cli/router.ts
@@ -139,8 +139,13 @@ function commandNameForJson(args: ParsedArgs): string {
 function safeJsonErrorContext(context: unknown): Record<string, unknown> | undefined {
   if (context === undefined) return undefined;
   const redacted = redactForSerialization(context);
-  return redacted !== null && typeof redacted === "object" && !Array.isArray(redacted)
-    ? redacted as Record<string, unknown>
+  if (redacted === null || typeof redacted !== "object" || Array.isArray(redacted)) {
+    return undefined;
+  }
+  const protectedDeleted = (redacted as Record<string, unknown>).protectedDeleted;
+  return Array.isArray(protectedDeleted) &&
+      protectedDeleted.every((path) => typeof path === "string")
+    ? { protectedDeleted }
     : undefined;
 }
 

--- a/cli/router.ts
+++ b/cli/router.ts
@@ -136,8 +136,31 @@ function commandNameForJson(args: ParsedArgs): string {
   return typeof command === "string" && command.length > 0 ? command : "cli";
 }
 
-function safeJsonErrorContext(context: unknown): Record<string, unknown> | undefined {
+export function safeJsonErrorContext(context: unknown): Record<string, unknown> | undefined {
   if (context === undefined) return undefined;
+  if (context !== null && typeof context === "object" && !Array.isArray(context)) {
+    const protectedDeleted = (context as Record<string, unknown>).protectedDeleted;
+    if (Array.isArray(protectedDeleted)) {
+      const limit = 1_000;
+      const bounded: string[] = [];
+      for (let index = 0; index < protectedDeleted.length && bounded.length < limit; index++) {
+        const path = protectedDeleted[index];
+        if (typeof path === "string") bounded.push(path);
+      }
+      const redactedBounded = redactForSerialization(bounded);
+      if (Array.isArray(redactedBounded)) {
+        return {
+          protectedDeleted: redactedBounded,
+          ...(protectedDeleted.length > bounded.length
+            ? {
+              protectedDeletedTruncated: true,
+              protectedDeletedOmitted: protectedDeleted.length - bounded.length,
+            }
+            : {}),
+        };
+      }
+    }
+  }
   const redacted = redactForSerialization(context);
   if (redacted === null || typeof redacted !== "object" || Array.isArray(redacted)) {
     return undefined;

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -236,9 +236,13 @@ describe("cli/sync/ignore", () => {
         assertEquals(anchoredRootFileChecker.isIgnored(".git"), true);
         assertEquals(warnings.length, 4, "a root file rule must not warn for protected children");
 
+        const anchoredRecursiveFileChecker = createIgnoreChecker([".env*", "!/**.json"]);
+        assertEquals(anchoredRecursiveFileChecker.isIgnored(".env"), true);
+        assertEquals(warnings.length, 5, "an anchored double-star must retain its warning");
+
         setJsonMode(true);
         assertEquals(createIgnoreChecker(["!.env/**"]).isIgnored(".env/other.json"), true);
-        assertEquals(warnings.length, 4, "JSON mode must not emit human warning text");
+        assertEquals(warnings.length, 5, "JSON mode must not emit human warning text");
       } finally {
         setJsonMode(false);
         warningStub.restore();

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -132,7 +132,6 @@ describe("cli/sync/ignore", () => {
         ".git",
         "!.env*.json",
         "!.env/**",
-        "!.envs/**",
         "!.veryfront",
         "!.veryfront/**",
         "!.git/**",
@@ -142,7 +141,6 @@ describe("cli/sync/ignore", () => {
       assertEquals(checker.isIgnored("config/.env.staging.yaml"), true);
       assertEquals(checker.isIgnored(".env/credentials.json"), true);
       assertEquals(checker.isIgnored(".env.d/production.json"), true);
-      assertEquals(checker.isIgnored(".envs/production.json"), true);
       assertEquals(checker.isIgnored(".ENV.PRODUCTION.JSON"), true);
       assertEquals(checker.isIgnored(".ENV/credentials.json"), true);
       assertEquals(checker.isIgnored(".veryfront"), true);
@@ -150,6 +148,19 @@ describe("cli/sync/ignore", () => {
       assertEquals(checker.isIgnored(".git/config"), true);
       assertEquals(checker.isProtected(".env/credentials.json"), true);
       assertEquals(checker.isProtected("src/app.ts"), false);
+    });
+
+    it("should keep negations working for names that only start with .env", () => {
+      const checker = createIgnoreChecker([
+        ".env*",
+        "!.envoy/**",
+        "!.environments/**",
+      ]);
+
+      assertEquals(checker.isIgnored(".envoy/config.json"), false);
+      assertEquals(checker.isIgnored(".environments/prod.json"), false);
+      assertEquals(checker.isProtected(".envoy/config.json"), false);
+      assertEquals(checker.isProtected(".environments/prod.json"), false);
     });
 
     it("should handle directory-trailing-slash patterns", () => {

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -332,9 +332,20 @@ describe("cli/sync/ignore", () => {
           "an anchored literal negation must include its implicit descendants",
         );
 
+        const partialWildcardChecker = createIgnoreChecker([
+          "!foo.ts",
+          "*e*",
+        ]);
+        assertEquals(partialWildcardChecker.isIgnored(".env", { isDirectory: true }), true);
+        assertEquals(
+          warnings.length,
+          12,
+          "one matching descendant probe must not imply full wildcard coverage",
+        );
+
         setJsonMode(true);
         assertEquals(createIgnoreChecker(["!.env/**"]).isIgnored(".env/other.json"), true);
-        assertEquals(warnings.length, 11, "JSON mode must not emit human warning text");
+        assertEquals(warnings.length, 12, "JSON mode must not emit human warning text");
       } finally {
         setJsonMode(false);
         warningStub.restore();

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -307,9 +307,20 @@ describe("cli/sync/ignore", () => {
           "a root-anchored positive cannot cancel an unanchored descendant negation",
         );
 
+        const parentOnlyChecker = createIgnoreChecker([
+          "!.env",
+          ".env*",
+        ]);
+        assertEquals(parentOnlyChecker.isIgnored(".env", { isDirectory: true }), true);
+        assertEquals(
+          warnings.length,
+          10,
+          "a parent-only positive cannot cancel a negation that also matches descendants",
+        );
+
         setJsonMode(true);
         assertEquals(createIgnoreChecker(["!.env/**"]).isIgnored(".env/other.json"), true);
-        assertEquals(warnings.length, 9, "JSON mode must not emit human warning text");
+        assertEquals(warnings.length, 10, "JSON mode must not emit human warning text");
       } finally {
         setJsonMode(false);
         warningStub.restore();

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -232,6 +232,10 @@ describe("cli/sync/ignore", () => {
         assertEquals(internalWildcardChecker.isIgnored("src/.env"), true);
         assertEquals(warnings.length, 4, "an internal wildcard must not hide the warning");
 
+        const anchoredRootFileChecker = createIgnoreChecker([".git", "!/*.ts"]);
+        assertEquals(anchoredRootFileChecker.isIgnored(".git"), true);
+        assertEquals(warnings.length, 4, "a root file rule must not warn for protected children");
+
         setJsonMode(true);
         assertEquals(createIgnoreChecker(["!.env/**"]).isIgnored(".env/other.json"), true);
         assertEquals(warnings.length, 4, "JSON mode must not emit human warning text");

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -213,9 +213,17 @@ describe("cli/sync/ignore", () => {
           "warning text must not carry terminal controls",
         );
 
+        const descendantChecker = createIgnoreChecker([".env*", "!.env/**"]);
+        assertEquals(descendantChecker.isIgnored(".env"), true);
+        assertEquals(
+          warnings.length,
+          2,
+          "a protected parent must warn before traversal drops a descendant negation",
+        );
+
         setJsonMode(true);
         assertEquals(createIgnoreChecker(["!.env/**"]).isIgnored(".env/other.json"), true);
-        assertEquals(warnings.length, 1, "JSON mode must not emit human warning text");
+        assertEquals(warnings.length, 2, "JSON mode must not emit human warning text");
       } finally {
         setJsonMode(false);
         warningStub.restore();

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -285,6 +285,17 @@ describe("cli/sync/ignore", () => {
           "a later parent-directory ignore cancels descendant negations",
         );
 
+        const wildcardCanceledChecker = createIgnoreChecker([
+          "!.env/foo.ts",
+          ".env/*.ts",
+        ]);
+        assertEquals(wildcardCanceledChecker.isIgnored(".env", { isDirectory: true }), true);
+        assertEquals(
+          warnings.length,
+          8,
+          "a later wildcard that covers a fixed negation cancels the warning",
+        );
+
         setJsonMode(true);
         assertEquals(createIgnoreChecker(["!.env/**"]).isIgnored(".env/other.json"), true);
         assertEquals(warnings.length, 8, "JSON mode must not emit human warning text");

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -271,6 +271,14 @@ describe("cli/sync/ignore", () => {
         assertEquals(canceledNegationChecker.isIgnored(".env"), true);
         assertEquals(warnings.length, 8, "a later matching ignore rule cancels the warning");
 
+        const broadlyCanceledChecker = createIgnoreChecker(["!.env/**", ".env"]);
+        assertEquals(broadlyCanceledChecker.isIgnored(".env"), true);
+        assertEquals(
+          warnings.length,
+          8,
+          "a later parent-directory ignore cancels descendant negations",
+        );
+
         setJsonMode(true);
         assertEquals(createIgnoreChecker(["!.env/**"]).isIgnored(".env/other.json"), true);
         assertEquals(warnings.length, 8, "JSON mode must not emit human warning text");

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -30,6 +30,17 @@ describe("cli/sync/ignore", () => {
       }
     });
 
+    it("reports the size limit for an oversized .vfignore", async () => {
+      await withTempDir(async (projectDir) => {
+        await Deno.writeTextFile(`${projectDir}/.vfignore`, "x".repeat(256 * 1_024 + 1));
+        await assertRejects(
+          () => loadIgnorePatterns(projectDir),
+          Error,
+          ".vfignore must not exceed 262144 characters",
+        );
+      });
+    });
+
     it("keeps secrets ignored when .vfignore negates the defaults", async () => {
       const projectDir = await Deno.makeTempDir();
       try {

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -225,9 +225,16 @@ describe("cli/sync/ignore", () => {
         assertEquals(wildcardChecker.isIgnored(".env"), true);
         assertEquals(warnings.length, 3, "a recursive prefix must not hide the warning");
 
+        const internalWildcardChecker = createIgnoreChecker([
+          "src/.env*",
+          "!src/**/.env/**",
+        ]);
+        assertEquals(internalWildcardChecker.isIgnored("src/.env"), true);
+        assertEquals(warnings.length, 4, "an internal wildcard must not hide the warning");
+
         setJsonMode(true);
         assertEquals(createIgnoreChecker(["!.env/**"]).isIgnored(".env/other.json"), true);
-        assertEquals(warnings.length, 3, "JSON mode must not emit human warning text");
+        assertEquals(warnings.length, 4, "JSON mode must not emit human warning text");
       } finally {
         setJsonMode(false);
         warningStub.restore();

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -240,9 +240,13 @@ describe("cli/sync/ignore", () => {
         assertEquals(anchoredRecursiveFileChecker.isIgnored(".env"), true);
         assertEquals(warnings.length, 5, "an anchored double-star must retain its warning");
 
+        const unanchoredNestedChecker = createIgnoreChecker([".env*", "!foo/bar.json"]);
+        assertEquals(unanchoredNestedChecker.isIgnored(".env"), true);
+        assertEquals(warnings.length, 6, "an unanchored nested rule must retain its warning");
+
         setJsonMode(true);
         assertEquals(createIgnoreChecker(["!.env/**"]).isIgnored(".env/other.json"), true);
-        assertEquals(warnings.length, 5, "JSON mode must not emit human warning text");
+        assertEquals(warnings.length, 6, "JSON mode must not emit human warning text");
       } finally {
         setJsonMode(false);
         warningStub.restore();

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -296,9 +296,20 @@ describe("cli/sync/ignore", () => {
           "a later wildcard that covers a fixed negation cancels the warning",
         );
 
+        const differentlyAnchoredChecker = createIgnoreChecker([
+          "!secret.json",
+          "/secret.json",
+        ]);
+        assertEquals(differentlyAnchoredChecker.isIgnored(".env", { isDirectory: true }), true);
+        assertEquals(
+          warnings.length,
+          9,
+          "a root-anchored positive cannot cancel an unanchored descendant negation",
+        );
+
         setJsonMode(true);
         assertEquals(createIgnoreChecker(["!.env/**"]).isIgnored(".env/other.json"), true);
-        assertEquals(warnings.length, 8, "JSON mode must not emit human warning text");
+        assertEquals(warnings.length, 9, "JSON mode must not emit human warning text");
       } finally {
         setJsonMode(false);
         warningStub.restore();

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -131,6 +131,8 @@ describe("cli/sync/ignore", () => {
         ".veryfront",
         ".git",
         "!.env*.json",
+        "!.env/**",
+        "!.envs/**",
         "!.veryfront",
         "!.veryfront/**",
         "!.git/**",
@@ -138,9 +140,16 @@ describe("cli/sync/ignore", () => {
 
       assertEquals(checker.isIgnored(".env.production.json"), true);
       assertEquals(checker.isIgnored("config/.env.staging.yaml"), true);
+      assertEquals(checker.isIgnored(".env/credentials.json"), true);
+      assertEquals(checker.isIgnored(".env.d/production.json"), true);
+      assertEquals(checker.isIgnored(".envs/production.json"), true);
+      assertEquals(checker.isIgnored(".ENV.PRODUCTION.JSON"), true);
+      assertEquals(checker.isIgnored(".ENV/credentials.json"), true);
       assertEquals(checker.isIgnored(".veryfront"), true);
       assertEquals(checker.isIgnored(".veryfront/state.json"), true);
       assertEquals(checker.isIgnored(".git/config"), true);
+      assertEquals(checker.isProtected(".env/credentials.json"), true);
+      assertEquals(checker.isProtected("src/app.ts"), false);
     });
 
     it("should handle directory-trailing-slash patterns", () => {

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -1,6 +1,10 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { withTempDir } from "#veryfront/testing/deno-compat.ts";
+import { stub } from "#std/testing/mock";
+import { scanLocalFiles } from "../commands/push/command.ts";
+import { setJsonMode } from "../shared/json-output.ts";
 import { createDefaultIgnoreChecker, createIgnoreChecker, loadIgnorePatterns } from "./ignore.ts";
 
 describe("cli/sync/ignore", () => {
@@ -153,7 +157,9 @@ describe("cli/sync/ignore", () => {
     it("should keep negations working for names that only start with .env", () => {
       const checker = createIgnoreChecker([
         ".env*",
+        "!.envoy",
         "!.envoy/**",
+        "!.environments",
         "!.environments/**",
       ]);
 
@@ -161,6 +167,59 @@ describe("cli/sync/ignore", () => {
       assertEquals(checker.isIgnored(".environments/prod.json"), false);
       assertEquals(checker.isProtected(".envoy/config.json"), false);
       assertEquals(checker.isProtected(".environments/prod.json"), false);
+    });
+
+    it("keeps negated .env-prefixed directories traversable by push", async () => {
+      await withTempDir(async (projectDir) => {
+        await Deno.mkdir(`${projectDir}/.envoy`, { recursive: true });
+        await Deno.mkdir(`${projectDir}/.environments`, { recursive: true });
+        await Deno.writeTextFile(`${projectDir}/.envoy/config.json`, "{}\n");
+        await Deno.writeTextFile(`${projectDir}/.environments/prod.json`, "{}\n");
+        const checker = createIgnoreChecker([
+          ".env*",
+          "!.envoy",
+          "!.envoy/**",
+          "!.environments",
+          "!.environments/**",
+        ]);
+
+        const files = await scanLocalFiles(projectDir, checker);
+
+        assertEquals(files.map((file) => file.path).sort(), [
+          ".environments/prod.json",
+          ".envoy/config.json",
+        ]);
+      });
+    });
+
+    it("warns only for a negated protected path and keeps JSON output clean", () => {
+      const warnings: string[] = [];
+      const warningStub = stub(console, "warn", (...values: unknown[]) => {
+        warnings.push(values.map(String).join(" "));
+      });
+      const path = ".env/credentials\u001b[31mforged.json";
+
+      try {
+        assertEquals(createIgnoreChecker([]).isIgnored(path), true);
+        assertEquals(warnings, [], "protection without a negation must stay silent");
+
+        const checker = createIgnoreChecker([`!${path}`]);
+        assertEquals(checker.isIgnored(path), true);
+        assertEquals(checker.isIgnored(path), true);
+        assertEquals(warnings.length, 1, "one dropped negation must emit one warning");
+        assertEquals(
+          warnings[0]?.includes("\u001b"),
+          false,
+          "warning text must not carry terminal controls",
+        );
+
+        setJsonMode(true);
+        assertEquals(createIgnoreChecker(["!.env/**"]).isIgnored(".env/other.json"), true);
+        assertEquals(warnings.length, 1, "JSON mode must not emit human warning text");
+      } finally {
+        setJsonMode(false);
+        warningStub.restore();
+      }
     });
 
     it("should handle directory-trailing-slash patterns", () => {

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -366,6 +366,11 @@ describe("cli/sync/ignore", () => {
         Error,
         ".vfignore patterns must not exceed",
       );
+      assertThrows(
+        () => createIgnoreChecker(Array.from({ length: 1_025 }, (_, index) => `file-${index}`)),
+        Error,
+        "1024 rules",
+      );
     });
   });
 

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -221,39 +221,47 @@ describe("cli/sync/ignore", () => {
           "a protected parent must warn before traversal drops a descendant negation",
         );
 
+        const divergentDescendantChecker = createIgnoreChecker(["!.env**", ".env*"]);
+        assertEquals(divergentDescendantChecker.isIgnored(".env"), true);
+        assertEquals(
+          warnings.length,
+          3,
+          "a later parent match must not hide a negation still effective for descendants",
+        );
+
         const wildcardChecker = createIgnoreChecker([".env*", "!**/.env/**"]);
         assertEquals(wildcardChecker.isIgnored(".env"), true);
-        assertEquals(warnings.length, 3, "a recursive prefix must not hide the warning");
+        assertEquals(warnings.length, 4, "a recursive prefix must not hide the warning");
 
         const internalWildcardChecker = createIgnoreChecker([
           "src/.env*",
           "!src/**/.env/**",
         ]);
         assertEquals(internalWildcardChecker.isIgnored("src/.env"), true);
-        assertEquals(warnings.length, 4, "an internal wildcard must not hide the warning");
+        assertEquals(warnings.length, 5, "an internal wildcard must not hide the warning");
 
         const anchoredRootFileChecker = createIgnoreChecker([".git", "!/*.ts"]);
         assertEquals(anchoredRootFileChecker.isIgnored(".git"), true);
-        assertEquals(warnings.length, 4, "a root file rule must not warn for protected children");
+        assertEquals(warnings.length, 5, "a root file rule must not warn for protected children");
 
         const anchoredRecursiveFileChecker = createIgnoreChecker([".env*", "!/**.json"]);
         assertEquals(anchoredRecursiveFileChecker.isIgnored(".env"), true);
-        assertEquals(warnings.length, 5, "an anchored double-star must retain its warning");
+        assertEquals(warnings.length, 6, "an anchored double-star must retain its warning");
 
         const unanchoredNestedChecker = createIgnoreChecker([".env*", "!foo/bar.json"]);
         assertEquals(unanchoredNestedChecker.isIgnored(".env"), true);
-        assertEquals(warnings.length, 6, "an unanchored nested rule must retain its warning");
+        assertEquals(warnings.length, 7, "an unanchored nested rule must retain its warning");
 
         const anchoredOtherPrefixChecker = createIgnoreChecker([".env*", "!/foo**.json"]);
         assertEquals(anchoredOtherPrefixChecker.isIgnored(".env"), true);
-        assertEquals(warnings.length, 6, "an unrelated anchored prefix must not warn");
+        assertEquals(warnings.length, 7, "an unrelated anchored prefix must not warn");
 
         const embeddedDoubleStarChecker = createIgnoreChecker([
           ".env*",
           "!/foo**/bar.json",
         ]);
         assertEquals(embeddedDoubleStarChecker.isIgnored("foo/.env"), true);
-        assertEquals(warnings.length, 7, "an embedded double-star must retain its warning");
+        assertEquals(warnings.length, 8, "an embedded double-star must retain its warning");
 
         const canceledNegationChecker = createIgnoreChecker([
           ".env*",
@@ -261,11 +269,11 @@ describe("cli/sync/ignore", () => {
           ".env/**",
         ]);
         assertEquals(canceledNegationChecker.isIgnored(".env"), true);
-        assertEquals(warnings.length, 7, "a later matching ignore rule cancels the warning");
+        assertEquals(warnings.length, 8, "a later matching ignore rule cancels the warning");
 
         setJsonMode(true);
         assertEquals(createIgnoreChecker(["!.env/**"]).isIgnored(".env/other.json"), true);
-        assertEquals(warnings.length, 7, "JSON mode must not emit human warning text");
+        assertEquals(warnings.length, 8, "JSON mode must not emit human warning text");
       } finally {
         setJsonMode(false);
         warningStub.restore();

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -318,9 +318,23 @@ describe("cli/sync/ignore", () => {
           "a parent-only positive cannot cancel a negation that also matches descendants",
         );
 
+        const anchoredParentOnlyChecker = createIgnoreChecker([
+          "!/.env",
+          ".env*",
+        ]);
+        assertEquals(
+          anchoredParentOnlyChecker.isIgnored(".env", { isDirectory: true }),
+          true,
+        );
+        assertEquals(
+          warnings.length,
+          11,
+          "an anchored literal negation must include its implicit descendants",
+        );
+
         setJsonMode(true);
         assertEquals(createIgnoreChecker(["!.env/**"]).isIgnored(".env/other.json"), true);
-        assertEquals(warnings.length, 10, "JSON mode must not emit human warning text");
+        assertEquals(warnings.length, 11, "JSON mode must not emit human warning text");
       } finally {
         setJsonMode(false);
         warningStub.restore();

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { withTempDir } from "#veryfront/testing/deno-compat.ts";
 import { stub } from "#std/testing/mock";
@@ -255,6 +255,14 @@ describe("cli/sync/ignore", () => {
       assertEquals(checker.isIgnored("build"), true);
       assertEquals(checker.isIgnored("src/build"), true);
       assertEquals(checker.isIgnored("building"), false);
+    });
+
+    it("bounds repository-controlled ignore rule complexity", () => {
+      assertThrows(
+        () => createIgnoreChecker([`${"segment/".repeat(128)}file.ts`]),
+        Error,
+        ".vfignore patterns must not exceed",
+      );
     });
   });
 

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -357,6 +357,34 @@ describe("cli/sync/ignore", () => {
           "an optional globstar directory covering the subtree cancels its negation",
         );
 
+        const boundarySensitiveGlobstarChecker = createIgnoreChecker([
+          "!keep.ts",
+          "/.**/n**",
+        ]);
+        assertEquals(
+          boundarySensitiveGlobstarChecker.isIgnored(".env", { isDirectory: true }),
+          true,
+        );
+        assertEquals(
+          warnings.length,
+          10,
+          "a nonempty globstar directory must end at a separator before advancing",
+        );
+
+        const leadingGlobstarDirectoryChecker = createIgnoreChecker([
+          "!keep.ts",
+          "/.**/*",
+        ]);
+        assertEquals(
+          leadingGlobstarDirectoryChecker.isIgnored(".env", { isDirectory: true }),
+          true,
+        );
+        assertEquals(
+          warnings.length,
+          10,
+          "a leading globstar directory can still cover the protected subtree",
+        );
+
         const parentOnlyChecker = createIgnoreChecker([
           "!.env",
           ".env*",
@@ -364,7 +392,7 @@ describe("cli/sync/ignore", () => {
         assertEquals(parentOnlyChecker.isIgnored(".env", { isDirectory: true }), true);
         assertEquals(
           warnings.length,
-          10,
+          11,
           "a parent-only positive cannot cancel a negation that also matches descendants",
         );
 
@@ -378,7 +406,7 @@ describe("cli/sync/ignore", () => {
         );
         assertEquals(
           warnings.length,
-          11,
+          12,
           "an anchored literal negation must include its implicit descendants",
         );
 
@@ -389,13 +417,13 @@ describe("cli/sync/ignore", () => {
         assertEquals(partialWildcardChecker.isIgnored(".env", { isDirectory: true }), true);
         assertEquals(
           warnings.length,
-          12,
+          13,
           "one matching descendant probe must not imply full wildcard coverage",
         );
 
         setJsonMode(true);
         assertEquals(createIgnoreChecker(["!.env/**"]).isIgnored(".env/other.json"), true);
-        assertEquals(warnings.length, 12, "JSON mode must not emit human warning text");
+        assertEquals(warnings.length, 13, "JSON mode must not emit human warning text");
       } finally {
         setJsonMode(false);
         warningStub.restore();

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -244,9 +244,28 @@ describe("cli/sync/ignore", () => {
         assertEquals(unanchoredNestedChecker.isIgnored(".env"), true);
         assertEquals(warnings.length, 6, "an unanchored nested rule must retain its warning");
 
+        const anchoredOtherPrefixChecker = createIgnoreChecker([".env*", "!/foo**.json"]);
+        assertEquals(anchoredOtherPrefixChecker.isIgnored(".env"), true);
+        assertEquals(warnings.length, 6, "an unrelated anchored prefix must not warn");
+
+        const embeddedDoubleStarChecker = createIgnoreChecker([
+          ".env*",
+          "!/foo**/bar.json",
+        ]);
+        assertEquals(embeddedDoubleStarChecker.isIgnored("foo/.env"), true);
+        assertEquals(warnings.length, 7, "an embedded double-star must retain its warning");
+
+        const canceledNegationChecker = createIgnoreChecker([
+          ".env*",
+          "!.env/**",
+          ".env/**",
+        ]);
+        assertEquals(canceledNegationChecker.isIgnored(".env"), true);
+        assertEquals(warnings.length, 7, "a later matching ignore rule cancels the warning");
+
         setJsonMode(true);
         assertEquals(createIgnoreChecker(["!.env/**"]).isIgnored(".env/other.json"), true);
-        assertEquals(warnings.length, 6, "JSON mode must not emit human warning text");
+        assertEquals(warnings.length, 7, "JSON mode must not emit human warning text");
       } finally {
         setJsonMode(false);
         warningStub.restore();

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -213,8 +213,11 @@ describe("cli/sync/ignore", () => {
           "warning text must not carry terminal controls",
         );
 
+        assertEquals(createIgnoreChecker(["!keep.ts"]).isIgnored(".env.production.json"), true);
+        assertEquals(warnings.length, 1, "a protected file must not be treated as a directory");
+
         const descendantChecker = createIgnoreChecker([".env*", "!.env/**"]);
-        assertEquals(descendantChecker.isIgnored(".env"), true);
+        assertEquals(descendantChecker.isIgnored(".env", { isDirectory: true }), true);
         assertEquals(
           warnings.length,
           2,
@@ -222,7 +225,7 @@ describe("cli/sync/ignore", () => {
         );
 
         const divergentDescendantChecker = createIgnoreChecker(["!.env**", ".env*"]);
-        assertEquals(divergentDescendantChecker.isIgnored(".env"), true);
+        assertEquals(divergentDescendantChecker.isIgnored(".env", { isDirectory: true }), true);
         assertEquals(
           warnings.length,
           3,
@@ -230,37 +233,40 @@ describe("cli/sync/ignore", () => {
         );
 
         const wildcardChecker = createIgnoreChecker([".env*", "!**/.env/**"]);
-        assertEquals(wildcardChecker.isIgnored(".env"), true);
+        assertEquals(wildcardChecker.isIgnored(".env", { isDirectory: true }), true);
         assertEquals(warnings.length, 4, "a recursive prefix must not hide the warning");
 
         const internalWildcardChecker = createIgnoreChecker([
           "src/.env*",
           "!src/**/.env/**",
         ]);
-        assertEquals(internalWildcardChecker.isIgnored("src/.env"), true);
+        assertEquals(internalWildcardChecker.isIgnored("src/.env", { isDirectory: true }), true);
         assertEquals(warnings.length, 5, "an internal wildcard must not hide the warning");
 
         const anchoredRootFileChecker = createIgnoreChecker([".git", "!/*.ts"]);
-        assertEquals(anchoredRootFileChecker.isIgnored(".git"), true);
+        assertEquals(anchoredRootFileChecker.isIgnored(".git", { isDirectory: true }), true);
         assertEquals(warnings.length, 5, "a root file rule must not warn for protected children");
 
         const anchoredRecursiveFileChecker = createIgnoreChecker([".env*", "!/**.json"]);
-        assertEquals(anchoredRecursiveFileChecker.isIgnored(".env"), true);
+        assertEquals(anchoredRecursiveFileChecker.isIgnored(".env", { isDirectory: true }), true);
         assertEquals(warnings.length, 6, "an anchored double-star must retain its warning");
 
         const unanchoredNestedChecker = createIgnoreChecker([".env*", "!foo/bar.json"]);
-        assertEquals(unanchoredNestedChecker.isIgnored(".env"), true);
+        assertEquals(unanchoredNestedChecker.isIgnored(".env", { isDirectory: true }), true);
         assertEquals(warnings.length, 7, "an unanchored nested rule must retain its warning");
 
         const anchoredOtherPrefixChecker = createIgnoreChecker([".env*", "!/foo**.json"]);
-        assertEquals(anchoredOtherPrefixChecker.isIgnored(".env"), true);
+        assertEquals(anchoredOtherPrefixChecker.isIgnored(".env", { isDirectory: true }), true);
         assertEquals(warnings.length, 7, "an unrelated anchored prefix must not warn");
 
         const embeddedDoubleStarChecker = createIgnoreChecker([
           ".env*",
           "!/foo**/bar.json",
         ]);
-        assertEquals(embeddedDoubleStarChecker.isIgnored("foo/.env"), true);
+        assertEquals(
+          embeddedDoubleStarChecker.isIgnored("foo/.env", { isDirectory: true }),
+          true,
+        );
         assertEquals(warnings.length, 8, "an embedded double-star must retain its warning");
 
         const canceledNegationChecker = createIgnoreChecker([
@@ -268,11 +274,11 @@ describe("cli/sync/ignore", () => {
           "!.env/**",
           ".env/**",
         ]);
-        assertEquals(canceledNegationChecker.isIgnored(".env"), true);
+        assertEquals(canceledNegationChecker.isIgnored(".env", { isDirectory: true }), true);
         assertEquals(warnings.length, 8, "a later matching ignore rule cancels the warning");
 
         const broadlyCanceledChecker = createIgnoreChecker(["!.env/**", ".env"]);
-        assertEquals(broadlyCanceledChecker.isIgnored(".env"), true);
+        assertEquals(broadlyCanceledChecker.isIgnored(".env", { isDirectory: true }), true);
         assertEquals(
           warnings.length,
           8,

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -30,6 +30,20 @@ describe("cli/sync/ignore", () => {
       }
     });
 
+    it("allows the advertised number of project rules in addition to defaults", async () => {
+      await withTempDir(async (projectDir) => {
+        await Deno.writeTextFile(
+          `${projectDir}/.vfignore`,
+          Array.from({ length: 1_024 }, (_, index) => `generated-${index}`).join("\n"),
+        );
+
+        const patterns = await loadIgnorePatterns(projectDir);
+        const checker = createIgnoreChecker(patterns);
+
+        assertEquals(checker.isIgnored("generated-1023"), true);
+      });
+    });
+
     it("reports the size limit for an oversized .vfignore", async () => {
       await withTempDir(async (projectDir) => {
         await Deno.writeTextFile(`${projectDir}/.vfignore`, "x".repeat(256 * 1_024 + 1));
@@ -316,6 +330,17 @@ describe("cli/sync/ignore", () => {
           warnings.length,
           9,
           "a root-anchored positive cannot cancel an unanchored descendant negation",
+        );
+
+        const anchoredSubtreeChecker = createIgnoreChecker([
+          "!keep.ts",
+          "/.env/**",
+        ]);
+        assertEquals(anchoredSubtreeChecker.isIgnored(".env", { isDirectory: true }), true);
+        assertEquals(
+          warnings.length,
+          9,
+          "an anchored ignore covering the protected subtree cancels its earlier negation",
         );
 
         const parentOnlyChecker = createIgnoreChecker([

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -221,9 +221,13 @@ describe("cli/sync/ignore", () => {
           "a protected parent must warn before traversal drops a descendant negation",
         );
 
+        const wildcardChecker = createIgnoreChecker([".env*", "!**/.env/**"]);
+        assertEquals(wildcardChecker.isIgnored(".env"), true);
+        assertEquals(warnings.length, 3, "a recursive prefix must not hide the warning");
+
         setJsonMode(true);
         assertEquals(createIgnoreChecker(["!.env/**"]).isIgnored(".env/other.json"), true);
-        assertEquals(warnings.length, 2, "JSON mode must not emit human warning text");
+        assertEquals(warnings.length, 3, "JSON mode must not emit human warning text");
       } finally {
         setJsonMode(false);
         warningStub.restore();

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -26,6 +26,22 @@ describe("cli/sync/ignore", () => {
       }
     });
 
+    it("keeps secrets ignored when .vfignore negates the defaults", async () => {
+      const projectDir = await Deno.makeTempDir();
+      try {
+        await Deno.writeTextFile(
+          `${projectDir}/.vfignore`,
+          "!.env*.json\n!.veryfront\n!.veryfront/**\n",
+        );
+        const checker = createIgnoreChecker(await loadIgnorePatterns(projectDir));
+
+        assertEquals(checker.isIgnored(".env.production.json"), true);
+        assertEquals(checker.isIgnored(".veryfront/state.json"), true);
+      } finally {
+        await Deno.remove(projectDir, { recursive: true });
+      }
+    });
+
     it("rejects a non-file .vfignore", async () => {
       const projectDir = await Deno.makeTempDir();
       try {
@@ -107,6 +123,24 @@ describe("cli/sync/ignore", () => {
       assertEquals(checker.isIgnored("server.log"), true);
       assertEquals(checker.isIgnored("keep.log"), false);
       assertEquals(checker.isIgnored("logs/keep.log"), false);
+    });
+
+    it("should not let negations re-include secrets or CLI state", () => {
+      const checker = createIgnoreChecker([
+        ".env*",
+        ".veryfront",
+        ".git",
+        "!.env*.json",
+        "!.veryfront",
+        "!.veryfront/**",
+        "!.git/**",
+      ]);
+
+      assertEquals(checker.isIgnored(".env.production.json"), true);
+      assertEquals(checker.isIgnored("config/.env.staging.yaml"), true);
+      assertEquals(checker.isIgnored(".veryfront"), true);
+      assertEquals(checker.isIgnored(".veryfront/state.json"), true);
+      assertEquals(checker.isIgnored(".git/config"), true);
     });
 
     it("should handle directory-trailing-slash patterns", () => {

--- a/cli/sync/ignore.test.ts
+++ b/cli/sync/ignore.test.ts
@@ -343,6 +343,20 @@ describe("cli/sync/ignore", () => {
           "an anchored ignore covering the protected subtree cancels its earlier negation",
         );
 
+        const optionalGlobstarDirectoryChecker = createIgnoreChecker([
+          "!keep.ts",
+          "/.env/**/*",
+        ]);
+        assertEquals(
+          optionalGlobstarDirectoryChecker.isIgnored(".env", { isDirectory: true }),
+          true,
+        );
+        assertEquals(
+          warnings.length,
+          9,
+          "an optional globstar directory covering the subtree cancels its negation",
+        );
+
         const parentOnlyChecker = createIgnoreChecker([
           "!.env",
           ".env*",

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -7,7 +7,7 @@ import { createFileSystem } from "veryfront/platform";
 import { cliLogger, logWarning } from "#cli/utils";
 import { isJsonMode } from "../shared/json-output.ts";
 import { isNotFoundError, lstat } from "veryfront/fs";
-import { sanitizeLogText } from "#veryfront/utils/logger/core.ts";
+import { sanitizeTerminalDiagnosticText } from "veryfront/errors";
 
 /** Default patterns always ignored */
 const DEFAULT_IGNORE_PATTERNS: readonly string[] = [
@@ -290,7 +290,7 @@ export function createIgnoreChecker(patterns: readonly string[]): IgnoreChecker 
       if (droppedNegation && !isJsonMode() && !warnedOverrides.has(normalizedPath)) {
         warnedOverrides.add(normalizedPath);
         logWarning(
-          `Ignoring protected path "${sanitizeLogText(normalizedPath)}". ` +
+          `Ignoring protected path "${sanitizeTerminalDiagnosticText(normalizedPath)}". ` +
             "A .vfignore negation cannot re-include " +
             "a path under .env, .veryfront, or .git.",
         );

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -101,6 +101,7 @@ interface IgnoreRule {
   negated: boolean;
   regex: RegExp;
   anchored: boolean;
+  leadingDoubleStar: boolean;
   literalPrefix: string;
   descendantPrefixRegexes: RegExp[];
 }
@@ -219,6 +220,7 @@ function patternToRule(rawPattern: string, caseInsensitive = false): IgnoreRule 
     negated,
     regex: new RegExp(`${prefix}${body}${suffix}`, caseInsensitive ? "i" : ""),
     anchored,
+    leadingDoubleStar: pattern.startsWith("**"),
     literalPrefix,
     descendantPrefixRegexes,
   };
@@ -251,7 +253,7 @@ function negatedRuleTargetsDescendant(rule: IgnoreRule, normalizedPath: string):
   // any directory, so a protected directory stops that negation from ever
   // being evaluated on a concrete child.
   if (!rule.literalPrefix) {
-    return !rule.anchored ||
+    return !rule.anchored || rule.leadingDoubleStar ||
       rule.descendantPrefixRegexes.some((prefix) => prefix.test(normalizedPath));
   }
   if (rule.descendantPrefixRegexes.some((prefix) => prefix.test(normalizedPath))) return true;

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -322,6 +322,7 @@ function negatedRuleTargetsDescendant(rule: IgnoreRule, normalizedPath: string):
   // protected directory, even when none of its literal segments are present
   // in the directory path itself.
   if (!rule.anchored) return true;
+  if (rule.regex.test(`${normalizedPath}/__veryfront_probe__.json`)) return true;
   return anchoredGlobCanMatchDescendant(rule.globTokens, normalizedPath);
 }
 

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -34,6 +34,13 @@ const DEFAULT_IGNORE_PATTERNS: readonly string[] = [
   "*~",
 ];
 
+/**
+ * Safety patterns that project-controlled `.vfignore` rules can never re-include.
+ * They hold credentials and local CLI state, so a negation such as `!.env*.json`
+ * must not make `veryfront push` read and upload them.
+ */
+const PROTECTED_IGNORE_PATTERNS: readonly string[] = [".env*", ".veryfront", ".git"];
+
 /** Supported file extensions for sync */
 const SUPPORTED_EXTENSIONS = new Set([
   ".ts",
@@ -179,14 +186,24 @@ function patternToRule(rawPattern: string): IgnoreRule | null {
   };
 }
 
+function toRules(patterns: readonly string[]): IgnoreRule[] {
+  return patterns.flatMap((pattern) => {
+    const rule = patternToRule(pattern);
+    return rule ? [rule] : [];
+  });
+}
+
+const PROTECTED_RULES = toRules(PROTECTED_IGNORE_PATTERNS);
+
+function isProtectedPath(normalizedPath: string): boolean {
+  return PROTECTED_RULES.some((rule) => rule.regex.test(normalizedPath));
+}
+
 /**
  * Create an ignore checker with loaded patterns
  */
 export function createIgnoreChecker(patterns: readonly string[]): IgnoreChecker {
-  const rules = patterns.flatMap((pattern) => {
-    const rule = patternToRule(pattern);
-    return rule ? [rule] : [];
-  });
+  const rules = toRules(patterns);
 
   function isIgnored(relativePath: string): boolean {
     const normalizedPath = relativePath.replace(/\\/g, "/");
@@ -195,6 +212,11 @@ export function createIgnoreChecker(patterns: readonly string[]): IgnoreChecker 
     for (const rule of rules) {
       if (!rule.regex.test(normalizedPath)) continue;
       ignored = !rule.negated;
+    }
+
+    if (!ignored && isProtectedPath(normalizedPath)) {
+      cliLogger.debug(`Keeping ${normalizedPath} ignored: .vfignore cannot re-include this path.`);
+      return true;
     }
 
     return ignored;

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -39,7 +39,7 @@ const DEFAULT_IGNORE_PATTERNS: readonly string[] = [
  * They hold credentials, local CLI state, and Git internals, so a negation such
  * as `!.env*.json` must not make `veryfront push` read and upload them.
  *
- * The trailing-slash `.env` entry also covers the plain file form, because a
+ * The trailing-slash `.env*/` pattern also covers the plain file form, because a
  * directory-only pattern compiles to a suffix of `(/` or end of string. It
  * matches `.env.production.json` and `.env/credentials.json` alike, so a
  * separate `.env` glob entry would be redundant.

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -250,7 +250,10 @@ function negatedRuleTargetsDescendant(rule: IgnoreRule, normalizedPath: string):
   // A wildcard before the first literal segment can match a descendant below
   // any directory, so a protected directory stops that negation from ever
   // being evaluated on a concrete child.
-  if (!rule.literalPrefix) return true;
+  if (!rule.literalPrefix) {
+    return !rule.anchored ||
+      rule.descendantPrefixRegexes.some((prefix) => prefix.test(normalizedPath));
+  }
   if (rule.descendantPrefixRegexes.some((prefix) => prefix.test(normalizedPath))) return true;
   const candidates = rule.anchored
     ? [normalizedPath]

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -366,7 +366,9 @@ function collectCanceledNegations(rules: readonly IgnoreRule[]): ReadonlySet<Ign
       if (
         laterPositivePatterns.has(signature) ||
         (literalPath.length > 0 &&
-          laterPositiveRules.some((positive) => positive.regex.test(literalPath)))
+          laterPositiveRules.some((positive) =>
+            (rule.anchored || !positive.anchored) && positive.regex.test(literalPath)
+          ))
       ) {
         canceled.add(rule);
       }

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -217,8 +217,16 @@ function toRules(patterns: readonly string[], caseInsensitive = false): IgnoreRu
 
 const PROTECTED_RULES = toRules(PROTECTED_IGNORE_PATTERNS, true);
 
+function normalizeIgnorePath(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
 function isProtectedPath(normalizedPath: string): boolean {
   return PROTECTED_RULES.some((rule) => rule.regex.test(normalizedPath));
+}
+
+function isProtected(relativePath: string): boolean {
+  return isProtectedPath(normalizeIgnorePath(relativePath));
 }
 
 /**
@@ -232,7 +240,7 @@ export function createIgnoreChecker(patterns: readonly string[]): IgnoreChecker 
   const warnedOverrides = new Set<string>();
 
   function isIgnored(relativePath: string): boolean {
-    const normalizedPath = relativePath.replace(/\\/g, "/");
+    const normalizedPath = normalizeIgnorePath(relativePath);
     let ignored = false;
 
     for (const rule of rules) {
@@ -245,17 +253,13 @@ export function createIgnoreChecker(patterns: readonly string[]): IgnoreChecker 
         warnedOverrides.add(normalizedPath);
         logWarning(
           `Ignoring protected path "${normalizedPath}". A .vfignore negation cannot re-include ` +
-            "a .env, .veryfront, or .git path.",
+            "a path under .env, .veryfront, or .git.",
         );
       }
       return true;
     }
 
     return ignored;
-  }
-
-  function isProtected(relativePath: string): boolean {
-    return isProtectedPath(relativePath.replace(/\\/g, "/"));
   }
 
   function isSupportedExtension(filename: string): boolean {

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -109,6 +109,7 @@ type GlobToken =
   | { type: "literal"; value: string }
   | { type: "single" }
   | { type: "star" }
+  | { type: "globstar-directory" }
   | { type: "double-star" };
 
 const MAX_IGNORE_PATTERN_LENGTH = 4_096;
@@ -209,8 +210,13 @@ function tokenizeGlob(pattern: string): GlobToken[] {
     const character = pattern[index]!;
     if (character === "*") {
       if (pattern[index + 1] === "*") {
-        tokens.push({ type: "double-star" });
-        index++;
+        if (pattern[index + 2] === "/") {
+          tokens.push({ type: "globstar-directory" });
+          index += 2;
+        } else {
+          tokens.push({ type: "double-star" });
+          index++;
+        }
       } else {
         tokens.push({ type: "star" });
       }
@@ -297,7 +303,10 @@ function epsilonClosure(tokens: readonly GlobToken[], states: ReadonlySet<number
   while (pending.length > 0) {
     const state = pending.pop()!;
     const token = tokens[state];
-    if (token?.type !== "star" && token?.type !== "double-star") continue;
+    if (
+      token?.type !== "star" && token?.type !== "double-star" &&
+      token?.type !== "globstar-directory"
+    ) continue;
     const next = state + 1;
     if (closure.has(next)) continue;
     closure.add(next);
@@ -323,7 +332,7 @@ function anchoredGlobCanMatchDescendant(
         nextStates.add(state + 1);
       } else if (token?.type === "star" && character !== "/") {
         nextStates.add(state);
-      } else if (token?.type === "double-star") {
+      } else if (token?.type === "double-star" || token?.type === "globstar-directory") {
         nextStates.add(state);
       }
     }
@@ -350,7 +359,7 @@ function anchoredGlobCoversEveryDescendant(
         nextStates.add(state + 1);
       } else if (token?.type === "star" && character !== "/") {
         nextStates.add(state);
-      } else if (token?.type === "double-star") {
+      } else if (token?.type === "double-star" || token?.type === "globstar-directory") {
         nextStates.add(state);
       }
     }
@@ -359,8 +368,14 @@ function anchoredGlobCoversEveryDescendant(
   }
 
   for (const state of states) {
-    if (tokens[state]?.type !== "double-star") continue;
-    if (epsilonClosure(tokens, new Set([state + 1])).has(tokens.length)) return true;
+    const token = tokens[state];
+    if (token?.type === "double-star") {
+      if (epsilonClosure(tokens, new Set([state + 1])).has(tokens.length)) return true;
+    }
+    if (
+      token?.type === "globstar-directory" && tokens[state + 1]?.type === "star" &&
+      epsilonClosure(tokens, new Set([state + 2])).has(tokens.length)
+    ) return true;
   }
   return false;
 }

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -328,17 +328,28 @@ function negatedRuleTargetsDescendant(rule: IgnoreRule, normalizedPath: string):
 function hasEffectiveDescendantNegation(
   rules: readonly IgnoreRule[],
   normalizedPath: string,
+  canceledNegations: ReadonlySet<IgnoreRule>,
 ): boolean {
-  for (let index = 0; index < rules.length; index++) {
-    const rule = rules[index]!;
+  for (const rule of rules) {
     if (!negatedRuleTargetsDescendant(rule, normalizedPath)) continue;
-    const canceled = rules.slice(index + 1).some((later) =>
-      !later.negated && later.regex.source === rule.regex.source &&
-      later.regex.flags === rule.regex.flags
-    );
-    if (!canceled) return true;
+    if (!canceledNegations.has(rule)) return true;
   }
   return false;
+}
+
+function collectCanceledNegations(rules: readonly IgnoreRule[]): ReadonlySet<IgnoreRule> {
+  const canceled = new Set<IgnoreRule>();
+  const laterPositivePatterns = new Set<string>();
+  for (let index = rules.length - 1; index >= 0; index--) {
+    const rule = rules[index]!;
+    const signature = `${rule.regex.source}\u0000${rule.regex.flags}`;
+    if (rule.negated) {
+      if (laterPositivePatterns.has(signature)) canceled.add(rule);
+    } else {
+      laterPositivePatterns.add(signature);
+    }
+  }
+  return canceled;
 }
 
 /**
@@ -346,6 +357,7 @@ function hasEffectiveDescendantNegation(
  */
 export function createIgnoreChecker(patterns: readonly string[]): IgnoreChecker {
   const rules = toRules(patterns);
+  const canceledNegations = collectCanceledNegations(rules);
   // A dropped negation silently changes what push and pull reconcile, so warn
   // at the default log level. Deduplicated per checker because every path is
   // tested many times during a single scan.
@@ -364,7 +376,7 @@ export function createIgnoreChecker(patterns: readonly string[]): IgnoreChecker 
 
     if (isProtectedPath(normalizedPath)) {
       const droppedNegation = lastMatchedRule?.negated ||
-        hasEffectiveDescendantNegation(rules, normalizedPath);
+        hasEffectiveDescendantNegation(rules, normalizedPath, canceledNegations);
       if (droppedNegation && !isJsonMode() && !warnedOverrides.has(normalizedPath)) {
         warnedOverrides.add(normalizedPath);
         logWarning(

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -365,10 +365,13 @@ function collectCanceledNegations(rules: readonly IgnoreRule[]): ReadonlySet<Ign
       }
       if (
         laterPositivePatterns.has(signature) ||
-        (literalPath.length > 0 &&
-          laterPositiveRules.some((positive) =>
-            (rule.anchored || !positive.anchored) && positive.regex.test(literalPath)
-          ))
+        (literalPath.length > 0 && laterPositiveRules.some((positive) => {
+          if (!(rule.anchored || !positive.anchored) || !positive.regex.test(literalPath)) {
+            return false;
+          }
+          const descendantProbe = `${literalPath}/__veryfront_probe__.json`;
+          return !rule.regex.test(descendantProbe) || positive.regex.test(descendantProbe);
+        }))
       ) {
         canceled.add(rule);
       }

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -101,9 +101,14 @@ interface IgnoreRule {
   negated: boolean;
   regex: RegExp;
   anchored: boolean;
-  crossDirectorySinglePattern: boolean;
-  descendantSegments: Array<RegExp | null>;
+  globTokens: GlobToken[];
 }
+
+type GlobToken =
+  | { type: "literal"; value: string }
+  | { type: "single" }
+  | { type: "star" }
+  | { type: "double-star" };
 
 const MAX_IGNORE_PATTERN_LENGTH = 4_096;
 const MAX_IGNORE_PATTERN_SEGMENTS = 128;
@@ -189,6 +194,26 @@ function globToRegex(pattern: string): string {
   return source;
 }
 
+function tokenizeGlob(pattern: string): GlobToken[] {
+  const tokens: GlobToken[] = [];
+  for (let index = 0; index < pattern.length; index++) {
+    const character = pattern[index]!;
+    if (character === "*") {
+      if (pattern[index + 1] === "*") {
+        tokens.push({ type: "double-star" });
+        index++;
+      } else {
+        tokens.push({ type: "star" });
+      }
+    } else if (character === "?") {
+      tokens.push({ type: "single" });
+    } else {
+      tokens.push({ type: "literal", value: character });
+    }
+  }
+  return tokens;
+}
+
 function patternToRule(rawPattern: string, caseInsensitive = false): IgnoreRule | null {
   let pattern = rawPattern.trim();
   if (!pattern || pattern.startsWith("#")) return null;
@@ -220,16 +245,11 @@ function patternToRule(rawPattern: string, caseInsensitive = false): IgnoreRule 
   const body = globToRegex(pattern);
   const prefix = anchored ? "^" : "(^|/)";
   const suffix = directoryOnly || (!hasSlash && !hasGlob) ? "(/|$)" : "$";
-  const descendantSegments = pathSegments.map((segment) =>
-    segment === "**" ? null : new RegExp(`^${globToRegex(segment)}$`, caseInsensitive ? "i" : "")
-  );
-
   return {
     negated,
     regex: new RegExp(`${prefix}${body}${suffix}`, caseInsensitive ? "i" : ""),
     anchored,
-    crossDirectorySinglePattern: !hasSlash && pattern.includes("**"),
-    descendantSegments,
+    globTokens: tokenizeGlob(pattern),
   };
 }
 
@@ -254,36 +274,71 @@ function isProtected(relativePath: string): boolean {
   return isProtectedPath(normalizeIgnorePath(relativePath));
 }
 
+function epsilonClosure(tokens: readonly GlobToken[], states: ReadonlySet<number>): Set<number> {
+  const closure = new Set(states);
+  const pending = [...states];
+  while (pending.length > 0) {
+    const state = pending.pop()!;
+    const token = tokens[state];
+    if (token?.type !== "star" && token?.type !== "double-star") continue;
+    const next = state + 1;
+    if (closure.has(next)) continue;
+    closure.add(next);
+    pending.push(next);
+  }
+  return closure;
+}
+
+function anchoredGlobCanMatchDescendant(
+  tokens: readonly GlobToken[],
+  normalizedPath: string,
+): boolean {
+  let states = epsilonClosure(tokens, new Set([0]));
+  const prefix = `${normalizedPath}/`;
+  for (let pathIndex = 0; pathIndex < prefix.length; pathIndex++) {
+    const character = prefix[pathIndex]!;
+    const nextStates = new Set<number>();
+    for (const state of states) {
+      const token = tokens[state];
+      if (token?.type === "literal" && token.value === character) {
+        nextStates.add(state + 1);
+      } else if (token?.type === "single" && character !== "/") {
+        nextStates.add(state + 1);
+      } else if (token?.type === "star" && character !== "/") {
+        nextStates.add(state);
+      } else if (token?.type === "double-star") {
+        nextStates.add(state);
+      }
+    }
+    states = epsilonClosure(tokens, nextStates);
+    if (states.size === 0) return false;
+  }
+  return states.size > 0;
+}
+
 function negatedRuleTargetsDescendant(rule: IgnoreRule, normalizedPath: string): boolean {
   if (!rule.negated || rule.regex.test(normalizedPath)) return false;
-  if (rule.crossDirectorySinglePattern) return true;
   // An unanchored rule can begin at any descendant segment below this
   // protected directory, even when none of its literal segments are present
   // in the directory path itself.
   if (!rule.anchored) return true;
+  return anchoredGlobCanMatchDescendant(rule.globTokens, normalizedPath);
+}
 
-  const pathSegments = normalizedPath.split("/");
-  const matchesFrom = (start: number): boolean => {
-    const memo = new Map<string, boolean>();
-    const visit = (patternIndex: number, pathIndex: number): boolean => {
-      const key = `${patternIndex}:${pathIndex}`;
-      const cached = memo.get(key);
-      if (cached !== undefined) return cached;
-      if (pathIndex === pathSegments.length) return patternIndex < rule.descendantSegments.length;
-      if (patternIndex === rule.descendantSegments.length) return false;
-
-      const matcher = rule.descendantSegments[patternIndex];
-      const matches = matcher === null
-        ? visit(patternIndex + 1, pathIndex) || visit(patternIndex, pathIndex + 1)
-        : matcher?.test(pathSegments[pathIndex]!) === true &&
-          visit(patternIndex + 1, pathIndex + 1);
-      memo.set(key, matches);
-      return matches;
-    };
-    return visit(0, start);
-  };
-
-  return matchesFrom(0);
+function hasEffectiveDescendantNegation(
+  rules: readonly IgnoreRule[],
+  normalizedPath: string,
+): boolean {
+  for (let index = 0; index < rules.length; index++) {
+    const rule = rules[index]!;
+    if (!negatedRuleTargetsDescendant(rule, normalizedPath)) continue;
+    const canceled = rules.slice(index + 1).some((later) =>
+      !later.negated && later.regex.source === rule.regex.source &&
+      later.regex.flags === rule.regex.flags
+    );
+    if (!canceled) return true;
+  }
+  return false;
 }
 
 /**
@@ -309,7 +364,7 @@ export function createIgnoreChecker(patterns: readonly string[]): IgnoreChecker 
 
     if (isProtectedPath(normalizedPath)) {
       const droppedNegation = lastMatchedRule?.negated ||
-        rules.some((rule) => negatedRuleTargetsDescendant(rule, normalizedPath));
+        hasEffectiveDescendantNegation(rules, normalizedPath);
       if (droppedNegation && !isJsonMode() && !warnedOverrides.has(normalizedPath)) {
         warnedOverrides.add(normalizedPath);
         logWarning(

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -5,7 +5,9 @@
 import { join } from "veryfront/platform/path";
 import { createFileSystem } from "veryfront/platform";
 import { cliLogger, logWarning } from "#cli/utils";
+import { isJsonMode } from "../shared/json-output.ts";
 import { isNotFoundError, lstat } from "veryfront/fs";
+import { sanitizeLogText } from "#veryfront/utils/logger/core.ts";
 
 /** Default patterns always ignored */
 const DEFAULT_IGNORE_PATTERNS: readonly string[] = [
@@ -242,17 +244,20 @@ export function createIgnoreChecker(patterns: readonly string[]): IgnoreChecker 
   function isIgnored(relativePath: string): boolean {
     const normalizedPath = normalizeIgnorePath(relativePath);
     let ignored = false;
+    let lastMatchedRule: IgnoreRule | undefined;
 
     for (const rule of rules) {
       if (!rule.regex.test(normalizedPath)) continue;
+      lastMatchedRule = rule;
       ignored = !rule.negated;
     }
 
     if (!ignored && isProtectedPath(normalizedPath)) {
-      if (!warnedOverrides.has(normalizedPath)) {
+      if (lastMatchedRule?.negated && !isJsonMode() && !warnedOverrides.has(normalizedPath)) {
         warnedOverrides.add(normalizedPath);
         logWarning(
-          `Ignoring protected path "${normalizedPath}". A .vfignore negation cannot re-include ` +
+          `Ignoring protected path "${sanitizeLogText(normalizedPath)}". ` +
+            "A .vfignore negation cannot re-include " +
             "a path under .env, .veryfront, or .git.",
         );
       }

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -101,6 +101,7 @@ interface IgnoreRule {
   negated: boolean;
   regex: RegExp;
   anchored: boolean;
+  implicitDescendants: boolean;
   globTokens: GlobToken[];
 }
 
@@ -249,6 +250,7 @@ function patternToRule(rawPattern: string, caseInsensitive = false): IgnoreRule 
     negated,
     regex: new RegExp(`${prefix}${body}${suffix}`, caseInsensitive ? "i" : ""),
     anchored,
+    implicitDescendants: directoryOnly || !hasSlash && !hasGlob,
     globTokens: tokenizeGlob(pattern),
   };
 }
@@ -331,11 +333,10 @@ function hasEffectiveDescendantNegation(
   normalizedPath: string,
   canceledNegations: ReadonlySet<IgnoreRule>,
 ): boolean {
-  const descendantProbe = `${normalizedPath}/__veryfront_probe__.json`;
   let lastBroadIgnoreIndex = -1;
   for (let index = 0; index < rules.length; index++) {
     const rule = rules[index]!;
-    if (!rule.negated && rule.regex.test(normalizedPath) && rule.regex.test(descendantProbe)) {
+    if (!rule.negated && rule.implicitDescendants && rule.regex.test(normalizedPath)) {
       lastBroadIgnoreIndex = index;
     }
   }
@@ -370,8 +371,7 @@ function collectCanceledNegations(rules: readonly IgnoreRule[]): ReadonlySet<Ign
           if (!(rule.anchored || !positive.anchored) || !positive.regex.test(literalPath)) {
             return false;
           }
-          const descendantProbe = `${literalPath}/__veryfront_probe__.json`;
-          return !rule.regex.test(descendantProbe) || positive.regex.test(descendantProbe);
+          return !rule.implicitDescendants || positive.implicitDescendants;
         }))
       ) {
         canceled.add(rule);

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -317,7 +317,7 @@ function anchoredGlobCanMatchDescendant(
 }
 
 function negatedRuleTargetsDescendant(rule: IgnoreRule, normalizedPath: string): boolean {
-  if (!rule.negated || rule.regex.test(normalizedPath)) return false;
+  if (!rule.negated) return false;
   // An unanchored rule can begin at any descendant segment below this
   // protected directory, even when none of its literal segments are present
   // in the directory path itself.

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -101,10 +101,12 @@ interface IgnoreRule {
   negated: boolean;
   regex: RegExp;
   anchored: boolean;
-  leadingDoubleStar: boolean;
-  literalPrefix: string;
-  descendantPrefixRegexes: RegExp[];
+  crossDirectorySinglePattern: boolean;
+  descendantSegments: Array<RegExp | null>;
 }
+
+const MAX_IGNORE_PATTERN_LENGTH = 4_096;
+const MAX_IGNORE_PATTERN_SEGMENTS = 128;
 
 /**
  * Load ignore patterns from .vfignore file
@@ -202,27 +204,32 @@ function patternToRule(rawPattern: string, caseInsensitive = false): IgnoreRule 
   if (directoryOnly) pattern = pattern.slice(0, -1);
   if (!pattern) return null;
 
+  const pathSegments = pattern.split("/");
+  if (
+    pattern.length > MAX_IGNORE_PATTERN_LENGTH ||
+    pathSegments.length > MAX_IGNORE_PATTERN_SEGMENTS
+  ) {
+    throw new Error(
+      `.vfignore patterns must not exceed ${MAX_IGNORE_PATTERN_LENGTH} characters or ` +
+        `${MAX_IGNORE_PATTERN_SEGMENTS} path segments.`,
+    );
+  }
+
   const hasSlash = pattern.includes("/");
   const hasGlob = /[*?]/.test(pattern);
   const body = globToRegex(pattern);
   const prefix = anchored ? "^" : "(^|/)";
   const suffix = directoryOnly || (!hasSlash && !hasGlob) ? "(/|$)" : "$";
-  const wildcardIndex = pattern.search(/[*?]/);
-  const literalPrefix = (wildcardIndex === -1 ? pattern : pattern.slice(0, wildcardIndex))
-    .replace(/\/+$/, "");
-  const pathSegments = pattern.split("/");
-  const descendantPrefixRegexes = pathSegments.slice(0, -1).map((_, index) => {
-    const prefixBody = globToRegex(pathSegments.slice(0, index + 1).join("/"));
-    return new RegExp(`${anchored ? "^" : "(^|/)"}${prefixBody}$`, caseInsensitive ? "i" : "");
-  });
+  const descendantSegments = pathSegments.map((segment) =>
+    segment === "**" ? null : new RegExp(`^${globToRegex(segment)}$`, caseInsensitive ? "i" : "")
+  );
 
   return {
     negated,
     regex: new RegExp(`${prefix}${body}${suffix}`, caseInsensitive ? "i" : ""),
     anchored,
-    leadingDoubleStar: pattern.startsWith("**"),
-    literalPrefix,
-    descendantPrefixRegexes,
+    crossDirectorySinglePattern: !hasSlash && pattern.includes("**"),
+    descendantSegments,
   };
 }
 
@@ -249,20 +256,35 @@ function isProtected(relativePath: string): boolean {
 
 function negatedRuleTargetsDescendant(rule: IgnoreRule, normalizedPath: string): boolean {
   if (!rule.negated || rule.regex.test(normalizedPath)) return false;
-  // A wildcard before the first literal segment can match a descendant below
-  // any directory, so a protected directory stops that negation from ever
-  // being evaluated on a concrete child.
-  if (!rule.literalPrefix) {
-    return !rule.anchored || rule.leadingDoubleStar ||
-      rule.descendantPrefixRegexes.some((prefix) => prefix.test(normalizedPath));
+  if (rule.crossDirectorySinglePattern) return true;
+  if (!rule.anchored && rule.descendantSegments.length === 1) return true;
+
+  const pathSegments = normalizedPath.split("/");
+  const matchesFrom = (start: number): boolean => {
+    const memo = new Map<string, boolean>();
+    const visit = (patternIndex: number, pathIndex: number): boolean => {
+      const key = `${patternIndex}:${pathIndex}`;
+      const cached = memo.get(key);
+      if (cached !== undefined) return cached;
+      if (pathIndex === pathSegments.length) return patternIndex < rule.descendantSegments.length;
+      if (patternIndex === rule.descendantSegments.length) return false;
+
+      const matcher = rule.descendantSegments[patternIndex];
+      const matches = matcher === null
+        ? visit(patternIndex + 1, pathIndex) || visit(patternIndex, pathIndex + 1)
+        : matcher?.test(pathSegments[pathIndex]!) === true &&
+          visit(patternIndex + 1, pathIndex + 1);
+      memo.set(key, matches);
+      return matches;
+    };
+    return visit(0, start);
+  };
+
+  if (rule.anchored) return matchesFrom(0);
+  for (let start = 0; start < pathSegments.length; start++) {
+    if (matchesFrom(start)) return true;
   }
-  if (rule.descendantPrefixRegexes.some((prefix) => prefix.test(normalizedPath))) return true;
-  const candidates = rule.anchored
-    ? [normalizedPath]
-    : normalizedPath.split("/").map((_, index, parts) => parts.slice(index).join("/"));
-  return candidates.some((candidate) =>
-    rule.literalPrefix === candidate || rule.literalPrefix.startsWith(`${candidate}/`)
-  );
+  return false;
 }
 
 /**

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -113,6 +113,8 @@ type GlobToken =
 
 const MAX_IGNORE_PATTERN_LENGTH = 4_096;
 const MAX_IGNORE_PATTERN_SEGMENTS = 128;
+const MAX_IGNORE_RULES = 1_024;
+const MAX_IGNORE_FILE_LENGTH = 256 * 1_024;
 
 /**
  * Load ignore patterns from .vfignore file
@@ -141,6 +143,9 @@ export async function loadIgnorePatterns(projectPath: string): Promise<string[]>
 
   try {
     const content = await fs.readTextFile(ignorePath);
+    if (content.length > MAX_IGNORE_FILE_LENGTH) {
+      throw new Error(`.vfignore must not exceed ${MAX_IGNORE_FILE_LENGTH} characters.`);
+    }
     const customPatterns = content
       .split("\n")
       .map((line) => line.trim())
@@ -256,6 +261,9 @@ function patternToRule(rawPattern: string, caseInsensitive = false): IgnoreRule 
 }
 
 function toRules(patterns: readonly string[], caseInsensitive = false): IgnoreRule[] {
+  if (patterns.length > MAX_IGNORE_RULES) {
+    throw new Error(`.vfignore must not contain more than ${MAX_IGNORE_RULES} rules.`);
+  }
   return patterns.flatMap((pattern) => {
     const rule = patternToRule(pattern, caseInsensitive);
     return rule ? [rule] : [];

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -4,7 +4,7 @@
 
 import { join } from "veryfront/platform/path";
 import { createFileSystem } from "veryfront/platform";
-import { cliLogger } from "#cli/utils";
+import { cliLogger, logWarning } from "#cli/utils";
 import { isNotFoundError, lstat } from "veryfront/fs";
 
 /** Default patterns always ignored */
@@ -39,10 +39,14 @@ const DEFAULT_IGNORE_PATTERNS: readonly string[] = [
  * They hold credentials, local CLI state, and Git internals, so a negation such
  * as `!.env*.json` must not make `veryfront push` read and upload them.
  *
- * The trailing-slash `.env*/` pattern also covers the plain file form, because a
- * directory-only pattern compiles to a suffix of `(/` or end of string. It
- * matches `.env.production.json` and `.env/credentials.json` alike, so a
- * separate `.env` glob entry would be redundant.
+ * The two `.env` entries are deliberately stricter than the `.env*` default:
+ * they cover `.env` itself and dot-suffixed variants such as `.env.local` and
+ * `.env.production.json`, but not unrelated names that merely start with `.env`
+ * (`.envoy`, `.environments`, `.envs`). Those keep the `.env*` default ignore
+ * and stay negatable, so a project that publishes files from such a directory
+ * is not forced to rename it. Both entries end in `/` so they match a directory
+ * too: a directory-only pattern compiles to a suffix of `/` or end of string,
+ * which also matches the plain file form.
  *
  * The set stays narrower than `DEFAULT_IGNORE_PATTERNS`. Build caches and
  * third-party tool metadata such as `.cache`, `.deno`, `.turbo`, `.vercel`, and
@@ -50,7 +54,8 @@ const DEFAULT_IGNORE_PATTERNS: readonly string[] = [
  * to publish a file under them, so those stay negatable.
  */
 const PROTECTED_IGNORE_PATTERNS: readonly string[] = [
-  ".env*/",
+  ".env/",
+  ".env.*/",
   ".veryfront",
   ".git",
 ];
@@ -221,6 +226,10 @@ function isProtectedPath(normalizedPath: string): boolean {
  */
 export function createIgnoreChecker(patterns: readonly string[]): IgnoreChecker {
   const rules = toRules(patterns);
+  // A dropped negation silently changes what push and pull reconcile, so warn
+  // at the default log level. Deduplicated per checker because every path is
+  // tested many times during a single scan.
+  const warnedOverrides = new Set<string>();
 
   function isIgnored(relativePath: string): boolean {
     const normalizedPath = relativePath.replace(/\\/g, "/");
@@ -232,9 +241,13 @@ export function createIgnoreChecker(patterns: readonly string[]): IgnoreChecker 
     }
 
     if (!ignored && isProtectedPath(normalizedPath)) {
-      cliLogger.debug(
-        `Keeping protected path ignored: .vfignore cannot re-include "${normalizedPath}".`,
-      );
+      if (!warnedOverrides.has(normalizedPath)) {
+        warnedOverrides.add(normalizedPath);
+        logWarning(
+          `Ignoring protected path "${normalizedPath}". A .vfignore negation cannot re-include ` +
+            "a .env, .veryfront, or .git path.",
+        );
+      }
       return true;
     }
 

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -257,7 +257,10 @@ function isProtected(relativePath: string): boolean {
 function negatedRuleTargetsDescendant(rule: IgnoreRule, normalizedPath: string): boolean {
   if (!rule.negated || rule.regex.test(normalizedPath)) return false;
   if (rule.crossDirectorySinglePattern) return true;
-  if (!rule.anchored && rule.descendantSegments.length === 1) return true;
+  // An unanchored rule can begin at any descendant segment below this
+  // protected directory, even when none of its literal segments are present
+  // in the directory path itself.
+  if (!rule.anchored) return true;
 
   const pathSegments = normalizedPath.split("/");
   const matchesFrom = (start: number): boolean => {
@@ -280,11 +283,7 @@ function negatedRuleTargetsDescendant(rule: IgnoreRule, normalizedPath: string):
     return visit(0, start);
   };
 
-  if (rule.anchored) return matchesFrom(0);
-  for (let start = 0; start < pathSegments.length; start++) {
-    if (matchesFrom(start)) return true;
-  }
-  return false;
+  return matchesFrom(0);
 }
 
 /**

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -141,23 +141,23 @@ export async function loadIgnorePatterns(projectPath: string): Promise<string[]>
     );
   }
 
+  let content: string;
   try {
-    const content = await fs.readTextFile(ignorePath);
-    if (content.length > MAX_IGNORE_FILE_LENGTH) {
-      throw new Error(`.vfignore must not exceed ${MAX_IGNORE_FILE_LENGTH} characters.`);
-    }
-    const customPatterns = content
-      .split("\n")
-      .map((line) => line.trim())
-      .filter((line) => line && !line.startsWith("#"));
-
-    patterns.push(...customPatterns);
+    content = await fs.readTextFile(ignorePath);
   } catch (error) {
     cliLogger.debug("Failed to read .vfignore:", error);
     throw new Error("Failed to read .vfignore. Fix the file permissions or path and try again.", {
       cause: error,
     });
   }
+  if (content.length > MAX_IGNORE_FILE_LENGTH) {
+    throw new Error(`.vfignore must not exceed ${MAX_IGNORE_FILE_LENGTH} characters.`);
+  }
+  const customPatterns = content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"));
+  patterns.push(...customPatterns);
 
   return patterns;
 }

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -315,28 +315,70 @@ function epsilonClosure(tokens: readonly GlobToken[], states: ReadonlySet<number
   return closure;
 }
 
+function activeGlobstarDirectoryState(tokens: readonly GlobToken[], tokenIndex: number): number {
+  return tokens.length + tokenIndex + 1;
+}
+
+function activeGlobstarDirectoryTokenIndex(
+  tokens: readonly GlobToken[],
+  state: number,
+): number | null {
+  if (state <= tokens.length) return null;
+  const tokenIndex = state - tokens.length - 1;
+  return tokens[tokenIndex]?.type === "globstar-directory" ? tokenIndex : null;
+}
+
+function transitionGlobState(
+  tokens: readonly GlobToken[],
+  state: number,
+  character: string,
+): number[] {
+  const activeGlobstarIndex = activeGlobstarDirectoryTokenIndex(tokens, state);
+  if (activeGlobstarIndex !== null) {
+    return character === "/" ? [state, activeGlobstarIndex + 1] : [state];
+  }
+
+  const token = tokens[state];
+  switch (token?.type) {
+    case "literal":
+      return token.value === character ? [state + 1] : [];
+    case "single":
+      return character === "/" ? [] : [state + 1];
+    case "star":
+      return character === "/" ? [] : [state];
+    case "double-star":
+      return [state];
+    case "globstar-directory": {
+      const activeState = activeGlobstarDirectoryState(tokens, state);
+      return character === "/" ? [activeState, state + 1] : [activeState];
+    }
+    default:
+      return [];
+  }
+}
+
+function advanceGlobStates(
+  tokens: readonly GlobToken[],
+  states: ReadonlySet<number>,
+  character: string,
+): Set<number> {
+  const nextStates = new Set<number>();
+  for (const state of states) {
+    for (const nextState of transitionGlobState(tokens, state, character)) {
+      nextStates.add(nextState);
+    }
+  }
+  return epsilonClosure(tokens, nextStates);
+}
+
 function anchoredGlobCanMatchDescendant(
   tokens: readonly GlobToken[],
   normalizedPath: string,
 ): boolean {
   let states = epsilonClosure(tokens, new Set([0]));
   const prefix = `${normalizedPath}/`;
-  for (let pathIndex = 0; pathIndex < prefix.length; pathIndex++) {
-    const character = prefix[pathIndex]!;
-    const nextStates = new Set<number>();
-    for (const state of states) {
-      const token = tokens[state];
-      if (token?.type === "literal" && token.value === character) {
-        nextStates.add(state + 1);
-      } else if (token?.type === "single" && character !== "/") {
-        nextStates.add(state + 1);
-      } else if (token?.type === "star" && character !== "/") {
-        nextStates.add(state);
-      } else if (token?.type === "double-star" || token?.type === "globstar-directory") {
-        nextStates.add(state);
-      }
-    }
-    states = epsilonClosure(tokens, nextStates);
+  for (const character of prefix) {
+    states = advanceGlobStates(tokens, states, character);
     if (states.size === 0) return false;
   }
   return states.size > 0;
@@ -348,33 +390,21 @@ function anchoredGlobCoversEveryDescendant(
 ): boolean {
   let states = epsilonClosure(tokens, new Set([0]));
   const prefix = `${normalizedPath}/`;
-  for (let pathIndex = 0; pathIndex < prefix.length; pathIndex++) {
-    const character = prefix[pathIndex]!;
-    const nextStates = new Set<number>();
-    for (const state of states) {
-      const token = tokens[state];
-      if (token?.type === "literal" && token.value === character) {
-        nextStates.add(state + 1);
-      } else if (token?.type === "single" && character !== "/") {
-        nextStates.add(state + 1);
-      } else if (token?.type === "star" && character !== "/") {
-        nextStates.add(state);
-      } else if (token?.type === "double-star" || token?.type === "globstar-directory") {
-        nextStates.add(state);
-      }
-    }
-    states = epsilonClosure(tokens, nextStates);
+  for (const character of prefix) {
+    states = advanceGlobStates(tokens, states, character);
     if (states.size === 0) return false;
   }
 
   for (const state of states) {
-    const token = tokens[state];
+    const activeGlobstarIndex = activeGlobstarDirectoryTokenIndex(tokens, state);
+    const tokenIndex = activeGlobstarIndex ?? state;
+    const token = tokens[tokenIndex];
     if (token?.type === "double-star") {
-      if (epsilonClosure(tokens, new Set([state + 1])).has(tokens.length)) return true;
+      if (epsilonClosure(tokens, new Set([tokenIndex + 1])).has(tokens.length)) return true;
     }
     if (
-      token?.type === "globstar-directory" && tokens[state + 1]?.type === "star" &&
-      epsilonClosure(tokens, new Set([state + 2])).has(tokens.length)
+      token?.type === "globstar-directory" && tokens[tokenIndex + 1]?.type === "star" &&
+      epsilonClosure(tokens, new Set([tokenIndex + 2])).has(tokens.length)
     ) return true;
   }
   return false;

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -39,7 +39,12 @@ const DEFAULT_IGNORE_PATTERNS: readonly string[] = [
  * They hold credentials and local CLI state, so a negation such as `!.env*.json`
  * must not make `veryfront push` read and upload them.
  */
-const PROTECTED_IGNORE_PATTERNS: readonly string[] = [".env*", ".veryfront", ".git"];
+const PROTECTED_IGNORE_PATTERNS: readonly string[] = [
+  ".env*",
+  ".env*/",
+  ".veryfront",
+  ".git",
+];
 
 /** Supported file extensions for sync */
 const SUPPORTED_EXTENSIONS = new Set([
@@ -68,6 +73,9 @@ const SUPPORTED_EXTENSIONS = new Set([
 export interface IgnoreChecker {
   /** Check if a path should be ignored */
   isIgnored(relativePath: string): boolean;
+
+  /** Check if a path is protected even when a project ignore rule negates it. */
+  isProtected(relativePath: string): boolean;
 
   /** Check if a file extension is supported */
   isSupportedExtension(filename: string): boolean;
@@ -159,7 +167,7 @@ function globToRegex(pattern: string): string {
   return source;
 }
 
-function patternToRule(rawPattern: string): IgnoreRule | null {
+function patternToRule(rawPattern: string, caseInsensitive = false): IgnoreRule | null {
   let pattern = rawPattern.trim();
   if (!pattern || pattern.startsWith("#")) return null;
 
@@ -182,18 +190,18 @@ function patternToRule(rawPattern: string): IgnoreRule | null {
 
   return {
     negated,
-    regex: new RegExp(`${prefix}${body}${suffix}`),
+    regex: new RegExp(`${prefix}${body}${suffix}`, caseInsensitive ? "i" : ""),
   };
 }
 
-function toRules(patterns: readonly string[]): IgnoreRule[] {
+function toRules(patterns: readonly string[], caseInsensitive = false): IgnoreRule[] {
   return patterns.flatMap((pattern) => {
-    const rule = patternToRule(pattern);
+    const rule = patternToRule(pattern, caseInsensitive);
     return rule ? [rule] : [];
   });
 }
 
-const PROTECTED_RULES = toRules(PROTECTED_IGNORE_PATTERNS);
+const PROTECTED_RULES = toRules(PROTECTED_IGNORE_PATTERNS, true);
 
 function isProtectedPath(normalizedPath: string): boolean {
   return PROTECTED_RULES.some((rule) => rule.regex.test(normalizedPath));
@@ -215,11 +223,15 @@ export function createIgnoreChecker(patterns: readonly string[]): IgnoreChecker 
     }
 
     if (!ignored && isProtectedPath(normalizedPath)) {
-      cliLogger.debug(`Keeping ${normalizedPath} ignored: .vfignore cannot re-include this path.`);
+      cliLogger.debug("Keeping protected path ignored: .vfignore cannot re-include it.");
       return true;
     }
 
     return ignored;
+  }
+
+  function isProtected(relativePath: string): boolean {
+    return isProtectedPath(relativePath.replace(/\\/g, "/"));
   }
 
   function isSupportedExtension(filename: string): boolean {
@@ -228,7 +240,7 @@ export function createIgnoreChecker(patterns: readonly string[]): IgnoreChecker 
     return SUPPORTED_EXTENSIONS.has(filename.slice(lastDot).toLowerCase());
   }
 
-  return { isIgnored, isSupportedExtension };
+  return { isIgnored, isProtected, isSupportedExtension };
 }
 
 /**

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -36,11 +36,20 @@ const DEFAULT_IGNORE_PATTERNS: readonly string[] = [
 
 /**
  * Safety patterns that project-controlled `.vfignore` rules can never re-include.
- * They hold credentials and local CLI state, so a negation such as `!.env*.json`
- * must not make `veryfront push` read and upload them.
+ * They hold credentials, local CLI state, and Git internals, so a negation such
+ * as `!.env*.json` must not make `veryfront push` read and upload them.
+ *
+ * The trailing-slash `.env` entry also covers the plain file form, because a
+ * directory-only pattern compiles to a suffix of `(/` or end of string. It
+ * matches `.env.production.json` and `.env/credentials.json` alike, so a
+ * separate `.env` glob entry would be redundant.
+ *
+ * The set stays narrower than `DEFAULT_IGNORE_PATTERNS`. Build caches and
+ * third-party tool metadata such as `.cache`, `.deno`, `.turbo`, `.vercel`, and
+ * `.netlify` hold no Veryfront credential, and a project can have a real reason
+ * to publish a file under them, so those stay negatable.
  */
 const PROTECTED_IGNORE_PATTERNS: readonly string[] = [
-  ".env*",
   ".env*/",
   ".veryfront",
   ".git",
@@ -223,7 +232,9 @@ export function createIgnoreChecker(patterns: readonly string[]): IgnoreChecker 
     }
 
     if (!ignored && isProtectedPath(normalizedPath)) {
-      cliLogger.debug("Keeping protected path ignored: .vfignore cannot re-include it.");
+      cliLogger.debug(
+        `Keeping protected path ignored: .vfignore cannot re-include "${normalizedPath}".`,
+      );
       return true;
     }
 

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -330,8 +330,18 @@ function hasEffectiveDescendantNegation(
   normalizedPath: string,
   canceledNegations: ReadonlySet<IgnoreRule>,
 ): boolean {
-  for (const rule of rules) {
+  const descendantProbe = `${normalizedPath}/__veryfront_probe__.json`;
+  let lastBroadIgnoreIndex = -1;
+  for (let index = 0; index < rules.length; index++) {
+    const rule = rules[index]!;
+    if (!rule.negated && rule.regex.test(normalizedPath) && rule.regex.test(descendantProbe)) {
+      lastBroadIgnoreIndex = index;
+    }
+  }
+  for (let index = 0; index < rules.length; index++) {
+    const rule = rules[index]!;
     if (!negatedRuleTargetsDescendant(rule, normalizedPath)) continue;
+    if (index < lastBroadIgnoreIndex) continue;
     if (!canceledNegations.has(rule)) return true;
   }
   return false;

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -157,6 +157,9 @@ export async function loadIgnorePatterns(projectPath: string): Promise<string[]>
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => line && !line.startsWith("#"));
+  if (customPatterns.length > MAX_IGNORE_RULES) {
+    throw new Error(`.vfignore must not contain more than ${MAX_IGNORE_RULES} rules.`);
+  }
   patterns.push(...customPatterns);
 
   return patterns;
@@ -260,8 +263,12 @@ function patternToRule(rawPattern: string, caseInsensitive = false): IgnoreRule 
   };
 }
 
-function toRules(patterns: readonly string[], caseInsensitive = false): IgnoreRule[] {
-  if (patterns.length > MAX_IGNORE_RULES) {
+function toRules(
+  patterns: readonly string[],
+  caseInsensitive = false,
+  maxRules = MAX_IGNORE_RULES,
+): IgnoreRule[] {
+  if (patterns.length > maxRules) {
     throw new Error(`.vfignore must not contain more than ${MAX_IGNORE_RULES} rules.`);
   }
   return patterns.flatMap((pattern) => {
@@ -326,6 +333,38 @@ function anchoredGlobCanMatchDescendant(
   return states.size > 0;
 }
 
+function anchoredGlobCoversEveryDescendant(
+  tokens: readonly GlobToken[],
+  normalizedPath: string,
+): boolean {
+  let states = epsilonClosure(tokens, new Set([0]));
+  const prefix = `${normalizedPath}/`;
+  for (let pathIndex = 0; pathIndex < prefix.length; pathIndex++) {
+    const character = prefix[pathIndex]!;
+    const nextStates = new Set<number>();
+    for (const state of states) {
+      const token = tokens[state];
+      if (token?.type === "literal" && token.value === character) {
+        nextStates.add(state + 1);
+      } else if (token?.type === "single" && character !== "/") {
+        nextStates.add(state + 1);
+      } else if (token?.type === "star" && character !== "/") {
+        nextStates.add(state);
+      } else if (token?.type === "double-star") {
+        nextStates.add(state);
+      }
+    }
+    states = epsilonClosure(tokens, nextStates);
+    if (states.size === 0) return false;
+  }
+
+  for (const state of states) {
+    if (tokens[state]?.type !== "double-star") continue;
+    if (epsilonClosure(tokens, new Set([state + 1])).has(tokens.length)) return true;
+  }
+  return false;
+}
+
 function negatedRuleTargetsDescendant(rule: IgnoreRule, normalizedPath: string): boolean {
   if (!rule.negated) return false;
   // An unanchored rule can begin at any descendant segment below this
@@ -344,7 +383,11 @@ function hasEffectiveDescendantNegation(
   let lastBroadIgnoreIndex = -1;
   for (let index = 0; index < rules.length; index++) {
     const rule = rules[index]!;
-    if (!rule.negated && rule.implicitDescendants && rule.regex.test(normalizedPath)) {
+    if (
+      !rule.negated &&
+      (rule.implicitDescendants && rule.regex.test(normalizedPath) ||
+        rule.anchored && anchoredGlobCoversEveryDescendant(rule.globTokens, normalizedPath))
+    ) {
       lastBroadIgnoreIndex = index;
     }
   }
@@ -396,7 +439,14 @@ function collectCanceledNegations(rules: readonly IgnoreRule[]): ReadonlySet<Ign
  * Create an ignore checker with loaded patterns
  */
 export function createIgnoreChecker(patterns: readonly string[]): IgnoreChecker {
-  const rules = toRules(patterns);
+  const hasDefaultPrefix = DEFAULT_IGNORE_PATTERNS.every(
+    (pattern, index) => patterns[index] === pattern,
+  );
+  const rules = toRules(
+    patterns,
+    false,
+    hasDefaultPrefix ? MAX_IGNORE_RULES + DEFAULT_IGNORE_PATTERNS.length : MAX_IGNORE_RULES,
+  );
   const canceledNegations = collectCanceledNegations(rules);
   // A dropped negation silently changes what push and pull reconcile, so warn
   // at the default log level. Deduplicated per checker because every path is

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -88,7 +88,7 @@ const SUPPORTED_EXTENSIONS = new Set([
 
 export interface IgnoreChecker {
   /** Check if a path should be ignored */
-  isIgnored(relativePath: string): boolean;
+  isIgnored(relativePath: string, options?: { isDirectory?: boolean }): boolean;
 
   /** Check if a path is protected even when a project ignore rule negates it. */
   isProtected(relativePath: string): boolean;
@@ -373,7 +373,7 @@ export function createIgnoreChecker(patterns: readonly string[]): IgnoreChecker 
   // tested many times during a single scan.
   const warnedOverrides = new Set<string>();
 
-  function isIgnored(relativePath: string): boolean {
+  function isIgnored(relativePath: string, options: { isDirectory?: boolean } = {}): boolean {
     const normalizedPath = normalizeIgnorePath(relativePath);
     let ignored = false;
     let lastMatchedRule: IgnoreRule | undefined;
@@ -386,7 +386,8 @@ export function createIgnoreChecker(patterns: readonly string[]): IgnoreChecker 
 
     if (isProtectedPath(normalizedPath)) {
       const droppedNegation = lastMatchedRule?.negated ||
-        hasEffectiveDescendantNegation(rules, normalizedPath, canceledNegations);
+        (options.isDirectory === true &&
+          hasEffectiveDescendantNegation(rules, normalizedPath, canceledNegations));
       if (droppedNegation && !isJsonMode() && !warnedOverrides.has(normalizedPath)) {
         warnedOverrides.add(normalizedPath);
         logWarning(

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -102,6 +102,7 @@ interface IgnoreRule {
   regex: RegExp;
   anchored: boolean;
   literalPrefix: string;
+  descendantPrefixRegexes: RegExp[];
 }
 
 /**
@@ -208,12 +209,18 @@ function patternToRule(rawPattern: string, caseInsensitive = false): IgnoreRule 
   const wildcardIndex = pattern.search(/[*?]/);
   const literalPrefix = (wildcardIndex === -1 ? pattern : pattern.slice(0, wildcardIndex))
     .replace(/\/+$/, "");
+  const pathSegments = pattern.split("/");
+  const descendantPrefixRegexes = pathSegments.slice(0, -1).map((_, index) => {
+    const prefixBody = globToRegex(pathSegments.slice(0, index + 1).join("/"));
+    return new RegExp(`${anchored ? "^" : "(^|/)"}${prefixBody}$`, caseInsensitive ? "i" : "");
+  });
 
   return {
     negated,
     regex: new RegExp(`${prefix}${body}${suffix}`, caseInsensitive ? "i" : ""),
     anchored,
     literalPrefix,
+    descendantPrefixRegexes,
   };
 }
 
@@ -244,6 +251,7 @@ function negatedRuleTargetsDescendant(rule: IgnoreRule, normalizedPath: string):
   // any directory, so a protected directory stops that negation from ever
   // being evaluated on a concrete child.
   if (!rule.literalPrefix) return true;
+  if (rule.descendantPrefixRegexes.some((prefix) => prefix.test(normalizedPath))) return true;
   const candidates = rule.anchored
     ? [normalizedPath]
     : normalizedPath.split("/").map((_, index, parts) => parts.slice(index).join("/"));

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -239,7 +239,11 @@ function isProtected(relativePath: string): boolean {
 }
 
 function negatedRuleTargetsDescendant(rule: IgnoreRule, normalizedPath: string): boolean {
-  if (!rule.negated || !rule.literalPrefix || rule.regex.test(normalizedPath)) return false;
+  if (!rule.negated || rule.regex.test(normalizedPath)) return false;
+  // A wildcard before the first literal segment can match a descendant below
+  // any directory, so a protected directory stops that negation from ever
+  // being evaluated on a concrete child.
+  if (!rule.literalPrefix) return true;
   const candidates = rule.anchored
     ? [normalizedPath]
     : normalizedPath.split("/").map((_, index, parts) => parts.slice(index).join("/"));

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -100,6 +100,8 @@ export interface IgnoreChecker {
 interface IgnoreRule {
   negated: boolean;
   regex: RegExp;
+  anchored: boolean;
+  literalPrefix: string;
 }
 
 /**
@@ -203,10 +205,15 @@ function patternToRule(rawPattern: string, caseInsensitive = false): IgnoreRule 
   const body = globToRegex(pattern);
   const prefix = anchored ? "^" : "(^|/)";
   const suffix = directoryOnly || (!hasSlash && !hasGlob) ? "(/|$)" : "$";
+  const wildcardIndex = pattern.search(/[*?]/);
+  const literalPrefix = (wildcardIndex === -1 ? pattern : pattern.slice(0, wildcardIndex))
+    .replace(/\/+$/, "");
 
   return {
     negated,
     regex: new RegExp(`${prefix}${body}${suffix}`, caseInsensitive ? "i" : ""),
+    anchored,
+    literalPrefix,
   };
 }
 
@@ -231,6 +238,16 @@ function isProtected(relativePath: string): boolean {
   return isProtectedPath(normalizeIgnorePath(relativePath));
 }
 
+function negatedRuleTargetsDescendant(rule: IgnoreRule, normalizedPath: string): boolean {
+  if (!rule.negated || !rule.literalPrefix || rule.regex.test(normalizedPath)) return false;
+  const candidates = rule.anchored
+    ? [normalizedPath]
+    : normalizedPath.split("/").map((_, index, parts) => parts.slice(index).join("/"));
+  return candidates.some((candidate) =>
+    rule.literalPrefix === candidate || rule.literalPrefix.startsWith(`${candidate}/`)
+  );
+}
+
 /**
  * Create an ignore checker with loaded patterns
  */
@@ -252,8 +269,10 @@ export function createIgnoreChecker(patterns: readonly string[]): IgnoreChecker 
       ignored = !rule.negated;
     }
 
-    if (!ignored && isProtectedPath(normalizedPath)) {
-      if (lastMatchedRule?.negated && !isJsonMode() && !warnedOverrides.has(normalizedPath)) {
+    if (isProtectedPath(normalizedPath)) {
+      const droppedNegation = lastMatchedRule?.negated ||
+        rules.some((rule) => negatedRuleTargetsDescendant(rule, normalizedPath));
+      if (droppedNegation && !isJsonMode() && !warnedOverrides.has(normalizedPath)) {
         warnedOverrides.add(normalizedPath);
         logWarning(
           `Ignoring protected path "${sanitizeLogText(normalizedPath)}". ` +

--- a/cli/sync/ignore.ts
+++ b/cli/sync/ignore.ts
@@ -350,13 +350,29 @@ function hasEffectiveDescendantNegation(
 function collectCanceledNegations(rules: readonly IgnoreRule[]): ReadonlySet<IgnoreRule> {
   const canceled = new Set<IgnoreRule>();
   const laterPositivePatterns = new Set<string>();
+  const laterPositiveRules: IgnoreRule[] = [];
   for (let index = rules.length - 1; index >= 0; index--) {
     const rule = rules[index]!;
     const signature = `${rule.regex.source}\u0000${rule.regex.flags}`;
     if (rule.negated) {
-      if (laterPositivePatterns.has(signature)) canceled.add(rule);
+      let literalPath = "";
+      for (const token of rule.globTokens) {
+        if (token.type !== "literal") {
+          literalPath = "";
+          break;
+        }
+        literalPath += token.value;
+      }
+      if (
+        laterPositivePatterns.has(signature) ||
+        (literalPath.length > 0 &&
+          laterPositiveRules.some((positive) => positive.regex.test(literalPath)))
+      ) {
+        canceled.add(rule);
+      }
     } else {
       laterPositivePatterns.add(signature);
+      laterPositiveRules.push(rule);
     }
   }
   return canceled;

--- a/docs/guides/deploy-from-ci.md
+++ b/docs/guides/deploy-from-ci.md
@@ -64,7 +64,9 @@ this handoff. Manage those files through another reviewed delivery path.
 Both commands use the same `.vfignore` rules. Ignored files and unsupported
 extensions are not reconciled with Veryfront. A `.vfignore` negation cannot
 re-include `.env*`, `.veryfront`, or `.git` paths: those stay ignored so local
-secrets and CLI state are never uploaded.
+secrets and CLI state are never uploaded. Run `veryfront push --prune` once
+after upgrading to remove any of those protected paths that an older CLI
+uploaded. Rotate any credential that was previously exposed.
 
 If the project has a `.vfignore`, keep it as a regular file inside the project
 and commit it to Git so the managed source set is reproducible. Symlinked

--- a/docs/guides/deploy-from-ci.md
+++ b/docs/guides/deploy-from-ci.md
@@ -68,6 +68,12 @@ secrets and CLI state are never uploaded. Run `veryfront push --prune` once
 after upgrading to remove any of those protected paths that an older CLI
 uploaded. Rotate any credential that was previously exposed.
 
+`push --prune` deletes every protected remote path, including one that was
+authored in the web editor rather than uploaded by an older CLI, and `.env*`
+also matches directories such as `.env.d/`. Push lists those paths before it
+deletes them. Use `veryfront push --prune --dry-run` to review the list first,
+and move any file you must keep to a path outside the protected set.
+
 If the project has a `.vfignore`, keep it as a regular file inside the project
 and commit it to Git so the managed source set is reproducible. Symlinked
 `.vfignore` files are rejected. Git cleanliness is recorded as provenance

--- a/docs/guides/deploy-from-ci.md
+++ b/docs/guides/deploy-from-ci.md
@@ -62,7 +62,9 @@ Binary images, fonts, archives, and other unsupported files remain outside
 this handoff. Manage those files through another reviewed delivery path.
 
 Both commands use the same `.vfignore` rules. Ignored files and unsupported
-extensions are not reconciled with Veryfront.
+extensions are not reconciled with Veryfront. A `.vfignore` negation cannot
+re-include `.env*`, `.veryfront`, or `.git` paths: those stay ignored so local
+secrets and CLI state are never uploaded.
 
 If the project has a `.vfignore`, keep it as a regular file inside the project
 and commit it to Git so the managed source set is reproducible. Symlinked

--- a/docs/guides/deploy-from-ci.md
+++ b/docs/guides/deploy-from-ci.md
@@ -64,12 +64,13 @@ this handoff. Manage those files through another reviewed delivery path.
 Both commands use the same `.vfignore` rules. Ignored files and unsupported
 extensions are not reconciled with Veryfront. A `.vfignore` negation cannot
 re-include `.env`, `.env.*`, `.veryfront`, or `.git` paths: those stay ignored
-so local secrets and CLI state are never uploaded. Push and Pull print a
-warning naming each path whose negation was dropped. Names that only begin with
-`.env`, such as `.envoy/` or `.environments/`, are not protected and stay
-negatable. Run `veryfront push --prune` once after upgrading to remove any
-protected path that an older CLI uploaded. Rotate any credential that was
-previously exposed.
+so local secrets and CLI state are never uploaded. Push prints a warning naming
+each path whose negation was dropped. Pull does the same for protected `.env`
+paths, and rejects remote `.git` or `.veryfront` metadata before changing local
+files. Names that only begin with `.env`, such as `.envoy/` or `.environments/`,
+are not protected and stay negatable. Run `veryfront push --prune` once after
+upgrading to remove any protected path that an older CLI uploaded. Rotate any
+credential that was previously exposed.
 
 `push --prune` deletes every protected remote path, including one that was
 authored in the web editor rather than uploaded by an older CLI, and the

--- a/docs/guides/deploy-from-ci.md
+++ b/docs/guides/deploy-from-ci.md
@@ -63,16 +63,22 @@ this handoff. Manage those files through another reviewed delivery path.
 
 Both commands use the same `.vfignore` rules. Ignored files and unsupported
 extensions are not reconciled with Veryfront. A `.vfignore` negation cannot
-re-include `.env*`, `.veryfront`, or `.git` paths: those stay ignored so local
-secrets and CLI state are never uploaded. Run `veryfront push --prune` once
-after upgrading to remove any of those protected paths that an older CLI
-uploaded. Rotate any credential that was previously exposed.
+re-include `.env`, `.env.*`, `.veryfront`, or `.git` paths: those stay ignored
+so local secrets and CLI state are never uploaded. Push and Pull print a
+warning naming each path whose negation was dropped. Names that only begin with
+`.env`, such as `.envoy/` or `.environments/`, are not protected and stay
+negatable. Run `veryfront push --prune` once after upgrading to remove any
+protected path that an older CLI uploaded. Rotate any credential that was
+previously exposed.
 
 `push --prune` deletes every protected remote path, including one that was
-authored in the web editor rather than uploaded by an older CLI, and `.env*`
-also matches directories such as `.env.d/`. Push lists those paths before it
-deletes them. Use `veryfront push --prune --dry-run` to review the list first,
-and move any file you must keep to a path outside the protected set.
+authored in the web editor rather than uploaded by an older CLI, and the
+patterns match directories too, so `.env.d/config.json` is in scope. Push
+prints the paths it removes, and `--json` runs carry the same list as
+`protectedDeleted` on the result envelope (`protectedWouldDelete` under
+`--dry-run`). Use `veryfront push --prune --dry-run` to review the list before
+a real prune, and move any file you must keep to a path outside the protected
+set.
 
 If the project has a `.vfignore`, keep it as a regular file inside the project
 and commit it to Git so the managed source set is reproducible. Symlinked


### PR DESCRIPTION
## Vulnerability

`loadIgnorePatterns()` prepends the built-in safety defaults (including `.env*` and `.veryfront`) and then appends project-controlled `.vfignore` lines, while `createIgnoreChecker().isIgnored()` uses ordered, last-match-wins gitignore semantics where a later `!` rule sets `ignored = false`. A repository could therefore ship a `.vfignore` containing `!.env*.json` or `!.veryfront` and make `veryfront push` scan, read, and upload the developer's local secrets and CLI state: `scanLocalFiles` in `cli/commands/push/command.ts` walks the project, skips only ignored paths, and uploads every remaining file with a supported extension (`.json`, `.yaml`, `.yml`, `.toml`, ...) with no separate dotfile or secret guard. Impact is a realistic credential leak for a developer who clones and pushes a malicious or surprising project; the same checker also drives `pull --prune`, so protected paths were exposed to destructive local reconciliation too. Bare `.env` / `.env.local` still fail the extension filter, which bounds but does not remove the exposure.

- Codex finding id: `213fd5063990819188c3fc1d7c49d141`
- Severity: medium
- Introduced in: `60968653be80eb7598385edfd86214993b812c16`

## Fix

### Ignore rules (`cli/sync/ignore.ts`)

`cli/sync/ignore.ts` now keeps a small `PROTECTED_IGNORE_PATTERNS` set (`.env/`, `.env.*/`, `.veryfront`, `.git`) compiled separately from the ordered rule list. `isIgnored()` still evaluates user rules in order, but a path matching a protected pattern is ignored regardless of any negation (fail-closed), and warns once per path at the default log level naming the path whose negation was dropped. A new `isProtected()` member exposes the same test to callers. Pattern compilation is factored into a shared `toRules()` helper; no other ignore semantics change, so legitimate negations such as `*.log` + `!keep.log` keep working. Push and pull both go through `createIgnoreChecker`, so both paths get the guarantee.

The protected set stays deliberately narrower than `DEFAULT_IGNORE_PATTERNS` on two axes. Build caches and third-party tool metadata (`.cache`, `.deno`, `.turbo`, `.vercel`, `.netlify`) hold no Veryfront credential and a project can have a real reason to publish a file under them, so those stay negatable. The `.env` entries are also stricter than the `.env*` default: they cover `.env` and dot-suffixed variants (`.env.local`, `.env.production.json`, `.env.d/`) but not unrelated names that merely start with `.env` such as `.envoy/` or `.environments/`, which keep the default ignore and stay negatable rather than becoming permanently unsyncable. The rationale is recorded in the code comment.

### Remote cleanup on prune (`cli/commands/push/command.ts`, `cli/commands/push/plan.ts`)

Blocking new uploads is not enough on its own: a project that already pushed with an older CLI has the secret sitting in Veryfront, and the new rule makes that remote copy permanently invisible to reconciliation. This PR therefore adds a destructive remediation path.

- `findRemoteFilesMissingLocally()` returns protected remote paths regardless of extension or ignore state, still behind the `!localPaths.has(path)` guard the name implies.
- `managedRemoteFiles` includes protected remote paths when `--prune` is requested, so the planner can see them. A separate `syncBaselineRemoteFiles` list drops them again before any `writeAppliedSyncTarget` call, so a partially applied push never seeds the local sync baseline with an entry `plan.nextFiles` deliberately excludes.
- `planPushChanges()` takes a new `protectedDeletePaths` option, intersected with `deletePaths` inside the planner so a non-subset entry cannot vanish from the baseline without being queued for deletion. Those paths skip the digest/`nextFiles` bookkeeping and skip the baseline comparison, because a protected path is never present in the local sync baseline and would otherwise always be reported as a conflict. The delete still carries `expectedVersionId` from the observed listing, so it remains an optimistic-concurrency delete rather than a blind one.

Net effect for reviewers and release notes: **`veryfront push --prune` now deletes remote paths matching `.env`, `.env.*`, `.veryfront`, or `.git`, including ones authored in the web editor rather than uploaded by an older CLI.** A `.vfignore` negation can no longer exempt them. The patterns match directories too, so a path such as `.env.d/config.json` is in scope. Pushes without `--prune` are unchanged and never delete these paths.

Every push mode signals the pruned paths by name: non-JSON runs print a warning listing them (outside the `--quiet` gate, since `--quiet` emits no result envelope), and JSON runs carry the same list as `protectedDeleted` on the result envelope, or `protectedWouldDelete` under `--dry-run`. `veryfront push --prune --dry-run` lists them without mutating anything. There is no interactive confirm prompt on push, so the warning is the only pre-delete signal.

The `.vfignore` documentation in `docs/guides/deploy-from-ci.md` records both the new ignore rule and the prune behavior.

## Test evidence

- `cli/sync/ignore.test.ts`: one regression test at the `loadIgnorePatterns` level writing a real `.vfignore` with `!.env*.json`, `!.veryfront`, `!.veryfront/**`; one at the `createIgnoreChecker` level covering `!.git/**`, nested paths, and `isProtected()`; and one asserting that `!.envoy/**` and `!.environments/**` still work.
- `cli/commands/push/plan.test.ts`: planner-level coverage that a protected delete uses the observed version and raises no conflict, and that a `protectedDeletePaths` entry outside `deletePaths` is ignored rather than silently dropped from `nextFiles`.
- `cli/commands/push/command.test.ts`: three command-level tests. `push --prune` issues `DELETE` for a leaked `.env.production.json` and `.veryfront/state.json`, each with an `expected_version_id` precondition; a push without `--prune` issues no `DELETE` and still refuses to upload a locally negated `.env.production.json`; and a `--json` prune names the paths in `protectedWouldDelete` / `protectedDeleted`.

- `deno task test:file cli/sync/ignore.test.ts` -- ok, 1 passed (26 steps)
- `deno task test:file cli/commands/push/plan.test.ts` -- ok, 1 passed (15 steps)
- `deno task test:file cli/commands/push/command.test.ts` -- ok, 14 passed (101 steps)
- `deno task test:file cli/commands/pull/command.test.ts` -- ok, 7 passed (68 steps)
- `deno fmt`, `deno lint`, `deno check` on the touched files -- clean
- `deno task lint:anti-slop`, `deno task lint:style`, `deno task lint:cli-boundary` -- pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Protected paths such as `.env`, `.env.*`, `.veryfront`, and `.git` can no longer be re-included through `.vfignore` negation rules.
  - `push --prune` identifies and removes protected remote paths, including those created through the web editor.
  - Push displays protected paths before deletion and supports reviewing them with `--dry-run`, including JSON results through `protectedWouldDelete` and `protectedDeleted`.
  - Protected paths remain untouched during standard pushes.
  - Warnings identify negated protected paths while avoiding exposure in JSON output.

- **Bug Fixes**
  - Error details now sanitize protected paths in JSON output.

- **Documentation**
  - Updated CI deployment guidance with protected-path behavior and cleanup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
