### PR TITLE
fix(agent): classify only provider-origin stream failures

### DIFF
--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -638,13 +638,7 @@ async function processActiveStream(
   abortSignal: AbortSignal | undefined,
 ): Promise<void> {
   const baseAdapter = createRuntimeStreamProviderAdapter({
-    open: (signal) => {
-      try {
-        return source.open(signal).fullStream;
-      } catch (error) {
-        throw createRuntimeProviderStreamFailure(error);
-      }
-    },
+    open: (signal) => source.open(signal).fullStream,
     options: {
       availableToolNames: callbacks?.availableToolNames
         ? new Set(callbacks.availableToolNames)
@@ -793,19 +787,11 @@ export function processStreamInternal(
   // provider wrappers. After Gate 2 the extensions emit raw streams, so the
   // legacy compatibility boundary reinstates the wrapper for source-opened
   // streams only; pre-opened results keep their historical unwrapped shape.
-  let result: RuntimeStreamResult;
-  if (isRuntimeStreamSource(resultOrSource)) {
-    try {
-      result = wrapLegacyRuntimeStreamResult(
-        resultOrSource.open(abortSignal ?? new AbortController().signal),
-      );
-    } catch (error) {
-      throwIfAborted(abortSignal);
-      throw createRuntimeProviderStreamFailure(error);
-    }
-  } else {
-    result = resultOrSource;
-  }
+  const result = isRuntimeStreamSource(resultOrSource)
+    ? wrapLegacyRuntimeStreamResult(
+      resultOrSource.open(abortSignal ?? new AbortController().signal),
+    )
+    : resultOrSource;
 
   const process = async () => {
     let eventCount = 0;

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -10,6 +10,10 @@
 
 import type { RuntimeStreamPart, RuntimeStreamResult } from "./runtime-tool-types.ts";
 import type { ModelRuntime } from "#veryfront/provider/types.ts";
+import {
+  createRuntimeProviderStreamFailure,
+  readRuntimeProviderStreamFailureCause,
+} from "#veryfront/runtime/provider-stream-error-provenance.ts";
 import { sendSSE } from "./sse-utils.ts";
 import {
   mergeToolCallInput,
@@ -95,33 +99,6 @@ export interface RuntimeStreamErrorEvent extends Record<string, unknown> {
   type: "error";
   error: string;
   code?: string;
-}
-
-const runtimeProviderStreamFailureCauses = new WeakMap<object, unknown>();
-
-class RuntimeProviderStreamFailure extends Error {
-  constructor(cause: unknown) {
-    super("Provider stream failed");
-    this.name = "RuntimeProviderStreamFailure";
-    runtimeProviderStreamFailureCauses.set(this, cause);
-  }
-}
-
-function createRuntimeProviderStreamFailure(error: unknown): RuntimeProviderStreamFailure {
-  return new RuntimeProviderStreamFailure(error);
-}
-
-function readRuntimeProviderStreamFailureCause(
-  error: unknown,
-): { found: false } | { found: true; cause: unknown } {
-  if (
-    (typeof error !== "object" || error === null) &&
-    typeof error !== "function"
-  ) {
-    return { found: false };
-  }
-  if (!runtimeProviderStreamFailureCauses.has(error)) return { found: false };
-  return { found: true, cause: runtimeProviderStreamFailureCauses.get(error) };
 }
 
 function wrapRuntimeProviderReadableStream(

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -9,6 +9,7 @@
  */
 
 import type { RuntimeStreamPart, RuntimeStreamResult } from "./runtime-tool-types.ts";
+import type { ModelRuntime } from "#veryfront/provider/types.ts";
 import { sendSSE } from "./sse-utils.ts";
 import {
   mergeToolCallInput,
@@ -29,7 +30,6 @@ import { setActiveSpanAttributes, SpanKind } from "#veryfront/observability";
 import { withSpan } from "#veryfront/observability/tracing/otlp-setup.ts";
 import { getHostEnv } from "#veryfront/platform/compat/process.ts";
 import { withToolInputStatusTransitions } from "#veryfront/provider/runtime-loader/tool-input-status.ts";
-import { ProviderError } from "#veryfront/provider/runtime-loader/provider-http.ts";
 import {
   applyLifecycleSnapshotToChatStreamState,
   createRuntimeStreamProviderAdapter,
@@ -60,7 +60,6 @@ import {
   isIntegrationAuthenticationActionResult,
 } from "#veryfront/tool/result.ts";
 import { compareStrings } from "#veryfront/utils/compare.ts";
-import { readOwnDataProperty } from "./data-property-descriptor.ts";
 
 const logger = serverLogger.component("agent");
 const LOCAL_TOOL_COMMIT_GRACE_MS = 250;
@@ -98,24 +97,106 @@ export interface RuntimeStreamErrorEvent extends Record<string, unknown> {
   code?: string;
 }
 
-function hasProviderStreamErrorEvidence(error: unknown): boolean {
-  let current = error;
-  try {
-    for (let depth = 0; depth < 64; depth += 1) {
-      if (current instanceof ProviderError) return true;
-      if (
-        typeof readOwnDataProperty(current, "responseBody", "provider stream error", false) ===
-          "string"
-      ) {
-        return true;
+const runtimeProviderStreamFailureCauses = new WeakMap<object, unknown>();
+
+class RuntimeProviderStreamFailure extends Error {
+  constructor(cause: unknown) {
+    super("Provider stream failed");
+    this.name = "RuntimeProviderStreamFailure";
+    runtimeProviderStreamFailureCauses.set(this, cause);
+  }
+}
+
+function createRuntimeProviderStreamFailure(error: unknown): RuntimeProviderStreamFailure {
+  return new RuntimeProviderStreamFailure(error);
+}
+
+function readRuntimeProviderStreamFailureCause(
+  error: unknown,
+): { found: false } | { found: true; cause: unknown } {
+  if (
+    (typeof error !== "object" || error === null) &&
+    typeof error !== "function"
+  ) {
+    return { found: false };
+  }
+  if (!runtimeProviderStreamFailureCauses.has(error)) return { found: false };
+  return { found: true, cause: runtimeProviderStreamFailureCauses.get(error) };
+}
+
+function wrapRuntimeProviderReadableStream(
+  stream: ReadableStream<unknown>,
+): ReadableStream<unknown> {
+  const reader = stream.getReader();
+  return new ReadableStream<unknown>({
+    async pull(controller) {
+      try {
+        const next = await reader.read();
+        if (next.done) controller.close();
+        else controller.enqueue(next.value);
+      } catch (error) {
+        controller.error(createRuntimeProviderStreamFailure(error));
       }
-      current = readOwnDataProperty(current, "lastError", "provider stream error", false);
-      if (current === undefined) return false;
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+}
+
+/** Mark failures thrown by a model and its stream as provider-originated. */
+export function withRuntimeProviderStreamErrorProvenance<CallOptions, ContentPart>(
+  model: ModelRuntime<CallOptions, ContentPart>,
+): ModelRuntime<CallOptions, ContentPart> {
+  const doStream = async (options: CallOptions) => {
+    try {
+      const result = await model.doStream(options);
+      return {
+        ...result,
+        stream: wrapRuntimeProviderReadableStream(result.stream),
+      };
+    } catch (error) {
+      throw createRuntimeProviderStreamFailure(error);
     }
-    return false;
+  };
+  const target = Object.create(model) as ModelRuntime<CallOptions, ContentPart>;
+  return new Proxy(target, {
+    get(_target, property) {
+      if (property === "doStream") return doStream;
+      return Reflect.get(model, property, model);
+    },
+  });
+}
+
+function isStreamLifecycleFailure(error: unknown): error is StreamLifecycleFailure {
+  try {
+    return error instanceof StreamLifecycleFailure;
   } catch {
     return false;
   }
+}
+
+function resolveRuntimeFallbackErrorEvent(error: unknown): RuntimeStreamErrorEvent {
+  try {
+    return {
+      type: "error",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } catch {
+    try {
+      return { type: "error", error: stringifyToolError(error) };
+    } catch {
+      return { type: "error", error: "Unknown error" };
+    }
+  }
+}
+
+/** Serialize an outer runtime failure without inferring provider provenance. */
+export function resolveRuntimeExecutionErrorEvent(error: unknown): RuntimeStreamErrorEvent {
+  const providerFailure = readRuntimeProviderStreamFailureCause(error);
+  if (providerFailure.found) return resolveRuntimeStreamErrorEvent(providerFailure.cause);
+  if (isStreamLifecycleFailure(error)) return resolveRuntimeStreamErrorEvent(error);
+  return resolveRuntimeFallbackErrorEvent(error);
 }
 
 /** Preserve only curated provider terminal details across the runtime stream boundary. */
@@ -132,9 +213,7 @@ export function resolveRuntimeStreamErrorEvent(error: unknown): RuntimeStreamErr
       };
     }
 
-    const knownProviderError = hasProviderStreamErrorEvidence(error)
-      ? resolveKnownProviderTerminalError(error)
-      : null;
+    const knownProviderError = resolveKnownProviderTerminalError(error);
     if (knownProviderError) {
       return {
         type: "error",
@@ -143,16 +222,9 @@ export function resolveRuntimeStreamErrorEvent(error: unknown): RuntimeStreamErr
       };
     }
 
-    return {
-      type: "error",
-      error: error instanceof Error ? error.message : String(error),
-    };
+    return resolveRuntimeFallbackErrorEvent(error);
   } catch {
-    try {
-      return { type: "error", error: stringifyToolError(error) };
-    } catch {
-      return { type: "error", error: "Unknown error" };
-    }
+    return resolveRuntimeFallbackErrorEvent(error);
   }
 }
 
@@ -393,11 +465,15 @@ function shouldIgnoreLateProviderBodyReadError(state: ChatStreamState, error: un
 async function readNextStreamPart(
   iterator: AsyncIterator<unknown>,
   state: ChatStreamState,
+  abortSignal?: AbortSignal,
 ): Promise<IteratorResult<unknown>> {
   try {
     return await iterator.next();
   } catch (error) {
-    if (!shouldIgnoreLateProviderBodyReadError(state, error)) {
+    throwIfAborted(abortSignal);
+    const providerFailure = readRuntimeProviderStreamFailureCause(error);
+    const streamError = providerFailure.found ? providerFailure.cause : error;
+    if (!shouldIgnoreLateProviderBodyReadError(state, streamError)) {
       throw error;
     }
 
@@ -406,7 +482,7 @@ async function readNextStreamPart(
       toolCallCount: state.toolCalls.size,
       toolResultCount: state.toolResults.length,
       textLength: state.accumulatedText.length,
-      error: getStreamErrorMessage(error),
+      error: getStreamErrorMessage(streamError),
     });
 
     return { done: true, value: undefined };
@@ -419,11 +495,12 @@ async function readNextStreamPartWithTimeout(
   timeoutMs: number,
   setTimeoutFn: typeof setTimeout = setTimeout,
   clearTimeoutFn: typeof clearTimeout = clearTimeout,
+  abortSignal?: AbortSignal,
 ): Promise<IteratorResult<unknown> | "timeout"> {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   try {
     return await Promise.race([
-      readNextStreamPart(iterator, state),
+      readNextStreamPart(iterator, state, abortSignal),
       new Promise<"timeout">((resolve) => {
         timeoutId = setTimeoutFn(() => resolve("timeout"), timeoutMs);
       }),
@@ -560,8 +637,14 @@ async function processActiveStream(
   callbacks: ChatStreamCallbacks | undefined,
   abortSignal: AbortSignal | undefined,
 ): Promise<void> {
-  const adapter = createRuntimeStreamProviderAdapter({
-    open: (signal) => source.open(signal).fullStream,
+  const baseAdapter = createRuntimeStreamProviderAdapter({
+    open: (signal) => {
+      try {
+        return source.open(signal).fullStream;
+      } catch (error) {
+        throw createRuntimeProviderStreamFailure(error);
+      }
+    },
     options: {
       availableToolNames: callbacks?.availableToolNames
         ? new Set(callbacks.availableToolNames)
@@ -571,6 +654,21 @@ async function processActiveStream(
       ),
     },
   });
+  const adapter: typeof baseAdapter = {
+    ...baseAdapter,
+    classifyError(error, snapshot) {
+      const providerFailure = readRuntimeProviderStreamFailureCause(error);
+      if (providerFailure.found) {
+        return baseAdapter.classifyError(providerFailure.cause, snapshot);
+      }
+      return {
+        code: "PROVIDER_STREAM_ERROR",
+        publicMessage: resolveRuntimeFallbackErrorEvent(error).error,
+        retryable: true,
+        terminal: false,
+      };
+    },
+  };
   const run = runStreamLifecycle({
     provider: adapter,
     policy: resolveRuntimeLifecyclePolicy(callbacks),
@@ -695,11 +793,19 @@ export function processStreamInternal(
   // provider wrappers. After Gate 2 the extensions emit raw streams, so the
   // legacy compatibility boundary reinstates the wrapper for source-opened
   // streams only; pre-opened results keep their historical unwrapped shape.
-  const result = isRuntimeStreamSource(resultOrSource)
-    ? wrapLegacyRuntimeStreamResult(
-      resultOrSource.open(abortSignal ?? new AbortController().signal),
-    )
-    : resultOrSource;
+  let result: RuntimeStreamResult;
+  if (isRuntimeStreamSource(resultOrSource)) {
+    try {
+      result = wrapLegacyRuntimeStreamResult(
+        resultOrSource.open(abortSignal ?? new AbortController().signal),
+      );
+    } catch (error) {
+      throwIfAborted(abortSignal);
+      throw createRuntimeProviderStreamFailure(error);
+    }
+  } else {
+    result = resultOrSource;
+  }
 
   const process = async () => {
     let eventCount = 0;
@@ -1033,6 +1139,7 @@ export function processStreamInternal(
             callbacks?.localToolInputIdleTimeoutMs ?? LOCAL_TOOL_INPUT_IDLE_MS,
             callbacks?.setTimeoutFn,
             callbacks?.clearTimeoutFn,
+            abortSignal,
           )
           : shouldStopForCommittedLocalToolCallNow
           ? await readNextStreamPartWithTimeout(
@@ -1041,6 +1148,7 @@ export function processStreamInternal(
             callbacks?.localToolCommitGraceMs ?? LOCAL_TOOL_COMMIT_GRACE_MS,
             callbacks?.setTimeoutFn,
             callbacks?.clearTimeoutFn,
+            abortSignal,
           )
           : shouldStopForIdleOutput
           ? await readNextStreamPartWithTimeout(
@@ -1049,6 +1157,7 @@ export function processStreamInternal(
             callbacks?.streamIdleTimeoutMs ?? STREAM_OUTPUT_IDLE_MS,
             callbacks?.setTimeoutFn,
             callbacks?.clearTimeoutFn,
+            abortSignal,
           )
           : shouldStopForIdleStart
           ? await readNextStreamPartWithTimeout(
@@ -1057,8 +1166,9 @@ export function processStreamInternal(
             callbacks?.streamIdleTimeoutMs ?? STREAM_START_IDLE_MS,
             callbacks?.setTimeoutFn,
             callbacks?.clearTimeoutFn,
+            abortSignal,
           )
-          : await readNextStreamPart(streamIterator, state);
+          : await readNextStreamPart(streamIterator, state, abortSignal);
         if (next === "timeout") {
           state.finishReason ??= wouldTimeOutIdle ? "stop" : "tool-calls";
           returnStreamIteratorOnce();

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -128,20 +128,36 @@ function wrapRuntimeProviderReadableStream(
   stream: ReadableStream<unknown>,
 ): ReadableStream<unknown> {
   const reader = stream.getReader();
-  return new ReadableStream<unknown>({
-    async pull(controller) {
-      try {
-        const next = await reader.read();
-        if (next.done) controller.close();
-        else controller.enqueue(next.value);
-      } catch (error) {
-        controller.error(createRuntimeProviderStreamFailure(error));
-      }
+  let released = false;
+  const releaseReader = () => {
+    if (released) return;
+    released = true;
+    reader.releaseLock();
+  };
+  return new ReadableStream<unknown>(
+    {
+      async pull(controller) {
+        try {
+          const next = await reader.read();
+          if (next.done) {
+            releaseReader();
+            controller.close();
+          } else controller.enqueue(next.value);
+        } catch (error) {
+          releaseReader();
+          controller.error(createRuntimeProviderStreamFailure(error));
+        }
+      },
+      async cancel(reason) {
+        try {
+          await reader.cancel(reason);
+        } finally {
+          releaseReader();
+        }
+      },
     },
-    cancel(reason) {
-      return reader.cancel(reason);
-    },
-  });
+    { highWaterMark: 0 },
+  );
 }
 
 /** Mark failures thrown by a model and its stream as provider-originated. */
@@ -194,7 +210,16 @@ function resolveRuntimeFallbackErrorEvent(error: unknown): RuntimeStreamErrorEve
 /** Serialize an outer runtime failure without inferring provider provenance. */
 export function resolveRuntimeExecutionErrorEvent(error: unknown): RuntimeStreamErrorEvent {
   const providerFailure = readRuntimeProviderStreamFailureCause(error);
-  if (providerFailure.found) return resolveRuntimeStreamErrorEvent(providerFailure.cause);
+  if (providerFailure.found) {
+    const knownProviderError = resolveKnownProviderTerminalError(providerFailure.cause);
+    return knownProviderError
+      ? {
+        type: "error",
+        error: knownProviderError.message,
+        code: knownProviderError.code,
+      }
+      : { type: "error", error: "Provider stream failed" };
+  }
   if (isStreamLifecycleFailure(error)) return resolveRuntimeStreamErrorEvent(error);
   return resolveRuntimeFallbackErrorEvent(error);
 }

--- a/src/agent/runtime/chat-stream-handler.ts
+++ b/src/agent/runtime/chat-stream-handler.ts
@@ -652,6 +652,13 @@ async function processActiveStream(
   });
   const adapter: typeof baseAdapter = {
     ...baseAdapter,
+    decode(part, snapshot) {
+      try {
+        return baseAdapter.decode(part, snapshot);
+      } catch (error) {
+        throw createRuntimeProviderStreamFailure(error);
+      }
+    },
     classifyError(error, snapshot) {
       const providerFailure = readRuntimeProviderStreamFailureCause(error);
       if (providerFailure.found) {

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -2659,17 +2659,18 @@ export class AgentRuntime {
       );
       const streamLifecycleMode = resolveStreamLifecycleModeFromEnv();
       const streamModel = withRuntimeProviderStreamErrorProvenance(languageModel);
+      const providerMessages = convertToTextGenerationRuntimeRequestMessages(
+        currentMessages,
+        // A server-local runtime fetches attachments from this machine,
+        // where a loopback or private-network URL resolves; only a remote
+        // provider needs the URL to be reachable from the internet.
+        { requireInternetReachableAttachments: !isLocalModelRuntime(languageModel) },
+      );
       const streamSource = createRuntimeStreamSource((streamSignal) =>
         streamText({
           model: streamModel,
           system: providerSystemPrompt,
-          messages: convertToTextGenerationRuntimeRequestMessages(
-            currentMessages,
-            // A server-local runtime fetches attachments from this machine,
-            // where a loopback or private-network URL resolves; only a remote
-            // provider needs the URL to be reachable from the internet.
-            { requireInternetReachableAttachments: !isLocalModelRuntime(languageModel) },
-          ),
+          messages: providerMessages,
           tools: runtimeTools,
           experimental_repairToolCall: repairToolCall,
           maxOutputTokens,

--- a/src/agent/runtime/index.ts
+++ b/src/agent/runtime/index.ts
@@ -55,11 +55,13 @@ import {
 import { runWithRuntimeRemoteToolSources } from "./remote-tool-source-context.ts";
 import {
   announceStreamedToolCallInput,
+  createRuntimeStreamSource,
   createStreamState,
   processStream,
-  resolveRuntimeStreamErrorEvent,
+  resolveRuntimeExecutionErrorEvent,
   type StreamingToolCall,
   type StreamingToolResult,
+  withRuntimeProviderStreamErrorProvenance,
 } from "./chat-stream-handler.ts";
 import { repairToolCall } from "./repair-tool-call.ts";
 import { MiddlewareChain } from "../middleware/chain.ts";
@@ -217,7 +219,6 @@ export {
 export { accumulateUsage, getMaxSteps, normalizeInput } from "./input-utils.ts";
 export { createStreamState, processStream } from "./chat-stream-handler.ts";
 import { resolveStreamLifecycleModeFromEnv } from "./stream-lifecycle-mode.ts";
-import { createRuntimeStreamSource } from "./chat-stream-handler.ts";
 export type {
   ChatStreamCallbacks,
   ChatStreamState,
@@ -1792,7 +1793,7 @@ export class AgentRuntime {
 
             this.status = "error";
             logger.error("Agent stream error", { error });
-            sendSSE(controller, encoder, resolveRuntimeStreamErrorEvent(error));
+            sendSSE(controller, encoder, resolveRuntimeExecutionErrorEvent(error));
             closeSSEStream(controller);
           } finally {
             abortScope.dispose();
@@ -2656,9 +2657,11 @@ export class AgentRuntime {
         currentSystemPrompt,
         runRuntimeContext,
       );
+      const streamLifecycleMode = resolveStreamLifecycleModeFromEnv();
+      const streamModel = withRuntimeProviderStreamErrorProvenance(languageModel);
       const streamSource = createRuntimeStreamSource((streamSignal) =>
         streamText({
-          model: languageModel,
+          model: streamModel,
           system: providerSystemPrompt,
           messages: convertToTextGenerationRuntimeRequestMessages(
             currentMessages,
@@ -2871,7 +2874,7 @@ export class AgentRuntime {
         onUsage: (usage) => accumulateUsage(totalUsage, usage),
         providerExecutedToolNames: getProviderExecutedToolNames(runtimeTools),
         availableToolNames: runtimeToolNames,
-        streamLifecycleMode: resolveStreamLifecycleModeFromEnv(),
+        streamLifecycleMode,
         traceSpanName: `chat ${effectiveModel}`,
         traceAttributes: {
           ...(genAiProviderName ? { "gen_ai.provider.name": genAiProviderName } : {}),

--- a/src/agent/runtime/provider-replay-emission.test.ts
+++ b/src/agent/runtime/provider-replay-emission.test.ts
@@ -307,8 +307,9 @@ describe("provider replay checkpoint emission", () => {
 
   it("fails the provider turn when streaming aborts before checkpoint capture", async () => {
     let failedTurns = 0;
+    const privateProviderMarker = "private provider replay failure <TOKEN>";
     const model = scriptedModel([() => {
-      throw new Error("provider stream failed");
+      throw new Error(privateProviderMarker);
     }], {
       modelId: "anthropic/failed-provider-replay-stream",
       provider: "anthropic",
@@ -330,7 +331,9 @@ describe("provider replay checkpoint emission", () => {
     const stream = await agent(config).stream({ input: "Answer" });
     const body = await stream.toDataStreamResponse().text();
 
-    assertEquals(body.includes("provider stream failed"), true);
+    assertEquals(body.includes("Provider stream failed"), true);
+    assertEquals(body.includes(privateProviderMarker), false);
+    assertEquals(body.includes('"type":"message-finish"'), false);
     assertEquals(failedTurns, 1);
   });
 

--- a/src/agent/runtime/runtime-stream-error-origin.test.ts
+++ b/src/agent/runtime/runtime-stream-error-origin.test.ts
@@ -1,0 +1,301 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { agent, runWithRunEventSink } from "../index.ts";
+import type { Agent } from "../types.ts";
+import type { ModelRuntime } from "#veryfront/provider/types.ts";
+import { scriptedModel } from "./model-runtime.test-helpers.ts";
+import { createSSECollector } from "./chat-stream-handler.test-helpers.ts";
+import {
+  createRuntimeStreamSource,
+  createStreamState,
+  processStream,
+  resolveRuntimeExecutionErrorEvent,
+  withRuntimeProviderStreamErrorProvenance,
+} from "./chat-stream-handler.ts";
+
+const PROVIDER_FAILURES = [
+  {
+    message: "provider capacity exceeded",
+    expected: {
+      type: "error",
+      code: "OVERLOADED_ERROR",
+      error: "The LLM provider is currently overloaded",
+    },
+  },
+  {
+    message: "provider returned 429",
+    expected: {
+      type: "error",
+      code: "RATE_LIMITED",
+      error: "Too many requests. Please wait a moment and try again.",
+    },
+  },
+] as const;
+
+async function withLifecycleMode<T>(
+  mode: "legacy" | "active",
+  run: () => Promise<T>,
+): Promise<T> {
+  const previous = Deno.env.get("VF_STREAM_LIFECYCLE_MODE");
+  Deno.env.set("VF_STREAM_LIFECYCLE_MODE", mode);
+  try {
+    return await run();
+  } finally {
+    if (previous === undefined) Deno.env.delete("VF_STREAM_LIFECYCLE_MODE");
+    else Deno.env.set("VF_STREAM_LIFECYCLE_MODE", previous);
+  }
+}
+
+async function captureFailure(run: () => Promise<void>): Promise<unknown> {
+  try {
+    await run();
+    return undefined;
+  } catch (error) {
+    return error;
+  }
+}
+
+async function streamBody(
+  runtimeAgent: Agent<never>,
+  onFinish?: () => void,
+): Promise<string> {
+  const result = await runtimeAgent.stream({
+    input: "Hello",
+    ...(onFinish ? { onFinish } : {}),
+  });
+  return await result.toDataStreamResponse().text();
+}
+
+describe("agent runtime stream error provenance", () => {
+  it("preserves private-field model receivers while adding provenance", async () => {
+    class PrivateFieldModel implements ModelRuntime {
+      readonly [key: string]: unknown;
+      readonly #modelId = "hosted/private-field-provenance";
+      #streamCalls = 0;
+
+      get modelId(): string {
+        return this.#modelId;
+      }
+
+      get provider(): string {
+        return "hosted";
+      }
+
+      doGenerate() {
+        return Promise.reject(new Error("generate must not be called"));
+      }
+
+      doStream() {
+        this.#streamCalls += 1;
+        return Promise.resolve({ stream: new ReadableStream() });
+      }
+
+      get streamCalls(): number {
+        return this.#streamCalls;
+      }
+    }
+
+    const model = new PrivateFieldModel();
+    Object.defineProperty(model, "doStream", {
+      configurable: false,
+      value: model.doStream.bind(model),
+      writable: false,
+    });
+    const wrapped = withRuntimeProviderStreamErrorProvenance(model);
+
+    assertEquals(wrapped.modelId, model.modelId);
+    await wrapped.doStream({});
+    assertEquals(model.streamCalls, 1);
+  });
+
+  it("keeps ignoring a late provider body-read failure after a completed legacy step", async () => {
+    await withLifecycleMode("legacy", async () => {
+      let pullCount = 0;
+      const model: ModelRuntime = {
+        provider: "hosted",
+        modelId: "hosted/late-provider-read",
+        doGenerate: () => Promise.reject(new Error("generate must not be called")),
+        doStream: () =>
+          Promise.resolve({
+            stream: new ReadableStream({
+              pull(controller) {
+                pullCount += 1;
+                if (pullCount === 1) {
+                  controller.enqueue({ type: "text-delta", text: "done" });
+                } else if (pullCount === 2) {
+                  controller.enqueue({ type: "finish", finishReason: "stop", totalUsage: null });
+                } else {
+                  controller.error(new Error("error reading a body from connection"));
+                }
+              },
+            }),
+          }),
+      };
+      const runtimeAgent = agent({
+        model: model.modelId,
+        system: "Late body read provenance test",
+        resolveModelTransport: async () => ({ model }),
+      });
+
+      const body = await streamBody(runtimeAgent);
+
+      assertStringIncludes(body, '"delta":"done"');
+      assertEquals(body.includes('"type":"error"'), false);
+    });
+  });
+
+  it("contains hostile application errors without consulting Proxy hooks", () => {
+    const applicationError = new Proxy(new Error("original fallback"), {
+      getPrototypeOf() {
+        throw new Error("hostile getPrototypeOf");
+      },
+    });
+
+    assertEquals(resolveRuntimeExecutionErrorEvent(applicationError), {
+      type: "error",
+      error: "Unknown error",
+    });
+  });
+
+  for (const mode of ["legacy", "active"] as const) {
+    it(`does not classify ${mode} middleware application failures as provider errors`, async () => {
+      await withLifecycleMode(mode, async () => {
+        const model = scriptedModel([{ text: "must not run" }], {
+          modelId: `hosted/middleware-error-origin-${mode}`,
+          only: "stream",
+        });
+        const runtimeAgent = agent({
+          model: model.modelId,
+          system: "Middleware error provenance test",
+          middleware: [async () => {
+            throw new Error("database capacity exceeded");
+          }],
+          resolveModelTransport: async () => ({ model }),
+        });
+
+        const body = await streamBody(runtimeAgent);
+
+        assertStringIncludes(body, '"error":"database capacity exceeded"');
+        assertEquals(body.includes("OVERLOADED_ERROR"), false);
+        assertEquals(model.callCount, 0);
+      });
+    });
+
+    it(`does not classify ${mode} completion callback failures as provider errors`, async () => {
+      await withLifecycleMode(mode, async () => {
+        const model = scriptedModel([{ text: "done" }], {
+          modelId: `hosted/on-finish-error-origin-${mode}`,
+          only: "stream",
+        });
+        const runtimeAgent = agent({
+          model: model.modelId,
+          system: "Completion callback error provenance test",
+          resolveModelTransport: async () => ({ model }),
+        });
+
+        const body = await streamBody(runtimeAgent, () => {
+          throw new Error("job 429 persistence failed");
+        });
+
+        assertStringIncludes(body, '"error":"job 429 persistence failed"');
+        assertEquals(body.includes("RATE_LIMITED"), false);
+        assertEquals(model.callCount, 1);
+      });
+    });
+
+    it(`does not classify ${mode} run-event sink failures as provider errors`, async () => {
+      await withLifecycleMode(mode, async () => {
+        const model = scriptedModel([{ text: "must not run" }], {
+          modelId: `hosted/run-event-error-origin-${mode}`,
+          only: "stream",
+        });
+        const runtimeAgent = agent({
+          model: model.modelId,
+          system: "Run-event error provenance test",
+          resolveModelTransport: async () => ({ model }),
+        });
+
+        const body = await runWithRunEventSink(
+          () => Promise.reject(new Error("database capacity exceeded")),
+          () => streamBody(runtimeAgent),
+        );
+
+        assertStringIncludes(body, '"error":"database capacity exceeded"');
+        assertEquals(body.includes("OVERLOADED_ERROR"), false);
+        assertEquals(model.callCount, 0);
+      });
+    });
+
+    it(`preserves ${mode} source-open provider failures`, async () => {
+      const { controller, encoder } = createSSECollector();
+      const failure = await captureFailure(() =>
+        processStream(
+          createRuntimeStreamSource(() => {
+            throw new Error(PROVIDER_FAILURES[0].message);
+          }),
+          createStreamState(),
+          controller,
+          encoder,
+          "provider-error",
+          { streamLifecycleMode: mode },
+        )
+      );
+
+      assertEquals(resolveRuntimeExecutionErrorEvent(failure), PROVIDER_FAILURES[0].expected);
+    });
+
+    it(`preserves ${mode} doStream rejection as a provider failure`, async () => {
+      await withLifecycleMode(mode, async () => {
+        for (const providerFailure of PROVIDER_FAILURES) {
+          const model: ModelRuntime = {
+            provider: "hosted",
+            modelId: `hosted/provider-rejection-${mode}`,
+            doGenerate: () => Promise.reject(new Error("generate must not be called")),
+            doStream: () => Promise.reject(new Error(providerFailure.message)),
+          };
+          const runtimeAgent = agent({
+            model: model.modelId,
+            system: "Provider rejection provenance test",
+            resolveModelTransport: async () => ({ model }),
+          });
+
+          const body = await streamBody(runtimeAgent);
+
+          assertStringIncludes(body, `"error":"${providerFailure.expected.error}"`);
+          assertStringIncludes(body, `"code":"${providerFailure.expected.code}"`);
+        }
+      });
+    });
+
+    it(`preserves ${mode} provider-stream rejection as a provider failure`, async () => {
+      await withLifecycleMode(mode, async () => {
+        for (const providerFailure of PROVIDER_FAILURES) {
+          const model: ModelRuntime = {
+            provider: "hosted",
+            modelId: `hosted/provider-stream-rejection-${mode}`,
+            doGenerate: () => Promise.reject(new Error("generate must not be called")),
+            doStream: () =>
+              Promise.resolve({
+                stream: new ReadableStream({
+                  start(controller) {
+                    controller.error(new Error(providerFailure.message));
+                  },
+                }),
+              }),
+          };
+          const runtimeAgent = agent({
+            model: model.modelId,
+            system: "Provider stream rejection provenance test",
+            resolveModelTransport: async () => ({ model }),
+          });
+
+          const body = await streamBody(runtimeAgent);
+
+          assertStringIncludes(body, `"error":"${providerFailure.expected.error}"`);
+          assertStringIncludes(body, `"code":"${providerFailure.expected.code}"`);
+        }
+      });
+    });
+  }
+});

--- a/src/runtime/provider-stream-error-provenance.ts
+++ b/src/runtime/provider-stream-error-provenance.ts
@@ -1,0 +1,29 @@
+const runtimeProviderStreamFailureCauses = new WeakMap<object, unknown>();
+
+class RuntimeProviderStreamFailure extends Error {
+  constructor(cause: unknown) {
+    super("Provider stream failed");
+    this.name = "RuntimeProviderStreamFailure";
+    runtimeProviderStreamFailureCauses.set(this, cause);
+  }
+}
+
+/** Mark an error from a proven provider-owned stream boundary. */
+export function createRuntimeProviderStreamFailure(error: unknown): Error {
+  if (readRuntimeProviderStreamFailureCause(error).found) return error as Error;
+  return new RuntimeProviderStreamFailure(error);
+}
+
+/** Read a provider-owned cause without exposing it on the public error object. */
+export function readRuntimeProviderStreamFailureCause(
+  error: unknown,
+): { found: false } | { found: true; cause: unknown } {
+  if (
+    (typeof error !== "object" || error === null) &&
+    typeof error !== "function"
+  ) {
+    return { found: false };
+  }
+  if (!runtimeProviderStreamFailureCauses.has(error)) return { found: false };
+  return { found: true, cause: runtimeProviderStreamFailureCauses.get(error) };
+}

--- a/src/runtime/runtime-bridge.ts
+++ b/src/runtime/runtime-bridge.ts
@@ -1146,6 +1146,13 @@ function normalizeStreamPart(part: unknown): unknown {
       };
     }
 
+    if ("text" in part && typeof part.text === "string") {
+      return {
+        type: "text-delta",
+        text: part.text,
+      };
+    }
+
     return part;
   }
 

--- a/src/runtime/runtime-bridge.ts
+++ b/src/runtime/runtime-bridge.ts
@@ -6,6 +6,7 @@
  * types and calls into this bridge at the edge.
  */
 import type { TextGenerationRuntimeMessage } from "#veryfront/agent/runtime/text-generation-runtime-message-types.ts";
+import { createRuntimeProviderStreamFailure } from "#veryfront/runtime/provider-stream-error-provenance.ts";
 import { recordErrorCount } from "#veryfront/observability/metrics/index.ts";
 import { serverLogger } from "#veryfront/utils";
 import type {
@@ -1230,23 +1231,31 @@ function normalizeStreamPart(part: unknown): unknown {
 
 async function* mapReadableStream(stream: ReadableStream<unknown>): AsyncIterable<unknown> {
   for await (const part of stream) {
-    yield normalizeStreamPart(part);
+    try {
+      yield normalizeStreamPart(part);
+    } catch (error) {
+      throw createRuntimeProviderStreamFailure(error);
+    }
   }
 }
 
 async function* textDeltasFromStream(stream: ReadableStream<unknown>): AsyncIterable<string> {
   for await (const part of stream) {
-    if (!part || typeof part !== "object" || !("type" in part) || part.type !== "text-delta") {
-      continue;
-    }
+    try {
+      if (!part || typeof part !== "object" || !("type" in part) || part.type !== "text-delta") {
+        continue;
+      }
 
-    if ("text" in part && typeof part.text === "string") {
-      yield part.text;
-      continue;
-    }
+      if ("text" in part && typeof part.text === "string") {
+        yield part.text;
+        continue;
+      }
 
-    if ("delta" in part && typeof part.delta === "string") {
-      yield part.delta;
+      if ("delta" in part && typeof part.delta === "string") {
+        yield part.delta;
+      }
+    } catch (error) {
+      throw createRuntimeProviderStreamFailure(error);
     }
   }
 }

--- a/tests/integration/agent/runtime-stream-error-origin.test.ts
+++ b/tests/integration/agent/runtime-stream-error-origin.test.ts
@@ -1,18 +1,18 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import { agent, runWithRunEventSink } from "../index.ts";
-import type { Agent } from "../types.ts";
+import { agent, runWithRunEventSink } from "#veryfront/agent/index.ts";
+import type { Agent } from "#veryfront/agent/types.ts";
 import type { ModelRuntime } from "#veryfront/provider/types.ts";
-import { scriptedModel } from "./model-runtime.test-helpers.ts";
-import { createSSECollector } from "./chat-stream-handler.test-helpers.ts";
+import { scriptedModel } from "#veryfront/agent/runtime/model-runtime.test-helpers.ts";
+import { createSSECollector } from "#veryfront/agent/runtime/chat-stream-handler.test-helpers.ts";
 import {
   createRuntimeStreamSource,
   createStreamState,
   processStream,
   resolveRuntimeExecutionErrorEvent,
   withRuntimeProviderStreamErrorProvenance,
-} from "./chat-stream-handler.ts";
+} from "#veryfront/agent/runtime/chat-stream-handler.ts";
 
 const PROVIDER_FAILURES = [
   {

--- a/tests/integration/agent/runtime-stream-error-origin.test.ts
+++ b/tests/integration/agent/runtime-stream-error-origin.test.ts
@@ -474,6 +474,43 @@ describe("agent runtime stream error provenance", () => {
       });
     });
 
+    it(`redacts ${mode} provider-part decoder failures`, async () => {
+      await withLifecycleMode(mode, async () => {
+        const privateMarker = `private-provider-decoder-${mode}`;
+        const providerPart = Object.defineProperty({ type: "text-delta" }, "text", {
+          enumerable: true,
+          get() {
+            throw new Error(privateMarker);
+          },
+        });
+        const model: ModelRuntime = {
+          provider: "hosted",
+          modelId: `hosted/provider-decoder-private-${mode}`,
+          doGenerate: () => Promise.reject(new Error("generate must not be called")),
+          doStream: () =>
+            Promise.resolve({
+              stream: new ReadableStream({
+                start(controller) {
+                  controller.enqueue(providerPart);
+                  controller.close();
+                },
+              }),
+            }),
+        };
+        const runtimeAgent = agent({
+          model: model.modelId,
+          system: "Provider decoder privacy test",
+          resolveModelTransport: async () => ({ model }),
+        });
+
+        const body = await streamBody(runtimeAgent);
+
+        assertStringIncludes(body, '"error":"Provider stream failed"');
+        assertEquals(body.includes(privateMarker), false);
+        assertEquals(body.includes('"code"'), false);
+      });
+    });
+
     it(`preserves ${mode} provider-stream rejection as a provider failure`, async () => {
       await withLifecycleMode(mode, async () => {
         for (const providerFailure of PROVIDER_FAILURES) {

--- a/tests/integration/agent/runtime-stream-error-origin.test.ts
+++ b/tests/integration/agent/runtime-stream-error-origin.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "#veryfront/testing/bdd.ts";
 import { agent, runWithRunEventSink } from "#veryfront/agent/index.ts";
 import type { Agent } from "#veryfront/agent/types.ts";
 import type { ModelRuntime } from "#veryfront/provider/types.ts";
+import { defineError } from "#veryfront/errors";
 import { scriptedModel } from "#veryfront/agent/runtime/model-runtime.test-helpers.ts";
 import { createSSECollector } from "#veryfront/agent/runtime/chat-stream-handler.test-helpers.ts";
 import {
@@ -32,6 +33,13 @@ const PROVIDER_FAILURES = [
     },
   },
 ] as const;
+
+const PRIVATE_PROVIDER_ERROR = defineError({
+  slug: "provider-private-runtime-test",
+  category: "GENERAL",
+  title: "Provider private runtime test",
+  status: 500,
+});
 
 async function withLifecycleMode<T>(
   mode: "legacy" | "active",
@@ -395,6 +403,66 @@ describe("agent runtime stream error provenance", () => {
         const runtimeAgent = agent({
           model: model.modelId,
           system: "Provider rejection privacy test",
+          resolveModelTransport: async () => ({ model }),
+        });
+
+        const body = await streamBody(runtimeAgent);
+
+        assertStringIncludes(body, '"error":"Provider stream failed"');
+        assertEquals(body.includes(privateMarker), false);
+        assertEquals(body.includes('"code"'), false);
+      });
+    });
+
+    it(`redacts ${mode} provider-owned VeryfrontError details`, async () => {
+      await withLifecycleMode(mode, async () => {
+        const privateMarker = `private-provider-veryfront-error-${mode}`;
+        const model: ModelRuntime = {
+          provider: "hosted",
+          modelId: `hosted/provider-private-veryfront-error-${mode}`,
+          doGenerate: () => Promise.reject(new Error("generate must not be called")),
+          doStream: () => Promise.reject(PRIVATE_PROVIDER_ERROR.create({ detail: privateMarker })),
+        };
+        const runtimeAgent = agent({
+          model: model.modelId,
+          system: "Provider VeryfrontError privacy test",
+          resolveModelTransport: async () => ({ model }),
+        });
+
+        const body = await streamBody(runtimeAgent);
+
+        assertStringIncludes(body, '"error":"Provider stream failed"');
+        assertEquals(body.includes(privateMarker), false);
+        assertEquals(body.includes('"code"'), false);
+      });
+    });
+
+    it(`redacts ${mode} provider-part normalization failures`, async () => {
+      await withLifecycleMode(mode, async () => {
+        const privateMarker = `private-provider-part-${mode}`;
+        const providerPart = Object.defineProperty({}, "type", {
+          enumerable: true,
+          get() {
+            throw new Error(privateMarker);
+          },
+        });
+        const model: ModelRuntime = {
+          provider: "hosted",
+          modelId: `hosted/provider-part-private-${mode}`,
+          doGenerate: () => Promise.reject(new Error("generate must not be called")),
+          doStream: () =>
+            Promise.resolve({
+              stream: new ReadableStream({
+                start(controller) {
+                  controller.enqueue(providerPart);
+                  controller.close();
+                },
+              }),
+            }),
+        };
+        const runtimeAgent = agent({
+          model: model.modelId,
+          system: "Provider part privacy test",
           resolveModelTransport: async () => ({ model }),
         });
 

--- a/tests/integration/agent/runtime-stream-error-origin.test.ts
+++ b/tests/integration/agent/runtime-stream-error-origin.test.ts
@@ -227,7 +227,7 @@ describe("agent runtime stream error provenance", () => {
       });
     });
 
-    it(`preserves ${mode} source-open provider failures`, async () => {
+    it(`does not classify ${mode} source-open application failures as provider errors`, async () => {
       const { controller, encoder } = createSSECollector();
       const failure = await captureFailure(() =>
         processStream(
@@ -242,7 +242,42 @@ describe("agent runtime stream error provenance", () => {
         )
       );
 
-      assertEquals(resolveRuntimeExecutionErrorEvent(failure), PROVIDER_FAILURES[0].expected);
+      assertEquals(resolveRuntimeExecutionErrorEvent(failure), {
+        type: "error",
+        error: PROVIDER_FAILURES[0].message,
+      });
+    });
+
+    it(`preserves ${mode} attachment validation failures before provider dispatch`, async () => {
+      await withLifecycleMode(mode, async () => {
+        const model = scriptedModel([{ text: "must not run" }], {
+          modelId: `hosted/attachment-error-origin-${mode}`,
+          only: "stream",
+        });
+        const runtimeAgent = agent({
+          model: model.modelId,
+          system: "Attachment validation provenance test",
+          resolveModelTransport: async () => ({ model }),
+        });
+
+        const result = await runtimeAgent.stream({
+          messages: [{
+            id: "attachment-message",
+            role: "user",
+            parts: [{
+              type: "file",
+              filename: "capacity.png",
+              mediaType: "image/png",
+              url: "http://localhost/file",
+            }],
+          }],
+        });
+        const body = await result.toDataStreamResponse().text();
+
+        assertStringIncludes(body, 'Attachment \\"capacity.png\\" cannot be sent to the model');
+        assertEquals(body.includes("OVERLOADED_ERROR"), false);
+        assertEquals(model.callCount, 0);
+      });
     });
 
     it(`preserves ${mode} doStream rejection as a provider failure`, async () => {

--- a/tests/integration/agent/runtime-stream-error-origin.test.ts
+++ b/tests/integration/agent/runtime-stream-error-origin.test.ts
@@ -109,6 +109,86 @@ describe("agent runtime stream error provenance", () => {
     assertEquals(model.streamCalls, 1);
   });
 
+  it("releases provider reader locks after completion, failure, and cancellation", async () => {
+    const completedSource = new ReadableStream({
+      start(controller) {
+        controller.close();
+      },
+    });
+    const failedSource = new ReadableStream({
+      start(controller) {
+        controller.error(new Error("private provider read failure"));
+      },
+    });
+    let cancelCount = 0;
+    let cancelReason: unknown;
+    const cancelledSource = new ReadableStream({
+      cancel(reason) {
+        cancelCount += 1;
+        cancelReason = reason;
+      },
+    });
+    const sources = [completedSource, failedSource, cancelledSource];
+    let call = 0;
+    const model: ModelRuntime = {
+      provider: "hosted",
+      modelId: "hosted/provider-reader-release",
+      doGenerate: () => Promise.reject(new Error("generate must not be called")),
+      doStream: () => Promise.resolve({ stream: sources[call++]! }),
+    };
+    const wrapped = withRuntimeProviderStreamErrorProvenance(model);
+
+    const completedReader = (await wrapped.doStream({})).stream.getReader();
+    assertEquals((await completedReader.read()).done, true);
+    completedReader.releaseLock();
+    assertEquals(completedSource.locked, false);
+
+    const failedReader = (await wrapped.doStream({})).stream.getReader();
+    await captureFailure(async () => {
+      await failedReader.read();
+    });
+    failedReader.releaseLock();
+    assertEquals(failedSource.locked, false);
+
+    const cancelledReader = (await wrapped.doStream({})).stream.getReader();
+    await cancelledReader.cancel("consumer stopped");
+    cancelledReader.releaseLock();
+    assertEquals(cancelledSource.locked, false);
+    assertEquals(cancelCount, 1);
+    assertEquals(cancelReason, "consumer stopped");
+  });
+
+  it("does not read ahead of a provider stream consumer", async () => {
+    let providerPulls = 0;
+    const providerStream = new ReadableStream(
+      {
+        pull() {
+          providerPulls += 1;
+        },
+      },
+      { highWaterMark: 0 },
+    );
+    const model: ModelRuntime = {
+      provider: "hosted",
+      modelId: "hosted/provider-backpressure",
+      doGenerate: () => Promise.reject(new Error("generate must not be called")),
+      doStream: () => Promise.resolve({ stream: providerStream }),
+    };
+
+    const wrapped = await withRuntimeProviderStreamErrorProvenance(model).doStream({});
+    await Promise.resolve();
+    assertEquals(providerPulls, 0);
+
+    const reader = wrapped.stream.getReader();
+    const read = reader.read();
+    await Promise.resolve();
+    assertEquals(providerPulls, 1);
+    await reader.cancel("consumer stopped");
+    assertEquals((await read).done, true);
+    reader.releaseLock();
+    assertEquals(providerStream.locked, false);
+  });
+
   it("keeps ignoring a late provider body-read failure after a completed legacy step", async () => {
     await withLifecycleMode("legacy", async () => {
       let pullCount = 0;
@@ -300,6 +380,29 @@ describe("agent runtime stream error provenance", () => {
           assertStringIncludes(body, `"error":"${providerFailure.expected.error}"`);
           assertStringIncludes(body, `"code":"${providerFailure.expected.code}"`);
         }
+      });
+    });
+
+    it(`redacts unknown ${mode} provider rejection details`, async () => {
+      await withLifecycleMode(mode, async () => {
+        const privateMarker = `private-provider-token-${mode}`;
+        const model: ModelRuntime = {
+          provider: "hosted",
+          modelId: `hosted/provider-private-rejection-${mode}`,
+          doGenerate: () => Promise.reject(new Error("generate must not be called")),
+          doStream: () => Promise.reject(new Error(privateMarker)),
+        };
+        const runtimeAgent = agent({
+          model: model.modelId,
+          system: "Provider rejection privacy test",
+          resolveModelTransport: async () => ({ model }),
+        });
+
+        const body = await streamBody(runtimeAgent);
+
+        assertStringIncludes(body, '"error":"Provider stream failed"');
+        assertEquals(body.includes(privateMarker), false);
+        assertEquals(body.includes('"code"'), false);
       });
     });
 


### PR DESCRIPTION
Stacked on #4424.

This follow-up establishes provider provenance at model doStream and provider stream boundaries. Application failures from middleware, completion callbacks, and run-event sinks retain their original uncoded runtime error, while plain provider overload and rate-limit failures retain canonical codes in legacy and active lifecycle modes.

It also preserves private-field model receivers, abort handling, late provider body-read compatibility, hostile error containment, and private provider diagnostic redaction.

Verification:
- pinned Deno 2.7.7 provenance matrix: 15 steps passed
- chat-stream-handler: 104 steps passed
- hosted run-stream: 67 steps passed
- runtime cancellation: 9 steps passed
- full mandatory pre-push formatting, lint, typecheck, generation, and unit matrix passed
- Codex uncommitted and stacked-base reviews: no actionable findings
- independent exact-head review: 97/100, no findings

Refs veryfront/veryfront-issue-inbox#192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved streaming error handling to accurately identify provider-originated failures.
  - Sanitized provider stream errors shown to users, preventing private error details from being exposed.
  - Preserved application and middleware errors without incorrectly labeling them as provider failures.
  - Improved cancellation handling, stream cleanup, backpressure, and late provider response failures.
  - Added support for additional text-delta stream formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->