### PR TITLE
docs: add public metrics and platform examples

### DIFF
--- a/docs/api-reference/veryfront/metrics.md
+++ b/docs/api-reference/veryfront/metrics.md
@@ -10,6 +10,18 @@ order: 20
 import { counter, gauge, histogram, metrics } from "veryfront/metrics";
 ```
 
+## Examples
+
+### Record application metrics
+
+```ts
+import { metrics } from "veryfront/metrics";
+
+metrics.counter("orders_processed_total", 1, { status: "completed" });
+metrics.histogram("order_processing_ms", 240);
+metrics.gauge("orders_queued", 3);
+```
+
 ## Exports
 
 ### Functions

--- a/docs/api-reference/veryfront/platform.md
+++ b/docs/api-reference/veryfront/platform.md
@@ -17,6 +17,16 @@ import {
 } from "veryfront/platform";
 ```
 
+## Examples
+
+### Inspect the current runtime
+
+```ts
+import { getOsType, getRuntimeVersion } from "veryfront/platform";
+
+console.log(`${getOsType()} ${getRuntimeVersion()}`);
+```
+
 ## Exports
 
 ### Functions

--- a/src/metrics/public.ts
+++ b/src/metrics/public.ts
@@ -2,6 +2,15 @@
  * Runtime/application metric hooks for project code.
  *
  * @module metrics
+ *
+ * @example Record application metrics
+ * ```ts
+ * import { metrics } from "veryfront/metrics";
+ *
+ * metrics.counter("orders_processed_total", 1, { status: "completed" });
+ * metrics.histogram("order_processing_ms", 240);
+ * metrics.gauge("orders_queued", 3);
+ * ```
  */
 
 import { counter, gauge, histogram } from "./index.ts";

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -3,6 +3,13 @@
  * compat, filesystem and KV abstractions for Deno, Node.js, and Bun.
  *
  * @module platform
+ *
+ * @example Inspect the current runtime
+ * ```ts
+ * import { getOsType, getRuntimeVersion } from "veryfront/platform";
+ *
+ * console.log(`${getOsType()} ${getRuntimeVersion()}`);
+ * ```
  */
 
 // Adapters


### PR DESCRIPTION
The API reference validator rejects the public `veryfront/metrics` and `veryfront/platform` barrels because neither barrel documents a copyable example. This adds project-safe examples through the existing public package exports and regenerates only their two reference pages. Runtime code and export surfaces are unchanged.

Related to veryfront/veryfront-issue-inbox#1031.

## Red/green evidence

- Red on clean `origin/main` with Deno 2.7.7: `validate-api-reference.ts` reported exactly the two missing `@example` tags.
- Green with Deno 2.7.7: all 45 public barrels and all 45 reference pages pass validation.
- Both documented examples import and execute through `veryfront/metrics` and `veryfront/platform`.

## Validation

- `deno run --allow-read scripts/docs/validate-api-reference.ts`
- `deno task docs:api-reference:check`
- `deno fmt --check src/metrics/public.ts src/platform/index.ts docs/api-reference/veryfront/metrics.md docs/api-reference/veryfront/platform.md`
- `deno task lint:barrel-jsdoc`
- Pre-push format, lint, typecheck, and full unit suite

`deno task verify:quick` proceeds through generation, layout, format, lint, TypeScript CI, style, chat, and codemod checks, then stops at the two pre-existing CLI boundary violations tracked independently by inbox issue 1030. The full docs validation passes its API reference, guide, quality, coverage, contract, and example checks, then reports the same two broken `src` links present on clean `origin/main` in `docs/getting-started/create-frontend.md` and `docs/guides/chat-ui.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added usage examples for recording application metrics, including counters, histograms, and gauges.
  - Added examples showing how to inspect the current operating system and runtime version.
  - Expanded API documentation with practical TypeScript snippets for metrics and platform information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->