### PR TITLE
Ignore inherited HeadersInit array slots

### DIFF
--- a/src/agent/service/definition.test.ts
+++ b/src/agent/service/definition.test.ts
@@ -1,5 +1,5 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { assertEquals, assertRejects, assertStringIncludes } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import {
   type AgentContract,
@@ -185,6 +185,57 @@ describe("agent/agent-service", () => {
 
     assertEquals(response.status, 200);
     assertEquals(await response.json(), expected);
+  });
+
+  it("uses only own slots from HeadersInit arrays and tuple entries", async () => {
+    const runtime = defineAgentService({
+      serviceName: "headers-init-own-slots-service",
+      agent: assistant,
+    }).createRuntime({
+      routes: [{
+        method: "GET",
+        path: "/headers",
+        handler: (request) =>
+          Response.json({
+            own: request.headers.get("X-Own"),
+            inherited: request.headers.get("X-Inherited"),
+          }),
+      }],
+    });
+    let inheritedReads = 0;
+    const outerPrototype = Object.create(Array.prototype);
+    Object.defineProperty(outerPrototype, "1", {
+      configurable: true,
+      get() {
+        inheritedReads += 1;
+        return ["X-Inherited", "outer"];
+      },
+    });
+    const headers: [string, string][] = [["X-Own", "present"]];
+    headers.length = 2;
+    Object.setPrototypeOf(headers, outerPrototype);
+
+    const response = await runtime.request("/headers", { headers });
+    assertEquals(inheritedReads, 0);
+    assertEquals(await response.json(), { own: "present", inherited: null });
+
+    const entryPrototype = Object.create(Array.prototype);
+    Object.defineProperty(entryPrototype, "1", {
+      configurable: true,
+      get() {
+        inheritedReads += 1;
+        return "inherited";
+      },
+    });
+    const sparseEntry = ["X-Sparse"] as unknown as [string, string];
+    sparseEntry.length = 2;
+    Object.setPrototypeOf(sparseEntry, entryPrototype);
+    await assertRejects(
+      async () => await runtime.request("/headers", { headers: [sparseEntry] }),
+      TypeError,
+      "Response header entry must contain a name and value",
+    );
+    assertEquals(inheritedReads, 0);
   });
 
   it("dispatches host-owned routes without taking over product policy", async () => {

--- a/src/agent/service/definition.test.ts
+++ b/src/agent/service/definition.test.ts
@@ -199,6 +199,7 @@ describe("agent/agent-service", () => {
           Response.json({
             own: request.headers.get("X-Own"),
             inherited: request.headers.get("X-Inherited"),
+            mutating: request.headers.get("X-Mutating"),
           }),
       }],
     });
@@ -217,7 +218,7 @@ describe("agent/agent-service", () => {
 
     const response = await runtime.request("/headers", { headers });
     assertEquals(inheritedReads, 0);
-    assertEquals(await response.json(), { own: "present", inherited: null });
+    assertEquals(await response.json(), { own: "present", inherited: null, mutating: null });
 
     const entryPrototype = Object.create(Array.prototype);
     Object.defineProperty(entryPrototype, "1", {
@@ -233,9 +234,65 @@ describe("agent/agent-service", () => {
     await assertRejects(
       async () => await runtime.request("/headers", { headers: [sparseEntry] }),
       TypeError,
-      "Response header entry must contain a name and value",
+      "Header entry must contain a name and value",
+    );
+    const incompleteIterable = {
+      *[Symbol.iterator]() {
+        yield ["X-Only-Name"];
+      },
+    } as unknown as HeadersInit;
+    await assertRejects(
+      async () => await runtime.request("/headers", { headers: incompleteIterable }),
+      TypeError,
+      "Header entry must contain a name and value",
     );
     assertEquals(inheritedReads, 0);
+
+    const mutatingEntry = ["X-Mutating", "captured"] as [string, string];
+    const mutatingPrototype = Object.create(Array.prototype);
+    Object.defineProperty(mutatingPrototype, "1", {
+      configurable: true,
+      get() {
+        inheritedReads += 1;
+        return "inherited";
+      },
+    });
+    Object.setPrototypeOf(mutatingEntry, mutatingPrototype);
+    Object.defineProperty(mutatingEntry, "0", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        Reflect.deleteProperty(mutatingEntry, "1");
+        return "X-Mutating";
+      },
+    });
+    await assertRejects(
+      async () => await runtime.request("/headers", { headers: [mutatingEntry] }),
+      TypeError,
+      "Header entry must contain a name and value",
+    );
+    assertEquals(inheritedReads, 0);
+
+    const updatingEntry = ["X-Mutating", "original"] as [string, string];
+    Object.defineProperty(updatingEntry, "0", {
+      configurable: true,
+      enumerable: true,
+      get() {
+        Object.defineProperty(updatingEntry, "1", {
+          configurable: true,
+          enumerable: true,
+          writable: true,
+          value: "updated",
+        });
+        return "X-Mutating";
+      },
+    });
+    const updatingResponse = await runtime.request("/headers", { headers: [updatingEntry] });
+    assertEquals(await updatingResponse.json(), {
+      own: null,
+      inherited: null,
+      mutating: "updated",
+    });
   });
 
   it("dispatches host-owned routes without taking over product policy", async () => {

--- a/src/agent/service/definition.ts
+++ b/src/agent/service/definition.ts
@@ -114,7 +114,18 @@ function appendHeader(target: Headers, name: unknown, value: unknown): void {
 }
 
 function appendHeaderEntry(target: Headers, entry: Iterable<unknown>): void {
-  const values = NativeArrayIsArray(entry) ? entry : NativeArrayFrom(entry);
+  if (NativeArrayIsArray(entry)) {
+    if (
+      entry.length !== 2 || !ObjectHasOwn(entry, 0) ||
+      !ObjectHasOwn(entry, 1)
+    ) {
+      throw new TypeError("Response header entry must contain a name and value");
+    }
+    appendHeader(target, entry[0], entry[1]);
+    return;
+  }
+
+  const values = NativeArrayFrom(entry);
   if (values.length !== 2) {
     throw new TypeError("Response header entry must contain a name and value");
   }
@@ -154,6 +165,7 @@ function copyHeaders(source: HeadersInit, target: Headers): void {
 
   if (NativeArrayIsArray(source)) {
     for (let index = 0; index < source.length; index++) {
+      if (!ObjectHasOwn(source, index)) continue;
       appendHeaderEntry(target, source[index]!);
     }
     return;

--- a/src/agent/service/definition.ts
+++ b/src/agent/service/definition.ts
@@ -115,19 +115,24 @@ function appendHeader(target: Headers, name: unknown, value: unknown): void {
 
 function appendHeaderEntry(target: Headers, entry: Iterable<unknown>): void {
   if (NativeArrayIsArray(entry)) {
-    if (
-      entry.length !== 2 || !ObjectHasOwn(entry, 0) ||
-      !ObjectHasOwn(entry, 1)
-    ) {
-      throw new TypeError("Response header entry must contain a name and value");
+    const nameDescriptor = ObjectGetOwnPropertyDescriptor(entry, 0);
+    if (entry.length !== 2 || !nameDescriptor) {
+      throw new TypeError("Header entry must contain a name and value");
     }
-    appendHeader(target, entry[0], entry[1]);
+    const name = readDescriptorValue(entry, nameDescriptor);
+    const valueDescriptor = ObjectGetOwnPropertyDescriptor(entry, 1);
+    if (!valueDescriptor) throw new TypeError("Header entry must contain a name and value");
+    appendHeader(
+      target,
+      name,
+      readDescriptorValue(entry, valueDescriptor),
+    );
     return;
   }
 
   const values = NativeArrayFrom(entry);
   if (values.length !== 2) {
-    throw new TypeError("Response header entry must contain a name and value");
+    throw new TypeError("Header entry must contain a name and value");
   }
   appendHeader(target, values[0], values[1]);
 }


### PR DESCRIPTION
Follow-up to #4422. Sparse `HeadersInit` arrays could resolve inherited numeric entries during header normalization. Header tuples now read each own property descriptor in order, so a name getter that deletes the value slot cannot fall through to an inherited getter, while legitimate updates to the own value slot are preserved.

The outer sequence skips inherited slots. Array and iterable entries share the same diagnostic for malformed pairs.

Validation on `c7201ba7c27c5087827112e2e01b58447402520a`:

- Pinned Deno 2.7.7 service suite: 60 tests and 191 steps passed; independent focused suite: 12/12.
- Node 24.20: 12/12; Bun 1.3.6 targeted suite passed.
- Typecheck, formatting, lint, static gates, npm build, and normal configured pre-push hook passed.
- Actual local Codex review and independent final review: no actionable findings; [100/100 review](https://github.com/veryfront/veryfront-code/pull/4432#issuecomment-5562210748).
