### PR TITLE
fix(proxy): retire legacy managed agent routes

### DIFF
--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -802,7 +802,10 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     }
 
     const internalRouteKind = classifyInternalControlPlaneRequest(req.method, routePolicyPathname);
-    if (internalRouteKind === "reserved") {
+    if (
+      internalRouteKind === "reserved" ||
+      (internalRouteKind !== "public" && routePolicyPathname !== url.pathname)
+    ) {
       return createProxyErrorContext(base, { status: 404, message: "Not found" });
     }
 

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -42,7 +42,10 @@ import {
 import { resolveProxyRequestAuthority, resolveProxyRequestHost } from "./request-host.ts";
 import { createProxyEndToEndHeaders } from "./hop-by-hop-headers.ts";
 import { withProxyStreamingBodyDuplex } from "./request-init.ts";
-import { isLegacyManagedAgentRoute } from "./legacy-managed-agent-route-denial.ts";
+import {
+  isLegacyManagedAgentRoute,
+  normalizeProxyRoutePolicyPathname,
+} from "./legacy-managed-agent-route-denial.ts";
 
 export const INTERNAL_PROXY_HEADERS = [
   "x-token",
@@ -790,12 +793,15 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     const parsedDomain = parseProjectDomain(host);
     const scope = getScope(parsedDomain.environment);
     const base = { scope, host, requestAuthority, parsedDomain };
+    const routePolicyPathname = normalizeProxyRoutePolicyPathname(url.pathname);
 
-    if (denyLegacyManagedAgentRoutes && isLegacyManagedAgentRoute(req.method, url.pathname)) {
+    if (
+      denyLegacyManagedAgentRoutes && isLegacyManagedAgentRoute(req.method, routePolicyPathname)
+    ) {
       return createProxyErrorContext(base, { status: 404, message: "Not found" });
     }
 
-    const internalRouteKind = classifyInternalControlPlaneRequest(req.method, url.pathname);
+    const internalRouteKind = classifyInternalControlPlaneRequest(req.method, routePolicyPathname);
     if (internalRouteKind === "reserved") {
       return createProxyErrorContext(base, { status: 404, message: "Not found" });
     }

--- a/src/proxy/handler.ts
+++ b/src/proxy/handler.ts
@@ -42,6 +42,7 @@ import {
 import { resolveProxyRequestAuthority, resolveProxyRequestHost } from "./request-host.ts";
 import { createProxyEndToEndHeaders } from "./hop-by-hop-headers.ts";
 import { withProxyStreamingBodyDuplex } from "./request-init.ts";
+import { isLegacyManagedAgentRoute } from "./legacy-managed-agent-route-denial.ts";
 
 export const INTERNAL_PROXY_HEADERS = [
   "x-token",
@@ -111,6 +112,7 @@ export interface ProxyConfig {
   previewApiClientSecret: string;
   apiToken?: string;
   localProjects?: Record<string, string>;
+  denyLegacyManagedAgentRoutes?: boolean;
 }
 
 export interface ProxyContext {
@@ -233,6 +235,13 @@ async function awaitForRequest<T>(
 
 export function createProxyHandler(options: ProxyHandlerOptions) {
   const { config, cache, logger } = options;
+  if (
+    config.denyLegacyManagedAgentRoutes !== undefined &&
+    typeof config.denyLegacyManagedAgentRoutes !== "boolean"
+  ) {
+    throw new TypeError("denyLegacyManagedAgentRoutes must be a boolean");
+  }
+  const denyLegacyManagedAgentRoutes = config.denyLegacyManagedAgentRoutes ?? false;
   const routingCacheTtlMs = readBoundedNonNegativeIntegerEnv(
     "VERYFRONT_PROXY_ROUTING_CACHE_TTL_MS",
     DEFAULT_PROXY_ROUTING_CACHE_TTL_MS,
@@ -781,6 +790,10 @@ export function createProxyHandler(options: ProxyHandlerOptions) {
     const parsedDomain = parseProjectDomain(host);
     const scope = getScope(parsedDomain.environment);
     const base = { scope, host, requestAuthority, parsedDomain };
+
+    if (denyLegacyManagedAgentRoutes && isLegacyManagedAgentRoute(req.method, url.pathname)) {
+      return createProxyErrorContext(base, { status: 404, message: "Not found" });
+    }
 
     const internalRouteKind = classifyInternalControlPlaneRequest(req.method, url.pathname);
     if (internalRouteKind === "reserved") {

--- a/src/proxy/legacy-managed-agent-route-denial.handler.test.ts
+++ b/src/proxy/legacy-managed-agent-route-denial.handler.test.ts
@@ -91,17 +91,24 @@ describe("proxy legacy managed agent route denial", () => {
         throw new Error("reserved route reached metadata lookup");
       },
     });
-    const request = new Request(
-      "https://project.preview.veryfront.com//api//control-plane/application-route/",
-      { method: "POST", body: "synthetic-body-marker" },
-    );
-
     try {
-      const context = await handler.processRequest(request);
-      assertEquals(context.error?.status, 404);
-      assertEquals(context.error?.message, "Not found");
+      for (
+        const path of [
+          "//api//control-plane/application-route/",
+          "/api/control-plane/runs/run_1/stream/",
+          "/channels/invoke/",
+        ]
+      ) {
+        const request = new Request(`https://project.preview.veryfront.com${path}`, {
+          method: "POST",
+          body: "synthetic-body-marker",
+        });
+        const context = await handler.processRequest(request);
+        assertEquals(context.error?.status, 404, path);
+        assertEquals(context.error?.message, "Not found", path);
+        assertEquals(request.bodyUsed, false, path);
+      }
       assertEquals(metadataRequests, 0);
-      assertEquals(request.bodyUsed, false);
     } finally {
       await handler.close();
     }

--- a/src/proxy/legacy-managed-agent-route-denial.handler.test.ts
+++ b/src/proxy/legacy-managed-agent-route-denial.handler.test.ts
@@ -32,6 +32,10 @@ describe("proxy legacy managed agent route denial", () => {
       ["DELETE", "/api/control-plane/runs/run_1"],
       ["POST", "//api/ag-ui"],
       ["POST", "///api/runs"],
+      ["POST", "/api/ag-ui/"],
+      ["POST", "/api//ag-ui"],
+      ["POST", "/api/runs//run_1//resume/"],
+      ["DELETE", "/api//control-plane/runs/run_1/"],
     ] as const;
     const hosts = [
       "project.preview.veryfront.com",
@@ -73,6 +77,31 @@ describe("proxy legacy managed agent route denial", () => {
         new Request("http://localhost/api/runs", { method: "POST" }),
       );
       assertEquals(context.error, undefined);
+    } finally {
+      await handler.close();
+    }
+  });
+
+  it("keeps renderer-equivalent internal namespace aliases reserved", async () => {
+    let metadataRequests = 0;
+    const handler = createProxyHandler({
+      config: BASE_CONFIG,
+      metadataFetch: () => {
+        metadataRequests++;
+        throw new Error("reserved route reached metadata lookup");
+      },
+    });
+    const request = new Request(
+      "https://project.preview.veryfront.com//api//control-plane/application-route/",
+      { method: "POST", body: "synthetic-body-marker" },
+    );
+
+    try {
+      const context = await handler.processRequest(request);
+      assertEquals(context.error?.status, 404);
+      assertEquals(context.error?.message, "Not found");
+      assertEquals(metadataRequests, 0);
+      assertEquals(request.bodyUsed, false);
     } finally {
       await handler.close();
     }

--- a/src/proxy/legacy-managed-agent-route-denial.handler.test.ts
+++ b/src/proxy/legacy-managed-agent-route-denial.handler.test.ts
@@ -1,4 +1,5 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals } from "#veryfront/testing/assert";
+import { describe, it } from "#veryfront/testing/bdd";
 import { createProxyHandler, type ProxyConfig } from "./handler.ts";
 
 const BASE_CONFIG: ProxyConfig = {
@@ -9,69 +10,71 @@ const BASE_CONFIG: ProxyConfig = {
   previewApiClientSecret: "secret",
 };
 
-Deno.test("enabled legacy managed agent denial returns before lookup and leaves request bodies unread", async () => {
-  let metadataRequests = 0;
-  const handler = createProxyHandler({
-    config: { ...BASE_CONFIG, denyLegacyManagedAgentRoutes: true },
-    metadataFetch: () => {
-      metadataRequests++;
-      throw new Error("legacy managed route reached metadata lookup");
-    },
-  });
-  const routes = [
-    ["POST", "/api/ag-ui"],
-    ["POST", "/api/runs"],
-    ["POST", "/api/runs/run_1/resume"],
-    ["DELETE", "/api/runs/run_1"],
-    ["POST", "/api/control-plane/agents/list"],
-    ["POST", "/api/control-plane/runs/run_1/execute"],
-    ["POST", "/api/control-plane/runs/run_1/stream"],
-    ["POST", "/api/control-plane/runs/run_1/resume"],
-    ["DELETE", "/api/control-plane/runs/run_1"],
-    ["POST", "//api/ag-ui"],
-    ["POST", "///api/runs"],
-  ] as const;
-  const hosts = [
-    "project.preview.veryfront.com",
-    "project.production.veryfront.com",
-    "project.example.test",
-  ] as const;
+describe("proxy legacy managed agent route denial", () => {
+  it("returns before lookup and leaves request bodies unread when enabled", async () => {
+    let metadataRequests = 0;
+    const handler = createProxyHandler({
+      config: { ...BASE_CONFIG, denyLegacyManagedAgentRoutes: true },
+      metadataFetch: () => {
+        metadataRequests++;
+        throw new Error("legacy managed route reached metadata lookup");
+      },
+    });
+    const routes = [
+      ["POST", "/api/ag-ui"],
+      ["POST", "/api/runs"],
+      ["POST", "/api/runs/run_1/resume"],
+      ["DELETE", "/api/runs/run_1"],
+      ["POST", "/api/control-plane/agents/list"],
+      ["POST", "/api/control-plane/runs/run_1/execute"],
+      ["POST", "/api/control-plane/runs/run_1/stream"],
+      ["POST", "/api/control-plane/runs/run_1/resume"],
+      ["DELETE", "/api/control-plane/runs/run_1"],
+      ["POST", "//api/ag-ui"],
+      ["POST", "///api/runs"],
+    ] as const;
+    const hosts = [
+      "project.preview.veryfront.com",
+      "project.production.veryfront.com",
+      "project.example.test",
+    ] as const;
 
-  try {
-    for (const host of hosts) {
-      for (const [method, path] of routes) {
-        const request = new Request(`https://${host}${path}`, {
-          method,
-          headers: {
-            authorization: "Bearer synthetic-control-plane-token",
-            "content-type": "application/json",
-            "x-token": "synthetic-platform-token",
-            "x-veryfront-control-plane-jws": "malformed",
-          },
-          body: method === "POST" ? JSON.stringify({ synthetic: "body-marker" }) : undefined,
-        });
+    try {
+      for (const host of hosts) {
+        for (const [method, path] of routes) {
+          const request = new Request(`https://${host}${path}`, {
+            method,
+            headers: {
+              authorization: "Bearer synthetic-control-plane-token",
+              "content-type": "application/json",
+              "x-token": "synthetic-platform-token",
+              "x-veryfront-control-plane-jws": "malformed",
+            },
+            body: method === "POST" ? JSON.stringify({ synthetic: "body-marker" }) : undefined,
+          });
 
-        const context = await handler.processRequest(request);
+          const context = await handler.processRequest(request);
 
-        assertEquals(context.error?.status, 404, `${method} ${host}${path}`);
-        assertEquals(context.error?.message, "Not found", `${method} ${host}${path}`);
-        assertEquals(request.bodyUsed, false, `${method} ${host}${path}`);
+          assertEquals(context.error?.status, 404, `${method} ${host}${path}`);
+          assertEquals(context.error?.message, "Not found", `${method} ${host}${path}`);
+          assertEquals(request.bodyUsed, false, `${method} ${host}${path}`);
+        }
       }
+      assertEquals(metadataRequests, 0);
+    } finally {
+      await handler.close();
     }
-    assertEquals(metadataRequests, 0);
-  } finally {
-    await handler.close();
-  }
-});
+  });
 
-Deno.test("legacy managed agent denial remains dormant when omitted", async () => {
-  const handler = createProxyHandler({ config: BASE_CONFIG });
-  try {
-    const context = await handler.processRequest(
-      new Request("http://localhost/api/runs", { method: "POST" }),
-    );
-    assertEquals(context.error, undefined);
-  } finally {
-    await handler.close();
-  }
+  it("remains dormant when omitted", async () => {
+    const handler = createProxyHandler({ config: BASE_CONFIG });
+    try {
+      const context = await handler.processRequest(
+        new Request("http://localhost/api/runs", { method: "POST" }),
+      );
+      assertEquals(context.error, undefined);
+    } finally {
+      await handler.close();
+    }
+  });
 });

--- a/src/proxy/legacy-managed-agent-route-denial.handler.test.ts
+++ b/src/proxy/legacy-managed-agent-route-denial.handler.test.ts
@@ -28,6 +28,8 @@ Deno.test("enabled legacy managed agent denial returns before lookup and leaves 
     ["POST", "/api/control-plane/runs/run_1/stream"],
     ["POST", "/api/control-plane/runs/run_1/resume"],
     ["DELETE", "/api/control-plane/runs/run_1"],
+    ["POST", "//api/ag-ui"],
+    ["POST", "///api/runs"],
   ] as const;
   const hosts = [
     "project.preview.veryfront.com",

--- a/src/proxy/legacy-managed-agent-route-denial.handler.test.ts
+++ b/src/proxy/legacy-managed-agent-route-denial.handler.test.ts
@@ -1,0 +1,75 @@
+import { assertEquals } from "@std/assert";
+import { createProxyHandler, type ProxyConfig } from "./handler.ts";
+
+const BASE_CONFIG: ProxyConfig = {
+  apiBaseUrl: "https://api.example.test",
+  apiClientId: "client",
+  apiClientSecret: "secret",
+  previewApiClientId: "client",
+  previewApiClientSecret: "secret",
+};
+
+Deno.test("enabled legacy managed agent denial returns before lookup and leaves request bodies unread", async () => {
+  let metadataRequests = 0;
+  const handler = createProxyHandler({
+    config: { ...BASE_CONFIG, denyLegacyManagedAgentRoutes: true },
+    metadataFetch: () => {
+      metadataRequests++;
+      throw new Error("legacy managed route reached metadata lookup");
+    },
+  });
+  const routes = [
+    ["POST", "/api/ag-ui"],
+    ["POST", "/api/runs"],
+    ["POST", "/api/runs/run_1/resume"],
+    ["DELETE", "/api/runs/run_1"],
+    ["POST", "/api/control-plane/agents/list"],
+    ["POST", "/api/control-plane/runs/run_1/execute"],
+    ["POST", "/api/control-plane/runs/run_1/stream"],
+    ["POST", "/api/control-plane/runs/run_1/resume"],
+    ["DELETE", "/api/control-plane/runs/run_1"],
+  ] as const;
+  const hosts = [
+    "project.preview.veryfront.com",
+    "project.production.veryfront.com",
+    "project.example.test",
+  ] as const;
+
+  try {
+    for (const host of hosts) {
+      for (const [method, path] of routes) {
+        const request = new Request(`https://${host}${path}`, {
+          method,
+          headers: {
+            authorization: "Bearer synthetic-control-plane-token",
+            "content-type": "application/json",
+            "x-token": "synthetic-platform-token",
+            "x-veryfront-control-plane-jws": "malformed",
+          },
+          body: method === "POST" ? JSON.stringify({ synthetic: "body-marker" }) : undefined,
+        });
+
+        const context = await handler.processRequest(request);
+
+        assertEquals(context.error?.status, 404, `${method} ${host}${path}`);
+        assertEquals(context.error?.message, "Not found", `${method} ${host}${path}`);
+        assertEquals(request.bodyUsed, false, `${method} ${host}${path}`);
+      }
+    }
+    assertEquals(metadataRequests, 0);
+  } finally {
+    await handler.close();
+  }
+});
+
+Deno.test("legacy managed agent denial remains dormant when omitted", async () => {
+  const handler = createProxyHandler({ config: BASE_CONFIG });
+  try {
+    const context = await handler.processRequest(
+      new Request("http://localhost/api/runs", { method: "POST" }),
+    );
+    assertEquals(context.error, undefined);
+  } finally {
+    await handler.close();
+  }
+});

--- a/src/proxy/legacy-managed-agent-route-denial.test.ts
+++ b/src/proxy/legacy-managed-agent-route-denial.test.ts
@@ -1,0 +1,49 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  isLegacyManagedAgentRoute,
+  parseLegacyManagedAgentRouteDeny,
+} from "./legacy-managed-agent-route-denial.ts";
+
+Deno.test("legacy managed agent route denial configuration is dormant by default and strict when set", () => {
+  assertEquals(parseLegacyManagedAgentRouteDeny(undefined), false);
+  assertEquals(parseLegacyManagedAgentRouteDeny(""), false);
+  assertEquals(parseLegacyManagedAgentRouteDeny("false"), false);
+  assertEquals(parseLegacyManagedAgentRouteDeny("true"), true);
+  assertThrows(
+    () => parseLegacyManagedAgentRouteDeny("TRUE"),
+    TypeError,
+    "must be exactly true or false",
+  );
+});
+
+Deno.test("legacy managed agent route denial matches only registered managed route shapes", () => {
+  const managedRoutes = [
+    ["POST", "/api/ag-ui"],
+    ["POST", "/api/runs"],
+    ["POST", "/api/runs/run_1/resume"],
+    ["DELETE", "/api/runs/run_1"],
+    ["POST", "/api/control-plane/agents/list"],
+    ["POST", "/api/control-plane/runs/run_1/execute"],
+    ["POST", "/api/control-plane/runs/run_1/stream"],
+    ["POST", "/api/control-plane/runs/run_1/resume"],
+    ["DELETE", "/api/control-plane/runs/run_1"],
+  ] as const;
+
+  for (const [method, pathname] of managedRoutes) {
+    assertEquals(isLegacyManagedAgentRoute(method, pathname), true, `${method} ${pathname}`);
+  }
+
+  const applicationRoutes = [
+    ["GET", "/api/ag-ui"],
+    ["GET", "/api/runs"],
+    ["POST", "/api/runs/run_1"],
+    ["POST", "/api/runs/run_1/resume/extra"],
+    ["DELETE", "/api/runs/run_1/extra"],
+    ["POST", "/api/control-plane/application-route"],
+    ["GET", "/api/control-plane/runs/run_1/stream"],
+  ] as const;
+
+  for (const [method, pathname] of applicationRoutes) {
+    assertEquals(isLegacyManagedAgentRoute(method, pathname), false, `${method} ${pathname}`);
+  }
+});

--- a/src/proxy/legacy-managed-agent-route-denial.test.ts
+++ b/src/proxy/legacy-managed-agent-route-denial.test.ts
@@ -27,6 +27,10 @@ Deno.test("legacy managed agent route denial matches only registered managed rou
     ["POST", "/api/control-plane/runs/run_1/stream"],
     ["POST", "/api/control-plane/runs/run_1/resume"],
     ["DELETE", "/api/control-plane/runs/run_1"],
+    ["POST", "//api/ag-ui"],
+    ["POST", "///api/runs"],
+    ["POST", "//api/runs/run_1/resume"],
+    ["DELETE", "//api/control-plane/runs/run_1"],
   ] as const;
 
   for (const [method, pathname] of managedRoutes) {

--- a/src/proxy/legacy-managed-agent-route-denial.test.ts
+++ b/src/proxy/legacy-managed-agent-route-denial.test.ts
@@ -33,6 +33,11 @@ describe("legacy managed agent route denial", () => {
       ["POST", "///api/runs"],
       ["POST", "//api/runs/run_1/resume"],
       ["DELETE", "//api/control-plane/runs/run_1"],
+      ["POST", "/api/ag-ui/"],
+      ["POST", "/api//ag-ui"],
+      ["POST", "/api///runs/"],
+      ["POST", "/api/runs//run_1//resume/"],
+      ["DELETE", "/api//control-plane/runs/run_1/"],
     ] as const;
 
     for (const [method, pathname] of managedRoutes) {
@@ -47,6 +52,7 @@ describe("legacy managed agent route denial", () => {
       ["DELETE", "/api/runs/run_1/extra"],
       ["POST", "/api/control-plane/application-route"],
       ["GET", "/api/control-plane/runs/run_1/stream"],
+      ["POST", "/api/ag-ui/extra"],
     ] as const;
 
     for (const [method, pathname] of applicationRoutes) {

--- a/src/proxy/legacy-managed-agent-route-denial.test.ts
+++ b/src/proxy/legacy-managed-agent-route-denial.test.ts
@@ -1,53 +1,56 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertThrows } from "#veryfront/testing/assert";
+import { describe, it } from "#veryfront/testing/bdd";
 import {
   isLegacyManagedAgentRoute,
   parseLegacyManagedAgentRouteDeny,
 } from "./legacy-managed-agent-route-denial.ts";
 
-Deno.test("legacy managed agent route denial configuration is dormant by default and strict when set", () => {
-  assertEquals(parseLegacyManagedAgentRouteDeny(undefined), false);
-  assertEquals(parseLegacyManagedAgentRouteDeny(""), false);
-  assertEquals(parseLegacyManagedAgentRouteDeny("false"), false);
-  assertEquals(parseLegacyManagedAgentRouteDeny("true"), true);
-  assertThrows(
-    () => parseLegacyManagedAgentRouteDeny("TRUE"),
-    TypeError,
-    "must be exactly true or false",
-  );
-});
+describe("legacy managed agent route denial", () => {
+  it("is dormant by default and strict when configured", () => {
+    assertEquals(parseLegacyManagedAgentRouteDeny(undefined), false);
+    assertEquals(parseLegacyManagedAgentRouteDeny(""), false);
+    assertEquals(parseLegacyManagedAgentRouteDeny("false"), false);
+    assertEquals(parseLegacyManagedAgentRouteDeny("true"), true);
+    assertThrows(
+      () => parseLegacyManagedAgentRouteDeny("TRUE"),
+      TypeError,
+      "must be exactly true or false",
+    );
+  });
 
-Deno.test("legacy managed agent route denial matches only registered managed route shapes", () => {
-  const managedRoutes = [
-    ["POST", "/api/ag-ui"],
-    ["POST", "/api/runs"],
-    ["POST", "/api/runs/run_1/resume"],
-    ["DELETE", "/api/runs/run_1"],
-    ["POST", "/api/control-plane/agents/list"],
-    ["POST", "/api/control-plane/runs/run_1/execute"],
-    ["POST", "/api/control-plane/runs/run_1/stream"],
-    ["POST", "/api/control-plane/runs/run_1/resume"],
-    ["DELETE", "/api/control-plane/runs/run_1"],
-    ["POST", "//api/ag-ui"],
-    ["POST", "///api/runs"],
-    ["POST", "//api/runs/run_1/resume"],
-    ["DELETE", "//api/control-plane/runs/run_1"],
-  ] as const;
+  it("matches only registered managed route shapes", () => {
+    const managedRoutes = [
+      ["POST", "/api/ag-ui"],
+      ["POST", "/api/runs"],
+      ["POST", "/api/runs/run_1/resume"],
+      ["DELETE", "/api/runs/run_1"],
+      ["POST", "/api/control-plane/agents/list"],
+      ["POST", "/api/control-plane/runs/run_1/execute"],
+      ["POST", "/api/control-plane/runs/run_1/stream"],
+      ["POST", "/api/control-plane/runs/run_1/resume"],
+      ["DELETE", "/api/control-plane/runs/run_1"],
+      ["POST", "//api/ag-ui"],
+      ["POST", "///api/runs"],
+      ["POST", "//api/runs/run_1/resume"],
+      ["DELETE", "//api/control-plane/runs/run_1"],
+    ] as const;
 
-  for (const [method, pathname] of managedRoutes) {
-    assertEquals(isLegacyManagedAgentRoute(method, pathname), true, `${method} ${pathname}`);
-  }
+    for (const [method, pathname] of managedRoutes) {
+      assertEquals(isLegacyManagedAgentRoute(method, pathname), true, `${method} ${pathname}`);
+    }
 
-  const applicationRoutes = [
-    ["GET", "/api/ag-ui"],
-    ["GET", "/api/runs"],
-    ["POST", "/api/runs/run_1"],
-    ["POST", "/api/runs/run_1/resume/extra"],
-    ["DELETE", "/api/runs/run_1/extra"],
-    ["POST", "/api/control-plane/application-route"],
-    ["GET", "/api/control-plane/runs/run_1/stream"],
-  ] as const;
+    const applicationRoutes = [
+      ["GET", "/api/ag-ui"],
+      ["GET", "/api/runs"],
+      ["POST", "/api/runs/run_1"],
+      ["POST", "/api/runs/run_1/resume/extra"],
+      ["DELETE", "/api/runs/run_1/extra"],
+      ["POST", "/api/control-plane/application-route"],
+      ["GET", "/api/control-plane/runs/run_1/stream"],
+    ] as const;
 
-  for (const [method, pathname] of applicationRoutes) {
-    assertEquals(isLegacyManagedAgentRoute(method, pathname), false, `${method} ${pathname}`);
-  }
+    for (const [method, pathname] of applicationRoutes) {
+      assertEquals(isLegacyManagedAgentRoute(method, pathname), false, method + " " + pathname);
+    }
+  });
 });

--- a/src/proxy/legacy-managed-agent-route-denial.ts
+++ b/src/proxy/legacy-managed-agent-route-denial.ts
@@ -1,0 +1,33 @@
+import { isControlPlaneSurfaceRoute } from "#veryfront/channels/control-plane.ts";
+
+export const LEGACY_MANAGED_AGENT_ROUTE_DENY_ENV =
+  "VERYFRONT_PROXY_DENY_LEGACY_MANAGED_AGENT_ROUTES";
+
+const DURABLE_RUN_PATH = /^\/api\/runs\/[^/]+$/u;
+const DURABLE_RUN_RESUME_PATH = /^\/api\/runs\/[^/]+\/resume$/u;
+
+/**
+ * Parse the trusted proxy switch that retires renderer-owned managed agent routes.
+ *
+ * The switch is deliberately dormant unless an operator supplies an exact
+ * boolean string. Rejecting malformed values prevents a misspelled cutover
+ * setting from silently leaving the legacy credential path available.
+ */
+export function parseLegacyManagedAgentRouteDeny(raw: string | undefined): boolean {
+  if (raw === undefined || raw === "" || raw === "false") return false;
+  if (raw === "true") return true;
+  throw new TypeError(
+    `${LEGACY_MANAGED_AGENT_ROUTE_DENY_ENV} must be exactly true or false`,
+  );
+}
+
+/** True only for legacy managed agent routes currently served by project runtimes. */
+export function isLegacyManagedAgentRoute(method: string, pathname: string): boolean {
+  const normalizedMethod = method.toUpperCase();
+  if (isControlPlaneSurfaceRoute(normalizedMethod, pathname)) return true;
+  if (normalizedMethod === "POST") {
+    return pathname === "/api/ag-ui" || pathname === "/api/runs" ||
+      DURABLE_RUN_RESUME_PATH.test(pathname);
+  }
+  return normalizedMethod === "DELETE" && DURABLE_RUN_PATH.test(pathname);
+}

--- a/src/proxy/legacy-managed-agent-route-denial.ts
+++ b/src/proxy/legacy-managed-agent-route-denial.ts
@@ -1,4 +1,5 @@
 import { isControlPlaneSurfaceRoute } from "#veryfront/channels/control-plane.ts";
+import { normalizeProxyOriginFormPath } from "./request-path.ts";
 
 export const LEGACY_MANAGED_AGENT_ROUTE_DENY_ENV =
   "VERYFRONT_PROXY_DENY_LEGACY_MANAGED_AGENT_ROUTES";
@@ -24,11 +25,22 @@ export function parseLegacyManagedAgentRouteDeny(raw: string | undefined): boole
 /** True only for legacy managed agent routes currently served by project runtimes. */
 export function isLegacyManagedAgentRoute(method: string, pathname: string): boolean {
   const normalizedMethod = method.toUpperCase();
-  const normalizedPathname = pathname.replace(/^\/\/+/, "/");
+  const normalizedPathname = normalizeProxyRoutePolicyPathname(pathname);
   if (isControlPlaneSurfaceRoute(normalizedMethod, normalizedPathname)) return true;
   if (normalizedMethod === "POST") {
     return normalizedPathname === "/api/ag-ui" || normalizedPathname === "/api/runs" ||
       DURABLE_RUN_RESUME_PATH.test(normalizedPathname);
   }
   return normalizedMethod === "DELETE" && DURABLE_RUN_PATH.test(normalizedPathname);
+}
+
+/** Match the path identity used by renderer app-route discovery. */
+export function normalizeProxyRoutePolicyPathname(pathname: string): string {
+  const originFormPathname = normalizeProxyOriginFormPath(pathname);
+  const segments = originFormPathname.split("/");
+  let normalizedPathname = "";
+  for (const segment of segments) {
+    if (segment.length > 0) normalizedPathname += `/${segment}`;
+  }
+  return normalizedPathname || "/";
 }

--- a/src/proxy/legacy-managed-agent-route-denial.ts
+++ b/src/proxy/legacy-managed-agent-route-denial.ts
@@ -24,10 +24,11 @@ export function parseLegacyManagedAgentRouteDeny(raw: string | undefined): boole
 /** True only for legacy managed agent routes currently served by project runtimes. */
 export function isLegacyManagedAgentRoute(method: string, pathname: string): boolean {
   const normalizedMethod = method.toUpperCase();
-  if (isControlPlaneSurfaceRoute(normalizedMethod, pathname)) return true;
+  const normalizedPathname = pathname.replace(/^\/\/+/, "/");
+  if (isControlPlaneSurfaceRoute(normalizedMethod, normalizedPathname)) return true;
   if (normalizedMethod === "POST") {
-    return pathname === "/api/ag-ui" || pathname === "/api/runs" ||
-      DURABLE_RUN_RESUME_PATH.test(pathname);
+    return normalizedPathname === "/api/ag-ui" || normalizedPathname === "/api/runs" ||
+      DURABLE_RUN_RESUME_PATH.test(normalizedPathname);
   }
-  return normalizedMethod === "DELETE" && DURABLE_RUN_PATH.test(pathname);
+  return normalizedMethod === "DELETE" && DURABLE_RUN_PATH.test(normalizedPathname);
 }

--- a/src/proxy/main.ts
+++ b/src/proxy/main.ts
@@ -16,6 +16,7 @@
  * - CACHE_TYPE: "memory" (default) or "extension"
  * - VERYFRONT_PROXY_EXPECTED_REPLICAS: Minimum proxy replicas required to acknowledge routing changes
  * - VERYFRONT_PROXY_ROUTING_INVALIDATION_SECRET: HMAC secret for Redis routing events and acknowledgements
+ * - VERYFRONT_PROXY_DENY_LEGACY_MANAGED_AGENT_ROUTES: Exact boolean cutover switch (default false)
  * - VERYFRONT_API_INTERNAL_URL: API URL for internal endpoints (falls back to VERYFRONT_PROXY_API_BASE_URL)
  * - VERYFRONT_API_INTERNAL_USER: Basic auth user for internal API
  * - VERYFRONT_API_INTERNAL_PASS: Basic auth pass for internal API
@@ -24,6 +25,10 @@
  */
 
 import { createProxyHandler, type ProxyConfig } from "./handler.ts";
+import {
+  LEGACY_MANAGED_AGENT_ROUTE_DENY_ENV,
+  parseLegacyManagedAgentRouteDeny,
+} from "./legacy-managed-agent-route-denial.ts";
 import { createCacheFromEnv } from "./cache/index.ts";
 import { acquireExtensionTokenCacheStoreFromEnv } from "./cache/extension-store.ts";
 import {
@@ -128,6 +133,9 @@ const config: ProxyConfig = {
   previewApiClientId: apiClientId,
   previewApiClientSecret: apiClientSecret,
   localProjects: getLocalProjects(),
+  denyLegacyManagedAgentRoutes: parseLegacyManagedAgentRouteDeny(
+    getEnv(LEGACY_MANAGED_AGENT_ROUTE_DENY_ENV),
+  ),
 };
 
 function resolveProxyBinding(): { hostname: string; port: number } {


### PR DESCRIPTION
## Problem

Managed agent requests still reach project renderer processes through legacy proxy routes. During the isolated broker rollout, the trusted proxy needs a dormant cutover switch that can retire those exact routes before it reads request bodies, obtains credentials, resolves projects, or constructs an upstream request.

## Change

- add strict startup parsing for `VERYFRONT_PROXY_DENY_LEGACY_MANAGED_AGENT_ROUTES` (default off)
- reject exact legacy AG-UI, durable run, and registered control-plane agent routes with a fixed non-redirecting 404 when enabled
- normalize the path identity accepted by renderer app-route discovery, preventing leading, interior, and trailing slash bypasses
- keep every non-canonical alias of an internal namespace route reserved
- preserve all current behavior while the switch is omitted or false

This is a dormant cutover component for private issue 1037. It does not enable the switch or claim that the full broker/executor rollout is complete.

## Verification

- `deno task test:file src/proxy/legacy-managed-agent-route-denial.test.ts src/proxy/legacy-managed-agent-route-denial.handler.test.ts src/proxy/handler.test.ts src/proxy/control-plane-signature.test.ts src/proxy/main.test.ts`
- `deno check --frozen` on all changed TypeScript files
- `deno lint` and `deno fmt --check` on all changed files
- local `codex review --base origin/main`: caught two path-alias regressions during iteration; no actionable findings on the final exact head
