### PR TITLE
feat(agent): bound executor session admission until settlement

### DIFF
--- a/src/agent/hosted/executor-session-pool.test.ts
+++ b/src/agent/hosted/executor-session-pool.test.ts
@@ -51,7 +51,7 @@ const sessionOptions: HostedExecutorSessionOptions = {
   request: {
     allocationId: "11111111-1111-4111-8111-111111111111",
     invocationId: "22222222-2222-4222-8222-222222222222",
-    projectId: "project-test",
+    owner: { scopeKind: "project", projectId: "project-test" },
     source: { type: "release", releaseId: "release-test" },
     requestedAt: 1000,
     prepareDeadlineAt: 2000,
@@ -411,7 +411,7 @@ describe("hosted executor session pool", () => {
       binding: {
         allocationId: sessionOptions.request.allocationId,
         invocationId: sessionOptions.request.invocationId,
-        projectId: sessionOptions.request.projectId,
+        owner: sessionOptions.request.owner,
         source: sessionOptions.request.source,
         generation: 1,
         brokerInstanceId: sessionOptions.expectedBrokerInstanceId,

--- a/src/agent/hosted/executor-session-pool.test.ts
+++ b/src/agent/hosted/executor-session-pool.test.ts
@@ -1,18 +1,18 @@
 import "#veryfront/schemas/_test-setup.ts";
 import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
-import type { ExecutorChannel } from "../executor/channel.ts";
-import { createClockDeadlineTimer } from "../streaming/lifecycle/deadlines.ts";
-import { ManualMonotonicClock } from "../streaming/lifecycle/testing.ts";
+import type { ExecutorChannel } from "#veryfront/agent/executor/channel.ts";
+import { createClockDeadlineTimer } from "#veryfront/agent/streaming/lifecycle/deadlines.ts";
+import { ManualMonotonicClock } from "#veryfront/agent/streaming/lifecycle/testing.ts";
 import type {
   HostedExecutorSession,
   HostedExecutorSessionCloseResult,
   HostedExecutorSessionOptions,
-} from "./executor-session.ts";
+} from "#veryfront/agent/hosted/executor-session.ts";
 import {
   createHostedExecutorSessionPool,
   type HostedExecutorSessionPool,
-} from "./executor-session-pool.ts";
+} from "#veryfront/agent/hosted/executor-session-pool.ts";
 
 function sessionDouble() {
   const closed = Promise.withResolvers<HostedExecutorSessionCloseResult>();

--- a/src/agent/hosted/executor-session-pool.test.ts
+++ b/src/agent/hosted/executor-session-pool.test.ts
@@ -1,0 +1,427 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertRejects, assertThrows } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import type { ExecutorChannel } from "../executor/channel.ts";
+import { createClockDeadlineTimer } from "../streaming/lifecycle/deadlines.ts";
+import { ManualMonotonicClock } from "../streaming/lifecycle/testing.ts";
+import type {
+  HostedExecutorSession,
+  HostedExecutorSessionCloseResult,
+  HostedExecutorSessionOptions,
+} from "./executor-session.ts";
+import {
+  createHostedExecutorSessionPool,
+  type HostedExecutorSessionPool,
+} from "./executor-session-pool.ts";
+
+function sessionDouble() {
+  const closed = Promise.withResolvers<HostedExecutorSessionCloseResult>();
+  const settled = Promise.withResolvers<void>();
+  const controller = new AbortController();
+  let closeCalls = 0;
+  const session: HostedExecutorSession = {
+    ready: Promise.withResolvers<ExecutorChannel>().promise,
+    closed: closed.promise,
+    settled: settled.promise,
+    signal: controller.signal,
+    binding: undefined,
+    accepted: false,
+    accept() {},
+    close() {
+      closeCalls++;
+      controller.abort();
+      return closed.promise;
+    },
+  };
+  return {
+    session,
+    closed,
+    settled,
+    get closeCalls() {
+      return closeCalls;
+    },
+    finish(release: HostedExecutorSessionCloseResult["release"] = "released") {
+      closed.resolve({ reason: "canceled", release });
+      settled.resolve();
+    },
+  };
+}
+
+const sessionOptions: HostedExecutorSessionOptions = {
+  request: {
+    allocationId: "11111111-1111-4111-8111-111111111111",
+    invocationId: "22222222-2222-4222-8222-222222222222",
+    projectId: "project-test",
+    source: { type: "release", releaseId: "release-test" },
+    requestedAt: 1000,
+    prepareDeadlineAt: 2000,
+    hardDeadlineAt: 3000,
+  },
+  expectedBrokerInstanceId: "broker-test",
+  expectedImage: `registry.example.test/executor@sha256:${"a".repeat(64)}`,
+  allocator: {
+    allocate() {
+      throw new Error("Synthetic allocation must not be called");
+    },
+    observe() {
+      throw new Error("Synthetic observation must not be called");
+    },
+    renew() {
+      throw new Error("Synthetic renewal must not be called");
+    },
+    release() {
+      throw new Error("Synthetic release must not be called");
+    },
+  },
+  connectTransport() {
+    throw new Error("Synthetic transport must not be called");
+  },
+  createOperations: () => ({ operations: new Map(), revoke() {} }),
+  clock: { now: () => 1000, ...createClockDeadlineTimer(new ManualMonotonicClock()) },
+};
+
+async function tick(): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+describe("hosted executor session pool", () => {
+  it("retains admission after bounded session close until underlying work settles", async () => {
+    const first = sessionDouble();
+    const second = sessionDouble();
+    let creations = 0;
+    const pool = createHostedExecutorSessionPool({
+      maxActive: 1,
+      createSession: () => (++creations === 1 ? first : second).session,
+    });
+    assertEquals(pool.start(sessionOptions), first.session);
+    first.closed.resolve({ reason: "canceled", release: "reaper-required" });
+    await tick();
+    assertEquals(pool.active, 1);
+    assertThrows(() => pool.start(sessionOptions), Error, "capacity");
+    assertEquals(creations, 1);
+    first.settled.resolve();
+    await tick();
+    assertEquals(pool.active, 0);
+    assertEquals(pool.start(sessionOptions), second.session);
+    const closed = pool.shutdown();
+    second.finish();
+    assertEquals((await closed).release, "released");
+    await pool.settled;
+    assertEquals(pool.active, 0);
+  });
+
+  it("reserves capacity before a reentrant session factory starts another allocation", async () => {
+    const fake = sessionDouble();
+    let insideActive = 0;
+    const pool: HostedExecutorSessionPool = createHostedExecutorSessionPool({
+      maxActive: 1,
+      createSession: () => {
+        insideActive = pool.active;
+        assertThrows(() => pool.start(sessionOptions), Error, "capacity");
+        return fake.session;
+      },
+    });
+    pool.start(sessionOptions);
+    assertEquals(insideActive, 1);
+    fake.finish();
+    await pool.shutdown();
+    await pool.settled;
+  });
+
+  it("releases a failed constructor reservation and permits another start", async () => {
+    const fake = sessionDouble();
+    let fail = true;
+    const pool = createHostedExecutorSessionPool({
+      maxActive: 1,
+      createSession: () => {
+        if (fail) throw new Error("Synthetic constructor failure");
+        return fake.session;
+      },
+    });
+    assertThrows(() => pool.start(sessionOptions), Error, "Synthetic constructor failure");
+    assertEquals(pool.active, 0);
+    fail = false;
+    assertEquals(pool.start(sessionOptions), fake.session);
+    fake.finish();
+    await pool.shutdown();
+    await pool.settled;
+  });
+
+  it("fences starts and closes a session returned during synchronous shutdown", async () => {
+    const fake = sessionDouble();
+    let shutdownResult: ReturnType<HostedExecutorSessionPool["shutdown"]> | undefined;
+    const pool: HostedExecutorSessionPool = createHostedExecutorSessionPool({
+      maxActive: 1,
+      createSession: () => {
+        shutdownResult = pool.shutdown();
+        assertEquals(pool.active, 1);
+        assertThrows(() => pool.start(sessionOptions), Error, "shut down");
+        return fake.session;
+      },
+    });
+    assertThrows(() => pool.start(sessionOptions), Error, "shut down");
+    assertEquals(fake.closeCalls, 1);
+    assertEquals(fake.session.signal.aborted, true);
+    assertEquals(pool.active, 1);
+    fake.finish();
+    assertEquals((await shutdownResult!).release, "released");
+    await pool.settled;
+    assertEquals(pool.active, 0);
+  });
+
+  it("releases a constructor that shuts down and then throws", async () => {
+    const pool: HostedExecutorSessionPool = createHostedExecutorSessionPool({
+      maxActive: 1,
+      createSession: () => {
+        void pool.shutdown();
+        throw new Error("Synthetic constructor failure");
+      },
+    });
+    assertThrows(() => pool.start(sessionOptions), Error, "Synthetic constructor failure");
+    assertEquals(await pool.closed, { release: "not-allocated", pending: 0 });
+    await pool.settled;
+  });
+
+  it("bounds shutdown notification while retaining sessions with pending cleanup", async () => {
+    const clock = new ManualMonotonicClock();
+    const fake = sessionDouble();
+    const pool = createHostedExecutorSessionPool({
+      maxActive: 1,
+      shutdownTimeoutMs: 100,
+      timer: createClockDeadlineTimer(clock),
+      createSession: () => fake.session,
+    });
+    pool.start(sessionOptions);
+    const closed = pool.shutdown();
+    assertEquals(pool.shutdown(), closed);
+    assertEquals(fake.closeCalls, 1);
+    assertEquals(pool.signal.aborted, true);
+    clock.advanceBy(100);
+    assertEquals(await closed, { release: "reaper-required", pending: 1 });
+    assertThrows(() => pool.start(sessionOptions), Error, "shut down");
+    let retired = false;
+    void pool.settled.then(() => {
+      retired = true;
+    });
+    await tick();
+    assertEquals(retired, false);
+    fake.finish();
+    await pool.settled;
+    assertEquals(retired, true);
+    assertEquals(pool.active, 0);
+    assertEquals(clock.pendingWaitCount, 0);
+    assertEquals(await pool.closed, { release: "reaper-required", pending: 1 });
+  });
+
+  it("reports acknowledged allocation release while still waiting for raw session work", async () => {
+    const fake = sessionDouble();
+    const pool = createHostedExecutorSessionPool({
+      maxActive: 1,
+      createSession: () => fake.session,
+    });
+    pool.start(sessionOptions);
+    const closed = pool.shutdown();
+    fake.closed.resolve({ reason: "canceled", release: "released" });
+    assertEquals(await closed, { release: "released", pending: 1 });
+    assertEquals(pool.active, 1);
+    fake.settled.resolve();
+    await pool.settled;
+  });
+
+  it("preserves per-session ownership and adds an independent shutdown owner", async () => {
+    const first = sessionDouble();
+    const second = sessionDouble();
+    const owner = new AbortController();
+    const shutdown = new AbortController();
+    const signals: AbortSignal[] = [];
+    const pool = createHostedExecutorSessionPool({
+      maxActive: 2,
+      signal: shutdown.signal,
+      createSession: (options) => {
+        signals.push(options.ownerSignal!);
+        return (signals.length === 1 ? first : second).session;
+      },
+    });
+    pool.start({ ...sessionOptions, ownerSignal: owner.signal });
+    pool.start(sessionOptions);
+    owner.abort();
+    assertEquals(signals.map((signal) => signal.aborted), [true, false]);
+    assertEquals(pool.signal.aborted, false);
+    shutdown.abort();
+    assertEquals(signals.map((signal) => signal.aborted), [true, true]);
+    assertEquals([first.closeCalls, second.closeCalls], [1, 1]);
+    first.finish();
+    second.finish();
+    await pool.closed;
+    await pool.settled;
+  });
+
+  it("never invokes the factory after shutdown was already requested", async () => {
+    const shutdown = new AbortController();
+    shutdown.abort();
+    let calls = 0;
+    const pool = createHostedExecutorSessionPool({
+      maxActive: 1,
+      signal: shutdown.signal,
+      createSession: () => {
+        calls++;
+        return sessionDouble().session;
+      },
+    });
+    assertThrows(() => pool.start(sessionOptions), Error, "shut down");
+    assertEquals(calls, 0);
+    assertEquals(await pool.closed, { release: "not-allocated", pending: 0 });
+    await pool.settled;
+  });
+
+  it("uses the real session by default and retires already canceled preparation", async () => {
+    const preparation = new AbortController();
+    preparation.abort();
+    const pool = createHostedExecutorSessionPool({ maxActive: 1 });
+    const session = pool.start({ ...sessionOptions, preparationSignal: preparation.signal });
+    assertEquals((await session.closed).release, "not-allocated");
+    await session.settled;
+    await tick();
+    assertEquals(pool.active, 0);
+    assertEquals(await pool.shutdown(), { release: "not-allocated", pending: 0 });
+    await pool.settled;
+  });
+
+  it("allows bounded reentrant creation while counting both constructor reservations", async () => {
+    const first = sessionDouble();
+    const second = sessionDouble();
+    let creations = 0;
+    const pool: HostedExecutorSessionPool = createHostedExecutorSessionPool({
+      maxActive: 2,
+      createSession: () => {
+        if (++creations === 1) {
+          assertEquals(pool.start(sessionOptions), second.session);
+          return first.session;
+        }
+        assertEquals(pool.active, 2);
+        assertThrows(() => pool.start(sessionOptions), Error, "capacity");
+        return second.session;
+      },
+    });
+    assertEquals(pool.start(sessionOptions), first.session);
+    assertEquals(pool.active, 2);
+    const closed = pool.shutdown();
+    first.finish();
+    second.finish("reaper-required");
+    assertEquals((await closed).release, "reaper-required");
+    await pool.settled;
+  });
+
+  it("closes a newly created session when its factory cancels the pool owner", async () => {
+    const shutdown = new AbortController();
+    const fake = sessionDouble();
+    let factorySignal: AbortSignal | undefined;
+    const pool = createHostedExecutorSessionPool({
+      maxActive: 1,
+      signal: shutdown.signal,
+      createSession: (options) => {
+        factorySignal = options.ownerSignal;
+        shutdown.abort();
+        return fake.session;
+      },
+    });
+    assertThrows(() => pool.start(sessionOptions), Error, "shut down");
+    assertEquals(factorySignal?.aborted, true);
+    assertEquals(fake.closeCalls, 1);
+    assertEquals(pool.active, 1);
+    fake.finish();
+    await pool.closed;
+    await pool.settled;
+  });
+
+  for (const failure of ["throw", "reject"] as const) {
+    it(`contains a session close ${failure} while retaining its retirement slot`, async () => {
+      const fake = sessionDouble();
+      fake.session.close = () => {
+        const error = new Error("Synthetic close error");
+        if (failure === "throw") throw error;
+        return Promise.reject(error);
+      };
+      const pool = createHostedExecutorSessionPool({
+        maxActive: 1,
+        createSession: () => fake.session,
+      });
+      pool.start(sessionOptions);
+      assertEquals(await pool.shutdown(), { release: "reaper-required", pending: 1 });
+      assertEquals(pool.active, 1);
+      fake.finish();
+      await pool.settled;
+      assertEquals(pool.active, 0);
+    });
+  }
+
+  it("fails closed on rejected retirement without recycling uncertain capacity", async () => {
+    const fake = sessionDouble();
+    const pool = createHostedExecutorSessionPool({
+      maxActive: 1,
+      createSession: () => fake.session,
+    });
+    pool.start(sessionOptions);
+    const rejected = assertRejects(() => pool.settled, Error, "retirement failed");
+    fake.settled.reject(new Error("Synthetic private retirement detail"));
+    await rejected;
+    assertEquals(await pool.closed, { release: "reaper-required", pending: 1 });
+    assertEquals(pool.active, 1);
+    assertThrows(() => pool.start(sessionOptions), Error, "shut down");
+    fake.closed.resolve({ reason: "failed", release: "reaper-required" });
+  });
+
+  it("rejects unbounded admission and notification limits before any creation", () => {
+    for (const maxActive of [0, -1, 1.5, Infinity, NaN, 257]) {
+      assertThrows(() => createHostedExecutorSessionPool({ maxActive }), TypeError);
+    }
+    for (const shutdownTimeoutMs of [0, -1, 1.5, Infinity, NaN, 30_001]) {
+      assertThrows(
+        () => createHostedExecutorSessionPool({ maxActive: 1, shutdownTimeoutMs }),
+        TypeError,
+      );
+    }
+  });
+
+  it("holds a real allocation through late cleanup and never allocates after shutdown", async () => {
+    const clock = new ManualMonotonicClock();
+    const timer = createClockDeadlineTimer(clock);
+    const allocation = Promise.withResolvers<unknown>();
+    let allocations = 0;
+    const pool = createHostedExecutorSessionPool({ maxActive: 1, shutdownTimeoutMs: 100, timer });
+    pool.start({
+      ...sessionOptions,
+      clock: { now: () => 1000 + clock.nowMs(), ...timer },
+      cleanupTimeoutMs: 50,
+      allocator: {
+        ...sessionOptions.allocator,
+        allocate() {
+          allocations++;
+          return allocation.promise;
+        },
+      },
+    });
+    assertEquals(allocations, 1);
+    const closed = pool.shutdown();
+    clock.advanceBy(50);
+    assertEquals(await closed, { release: "reaper-required", pending: 1 });
+    assertThrows(() => pool.start(sessionOptions), Error, "shut down");
+    assertEquals(allocations, 1);
+    allocation.resolve({
+      binding: {
+        allocationId: sessionOptions.request.allocationId,
+        invocationId: sessionOptions.request.invocationId,
+        projectId: sessionOptions.request.projectId,
+        source: sessionOptions.request.source,
+        generation: 1,
+        brokerInstanceId: sessionOptions.expectedBrokerInstanceId,
+      },
+      phase: "preparing",
+      expiresAt: 2000,
+    });
+    await pool.settled;
+    assertEquals(pool.active, 0);
+    assertEquals(allocations, 1);
+    assertEquals(clock.pendingWaitCount, 0);
+  });
+});

--- a/src/agent/hosted/executor-session-pool.ts
+++ b/src/agent/hosted/executor-session-pool.ts
@@ -1,14 +1,14 @@
-import { performanceMonotonicClock } from "../streaming/lifecycle/clock.ts";
+import { performanceMonotonicClock } from "#veryfront/agent/streaming/lifecycle/clock.ts";
 import {
   type AbsoluteDeadlineTimer,
   createClockDeadlineTimer,
-} from "../streaming/lifecycle/deadlines.ts";
+} from "#veryfront/agent/streaming/lifecycle/deadlines.ts";
 import {
   createHostedExecutorSession,
   type HostedExecutorSession,
   type HostedExecutorSessionCloseResult,
   type HostedExecutorSessionOptions,
-} from "./executor-session.ts";
+} from "#veryfront/agent/hosted/executor-session.ts";
 
 export interface HostedExecutorSessionPoolOptions {
   /** Finite process admission ceiling, including preparation and resource retirement. Maximum 256. */

--- a/src/agent/hosted/executor-session-pool.ts
+++ b/src/agent/hosted/executor-session-pool.ts
@@ -1,0 +1,205 @@
+import { performanceMonotonicClock } from "../streaming/lifecycle/clock.ts";
+import {
+  type AbsoluteDeadlineTimer,
+  createClockDeadlineTimer,
+} from "../streaming/lifecycle/deadlines.ts";
+import {
+  createHostedExecutorSession,
+  type HostedExecutorSession,
+  type HostedExecutorSessionCloseResult,
+  type HostedExecutorSessionOptions,
+} from "./executor-session.ts";
+
+export interface HostedExecutorSessionPoolOptions {
+  /** Finite process admission ceiling, including preparation and resource retirement. Maximum 256. */
+  maxActive: number;
+  signal?: AbortSignal;
+  /** Bounds shutdown notification, never the underlying work's admission lifetime. Default five seconds, maximum 30 seconds. */
+  shutdownTimeoutMs?: number;
+  timer?: AbsoluteDeadlineTimer;
+  /** Trusted synchronous factory. A thrown constructor must clean up its own partial resources. */
+  createSession?: (options: HostedExecutorSessionOptions) => HostedExecutorSession;
+}
+
+export interface HostedExecutorSessionPoolShutdownResult {
+  /** Aggregated allocation release acknowledgement, independent of raw work in pool.settled. */
+  release: HostedExecutorSessionCloseResult["release"];
+  /** Sessions or constructor reservations still holding process admission when notified. */
+  pending: number;
+}
+
+export interface HostedExecutorSessionPool {
+  readonly active: number;
+  /** Independent lifetime owner propagated to every admitted session. */
+  readonly signal: AbortSignal;
+  /** Bounded shutdown result. It does not certify that underlying work has retired. */
+  readonly closed: Promise<HostedExecutorSessionPoolShutdownResult>;
+  /** Resolves after shutdown and all sessions' raw work settles. A rejected session retirement fails this promise. */
+  readonly settled: Promise<void>;
+  /** Synchronously reserve capacity. Overload and shutdown reject without queuing or invoking the factory. */
+  start(options: HostedExecutorSessionOptions): HostedExecutorSession;
+  /** Permanently stop admission and synchronously request closure of all active sessions. */
+  shutdown(): Promise<HostedExecutorSessionPoolShutdownResult>;
+}
+
+interface Reservation {
+  session?: HostedExecutorSession;
+  closing: boolean;
+  result?: HostedExecutorSessionCloseResult;
+}
+
+function limit(value: number, maximum: number): number {
+  if (!Number.isSafeInteger(value) || value < 1 || value > maximum) {
+    throw new TypeError("Executor session pool requires bounded positive integer limits");
+  }
+  return value;
+}
+
+/** Process-local admission only. Session construction owns authorization, allocation, and lifecycle policy. */
+export function createHostedExecutorSessionPool(
+  options: HostedExecutorSessionPoolOptions,
+): HostedExecutorSessionPool {
+  return new SessionPool(options);
+}
+
+class SessionPool implements HostedExecutorSessionPool {
+  readonly #maximum: number;
+  readonly #timeout: number;
+  readonly #timer: AbsoluteDeadlineTimer;
+  readonly #createSession: NonNullable<HostedExecutorSessionPoolOptions["createSession"]>;
+  readonly #controller = new AbortController();
+  readonly #closed = Promise.withResolvers<HostedExecutorSessionPoolShutdownResult>();
+  readonly #settled = Promise.withResolvers<void>();
+  readonly #active = new Set<Reservation>();
+  readonly #shutdownSignal?: AbortSignal;
+  readonly #onShutdown = () => {
+    void this.shutdown();
+  };
+  #stopped = false;
+  #notified = false;
+  #shutdownReservations: Reservation[] = [];
+  #shutdownTimer?: unknown;
+  #retirementFailed = false;
+
+  constructor(options: HostedExecutorSessionPoolOptions) {
+    this.#maximum = limit(options.maxActive, 256);
+    this.#timeout = limit(options.shutdownTimeoutMs ?? 5000, 30_000);
+    this.#timer = options.timer ?? createClockDeadlineTimer(performanceMonotonicClock);
+    this.#createSession = options.createSession ?? createHostedExecutorSession;
+    this.#shutdownSignal = options.signal;
+    void this.settled.catch(() => {});
+    options.signal?.addEventListener("abort", this.#onShutdown, { once: true });
+    if (options.signal?.aborted) void this.shutdown();
+  }
+
+  get active(): number {
+    return this.#active.size;
+  }
+  get signal(): AbortSignal {
+    return this.#controller.signal;
+  }
+  get closed(): Promise<HostedExecutorSessionPoolShutdownResult> {
+    return this.#closed.promise;
+  }
+  get settled(): Promise<void> {
+    return this.#settled.promise;
+  }
+
+  start(options: HostedExecutorSessionOptions): HostedExecutorSession {
+    if (this.#stopped) throw new Error("Executor session pool is shut down");
+    if (this.#active.size >= this.#maximum) {
+      throw new Error("Executor session pool capacity exceeded");
+    }
+    const reservation: Reservation = { closing: false };
+    this.#active.add(reservation);
+    let session: HostedExecutorSession;
+    try {
+      const ownerSignal = options.ownerSignal
+        ? AbortSignal.any([this.signal, options.ownerSignal])
+        : this.signal;
+      session = this.#createSession({ ...options, ownerSignal });
+    } catch (error) {
+      reservation.result = { reason: "construction-failed", release: "not-allocated" };
+      this.#active.delete(reservation);
+      this.#checkShutdown();
+      throw error;
+    }
+    reservation.session = session;
+    void session.closed.then((result) => {
+      reservation.result ??= result;
+      this.#checkShutdown();
+    }, () => {
+      reservation.result = { reason: "cleanup-failed", release: "reaper-required" };
+      this.#checkShutdown();
+    });
+    void session.settled.then(() => {
+      this.#active.delete(reservation);
+      this.#checkShutdown();
+    }, () => {
+      // Failed retirement cannot certify that process capacity is reusable.
+      this.#retirementFailed = true;
+      reservation.result = { reason: "retirement-failed", release: "reaper-required" };
+      this.#settled.reject(new Error("Executor session pool retirement failed"));
+      void this.shutdown();
+      this.#checkShutdown();
+    });
+    if (this.#stopped) {
+      this.#close(reservation);
+      throw new Error("Executor session pool is shut down");
+    }
+    return session;
+  }
+
+  shutdown(): Promise<HostedExecutorSessionPoolShutdownResult> {
+    if (this.#stopped) return this.closed;
+    this.#stopped = true;
+    this.#shutdownSignal?.removeEventListener("abort", this.#onShutdown);
+    this.#shutdownReservations = [...this.#active];
+    this.#shutdownTimer = this.#timer.schedule(() => this.#notify(true), this.#timeout);
+    this.#controller.abort(new Error("Executor session pool is shut down"));
+    for (const reservation of this.#shutdownReservations) this.#close(reservation);
+    this.#checkShutdown();
+    return this.closed;
+  }
+
+  #close(reservation: Reservation): void {
+    if (!reservation.session || reservation.closing) return;
+    reservation.closing = true;
+    const session = reservation.session;
+    void (async () => {
+      try {
+        // Completion belongs to session.closed; observe this call only to contain close failures.
+        await session.close("canceled");
+      } catch {
+        this.#closeFailed(reservation);
+      }
+    })();
+  }
+
+  #closeFailed(reservation: Reservation): void {
+    reservation.result = { reason: "cleanup-failed", release: "reaper-required" };
+    this.#checkShutdown();
+  }
+
+  #checkShutdown(): void {
+    if (!this.#stopped) return;
+    if (!this.#notified && this.#shutdownReservations.every((reservation) => reservation.result)) {
+      this.#notify(false);
+    }
+    if (this.#active.size === 0 && !this.#retirementFailed) this.#settled.resolve();
+  }
+
+  #notify(timedOut: boolean): void {
+    if (this.#notified) return;
+    this.#notified = true;
+    this.#timer.cancel(this.#shutdownTimer);
+    const release = timedOut || this.#retirementFailed ||
+        this.#shutdownReservations.some((entry) => entry.result?.release === "reaper-required")
+      ? "reaper-required"
+      : this.#shutdownReservations.some((entry) => entry.result?.release === "released")
+      ? "released"
+      : "not-allocated";
+    this.#shutdownReservations = [];
+    this.#closed.resolve(Object.freeze({ release, pending: this.active }));
+  }
+}

--- a/src/agent/hosted/executor-session-schema.ts
+++ b/src/agent/hosted/executor-session-schema.ts
@@ -29,7 +29,7 @@ export const getHostedExecutorSourceSchema = defineSchema((v) =>
 /** Trusted source owner, independent of the invocation's application project. */
 export const getHostedExecutorOwnerSchema = defineSchema((v) =>
   v.discriminatedUnion("scopeKind", [
-    v.object({ scopeKind: v.literal("global"), serviceName: getIdentifierSchema() }).strict(),
+    v.object({ scopeKind: v.literal("global"), serviceName: v.string().min(1).max(128) }).strict(),
     v.object({ scopeKind: v.literal("project"), projectId: getIdentifierSchema() }).strict(),
   ])
 );

--- a/src/agent/hosted/executor-session-schema.ts
+++ b/src/agent/hosted/executor-session-schema.ts
@@ -26,12 +26,20 @@ export const getHostedExecutorSourceSchema = defineSchema((v) =>
   ])
 );
 
+/** Trusted source owner, independent of the invocation's application project. */
+export const getHostedExecutorOwnerSchema = defineSchema((v) =>
+  v.discriminatedUnion("scopeKind", [
+    v.object({ scopeKind: v.literal("global"), serviceName: getIdentifierSchema() }).strict(),
+    v.object({ scopeKind: v.literal("project"), projectId: getIdentifierSchema() }).strict(),
+  ])
+);
+
 /** The control plane injects authenticated brokerInstanceId; callers cannot submit it here. */
 export const getHostedExecutorAllocationRequestSchema = defineSchema((v) =>
   v.object({
     allocationId: getAllocationIdSchema(),
     invocationId: getAllocationIdSchema(),
-    projectId: getIdentifierSchema(),
+    owner: getHostedExecutorOwnerSchema(),
     source: getHostedExecutorSourceSchema(),
     requestedAt: getTimestampSchema(),
     prepareDeadlineAt: getTimestampSchema(),
@@ -48,7 +56,7 @@ export const getHostedExecutorBindingSchema = defineSchema((v) =>
     generation: v.number().int().positive().max(Number.MAX_SAFE_INTEGER),
     invocationId: getAllocationIdSchema(),
     brokerInstanceId: getIdentifierSchema(),
-    projectId: getIdentifierSchema(),
+    owner: getHostedExecutorOwnerSchema(),
     source: getHostedExecutorSourceSchema(),
   }).strict()
 );
@@ -96,6 +104,7 @@ const getAllocationBindingEnvelopeSchema = defineSchema((v) =>
 export type HostedExecutorAllocationRequest = InferSchema<
   ReturnType<typeof getHostedExecutorAllocationRequestSchema>
 >;
+export type HostedExecutorOwner = InferSchema<ReturnType<typeof getHostedExecutorOwnerSchema>>;
 export type HostedExecutorBinding = InferSchema<ReturnType<typeof getHostedExecutorBindingSchema>>;
 export type HostedExecutorAllocation = InferSchema<
   ReturnType<typeof getHostedExecutorAllocationSchema>
@@ -118,7 +127,21 @@ export function parseHostedExecutorData<T>(schema: Schema<T>, value: unknown): T
 /** Capture only an exact validated identity, even when the remaining view is invalid. */
 export function readHostedExecutorBinding(value: unknown): HostedExecutorBinding {
   const { binding } = parseHostedExecutorData(getAllocationBindingEnvelopeSchema(), value);
-  return Object.freeze({ ...binding, source: Object.freeze(binding.source) });
+  return Object.freeze({
+    ...binding,
+    owner: Object.freeze(binding.owner),
+    source: Object.freeze(binding.source),
+  });
+}
+
+export function sameHostedExecutorOwner(
+  actual: HostedExecutorOwner,
+  expected: HostedExecutorOwner,
+): boolean {
+  return actual.scopeKind === "global" && expected.scopeKind === "global"
+    ? actual.serviceName === expected.serviceName
+    : actual.scopeKind === "project" && expected.scopeKind === "project" &&
+      actual.projectId === expected.projectId;
 }
 
 export function sameHostedExecutorBinding(
@@ -129,6 +152,6 @@ export function sameHostedExecutorBinding(
     actual.generation === expected.generation &&
     actual.invocationId === expected.invocationId &&
     actual.brokerInstanceId === expected.brokerInstanceId &&
-    actual.projectId === expected.projectId &&
+    sameHostedExecutorOwner(actual.owner, expected.owner) &&
     verifyHostedRuntimeSourceBinding(expected.source, actual.source) === undefined;
 }

--- a/src/agent/hosted/executor-session.test.ts
+++ b/src/agent/hosted/executor-session.test.ts
@@ -9,13 +9,19 @@ import {
   type HostedExecutorAllocatorClient,
   type HostedExecutorSessionOptions,
 } from "./executor-session.ts";
-import type { HostedExecutorAllocation } from "./executor-session-schema.ts";
+import {
+  getHostedExecutorAllocationRequestSchema,
+  type HostedExecutorAllocation,
+  type HostedExecutorOwner,
+  readHostedExecutorBinding,
+  sameHostedExecutorBinding,
+} from "./executor-session-schema.ts";
 import type { ExecutorNodeTransport } from "./executor-node-transport.ts";
 
 const request = {
   allocationId: "11111111-1111-4111-8111-111111111111",
   invocationId: "22222222-2222-4222-8222-222222222222",
-  projectId: "project-test",
+  owner: { scopeKind: "project" as const, projectId: "project-test" },
   source: { type: "release" as const, releaseId: "release-test" },
   requestedAt: 1000,
   prepareDeadlineAt: 4000,
@@ -27,7 +33,7 @@ const fullBinding = {
   invocationId: binding.invocationId,
   generation: binding.generation,
   brokerInstanceId: binding.brokerInstanceId,
-  projectId: binding.projectId,
+  owner: binding.owner,
   source: binding.source,
 };
 const image = `registry.example.test/executor@sha256:${"a".repeat(64)}`;
@@ -37,11 +43,13 @@ async function tick(): Promise<void> {
 }
 
 function fixture(overrides: Partial<HostedExecutorSessionOptions> = {}) {
+  const expectedRequest = structuredClone(overrides.request ?? request);
+  const expectedBinding = { ...fullBinding, owner: expectedRequest.owner };
   const time = new ManualMonotonicClock();
   const clock = createHostedExecutorSessionClock(1000, time);
   const calls: string[] = [];
   const returned: HostedExecutorAllocation = {
-    binding: fullBinding,
+    binding: expectedBinding,
     phase: "ready",
     expiresAt: 2000,
     endpoint: {
@@ -61,27 +69,27 @@ function fixture(overrides: Partial<HostedExecutorSessionOptions> = {}) {
   const allocator: HostedExecutorAllocatorClient = {
     allocate(input, bootstrap) {
       calls.push("allocate");
-      assertEquals(input, request);
+      assertEquals(input, expectedRequest);
       allocatedKey = bootstrap.channelKey;
       allocatedKeyCopy = new Uint8Array(allocatedKey);
       return Promise.resolve(structuredClone(returned));
     },
     observe(input) {
       calls.push("observe");
-      assertEquals(input, fullBinding);
+      assertEquals(input, expectedBinding);
       return Promise.resolve(structuredClone(returned));
     },
     renew(input) {
       calls.push("renew");
-      assertEquals(input, fullBinding);
+      assertEquals(input, expectedBinding);
       returned.expiresAt = Math.min(clock.now() + 1000, request.hardDeadlineAt);
       return Promise.resolve(structuredClone(returned));
     },
     release(input, reason) {
       calls.push(`release:${reason}`);
-      assertEquals(input, fullBinding);
+      assertEquals(input, expectedBinding);
       return Promise.resolve({
-        binding: fullBinding,
+        binding: expectedBinding,
         phase: "released",
         expiresAt: returned.expiresAt,
         reason,
@@ -89,7 +97,7 @@ function fixture(overrides: Partial<HostedExecutorSessionOptions> = {}) {
     },
   };
   const options: HostedExecutorSessionOptions = {
-    request,
+    request: expectedRequest,
     expectedBrokerInstanceId: fullBinding.brokerInstanceId,
     expectedImage: image,
     allocator,
@@ -127,7 +135,7 @@ function fixture(overrides: Partial<HostedExecutorSessionOptions> = {}) {
     },
     createOperations(input, signal) {
       calls.push("operations");
-      assertEquals(input, fullBinding);
+      assertEquals(input, expectedBinding);
       assertEquals(signal.aborted, false);
       return {
         operations: new Map(),
@@ -165,6 +173,120 @@ function fixture(overrides: Partial<HostedExecutorSessionOptions> = {}) {
 }
 
 describe("hosted executor session", () => {
+  it("owns a global metadata session without any application project", async () => {
+    const owner: HostedExecutorOwner = { scopeKind: "global", serviceName: "platform-agent" };
+    const f = fixture({ request: { ...request, owner } });
+    const session = f.start();
+    const channel = await session.ready;
+    assertEquals(session.binding?.owner, owner);
+    assertEquals(Object.hasOwn(f.options.request, "projectId"), false);
+    assertEquals(Object.hasOwn(session.binding!, "projectId"), false);
+    assertEquals(await channel.request("echo", { discovery: true }), { discovery: true });
+    assertEquals((await session.close("completed")).release, "released");
+    await session.settled;
+    await f.peerClosed();
+  });
+
+  it("snapshots and freezes owner before allocator work and operation grants", async () => {
+    const owner: HostedExecutorOwner = { scopeKind: "global", serviceName: "platform-agent" };
+    const f = fixture({ request: { ...request, owner } });
+    const allocate = f.allocator.allocate;
+    f.allocator.allocate = (input, bootstrap, signal) => {
+      assert(Object.isFrozen(input.owner));
+      assertThrows(() => Object.assign(input.owner, { serviceName: "foreign" }), TypeError);
+      return allocate(input, bootstrap, signal);
+    };
+    const session = f.start();
+    owner.serviceName = "changed-after-start";
+    await session.ready;
+    assertEquals(session.binding?.owner, { scopeKind: "global", serviceName: "platform-agent" });
+    assert(Object.isFrozen(session.binding?.owner));
+    assertThrows(
+      () => Object.assign(session.binding!.owner, { serviceName: "foreign" }),
+      TypeError,
+    );
+    await session.close();
+    await session.settled;
+    await f.peerClosed();
+  });
+
+  for (
+    const owner of [undefined, {}, { scopeKind: "global" }, { scopeKind: "project" }, {
+      scopeKind: "global",
+      serviceName: "",
+    }, { scopeKind: "global", serviceName: "agent", projectId: "project" }]
+  ) {
+    it(`rejects missing or ambiguous allocation owner ${JSON.stringify(owner)}`, () => {
+      assertEquals(
+        getHostedExecutorAllocationRequestSchema().safeParse({ ...request, owner }).success,
+        false,
+      );
+    });
+  }
+
+  it("does not interpret a legacy project or absent owner as global", () => {
+    const { owner: _owner, ...rest } = request;
+    assertEquals(
+      getHostedExecutorAllocationRequestSchema().safeParse({ ...rest, projectId: "legacy-project" })
+        .success,
+      false,
+    );
+    assertEquals(getHostedExecutorAllocationRequestSchema().safeParse(rest).success, false);
+  });
+
+  it("compares scope and identity and freezes captured source ownership", () => {
+    const owner: HostedExecutorOwner = { scopeKind: "global", serviceName: "platform-agent" };
+    const captured = readHostedExecutorBinding({ binding: { ...fullBinding, owner } });
+    owner.serviceName = "changed";
+    assert(Object.isFrozen(captured.owner));
+    assertEquals(captured.owner, { scopeKind: "global", serviceName: "platform-agent" });
+    assertEquals(
+      sameHostedExecutorBinding(captured, {
+        ...captured,
+        owner: { scopeKind: "project", projectId: "platform-agent" },
+      }),
+      false,
+    );
+    assertEquals(
+      sameHostedExecutorBinding(captured, {
+        ...captured,
+        owner: { scopeKind: "global", serviceName: "another-service" },
+      }),
+      false,
+    );
+  });
+
+  it("rejects a foreign release acknowledgement while keeping the original owner binding", async () => {
+    const f = fixture({
+      request: { ...request, owner: { scopeKind: "global", serviceName: "platform-agent" } },
+    });
+    f.allocator.release = (binding, reason) => {
+      assertEquals(binding.owner, { scopeKind: "global", serviceName: "platform-agent" });
+      return Promise.resolve({
+        binding: { ...binding, owner: { scopeKind: "project", projectId: "platform-agent" } },
+        phase: "released",
+        reason,
+        expiresAt: 2000,
+      });
+    };
+    const session = f.start();
+    await session.ready;
+    assertEquals((await session.close()).release, "reaper-required");
+    await session.settled;
+    await f.peerClosed();
+  });
+  it("accepts explicit global discovery ownership without a project", () => {
+    const parsed = getHostedExecutorAllocationRequestSchema().safeParse({
+      allocationId: request.allocationId,
+      invocationId: request.invocationId,
+      owner: { scopeKind: "global", serviceName: "platform-agent" },
+      source: request.source,
+      requestedAt: request.requestedAt,
+      prepareDeadlineAt: request.prepareDeadlineAt,
+      hardDeadlineAt: request.hardDeadlineAt,
+    });
+    assertEquals(parsed.success, true);
+  });
   it("anchors UTC deadlines to a monotonic elapsed clock", async () => {
     const time = new ManualMonotonicClock();
     time.advanceBy(50);
@@ -347,7 +469,7 @@ describe("hosted executor session", () => {
       "allocationId",
       "invocationId",
       "brokerInstanceId",
-      "projectId",
+      "owner",
       "source",
     ] as const
   ) {
@@ -355,6 +477,8 @@ describe("hosted executor session", () => {
       const f = fixture();
       const changed = field === "source"
         ? { type: "release", releaseId: "other-release" }
+        : field === "owner"
+        ? { scopeKind: "project", projectId: "other-project" }
         : field.endsWith("Id") && (field === "allocationId" || field === "invocationId")
         ? "33333333-3333-4333-8333-333333333333"
         : "other-identity";
@@ -390,7 +514,7 @@ describe("hosted executor session", () => {
     });
   }
 
-  for (const loss of ["policy", "lease", "pod", "generation", "image"] as const) {
+  for (const loss of ["policy", "lease", "pod", "generation", "image", "owner"] as const) {
     it(`revokes channel work on ${loss} loss and never reattaches`, async () => {
       const f = fixture();
       const session = f.start();
@@ -399,6 +523,12 @@ describe("hosted executor session", () => {
       if (loss === "lease") f.returned.expiresAt = 1000;
       if (loss === "pod") f.returned.endpoint!.podUid = "replacement-pod";
       if (loss === "generation") f.returned.binding = { ...fullBinding, generation: 8 };
+      if (loss === "owner") {
+        f.returned.binding = {
+          ...fullBinding,
+          owner: { scopeKind: "global", serviceName: "foreign-service" },
+        };
+      }
       if (loss === "image") {
         f.returned.endpoint!.image = `registry.example.test/executor@sha256:${"b".repeat(64)}`;
       }

--- a/src/agent/hosted/executor-session.test.ts
+++ b/src/agent/hosted/executor-session.test.ts
@@ -174,7 +174,7 @@ function fixture(overrides: Partial<HostedExecutorSessionOptions> = {}) {
 
 describe("hosted executor session", () => {
   it("owns a global metadata session without any application project", async () => {
-    const owner: HostedExecutorOwner = { scopeKind: "global", serviceName: "platform-agent" };
+    const owner: HostedExecutorOwner = { scopeKind: "global", serviceName: "@example/agent" };
     const f = fixture({ request: { ...request, owner } });
     const session = f.start();
     const channel = await session.ready;

--- a/src/agent/hosted/executor-session.ts
+++ b/src/agent/hosted/executor-session.ts
@@ -54,7 +54,7 @@ export interface HostedExecutorSessionOptions {
   request: HostedExecutorAllocationRequest;
   /** Authenticated broker Pod UID, independently known by the trusted caller. */
   expectedBrokerInstanceId: string;
-  /** Digest-pinned image independently resolved for request.source by the trusted caller. */
+  /** Digest-pinned image independently resolved for request.owner and source by the trusted caller. */
   expectedImage: string;
   allocator: HostedExecutorAllocatorClient;
   /** Authenticate one connection. Snapshot the allocation key before awaiting. */
@@ -175,7 +175,11 @@ class Session implements HostedExecutorSession {
       getHostedExecutorAllocationRequestSchema(),
       options.request,
     );
-    this.#request = Object.freeze({ ...request, source: Object.freeze(request.source) });
+    this.#request = Object.freeze({
+      ...request,
+      owner: Object.freeze(request.owner),
+      source: Object.freeze(request.source),
+    });
     this.#expectedBroker = options.expectedBrokerInstanceId;
     this.#expectedImage = parseHostedExecutorData(
       getHostedExecutorImageSchema(),
@@ -185,7 +189,7 @@ class Session implements HostedExecutorSession {
       allocationId: request.allocationId,
       invocationId: request.invocationId,
       generation: 1,
-      projectId: request.projectId,
+      owner: request.owner,
       source: request.source,
       brokerInstanceId: this.#expectedBroker,
     });
@@ -372,7 +376,7 @@ class Session implements HostedExecutorSession {
     const expected = this.#binding ?? {
       allocationId: this.#request.allocationId,
       invocationId: this.#request.invocationId,
-      projectId: this.#request.projectId,
+      owner: this.#request.owner,
       source: this.#request.source,
       brokerInstanceId: this.#expectedBroker,
       generation: binding.generation,


### PR DESCRIPTION
Bound the number of executor sessions a broker process can own, including preparation and unfinished cleanup. Capacity is reserved before invoking the session factory and released only when `session.settled` resolves.

Overload and shutdown reject new sessions without queuing. Shutdown revokes owners and closes sessions immediately, with separate bounded notification and full-retirement promises. Reentrant or throwing factories and late allocation results cannot bypass admission.

Validation: 17 pool scenarios, existing session/channel regressions, native Node tests, types, lint and formatting pass. Both required reviews found no remaining actionable defects.

Stacked on #4442. This internal component does not activate hosted executor routes; source ownership, concrete clients, preparation and deployment validation remain part of veryfront/veryfront-issue-inbox#1037.
