### PR TITLE
fix(ci): give the sentry runtime packages job headroom on its timeout

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -694,7 +694,8 @@ jobs:
   tests-sentry-runtime-packages:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Cold-cache runs take ~12-15min; 15 was cutting it too close.
+    timeout-minutes: 20
     name: tests (sentry runtime packages)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary
- main's CI/CD kept going red today: `tests-sentry-runtime-packages` has `timeout-minutes: 15`, but a cold-cache run takes ~12-15min. Both times it crept over 15min (22:17 and 22:39 UTC runs) it got timeout-cancelled — GitHub reports this as job conclusion "cancelled".
- That cascades: `prerelease` needs this job and auto-skips when a dependency doesn't succeed, then `quality-gate-registry` still runs (its `if` uses `always()` by design — see `tests/integration/ci/registry-release-workflow.test.ts`) and hard-fails with "exact version and GITHUB_SHA are required" since there's no RC_VERSION to check.
- Bump the timeout to 20min for headroom. One-line change, no logic touched.

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] No test references this job's timeout value
- [ ] CI green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the runtime package test workflow timeout to improve reliability for slower cold-cache runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->