### PR TITLE
fix(ci): recognize completed Codex review summaries

### DIFF
--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -1226,6 +1226,7 @@ jobs:
       status_id: ${{ steps.reuse.outputs.merge-group-status-id }}
     permissions:
       contents: read
+      issues: read
       pull-requests: read
       statuses: write
     concurrency:

--- a/.github/workflows/automated-review-gate.yml
+++ b/.github/workflows/automated-review-gate.yml
@@ -82,6 +82,7 @@ jobs:
         target: ${{ fromJSON(needs.timeout_targets.outputs.targets) }}
     permissions:
       contents: read
+      issues: read
       pull-requests: write
       statuses: write
     concurrency:

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -19,6 +19,7 @@ const REVIEW_REQUEST_MARKER =
 const FULL_SHA = /^[0-9a-f]{40}$/i;
 const REQUEST_KEY = /^[a-z0-9-]{1,64}$/i;
 const MAX_ITEMS_PER_SOURCE = 500;
+const CODEX_REACTION_RETRY_DELAYS_MS = [1000, 2000, 4000];
 const MAX_TIMEOUT_TARGETS_PER_RUN = 25;
 const MAX_TIMEOUT_DISCOVERY_PAGES = 20;
 const TIMEOUT_DISCOVERY_ROTATION_MS = 10 * 60 * 1000;
@@ -50,6 +51,8 @@ const REVIEW_BOUNDARY_REQUEST_KEYS = new Map([
 const NO_COMMIT = () => Promise.resolve(undefined);
 /** @type {(login: string) => Promise<boolean>} */
 const NO_TRUSTED_HUMAN = () => Promise.resolve(false);
+const WAIT_FOR_REACTION = (delayMs) =>
+  new Promise((resolve) => setTimeout(resolve, delayMs));
 
 export const AUTOMATED_REVIEW_STATUS_CONTEXT = "Automated review";
 export const AUTOMATED_REVIEW_TIMEOUT_MS = 30 * 60 * 1000;
@@ -183,6 +186,37 @@ function parseCompletedCodexSummary(comment) {
     completedAt > updatedAt
   ) return undefined;
   return { shortRef: row[3], completedAt, updatedAt };
+}
+
+async function resolvedCompletedCodexSummary(
+  comment,
+  headSha,
+  boundary,
+  resolveCommit,
+) {
+  const summary = parseCompletedCodexSummary(comment);
+  if (
+    !summary ||
+    (boundary !== undefined &&
+      (summary.completedAt <= boundary.time ||
+        summary.updatedAt <= boundary.time)) ||
+    !headSha.toLowerCase().startsWith(summary.shortRef.toLowerCase())
+  ) return undefined;
+  const resolved = await resolveCommit(summary.shortRef);
+  return typeof resolved === "string" && FULL_SHA.test(resolved) &&
+      resolved.toLowerCase() === headSha.toLowerCase()
+    ? summary
+    : undefined;
+}
+
+function codexCompletionReaction(reactions, summary, boundary) {
+  return reactions.find((candidate) => {
+    const createdAt = Date.parse(candidate?.created_at ?? "");
+    return isPinnedCodexReaction(candidate?.user) &&
+      candidate?.content === "+1" &&
+      Number.isFinite(createdAt) && createdAt > summary.updatedAt &&
+      (boundary === undefined || createdAt > boundary.time);
+  });
 }
 
 function isPinnedGraphqlBot(user, login) {
@@ -1002,26 +1036,14 @@ export async function findAutomatedReview(
   }
 
   for (const comment of comments) {
-    const summary = parseCompletedCodexSummary(comment);
-    if (
-      !summary ||
-      (boundary !== undefined &&
-        (summary.completedAt <= boundary.time ||
-          summary.updatedAt <= boundary.time)) ||
-      !headSha.toLowerCase().startsWith(summary.shortRef.toLowerCase())
-    ) continue;
-    const resolved = await resolveCommit(summary.shortRef);
-    if (
-      typeof resolved !== "string" || !FULL_SHA.test(resolved) ||
-      resolved.toLowerCase() !== headSha.toLowerCase()
-    ) continue;
-    const reaction = reactions.find((candidate) => {
-      const createdAt = Date.parse(candidate?.created_at ?? "");
-      return isPinnedCodexReaction(candidate?.user) &&
-        candidate?.content === "+1" &&
-        Number.isFinite(createdAt) && createdAt > summary.updatedAt &&
-        (boundary === undefined || createdAt > boundary.time);
-    });
+    const summary = await resolvedCompletedCodexSummary(
+      comment,
+      headSha,
+      boundary,
+      resolveCommit,
+    );
+    if (!summary) continue;
+    const reaction = codexCompletionReaction(reactions, summary, boundary);
     if (!reaction) continue;
     codexSuccesses.push({
       evidence: reaction,
@@ -1361,6 +1383,9 @@ export async function publishAutomatedReviewStatus({
   queuePropagationPending = false,
   reviewEpochNotBefore = /** @type {string | undefined} */ (undefined),
   reviewEpochRunKey = /** @type {string | undefined} */ (undefined),
+  reactionRetryAttempt = 0,
+  waitForReaction = WAIT_FOR_REACTION,
+  retrySnapshot = undefined,
 }) {
   let review;
   let failure;
@@ -1401,6 +1426,12 @@ export async function publishAutomatedReviewStatus({
     (!Number.isSafeInteger(reviewTimeoutMs) || reviewTimeoutMs < 1)
   ) {
     failure = new Error("Review timeout is invalid");
+  } else if (
+    !Number.isSafeInteger(reactionRetryAttempt) || reactionRetryAttempt < 0 ||
+    reactionRetryAttempt > CODEX_REACTION_RETRY_DELAYS_MS.length ||
+    typeof waitForReaction !== "function"
+  ) {
+    failure = new Error("Review reaction retry is invalid");
   } else if (!FULL_SHA.test(headSha)) {
     failure = new Error("Captured head is malformed");
   } else {
@@ -1418,6 +1449,10 @@ export async function publishAutomatedReviewStatus({
       pullAuthor = current?.data?.user?.login;
       pullSnapshotUpdatedAt = current?.data?.updated_at;
       baseBinding = pullRequestBaseBinding(current?.data);
+      if (
+        retrySnapshot !== undefined &&
+        retrySnapshot?.baseBinding !== baseBinding
+      ) throw new Error("Pull request base changed during reaction retry");
       baseRef = current?.data?.base?.ref;
       isDraft = current?.data?.draft === true;
     } catch (error) {
@@ -1494,6 +1529,13 @@ export async function publishAutomatedReviewStatus({
         baseBinding,
       );
       reviewEpochAtEvaluation = latestReviewEpochChange(events);
+      if (
+        retrySnapshot !== undefined &&
+        !sameReviewEpoch(
+          retrySnapshot?.reviewEpoch,
+          reviewEpochAtEvaluation,
+        )
+      ) throw new Error("Pull request lifecycle changed during reaction retry");
       reviewBoundary = activeReviewBoundary(
         latestReviewRequest(comments, headSha),
         reviewNotBefore,
@@ -1573,6 +1615,59 @@ export async function publishAutomatedReviewStatus({
           reviewNotBefore,
           runBoundRequest !== undefined,
         );
+        if (
+          !review &&
+          reactionRetryAttempt < CODEX_REACTION_RETRY_DELAYS_MS.length
+        ) {
+          const summaryBoundary = activeReviewBoundary(
+            latestReviewRequest(comments, headSha),
+            reviewNotBefore,
+            reviewEpochAtEvaluation,
+            runBoundRequest !== undefined,
+          );
+          let waitsForReaction = false;
+          for (const comment of comments) {
+            const summary = await resolvedCompletedCodexSummary(
+              comment,
+              headSha,
+              summaryBoundary,
+              (ref) => resolveCommitRef(github, common, ref),
+            );
+            if (
+              summary &&
+              !codexCompletionReaction(reactions, summary, summaryBoundary)
+            ) {
+              waitsForReaction = true;
+              break;
+            }
+          }
+          if (waitsForReaction) {
+            await waitForReaction(
+              CODEX_REACTION_RETRY_DELAYS_MS[reactionRetryAttempt],
+            );
+            return publishAutomatedReviewStatus({
+              github,
+              owner,
+              repo,
+              pullNumber,
+              headSha,
+              pullUrl,
+              reviewResetKey,
+              reviewFailureCommentId,
+              now,
+              reviewTimeoutMs,
+              queuePropagationPending,
+              reviewEpochNotBefore,
+              reviewEpochRunKey,
+              reactionRetryAttempt: reactionRetryAttempt + 1,
+              waitForReaction,
+              retrySnapshot: {
+                baseBinding,
+                reviewEpoch: reviewEpochAtEvaluation,
+              },
+            });
+          }
+        }
         if (!review) {
           if (
             existingPropagationRetryStatus &&

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -1144,6 +1144,56 @@ async function collectAll(github, endpoint, parameters, source) {
   return items;
 }
 
+async function collectAutomatedReviewEvidence(
+  github,
+  common,
+  pullNumber,
+  headSha,
+  sourcePrefix = "",
+) {
+  const source = (name) => `${sourcePrefix}${name}`;
+  const [reviews, comments, reactions, events, statuses, timeline] =
+    await Promise.all([
+      collectAll(
+        github,
+        github.rest.pulls.listReviews,
+        { ...common, pull_number: pullNumber },
+        source("reviews"),
+      ),
+      collectAll(
+        github,
+        github.rest.issues.listComments,
+        { ...common, issue_number: pullNumber },
+        source("comments"),
+      ),
+      collectAll(
+        github,
+        github.rest.reactions.listForIssue,
+        { ...common, issue_number: pullNumber },
+        source("pull request reactions"),
+      ),
+      collectAll(
+        github,
+        github.rest.issues.listEvents,
+        { ...common, issue_number: pullNumber },
+        source("pull request events"),
+      ),
+      collectAll(
+        github,
+        github.rest.repos.listCommitStatusesForRef,
+        { ...common, ref: headSha },
+        source("review statuses"),
+      ),
+      collectAll(
+        github,
+        github.rest.issues.listEventsForTimeline,
+        { ...common, issue_number: pullNumber },
+        source("pull request timeline"),
+      ),
+    ]);
+  return { reviews, comments, reactions, events, statuses, timeline };
+}
+
 async function resolveCommitRef(github, common, ref) {
   try {
     const response = await github.rest.repos.getCommit({ ...common, ref });
@@ -1462,46 +1512,13 @@ export async function publishAutomatedReviewStatus({
   if (!failure) {
     try {
       const common = { owner, repo };
-      const [reviews, comments, reactions, events, statuses, timeline] = await Promise.all(
-        [
-          collectAll(
-            github,
-            github.rest.pulls.listReviews,
-            { ...common, pull_number: pullNumber },
-            "reviews",
-          ),
-          collectAll(
-            github,
-            github.rest.issues.listComments,
-            { ...common, issue_number: pullNumber },
-            "comments",
-          ),
-          collectAll(
-            github,
-            github.rest.reactions.listForIssue,
-            { ...common, issue_number: pullNumber },
-            "pull request reactions",
-          ),
-          collectAll(
-            github,
-            github.rest.issues.listEvents,
-            { ...common, issue_number: pullNumber },
-            "pull request events",
-          ),
-          collectAll(
-            github,
-            github.rest.repos.listCommitStatusesForRef,
-            { ...common, ref: headSha },
-            "review statuses",
-          ),
-          collectAll(
-            github,
-            github.rest.issues.listEventsForTimeline,
-            { ...common, issue_number: pullNumber },
-            "pull request timeline",
-          ),
-        ],
-      );
+      const { reviews, comments, reactions, events, statuses, timeline } =
+        await collectAutomatedReviewEvidence(
+          github,
+          common,
+          pullNumber,
+          headSha,
+        );
       effectiveReviewResetKey = durableReviewRequestKey(
         events,
         reviewResetKey,
@@ -2919,45 +2936,13 @@ async function readMergeGroupSourceEvidence({
   pullNumber,
   sourceHeadSha,
 }) {
-  const [reviews, comments, reactions, events, statuses, timeline] = await Promise.all([
-    collectAll(
-      github,
-      github.rest.pulls.listReviews,
-      { ...common, pull_number: pullNumber },
-      "source reviews",
-    ),
-    collectAll(
-      github,
-      github.rest.issues.listComments,
-      { ...common, issue_number: pullNumber },
-      "source comments",
-    ),
-    collectAll(
-      github,
-      github.rest.reactions.listForIssue,
-      { ...common, issue_number: pullNumber },
-      "source pull request reactions",
-    ),
-    collectAll(
-      github,
-      github.rest.issues.listEvents,
-      { ...common, issue_number: pullNumber },
-      "source pull request events",
-    ),
-    collectAll(
-      github,
-      github.rest.repos.listCommitStatusesForRef,
-      { ...common, ref: sourceHeadSha },
-      "source review statuses",
-    ),
-    collectAll(
-      github,
-      github.rest.issues.listEventsForTimeline,
-      { ...common, issue_number: pullNumber },
-      "source review timeline",
-    ),
-  ]);
-  return { reviews, comments, reactions, events, statuses, timeline };
+  return collectAutomatedReviewEvidence(
+    github,
+    common,
+    pullNumber,
+    sourceHeadSha,
+    "source ",
+  );
 }
 
 async function requireCurrentAutomatedReview({
@@ -3482,44 +3467,14 @@ async function revalidateAutomatedReviewRequest({
   marker,
 }) {
   const common = { owner, repo };
-  const [reviews, comments, reactions, events, statuses, timeline] = await Promise.all([
-    collectAll(
+  const { reviews, comments, reactions, events, statuses, timeline } =
+    await collectAutomatedReviewEvidence(
       github,
-      github.rest.pulls.listReviews,
-      { ...common, pull_number: pullNumber },
-      "final request reviews",
-    ),
-    collectAll(
-      github,
-      github.rest.issues.listComments,
-      { ...common, issue_number: pullNumber },
-      "final request comments",
-    ),
-    collectAll(
-      github,
-      github.rest.reactions.listForIssue,
-      { ...common, issue_number: pullNumber },
-      "final request reactions",
-    ),
-    collectAll(
-      github,
-      github.rest.issues.listEvents,
-      { ...common, issue_number: pullNumber },
-      "final request events",
-    ),
-    collectAll(
-      github,
-      github.rest.repos.listCommitStatusesForRef,
-      { ...common, ref: headSha },
-      "final request statuses",
-    ),
-    collectAll(
-      github,
-      github.rest.issues.listEventsForTimeline,
-      { ...common, issue_number: pullNumber },
-      "final request timeline",
-    ),
-  ]);
+      common,
+      pullNumber,
+      headSha,
+      "final request ",
+    );
   if (validateRequestEpoch) {
     const currentKey = resolveAutomatedReviewRequestEpochKey(
       events,

--- a/scripts/ci/automated-review-gate.mjs
+++ b/scripts/ci/automated-review-gate.mjs
@@ -7,6 +7,10 @@ const BOTS = new Map([
 const CODEX_LOGIN = "chatgpt-codex-connector[bot]";
 const GITHUB_ACTIONS_LOGIN = "github-actions[bot]";
 const CODEX_NO_FINDINGS = "Codex Review: Didn't find any major issues.";
+const CODEX_REVIEW_SUMMARY_MARKER =
+  "<!-- codex-pull-request-review-summary -->";
+const CODEX_REVIEW_SUMMARY_ROW =
+  /^\| 📝 \*\*Code Review\*\* \| ✅ \*\*Completed\*\* <relative-time datetime="([^"]+)">([^<]+)<\/relative-time> \| `([0-9a-f]{7,40})` \| ([^|\r\n]+) \|$/;
 const CODEX_USAGE_LIMIT =
   /^You have reached your Codex usage limits(?: for [^.]+)?\. Please try again later\.$/i;
 const CODEX_REVIEWED_COMMIT = /\*\*Reviewed commit:\*\* `([0-9a-f]{10})`/i;
@@ -135,6 +139,50 @@ function isPinnedBot(user, login) {
   return user?.login === login &&
     user?.id === BOTS.get(login) &&
     user?.type === "Bot";
+}
+
+function isPinnedCodexReaction(user) {
+  // GitHub reports this app identity as User on issue reactions and Bot on
+  // issue comments. Keep that API-specific variation local to reactions.
+  return user?.login === CODEX_LOGIN &&
+    user?.id === BOTS.get(CODEX_LOGIN) &&
+    (user?.type === "Bot" || user?.type === "User");
+}
+
+function parseCompletedCodexSummary(comment) {
+  if (
+    !isPinnedBot(comment?.user, CODEX_LOGIN) ||
+    typeof comment?.body !== "string"
+  ) return undefined;
+  const lines = comment.body.replaceAll("\r\n", "\n").split("\n");
+  const expectedPrefix = [
+    CODEX_REVIEW_SUMMARY_MARKER,
+    "",
+    "## Codex Review Summary",
+    "",
+    "This comment shows the latest Codex review activity on this pull request.",
+    "",
+    "| Review | Status | Commit | Review trigger |",
+    "| --- | --- | --- | --- |",
+  ];
+  if (
+    expectedPrefix.some((line, index) => lines[index] !== line) ||
+    (lines[9] !== undefined && lines[9] !== "") ||
+    lines.slice(9).some((line) => /^\|.*\|$/.test(line.trim()))
+  ) return undefined;
+  const row = CODEX_REVIEW_SUMMARY_ROW.exec(lines[8] ?? "");
+  if (!row || row[1] !== row[2] || row[4].trim().length === 0) {
+    return undefined;
+  }
+  const completedAt = Date.parse(row[1]);
+  const createdAt = Date.parse(comment?.created_at ?? "");
+  const updatedAt = Date.parse(comment?.updated_at ?? "");
+  if (
+    !Number.isFinite(completedAt) || !Number.isFinite(createdAt) ||
+    !Number.isFinite(updatedAt) || createdAt > updatedAt ||
+    completedAt > updatedAt
+  ) return undefined;
+  return { shortRef: row[3], completedAt, updatedAt };
 }
 
 function isPinnedGraphqlBot(user, login) {
@@ -857,6 +905,7 @@ export async function findAutomatedReview(
   {
     reviews,
     comments,
+    reactions = /** @type {unknown[]} */ ([]),
     events = /** @type {unknown[]} */ ([]),
     timeline = /** @type {unknown[]} */ ([]),
   },
@@ -950,6 +999,43 @@ export async function findAutomatedReview(
         };
       }
     }
+  }
+
+  for (const comment of comments) {
+    const summary = parseCompletedCodexSummary(comment);
+    if (
+      !summary ||
+      (boundary !== undefined &&
+        (summary.completedAt <= boundary.time ||
+          summary.updatedAt <= boundary.time)) ||
+      !headSha.toLowerCase().startsWith(summary.shortRef.toLowerCase())
+    ) continue;
+    const resolved = await resolveCommit(summary.shortRef);
+    if (
+      typeof resolved !== "string" || !FULL_SHA.test(resolved) ||
+      resolved.toLowerCase() !== headSha.toLowerCase()
+    ) continue;
+    const reaction = reactions.find((candidate) => {
+      const createdAt = Date.parse(candidate?.created_at ?? "");
+      return isPinnedCodexReaction(candidate?.user) &&
+        candidate?.content === "+1" &&
+        Number.isFinite(createdAt) && createdAt > summary.updatedAt &&
+        (boundary === undefined || createdAt > boundary.time);
+    });
+    if (!reaction) continue;
+    codexSuccesses.push({
+      evidence: reaction,
+      time: evidenceTime(reaction, "reacted", "created"),
+      timelineEvent: "reacted",
+      proof: {
+        reviewer: CODEX_LOGIN,
+        source: "codex-summary",
+        state: "COMMENTED",
+        url: typeof comment.html_url === "string"
+          ? comment.html_url
+          : undefined,
+      },
+    });
   }
 
   for (const comment of comments) {
@@ -1341,7 +1427,7 @@ export async function publishAutomatedReviewStatus({
   if (!failure) {
     try {
       const common = { owner, repo };
-      const [reviews, comments, events, statuses, timeline] = await Promise.all(
+      const [reviews, comments, reactions, events, statuses, timeline] = await Promise.all(
         [
           collectAll(
             github,
@@ -1354,6 +1440,12 @@ export async function publishAutomatedReviewStatus({
             github.rest.issues.listComments,
             { ...common, issue_number: pullNumber },
             "comments",
+          ),
+          collectAll(
+            github,
+            github.rest.reactions.listForIssue,
+            { ...common, issue_number: pullNumber },
+            "pull request reactions",
           ),
           collectAll(
             github,
@@ -1469,7 +1561,7 @@ export async function publishAutomatedReviewStatus({
             REVIEW_EPOCH_EVENTS.has(reviewBoundary?.kind)))
       ) {
         review = await findAutomatedReview(
-          { reviews, comments, events, timeline },
+          { reviews, comments, reactions, events, timeline },
           headSha,
           (ref) => resolveCommitRef(github, common, ref),
           (login) =>
@@ -2732,7 +2824,7 @@ async function readMergeGroupSourceEvidence({
   pullNumber,
   sourceHeadSha,
 }) {
-  const [reviews, comments, events, statuses, timeline] = await Promise.all([
+  const [reviews, comments, reactions, events, statuses, timeline] = await Promise.all([
     collectAll(
       github,
       github.rest.pulls.listReviews,
@@ -2744,6 +2836,12 @@ async function readMergeGroupSourceEvidence({
       github.rest.issues.listComments,
       { ...common, issue_number: pullNumber },
       "source comments",
+    ),
+    collectAll(
+      github,
+      github.rest.reactions.listForIssue,
+      { ...common, issue_number: pullNumber },
+      "source pull request reactions",
     ),
     collectAll(
       github,
@@ -2764,7 +2862,7 @@ async function readMergeGroupSourceEvidence({
       "source review timeline",
     ),
   ]);
-  return { reviews, comments, events, statuses, timeline };
+  return { reviews, comments, reactions, events, statuses, timeline };
 }
 
 async function requireCurrentAutomatedReview({
@@ -3289,7 +3387,7 @@ async function revalidateAutomatedReviewRequest({
   marker,
 }) {
   const common = { owner, repo };
-  const [reviews, comments, events, statuses, timeline] = await Promise.all([
+  const [reviews, comments, reactions, events, statuses, timeline] = await Promise.all([
     collectAll(
       github,
       github.rest.pulls.listReviews,
@@ -3301,6 +3399,12 @@ async function revalidateAutomatedReviewRequest({
       github.rest.issues.listComments,
       { ...common, issue_number: pullNumber },
       "final request comments",
+    ),
+    collectAll(
+      github,
+      github.rest.reactions.listForIssue,
+      { ...common, issue_number: pullNumber },
+      "final request reactions",
     ),
     collectAll(
       github,
@@ -3358,7 +3462,7 @@ async function revalidateAutomatedReviewRequest({
   }
   const baseBinding = pullRequestBaseBinding(refreshed?.data);
   const review = await findAutomatedReview(
-    { reviews, comments, events, timeline },
+    { reviews, comments, reactions, events, timeline },
     headSha,
     (ref) => resolveCommitRef(github, common, ref),
     (login) =>

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -29,6 +29,8 @@ const HEAD = "a4804e5b9a0c9c45da7c4866d9eb317c878b029c";
 const OTHER_HEAD = "d258d506fede01c84b61bc40488059447d755a5a";
 const BASE_HEAD = "e724246c0e05c8dcf0db41f024f4592128222937";
 const NEW_HEAD = "b8459394dd5bac3a6736ee4c7723d7f291abb382";
+const LIVE_CODEX_SUMMARY_HEAD =
+  "60c61968ce726689e6ab9e5438d08e8bf8a11ced";
 const BASE_REPOSITORY_ID = 1_101_259_327;
 const BASE_REF = "main";
 const OTHER_BASE_REF = "release";
@@ -130,6 +132,61 @@ function codexFindingComment(
   };
 }
 
+function codexReviewSummary(
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id: 5559783108,
+    user: bot("chatgpt-codex-connector[bot]", CODEX_ID),
+    body: [
+      "<!-- codex-pull-request-review-summary -->",
+      "",
+      "## Codex Review Summary",
+      "",
+      "This comment shows the latest Codex review activity on this pull request.",
+      "",
+      "| Review | Status | Commit | Review trigger |",
+      "| --- | --- | --- | --- |",
+      `| 📝 **Code Review** | ✅ **Completed** <relative-time datetime="2026-09-06T14:32:42.547857Z">2026-09-06T14:32:42.547857Z</relative-time> | \`${HEAD.slice(0, 7)}\` | Manual request |`,
+      "",
+      "",
+      "",
+      "<details> <summary>ℹ️ About Codex in GitHub</summary>",
+      "<br/>",
+      "",
+      "[Your team has set up Codex to review pull requests in this repo](https://chatgpt.com/codex/cloud/settings/general). Reviews are triggered when you",
+      "- Open a pull request for review",
+      "- Mark a draft as ready",
+      '- Comment "@codex review" or "@codex security review".',
+      "",
+      "Codex reacts with 👀 while any review is running, comments if it has suggestions, and reacts with 👍 once all reviews finish with no findings.",
+      "",
+      "</details>",
+    ].join("\n"),
+    html_url:
+      "https://github.com/veryfront/veryfront-code/pull/4425#issuecomment-5559783108",
+    created_at: "2026-09-06T14:11:44Z",
+    updated_at: "2026-09-06T14:32:43Z",
+    ...overrides,
+  };
+}
+
+function codexCompletionReaction(
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id: 491342489,
+    user: {
+      login: "chatgpt-codex-connector[bot]",
+      id: CODEX_ID,
+      type: "User",
+    },
+    content: "+1",
+    created_at: "2026-09-06T14:32:45Z",
+    ...overrides,
+  };
+}
+
 function codexRateLimitComment(
   createdAt = "2026-08-25T08:01:00Z",
 ) {
@@ -195,6 +252,230 @@ function record(value: unknown, label: string): Record<string, unknown> {
 }
 
 describe("automated review evidence", () => {
+  it("accepts the live Codex completed-summary proof with its later connector reaction", async () => {
+    const liveSummary = codexReviewSummary({
+      body: (codexReviewSummary().body as string).replace(
+        HEAD.slice(0, 7),
+        LIVE_CODEX_SUMMARY_HEAD.slice(0, 7),
+      ),
+    });
+    const result = await findAutomatedReview(
+      {
+        reviews: [],
+        comments: [liveSummary],
+        reactions: [codexCompletionReaction()],
+      },
+      LIVE_CODEX_SUMMARY_HEAD,
+      (ref) =>
+        Promise.resolve(
+          ref === LIVE_CODEX_SUMMARY_HEAD.slice(0, 7)
+            ? LIVE_CODEX_SUMMARY_HEAD
+            : undefined,
+        ),
+    );
+    assertEquals(result?.source, "codex-summary");
+    assertEquals(result?.reviewer, "chatgpt-codex-connector[bot]");
+    assertEquals(
+      (await findAutomatedReview(
+        { reviews: [], comments: [codexComment()] },
+        HEAD,
+        () => Promise.resolve(HEAD),
+      ))?.source,
+      "codex-comment",
+      "legacy immutable no-findings proof remains valid",
+    );
+  });
+
+  it("requires both halves of Codex summary proof from the pinned connector", async () => {
+    const resolveHead = () => Promise.resolve(HEAD);
+    const rejectedEvidence = [
+      { comments: [codexReviewSummary()], reactions: [] },
+      { comments: [], reactions: [codexCompletionReaction()] },
+      {
+        comments: [codexReviewSummary()],
+        reactions: [codexCompletionReaction({
+          user: { login: "other-connector[bot]", id: CODEX_ID, type: "User" },
+        })],
+      },
+      {
+        comments: [codexReviewSummary()],
+        reactions: [codexCompletionReaction({
+          user: {
+            login: "chatgpt-codex-connector[bot]",
+            id: CODEX_ID + 1,
+            type: "User",
+          },
+        })],
+      },
+      {
+        comments: [codexReviewSummary()],
+        reactions: [codexCompletionReaction({ content: "eyes" })],
+      },
+      {
+        comments: [codexReviewSummary({
+          user: bot("other-connector[bot]", CODEX_ID),
+        })],
+        reactions: [codexCompletionReaction()],
+      },
+      {
+        comments: [codexReviewSummary({
+          user: bot("chatgpt-codex-connector[bot]", CODEX_ID + 1),
+        })],
+        reactions: [codexCompletionReaction()],
+      },
+      {
+        comments: [codexReviewSummary()],
+        reactions: [codexCompletionReaction({
+          user: {
+            login: "chatgpt-codex-connector[bot]",
+            id: CODEX_ID,
+            type: "Organization",
+          },
+        })],
+      },
+    ];
+    for (const evidence of rejectedEvidence) {
+      assertEquals(
+        await findAutomatedReview({ reviews: [], ...evidence }, HEAD, resolveHead),
+        undefined,
+      );
+    }
+    for (const type of ["Bot", "User"]) {
+      assertEquals(
+        (await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [codexReviewSummary()],
+            reactions: [codexCompletionReaction({
+              user: {
+                login: "chatgpt-codex-connector[bot]",
+                id: CODEX_ID,
+                type,
+              },
+            })],
+          },
+          HEAD,
+          resolveHead,
+        ))?.source,
+        "codex-summary",
+      );
+    }
+  });
+
+  it("rejects stale, ambiguous, and malformed Codex completed summaries", async () => {
+    const body = codexReviewSummary().body as string;
+    const row = body.split("\n")[8];
+    const rejected = [
+      [codexReviewSummary({
+        body: body.replace(`\`${HEAD.slice(0, 7)}\``, "`d258d50`"),
+      }), OTHER_HEAD],
+      [codexReviewSummary(), undefined],
+      [codexReviewSummary({
+        body: body.replace("✅ **Completed**", "🟡 **In progress**"),
+      }), HEAD],
+      [codexReviewSummary({
+        body: body.replace(`${row}\n\n`, `${row}\n\n  ${row}\n`),
+      }), HEAD],
+      [codexReviewSummary({
+        body: body.replace(
+          "| Review | Status | Commit | Review trigger |",
+          "| Status | Review | Commit | Review trigger |",
+        ),
+      }), HEAD],
+      [codexReviewSummary({ updated_at: "2026-09-06T14:32:41Z" }), HEAD],
+      [codexReviewSummary({ created_at: "not-a-date" }), HEAD],
+    ] as const;
+    for (const [summary, resolved] of rejected) {
+      assertEquals(
+        await findAutomatedReview(
+          {
+            reviews: [],
+            comments: [summary],
+            reactions: [codexCompletionReaction()],
+          },
+          HEAD,
+          () => Promise.resolve(resolved),
+        ),
+        undefined,
+      );
+    }
+  });
+
+  it("requires a current completion reaction and preserves epochs and later findings", async () => {
+    const resolveHead = () => Promise.resolve(HEAD);
+    const evidence = {
+      reviews: [],
+      comments: [codexReviewSummary()],
+      reactions: [codexCompletionReaction()],
+    };
+    assertEquals(
+      (await findAutomatedReview(evidence, HEAD, resolveHead))?.source,
+      "codex-summary",
+    );
+    evidence.reactions = [];
+    assertEquals(await findAutomatedReview(evidence, HEAD, resolveHead), undefined);
+    for (const createdAt of ["2026-09-06T14:32:43Z", "not-a-date"]) {
+      assertEquals(
+        await findAutomatedReview(
+          { ...evidence, reactions: [codexCompletionReaction({ created_at: createdAt })] },
+          HEAD,
+          resolveHead,
+        ),
+        undefined,
+      );
+    }
+    const boundary = Date.parse("2026-09-06T14:32:43Z");
+    assertEquals(
+      await findAutomatedReview(
+        { ...evidence, reactions: [codexCompletionReaction()] },
+        HEAD,
+        resolveHead,
+        undefined,
+        boundary,
+      ),
+      undefined,
+      "a stale completed summary cannot be revived by a newer reaction",
+    );
+    const freshSummary = codexReviewSummary({
+      body: (codexReviewSummary().body as string).replaceAll(
+        "2026-09-06T14:32:42.547857Z",
+        "2026-09-06T14:32:44Z",
+      ),
+      updated_at: "2026-09-06T14:32:44Z",
+    });
+    assertEquals(
+      (await findAutomatedReview(
+        {
+          ...evidence,
+          comments: [freshSummary],
+          reactions: [codexCompletionReaction()],
+        },
+        HEAD,
+        resolveHead,
+        undefined,
+        boundary,
+      ))?.source,
+      "codex-summary",
+    );
+    assertEquals(
+      await findAutomatedReview(
+        {
+          ...evidence,
+          comments: [
+            codexReviewSummary(),
+            codexFindingComment(HEAD.slice(0, 10), {
+              created_at: "2026-09-06T14:32:46Z",
+              updated_at: "2026-09-06T14:32:46Z",
+            }),
+          ],
+          reactions: [codexCompletionReaction()],
+        },
+        HEAD,
+        resolveHead,
+      ),
+      undefined,
+    );
+  });
   it("accepts the compact Codex no-findings verdict and rejects stale verdicts", async () => {
     const fixtures = [
       {
@@ -1065,6 +1346,7 @@ function githubFixture(options: {
   const endpoints = {
     reviews: () => undefined,
     comments: () => undefined,
+    reactions: () => undefined,
     events: () => undefined,
     statuses: () => undefined,
     refs: () => undefined,
@@ -1142,6 +1424,7 @@ function githubFixture(options: {
           return Promise.resolve();
         },
       },
+      reactions: { listForIssue: endpoints.reactions },
       git: {
         listMatchingRefs: endpoints.refs,
         getRef: (parameters: Record<string, unknown>) => {
@@ -1191,7 +1474,8 @@ describe("automated review publication", () => {
     const fixture = githubFixture({
       pages: {
         reviews: [[], []],
-        comments: [[], [codexComment()]],
+        comments: [[], [codexReviewSummary()]],
+        reactions: [[], [codexCompletionReaction()]],
         events: [[], []],
       },
       headResponses: [HEAD],
@@ -3048,6 +3332,7 @@ describe("automated review publication", () => {
     const partialPages = [
       "reviews",
       "comments",
+      "reactions",
       "events",
       "statuses",
       "timeline",
@@ -4586,6 +4871,30 @@ describe("merge queue review propagation", () => {
     );
   });
 
+  it("revalidates completed-summary proof before reusing it for a merge group", async () => {
+    const fixture = githubFixture({
+      pages: {
+        comments: [[codexReviewSummary()]],
+        reactions: [[codexCompletionReaction()]],
+        statuses: [[automatedReviewStatus()]],
+      },
+      commit: HEAD,
+      headResponses: [HEAD, HEAD],
+    });
+    const result = await publishMergeGroupReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      sourceHeadSha: HEAD,
+      baseHeadSha: BASE_HEAD,
+      mergeGroupSha: OTHER_HEAD,
+    });
+    assertEquals(result.state, "success");
+    assertEquals(fixture.published[0]?.sha, OTHER_HEAD);
+    assertEquals(fixture.published[0]?.state, "success");
+  });
+
   it("fails closed when the live merge-queue binding does not match", async () => {
     const staleBindings = [
       ["source", activeQueueBinding({ headRefOid: OTHER_HEAD })],
@@ -5185,6 +5494,7 @@ describe("merge queue review propagation", () => {
 
 function requestFixture(options: {
   comments?: Record<string, unknown>[];
+  reactions?: Record<string, unknown>[];
   events?: Record<string, unknown>[];
   eventResponses?: Record<string, unknown>[][];
   reviews?: Record<string, unknown>[];
@@ -5199,6 +5509,7 @@ function requestFixture(options: {
   const posted: Record<string, unknown>[] = [];
   const state = {
     comments: options.comments ?? [],
+    reactions: options.reactions ?? [],
     events: options.events ?? [],
     reviews: options.reviews ?? [],
     statuses: options.statuses ?? [],
@@ -5208,6 +5519,7 @@ function requestFixture(options: {
     draft: options.draft ?? false,
   };
   const listComments = () => undefined;
+  const listReactions = () => undefined;
   const listEvents = () => undefined;
   const listReviews = () => undefined;
   const listStatuses = () => undefined;
@@ -5219,6 +5531,7 @@ function requestFixture(options: {
     paginate: {
       async *iterator(endpoint: unknown) {
         if (endpoint === listComments) yield { data: state.comments };
+        else if (endpoint === listReactions) yield { data: state.reactions };
         else if (endpoint === listEvents) {
           const events = options.eventResponses?.[
             Math.min(eventRead++, options.eventResponses.length - 1)
@@ -5240,6 +5553,7 @@ function requestFixture(options: {
           return Promise.resolve();
         },
       },
+      reactions: { listForIssue: listReactions },
       pulls: {
         listReviews,
         get: () =>
@@ -5360,6 +5674,22 @@ describe("automated review request", () => {
     assertEquals(result.requested, false);
     assertEquals(result.reason, "reviewed");
     assertEquals(fixture.posted, []);
+
+    const completedSummary = requestFixture({
+      comments: [codexReviewSummary()],
+      reactions: [codexCompletionReaction()],
+    });
+    const completedSummaryResult = await requestAutomatedReview({
+      github: completedSummary.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      revalidateReviewEvidence: true,
+    });
+    assertEquals(completedSummaryResult.requested, false);
+    assertEquals(completedSummaryResult.reason, "reviewed");
+    assertEquals(completedSummary.posted, []);
 
     const changedHead = requestFixture({ headResponses: [HEAD, OTHER_HEAD] });
     const changedHeadResult = await requestAutomatedReview({
@@ -6990,6 +7320,7 @@ describe("automated review workflow", () => {
       record(mergeGroupJob.permissions, "merge group permissions"),
       {
         contents: "read",
+        issues: "read",
         "pull-requests": "read",
         statuses: "write",
       },

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -1470,6 +1470,127 @@ function githubFixture(options: {
 }
 
 describe("automated review publication", () => {
+  it("retries a completed summary until its connector reaction is visible", async () => {
+    let waits = 0;
+    const fixture = githubFixture({
+      pages: {
+        comments: [[codexReviewSummary()]],
+      },
+      pageResponses: {
+        reactions: [[[]], [[codexCompletionReaction()]]],
+      },
+      commit: HEAD,
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      waitForReaction: () => {
+        waits++;
+        return Promise.resolve();
+      },
+    });
+
+    assertEquals(result.state, "success");
+    assertEquals(result.review?.source, "codex-summary");
+    assertEquals(waits, 1);
+    assertEquals(fixture.published.length, 1);
+  });
+
+  it("bounds completed-summary reaction retries before remaining pending", async () => {
+    let waits = 0;
+    const fixture = githubFixture({
+      pages: { comments: [[codexReviewSummary()]] },
+      commit: HEAD,
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      waitForReaction: () => {
+        waits++;
+        return Promise.resolve();
+      },
+    });
+
+    assertEquals(result.state, "pending");
+    assertEquals(waits, 3);
+    assertEquals(fixture.published.length, 1);
+    assertEquals(fixture.published[0]?.state, "pending");
+  });
+
+  it("cancels reaction retry when the head, base, or lifecycle changes", async () => {
+    const changedSnapshots = [
+      githubFixture({
+        pages: { comments: [[codexReviewSummary()]] },
+        headResponses: [HEAD, OTHER_HEAD],
+        commit: HEAD,
+      }),
+      githubFixture({
+        pages: { comments: [[codexReviewSummary()]] },
+        pullResponses: [
+          associatedPull(),
+          associatedPull({ base: { ref: OTHER_BASE_REF, repo: { id: BASE_REPOSITORY_ID } } }),
+        ],
+        commit: HEAD,
+      }),
+      githubFixture({
+        pages: { comments: [[codexReviewSummary()]] },
+        pageResponses: {
+          events: [[[]], [[{
+            event: "base_ref_changed",
+            id: 42,
+            created_at: "2026-09-06T14:32:44Z",
+          }]]],
+        },
+        commit: HEAD,
+      }),
+    ];
+
+    for (const fixture of changedSnapshots) {
+      const result = await publishAutomatedReviewStatus({
+        github: fixture.github,
+        owner: "veryfront",
+        repo: "veryfront-code",
+        pullNumber: 1,
+        headSha: HEAD,
+        pullUrl: "https://example.test/pr/1",
+        waitForReaction: () => Promise.resolve(),
+      });
+      assertEquals(result.state, "failure");
+      assertEquals(fixture.published.length, 1);
+      assertEquals(fixture.published[0]?.state, "failure");
+    }
+  });
+
+  it("fails closed when reaction retrieval fails during a retry", async () => {
+    const malformedPage = {} as unknown as unknown[];
+    const fixture = githubFixture({
+      pages: { comments: [[codexReviewSummary()]] },
+      pageResponses: { reactions: [[[]], [malformedPage]] },
+      commit: HEAD,
+    });
+    const result = await publishAutomatedReviewStatus({
+      github: fixture.github,
+      owner: "veryfront",
+      repo: "veryfront-code",
+      pullNumber: 1,
+      headSha: HEAD,
+      pullUrl: "https://example.test/pr/1",
+      waitForReaction: () => Promise.resolve(),
+    });
+
+    assertEquals(result.state, "failure");
+    assert(result.failure instanceof Error);
+    assertEquals(fixture.published[0]?.state, "failure");
+  });
+
   it("fully paginates every evidence source before publishing success", async () => {
     const fixture = githubFixture({
       pages: {

--- a/scripts/ci/automated-review-gate.test.ts
+++ b/scripts/ci/automated-review-gate.test.ts
@@ -6869,6 +6869,7 @@ describe("automated review workflow", () => {
       record(timeoutJob.permissions, "timeout publisher permissions"),
       {
         contents: "read",
+        issues: "read",
         "pull-requests": "write",
         statuses: "write",
       },


### PR DESCRIPTION
The automated review gate could not consume the Codex connector's current summary format, so an automatic review that completed without findings left the gate pending until a separate manual review happened to emit the legacy comment format. This adds fail-closed composite proof for the current format: one canonical Completed summary row for the uniquely resolved current head plus the pinned connector's later `+1` PR reaction.

The parser preserves review-epoch invalidation, revocation, and later-findings precedence. Reactions are fully paginated through one shared evidence collector in initial reconciliation, final request revalidation, and merge-group reuse. When a current Completed summary arrives just before its reaction, the publisher performs bounded 1/2/4-second retries and refetches the complete pull/evidence snapshot each time. The merge-group job gains only `issues: read`, which GitHub requires for its issue-reactions endpoint; status thresholds, actor allowlists, and branch protection are unchanged.

Closes veryfront/veryfront-issue-inbox#1033.

## Red / green evidence

- Red on clean `origin/main` with Deno 2.7.7: the authentic PR #4425 summary/reaction payload returned no `findAutomatedReview` proof, while the legacy immutable no-findings control passed.
- Green with Deno 2.7.7: 8 automated-review-gate suites, 157 steps, zero failures.
- Targeted `deno check` passed.
- Normal pre-push hook passed format, lint, typecheck, and the full unit suite without bypass.
- Independent pre-push security review of `83c68b849bc550593954470c196964f7f54eed5a`: 98/100, APPROVE, no findings.

Regression coverage includes the real connector payload, missing/stale/deleted and delayed reactions, retry caps and snapshot drift, pinned login and immutable account IDs, the reaction API's Bot/User type variation, stale and ambiguous commits, malformed and multipart summary rows, edited-summary timing, lifecycle epochs, later findings, legacy/formal controls, pagination, merge-group reuse, request suppression, and retrieval failure behavior.
