### PR TITLE
fix(ssr): recover custom error pages after transient failures

### DIFF
--- a/src/server/handlers/request/ssr/error-page-fallback-recovery.test.ts
+++ b/src/server/handlers/request/ssr/error-page-fallback-recovery.test.ts
@@ -1,0 +1,120 @@
+import "#veryfront/schemas/_test-setup.ts";
+import * as React from "react";
+import * as ReactDOMServer from "react-dom/server";
+import { assertEquals, assertExists, assertStringIncludes } from "#veryfront/testing/assert.ts";
+import { afterEach, describe, it } from "#veryfront/testing/bdd.ts";
+import { createMockAdapter } from "#veryfront/platform/adapters/mock.ts";
+import {
+  __injectProjectReactForTests,
+  __injectReactDOMServerForTests,
+  resetReactCache,
+} from "#veryfront/react/compat/ssr-adapter/server-loader.ts";
+import { ResponseBuilder } from "#veryfront/security/http/response/builder.ts";
+import {
+  __injectCacheForTests,
+  __setComponentSourceLoaderForTests,
+  tryErrorPageFallback,
+} from "./error-page-fallback.ts";
+
+afterEach(() => {
+  __injectCacheForTests(null);
+  __setComponentSourceLoaderForTests(null);
+  resetReactCache();
+});
+
+describe("error page recovery", () => {
+  for (const resolution of ["extensions", "resolver"] as const) {
+    for (
+      const { stage, warm } of [
+        { stage: "discovery", warm: false },
+        { stage: "source read", warm: false },
+        { stage: "module load", warm: false },
+        { stage: "dependency lookup", warm: false },
+        { stage: "module load", warm: true },
+      ] as const
+    ) {
+      it(`recovers after a ${stage} failure with ${resolution} and a ${warm ? "warm" : "cold"} cache`, async () => {
+        const entries = new Map<string, string>();
+        __injectCacheForTests({
+          get: (key: string) => Promise.resolve(entries.get(key) ?? null),
+          set: (key: string, value: string) => {
+            entries.set(key, value);
+            return Promise.resolve();
+          },
+          delete: (key: string) => {
+            entries.delete(key);
+            return Promise.resolve();
+          },
+        } as never);
+        __injectProjectReactForTests(React);
+        __injectReactDOMServerForTests(ReactDOMServer as never);
+
+        const projectDir = "/error-page-recovery";
+        const filePath = `${projectDir}/pages/500.tsx`;
+        let unavailable = false;
+        const failDuring = (operation: typeof stage) => {
+          if (unavailable && stage === operation) throw new Error("Temporarily unavailable");
+        };
+        const adapter = createMockAdapter();
+        adapter.fs.directories.add(`${projectDir}/pages`);
+        adapter.fs.files.set(filePath, "export default function ErrorPage() {}");
+        const stat = adapter.fs.stat;
+        adapter.fs.stat = (path) => {
+          if (path === filePath) failDuring("discovery");
+          return stat(path);
+        };
+        const readFile = adapter.fs.readFile;
+        adapter.fs.readFile = (path) => {
+          assertEquals(path, filePath);
+          failDuring("source read");
+          return readFile(path);
+        };
+        if (resolution === "resolver") {
+          adapter.fs.resolveFile = (path) => {
+            if (!path.endsWith("/500")) return Promise.resolve(null);
+            failDuring("discovery");
+            return Promise.resolve("pages/500.tsx");
+          };
+        }
+        __setComponentSourceLoaderForTests((_source, path) => {
+          assertEquals(path, filePath);
+          failDuring("module load");
+          if (unavailable && stage === "dependency lookup") {
+            throw Object.assign(new Error("Missing dependency"), { code: "ENOENT" });
+          }
+          return Promise.resolve(() => React.createElement("main", null, "Recovered error page"));
+        });
+        const ctx = {
+          projectDir,
+          projectId: "error-page-recovery",
+          adapter,
+          isLocalProject: false,
+          securityConfig: null,
+          config: { react: { version: React.version } },
+        };
+        const runFallback = () =>
+          tryErrorPageFallback(
+            new Request("http://localhost/boom"),
+            ctx,
+            new ResponseBuilder(),
+            { statusCode: 500, pathname: "/boom" },
+            { cacheKey: "off", dependencies: {} },
+          );
+
+        if (warm) {
+          const initial = await runFallback();
+          assertExists(initial);
+          assertStringIncludes(await initial.text(), "<main>Recovered error page</main>");
+        }
+        unavailable = true;
+        assertEquals(await runFallback(), null, "an outage must allow the generic fallback");
+
+        unavailable = false;
+        const recovered = await runFallback();
+        assertExists(recovered, "a load failure must not become a cached absence");
+        assertEquals(recovered.status, 500);
+        assertStringIncludes(await recovered.text(), "<main>Recovered error page</main>");
+      });
+    }
+  }
+});

--- a/src/server/handlers/request/ssr/error-page-fallback.test.ts
+++ b/src/server/handlers/request/ssr/error-page-fallback.test.ts
@@ -548,7 +548,7 @@ describe("server/handlers/request/ssr/error-page-fallback", () => {
               mtime: null,
             });
           }
-          return Promise.reject(new Error("not found"));
+          return Promise.reject(Object.assign(new Error("Missing file"), { code: "ENOENT" }));
         },
       });
       const ctx = makeCtx({ adapter });

--- a/src/server/handlers/request/ssr/error-page-fallback.ts
+++ b/src/server/handlers/request/ssr/error-page-fallback.ts
@@ -3,6 +3,7 @@ import type { HandlerContext } from "../../types.ts";
 import type { ResponseBuilder } from "#veryfront/security/index.ts";
 import type { CacheRepository } from "#veryfront/repositories/types.ts";
 import { join as joinPath } from "#veryfront/compat/path/index.ts";
+import { isNotFoundError } from "#veryfront/compat/fs.ts";
 import { serverLogger } from "#veryfront/utils";
 import { buildErrorPageCacheKey } from "#veryfront/cache";
 import { computeContentSourceId } from "#veryfront/cache/keys.ts";
@@ -256,18 +257,20 @@ async function tryLoadErrorPage(
         return component;
       }
     } catch (_) {
-      // expected: resolveFile may fail, fall through to extension probing
+      // A resolution or load failure does not establish that the page is absent.
     }
 
-    await setCachedMiss(cacheKey, ctx);
     return null;
   }
 
+  let confirmedMissing = true;
   for (const ext of ERROR_PAGE_EXTENSIONS) {
     const filePath = joinPath(pagesDir, `${pageType}${ext}`);
     try {
       const stat = await ctx.adapter.fs.stat(filePath);
       if (!stat.isFile) continue;
+      // Keep an existing page retryable even if reading or importing it fails.
+      confirmedMissing = false;
 
       const component = await loadErrorComponent(
         filePath,
@@ -281,12 +284,12 @@ async function tryLoadErrorPage(
         await setCachedPath(cacheKey, filePath);
         return component;
       }
-    } catch (_) {
-      // expected: file with this extension doesn't exist
+    } catch (error) {
+      if (!isNotFoundError(error)) confirmedMissing = false;
     }
   }
 
-  await setCachedMiss(cacheKey, ctx);
+  if (confirmedMissing) await setCachedMiss(cacheKey, ctx);
   return null;
 }
 


### PR DESCRIPTION
## Description

Keep custom error pages available after temporary filesystem or dependency failures.

Previously, a failed discovery, source read, or module import could cache an existing error page as absent. Later requests continued to use the generic fallback even after the underlying failure recovered.

This fix caches only confirmed absence. It preserves the existing generic fallback during an outage and retries loading on the next request. It adds no retry loop, dependency, or public API change.

## Related issues

Discovered during verification following #4423. Broader renderer integration remains tracked separately in veryfront/veryfront-issue-inbox#1035.

## Type of change

- [x] Bug fix (non-breaking)
- [x] Test update

## Verification

- Ten colocated recovery cases fail against the original implementation and pass with the fix. Coverage includes cold and warm caches, both resolution paths, and missing dependencies.
- `deno task test:file src/server/handlers/request/ssr`: 163 steps pass.
- `deno task test:file src/platform/compat/fs.test.ts`: 58 steps pass.
- Focused Node recovery and prepared-fallback tests: 12 tests pass.
- Focused Bun recovery and prepared-fallback tests: 2 files pass.
- Local HTTP smoke checks: 7 pass. Chromium hydration and interactive state updates pass.
- Formatting, lint, source/test typechecks, test-layout, and diff checks pass.
- `codex review --uncommitted` and `codex review --base origin/main`: no actionable findings for head `8af1c6389b43cc1d790316d834115bc5be68d58a`.

Local verification does not replace staging rollout verification. This PR does not change resource sizing or deploy to production.

## Checklist

- [x] Documentation impact checked: no public API or configuration changes.
- [x] Added tests that reproduce the failure and verify recovery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Error-page fallback recovery now retries after transient discovery, file-reading, module-loading, or dependency failures instead of caching a missing page.
  - Genuine missing error pages continue to use the generic fallback appropriately.
  - Improved handling of missing-file errors during error-page resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->