### PR TITLE
ci: standardize SonarQube quality gate check

### DIFF
--- a/.github/QUALITY_GATES.md
+++ b/.github/QUALITY_GATES.md
@@ -31,7 +31,7 @@ The active merge queue ruleset gives required checks at least 70 minutes to
 report a conclusion. This covers the longest configured dependency path: 60
 minutes for binary end-to-end tests and 2 minutes for the aggregate merge gate,
 plus 8 minutes of runner scheduling headroom. The sequential coverage and Sonar
-path has a lower 57-minute maximum.
+path has a lower 59-minute maximum.
 
 Evidence: [CI workflow](workflows/cicd.yml) and
 [merge gate contract](../tests/integration/ci/merge-quality-gate-workflow.test.ts).

--- a/.github/QUALITY_GATES.md
+++ b/.github/QUALITY_GATES.md
@@ -12,13 +12,20 @@ the full Node and Bun runtime suites, binary end-to-end tests, and RSC browser
 end-to-end tests to succeed for pull requests, merge queue runs, and main
 pushes. Sonar analysis is also mandatory for merge queue runs, main pushes,
 manually dispatched runs, and trusted pull requests. The scanner waits for the
-server-side SonarCloud Quality Gate, so the required `sonar` check fails when
-that gate fails rather than only when report upload fails. A failed, skipped, or
-cancelled dependency fails the aggregate check, except that Sonar is
-intentionally skipped and ignored for fork and Dependabot pull requests because
-those runs cannot receive `SONAR_TOKEN`. Fork pull requests still skip other
-protected dependency jobs and therefore fail this aggregate gate closed.
-Codecov reporting remains advisory.
+server-side SonarQube Cloud Quality Gate, so the required
+`SonarQube Cloud quality gate` check fails when that gate fails rather than only
+when report upload fails. This uses only the scoped Execute Analysis
+token and does not query private measures. A failed, skipped, or cancelled
+dependency fails the aggregate check, except that Sonar is intentionally
+skipped and ignored for fork and Dependabot pull requests because those runs
+cannot receive `SONAR_TOKEN`. Fork pull requests still skip other protected
+dependency jobs and therefore fail this aggregate gate closed. Codecov
+reporting remains advisory.
+
+The scanner still emits the legacy `sonar` check during the ruleset migration.
+`SonarQube Cloud quality gate` is the canonical final check and depends on that
+scanner result. Remove the legacy check name only after the ruleset requires
+the canonical name and the canonical check has passed on `main`.
 
 The active merge queue ruleset gives required checks at least 70 minutes to
 report a conclusion. This covers the longest configured dependency path: 60
@@ -42,10 +49,11 @@ For pull requests and merge queue runs, `quality gate (artifact)` is a separate
 stable required check from `quality gate (merge)`. Runtime compatibility lanes
 are aggregated only by the artifact gate, so `quality-gate-merge` does not
 duplicate them. The workflow exposes both stable check names for repository
-rules to require. The required `sonar` check is the merge-blocking SonarCloud
-quality gate. The separate `SonarCloud Code Analysis` decoration remains
-informational because secret-dependent analysis is intentionally skipped for
-Dependabot and fork pull requests.
+rules to require. The required `SonarQube Cloud quality gate` check is the
+merge-blocking SonarQube Cloud quality gate. The separate
+`SonarCloud Code Analysis` decoration remains informational because
+secret-dependent analysis is intentionally skipped for Dependabot and fork pull
+requests.
 
 Evidence: [artifact implementation](../scripts/ci/npm-compatibility-artifact.ts),
 [artifact contract](../tests/integration/ci/npm-compatibility-artifact.test.ts),

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -495,17 +495,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     needs: [sonar]
-    if: ${{ always() }}
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') }}
     steps:
       - name: Require server-side quality gate
         env:
-          SONAR_REQUIRED: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') }}
           SONAR_RESULT: ${{ needs.sonar.result }}
         run: |
-          if [ "$SONAR_REQUIRED" != "true" ]; then
-            echo "SonarQube Cloud analysis is intentionally skipped for untrusted pull requests."
-            exit 0
-          fi
           if [ "$SONAR_RESULT" != "success" ]; then
             echo "::error::Server-side SonarQube Cloud quality gate finished with $SONAR_RESULT"
             exit 1

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -462,6 +462,8 @@ jobs:
   sonar:
     runs-on: ubuntu-latest
     timeout-minutes: 35
+    # Keep this legacy check name until the repository ruleset requires the
+    # canonical gate below. Removing it earlier would leave `sonar` expected.
     name: sonar
     needs: [coverage-shards]
     if: ${{ needs.coverage-shards.result == 'success' && ((github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]')) }}
@@ -487,6 +489,27 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  sonar-quality-gate:
+    name: SonarQube Cloud quality gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    needs: [sonar]
+    if: ${{ always() }}
+    steps:
+      - name: Require server-side quality gate
+        env:
+          SONAR_REQUIRED: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') }}
+          SONAR_RESULT: ${{ needs.sonar.result }}
+        run: |
+          if [ "$SONAR_REQUIRED" != "true" ]; then
+            echo "SonarQube Cloud analysis is intentionally skipped for untrusted pull requests."
+            exit 0
+          fi
+          if [ "$SONAR_RESULT" != "success" ]; then
+            echo "::error::Server-side SonarQube Cloud quality gate finished with $SONAR_RESULT"
+            exit 1
+          fi
 
   tests-e2e-rsc-browser:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
@@ -548,7 +571,7 @@ jobs:
       - tests-bun
       - tests-binary-e2e
       - tests-e2e-rsc-browser
-      - sonar
+      - sonar-quality-gate
     if: ${{ always() }}
     steps:
       - name: Require merge correctness dependencies
@@ -558,7 +581,7 @@ jobs:
           SONAR_REQUIRED: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]') }}
           SOURCE_CHECKS_RESULT: ${{ needs.ci.result }}
           COVERAGE_RESULT: ${{ needs.coverage.result }}
-          SONAR_RESULT: ${{ needs.sonar.result }}
+          SONAR_RESULT: ${{ needs.sonar-quality-gate.result }}
           INTEGRATION_TESTS_RESULT: ${{ needs.tests.result }}
           NODE_RUNTIME_TESTS_RESULT: ${{ needs.tests-node.result }}
           NODE_SANDBOX_TESTS_RESULT: ${{ needs.tests-node-sandbox.result }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,9 +5,10 @@ sonar.sourceEncoding=UTF-8
 sonar.sources=.
 sonar.exclusions=coverage-profiles/**
 
-# The required CI `sonar` check must represent the server-side Quality Gate,
-# not only successful report upload. Keep enough time for SonarCloud to process
-# this repository's large analysis before the scanner reports the result.
+# The required CI `SonarQube Cloud quality gate` check represents the
+# server-side Quality Gate, not only successful report upload. Keep enough time
+# for SonarQube Cloud to process this repository's large analysis before the
+# scanner reports the result.
 sonar.qualitygate.wait=true
 sonar.qualitygate.timeout=1200
 

--- a/tests/integration/ci/merge-quality-gate-workflow.test.ts
+++ b/tests/integration/ci/merge-quality-gate-workflow.test.ts
@@ -80,6 +80,46 @@ function parseProperties(content: string): Map<string, string> {
   return properties;
 }
 
+function jobNeeds(job: YamlRecord, context: string): string[] {
+  if (job.needs === undefined) return [];
+  if (typeof job.needs === "string") return [job.needs];
+  assert(Array.isArray(job.needs), `${context} needs must be a string or array`);
+  assert(
+    job.needs.every((dependency) => typeof dependency === "string"),
+    `${context} needs entries must be job names`,
+  );
+  return job.needs as string[];
+}
+
+function longestJobPathMinutes(
+  jobs: YamlRecord,
+  jobName: string,
+  memo = new Map<string, number>(),
+  active = new Set<string>(),
+): number {
+  const cached = memo.get(jobName);
+  if (cached !== undefined) return cached;
+  assert(!active.has(jobName), `workflow jobs must not contain a needs cycle at ${jobName}`);
+
+  const job = asRecord(jobs[jobName], `${jobName} job`);
+  const timeout = Number(job["timeout-minutes"]);
+  assert(
+    Number.isFinite(timeout) && timeout > 0,
+    `${jobName} must have a positive timeout-minutes value`,
+  );
+
+  active.add(jobName);
+  const dependencies = jobNeeds(job, `${jobName} job`);
+  const dependencyMinutes = dependencies.length === 0 ? 0 : Math.max(
+    ...dependencies.map((dependency) => longestJobPathMinutes(jobs, dependency, memo, active)),
+  );
+  active.delete(jobName);
+
+  const total = timeout + dependencyMinutes;
+  memo.set(jobName, total);
+  return total;
+}
+
 async function readMergeGate(): Promise<YamlRecord> {
   const workflow = await readWorkflow();
   const jobs = asRecord(workflow.jobs, "cicd workflow jobs");
@@ -303,32 +343,24 @@ describe("merge quality gate workflow", () => {
   it("keeps the longest merge-gate path within the merge queue response budget", async () => {
     const workflow = await readWorkflow();
     const jobs = asRecord(workflow.jobs, "cicd workflow jobs");
-    const mergeGate = asRecord(
-      jobs["quality-gate-merge"],
-      "merge quality gate job",
+    const mergeGatePathMinutes = longestJobPathMinutes(jobs, "quality-gate-merge");
+    const mergeGateTimeoutMinutes = Number(
+      asRecord(jobs["quality-gate-merge"], "merge quality gate job")["timeout-minutes"],
     );
-    const dependencyTimeouts = REQUIRED_DEPENDENCIES.map((jobName) => {
-      const job = asRecord(jobs[jobName], `${jobName} job`);
-      const timeout = Number(job["timeout-minutes"]);
-      assert(
-        Number.isFinite(timeout) && timeout > 0,
-        `${jobName} must have a positive timeout-minutes value`,
-      );
-      return timeout;
-    });
-    const maximumDependencyMinutes = Math.max(...dependencyTimeouts);
-    const mergeGateMinutes = Number(mergeGate["timeout-minutes"]);
+    const sonarPathMinutes = longestJobPathMinutes(jobs, "sonar-quality-gate") +
+      mergeGateTimeoutMinutes;
+    const qualityGates = await readRepoFile(".github/QUALITY_GATES.md");
 
     assert(
-      maximumDependencyMinutes + mergeGateMinutes +
-          MERGE_QUEUE_SCHEDULING_HEADROOM_MINUTES <=
+      mergeGatePathMinutes + MERGE_QUEUE_SCHEDULING_HEADROOM_MINUTES <=
         MERGE_QUEUE_RESPONSE_TIMEOUT_MINUTES,
-      "merge queue response timeout must cover the longest merge-gate dependency and aggregate timeouts with scheduling headroom",
+      "merge queue response timeout must cover the longest transitive merge-gate path with scheduling headroom",
     );
     assertStringIncludes(
-      await readRepoFile(".github/QUALITY_GATES.md"),
+      qualityGates,
       `at least ${MERGE_QUEUE_RESPONSE_TIMEOUT_MINUTES} minutes`,
     );
+    assertStringIncludes(qualityGates, `${sonarPathMinutes}-minute maximum`);
   });
 
   it("documents Sonar enforcement for manually dispatched runs", async () => {

--- a/tests/integration/ci/merge-quality-gate-workflow.test.ts
+++ b/tests/integration/ci/merge-quality-gate-workflow.test.ts
@@ -35,6 +35,7 @@ const SONAR_REQUIRED_CONDITION =
 const SONAR_REQUIRED_EXPRESSION = `\${{ ${SONAR_REQUIRED_CONDITION} }}`;
 const SONAR_JOB_EXPRESSION =
   `\${{ needs.coverage-shards.result == 'success' && (${SONAR_REQUIRED_CONDITION}) }}`;
+const SONAR_GATE_JOB_EXPRESSION = `\${{ always() && ${SONAR_REQUIRED_CONDITION} }}`;
 const SONAR_JOB_TIMEOUT_MINUTES = 35;
 const SONAR_QUALITY_GATE_TIMEOUT_SECONDS = 1200;
 const SONAR_CHECK_NAME = "SonarQube Cloud quality gate";
@@ -136,13 +137,11 @@ async function runGate(
 
 async function runSonarGate(
   sonarResult: string,
-  sonarRequired = true,
 ): Promise<Deno.CommandOutput> {
   const step = sonarGateStep(await readSonarGate());
   return await new Deno.Command("bash", {
     args: ["-c", String(step.run)],
     env: {
-      SONAR_REQUIRED: String(sonarRequired),
       SONAR_RESULT: sonarResult,
     },
     stdout: "piped",
@@ -204,16 +203,13 @@ describe("merge quality gate workflow", () => {
       jobs["sonar-quality-gate"],
       "SonarQube Cloud quality gate job",
     );
-    const sonarGateEnv = asRecord(
-      sonarGateStep(sonarGate).env,
-      "SonarQube Cloud quality gate env",
-    );
+    const sonarGateEnv = asRecord(sonarGateStep(sonarGate).env, "SonarQube Cloud quality gate env");
     const gate = asRecord(jobs["quality-gate-merge"], "merge quality gate job");
     const step = gateStep(gate);
     const gateEnv = asRecord(step.env, "merge quality gate result env");
 
     assertEquals(sonar.if, SONAR_JOB_EXPRESSION);
-    assertEquals(sonarGateEnv.SONAR_REQUIRED, SONAR_REQUIRED_EXPRESSION);
+    assertEquals(sonarGate.if, SONAR_GATE_JOB_EXPRESSION);
     assertEquals(sonarGateEnv.SONAR_RESULT, "${{ needs.sonar.result }}");
     assertEquals(gateEnv.SONAR_REQUIRED, SONAR_REQUIRED_EXPRESSION);
   });
@@ -229,7 +225,7 @@ describe("merge quality gate workflow", () => {
     assertEquals(sonar.name, LEGACY_SONAR_CHECK_NAME);
     assertEquals(sonarGate.name, SONAR_CHECK_NAME);
     assertEquals(sonarGate.needs, ["sonar"]);
-    assertEquals(sonarGate.if, "${{ always() }}");
+    assertEquals(sonarGate.if, SONAR_GATE_JOB_EXPRESSION);
     const sonarProperties = parseProperties(
       await readRepoFile("sonar-project.properties"),
     );
@@ -254,7 +250,6 @@ describe("merge quality gate workflow", () => {
         `required Sonar result ${result} must fail the canonical check`,
       );
     }
-    assertEquals((await runSonarGate("skipped", false)).code, 0);
   });
 
   it("imports normalized shard coverage with pinned actions and no private-measures API", async () => {

--- a/tests/integration/ci/merge-quality-gate-workflow.test.ts
+++ b/tests/integration/ci/merge-quality-gate-workflow.test.ts
@@ -17,12 +17,12 @@ const REQUIRED_DEPENDENCIES = [
   "tests-bun",
   "tests-binary-e2e",
   "tests-e2e-rsc-browser",
-  "sonar",
+  "sonar-quality-gate",
 ] as const;
 const RESULT_ENV = {
   SOURCE_CHECKS_RESULT: "${{ needs.ci.result }}",
   COVERAGE_RESULT: "${{ needs.coverage.result }}",
-  SONAR_RESULT: "${{ needs.sonar.result }}",
+  SONAR_RESULT: "${{ needs.sonar-quality-gate.result }}",
   INTEGRATION_TESTS_RESULT: "${{ needs.tests.result }}",
   NODE_RUNTIME_TESTS_RESULT: "${{ needs.tests-node.result }}",
   NODE_SANDBOX_TESTS_RESULT: "${{ needs.tests-node-sandbox.result }}",
@@ -37,6 +37,8 @@ const SONAR_JOB_EXPRESSION =
   `\${{ needs.coverage-shards.result == 'success' && (${SONAR_REQUIRED_CONDITION}) }}`;
 const SONAR_JOB_TIMEOUT_MINUTES = 35;
 const SONAR_QUALITY_GATE_TIMEOUT_SECONDS = 1200;
+const SONAR_CHECK_NAME = "SonarQube Cloud quality gate";
+const LEGACY_SONAR_CHECK_NAME = "sonar";
 const MERGE_QUEUE_RESPONSE_TIMEOUT_MINUTES = 70;
 const MERGE_QUEUE_SCHEDULING_HEADROOM_MINUTES = 8;
 
@@ -83,6 +85,12 @@ async function readMergeGate(): Promise<YamlRecord> {
   return asRecord(jobs["quality-gate-merge"], "merge quality gate job");
 }
 
+async function readSonarGate(): Promise<YamlRecord> {
+  const workflow = await readWorkflow();
+  const jobs = asRecord(workflow.jobs, "cicd workflow jobs");
+  return asRecord(jobs["sonar-quality-gate"], "SonarQube Cloud quality gate job");
+}
+
 function gateStep(job: YamlRecord): YamlRecord {
   assert(Array.isArray(job.steps), "merge quality gate steps must be an array");
   const step = job.steps.find((value) =>
@@ -91,6 +99,16 @@ function gateStep(job: YamlRecord): YamlRecord {
   );
   assert(step, "merge quality gate must require its dependencies");
   return asRecord(step, "merge quality gate result step");
+}
+
+function sonarGateStep(job: YamlRecord): YamlRecord {
+  assert(Array.isArray(job.steps), "SonarQube Cloud quality gate steps must be an array");
+  const step = job.steps.find((value) =>
+    asRecord(value, "SonarQube Cloud quality gate step").name ===
+      "Require server-side quality gate"
+  );
+  assert(step, "SonarQube Cloud quality gate must require the scanner result");
+  return asRecord(step, "SonarQube Cloud quality gate result step");
 }
 
 async function runGate(
@@ -110,6 +128,22 @@ async function runGate(
     env: {
       ...env,
       SONAR_REQUIRED: String(options.sonarRequired ?? true),
+    },
+    stdout: "piped",
+    stderr: "piped",
+  }).output();
+}
+
+async function runSonarGate(
+  sonarResult: string,
+  sonarRequired = true,
+): Promise<Deno.CommandOutput> {
+  const step = sonarGateStep(await readSonarGate());
+  return await new Deno.Command("bash", {
+    args: ["-c", String(step.run)],
+    env: {
+      SONAR_REQUIRED: String(sonarRequired),
+      SONAR_RESULT: sonarResult,
     },
     stdout: "piped",
     stderr: "piped",
@@ -166,11 +200,21 @@ describe("merge quality gate workflow", () => {
     const workflow = await readWorkflow();
     const jobs = asRecord(workflow.jobs, "cicd workflow jobs");
     const sonar = asRecord(jobs.sonar, "sonar job");
+    const sonarGate = asRecord(
+      jobs["sonar-quality-gate"],
+      "SonarQube Cloud quality gate job",
+    );
+    const sonarGateEnv = asRecord(
+      sonarGateStep(sonarGate).env,
+      "SonarQube Cloud quality gate env",
+    );
     const gate = asRecord(jobs["quality-gate-merge"], "merge quality gate job");
     const step = gateStep(gate);
     const gateEnv = asRecord(step.env, "merge quality gate result env");
 
     assertEquals(sonar.if, SONAR_JOB_EXPRESSION);
+    assertEquals(sonarGateEnv.SONAR_REQUIRED, SONAR_REQUIRED_EXPRESSION);
+    assertEquals(sonarGateEnv.SONAR_RESULT, "${{ needs.sonar.result }}");
     assertEquals(gateEnv.SONAR_REQUIRED, SONAR_REQUIRED_EXPRESSION);
   });
 
@@ -178,6 +222,14 @@ describe("merge quality gate workflow", () => {
     const workflow = await readWorkflow();
     const jobs = asRecord(workflow.jobs, "cicd workflow jobs");
     const sonar = asRecord(jobs.sonar, "sonar job");
+    const sonarGate = asRecord(
+      jobs["sonar-quality-gate"],
+      "SonarQube Cloud quality gate job",
+    );
+    assertEquals(sonar.name, LEGACY_SONAR_CHECK_NAME);
+    assertEquals(sonarGate.name, SONAR_CHECK_NAME);
+    assertEquals(sonarGate.needs, ["sonar"]);
+    assertEquals(sonarGate.if, "${{ always() }}");
     const sonarProperties = parseProperties(
       await readRepoFile("sonar-project.properties"),
     );
@@ -191,6 +243,66 @@ describe("merge quality gate workflow", () => {
       sonarProperties.get("sonar.qualitygate.timeout"),
       String(SONAR_QUALITY_GATE_TIMEOUT_SECONDS),
     );
+  });
+
+  it("makes the canonical Sonar check fail closed for required analysis", async () => {
+    assertEquals((await runSonarGate("success")).code, 0);
+    for (const result of ["failure", "skipped", "cancelled"]) {
+      assertEquals(
+        (await runSonarGate(result)).code,
+        1,
+        `required Sonar result ${result} must fail the canonical check`,
+      );
+    }
+    assertEquals((await runSonarGate("skipped", false)).code, 0);
+  });
+
+  it("imports normalized shard coverage with pinned actions and no private-measures API", async () => {
+    const workflow = await readWorkflow();
+    const jobs = asRecord(workflow.jobs, "cicd workflow jobs");
+    const sonar = asRecord(jobs.sonar, "sonar job");
+    assert(Array.isArray(sonar.steps), "sonar steps must be an array");
+    const steps = sonar.steps.map((step) => asRecord(step, "sonar step"));
+    const downloadIndex = steps.findIndex((step) =>
+      step.name === "Download unit coverage lcov files"
+    );
+    const normalizeIndex = steps.findIndex((step) => step.name === "Normalize lcov paths");
+    const scanIndex = steps.findIndex((step) => step.name === "SonarQube Cloud scan");
+
+    assert(downloadIndex >= 0, "sonar must download the coverage artifacts");
+    assert(
+      normalizeIndex > downloadIndex,
+      "sonar must normalize downloaded coverage",
+    );
+    assert(
+      scanIndex > normalizeIndex,
+      "sonar must scan after coverage normalization",
+    );
+    assertStringIncludes(
+      String(steps[normalizeIndex].run),
+      'sed -i "s|^SF:${GITHUB_WORKSPACE}/|SF:|"',
+    );
+
+    const sonarProperties = parseProperties(
+      await readRepoFile("sonar-project.properties"),
+    );
+    assertEquals(
+      sonarProperties.get("sonar.javascript.lcov.reportPaths"),
+      "coverage-profiles/coverage-shard-*/lcov.info",
+    );
+
+    for (const step of steps) {
+      if (typeof step.uses !== "string" || step.uses.startsWith("./")) continue;
+      assert(
+        /^[^@]+@[0-9a-f]{40}$/.test(step.uses),
+        `third-party action must be pinned to a commit SHA: ${step.uses}`,
+      );
+    }
+
+    const runCommands = steps.map((step) => String(step.run ?? "")).join("\n");
+    assertEquals(runCommands.includes("api/measures"), false);
+    assertEquals(runCommands.includes("api/qualitygates"), false);
+    assertEquals(runCommands.includes("curl"), false);
   });
 
   it("keeps the longest merge-gate path within the merge queue response budget", async () => {


### PR DESCRIPTION
## Summary

- expose `SonarQube Cloud quality gate` as the stable final Sonar check
- retain the existing `sonar` scanner check during the repository ruleset transition
- keep scanner-side waiting for the shared server-side quality gate using the scoped Execute Analysis token
- contract-test normalized four-shard LCOV import, immutable action pins, and fail-closed gate propagation without private-measures API calls

## Validation

- `deno task test:file tests/integration/ci/merge-quality-gate-workflow.test.ts`
- `deno task lint:ci-typescript`
- `git diff --check`
- `codex review --base main`

## Ruleset transition

Keep the existing required `sonar` context until this PR reports `SonarQube Cloud quality gate` successfully. After the canonical check is green on `main`, replace the required `sonar` context with `SonarQube Cloud quality gate`.
