### PR TITLE
fix(proxy): settle WebSocket cleanup before close events

### DIFF
--- a/src/proxy/websocket-client.test.ts
+++ b/src/proxy/websocket-client.test.ts
@@ -124,6 +124,42 @@ function silentStream(cancel?: () => Promise<void>): {
 }
 
 describe("upstream WebSocket client", () => {
+  it("settles stream ownership when the open callback throws", async () => {
+    const cancelStarted = Promise.withResolvers<void>();
+    const canceled = Promise.withResolvers<void>();
+    const { stream } = silentStream(() => {
+      cancelStarted.resolve();
+      return canceled.promise;
+    });
+    const socket = new UpstreamWebSocket("ws://upstream.test/_ws", new Headers(), () => stream);
+    const errored = Promise.withResolvers<void>();
+    const closed = Promise.withResolvers<void>();
+    let closeCount = 0;
+    socket.onopen = () => {
+      throw new Error("synthetic open callback failure");
+    };
+    socket.onerror = () => errored.resolve();
+    socket.onclose = () => {
+      closeCount++;
+      closed.resolve();
+    };
+    try {
+      await errored.promise;
+      await cancelStarted.promise;
+      assertEquals(socket.readyState, WebSocket.CLOSING);
+      assertEquals(closeCount, 0);
+    } finally {
+      canceled.resolve();
+      stream.close();
+    }
+    await closed.promise;
+    const connection = await stream.opened;
+    assertEquals(socket.readyState, WebSocket.CLOSED);
+    assertEquals(connection.readable.locked, false);
+    assertEquals(connection.writable.locked, false);
+    assertEquals(closeCount, 1);
+  });
+
   it("waits for deferred reader cancellation before reporting close", async () => {
     const cancellationStarted = Promise.withResolvers<void>();
     const cancellationFinished = Promise.withResolvers<void>();

--- a/src/proxy/websocket-client.test.ts
+++ b/src/proxy/websocket-client.test.ts
@@ -24,7 +24,7 @@ function startUpstreamServer(options: { rejectWith?: number } = {}): UpstreamSer
   const seenHeaders = new Promise<Record<string, string | null>>((resolve) => {
     resolveHeaders = resolve;
   });
-  const sockets = new Set<WebSocket>();
+  const sockets = new Map<WebSocket, Promise<void>>();
 
   // Bind ephemerally (port 0) so parallel test modules never collide on a fixed
   // port, and to 127.0.0.1 to avoid IPv6 flakiness — same shape as the other
@@ -45,14 +45,18 @@ function startUpstreamServer(options: { rejectWith?: number } = {}): UpstreamSer
       }
       const { socket, response } = Deno.upgradeWebSocket(req);
       socket.binaryType = "arraybuffer";
-      sockets.add(socket);
+      const closed = Promise.withResolvers<void>();
+      sockets.set(socket, closed.promise);
       socket.onmessage = (event) => {
         if (socket.readyState !== WebSocket.OPEN) return;
         // Binary frames are echoed verbatim so the caller can check byte fidelity.
         if (typeof event.data === "string") socket.send(`echo:${event.data}`);
         else socket.send(event.data as ArrayBuffer);
       };
-      socket.onclose = () => sockets.delete(socket);
+      socket.onclose = () => {
+        sockets.delete(socket);
+        closed.resolve();
+      };
       return response;
     },
   );
@@ -63,11 +67,12 @@ function startUpstreamServer(options: { rejectWith?: number } = {}): UpstreamSer
     url: new URL(`ws://${addr.hostname}:${addr.port}/_ws`),
     seenHeaders,
     async close() {
-      for (const socket of sockets) {
+      const closedSockets = [...sockets.values()];
+      for (const socket of sockets.keys()) {
         if (socket.readyState === WebSocket.OPEN) socket.close();
       }
       controller.abort();
-      await server.finished;
+      await Promise.all([server.finished, ...closedSockets]);
     },
   };
 }
@@ -86,7 +91,7 @@ function identityHeaders(): Headers {
  * a real `WebSocketStream` does: it does not settle a read already awaiting the
  * next frame.
  */
-function silentStream(): {
+function silentStream(cancel?: () => Promise<void>): {
   stream: UpstreamWebSocketStream;
   readCancelled: () => boolean;
 } {
@@ -99,6 +104,7 @@ function silentStream(): {
   const readable = new ReadableStream<string | Uint8Array>({
     cancel() {
       cancelled = true;
+      return cancel?.();
     },
   });
 
@@ -118,6 +124,116 @@ function silentStream(): {
 }
 
 describe("upstream WebSocket client", () => {
+  it("waits for deferred reader cancellation before reporting close", async () => {
+    const cancellationStarted = Promise.withResolvers<void>();
+    const cancellationFinished = Promise.withResolvers<void>();
+    const { stream } = silentStream(() => {
+      cancellationStarted.resolve();
+      return cancellationFinished.promise;
+    });
+    const socket = new UpstreamWebSocket("ws://upstream.test/_ws", new Headers(), () => stream);
+    await new Promise<void>((resolve) => {
+      socket.onopen = () => resolve();
+    });
+    let closeCount = 0;
+    const closed = new Promise<void>((resolve) => {
+      socket.onclose = () => {
+        closeCount++;
+        resolve();
+      };
+    });
+    socket.close(1000, "done");
+    await cancellationStarted.promise;
+    try {
+      assertEquals(
+        closeCount,
+        0,
+        "close cannot claim completion before reader cancellation settles",
+      );
+    } finally {
+      cancellationFinished.resolve();
+      await closed;
+    }
+    assertEquals(closeCount, 1);
+    const connection = await stream.opened;
+    assertEquals(connection.readable.locked, false);
+    assertEquals(connection.writable.locked, false);
+  });
+
+  it("waits for cancellation of a late unopened connection before reporting close", async () => {
+    const opened = Promise.withResolvers<UpstreamWebSocketConnection>();
+    const closed = Promise.withResolvers<{ closeCode?: number; reason?: string }>();
+    const cancelStarted = Promise.withResolvers<void>();
+    const canceled = Promise.withResolvers<void>();
+    const socket = new UpstreamWebSocket("ws://upstream.test/_ws", new Headers(), () => ({
+      opened: opened.promise,
+      closed: closed.promise,
+      close() {
+        closed.resolve({ closeCode: 1000 });
+      },
+    }));
+    let openCount = 0;
+    let closeCount = 0;
+    socket.onopen = () => {
+      openCount++;
+    };
+    const closeEvent = new Promise<void>((resolve) => {
+      socket.onclose = () => {
+        closeCount++;
+        resolve();
+      };
+    });
+    socket.close();
+    opened.resolve({
+      readable: new ReadableStream<string | Uint8Array>({
+        cancel() {
+          cancelStarted.resolve();
+          return canceled.promise;
+        },
+      }),
+      writable: new WritableStream<string | Uint8Array>(),
+    });
+    await cancelStarted.promise;
+    try {
+      assertEquals(closeCount, 0);
+      assertEquals(openCount, 0);
+    } finally {
+      canceled.resolve();
+      await closeEvent;
+    }
+    assertEquals(closeCount, 1);
+  });
+
+  it("releases native loopback stream locks before each close event", async () => {
+    const server = startUpstreamServer();
+    const nativeFactory = resolveUpstreamWebSocketStreamFactory();
+    try {
+      for (let attempt = 0; attempt < 32; attempt++) {
+        let nativeStream: UpstreamWebSocketStream | undefined;
+        const socket = connectUpstreamWebSocket(server.url, new Headers(), (url, init) => {
+          nativeStream = nativeFactory(url, init);
+          return nativeStream;
+        });
+        await new Promise<void>((resolve) => {
+          socket.onopen = () => resolve();
+        });
+        const connection = await nativeStream!.opened;
+        let locksAtClose: boolean[] = [];
+        const closed = new Promise<void>((resolve) => {
+          socket.onclose = () => {
+            locksAtClose = [connection.readable.locked, connection.writable.locked];
+            resolve();
+          };
+        });
+        socket.close(1000, "done");
+        await closed;
+        assertEquals(locksAtClose, [false, false]);
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
   it("settles a pending read when the socket closes", async () => {
     // Regression guard for a leak that surfaced as an intermittent CI failure on
     // unrelated pull requests: closing left `read()` awaiting the next frame, so

--- a/src/proxy/websocket-client.ts
+++ b/src/proxy/websocket-client.ts
@@ -74,6 +74,8 @@ export class UpstreamWebSocket {
   #reader: ReadableStreamDefaultReader<string | Uint8Array> | null = null;
   #readyState: number = WebSocket.CONNECTING;
   #writes: Promise<void> = Promise.resolve();
+  #opening: Promise<void>;
+  #reading: Promise<void> = Promise.resolve();
   #settled = false;
 
   onopen: ((event: Event) => void) | null = null;
@@ -83,7 +85,7 @@ export class UpstreamWebSocket {
 
   constructor(url: URL | string, headers: Headers, factory: UpstreamWebSocketStreamFactory) {
     this.#stream = factory(url.toString(), { headers: [...headers] });
-    this.#stream.opened.then(
+    this.#opening = this.#stream.opened.then(
       (connection) => this.#open(connection),
       (error: unknown) => this.#fail(error),
     );
@@ -124,16 +126,16 @@ export class UpstreamWebSocket {
     }
   }
 
-  #open(connection: UpstreamWebSocketConnection): void {
+  async #open(connection: UpstreamWebSocketConnection): Promise<void> {
     if (this.#readyState !== WebSocket.CONNECTING) {
       // Closed while connecting; drop the connection we just inherited.
-      connection.readable.cancel().catch(() => {});
+      await connection.readable.cancel().catch(() => {});
       return;
     }
     this.#writer = connection.writable.getWriter();
     this.#readyState = WebSocket.OPEN;
     this.onopen?.(new Event("open"));
-    this.#pump(connection.readable);
+    this.#reading = this.#pump(connection.readable);
   }
 
   async #pump(readable: ReadableStream<string | Uint8Array>): Promise<void> {
@@ -157,18 +159,22 @@ export class UpstreamWebSocket {
     if (this.#settled) return;
     const message = error instanceof Error ? error.message : String(error);
     this.onerror?.(new ErrorEvent("error", { message }));
-    this.#close(1006, message, false);
+    void this.#close(1006, message, false);
   }
 
-  #close(code: number, reason: string, wasClean: boolean): void {
+  async #close(code: number, reason: string, wasClean: boolean): Promise<void> {
     if (this.#settled) return;
     this.#settled = true;
+    this.#readyState = WebSocket.CLOSING;
+    // A late opened connection owns cancellation too. Neither the close event
+    // nor reader.cancel() alone establishes that the receive pump has finished.
+    await this.#opening;
+    await this.#reader?.cancel().catch(() => {});
+    await this.#reading;
+    await this.#writes;
+    this.#writer?.releaseLock();
+    this.#writer = null;
     this.#readyState = WebSocket.CLOSED;
-    // Settle the read still pending on the socket. Closing the stream resolves
-    // `closed` and fires this handler, but it does not settle a `read()` that is
-    // already awaiting the next frame, so the operation would outlive the
-    // connection it belongs to.
-    this.#reader?.cancel().catch(() => {});
     this.onclose?.(new CloseEvent("close", { code, reason, wasClean }));
   }
 }

--- a/src/proxy/websocket-client.ts
+++ b/src/proxy/websocket-client.ts
@@ -88,7 +88,7 @@ export class UpstreamWebSocket {
     this.#opening = this.#stream.opened.then(
       (connection) => this.#open(connection),
       (error: unknown) => this.#fail(error),
-    );
+    ).catch((error: unknown) => this.#fail(error));
     this.#stream.closed.then(
       (info) => this.#close(info.closeCode ?? 1005, info.reason ?? "", true),
       (error: unknown) => this.#fail(error),
@@ -134,8 +134,11 @@ export class UpstreamWebSocket {
     }
     this.#writer = connection.writable.getWriter();
     this.#readyState = WebSocket.OPEN;
-    this.onopen?.(new Event("open"));
-    this.#reading = this.#pump(connection.readable);
+    try {
+      this.onopen?.(new Event("open"));
+    } finally {
+      this.#reading = this.#pump(connection.readable);
+    }
   }
 
   async #pump(readable: ReadableStream<string | Uint8Array>): Promise<void> {
@@ -168,7 +171,7 @@ export class UpstreamWebSocket {
     this.#readyState = WebSocket.CLOSING;
     // A late opened connection owns cancellation too. Neither the close event
     // nor reader.cancel() alone establishes that the receive pump has finished.
-    await this.#opening;
+    await this.#opening.catch(() => {});
     await this.#reader?.cancel().catch(() => {});
     await this.#reading;
     await this.#writes;


### PR DESCRIPTION
The upstream WebSocket client emitted `close` while reader cancellation and its receive pump were still running. Under CI coverage, the next-message operation could outlive the test and fail the leak check.

Join opening, cancellation, receive and queued-write cleanup, then release the writer before emitting one close event. The test server also waits for its owned upgraded sockets to close.

Callback failures also retain ownership: a throwing `onopen` now reports the error and completes original stream cancellation before emitting close. The new regression fails on the previous implementation and passes with the fix.

Validation: deterministic deferred-cancellation and late-opening regressions failed before the fix. Native Deno loopback tests verify both stream locks are released at the close callback; 51 proxy suites and 544 steps pass under parallel coverage with leak tracing. Focused tests on the current main base, types, formatting, generated-reference checks, and both required reviews pass.

Current-head validation additionally passes all 14 focused cases, type checks, lint, formatting and exact-head review. Review claimed a duplicate `closed` declaration; inspection found one declaration per block, confirmed by type checking, so no deletion was needed.
