### PR TITLE
fix(security): scope stale MDX ESM cache recovery to mutable content sources

### DIFF
--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -18,7 +18,7 @@ import {
   toError,
   VeryfrontError,
 } from "#veryfront/errors";
-import { __resetStaleMdxEsmRecoveryStateForTests } from "../page-rendering.ts";
+import { __resetStaleMdxEsmRecoveryStateForTests } from "#veryfront/rendering/page-rendering.ts";
 import { cachePageCss, getPageCssCacheKey } from "./css-cache.ts";
 import { cacheCSSAsync, hashCSS } from "#veryfront/html/styles-builder/index.ts";
 import { RELEASE_ASSET_MANIFEST_ENV_FLAG } from "#veryfront/release-assets/constants.ts";

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -1341,6 +1341,62 @@ describe("RenderPipeline behavior", () => {
     assertEquals(sourceRefreshes, 1);
   });
 
+  it("renderPage recovers preview caches from the pipeline's configured content source", async () => {
+    const slug = "/behavior-configured-preview-stale-mdx";
+    let renderAttempts = 0;
+    let sourceRefreshes = 0;
+    // The pipeline carries the preview content source in its own config and the
+    // request supplies no override, which is how resolveModuleLoaderConfig
+    // resolves the namespace. Recovery must use the same fallback.
+    const pipeline = createPipeline("/project/pages/behavior-configured-preview-stale-mdx.mdx", {
+      mode: "production",
+      contentSourceId: "preview-main",
+      adapter: {
+        env: { get: () => undefined },
+        fs: {
+          exists: async () => false,
+          refreshSourceSnapshot: () => {
+            sourceRefreshes++;
+            return Promise.resolve();
+          },
+        },
+      } as any,
+      pageRenderer: {
+        preparePageBundles: async () => {
+          renderAttempts++;
+          if (renderAttempts === 1) {
+            throw new Error(
+              "The requested module 'file:///cache/vfmod.mjs' does not provide an export named 'default'",
+            );
+          }
+
+          return {
+            pageElement: {},
+            pageBundle: {},
+          };
+        },
+      } as any,
+    } as Partial<RenderPipelineConfig>);
+
+    const result = await pipeline.renderPage(slug, {
+      delivery: "string",
+      projectId: "project-1",
+      projectSlug: "project-slug",
+    });
+
+    assertEquals(result.html, "<!doctype html><html><body>ok</body></html>");
+    assertEquals(
+      renderAttempts,
+      2,
+      "a preview source configured on the pipeline must still get its recovery retry",
+    );
+    assertEquals(
+      sourceRefreshes,
+      1,
+      "recovery must classify the configured content source, not the missing request override",
+    );
+  });
+
   it("renderPage does not recover caches for a released production content source", async () => {
     const slug = "/behavior-release-stale-mdx";
     let renderAttempts = 0;

--- a/src/rendering/orchestrator/pipeline.behavior.test.ts
+++ b/src/rendering/orchestrator/pipeline.behavior.test.ts
@@ -18,6 +18,7 @@ import {
   toError,
   VeryfrontError,
 } from "#veryfront/errors";
+import { __resetStaleMdxEsmRecoveryStateForTests } from "../page-rendering.ts";
 import { cachePageCss, getPageCssCacheKey } from "./css-cache.ts";
 import { cacheCSSAsync, hashCSS } from "#veryfront/html/styles-builder/index.ts";
 import { RELEASE_ASSET_MANIFEST_ENV_FLAG } from "#veryfront/release-assets/constants.ts";
@@ -202,6 +203,7 @@ describe("RenderPipeline behavior", () => {
     else setEnv("LOG_LEVEL", originalLogLevel);
     __resetLoggerConfigForTests();
     __resetLogRecordEmitterForTests();
+    __resetStaleMdxEsmRecoveryStateForTests();
   });
 
   it("threads render cancellation through layout preload and application", async () => {
@@ -1337,6 +1339,51 @@ describe("RenderPipeline behavior", () => {
     assertEquals(result.html, "<!doctype html><html><body>ok</body></html>");
     assertEquals(renderAttempts, 2);
     assertEquals(sourceRefreshes, 1);
+  });
+
+  it("renderPage does not recover caches for a released production content source", async () => {
+    const slug = "/behavior-release-stale-mdx";
+    let renderAttempts = 0;
+    let sourceRefreshes = 0;
+    const pipeline = createPipeline("/project/pages/behavior-release-stale-mdx.mdx", {
+      mode: "production",
+      adapter: {
+        env: { get: () => undefined },
+        fs: {
+          exists: async () => false,
+          refreshSourceSnapshot: () => {
+            sourceRefreshes++;
+            return Promise.resolve();
+          },
+        },
+      } as any,
+      pageRenderer: {
+        preparePageBundles: () => {
+          renderAttempts++;
+          // A shipped broken import keeps producing this message, so an
+          // unauthenticated request must not be able to buy a cache purge
+          // with it.
+          throw new Error(
+            "The requested module 'file:///cache/vfmod.mjs' does not provide an export named 'default'",
+          );
+        },
+      } as any,
+    } as Partial<RenderPipelineConfig>);
+
+    await assertRejects(
+      () =>
+        pipeline.renderPage(slug, {
+          delivery: "string",
+          projectId: "project-1",
+          projectSlug: "project-slug",
+          contentSourceId: "release-abc123",
+        }),
+      Error,
+      "does not provide an export named",
+    );
+
+    assertEquals(renderAttempts, 1, "a released source must not pay a recovery retry");
+    assertEquals(sourceRefreshes, 0, "a released source must not flush its source snapshot");
   });
 
   it("renderPage emits request-profiler timings for pipeline stages", async () => {

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -759,6 +759,9 @@ export class RenderPipeline {
     };
     const projectSlug = options?.projectSlug || options?.projectId || "unknown";
     const projectId = options?.projectId ?? this.config.projectId ?? this.config.projectDir;
+    // Mirror the fallback in resolveModuleLoaderConfig so stale-cache recovery
+    // classifies and purges the same namespace the module loader compiled into.
+    const contentSourceId = options?.contentSourceId ?? this.config.contentSourceId;
     const cacheKey = this.buildCacheKey(slug, options, dependencyPinningCacheKey);
 
     let cacheResult: Awaited<ReturnType<typeof this.config.cacheCoordinator.checkCache>> | null =
@@ -1118,7 +1121,7 @@ export class RenderPipeline {
           adapter: this.config.adapter,
           projectId,
           projectSlug,
-          contentSourceId: options?.contentSourceId,
+          contentSourceId,
           slug,
           pagePath: slug,
           mode: this.config.mode,
@@ -1130,7 +1133,7 @@ export class RenderPipeline {
             slug,
             projectId,
             projectSlug,
-            contentSourceId: options?.contentSourceId,
+            contentSourceId,
           });
           return await renderOnce();
         }

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -1119,6 +1119,7 @@ export class RenderPipeline {
       if (isMdxEsmExportMismatchError(error)) {
         const recovered = await recoverStaleMdxEsmPreviewCaches({
           adapter: this.config.adapter,
+          projectDir: this.config.projectDir,
           projectId,
           projectSlug,
           contentSourceId,

--- a/src/rendering/orchestrator/pipeline.ts
+++ b/src/rendering/orchestrator/pipeline.ts
@@ -1121,6 +1121,7 @@ export class RenderPipeline {
           contentSourceId: options?.contentSourceId,
           slug,
           pagePath: slug,
+          mode: this.config.mode,
         });
 
         if (recovered) {

--- a/src/rendering/page-rendering.test.ts
+++ b/src/rendering/page-rendering.test.ts
@@ -407,6 +407,127 @@ describe("rendering/page-rendering", () => {
     assertEquals(sourceRefreshes, 1);
   });
 
+  it("lets a later identity lookup join an active recovery", async () => {
+    let sourceRefreshes = 0;
+    let refreshStarted = false;
+    let resolveRefresh!: () => void;
+    const refreshPromise = new Promise<void>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const identityResolvers: Array<(identity: string) => void> = [];
+    const adapter = {
+      fs: {
+        getSourceSnapshotIdentity: () =>
+          new Promise<string>((resolve) => identityResolvers.push(resolve)),
+        refreshSourceSnapshot: () => {
+          sourceRefreshes++;
+          refreshStarted = true;
+          return refreshPromise;
+        },
+      },
+    } as unknown as RuntimeAdapter;
+
+    const recover = () =>
+      recoverStaleMdxEsmPreviewCaches({
+        adapter,
+        projectDir: "/project",
+        projectId: "project-1",
+        contentSourceId: "preview-main",
+        slug: "probe",
+        pagePath: "/probe",
+        mode: "production",
+      });
+
+    const first = recover();
+    assertEquals(identityResolvers.length, 1);
+    identityResolvers[0]("branch:project-1:main");
+    for (let index = 0; index < 10 && !refreshStarted; index++) await Promise.resolve();
+    assertEquals(refreshStarted, true);
+
+    const later = recover();
+    assertEquals(identityResolvers.length, 2);
+    resolveRefresh();
+    assertEquals(await first, true);
+    identityResolvers[1]("branch:project-1:main");
+    assertEquals(
+      await later,
+      true,
+      "a lookup that started during recovery must retry after that recovery completes",
+    );
+    assertEquals(sourceRefreshes, 1);
+  });
+
+  it("starts the recovery cooldown after the refresh completes", async () => {
+    using time = new FakeTime();
+    let sourceRefreshes = 0;
+    let refreshStarted = false;
+    let resolveRefresh!: () => void;
+    const refreshPromise = new Promise<void>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const adapter = {
+      fs: {
+        refreshSourceSnapshot: () => {
+          sourceRefreshes++;
+          refreshStarted = true;
+          return refreshPromise;
+        },
+      },
+    } as unknown as RuntimeAdapter;
+
+    const recover = () =>
+      recoverStaleMdxEsmPreviewCaches({
+        adapter,
+        projectDir: "/project",
+        projectId: "project-1",
+        contentSourceId: "preview-main",
+        slug: "probe",
+        pagePath: "/probe",
+        mode: "production",
+      });
+
+    const first = recover();
+    for (let index = 0; index < 10 && !refreshStarted; index++) await Promise.resolve();
+    assertEquals(refreshStarted, true);
+    time.tick(30_000);
+    resolveRefresh();
+    assertEquals(await first, true);
+
+    assertEquals(
+      await recover(),
+      false,
+      "a slow recovery must keep the full cooldown after it completes",
+    );
+    assertEquals(sourceRefreshes, 1);
+  });
+
+  it("falls back to adapter-scoped recovery when identity lookup rejects", async () => {
+    let sourceRefreshes = 0;
+    const adapter = {
+      fs: {
+        getSourceSnapshotIdentity: () => Promise.reject(new Error("identity unavailable")),
+        refreshSourceSnapshot: () => {
+          sourceRefreshes++;
+          return Promise.resolve();
+        },
+      },
+    } as unknown as RuntimeAdapter;
+
+    assertEquals(
+      await recoverStaleMdxEsmPreviewCaches({
+        adapter,
+        projectDir: "/project",
+        projectId: "project-1",
+        contentSourceId: "preview-main",
+        slug: "probe",
+        pagePath: "/probe",
+        mode: "production",
+      }),
+      true,
+    );
+    assertEquals(sourceRefreshes, 1);
+  });
+
   it("keeps a refreshed namespace from being evicted as the oldest tracked entry", async () => {
     using time = new FakeTime();
     let sourceRefreshes = 0;

--- a/src/rendering/page-rendering.test.ts
+++ b/src/rendering/page-rendering.test.ts
@@ -396,9 +396,9 @@ describe("rendering/page-rendering", () => {
     const fast = recover();
     assertEquals(identityResolvers.length, 2);
 
-    identityResolvers[1]("branch:project-1:main");
+    identityResolvers[1]!("branch:project-1:main");
     assertEquals(await fast, true);
-    identityResolvers[0]("branch:project-1:main");
+    identityResolvers[0]!("branch:project-1:main");
     assertEquals(
       await delayed,
       true,
@@ -440,7 +440,7 @@ describe("rendering/page-rendering", () => {
 
     const first = recover();
     assertEquals(identityResolvers.length, 1);
-    identityResolvers[0]("branch:project-1:main");
+    identityResolvers[0]!("branch:project-1:main");
     for (let index = 0; index < 10 && !refreshStarted; index++) await Promise.resolve();
     assertEquals(refreshStarted, true);
 
@@ -448,7 +448,7 @@ describe("rendering/page-rendering", () => {
     assertEquals(identityResolvers.length, 2);
     resolveRefresh();
     assertEquals(await first, true);
-    identityResolvers[1]("branch:project-1:main");
+    identityResolvers[1]!("branch:project-1:main");
     assertEquals(
       await later,
       true,

--- a/src/rendering/page-rendering.test.ts
+++ b/src/rendering/page-rendering.test.ts
@@ -8,6 +8,7 @@ import {
   assertStringIncludes,
 } from "#veryfront/testing/assert.ts";
 import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { FakeTime } from "#std/testing/time";
 import * as React from "react";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { type MDXLoadModuleOptions, mdxRenderer } from "#veryfront/transforms/mdx/index.ts";
@@ -16,6 +17,7 @@ import {
   __resetStaleMdxEsmRecoveryStateForTests,
   handleMDXPage,
   prepareMDXPageBundles,
+  recoverStaleMdxEsmPreviewCaches,
 } from "./page-rendering.ts";
 import { PageRenderer } from "./page-renderer.ts";
 import {
@@ -300,6 +302,62 @@ describe("rendering/page-rendering", () => {
     } finally {
       mutableRenderer.loadModuleESM = originalLoadModuleESM;
     }
+  });
+
+  it("keeps a refreshed namespace from being evicted as the oldest tracked entry", async () => {
+    using time = new FakeTime();
+    let sourceRefreshes = 0;
+
+    const adapter = {
+      fs: {
+        refreshSourceSnapshot: () => {
+          sourceRefreshes++;
+          return Promise.resolve();
+        },
+      },
+    } as unknown as RuntimeAdapter;
+
+    const recover = (contentSourceId: string) =>
+      recoverStaleMdxEsmPreviewCaches({
+        adapter,
+        projectSlug: "project-slug",
+        contentSourceId,
+        slug: "probe",
+        pagePath: "/probe",
+        mode: "production",
+      });
+
+    // "preview-hot" is tracked first, so with insertion-order eviction it is
+    // the head of the map even after a later recovery refreshes it.
+    assertEquals(await recover("preview-hot"), true);
+
+    // A second namespace stays young enough to survive the prune below, so the
+    // size cap has a genuinely older entry to evict.
+    time.tick(20_000);
+    assertEquals(await recover("preview-cold"), true);
+
+    // Past the cooldown, "preview-hot" recovers again and becomes the most
+    // recently used namespace.
+    time.tick(11_000);
+    assertEquals(await recover("preview-hot"), true);
+
+    // Fill the tracking map to its 512 namespace ceiling. The overflow must
+    // evict "preview-cold", not the namespace that just recovered.
+    for (let index = 0; index < 511; index++) {
+      assertEquals(await recover(`preview-filler-${index}`), true);
+    }
+
+    const refreshesBeforeReprobe = sourceRefreshes;
+    assertEquals(
+      await recover("preview-hot"),
+      false,
+      "the most recently recovered namespace must still be on cooldown after the size cap evicts",
+    );
+    assertEquals(
+      sourceRefreshes,
+      refreshesBeforeReprobe,
+      "an evicted cooldown entry would let the namespace refresh its source snapshot again immediately",
+    );
   });
 
   it("creates MDX elements with the requested project React version", async () => {

--- a/src/rendering/page-rendering.test.ts
+++ b/src/rendering/page-rendering.test.ts
@@ -304,6 +304,37 @@ describe("rendering/page-rendering", () => {
     }
   });
 
+  it("scopes recovery cooldowns and single-flight runs to the source snapshot identity", async () => {
+    let sourceRefreshes = 0;
+    const createAdapter = (identity: string): RuntimeAdapter => ({
+      fs: {
+        getSourceSnapshotIdentity: () => identity,
+        refreshSourceSnapshot: () => {
+          sourceRefreshes++;
+          return Promise.resolve();
+        },
+      },
+    } as unknown as RuntimeAdapter);
+
+    const recover = (adapter: RuntimeAdapter) =>
+      recoverStaleMdxEsmPreviewCaches({
+        adapter,
+        projectId: "project-1",
+        contentSourceId: "preview-main",
+        slug: "probe",
+        pagePath: "/probe",
+        mode: "production",
+      });
+
+    assertEquals(await recover(createAdapter("branch:project-1:principal-a")), true);
+    assertEquals(await recover(createAdapter("branch:project-1:principal-b")), true);
+    assertEquals(
+      sourceRefreshes,
+      2,
+      "distinct source snapshot identities must not share a recovery cooldown",
+    );
+  });
+
   it("keeps a refreshed namespace from being evicted as the oldest tracked entry", async () => {
     using time = new FakeTime();
     let sourceRefreshes = 0;

--- a/src/rendering/page-rendering.test.ts
+++ b/src/rendering/page-rendering.test.ts
@@ -12,7 +12,11 @@ import * as React from "react";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import { type MDXLoadModuleOptions, mdxRenderer } from "#veryfront/transforms/mdx/index.ts";
 import type { EntityInfo } from "#veryfront/types";
-import { handleMDXPage, prepareMDXPageBundles } from "./page-rendering.ts";
+import {
+  __resetStaleMdxEsmRecoveryStateForTests,
+  handleMDXPage,
+  prepareMDXPageBundles,
+} from "./page-rendering.ts";
 import { PageRenderer } from "./page-renderer.ts";
 import {
   __setServerModuleLoaderForTests,
@@ -40,6 +44,7 @@ describe("rendering/page-rendering", () => {
   afterEach(() => {
     resetReactCache();
     __setServerModuleLoaderForTests(null);
+    __resetStaleMdxEsmRecoveryStateForTests();
   });
 
   it("keeps SSR module code separate from the browser client bundle", async () => {
@@ -152,6 +157,145 @@ describe("rendering/page-rendering", () => {
         sourceRefreshes,
         0,
         "a render failure that is not an ESM export mismatch must not flush the preview source snapshot",
+      );
+    } finally {
+      mutableRenderer.loadModuleESM = originalLoadModuleESM;
+    }
+  });
+
+  it("does not recover preview caches for an immutable release content source", async () => {
+    const pageInfo = createMDXPageInfo("# MDX Probe");
+    const originalLoadModuleESM = mdxRenderer.loadModuleESM;
+    let loadAttempts = 0;
+    let sourceRefreshes = 0;
+
+    const adapter = {
+      fs: {
+        refreshSourceSnapshot: () => {
+          sourceRefreshes++;
+          return Promise.resolve();
+        },
+      },
+    } as unknown as RuntimeAdapter;
+
+    const mutableRenderer = mdxRenderer as unknown as {
+      loadModuleESM: typeof mdxRenderer.loadModuleESM;
+    };
+
+    mutableRenderer.loadModuleESM = () => {
+      loadAttempts++;
+      throw new Error(
+        "The requested module 'file:///cache/vfmod.mjs' does not provide an export named 'default'",
+      );
+    };
+
+    try {
+      const error = await assertRejects(
+        () =>
+          handleMDXPage(
+            pageInfo,
+            "probe",
+            "/project",
+            {},
+            () => Promise.resolve({ compiledCode: "", frontmatter: {}, headings: [] }),
+            adapter,
+            {
+              projectId: "project-release",
+              projectSlug: "project-slug",
+              contentSourceId: "release-abc123",
+              mode: "production",
+            },
+          ),
+        Error,
+        "Failed to import MDX page via ESM",
+      );
+      assertInstanceOf(error, Error);
+
+      assertEquals(
+        sourceRefreshes,
+        0,
+        "a released production source must never flush its source snapshot from a public render error",
+      );
+      assertEquals(
+        loadAttempts,
+        1,
+        "a released production source must not pay a cache-eviction retry for a render error",
+      );
+      assertEquals(
+        error.message.includes("after cache refresh"),
+        false,
+        "no recovery ran, so the failure must not be reported as a post-recovery failure",
+      );
+    } finally {
+      mutableRenderer.loadModuleESM = originalLoadModuleESM;
+    }
+  });
+
+  it("recovers a preview content source at most once per cooldown window", async () => {
+    const pageInfo = createMDXPageInfo("# MDX Probe");
+    const originalLoadModuleESM = mdxRenderer.loadModuleESM;
+    let loadAttempts = 0;
+    let sourceRefreshes = 0;
+
+    const adapter = {
+      fs: {
+        refreshSourceSnapshot: () => {
+          sourceRefreshes++;
+          return Promise.resolve();
+        },
+      },
+    } as unknown as RuntimeAdapter;
+
+    const mutableRenderer = mdxRenderer as unknown as {
+      loadModuleESM: typeof mdxRenderer.loadModuleESM;
+    };
+
+    mutableRenderer.loadModuleESM = () => {
+      loadAttempts++;
+      throw new Error(
+        "The requested module 'file:///cache/vfmod.mjs' does not provide an export named 'default'",
+      );
+    };
+
+    // No projectId, so the namespace purge is skipped and the case stays
+    // hermetic; the snapshot refresh alone proves whether recovery ran.
+    const renderOnce = () =>
+      assertRejects(
+        () =>
+          handleMDXPage(
+            pageInfo,
+            "probe",
+            "/project",
+            {},
+            () => Promise.resolve({ compiledCode: "", frontmatter: {}, headings: [] }),
+            adapter,
+            {
+              projectSlug: "project-slug",
+              contentSourceId: "preview-main",
+              mode: "production",
+            },
+          ),
+        Error,
+        "Failed to import MDX page via ESM",
+      );
+
+    try {
+      await renderOnce();
+      assertEquals(sourceRefreshes, 1, "the first preview failure must recover once");
+      assertEquals(loadAttempts, 2, "the first preview failure must retry once");
+
+      await renderOnce();
+      await renderOnce();
+
+      assertEquals(
+        sourceRefreshes,
+        1,
+        "a route that keeps failing must not refresh the source snapshot on every request",
+      );
+      assertEquals(
+        loadAttempts,
+        4,
+        "requests inside the cooldown must fail without paying a second recovery retry",
       );
     } finally {
       mutableRenderer.loadModuleESM = originalLoadModuleESM;

--- a/src/rendering/page-rendering.test.ts
+++ b/src/rendering/page-rendering.test.ts
@@ -18,7 +18,7 @@ import {
   handleMDXPage,
   prepareMDXPageBundles,
   recoverStaleMdxEsmPreviewCaches,
-} from "./page-rendering.ts";
+} from "#veryfront/rendering/page-rendering.ts";
 import { PageRenderer } from "./page-renderer.ts";
 import {
   __setServerModuleLoaderForTests,
@@ -319,6 +319,7 @@ describe("rendering/page-rendering", () => {
     const recover = (adapter: RuntimeAdapter) =>
       recoverStaleMdxEsmPreviewCaches({
         adapter,
+        projectDir: "/project",
         projectId: "project-1",
         contentSourceId: "preview-main",
         slug: "probe",
@@ -333,6 +334,77 @@ describe("rendering/page-rendering", () => {
       2,
       "distinct source snapshot identities must not share a recovery cooldown",
     );
+  });
+
+  it("does not share recovery cooldowns between identity-less adapters", async () => {
+    let sourceRefreshes = 0;
+    const createAdapter = (): RuntimeAdapter => ({
+      fs: {
+        refreshSourceSnapshot: () => {
+          sourceRefreshes++;
+          return Promise.resolve();
+        },
+      },
+    } as unknown as RuntimeAdapter);
+
+    const recover = (adapter: RuntimeAdapter) =>
+      recoverStaleMdxEsmPreviewCaches({
+        adapter,
+        projectDir: "/project",
+        projectId: "project-1",
+        contentSourceId: "preview-main",
+        slug: "probe",
+        pagePath: "/probe",
+        mode: "production",
+      });
+
+    assertEquals(await recover(createAdapter()), true);
+    assertEquals(await recover(createAdapter()), true);
+    assertEquals(
+      sourceRefreshes,
+      2,
+      "identity-less adapters must not share a process-global recovery cooldown",
+    );
+  });
+
+  it("lets a delayed identity lookup join a recovery that started after it", async () => {
+    let sourceRefreshes = 0;
+    const identityResolvers: Array<(identity: string) => void> = [];
+    const adapter = {
+      fs: {
+        getSourceSnapshotIdentity: () =>
+          new Promise<string>((resolve) => identityResolvers.push(resolve)),
+        refreshSourceSnapshot: () => {
+          sourceRefreshes++;
+          return Promise.resolve();
+        },
+      },
+    } as unknown as RuntimeAdapter;
+
+    const recover = () =>
+      recoverStaleMdxEsmPreviewCaches({
+        adapter,
+        projectDir: "/project",
+        projectId: "project-1",
+        contentSourceId: "preview-main",
+        slug: "probe",
+        pagePath: "/probe",
+        mode: "production",
+      });
+
+    const delayed = recover();
+    const fast = recover();
+    assertEquals(identityResolvers.length, 2);
+
+    identityResolvers[1]("branch:project-1:main");
+    assertEquals(await fast, true);
+    identityResolvers[0]("branch:project-1:main");
+    assertEquals(
+      await delayed,
+      true,
+      "a request already waiting for its key must retry after a newer recovery succeeds",
+    );
+    assertEquals(sourceRefreshes, 1);
   });
 
   it("keeps a refreshed namespace from being evicted as the oldest tracked entry", async () => {
@@ -351,6 +423,7 @@ describe("rendering/page-rendering", () => {
     const recover = (contentSourceId: string) =>
       recoverStaleMdxEsmPreviewCaches({
         adapter,
+        projectDir: "/project",
         projectSlug: "project-slug",
         contentSourceId,
         slug: "probe",

--- a/src/rendering/page-rendering.ts
+++ b/src/rendering/page-rendering.ts
@@ -45,8 +45,19 @@ const STALE_MDX_ESM_RECOVERY_MAX_TRACKED_NAMESPACES = 512;
 
 /** Namespace key -> epoch ms at which its last recovery started. */
 const staleMdxEsmRecoveryAttempts = new Map<string, number>();
+
+/**
+ * Holder for one in-flight recovery. The promise is wrapped so the map stores a
+ * plain identity token: the `finally` block below compares the stored entry
+ * against the one it created, and comparing a wrapper keeps that check from
+ * reading as a forgotten `await` on a bare promise.
+ */
+interface StaleMdxEsmRecoveryRun {
+  promise: Promise<boolean>;
+}
+
 /** Namespace key -> in-flight recovery, so concurrent renders share one pass. */
-const staleMdxEsmRecoveryInFlight = new Map<string, Promise<boolean>>();
+const staleMdxEsmRecoveryInFlight = new Map<string, StaleMdxEsmRecoveryRun>();
 
 // HEURISTIC: detect stale-cache ESM export mismatches by matching runtime
 // error messages. Both the "does not provide an export named" phrasing and the
@@ -62,7 +73,7 @@ export function isMdxEsmExportMismatchError(error: unknown): boolean {
 
 /**
  * Stale-cache recovery is a PREVIEW affordance: only a mutable content source
- * — a local checkout or a branch preview — can drift out of step with the ESM
+ * (a local checkout or a branch preview) can drift out of step with the ESM
  * modules compiled and cached for it. An immutable release source that raises
  * the same error is serving a genuinely broken build, and the message match is
  * a heuristic that user code (including generateMetadata) can produce, so
@@ -152,7 +163,7 @@ export async function recoverStaleMdxEsmPreviewCaches(
 
   const key = getStaleMdxEsmRecoveryKey(options);
   const inFlight = staleMdxEsmRecoveryInFlight.get(key);
-  if (inFlight) return await inFlight;
+  if (inFlight) return await inFlight.promise;
 
   const now = Date.now();
   const attemptedAt = staleMdxEsmRecoveryAttempts.get(key);
@@ -169,14 +180,19 @@ export async function recoverStaleMdxEsmPreviewCaches(
     return false;
   }
 
+  // Delete before re-inserting so a refreshed key moves to the end of the map.
+  // Map iteration order is fixed at first insert, so a plain `set` on an
+  // existing key would leave the most recently recovered namespace sitting at
+  // the head of the size-cap eviction order below.
+  staleMdxEsmRecoveryAttempts.delete(key);
   staleMdxEsmRecoveryAttempts.set(key, now);
   pruneStaleMdxEsmRecoveryAttempts(now);
 
-  const recovery = performStaleMdxEsmRecovery(options);
+  const recovery: StaleMdxEsmRecoveryRun = { promise: performStaleMdxEsmRecovery(options) };
   staleMdxEsmRecoveryInFlight.set(key, recovery);
 
   try {
-    return await recovery;
+    return await recovery.promise;
   } finally {
     if (staleMdxEsmRecoveryInFlight.get(key) === recovery) {
       staleMdxEsmRecoveryInFlight.delete(key);

--- a/src/rendering/page-rendering.ts
+++ b/src/rendering/page-rendering.ts
@@ -45,10 +45,10 @@ const STALE_MDX_ESM_RECOVERY_COOLDOWN_MS = 30_000;
 /** Ceiling on remembered namespaces, so the cooldown map cannot grow without bound. */
 const STALE_MDX_ESM_RECOVERY_MAX_TRACKED_NAMESPACES = 512;
 
-/** Namespace key -> epoch ms at which its last recovery started. */
+/** Namespace key -> epoch ms at which its last recovery completed or was attempted. */
 const staleMdxEsmRecoveryAttempts = new Map<string, number>();
-/** Key -> request sequence that most recently completed recovery successfully. */
-const staleMdxEsmRecoveryCompletedBy = new Map<string, number>();
+/** Key -> latest request sequence that was already in flight when recovery completed. */
+const staleMdxEsmRecoveryCompletedThrough = new Map<string, number>();
 /** Each recovery request gets an order so delayed identity lookups can join a newer pass. */
 let nextStaleMdxEsmRecoveryRequestSequence = 0;
 
@@ -114,7 +114,15 @@ async function getStaleMdxEsmRecoveryKey(
   const namespace = options.projectId ?? options.projectSlug ?? options.projectDir;
   if (!namespace) return undefined;
 
-  const sourceSnapshotIdentity = await options.adapter.fs.getSourceSnapshotIdentity?.();
+  let sourceSnapshotIdentity: string | undefined;
+  try {
+    sourceSnapshotIdentity = await options.adapter.fs.getSourceSnapshotIdentity?.();
+  } catch {
+    // An unavailable identity must not replace the original render error or
+    // prevent cache-only recovery. The per-adapter fallback still isolates the
+    // recovery state from other identity-less adapters.
+    sourceSnapshotIdentity = undefined;
+  }
   let adapterIdentity = sourceSnapshotIdentity;
   if (adapterIdentity === undefined) {
     const fs = options.adapter.fs as object;
@@ -133,7 +141,7 @@ function pruneStaleMdxEsmRecoveryAttempts(now: number): void {
   for (const [key, attemptedAt] of staleMdxEsmRecoveryAttempts) {
     if (now - attemptedAt >= STALE_MDX_ESM_RECOVERY_COOLDOWN_MS) {
       staleMdxEsmRecoveryAttempts.delete(key);
-      staleMdxEsmRecoveryCompletedBy.delete(key);
+      staleMdxEsmRecoveryCompletedThrough.delete(key);
     }
   }
 
@@ -142,7 +150,7 @@ function pruneStaleMdxEsmRecoveryAttempts(now: number): void {
     const oldest = staleMdxEsmRecoveryAttempts.keys().next();
     if (oldest.done) break;
     staleMdxEsmRecoveryAttempts.delete(oldest.value);
-    staleMdxEsmRecoveryCompletedBy.delete(oldest.value);
+    staleMdxEsmRecoveryCompletedThrough.delete(oldest.value);
   }
 }
 
@@ -201,8 +209,8 @@ export async function recoverStaleMdxEsmPreviewCaches(
   // A negative delta means the wall clock stepped backwards; treat it as
   // "still cooling down" rather than handing out an unbounded retry budget.
   if (attemptedAt !== undefined && now - attemptedAt < STALE_MDX_ESM_RECOVERY_COOLDOWN_MS) {
-    const completedBy = staleMdxEsmRecoveryCompletedBy.get(key);
-    if (completedBy !== undefined && completedBy >= requestSequence) return true;
+    const completedThrough = staleMdxEsmRecoveryCompletedThrough.get(key);
+    if (completedThrough !== undefined && completedThrough >= requestSequence) return true;
 
     logger.debug("Skipping stale MDX ESM cache recovery still within its cooldown", {
       slug: options.slug,
@@ -227,7 +235,19 @@ export async function recoverStaleMdxEsmPreviewCaches(
 
   try {
     const recovered = await recovery.promise;
-    if (recovered) staleMdxEsmRecoveryCompletedBy.set(key, requestSequence);
+    if (recovered) {
+      // Start the cooldown after the expensive refresh/purge completes. This
+      // also records every request sequence that was already pending, so a
+      // slower identity lookup can still join this completed recovery.
+      const completedAt = Date.now();
+      staleMdxEsmRecoveryAttempts.delete(key);
+      staleMdxEsmRecoveryAttempts.set(key, completedAt);
+      staleMdxEsmRecoveryCompletedThrough.set(
+        key,
+        nextStaleMdxEsmRecoveryRequestSequence,
+      );
+      pruneStaleMdxEsmRecoveryAttempts(completedAt);
+    }
     return recovered;
   } finally {
     if (staleMdxEsmRecoveryInFlight.get(key) === recovery) {
@@ -239,7 +259,7 @@ export async function recoverStaleMdxEsmPreviewCaches(
 /** Test-only: drop the recovery cooldown so cases do not leak into each other. */
 export function __resetStaleMdxEsmRecoveryStateForTests(): void {
   staleMdxEsmRecoveryAttempts.clear();
-  staleMdxEsmRecoveryCompletedBy.clear();
+  staleMdxEsmRecoveryCompletedThrough.clear();
   staleMdxEsmRecoveryInFlight.clear();
   nextStaleMdxEsmRecoveryRequestSequence = 0;
 }

--- a/src/rendering/page-rendering.ts
+++ b/src/rendering/page-rendering.ts
@@ -98,9 +98,12 @@ export function isMutableMdxEsmContentSource(
     contentSourceId.startsWith("local-");
 }
 
-function getStaleMdxEsmRecoveryKey(options: StaleMdxEsmRecoveryOptions): string {
+async function getStaleMdxEsmRecoveryKey(
+  options: StaleMdxEsmRecoveryOptions,
+): Promise<string> {
   const namespace = options.projectId ?? options.projectSlug ?? "";
-  return `${namespace}::${options.contentSourceId ?? ""}`;
+  const sourceSnapshotIdentity = await options.adapter.fs.getSourceSnapshotIdentity?.();
+  return `${namespace}::${options.contentSourceId ?? ""}::${sourceSnapshotIdentity ?? ""}`;
 }
 
 function pruneStaleMdxEsmRecoveryAttempts(now: number): void {
@@ -161,7 +164,7 @@ export async function recoverStaleMdxEsmPreviewCaches(
     return false;
   }
 
-  const key = getStaleMdxEsmRecoveryKey(options);
+  const key = await getStaleMdxEsmRecoveryKey(options);
   const inFlight = staleMdxEsmRecoveryInFlight.get(key);
   if (inFlight) return await inFlight.promise;
 

--- a/src/rendering/page-rendering.ts
+++ b/src/rendering/page-rendering.ts
@@ -29,7 +29,24 @@ interface StaleMdxEsmRecoveryOptions {
   contentSourceId?: string;
   slug: string;
   pagePath: string;
+  /** Render mode of the failing request ("development" | "production"). */
+  mode?: string;
 }
+
+/**
+ * A recovered namespace stays on cooldown for this long. Recovery deletes the
+ * project's whole MDX ESM cache namespace and forces a source-snapshot
+ * refresh, so a route whose error survives the retry must not be able to pay
+ * that cost again on the very next request.
+ */
+const STALE_MDX_ESM_RECOVERY_COOLDOWN_MS = 30_000;
+/** Ceiling on remembered namespaces, so the cooldown map cannot grow without bound. */
+const STALE_MDX_ESM_RECOVERY_MAX_TRACKED_NAMESPACES = 512;
+
+/** Namespace key -> epoch ms at which its last recovery started. */
+const staleMdxEsmRecoveryAttempts = new Map<string, number>();
+/** Namespace key -> in-flight recovery, so concurrent renders share one pass. */
+const staleMdxEsmRecoveryInFlight = new Map<string, Promise<boolean>>();
 
 // HEURISTIC: detect stale-cache ESM export mismatches by matching runtime
 // error messages. Both the "does not provide an export named" phrasing and the
@@ -43,7 +60,54 @@ export function isMdxEsmExportMismatchError(error: unknown): boolean {
     /requested module|import/i.test(message);
 }
 
-export async function recoverStaleMdxEsmPreviewCaches(
+/**
+ * Stale-cache recovery is a PREVIEW affordance: only a mutable content source
+ * — a local checkout or a branch preview — can drift out of step with the ESM
+ * modules compiled and cached for it. An immutable release source that raises
+ * the same error is serving a genuinely broken build, and the message match is
+ * a heuristic that user code (including generateMetadata) can produce, so
+ * recovering there would let every unauthenticated public request evict the
+ * project's entire MDX ESM cache namespace and force a backend source-snapshot
+ * refresh plus a full module rebuild. Classification mirrors
+ * `computeContentSourceId`, the single source of truth for these ids, and
+ * fails closed for an id it does not recognize.
+ */
+export function isMutableMdxEsmContentSource(
+  contentSourceId: string | undefined,
+  mode?: string,
+): boolean {
+  // A development-mode render is the local dev server, whose sources are
+  // mutable files on disk even when no content source id is threaded through.
+  if (mode === "development") return true;
+  if (!contentSourceId) return false;
+
+  return contentSourceId === "preview" ||
+    contentSourceId === "preview-draft" ||
+    contentSourceId.startsWith("preview-") ||
+    contentSourceId.startsWith("local-");
+}
+
+function getStaleMdxEsmRecoveryKey(options: StaleMdxEsmRecoveryOptions): string {
+  const namespace = options.projectId ?? options.projectSlug ?? "";
+  return `${namespace}::${options.contentSourceId ?? ""}`;
+}
+
+function pruneStaleMdxEsmRecoveryAttempts(now: number): void {
+  for (const [key, attemptedAt] of staleMdxEsmRecoveryAttempts) {
+    if (now - attemptedAt >= STALE_MDX_ESM_RECOVERY_COOLDOWN_MS) {
+      staleMdxEsmRecoveryAttempts.delete(key);
+    }
+  }
+
+  // Map iteration is insertion ordered, so the first key is the oldest entry.
+  while (staleMdxEsmRecoveryAttempts.size > STALE_MDX_ESM_RECOVERY_MAX_TRACKED_NAMESPACES) {
+    const oldest = staleMdxEsmRecoveryAttempts.keys().next();
+    if (oldest.done) break;
+    staleMdxEsmRecoveryAttempts.delete(oldest.value);
+  }
+}
+
+async function performStaleMdxEsmRecovery(
   options: StaleMdxEsmRecoveryOptions,
 ): Promise<boolean> {
   let recovered = false;
@@ -70,6 +134,60 @@ export async function recoverStaleMdxEsmPreviewCaches(
   }
 
   return recovered;
+}
+
+export async function recoverStaleMdxEsmPreviewCaches(
+  options: StaleMdxEsmRecoveryOptions,
+): Promise<boolean> {
+  if (!isMutableMdxEsmContentSource(options.contentSourceId, options.mode)) {
+    logger.debug("Skipping stale MDX ESM cache recovery for an immutable content source", {
+      slug: options.slug,
+      pagePath: options.pagePath,
+      projectId: options.projectId,
+      projectSlug: options.projectSlug,
+      contentSourceId: options.contentSourceId,
+    });
+    return false;
+  }
+
+  const key = getStaleMdxEsmRecoveryKey(options);
+  const inFlight = staleMdxEsmRecoveryInFlight.get(key);
+  if (inFlight) return await inFlight;
+
+  const now = Date.now();
+  const attemptedAt = staleMdxEsmRecoveryAttempts.get(key);
+  // A negative delta means the wall clock stepped backwards; treat it as
+  // "still cooling down" rather than handing out an unbounded retry budget.
+  if (attemptedAt !== undefined && now - attemptedAt < STALE_MDX_ESM_RECOVERY_COOLDOWN_MS) {
+    logger.debug("Skipping stale MDX ESM cache recovery still within its cooldown", {
+      slug: options.slug,
+      pagePath: options.pagePath,
+      projectId: options.projectId,
+      projectSlug: options.projectSlug,
+      contentSourceId: options.contentSourceId,
+    });
+    return false;
+  }
+
+  staleMdxEsmRecoveryAttempts.set(key, now);
+  pruneStaleMdxEsmRecoveryAttempts(now);
+
+  const recovery = performStaleMdxEsmRecovery(options);
+  staleMdxEsmRecoveryInFlight.set(key, recovery);
+
+  try {
+    return await recovery;
+  } finally {
+    if (staleMdxEsmRecoveryInFlight.get(key) === recovery) {
+      staleMdxEsmRecoveryInFlight.delete(key);
+    }
+  }
+}
+
+/** Test-only: drop the recovery cooldown so cases do not leak into each other. */
+export function __resetStaleMdxEsmRecoveryStateForTests(): void {
+  staleMdxEsmRecoveryAttempts.clear();
+  staleMdxEsmRecoveryInFlight.clear();
 }
 
 export async function prepareMDXPageBundles(
@@ -256,6 +374,7 @@ export function handleMDXPage(
               contentSourceId: options?.contentSourceId,
               slug,
               pagePath: path,
+              mode: options?.mode,
             });
           } catch (recoveryError) {
             logger.warn("Failed to recover stale MDX ESM preview caches", {

--- a/src/rendering/page-rendering.ts
+++ b/src/rendering/page-rendering.ts
@@ -24,6 +24,8 @@ interface PreparedMDXPageBundles {
 
 interface StaleMdxEsmRecoveryOptions {
   adapter: RuntimeAdapter;
+  /** Stable filesystem identity used when projectId and projectSlug are absent. */
+  projectDir: string;
   projectId?: string;
   projectSlug?: string;
   contentSourceId?: string;
@@ -45,6 +47,14 @@ const STALE_MDX_ESM_RECOVERY_MAX_TRACKED_NAMESPACES = 512;
 
 /** Namespace key -> epoch ms at which its last recovery started. */
 const staleMdxEsmRecoveryAttempts = new Map<string, number>();
+/** Key -> request sequence that most recently completed recovery successfully. */
+const staleMdxEsmRecoveryCompletedBy = new Map<string, number>();
+/** Each recovery request gets an order so delayed identity lookups can join a newer pass. */
+let nextStaleMdxEsmRecoveryRequestSequence = 0;
+
+/** Identity-less adapters still need distinct recovery state. */
+const staleMdxEsmAdapterIds = new WeakMap<object, number>();
+let nextStaleMdxEsmAdapterId = 0;
 
 /**
  * Holder for one in-flight recovery. The promise is wrapped so the map stores a
@@ -100,16 +110,30 @@ export function isMutableMdxEsmContentSource(
 
 async function getStaleMdxEsmRecoveryKey(
   options: StaleMdxEsmRecoveryOptions,
-): Promise<string> {
-  const namespace = options.projectId ?? options.projectSlug ?? "";
+): Promise<string | undefined> {
+  const namespace = options.projectId ?? options.projectSlug ?? options.projectDir;
+  if (!namespace) return undefined;
+
   const sourceSnapshotIdentity = await options.adapter.fs.getSourceSnapshotIdentity?.();
-  return `${namespace}::${options.contentSourceId ?? ""}::${sourceSnapshotIdentity ?? ""}`;
+  let adapterIdentity = sourceSnapshotIdentity;
+  if (adapterIdentity === undefined) {
+    const fs = options.adapter.fs as object;
+    let adapterId = staleMdxEsmAdapterIds.get(fs);
+    if (adapterId === undefined) {
+      adapterId = ++nextStaleMdxEsmAdapterId;
+      staleMdxEsmAdapterIds.set(fs, adapterId);
+    }
+    adapterIdentity = `identity-less-adapter-${adapterId}`;
+  }
+
+  return `${namespace}::${options.contentSourceId ?? ""}::${adapterIdentity}`;
 }
 
 function pruneStaleMdxEsmRecoveryAttempts(now: number): void {
   for (const [key, attemptedAt] of staleMdxEsmRecoveryAttempts) {
     if (now - attemptedAt >= STALE_MDX_ESM_RECOVERY_COOLDOWN_MS) {
       staleMdxEsmRecoveryAttempts.delete(key);
+      staleMdxEsmRecoveryCompletedBy.delete(key);
     }
   }
 
@@ -118,6 +142,7 @@ function pruneStaleMdxEsmRecoveryAttempts(now: number): void {
     const oldest = staleMdxEsmRecoveryAttempts.keys().next();
     if (oldest.done) break;
     staleMdxEsmRecoveryAttempts.delete(oldest.value);
+    staleMdxEsmRecoveryCompletedBy.delete(oldest.value);
   }
 }
 
@@ -164,7 +189,10 @@ export async function recoverStaleMdxEsmPreviewCaches(
     return false;
   }
 
+  const requestSequence = ++nextStaleMdxEsmRecoveryRequestSequence;
   const key = await getStaleMdxEsmRecoveryKey(options);
+  if (key === undefined) return false;
+
   const inFlight = staleMdxEsmRecoveryInFlight.get(key);
   if (inFlight) return await inFlight.promise;
 
@@ -173,6 +201,9 @@ export async function recoverStaleMdxEsmPreviewCaches(
   // A negative delta means the wall clock stepped backwards; treat it as
   // "still cooling down" rather than handing out an unbounded retry budget.
   if (attemptedAt !== undefined && now - attemptedAt < STALE_MDX_ESM_RECOVERY_COOLDOWN_MS) {
+    const completedBy = staleMdxEsmRecoveryCompletedBy.get(key);
+    if (completedBy !== undefined && completedBy >= requestSequence) return true;
+
     logger.debug("Skipping stale MDX ESM cache recovery still within its cooldown", {
       slug: options.slug,
       pagePath: options.pagePath,
@@ -195,7 +226,9 @@ export async function recoverStaleMdxEsmPreviewCaches(
   staleMdxEsmRecoveryInFlight.set(key, recovery);
 
   try {
-    return await recovery.promise;
+    const recovered = await recovery.promise;
+    if (recovered) staleMdxEsmRecoveryCompletedBy.set(key, requestSequence);
+    return recovered;
   } finally {
     if (staleMdxEsmRecoveryInFlight.get(key) === recovery) {
       staleMdxEsmRecoveryInFlight.delete(key);
@@ -206,7 +239,9 @@ export async function recoverStaleMdxEsmPreviewCaches(
 /** Test-only: drop the recovery cooldown so cases do not leak into each other. */
 export function __resetStaleMdxEsmRecoveryStateForTests(): void {
   staleMdxEsmRecoveryAttempts.clear();
+  staleMdxEsmRecoveryCompletedBy.clear();
   staleMdxEsmRecoveryInFlight.clear();
+  nextStaleMdxEsmRecoveryRequestSequence = 0;
 }
 
 export async function prepareMDXPageBundles(
@@ -388,6 +423,7 @@ export function handleMDXPage(
           try {
             recovered = await recoverStaleMdxEsmPreviewCaches({
               adapter,
+              projectDir,
               projectId: options?.projectId,
               projectSlug: options?.projectSlug,
               contentSourceId: options?.contentSourceId,

--- a/tests/integration/renderer/mdx-esm-stale-export-refresh.test.ts
+++ b/tests/integration/renderer/mdx-esm-stale-export-refresh.test.ts
@@ -15,7 +15,10 @@ import { exists, mkdir, remove, writeTextFile } from "#veryfront/compat/fs.ts";
 import type { RuntimeAdapter } from "#veryfront/platform/adapters/base.ts";
 import type { EntityInfo } from "#veryfront/types";
 import { mdxRenderer } from "#veryfront/transforms/mdx/index.ts";
-import { handleMDXPage } from "#veryfront/rendering/page-rendering.ts";
+import {
+  __resetStaleMdxEsmRecoveryStateForTests,
+  handleMDXPage,
+} from "#veryfront/rendering/page-rendering.ts";
 import {
   __setServerModuleLoaderForTests,
   resetReactCache,
@@ -47,6 +50,7 @@ describe("rendering/page-rendering preview ESM cache recovery", () => {
   afterEach(() => {
     resetReactCache();
     __setServerModuleLoaderForTests(null);
+    __resetStaleMdxEsmRecoveryStateForTests();
   });
 
   it("refreshes preview caches and retries once when MDX ESM imports have stale exports", async () => {


### PR DESCRIPTION
## Vulnerability

The stale-MDX recovery path added in `9d4cd8e` is named and documented as *preview* recovery, but neither the error detector nor its two call sites checked that the request was actually a preview render. `isMdxEsmExportMismatchError` matches only on an error-message regex — a self-described heuristic that ordinary user code, including a throwing `generateMetadata`, can produce — and both `handleMDXPage` (`src/rendering/page-rendering.ts`) and `RenderPipeline.renderPage` (`src/rendering/orchestrator/pipeline.ts`, which has render-mode guards elsewhere but not here) invoked `recoverStaleMdxEsmPreviewCaches` unconditionally on a match. Recovery then called `adapter.fs.refreshSourceSnapshot` (whose public form on the hosted veryfront FS adapter has no source-type guard, unlike the branch-only `ensureSourceSnapshotFresh`) and `clearMdxEsmCacheNamespace`, which recursively deletes the entire `{projectId}/{contentSourceId}` disk cache namespace plus the in-memory module caches. There was no cooldown, throttle, or cross-request single-flight around any of it, and no negative caching of the failing render to break the loop. On any released production route that persistently yields the matched message — a broken import that shipped, or user-code errors whose message matches the loose regex — every unauthenticated public request evicted the project's hot MDX ESM transform cache and forced a backend source-snapshot refresh plus a full module rebuild: an unauthenticated cache-eviction and load-amplification DoS that degrades every page of the project and adds backend load.

- Codex finding id: `f66efef043ac8191928143cc370cc32d`
- Severity: medium

## Fix

- `recoverStaleMdxEsmPreviewCaches` now runs only for a **mutable** content source. `isMutableMdxEsmContentSource` classifies the `contentSourceId` using the same vocabulary `computeContentSourceId` owns as the single source of truth (`local-*`, `preview-*`, plus the legacy `preview` / `preview-draft` values that the cache registry already recognizes), and additionally allows `mode === "development"`, whose sources are mutable files on the local dev server even when no content source id is threaded through. An id it does not recognize fails closed. An immutable `release-*` source that raises the same error is serving a genuinely broken build, so it gets the error rather than a cache purge.
- Both call sites now thread the render mode into the recovery options (`options?.mode` in `handleMDXPage`, `this.config.mode` in `RenderPipeline.renderPage`).
- Added a per-`(projectId, contentSourceId)` single-flight plus a 30s cooldown, so a route that keeps failing after its retry cannot buy a fresh namespace purge and snapshot refresh on the very next request. The cooldown map prunes expired entries and is capped at 512 namespaces, so it cannot grow without bound; a backward wall-clock step is treated as "still cooling down" rather than as an unbounded retry budget.

No behavior change for the case the path was built for: a branch preview still refreshes its snapshot, purges its namespace, and retries once.

## Test evidence

New regression tests, each verified to fail against the unfixed code (temporarily bypassing the new gate made all three fail) and to pass with the fix:

- `src/rendering/page-rendering.test.ts` — "does not recover preview caches for an immutable release content source": an export-mismatch error on `release-abc123` performs no snapshot refresh and no retry.
- `src/rendering/page-rendering.test.ts` — "recovers a preview content source at most once per cooldown window": three consecutive failing preview renders produce exactly one snapshot refresh and one recovery retry.
- `src/rendering/orchestrator/pipeline.behavior.test.ts` — "renderPage does not recover caches for a released production content source": covers the pipeline call site directly.

Existing coverage kept green, including the intended-path cases `tests/integration/renderer/mdx-esm-stale-export-refresh.test.ts` and "renderPage refreshes preview caches and retries stale MDX ESM export mismatches".

Commands run in the worktree:

- `deno fmt --check` on the five touched files — clean
- `DENO_NO_PACKAGE_JSON=1 deno lint src/rendering tests/integration/renderer` — 279 files, clean
- `deno check src/rendering/index.ts src/rendering/page-rendering.ts src/rendering/orchestrator/pipeline.ts` — clean
- `deno task test:file src/rendering` — **112 passed (2083 steps), 0 failed**
- `deno task test:file tests/integration/renderer/mdx-esm-stale-export-refresh.test.ts` — 1 passed, 0 failed

## Follow-up

`veryfront-api` pins `veryfront@0.1.1255`, which carries the unfixed code; that pin needs a bump to the release containing this fix. That bump is out of scope for this PR.

https://claude.ai/code/session_01QfWNMiUhvWMKWi6BGfVdY3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preview recovery for stale MDX modules by using the configured content source when no request-level override is provided.
  - Prevented recovery attempts for released production content, avoiding unnecessary retries and source refreshes.
  - Limited duplicate recovery attempts during concurrent requests and within a short cooldown window.
  - Improved recovery tracking across preview snapshots to reduce stale-cache issues while retaining recently refreshed content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->