### PR TITLE
fix(security): bound Moonshot tool schema $ref inlining

### DIFF
--- a/src/agent/runtime/model-tool-converter.test.ts
+++ b/src/agent/runtime/model-tool-converter.test.ts
@@ -13,6 +13,14 @@ function containsKey(value: unknown, key: string): boolean {
   return Object.values(value).some((item) => containsKey(item, key));
 }
 
+function countNodes(value: unknown): number {
+  if (Array.isArray(value)) {
+    return value.reduce<number>((total, item) => total + countNodes(item), 1);
+  }
+  if (!value || typeof value !== "object") return 1;
+  return Object.values(value).reduce<number>((total, item) => total + countNodes(item), 1);
+}
+
 function getRuntimeToolSchema(tool: unknown): unknown {
   if (!tool || typeof tool !== "object" || !("inputSchema" in tool)) return undefined;
   const inputSchema = (tool as { inputSchema?: unknown }).inputSchema;
@@ -455,6 +463,42 @@ describe("model-tool-converter", () => {
     assertEquals(properties.acceptance_criteria?.$ref, "#/$defs/acceptanceCriteria");
     assertEquals(schema.definitions, undefined);
     assertEquals(defs.acceptanceCriteria?.type, "array");
+  });
+
+  it("bounds Moonshot ref expansion across the whole tool set", () => {
+    // A per-schema budget bounds one tool in isolation. A remote MCP source may return
+    // hundreds of individually-admissible schemas, so the conversion pass has to share
+    // one expansion budget or the worst case is multiplied by the tool count.
+    const levelCount = 15;
+    const properties: Record<string, unknown> = {
+      [`level${levelCount}`]: { type: "string" },
+    };
+    for (let level = levelCount - 1; level >= 0; level -= 1) {
+      properties[`level${level}`] = {
+        type: "object",
+        properties: {
+          left: { $ref: `#/properties/level${level + 1}` },
+          right: { $ref: `#/properties/level${level + 1}` },
+        },
+      };
+    }
+
+    const tools = Array.from({ length: 50 }, (_unused, index) => ({
+      name: `fan_out_${index}`,
+      description: "Fan-out ref schema",
+      parameters: { type: "object", properties },
+    }));
+
+    const result = convertToolsToRuntimeTools(tools as never, {
+      model: "veryfront-cloud/moonshotai/kimi-k2.6",
+    });
+
+    let totalNodes = 0;
+    for (let index = 0; index < tools.length; index += 1) {
+      totalNodes += countNodes(getRuntimeToolSchema(result?.[`fan_out_${index}`]));
+    }
+
+    assertEquals(totalNodes < 400_000, true);
   });
 
   it("normalizes short Kimi alias runtime tool schemas", () => {

--- a/src/agent/runtime/model-tool-converter.ts
+++ b/src/agent/runtime/model-tool-converter.ts
@@ -23,6 +23,7 @@ import {
   createOpenAIWebSearchToolSet,
 } from "./provider-native-tools.ts";
 import {
+  createMoonshotSchemaExpansionBudget,
   normalizeProviderToolInputSchema,
   sanitizeProviderToolSchema,
   selectProviderCompatibleTools,
@@ -82,6 +83,10 @@ export function convertToolsToRuntimeTools(
   const compatibleTools = selectProviderCompatibleTools(tools, {
     model: options?.model,
   });
+  // One budget for the whole tool set: a per-schema cap bounds each tool in isolation,
+  // but a source advertising hundreds of admissible schemas would otherwise multiply
+  // the worst-case `$ref` expansion by the tool count.
+  const moonshotExpansionBudget = createMoonshotSchemaExpansionBudget();
 
   for (const def of compatibleTools) {
     if (providerNativeToolNames.has(def.name)) {
@@ -95,6 +100,7 @@ export function convertToolsToRuntimeTools(
         inputSchema: createRuntimeJsonSchema(
           sanitizeProviderToolSchema(normalizeProviderToolInputSchema(def.parameters), {
             model: options?.model,
+            moonshotExpansionBudget,
           }),
         ),
       }),

--- a/src/agent/runtime/provider-tool-compat.test.ts
+++ b/src/agent/runtime/provider-tool-compat.test.ts
@@ -369,6 +369,23 @@ describe("provider-tool-compat", () => {
     assertEquals(JSON.stringify(sanitized).includes("#/properties/level"), true);
   });
 
+  it("charges Moonshot expansion for JSON-escaped and multi-byte description bytes", () => {
+    // A NUL serializes to the six-byte escape "\\u0000", so character length undercounts
+    // the payload sixfold; counting characters would let this expand past the byte cap.
+    const escaped = sanitizeProviderToolSchema(
+      buildFanOutRefSchema(15, "\u0000".repeat(2_000)) as never,
+      { model: "veryfront-cloud/moonshotai/kimi-k2.6" },
+    );
+    assertEquals(JSON.stringify(escaped).length < 1_000_000, true);
+
+    // Non-ASCII text costs up to four UTF-8 bytes per code point for the same reason.
+    const multiByte = sanitizeProviderToolSchema(
+      buildFanOutRefSchema(15, "\u{1f600}".repeat(2_000)) as never,
+      { model: "veryfront-cloud/moonshotai/kimi-k2.6" },
+    );
+    assertEquals(JSON.stringify(multiByte).length < 1_000_000, true);
+  });
+
   it("bounds Moonshot ref inlining across a whole tool set", () => {
     // A per-schema budget bounds one tool; a source returning many admissible schemas
     // would otherwise multiply the worst case by the tool count.

--- a/src/agent/runtime/provider-tool-compat.test.ts
+++ b/src/agent/runtime/provider-tool-compat.test.ts
@@ -17,6 +17,14 @@ function dummyTool(name: string): ToolDefinition {
   };
 }
 
+function countNodes(value: unknown): number {
+  if (Array.isArray(value)) {
+    return value.reduce<number>((total, item) => total + countNodes(item), 1);
+  }
+  if (!value || typeof value !== "object") return 1;
+  return Object.values(value).reduce<number>((total, item) => total + countNodes(item), 1);
+}
+
 function containsKey(value: unknown, key: string): boolean {
   if (!value || typeof value !== "object") return false;
   if (Object.hasOwn(value, key)) return true;
@@ -304,6 +312,33 @@ describe("provider-tool-compat", () => {
     assertEquals(properties.acceptance_criteria?.$ref, undefined);
     assertEquals(properties.acceptance_criteria?.type, "array");
     assertEquals(JSON.stringify(sanitized).includes("#/properties/"), false);
+  });
+
+  it("bounds Moonshot ref inlining for fan-out ref chains", () => {
+    const levelCount = 40;
+    const properties: Record<string, unknown> = {
+      [`level${levelCount}`]: { type: "string" },
+    };
+    for (let level = levelCount - 1; level >= 0; level -= 1) {
+      properties[`level${level}`] = {
+        type: "object",
+        properties: {
+          left: { $ref: `#/properties/level${level + 1}` },
+          right: { $ref: `#/properties/level${level + 1}` },
+        },
+      };
+    }
+
+    const sanitized = sanitizeProviderToolSchema(
+      { type: "object", properties } as never,
+      { model: "veryfront-cloud/moonshotai/kimi-k2.6" },
+    );
+
+    // Without a shared expansion budget every sibling ref re-expands, so this compact
+    // schema would grow to roughly 2^40 nodes before the model call is even made.
+    assertEquals(countNodes(sanitized) < 200_000, true);
+    // The budget stops inlining rather than expanding, so deep refs stay as references.
+    assertEquals(JSON.stringify(sanitized).includes("#/properties/level"), true);
   });
 
   it("preserves Moonshot tool properties named definitions", () => {

--- a/src/agent/runtime/provider-tool-compat.test.ts
+++ b/src/agent/runtime/provider-tool-compat.test.ts
@@ -2,6 +2,7 @@ import { assertEquals, assertStrictEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import type { ToolDefinition } from "#veryfront/tool";
 import {
+  createMoonshotSchemaExpansionBudget,
   getProviderToolProfile,
   normalizeProviderToolInputSchema,
   sanitizeProviderToolSchema,
@@ -23,6 +24,30 @@ function countNodes(value: unknown): number {
   }
   if (!value || typeof value !== "object") return 1;
   return Object.values(value).reduce<number>((total, item) => total + countNodes(item), 1);
+}
+
+/**
+ * Build a schema whose every level fans out into two references to the next level, so
+ * naive `$ref` inlining grows as 2^levelCount.
+ */
+function buildFanOutRefSchema(levelCount: number, description?: string) {
+  const terminal: Record<string, unknown> = { type: "string" };
+  if (description !== undefined) terminal.description = description;
+  const properties: Record<string, unknown> = { [`level${levelCount}`]: terminal };
+
+  for (let level = levelCount - 1; level >= 0; level -= 1) {
+    const node: Record<string, unknown> = {
+      type: "object",
+      properties: {
+        left: { $ref: `#/properties/level${level + 1}` },
+        right: { $ref: `#/properties/level${level + 1}` },
+      },
+    };
+    if (description !== undefined) node.description = description;
+    properties[`level${level}`] = node;
+  }
+
+  return { type: "object", properties };
 }
 
 function containsKey(value: unknown, key: string): boolean {
@@ -315,30 +340,75 @@ describe("provider-tool-compat", () => {
   });
 
   it("bounds Moonshot ref inlining for fan-out ref chains", () => {
-    const levelCount = 40;
-    const properties: Record<string, unknown> = {
-      [`level${levelCount}`]: { type: "string" },
-    };
-    for (let level = levelCount - 1; level >= 0; level -= 1) {
-      properties[`level${level}`] = {
-        type: "object",
-        properties: {
-          left: { $ref: `#/properties/level${level + 1}` },
-          right: { $ref: `#/properties/level${level + 1}` },
-        },
-      };
-    }
-
+    // 15 levels, not a deeper hostile case: without the budget this already expands to
+    // roughly 327,000 nodes, which trips the assertion below while still completing
+    // promptly. A 40-level case would instead hang or exhaust the worker on regression,
+    // reporting a timeout rather than a useful failure.
     const sanitized = sanitizeProviderToolSchema(
-      { type: "object", properties } as never,
+      buildFanOutRefSchema(15) as never,
       { model: "veryfront-cloud/moonshotai/kimi-k2.6" },
     );
 
-    // Without a shared expansion budget every sibling ref re-expands, so this compact
-    // schema would grow to roughly 2^40 nodes before the model call is even made.
+    // Without an expansion budget every sibling ref re-expands, so this compact schema
+    // would grow to roughly 2^15 leaves before the model call is even made.
     assertEquals(countNodes(sanitized) < 200_000, true);
     // The budget stops inlining rather than expanding, so deep refs stay as references.
     assertEquals(JSON.stringify(sanitized).includes("#/properties/level"), true);
+  });
+
+  it("bounds Moonshot ref inlining by serialized bytes, not just node count", () => {
+    // Every ref target carries a large description. The node budget alone counts each
+    // description as a single node, so ~20,000 admitted nodes could still serialize to
+    // tens of megabytes; the byte budget is what actually bounds the request payload.
+    const sanitized = sanitizeProviderToolSchema(
+      buildFanOutRefSchema(15, "x".repeat(2_000)) as never,
+      { model: "veryfront-cloud/moonshotai/kimi-k2.6" },
+    );
+
+    assertEquals(JSON.stringify(sanitized).length < 1_000_000, true);
+    assertEquals(JSON.stringify(sanitized).includes("#/properties/level"), true);
+  });
+
+  it("bounds Moonshot ref inlining across a whole tool set", () => {
+    // A per-schema budget bounds one tool; a source returning many admissible schemas
+    // would otherwise multiply the worst case by the tool count.
+    const budget = createMoonshotSchemaExpansionBudget();
+    let totalNodes = 0;
+    for (let index = 0; index < 50; index += 1) {
+      totalNodes += countNodes(sanitizeProviderToolSchema(
+        buildFanOutRefSchema(15) as never,
+        {
+          model: "veryfront-cloud/moonshotai/kimi-k2.6",
+          moonshotExpansionBudget: budget,
+        },
+      ));
+    }
+
+    // Per-schema budgets alone would allow ~50x the single-schema ceiling here.
+    assertEquals(totalNodes < 400_000, true);
+  });
+
+  it("still inlines refs for every tool in an ordinary tool set", () => {
+    // The tool-set budget is charged only for inlined material, so a long list of
+    // modest schemas must not starve later tools of inlining.
+    const budget = createMoonshotSchemaExpansionBudget();
+    for (let index = 0; index < 500; index += 1) {
+      const sanitized = sanitizeProviderToolSchema(
+        {
+          type: "object",
+          properties: {
+            target: { type: "string", description: "target" },
+            alias: { $ref: "#/properties/target" },
+          },
+        } as never,
+        {
+          model: "veryfront-cloud/moonshotai/kimi-k2.6",
+          moonshotExpansionBudget: budget,
+        },
+      );
+
+      assertEquals(JSON.stringify(sanitized).includes("$ref"), false);
+    }
   });
 
   it("preserves Moonshot tool properties named definitions", () => {

--- a/src/agent/runtime/provider-tool-compat.ts
+++ b/src/agent/runtime/provider-tool-compat.ts
@@ -383,13 +383,52 @@ function createMoonshotInlineBudget(
   };
 }
 
+/**
+ * Encoded size of a JSON string literal, including quotes.
+ *
+ * Character count undercounts badly for schemas the budget is meant to bound: control
+ * characters expand to six-byte `\uXXXX` escapes and non-ASCII text costs two to four
+ * UTF-8 bytes, so a hostile description can serialize to many times its length. This
+ * walks code points rather than allocating an intermediate `JSON.stringify` result.
+ */
+function estimateEncodedStringBytes(value: string): number {
+  let bytes = 2;
+
+  for (const character of value) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code === 0x22 || code === 0x5c) {
+      bytes += 2;
+    } else if (
+      code === 0x08 || code === 0x09 || code === 0x0a || code === 0x0c || code === 0x0d
+    ) {
+      bytes += 2;
+    } else if (code < 0x20) {
+      bytes += 6;
+    } else if (code < 0x80) {
+      bytes += 1;
+    } else if (code < 0x800) {
+      bytes += 2;
+    } else if (code >= 0xd800 && code <= 0xdfff) {
+      // Iterating code points only yields a surrogate when it is unpaired, and
+      // `JSON.stringify` escapes those to `\uXXXX`.
+      bytes += 6;
+    } else if (code < 0x10000) {
+      bytes += 3;
+    } else {
+      bytes += 4;
+    }
+  }
+
+  return bytes;
+}
+
 /** Approximate the serialized size one schema node contributes, excluding its children. */
 function estimateSerializedNodeBytes(value: unknown): number {
-  if (typeof value === "string") return value.length + 2;
+  if (typeof value === "string") return estimateEncodedStringBytes(value);
   if (Array.isArray(value)) return 2;
   if (isPlainRecord(value)) {
     let bytes = 2;
-    for (const key of Object.keys(value)) bytes += key.length + 4;
+    for (const key of Object.keys(value)) bytes += estimateEncodedStringBytes(key) + 2;
     return bytes;
   }
   return 8;

--- a/src/agent/runtime/provider-tool-compat.ts
+++ b/src/agent/runtime/provider-tool-compat.ts
@@ -27,6 +27,16 @@ const OPENAI_MAX_TOOLS = 128;
 const MOONSHOT_MAX_REF_INLINE_DEPTH = 32;
 /** Node budget for one Moonshot schema sanitization pass, bounding `$ref` inlining growth. */
 const MOONSHOT_MAX_INLINED_SCHEMA_NODES = 20_000;
+/**
+ * Serialized-byte budget for one Moonshot schema sanitization pass. Nodes alone do not
+ * bound payload size: a single large `description` string counts as one node but is
+ * duplicated by every inlined copy of its `$ref` target.
+ */
+const MOONSHOT_MAX_INLINED_SCHEMA_BYTES = 512 * 1024;
+/** Node budget for `$ref` inlining across one tool-set conversion pass. */
+const MOONSHOT_MAX_INLINED_TOOL_SET_NODES = 200_000;
+/** Serialized-byte budget for `$ref` inlining across one tool-set conversion pass. */
+const MOONSHOT_MAX_INLINED_TOOL_SET_BYTES = 8 * 1024 * 1024;
 const PERMISSIVE_TOOL_INPUT_SCHEMA: JsonSchema = {
   type: "object",
   properties: {},
@@ -333,25 +343,90 @@ function resolveLocalJsonPointer(root: unknown, ref: string): unknown {
   return current;
 }
 
-interface MoonshotInlineBudget {
+/**
+ * Expansion budget shared by every schema in one tool-set conversion pass.
+ *
+ * A per-schema budget alone bounds each tool in isolation but not the collection: a
+ * remote MCP source may return hundreds of individually-admissible schemas, so the
+ * worst case is multiplied by the tool count. This budget is charged only for material
+ * produced by `$ref` inlining, so ordinary (ref-free) schemas never consume it no
+ * matter how many tools the source advertises.
+ */
+export interface MoonshotSchemaExpansionBudget {
   remainingNodes: number;
+  remainingBytes: number;
 }
 
-function createMoonshotInlineBudget(): MoonshotInlineBudget {
-  return { remainingNodes: MOONSHOT_MAX_INLINED_SCHEMA_NODES };
+/** Create a tool-set-wide Moonshot `$ref` expansion budget. */
+export function createMoonshotSchemaExpansionBudget(): MoonshotSchemaExpansionBudget {
+  return {
+    remainingNodes: MOONSHOT_MAX_INLINED_TOOL_SET_NODES,
+    remainingBytes: MOONSHOT_MAX_INLINED_TOOL_SET_BYTES,
+  };
+}
+
+interface MoonshotInlineBudget {
+  /** Per-schema allowance, charged for every visited node. */
+  remainingNodes: number;
+  remainingBytes: number;
+  /** Tool-set allowance, charged only for nodes produced by inlining. */
+  shared: MoonshotSchemaExpansionBudget;
+}
+
+function createMoonshotInlineBudget(
+  shared: MoonshotSchemaExpansionBudget,
+): MoonshotInlineBudget {
+  return {
+    remainingNodes: MOONSHOT_MAX_INLINED_SCHEMA_NODES,
+    remainingBytes: MOONSHOT_MAX_INLINED_SCHEMA_BYTES,
+    shared,
+  };
+}
+
+/** Approximate the serialized size one schema node contributes, excluding its children. */
+function estimateSerializedNodeBytes(value: unknown): number {
+  if (typeof value === "string") return value.length + 2;
+  if (Array.isArray(value)) return 2;
+  if (isPlainRecord(value)) {
+    let bytes = 2;
+    for (const key of Object.keys(value)) bytes += key.length + 4;
+    return bytes;
+  }
+  return 8;
+}
+
+function hasMoonshotInlineBudget(budget: MoonshotInlineBudget): boolean {
+  return budget.remainingNodes > 0 && budget.remainingBytes > 0 &&
+    budget.shared.remainingNodes > 0 && budget.shared.remainingBytes > 0;
+}
+
+function chargeMoonshotInlineBudget(
+  budget: MoonshotInlineBudget,
+  value: unknown,
+  inlineDepth: number,
+): void {
+  const bytes = estimateSerializedNodeBytes(value);
+  budget.remainingNodes -= 1;
+  budget.remainingBytes -= bytes;
+  if (inlineDepth > 0) {
+    // Only material introduced by `$ref` inlining is amplification, so only that is
+    // charged to the tool-set budget.
+    budget.shared.remainingNodes -= 1;
+    budget.shared.remainingBytes -= bytes;
+  }
 }
 
 function sanitizeMoonshotSchemaValue(
   value: unknown,
-  root: unknown = value,
-  seenRefs: ReadonlySet<string> = new Set(),
-  inlineDepth = 0,
-  budget: MoonshotInlineBudget = createMoonshotInlineBudget(),
+  root: unknown,
+  seenRefs: ReadonlySet<string>,
+  inlineDepth: number,
+  budget: MoonshotInlineBudget,
 ): unknown {
   // `seenRefs` only blocks cycles along the current path, so sibling references to the
-  // same target still re-expand. A shared node budget and depth cap keep a hostile
+  // same target still re-expand. Shared node/byte budgets and a depth cap keep a hostile
   // (or merely dense) schema from expanding exponentially during inlining.
-  budget.remainingNodes -= 1;
+  chargeMoonshotInlineBudget(budget, value, inlineDepth);
 
   if (Array.isArray(value)) {
     return value.map((item) =>
@@ -369,7 +444,7 @@ function sanitizeMoonshotSchemaValue(
     !value.$ref.startsWith("#/definitions/") &&
     !seenRefs.has(value.$ref) &&
     inlineDepth < MOONSHOT_MAX_REF_INLINE_DEPTH &&
-    budget.remainingNodes > 0
+    hasMoonshotInlineBudget(budget)
   ) {
     const resolved = resolveLocalJsonPointer(root, value.$ref);
     if (resolved !== undefined && resolved !== value) {
@@ -575,10 +650,21 @@ export function normalizeProviderToolInputSchema(schema: JsonSchema): JsonSchema
   } as JsonSchema;
 }
 
+/** Options accepted by {@link sanitizeProviderToolSchema}. */
+export interface SanitizeProviderToolSchemaOptions
+  extends Pick<ProviderToolCompatOptions, "model"> {
+  /**
+   * Expansion budget shared across every tool in one conversion pass. Callers that
+   * sanitize a whole tool set should create one budget and reuse it so `$ref` inlining
+   * is bounded for the collection, not merely per schema.
+   */
+  moonshotExpansionBudget?: MoonshotSchemaExpansionBudget;
+}
+
 /** Zod schema for sanitize provider tool. */
 export function sanitizeProviderToolSchema(
   schema: JsonSchema,
-  options: Pick<ProviderToolCompatOptions, "model"> = {},
+  options: SanitizeProviderToolSchemaOptions = {},
 ): JsonSchema {
   const profile = getProviderToolProfile(options.model);
   if (!profile.sanitizeSchema) return schema;
@@ -590,7 +676,16 @@ export function sanitizeProviderToolSchema(
   }
 
   if (profile.provider === "moonshot") {
-    return sanitizeMoonshotSchemaValue(propertyKeySafeSchema) as JsonSchema;
+    const budget = createMoonshotInlineBudget(
+      options.moonshotExpansionBudget ?? createMoonshotSchemaExpansionBudget(),
+    );
+    return sanitizeMoonshotSchemaValue(
+      propertyKeySafeSchema,
+      propertyKeySafeSchema,
+      new Set(),
+      0,
+      budget,
+    ) as JsonSchema;
   }
 
   if (profile.provider === "anthropic") {

--- a/src/agent/runtime/provider-tool-compat.ts
+++ b/src/agent/runtime/provider-tool-compat.ts
@@ -23,6 +23,10 @@ export interface ProviderToolCompatOptions {
 }
 
 const OPENAI_MAX_TOOLS = 128;
+/** Maximum nesting of inlined Moonshot `$ref` targets before references are left in place. */
+const MOONSHOT_MAX_REF_INLINE_DEPTH = 32;
+/** Node budget for one Moonshot schema sanitization pass, bounding `$ref` inlining growth. */
+const MOONSHOT_MAX_INLINED_SCHEMA_NODES = 20_000;
 const PERMISSIVE_TOOL_INPUT_SCHEMA: JsonSchema = {
   type: "object",
   properties: {},
@@ -329,13 +333,30 @@ function resolveLocalJsonPointer(root: unknown, ref: string): unknown {
   return current;
 }
 
+interface MoonshotInlineBudget {
+  remainingNodes: number;
+}
+
+function createMoonshotInlineBudget(): MoonshotInlineBudget {
+  return { remainingNodes: MOONSHOT_MAX_INLINED_SCHEMA_NODES };
+}
+
 function sanitizeMoonshotSchemaValue(
   value: unknown,
   root: unknown = value,
   seenRefs: ReadonlySet<string> = new Set(),
+  inlineDepth = 0,
+  budget: MoonshotInlineBudget = createMoonshotInlineBudget(),
 ): unknown {
+  // `seenRefs` only blocks cycles along the current path, so sibling references to the
+  // same target still re-expand. A shared node budget and depth cap keep a hostile
+  // (or merely dense) schema from expanding exponentially during inlining.
+  budget.remainingNodes -= 1;
+
   if (Array.isArray(value)) {
-    return value.map((item) => sanitizeMoonshotSchemaValue(item, root, seenRefs));
+    return value.map((item) =>
+      sanitizeMoonshotSchemaValue(item, root, seenRefs, inlineDepth, budget)
+    );
   }
 
   if (!isPlainRecord(value)) {
@@ -346,16 +367,25 @@ function sanitizeMoonshotSchemaValue(
     typeof value.$ref === "string" &&
     !value.$ref.startsWith("#/$defs/") &&
     !value.$ref.startsWith("#/definitions/") &&
-    !seenRefs.has(value.$ref)
+    !seenRefs.has(value.$ref) &&
+    inlineDepth < MOONSHOT_MAX_REF_INLINE_DEPTH &&
+    budget.remainingNodes > 0
   ) {
     const resolved = resolveLocalJsonPointer(root, value.$ref);
     if (resolved !== undefined && resolved !== value) {
       const nextSeenRefs = new Set(seenRefs);
       nextSeenRefs.add(value.$ref);
-      const sanitizedResolved = sanitizeMoonshotSchemaValue(resolved, root, nextSeenRefs);
+      const nextInlineDepth = inlineDepth + 1;
+      const sanitizedResolved = sanitizeMoonshotSchemaValue(
+        resolved,
+        root,
+        nextSeenRefs,
+        nextInlineDepth,
+        budget,
+      );
       const { $ref: _ref, ...siblings } = value;
       const sanitizedSiblings = Object.keys(siblings).length > 0
-        ? sanitizeMoonshotSchemaValue(siblings, root, nextSeenRefs)
+        ? sanitizeMoonshotSchemaValue(siblings, root, nextSeenRefs, nextInlineDepth, budget)
         : undefined;
 
       return isPlainRecord(sanitizedResolved) && isPlainRecord(sanitizedSiblings)
@@ -373,7 +403,7 @@ function sanitizeMoonshotSchemaValue(
     }
 
     if (key === "definitions") {
-      sanitized.$defs = sanitizeMoonshotSchemaValue(child, root, seenRefs);
+      sanitized.$defs = sanitizeMoonshotSchemaValue(child, root, seenRefs, inlineDepth, budget);
       continue;
     }
 
@@ -381,13 +411,13 @@ function sanitizeMoonshotSchemaValue(
       sanitized.properties = Object.fromEntries(
         Object.entries(child).map(([propertyName, propertySchema]) => [
           propertyName,
-          sanitizeMoonshotSchemaValue(propertySchema, root, seenRefs),
+          sanitizeMoonshotSchemaValue(propertySchema, root, seenRefs, inlineDepth, budget),
         ]),
       );
       continue;
     }
 
-    sanitized[key] = sanitizeMoonshotSchemaValue(child, root, seenRefs);
+    sanitized[key] = sanitizeMoonshotSchemaValue(child, root, seenRefs, inlineDepth, budget);
   }
 
   return sanitized;


### PR DESCRIPTION
## Summary

Moonshot/Kimi tool schema sanitization (`sanitizeMoonshotSchemaValue`, added in 9e25ab389) inlines local JSON Pointer `$ref`s that point outside `#/$defs/`. Its only guard is `seenRefs`, which is copied per expansion (`const nextSeenRefs = new Set(seenRefs)`) and therefore blocks cycles only along the current recursion path — sibling `$ref`s to the same target each re-expand, with no depth cap, node budget, or serialized-size limit. A remote MCP server can return a compact schema where every referenced property holds two `$ref`s to the next property; it passes the remote-MCP input guards (`MAX_REMOTE_MCP_TOOL_SCHEMA_BYTES` 16 KiB / `_DEPTH` 64 / `_NODES` 4096, which bound the *input* only) yet expands exponentially during tool conversion — before `generateText`/`streamText` is even called. Repeated public agent requests against an agent configured with such a source can tie up or crash the runtime.

Measured on `main` with a chained fan-out-2 schema: a 159-node input expanded to 41,942,969 nodes in 49.4 s (`levels=22`), doubling per added level; the 285-node, 40-level case is ~2^40 nodes.

## Finding

- Codex finding id: `f082a6a4a7648191ab116d79e1d689fb`
- Severity: medium
- Introduced in: 9e25ab3890f56b7e337e2a098574360a6f3ecf25
- Paths: `src/agent/runtime/provider-tool-compat.ts` (reached via `src/agent/runtime/model-tool-converter.ts`, with attacker-controlled schemas arriving through `src/tool/remote-mcp.ts`)

## Fix

`sanitizeMoonshotSchemaValue` now threads a shared expansion budget (`MOONSHOT_MAX_INLINED_SCHEMA_NODES = 20_000`) and an inline depth cap (`MOONSHOT_MAX_REF_INLINE_DEPTH = 32`) through the recursion. Every visited node consumes one unit of the shared budget; a `$ref` is inlined only while budget and depth remain. Once either limit is reached, no further expansion happens — the reference is left in place, which is exactly the pre-inlining behavior — so sanitization stays bounded and degrades gracefully rather than exhausting the runtime. Cycle protection via `seenRefs` is unchanged, and legitimate schemas (the existing inlining tests, including the staging `#/properties/expectations` case that motivated the original commit) are unaffected.

With the fix the same adversarial inputs are bounded: 40 levels / 285 input nodes → 16,895 output nodes in 27.8 ms (10/20/30/40 levels all land at 10k–17k nodes, under 30 ms).

## Test evidence

New regression test `bounds Moonshot ref inlining for fan-out ref chains` in `src/agent/runtime/provider-tool-compat.test.ts` builds a 40-level fan-out-2 ref chain and asserts the sanitized output stays under 200k nodes and still carries un-inlined `#/properties/level` references. Without the budget this test does not terminate in any practical time.

- `deno task test:file src/agent/runtime/provider-tool-compat.test.ts` — ok, 16 steps passed (new test 133 ms)
- `deno task test:file src/agent/runtime/model-tool-converter.test.ts` — ok, 24 steps passed
- `deno fmt --check` and `deno lint` on both touched files — clean
- `deno check src/agent/runtime/provider-tool-compat.ts src/agent/runtime/provider-tool-compat.test.ts` — clean

https://claude.ai/code/session_01QfWNMiUhvWMKWi6BGfVdY3