### PR TITLE
ci: standardize Sonar quality gate check

### DIFF
--- a/.github/QUALITY_GATES.md
+++ b/.github/QUALITY_GATES.md
@@ -22,10 +22,9 @@ cannot receive `SONAR_TOKEN`. Fork pull requests still skip other protected
 dependency jobs and therefore fail this aggregate gate closed. Codecov
 reporting remains advisory.
 
-The scanner still emits the legacy `sonar` check during the ruleset migration.
-`SonarQube Cloud quality gate` is the canonical final check and depends on that
-scanner result. Remove the legacy check name only after the ruleset requires
-the canonical name and the canonical check has passed on `main`.
+The scanner emits the diagnostic `SonarQube Cloud scan` check.
+`SonarQube Cloud quality gate` is the only Sonar check required by the ruleset
+and depends on that scanner result.
 
 The active merge queue ruleset gives required checks at least 70 minutes to
 report a conclusion. This covers the longest configured dependency path: 60

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -462,9 +462,7 @@ jobs:
   sonar:
     runs-on: ubuntu-latest
     timeout-minutes: 35
-    # Keep this legacy check name until the repository ruleset requires the
-    # canonical gate below. Removing it earlier would leave `sonar` expected.
-    name: sonar
+    name: SonarQube Cloud scan
     needs: [coverage-shards]
     if: ${{ needs.coverage-shards.result == 'success' && ((github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name != 'pull_request' || github.event.pull_request.user.login != 'dependabot[bot]')) }}
     permissions:

--- a/src/config/cicd-coverage-workflow.test.ts
+++ b/src/config/cicd-coverage-workflow.test.ts
@@ -151,7 +151,7 @@ describe("cicd coverage workflow", () => {
     assertStringIncludes(workflow, "Download unit coverage lcov files");
     assertStringIncludes(workflow, "pattern: coverage-shard-*");
     assertStringIncludes(workflow, "sonar:");
-    assertStringIncludes(workflow, "name: sonar");
+    assertStringIncludes(workflow, "name: SonarQube Cloud scan");
     assertStringIncludes(
       await readRepoFile("sonar-project.properties"),
       "sonar.javascript.node.maxspace=8192",

--- a/tests/integration/ci/merge-quality-gate-workflow.test.ts
+++ b/tests/integration/ci/merge-quality-gate-workflow.test.ts
@@ -39,7 +39,7 @@ const SONAR_GATE_JOB_EXPRESSION = `\${{ always() && ${SONAR_REQUIRED_CONDITION} 
 const SONAR_JOB_TIMEOUT_MINUTES = 35;
 const SONAR_QUALITY_GATE_TIMEOUT_SECONDS = 1200;
 const SONAR_CHECK_NAME = "SonarQube Cloud quality gate";
-const LEGACY_SONAR_CHECK_NAME = "sonar";
+const SONAR_SCAN_CHECK_NAME = "SonarQube Cloud scan";
 const MERGE_QUEUE_RESPONSE_TIMEOUT_MINUTES = 70;
 const MERGE_QUEUE_SCHEDULING_HEADROOM_MINUTES = 8;
 
@@ -262,7 +262,7 @@ describe("merge quality gate workflow", () => {
       jobs["sonar-quality-gate"],
       "SonarQube Cloud quality gate job",
     );
-    assertEquals(sonar.name, LEGACY_SONAR_CHECK_NAME);
+    assertEquals(sonar.name, SONAR_SCAN_CHECK_NAME);
     assertEquals(sonarGate.name, SONAR_CHECK_NAME);
     assertEquals(sonarGate.needs, ["sonar"]);
     assertEquals(sonarGate.if, SONAR_GATE_JOB_EXPRESSION);


### PR DESCRIPTION
## Summary

- rename the diagnostic scanner check from the transitional "sonar" label
- keep "SonarQube Cloud quality gate" as the single required Sonar check
- update the workflow contract and quality-gate runbook

The active GitHub ruleset was switched to the canonical check only after that check had passed on main.

## Verification

- deno task test:file tests/integration/ci/merge-quality-gate-workflow.test.ts
- codex review --base main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/CD**
  - Renamed the SonarQube scan check to **“SonarQube Cloud scan”** for clearer status reporting.
  - The **“SonarQube Cloud quality gate”** remains the required check and now explicitly depends on the scan result.

- **Documentation**
  - Updated merge-correctness guidance to reflect the current SonarQube Cloud check names.
  - Removed references to the legacy **“sonar”** check and migration-only instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->