### PR TITLE
fix(ci): bound the sentry smoke's npm calls instead of raising the job timeout

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -694,8 +694,12 @@ jobs:
   tests-sentry-runtime-packages:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
-    # Cold-cache runs take ~12-15min; 15 was cutting it too close.
-    timeout-minutes: 20
+    # Real work here is ~40s: setup-deno takes 7-10s whether the cache is warm or
+    # cold, and the smoke itself normally runs in ~20s. The long runs were a
+    # single hung `npm install` inside the smoke, not a cold cache. Each
+    # subprocess in the smoke now carries its own deadline, so a stall fails fast
+    # naming the command; this budget only has to cover one bounded stall.
+    timeout-minutes: 10
     name: tests (sentry runtime packages)
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/scripts/build/bounded-command.ts
+++ b/scripts/build/bounded-command.ts
@@ -1,0 +1,74 @@
+/**
+ * Deadline-bounded subprocess runner for the build smokes.
+ *
+ * The Sentry runtime package smoke shells out to npm, node, and deno. Without a
+ * per-command deadline a hung `npm install` consumes the whole CI job budget and
+ * surfaces as an opaque job-level "cancelled" that names nothing, so the next
+ * reader cannot tell which command stalled. Every invocation carries its own
+ * timeout here, and a stalled command fails fast naming itself.
+ */
+
+export interface BoundedCommandInput {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd?: string;
+  readonly env?: Record<string, string>;
+  readonly timeoutMs: number;
+}
+
+export interface BoundedCommandResult {
+  readonly code: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+const decoder = new TextDecoder();
+
+/** Names the command and its deadline so a timeout is attributable in CI logs. */
+export function formatBoundedCommandTimeout(
+  input: Pick<BoundedCommandInput, "command" | "args" | "timeoutMs">,
+): string {
+  return `${input.command} ${
+    input.args.join(" ")
+  } timed out after ${input.timeoutMs}ms`;
+}
+
+/**
+ * Runs a command and kills it once `timeoutMs` elapses.
+ *
+ * Aborting the signal terminates the child. Deno may then either resolve
+ * `output()` with the killed status or reject, so both paths funnel into the
+ * same named timeout error.
+ */
+export async function runBoundedCommand(
+  input: BoundedCommandInput,
+): Promise<BoundedCommandResult> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), input.timeoutMs);
+  let output: Deno.CommandOutput | undefined;
+  try {
+    output = await new Deno.Command(input.command, {
+      args: [...input.args],
+      cwd: input.cwd,
+      env: input.env,
+      stdin: "null",
+      stdout: "piped",
+      stderr: "piped",
+      signal: controller.signal,
+    }).output();
+  } catch (error) {
+    if (!controller.signal.aborted) throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (controller.signal.aborted || output === undefined) {
+    throw new Error(formatBoundedCommandTimeout(input));
+  }
+
+  return {
+    code: output.code,
+    stdout: decoder.decode(output.stdout),
+    stderr: decoder.decode(output.stderr),
+  };
+}

--- a/scripts/build/sentry-runtime-packages.test.ts
+++ b/scripts/build/sentry-runtime-packages.test.ts
@@ -1,6 +1,7 @@
 import { join, toFileUrl } from "#std/path";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
+import { runBoundedCommand } from "./bounded-command.ts";
 import { buildExtensionPackages } from "./build-npm-extension-packages.ts";
 import type {
   ExtensionManifest,
@@ -13,6 +14,13 @@ import type {
 const LEGACY_PACKAGE = "@veryfront/ext-observability-sentry";
 const NODE_PACKAGE = "@veryfront/ext-observability-sentry-node";
 const DENO_PACKAGE = "@veryfront/ext-observability-sentry-deno";
+
+// Every subprocess below gets its own deadline. A registry call that hangs must
+// fail fast naming itself rather than silently eating the CI job budget: the
+// npm steps here normally finish in a few seconds, and the node/deno import
+// checks in under a second, so these bounds are orders of magnitude of headroom.
+const NPM_COMMAND_TIMEOUT_MS = 240_000;
+const RUNTIME_EVAL_TIMEOUT_MS = 120_000;
 
 describe("Sentry runtime package generation", () => {
   it("resolves only matching SDKs and keeps runtime leaves undiscoverable", async () => {
@@ -251,6 +259,7 @@ async function assertIsolatedNodeConsumer(input: {
       command: "npm",
       args: ["install", "--ignore-scripts", "--legacy-peer-deps"],
       cwd: consumerDir,
+      timeoutMs: NPM_COMMAND_TIMEOUT_MS,
     });
     await assertInstalledPackages(
       consumerDir,
@@ -261,6 +270,7 @@ async function assertIsolatedNodeConsumer(input: {
       command: "node",
       args: ["--input-type=module", "--eval", input.importStatement],
       cwd: consumerDir,
+      timeoutMs: RUNTIME_EVAL_TIMEOUT_MS,
     });
   } finally {
     await Deno.remove(consumerDir, { recursive: true });
@@ -287,6 +297,7 @@ async function assertIsolatedDenoConsumer(input: {
       command: "npm",
       args: ["install", "--ignore-scripts", "--legacy-peer-deps"],
       cwd: consumerDir,
+      timeoutMs: NPM_COMMAND_TIMEOUT_MS,
     });
     await assertInstalledPackages(
       consumerDir,
@@ -298,6 +309,7 @@ async function assertIsolatedDenoConsumer(input: {
       args: ["eval", input.importStatement],
       cwd: consumerDir,
       env: { DENO_NO_PACKAGE_JSON: "0" },
+      timeoutMs: RUNTIME_EVAL_TIMEOUT_MS,
     });
   } finally {
     await Deno.remove(consumerDir, { recursive: true });
@@ -311,22 +323,17 @@ async function createConsumerPackage(
   const consumerDir = await Deno.makeTempDir();
   const packDir = join(consumerDir, "packs");
   await Deno.mkdir(packDir);
-  const packOutput = await new Deno.Command("npm", {
+  const packOutput = await runBoundedCommand({
+    command: "npm",
     args: ["pack", packageDir, "--pack-destination", packDir, "--json"],
-    stderr: "piped",
-    stdout: "piped",
-  }).output();
+    timeoutMs: NPM_COMMAND_TIMEOUT_MS,
+  });
   if (packOutput.code !== 0) {
-    const decoder = new TextDecoder();
     throw new Error(
-      `npm pack failed with ${packOutput.code}\n${
-        decoder.decode(packOutput.stdout)
-      }\n${decoder.decode(packOutput.stderr)}`,
+      `npm pack failed with ${packOutput.code}\n${packOutput.stdout}\n${packOutput.stderr}`,
     );
   }
-  const packResult = JSON.parse(
-    new TextDecoder().decode(packOutput.stdout),
-  ) as Array<{
+  const packResult = JSON.parse(packOutput.stdout) as Array<{
     filename: string;
   }>;
   const tarball = packResult[0]?.filename;
@@ -391,21 +398,13 @@ async function runCommand(input: {
   args: string[];
   cwd: string;
   env?: Record<string, string>;
+  timeoutMs: number;
 }): Promise<void> {
-  const output = await new Deno.Command(input.command, {
-    args: input.args,
-    cwd: input.cwd,
-    env: input.env,
-    stderr: "piped",
-    stdout: "piped",
-  }).output();
+  const output = await runBoundedCommand(input);
   if (output.code === 0) return;
 
-  const decoder = new TextDecoder();
   throw new Error(
-    `${input.command} ${input.args.join(" ")} failed with ${output.code}\n${
-      decoder.decode(output.stdout)
-    }\n${decoder.decode(output.stderr)}`,
+    `${input.command} ${input.args.join(" ")} failed with ${output.code}\n${output.stdout}\n${output.stderr}`,
   );
 }
 

--- a/scripts/test/test-semantic-audit-migration.ts
+++ b/scripts/test/test-semantic-audit-migration.ts
@@ -1456,7 +1456,6 @@ export const TEST_SEMANTIC_AUDIT_MIGRATION_ENTRIES:
     entry("scripts/build/sentry-runtime-packages.test.ts", [
       "filesystem-read",
       "filesystem-write",
-      "process",
       "shared-cwd",
     ], {
       "disposition": "integration-relocation",

--- a/tests/integration/semantic-unit-boundary/scripts/build/bounded-command.test.ts
+++ b/tests/integration/semantic-unit-boundary/scripts/build/bounded-command.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Integration test for the build smokes' deadline-bounded subprocess runner.
+ * It spawns real child processes, so it lives at the integration boundary
+ * rather than colocated with scripts/build/bounded-command.ts.
+ */
+
+import {
+  assertEquals,
+  assertInstanceOf,
+  assertRejects,
+  assertStringIncludes,
+} from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { runBoundedCommand } from "../../../../../scripts/build/bounded-command.ts";
+
+describe("bounded build subprocess", () => {
+  it("returns the output of a command that finishes inside its deadline", async () => {
+    const result = await runBoundedCommand({
+      command: Deno.execPath(),
+      args: ["eval", "console.log('finished')"],
+      timeoutMs: 60_000,
+    });
+
+    assertEquals(result.code, 0);
+    assertStringIncludes(result.stdout, "finished");
+  });
+
+  it("kills a stalled command and names it in the failure", async () => {
+    const error = await assertRejects(
+      () =>
+        runBoundedCommand({
+          command: Deno.execPath(),
+          // A pending timer keeps the event loop alive, so this child really
+          // blocks until the runner kills it.
+          args: ["eval", "await new Promise((resolve) => setTimeout(resolve, 600000));"],
+          timeoutMs: 500,
+        }),
+      Error,
+    );
+
+    assertInstanceOf(error, Error);
+    // The message must identify which command stalled: a job-level cancel names
+    // nothing, which is exactly what made the CI stalls unattributable.
+    assertStringIncludes(error.message, "timed out after 500ms");
+    assertStringIncludes(error.message, "eval");
+  });
+});


### PR DESCRIPTION
Follow-up to #4406, which raised `tests-sentry-runtime-packages` from 15 to 20 minutes on the rationale that "Cold-cache runs take ~12-15min". The run telemetry contradicts that, so this replaces the timeout bump with a fix that bounds the actual failure.

## The cold-cache diagnosis is wrong

`setup-deno` takes **7s in the cancelled run** (33812374855) and **10s in the fastest run** (33733483564) — it is *faster* in the slow run, so cache warmth explains none of the variance. All of it is in step 5:

| Run | step 5 |
|---|---|
| 33733483564 (fast) | 20s |
| 33811244820 | 8m33s |
| 33811519213 | 11m49s |
| 33812374855 | 14m57s, cancelled at 15m15s |

In the cancelled run, all three dnt package builds completed six seconds into the step, followed by ~14m50s of total silence and then `Terminate orphan process: pid (2610) (npm install)`. The stall is a single hung `npm install`, not cache warming.

20 minutes sits inside the already-observed range, so the same cancel → prerelease-skip → registry-gate cascade recurs — just later, and still with no signal about which command hung.

## What this does

- Adds `scripts/build/bounded-command.ts` — an `AbortController` + `signal:` wrapper for `Deno.Command`, following the existing pattern in `scripts/test/npm-install-smoke.ts`.
- Routes all 8 npm invocations (4 `npm pack`, 4 `npm install`) and the 4 runtime evals in the smoke through it. A stall is now killed and reported as `<command> <args> timed out after <n>ms`, so the stalled command names itself.
- Bounds: `NPM_COMMAND_TIMEOUT_MS=240_000`, `RUNTIME_EVAL_TIMEOUT_MS=120_000`. Real npm steps take a few seconds; evals under a second.
- Job timeout 20 → **10** minutes. The smoke runs in ~20s, setup+checkout ~15s, and the worst realistic case is now one bounded stall (240s) plus real work ≈ 4.5 min. 10m keeps better than 2× margin.
- Replaces the inaccurate comment with the measured cause.
- Removes the now-stale `process` effect for `sentry-runtime-packages.test.ts` from `scripts/test/test-semantic-audit-migration.ts` (moving `Deno.Command` out of the test file made it stale). This *shrinks* the inventory.

## Test plan

`tests/integration/semantic-unit-boundary/scripts/build/bounded-command.test.ts` pins the deadline. Verified it fails without the fix by removing `signal: controller.signal` and the abort check: `EXIT=1, AssertionError: Expected function to reject`. Restored: `EXIT=0`, the stall step completes in 503ms.

Placed under `tests/` rather than colocated because `UNIT_ROOTS` includes `scripts`, so a process-spawning test in `scripts/build/` would trip the semantic-disposition gate.

## Trade-off worth a look

The two slow-but-green runs (8m33s, 11m49s) would now **fail fast** if that time was a single npm call exceeding the 240s bound. That is the intent — a named 4-minute failure beats a 12-minute silent hang — but it does convert some previously-green runs to red. If that is unacceptable, raise `NPM_COMMAND_TIMEOUT_MS` and the job timeout together rather than only the job timeout.

https://claude.ai/code/session_015et5VQWnPty47pvVxP42f2