### PR TITLE
fix(cli): route host config through private aliases

### DIFF
--- a/cli/mcp/remote-file-tools.ts
+++ b/cli/mcp/remote-file-tools.ts
@@ -31,10 +31,7 @@ import {
 } from "#cli/shared/config";
 import { getEnvSource } from "veryfront/utils/env-loader";
 import { getHostSecret } from "#cli/process-env";
-import {
-  requireHostPrivateApiHttps,
-  resolveHostOwnedApiBaseUrl,
-} from "#veryfront/config/host-api-base.ts";
+import { requireHostPrivateApiHttps, resolveHostOwnedApiBaseUrl } from "#cli/host-api-base";
 import {
   buildProjectApiPath,
   buildProjectFilePath,

--- a/cli/shared/runtime-auth.ts
+++ b/cli/shared/runtime-auth.ts
@@ -1,7 +1,7 @@
 import { deleteEnv, deleteHostSecret, getEnv, setEnv, setHostSecret } from "#cli/process-env";
 import { readToken } from "../auth/token-store.ts";
 import { getEnvironmentConfig } from "veryfront/config";
-import { refreshEnvironmentConfig } from "#veryfront/config/environment-config.ts";
+import { refreshEnvironmentConfig } from "#cli/environment-config";
 import {
   getEnvSource,
   markConfigFileSource,

--- a/deno.json
+++ b/deno.json
@@ -395,6 +395,8 @@
     "#cli/observability/error-collector": "./src/observability/error-collector.ts",
     "#cli/observability/log-buffer": "./src/observability/log-buffer.ts",
     "#cli/production-error-reporting": "./src/server/production-error-reporting.ts",
+    "#cli/environment-config": "./src/config/environment-config.ts",
+    "#cli/host-api-base": "./src/config/host-api-base.ts",
     "#cli/host-runtime": "./src/platform/compat/process/host-runtime.ts",
     "#cli/platform-runtime": "./src/platform/compat/runtime.ts",
     "#cli/process-env": "./src/platform/compat/process/env.ts",

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -3734,15 +3734,14 @@ export default config as const;
         await writeTextFile(`${projectDir}/package.json`, JSON.stringify({ type: "module" }));
 
         for (const specifier of ["#cli/environment-config", "#cli/host-api-base"]) {
-          await assertRejects(
+          const error = await assertRejects(
             () =>
               rewriteProjectConfigImportsFromProject(
                 `import value from ${JSON.stringify(specifier)};\nexport default value;\n`,
                 configPath,
               ),
-            Error,
-            `Cannot find module '${specifier}'`,
           );
+          assertStringIncludes(error.message, specifier);
         }
       }, { prefix: "vf-config-host-private-cli-alias-" });
     });

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -3728,6 +3728,25 @@ export default config as const;
       }, { prefix: "vf-config-import-alias-" });
     });
 
+    it("does not inherit host-private CLI aliases into project configuration", async () => {
+      await withTempDir(async (projectDir) => {
+        const configPath = `${projectDir}/veryfront.config.ts`;
+        await writeTextFile(`${projectDir}/package.json`, JSON.stringify({ type: "module" }));
+
+        for (const specifier of ["#cli/environment-config", "#cli/host-api-base"]) {
+          await assertRejects(
+            () =>
+              rewriteProjectConfigImportsFromProject(
+                `import value from ${JSON.stringify(specifier)};\nexport default value;\n`,
+                configPath,
+              ),
+            Error,
+            `Cannot find module '${specifier}'`,
+          );
+        }
+      }, { prefix: "vf-config-host-private-cli-alias-" });
+    });
+
     it("rejects invalid slash-prefixed project package import names", async () => {
       await withTempDir(async (projectDir) => {
         const configPath = `${projectDir}/veryfront.config.ts`;

--- a/src/config/loader.test.ts
+++ b/src/config/loader.test.ts
@@ -3741,6 +3741,7 @@ export default config as const;
                 configPath,
               ),
           );
+          assertInstanceOf(error, Error);
           assertStringIncludes(error.message, specifier);
         }
       }, { prefix: "vf-config-host-private-cli-alias-" });

--- a/tests/integration/deno-config-cli-aliases.test.ts
+++ b/tests/integration/deno-config-cli-aliases.test.ts
@@ -1,6 +1,7 @@
-import { assertEquals } from "#std/assert";
 import { walk } from "#std/fs/walk";
 import { fromFileUrl } from "#std/path";
+import { assertEquals } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
 
 const repoRoot = fromFileUrl(new URL("../../", import.meta.url));
 
@@ -65,15 +66,17 @@ Deno.test("every #cli/* and #veryfront/cli/* import alias has at least one calle
   assertEquals(dead, [], `Dead cli aliases (no callers in cli/ or src/): ${dead.join(", ")}`);
 });
 
-Deno.test("host-private CLI aliases remain exact and unpublished", async () => {
-  const config = await readConfig("deno.json");
-  const aliases = {
-    "#cli/environment-config": "./src/config/environment-config.ts",
-    "#cli/host-api-base": "./src/config/host-api-base.ts",
-  } as const;
+describe("host-private CLI aliases", () => {
+  it("remain exact and unpublished", async () => {
+    const config = await readConfig("deno.json");
+    const aliases = {
+      "#cli/environment-config": "./src/config/environment-config.ts",
+      "#cli/host-api-base": "./src/config/host-api-base.ts",
+    } as const;
 
-  for (const [alias, target] of Object.entries(aliases)) {
-    assertEquals(config.imports?.[alias], target);
-    assertEquals(Object.values(config.exports ?? {}).includes(target), false);
-  }
+    for (const [alias, target] of Object.entries(aliases)) {
+      assertEquals(config.imports?.[alias], target);
+      assertEquals(Object.values(config.exports ?? {}).includes(target), false);
+    }
+  });
 });

--- a/tests/integration/deno-config-cli-aliases.test.ts
+++ b/tests/integration/deno-config-cli-aliases.test.ts
@@ -4,9 +4,18 @@ import { fromFileUrl } from "#std/path";
 
 const repoRoot = fromFileUrl(new URL("../../", import.meta.url));
 
-async function readImports(relPath: string): Promise<Record<string, string>> {
+interface DenoConfig {
+  imports?: Record<string, string>;
+  exports?: Record<string, string>;
+}
+
+async function readConfig(relPath: string): Promise<DenoConfig> {
   const text = await Deno.readTextFile(`${repoRoot}${relPath}`);
-  const parsed = JSON.parse(text);
+  return JSON.parse(text);
+}
+
+async function readImports(relPath: string): Promise<Record<string, string>> {
+  const parsed = await readConfig(relPath);
   return parsed.imports ?? {};
 }
 
@@ -54,4 +63,17 @@ Deno.test("every #cli/* and #veryfront/cli/* import alias has at least one calle
   }
 
   assertEquals(dead, [], `Dead cli aliases (no callers in cli/ or src/): ${dead.join(", ")}`);
+});
+
+Deno.test("host-private CLI aliases remain exact and unpublished", async () => {
+  const config = await readConfig("deno.json");
+  const aliases = {
+    "#cli/environment-config": "./src/config/environment-config.ts",
+    "#cli/host-api-base": "./src/config/host-api-base.ts",
+  } as const;
+
+  for (const [alias, target] of Object.entries(aliases)) {
+    assertEquals(config.imports?.[alias], target);
+    assertEquals(Object.values(config.exports ?? {}).includes(target), false);
+  }
 });


### PR DESCRIPTION
The CLI boundary validator rejects two legitimate host-private configuration imports because they bypass the established local `#cli/*` adapter boundary. This adds exact CLI-only aliases for those modules and switches the two callers without exposing either module through the public package exports.

Related to veryfront/veryfront-issue-inbox#1030.

## Security boundary

- The aliases point at the existing host API base and environment configuration modules and remain absent from `deno.json` public exports.
- Project configuration resolves `#...` specifiers only from its nearest project `package.json#imports`; it does not inherit Veryfront's repository aliases.
- Existing config-loader containment still rejects imports that escape the project package through absolute paths, parent traversal, `node_modules`, or symlinks.

## Red/green evidence

- Red: `deno task lint:cli-boundary` reported the two direct `#veryfront/config/**.ts` imports.
- Red: the new alias contract test failed while the exact `#cli/*` aliases were absent.
- Green: the CLI boundary validator passes and the alias contract keeps both target modules unpublished.

## Validation

- `deno task lint:cli-boundary`
- `deno task test:file tests/integration/deno-config-cli-aliases.test.ts`
- `deno task test:file src/config/loader.test.ts` (402 steps)
- `deno task test:file cli/shared/runtime-auth.test.ts cli/mcp/remote-file-tools.test.ts` (88 steps)
- Focused format and lint checks
- `deno task typecheck`
- Full pre-push format, lint, typecheck, and unit suite

All commands used the repository-pinned Deno 2.7.7. Inbox issue 1031 has since merged into `main`; the new-head CI run validates this fix against that current base.
