### PR TITLE
fix(ci): retry npm publish on transient identity token errors

### DIFF
--- a/scripts/ci/publish-npm-packages.sh
+++ b/scripts/ci/publish-npm-packages.sh
@@ -120,14 +120,19 @@ verify_npm_compatibility_artifact() {
 }
 
 # npm answers a burst of publishes with `409 Conflict - Failed to save
-# packument`; the conflicting write sometimes still lands.
+# packument`; the conflicting write sometimes still lands. The GitHub Actions
+# OIDC endpoint that `--provenance` calls for each publish separately fails a
+# single request under the same back-to-back loop (IDENTITY_TOKEN_READ_ERROR)
+# without ever reaching the registry, so retrying it through this same loop is
+# safe: the registry recheck below just reports the version still absent, and
+# the publish is retried as if it were a fresh attempt.
 NPM_PUBLISH_CONFLICT_ATTEMPTS="${NPM_PUBLISH_CONFLICT_ATTEMPTS:-5}"
 NPM_PUBLISH_CONFLICT_DELAY_SECONDS="${NPM_PUBLISH_CONFLICT_DELAY_SECONDS:-15}"
 
 is_transient_publish_conflict() {
   CONFLICT_OUTPUT_CANDIDATE="$1"
   printf '%s\n' "${CONFLICT_OUTPUT_CANDIDATE}" \
-    | grep -Eq 'npm error code E409|409 Conflict|Failed to save packument'
+    | grep -Eq 'npm error code E409|409 Conflict|Failed to save packument|IDENTITY_TOKEN_READ_ERROR'
 }
 
 # npm rejects a reused name/version with "You cannot publish over the

--- a/scripts/ci/publish-npm-packages.sh
+++ b/scripts/ci/publish-npm-packages.sh
@@ -135,6 +135,11 @@ is_transient_publish_failure() {
     | grep -Eq 'npm error code E409|409 Conflict|Failed to save packument|IDENTITY_TOKEN_READ_ERROR'
 }
 
+is_identity_token_read_failure() {
+  IDENTITY_OUTPUT_CANDIDATE="$1"
+  printf '%s\n' "${IDENTITY_OUTPUT_CANDIDATE}" | grep -Fq 'IDENTITY_TOKEN_READ_ERROR'
+}
+
 # npm rejects a reused name/version with "You cannot publish over the
 # previously published versions". That answer comes from the registry's write
 # side, so it is authoritative that the version exists even while the read
@@ -243,7 +248,7 @@ publish_npm_package_with_retry() {
   PUBLISH_PACKAGE_NAME="$2"
   PUBLISH_SPEC="$3"
   shift 3
-  PUBLISH_SAW_TRANSIENT_FAILURE=0
+  PUBLISH_SAW_REGISTRY_CONFLICT=0
   for PUBLISH_ATTEMPT in $(seq 1 "${NPM_PUBLISH_CONFLICT_ATTEMPTS}"); do
     if [[ "${PUBLISH_ATTEMPT}" -gt 1 ]]; then
       # npm refuses to reuse a published name/version, so a write that landed
@@ -268,13 +273,15 @@ publish_npm_package_with_retry() {
       # Only the recover mode may reinterpret an already-published rejection
       # that races an earlier conflict; the fail-closed mode reports npm's
       # rejection as-is so an existing version always fails the release.
-      if [[ "${PUBLISH_SAW_TRANSIENT_FAILURE}" -eq 1 && "${PUBLISH_RETRY_MODE}" == "recover" ]] \
+      if [[ "${PUBLISH_SAW_REGISTRY_CONFLICT}" -eq 1 && "${PUBLISH_RETRY_MODE}" == "recover" ]] \
         && recover_publish_rejection_after_conflict "${PUBLISH_PACKAGE_NAME}" "${PUBLISH_OUTPUT}"; then
         return 0
       fi
       return "${PUBLISH_STATUS}"
     fi
-    PUBLISH_SAW_TRANSIENT_FAILURE=1
+    if ! is_identity_token_read_failure "${PUBLISH_OUTPUT}"; then
+      PUBLISH_SAW_REGISTRY_CONFLICT=1
+    fi
 
     resolve_publish_conflict "${PUBLISH_PACKAGE_NAME}" \
       && PUBLISH_CONFLICT_STATE=0 || PUBLISH_CONFLICT_STATE=$?
@@ -284,7 +291,7 @@ publish_npm_package_with_retry() {
     if [[ "${PUBLISH_ATTEMPT}" -lt "${NPM_PUBLISH_CONFLICT_ATTEMPTS}" ]]; then
       echo "Transient npm publish failure for ${PUBLISH_PACKAGE_NAME}@${VERSION}; retrying in ${NPM_PUBLISH_CONFLICT_DELAY_SECONDS}s (attempt ${PUBLISH_ATTEMPT}/${NPM_PUBLISH_CONFLICT_ATTEMPTS})."
       sleep "${NPM_PUBLISH_CONFLICT_DELAY_SECONDS}"
-    elif [[ "${PUBLISH_RETRY_MODE}" == "recover" ]] \
+    elif [[ "${PUBLISH_RETRY_MODE}" == "recover" && "${PUBLISH_SAW_REGISTRY_CONFLICT}" -eq 1 ]] \
       && wait_for_npm_git_head "${PUBLISH_PACKAGE_NAME}"; then
       echo "::notice::${PUBLISH_PACKAGE_NAME}@${VERSION} landed after the final transient publish failure; continuing."
       return 0

--- a/scripts/ci/publish-npm-packages.sh
+++ b/scripts/ci/publish-npm-packages.sh
@@ -129,7 +129,7 @@ verify_npm_compatibility_artifact() {
 NPM_PUBLISH_CONFLICT_ATTEMPTS="${NPM_PUBLISH_CONFLICT_ATTEMPTS:-5}"
 NPM_PUBLISH_CONFLICT_DELAY_SECONDS="${NPM_PUBLISH_CONFLICT_DELAY_SECONDS:-15}"
 
-is_transient_publish_conflict() {
+is_transient_publish_failure() {
   CONFLICT_OUTPUT_CANDIDATE="$1"
   printf '%s\n' "${CONFLICT_OUTPUT_CANDIDATE}" \
     | grep -Eq 'npm error code E409|409 Conflict|Failed to save packument|IDENTITY_TOKEN_READ_ERROR'
@@ -243,7 +243,7 @@ publish_npm_package_with_retry() {
   PUBLISH_PACKAGE_NAME="$2"
   PUBLISH_SPEC="$3"
   shift 3
-  PUBLISH_SAW_CONFLICT=0
+  PUBLISH_SAW_TRANSIENT_FAILURE=0
   for PUBLISH_ATTEMPT in $(seq 1 "${NPM_PUBLISH_CONFLICT_ATTEMPTS}"); do
     if [[ "${PUBLISH_ATTEMPT}" -gt 1 ]]; then
       # npm refuses to reuse a published name/version, so a write that landed
@@ -264,17 +264,17 @@ publish_npm_package_with_retry() {
     if [[ "${PUBLISH_STATUS}" -eq 0 ]]; then
       return 0
     fi
-    if ! is_transient_publish_conflict "${PUBLISH_OUTPUT}"; then
+    if ! is_transient_publish_failure "${PUBLISH_OUTPUT}"; then
       # Only the recover mode may reinterpret an already-published rejection
       # that races an earlier conflict; the fail-closed mode reports npm's
       # rejection as-is so an existing version always fails the release.
-      if [[ "${PUBLISH_SAW_CONFLICT}" -eq 1 && "${PUBLISH_RETRY_MODE}" == "recover" ]] \
+      if [[ "${PUBLISH_SAW_TRANSIENT_FAILURE}" -eq 1 && "${PUBLISH_RETRY_MODE}" == "recover" ]] \
         && recover_publish_rejection_after_conflict "${PUBLISH_PACKAGE_NAME}" "${PUBLISH_OUTPUT}"; then
         return 0
       fi
       return "${PUBLISH_STATUS}"
     fi
-    PUBLISH_SAW_CONFLICT=1
+    PUBLISH_SAW_TRANSIENT_FAILURE=1
 
     resolve_publish_conflict "${PUBLISH_PACKAGE_NAME}" \
       && PUBLISH_CONFLICT_STATE=0 || PUBLISH_CONFLICT_STATE=$?
@@ -282,11 +282,11 @@ publish_npm_package_with_retry() {
       return "${PUBLISH_CONFLICT_STATE}"
     fi
     if [[ "${PUBLISH_ATTEMPT}" -lt "${NPM_PUBLISH_CONFLICT_ATTEMPTS}" ]]; then
-      echo "npm registry conflict publishing ${PUBLISH_PACKAGE_NAME}@${VERSION}; retrying in ${NPM_PUBLISH_CONFLICT_DELAY_SECONDS}s (attempt ${PUBLISH_ATTEMPT}/${NPM_PUBLISH_CONFLICT_ATTEMPTS})."
+      echo "Transient npm publish failure for ${PUBLISH_PACKAGE_NAME}@${VERSION}; retrying in ${NPM_PUBLISH_CONFLICT_DELAY_SECONDS}s (attempt ${PUBLISH_ATTEMPT}/${NPM_PUBLISH_CONFLICT_ATTEMPTS})."
       sleep "${NPM_PUBLISH_CONFLICT_DELAY_SECONDS}"
     elif [[ "${PUBLISH_RETRY_MODE}" == "recover" ]] \
       && wait_for_npm_git_head "${PUBLISH_PACKAGE_NAME}"; then
-      echo "::notice::${PUBLISH_PACKAGE_NAME}@${VERSION} landed after the final npm registry conflict; continuing."
+      echo "::notice::${PUBLISH_PACKAGE_NAME}@${VERSION} landed after the final transient publish failure; continuing."
       return 0
     elif [[ "${PUBLISH_RETRY_MODE}" == "recover" && -n "${PUBLISHED_GIT_HEAD}" ]]; then
       echo "::error::${PUBLISH_PACKAGE_NAME}@${VERSION} exists with a different commit after the final registry conflict." >&2

--- a/scripts/ci/publish-npm-packages.test.ts
+++ b/scripts/ci/publish-npm-packages.test.ts
@@ -1066,6 +1066,41 @@ describe("npm package publishing", () => {
     });
   }
 
+  it("does not poll registry metadata after identity-token retries are exhausted", async () => {
+    await withPackageFixture("@veryfront/ext-llm-google", async ({ packageDir, npmLog }) => {
+      const output = await runBash(
+        [
+          "set -euo pipefail",
+          'source "$SCRIPT_PATH"',
+          "npm() {",
+          LOG_NPM_CALL,
+          '  if [ "$1" = "publish" ]; then',
+          '    printf "%s\\n" "$IDENTITY_TOKEN_OUTPUT"',
+          "    return 1",
+          "  fi",
+          "  return 1",
+          "}",
+          "sleep() { :; }",
+          'rc_publish_package_dir "$PACKAGE_DIR" || echo "EXIT=$?"',
+        ].join("\n"),
+        {
+          IDENTITY_TOKEN_OUTPUT,
+          GITHUB_SHA: "0".repeat(40),
+          NPM_LOG: npmLog,
+          NPM_PUBLISH_CONFLICT_ATTEMPTS: "2",
+          NPM_PUBLISH_CONFLICT_DELAY_SECONDS: "0",
+          PACKAGE_DIR: packageDir,
+          VERSION: "0.1.0",
+        },
+      );
+
+      assertStringIncludes(decoder.decode(output.stdout), "EXIT=1");
+      const calls = await loggedNpmCalls(npmLog);
+      assertEquals(calls.filter((line) => line.startsWith("publish ")).length, 2);
+      assertEquals(calls.filter((line) => line.startsWith("view ")).length, 7);
+    });
+  });
+
   it("accepts a 409 whose publish already landed in rc_publish_package_dir", async () => {
     await withPackageFixture("@veryfront/ext-llm-google", async ({ packageDir, npmLog }) => {
       const output = await runBash(

--- a/scripts/ci/publish-npm-packages.test.ts
+++ b/scripts/ci/publish-npm-packages.test.ts
@@ -1003,6 +1003,69 @@ describe("npm package publishing", () => {
     });
   }
 
+  // The GitHub Actions OIDC endpoint that `--provenance` calls for each
+  // publish separately can fail a single request under the same back-to-back
+  // loop, without the publish ever reaching the registry.
+  const IDENTITY_TOKEN_OUTPUT =
+    "npm error code IDENTITY_TOKEN_READ_ERROR\nnpm error error retrieving identity token";
+
+  for (
+    const publishFunction of [
+      "rc_publish_package_dir",
+      "release_publish_package_dir",
+    ]
+  ) {
+    it(`retries a transient npm identity token error in ${publishFunction}`, async () => {
+      await withTempDir(async (stateDir) => {
+        const packageDir = `${stateDir}/package`;
+        const npmLog = `${stateDir}/npm.log`;
+        await Deno.mkdir(packageDir);
+        await Deno.writeTextFile(
+          `${packageDir}/package.json`,
+          JSON.stringify({ name: "@veryfront/ext-llm-google" }),
+        );
+        await Deno.writeTextFile(npmLog, "");
+
+        const output = await runBash(
+          [
+            "set -euo pipefail",
+            'source "$SCRIPT_PATH"',
+            "npm() {",
+            '  printf "%s\\n" "$*" >> "$NPM_LOG"',
+            '  if [ "$1" = "publish" ]; then',
+            '    if [ "$(grep -c "^publish" "$NPM_LOG")" -eq 1 ]; then',
+            '      printf "%s\\n" "$IDENTITY_TOKEN_OUTPUT"',
+            "      return 1",
+            "    fi",
+            "    return 0",
+            "  fi",
+            '  if [ "$1" = "view" ]; then',
+            // the publish never reached the registry, so it is still absent
+            '    if [ "$(grep -c "^publish" "$NPM_LOG")" -le 1 ]; then return 1; fi',
+            '    printf "%s\\n" "$GITHUB_SHA"',
+            "    return 0",
+            "  fi",
+            "}",
+            `${publishFunction} "$PACKAGE_DIR"`,
+          ].join("\n"),
+          {
+            IDENTITY_TOKEN_OUTPUT,
+            GITHUB_SHA: "0".repeat(40),
+            NPM_LOG: npmLog,
+            NPM_PUBLISH_CONFLICT_DELAY_SECONDS: "0",
+            PACKAGE_DIR: packageDir,
+            VERSION: "0.1.0",
+          },
+        );
+
+        assertEquals(output.code, 0, decoder.decode(output.stderr));
+        const publishes = (await Deno.readTextFile(npmLog)).trim().split("\n")
+          .filter((line) => line.startsWith("publish"));
+        assertEquals(publishes.length, 2);
+      });
+    });
+  }
+
   it("accepts a 409 whose publish already landed in rc_publish_package_dir", async () => {
     await withPackageFixture("@veryfront/ext-llm-google", async ({ packageDir, npmLog }) => {
       const output = await runBash(


### PR DESCRIPTION
## Summary
- main's CI/CD run for the merged dependabot PR (#4403, commit d1314958) failed the `prerelease` job: `npm error code IDENTITY_TOKEN_READ_ERROR` while publishing `@veryfront/ext-image-sharp` with `--provenance`. The GitHub Actions OIDC token endpoint that `--provenance` calls per package occasionally fails a single request under the back-to-back publish loop, without the publish ever reaching the registry.
- Widen `is_transient_publish_conflict` to also match `IDENTITY_TOKEN_READ_ERROR`, so it's retried through the existing conflict-retry loop (`publish_npm_package_with_retry`). The registry recheck that loop performs just reports the version still absent for this error, so the publish is retried as a fresh attempt.

## Test plan
- [x] `deno test --config=scripts/test.deno.json --no-check --allow-read --allow-write --allow-env=... --allow-run scripts/ci/publish-npm-packages.test.ts` — 39/39 steps pass, including two new tests mirroring the existing 409-conflict coverage for both `rc_publish_package_dir` and `release_publish_package_dir`.
- [ ] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package publishing reliability by automatically retrying certain transient authentication and registry errors.
  - Preserved fail-closed behavior for stable releases while allowing recovery workflows to reconcile temporary publishing races.

- **Tests**
  - Added coverage to verify that affected publishing operations retry once and succeed when the transient error clears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->