### PR TITLE
fix(agent): stop a failed detached run from crashing the process

### DIFF
--- a/src/agent/service/detached-run-tracker.test.ts
+++ b/src/agent/service/detached-run-tracker.test.ts
@@ -20,6 +20,46 @@ function deferred(): { promise: Promise<void>; resolve: () => Promise<void> } {
   };
 }
 
+/** Subscribes to unhandled rejections across Deno (WHATWG events) and Node/Bun (`process.on`). */
+function onUnhandledRejectionForTest(onReason: (reason: unknown) => void): () => void {
+  const target = globalThis as {
+    addEventListener?: (
+      type: string,
+      listener: (event: { reason: unknown; preventDefault(): void }) => void,
+    ) => void;
+    removeEventListener?: (
+      type: string,
+      listener: (event: { reason: unknown; preventDefault(): void }) => void,
+    ) => void;
+    process?: {
+      on?: (event: string, listener: (reason: unknown) => void) => void;
+      off?: (event: string, listener: (reason: unknown) => void) => void;
+    };
+  };
+
+  if (
+    typeof target.addEventListener === "function" &&
+    typeof target.removeEventListener === "function"
+  ) {
+    const listener = (event: { reason: unknown; preventDefault(): void }) => {
+      onReason(event.reason);
+      event.preventDefault();
+    };
+    target.addEventListener("unhandledrejection", listener);
+    return () => target.removeEventListener?.("unhandledrejection", listener);
+  }
+
+  const targetProcess = target.process;
+  if (typeof targetProcess?.on === "function" && typeof targetProcess.off === "function") {
+    const off = targetProcess.off.bind(targetProcess);
+    const listener = (reason: unknown) => onReason(reason);
+    targetProcess.on("unhandledRejection", listener);
+    return () => off("unhandledRejection", listener);
+  }
+
+  throw new Error("No supported unhandled-rejection API in this runtime");
+}
+
 describe("agent/detached-run-tracker", () => {
   it("tracks, cancels, and drains active run executions", async () => {
     const tracker = createDetachedRunTracker<{ result: unknown; isError: boolean }>({
@@ -163,11 +203,9 @@ describe("agent/detached-run-tracker", () => {
   it("does not produce an unhandled rejection when a registered execution fails", async () => {
     const tracker = createDetachedRunTracker();
     let unhandled: unknown;
-    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
-      unhandled = event.reason;
-      event.preventDefault();
-    };
-    globalThis.addEventListener("unhandledrejection", onUnhandledRejection);
+    const unsubscribe = onUnhandledRejectionForTest((reason) => {
+      unhandled = reason;
+    });
 
     try {
       // The caller (durable-chat-run-start.ts) awaits this same promise
@@ -177,7 +215,7 @@ describe("agent/detached-run-tracker", () => {
       tracker.registerExecution("run_1", execution);
       await new Promise((resolve) => setTimeout(resolve, 0));
     } finally {
-      globalThis.removeEventListener("unhandledrejection", onUnhandledRejection);
+      unsubscribe();
     }
 
     assertEquals(unhandled, undefined);

--- a/src/agent/service/detached-run-tracker.test.ts
+++ b/src/agent/service/detached-run-tracker.test.ts
@@ -159,4 +159,27 @@ describe("agent/detached-run-tracker", () => {
 
     await execution.resolve();
   });
+
+  it("does not produce an unhandled rejection when a registered execution fails", async () => {
+    const tracker = createDetachedRunTracker();
+    let unhandled: unknown;
+    const onUnhandledRejection = (event: PromiseRejectionEvent) => {
+      unhandled = event.reason;
+      event.preventDefault();
+    };
+    globalThis.addEventListener("unhandledrejection", onUnhandledRejection);
+
+    try {
+      // The caller (durable-chat-run-start.ts) awaits this same promise
+      // directly, so its rejection is already handled there.
+      const execution = Promise.reject(new Error("boom"));
+      execution.catch(() => {});
+      tracker.registerExecution("run_1", execution);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    } finally {
+      globalThis.removeEventListener("unhandledrejection", onUnhandledRejection);
+    }
+
+    assertEquals(unhandled, undefined);
+  });
 });

--- a/src/agent/service/detached-run-tracker.ts
+++ b/src/agent/service/detached-run-tracker.ts
@@ -93,6 +93,8 @@ export function createDetachedRunTracker<TResumeValue = unknown>(
         activeExecutions.delete(runId);
         untrackRun(runId);
       });
+      // Only waitForDrain (shutdown) ever reads this promise; unhandled otherwise, a rejection crashes the process.
+      trackedExecution.catch(() => {});
 
       activeExecutions.set(runId, trackedExecution);
     },

--- a/src/agent/service/detached-run-tracker.ts
+++ b/src/agent/service/detached-run-tracker.ts
@@ -93,7 +93,7 @@ export function createDetachedRunTracker<TResumeValue = unknown>(
         activeExecutions.delete(runId);
         untrackRun(runId);
       });
-      // Only waitForDrain (shutdown) ever reads this promise; unhandled otherwise, a rejection crashes the process.
+      // Only waitForDrain (shutdown) reads this promise. Without a rejection handler, a failure triggers an unhandled rejection and crashes the process.
       trackedExecution.catch(() => {});
 
       activeExecutions.set(runId, trackedExecution);


### PR DESCRIPTION
## Summary

`DetachedRunTracker.registerExecution`'s `.finally()` derives a new promise (`trackedExecution`) that's only ever read by `waitForDrain`, which only runs during shutdown. During normal operation nothing attaches a rejection handler to it, so a failed detached run became an **unhandled promise rejection and crashed the whole process** instead of just failing that one run.

## How this was found

Staging's `veryfront-agent` pods were crash-looping — 6 restarts each in 16 minutes — once [code#4407](https://github.com/veryfront/veryfront-code/pull/4407) let run-scoped inference credentials actually reach `requireSecureInferenceApiBaseUrl` in `src/provider/veryfront-cloud/shared.ts` for the first time (that check only runs when a run-scoped credential is present, which #4407 fixed the binding for). That check currently rejects staging's `VERYFRONT_API_URL`, which is a legitimate internal-cluster address (`http://veryfront-api.veryfront-staging.svc.cluster.local`) but plain HTTP, not HTTPS or loopback.

**That URL-policy question is separate and intentionally not addressed by this PR.** Whether a trusted internal cluster hostname should be treated as safe for run-scoped credentials is a real security tradeoff, not something to silently loosen as a side effect of a crash fix. This PR only stops the crash: the underlying request will still fail cleanly with a 400 (`CONFIG_INVALID`) until that policy question is resolved separately — it just won't take the process down anymore.

## Verification

- New regression test using a real `unhandledrejection` listener on `globalThis`, negative-controlled: reverted the fix and confirmed the test fails (`unhandled` captures the rejection) before restoring it.
- Full `detached-run-tracker.test.ts` suite: 7/7 passing.
- `deno fmt` / `deno lint` / `deno check` clean on both changed files.
- Semantic-unit-boundary lint gate unaffected (no new global-mutation surface).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented rejected background executions from triggering unhandled promise rejection errors or crashing the process.
  * Preserved existing shutdown behavior while ensuring execution failures remain safely handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->