### PR TITLE
test(agent): cover real provider overload responses

### DIFF
--- a/src/chat/provider-errors.test.ts
+++ b/src/chat/provider-errors.test.ts
@@ -5,6 +5,24 @@ import { parseProviderError } from "./provider-errors.ts";
 import { buildProviderError } from "#veryfront/provider/runtime-loader/provider-http.ts";
 
 describe("chat/provider-errors", () => {
+  it("preserves typed provider overload failures without exposing provider bodies", async () => {
+    for (const provider of ["anthropic", "openai", "google"] as const) {
+      const error = await buildProviderError(
+        provider,
+        new Response("private provider diagnostic", {
+          status: provider === "anthropic" ? 529 : 503,
+        }),
+      );
+
+      const expected = {
+        code: "OVERLOADED_ERROR",
+        message: "The LLM provider is currently overloaded",
+      };
+      assertEquals(parseProviderError(error), expected);
+      assertEquals(parseProviderError({ lastError: error }), expected);
+    }
+  });
+
   it("parses gateway problem JSON strings and direct provider problem objects", () => {
     assertEquals(
       parseProviderError(JSON.stringify({

--- a/src/chat/provider-errors.ts
+++ b/src/chat/provider-errors.ts
@@ -1,5 +1,8 @@
 import { safeJsonParse } from "#veryfront/utils/json.ts";
-import { ProviderQuotaError } from "#veryfront/provider/runtime-loader/provider-http.ts";
+import {
+  ProviderOverloadedError,
+  ProviderQuotaError,
+} from "#veryfront/provider/runtime-loader/provider-http.ts";
 export { safeJsonParse };
 export type { SafeJsonParseResult } from "#veryfront/utils/json.ts";
 
@@ -431,6 +434,13 @@ function parseProviderErrorInner(
 
   if (error instanceof ProviderQuotaError) {
     return AI_PROVIDER_BILLING_ERROR;
+  }
+
+  if (error instanceof ProviderOverloadedError) {
+    return {
+      code: "OVERLOADED_ERROR",
+      message: "The LLM provider is currently overloaded",
+    };
   }
 
   if (isErrorRecord(error)) {


### PR DESCRIPTION
## Summary

Stacked follow-up to #4424, targeting its branch. Addresses [typed overload review feedback](https://github.com/veryfront/veryfront-code/pull/4424#discussion_r3944369151).

- Recognize the existing `ProviderOverloadedError` before message heuristics, preserving the established `OVERLOADED_ERROR` code and canonical public text.
- Cover real Anthropic 529 and OpenAI/Google 503 errors, directly and inside a retry envelope, without exposing provider response bodies.
- No generic HTTP-status heuristic, new dependency, version change, or release publication.

## Verification

- Red: the new real-provider-error regression produced `EXTERNAL_SERVICE_ERROR` instead of `OVERLOADED_ERROR`.
- Green: pinned Deno 2.7.7 provider parser, 30 steps passed; adjacent stream-outcome, provider HTTP and hosted terminal suites, 21 tests / 107 steps passed.
- Changed-file typecheck, format, lint and diff checks passed.
- Actual local `codex review --uncommitted` and `codex review --base 562bdfd1ace8c85f8a9d300fc99bf01b47e6ea29`: no actionable findings. CLI test attempts encountered an unpinned-runtime initialization error and sandbox cache-write restriction; separate raw pinned author test runs passed.
- Mandatory pre-push checks and independent exact-head score are tracked below. Draft until final CI, review and thread gates pass.

Issue [veryfront-issue-inbox#192](https://github.com/veryfront/veryfront-issue-inbox/issues/192) remains open for the complete parent fix and staging verification.
