### PR TITLE
test(agent): use hosted inference import alias

### DIFF
--- a/src/agent/hosted/chat-request.test.ts
+++ b/src/agent/hosted/chat-request.test.ts
@@ -19,7 +19,7 @@ import {
   MAX_HOSTED_CHAT_REQUEST_MESSAGES,
 } from "./chat-request.ts";
 import { createHostedRunEventWriterCapabilityForRequest } from "./child-run-event-writer-token.ts";
-import { createHostedInferenceModelResolver } from "./inference-credential.ts";
+import { createHostedInferenceModelResolver } from "#veryfront/agent/hosted/inference-credential.ts";
 
 const conversationId = "10000000-1000-4000-8000-100000000001";
 const messageId = "10000000-1000-4000-8000-100000000002";


### PR DESCRIPTION
## Summary

- use the canonical internal alias for the hosted inference credential test import
- address the remaining outside-diff CodeRabbit finding from #4407

## Verification

- hosted chat parser suite: 89 steps passed
- deno fmt --check and deno lint
- dependency and module boundary checks
- test typecheck baseline
- codex review --base origin/main: no actionable findings