### PR TITLE
fix(deps): patch fast-uri security alerts

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -3349,8 +3349,8 @@
         "micromatch"
       ]
     },
-    "fast-uri@3.1.5": {
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="
+    "fast-uri@3.1.7": {
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="
     },
     "fast-xml-builder@1.3.0": {
       "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",

--- a/scripts/build/proxy-deno.lock
+++ b/scripts/build/proxy-deno.lock
@@ -1132,8 +1132,8 @@
     "fast-deep-equal@3.1.3": {
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
-    "fast-uri@3.1.5": {
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="
+    "fast-uri@3.1.7": {
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="
     },
     "fetch-blob@3.2.0": {
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",


### PR DESCRIPTION
Upgrade the transitive fast-uri dependency from 3.1.5 to 3.1.7 in the main and proxy-build Deno lockfiles. This addresses Dependabot alerts #42, #43, #44, and #45 for URL normalization and host-confusion vulnerabilities. The Node test lockfile already uses 3.1.7.

Validation: proxy lock generation completed without additional changes; schema-extension tests passed 48 steps; binary-build contract tests passed 20 tests. Both local Codex reviews passed, including the full branch comparison against origin/main.
