### PR TITLE
fix(agent): preserve safe credit details and guidance

### DIFF
--- a/src/agent/conversation/hosted-terminal.test.ts
+++ b/src/agent/conversation/hosted-terminal.test.ts
@@ -375,7 +375,7 @@ describe("agent/conversation-hosted-terminal", () => {
     assertEquals(resolveConversationHostedStreamErrorState(error), {
       status: "failed",
       terminalErrorCode: "INSUFFICIENT_CREDITS",
-      terminalErrorMessage: "Purchase additional credits or select a lower-cost model.",
+      terminalErrorMessage: "Insufficient AI credits",
     });
   });
 

--- a/src/agent/conversation/hosted-terminal.test.ts
+++ b/src/agent/conversation/hosted-terminal.test.ts
@@ -375,7 +375,8 @@ describe("agent/conversation-hosted-terminal", () => {
     assertEquals(resolveConversationHostedStreamErrorState(error), {
       status: "failed",
       terminalErrorCode: "INSUFFICIENT_CREDITS",
-      terminalErrorMessage: "Insufficient AI credits",
+      terminalErrorMessage:
+        "Insufficient AI credits. Purchase additional credits or upgrade your subscription plan.",
     });
   });
 

--- a/src/agent/hosted/child-lifecycle.test.ts
+++ b/src/agent/hosted/child-lifecycle.test.ts
@@ -604,10 +604,15 @@ describe("agent/hosted-child-lifecycle", () => {
       getExecutionSnapshot: () => null,
     });
 
-    assertEquals(calls, ["failed:INSUFFICIENT_CREDITS:Insufficient AI credits"]);
+    assertEquals(calls, [
+      "failed:INSUFFICIENT_CREDITS:Insufficient AI credits. Purchase additional credits or upgrade your subscription plan.",
+    ]);
     assertEquals(result.status, "failed");
     assertEquals(result.terminalState.terminalErrorCode, "INSUFFICIENT_CREDITS");
-    assertEquals(result.terminalState.terminalErrorMessage, "Insufficient AI credits");
+    assertEquals(
+      result.terminalState.terminalErrorMessage,
+      "Insufficient AI credits. Purchase additional credits or upgrade your subscription plan.",
+    );
   });
 
   it("skips selected terminal persistence while preserving failure state", async () => {

--- a/src/agent/hosted/child-lifecycle.test.ts
+++ b/src/agent/hosted/child-lifecycle.test.ts
@@ -604,10 +604,10 @@ describe("agent/hosted-child-lifecycle", () => {
       getExecutionSnapshot: () => null,
     });
 
-    assertEquals(calls, ["failed:INSUFFICIENT_CREDITS:Purchase credits."]);
+    assertEquals(calls, ["failed:INSUFFICIENT_CREDITS:Insufficient AI credits"]);
     assertEquals(result.status, "failed");
     assertEquals(result.terminalState.terminalErrorCode, "INSUFFICIENT_CREDITS");
-    assertEquals(result.terminalState.terminalErrorMessage, "Purchase credits.");
+    assertEquals(result.terminalState.terminalErrorMessage, "Insufficient AI credits");
   });
 
   it("skips selected terminal persistence while preserving failure state", async () => {

--- a/src/agent/hosted/durable-child-fork-execution.test.ts
+++ b/src/agent/hosted/durable-child-fork-execution.test.ts
@@ -314,7 +314,10 @@ describe("agent/hosted-durable-child-fork-execution", () => {
     });
 
     assertEquals(durableResult.terminalErrorCode, "INSUFFICIENT_CREDITS");
-    assertEquals(durableResult.terminalErrorMessage, "Insufficient AI credits");
+    assertEquals(
+      durableResult.terminalErrorMessage,
+      "Insufficient AI credits. Purchase additional credits or upgrade your subscription plan.",
+    );
   });
 
   it("sanitizes malformed child transcript text in durable invoke success results", () => {

--- a/src/agent/hosted/durable-child-fork-execution.test.ts
+++ b/src/agent/hosted/durable-child-fork-execution.test.ts
@@ -314,7 +314,7 @@ describe("agent/hosted-durable-child-fork-execution", () => {
     });
 
     assertEquals(durableResult.terminalErrorCode, "INSUFFICIENT_CREDITS");
-    assertEquals(durableResult.terminalErrorMessage, "Purchase credits.");
+    assertEquals(durableResult.terminalErrorMessage, "Insufficient AI credits");
   });
 
   it("sanitizes malformed child transcript text in durable invoke success results", () => {

--- a/src/agent/hosted/stream-terminal-error.test.ts
+++ b/src/agent/hosted/stream-terminal-error.test.ts
@@ -145,7 +145,8 @@ Deno.test("getEmptyHostedFinalizedMessageTerminalError prefers a real terminal e
     }),
     {
       code: "INSUFFICIENT_CREDITS",
-      message: "Insufficient AI credits",
+      message:
+        "Insufficient AI credits. Purchase additional credits or upgrade your subscription plan.",
     },
   );
 });

--- a/src/agent/hosted/stream-terminal-error.test.ts
+++ b/src/agent/hosted/stream-terminal-error.test.ts
@@ -145,7 +145,7 @@ Deno.test("getEmptyHostedFinalizedMessageTerminalError prefers a real terminal e
     }),
     {
       code: "INSUFFICIENT_CREDITS",
-      message: "Purchase additional credits or upgrade your subscription plan.",
+      message: "Insufficient AI credits",
     },
   );
 });

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -1867,7 +1867,8 @@ describe("chat-stream-handler", () => {
 
       assertEquals(events, [{
         type: "error",
-        error: "Insufficient AI credits",
+        error:
+          "Insufficient AI credits. Purchase additional credits or upgrade your subscription plan.",
         code: "INSUFFICIENT_CREDITS",
       }]);
       assertEquals(JSON.stringify(events).includes("provider-private-diagnostic"), false);

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -1867,7 +1867,7 @@ describe("chat-stream-handler", () => {
 
       assertEquals(events, [{
         type: "error",
-        error: "Purchase additional credits or select a lower-cost model.",
+        error: "Insufficient AI credits",
         code: "INSUFFICIENT_CREDITS",
       }]);
       assertEquals(JSON.stringify(events).includes("provider-private-diagnostic"), false);

--- a/src/chat/final-step-fallback.test.ts
+++ b/src/chat/final-step-fallback.test.ts
@@ -516,7 +516,7 @@ describe("chat/final-step-fallback", () => {
           }),
         },
       }),
-      { code: "RESOURCE_LIMIT_EXCEEDED", message: "Reduce request size and try again." },
+      { code: "RESOURCE_LIMIT_EXCEEDED", message: "Resource limit exceeded" },
     );
   });
 });

--- a/src/chat/provider-errors.test.ts
+++ b/src/chat/provider-errors.test.ts
@@ -5,6 +5,37 @@ import { parseProviderError } from "./provider-errors.ts";
 import { buildProviderError } from "#veryfront/provider/runtime-loader/provider-http.ts";
 
 describe("chat/provider-errors", () => {
+  it("does not expose provider text from recognized problem bodies", async () => {
+    for (const slug of ["insufficient-credits", "resource-limit-exceeded"]) {
+      const problem = {
+        slug,
+        error: "private prompt fragment",
+        suggestion: "private provider diagnostic",
+      };
+      const expected = {
+        code: slug === "insufficient-credits" ? "INSUFFICIENT_CREDITS" : "RESOURCE_LIMIT_EXCEEDED",
+        message: slug === "insufficient-credits"
+          ? "Insufficient AI credits"
+          : "Resource limit exceeded",
+        status: 402,
+      };
+
+      assertEquals(parseProviderError(problem), expected);
+      assertEquals(
+        parseProviderError(
+          await buildProviderError(
+            "openai",
+            new Response(JSON.stringify(problem), {
+              status: 402,
+              headers: { "content-type": "application/json" },
+            }),
+          ),
+        ),
+        expected,
+      );
+    }
+  });
+
   it("parses gateway problem JSON strings and direct provider problem objects", () => {
     assertEquals(
       parseProviderError(JSON.stringify({
@@ -13,7 +44,7 @@ describe("chat/provider-errors", () => {
       })),
       {
         code: "INSUFFICIENT_CREDITS",
-        message: "Purchase additional credits or upgrade your subscription plan.",
+        message: "Insufficient AI credits",
         status: 402,
       },
     );
@@ -25,7 +56,7 @@ describe("chat/provider-errors", () => {
       }),
       {
         code: "RESOURCE_LIMIT_EXCEEDED",
-        message: "Reduce the request size.",
+        message: "Resource limit exceeded",
         status: 402,
       },
     );
@@ -71,6 +102,39 @@ describe("chat/provider-errors", () => {
     );
   });
 
+  it("keeps validated credit amounts without copying private problem text", () => {
+    assertEquals(
+      parseProviderError({
+        slug: "insufficient-credits",
+        error: "private prompt fragment",
+        suggestion: "private provider diagnostic",
+        balance: 12,
+        required: 20,
+      }),
+      {
+        code: "INSUFFICIENT_CREDITS",
+        message:
+          "Insufficient AI credits: 20 credits required, 12 available. Purchase additional credits or upgrade your subscription plan.",
+        status: 402,
+      },
+    );
+    assertEquals(
+      parseProviderError({
+        slug: "insufficient-credits",
+        error: "Agent run credit limit exceeded: private prompt fragment",
+        suggestion: "private provider diagnostic",
+        balance: 57.25,
+        required: 85.5,
+      }),
+      {
+        code: "INSUFFICIENT_CREDITS",
+        message:
+          "Agent run credit limit exceeded: 85.5 credits required, 57.25 remaining. Start a new reviewed run or reduce the scope of this run.",
+        status: 402,
+      },
+    );
+  });
+
   it("falls back safely when gateway credit values are invalid", () => {
     assertEquals(
       parseProviderError({
@@ -82,7 +146,7 @@ describe("chat/provider-errors", () => {
       }),
       {
         code: "INSUFFICIENT_CREDITS",
-        message: "Start a new reviewed run.",
+        message: "Agent run credit limit exceeded",
         status: 402,
       },
     );
@@ -96,7 +160,7 @@ describe("chat/provider-errors", () => {
       }),
       {
         code: "INSUFFICIENT_CREDITS",
-        message: "AI credit limit exceeded",
+        message: "Insufficient AI credits",
         status: 402,
       },
     );
@@ -343,7 +407,7 @@ describe("chat/provider-errors", () => {
       ),
       {
         code: "RESOURCE_LIMIT_EXCEEDED",
-        message: "Reduce the request size.",
+        message: "Resource limit exceeded",
         status: 402,
       },
     );

--- a/src/chat/provider-errors.test.ts
+++ b/src/chat/provider-errors.test.ts
@@ -15,7 +15,7 @@ describe("chat/provider-errors", () => {
       const expected = {
         code: slug === "insufficient-credits" ? "INSUFFICIENT_CREDITS" : "RESOURCE_LIMIT_EXCEEDED",
         message: slug === "insufficient-credits"
-          ? "Insufficient AI credits"
+          ? "Insufficient AI credits. Purchase additional credits or upgrade your subscription plan."
           : "Resource limit exceeded",
         status: 402,
       };
@@ -44,7 +44,8 @@ describe("chat/provider-errors", () => {
       })),
       {
         code: "INSUFFICIENT_CREDITS",
-        message: "Insufficient AI credits",
+        message:
+          "Insufficient AI credits. Purchase additional credits or upgrade your subscription plan.",
         status: 402,
       },
     );
@@ -146,7 +147,8 @@ describe("chat/provider-errors", () => {
       }),
       {
         code: "INSUFFICIENT_CREDITS",
-        message: "Agent run credit limit exceeded",
+        message:
+          "Agent run credit limit exceeded. Start a new reviewed run or reduce the scope of this run.",
         status: 402,
       },
     );
@@ -163,6 +165,26 @@ describe("chat/provider-errors", () => {
         message: "Insufficient AI credits",
         status: 402,
       },
+    );
+  });
+
+  it("preserves guidance presence without requiring usable credit amounts", () => {
+    assertEquals(
+      parseProviderError({
+        slug: "insufficient-credits",
+        error: "private provider detail",
+        suggestion: "private provider guidance",
+        balance: 12,
+        required: -1,
+      }).message,
+      "Insufficient AI credits. Purchase additional credits or upgrade your subscription plan.",
+    );
+    assertEquals(
+      parseProviderError({
+        slug: "insufficient-credits",
+        error: "Agent run credit limit exceeded",
+      }).message,
+      "Agent run credit limit exceeded",
     );
   });
 

--- a/src/chat/provider-errors.ts
+++ b/src/chat/provider-errors.ts
@@ -136,11 +136,12 @@ function parseEmbeddedErrorJson(value: string): unknown | null {
 function formatCreditProblemMessage(
   body: Record<string, unknown>,
   error: string | null,
-  suggestion: string | null,
+  hasSuggestion: boolean,
 ): string {
   const balance = body.balance;
   const required = body.required;
-  const fallback = suggestion ?? error ?? "Insufficient AI credits";
+  const isRunLimit = error?.toLowerCase().includes("agent run credit limit") ?? false;
+  const fallback = isRunLimit ? "Agent run credit limit exceeded" : "Insufficient AI credits";
   if (
     typeof balance !== "number" || !Number.isFinite(balance) || balance < 0 ||
     typeof required !== "number" || !Number.isFinite(required) || required < 0
@@ -148,16 +149,17 @@ function formatCreditProblemMessage(
     return fallback;
   }
 
-  const summary = error ?? "Insufficient AI credits";
-  const availability = error?.toLowerCase().includes("agent run credit limit")
-    ? "remaining"
-    : "available";
+  const summary = error === "AI credit limit exceeded" ? "AI credit limit exceeded" : fallback;
+  const availability = isRunLimit ? "remaining" : "available";
+  const suggestion = isRunLimit
+    ? "Start a new reviewed run or reduce the scope of this run."
+    : "Purchase additional credits or upgrade your subscription plan.";
   return `${summary}: ${required} credits required, ${balance} ${availability}.${
-    suggestion ? ` ${suggestion}` : ""
+    hasSuggestion ? ` ${suggestion}` : ""
   }`;
 }
 
-/** Parses known problem body. */
+/** Parses known problem bodies without exposing provider-controlled text. */
 export function parseKnownProblemBody(body: unknown): ParsedProviderError | null {
   if (!isErrorRecord(body)) {
     return null;
@@ -175,7 +177,7 @@ export function parseKnownProblemBody(body: unknown): ParsedProviderError | null
   if (slug === "insufficient-credits" || error === "AI credit limit exceeded") {
     return {
       code: "INSUFFICIENT_CREDITS",
-      message: formatCreditProblemMessage(body, error, suggestion),
+      message: formatCreditProblemMessage(body, error, Boolean(suggestion)),
       status: 402,
     };
   }
@@ -183,7 +185,7 @@ export function parseKnownProblemBody(body: unknown): ParsedProviderError | null
   if (slug === "resource-limit-exceeded") {
     return {
       code: "RESOURCE_LIMIT_EXCEEDED",
-      message: suggestion ?? error ?? "Resource limit exceeded",
+      message: "Resource limit exceeded",
       status: 402,
     };
   }

--- a/src/chat/provider-errors.ts
+++ b/src/chat/provider-errors.ts
@@ -142,18 +142,18 @@ function formatCreditProblemMessage(
   const required = body.required;
   const isRunLimit = error?.toLowerCase().includes("agent run credit limit") ?? false;
   const fallback = isRunLimit ? "Agent run credit limit exceeded" : "Insufficient AI credits";
+  const suggestion = isRunLimit
+    ? "Start a new reviewed run or reduce the scope of this run."
+    : "Purchase additional credits or upgrade your subscription plan.";
   if (
     typeof balance !== "number" || !Number.isFinite(balance) || balance < 0 ||
     typeof required !== "number" || !Number.isFinite(required) || required < 0
   ) {
-    return fallback;
+    return hasSuggestion ? `${fallback}. ${suggestion}` : fallback;
   }
 
   const summary = error === "AI credit limit exceeded" ? "AI credit limit exceeded" : fallback;
   const availability = isRunLimit ? "remaining" : "available";
-  const suggestion = isRunLimit
-    ? "Start a new reviewed run or reduce the scope of this run."
-    : "Purchase additional credits or upgrade your subscription plan.";
   return `${summary}: ${required} credits required, ${balance} ${availability}.${
     hasSuggestion ? ` ${suggestion}` : ""
   }`;

--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -963,7 +963,7 @@ describe("internal-agents/run-stream", () => {
         assertEquals(runErrorIndex > stepStartedIndex, true);
         assertEquals(
           runError?.message,
-          "Purchase additional credits or select a lower-cost model.",
+          "Insufficient AI credits",
         );
         assertEquals(runError?.code, "INSUFFICIENT_CREDITS");
         assertEquals(JSON.stringify(runError).includes("provider-private-diagnostic"), false);

--- a/src/internal-agents/run-stream.test.ts
+++ b/src/internal-agents/run-stream.test.ts
@@ -963,7 +963,7 @@ describe("internal-agents/run-stream", () => {
         assertEquals(runErrorIndex > stepStartedIndex, true);
         assertEquals(
           runError?.message,
-          "Insufficient AI credits",
+          "Insufficient AI credits. Purchase additional credits or upgrade your subscription plan.",
         );
         assertEquals(runError?.code, "INSUFFICIENT_CREDITS");
         assertEquals(JSON.stringify(runError).includes("provider-private-diagnostic"), false);

--- a/src/provider/runtime-loader/provider-http.test.ts
+++ b/src/provider/runtime-loader/provider-http.test.ts
@@ -452,7 +452,7 @@ describe("provider-http", () => {
       assertEquals(Object.keys(err).includes("responseBody"), false);
       assertEquals(parseProviderError(err), {
         code: "RESOURCE_LIMIT_EXCEEDED",
-        message: "Reduce the request size and try again.",
+        message: "Resource limit exceeded",
         status: 402,
       });
     });


### PR DESCRIPTION
## Summary

Stacked follow-up to #4424 for [problem-body text sanitization](https://github.com/veryfront/veryfront-code/pull/4424#discussion_r3944406674).

The latest parent already has canonical summaries and child/fork terminal-code propagation. This reconciled follow-up keeps those changes and preserves the original validated credit amounts and fixed public guidance without restoring provider-controlled text.

- Replace provider-controlled credit/resource error and suggestion text with canonical public messages.
- Preserve stable error codes, HTTP402 classification, valid finite nonnegative required/balance amounts, and run-budget remaining versus account available wording.
- Preserve credit-message formatting when guidance is absent; when supplied, emit fixed public guidance rather than arbitrary provider text.
- Update shared runtime, hosted, final-step and provider-HTTP expectations. No dependencies, version changes, or release publication.

## Verification

- Red: a recognized problem body exposed the synthetic private diagnostic as its public message.
- Green: the reconciled parent and follow-up pass33test groups/445steps under pinned Deno2.7.7, including real provider responses, numeric and guidance cases, runtime/hosted/internal streams, decoder, and child/fork consumers.
- Changed-file typecheck, lint, format and diff checks pass.
- Actual local Codex reviews and broader tests identified missed consumer expectations; all are addressed while preserving the existing no-guidance credit format. Final local branch review has no actionable findings; its test attempt used unpinned Deno2.9.4 and failed initialization, while separate pinned author/reviewer runs pass.
- Independent exact-head reviews and scores are recorded below. Each new commit requires a fresh review; historical scores do not approve a newer head.
- Mandatory push checks and GitHub CI must pass before merge into the parent branch. Issue192 remains open for complete parent delivery and staging verification.
