### PR TITLE
fix(agent): bind native response defaults on Node

### DIFF
--- a/docs/guides/agent-service-runtime.md
+++ b/docs/guides/agent-service-runtime.md
@@ -64,10 +64,13 @@ entries. Route handlers retain ordinary-object params; decoded keys bypass
 inherited setters.
 
 Framework responses supply explicit status, status text, and empty-header defaults
-to native constructors. This prevents Node's intermediate Web IDL dictionary from
-inheriting response fields from `Object.prototype`, including CORS headers for a
-denied origin. These defaults apply only to omitted values. Invalid response
-values still fail native validation, and host handler errors propagate unchanged.
+to native constructors. These defaults override inherited data properties,
+including CORS headers for a denied origin, and apply only to omitted values.
+If `Object.prototype` defines an accessor for `headers`, `status`, or `statusText`,
+response construction throws a `TypeError` before native option conversion can
+invoke it. The runtime does not remove the accessor, return an empty response, or
+retry with weaker CORS rules. Invalid response values still fail native
+validation, and host handler errors propagate unchanged.
 
 The service discovers the same project primitives as the app runtime:
 

--- a/docs/guides/agent-service-runtime.md
+++ b/docs/guides/agent-service-runtime.md
@@ -64,11 +64,13 @@ entries. Route handlers retain ordinary-object params; decoded keys bypass
 inherited setters.
 
 Framework responses supply explicit status, status text, and empty-header defaults
-to native constructors. These defaults override inherited data properties,
+to native constructors. These defaults override writable inherited data properties,
 including CORS headers for a denied origin, and apply only to omitted values.
 If `Object.prototype` defines an accessor for `headers`, `status`, or `statusText`,
 response construction throws a `TypeError` before native option conversion can
-invoke it. The runtime does not remove the accessor, return an empty response, or
+invoke it. On Node, non-writable inherited data properties for these fields also
+cause native construction to throw a `TypeError`. The runtime does not remove
+these properties, return an empty response, or
 retry with weaker CORS rules. Invalid response values still fail native
 validation, and host handler errors propagate unchanged.
 

--- a/docs/guides/agent-service-runtime.md
+++ b/docs/guides/agent-service-runtime.md
@@ -63,6 +63,12 @@ use captured operations. Sparse route, origin, method, and header arrays ignore 
 entries. Route handlers retain ordinary-object params; decoded keys bypass
 inherited setters.
 
+Framework responses supply explicit status, status text, and empty-header defaults
+to native constructors. This prevents Node's intermediate Web IDL dictionary from
+inheriting response fields from `Object.prototype`, including CORS headers for a
+denied origin. These defaults apply only to omitted values. Invalid response
+values still fail native validation, and host handler errors propagate unchanged.
+
 The service discovers the same project primitives as the app runtime:
 
 - `agents/`

--- a/scripts/test/run-suite.test.ts
+++ b/scripts/test/run-suite.test.ts
@@ -745,6 +745,7 @@ async function legacyRuntimeFiles(runtime: "node" | "bun"): Promise<string[]> {
       "tests/integration/runtime/compat/kv-polyfill.test.ts",
       "tests/integration/runtime/compat/spawn-missing-executable.test.ts",
       "tests/integration/security/sandbox-runtime-guard.test.ts",
+      "tests/integration/agent/service-response-init.test.ts",
       "tests/integration/semantic-unit-boundary/src/transforms/pipeline/__fixtures__/fixture-runner-ssr.test.ts",
     ]
     : [
@@ -756,6 +757,7 @@ async function legacyRuntimeFiles(runtime: "node" | "bun"): Promise<string[]> {
       "tests/integration/runtime/compat/kv-polyfill.test.ts",
       "tests/integration/runtime/compat/spawn-missing-executable.test.ts",
       "tests/integration/security/sandbox-runtime-guard.test.ts",
+      "tests/integration/agent/service-response-init.test.ts",
       "tests/integration/semantic-unit-boundary/src/transforms/pipeline/__fixtures__/fixture-runner-ssr.test.ts",
     ];
   const incompatible = runtime === "node"

--- a/scripts/test/run-suite.ts
+++ b/scripts/test/run-suite.ts
@@ -112,6 +112,7 @@ const RUNTIME_PATTERNS = {
     "tests/integration/runtime/compat/kv-polyfill.test.ts",
     "tests/integration/runtime/compat/spawn-missing-executable.test.ts",
     "tests/integration/security/sandbox-runtime-guard.test.ts",
+    "tests/integration/agent/service-response-init.test.ts",
     SSR_PIPELINE_RUNTIME_FIXTURE,
   ],
   bun: [
@@ -123,6 +124,7 @@ const RUNTIME_PATTERNS = {
     "tests/integration/runtime/compat/kv-polyfill.test.ts",
     "tests/integration/runtime/compat/spawn-missing-executable.test.ts",
     "tests/integration/security/sandbox-runtime-guard.test.ts",
+    "tests/integration/agent/service-response-init.test.ts",
     SSR_PIPELINE_RUNTIME_FIXTURE,
   ],
 } as const;

--- a/src/agent/service/definition.test.ts
+++ b/src/agent/service/definition.test.ts
@@ -17,6 +17,33 @@ const assistant = agent({
 });
 
 describe("agent/agent-service", () => {
+  it("rejects unsafe response options without invoking inherited accessors", async () => {
+    const runtime = defineAgentService({ serviceName: "response-policy", agent: assistant })
+      .createRuntime();
+    const request = new Request("http://localhost/liveness");
+    const original = Object.getOwnPropertyDescriptor(Object.prototype, "headers");
+    let accessorCalls = 0;
+    Object.defineProperty(Object.prototype, "headers", {
+      configurable: true,
+      get() {
+        accessorCalls++;
+        return {};
+      },
+    });
+    try {
+      await assertRejects(
+        () => runtime.fetch(request),
+        TypeError,
+        "Cannot construct a response with inherited option accessors",
+      );
+    } finally {
+      if (original) Object.defineProperty(Object.prototype, "headers", original);
+      else Reflect.deleteProperty(Object.prototype, "headers");
+    }
+    assertEquals(accessorCalls, 0);
+    assertEquals(await (await runtime.fetch(request)).text(), "OK");
+  });
+
   it("exports a typed contract surface for future hosted service adoption", () => {
     const durableRunSink: DurableRunSink<
       { requestId: string },

--- a/src/agent/service/definition.test.ts
+++ b/src/agent/service/definition.test.ts
@@ -17,33 +17,6 @@ const assistant = agent({
 });
 
 describe("agent/agent-service", () => {
-  it("rejects unsafe response options without invoking inherited accessors", async () => {
-    const runtime = defineAgentService({ serviceName: "response-policy", agent: assistant })
-      .createRuntime();
-    const request = new Request("http://localhost/liveness");
-    const original = Object.getOwnPropertyDescriptor(Object.prototype, "headers");
-    let accessorCalls = 0;
-    Object.defineProperty(Object.prototype, "headers", {
-      configurable: true,
-      get() {
-        accessorCalls++;
-        return {};
-      },
-    });
-    try {
-      await assertRejects(
-        () => runtime.fetch(request),
-        TypeError,
-        "Cannot construct a response with inherited option accessors",
-      );
-    } finally {
-      if (original) Object.defineProperty(Object.prototype, "headers", original);
-      else Reflect.deleteProperty(Object.prototype, "headers");
-    }
-    assertEquals(accessorCalls, 0);
-    assertEquals(await (await runtime.fetch(request)).text(), "OK");
-  });
-
   it("exports a typed contract surface for future hosted service adoption", () => {
     const durableRunSink: DurableRunSink<
       { requestId: string },

--- a/src/agent/service/definition.ts
+++ b/src/agent/service/definition.ts
@@ -242,11 +242,12 @@ function createNativeResponse(
   status?: number,
   statusText?: string,
 ): Response {
-  if (status === undefined && statusText === undefined) return new NativeResponse(body);
-
+  // Node converts the init into an ordinary dictionary internally. Supply
+  // every field so that dictionary cannot inherit response defaults.
   const init: ResponseInit = ObjectCreate(null);
-  if (status !== undefined) init.status = status;
-  if (statusText !== undefined) init.statusText = statusText;
+  init.headers = EmptyHeadersInit;
+  init.status = status === undefined ? 200 : status;
+  init.statusText = statusText === undefined ? "" : statusText;
   return new NativeResponse(body, init);
 }
 

--- a/src/agent/service/definition.ts
+++ b/src/agent/service/definition.ts
@@ -1,4 +1,5 @@
 import type { Agent } from "../types.ts";
+import { buildResponseInit } from "./response-init.ts";
 
 // Capture before project modules load: ingress requests still carry host
 // credentials while the service selects a route and applies CORS policy.
@@ -11,7 +12,6 @@ const NativeHeaders = Headers;
 const NativeResponse = Response;
 const NativeSet = Set;
 const NativeString = String;
-const NativeTypeError = TypeError;
 const NativeURLSearchParams = URLSearchParams;
 const NativeHasInstance = Function.prototype[Symbol.hasInstance];
 const NativeArrayFrom = Array.from;
@@ -51,7 +51,6 @@ const NativeDecodeURIComponent = decodeURIComponent;
 const StringToUpperCase = String.prototype.toUpperCase;
 const ObjectHasOwn = Object.hasOwn;
 const EmptyHeadersInit: Record<string, string> = ObjectCreate(null);
-const ResponseInitFields = ["headers", "status", "statusText"] as const;
 const RequestInitFields = [
   "body",
   "cache",
@@ -244,22 +243,7 @@ function createNativeResponse(
   status?: number,
   statusText?: string,
 ): Response {
-  // Node assigns into a normal internal dictionary, so inherited accessors
-  // can intercept even explicit fields. Reject that state without invoking
-  // project code or changing process-wide prototypes during construction.
-  for (let index = 0; index < ResponseInitFields.length; index++) {
-    const field = ResponseInitFields[index]!;
-    const descriptor = ObjectGetOwnPropertyDescriptor(NativeObjectPrototype, field);
-    if (descriptor && !ObjectHasOwn(descriptor, "value")) {
-      throw new NativeTypeError("Cannot construct a response with inherited option accessors");
-    }
-  }
-  // Node converts the init into an ordinary dictionary internally. Supply
-  // every field so that dictionary cannot inherit response defaults.
-  const init: ResponseInit = ObjectCreate(null);
-  init.headers = EmptyHeadersInit;
-  init.status = status === undefined ? 200 : status;
-  init.statusText = statusText === undefined ? "" : statusText;
+  const init = buildResponseInit(NativeObjectPrototype, status, statusText);
   return new NativeResponse(body, init);
 }
 

--- a/src/agent/service/definition.ts
+++ b/src/agent/service/definition.ts
@@ -11,6 +11,7 @@ const NativeHeaders = Headers;
 const NativeResponse = Response;
 const NativeSet = Set;
 const NativeString = String;
+const NativeTypeError = TypeError;
 const NativeURLSearchParams = URLSearchParams;
 const NativeHasInstance = Function.prototype[Symbol.hasInstance];
 const NativeArrayFrom = Array.from;
@@ -50,6 +51,7 @@ const NativeDecodeURIComponent = decodeURIComponent;
 const StringToUpperCase = String.prototype.toUpperCase;
 const ObjectHasOwn = Object.hasOwn;
 const EmptyHeadersInit: Record<string, string> = ObjectCreate(null);
+const ResponseInitFields = ["headers", "status", "statusText"] as const;
 const RequestInitFields = [
   "body",
   "cache",
@@ -242,6 +244,16 @@ function createNativeResponse(
   status?: number,
   statusText?: string,
 ): Response {
+  // Node assigns into a normal internal dictionary, so inherited accessors
+  // can intercept even explicit fields. Reject that state without invoking
+  // project code or changing process-wide prototypes during construction.
+  for (let index = 0; index < ResponseInitFields.length; index++) {
+    const field = ResponseInitFields[index]!;
+    const descriptor = ObjectGetOwnPropertyDescriptor(NativeObjectPrototype, field);
+    if (descriptor && !ObjectHasOwn(descriptor, "value")) {
+      throw new NativeTypeError("Cannot construct a response with inherited option accessors");
+    }
+  }
   // Node converts the init into an ordinary dictionary internally. Supply
   // every field so that dictionary cannot inherit response defaults.
   const init: ResponseInit = ObjectCreate(null);

--- a/src/agent/service/response-init.test.ts
+++ b/src/agent/service/response-init.test.ts
@@ -1,0 +1,71 @@
+import { assertEquals, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { buildResponseInit } from "./response-init.ts";
+
+describe("agent service response init", () => {
+  it("supplies own defaults in dictionaries without prototypes", () => {
+    const init = buildResponseInit({});
+
+    assertEquals(Object.getPrototypeOf(init), null);
+    assertEquals(Object.keys(init), ["headers", "status", "statusText"]);
+    assertEquals(Object.getPrototypeOf(init.headers), null);
+    assertEquals(Object.keys(init.headers!), []);
+    assertEquals(init.status, 200);
+    assertEquals(init.statusText, "");
+  });
+
+  it("keeps headers independent between constructed option dictionaries", () => {
+    const first = buildResponseInit({});
+    const headers = first.headers as Record<string, string>;
+    headers["Access-Control-Allow-Origin"] = "https://untrusted.example.test";
+
+    const second = buildResponseInit({});
+    assertEquals(Object.keys(second.headers!), []);
+  });
+
+  it("preserves explicit values, including values native validation must reject", () => {
+    const valid = buildResponseInit({}, 201, "Created");
+    assertEquals(valid.status, 201);
+    assertEquals(valid.statusText, "Created");
+
+    const invalid = buildResponseInit({}, 99, "invalid\ntext");
+    assertEquals(invalid.status, 99);
+    assertEquals(invalid.statusText, "invalid\ntext");
+  });
+
+  it("overrides inherited data properties with explicit response defaults", () => {
+    const prototype = {
+      headers: { "Access-Control-Allow-Origin": "https://untrusted.example.test" },
+      status: 503,
+      statusText: "Injected",
+    };
+    const init = buildResponseInit(prototype);
+
+    assertEquals(Object.keys(init.headers!), []);
+    assertEquals(init.status, 200);
+    assertEquals(init.statusText, "");
+  });
+
+  for (const field of ["headers", "status", "statusText"]) {
+    it(`rejects ${field} accessors without invoking them`, () => {
+      let accessorCalls = 0;
+      const accessors: PropertyDescriptor[] = [
+        { get: () => accessorCalls++ },
+        { set: () => accessorCalls++ },
+        { get: () => accessorCalls++, set: () => accessorCalls++ },
+        { get: undefined },
+      ];
+      for (const descriptor of accessors) {
+        const prototype = Object.create(null);
+        Object.defineProperty(prototype, field, descriptor);
+
+        assertThrows(
+          () => buildResponseInit(prototype, 201, "Created"),
+          TypeError,
+          "Cannot construct a response with inherited option accessors",
+        );
+      }
+      assertEquals(accessorCalls, 0);
+    });
+  }
+});

--- a/src/agent/service/response-init.ts
+++ b/src/agent/service/response-init.ts
@@ -1,0 +1,29 @@
+const ObjectCreate = Object.create;
+const ObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const ObjectHasOwn = Object.hasOwn;
+const NativeTypeError = TypeError;
+const ResponseInitFields = ["headers", "status", "statusText"] as const;
+
+/** Build explicit response options after inspecting the native dictionary's prototype. */
+export function buildResponseInit(
+  objectPrototype: object,
+  status?: number,
+  statusText?: string,
+): ResponseInit {
+  // Node assigns into a normal internal dictionary, so inherited accessors
+  // can intercept even explicit fields. Reject that state without invoking
+  // project code or changing process-wide prototypes during construction.
+  for (let index = 0; index < ResponseInitFields.length; index++) {
+    const field = ResponseInitFields[index]!;
+    const descriptor = ObjectGetOwnPropertyDescriptor(objectPrototype, field);
+    if (descriptor && !ObjectHasOwn(descriptor, "value")) {
+      throw new NativeTypeError("Cannot construct a response with inherited option accessors");
+    }
+  }
+  // Supply every field so Node's internal dictionary cannot inherit defaults.
+  const init: ResponseInit = ObjectCreate(null);
+  init.headers = ObjectCreate(null);
+  init.status = status === undefined ? 200 : status;
+  init.statusText = statusText === undefined ? "" : statusText;
+  return init;
+}

--- a/src/agent/service/response-init.ts
+++ b/src/agent/service/response-init.ts
@@ -4,9 +4,15 @@ const ObjectHasOwn = Object.hasOwn;
 const NativeTypeError = TypeError;
 const ResponseInitFields = ["headers", "status", "statusText"] as const;
 
+interface ResponseInitPrototype {
+  headers?: unknown;
+  status?: unknown;
+  statusText?: unknown;
+}
+
 /** Build explicit response options after inspecting the native dictionary's prototype. */
 export function buildResponseInit(
-  objectPrototype: object,
+  objectPrototype: ResponseInitPrototype,
   status?: number,
   statusText?: string,
 ): ResponseInit {

--- a/tests/integration/agent/service-response-init.test.ts
+++ b/tests/integration/agent/service-response-init.test.ts
@@ -1,0 +1,130 @@
+import {
+  assertEquals,
+  assertRejects,
+  assertStrictEquals,
+  assertThrows,
+} from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { defineAgentService } from "#veryfront/agent/service/definition.ts";
+
+const allowedOrigin = "https://studio.example.test";
+const deniedOrigin = "https://untrusted.example.test";
+
+describe("agent service native response init", () => {
+  it("propagates host errors and rejects malformed headers without a success fallback", async () => {
+    const failure = new Error("synthetic host failure");
+    const runtime = defineAgentService({
+      serviceName: "failures",
+      agents: {},
+      defaultAgentId: "test",
+      server: { cors: true },
+    }).createRuntime({
+      routes: [{
+        path: "/fail",
+        method: "GET",
+        handler: () => {
+          throw failure;
+        },
+      }, {
+        path: "/invalid-status",
+        method: "GET",
+        handler: () => ({ body: null, headers: {}, status: 99, statusText: "" } as Response),
+      }, {
+        path: "/invalid-status-text",
+        method: "GET",
+        handler:
+          () => ({ body: null, headers: {}, status: 200, statusText: "invalid\ntext" } as Response),
+      }],
+    });
+    await assertRejects(
+      () =>
+        runtime.request("/fail").catch((error: unknown) => {
+          assertStrictEquals(error, failure);
+          throw error;
+        }),
+      Error,
+      "synthetic host failure",
+    );
+    assertThrows(
+      () => runtime.request("/fail", { headers: { "invalid\nname": "value" } }),
+      TypeError,
+    );
+    await assertRejects(() => runtime.request("/invalid-status"), RangeError);
+    let nativeStatusTextError: unknown;
+    let nativeStatusText: string | undefined;
+    try {
+      nativeStatusText = new Response(null, { statusText: "invalid\ntext" }).statusText;
+    } catch (error) {
+      nativeStatusTextError = error;
+    }
+    // Bun currently accepts this status text; retain each runtime's native
+    // validation outcome rather than adding a silent framework normalization.
+    if (nativeStatusTextError) {
+      await assertRejects(() => runtime.request("/invalid-status-text"), TypeError);
+    } else {
+      assertEquals((await runtime.request("/invalid-status-text")).statusText, nativeStatusText);
+    }
+  });
+
+  it("does not inherit response headers or status text from Object.prototype", async () => {
+    const hostResponse = new Response("synthetic-response-canary", {
+      headers: { "X-Host": "keep" },
+    });
+    const ordinary = defineAgentService({
+      serviceName: "plain",
+      agents: {},
+      defaultAgentId: "test",
+    }).createRuntime();
+    const cors = defineAgentService({
+      serviceName: "cors",
+      agents: {},
+      defaultAgentId: "test",
+      server: { cors: { origins: [allowedOrigin], credentials: true } },
+    }).createRuntime({
+      routes: [{ path: "/custom", method: "GET", handler: () => hostResponse }],
+    });
+    const requests = ["/liveness", "/readiness", "/missing", "/custom"].map((path) =>
+      new Request(`https://agent.example.test${path}`, { headers: { Origin: deniedOrigin } })
+    );
+    const preflight = new Request("https://agent.example.test/custom", {
+      method: "OPTIONS",
+      headers: { Origin: deniedOrigin, "Access-Control-Request-Method": "GET" },
+    });
+    const responses: Response[] = [];
+    const headersDescriptor = Object.getOwnPropertyDescriptor(Object.prototype, "headers");
+    const statusDescriptor = Object.getOwnPropertyDescriptor(Object.prototype, "statusText");
+    Object.defineProperties(Object.prototype, {
+      headers: {
+        configurable: true,
+        writable: true,
+        value: {
+          "Access-Control-Allow-Origin": deniedOrigin,
+          "Access-Control-Allow-Credentials": "true",
+        },
+      },
+      statusText: { configurable: true, writable: true, value: "Injected" },
+    });
+    try {
+      responses.push(await ordinary.fetch(requests[0]!));
+      for (const request of requests) responses.push(await cors.fetch(request));
+      responses.push(await cors.fetch(preflight));
+      cors.setShuttingDown();
+      responses.push(await cors.fetch(requests[1]!));
+    } finally {
+      if (headersDescriptor) Object.defineProperty(Object.prototype, "headers", headersDescriptor);
+      else Reflect.deleteProperty(Object.prototype, "headers");
+      if (statusDescriptor) Object.defineProperty(Object.prototype, "statusText", statusDescriptor);
+      else Reflect.deleteProperty(Object.prototype, "statusText");
+    }
+
+    assertEquals(responses.map((response) => response.status), [200, 200, 200, 404, 200, 204, 503]);
+    assertEquals(await responses[4]!.text(), "synthetic-response-canary");
+    assertEquals(responses[4]!.headers.get("X-Host"), "keep");
+    for (const response of responses) {
+      assertEquals(response.headers.get("Access-Control-Allow-Origin"), null);
+      assertEquals(response.headers.get("Access-Control-Allow-Credentials"), null);
+      assertEquals(response.statusText, "");
+      if (!response.bodyUsed) await response.body?.cancel();
+    }
+  });
+});

--- a/tests/integration/agent/service-response-init.test.ts
+++ b/tests/integration/agent/service-response-init.test.ts
@@ -11,6 +11,62 @@ const allowedOrigin = "https://studio.example.test";
 const deniedOrigin = "https://untrusted.example.test";
 
 describe("agent service native response init", () => {
+  it("rejects inherited response accessors before native conversion invokes them", async () => {
+    const runtime = defineAgentService({
+      serviceName: "response-accessors",
+      agents: {},
+      defaultAgentId: "test",
+      server: { cors: { origins: [allowedOrigin], credentials: true } },
+    }).createRuntime();
+    const request = new Request("https://agent.example.test/liveness", {
+      headers: { Origin: deniedOrigin },
+    });
+
+    for (const field of ["headers", "status", "statusText"]) {
+      const original = Object.getOwnPropertyDescriptor(Object.prototype, field);
+      let reads = 0;
+      let writes = 0;
+      let failure: unknown;
+      let response: Response | undefined;
+      Object.defineProperty(Object.prototype, field, {
+        configurable: true,
+        get() {
+          reads++;
+          if (field === "headers") {
+            return { "Access-Control-Allow-Origin": deniedOrigin };
+          }
+          return field === "status" ? 200 : "Injected";
+        },
+        set() {
+          writes++;
+        },
+      });
+      try {
+        response = await runtime.fetch(request);
+      } catch (error) {
+        failure = error;
+      } finally {
+        if (original) Object.defineProperty(Object.prototype, field, original);
+        else Reflect.deleteProperty(Object.prototype, field);
+      }
+      await response?.body?.cancel();
+      assertEquals(reads, 0, `${field} getter must not run`);
+      assertEquals(writes, 0, `${field} setter must not run`);
+      assertEquals(failure instanceof TypeError, true, `${field} must fail explicitly`);
+      assertEquals(
+        (failure as Error).message,
+        "Cannot construct a response with inherited option accessors",
+      );
+    }
+
+    const response = await runtime.request("/liveness", {
+      headers: { Origin: allowedOrigin },
+    });
+    assertEquals(response.status, 200);
+    assertEquals(response.headers.get("Access-Control-Allow-Origin"), allowedOrigin);
+    assertEquals(await response.text(), "OK");
+  });
+
   it("propagates host errors and rejects malformed headers without a success fallback", async () => {
     const failure = new Error("synthetic host failure");
     const runtime = defineAgentService({


### PR DESCRIPTION
Node's native response-option conversion can inherit headers and status text from Object.prototype, including CORS headers for a denied origin. Framework responses now receive fresh, explicit defaults. Inherited option accessors cause a TypeError before native conversion can invoke them; non-writable fields retain Node's native failure behavior.

Defaults apply only to omitted values. Invalid statuses and malformed headers still fail, and host errors propagate unchanged. A pure internal option builder provides independently tested validation while the existing integration regression exercises native response construction across runtimes.

Validation:
- Focused Deno suite: 58 steps passed. Focused Node suite: 22 tests passed. Bun: 3 registered test files passed.
- Option-builder unit coverage: 100% lines, branches and functions. Each call receives independent headers.
- Full lint:ci, typecheck, semantic test audit, API-reference and diff checks passed; no gate exclusions or baselines changed.
- The final CI-produced npm artifact passed 60 response-option/path cases on Node 22.3.0, 24.14.0 and 24.20.0, plus ordinary CORS/body and host-error-identity controls. Synthetic data, isolated local processes, zero network calls.
- Independent reviews approved the response correction and helper extraction.

Implementation and deployed verification are tracked in https://github.com/veryfront/veryfront-issue-inbox/issues/1036. Keep that issue open until the published artifact passes staging verification.

The separate native credential-processing boundary remains unresolved in https://github.com/veryfront/veryfront-issue-inbox/issues/1037. This PR does not establish complete shared-realm isolation.

The passing Sonar gate reports three minor style suggestions that are intentionally not applied: indexed iteration avoids replaceable iterator hooks, and undefined-only defaults preserve native behavior for invalid null values. Replacing those constructs with for-of or nullish coalescing would change the security/compatibility contract.
