### PR TITLE
fix(agent): surface provider workspace usage limits

### DIFF
--- a/src/agent/hosted/child-lifecycle.test.ts
+++ b/src/agent/hosted/child-lifecycle.test.ts
@@ -747,6 +747,56 @@ describe("agent/hosted-child-lifecycle", () => {
     });
   });
 
+  it("persists a workspace usage-limit diagnosis across the hosted child run boundary", async () => {
+    const providerError = await buildProviderError(
+      "anthropic",
+      new Response(
+        JSON.stringify({
+          type: "error",
+          error: {
+            type: "invalid_request_error",
+            message:
+              "You have reached your specified workspace API usage limits. You will regain access on 2026-08-01 at 00:00 UTC. <TOKEN> <PROMPT>",
+          },
+        }),
+        { status: 400 },
+      ),
+    );
+    const expectedMessage =
+      "The AI provider workspace API usage limit has been reached. Wait for the limit to reset, or ask an administrator to raise the workspace limit.";
+    const snapshots: ChildRunExecutionSnapshot[] = [];
+    const childResult = await handleHostedChildForkFailure({
+      error: new Error(getHostedStreamErrorText(providerError)),
+      description: "Summarize the repo",
+      kind: "invoke_agent",
+      finalText: "",
+      toolCalls: [],
+      toolResults: [],
+      startTime: Date.now(),
+      onSettled: (snapshot) => {
+        snapshots.push(snapshot);
+      },
+    });
+    assertEquals(snapshots.length, 1);
+    assertEquals(snapshots[0]?.error, expectedMessage);
+    let persisted: unknown;
+    const result = await runHostedChildExecutionLifecycle({
+      adapter: {
+        failed: (state) => {
+          persisted = state;
+        },
+      },
+      executionFailedCode: "INVOKE_AGENT_FAILED",
+      execute: () => Promise.resolve(childResult),
+      getExecutionSnapshot: () => snapshots[0] ?? null,
+    });
+
+    assertEquals(result.status, "failed");
+    assertEquals(result.terminalState.terminalErrorCode, "AI_PROVIDER_WORKSPACE_LIMIT_EXCEEDED");
+    assertEquals(result.terminalState.terminalErrorMessage, expectedMessage);
+    assertEquals(persisted, result.terminalState);
+  });
+
   it("keeps a child run's schema rejection classified across the run boundary", async () => {
     // The child run boundary is the route the plain-message matcher in
     // `resolveKnownProviderTerminalError` exists for, so walk it end to end

--- a/src/agent/runtime/chat-stream-handler.test.ts
+++ b/src/agent/runtime/chat-stream-handler.test.ts
@@ -34,7 +34,12 @@ import {
   toConversationPartsFromUiMessage,
 } from "#veryfront/chat/conversation.ts";
 import type { ChatUiMessage } from "#veryfront/chat/types.ts";
-import { ProviderOverloadedError, ProviderQuotaError } from "#veryfront/provider/runtime-loader.ts";
+import {
+  ProviderOverloadedError,
+  ProviderQuotaError,
+  ProviderRequestError,
+  requestStream,
+} from "#veryfront/provider/runtime-loader.ts";
 
 afterEach(() => {
   _resetShimForTests();
@@ -1919,6 +1924,44 @@ describe("chat-stream-handler", () => {
         assertEquals(event, testCase.expected);
         assertEquals(JSON.stringify(event).includes("provider-private"), false);
       }
+    });
+
+    it("surfaces workspace usage limits from the provider HTTP stream in terminal events", async () => {
+      let attempts = 0;
+      const providerError = await assertRejects(
+        () =>
+          requestStream({
+            url: "https://provider.test/messages",
+            providerKind: "anthropic",
+            providerLabel: "veryfront-cloud",
+            init: { method: "POST" },
+            fetchImpl: () => {
+              attempts++;
+              return Promise.resolve(
+                new Response(
+                  JSON.stringify({
+                    type: "error",
+                    error: {
+                      type: "invalid_request_error",
+                      message:
+                        "You have reached your specified workspace API usage limits. You will regain access on 2026-08-01 at 00:00 UTC. <TOKEN> <PROMPT>",
+                    },
+                  }),
+                  { status: 400 },
+                ),
+              );
+            },
+          }),
+        ProviderRequestError,
+      );
+
+      assertEquals(attempts, 1);
+      assertEquals(resolveRuntimeStreamErrorEvent(providerError), {
+        type: "error",
+        code: "AI_PROVIDER_WORKSPACE_LIMIT_EXCEEDED",
+        error:
+          "The AI provider workspace API usage limit has been reached. Wait for the limit to reset, or ask an administrator to raise the workspace limit.",
+      });
     });
 
     it("preserves typed provider quota failures before applying 429 heuristics", () => {

--- a/src/chat/provider-errors.test.ts
+++ b/src/chat/provider-errors.test.ts
@@ -298,6 +298,58 @@ describe("chat/provider-errors", () => {
     );
   });
 
+  it("classifies workspace API usage limits without copying provider-controlled text", async () => {
+    const expected = {
+      code: "AI_PROVIDER_WORKSPACE_LIMIT_EXCEEDED",
+      message:
+        "The AI provider workspace API usage limit has been reached. Wait for the limit to reset, or ask an administrator to raise the workspace limit.",
+      status: 502,
+    };
+    const body = {
+      type: "error",
+      error: {
+        type: "invalid_request_error",
+        message:
+          "You have reached your specified workspace API usage limits. You will regain access on 2026-08-01 at 00:00 UTC. <TOKEN> <PROMPT>",
+      },
+    };
+    const error = await buildProviderError(
+      "anthropic",
+      new Response(JSON.stringify(body), { status: 400 }),
+    );
+
+    assertEquals(parseProviderError(error), expected);
+    assertEquals(parseProviderError({ lastError: error }), expected);
+    assertEquals(parseProviderError(new Error(expected.message)), expected);
+    assertEquals(error.message, "Provider request failed with status 400");
+    assertEquals(Object.keys(error).includes("responseBody"), false);
+  });
+
+  it("does not misclassify unrelated workspace or usage-limit failures", async () => {
+    for (
+      const message of [
+        "Workspace API usage limits are configured.",
+        "You have reached the maximum workspace count.",
+        "You have reached your specified API usage limits.",
+        "Workspace API usage limits could not be loaded. <TOKEN>",
+      ]
+    ) {
+      const error = await buildProviderError(
+        "anthropic",
+        new Response(
+          JSON.stringify({
+            error: { type: "invalid_request_error", message },
+          }),
+          { status: 400 },
+        ),
+      );
+      assertEquals(parseProviderError(error), {
+        code: "EXTERNAL_SERVICE_ERROR",
+        message: "LLM provider service error",
+      });
+    }
+  });
+
   it("classifies upstream provider billing failures separately from user credits", () => {
     const expected = {
       code: "AI_PROVIDER_BILLING_ERROR",

--- a/src/chat/provider-errors.ts
+++ b/src/chat/provider-errors.ts
@@ -45,6 +45,13 @@ const AI_PROVIDER_SPEND_LIMIT_ERROR = {
   status: 402,
 } as const;
 
+const AI_PROVIDER_WORKSPACE_LIMIT_ERROR = {
+  code: "AI_PROVIDER_WORKSPACE_LIMIT_EXCEEDED",
+  message:
+    "The AI provider workspace API usage limit has been reached. Wait for the limit to reset, or ask an administrator to raise the workspace limit.",
+  status: 502,
+} as const;
+
 const AI_PROVIDER_BILLING_ERROR = {
   code: "AI_PROVIDER_BILLING_ERROR",
   message:
@@ -295,6 +302,13 @@ function isAssistantPrefillUnsupportedMessage(message: string): boolean {
   return mentionsAssistantPrefill && rejectsAssistantPrefill;
 }
 
+// Match both the provider rejection and the curated text that crosses child-run
+// boundaries. Return only curated wording; provider messages may echo secrets.
+function isProviderWorkspaceLimitMessage(normalizedMessage: string): boolean {
+  return normalizedMessage.includes("workspace api usage limit") &&
+    (normalizedMessage.includes("have reached") || normalizedMessage.includes("has been reached"));
+}
+
 // Detects provider-side billing errors reported via invalid_request_error messages.
 // Requires three independent signals to reduce false positives: the message must
 // mention (a) a known provider API, (b) billing/account, and (c) low credit balance.
@@ -344,6 +358,9 @@ function isInvalidRequestEnvelope(body: Record<string, unknown>): boolean {
  */
 function classifyInvalidRequestMessage(message: string): ParsedProviderError | null {
   const normalizedMessage = message.toLowerCase();
+  if (isProviderWorkspaceLimitMessage(normalizedMessage)) {
+    return AI_PROVIDER_WORKSPACE_LIMIT_ERROR;
+  }
   if (isProviderBillingMessage(normalizedMessage)) {
     return AI_PROVIDER_BILLING_ERROR;
   }
@@ -536,6 +553,9 @@ function parseProviderErrorInner(
     // whose envelope carries no `invalid_request_error` type at all.
     if (isOpenObjectSchemaRejection(message)) {
       return OUTPUT_SCHEMA_NOT_CLOSED_ERROR;
+    }
+    if (isProviderWorkspaceLimitMessage(normalizedMessage)) {
+      return AI_PROVIDER_WORKSPACE_LIMIT_ERROR;
     }
     if (isProviderBillingMessage(normalizedMessage)) {
       return AI_PROVIDER_BILLING_ERROR;


### PR DESCRIPTION
An Anthropic workspace API usage-limit rejection arrives as HTTP 400 with `invalid_request_error`, but agent terminal events currently show only the HTTP status. Recognize that failure in the shared provider classifier and surface a curated message explaining that the workspace limit was reached and must reset or be raised. The diagnosis and error code survive hosted child-run persistence.

Keep raw provider bodies private and preserve generic fallbacks for unrelated failures. Provider error messages can echo credentials and prompts, so the fix emits curated text rather than copying upstream text.

Validation:
- Reproduced against the installed staging runtime package `0.1.1258-rc.18787` using one synthetic intercepted provider HTTP 400: classification, terminal event, hosted message, and child round-trip checks fail as expected; one-attempt and privacy checks pass.
- Red/green regression reproduced the reported generic status message through a real intercepted provider HTTP stream, shared classification, and hosted child persistence.
- All three changed test suites pass (172 steps); adjacent provider/terminal suites pass (119 steps); hosted execution/runtime bridge suites pass (83 steps).
- Changed-file lint, type checking, formatting, `git diff --check`, and generated API reference check pass.
- Local `codex review --uncommitted` and `codex review --base origin/main` report no actionable findings. Review subprocess tests hit read-only preload temporary-directory restrictions; the independent writable test runs above pass completely.

Refs veryfront/veryfront-issue-inbox#1012. Keep the issue open until staging verification completes after merge and release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace API usage-limit errors are now consistently identified with a dedicated error code.
  * Users receive a clear, curated message when workspace provider limits are exceeded.
  * Provider-specific and potentially sensitive error details are no longer exposed.
  * Error handling remains generic for unrelated workspace or usage-limit messages, preventing incorrect classifications.
  * Hosted child runs now preserve the correct failed terminal state and error information when this limit is encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->