### PR TITLE
fix(security): keep eval data from restoring disabled agent-service scope

### DIFF
--- a/src/eval/agent-service-hardening.test.ts
+++ b/src/eval/agent-service-hardening.test.ts
@@ -6,6 +6,7 @@ import {
   assertThrows,
 } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { datasets, evalAgent, runEval } from "veryfront/eval";
 import {
   buildAgentServiceEvalRequestBody,
   buildLiveEvalCaseMetadata,
@@ -323,6 +324,81 @@ describe("eval/agent-service hardening", () => {
     });
     assertEquals(Object.hasOwn(prototypeBody.state, "__proto__"), true);
     assertEquals(prototypeBody.state.__proto__, "preserved");
+  });
+
+  it("keeps eval example data from re-enabling explicitly disabled request scope", () => {
+    const scopedExample = {
+      prompt: "Run",
+      projectId: "project_attacker",
+      conversationId: "conversation_attacker",
+      branchId: "branch_attacker",
+      model: "provider/attacker",
+    };
+
+    const disabledBody = buildAgentServiceEvalRequestBody({
+      exampleId: "case-1",
+      input: scopedExample,
+      projectId: null,
+      conversationId: null,
+      branchId: null,
+      model: null,
+    });
+    assertEquals(disabledBody.forwardedProps, undefined);
+
+    const omittedBody = buildAgentServiceEvalRequestBody({
+      exampleId: "case-2",
+      input: scopedExample,
+    });
+    assertEquals(omittedBody.forwardedProps, {
+      veryfront: {
+        projectId: "project_attacker",
+        conversationId: "conversation_attacker",
+        branchId: "branch_attacker",
+        model: "provider/attacker",
+      },
+    });
+  });
+
+  it("does not let eval data restore project scope disabled in the adapter config", async () => {
+    const requestBodies: Array<Record<string, unknown>> = [];
+    const adapter = createAgentServiceEvalAdapter({
+      endpoint: "http://127.0.0.1:4311/api/ag-ui",
+      authToken: "token",
+      projectId: null,
+      conversationId: null,
+      branchId: null,
+      model: null,
+      fetch: async (_input, init) => {
+        requestBodies.push(JSON.parse(String(init?.body)));
+        return createCompletedSseResponse();
+      },
+    });
+
+    const report = await runEval(
+      evalAgent({
+        id: "eval:unscoped",
+        target: "agent:veryfront",
+        dataset: datasets.inline([
+          {
+            id: "smoke",
+            input: {
+              prompt: "List files",
+              projectId: "project_attacker",
+              conversationId: "conversation_attacker",
+              branchId: "branch_attacker",
+              model: "provider/attacker",
+            },
+          },
+        ]),
+      }),
+      {
+        adapters: { agent: adapter },
+        now: () => new Date("2026-06-20T10:00:00.000Z"),
+      },
+    );
+
+    assertEquals(report.records[0]?.completed, true);
+    assertEquals(requestBodies[0]?.forwardedProps, undefined);
   });
 
   it("contains async verifier failures and always runs lifecycle cleanup", async () => {

--- a/src/eval/agent-service.ts
+++ b/src/eval/agent-service.ts
@@ -199,14 +199,29 @@ function getInputMetadata(input: unknown): Record<string, unknown> {
   return { ...input.metadata };
 }
 
+/**
+ * Resolve a request scope override.
+ *
+ * Only an omitted (`undefined`) caller value falls back to the eval example's
+ * own data. An explicit `null` is the caller disabling that scope, so untrusted
+ * example data must not be able to reintroduce it.
+ */
+function resolveScopeOverride(
+  configured: string | null | undefined,
+  fromExample: unknown,
+): string | null {
+  if (configured !== undefined) return configured;
+  return readString(fromExample) ?? null;
+}
+
 function getRequestOverrides(input: BuildAgentServiceEvalRequestBodyInput) {
   const record = isRecord(input.input) ? input.input : {};
   return {
     agentId: input.agentId ?? null,
-    projectId: input.projectId ?? readString(record.projectId) ?? null,
-    conversationId: input.conversationId ?? readString(record.conversationId) ?? null,
-    branchId: input.branchId ?? readString(record.branchId) ?? null,
-    model: input.model ?? readString(record.model) ?? null,
+    projectId: resolveScopeOverride(input.projectId, record.projectId),
+    conversationId: resolveScopeOverride(input.conversationId, record.conversationId),
+    branchId: resolveScopeOverride(input.branchId, record.branchId),
+    model: resolveScopeOverride(input.model, record.model),
     allowedTools: input.allowedTools ?? readStringArray(record.allowedTools),
     forceRuntimeOverrides: input.forceRuntimeOverrides ?? record.forceRuntimeOverrides === true,
     maxSteps: input.maxSteps ?? readFiniteNumber(record.maxSteps),


### PR DESCRIPTION
## Summary

The agent-service eval adapter lets a harness disable project-scoped execution by passing an explicit `projectId: null` (the config type is `string | null`, and the same holds for `conversationId`, `branchId` and `model`). But `getRequestOverrides()` in `src/eval/agent-service.ts` resolved those four fields with nullish coalescing — `input.projectId ?? readString(record.projectId) ?? null` — where `record` is the eval example's own `input`. An explicit `null` therefore fell straight through to values read from the eval data, and the resulting scope was emitted in `forwardedProps.veryfront` and sent to the live agent service with the configured Authorization bearer token. A trusted CI/harness running attacker-controlled eval data while deliberately keeping the run unscoped could have that data reintroduce a project, conversation or branch id and steer the run into project-scoped tools, files and API state reachable by that token. The server still verifies token access, so this is not unauthenticated cross-tenant access, but it is a confused-deputy bypass of the caller's intended scoping restrictions.

## Finding

- Codex finding id: `c8c27e0d32988191ae21589e8bcae4bf` (finding 134)
- Severity: medium
- Path: `src/eval/agent-service.ts` (introduced in `e77ddd725a821901105731c5f553f45426128023`)

Commit `2888c1818` ("fix(security): prevent client-controlled AG-UI agent selection", #4199) removed exactly this eval-data fallback for `agentId`, but left `projectId`, `conversationId`, `branchId` and `model` in place.

## Fix

Added a small `resolveScopeOverride()` helper and used it for those four fields in `getRequestOverrides()`. Only an omitted (`undefined`) caller value now falls back to the eval example's data — the documented convenience for unconfigured adapters is preserved. An explicit `null` is treated as the caller disabling that scope and is never overridden by example data. `allowedTools`, `forceRuntimeOverrides` and `maxSteps` are unchanged: their config types do not admit `null`, so `??` already only fires on an omitted value.

No public API surface changed; `deno task docs:api-reference:check` reports the generated reference is still current.

## Test evidence

Two regression tests added to `src/eval/agent-service-hardening.test.ts`:

- `keeps eval example data from re-enabling explicitly disabled request scope` — `buildAgentServiceEvalRequestBody` with `projectId/conversationId/branchId/model: null` and an example supplying all four yields no `forwardedProps` at all, while omitting them still lets the example data through (documented behavior preserved).
- `does not let eval data restore project scope disabled in the adapter config` — an end-to-end `runEval` against `createAgentServiceEvalAdapter({ projectId: null, ... })` with a hostile example captures the outgoing AG-UI request body and asserts `forwardedProps` is absent.

Both tests fail on the pre-fix source (verified by reverting `src/eval/agent-service.ts` and re-running: `FAILED | 0 passed (30 steps) | 1 failed (2 steps)`) and pass with it.

Commands run locally in a worktree off `origin/main`:

- `deno fmt --check src/eval/agent-service.ts src/eval/agent-service-hardening.test.ts` — clean
- `deno lint src/eval/agent-service.ts src/eval/agent-service-hardening.test.ts` — clean
- `deno check src/eval/index.ts` — clean
- `deno task test:file src/eval/agent-service-hardening.test.ts` — ok, 32 steps
- `deno task test:file src/eval/agent-service.test.ts` — ok, 30 steps
- `deno task lint:anti-slop` — baseline ok
- `deno task docs:api-reference:check` — reference current

https://claude.ai/code/session_01QfWNMiUhvWMKWi6BGfVdY3
