### PR TITLE
fix(chat): preserve decoded AG-UI error codes

### DIFF
--- a/src/chat/ag-ui.test.ts
+++ b/src/chat/ag-ui.test.ts
@@ -3,6 +3,10 @@ import { assertEquals, assertExists, assertThrows } from "#veryfront/testing/ass
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { unregister } from "#veryfront/extensions/contracts.ts";
 import {
+  createAgUiRunErrorEvent,
+  createAgUiSseErrorResponse,
+} from "#veryfront/agent/ag-ui/host-support.ts";
+import {
   createAgUiChatEventDecoderState,
   decodeAgUiSseChunk,
   flushAgUiSseChunk,
@@ -365,6 +369,37 @@ describe("chat/ag-ui", () => {
 
     assertEquals(result.events.length, 1);
     assertEquals(result.events[0]?.chatEvents, [{ type: "abort" }]);
+  });
+
+  it("round-trips non-cancellation error codes through public AG-UI encode and decode", async () => {
+    const response = createAgUiSseErrorResponse(
+      createAgUiRunErrorEvent("Purchase additional credits.", "INSUFFICIENT_CREDITS"),
+      402,
+    );
+    const result = decodeAgUiSseChunk(
+      createAgUiChatEventDecoderState(),
+      await response.text(),
+    );
+
+    assertEquals(result.events[0]?.chatEvents, [{
+      type: "error",
+      errorText: "Purchase additional credits.",
+      code: "INSUFFICIENT_CREDITS",
+    }]);
+
+    const legacyResponse = createAgUiSseErrorResponse(
+      createAgUiRunErrorEvent("Legacy failure"),
+      500,
+    );
+    const legacyResult = decodeAgUiSseChunk(
+      createAgUiChatEventDecoderState(),
+      await legacyResponse.text(),
+    );
+
+    assertEquals(legacyResult.events[0]?.chatEvents, [{
+      type: "error",
+      errorText: "Legacy failure",
+    }]);
   });
 
   it("keeps fallback reasoning ids stable across start, delta, and end", () => {

--- a/src/chat/ag-ui.ts
+++ b/src/chat/ag-ui.ts
@@ -898,6 +898,7 @@ function mapWireEventToChatEvents(
         errorText: wireEvent.payload.message?.length
           ? wireEvent.payload.message
           : "Conversation agent run failed",
+        ...(wireEvent.payload.code ? { code: wireEvent.payload.code } : {}),
       }];
   }
 }


### PR DESCRIPTION
## Summary

- preserve non-cancellation `RunError.code` values when public AG-UI SSE is decoded into `ChatStreamEvent`
- retain the existing `CANCELLED` to abort mapping
- retain legacy code-less error events unchanged

This is a focused stacked follow-up to #4424 and addresses [discussion 3944406677](https://github.com/veryfront/veryfront-code/pull/4424#discussion_r3944406677). It references [veryfront-issue-inbox#192](https://github.com/veryfront/veryfront-issue-inbox/issues/192) without closing it; staging verification remains separate.

## Verification

- Red: the public `createAgUiRunErrorEvent` / `createAgUiSseErrorResponse` to `decodeAgUiSseChunk` regression omitted `INSUFFICIENT_CREDITS`
- Green: pinned Deno 2.7.7 targeted suite, 7 files and 98 steps passed
- `deno fmt --check src/chat/ag-ui.ts src/chat/ag-ui.test.ts`
- `deno check --config=deno.json src/chat/ag-ui.ts`
- mandatory pre-push checks passed: formatting, lint, full typecheck, unit batches, serial tests, cwd tests
- local Codex uncommitted and base reviews found no actionable regressions
- independent exact-head review: 100/100, no actionable findings

## Stack

- Base branch: `fix/issue-192-runtime-terminal-codes`
- Base SHA: `83f1621d947b9f74bf867b4264a8b832c0b6fd83`
- Head SHA: `27c5249216db9179928ad2926d727f8b71d4b2d9`
