### PR TITLE
fix(agent): bind inference token on default chat dispatch

### DIFF
--- a/src/agent/hosted/chat-request-parser.ts
+++ b/src/agent/hosted/chat-request-parser.ts
@@ -43,6 +43,17 @@ import {
 
 const IntrinsicReflectApply = Reflect.apply;
 const JsonParse = JSON.parse;
+const RequestHeadersGetter = Object.getOwnPropertyDescriptor(Request.prototype, "headers")?.get;
+const HeadersGet = Headers.prototype.get;
+const StringTrim = String.prototype.trim;
+
+function readRequestHeader(request: Request, name: string): string | undefined {
+  if (!RequestHeadersGetter) return undefined;
+  const headers = IntrinsicReflectApply(RequestHeadersGetter, request, []) as Headers;
+  const value = IntrinsicReflectApply(HeadersGet, headers, [name]) as string | null;
+  if (value === null) return undefined;
+  return (IntrinsicReflectApply(StringTrim, value, []) as string) || undefined;
+}
 
 /** Internal control-plane credential for exact-run durable event appends. */
 export const RUN_EVENT_APPEND_TOKEN_HEADER = "X-Veryfront-Run-Event-Token";
@@ -192,7 +203,7 @@ async function withVerifiedRunEventAppendToken(
   >,
   inferenceAuthToken?: string,
 ): Promise<ParsedHostedChatRequest | Response> {
-  const token = request.headers.get(RUN_EVENT_APPEND_TOKEN_HEADER)?.trim();
+  const token = readRequestHeader(request, RUN_EVENT_APPEND_TOKEN_HEADER);
   if (!token) {
     const hasLegacyReplayState = isRecord(parsedRequest.forwardedProps) &&
       Object.hasOwn(
@@ -634,7 +645,7 @@ export async function parseHostedChatRequestFromRequest(
     options.verifyRunEventAppendToken,
     false,
     undefined,
-    request.headers.get(INFERENCE_TOKEN_HEADER)?.trim() || undefined,
+    readRequestHeader(request, INFERENCE_TOKEN_HEADER),
   );
 }
 

--- a/src/agent/hosted/chat-request-parser.ts
+++ b/src/agent/hosted/chat-request-parser.ts
@@ -48,11 +48,16 @@ const RequestHeadersGetter = Object.getOwnPropertyDescriptor(Request.prototype, 
 const HeadersGet = Headers.prototype.get;
 const StringTrim = String.prototype.trim;
 
-function readRequestHeader(request: Request, name: string): string | undefined {
+function readRequestHeaderRaw(request: Request, name: string): string | undefined {
   if (!RequestHeadersGetter) return undefined;
   const headers = IntrinsicReflectApply(RequestHeadersGetter, request, []) as Headers;
   const value = IntrinsicReflectApply(HeadersGet, headers, [name]) as string | null;
-  if (value === null) return undefined;
+  return value === null ? undefined : value;
+}
+
+function readRequestHeader(request: Request, name: string): string | undefined {
+  const value = readRequestHeaderRaw(request, name);
+  if (value === undefined) return undefined;
   return IntrinsicReflectApply(StringTrim, value, []) as string;
 }
 
@@ -65,9 +70,14 @@ function readRequestHeader(request: Request, name: string): string | undefined {
  * `requireInferenceProviderCredential` at the point the credential is
  * actually used -- potentially after the run has already been durably
  * accepted.
+ *
+ * Reads the raw, untrimmed value: trimming first would let edge whitespace
+ * (including non-ASCII whitespace such as U+00A0) silently disappear before
+ * the visible-ASCII check runs, turning a malformed header into a validated
+ * one instead of a 400.
  */
 function readInferenceTokenHeader(request: Request): string | undefined | Response {
-  const value = readRequestHeader(request, INFERENCE_TOKEN_HEADER);
+  const value = readRequestHeaderRaw(request, INFERENCE_TOKEN_HEADER);
   if (value === undefined) return undefined;
   try {
     return requireInferenceProviderCredential(value, "Inference token header");

--- a/src/agent/hosted/chat-request-parser.ts
+++ b/src/agent/hosted/chat-request-parser.ts
@@ -53,7 +53,7 @@ function readRequestHeader(request: Request, name: string): string | undefined {
   const headers = IntrinsicReflectApply(RequestHeadersGetter, request, []) as Headers;
   const value = IntrinsicReflectApply(HeadersGet, headers, [name]) as string | null;
   if (value === null) return undefined;
-  return (IntrinsicReflectApply(StringTrim, value, []) as string) || undefined;
+  return IntrinsicReflectApply(StringTrim, value, []) as string;
 }
 
 /**
@@ -225,7 +225,7 @@ async function withVerifiedRunEventAppendToken(
     ChatRequestContext,
     "runtimeTargetKind" | "runtimeTargetEnvironmentId"
   >,
-  inferenceAuthToken?: string,
+  bindInferenceTokenHeader = false,
 ): Promise<ParsedHostedChatRequest | Response> {
   const token = readRequestHeader(request, RUN_EVENT_APPEND_TOKEN_HEADER);
   if (!token) {
@@ -264,6 +264,13 @@ async function withVerifiedRunEventAppendToken(
       { errorCode: "INVALID_RUN_EVENT_APPEND_TOKEN" },
       { status: 403 },
     );
+  }
+
+  const inferenceAuthToken = bindInferenceTokenHeader
+    ? readInferenceTokenHeader(request)
+    : undefined;
+  if (inferenceAuthToken !== undefined && typeof inferenceAuthToken !== "string") {
+    return inferenceAuthToken;
   }
 
   // The grant rides on the verified token, so it is trusted on every path that
@@ -653,11 +660,6 @@ export async function parseHostedChatRequestFromRequest(
     });
   }
 
-  const inferenceAuthToken = readInferenceTokenHeader(request);
-  if (inferenceAuthToken !== undefined && typeof inferenceAuthToken !== "string") {
-    return inferenceAuthToken;
-  }
-
   const parsedRequest = await buildParsedHostedChatRequest({
     authToken: authenticatedRequest.authToken,
     userId: authenticatedRequest.userId,
@@ -674,7 +676,7 @@ export async function parseHostedChatRequestFromRequest(
     options.verifyRunEventAppendToken,
     false,
     undefined,
-    inferenceAuthToken,
+    true,
   );
 }
 

--- a/src/agent/hosted/chat-request-parser.ts
+++ b/src/agent/hosted/chat-request-parser.ts
@@ -31,6 +31,7 @@ import {
 import { getHostedChatUiToolIdentity } from "./chat-request-tool-part.ts";
 import { registerHostedRunEventWriterToken } from "./child-run-event-writer-token.ts";
 import { registerHostedInferenceCredential } from "./inference-credential.ts";
+import { requireInferenceProviderCredential } from "#veryfront/provider/runtime-loader/provider-request-init.ts";
 import {
   MAX_GRANTED_INTEGRATION_TOOL_NAMES,
   MAX_REMOTE_INTEGRATION_TOOL_NAME_LENGTH,
@@ -53,6 +54,29 @@ function readRequestHeader(request: Request, name: string): string | undefined {
   const value = IntrinsicReflectApply(HeadersGet, headers, [name]) as string | null;
   if (value === null) return undefined;
   return (IntrinsicReflectApply(StringTrim, value, []) as string) || undefined;
+}
+
+/**
+ * Reads and validates the inference token header with the same visible-ASCII
+ * and byte-size checks `credentials.inferenceAuthToken` gets from its Zod
+ * schema on the runtime-invocation path (`inferenceCredential()` in
+ * `agent-invocation-contract.ts`). Without this, a malformed or oversized
+ * header value is accepted and bound here, then only fails later inside
+ * `requireInferenceProviderCredential` at the point the credential is
+ * actually used -- potentially after the run has already been durably
+ * accepted.
+ */
+function readInferenceTokenHeader(request: Request): string | undefined | Response {
+  const value = readRequestHeader(request, INFERENCE_TOKEN_HEADER);
+  if (value === undefined) return undefined;
+  try {
+    return requireInferenceProviderCredential(value, "Inference token header");
+  } catch (error) {
+    return createValidationErrorResponse({
+      messagePrefix: "Invalid request",
+      validationMessage: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 /** Internal control-plane credential for exact-run durable event appends. */
@@ -629,6 +653,11 @@ export async function parseHostedChatRequestFromRequest(
     });
   }
 
+  const inferenceAuthToken = readInferenceTokenHeader(request);
+  if (inferenceAuthToken instanceof Response) {
+    return inferenceAuthToken;
+  }
+
   const parsedRequest = await buildParsedHostedChatRequest({
     authToken: authenticatedRequest.authToken,
     userId: authenticatedRequest.userId,
@@ -645,7 +674,7 @@ export async function parseHostedChatRequestFromRequest(
     options.verifyRunEventAppendToken,
     false,
     undefined,
-    readRequestHeader(request, INFERENCE_TOKEN_HEADER),
+    inferenceAuthToken,
   );
 }
 

--- a/src/agent/hosted/chat-request-parser.ts
+++ b/src/agent/hosted/chat-request-parser.ts
@@ -654,7 +654,7 @@ export async function parseHostedChatRequestFromRequest(
   }
 
   const inferenceAuthToken = readInferenceTokenHeader(request);
-  if (inferenceAuthToken instanceof Response) {
+  if (inferenceAuthToken !== undefined && typeof inferenceAuthToken !== "string") {
     return inferenceAuthToken;
   }
 

--- a/src/agent/hosted/chat-request-parser.ts
+++ b/src/agent/hosted/chat-request-parser.ts
@@ -46,6 +46,8 @@ const JsonParse = JSON.parse;
 
 /** Internal control-plane credential for exact-run durable event appends. */
 export const RUN_EVENT_APPEND_TOKEN_HEADER = "X-Veryfront-Run-Event-Token";
+/** Internal control-plane credential for managed inference on legacy chat dispatches. */
+export const INFERENCE_TOKEN_HEADER = "X-Veryfront-Inference-Token";
 
 /** Public API contract for hosted chat request principal. */
 export type HostedChatRequestPrincipal = {
@@ -188,6 +190,7 @@ async function withVerifiedRunEventAppendToken(
     ChatRequestContext,
     "runtimeTargetKind" | "runtimeTargetEnvironmentId"
   >,
+  inferenceAuthToken?: string,
 ): Promise<ParsedHostedChatRequest | Response> {
   const token = request.headers.get(RUN_EVENT_APPEND_TOKEN_HEADER)?.trim();
   if (!token) {
@@ -257,6 +260,7 @@ async function withVerifiedRunEventAppendToken(
       runId,
     },
   );
+  registerHostedInferenceCredential(verifiedRequest, inferenceAuthToken);
   return verifiedRequest;
 }
 
@@ -629,6 +633,8 @@ export async function parseHostedChatRequestFromRequest(
     parsedRequest,
     options.verifyRunEventAppendToken,
     false,
+    undefined,
+    request.headers.get(INFERENCE_TOKEN_HEADER)?.trim() || undefined,
   );
 }
 

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -2,6 +2,7 @@ import "#veryfront/schemas/_test-setup.ts";
 import { convertUiMessagesToProviderModelMessages } from "../../chat/provider-message-conversion.ts";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { DEFAULT_MAX_BODY_SIZE_BYTES } from "#veryfront/utils/constants/index.ts";
 import {
   buildHostedChatRequestForwardedPropsFromRuntimeAgentInvocation,
@@ -19,6 +20,7 @@ import {
   MAX_HOSTED_CHAT_REQUEST_MESSAGES,
 } from "./chat-request.ts";
 import { createHostedRunEventWriterCapabilityForRequest } from "./child-run-event-writer-token.ts";
+import { createHostedInferenceModelResolver } from "./inference-credential.ts";
 
 const conversationId = "10000000-1000-4000-8000-100000000001";
 const messageId = "10000000-1000-4000-8000-100000000002";
@@ -35,6 +37,23 @@ const environmentRuntimeSource = {
 } as const;
 const replayToolName = "github__get_pr_diff";
 const replayOutput = { files: ["src/chat/conversation.ts"] };
+
+function readableStreamFrom<T>(values: Iterable<T>): ReadableStream<T> {
+  return new ReadableStream({
+    start(controller) {
+      for (const value of values) controller.enqueue(value);
+      controller.close();
+    },
+  });
+}
+
+async function drainStream(stream: ReadableStream<unknown>): Promise<void> {
+  const reader = stream.getReader();
+  while (!(await reader.read()).done) {
+    // drain: the assertion targets the outgoing authorization header
+  }
+  reader.releaseLock();
+}
 const rawReplayToolCallPart = {
   type: "tool_call",
   id: "tool-call-1",
@@ -1866,6 +1885,70 @@ describe("agent/hosted-chat-request", () => {
     assertEquals(parsed.upstreamParentRunId, "run_parent_1");
     assertEquals(parsed.spawnedFromToolCallId, "tool_1");
     assertEquals(parsed.persistLatestUserMessageBeforeDurableRun, false);
+  });
+
+  it("binds a header inference credential only after the run-event token verifies", async () => {
+    const requestBody = JSON.stringify({
+      messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
+      context: { conversationId, projectId, branchId },
+      durableRootRun: { runId: "run_root_1", messageId },
+    });
+    const headers = {
+      "X-Veryfront-Run-Event-Token": "run-event-service-token",
+      "X-Veryfront-Inference-Token": "run-scoped-inference-token",
+    };
+    const options = {
+      authenticate: () => Promise.resolve({ userId, authToken: "control-plane-token" }),
+      verifyProjectAccess: () => Promise.resolve({ success: true as const }),
+      verifyRunEventAppendToken: () => Promise.resolve(true),
+    };
+
+    const parsed = await parseHostedChatRequestFromRequest(
+      new Request("https://agent.example.com/api/runs", {
+        method: "POST",
+        headers,
+        body: requestBody,
+      }),
+      options,
+    );
+    if (parsed instanceof Response) throw new Error("Expected parsed request");
+    const resolveModel = createHostedInferenceModelResolver(parsed);
+    assertEquals(typeof resolveModel, "function");
+
+    let capturedAuthorization: string | null = null;
+    installMockFetch(
+      (async (input: URL | Request | string, init?: RequestInit) => {
+        const request = new Request(input, init);
+        capturedAuthorization = request.headers.get("Authorization");
+        return new Response(
+          readableStreamFrom([
+            new TextEncoder().encode('data: {"choices":[{"finish_reason":"stop"}]}\n\n'),
+            new TextEncoder().encode("data: [DONE]\n\n"),
+          ]),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }) as typeof fetch,
+    );
+    try {
+      const model = resolveModel?.("veryfront-cloud/openai/gpt-test");
+      if (!model) throw new Error("Expected private inference model");
+      const result = await model.doStream({ prompt: [] });
+      await drainStream(result.stream);
+    } finally {
+      restoreMockFetch();
+    }
+    assertEquals(capturedAuthorization, "Bearer run-scoped-inference-token");
+
+    const unverified = await parseHostedChatRequestFromRequest(
+      new Request("https://agent.example.com/api/runs", {
+        method: "POST",
+        headers: { "X-Veryfront-Inference-Token": "run-scoped-inference-token" },
+        body: requestBody,
+      }),
+      options,
+    );
+    if (unverified instanceof Response) throw new Error("Expected parsed request");
+    assertEquals(createHostedInferenceModelResolver(unverified), undefined);
   });
 
   it("does not trust runtime environment targets from public hosted chat requests", async () => {

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -1915,49 +1915,6 @@ describe("agent/hosted-chat-request", () => {
     assertEquals(exposed, false);
   });
 
-  it("does not expose the inference header through a replaced Response constructor", async () => {
-    const inferenceToken = "run-scoped-inference-token";
-    const request = new Request("https://agent.example.test/api/runs", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "X-Veryfront-Run-Event-Token": "run-event-service-token",
-        "X-Veryfront-Inference-Token": inferenceToken,
-      },
-      body: JSON.stringify({
-        messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
-        context: { conversationId, projectId, branchId },
-        durableRootRun: { runId: "run_root_1", messageId },
-      }),
-    });
-    const NativeResponse = globalThis.Response;
-    const nativeHasInstance = Function.prototype[Symbol.hasInstance];
-    const observedValues: unknown[] = [];
-    class ObservingResponse extends NativeResponse {
-      static override [Symbol.hasInstance](value: unknown): boolean {
-        observedValues.push(value);
-        return Reflect.apply(nativeHasInstance, NativeResponse, [value]) as boolean;
-      }
-    }
-
-    const parsed = await (async () => {
-      globalThis.Response = ObservingResponse as typeof Response;
-      try {
-        return await parseHostedChatRequestFromRequest(request, {
-          authenticate: () => Promise.resolve({ userId, authToken: "control-plane-token" }),
-          verifyProjectAccess: () => Promise.resolve({ success: true as const }),
-          verifyRunEventAppendToken: () => Promise.resolve(true),
-        });
-      } finally {
-        globalThis.Response = NativeResponse;
-      }
-    })();
-
-    if (parsed instanceof NativeResponse) throw new Error("Expected parsed request");
-    assertEquals(observedValues.includes(inferenceToken), false);
-    assertEquals(typeof createHostedInferenceModelResolver(parsed), "function");
-  });
-
   it("ignores a malformed inference header without a verified run-event token", async () => {
     const parsed = await parseHostedChatRequestFromRequest(
       new Request("https://agent.example.test/api/runs", {

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -1915,6 +1915,49 @@ describe("agent/hosted-chat-request", () => {
     assertEquals(exposed, false);
   });
 
+  it("does not expose the inference header through a replaced Response constructor", async () => {
+    const inferenceToken = "run-scoped-inference-token";
+    const request = new Request("https://agent.example.test/api/runs", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-Veryfront-Run-Event-Token": "run-event-service-token",
+        "X-Veryfront-Inference-Token": inferenceToken,
+      },
+      body: JSON.stringify({
+        messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
+        context: { conversationId, projectId, branchId },
+        durableRootRun: { runId: "run_root_1", messageId },
+      }),
+    });
+    const NativeResponse = globalThis.Response;
+    const nativeHasInstance = Function.prototype[Symbol.hasInstance];
+    const observedValues: unknown[] = [];
+    class ObservingResponse extends NativeResponse {
+      static override [Symbol.hasInstance](value: unknown): boolean {
+        observedValues.push(value);
+        return Reflect.apply(nativeHasInstance, NativeResponse, [value]) as boolean;
+      }
+    }
+
+    const parsed = await (async () => {
+      globalThis.Response = ObservingResponse as typeof Response;
+      try {
+        return await parseHostedChatRequestFromRequest(request, {
+          authenticate: () => Promise.resolve({ userId, authToken: "control-plane-token" }),
+          verifyProjectAccess: () => Promise.resolve({ success: true as const }),
+          verifyRunEventAppendToken: () => Promise.resolve(true),
+        });
+      } finally {
+        globalThis.Response = NativeResponse;
+      }
+    })();
+
+    if (parsed instanceof NativeResponse) throw new Error("Expected parsed request");
+    assertEquals(observedValues.includes(inferenceToken), false);
+    assertEquals(typeof createHostedInferenceModelResolver(parsed), "function");
+  });
+
   it("ignores a default-chat inference header without a verified run-event token", async () => {
     const parsed = await parseHostedChatRequestFromRequest(
       new Request("https://agent.example.test/api/runs", {

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -19,6 +19,7 @@ import {
   MAX_HOSTED_CHAT_REQUEST_MESSAGES,
 } from "./chat-request.ts";
 import { createHostedRunEventWriterCapabilityForRequest } from "./child-run-event-writer-token.ts";
+import { createHostedInferenceModelResolver } from "./inference-credential.ts";
 
 const conversationId = "10000000-1000-4000-8000-100000000001";
 const messageId = "10000000-1000-4000-8000-100000000002";
@@ -1866,6 +1867,61 @@ describe("agent/hosted-chat-request", () => {
     assertEquals(parsed.upstreamParentRunId, "run_parent_1");
     assertEquals(parsed.spawnedFromToolCallId, "tool_1");
     assertEquals(parsed.persistLatestUserMessageBeforeDurableRun, false);
+  });
+
+  it("reads the default-chat inference header through captured intrinsics", async () => {
+    const request = new Request("https://agent.example.test/api/runs", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-Veryfront-Run-Event-Token": "run-event-service-token",
+        "X-Veryfront-Inference-Token": "run-scoped-inference-token",
+      },
+      body: JSON.stringify({
+        messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
+        context: { conversationId, projectId, branchId },
+        durableRootRun: { runId: "run_root_1", messageId },
+      }),
+    });
+    const requestHeadersDescriptor = Object.getOwnPropertyDescriptor(
+      Request.prototype,
+      "headers",
+    )!;
+    const headersGetDescriptor = Object.getOwnPropertyDescriptor(Headers.prototype, "get")!;
+    const requestHeaders = Reflect.apply(requestHeadersDescriptor.get!, request, []) as Headers;
+    let exposed = false;
+
+    Object.defineProperty(Request.prototype, "headers", {
+      ...requestHeadersDescriptor,
+      get() {
+        if (this === request) exposed = true;
+        return Reflect.apply(requestHeadersDescriptor.get!, this, []);
+      },
+    });
+    Object.defineProperty(Headers.prototype, "get", {
+      ...headersGetDescriptor,
+      value(this: Headers, name: string) {
+        if (this === requestHeaders && name.toLowerCase() === "x-veryfront-inference-token") {
+          exposed = true;
+        }
+        return Reflect.apply(headersGetDescriptor.value!, this, [name]);
+      },
+    });
+
+    try {
+      const parsed = await parseHostedChatRequestFromRequest(request, {
+        authenticate: () => Promise.resolve({ userId, authToken: "control-plane-token" }),
+        verifyProjectAccess: () => Promise.resolve({ success: true as const }),
+        verifyRunEventAppendToken: () => Promise.resolve(true),
+      });
+      if (parsed instanceof Response) throw new Error("Expected parsed request");
+      assertEquals(typeof createHostedInferenceModelResolver(parsed), "function");
+    } finally {
+      Object.defineProperty(Request.prototype, "headers", requestHeadersDescriptor);
+      Object.defineProperty(Headers.prototype, "get", headersGetDescriptor);
+    }
+
+    assertEquals(exposed, false);
   });
 
   it("does not trust runtime environment targets from public hosted chat requests", async () => {

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -2,7 +2,6 @@ import "#veryfront/schemas/_test-setup.ts";
 import { convertUiMessagesToProviderModelMessages } from "../../chat/provider-message-conversion.ts";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { installMockFetch, restoreMockFetch } from "#veryfront/testing/mock-fetch.ts";
 import { DEFAULT_MAX_BODY_SIZE_BYTES } from "#veryfront/utils/constants/index.ts";
 import {
   buildHostedChatRequestForwardedPropsFromRuntimeAgentInvocation,
@@ -20,7 +19,6 @@ import {
   MAX_HOSTED_CHAT_REQUEST_MESSAGES,
 } from "./chat-request.ts";
 import { createHostedRunEventWriterCapabilityForRequest } from "./child-run-event-writer-token.ts";
-import { createHostedInferenceModelResolver } from "./inference-credential.ts";
 
 const conversationId = "10000000-1000-4000-8000-100000000001";
 const messageId = "10000000-1000-4000-8000-100000000002";
@@ -37,23 +35,6 @@ const environmentRuntimeSource = {
 } as const;
 const replayToolName = "github__get_pr_diff";
 const replayOutput = { files: ["src/chat/conversation.ts"] };
-
-function readableStreamFrom<T>(values: Iterable<T>): ReadableStream<T> {
-  return new ReadableStream({
-    start(controller) {
-      for (const value of values) controller.enqueue(value);
-      controller.close();
-    },
-  });
-}
-
-async function drainStream(stream: ReadableStream<unknown>): Promise<void> {
-  const reader = stream.getReader();
-  while (!(await reader.read()).done) {
-    // drain: the assertion targets the outgoing authorization header
-  }
-  reader.releaseLock();
-}
 const rawReplayToolCallPart = {
   type: "tool_call",
   id: "tool-call-1",
@@ -1885,70 +1866,6 @@ describe("agent/hosted-chat-request", () => {
     assertEquals(parsed.upstreamParentRunId, "run_parent_1");
     assertEquals(parsed.spawnedFromToolCallId, "tool_1");
     assertEquals(parsed.persistLatestUserMessageBeforeDurableRun, false);
-  });
-
-  it("binds a header inference credential only after the run-event token verifies", async () => {
-    const requestBody = JSON.stringify({
-      messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
-      context: { conversationId, projectId, branchId },
-      durableRootRun: { runId: "run_root_1", messageId },
-    });
-    const headers = {
-      "X-Veryfront-Run-Event-Token": "run-event-service-token",
-      "X-Veryfront-Inference-Token": "run-scoped-inference-token",
-    };
-    const options = {
-      authenticate: () => Promise.resolve({ userId, authToken: "control-plane-token" }),
-      verifyProjectAccess: () => Promise.resolve({ success: true as const }),
-      verifyRunEventAppendToken: () => Promise.resolve(true),
-    };
-
-    const parsed = await parseHostedChatRequestFromRequest(
-      new Request("https://agent.example.com/api/runs", {
-        method: "POST",
-        headers,
-        body: requestBody,
-      }),
-      options,
-    );
-    if (parsed instanceof Response) throw new Error("Expected parsed request");
-    const resolveModel = createHostedInferenceModelResolver(parsed);
-    assertEquals(typeof resolveModel, "function");
-
-    let capturedAuthorization: string | null = null;
-    installMockFetch(
-      (async (input: URL | Request | string, init?: RequestInit) => {
-        const request = new Request(input, init);
-        capturedAuthorization = request.headers.get("Authorization");
-        return new Response(
-          readableStreamFrom([
-            new TextEncoder().encode('data: {"choices":[{"finish_reason":"stop"}]}\n\n'),
-            new TextEncoder().encode("data: [DONE]\n\n"),
-          ]),
-          { status: 200, headers: { "content-type": "text/event-stream" } },
-        );
-      }) as typeof fetch,
-    );
-    try {
-      const model = resolveModel?.("veryfront-cloud/openai/gpt-test");
-      if (!model) throw new Error("Expected private inference model");
-      const result = await model.doStream({ prompt: [] });
-      await drainStream(result.stream);
-    } finally {
-      restoreMockFetch();
-    }
-    assertEquals(capturedAuthorization, "Bearer run-scoped-inference-token");
-
-    const unverified = await parseHostedChatRequestFromRequest(
-      new Request("https://agent.example.com/api/runs", {
-        method: "POST",
-        headers: { "X-Veryfront-Inference-Token": "run-scoped-inference-token" },
-        body: requestBody,
-      }),
-      options,
-    );
-    if (unverified instanceof Response) throw new Error("Expected parsed request");
-    assertEquals(createHostedInferenceModelResolver(unverified), undefined);
   });
 
   it("does not trust runtime environment targets from public hosted chat requests", async () => {

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -1915,6 +1915,33 @@ describe("agent/hosted-chat-request", () => {
     assertEquals(exposed, false);
   });
 
+  it("ignores a default-chat inference header without a verified run-event token", async () => {
+    const parsed = await parseHostedChatRequestFromRequest(
+      new Request("https://agent.example.test/api/runs", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "X-Veryfront-Inference-Token": "unverified-inference-token",
+        },
+        body: JSON.stringify({
+          messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
+          context: { conversationId, projectId, branchId },
+          durableRootRun: { runId: "run_root_1", messageId },
+        }),
+      }),
+      {
+        authenticate: () => Promise.resolve({ userId, authToken: "control-plane-token" }),
+        verifyProjectAccess: () => Promise.resolve({ success: true as const }),
+        verifyRunEventAppendToken: () => {
+          throw new Error("run-event verification must not run without its token");
+        },
+      },
+    );
+
+    if (parsed instanceof Response) throw new Error("Expected parsed request");
+    assertEquals(createHostedInferenceModelResolver(parsed), undefined);
+  });
+
   it("does not trust runtime environment targets from public hosted chat requests", async () => {
     const parsed = await parseHostedChatRequestFromRequest(
       new Request("https://agent.example.com/api/runs", {
@@ -2295,12 +2322,13 @@ describe("agent/hosted-chat-request", () => {
     assertEquals(parsed.success, false);
   });
 
-  it("rejects a run-event append header that is not cryptographically verified", async () => {
+  it("rejects an inference header when the run-event token is not verified", async () => {
     const response = await parseHostedChatRequestFromRequest(
       new Request("https://agent.example.com/api/runs", {
         method: "POST",
         headers: {
           "X-Veryfront-Run-Event-Token": "forged-run-event-token",
+          "X-Veryfront-Inference-Token": "unverified-inference-token",
         },
         body: JSON.stringify({
           messages: [],

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -1958,13 +1958,13 @@ describe("agent/hosted-chat-request", () => {
     assertEquals(typeof createHostedInferenceModelResolver(parsed), "function");
   });
 
-  it("ignores a default-chat inference header without a verified run-event token", async () => {
+  it("ignores a malformed inference header without a verified run-event token", async () => {
     const parsed = await parseHostedChatRequestFromRequest(
       new Request("https://agent.example.test/api/runs", {
         method: "POST",
         headers: {
           "content-type": "application/json",
-          "X-Veryfront-Inference-Token": "unverified-inference-token",
+          "X-Veryfront-Inference-Token": "unverified inference token",
         },
         body: JSON.stringify({
           messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
@@ -2020,32 +2020,34 @@ describe("agent/hosted-chat-request", () => {
     assertStringIncludes(body.message, "16");
   });
 
-  it("rejects a non-visible-ASCII default-chat inference header before binding it", async () => {
-    const response = await parseHostedChatRequestFromRequest(
-      new Request("https://agent.example.test/api/runs", {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "X-Veryfront-Run-Event-Token": "run-event-service-token",
-          "X-Veryfront-Inference-Token": "token with a space",
-        },
-        body: JSON.stringify({
-          messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
-          context: { conversationId, projectId, branchId },
-          durableRootRun: { runId: "run_root_1", messageId },
+  it("rejects blank and non-visible-ASCII inference headers after writer verification", async () => {
+    for (const inferenceToken of ["", "token with a space"]) {
+      const response = await parseHostedChatRequestFromRequest(
+        new Request("https://agent.example.test/api/runs", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "X-Veryfront-Run-Event-Token": "run-event-service-token",
+            "X-Veryfront-Inference-Token": inferenceToken,
+          },
+          body: JSON.stringify({
+            messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
+            context: { conversationId, projectId, branchId },
+            durableRootRun: { runId: "run_root_1", messageId },
+          }),
         }),
-      }),
-      {
-        authenticate: () => Promise.resolve({ userId, authToken: "control-plane-token" }),
-        verifyProjectAccess: () => Promise.resolve({ success: true as const }),
-        verifyRunEventAppendToken: () => Promise.resolve(true),
-      },
-    );
+        {
+          authenticate: () => Promise.resolve({ userId, authToken: "control-plane-token" }),
+          verifyProjectAccess: () => Promise.resolve({ success: true as const }),
+          verifyRunEventAppendToken: () => Promise.resolve(true),
+        },
+      );
 
-    if (!(response instanceof Response)) {
-      throw new Error("Expected a validation error response");
+      if (!(response instanceof Response)) {
+        throw new Error("Expected a validation error response");
+      }
+      assertEquals(response.status, 400);
     }
-    assertEquals(response.status, 400);
   });
 
   it("does not trust runtime environment targets from public hosted chat requests", async () => {
@@ -2434,7 +2436,7 @@ describe("agent/hosted-chat-request", () => {
         method: "POST",
         headers: {
           "X-Veryfront-Run-Event-Token": "forged-run-event-token",
-          "X-Veryfront-Inference-Token": "unverified-inference-token",
+          "X-Veryfront-Inference-Token": "unverified inference token",
         },
         body: JSON.stringify({
           messages: [],

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -1942,6 +1942,69 @@ describe("agent/hosted-chat-request", () => {
     assertEquals(createHostedInferenceModelResolver(parsed), undefined);
   });
 
+  it("rejects an oversized default-chat inference header before binding it", async () => {
+    // credentials.inferenceAuthToken gets a 16 KB byte-size check from its Zod
+    // schema on the runtime-invocation path; the header carrying the same
+    // credential on the default-chat path must reject a value past that bound
+    // instead of registering it and only failing later at point of use.
+    const oversizedToken = "a".repeat(16 * 1024 + 1);
+    const response = await parseHostedChatRequestFromRequest(
+      new Request("https://agent.example.test/api/runs", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "X-Veryfront-Run-Event-Token": "run-event-service-token",
+          "X-Veryfront-Inference-Token": oversizedToken,
+        },
+        body: JSON.stringify({
+          messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
+          context: { conversationId, projectId, branchId },
+          durableRootRun: { runId: "run_root_1", messageId },
+        }),
+      }),
+      {
+        authenticate: () => Promise.resolve({ userId, authToken: "control-plane-token" }),
+        verifyProjectAccess: () => Promise.resolve({ success: true as const }),
+        verifyRunEventAppendToken: () => Promise.resolve(true),
+      },
+    );
+
+    if (!(response instanceof Response)) {
+      throw new Error("Expected a validation error response");
+    }
+    assertEquals(response.status, 400);
+    const body = await response.json();
+    assertStringIncludes(body.message, "16");
+  });
+
+  it("rejects a non-visible-ASCII default-chat inference header before binding it", async () => {
+    const response = await parseHostedChatRequestFromRequest(
+      new Request("https://agent.example.test/api/runs", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "X-Veryfront-Run-Event-Token": "run-event-service-token",
+          "X-Veryfront-Inference-Token": "token with a space",
+        },
+        body: JSON.stringify({
+          messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
+          context: { conversationId, projectId, branchId },
+          durableRootRun: { runId: "run_root_1", messageId },
+        }),
+      }),
+      {
+        authenticate: () => Promise.resolve({ userId, authToken: "control-plane-token" }),
+        verifyProjectAccess: () => Promise.resolve({ success: true as const }),
+        verifyRunEventAppendToken: () => Promise.resolve(true),
+      },
+    );
+
+    if (!(response instanceof Response)) {
+      throw new Error("Expected a validation error response");
+    }
+    assertEquals(response.status, 400);
+  });
+
   it("does not trust runtime environment targets from public hosted chat requests", async () => {
     const parsed = await parseHostedChatRequestFromRequest(
       new Request("https://agent.example.com/api/runs", {

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -1978,7 +1978,16 @@ describe("agent/hosted-chat-request", () => {
   });
 
   it("rejects blank and non-visible-ASCII inference headers after writer verification", async () => {
-    for (const inferenceToken of ["", "token with a space"]) {
+    for (
+      const inferenceToken of [
+        "",
+        "token with a space",
+        // U+00A0 (non-breaking space) is whitespace under String.prototype.trim,
+        // so a naive trim-then-validate order would silently strip it and bind
+        // an unintended credential instead of rejecting the malformed header.
+        " padded-token ",
+      ]
+    ) {
       const response = await parseHostedChatRequestFromRequest(
         new Request("https://agent.example.test/api/runs", {
           method: "POST",

--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -1883,43 +1883,34 @@ describe("agent/hosted-chat-request", () => {
         durableRootRun: { runId: "run_root_1", messageId },
       }),
     });
-    const requestHeadersDescriptor = Object.getOwnPropertyDescriptor(
-      Request.prototype,
-      "headers",
-    )!;
-    const headersGetDescriptor = Object.getOwnPropertyDescriptor(Headers.prototype, "get")!;
-    const requestHeaders = Reflect.apply(requestHeadersDescriptor.get!, request, []) as Headers;
+    const requestHeadersGetter = Object.getOwnPropertyDescriptor(Request.prototype, "headers")!
+      .get!;
+    const headersGet = Object.getOwnPropertyDescriptor(Headers.prototype, "get")!.value!;
+    const requestHeaders = Reflect.apply(requestHeadersGetter, request, []) as Headers;
     let exposed = false;
 
-    Object.defineProperty(Request.prototype, "headers", {
-      ...requestHeadersDescriptor,
+    Object.defineProperty(request, "headers", {
+      configurable: true,
       get() {
-        if (this === request) exposed = true;
-        return Reflect.apply(requestHeadersDescriptor.get!, this, []);
+        exposed = true;
+        return requestHeaders;
       },
     });
-    Object.defineProperty(Headers.prototype, "get", {
-      ...headersGetDescriptor,
-      value(this: Headers, name: string) {
-        if (this === requestHeaders && name.toLowerCase() === "x-veryfront-inference-token") {
-          exposed = true;
-        }
-        return Reflect.apply(headersGetDescriptor.value!, this, [name]);
+    Object.defineProperty(requestHeaders, "get", {
+      configurable: true,
+      value(name: string) {
+        exposed = true;
+        return Reflect.apply(headersGet, requestHeaders, [name]);
       },
     });
 
-    try {
-      const parsed = await parseHostedChatRequestFromRequest(request, {
-        authenticate: () => Promise.resolve({ userId, authToken: "control-plane-token" }),
-        verifyProjectAccess: () => Promise.resolve({ success: true as const }),
-        verifyRunEventAppendToken: () => Promise.resolve(true),
-      });
-      if (parsed instanceof Response) throw new Error("Expected parsed request");
-      assertEquals(typeof createHostedInferenceModelResolver(parsed), "function");
-    } finally {
-      Object.defineProperty(Request.prototype, "headers", requestHeadersDescriptor);
-      Object.defineProperty(Headers.prototype, "get", headersGetDescriptor);
-    }
+    const parsed = await parseHostedChatRequestFromRequest(request, {
+      authenticate: () => Promise.resolve({ userId, authToken: "control-plane-token" }),
+      verifyProjectAccess: () => Promise.resolve({ success: true as const }),
+      verifyRunEventAppendToken: () => Promise.resolve(true),
+    });
+    if (parsed instanceof Response) throw new Error("Expected parsed request");
+    assertEquals(typeof createHostedInferenceModelResolver(parsed), "function");
 
     assertEquals(exposed, false);
   });

--- a/src/agent/service/auth.test.ts
+++ b/src/agent/service/auth.test.ts
@@ -234,21 +234,16 @@ describe("agent/agent-service-auth", () => {
         "x-veryfront-inference-token": "private-inference-token",
       },
     });
-    const originalHeaders = Object.getOwnPropertyDescriptor(Request.prototype, "headers")!;
     let replacementCalled = false;
-    Object.defineProperty(Request.prototype, "headers", {
+    Object.defineProperty(request, "headers", {
       configurable: true,
       get() {
         replacementCalled = true;
         throw new Error("project getter must not receive the request");
       },
     });
-    try {
-      assertEquals(getHostedServiceTokenFromRequest(request), "bearer-token");
-      assertEquals(replacementCalled, false);
-    } finally {
-      Object.defineProperty(Request.prototype, "headers", originalHeaders);
-    }
+    assertEquals(getHostedServiceTokenFromRequest(request), "bearer-token");
+    assertEquals(replacementCalled, false);
   });
 
   it("returns null when no auth token exists", () => {

--- a/src/agent/service/auth.test.ts
+++ b/src/agent/service/auth.test.ts
@@ -227,6 +227,30 @@ describe("agent/agent-service-auth", () => {
     assertEquals(getHostedServiceTokenFromRequest(request), "bearer-token");
   });
 
+  it("does not expose request headers through a replaced prototype getter", () => {
+    const request = new Request("https://agent.test/run", {
+      headers: {
+        authorization: "Bearer bearer-token",
+        "x-veryfront-inference-token": "private-inference-token",
+      },
+    });
+    const originalHeaders = Object.getOwnPropertyDescriptor(Request.prototype, "headers")!;
+    let replacementCalled = false;
+    Object.defineProperty(Request.prototype, "headers", {
+      configurable: true,
+      get() {
+        replacementCalled = true;
+        throw new Error("project getter must not receive the request");
+      },
+    });
+    try {
+      assertEquals(getHostedServiceTokenFromRequest(request), "bearer-token");
+      assertEquals(replacementCalled, false);
+    } finally {
+      Object.defineProperty(Request.prototype, "headers", originalHeaders);
+    }
+  });
+
   it("returns null when no auth token exists", () => {
     const request = new Request("https://agent.test/run");
     assertStrictEquals(getHostedServiceTokenFromRequest(request), null);

--- a/src/agent/service/auth.ts
+++ b/src/agent/service/auth.ts
@@ -3,6 +3,19 @@ import { NOT_SUPPORTED } from "#veryfront/errors";
 import { importFirstPartyExtensionModule } from "#veryfront/extensions/first-party-import.ts";
 import type { AuthProvider, TokenPayload } from "#veryfront/extensions/auth/index.ts";
 
+const ReflectApply = Reflect.apply;
+const RequestHeadersGetter = Object.getOwnPropertyDescriptor(Request.prototype, "headers")?.get;
+const HeadersGet = Headers.prototype.get;
+const RegExpExec = RegExp.prototype.exec;
+const StringStartsWith = String.prototype.startsWith;
+const StringSlice = String.prototype.slice;
+
+function readRequestHeader(request: Request, name: string): string | null {
+  if (!RequestHeadersGetter) return null;
+  const headers = ReflectApply(RequestHeadersGetter, request, []) as Headers;
+  return ReflectApply(HeadersGet, headers, [name]) as string | null;
+}
+
 /** Public API contract for hosted service auth error code. */
 export type HostedServiceAuthErrorCode =
   | "UNAUTHENTICATED"
@@ -232,12 +245,16 @@ async function getAuthProvider(
 
 /** Request payload for get hosted service token from. */
 export function getHostedServiceTokenFromRequest(request: Request): string | null {
-  const cookies = request.headers.get("cookie") || "";
-  const cookieMatch = cookies.match(/(?:^|;\s*)authToken=([^;]+)/);
+  const cookies = readRequestHeader(request, "cookie") || "";
+  const cookieMatch = ReflectApply(RegExpExec, /(?:^|;\s*)authToken=([^;]+)/, [cookies]) as
+    | RegExpExecArray
+    | null;
   if (cookieMatch?.[1]) return cookieMatch[1];
 
-  const authHeader = request.headers.get("authorization");
-  if (authHeader?.startsWith("Bearer ")) return authHeader.slice(7);
+  const authHeader = readRequestHeader(request, "authorization");
+  if (authHeader && ReflectApply(StringStartsWith, authHeader, ["Bearer "])) {
+    return ReflectApply(StringSlice, authHeader, [7]) as string;
+  }
 
   return null;
 }

--- a/src/provider/runtime-loader/provider-request-init.ts
+++ b/src/provider/runtime-loader/provider-request-init.ts
@@ -2,43 +2,31 @@ import { MAX_RUNTIME_INFERENCE_CREDENTIAL_BYTES } from "#veryfront/security/cred
 
 const IntrinsicReflectApply = Reflect.apply;
 const StringPrototypeTrim = String.prototype.trim;
-const RegExpPrototypeTest = RegExp.prototype.test;
-const TextEncoderEncode = TextEncoder.prototype.encode;
-// The shared %TypedArray% prototype -- Uint8Array.prototype's own prototype --
-// carries the one `byteLength` getter every typed array subclass inherits.
-const TypedArrayByteLengthGetter = Object.getOwnPropertyDescriptor(
-  Object.getPrototypeOf(Uint8Array.prototype) as object,
-  "byteLength",
-)?.get;
+const StringPrototypeCharCodeAt = String.prototype.charCodeAt;
 const ANTHROPIC_FINE_GRAINED_TOOL_STREAMING_BETA = "fine-grained-tool-streaming-2025-05-14";
 const ANTHROPIC_MCP_CLIENT_BETA = "mcp-client-2025-11-20";
 const DEPRECATED_ANTHROPIC_MCP_CLIENT_BETA = "mcp-client-2025-04-04";
 const MAX_PROVIDER_CREDENTIAL_BYTES = 8 * 1024;
 const MAX_INFERENCE_CREDENTIAL_BYTES = MAX_RUNTIME_INFERENCE_CREDENTIAL_BYTES;
-const PROVIDER_CREDENTIAL_ENCODER = new TextEncoder();
-const CREDENTIAL_PATTERN = /^[\x21-\x7e]+$/;
 
 function trimCredential(value: string): string {
   return IntrinsicReflectApply(StringPrototypeTrim, value, []) as string;
 }
 
 function matchesCredentialPattern(value: string): boolean {
-  return IntrinsicReflectApply(RegExpPrototypeTest, CREDENTIAL_PATTERN, [value]) as boolean;
+  if (value.length === 0) return false;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = IntrinsicReflectApply(StringPrototypeCharCodeAt, value, [index]) as number;
+    if (code < 0x21 || code > 0x7e) return false;
+  }
+  return true;
 }
 
-/**
- * Reads the encoded credential's byte length through a getter captured at
- * module load, not the live `.byteLength` accessor. Project code sharing this
- * realm can redefine the configurable %TypedArray%.prototype.byteLength
- * getter; a live read would hand it the encoded credential bytes as `this`,
- * letting it decode and retain the run-scoped credential.
- */
 function credentialByteLength(value: string): number {
-  const encoded = IntrinsicReflectApply(TextEncoderEncode, PROVIDER_CREDENTIAL_ENCODER, [
-    value,
-  ]) as Uint8Array;
-  if (!TypedArrayByteLengthGetter) return encoded.byteLength;
-  return IntrinsicReflectApply(TypedArrayByteLengthGetter, encoded, []) as number;
+  // The visible-ASCII check runs before this function, so UTF-8 bytes and
+  // UTF-16 code units are identical. Avoid materializing secret-bearing bytes
+  // that a replaced typed-array intrinsic could observe.
+  return value.length;
 }
 
 /**

--- a/src/provider/runtime-loader/provider-request-init.ts
+++ b/src/provider/runtime-loader/provider-request-init.ts
@@ -4,6 +4,12 @@ const IntrinsicReflectApply = Reflect.apply;
 const StringPrototypeTrim = String.prototype.trim;
 const RegExpPrototypeTest = RegExp.prototype.test;
 const TextEncoderEncode = TextEncoder.prototype.encode;
+// The shared %TypedArray% prototype -- Uint8Array.prototype's own prototype --
+// carries the one `byteLength` getter every typed array subclass inherits.
+const TypedArrayByteLengthGetter = Object.getOwnPropertyDescriptor(
+  Object.getPrototypeOf(Uint8Array.prototype) as object,
+  "byteLength",
+)?.get;
 const ANTHROPIC_FINE_GRAINED_TOOL_STREAMING_BETA = "fine-grained-tool-streaming-2025-05-14";
 const ANTHROPIC_MCP_CLIENT_BETA = "mcp-client-2025-11-20";
 const DEPRECATED_ANTHROPIC_MCP_CLIENT_BETA = "mcp-client-2025-04-04";
@@ -20,11 +26,19 @@ function matchesCredentialPattern(value: string): boolean {
   return IntrinsicReflectApply(RegExpPrototypeTest, CREDENTIAL_PATTERN, [value]) as boolean;
 }
 
+/**
+ * Reads the encoded credential's byte length through a getter captured at
+ * module load, not the live `.byteLength` accessor. Project code sharing this
+ * realm can redefine the configurable %TypedArray%.prototype.byteLength
+ * getter; a live read would hand it the encoded credential bytes as `this`,
+ * letting it decode and retain the run-scoped credential.
+ */
 function credentialByteLength(value: string): number {
-  return (IntrinsicReflectApply(TextEncoderEncode, PROVIDER_CREDENTIAL_ENCODER, [
+  const encoded = IntrinsicReflectApply(TextEncoderEncode, PROVIDER_CREDENTIAL_ENCODER, [
     value,
-  ]) as Uint8Array)
-    .byteLength;
+  ]) as Uint8Array;
+  if (!TypedArrayByteLengthGetter) return encoded.byteLength;
+  return IntrinsicReflectApply(TypedArrayByteLengthGetter, encoded, []) as number;
 }
 
 /**

--- a/tests/integration/agent/run-scoped-inference-credential.test.ts
+++ b/tests/integration/agent/run-scoped-inference-credential.test.ts
@@ -820,6 +820,81 @@ describe("run-scoped inference credential", () => {
     assertEquals(exposedToSharedRealmJson, false);
   });
 
+  it("routes a default-chat inference header to gateway Authorization", async () => {
+    setEnv("VERYFRONT_API_TOKEN", "broader-project-runtime-token");
+    setEnv("VERYFRONT_PROJECT_SLUG", "provider-test-project");
+    let capturedAuthorization: string | null = null;
+    let frameworkModel: ReturnType<typeof resolveModel> | undefined;
+    const encoder = new TextEncoder();
+    installMockFetch(
+      (async (input: URL | Request | string, init?: RequestInit) => {
+        const request = new Request(input, init);
+        capturedAuthorization = request.headers.get("Authorization");
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode('data: {"choices":[{"finish_reason":"stop"}]}\n\n'),
+              );
+              controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+              controller.close();
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/event-stream" } },
+        );
+      }) as typeof fetch,
+    );
+
+    const routeSet = createHostedAgentServiceRouteSet({
+      tracker: createDetachedRunTracker<AgUiResumeValue>(),
+      runtimeSource: { type: "release", releaseId: "release-42" },
+      authenticateRequest: async (): Promise<HostedServiceAuthenticatedRequest | Response> => ({
+        authToken: "broader-control-plane-token",
+        userId: "user-1",
+      }),
+      verifyProjectAccess: async () => ({ success: true }),
+      verifyRunEventAppendToken: async () => ({ verified: true }),
+      prepareExecution: async (request) => {
+        frameworkModel = createHostedInferenceModelResolver(request)?.(
+          "veryfront-cloud/openai/gpt-test",
+        );
+        return { executionId: "exec-default-chat" };
+      },
+      streamExecutionToAgUiResponse: () => new Response("streamed"),
+      startDetachedExecution: async () => {
+        if (!frameworkModel) throw new TypeError("Expected framework model");
+        const result = await frameworkModel.doStream({ prompt: [] });
+        await drainStream(result.stream);
+      },
+    });
+    const response = await routeSet.handleDurableChatRunExecuteRequest({
+      request: new Request("https://agent.example.test/api/runs", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "X-Veryfront-Run-Event-Token": "run-event-token",
+          "X-Veryfront-Inference-Token": "run-scoped-inference-token",
+        },
+        body: JSON.stringify({
+          messages: [{ id: "message-1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
+          context: {
+            conversationId: "00000000-0000-4000-8000-000000000001",
+            projectId: "00000000-0000-4000-8000-000000000005",
+            branchId: null,
+          },
+          model: "openai/gpt-test",
+          durableRootRun: {
+            runId: "run-default-chat",
+            messageId: "00000000-0000-4000-8000-000000000002",
+          },
+        }),
+      }),
+    });
+
+    assertEquals(response.status, 202);
+    assertEquals(capturedAuthorization, "Bearer run-scoped-inference-token");
+  });
+
   it("ignores an inference credential without a verified run-event token", async () => {
     setEnv("VERYFRONT_API_TOKEN", "broader-project-runtime-token");
     setEnv("VERYFRONT_PROJECT_SLUG", "provider-test-project");

--- a/tests/integration/semantic-unit-boundary/src/agent/hosted/chat-request-response-intrinsics.test.ts
+++ b/tests/integration/semantic-unit-boundary/src/agent/hosted/chat-request-response-intrinsics.test.ts
@@ -1,10 +1,11 @@
-// This security boundary test intentionally replaces a shared-realm constructor,
-// so it belongs in the semantic integration suite rather than a unit module.
+// These security boundary tests intentionally replace shared-realm intrinsics,
+// so they belong in the semantic integration suite rather than a unit module.
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { parseHostedChatRequestFromRequest } from "#veryfront/agent/hosted/chat-request-parser.ts";
 import { createHostedInferenceModelResolver } from "#veryfront/agent/hosted/inference-credential.ts";
+import { requireInferenceProviderCredential } from "#veryfront/provider/runtime-loader/provider-request-init.ts";
 
 const conversationId = "10000000-1000-4000-8000-100000000001";
 const messageId = "10000000-1000-4000-8000-100000000002";
@@ -12,7 +13,7 @@ const userId = "10000000-1000-4000-8000-100000000004";
 const projectId = "10000000-1000-4000-8000-100000000005";
 const branchId = "10000000-1000-4000-8000-100000000006";
 
-describe("hosted chat Response intrinsic boundary", () => {
+describe("hosted inference credential intrinsic boundaries", () => {
   it("does not expose the inference header through a replaced Response constructor", async () => {
     const inferenceToken = "run-scoped-inference-token";
     const request = new Request("https://agent.example.test/api/runs", {
@@ -54,5 +55,61 @@ describe("hosted chat Response intrinsic boundary", () => {
     if (parsed instanceof NativeResponse) throw new Error("Expected parsed request");
     assertEquals(observedValues.includes(inferenceToken), false);
     assertEquals(typeof createHostedInferenceModelResolver(parsed), "function");
+  });
+
+  it("does not expose credential bytes through a replaced typed-array byteLength getter", () => {
+    const inferenceToken = "run-scoped-inference-token";
+    const typedArrayPrototype = Object.getPrototypeOf(Uint8Array.prototype);
+    const byteLengthDescriptor = Object.getOwnPropertyDescriptor(
+      typedArrayPrototype,
+      "byteLength",
+    );
+    if (typeof byteLengthDescriptor?.get !== "function") {
+      throw new TypeError("Expected the typed-array byteLength getter");
+    }
+    const nativeByteLengthGetter = byteLengthDescriptor.get;
+    const observedReceivers: Uint8Array[] = [];
+
+    Object.defineProperty(typedArrayPrototype, "byteLength", {
+      ...byteLengthDescriptor,
+      get(this: Uint8Array): number {
+        observedReceivers.push(this);
+        return Reflect.apply(nativeByteLengthGetter, this, []) as number;
+      },
+    });
+    try {
+      assertEquals(
+        requireInferenceProviderCredential(inferenceToken, "Inference token header"),
+        inferenceToken,
+      );
+    } finally {
+      Object.defineProperty(typedArrayPrototype, "byteLength", byteLengthDescriptor);
+    }
+
+    assertEquals(
+      observedReceivers.some((bytes) => new TextDecoder().decode(bytes) === inferenceToken),
+      false,
+    );
+  });
+
+  it("does not expose credentials through a replaced RegExp exec method", () => {
+    const inferenceToken = "run-scoped-inference-token";
+    const nativeExec = RegExp.prototype.exec;
+    const observedValues: unknown[] = [];
+
+    RegExp.prototype.exec = function (value: string): RegExpExecArray | null {
+      observedValues.push(value);
+      return Reflect.apply(nativeExec, this, [value]) as RegExpExecArray | null;
+    };
+    try {
+      assertEquals(
+        requireInferenceProviderCredential(inferenceToken, "Inference token header"),
+        inferenceToken,
+      );
+    } finally {
+      RegExp.prototype.exec = nativeExec;
+    }
+
+    assertEquals(observedValues.includes(inferenceToken), false);
   });
 });

--- a/tests/integration/semantic-unit-boundary/src/agent/hosted/chat-request-response-intrinsics.test.ts
+++ b/tests/integration/semantic-unit-boundary/src/agent/hosted/chat-request-response-intrinsics.test.ts
@@ -1,0 +1,58 @@
+// This security boundary test intentionally replaces a shared-realm constructor,
+// so it belongs in the semantic integration suite rather than a unit module.
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { parseHostedChatRequestFromRequest } from "#veryfront/agent/hosted/chat-request-parser.ts";
+import { createHostedInferenceModelResolver } from "#veryfront/agent/hosted/inference-credential.ts";
+
+const conversationId = "10000000-1000-4000-8000-100000000001";
+const messageId = "10000000-1000-4000-8000-100000000002";
+const userId = "10000000-1000-4000-8000-100000000004";
+const projectId = "10000000-1000-4000-8000-100000000005";
+const branchId = "10000000-1000-4000-8000-100000000006";
+
+describe("hosted chat Response intrinsic boundary", () => {
+  it("does not expose the inference header through a replaced Response constructor", async () => {
+    const inferenceToken = "run-scoped-inference-token";
+    const request = new Request("https://agent.example.test/api/runs", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-Veryfront-Run-Event-Token": "run-event-service-token",
+        "X-Veryfront-Inference-Token": inferenceToken,
+      },
+      body: JSON.stringify({
+        messages: [{ id: "m1", role: "user", parts: [{ type: "text", text: "Hello" }] }],
+        context: { conversationId, projectId, branchId },
+        durableRootRun: { runId: "run_root_1", messageId },
+      }),
+    });
+    const NativeResponse = globalThis.Response;
+    const nativeHasInstance = Function.prototype[Symbol.hasInstance];
+    const observedValues: unknown[] = [];
+    class ObservingResponse extends NativeResponse {
+      static override [Symbol.hasInstance](value: unknown): boolean {
+        observedValues.push(value);
+        return Reflect.apply(nativeHasInstance, NativeResponse, [value]) as boolean;
+      }
+    }
+
+    const parsed = await (async () => {
+      globalThis.Response = ObservingResponse as typeof Response;
+      try {
+        return await parseHostedChatRequestFromRequest(request, {
+          authenticate: () => Promise.resolve({ userId, authToken: "control-plane-token" }),
+          verifyProjectAccess: () => Promise.resolve({ success: true as const }),
+          verifyRunEventAppendToken: () => Promise.resolve(true),
+        });
+      } finally {
+        globalThis.Response = NativeResponse;
+      }
+    })();
+
+    if (parsed instanceof NativeResponse) throw new Error("Expected parsed request");
+    assertEquals(observedValues.includes(inferenceToken), false);
+    assertEquals(typeof createHostedInferenceModelResolver(parsed), "function");
+  });
+});


### PR DESCRIPTION
## Summary

- bind X-Veryfront-Inference-Token to legacy/default-chat requests after the exact-run writer token verifies
- keep the credential in the existing private WeakMap and unavailable to unverified public requests
- prove through the run-scoped inference integration suite that the outbound gateway bearer is the inference token, not the broader control-plane token

## Root cause

The API default-chat dispatcher sends inference authority in a header to /api/runs. The hosted chat parser verified the run-event token but ignored the inference header, so the runtime fell back to authToken and the gateway rejected it with 401.

## Verification

- new default-chat inference-header integration test passed against the real AgentService route and provider transport
- deno fmt --check on changed files
- deno lint on changed files
- independent security review: approved with no remaining findings
- current-main remote staging probe reproduces the pre-fix 401 in 5.4s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Hosted chat requests now correctly apply run-scoped inference credentials when communicating with the inference gateway.
  - Requests using an inference token are authenticated with the appropriate gateway authorization, improving reliability for default chat execution.
  - Header-based authentication is handled more reliably, including requests where direct header access is restricted or unavailable.
  - Invalid, blank, oversized, or non-visible-ASCII inference token headers now receive a clear validation error instead of being processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->