### PR TITLE
feat(rendering): derive complete render generation identities

### DIFF
--- a/src/rendering/render-generation-binding.test.ts
+++ b/src/rendering/render-generation-binding.test.ts
@@ -1,5 +1,6 @@
 import "#veryfront/schemas/_test-setup.ts";
-import { assertEquals, assertNotEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { VeryfrontError } from "#veryfront/errors";
+import { assert, assertEquals, assertNotEquals, assertRejects } from "#veryfront/testing/assert.ts";
 import { describe, it } from "#veryfront/testing/bdd.ts";
 import { RenderGeneration } from "./render-generation.ts";
 import { RenderGenerationPool } from "./render-generation-pool.ts";
@@ -25,6 +26,7 @@ describe("render generation binding", () => {
     const first = await resolveRenderGenerationIdentity(binding());
     const second = await resolveRenderGenerationIdentity({ ...binding() });
     assertEquals(first, second);
+    // Changing the framing or hash domains requires a version bump and new vectors.
     assertEquals(first, {
       scopeId: "d1f4e59c809a7600f08cc9b738e04eda45b9b09b4189b0a1440d144cd8b27730",
       generationId: "c5f732ad26027ce9d6b5c276b1a7f638d68bf2f3b45c723db07d80153f8bbaeb",
@@ -71,24 +73,29 @@ describe("render generation binding", () => {
   it("rejects incomplete, extra, inherited, and invalid fields", async () => {
     for (const field of Object.keys(binding())) {
       for (const value of [undefined, null, "", 1, "x".repeat(1025), "\ud800"]) {
-        await assertRejects(
+        const error = await assertRejects(
           () =>
             resolveRenderGenerationIdentity(
               { ...binding(), [field]: value } as RenderGenerationBinding,
             ),
-          TypeError,
+          VeryfrontError,
           "Render generation binding",
         );
+        assert(error instanceof VeryfrontError);
+        assertEquals(error.slug, "invalid-argument");
+        assertEquals(error.status, 400);
       }
     }
     for (
       const value of [null, [], Object.create(binding()), { ...binding(), extra: "unsupported" }]
     ) {
-      await assertRejects(
+      const error = await assertRejects(
         () => resolveRenderGenerationIdentity(value as RenderGenerationBinding),
-        TypeError,
+        VeryfrontError,
         "Render generation binding",
       );
+      assert(error instanceof VeryfrontError);
+      assertEquals(error.slug, "invalid-argument");
     }
     await resolveRenderGenerationIdentity({ ...binding(), sourceSnapshotId: "x".repeat(1024) });
   });
@@ -109,11 +116,14 @@ describe("render generation binding", () => {
       },
     });
     for (const value of [accessor, proxy]) {
-      await assertRejects(
+      const error = await assertRejects(
         () => resolveRenderGenerationIdentity(value),
-        TypeError,
+        VeryfrontError,
         "Render generation binding",
       );
+      assert(error instanceof VeryfrontError);
+      assertEquals(error.slug, "invalid-argument");
+      assertEquals(error.status, 400);
     }
     assertEquals(hooks, 0);
   });

--- a/src/rendering/render-generation-binding.test.ts
+++ b/src/rendering/render-generation-binding.test.ts
@@ -1,0 +1,170 @@
+import "#veryfront/schemas/_test-setup.ts";
+import { assertEquals, assertNotEquals, assertRejects } from "#veryfront/testing/assert.ts";
+import { describe, it } from "#veryfront/testing/bdd.ts";
+import { RenderGeneration } from "./render-generation.ts";
+import { RenderGenerationPool } from "./render-generation-pool.ts";
+import {
+  type RenderGenerationBinding,
+  resolveRenderGenerationIdentity,
+} from "./render-generation-binding.ts";
+
+const binding = (): RenderGenerationBinding => ({
+  projectId: "project-one",
+  environmentId: "preview",
+  sourceSnapshotId: "source-one",
+  configurationId: "configuration-one",
+  dependencySnapshotId: "dependencies-one",
+  artifactId: "artifacts-one",
+  frameworkId: "framework-one",
+  runtimeId: "deno-test",
+  executionPolicyId: "policy-one",
+});
+
+describe("render generation binding", () => {
+  it("produces the same bounded frozen identity from independent copies", async () => {
+    const first = await resolveRenderGenerationIdentity(binding());
+    const second = await resolveRenderGenerationIdentity({ ...binding() });
+    assertEquals(first, second);
+    assertEquals(first, {
+      scopeId: "d1f4e59c809a7600f08cc9b738e04eda45b9b09b4189b0a1440d144cd8b27730",
+      generationId: "c5f732ad26027ce9d6b5c276b1a7f638d68bf2f3b45c723db07d80153f8bbaeb",
+    });
+    assertEquals(Object.isFrozen(first), true);
+    assertEquals(first.scopeId.length, 64);
+    assertEquals(first.generationId.length, 64);
+    assertEquals(JSON.stringify(first).includes("project-one"), false);
+  });
+
+  for (const field of Object.keys(binding()) as (keyof RenderGenerationBinding)[]) {
+    it(`does not reuse a generation when ${field} changes`, async () => {
+      const original = binding();
+      const first = await resolveRenderGenerationIdentity(original);
+      const changed = await resolveRenderGenerationIdentity({ ...original, [field]: "changed" });
+      assertNotEquals(first.generationId, changed.generationId);
+      assertEquals(
+        first.scopeId === changed.scopeId,
+        field !== "projectId" && field !== "environmentId",
+      );
+    });
+  }
+
+  it("snapshots every input before hashing yields", async () => {
+    const original = binding();
+    const pending = resolveRenderGenerationIdentity(original);
+    Object.assign(original, { sourceSnapshotId: "replacement", executionPolicyId: "replacement" });
+    assertEquals(await pending, await resolveRenderGenerationIdentity(binding()));
+  });
+
+  it("frames field boundaries and preserves Unicode without normalization", async () => {
+    const first = { ...binding(), projectId: "a", environmentId: "b:c" };
+    const second = { ...binding(), projectId: "a:b", environmentId: "c" };
+    assertNotEquals(
+      await resolveRenderGenerationIdentity(first),
+      await resolveRenderGenerationIdentity(second),
+    );
+    assertNotEquals(
+      await resolveRenderGenerationIdentity({ ...binding(), sourceSnapshotId: "é" }),
+      await resolveRenderGenerationIdentity({ ...binding(), sourceSnapshotId: "e\u0301" }),
+    );
+  });
+
+  it("rejects incomplete, extra, inherited, and invalid fields", async () => {
+    for (const field of Object.keys(binding())) {
+      for (const value of [undefined, null, "", 1, "x".repeat(1025), "\ud800"]) {
+        await assertRejects(
+          () =>
+            resolveRenderGenerationIdentity(
+              { ...binding(), [field]: value } as RenderGenerationBinding,
+            ),
+          TypeError,
+          "Render generation binding",
+        );
+      }
+    }
+    for (
+      const value of [null, [], Object.create(binding()), { ...binding(), extra: "unsupported" }]
+    ) {
+      await assertRejects(
+        () => resolveRenderGenerationIdentity(value as RenderGenerationBinding),
+        TypeError,
+        "Render generation binding",
+      );
+    }
+    await resolveRenderGenerationIdentity({ ...binding(), sourceSnapshotId: "x".repeat(1024) });
+  });
+
+  it("rejects accessors and proxies without executing their hooks", async () => {
+    let hooks = 0;
+    const accessor = {
+      ...binding(),
+      get sourceSnapshotId() {
+        hooks++;
+        return "source-one";
+      },
+    };
+    const proxy = new Proxy(binding(), {
+      getOwnPropertyDescriptor() {
+        hooks++;
+        throw new Error("hook");
+      },
+    });
+    for (const value of [accessor, proxy]) {
+      await assertRejects(
+        () => resolveRenderGenerationIdentity(value),
+        TypeError,
+        "Render generation binding",
+      );
+    }
+    assertEquals(hooks, 0);
+  });
+
+  it("reuses exact bindings locally while separate replicas retain independent owners", async () => {
+    const pools = [0, 1].map(() =>
+      new RenderGenerationPool({ maxGenerations: 2, maxConcurrentRenders: 1 })
+    );
+    const created = [0, 0];
+    const oldIdentity = await resolveRenderGenerationIdentity(binding());
+    const newIdentity = await resolveRenderGenerationIdentity({
+      ...binding(),
+      configurationId: "configuration-two",
+    });
+    const request = () => new Request("http://localhost/page");
+    const create = (replica: number, text: string) => () => {
+      created[replica]!++;
+      return new RenderGeneration({
+        executor: { render: async () => new Response(text), stop: async () => {} },
+        releaseArtifacts: async () => {},
+        maxConcurrentRenders: 1,
+        drainTimeoutMs: 0,
+      });
+    };
+    try {
+      for (const [replica, pool] of pools.entries()) {
+        assertEquals(
+          await (await pool.render(request(), oldIdentity, create(replica, "old"))).text(),
+          "old",
+        );
+        assertEquals(
+          await (await pool.render(
+            request(),
+            await resolveRenderGenerationIdentity(binding()),
+            create(replica, "unexpected"),
+          )).text(),
+          "old",
+        );
+      }
+      assertEquals(
+        await (await pools[0]!.render(request(), newIdentity, create(0, "new"))).text(),
+        "new",
+      );
+      await pools[0]!.retire(oldIdentity);
+      assertEquals(
+        await (await pools[1]!.render(request(), oldIdentity, create(1, "unexpected"))).text(),
+        "old",
+      );
+      assertEquals(created, [2, 1]);
+    } finally {
+      await Promise.all(pools.map((pool) => pool.close()));
+    }
+  });
+});

--- a/src/rendering/render-generation-binding.ts
+++ b/src/rendering/render-generation-binding.ts
@@ -1,0 +1,83 @@
+import {
+  canIdentifyProxyWithoutHooks,
+  isProxyWithoutHooks,
+} from "#veryfront/platform/compat/error-introspection.ts";
+import type { WorkerGenerationIdentity } from "#veryfront/security/sandbox/worker-generation.ts";
+import { computeHash } from "#veryfront/utils/hash-utils.ts";
+import { isWellFormedString } from "#veryfront/utils/is-well-formed-string.ts";
+
+/** Host-owned immutable input identities, never credentials or mutable branch aliases. */
+export interface RenderGenerationBinding {
+  readonly projectId: string;
+  readonly environmentId: string;
+  /** Covers the complete source view, including routes and client assets. */
+  readonly sourceSnapshotId: string;
+  /** Covers resolved configuration and environment values without exposing them. */
+  readonly configurationId: string;
+  readonly dependencySnapshotId: string;
+  /** Content identity of the prepared graph, never its replica-local directory. */
+  readonly artifactId: string;
+  /** Exact framework build, including its release identity. */
+  readonly frameworkId: string;
+  /** Exact runtime build and native package/asset bindings. */
+  readonly runtimeId: string;
+  /** Filesystem, network, resource and process-lifetime policy revision. */
+  readonly executionPolicyId: string;
+}
+
+const freeze = Object.freeze;
+const ownKeys = Reflect.ownKeys;
+const getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const hasOwn = Object.hasOwn;
+const fields = freeze(
+  [
+    "projectId",
+    "environmentId",
+    "sourceSnapshotId",
+    "configurationId",
+    "dependencySnapshotId",
+    "artifactId",
+    "frameworkId",
+    "runtimeId",
+    "executionPolicyId",
+  ] as const,
+);
+
+/**
+ * Derive the existing render pool identity from a complete host binding.
+ * Every field must be an own data property containing 1 to 1024 well-formed
+ * UTF-16 code units. All fields are captured before asynchronous hashing.
+ * Field order, framing and hash domains are versioned and replica-independent.
+ *
+ * The trusted caller must first authorize the project/environment and capture
+ * the actual immutable inputs named here. This checks their identity shape,
+ * not their contents, permissions, or isolation. It issues no execution grant.
+ * Standalone hosts use their own project/environment identities; no Cloud
+ * service, shared local path, process ID, or request data enters these keys.
+ */
+export async function resolveRenderGenerationIdentity(
+  binding: RenderGenerationBinding,
+): Promise<Readonly<WorkerGenerationIdentity>> {
+  if (
+    !canIdentifyProxyWithoutHooks || binding === null || typeof binding !== "object" ||
+    isProxyWithoutHooks(binding) || ownKeys(binding).length !== fields.length
+  ) throw new TypeError("Render generation binding requires exactly its non-proxy data fields");
+
+  let scope = "veryfront-render-scope:v1:";
+  let generation = "veryfront-render-generation:v1:";
+  for (let index = 0; index < fields.length; index++) {
+    const descriptor = getOwnPropertyDescriptor(binding, fields[index]!);
+    if (!descriptor || !hasOwn(descriptor, "value")) {
+      throw new TypeError("Render generation binding fields must be own data properties");
+    }
+    const value: unknown = descriptor.value;
+    if (
+      typeof value !== "string" || value.length < 1 || value.length > 1024 ||
+      !isWellFormedString(value)
+    ) throw new TypeError("Render generation binding fields must be bounded non-empty text");
+    const framed = `${value.length}:${value}`;
+    if (index < 2) scope += framed;
+    generation += framed;
+  }
+  return freeze({ scopeId: await computeHash(scope), generationId: await computeHash(generation) });
+}

--- a/src/rendering/render-generation-binding.ts
+++ b/src/rendering/render-generation-binding.ts
@@ -3,6 +3,7 @@ import {
   isProxyWithoutHooks,
 } from "#veryfront/platform/compat/error-introspection.ts";
 import type { WorkerGenerationIdentity } from "#veryfront/security/sandbox/worker-generation.ts";
+import { INVALID_ARGUMENT } from "#veryfront/errors";
 import { computeHash } from "#veryfront/utils/hash-utils.ts";
 import { isWellFormedString } from "#veryfront/utils/is-well-formed-string.ts";
 
@@ -48,6 +49,8 @@ const fields = freeze(
  * Every field must be an own data property containing 1 to 1024 well-formed
  * UTF-16 code units. All fields are captured before asynchronous hashing.
  * Field order, framing and hash domains are versioned and replica-independent.
+ * Native proxy detection is required, as provided by Deno, Node and Bun.
+ * Unsupported hosts reject binding validation without inspecting its fields.
  *
  * The trusted caller must first authorize the project/environment and capture
  * the actual immutable inputs named here. This checks their identity shape,
@@ -61,20 +64,30 @@ export async function resolveRenderGenerationIdentity(
   if (
     !canIdentifyProxyWithoutHooks || binding === null || typeof binding !== "object" ||
     isProxyWithoutHooks(binding) || ownKeys(binding).length !== fields.length
-  ) throw new TypeError("Render generation binding requires exactly its non-proxy data fields");
+  ) {
+    throw INVALID_ARGUMENT.create({
+      detail: "Render generation binding requires exactly its non-proxy data fields",
+    });
+  }
 
   let scope = "veryfront-render-scope:v1:";
   let generation = "veryfront-render-generation:v1:";
   for (let index = 0; index < fields.length; index++) {
     const descriptor = getOwnPropertyDescriptor(binding, fields[index]!);
     if (!descriptor || !hasOwn(descriptor, "value")) {
-      throw new TypeError("Render generation binding fields must be own data properties");
+      throw INVALID_ARGUMENT.create({
+        detail: "Render generation binding fields must be own data properties",
+      });
     }
     const value: unknown = descriptor.value;
     if (
       typeof value !== "string" || value.length < 1 || value.length > 1024 ||
       !isWellFormedString(value)
-    ) throw new TypeError("Render generation binding fields must be bounded non-empty text");
+    ) {
+      throw INVALID_ARGUMENT.create({
+        detail: "Render generation binding fields must be bounded non-empty text",
+      });
+    }
     const framed = `${value.length}:${value}`;
     if (index < 2) scope += framed;
     generation += framed;


### PR DESCRIPTION
## Summary

First bounded prerequisite for https://github.com/veryfront/veryfront-issue-inbox/issues/1035.

- Add an internal renderer-owned constructor for the existing `WorkerGenerationIdentity` used by `RenderGenerationPool`.
- Bind project/environment, complete source snapshot, resolved configuration, dependency snapshot, prepared artifacts, exact framework/runtime build, and execution policy into a versioned SHA-256 identity.
- Validate bounded own data fields without invoking getters or proxy traps and capture all fields before asynchronous hashing. Rejections use the existing registered `invalid-argument` error.
- Keep the pool and its lifecycle unchanged. No public export, new dependency, grant issuer, allocator, deployment flag, or production dispatch is added.

The trusted caller must authorize the scope and capture the actual immutable inputs. These identifiers are not proof of content or authority, and the digest is not an execution grant or a sandbox. Source identity includes routes and client assets; runtime identity includes native package/asset bindings. Replica-local artifact paths never enter the keys.

## Verification

- 53 focused binding/pool/generation tests pass on Deno, Node and Bun, including a fixed shared identity vector.
- Colocated tests cover each field's effect, invalid/missing/extra/inherited fields, Unicode and framing, accessor/proxy rejection, mutation during hashing, local pool reuse and independent replica-local owners.
- The unchanged native process integration test for old/new generation overlap and independent replica cleanup passes.
- Explicit Deno typecheck and focused lint/format checks pass.
- `deno task lint:ci` and `deno task fmt:check` pass, including test classification/typecheck and generated-reference checks.
- `codex review --uncommitted` and `codex review --base origin/main` completed without actionable findings for head `e0818828085707ab595449dd073df8a16a68924b`. The updated branch review passed 95 focused and related steps, plus type/lint/format/diff checks.

## Remaining work

This does not select a generation in production, mint a renderer grant, install an executor, or fix Cloud hydration end to end. Trusted input capture, credentials outside project execution, native packages, authenticated bootstrap/dispatch, and strict cold-replica/rolling-replacement verification remain in #1035/#1042. Existing agent-executor allocation and channel work stays separate and must be reused where appropriate.

No Cloud activation or production promotion is part of this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added deterministic render-generation identity resolution based on validated project, environment, configuration, runtime, and execution details.
  - Render identities are consistently reused when inputs match, while changes to relevant inputs produce distinct identities.
  - Invalid, malformed, or unsafe binding values are rejected with clear validation errors.
  - Identity handling supports Unicode and delimiter-containing values reliably across replicas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
